### PR TITLE
lean(cooperative): prove MonotoneGame.winning_upward_closed (up-set of winning coalitions)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1072,6 +1072,22 @@ theorem le_of_subset {G : TUGame N} (hG : MonotoneGame G) {S T : Finset N}
     (h : S ⊆ T) : G.v S ≤ G.v T :=
   hG h
 
+/-- The winning coalitions of a monotone simple game form an up-set: enlarging a winning
+    coalition keeps it winning.
+
+    Monotonicity gives `v S ≤ v T` for `S ⊆ T`; since `v S = 1` and `SimpleGame` forces
+    `v T ∈ {0, 1}`, this rules out `v T = 0`, leaving `v T = 1`. This is the defining
+    property of a *proper* simple voting game and the bridge from `MonotoneGame` to the
+    veto theory. -/
+theorem winning_upward_closed {G : TUGame N} (hG : MonotoneGame G) (hG' : SimpleGame G)
+    {S T : Finset N} (hST : S ⊆ T) (hwin : G.v S = 1) : G.v T = 1 := by
+  -- Monotonicity: `v S ≤ v T`, and `v S = 1` so `1 ≤ v T`; with `v T ∈ {0,1}` this
+  -- rules out `v T = 0`, hence `v T = 1`.
+  apply SimpleGame.eq_one_of_ne_zero hG' T
+  intro hzero
+  have : (1 : ℝ) ≤ G.v T := hwin ▸ hG hST
+  linarith
+
 end MonotoneGame
 
 /-- A weighted voting game with non-negative weights is monotone: enlarging a coalition


### PR DESCRIPTION
## `MonotoneGame.winning_upward_closed` — up-set of winning coalitions (first rich-veto-theory theorem)

The **first theorem of the rich veto theory** that `MonotoneGame` (#4149) was merged to enable.
ai-01 merged #4149 (#4153/#4156/#4160 with it) at 15:24Z specifically noting MonotoneGame was
"la fondation pour la veto theory RICHE à venir (up-sets / monotone thms)". This PR delivers that
first up-set theorem.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `MonotoneGame.winning_upward_closed` | `[MonotoneGame G] → [SimpleGame G] → S ⊆ T → v S = 1 → v T = 1` | up-set of winning coalitions |

### Why this matters (the bridge to veto theory)

In voting theory, a **proper** simple game is one where the family of winning coalitions is an
**up-set**: enlarging a winning coalition keeps it winning. This PR proves that property holds for
any monotone simple game:

- Monotonicity (`MonotoneGame`) gives `v S ≤ v T` whenever `S ⊆ T`.
- `v S = 1` (winning), so `1 ≤ v T`.
- `SimpleGame` forces `v T ∈ {0, 1}` — `1 ≤ v T` rules out `v T = 0`, leaving `v T = 1`.

This is the direct application of `MonotoneGame` that the upcoming veto theorems need
(e.g. a critical player whose removal keeps the coalition winning requires the up-set to reason
about supersets). `MonotoneGame.le_of_subset` (reader) → `winning_upward_closed` (first corollary).

### Built on freshly-merged foundations

Prouvable from `origin/main` directly — uses only:
- `MonotoneGame` + `MonotoneGame.le_of_subset` (just merged, #4149)
- `SimpleGame.eq_one_of_ne_zero` (merged, #4134)

No stacking on pending PRs; this is the first commit past the merge point.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (15s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +16), inserted inside `namespace MonotoneGame` after
  `le_of_subset`. **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
