### PR TITLE
refactor(qc): relocate HMM alpha notebook Probas -> QC, fix FR accents

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -11,7 +11,7 @@ maturity: PRODUCTION=44
 
 Le monde réel est incertain. Un diagnostic medical n'est jamais sur a 100%, un classement sportif depend de performances intrinsequement variables, et les données que nous collectons sont toujours bruitees ou incompletes. La programmation probabiliste offre un cadre rigoureux pour modeliser cette incertitude : plutôt que de calculer une seule reponse, on obtient une **distribution de probabilités** qui quantifie notre confiance dans chaque resultat possible.
 
-Cette série couvre trois stack complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inference exacte par message passing, **PyMC** (Python) pour l'echantillonnage MCMC moderne, et des **applications standalone** (RSA, HMM trading). Les 21 notebooks Infer.NET couvrent les fondements mathematiques (distributions, graphs de facteurs), les modèles classiques (reseaux bayesiens, TrueSkill, LDA, HMM), puis la théorie de la décision bayésienne — jusqu'a un compagnon **Lean 4** (Infer-20b, adosse au projet Lake `gittins_lean`) qui demontre formellement les identites d'escompte de l'indice de Gittins. Les 20 notebooks PyMC reprennent l'intégralité des modèles Infer.NET en Python avec l'echantillonnage NUTS, offrant un pont naturel vers l'ecosysteme data science : fondations 1-3, modèles classiques 4-13, et théorie de la décision 14-20.
+Cette série couvre trois stack complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inference exacte par message passing, **PyMC** (Python) pour l'echantillonnage MCMC moderne, et des **applications standalone** (RSA). Les 21 notebooks Infer.NET couvrent les fondements mathematiques (distributions, graphs de facteurs), les modèles classiques (reseaux bayesiens, TrueSkill, LDA, HMM), puis la théorie de la décision bayésienne — jusqu'a un compagnon **Lean 4** (Infer-20b, adosse au projet Lake `gittins_lean`) qui demontre formellement les identites d'escompte de l'indice de Gittins. Les 20 notebooks PyMC reprennent l'intégralité des modèles Infer.NET en Python avec l'echantillonnage NUTS, offrant un pont naturel vers l'ecosysteme data science : fondations 1-3, modèles classiques 4-13, et théorie de la décision 14-20.
 
 ## Pourquoi cette série
 
@@ -103,7 +103,7 @@ Pour les étudiants en recherche operationnelle ou finance :
 
 #### Parcours rapide Python (standalone, ~2h)
 
-Si vous préférez Python au C#, commencez par Infer-101.ipynb (introduction standalone avec modèles Two Coins et Cyclist) puis Pyro_RSA_Hyperbole.ipynb (application a la linguistique pragmatique avec le framework RSA). Le notebook PyMC-HMM-Trading-Alpha.ipynb applique les HMM gaussiens a la génération de signaux de trading.
+Si vous préférez Python au C#, commencez par Infer-101.ipynb (introduction standalone avec modèles Two Coins et Cyclist) puis Pyro_RSA_Hyperbole.ipynb (application a la linguistique pragmatique avec le framework RSA).
 
 #### Parcours PyMC complet (20 notebooks, ~14h)
 
@@ -141,7 +141,6 @@ Les notebooks PyMC dans `PyMC/` reprennent l'intégralité des 20 modèles Infer
 Probas/
 ├── Infer-101.ipynb              # Introduction Python/C# (standalone)
 ├── Pyro_RSA_Hyperbole.ipynb     # Pragmatique linguistique (Python)
-├── PyMC-HMM-Trading-Alpha.ipynb # HMM gaussien pour trading (Python)
 ├── PyMC/                # Port PyMC complet des modeles Infer.NET (20 notebooks)
 │   ├── PyMC-1-Setup.ipynb ... PyMC-20-Decision-Sequential.ipynb
 │   └── (port en cours d'enrichissement)
@@ -284,13 +283,12 @@ Port Python complet des modèles Infer.NET, utilisant l'echantillonnage MCMC (NU
 | 19 | [PyMC-19-Decision-Expert-Systems](PyMC/PyMC-19-Decision-Expert-Systems.ipynb) | Systemes experts, Minimax, Minimax Regret, decisions robustes |
 | 20 | [PyMC-20-Decision-Sequential](PyMC/PyMC-20-Decision-Sequential.ipynb) | MDPs, itération de valeur/politique, bandits, POMDPs |
 
-## Applications standalone (3 notebooks)
+## Applications standalone (2 notebooks)
 
 | Notebook | Kernel | Contenu | Durée |
 | -------- | ------- | ------- | ----- |
 | [Infer-101](Infer-101.ipynb) | .NET (C#) + Python | Introduction Infer.NET, Two Coins, Cyclist | 1h |
 | [Pyro_RSA_Hyperbole](Pyro_RSA_Hyperbole.ipynb) | Python 3 | Rational Speech Acts, hyperboles | 30 min |
-| [PyMC-HMM-Trading-Alpha](PyMC-HMM-Trading-Alpha.ipynb) | Python 3 | HMM gaussien pour signaux de trading | 45 min |
 
 ## Prerequisites
 
@@ -364,7 +362,7 @@ Derriere chaque modèle de la série se cache un systeme réel déjà en product
 - **Item Response Theory** (notebook 5) est le moteur des tests adaptatifs comme le GMAT ou le GRE : la difficulte de chaque question est calibree probabilistiquement, et le test s'ajuste en temps réel au niveau estime du candidat.
 - **Les reseaux bayesiens** (notebooks 4, 7) fondent les systemes d'aide au diagnostic medical (de QMR-DT aux outils modernes) et le filtrage anti-spam : ils propagent l'incertitude entre symptomes, causes et observations.
 - **LDA / topic models** (notebook 9) structurent automatiquement de grands corpus — decouverte de thematiques dans des archives de presse, cartographie de la litterature scientifique, analyse de tickets support.
-- **Les HMM** (notebook 11, et `PyMC-HMM-Trading-Alpha`) detectent les regimes caches : phases de marche en finance, reconnaissance de la parole, segmentation de sequences biologiques.
+- **Les HMM** (notebook 11) detectent les regimes caches : phases de marche en finance, reconnaissance de la parole, segmentation de sequences biologiques.
 - **Les systemes de recommandation bayesiens** (notebook 12) sont la version « avec barre d'incertitude » du collaborative filtering de Netflix ou Amazon — utile pour decider quand explorer un nouvel item plutôt que d'exploiter une preference connue.
 - **Le crowdsourcing** (notebook 10) modelise la fiabilite de chaque annotateur (Mechanical Turk, labellisation de datasets) pour reconstruire la verite terrain malgre des votes bruites.
 - **La théorie de la décision et les MDPs** (notebooks 14-20) relient la série au controle sequentiel : gestion de stocks, maintenance predictive, et passerelle directe vers le [reinforcement learning](../RL/).

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -4,7 +4,7 @@ Pipeline d'entraînement complet pour modèles ML sur données financières OHLC
 
 ## Classification type (c) — standalone
 
-Les 4 notebooks de ce répertoire sont des **recherches indépendantes (c)** — analyses utilisant des données locales (yfinance, sklearn, PyTorch), sans dépendance QuantConnect Cloud.
+Les notebooks de ce répertoire sont des **recherches indépendantes (c)** — analyses utilisant des données locales (yfinance, sklearn, PyTorch), sans dépendance QuantConnect Cloud.
 
 | Notebook | Sujet | Type |
 |----------|-------|------|
@@ -12,6 +12,7 @@ Les 4 notebooks de ce répertoire sont des **recherches indépendantes (c)** —
 | `m3_har_asymmetric_semivariance.ipynb` | HAR semi-variance asymétrique | (c) |
 | `research_what_dl_can_predict.ipynb` | Ce que le DL peut prédire en finance | (c) |
 | `research_l4_decision_transformer.ipynb` | Évaluation Decision Transformer | (c) |
+| `hmm_alpha_research.ipynb` | HMM gaussien pour alpha trading (Broad Ch6 Ex4) | (c) |
 
 Classification complète : [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md)
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb
@@ -14,14 +14,14 @@
     "tags": []
    },
    "source": [
-    "# HMM Gaussian Alpha -- Generation de signaux directionnels par modeles de Markov caches\n",
+    "# HMM Gaussian Alpha -- Génération de signaux directionnels par modèles de Markov cachés\n",
     "\n",
-    "**Serie** : Probabilites appliquees au trading\n",
-    "**Duree estimee** : 90 minutes\n",
+    "**Série** : Probabilités appliquées au trading\n",
+    "**Durée estimee** : 90 minutes\n",
     "**Niveau** : Avance (graduate-level AI/ML)\n",
-    "**Prerequis** : Python 3.10+, notions de chaines de Markov, probabilites, trading\n",
+    "**Prerequis** : Python 3.10+, notions de chaînes de Markov, probabilités, trading\n",
     "\n",
-    "**Reference** : Broad, J. (2025). *Hands-On AI Trading with Python*, Chapitre 6, Exercice 4.\n",
+    "**Référence** : Broad, J. (2025). *Hands-On AI Trading with Python*, Chapitre 6, Exercice 4.\n",
     "\n",
     "---\n",
     "\n",
@@ -29,42 +29,42 @@
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
     "\n",
-    "1. Modeliser les regimes de marche avec des chaines de Markov cachees (HMM gaussiens)\n",
-    "2. Distinguer l'usage d'un HMM comme **source alpha** (signal directionnel) vs detecteur de regime\n",
-    "3. Implment un HMM a 2 etats (baseline Broad Ex4) puis 3 etats sur des donnees crypto\n",
-    "4. Valider la robustesse par walk-forward 5-fold x 4 seeds avec couts de transaction\n",
+    "1. Modéliser les régimes de marché avec des chaînes de Markov cachées (HMM gaussiens)\n",
+    "2. Distinguer l'usage d'un HMM comme **source alpha** (signal directionnel) vs detecteur de régime\n",
+    "3. Implment un HMM a 2 états (baseline Broad Ex4) puis 3 états sur des données crypto\n",
+    "4. Valider la robustesse par walk-forward 5-fold x 4 seeds avec coûts de transaction\n",
     "5. Produire un verdict explicite (BEATS / NO BEATS / INCONCLUSIVE) contre le benchmark buy-and-hold\n",
     "\n",
     "## Navigation\n",
     "\n",
     "| Precedent | Suivant |\n",
     "|-----------|--------|\n",
-    "| [Catalogue Probas](README.md) | -- |\n",
+    "| [Catalogue ML-Training](README.md) | -- |\n",
     "\n",
     "---\n",
     "\n",
     "## Introduction\n",
     "\n",
-    "Les **modeles de Markov caches (HMM)** sont des modeles probabilistes ou le systeme evolue entre etats non observes (\"caches\"), et les observations (rendements, volatilite) sont des emissions probabilistes depuis ces etats.\n",
+    "Les **modèles de Markov cachés (HMM)** sont des modèles probabilistes ou le système evolue entre états non observes (\"cachés\"), et les observations (rendements, volatilité) sont des emissions probabilistes depuis ces états.\n",
     "\n",
-    "En finance, les etats caches correspondent typiquement a des **regimes de marche** : tendance haussiere, tendance baissiere, range/consolidation. L'idee fondamentale est que les transitions entre regimes suivent une chaine de Markov -- l'etat futur depend seulement de l'etat present.\n",
+    "En finance, les états cachés correspondent typiquement a des **régimes de marché** : tendance haussière, tendance baissière, range/consolidation. L'idee fondamentale est que les transitions entre régimes suivent une chaîne de Markov -- l'état futur depend seulement de l'état present.\n",
     "\n",
-    "### HMM comme source alpha vs detecteur de regime\n",
+    "### HMM comme source alpha vs detecteur de régime\n",
     "\n",
-    "L'approche la plus courante consiste a utiliser l'HMM comme detecteur de regime pour piloter un melange d'experts (MoE). Ce notebook adopte une approche differente, inspiree de **Broad Ch6 Ex4** :\n",
+    "L'approche la plus courante consiste a utiliser l'HMM comme detecteur de régime pour piloter un melange d'experts (MoE). Ce notebook adopte une approche différente, inspiree de **Broad Ch6 Ex4** :\n",
     "\n",
-    "- **Source alpha** : les predictions d'etat de l'HMM generent directement des signaux long/short/flat\n",
-    "- L'etat avec la moyenne de rendement la plus elevee -> signal LONG\n",
-    "- L'etat avec la moyenne negative -> signal FLAT ou SHORT\n",
-    "- Pas de MoE, pas de modele secondaire -- l'HMM est le generateur de signal\n",
+    "- **Source alpha** : les predictions d'état de l'HMM generent directement des signaux long/short/flat\n",
+    "- L'état avec la moyenne de rendement la plus élevée -> signal LONG\n",
+    "- L'état avec la moyenne negative -> signal FLAT ou SHORT\n",
+    "- Pas de MoE, pas de modèle secondaire -- l'HMM est le generateur de signal\n",
     "\n",
     "### Plan du notebook\n",
     "\n",
-    "1. Chargement et preparation des donnees (BTC + ETH)\n",
+    "1. Chargement et préparation des données (BTC + ETH)\n",
     "2. Feature engineering pour l'HMM\n",
-    "3. HMM gaussien 2-etats (baseline Broad Ex4)\n",
-    "4. Generation de signaux et backtest in-sample\n",
-    "5. Extension a 3 etats avec selection par AIC/BIC\n",
+    "3. HMM gaussien 2-états (baseline Broad Ex4)\n",
+    "4. Génération de signaux et backtest in-sample\n",
+    "5. Extension a 3 états avec sélection par AIC/BIC\n",
     "6. Validation walk-forward 5-fold x 4 seeds\n",
     "7. Verdict explicite et extension multi-actif"
    ]
@@ -148,9 +148,9 @@
     "tags": []
    },
    "source": [
-    "## 2. Chargement et preparation des donnees\n",
+    "## 2. Chargement et préparation des données\n",
     "\n",
-    "Nous utilisons les donnees BTC-USD journalieres depuis le CSV Bitstamp (source principale) avec un fallback yfinance. Les donnees ETH-USD sont chargees via yfinance. Les deux series sont fusionnees sur l'index temporel pour les analyses multi-actif."
+    "Nous utilisons les données BTC-USD journalieres depuis le CSV Bitstamp (source principale) avec un fallback yfinance. Les données ETH-USD sont chargees via yfinance. Les deux séries sont fusionnees sur l'index temporel pour les analyses multi-actif."
    ]
   },
   {
@@ -234,7 +234,7 @@
    "source": [
     "### Chargement ETH et fusion du panel\n",
     "\n",
-    "Maintenant que les donnees BTC sont chargees, nous ajoutons l'ETH-USD et fusionnons les deux series sur l'index temporel commun."
+    "Maintenant que les données BTC sont chargees, nous ajoutons l'ETH-USD et fusionnons les deux séries sur l'index temporel commun."
    ]
   },
   {
@@ -321,7 +321,7 @@
    "source": [
     "### Chargement SOL-USD et extension du panel\n",
     "\n",
-    "Pour l'analyse multi-actif complete, nous ajoutons le SOL-USD (3e crypto-actif par capitalisation). Le panel resultant couvre BTC + ETH + SOL, permettant des features cross-asset et un HMM joint."
+    "Pour l'analyse multi-actif complète, nous ajoutons le SOL-USD (3e crypto-actif par capitalisation). Le panel resultant couvre BTC + ETH + SOL, permettant des features cross-asset et un HMM joint."
    ]
   },
   {
@@ -408,12 +408,12 @@
     "\n",
     "### Construction des variables pour le HMM\n",
     "\n",
-    "Le HMM gaussien utilise les observations pour inferer les etats caches. Nous construisons un jeu de features pertinent pour capturer les regimes de marche :\n",
+    "Le HMM gaussien utilise les observations pour inferer les états cachés. Nous construisons un jeu de features pertinent pour capturer les régimes de marché :\n",
     "\n",
     "| Feature | Formule | Rationale |\n",
     "|---------|---------|------------|\n",
     "| Log-rendement | $r_t = \\ln(P_t / P_{t-1})$ | Signal directionnel brut |\n",
-    "| Volatilite realisee 20j | $\\sigma_{20} = \\sqrt{\\sum_{i=0}^{19} r_{t-i}^2}$ | Regime de volatilite |\n",
+    "| Volatilité realisee 20j | $\\sigma_{20} = \\sqrt{\\sum_{i=0}^{19} r_{t-i}^2}$ | Régime de volatilité |\n",
     "| Momentum 5j | $m_5 = \\sum_{i=0}^{4} r_{t-i}$ | Tendance court terme |\n",
     "\n",
     "La **normalisation** des features est essentielle pour la convergence de l'algorithme EM du HMM gaussien (Broad Ch6 recommande le StandardScaler)."
@@ -534,14 +534,14 @@
    "source": [
     "### Analyse descriptive des features\n",
     "\n",
-    "Les 9 features construites couvrent 1562 jours d'observation apres elimination des NaN des fenetres glissantes. Les statistiques descriptives revelent :\n",
+    "Les 9 features construites couvrent 1562 jours d'observation apres elimination des NaN des fenêtres glissantes. Les statistiques descriptives revelent :\n",
     "\n",
     "- **btc_ret** : rendement journalier moyen de +0.125%, avec un ecart-type de 3.28% et des extremes de -16.9% a +17.8% (queues lourdes typiques des crypto-actifs)\n",
-    "- **btc_vol20** : volatilite 20j oscillant entre 0.6% et 7.0% par jour, avec des pics correspondent aux periodes de stress\n",
+    "- **btc_vol20** : volatilité 20j oscillant entre 0.6% et 7.0% par jour, avec des pics correspondent aux periodes de stress\n",
     "- **btc_eth_corr** : correlation moyenne de 0.82 entre BTC et ETH, confirmant un mouvement structurellement lie\n",
     "- **btc_sol_corr** : correlation plus faible (0.59) avec SOL, offrant un potentiel de diversification\n",
     "\n",
-    "Le graphe suivant visualise l'evolution temporelle du prix BTC, des rendements et de la volatilite pour identifier visuellement les regimes de marche."
+    "Le graphe suivant visualise l'evolution temporelle du prix BTC, des rendements et de la volatilité pour identifier visuellement les régimes de marché."
    ]
   },
   {
@@ -558,18 +558,18 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Exploration des features et selection\n",
+    "### Exercice 1 : Exploration des features et sélection\n",
     "\n",
-    "**Objectif** : Construire un jeu de features alternatif et observer l'impact sur la separation visuelle des regimes de marche.\n",
+    "**Objectif** : Construire un jeu de features alternatif et observer l'impact sur la separation visuelle des régimes de marché.\n",
     "\n",
-    "**Contexte** : Les features actuelles incluent le log-rendement, la volatilite 20j et le momentum 5j. D'autres combinaisons pourraient mieux capturer les regimes.\n",
+    "**Contexte** : Les features actuelles incluent le log-rendement, la volatilité 20j et le momentum 5j. D'autres combinaisons pourraient mieux capturer les régimes.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Essayez d'ajouter la volatilite 5j (`returns.rolling(5).std()`) et le volume de rendement (`returns.abs().rolling(10).mean()`)\n",
+    "- # Indice 1 : Essayez d'ajouter la volatilité 5j (`returns.rolling(5).std()`) et le volume de rendement (`returns.abs().rolling(10).mean()`)\n",
     "- # Indice 2 : Utilisez `features.describe()` pour verifier les statistiques descriptives\n",
-    "- # Etape 1 : Ajouter au moins 2 nouvelles features au DataFrame `features`\n",
-    "- # Etape 2 : Verifier les correlations entre features avec `features.corr()`\n",
-    "- # Etape 3 : Selectionner un sous-ensemble non-correle pour le HMM"
+    "- # Étape 1 : Ajouter au moins 2 nouvelles features au DataFrame `features`\n",
+    "- # Étape 2 : Verifier les correlations entre features avec `features.corr()`\n",
+    "- # Étape 3 : Selectionner un sous-ensemble non-correle pour le HMM"
    ]
   },
   {
@@ -677,9 +677,9 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Distribution des features\n",
+    "### Interprétation : Distribution des features\n",
     "\n",
-    "Les log-rendements BTC montrent la caracteristique \"fat tails\" typique des crypto-actifs : une distribution centree sur zero mais avec des outliers frequents (crashes et rallies). La volatilite 20j oscille entre periodes calmes et pic de stress, ce qui est precisement ce que le HMM doit capturer comme regimes distincts."
+    "Les log-rendements BTC montrent la caractéristique \"fat tails\" typique des crypto-actifs : une distribution centree sur zero mais avec des outliers frequents (crashes et rallies). La volatilité 20j oscille entre periodes calmes et pic de stress, ce qui est precisement ce que le HMM doit capturer comme régimes distincts."
    ]
   },
   {
@@ -696,9 +696,9 @@
     "tags": []
    },
    "source": [
-    "### Entrainement et decodage des etats\n",
+    "### Entrainement et décodage des états\n",
     "\n",
-    "Nous normalisons les features et fittons le HMM. L'algorithme EM (Baum-Welch) estibe les parametres, puis Viterbi decode la sequence d'etats la plus probable."
+    "Nous normalisons les features et fittons le HMM. L'algorithme EM (Baum-Welch) estibe les paramètres, puis Viterbi decode la sequence d'états la plus probable."
    ]
   },
   {
@@ -715,19 +715,19 @@
     "tags": []
    },
    "source": [
-    "## 4. HMM gaussien a 2 etats -- Baseline Broad Ex4\n",
+    "## 4. HMM gaussien a 2 états -- Baseline Broad Ex4\n",
     "\n",
-    "Conformement a l'exercice 4 du chapitre 6 de Broad, nous commencons par un **HMM gaussien a 2 etats**. Le choix de 2 etats est la configuration minimale : un etat \"bull\" (rendement positif, faible volatilite) et un etat \"bear\" (rendement negatif, forte volatilite).\n",
+    "Conformement a l'exercice 4 du chapitre 6 de Broad, nous commencons par un **HMM gaussien a 2 états**. Le choix de 2 états est la configuration minimale : un état \"bull\" (rendement positif, faible volatilité) et un état \"bear\" (rendement negatif, forte volatilité).\n",
     "\n",
-    "### Modele\n",
+    "### Modèle\n",
     "\n",
     "Un HMM gaussien est defini par le triplet $\\lambda = (A, B, \\pi)$ :\n",
     "\n",
     "- **A** : matrice de transition $a_{ij} = P(s_{t+1} = j | s_t = i)$\n",
     "- **B** : distributions d'emission $b_i(x) = \\mathcal{N}(x | \\mu_i, \\Sigma_i)$\n",
-    "- $\\pi$ : distribution initiale des etats\n",
+    "- $\\pi$ : distribution initiale des états\n",
     "\n",
-    "L'apprentissage se fait par l'algorithme **EM (Baum-Welch)**, et l'inference des etats caches par **Viterbi** (chemin le plus probable)."
+    "L'apprentissage se fait par l'algorithme **EM (Baum-Welch)**, et l'inference des états cachés par **Viterbi** (chemin le plus probable)."
    ]
   },
   {
@@ -826,16 +826,16 @@
     "tags": []
    },
    "source": [
-    "### Visualisation des etats decales\n",
+    "### Visualisation des états decales\n",
     "\n",
-    "L'HMM a converge en 200 iterations avec un log-likelihood de -5441.67. Les deux etats se distinguent clairement par la volatilite :\n",
+    "L'HMM a converge en 200 iterations avec un log-likelihood de -5441.67. Les deux états se distinguent clairement par la volatilité :\n",
     "\n",
-    "| Etat | Occupation | Moy. rendement | Moy. volatilite | Interpretation |\n",
+    "| État | Occupation | Moy. rendement | Moy. volatilité | Interprétation |\n",
     "|------|-----------|---------------|-----------------|----------------|\n",
-    "| 0 | 46.0% | -0.030 | -0.811 | Regime calme (faible vol, rendement legerement negatif) |\n",
-    "| 1 | 54.0% | +0.026 | +0.703 | Regime actif (vol plus elevee, rendement positif) |\n",
+    "| 0 | 46.0% | -0.030 | -0.811 | Régime calme (faible vol, rendement legerement negatif) |\n",
+    "| 1 | 54.0% | +0.026 | +0.703 | Régime actif (vol plus élevée, rendement positif) |\n",
     "\n",
-    "Les probabilites de transition diagonales (0.969 et 0.973) indiquent des regimes persistants, avec une duree moyenne d'environ 30-37 jours. La cellule suivante projette les etats decales sur la courbe de prix BTC pour visualiser les periodes de chaque regime."
+    "Les probabilités de transition diagonales (0.969 et 0.973) indiquent des régimes persistants, avec une durée moyenne d'environ 30-37 jours. La cellule suivante projette les états decales sur la courbe de prix BTC pour visualiser les periodes de chaque régime."
    ]
   },
   {
@@ -912,7 +912,7 @@
    "source": [
     "### Visualisation de la performance\n",
     "\n",
-    "Comparaison graphique des rendements cumules entre la strategie HMM et le buy-and-hold."
+    "Comparaison graphique des rendements cumules entre la stratégie HMM et le buy-and-hold."
    ]
   },
   {
@@ -929,18 +929,18 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Etats caches du HMM a 2 etats\n",
+    "### Interprétation : États cachés du HMM a 2 états\n",
     "\n",
-    "Le HMM a 2 etats separe typiquement le marche en deux regimes :\n",
+    "Le HMM a 2 états separe typiquement le marché en deux régimes :\n",
     "\n",
-    "| Etat | Caracteristique | Interpretation |\n",
+    "| État | Caractéristique | Interprétation |\n",
     "|------|-----------------|----------------|\n",
-    "| Etat 0 | Moyenne de rendement positive (en espace standardise) | Regime bull / tendance haussiere |\n",
-    "| Etat 1 | Moyenne de rendement negative | Regime bear / correction |\n",
+    "| État 0 | Moyenne de rendement positive (en espace standardise) | Régime bull / tendance haussière |\n",
+    "| État 1 | Moyenne de rendement negative | Régime bear / correction |\n",
     "\n",
-    "La **matrice de transition** indique la persistance de chaque regime : des probabilites diagonales elevees (proches de 1) signifient que les regimes sont stables, ce qui est desirable pour la generation de signaux. Des regimes trop volatils (transitions frequentes) produisent trop de trades.\n",
+    "La **matrice de transition** indique la persistance de chaque régime : des probabilités diagonales élevées (proches de 1) signifient que les régimes sont stables, ce qui est desirable pour la génération de signaux. Des régimes trop volatils (transitions frequentes) produisent trop de trades.\n",
     "\n",
-    "> **Note technique** : L'assignation etat 0 = bull et etat 1 = bear n'est pas garantie -- l'algorithme EM peut inverser les labels. Il faut toujours verifier les moyennes pour identifier l'etat \"long\"."
+    "> **Note technique** : L'assignation état 0 = bull et état 1 = bear n'est pas garantie -- l'algorithme EM peut inverser les labels. Il faut toujours verifier les moyennes pour identifier l'état \"long\"."
    ]
   },
   {
@@ -957,14 +957,14 @@
     "tags": []
    },
    "source": [
-    "## 5. Generation du signal alpha\n",
+    "## 5. Génération du signal alpha\n",
     "\n",
-    "La conversion des etats caches en signal de trading suit la logique de **source alpha** (Broad Ex4) :\n",
+    "La conversion des états cachés en signal de trading suit la logique de **source alpha** (Broad Ex4) :\n",
     "\n",
-    "- Etat avec la moyenne de rendement la plus elevee -> position LONG (signal = +1)\n",
-    "- Etat avec la moyenne la plus basse -> position FLAT (signal = 0)\n",
+    "- État avec la moyenne de rendement la plus élevée -> position LONG (signal = +1)\n",
+    "- État avec la moyenne la plus basse -> position FLAT (signal = 0)\n",
     "\n",
-    "Le rendement strategie est simplement : $r^{strat}_t = signal_t \\times r_t$\n",
+    "Le rendement stratégie est simplement : $r^{strat}_t = signal_t \\times r_t$\n",
     "\n",
     "Attention : cette evaluation est **in-sample** et represente un plafond de performance. La validation out-of-sample sera realisee en section 7."
    ]
@@ -985,7 +985,7 @@
    "source": [
     "### Comparaison AIC/BIC\n",
     "\n",
-    "Nous comparons les modeles a 2, 3 et 4 etats pour determiner la complexite optimale."
+    "Nous comparons les modèles a 2, 3 et 4 états pour determiner la complexite optimale."
    ]
   },
   {
@@ -1002,9 +1002,9 @@
     "tags": []
    },
    "source": [
-    "### Decodage et signaux 3 etats\n",
+    "### Décodage et signaux 3 états\n",
     "\n",
-    "Entraainement du HMM a 3 etats et generation des signaux long/short/flat."
+    "Entraainement du HMM a 3 états et génération des signaux long/short/flat."
    ]
   },
   {
@@ -1090,9 +1090,9 @@
    "source": [
     "### Performance in-sample\n",
     "\n",
-    "Les resultats in-sample montrent que la strategie HMM 2 etats genere un Sharpe de 0.685, legerement inferieur au buy-and-hold (0.728), pour un rendement cumule de 167.1% contre 194.9%. Avec seulement 43 trades sur 4 ans, la strategie est peu active -- le HMM identifie des regimes persistants et change rarement de position.\n",
+    "Les résultats in-sample montrent que la stratégie HMM 2 états genere un Sharpe de 0.685, legerement inferieur au buy-and-hold (0.728), pour un rendement cumule de 167.1% contre 194.9%. Avec seulement 43 trades sur 4 ans, la stratégie est peu active -- le HMM identifie des régimes persistants et change rarement de position.\n",
     "\n",
-    "Le graphe suivant compare les rendements cumules de la strategie HMM et du buy-and-hold sur toute la periode. Attention : ces resultats sont in-sample et representent un plafond theorique."
+    "Le graphe suivant compare les rendements cumules de la stratégie HMM et du buy-and-hold sur toute la periode. Attention : ces résultats sont in-sample et representent un plafond théorique."
    ]
   },
   {
@@ -1109,18 +1109,18 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Generation de signaux avec seuils adaptes\n",
+    "### Exercice 2 : Génération de signaux avec seuils adaptes\n",
     "\n",
-    "**Objectif** : Implementer une strategie de signal avec un seuil de probabilite filtre pour reduire les faux signaux.\n",
+    "**Objectif** : Implementer une stratégie de signal avec un seuil de probabilité filtre pour reduire les faux signaux.\n",
     "\n",
-    "**Contexte** : La strategie actuelle utilise simplement l'etat decode par Viterbi comme signal. En pratique, on peut utiliser les probabilites a posteriori des etats pour filtrer les signaux a faible confiance.\n",
+    "**Contexte** : La stratégie actuelle utilise simplement l'état decode par Viterbi comme signal. En pratique, on peut utiliser les probabilités a posteriori des états pour filtrer les signaux a faible confiance.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Utilisez `model_2s.predict_proba(X_scaled)` pour obtenir les probabilites d'appartenance a chaque etat\n",
-    "- # Indice 2 : Ne genere un signal que si la probabilite de l'etat dominant depasse un seuil (ex: 0.7)\n",
-    "- # Etape 1 : Calculer les probabilites a posteriori pour chaque observation\n",
-    "- # Etape 2 : Definir un seuil de confiance et filtrer les signaux\n",
-    "- # Etape 3 : Comparer le nombre de trades et la performance avec la strategie sans filtre"
+    "- # Indice 1 : Utilisez `model_2s.predict_proba(X_scaled)` pour obtenir les probabilités d'appartenance a chaque état\n",
+    "- # Indice 2 : Ne genere un signal que si la probabilité de l'état dominant depasse un seuil (ex: 0.7)\n",
+    "- # Étape 1 : Calculer les probabilités a posteriori pour chaque observation\n",
+    "- # Étape 2 : Definir un seuil de confiance et filtrer les signaux\n",
+    "- # Étape 3 : Comparer le nombre de trades et la performance avec la stratégie sans filtre"
    ]
   },
   {
@@ -1233,15 +1233,15 @@
     "tags": []
    },
    "source": [
-    "## 6. Extension a 3 etats\n",
+    "## 6. Extension a 3 états\n",
     "\n",
-    "Broad Ch6 recommande de commencer avec 2 etats et d'augmenter a 3 si necessaire. Un troisieme etat peut capturer un regime de range/consolidation distinct des tendances haussieres et baissieres.\n",
+    "Broad Ch6 recommande de commencer avec 2 états et d'augmenter a 3 si necessaire. Un troisieme état peut capturer un régime de range/consolidation distinct des tendances haussieres et baissieres.\n",
     "\n",
-    "### Selection du nombre d'etats\n",
+    "### Sélection du nombre d'états\n",
     "\n",
-    "Nous comparons les modeles avec les criteres d'information :\n",
+    "Nous comparons les modèles avec les critères d'information :\n",
     "\n",
-    "- **AIC** (Akaike) : $-2 \\ln L + 2k$ -- penalise le nombre de parametres\n",
+    "- **AIC** (Akaike) : $-2 \\ln L + 2k$ -- penalise le nombre de paramètres\n",
     "- **BIC** (Bayes) : $-2 \\ln L + k \\ln(n)$ -- penalisation plus forte pour grands echantillons"
    ]
   },
@@ -1347,11 +1347,11 @@
     "tags": []
    },
    "source": [
-    "## 6b. Extension a 4 etats\n",
+    "## 6b. Extension a 4 états\n",
     "\n",
-    "L'AIC et le BIC selectionnent tous deux 4 etats comme configuration optimale. Un 4e etat peut capturer un regime de volatilite extreme (crash ou rally) distinct des regimes \"calme\", \"tendance\", et \"correction\" du modele a 3 etats.\n",
+    "L'AIC et le BIC selectionnent tous deux 4 états comme configuration optimale. Un 4e état peut capturer un régime de volatilité extreme (crash ou rally) distinct des régimes \"calme\", \"tendance\", et \"correction\" du modèle a 3 états.\n",
     "\n",
-    "### HMM a 4 etats : decodage et signaux"
+    "### HMM a 4 états : décodage et signaux"
    ]
   },
   {
@@ -1484,9 +1484,9 @@
     "tags": []
    },
    "source": [
-    "### Execution walk-forward : BTC avec 3 etats\n",
+    "### Execution walk-forward : BTC avec 3 états\n",
     "\n",
-    "Meme protocole avec 3 etats pour comparer."
+    "Même protocole avec 3 états pour comparer."
    ]
   },
   {
@@ -1572,7 +1572,7 @@
    "source": [
     "### Synthese et edge cross-seed\n",
     "\n",
-    "Aggregation des resultats par configuration et calcul de l'edge (ratio mean/std du Sharpe)."
+    "Aggregation des résultats par configuration et calcul de l'edge (ratio mean/std du Sharpe)."
    ]
   },
   {
@@ -1672,13 +1672,13 @@
    "source": [
     "## 7. Validation walk-forward\n",
     "\n",
-    "L'evaluation in-sample est trompeuse car le HMM a ete fitte sur les memes donnees qu'il predit. Pour mesurer la veritable capacite predictive, nous implementons une validation **walk-forward** :\n",
+    "L'evaluation in-sample est trompeuse car le HMM a ete fitte sur les mêmes données qu'il predit. Pour mesurer la veritable capacite predictive, nous implementons une validation **walk-forward** :\n",
     "\n",
-    "- **Fenetre d'entrainement expansive** : a chaque fold, on utilise toutes les donnees passees\n",
-    "- **Fenetre de test fixe** : 6 mois de donnees non-vues\n",
+    "- **Fenêtre d'entrainement expansive** : a chaque fold, on utilise toutes les données passees\n",
+    "- **Fenêtre de test fixe** : 6 mois de données non-vues\n",
     "- **4 seeds** (0, 1, 7, 42) pour capturer la stochasticite de l'initialisation EM\n",
-    "- **5 folds** pour couvrir differentes conditions de marche\n",
-    "- **Couts de transaction** : 10 bps aller-retour (crypto)\n",
+    "- **5 folds** pour couvrir différentes conditions de marché\n",
+    "- **Coûts de transaction** : 10 bps aller-retour (crypto)\n",
     "\n",
     "### Metriques\n",
     "\n",
@@ -1842,13 +1842,13 @@
     "tags": []
    },
    "source": [
-    "## 7b. Analyse de persistance des regimes\n",
+    "## 7b. Analyse de persistance des régimes\n",
     "\n",
-    "La persistance d'un regime est mesuree par les elements diagonaux de la matrice de transition $a_{ii} = P(s_{t+1} = i | s_t = i)$. Une persistance elevee signifie que le regime est stable, ce qui est desirable pour la generation de signaux (moins de trades, moins de couts de transaction).\n",
+    "La persistance d'un régime est mesuree par les elements diagonaux de la matrice de transition $a_{ii} = P(s_{t+1} = i | s_t = i)$. Une persistance élevée signifie que le régime est stable, ce qui est desirable pour la génération de signaux (moins de trades, moins de coûts de transaction).\n",
     "\n",
-    "La **duree moyenne d'un regime** se calcule comme : $\\bar{d}_i = \\frac{1}{1 - a_{ii}}$\n",
+    "La **durée moyenne d'un régime** se calcule comme : $\\bar{d}_i = \\frac{1}{1 - a_{ii}}$\n",
     "\n",
-    "Par exemple, si $a_{ii} = 0.97$, le regime dure en moyenne $1/(1-0.97) = 33$ jours."
+    "Par exemple, si $a_{ii} = 0.97$, le régime dure en moyenne $1/(1-0.97) = 33$ jours."
    ]
   },
   {
@@ -1865,9 +1865,9 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Persistence et duree des regimes\n",
+    "### Interprétation : Persistance et durée des régimes\n",
     "\n",
-    "Des valeurs de persistence elevees (P(stay) > 0.95) indiquent des regimes stables. Les regimes avec une faible persistence generent davantage de changements d'etat, ce qui se traduit par plus de trades et des couts de transaction plus eleves. La configuration optimale devrait maximiser la persistence tout en capturant les regimes distincts."
+    "Des valeurs de persistance élevées (P(stay) > 0.95) indiquent des régimes stables. Les régimes avec une faible persistance generent davantage de changements d'état, ce qui se traduit par plus de trades et des coûts de transaction plus élevés. La configuration optimale devrait maximiser la persistance tout en capturant les régimes distincts."
    ]
   },
   {
@@ -2040,7 +2040,7 @@
     "tags": []
    },
    "source": [
-    "### Resultats ETH et tableau recapitulatif\n",
+    "### Résultats ETH et tableau recapitulatif\n",
     "\n",
     "Execution du walk-forward sur ETH-USD et comparaison finale cross-asset."
    ]
@@ -2059,7 +2059,7 @@
     "tags": []
    },
    "source": [
-    "### Execution walk-forward : BTC avec 2 etats"
+    "### Execution walk-forward : BTC avec 2 états"
    ]
   },
   {
@@ -2173,11 +2173,11 @@
     "tags": []
    },
    "source": [
-    "### Walk-forward BTC 3 etats\n",
+    "### Walk-forward BTC 3 états\n",
     "\n",
-    "Le walk-forward a 2 etats est termine avec 20 combinaisons valides sur 20. On observe que le Sharpe moyen (3.385) est superieur au B&H (3.103) mais le cum_return moyen est negatif (-20.27%), ce qui signale une incoherence entre la mesure de risque ajuste et le rendement absolu. Les frequents warnings de non-convergence de l'algorithme EM montrent que le modele a 2 etats est parfois instable.\n",
+    "Le walk-forward a 2 états est termine avec 20 combinaisons valides sur 20. On observe que le Sharpe moyen (3.385) est superieur au B&H (3.103) mais le cum_return moyen est negatif (-20.27%), ce qui signale une incoherence entre la mesure de risque ajuste et le rendement absolu. Les frequents warnings de non-convergence de l'algorithme EM montrent que le modèle a 2 états est parfois instable.\n",
     "\n",
-    "La cellule suivante execute le meme protocole walk-forward avec 3 etats pour comparer."
+    "La cellule suivante execute le même protocole walk-forward avec 3 états pour comparer."
    ]
   },
   {
@@ -2261,9 +2261,9 @@
     "tags": []
    },
    "source": [
-    "### Walk-forward BTC 3 etats et synthese\n",
+    "### Walk-forward BTC 3 états et synthese\n",
     "\n",
-    "Meme protocole avec 3 etats, puis comparaison des deux configurations."
+    "Même protocole avec 3 états, puis comparaison des deux configurations."
    ]
   },
   {
@@ -2383,7 +2383,7 @@
    "source": [
     "### Synthese et calcul du verdict\n",
     "\n",
-    "Le walk-forward a 4 etats (optimal selon AIC/BIC) est termine. Les resultats montrent que les modeles a plus d'etats produisent des Sharpe ratios plus eleves mais avec une plus grande variance inter-seeds. La cellule suivante regroupe les verdicts des trois configurations (2, 3 et 4 etats) et calcule l'**edge cross-seed** (ratio mean/std du Sharpe) pour determiner si la strategie bat significativement le buy-and-hold. Le seuil de validation est un edge >= 2 sigma."
+    "Le walk-forward a 4 états (optimal selon AIC/BIC) est termine. Les résultats montrent que les modèles a plus d'états produisent des Sharpe ratios plus élevés mais avec une plus grande variance inter-seeds. La cellule suivante regroupe les verdicts des trois configurations (2, 3 et 4 états) et calcule l'**edge cross-seed** (ratio mean/std du Sharpe) pour determiner si la stratégie bat significativement le buy-and-hold. Le seuil de validation est un edge >= 2 sigma."
    ]
   },
   {
@@ -2400,18 +2400,18 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Analyse de sensibilite aux couts de transaction\n",
+    "### Exercice 3 : Analyse de sensibilite aux coûts de transaction\n",
     "\n",
-    "**Objectif** : Etudier l'impact des couts de transaction sur la performance walk-forward en faisant varier le parametre `cost_bps`.\n",
+    "**Objectif** : Étudier l'impact des coûts de transaction sur la performance walk-forward en faisant varier le paramètre `cost_bps`.\n",
     "\n",
-    "**Contexte** : Les couts de transaction en crypto varient selon l'exchange et la taille des ordres. La valeur par defaut est 10 bps, mais certains brokers facturent plus.\n",
+    "**Contexte** : Les coûts de transaction en crypto varient selon l'exchange et la taille des ordres. La valeur par défaut est 10 bps, mais certains brokers facturent plus.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Appelez `walk_forward_hmm()` avec differentes valeurs de `cost_bps` : [0, 5, 10, 20, 50]\n",
+    "- # Indice 1 : Appelez `walk_forward_hmm()` avec différentes valeurs de `cost_bps` : [0, 5, 10, 20, 50]\n",
     "- # Indice 2 : Pour chaque valeur, calculez le Sharpe moyen et le nombre de trades moyen\n",
-    "- # Etape 1 : Executer le walk-forward avec cost_bps=0 (pas de couts) comme reference\n",
-    "- # Etape 2 : Executer avec cost_bps=5, 10, 20, 50\n",
-    "- # Etape 3 : Tracer la courbe Sharpe vs cost_bps et identifier le seuil de rentabilite"
+    "- # Étape 1 : Executer le walk-forward avec cost_bps=0 (pas de coûts) comme référence\n",
+    "- # Étape 2 : Executer avec cost_bps=5, 10, 20, 50\n",
+    "- # Étape 3 : Tracer la courbe Sharpe vs cost_bps et identifier le seuil de rentabilite"
    ]
   },
   {
@@ -2556,13 +2556,13 @@
    "source": [
     "## 8. Verdict explicite\n",
     "\n",
-    "Conformement aux criteres de validation du projet (cf. CLAUDE.md section G.2), un verdict de performance doit etre base sur des preuves statistiques robustes :\n",
+    "Conformement aux critères de validation du projet (cf. CLAUDE.md section G.2), un verdict de performance doit etre base sur des preuves statistiques robustes :\n",
     "\n",
-    "| Verdict | Critere |\n",
+    "| Verdict | Critère |\n",
     "|---------|----------|\n",
-    "| **BEATS** | Sharpe moyen > 0, edge >= 2 sigma, Sharpe strategie > Sharpe B&H |\n",
+    "| **BEATS** | Sharpe moyen > 0, edge >= 2 sigma, Sharpe stratégie > Sharpe B&H |\n",
     "| **NO BEATS** | Sharpe moyen <= 0 OU edge < 2 sigma |\n",
-    "| **INCONCLUSIVE** | Resultats borderline (0 < edge < 2 sigma) |"
+    "| **INCONCLUSIVE** | Résultats borderline (0 < edge < 2 sigma) |"
    ]
   },
   {
@@ -2685,7 +2685,7 @@
    "source": [
     "## 9. Extension multi-actif : ETH\n",
     "\n",
-    "Pour evaluer la robustesse cross-asset de l'alpha HMM, nous appliquons le meme pipeline walk-forward sur ETH-USD. Une strategie robuste devrait montrer des resultats positifs sur au moins deux actifs du meme univers (crypto)."
+    "Pour evaluer la robustesse cross-asset de l'alpha HMM, nous appliquons le même pipeline walk-forward sur ETH-USD. Une stratégie robuste devrait montrer des résultats positifs sur au moins deux actifs du même univers (crypto)."
    ]
   },
   {
@@ -2814,11 +2814,11 @@
    "source": [
     "## 9b. Extension a SOL-USD\n",
     "\n",
-    "Nous ajoutons SOL-USD au panel walk-forward (2, 3 et 4 etats) pour tester la robustesse sur un 3e crypto-actif plus recent et plus volatil. SOL dispose de moins d'historique (depuis 2020), ce qui reduit le nombre de folds walk-forward exploitables.\n",
+    "Nous ajoutons SOL-USD au panel walk-forward (2, 3 et 4 états) pour tester la robustesse sur un 3e crypto-actif plus recent et plus volatil. SOL dispose de moins d'historique (depuis 2020), ce qui reduit le nombre de folds walk-forward exploitables.\n",
     "\n",
     "## 9c. HMM joint multi-actif\n",
     "\n",
-    "Un HMM joint utilise les features cross-asset (rendements BTC+ETH+SOL, correlations glissantes, momentum relatif) pour detecter les regimes a l'echelle du panel crypto. Le signal est ensuite applique au BTC-USD seul. L'hypothese est qu'un modele joint capture des transitions de regime que les modeles mono-actif ne voient pas."
+    "Un HMM joint utilise les features cross-asset (rendements BTC+ETH+SOL, correlations glissantes, momentum relatif) pour detecter les régimes a l'échelle du panel crypto. Le signal est ensuite applique au BTC-USD seul. L'hypothèse est qu'un modèle joint capture des transitions de régime que les modèles mono-actif ne voient pas."
    ]
   },
   {
@@ -3175,33 +3175,33 @@
     "\n",
     "### Recapitulatif\n",
     "\n",
-    "Ce notebook a implemente un pipeline complet d'alpha generation par HMM gaussiens sur un panel crypto a 3 actifs (BTC-USD, ETH-USD, SOL-USD) :\n",
+    "Ce notebook a implemente un pipeline complet d'alpha génération par HMM gaussiens sur un panel crypto a 3 actifs (BTC-USD, ETH-USD, SOL-USD) :\n",
     "\n",
-    "| Etape | Contenu |\n",
+    "| Étape | Contenu |\n",
     "|-------|----------|\n",
-    "| 1. Donnees | BTC-USD (Bitstamp) + ETH-USD + SOL-USD (yfinance), log-rendements journaliers |\n",
-    "| 2. Features | Rendements multi-actif, volatilite 20j, momentum 5j, correlations glissantes, momentum relatif |\n",
-    "| 3. Baseline | HMM 2 etats (Broad Ch6 Ex4) -- source alpha directionnelle |\n",
-    "| 4. Extension | HMM 3 etats (long/short/flat) et 4 etats (optimal AIC/BIC) |\n",
-    "| 5. Persistence | Analyse de la duree moyenne des regimes via la matrice de transition |\n",
-    "| 6. Validation | Walk-forward 5-fold x 4 seeds, couts de transaction 10 bps, verdict edge >= 2 sigma |\n",
-    "| 7. Multi-actif | SOL-USD (2/3/4 etats) + HMM joint cross-asset |\n",
+    "| 1. Données | BTC-USD (Bitstamp) + ETH-USD + SOL-USD (yfinance), log-rendements journaliers |\n",
+    "| 2. Features | Rendements multi-actif, volatilité 20j, momentum 5j, correlations glissantes, momentum relatif |\n",
+    "| 3. Baseline | HMM 2 états (Broad Ch6 Ex4) -- source alpha directionnelle |\n",
+    "| 4. Extension | HMM 3 états (long/short/flat) et 4 états (optimal AIC/BIC) |\n",
+    "| 5. Persistance | Analyse de la durée moyenne des régimes via la matrice de transition |\n",
+    "| 6. Validation | Walk-forward 5-fold x 4 seeds, coûts de transaction 10 bps, verdict edge >= 2 sigma |\n",
+    "| 7. Multi-actif | SOL-USD (2/3/4 états) + HMM joint cross-asset |\n",
     "\n",
     "### Points cles\n",
     "\n",
-    "1. **Selection AIC/BIC** : les deux criteres selectionnent 4 etats comme configuration optimale sur BTC. Le 4e etat capture un regime de volatilite extreme distinct des regimes classiques\n",
-    "2. **Persistence des regimes** : les modeles a 2 etats montrent la persistence la plus elevee (P(stay) > 0.96), tandis que les modeles a 4 etats ont des regimes plus courts mais plus differencies\n",
+    "1. **Sélection AIC/BIC** : les deux critères selectionnent 4 états comme configuration optimale sur BTC. Le 4e état capture un régime de volatilité extreme distinct des régimes classiques\n",
+    "2. **Persistance des régimes** : les modèles a 2 états montrent la persistance la plus élevée (P(stay) > 0.96), tandis que les modèles a 4 états ont des régimes plus courts mais plus differencies\n",
     "3. **Sensibilite aux seeds** : l'initialisation EM est stochastique. La validation multi-seeds (0, 1, 7, 42) est indispensable pour mesurer la robustesse reelle\n",
-    "4. **Couts de transaction** : en crypto (10 bps aller-retour), les frequents changements d'etat reduisent significativement le Sharpe net, en particulier pour les modeles a 4 etats\n",
-    "5. **HMM joint** : l'utilisation de features cross-asset (correlations BTC-ETH, BTC-SOL, momentum relatif) ne montre pas d'amelioration significative par rapport aux modeles mono-actif\n",
+    "4. **Coûts de transaction** : en crypto (10 bps aller-retour), les frequents changements d'état reduisent significativement le Sharpe net, en particulier pour les modèles a 4 états\n",
+    "5. **HMM joint** : l'utilisation de features cross-asset (correlations BTC-ETH, BTC-SOL, momentum relatif) ne montre pas d'amelioration significative par rapport aux modèles mono-actif\n",
     "\n",
     "### Limites et pistes d'amelioration\n",
     "\n",
-    "- **Horizon temporel** : les HMM sont des modeles a un pas de temps. Ajouter des features retardees (lagged features) peut ameliorer la prediction\n",
-    "- **Emissions non gaussiennes** : les rendements crypto ont des queues lourdes. Un HMM a melange de Student ou un HMM a regime-switching avec volatilite stochastique serait plus adapte\n",
-    "- **Fenetre glissante** : remplacer la fenetre expansive par une fenetre glissante (ex: 252 jours) pour s'adapter aux changements de regime structurels\n",
-    "- **Ensemble de HMM** : combiner les predictions de plusieurs HMM (differents seeds, differents nombres d'etats) pour reduire la variance\n",
-    "- **Horizons multiples** : appliquer le signal HMM sur differentes horizons de rebalancement (journalier, hebdomadaire) pour optimiser le ratio signal/bruit\n",
+    "- **Horizon temporel** : les HMM sont des modèles a un pas de temps. Ajouter des features retardees (lagged features) peut ameliorer la prediction\n",
+    "- **Emissions non gaussiennes** : les rendements crypto ont des queues lourdes. Un HMM a melange de Student ou un HMM a régime-switching avec volatilité stochastique serait plus adapte\n",
+    "- **Fenêtre glissante** : remplacer la fenêtre expansive par une fenêtre glissante (ex: 252 jours) pour s'adapter aux changements de régime structurels\n",
+    "- **Ensemble de HMM** : combiner les predictions de plusieurs HMM (differents seeds, differents nombres d'états) pour reduire la variance\n",
+    "- **Horizons multiples** : appliquer le signal HMM sur différentes horizons de rebalancement (journalier, hebdomadaire) pour optimiser le ratio signal/bruit\n",
     "\n",
     "---\n",
     "\n",
@@ -3209,7 +3209,7 @@
     "\n",
     "| Precedent | Suivant |\n",
     "|-----------|--------|\n",
-    "| [Catalogue Probas](README.md) | -- |"
+    "| [Catalogue ML-Training](README.md) | -- |"
    ]
   }
  ],
@@ -3237,8 +3237,8 @@
    "end_time": "2026-06-05T01:29:00.396623+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/PyMC-HMM-Trading-Alpha.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/PyMC-HMM-Trading-Alpha.ipynb",
+   "input_path": "hmm_alpha_research.ipynb",
+   "output_path": "hmm_alpha_research.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T01:28:06.185206+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Context

Resolves dispatch **#4186** (po-2026 transverse analysis, lane explicitly po-2025 OR po-2024). Source `Probas/` = my partition (retrait + accents); destination QC = surgical move + nav. Claimed anti-collision (po-2024 deep in MGS/GameTheory, not touching ML-Training-Pipeline).

## What & why

`Probas/PyMC-HMM-Trading-Alpha.ipynb` was **misplaced**: it does **not use PyMC** (real imports verified firsthand: `hmmlearn`/`sklearn`/`yfinance` — `pymc` absent), and its content is purely **trading-alpha research** (walk-forward 5-fold × 4 seeds, 10 bps transaction costs, honest BEATS/NO BEATS verdict, ref *Hands-On AI Trading* Broad Ch6 Ex4). Its true home is `QuantConnect/ML-Training-Pipeline/`, next to the sibling `m5_hmm_regime_research.ipynb` (HMM regime — complementary, not a duplicate).

## Change (1 atomic PR)

| Step | Detail |
|------|--------|
| **Move** | `Probas/PyMC-HMM-Trading-Alpha.ipynb` → `QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb` (drop misleading "PyMC" prefix; matches sibling `_research.ipynb` convention). Git rename detected. |
| **FR accents** | ~318 restored in markdown (etats/régimes/modèles/coûts/génération/cachés/décodage/préparation/sélection/durée/critère/référence/complète/volatilité/données/probabilités/marché/même/fenêtre/...). **Markdown-only** (C.2 exception, no re-exec). |
| **Nav** | Notebook links `Catalogue Probas` → `Catalogue ML-Training`; Probas README drops 6 HMM-trading refs (standalone 3→2 notebooks); ML-Training-Pipeline README inscribes the notebook in its type-(c) table. |
| **Metadata** | `metadata.papermill` input/output_path normalized to basename (stale post-move) — metadata, **not** a cell output (allowed exception); execution provenance (duration/start_time/version) preserved. |

## Validation (firsthand, G.1)

- ✅ Acceptance grep on the #4186 named subset returns **only `seuil`/`seuils`** — correct French (no accent), acknowledged grep FP. ~0 real hits.
- ✅ Code cells untouched: **27/27 keep outputs + execution_count** (C.2 preserved — I never edited code).
- ✅ `scan_md_hierarchy.py` still **0/1 flagged** (accents didn't break heading structure).
- ✅ JSON valid, 65 cells (27 code / 38 md).
- ✅ All 7 `marche→marché` substitutions reviewed = market context (no verb "marcher" false-positives).
- ✅ Catalog **not regenerated** (catalog-pr-hygiene); left to the cron / catalog-drift lane.

## Known follow-up (NOT edited here — different partition)

`SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb` has a cross-reference table row linking to the old `Probas/PyMC-HMM-Trading-Alpha` path (and repeats the "PyMC" misconception). That's the SymbolicLearning series owner's partition — flagged for them, not touched in this move PR.

See #4186
See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)