### PR TITLE
docs(z3-python): add Mermaid concept diagrams to Z3-Python README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -78,6 +78,19 @@ La série manipule un vocabulaire précis hérité de la programmation par contr
 | **Front de Pareto** | Ensemble des solutions non-dominées lorsque plusieurs objectifs se contredisent : les compromis optimaux, à départager par un humain. | 06 |
 | **Preuve par réfutation** | Une formule est valide si sa négation est insatisfiable (`unsat` sur la négation = la formule tient dans tous les cas). | 05 |
 
+```mermaid
+flowchart TD
+    A["Assertions / contraintes<br/>s.add(...)"] --> CK["s.check()"]
+    CK --> SAT["<b>sat</b>"]
+    CK --> UNS["<b>unsat</b>"]
+    CK --> UNK["<b>unknown</b>"]
+    SAT --> MS["Extraire le modèle<br/>s.model() — un témoin concret"]
+    UNS --> UC["Diagnostiquer le noyau<br/>unsat_core() — quelles contraintes<br/>conflictuent ?"]
+    UNK --> LIM["Reconnaître la limite<br/>théorie non décidable /<br/>quantificateurs / timeout"]
+```
+
+Les **trois verdicts** de `check()` appellent trois postures distinctes — c'est l'épine dorsale de l'usage du solveur, posée au notebook 01 et raffinée jusqu'au noyau d'insatisfiabilité et à la preuve par réfutation.
+
 ## Prérequis
 
 | Besoin | Détail |
@@ -164,6 +177,20 @@ Cette série vous a donné accès à **l'intégralité de la machinerie Z3**, sa
 - **La finesse** — que la distinction **satisfiabilité vs optimisation** structure l'usage du solveur : `Solver` répond « le problème a-t-il une solution ? » (`sat`/`unsat`), `Optimize` ajoute « quelle est la *meilleure* solution ? ». Et que les trois verdicts (`sat`/`unsat`/`unknown`) appellent trois postures distinctes : extraire un modèle, diagnostiquer le noyau d'insatisfiabilité, ou reconnaître honnêtement la limite du solveur (théorie non décidable, quantificateurs, timeout).
 
 La thèse est puissante et honnêtement présentée : z3-py ne promet pas la performance (Z3 est NP-difficile), mais il promet l'**expressivité** — modéliser ce que l'on *veut*, dans un langage naturel riche (entiers, réels, bits, tableaux, chaînes, quantificateurs), et laisser le solveur faire le travail de recherche. Le compromis est clair : on troque la garantie de performance contre la concision déclarative et l'accès aux théories.
+
+```mermaid
+flowchart TD
+    Q{"Un objectif<br/>à optimiser ?"}
+    Q -->|"non — juste décider"| SOLV["<b>Solver</b><br/>sat / unsat"]
+    Q -->|"oui"| OPT["<b>Optimize</b><br/>maximize / minimize"]
+    OPT --> MO{"Plusieurs<br/>objectifs ?"}
+    MO -->|"un seul"| ONE["Solution optimale<br/>unique"]
+    MO -->|"par priorité"| LEX["Lexicographique<br/>optimise puis gèle<br/>l'optimum précédent"]
+    MO -->|"contradictoires"| PARETO["Front de Pareto<br/>compromis non-dominés"]
+    PARETO --> MAXSAT["MaxSAT<br/>relâche en souples pondérées<br/>les contraintes les moins critiques"]
+```
+
+Le diagramme ci-dessus situe les deux postures du solveur — **décider** (`Solver`) ou **optimiser** (`Optimize`) — et l'escalade du notebook 06 : d'un objectif unique à plusieurs objectifs par priorité (lexicographique), puis, lorsque les objectifs se contredisent, au **front de Pareto** et à la relaxation **MaxSAT**.
 
 ### Prochaines étapes
 


### PR DESCRIPTION
## Summary

Rolling editorial finish (**Epic #4212**) — Z3-Python family (`MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md`). Adds two GitHub-native Mermaid concept diagrams to a README that had **0 diagrams**. Markdown-only, pure addition.

See #4212 (partial contribution to the rolling editorial-finish epic).

## Changes

Two diagrams, scoped to the README alone (+27 / 0 deletions):

1. **Les 3 verdicts et leurs postures** (after the *Concepts clés* table) — `s.check()` forks to `sat` → extract model / `unsat` → diagnose `unsat_core()` / `unknown` → acknowledge limit. Visualizes the recurring SMT decision spine introduced in notebook 01.

2. **Optimization escalation** (*Conclusion*) — `Solver` (décider) vs `Optimize` (optimiser), then single objective → lexicographique (by priority) → front de Pareto (contradictory) → MaxSAT (soft relaxation). Visualizes the notebook 06 capstone arc.

## Validation

- `grep -c '\`\`\`mermaid'` README: **0 → 2** ; total fences even (6 = 3 pairs, incl. pre-existing `pip install` bash block), no orphaned blocks.
- Diff is pure addition — no existing prose/links/anchors touched.
- No `CATALOG-STATUS` marker in this file (nothing to preserve byte-identical).
- Scope: README only. The dirty `SymbolicAI/SMT/Automata` submodule is **not** staged (#2979, user-gated).
- Mermaid labels: quoted `["…"]`, `<b>`/`<br/>`, em-dash/middle-dot/`…` safe in UTF-8; diamond decision nodes via `{…}`; renders natively on GitHub (SOTA, cf [sota-not-workaround.md](.claude/rules/sota-not-workaround.md)).

## Partition

po-2025 lane (Z3/Argumentum/.NET/Probas). Disjoint from po-2024 (Search/MGS/GameTheory/Sudoku) and po-2026 (Lean) — no collision. Sibling to PR #4238 (Z3 C# family).