### PR TITLE
docs(z3-linq): anchor SMT academic references at teaching point (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/01_Linq2Z3_Intro.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/01_Linq2Z3_Intro.ipynb
@@ -340,7 +340,7 @@
     "Le solveur Z3 trouve une solution (il peut y en avoir plusieurs). L'exécution ci-dessus donne par exemple :\n",
     "- Une affectation valide : X1 = 3, X2 = 0, X3 = 1, X4 = 0, X5 = 1\n",
     "\n",
-    "> **Note**: Z3 est un solveur SMT (Satisfiability Modulo Theories) capable de résoudre des contraintes sur des entiers, des réels, des tableaux, etc. LINQ To Z3 offre une interface C# naturelle pour exprimer ces contraintes."
+    "> **Note**: Z3 est un solveur SMT (Satisfiability Modulo Theories) capable de résoudre des contraintes sur des entiers, des réels, des tableaux, etc. LINQ To Z3 offre une interface C# naturelle pour exprimer ces contraintes. Pour les fondements théoriques de la résolution SMT (DPLL(T)) et la présentation du solveur Z3 lui-même, voir de Moura & Bjørner, *Z3: An Efficient SMT Solver* (TACAS 2008) et Nieuwenhuis, Oliveras & Tinelli, *Solving SAT and SAT Modulo Theories: From an Abstract DPLL Procedure to DPLL(T)* (JACM 2006) ; la théorie des tableaux (notebook 3) et le standard SMT-LIB (notebooks 3, 6) sont ancrés dans la section Références du README."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -165,6 +165,17 @@ Ces ressources relèvent de l'Epic **#2978** (le Sudoku comme regex symbolique) 
 - [MyIntelligenceAgency/Z3.LinqBinding@EPFdevelopment](https://github.com/MyIntelligenceAgency/Z3.LinqBinding/tree/EPFdevelopment) (branche contributions jsboige)
 - [Issue upstream #29](https://github.com/endjin/Z3.Linq/issues/29) (discussion contributions)
 
+## Références académiques
+
+La série manipule un vocabulaire précis (SMT, théorie des tableaux, standard SMT-LIB) hérité de la logique et de la vérification automatique. Les fondements théoriques des concepts introduits aux points d'enseignement :
+
+| Référence | Couverture |
+|-----------|------------|
+| de Moura & Bjørner, "Z3: An Efficient SMT Solver" (TACAS 2008) | Solveur Z3 utilisé tout au long de la série |
+| Nieuwenhuis, Oliveras & Tinelli, "Solving SAT and SAT Modulo Theories: From an Abstract DPLL Procedure to DPLL(T)" (JACM 2006) | Fondements théoriques de la résolution SMT (DPLL(T)) |
+| Barrett, Fontaine & Tinelli, "The SMT-LIB Standard: Version 2.6" (2017) | Standard SMT-LIB émis par le convertisseur et consommé par Z3 (notebooks 03, 06) |
+| McCarthy, "Towards a Mathematical Science of Computation" (IFIP 1962) | Axiomes de la théorie des tableaux `select`/`store` (notebook 03) |
+
 ## FAQ / Troubleshooting
 
 | Problème | Solution |


### PR DESCRIPTION
## Summary

Audit citations Epic **#3164** extension on `Z3/` (C# Z3.Linq series) — same omission pattern as the sister Z3-Python series (#4167, merged). The README **names "Z3 ... solveur SMT (Satisfiability Modulo Theories)"** at multiple teaching points (overview, "Contexte technique") and **notebook 03 names the McCarthy axioms** (`select`/`store`) **and the SMT-LIB standard** — all **without a single academic reference**. The README had a "Liens" section (GitHub repos only) but no References section.

This PR anchors the 4 canonical references for the concepts named at teaching points.

## Changes

- **`01_Linq2Z3_Intro.ipynb`** (cell ~L343, the "Note" blockquote teaching point): append a pointer to **de Moura & Bjørner, "Z3: An Efficient SMT Solver" (TACAS 2008)** and **Nieuwenhuis, Oliveras & Tinelli, DPLL(T) (JACM 2006)**. Array theory + SMT-LIB anchored in the README References.
- **`README.md`**: add a new "Références académiques" section (4 papers) before the FAQ.

## References anchored (per concept named in the series)

| Concept named at teaching point | Reference anchored |
|---------------------------------|--------------------|
| **Z3** (the solver itself) | de Moura & Bjørner, "Z3: An Efficient SMT Solver" (TACAS 2008) |
| **SMT solving** (README "Contexte technique") | Nieuwenhuis, Oliveras & Tinelli, DPLL(T) (JACM 2006) |
| **SMT-LIB standard** (notebooks 03, 06 — `re.inter`/`re.comp`, `select`/`store`) | Barrett, Fontaine & Tinelli, "The SMT-LIB Standard: Version 2.6" (2017) |
| **Array-theory axioms `select`/`store`** (notebook 03 — "axiomes de McCarthy") | McCarthy, "Towards a Mathematical Science of Computation" (IFIP 1962) |

Each reference is the canonical anchor for a concept the series already names at a teaching point.

## Markdown-only (C.2 exception)

Notebook prose append + README new section. Per C.2, markdown-only edits do not require re-execution (prior outputs valid). The notebook code cells are untouched.

## Diff

`2 files changed, 12 insertions(+), 1 deletion(-)`. The notebook edit is a **single source-line append** (source array preserved — byte replacement, no list→string churn). Base fresh off `origin/main`. No catalog churn.

## Coordination note

This is the third sibling PR of the #3164 audit on my partition (po-2025): #4162 (Argument_Analysis, merged), #4167 (Z3-Python, merged/open), #4171 (this). The Z3/ C# series is explicitly my partition (memory `partition-symbolicai-subdir-z3-argumentum`).

See #3164

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>