### PR TITLE
docs(gametheory): Mermaid diagram for series Structure (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -59,6 +59,23 @@ La série s'articule autour d'un **fil principal** qui suit la maturation histor
 
 Chaque notebook principal renvoie vers ses side tracks ; ceux-ci se lisent indépendamment et ne sont jamais des prérequis du fil principal.
 
+```mermaid
+flowchart TD
+    subgraph FIL["<b>Fil principal</b> — maturation historique"]
+        direction LR
+        P1["<b>Phase 1</b><br/>Notebooks 1-6<br/>statiques : Nash, minimax"]
+        P2["<b>Phase 2</b><br/>Notebooks 7-12<br/>dynamiques : induction, info. incomplète"]
+        P3["<b>Phase 3</b><br/>Notebooks 13-17<br/>frontières : CFR, mécanismes, RL"]
+        P1 --> P2 --> P3
+    end
+    LEAN["<b>Fil transversal Lean (b)</b><br/>2b · 4b · 8b · 15b<br/>preuve formelle des grands théorèmes"]
+    PYC["<b>Fil transversal Python (c)</b><br/>4c · 8c · 15c<br/>variantes &amp; visualisations"]
+    SC["<b>Sous-série SocialChoice</b><br/>SC-01 → SC-04<br/>Arrow · Sen · vote · SAT/Z3"]
+    FIL -.->|"formalise"| LEAN
+    FIL -.->|"approfondit"| PYC
+    FIL -.->|"prolonge (choix social)"| SC
+```
+
 ### Partie 1 : Fondations et Jeux statiques (Notebooks 1-6)
 
 | # | Notebook | Kernel | Contenu | Durée |


### PR DESCRIPTION
## Summary

Adds a Mermaid `flowchart TD` to the **`## Structure`** section of `MyIA.AI.Notebooks/GameTheory/README.md`, visualising the topology the surrounding prose already describes:

- **Fil principal** (3-phase maturation: Phase 1 statiques → Phase 2 dynamiques → Phase 3 frontières)
- **Fil transversal Lean (b)** — formalises the main thread's theorems (2b·4b·8b·15b)
- **Fil transversal Python (c)** — deepens with variants/visualisations (4c·8c·15c)
- **Sous-série SocialChoice** (SC-01→SC-04) — prolongs the choice-social block

Visualises content already present in the prose; adds no new information.

Part of the `#4212` editorial-finition lane (rolling, family-partitioned Mermaid diagrams on READMEs). Disjoint from po-2025's `#4229` (Argument_Analysis family) and my cycle-50 Search/MGS family (#4232/#4234/#4235/#4236/#4237).

## Verification

- **Markdown-only** → C.2 exception (no re-execution needed).
- **Fence balance**: 1 new ```` ```mermaid ```` block, balanced open/close (verified via grep `^\`\`\`` — new pair at lines 62/77, all pre-existing pairs intact).
- **CATALOG-STATUS** marker byte-identical to `origin/main` (lines 5-10 unchanged).
- **Faithfulness**: every node/edge maps to an element of the existing Structure prose (fil principal 3 phases + 2 fils transversaux + sous-série SocialChoice). No information added.
- **Base**: fresh `origin/main` (`c58ff674b`), rebased post cycle-49 sweep.
- **Diff**: `+17/-0` (single README, insertion only).

See #4212