### PR TITLE
docs(qcpy-18): citation audit ML-Features-Engineering (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
@@ -521,7 +521,9 @@
     "\n",
     "Les données simulées ici sont uniquement pour démonstration pédagogique.\n",
     "\n",
-    "---"
+    "---\n",
+    "\n",
+    "> *Ancre savante -- Fama, E.F. (1965), The Behavior of Stock-Market Prices, The Journal of Business 38(1):34-105. (Formalisation de l'hypothese de marche aleatoire / random walk des prix, fondee sur l'efficience informationnelle ; justifie la non-stationnarite des prix et le passage aux rendements stationnaires.)*\n"
    ]
   },
   {
@@ -952,7 +954,9 @@
     "\n",
     "- **RSI** : Deja normalise [0, 100]\n",
     "- **MACD** : Diviser par le prix ou utiliser le ratio\n",
-    "- **BB** : Utiliser %B (position normalisee)"
+    "- **BB** : Utiliser %B (position normalisee)\n",
+    "\n",
+    "> *Ancre savante -- Wilder, J.W. (1978), New Concepts in Technical Trading Systems, Trend Research, Greensboro, NC. ISBN 978-0-89459-027-6. (Origine du RSI (Relative Strength Index) et de l'ATR (Average True Range), deux indicateurs de momentum et de volatilite les plus utilises.)*\n"
    ]
   },
   {
@@ -1339,7 +1343,9 @@
     "- Le ML peut sélectionner ceux qui sont pertinents\n",
     "- La redondance est gérée plus tard par feature selection\n",
     "\n",
-    "---"
+    "---\n",
+    "\n",
+    "> *Ancre savante -- Jegadeesh, N. & Titman, S. (1993), Returns to Buying Winners and Selling Losers: Implications for Stock Market Efficiency, The Journal of Finance 48(1):65-91. DOI 10.1111/j.1540-6261.1993.tb04702.x. (Anomalie de momentum : les titres gagnants surperforment a court terme, fonde le momentum comme feature predictive.)*\n"
    ]
   },
   {
@@ -2290,7 +2296,9 @@
     "- Le seuil (threshold) permet d'ajuster l'équilibre des classes\n",
     "- Pour un marché haussier, les labels Up seront naturellement plus fréquents\n",
     "\n",
-    "---"
+    "---\n",
+    "\n",
+    "> *Ancre savante -- Sharpe, W.F. (1966), Mutual Fund Performance, The Journal of Business 39(1):119-138. DOI 10.1086/294846. (Ratio de Sharpe / reward-to-variability : rendement ajuste au risque, utilise ici comme cible (target_sharpe) du feature engineering.)*\n"
    ]
   },
   {
@@ -2601,7 +2609,9 @@
     "       +-- Embedded Methods (integre dans le modele)\n",
     "              +-- L1 Regularization (Lasso)\n",
     "              +-- Tree-based importance\n",
-    "```"
+    "```\n",
+    "\n",
+    "> *Ancres savantes -- Pearson, K. (1901), On Lines and Planes of Closest Fit to Systems of Points in Space, The London, Edinburgh, and Dublin Philosophical Magazine and Journal of Science 2(11):559-572. DOI 10.1080/14786440109462720 (origine de l'ACP / PCA, reduction de dimensionnalite) ; Guyon, I., Weston, J., Barnhill, S. & Vapnik, V. (2002), Gene Selection for Cancer Classification using Support Vector Machines, Machine Learning 46(1-3):389-422. DOI 10.1023/A:1012487302797 (Recursive Feature Elimination / RFE, methode wrapper de selection de features).)*\n"
    ]
   },
   {
@@ -3005,7 +3015,9 @@
     "",
     "**Indices** :",
     "- # Indice : `from sklearn.feature_selection import mutual_info_classif`",
-    "- # Indice : `from matplotlib_venn import venn2` pour le diagramme de Venn"
+    "- # Indice : `from matplotlib_venn import venn2` pour le diagramme de Venn\n",
+    "\n",
+    "> *Ancre savante -- Shannon, C.E. (1948), A Mathematical Theory of Communication, Bell System Technical Journal 27(3):379-423. DOI 10.1002/j.1538-7305.1948.tb01338.x. (Theorie de l'information : la mutual information mesure la dependance (lineaire ET non-lineaire) entre deux variables, capture ce que la correlation de Pearson rate.)*\n"
    ]
   },
   {
@@ -4353,7 +4365,18 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook complete. Pret pour QC-Py-19 (Classification Models).**"
+    "**Notebook complete. Pret pour QC-Py-19 (Classification Models).**\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Fama, E.F. (1965). The Behavior of Stock-Market Prices. The Journal of Business 38(1):34-105.\n",
+    "- Guyon, I., Weston, J., Barnhill, S. & Vapnik, V. (2002). Gene Selection for Cancer Classification using Support Vector Machines. Machine Learning 46(1-3):389-422. DOI 10.1023/A:1012487302797.\n",
+    "- Jegadeesh, N. & Titman, S. (1993). Returns to Buying Winners and Selling Losers: Implications for Stock Market Efficiency. The Journal of Finance 48(1):65-91. DOI 10.1111/j.1540-6261.1993.tb04702.x.\n",
+    "- Pearson, K. (1901). On Lines and Planes of Closest Fit to Systems of Points in Space. Philosophical Magazine 2(11):559-572. DOI 10.1080/14786440109462720.\n",
+    "- Shannon, C.E. (1948). A Mathematical Theory of Communication. Bell System Technical Journal 27(3):379-423. DOI 10.1002/j.1538-7305.1948.tb01338.x.\n",
+    "- Sharpe, W.F. (1966). Mutual Fund Performance. The Journal of Business 39(1):119-138. DOI 10.1086/294846.\n",
+    "- Wilder, J.W. (1978). New Concepts in Technical Trading Systems. Trend Research, Greensboro, NC. ISBN 978-0-89459-027-6.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Citation audit of **QC-Py-18-ML-Features-Engineering** (epic #3164, verdict OMISSION). The notebook teaches ML feature engineering for trading — momentum, technical indicators (RSI/ATR/MACD/Bollinger), fundamentals, mutual information, feature selection — but named fundamental concepts appeared in prose without scholarly anchors (0 DOI, generic section).

Fix = **markdown-additive** footnotes `> *Ancre savante -- ...*` + a `### References academiques` section. No code touched.

## Anchors added (6 anchors, 7 citations)

| Cell | Concept | Anchor |
|------|---------|--------|
| 8 | Random walk / price non-stationarity | Fama 1965, *J. Business* 38(1):34-105 |
| 16 | RSI + ATR origin | Wilder 1978, *New Concepts in Technical Trading Systems* |
| 20 | Momentum anomaly | Jegadeesh & Titman 1993, *J. Finance* 48(1):65-91 (DOI 10.1111/j.1540-6261.1993.tb04702.x) |
| 32 | target_sharpe / reward-to-variability | Sharpe 1966, *J. Business* 39(1):119-138 (DOI 10.1086/294846) |
| 36 | PCA + RFE (grouped) | Pearson 1901, *Phil. Mag.* 2(11):559-572 (DOI 10.1080/14786440109462720) ; Guyon, Weston, Barnhill & Vapnik 2002, *Machine Learning* 46(1-3):389-422 (DOI 10.1023/A:1012487302797) |
| 42 | Mutual information | Shannon 1948, *Bell System Tech. J.* 27(3):379-423 (DOI 10.1002/j.1538-7305.1948.tb01338.x) |

A `### References academiques` section (7 entries) is appended to the Conclusion cell (cell 59).

## Honest drops (practitioner-only, no clean single originator)

- **MACD** (Gerald Appel) — practitioner, no founding scholarly publication → not anchored.
- **Stochastic oscillator** (George Lane) — attribution contested, no founding publication → not anchored.

Consistent with the VWAP drop in QC-Py-14 (#4123) and the De Graaf → DeMiguel factual correction in QC-Py-08 (#4125).

## Verification

- **Code untouched**: 25/25 code cells **byte-identical** (sha1 of joined source identical pre/post edit).
- `python scripts/notebook_tools/notebook_tools.py validate` → **OK, 0 errors, 0 warnings**.
- All citations **web-verified** (Jegadeesh-Titman via Wiley/RePEc/JSTOR, Shannon via Wiley BSTJ, Pearson via Taylor & Francis, Guyon via Springer, Sharpe DOI via SCIRP, Fama pages via JSTOR).
- Fresh branch from `origin/main` (no catalog churn). Markdown-only diff (+30/-7, the −7 is JSON newline-normalization of markdown cell last-elements).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)