### PR TITLE
docs(search-py): anchor canonical citations Search-6-AdversarialSearch (Minimax/Alpha-Beta)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
@@ -121,7 +121,8 @@
     "| **Information parfaite** | Les deux joueurs connaissent l'etat complet du jeu |\n",
     "| **Tour a tour** | Les joueurs jouent alternativement |\n",
     "| **Deterministe** | Le resultat d'une action est certain (pas de hasard) |\n",
-    "| **Fini** | Le jeu se termine toujours en un nombre fini de coups |"
+    "| **Fini** | Le jeu se termine toujours en un nombre fini de coups |\n",
+    "\n\n> *Ancres savantes -- von Neumann, J. (1928), Zur Theorie der Gesellschaftsspiele, Mathematische Annalen 100:295-320 (théorème minimax, fondement des jeux à somme nulle, dont découle l'algorithme Minimax d'évaluation de l'arbre de jeu) ; Shannon, C.E. (1950), Programming a Computer for Playing Chess, Philosophical Magazine 41(314):256-275 (propose l'évaluation minimax de l'arbre de jeu avec fonction d'évaluation statique — l'acte de naissance de la programmation de jeux par ordinateur) ; Knuth, D.E. & Moore, R.W. (1975), An Analysis of Alpha-Beta Pruning, Artificial Intelligence 6(4):293-326 (analyse complète de l'élagage alpha-bêta, borne O(b^(m/2)) sur l'arbre élagué vs O(b^m) pour Minimax brut) ; Zobrist, A.L. (1970), A New Hashing Method with Application for Game Playing, ICCV Report 88, University of Wisconsin (hachage de Zobrist pour indexer les positions de jeu dans les tables de transposition) ; Korf, R.E. (1985), Depth-first Iterative-Deepening: An Optimal Admissible Tree Search, Artificial Intelligence 27(1):97-109 (approfondissement itératif, recherche par profondeur croissante bornée en temps).*"
    ]
   },
   {
@@ -1739,7 +1740,8 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Recherche informee](Search-3-Informed.ipynb) | [Index](../README.md) | [MCTS >>](Search-7-MCTS-And-Beyond.ipynb)"
+    "**Navigation** : [<< Recherche informee](Search-3-Informed.ipynb) | [Index](../README.md) | [MCTS >>](Search-7-MCTS-And-Beyond.ipynb)\n",
+    "\n\n### References academiques\n\n- von Neumann, J. (1928). Zur Theorie der Gesellschaftsspiele. Mathematische Annalen 100:295-320.\n- Shannon, C.E. (1950). Programming a Computer for Playing Chess. Philosophical Magazine 41(314):256-275.\n- Knuth, D.E. & Moore, R.W. (1975). An Analysis of Alpha-Beta Pruning. Artificial Intelligence 6(4):293-326.\n- Zobrist, A.L. (1970). A New Hashing Method with Application for Game Playing. ICCV Report 88, University of Wisconsin.\n- Korf, R.E. (1985). Depth-first Iterative-Deepening: An Optimal Admissible Tree Search. Artificial Intelligence 27(1):97-109.\n\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Continuation of the **#3164 citation audit** — Search-Python foundational course (batch 4). Markdown-additive: a scholarly inline blockquote at the introduction + a `### References academiques` cell at the conclusion. **0 code cells changed** — pure pedagogical prose, C.2 markdown-only exception, no re-execution needed.

## Notebook anchored

**Search-6-AdversarialSearch.ipynb** — game-tree search (Minimax / Alpha-Beta / Iterative Deepening / Transposition Tables). G.1 firsthand confirmed these are the notebook's *central* taught subjects (sections 3-6), not passing mentions:

| Taught technique | Canonical anchor |
|------------------|------------------|
| Minimax (§3) | von Neumann (1928) minimax theorem + Shannon (1950) *Programming a Computer for Playing Chess* — game-tree minimax evaluation, the founding act of computer game-playing |
| Alpha-Beta pruning (§4) | Knuth & Moore (1975) *An Analysis of Alpha-Beta Pruning* — canonical analysis, `O(b^(m/2))` bound on the pruned tree vs `O(b^m)` for brute Minimax |
| Iterative Deepening (§5) | Korf (1985) — iterative-deepening as time-bounded search |
| Transposition Tables (§6) | Zobrist (1970) *A New Hashing Method with Application for Game Playing* — Zobrist hashing to index game positions |

**Genuine OMISSION**: the notebook had no `References academiques` cell and no scholarly anchor — the four techniques were taught with zero academic grounding.

## Validation

- `git diff` vs `origin/main`: markdown cells only, **0 code cells changed** (verified via JSON cell-type comparison).
- `nbformat` preserved (`json.dump indent=1, ensure_ascii=False`, no-BOM, UTF-8) — matches repo convention, no spurious churn.
- No re-execution required (C.2 markdown-only exception).

See #3164

---
*Part of the standing citation-audit directive. Search-Python batches: #4169 (Search-2/4), #4175 (Search-3/11), #4180 (Search-1/7) — all MERGED. RL track complete: #4147/#4166 (MERGED). Next-cycle candidate (G.1 pending): Search-10-SymbolicAutomata (91 cells, no refs, partition-check needed).*
