### PR TITLE
docs(smt): add SAT->SMT jump Mermaid to SMT index README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
@@ -10,6 +10,33 @@ Ce répertoire regroupe les séries consacrées aux **solveurs SMT** (*Satisfiab
 
 Un solveur **SAT** décide si une formule booléenne est satisfiable. Un solveur **SMT** étend SAT en raisonnant directement sur des *théories* : arithmétique linéaire sur les entiers et les réels, tableaux (`Array`), vecteurs de bits (`BitVec`), chaînes de caractères, fonctions non interprétées. Plutôt que d'encoder un Sudoku ou un planificateur de repas en variables booléennes à la main, on exprime les contraintes dans le langage naturel de la théorie concernée, et le solveur retourne un modèle (`sat`) ou prouve l'impossibilité (`unsat`).
 
+```mermaid
+flowchart LR
+    SAT["<b>SAT</b><br/>booléens seuls<br/>(encodage manuel)"]
+    SMT["<b>SMT</b><br/>booléens + théories"]
+    SAT -->|"+ théories"| SMT
+    TH1["arithmétique linéaire<br/>(int, real)"]
+    TH2["tableaux<br/>Array select/store"]
+    TH3["vecteurs de bits<br/>BitVec"]
+    TH4["chaînes<br/>+ regex"]
+    SMT --> TH1
+    SMT --> TH2
+    SMT --> TH3
+    SMT --> TH4
+    TH1 --> V{"check()"}
+    TH2 --> V
+    TH3 --> V
+    TH4 --> V
+    V -->|"sat"| M["modèle<br/>(solution)"]
+    V -->|"unsat"| U["impossibilité<br/>prouvée"]
+    classDef sat fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    classDef smt fill:#d1ecf1,stroke:#0c5460,stroke-width:2px;
+    class SAT sat;
+    class SMT smt;
+```
+
+Le saut **SAT → SMT** : plutôt que d'encoder un problème en variables booléennes à la main (coûteux, illisible), on l'exprime directement dans sa théorie naturelle — entiers, tableaux, bits, chaînes — et le solveur raisonne sur cette expressivité avant de rendre son verdict.
+
 **Z3** est le solveur SMT le plus utilisé en recherche comme en industrie (vérification de programmes, planification, synthèse, sécurité). Les deux séries ci-dessous l'exploitent via deux bindings différents.
 
 ## Les deux séries


### PR DESCRIPTION
## Summary

Rolling editorial finish (**Epic #4212**) — README index de la famille SMT (`MyIA.AI.Notebooks/SymbolicAI/SMT/README.md`, 66 lignes, **0 diagramme**). Ajoute **un** diagramme Mermaid natif GitHub. Markdown-only, pure addition.

See #4212 (contribution partielle à l'Epic de finition éditoriale rolling).

## Changement

**Un seul diagramme** — le saut **SAT → SMT** (section « Qu'est-ce que SMT ? ») : SAT (booléens seuls, encodage manuel) →(+théories)→ SMT (booléens + théories : arithmétique linéaire, `Array`, `BitVec`, chaînes + regex), puis `check()` fourche vers `sat` (modèle/solution) ou `unsat` (impossibilité prouvée). Visualise le concept fondamental qui justifie tout l'index : plutôt que d'encoder un problème en booléens à la main, l'exprimer dans sa théorie naturelle et laisser le solveur raisonner.

**Délibérément UN diagramme** (pas deux) : pour un index court de 66 lignes, un seul diagramme de concept authentique ancre l'introduction sans la surcharger. Respect de **Prong B** (sota-not-workaround : concept non-trivial, pas du décor) et élégance.

## Validation

- `grep -c '\`\`\`mermaid'` README : **0 → 1** ; total des fences pair (2 = 1 paire), aucun bloc orphelin.
- Pas de marqueur `CATALOG-STATUS` dans ce fichier (rien à préserver byte-identical).
- Diff = pure addition (+27, 0 délétions). Pas de modification de prose/liens/ancres existants.
- Scope : README seul. Le sous-module `SymbolicAI/SMT/Automata` (dirty) n'est **pas** staged (#2979, user-gated).
- Étiquettes Mermaid : quotées `["…"]`, `<b>`/`<br/>`, `classDef`/`class` coloration (SAT jaune / SMT bleu) ; rendu natif GitHub (SOTA, cf [sota-not-workaround.md](.claude/rules/sota-not-workaround.md)).

## Partition

Lane po-2025 (Z3/Argumentum/.NET/Probas). README index parent des séries Z3 (#4238) et Z3-Python (#4240) déjà livrées — ce diagramme ancre leur introduction commune. Disjoint de po-2024 (Sudoku root #4249 géré par po-2024) et po-2026 (Lean).