### PR TITLE
lean(kelly): foundational growth lemmas + honest docstring (0 sorry) (See #4052 #4038)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Growth.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Growth.lean
@@ -13,10 +13,12 @@ Maximiser `g` revient à maximiser la **croissance asymptotique du capital** com
 sur une infinité de paris indépendants (c'est l'optimalité de Kelly). Voir l'issue
 #4052.
 
-Ce module définit `growth` et établit la **concavité stricte** de `g` sur la zone
-admissible (vue calcul : `g''(f) < 0`). Le théorème phare d'optimalité — qui prouve
-directement `g(f) ≤ g(f*)` via la tangente `log t ≤ t − 1`, sans recourir à la
-concavité abstraite — vit dans `Kelly.lean`.
+Ce module définit `growth` et `growthGrad`, et pose les **faits fondamentaux** de
+ligne de base (croissance nulle sans pari, pente à l'origine = l'avantage). La
+concavité stricte de `g` sur la zone admissible (vue calcul `g''(f) < 0`) est la
+stratégie de preuve **contournée** par le théorème phare d'optimalité, qui démontre
+directement `g(f) ≤ g(f*)` via la tangente `log t ≤ t − 1` plutôt que d'invoquer la
+concavité abstraite — ce phare vit dans `Kelly.lean`.
 -/
 
 namespace KellyLean
@@ -34,5 +36,25 @@ noncomputable def growth (β : Bet) (f : ℝ) : ℝ :=
     ordre `growthGrad β f* = 0`). -/
 noncomputable def growthGrad (β : Bet) (f : ℝ) : ℝ :=
   β.p * β.b / winWealth β f - q β / loseWealth β f
+
+/-- **Croissance nulle sans pari** : `g(0) = 0`. Ne rien miser (`f = 0`) laisse le
+    capital inchangé — les deux multiplicateurs de richesse valent `1`, et `log 1 = 0`.
+    C'est la **ligne de base** du critère de Kelly : toute fraction `f` avec `g(f) > 0`
+    bat le « ne rien faire », toute fraction avec `g(f) < 0` lui est inférieure
+    (cf `Kelly.kelly_optimal`, qui garantit `g(f) ≤ g(f*)` et, l'edge étant positif,
+    `g(f*) > 0 = g(0)`). -/
+lemma growth_zero (β : Bet) : growth β 0 = 0 := by
+  unfold growth winWealth loseWealth
+  simp [Real.log_one]
+
+/-- **Pente à l'origine = l'avantage** : `g'(0) = b·p − q`. Sans mise (`f = 0`), la
+    pente du log-croissance vaut exactement l'« edge » `b·p − q` — soit le **numérateur**
+    de la fraction de Kelly `f* = (b·p − q)/b`. Ainsi `g'(0) > 0` ⟺ `f* > 0` (pari
+    favorable, miser), `g'(0) < 0` ⟺ `f* < 0` (pari défavorable, shorter). C'est le
+    pont entre la géométrie locale de `g` (sa pente en `0`) et le sens de la mise
+    optimale. -/
+lemma growthGrad_zero (β : Bet) : growthGrad β 0 = β.p * β.b - q β := by
+  unfold growthGrad winWealth loseWealth
+  simp [div_one]
 
 end KellyLean


### PR DESCRIPTION
## Summary

Step (3) companion for the **kelly_lean** flagship — completing the astar/sudoku/kelly trio of "fill a def-only module with 0-sorry foundational lemmas + fix the over-claiming docstring".

`Kelly/Growth.lean` was definition-only (`growth`, `growthGrad`, 0 theorems), yet its docstring **over-claimed** « établit la concavité stricte de g (g''(f) < 0) » — a result **never proven** (the flagship `Kelly.lean` deliberately *avoids* abstract concavity, proving `g(f) ≤ g(f*)` directly via `log t ≤ t − 1`). Same docstring-over-promise / def-only pattern caught G.1-firsthand in `astar/Heuristic.lean` (#4201) and `sudoku/Basic.lean` (#4215).

> **Unblocked this cycle**: deferred last cycle because the kelly flagship `#4164` was not yet merged (companion would have stacked/collided). `#4164` merged 2026-06-24T19:20:23Z → companion now cleanly stackable on `main`.

### Lemmas added (0 sorry)

\`\`\`lean
lemma growth_zero (β : Bet) : growth β 0 = 0
lemma growthGrad_zero (β : Bet) : growthGrad β 0 = β.p * β.b - q β
\`\`\`

- **`growth_zero`** — the **no-bet baseline**: `f = 0` leaves both wealth multipliers at `1`, `log 1 = 0`. The Kelly reference line: any `f` with `g(f) > 0` beats "do nothing". (Consequence: `kelly_unique` applied at `f = 0` gives `g(f*) > g(0) = 0` whenever the edge `bp − q ≠ 0`.)
- **`growthGrad_zero`** — the slope at the origin equals the **edge** `bp − q`, the **numerator** of the Kelly fraction `f* = (bp − q)/b`. So `g'(0) > 0 ⟺ f* > 0` (favorable bet), `g'(0) < 0 ⟺ f* < 0` (unfavorable, short). Bridges the local geometry of `g` with the sign of the optimal bet.

These parallel astar's `zero_admissible`/`zero_consistent` (the `f = 0` / Dijkstra base case, #4201).

### Docstring honesty fix

Removed the false « établit la concavité stricte » claim (never proven); replaced with an accurate description (defines `growth`/`growthGrad`, poses baseline facts; concavity is the proof-strategy **avoided** by the flagship). This is **not** anti-regression: it removes an *unproven claim*, not proven content.

## Lean PR checklist (§B)

| Item | Value |
|------|-------|
| `grep -cE '^\s*sorry\b' Kelly/Growth.lean` (after) | **0** |
| `grep -cE '^\s*sorry\b' Kelly/Growth.lean` (before) | **0** (was def-only, 0 thm) |
| `lake build Kelly` | **SUCCESS** (8496 jobs; `Kelly.lean` importer rebuilt clean — **no regression**) |
| `#print axioms KellyLean.growth_zero` | `[propext, Classical.choice, Quot.sound]` — standard triple, **no sorryAx** |
| `#print axioms KellyLean.growthGrad_zero` | `[propext, Classical.choice, Quot.sound]` — **no sorryAx** |
| Prover Python refactor? | N/A (pure Lean math lake, no `agent_tests/prover/`) |

### No regression
- Diff: **+26/−4** (2 lemmas add-only + docstring honesty fix).
- `Bet.lean` and `Kelly.lean` untouched, still 0 sorry; flagship `kelly_optimal`/`kelly_unique` intact.

## Scope

See #4052 (Kelly lake epic — companion lemma, partial contribution, epic stays open). See #4038 (Lean roadmap). This completes the step (3) companion trio (astar #4201 + sudoku #4215 + kelly this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)