### PR TITLE
lean(cooperative): add ProperGame predicate + weighted_voting_game_proper validator

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1118,6 +1118,49 @@ theorem weighted_voting_game_monotone (weights : N → ℝ) (quota : ℝ) (hquot
   · exact zero_le_one                                 -- S does not, T does: 0 ≤ 1
   · exact le_refl _                                   -- neither: 0 ≤ 0
 
+/-! ## Proper games
+
+A *proper* (transferable-utility) game is one where a coalition and its complement cannot both
+be winning: `v S = 1 → v Sᶜ = 0`. For a simple game this is the standard "no two complementary
+coalitions both win" property of a proper simple voting game (the complement of a winning
+coalition is losing). A weighted voting game is proper whenever the quota strictly exceeds half
+the total weight, since the weights of complementary coalitions sum to the total. -/
+def ProperGame (G : TUGame N) : Prop :=
+  ∀ ⦃S : Finset N⦄, G.v S = 1 → G.v Sᶜ = 0
+
+namespace ProperGame
+
+/-- In a proper game, the complement of a winning coalition is losing. -/
+theorem complement_loses {G : TUGame N} (hG : ProperGame G) {S : Finset N}
+    (hwin : G.v S = 1) : G.v Sᶜ = 0 :=
+  hG hwin
+
+end ProperGame
+
+/-- A weighted voting game whose quota strictly exceeds half the total weight is proper: if a
+    coalition's weight meets the quota, the complementary coalition's weight is strictly below it
+    (the two complementary weights sum to the total, which is less than `2 * quota`), so the
+    complement loses. No sign assumption on the weights is needed — this is a pure consequence of
+    the quota-to-total ratio. -/
+theorem weighted_voting_game_proper (weights : N → ℝ) (quota : ℝ) (hquota : 0 < quota)
+    (hproper : 2 * quota > ∑ i, weights i) :
+    ProperGame (WeightedVotingGame weights quota hquota) := by
+  intro S hwin
+  simp only [WeightedVotingGame] at hwin ⊢
+  -- Decode `S` winning into its weight reaching the quota.
+  have hS : ∑ i ∈ S, weights i ≥ quota := by
+    split_ifs at hwin with h
+    · exact h
+    · linarith
+  -- The complementary coalition's weight is `total − ∑_S`, hence `< quota`.
+  have hSc : ∑ i ∈ Sᶜ, weights i = ∑ i, weights i - ∑ i ∈ S, weights i := by
+    rw [← Finset.sum_add_sum_compl S weights]; ring
+  have hSc_lt : ∑ i ∈ Sᶜ, weights i < quota := by rw [hSc]; linarith
+  -- The complement does not reach the quota, so its value is `0`.
+  split_ifs with h
+  · linarith
+  · rfl
+
 /-- Player i is critical in coalition S if removing them causes S to lose -/
 def Critical (G : TUGame N) (i : N) (S : Finset N) : Prop :=
   i ∈ S ∧ G.v S = 1 ∧ G.v (S.erase i) = 0


### PR DESCRIPTION
## `ProperGame` — a coalition and its complement cannot both win (step 6 deep-queue)

New game-class infrastructure mirroring `MonotoneGame` (#4149) and `SimpleGame` (#4134): a
*proper* (transferable-utility) game is one where a coalition and its complement cannot both be
winning — `v S = 1 → v Sᶜ = 0`. For a simple game this is the standard "no two complementary
coalitions both win" property of a proper simple voting game. This is the foundation the
proper+strong / dual-game theory (ai-01 deep-queue step 6) builds on.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `ProperGame` | `∀ S, v S = 1 → v Sᶜ = 0` | proper-game predicate |
| `ProperGame.complement_loses` | `ProperGame G → v S = 1 → v Sᶜ = 0` | reader (trivial unfold) |
| `weighted_voting_game_proper` | `2 * quota > ∑ weights → ProperGame (WeightedVotingGame …)` | non-vacuous validator |

### Why the validator needs only `2 * quota > ∑ weights`

A weighted voting game is proper whenever the quota strictly exceeds half the total weight:

- If `S` wins then `∑_S weights ≥ quota`.
- The complementary weights satisfy `∑_{Sᶜ} = ∑_univ − ∑_S` (pure partition identity,
  `Finset.sum_add_sum_compl`).
- Hence `∑_{Sᶜ} ≤ ∑_univ − quota`, and since `2 * quota > ∑_univ` we have
  `∑_univ − quota < quota`, so `∑_{Sᶜ} < quota` and `Sᶜ` loses.

**No sign assumption on the weights is needed** — this is a pure consequence of the
quota-to-total ratio. (The first draft carried an `hw : ∀ i, 0 ≤ weights i` hypothesis, but
`linarith` discharged the proof without it; dropped as genuinely superfluous — verify-before-claiming.)

### Independent of pending PRs (no stacking, no conflict)

Prouvable from `origin/main` (tip `7254859eb`) directly — uses only `WeightedVotingGame` + `SimpleGame`-era
primitives. **Disjoint region** from the two pending cooperative-games PRs:

| PR | Region (Shapley.lean) | Size |
|----|----------------------|------|
| #4187 veto_iff_critical_of_winning | after `veto_critical_of_winning` (~L1238) | +16 |
| #4190 veto_not_dummy | after `dummy_banzhaf_raw_zero` (~L1294) | +24 |
| **this PR** | **after `weighted_voting_game_monotone` (~L1119)** | **+43** |

Three distinct insertion anchors → merge in any order with no text conflict.

### Note on ai-01 deep-queue step 3

Step 3 (`veto ⟹ veto_banzhaf ≥ 1`) is **already covered** by `veto_banzhaf_raw_pos` (#4153 merged),
which proves `0 < BanzhafRaw G i`; in `ℕ`, `0 < n ↔ 1 ≤ n`. So it is a trivial corollary, not a
substantive new result — skipped per G.3 (no marginal progress dressed as DONE). This PR advances
to step 6 infrastructure instead.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (16s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +43/0), pure insertion after `weighted_voting_game_monotone`.
  **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)