### PR TITLE
lean(cooperative): prove dictator_banzhaf_pos (Dictator -> 0 < BanzhafRaw)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1055,6 +1055,24 @@ def VetoPlayer (G : TUGame N) (i : N) : Prop :=
 def Dictator (G : TUGame N) (i : N) : Prop :=
   G.v {i} = 1 ∧ VetoPlayer G i
 
+/-- A dictator has a strictly positive raw Banzhaf index. The positive counterpart of
+    `dummy_banzhaf_raw_zero`: a dummy never changes a coalition's value (BanzhafRaw = 0),
+    whereas a dictator wins alone (`v {i} = 1`, the first conjunct of `Dictator`) and the
+    empty coalition has value `0` (`TUGame.empty_zero`), so `{i}` is a critical coalition
+    (`i ∈ {i}`, `v {i} = 1`, `v ({i}.erase i) = v ∅ = 0`). Hence the critical-coalition
+    filter is non-empty and its cardinality is positive. -/
+theorem dictator_banzhaf_pos (G : TUGame N) (i : N) (h : Dictator G i) :
+    0 < BanzhafRaw G i := by
+  have hcrit : Critical G i ({i} : Finset N) := by
+    refine ⟨?_, ?_, ?_⟩
+    · simp
+    · exact h.1
+    · have herase : ({i} : Finset N).erase i = ∅ := by simp
+      rw [herase]
+      exact G.empty_zero
+  simp only [BanzhafRaw]
+  exact Finset.card_pos.mpr ⟨{i}, Finset.mem_filter.2 ⟨Finset.mem_univ _, hcrit⟩⟩
+
 /-- Dummy player: adds no value -/
 def DummyPlayer (G : TUGame N) (i : N) : Prop :=
   ∀ S : Finset N, i ∉ S → G.v (S ∪ {i}) = G.v S


### PR DESCRIPTION
## `dictator_banzhaf_pos`: a dictator has strictly positive Banzhaf index

Positive counterpart of `dummy_banzhaf_raw_zero` (already on main): a dummy player
never changes a coalition's value (`BanzhafRaw = 0`), whereas a **dictator** wins alone
and is therefore critical in the singleton coalition `{i}`.

### Theorem

```lean
theorem dictator_banzhaf_pos (G : TUGame N) (i : N) (h : Dictator G i) :
    0 < BanzhafRaw G i
```

**Proof.** A dictator `i` satisfies `v {i} = 1` (first conjunct of `Dictator`), and the
empty coalition has value `0` (`TUGame.empty_zero`). Hence `{i}` is critical:
`i ∈ {i}`, `v {i} = 1`, `v ({i}.erase i) = v ∅ = 0`. The critical-coalition filter is
non-empty, so its cardinality (`BanzhafRaw`) is positive (via `Finset.card_pos`).

Together with `dummy_banzhaf_raw_zero`, this completes the dummy/dictator contrast for
the raw Banzhaf index: dummy → 0, dictator → > 0.

### Proof integrity (lean-merge-discipline §1)

```
✔ [8434/8435] Built CooperativeGames (16s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (8435 jobs, LAKE_EXIT=0)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (pure addition, no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +18, theorem inserted right after the `Dictator` definition), **0 catalogue file touched**
- **independent of #4134** (`SimpleGame` foundation): uses only `empty_zero` + the `Dictator` def + `BanzhafRaw`, no `SimpleGame` hypothesis. Content region is disjoint from #4134's insertion point → merges cleanly in either order.

### Atomic / scope

One theorem, one subject (the dummy/dictator Banzhaf contrast). Part of the Veto/Dictator
structural axis that follows the Banzhaf index consolidation (#4130) and `SimpleGame`
foundation (#4134).

See #4071 #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
