### PR TITLE
docs(search-py): anchor canonical citations Search-10-SymbolicAutomata (DFA/NFA + symbolic)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
@@ -77,7 +77,8 @@
     "\n",
     "> **Theoreme de Kleene** : Tout langage reconnu par un automate fini est regulier et reciproquement.\n",
     "\n",
-    "> **Theoreme de Rabin-Scott** : NFA et DFA reconnaissent les memes langages (NFA peut etre converti en DFA)."
+    "> **Theoreme de Rabin-Scott** : NFA et DFA reconnaissent les memes langages (NFA peut etre converti en DFA).\n",
+    "\n\n> *Ancres savantes -- Kleene, S.C. (1956), Representation of Events in Nerve Nets and Finite Automata, in C.E. Shannon & J. McCarthy (eds.), Automata Studies, Annals of Mathematics Studies 34, Princeton University Press:3-42 (theoreme de Kleene : equivalence entre langages reconnus par automates finis et expressions regulieres, deja nomme ci-dessus) ; Rabin, M.O. & Scott, D. (1959), Finite Automata and Their Decision Problems, IBM Journal of Research and Development 3(2):114-125 (theoreme de Rabin-Scott : equivalence NFA/DFA, conversion non-deterministe vers deterministe — prix Turing 1976, deja nomme ci-dessus) ; Hopcroft, J.E., Motwani, R. & Ullman, J.D. (2007), Introduction to Automata Theory, Languages, and Computation (3rd ed.), Pearson (manuel de reference sur les automates finis, operations de fermeture et minimisation) ; D'Antoni, L. & Veanes, M. (2017), The Power of Symbolic Automata and Transducers, Theoretical Computer Science 719:199-211 (automates symboliques : transition etiquetee par un predicat sur un alphabet potentiellement infini, fondement theorique de l'extension avec Z3 presentee sections 3-4) ; de Moura, L. & Bjorner, N. (2008), Z3: An Efficient SMT Solver, TACAS 2008, LNCS 4963:337-340 (solveur SMT utilise comme moteur de decision des transitions symboliques).*"
    ]
   },
   {
@@ -4090,7 +4091,8 @@
     "\n",
     "Cette approche ouvre des applications de **verification de proprietes** : portes codees (security system), compteurs bornes avec invariants, et meme Mini-Sudoku 2x2 comme automate symbolique.\n",
     "\n",
-    "**Suite** : [Search-11 - Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Retour au sommaire](../README.md)"
+    "**Suite** : [Search-11 - Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Retour au sommaire](../README.md)\n",
+    "\n\n### References academiques\n\n- Kleene, S.C. (1956). Representation of Events in Nerve Nets and Finite Automata. In C.E. Shannon & J. McCarthy (eds.), Automata Studies, Annals of Mathematics Studies 34, Princeton University Press:3-42.\n- Rabin, M.O. & Scott, D. (1959). Finite Automata and Their Decision Problems. IBM Journal of Research and Development 3(2):114-125.\n- Hopcroft, J.E., Motwani, R. & Ullman, J.D. (2007). Introduction to Automata Theory, Languages, and Computation (3rd ed.). Pearson.\n- D'Antoni, L. & Veanes, M. (2017). The Power of Symbolic Automata and Transducers. Theoretical Computer Science 719:199-211.\n- de Moura, L. & Bjorner, N. (2008). Z3: An Efficient SMT Solver. TACAS 2008, LNCS 4963:337-340.\n\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Continuation of the **#3164 citation audit** — Search-Python foundational course (batch 5). Markdown-additive: a scholarly inline blockquote at the introduction + a `### References academiques` cell at the conclusion. **0 code cells changed** — pure pedagogical prose, C.2 markdown-only exception, no re-execution needed.

## Notebook anchored

**Search-10-SymbolicAutomata.ipynb** — finite automata (DFA/NFA, sections 1-2) + symbolic automata with Z3 (the notebook's flagship subject, sections 3-4).

**G.1 firsthand finding (textbook OMISSION case)**: the notebook *already names* the **Kleene theorem** and the **Rabin-Scott theorem** in its intro cell — but with **no academic citation** (no paper, year, or venue) and **no `References academiques` cell**. This is the canonical OMISSION pattern #3164 targets: the concept is present, the scholarly grounding is missing. The anchor gives those already-named theorems their formal citation and additionally grounds the flagship subject (symbolic automata).

| Named/taught concept | Canonical anchor |
|----------------------|------------------|
| Kleene theorem (named in cell) | Kleene (1956) *Representation of Events in Nerve Nets and Finite Automata*, Automata Studies, Annals of Math Studies 34, Princeton:3-42 |
| Rabin-Scott theorem, NFA/DFA (named in cell) | Rabin & Scott (1959) *Finite Automata and Their Decision Problems*, IBM J. Res. Dev. 3(2):114-125 (Turing Award 1976) |
| Finite automata (reference textbook) | Hopcroft, Motwani & Ullman (2007) *Introduction to Automata Theory, Languages, and Computation* |
| Symbolic automata (flagship §3-4) | D'Antoni & Veanes (2017) *The Power of Symbolic Automata and Transducers*, TCS 719:199-211 |
| Z3 decision engine | de Moura & Bjørner (2008) *Z3: An Efficient SMT Solver*, TACAS 2008 |

## Validation

- `git diff` vs `origin/main`: markdown cells only, **0 code cells changed** (verified via JSON cell-type comparison).
- `nbformat` preserved (`json.dump indent=1, ensure_ascii=False`, no-BOM, UTF-8) — matches repo convention, no spurious churn.
- No re-execution required (C.2 markdown-only exception).

See #3164

---
*Part of the standing citation-audit directive. Search-Python batches: #4169 (Search-2/4), #4175 (Search-3/11), #4180 (Search-1/7), #4184 (Search-6) — all MERGED. RL track complete: #4147/#4166. Partition: Search-10 lives in `Search/Part1-Foundations/` (Python, kernel python3) = po-2025 lane, NOT `SymbolicAI/` (po-2024).*
