### PR TITLE
docs(casestudies): add deterministic/probabilistic frontier Mermaid to Oncology-Planning README

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/README.md
@@ -4,6 +4,22 @@
 
 Ce devoir de contrôle continu combine **IA symbolique** et **programmation probabiliste** à travers un cas d'usage médical : l'aide à la décision en oncologie.
 
+Les deux familles d'IA ne s'opposent pas : elles se répartissent le long d'une **frontière** — ce qui *doit être respecté* (déterministe) et ce qui *doit être estimé* (probabiliste) — pour produire un **jumeau numérique** du patient capable de simuler des scénarios :
+
+```mermaid
+flowchart LR
+    subgraph DET["Déterministe — doit être respecté"]
+        O["Ontologie<br/>des chimiothérapies"] --> CSP["Planification<br/>CSP des cures"]
+    end
+    subgraph PROB["Probabiliste — doit être estimé"]
+        T["Toxicité cumulée<br/>(variable latente)"] --> PYRO["Inférence Pyro<br/>profil patient"]
+    end
+    CSP -->|"calendrier valide"| JN["Jumeau numérique<br/>du patient"]
+    PYRO -->|"incertitude"| JN
+    Q{"« Et si ? »<br/>dose / report"} --> JN
+    JN --> DEC["Décision médicale<br/>éclairée par scénarios"]
+```
+
 ### Structure du dossier
 
 ```


### PR DESCRIPTION
## Summary

Add a GitHub-native concept diagram to the `CaseStudies/Oncology-Planning/` README, anchoring the case study's central thesis visually.

The README states the thesis (combine IA symbolique + programmation probabiliste for oncology decision-support) but never *shows* how the two families relate. The new Mermaid diagram makes the architecture explicit: symbolic AI (ontology of chemotherapies → CSP cure scheduling) and probabilistic programming (Pyro inferring the latent toxicity profile) are drawn as **two sides of a frontier** — *deterministic (what must be respected)* vs *probabilistic (what must be estimated)* — converging into a **digital twin** of the patient that answers "what-if" scenarios (maintain dose, reduce, postpone).

## Why this is authentic (Prong B), not decoration

- The **subgraph labels** ("doit être respecté" / "doit être estimé") echo verbatim the Conclusion's framing (line 143: *le déterministe (ce qui doit être respecté) et le probabiliste (ce qui doit être estimé)*).
- Every node label is **grounded in the README vocabulary**: Ontologie des chimiothérapies, Planification CSP des cures, Toxicité cumulée (variable latente), Inférence Pyro, Jumeau numérique, « Et si ? » — no invented terms.
- Concept is **distinct from Diagnostic-Medical #4267**: this is a 2-family *chain* (deterministic + probabilistic → digital twin), not the 4-paradigm-in-parallel orchestration. Anti-duplication across sibling PRs.

## Scope

- Single file, markdown-only, +16 / -0.
- Placement: Vue d'ensemble, right after the thesis sentence (introduces the architecture before the student dives into Pyro specifics).
- 1 authentic diagram (Prong B elegance — the concept is genuinely non-trivial: where to draw the deterministic/probabilistic frontier).

## Anti-regression / hygiene

- Pure additive, no existing content removed or relabeled.
- No `CATALOG-STATUS` marker on this leaf README (case studies are not a cataloged series).
- No notebook touched, no code touched, no outputs touched.
- Mermaid labels quoted (`["..."]`), `<br/>` for line breaks, diamond decision node `{...}`, guillemets « » safe in UTF-8 — all GitHub-native rendering.

See #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)