### PR TITLE
docs(probas): add Mermaid concept diagrams to Probas parent README

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -36,6 +36,21 @@ Au-delà de la méthodologie, cette série couvre des **applications réelles** 
 | **Combinaison de sources** | Requiert ingenierie manuelle | Probabilites conditionnelles structurees |
 | **Decisions** | Basées sur un point | Basées sur E[U] (utilite esperee) |
 
+```mermaid
+flowchart LR
+    D["Données<br/>(observations)"] --> ML["ML classique<br/>(déterministe)"]
+    D --> PP["Programmation<br/>probabiliste"]
+    ML --> P1["Un seul résultat<br/>ex: 0.73"]
+    PP --> P2["Une distribution<br/>ex: N(0.73, 0.12)"]
+    P1 --> U1["Incertitude<br/>non quantifiée"]
+    P2 --> U2["Incertitude<br/>native<br/>(intervalles de crédibilité)"]
+    U2 --> DEC["Décision basée sur<br/>E[U] (utilité espérée)"]
+    classDef dist fill:#d1ecf1,stroke:#0c5460,stroke-width:2px;
+    class P2,U2,DEC dist;
+```
+
+La différence fondatrice : le ML classique produit un **point**, la programmation probabiliste produit une **distribution** (en bleu). Cette incertitude native se propage jusqu'à la décision — on maximise l'utilité espérée `E[U]`, pas un seul score.
+
 ## Objectifs d'apprentissage
 
 À l'issue de cette série, vous serez capable de :
@@ -110,6 +125,29 @@ Si vous préférez Python au C#, commencez par Infer-101.ipynb (introduction sta
 Les notebooks PyMC dans `PyMC/` reprennent l'intégralité des 20 modèles Infer.NET en Python avec PyMC et l'echantillonnage NUTS : fondations (1-3), modèles classiques (4-13), et théorie de la décision (14-20). Ils constituent un excellent complement pour comparer les approches d'inference (message passing vs MCMC) et rejoindre l'ecosysteme Python data science. La progression suit la même structure pédagogique en 3 phases que la série Infer.NET.
 
 ## Quel stack choisir ?
+
+```mermaid
+flowchart TD
+    START(["Votre profil ?"])
+    START --> Q1{"Vous venez du<br/>C# / .NET ?"}
+    START --> Q2{"Vous venez du<br/>Python / data science ?"}
+    START --> Q3{"Indécis ?<br/>Découverte rapide"}
+    Q1 -->|"oui"| INFER["<b>Infer.NET</b><br/>API C# native · Roslyn ·<br/>factor graphs · inference exacte<br/>(EP/VMP)"]
+    Q2 -->|"oui"| PYMC["<b>PyMC</b><br/>with pm.Model() · NUTS ·<br/>écosystème pandas/arviz"]
+    Q3 --> IN101["<b>Infer-101</b><br/>(standalone, 45 min)"]
+    INFER --> PIVOT1{"Modèle trop complexe<br/>ou pipeline Python ?"}
+    PYMC --> PIVOT2{"Besoin d'inference exacte<br/>(VMP/EP) ou .NET ?"}
+    PIVOT1 -->|"oui"| PYMC
+    PIVOT2 -->|"oui"| INFER
+    classDef infer fill:#d4edda,stroke:#28a745,stroke-width:2px;
+    classDef pymc fill:#cce5ff,stroke:#004085,stroke-width:2px;
+    classDef entry fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    class INFER infer;
+    class PYMC pymc;
+    class IN101 entry;
+```
+
+Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passing, déterministe) et **PyMC** (Python, MCMC, flexible). L'arbre ci-dessus donne le point d'entrée selon votre profil — et le pont de bascule vers l'autre stack quand le modèle ou l'environnement l'exige. Le détail comparatif notebook-par-notebook figure dans le [Parcours inference comparée](#parcours-inference-comparee-infernet-vs-pymc-15h) ci-dessous.
 
 ### Si vous venez du C# / .NET
 


### PR DESCRIPTION
## Summary

Rolling editorial finish (**Epic #4212**) — famille Probas **parent** (`MyIA.AI.Notebooks/Probas/README.md`, 495 lignes, index de la série, **0 diagramme**). Ajoute deux diagrammes Mermaid natifs GitHub. Markdown-only, pure addition.

See #4212 (contribution partielle à l'Epic de finition éditoriale rolling).

## Changements

Deux diagrammes, scope = README seul (+38 / 0 délétions) :

1. **ML classique vs programmation probabiliste** (après le tableau « Qu'est-ce que ») — mêmes données → le ML produit un **point** (0.73), la PP produit une **distribution** N(0.73, 0.12). L'incertitude native se propage jusqu'à la décision (E[U], utilité espérée). Visualise l'**identité fondatrice** de la série.

2. **Arbre de décision de stack** (« Quel stack choisir ? ») — le contenu de routage réel de l'index parent : point d'entrée selon le profil (C#/.NET → Infer.NET, Python/DS → PyMC, indécis → Infer-101) + arête de bascule vers l'autre stack quand le modèle ou l'environnement l'exige. Color-codé (Infer.NET vert, PyMC bleu, entrée jaune) ; pointe vers le tableau « Parcours inference comparée » pour la comparaison notebook-par-notebook.

## Validation

- `grep -c '\`\`\`mermaid'` README : **0 → 2** ; total des fences pair (20 = 10 paires, incluant les blocs bash/code préexistants), aucun bloc orphelin.
- **Marqueur `CATALOG-STATUS` byte-identical à `origin/main`** (vérifié via `diff` sur les lignes 3-7 : vide = identique).
- Diff = pure addition (2 diagrammes + 2 légendes). Pas de modification de prose/liens/ancres existants.
- Scope : README seul. Le sous-module `SymbolicAI/SMT/Automata` (dirty) n'est **pas** staged (#2979, user-gated).
- Étiquettes Mermaid : quotées `["…"]`, `<b>`/`<br/>`, `classDef`/`class` triple-coloration (Infer vert / PyMC bleu / entrée jaune) ; rendu natif GitHub (SOTA, cf [sota-not-workaround.md](.claude/rules/sota-not-workaround.md)).

## Partition

Lane po-2025 (Z3/Argumentum/.NET/Probas). Disjoint de po-2024 (Search/MGS/GameTheory/Sudoku) et po-2026 (Lean). Frère des PR #4229/#4238/#4240/#4242 (Z3/Argumentum/Tweety) et #4253/#4254 (PyMC/Infer) — le README parent Probas est l'index qui surplombe les deux stacks, ses diagrammes sont donc complémentaires et non-redondants avec les READMEs enfants.

## Distinction vs #4253/#4254

- #4253 (PyMC) = fourche moteur MCMC ↔ message-passing (le fil rouge commun).
- #4254 (Infer) = compilation Roslyn → 3-moteurs EP/VMP/Gibbs (Infer-specific).
- **Celui-ci (Probas parent)** = ML vs PP (l'identité de la série) + arbre de décision de stack (le routage de l'index). Trois angles distincts, 0 duplication.