### PR TITLE
lean(sudoku): prove full_house_present (pigeonhole, 0 sorry) (See #4055 #4038)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Basic.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Basic.lean
@@ -56,4 +56,31 @@ def IsPeer (scopes : Scopes ι) (c c' : ι) : Prop :=
 def PresentIn (σ : Solution ι V) (s : Finset ι) (v : V) : Prop :=
   ∃ c ∈ s, σ c = v
 
+/-- **Lemme de la maison pleine.** Si une portée `s` contient autant de cellules que de
+    valeurs possibles (`s.card = card V`) et qu'une affectation `σ` est toutes-distinctes
+    sur `s`, alors **toute** valeur `v` est présente dans `s`.
+
+    C'est l'argument de pigeonhole : `σ` restreinte à `s` est injective, donc son image
+    a `card s = card V` éléments distincts — soit la totalité de `V` — donc toute valeur
+    y apparaît. Ce lemme rend automatique l'hypothèse `PresentIn σ s v` du « hidden single »
+    (`Propagation.hidden_single_sound`) dans le cas plein-maison (cf #4055). -/
+theorem full_house_present {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
+    [DecidableEq V] (σ : Solution ι V) (s : Finset ι) (v : V)
+    (hcard : s.card = Fintype.card V) (hAD : AllDistinctOn σ s) : PresentIn σ s v := by
+  -- `AllDistinctOn σ s` ⟺ `Set.InjOn σ s` (même forme, Finset/Set membership defeq)
+  have hinj : Set.InjOn σ s := by
+    intros c hc c' hc' heq
+    exact hAD hc hc' heq
+  -- L'image `σ '' s` a même cardinalité que `s` (injectivité)
+  have hcard_img : (Finset.image σ s).card = s.card := Finset.card_image_of_injOn hinj
+  -- `σ '' s ⊆ univ`, de même cardinalité que `univ` (= card V) ⟹ `σ '' s = univ`
+  have hsub : Finset.image σ s ⊆ (Finset.univ : Finset V) := Finset.subset_univ _
+  have heq_img : Finset.image σ s = (Finset.univ : Finset V) := by
+    apply Finset.eq_of_subset_of_card_le hsub
+    rw [hcard_img, hcard]; simp
+  -- `v ∈ σ '' s` (= univ), puis `mem_image` ⟺ `∃ c ∈ s, σ c = v` = `PresentIn`
+  have hmem : v ∈ Finset.image σ s := heq_img ▸ Finset.mem_univ v
+  rw [Finset.mem_image] at hmem
+  exact hmem
+
 end Sudoku


### PR DESCRIPTION
## Summary

Step (3) of ai-01's Lean deep-queue — companion lemma for the **sudoku_lean** flagship.

`Sudoku/Basic.lean` was definition-only (7 core defs: `Scopes`, `Solution`, `AllDistinctOn`, `IsSolution`, `AgreesWith`, `IsPeer`, `PresentIn`) but proved **0** theorems. This adds the foundational **full-house (pigeonhole) lemma** the module's own docstring promised but never delivered.

### Theorem

\`\`\`lean
theorem full_house_present {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
    [DecidableEq V] (σ : Solution ι V) (s : Finset ι) (v : V)
    (hcard : s.card = Fintype.card V) (hAD : AllDistinctOn σ s) : PresentIn σ s v
\`\`\`

**Full-house / pigeonhole:** if a scope `s` has `|s| = |V|` cells and `σ` is all-distinct on `s`, then **every** value `v` is present in `s`.

This makes **automatic** the `PresentIn σ s v` hypothesis of `Propagation.hidden_single_sound` in the full-house case (a "house" = row/col/block, all full ⟹ every value occurs once).

### Proof (0 sorry)

1. `AllDistinctOn σ s` ⟺ `Set.InjOn σ s` (nested binder — the memberships interleave the implicit `⦃x₁⦄`, `⦃x₂⦄`, hence `intros c hc c' hc' heq`).
2. `Finset.card_image_of_injOn` ⟹ `|σ '' s| = |s| = card V`.
3. `σ '' s ⊆ univ` with equal cardinality ⟹ `σ '' s = univ` (`eq_of_subset_of_card_le` + `simp` to close the `card univ ≤ card V` leaf).
4. Any `v ∈ univ = σ '' s`, then `mem_image` ⟺ `∃ c ∈ s, σ c = v` = `PresentIn`.

## Lean PR checklist (§B)

| Item | Value |
|------|-------|
| `grep -cE '^\s*sorry\b' Sudoku/Basic.lean` (after) | **0** |
| `grep -cE '^\s*sorry\b' Sudoku/Basic.lean` (before) | **0** (was def-only, 0 thm) |
| `lake build Sudoku` | **SUCCESS** (8495 jobs, `Propagation` rebuilt clean — no regression) |
| `#print axioms Sudoku.full_house_present` | `[propext, Classical.choice, Quot.sound]` — standard triple, **no sorryAx** |
| Prover Python refactor? | N/A (pure Lean math lake, no `agent_tests/prover/`) |

### No regression
- Diff is **add-only**: 27 lines added, **0 deletions**.
- `Propagation.lean` (6 prose mentions "0 `sorry`" in docstrings) untouched, still 0 standalone-tactic sorries.
- Abstract constraint model (9×9 = instance, not special case) preserved.

## Scope

See #4055 (Sudoku lake epic — this is a companion lemma, partial contribution, epic stays open). See #4038 (Lean roadmap, astar/sudoku/erc20 companions). This is step (3) of the deep-queue; astar companion shipped as #4201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)