### PR TITLE
docs(search): Mermaid Structure diagram — Applications README

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -35,6 +35,21 @@ Applications/
 └── Hybrid/     # Metaheuristiques / GA (7 notebooks)
 ```
 
+```mermaid
+flowchart LR
+    P1["<b>Partie 1 — Search</b><br/>exploration, jeux adversariaux"]
+    P2["<b>Partie 2 — CSP</b><br/>modélisation déclarative<br/>(X, D, C) + propagation"]
+    P4["<b>Partie 4 — Métaheuristiques</b><br/>SA, GA, ACO, recuit"]
+    S["<b>Applications Search</b> (2)<br/>ConnectFour : Minimax,<br/>MCTS, DQN-RL"]
+    C["<b>Applications CSP</b> (12)<br/>N-Queens, GraphColoring,<br/>Nurse/JobShop, Minesweeper,<br/>Wordle, Picross, WFC..."]
+    H["<b>Applications Hybrides</b> (7)<br/>EdgeDetection, Portfolio,<br/>TSP, VRP, Hyperparameter"]
+    P1 --> S
+    P2 --> C
+    P4 --> H
+    S -.->|"benchmark croisé"| H
+    C -.->|"quand l'espace explose"| H
+```
+
 ---
 
 ## Applications Search (`Search/`)


### PR DESCRIPTION
## Summary

Ajoute un diagramme Mermaid `flowchart LR` au README Applications, juste apres le bloc **Structure** (arbre ASCII existant), pour visualiser la dimension conceptuelle que l'arbre ne porte pas.

L'arbre ASCII montre la **disposition des repertoires** ; le Mermaid montre la **genealogie conceptuelle** : les 3 categories d'applications (Search/CSP/Hybrid) sont alimentees par leurs parties fondatrices respectives (Partie 1/2/4), avec deux ponts pointilles vers l'Hybride ("quand l'espace explose" ou "l'objectif se complique") — coherant avec la prose de la Conclusion (ligne 173).

## Verifications

- **Markdown-only** : aucun changelog de cellule code -> exception C.2 (pas de re-execution)
- **Fence balance** : `text` (open 31 / close 36) + `mermaid` (open 38 / close 51) = 2 paires equilibrees
- **Aucun marqueur CATALOG-STATUS** sur ce README sous-serie -> rien a preserver byte-identique
- **Complementaire, non redondant** : l'arbre = disposition fichiers, le Mermaid = flux conceptuel (genealogie parties->categories)
- Base fraiche (`origin/main` c58ff674b)

## Contexte

Epic finition editoriale #4212 (rolling, famille-partitionne). 5e PR du cycle 50 apres #4232 (Part4), #4234 (Search root), #4235 (Part1), #4236 (Part2-CSP). Derniere famille Search de ma partition.

See #4212