### PR TITLE
lean(cooperative): add veto_shapley_pos (veto player has positive Shapley value)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1379,6 +1379,68 @@ theorem veto_banzhaf_raw_pos (G : TUGame N) (hG : SimpleGame G) (i : N)
   simp only [BanzhafRaw]
   exact Finset.card_pos.mpr ⟨Finset.univ, Finset.mem_filter.2 ⟨Finset.mem_univ _, hcrit⟩⟩
 
+/-- Every Shapley coefficient `s! * (n - s - 1)! / n!` is strictly positive, being a ratio of
+    strictly positive factorials (`0! = 1`). -/
+private theorem shapleyCoef_pos (n s : ℕ) : 0 < shapleyCoef n s := by
+  unfold shapleyCoef
+  exact div_pos (by exact_mod_cast Nat.mul_pos (Nat.factorial_pos _) (Nat.factorial_pos _))
+    (by exact_mod_cast Nat.factorial_pos _)
+
+/-- A veto player has a strictly positive Shapley value when the grand coalition wins.
+
+    The Shapley pendant of `dummy_shapley_zero` (a dummy has Shapley value `0`) and the
+    `veto_banzhaf_raw_pos` analogue for the Shapley value. The Shapley value is the weighted sum of
+    `i`'s marginal contributions over all predecessor coalitions `S` (with `i ∉ S`). For a veto
+    player in a simple game every such predecessor set is losing (`v S = 0` by
+    `veto_losing_without`), so each marginal contribution is `v (S ∪ {i}) ∈ {0, 1} ≥ 0`, and each
+    term of the sum is non-negative (positive coefficient times a non-negative contribution). The
+    grand coalition minus `i` is one such predecessor set; its marginal contribution is
+    `v univ - v (univ \ {i}) = 1 - 0 = 1` (by `hwin`), weighted by the strictly positive Shapley
+    coefficient it gives a strictly positive term. The whole sum is at least that single positive
+    term, hence strictly positive.
+
+    As with `veto_banzhaf_raw_pos`, the non-degeneracy hypothesis `hwin` is essential: without any
+    winning coalition a player is vacuously a veto player yet has Shapley value `0`. -/
+theorem veto_shapley_pos (G : TUGame N) (hG : SimpleGame G) (i : N)
+    (hv : VetoPlayer G i) (hwin : G.v Finset.univ = 1) :
+    0 < shapleyValue G i := by
+  -- The grand coalition minus i is a predecessor set of i whose marginal contribution is `1`.
+  set T := (Finset.univ \ ({i} : Finset N)) with hTdef
+  have hTni : i ∉ T := by simp [hTdef]
+  have hTuni : T ∪ ({i} : Finset N) = Finset.univ :=
+    Finset.sdiff_union_of_subset (Finset.subset_univ _)
+  have hvT : G.v T = 0 := veto_losing_without hG hv hTni
+  -- Every Shapley-sum term is non-negative: `v S = 0` (veto, `i ∉ S`), so the marginal
+  -- contribution is `v (S ∪ {i}) ∈ {0, 1}` and the coefficient is strictly positive.
+  have hnonneg : ∀ S ∈ Finset.univ.filter fun S => i ∉ S,
+      0 ≤ shapleyCoef (Fintype.card N) S.card * G.marginalContribution i S := by
+    rintro S hS
+    obtain ⟨-, hni⟩ := Finset.mem_filter.mp hS
+    have hvS : G.v S = 0 := veto_losing_without hG hv hni
+    have hmc : G.marginalContribution i S = G.v (S ∪ {i}) := by
+      show G.v (S ∪ {i}) - G.v S = G.v (S ∪ {i})
+      rw [hvS, sub_zero]
+    rw [hmc]
+    have hvSi : 0 ≤ G.v (S ∪ {i}) := by
+      rcases hG (S ∪ {i}) with h | h <;> rw [h] <;> norm_num
+    exact mul_nonneg (shapleyCoef_pos _ _).le hvSi
+  -- The term indexed by `T` is strictly positive: marginal `= 1`, coefficient `> 0`.
+  have hTin : T ∈ Finset.univ.filter fun S => i ∉ S := by
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]; exact hTni
+  have hmcT : G.marginalContribution i T = 1 := by
+    show G.v (T ∪ {i}) - G.v T = 1
+    rw [hTuni, hvT, sub_zero]; exact hwin
+  have htermT :
+      0 < shapleyCoef (Fintype.card N) T.card * G.marginalContribution i T := by
+    rw [hmcT]; exact mul_pos (shapleyCoef_pos _ _) zero_lt_one
+  -- The sum over the whole filter is at least the single positive term indexed by `T`.
+  have hle :=
+    Finset.sum_le_sum_of_subset_of_nonneg
+      (Finset.singleton_subset_iff.mpr hTin)
+      (fun S hSF _ => hnonneg S hSF)
+  rw [Finset.sum_singleton] at hle
+  exact htermT.trans_le hle
+
 /-- Dummy player: adds no value -/
 def DummyPlayer (G : TUGame N) (i : N) : Prop :=
   ∀ S : Finset N, i ∉ S → G.v (S ∪ {i}) = G.v S


### PR DESCRIPTION
## `veto_shapley_pos` — a veto player has a strictly positive Shapley value

**Deep-queue step 7** (Shapley lower bound for veto players). The Shapley pendant of
`dummy_shapley_zero` (a dummy has Shapley value `0`) and the `veto_banzhaf_raw_pos` analogue for
the Shapley value. A capstone power-index theorem for the Veto/Shapley lane.

> Note: my earlier dashboard note flagged this as "RISK false-in-general". On careful
> re-derivation it is **TRUE**: the issue I worried about (a veto player can have `v {i} = 0`,
> unlike a dictator) does not affect the Shapley bound, because the Shapley value sums marginal
> contributions over *all* orderings, and the ordering where `i` is last (predecessor set
> `univ \ {i}`) always contributes `1/n > 0` under `hwin`. The `v {i} = 0` case only zeroes the
> singleton-predecessor term, not the whole sum.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `shapleyCoef_pos` | `0 < shapleyCoef n s` | helper: coefficients are ratios of positive factorials |
| `veto_shapley_pos` | `SimpleGame G → VetoPlayer G i → G.v univ = 1 → 0 < shapleyValue G i` | veto ⟹ positive Shapley |

### Proof

The Shapley value is `∑ S (i ∉ S), shapleyCoef(n, |S|) * (v(S ∪ {i}) - v(S))`.

- For a veto player `i` in a `SimpleGame`, every predecessor set `S` (with `i ∉ S`) is losing:
  `v S = 0` by `veto_losing_without` (SimpleGame + VetoPlayer).
- Hence each marginal contribution is `v(S ∪ {i}) - 0 = v(S ∪ {i}) ∈ {0, 1} ≥ 0`, and each sum
  term is `non-negative coef * non-negative contribution ≥ 0` (`mul_nonneg`).
- The grand coalition minus `i` is a predecessor set whose marginal contribution is
  `v univ - v(univ \ {i}) = 1 - 0 = 1` (by `hwin`); its coefficient `shapleyCoef(n, n-1) = 1/n > 0`
  (`shapleyCoef_pos`), so that single term is strictly positive.
- The whole sum is at least that single positive term (`Finset.sum_le_sum_of_subset_of_nonneg`
  with the singleton `{univ \ {i}}` ⊆ the filter), hence strictly positive.

As with `veto_banzhaf_raw_pos`, the non-degeneracy hypothesis `hwin` is essential: without any
winning coalition a player is vacuously a veto player yet has Shapley value `0`.

Self-contained: needs only `SimpleGame`, `VetoPlayer`, `veto_losing_without`, `shapleyValue`
(all on main). No reference to unmerged symbols — no stacking.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (15s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS** firsthand (LAKE_EXIT=0, native `lake.exe`)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (`^\s*sorry\s*$|:=\s*by\s*sorry`, `--exclude-dir=.lake`) — no proof stubbed → no regression
- axiom check: no `sorry`/`sorryAx` in build log; standard axioms only
- diff scope: **1 file** (`Shapley.lean` +62), inserted after `veto_banzhaf_raw_pos`, before `DummyPlayer`. **0 catalogue file touched**.
- branch: fresh from `origin/main` tip `c58ff674b` (0 behind / 1 ahead), no rebase needed.
- one cosmetic `linter.unnecessarySeqFocus` style suggestion on the `rcases ... <;> ...` line (non-blocking; the file already carries several `[DecidableEq N] unused` linter notes on existing theorems).

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)