### PR TITLE
docs(qcpy35): RL Portfolio citation audit -- Markowitz + Q-learning/SARSA + References

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
@@ -94,7 +94,9 @@
     "\n",
     "> **Contrainte Docker QC** : seuls 5 tickers ont des donnees disponibles :\n",
     "> SPY, QQQ, AAPL, GOOGL, IWM. Nous utilisons SPY comme proxy equity\n",
-    "> et simulons un proxy obligataire via une serie synthetique correlee negativement."
+    "> et simulons un proxy obligataire via une serie synthetique correlee negativement.\n",
+    "\n",
+    "> *Ancre savante -- Markowitz, H. (1952), Portfolio Selection, The Journal of Finance 7(2):77-91 (DOI 10.1111/j.1540-6261.1952.tb01525.x). (Theorie moderne du portefeuille / Modern Portfolio Theory : allocation optimale des poids par minimisation de la variance pour un rendement cible donne, formalisation moyenne-variance. C'est la reference a \"l'optimisation de portefeuille classique (Markowski)\" que le RL vient completer en apprenant la politique par interaction au lieu de resoudre le probleme quadratique.)*\n"
    ]
   },
   {
@@ -462,7 +464,9 @@
     "- $\\alpha$ = taux d'apprentissage (0.1)\n",
     "- $\\gamma$ = facteur d'actualisation (0.95)\n",
     "- $r$ = recompense (Sharpe roule 20j)\n",
-    "- $\\epsilon$ decay de 1.0 a 0.05 sur les episodes"
+    "- $\\epsilon$ decay de 1.0 a 0.05 sur les episodes\n",
+    "\n",
+    "> *Ancre savante -- Sutton, R.S. & Barto, A.G. (2018), Reinforcement Learning: An Introduction (2nd ed.), MIT Press, ISBN 978-0-262-03924-6. (Manuel de reference du RL : formalise le dilemme exploration/exploitation, la politique epsilon-greedy et son decay, et la taxonomie on-policy vs off-policy utilisee pour opposer SARSA et Q-learning dans l'exercice 3. Source canonique des concepts de reward, d'etat, d'action et de politique manipules dans tout le notebook.)*\n"
    ]
   },
   {
@@ -704,7 +708,9 @@
     "",
     "**Indices** :",
     "- # Indice : La difference avec Q-learning est `Q(s',a')` (action prise) vs `max_a Q(s',a)` (action optimale)",
-    "- # Indice : L'action a' est choisie avec la meme politique epsilon-greedy"
+    "- # Indice : L'action a' est choisie avec la meme politique epsilon-greedy\n",
+    "\n",
+    "> *Ancres savantes -- Watkins, C.J.C.H. (1989), Learning from Delayed Rewards, PhD thesis, University of Cambridge (Q-learning : update off-policy Q(s,a) <- Q(s,a) + alpha[r + gamma * max_a' Q(s',a') - Q(s,a)], l'agent apprend la valeur de la politique greedy optimale en suivant une politique comportementale differente ; cf. Watkins & Dayan 1992, Machine Learning 8(3-4):279-292 pour la convergence) ; Rummery, G.A. & Niranjan, M. (1994), On-line Q-learning using connectionist systems, Technical Report CUED/F-INFENG/TR 166, Cambridge University Engineering Department (SARSA -- a l'origine \"Modified Connectionist Q-Learning\" : update on-policy Q(s,a) <- Q(s,a) + alpha[r + gamma * Q(s',a') - Q(s,a)] utilisant l'action reellement prise, plus conservateur que Q-learning comme note dans l'exercice).)*\n"
    ]
   },
   {
@@ -775,7 +781,16 @@
     "   (Proportional Transaction Cost model)\n",
     "\n",
     "> **Pour aller plus loin** : Le notebook QC-Py-32 implemente un agent DQN\n",
-    "> complet pour le trading multi-actifs avec replay buffer et target network."
+    "> complet pour le trading multi-actifs avec replay buffer et target network.\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Markowitz, H. (1952). Portfolio Selection. The Journal of Finance, 7(2):77-91. DOI 10.1111/j.1540-6261.1952.tb01525.x.\n",
+    "- Rummery, G.A. & Niranjan, M. (1994). On-line Q-learning using connectionist systems. Technical Report CUED/F-INFENG/TR 166, Cambridge University Engineering Department.\n",
+    "- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press. ISBN 978-0-262-03924-6.\n",
+    "- Watkins, C.J.C.H. (1989). Learning from Delayed Rewards. PhD thesis, University of Cambridge.\n",
+    "- Watkins, C.J.C.H. & Dayan, P. (1992). Q-learning. Machine Learning, 8(3-4):279-292.\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Verdict **OMISSION pleine** (0 ancre savante [singular + plural forms checked], 0 References academiques; canonical originators named in prose without citation). Same profile as QC-Py-34 (#4141) and the QC-Py-32/33 RL family.

### Corrected G.1 scan heuristic
**Lesson recorded this cycle**: the QC-Py series uses BOTH "Ancre savante" (singular) AND "Ancres savantes" (plural, when one footnote groups multiple citations). My earlier deep-queue scan only counted the singular form, systematically over-counting OMISSIONs. QC-Py-19 (7-entry References section) and QC-Py-24 (already has VAE/LSTM/HMM/BIC anchors in plural form) were re-classified FAITHFUL on firsthand read — not fixed (would be padding, anti-padding G.5). QC-Py-35 verified firsthand as a **genuine** 0-anchor / 0-refs OMISSION.

### Fixed — 3 anchors + References (QC-Py-35)
| Cell | Concept | Canonical anchor |
|------|---------|------------------|
| md[2] | Markowitz portfolio optimization | **Markowitz (1952)**, Portfolio Selection, J. of Finance 7(2):77-91, DOI 10.1111/j.1540-6261.1952.tb01525.x |
| md[10] | exploration/exploitation, epsilon-greedy decay, on/off-policy | **Sutton & Barto (2018)**, RL: An Introduction (2nd ed.), MIT Press |
| md[12] | Q-learning + SARSA (exercice 3) | **Watkins (1989)** PhD thesis Cambridge + Watkins & Dayan (1992) ML 8:279-292 ; **Rummery & Niranjan (1994)** CUED TR 166 |
| md[16] | closing cell | `### References academiques` (5 entries) |

## Validation
- **Markdown-only** (rule C.3 — no re-execution): code cells byte-identical (`source` + `outputs` + `execution_count`) vs `origin/main`; only md cells [2, 10, 12, 16] changed.
- `notebook_tools validate`: **0 error**, 1 **pre-existing** warning (cell 10 unbalanced `$$` LaTeX — origin/main cell 10 has 16 `$` in original prose; my footnote has zero `$`; not a regression).
- 4 textbook-grade canonical papers (no web-reverification needed).
- Diff: `+19 / -4`, 1 file, no catalogue / submodule churn.

See #3164.
