### PR TITLE
docs(qcpy-16): add scholarly anchors Graham 1949 + Loughran&McDonald 2011 (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -406,7 +406,9 @@
     "- Low P/B               - Moat (competitive)      - Compound growth\n",
     "- Below intrinsic       - Consistent earnings\n",
     "  value\n",
-    "```"
+    "```\n",
+    "\n",
+    "> *Ancre savante -- Graham, B. (1949), « The Intelligent Investor: A Book of Practical Counsel », Harper & Brothers, New York (1re edition 1949 ; editions revises 1954, 1959, 1965, 1973). Origine canonique de l'investissement value : le chapitre 20 formalise la **marge de securite** (margin of safety) comme concept central -- acheter un actif sensiblement en dessous de sa valeur intrinseque pour que la marge absorbe l'erreur d'estimation et les aleas defavorables. Graham y distingue aussi l'investisseur defensif de l'investisseur entreprenant et introduit l'allegorie de Mr. Market. Warren Buffett, eleve de Graham a Columbia, en a fait l'application moderne illustree par le schema ci-dessus (marge de securite + qualite de l'entreprise + detention long terme) -- les criteres P/E bas, ROE eleve et market cap liquide de la strategie Value Complete materialisent ce principe.*\n"
    ]
   },
   {
@@ -970,7 +972,9 @@
     "Les traders quantitatifs utilisent souvent le NLP pour analyser le texte des filings :\n",
     "- **Sentiment Analysis** : Positif/negatif\n",
     "- **Keyword Detection** : \"acquisition\", \"termination\", \"investigation\"\n",
-    "- **Complexity Analysis** : Readability scores"
+    "- **Complexity Analysis** : Readability scores\n",
+    "\n",
+    "> *Ancre savante -- Loughran, T. & McDonald, B. (2011), « When Is a Liability Not a Liability? Textual Analysis, Dictionaries, and 10-Ks », The Journal of Finance 66(1):35-65 (DOI 10.1111/j.1540-6261.2010.01625.x). Montre que les dictionnaires de sentiment generiques (notamment le Harvard IV-4) classent a tort comme negatifs pres de trois quarts des mots frequents en contexte financier (ex. « liability », « tax », « cost » n'y sont pas pejoratifs) ; les auteurs construisent donc un lexique finance-specifique (Loughran-McDonald Master Dictionary, six listes : negative, positive, uncertainty, litigious, constraining, superfluous) calibre sur un large corpus de 10-Ks 1994-2008, qu'ils relient au rendement, au volume, a la volatilite et aux fraudes. C'est la reference methodologique du NLP sur filings enseigne dans cette section 3.2 (sentiment, keyword detection, readability) -- la raison pour laquelle un lexique finance-dedie est preferable a un dictionnaire generaliste pour analyser le texte des SEC filings.*\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

#3164 citation audit, 1st pass on **QC-Py-16-Alternative-Data**.

**Verdict: OMISSION mineure.** The notebook already carries 5 scholarly anchors in its References cell (`Ball & Brown 1968` PEAD, `Bernard & Thomas 1989` drift, `Fama & French 1992` value, `Chan 2003` news momentum, `Tetlock 2007` media sentiment). Two teaching points, however, cited no originator at the concept-definition cell:

| Cell | Teaching point | Anchor added |
|------|----------------|--------------|
| `cell[9]` — *Théorie Value Investing* | Margin of Safety + Warren Buffett approach + intrinsic value (P/E bas, ROE élevé, marge vs valeur intrinsèque) | **Graham, B. (1949)**, *The Intelligent Investor*, Harper & Brothers, New York (1st ed. 1949; rev. 1954/1959/1965/1973). Margin of safety = Ch. 20 (pre-ISBN era, cite by title/author/year/publisher). |
| `cell[22]` — *3.2 Structure d'Intégration SEC / Analyse NLP des Filings* | NLP textual analysis of SEC filings (sentiment, keyword detection, readability) | **Loughran & McDonald (2011)**, *When Is a Liability Not a Liability? Textual Analysis, Dictionaries, and 10-Ks*, J. Finance 66(1):35-65, DOI `10.1111/j.1540-6261.2010.01625.x` |

Both anchors **web-verified** against primary sources (Wiley/J.Finance + Notre Dame SRAF for L&M; Harper & Brothers 1949 first edition record for Graham).

## Edition — markdown-additive

- **0 code cell changed.** Footnote anchors appended to 2 markdown cells only.
- **List-direct edit** (mutate `cell['source']` list per-line, never join+resplit) — per the QC-Py-25 cell-7 mash lesson.
- **Catalogue byte-identical** (`COURSE_CATALOG.generated.{json,md}` untouched on branch).

## Validation

```
validate-notebooks QC-Py-16-Alternative-Data.ipynb
  OK: 1  Warnings: 0  Errors: 0
code cells byte-identical (sha1 pre == post): 18/18 unchanged
```

Part of the #3164 QC-Py citation-audit deep-queue. See #3164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)