### PR TITLE
docs(gametheory): anchor Nash 1950/1951 + von Neumann 1928 founding theorems — #3164

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
@@ -42,7 +42,9 @@
     "### Duree estimee : 60 minutes\n",
     "\n",
     "### Theoreme de Nash (1950)\n",
-    "> Tout jeu fini a au moins un equilibre de Nash (potentiellement en strategies mixtes)."
+    "> Tout jeu fini a au moins un equilibre de Nash (potentiellement en strategies mixtes).\n",
+    "\n",
+    "**Source primaire.** L'existence de l'equilibre de Nash est demontree par John F. Nash dans *Equilibrium Points in N-Person Games* (Proceedings of the National Academy of Sciences 36(1):48-49, 1950 ; DOI 10.1073/pnas.36.1.48), puis developpee en pleine generalite dans *Non-Cooperative Games* (Annals of Mathematics 54(2):286-295, 1951). L'existence repose sur le theoreme du point fixe de Brouwer (point fixe de la meilleure reponse), detaille dans le side track Lean [4b-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax.ipynb
@@ -40,7 +40,9 @@
     "\n",
     "### Theoreme Minimax (Von Neumann, 1928)\n",
     "> Dans tout jeu a deux joueurs et somme nulle, il existe une valeur $v$ telle que :\n",
-    "> $$\\max_{\\sigma} \\min_{\\tau} u(\\sigma, \\tau) = \\min_{\\tau} \\max_{\\sigma} u(\\sigma, \\tau) = v$$"
+    "> $$\\max_{\\sigma} \\min_{\\tau} u(\\sigma, \\tau) = \\min_{\\tau} \\max_{\\sigma} u(\\sigma, \\tau) = v$$\n",
+    "\n",
+    "**Source primaire.** Le theoreme minimax (existence d'une valeur du jeu en strategies mixtes pour tout jeu a somme nulle) est etabli par John von Neumann dans *Zur Theorie der Gesellschaftsspiele* (Mathematische Annalen 100:295-320, 1928 ; DOI 10.1007/BF01448847) -- l'acte de naissance de la theorie des jeux. L'equivalence avec la dualite forte de la programmation lineaire, utilisee pour la resolution numerique plus loin dans ce notebook, a ete demontree ulterieurement par Dantzig, von Neumann et Gale."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Extends the **#3164 citation-anchoring** audit to the **GameTheory .NET series** (my partition — disjoint from QC). These are the two foundational theorems of game theory, both taught with author+year attribution but **without citing the primary paper** — the exact #3164 omission pattern.

| Notebook | Teaching point (read firsthand) | Added anchor |
|----------|---------------------------------|--------------|
| `GameTheory-4-NashEquilibrium.ipynb` (cell 0) | « ### Théorème de Nash (1950) » + conclusion « concept central ... introduit par John Nash en 1950 » | **Nash 1950** (PNAS 36(1):48-49) + **1951** (Ann. Math. 54(2):286-295) + Brouwer fixed-point note + cross-ref to Lean side track 4b |
| `GameTheory-5-ZeroSum-Minimax.ipynb` (cell 0) | « ### Théorème Minimax (Von Neumann, 1928) » + intro « célèbre théorème minimax de Von Neumann (1928) » | **von Neumann 1928** *Zur Theorie der Gesellschaftsspiele* (Math. Ann. 100:295-320) + LP-duality note (Dantzig/von Neumann/Gale) connecting to the notebook's LP resolution |

## Verification methodology (anti-hallucination, G.1)

- **Omission confirmed firsthand** by reading both notebooks' intro + theorem cells (not regex-counting — unreliable, cf `exo-counting-unreliable` lesson). Each states the theorem attributed to author+year but **no `References` section exists** in either notebook, and the papers were never named.
- **Canonical citations verified by web search** (5+ independent sources each — SFI Press, Econlib, SpringerLink, Privatdozent, SciRP, EuDML):
  > Nash, J. (1950) *Equilibrium Points in N-Person Games*, PNAS 36(1):48–49, DOI 10.1073/pnas.36.1.48.
  > Nash, J.F. (1951) *Non-Cooperative Games*, Annals of Mathematics 54(2):286–295.
  > von Neumann, J. (1928) *Zur Theorie der Gesellschaftsspiele*, Mathematische Annalen 100:295–320, DOI 10.1007/BF01448847.

## Why this is #3164 (citation anchoring), not concept-density

These notebooks already have rich pedagogy (exercises, Lean side-tracks, LP resolution). They are **not** missing the concept — they teach Nash equilibrium and minimax well, but without pointing the student at the academic origin. The #3164 grain is exactly that: anchor the primary source at the teaching point, footnote-style.

**Pedagogical cross-ref added**: GT-4 anchor links to the Lean side track `4b-NashExistence` (where Brouwer's fixed point is formalized) — reinforcing the lib+notebook co-evolution. GT-5 anchor links von Neumann's 1928 theorem to the **LP duality** the notebook uses numerically (Dantzig/von Neumann/Gale), giving the student the historical reason LP solves minimax.

## Scope / safety

- **Markdown-only** → C.2 exception (no re-execution; `execution_count` + `outputs` untouched on all 28 code cells: `null_exec=0`, `empty_out=0`).
- **Diff**: `2 files changed, 8 insertions(+), 4 deletions(-)`. The 4 deletions are JSON reflow (source last-line gains trailing `\n` + closing brace shifts) — pure markdown, no cell renumbering, no content removed. Surgical JSON edit (`json.load` + `json.dump(indent=1)`) preserves byte-for-byte format.
- **0 catalog churn**, 0 README, no other files. Base `c58ff674b` (fresh `origin/main` post-merge-sweep).
- Anchors in FR prose matching the notebooks' ASCII-French style.

Epic contribution — `See #3164` (epic stays open; GameTheory-8 CombinatorialGames — Bouton 1901 / Sprague-Grundy — is a follow-up candidate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)