### PR TITLE
docs(qcpy-23b): add scholarly anchors for PatchTST + iTransformer (2e-passe, See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
@@ -239,7 +239,9 @@
     "1. **Patching** : reduit la sequence de L a L/P tokens (P = patch length)\n",
     "2. **Channel independence** : chaque variable est traitee independemment avec poids partages\n",
     "\n",
-    "**Resultat** : Complexite reduite de O(L^2) a O((L/P)^2)"
+    "**Resultat** : Complexite reduite de O(L^2) a O((L/P)^2)\n",
+    "\n",
+    "> *Ancre savante -- Nie, Nguyen, Sinthong & Kalagnanam (2023), « A Time Series is Worth 64 Words: Long-term Forecasting with Transformers », ICLR 2023 (arXiv:2211.14730) -- origine du patching (decoupage en patches reduisant la sequence de L a L/P tokens) et de l'independance des canaux, les deux innovations decrites ci-dessus.*"
    ]
   },
   {
@@ -429,7 +431,9 @@
     "\n",
     "Pour N=5 variables et L=96 pas de temps :\n",
     "- Standard : 96^2 = 9 216 paires\n",
-    "- iTransformer : 5^2 = 25 paires"
+    "- iTransformer : 5^2 = 25 paires\n",
+    "\n",
+    "> *Ancre savante -- Liu, Hu, Zhang, Wu, Wang, Ma & Long (2024), « iTransformer: Inverted Transformers Are Effective for Time Series Forecasting », ICLR 2024 Spotlight (arXiv:2310.06625) -- inversion des axes (attention sur les variables plutot que sur le temps), le principe cle enseigne ci-dessus.*"
    ]
   },
   {


### PR DESCRIPTION
## 2e-passe scholarly anchors — QC-Py-23b-PatchTST-iTransformer (See #3164)

Markdown-additive citation anchoring on the notebook whose **filename IS its two central topics** (PatchTST + iTransformer). The 1st pass (#3691) anchored the prerequisite Vaswani 2017 Transformer (Partie 1), but left both topics **taught-as-concept without an inline scholarly anchor at the teaching point** — they were only named in the section headings and listed in the References cell.

### Anchors added (2)

| Partie | Paper | Cell |
|--------|-------|------|
| 2 (PatchTST) | Nie, Nguyen, Sinthong & Kalagnanam 2023, "A Time Series is Worth 64 Words", ICLR 2023 (**arXiv:2211.14730**) — patching + channel independence | `ecab120f` |
| 3 (iTransformer) | Liu, Hu, Zhang, Wu, Wang, Ma & Long 2024, "iTransformer: Inverted Transformers Are Effective...", **ICLR 2024 Spotlight** (**arXiv:2310.06625**) — inverted axes | `1f1ef3d6` |

Same 2e-passe pattern as QC-Py-22 (#4157) and QC-Py-23 (#4139): 1st pass anchors the foundational paper, misses the SOTA papers taught in dedicated `## Partie` sections.

### G.1 / §D validation (markdown-only, C.2 exception)
- **arXiv IDs web-verified** this session vs primary sources: arXiv abs pages, OpenReview (PatchTST `Jbdc0vTOcol`, iTransformer `JePfAI8fah`), DBLP, official GitHub (yuqinie98/PatchTST, thuml/iTransformer).
- **Code cells byte-identical** (sha1): 13/13 code cells unchanged. Markdown-only edit → C.2 exception (no re-exec required; rule C.2).
- **List-direct mutation** (foundational lesson from QC-Py-25 cell-7 mash): `source` list spliced in-place, never join+resplit. All original source elements preserved (+1 new per cell).
- Cell count (27) + cell_type sequence unchanged. `notebook_tools validate` → **OK, 0 warning, 0 erreur**.
- **Catalogue byte-identical**, submodule `openzeppelin-contracts` NOT staged (pre-existing churn, untouched).
- No `Closes` — partial contribution to epic #3164 (`See #3164`).

### Scope discipline (G.5, not padding)
Both papers are the notebook's **central topics** (taught in dedicated `## Partie` sections explaining the innovations), not peripheral — anchoring them at the teaching point is genuine OMISSION repair, not citation padding. Existing References entries (Nie/Liu) left untouched (already correct); de Prado 2018 left as decorative reference (no prose invokes AFML content).
