### PR TITLE
docs(search-py): anchor canonical search algorithms in Informed/Metaheuristics (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
@@ -189,7 +189,8 @@
     "| **Evolution-based** | Theorie de l'evolution, genetique | GA, DE, ES | \n",
     "| **Swarm-based** | Comportements collectifs (essaims) | PSO, ABC, ACO, GWO |\n",
     "| **Physics-based** | Loi physique | SA, GRAVITY, ELECTRO | \n",
-    "| **Human-based** | Comportement humain | BRO, TS, CA |"
+    "| **Human-based** | Comportement humain | BRO, TS, CA |\n",
+    "\n\n> *Ancres savantes -- Kennedy, J. & Eberhart, R. (1995), Particle Swarm Optimization, Proc. IEEE Int. Conf. on Neural Networks IV:1942-1948 (PSO, essaim de particules ajustant leurs vitesses vers le meilleur personnel et global) ; Karaboga, D. (2005), An Idea Based on Honey Bee Swarm for Numerical Optimization, Technical Report-TR06, Erciyes University (Artificial Bee Colony, ABC, rôles employée/observatrice/éclaireuse) ; Kirkpatrick, S., Gelatt, C.D. & Vecchi, M.P. (1983), Optimization by Simulated Annealing, Science 220(4598):671-680 (recuit simulé, accepte des dégradations selon une température décroissante pour échapper aux optima locaux) ; Yang, X.-S. (2010), Nature-Inspired Metaheuristic Algorithms (2nd ed.), Luniver Press (taxonomie evolution/swarm/physics/human-based et cadre des métaheuristiques sans dérivée).*"
    ]
   },
   {
@@ -33763,7 +33764,8 @@
     "\n",
     "MEALPy offre une interface uniforme pour 100+ metaheuristiques, facilite les comparaisons systematiques, et permet l'analyse de sensibilite aux parametres.\n",
     "\n",
-    "**Suite** : [App-13 - TSP Metaheuristiques](../Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb) | [Retour au sommaire](../README.md)"
+    "**Suite** : [App-13 - TSP Metaheuristiques](../Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb) | [Retour au sommaire](../README.md)\n",
+    "\n\n### References academiques\n\n- Kennedy, J. & Eberhart, R. (1995). Particle Swarm Optimization. Proc. IEEE International Conference on Neural Networks IV:1942-1948.\n- Karaboga, D. (2005). An Idea Based on Honey Bee Swarm for Numerical Optimization. Technical Report-TR06, Erciyes University, Turkey.\n- Kirkpatrick, S., Gelatt, C.D. & Vecchi, M.P. (1983). Optimization by Simulated Annealing. Science 220(4598):671-680.\n- Yang, X.-S. (2010). Nature-Inspired Metaheuristic Algorithms (2nd ed.). Luniver Press.\n\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -157,7 +157,8 @@
     "| Itinéraire | Ville actuelle | Ville destination | Distance à vol d'oiseau |\n",
     "| Jeu de taquin | État du plateau | État résolu | Nombre de pièces hors place |\n",
     "\n",
-    "Ce notebook détaille ces exemples et implémente les algorithmes qui exploitent ces heuristiques.\n"
+    "Ce notebook détaille ces exemples et implémente les algorithmes qui exploitent ces heuristiques.\n",
+    "\n\n> *Ancres savantes -- Hart, P.E., Nilsson, N.J. & Raphael, B. (1968), A Formal Basis for the Heuristic Determination of Minimum Cost Paths, IEEE Transactions on Systems Science and Cybernetics 4(2):100-107 (A*, combine le coût accumulé g(n) et l'heuristique h(n) admissible pour un plus court chemin optimal) ; Pohl, I. (1970), Heuristic Search Viewed as Path Finding in a Graph, Artificial Intelligence 1(3-4):193-204 (Greedy Best-First, exploite h(n) seul, rapide mais non optimal) ; Korf, R.E. (1985), Depth-first Iterative-Deepening: An Optimal Admissible Tree Search, Artificial Intelligence 27(1):97-109 (IDA*, A* itératif borné mémoire) ; Nilsson, N.J. (1980), Principles of Artificial Intelligence, Tioga (admissibilité et consistance des heuristiques) ; Russell, S. & Norvig, P. (2020), Artificial Intelligence: A Modern Approach (4th ed.), Pearson (cadre de la recherche informée et des heuristiques admissibles/consistantes).*"
    ]
   },
   {
@@ -3404,7 +3405,8 @@
     "\n",
     "Ce notebook a présenté les algorithmes de recherche informée, qui utilisent des connaissances spécifiques du problème (heuristiques) pour guider l'exploration. L'efficacité de ces algorithmes dépend crucialement de la qualité de l'heuristique.\n",
     "\n",
-    "**Prochain notebook** : [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) — Découvrez les algorithmes de recherche locale (Hill Climbing, Simulated Annealing, Tabu Search) qui explorent l'espace de recherche de manière différente, sans maintenir de frontière explicite.\n"
+    "**Prochain notebook** : [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) — Découvrez les algorithmes de recherche locale (Hill Climbing, Simulated Annealing, Tabu Search) qui explorent l'espace de recherche de manière différente, sans maintenir de frontière explicite.\n",
+    "\n\n### References academiques\n\n- Hart, P.E., Nilsson, N.J. & Raphael, B. (1968). A Formal Basis for the Heuristic Determination of Minimum Cost Paths. IEEE Transactions on Systems Science and Cybernetics 4(2):100-107.\n- Pohl, I. (1970). Heuristic Search Viewed as Path Finding in a Graph. Artificial Intelligence 1(3-4):193-204.\n- Korf, R.E. (1985). Depth-first Iterative-Deepening: An Optimal Admissible Tree Search. Artificial Intelligence 27(1):97-109.\n- Nilsson, N.J. (1980). Principles of Artificial Intelligence. Tioga Publishing.\n- Russell, S. & Norvig, P. (2020). Artificial Intelligence: A Modern Approach (4th ed.). Pearson.\n\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Citation audit **#3164** Search-Python batch 2 (follows #4169 Uninformed/LocalSearch). 2 more Search-Python foundational course notebooks taught canonical algorithms NAMED-but-not-anchored (genuine OMISSION). Each notebook is a foundational COURSE whose subject IS the anchored algorithm(s).

Recipe identical to #4169/#4147/#4166: an inline scholarly-anchor blockquote appended where the concept is introduced + a References academiques block appended to the Conclusion cell. Both markdown-additive.

## Targets (all firsthand G.1 verified OMISSION)

| Notebook | Subject (taught as course) | Anchored papers |
|----------|----------------------------|-----------------|
| Search-3-Informed | Greedy Best-First / A* / IDA* / heuristics (sections 3-6) | Hart, Nilsson & Raphael 1968 (A*) + Pohl 1970 (Greedy Best-First) + Korf 1985 (IDA*) + Nilsson 1980 (admissibility/consistency) + Russell & Norvig 2020 |
| Search-11-Metaheuristics | PSO / ABC / SA / BRO (sections 4-7, via MEALPy) | Kennedy & Eberhart 1995 (PSO) + Karaboga 2005 (Artificial Bee Colony) + Kirkpatrick, Gelatt & Vecchi 1983 (Simulated Annealing) + Yang 2010 (metaheuristics taxonomy) |

## Firsthand G.1 (scanner-FP correction)

The OMISSION scanner flagged GA/ACO on Search-11-Metaheuristics. Firsthand read of the source disproved this: GA/ACO appear only as passing MEALPy library/benchmark mentions, NOT taught sections. The notebook TEACHES PSO (section 4), ABC (section 5), SA (section 6), BRO (section 7). I anchored what is taught, not what the keyword-scanner matched.

## Validation

- Code byte-identical: 0 code cells changed across both (source + outputs + execution_count identical to origin/main). Markdown-only -> C.2 exception (no re-execution).
- Validate: notebook_tools validate = 0 errors each (2 pre-existing warnings confirmed identical on origin/main for each notebook -- not a regression).
- nbformat robustness: handled source-as-list for both notebooks (verified).

## Scope

Same family (Search-Python foundational), single #3164 audit pass. With #4169, this anchors 4 of the foundational Search course notebooks (Uninformed/LocalSearch/Informed/Metaheuristics). Remaining candidates (Search-1-StateSpace, Search-6-AdversarialSearch, Search-7-MCTS, App-11-Picross, App-13-TSP, App-18-HyperparameterTuning) = follow-up grains if endorsed.

See #3164

Generated with Claude Code