### PR TITLE
docs(gt-python): anchor canonical citations GT-4c-NashExistence (Brouwer/Kakutani/Nash)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
@@ -47,7 +47,8 @@
     "5. Identifier le role des hypotheses via des **contre-exemples** au theoreme\n",
     "\n",
     "### Duree estimee : 30 minutes",
-    "\n\n### Prerequis\n- Notebook 4 : Equilibre de Nash (definition et calcul)\n- Bases Python : numpy, matplotlib"
+    "\n\n### Prerequis\n- Notebook 4 : Equilibre de Nash (definition et calcul)\n- Bases Python : numpy, matplotlib\n",
+    "\n\n> *Ancres savantes -- Brouwer, L.E.J. (1911), Uber Abbildung von Mannigfaltigkeiten, Mathematische Annalen 71(1):97-115 (theoreme du point fixe de Brouwer : toute application continue d'un convexe compact dans lui-meme admet un point fixe — fondement illustre numeriquement sections 2 et 5) ; Kakutani, S. (1941), A Generalization of Brouwer's Fixed Point Theorem, Duke Mathematical Journal 8(3):457-459 (theoreme du point fixe pour les correspondances multivoques — la preuve originale de Nash dans sa these de 1950 utilisait cette generalisation, Brouwer etant le cas des fonctions univoques) ; Nash, J.F. (1950), Equilibrium Points in N-Person Games, Proceedings of the National Academy of Sciences 36(1):48-49 (theoreme d'existence de l'equilibre de Nash, sujet titulaire de ce notebook : tout jeu fini a au moins un equilibre en strategies mixtes) ; Nash, J.F. (1951), Non-Cooperative Games, Annals of Mathematics 54(2):286-295 (version journal, preuve simplifiee via Brouwer directement ; prix Nobel d'economie 1994 pour cette contribution).*"
    ]
   },
   {
@@ -1907,7 +1908,8 @@
     "\n",
     "La lecture guidee du depot math-xmum/Brouwer a revele la chaine de preuves formelle en Lean 4 : Lemme de Scarf (combinatoire des colorages) puis Lemme de Sperner puis Brouwer sur le simplexe puis extension au produit de simplexes puis existence de Nash. Cette architecture modulaire, ou un resultat combinatoire profond (~3000 lignes) engendre par deductions successives le theoreme de Nash, illustre la puissance des mathematiques formalisees.\n",
     "\n",
-    "Le notebook companion [GameTheory-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) propose la formalisation Lean 4 correspondante, tandis que le notebook suivant dans la serie principale, [GameTheory-5-ZeroSum-Minimax](GameTheory-5-ZeroSum-Minimax.ipynb), specialise l'analyse aux jeux a somme nulle ou le theoreme minimax de Von Neumann fournit des garanties encore plus fortes."
+    "Le notebook companion [GameTheory-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) propose la formalisation Lean 4 correspondante, tandis que le notebook suivant dans la serie principale, [GameTheory-5-ZeroSum-Minimax](GameTheory-5-ZeroSum-Minimax.ipynb), specialise l'analyse aux jeux a somme nulle ou le theoreme minimax de Von Neumann fournit des garanties encore plus fortes.\n",
+    "\n\n### References academiques\n\n- Brouwer, L.E.J. (1911). Uber Abbildung von Mannigfaltigkeiten. Mathematische Annalen 71(1):97-115.\n- Kakutani, S. (1941). A Generalization of Brouwer's Fixed Point Theorem. Duke Mathematical Journal 8(3):457-459.\n- Nash, J.F. (1950). Equilibrium Points in N-Person Games. Proceedings of the National Academy of Sciences 36(1):48-49.\n- Nash, J.F. (1951). Non-Cooperative Games. Annals of Mathematics 54(2):286-295.\n\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Continuation of the **#3164 citation audit** — GameTheory-Python. Markdown-additive: a scholarly inline blockquote at the introduction + a `### References academiques` cell at the conclusion. **0 code cells changed** — pure pedagogical prose, C.2 markdown-only exception, no re-execution needed.

## Notebook anchored

**GameTheory-4c-NashExistence-Python.ipynb** — the Nash equilibrium *existence* theorem, taught via the Brouwer fixed-point theorem.

**G.1 firsthand finding (textbook OMISSION)**: this notebook teaches two of the most canonical results in game theory as its **central subjects** —
- the **Brouwer fixed-point theorem** (§2 numerical illustrations, §4 lecture guidee on the `math-xmum/Brouwer` Lean proof chain, §5 contre-exemples showing why compact/convex/continuous hypotheses are necessary);
- the **Nash existence theorem** (titular subject, §3 Matching Pennies application showing mixed-strategy equilibrium as a Brouwer fixed point).

It names Brouwer, Kakutani, and "Lemme de Scarf" throughout the prose and even references a formal Lean proof chain — yet had **zero academic citation** (no paper, year, or venue) and no `References academiques` cell. The canonical theorems were present as teaching content; the founding papers were absent.

| Taught canonical result | Founding paper anchored |
|-------------------------|-------------------------|
| Brouwer fixed-point theorem (§2/4/5) | Brouwer (1911) *Über Abbildung von Mannigfaltigkeiten*, Math. Annalen 71:97-115 |
| Kakutani generalization (Nash's original proof tool) | Kakutani (1941) *A Generalization of Brouwer's Fixed Point Theorem*, Duke Math. J. 8(3):457-459 |
| Nash existence theorem (titular subject) | Nash (1950) *Equilibrium Points in N-Person Games*, PNAS 36(1):48-49 |
| Nash (journal version) | Nash (1951) *Non-Cooperative Games*, Annals of Mathematics 54(2):286-295 (Nobel Economics Prize 1994) |

## Partition note (collision-free)

This is a **Python** notebook (`kernel: python3`) at `GameTheory/` root, disjoint from po-2026's Lean work (`social_choice_lean/`, `CooperativeGames/` — both Lean 4, separate subdirs). The memory `python-turf-audited-faithful-3164` attributes the GameTheory-*Python* audit to the po-2025 lane. The prior "FIDELE" verdict was a *fidelity* check (algorithms faithfully implemented, GT-13 has Zinkevich 2007); this PR addresses the separate *OMISSION* question for GT-4c, which named its canonical theorems without their founding papers.

## Validation

- `git diff` vs `origin/main`: markdown cells only, **0 code cells changed** (verified via JSON cell-type comparison).
- `nbformat` preserved (`json.dump indent=1, ensure_ascii=False`, no-BOM, UTF-8) — matches repo convention, no spurious churn.
- No re-execution required (C.2 markdown-only exception).

See #3164

---
*Part of the standing citation-audit directive. GameTheory-Python: GT-13 was already anchored (Zinkevich 2007, fidelity audit). This PR anchors GT-4c (Nash existence). Other GT-Python notebooks (GT-2 NormalForm, GT-9 BackwardInduction, SocialChoice Python) are candidates for future batches.*
