### PR TITLE
lean(cooperative): prove veto_not_dummy (veto player is never a dummy, under non-degeneracy)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1293,6 +1293,30 @@ theorem dummy_banzhaf_raw_zero (G : TUGame N) (i : N) (h : DummyPlayer G i) :
   rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
   exact fun S _ hcrit => hneq S hcrit
 
+/-- A veto player is never a dummy player, provided the grand coalition wins.
+
+    The veto pendant of `dictator_not_dummy`: the two roles are mutually exclusive. A dummy
+    player never changes a coalition's value; applied to `Finset.univ.erase i` (which `i` is
+    absent from), this gives `v (univ.erase i ∪ {i}) = v (univ.erase i)`, i.e.
+    `v univ = v (univ.erase i)`. But a veto player forces `v (univ.erase i) = 0` (via
+    `veto_losing_without`, since `i ∉ univ.erase i`), while the non-degeneracy hypothesis
+    `hwin : v univ = 1` gives `v univ = 1`. The equality `1 = 0` is a contradiction. -/
+theorem veto_not_dummy (G : TUGame N) (hG : SimpleGame G) (i : N) (hv : VetoPlayer G i)
+    (hwin : G.v Finset.univ = 1) : ¬ DummyPlayer G i := by
+  intro hd
+  -- A dummy never changes a coalition's value; applied to `univ.erase i` (which excludes `i`):
+  have hni : i ∉ Finset.univ.erase i := by simp [Finset.mem_erase]
+  have hdummy := hd (Finset.univ.erase i) hni
+  -- `univ.erase i ∪ {i} = univ` (the player's absence followed by addition recovers the universe).
+  have huniv : Finset.univ.erase i ∪ ({i} : Finset N) = Finset.univ := by
+    ext j; simp [Finset.mem_univ]
+  rw [huniv] at hdummy
+  -- A veto player forces `v (univ.erase i) = 0` (it is absent from that coalition).
+  rw [veto_losing_without hG hv hni] at hdummy
+  -- `hdummy : v univ = 0` contradicts `hwin : v univ = 1`.
+  rw [hdummy] at hwin
+  linarith
+
 /-- A dictator is never a dummy player.
 
     The two extreme player roles are mutually exclusive. A dummy player adds no value to any


### PR DESCRIPTION
## `veto_not_dummy` — a veto player is never a dummy (under non-degeneracy)

**Step 2 of ai-01's veto-theory deep-queue** (burn in order). The veto pendant of
`dictator_not_dummy` (merged, #4160): the two roles — veto player and dummy — are mutually
exclusive, exactly as dictator and dummy are.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `veto_not_dummy` | `[SimpleGame G] → VetoPlayer G i → v univ = 1 → ¬ DummyPlayer G i` | veto and dummy are mutually exclusive |

### Proof

- A dummy player never changes a coalition's value. Applied to `Finset.univ.erase i` (which `i`
  is absent from): `v (univ.erase i ∪ {i}) = v (univ.erase i)`.
- Since `univ.erase i ∪ {i} = univ` (extenspuality — adding the absent player back recovers the
  universe), this becomes `v univ = v (univ.erase i)`.
- A veto player forces `v (univ.erase i) = 0` via `veto_losing_without` (#4181, merged) — the
  player is absent from `univ.erase i`, so that coalition is losing.
- But the non-degeneracy hypothesis `hwin : v univ = 1` gives `v univ = 1`. The equality
  `v univ = v (univ.erase i)` then forces `1 = 0`, a contradiction (`linarith`).

The non-degeneracy hypothesis `hwin : v univ = 1` is essential: in a fully degenerate game
(`v univ = 0`, no winning coalition) a player is *vacuously* a veto player (`∀ S, v S = 1 → i ∈ S`
holds vacuously) and could simultaneously be a dummy — the exclusion requires the grand coalition
to actually win.

### Independent of pending PR #4187 (no stacking, no conflict)

Prouvable from `origin/main` (tip `7254859eb`) directly — uses only:
- `veto_losing_without` (#4181, merged)
- `DummyPlayer` + `SimpleGame` + `VetoPlayer` (on main)

**Disjoint region** from the one pending cooperative-games PR #4187 (`veto_iff_critical_of_winning`):

| PR | Region (Shapley.lean) | Size |
|----|----------------------|------|
| #4187 veto_iff_critical_of_winning | after `veto_critical_of_winning` (~L1238) | +16 |
| **this PR** | **after `dummy_banzhaf_raw_zero` (~L1294)** | **+24** |

Distinct anchors → merge in any order with no text conflict.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (16s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +24/0), pure insertion after `dummy_banzhaf_raw_zero`.
  **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)