### PR TITLE
docs(casestudies): add 4-paradigm orchestration Mermaid to Diagnostic-Medical README

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/README.md
@@ -9,6 +9,20 @@ Ce projet implémente un système de diagnostic médical intelligent combinant q
 3. **Algorithmes Génétiques** : Optimisation évolutionnaire des paramètres diagnostiques
 4. **Solveur Z3** : Validation par contraintes des protocoles thérapeutiques
 
+Chacune de ces approches répond à une **facette distincte** du problème (classer, chercher, calibrer, vérifier) ; leur intégration en un pipeline cohérent — davantage que la maîtrise isolée de chacune — est précisément la thèse de ce cas d'étude :
+
+```mermaid
+flowchart LR
+    C1["Classer<br/>le patient"] -->|"règles cliniques"| R["Agent rationnel"]
+    C2["Chercher<br/>le diagnostic"] -->|"heuristique admissible"| A["Recherche A*"]
+    C3["Calibrer<br/>les paramètres"] -->|"espace vaste"| G["Algorithme génétique"]
+    C4["Vérifier<br/>le protocole"] -->|"garantie formelle"| Z["Solveur Z3"]
+    R --> DEC["Aide à la décision<br/>thérapeutique"]
+    A --> DEC
+    G --> DEC
+    Z --> DEC
+```
+
 ### Objectifs pédagogiques
 
 - Maîtriser les algorithmes de recherche (BFS, DFS, A*)


### PR DESCRIPTION
## Summary

Add a GitHub-native concept diagram to the `CaseStudies/Diagnostic-Medical/` README, anchoring the case study's central thesis visually.

The README lists four complementary algorithmic approaches (rules agent, A*, genetic algorithm, Z3) but never *shows* how they fit together. The new Mermaid diagram makes the orchestration explicit: each facet of a diagnostic problem (classify, search, calibrate, verify) maps to the specialized tool best suited to it, and the four compose into a coherent decision-support pipeline.

The pedagogy lives **on the edges** — each arrow carries the *reason* that tool fits that facet (règles cliniques, heuristique admissible, espace vaste, garantie formelle) — so the diagram anchors exactly what the Conclusion argues in prose (`aucun paradigme isolé ne suffit`), not decoration.

## Scope

- Single file, markdown-only, +14 / -0.
- Placement: Vue d'ensemble, right after the 4-approach list (introduces the architecture before the reader dives into objectives).
- 1 authentic diagram (Prong B elegance, not 2 forced) — the concept is genuinely non-trivial (multi-paradigm orchestration).

## Anti-regression / hygiene

- Pure additive, no existing content removed or relabeled.
- No `CATALOG-STATUS` marker on this leaf README (case studies are not a cataloged series) — nothing to keep byte-identical.
- No notebook touched, no code touched, no outputs touched.
- Mermaid labels quoted (`["..."]`), `<br/>` for line breaks, em-dash in prose — all GitHub-native rendering.

See #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)