### PR TITLE
docs(search): Part4-MGS README — Mermaid arc diagram (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
@@ -58,6 +58,19 @@ Cette partie se compose de quatorze notebooks .NET Interactive (C#), hébergés 
 
 La série couvre désormais l'arc complet : du moteur autonome (MGS-1) à la **reconstruction** des composés publiés depuis leurs primitives (MGS-5), puis à la comparaison sur benchmarks (MGS-6), à la **généralité** de la grammaire sur une représentation combinatoire (MGS-7) et à la **visualisation** des paysages de fitness, jusqu'à un relief terrestre réel (MGS-8/9), puis à la **caractérisation empirique du biais central** des composés (MGS-10) et à la **mesure falsifiable d'une synergie** d'îles hétérogènes (MGS-11), enfin au **second biais des bancs CEC** : l'alignement d'axes par rotation du paysage (MGS-12), puis à la **visualisation géométrique** de ce mécanisme — pourquoi la rotation brise la séparabilité, vu en heatmaps des paysages dé-biaisés (MGS-13) —, puis au **retour critique sur MGS-11** : MGS-14 y retrouve une synergie d'îles en calibrant la migration et le ratio exploration/exploitation, et la montre **conditionnelle** au paysage (robuste sur Ackley, absente sur Rastrigin). Descriptions détaillées notebook par notebook : voir « Parcours détaillé » ci-dessous. Feuille de route du fork : [ROADMAP.md](https://github.com/jsboige/MetaGeneticSharp/blob/main/ROADMAP.md).
 
+L'arc se résume en six vagues conceptuelles, chacune posant la brique que la suivante compose :
+
+```mermaid
+flowchart LR
+    W1["<b>Socle &amp; composition</b><br/>MGS-1 — Moteur autonome<br/>MGS-2 — Grammaire fluente<br/>(Match, Container, Scoped)"]
+    W2["<b>Structuration de population</b><br/>MGS-3 — Eukaryote<br/>(sous-populations)<br/>MGS-4 — Islands (migration)"]
+    W3["<b>Composés publiés &amp; confrontation</b><br/>MGS-5 — Reconstruire WOA/EO/FBI<br/>MGS-6 — Benchmarks<br/>(No-Free-Lunch)<br/>MGS-7 — TSP combinatoire"]
+    W4["<b>Paysages de fitness</b><br/>MGS-8 — Landscape Explorer<br/>MGS-9 — Everest (relief réel)"]
+    W5["<b>Biais &amp; mesure falsifiable</b><br/>MGS-10 — Biais central<br/>(Kudela 2022)<br/>MGS-11 — Synergie d'îles<br/>(verdict négatif)"]
+    W6["<b>Rotation &amp; retour critique</b><br/>MGS-12 — Alignement d'axes<br/>MGS-13 — Paysages dé-biaisés<br/>MGS-14 — Synergie conditionnelle"]
+    W1 --> W2 --> W3 --> W4 --> W5 --> W6
+```
+
 ## Parcours détaillé
 
 ### 1 — Introduction


### PR DESCRIPTION
## Contexte

Part of #4212 (finition éditoriale — aération prose + visuels Mermaid, famille-partitionnée). **Famille : Search/Part4-Metaheuristics** (MGS lane, partition po-2024 .NET). Disjoint de la famille Argument_Analysis livrée en parallèle par po-2025 (#4229).

## Constat

Le README de la Partie 4 (218 lignes, 14 notebooks) ouvrait par un **mur de texte** : un paragraphe d'arc de 40 lignes (l.59) décrivant l'enchaînement conceptuel des 14 notebooks en une seule phrase dense. Aucun visuel n'aidait à saisir la progression d'ensemble avant la lecture détaillée.

## Changement

Insertion d'un **diagramme Mermaid** (flowchart LR) juste après le paragraphe d'arc, qui mappe les 14 notebooks en **6 vagues conceptuelles** :

1. **Socle & composition** — MGS-1 (moteur autonome), MGS-2 (grammaire fluente)
2. **Structuration de population** — MGS-3 (Eukaryote), MGS-4 (Islands)
3. **Composés publiés & confrontation** — MGS-5 (WOA/EO/FBI), MGS-6 (benchmarks), MGS-7 (TSP)
4. **Paysages de fitness** — MGS-8 (Landscape Explorer), MGS-9 (Everest)
5. **Biais & mesure falsifiable** — MGS-10 (biais central), MGS-11 (synergie, verdict négatif)
6. **Rotation & retour critique** — MGS-12 (axes), MGS-13 (dé-biaisés), MGS-14 (synergie conditionnelle)

Chaque vague « pose la brique que la suivante compose » — le fil rouge de la série.

## Vérifications

- **Exactitude** : les 14 mappings notebook→vague sont dérivés **verbatim du contenu du README** (table des notebooks l.42-57 + parcours détaillé l.63-125). Aucune fabrication, aucun concept inventé.
- **Aération réelle** : le diagramme succède au mur de texte d'arc et le résume visuellement (ne le remplace pas — la prose détaillée reste).
- **Mermaid valide** : 1 bloc mermaid, fences équilibrées (4 = 1 mermaid + 1 powershell existant), rendu natif GitHub.
- **Markdown-only** (fichier `.md`) → règle C.2 n/a (pas de notebook).
- **readme-french-first** : labels FR.
- **catalog-pr-hygiene** : 0 marqueur CATALOG-STATUS dans ce README de série → byte-identique à `origin/main` (base fraîche `c58ff674b`).
- Diff : +13/-0, 1 fichier.

See #4212

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>