### PR TITLE
docs(qcpy22): Deep-Learning-LSTM survey citation audit -- 4 SOTA architecture anchors (DLinear/PatchTST/iTransformer/TimeMixer)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
@@ -1043,7 +1043,9 @@
     "\n",
     "1. **Decomposition**: Separe les patterns long-terme (trend) et court-terme (seasonal)\n",
     "2. **Linearite**: Les series financieres ont souvent des relations quasi-lineaires\n",
-    "3. **Simplicite**: Moins de parametres = moins d'overfitting"
+    "3. **Simplicite**: Moins de parametres = moins d'overfitting\n",
+    "\n",
+    "> *Ancre savante -- Zeng, A., Chen, M., Zhang, L. & Xu, Q. (2023), « Are Transformers Effective for Time Series Forecasting? », Proceedings of the AAAI Conference on Artificial Intelligence 37(9):11121-11128 (arXiv:2205.13504). Introduit DLinear (Decomposition + Linear) : en decomposant la serie en tendance + saisonnalite puis en appliquant une couche lineaire 1D a chaque composante, ce modele MLP minimal egale ou surpasse les Transformers les plus elaborés sur le long-term forecasting -- le resultat fondateur qui motive la Partie 3 comme baseline simple a battre.*\n"
    ]
   },
   {
@@ -1630,7 +1632,9 @@
     "1. **Reduction de sequence**: n/patch_len tokens au lieu de n\n",
     "2. **Semantic locale**: Chaque patch capture un pattern local\n",
     "3. **Moins de compute**: O((n/p)^2) au lieu de O(n^2)\n",
-    "4. **Meilleure generalisation**: Vision-like tokenization"
+    "4. **Meilleure generalisation**: Vision-like tokenization\n",
+    "\n",
+    "> *Ancre savante -- Nie, Y., Nguyen, N. H., Sinthong, P. & Kalagnanam, J. (2023), « A Time Series is Worth 64 Words: Long-term Forecasting with Transformers », ICLR 2023 (arXiv:2211.14730). Introduit PatchTST : decoupe la serie en patches (groupes de points consecutifs traites comme un token, a la maniere des patches d'image en ViT) + independance des canaux (channel-independence), reduisant la longueur de sequence de n a n/patch_len et donc le cout d'attention de O(n^2) a O((n/patch_len)^2) -- l'innovation enseignee dans la Partie 4.*\n"
    ]
   },
   {
@@ -2149,7 +2153,9 @@
     "\n",
     "1. **Correlations inter-variables**: Capture les relations entre features\n",
     "2. **Embedding riche**: Chaque variable embede sa serie complete\n",
-    "3. **Scalabilite**: O(n_vars^2) au lieu de O(n_time^2)"
+    "3. **Scalabilite**: O(n_vars^2) au lieu de O(n_time^2)\n",
+    "\n",
+    "> *Ancre savante -- Liu, Y., Hu, T., Zhang, H., Wu, H., Wang, S., Ma, L. & Long, M. (2024), « iTransformer: Inverted Transformers Are Effective for Time Series Forecasting », ICLR 2024 Spotlight (arXiv:2310.06625). Introduit iTransformer : inverse la dimension d'application de l'attention -- au lieu d'attendre les timesteps (points temporels), chaque VARIABLE (variate) est embarquee comme un token et l'attention capture les correlations inter-variables, avec un cout O(n_vars^2) au lieu de O(n_time^2) -- le principe d'attention inversee de la Partie 5.*\n"
    ]
   },
   {
@@ -2573,7 +2579,9 @@
     "\n",
     "1. **Pas d'attention**: Plus simple, plus rapide\n",
     "2. **Multiscale**: Capture patterns a differentes echelles\n",
-    "3. **Efficace**: SOTA sur plusieurs benchmarks"
+    "3. **Efficace**: SOTA sur plusieurs benchmarks\n",
+    "\n",
+    "> *Ancre savante -- Wang, S., Wu, H., Shi, X., Hu, T., Luo, H., Ma, L., Zhang, J. Y. & Zhou, J. (2024), « TimeMixer: Decomposable Multiscale Mixing for Time Series Forecasting », ICLR 2024 (arXiv:2405.14616). Introduit TimeMixer : architecture purement MLP (sans attention) qui decompose la serie a plusieurs echelles temporelles puis melange ces echelles via Past-Decomposable-Mixing (extraction du passe) et Future-Multipredictor-Mixing (prediction) -- l'approche multiscale enseignee dans la Partie 6.*\n"
    ]
   },
   {


### PR DESCRIPTION
2e-passe of the #3164 QC-Py citation audit on **QC-Py-22 — Deep-Learning-LSTM** (a survey of SOTA 2023-2024 time-series architectures).

## Verdict: residual OMISSION (2e-passe), firsthand-confirmed

The 1st pass (#3718) anchored the **foundational** Transformer (Vaswani 2017) + LSTM (Hochreiter 1997) in the timeline cell. The firsthand-confirmed **residual**: the notebook **teaches 4 SOTA architectures** in dedicated `## Partie N` + `### Concept` sections — **DLinear** (Partie 3), **PatchTST** (Partie 4), **iTransformer** (Partie 5), **TimeMixer** (Partie 6) — each *explaining the architecture's innovation* (trend/seasonal decomposition + linear, patch tokenization, inverted attention, multiscale MLP mixing) with **venue+year in the heading but NO scholarly anchor** (no author, no arXiv, no citation footnote). The 4 papers are listed in a `## References SOTA` survey table (by title+conference+github) yet never cited at their **teaching point**.

This is the exact 2e-passe pattern (cf QC-Py-23 #4139): the 1st pass anchored the foundational paper but missed the 4 SOTA papers the notebook is actually **about**. Genuinely not padding (G.5) — each is taught-as-concept in a dedicated section with prose explaining *why* it works.

## Edition (markdown-additive, 0 code cell changed)

Append 1 footnote anchor to each of the 4 Concept cells (list-direct — mutate `cell['source']` list, never join+resplit, cf the QC-Py-25 cell-7 mash lesson):

| Cell | Architecture | Citation |
|------|-------------|----------|
| cell[22] | DLinear | Zeng, Chen, Zhang & Xu (2023), *AAAI* 37(9):11121-11128, arXiv:2205.13504 |
| cell[31] | PatchTST | Nie, Nguyen, Sinthong & Kalagnanam (2023), ICLR 2023, arXiv:2211.14730 |
| cell[40] | iTransformer | Liu, Hu, Zhang, Wu, Wang, Ma & Long (2024), ICLR 2024 Spotlight, arXiv:2310.06625 |
| cell[47] | TimeMixer | Wang, Wu, Shi, Hu, Luo, Ma, Zhang & Zhou (2024), ICLR 2024, arXiv:2405.14616 |

Authors/arXiv **web-verified via searxng** (WebFetch was 502 this cycle) against arXiv + OpenReview + Semantic Scholar + ICLR proceedings + official GitHub repos (cure-lab/LTSF-Linear, yuqinie98/PatchTST, thuml/iTransformer, kwuking/TimeMixer).

## Proofs (G.1 / C.2 / C.3)

- `git diff --stat`: **12 insertions, 4 deletions** (each "deletion" = trailing newline added to the last Avantages line of a Concept cell for a clean list-direct append; all 4 edited cells are markdown).
- JSON valid: 71 cells (29 code, 42 markdown); **code-cells source sha1 byte-IDENTICAL to `origin/main`** (`5d6c9b15a3813c61`, 29 cells) — **0 code cell changed**.
- markdown-only edit → **C.2 exception** (pre-existing code-cell outputs preserved unchanged).
- Catalogue + submodule byte-identical to `main`.

## Scope

Single notebook, 4 anchors (one SOTA architecture each, the highest-yield 2e-passe grain in the QC-Py series — 4 taught-as-concept architectures, all unanchored). No code change, no re-execution (markdown-only exception).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)