### PR TITLE
docs(gt-python): anchor canonical citations GT-2-NormalForm (minimax/Nash/vNM)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
@@ -44,7 +44,8 @@
     "\n",
     "### Prerequis\n",
     "- Notebook 1 (Setup) complete\n",
-    "- Notions de base en algebre lineaire (matrices)"
+    "- Notions de base en algebre lineaire (matrices)\n",
+    "\n\n> *Ancres savantes -- von Neumann, J. (1928), Zur Theorie der Gesellschaftsspiele, Mathematische Annalen 100:295-320 (theoreme du minimax pour les jeux a somme nulle, deja nomme ci-dessus — toute matrice de gains admet une valeur en strategies mixtes) ; von Neumann, J. & Morgenstern, O. (1944), Theory of Games and Economic Behavior, Princeton University Press (acte de naissance de la theorie des jeux moderne : formalisme des jeux en forme normale G=(N,S,u) enseigne dans ce notebook, axiomes d'utilite esperee justifiant la maximisation du gain esperer) ; Nash, J.F. (1950), Equilibrium Points in N-Person Games, Proceedings of the National Academy of Sciences 36(1):48-49 (theoreme d'existence de l'equilibre de Nash, deja nomme ci-dessus — tout jeu fini possede au moins un equilibre en strategies mixtes) ; Nash, J.F. (1951), Non-Cooperative Games, Annals of Mathematics 54(2):286-295 (version journal, preuve via le theoreme du point fixe de Brouwer ; prix Nobel d'economie 1994).*"
    ]
   },
   {
@@ -2167,7 +2168,8 @@
     "\n",
     "L'analyse de Pierre-Feuille-Ciseaux a introduit la necessite des strategies mixtes : lorsque les meilleures reponses forment un cycle, aucun equilibre en strategies pures n'existe, et la randomisation uniforme constitue le seul equilibre stable. Cette observation motive naturellement l'etude systematique des equilibres de Nash dans les notebooks suivants.\n",
     "\n",
-    "Le notebook suivant, [GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb), approfondit la classification topologique des jeux 2x2 en etudiant les 144 configurations possibles des matrices de gains, leurs symetries et les relations entre types de jeux."
+    "Le notebook suivant, [GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb), approfondit la classification topologique des jeux 2x2 en etudiant les 144 configurations possibles des matrices de gains, leurs symetries et les relations entre types de jeux.\n",
+    "\n\n### References academiques\n\n- von Neumann, J. (1928). Zur Theorie der Gesellschaftsspiele. Mathematische Annalen 100:295-320.\n- von Neumann, J. & Morgenstern, O. (1944). Theory of Games and Economic Behavior. Princeton University Press.\n- Nash, J.F. (1950). Equilibrium Points in N-Person Games. Proceedings of the National Academy of Sciences 36(1):48-49.\n- Nash, J.F. (1951). Non-Cooperative Games. Annals of Mathematics 54(2):286-295.\n\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Continuation of the **#3164 citation audit** — GameTheory-Python. Markdown-additive: a scholarly inline blockquote at the introduction + a `### References academiques` cell at the conclusion. **0 code cells changed** — pure pedagogical prose, C.2 markdown-only exception, no re-execution needed.

## Notebook anchored

**GameTheory-2-NormalForm.ipynb** — the foundational chapter on normal-form games (the `G = (N, S, u)` formalism), teaching formal definitions, dominance (IESDS), best response, mixed-strategy equilibria, and Nash equilibrium across 9 sections + 4 exercises.

**G.1 firsthand finding (textbook OMISSION)**: the notebook states two of the most canonical results in game theory as **formal theorem blocks** in its prose —
- the **minimax theorem** (von Neumann, 1928);
- the **Nash equilibrium existence theorem** (Nash, 1950);

— but with **no academic citation** (only author + year inline, no venue or journal) and **no `References academiques` cell**. The canonical theorems were named as teaching content; the founding papers were absent. This is the same OMISSION pattern as GT-4c (PR #4203), correctly surfaced because the prior "FIDELE" verdict was a *fidelity* check, not an OMISSION check.

| Taught canonical result | Founding paper anchored |
|-------------------------|-------------------------|
| Minimax theorem (named in cell, §16) | von Neumann (1928) *Zur Theorie der Gesellschaftsspiele*, Math. Annalen 100:295-320 |
| Normal-form formalism origin + expected utility | von Neumann & Morgenstern (1944) *Theory of Games and Economic Behavior*, Princeton UP |
| Nash equilibrium existence (named in cell) | Nash (1950) *Equilibrium Points in N-Person Games*, PNAS 36(1):48-49 |
| Nash (journal version) | Nash (1951) *Non-Cooperative Games*, Annals of Mathematics 54(2):286-295 (Nobel Economics Prize 1994) |

## Partition note (collision-free)

This is a **Python** notebook (`kernel: python3`) at `GameTheory/` root, disjoint from po-2026's Lean work (`social_choice_lean/`, `CooperativeGames/` — both Lean 4, separate subdirs). The GameTheory-*Python* audit belongs to the po-2025 lane.

## Validation

- `git diff` vs `origin/main`: markdown cells only, **0 code cells changed** (verified via JSON cell-type comparison).
- `nbformat` preserved (`json.dump indent=1, ensure_ascii=False`, no-BOM, UTF-8) — matches repo convention, no spurious churn.
- No re-execution required (C.2 markdown-only exception).

See #3164

---
*Part of the standing citation-audit directive. GameTheory-Python: GT-4c (Nash existence) anchored in #4203, GT-2 (NormalForm) in this PR. Remaining candidates: GT-9-BackwardInduction (Selten chain-store paradox), SocialChoice-Python (Arrow/Condorcet/Borda).*
