### PR TITLE
docs(argument-analysis): Mermaid architecture + pipeline diagrams (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -94,24 +94,19 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 
 ## Architecture
 
-```
-                    ┌─────────────┐
-                    │  Executor   │
-                    └──────┬──────┘
-                           │
-           ┌───────────────┼───────────────┐
-           │               │               │
-    ┌──────▼──────┐ ┌──────▼──────┐ ┌──────▼──────┐
-    │  Informal   │ │     PL      │ │ Orchestration│
-    │   Agent     │ │   Agent     │ │    Agent     │
-    └─────────────┘ └─────────────┘ └──────────────┘
-           │               │               │
-           └───────────────┴───────────────┘
-                           │
-                    ┌──────▼──────┐
-                    │   Tweety    │
-                    │  (Java/JPype)│
-                    └─────────────┘
+```mermaid
+flowchart TD
+    EX(["<b>Executor</b><br/>point d'entrée batch<br/>Papermill / MCP"])
+    IA["<b>Informal Agent</b><br/>extraction du tissu argumentatif<br/>+ détection de sophismes — couche LLM"]
+    PL["<b>PL Agent</b><br/>formalisation en<br/>logique propositionnelle"]
+    OR["<b>Orchestration Agent</b><br/>coordination déterministe<br/>ou conversationnelle"]
+    TW[("<b>Tweety</b><br/>solveur formel unique<br/>Java / JPype")]
+    EX --> IA
+    EX --> PL
+    EX --> OR
+    IA --> TW
+    PL --> TW
+    OR --> TW
 ```
 
 L'`Executor` est le seul point d'entrée (exécution batch via Papermill/MCP) : il déclenche la chaîne et agrège le rapport final. Le travail se *fan-out* vers trois agents spécialisés — **Informal** (extraction du tissu argumentatif et détection de sophismes, couche LLM), **PL** (formalisation en logique propositionnelle) et **Orchestration** (coordination déterministe ou conversationnelle) — puis *converge* vers **Tweety**, le solveur formel unique (Java via JPype).
@@ -125,6 +120,16 @@ Cette topologie en entonnoir n'est pas accidentelle : la cohérence logique est 
 3. **Validation** - Vérification cohérence via Tweety
 4. **Évaluation** - Détection de sophismes et faiblesses
 5. **Rapport** - Génération conclusion structurée
+
+```mermaid
+flowchart LR
+    TXT(["Texte<br/>argumentatif"]) --> E1["1 · Extraction<br/>prémisses, conclusions"]
+    E1 --> E2["2 · Formalisation<br/>logique propositionnelle"]
+    E2 --> E3["3 · Validation<br/>cohérence (SAT)"]
+    E3 --> E4["4 · Évaluation<br/>sophismes, faiblesses"]
+    E4 --> RAP["5 · Rapport<br/>synthèse groundée"]
+    E3 -. "requêtes SAT" .-> TW[("Tweety<br/>Java / JPype")]
+```
 
 ## Exemple de trace du pipeline
 


### PR DESCRIPTION
## Context

Per ai-01 dispatch (2026-06-25 23:50Z), po-2025 steer item #3 = **#4212 finition éditoriale** (aération prose + visuels Mermaid) sur les READMEs de ma partition (Z3/Argumentation).

**G.1 firsthand finding**: of the 4 dispatched items, only #4212 had a real gap:
- Item 2 (#1650 Phase 0.5 FR backfill) = **phantom for my partition** — all in-scope READMEs (Z3, Z3-Python, Argument_Analysis, Tweety + sub-READMEs) are *already* FR. The only EN README (`SMT/Z3.Linq/README.md`) is the upstream endjin/Z3.Linq vendored library README, **explicitly out of scope** per readme-french-first (\"fork vendored Z3.Linq\").
- #4212 was a genuine gap: my partition READMEs had **0 Mermaid diagrams / 0 concept visuals** (verified by scan). The Argument_Analysis README used ASCII-art for its architecture and a plain numbered list for its pipeline.

## Changes (Argument_Analysis family — 1 family per #4212's rolling model)

1. **Architecture diagram**: replaced the 19-line ASCII-art block with a **Mermaid flowchart** (`flowchart TD`). Preserves the funnel topology documented in the surrounding prose: single entry `Executor` fans out to three agents (Informal / PL / Orchestration), all converge to the single formal solver `Tweety`. Renders natively on GitHub; ASCII art was the degraded, hard-to-maintain version.
2. **Pipeline diagram**: added a **Mermaid flowchart** (`flowchart LR`) after the 5-stage analysis list, showing the SAT queries forking to Tweety — the pipeline was previously text-only.

## Validation

- Markdown-only (C.2 exception — README, no notebook touched, no re-exec needed).
- `CATALOG-STATUS` marker preserved **byte-identical** (catalog-pr-hygiene).
- Mermaid fences balanced (2 `mermaid` blocks, 16 fences total, even).
- Diff scoped to the single README (+23/-18); the dirty `SymbolicAI/SMT/Automata` submodule is **not** staged.
- FR content (readme-french-first).

## Scope / next

One family this PR (Argument_Analysis). Next families on my partition (Z3, Z3-Python, Tweety) are queued for subsequent rolling PRs. `See #4212` (partial contribution to the rolling epic).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>