### PR TITLE
lean(decision-theory): Coherence module — de Finetti Dutch Book (constructive dir, 0 sorry)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence.lean
@@ -1,0 +1,33 @@
+import Coherence.Basic
+import Coherence.DutchBook
+
+/-!
+# Decision Theory — Dutch Book / cohérence (de Finetti)
+
+Formalisation du théorème de cohérence de de Finetti (cas fini) : la fondation
+conceptuelle des probabilités. Des prix de pari **incohérents** (violant
+l'inclusion–exclusion) exposent l'agent à un **Dutch Book** — un livret de paris à
+perte sûre. La cohérence *force* donc les axiomes de probabilité.
+
+## Contenu
+- `Coherence.Basic` : événements (`Event`), fonctions de prix (`Price`), indicatrices,
+  et l'identité d'inclusion–exclusion (`ind_inclusion_exclusion`) — la clé de voûte.
+- `Coherence.DutchBook` : la direction constructive « incohérence ⟹ Dutch Book »
+  (`non_additive_implies_dutch_book`, witness explicite, 0 `sorry`) et sa contraposée
+  « cohérence ⟹ additivité » (`coherent_on_implies_additive`).
+
+## Statut
+- Prouvé sans `sorry` : la direction constructive (violation de l'inclusion–exclusion
+  ⟹ Dutch Book avec mises explicites `(1,1,−1,−1)` ou l'inverse), et la cohérence ⟹
+  additivité sur deux événements.
+- Ouvert (jalon suivant) : la réciproque « additivité ⟹ cohérence » et le
+  `coherent_iff_probability` complet (additivité générale + normalisation
+  `q ∅ = 0`, `q univ = 1`), qui nécessitent la séparation d'hyperplans / dualité LP
+  en dimension finie (faisabilité Lean « MOYENNE », cf #4050).
+
+## Références croisées
+- `Utility` (même lake) : représentation d'utilité espérée vNM — l'autre fondation
+  de la théorie de la décision sous risque.
+- Infer-14 (Infer.NET) : utilité espérée bayésienne sous postérieure.
+- PyMC-14 (PyMC) : estimation d'utilité espérée par échantillonnage postérieur.
+-/

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Basic.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Basic.lean
@@ -1,0 +1,52 @@
+import Mathlib
+
+/-!
+# Coherence.Basic — événements, prix, tickets (de Finetti)
+
+Fondations de l'argument du Dutch Book. Un agent qui parie attribue un prix unitaire
+`q A` à chaque événement `A` (un ticket qui paie 1 € si `A` se réalise) ; l'agent
+achète ET vend au même prix `q A` (pas de spread bid–ask). Le théorème de de Finetti
+(cas fini) dit que des prix violant les axiomes de probabilité exposent l'agent à un
+*Dutch Book* — un livret de paris garantissant une perte sûre. Voir `DutchBook.lean`.
+
+C'est la fondation conceptuelle du *pourquoi* des probabilités (additives, normalisées)
+plutôt que des fonctions de croyance arbitraires : la cohérence *force* les axiomes
+de Kolmogorov. Pédagogiquement, ce module répond à la question fondatrice de toute la
+série Probas : « pourquoi `P(A∪B) = P(A) + P(B) − P(A∩B)` ? » — parce que sinon, un
+arbitragiste construit un pari à perte sûre.
+
+Références croisées :
+- Infer-14 (Infer.NET) : espérance d'utilité bayésienne sous incertitude sur la postérieure.
+- PyMC-14 (PyMC) : estimation d'utilité espérée par échantillonnage postérieur.
+-/
+
+namespace Coherence
+
+variable {Ω : Type*} [Fintype Ω] [DecidableEq Ω]
+
+/-- Un événement est un ensemble fini d'états du monde. -/
+abbrev Event (Ω : Type*) [Fintype Ω] [DecidableEq Ω] := Finset Ω
+
+/-- Une fonction de prix (quotient de pari) : `q A` est le prix unitaire (en €) d'un
+    ticket payant 1 € si l'événement `A` se réalise. L'agent achète et vend au même
+    prix `q A` (pas de spread) — le cadre standard de de Finetti. -/
+abbrev Price (Ω : Type*) [Fintype Ω] [DecidableEq Ω] := Event Ω → ℝ
+
+/-- L'indicatrice `𝟙_{ω ∈ A}` comme un réel (1 si l'état `ω` réalise `A`, 0 sinon). -/
+def ind (A : Event Ω) (ω : Ω) : ℝ := if ω ∈ A then 1 else 0
+
+/-- Identité d'inclusion–exclusion pour les indicatrices :
+    `𝟙_A + 𝟙_B − 𝟙_{A∩B} − 𝟙_{A∪B} = 0` en tout état `ω`.
+
+    C'est la clé de voûte du Dutch Book : elle rend le gain des quatre tickets
+    déterministe (indépendant de l'état réalisé). Voir `DutchBook.lean`.
+
+    **Preuve** : disjonction sur l'appartenance `(ω ∈ A, ω ∈ B)` (4 cas) ; dans chaque
+    cas, l'identité se réduit à une équation arithmétique triviale. -/
+lemma ind_inclusion_exclusion (A B : Event Ω) (ω : Ω) :
+    ind A ω + ind B ω - ind (A ∩ B) ω - ind (A ∪ B) ω = 0 := by
+  unfold ind
+  simp only [Finset.mem_inter, Finset.mem_union]
+  by_cases hA : ω ∈ A <;> by_cases hB : ω ∈ B <;> simp [hA, hB]
+
+end Coherence

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/DutchBook.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/DutchBook.lean
@@ -1,0 +1,101 @@
+import Mathlib
+import Coherence.Basic
+
+/-!
+# Coherence.DutchBook — incohérence ⟹ Dutch Book (de Finetti, direction constructive)
+
+Issue #4050. Le théorème de cohérence de de Finetti (cas fini) établit la
+correspondance entre **cohérence** (absence de pari à perte sûre) et **additivité**
+(la fonction de prix satisfait l'inclusion–exclusion, donc est une mesure de
+probabilité). On prouve ici la **direction constructive**, mécaniquement centrale :
+si les prix violent l'inclusion–exclusion sur deux événements, un *Dutch Book*
+explicite existe (mises concrètes sur les quatre tickets `A, B, A∩B, A∪B` donnant
+une perte sûre). La contraposée donne « cohérence ⟹ additivité ».
+
+La clé mathématique est l'identité d'inclusion–exclusion des indicatrices
+(`ind_inclusion_exclusion` dans `Basic.lean`) : `𝟙_A + 𝟙_B − 𝟙_{A∩B} − 𝟙_{A∪B} = 0`
+en tout état, donc le gain des quatre tickets avec mises `(1, 1, −1, −1)` est
+exactement `δ := q(A∪B) + q(A∩B) − q(A) − q(B)`, **indépendant de l'état**. Si
+`δ ≠ 0`, on choisit le signe des mises pour garantir une perte sûre = un Dutch Book.
+
+**Cadrage honnête (G.3/G.9).** On prouve la direction « incohérence ⟹ Dutch Book »
+(constructive, witness explicite, 0 `sorry`) et sa contraposée « cohérence ⟹
+additivité sur deux événements ». La réciproque « additivité ⟹ cohérence » (et le
+`coherent_iff_probability` complet : additivité générale + normalisation `q ∅ = 0`,
+`q univ = 1`) nécessite la **séparation d'hyperplans / dualité LP** en dimension finie
+(faisabilité Lean évaluée « MOYENNE » dans #4050) et est laissée **ouverte** comme
+jalon suivant — non `sorry`-backed. Cette structure (une direction prouvée + la
+réciproque ouverte documentée) est cohérente avec le module `Utility` du même lake
+(direction sound prouvée, existence Herstein–Milnor ouverte). Voir de Finetti (1937).
+-/
+
+namespace Coherence
+
+variable {Ω : Type*} [Fintype Ω] [DecidableEq Ω]
+
+/-! ## Gain d'un livret de quatre tickets et Dutch Book -/
+
+/-- Le gain net à l'état `ω` d'un livret de quatre tickets sur `(A, B, A∩B, A∪B)` avec
+    mises `(sA, sB, sAB, sAU)` (mise positive = achat, négative = vente). Chaque ticket
+    paie l'indicatrice de son événement et coûte `q(événement)` : le gain net d'un
+    ticket est `mise × (indicatrice − prix)`. -/
+def ieGain (q : Price Ω) (A B : Event Ω) (sA sB sAB sAU : ℝ) (ω : Ω) : ℝ :=
+  sA * (ind A ω - q A) + sB * (ind B ω - q B)
+    + sAB * (ind (A ∩ B) ω - q (A ∩ B)) + sAU * (ind (A ∪ B) ω - q (A ∪ B))
+
+/-- Un **Dutch Book** par inclusion–exclusion : des mises sur `(A, B, A∩B, A∪B)` dont
+    le gain net est **strictement négatif en tout état** — une perte sûre pour l'agent
+    (et un profit sûr pour l'arbitragiste). -/
+def IsIEArbitrage (q : Price Ω) (A B : Event Ω) (sA sB sAB sAU : ℝ) : Prop :=
+  ∀ ω : Ω, ieGain q A B sA sB sAB sAU ω < 0
+
+/-! ## Théorèmes cibles (direction constructive) -/
+
+/-- **de Finetti (cas fini, ⟸, constructif).** Si le prix `q` viole l'inclusion–
+    exclusion sur les événements `A, B` (`q(A∪B) + q(A∩B) ≠ q A + q B`), alors un
+    Dutch Book existe : mises explicites sur `(A, B, A∩B, A∪B)` donnant une perte sûre.
+
+    **Preuve** (0 `sorry`) : posons `δ := q(A∪B) + q(A∩B) − q A − q B ≠ 0`. Par
+    l'identité d'inclusion–exclusion (`ind_inclusion_exclusion`), le gain du livret
+    avec mises `(1, 1, −1,−1)` vaut exactement `δ` en tout état (la combinaison
+    d'indicatrices s'annule). Si `δ < 0`, ces mises sont le Dutch Book. Si `δ > 0`, on
+    inverse les signes `(−1, −1, 1, 1)` et le gain devient `−δ < 0`. Dans les deux cas,
+    `linarith` conclut à partir de l'identité des indicatrices. -/
+theorem non_additive_implies_dutch_book (q : Price Ω) (A B : Event Ω)
+    (h : q (A ∪ B) + q (A ∩ B) ≠ q A + q B) :
+    ∃ sA sB sAB sAU : ℝ, IsIEArbitrage q A B sA sB sAB sAU := by
+  set δ := q (A ∪ B) + q (A ∩ B) - q A - q B
+  have hδ : δ ≠ 0 := fun heq => h (by linarith)
+  by_cases hδn : δ < 0
+  · -- δ < 0 : mises (1, 1, −1, −1) → gain = δ < 0 en tout état.
+    refine ⟨1, 1, -1, -1, ?_⟩
+    intro ω
+    simp only [ieGain]
+    have hie := ind_inclusion_exclusion A B ω
+    linarith
+  · -- δ ≥ 0 ; avec δ ≠ 0 ⟹ δ > 0 : mises (−1, −1, 1, 1) → gain = −δ < 0.
+    have hδge : 0 ≤ δ := not_lt.mp hδn
+    have hδp : 0 < δ := lt_of_le_of_ne hδge (Ne.symm hδ)
+    refine ⟨-1, -1, 1, 1, ?_⟩
+    intro ω
+    simp only [ieGain]
+    have hie := ind_inclusion_exclusion A B ω
+    linarith
+
+/-- Les prix sont **cohérents** sur `(A, B)` si aucun Dutch Book n'existe sur les quatre
+    événements `(A, B, A∩B, A∪B)`. -/
+def CoherentOn (q : Price Ω) (A B : Event Ω) : Prop :=
+  ∀ sA sB sAB sAU : ℝ, ¬ IsIEArbitrage q A B sA sB sAB sAU
+
+/-- **Cohérence ⟹ inclusion–exclusion (de Finetti, contraposée).** Si aucun Dutch Book
+    n'existe sur `(A, B, A∩B, A∪B)`, alors `q` est additif sur `A, B` : la fonction de
+    prix satisfait l'inclusion–exclusion `q(A∪B) + q(A∩B) = q A + q B`. C'est la
+    contraposée immédiate de `non_additive_implies_dutch_book`. -/
+theorem coherent_on_implies_additive (q : Price Ω) (A B : Event Ω)
+    (hc : CoherentOn q A B) :
+    q (A ∪ B) + q (A ∩ B) = q A + q B := by
+  by_contra h
+  obtain ⟨sA, sB, sAB, sAU, harb⟩ := non_additive_implies_dutch_book q A B h
+  exact hc sA sB sAB sAU harb
+
+end Coherence

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.md
@@ -3,7 +3,7 @@
 Lake **à la racine de la série `Probas`**, formalisant des résultats canoniques de
 théorie de la décision — visible des deux pistes de la série (Infer.NET / PyMC).
 
-Deux modules livrés :
+Trois modules livrés :
 
 - **Gittins** : le problème du **bandit manchot multi-bras** (multi-armed bandit) et
   l'**indice de Gittins** (Gittins 1979, Weber 1992) — la politique optimale pour le
@@ -12,15 +12,22 @@ Deux modules livrés :
   énoncé mais intraitable** dans le Mathlib actuel (pas de formalisation
   MDP/Bellman), maintenu en `sorry`.
 - **Utility** : la **représentation d'utilité espérée** de **von Neumann–Morgenstern**
-  (PR courante, `See #4049`). Le module formalise les **quatre axiomes vNM**
-  (complétude, transitivité, indépendance, continuité/Archimède) sur les loteries,
-  prouve **sans aucun `sorry`** la **direction saine** du théorème (existence d'une
-  représentation ⟹ rationalité, i.e. les quatre axiomes) et la **stabilité affine**
-  (cardinalité : l'utilité n'est déterminée qu'à transformation affine positive
-  près). La **direction d'existence** (rationalité ⟹ représentation, Herstein–Milnor
-  1953) est documentée comme **jalon ouvert**.
+  (`See #4049`). Le module formalise les **quatre axiomes vNM** (complétude,
+  transitivité, indépendance, continuité/Archimède) sur les loteries, prouve **sans
+  aucun `sorry`** la **direction saine** du théorème (existence d'une représentation
+  ⟹ rationalité, i.e. les quatre axiomes) et la **stabilité affine** (cardinalité :
+  l'utilité n'est déterminée qu'à transformation affine positive près). La **direction
+  d'existence** (rationalité ⟹ représentation, Herstein–Milnor 1953) est documentée
+  comme **jalon ouvert**.
+- **Coherence** : la **cohérence de de Finetti / Dutch Book** (`See #4050`). Le module
+  prouve **sans aucun `sorry`** la **direction constructive** du théorème de cohérence
+  (cas fini) : des prix de pari violant l'inclusion–exclusion exposent l'agent à un
+  *Dutch Book* explicite (livret de paris à perte sûre, mises concrètes `(1,1,−1,−1)`
+  ou l'inverse), via l'identité d'inclusion–exclusion des indicatrices. Sa contraposée
+  donne « cohérence ⟹ additivité ». La **réciproque** (additivité + normalisation ⟹
+  cohérence, i.e. la fonction de prix est une probabilité) nécessite la séparation
+  d'hyperplans / dualité LP et est documentée comme **jalon ouvert**.
 
-Modules prévus (roadmap Lean #4038) : cohérence **Dutch Book / de Finetti** (#4050).
 Notebook compagnon Lean :
 [`Infer/Infer-20b-Lean-Gittins.ipynb`](../Infer/Infer-20b-Lean-Gittins.ipynb).
 
@@ -29,11 +36,13 @@ Notebook compagnon Lean :
 - **Toolchain** : `leanprover/lean4:v4.30.0-rc2`
 - **Sorry** : **5** — tous dans `Gittins/GittinsTheorem.lean` (le théorème
   d'optimalité + propriétés de l'indice). `Gittins/Discount.lean` = **0 sorry**
-  (entièrement prouvé), `Gittins/Basic.lean` = 0. Le module **`Utility` entier =
-  0 sorry** (direction saine vNM + stabilité affine, entièrement prouvé).
-- **Build** : `lake build Gittins Utility` (dépend de Mathlib4)
+  (entièrement prouvé), `Gittins/Basic.lean` = 0. Les modules **`Utility` et
+  `Coherence` entiers = 0 sorry** (entièrement prouvés, jalon ouvert documenté non
+  `sorry`-backed).
+- **Build** : `lake build Gittins Utility Coherence` (dépend de Mathlib4)
 - **Dépendances** : Mathlib4 (`v4.30.0-rc2`) — analyse réelle pour les lemmes
-  d'actualisation, structure ordonnée et affine de `ℝ` pour vNM
+  d'actualisation, structure ordonnée et affine de `ℝ` pour vNM, théorie des `Finset`
+  / inclusion–exclusion pour la cohérence de de Finetti
 
 ## Ce qui est formalisé
 
@@ -110,6 +119,51 @@ notebooks d'inférence bayésienne de la série `Probas` :
   explique pourquoi seules les **différences** d'utilité (pas les niveaux) sont
   identifiables à partir des données de choix.
 
+### Cohérence de de Finetti / Dutch Book
+
+Le module **`Coherence`** formalise l'argument du **Dutch Book** de de Finetti (1937) :
+la **fondation conceptuelle des probabilités**. Un agent attribue un prix unitaire
+`q A` (en €) à chaque événement `A` — un ticket qui paie 1 € si `A` se réalise — et
+achète ET vend au même prix (pas de spread). Le théorème dit que des prix **cohérents**
+(sans pari à perte sûre) coïncident avec les **mesures de probabilité** (additives,
+normalisées). La **cohérence force donc les axiomes de Kolmogorov** : pourquoi
+`P(A∪B) = P(A) + P(B) − P(A∩B)` plutôt qu'une fonction de croyance arbitraire ? Parce
+que sinon, un arbitragiste construit un livret de paris à **perte sûre**.
+
+La formalisation livre **sans aucun `sorry`** la **direction constructive** et sa
+contraposée :
+
+- **Prouvé** (`DutchBook.lean`) :
+  - `ind_inclusion_exclusion` — la clé de voûte : l'identité d'inclusion–exclusion des
+    indicatrices `𝟙_A + 𝟙_B − 𝟙_{A∩B} − 𝟙_{A∪B} = 0` en tout état (disjonction sur
+    `(ω ∈ A, ω ∈ B)`).
+  - `non_additive_implies_dutch_book` — **direction constructive** : si les prix
+    violent l'inclusion–exclusion (`δ := q(A∪B)+q(A∩B)−q A−q B ≠ 0`), un **Dutch Book
+    existe avec mises explicites**. L'identité des indicatrices rend le gain du livret
+    `(1,1,−1,−1)` exactement égal à `δ` en tout état ; on choisit le signe des mises
+    pour garantir une perte stricte.
+  - `coherent_on_implies_additive` — **contraposée** : si aucun Dutch Book n'existe
+    sur `(A, B, A∩B, A∪B)`, alors `q` satisfait l'inclusion–exclusion.
+- **Énoncé, jalon ouvert** (réciproque) : la direction « additivité + normalisation
+  ⟹ cohérence » (le `coherent_iff_probability` complet, qui fait de `q` une mesure de
+  probabilité) nécessite la **séparation d'hyperplans / dualité LP** en dimension
+  finie. Elle est laissée comme **jalon naturel** et **délibérément non `sorry`-backed**
+  — la bibliothèque reste entièrement `sorry`-free. Cette structure (une direction
+  prouvée + la réciproque ouverte documentée) est cohérente avec le module `Utility`
+  du même lake (direction saine prouvée, existence Herstein–Milnor ouverte).
+
+Les primitives (`Basic.lean`) : `Event` (= `Finset Ω`), `Price` (= `Event Ω → ℝ`),
+et l'indicatrice `ind` comme réel.
+
+#### Pourquoi des probabilités ? — fondement épistémique
+
+Cette formalisation répond à la question fondatrice de toute la série `Probas` :
+**pourquoi des probabilités (additives, normalisées) ?** Les notebooks d'inférence
+bayésienne (Infer-14, PyMC-14) manipulent des distributions postérieures comme des
+probabilités au sens de Kolmogorov ; le théorème de cohérence justifie ce cadre
+comme **le seul exempt d'arbitrage** — un fondement non utilitaire (contrairement à
+vNM, qui porte sur les *préférences* sous risque), mais purement *épistémique*.
+
 ## Modules
 
 | Fichier | Lignes | sorry | Contenu |
@@ -122,6 +176,9 @@ notebooks d'inférence bayésienne de la série `Probas` :
 | `Utility/Axioms.lean` | 65 | 0 | Les **quatre axiomes vNM** — `IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous` (solvabilité des mélanges), `IsRational`, plus `StrictPref`. |
 | `Utility/Representation.lean` | 181 | 0 | **Direction saine prouvée** (`rep_complete`, `rep_transitive`, `rep_independent`, `rep_continuous`, `expected_utility_rep_is_rational`) + **stabilité affine** (`affine_rep_is_rep`). Direction d'existence documentée comme jalon ouvert. |
 | `Utility.lean` | ~30 | 0 | Imports parapluie + doc de statut |
+| `Coherence/Basic.lean` | 52 | 0 | Primitives de Finetti — `Event` (= `Finset Ω`), `Price` (= `Event Ω → ℝ`), indicatrice `ind`, et la clé de voûte `ind_inclusion_exclusion` (inclusion–exclusion des indicatrices). |
+| `Coherence/DutchBook.lean` | 101 | 0 | **Direction constructive prouvée** (`non_additive_implies_dutch_book`, mises explicites `(1,1,−1,−1)`/inverse) + contraposée `coherent_on_implies_additive`. Réciproque (dualité LP) documentée comme jalon ouvert. |
+| `Coherence.lean` | 33 | 0 | Imports parapluie + doc de statut |
 
 ## Pourquoi le théorème d'optimalité est intractable
 
@@ -143,7 +200,7 @@ son docstring) plutôt qu'affaibli silencieusement.
 
 ```bash
 # Depuis ce répertoire (WSL requis)
-lake build Gittins Utility
+lake build Gittins Utility Coherence
 # Dépend de Mathlib4 — le premier build est lourd, les builds suivants utilisent le cache
 ```
 

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/lakefile.lean
@@ -14,3 +14,7 @@ lean_lib Gittins where
 @[default_target]
 lean_lib Utility where
   roots := #[`Utility]
+
+@[default_target]
+lean_lib Coherence where
+  roots := #[`Coherence]


### PR DESCRIPTION
## Summary

Add the **`Coherence`** module to `decision_theory_lean`: de Finetti's coherence
theorem (finite case) — the **conceptual foundation of probability**. An agent that
bets assigns a unit price `q A` to each event `A`; the theorem says coherent prices
(no sure-loss book) coincide with probability measures. Coherence *forces* the
Kolmogorov axioms — this answers the foundational question of the whole `Probas`
series: *why* `P(A∪B) = P(A) + P(B) − P(A∩B)`? Because otherwise an arbitrageur
builds a sure-loss book.

`See #4050` (Lean decision-theory roadmap). `See #4038` (Lean-series Epic). Not
`Closes` — #4050 and #4038 are epics with further milestones.

## What is formalized (0 sorry)

**Coherence/Basic.lean**
- `Event` (= `Finset Ω`), `Price` (= `Event Ω → ℝ`), indicator `ind : Event Ω → Ω → ℝ`.
- `ind_inclusion_exclusion` — the **keystone**: `𝟙_A + 𝟙_B − 𝟙_{A∩B} − 𝟙_{A∪B} = 0` in
  every state. Proof: 4-case disjunction on `(ω ∈ A, ω ∈ B)`, each case reduces to a
  trivial ring identity.

**Coherence/DutchBook.lean**
- `ieGain` — net gain at state `ω` of a 4-ticket book on `(A, B, A∩B, A∪B)`.
- `IsIEArbitrage` — a Dutch Book: net gain **strictly negative in every state**.
- `non_additive_implies_dutch_book` — **CONSTRUCTIVE direction** (de Finetti ⟸): if
  prices violate inclusion-exclusion (`δ := q(A∪B)+q(A∩B)−q A−q B ≠ 0`), an explicit
  Dutch Book exists with mises `(1, 1, −1, −1)` (if `δ < 0`) or `(−1, −1, 1, 1)` (if
  `δ > 0`). The indicator identity makes the book's gain exactly `δ` (resp. `−δ`) in
  every state — **deterministic, state-independent**. `linarith` closes from the
  inclusion-exclusion identity.
- `coherent_on_implies_additive` — **CONTRAPOSITIVE**: no Dutch Book on
  `(A, B, A∩B, A∪B)` ⇒ `q` satisfies inclusion-exclusion.

## What is deliberately OPEN (not sorry-backed)

The **converse** — additivity + normalization (`q ∅ = 0`, `q univ = 1`) ⇒ coherence,
i.e. the full `coherent_iff_probability` making `q` a probability measure — requires
**hyperplane separation / LP duality** in finite dimension. It is documented as a
natural OPEN milestone and is **deliberately NOT `sorry`-backed** — the library stays
entirely sorry-free. This mirrors the `Utility` module of the same lake (sound
direction proved, Herstein–Milnor existence open).

## Verification

| Check | Result |
|-------|--------|
| `lake build Gittins Utility Coherence` | **SUCCESS** (8326 jobs, exit 0) |
| sorry in Coherence | **0** (3 prose mentions only — counted by the `standalone-tactic` CI filter as 0) |
| Gittins sorry baseline | **5** (unchanged — `lean-decision-theory.yml` baseline 3 standalone-tactic holds) |
| Warnings in Coherence files | **0** (pre-existing Gittins warnings untouched) |
| `#print axioms` | `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`** |
| CI workflow | Covered by existing `lean-decision-theory.yml` (project-path glob-matches the lake; **sorry-baseline 3, mode `standalone-tactic`** — Coherence adds 0, Gittins holds at 3) |

## Honest scope (G.3/G.9)

One direction proven constructively with an explicit witness (mises `(1,1,−1,−1)` or
inverted), its contrapositive, and the keystone identity — all 0 sorry. The converse
documented as OPEN, not sorry-stubbed. Honest percentage: the constructive direction +
contrapositive of the two-event de Finetti theorem are proven; the converse and the
full normalisation/additivity generalization remain open milestones.

Co-Authored-By: Claude <noreply@anthropic.com>