### PR TITLE
docs(cooperative-games): document veto/simple-voting-game theory in README

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
@@ -22,7 +22,52 @@ Formalisation en Lean 4 de la théorie des jeux coopératifs (valeur de Shapley,
 - **Unicité de la valeur de Shapley** : prouvé que la valeur de Shapley est l'unique valeur satisfaisant les axiomes d'efficacité, symétrie, joueur nul et additivité (Shapley.lean, 0 sorry)
 - **Définitions du Cœur** : jeu coopératif, fonction caractéristique, ensemble des joueurs, Cœur (Basic.lean)
 - **Direction `←` de Bondareva-Shapley** (balanced ⇒ Cœur non vide) : **entièrement prouvée** via la machinerie de séparation de cône du module `ConeKernel.lean` (`ProperCone.hyperplane_separation_point` de Mathlib)
-- **Indice de pouvoir de Banzhaf** : cadre défini (`Critical G i S`, `BanzhafRaw G i` — nombre de coalitions pour lesquelles `i` est critique) avec le théorème `dummy_banzhaf_raw_zero` : un joueur dummy (qui ne change jamais la valeur de coalition) a un indice de Banzhaf brut nul (Shapley.lean, 0 sorry, PR #4011)
+- **Indice de pouvoir de Banzhaf** : cadre défini (`Critical G i S`, `BanzhafRaw G i`, `BanzhafIndex G i`) avec la consolidation complète (non-négativité `banzhaf_index_nonneg`, borne supérieure `banzhaf_index_le_two`, caractérisation par zéro `banzhaf_index_eq_zero_iff`, positivité `banzhaf_index_pos_iff`, symétrie `banzhaf_raw_symmetric`), le tout à 0 sorry (Shapley.lean, PRs #4011/#4037/#4130)
+- **Théorie des jeux de vote simples** : taxonomie des joueurs (`VetoPlayer`, `Dictator`, `DummyPlayer`) et des familles de coalitions (`SimpleGame`, `MonotoneGame`, `ProperGame`, `StrongGame`, `SelfDualGame`) avec leurs théorèmes de pouvoir (voir ci-dessous), le tout à 0 sorry (Shapley.lean, depuis la fondation `SimpleGame` PR #4134)
+
+## Théorie des jeux de vote simples
+
+La série formalise la théorie classique des jeux de vote simples (jeux où chaque
+coalition est soit gagnante `v S = 1` soit perdante `v S = 0`), au-dessus des
+`WeightedVotingGame` (jeux à quota pondéré). Cette infrastructure porte les théorèmes
+d'indice de pouvoir pour les types de joueurs canoniques.
+
+### Prédicats de structure
+
+- **`SimpleGame G`** — jeu à valeur binaire (`v S ∈ {0, 1}`), prouvé pour tout
+  `WeightedVotingGame` (`weighted_voting_game_simple`). Lecteurs `eq_one_of_ne_zero` /
+  `eq_zero_of_ne_one`.
+- **`MonotoneGame G`** — agrandir une coalition n'en diminue pas la valeur
+  (`S ⊆ T → v S ≤ v T`), lecteur `le_of_subset`. Les coalitions gagnantes forment un
+  **up-set** (`winning_upward_closed`), les perdantes un **down-set**
+  (`losing_downward_closed`).
+- **`ProperGame G`** / **`StrongGame G`** — duaux sur le complément : un jeu *propre*
+  (`v S = 1 → v Sᶜ = 0`) interdit qu'une coalition et son complément gagnent toutes deux ;
+  un jeu *fort* (`v S = 0 → v Sᶜ = 1`) impose qu'au moins l'une des deux gagne.
+- **`SelfDualGame G`** — pont `ProperGame G ∧ StrongGame G` (jeu décisif) ; un jeu fort
+  est non-dégénéré : la grande coalition gagne (`strong_grand_wins`).
+- **`MinimalWinning G S`** — coalition gagnante irréductible (`v S = 1 ∧ ∀ T ⊂ S, v T = 0`) :
+  le noyau des coalitions clés dont le poids atteint juste le quota.
+
+### Taxonomie des joueurs
+
+- **`VetoPlayer G i`** — appartient à toute coalition gagnante (`∀ S, v S = 1 → i ∈ S`).
+  Un veto est critique dans **chaque** coalition gagnante (`veto_critical_of_winning`) ;
+  la réciproque tient (`veto_iff_critical_of_winning`), et toute coalition sans lui est
+  perdante (`veto_losing_without`).
+- **`Dictator G i`** — gagne seul et a le veto (`v {i} = 1 ∧ VetoPlayer G i`) ; un dictateur
+  est **unique** (`dictator_unique`), a un indice de Banzhaf strictement positif
+  (`dictator_banzhaf_pos`) et n'est pas un dummy (`dictator_not_dummy`).
+- **`DummyPlayer G i`** — ne change jamais la valeur d'une coalition ; son indice de
+  Banzhaf brut est nul (`dummy_banzhaf_raw_zero`).
+
+### Théorèmes d'indice de pouvoir
+
+- Un veto a un indice de Banzhaf brut **strictement positif** lorsque la grande coalition
+  gagne (`veto_banzhaf_raw_pos`, `hwin` essential sous non-dégénérescence).
+- Un veto n'est pas un dummy (`veto_not_dummy`) — pendant veto de `dictator_not_dummy`.
+- L'indice de Banzhaf normalisé hérite de la symétrie (`banzhaf_index_symmetric`) et de la
+  nullité des dummies (`banzhaf_index_dummy_zero`).
 
 ## Indice de pouvoir de Banzhaf
 
@@ -70,28 +115,27 @@ de Banzhaf bruts. Cette lignée power-index (`dummy_banzhaf_raw_zero` #4011 →
 ## Conclusion
 
 Ce projet formalise la théorie des jeux coopératifs en Lean 4 — la **valeur de Shapley**
-(close, 0 `sorry`) et le **Cœur** avec le **théorème de Bondareva-Shapley** (0 `sorry`,
-prouvé dans les deux directions). Il compile avec `lake build CooperativeGames` sur
-Mathlib4 (toolchain `v4.30.0-rc2`).
+(close, 0 `sorry`), le **Cœur** avec le **théorème de Bondareva-Shapley** (0 `sorry`,
+prouvé dans les deux directions), et la **théorie des jeux de vote simples** avec sa
+taxonomie des joueurs et les théorèmes d'indice de pouvoir associés (0 `sorry`). Il compile
+avec `lake build CooperativeGames` sur Mathlib4 (toolchain `v4.30.0-rc2`).
 
 ### Ce qui est prouvé
 
 - **Unicité de la valeur de Shapley** (`Shapley.lean`, 0 `sorry`) : la valeur de Shapley
   est l'allocation *unique* satisfaisant efficacité, symétrie, joueur nul et additivité —
   la caractérisation axiomatique de Shapley (1953).
-- **Indices de pouvoir et joueurs dummy** (`Shapley.lean`, 0 `sorry`) : en plus de la
-  caractérisation de la valeur de Shapley, le module formalise la notion de joueur nul/dummy
-  (`NullPlayer`, `DummyPlayer`) avec les deux théorèmes de nullité `dummy_shapley_zero`
-  (un joueur dummy reçoit une valeur de Shapley nulle) et `dummy_banzhaf_raw_zero`
-  (un joueur dummy a un indice de Banzhaf brut nul). Le cadre Banzhaf repose sur la
-  définition `Critical G i S` (le joueur `i` est critique pour la coalition `S` lorsque
-  `i ∈ S`, `G.v S = 1` mais `G.v (S.erase i) = 0`) et sur l'indice brut
-  `BanzhafRaw G i` qui compte les coalitions critiques via un filtre sur `Finset.univ`
-  (PR #4011). L'**indice de Banzhaf normalisé** `BanzhafIndex G i = BanzhafRaw G i / 2^(n-1)`
-  (probabilité que `i` soit pivot dans une coalition contenant `i` tirée uniformément) hérite
-  des deux propriétés clés : `banzhaf_index_symmetric` (joueurs interchangeables ⟹ indices
-  normalisés égaux, analogue de `shapley_symmetric`) et `banzhaf_index_dummy_zero` (joueur
-  dummy ⟹ indice normalisé nul).
+- **Indices de pouvoir de Banzhaf** (`Shapley.lean`, 0 `sorry`) : indice brut
+  `BanzhafRaw G i` (compte des coalitions critiques via `Critical G i S`) et indice normalisé
+  `BanzhafIndex G i = BanzhafRaw G i / 2^(n-1)` — consolidation complète prouvée :
+  non-négativité, borne supérieure `≤ 2`, caractérisation par zéro, positivité, symétrie,
+  nullité des dummies (PRs #4011/#4037/#4130). Détails ci-dessus
+  (section « Indice de pouvoir de Banzhaf »).
+- **Théorie des jeux de vote simples** (`Shapley.lean`, 0 `sorry`) : taxonomie des joueurs
+  (`VetoPlayer`, `Dictator`, `DummyPlayer`) et des familles de coalitions (`SimpleGame`,
+  `MonotoneGame`, `ProperGame`, `StrongGame`, `SelfDualGame`, `MinimalWinning`) avec leurs
+  théorèmes de pouvoir (dictateur unique, veto positif en Banzhaf, veto critique dans toute
+  coalition gagnante, etc.). Détails ci-dessus (section « Théorie des jeux de vote simples »).
 - **Cœur + théorème de Bondareva-Shapley** (`Basic.lean` + `ConeKernel.lean`) : jeu
   coopératif, fonction caractéristique, le Cœur et la condition de jeu équilibré (balanced),
   avec la direction `←` (balanced ⇒ Cœur non vide) **entièrement prouvée** par séparation de


### PR DESCRIPTION
## Document the simple-voting-game theory in the cooperative_games_lean README

**Wave-0 #3978** (Part of #3973 — READMEs feuilles Lean, owner po-2026). The
`cooperative_games_lean/README.md` was ~10 cycles stale: it documented the Shapley
uniqueness, Bondareva-Shapley Core theorem, and Banzhaf framework but omitted the entire
simple-voting-game theory added since (cycles 73-92).

### What changed (README.md only, +61/-17)

| Section | Change |
|---------|--------|
| **Resultats cles** | New bullet for « théorie des jeux de vote simples »; Banzhaf bullet updated to cite the full consolidation (`banzhaf_index_nonneg`/`le_two`/`eq_zero_iff`/`pos_iff`/`symmetric`) |
| **NEW: Théorie des jeux de vote simples** | Full section: structure predicates (`SimpleGame`, `MonotoneGame`, `ProperGame`/`StrongGame`/`SelfDualGame`, `MinimalWinning`), player taxonomy (`VetoPlayer`/`Dictator`/`DummyPlayer`), power-index theorems (`veto_critical_of_winning`, `dictator_unique`, `veto_banzhaf_raw_pos`, `veto_not_dummy`, ...) |
| **Conclusion > Ce qui est prouvé** | Replaces the stale "dummy + Banzhaf" bullet with a consolidated Banzhaf bullet + a veto/simple-game-theory bullet |

French-first per the `readme-french-first` rule (existing README is already FR; the additions match).

### Verification (G.1 / verify-before-claiming)

- **Proof state re-verified firsthand**: `grep -cE '^\s*sorry\s*$|:=\s*by\s*sorry'` (excluding `.lake/`) over every `.lean` file on `origin/main` = **0 across all 5 files** (Shapley/Basic/ConeKernel/CooperativeGames/lakefile). The README's "0 sorry" claim is accurate, not propagated from memory.
- **Every cited symbol exists**: all 32 theorem/def names cited (e.g. `veto_iff_critical_of_winning`, `strong_grand_wins`, `banzhaf_index_le_two`) verified present on `origin/main` `Shapley.lean`. **Not cited** (honest): `carrier`, `mem_carrier_iff_veto`, `veto_shapley_pos` — these are on **PENDING** PRs (#4248, #4257), not yet on `main`, so they are not described as proven.
- **PR refs honest**: cited PRs (#4011/#4037/#4130/#4134) are all **MERGED**. The 4 individual Banzhaf PRs (#4102/#4109/#4115/#4118) are CLOSED (folded into consolidation #4130), so the README cites #4130 rather than the closed children.

### Scope

Docs-only. No `.lean`, no catalogue, no `FORMAL_STATUS.md`, no `CATALOG-STATUS` marker touched (the file has none). `git diff --stat` = 1 file.

See #3973 See #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)