### PR TITLE
docs(csp): add founding citations CSP-4/5/6 (scheduling, optimization, hybridization)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb
@@ -36,7 +36,8 @@
     "\n",
     "- Notebooks CSP-1 à CSP-3 (fondements CSP)\n",
     "- Python 3.10+ : ortools, matplotlib, numpy\n",
-    "- Connaissances de base en OR-Tools CP-SAT\n"
+    "- Connaissances de base en OR-Tools CP-SAT\n",
+    "\n\n> *Ancres savantes -- Garey, M.R. & Johnson, D.S. (1979), Computers and Intractability: A Guide to the Theory of NP-Completeness, W.H. Freeman (JSSP et RCPSP parmi les problemes d'ordonnancement NP-difficiles de reference, base du catalogue cite) ; Brucker, P. (2007), Scheduling Algorithms (5th ed.), Springer (manuel de reference sur le job-shop scheduling et les ordonnancements a contraintes de ressources) ; Herroelen, W., De Reyck, B. & Demeulemeester, E. (1998), Resource-Constrained Project Scheduling: A Survey of Recent Developments, Computers & Operations Research 25(4):279-302 (RCPSP, classification des methodes exactes et heuristiques) ; Burke, E.K., De Causmaecker, P., Vanden Berghe, G. & Van Landeghem, H. (2004), The State of the Art of Nurse Rostering, Journal of Scheduling 7(6):441-499 (survey de reference sur le Nurse Scheduling Problem).*"
    ]
   },
   {
@@ -2172,7 +2173,8 @@
     "1. **OR-Tools Documentation**: https://developers.google.com/optimization/scheduling\n",
     "2. **Handbook of Scheduling** (2004): J.Y.-T. Leung ed.\n",
     "3. **Constraint-Based Scheduling** (2001): P. Baptiste, C. Le Pape, W. Nuijten\n",
-    "4. **CP-SAT Primer**: https://github.com/google/or-tools/tree/stable/ortools/sat/docs"
+    "4. **CP-SAT Primer**: https://github.com/google/or-tools/tree/stable/ortools/sat/docs\n",
+    "\n5. Garey, M.R. & Johnson, D.S. (1979). Computers and Intractability: A Guide to the Theory of NP-Completeness. W.H. Freeman.\n6. Brucker, P. (2007). Scheduling Algorithms (5th ed.). Springer.\n7. Herroelen, W., De Reyck, B. & Demeulemeester, E. (1998). Resource-Constrained Project Scheduling: A Survey of Recent Developments. Computers & Operations Research 25(4):279-302.\n8. Burke, E.K., De Causmaecker, P., Vanden Berghe, G. & Van Landeghem, H. (2004). The State of the Art of Nurse Rostering. Journal of Scheduling 7(6):441-499.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -37,7 +37,8 @@
     "- Notebooks CSP-1 à CSP-3 (fondements CSP)\n",
     "- CSP-4-Scheduling (ordonnancement)\n",
     "- Python 3.10+ : ortools, matplotlib, numpy\n",
-    "- Notions de base en optimisation combinatoire\n"
+    "- Notions de base en optimisation combinatoire\n",
+    "\n\n> *Ancres savantes -- Dantzig, G.B. (1957), Discrete-Variable Extremum Problems, Operations Research 5(2):266-288 (knapsack 0/1, relaxation continue fractionnaire borneant l'optimum, fondement de la resolution par branch-and-bound) ; Johnson, D.S. (1974), Fast Algorithms for Bin Packing, Journal of Computer and System Sciences 8(3):272-314 (heuristique First-Fit-Decreasing pour le Bin Packing, garantie de performance 11/9*OPT) ; Garey, M.R. & Johnson, D.S. (1979), Computers and Intractability, W.H. Freeman (Bin Packing et Knapsack parmi les 21 problemes NP-complets fondateurs) ; Gilmore, P.C. & Gomory, R.E. (1961), A Linear Programming Approach to the Cutting-Stock Problem, Operations Research 9(6):849-859 (Cutting Stock, generation de colonnes fondatrice) ; Markowitz, H. (1952), Portfolio Selection, The Journal of Finance 7(1):77-91 (theorie moderne du portefeuille : frontier efficiente moyenne-variance, deja nomme ci-dessous).*"
    ]
   },
   {
@@ -2508,7 +2509,8 @@
     "1. **OR-Tools Bin Packing**: https://developers.google.com/optimization/bin\n",
     "2. **Knapsack Problems** (2004): H. Kellerer, U. Pferschy, D. Pisinger\n",
     "3. **Integer Programming** (1998): L. Wolsey\n",
-    "4. **Modern Portfolio Theory**: H. Markowitz (1952)"
+    "4. **Modern Portfolio Theory**: H. Markowitz (1952)\n",
+    "\n5. Dantzig, G.B. (1957). Discrete-Variable Extremum Problems. Operations Research 5(2):266-288.\n6. Johnson, D.S. (1974). Fast Algorithms for Bin Packing. Journal of Computer and System Sciences 8(3):272-314.\n7. Gilmore, P.C. & Gomory, R.E. (1961). A Linear Programming Approach to the Cutting-Stock Problem. Operations Research 9(6):849-859.\n8. Markowitz, H. (1952). Portfolio Selection. The Journal of Finance 7(1):77-91.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
@@ -38,7 +38,8 @@
     "- CSP-4-Scheduling (ordonnancement)\n",
     "- CSP-5-Optimization (optimisation combinatoire)\n",
     "- Python 3.10+ : ortools, matplotlib\n",
-    "- Notions de base en SAT solving et machine learning\n"
+    "- Notions de base en SAT solving et machine learning\n",
+    "\n\n> *Ancres savantes -- Ohrimenko, A., Stuckey, P.J. & Codish, M. (2009), Propagation via Lazy Clause Generation, Constraints 14(3):357-391 (Lazy Clause Generation : un solveur CP propage et genere a la volee des clauses SAT appries, fusion CP-SAT fondatrice, sections 1-2) ; Een, N. & Sorensson, N. (2006), Translating Pseudo-Boolean Constraints into SAT, Journal on Satisfiability, Boolean Modeling and Computation 2:1-26 (CP-SAT : encodage des contraintes pseudo-Booleennes en SAT, moteur de Google OR-Tools CP-SAT, section 2) ; Kotthoff, L. (2016), Algorithm Selection for Combinatorial Search Problems: A Survey, AI Magazine 35(3):48-60 (Machine Learning pour le branching et la selection de strategies, section 3) ; Xu, L., Hutter, F., Hoos, H.H. & Leyton-Brown, K. (2008), SATzilla: Portfolio-based Algorithm Selection for SAT, Journal of Artificial Intelligence Research 32:565-606 (portfolio solving, section 5).*"
    ]
   },
   {
@@ -2076,7 +2077,8 @@
     "1. **Lazy Clause Generation** (2010): T. Feydy, P.J. Stuckey\n",
     "2. **CP-SAT Primer** (2023): Google OR-Tools Team\n",
     "3. **Machine Learning for CP** (2018): E. Balas et al.\n",
-    "4. **LLM + Reasoning** (2023):_chain-of-thought papers"
+    "4. **LLM + Reasoning** (2023):_chain-of-thought papers\n",
+    "\n5. Ohrimenko, A., Stuckey, P.J. & Codish, M. (2009). Propagation via Lazy Clause Generation. Constraints 14(3):357-391.\n6. Een, N. & Sorensson, N. (2006). Translating Pseudo-Boolean Constraints into SAT. Journal on Satisfiability, Boolean Modeling and Computation 2:1-26.\n7. Kotthoff, L. (2016). Algorithm Selection for Combinatorial Search Problems: A Survey. AI Magazine 35(3):48-60.\n8. Xu, L., Hutter, F., Hoos, H.H. & Leyton-Brown, K. (2008). SATzilla: Portfolio-based Algorithm Selection for SAT. Journal of Artificial Intelligence Research 32:565-606.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Continuation of the **#3164 citation audit** — Part2-CSP notebooks. Unlike the Part1-Foundations notebooks (which had *no* References at all), CSP-4/5/6 **already had a `## Références` cell** with documentation links and some textbooks. G.1 firsthand confirmed they were **missing the canonical FOUNDING papers** for the taught problems. This PR **adds the missing founding anchors while preserving all existing references** (anti-regression) + an inline scholarly blockquote @ each intro.

Markdown-additive: **0 code cells changed** (C.2 markdown-only exception, verified byte-identity vs `origin/main` for all 3 notebooks).

## Notebooks reinforced

**CSP-4-Scheduling.ipynb** — JSSP / RCPSP / Nurse scheduling:
- Garey & Johnson (1979) *Computers and Intractability* (NP-hard reference catalog)
- Brucker (2007) *Scheduling Algorithms* (reference textbook)
- Herroelen, De Reyck & Demeulemeester (1998) RCPSP survey, C&OR 25(4):279-302
- Burke et al. (2004) Nurse rostering state of the art, J. Scheduling 7(6):441-499

**CSP-5-Optimization.ipynb** — BPP / Knapsack / Cutting-Stock / Portfolio:
- Dantzig (1957) *Discrete-Variable Extremum Problems*, OR 5(2):266-288 (knapsack relaxation)
- Johnson (1974) *Fast Algorithms for Bin Packing*, JCSS 8(3):272-314 (FFD, 11/9·OPT)
- Garey & Johnson (1979) (NP-completeness)
- Gilmore & Gomory (1961) *Cutting-Stock*, OR 9(6):849-859 (column generation)
- Markowitz (1952) *Portfolio Selection*, J. of Finance 7(1):77-91 (formalizes the bare citation already present)

**CSP-6-Hybridization.ipynb** — LCG / CP-SAT / ML+CP / Portfolio:
- Ohrimenko, Stuckey & Codish (2009) *Propagation via Lazy Clause Generation*, Constraints 14(3):357-391 (LCG founding paper — the notebook cited Feydy & Stuckey 2010, but the foundational CP-SAT fusion paper is Ohrimenko et al. 2009)
- Eén & Sörensson (2006) *Translating Pseudo-Boolean Constraints into SAT*, JSAT 2:1-26 (CP-SAT engine)
- Kotthoff (2016) *Algorithm Selection Survey*, AI Magazine 35(3):48-60 (ML for branching)
- Xu et al. (2008) *SATzilla*, JAIR 32:565-606 (portfolio solving)

## G.1 firsthand verification

Each notebook was **read firsthand** to confirm the taught problems are the notebook's central subjects (JSSP/RCPSP/Nurse for CSP-4; BPP/Knapsack/Cutting-Stock/Portfolio for CSP-5; LCG/CP-SAT/ML-CP for CSP-6). The existing `## Références` cells were inspected — they contained OR-Tools docs, a few textbooks (Leung, Baptiste/Le Pape/Nuijten, Kellerer/Pferschy/Pisinger, Wolsey), and a bare Markowitz citation, but **not** the founding papers now added. Existing references are fully preserved (anti-regression).

## Validation

- `git diff` vs `origin/main`: markdown cells only, **0 code cells changed** (verified via JSON cell-type comparison for all 3).
- Anti-regression: existing `## Références` items (Feydy/Stuckey, CP-SAT Primer, Balas, Kellerer et al., Wolsey, Leung, Baptiste et al.) verified present in the diff unchanged — only appended lines added.
- `nbformat` preserved (`json.dump indent=1, ensure_ascii=False`, no-BOM, UTF-8).

See #3164

---
*Part of the standing citation-audit directive. Part2-CSP: CSP-1/2/3/7/8/9 were already anchored (pre-existing). This PR covers CSP-4/5/6. Partition: Part2-CSP = Python (kernel python3) = po-2025 lane.*
