### PR TITLE
docs(z3): remove obsolete same-cell workaround narrative from 06b/06c

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06b_RecipeML_Corpus.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06b_RecipeML_Corpus.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "63094e14",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.0052,
+     "end_time": "2026-06-24T09:51:51.880230+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:51.875030+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Notebook 06b - Corpus RecipeML : modélisation SMT sur données externes\n",
     "\n",
@@ -33,10 +42,17 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:03:03.984819Z",
-     "iopub.status.busy": "2026-06-23T20:03:03.977917Z",
-     "iopub.status.idle": "2026-06-23T20:03:05.107713Z",
-     "shell.execute_reply": "2026-06-23T20:03:05.105962Z"
+     "iopub.execute_input": "2026-06-24T09:51:51.913381Z",
+     "iopub.status.busy": "2026-06-24T09:51:51.905125Z",
+     "iopub.status.idle": "2026-06-24T09:51:54.243814Z",
+     "shell.execute_reply": "2026-06-24T09:51:54.236045Z"
+    },
+    "papermill": {
+     "duration": 2.35257,
+     "end_time": "2026-06-24T09:51:54.244103+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:51.891533+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -46,7 +62,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-36108.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-45744.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -91,12 +107,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.54.226.85:2048/\", \"http://192.168.48.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://10.54.226.85:2048/\", \"http://172.18.144.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '36108.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '45744.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -180,7 +196,16 @@
   {
    "cell_type": "markdown",
    "id": "b80af59e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006914,
+     "end_time": "2026-06-24T09:51:54.259866+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:54.252952+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -197,13 +222,22 @@
     "1. **Sélection booléenne avec agrégation nutritionnelle conditionnelle** (section 3) — un `BoolExpr` par recette, somme pondérée via `MkITE`, contraintes de budget / protéines / exclusion d'allergène. C'est la même technique que le notebook 05 section 5, mais **alimentée par les valeurs issues du XML**.\n",
     "2. **Plan hiérarchique multi-jours en `int[][]`** (section 4) — sélection d'indices de recettes dans le corpus parsé, avec **non-répétition** via `Z3Methods.Distinct` en mode `CollectionHandling.Array`. Le même mécanisme qui structure un Sudoku (notebook 04) ou un plan hebdomadaire (notebook 05 section 7) s'applique ici sans modification.\n",
     "\n",
-    "> **Note technique** : pour la section 4, le modèle `int[][]` et l'appel `.Solve()` sont **dans la même cellule**. C'est délibéré — voir l'avertissement dans la section 4."
+    "> **Note de lisibilité** : la section 4 regroupe dans une même cellule la déclaration des bornes, la construction du théorème `Where(...)` et l'appel `.Solve()`. C'est un choix de **présentation** (bornes et contraintes se lisent d'un bloc) — voir la section 4 pour le contexte technique sous-jacent."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "b54099a6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005217,
+     "end_time": "2026-06-24T09:51:54.271527+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:54.266310+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -236,10 +270,17 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:03:05.109148Z",
-     "iopub.status.busy": "2026-06-23T20:03:05.108958Z",
-     "iopub.status.idle": "2026-06-23T20:03:05.249044Z",
-     "shell.execute_reply": "2026-06-23T20:03:05.248757Z"
+     "iopub.execute_input": "2026-06-24T09:51:54.284390Z",
+     "iopub.status.busy": "2026-06-24T09:51:54.283950Z",
+     "iopub.status.idle": "2026-06-24T09:51:54.611056Z",
+     "shell.execute_reply": "2026-06-24T09:51:54.610659Z"
+    },
+    "papermill": {
+     "duration": 0.333923,
+     "end_time": "2026-06-24T09:51:54.611257+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:54.277334+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -330,7 +371,16 @@
   {
    "cell_type": "markdown",
    "id": "ae95c930",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003717,
+     "end_time": "2026-06-24T09:51:54.623252+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:54.619535+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -350,10 +400,17 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:03:05.250989Z",
-     "iopub.status.busy": "2026-06-23T20:03:05.250804Z",
-     "iopub.status.idle": "2026-06-23T20:03:05.514814Z",
-     "shell.execute_reply": "2026-06-23T20:03:05.514656Z"
+     "iopub.execute_input": "2026-06-24T09:51:54.635288Z",
+     "iopub.status.busy": "2026-06-24T09:51:54.635054Z",
+     "iopub.status.idle": "2026-06-24T09:51:55.236181Z",
+     "shell.execute_reply": "2026-06-24T09:51:55.235954Z"
+    },
+    "papermill": {
+     "duration": 0.606343,
+     "end_time": "2026-06-24T09:51:55.236286+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:54.629943+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -473,7 +530,16 @@
   {
    "cell_type": "markdown",
    "id": "942bea8e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004649,
+     "end_time": "2026-06-24T09:51:55.247506+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:55.242857+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : le corpus est prêt pour le solveur\n",
     "\n",
@@ -495,7 +561,16 @@
   {
    "cell_type": "markdown",
    "id": "63703a33",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005313,
+     "end_time": "2026-06-24T09:51:55.257554+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:55.252241+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -527,10 +602,17 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:03:05.516103Z",
-     "iopub.status.busy": "2026-06-23T20:03:05.515907Z",
-     "iopub.status.idle": "2026-06-23T20:03:05.756402Z",
-     "shell.execute_reply": "2026-06-23T20:03:05.756184Z"
+     "iopub.execute_input": "2026-06-24T09:51:55.269889Z",
+     "iopub.status.busy": "2026-06-24T09:51:55.269551Z",
+     "iopub.status.idle": "2026-06-24T09:51:55.748814Z",
+     "shell.execute_reply": "2026-06-24T09:51:55.748109Z"
+    },
+    "papermill": {
+     "duration": 0.486752,
+     "end_time": "2026-06-24T09:51:55.749087+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:55.262335+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -663,7 +745,16 @@
   {
    "cell_type": "markdown",
    "id": "70b904bd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004773,
+     "end_time": "2026-06-24T09:51:55.760092+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:55.755319+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : ce que le solveur a choisi\n",
     "\n",
@@ -684,7 +775,16 @@
   {
    "cell_type": "markdown",
    "id": "98366124",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005526,
+     "end_time": "2026-06-24T09:51:55.770619+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:55.765093+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -695,11 +795,15 @@
     "1. Les bornes d'index ne proviennent plus d'une `foodDatabase` codée à la main mais du **corpus RecipeML** (`corpus`).\n",
     "2. On impose une **non-répétition** entre les déjeuners via `Z3Methods.Distinct` — le mode `CollectionHandling.Array` explicite, marqueur des colonnes SMT globales (notebook 05 section 7 variante B).\n",
     "\n",
-    "### Avertissement technique important (workaround confirmé)\n",
+    "### Contexte technique : le modèle de soumission de .NET Interactive\n",
     "\n",
-    "> La cellule ci-dessous regroupe **dans le même bloc** la déclaration des bornes (`platLo`, `platHi`, etc.), la construction du théorème `Where(...)`, **et** l'appel `.Solve()`. Ce n'est pas un hasard : c'est le **workaround validé** pour le pattern `int[][]` en kernel `.net-csharp`.\n",
+    "> La cellule ci-dessous regroupe **dans le même bloc** la déclaration des bornes (`platLo`, `platHi`, etc.), la construction du théorème `Where(...)`, **et** l'appel `.Solve()`. C'est un choix de **lisibilité** : bornes et contraintes se lisent d'un seul tenant.\n",
     ">\n",
-    "> Raison profonde : `ExpressionVisitor.VisitMember` (fork Z3.Linq) résout par réflexion les constantes capturées depuis une **autre cellule .NET Interactive**. Capturer dans une contrainte `Where(...)` une variable déclarée dans une cellule précédente déclenche `ArgumentException : field defined on Submission#N is not a field on Submission#M`. La parade : tout garder dans le même scope. Deux Solves `int[][]` **dans la même cellule** fonctionnent ; un Solve `int[][]` capturant des variables d'une cellule précédente ne fonctionne pas."
+    "> **Arrière-plan technique** (utile à connaître) : en kernel `.net-csharp`, chaque cellule est compilée dans un assembly dynamique distinct appelé une *submission* (`Submission#0`, `Submission#1`, …). Lorsqu'un lambda de contrainte capture une variable déclarée dans une autre cellule, le runtime doit résoudre cette capture *cross-submission*. Historiquement, le `ExpressionVisitor` du fork Z3.Linq résolvait ces constantes par réflexion (`field.GetValue(target)`), ce qui échouait avec une `ArgumentException : field defined on Submission#N is not a field on Submission#M`.\n",
+    ">\n",
+    "> **Ce bug est désormais résolu** : le correctif apporté à `Theorem.AssertConstraints` (réplique de l'issue fork #2) replie les constantes capturées en littéraux via `PartialEvaluator.PartialEval` **avant** la visite de l'arbre d'expression, neutralisant la résolution réflexive cross-assembly. La capture d'une variable déclarée dans une cellule précédente fonctionne donc **désormais** — un test de régression polyglot le valide (`CrossSubmissionCaptureRepro.ipynb`).\n",
+    ">\n",
+    "> Garder bornes + contraintes + solve dans la même cellule reste une bonne pratique de **lisibilité** (et facilite le débogage d'un modèle isolé), mais ce n'est plus une exigence technique."
    ]
   },
   {
@@ -711,10 +815,17 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:03:05.758348Z",
-     "iopub.status.busy": "2026-06-23T20:03:05.758135Z",
-     "iopub.status.idle": "2026-06-23T20:03:05.940036Z",
-     "shell.execute_reply": "2026-06-23T20:03:05.939834Z"
+     "iopub.execute_input": "2026-06-24T09:51:55.783086Z",
+     "iopub.status.busy": "2026-06-24T09:51:55.782476Z",
+     "iopub.status.idle": "2026-06-24T09:51:56.109745Z",
+     "shell.execute_reply": "2026-06-24T09:51:56.109433Z"
+    },
+    "papermill": {
+     "duration": 0.33444,
+     "end_time": "2026-06-24T09:51:56.109848+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:55.775408+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -731,7 +842,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Théorème hiérarchique int[][] résolu en 28,3 ms (status : SAT)\n",
+      "Théorème hiérarchique int[][] résolu en 65,6 ms (status : SAT)\n",
       "\r\n"
      ]
     },
@@ -759,8 +870,8 @@
    ],
    "source": [
     "// Théorème hiérarchique int[][] sur le corpus RecipeML.\n",
-    "// ATTENTION (workaround confirmé) : bornes + Where(...) + Solve() dans la MÊME cellule.\n",
-    "// Ne pas capturer des variables déclarées dans une cellule précédente dans le lambda Where(...).\n",
+    "// Recommandation de lisibilité : bornes + Where(...) + Solve() dans la MÊME cellule.\n",
+    "// (La capture cross-submission est désormais supportée par le correctif AssertConstraints.)\n",
     "\n",
     "public class DayPlan\n",
     "{\n",
@@ -819,7 +930,16 @@
   {
    "cell_type": "markdown",
    "id": "ffdb291c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005092,
+     "end_time": "2026-06-24T09:51:56.120570+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.115478+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : non-répétition comme contrainte globale SMT\n",
     "\n",
@@ -835,14 +955,23 @@
     "**Points clés** :\n",
     "\n",
     "1. Le **même pattern `int[][]`** qui structure un Sudoku (notebook 04) ou un plan hebdomadaire (notebook 05 section 7) fonctionne à l'identique sur un corpus externe — la source de données est orthogonale au modèle.\n",
-    "2. Le workaround même-cellule ne **limite pas** l'expressivité du modèle : il contraint uniquement l'**organisation des cellules** du notebook. Le code reste déclaratif.\n",
+    "2. L'organisation « tout dans la même cellule » est un choix de **lisibilité** : elle n'impose aucune limite d'expressivité au modèle. Depuis le correctif `AssertConstraints` (capture cross-submission désormais supportée), les contraintes peuvent aussi bien référencer des variables déclarées dans une cellule précédente — le code reste déclaratif.\n",
     "3. Avec 3 plats dans le corpus et une contrainte de 3 déjeuners distincts, le solver fait une **permutation complète** de la catégorie `plat` — un cas de non-trivialité Prong-B : la contrainte `Distinct` accomplit ici un travail qu'une simple borne ne pourrait pas exprimer."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ecff06ff",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005209,
+     "end_time": "2026-06-24T09:51:56.130975+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.125766+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -867,7 +996,16 @@
   {
    "cell_type": "markdown",
    "id": "9d0774ee",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005945,
+     "end_time": "2026-06-24T09:51:56.142296+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.136351+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -879,7 +1017,16 @@
   {
    "cell_type": "markdown",
    "id": "ba9a97d9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005037,
+     "end_time": "2026-06-24T09:51:56.153971+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.148934+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 : Contrainte de glucides dans le menu booléen\n",
     "\n",
@@ -900,10 +1047,17 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:03:05.941407Z",
-     "iopub.status.busy": "2026-06-23T20:03:05.941218Z",
-     "iopub.status.idle": "2026-06-23T20:03:05.977045Z",
-     "shell.execute_reply": "2026-06-23T20:03:05.976850Z"
+     "iopub.execute_input": "2026-06-24T09:51:56.166554Z",
+     "iopub.status.busy": "2026-06-24T09:51:56.165898Z",
+     "iopub.status.idle": "2026-06-24T09:51:56.225717Z",
+     "shell.execute_reply": "2026-06-24T09:51:56.225329Z"
+    },
+    "papermill": {
+     "duration": 0.066891,
+     "end_time": "2026-06-24T09:51:56.225836+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.158945+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -932,7 +1086,16 @@
   {
    "cell_type": "markdown",
    "id": "940394d9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005249,
+     "end_time": "2026-06-24T09:51:56.236411+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.231162+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 : Menu à protéines maximales sous budget (dichotomie)\n",
     "\n",
@@ -953,10 +1116,17 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:03:05.978292Z",
-     "iopub.status.busy": "2026-06-23T20:03:05.978083Z",
-     "iopub.status.idle": "2026-06-23T20:03:06.006923Z",
-     "shell.execute_reply": "2026-06-23T20:03:06.006490Z"
+     "iopub.execute_input": "2026-06-24T09:51:56.249298Z",
+     "iopub.status.busy": "2026-06-24T09:51:56.248559Z",
+     "iopub.status.idle": "2026-06-24T09:51:56.342368Z",
+     "shell.execute_reply": "2026-06-24T09:51:56.341887Z"
+    },
+    "papermill": {
+     "duration": 0.101099,
+     "end_time": "2026-06-24T09:51:56.342672+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.241573+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -988,7 +1158,16 @@
   {
    "cell_type": "markdown",
    "id": "8fd0c062",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008207,
+     "end_time": "2026-06-24T09:51:56.359592+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.351385+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 : Menu végétarien uniquement\n",
     "\n",
@@ -1009,10 +1188,17 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:03:06.008420Z",
-     "iopub.status.busy": "2026-06-23T20:03:06.008215Z",
-     "iopub.status.idle": "2026-06-23T20:03:06.045616Z",
-     "shell.execute_reply": "2026-06-23T20:03:06.045041Z"
+     "iopub.execute_input": "2026-06-24T09:51:56.378204Z",
+     "iopub.status.busy": "2026-06-24T09:51:56.377800Z",
+     "iopub.status.idle": "2026-06-24T09:51:56.469963Z",
+     "shell.execute_reply": "2026-06-24T09:51:56.469764Z"
+    },
+    "papermill": {
+     "duration": 0.102105,
+     "end_time": "2026-06-24T09:51:56.470055+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.367950+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -1043,7 +1229,16 @@
   {
    "cell_type": "markdown",
    "id": "39b6913c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004609,
+     "end_time": "2026-06-24T09:51:56.479805+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:51:56.475196+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1059,7 +1254,7 @@
     "| Sélection booléenne + allergène | `MkNot(s.Var)` pour chaque recette contenant l'allergène banni |\n",
     "| Agrégation nutritionnelle | `Aggregate` + `MkITE` — valeurs du corpus, expression Z3 standard |\n",
     "| Plan multi-jours non-répétitif | `int[][]` + `Z3Methods.Distinct` + `CollectionHandling.Array` explicite |\n",
-    "| Workaround même-cellule | Bornes + `Where(...)` + `Solve()` **dans la même cellule** (capture cross-submission impossible) |\n",
+    "| Organisation du code | Bornes + `Where(...)` + `Solve()` regroupés pour la **lisibilité** (capture cross-submission désormais supportée par le correctif `AssertConstraints`) |\n",
     "\n",
     "### Perspective\n",
     "\n",
@@ -1081,6 +1276,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "12.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 13.987246,
+   "end_time": "2026-06-24T09:51:56.720743+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\06b_RecipeML_Corpus.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\06b_RecipeML_Corpus_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-24T09:51:42.733497+00:00",
+   "version": "2.7.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "hdr-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00532,
+     "end_time": "2026-06-24T09:53:55.877189+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:55.871869+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Notebook 06c - Rendu HTML des solutions Z3 : visualisation structurée d'un planificateur de repas\n",
     "\n",
@@ -28,7 +37,16 @@
   {
    "cell_type": "markdown",
    "id": "intro-gap",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005976,
+     "end_time": "2026-06-24T09:53:55.889485+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:55.883509+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -58,11 +76,19 @@
    "id": "setup-imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:20.185578Z",
-     "iopub.status.busy": "2026-06-23T20:47:20.172622Z",
-     "iopub.status.idle": "2026-06-23T20:47:21.535690Z",
-     "shell.execute_reply": "2026-06-23T20:47:21.517925Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:53:55.920203Z",
+     "iopub.status.busy": "2026-06-24T09:53:55.909414Z",
+     "iopub.status.idle": "2026-06-24T09:53:58.031892Z",
+     "shell.execute_reply": "2026-06-24T09:53:58.026610Z"
+    },
+    "papermill": {
+     "duration": 2.137043,
+     "end_time": "2026-06-24T09:53:58.032153+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:55.895110+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -70,7 +96,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-34940.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-50588.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -115,12 +141,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.54.226.85:2048/\", \"http://192.168.48.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://10.54.226.85:2048/\", \"http://172.18.144.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '34940.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '50588.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -206,7 +232,16 @@
   {
    "cell_type": "markdown",
    "id": "sec1-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006986,
+     "end_time": "2026-06-24T09:53:58.048037+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:58.041051+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -223,11 +258,19 @@
    "id": "sec1-corpus",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:21.549526Z",
-     "iopub.status.busy": "2026-06-23T20:47:21.549176Z",
-     "iopub.status.idle": "2026-06-23T20:47:22.492643Z",
-     "shell.execute_reply": "2026-06-23T20:47:22.491963Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:53:58.064573Z",
+     "iopub.status.busy": "2026-06-24T09:53:58.063952Z",
+     "iopub.status.idle": "2026-06-24T09:53:58.909137Z",
+     "shell.execute_reply": "2026-06-24T09:53:58.908851Z"
+    },
+    "papermill": {
+     "duration": 0.853797,
+     "end_time": "2026-06-24T09:53:58.909287+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:58.055490+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -356,7 +399,16 @@
   {
    "cell_type": "markdown",
    "id": "sec2-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004649,
+     "end_time": "2026-06-24T09:53:58.919068+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:58.914419+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -386,11 +438,19 @@
    "id": "sec2-helpers",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:22.495710Z",
-     "iopub.status.busy": "2026-06-23T20:47:22.495292Z",
-     "iopub.status.idle": "2026-06-23T20:47:22.929249Z",
-     "shell.execute_reply": "2026-06-23T20:47:22.928544Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:53:58.934294Z",
+     "iopub.status.busy": "2026-06-24T09:53:58.933650Z",
+     "iopub.status.idle": "2026-06-24T09:53:59.314306Z",
+     "shell.execute_reply": "2026-06-24T09:53:59.313760Z"
+    },
+    "papermill": {
+     "duration": 0.387346,
+     "end_time": "2026-06-24T09:53:59.314621+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:58.927275+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -506,7 +566,16 @@
   {
    "cell_type": "markdown",
    "id": "sec3-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005592,
+     "end_time": "2026-06-24T09:53:59.327479+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:59.321887+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -523,11 +592,19 @@
    "id": "sec3-solve",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:22.931940Z",
-     "iopub.status.busy": "2026-06-23T20:47:22.931541Z",
-     "iopub.status.idle": "2026-06-23T20:47:23.491970Z",
-     "shell.execute_reply": "2026-06-23T20:47:23.491617Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:53:59.355731Z",
+     "iopub.status.busy": "2026-06-24T09:53:59.355041Z",
+     "iopub.status.idle": "2026-06-24T09:53:59.878253Z",
+     "shell.execute_reply": "2026-06-24T09:53:59.878608Z"
+    },
+    "papermill": {
+     "duration": 0.546322,
+     "end_time": "2026-06-24T09:53:59.878788+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:59.332466+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -617,7 +694,16 @@
   {
    "cell_type": "markdown",
    "id": "sec3-interp",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006361,
+     "end_time": "2026-06-24T09:53:59.893390+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:59.887029+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : ce que l'encodage couleur revele d'un coup d'oeil\n",
     "\n",
@@ -641,7 +727,16 @@
   {
    "cell_type": "markdown",
    "id": "sec4-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004626,
+     "end_time": "2026-06-24T09:53:59.903573+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:59.898947+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -649,9 +744,11 @@
     "\n",
     "On étend au plan multi-jours du notebook 06b section 4 : un `int[][]` (3 jours x 2 créneaux) peuplé d'indices de recettes dans le corpus, avec contrainte de non-répétition des déjeuners via `Z3Methods.Distinct` en mode `CollectionHandling.Array`.\n",
     "\n",
-    "### Workaround technique (rappel)\n",
+    "### Rappel technique : modèle de soumission .NET Interactive\n",
     "\n",
-    "> La cellule ci-dessous regroupe **dans le même bloc** la déclaration des bornes (`entLo`, `pltLo`, etc.), la construction du théorème `Where(...)`, **et** l'appel `.Solve()`. Ce n'est pas un hasard : c'est le **workaround validé** pour le pattern `int[][]` en kernel `.net-csharp`. Capturer dans une contrainte `Where(...)` une variable déclarée dans une cellule précédente déclenche `ArgumentException` (le `ExpressionVisitor` du fork Z3.Linq résout par réflexion les constantes cross-submission, ce qui échoue). La parade : tout garder dans le même scope."
+    "> La cellule ci-dessous regroupe **dans le même bloc** la déclaration des bornes (`entLo`, `pltLo`, etc.), la construction du théorème `Where(...)`, **et** l'appel `.Solve()`. C'est un choix de **lisibilité** : bornes et contraintes se lisent d'un seul tenant.\n",
+    ">\n",
+    "> **Arrière-plan** : chaque cellule `.net-csharp` compile dans un assembly dynamique distinct (une *submission* `Submission#N`). Capturer dans un lambda une variable d'une autre cellule exige une résolution *cross-submission*. Ce cas, historiquement cassant en `ArgumentException` dans le fork Z3.Linq, est **désormais résolu** : `Theorem.AssertConstraints` replie les constantes capturées en littéraux via `PartialEvaluator.PartialEval` avant la visite de l'arbre. La capture cross-cellule fonctionne — garder tout dans la même cellule reste une **recommandation de lisibilité**, plus une exigence."
    ]
   },
   {
@@ -660,11 +757,19 @@
    "id": "sec4-solve",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:23.494792Z",
-     "iopub.status.busy": "2026-06-23T20:47:23.494373Z",
-     "iopub.status.idle": "2026-06-23T20:47:23.838605Z",
-     "shell.execute_reply": "2026-06-23T20:47:23.838891Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:53:59.914576Z",
+     "iopub.status.busy": "2026-06-24T09:53:59.914325Z",
+     "iopub.status.idle": "2026-06-24T09:54:00.322062Z",
+     "shell.execute_reply": "2026-06-24T09:54:00.322422Z"
+    },
+    "papermill": {
+     "duration": 0.414761,
+     "end_time": "2026-06-24T09:54:00.322599+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:53:59.907838+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -678,7 +783,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Theoreme int[][] resolu en 74,4 ms (status : SAT)\r\n"
+      "Theoreme int[][] resolu en 92,3 ms (status : SAT)\r\n"
      ]
     },
     {
@@ -702,7 +807,8 @@
    ],
    "source": [
     "// Theoreme hierarchique int[][] sur le corpus RecipeML, rendu en grille HTML.\n",
-    "// ATTENTION (workaround confirme) : bornes + Where(...) + Solve() dans la MEME cellule.\n",
+    "// Recommandation de lisibilite : bornes + Where(...) + Solve() dans la MEME cellule.\n",
+    "// (La capture cross-submission est desormais supportee par le correctif AssertConstraints.)\n",
     "\n",
     "public class DayPlan\n",
     "{\n",
@@ -745,7 +851,16 @@
   {
    "cell_type": "markdown",
    "id": "sec4-interp",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006002,
+     "end_time": "2026-06-24T09:54:00.335793+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:00.329791+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : la grille rend la variété visible\n",
     "\n",
@@ -769,7 +884,16 @@
   {
    "cell_type": "markdown",
    "id": "sec5-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007938,
+     "end_time": "2026-06-24T09:54:00.348188+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:00.340250+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -786,11 +910,19 @@
    "id": "sec5-solve",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:23.841433Z",
-     "iopub.status.busy": "2026-06-23T20:47:23.841041Z",
-     "iopub.status.idle": "2026-06-23T20:47:24.637241Z",
-     "shell.execute_reply": "2026-06-23T20:47:24.637835Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:54:00.362022Z",
+     "iopub.status.busy": "2026-06-24T09:54:00.361371Z",
+     "iopub.status.idle": "2026-06-24T09:54:01.117233Z",
+     "shell.execute_reply": "2026-06-24T09:54:01.116954Z"
+    },
+    "papermill": {
+     "duration": 0.764494,
+     "end_time": "2026-06-24T09:54:01.117337+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:00.352843+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -909,7 +1041,16 @@
   {
    "cell_type": "markdown",
    "id": "sec5-interp",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005328,
+     "end_time": "2026-06-24T09:54:01.128251+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.122923+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : le solveur comme explorateur de l'espace des solutions\n",
     "\n",
@@ -931,7 +1072,16 @@
   {
    "cell_type": "markdown",
    "id": "recap-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004973,
+     "end_time": "2026-06-24T09:54:01.138252+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.133279+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -955,7 +1105,16 @@
   {
    "cell_type": "markdown",
    "id": "exercices-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004896,
+     "end_time": "2026-06-24T09:54:01.148114+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.143218+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -967,7 +1126,16 @@
   {
    "cell_type": "markdown",
    "id": "exo1-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009243,
+     "end_time": "2026-06-24T09:54:01.166591+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.157348+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 : Badge végétarien dans la carte de menu\n",
     "\n",
@@ -985,11 +1153,19 @@
    "id": "exo1-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:24.640619Z",
-     "iopub.status.busy": "2026-06-23T20:47:24.640186Z",
-     "iopub.status.idle": "2026-06-23T20:47:24.868237Z",
-     "shell.execute_reply": "2026-06-23T20:47:24.867850Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:54:01.177732Z",
+     "iopub.status.busy": "2026-06-24T09:54:01.177482Z",
+     "iopub.status.idle": "2026-06-24T09:54:01.286259Z",
+     "shell.execute_reply": "2026-06-24T09:54:01.286026Z"
+    },
+    "papermill": {
+     "duration": 0.115055,
+     "end_time": "2026-06-24T09:54:01.286357+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.171302+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1022,7 +1198,16 @@
   {
    "cell_type": "markdown",
    "id": "exo2-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005586,
+     "end_time": "2026-06-24T09:54:01.297855+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.292269+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 : Total kcal par jour dans la grille hebdomadaire\n",
     "\n",
@@ -1040,11 +1225,19 @@
    "id": "exo2-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:24.870501Z",
-     "iopub.status.busy": "2026-06-23T20:47:24.870058Z",
-     "iopub.status.idle": "2026-06-23T20:47:24.940452Z",
-     "shell.execute_reply": "2026-06-23T20:47:24.939762Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:54:01.310091Z",
+     "iopub.status.busy": "2026-06-24T09:54:01.309803Z",
+     "iopub.status.idle": "2026-06-24T09:54:01.371900Z",
+     "shell.execute_reply": "2026-06-24T09:54:01.371684Z"
+    },
+    "papermill": {
+     "duration": 0.068804,
+     "end_time": "2026-06-24T09:54:01.372000+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.303196+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1074,7 +1267,16 @@
   {
    "cell_type": "markdown",
    "id": "exo3-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005496,
+     "end_time": "2026-06-24T09:54:01.383701+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.378205+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 : Front de Pareto 2D (budget × plancher protéines) rendu en heatmap\n",
     "\n",
@@ -1092,11 +1294,19 @@
    "id": "exo3-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T20:47:24.943044Z",
-     "iopub.status.busy": "2026-06-23T20:47:24.942566Z",
-     "iopub.status.idle": "2026-06-23T20:47:25.004587Z",
-     "shell.execute_reply": "2026-06-23T20:47:25.003859Z"
-    }
+     "iopub.execute_input": "2026-06-24T09:54:01.396944Z",
+     "iopub.status.busy": "2026-06-24T09:54:01.396647Z",
+     "iopub.status.idle": "2026-06-24T09:54:01.449996Z",
+     "shell.execute_reply": "2026-06-24T09:54:01.449687Z"
+    },
+    "papermill": {
+     "duration": 0.060834,
+     "end_time": "2026-06-24T09:54:01.450098+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.389264+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1124,7 +1334,16 @@
   {
    "cell_type": "markdown",
    "id": "conclusion",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005673,
+     "end_time": "2026-06-24T09:54:01.461840+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T09:54:01.456167+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1162,6 +1381,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "12.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 9.48066,
+   "end_time": "2026-06-24T09:54:01.702045+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\06c_Meal_Planner_Visualization.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\06c_Meal_Planner_Visualization_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-24T09:53:52.221385+00:00",
+   "version": "2.7.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {


### PR DESCRIPTION
## Summary

Epic **#1206** — Z3.Linq series. Pedagogical-debt cleanup **after** the submodule bump landed in #4124.

The cross-submission capture bug (fork issue #2) is now **resolved** by the `Theorem.AssertConstraints` fix — `PartialEvaluator.PartialEval` folds captured constants to literals before expression visiting, neutralizing the reflexive cross-assembly resolution that crashed. A polyglot regression test (`CrossSubmissionCaptureRepro.ipynb`) validates that cross-cell capture works.

Notebooks **06b** (RecipeML Corpus) and **06c** (Meal Planner Visualization) documented the "keep bounds + `Where(...)` + `.Solve()` in the same cell" rule as a **mandatory workaround**, with dedicated sections (`### Avertissement technique important (workaround confirmé)`, `### Workaround technique (rappel)`). That narrative is now **obsolete** — the crash it worked around no longer occurs.

## What changed

Reformulated to keep the **veridique, pedagogically valuable** explanation of the .NET Interactive submission model (`Submission#N` dynamic assemblies), but reframed "same cell" from a mandatory workaround to a **readability recommendation**, with an explicit note that the historical crash is resolved and cross-cell capture now works.

| Notebook | Cells |
|----------|-------|
| 06b_RecipeML_Corpus | intro note + Avertissement section + §4 interp pt 2 + conclusion table row + code comment (5 cells) |
| 06c_Meal_Planner_Visualization | Workaround section + code comment (2 cells) |

Same proven approach as the merged #4129 (notebook 05). Code behavior is **unchanged** — only prose and code comments relaxed.

## Validation (rule C.2)

Both notebooks re-executed end-to-end (kernel `.net-csharp`, CWD = notebook dir for relative `#r`):

- **06b**: 8/8 code cells, `execution_count` populated, 0 errors, 0 empty outputs
- **06c**: 9/9 code cells, `execution_count` populated, 0 errors, 0 empty outputs
- grep `workaround` (source-only) in both notebooks: **0 residual mentions**
- Catalogue (`COURSE_CATALOG.generated.*`): byte-identique to `main` (untouched)

Part of #1206 (Z3.Linq Epic). See #1206, #4124 (submodule bump), #4129 (notebook 05 prose).