### PR TITLE
docs(qcpy-19): add scholarly anchors RF + GB/XGB + ROC + Walk-Forward (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
@@ -608,7 +608,9 @@
     "| `n_estimators` | Nombre d'arbres | 100-500 |\n",
     "| `max_depth` | Profondeur max par arbre | 5-15 |\n",
     "| `min_samples_leaf` | Echantillons min par feuille | 5-20 |\n",
-    "| `max_features` | Features par split | 'sqrt' ou 0.3-0.7 |"
+    "| `max_features` | Features par split | 'sqrt' ou 0.3-0.7 |\n",
+    "\n",
+    "> *Ancre savante -- Breiman, L. (2001), « Random Forests », Machine Learning 45(1):5-32 (DOI 10.1023/A:1010933404324). Introduit les Random Forests : un ensemble d'arbres de decision construits chacun sur un bootstrap sample (tirage avec remise) de l'echantillon, avec une selection aleatoire d'un sous-ensemble de variables a chaque split (feature subsampling). Ces deux sources d'alea decorrelent les arbres, et l'agregation par **vote majoritaire** (schema d'architecture ci-dessus) reduit la variance sans augmenter le biais -- le remede au sur-apprentissage dont souffrent les arbres individuels.*\n"
    ]
   },
   {
@@ -1067,7 +1069,9 @@
     "| `subsample` | Ratio d'echantillons par arbre | 0.7-0.9 |\n",
     "| `colsample_bytree` | Ratio de features par arbre | 0.7-0.9 |\n",
     "| `reg_alpha` | Regularisation L1 | 0-1 |\n",
-    "| `reg_lambda` | Regularisation L2 | 1-10 |"
+    "| `reg_lambda` | Regularisation L2 | 1-10 |\n",
+    "\n",
+    "> *Ancres savantes -- Friedman, J. H. (2001), « Greedy Function Approximation: A Gradient Boosting Machine », The Annals of Statistics 29(5):1189-1232 (1999 Reitz Lecture, DOI 10.1214/aos/1013203451) -- Gradient Boosting (MART) : au lieu d'agreger des arbres independants (bagging, Random Forest), on les construit **sequentiellement** en ajustant chaque nouvel arbre au gradient des residus du precedent -- le schema « corrige les erreurs du precedent » ci-dessus. La regularisation L1/L2 et le learning_rate en font le principe de base enseigne dans cette Partie 3. Chen, T. & Guestrin, C. (2016), « XGBoost: A Scalable Tree Boosting System », Proceedings of the 22nd ACM SIGKDD (KDD '16):785-794 (arXiv:1603.02754, DOI 10.1145/2939672.2939785) -- XGBoost : implementation optimisee du gradient boosting (objectif regularise, split finding sparsity-aware, cache-aware et out-of-core) qui en a fait le standard de fait du ML tabulaire, demontre dans cette Partie 3 (early stopping, gestion native des NaN, comparaison vs RF).*\n"
    ]
   },
   {
@@ -1925,7 +1929,9 @@
     "- Le seuil de probabilité optimal peut être choisi sur la courbe ROC\n",
     "- Balance entre FP (faux signaux d'achat) et FN (opportunités manquées)\n",
     "\n",
-    "---"
+    "---\n",
+    "\n",
+    "> *Ancre savante -- Fawcett, T. (2006), « An introduction to ROC analysis », Pattern Recognition Letters 27(8):861-874 (DOI 10.1016/j.patrec.2005.10.010). Reference pedagogique standard pour les courbes ROC en machine learning : formalise le **False Positive Rate** (axe X = 1 - specificite) et le **True Positive Rate** (axe Y = sensibilite/recall), l'aire sous la courbe (AUC) comme mesure d'independance du seuil, et la lecture de la courbe (coin superieur gauche = classifieur ideal AUC = 1.0, diagonale = classifieur aleatoire AUC = 0.5). Les courbes ROC ont pour origine la theorie de la detection du signal (Egan 1975, Swets 1973) ; Fawcett 2006 en est l'introduction canonique adoptee par la communaute ML/data mining, illustree par les courbes RF vs XGBoost ci-dessus.*\n"
    ]
   },
   {
@@ -1945,7 +1951,9 @@
     "\n",
     "-> Train grandit                     -> Train a taille fixe\n",
     "-> Plus de donnees                   -> Plus recent = plus pertinent\n",
-    "```"
+    "```\n",
+    "\n",
+    "> *Ancre savante -- Pardo, R. (2008), « The Evaluation and Optimization of Trading Strategies », 2e edition, Wiley Trading (ISBN 978-0-470-12801-5). Reference canonique de la **Walk-Forward Analysis** : au lieu d'un simple split train/test statique, on optimise le modele sur une fenetre, le teste sur la periode suivante (out-of-sample), puis on decale la fenetre (expanding ou sliding window, schema ci-dessus) et on reitere. Seule une strategy qui reste profitable sur les fenetres out-of-sample successives est jugee robuste -- le controle contre le sur-ajustement a une periode historique unique, enseigne dans cette section 4.2.*\n"
    ]
   },
   {
@@ -3977,7 +3985,19 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook complete. La classification ML est un outil puissant mais doit etre utilisee avec rigueur: validation robuste, retrain regulier, et gestion du risque appropriee.**"
+    "**Notebook complete. La classification ML est un outil puissant mais doit etre utilisee avec rigueur: validation robuste, retrain regulier, et gestion du risque appropriee.**\n",
+    "\n",
+    "\n### References academiques\n",
+    "\n",
+    "- Breiman, L. (2001). *Random Forests*. Machine Learning, 45(1), 5-32. https://doi.org/10.1023/A:1010933404324\n",
+    "\n",
+    "- Friedman, J. H. (2001). *Greedy Function Approximation: A Gradient Boosting Machine*. The Annals of Statistics, 29(5), 1189-1232. https://doi.org/10.1214/aos/1013203451\n",
+    "\n",
+    "- Chen, T., & Guestrin, C. (2016). *XGBoost: A Scalable Tree Boosting System*. Proceedings of the 22nd ACM SIGKDD (KDD '16), 785-794. arXiv:1603.02754. https://doi.org/10.1145/2939672.2939785\n",
+    "\n",
+    "- Fawcett, T. (2006). *An introduction to ROC analysis*. Pattern Recognition Letters, 27(8), 861-874. https://doi.org/10.1016/j.patrec.2005.10.010\n",
+    "\n",
+    "- Pardo, R. (2008). *The Evaluation and Optimization of Trading Strategies* (2nd ed.). Wiley. ISBN 978-0-470-12801-5\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

#3164 citation audit, 1st pass on **QC-Py-19-ML-Supervised-Classification**.

**Verdict: OMISSION pleine.** The notebook carries **0** scholarly anchors (`Ancre(s) savante(s)` — singular or plural), 0 DOI, 0 arXiv. The recap cell `[59]` *Conclusion / Récapitulatif* names 3 originators inline (Breiman 2001, Chen & Guestrin 2016, Pardo 2008), but those are recap mentions, **not** scholarly anchors at the concept-definition teaching cells. **G.1 firsthand correction:** a prior reclassification "FAITHFUL (7-entry References)" in memory was wrong — it confused inline year-mentions in a recap for anchors. Exact profile of QC-Py-20 (#4161, also OMISSION pleine, 6 anchors).

4 teaching cells cited no originator at the concept-definition point:

| Cell | Teaching point | Anchor added |
|------|----------------|--------------|
| `md[15]` — *Architecture Random Forest* | Bagging + majority vote | **Breiman (2001)**, *Random Forests*, Machine Learning 45(1):5-32, DOI `10.1023/A:1010933404324` |
| `md[25]` — *Gradient Boosting vs Random Forest* | Sequential error correction | **Friedman (2001)** GB, Annals of Statistics 29(5):1189-1232, DOI `10.1214/aos/1013203451` + **Chen & Guestrin (2016)** XGBoost, KDD '16:785-794, arXiv:1603.02754, DOI `10.1145/2939672.2939785` |
| `md[43]` — *Courbes ROC* | FPR/TPR + AUC interpretation | **Fawcett (2006)**, *An introduction to ROC analysis*, Pattern Recognition Letters 27(8):861-874, DOI `10.1016/j.patrec.2005.10.010` |
| `md[44]` — *4.2 Walk-Forward Validation* | Expanding/sliding window | **Pardo (2008)**, *The Evaluation and Optimization of Trading Strategies*, 2nd ed., Wiley, ISBN 978-0-470-12801-5 |

Plus a `### References academiques` subsection appended to the recap cell `[59]` (5 entries).

## Web-verification

- **RF / GB / XGBoost** = textbook-grade canonical (re-verified in QC-Py-20 #4161).
- **Fawcett (2006)** ROC — web-verified via searxng (ScienceDirect, ACM DL, Semantic Scholar all converge on Pattern Recognition Letters 27(8):861-874, DOI `10.1016/j.patrec.2005.10.010`).
- **Pardo (2008)** Walk-Forward — web-verified via searxng (Wiley, Amazon, Goodreads; walk-forward analysis = cornerstone theory of the book).

## Edition — markdown-additive

- **0 code cell changed.** Footnote anchors appended to 4 markdown cells + 1 References subsection in the recap.
- **List-direct edit** (mutate `cell['source']` list per-line, never join+resplit) — per the QC-Py-25 cell-7 mash lesson.
- **Catalogue byte-identical** (`COURSE_CATALOG.generated.{json,md}` untouched on branch).

## Validation

```
validate-notebooks QC-Py-19-ML-Supervised-Classification.ipynb
  OK: 1  Warnings: 0  Errors: 0
code cells byte-identical (sha1 pre == post): 27/27 unchanged
cell count unchanged: 60 cells
```

Part of the #3164 QC-Py citation-audit deep-queue. See #3164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)