### PR TITLE
fix(sl-10): repair stale HMM cross-ref after #4192 notebook move

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
@@ -2229,7 +2229,7 @@
     "| [`Probas/Infer/Infer-11-Sequences`](../../Probas/Infer/Infer-11-Sequences.ipynb) | distributions sur sequences = automates ponderes (le coeur du pont) |\n",
     "| [`Probas/Infer-101`](../../Probas/Infer-101.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |\n",
     "| [`Probas/Infer/Infer-3-Factor-Graphs`](../../Probas/Infer/Infer-3-Factor-Graphs.ipynb) | graphes de facteurs + passage de messages = le forward generalise |\n",
-    "| [`Probas/PyMC-HMM-Trading-Alpha`](../../Probas/PyMC-HMM-Trading-Alpha.ipynb) | le meme HMM, cote Python (PyMC) |\n",
+    "| [`HMM Gaussian Alpha`](../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb) | le meme HMM gaussien, cote Python (hmmlearn) |\n",
     "\n",
     "### Pour aller plus loin (exercice du pont)\n",
     "\n",


### PR DESCRIPTION
## Summary

SL-10 (Active Automata Learning / L\*) section 9 « Pont vers Infer.NET » contains a cross-reference table linking the HMM notebook on the Python side. One row pointed at \`Probas/PyMC-HMM-Trading-Alpha.ipynb\`, a path that **no longer exists**: that notebook was relocated to \`QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb\` by **#4192** (merged).

This PR repairs the single broken row:
- **Path**: \`../../Probas/PyMC-HMM-Trading-Alpha.ipynb\` → \`../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb\` (same \`../../\` relative convention as the other 3 Infer rows in the table).
- **Label**: the description said « cote Python (PyMC) », but the relocated notebook imports \`from hmmlearn import hmm\` — **not** PyMC. Corrected to « cote Python (hmmlearn) » to reflect the actual library. Display text updated to the notebook's real title « HMM Gaussian Alpha ».

## Scope

Single-subject, atomic (G.4). One markdown table row in one markdown cell of \`SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb\`. Nothing else touched.

## Verification

- **C.2 exception (markdown-only)**: edited cell is \`cell_type: markdown\` — no \`execution_count\`, no \`outputs\`. No re-execution required.
- **Minimal diff**: surgical \`json.load\` / \`json.dump(indent=1, ensure_ascii=False)\` round-trip (not \`NotebookEdit\`, which re-serializes papermill metadata). Diff = \`1 insertion(+), 1 deletion(-)\`, byte-for-byte.
- **Target exists** (G.1): \`hmm_alpha_research.ipynb\` present at the new path from the worktree rooted on fresh \`origin/main\` (HEAD \`469c37cab\`).
- **Old path confirmed gone**: \`Probas/PyMC-HMM-Trading-Alpha.ipynb\` → \`No such file\` (link was dead, fix is necessary).
- **Other 3 table rows intact**: \`Infer-11-Sequences\`, \`Infer-101\`, \`Infer-3-Factor-Graphs\` paths verified unchanged and resolving.
- **JSON valid** post-edit.

See #4192