### PR TITLE
lean(cooperative): prove dictator_unique (at most one Dictator)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1093,6 +1093,17 @@ def VetoPlayer (G : TUGame N) (i : N) : Prop :=
 def Dictator (G : TUGame N) (i : N) : Prop :=
   G.v {i} = 1 ∧ VetoPlayer G i
 
+/-- A game has at most one dictator.
+
+    If both `i` and `j` are dictators, then `j` is a veto player (`Dictator` second conjunct),
+    and `i` wins alone (`v {i} = 1`, first conjunct of `Dictator i`). Applying the veto
+    property of `j` to the winning coalition `{i}` forces `j ∈ {i}`, i.e. `j = i`. -/
+theorem dictator_unique (G : TUGame N) (i j : N) (hi : Dictator G i) (hj : Dictator G j) :
+    i = j := by
+  -- `j` is a veto player (`Dictator` second conjunct) and `i` wins alone
+  -- (`v {i} = 1`, first conjunct), so the veto property forces `j ∈ {i}`, i.e. `j = i`.
+  exact (Finset.mem_singleton.mp (hj.2 {i} hi.1)).symm
+
 /-- A dictator has a strictly positive raw Banzhaf index. The positive counterpart of
     `dummy_banzhaf_raw_zero`: a dummy never changes a coalition's value (BanzhafRaw = 0),
     whereas a dictator wins alone (`v {i} = 1`, the first conjunct of `Dictator`) and the


### PR DESCRIPTION
## `dictator_unique` — at most one Dictator (structural companion)

A standard structural result for the **Dictator** player role: a game has **at most one
dictator**. The natural companion to the `Dictator` definition (which landed with the
cooperative-games Banzhaf work), grouping with the existing `dictator_banzhaf_pos` (#4138).

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `dictator_unique` | `Dictator G i → Dictator G j → i = j` | structural uniqueness theorem |

### Proof

If both `i` and `j` are dictators:
- `j` is a veto player (`Dictator` second conjunct: `VetoPlayer G j`).
- `i` wins alone (`v {i} = 1`, first conjunct of `Dictator i`).
- The veto property of `j` (`∀ S, v S = 1 → j ∈ S`) applied to the winning coalition `{i}`
  forces `j ∈ {i}`, i.e. `j = i`.

One line: `exact (Finset.mem_singleton.mp (hj.2 {i} hi.1)).symm`.

### Independent of pending PRs (no stacking, no conflict)

This theorem needs only the `Dictator` + `VetoPlayer` definitions (both long on `main`).
It is **independent** of:
- **#4149** (`MonotoneGame`) — not needed here.
- **#4153** (`veto_banzhaf_raw_pos`) — the veto block inserts after `dictator_banzhaf_pos` (~L1112);
  this PR inserts right after `def Dictator` (~L1094). Disjoint line regions → merge in any order,
  no text conflict.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (15s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +11), inserted after `def Dictator`. **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
