### PR TITLE
docs(sudoku): anchor founding citations GA+SA (Holland 1975, Kirkpatrick 1983) — #3164

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -26,6 +26,8 @@
     "3. Concevoir differentes representations chromosomiques pour un probleme de contraintes\n",
     "4. Analyser les performances et comparer les approches genetiques\n",
     "\n",
+    "**Source primaire.** Les algorithmes genetiques ont ete formalises par John H. Holland dans *Adaptation in Natural and Artificial Systems* (University of Michigan Press, 1975 ; 2e ed. MIT Press, 1992), qui etablit la selection, le croisement et la mutation comme mecanismes d'adaptation. Ce notebook en met en oeuvre la trilogie operative (selection -> croisement -> mutation) sur une instance de Sudoku.\n",
+    "\n",
     "**Voir aussi** : [Search-5-GeneticAlgorithms](../Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) pour la theorie des algorithmes genetiques\n",
     "\n",
     "### Prerequis\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -86,7 +86,9 @@
     "\n",
     "$$P(\\text{accepter}) = \\begin{cases} 1 & \\text{si } \\Delta E \\leq 0 \\text{ (amelioration)} \\\\ e^{-\\Delta E / T} & \\text{si } \\Delta E > 0 \\text{ (degradation)} \\end{cases}$$\n",
     "\n",
-    "ou $\\Delta E = E(\\text{voisin}) - E(\\text{courant})$ et $T$ est la temperature courante."
+    "ou $\\Delta E = E(\\text{voisin}) - E(\\text{courant})$ et $T$ est la temperature courante.\n",
+    "\n",
+    "**Sources primaires.** Le critere d'acceptation de Metropolis -- accepter une degradation avec probabilite $e^{-\\Delta E/T}$ -- a ete introduit dans l'etude des equations d'etat par simulation de Monte-Carlo (Metropolis, Rosenbluth, Rosenbluth, Teller & Teller, *Journal of Chemical Physics* 21(6):1087-1092, 1953). Son transfert a l'optimisation combinatoire sous le nom de *recuit simule* est l'apport fondateur de Kirkpatrick, Gelatt & Vecchi, *Science* 220(4598):671-680, 1983."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Extends the **#3164 citation-anchoring** audit to the Sudoku series (my .NET partition). Two notebooks teach a *founding* concept (genetic algorithm, simulated annealing) without anchoring the primary source — the exact omission pattern po-2025 treated on PyMC-9 (LDA, PR #4195).

This PR adds **one markdown paragraph per notebook**, anchored at the teaching point where the concept is introduced.

| Notebook | Teaching point (read firsthand) | Added anchor |
|----------|---------------------------------|--------------|
| `Sudoku-3-Genetic-Csharp.ipynb` (cell 0) | Objective #1 « Comprendre les principes fondamentaux des algorithmes génétiques (sélection, croisement, mutation) » | **Holland 1975** — *Adaptation in Natural and Artificial Systems* |
| `Sudoku-4-SimulatedAnnealing-Csharp.ipynb` (cell 1) | Formulation of SA + « Critère d'acceptation de Metropolis » | **Metropolis 1953** (J. Chem. Phys. 21(6):1087-1092) + **Kirkpatrick, Gelatt & Vecchi 1983** (Science 220(4598):671-680) |

## Verification methodology (anti-hallucination, G.1)

- **Omission confirmed firsthand** by reading the notebooks' teaching points (not regex-counting — counting is unreliable, cf the `exo-counting-unreliable` lesson).
- **Absence verified**: `grep -i` for `Holland`, `Goldberg`, `Kirkpatrick`, `Metropolis` returned only the bare criterion *name* in Sudoku-4 (no source citation).
- **Canonical citations verified by web search** (not from memory):
  - Holland, J.H. (1975) — confirmed by 5 independent sources (MIT Press, SciRP, OpenLibrary).
  - Kirkpatrick, Gelatt & Vecchi (1983) *Science* 220(4598):671-680 — DOI 10.1126/science.220.4598.671.
  - Metropolis et al. (1953) *J. Chem. Phys.* 21(6):1087-1092.

## Why this is #3164 (citation anchoring), not concept-density

These notebooks already have rich pedagogy (exercises, navigation, interpretation cells). They are **not** missing a concept — they teach the founding concept well but without pointing the student at the academic origin. The #3164 grain is exactly that: anchor the primary source at the teaching point, the way a good textbook footnote would.

## Scope / safety

- **Markdown-only edit** → C.2 exception (no re-execution required; `execution_count` + `outputs` untouched on all code cells).
- **Diff**: `2 files changed, 5 insertions(+), 1 deletion(-)`. The single deletion is a JSON line-split (the anchored cell's last line gains a trailing `\n` to allow the appended paragraph) — pure markdown, no cell renumbering.
- **0 catalog churn**, 0 README touched, no other files. Surgical JSON edit (`json.load` + `json.dump(indent=1)`) preserves byte-for-byte format.
- Anchors placed in FR prose matching the notebooks' existing ASCII-French style.

Epic contribution — `See #3164` (the epic stays open; other notebook families remain to be audited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)