### PR TITLE
docs(gt): fix 8 stale GameTheory-16b/c/e notebook refs (dead-link repair)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
@@ -103,7 +103,7 @@ Note: `_GoalExtract.lean` (former prover test file) has been removed from the re
 
 **Build**: `lake build` — SUCCESS | **Reference only, not for proving**
 
-**Content**: Imports Peters' library (Gibbard-Satterthwaite, Duggan-Schwartz, 4 Condorcet impossibilities, 15+ voting rules with axiom verification). Serves as the backend for notebook `GameTheory-16e-SocialChoiceLean-Tour.ipynb`.
+**Content**: Imports Peters' library (Gibbard-Satterthwaite, Duggan-Schwartz, 4 Condorcet impossibilities, 15+ voting rules with axiom verification). Backend Lake for the (planned, not yet created) SocialChoiceLean tour companion notebook.
 
 **Relationship to `social_choice_lean`**: Complementary, not duplicate. `social_choice_lean` uses custom `PrefOrder` framework (our proofs). `social_choice_lean_peters` uses Peters' `LinearOrder` framework (external reference). Both kept for pedagogical completeness.
 

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
@@ -33,7 +33,7 @@ Résultats formalisés par Peters :
 
 **Intégration dans notre projet** (3 phases) :
 1. **Phase 1** (ce dépôt) : Citations et références croisées
-2. **Phase 2** : Notebook dédié (`GameTheory-16e-SocialChoiceLean-Tour.ipynb`) + projet Lake séparé (`social_choice_lean_peters/`)
+2. **Phase 2** : Projet Lake séparé ([`social_choice_lean_peters/`](../social_choice_lean_peters/)) ; notebook compagnon de tour prévu (pas encore créé)
 3. **Phase 3** : Portage sélectif dans notre framework `PrefOrder` (impossibilités Condorcet, règles de scoring)
 
 **Différences de framework** :
@@ -196,11 +196,11 @@ lake test
 
 ## Intégration avec la série GameTheory
 
-Ces formalisations Lean sont les bases théoriques pour les notebooks :
+Ces formalisations Lean sont les bases théoriques pour les notebooks de la sous-série `SocialChoice/` :
 
-- **GameTheory-16b-Lean-SocialChoice** : Applications pratiques
-- **GameTheory-16c-SocialChoice-Python** : Simulations numériques
-- **GameTheory-16e-SocialChoiceLean-Tour** : Tour des résultats de DominikPeters/SocialChoiceLean
+- [`02-Lean-SocialChoice-Formal.ipynb`](../SocialChoice/02-Lean-SocialChoice-Formal.ipynb) : applications pratiques des formalisations (kernel Lean 4)
+- [`03-Voting-Methods.ipynb`](../SocialChoice/03-Voting-Methods.ipynb) : simulations numériques des méthodes de vote (Python)
+- Le tour des résultats de DominikPeters/SocialChoiceLean — backend [`social_choice_lean_peters/`](../social_choice_lean_peters/) (notebook compagnon prévu, pas encore créé)
 
 ## Liens utiles
 

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.en.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.en.md
@@ -30,7 +30,7 @@ Complementary, not duplicate. `social_choice_lean` uses custom `PrefOrder` (our 
 
 ## Notes
 
-- Backend for notebook `GameTheory-16e-SocialChoiceLean-Tour.ipynb`
+- Backend Lake for a (planned, not yet created) tour companion notebook
 - Peters' repo pinned at commit `d679d950` for reproducibility
 - Peters uses `LinearOrder` (strict, Mathlib); we use `PrefOrder` (reflexive, total, transitif)
 
@@ -64,8 +64,8 @@ the framework choice shapes the definitions and proofs.
 
 ### Where to go next
 
-- **Notebook**: `GameTheory-16e-SocialChoiceLean-Tour.ipynb` — the teaching
-  companion this project backs.
+- **Companion notebook**: planned (not yet created) — a teaching tour of Peters'
+  results, which this project would back.
 - **Upstream**: [DominikPeters/SocialChoiceLean](https://github.com/DominikPeters/SocialChoiceLean) (MIT).
 - **Our proofs**: [`social_choice_lean/`](../social_choice_lean/) — Arrow / Sen /
   median voter in the `PrefOrder` framework.

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.md
@@ -32,7 +32,7 @@ Complémentaire, sans doublon. `social_choice_lean` utilise un `PrefOrder` perso
 
 ## Notes
 
-- Backend du notebook `GameTheory-16e-SocialChoiceLean-Tour.ipynb`
+- Backend Lake pour un notebook compagnon de tour (prévu, pas encore créé)
 - Le dépôt de Peters est pinné au commit `d679d950` pour la reproductibilité
 - Peters utilise `LinearOrder` (strict, Mathlib) ; nous utilisons `PrefOrder` (réflexif, total, transitif)
 
@@ -68,8 +68,8 @@ preuves.
 
 ### Où aller ensuite
 
-- **Notebook** : `GameTheory-16e-SocialChoiceLean-Tour.ipynb` — le compagnon
-  pédagogique auquel ce projet sert de backend.
+- **Notebook compagnon** : prévu (pas encore créé) — un tour pédagogique des résultats
+  de Peters, auquel ce projet servirait de backend.
 - **Amont** : [`DominikPeters/SocialChoiceLean`](https://github.com/DominikPeters/SocialChoiceLean) (MIT).
 - **Nos preuves** : [`social_choice_lean/`](../social_choice_lean/) — Arrow / Sen /
   électeur médian dans le cadre `PrefOrder`.


### PR DESCRIPTION
## Summary

The SocialChoice docs referenced notebooks `GameTheory-16b/c/e-*` at the GameTheory root that **do not exist** (confirmed firsthand: only `GameTheory-16-MechanismDesign.ipynb` exists at the root; the real SocialChoice notebooks live in the `SocialChoice/` sub-series).

## G.1 verification (firsthand)

- `GameTheory-16b/c/e-*` at root: **do not exist** (only `GameTheory-16-MechanismDesign.ipynb` does).
- Real SocialChoice notebooks (verified kernels): `SocialChoice/02-Lean-SocialChoice-Formal.ipynb` (lean4-wsl), `SocialChoice/03-Voting-Methods.ipynb` (python3).
- `social_choice_lean_peters/` backend lake: **exists**; the companion *tour notebook*: **never created**.

## Fixes (4 files, 8 refs)

| Stale ref | Honest fix |
|---|---|
| `16b-Lean-SocialChoice` | real link → `SocialChoice/02-Lean-SocialChoice-Formal.ipynb` (Lean4, verified) |
| `16c-SocialChoice-Python` | real link → `SocialChoice/03-Voting-Methods.ipynb` (python3, verified) |
| `16e-SocialChoiceLean-Tour` (×5 sites) | rephrased \"planned, not yet created\" — no fabricated dead link |

Files: `LEAN_INVENTORY.md`, `social_choice_lean/README.md`, `social_choice_lean_peters/README.md` (+`README.en.md` parity).

## Note on the finding's framing

This was flagged by po-2024's cross-partition dead-link scan (cycle 54) as \"renamed to SC-01..04 during reorg.\" G.1 firsthand showed that framing was itself inaccurate — there is no `SC-01..04` rename either; the real notebooks are `SocialChoice/01-04`. This PR corrects against what actually exists, not against po-2024's hypothesis.

Doc drift only — no code/proof touched, no catalog churn, no `CATALOG-STATUS` markers in any touched file. Markdown-only (C.2 exception — no re-exec needed). Single subject (8 refs, one dead-link cluster), atomic (G.4 single-subject; the 4 files are all the same stale-ref cluster).

Co-Authored-By: Claude <noreply@anthropic.com>