### PR TITLE
docs(z3): add Mermaid concept diagrams to SMT/Z3 README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -24,6 +24,17 @@ L'intérêt pédagogique : au lieu d'écrire un algorithme de backtracking pour 
 | **Vérification** | Tester les solutions | Les solutions satisfont les contraintes par construction |
 | **Limite** | Difficile à généraliser | Performance sur les très grandes instances |
 
+```mermaid
+flowchart LR
+    CD["Code C# déclaratif<br/>LINQ + Theorem&lt;T&gt;<br/>(contraintes)"] -->|"binding Z3.Linq"| SMT["Formule SMT<br/>solveur-agnostique"]
+    SMT -->|"théories<br/>(int, real, arrays, …)"| Z3[("Z3<br/>solveur SMT")]
+    Z3 --> SAT{"Satisfiable ?"}
+    SAT -->|"oui"| SOL["Solution / témoin<br/>(.Solve / .Optimize)"]
+    SAT -->|"non"| UNS["UNSAT<br/>(preuve d'impossibilité)"]
+```
+
+L'abstraction centrale du binding : on reste en C#, on décrit des contraintes, et le pipeline ci-dessus — traduction vers le solveur puis décision — se fait sans écrire un seul appel Z3 bas niveau.
+
 ## Vue d'ensemble
 
 | # | Notebook | Sujet | Durée | Statut |
@@ -153,6 +164,26 @@ La distinction centrale, que le Sudoku met en scène de façon frappante :
 | **Complexité** | Linéaire, non-backtracking | NP-dur en général (recherche dans l'espace des solutions) |
 | **Rôle** | Vérificateur (certifie) | Producteur (témoigne) |
 | **Dans cette série** | — (Z3.Linq cible la résolution d'entiers/arrays) | Cœur de la série : `Theorem<T>.Solve()` / `.Optimize()` |
+
+```mermaid
+flowchart LR
+    subgraph REC["Reconnaissance — vérifier"]
+        direction TB
+        RC["Candidat complet<br/>(chaîne / grille)"] --> RV["RE# / Z3 InRe<br/>vérification, linéaire"]
+        RV --> RD{"Motif<br/>satisfait ?"}
+        RD -->|"oui"| RO["certifié"]
+        RD -->|"non"| RX["rejeté"]
+    end
+    subgraph RES["Résolution — produire"]
+        direction TB
+        SC["Contraintes partielles<br/>(LINQ / Theorem)"] --> SV["Z3 solveur<br/>recherche, NP-dur"]
+        SV --> SD{"Satisfiable ?"}
+        SD -->|"oui"| SO["Témoin produit<br/>(.Solve / .Optimize)"]
+        SD -->|"non"| SX["UNSAT"]
+    end
+```
+
+L'asymétrie visible : la reconnaissance reçoit un **candidat complet** et le juge, la résolution ne reçoit que des **contraintes partielles** et doit construire le candidat. Le vérificateur est donc imbattable sur une grille donnée (linéaire), mais ne sait rien *inventer* — c'est ce que la série enseigne à demander au solveur.
 
 > **Leçon** : un vérificateur rapide (RE# valide une ligne Sudoku en ~18 ms) peut être **plus rapide qu'un résolveur** (Z3 produit la grille en ~27 ms) — il certifie ce qu'il ne peut produire. Les notebooks de cette série enseignent le côté *résolution* ; Z3-Python-04 et Sudoku-13 enseignent le côté *reconnaissance* et le pont entre les deux.
 


### PR DESCRIPTION
## Summary

Rolling editorial finish (**Epic #4212**) — Z3 family (`MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md`). Adds two GitHub-native Mermaid concept diagrams to a README that had **0 diagrams**, augmenting text-only sections. Markdown-only, pure addition.

See #4212 (partial contribution to the rolling editorial-finish epic).

## Changes

Two diagrams, scoped to the README alone (+31 / 0 deletions):

1. **Declarative pipeline** (after the *Déclaratif vs Impératif* table) — `C# LINQ + Theorem<T>` →(binding Z3.Linq)→ `Formule SMT` →(théories)→ `Z3 solveur` → SAT fork (`Solution / témoin` | `UNSAT`). Introduces the central paradigm the series teaches.

2. **Reconnaissance vs Résolution** (the series' central thesis, *Reconnaître ≠ Résoudre*) — two subgraphs contrasting the **vérifier** path (RE#/Z3 InRe, linéaire, takes a full candidate) with the **produire** path (Z3, NP-dur, takes partial constraints, builds the witness). Visualizes the asymmetry the prose table details.

## Validation

- `grep -c '\`\`\`mermaid'` README: **0 → 2** ; total fences even (4), no orphaned blocks.
- Diff is pure addition — no existing prose/links/anchors touched.
- No `CATALOG-STATUS` marker in this file (nothing to preserve byte-identical).
- Scope: README only. The dirty `SymbolicAI/SMT/Automata` submodule is **not** staged (#2979, user-gated).
- Mermaid labels use `<br/>` + quoted `["…"]` (em-dash, middle-dot, `…`, `&lt;T&gt;` all safe in UTF-8); renders natively on GitHub (SOTA over degraded ASCII art, cf [sota-not-workaround.md](.claude/rules/sota-not-workaround.md)).

## Partition

po-2025 lane (Z3/Argumentum/.NET/Probas). Disjoint from po-2024 (Search/MGS/GameTheory/Sudoku) and po-2026 (Lean) — no collision.