### PR TITLE
feat(astar): Consistency.lean — consistent_implies_admissible (telescoping), sorry 0 (See #4048 phase 2)

### DIFF
--- a/.github/workflows/lean-astar.yml
+++ b/.github/workflows/lean-astar.yml
@@ -1,0 +1,39 @@
+name: Lean CI (astar_lean)
+
+# CI for astar_lean (Search/astar_lean) — A* optimality lake at the Search series
+# root. Formalizes the landmark theorems of A* (Hart, Nilsson & Raphael, 1968):
+# phase-1 `admissible_implies_optimal` (PR #4090), phase-2
+# `consistent_implies_admissible` (téléscopage, this PR). See #4048, roadmap #4038,
+# registry #3801 (prong B « problème non-trivial » — répond au grief BFS-vs-A*
+# dégénéré sur graphe à coût uniforme).
+#
+# sorry-filter-mode=standalone-tactic, baseline=0: the astar lake is fully
+# sorry-free across all modules (Graph, Heuristic, Optimality, Consistency).
+# standalone-tactic counts only standalone `sorry` tokens (never false-positives on
+# prose); baseline 0 = any new standalone sorry fails CI. See lean-build.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/Search/astar_lean/**.lean'
+      - 'MyIA.AI.Notebooks/Search/astar_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/Search/astar_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/Search/astar_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/Search/astar_lean/**.lean'
+      - 'MyIA.AI.Notebooks/Search/astar_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/Search/astar_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/Search/astar_lean/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/Search/astar_lean
+      display-name: astar_lean
+      sorry-baseline: "0"
+      sorry-filter-mode: standalone-tactic

--- a/MyIA.AI.Notebooks/Search/astar_lean/Astar.lean
+++ b/MyIA.AI.Notebooks/Search/astar_lean/Astar.lean
@@ -1,3 +1,4 @@
 import Astar.Graph
 import Astar.Heuristic
 import Astar.Optimality
+import Astar.Consistency

--- a/MyIA.AI.Notebooks/Search/astar_lean/Astar/Consistency.lean
+++ b/MyIA.AI.Notebooks/Search/astar_lean/Astar/Consistency.lean
@@ -1,0 +1,101 @@
+import Mathlib
+import Astar.Graph
+import Astar.Heuristic
+import Astar.Optimality
+
+/-!
+# Astar.Consistency — consistance ⟹ admissibilité (téléscopage)
+
+Issue #4048, théorème cible `consistent_implies_admissible`. La **consistance**
+(monotonie par arc : `h n ≤ edge n n' + h n'`) est une condition **locale** ;
+l'**admissibilité** (`h n ≤ hStar n`) est une condition **globale**. Le pont entre les
+deux est un **téléscopage** : le long des arcs d'un chemin `start = v₀ → v₁ → … → vₖ =
+goal`, la consistance se compose en
+
+```
+h(start) ≤ edge(v₀,v₁) + h(v₁)
+         ≤ edge(v₀,v₁) + edge(v₁,v₂) + h(v₂)
+         ≤ …
+         ≤ pathCost(p) + h(goal).
+```
+
+Sous l'hypothèse naturelle `h(goal) = 0` (l'heuristique est nulle au but), il vient
+**`h(start) ≤ pathCost(p)` pour tout chemin `p` allant au but** — c'est exactement la
+borne globale que l'admissibilité fournit aussi (cf `admissible_head_bound` dans
+`Optimality.lean`). C'est le contenu substantiel de « la consistance implique
+l'admissibilité » : la condition locale, par téléscopage, atteint gratuitement la
+borne globale.
+
+**Note de cadrage (honnête).** Dans ce modèle abstrait, `hStar` n'est qu'une *borne
+inférieure* sur les coûts de chemins (`IsTrueRemainingCost`), pas nécessairement le
+coût optimal réalisé. La consistance donne `h(start) ≤ pathCost(p)` pour **tout**
+chemin réalisé `p` ; en déduire `h(start) ≤ hStar(start)` nécessiterait que `hStar`
+soit le *minimum atteint* (graphe fini, chemins simples en nombre fini). Cette
+« réalisabilité de `hStar` » est délibérément laissée abstraite ici (cf #4048 : on
+prouve la **forme abstraite**). Le résultat `consistent_implies_path_bound` ci-dessous
+est donc le **théorème substantiel pleinement prouvé** ; il entraîne l'admissibilité au
+sens « ne surestime jamais un coût de chemin réalisé », qui est le mécanisme exact
+d'optimalité de A*. Voir Hart, Nilsson & Raphael (1968).
+-/
+
+namespace Astar
+
+variable {V : Type*} (G : WeightedGraph V)
+
+/-- **Consistance ⟹ borne sur le chemin (téléscopage).** Théorème cible #4048
+    (`consistent_implies_admissible`). Une heuristique **consistante** nulle au but
+    (`h goal = 0`) ne dépasse jamais le coût d'un chemin réalisé vers le but : pour
+    tout chemin `p` de `start` à `goal`, `h(start) ≤ pathCost(p)`.
+
+    La consistance est locale (par arc) ; par téléscopage le long des arcs du chemin,
+    elle atteint la même borne globale que l'admissibilité (`h ≤ hStar ≤ pathCost`).
+    C'est le mécanisme exact qui rend A* optimal sous heuristique consistante : la
+    fonction `f = g + h` est alors croissante le long des chemins, donc aucun nœud
+    n'est jamais ré-expansé (cf Hart, Nilsson & Raphael 1968). -/
+theorem consistent_implies_path_bound (h : V → NNReal) (goal : V)
+    (hCons : Consistent G h) (hGoal : h goal = 0)
+    (start : V) (p : Path V) (hp : PathFrom start goal p) :
+    h start ≤ pathCost G p := by
+  obtain ⟨hnel, hhead, hlast⟩ := hp
+  -- Lemme auxiliaire : pour toute liste `q` finissant au `goal`, `h(q.head) ≤ pathCost q`.
+  -- (On garde `start` abstrait via sa position de tête, pour pouvoir récurer sur la queue.)
+  have key : ∀ (q : Path V), q.getLast? = some goal →
+      ∀ s : V, q.head? = some s → h s ≤ pathCost G q := by
+    intro q
+    induction q with
+    | nil => simp
+    | cons hd tl ih =>
+      intro hqgoal s hs
+      -- `hs : (hd :: tl).head? = some s`  ⟹  `hd = s`. (`subst` élimine `s`, garde `hd`.)
+      have hhd : hd = s := by simp_all
+      subst hhd
+      cases tl with
+      | nil =>
+        -- `q = [hd]`, `getLast? = some goal` ⟹ `hd = goal`, puis `pathCost = 0`.
+        have hhdg : hd = goal := by simp_all
+        simp only [pathCost_singleton]
+        rw [hhdg, hGoal]
+      | cons w rest' =>
+        -- `q = hd :: w :: rest'`. Le dernier sommet est porté par la queue.
+        have hqgoal' : (w :: rest').getLast? = some goal := by simp_all
+        -- Récurrence sur la queue `(w :: rest')` : `h w ≤ pathCost(w :: rest')`.
+        have hihw : h w ≤ pathCost G (w :: rest') := ih hqgoal' w (by simp)
+        -- Consistance à l'arc `(hd, w)` : `h hd ≤ edge(hd,w) + h w`.
+        have hcons := hCons hd w
+        -- `pathCost(hd :: w :: rest') = edge(hd,w) + pathCost(w :: rest')`.
+        simp only [pathCost_cons_cons]
+        linarith
+  exact key p hlast start hhead
+
+/-- **Consistance ⟹ admissibilité au sens du chemin.** Corollaire immédiat du
+    téléscopage : sous une heuristique consistante nulle au but, l'heuristique au
+    départ ne dépasse jamais le coût d'un chemin menant au but — exactement la borne
+    que fournit l'admissibilité (`admissible_head_bound`), atteinte ici sans hypothèse
+    sur `hStar`. -/
+theorem consistent_implies_admissible_bound (h : V → NNReal) (goal : V)
+    (hCons : Consistent G h) (hGoal : h goal = 0)
+    (start : V) (p : Path V) (hp : PathFrom start goal p) :
+    h start ≤ pathCost G p :=
+  consistent_implies_path_bound G h goal hCons hGoal start p hp
+
+end Astar

--- a/MyIA.AI.Notebooks/Search/astar_lean/README.md
+++ b/MyIA.AI.Notebooks/Search/astar_lean/README.md
@@ -55,7 +55,8 @@ cf #4048) : la **borne en `f`** qui est le mécanisme exact d'optimalité de A*.
 
 - [`Astar/Graph.lean`](Astar/Graph.lean) — `WeightedGraph`, `pathCost`, `PathFrom`.
 - [`Astar/Heuristic.lean`](Astar/Heuristic.lean) — `Admissible`, `Consistent`.
-- [`Astar/Optimality.lean`](Astar/Optimality.lean) — théorème phare.
+- [`Astar/Optimality.lean`](Astar/Optimality.lean) — théorème phare (`admissible_implies_optimal`).
+- [`Astar/Consistency.lean`](Astar/Consistency.lean) — `consistent_implies_path_bound` (consistance ⟹ admissibilité, téléscopage).
 
 ## Théorème phare
 
@@ -76,6 +77,44 @@ C'est la borne en `f` en chaque nœud — le mécanisme exact d'optimalité de A
 le pas via `le_trans`. Le fait clé : un suffixe d'un chemin allant au but va encore au
 but (`suffix_pathFrom`).
 
+## Consistance ⟹ admissibilité (téléscopage) — phase 2
+
+```lean
+theorem consistent_implies_path_bound (h : V → NNReal) (goal : V)
+    (hCons : Consistent G h) (hGoal : h goal = 0)
+    (start : V) (p : Path V) (hp : PathFrom start goal p) :
+    h start ≤ pathCost G p
+```
+
+La **consistance** (`h n ≤ edge n n' + h n'`, condition *locale* par arc) implique
+l'**admissibilité** (*globale*) par un **téléscopage** le long des arcs d'un chemin
+`start = v₀ → v₁ → … → vₖ = goal` :
+
+```text
+h(start) ≤ edge(v₀,v₁) + h(v₁) ≤ edge(v₀,v₁) + edge(v₁,v₂) + h(v₂) ≤ … ≤ pathCost(p) + h(goal).
+```
+
+Sous l'hypothèse naturelle `h(goal) = 0`, il vient **`h(start) ≤ pathCost(p)` pour tout
+chemin `p` allant au but** — exactement la borne globale que l'admissibilité fournit
+aussi (`admissible_head_bound`), atteinte ici sans hypothèse sur `hStar`. C'est le
+mécanisme exact qui rend A* optimal sous heuristique consistante : la fonction `f = g + h`
+est alors croissante le long des chemins, donc aucun nœud n'est jamais ré-expansé.
+
+**Preuve** (0 `sorry`, axiomes `[propext, Classical.choice, Quot.sound]`) : récurrence sur
+la liste-chemin. Cas singleton `[goal]` : `pathCost = 0` et `h(goal) = 0`. Cas
+`hd :: w :: rest'` : récurrence sur la queue donne `h w ≤ pathCost(w :: rest')`, la
+consistance à l'arc `(hd, w)` donne `h hd ≤ edge(hd, w) + h w`, et
+`pathCost(hd :: w :: rest') = edge(hd, w) + pathCost(w :: rest')` ; `linarith` conclut.
+
+**Cadrage honnête.** Dans ce modèle abstrait, `hStar` n'est qu'une *borne inférieure* sur
+les coûts de chemins (`IsTrueRemainingCost`), pas nécessairement le coût optimal *réalisé*.
+Le téléscopage donne `h(start) ≤ pathCost(p)` pour **tout** chemin réalisé `p` — le
+mécanisme exact d'optimalité de A* (« ne surestime jamais un coût de chemin réalisé »).
+En déduire `h(start) ≤ hStar(start)` nécessiterait que `hStar` soit le *minimum atteint*
+(graphe fini, chemins simples en nombre fini) : cette « réalisabilité de `hStar` » est
+laissée ouverte (phase suivante, construction effective de `hStar`). On prouve donc ici
+la **forme abstraite** suggérée par #4048.
+
 ## Construction
 
 ```bash
@@ -88,16 +127,16 @@ Prérequis : [elan](https://github.com/leanprover/elan) (toolchain
 
 ## État et suite
 
-Ce premier livrable (#4048 phase 1) couvre :
+Ce livrable couvre les phases 1-2 (#4048) :
 
 - [x] Scaffolding du lake (lakefile, toolchain, `.gitignore`)
 - [x] Modèle (`WeightedGraph`, `pathCost`, `PathFrom`)
 - [x] Définitions (`Admissible`, `Consistent`, `IsTrueRemainingCost`)
-- [x] **Théorème phare `admissible_implies_optimal` — 0 `sorry`** (critère de sortie #4048)
+- [x] **Théorème phare `admissible_implies_optimal` — 0 `sorry`** (phase 1, PR #4090)
+- [x] **`consistent_implies_admissible` — 0 `sorry`** (phase 2, téléscopage de la consistance le long du chemin)
 
 Phases suivantes (suivi #4048) :
 
-- [ ] `consistent_implies_admissible` (téléscopage de la consistance le long du chemin optimal)
 - [ ] `consistent_implies_monotone_f` (`f = g + h` croissante ⇒ pas de ré-expansion)
 - [ ] Construction effective de `hStar` sur graphe fini (minimum sur chemins simples)
 - [ ] Modélisation de la file de priorité et preuve « A* renvoie le chemin optimal » bout-en-bout


### PR DESCRIPTION
## Summary

Phase 2 of the A\* optimality lake (**#4048**, roadmap #4038, registry #3801 prong B « problème non-trivial »). Proves the second landmark theorem: **consistency ⟹ admissibility**, by telescoping the per-arc consistency inequality along a path's arcs.

This is a **partial delivery** to the open epic #4048 (phase 1 `admissible_implies_optimal` shipped via merged PR #4090; phases 3+ remain). Using `See #4048` (not `Closes`) — the issue stays open.

### The theorem

```lean
theorem consistent_implies_path_bound (h : V → NNReal) (goal : V)
    (hCons : Consistent G h) (hGoal : h goal = 0)
    (start : V) (p : Path V) (hp : PathFrom start goal p) :
    h start ≤ pathCost G p
```

Consistency (local, per-arc: `h n ≤ edge n n' + h n'`) implies admissibility (global) by telescoping along a path `start = v₀ → v₁ → … → vₖ = goal`:

```
h(start) ≤ edge(v₀,v₁) + h(v₁) ≤ … ≤ pathCost(p) + h(goal)
```

hence `h(start) ≤ pathCost p` under `h goal = 0` — exactly the global bound that admissibility provides (`admissible_head_bound` in `Optimality.lean`), reached here **without any assumption on `hStar`**. This is the precise mechanism making A\* optimal under a consistent heuristic: `f = g + h` is non-decreasing along paths, so no node is ever re-expanded (Hart, Nilsson & Raphael, 1968).

## Changes (4 files, atomic — one subject, one domain)

- **`Astar/Consistency.lean`** (new): `consistent_implies_path_bound` + `consistent_implies_admissible_bound`. Proof by list induction: singleton `[goal]` → `pathCost = 0`, `h goal = 0`; `hd :: w :: rest'` → IH on tail (`h w ≤ pathCost(w :: rest')`) + arc-consistency (`h hd ≤ edge(hd,w) + h w`) + `pathCost_cons_cons`, `linarith` concludes.
- **`Astar.lean`**: add `import Astar.Consistency` to the umbrella.
- **`README.md`**: phase-2 section (statement, telescoping derivation, proof sketch, honest framing) + checklist phase-2 ticked.
- **`.github/workflows/lean-astar.yml`** (new): reusable `lean-build.yml` CI for the lake, `sorry-baseline: "0"`, `standalone-tactic` filter (catches any new bare `sorry`; never false-positives on prose).

## Verification (lean-merge-discipline §1)

- `lake build Astar` **SUCCESS** (8497 jobs, 0 error, 0 warning on the new module). Toolchain `leanprover/lean4:v4.31.0-rc1`, Mathlib `v4.31.0-rc1`.
- **0 `sorry`** in all source `.lean` (excluding vendored `.lake/packages`):
  ```
  $ grep -rn "sorry" astar_lean/ --include=*.lean --exclude-dir=.lake
  (empty)
  ```
- **`#print axioms`** = `[propext, Classical.choice, Quot.sound]` — standard Mathlib axioms, **no `sorryAx`**:
  ```
  'Astar.consistent_implies_path_bound' depends on axioms: [propext, Classical.choice, Quot.sound]
  'Astar.consistent_implies_admissible_bound' depends on axioms: [propext, Classical.choice, Quot.sound]
  ```

## Honest scoping (G.3 / G.9)

The abstract `hStar` is a **lower bound** on path costs (`IsTrueRemainingCost`), not necessarily the attained optimum. The telescoping gives `h(start) ≤ pathCost(p)` for **every realized path** `p` — the exact optimality mechanism of A\* ("never overestimates a realized path cost"). Deducing `h(start) ≤ hStar(start)` would require `hStar` to be the **attained minimum** (finite graph, finitely many simple paths): this "attainability of `hStar`" is deliberately left **OPEN** as the next phase (effective construction of `hStar`), **not** sorry-backed. No theorem is stubbed.

## PR body checklist (lean-merge-discipline §B)

1. **`grep -c sorry` before/after** — N/A (0 before, 0 after; only `Consistency.lean` is new and it has 0).
2. **`lake build` SUCCESS** — local, 8497 jobs, ✅ (pasted above).
3. **Proof integrity (axiom check)** — ✅ `[propext, Classical.choice, Quot.sound]`, no `sorryAx`.
4. **No prover Python refactor** — N/A (pure Lean addition).

Review/merge: ai-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)