### PR TITLE
docs(qcpy): citation audit QC-Py-34 RL SAC + A2C (SAC + A3C + Sutton-Barto) + References

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
@@ -66,7 +66,9 @@
     "- On-policy synchrone (version simplifiee de A3C sans parallelisme)\n",
     "- Utilise l'avantage (reward - baseline) pour reduire la variance\n",
     "- Plus simple et plus rapide que PPO (pas de clipping, pas de PPO epochs)\n",
-    "- Moins stable que PPO mais plus rapide a converger"
+    "- Moins stable que PPO mais plus rapide a converger\n",
+    "\n",
+    "> *Ancre savante -- Sutton, R.S. & Barto, A.G. (2018), Reinforcement Learning: An Introduction (2nd ed.), MIT Press, ISBN 978-0-262-03924-6. (Manuel de reference du RL : formalise la taxonomie value-based vs policy-gradient et on-policy vs off-policy utilisee ici pour positionner DQN/PPO/A2C/SAC ; source canonique des concepts de politique, fonction de valeur, avantage et equation de Bellman.)*\n"
    ]
   },
   {
@@ -518,7 +520,9 @@
     "- **Double Q-network** : Deux evaluateurs Q pour reduire la surestimation\n",
     "- **V-network** : Fonction de valeur separee (stabilise l'apprentissage)\n",
     "- **Target networks** : Copie lente pour stabilite\n",
-    "- **Replay buffer** : Stocke les transitions pour reutilisation"
+    "- **Replay buffer** : Stocke les transitions pour reutilisation\n",
+    "\n",
+    "> *Ancres savantes -- Haarnoja, T., Zhou, A., Abbeel, P. & Levine, S. (2018), Soft Actor-Critic: Off-Policy Maximum Entropy Deep Reinforcement Learning with a Stochastic Actor, ICML 2018 (arXiv:1801.01290) (algorithme SAC : actor-critic off-policy maximisant recompense ET entropie, double Q-network + target smoothing + temperature alpha auto-adaptable) ; Haarnoja, T., Zhou, A., Hartikainen, K. et al. (2018), Soft Actor-Critic Algorithms and Applications (arXiv:1812.05905) (cadre du RL a entropie maximale, justification theorique de la regularisation par l'entropie et de l'exploration automatique).)*\n"
    ]
   },
   {
@@ -748,7 +752,9 @@
     "- Pas de clipping : l'avantage est utilise directement\n",
     "- Pas de PPO epochs : une seule passe par batch\n",
     "- Plus rapide par step mais moins stable sur les marches bruites\n",
-    "- N steps returns au lieu de GAE"
+    "- N steps returns au lieu de GAE\n",
+    "\n",
+    "> *Ancres savantes -- Mnih, V., Puigdomenech Badia, A., Mirza, M. et al. (2016), Asynchronous Methods for Deep Reinforcement Learning, ICML 2016 (arXiv:1602.01783) (A3C = acteurs-asynchrones ; A2C en est la variante synchrone deterministe decrite ici, sans parallelisme) ; Sutton, R.S., McAllester, D., Singh, S. & Mansour, Y. (2000), Policy Gradient Methods for Reinforcement Learning with Function Approximation, NeurIPS 2000 (cadre des methodes policy-gradient avec approximateur de fonction, fondement de l'acteur et de l'usage de l'avantage A(s,a) = R - V(s) comme signal).)*\n"
    ]
   },
   {
@@ -1577,7 +1583,16 @@
     "- **Overfitting** : Les hyperparametres doivent etre valides par walk-forward\n",
     "- **Reward shaping** : La fonction de recompense est le choix le plus impactant\n",
     "- **Approches hierarchiques** : Combiner un meta-controleur avec des sous-politiques\n",
-    "- **Multi-agent** : Plusieurs agents cooperatifs pour differents actifs ou horizons"
+    "- **Multi-agent** : Plusieurs agents cooperatifs pour differents actifs ou horizons\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Haarnoja, T., Zhou, A., Abbeel, P. & Levine, S. (2018). Soft Actor-Critic: Off-Policy Maximum Entropy Deep Reinforcement Learning with a Stochastic Actor. ICML 2018. arXiv:1801.01290.\n",
+    "- Haarnoja, T., Zhou, A., Hartikainen, K. et al. (2018). Soft Actor-Critic Algorithms and Applications. arXiv:1812.05905.\n",
+    "- Mnih, V., Puigdomenech Badia, A., Mirza, M. et al. (2016). Asynchronous Methods for Deep Reinforcement Learning. ICML 2016. arXiv:1602.01783.\n",
+    "- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press. ISBN 978-0-262-03924-6.\n",
+    "- Sutton, R.S., McAllester, D., Singh, S. & Mansour, Y. (2000). Policy Gradient Methods for Reinforcement Learning with Function Approximation. NeurIPS 2000.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Citation audit **QC-Py-34-RL-SAC-A2C-Trading.ipynb** for **#3164** (verdict **OMISSION pleine**).

0 scholarly anchors, 0 References section, but 138× SAC / 133× A2C named in prose with canonical originators (Haarnoja, Mnih) named without citation. Same profile as QC-Py-32 DQN (#3784) and QC-Py-33 PPO (#3786).

## Anchors added (3 markdown cells + References)

| Cell | Concept | Citation |
|------|---------|----------|
| 3 | RL taxonomy (on/off-policy × value/policy-gradient) | Sutton & Barto (2018), *Reinforcement Learning: An Introduction* (2nd ed.), MIT Press, ISBN 978-0-262-03924-6 |
| 12 | **SAC** (named "Haarnoja et al. 2018") | Haarnoja, Zhou, Abbeel & Levine (2018), ICML, arXiv:1801.01290 + max-entropy RL framework (Haarnoja et al. 2018, arXiv:1812.05905) |
| 17 | **A3C/A2C** (named "version synchrone de A3C") | Mnih et al. (2016), ICML, arXiv:1602.01783 + policy-gradient framework (Sutton, McAllester, Singh & Mansour 2000, NeurIPS) |
| 39 | Conclusion | Appended **References academiques** section (5 entries) |

## Verification

- **0 code cells changed** (byte-identical source/outputs/execution_count)
- Only markdown cells **3, 12, 17, 39** modified (+19/-4 content-level)
- 40 cells total (unchanged)
- `notebook_tools validate`: **0 error** (1 pre-existing warning, also on `origin/main`)
- 0 `raise NotImplementedError` / `assert False` patterns
- All 4 papers are textbook-grade canonical RL references (no web-reverification needed)

See #3164. (Partial contribution to the QC-Py citation-audit epic — not closing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)