### PR TITLE
feat(gt): 11b Lean 4 companion — Vickrey theorem (voie B, #4040)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11b-Lean-BayesianGamesExt.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11b-Lean-BayesianGamesExt.ipynb
@@ -1,0 +1,1216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dfc2a8af",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009624,
+     "end_time": "2026-06-25T04:30:31.087611+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:31.077987+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-11b — Jeux Bayésiens en Lean 4 (companion)\n",
+    "\n",
+    "**Notebook compagnon Lean 4 de `GameTheory-11-BayesianGames.ipynb`** (qui traite les jeux bayésiens en Python).\n",
+    "Cette extension formalise en Lean 4 le résultat central des enchères à valeur privée : **le théorème de Vickrey** (enchère au second prix — *second-price sealed-bid*), exécuté dans le kernel `lean4-wsl`.\n",
+    "\n",
+    "## Provenance — ces résultats sont prouvés SANS sorry dans le lake\n",
+    "\n",
+    "Les théorèmes exécutés ci-dessous sont **restatés à l'identique** depuis le lake\n",
+    "[`lean_game_defs_ext/`](https://github.com/jsboige/CoursIA/tree/main/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext)\n",
+    "(module `Bayesian`), où ils sont **prouvés sans aucun `sorry`**. Le lake est un\n",
+    "projet Lean 4 *self-contained* (core Lean 4, **sans Mathlib**) — donc ses énoncés\n",
+    "se ré-élaborent tels quels dans le kernel notebook. On les restate ici pour\n",
+    "**exécution pédagogique vérifiée** : le kernel `lean4-wsl` élabore réellement les\n",
+    "vrais énoncés et produire les sorties (`#check`, `#eval`) ci-dessous.\n",
+    "\n",
+    "> **Preuve de compilation du lake (exécution réelle, hors notebook car le kernel ne lance pas `lake`) :**\n",
+    "> ```\n",
+    "> $ cd lean_game_defs_ext && lake build Bayesian\n",
+    "> ✔ [13/13] Built Bayesian\n",
+    "> Build completed successfully (13 jobs).\n",
+    "> $ grep -rnE '^\\s*sorry\\b' Bayesian/*.lean | wc -l\n",
+    "> 0\n",
+    "> ```\n",
+    "\n",
+    "**Pourquoi restate inline plutôt que `import Bayesian.Vickrey` ?** Le kernel\n",
+    "interactif `lean4-wsl` (REPL `lean4_jupyter`) résout les `import` de modules lake\n",
+    "**uniquement au démarrage du process REPL**, pas depuis une commande `import`\n",
+    "interactive en cours de notebook (un `import` en milieu de flux n'est pas un\n",
+    "module-load en Lean). Aucun notebook `GameTheory/*.ipynb` n'importe un lake — les\n",
+    "notebooks Lean `2b/4b/8b/15b` sont tous *self-contained*. Ce notebook suit ce\n",
+    "même pattern établi (issue #4040, voie B). Le travail d'exploration\n",
+    "import-from-lake (prelude `NotebookCtx`, launch via lake-env) continue en\n",
+    "side-track sur #4251.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0b9552b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T04:30:31.108818Z",
+     "iopub.status.busy": "2026-06-25T04:30:31.108593Z",
+     "iopub.status.idle": "2026-06-25T04:30:32.339040Z",
+     "shell.execute_reply": "2026-06-25T04:30:32.338157Z"
+    },
+    "papermill": {
+     "duration": 1.242253,
+     "end_time": "2026-06-25T04:30:32.339728+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:31.097475+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">4</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Nat</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Nat<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#eval 2 + 2\\n#check Nat\\n\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 5},\r\n",
+       "   \"data\": \"4\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"Nat : Type\"}],\r\n",
+       " \"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#eval 2 + 2\n",
+       "─────▶  4\n",
+       "#check Nat\n",
+       "──────▶  Nat : Type\n",
+       "\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#eval 2 + 2\\n#check Nat\\n\"}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 5},\r\n",
+       "   \"data\": \"4\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"Nat : Type\"}],\r\n",
+       " \"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#eval 2 + 2\n",
+    "#check Nat\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee26a93b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009326,
+     "end_time": "2026-06-25T04:30:32.357595+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:32.348269+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Sommes finies sur `Fin n` (`sumFin`)\n",
+    "\n",
+    "Mathlib n'étant pas disponible (projet core-only), on définit une somme par récurrence structurelle sur `n`. C'est l'infrastructure d'espérance utilité des jeux bayésiens. (Source : `lean_game_defs_ext/Bayesian/Sum.lean`.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ecbba6f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T04:30:32.375466Z",
+     "iopub.status.busy": "2026-06-25T04:30:32.375305Z",
+     "iopub.status.idle": "2026-06-25T04:30:32.527981Z",
+     "shell.execute_reply": "2026-06-25T04:30:32.527100Z"
+    },
+    "papermill": {
+     "duration": 0.162948,
+     "end_time": "2026-06-25T04:30:32.528497+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:32.365549+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>sumFin<span class=\"w\"> </span>:<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Int)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Int</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"bp\">_</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"mi\">0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>sumFin<span class=\"w\"> </span>n<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>f<span class=\"w\"> </span>i<span class=\"bp\">.</span>succ)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">@[</span>simp<span class=\"kd\">]</span><span class=\"w\"> </span><span class=\"kn\">theorem</span><span class=\"w\"> </span>sumFin_zero<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Int)<span class=\"w\"> </span>:<span class=\"w\"> </span>sumFin<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>rfl</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">@[</span>simp<span class=\"kd\">]</span><span class=\"w\"> </span><span class=\"kn\">theorem</span><span class=\"w\"> </span>sumFin_succ<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Int)<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    sumFin<span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>sumFin<span class=\"w\"> </span>n<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>f<span class=\"w\"> </span>i<span class=\"bp\">.</span>succ)<span class=\"w\"> </span>:=<span class=\"w\"> </span>rfl</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">@[</span>simp<span class=\"kd\">]</span><span class=\"w\"> </span><span class=\"kn\">theorem</span><span class=\"w\"> </span>sumFin_zero_fun<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    sumFin<span class=\"w\"> </span>n<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span><span class=\"bp\">_</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>(<span class=\"mi\">0</span><span class=\"w\"> </span>:<span class=\"w\"> </span>Int))<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  induction<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>zero<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>simp</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>succ<span class=\"w\"> </span>n<span class=\"w\"> </span>ih<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>simp<span class=\"w\"> </span>[ih]</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- La dominance ponctuelle se transfère aux sommes. -/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>sumFin_mono<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat}<span class=\"w\"> </span>{f<span class=\"w\"> </span>g<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Int}<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>i,<span class=\"w\"> </span>f<span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>g<span class=\"w\"> </span>i)<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    sumFin<span class=\"w\"> </span>n<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>sumFin<span class=\"w\"> </span>n<span class=\"w\"> </span>g<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  induction<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>zero<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>simp</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>succ<span class=\"w\"> </span>n<span class=\"w\"> </span>ih<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    simp<span class=\"w\"> </span>only<span class=\"w\"> </span>[sumFin_succ]</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    exact<span class=\"w\"> </span>Int<span class=\"bp\">.</span>add_le_add<span class=\"w\"> </span>(h<span class=\"w\"> </span><span class=\"mi\">0</span>)<span class=\"w\"> </span>(ih<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>h<span class=\"w\"> </span>i<span class=\"bp\">.</span>succ))</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"def sumFin : (n : Nat) \\u2192 (Fin n \\u2192 Int) \\u2192 Int\\n  | 0, _ => 0\\n  | n + 1, f => f 0 + sumFin n (fun i => f i.succ)\\n\\n@[simp] theorem sumFin_zero (f : Fin 0 \\u2192 Int) : sumFin 0 f = 0 := rfl\\n\\n@[simp] theorem sumFin_succ (n : Nat) (f : Fin (n + 1) \\u2192 Int) :\\n    sumFin (n + 1) f = f 0 + sumFin n (fun i => f i.succ) := rfl\\n\\n@[simp] theorem sumFin_zero_fun (n : Nat) :\\n    sumFin n (fun _ => (0 : Int)) = 0 := by\\n  induction n with\\n  | zero => simp\\n  | succ n ih => simp [ih]\\n\\n/-- La dominance ponctuelle se transf\\u00e8re aux sommes. -/\\ntheorem sumFin_mono {n : Nat} {f g : Fin n \\u2192 Int} (h : \\u2200 i, f i \\u2264 g i) :\\n    sumFin n f \\u2264 sumFin n g := by\\n  induction n with\\n  | zero => simp\\n  | succ n ih =>\\n    simp only [sumFin_succ]\\n    exact Int.add_le_add (h 0) (ih (fun i => h i.succ))\\n\", \"env\": 0}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 1}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "def sumFin : (n : Nat) → (Fin n → Int) → Int\n",
+       "  | 0, _ => 0\n",
+       "  | n + 1, f => f 0 + sumFin n (fun i => f i.succ)\n",
+       "\n",
+       "@[simp] theorem sumFin_zero (f : Fin 0 → Int) : sumFin 0 f = 0 := rfl\n",
+       "\n",
+       "@[simp] theorem sumFin_succ (n : Nat) (f : Fin (n + 1) → Int) :\n",
+       "    sumFin (n + 1) f = f 0 + sumFin n (fun i => f i.succ) := rfl\n",
+       "\n",
+       "@[simp] theorem sumFin_zero_fun (n : Nat) :\n",
+       "    sumFin n (fun _ => (0 : Int)) = 0 := by\n",
+       "  induction n with\n",
+       "  | zero => simp\n",
+       "  | succ n ih => simp [ih]\n",
+       "\n",
+       "/-- La dominance ponctuelle se transfère aux sommes. -/\n",
+       "theorem sumFin_mono {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i ≤ g i) :\n",
+       "    sumFin n f ≤ sumFin n g := by\n",
+       "  induction n with\n",
+       "  | zero => simp\n",
+       "  | succ n ih =>\n",
+       "    simp only [sumFin_succ]\n",
+       "    exact Int.add_le_add (h 0) (ih (fun i => h i.succ))\n",
+       "\n",
+       "--% env 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"def sumFin : (n : Nat) \\u2192 (Fin n \\u2192 Int) \\u2192 Int\\n  | 0, _ => 0\\n  | n + 1, f => f 0 + sumFin n (fun i => f i.succ)\\n\\n@[simp] theorem sumFin_zero (f : Fin 0 \\u2192 Int) : sumFin 0 f = 0 := rfl\\n\\n@[simp] theorem sumFin_succ (n : Nat) (f : Fin (n + 1) \\u2192 Int) :\\n    sumFin (n + 1) f = f 0 + sumFin n (fun i => f i.succ) := rfl\\n\\n@[simp] theorem sumFin_zero_fun (n : Nat) :\\n    sumFin n (fun _ => (0 : Int)) = 0 := by\\n  induction n with\\n  | zero => simp\\n  | succ n ih => simp [ih]\\n\\n/-- La dominance ponctuelle se transf\\u00e8re aux sommes. -/\\ntheorem sumFin_mono {n : Nat} {f g : Fin n \\u2192 Int} (h : \\u2200 i, f i \\u2264 g i) :\\n    sumFin n f \\u2264 sumFin n g := by\\n  induction n with\\n  | zero => simp\\n  | succ n ih =>\\n    simp only [sumFin_succ]\\n    exact Int.add_le_add (h 0) (ih (fun i => h i.succ))\\n\", \"env\": 0}\n",
+       "Raw output:\n",
+       "{\"env\": 1}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def sumFin : (n : Nat) → (Fin n → Int) → Int\n",
+    "  | 0, _ => 0\n",
+    "  | n + 1, f => f 0 + sumFin n (fun i => f i.succ)\n",
+    "\n",
+    "@[simp] theorem sumFin_zero (f : Fin 0 → Int) : sumFin 0 f = 0 := rfl\n",
+    "\n",
+    "@[simp] theorem sumFin_succ (n : Nat) (f : Fin (n + 1) → Int) :\n",
+    "    sumFin (n + 1) f = f 0 + sumFin n (fun i => f i.succ) := rfl\n",
+    "\n",
+    "@[simp] theorem sumFin_zero_fun (n : Nat) :\n",
+    "    sumFin n (fun _ => (0 : Int)) = 0 := by\n",
+    "  induction n with\n",
+    "  | zero => simp\n",
+    "  | succ n ih => simp [ih]\n",
+    "\n",
+    "/-- La dominance ponctuelle se transfère aux sommes. -/\n",
+    "theorem sumFin_mono {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i ≤ g i) :\n",
+    "    sumFin n f ≤ sumFin n g := by\n",
+    "  induction n with\n",
+    "  | zero => simp\n",
+    "  | succ n ih =>\n",
+    "    simp only [sumFin_succ]\n",
+    "    exact Int.add_le_add (h 0) (ih (fun i => h i.succ))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23795eb0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014923,
+     "end_time": "2026-06-25T04:30:32.559342+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:32.544419+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Types d'Harsanyi — jeu bayésien fini à deux joueurs\n",
+    "\n",
+    "`BayesGame2` encode un jeu bayésien à deux joueurs, types et actions finis (`Fin n`), avec un *prior commun non normalisé* donné par des poids `Nat` (`w t1 t2`). Les utilités dépendent du profil de types complet et du profil d'actions. Les stratégies sont *pures et contingentes au type* ; `interimU` est l'utilité espérée interim (conditionnelle à son propre type). (Source : `lean_game_defs_ext/Bayesian/Types.lean`.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ea08c806",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T04:30:32.579794Z",
+     "iopub.status.busy": "2026-06-25T04:30:32.579623Z",
+     "iopub.status.idle": "2026-06-25T04:30:32.723554Z",
+     "shell.execute_reply": "2026-06-25T04:30:32.722722Z"
+    },
+    "papermill": {
+     "duration": 0.154398,
+     "end_time": "2026-06-25T04:30:32.724105+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:32.569707+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">structure</span><span class=\"w\"> </span>BayesGame2<span class=\"w\"> </span><span class=\"kn\">where</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  nT1<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  nT2<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  nA1<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  nA2<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  w<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>nT1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>nT2<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Nat</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  u1<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>nT1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>nT2<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>nA1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>nA2<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Int</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  u2<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>nT1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>nT2<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>nA1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>nA2<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Int</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>Strategy1<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>BayesGame2)<span class=\"w\"> </span>:=<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nA1</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>Strategy2<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>BayesGame2)<span class=\"w\"> </span>:=<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT2<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nA2</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>interimU1<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>BayesGame2)<span class=\"w\"> </span>(t1<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT1)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nA1)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (s2<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy2<span class=\"w\"> </span>g)<span class=\"w\"> </span>:<span class=\"w\"> </span>Int<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  sumFin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT2<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>t2<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>(g<span class=\"bp\">.</span>w<span class=\"w\"> </span>t1<span class=\"w\"> </span>t2<span class=\"w\"> </span>:<span class=\"w\"> </span>Int)<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>g<span class=\"bp\">.</span>u1<span class=\"w\"> </span>t1<span class=\"w\"> </span>t2<span class=\"w\"> </span>a<span class=\"w\"> </span>(s2<span class=\"w\"> </span>t2))</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>interimU2<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>BayesGame2)<span class=\"w\"> </span>(t2<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT2)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nA2)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (s1<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy1<span class=\"w\"> </span>g)<span class=\"w\"> </span>:<span class=\"w\"> </span>Int<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  sumFin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT1<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>t1<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>(g<span class=\"bp\">.</span>w<span class=\"w\"> </span>t1<span class=\"w\"> </span>t2<span class=\"w\"> </span>:<span class=\"w\"> </span>Int)<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>g<span class=\"bp\">.</span>u2<span class=\"w\"> </span>t1<span class=\"w\"> </span>t2<span class=\"w\"> </span>(s1<span class=\"w\"> </span>t1)<span class=\"w\"> </span>a)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exAnteU1<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>BayesGame2)<span class=\"w\"> </span>(s1<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy1<span class=\"w\"> </span>g)<span class=\"w\"> </span>(s2<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy2<span class=\"w\"> </span>g)<span class=\"w\"> </span>:<span class=\"w\"> </span>Int<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  sumFin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT1<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>t1<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>interimU1<span class=\"w\"> </span>g<span class=\"w\"> </span>t1<span class=\"w\"> </span>(s1<span class=\"w\"> </span>t1)<span class=\"w\"> </span>s2)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>exAnteU2<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>BayesGame2)<span class=\"w\"> </span>(s1<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy1<span class=\"w\"> </span>g)<span class=\"w\"> </span>(s2<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy2<span class=\"w\"> </span>g)<span class=\"w\"> </span>:<span class=\"w\"> </span>Int<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  sumFin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT2<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>t2<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>interimU2<span class=\"w\"> </span>g<span class=\"w\"> </span>t2<span class=\"w\"> </span>(s2<span class=\"w\"> </span>t2)<span class=\"w\"> </span>s1)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"structure BayesGame2 where\\n  nT1 : Nat\\n  nT2 : Nat\\n  nA1 : Nat\\n  nA2 : Nat\\n  w : Fin nT1 \\u2192 Fin nT2 \\u2192 Nat\\n  u1 : Fin nT1 \\u2192 Fin nT2 \\u2192 Fin nA1 \\u2192 Fin nA2 \\u2192 Int\\n  u2 : Fin nT1 \\u2192 Fin nT2 \\u2192 Fin nA1 \\u2192 Fin nA2 \\u2192 Int\\n\\ndef Strategy1 (g : BayesGame2) := Fin g.nT1 \\u2192 Fin g.nA1\\ndef Strategy2 (g : BayesGame2) := Fin g.nT2 \\u2192 Fin g.nA2\\n\\ndef interimU1 (g : BayesGame2) (t1 : Fin g.nT1) (a : Fin g.nA1)\\n    (s2 : Strategy2 g) : Int :=\\n  sumFin g.nT2 (fun t2 => (g.w t1 t2 : Int) * g.u1 t1 t2 a (s2 t2))\\n\\ndef interimU2 (g : BayesGame2) (t2 : Fin g.nT2) (a : Fin g.nA2)\\n    (s1 : Strategy1 g) : Int :=\\n  sumFin g.nT1 (fun t1 => (g.w t1 t2 : Int) * g.u2 t1 t2 (s1 t1) a)\\n\\ndef exAnteU1 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=\\n  sumFin g.nT1 (fun t1 => interimU1 g t1 (s1 t1) s2)\\n\\ndef exAnteU2 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=\\n  sumFin g.nT2 (fun t2 => interimU2 g t2 (s2 t2) s1)\\n\", \"env\": 1}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 2}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "structure BayesGame2 where\n",
+       "  nT1 : Nat\n",
+       "  nT2 : Nat\n",
+       "  nA1 : Nat\n",
+       "  nA2 : Nat\n",
+       "  w : Fin nT1 → Fin nT2 → Nat\n",
+       "  u1 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int\n",
+       "  u2 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int\n",
+       "\n",
+       "def Strategy1 (g : BayesGame2) := Fin g.nT1 → Fin g.nA1\n",
+       "def Strategy2 (g : BayesGame2) := Fin g.nT2 → Fin g.nA2\n",
+       "\n",
+       "def interimU1 (g : BayesGame2) (t1 : Fin g.nT1) (a : Fin g.nA1)\n",
+       "    (s2 : Strategy2 g) : Int :=\n",
+       "  sumFin g.nT2 (fun t2 => (g.w t1 t2 : Int) * g.u1 t1 t2 a (s2 t2))\n",
+       "\n",
+       "def interimU2 (g : BayesGame2) (t2 : Fin g.nT2) (a : Fin g.nA2)\n",
+       "    (s1 : Strategy1 g) : Int :=\n",
+       "  sumFin g.nT1 (fun t1 => (g.w t1 t2 : Int) * g.u2 t1 t2 (s1 t1) a)\n",
+       "\n",
+       "def exAnteU1 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=\n",
+       "  sumFin g.nT1 (fun t1 => interimU1 g t1 (s1 t1) s2)\n",
+       "\n",
+       "def exAnteU2 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=\n",
+       "  sumFin g.nT2 (fun t2 => interimU2 g t2 (s2 t2) s1)\n",
+       "\n",
+       "--% env 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"structure BayesGame2 where\\n  nT1 : Nat\\n  nT2 : Nat\\n  nA1 : Nat\\n  nA2 : Nat\\n  w : Fin nT1 \\u2192 Fin nT2 \\u2192 Nat\\n  u1 : Fin nT1 \\u2192 Fin nT2 \\u2192 Fin nA1 \\u2192 Fin nA2 \\u2192 Int\\n  u2 : Fin nT1 \\u2192 Fin nT2 \\u2192 Fin nA1 \\u2192 Fin nA2 \\u2192 Int\\n\\ndef Strategy1 (g : BayesGame2) := Fin g.nT1 \\u2192 Fin g.nA1\\ndef Strategy2 (g : BayesGame2) := Fin g.nT2 \\u2192 Fin g.nA2\\n\\ndef interimU1 (g : BayesGame2) (t1 : Fin g.nT1) (a : Fin g.nA1)\\n    (s2 : Strategy2 g) : Int :=\\n  sumFin g.nT2 (fun t2 => (g.w t1 t2 : Int) * g.u1 t1 t2 a (s2 t2))\\n\\ndef interimU2 (g : BayesGame2) (t2 : Fin g.nT2) (a : Fin g.nA2)\\n    (s1 : Strategy1 g) : Int :=\\n  sumFin g.nT1 (fun t1 => (g.w t1 t2 : Int) * g.u2 t1 t2 (s1 t1) a)\\n\\ndef exAnteU1 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=\\n  sumFin g.nT1 (fun t1 => interimU1 g t1 (s1 t1) s2)\\n\\ndef exAnteU2 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=\\n  sumFin g.nT2 (fun t2 => interimU2 g t2 (s2 t2) s1)\\n\", \"env\": 1}\n",
+       "Raw output:\n",
+       "{\"env\": 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "structure BayesGame2 where\n",
+    "  nT1 : Nat\n",
+    "  nT2 : Nat\n",
+    "  nA1 : Nat\n",
+    "  nA2 : Nat\n",
+    "  w : Fin nT1 → Fin nT2 → Nat\n",
+    "  u1 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int\n",
+    "  u2 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int\n",
+    "\n",
+    "def Strategy1 (g : BayesGame2) := Fin g.nT1 → Fin g.nA1\n",
+    "def Strategy2 (g : BayesGame2) := Fin g.nT2 → Fin g.nA2\n",
+    "\n",
+    "def interimU1 (g : BayesGame2) (t1 : Fin g.nT1) (a : Fin g.nA1)\n",
+    "    (s2 : Strategy2 g) : Int :=\n",
+    "  sumFin g.nT2 (fun t2 => (g.w t1 t2 : Int) * g.u1 t1 t2 a (s2 t2))\n",
+    "\n",
+    "def interimU2 (g : BayesGame2) (t2 : Fin g.nT2) (a : Fin g.nA2)\n",
+    "    (s1 : Strategy1 g) : Int :=\n",
+    "  sumFin g.nT1 (fun t1 => (g.w t1 t2 : Int) * g.u2 t1 t2 (s1 t1) a)\n",
+    "\n",
+    "def exAnteU1 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=\n",
+    "  sumFin g.nT1 (fun t1 => interimU1 g t1 (s1 t1) s2)\n",
+    "\n",
+    "def exAnteU2 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=\n",
+    "  sumFin g.nT2 (fun t2 => interimU2 g t2 (s2 t2) s1)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0751c69",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007953,
+     "end_time": "2026-06-25T04:30:32.741902+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:32.733949+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Équilibre Bayésien de Nash (`isBNE`)\n",
+    "\n",
+    "Un profil de stratégies est un **BNE** si aucun type d'aucun joueur n'a de déviante d'action unilatérale profitable, en utilité interim. Les quantificateurs ne portent que sur des types `Fin` et des actions `Fin` de comparaisons `Int` décidables → **la propriété est décidable** (`decide` fonctionne sur les jeux concrets). (Source : `lean_game_defs_ext/Bayesian/BNE.lean`.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "94f94bc1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T04:30:32.762928Z",
+     "iopub.status.busy": "2026-06-25T04:30:32.762722Z",
+     "iopub.status.idle": "2026-06-25T04:30:32.872297Z",
+     "shell.execute_reply": "2026-06-25T04:30:32.871500Z"
+    },
+    "papermill": {
+     "duration": 0.120057,
+     "end_time": "2026-06-25T04:30:32.872841+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:32.752784+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">@[</span>reducible<span class=\"kd\">]</span><span class=\"w\"> </span><span class=\"kn\">def</span><span class=\"w\"> </span>isBNE<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>BayesGame2)<span class=\"w\"> </span>(s1<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy1<span class=\"w\"> </span>g)<span class=\"w\"> </span>(s2<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy2<span class=\"w\"> </span>g)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span><span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (<span class=\"bp\">∀</span><span class=\"w\"> </span>t1<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT1,<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>a<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nA1,</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      interimU1<span class=\"w\"> </span>g<span class=\"w\"> </span>t1<span class=\"w\"> </span>a<span class=\"w\"> </span>s2<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>interimU1<span class=\"w\"> </span>g<span class=\"w\"> </span>t1<span class=\"w\"> </span>(s1<span class=\"w\"> </span>t1)<span class=\"w\"> </span>s2)<span class=\"w\"> </span><span class=\"bp\">∧</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (<span class=\"bp\">∀</span><span class=\"w\"> </span>t2<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nT2,<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>a<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>g<span class=\"bp\">.</span>nA2,</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      interimU2<span class=\"w\"> </span>g<span class=\"w\"> </span>t2<span class=\"w\"> </span>a<span class=\"w\"> </span>s1<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>interimU2<span class=\"w\"> </span>g<span class=\"w\"> </span>t2<span class=\"w\"> </span>(s2<span class=\"w\"> </span>t2)<span class=\"w\"> </span>s1)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"@[reducible] def isBNE (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Prop :=\\n  (\\u2200 t1 : Fin g.nT1, \\u2200 a : Fin g.nA1,\\n      interimU1 g t1 a s2 \\u2264 interimU1 g t1 (s1 t1) s2) \\u2227\\n  (\\u2200 t2 : Fin g.nT2, \\u2200 a : Fin g.nA2,\\n      interimU2 g t2 a s1 \\u2264 interimU2 g t2 (s2 t2) s1)\\n\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "@[reducible] def isBNE (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Prop :=\n",
+       "  (∀ t1 : Fin g.nT1, ∀ a : Fin g.nA1,\n",
+       "      interimU1 g t1 a s2 ≤ interimU1 g t1 (s1 t1) s2) ∧\n",
+       "  (∀ t2 : Fin g.nT2, ∀ a : Fin g.nA2,\n",
+       "      interimU2 g t2 a s1 ≤ interimU2 g t2 (s2 t2) s1)\n",
+       "\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"@[reducible] def isBNE (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Prop :=\\n  (\\u2200 t1 : Fin g.nT1, \\u2200 a : Fin g.nA1,\\n      interimU1 g t1 a s2 \\u2264 interimU1 g t1 (s1 t1) s2) \\u2227\\n  (\\u2200 t2 : Fin g.nT2, \\u2200 a : Fin g.nA2,\\n      interimU2 g t2 a s1 \\u2264 interimU2 g t2 (s2 t2) s1)\\n\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "@[reducible] def isBNE (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Prop :=\n",
+    "  (∀ t1 : Fin g.nT1, ∀ a : Fin g.nA1,\n",
+    "      interimU1 g t1 a s2 ≤ interimU1 g t1 (s1 t1) s2) ∧\n",
+    "  (∀ t2 : Fin g.nT2, ∀ a : Fin g.nA2,\n",
+    "      interimU2 g t2 a s1 ≤ interimU2 g t2 (s2 t2) s1)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95b9f116",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008379,
+     "end_time": "2026-06-25T04:30:32.892231+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:32.883852+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Enchère de Vickrey (second-prix) — l'enchère `spa`\n",
+    "\n",
+    "Deux enchérisseurs, valorisations et enchères dans `Fin n`, prior uniforme (poids 1). Le gagnant paie l'enchère du perdant (le *second prix*) ; les utilités sont mises à l'échelle par 2 pour que le partage d'égalité reste entier. Enchérer sa vraie valeur (`spaTruthful`) est la stratégie étudiée. (Source : `lean_game_defs_ext/Bayesian/Vickrey.lean`.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "66b98b20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T04:30:32.911025Z",
+     "iopub.status.busy": "2026-06-25T04:30:32.910752Z",
+     "iopub.status.idle": "2026-06-25T04:30:33.039447Z",
+     "shell.execute_reply": "2026-06-25T04:30:33.038540Z"
+    },
+    "papermill": {
+     "duration": 0.138424,
+     "end_time": "2026-06-25T04:30:33.039931+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:32.901507+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">@[</span>reducible<span class=\"kd\">]</span><span class=\"w\"> </span><span class=\"kn\">def</span><span class=\"w\"> </span>spa<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>BayesGame2<span class=\"w\"> </span><span class=\"kn\">where</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  nT1<span class=\"w\"> </span>:=<span class=\"w\"> </span>n</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  nT2<span class=\"w\"> </span>:=<span class=\"w\"> </span>n</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  nA1<span class=\"w\"> </span>:=<span class=\"w\"> </span>n</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  nA2<span class=\"w\"> </span>:=<span class=\"w\"> </span>n</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  w<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span><span class=\"bp\">_</span><span class=\"w\"> </span><span class=\"bp\">_</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"mi\">1</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  u1<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>v1<span class=\"w\"> </span><span class=\"bp\">_</span><span class=\"w\"> </span>b1<span class=\"w\"> </span>b2<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"k\">if</span><span class=\"w\"> </span>b2<span class=\"bp\">.</span>val<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>b1<span class=\"bp\">.</span>val<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>((v1<span class=\"bp\">.</span>val<span class=\"w\"> </span>:<span class=\"w\"> </span>Int)<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>b2<span class=\"bp\">.</span>val)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"k\">else</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>b1<span class=\"bp\">.</span>val<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>b2<span class=\"bp\">.</span>val<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span>(v1<span class=\"bp\">.</span>val<span class=\"w\"> </span>:<span class=\"w\"> </span>Int)<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>b2<span class=\"bp\">.</span>val</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"k\">else</span><span class=\"w\"> </span><span class=\"mi\">0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  u2<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span><span class=\"bp\">_</span><span class=\"w\"> </span>v2<span class=\"w\"> </span>b1<span class=\"w\"> </span>b2<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"k\">if</span><span class=\"w\"> </span>b1<span class=\"bp\">.</span>val<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>b2<span class=\"bp\">.</span>val<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>((v2<span class=\"bp\">.</span>val<span class=\"w\"> </span>:<span class=\"w\"> </span>Int)<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>b1<span class=\"bp\">.</span>val)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"k\">else</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>b1<span class=\"bp\">.</span>val<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>b2<span class=\"bp\">.</span>val<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span>(v2<span class=\"bp\">.</span>val<span class=\"w\"> </span>:<span class=\"w\"> </span>Int)<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>b1<span class=\"bp\">.</span>val</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"k\">else</span><span class=\"w\"> </span><span class=\"mi\">0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- Enchère honnête (joueur 1) : bid = valeur. -/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">@[</span>reducible<span class=\"kd\">]</span><span class=\"w\"> </span><span class=\"kn\">def</span><span class=\"w\"> </span>spaTruthful1<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy1<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>v<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>v</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- Enchère honnête (joueur 2). -/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">@[</span>reducible<span class=\"kd\">]</span><span class=\"w\"> </span><span class=\"kn\">def</span><span class=\"w\"> </span>spaTruthful2<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy2<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>v<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>v</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"@[reducible] def spa (n : Nat) : BayesGame2 where\\n  nT1 := n\\n  nT2 := n\\n  nA1 := n\\n  nA2 := n\\n  w := fun _ _ => 1\\n  u1 := fun v1 _ b1 b2 =>\\n    if b2.val < b1.val then 2 * ((v1.val : Int) - b2.val)\\n    else if b1.val = b2.val then (v1.val : Int) - b2.val\\n    else 0\\n  u2 := fun _ v2 b1 b2 =>\\n    if b1.val < b2.val then 2 * ((v2.val : Int) - b1.val)\\n    else if b1.val = b2.val then (v2.val : Int) - b1.val\\n    else 0\\n\\n/-- Ench\\u00e8re honn\\u00eate (joueur 1) : bid = valeur. -/\\n@[reducible] def spaTruthful1 (n : Nat) : Strategy1 (spa n) := fun v => v\\n\\n/-- Ench\\u00e8re honn\\u00eate (joueur 2). -/\\n@[reducible] def spaTruthful2 (n : Nat) : Strategy2 (spa n) := fun v => v\\n\", \"env\": 3}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 4}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "@[reducible] def spa (n : Nat) : BayesGame2 where\n",
+       "  nT1 := n\n",
+       "  nT2 := n\n",
+       "  nA1 := n\n",
+       "  nA2 := n\n",
+       "  w := fun _ _ => 1\n",
+       "  u1 := fun v1 _ b1 b2 =>\n",
+       "    if b2.val < b1.val then 2 * ((v1.val : Int) - b2.val)\n",
+       "    else if b1.val = b2.val then (v1.val : Int) - b2.val\n",
+       "    else 0\n",
+       "  u2 := fun _ v2 b1 b2 =>\n",
+       "    if b1.val < b2.val then 2 * ((v2.val : Int) - b1.val)\n",
+       "    else if b1.val = b2.val then (v2.val : Int) - b1.val\n",
+       "    else 0\n",
+       "\n",
+       "/-- Enchère honnête (joueur 1) : bid = valeur. -/\n",
+       "@[reducible] def spaTruthful1 (n : Nat) : Strategy1 (spa n) := fun v => v\n",
+       "\n",
+       "/-- Enchère honnête (joueur 2). -/\n",
+       "@[reducible] def spaTruthful2 (n : Nat) : Strategy2 (spa n) := fun v => v\n",
+       "\n",
+       "--% env 4\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"@[reducible] def spa (n : Nat) : BayesGame2 where\\n  nT1 := n\\n  nT2 := n\\n  nA1 := n\\n  nA2 := n\\n  w := fun _ _ => 1\\n  u1 := fun v1 _ b1 b2 =>\\n    if b2.val < b1.val then 2 * ((v1.val : Int) - b2.val)\\n    else if b1.val = b2.val then (v1.val : Int) - b2.val\\n    else 0\\n  u2 := fun _ v2 b1 b2 =>\\n    if b1.val < b2.val then 2 * ((v2.val : Int) - b1.val)\\n    else if b1.val = b2.val then (v2.val : Int) - b1.val\\n    else 0\\n\\n/-- Ench\\u00e8re honn\\u00eate (joueur 1) : bid = valeur. -/\\n@[reducible] def spaTruthful1 (n : Nat) : Strategy1 (spa n) := fun v => v\\n\\n/-- Ench\\u00e8re honn\\u00eate (joueur 2). -/\\n@[reducible] def spaTruthful2 (n : Nat) : Strategy2 (spa n) := fun v => v\\n\", \"env\": 3}\n",
+       "Raw output:\n",
+       "{\"env\": 4}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "@[reducible] def spa (n : Nat) : BayesGame2 where\n",
+    "  nT1 := n\n",
+    "  nT2 := n\n",
+    "  nA1 := n\n",
+    "  nA2 := n\n",
+    "  w := fun _ _ => 1\n",
+    "  u1 := fun v1 _ b1 b2 =>\n",
+    "    if b2.val < b1.val then 2 * ((v1.val : Int) - b2.val)\n",
+    "    else if b1.val = b2.val then (v1.val : Int) - b2.val\n",
+    "    else 0\n",
+    "  u2 := fun _ v2 b1 b2 =>\n",
+    "    if b1.val < b2.val then 2 * ((v2.val : Int) - b1.val)\n",
+    "    else if b1.val = b2.val then (v2.val : Int) - b1.val\n",
+    "    else 0\n",
+    "\n",
+    "/-- Enchère honnête (joueur 1) : bid = valeur. -/\n",
+    "@[reducible] def spaTruthful1 (n : Nat) : Strategy1 (spa n) := fun v => v\n",
+    "\n",
+    "/-- Enchère honnête (joueur 2). -/\n",
+    "@[reducible] def spaTruthful2 (n : Nat) : Strategy2 (spa n) := fun v => v\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d3bd493",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008602,
+     "end_time": "2026-06-25T04:30:33.058609+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:33.050007+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.1 Argument de dominance\n",
+    "\n",
+    "L'argument classique de Vickrey : enchérir sa vraie valeur **domine faiblement** toute autre enchère, *point par point* — contre n'importe quelle enchère adverse, dans n'importe quel état. Quel que soit le prix (l'enchère adverse), dévier de `v` ne peut que forfaiter un gain profitable (`b1 < v`) ou acheter à perte (`b1 > v`), jamais améliorer — car le **prix payé ne dépend pas de sa propre enchère**. La dominance ponctuelle se transfère ensuite à l'utilité interim via `sumFin_mono`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3f4c5cce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T04:30:33.076415Z",
+     "iopub.status.busy": "2026-06-25T04:30:33.076254Z",
+     "iopub.status.idle": "2026-06-25T04:30:33.443419Z",
+     "shell.execute_reply": "2026-06-25T04:30:33.442553Z"
+    },
+    "papermill": {
+     "duration": 0.376906,
+     "end_time": "2026-06-25T04:30:33.443947+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:33.067041+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- Vickrey dominance, joueur 1 : la vraie valeur domine faiblement toute autre enchère.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    On<span class=\"w\"> </span>d<span class=\"bp\">é</span>plie<span class=\"w\"> </span><span class=\"ss\">`spa</span><span class=\"bp\">`</span><span class=\"w\"> </span>explicitement<span class=\"w\"> </span>via<span class=\"w\"> </span><span class=\"ss\">`simp</span><span class=\"w\"> </span>only<span class=\"w\"> </span>[spa]<span class=\"bp\">`</span><span class=\"w\"> </span>(au<span class=\"w\"> </span>lieu<span class=\"w\"> </span>d&#39;un<span class=\"w\"> </span><span class=\"ss\">`show</span><span class=\"bp\">`</span><span class=\"w\"> </span>defeq)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    pour<span class=\"w\"> </span>rester<span class=\"w\"> </span>robuste<span class=\"w\"> </span>aux<span class=\"w\"> </span>variations<span class=\"w\"> </span>d&#39;<span class=\"bp\">é</span>laboration<span class=\"w\"> </span>defeq<span class=\"w\"> </span>entre<span class=\"w\"> </span>versions<span class=\"w\"> </span>de<span class=\"w\"> </span>Lean<span class=\"w\"> </span><span class=\"bp\">;</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    la<span class=\"w\"> </span>preuve<span class=\"w\"> </span>est<span class=\"w\"> </span>identique<span class=\"w\"> </span><span class=\"bp\">à</span><span class=\"w\"> </span>celle<span class=\"w\"> </span>du<span class=\"w\"> </span>lake<span class=\"w\"> </span>(case<span class=\"w\"> </span>analysis<span class=\"w\"> </span>sur<span class=\"w\"> </span>qui<span class=\"w\"> </span>gagne,<span class=\"w\"> </span>close<span class=\"w\"> </span>par<span class=\"w\"> </span><span class=\"ss\">`omega</span><span class=\"bp\">`</span>)<span class=\"bp\">.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    NB<span class=\"w\"> </span>:<span class=\"w\"> </span>le<span class=\"w\"> </span>linter<span class=\"w\"> </span>signale<span class=\"w\"> </span><span class=\"bp\">«</span><span class=\"w\"> </span>simp<span class=\"w\"> </span>argument<span class=\"w\"> </span>unused:<span class=\"w\"> </span>spa<span class=\"w\"> </span><span class=\"bp\">»</span><span class=\"w\"> </span><span class=\"bp\">—</span><span class=\"w\"> </span>faux<span class=\"w\"> </span>positif<span class=\"w\"> </span>connu<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"ss\">`simp</span><span class=\"bp\">`</span><span class=\"w\"> </span>d<span class=\"bp\">é</span>plie<span class=\"w\"> </span>effectivement<span class=\"w\"> </span><span class=\"ss\">`spa</span><span class=\"bp\">`</span><span class=\"w\"> </span>(n<span class=\"bp\">é</span>cessaire<span class=\"w\"> </span>pour<span class=\"w\"> </span>que<span class=\"w\"> </span><span class=\"ss\">`split</span><span class=\"bp\">`</span><span class=\"w\"> </span>voie<span class=\"w\"> </span>les<span class=\"w\"> </span><span class=\"ss\">`if</span><span class=\"bp\">`</span>),</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    mais<span class=\"w\"> </span>ne<span class=\"w\"> </span>le<span class=\"w\"> </span>compte<span class=\"w\"> </span>pas<span class=\"w\"> </span>comme<span class=\"w\"> </span>r<span class=\"bp\">è</span>gle<span class=\"w\"> </span>de<span class=\"w\"> </span>r<span class=\"bp\">éé</span>criture<span class=\"bp\">.</span><span class=\"w\"> </span><span class=\"bp\">-/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>spa_truthful_dominant1<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(v<span class=\"w\"> </span>t2<span class=\"w\"> </span>b1<span class=\"w\"> </span>b2<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n)<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (spa<span class=\"w\"> </span>n)<span class=\"bp\">.</span>u1<span class=\"w\"> </span>v<span class=\"w\"> </span>t2<span class=\"w\"> </span>b1<span class=\"w\"> </span>b2<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"bp\">.</span>u1<span class=\"w\"> </span>v<span class=\"w\"> </span>t2<span class=\"w\"> </span>v<span class=\"w\"> </span>b2<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\">  simp<span class=\"w\"> </span>only<span class=\"w\"> </span>[spa]</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>This<span class=\"w\"> </span>simp<span class=\"w\"> </span>argument<span class=\"w\"> </span>is<span class=\"w\"> </span>unused:\n",
+       "<span class=\"w\">  </span>spa\n",
+       "\n",
+       "Hint:<span class=\"w\"> </span>Omit<span class=\"w\"> </span>it<span class=\"w\"> </span><span class=\"k\">from</span><span class=\"w\"> </span>the<span class=\"w\"> </span>simp<span class=\"w\"> </span>argument<span class=\"w\"> </span>list<span class=\"bp\">.</span>\n",
+       "<span class=\"w\">  </span>simp<span class=\"w\"> </span>only<span class=\"w\"> </span><span class=\"bp\">̵</span>[<span class=\"bp\">̵</span>s<span class=\"bp\">̵</span>p<span class=\"bp\">̵</span>a<span class=\"bp\">̵</span>]<span class=\"bp\">̵</span>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedSimpArgs<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  repeat&#39;<span class=\"w\"> </span>split</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  all_goals<span class=\"w\"> </span>omega</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- Vickrey dominance, joueur 2 (symétrique). -/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>spa_truthful_dominant2<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(t1<span class=\"w\"> </span>v<span class=\"w\"> </span>b1<span class=\"w\"> </span>b2<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n)<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (spa<span class=\"w\"> </span>n)<span class=\"bp\">.</span>u2<span class=\"w\"> </span>t1<span class=\"w\"> </span>v<span class=\"w\"> </span>b1<span class=\"w\"> </span>b2<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"bp\">.</span>u2<span class=\"w\"> </span>t1<span class=\"w\"> </span>v<span class=\"w\"> </span>b1<span class=\"w\"> </span>v<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\">  simp<span class=\"w\"> </span>only<span class=\"w\"> </span>[spa]</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>This<span class=\"w\"> </span>simp<span class=\"w\"> </span>argument<span class=\"w\"> </span>is<span class=\"w\"> </span>unused:\n",
+       "<span class=\"w\">  </span>spa\n",
+       "\n",
+       "Hint:<span class=\"w\"> </span>Omit<span class=\"w\"> </span>it<span class=\"w\"> </span><span class=\"k\">from</span><span class=\"w\"> </span>the<span class=\"w\"> </span>simp<span class=\"w\"> </span>argument<span class=\"w\"> </span>list<span class=\"bp\">.</span>\n",
+       "<span class=\"w\">  </span>simp<span class=\"w\"> </span>only<span class=\"w\"> </span><span class=\"bp\">̵</span>[<span class=\"bp\">̵</span>s<span class=\"bp\">̵</span>p<span class=\"bp\">̵</span>a<span class=\"bp\">̵</span>]<span class=\"bp\">̵</span>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedSimpArgs<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  repeat&#39;<span class=\"w\"> </span>split</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  all_goals<span class=\"w\"> </span>omega</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- La dominance ponctuelle =&gt; meilleure réponse interim (joueur 1). -/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>spa_interim_best1<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(v<span class=\"w\"> </span>a<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n)<span class=\"w\"> </span>(s2<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy2<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n))<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    interimU1<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"w\"> </span>v<span class=\"w\"> </span>a<span class=\"w\"> </span>s2<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>interimU1<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"w\"> </span>v<span class=\"w\"> </span>(spaTruthful1<span class=\"w\"> </span>n<span class=\"w\"> </span>v)<span class=\"w\"> </span>s2<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  apply<span class=\"w\"> </span>sumFin_mono</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  intro<span class=\"w\"> </span>t2</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  exact<span class=\"w\"> </span>Int<span class=\"bp\">.</span>mul_le_mul_of_nonneg_left</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (spa_truthful_dominant1<span class=\"w\"> </span>n<span class=\"w\"> </span>v<span class=\"w\"> </span>t2<span class=\"w\"> </span>a<span class=\"w\"> </span>(s2<span class=\"w\"> </span>t2))<span class=\"w\"> </span>(<span class=\"k\">by</span><span class=\"w\"> </span>omega)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- Meilleure réponse interim, joueur 2. -/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>spa_interim_best2<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(v<span class=\"w\"> </span>a<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n)<span class=\"w\"> </span>(s1<span class=\"w\"> </span>:<span class=\"w\"> </span>Strategy1<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n))<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    interimU2<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"w\"> </span>v<span class=\"w\"> </span>a<span class=\"w\"> </span>s1<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>interimU2<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"w\"> </span>v<span class=\"w\"> </span>(spaTruthful2<span class=\"w\"> </span>n<span class=\"w\"> </span>v)<span class=\"w\"> </span>s1<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  apply<span class=\"w\"> </span>sumFin_mono</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  intro<span class=\"w\"> </span>t1</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  exact<span class=\"w\"> </span>Int<span class=\"bp\">.</span>mul_le_mul_of_nonneg_left</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (spa_truthful_dominant2<span class=\"w\"> </span>n<span class=\"w\"> </span>t1<span class=\"w\"> </span>v<span class=\"w\"> </span>(s1<span class=\"w\"> </span>t1)<span class=\"w\"> </span>a)<span class=\"w\"> </span>(<span class=\"k\">by</span><span class=\"w\"> </span>omega)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"/-- Vickrey dominance, joueur 1 : la vraie valeur domine faiblement toute autre ench\\u00e8re.\\n    On d\\u00e9plie `spa` explicitement via `simp only [spa]` (au lieu d'un `show` defeq)\\n    pour rester robuste aux variations d'\\u00e9laboration defeq entre versions de Lean ;\\n    la preuve est identique \\u00e0 celle du lake (case analysis sur qui gagne, close par `omega`).\\n    NB : le linter signale \\u00ab simp argument unused: spa \\u00bb \\u2014 faux positif connu :\\n    `simp` d\\u00e9plie effectivement `spa` (n\\u00e9cessaire pour que `split` voie les `if`),\\n    mais ne le compte pas comme r\\u00e8gle de r\\u00e9\\u00e9criture. -/\\ntheorem spa_truthful_dominant1 (n : Nat) (v t2 b1 b2 : Fin n) :\\n    (spa n).u1 v t2 b1 b2 \\u2264 (spa n).u1 v t2 v b2 := by\\n  simp only [spa]\\n  repeat' split\\n  all_goals omega\\n\\n/-- Vickrey dominance, joueur 2 (sym\\u00e9trique). -/\\ntheorem spa_truthful_dominant2 (n : Nat) (t1 v b1 b2 : Fin n) :\\n    (spa n).u2 t1 v b1 b2 \\u2264 (spa n).u2 t1 v b1 v := by\\n  simp only [spa]\\n  repeat' split\\n  all_goals omega\\n\\n/-- La dominance ponctuelle => meilleure r\\u00e9ponse interim (joueur 1). -/\\ntheorem spa_interim_best1 (n : Nat) (v a : Fin n) (s2 : Strategy2 (spa n)) :\\n    interimU1 (spa n) v a s2 \\u2264 interimU1 (spa n) v (spaTruthful1 n v) s2 := by\\n  apply sumFin_mono\\n  intro t2\\n  exact Int.mul_le_mul_of_nonneg_left\\n    (spa_truthful_dominant1 n v t2 a (s2 t2)) (by omega)\\n\\n/-- Meilleure r\\u00e9ponse interim, joueur 2. -/\\ntheorem spa_interim_best2 (n : Nat) (v a : Fin n) (s1 : Strategy1 (spa n)) :\\n    interimU2 (spa n) v a s1 \\u2264 interimU2 (spa n) v (spaTruthful2 n v) s1 := by\\n  apply sumFin_mono\\n  intro t1\\n  exact Int.mul_le_mul_of_nonneg_left\\n    (spa_truthful_dominant2 n t1 v (s1 t1) a) (by omega)\\n\", \"env\": 4}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 13},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 16},\r\n",
+       "   \"data\":\r\n",
+       "   \"This simp argument is unused:\\n  spa\\n\\nHint: Omit it from the simp argument list.\\n  simp only ̵[̵s̵p̵a̵]̵\\n\\nNote: This linter can be disabled with `set_option linter.unusedSimpArgs false`\"},\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 17, \"column\": 13},\r\n",
+       "   \"endPos\": {\"line\": 17, \"column\": 16},\r\n",
+       "   \"data\":\r\n",
+       "   \"This simp argument is unused:\\n  spa\\n\\nHint: Omit it from the simp argument list.\\n  simp only ̵[̵s̵p̵a̵]̵\\n\\nNote: This linter can be disabled with `set_option linter.unusedSimpArgs false`\"}],\r\n",
+       " \"env\": 5}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "/-- Vickrey dominance, joueur 1 : la vraie valeur domine faiblement toute autre enchère.\n",
+       "    On déplie `spa` explicitement via `simp only [spa]` (au lieu d'un `show` defeq)\n",
+       "    pour rester robuste aux variations d'élaboration defeq entre versions de Lean ;\n",
+       "    la preuve est identique à celle du lake (case analysis sur qui gagne, close par `omega`).\n",
+       "    NB : le linter signale « simp argument unused: spa » — faux positif connu :\n",
+       "    `simp` déplie effectivement `spa` (nécessaire pour que `split` voie les `if`),\n",
+       "    mais ne le compte pas comme règle de réécriture. -/\n",
+       "theorem spa_truthful_dominant1 (n : Nat) (v t2 b1 b2 : Fin n) :\n",
+       "    (spa n).u1 v t2 b1 b2 ≤ (spa n).u1 v t2 v b2 := by\n",
+       "  simp only [spa]\n",
+       "             ───▶ 🟨 This simp argument is unused:\n",
+       "  spa\n",
+       "\n",
+       "Hint: Omit it from the simp argument list.\n",
+       "  simp only ̵[̵s̵p̵a̵]̵\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`\n",
+       "  repeat' split\n",
+       "  all_goals omega\n",
+       "\n",
+       "/-- Vickrey dominance, joueur 2 (symétrique). -/\n",
+       "theorem spa_truthful_dominant2 (n : Nat) (t1 v b1 b2 : Fin n) :\n",
+       "    (spa n).u2 t1 v b1 b2 ≤ (spa n).u2 t1 v b1 v := by\n",
+       "  simp only [spa]\n",
+       "             ───▶ 🟨 This simp argument is unused:\n",
+       "  spa\n",
+       "\n",
+       "Hint: Omit it from the simp argument list.\n",
+       "  simp only ̵[̵s̵p̵a̵]̵\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`\n",
+       "  repeat' split\n",
+       "  all_goals omega\n",
+       "\n",
+       "/-- La dominance ponctuelle => meilleure réponse interim (joueur 1). -/\n",
+       "theorem spa_interim_best1 (n : Nat) (v a : Fin n) (s2 : Strategy2 (spa n)) :\n",
+       "    interimU1 (spa n) v a s2 ≤ interimU1 (spa n) v (spaTruthful1 n v) s2 := by\n",
+       "  apply sumFin_mono\n",
+       "  intro t2\n",
+       "  exact Int.mul_le_mul_of_nonneg_left\n",
+       "    (spa_truthful_dominant1 n v t2 a (s2 t2)) (by omega)\n",
+       "\n",
+       "/-- Meilleure réponse interim, joueur 2. -/\n",
+       "theorem spa_interim_best2 (n : Nat) (v a : Fin n) (s1 : Strategy1 (spa n)) :\n",
+       "    interimU2 (spa n) v a s1 ≤ interimU2 (spa n) v (spaTruthful2 n v) s1 := by\n",
+       "  apply sumFin_mono\n",
+       "  intro t1\n",
+       "  exact Int.mul_le_mul_of_nonneg_left\n",
+       "    (spa_truthful_dominant2 n t1 v (s1 t1) a) (by omega)\n",
+       "\n",
+       "--% env 5\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"/-- Vickrey dominance, joueur 1 : la vraie valeur domine faiblement toute autre ench\\u00e8re.\\n    On d\\u00e9plie `spa` explicitement via `simp only [spa]` (au lieu d'un `show` defeq)\\n    pour rester robuste aux variations d'\\u00e9laboration defeq entre versions de Lean ;\\n    la preuve est identique \\u00e0 celle du lake (case analysis sur qui gagne, close par `omega`).\\n    NB : le linter signale \\u00ab simp argument unused: spa \\u00bb \\u2014 faux positif connu :\\n    `simp` d\\u00e9plie effectivement `spa` (n\\u00e9cessaire pour que `split` voie les `if`),\\n    mais ne le compte pas comme r\\u00e8gle de r\\u00e9\\u00e9criture. -/\\ntheorem spa_truthful_dominant1 (n : Nat) (v t2 b1 b2 : Fin n) :\\n    (spa n).u1 v t2 b1 b2 \\u2264 (spa n).u1 v t2 v b2 := by\\n  simp only [spa]\\n  repeat' split\\n  all_goals omega\\n\\n/-- Vickrey dominance, joueur 2 (sym\\u00e9trique). -/\\ntheorem spa_truthful_dominant2 (n : Nat) (t1 v b1 b2 : Fin n) :\\n    (spa n).u2 t1 v b1 b2 \\u2264 (spa n).u2 t1 v b1 v := by\\n  simp only [spa]\\n  repeat' split\\n  all_goals omega\\n\\n/-- La dominance ponctuelle => meilleure r\\u00e9ponse interim (joueur 1). -/\\ntheorem spa_interim_best1 (n : Nat) (v a : Fin n) (s2 : Strategy2 (spa n)) :\\n    interimU1 (spa n) v a s2 \\u2264 interimU1 (spa n) v (spaTruthful1 n v) s2 := by\\n  apply sumFin_mono\\n  intro t2\\n  exact Int.mul_le_mul_of_nonneg_left\\n    (spa_truthful_dominant1 n v t2 a (s2 t2)) (by omega)\\n\\n/-- Meilleure r\\u00e9ponse interim, joueur 2. -/\\ntheorem spa_interim_best2 (n : Nat) (v a : Fin n) (s1 : Strategy1 (spa n)) :\\n    interimU2 (spa n) v a s1 \\u2264 interimU2 (spa n) v (spaTruthful2 n v) s1 := by\\n  apply sumFin_mono\\n  intro t1\\n  exact Int.mul_le_mul_of_nonneg_left\\n    (spa_truthful_dominant2 n t1 v (s1 t1) a) (by omega)\\n\", \"env\": 4}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 13},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 16},\r\n",
+       "   \"data\":\r\n",
+       "   \"This simp argument is unused:\\n  spa\\n\\nHint: Omit it from the simp argument list.\\n  simp only ̵[̵s̵p̵a̵]̵\\n\\nNote: This linter can be disabled with `set_option linter.unusedSimpArgs false`\"},\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 17, \"column\": 13},\r\n",
+       "   \"endPos\": {\"line\": 17, \"column\": 16},\r\n",
+       "   \"data\":\r\n",
+       "   \"This simp argument is unused:\\n  spa\\n\\nHint: Omit it from the simp argument list.\\n  simp only ̵[̵s̵p̵a̵]̵\\n\\nNote: This linter can be disabled with `set_option linter.unusedSimpArgs false`\"}],\r\n",
+       " \"env\": 5}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "/-- Vickrey dominance, joueur 1 : la vraie valeur domine faiblement toute autre enchère.\n",
+    "    On déplie `spa` explicitement via `simp only [spa]` (au lieu d'un `show` defeq)\n",
+    "    pour rester robuste aux variations d'élaboration defeq entre versions de Lean ;\n",
+    "    la preuve est identique à celle du lake (case analysis sur qui gagne, close par `omega`).\n",
+    "    NB : le linter signale « simp argument unused: spa » — faux positif connu :\n",
+    "    `simp` déplie effectivement `spa` (nécessaire pour que `split` voie les `if`),\n",
+    "    mais ne le compte pas comme règle de réécriture. -/\n",
+    "theorem spa_truthful_dominant1 (n : Nat) (v t2 b1 b2 : Fin n) :\n",
+    "    (spa n).u1 v t2 b1 b2 ≤ (spa n).u1 v t2 v b2 := by\n",
+    "  simp only [spa]\n",
+    "  repeat' split\n",
+    "  all_goals omega\n",
+    "\n",
+    "/-- Vickrey dominance, joueur 2 (symétrique). -/\n",
+    "theorem spa_truthful_dominant2 (n : Nat) (t1 v b1 b2 : Fin n) :\n",
+    "    (spa n).u2 t1 v b1 b2 ≤ (spa n).u2 t1 v b1 v := by\n",
+    "  simp only [spa]\n",
+    "  repeat' split\n",
+    "  all_goals omega\n",
+    "\n",
+    "/-- La dominance ponctuelle => meilleure réponse interim (joueur 1). -/\n",
+    "theorem spa_interim_best1 (n : Nat) (v a : Fin n) (s2 : Strategy2 (spa n)) :\n",
+    "    interimU1 (spa n) v a s2 ≤ interimU1 (spa n) v (spaTruthful1 n v) s2 := by\n",
+    "  apply sumFin_mono\n",
+    "  intro t2\n",
+    "  exact Int.mul_le_mul_of_nonneg_left\n",
+    "    (spa_truthful_dominant1 n v t2 a (s2 t2)) (by omega)\n",
+    "\n",
+    "/-- Meilleure réponse interim, joueur 2. -/\n",
+    "theorem spa_interim_best2 (n : Nat) (v a : Fin n) (s1 : Strategy1 (spa n)) :\n",
+    "    interimU2 (spa n) v a s1 ≤ interimU2 (spa n) v (spaTruthful2 n v) s1 := by\n",
+    "  apply sumFin_mono\n",
+    "  intro t1\n",
+    "  exact Int.mul_le_mul_of_nonneg_left\n",
+    "    (spa_truthful_dominant2 n t1 v (s1 t1) a) (by omega)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1e7848d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009581,
+     "end_time": "2026-06-25T04:30:33.465158+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:33.455577+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.2 Théorème de Vickrey — résultat clé\n",
+    "\n",
+    "**Le profil d'enchères honnêtes est un équilibre bayésien de Nash de l'enchère au second prix, pour TOUT `n`.** Théorème général — sans `decide`, sans vérification d'instance — ce qui contraste avec l'enchère au premier prix, où l'enchère honnête n'est PAS un BNE (cf. `Auction.lean` dans le lake). La preuve combine les deux meilleures réponses interim ci-dessus dans la conjonction `isBNE`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "82d7af05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T04:30:33.483733Z",
+     "iopub.status.busy": "2026-06-25T04:30:33.483572Z",
+     "iopub.status.idle": "2026-06-25T04:30:33.594212Z",
+     "shell.execute_reply": "2026-06-25T04:30:33.593417Z"
+    },
+    "papermill": {
+     "duration": 0.121411,
+     "end_time": "2026-06-25T04:30:33.594779+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:33.473368+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- **Théorème de Vickrey** (fini, deux enchérisseurs) : le profil honnête est un BNE pour tout n. -/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>spa_truthful_bne<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    isBNE<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"w\"> </span>(spaTruthful1<span class=\"w\"> </span>n)<span class=\"w\"> </span>(spaTruthful2<span class=\"w\"> </span>n)<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">⟨</span><span class=\"k\">fun</span><span class=\"w\"> </span>t1<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>spa_interim_best1<span class=\"w\"> </span>n<span class=\"w\"> </span>t1<span class=\"w\"> </span>a<span class=\"w\"> </span>(spaTruthful2<span class=\"w\"> </span>n),</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">   <span class=\"k\">fun</span><span class=\"w\"> </span>t2<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>spa_interim_best2<span class=\"w\"> </span>n<span class=\"w\"> </span>t2<span class=\"w\"> </span>a<span class=\"w\"> </span>(spaTruthful1<span class=\"w\"> </span>n)<span class=\"bp\">⟩</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>spa_truthful_bne</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> spa_truthful_bne<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>isBNE<span class=\"w\"> </span>(spa<span class=\"w\"> </span>n)<span class=\"w\"> </span>(spaTruthful1<span class=\"w\"> </span>n)<span class=\"w\"> </span>(spaTruthful2<span class=\"w\"> </span>n)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"/-- **Th\\u00e9or\\u00e8me de Vickrey** (fini, deux ench\\u00e9risseurs) : le profil honn\\u00eate est un BNE pour tout n. -/\\ntheorem spa_truthful_bne (n : Nat) :\\n    isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n) :=\\n  \\u27e8fun t1 a => spa_interim_best1 n t1 a (spaTruthful2 n),\\n   fun t2 a => spa_interim_best2 n t2 a (spaTruthful1 n)\\u27e9\\n\\n#check spa_truthful_bne\\n\", \"env\": 5}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"spa_truthful_bne (n : Nat) : isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n)\"}],\r\n",
+       " \"env\": 6}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "/-- **Théorème de Vickrey** (fini, deux enchérisseurs) : le profil honnête est un BNE pour tout n. -/\n",
+       "theorem spa_truthful_bne (n : Nat) :\n",
+       "    isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n) :=\n",
+       "  ⟨fun t1 a => spa_interim_best1 n t1 a (spaTruthful2 n),\n",
+       "   fun t2 a => spa_interim_best2 n t2 a (spaTruthful1 n)⟩\n",
+       "\n",
+       "#check spa_truthful_bne\n",
+       "──────▶  spa_truthful_bne (n : Nat) : isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n)\n",
+       "\n",
+       "--% env 6\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"/-- **Th\\u00e9or\\u00e8me de Vickrey** (fini, deux ench\\u00e9risseurs) : le profil honn\\u00eate est un BNE pour tout n. -/\\ntheorem spa_truthful_bne (n : Nat) :\\n    isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n) :=\\n  \\u27e8fun t1 a => spa_interim_best1 n t1 a (spaTruthful2 n),\\n   fun t2 a => spa_interim_best2 n t2 a (spaTruthful1 n)\\u27e9\\n\\n#check spa_truthful_bne\\n\", \"env\": 5}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"spa_truthful_bne (n : Nat) : isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n)\"}],\r\n",
+       " \"env\": 6}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "/-- **Théorème de Vickrey** (fini, deux enchérisseurs) : le profil honnête est un BNE pour tout n. -/\n",
+    "theorem spa_truthful_bne (n : Nat) :\n",
+    "    isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n) :=\n",
+    "  ⟨fun t1 a => spa_interim_best1 n t1 a (spaTruthful2 n),\n",
+    "   fun t2 a => spa_interim_best2 n t2 a (spaTruthful1 n)⟩\n",
+    "\n",
+    "#check spa_truthful_bne\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b3cf084",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008688,
+     "end_time": "2026-06-25T04:30:33.613626+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:33.604938+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.3 Rente d'information — instance décidable\n",
+    "\n",
+    "À l'équilibre honnête Vickrey avec valorisations `{0, 1, 2}`, le type haut gagne une utilité interim **strictement positive** (rente d'information concrète = 6 à l'échelle : gagne en payant 0 puis 1 contre les types bas, égalité à 2 pour un surplus nul). La décidabilité de `isBNE` (quantificateurs sur `Fin` de comparaisons `Int`) permet de le prouver par `decide` sur cette instance concrète.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e248d325",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T04:30:33.632820Z",
+     "iopub.status.busy": "2026-06-25T04:30:33.632666Z",
+     "iopub.status.idle": "2026-06-25T04:30:33.756332Z",
+     "shell.execute_reply": "2026-06-25T04:30:33.755681Z"
+    },
+    "papermill": {
+     "duration": 0.134533,
+     "end_time": "2026-06-25T04:30:33.757148+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:33.622615+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"sd\">/-- Le type haut garde une rente d&#39;information strictement positive (instance concrète décidable). -/</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>spa_truthful_pos_three<span class=\"w\"> </span>:</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>interimU1<span class=\"w\"> </span>(spa<span class=\"w\"> </span><span class=\"mi\">3</span>)<span class=\"w\"> </span><span class=\"bp\">⟨</span><span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"k\">by</span><span class=\"w\"> </span>decide<span class=\"bp\">⟩</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        (spaTruthful1<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span><span class=\"bp\">⟨</span><span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"k\">by</span><span class=\"w\"> </span>decide<span class=\"bp\">⟩</span>)<span class=\"w\"> </span>(spaTruthful2<span class=\"w\"> </span><span class=\"mi\">3</span>)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  decide</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Valeur concrète de l&#39;utilité interim du type haut (valuations {0,1,2}) :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>interimU1<span class=\"w\"> </span>(spa<span class=\"w\"> </span><span class=\"mi\">3</span>)<span class=\"w\"> </span>(<span class=\"mi\">2</span><span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span><span class=\"mi\">3</span>)<span class=\"w\"> </span>(spaTruthful1<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>(<span class=\"mi\">2</span><span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span><span class=\"mi\">3</span>))<span class=\"w\"> </span>(spaTruthful2<span class=\"w\"> </span><span class=\"mi\">3</span>)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">6</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 7</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"/-- Le type haut garde une rente d'information strictement positive (instance concr\\u00e8te d\\u00e9cidable). -/\\ntheorem spa_truthful_pos_three :\\n    0 < interimU1 (spa 3) \\u27e82, by decide\\u27e9\\n        (spaTruthful1 3 \\u27e82, by decide\\u27e9) (spaTruthful2 3) := by\\n  decide\\n\\n-- Valeur concr\\u00e8te de l'utilit\\u00e9 interim du type haut (valuations {0,1,2}) :\\n#eval interimU1 (spa 3) (2 : Fin 3) (spaTruthful1 3 (2 : Fin 3)) (spaTruthful2 3)\\n\", \"env\": 6}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 5},\r\n",
+       "   \"data\": \"6\"}],\r\n",
+       " \"env\": 7}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "/-- Le type haut garde une rente d'information strictement positive (instance concrète décidable). -/\n",
+       "theorem spa_truthful_pos_three :\n",
+       "    0 < interimU1 (spa 3) ⟨2, by decide⟩\n",
+       "        (spaTruthful1 3 ⟨2, by decide⟩) (spaTruthful2 3) := by\n",
+       "  decide\n",
+       "\n",
+       "-- Valeur concrète de l'utilité interim du type haut (valuations {0,1,2}) :\n",
+       "#eval interimU1 (spa 3) (2 : Fin 3) (spaTruthful1 3 (2 : Fin 3)) (spaTruthful2 3)\n",
+       "─────▶  6\n",
+       "\n",
+       "--% env 7\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"/-- Le type haut garde une rente d'information strictement positive (instance concr\\u00e8te d\\u00e9cidable). -/\\ntheorem spa_truthful_pos_three :\\n    0 < interimU1 (spa 3) \\u27e82, by decide\\u27e9\\n        (spaTruthful1 3 \\u27e82, by decide\\u27e9) (spaTruthful2 3) := by\\n  decide\\n\\n-- Valeur concr\\u00e8te de l'utilit\\u00e9 interim du type haut (valuations {0,1,2}) :\\n#eval interimU1 (spa 3) (2 : Fin 3) (spaTruthful1 3 (2 : Fin 3)) (spaTruthful2 3)\\n\", \"env\": 6}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 5},\r\n",
+       "   \"data\": \"6\"}],\r\n",
+       " \"env\": 7}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "/-- Le type haut garde une rente d'information strictement positive (instance concrète décidable). -/\n",
+    "theorem spa_truthful_pos_three :\n",
+    "    0 < interimU1 (spa 3) ⟨2, by decide⟩\n",
+    "        (spaTruthful1 3 ⟨2, by decide⟩) (spaTruthful2 3) := by\n",
+    "  decide\n",
+    "\n",
+    "-- Valeur concrète de l'utilité interim du type haut (valuations {0,1,2}) :\n",
+    "#eval interimU1 (spa 3) (2 : Fin 3) (spaTruthful1 3 (2 : Fin 3)) (spaTruthful2 3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "895780e6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00911,
+     "end_time": "2026-06-25T04:30:33.777231+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T04:30:33.768121+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Récapitulatif et résultats complémentaires du lake\n",
+    "\n",
+    "Ce notebook a **restaté et exécuté** le résultat central — le **théorème de Vickrey** (`spa_truthful_bne`, valable pour tout `n`, 0 sorry) — dans le kernel `lean4-wsl`. Le lake `lean_game_defs_ext/Bayesian` prouve en outre, également **sans sorry** :\n",
+    "\n",
+    "- **`isBNE_scaleW`** (`BNE.lean`) : le statut de BNE est **invariant par remise à l'échelle du prior** (indépendance de normalisation — les poids `Nat` représentent toute mesure de probabilité proportionnelle).\n",
+    "- **Principe de déviation à un coup** (`exAnteU1/2_le_of_interim_best`, `bne_exAnte`) : l'optimalité interim implique l'optimalité ex-ante contre toute déviation contingente au type.\n",
+    "- **Monotonie de Blackwell** (`Information.lean`, `valueSignal_mono`) : pour un décideur seul, un signal plus fin (`σ = h ∘ τ`) vaut au moins autant — **l'information ne nuit jamais à un joueur solitaire** (mais peut nuire strictement dans un *jeu*, cf. `InfoGames.lean`).\n",
+    "- **Enchère au premier prix** (`Auction.lean`) : l'enchère honnête n'y est **pas** un BNE (`truthful_not_bne_two/three`).\n",
+    "\n",
+    "Ces résultats se vérifient par la compilation du lake ci-dessus (`lake build Bayesian`, 0 sorry). Le pattern *self-contained* de ce notebook (restate inline, kernel élabore les vrais énoncés) est exactement celui des notebooks `2b/4b/8b/15b`.\n",
+    "\n",
+    "### Références\n",
+    "\n",
+    "- Vickrey, W. (1961). *Counterspeculation, Auctions, and Competitive Sealed Tenders*. Journal of Finance, 16(1), 8–37.\n",
+    "- Harsanyi, J. C. (1967). *Games with Incomplete Information Played by \"Bayesian\" Players*. Management Science, 14(3).\n",
+    "- Blackwell, D. (1951). *Comparison of Experiments*. Proc. 2nd Berkeley Symp. Math. Statist. Probab.\n",
+    "\n",
+    "### Prochaine étape\n",
+    "\n",
+    "L'extension à l'import direct d'un lake depuis le kernel `lean4-wsl` (prelude `NotebookCtx`, lancement via lake-env) est étudiée en side-track sur l'issue #4251 (Part of #4038).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "lean4-wsl",
+   "display_name": "Lean 4 (WSL)"
+  },
+  "language_info": {
+   "name": "lean"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.998521,
+   "end_time": "2026-06-25T04:30:34.003670+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-11b-Lean-BayesianGamesExt.ipynb",
+   "output_path": "out11b_v5.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-25T04:30:28.005149+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Delivers **voie (B)** of ai-01's #4040 steer (03:07Z): a **self-contained Lean 4 companion notebook** (`GameTheory-11b-Lean-BayesianGamesExt.ipynb`) restating the Vickrey second-price auction result proven **0-sorry** in the `lean_game_defs_ext/Bayesian` lake, **executed in the `lean4-wsl` kernel with REAL outputs** (the kernel re-elaborates the actual statements).

Restates verbatim from the lake (core Lean 4, **no Mathlib**, self-contained):
- `sumFin` (structural recursion over `Fin n`) + `sumFin_mono`
- `BayesGame2` (Harsanyi types, prior weights, `interimU1/2`, `exAnteU1/2`)
- `isBNE` (Bayesian Nash equilibrium, decidable — `∀` over `Fin` of `Int` comparisons)
- `spa` second-price auction + `spaTruthful1/2`
- dominance (`spa_truthful_dominant1/2`), interim best-response (`spa_interim_best1/2`)
- **keystone** `spa_truthful_bne (n : Nat) : isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n)` for all `n`
- concrete decide `spa_truthful_pos_three` + `#eval` showing the information-rent = **6**

**Why inline-restate not `import`:** the `lean4-wsl` REPL resolves module imports **only at process startup**, not from interactive mid-notebook `import` commands (a bare `import` mid-stream is not a module-load in Lean). No `lean4-wsl` notebook in the repo imports a lake lib — `2b/4b/8b/15b` are all self-contained. This notebook follows that established pattern. The lake itself builds fine (`lake build Bayesian`, 0 sorry). Import-from-lake exploration (prelude `NotebookCtx` / lake-env launch) continues as a side-track on **#4251**.

## Validation (rule §D — notebook PR)

1. **Execution (papermill, kernel `lean4-wsl`):** all 17 cells executed; 8 code cells, `execution_count` 1..8, **0 errors**.
   - cell0 smoke: `#eval 2+2 ──▶ 4`, `#check Nat ──▶ Nat : Type`
   - cell6 keystone compiles: `#check spa_truthful_bne ──▶ spa_truthful_bne (n : Nat) : isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n)`
   - cell7 `#eval interimU1 (spa 3) ... ──▶ 6` (concrete information-rent)
2. **0 `NotImplementedError` / `assert False` / `1/0`:** confirmed (grep = 0).
3. **C.2 (notebooks committed WITH outputs):** every code cell has `execution_count: <int>` + non-empty outputs (script-verified, 0 problems).
4. **No anti-regression:** new notebook (no prior proofs removed); no `sorry` (the restated theorems are fully proven inline).

The dominance proof uses `simp only [spa]; repeat' split; all_goals omega` (explicit `spa` unfold, robust across Lean versions — the lake's `show` defeq is fragile in v4.30.0 release). The accompanying linter "simp argument unused: spa" is a **known false-positive** (simp unfolds `spa`, needed for `split` to see the `if`-branches, but the linter only tracks rewrite-*rule* usage); documented inline in the theorem docstring.

## Side-finding (for coordination, not this PR's scope)

Mid-task I diagnosed and **fixed a `lean4-wsl` kernel regression I had caused** in an earlier voie-A POC: my voie-A experiment (added `require lean_game_defs_ext` + bumped `notebook_context` to v4.30.0-rc2) contaminated the kernel's REPL CWD, breaking the kernel globally. Restored `notebook_context` to its clean pre-voie-A state from backup (POC preserved separately at `notebook_context_voieA_poc` for #4251). Kernel now works again. **Consequence:** the committed Lean outputs of `2b/4b/8b/15b` are pre-regression-stale and could be re-executed now that the kernel is fixed — that's a separate issue, not this PR.

See #4040

Co-Authored-By: Claude <noreply@anthropic.com>