### PR TITLE
lean(cooperative): prove losing_downward_closed (down-set of losing coalitions)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1074,6 +1074,18 @@ theorem le_of_subset {G : TUGame N} (hG : MonotoneGame G) {S T : Finset N}
 
 end MonotoneGame
 
+/-- The losing coalitions of a monotone simple game form a down-set: shrinking a losing
+    coalition keeps it losing. The dual of the winning up-set property: monotonicity gives
+    `v S ≤ v T`, and `v T = 0` forces `v S ≤ 0 < 1`; `SimpleGame` then rules out `v S = 1`,
+    leaving `v S = 0`. -/
+theorem losing_downward_closed {G : TUGame N} (hG : MonotoneGame G) (hG' : SimpleGame G)
+    {S T : Finset N} (hST : S ⊆ T) (hlose : G.v T = 0) : G.v S = 0 := by
+  -- Monotonicity: `v S ≤ v T = 0`, so `v S ≤ 0 < 1`; `SimpleGame` then rules out `v S = 1`.
+  apply SimpleGame.eq_zero_of_ne_one hG' S
+  intro hone
+  have : G.v S ≤ G.v T := MonotoneGame.le_of_subset hG hST
+  linarith
+
 /-- A weighted voting game with non-negative weights is monotone: enlarging a coalition
     adds non-negative weight, so the weight sum can only increase, hence `v` (an
     `if sum ≥ quota then 1 else 0`) cannot decrease. -/


### PR DESCRIPTION
## `losing_downward_closed` — down-set of losing coalitions (dual of the winning up-set)

The **second theorem of the rich veto theory** enabled by `MonotoneGame` (#4149). The dual
of `winning_upward_closed` (#4163, pending): the losing coalitions of a monotone simple game
form a **down-set** — shrinking a losing coalition keeps it losing.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `losing_downward_closed` | `[MonotoneGame G] [SimpleGame G] → S ⊆ T → v T = 0 → v S = 0` | down-set of losing coalitions |

### Proof (dual of the up-set)

- Monotonicity (`MonotoneGame.le_of_subset`) gives `v S ≤ v T` whenever `S ⊆ T`.
- `v T = 0` (losing), so `v S ≤ 0`, in particular `v S < 1`.
- `SimpleGame` forces `v S ∈ {0, 1}` — `v S < 1` rules out `v S = 1`, leaving `v S = 0`.

Together with `winning_upward_closed` (winning up-set) this completes the **up-set / down-set
pair** that characterises the winning and losing families of a *proper* simple voting game.

### Independent of #4163 (no text conflict)

Both #4163 and this PR touch the `MonotoneGame` area but in **disjoint regions**:
- **#4163** inserts `winning_upward_closed` **inside** `namespace MonotoneGame`
  (between `le_of_subset` and `end MonotoneGame`).
- **this PR** inserts `losing_downward_closed` **at top level, after** `end MonotoneGame`
  (before `weighted_voting_game_monotone`).

Distinct anchors → merge in any order with no text conflict. (The docstring references the
winning *up-set property* in prose, not the `winning_upward_closed` symbol by name, so it
remains accurate regardless of merge order.)

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (16s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +12), inserted after `end MonotoneGame`. **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
