### PR TITLE
lean(cooperative): add MinimalWinning def + veto_mem/critical_of_minimal lemmas

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1365,6 +1365,35 @@ theorem veto_iff_critical_of_winning {G : TUGame N} (hG : SimpleGame G) (i : N) 
   · intro h S hS
     exact (h S hS).1
 
+/-- A *minimal winning coalition*: `S` is winning, but every proper subset is losing.
+
+    Minimal winning coalitions are the minimal elements of the up-set of winning coalitions;
+    they form the irreducible "key" coalitions whose weight just reaches the quota in a weighted
+    voting game. A veto player, which belongs to every winning coalition, in particular belongs
+    to every minimal winning coalition. -/
+def MinimalWinning (G : TUGame N) (S : Finset N) : Prop :=
+  G.v S = 1 ∧ ∀ T ⊂ S, G.v T = 0
+
+/-- A veto player belongs to every minimal winning coalition.
+
+    A minimal winning coalition is in particular winning, so the veto property
+    (`∀ winning S, i ∈ S`) forces membership. -/
+theorem veto_mem_minimal_winning {G : TUGame N} (i : N) (hv : VetoPlayer G i)
+    {S : Finset N} (hmin : MinimalWinning G S) : i ∈ S :=
+  hv S hmin.1
+
+/-- Every member of a minimal winning coalition is critical.
+
+    Minimality says every proper subset loses, so removing any member `i ∈ S` (which yields the
+    proper subset `S.erase i`) makes `S` losing: `v (S.erase i) = 0`. Combined with `v S = 1` and
+    `i ∈ S`, this is exactly `Critical G i S`. No `SimpleGame` hypothesis is needed — this holds
+    for any `MinimalWinning` coalition (which already forces `v S = 1`). -/
+theorem critical_of_minimal_winning {G : TUGame N} {S : Finset N}
+    (hmin : MinimalWinning G S) {i : N} (himem : i ∈ S) : Critical G i S := by
+  refine ⟨himem, hmin.1, ?_⟩
+  -- `S.erase i` is a proper subset of `S` since `i ∈ S`, so minimality makes it losing.
+  exact hmin.2 (S.erase i) (Finset.erase_ssubset himem)
+
 /-- A veto player has a strictly positive raw Banzhaf index when the grand coalition wins.
 
     The veto pendant of `dummy_banzhaf_raw_zero` (a dummy has `BanzhafRaw = 0`): a veto player


### PR DESCRIPTION
## `MinimalWinning` — minimal winning coalitions (step 5 of ai-01 deep-queue)

New infrastructure for the irreducible "key" coalitions of a voting game: a *minimal winning
coalition* is one that is winning but every proper subset is losing — the minimal elements of
the up-set of winning coalitions (in a weighted voting game, those whose weight just reaches the
quota).

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `MinimalWinning` | `v S = 1 ∧ ∀ T ⊂ S, v T = 0` | minimal winning coalition predicate |
| `veto_mem_minimal_winning` | `VetoPlayer G i → MinimalWinning G S → i ∈ S` | a veto player is in every minimal winning coalition |
| `critical_of_minimal_winning` | `MinimalWinning G S → i ∈ S → Critical G i S` | every member of a minimal winning coalition is critical |

### Proofs

- **`veto_mem_minimal_winning`**: a minimal winning coalition is in particular winning
  (`MinimalWinning.1`), so the veto property (`∀ winning S, i ∈ S`) forces membership.
- **`critical_of_minimal_winning`**: removing any member `i ∈ S` yields `S.erase i`, which
  `Finset.erase_ssubset` proves is a *proper* subset of `S`; minimality (`MinimalWinning.2`)
  then forces `v (S.erase i) = 0`, and together with `v S = 1` and `i ∈ S` this is `Critical`.
  **No `SimpleGame` hypothesis needed** — the definition of `MinimalWinning` already pins
  `v S = 1`. The first draft carried `hG : SimpleGame G`, unused; dropped (verify-before-claiming).

### Independent of any pending PR (no stacking, no conflict)

Prouvable from `origin/main` (tip `c58ff674b`, the freshly-merged SelfDualGame) directly — uses
only `VetoPlayer`, `Critical`, and Mathlib `Finset.erase_ssubset`. Pure insertion after
`veto_iff_critical_of_winning` (~L1367), before `veto_banzhaf_raw_pos`. Disjoint region; no other
cooperative-games PR is currently pending.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (17s)
Build completed successfully (8435 jobs).
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +29/0), pure insertion. **0 catalogue file touched**.
- branch: fresh from `origin/main` (0 behind / 1 ahead), no rebase needed.

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)