### PR TITLE
docs(lean-knot): refresh series README Knot table post-#4035 (Path B) (See #2874 See #3003)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -410,7 +410,7 @@ Le notebook Lean-17b (Invariants de Nœuds) est le pendant pedagogique du projet
 | résultat | Fichier Lean | Notebook | Statut |
 |----------|-------------|----------|--------|
 | Transfert forward (R1 connecte préserve la tricolorabilité) | `knot_lean/Knots/Invariant.lean` | 17b | 0 sorry (#3000, sorry-free) |
-| Transfert backward (partiel) | `knot_lean/Knots/Invariant.lean` | 17b | 2 sorries résiduels §9.1 (num prouvé #3163 ; fox/col partiellement prouvés #3154/#3168) |
+| Transfert backward (partiel) | `knot_lean/Knots/Invariant.lean` | 17b | Path B shipped (#3003/#4035) : invariant de Fox classique restauré (arc-égalité c₂=c₄) + pont GF(3) `triColorFoxCondition_iff_sum_mod_three` prouvé ; `num` prouvé #3163 ; 2 résiduels §9.1 (fox/col all-distinct) OPEN research-HOLD (BG-prover #2874) |
 | Tricolorabilité du noeud de Conway (11n34) | `knot_lean/Knots/Conway.lean` | 17a | scaffolding |
 | Théorème d'invariance par Reidemeister (PL topology) | `knot_lean/Knots/Reidemeister.lean` | 17b | 2 sorry (out-of-scope PL) |
 


### PR DESCRIPTION
## Summary

One-row refresh of the series-level `SymbolicAI/Lean/README.md` Knot table. PR #4035 (Path B, MERGED) updated `knot_lean/README.md` + `Knots/Invariant.lean` + CI but **not** the series README — so its Knot table stayed PRE-Path-B. This is the flagged "Next" follow-up under Knot #3003.

## What changed (1 file, 1 line)

The "Transfert backward (partiel)" row (L413) status cell:
- **Before**: `2 sorries résiduels §9.1 (num prouvé #3163 ; fox/col partiellement prouvés #3154/#3168)` — stale issue refs, omits Path B.
- **After**: `Path B shipped (#3003/#4035) : invariant de Fox classique restauré (arc-égalité c₂=c₄) + pont GF(3) \`triColorFoxCondition_iff_sum_mod_three\` prouvé ; \`num\` prouvé #3163 ; 2 résiduels §9.1 (fox/col all-distinct) OPEN research-HOLD (BG-prover #2874)`

## Verification (G.1 firsthand against code)

- `triColorFoxCondition_iff_sum_mod_three` EXISTS at `Knots/Invariant.lean:207` (proven, GF(3) per-crossing bridge)
- `Reidemeister1Connected.tricolorable_forward` at L715 (#3000, 0-sorry)
- `Reidemeister1Connected.tricolorable_backward` at L1373 (partial, §9.1 residuals)
- `Invariant.lean` real sorry count = 5 (matches `knot_lean/README.md` table)
- Mirrored canonical state from `knot_lean/README.md` (updated by #4035): Path B restored classical Fox (arc-equality), GF(3) bridge proven, universal lemma `tricolorability_of_two_crossings` DROPPED (FALSE under Path B), §9.1 fox/col all-distinct OPEN

## Honesty (G.3/G.9)

- §9.1 residuals documented **OPEN research-HOLD** (BG-prover #2874, verdict *NE PAS LANCER* in force) — not over-stated as progress.
- Other rows **unchanged** — still accurate: forward (#3000 0-sorry), Conway 11n34 (scaffolding), Reidemeister (2 sorry, out-of-scope PL).

## Discipline

- Doc-only (C.2 markdown exception — no re-exec needed)
- Atomic: 1 subject (Knot table post-#4035), 1 file, 1 line (`+1/−1`)
- No catalog churn (no `CATALOG-STATUS` markers touched)
- `See #2874 See #3003` (epic/research — no auto-close)
- Fresh branch from `origin/main`, no `--force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)