### PR TITLE
lean(cooperative): prove veto_banzhaf_raw_pos (VetoPlayer -> 0 < BanzhafRaw)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1111,6 +1111,37 @@ theorem dictator_banzhaf_pos (G : TUGame N) (i : N) (h : Dictator G i) :
   simp only [BanzhafRaw]
   exact Finset.card_pos.mpr ⟨{i}, Finset.mem_filter.2 ⟨Finset.mem_univ _, hcrit⟩⟩
 
+/-- A veto player is critical in the grand coalition, provided the grand coalition wins.
+
+    `VetoPlayer G i` forces `i ∈ S` for every winning `S`. Applied to `S = univ.erase i`, if
+    `v (univ.erase i) = 1` then `i ∈ univ.erase i`, contradicting `i ∉ univ.erase i`; hence
+    `v (univ.erase i) ≠ 1`, and `SimpleGame` forces `v (univ.erase i) = 0`. Together with
+    `v univ = 1` (`hwin`) and `i ∈ univ`, this makes `univ` a critical coalition for `i`. -/
+theorem veto_critical_in_grand {G : TUGame N} (hG : SimpleGame G) {i : N}
+    (hv : VetoPlayer G i) (hwin : G.v Finset.univ = 1) :
+    Critical G i Finset.univ := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact Finset.mem_univ i
+  · exact hwin
+  · apply SimpleGame.eq_zero_of_ne_one hG (Finset.univ.erase i)
+    intro heq
+    have hni : i ∉ Finset.univ.erase i := by simp [Finset.mem_erase]
+    exact hni (hv (Finset.univ.erase i) heq)
+
+/-- A veto player has a strictly positive raw Banzhaf index when the grand coalition wins.
+
+    The veto pendant of `dummy_banzhaf_raw_zero` (a dummy has `BanzhafRaw = 0`): a veto player
+    is critical in the grand coalition (`veto_critical_in_grand`, using `SimpleGame`), so the
+    critical-coalition filter is non-empty and its cardinality is positive. Note that, unlike
+    `dictator_banzhaf_pos`, this needs the grand-coalition-wins hypothesis `hwin`: without any
+    winning coalition a player is vacuously a veto player yet has `BanzhafRaw = 0`. -/
+theorem veto_banzhaf_raw_pos (G : TUGame N) (hG : SimpleGame G) (i : N)
+    (hv : VetoPlayer G i) (hwin : G.v Finset.univ = 1) :
+    0 < BanzhafRaw G i := by
+  have hcrit : Critical G i Finset.univ := veto_critical_in_grand hG hv hwin
+  simp only [BanzhafRaw]
+  exact Finset.card_pos.mpr ⟨Finset.univ, Finset.mem_filter.2 ⟨Finset.mem_univ _, hcrit⟩⟩
+
 /-- Dummy player: adds no value -/
 def DummyPlayer (G : TUGame N) (i : N) : Prop :=
   ∀ S : Finset N, i ∉ S → G.v (S ∪ {i}) = G.v S


### PR DESCRIPTION
## `veto_banzhaf_raw_pos` — Veto power-index (BanzhafRaw sign trio complete)

Completes the **BanzhafRaw sign trio** for the player-power family, alongside
`dummy_banzhaf_raw_zero` (= 0, on main) and `dictator_banzhaf_pos` (> 0, #4138):

| Player role | BanzhafRaw | Theorem | Status |
|-------------|-----------|--------|--------|
| Dummy | `= 0` | `dummy_banzhaf_raw_zero` | on main |
| Dictator | `0 <` | `dictator_banzhaf_pos` | #4138 merged |
| **Veto** | **`0 <`** | **`veto_banzhaf_raw_pos`** | **this PR** |

### Added (all proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `veto_critical_in_grand` | `[SimpleGame G] → VetoPlayer G i → G.v univ = 1 → Critical G i univ` | helper / reader |
| `veto_banzhaf_raw_pos` | `[SimpleGame G] → VetoPlayer G i → G.v univ = 1 → 0 < BanzhafRaw G i` | the power-index theorem |

### Why `SimpleGame` suffices (G.1 re-check vs cycle-75)

Cycle 75 flagged `veto_banzhaf_raw_pos` as needing monotonicity. Re-deriving the logic
shows **`SimpleGame` alone is enough** for *this* theorem: the real prerequisite is the
non-triviality hypothesis `hwin : G.v univ = 1`. The proof:

- `VetoPlayer G i` forces `i ∈ S` for every winning `S`.
- Applied to `S = univ.erase i`: if `v (univ.erase i) = 1` then `i ∈ univ.erase i`,
  contradicting `i ∉ univ.erase i`. Hence `v (univ.erase i) ≠ 1`.
- `SimpleGame` (eq_zero_of_ne_one) forces `v (univ.erase i) = 0`.
- With `v univ = 1` (`hwin`) and `i ∈ univ`, `univ` is a critical coalition → positive BanzhafRaw.

`hwin` is genuinely necessary: without any winning coalition, a player is *vacuously* a
veto player (`∀ S, v S = 1 → ...` is vacuous when `v S = 0` always) yet has `BanzhafRaw = 0`.

`MonotoneGame` (#4149, pending merge) stays valuable for the *broader* veto theory (up-set
properties, more theorems), but is **not** required for this power-index result. This PR
is therefore **independent of #4149** — provable from fresh `main` (which has `SimpleGame`
from #4134) with no stacking.

### Style note

Uses an explicit `(hG : SimpleGame G)` hypothesis (matching the file's convention —
`dictator_banzhaf_pos` / `dummy_banzhaf_raw_zero` all take explicit `G` + explicit hypotheses)
rather than `[SimpleGame G]` instance-bracket. Trivial to refactor to instance style once the
veto theorem family grows and the hypothesis needs threading through many theorems.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (14s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +31), inserted after `dictator_banzhaf_pos`, before `DummyPlayer`. **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
