### PR TITLE
feat(qc): add 3 pedagogical exercises to research_quality_lowvol (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/research/research_quality_lowvol.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_quality_lowvol.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "qlv-00",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004725,
+     "end_time": "2026-06-24T23:02:31.585174+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:31.580449+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Recherche Stratégie #5 : Quality + Low Volatility Factor Tilt\n",
     "\n",
@@ -44,7 +54,23 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "qlv-01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:31.595617Z",
+     "iopub.status.busy": "2026-06-24T23:02:31.595274Z",
+     "iopub.status.idle": "2026-06-24T23:02:34.645668Z",
+     "shell.execute_reply": "2026-06-24T23:02:34.643860Z"
+    },
+    "papermill": {
+     "duration": 3.057547,
+     "end_time": "2026-06-24T23:02:34.647429+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:31.589882+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -56,11 +82,50 @@
      ]
     }
    ],
-   "source": "import numpy as np\nimport pandas as pd\nfrom pathlib import Path\n\n# Config\nPANIER_CSV = Path(\"c:/dev/CoursIA/MyIA.AI.Notebooks/QuantConnect/datasets/panier/panier_close_all.csv\")\nLOOKBACK = 252           # 1y lookback for factor scoring\nVOL_LOOKBACK = 63        # 3m volatility\nREBAL_FREQ = 21          # monthly rebalance\nN_LONG = 8               # top N assets to hold\nTX_COST = 0.001          # 10bps transaction cost per trade\nSEEDS = [0, 1, 7, 42]\nN_SPLITS = 5\nFEE_BPS = 10\n\n# Load panier\ndf = pd.read_csv(PANIER_CSV, index_col=0, parse_dates=True)\ndf.index = pd.DatetimeIndex(df.index)\ndf = df.sort_index()\n# Exclude VIX (volatility index, no price return)\nexclude = ['VIX']\ncols = [c for c in df.columns if c not in exclude]\nprices = df[cols].ffill().dropna(how='all')\n# Keep only business days for fair comparison (crypto has 365d, equities only weekdays)\nprices = prices[prices.index.dayofweek < 5]\nprint(f\"Panier: {prices.shape[1]} symbols, {prices.shape[0]} jours (business days only)\")\nprint(f\"Periode: {prices.index.min().date()} -> {prices.index.max().date()}\")\nprint(f\"Symbols: {list(prices.columns)}\")"
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Config\n",
+    "PANIER_CSV = Path(\"c:/dev/CoursIA/MyIA.AI.Notebooks/QuantConnect/datasets/panier/panier_close_all.csv\")\n",
+    "LOOKBACK = 252           # 1y lookback for factor scoring\n",
+    "VOL_LOOKBACK = 63        # 3m volatility\n",
+    "REBAL_FREQ = 21          # monthly rebalance\n",
+    "N_LONG = 8               # top N assets to hold\n",
+    "TX_COST = 0.001          # 10bps transaction cost per trade\n",
+    "SEEDS = [0, 1, 7, 42]\n",
+    "N_SPLITS = 5\n",
+    "FEE_BPS = 10\n",
+    "\n",
+    "# Load panier\n",
+    "df = pd.read_csv(PANIER_CSV, index_col=0, parse_dates=True)\n",
+    "df.index = pd.DatetimeIndex(df.index)\n",
+    "df = df.sort_index()\n",
+    "# Exclude VIX (volatility index, no price return)\n",
+    "exclude = ['VIX']\n",
+    "cols = [c for c in df.columns if c not in exclude]\n",
+    "prices = df[cols].ffill().dropna(how='all')\n",
+    "# Keep only business days for fair comparison (crypto has 365d, equities only weekdays)\n",
+    "prices = prices[prices.index.dayofweek < 5]\n",
+    "print(f\"Panier: {prices.shape[1]} symbols, {prices.shape[0]} jours (business days only)\")\n",
+    "print(f\"Periode: {prices.index.min().date()} -> {prices.index.max().date()}\")\n",
+    "print(f\"Symbols: {list(prices.columns)}\")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "qlv-02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00448,
+     "end_time": "2026-06-24T23:02:34.657390+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:34.652910+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Construction des scores factoriels\n",
     "\n",
@@ -74,7 +139,23 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "qlv-03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:34.670881Z",
+     "iopub.status.busy": "2026-06-24T23:02:34.670151Z",
+     "iopub.status.idle": "2026-06-24T23:02:34.897776Z",
+     "shell.execute_reply": "2026-06-24T23:02:34.895999Z"
+    },
+    "papermill": {
+     "duration": 0.237036,
+     "end_time": "2026-06-24T23:02:34.899242+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:34.662206+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -97,11 +178,150 @@
      ]
     }
    ],
-   "source": "def compute_factor_scores(prices: pd.DataFrame, lookback: int = 252, vol_lb: int = 63) -> pd.DataFrame:\n    \"\"\"Compute monthly quality + low-vol factor scores.\n    \n    Quality = annualized return over lookback (momentum as quality proxy).\n    Low Vol = inverse of realized vol over vol_lb.\n    Score = 0.5 * z(quality) + 0.5 * z(low_vol)\n    \"\"\"\n    ret = prices.pct_change()\n    # Quality: rolling annualized return\n    quality = ret.rolling(lookback, min_periods=int(lookback * 0.8)).mean() * 252\n    # Low vol: inverse of rolling vol\n    vol = ret.rolling(vol_lb, min_periods=int(vol_lb * 0.8)).std() * 252**0.5\n    low_vol = 1.0 / vol.replace(0, np.nan)\n    \n    # Resample to monthly (end of month)\n    quality_m = quality.resample('ME').last()\n    low_vol_m = low_vol.resample('ME').last()\n    \n    # Cross-sectional z-score each month\n    def zscore_cross(row):\n        valid = row.dropna()\n        if len(valid) < 3:\n            return pd.Series(np.nan, index=row.index)\n        mu, sd = valid.mean(), valid.std()\n        if sd < 1e-12:\n            return pd.Series(0.0, index=row.index)\n        return (row - mu) / sd\n    \n    q_z = quality_m.apply(zscore_cross, axis=1)\n    lv_z = low_vol_m.apply(zscore_cross, axis=1)\n    \n    composite = 0.5 * q_z + 0.5 * lv_z\n    return composite.dropna(how='all')\n\nscores = compute_factor_scores(prices)\n# Check coverage\nvalid_per_row = scores.notna().sum(axis=1)\nprint(f\"Factor scores: {scores.shape[0]} mois x {scores.shape[1]} symboles\")\nprint(f\"Valid scores per row: min={valid_per_row.min()}, median={valid_per_row.median()}, max={valid_per_row.max()}\")\nprint(f\"\\nDernier mois top-5:\")\nlast = scores.iloc[-1].dropna().sort_values(ascending=False)\nfor sym, val in last.head(5).items():\n    print(f\"  {sym:8s}: score = {val:+.3f}\")\nprint(f\"\\nDernier mois bottom-3:\")\nfor sym, val in last.tail(3).items():\n    print(f\"  {sym:8s}: score = {val:+.3f}\")"
+   "source": [
+    "def compute_factor_scores(prices: pd.DataFrame, lookback: int = 252, vol_lb: int = 63) -> pd.DataFrame:\n",
+    "    \"\"\"Compute monthly quality + low-vol factor scores.\n",
+    "    \n",
+    "    Quality = annualized return over lookback (momentum as quality proxy).\n",
+    "    Low Vol = inverse of realized vol over vol_lb.\n",
+    "    Score = 0.5 * z(quality) + 0.5 * z(low_vol)\n",
+    "    \"\"\"\n",
+    "    ret = prices.pct_change()\n",
+    "    # Quality: rolling annualized return\n",
+    "    quality = ret.rolling(lookback, min_periods=int(lookback * 0.8)).mean() * 252\n",
+    "    # Low vol: inverse of rolling vol\n",
+    "    vol = ret.rolling(vol_lb, min_periods=int(vol_lb * 0.8)).std() * 252**0.5\n",
+    "    low_vol = 1.0 / vol.replace(0, np.nan)\n",
+    "    \n",
+    "    # Resample to monthly (end of month)\n",
+    "    quality_m = quality.resample('ME').last()\n",
+    "    low_vol_m = low_vol.resample('ME').last()\n",
+    "    \n",
+    "    # Cross-sectional z-score each month\n",
+    "    def zscore_cross(row):\n",
+    "        valid = row.dropna()\n",
+    "        if len(valid) < 3:\n",
+    "            return pd.Series(np.nan, index=row.index)\n",
+    "        mu, sd = valid.mean(), valid.std()\n",
+    "        if sd < 1e-12:\n",
+    "            return pd.Series(0.0, index=row.index)\n",
+    "        return (row - mu) / sd\n",
+    "    \n",
+    "    q_z = quality_m.apply(zscore_cross, axis=1)\n",
+    "    lv_z = low_vol_m.apply(zscore_cross, axis=1)\n",
+    "    \n",
+    "    composite = 0.5 * q_z + 0.5 * lv_z\n",
+    "    return composite.dropna(how='all')\n",
+    "\n",
+    "scores = compute_factor_scores(prices)\n",
+    "# Check coverage\n",
+    "valid_per_row = scores.notna().sum(axis=1)\n",
+    "print(f\"Factor scores: {scores.shape[0]} mois x {scores.shape[1]} symboles\")\n",
+    "print(f\"Valid scores per row: min={valid_per_row.min()}, median={valid_per_row.median()}, max={valid_per_row.max()}\")\n",
+    "print(f\"\\nDernier mois top-5:\")\n",
+    "last = scores.iloc[-1].dropna().sort_values(ascending=False)\n",
+    "for sym, val in last.head(5).items():\n",
+    "    print(f\"  {sym:8s}: score = {val:+.3f}\")\n",
+    "print(f\"\\nDernier mois bottom-3:\")\n",
+    "for sym, val in last.tail(3).items():\n",
+    "    print(f\"  {sym:8s}: score = {val:+.3f}\")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "qlv-ex1-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004747,
+     "end_time": "2026-06-24T23:02:34.909917+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:34.905170+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 -- Ajouter un facteur Momentum 12-1\n",
+    "\n",
+    "Le notebook mesure la *Quality* via le rendement annualise sur 252 jours. Un facteur canonique\n",
+    "complementaire est le **Momentum 12-1** (Jegadeesh & Titman 1993) : rendement cumule sur\n",
+    "12 mois **excluant** le dernier mois, afin d'isoler le momentum de moyen terme en retirant\n",
+    "l'effet de court terme (reversal).\n",
+    "\n",
+    "**Objectif** : completer la fonction ci-dessous pour calculer le momentum 12-1 sur le panier.\n",
+    "\n",
+    "**Indices** :\n",
+    "- *Etape 1* : rendement cumule sur ~12 mois (`prices.pct_change(252)`).\n",
+    "- *Etape 2* : retirer le rendement du dernier mois (`prices.pct_change(21)`).\n",
+    "- *Etape 3* : resampler en fin de mois (`resample('ME').last()`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "qlv-ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:34.925162Z",
+     "iopub.status.busy": "2026-06-24T23:02:34.924477Z",
+     "iopub.status.idle": "2026-06-24T23:02:34.933853Z",
+     "shell.execute_reply": "2026-06-24T23:02:34.931523Z"
+    },
+    "papermill": {
+     "duration": 0.01953,
+     "end_time": "2026-06-24T23:02:34.935524+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:34.915994+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : implementer compute_momentum_12_1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Momentum 12-1 (Jegadeesh & Titman 1993)\n",
+    "# TODO etudiant : completer la fonction ci-dessous\n",
+    "def compute_momentum_12_1(prices: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"Momentum 12-1 : rendement cumule 12 mois excluant le dernier mois.\n",
+    "\n",
+    "    Indice : mom_12_1(t) ~ prices(t)/prices(t-252) - 1  puis  retirer le rendement\n",
+    "    du dernier mois (approximation pct_change(21)).\n",
+    "    Retourner un DataFrame mensuel (resample 'ME').\n",
+    "    \"\"\"\n",
+    "    # Etape 1 : rendement cumule sur ~12 mois (252 jours de cotation)\n",
+    "    mom_12 = None  # TODO etudiant : prices.pct_change(252)\n",
+    "\n",
+    "    # Etape 2 : retirer le rendement du dernier mois (~21 jours)\n",
+    "    mom_recent = None  # TODO etudiant : prices.pct_change(21)\n",
+    "\n",
+    "    # Etape 3 : momentum 12-1 puis resample fin de mois\n",
+    "    mom_12_1 = None  # TODO etudiant : (mom_12 - mom_recent).resample('ME').last()\n",
+    "\n",
+    "    return mom_12_1\n",
+    "\n",
+    "print(\"Exercice 1 a completer : implementer compute_momentum_12_1\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qlv-04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006309,
+     "end_time": "2026-06-24T23:02:34.948333+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:34.942024+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Backtest factor-tilted portfolio\n",
     "\n",
@@ -112,8 +332,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 4,
+   "id": "qlv-05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:34.964789Z",
+     "iopub.status.busy": "2026-06-24T23:02:34.964142Z",
+     "iopub.status.idle": "2026-06-24T23:02:35.811772Z",
+     "shell.execute_reply": "2026-06-24T23:02:35.810442Z"
+    },
+    "papermill": {
+     "duration": 0.857658,
+     "end_time": "2026-06-24T23:02:35.812781+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:34.955123+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -130,11 +366,110 @@
      ]
     }
    ],
-   "source": "def run_factor_tilt_backtest(prices: pd.DataFrame, scores: pd.DataFrame, n_long: int = 8,\n                            tx_cost: float = 0.001) -> pd.DataFrame:\n    \"\"\"Run monthly factor-tilted backtest.\n    \n    Each month: select top n_long by composite score, equal-weight.\n    Returns net of tx costs on position changes.\n    \"\"\"\n    ret = prices.pct_change()\n    # Monthly returns (next month after signal)\n    monthly_ret = ret.resample('ME').apply(lambda x: (1+x).prod()-1)\n    \n    signal_dates = scores.index\n    ret_dates = monthly_ret.index\n    \n    factor_ret = []\n    bh_ret = []\n    dates = []\n    prev_holdings = None\n    \n    for i in range(len(signal_dates) - 1):\n        sig_date = signal_dates[i]\n        future_rets = ret_dates[ret_dates > sig_date]\n        if len(future_rets) == 0:\n            break\n        ret_date = future_rets[0]\n        if ret_date not in monthly_ret.index:\n            continue\n        \n        row_scores = scores.loc[sig_date].dropna()\n        if len(row_scores) < n_long:\n            continue\n        selected = row_scores.nlargest(n_long).index.tolist()\n        \n        next_ret = monthly_ret.loc[ret_date]\n        valid_selected = [s for s in selected if s in next_ret.index and not np.isnan(next_ret[s])]\n        if len(valid_selected) < 3:\n            continue\n        port_ret = next_ret[valid_selected].mean()\n        \n        if prev_holdings is not None:\n            turnover = len(set(valid_selected) - set(prev_holdings)) + len(set(prev_holdings) - set(valid_selected))\n            turnover_frac = turnover / (2 * n_long)\n            port_ret -= turnover_frac * tx_cost\n        else:\n            port_ret -= tx_cost\n        \n        all_valid = next_ret.dropna()\n        bh = all_valid.mean()\n        \n        factor_ret.append(port_ret)\n        bh_ret.append(bh)\n        dates.append(ret_date)\n        prev_holdings = valid_selected\n    \n    result = pd.DataFrame({\n        'factor': factor_ret,\n        'bh': bh_ret\n    }, index=pd.DatetimeIndex(dates))\n    return result\n\nbt = run_factor_tilt_backtest(prices, scores, n_long=N_LONG, tx_cost=TX_COST)\n\ndef sharpe_ann(returns):\n    if len(returns) < 3:\n        return float('nan')\n    mu = returns.mean()\n    sigma = returns.std()\n    if sigma < 1e-12:\n        return float('nan')\n    return (mu / sigma) * 12**0.5\n\nfactor_sharpe = sharpe_ann(bt['factor'])\nbh_sharpe = sharpe_ann(bt['bh'])\n\nif len(bt) > 0:\n    factor_cagr = (1 + bt['factor']).prod() ** (12/len(bt)) - 1\n    bh_cagr = (1 + bt['bh']).prod() ** (12/len(bt)) - 1\nelse:\n    factor_cagr = bh_cagr = float('nan')\n\nprint(f\"{'='*70}\")\nprint(f\"Backtest Quality+LowVol: {len(bt)} mois, top-{N_LONG}, tx={TX_COST*10000:.0f}bps\")\nprint(f\"{'='*70}\")\nprint(f\"Factor tilt: Sharpe={factor_sharpe:.3f}, CAGR={factor_cagr:.2%}\")\nprint(f\"B&H equal:   Sharpe={bh_sharpe:.3f}, CAGR={bh_cagr:.2%}\")\nprint(f\"Delta Sharpe: {factor_sharpe - bh_sharpe:+.3f}\")\nif len(bt) > 0:\n    print(f\"\\nCumulative: Factor={(1+bt['factor']).prod():.2f}x, B&H={(1+bt['bh']).prod():.2f}x\")"
+   "source": [
+    "def run_factor_tilt_backtest(prices: pd.DataFrame, scores: pd.DataFrame, n_long: int = 8,\n",
+    "                            tx_cost: float = 0.001) -> pd.DataFrame:\n",
+    "    \"\"\"Run monthly factor-tilted backtest.\n",
+    "    \n",
+    "    Each month: select top n_long by composite score, equal-weight.\n",
+    "    Returns net of tx costs on position changes.\n",
+    "    \"\"\"\n",
+    "    ret = prices.pct_change()\n",
+    "    # Monthly returns (next month after signal)\n",
+    "    monthly_ret = ret.resample('ME').apply(lambda x: (1+x).prod()-1)\n",
+    "    \n",
+    "    signal_dates = scores.index\n",
+    "    ret_dates = monthly_ret.index\n",
+    "    \n",
+    "    factor_ret = []\n",
+    "    bh_ret = []\n",
+    "    dates = []\n",
+    "    prev_holdings = None\n",
+    "    \n",
+    "    for i in range(len(signal_dates) - 1):\n",
+    "        sig_date = signal_dates[i]\n",
+    "        future_rets = ret_dates[ret_dates > sig_date]\n",
+    "        if len(future_rets) == 0:\n",
+    "            break\n",
+    "        ret_date = future_rets[0]\n",
+    "        if ret_date not in monthly_ret.index:\n",
+    "            continue\n",
+    "        \n",
+    "        row_scores = scores.loc[sig_date].dropna()\n",
+    "        if len(row_scores) < n_long:\n",
+    "            continue\n",
+    "        selected = row_scores.nlargest(n_long).index.tolist()\n",
+    "        \n",
+    "        next_ret = monthly_ret.loc[ret_date]\n",
+    "        valid_selected = [s for s in selected if s in next_ret.index and not np.isnan(next_ret[s])]\n",
+    "        if len(valid_selected) < 3:\n",
+    "            continue\n",
+    "        port_ret = next_ret[valid_selected].mean()\n",
+    "        \n",
+    "        if prev_holdings is not None:\n",
+    "            turnover = len(set(valid_selected) - set(prev_holdings)) + len(set(prev_holdings) - set(valid_selected))\n",
+    "            turnover_frac = turnover / (2 * n_long)\n",
+    "            port_ret -= turnover_frac * tx_cost\n",
+    "        else:\n",
+    "            port_ret -= tx_cost\n",
+    "        \n",
+    "        all_valid = next_ret.dropna()\n",
+    "        bh = all_valid.mean()\n",
+    "        \n",
+    "        factor_ret.append(port_ret)\n",
+    "        bh_ret.append(bh)\n",
+    "        dates.append(ret_date)\n",
+    "        prev_holdings = valid_selected\n",
+    "    \n",
+    "    result = pd.DataFrame({\n",
+    "        'factor': factor_ret,\n",
+    "        'bh': bh_ret\n",
+    "    }, index=pd.DatetimeIndex(dates))\n",
+    "    return result\n",
+    "\n",
+    "bt = run_factor_tilt_backtest(prices, scores, n_long=N_LONG, tx_cost=TX_COST)\n",
+    "\n",
+    "def sharpe_ann(returns):\n",
+    "    if len(returns) < 3:\n",
+    "        return float('nan')\n",
+    "    mu = returns.mean()\n",
+    "    sigma = returns.std()\n",
+    "    if sigma < 1e-12:\n",
+    "        return float('nan')\n",
+    "    return (mu / sigma) * 12**0.5\n",
+    "\n",
+    "factor_sharpe = sharpe_ann(bt['factor'])\n",
+    "bh_sharpe = sharpe_ann(bt['bh'])\n",
+    "\n",
+    "if len(bt) > 0:\n",
+    "    factor_cagr = (1 + bt['factor']).prod() ** (12/len(bt)) - 1\n",
+    "    bh_cagr = (1 + bt['bh']).prod() ** (12/len(bt)) - 1\n",
+    "else:\n",
+    "    factor_cagr = bh_cagr = float('nan')\n",
+    "\n",
+    "print(f\"{'='*70}\")\n",
+    "print(f\"Backtest Quality+LowVol: {len(bt)} mois, top-{N_LONG}, tx={TX_COST*10000:.0f}bps\")\n",
+    "print(f\"{'='*70}\")\n",
+    "print(f\"Factor tilt: Sharpe={factor_sharpe:.3f}, CAGR={factor_cagr:.2%}\")\n",
+    "print(f\"B&H equal:   Sharpe={bh_sharpe:.3f}, CAGR={bh_cagr:.2%}\")\n",
+    "print(f\"Delta Sharpe: {factor_sharpe - bh_sharpe:+.3f}\")\n",
+    "if len(bt) > 0:\n",
+    "    print(f\"\\nCumulative: Factor={(1+bt['factor']).prod():.2f}x, B&H={(1+bt['bh']).prod():.2f}x\")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "qlv-06",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003734,
+     "end_time": "2026-06-24T23:02:35.820811+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:35.817077+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Walk-forward 5-fold + multi-seed\n",
     "\n",
@@ -144,8 +479,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 5,
+   "id": "qlv-07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:35.830337Z",
+     "iopub.status.busy": "2026-06-24T23:02:35.829996Z",
+     "iopub.status.idle": "2026-06-24T23:02:38.641984Z",
+     "shell.execute_reply": "2026-06-24T23:02:38.640853Z"
+    },
+    "papermill": {
+     "duration": 2.818374,
+     "end_time": "2026-06-24T23:02:38.642997+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:35.824623+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -258,7 +609,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "qlv-08",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003026,
+     "end_time": "2026-06-24T23:02:38.650275+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.647249+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Analyse par régime de marché\n",
     "\n",
@@ -267,8 +628,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 6,
+   "id": "qlv-09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:38.657430Z",
+     "iopub.status.busy": "2026-06-24T23:02:38.657171Z",
+     "iopub.status.idle": "2026-06-24T23:02:38.678135Z",
+     "shell.execute_reply": "2026-06-24T23:02:38.677228Z"
+    },
+    "papermill": {
+     "duration": 0.025525,
+     "end_time": "2026-06-24T23:02:38.678804+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.653279+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -288,11 +665,66 @@
      ]
     }
    ],
-   "source": "# Regime analysis using SPY 6-month momentum\nspy = prices['SPY'].dropna()\nspy_6m = spy.pct_change(126).resample('ME').last().dropna()\n\ndef classify_regime(ret):\n    if ret > 0.10:\n        return 'Bull'\n    elif ret < -0.10:\n        return 'Bear'\n    return 'Neutral'\n\nregimes = spy_6m.apply(classify_regime)\n# Convert regimes index to PeriodIndex for alignment\nregimes_period = regimes.copy()\nregimes_period.index = regimes_period.index.to_period('M')\n\nprint(f\"{'='*60}\")\nprint(f\"Performance par regime de marche\")\nprint(f\"{'='*60}\")\n\n# Align regime with backtest dates using PeriodIndex\nbt_period_idx = bt.index.to_period('M')\n\nfor regime in ['Bull', 'Neutral', 'Bear']:\n    mask = [regimes_period.get(p, None) == regime for p in bt_period_idx]\n    mask = np.array(mask)\n    n_months = mask.sum()\n    if n_months < 3:\n        print(f\"{regime:8s}: {n_months} mois (insuffisant)\")\n        continue\n    f_sh = sharpe_ann(bt['factor'][mask])\n    f_cagr = (1+bt['factor'][mask]).prod() ** (12/n_months) - 1\n    f_vol = bt['factor'][mask].std() * 12**0.5\n    print(f\"{regime:8s}: {n_months:3d} mois, Sharpe {f_sh:+.3f}, CAGR {f_cagr:+.2%}, Vol {f_vol:.2%}\")\n\nprint(f\"\\n--- B&H equal par regime ---\")\nfor regime in ['Bull', 'Neutral', 'Bear']:\n    mask = [regimes_period.get(p, None) == regime for p in bt_period_idx]\n    mask = np.array(mask)\n    n_months = mask.sum()\n    if n_months < 3:\n        continue\n    b_cagr = (1+bt['bh'][mask]).prod() ** (12/n_months) - 1\n    print(f\"{regime:8s}: {n_months:3d} mois, CAGR {b_cagr:+.2%}\")"
+   "source": [
+    "# Regime analysis using SPY 6-month momentum\n",
+    "spy = prices['SPY'].dropna()\n",
+    "spy_6m = spy.pct_change(126).resample('ME').last().dropna()\n",
+    "\n",
+    "def classify_regime(ret):\n",
+    "    if ret > 0.10:\n",
+    "        return 'Bull'\n",
+    "    elif ret < -0.10:\n",
+    "        return 'Bear'\n",
+    "    return 'Neutral'\n",
+    "\n",
+    "regimes = spy_6m.apply(classify_regime)\n",
+    "# Convert regimes index to PeriodIndex for alignment\n",
+    "regimes_period = regimes.copy()\n",
+    "regimes_period.index = regimes_period.index.to_period('M')\n",
+    "\n",
+    "print(f\"{'='*60}\")\n",
+    "print(f\"Performance par regime de marche\")\n",
+    "print(f\"{'='*60}\")\n",
+    "\n",
+    "# Align regime with backtest dates using PeriodIndex\n",
+    "bt_period_idx = bt.index.to_period('M')\n",
+    "\n",
+    "for regime in ['Bull', 'Neutral', 'Bear']:\n",
+    "    mask = [regimes_period.get(p, None) == regime for p in bt_period_idx]\n",
+    "    mask = np.array(mask)\n",
+    "    n_months = mask.sum()\n",
+    "    if n_months < 3:\n",
+    "        print(f\"{regime:8s}: {n_months} mois (insuffisant)\")\n",
+    "        continue\n",
+    "    f_sh = sharpe_ann(bt['factor'][mask])\n",
+    "    f_cagr = (1+bt['factor'][mask]).prod() ** (12/n_months) - 1\n",
+    "    f_vol = bt['factor'][mask].std() * 12**0.5\n",
+    "    print(f\"{regime:8s}: {n_months:3d} mois, Sharpe {f_sh:+.3f}, CAGR {f_cagr:+.2%}, Vol {f_vol:.2%}\")\n",
+    "\n",
+    "print(f\"\\n--- B&H equal par regime ---\")\n",
+    "for regime in ['Bull', 'Neutral', 'Bear']:\n",
+    "    mask = [regimes_period.get(p, None) == regime for p in bt_period_idx]\n",
+    "    mask = np.array(mask)\n",
+    "    n_months = mask.sum()\n",
+    "    if n_months < 3:\n",
+    "        continue\n",
+    "    b_cagr = (1+bt['bh'][mask]).prod() ** (12/n_months) - 1\n",
+    "    print(f\"{regime:8s}: {n_months:3d} mois, CAGR {b_cagr:+.2%}\")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "qlv-10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003077,
+     "end_time": "2026-06-24T23:02:38.685240+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.682163+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Verdict et conclusion\n",
     "\n",
@@ -304,8 +736,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 7,
+   "id": "qlv-11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:38.692473Z",
+     "iopub.status.busy": "2026-06-24T23:02:38.692217Z",
+     "iopub.status.idle": "2026-06-24T23:02:38.700396Z",
+     "shell.execute_reply": "2026-06-24T23:02:38.699632Z"
+    },
+    "papermill": {
+     "duration": 0.01295,
+     "end_time": "2026-06-24T23:02:38.701177+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.688227+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -383,6 +831,177 @@
     "    marker = ' <<<' if n == 5 else ''\n",
     "    print(f\"  {n}. {name:30s} | {v:15s} | {pr}{marker}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qlv-sec6-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003046,
+     "end_time": "2026-06-24T23:02:38.707408+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.704362+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exercices d'extension\n",
+    "\n",
+    "Les exercices ci-dessous approfondissent le notebook au-dela du verdict de reference.\n",
+    "Ils restent **stubs** (a completer) -- le notebook s'execute de bout en bout meme non resolus.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qlv-ex2-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002988,
+     "end_time": "2026-06-24T23:02:38.715261+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.712273+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 -- Score composite a 3 facteurs (ponderation personnalisee)\n",
+    "\n",
+    "Le notebook combine Quality + LowVol en 50/50. Integrer a present le **Momentum 12-1**\n",
+    "(Exercice 1) comme troisieme facteur et tester une ponderation differente (ex: 40% Quality,\n",
+    "30% LowVol, 30% Momentum).\n",
+    "\n",
+    "**Objectif** : ecrire une fonction de scoring 3-facteurs parametrable.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Reutiliser une z-score cross-sectionnel (cf. `zscore_cross` plus haut) pour normaliser chaque facteur.\n",
+    "- La signature prend les 3 series factorielles mensuelles + un tuple de poids `(w_q, w_lv, w_mom)`.\n",
+    "- Verifier que la somme des poids vaut 1.0.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "qlv-ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:38.722575Z",
+     "iopub.status.busy": "2026-06-24T23:02:38.722320Z",
+     "iopub.status.idle": "2026-06-24T23:02:38.726861Z",
+     "shell.execute_reply": "2026-06-24T23:02:38.725939Z"
+    },
+    "papermill": {
+     "duration": 0.00913,
+     "end_time": "2026-06-24T23:02:38.727501+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.718371+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : implementer compute_three_factor_score\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Score composite a 3 facteurs\n",
+    "# TODO etudiant : completer la fonction ci-dessous\n",
+    "def compute_three_factor_score(quality_m, low_vol_m, momentum_m, weights=(0.4, 0.3, 0.3)):\n",
+    "    \"\"\"Score composite z-score 3 facteurs : Quality + LowVol + Momentum_12_1.\n",
+    "\n",
+    "    weights = (w_quality, w_lowvol, w_momentum), somme a 1.0.\n",
+    "    Indice : appliquer un z-score cross-sectionnel a chaque facteur mensuel, puis combiner\n",
+    "    lineairement avec les poids. Retourner un DataFrame mensuel composite.\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : z-score cross-sectionnel de chaque facteur mensuel\n",
+    "    # TODO etudiant : combiner avec les poids (verifier sum(weights) ~ 1.0)\n",
+    "    composite = None  # TODO etudiant\n",
+    "    return composite\n",
+    "\n",
+    "print(\"Exercice 2 a completer : implementer compute_three_factor_score\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qlv-ex3-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003252,
+     "end_time": "2026-06-24T23:02:38.734053+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.730801+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 -- Portefeuille long-short (market-neutral)\n",
+    "\n",
+    "Le backtest de reference est **long-only** (top-N). Un test plus exigeant de la force du signal\n",
+    "est un portefeuille **long-short** : long les top-N, short les bottom-N. Si le signal est\n",
+    "purement directionnel (tout monte ensemble), le long-short aura un Sharpe faible ; s'il\n",
+    "capture un spread relatif, le long-short sera positif.\n",
+    "\n",
+    "**Objectif** : adapter `run_factor_tilt_backtest` en version long-short market-neutral.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Selectionner top-N (long) ET bottom-N (short) par score composite.\n",
+    "- Rendement portefeuille = `mean(long_rets) - mean(short_rets)`.\n",
+    "- Gérer le cout de transaction des deux cotes (long turnover + short turnover).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "qlv-ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T23:02:38.742152Z",
+     "iopub.status.busy": "2026-06-24T23:02:38.741876Z",
+     "iopub.status.idle": "2026-06-24T23:02:38.746036Z",
+     "shell.execute_reply": "2026-06-24T23:02:38.745223Z"
+    },
+    "papermill": {
+     "duration": 0.009729,
+     "end_time": "2026-06-24T23:02:38.746864+00:00",
+     "exception": false,
+     "start_time": "2026-06-24T23:02:38.737135+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : implementer run_long_short_backtest\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Portefeuille long-short market-neutral\n",
+    "# TODO etudiant : completer la fonction ci-dessous\n",
+    "def run_long_short_backtest(prices, scores, n_side=8, tx_cost=0.001):\n",
+    "    \"\"\"Backtest long-short : long top-N, short bottom-N, equal-weight chaque cote.\n",
+    "\n",
+    "    Indice : reprendre la structure de run_factor_tilt_backtest, mais selectionner\n",
+    "    en plus les bottom-N (nsmallest). Rendement mensuel = mean(long) - mean(short),\n",
+    "    net des couts de transaction sur les deux cotes.\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : boucle mensuelle selection top-N (long) + bottom-N (short)\n",
+    "    # TODO etudiant : calcul du rendement long-short net de couts\n",
+    "    ls_returns = None  # TODO etudiant\n",
+    "    return ls_returns\n",
+    "\n",
+    "print(\"Exercice 3 a completer : implementer run_long_short_backtest\")\n"
+   ]
   }
  ],
  "metadata": {
@@ -392,8 +1011,28 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 11.713488,
+   "end_time": "2026-06-24T23:02:39.211364+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_quality_lowvol.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_quality_lowvol_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-24T23:02:27.497876+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

`research_quality_lowvol.ipynb` (Strategy #5, EPIC #1409) is a **pedagogical** notebook (states "Objectifs d'apprentissage" + "Durée estimée: 15 min" in its header) but had **0 exercises** — below the `>=3` threshold of rule [three-exercises-per-notebook.md](.claude/rules/three-exercises-per-notebook.md).

This PR adds **3 C.1-compliant exercise stubs**, aligned with the notebook's stated learning objectives (comprendre Quality/LowVol, implémenter un scoring, comparer factor-tilted vs B&H):

| # | Exercise | Placement | Why discriminating (Prong B) |
|---|----------|-----------|------------------------------|
| Ex1 | Momentum 12-1 factor (Jegadeesh-Titman 1993) | after section 1 (scoring) | Distinct from the notebook's Quality proxy: excludes the last month to isolate mid-term momentum |
| Ex2 | 3-factor composite score with custom weights | section 6 | Extends the 50/50 Quality+LowVol blend to a parameterised 3-factor combination |
| Ex3 | Long-short market-neutral portfolio | section 6 | Distinct from the long-only reference backtest — tests whether the signal is directional or relative |

Stubs use `return None` + `# TODO etudiant` + `print("Exercice N a completer")` (C.1: notebook executes end-to-end even unresolved, no `raise NotImplementedError`/`assert False`/`1/0`).

## Validation (H.1)

```
papermill re-exec: SUCCESS, 19/19 cells, 0 error (15.1s)
code cells: 9 (6 original + 3 stubs)
  execution_count None: 0
  0 outputs: 0
exercise stub outputs:
  qlv-ex1-code exec_count=3 -> "Exercice 1 a completer : implementer compute_momentum_12_1"
  qlv-ex2-code exec_count=8 -> "Exercice 2 a completer : implementer compute_three_factor_score"
  qlv-ex3-code exec_count=9 -> "Exercice 3 a completer : implementer run_long_short_backtest"
anti-regression grep: 0 forbidden patterns
notebook_tools validate: OK 1 / Warnings 0 / Errors 0
```

**Anti-regression**: apply-script sha1 guard confirms the **6 original code cells are byte-identical** (source content unchanged). 

**Note on diff size**: the notebook's long source cells were stored as compact single-line strings (`"source": "...\n..."`); the papermill re-exec normalised them to the standard line-list representation. This is cosmetic (content sha1-verified identical), not a content change. Outputs regenerated per C.2 (code-cell additions require full re-exec).

## Scope

- 1 notebook, 1 file changed (+659/-20 incl. regenerated outputs).
- Catalogue byte-identical to origin/main (catalog-pr-hygiene).
- Atomic: single subject (#2161 rollout on 1 pedagogical notebook).

See #2161 (rollout, partial). See #1409 (curriculum context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)