### PR TITLE
lean(cooperative): MonotoneGame predicate foundation (Veto/Dictator arch, greenlit)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1053,6 +1053,43 @@ theorem eq_zero_of_ne_one {G : TUGame N} (hG : SimpleGame G) (S : Finset N)
 
 end SimpleGame
 
+/-! ## Monotone games
+
+A *monotone* (transferable-utility) game is one where enlarging a coalition never
+decreases its value: `S ⊆ T → v S ≤ v T`. For a simple game this specialises to the
+up-set property of the winning coalitions — `S` winning and `S ⊆ T` implies `T` winning
+— the defining feature of a *proper* simple voting game.
+
+Together with `SimpleGame`, `MonotoneGame` packages the hypotheses the Veto/Dictator
+power-index theorems assume (architectural greenlight, ai-01 cycle 75→76). -/
+def MonotoneGame (G : TUGame N) : Prop :=
+  ∀ ⦃S T : Finset N⦄, S ⊆ T → G.v S ≤ G.v T
+
+namespace MonotoneGame
+
+/-- In a monotone game, a larger coalition has at least as large a value. -/
+theorem le_of_subset {G : TUGame N} (hG : MonotoneGame G) {S T : Finset N}
+    (h : S ⊆ T) : G.v S ≤ G.v T :=
+  hG h
+
+end MonotoneGame
+
+/-- A weighted voting game with non-negative weights is monotone: enlarging a coalition
+    adds non-negative weight, so the weight sum can only increase, hence `v` (an
+    `if sum ≥ quota then 1 else 0`) cannot decrease. -/
+theorem weighted_voting_game_monotone (weights : N → ℝ) (quota : ℝ) (hquota : 0 < quota)
+    (hw : ∀ i, 0 ≤ weights i) :
+    MonotoneGame (WeightedVotingGame weights quota hquota) := by
+  intro S T hST
+  have hsum : ∑ i ∈ S, weights i ≤ ∑ i ∈ T, weights i :=
+    Finset.sum_le_sum_of_subset_of_nonneg hST (fun i _ _ => hw i)
+  simp only [WeightedVotingGame]
+  split_ifs with h₁ h₂
+  · exact le_refl _                                   -- both reach quota: 1 ≤ 1
+  · exact absurd (le_trans h₁ hsum) h₂               -- S reaches, T does not: impossible
+  · exact zero_le_one                                 -- S does not, T does: 0 ≤ 1
+  · exact le_refl _                                   -- neither: 0 ≤ 0
+
 /-- Player i is critical in coalition S if removing them causes S to lose -/
 def Critical (G : TUGame N) (i : N) (S : Finset N) : Prop :=
   i ∈ S ∧ G.v S = 1 ∧ G.v (S.erase i) = 0


### PR DESCRIPTION
## Foundation: `MonotoneGame` predicate (Veto/Dictator architecture, greenlit)

Second architectural predicate for the **Veto/Dictator** theorem family. Following the
`SimpleGame` foundation (#4134, merged), the dashboard greenlight (ai-01 cycle 76) approved
defining a **separate `MonotoneGame` predicate** — the up-set property that proper simple
voting games satisfy, and the missing hypothesis that makes the veto power-index theorems
true (see the cycle-75 finding: `veto_banzhaf_raw_pos` is false on an arbitrary `TUGame`).

### Added (all proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `MonotoneGame G` | `∀ S T, S ⊆ T → G.v S ≤ G.v T` | the up-set / monotonicity predicate |
| `MonotoneGame.le_of_subset` | `S ⊆ T → G.v S ≤ G.v T` | reader |
| `weighted_voting_game_monotone` | `MonotoneGame (WeightedVotingGame weights quota hquota)` under `hw : ∀ i, 0 ≤ weights i` | validator |

### Why this design (decided by ai-01 greenlight)

The cycle-75 ASK surfaced that `WeightedVotingGame`'s definition does **not** assume
non-negative weights, so monotonicity cannot be asserted of it unconditionally. ai-01
approved **option 2** (separate predicate, non-breaking) over option 1 (mutating the
`WeightedVotingGame` signature — rejected as breaking) and option 3 (per-theorem hypothesis
— rejected as verbose). The validator takes the `weights ≥ 0` hypothesis **once**, as a
standalone theorem, rather than repeating it on every veto theorem.

### Proof integrity (lean-merge-discipline §1)

```
✔ [8434/8435] Built CooperativeGames (...)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (pure additions, no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +38, block inserted right after `end SimpleGame`), **0 catalogue file touched**
- the `weighted_voting_game_monotone` proof: `sum_le_sum_of_subset_of_nonneg` gives the weight-sum order; `split_ifs with h1 h2` on the two `if sum >= quota` guards dispatches all 4 cases; the "S reaches quota but T does not" case is rendered impossible by `absurd (le_trans h1 hsum) h2` (the weight-sum inequality forces T to reach quota too).

### What this does NOT do (deliberate, atomic)

Foundation only. The veto power-index theorems (e.g. `veto_banzhaf_raw_pos` under
`[MonotoneGame G] [SimpleGame G]`, `veto_critical_of_winning`) come in follow-up PRs once
this predicate lands. Keeping this PR atomic (predicate + validator + reader) per
one-subject-per-PR discipline.

See #4071 #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
