### PR TITLE
feat(conway): FractranLemmas — FRACTRAN step/run calibration (0 sorry, See #2162)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/FractranLemmas.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/FractranLemmas.lean
@@ -1,0 +1,67 @@
+/-
+Conway's FRACTRAN — companion lemmas
+John Horton Conway (1937-2020)
+
+These lemmas sit on top of `Conway.Fractran` (the FRACTRAN universal machine) and
+form a calibration ladder over its step/run semantics, parallel to the existing
+`Conway.DoomsdayLemmas` and `Conway.LookAndSayLemmas` companion files. Until now
+`Fractran.lean` was the only Conway module with definitions but no companion theorems.
+
+  - `fractranStep_empty` / `fractranRun_zero`
+        : definitionally-true base cases (halt on empty program; 0-step run)   -> rfl
+  - `fracMulNat_den_one`
+        : a fraction num/1 is a whole multiplier, hence always applicable      -> simp + omega
+  - `fracMulNat_six_halves` / `fracMulNat_seven_not_halves`
+        : closed applicability checks (6 divisible by 2; 7 not)                -> decide
+  - `fractranStep_single_two_to_three` / `fractranStep_single_halts_at_three`
+        : the single-fraction program {3/2} sends 2 → 3, then halts at 3       -> decide
+  - `fractranRun_single_trace`
+        : the bounded trace 2 → 3 (halt) of {3/2}                               -> decide
+
+All proofs discharged with no stubs. These facts are pure core Lean 4 (no Mathlib needed) — FRACTRAN's
+step/run are structural recursions over Nat/List, decidable on concrete inputs.
+See #2162 (Conway family).
+-/
+
+import Conway.Fractran
+
+namespace Conway
+
+/-- BASE (rfl): an empty FRACTRAN program halts immediately — no fraction applies. -/
+theorem fractranStep_empty (n : Nat) : fractranStep [] n = none := rfl
+
+/-- BASE (rfl): running any program for 0 steps yields just the starting value. -/
+theorem fractranRun_zero (prog : List Frac) (n : Nat) : fractranRun prog n 0 = [n] := rfl
+
+/-- STEP (simp+omega): a fraction num/1 is an integer multiplier, hence always
+    applicable (`n * num` is divisible by 1 trivially). -/
+theorem fracMulNat_den_one (n : Nat) (f : Frac) (h : f.den = 1) :
+    fracMulNat n f = true := by
+  simp [fracMulNat, h, Nat.mod_one]
+
+/-- CALIBRATION (decide): 6 is divisible by 2, so the fraction {3/2} applies at 6. -/
+theorem fracMulNat_six_halves : fracMulNat 6 (frac 3 2 (by omega)) = true := by
+  decide
+
+/-- CALIBRATION (decide): 7 is NOT divisible by 2, so {3/2} does not apply at 7. -/
+theorem fracMulNat_seven_not_halves : fracMulNat 7 (frac 3 2 (by omega)) = false := by
+  decide
+
+/-- STEP (decide): the single-fraction program {3/2} sends 2 → 3 (2 · 3 / 2 = 3). -/
+theorem fractranStep_single_two_to_three :
+    fractranStep [frac 3 2 (by omega)] 2 = some 3 := by
+  decide
+
+/-- HALT (decide): the single-fraction program {3/2} halts at 3 (3 · 3 = 9 is not
+    divisible by 2, so no fraction applies). -/
+theorem fractranStep_single_halts_at_three :
+    fractranStep [frac 3 2 (by omega)] 3 = none := by
+  decide
+
+/-- RUN (decide): running {3/2} from 2 for 5 steps yields the trace [2, 3]
+    (2 → 3, then halt at 3). -/
+theorem fractranRun_single_trace :
+    fractranRun [frac 3 2 (by omega)] 2 5 = [2, 3] := by
+  decide
+
+end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -18,6 +18,7 @@ Formalisation en Lean 4 des jeux et algorithmes mathématiques de John Conway.
 | `Conway/Doomsday.lean` | 0 | Algorithme Doomsday (calcul du jour de la semaine) |
 | `Conway/DoomsdayLemmas.lean` | 0 | Lemmes pour l'algorithme Doomsday |
 | `Conway/Fractran.lean` | 0 | Langage de programmation FRACTRAN |
+| `Conway/FractranLemmas.lean` | 0 | Lemmes pour FRACTRAN (step/run : halt vide, 0-run, applicabilité `num/1`, trace concrète `{3/2}` 2→3) |
 | `Conway/LookAndSay.lean` | 0 | Suite Look-and-Say |
 | `Conway/LookAndSayLemmas.lean` | 0 | Lemmes pour la suite Look-and-Say |
 | `Conway/Nim.lean` | 0 | Théorie des jeux de Nim |


### PR DESCRIPTION
## Summary

Companion theorem file for `Conway.Fractran` (the FRACTRAN universal machine). `Fractran.lean` was the **only Conway module with definitions but no companion theorems** — every other Conway module already has its `X`+`XLemmas` pair (`Doomsday`/`DoomsdayLemmas`, `LookAndSay`/`LookAndSayLemmas`). This closes that gap following the same companion-lemma pattern (like astar #4201, sudoku #4215, kelly #4223, gittins #4252).

`Fractran.lean` is pure core Lean 4 (Nat-based, no Mathlib import) — its step/run are structural recursions, decidable on concrete inputs.

## Theorems (calibration ladder over FRACTRAN step/run semantics)

| Theorem | Statement | Proof |
|---|---|---|
| `fractranStep_empty` | empty program halts (`fractranStep [] n = none`) | `rfl` |
| `fractranRun_zero` | 0-step run = `[n]` | `rfl` |
| `fracMulNat_den_one` | a `num/1` fraction always applies (integer multiplier) | `simp + Nat.mod_one` |
| `fracMulNat_six_halves` | 6 divisible by 2 → `{3/2}` applies | `decide` |
| `fracMulNat_seven_not_halves` | 7 not divisible by 2 → `{3/2}` does not apply | `decide` |
| `fractranStep_single_two_to_three` | `{3/2}` sends 2 → 3 | `decide` |
| `fractranStep_single_halts_at_three` | `{3/2}` halts at 3 (9 not divisible by 2) | `decide` |
| `fractranRun_single_trace` | bounded trace `[2, 3]` of `{3/2}` | `decide` |

## Validation (rule §B — Lean PR)

1. **`grep -c sorry` before/after**: NEW file (0 → 0). Lake standalone-tactic total **7 → 7** (all 7 pre-existing in `Life/HashlifeCorrectness.lean`, untouched). This file contributes **0**. Reproduced the exact CI filter (`^\s*sorry\b` | `· sorry`) firsthand — total = baseline.
2. **`lake build Conway.FractranLemmas`**: **SUCCESS** — "Build completed successfully (3 jobs)".
3. **Axiom integrity**: 0 sorry in source → no `sorryAx` possible (build success ⟹ no `sorry`/`admit`). Theorems use `rfl`/`decide`/`simp` on Nat.
4. **Anti-regression**: new file, no existing proof modified.

## CI

`lean-conway.yml` baseline=7 (`standalone-tactic` mode), unchanged by this PR (the 7 live in `Life/HashlifeCorrectness.lean`). I also verified the new file contains **zero occurrences of the word "sorry"** (even in comments) to avoid any prose-header counting ambiguity.

See #2162

Co-Authored-By: Claude <noreply@anthropic.com>