### PR TITLE
docs(search-py): anchor canonical citations Search-1 (state-space) + Search-7 (MCTS/AlphaGo)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
@@ -68,7 +68,8 @@
     "- **Rigueur** : la solution est un chemin verifiable dans un graphe bien defini\n",
     "- **Analyse** : on peut raisonner sur la completude, l'optimalite et la complexite\n",
     "\n",
-    "> **Reference** : Ce notebook suit le chapitre 3 de *Artificial Intelligence: A Modern Approach* (Russell & Norvig)."
+    "> **Reference** : Ce notebook suit le chapitre 3 de *Artificial Intelligence: A Modern Approach* (Russell & Norvig).\n",
+    "\n\n> *Ancres savantes -- Newell, A. & Simon, H.A. (1961), GPS, A Program That Simulates Human Thought, in R. Gunbaum & E. Paul (eds.), Thinking Machines, Basic Books (formalisation pionnière du state-space search : état initial, opérateurs, état-but) ; Amarel, S. (1968), On Representations of Problems of Reasoning About Actions, Machine Intelligence 3:131-171 (représentation d'état et importance de la formulation pour la complexité de recherche) ; Russell, S. & Norvig, P. (2020), Artificial Intelligence: A Modern Approach (4th ed.), Pearson (cadre formel du problème de recherche : états, actions, coût, heuristique, chapitre 3).*"
    ]
   },
   {
@@ -2387,7 +2388,7 @@
   {
    "cell_type": "markdown",
    "id": "1fd61d48",
-   "source": "## Resume et perspectives\n\nCe notebook a pose les fondements de la recherche dans les espaces d'etats : la formalisation en 5-tuple $(S, s_0, A, T, G)$, la modelisation de problemes concrets (aspirateur, taquin, itineraire), et l'analyse des proprietes qui influencent le choix algorithmique. La distinction entre cout uniforme et cout variable, illustree par l'exemple de l'itineraire, sera determinante dans les prochains notebooks.\n\n**Le passage au [notebook Search-2-Uninformed](Search-2-Uninformed.ipynb)** aborde les algorithmes systematiques -- BFS, DFS, UCS -- qui exploitent uniquement la structure du graphe d'etats, sans connaissance specifique du probleme, pour garantir completude et optimalite selon les conditions.",
+   "source": "## Resume et perspectives\n\nCe notebook a pose les fondements de la recherche dans les espaces d'etats : la formalisation en 5-tuple $(S, s_0, A, T, G)$, la modelisation de problemes concrets (aspirateur, taquin, itineraire), et l'analyse des proprietes qui influencent le choix algorithmique. La distinction entre cout uniforme et cout variable, illustree par l'exemple de l'itineraire, sera determinante dans les prochains notebooks.\n\n**Le passage au [notebook Search-2-Uninformed](Search-2-Uninformed.ipynb)** aborde les algorithmes systematiques -- BFS, DFS, UCS -- qui exploitent uniquement la structure du graphe d'etats, sans connaissance specifique du probleme, pour garantir completude et optimalite selon les conditions.\n\n\n\n### References academiques\n\n- Newell, A. & Simon, H.A. (1961). GPS, A Program That Simulates Human Thought. In R. Gunbaum & E. Paul (eds.), Thinking Machines. Basic Books.\n- Amarel, S. (1968). On Representations of Problems of Reasoning About Actions. Machine Intelligence 3:131-171.\n- Russell, S. & Norvig, P. (2020). Artificial Intelligence: A Modern Approach (4th ed.). Pearson.\n\n",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -112,7 +112,8 @@
     "- **MCTS** pour la recherche\n",
     "- **Reseaux de neurones** pour l'evaluation (policy + value networks)\n",
     "\n",
-    "MCTS permet d'explorer intelligemment sans fonction d'evaluation experte !"
+    "MCTS permet d'explorer intelligemment sans fonction d'evaluation experte !\n",
+    "\n\n> *Ancres savantes -- von Neumann, J. (1928), Zur Theorie der Gesellschaftsspiele, Mathematische Annalen 100:295-320 (théorème minimax, fondement des jeux à somme nulle, dont découle Minimax avec Alpha-Beta) ; Kocsis, L. & Szepesvári, C. (2006), Bandit Based Monte-Carlo Planning, ECML 2006, LNCS 4212:282-293 (MCTS + Upper Confidence Bound for Trees = UCT, équilibre exploration/exploitation dans l'arbre de jeu) ; Silver, D., Huang, A., Maddison, C.J. et al. (2016), Mastering the game of Go with deep neural networks and tree search, Nature 529:484-489 (AlphaGo, combine MCTS avec réseaux de valeur et de politique appris par renforcement) ; Silver, D., Schrittwieser, J., Simonyan, K. et al. (2017), Mastering the game of Go without human knowledge, Nature 550:354-359 (AlphaGo Zero, apprentissage auto-supervisé sans données humaines) ; Browne, C.B., Powley, E., Whitehouse, D. et al. (2012), A Survey of Monte Carlo Tree Search Methods, IEEE Trans. Comput. Intell. AI Games 4(1):1-43 (survey de référence sur MCTS).*"
    ]
   },
   {
@@ -2292,7 +2293,8 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Recherche adversariale](Search-6-AdversarialSearch.ipynb) | [Index](../README.md) | [Dancing Links >>](Search-8-DancingLinks.ipynb)"
+    "**Navigation** : [<< Recherche adversariale](Search-6-AdversarialSearch.ipynb) | [Index](../README.md) | [Dancing Links >>](Search-8-DancingLinks.ipynb)\n",
+    "\n\n### References academiques\n\n- von Neumann, J. (1928). Zur Theorie der Gesellschaftsspiele. Mathematische Annalen 100:295-320.\n- Kocsis, L. & Szepesvari, C. (2006). Bandit Based Monte-Carlo Planning. ECML 2006, LNCS 4212:282-293.\n- Silver, D., Huang, A., Maddison, C.J. et al. (2016). Mastering the game of Go with deep neural networks and tree search. Nature 529:484-489.\n- Silver, D., Schrittwieser, J., Simonyan, K. et al. (2017). Mastering the game of Go without human knowledge. Nature 550:354-359.\n- Browne, C.B., Powley, E., Whitehouse, D. et al. (2012). A Survey of Monte Carlo Tree Search Methods. IEEE Transactions on Computational Intelligence and AI in Games 4(1):1-43.\n\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Continuation of the **#3164 citation audit** — Search-Python foundational course notebooks (batch 3 of the Search-Py track). Markdown-additive: a scholarly inline blockquote at the notebook's introduction + a `### References academiques` cell at the conclusion. **0 code cells changed** — pure pedagogical prose, so the C.2 markdown-only exception applies and no re-execution is needed.

## Notebooks anchored

**Search-1-StateSpace.ipynb** — state-space search *formulation* (the notebook is the formal framework chapter, not a single algorithm):
- Newell & Simon (1961, GPS) — pioneering state-space formalization (initial state, operators, goal state).
- Amarel (1968) — problem representation and the impact of formulation on search complexity.
- Russell & Norvig (2020, AIMA ch.3) — formal search-problem framework (states, actions, cost, heuristic).
- Strengthens the notebook's existing *weak* inline "ch.3 Russell & Norvig" reference into a proper multi-anchor scholarly block.

**Search-7-MCTS-And-Beyond.ipynb** — MCTS / AlphaGo / AlphaZero (the notebook's central subject):
- von Neumann (1928) — minimax theorem, foundation of zero-sum games.
- Kocsis & Szepesvári (2006) — UCT, MCTS exploration/exploitation balance.
- Silver et al. (2016, *Nature*) — AlphaGo (MCTS + value/policy networks via RL).
- Silver et al. (2017, *Nature*) — AlphaGo Zero (self-supervised, no human data).
- Browne et al. (2012) — reference MCTS survey.

## G.1 firsthand verification

Each notebook was **read firsthand** to confirm it *teaches* the algorithm as the central subject (scanner flags concept presence but cannot distinguish "taught" from "passing mention"):
- Search-1 = the state-space formalization chapter (states/operators/goal/cost are the actual lecture content).
- Search-7 = MCTS / AlphaGo / AlphaZero are the *entire* lecture (Minimax limits → MCTS → AlphaGo → AlphaZero). The scanner's GA/ACO flags were **false positives** (passing mentions in a comparison table), correctly skipped.

## Validation

- `git diff` vs `origin/main`: markdown cells only, **0 code cells changed** (verified via JSON cell-type comparison against `origin/main:<nb>`).
- `nbformat` preserved (`json.dump indent=1, ensure_ascii=False`, no-BOM, UTF-8) — matches repo convention, no spurious churn.
- No re-execution required (C.2 markdown-only exception).

See #3164

---
*Part of the standing citation-audit directive. Batch 1: #4169 (Uninformed/LocalSearch). Batch 2: #4175 (Informed/Metaheuristics). RL track already complete: #4147 (merged) + #4166.*
