### PR TITLE
docs(qcpy): citation audit QC-Py-23 SSM/Mamba (S4 + Mamba + LSTM) + References

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -651,7 +651,9 @@
     "\n",
     "**Résultat** : Premier SSM compétitif avec les Transformers sur Long Range Arena.\n",
     "\n",
-    "> *Ancre savante -- Tay, Dehghani, Abnar et al. (2021), « Long Range Arena: A Benchmark for Efficient Transformers », ICLR 2021 (arXiv:2011.04016) -- benchmark de référence comparant Transformers efficaces et SSM sur longues séquences.*"
+    "> *Ancre savante -- Tay, Dehghani, Abnar et al. (2021), « Long Range Arena: A Benchmark for Efficient Transformers », ICLR 2021 (arXiv:2011.04016) -- benchmark de référence comparant Transformers efficaces et SSM sur longues séquences.*\n",
+    "\n",
+    "> *Ancre savante -- Gu, A., Goel, K. & Re, C. (2022), Efficiently Modeling Long Sequences with Structured State Spaces, ICLR 2022 (arXiv:2111.00396). (Papier S4 : representation NPLR + noyau de Cauchy via FFT, premier SSM competitif avec les Transformers sur les benchmarks Long Range Arena ; fonde l'initialisation HiPPO comme condition de stabilite.) Suite directe de HiPPO (Gu, Dao, Ermon, Rudra & Re 2020, arXiv:2008.07669).*\n"
    ]
   },
   {
@@ -934,7 +936,9 @@
     "Mamba utilise des optimisations GPU spécifiques :\n",
     "- **Parallel scan** au lieu de récurrence séquentielle\n",
     "- **Kernel fusion** pour réduire les accès mémoire\n",
-    "- **Recomputation** dans le backward pass"
+    "- **Recomputation** dans le backward pass\n",
+    "\n",
+    "> *Ancre savante -- Gu, A. & Dao, T. (2023), Mamba: Linear-Time Sequence Modeling with Selective State Spaces (arXiv:2312.00752). (Innovation cle : rendre les matrices B, C et le pas Delta dependants de l'input -> state space model selectif, contexte-aware, complexite lineaire O(n) vs quadratique O(n^2) de l'attention ; scan parallele hardware-aware.) Generalise S4 (Gu, Goel & Re 2022) en levant la contrainte de matrices fixes.*\n"
    ]
   },
   {
@@ -2286,7 +2290,9 @@
     "\n",
     "## Partie 6 : Comparaison LSTM vs Transformer vs Mamba (10 min)\n",
     "\n",
-    "### Benchmark sur les mêmes données"
+    "### Benchmark sur les mêmes données\n",
+    "\n",
+    "> *Ancre savante -- Hochreiter, S. & Schmidhuber, J. (1997), Long Short-Term Memory, Neural Computation 9(8):1735-1780. DOI 10.1162/neco.1997.9.8.1735. (Architecture LSTM a portes forget/input/output, resout le vanishing-gradient des RNN classiques sur les longues sequences ; baseline recurrente de la comparaison LSTM vs Transformer vs Mamba ci-dessous. Vaswani et al. 2017 / Gu & Dao 2023 sont ancrees dans les Parties 1 et 3.)*\n"
    ]
   },
   {
@@ -3139,7 +3145,16 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook complété. Vous maîtrisez maintenant les State Space Models (Mamba) pour le trading algorithmique à complexité O(n).**"
+    "**Notebook complété. Vous maîtrisez maintenant les State Space Models (Mamba) pour le trading algorithmique à complexité O(n).**\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Gu, A. & Dao, T. (2023). Mamba: Linear-Time Sequence Modeling with Selective State Spaces. arXiv:2312.00752.\n",
+    "- Gu, A., Goel, K. & Re, C. (2022). Efficiently Modeling Long Sequences with Structured State Spaces. ICLR 2022. arXiv:2111.00396.\n",
+    "- Gu, A., Dao, T., Ermon, S., Rudra, A. & Re, C. (2020). HiPPO: Recurrent Memory with Optimal Polynomial Projections. NeurIPS 2020. arXiv:2008.07669.\n",
+    "- Hochreiter, S. & Schmidhuber, J. (1997). Long Short-Term Memory. Neural Computation 9(8):1735-1780. DOI 10.1162/neco.1997.9.8.1735.\n",
+    "- Vaswani, A. et al. (2017). Attention Is All You Need. NeurIPS 2017. arXiv:1706.03762.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Citation audit **QC-Py-23-Attention-Transformers.ipynb** for **#3164** (verdict **OMISSION**, markdown-additive).

The notebook covers **State Space Models / S4 / Mamba** (the filename "Attention-Transformers" is legacy). It already had 2 ad-hoc anchors (Vaswani 2017 cell 3, HiPPO cell 11); this PR fills the genuine OMISSION gaps.

## Anchors added (3)

| Cell | Concept | Citation | Why anchored |
|------|---------|----------|--------------|
| 11 | **S4** (Structured State Space) | Gu, Goel & Ré (2022), ICLR, arXiv:2111.00396 | Heading named "ICLR 2022" but no citation |
| 16 | **Mamba** (Selective State Spaces) | Gu & Dao (2023), arXiv:2312.00752 | Named inline "Gu & Dao, 2023" without full anchor |
| 35 | **LSTM** (benchmark baseline) | Hochreiter & Schmidhuber (1997), Neural Computation 9(8):1735-1780, DOI 10.1162/neco.1997.9.8.1735 | Named as comparison baseline without anchor |

**References academiques** section appended to cell 44 (Conclusion): 5 entries (Mamba, S4, HiPPO, LSTM, Vaswani 2017).

## Verification

- **0 code cells changed** (byte-identical source/outputs/execution_count)
- Only markdown cells **11, 16, 35, 44** modified (+19/-4 content-level)
- 45 cells total (unchanged)
- `notebook_tools validate`: **0 error** (1 pre-existing cell-id warning also present on `origin/main` — not a regression)
- 0 `raise NotImplementedError` / `assert False` patterns
- All 3 citations are textbook-grade canonical papers (no web-reverification needed)

See #3164. (Partial contribution to the QC-Py citation-audit epic — not closing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)