### PR TITLE
docs(qcpy-17): add scholarly anchors De Bondt&Thaler 1985 + Baker&Wurgler 2006 (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
@@ -300,7 +300,9 @@
     "|Benzinga  |         | Seeking   |        | Press      |\n",
     "+----------+         | Alpha     |        | Releases   |\n",
     "                     +-----------+        +------------+\n",
-    "```"
+    "```\n",
+    "\n",
+    "> *Ancre savante -- Baker, M. & Wurgler, J. (2006), « Investor Sentiment and the Cross-Section of Stock Returns », The Journal of Finance 61(4):1645-1680 (DOI 10.1111/j.1540-6261.2006.00885.x). Formalise le sentiment des investisseurs comme une force systematique affectant la section transversale des rendements : les actions speculatives (petites capitalisations, jeunes, volatiles, en perte) sont les plus sensibles au sentiment, et l'effet est le plus fort quand le sentiment est a un extreme. Cette ancre fonde la notion de « sentiment de marche » definie ci-dessus comme une attitude collective mesurable et predictive -- la base conceptuelle de toute la Partie 1 et des strategies sentiment qui suivent.*\n"
    ]
   },
   {
@@ -2180,7 +2182,9 @@
     "\n",
     "- **VIX eleve** : Peur extreme -> opportunite d'achat\n",
     "- **Put/Call ratio eleve** : Pessimisme extreme -> acheter\n",
-    "- **Magazine covers** : Quand les medias mainstream sont unanimement bullish -> vendre"
+    "- **Magazine covers** : Quand les medias mainstream sont unanimement bullish -> vendre\n",
+    "\n",
+    "> *Ancre savante -- De Bondt, W. F. M. & Thaler, R. (1985), « Does the Stock Market Overreact? », The Journal of Finance 40(3):793-805 (DOI 10.1111/j.1540-6261.1985.tb05004.x). Etablit empiriquement l'hypothese de surreaction : les actions qui ont le plus sous-performe (perdants) sur 3-5 ans surperforment ensuite les gagnants passes, signe que le marche exagere les mouvements aux extremes puis mean-revert. C'est le fondement theorique du trading contrarien enseigne dans cette Partie 4 -- l'idee que les extremes de sentiment (euphorie > 0.7 -> VENDRE, panique < -0.7 -> ACHETER) sont des signaux de retournement, parce que le marche surreact a ces extremes avant de corriger.*\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

#3164 citation audit, 1st pass on **QC-Py-17-Sentiment-Analysis**.

**Verdict: OMISSION mineure.** The notebook already carries 6 scholarly anchors in its References cell (`Loughran & McDonald 2011`, `Tetlock 2007`, `Garcia 2013`, `Hutto & Gilbert 2014` VADER, `Devlin 2019` BERT, `Araci 2019` FinBERT). Two teaching points, however, cited no originator at the concept-definition cell:

| Cell | Teaching point | Anchor added |
|------|----------------|--------------|
| `cell[7]` — Partie 1 *"Qu'est-ce que le Sentiment de Marche?"* | Defines market sentiment as a collective-investor behavioral construct | **Baker & Wurgler (2006)**, *Investor Sentiment and the Cross-Section of Stock Returns*, J. Finance 61(4):1645-1680, DOI `10.1111/j.1540-6261.2006.00885.x` |
| `cell[33]` — Partie 4 *"Théorie du Sentiment Contrarien"* | Extreme-sentiment reversal (euphorie→VENDRE, panique→ACHETER) | **De Bondt & Thaler (1985)**, *Does the Stock Market Overreact?*, J. Finance 40(3):793-805, DOI `10.1111/j.1540-6261.1985.tb05004.x` |

Both anchors **web-verified** against primary sources (Wiley / *Journal of Finance*).

## Edition — markdown-additive

- **0 code cell changed.** Footnote anchors appended to 2 markdown cells only.
- **List-direct edit** (mutate `cell['source']` list per-line, never join+resplit) — per the QC-Py-25 cell-7 mash lesson.
- **Catalogue byte-identical** (`COURSE_CATALOG.generated.{json,md}` untouched on branch).

## Validation

```
validate-notebooks QC-Py-17-Sentiment-Analysis.ipynb
  OK: 1  Warnings: 0  Errors: 0
code cells byte-identical (sha1 pre == post): 22/22 unchanged
```

Part of the #3164 QC-Py citation-audit deep-queue. See #3164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)