### PR TITLE
fix(genai-video-01-2): add missing pandas import (NameError: pd at cell18)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.003407,
-     "end_time": "2026-05-13T06:01:52.579553",
+     "duration": 0.012183,
+     "end_time": "2026-06-24T12:38:47.770614",
      "exception": false,
-     "start_time": "2026-05-13T06:01:52.576146",
+     "start_time": "2026-06-24T12:38:47.758431",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "id": "cell-1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:01:52.586680Z",
-     "iopub.status.busy": "2026-05-13T06:01:52.586360Z",
-     "iopub.status.idle": "2026-05-13T06:01:52.592623Z",
-     "shell.execute_reply": "2026-05-13T06:01:52.591780Z"
+     "iopub.execute_input": "2026-06-24T12:38:47.780234Z",
+     "iopub.status.busy": "2026-06-24T12:38:47.780041Z",
+     "iopub.status.idle": "2026-06-24T12:38:47.783688Z",
+     "shell.execute_reply": "2026-06-24T12:38:47.783336Z"
     },
     "papermill": {
-     "duration": 0.011486,
-     "end_time": "2026-05-13T06:01:52.594045",
+     "duration": 0.007514,
+     "end_time": "2026-06-24T12:38:47.784392",
      "exception": false,
-     "start_time": "2026-05-13T06:01:52.582559",
+     "start_time": "2026-06-24T12:38:47.776878",
      "status": "completed"
     },
     "tags": [
@@ -94,16 +94,16 @@
    "id": "6e60d4a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:01:52.601248Z",
-     "iopub.status.busy": "2026-05-13T06:01:52.600964Z",
-     "iopub.status.idle": "2026-05-13T06:01:52.605336Z",
-     "shell.execute_reply": "2026-05-13T06:01:52.604719Z"
+     "iopub.execute_input": "2026-06-24T12:38:47.789739Z",
+     "iopub.status.busy": "2026-06-24T12:38:47.789551Z",
+     "iopub.status.idle": "2026-06-24T12:38:47.792551Z",
+     "shell.execute_reply": "2026-06-24T12:38:47.792112Z"
     },
     "papermill": {
-     "duration": 0.009136,
-     "end_time": "2026-05-13T06:01:52.606308",
+     "duration": 0.006457,
+     "end_time": "2026-06-24T12:38:47.793188",
      "exception": false,
-     "start_time": "2026-05-13T06:01:52.597172",
+     "start_time": "2026-06-24T12:38:47.786731",
      "status": "completed"
     },
     "tags": [
@@ -121,10 +121,10 @@
    "id": "la3gu6bwuye",
    "metadata": {
     "papermill": {
-     "duration": 0.002674,
-     "end_time": "2026-05-13T06:01:52.611818",
+     "duration": 0.002152,
+     "end_time": "2026-06-24T12:38:47.797680",
      "exception": false,
-     "start_time": "2026-05-13T06:01:52.609144",
+     "start_time": "2026-06-24T12:38:47.795528",
      "status": "completed"
     },
     "tags": []
@@ -139,16 +139,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:01:52.618629Z",
-     "iopub.status.busy": "2026-05-13T06:01:52.618320Z",
-     "iopub.status.idle": "2026-05-13T06:01:53.266456Z",
-     "shell.execute_reply": "2026-05-13T06:01:53.265428Z"
+     "iopub.execute_input": "2026-06-24T12:38:47.803676Z",
+     "iopub.status.busy": "2026-06-24T12:38:47.803291Z",
+     "iopub.status.idle": "2026-06-24T12:38:54.605968Z",
+     "shell.execute_reply": "2026-06-24T12:38:54.605388Z"
     },
     "papermill": {
-     "duration": 0.653147,
-     "end_time": "2026-05-13T06:01:53.267766",
+     "duration": 6.807223,
+     "end_time": "2026-06-24T12:38:54.606985",
      "exception": false,
-     "start_time": "2026-05-13T06:01:52.614619",
+     "start_time": "2026-06-24T12:38:47.799762",
      "status": "completed"
     },
     "tags": []
@@ -158,10 +158,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Dependances: 13/13 disponibles\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       ".env charge depuis: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n",
       "Helpers GenAI importes\n",
       "GPT-5 Video Understanding\n",
-      "Date : 2026-05-13 08:01:53\n",
+      "Date : 2026-06-24 14:38:54\n",
       "Mode : interactive, Modele : gpt-5-mini\n",
       "Frames a envoyer : 8, Strategie : uniform\n"
      ]
@@ -280,6 +287,7 @@
     "from typing import Dict, List, Any, Optional, Tuple\n",
     "from io import BytesIO\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "from PIL import Image, ImageDraw\n",
     "import matplotlib.pyplot as plt\n",
     "import logging\n",
@@ -334,10 +342,10 @@
    "id": "i7pv0bi0jdb",
    "metadata": {
     "papermill": {
-     "duration": 0.002779,
-     "end_time": "2026-05-13T06:01:53.273639",
+     "duration": 0.002539,
+     "end_time": "2026-06-24T12:38:54.612383",
      "exception": false,
-     "start_time": "2026-05-13T06:01:53.270860",
+     "start_time": "2026-06-24T12:38:54.609844",
      "status": "completed"
     },
     "tags": []
@@ -352,16 +360,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:01:53.280915Z",
-     "iopub.status.busy": "2026-05-13T06:01:53.280229Z",
-     "iopub.status.idle": "2026-05-13T06:01:56.192952Z",
-     "shell.execute_reply": "2026-05-13T06:01:56.191890Z"
+     "iopub.execute_input": "2026-06-24T12:38:54.618648Z",
+     "iopub.status.busy": "2026-06-24T12:38:54.618356Z",
+     "iopub.status.idle": "2026-06-24T12:38:56.683657Z",
+     "shell.execute_reply": "2026-06-24T12:38:56.683043Z"
     },
     "papermill": {
-     "duration": 2.91773,
-     "end_time": "2026-05-13T06:01:56.194194",
+     "duration": 2.070083,
+     "end_time": "2026-06-24T12:38:56.684979",
      "exception": false,
-     "start_time": "2026-05-13T06:01:53.276464",
+     "start_time": "2026-06-24T12:38:54.614896",
      "status": "completed"
     },
     "tags": []
@@ -441,10 +449,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.002871,
-     "end_time": "2026-05-13T06:01:56.200413",
+     "duration": 0.003431,
+     "end_time": "2026-06-24T12:38:56.692200",
      "exception": false,
-     "start_time": "2026-05-13T06:01:56.197542",
+     "start_time": "2026-06-24T12:38:56.688769",
      "status": "completed"
     },
     "tags": []
@@ -463,16 +471,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:01:56.207883Z",
-     "iopub.status.busy": "2026-05-13T06:01:56.207517Z",
-     "iopub.status.idle": "2026-05-13T06:01:59.926269Z",
-     "shell.execute_reply": "2026-05-13T06:01:59.925222Z"
+     "iopub.execute_input": "2026-06-24T12:38:56.700446Z",
+     "iopub.status.busy": "2026-06-24T12:38:56.700003Z",
+     "iopub.status.idle": "2026-06-24T12:38:57.872861Z",
+     "shell.execute_reply": "2026-06-24T12:38:57.872318Z"
     },
     "papermill": {
-     "duration": 3.72395,
-     "end_time": "2026-05-13T06:01:59.927546",
+     "duration": 1.177963,
+     "end_time": "2026-06-24T12:38:57.873648",
      "exception": false,
-     "start_time": "2026-05-13T06:01:56.203596",
+     "start_time": "2026-06-24T12:38:56.695685",
      "status": "completed"
     },
     "tags": []
@@ -605,10 +613,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.003508,
-     "end_time": "2026-05-13T06:01:59.934773",
+     "duration": 0.002637,
+     "end_time": "2026-06-24T12:38:57.879341",
      "exception": false,
-     "start_time": "2026-05-13T06:01:59.931265",
+     "start_time": "2026-06-24T12:38:57.876704",
      "status": "completed"
     },
     "tags": []
@@ -627,16 +635,16 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:01:59.943376Z",
-     "iopub.status.busy": "2026-05-13T06:01:59.943033Z",
-     "iopub.status.idle": "2026-05-13T06:02:03.082122Z",
-     "shell.execute_reply": "2026-05-13T06:02:03.080799Z"
+     "iopub.execute_input": "2026-06-24T12:38:57.885610Z",
+     "iopub.status.busy": "2026-06-24T12:38:57.885425Z",
+     "iopub.status.idle": "2026-06-24T12:39:00.431839Z",
+     "shell.execute_reply": "2026-06-24T12:39:00.431320Z"
     },
     "papermill": {
-     "duration": 3.145349,
-     "end_time": "2026-05-13T06:02:03.083961",
+     "duration": 2.550635,
+     "end_time": "2026-06-24T12:39:00.432556",
      "exception": false,
-     "start_time": "2026-05-13T06:01:59.938612",
+     "start_time": "2026-06-24T12:38:57.881921",
      "status": "completed"
     },
     "tags": []
@@ -781,23 +789,102 @@
   {
    "cell_type": "markdown",
    "id": "bac0ec80",
-   "source": "### Exercice 1 : Echantillonnage par detection de scene\n\nDans la Section 2, nous avons compare echantillonnage uniforme et keyframe. L'objectif est d'implementer une variante plus robuste : un **detecteur de scene** qui calcule un score de changement cumulatif.\n\n**Contexte** : Le keyframe sampling de la Section 2 trie les frames par difference decroissante, ce qui peut selectionner des frames proches les unes des autres. Un vrai detecteur de scene parcourt la video sequentiellement et declenche une detection quand le score cumule depasse un seuil.\n\n**Etapes** :\n1. Parcourir les frames sequentiellement et calculer la difference cumulee\n2. Quand la difference cumulee depasse un seuil, enregistrer l'indice et reinitialiser le compteur\n3. Complter avec un echantillonnage uniforme pour atteindre `n_frames` si besoin\n\n**Indices** :\n- Initialisez un accumulateur `cum_diff = 0` a zero\n- Le seuil peut etre la somme totale des differences divisee par le nombre de scenes attendues\n- Verifiez que les indices sont uniques et tries avant de retourner",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.005658,
+     "end_time": "2026-06-24T12:39:00.441589",
+     "exception": false,
+     "start_time": "2026-06-24T12:39:00.435931",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Echantillonnage par detection de scene\n",
+    "\n",
+    "Dans la Section 2, nous avons compare echantillonnage uniforme et keyframe. L'objectif est d'implementer une variante plus robuste : un **detecteur de scene** qui calcule un score de changement cumulatif.\n",
+    "\n",
+    "**Contexte** : Le keyframe sampling de la Section 2 trie les frames par difference decroissante, ce qui peut selectionner des frames proches les unes des autres. Un vrai detecteur de scene parcourt la video sequentiellement et declenche une detection quand le score cumule depasse un seuil.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Parcourir les frames sequentiellement et calculer la difference cumulee\n",
+    "2. Quand la difference cumulee depasse un seuil, enregistrer l'indice et reinitialiser le compteur\n",
+    "3. Complter avec un echantillonnage uniforme pour atteindre `n_frames` si besoin\n",
+    "\n",
+    "**Indices** :\n",
+    "- Initialisez un accumulateur `cum_diff = 0` a zero\n",
+    "- Le seuil peut etre la somme totale des differences divisee par le nombre de scenes attendues\n",
+    "- Verifiez que les indices sont uniques et tries avant de retourner"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "e524028b",
-   "source": "# Exercice 1 : Echantillonnage par detection de scene\n\ndef sample_frames_scene_detect(frames: List[np.ndarray],\n                                n_frames: int = 8) -> Tuple[List[np.ndarray], List[int]]:\n    \"\"\"\n    Echantillonnage par detection de scene sequentielle.\n    \n    Args:\n        frames: Liste de frames (H, W, 3)\n        n_frames: Nombre de frames a selectionner\n    \n    Returns:\n        Tuple (frames_selectionnees, indices)\n    \"\"\"\n    # Etape 1 : Calculer les differences entre frames consecutives\n    diffs = []  # TODO etudiant : remplir avec les differences\n    total_diff = sum(diffs) if diffs else 1\n    threshold = total_diff / n_frames  # Seuil adapte\n    \n    # Etape 2 : Detection sequentielle\n    selected_indices = [0]  # Toujours inclure la premiere frame\n    cum_diff = 0.0\n    \n    # TODO etudiant : parcourir les differences, accumuler, detecter les seuils\n    \n    # Etape 3 : Completer avec echantillonnage uniforme si necessaire\n    # TODO etudiant : si len(selected_indices) < n_frames, ajouter des indices uniformes\n    \n    # TODO etudiant : trier et dedoublonner les indices\n    return [], []\n\n\n# TODO etudiant : Tester et comparer les trois strategies\n# scene_frames, scene_indices = sample_frames_scene_detect(all_frames, n_frames=8)\n# print(f\"Scene detect : {scene_indices}\")\n# print(f\"Uniforme     : {np.linspace(0, len(all_frames)-1, 8, dtype=int).tolist()}\")\n# print(f\"Keyframe     : {keyframe_indices}\")\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T12:39:00.454972Z",
+     "iopub.status.busy": "2026-06-24T12:39:00.454719Z",
+     "iopub.status.idle": "2026-06-24T12:39:00.459284Z",
+     "shell.execute_reply": "2026-06-24T12:39:00.458758Z"
+    },
+    "papermill": {
+     "duration": 0.012643,
+     "end_time": "2026-06-24T12:39:00.460172",
+     "exception": false,
+     "start_time": "2026-06-24T12:39:00.447529",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 1 : Echantillonnage par detection de scene\n",
+    "\n",
+    "def sample_frames_scene_detect(frames: List[np.ndarray],\n",
+    "                                n_frames: int = 8) -> Tuple[List[np.ndarray], List[int]]:\n",
+    "    \"\"\"\n",
+    "    Echantillonnage par detection de scene sequentielle.\n",
+    "    \n",
+    "    Args:\n",
+    "        frames: Liste de frames (H, W, 3)\n",
+    "        n_frames: Nombre de frames a selectionner\n",
+    "    \n",
+    "    Returns:\n",
+    "        Tuple (frames_selectionnees, indices)\n",
+    "    \"\"\"\n",
+    "    # Etape 1 : Calculer les differences entre frames consecutives\n",
+    "    diffs = []  # TODO etudiant : remplir avec les differences\n",
+    "    total_diff = sum(diffs) if diffs else 1\n",
+    "    threshold = total_diff / n_frames  # Seuil adapte\n",
+    "    \n",
+    "    # Etape 2 : Detection sequentielle\n",
+    "    selected_indices = [0]  # Toujours inclure la premiere frame\n",
+    "    cum_diff = 0.0\n",
+    "    \n",
+    "    # TODO etudiant : parcourir les differences, accumuler, detecter les seuils\n",
+    "    \n",
+    "    # Etape 3 : Completer avec echantillonnage uniforme si necessaire\n",
+    "    # TODO etudiant : si len(selected_indices) < n_frames, ajouter des indices uniformes\n",
+    "    \n",
+    "    # TODO etudiant : trier et dedoublonner les indices\n",
+    "    return [], []\n",
+    "\n",
+    "\n",
+    "# TODO etudiant : Tester et comparer les trois strategies\n",
+    "# scene_frames, scene_indices = sample_frames_scene_detect(all_frames, n_frames=8)\n",
+    "# print(f\"Scene detect : {scene_indices}\")\n",
+    "# print(f\"Uniforme     : {np.linspace(0, len(all_frames)-1, 8, dtype=int).tolist()}\")\n",
+    "# print(f\"Keyframe     : {keyframe_indices}\")\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -805,10 +892,10 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.007049,
-     "end_time": "2026-05-13T06:02:03.096878",
+     "duration": 0.005835,
+     "end_time": "2026-06-24T12:39:00.470578",
      "exception": false,
-     "start_time": "2026-05-13T06:02:03.089829",
+     "start_time": "2026-06-24T12:39:00.464743",
      "status": "completed"
     },
     "tags": []
@@ -834,20 +921,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:02:03.110701Z",
-     "iopub.status.busy": "2026-05-13T06:02:03.110248Z",
-     "iopub.status.idle": "2026-05-13T06:02:06.561247Z",
-     "shell.execute_reply": "2026-05-13T06:02:06.560395Z"
+     "iopub.execute_input": "2026-06-24T12:39:00.481058Z",
+     "iopub.status.busy": "2026-06-24T12:39:00.480697Z",
+     "iopub.status.idle": "2026-06-24T12:39:03.833318Z",
+     "shell.execute_reply": "2026-06-24T12:39:03.832419Z"
     },
     "papermill": {
-     "duration": 3.458378,
-     "end_time": "2026-05-13T06:02:06.562506",
+     "duration": 3.360745,
+     "end_time": "2026-06-24T12:39:03.834420",
      "exception": false,
-     "start_time": "2026-05-13T06:02:03.104128",
+     "start_time": "2026-06-24T12:39:00.473675",
      "status": "completed"
     },
     "tags": []
@@ -1029,10 +1116,10 @@
    "id": "4n1q500f8lb",
    "metadata": {
     "papermill": {
-     "duration": 0.003864,
-     "end_time": "2026-05-13T06:02:06.570423",
+     "duration": 0.003058,
+     "end_time": "2026-06-24T12:39:03.841747",
      "exception": false,
-     "start_time": "2026-05-13T06:02:06.566559",
+     "start_time": "2026-06-24T12:39:03.838689",
      "status": "completed"
     },
     "tags": []
@@ -1043,20 +1130,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:02:06.579907Z",
-     "iopub.status.busy": "2026-05-13T06:02:06.579610Z",
-     "iopub.status.idle": "2026-05-13T06:02:09.017316Z",
-     "shell.execute_reply": "2026-05-13T06:02:09.016485Z"
+     "iopub.execute_input": "2026-06-24T12:39:03.848942Z",
+     "iopub.status.busy": "2026-06-24T12:39:03.848739Z",
+     "iopub.status.idle": "2026-06-24T12:39:08.555096Z",
+     "shell.execute_reply": "2026-06-24T12:39:08.553641Z"
     },
     "papermill": {
-     "duration": 2.444438,
-     "end_time": "2026-05-13T06:02:09.018825",
+     "duration": 4.711844,
+     "end_time": "2026-06-24T12:39:08.556512",
      "exception": false,
-     "start_time": "2026-05-13T06:02:06.574387",
+     "start_time": "2026-06-24T12:39:03.844668",
      "status": "completed"
     },
     "tags": []
@@ -1177,48 +1264,236 @@
   {
    "cell_type": "markdown",
    "id": "8d558a38",
-   "source": "### Exercice 2 : Systeme de Video Q&A automatise\n\nDans la Section 3, nous avons pose manuellement trois questions a GPT-5. L'objectif est de creer un systeme qui **genere automatiquement des questions** pertinentes a partir d'une analyse initiale, puis les pose.\n\n**Contexte** : Un pipeline Video Q&A complet analyse d'abord la video pour identifier les elements cles, puis genere des questions ciblees pour verifier ou approfondir la comprehension.\n\n**Etapes** :\n1. Faire une premiere analyse globale de la video (description courte)\n2. A partir de la description, generer 3 questions pertinentes automatiquement\n3. Poser chaque question a GPT-5 et collecter les reponses\n4. Presenter les resultats dans un DataFrame pandas\n\n**Indices** :\n- Le premier appel peut utiliser un prompt du type \"Liste les 3 elements les plus importants de cette video\"\n- A partir des elements identifies, construisez des questions comme \"Quelle est la couleur de [element] ?\" ou \"Quand [evenement] se produit-il ?\"\n- Utilisez un dictionnaire pour structurer chaque Q&A avec question, reponse, tokens et temps",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.002895,
+     "end_time": "2026-06-24T12:39:08.563424",
+     "exception": false,
+     "start_time": "2026-06-24T12:39:08.560529",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Systeme de Video Q&A automatise\n",
+    "\n",
+    "Dans la Section 3, nous avons pose manuellement trois questions a GPT-5. L'objectif est de creer un systeme qui **genere automatiquement des questions** pertinentes a partir d'une analyse initiale, puis les pose.\n",
+    "\n",
+    "**Contexte** : Un pipeline Video Q&A complet analyse d'abord la video pour identifier les elements cles, puis genere des questions ciblees pour verifier ou approfondir la comprehension.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Faire une premiere analyse globale de la video (description courte)\n",
+    "2. A partir de la description, generer 3 questions pertinentes automatiquement\n",
+    "3. Poser chaque question a GPT-5 et collecter les reponses\n",
+    "4. Presenter les resultats dans un DataFrame pandas\n",
+    "\n",
+    "**Indices** :\n",
+    "- Le premier appel peut utiliser un prompt du type \"Liste les 3 elements les plus importants de cette video\"\n",
+    "- A partir des elements identifies, construisez des questions comme \"Quelle est la couleur de [element] ?\" ou \"Quand [evenement] se produit-il ?\"\n",
+    "- Utilisez un dictionnaire pour structurer chaque Q&A avec question, reponse, tokens et temps"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "7ea82b54",
-   "source": "# Exercice 2 : Systeme de Video Q&A automatise\n\ndef auto_video_qa(encoded_frames: List[str],\n                  frame_timestamps: List[float],\n                  n_questions: int = 3) -> pd.DataFrame:\n    \"\"\"\n    Genere automatiquement des questions sur une video et y repond.\n    \n    Args:\n        encoded_frames: Frames encodees en base64\n        frame_timestamps: Timestamps correspondants\n        n_questions: Nombre de questions a generer\n    \n    Returns:\n        DataFrame avec colonnes : question, reponse, tokens, temps_reponse\n    \"\"\"\n    # Etape 1 : Analyse initiale pour identifier les elements cles\n    # TODO etudiant : appeler analyze_video_with_gpt5 avec un prompt d'identification\n    \n    # Etape 2 : Generer des questions a partir de l'analyse\n    # TODO etudiant : parser la reponse pour extraire les elements\n    # TODO etudiant : construire des questions ciblees\n    \n    # Etape 3 : Poser chaque question\n    # TODO etudiant : boucler sur les questions, appeler l'API, collecter\n    \n    # Etape 4 : Retourner un DataFrame\n    results = []  # TODO etudiant : remplir avec des dicts\n    return pd.DataFrame(results)\n\n\n# TODO etudiant : Tester le systeme\n# df_qa = auto_video_qa(encoded_frames, timestamps, n_questions=3)\n# print(df_qa.to_string())\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T12:39:08.570439Z",
+     "iopub.status.busy": "2026-06-24T12:39:08.570265Z",
+     "iopub.status.idle": "2026-06-24T12:39:08.573777Z",
+     "shell.execute_reply": "2026-06-24T12:39:08.573286Z"
+    },
+    "papermill": {
+     "duration": 0.008173,
+     "end_time": "2026-06-24T12:39:08.574625",
+     "exception": false,
+     "start_time": "2026-06-24T12:39:08.566452",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 2 : Systeme de Video Q&A automatise\n",
+    "\n",
+    "def auto_video_qa(encoded_frames: List[str],\n",
+    "                  frame_timestamps: List[float],\n",
+    "                  n_questions: int = 3) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Genere automatiquement des questions sur une video et y repond.\n",
+    "    \n",
+    "    Args:\n",
+    "        encoded_frames: Frames encodees en base64\n",
+    "        frame_timestamps: Timestamps correspondants\n",
+    "        n_questions: Nombre de questions a generer\n",
+    "    \n",
+    "    Returns:\n",
+    "        DataFrame avec colonnes : question, reponse, tokens, temps_reponse\n",
+    "    \"\"\"\n",
+    "    # Etape 1 : Analyse initiale pour identifier les elements cles\n",
+    "    # TODO etudiant : appeler analyze_video_with_gpt5 avec un prompt d'identification\n",
+    "    \n",
+    "    # Etape 2 : Generer des questions a partir de l'analyse\n",
+    "    # TODO etudiant : parser la reponse pour extraire les elements\n",
+    "    # TODO etudiant : construire des questions ciblees\n",
+    "    \n",
+    "    # Etape 3 : Poser chaque question\n",
+    "    # TODO etudiant : boucler sur les questions, appeler l'API, collecter\n",
+    "    \n",
+    "    # Etape 4 : Retourner un DataFrame\n",
+    "    results = []  # TODO etudiant : remplir avec des dicts\n",
+    "    return pd.DataFrame(results)\n",
+    "\n",
+    "\n",
+    "# TODO etudiant : Tester le systeme\n",
+    "# df_qa = auto_video_qa(encoded_frames, timestamps, n_questions=3)\n",
+    "# print(df_qa.to_string())\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "4c35f6d4",
-   "source": "### Exercice 3 : Ordonnancement temporel d'evenements\n\nDans la Section 3, GPT-5 analyse les frames et identifie les scenes. L'objectif est d'implementer une fonction qui extrait automatiquement les **evenements et leur ordre chronologique** a partir de la reponse du modele, puis les compare avec la verite terrain.\n\n**Contexte** : Comprendre l'ordre temporel d'une video est essentiel pour le resume automatique et l'indexation. Un bon systeme doit non seulement identifier les evenements mais aussi les placer correctement sur une ligne de temps.\n\n**Etapes** :\n1. Envoyer un prompt demandant a GPT-5 de lister les evenements dans l'ordre chronologique\n2. Parser la reponse pour extraire chaque evenement et son timestamp estime\n3. Comparer l'ordre extrait avec l'ordre reel des scenes (defini dans `scenes`)\n4. Calculer un score d'exactitude : nombre d'evenements dans le bon ordre / total\n\n**Indices** :\n- Prompt suggere : \"Liste les evenements de cette video dans l'ordre chronologique. Pour chaque evenement, indique le timestamp approximatif et une courte description.\"\n- Pour parser, utilisez des expressions regulieres pour detecter les timestamps (`\\d+\\.?\\d*\\s*s`)\n- L'ordre reel est celui de la liste `scenes` (scene 0, puis scene 1, etc.)\n- Le score d'exactitude peut se baser sur le nombre d'inversions dans la sequence extraite",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003127,
+     "end_time": "2026-06-24T12:39:08.580825",
+     "exception": false,
+     "start_time": "2026-06-24T12:39:08.577698",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Ordonnancement temporel d'evenements\n",
+    "\n",
+    "Dans la Section 3, GPT-5 analyse les frames et identifie les scenes. L'objectif est d'implementer une fonction qui extrait automatiquement les **evenements et leur ordre chronologique** a partir de la reponse du modele, puis les compare avec la verite terrain.\n",
+    "\n",
+    "**Contexte** : Comprendre l'ordre temporel d'une video est essentiel pour le resume automatique et l'indexation. Un bon systeme doit non seulement identifier les evenements mais aussi les placer correctement sur une ligne de temps.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Envoyer un prompt demandant a GPT-5 de lister les evenements dans l'ordre chronologique\n",
+    "2. Parser la reponse pour extraire chaque evenement et son timestamp estime\n",
+    "3. Comparer l'ordre extrait avec l'ordre reel des scenes (defini dans `scenes`)\n",
+    "4. Calculer un score d'exactitude : nombre d'evenements dans le bon ordre / total\n",
+    "\n",
+    "**Indices** :\n",
+    "- Prompt suggere : \"Liste les evenements de cette video dans l'ordre chronologique. Pour chaque evenement, indique le timestamp approximatif et une courte description.\"\n",
+    "- Pour parser, utilisez des expressions regulieres pour detecter les timestamps (`\\d+\\.?\\d*\\s*s`)\n",
+    "- L'ordre reel est celui de la liste `scenes` (scene 0, puis scene 1, etc.)\n",
+    "- Le score d'exactitude peut se baser sur le nombre d'inversions dans la sequence extraite"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "7fc33e46",
-   "source": "# Exercice 3 : Ordonnancement temporel d'evenements\n\nimport re\n\ndef extract_temporal_order(video_frames_b64: List[str],\n                           frame_timestamps: List[float],\n                           ground_truth_scenes: List[Dict],\n                           analyze_fn=None) -> Dict[str, Any]:\n    \"\"\"\n    Extrait l'ordre chronologique des evenements et le compare a la verite terrain.\n    \n    Args:\n        video_frames_b64: Frames encodees en base64\n        frame_timestamps: Timestamps correspondants\n        ground_truth_scenes: Liste des scenes avec leur ordre reel\n        analyze_fn: Fonction d'analyse GPT-5 (ou None pour mode simulation)\n    \n    Returns:\n        Dict avec evenements extraits, score d'exactitude et details\n    \"\"\"\n    # Etape 1 : Prompt pour extraction chronologique\n    prompt = (\n        \"Liste les evenements de cette video dans l'ordre chronologique. \"\n        \"Pour chaque evenement, indique le timestamp approximatif \"\n        \"et une courte description (1 phrase).\"\n    )\n    \n    # TODO etudiant : appeler analyze_fn si disponible\n    response_text = \"\"  # TODO etudiant : texte de la reponse\n    \n    # Etape 2 : Parser les evenements et timestamps\n    # TODO etudiant : utiliser re.findall(r'(\\d+\\.?\\d*)\\s*s', response_text)\n    # TODO etudiant : associer chaque timestamp a la description la plus proche\n    extracted_events = []  # TODO etudiant : liste de dicts {'timestamp', 'description'}\n    \n    # Etape 3 : Comparer avec la verite terrain\n    n_correct = 0  # TODO etudiant : compter les evenements dans le bon ordre\n    total = len(ground_truth_scenes)\n    \n    # TODO etudiant : pour chaque paire consecutive d'evenements extraits,\n    # verifier que l'ordre est correct par rapport a la verite terrain\n    \n    accuracy_score = 0.0  # TODO etudiant : n_correct / total\n    \n    return {\n        'evenements_extraits': extracted_events,\n        'score_exactitude': accuracy_score,\n        'total_scenes': total,\n        'reponse_brute': response_text\n    }\n\n\n# TODO etudiant : Tester avec la video multi-scenes\n# result_order = extract_temporal_order(\n#     encoded_frames, timestamps, scenes,\n#     analyze_fn=analyze_video_with_gpt5 if openai_available else None\n# )\n# print(f\"Evenements extraits : {len(result_order['evenements_extraits'])}\")\n# print(f\"Score d'exactitude : {result_order['score_exactitude']:.2f}\")\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 12,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T12:39:08.588703Z",
+     "iopub.status.busy": "2026-06-24T12:39:08.588510Z",
+     "iopub.status.idle": "2026-06-24T12:39:08.592915Z",
+     "shell.execute_reply": "2026-06-24T12:39:08.592401Z"
+    },
+    "papermill": {
+     "duration": 0.009378,
+     "end_time": "2026-06-24T12:39:08.593747",
+     "exception": false,
+     "start_time": "2026-06-24T12:39:08.584369",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Ordonnancement temporel d'evenements\n",
+    "\n",
+    "import re\n",
+    "\n",
+    "def extract_temporal_order(video_frames_b64: List[str],\n",
+    "                           frame_timestamps: List[float],\n",
+    "                           ground_truth_scenes: List[Dict],\n",
+    "                           analyze_fn=None) -> Dict[str, Any]:\n",
+    "    \"\"\"\n",
+    "    Extrait l'ordre chronologique des evenements et le compare a la verite terrain.\n",
+    "    \n",
+    "    Args:\n",
+    "        video_frames_b64: Frames encodees en base64\n",
+    "        frame_timestamps: Timestamps correspondants\n",
+    "        ground_truth_scenes: Liste des scenes avec leur ordre reel\n",
+    "        analyze_fn: Fonction d'analyse GPT-5 (ou None pour mode simulation)\n",
+    "    \n",
+    "    Returns:\n",
+    "        Dict avec evenements extraits, score d'exactitude et details\n",
+    "    \"\"\"\n",
+    "    # Etape 1 : Prompt pour extraction chronologique\n",
+    "    prompt = (\n",
+    "        \"Liste les evenements de cette video dans l'ordre chronologique. \"\n",
+    "        \"Pour chaque evenement, indique le timestamp approximatif \"\n",
+    "        \"et une courte description (1 phrase).\"\n",
+    "    )\n",
+    "    \n",
+    "    # TODO etudiant : appeler analyze_fn si disponible\n",
+    "    response_text = \"\"  # TODO etudiant : texte de la reponse\n",
+    "    \n",
+    "    # Etape 2 : Parser les evenements et timestamps\n",
+    "    # TODO etudiant : utiliser re.findall(r'(\\d+\\.?\\d*)\\s*s', response_text)\n",
+    "    # TODO etudiant : associer chaque timestamp a la description la plus proche\n",
+    "    extracted_events = []  # TODO etudiant : liste de dicts {'timestamp', 'description'}\n",
+    "    \n",
+    "    # Etape 3 : Comparer avec la verite terrain\n",
+    "    n_correct = 0  # TODO etudiant : compter les evenements dans le bon ordre\n",
+    "    total = len(ground_truth_scenes)\n",
+    "    \n",
+    "    # TODO etudiant : pour chaque paire consecutive d'evenements extraits,\n",
+    "    # verifier que l'ordre est correct par rapport a la verite terrain\n",
+    "    \n",
+    "    accuracy_score = 0.0  # TODO etudiant : n_correct / total\n",
+    "    \n",
+    "    return {\n",
+    "        'evenements_extraits': extracted_events,\n",
+    "        'score_exactitude': accuracy_score,\n",
+    "        'total_scenes': total,\n",
+    "        'reponse_brute': response_text\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "# TODO etudiant : Tester avec la video multi-scenes\n",
+    "# result_order = extract_temporal_order(\n",
+    "#     encoded_frames, timestamps, scenes,\n",
+    "#     analyze_fn=analyze_video_with_gpt5 if openai_available else None\n",
+    "# )\n",
+    "# print(f\"Evenements extraits : {len(result_order['evenements_extraits'])}\")\n",
+    "# print(f\"Score d'exactitude : {result_order['score_exactitude']:.2f}\")\n",
+    "print(\"Exercice a completer\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "r9gqns9md1f",
    "metadata": {
     "papermill": {
-     "duration": 0.00452,
-     "end_time": "2026-05-13T06:02:09.028318",
+     "duration": 0.003178,
+     "end_time": "2026-06-24T12:39:08.600186",
      "exception": false,
-     "start_time": "2026-05-13T06:02:09.023798",
+     "start_time": "2026-06-24T12:39:08.597008",
      "status": "completed"
     },
     "tags": []
@@ -1229,20 +1504,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:02:09.039196Z",
-     "iopub.status.busy": "2026-05-13T06:02:09.038411Z",
-     "iopub.status.idle": "2026-05-13T06:02:09.046808Z",
-     "shell.execute_reply": "2026-05-13T06:02:09.045788Z"
+     "iopub.execute_input": "2026-06-24T12:39:08.607769Z",
+     "iopub.status.busy": "2026-06-24T12:39:08.607577Z",
+     "iopub.status.idle": "2026-06-24T12:39:08.613042Z",
+     "shell.execute_reply": "2026-06-24T12:39:08.612408Z"
     },
     "papermill": {
-     "duration": 0.015445,
-     "end_time": "2026-05-13T06:02:09.048249",
+     "duration": 0.010262,
+     "end_time": "2026-06-24T12:39:08.613707",
      "exception": false,
-     "start_time": "2026-05-13T06:02:09.032804",
+     "start_time": "2026-06-24T12:39:08.603445",
      "status": "completed"
     },
     "tags": []
@@ -1308,10 +1583,10 @@
    "id": "cell-12",
    "metadata": {
     "papermill": {
-     "duration": 0.004341,
-     "end_time": "2026-05-13T06:02:09.057288",
+     "duration": 0.003227,
+     "end_time": "2026-06-24T12:39:08.620143",
      "exception": false,
-     "start_time": "2026-05-13T06:02:09.052947",
+     "start_time": "2026-06-24T12:39:08.616916",
      "status": "completed"
     },
     "tags": []
@@ -1340,20 +1615,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:02:09.067042Z",
-     "iopub.status.busy": "2026-05-13T06:02:09.066751Z",
-     "iopub.status.idle": "2026-05-13T06:02:09.084611Z",
-     "shell.execute_reply": "2026-05-13T06:02:09.083842Z"
+     "iopub.execute_input": "2026-06-24T12:39:08.628144Z",
+     "iopub.status.busy": "2026-06-24T12:39:08.627677Z",
+     "iopub.status.idle": "2026-06-24T12:39:08.643363Z",
+     "shell.execute_reply": "2026-06-24T12:39:08.642995Z"
     },
     "papermill": {
-     "duration": 0.024307,
-     "end_time": "2026-05-13T06:02:09.085823",
+     "duration": 0.020449,
+     "end_time": "2026-06-24T12:39:08.644002",
      "exception": false,
-     "start_time": "2026-05-13T06:02:09.061516",
+     "start_time": "2026-06-24T12:39:08.623553",
      "status": "completed"
     },
     "tags": []
@@ -1366,12 +1641,12 @@
       "\n",
       "--- STATISTIQUES DE SESSION ---\n",
       "========================================\n",
-      "Date : 2026-05-13 08:02:09\n",
+      "Date : 2026-06-24 14:39:08\n",
       "Modele : gpt-5-mini\n",
       "Strategie : uniform\n",
       "Frames envoyees : 8\n",
       "Payload total : 85.5 KB\n",
-      "Resultats sauvegardes : gpt5_analysis_20260513_080209.json\n",
+      "Resultats sauvegardes : gpt5_analysis_20260624_143908.json\n",
       "\n",
       "--- PROCHAINES ETAPES ---\n",
       "1. Notebook 01-3 : Analyse video locale avec Qwen2.5-VL (GPU, temporal grounding)\n",
@@ -1379,7 +1654,7 @@
       "3. Notebook 01-4 : Amelioration video avec Real-ESRGAN\n",
       "4. Notebook 01-5 : Generation video avec AnimateDiff\n",
       "\n",
-      "Notebook 01-2 GPT-5 Video Understanding termine - 08:02:09\n"
+      "Notebook 01-2 GPT-5 Video Understanding termine - 14:39:08\n"
      ]
     }
    ],
@@ -1424,10 +1699,10 @@
    "id": "0y12a6oulkeq",
    "metadata": {
     "papermill": {
-     "duration": 0.004426,
-     "end_time": "2026-05-13T06:02:09.094891",
+     "duration": 0.003152,
+     "end_time": "2026-06-24T12:39:08.650455",
      "exception": false,
-     "start_time": "2026-05-13T06:02:09.090465",
+     "start_time": "2026-06-24T12:39:08.647303",
      "status": "completed"
     },
     "tags": []
@@ -1466,20 +1741,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "fbk44kwjegd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T06:02:09.105334Z",
-     "iopub.status.busy": "2026-05-13T06:02:09.104706Z",
-     "iopub.status.idle": "2026-05-13T06:02:09.110085Z",
-     "shell.execute_reply": "2026-05-13T06:02:09.109299Z"
+     "iopub.execute_input": "2026-06-24T12:39:08.658765Z",
+     "iopub.status.busy": "2026-06-24T12:39:08.658544Z",
+     "iopub.status.idle": "2026-06-24T12:39:08.663246Z",
+     "shell.execute_reply": "2026-06-24T12:39:08.662551Z"
     },
     "papermill": {
-     "duration": 0.011876,
-     "end_time": "2026-05-13T06:02:09.111184",
+     "duration": 0.009763,
+     "end_time": "2026-06-24T12:39:08.663977",
      "exception": false,
-     "start_time": "2026-05-13T06:02:09.099308",
+     "start_time": "2026-06-24T12:39:08.654214",
      "status": "completed"
     },
     "tags": []
@@ -1535,9 +1810,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "83e7a6f9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004242,
+     "end_time": "2026-06-24T12:39:08.672345",
+     "exception": false,
+     "start_time": "2026-06-24T12:39:08.668103",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de 01 2 gpt 5 video understanding. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les Exemple guides proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a permis d'explorer les aspects essentiels de 01 2 gpt 5 video understanding. Les points cles :\n",
+    "\n",
+    "- Les concepts fondamentaux ont ete presentes et illustres\n",
+    "- Les Exemple guides proposent une mise en pratique progressive\n",
+    "- Les resultats obtenus permettent de valider la comprehension\n",
+    "\n",
+    "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
    ]
   }
  ],
@@ -1561,16 +1854,16 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 19.860059,
-   "end_time": "2026-05-13T06:02:09.688334",
+   "duration": 23.795494,
+   "end_time": "2026-06-24T12:39:09.779289",
    "environment_variables": {},
    "exception": null,
-   "input_path": "01-2-GPT-5-Video-Understanding.ipynb",
-   "output_path": "d:/tmp/video_01-2_out.ipynb",
+   "input_path": "MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },
-   "start_time": "2026-05-13T06:01:49.828275",
+   "start_time": "2026-06-24T12:38:45.983795",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Fixes a **preexisting execution bug** in Video 01-2-GPT-5-Video-Understanding that broke end-to-end notebook execution.

## Root cause (verified firsthand G.1)
cell18 (Exercice 2) declares:
```python
def auto_video_qa(...) -> pd.DataFrame:
    ...
    return pd.DataFrame(results)
```
but the notebook **never imports pandas as `pd`**. The type annotation `-> pd.DataFrame` is evaluated at `def` time (no `from __future__ import annotations`), so papermill raised:
```
NameError: name 'pd' is not defined
```
at cell18, aborting execution. Grep confirms: `import pandas as pd` = 0 occurrences; bare `import pandas` only inside a try/except guard in cell4 (sets `PANDAS_AVAILABLE` but does not bind `pd`).

## Fix
Add `import pandas as pd` to the cell4 setup block, next to `import numpy as np`. **Import setup only** — the exercise stub is NOT filled:
- 6× `# TODO etudiant` preserved
- `results = []` stays empty
- signature `-> pd.DataFrame` unchanged (now valid)
- still prints `"Exercice a completer"`

This complies with rule C.1 (no voluntary error; notebook runs end-to-end with exercises uncompleted) and exercise-example-labeling (stub content untouched).

## Execution proof (rule §D / C.2)
Re-executed via `python -m papermill NB NB --cwd MyIA.AI.Notebooks/GenAI --execution-timeout 300` (CUDA_VISIBLE_DEVICES=\"\"; pure-API notebook — 0 GPU/service markers, GPT-5 vision via OpenAI API).

```
01-2-GPT-5-Video-Understanding: cells=14 null_exec=0 errors=0 NIE=0 secrets=0
cell18 execution_count: 10   (was None — failed to define the function)
cell18 errors: 0
cell18 stream: "Exercice a completer"
```
Notebook now executes 28/28 cells to completion.

## Scope (rule C.3)
Single notebook. Only real source change = one `import pandas as pd` line (verified via `git diff | grep pandas`); remaining diff = regenerated outputs from re-exec.

## Known residual (transparency G.3)
`machine_leaks=1` (`D:\Dev\CoursIA` in output) — the preexisting env-path leak, **not** fixed here. It was deferred precisely because this bug blocked re-execution. Once this PR merges, a follow-up PR will apply the env-path fix-at-source (`{env_path}`→`{env_path.name}`). See #4080.

Co-Authored-By: Claude <noreply@anthropic.com>