### PR TITLE
fix(mgs-12): heading hierarchy — Partie D level + hint-as-H1 demote (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-12-AxisAlignment.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-12-AxisAlignment.ipynb
@@ -914,7 +914,7 @@
     "tags": []
    },
    "source": [
-    "# Partie D — La signature révélée : plus haute dimension\n",
+    "## Partie D — La signature révélée : plus haute dimension\n",
     "\n",
     "La partie C, en dimension 2, n'a montré **aucun** écart : tous les optimiseurs résolvent Rosenbrock 2D (rotationnée ou non), il n'y a pas de marge pour qu'un alignement sur les axes pénalise. C'est la leçon méthodologique rappelée plus haut : un banc ne prouve un biais opérateur que si le problème est **assez dur**.\n",
     "\n",
@@ -1152,7 +1152,7 @@
     "\n",
     "Ajoutez **DE/best/1** ou un crossover *arithmétique entier* (moyenne pondérée des deux parents, $\\alpha A + (1-\\alpha)B$) au banc de la partie C. Le crossover arithmétique est-il plus ou moins robuste à la rotation que le crossover uniforme ? Mesurez le $\\Delta$ et confrontez à votre intuition sur la structure de l'opérateur.\n",
     "\n",
-    "# Indice : le crossover arithmétique produit un descendant *sur le segment* entre les parents (combinaison convexe) — une opération géométrique indépendante du repère, donc *a priori* équivariante par rotation.\n"
+    "**Indice** : le crossover arithmétique produit un descendant *sur le segment* entre les parents (combinaison convexe) — une opération géométrique indépendante du repère, donc *a priori* équivariante par rotation.\n"
    ]
   },
   {
@@ -1211,7 +1211,7 @@
     "\n",
     "La partie D a révélé la signature à la dimension 5. Reprenez son protocole à la **dimension 10** (bornes $[-30, 30]$, mêmes 5 graines, médiane). Le $\\Delta$ des opérateurs alignés sur les axes (GA uniforme, BBPSO) grandit-il avec la dimension ? C'est l'intuition CEC : plus la dimension est élevée, plus la rotation est discriminante. Attention au budget : à très haute dimension tout le monde échoue et le signal disparaît — gardez un NFE où il reste de la marge.\n",
     "\n",
-    "# Étape 1 : remplacer dimD par 10. # Étape 2 : relancer la paire roté/non roté sur les 5 graines. # Étape 3 : comparer les Δ à ceux de la dimension 5.\n"
+    "**Étape 1** : remplacer dimD par 10. **Étape 2** : relancer la paire roté/non roté sur les 5 graines. **Étape 3** : comparer les Δ à ceux de la dimension 5.\n"
    ]
   },
   {
@@ -1267,7 +1267,7 @@
     "\n",
     "Composez les deux décorateurs : `new RotatedFitness(new ShiftedFitness(new RosenbrockFitness(), offset), M)` avec un `offset` non nul (via `ShiftVectors.Seeded`) et la matrice `M`. Vérifiez que l'optimum est à la fois décalé et rotationné, et lancez un optimiseur : combine-t-on les deux difficultés ? Quelle borne faut-il pour rester dans le domaine ?\n",
     "\n",
-    "# Indice : l'optimum est en $M^{\\top}(1,1) + o$ ; choisir bornes et offset pour qu'il reste atteignable.\n"
+    "**Indice** : l'optimum est en $M^{\\top}(1,1) + o$ ; choisir bornes et offset pour qu'il reste atteignable.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Heading-hierarchy cleanup of **MGS-12-AxisAlignment** (Search/Part4-Metaheuristics, `.net-csharp` kernel). Routed to my .NET lane by **po-2025** (dashboard 2026-06-24T07:41Z) — same hint-as-H1 class as #4113 (Infer-11) and #4127 (Sudoku), which po-2025 fixed for Python and correctly left to me for .NET to avoid collision. **Source-only markdown, zero drift** (no code cell, output, or exec_count touched).

## Fixes (cells 15/20/22/24, all markdown)

| Cell | Before | After | Rationale |
|------|--------|-------|-----------|
| 15 | `# Partie D — ...` | `## Partie D — ...` | Structural: Parties A/B/C are H2 (cells 6/9/12); only D was H1 — typo. Now consistent. |
| 20 | `# Indice : le crossover...` | `**Indice** : le crossover...` | Hint promoted to H1 -> demoted to bold inline. |
| 22 | `# Étape 1 : ... # Étape 2 : ... # Étape 3 : ...` | `**Étape 1** : ... **Étape 2** : ... **Étape 3** : ...` | 3 hints on one line. |
| 24 | `# Indice : l'optimum est en...` | `**Indice** : l'optimum...` | Hint-as-H1. |

The doc title (cell 0) remains the only legitimate H1.

## G.1 re-verification note

po-2025 reported cell indices 17/19/21; on direct re-read the actual offending cells are 20/22/24 (and 21 is a C# code cell whose `// Exercice 1` is a comment, not markdown). Confirmed the finding is real, corrected the indices, and added a cell-15 structural fix po-2025 didn't flag.

## Verification

- **Zero drift**: exactly cells [15,20,22,24] changed, all `markdown`. The sha1 of `{type, source, outputs, execution_count}` is identical for the other 23 cells.
- `notebook_tools validate` → OK, 0 errors (1 pre-existing warning, unrelated to headings).
- Post-fix markdown-H1 scan → only the title (cell 0) remains.
- Markdown-only diff +5/-5.

See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)