### PR TITLE
lean(cooperative): add strong_grand_wins (StrongGame → grand coalition wins)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1096,6 +1096,17 @@ theorem weighted_voting_game_strong (weights : N → ℝ) (quota : ℝ) (hquota 
   -- The complement reaches the quota, so its value is `1`.
   exact if_pos hSc_ge
 
+/-- A strong game has a winning grand coalition.
+
+    The empty coalition is always losing (`TUGame.empty_zero`), and its complement is the grand
+    coalition `Finset.univ`. The strong property (`v S = 0 → v Sᶜ = 1`) applied to `S = ∅`
+    therefore forces `v univ = 1`: a strong game is non-degenerate in the sense that the grand
+    coalition wins. -/
+theorem strong_grand_wins {G : TUGame N} (hG : StrongGame G) : G.v Finset.univ = 1 := by
+  have hcomp : (∅ : Finset N)ᶜ = Finset.univ := by simp
+  have := hG G.empty_zero
+  rwa [hcomp] at this
+
 /-! ## Monotone games
 
 A *monotone* (transferable-utility) game is one where enlarging a coalition never


### PR DESCRIPTION
## `strong_grand_wins` — a strong game forces the grand coalition to win

**Step 6 follow-on** of the rich veto / simple-voting-game theory enabled by the
proper/strong/self-dual infrastructure (#4196 ProperGame, #4206 StrongGame, #4221 SelfDualGame).
`StrongGame` is the dual of `ProperGame`; this theorem establishes its **non-degeneracy**:
the grand coalition is winning.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `strong_grand_wins` | `StrongGame G → G.v Finset.univ = 1` | non-degeneracy of strong games |

### Proof

- The empty coalition is always losing: `TUGame.empty_zero : G.v ∅ = 0`.
- Its complement is the grand coalition: `(∅ : Finset N)ᶜ = Finset.univ` (closed by `simp`).
- The strong property `v S = 0 → v Sᶜ = 1` applied to `S = ∅` therefore yields `v univ = 1`.

Self-contained: needs only `StrongGame` (on main, #4206) + `TUGame.empty_zero`. No reference to
unmerged symbols — no stacking on #4231 (MinimalWinning, still pending review).

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (16s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native `lake.exe`)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (`^\s*sorry\s*$|:=\s*by\s*sorry`, `--exclude-dir=.lake`) — no proof stubbed → no regression
- axiom check: standard axioms only (`empty_zero`, Finset `simp` lemmas); no `sorry`/`sorryAx`
- diff scope: **1 file** (`Shapley.lean` +11), inserted after `weighted_voting_game_strong`, before `## Monotone games`. **0 catalogue file touched**.
- branch: fresh from `origin/main` tip `c58ff674b` (0 behind / 1 ahead), no rebase needed.

The `push_neg` deprecation warning at L1089 is in the **existing** `weighted_voting_game_strong`
(merged in #4206); this PR's new theorem adds **zero** new warnings (uses `simp` + `rwa` only).

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)