### PR TITLE
lean(cooperative): prove veto_critical_of_winning (veto player critical in every winning coalition)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1176,6 +1176,25 @@ theorem veto_critical_in_grand {G : TUGame N} (hG : SimpleGame G) {i : N}
     have hni : i ∉ Finset.univ.erase i := by simp [Finset.mem_erase]
     exact hni (hv (Finset.univ.erase i) heq)
 
+/-- A veto player is critical in *every* winning coalition.
+
+    The general form of which `veto_critical_in_grand` is the grand-coalition instance:
+    specializing `S` to `Finset.univ` recovers it. `VetoPlayer G i` forces `i ∈ S` for every
+    winning `S`. To show `i` is critical in a winning `S` we need `v (S.erase i) = 0`: if
+    `v (S.erase i) = 1` then the veto property would force `i ∈ S.erase i`, contradicting
+    `i ∉ S.erase i`; hence `v (S.erase i) ≠ 1`, and `SimpleGame` forces `v (S.erase i) = 0`.
+    Together with `v S = 1` (`hwin`) and `i ∈ S`, this makes `S` a critical coalition for `i`. -/
+theorem veto_critical_of_winning {G : TUGame N} (hG : SimpleGame G) {i : N}
+    (hv : VetoPlayer G i) {S : Finset N} (hwin : G.v S = 1) :
+    Critical G i S := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact hv S hwin
+  · exact hwin
+  · apply SimpleGame.eq_zero_of_ne_one hG (S.erase i)
+    intro heq
+    have hni : i ∉ S.erase i := by simp [Finset.mem_erase]
+    exact hni (hv (S.erase i) heq)
+
 /-- A veto player has a strictly positive raw Banzhaf index when the grand coalition wins.
 
     The veto pendant of `dummy_banzhaf_raw_zero` (a dummy has `BanzhafRaw = 0`): a veto player


### PR DESCRIPTION
## `veto_critical_of_winning` — a veto player is critical in *every* winning coalition

The **general form** of which `veto_critical_in_grand` (merged, #4153) is the grand-coalition
instance: specializing `S` to `Finset.univ` recovers it. Where the existing theorem shows a
veto player is critical in the *grand* coalition (when it wins), this PR shows it is critical
in **every** winning coalition.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `veto_critical_of_winning` | `[SimpleGame G] → VetoPlayer G i → v S = 1 → Critical G i S` | veto player is critical in every winning coalition |

### Proof

`VetoPlayer G i` forces `i ∈ S` for every winning `S`. To show `i` is critical in a winning `S`
we need `v (S.erase i) = 0`:

- Suppose `v (S.erase i) = 1`. The veto property applied to the winning `S.erase i` forces
  `i ∈ S.erase i`, contradicting `i ∉ S.erase i`.
- Hence `v (S.erase i) ≠ 1`, and `SimpleGame` forces `v (S.erase i) = 0`.

Together with `v S = 1` (`hwin`) and `i ∈ S` (`hv S hwin`), this makes `S` a critical coalition
for `i`. The proof mirrors `veto_critical_in_grand` exactly, generalizing `Finset.univ` → `S`
and `Finset.mem_univ i` → `hv S hwin`.

### Independent of pending PRs (no stacking, no conflict)

Prouvable from `main` alone (needs only `SimpleGame` + `VetoPlayer` + `Critical` + Mathlib
`Finset.mem_erase`). **Disjoint region** from the two pending cooperative-games PRs:

| PR | Region (Shapley.lean) | Size |
|----|----------------------|------|
| #4163 winning_upward_closed | inside `namespace MonotoneGame` (~L1060) | +16 |
| #4172 losing_downward_closed | top-level after `end MonotoneGame` (~L1075) | +12 |
| **this PR** | **after `veto_critical_in_grand` (~L1162)** | **+19** |

Three distinct insertion anchors → merge in any order with no text conflict.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (14s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +19/0), pure insertion after `veto_critical_in_grand`.
  **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)