### PR TITLE
fix(genai-texte-11): fix-at-source absolute env-path leak (Quantization, BATCH_MODE)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -6,16 +6,16 @@
    "id": "a1b2c3d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:28:04.783601Z",
-     "iopub.status.busy": "2026-06-19T21:28:04.783601Z",
-     "iopub.status.idle": "2026-06-19T21:28:04.788235Z",
-     "shell.execute_reply": "2026-06-19T21:28:04.788235Z"
+     "iopub.execute_input": "2026-06-24T14:46:01.933112Z",
+     "iopub.status.busy": "2026-06-24T14:46:01.932827Z",
+     "iopub.status.idle": "2026-06-24T14:46:01.936961Z",
+     "shell.execute_reply": "2026-06-24T14:46:01.936306Z"
     },
     "papermill": {
-     "duration": 0.018549,
-     "end_time": "2026-06-06T07:15:05.174435",
+     "duration": 0.011243,
+     "end_time": "2026-06-24T14:46:01.938180",
      "exception": false,
-     "start_time": "2026-06-06T07:15:05.155886",
+     "start_time": "2026-06-24T14:46:01.926937",
      "status": "completed"
     },
     "tags": [
@@ -31,19 +31,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "86a62b2f",
+   "id": "ca3c45ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:28:04.790586Z",
-     "iopub.status.busy": "2026-06-19T21:28:04.789584Z",
-     "iopub.status.idle": "2026-06-19T21:28:04.792708Z",
-     "shell.execute_reply": "2026-06-19T21:28:04.792708Z"
+     "iopub.execute_input": "2026-06-24T14:46:01.949318Z",
+     "iopub.status.busy": "2026-06-24T14:46:01.948746Z",
+     "iopub.status.idle": "2026-06-24T14:46:01.952019Z",
+     "shell.execute_reply": "2026-06-24T14:46:01.951398Z"
     },
     "papermill": {
-     "duration": 0.01325,
-     "end_time": "2026-06-06T07:15:05.193869",
+     "duration": 0.010057,
+     "end_time": "2026-06-24T14:46:01.953107",
      "exception": false,
-     "start_time": "2026-06-06T07:15:05.180619",
+     "start_time": "2026-06-24T14:46:01.943050",
      "status": "completed"
     },
     "tags": [
@@ -61,10 +61,10 @@
    "id": "b2c3d4e5",
    "metadata": {
     "papermill": {
-     "duration": 0.008608,
-     "end_time": "2026-06-06T07:15:05.209485",
+     "duration": 0.004339,
+     "end_time": "2026-06-24T14:46:01.961851",
      "exception": false,
-     "start_time": "2026-06-06T07:15:05.200877",
+     "start_time": "2026-06-24T14:46:01.957512",
      "status": "completed"
     },
     "tags": []
@@ -104,10 +104,10 @@
    "id": "c3d4e5f6",
    "metadata": {
     "papermill": {
-     "duration": 0.00669,
-     "end_time": "2026-06-06T07:15:05.223415",
+     "duration": 0.004499,
+     "end_time": "2026-06-24T14:46:01.972226",
      "exception": false,
-     "start_time": "2026-06-06T07:15:05.216725",
+     "start_time": "2026-06-24T14:46:01.967727",
      "status": "completed"
     },
     "tags": []
@@ -152,10 +152,10 @@
    "id": "d4e5f6a7",
    "metadata": {
     "papermill": {
-     "duration": 0.007718,
-     "end_time": "2026-06-06T07:15:05.239823",
+     "duration": 0.005693,
+     "end_time": "2026-06-24T14:46:01.983521",
      "exception": false,
-     "start_time": "2026-06-06T07:15:05.232105",
+     "start_time": "2026-06-24T14:46:01.977828",
      "status": "completed"
     },
     "tags": []
@@ -174,16 +174,16 @@
    "id": "e5f6a7b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:28:04.794281Z",
-     "iopub.status.busy": "2026-06-19T21:28:04.794281Z",
-     "iopub.status.idle": "2026-06-19T21:29:23.990154Z",
-     "shell.execute_reply": "2026-06-19T21:29:23.990154Z"
+     "iopub.execute_input": "2026-06-24T14:46:01.995477Z",
+     "iopub.status.busy": "2026-06-24T14:46:01.995103Z",
+     "iopub.status.idle": "2026-06-24T14:46:08.664887Z",
+     "shell.execute_reply": "2026-06-24T14:46:08.664086Z"
     },
     "papermill": {
-     "duration": 148.920017,
-     "end_time": "2026-06-06T07:17:34.167881",
+     "duration": 6.677216,
+     "end_time": "2026-06-24T14:46:08.665971",
      "exception": false,
-     "start_time": "2026-06-06T07:15:05.247864",
+     "start_time": "2026-06-24T14:46:01.988755",
      "status": "completed"
     },
     "tags": []
@@ -193,8 +193,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
+      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
       "\n",
-      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
+      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
       "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     },
@@ -245,10 +247,10 @@
    "id": "f6a7b8c9",
    "metadata": {
     "papermill": {
-     "duration": 0.007162,
-     "end_time": "2026-06-06T07:17:34.180980",
+     "duration": 0.004012,
+     "end_time": "2026-06-24T14:46:08.673902",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.173818",
+     "start_time": "2026-06-24T14:46:08.669890",
      "status": "completed"
     },
     "tags": []
@@ -277,10 +279,10 @@
    "id": "a7b8c9d0",
    "metadata": {
     "papermill": {
-     "duration": 0.007025,
-     "end_time": "2026-06-06T07:17:34.195895",
+     "duration": 0.003756,
+     "end_time": "2026-06-24T14:46:08.681577",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.188870",
+     "start_time": "2026-06-24T14:46:08.677821",
      "status": "completed"
     },
     "tags": []
@@ -318,16 +320,16 @@
    "id": "b8c9d0e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:23.992199Z",
-     "iopub.status.busy": "2026-06-19T21:29:23.992199Z",
-     "iopub.status.idle": "2026-06-19T21:29:23.997166Z",
-     "shell.execute_reply": "2026-06-19T21:29:23.997166Z"
+     "iopub.execute_input": "2026-06-24T14:46:08.691114Z",
+     "iopub.status.busy": "2026-06-24T14:46:08.690754Z",
+     "iopub.status.idle": "2026-06-24T14:46:08.697195Z",
+     "shell.execute_reply": "2026-06-24T14:46:08.696565Z"
     },
     "papermill": {
-     "duration": 0.017846,
-     "end_time": "2026-06-06T07:17:34.219808",
+     "duration": 0.012801,
+     "end_time": "2026-06-24T14:46:08.698240",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.201962",
+     "start_time": "2026-06-24T14:46:08.685439",
      "status": "completed"
     },
     "tags": []
@@ -390,10 +392,10 @@
    "id": "40274ffc",
    "metadata": {
     "papermill": {
-     "duration": 0.007945,
-     "end_time": "2026-06-06T07:17:34.234425",
+     "duration": 0.003997,
+     "end_time": "2026-06-24T14:46:08.706567",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.226480",
+     "start_time": "2026-06-24T14:46:08.702570",
      "status": "completed"
     },
     "tags": []
@@ -424,16 +426,16 @@
    "id": "145ba24f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:23.999637Z",
-     "iopub.status.busy": "2026-06-19T21:29:23.998480Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.002598Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.002598Z"
+     "iopub.execute_input": "2026-06-24T14:46:08.716584Z",
+     "iopub.status.busy": "2026-06-24T14:46:08.716155Z",
+     "iopub.status.idle": "2026-06-24T14:46:08.721098Z",
+     "shell.execute_reply": "2026-06-24T14:46:08.720596Z"
     },
     "papermill": {
-     "duration": 0.017294,
-     "end_time": "2026-06-06T07:17:34.258942",
+     "duration": 0.011454,
+     "end_time": "2026-06-24T14:46:08.721974",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.241648",
+     "start_time": "2026-06-24T14:46:08.710520",
      "status": "completed"
     },
     "tags": []
@@ -495,10 +497,10 @@
    "id": "c9d0e1f2",
    "metadata": {
     "papermill": {
-     "duration": 0.006833,
-     "end_time": "2026-06-06T07:17:34.271834",
+     "duration": 0.003738,
+     "end_time": "2026-06-24T14:46:08.729605",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.265001",
+     "start_time": "2026-06-24T14:46:08.725867",
      "status": "completed"
     },
     "tags": []
@@ -528,10 +530,10 @@
    "id": "d0e1f2a3",
    "metadata": {
     "papermill": {
-     "duration": 0.007763,
-     "end_time": "2026-06-06T07:17:34.286854",
+     "duration": 0.0036,
+     "end_time": "2026-06-24T14:46:08.736829",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.279091",
+     "start_time": "2026-06-24T14:46:08.733229",
      "status": "completed"
     },
     "tags": []
@@ -587,10 +589,10 @@
    "id": "e1f2a3b4",
    "metadata": {
     "papermill": {
-     "duration": 0.006461,
-     "end_time": "2026-06-06T07:17:34.300097",
+     "duration": 0.004986,
+     "end_time": "2026-06-24T14:46:08.745629",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.293636",
+     "start_time": "2026-06-24T14:46:08.740643",
      "status": "completed"
     },
     "tags": []
@@ -612,16 +614,16 @@
    "id": "f2a3b4c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.004609Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.004609Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.010122Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.009612Z"
+     "iopub.execute_input": "2026-06-24T14:46:08.757136Z",
+     "iopub.status.busy": "2026-06-24T14:46:08.756251Z",
+     "iopub.status.idle": "2026-06-24T14:46:08.765151Z",
+     "shell.execute_reply": "2026-06-24T14:46:08.764440Z"
     },
     "papermill": {
-     "duration": 0.017746,
-     "end_time": "2026-06-06T07:17:34.324180",
+     "duration": 0.016822,
+     "end_time": "2026-06-24T14:46:08.766265",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.306434",
+     "start_time": "2026-06-24T14:46:08.749443",
      "status": "completed"
     },
     "tags": []
@@ -693,10 +695,10 @@
    "id": "a3b4c5d6",
    "metadata": {
     "papermill": {
-     "duration": 0.008211,
-     "end_time": "2026-06-06T07:17:34.341828",
+     "duration": 0.003577,
+     "end_time": "2026-06-24T14:46:08.773582",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.333617",
+     "start_time": "2026-06-24T14:46:08.770005",
      "status": "completed"
     },
     "tags": []
@@ -726,10 +728,10 @@
    "id": "b4c5d6e7",
    "metadata": {
     "papermill": {
-     "duration": 0.008731,
-     "end_time": "2026-06-06T07:17:34.359731",
+     "duration": 0.00369,
+     "end_time": "2026-06-24T14:46:08.780772",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.351000",
+     "start_time": "2026-06-24T14:46:08.777082",
      "status": "completed"
     },
     "tags": []
@@ -773,16 +775,16 @@
    "id": "c5d6e7f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.012128Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.012128Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.016514Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.016146Z"
+     "iopub.execute_input": "2026-06-24T14:46:08.790165Z",
+     "iopub.status.busy": "2026-06-24T14:46:08.789773Z",
+     "iopub.status.idle": "2026-06-24T14:46:08.794984Z",
+     "shell.execute_reply": "2026-06-24T14:46:08.794288Z"
     },
     "papermill": {
-     "duration": 0.020343,
-     "end_time": "2026-06-06T07:17:34.388613",
+     "duration": 0.011324,
+     "end_time": "2026-06-24T14:46:08.796032",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.368270",
+     "start_time": "2026-06-24T14:46:08.784708",
      "status": "completed"
     },
     "tags": []
@@ -934,10 +936,10 @@
    "id": "8499bea0",
    "metadata": {
     "papermill": {
-     "duration": 0.006807,
-     "end_time": "2026-06-06T07:17:34.403953",
+     "duration": 0.004026,
+     "end_time": "2026-06-24T14:46:08.803932",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.397146",
+     "start_time": "2026-06-24T14:46:08.799906",
      "status": "completed"
     },
     "tags": []
@@ -967,16 +969,16 @@
    "id": "01c21b88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.018719Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.017720Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.022898Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.022898Z"
+     "iopub.execute_input": "2026-06-24T14:46:08.814046Z",
+     "iopub.status.busy": "2026-06-24T14:46:08.813732Z",
+     "iopub.status.idle": "2026-06-24T14:46:08.818973Z",
+     "shell.execute_reply": "2026-06-24T14:46:08.818313Z"
     },
     "papermill": {
-     "duration": 0.014718,
-     "end_time": "2026-06-06T07:17:34.424531",
+     "duration": 0.012211,
+     "end_time": "2026-06-24T14:46:08.820448",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.409813",
+     "start_time": "2026-06-24T14:46:08.808237",
      "status": "completed"
     },
     "tags": []
@@ -1031,10 +1033,10 @@
    "id": "d6e7f8a9",
    "metadata": {
     "papermill": {
-     "duration": 0.006344,
-     "end_time": "2026-06-06T07:17:34.436501",
+     "duration": 0.005743,
+     "end_time": "2026-06-24T14:46:08.831110",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.430157",
+     "start_time": "2026-06-24T14:46:08.825367",
      "status": "completed"
     },
     "tags": []
@@ -1073,10 +1075,10 @@
    "id": "e7f8a9b0",
    "metadata": {
     "papermill": {
-     "duration": 0.005898,
-     "end_time": "2026-06-06T07:17:34.448554",
+     "duration": 0.004291,
+     "end_time": "2026-06-24T14:46:08.841113",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.442656",
+     "start_time": "2026-06-24T14:46:08.836822",
      "status": "completed"
     },
     "tags": []
@@ -1133,16 +1135,16 @@
    "id": "f8a9b0c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.024919Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.024919Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.028223Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.028223Z"
+     "iopub.execute_input": "2026-06-24T14:46:08.851572Z",
+     "iopub.status.busy": "2026-06-24T14:46:08.851140Z",
+     "iopub.status.idle": "2026-06-24T14:46:08.857965Z",
+     "shell.execute_reply": "2026-06-24T14:46:08.857384Z"
     },
     "papermill": {
-     "duration": 0.015358,
-     "end_time": "2026-06-06T07:17:34.469825",
+     "duration": 0.013762,
+     "end_time": "2026-06-24T14:46:08.859253",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.454467",
+     "start_time": "2026-06-24T14:46:08.845491",
      "status": "completed"
     },
     "tags": []
@@ -1279,10 +1281,10 @@
    "id": "74c573fd",
    "metadata": {
     "papermill": {
-     "duration": 0.006891,
-     "end_time": "2026-06-06T07:17:34.482900",
+     "duration": 0.004244,
+     "end_time": "2026-06-24T14:46:08.867846",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.476009",
+     "start_time": "2026-06-24T14:46:08.863602",
      "status": "completed"
     },
     "tags": []
@@ -1311,16 +1313,16 @@
    "id": "a20f8fa6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.030244Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.029247Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.033750Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.033242Z"
+     "iopub.execute_input": "2026-06-24T14:46:08.879194Z",
+     "iopub.status.busy": "2026-06-24T14:46:08.878437Z",
+     "iopub.status.idle": "2026-06-24T14:46:08.884093Z",
+     "shell.execute_reply": "2026-06-24T14:46:08.883442Z"
     },
     "papermill": {
-     "duration": 0.018227,
-     "end_time": "2026-06-06T07:17:34.506977",
+     "duration": 0.012917,
+     "end_time": "2026-06-24T14:46:08.885238",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.488750",
+     "start_time": "2026-06-24T14:46:08.872321",
      "status": "completed"
     },
     "tags": []
@@ -1372,10 +1374,10 @@
    "id": "a9b0c1d2",
    "metadata": {
     "papermill": {
-     "duration": 0.007021,
-     "end_time": "2026-06-06T07:17:34.523250",
+     "duration": 0.004236,
+     "end_time": "2026-06-24T14:46:08.894227",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.516229",
+     "start_time": "2026-06-24T14:46:08.889991",
      "status": "completed"
     },
     "tags": []
@@ -1408,10 +1410,10 @@
    "id": "b0c1d2e3",
    "metadata": {
     "papermill": {
-     "duration": 0.006368,
-     "end_time": "2026-06-06T07:17:34.534427",
+     "duration": 0.004913,
+     "end_time": "2026-06-24T14:46:08.903602",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.528059",
+     "start_time": "2026-06-24T14:46:08.898689",
      "status": "completed"
     },
     "tags": []
@@ -1467,16 +1469,16 @@
    "id": "c1d2e3f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.035202Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.035202Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.660639Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.660639Z"
+     "iopub.execute_input": "2026-06-24T14:46:08.915156Z",
+     "iopub.status.busy": "2026-06-24T14:46:08.914744Z",
+     "iopub.status.idle": "2026-06-24T14:46:10.115937Z",
+     "shell.execute_reply": "2026-06-24T14:46:10.114664Z"
     },
     "papermill": {
-     "duration": 1.448871,
-     "end_time": "2026-06-06T07:17:35.988203",
+     "duration": 1.208883,
+     "end_time": "2026-06-24T14:46:10.117565",
      "exception": false,
-     "start_time": "2026-06-06T07:17:34.539332",
+     "start_time": "2026-06-24T14:46:08.908682",
      "status": "completed"
     },
     "tags": []
@@ -1486,9 +1488,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
-      "Configurez OPENAI_API_KEY_2/3, OPENAI_BASE_URL_2/3, OPENAI_CHAT_MODEL_ID_2/3\n",
-      "Voir le fichier .env.example pour les details de configuration\n",
+      ".env charge depuis: .env\n",
       "Aucun endpoint vLLM local configure (OPENAI_BASE_URL_2/3 absents du .env).\n",
       "Les benchmarks ci-apres proviennent de la stack de production (3x RTX 4090).\n"
      ]
@@ -1514,7 +1514,7 @@
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
     "if env_loaded:\n",
-    "    print(f\".env charge depuis: {env_path}\")\n",
+    "    print(f\".env charge depuis: {env_path.name}\")\n",
     "else:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
     "    print(\"Configurez OPENAI_API_KEY_2/3, OPENAI_BASE_URL_2/3, OPENAI_CHAT_MODEL_ID_2/3\")\n",
@@ -1574,10 +1574,10 @@
    "id": "i069zh3a5i",
    "metadata": {
     "papermill": {
-     "duration": 0.005969,
-     "end_time": "2026-06-06T07:17:36.000377",
+     "duration": 0.005796,
+     "end_time": "2026-06-24T14:46:10.129997",
      "exception": false,
-     "start_time": "2026-06-06T07:17:35.994408",
+     "start_time": "2026-06-24T14:46:10.124201",
      "status": "completed"
     },
     "tags": []
@@ -1594,16 +1594,16 @@
    "id": "c52d5886",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.660639Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.660639Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.665996Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.665996Z"
+     "iopub.execute_input": "2026-06-24T14:46:10.142989Z",
+     "iopub.status.busy": "2026-06-24T14:46:10.142641Z",
+     "iopub.status.idle": "2026-06-24T14:46:10.149648Z",
+     "shell.execute_reply": "2026-06-24T14:46:10.148366Z"
     },
     "papermill": {
-     "duration": 0.016513,
-     "end_time": "2026-06-06T07:17:36.022945",
+     "duration": 0.015628,
+     "end_time": "2026-06-24T14:46:10.151316",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.006432",
+     "start_time": "2026-06-24T14:46:10.135688",
      "status": "completed"
     },
     "tags": []
@@ -1645,10 +1645,10 @@
    "id": "d2e3f4a5",
    "metadata": {
     "papermill": {
-     "duration": 0.008943,
-     "end_time": "2026-06-06T07:17:36.039445",
+     "duration": 0.005646,
+     "end_time": "2026-06-24T14:46:10.163297",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.030502",
+     "start_time": "2026-06-24T14:46:10.157651",
      "status": "completed"
     },
     "tags": []
@@ -1680,10 +1680,10 @@
    "id": "e3f4a5b6",
    "metadata": {
     "papermill": {
-     "duration": 0.007609,
-     "end_time": "2026-06-06T07:17:36.053817",
+     "duration": 0.005667,
+     "end_time": "2026-06-24T14:46:10.174869",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.046208",
+     "start_time": "2026-06-24T14:46:10.169202",
      "status": "completed"
     },
     "tags": []
@@ -1712,16 +1712,16 @@
    "id": "f4a5b6c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.667647Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.667647Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.672370Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.672370Z"
+     "iopub.execute_input": "2026-06-24T14:46:10.189385Z",
+     "iopub.status.busy": "2026-06-24T14:46:10.188622Z",
+     "iopub.status.idle": "2026-06-24T14:46:10.197593Z",
+     "shell.execute_reply": "2026-06-24T14:46:10.196646Z"
     },
     "papermill": {
-     "duration": 0.020809,
-     "end_time": "2026-06-06T07:17:36.080613",
+     "duration": 0.019195,
+     "end_time": "2026-06-24T14:46:10.199514",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.059804",
+     "start_time": "2026-06-24T14:46:10.180319",
      "status": "completed"
     },
     "tags": []
@@ -1808,10 +1808,10 @@
    "id": "a5b6c7d8",
    "metadata": {
     "papermill": {
-     "duration": 0.007637,
-     "end_time": "2026-06-06T07:17:36.097432",
+     "duration": 0.005782,
+     "end_time": "2026-06-24T14:46:10.211040",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.089795",
+     "start_time": "2026-06-24T14:46:10.205258",
      "status": "completed"
     },
     "tags": []
@@ -1853,10 +1853,10 @@
    "id": "b6c7d8e9",
    "metadata": {
     "papermill": {
-     "duration": 0.00957,
-     "end_time": "2026-06-06T07:17:36.116820",
+     "duration": 0.005744,
+     "end_time": "2026-06-24T14:46:10.222780",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.107250",
+     "start_time": "2026-06-24T14:46:10.217036",
      "status": "completed"
     },
     "tags": []
@@ -1885,16 +1885,16 @@
    "id": "c7d8e9f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-19T21:29:24.672370Z",
-     "iopub.status.busy": "2026-06-19T21:29:24.672370Z",
-     "iopub.status.idle": "2026-06-19T21:29:24.677654Z",
-     "shell.execute_reply": "2026-06-19T21:29:24.677654Z"
+     "iopub.execute_input": "2026-06-24T14:46:10.239307Z",
+     "iopub.status.busy": "2026-06-24T14:46:10.238745Z",
+     "iopub.status.idle": "2026-06-24T14:46:10.247643Z",
+     "shell.execute_reply": "2026-06-24T14:46:10.246415Z"
     },
     "papermill": {
-     "duration": 0.017995,
-     "end_time": "2026-06-06T07:17:36.141994",
+     "duration": 0.021741,
+     "end_time": "2026-06-24T14:46:10.250326",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.123999",
+     "start_time": "2026-06-24T14:46:10.228585",
      "status": "completed"
     },
     "tags": []
@@ -1961,10 +1961,10 @@
    "id": "d8e9f0a1",
    "metadata": {
     "papermill": {
-     "duration": 0.008221,
-     "end_time": "2026-06-06T07:17:36.158624",
+     "duration": 0.006227,
+     "end_time": "2026-06-24T14:46:10.263158",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.150403",
+     "start_time": "2026-06-24T14:46:10.256931",
      "status": "completed"
     },
     "tags": []
@@ -1997,10 +1997,10 @@
    "id": "e9f0a1b2",
    "metadata": {
     "papermill": {
-     "duration": 0.00854,
-     "end_time": "2026-06-06T07:17:36.175478",
+     "duration": 0.008649,
+     "end_time": "2026-06-24T14:46:10.282052",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.166938",
+     "start_time": "2026-06-24T14:46:10.273403",
      "status": "completed"
     },
     "tags": []
@@ -2048,10 +2048,10 @@
    "id": "f0a1b2c3",
    "metadata": {
     "papermill": {
-     "duration": 0.010488,
-     "end_time": "2026-06-06T07:17:36.193664",
+     "duration": 0.006429,
+     "end_time": "2026-06-24T14:46:10.295146",
      "exception": false,
-     "start_time": "2026-06-06T07:17:36.183176",
+     "start_time": "2026-06-24T14:46:10.288717",
      "status": "completed"
     },
     "tags": []
@@ -2123,20 +2123,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 154.628893,
-   "end_time": "2026-06-06T07:17:37.092967",
+   "duration": 11.320512,
+   "end_time": "2026-06-24T14:46:11.178831",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Texte\\11_Quantization.ipynb",
-   "output_path": "d:\\tmp\\h3_test_11.ipynb",
+   "input_path": "MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },
-   "start_time": "2026-06-06T07:15:02.464074",
+   "start_time": "2026-06-24T14:45:59.858319",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Fleet-wide GenAI env-path rollout, **Texte 11_Quantization** (single notebook).

## Problem
`print(f".env charge depuis: {env_path}")` → committed output contained `D:\Dev\CoursIA\...`.

## Why this notebook is re-exec-able (G.1 / SOTA §A — RECOVERABLE-LOCAL, not GPU-blocked)
11_Quantization is a quantization notebook that uses `torch.cuda` / BitsAndBytes for its **live** demos. However, it gates the GPU work behind `BATCH_MODE` (reads `os.getenv("BATCH_MODE", "false")`):
- `BATCH_MODE=true` → the BitsAndBytes / torch.cuda demos run as **lecture-seule** (read-only presentation), and the notebook executes fully on CPU.

So with `BATCH_MODE=true` + `CUDA_VISIBLE_DEVICES=""`, the notebook re-executes end-to-end without a GPU. Verdict: **RECOVERABLE-LOCAL** (installed/invoke-able on the worker), no workaround degradation — the real content (GPTQ/AWQ theory, comparison tables, scripts) runs; only the live GPU quantization call is intentionally skipped by the notebook's own BATCH_MODE switch.

## Fix at source (Stop & Repair)
`{env_path}` → `{env_path.name}`. Re-executed to regenerate output from corrected source.

## Execution proof (rule §D / C.2)
```
python -m papermill NB NB --cwd MyIA.AI.Notebooks/GenAI --execution-timeout 300 -p BATCH_MODE true
```
(with `CUDA_VISIBLE_DEVICES="" BATCH_MODE=true` in the env)

```
11_Quantization: cells=14 null_exec=0 errors=0 NIE=0 raw_env=0 machine_leaks=0 secrets=0
```
- 0 machine-path leak (`D:\Dev\CoursIA`).
- 0 `raise NotImplementedError` (C.1).
- Source diff = one `{env_path}`→`{env_path.name}` line (verified); rest = regenerated output.

## Scope (rule C.3)
Single notebook.

See #4080. (Earlier batches: Texte 1-4 #4135, Texte 5-9 #4145.)

Co-Authored-By: Claude <noreply@anthropic.com>