### PR TITLE
lean(cooperative): add SimpleGame predicate foundation (Veto/Dictator arch, greenlit)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1015,6 +1015,44 @@ noncomputable def WeightedVotingGame (weights : N → ℝ) (quota : ℝ) (hquota
   v := fun S => if ∑ i ∈ S, weights i ≥ quota then 1 else 0
   empty_zero := by simp [hquota]
 
+/-! ## Simple games
+
+A *simple game* is a transferable-utility game whose characteristic function takes only
+the values `0` (losing coalition) and `1` (winning coalition). This is the natural setting
+for voting-power notions: `VetoPlayer`, `Dictator`, `Critical`, and the Banzhaf indices are
+only meaningful under this constraint (otherwise `v S ∈ {0, 1}` fails and the Banzhaf
+normalisation `2 ^ (|N| - 1)` no longer matches the range of `v`).
+
+The `SimpleGame G` predicate packages the `v ∈ {0, 1}` constraint that the Veto/Dictator
+axioms (architectural greenlight, cycle 73) will assume. -/
+def SimpleGame (G : TUGame N) : Prop :=
+  ∀ S : Finset N, G.v S = 0 ∨ G.v S = 1
+
+/-- A `WeightedVotingGame` is simple: its characteristic function is an `if … then 1 else 0`,
+so every coalition's value is `0` or `1`. -/
+theorem weighted_voting_game_simple (weights : N → ℝ) (quota : ℝ) (hquota : 0 < quota) :
+    SimpleGame (WeightedVotingGame weights quota hquota) := by
+  intro S
+  simp only [WeightedVotingGame]
+  by_cases h : ∑ i ∈ S, weights i ≥ quota
+  · exact Or.inr (if_pos h)
+  · exact Or.inl (if_neg h)
+
+namespace SimpleGame
+
+/-- In a simple game, a value that is not `0` must be `1`. This is the contrapositive reader
+    used by the Veto/Dictator theorems to upgrade `v S ≠ 0` into `v S = 1`. -/
+theorem eq_one_of_ne_zero {G : TUGame N} (hG : SimpleGame G) (S : Finset N)
+    (hne : G.v S ≠ 0) : G.v S = 1 :=
+  (hG S).resolve_left hne
+
+/-- In a simple game, a value that not `1` must be `0`. Symmetric reader. -/
+theorem eq_zero_of_ne_one {G : TUGame N} (hG : SimpleGame G) (S : Finset N)
+    (hne : G.v S ≠ 1) : G.v S = 0 :=
+  (hG S).resolve_right hne
+
+end SimpleGame
+
 /-- Player i is critical in coalition S if removing them causes S to lose -/
 def Critical (G : TUGame N) (i : N) (S : Finset N) : Prop :=
   i ∈ S ∧ G.v S = 1 ∧ G.v (S.erase i) = 0


### PR DESCRIPTION
## Foundation: `SimpleGame` predicate (Veto/Dictator architecture, greenlit)

Architectural first step for the **Veto/Dictator** theorem family. The dashboard
greenlight (ai-01, cycle 73) validated the `SimpleGame v ∈ {0, 1}` predicate as the
next architectural step — `VetoPlayer`, `Dictator`, and the Banzhaf criticality
notions are only meaningful when `v` takes values in `{0, 1}` (otherwise the Banzhaf
normalisation `2 ^ (|N| - 1)` does not match the range of `v`). This PR lays the
foundation: the predicate + a validator + the two contrapositive readers the
downstream theorems will need.

### Added (all proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `SimpleGame G` | `∀ S, G.v S = 0 ∨ G.v S = 1` | the `v ∈ {0,1}` predicate |
| `weighted_voting_game_simple` | `SimpleGame (WeightedVotingGame weights quota hquota)` | validator: weighted voting games are simple |
| `SimpleGame.eq_one_of_ne_zero` | `G.v S ≠ 0 → G.v S = 1` | reader (upgrade `≠ 0` to `= 1`) |
| `SimpleGame.eq_zero_of_ne_one` | `G.v S ≠ 1 → G.v S = 0` | reader (symmetric) |

### Proof integrity (lean-merge-discipline §1)

```
✔ [8434/8435] Built CooperativeGames (18s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (8435 jobs, LAKE_EXIT=0)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (precise `^\s*sorry\s*$` / `:= by sorry` grep; pure additions, no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +38, clean additions after `WeightedVotingGame`), **0 catalogue file touched**
- the `weighted_voting_game_simple` proof: case-split on `∑ i ∈ S, weights i ≥ quota`, `if_pos` / `if_neg` close each branch.
- Linter note: `[DecidableEq N] unused` warnings on 3 theorems — the `omit … in` form the linter suggests breaks the parser (`unexpected token 'omit'`); these warnings are left, matching the pre-existing convention (L560/L568 have identical `unusedSectionVars` warnings untouched by original authors).

### What this does NOT do (deliberate, atomic)

This is the **foundation** only. The actual Veto/Dictator theorems (e.g.
"veto players have positive Banzhaf index", "a dictator is the unique critical player")
come in follow-up PRs once this predicate lands. Keeping this PR atomic (predicate +
validator + readers) per one-subject-per-PR discipline.

Follows the consolidation of the 4 Banzhaf index lemmas (#4130, merged) which completed
the sign/bound characterisation of `BanzhafIndex`. This opens the structural Veto/Dictator
axis.

See #4071 #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
