### PR TITLE
lean(cooperative): add SelfDualGame predicate + readers (proper+strong bridge)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1204,6 +1204,33 @@ theorem weighted_voting_game_proper (weights : N → ℝ) (quota : ℝ) (hquota 
   · linarith
   · rfl
 
+/-! ## Self-dual games
+
+A *self-dual* (transferable-utility) game is one that is simultaneously *proper* (a coalition and
+its complement cannot both win) and *strong* (they cannot both lose). For a simple game this is
+the canonical "decisive" / self-dual voting game: for every coalition, exactly one of it and its
+complement wins. -/
+def SelfDualGame (G : TUGame N) : Prop :=
+  ProperGame G ∧ StrongGame G
+
+namespace SelfDualGame
+
+/-- A self-dual game is proper. -/
+theorem proper (G : TUGame N) (hG : SelfDualGame G) : ProperGame G := hG.1
+
+/-- A self-dual game is strong. -/
+theorem strong (G : TUGame N) (hG : SelfDualGame G) : StrongGame G := hG.2
+
+/-- In a self-dual simple game, exactly one of a coalition and its complement wins: `v S = 1`
+    forces `v Sᶜ = 0` (proper), and `v S = 0` forces `v Sᶜ = 1` (strong). -/
+theorem complement_flip {G : TUGame N} (hG : SelfDualGame G) {S : Finset N}
+    (hS : G.v S = 1 ∨ G.v S = 0) : G.v Sᶜ = 0 ∨ G.v Sᶜ = 1 := by
+  rcases hS with h1 | h0
+  · exact Or.inl (hG.1 h1)
+  · exact Or.inr (hG.2 h0)
+
+end SelfDualGame
+
 /-- Player i is critical in coalition S if removing them causes S to lose -/
 def Critical (G : TUGame N) (i : N) (S : Finset N) : Prop :=
   i ∈ S ∧ G.v S = 1 ∧ G.v (S.erase i) = 0


### PR DESCRIPTION
## `SelfDualGame` — a decisive voting game (proper ∧ strong), the step 6 finale

The bridge connecting `ProperGame` (#4196) and `StrongGame` (#4206) — both just merged.
A *self-dual* (transferable-utility) game is simultaneously proper (a coalition and its
complement cannot both win) and strong (they cannot both lose), i.e. a *decisive* voting game:
for every coalition exactly one of it and its complement wins. This completes ai-01's
deep-queue step 6 ("jeu dual/self-dual proper+strong").

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `SelfDualGame` | `ProperGame G ∧ StrongGame G` | decisive-game predicate |
| `SelfDualGame.proper` | `SelfDualGame G → ProperGame G` | projection reader |
| `SelfDualGame.strong` | `SelfDualGame G → StrongGame G` | projection reader |
| `SelfDualGame.complement_flip` | `SelfDualGame G → (v S = 1 ∨ v S = 0) → (v Sᶜ = 0 ∨ v Sᶜ = 1)` | proper+strong combined |

### Why no `weighted_voting_game_self_dual` validator

A first draft carried a `weighted_voting_game_self_dual` validator with hypotheses
`2 * quota > ∑ weights` (proper) **and** `2 * quota ≤ ∑ weights` (strong) simultaneously.
Those hypotheses are **mutually contradictory** (`2q > total ∧ 2q ≤ total` is unsatisfiable), so
the theorem, while it would type-check, would be **vacuous / never applicable** — a dishonest
"validator". It was removed rather than dressed up as a real result (verify-before-claiming).
A weighted voting game with real weights is generically either proper *or* strong depending on
which side of half-the-total the quota sits, not both; the genuine self-dual case is a
non-generic tie and does not make a clean non-vacuous validator. The predicate + readers here
are the honest, useful deliverable.

### Built on freshly-merged foundations

Prouvable from `origin/main` (tip `d7a548bb1`) directly — uses only:
- `ProperGame` (#4196, merged @23:39Z)
- `StrongGame` (#4206, merged @23:39Z)

Both prerequisites merged this cycle, so this bridge carries **no stacking** risk.

### Independent region (no conflict)

Pure insertion after `weighted_voting_game_proper` (~L1206), before `def Critical` (~L1207).
Disjoint from any other pending cooperative-games work (all four prior PRs merged).

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (14s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +27/0), pure insertion. **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)