### PR TITLE
docs(pymc9): anchor LDA foundational paper at teaching point

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models.ipynb
@@ -162,6 +162,7 @@
     "## 2. Le Modele Generatif LDA\n",
     "\n",
     "La **Latent Dirichlet Allocation** (LDA) est le modele de sujet le plus courant.\n",
+    "> **Source primaire** : Blei, D. M., Ng, A. Y. & Jordan, M. I. (2003), *Latent Dirichlet Allocation*, Journal of Machine Learning Research 3:993-1022. C'est ce papier qui formalise le modele generatif ci-dessous (priors Dirichlet phi sur les distributions de mots et theta sur les proportions de sujets, variable latente z assignant chaque mot a un sujet) --- l'un des modeles probabilistes les plus cites en informatique.\n",
     "\n",
     "### Structure du modele\n",
     "\n",


### PR DESCRIPTION
## Context

Epic **#3164** (citation audit) — PyMC series extension (my partition: Probas/PyMC). I completed Infer (21 notebooks) last cycle; this audits the PyMC port.

## Finding (firsthand, G.1)

`Probas/PyMC/PyMC-9-Topic-Models.ipynb` teaches **Latent Dirichlet Allocation (LDA)** in depth — 6+ sections: the full generative model (Dirichlet priors `phi` over word-distributions and `theta` over topic-proportions, latent assignment `z`, categorical word emission), symmetric vs asymmetric priors, and extensions (CTM/DTM/sLDA). LDA is named repeatedly at teaching points.

But:
- **No academic anchor** for LDA anywhere in the notebook.
- **No references section** at all.
- The **Infer.NET sibling (Infer-9) carries the anchor** ("*introduit par David Blei, Andrew Ng et Michael Jordan en 2003*" + a timeline row "2003 | Publication originale de LDA"). The PyMC port dropped it.

This is the exact #3164 pattern: concept named at the teaching point, foundational paper missing.

## Change

Anchor the foundational paper at the LDA intro teaching point, matching the PyMC series' existing "**Source primaire**" convention (cf. PyMC-6 TrueSkill):

> **Source primaire** : Blei, D. M., Ng, A. Y. & Jordan, M. I. (2003), *Latent Dirichlet Allocation*, Journal of Machine Learning Research 3:993-1022.

Markdown-only (C.2 exception, no re-execution).

## Validation

- `git diff --stat`: **+1 / −0** (1 source-array line inserted; json.dump matched the original indent=1 format exactly — no format drift).
- Code cells untouched: **15/15 keep outputs + execution_count**.
- `scan_md_hierarchy.py`: still **0/1 flagged** (blockquote doesn't affect heading structure).
- JSON valid, 33 cells.

## Scope

Single anchor at the teaching point — deliberately bounded. Not adding a full references section (would be scope creep); the inline "Source primaire" blockquote mirrors the established PyMC-6 pattern.

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)