### PR TITLE
feat(astar): consistent_implies_f_monotone — f=g+h monotone (phase 3), sorry 0 (See #4048)

### DIFF
--- a/MyIA.AI.Notebooks/Search/astar_lean/Astar/Consistency.lean
+++ b/MyIA.AI.Notebooks/Search/astar_lean/Astar/Consistency.lean
@@ -98,4 +98,34 @@ theorem consistent_implies_admissible_bound (h : V → NNReal) (goal : V)
     h start ≤ pathCost G p :=
   consistent_implies_path_bound G h goal hCons hGoal start p hp
 
+/-! ## Phase 3 : monotonicité de `f = g + h` (pas de ré-expansion) -/
+
+/-- **Consistance ⟹ `f = g + h` monotone.** Théorème cible #4048 phase 3
+    (`consistent_implies_monotone_f`). Sous une heuristique **consistante**, la fonction
+    d'évaluation `f = g + h` (coût déjà parcouru `g` + heuristique `h`) est **croissante**
+    le long des expansions : si le coût déjà parcouru progresse du poids de l'arc
+    (`g n' = g n + edge n n'`), alors `f` n'augmente pas (`f n ≤ f n'`).
+
+    C'est le mécanisme exact qui rend A* **efficace** sous heuristique consistante : la
+    frontière de `f` ne recule jamais, donc **aucun nœud n'est jamais ré-expansé**. À
+    comparer avec une heuristique admissible (mais non consistante), qui garantit
+    l'optimalité (phase 1) mais autorise des ré-expansions. La formalisation de la
+    « non-ré-expansion » elle-même (modélisation de la file de priorité) est laissée à la
+    phase 4 (cf #4048) — on prouve ici le **lemme mathématique central**, qui en est la
+    cause exacte. Voir Hart, Nilsson & Raphael (1968).
+
+    **Preuve** (1 ligne) : `g n' + h n' = g n + edge n n' + h n' ≥ g n + h n` par
+    consistance (`h n ≤ edge n n' + h n'`), donc `linarith` après réécriture de `g n'`.
+
+    Note d'abstraction : `g` est laissé paramètre (non calculé) — le résultat vaut pour
+    toute fonction de coût déjà parcouru satisfaisant la relation d'avancement par arc,
+    indépendamment du chemin spécifique emprunté pour l'atteindre. -/
+theorem consistent_implies_f_monotone (h : V → NNReal)
+    (hCons : Consistent G h)
+    (g : V → NNReal) (n n' : V)
+    (hg : g n' = g n + G.edge n n') :
+    g n + h n ≤ g n' + h n' := by
+  rw [hg]
+  linarith [hCons n n']
+
 end Astar

--- a/MyIA.AI.Notebooks/Search/astar_lean/README.md
+++ b/MyIA.AI.Notebooks/Search/astar_lean/README.md
@@ -115,6 +115,35 @@ En déduire `h(start) ≤ hStar(start)` nécessiterait que `hStar` soit le *mini
 laissée ouverte (phase suivante, construction effective de `hStar`). On prouve donc ici
 la **forme abstraite** suggérée par #4048.
 
+## Consistance ⟹ `f = g + h` monotone (pas de ré-expansion) — phase 3
+
+```lean
+theorem consistent_implies_f_monotone (h : V → NNReal)
+    (hCons : Consistent G h)
+    (g : V → NNReal) (n n' : V)
+    (hg : g n' = g n + G.edge n n') :
+    g n + h n ≤ g n' + h n'
+```
+
+Sous une heuristique **consistante**, la fonction d'évaluation `f = g + h` (coût déjà
+parcouru `g` + heuristique `h`) est **croissante** le long des expansions : si `g`
+ progresse du poids de l'arc (`g n' = g n + edge n n'`), alors `f` n'augmente pas
+(`f n ≤ f n'`). C'est le mécanisme exact qui rend A* **efficace** sous heuristique
+consistante : la frontière de `f` ne recule jamais, donc **aucun nœud n'est jamais
+ré-expansé** — par contraste avec une heuristique admissible (mais non consistante) qui
+garantit l'optimalité (phase 1) mais autorise des ré-expansions.
+
+**Preuve** (0 `sorry`, axiomes `[propext, Classical.choice, Quot.sound]`, 1 ligne) :
+`g n' + h n' = g n + edge n n' + h n' ≥ g n + h n` par consistance
+(`h n ≤ edge n n' + h n'`), donc `linarith` après réécriture de `g n'`.
+
+**Abstraction.** `g` est laissé paramètre (non calculé) : le résultat vaut pour toute
+fonction de coût déjà parcouru satisfaisant la relation d'avancement par arc,
+indépendamment du chemin spécifique. La formalisation de la **« non-ré-expansion »
+elle-même** (modélisation de la file de priorité, open/closed sets, terminaison) est la
+**phase 4** (cf #4048) — on prouve ici le **lemme mathématique central** qui en est la
+cause exacte, pas l'algorithme complet.
+
 ## Construction
 
 ```bash
@@ -127,17 +156,17 @@ Prérequis : [elan](https://github.com/leanprover/elan) (toolchain
 
 ## État et suite
 
-Ce livrable couvre les phases 1-2 (#4048) :
+Ce livrable couvre les phases 1-3 (#4048) :
 
 - [x] Scaffolding du lake (lakefile, toolchain, `.gitignore`)
 - [x] Modèle (`WeightedGraph`, `pathCost`, `PathFrom`)
 - [x] Définitions (`Admissible`, `Consistent`, `IsTrueRemainingCost`)
 - [x] **Théorème phare `admissible_implies_optimal` — 0 `sorry`** (phase 1, PR #4090)
 - [x] **`consistent_implies_admissible` — 0 `sorry`** (phase 2, téléscopage de la consistance le long du chemin)
+- [x] **`consistent_implies_f_monotone` — 0 `sorry`** (phase 3, `f = g + h` croissante ⇒ pas de ré-expansion)
 
 Phases suivantes (suivi #4048) :
 
-- [ ] `consistent_implies_monotone_f` (`f = g + h` croissante ⇒ pas de ré-expansion)
 - [ ] Construction effective de `hStar` sur graphe fini (minimum sur chemins simples)
 - [ ] Modélisation de la file de priorité et preuve « A* renvoie le chemin optimal » bout-en-bout
 


### PR DESCRIPTION
## Summary

Phase 3 of the A* optimality lake (**#4048**, roadmap #4038, registry #3801 prong B). Proves the third landmark theorem: **consistency ⟹ `f = g + h` is monotone (non-decreasing along expansions)** — the exact mechanism making A* *efficient* (no node ever re-expanded) under a consistent heuristic.

Partial delivery to the open epic #4048 (phases 1 `admissible_implies_optimal` + 2 `consistent_implies_admissible` already shipped via merged #4090 and open #4142; phase 4 = priority-queue modeling remains). Using `See #4048`.

### The theorem

```lean
theorem consistent_implies_f_monotone (h : V → NNReal)
    (hCons : Consistent G h)
    (g : V → NNReal) (n n' : V)
    (hg : g n' = g n + G.edge n n') :
    g n + h n ≤ g n' + h n'
```

Under a consistent heuristic, the evaluation function `f = g + h` (cost-so-far `g` + heuristic `h`) is non-decreasing along expansions: if `g` advances by the edge weight (`g n' = g n + edge n n'`), then `f` does not decrease (`f n ≤ f n'`). The f-frontier never recedes ⇒ **no node is ever re-expanded**. Contrast: an admissible-but-not-consistent heuristic guarantees optimality (phase 1) but *permits* re-expansions.

### Proof (1 line, 0 sorry)

`g n' + h n' = g n + edge n n' + h n' ≥ g n + h n` by consistency (`h n ≤ edge n n' + h n'`), so `linarith` after `rw [hg]`. Compiled first-try.

## Stacking note (please read)

This branch is **stacked on phase 2 (PR #4142)** — `Consistency.lean` only exists on `feature/astar-consistent-4048` (phase 2), not yet merged. So this PR currently shows **2 commits** (phase 2 + phase 3). **Once #4142 merges to main, GitHub auto-rebases this PR and it shows only the phase-3 delta** (the single new theorem `consistent_implies_f_monotone` + README section). Two review options:
- **(a) merge #4142 first**, then this PR cleans to a 1-commit phase-3 delta, or
- **(b) review the phase-3 delta now** (just `consistent_implies_f_monotone` added before `end Astar` in `Consistency.lean` + the README phase-3 section) — independent of any phase-2 changes.

The phase-3 theorem is independent of phase-2's theorems (both are consequences of `Consistent`, defined in `Heuristic.lean` on main), so it rebases trivially regardless of phase-2 review outcomes.

## Changes (2 files vs phase-2 branch; atomic vs main once #4142 merges)

- **`Astar/Consistency.lean`**: add `consistent_implies_f_monotone` + section 3 header. `g` is a parameter (any cost-so-far satisfying the arc-advance relation), abstracted from the specific path.
- **`README.md`**: phase-3 section (statement, proof, abstraction, phase-4 framing) + checklist phase-3 ticked.

## Verification (lean-merge-discipline §1)

- `lake build Astar` **SUCCESS** (8497 jobs, 0 error, compiled first-try — 2-tactic proof). Toolchain `lean 4 v4.31.0-rc1`, Mathlib `v4.31.0-rc1`.
- **0 `sorry`** in `Consistency.lean` (and all source, `.lake` excluded).
- **`#print axioms`** = `[propext, Classical.choice, Quot.sound]` — standard Mathlib axioms, **no `sorryAx`**.

## Honest scoping (G.3 / G.9)

The formalization of "no re-expansion" itself (priority-queue modeling: open/closed sets, termination) is **phase 4** (cf #4048). This PR proves the **central mathematical lemma** that is its exact cause (`f` monotone ⟹ frontier non-receding ⟹ no re-expansion), not the full algorithm. Left **OPEN** (not sorry-backed) — no theorem stubbed.

## PR body checklist (lean-merge-discipline §B)

1. `grep -c sorry` before/after — N/A (0 before, 0 after; the new theorem has 0).
2. `lake build` SUCCESS — local, 8497 jobs, ✅ (above).
3. Proof integrity (axiom check) — ✅ `[propext, Classical.choice, Quot.sound]`, no `sorryAx`.
4. No prover Python refactor — N/A (pure Lean addition).

Review/merge: ai-01. (Recommend merging #4142 first so this cleans to a 1-commit delta.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)