### PR TITLE
lean(cooperative): prove dictator_not_dummy (Dictator -> not DummyPlayer)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1154,6 +1154,24 @@ theorem dummy_banzhaf_raw_zero (G : TUGame N) (i : N) (h : DummyPlayer G i) :
   rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
   exact fun S _ hcrit => hneq S hcrit
 
+/-- A dictator is never a dummy player.
+
+    The two extreme player roles are mutually exclusive. A dummy player adds no value to any
+    coalition it is absent from; applied to the empty coalition this yields `v (∅ ∪ {i}) = v ∅`,
+    i.e. `v {i} = 0` (via `TUGame.empty_zero`). But a dictator wins alone (`v {i} = 1`, the first
+    conjunct of `Dictator`), a contradiction. This is the player-type analogue of the BanzhafRaw
+    sign split (`dictator_banzhaf_pos` : `> 0`, `dummy_banzhaf_raw_zero` : `= 0`). -/
+theorem dictator_not_dummy (G : TUGame N) (i : N) (h : Dictator G i) :
+    ¬ DummyPlayer G i := by
+  intro hd
+  -- The dummy hypothesis at the empty coalition gives `v {i} = v ∅ = 0`.
+  have hdummy : G.v ({i} : Finset N) = 0 := by
+    have hni : (i : N) ∉ (∅ : Finset N) := by simp
+    have heq := hd ∅ hni
+    rw [Finset.empty_union, G.empty_zero] at heq
+    exact heq
+  linarith [h.1]
+
 /-- Coalitional swap used by `banzhaf_raw_symmetric`. In a coalition `S`, replace the lone
     member of `{i, j}` by the other (if `S` contains exactly one of `i, j`); coalitions
     containing both or neither are fixed. It is an involution and preserves the game value


### PR DESCRIPTION
## `dictator_not_dummy` — Dictator and DummyPlayer are mutually exclusive

A **player-type taxonomy** result for the cooperative-game player roles: the two extreme
roles — a **dictator** (wins alone, has veto) and a **dummy** (adds no value) — **cannot be
the same player**. The structural companion to the BanzhafRaw sign split, placed alongside
the existing `dummy_banzhaf_raw_zero` (= 0) and `dictator_banzhaf_pos` (> 0, #4138).

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `dictator_not_dummy` | `Dictator G i → ¬ DummyPlayer G i` | player-type orthogonality |

### Proof

- `DummyPlayer G i` says: for every coalition `S` not containing `i`,
  `v (S ∪ {i}) = v S`.
- Applied to the empty coalition (`i ∉ ∅`): `v (∅ ∪ {i}) = v ∅`.
- `∅ ∪ {i} = {i}` (`Finset.empty_union`) and `v ∅ = 0` (`TUGame.empty_zero`), so `v {i} = 0`.
- But `Dictator G i`'s first conjunct is `v {i} = 1`. `1 = 0` is a contradiction (`linarith`).

This is the **player-type** form of the same exclusion the BanzhafRaw sign split expresses
**arithmetically** (`0 < BanzhafRaw` vs `BanzhafRaw = 0` cannot both hold for one player).

### Independent of pending PRs (no stacking, no conflict)

Prouvable from `main` alone (needs only `Dictator`, `DummyPlayer`, `TUGame.empty_zero`).
**Disjoint region** from the three pending cooperative-games PRs:

| PR | Region (Shapley.lean) | Size |
|----|----------------------|------|
| #4149 MonotoneGame | after `end SimpleGame` (~L1054) | +37 |
| #4156 dictator_unique | after `def Dictator` (~L1094) | +11 |
| #4153 veto_banzhaf_raw_pos | after `dictator_banzhaf_pos` (~L1112) | +31 |
| **#4157 this** | **after `dummy_banzhaf_raw_zero` (~L1155)** | **+18** |

Four distinct insertion anchors → all merge in any order with no text conflict.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (15s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +18), inserted after `dummy_banzhaf_raw_zero`. **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
