### PR TITLE
docs(lean): add LEAN_INVENTORY for SymbolicAI/Lean + Probas (See #4041 See #4038)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/Probas/LEAN_INVENTORY.md
@@ -1,0 +1,134 @@
+# Inventaire des projets Lean 4 — `Probas`
+
+Inventaire transverse des projets de formalisation Lean 4 sous `Probas/`, sur le modèle de
+[`GameTheory/LEAN_INVENTORY.md`](../GameTheory/LEAN_INVENTORY.md) et
+[`SymbolicAI/Lean/LEAN_INVENTORY.md`](../SymbolicAI/Lean/LEAN_INVENTORY.md). Source de
+vérité : corps de l'Epic
+[#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification `firsthand` (issue
+[#4041](https://github.com/jsboige/CoursIA/issues/4041)). Colonne *sorry (production)* =
+métrique CI `standalone-tactic` (les mentions prose « 0 sorry »/« sans sorry » n'entrent pas
+dans ce compte ; cf.
+[`lean-ci-sorry-filter`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+
+## Résumé
+
+| Lake | Toolchain | sorry (production) | Modules | Notebook câblé | Classe | Suivi |
+|------|-----------|--------------------:|--------:|---------------:|--------|-------|
+| `decision_theory_lean` | v4.30.0-rc2 | 5¹ | 8 (3 libs) | 0² | PEDA/REF | #4049, #4050, #4039 |
+| `Infer/gittins_lean` | — | — | 0³ | 0 | SCAFFOLD | #4039 (broken stub) |
+| **Total** | — | **5** | **8** | — | — | — |
+
+¹ Les 5 `sorry` standalone-tactic de `decision_theory_lean` sont **tous** dans
+`Gittins/GittinsTheorem.lean` (théorème d'optimalité de l'index de Gittins). Le fichier
+documente **explicitement** en-tête : « The full proof is INTRACTABLE in the current Mathlib
+(no MDP/bandit/Bellman). We state the theorem and provide sorry placeholders. » →
+classification **INTRINSIC**, pas un gap pédagogique : la machinerie MDP/Bellman n'existe
+pas encore dans Mathlib. Les libs `Utility` et `Coherence` sont **0 sorry**.
+
+² Aucun notebook n'importe directement le lake `decision_theory_lean`. La série Infer
+« Decision » (Infer-14 Utility-Foundations → Infer-20 Sequential) est le **companion
+conceptuel** (.NET Interactive, décision/utilité) ; le câblage formel du lake comme
+compagnon Lean n'est pas encore effectué.
+
+³ `Infer/gittins_lean` n'est **pas** un lake buildable : il ne contient que
+`lake-manifest.json` + `.lake/` (packages vendés), **sans** `lakefile.lean`,
+`lean-toolchain`, ni aucune source `.lean`. Échafaudage abandonné. La formalisation réelle
+de Gittins vit dans `decision_theory_lean/Gittins/`.
+
+---
+
+## Par lake
+
+### 1. decision_theory_lean — PEDAGOGIQUE / REFERENCE (3 libs)
+
+**Objectif** : formalisation des fondements de la théorie de la décision — utilité espérée
+(vNM), cohérence probabiliste (de Finetti Dutch Book), index de Gittins (bandits manchots à
+escompte géométrique).
+
+- **Toolchain** : v4.30.0-rc2 · **Dépendance** : Mathlib4
+- **libs** (`lean_lib`) : `Gittins`, `Utility`, `Coherence`
+- **sorry (production)** : **5** (tous INTRINSIC dans Gittins, voir note ¹)
+
+#### `Utility/` (3 fichiers) — 0 sorry · PEDA/REF · #4049
+
+Théorie de l'utilité espérée (von Neumann–Morgenstern). Axiomes de rationalité
+(`IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous`) dans `Axioms.lean` ;
+loteries, espérance, mixage dans `Basic.lean` (lemmes `expectation_mix`,
+`expectation_add`, `expectation_smul`, `expectation_const`, `expectation_affine` — tous
+prouvés) ; théorèmes de représentation dans `Representation.lean`.
+
+- **Prouvé** : `expected_utility_rep_is_rational` (direction **sound** : une représentation
+  EU implique la rationalité VNM), `affine_rep_is_rep` (**stabilité affine** : une
+  transformation affine positive d'une utilité EU reste une représentation), +
+  `rep_complete`/`rep_transitive`/`rep_independent`/`rep_continuous`.
+- **OPEN (non sorry-backed)** : direction **existence** (Herstein–Milnor 1953 :
+  rationalité ⟹ représentation EU) — documentée honnêtement comme jalon ouvert dans
+  l'en-tête du fichier, **pas** un `sorry`. La lib livre la direction sound entièrement
+  sorry-free.
+
+#### `Coherence/` (2 fichiers) — 0 sorry · PEDA/REF · #4050
+
+Cohérence probabiliste au sens de de Finetti (Dutch Book). Indicateur nu
+`ind A ω := if ω ∈ A then 1 else 0` dans `Basic.lean` ; Dutch Book dans `DutchBook.lean`.
+
+- **Prouvé** : `ind_inclusion_exclusion` (keystone : l'indicateur satisfait
+  inclusion-exclusion `ind (A∪B) = ind A + ind B − ind (A∩B)`), `non_additive_implies_dutch_book`
+  (direction **constructive** de de Finetti : une fonction de prix non-additive admet un
+  Dutch Book, witness de mises `(1,1,−1,−1)`), `coherent_on_implies_additive` (**contraposée**
+  : la cohérence entraîne l'additivité).
+- **OPEN (non sorry-backed)** : réciproque `coherent_iff_probability` (dualité
+  programmation linéaire : cohérence ⟺ fonction de probabilité) — documentée comme jalon
+  ouvert, pas un `sorry`.
+
+#### `Gittins/` (3 fichiers) — 5 sorry (INTRINSIC) · REF · #4039
+
+Index de Gittins pour les bandits manchots à escompte géométrique.
+
+- **Prouvé (0 sorry)** : `Basic.lean` (types purs : `BanditArm`, `BanditInstance`,
+  `Policy`, sans dépendance Mathlib) + `Discount.lean` (identités d'escompte géométrique via
+  `tsum_geometric_of_lt_one`, `geometricPartialSum`).
+- **INTRINSIC (5 sorry)** : `GittinsTheorem.lean` — théorème d'optimalité de l'index de
+  Gittins. **Plafond atteignable honnête** : la preuve complète nécessite la machinerie
+  MDP / programmation dynamique / équation de Bellman, **absente** de Mathlib à ce jour. Le
+  théorème est **énoncé** avec placeholders `sorry` documentés en-tête (pas maquillés en
+  résultat prouvé). Quand Mathlib gagnera un formalisme MDP, ces `sorry` deviennent la
+  prochaine cible.
+
+### 2. Infer/gittins_lean — SCAFFOLD (broken stub)
+
+**Objectif (abandonné)** : formalisation de l'index de Gittins, prématurément ébauchée sous
+`Infer/`.
+
+- **État** : **PAS un lake buildable**. Contenu = `lake-manifest.json` (3158 o) +
+  `.lake/packages/` (Mathlib vendé). **Manquent** : `lakefile.lean`, `lean-toolchain`,
+  et **toute source `.lean`**.
+- **Classification** : SCAFFOLD abandonné. La formalisation réelle de Gittins vit dans
+  `decision_theory_lean/Gittins/` (voir ci-dessus). `gittins_lean` est un reliquat à nettoyer
+  ou à supprimer (issue #4039).
+- **Suivi** : #4039 (G.1 : le corps de l'issue mentionnait « 1 lake gittins » — vérification
+  firsthand révèle qu'il s'agit de ce stub non-buildable ; le vrai lake est
+  `decision_theory_lean`).
+
+---
+
+## Classes (taxonomie Epic #4038)
+
+| Classe | Définition | Lakes |
+|--------|-----------|-------|
+| **PEDA/REF** | Pédagogique / formalisation de référence | decision_theory_lean |
+| **SCAFFOLD** | Échafaudage partiel / non-buildable | Infer/gittins_lean (broken) |
+
+## Notes transverses
+
+- **Honnêteté des jalons ouverts (G.3/G.9)** : `decision_theory_lean` documente ses jalons
+  non atteints (existence Herstein–Milnor, réciproque `coherent_iff_probability`, théorème
+  de Gittins) **explicitement comme OPEN / INTRINSIC** — jamais masqués en résultats prouvés,
+  jamais sorry-stubbés pour faire passer une métrique. La direction *sound* de chaque
+  résultat est livrée 0 sorry.
+- **WDAC workaround** : `decision_theory_lean` (cohorte v4.30.0-rc2) se construit en
+  réutilisant le `.lake` d'un lake frère binairement compatible (wholesale
+  `cp -r sibling/.lake` + `lake-manifest.json`, révision Mathlib identique). Cf.
+  [`lean-wdac-olean-wholesale-copy`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+- **Coordination finitude-derivatives (#2978)** : `decision_theory_lean` Gittins est
+  coordonné avec `finiteness_lean` (#3111) — pas de chevauchement (Gittins = décision
+  séquentielle, finiteness = résultat de finitude standalone).

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/LEAN_INVENTORY.md
@@ -1,0 +1,145 @@
+# Inventaire des projets Lean 4 — `SymbolicAI/Lean`
+
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `SymbolicAI/Lean/`,
+sur le modèle de [`GameTheory/LEAN_INVENTORY.md`](../../GameTheory/LEAN_INVENTORY.md).
+Source de vérité : corps de l'Epic
+[#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification `firsthand` (issue
+[#4041](https://github.com/jsboige/CoursIA/issues/4041)). Colonne *sorry (production)* =
+métrique CI `standalone-tactic` (les mentions prose « 0 sorry »/« sans sorry » et les
+définitions `:= sorry` non-tactique n'entrent pas dans ce compte ; cf.
+[`lean-ci-sorry-filter`](../../../../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+
+## Résumé
+
+| Lake | Toolchain | sorry (production) | Modules | Notebook câblé | Classe | Suivi |
+|------|-----------|--------------------:|--------:|---------------:|--------|-------|
+| `grothendieck_lean` | v4.30.0-rc2 | 0 | 20 | 4 | REF | #2159, #1646 |
+| `conway_lean` | v4.30.0-rc2 | 6¹ | 12 | 24 | PEDA | #1453, #1651, #2162 |
+| `knot_lean` | v4.31.0-rc1 | 3² | 6 | 2 | PEDA/REF | #2874, #3003 |
+| `finiteness_lean` | v4.30.0-rc2 | 0 | 1 | 2 | REF | #3111 |
+| `sensitivity_lean` | v4.30.0-rc2 | 0 | 4 | 2 | PEDA/REF | famille calibration |
+| `calibration_lean` | v4.30.0-rc2 | 0³ | 3 | 0 | HARNESS | #1764 |
+| `mathlib_examples` | v4.30.0-rc2 | 0 | 1 | 0 | REF | référence |
+| **Total** | — | **9** | **47** | — | — | — |
+
+¹ Les 6 `sorry` de `conway_lean` sont des **cibles de prover intentionnelles** dans
+`Conway/Life/HashlifeCorrectness.lean` (Hashlife) — chaque `sorry` est un sous-but
+auto-contenu destiné au harnais de preuve (`agent_tests/prover/`), pas une régression de
+contenu pédagogique. Le reste de la série Conway (Doomsday, FRACTRAN, Look-and-Say, Nim,
+Angel) est prouvé 0 sorry.
+² `knot_lean` = **research-HOLD** : théorie des nœuds (#2874). Les `sorry` sont des
+définitions non définies (`AreMutants`, `alexanderPolynomial`, `IsSmoothlySlice`,
+`IsTopologicallySlice := sorry`) et des preuves de transfert classique ouvertes. Le pont
+GF(3) Path B (`triColorFoxCondition_iff_sum_mod_three`) est prouvé (#3003, sorry net-zéro
+vs `main`). Niveau recherche, pas un gap pédagogique.
+³ `calibration_lean` est un **composant de harnais** (prover calibration, déplacé depuis
+GameTheory, #1764). Les `· sorry` inline de `Calibration/Nash.lean` sont un **fixture de
+test intentionnel** (le harnais doit gérer un *sorry-increase* 1→2 sans régression) — pas
+du code de production, donc *sorry (production) = 0*.
+
+---
+
+## Par lake
+
+### 1. grothendieck_lean — REFERENCE (recherche)
+
+**Objectif** : formalisation étendue de résultats à la Grothendieck (topos, sites,
+faisceaux, topologie dense, foncteur constant, lemme d'Yoneda, conservativité).
+
+- **Toolchain** : v4.30.0-rc2 · **Dépendance** : Mathlib4
+- **Modules** : `Grothendieck/` (20 fichiers) + umbrella `Grothendieck.lean`
+- **sorry (production)** : **0** — entièrement prouvé à la création (« All `sorry`s
+  eliminated at creation »). Build SUCCESS.
+- **Notebook câblé** : 4 notebooks (série SymbolicAI/Lean).
+- **Suivi** : Epic #1646, #2159 (Phase 6-8).
+
+### 2. conway_lean — PEDAGOGIQUE (hommage Conway)
+
+**Objectif** : hommage à John H. Conway — Doomsday, FRACTRAN, Look-and-Say, Nim, Angel,
+Game of Life / Hashlife.
+
+- **Toolchain** : v4.30.0-rc2 · **Dépendance** : Mathlib4
+- **Modules** : `Conway/` (12 fichiers) + umbrella + `patterns/` + `scripts/`
+- **sorry (production)** : **6** (cibles de prover Hashlife, voir note ¹). Sujets non-Hashlife
+  prouvés (Doomsday, FRACTRAN, etc. via `native_decide`).
+- **Notebook câblé** : 24 notebooks (série Conway la plus câblée).
+- **Suivi** : Epic #1453, #1651 ; Conway P5 (#2162) = research-HOLD.
+
+### 3. knot_lean — PEDAGOGIQUE / REFERENCE (research-HOLD)
+
+**Objectif** : théorie des nœuds — tricolorabilité, polynôme d'Alexander, mutants, slicing,
+théorème de Conway.
+
+- **Toolchain** : v4.31.0-rc1 (diffère de la cohorte SymbolicAI — cohorte knot/kelly/planning)
+  · **Dépendance** : Mathlib4
+- **Modules** : `Knots/` (6 fichiers) + umbrella `Knots.lean`
+- **sorry (production)** : **3** + définitions `:= sorry` (research-HOLD, voir note ²).
+- **Notebook câblé** : 2 notebooks.
+- **Suivi** : #2874 (mandate-C trio MERGED #3997/#3999/#4003), #3003 (Path B GF(3) SHIPPED).
+
+### 4. finiteness_lean — REFERENCE
+
+**Objectif** : formalisation compacte d'un résultat de finitude.
+
+- **Toolchain** : v4.30.0-rc2 · **Dépendance** : Mathlib4
+- **Modules** : `Finiteness/` (1 fichier) + umbrella `Finiteness.lean`
+- **sorry (production)** : **0**. Build SUCCESS.
+- **Notebook câblé** : 2 notebooks.
+- **Suivi** : #3111 (MERGED).
+
+### 5. sensitivity_lean — PEDAGOGIQUE / REFERENCE
+
+**Objectif** : analyse de sensibilité / calibration (proche de la famille calibration).
+
+- **Toolchain** : v4.30.0-rc2 · **Dépendance** : Mathlib4
+- **Modules** : `Sensitivity/` (4 fichiers) + umbrella + `NOTICE.md`
+- **sorry (production)** : **0**. Build SUCCESS.
+- **Notebook câblé** : 2 notebooks.
+- **Suivi** : famille calibration.
+
+### 6. calibration_lean — HARNESS (prover calibration)
+
+**Objectif** : composant du harnais de calibration du prouveur (cibles de test pour le
+prover, déplacé depuis GameTheory).
+
+- **Toolchain** : v4.30.0-rc2 · **Dépendance** : Mathlib4
+- **Modules** : `Calibration/` (3 fichiers) + umbrella `Calibration.lean`
+- **sorry (production)** : **0** (les `· sorry` inline sont un fixture de test intentionnel,
+  voir note ³).
+- **Notebook câblé** : 0 (composant harnais, pas pédagogique).
+- **Suivi** : #1764.
+
+### 7. mathlib_examples — REFERENCE
+
+**Objectif** : exemples de référence illustrant l'usage de Mathlib.
+
+- **Toolchain** : v4.30.0-rc2 · **Dépendance** : Mathlib4
+- **Modules** : `MathLibExamples/` (1 fichier) + umbrella `MathLibExamples.lean`
+- **sorry (production)** : **0**.
+- **Notebook câblé** : 0 (référence).
+- **Suivi** : référence (pas d'issue dédiée).
+
+---
+
+## Classes (taxonomie Epic #4038)
+
+| Classe | Définition | Lakes |
+|--------|-----------|-------|
+| **PEDA** | Pédagogique (enseigne un concept,面向 étudiants, notebooks compagnons) | conway_lean, knot_lean, sensitivity_lean |
+| **REF** | Formalisation de référence / recherche (pas directement pédagogique) | grothendieck_lean, finiteness_lean, mathlib_examples |
+| **HARNESS** | Composant de harnais (prover calibration / test fixture) | calibration_lean |
+| **SCAFFOLD** | Échafaudage partiel / en cours | _(aucun — tous sont buildables)_ |
+
+## Notes transverses
+
+- **WDAC workaround** (Windows Defender Application Control bloque `clang.exe` + `lake exe
+  cache get`) : tous les lakes se construisent en réutilisant le `.lake` d'un lake frère
+  binairement compatible (wholesale `cp -r sibling/.lake` + `lake-manifest.json`), à
+  condition d'une révision Mathlib identique. Cohorte v4.30.0-rc2 (calibration, conway,
+  finiteness, grothendieck, mathlib_examples, sensitivity, decision_theory) ; cohorte
+  v4.31.0-rc1 (knot, kelly, planning, perceptron, astar, erc20, argumentation, minimax,
+  sudoku, cooperative).
+- **`SymbolicAI/Lean/examples/llm_assisted_proof.lean`** (2 `sorry`) est un *exemple
+  pédagogique* (non production) — non compté dans le tableau ci-dessus.
+- **`finiteness_lean`** est également référencé depuis l'Epic finitude-derivatives (#2978,
+  coordination vérifiée avec `decision_theory_lean` Gittins — pas de chevauchement).


### PR DESCRIPTION
## Summary

Transverse Lean 4 lake inventory on the [`GameTheory/LEAN_INVENTORY.md`](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md) model, **firsthand-verified** (issue #4041). Two new standalone docs, no code touched.

Part of roadmap epic #4038 (Lean formalization inventory). See #4041 (not `Closes` — verification issue stays open for the remaining series: GameTheory is already inventoried; QuantConnect/Planners/SmartContract/ML/Search families still pending separate inventories).

## Files

- `MyIA.AI.Notebooks/SymbolicAI/Lean/LEAN_INVENTORY.md` — **7 lakes, 47 modules, 9 production sorry**
- `MyIA.AI.Notebooks/Probas/LEAN_INVENTORY.md` — **decision_theory_lean** (3 libs, 8 modules, 5 INTRINSIC sorry) + broken-stub note

## sorry metric = CI `standalone-tactic`

Per [`lean-ci-sorry-filter`](https://github.com/jsboige/CoursIA/blob/main/.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md): prose mentions ("0 sorry", "All sorry's eliminated") and non-tactic `:= sorry` defs are **excluded**. Counted via `grep -rnE '^\s*sorry\b'` over non-`.lake` sources.

## Honest classification (G.3/G.9 — no sorry-stubbing, milestones documented OPEN)

**SymbolicAI/Lean (9 prod sorry):**
| sorry | type | reason |
|------:|------|--------|
| 6 (conway HashlifeCorrectness) | research-target | intentional prover harness targets (`agent_tests/prover/`), not pedagogy regression |
| 3 (knot) | research-HOLD | #2874 knot theory — undefined defs + open classical transfer; GF(3) Path B #3003 proven net-zero |
| 0 × 5 lakes | — | grothendieck/finiteness/sensitivity/mathlib_examples (REF) + calibration (HARNESS: inline `· sorry` = test fixture → prod=0) |

**Probas (5 INTRINSIC sorry, all in `Gittins/GittinsTheorem.lean`):**
- `Utility` (#4049) = **0 sorry** — vNM sound direction `expected_utility_rep_is_rational` + affine stability. Herstein-Milnor existence **documented OPEN** (not sorry-backed).
- `Coherence` (#4050) = **0 sorry** — de Finetti keystone `ind_inclusion_exclusion` + `non_additive_implies_dutch_book` + `coherent_on_implies_additive`. `coherent_iff_probability` reciproque **documented OPEN**.
- `Gittins` = **5 INTRINSIC** — file header states verbatim "full proof INTRACTABLE in current Mathlib (no MDP/bandit/Bellman)". Basic + Discount are sorry-free. Honest ceiling, not masked as proven.

## G.1 finding: gittins_lean is a broken stub

`Infer/gittins_lean` is **not a buildable lake** — only `lake-manifest.json` + vendored `.lake/`, no `lakefile.lean`/`lean-toolchain`/sources. Classified SCAFFOLD; real Gittins formalization lives in `decision_theory_lean/Gittins/`. This corrects #4039's mention of "1 lake gittins".

## Verification

- [x] Toolchain + module counts: `cat lean-toolchain`, `grep lean_lib lakefile.lean`, `find <dir> -name '*.lean'` per lake
- [x] sorry counts: `grep -rnE '^\s*sorry\b'` (production) vs `grep -rnoE '\bsorry\b'` (incl prose, over-counts)
- [x] G.1 cross-check: gittins_lean broken-stub confirmed via `test -f lakefile.lean` = MISSING
- [x] No catalog churn (new standalone docs, no `CATALOG-STATUS` markers)
- [x] Atomic: 1 subject (#4041), 2 files, 279 insertions, 0 deletions
- Docs-only PR — no `lake build` applicable (no `.lean` touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)