### PR TITLE
docs(tweety): complete README references table with notebook-anchored papers

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -510,6 +510,14 @@ La version est configurable dans `Tweety-1-Setup.ipynb` (variable `TWEETY_VERSIO
 | Besnard & Hunter, *Elements of Argumentation* (2008) | Notebooks 5-7, théorie argumentation |
 | Brewka, Eiter & Truszczynski, "Answer Set Programming at a Glance" (2011) | Notebook 6, ASP/Clingo |
 | Russell & Norvig, *AIMA* 4e éd., ch. 7-8 | Cadre général logique et SAT |
+| Gärdenfors & Makinson (1988) | Notebook 4, enracinement épistémique (caractérisation AGM) |
+| Caminada (2006); Modgil & Caminada (2009) | Notebook 5, labellings trivalués (in/out/undec) |
+| Baroni et al. (2005) | Notebook 5, sémantique CF2 (cycles impairs) |
+| García & Simari, "Defeasible Logic Programming" (2004) | Notebook 6, DeLP |
+| Brewka & Woltran, "Abstract Dialectical Frameworks" (2010) | Notebook 7a, ADF |
+| Cayrol & Lagasquie-Schiex (2005) | Notebook 7a, frameworks bipolaires (BAF) |
+| Bonzon, Delobelle, Konieczny & Maudet (2016) | Notebook 7b, sémantiques de classement |
+| Arrow, "Social Choice and Individual Values" (1951) | Notebook 9, théorème d'impossibilité (choix social) |
 
 ### Ressources en ligne
 


### PR DESCRIPTION
## Context

Epic #3164 (citation audit) — **Tweety loan** step 1 (argumentation grain, partition po-2025).

## Finding (firsthand, G.1)

Auditing the Tweety series against the #3164 recipe (anchor academic references where concepts are named at teaching points), I verified that **every Tweety notebook already anchors its foundational concept via an "Origine." blockquote** — the notebooks are citation-saturated (the target state). So there is **no notebook-level OMISSION** to fix.

However, the **series-level README references table** (7 rows) under-indexed that notebook-level anchoring: it listed Dung, ASPIC+, AGM, Enderton, Besnard&Hunter, Brewka-ASP, Russell&Norvig but omitted 8 distinct foundational papers the notebooks anchor at major teaching sections. A reader using the README as the series' academic index would miss CF2, DeLP, ADF, BAF, ranking semantics, labellings, epistemic entrenchment and Arrow.

## Change

Markdown-only completion of the references table (+8 rows), each citation verified **verbatim** from the corresponding notebook "Origine." blockquote:

| Paper | Anchors | Notebook |
|-------|---------|----------|
| Gärdenfors & Makinson (1988) | enracinement épistémique | Tweety-4 |
| Caminada (2006); Modgil & Caminada (2009) | labellings trivalués | Tweety-5 |
| Baroni et al. (2005) | CF2 semantics | Tweety-5 |
| García & Simari (2004) | DeLP | Tweety-6 |
| Brewka & Woltran (2010) | ADF | Tweety-7a |
| Cayrol & Lagasquie-Schiex (2005) | bipolar frameworks (BAF) | Tweety-7a |
| Bonzon, Delobelle, Konieczny & Maudet (2016) | ranking semantics | Tweety-7b |
| Arrow (1951) | impossibility theorem / social choice | Tweety-9 |

## Validation

- Markdown-only edit → C.2 exception, no re-execution needed.
- `git diff --stat`: 1 file, +8 / -0.
- No catalog churn, no notebook source touched.

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)