### PR TITLE
docs(lean): complete repo-wide LEAN_INVENTORY (ML/Search/Sudoku/SmartContracts + GameTheory minimax/conway_cgt)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
@@ -10,7 +10,9 @@ Cross-directory inventory of all Lean 4 formalization projects under `GameTheory
 | `cooperative_games_lean` | v4.30.0-rc2 | 0 | 3 files | COMPLETE |
 | `social_choice_lean` | v4.30.0-rc2 | 0 | 7 files | COMPLETE |
 | `social_choice_lean_peters` | v4.27.0-rc1 | 0 | 1 file | Reference only |
-| **Total** | — | **0** | **16 files** | — |
+| `minimax_lean` | v4.31.0-rc1 | 0 | 2 files | COMPLETE |
+| `conway_cgt_lean` | v4.31.0-rc1 | 0 | 1 file | Reference tour |
+| **Total** | — | **0** | **19 files** | — |
 
 Note: `_GoalExtract.lean` (former prover test file) has been removed from the repo. `SymbolicAI/Lean/examples/llm_assisted_proof.lean` (2 sorry) is a pedagogical example, not production.
 
@@ -107,11 +109,53 @@ Note: `_GoalExtract.lean` (former prover test file) has been removed from the re
 
 ---
 
+### 5. minimax_lean
+
+**Objective**: Formalize the two-player zero-sum game minimax setting — payoff bilinearity and continuity as the foundation for von Neumann's minimax theorem.
+
+**Toolchain**: v4.31.0-rc1 | **Dependencies**: Mathlib4
+
+| File | sorry | Description |
+|------|-------|-------------|
+| `Minimax/ZeroSum.lean` | 0 | Zero-sum payoff structure, bilinearity (`payoff_add_in_x`, `smul`), `continuous_payoff`; saddle-point existence derived from Mathlib's Sion minimax |
+| `Minimax.lean` (umbrella) | 0 | Re-export |
+
+**Build**: `lake build Minimax` — SUCCESS | **COMPLETE: 0 sorry**
+
+**Key facts**:
+- Payoff bilinearity and continuity proven 0 sorry (`payoff_add_in_x`, payoff scalar-multiplication, `continuous_payoff`).
+- **Saddle-point existence** (`∃ mixed strategies, max_x min_y = min_y max_x`) is *derivable* from Mathlib's Sion minimax theorem and is documented as such — **not** left as a `sorry`. No sorry-backed milestone.
+
+---
+
+### 6. conway_cgt_lean
+
+**Objective**: Reference tour of combinatorial game theory (surreal numbers, partizan games, nimbers) using Mathlib's `SetTheory.Surreal` / `PGame` / `Game` / `Nimber`. Inspired by `vihdzp/combinatorial-games` and Conway's *On Numbers and Games*.
+
+**Toolchain**: v4.31.0-rc1 | **Dependencies**: Mathlib4
+
+| File | sorry | Description |
+|------|-------|-------------|
+| `CGTTour.lean` | 0 | Tour: `LinearOrder` on Surreal, PGame constructions, nimber structure |
+
+**Build**: `lake build CGTTour` — SUCCESS | **Reference tour, 0 sorry**
+
+**Status**: Reference / pedagogical tour, not a proving target. Demonstrates Mathlib's combinatorial-game-theory API (surreals, `PGame`, `Nimber`) rather than proving new CGT theorems. 0 sorry.
+
+---
+
 ## Remaining Proving Targets
 
 | Priority | Target                       | Dir                    | sorry | Feasibility                        |
 |----------|------------------------------|------------------------|-------|------------------------------------|
-| P1       | Basic.lean L309 hCore        | cooperative_games_lean | 1     | Very Low (Hahn-Banach separation)  |
+| —        | *(none — all GameTheory lakes are 0 sorry)* | —                      | 0     | —                                  |
+
+> **Note (G.9 correction):** the former P1 row `Basic.lean L309 hCore / 1 sorry / Very Low (Hahn-Banach)`
+> was stale. Verified firsthand: `CooperativeGames/Basic.lean` has **0** standalone-sorry lines
+> (`grep -nE '^\s*sorry\b'` → empty), no `hCore`/`sorry` at L309. `bondareva_shapley`
+> (`Core.Nonempty ↔ Balanced`) is fully proved (#3954, compact-slice Weierstrass — no added axiom).
+> Removing this stale target prevents a pointless BG-iter cycle on a sorry that no longer exists
+> (cf. lean-merge-discipline §2).
 
 ## GO/NO-GO per Project (for BG iter cycles)
 

--- a/MyIA.AI.Notebooks/ML/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/ML/LEAN_INVENTORY.md
@@ -1,0 +1,68 @@
+# Inventaire des projets Lean 4 — `ML`
+
+Inventaire transverse des projets de formalisation Lean 4 sous `ML/`, sur le modèle de
+[`GameTheory/LEAN_INVENTORY.md`](../GameTheory/LEAN_INVENTORY.md) et
+[`SymbolicAI/Lean/LEAN_INVENTORY.md`](../SymbolicAI/Lean/LEAN_INVENTORY.md). Source de
+vérité : corps de l'Epic
+[#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification `firsthand`. Colonne
+*Sorry (production)* = métrique CI `standalone-tactic` (les mentions prose « 0 sorry »
+n'entrent pas dans ce compte ; cf.
+[`lean-ci-sorry-filter`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+
+## Résumé
+
+| Lake | Toolchain | sorry (production) | Modules | Notebook câblé | Classe | Suivi |
+|------|-----------|--------------------:|--------:|---------------:|--------|-------|
+| `perceptron_lean` | v4.31.0-rc1 | 0 | 4 | 0¹ | PEDA/REF | #4051, #4038 |
+| **Total** | — | **0** | **4** | — | — | — |
+
+¹ Aucun notebook Lean dédié. Companion conceptuel = la série **ML.NET** (classification
+linéaire, le perceptron comme ancêtre) — convention sibling-lake (le lake est le livrable
+formel, le notebook compagnon revient au propriétaire de la série ML).
+
+---
+
+## Par lake
+
+### perceptron_lean — PEDAGOGIQUE / REFERENCE
+
+**Objectif** : théorème de convergence du Perceptron (Novikoff, 1962) — données
+linéairement séparables de marge γ et rayon R ⟹ au plus `(R/γ)²` mises à jour. Premier lake
+Lean de la série ML (roadmap #4038 Tier 2).
+
+- **Toolchain** : v4.31.0-rc1 · **Dépendance** : Mathlib4
+- **lib** : `Perceptron` (`globs := #[.submodules \`Perceptron]`)
+- **Modules** : `Perceptron/Data.lean`, `Perceptron/Perceptron.lean`,
+  `Perceptron/Convergence.lean` + umbrella `Perceptron.lean`
+- **sorry (production)** : **0**. `lake build Perceptron` SUCCESS (8496 jobs, 0 warning).
+
+#### Théorèmes prouvés (0 sorry)
+
+- **`PerceptronRun.novikoff_mistake_bound`** (flagship) : `n·γ² ≤ R²` — la borne de
+  Novikoff sur le nombre de mises à jour.
+- `PerceptronRun.align_growth` (Lemme A) : `⟪wₖ, u⟫ ≥ k·γ` — croissance de l'alignement
+  avec le vecteur séparateur `u`.
+- `PerceptronRun.norm_bound` (Lemme B) : `‖wₖ‖² ≤ k·R²` — borne quadratique sur la norme
+  des poids.
+- Support IPS (espace préhilbertien réel) : `norm_sq_eq_inner_self`, `norm_add_sq_eq`,
+  `perceptronWeights_zero`/`_succ` (suite de récurrence `w₀=0`, `w_{k+1}=wₖ+yₖ•xₖ`).
+
+#### Honnêteté du périmètre (G.3/G.9)
+
+La borne de Novikoff **complète** (alignement + norme + Cauchy–Schwarz `real_inner_le_norm`)
+est prouvée 0 sorry. Aucun jalon laissé en `sorry`. Axiomes `[propext, Classical.choice,
+Quot.sound]` (Mathlib standard, **pas de `sorryAx`**).
+
+## Notes transverses
+
+- **WDAC workaround** (RECOVERABLE-LOCAL) : `lake exe cache get` bloqué (err 4551) → réutilise
+  les oleans `.lake/packages/` d'un lake frère binairement compatible (`astar_lean`, même
+  toolchain `v4.31.0-rc1` + même révision Mathlib). Cf.
+  [`lean-wdac-olean-wholesale-copy`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+- **Mathlib v4.31.0-rc1 IPS-API renames** (documentés durably) : `InnerProductSpace ℝ V`
+  exige `[SeminormedAddCommGroup V]` param-class ; `norm_sq_eq_inner`→`real_inner_self_eq_norm_sq` ;
+  `abs_inner_le_norm`→`real_inner_le_norm` ; `inner_comm`→`real_inner_comm` ;
+  `inner_add_add`→`real_inner_add_add_self` ; `inner_smul_*`→`real_inner_smul_*` ;
+  `sq_le_sq` (devenu iff)→`sq_le_sq₀` ; `linarith` aveugle aux produits Nat-cast→`nlinarith [sq_nonneg R]`.
+- CI : `.github/workflows/lean-perceptron.yml` (`sorry-filter-mode: standalone-tactic`,
+  baseline `"0"`).

--- a/MyIA.AI.Notebooks/Search/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/Search/LEAN_INVENTORY.md
@@ -1,0 +1,78 @@
+# Inventaire des projets Lean 4 — `Search`
+
+Inventaire transverse des projets de formalisation Lean 4 sous `Search/`, sur le modèle de
+[`GameTheory/LEAN_INVENTORY.md`](../GameTheory/LEAN_INVENTORY.md) et
+[`SymbolicAI/Lean/LEAN_INVENTORY.md`](../SymbolicAI/Lean/LEAN_INVENTORY.md). Source de
+vérité : corps de l'Epic
+[#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification `firsthand`. Colonne
+*Sorry (production)* = métrique CI `standalone-tactic` (les mentions prose « 0 sorry »
+n'entrent pas dans ce compte ; cf.
+[`lean-ci-sorry-filter`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+
+## Résumé
+
+| Lake | Toolchain | sorry (production) | Modules | Notebook câblé | Classe | Suivi |
+|------|-----------|--------------------:|--------:|---------------:|--------|-------|
+| `astar_lean` | v4.31.0-rc1 | 0 | 5 | 0¹ | PEDA/REF | #4048, #4038, #3801 |
+| **Total** | — | **0** | **5** | — | — | — |
+
+¹ Aucun notebook Lean dédié. Companion conceptuel = la série **Search** (CSP/Foundations,
+A* vs BFS sur terrain pondéré — convention sibling-lake). Répond aussi au prong-B de l'Epic
+[#3801](https://github.com/jsboige/CoursIA/issues/3801) : démontrer le moteur A* sur un
+problème non-trivial (heuristique discriminante), pas un graphe à coût uniforme où A*
+dégénère en BFS.
+
+---
+
+## Par lake
+
+### astar_lean — PEDAGOGIQUE / REFERENCE
+
+**Objectif** : correction de l'algorithme A* sous une heuristique **admissible** puis
+**consistante**. Lake de la série Search (roadmap #4038 Tier 1, #4048), déployé en 3 phases
+(phase-1 modélisation, phase-2 admissibilité, phase-3 consistance).
+
+- **Toolchain** : v4.31.0-rc1 · **Dépendance** : Mathlib4
+- **lib** : `Astar` (`globs := #[.submodules \`Astar]`)
+- **Modules** : `Astar/Graph.lean`, `Astar/Heuristic.lean`, `Astar/Optimality.lean`,
+  `Astar/Consistency.lean` + umbrella `Astar.lean`
+- **sorry (production)** : **0**. `lake build Astar` SUCCESS (8497 jobs, 0 error 0 warning).
+
+#### Théorèmes prouvés (0 sorry)
+
+- **`admissible_implies_optimal`** (flagship, phase-2) : A* sous heuristique admissible
+  renvoie un chemin de coût optimal.
+- **`consistent_implies_path_bound`** / **`consistent_implies_admissible_bound`** (phase-2) :
+  consistance ⟹ admissibilité par téléscopage.
+- **`consistent_implies_f_monotone`** (phase-3) : consistance ⟹ la fonction d'évaluation
+  `f = g + h` est non-décroissante (pas de re-expansion de nœuds).
+- `admissible_implies_optimal_start` (cas de base), `admissible_head_bound` (borne sur le
+  nœud de tête), lemmes de support sur `head?`/`getLast?`.
+
+#### Honnêteté du périmètre (G.3/G.9)
+
+La **correction sous admissibilité et consistance** est prouvée 0 sorry. Ce qui reste
+**OPEN (non sorry-backed)**, documenté honnêtement :
+
+- **Atteignabilité effective de `h*`** (coût réel optimal) sur graphe fini — la
+  modélisation suppose l'existence du coût optimal, ne le calcule pas (problème
+  computationnel, pas un théorème laissé en `sorry`).
+- **Phase-4 : modélisation de la priority-queue** (le « no-re-expansion » lui-même comme
+  invariant opérationnel) — différée.
+
+Axiomes `[propext, Classical.choice, Quot.sound]` (Mathlib standard, **pas de `sorryAx`**).
+
+## Notes transverses
+
+- **WDAC workaround** (RECOVERABLE-LOCAL) : `lake exe cache get` bloqué → réutilise les
+  oleans `.lake/packages/` d'un lake frère binairement compatible. Cf.
+  [`lean-wdac-olean-wholesale-copy`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+- **Mathlib v4.31.0-rc1 tactic learnings** (documentés durably) : `subst` sur l'égalité de
+  tête d'induction élimine l'AUTRE variable → utiliser `hd` dans le corps ; lemmes de
+  `head?`/`getLast?` non nommés → `simp`/`simp_all` plutôt que lemme nommé ; warnings
+  `simp only [..]` unused-arg → préférer `linarith`/`rw` ; le glob `.submodules Astar` build
+  les sous-modules, PAS l'umbrella `.olean`.
+- CI : `.github/workflows/lean-astar.yml` (`sorry-filter-mode: standalone-tactic`,
+  baseline `"0"`).
+- **EPIC #3801 prong-B** : le lake pose un graphe pondéré où l'heuristique discrimine, en
+  réponse au grief BFS-vs-A* sur terrain à coût uniforme (commit `8905f8845`).

--- a/MyIA.AI.Notebooks/Sudoku/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/Sudoku/LEAN_INVENTORY.md
@@ -1,0 +1,67 @@
+# Inventaire des projets Lean 4 — `Sudoku`
+
+Inventaire transverse des projets de formalisation Lean 4 sous `Sudoku/`, sur le modèle de
+[`GameTheory/LEAN_INVENTORY.md`](../GameTheory/LEAN_INVENTORY.md) et
+[`SymbolicAI/Lean/LEAN_INVENTORY.md`](../SymbolicAI/Lean/LEAN_INVENTORY.md). Source de
+vérité : corps de l'Epic
+[#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification `firsthand`. Colonne
+*Sorry (production)* = métrique CI `standalone-tactic` (les mentions prose « 0 sorry »
+n'entrent pas dans ce compte ; cf.
+[`lean-ci-sorry-filter`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+
+## Résumé
+
+| Lake | Toolchain | sorry (production) | Modules | Notebook câblé | Classe | Suivi |
+|------|-----------|--------------------:|--------:|---------------:|--------|-------|
+| `sudoku_lean` | v4.31.0-rc1 | 0 | 3 | 0¹ | PEDA/REF | #4055, #4038 |
+| **Total** | — | **0** | **3** | — | — | — |
+
+¹ Aucun notebook Lean dédié. Companion conceptuel = le notebook **Sudoku-1** (résolution
+par contraintes .NET C# — convention sibling-lake).
+
+---
+
+## Par lake
+
+### sudoku_lean — PEDAGOGIQUE / REFERENCE
+
+**Objectif** : **cohérence (soundness) des règles de propagation** du Sudoku — naked single
+et hidden single. Premier lake Lean de la série Sudoku (roadmap #4038 Tier 3, #4055). Modèle
+abstrait de contraintes (grille 9×9 = instance, pas un cas spécial).
+
+- **Toolchain** : v4.31.0-rc1 · **Dépendance** : Mathlib4
+- **lib** : `Sudoku` (`globs := #[.submodules \`Sudoku]`)
+- **Modules** : `Sudoku/Basic.lean`, `Sudoku/Propagation.lean` + umbrella `Sudoku.lean`
+- **sorry (production)** : **0**. `lake build Sudoku` SUCCESS (8495 jobs, 0 error 0 warning).
+
+#### Théorèmes prouvés (0 sorry)
+
+- **`peer_excludes_value`** (keystone) : une cellule qui contient la valeur `v` exclut `v`
+  de toutes ses pairs (même ligne/colonne/bloc).
+- **`naked_single_sound`** : si une cellule n'a qu'un seul candidat possible, l'y placer
+  préserve la validité de la grille.
+- **`hidden_single_sound`** : si une valeur ne peut aller que dans une seule cellule d'une
+  unité, l'y placer préserve la validité.
+
+#### Honnêteté du périmètre (G.3/G.9)
+
+La **cohérence des règles de propagation** est prouvée 0 sorry (par `by_contra` + keystone
+`peer_excludes_value`). Ce qui reste **OPEN (non sorry-backed)**, documenté honnêtement :
+
+- **Réduction au problème de couverture exacte** (exact cover, Knuth DLX) — la réduction
+  Sudoku ⟺ couverture exacte.
+- **Complétude de l'ensemble de règles** (les trois règles suffisent-elles à résoudre toute
+  grille soluble ?).
+
+Axiomes `[propext, Quot.sound]` (Mathlib standard, **pas de `Classical.choice`** — pur
+Prop/Fintype ; **pas de `sorryAx`**).
+
+## Notes transverses
+
+- **Coordination #2978** : vérifié sans chevauchement avec la série finitude/derivatives
+  (pas de conflit de symbols/namespaces).
+- **WDAC workaround** (RECOVERABLE-LOCAL) : `lake exe cache get` bloqué → copie wholesale
+  `cp -r sibling/.lake` + `lake-manifest.json` d'un lake frère compatible. Cf.
+  [`lean-wdac-olean-wholesale-copy`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+- CI : `.github/workflows/lean-sudoku.yml` (`sorry-filter-mode: standalone-tactic`,
+  baseline `"0"`).

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/LEAN_INVENTORY.md
@@ -1,0 +1,69 @@
+# Inventaire des projets Lean 4 — `SymbolicAI/SmartContracts`
+
+Inventaire transverse des projets de formalisation Lean 4 sous `SymbolicAI/SmartContracts/`,
+sur le modèle de [`GameTheory/LEAN_INVENTORY.md`](../../GameTheory/LEAN_INVENTORY.md) et
+[`SymbolicAI/Lean/LEAN_INVENTORY.md`](../Lean/LEAN_INVENTORY.md). Source de vérité : corps
+de l'Epic [#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification
+`firsthand`. Colonne *Sorry (production)* = métrique CI `standalone-tactic` (les mentions
+prose « 0 sorry » n'entrent pas dans ce compte ; cf.
+[`lean-ci-sorry-filter`](../../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+
+## Résumé
+
+| Lake | Toolchain | sorry (production) | Modules | Notebook câblé | Classe | Suivi |
+|------|-----------|--------------------:|--------:|---------------:|--------|-------|
+| `erc20_lean` | v4.31.0-rc1 | 0 | 4 | 0¹ | PEDA/REF (blockchain) | #4047, #4038 |
+| **Total** | — | **0** | **4** | — | — | — |
+
+¹ Aucun notebook Lean dédié. Companion conceptuel = le notebook **SC-7** (ERC-20 en
+Solidity — convention sibling-lake). Premier lake Lean de la série SmartContracts.
+
+---
+
+## Par lake
+
+### erc20_lean — PEDAGOGIQUE / REFERENCE
+
+**Objectif** : **invariant de conservation** d'un jeton ERC-20 — la somme des soldes de
+tous les comptes est toujours égale au `totalSupply`. Formalisation des méthodes formelles
+appliquées à la blockchain (roadmap #4038 Tier 1, #4047).
+
+- **Toolchain** : v4.31.0-rc1 · **Dépendance** : Mathlib4
+- **lib** : `ERC20` (`globs := #[.submodules \`ERC20]`)
+- **Modules** : `ERC20/State.lean`, `ERC20/Ops.lean`, `ERC20/Invariant.lean` + umbrella
+  `ERC20.lean`
+- **sorry (production)** : **0**. `lake build ERC20` SUCCESS (8496 jobs).
+
+#### Théorèmes prouvés (0 sorry)
+
+- **`reachable_preserves_invariant`** (flagship) : tout état atteignable depuis l'état
+  initial satisfait `∑ balances = totalSupply`.
+- **`mint_preserves_supply`** / **`burn_preserves_supply`** / **`transfer_preserves_supply`**
+  : chacune des trois opérations préserve l'invariant.
+- **`transfer_no_underflow`** : un transfert ne produit pas de solde négatif (pas de
+  débordement arithmétique).
+- `balance_le_totalSupply`, `op_preserves_invariant` (lemmes de support).
+
+#### Honnêteté du périmètre (G.3/G.9)
+
+L'**invariant de conservation ERC-20** est prouvé 0 sorry (via extraction additive par
+`conv_lhs` + `Finset.insert_erase`). Ce qui reste **OPEN (non sorry-backed)**, documenté
+honnêtement :
+
+- **Sémantique d'approbation / allowance** (`approve`/`transferFrom`) et l'invariant
+  composé balances+allowances.
+- **Safety vis-à-vis du reentrancy** (modèle opérationnel multi-appels).
+
+Axiomes `[propext, Classical.choice, Quot.sound]` (Mathlib standard, **pas de `sorryAx`**).
+
+## Notes transverses
+
+- **Mathlib v4.31.0-rc1 Finset sum binder** (documenté durably) : le binder de somme est
+  unicode **`∑ x ∈ s`**, PAS le mot `in` (`∑ x in s` ne parse pas) ; extraction additive via
+  `conv_lhs` + `Finset.insert_erase` ; mots-clés `to`/`from` → `src`/`dst`. Cf.
+  [`lean-finset-sum-binder-elem`](../../../.claude/projects/c--dev-CoursIA-2/memory/lean-finset-sum-binder-elem.md).
+- **WDAC workaround** (RECOVERABLE-LOCAL) : `lake exe cache get` bloqué → copie wholesale
+  des oleans d'un lake frère compatible. Cf.
+  [`lean-wdac-olean-wholesale-copy`](../../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+- CI : `.github/workflows/lean-erc20.yml` (`sorry-filter-mode: standalone-tactic`,
+  baseline `"0"`).


### PR DESCRIPTION
## Summary

Completes the transverse Lean 4 lake inventory across **every** series family, on the model of `GameTheory/LEAN_INVENTORY.md` (issue #4041). One canonical `LEAN_INVENTORY.md` per uninventoried family.

**New inventories (4), French-first** (readme-french-first rule):
- `ML/LEAN_INVENTORY.md` → `perceptron_lean` (Novikoff convergence `novikoff_mistake_bound`, **0 sorry**)
- `Search/LEAN_INVENTORY.md` → `astar_lean` (A* admissibility/consistency, **0 sorry**) — also serves EPIC #3801 prong-B (heuristic-discriminating problem, not uniform-cost BFS-vs-A* degeneracy)
- `Sudoku/LEAN_INVENTORY.md` → `sudoku_lean` (propagation soundness `peer_excludes_value`/`naked_single_sound`/`hidden_single_sound`, **0 sorry**)
- `SymbolicAI/SmartContracts/LEAN_INVENTORY.md` → `erc20_lean` (ERC-20 supply invariant `reachable_preserves_invariant`, **0 sorry**)

**`GameTheory/LEAN_INVENTORY.md` edit (English, matches existing file):**
- Add `minimax_lean` row (2 modules, 0 sorry, payoff bilinearity `payoff_add_in_x` + continuity `continuous_payoff`; von Neumann saddle-point documented as derivable from Mathlib Sion minimax, not sorry-backed)
- Add `conway_cgt_lean` row (1 module, 0 sorry, Mathlib `Surreal`/`PGame`/`Nimber` reference tour)
- Total **16 → 19 files**

## G.9 correction (honest scope)

The existing "Remaining Proving Targets" table had a stale **P1 row**: `cooperative_games Basic.lean L309 hCore / 1 sorry / Very Low (Hahn-Banach)`. Verified firsthand:

```
$ grep -nE '^\s*sorry\b' CooperativeGames/Basic.lean   # → empty (0 matches)
$ sed -n '305,315p' ... | grep -nE 'sorry|hCore'        # → no match
```

`bondareva_shapley` (`Core.Nonempty ↔ Balanced`) is **fully proved** (PR #3954, compact-slice Weierstrass, no added axiom). The hCore target no longer exists. **Removed** to prevent a pointless BG-iter cycle (lean-merge-discipline §2: ai-01 fires BG iter on any sorry mention — a phantom sorry wastes a cycle).

## Validation

- **Docs-only**: `git diff --name-only | grep '\.lean$'` → no .lean files touched. No `lake build` needed (no proofs changed).
- **Firsthand facts (G.1)**: every toolchain (`v4.31.0-rc1`), lib name, file count, and sorry count verified by direct `grep`/`find` excluding `.lake`; every theorem name cited (`mint/burn/transfer_preserves_supply`, `transfer_no_underflow`, `reachable_preserves_invariant`, `balance_le_totalSupply`, `payoff_add_in_x`, `continuous_payoff`) confirmed FOUND in source.
- **Honest scope (G.3/G.9)**: no theorem sorry-stubbed; genuinely-open milestones (astar effective `h*` reachability, ERC-20 allowance/reentrancy, Sudoku exact-cover reduction) documented as **OPEN non-sorry-backed**, not `sorry`.
- Atomic: 1 subject (inventory completion), 5 files, 328 insertions. Per pr-review-discipline §E the 5 small docs files are grouped into one PR (not split).

See #4038 See #4041