### PR TITLE
docs(gametheory): anchor von Neumann & Morgenstern 1944 normal form (#3164)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
@@ -114,6 +114,8 @@
     "- $u = (u_1, u_2, ..., u_n)$ : fonctions d'**utilite** (gains)\n",
     "  - $u_i : S \\to \\mathbb{R}$ : gain du joueur $i$ pour chaque profil de strategies\n",
     "\n",
+    "**Source primaire.** La representation d'un jeu en forme normale (ou strategique) par le triplet $G = (N, S, u)$ -- joueurs, strategies, fonctions d'utilite -- est codifiee par John von Neumann et Oskar Morgenstern dans *Theory of Games and Economic Behavior* (Princeton University Press, 1944), l'ouvrage fondateur de la theorie des jeux. Ce cadre, qui systematise l'usage des matrices de gains et de l'utilite esperee, demeure la definition standard de reference ; les notions de meilleure reponse et d'equilibre etudiees plus loin dans cette serie s'appuient directement sur ce formalisme.\n",
+    "\n",
     "### Cas particulier : jeux 2 joueurs\n",
     "\n",
     "Pour 2 joueurs avec $m$ et $n$ strategies, on represente le jeu par deux matrices :\n",


### PR DESCRIPTION
## Contexte

Suite de l'audit #3164 (citation anchoring) sur la série GameTheory .NET (cf #4225 Nash/minimax, #4226 Bouton/Sprague-Grundy livrés en parallèle).

`GameTheory-2-NormalForm` enseigne la formalisation canonique du jeu en forme normale — le triplet `G = (N, S, u)` (joueurs, stratégies, fonctions d'utilité), cell[2] — sans ancrer la source fondatrice. C'est l'omission la plus nette de la série : la **forme normale** est précisément le concept fondateur codifié par l'ouvrage qui a fondé la théorie des jeux.

## Changement

Ancre *Source primaire* après la définition formelle du triplet, avant le sous-paragraphe « Cas particulier : jeux 2 joueurs » :

> La représentation d'un jeu en forme normale (ou stratégique) par le triplet G = (N, S, u) — joueurs, stratégies, fonctions d'utilité — est codifiée par John von Neumann et Oskar Morgenstern dans *Theory of Games and Economic Behavior* (Princeton University Press, 1944), l'ouvrage fondateur de la théorie des jeux.

## Vérifications

- **Citation vérifiée** via WebSearch (4 sources indépendantes : JSTOR 60th anniversary edition, Scientific Research Publishing, UVA PDF de l'original, Alignment Forum) — von Neumann & Morgenstern 1944, Princeton University Press, Princeton.
- **Diff minimal** : 2 insertions, 0 suppression, cell[2] markdown uniquement.
- **C.2 exception** : modification markdown-only → pas de re-exécution (outputs précédents valides).
- **C.1** : aucun stub/exercice touché.
- **Catalogue** : byte-identique à `origin/main` (règle catalog-pr-hygiene HARD 1 respectée).
- JSON bien-formed (`json.load` OK).

See #3164

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>