### PR TITLE
docs(search): Mermaid Progression diagram — Part2-CSP README

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -46,6 +46,17 @@ CSP-1 et CSP-2 sont incontournables : tout le paradigme — un modèle déclarat
 - **Frontières** : CSP-6 (Hybridization, le notebook le plus avancé), puis CSP-7/8/9 (Soft/Temporal/Distributed)
 - **Indépendants** : CSP-7, CSP-8 et CSP-9 sont accessibles après CSP-1 + CSP-2
 
+```mermaid
+flowchart LR
+    SOCLE["<b>Socle du paradigme</b><br/>CSP-1 — Modèle (X, D, C)<br/>&amp; backtracking + MRV/LCV<br/>CSP-2 — Propagation<br/>(AC-3, Forward Checking, MAC)"]
+    APP["<b>Applications industrielles</b><br/>CSP-3 — Contraintes globales<br/>→ CSP-4 Scheduling<br/>→ CSP-5 Optimization"]
+    FRO["<b>Frontières</b><br/>CSP-6 — Hybridization<br/>(LCG, CP+SAT/ML/LLM)<br/>→ CSP-7 Soft<br/>→ CSP-8 Temporal<br/>→ CSP-9 Distributed"]
+    IND["<b>Indépendants</b><br/>CSP-7 / CSP-8 / CSP-9<br/>(accessibles dès<br/>CSP-1 + CSP-2)"]
+    SOCLE --> APP
+    SOCLE --> FRO
+    SOCLE --> IND
+```
+
 Les notebooks CSP présupposent les bases de la Partie 1 : formalisation en espace d'états ([Search-1](../Part1-Foundations/Search-1-StateSpace.ipynb)) et backtracking ([Search-2](../Part1-Foundations/Search-2-Uninformed.ipynb)).
 
 ## Prérequis & environnement


### PR DESCRIPTION
## Summary

Ajoute un diagramme Mermaid `flowchart LR` au README de la Partie 2 (Programmation par Contraintes), juste apres la section **Progression** (prose existante lignes 43-47).

Le diagramme visualise le parcours non-lineaire deja decrit en prose : le socle **CSP-1/CSP-2** (modele X/D/C + propagation AC-3/MAC) se ramifie vers **3 chemins** distincts :
- **Applications industrielles** : CSP-3 (globales) -> CSP-4 Scheduling / CSP-5 Optimization
- **Frontieres** : CSP-6 Hybridization (LCG, CP+SAT/ML/LLM) -> CSP-7 Soft / CSP-8 Temporal / CSP-9 Distributed
- **Independants** : CSP-7/8/9 accessibles des CSP-1+CSP-2

## Verifications

- **Markdown-only** : aucun changelog de cellule code -> exception C.2 (pas de re-execution requise)
- **Fence balance** : `mermaid` (open 49 / close 58) + `text` (open 89 / close 103) = 2 paires equilibrees
- **Aucun marqueur CATALOG-STATUS** sur ce README sous-serie -> rien a preserver byte-identique
- **Fidelite prose** : le diagramme visualise la section Progression existante sans ajouter d'information nouvelle
- Base fraiche (`origin/main` c58ff674b)

## Contexte

Epic finition editoriale #4212 (rolling, famille-partitionne). 4e PR du cycle 50 apres #4232 (Part4-Metaheuristics), #4234 (Search root), #4235 (Part1-Foundations).

See #4212