### PR TITLE
lean(cooperative): add StrongGame predicate + weighted_voting_game_strong validator

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1053,6 +1053,49 @@ theorem eq_zero_of_ne_one {G : TUGame N} (hG : SimpleGame G) (S : Finset N)
 
 end SimpleGame
 
+/-! ## Strong games
+
+A *strong* (transferable-utility) game is the dual of a proper game: a coalition and its
+complement cannot both be losing — `v S = 0 → v Sᶜ = 1`. For a simple game this says the
+complement of a losing coalition is winning. Together with `ProperGame`, `StrongGame` defines
+a *self-dual* (proper and strong) simple voting game. A weighted voting game is strong whenever
+the quota does not exceed half the total weight. -/
+def StrongGame (G : TUGame N) : Prop :=
+  ∀ ⦃S : Finset N⦄, G.v S = 0 → G.v Sᶜ = 1
+
+namespace StrongGame
+
+/-- In a strong game, the complement of a losing coalition is winning. -/
+theorem complement_wins {G : TUGame N} (hG : StrongGame G) {S : Finset N}
+    (hlose : G.v S = 0) : G.v Sᶜ = 1 :=
+  hG hlose
+
+end StrongGame
+
+/-- A weighted voting game whose quota does not exceed half the total weight is strong: if a
+    coalition's weight falls short of the quota, the complementary coalition's weight meets it
+    (the two complementary weights sum to the total, which is at least `2 * quota`), so the
+    complement wins. No sign assumption on the weights is needed — a pure consequence of the
+    quota-to-total ratio. -/
+theorem weighted_voting_game_strong (weights : N → ℝ) (quota : ℝ) (hquota : 0 < quota)
+    (hstrong : 2 * quota ≤ ∑ i, weights i) :
+    StrongGame (WeightedVotingGame weights quota hquota) := by
+  intro S hlose
+  simp only [WeightedVotingGame] at hlose ⊢
+  -- Decode `S` losing into its weight falling short of the quota: if it reached the quota the
+  -- `if` would evaluate to `1`, contradicting `hlose : … = 0`.
+  have hS : ∑ i ∈ S, weights i < quota := by
+    by_contra hge
+    push_neg at hge
+    rw [if_pos hge] at hlose
+    linarith
+  -- The complementary coalition's weight is `total − ∑_S`, hence `≥ quota`.
+  have hSc : ∑ i ∈ Sᶜ, weights i = ∑ i, weights i - ∑ i ∈ S, weights i := by
+    rw [← Finset.sum_add_sum_compl S weights]; ring
+  have hSc_ge : ∑ i ∈ Sᶜ, weights i ≥ quota := by rw [hSc]; linarith
+  -- The complement reaches the quota, so its value is `1`.
+  exact if_pos hSc_ge
+
 /-! ## Monotone games
 
 A *monotone* (transferable-utility) game is one where enlarging a coalition never


### PR DESCRIPTION
## `StrongGame` — a coalition and its complement cannot both lose (completes step 6: proper+strong)

The **dual of `ProperGame`** (#4196 pending): where a *proper* game forbids a coalition and its
complement from both *winning* (`v S = 1 → v Sᶜ = 0`), a *strong* game forbids them from both
*losing* (`v S = 0 → v Sᶜ = 1`). A simple voting game that is **both proper and strong** is
*self-dual* — the completion of ai-01 deep-queue step 6 ("jeu dual/self-dual proper+strong").

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `StrongGame` | `∀ S, v S = 0 → v Sᶜ = 1` | strong-game predicate (dual of ProperGame) |
| `StrongGame.complement_wins` | `StrongGame G → v S = 0 → v Sᶜ = 1` | reader (trivial unfold) |
| `weighted_voting_game_strong` | `2 * quota ≤ ∑ weights → StrongGame (WeightedVotingGame …)` | non-vacuous validator |

### Why the validator needs only `2 * quota ≤ ∑ weights`

The exact dual of the proper condition: a weighted voting game is strong whenever the quota does
not exceed half the total weight.

- If `S` loses then `∑_S weights < quota`.
- The complementary weights satisfy `∑_{Sᶜ} = ∑_univ − ∑_S` (pure partition identity).
- Hence `∑_{Sᶜ} ≥ ∑_univ − quota ≥ quota` (since `2 * quota ≤ ∑_univ` gives `∑_univ − quota ≥ quota`),
  so `Sᶜ` wins.

**No sign assumption on the weights** — pure quota-to-total ratio, exactly mirroring the proper
validator. The `hS : ∑_S < quota` decode uses `by_contra` + `push_neg` + `if_pos` (a negation
`¬(∑ ≥ quota)` does *not* unify with `∑ < quota` directly, so the contrapositive is cleaner than
`split_ifs` here).

### Independent of pending PRs (no stacking, no conflict)

Prouvable from `origin/main` (tip `7254859eb`) directly — `StrongGame` is an **independent**
predicate that does not reference `ProperGame` (#4196). **Disjoint region** from all three pending
cooperative-games PRs:

| PR | Region (Shapley.lean) | Size |
|----|----------------------|------|
| #4187 veto_iff_critical_of_winning | after `veto_critical_of_winning` (~L1238) | +16 |
| #4190 veto_not_dummy | after `dummy_banzhaf_raw_zero` (~L1294) | +24 |
| #4196 ProperGame | after `weighted_voting_game_monotone` (~L1119) | +43 |
| **this PR** | **after `end SimpleGame` (~L1054)** | **+43** |

Four distinct insertion anchors → merge in any order with no text conflict. (Once #4196 and this
PR both merge, a follow-up can define the self-dual bridge `SelfDualGame G := ProperGame G ∧ StrongGame G`.)

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (15s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +43/0), pure insertion after `end SimpleGame`.
  **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)