### PR TITLE
lean(cooperative): add carrier (intersection of winning coalitions) + iff veto players

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1405,6 +1405,30 @@ theorem critical_of_minimal_winning {G : TUGame N} {S : Finset N}
   -- `S.erase i` is a proper subset of `S` since `i ∈ S`, so minimality makes it losing.
   exact hmin.2 (S.erase i) (Finset.erase_ssubset himem)
 
+/-- The carrier of a game: the intersection of all its winning coalitions.
+
+    In voting theory the *carrier* is the set of players who belong to every winning coalition.
+    By the definition of `VetoPlayer`, membership in the carrier coincides exactly with being a
+    veto player (see `mem_carrier_iff_veto`). The notion is defined for every game; it is
+    non-trivial precisely under non-degeneracy (the existence of at least one winning coalition),
+    in which case the carrier is the set of veto players. -/
+def carrier (G : TUGame N) : Set N :=
+  ⋂₀ { S : Set N | ∃ t : Finset N, (t : Set N) = S ∧ G.v t = 1 }
+
+/-- A player belongs to the carrier (the intersection of all winning coalitions) if and only if
+    it is a veto player. Both directions are the unfoldings of the intersection (`Set.mem_sInter`,
+    membership in an arbitrary intersection is membership in each component) and of `VetoPlayer`
+    (a veto player lies in every winning coalition). -/
+theorem mem_carrier_iff_veto (G : TUGame N) (i : N) :
+    i ∈ carrier G ↔ VetoPlayer G i := by
+  constructor
+  · intro hi t ht
+    exact Finset.mem_coe.mp (Set.mem_sInter.mp hi (t : Set N) ⟨t, rfl, ht⟩)
+  · intro hv
+    apply Set.mem_sInter.mpr
+    rintro S ⟨t, rfl, ht⟩
+    exact Finset.mem_coe.mpr (hv t ht)
+
 /-- A veto player has a strictly positive raw Banzhaf index when the grand coalition wins.
 
     The veto pendant of `dummy_banzhaf_raw_zero` (a dummy has `BanzhafRaw = 0`): a veto player


### PR DESCRIPTION
## `carrier` — the intersection of all winning coalitions equals the veto players

**Deep-queue step** (carrier = ⋂ winning coalitions = set of veto players). Introduces the
*carrier* of a cooperative game — a standard voting-theory notion — as the intersection of all
winning coalitions, and proves that membership in the carrier coincides with being a veto player.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `carrier` | `⋂₀ { S : Set N | ∃ t : Finset N, (t : Set N) = S ∧ G.v t = 1 }` | intersection of all winning coalitions |
| `mem_carrier_iff_veto` | `i ∈ carrier G ↔ VetoPlayer G i` | carrier membership iff veto player |

### Proof

The iff holds for **every** game (no `SimpleGame` hypothesis needed — both sides are defined for
general games):

- **Forward** (`i ∈ carrier G → VetoPlayer G i`): `Set.mem_sInter` unfolds intersection membership
  into "membership in each component", so for any winning coalition `t`, `i ∈ (t : Set N)`;
  `Finset.mem_coe` converts back to Finset membership `i ∈ t`, which is the `VetoPlayer` definition.
- **Reverse** (`VetoPlayer G i → i ∈ carrier G`): `VetoPlayer` gives `i ∈ t` for every winning `t`;
  `Finset.mem_coe` lifts to Set membership, and `Set.mem_sInter.mpr` packages it as intersection
  membership.

Both directions are the canonical unfoldings, so the proof is short by design — the contribution is
**naming** the carrier notion and connecting it to `VetoPlayer`, in the same spirit as the
`MinimalWinning` definition (#4231). The notion is non-trivial precisely under non-degeneracy
(≥1 winning coalition), in which case the carrier is exactly the set of veto players.

Self-contained: needs only `VetoPlayer` (on main) + `TUGame`. No reference to unmerged symbols.

### Proof integrity (lean-merge-discipline §1 / §B)

```
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native `lake.exe`)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (`^\s*sorry\s*$|:=\s*by\s*sorry`, `--exclude-dir=.lake`) — no proof stubbed → no regression
- axiom check: standard axioms only (`Set.mem_sInter`, `Finset.mem_coe`); no `sorry`/`sorryAx`
- diff scope: **1 file** (`Shapley.lean` +24), inserted after `veto_iff_critical_of_winning`, before `veto_banzhaf_raw_pos`. **0 catalogue file touched**.
- branch: fresh from `origin/main` tip `c58ff674b` (0 behind / 1 ahead), no rebase needed.

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)