### PR TITLE
docs(tweety): add Mermaid concept diagrams to Tweety README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -59,6 +59,20 @@ Cette série ne propose pas de choisir l'un ou l'autre, mais de **comprendre les
 
 ## Parcours d'apprentissage
 
+```mermaid
+flowchart LR
+    P1["<b>Phase 1</b><br/>Fondations<br/>logiques PL / FOL / DL / modale<br/>NB 1-3"]
+    P2["<b>Phase 2</b><br/>Révision de croyances<br/>AGM, MUS, MaxSAT<br/>NB 4"]
+    P3["<b>Phase 3</b><br/>Argumentation<br/>Dung + ASPIC/DeLP<br/>NB 5-6"]
+    P4["<b>Phase 4</b><br/>Frameworks avancés<br/>ADF, WAF, ranking, probabiliste<br/>NB 7a-7b"]
+    P5["<b>Phase 5</b><br/>Applications<br/>dialogues, vote, préférences<br/>NB 8-9"]
+    P1 --> P2 --> P3 --> P4 --> P5
+    classDef core fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    class P3 core;
+```
+
+Le cœur de la série est la **Phase 3** (argumentation, surlignée) — les fondations logiques et la révision de croyances y mènent, les frameworks avancés et les applications en découlent. Le détail de chaque phase suit.
+
 ### Phase 1 : Fondations (Notebooks 1-3, ~1.5h)
 
 La série débute avec le notebook 1 (Setup) qui configure toute l'environnement : téléchargement automatique du JDK Zulu, des 39 JARs des modules TweetyProject 1.30 (plus 3 dépendances externes), et des outils externes (Clingo pour ASP, SPASS pour la logique modale, EProver pour le premier ordre). Une fois la JVM initialisée via JPype, le notebook 2 plonge dans les logiques fondamentales : la logique propositionnelle avec les opérateurs booléens, la satisfaisabilité (SAT) via pySAT, et la logique du premier ordre avec la construction de signatures et le raisonnement avec EProver. Le notebook 3 étend ces fondations aux logiques de Description (DL) pour les ontologies, la logique modale (nécessité/possibilité) pour le raisonnement sur les mondes possibles, les formules booléennes quantifiées (QBF), et la logique conditionnelle pour le raisonnement defeasible. À l'issue de cette phase, vous maîtrisez les outils de base du raisonnement formel.
@@ -391,6 +405,23 @@ Derrière chaque cadre de la série se cache une application réelle ou un probl
 - **La révision de croyances AGM** (notebook 4) formalise comment un système rationnel met à jour ses connaissances quand une information contradictoire arrive. Applications en intégration de données, diagnostic de bases de connaissance, et fusion de sources d'information.
 - **Les frameworks étendus** (notebook 7a) généralisent Dung pour capturer des situations réelles où des arguments ont plusieurs preconditions (ADF), où des attaques ont des poids variés (WAF), ou des groupes d'arguments attaquent collectivement (SetAF).
 - **La théorie du vote** (notebook 9) est au cœur des systèmes de recommandation collective, de l'agrégation de préférences en intelligence artificielle, et des mécanismes d'incitation (mechanism design).
+
+#### Un framework de Dung, visualisé
+
+L'argumentation abstraite de Dung (notebook 5) se réduit à un **graphe orienté** : des nœuds (les arguments) et des flèches (les attaques). La question n'est pas « l'argument est-il vrai ? » mais **« survive-t-il aux attaques ? »** — c'est ce que calculent les sémantiques. Exemple minimal :
+
+```mermaid
+flowchart LR
+    C(["<b>C</b>"]) -->|"attaque"| B["<b>B</b>"]
+    B -->|"attaque"| A["<b>A</b>"]
+    classDef acc fill:#d4edda,stroke:#28a745,stroke-width:2px,color:#155724;
+    classDef rej fill:#f8d7da,stroke:#dc3545,stroke-width:2px,color:#721c24;
+    class C acc;
+    class A acc;
+    class B rej;
+```
+
+**Extension grounded** : `C` n'est attaqué par personne → **accepté** ; `B` est attaqué par l'accepté `C` → **rejeté** ; `A` n'est attaqué que par le rejeté `B` → **accepté**. D'où `{A, C}`. La règle se tient en une phrase : *un argument est acceptable si tous ses attaquants sont eux-mêmes défaits*. Les sémantiques preferred/stable, les cycles (CF2) et le raisonnement causal du notebook 5 raffinent ce même calcul.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Rolling editorial finish (**Epic #4212**) — Tweety family (`MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md`). Adds two GitHub-native Mermaid diagrams to a 568-line README that had **0 diagrams**. Markdown-only, pure addition.

See #4212 (partial contribution to the rolling editorial-finish epic).

## Changes

Two diagrams, scoped to the README alone (+31 / 0 deletions):

1. **Parcours pédagogique 5 phases** (*Parcours d'apprentissage*) — LR flowchart : Fondations (NB1-3) → Révision AGM (NB4) → **Argumentation** (NB5-6, surlignée = cœur de la série) → Frameworks avancés (NB7a-7b) → Applications multi-agents (NB8-9). Visualise l'arc pédagogique et positionne l'argumentation comme pivot.

2. **Un framework de Dung, visualisé** (*Exemples concrets*) — graphe d'attaque concret à 3 nœuds `C → B → A`, extension grounded `{A, C}` mise en évidence (vert = accepté, rouge = rejeté). Montre ce qu'**est** un framework de Dung (un graphe orienté) et comment les sémantiques calculent la **survie** aux attaques, pas la vérité — la distinction conceptuelle centrale du notebook 5.

## Validation

- `grep -c '\`\`\`mermaid'` README : **0 → 2** ; total des fences pair (20 = 10 paires, incluant les blocs bash/code d'installation préexistants), aucun bloc orphelin.
- **Marqueur `CATALOG-STATUS` byte-identical à `origin/main`** (vérifié via `diff` sur les lignes 5-10 : vide = identique).
- Le diff est une pure addition — aucune prose/liens/ancres existants modifiés.
- Scope : README uniquement. Le sous-module `SymbolicAI/SMT/Automata` (dirty) n'est **pas** staged (#2979, user-gated).
- Étiquettes Mermaid : quotées `["…"]`, `<b>`/`<br/>`, `classDef`/`class` pour la coloration des nœuds accepté/rejeté ; rendu natif sur GitHub (SOTA, cf [sota-not-workaround.md](.claude/rules/sota-not-workaround.md)).

## Partition

po-2025 lane (Z3/Argumentum/.NET/Probas). Disjoint de po-2024 (Search/MGS/GameTheory/Sudoku) et po-2026 (Lean) — aucune collision. Le seul PR du paquet avec un marqueur `CATALOG-STATUS` (préservé byte-identical). Frères de #4238 (Z3 C#) et #4240 (Z3-Python).