### PR TITLE
fix(genai): migrate 00-1 Environment-Setup image smoke test dall-e-3 -> gpt-image-1 (Axe-2 SOTA-OK)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-1-Environment-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-1-Environment-Setup.ipynb
@@ -5,10 +5,10 @@
    "id": "c18f4973",
    "metadata": {
     "papermill": {
-     "duration": 0.003285,
-     "end_time": "2026-05-09T22:49:39.360676",
+     "duration": 0.003104,
+     "end_time": "2026-06-25T04:46:03.992577",
      "exception": false,
-     "start_time": "2026-05-09T22:49:39.357391",
+     "start_time": "2026-06-25T04:46:03.989473",
      "status": "completed"
     },
     "tags": []
@@ -42,16 +42,16 @@
    "id": "9d592e21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T22:49:39.368128Z",
-     "iopub.status.busy": "2026-05-09T22:49:39.367638Z",
-     "iopub.status.idle": "2026-05-09T22:49:39.372350Z",
-     "shell.execute_reply": "2026-05-09T22:49:39.371781Z"
+     "iopub.execute_input": "2026-06-25T04:46:03.999585Z",
+     "iopub.status.busy": "2026-06-25T04:46:03.999145Z",
+     "iopub.status.idle": "2026-06-25T04:46:04.113134Z",
+     "shell.execute_reply": "2026-06-25T04:46:04.112344Z"
     },
     "papermill": {
-     "duration": 0.009966,
-     "end_time": "2026-05-09T22:49:39.373428",
+     "duration": 0.118941,
+     "end_time": "2026-06-25T04:46:04.114413",
      "exception": false,
-     "start_time": "2026-05-09T22:49:39.363462",
+     "start_time": "2026-06-25T04:46:03.995472",
      "status": "completed"
     },
     "tags": [
@@ -95,16 +95,16 @@
    "id": "786495c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T22:49:39.380356Z",
-     "iopub.status.busy": "2026-05-09T22:49:39.380073Z",
-     "iopub.status.idle": "2026-05-09T22:49:39.383649Z",
-     "shell.execute_reply": "2026-05-09T22:49:39.382996Z"
+     "iopub.execute_input": "2026-06-25T04:46:04.126107Z",
+     "iopub.status.busy": "2026-06-25T04:46:04.125785Z",
+     "iopub.status.idle": "2026-06-25T04:46:04.129596Z",
+     "shell.execute_reply": "2026-06-25T04:46:04.129052Z"
     },
     "papermill": {
-     "duration": 0.009262,
-     "end_time": "2026-05-09T22:49:39.385204",
+     "duration": 0.014149,
+     "end_time": "2026-06-25T04:46:04.131125",
      "exception": false,
-     "start_time": "2026-05-09T22:49:39.375942",
+     "start_time": "2026-06-25T04:46:04.116976",
      "status": "completed"
     },
     "tags": [
@@ -120,6 +120,16 @@
   {
    "cell_type": "markdown",
    "id": "7f98e932",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002209,
+     "end_time": "2026-06-25T04:46:04.136003",
+     "exception": false,
+     "start_time": "2026-06-25T04:46:04.133794",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Initialisation de l'environnement GenAI\n",
     "\n",
@@ -143,8 +153,7 @@
     "- Provider API selectionne (openrouter, openai, local)\n",
     "\n",
     "> **Note technique** : Le module `autoreload` permet de recharger automatiquement les modules modifies pendant le developpement.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -152,16 +161,16 @@
    "id": "064f3b81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T22:49:39.392411Z",
-     "iopub.status.busy": "2026-05-09T22:49:39.392026Z",
-     "iopub.status.idle": "2026-05-09T22:49:42.889542Z",
-     "shell.execute_reply": "2026-05-09T22:49:42.888689Z"
+     "iopub.execute_input": "2026-06-25T04:46:04.141746Z",
+     "iopub.status.busy": "2026-06-25T04:46:04.141338Z",
+     "iopub.status.idle": "2026-06-25T04:46:10.946026Z",
+     "shell.execute_reply": "2026-06-25T04:46:10.944978Z"
     },
     "papermill": {
-     "duration": 3.502444,
-     "end_time": "2026-05-09T22:49:42.890675",
+     "duration": 6.809409,
+     "end_time": "2026-06-25T04:46:10.947630",
      "exception": false,
-     "start_time": "2026-05-09T22:49:39.388231",
+     "start_time": "2026-06-25T04:46:04.138221",
      "status": "completed"
     },
     "tags": []
@@ -174,7 +183,7 @@
       "✅ Configuration chargée depuis D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n",
       "📁 Helpers partagés ajoutés: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\shared\\helpers\n",
       "🎨 GenAI CoursIA - Environment Setup\n",
-      "📅 2026-05-10 00:49:42\n",
+      "📅 2026-06-25 06:46:10\n",
       "🔧 Mode: interactive, Provider: openrouter\n"
      ]
     }
@@ -229,6 +238,16 @@
   {
    "cell_type": "markdown",
    "id": "44a4fa78",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002555,
+     "end_time": "2026-06-25T04:46:10.953397",
+     "exception": false,
+     "start_time": "2026-06-25T04:46:10.950842",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Validation de l'environnement GenAI\n",
     "\n",
@@ -247,8 +266,7 @@
     "- Le statut est stocke dans `environment_status` pour usage ulterieur\n",
     "\n",
     "Cette approche modulaire permet d'identifier precisement quelle composante pose probleme.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -256,16 +274,16 @@
    "id": "9ebe55ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T22:49:42.896638Z",
-     "iopub.status.busy": "2026-05-09T22:49:42.896165Z",
-     "iopub.status.idle": "2026-05-09T22:49:43.000454Z",
-     "shell.execute_reply": "2026-05-09T22:49:42.999566Z"
+     "iopub.execute_input": "2026-06-25T04:46:10.959715Z",
+     "iopub.status.busy": "2026-06-25T04:46:10.959490Z",
+     "iopub.status.idle": "2026-06-25T04:46:10.984043Z",
+     "shell.execute_reply": "2026-06-25T04:46:10.983540Z"
     },
     "papermill": {
-     "duration": 0.108786,
-     "end_time": "2026-05-09T22:49:43.001739",
+     "duration": 0.028679,
+     "end_time": "2026-06-25T04:46:10.984854",
      "exception": false,
-     "start_time": "2026-05-09T22:49:42.892953",
+     "start_time": "2026-06-25T04:46:10.956175",
      "status": "completed"
     },
     "tags": []
@@ -380,10 +398,10 @@
    "id": "3c641e79",
    "metadata": {
     "papermill": {
-     "duration": 0.002266,
-     "end_time": "2026-05-09T22:49:43.007133",
+     "duration": 0.001579,
+     "end_time": "2026-06-25T04:46:10.988260",
      "exception": false,
-     "start_time": "2026-05-09T22:49:43.004867",
+     "start_time": "2026-06-25T04:46:10.986681",
      "status": "completed"
     },
     "tags": []
@@ -413,6 +431,16 @@
   {
    "cell_type": "markdown",
    "id": "bf48dd14",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001671,
+     "end_time": "2026-06-25T04:46:10.991598",
+     "exception": false,
+     "start_time": "2026-06-25T04:46:10.989927",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Test de generation d'image - Validation fonctionnelle\n",
     "\n",
@@ -428,8 +456,7 @@
     "**Modele utilise** : `openai/dall-e-3` via OpenRouter  \n",
     "**Prompt** : \"A simple test image: colorful abstract shapes\"  \n",
     "**Resolution** : 1024x1024 pixels\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -437,16 +464,16 @@
    "id": "c672c27d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T22:49:43.013443Z",
-     "iopub.status.busy": "2026-05-09T22:49:43.012705Z",
-     "iopub.status.idle": "2026-05-09T22:49:43.573002Z",
-     "shell.execute_reply": "2026-05-09T22:49:43.571876Z"
+     "iopub.execute_input": "2026-06-25T04:46:10.996313Z",
+     "iopub.status.busy": "2026-06-25T04:46:10.996023Z",
+     "iopub.status.idle": "2026-06-25T04:46:25.877653Z",
+     "shell.execute_reply": "2026-06-25T04:46:25.877073Z"
     },
     "papermill": {
-     "duration": 0.56552,
-     "end_time": "2026-05-09T22:49:43.574787",
+     "duration": 14.885174,
+     "end_time": "2026-06-25T04:46:25.878639",
      "exception": false,
-     "start_time": "2026-05-09T22:49:43.009267",
+     "start_time": "2026-06-25T04:46:10.993465",
      "status": "completed"
     },
     "tags": []
@@ -457,16 +484,17 @@
      "output_type": "stream",
      "text": [
       "🧪 Test génération d'image...\n",
-      "📡 Appel API OpenRouter...\n"
+      "📡 Appel API OpenAI (gpt-image-1)...\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "⚠️  Erreur API: 404\n",
-      "Response: <!DOCTYPE html><html lang=\"en\"><head><meta charSet=\"utf-8\"/><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, minimum-scale=1\"/><link rel=\"stylesheet\" href=\"/_next/static/chunks/15ko...\n",
-      "✅ Validation APIs complétée (génération non testée)\n"
+      "✅ Test génération réussi !\n",
+      "🎨 Modèle: gpt-image-1\n",
+      "📝 Prompt: A simple test image: colorful abstract shapes\n",
+      "🖼️  Image générée: base64 (1547260 chars)\n"
      ]
     }
    ],
@@ -487,55 +515,70 @@
     "    \n",
     "    print(\"🧪 Test génération d'image...\")\n",
     "    \n",
-    "    # Test simple avec OpenRouter (prioritaire)\n",
-    "    if environment_status[\"apis\"][\"openrouter\"]:\n",
+    "    # OpenRouter = chat-completion uniquement (pas d'endpoint /images/generations ;\n",
+    "    # un appel image via OpenRouter renvoie 404). On valide donc la generation d'image\n",
+    "    # via OpenAI direct avec gpt-image-1 (le modele image actuel d'OpenAI ; dall-e-3 est\n",
+    "    # retire). gpt-image-1 retourne l'image en base64 (b64_json), pas une URL.\n",
+    "    if environment_status[\"apis\"][\"openai\"]:\n",
     "        try:\n",
     "            headers = {\n",
-    "                'Authorization': f'Bearer {os.getenv(\"OPENROUTER_API_KEY\")}',\n",
+    "                'Authorization': f'Bearer {os.getenv(\"OPENAI_API_KEY\")}',\n",
     "                'Content-Type': 'application/json'\n",
     "            }\n",
-    "            \n",
-    "            # Test avec un modèle simple\n",
+    "\n",
+    "            # gpt-image-1, qualite \"low\" = cout minimal pour un smoke test de validation\n",
     "            payload = {\n",
-    "                'model': 'openai/dall-e-3',\n",
+    "                'model': 'gpt-image-1',\n",
     "                'prompt': 'A simple test image: colorful abstract shapes',\n",
     "                'size': '1024x1024',\n",
-    "                'quality': 'standard',\n",
+    "                'quality': 'low',\n",
     "                'n': 1\n",
     "            }\n",
-    "            \n",
-    "            print(\"📡 Appel API OpenRouter...\")\n",
+    "\n",
+    "            print(\"📡 Appel API OpenAI (gpt-image-1)...\")\n",
     "            response = requests.post(\n",
-    "                'https://openrouter.ai/api/v1/images/generations',\n",
+    "                'https://api.openai.com/v1/images/generations',\n",
     "                headers=headers,\n",
     "                json=payload,\n",
     "                timeout=60\n",
     "            )\n",
-    "            \n",
+    "\n",
     "            if response.status_code == 200:\n",
     "                result = response.json()\n",
     "                print(\"✅ Test génération réussi !\")\n",
     "                print(f\"🎨 Modèle: {payload['model']}\")\n",
     "                print(f\"📝 Prompt: {payload['prompt']}\")\n",
-    "                \n",
+    "\n",
     "                if 'data' in result and len(result['data']) > 0:\n",
-    "                    image_url = result['data'][0].get('url')\n",
-    "                    if image_url:\n",
-    "                        print(f\"🖼️  Image générée: {image_url[:50]}...\")\n",
+    "                    # gpt-image-1 retourne b64_json (pas d'URL comme dall-e-3)\n",
+    "                    _b64 = result['data'][0].get('b64_json')\n",
+    "                    _url = result['data'][0].get('url')\n",
+    "                    if _b64:\n",
+    "                        print(f\"🖼️  Image générée: base64 ({len(_b64)} chars)\")\n",
     "                        return {\n",
     "                            'success': True,\n",
-    "                            'provider': 'openrouter',\n",
+    "                            'provider': 'openai',\n",
     "                            'model': payload['model'],\n",
-    "                            'image_url': image_url\n",
+    "                            'image_url': f\"data:image/png;base64,{_b64[:60]}... (b64)\"\n",
     "                        }\n",
-    "                \n",
-    "                return {'success': True, 'provider': 'openrouter'}\n",
+    "                    elif _url:\n",
+    "                        print(f\"🖼️  Image générée: {_url[:50]}...\")\n",
+    "                        return {\n",
+    "                            'success': True,\n",
+    "                            'provider': 'openai',\n",
+    "                            'model': payload['model'],\n",
+    "                            'image_url': _url\n",
+    "                        }\n",
+    "\n",
+    "                return {'success': True, 'provider': 'openai'}\n",
     "            else:\n",
     "                print(f\"⚠️  Erreur API: {response.status_code}\")\n",
     "                print(f\"Response: {response.text[:200]}...\")\n",
-    "                \n",
+    "\n",
     "        except Exception as e:\n",
-    "            print(f\"❌ Erreur test OpenRouter: {str(e)[:100]}...\")\n",
+    "            print(f\"❌ Erreur test OpenAI: {str(e)[:100]}...\")\n",
+    "    elif environment_status[\"apis\"][\"openrouter\"]:\n",
+    "        print(\"ℹ️  OpenRouter configuré (chat-completion uniquement, pas de génération d'images)\")\n",
     "    \n",
     "    print(\"✅ Validation APIs complétée (génération non testée)\")\n",
     "    return {'success': False, 'reason': 'api_available_but_generation_failed'}\n",
@@ -553,10 +596,10 @@
    "id": "a4e9009a",
    "metadata": {
     "papermill": {
-     "duration": 0.003467,
-     "end_time": "2026-05-09T22:49:43.582756",
+     "duration": 0.002558,
+     "end_time": "2026-06-25T04:46:25.883846",
      "exception": false,
-     "start_time": "2026-05-09T22:49:43.579289",
+     "start_time": "2026-06-25T04:46:25.881288",
      "status": "completed"
     },
     "tags": []
@@ -583,6 +626,16 @@
   {
    "cell_type": "markdown",
    "id": "89864f5c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002459,
+     "end_time": "2026-06-25T04:46:25.889053",
+     "exception": false,
+     "start_time": "2026-06-25T04:46:25.886594",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Rapport de configuration et score de sante\n",
     "\n",
@@ -601,8 +654,7 @@
     "- Test de generation reussi : +10 points\n",
     "\n",
     "Le rapport est sauvegarde dans le repertoire `outputs/generated/` avec un timestamp unique.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -610,16 +662,16 @@
    "id": "93e45cc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T22:49:43.592427Z",
-     "iopub.status.busy": "2026-05-09T22:49:43.591881Z",
-     "iopub.status.idle": "2026-05-09T22:49:43.655844Z",
-     "shell.execute_reply": "2026-05-09T22:49:43.654371Z"
+     "iopub.execute_input": "2026-06-25T04:46:25.896328Z",
+     "iopub.status.busy": "2026-06-25T04:46:25.895937Z",
+     "iopub.status.idle": "2026-06-25T04:46:25.959784Z",
+     "shell.execute_reply": "2026-06-25T04:46:25.958649Z"
     },
     "papermill": {
-     "duration": 0.070933,
-     "end_time": "2026-05-09T22:49:43.657221",
+     "duration": 0.069495,
+     "end_time": "2026-06-25T04:46:25.961189",
      "exception": false,
-     "start_time": "2026-05-09T22:49:43.586288",
+     "start_time": "2026-06-25T04:46:25.891694",
      "status": "completed"
     },
     "tags": []
@@ -633,18 +685,15 @@
       "==================================================\n",
       "📋 RAPPORT CONFIGURATION GENAI COURSIA\n",
       "==================================================\n",
-      "🏥 Score de santé: 75/100\n",
+      "🏥 Score de santé: 85/100\n",
       "⚙️  Configuration: ✅ Chargée\n",
       "🌐 APIs disponibles: 2/2\n",
       "🐳 Services Docker: 0/3\n",
-      "⚠️  Test génération: Échoué\n",
-      "\n",
-      "💡 RECOMMANDATIONS:\n",
-      "1. Vérifier la validité des clés API et les quotas\n",
+      "✅ Test génération: Réussi (openai)\n",
       "\n",
       "🎉 Environnement optimal - Tous les modules GenAI disponibles\n",
       "\n",
-      "💾 Rapport sauvegardé: outputs\\generated\\environment_setup_report_20260510_004943.json\n",
+      "💾 Rapport sauvegardé: outputs\\generated\\environment_setup_report_20260625_064625.json\n",
       "\n",
       "🚀 Environnement GenAI CoursIA prêt !\n"
      ]
@@ -744,10 +793,10 @@
    "id": "1c307b36",
    "metadata": {
     "papermill": {
-     "duration": 0.002651,
-     "end_time": "2026-05-09T22:49:43.662508",
+     "duration": 0.002942,
+     "end_time": "2026-06-25T04:46:25.967523",
      "exception": false,
-     "start_time": "2026-05-09T22:49:43.659857",
+     "start_time": "2026-06-25T04:46:25.964581",
      "status": "completed"
     },
     "tags": []
@@ -809,16 +858,16 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.687368,
-   "end_time": "2026-05-09T22:49:44.000862",
+   "duration": 25.336886,
+   "end_time": "2026-06-25T04:46:26.209829",
    "environment_variables": {},
    "exception": null,
-   "input_path": "00-1-Environment-Setup.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/00-1_output.ipynb",
+   "input_path": "00-GenAI-Environment/00-1-Environment-Setup.ipynb",
+   "output_path": "00-GenAI-Environment/00-1-Environment-Setup.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },
-   "start_time": "2026-05-09T22:49:37.313494",
+   "start_time": "2026-06-25T04:46:00.872943",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Context

OpenAI retired **dall-e-3**. `00-1-Environment-Setup.ipynb` cell 9 (image-generation smoke test) was pinned to `openai/dall-e-3` via **OpenRouter** (`/v1/images/generations`). Verified firsthand (G.1): the committed output on origin/main **already fails 404** — OpenRouter returns an HTML Next.js page because OpenRouter is **chat-completion only** and has no `/images/generations` endpoint. The sibling notebook `01-1` states this explicitly: "OpenRouter ne supporte PAS le endpoint /v1/images/generations".

So a bare model-id swap would **still 404**. The smoke test silently reported "génération non testée" — misleading: the env-validation never actually validated the current image model.

Part of Epic #3801 (GenAI Axe-2 SOTA). See #3801 (partial — epic ongoing).

## Verdict: RECOVERABLE-LOCAL -> SOTA-OK

Reworked the smoke test to validate the **real current image path**: gpt-image-1 via OpenAI direct (`api.openai.com/v1/images/generations`).

## Changes (surgical — cell 9 source only)

| Change | Before | After |
|--------|--------|-------|
| Provider branch | `if environment_status["apis"]["openrouter"]:` | `if environment_status["apis"]["openai"]:` (+ `elif openrouter:` chat-only note) |
| Endpoint | `openrouter.ai/api/v1/images/generations` (404) | `api.openai.com/v1/images/generations` |
| Model | `openai/dall-e-3` | `gpt-image-1` |
| Quality | `standard` (→400 on gpt-image-1) | `low` (minimal-cost smoke test) |
| Response handling | `result['data'][0].get('url')` | `b64_json`-aware (gpt-image-1 returns base64, not URL) |
| `response_format` | n/a (raw payload) | omitted (gpt-image-1 doesn't accept it → 400) |

Only cell 9 source changed (verified via source diff). 149/100 = output churn from re-exec (normal for C.2).

## Validation (real execution)

- **Papermill re-exec: all cells, COMPLETED, 0 cell errors.** `--cwd MyIA.AI.Notebooks/GenAI --execution-timeout 300`, `CUDA_VISIBLE_DEVICES=""` (image gen is API, no GPU).
- **cell 9 PROOF (SOTA-OK)**: the smoke test now **actually validates gpt-image-1**:
  ```
  📡 Appel API OpenAI (gpt-image-1)...
  ✅ Test génération réussi !
  🎨 Modèle: gpt-image-1
  🖼️  Image générée: base64 (1547260 chars)   # ~1.1MB real PNG
  ```
  Final report: "✅ Test génération: Réussi (openai)", health 85/100, "Environnement optimal".
  Before (origin/main): silent 404 + "génération non testée".
- verify_nb: null_exec=0, errors=0, NotImplementedError=0, secrets=0.
- LF normalized per `.gitattributes`.

## Pre-existing out-of-scope signal (principle 3)

`verify_nb` reports `machine_leaks=2` — this is **identical to origin/main** (parity verified: branch 2 == origin/main 2). The leak is in **cell 4** (not my cell 9), printing absolute paths: `print(f"✅ Configuration chargée depuis {ENV_FILE}")` + `print(f"📁 Helpers partagés ajoutés: {SHARED_PATH}")`. This machine (po-2023) last executed 00-1, so its path is in origin/main's output too.

- **Not a regression**: same leak count before and after; I did not touch cell 4 source.
- **Belongs to the env-path fleet rollout** (See #4080, #4105 — `~62 notebooks impriment chemin absolu machine`), family-partitioned (collision risk with po-2025). Not fixed here to keep this PR atomic (one subject: dall-e-3 → gpt-image-1) and avoid crossing Epics.

A dedicated env-path PR for 00-1 cell 4 (`{ENV_FILE}` → relative/`.name`) is the correct follow-up.

## Scope

Single notebook, single subject (dall-e-3 -> gpt-image-1 smoke test). No unrelated edits. Catalog byte-identical to main (not regenerated).