### PR TITLE
docs(sudoku): anchor Kennedy & Eberhart 1995 PSO primary citation — #3164

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -51,6 +51,8 @@
     "\n",
     "Le **Particle Swarm Optimization** (PSO) est une metaheuristique inspiree du comportement social des oiseaux et des poissons. Developpe par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.\n",
     "\n",
+    "**Source primaire.** Le PSO a ete introduit par James Kennedy et Russell Eberhart dans *Particle Swarm Optimization* (1995), Proceedings of the IEEE International Conference on Neural Networks (Perth, vol. 4, pp. 1942-1948 ; DOI 10.1109/ICNN.1995.488968). Inspire des modeles sociaux de Reynolds sur les vols d'oiseaux, il formalise la notion de particule guidee conjointement par sa meilleure experience personnelle (pBest) et celle de l'essaim (gBest) -- l'equation de mise a jour ci-dessous en est la formulation canonique.\n",
+    "\n",
     "### Principes fondamentaux (PSO canonique)\n",
     "\n",
     "1. **Particules** : Chaque particule represente une solution candidate\n",


### PR DESCRIPTION
## Summary

Continues the **#3164 citation-anchoring** audit on the Sudoku series (my .NET partition). Sibling to #4202 (Sudoku-3 GA / Sudoku-4 SA) and #4207 (Sudoku-2 DLX).

`Sudoku-5-PSO-Csharp.ipynb` teaches **Particle Swarm Optimization** and names « Kennedy et Eberhart en 1995 » at the teaching point, then presents the **canonical velocity update equation** (pBest / gBest). But the notebook had **no references section at all** — the founding paper was never cited.

## Change (markdown-only, 1 cell, +2 lines)

A **« Source primaire »** paragraph anchored right after the Kennedy-Eberhart introduction, linking the canonical velocity equation presented just below to its academic origin.

## G.1 verification (anti-hallucination)

- **Omission confirmed firsthand**: scanned all 33 cells — no `References`/`Origine`/`Source primaire`/`Bibliographie` section exists. Kennedy/Eberhart appear exactly once (the bare naming at the teaching point).
- **Citation verified by web search** (IEEE Xplore, SciRP, Semantic Scholar, Tufts, U. Washington — 5 independent sources):
  > Kennedy, J. & Eberhart, R. (1995), *Particle Swarm Optimization*, Proc. IEEE Int. Conf. on Neural Networks, Perth, Australia, vol. 4, pp. 1942–1948, DOI 10.1109/ICNN.1995.488968.

## Sudoku series #3164 audit — current coverage

| Notebook | Founding concept | Anchor | PR |
|----------|------------------|--------|----|
| Sudoku-2-DancingLinks (C#) | Knuth 2000 DLX | added | #4207 |
| Sudoku-3-Genetic (C#) | Holland 1975 GA | added | #4202 |
| Sudoku-4-SimulatedAnnealing (C#) | Metropolis 1953 + Kirkpatrick 1983 SA | added | #4202 |
| **Sudoku-5-PSO (C#)** | **Kennedy & Eberhart 1995 PSO** | **added (this PR)** | **here** |
| Sudoku-7-Norvig (C#) | Norvig essay | already cited (untouched) | — |

Notebooks teaching a **tool/library** rather than a founding concept (Sudoku-1 Backtracking, Sudoku-6 AIMA-CSP — heavily cites Russell&Norvig, Sudoku-10 OR-Tools, Sudoku-12 Z3, Sudoku-15 Infer, Sudoku-16 NN, Sudoku-17 LLM) are not #3164 omissions and were left untouched (resisted fabrication, G.5).

## Scope / safety

- **Markdown-only** → C.2 exception (no re-execution; `null_exec=0`, `empty_out=0` on all 13 code cells).
- **Diff**: `1 file changed, 2 insertions(+)`. No catalog touch, no other files. Surgical JSON edit.
- FR prose matching the notebook's ASCII-French style.

Epic contribution — `See #3164`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)