### PR TITLE
lean(decision-theory): strict-pref + indifference under vNM representation (0 sorry) (See #4049 #4038)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Utility/Representation.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Utility/Representation.lean
@@ -159,6 +159,61 @@ theorem affine_rep_is_rep (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityR
 
 end AffineStability
 
+section StrictAndIndifference
+
+/-!
+## Strict preference and indifference under a representation
+
+The weak representation `IsExpectedUtilityRep u P` pins down `p ≽ q ↔ E_p[u] ≥ E_q[u]`.
+Two companion characterisations follow by elementary reasoning on the order of `ℝ`,
+completing the trichotomy weak / strict / indifferent of a represented preference —
+the vNM analogue of the mono-book / probability-weights dichotomy of `Coherence`.
+-/
+
+/-- Under a representation, **strict preference** `p ≻ q` (weakly preferred one way,
+    not the other) holds exactly when the expected utility under `p` *strictly* exceeds
+    that under `q`. This is the strict companion of `IsExpectedUtilityRep`. -/
+theorem rep_strict_iff (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)
+    (p q : Lottery α) :
+    StrictPref P p q ↔ expectation p u > expectation q u := by
+  show P p q ∧ ¬ P q p ↔ expectation p u > expectation q u
+  refine ⟨fun ⟨hpp, hnqp⟩ => ?_, fun hgt => ⟨?_, ?_⟩⟩
+  · -- P p q ∧ ¬ P q p  ⟹ E_p > E_q
+    have hge : expectation p u ≥ expectation q u := (h p q).mp hpp
+    by_contra hneg
+    -- hneg : ¬ E_p > E_q  ⟹  E_p ≤ E_q  ⟹  P q p, contradicting hnqp
+    exact hnqp ((h q p).mpr (not_lt.mp hneg))
+  · -- E_p > E_q  ⟹  P p q
+    exact (h p q).mpr (le_of_lt hgt)
+  · -- E_p > E_q  ⟹  ¬ P q p
+    intro hqp
+    have hle := (h q p).mp hqp
+    linarith
+
+/-- Under a representation, **indifference** `p ~ q` (each weakly preferred to the other)
+    holds exactly when the two expected utilities coincide. Together with
+    `rep_strict_iff`, this partitions a represented preference into the three exhaustive
+    cases (strict-p / strict-q / indifferent) via the trichotomy of `ℝ`. -/
+theorem rep_indifference_iff (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)
+    (p q : Lottery α) :
+    (P p q ∧ P q p) ↔ expectation p u = expectation q u := by
+  refine ⟨fun ⟨hpp, hqp⟩ => ?_, fun heq => ?_⟩
+  · -- P p q ∧ P q p  ⟹  E_p = E_q  (squeeze the two inequalities)
+    have hge := (h p q).mp hpp
+    have hle := (h q p).mp hqp
+    linarith
+  · -- E_p = E_q  ⟹  P p q ∧ P q p
+    exact ⟨(h p q).mpr (by linarith), (h q p).mpr (by linarith)⟩
+
+/-- **Irreflexivity of strict preference** under a representation: no lottery is strictly
+    preferred to itself. Immediate corollary of `rep_strict_iff` (`E_p > E_p` is absurd). -/
+theorem strict_irrefl (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)
+    (p : Lottery α) : ¬ StrictPref P p p := by
+  rw [rep_strict_iff u P h]
+  exact lt_irrefl _
+
+end StrictAndIndifference
+
 /-!
 ## Existence direction — OPEN milestone
 


### PR DESCRIPTION
## Companion du module VNM (#4049, CLOSED) — trichotomie stricte / indifférence de la représentation

Le module `Utility` (#4049) a livré la **direction sound** du théorème de représentation vNM : `IsExpectedUtilityRep u P` (la version **faible** `p ≽ q ↔ E_p[u] ≥ E_q[u]`), les 4 axiomes sous représentation, et la stabilité affine. Cette PR complète la **trichotomie faible / stricte / indifférente** que la version faible seule laissait ouverte — le compagnon naturel, parallèle à la dichotomie mono-livret / poids-probabilistes de `Coherence` (#4193 + #4244).

### Contenu (`Utility/Representation.lean`, +55/-0, ajout pur — nouvelle section `StrictAndIndifference`)

| Lemme | Énoncé |
|-------|--------|
| `rep_strict_iff` | `StrictPref P p q ↔ expectation p u > expectation q u` — la version stricte de la représentation |
| `rep_indifference_iff` | `(P p q ∧ P q p) ↔ expectation p u = expectation q u` — indifférence ↔ égalité des utilités espérées |
| `strict_irrefl` | `¬ StrictPref P p p` — irreflexivité (corollaire immédiat via `lt_irrefl`) |

`StrictPref` était défini (`Axioms.lean:29`) mais **jamais relié aux espérances** — gap désormais comblé. Les trois cas (préféré-strictement / strictement-préféré / indifférent) sont exhaustifs via la trichotomie de `ℝ`.

### Cadrage honnête (G.3/G.9)
La **direction existence** du théorème vNM (toute préférence rationnelle admet une représentation, Herstein–Milnor 1953) reste **OPEN** (documenté dans le module). Cette PR enrichit le module CLOSED #4049, ne touche pas au jalon existence.

### §B — Preuve de progrès vérifiable (Lean PR)
1. **`grep -c sorry`** : les 6 occurrences de "sorry" dans `Representation.lean` sont **toutes prose pré-existante** (lignes 18, 21, 45, 125, 231, 232 — docstrings « sorry-free » / « sorry-backed »). Mes ajouts : **0 nouveau sorry** (ajout pur). CI `standalone-tactic` baseline : net-zéro.
2. **Lake build SUCCESS** : `lake build Utility` → `Build completed successfully (8317 jobs)` ; `✔ Built Utility.Representation (246s)` (build local, succès attesté par la chaîne lake, exit vérifié).
3. **Proof integrity SUCCESS** : `#print axioms` sur les 3 nouveaux lemmes → `[propext, Classical.choice, Quot.sound]` — **no sorryAx**.
4. N/A (pas de refactor prover Python).

### Anti-regression
Ajout pur (+55/-0), aucun contenu existant modifié. Preuves utilisent uniquement `linarith`, `not_lt`, `le_of_lt`, `lt_irrefl` + le keystone `IsExpectedUtilityRep`. Compatible avec le module CLOSED.

See #4049, #4038. Epic CoursIA-2 Lean deep-queue (po-2026, item #2 — grains tractables no-new-lake).