### PR TITLE
docs(z3): retire obsolete same-cell workaround caveat in 05

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
@@ -42,10 +42,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:31.128243Z",
-     "iopub.status.busy": "2026-06-23T17:06:31.123580Z",
-     "iopub.status.idle": "2026-06-23T17:06:32.111398Z",
-     "shell.execute_reply": "2026-06-23T17:06:32.109297Z"
+     "iopub.execute_input": "2026-06-24T07:49:05.853772Z",
+     "iopub.status.busy": "2026-06-24T07:49:05.835214Z",
+     "iopub.status.idle": "2026-06-24T07:49:10.261817Z",
+     "shell.execute_reply": "2026-06-24T07:49:10.254005Z"
     },
     "papermill": {
      "duration": 0.994695,
@@ -65,7 +65,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-23408.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-41248.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -110,12 +110,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.143.196.232:2048/\", \"http://192.168.48.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://10.54.226.85:2048/\", \"http://172.18.144.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '23408.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '41248.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -259,10 +259,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:32.136211Z",
-     "iopub.status.busy": "2026-06-23T17:06:32.135835Z",
-     "iopub.status.idle": "2026-06-23T17:06:32.385333Z",
-     "shell.execute_reply": "2026-06-23T17:06:32.385224Z"
+     "iopub.execute_input": "2026-06-24T07:49:10.265507Z",
+     "iopub.status.busy": "2026-06-24T07:49:10.264849Z",
+     "iopub.status.idle": "2026-06-24T07:49:11.102099Z",
+     "shell.execute_reply": "2026-06-24T07:49:11.100904Z"
     },
     "papermill": {
      "duration": 0.254556,
@@ -376,10 +376,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:32.402978Z",
-     "iopub.status.busy": "2026-06-23T17:06:32.402817Z",
-     "iopub.status.idle": "2026-06-23T17:06:32.635130Z",
-     "shell.execute_reply": "2026-06-23T17:06:32.635020Z"
+     "iopub.execute_input": "2026-06-24T07:49:11.108153Z",
+     "iopub.status.busy": "2026-06-24T07:49:11.107089Z",
+     "iopub.status.idle": "2026-06-24T07:49:12.052882Z",
+     "shell.execute_reply": "2026-06-24T07:49:12.051928Z"
     },
     "papermill": {
      "duration": 0.235925,
@@ -520,10 +520,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:32.664250Z",
-     "iopub.status.busy": "2026-06-23T17:06:32.663929Z",
-     "iopub.status.idle": "2026-06-23T17:06:32.771369Z",
-     "shell.execute_reply": "2026-06-23T17:06:32.771128Z"
+     "iopub.execute_input": "2026-06-24T07:49:12.056353Z",
+     "iopub.status.busy": "2026-06-24T07:49:12.055769Z",
+     "iopub.status.idle": "2026-06-24T07:49:12.346956Z",
+     "shell.execute_reply": "2026-06-24T07:49:12.346004Z"
     },
     "papermill": {
      "duration": 0.116773,
@@ -696,10 +696,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:32.807831Z",
-     "iopub.status.busy": "2026-06-23T17:06:32.807604Z",
-     "iopub.status.idle": "2026-06-23T17:06:33.038847Z",
-     "shell.execute_reply": "2026-06-23T17:06:33.038642Z"
+     "iopub.execute_input": "2026-06-24T07:49:12.352622Z",
+     "iopub.status.busy": "2026-06-24T07:49:12.351920Z",
+     "iopub.status.idle": "2026-06-24T07:49:12.958210Z",
+     "shell.execute_reply": "2026-06-24T07:49:12.957738Z"
     },
     "papermill": {
      "duration": 0.237558,
@@ -908,10 +908,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:33.084692Z",
-     "iopub.status.busy": "2026-06-23T17:06:33.084345Z",
-     "iopub.status.idle": "2026-06-23T17:06:33.258281Z",
-     "shell.execute_reply": "2026-06-23T17:06:33.258153Z"
+     "iopub.execute_input": "2026-06-24T07:49:12.961418Z",
+     "iopub.status.busy": "2026-06-24T07:49:12.960850Z",
+     "iopub.status.idle": "2026-06-24T07:49:13.528257Z",
+     "shell.execute_reply": "2026-06-24T07:49:13.527290Z"
     },
     "papermill": {
      "duration": 0.185245,
@@ -1143,10 +1143,10 @@
    "id": "90bea1fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:33.281709Z",
-     "iopub.status.busy": "2026-06-23T17:06:33.281527Z",
-     "iopub.status.idle": "2026-06-23T17:06:33.507392Z",
-     "shell.execute_reply": "2026-06-23T17:06:33.507245Z"
+     "iopub.execute_input": "2026-06-24T07:49:13.532051Z",
+     "iopub.status.busy": "2026-06-24T07:49:13.531414Z",
+     "iopub.status.idle": "2026-06-24T07:49:14.146220Z",
+     "shell.execute_reply": "2026-06-24T07:49:14.145308Z"
     },
     "papermill": {
      "duration": 0.230148,
@@ -1170,7 +1170,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "[A] Montée en gamme (mode Array implicite) résolue en pur LINQ int[][] : 29,1 ms\n",
+      "[A] Montée en gamme (mode Array implicite) résolue en pur LINQ int[][] : 60,0 ms\n",
       "\r\n"
      ]
     },
@@ -1221,7 +1221,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "[B] Permutation totale (mode Array explicite, Distinct cross-row) résolue en : 28,4 ms\n",
+      "[B] Permutation totale (mode Array explicite, Distinct cross-row) résolue en : 45,9 ms\n",
       "\r\n"
      ]
     },
@@ -1420,7 +1420,7 @@
     "\n",
     "**Mode `Array` explicite — symétrie avec la section 9.** Déclarer `DefaultCollectionHandling = CollectionHandling.Array` rend visible ce que la section 7 utilisait implicitement : les deux contextes sont identiques (le mode `Array` est le défaut). La section 9 démontrera la même enum sur un `Plate` **1D** (`int[]`) et comparera `Array` vs `Constants` ; ici on confirme que le DSL modélise `int[][]` comme des `ArrayExpr` Z3 imbriqués à **tous** les niveaux hiérarchiques.\n",
     "\n",
-    "> **Note (.NET Interactive).** Les deux variantes vivent dans **une seule cellule**, à dessein. Une contrainte Z3.Linq capture parfois une variable hôte (ici les bornes `entLo`, `entHi`, …) ; le visiteur d'expressions résout cette capture par réflexion sur l'objet *closure*. Or le kernel .NET Interactive compile chaque cellule en une classe `Submission#N` distincte : une variable top-level déclarée en section 7 n'est pas un champ de la *closure* d'un `Solve()` lancé dans une **autre** cellule, ce qui lève un `ArgumentException`. Règle pratique : **garder, dans une même cellule, la déclaration des bornes capturées et le `Solve()` qui les utilise** (le fork lui-même n'a pas cette limite — ses tests xUnit enchaînent plusieurs `Solve` sur `int[][]` sans souci).\n"
+    "> **Note (.NET Interactive — submissions et capture).** Le kernel .NET Interactive compile chaque cellule en une classe `Submission#N` distincte. Une contrainte Z3.Linq qui capture une variable hôte (ici les bornes `entLo`, `entHi`, …) voit le visiteur d'expressions résoudre cette capture par réflexion sur l'objet *closure*. Historiquement, capturer une variable top-level déclarée dans une **autre** cellule levait un `ArgumentException` (le champ de la *closure* n'était pas trouvé sur la submission du `Solve()`) ; aussi les deux variantes vivent-elles ici dans **une seule cellule**. **Ce blocage est désormais résolu** : le fix fork `AssertConstraints` (PR `MyIntelligenceAgency/Z3.Linq`#3, partial-eval du corps de contrainte avant visite) replie les constantes capturées en littéraux, ce qui rend la capture cross-cell fonctionnelle — les tests xUnit du fork enchaînent plusieurs `Solve` sur `int[][]` sans souci. La **même cellule reste néanmoins le pattern recommandé** pour un notebook lisible et autonome."
    ]
   },
   {
@@ -1481,10 +1481,10 @@
    "id": "b6203e70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:33.548592Z",
-     "iopub.status.busy": "2026-06-23T17:06:33.548425Z",
-     "iopub.status.idle": "2026-06-23T17:06:33.665386Z",
-     "shell.execute_reply": "2026-06-23T17:06:33.665269Z"
+     "iopub.execute_input": "2026-06-24T07:49:14.149804Z",
+     "iopub.status.busy": "2026-06-24T07:49:14.149265Z",
+     "iopub.status.idle": "2026-06-24T07:49:14.416015Z",
+     "shell.execute_reply": "2026-06-24T07:49:14.415616Z"
     },
     "papermill": {
      "duration": 0.122003,
@@ -1643,10 +1643,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:33.698036Z",
-     "iopub.status.busy": "2026-06-23T17:06:33.697848Z",
-     "iopub.status.idle": "2026-06-23T17:06:33.728783Z",
-     "shell.execute_reply": "2026-06-23T17:06:33.728676Z"
+     "iopub.execute_input": "2026-06-24T07:49:14.419184Z",
+     "iopub.status.busy": "2026-06-24T07:49:14.418694Z",
+     "iopub.status.idle": "2026-06-24T07:49:14.493961Z",
+     "shell.execute_reply": "2026-06-24T07:49:14.493055Z"
     },
     "papermill": {
      "duration": 0.036068,
@@ -1716,10 +1716,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:33.745806Z",
-     "iopub.status.busy": "2026-06-23T17:06:33.745649Z",
-     "iopub.status.idle": "2026-06-23T17:06:33.769290Z",
-     "shell.execute_reply": "2026-06-23T17:06:33.769163Z"
+     "iopub.execute_input": "2026-06-24T07:49:14.496650Z",
+     "iopub.status.busy": "2026-06-24T07:49:14.496130Z",
+     "iopub.status.idle": "2026-06-24T07:49:14.546470Z",
+     "shell.execute_reply": "2026-06-24T07:49:14.546077Z"
     },
     "papermill": {
      "duration": 0.028678,
@@ -1786,10 +1786,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:33.787346Z",
-     "iopub.status.busy": "2026-06-23T17:06:33.787173Z",
-     "iopub.status.idle": "2026-06-23T17:06:33.813971Z",
-     "shell.execute_reply": "2026-06-23T17:06:33.813861Z"
+     "iopub.execute_input": "2026-06-24T07:49:14.548773Z",
+     "iopub.status.busy": "2026-06-24T07:49:14.548320Z",
+     "iopub.status.idle": "2026-06-24T07:49:14.611250Z",
+     "shell.execute_reply": "2026-06-24T07:49:14.610456Z"
     },
     "papermill": {
      "duration": 0.032559,
@@ -1845,9 +1845,9 @@
     "\n",
     "**Indice — bornes de catégorie.** Reprenez le calcul des bornes (`entLo`, `entHi`, …) avec `foodDatabase.FindIndex` / `FindLastIndex`.\n",
     "\n",
-    "**Indice — une seule cellule (.NET Interactive).** Déclarez les bornes **dans la même cellule** que le `Solve()` qui les capture (cf. la note de la section 7.1) : sous le kernel .NET Interactive, une contrainte ne peut pas capturer une variable top-level définie dans une *autre* cellule.\n",
+    "**Indice — lisibilité .NET Interactive.** Pour garder le notebook lisible, déclarez les bornes **dans la même cellule** que le `Solve()` qui les capture. La capture cross-cell est désormais fonctionnelle (le fix fork `AssertConstraints` lève l'ancien blocage), mais la même cellule reste le pattern le plus clair pour un exercice autonome.\n",
     "\n",
-    "**Indice — `Distinct` cross-row.** `Z3Methods.Distinct(p.Plan[0][0], p.Plan[1][0], p.Plan[2][0])` s'applique directement à une colonne d'un `int[][]` (même marqueur que les lignes/colonnes d'un Sudoku, notebook 04).\n"
+    "**Indice — `Distinct` cross-row.** `Z3Methods.Distinct(p.Plan[0][0], p.Plan[1][0], p.Plan[2][0])` s'applique directement à une colonne d'un `int[][]` (même marqueur que les lignes/colonnes d'un Sudoku, notebook 04)."
    ]
   },
   {
@@ -1856,10 +1856,10 @@
    "id": "aa925fc9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T17:06:33.833256Z",
-     "iopub.status.busy": "2026-06-23T17:06:33.833029Z",
-     "iopub.status.idle": "2026-06-23T17:06:33.856394Z",
-     "shell.execute_reply": "2026-06-23T17:06:33.856294Z"
+     "iopub.execute_input": "2026-06-24T07:49:14.614281Z",
+     "iopub.status.busy": "2026-06-24T07:49:14.613592Z",
+     "iopub.status.idle": "2026-06-24T07:49:14.661876Z",
+     "shell.execute_reply": "2026-06-24T07:49:14.661451Z"
     },
     "papermill": {
      "duration": 0.029667,
@@ -1881,7 +1881,9 @@
    ],
    "source": [
     "// Exercice 4 : modèle hiérarchique combiné (montée en gamme sur les plats + permutation des entrées/desserts).\n",
-    "// Tout dans CETTE cellule (bornes + Solve) pour rester dans la meme submission .NET Interactive.\n",
+    "// Recommandation .NET Interactive : gardez idéalement les bornes et le Solve() dans la même cellule\n",
+    "// (la capture cross-cell fonctionne désormais grâce au fix fork AssertConstraints, mais la même cellule\n",
+    "// reste le pattern le plus lisible).\n",
     "\n",
     "// TODO etudiant : recalculer les bornes de categorie ici (entLo/entHi/pltLo/pltHi/desLo/desHi)\n",
     "//   via foodDatabase.FindIndex / FindLastIndex\n",
@@ -1890,7 +1892,7 @@
     "// TODO etudiant : entrees + desserts en permutation -> Z3Methods.Distinct(p.Plan[0][k], p.Plan[1][k], p.Plan[2][k])\n",
     "// TODO etudiant : resoudre et afficher le plan combine\n",
     "\n",
-    "Console.WriteLine(\"Exercice a completer : modele hierarchique combine\");\n"
+    "Console.WriteLine(\"Exercice a completer : modele hierarchique combine\");"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Retires the obsolete cross-submission capture caveat in `05_Meal_Planner_Hierarchical.ipynb`, now that the fork fix is merged and landed on main (#4124). The "keep everything in one cell" guidance was presented as a **hard rule driven by a real crash** (`ArgumentException`); that crash is **now resolved**, so the caveat is reworded to reflect reality.

**Prose only** — the code and structure of the notebook are unchanged. Three spots updated:

| Cell | Before | After |
|------|--------|-------|
| §7.1 note | "Rule: keep bounds + `Solve()` in one cell (otherwise `ArgumentException`)" | Explanation of the `Submission#N` mechanism (still true and pedagogically valuable) + note that the crash is **now resolved** by the fork `AssertConstraints` fix ([MyIntelligenceAgency/Z3.Linq#3](https://github.com/MyIntelligenceAgency/Z3.Linq/pull/3)). Same-cell pattern kept as a recommended (not mandatory) readability convention. |
| Ex. 4 hint | "must be in one cell (.NET Interactive)" | "for readability, keep in one cell" (cross-cell now functional) |
| Ex. 4 stub comment | "stay in the same submission" | same relaxation |

## Why keep the explanation at all

The `Submission#N` mechanism of .NET Interactive (each cell = a separate dynamic assembly) is **real and pedagogically valuable** — students should understand it. Only the *crash* is resolved. So the section is reworded, not deleted: it now teaches the mechanism and documents the historical bug + its fix, rather than prescribing a workaround as a current constraint.

## Validation

- Re-executed end-to-end (kernel `.net-csharp`, CWD = notebook dir): **12/12 code cells** with `execution_count` + outputs, **0 errors** (rule C.2/H.3).
- Anti-regression: Exercise 4 stub stays C.1-conformant (`Console.WriteLine("Exercice a completer...")`, no `raise`/`assert`/`1/0`).
- Catalogue byte-identical to main.
- `Automata` submodule (pre-existing dirty pointer) intentionally untouched.

## Scope / dependencies

- `See #1206` (Z3.Linq Epic).
- Depends on **#4124** (the submodule bump landing the `AssertConstraints` fix on main) — merged; this PR only updates the prose that referenced the now-fixed bug.

Developed with AI assistance (GLM-5.2).