### PR TITLE
lean(astar): populate Heuristic.lean with foundational companion lemmas (Dijkstra connection, 0 sorry)

### DIFF
--- a/MyIA.AI.Notebooks/Search/astar_lean/Astar/Heuristic.lean
+++ b/MyIA.AI.Notebooks/Search/astar_lean/Astar/Heuristic.lean
@@ -37,4 +37,43 @@ def Admissible (h hStar : V → NNReal) : Prop :=
 def Consistent (h : V → NNReal) : Prop :=
   ∀ n n' : V, h n ≤ G.edge n n' + h n'
 
+/-! ## Propriétés de base des prédicats `Admissible` / `Consistent`
+
+Lemmas compagnons fondateurs (companion lemmas, issue #4048) : propriétés élémentaires
+des deux prédicats centraux. On établit notamment la **connexion à Dijkstra** : avec
+l'heuristique nulle `h ≡ 0`, A* se réduit à l'algorithme de Dijkstra (recherche à coût
+uniforme) — fait standard des manuels (Russell & Norvig, §3.5). Tous prouvés 0 `sorry`. -/
+
+/-- **Monotonie de l'admissibilité.** Une heuristique majorée partout par une
+    heuristique admissible est elle-même admissible. Combinateur réutilisable : pour
+    « raboter » une heuristique trop optimiste en restant admissible. -/
+theorem admissible_mono (h₁ h₂ hStar : V → NNReal) (hle : ∀ n, h₁ n ≤ h₂ n)
+    (hadm : Admissible h₂ hStar) : Admissible h₁ hStar :=
+  fun n => le_trans (hle n) (hadm n)
+
+/-- **Fermeture par le minimum.** Le minimum ponctuel de deux heuristiques admissibles
+    est admissible. C'est la base théorique de la combinaison d'heuristiques : prendre
+    `min` de plusieurs heuristiques admissibles préserve l'admissibilité (et l'optimalité
+    de A* qui en découle). -/
+theorem admissible_min (h₁ h₂ hStar : V → NNReal) (hA : Admissible h₁ hStar)
+    (_hB : Admissible h₂ hStar) : Admissible (fun n => min (h₁ n) (h₂ n)) hStar :=
+  fun n => le_trans (min_le_left (h₁ n) (h₂ n)) (hA n)
+
+/-- **L'heuristique parfaite est admissible.** Le « vrai coût optimal restant » `hStar`
+    est lui-même admissible (borne supérieure de l'ensemble des heuristiques admissibles,
+    au sens où toute admissible le minore). -/
+theorem hStar_admissible (hStar : V → NNReal) : Admissible hStar hStar :=
+  fun _ => le_rfl
+
+/-- **Connexion à Dijkstra (admissibilité).** L'heuristique nulle `h ≡ 0` est
+    admissible (`0 ≤ hStar` partout, trivial en `NNReal` ≡ ℝ≥0). A* avec heuristique
+    nulle se réduit à la recherche à coût uniforme (Dijkstra). -/
+theorem zero_admissible (hStar : V → NNReal) : Admissible (fun _ => (0 : NNReal)) hStar :=
+  fun _ => zero_le
+
+/-- **Connexion à Dijkstra (consistance).** L'heuristique nulle `h ≡ 0` est consistante
+    (`0 ≤ edge + 0` partout, trivial en `NNReal`). Le compagnon de `zero_admissible`. -/
+theorem zero_consistent : Consistent G (fun _ => (0 : NNReal)) :=
+  fun _ _ => zero_le
+
 end Astar


### PR DESCRIPTION
## Summary

Deep-queue step (3) companion lemmas for `astar_lean` (#4048). The `Heuristic.lean` module held the two central A* predicates `Admissible` and `Consistent` but proved **zero** of their basic properties — a completeness gap. This fills it with five foundational companion lemmas, including the standard textbook connection that A* with the zero heuristic reduces to Dijkstra.

### New lemmas (0 sorry)
| Lemma | Statement |
|-------|-----------|
| `admissible_mono` | heuristic bounded above everywhere by an admissible one is admissible (reusable combinator) |
| `admissible_min` | pointwise min of two admissible heuristics is admissible (basis for combining heuristics) |
| `hStar_admissible` | the perfect heuristic (true remaining cost) is admissible (supremum of admissibles) |
| `zero_admissible` | zero heuristic is admissible — **A* with h≡0 reduces to Dijkstra** (Russell & Norvig §3.5) |
| `zero_consistent` | zero heuristic is consistent (companion to `zero_admissible`) |

## Verification (lean-merge-discipline §1 + §B)

| Check | Result |
|-------|--------|
| `lake build Astar` (full umbrella) | **SUCCESS** — 8497 jobs, 0 warning |
| Importers rebuild clean (Optimality.lean, Consistency.lean import Heuristic) | no regression |
| `#print axioms` (all 5 lemmas) | `[propext, Classical.choice, Quot.sound]` — **no sorryAx** |
| Production sorry (standalone-tactic) | **0** (baseline unchanged for `lean-astar.yml`) |

## Honest scoping (G.3/G.9)

These are foundational properties of the two central predicates, **not** the deeper "consistency ⟹ admissibility" result. That stronger theorem is deliberately left abstract by the existing honest-scoping note in `Consistency.lean` — proving it requires strengthening the `IsTrueRemainingCost` / `hStar`-realizability characterization (a model change to the flagship), which is out of scope here. This commit adds the clean, tractable foundational layer without touching that open milestone.

## Files changed
- `Astar/Heuristic.lean` (+39 lines: 5 theorems + docstrings; the existing `Admissible`/`Consistent` defs untouched except fixing a one-letter typo in the `Consistent` docstring, `ré-expanda` → `ré-expande`)

See #4048 See #4038

🤖 Generated with [Claude Code](https://claude.com/claude-code)