### PR TITLE
docs(qcpy24): Autoencoders anomaly citation audit -- K-Means (MacQueen + Lloyd) anchor

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
@@ -1684,7 +1684,9 @@
     "Paramètres appris :\n",
     "- **Matrice de transition** A : P(S_t | S_{t-1})\n",
     "- **Émissions** B : P(O_t | S_t) - Gaussienne pour données continues\n",
-    "- **Probabilités initiales** π"
+    "- **Probabilités initiales** π\n",
+    "\n",
+    "> *Ancres savantes -- MacQueen, J. (1967), « Some Methods for Classification and Analysis of Multivariate Observations », Proceedings of the Fifth Berkeley Symposium on Mathematical Statistics and Probability, vol. 1, pp. 281-297 -- K-means : a nomme et popularise l'algorithme de partitionnement iteratif en K centroides minimisant l'inertie intra-classe (ici utilise via sklearn.cluster.KMeans comme baseline de regime-switching que le HMM vient ameliorer) ; Lloyd, S. P. (1982), « Least squares quantization in PCM », IEEE Transactions on Information Theory 28(2):129-137 -- formulation iterative standard assignement/update (ecrit en 1957, publie en 1982) qui est exactement l'algorithme implemente par sklearn et dont les limites (nombre de clusters fixe, pas de dynamique temporelle, sensibilité a l'initialisation) motivent le passage au HMM dans cette section.*\n"
    ]
   },
   {
@@ -3080,6 +3082,8 @@
     "- **Baum, L. E. & Petrie, T.** (1966). *Statistical Inference for Probabilistic Functions of Finite State Markov Chains*. The Annals of Mathematical Statistics, 37(6), 1554-1563. Hidden Markov Model (HMM).\n",
     "- **Viterbi, A.** (1967). *Error Bounds for Convolutional Codes and an Asymptotically Optimum Decoding Algorithm*. IEEE Transactions on Information Theory, 13(2), 260-269. Algorithme de Viterbi (séquence d'états la plus probable).\n",
     "- **Schwarz, G.** (1978). *Estimating the Dimension of a Model*. The Annals of Statistics, 6(2), 461-464. Bayesian Information Criterion (BIC).\n",
+    "- **MacQueen, J.** (1967). *Some Methods for Classification and Analysis of Multivariate Observations*. Proceedings of the Fifth Berkeley Symposium on Mathematical Statistics and Probability, 1, 281-297. Algorithme K-means (nomme et popularise).\n",
+    "- **Lloyd, S. P.** (1982). *Least squares quantization in PCM*. IEEE Transactions on Information Theory, 28(2), 129-137. Formulation iterative standard du K-means (ecrit 1957).\n",
     "\n",
     "### Ressources\n",
     "\n",


### PR DESCRIPTION
2e-passe of the #3164 QC-Py citation audit on **QC-Py-24 — Autoencoders & Anomaly Detection**.

## Verdict: PARTIAL (K-Means residual), firsthand-confirmed

QC-Py-24 was already PARTIAL (2 existing plural scholarly anchors):
- Kingma & Welling (2014) VAE + Hochreiter & Schmidhuber (1997) LSTM (Temporal VAE cell)
- Baum & Petrie (1966) HMM + Schwarz (1978) BIC (regime-switching cell)

The **firsthand-confirmed residual**: **K-Means** is named dozens of times across the notebook (regime-switching comparison, `sklearn.cluster.KMeans`, the whole "Pourquoi HMM plutot que K-Means ?" section) **without any scholarly anchor**, and is **absent from the References list** — where even **Viterbi** (an HMM derivative) is cited. This is a high-value grain: the notebook builds its entire regime-switching section on the HMM-vs-K-Means opposition, yet only one side of the comparison was anchored.

## Edition (markdown-additive, 0 code cell changed)

- **cell[28]** ("Pourquoi HMM plutot que K-Means ?"): plural anchor **MacQueen (1967)** (named/popularized K-means, *Proc. Fifth Berkeley Symposium*) + **Lloyd (1982)** (iterative assignement/update standard, written 1957, *IEEE Trans. Inf. Theory*) — placed alongside the existing HMM anchor so the two regime-switching approaches are now scholarly-compared side by side.
- **cell[51]** (### References): insert MacQueen + Lloyd after the Schwarz entry.

MacQueen 1967 + Lloyd 1982 = textbook-grade canonical, no web-reverification needed.

## Proofs (G.1 / C.2 / C.3)

- `git diff --stat`: **5 insertions, 1 deletion** (the "deletion" is a trailing newline added to the last line of cell[28] for a clean append; both edited cells are markdown).
- JSON valid: 52 cells (21 code, 31 markdown), **0 code cell touched**.
- markdown-only edit → **C.2 exception** (pre-existing code-cell outputs preserved unchanged).
- `grep -oE "Ancres? savantes?"` confirmed both forms present (2 plural anchors + 1 new plural anchor); `grep -nE '#{1,3} *(R[eé]f[eé]rences|References)'` confirmed References sections (K-Means now cited in cell[51]).

## Scope

Single notebook, single grain (K-Means). No code change, no re-execution (markdown-only exception). Catalogue byte-identical to `main`.

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)