### PR TITLE
lean(cooperative): prove veto_iff_critical_of_winning (veto iff critical in every winning coalition)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1236,6 +1236,22 @@ theorem veto_critical_of_winning {G : TUGame N} (hG : SimpleGame G) {i : N}
     have hni : i ∉ S.erase i := by simp [Finset.mem_erase]
     exact hni (hv (S.erase i) heq)
 
+/-- A player is a veto player if and only if it is critical in every winning coalition.
+
+    The reciprocal of `veto_critical_of_winning`: being a veto player is *equivalent* to being
+    critical in every winning coalition. The forward direction is `veto_critical_of_winning` (a
+    veto player belongs to every winning coalition and its removal makes it losing); the reverse
+    direction is immediate because criticality `Critical G i S` includes the membership `i ∈ S`,
+    so being critical in every winning coalition recovers `VetoPlayer G i` (`∀ winning S, i ∈ S`).
+    The characterization is meaningful under non-degeneracy (existence of at least one winning
+    coalition); in the fully degenerate case (no winning coalition) both sides hold vacuously. -/
+theorem veto_iff_critical_of_winning {G : TUGame N} (hG : SimpleGame G) (i : N) :
+    VetoPlayer G i ↔ ∀ S : Finset N, G.v S = 1 → Critical G i S := by
+  constructor
+  · exact fun hv S hS => veto_critical_of_winning hG hv hS
+  · intro h S hS
+    exact (h S hS).1
+
 /-- A veto player has a strictly positive raw Banzhaf index when the grand coalition wins.
 
     The veto pendant of `dummy_banzhaf_raw_zero` (a dummy has `BanzhafRaw = 0`): a veto player


### PR DESCRIPTION
## `veto_iff_critical_of_winning` — a veto player **iff** critical in every winning coalition

**Step 1 of ai-01's veto-theory deep-queue** (burn in order, no stacking). The reciprocal of
`veto_critical_of_winning` (merged, #4176): being a veto player is *equivalent* to being critical
in every winning coalition — a clean iff characterization.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `veto_iff_critical_of_winning` | `VetoPlayer G i ↔ (∀ S, v S = 1 → Critical G i S)` | iff characterization of veto via criticality |

### Proof

The two directions:

- **Forward** (`→`): `veto_critical_of_winning` (#4176) — a veto player belongs to every winning
  coalition and its removal makes it losing, so it is critical in every winning coalition.
- **Reverse** (`←`): being critical in every winning coalition implies veto. Immediate by
  projection: `Critical G i S` includes the membership `i ∈ S` (its first conjunct), so
  `∀ S, v S = 1 → Critical G i S` yields `∀ S, v S = 1 → i ∈ S`, which is exactly `VetoPlayer G i`.

The characterization is meaningful under **non-degeneracy** (existence of at least one winning
coalition); in the fully degenerate case (no winning coalition) both sides hold vacuously, so the
iff is unconditionally true.

### Built on freshly-merged foundations

Prouvable from `origin/main` (tip `7254859eb`) directly — uses only:
- `veto_critical_of_winning` (#4176, merged)
- `VetoPlayer` + `Critical` (on main since #4134/#4153 era)

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (16s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +16/0), pure insertion after `veto_critical_of_winning`.
  **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)