### PR TITLE
docs(gt-python): anchor canonical citations GT-9-BackwardInduction (Kuhn/Rosenthal/Selten/Maynard Smith)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
@@ -36,7 +36,8 @@
     "- Notions d'equilibre de Nash et de best response\n",
     "- Bases de la recursivite (pour comprendre l'algorithme)\n",
     "\n",
-    "### Duree estimee : 55 minutes"
+    "### Duree estimee : 55 minutes\n",
+    "\n\n> *Ancres savantes -- Kuhn, H.W. (1953), Extensive Games and the Problem of Information, Contributions to the Theory of Games II, Annals of Mathematics Studies 28, Princeton University Press:193-216 (jeux sous forme extensive et induction arriere : representation en arbre de decision, information parfaite, resolution des sous-jeux — la methode fondamentale enseignee dans ce notebook) ; Rosenthal, R.W. (1981), Games of Perfect Information, Predatory Pricing and the Chain-Store Paradox, Journal of Economic Theory 25(1):92-100 (jeu du mille-pattes / centipede, paradoxe section 2 : la rationalite de l'induction arriere contredit l'intuition) ; Selten, R. (1978), The Chain Store Paradox, Theory and Decision 9(2):127-159 (paradoxe de la chaine de magasins, deja nomme \"(Selten)\" section 4 : un monopoliste national ne punirait jamais rationnellement un entrant, contredit par l'observation empirique) ; Maynard Smith, J. (1974), The Theory of Games and the Evolution of Animal Conflicts, Journal of Theoretical Biology 47(1):209-221 (jeux d'escalade / war of attrition, section 3 : le conflit couteux comme jeu d'engagement progressif en theorie evolutionnaire).*"
    ]
   },
   {
@@ -1845,7 +1846,8 @@
     "\n",
     "Les simulations de rationalite limitee ont constitue un resultat marquant : une faible probabilite d'irrationalite suffit a transformer radicalement les resultats, suggerant que la connaissance commune de la rationalite est une hypothese forte dont la relaxation enrichit considerablement le modele predictif.\n",
     "\n",
-    "Le raffinement de ces concepts se poursuit avec l'etude des menaces credibles et de l'induction avant : [GameTheory-10-ForwardInduction-SPE](GameTheory-10-ForwardInduction-SPE.ipynb)."
+    "Le raffinement de ces concepts se poursuit avec l'etude des menaces credibles et de l'induction avant : [GameTheory-10-ForwardInduction-SPE](GameTheory-10-ForwardInduction-SPE.ipynb).\n",
+    "\n\n### References academiques\n\n- Kuhn, H.W. (1953). Extensive Games and the Problem of Information. Contributions to the Theory of Games II, Annals of Mathematics Studies 28, Princeton University Press:193-216.\n- Rosenthal, R.W. (1981). Games of Perfect Information, Predatory Pricing and the Chain-Store Paradox. Journal of Economic Theory 25(1):92-100.\n- Selten, R. (1978). The Chain Store Paradox. Theory and Decision 9(2):127-159.\n- Maynard Smith, J. (1974). The Theory of Games and the Evolution of Animal Conflicts. Journal of Theoretical Biology 47(1):209-221.\n\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Continuation of the **#3164 citation audit** — GameTheory-Python. Markdown-additive: a scholarly inline blockquote at the introduction + a `### References academiques` cell at the conclusion. **0 code cells changed** — pure pedagogical prose, C.2 markdown-only exception, no re-execution needed.

## Notebook anchored

**GameTheory-9-BackwardInduction.ipynb** — backward induction (the fundamental method for solving perfect-information sequential games), illustrated through three canonical game-theory paradoxes.

**G.1 firsthand finding (textbook OMISSION)**: the notebook teaches backward induction (titular, §1) and three canonical paradoxes as central subjects — the Centipede game (§2), the War of Attrition (§3), and the Chain-store paradox (§4). The chain-store paradox was named only as "(Selten)" with **zero academic citation**; the other concepts were taught with no founding papers either. Same OMISSION pattern as GT-2 (#4216) and GT-4c (#4203).

| Taught canonical result / concept | Founding paper anchored |
|-----------------------------------|-------------------------|
| Backward induction (titular §1) | Kuhn (1953) *Extensive Games and the Problem of Information*, Annals of Math Studies 28, Princeton UP:193-216 |
| Centipede game (§2) | Rosenthal (1981) *Games of Perfect Information, Predatory Pricing and the Chain-Store Paradox*, J. Economic Theory 25(1):92-100 |
| Chain-store paradox (§4, named "(Selten)") | Selten (1978) *The Chain Store Paradox*, Theory and Decision 9(2):127-159 |
| War of Attrition (§3) | Maynard Smith (1974) *The Theory of Games and the Evolution of Animal Conflicts*, J. Theoretical Biology 47(1):209-221 |

## Partition note (collision-free)

This is a **Python** notebook (`kernel: python3`) at `GameTheory/` root, disjoint from po-2026's Lean work (`social_choice_lean/`, `CooperativeGames/` — both Lean 4, separate subdirs). The GameTheory-*Python* audit belongs to the po-2025 lane.

## Validation

- `git diff` vs `origin/main`: markdown cells only, **0 code cells changed** (verified via JSON cell-type comparison).
- `nbformat` preserved (`json.dump indent=1, ensure_ascii=False`, no-BOM, UTF-8) — matches repo convention, no spurious churn.
- No re-execution required (C.2 markdown-only exception).

See #3164

---
*Part of the standing citation-audit directive. GameTheory-Python audit: GT-4c (#4203, MERGED), GT-2 (#4216, MERGED), GT-9 (this PR). Remaining candidate: SocialChoice-Python (Arrow/Condorcet/Borda).*
