### PR TITLE
docs(qcpy-06): citation audit Options — Black-Scholes-Merton (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -547,7 +547,9 @@
     "  90j    60j    30j    0j\n",
     "```\n",
     "\n",
-    "**Conseil** : Les vendeurs d'options profitent du theta decay, les acheteurs le subissent."
+    "**Conseil** : Les vendeurs d'options profitent du theta decay, les acheteurs le subissent.\n",
+    "\n",
+    "> *Ancres savantes -- Black, F. & Scholes, M. (1973), The Pricing of Options and Corporate Liabilities, Journal of Political Economy 81(3):637-654. DOI 10.1086/260062 (formule d'evaluation des options dont les Greeks sont les derivees partielles : delta/gamma/theta/vega/rho) ; Merton, R.C. (1973), Theory of Rational Option Pricing, Bell Journal of Economics and Management Science 4(1):141-183 (argument de couverture dynamique / delta-neutral, valuation risque-neutre). Ces deux travaux fondateurs ont value le prix Nobel d'economie 1997 a Merton et Scholes).*\n"
    ]
   },
   {
@@ -1904,7 +1906,13 @@
     "\n",
     "**Felicitations !** Vous maitrisez maintenant les bases du trading d'options sur QuantConnect. Les options offrent une flexibilite enorme pour la gestion de portefeuille, la generation de revenus, et la speculation. Utilisez ces connaissances avec prudence et commencez toujours par des positions petites.\n",
     "\n",
-    "**Prochain notebook** : QC-Py-07 - Futures et Commodities"
+    "**Prochain notebook** : QC-Py-07 - Futures et Commodities\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Black, F. & Scholes, M. (1973). The Pricing of Options and Corporate Liabilities. Journal of Political Economy 81(3):637-654. DOI 10.1086/260062.\n",
+    "- Merton, R.C. (1973). Theory of Rational Option Pricing. Bell Journal of Economics and Management Science 4(1):141-183.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Citation audit of **QC-Py-06-Options-Trading** (epic #3164, verdict OMISSION). The notebook's scholarly core is the **Greeks** (Delta/Gamma/Theta/Vega/Rho taught as "mesures de sensibilité" for risk management) and delta-neutral hedging — but the foundational options-pricing theory had no anchor (0 DOI, no References).

Fix = **markdown-additive** footnote `> *Ancres savantes -- ...*` + References section. No code touched.

## Anchor added (1 anchor, 2 citations)

| Cell | Concept | Anchor |
|------|---------|--------|
| 18 | Greeks = option-pricing partial derivatives + delta-neutral hedging | **Black & Scholes 1973** (*J. Political Economy* 81(3):637-654, DOI 10.1086/260062) + **Merton 1973** (*Bell J. Economics* 4(1):141-183), grouped |

A `### References academiques` section (2 entries) is appended to the Conclusion (cell 53).

## Honest drops (anti-padding, G.5)

The notebook teaches Greeks and QC option mechanics, not the following — anchoring them would be padding:
- **Cox-Ross-Rubinstein 1979** (binomial tree) — not taught; QC uses its built-in pricer.
- **Latané-Rendleman 1976** (implied volatility) — not taught as a concept; Vega (Greek) is already covered by Black-Scholes.
- **Bachelier 1900** — no historical-context section in the notebook.
- **Stoll 1969** (put-call parity) — implied by Covered Call/Protective Put strategies but the parity identity is not derived.

## Verification

- **Code untouched**: 13/13 code cells **byte-identical** (sha1 of joined source identical pre/post edit).
- `python scripts/notebook_tools/notebook_tools.py validate` → **OK, 0 errors, 0 warnings**.
- Citations **web-verified** (JPE journals.uchicago.edu, EconPapers, Springer for Merton, AFA issue page).
- Fresh branch from `origin/main`. Markdown-only diff (+10/-2).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)