### PR TITLE
docs(qcpy20): anchor 6 ML methods (Ridge/Lasso/ElasticNet + RF/GB/XGBoost) #3164

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
@@ -507,7 +507,9 @@
     "  - Combine les avantages des deux\n",
     "  - Features correlees + sparse solution\n",
     "  - Plus flexible\n",
-    "```"
+    "```\n",
+    "\n",
+    "> *Ancres savantes -- Hoerl, A. E. & Kennard, R. W. (1970), « Ridge Regression: Biased Estimation for Nonorthogonal Problems », Technometrics 12(1):55-67 (DOI 10.1080/00401706.1970.10488634) -- Ridge regression : introduit la penalite L2 (terme lambda*||beta||^2) qui reserre les coefficients vers zero sans jamais les annuler, contre le sur-apprentissage en presence de colinearite ; la table de regularisation ci-dessus l'illustre comme le cas L2 de la famille. Tibshirani, R. (1996), « Regression Shrinkage and Selection via the Lasso », Journal of the Royal Statistical Society Series B 58(1):267-288 (DOI 10.1111/j.2517-6161.1996.tb02080.x) -- Lasso : la penalite L1 (lambda*||beta||_1) produit une parcimonie exacte (coefficients ramenes a zero), c'est-a-dire une selection de variables automatique, que Ridge ne permet pas. Zou, H. & Hastie, T. (2005), « Regularization and Variable Selection via the Elastic Net », JRSS-B 67(2):301-320 -- Elastic Net : combine les penalites L1 et L2 pour recuperer la selection de variables du Lasso tout en stabilisant les groupes de variables correlees (ou le Lasso pur en selectionne une sur N au hasard), d'ou le compromis ridge-lasso enseigne dans cette Partie 2.*\n"
    ]
   },
   {
@@ -1051,7 +1053,9 @@
     "   |\n",
     "   v\n",
     "Prediction finale = Moyenne(Prediction 1, ..., Prediction N)\n",
-    "```"
+    "```\n",
+    "\n",
+    "> *Ancres savantes -- Breiman, L. (2001), « Random Forests », Machine Learning 45(1):5-32 (DOI 10.1023/A:1010933404324) -- Random Forest : generalise le bagging (Bootstrap AGGregatING) en ajoutant une selection aleatoire d'un sous-ensemble de variables a chaque split (feature subsampling), decorrelant les arbres et reduisant la variance par moyenne -- le schema de bootstrap du « Random Forest Regressor » ci-dessus materialise ce principe. Friedman, J. H. (2001), « Greedy Function Approximation: A Gradient Boosting Machine », The Annals of Statistics 29(5):1189-1232 (1999 Reitz Lecture, DOI 10.1214/aos/1013203451) -- Gradient Boosting (MART) : au lieu d'agreger des arbres independants (bagging), on les construit sequentiellement en ajustant chaque nouvel arbre au gradient des residus du precedent, minimisant une fonction de perte additive -- le principe recursif sur les residus enseigne dans cette Partie 3. Chen, T. & Guestrin, C. (2016), « XGBoost: A Scalable Tree Boosting System », Proceedings of the 22nd ACM SIGKDD (KDD '16):785-794 (arXiv:1603.02754, DOI 10.1145/2939672.2939785) -- XGBoost : implementation optimisee du gradient boosting (objectif regularise, split finding sparsity-aware, cache-aware et out-of-core) qui en a fait le standard de fait du tabular ML et dont l'usage via sklearn/xgboost est demontre dans cette Partie 3.*\n"
    ]
   },
   {


### PR DESCRIPTION
## Context

#3164 citation audit, 1st pass on **QC-Py-20 (ML-Regression-Prediction)** — a genuinely unaudited notebook (0 anchors found). It teaches 6 ML methods by name across 2 `## Partie` cells — a **regularisation table** (Ridge / Lasso / ElasticNet, Partie 2) and an **ensemble table + Random Forest bootstrap diagram** (RandomForest / GradientBoosting / XGBoost, Partie 3) — but cites **no originator at the concept definition point**. (The Conclusion cell recaps 4 of them with author+year inline, but that is a summary, not an anchor at the teaching point.)

This is the standard `#3164` markdown-additive pattern (cf #4154 QC-Py-24 K-Means, #4157 QC-Py-22 SOTA archs): append one plural scholarly footnote anchor to each Partie cell, citing the originator where the concept is *defined*.

## Changes

Markdown-additive, **0 code cell changed** (25 code cells sha1 byte-identical to `origin/main`).

- **Partie 2 — cell 12** (`## Partie 2 : Linear Regression - Ridge, Lasso, ElasticNet`): plural anchor
  - **Ridge** — Hoerl & Kennard (1970), *Technometrics* 12(1):55-67 — DOI [10.1080/00401706.1970.10488634](https://doi.org/10.1080/00401706.1970.10488634)
  - **Lasso** — Tibshirani (1996), *JRSS-B* 58(1):267-288 — DOI [10.1111/j.2517-6161.1996.tb02080.x](https://doi.org/10.1111/j.2517-6161.1996.tb02080.x)
  - **Elastic Net** — Zou & Hastie (2005), *JRSS-B* 67(2):301-320
- **Partie 3 — cell 24** (`## Partie 3 : Ensemble Methods - Random Forest et Gradient Boosting`): plural anchor
  - **Random Forest** — Breiman (2001), *Machine Learning* 45(1):5-32 — DOI [10.1023/A:1010933404324](https://doi.org/10.1023/A:1010933404324)
  - **Gradient Boosting** — Friedman (2001), *Annals of Statistics* 29(5):1189-1232 (1999 Reitz Lecture) — DOI [10.1214/aos/1013203451](https://doi.org/10.1214/aos/1013203451)
  - **XGBoost** — Chen & Guestrin (2016), *KDD '16* pp.785-794 — arXiv:1603.02754, DOI [10.1145/2939672.2939785](https://doi.org/10.1145/2939672.2939785)

## Verification

- **Web-verified vs primary sources** (Technometrics/JSTOR, Oxford Academic JRSS-B, Stanford-Hastie, Springer/Berkeley-Breiman, Project Euclid-Friedman, arXiv + ACM DL-Chen&Guestrin), 2026-06-24.
- JSON valid, 67 cells.
- `git diff --stat`: `+6/-2`. The `-2` are benign code-fence-closer newline normalization (`"```"` → `"```\n"`) — rendered markdown is byte-identical, no content lost.
- **25 code cells sha1 byte-identical to `origin/main`** → 0 code cell changed (markdown-only edit, C.2 exception: prior outputs remain valid).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)