### PR TITLE
feat(mgs): MGS-7-TSP Config 4 — geometric crossover under insertion/Ulam metric (See #3964)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7-TSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7-TSP.ipynb
@@ -5,10 +5,10 @@
    "id": "bafc5427",
    "metadata": {
     "papermill": {
-     "duration": 0.006353,
-     "end_time": "2026-06-23T03:15:15.773789+00:00",
+     "duration": 0.004226,
+     "end_time": "2026-06-24T11:59:31.992392+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:15.767436+00:00",
+     "start_time": "2026-06-24T11:59:31.988166+00:00",
      "status": "completed"
     },
     "tags": []
@@ -32,16 +32,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:15.793601Z",
-     "iopub.status.busy": "2026-06-23T03:15:15.785667Z",
-     "iopub.status.idle": "2026-06-23T03:15:17.748093Z",
-     "shell.execute_reply": "2026-06-23T03:15:17.743447Z"
+     "iopub.execute_input": "2026-06-24T11:59:32.013436Z",
+     "iopub.status.busy": "2026-06-24T11:59:32.005315Z",
+     "iopub.status.idle": "2026-06-24T11:59:34.501716Z",
+     "shell.execute_reply": "2026-06-24T11:59:34.496887Z"
     },
     "papermill": {
-     "duration": 1.97063,
-     "end_time": "2026-06-23T03:15:17.748211+00:00",
+     "duration": 2.505545,
+     "end_time": "2026-06-24T11:59:34.501831+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:15.777581+00:00",
+     "start_time": "2026-06-24T11:59:31.996286+00:00",
      "status": "completed"
     },
     "tags": []
@@ -97,12 +97,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%16:2048/\",\"http://172.30.16.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:a911:67ab:50dc:4e69:2048/\",\"http://2a01:e0a:9d4:f320:ad1a:8e3f:5f41:4d97:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::5aa8:3689:ec4d:c9e6%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%16:2048/\",\"http://172.30.16.1:2048/\",\"http://fe80::5aa8:3689:ec4d:c9e6%44:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6428:785:4daa:dcda:2048/\",\"http://2a01:e0a:9d4:f320:a911:67ab:50dc:4e69:2048/\",\"http://2a01:e0a:9d4:f320:ad1a:8e3f:5f41:4d97:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '666872.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '1135632.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -224,10 +224,10 @@
    "id": "8f73b773",
    "metadata": {
     "papermill": {
-     "duration": 0.003013,
-     "end_time": "2026-06-23T03:15:17.754659+00:00",
+     "duration": 0.002662,
+     "end_time": "2026-06-24T11:59:34.507518+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:17.751646+00:00",
+     "start_time": "2026-06-24T11:59:34.504856+00:00",
      "status": "completed"
     },
     "tags": []
@@ -249,16 +249,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:17.761186Z",
-     "iopub.status.busy": "2026-06-23T03:15:17.761020Z",
-     "iopub.status.idle": "2026-06-23T03:15:17.944109Z",
-     "shell.execute_reply": "2026-06-23T03:15:17.943941Z"
+     "iopub.execute_input": "2026-06-24T11:59:34.514027Z",
+     "iopub.status.busy": "2026-06-24T11:59:34.513715Z",
+     "iopub.status.idle": "2026-06-24T11:59:34.721229Z",
+     "shell.execute_reply": "2026-06-24T11:59:34.721051Z"
     },
     "papermill": {
-     "duration": 0.187016,
-     "end_time": "2026-06-23T03:15:17.944203+00:00",
+     "duration": 0.211236,
+     "end_time": "2026-06-24T11:59:34.721312+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:17.757187+00:00",
+     "start_time": "2026-06-24T11:59:34.510076+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,10 +287,10 @@
    "id": "7c55e107",
    "metadata": {
     "papermill": {
-     "duration": 0.003593,
-     "end_time": "2026-06-23T03:15:17.951902+00:00",
+     "duration": 0.003594,
+     "end_time": "2026-06-24T11:59:34.728875+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:17.948309+00:00",
+     "start_time": "2026-06-24T11:59:34.725281+00:00",
      "status": "completed"
     },
     "tags": []
@@ -310,16 +310,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:17.960518Z",
-     "iopub.status.busy": "2026-06-23T03:15:17.960272Z",
-     "iopub.status.idle": "2026-06-23T03:15:18.362969Z",
-     "shell.execute_reply": "2026-06-23T03:15:18.362821Z"
+     "iopub.execute_input": "2026-06-24T11:59:34.738442Z",
+     "iopub.status.busy": "2026-06-24T11:59:34.738200Z",
+     "iopub.status.idle": "2026-06-24T11:59:35.163859Z",
+     "shell.execute_reply": "2026-06-24T11:59:35.163717Z"
     },
     "papermill": {
-     "duration": 0.407709,
-     "end_time": "2026-06-23T03:15:18.363042+00:00",
+     "duration": 0.431251,
+     "end_time": "2026-06-24T11:59:35.163938+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:17.955333+00:00",
+     "start_time": "2026-06-24T11:59:34.732687+00:00",
      "status": "completed"
     },
     "tags": []
@@ -372,10 +372,10 @@
    "id": "dcbc1d6a",
    "metadata": {
     "papermill": {
-     "duration": 0.003407,
-     "end_time": "2026-06-23T03:15:18.369950+00:00",
+     "duration": 0.003564,
+     "end_time": "2026-06-24T11:59:35.170947+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.366543+00:00",
+     "start_time": "2026-06-24T11:59:35.167383+00:00",
      "status": "completed"
     },
     "tags": []
@@ -395,16 +395,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:18.377747Z",
-     "iopub.status.busy": "2026-06-23T03:15:18.377545Z",
-     "iopub.status.idle": "2026-06-23T03:15:18.533905Z",
-     "shell.execute_reply": "2026-06-23T03:15:18.533772Z"
+     "iopub.execute_input": "2026-06-24T11:59:35.178271Z",
+     "iopub.status.busy": "2026-06-24T11:59:35.178082Z",
+     "iopub.status.idle": "2026-06-24T11:59:35.330440Z",
+     "shell.execute_reply": "2026-06-24T11:59:35.330304Z"
     },
     "papermill": {
-     "duration": 0.160613,
-     "end_time": "2026-06-23T03:15:18.533970+00:00",
+     "duration": 0.156631,
+     "end_time": "2026-06-24T11:59:35.330508+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.373357+00:00",
+     "start_time": "2026-06-24T11:59:35.173877+00:00",
      "status": "completed"
     },
     "tags": []
@@ -414,7 +414,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Baseline (panmictic)       tour final = 440,8\r\n"
+      "Baseline (panmictic)       tour final = 422,6\r\n"
      ]
     }
    ],
@@ -430,10 +430,10 @@
    "id": "9bd50e53",
    "metadata": {
     "papermill": {
-     "duration": 0.002822,
-     "end_time": "2026-06-23T03:15:18.539864+00:00",
+     "duration": 0.00277,
+     "end_time": "2026-06-24T11:59:35.336525+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.537042+00:00",
+     "start_time": "2026-06-24T11:59:35.333755+00:00",
      "status": "completed"
     },
     "tags": []
@@ -453,16 +453,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:18.546629Z",
-     "iopub.status.busy": "2026-06-23T03:15:18.546439Z",
-     "iopub.status.idle": "2026-06-23T03:15:18.682848Z",
-     "shell.execute_reply": "2026-06-23T03:15:18.682693Z"
+     "iopub.execute_input": "2026-06-24T11:59:35.343240Z",
+     "iopub.status.busy": "2026-06-24T11:59:35.343050Z",
+     "iopub.status.idle": "2026-06-24T11:59:35.505943Z",
+     "shell.execute_reply": "2026-06-24T11:59:35.505764Z"
     },
     "papermill": {
-     "duration": 0.140353,
-     "end_time": "2026-06-23T03:15:18.682927+00:00",
+     "duration": 0.16679,
+     "end_time": "2026-06-24T11:59:35.506027+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.542574+00:00",
+     "start_time": "2026-06-24T11:59:35.339237+00:00",
      "status": "completed"
     },
     "tags": []
@@ -472,7 +472,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Islands (4 x 10, Static)   tour final = 513,9\r\n"
+      "Islands (4 x 10, Static)   tour final = 456,9\r\n"
      ]
     }
    ],
@@ -493,10 +493,10 @@
    "id": "mgs7-geo-md",
    "metadata": {
     "papermill": {
-     "duration": 0.00384,
-     "end_time": "2026-06-23T03:15:18.690772+00:00",
+     "duration": 0.003385,
+     "end_time": "2026-06-24T11:59:35.513466+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.686932+00:00",
+     "start_time": "2026-06-24T11:59:35.510081+00:00",
      "status": "completed"
     },
     "tags": []
@@ -523,16 +523,16 @@
    "id": "mgs7-geo-run",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:18.698958Z",
-     "iopub.status.busy": "2026-06-23T03:15:18.698758Z",
-     "iopub.status.idle": "2026-06-23T03:15:18.798276Z",
-     "shell.execute_reply": "2026-06-23T03:15:18.798106Z"
+     "iopub.execute_input": "2026-06-24T11:59:35.520881Z",
+     "iopub.status.busy": "2026-06-24T11:59:35.520685Z",
+     "iopub.status.idle": "2026-06-24T11:59:35.607130Z",
+     "shell.execute_reply": "2026-06-24T11:59:35.606998Z"
     },
     "papermill": {
-     "duration": 0.104197,
-     "end_time": "2026-06-23T03:15:18.798369+00:00",
+     "duration": 0.090633,
+     "end_time": "2026-06-24T11:59:35.607198+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.694172+00:00",
+     "start_time": "2026-06-24T11:59:35.516565+00:00",
      "status": "completed"
     },
     "tags": []
@@ -542,7 +542,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Geometric (Moraglio)       tour final = 674,1\r\n"
+      "Geometric (Moraglio)       tour final = 556,6\r\n"
      ]
     }
    ],
@@ -560,13 +560,168 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b709f241",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002865,
+     "end_time": "2026-06-24T11:59:35.613344+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T11:59:35.610479+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Config 4 — une seconde géométrie : la distance d'insertion (Ulam)\n",
+    "\n",
+    "La Config 3 a choisi la métrique de **swap** (distance de Cayley : combien de transpositions séparent deux ordres). Mais une permutation admet **plusieurs métriques naturelles**. La distance d'**insertion** (ou distance d'Ulam) compte combien d'éléments il faut **déplacer** — en décalant les autres — pour passer d'un ordre à l'autre : un seul déplacement peut faire progresser un élément de plusieurs positions d'un coup, là où un swap n'échange que deux éléments voisins en positions.\n",
+    "\n",
+    "Le fork expose un second embedding, `InsertionEmbedding<int>`, qui réalise cette autre géométrie : la progéniture marche vers le centroïde métrique non plus par `FlipGene` (transposition de deux positions) mais par `InsertAt` (extraction d'un élément + décalage du segment intermédiaire + repose à la destination).\n",
+    "\n",
+    "**C'est le point central du deep learning géométrique.** La « géométrie » d'un crossover n'est pas unique : elle est **déterminée par le choix de la métrique**. Deux métriques distinctes (swap vs insertion) définissent deux espaces métriques distincts, donc deux **segments géodésiques distincts** entre les mêmes parents, donc des descendants **différents** atteignables en un seul pas de crossover. Changer d'embedding change le paysage exploré, sans toucher au moteur (`GeometricCrossover`) ni à l'opérateur géométrique (le centroïde) — c'est l'embedding qui porte la géométrie, pas l'inverse.\n",
+    "\n",
+    "**Démonstration directe.** Avant le run, montrons sur un petit exemple que swap et insertion, partant du même parent vers la même cible (une permutation), n'atteignent **pas** le même descendant en un pas. La subtilité : l'opérateur centroïde à deux parents produit une cible qui n'est pas une permutation (le milieu de `[0,1,2]` et `[2,0,1]` est `[1,0.5,1.5]`), et les deux walks dégradent alors symétriquement — c'est précisément la limite du centroïde naïf signalée plus haut. La distinction géométrique n'est nette que vers une **cible qui est elle-même une permutation**, ce que l'on fixe ci-dessous."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e037208d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T11:59:35.621503Z",
+     "iopub.status.busy": "2026-06-24T11:59:35.621329Z",
+     "iopub.status.idle": "2026-06-24T11:59:35.845726Z",
+     "shell.execute_reply": "2026-06-24T11:59:35.845535Z"
+    },
+    "papermill": {
+     "duration": 0.228814,
+     "end_time": "2026-06-24T11:59:35.845814+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T11:59:35.617000+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  parent             = [0, 1, 2, 3, 4]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cible (permutation)= [2, 0, 1, 3, 4]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1 pas swap (Cayley)    = [2, 1, 0, 3, 4]   (transposition)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1 pas insertion (Ulam) = [2, 0, 1, 3, 4]   (déplacement+décalage)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  -> distincts en un pas ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Geometric (insertion/Ulam) tour final = 570,2\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Config 4 : crossover géométrique sous la métrique d'insertion (Ulam).\n",
+    "// GeometricCrossover<int>(ordered:true) câble par DÉFAUT OrderedEmbedding (swap/Cayley = Config 3).\n",
+    "// Pour la métrique d'insertion on INJECTE InsertionEmbedding : la progéniture marche vers le\n",
+    "// centroïde par InsertAt (déplacement+décalage), pas par FlipGene (swap).\n",
+    "\n",
+    "// (A) Démonstration RÉELLE : swap vs insertion vers une MÊME cible-permutation, en un pas.\n",
+    "// Un chromosome de permutation minimal (sous-classe de ChromosomeBase) pour l'illustration.\n",
+    "public sealed class IntPerm : ChromosomeBase\n",
+    "{\n",
+    "    private readonly int[] _init;\n",
+    "    public IntPerm(int[] values) : base(values.Length)\n",
+    "    {\n",
+    "        _init = values;\n",
+    "        for (int i = 0; i < values.Length; i++) ReplaceGene(i, new Gene(values[i]));\n",
+    "    }\n",
+    "    public override IChromosome CreateNew() => new IntPerm(_init);\n",
+    "    public override Gene GenerateGene(int geneIndex) => new Gene(_init[geneIndex]);\n",
+    "    public int[] ToArray() => GetGenes().Select(g => (int)g.Value).ToArray();\n",
+    "}\n",
+    "\n",
+    "var permParent = new IntPerm(new[] { 0, 1, 2, 3, 4 });\n",
+    "var permTarget = new[] { 2, 0, 1, 3, 4 };   // une permutation valide (= la cible métrique)\n",
+    "\n",
+    "// SingleFirstAllowed : UN seul pas accepté vers la cible, puis retour.\n",
+    "var swapEmb = new OrderedEmbedding<int>\n",
+    "{\n",
+    "    IsOrdered = true,\n",
+    "    GeneSelectionMode = GeneSelectionMode.SingleFirstAllowed,\n",
+    "};\n",
+    "var insertionEmb = new InsertionEmbedding<int>\n",
+    "{\n",
+    "    IsOrdered = true,\n",
+    "    GeneSelectionMode = GeneSelectionMode.SingleFirstAllowed,\n",
+    "};\n",
+    "\n",
+    "var swapOffspring      = ((IntPerm)swapEmb.MapFromGeometry(\n",
+    "    new List<IChromosome> { permParent }, permTarget)).ToArray();\n",
+    "var insertionOffspring = ((IntPerm)insertionEmb.MapFromGeometry(\n",
+    "    new List<IChromosome> { permParent }, permTarget)).ToArray();\n",
+    "\n",
+    "Console.WriteLine($\"  parent             = [{string.Join(\", \", permParent.ToArray())}]\");\n",
+    "Console.WriteLine($\"  cible (permutation)= [{string.Join(\", \", permTarget)}]\");\n",
+    "Console.WriteLine($\"  1 pas swap (Cayley)    = [{string.Join(\", \", swapOffspring)}]   (transposition)\");\n",
+    "Console.WriteLine($\"  1 pas insertion (Ulam) = [{string.Join(\", \", insertionOffspring)}]   (déplacement+décalage)\");\n",
+    "Console.WriteLine($\"  -> distincts en un pas ? {(!swapOffspring.SequenceEqual(insertionOffspring))}\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "// (B) Run GA sous la métrique d'insertion : mêmes parents initiaux (ResetRng(7) dans Run)\n",
+    "// que baseline + îles + géométrique(swap) -> seul le choix de la métrique diffère.\n",
+    "var insertionGeo = new GeometricCrossover<int>(ordered: true);\n",
+    "insertionGeo.GeometryEmbedding = new InsertionEmbedding<int> { IsOrdered = true };\n",
+    "var insertion = Run(\"Geometric (insertion/Ulam)\", 100, 40,\n",
+    "    insertionGeo,\n",
+    "    new ReverseSequenceMutation(),\n",
+    "    new DefaultMetaHeuristic());\n",
+    "Console.WriteLine($\"{insertion.Label,-26} tour final = {insertion.FinalTourLength:F1}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d32ca4b9",
    "metadata": {
     "papermill": {
-     "duration": 0.003668,
-     "end_time": "2026-06-23T03:15:18.806069+00:00",
+     "duration": 0.004243,
+     "end_time": "2026-06-24T11:59:35.854570+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.802401+00:00",
+     "start_time": "2026-06-24T11:59:35.850327+00:00",
      "status": "completed"
     },
     "tags": []
@@ -579,23 +734,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "5e4329ca",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:18.814624Z",
-     "iopub.status.busy": "2026-06-23T03:15:18.814391Z",
-     "iopub.status.idle": "2026-06-23T03:15:18.966574Z",
-     "shell.execute_reply": "2026-06-23T03:15:18.966424Z"
+     "iopub.execute_input": "2026-06-24T11:59:35.863929Z",
+     "iopub.status.busy": "2026-06-24T11:59:35.863719Z",
+     "iopub.status.idle": "2026-06-24T11:59:36.033520Z",
+     "shell.execute_reply": "2026-06-24T11:59:36.033381Z"
     },
     "papermill": {
-     "duration": 0.157036,
-     "end_time": "2026-06-23T03:15:18.966652+00:00",
+     "duration": 0.174766,
+     "end_time": "2026-06-24T11:59:36.033587+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.809616+00:00",
+     "start_time": "2026-06-24T11:59:35.858821+00:00",
      "status": "completed"
     },
     "tags": []
@@ -619,21 +774,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Baseline (panmictic)       |      440,8 |        0,0 %\r\n"
+      "Baseline (panmictic)       |      422,6 |        0,0 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Islands (4 x 10, Static)   |      513,9 |      -16,6 %\r\n"
+      "Islands (4 x 10, Static)   |      456,9 |       -8,1 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Geometric (Moraglio)       |      674,1 |      -52,9 %\r\n"
+      "Geometric (Moraglio)       |      556,6 |      -31,7 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Geometric (insertion/Ulam) |      570,2 |      -34,9 %\r\n"
      ]
     },
     {
@@ -654,26 +816,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Baseline (panmictic)    g1=909  g26=688  g51=551  g76=462  g100=441\r\n"
+      "  Baseline (panmictic)    g1=717  g26=556  g51=470  g76=426  g100=423\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Islands (4 x 10, Static)g1=897  g26=709  g51=672  g76=554  g100=514\r\n"
+      "  Islands (4 x 10, Static)g1=783  g26=494  g51=466  g76=466  g100=457\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Geometric (Moraglio)    g1=925  g26=763  g51=716  g76=693  g100=674\r\n"
+      "  Geometric (Moraglio)    g1=879  g26=719  g51=712  g76=604  g100=557\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Geometric (insertion/Ulam)g1=895  g26=807  g51=614  g76=583  g100=570\r\n"
      ]
     }
    ],
    "source": [
-    "var results = new[] { baseline, island, geometric };\n",
+    "var results = new[] { baseline, island, geometric, insertion };\n",
     "Console.WriteLine($\"{\"Config\",-26} | {\"Tour final\",10} | {\"vs baseline\",12}\");\n",
     "Console.WriteLine(new string('-', 54));\n",
     "double refLen = baseline.FinalTourLength;\n",
@@ -699,10 +868,10 @@
    "id": "c6179941",
    "metadata": {
     "papermill": {
-     "duration": 0.003798,
-     "end_time": "2026-06-23T03:15:18.974156+00:00",
+     "duration": 0.003747,
+     "end_time": "2026-06-24T11:59:36.041175+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.970358+00:00",
+     "start_time": "2026-06-24T11:59:36.037428+00:00",
      "status": "completed"
     },
     "tags": []
@@ -716,7 +885,9 @@
     "\n",
     "Le fait que le modèle insulaire batte, égalise ou perde sur ce TSP de taille 20 est secondaire ; le point est ailleurs : **la même brique structure des recherches sur des représentations disjointes**. C'est ce qui distingue un composant réutilisable d'une métaphore monolithique attachée à un type de problème.\n",
     "\n",
-    "**Nuance apportée par le crossover géométrique (Config 3).** Le constat « les composés géométriques sont typés » vaut pour leurs *opérateurs continus* (centroïde, spirale sur `double`). Mais la Config 3 montre que le **crossover géométrique lui-même** s'étend aux permutations dès qu'on lui fournit un embedding métrique (`OrderedEmbedding`, distance de swap). Ce n'est donc pas la *composition géométrique* qui est cantonnée aux `double`, c'est l'**espace métrique choisi** : un opérateur géométrique n'est pertinent que si son embedding reflète la structure du problème. Le centroïde naïf sur étiquettes d'indice en est la limite — d'où l'intérêt des embeddings permutation-équivariants (deep learning géométrique)."
+    "**Nuance apportée par le crossover géométrique (Config 3).** Le constat « les composés géométriques sont typés » vaut pour leurs *opérateurs continus* (centroïde, spirale sur `double`). Mais la Config 3 montre que le **crossover géométrique lui-même** s'étend aux permutations dès qu'on lui fournit un embedding métrique (`OrderedEmbedding`, distance de swap). Ce n'est donc pas la *composition géométrique* qui est cantonnée aux `double`, c'est l'**espace métrique choisi** : un opérateur géométrique n'est pertinent que si son embedding reflète la structure du problème. Le centroïde naïf sur étiquettes d'indice en est la limite — d'où l'intérêt des embeddings permutation-équivariants (deep learning géométrique).\n",
+    "\n",
+    "**Une géométrie, ou l'autre ? (Config 4).** La Config 3 et la Config 4 partagent tout sauf un choix : la métrique. Même moteur (`GeometricCrossover`), même opérateur (centroïde), mêmes parents initiaux. Seul l'embedding diffère (`OrderedEmbedding` en swap-distance vs `InsertionEmbedding` en insertion/Ulam-distance). La théorie prédit — et la démonstration directe le confirme — que les deux n'atteignent **pas** le même descendant en un pas : un swap et une insertion, depuis le même parent vers la même cible-permutation, empruntent des géodésiques distinctes. Le deep learning géométrique pousse plus loin : il n'y a pas de métrique « correcte » dans l'absolu, seulement un embedding **adapté à la structure du problème**. Sur TSP, ni swap ni insertion n'ont de privilège géographique (ce sont des distances sur les étiquettes d'indice) ; les deux sont des baselines, et un embedding appris équivariant par permutation ferait mieux que les deux."
    ]
   },
   {
@@ -724,10 +895,10 @@
    "id": "b00ffa1e",
    "metadata": {
     "papermill": {
-     "duration": 0.003844,
-     "end_time": "2026-06-23T03:15:18.981365+00:00",
+     "duration": 0.003205,
+     "end_time": "2026-06-24T11:59:36.047689+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.977521+00:00",
+     "start_time": "2026-06-24T11:59:36.044484+00:00",
      "status": "completed"
     },
     "tags": []
@@ -740,23 +911,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "02492166",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:18.990010Z",
-     "iopub.status.busy": "2026-06-23T03:15:18.989804Z",
-     "iopub.status.idle": "2026-06-23T03:15:19.050459Z",
-     "shell.execute_reply": "2026-06-23T03:15:19.050275Z"
+     "iopub.execute_input": "2026-06-24T11:59:36.055829Z",
+     "iopub.status.busy": "2026-06-24T11:59:36.055622Z",
+     "iopub.status.idle": "2026-06-24T11:59:36.097156Z",
+     "shell.execute_reply": "2026-06-24T11:59:36.097027Z"
     },
     "papermill": {
-     "duration": 0.065749,
-     "end_time": "2026-06-23T03:15:19.050538+00:00",
+     "duration": 0.046321,
+     "end_time": "2026-06-24T11:59:36.097221+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:18.984789+00:00",
+     "start_time": "2026-06-24T11:59:36.050900+00:00",
      "status": "completed"
     },
     "tags": []
@@ -766,7 +937,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Exercice 1] À compléter. Référence : baseline-OX1 = 440,8.\r\n"
+      "[Exercice 1] À compléter. Référence : baseline-OX1 = 422,6.\r\n"
      ]
     }
    ],
@@ -784,10 +955,10 @@
    "id": "3bdcaaf7",
    "metadata": {
     "papermill": {
-     "duration": 0.003565,
-     "end_time": "2026-06-23T03:15:19.058158+00:00",
+     "duration": 0.003693,
+     "end_time": "2026-06-24T11:59:36.104700+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:19.054593+00:00",
+     "start_time": "2026-06-24T11:59:36.101007+00:00",
      "status": "completed"
     },
     "tags": []
@@ -800,23 +971,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "b57733c3",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:19.066765Z",
-     "iopub.status.busy": "2026-06-23T03:15:19.066504Z",
-     "iopub.status.idle": "2026-06-23T03:15:19.098330Z",
-     "shell.execute_reply": "2026-06-23T03:15:19.098181Z"
+     "iopub.execute_input": "2026-06-24T11:59:36.114514Z",
+     "iopub.status.busy": "2026-06-24T11:59:36.114315Z",
+     "iopub.status.idle": "2026-06-24T11:59:36.160674Z",
+     "shell.execute_reply": "2026-06-24T11:59:36.160528Z"
     },
     "papermill": {
-     "duration": 0.036634,
-     "end_time": "2026-06-23T03:15:19.098444+00:00",
+     "duration": 0.051979,
+     "end_time": "2026-06-24T11:59:36.160751+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:19.061810+00:00",
+     "start_time": "2026-06-24T11:59:36.108772+00:00",
      "status": "completed"
     },
     "tags": []
@@ -826,7 +997,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Exercice 2] À compléter. Référence : islands-Static = 513,9.\r\n"
+      "[Exercice 2] À compléter. Référence : islands-Static = 456,9.\r\n"
      ]
     }
    ],
@@ -842,10 +1013,10 @@
    "id": "28693e46",
    "metadata": {
     "papermill": {
-     "duration": 0.003565,
-     "end_time": "2026-06-23T03:15:19.106359+00:00",
+     "duration": 0.003544,
+     "end_time": "2026-06-24T11:59:36.168040+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:19.102794+00:00",
+     "start_time": "2026-06-24T11:59:36.164496+00:00",
      "status": "completed"
     },
     "tags": []
@@ -858,23 +1029,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "6b33c457",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:15:19.114192Z",
-     "iopub.status.busy": "2026-06-23T03:15:19.114016Z",
-     "iopub.status.idle": "2026-06-23T03:15:19.170123Z",
-     "shell.execute_reply": "2026-06-23T03:15:19.169952Z"
+     "iopub.execute_input": "2026-06-24T11:59:36.175848Z",
+     "iopub.status.busy": "2026-06-24T11:59:36.175644Z",
+     "iopub.status.idle": "2026-06-24T11:59:36.205053Z",
+     "shell.execute_reply": "2026-06-24T11:59:36.204916Z"
     },
     "papermill": {
-     "duration": 0.060391,
-     "end_time": "2026-06-23T03:15:19.170200+00:00",
+     "duration": 0.033772,
+     "end_time": "2026-06-24T11:59:36.205126+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:19.109809+00:00",
+     "start_time": "2026-06-24T11:59:36.171354+00:00",
      "status": "completed"
     },
     "tags": []
@@ -902,10 +1073,10 @@
    "id": "fcd7ca59",
    "metadata": {
     "papermill": {
-     "duration": 0.003582,
-     "end_time": "2026-06-23T03:15:19.177579+00:00",
+     "duration": 0.003761,
+     "end_time": "2026-06-24T11:59:36.213160+00:00",
      "exception": false,
-     "start_time": "2026-06-23T03:15:19.173997+00:00",
+     "start_time": "2026-06-24T11:59:36.209399+00:00",
      "status": "completed"
     },
     "tags": []
@@ -921,6 +1092,8 @@
     "\n",
     "\n",
     "**Extension : crossover géométrique de Moraglio.** La Config 3 (`GeometricCrossover<int>` + `OrderedEmbedding`) étend la géométrie aux permutations : la progéniture marche par swaps sur le segment métrique entre parents. Le résultat empirique (tour final reporté dans la comparaison ci-dessus) se lit à l'aune de la théorie — l'opérateur centroïde agit sur des étiquettes d'indice sans signification géographique, ce qui borne ce qu'un crossover géométrique *naïf* peut atteindre et motive les embeddings permutation-équivariants du deep learning géométrique.\n",
+    "\n",
+    "**Extension : seconde métrique géométrique (Config 4).** Le `InsertionEmbedding<int>` (métrique d'insertion/Ulam) le confirme par contraste : changer uniquement d'embedding — sans toucher au moteur `GeometricCrossover` ni à l'opérateur centroïde — change le paysage exploré, car swap-distance et insertion-distance sont deux métriques distinctes qui définissent deux segments géodésiques distincts entre les mêmes parents. Deux descendants différents deviennent atteignables en un seul pas de crossover : c'est l'embedding (le choix de la métrique), et non le moteur, qui porte la géométrie.\n",
     "\n",
     "**Références.**\n",
     "- A. Moraglio & R. Poli, *Topological Interpretation of Crossover*, GECCO 2004 ; A. Moraglio, *Towards a Geometric Unification of Evolutionary Algorithms*, thèse 2007 — le cadre du crossover géométrique (segment métrique entre parents, valide en toute métrique, dont la distance de swap).\n",
@@ -945,14 +1118,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.566825,
-   "end_time": "2026-06-23T03:15:19.414530+00:00",
+   "duration": 8.240763,
+   "end_time": "2026-06-24T11:59:36.451769+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MGS-7-TSP.ipynb",
-   "output_path": "MGS-7-TSP_output.ipynb",
+   "output_path": "MGS-7-TSP_exec_out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-23T03:15:12.847705+00:00",
+   "start_time": "2026-06-24T11:59:28.211006+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Completes **#3964 Option B** (geometric deep learning prolongation, GREENLIT by ai-01 2026-06-24T07:26Z): a **2nd permutation-metric geometric embedding** (`InsertionEmbedding` / Ulam insertion metric) demonstrated on the MGS-7 TSP notebook, distinct from the existing `OrderedEmbedding` (swap/Cayley) of Config 3.

This is the **Prong-B showcase** MGS-7 Config 3 lacked: Config 3 showed only "geometric worse than naive" (quasi-degenerate). Config 4 proves that **two distinct permutation metrics define two distinct geodesic segments**, hence distinct offspring reachable in a single crossover step — the real distinctive capacity of a metric-swappable geometric motor.

## Changes (2 files, atomic)

1. **Submodule bump** `MetaGeneticSharp 2717fe7 -> 5c12322` (fork PR [jsboige/MetaGeneticSharp#35](https://github.com/jsboige/MetaGeneticSharp/pull/35) merged): `InsertionEmbedding<int>` (Ulam/insertion metric), 2nd Moraglio geometric embedding. Fork suite 325 passed, 0 regression.
2. **`MGS-7-TSP.ipynb` Config 4** — markdown + code cell after Config 3, plus Lecture nuance and Conclusion extension.

## Config 4 pedagogy (two honest parts)

**(A) Geodesic distinction proven for real.** From parent `[0,1,2,3,4]` toward the SAME permutation target `[2,0,1,3,4]`, computed (not hardcoded):
- one **swap** step (Cayley) -> `[2,1,0,3,4]` (transposition of positions 0 and 2)
- one **insertion** step (Ulam) -> `[2,0,1,3,4]` (relocate 2 from index 2 to 0)
- `distincts en un pas ? True`

This is the geometric-DL point: **the metric, not the motor, carries the geometry.** Changing only the embedding (`OrderedEmbedding` -> `InsertionEmbedding`) — same `GeometricCrossover`, same centroid operator — changes the explored landscape.

**(B) GA run under insertion/Ulam** added to the Comparaison table:

| Config | Tour final | vs baseline |
|--------|-----------|-------------|
| Baseline (panmictic) | 422.6 | 0.0 % |
| Islands (4x10, Static) | 456.9 | -8.1 % |
| Geometric (Moraglio, swap) | 556.6 | -31.7 % |
| **Geometric (insertion/Ulam)** | **570.2** | **-34.9 %** |

Honest result: insertion tracks swap (both bounded by the naive centroid on city-label indices — the exact limit Config 3 already documented). The point is not "insertion wins/loses" but "a different metric explores a different landscape with the same motor".

## Verification (C.2 / H.3)

- Re-executed end-to-end with `.net-csharp` papermill: **24/24 cells, 0 errors, 0 null execution_count**.
- Part (A) outputs computed live (swap `[2,1,0,3,4]` != insertion `[2,0,1,3,4]`, `True`) — match the fork keystone test `UlamVsCayley_DistinctGeodesicFromSameParentAndTarget`.
- 3 exercises preserved (C.1: 0 `raise`/`assert`/`1/0`). No `# Solution`/`# Exemple resolu` cell removed.
- No catalog churn (`COURSE_CATALOG.generated.*` byte-identical to main).

## Anti-degradation (sota-not-workaround)

- **Real tool**: `InsertionEmbedding` is real fork code (325 tests green), not a toy.
- **Non-trivial**: Ulam vs Cayley genuinely distinguishes two geometries (Part A proves distinct offspring in 1 step) — the motor's distinctive capacity (geometric crossover with swappable metric) is visible in the output.
- **Real outputs**: actual `.net-csharp` papermill re-exec, no degraded/scrubbed output.

See #3964 (Epic #1203 continues — never `Closes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
