### PR TITLE
docs(z3-python): anchor SMT academic references at teaching point (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -130,6 +130,17 @@ Le pattern « décrire les contraintes, laisser le solveur résoudre » s'appliq
 - [Série Z3 C# (Z3.Linq)](../Z3/README.md) — série sœur en .NET 9
 - [Série Sudoku](../../../Sudoku/README.md) — compare Z3 à 10 autres approches algorithmiques
 
+## Références académiques
+
+La série manipule un vocabulaire précis (SMT, tactiques, MaxSAT, théories) hérité de la logique et de la vérification automatique. Les fondements théoriques et les papiers fondateurs des concepts introduits :
+
+| Référence | Couverture |
+|-----------|------------|
+| de Moura & Bjorner, "Z3: An Efficient SMT Solver" (TACAS 2008) | Solveur Z3 utilisé tout au long de la série |
+| Nieuwenhuis, Oliveras & Tinelli, "Solving SAT and SAT Modulo Theories: From an Abstract DPLL Procedure to DPLL(T)" (JACM 2006) | Fondements théoriques de la résolution SMT (DPLL(T)) |
+| de Moura & Passmore, "The Strategy Challenge in SMT Solving" (SMT 2013) | Tactiques et stratégies de résolution (notebook 03) |
+| Morgado, Heras, Liffiton, Planes & Marques-Silva, "Iterative and core-guided MaxSAT solving: A survey and assessment" (Constraints 2013) | MaxSAT, relaxation des contraintes dures en souples (notebook 06) |
+
 ## FAQ / Troubleshooting
 
 | Problème | Solution |

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -138,7 +138,7 @@ La série manipule un vocabulaire précis (SMT, tactiques, MaxSAT, théories) h�
 |-----------|------------|
 | de Moura & Bjorner, "Z3: An Efficient SMT Solver" (TACAS 2008) | Solveur Z3 utilisé tout au long de la série |
 | Nieuwenhuis, Oliveras & Tinelli, "Solving SAT and SAT Modulo Theories: From an Abstract DPLL Procedure to DPLL(T)" (JACM 2006) | Fondements théoriques de la résolution SMT (DPLL(T)) |
-| de Moura & Passmore, "The Strategy Challenge in SMT Solving" (SMT 2013) | Tactiques et stratégies de résolution (notebook 03) |
+| de Moura & Passmore, "The Strategy Challenge in SMT Solving" (2013) | Tactiques et stratégies de résolution (notebook 03) |
 | Morgado, Heras, Liffiton, Planes & Marques-Silva, "Iterative and core-guided MaxSAT solving: A survey and assessment" (Constraints 2013) | MaxSAT, relaxation des contraintes dures en souples (notebook 06) |
 
 ## FAQ / Troubleshooting

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-01-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-01-Introduction.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Z3** est un solveur SMT (*Satisfiability Modulo Theories*) developpe par Microsoft Research. Un solveur SMT determine si un ensemble de contraintes logiques et arithmetiques peut etre satisfait, et si oui, fournit un **modele** (une assignation concrete des variables). Cette serie utilise **z3-py**, le binding Python officiel (package pip `z3-solver`), qui expose l'integralite de l'API Z3 sans la limitation d'un binding declaratif."
+    "**Z3** est un solveur SMT (*Satisfiability Modulo Theories*) developpe par Microsoft Research. Un solveur SMT determine si un ensemble de contraintes logiques et arithmetiques peut etre satisfait, et si oui, fournit un **modele** (une assignation concrete des variables). Cette serie utilise **z3-py**, le binding Python officiel (package pip `z3-solver`), qui expose l'integralite de l'API Z3 sans la limitation d'un binding declaratif. Pour les fondements theoriques de la resolution SMT (DPLL(T)) et la presentation du solveur Z3 lui-meme, voir de Moura & Bjorner, *Z3: An Efficient SMT Solver* (TACAS 2008) et Nieuwenhuis, Oliveras & Tinelli, *Solving SAT and SAT Modulo Theories: From an Abstract DPLL Procedure to DPLL(T)* (JACM 2006) ; les tactiques (notebook 3) et MaxSAT (notebook 6) sont ancrees dans la section References du README."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit citations Epic **#3164** on `Z3-Python/` (dispatch ai-01 2026-06-24 15:25Z, second half: "Z3-Python si méthodes SMT nommées sans ancre"). The series **names SMT concepts across the README** ("Concepts clés" table: Z3, Tactique, MaxSAT, Noyau d'insatisfiabilité, Array) **and describes SMT solving** in its "Contexte technique" section — the 01-Introduction notebook introduces Z3 as "un solveur SMT ... développé par Microsoft Research" — **all without a single academic reference**. The README had a "Liens" section (documentation URLs only) but no References section.

This PR anchors the 4 canonical SMT papers.

## Changes

- **`Z3-Python-01-Introduction.ipynb`** (title cell `nb01-title`): append a teaching-point pointer to **de Moura & Bjørner, "Z3: An Efficient SMT Solver" (TACAS 2008)** and **Nieuwenhuis, Oliveras & Tinelli, DPLL(T) (JACM 2006)** at the intro paragraph where Z3 is introduced. Tactics (notebook 3) and MaxSAT (notebook 6) anchored in the README References.
- **`README.md`**: add a new "Références académiques" section (4 papers) before the FAQ.

## Papers anchored (per concept named in the series)

| Concept named | Reference anchored |
|---------------|--------------------|
| **Z3** (the solver itself) | de Moura & Bjørner, "Z3: An Efficient SMT Solver" (TACAS 2008) |
| **SMT solving** (README "Contexte technique") | Nieuwenhuis, Oliveras & Tinelli, DPLL(T) (JACM 2006) |
| **Tactique** (notebook 03) | de Moura & Passmore, "The Strategy Challenge in SMT Solving" (SMT 2013) |
| **MaxSAT** (notebook 06) | Morgado et al., "Iterative and core-guided MaxSAT solving" (Constraints 2013) |

Each paper is the canonical reference for the concept the series introduces at a teaching point.

## Markdown-only (C.2 exception)

Notebook prose append + README new section. Per C.2, markdown-only edits do not require re-execution (prior outputs valid). The notebook code cells are untouched.

## Diff

`2 files changed, 12 insertions(+), 1 deletion(-)`. The notebook edit is a **single source-line append** (source array preserved — byte replacement, no list→string churn). Base fresh off `origin/main`.

See #3164

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>