### PR TITLE
lean(cooperative): add banzhaf_index_le_one (Penrose-Banzhaf index ≤ 1)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -1866,3 +1866,61 @@ theorem banzhaf_index_le_two (G : TUGame N) (i : N) : BanzhafIndex G i ≤ 2 := 
       ≤ ((Finset.univ : Finset (Finset N)).card : ℝ) := by exact_mod_cast banzhaf_raw_le_univ G i
     _ = (2 ^ Fintype.card N : ℝ) := by rw [hcard]; norm_cast
     _ = 2 * (2 : ℝ) ^ (Fintype.card N - 1) := by rw [h2]
+
+/-- The normalized Banzhaf index is at most 1: the raw count `BanzhafRaw` only registers
+    coalitions where `i` is critical, and a critical player must be a member
+    (`critical_implies_mem`), so the critical-coalition filter is contained in the filter of
+    coalitions *containing* `i`. There are exactly `2 ^ (card N - 1)` such coalitions (insert/erase
+    bijection with the subsets of `N \ {i}`: each of the other `card N - 1` players is in or out,
+    and `i` is forced in). Normalizing `BanzhafRaw ≤ 2 ^ (card N - 1)` by `2 ^ (card N - 1)` leaves
+    a quotient at most 1 — the Penrose-Banzhaf index is a probability-like quantity in `[0, 1]`.
+    This tightens `banzhaf_index_le_two` (which used the cruder `banzhaf_raw_le_univ ≤ 2 ^ card N`
+    bound) and pairs with `banzhaf_index_nonneg` to pin the index in `[0, 1]`. The player `i : N`
+    forces `0 < card N`, so the Nat-subtraction `card N - 1` does not underflow. -/
+theorem banzhaf_index_le_one (G : TUGame N) (i : N) : BanzhafIndex G i ≤ 1 := by
+  have hn : 0 < Fintype.card N := Fintype.card_pos_iff.mpr ⟨i⟩
+  have hdenom : 0 < (2 : ℝ) ^ (Fintype.card N - 1) := pow_pos (by norm_num) _
+  -- a critical coalition must contain i, so the critical filter ⊆ the membership filter
+  have hsubset :
+      (Finset.univ.filter fun S => Critical G i S) ⊆
+        (Finset.univ : Finset (Finset N)).filter (fun S => i ∈ S) :=
+    fun S hS =>
+      Finset.mem_filter.mpr
+        ⟨Finset.mem_univ _, critical_implies_mem G i S (Finset.mem_filter.mp hS).2⟩
+  -- coalitions containing i ↔ subsets of (univ.erase i) via insert/erase (a bijection)
+  have hmemcard :
+      ((Finset.univ : Finset (Finset N)).filter (fun S => i ∈ S)).card =
+        2 ^ (Fintype.card N - 1) := by
+    have heq :
+        (Finset.univ : Finset (Finset N)).filter (fun S => i ∈ S) =
+          ((Finset.univ : Finset N).erase i).powerset.image (insert i) := by
+      ext S
+      constructor
+      · intro h
+        obtain ⟨-, hmem⟩ := Finset.mem_filter.mp h
+        refine Finset.mem_image.mpr ⟨S.erase i, ?_, ?_⟩
+        · exact Finset.mem_powerset.mpr (Finset.erase_subset_erase i (Finset.subset_univ S))
+        · rw [Finset.insert_erase hmem]
+      · intro h
+        obtain ⟨T, hT, hST⟩ := Finset.mem_image.mp h
+        refine Finset.mem_filter.mpr ⟨Finset.mem_univ _, ?_⟩
+        rw [← hST]; exact Finset.mem_insert_self i T
+    rw [heq]
+    have hinj :
+        Set.InjOn (insert i)
+          (((Finset.univ : Finset N).erase i).powerset : Set (Finset N)) := by
+      intros T₁ hT₁ T₂ hT₂ heq
+      have hsub₁ : T₁ ⊆ (Finset.univ : Finset N).erase i :=
+        Finset.mem_powerset.mp (Finset.mem_coe.mp hT₁)
+      have hsub₂ : T₂ ⊆ (Finset.univ : Finset N).erase i :=
+        Finset.mem_powerset.mp (Finset.mem_coe.mp hT₂)
+      have hi₁ : i ∉ T₁ := fun h => by simpa using hsub₁ h
+      have hi₂ : i ∉ T₂ := fun h => by simpa using hsub₂ h
+      have hstrip : (insert i T₁).erase i = (insert i T₂).erase i := by rw [heq]
+      rwa [Finset.erase_insert hi₁, Finset.erase_insert hi₂] at hstrip
+    have herase : ((Finset.univ : Finset N).erase i).card = Fintype.card N - 1 := by
+      rw [Finset.card_erase_of_mem (Finset.mem_univ (i : N)), Finset.card_univ]
+    rw [Finset.card_image_of_injOn hinj, Finset.card_powerset, herase]
+  rw [BanzhafIndex, div_le_iff₀ hdenom, one_mul]
+  unfold BanzhafRaw
+  exact_mod_cast (Finset.card_le_card hsubset).trans hmemcard.le


### PR DESCRIPTION
## `banzhaf_index_le_one` — tight upper bound `BanzhafIndex ≤ 1`

The **probability-like bound** on the normalized (absolute Penrose-Banzhaf) power
index. `banzhaf_index_le_two` (#4109-then-#4130, merged) gave the crude `≤ 2`
bound via `banzhaf_raw_le_univ ≤ 2^(card N)`; this tightens it to the true
`≤ 1` by exploiting that **a critical coalition must contain the player**.

### Added (proven, 0 sorry)

| Symbol | Statement | Role |
|--------|-----------|------|
| `banzhaf_index_le_one` | `BanzhafIndex G i ≤ 1` | tight upper bound; pins index in `[0,1]` with `banzhaf_index_nonneg` |

### Proof

A critical coalition `S` satisfies `i ∈ S` (`critical_implies_mem`, first conjunct
of `Critical`), so the critical-coalition filter is **contained** in the filter of
coalitions *containing* `i`. There are exactly `2 ^ (card N - 1)` such coalitions:

- **insert/erase bijection** between `{ S : i ∈ S }` and the powerset of
  `univ.erase i` (`T ↦ insert i T`): membership-of-`i` ↔ `T ⊆ N \ {i}`, with
  `insert_erase` / `erase_insert` (requires `i ∉ T`, which holds since
  `T ⊆ univ.erase i`).
- `card_image_of_injOn` (with `Set.InjOn`) collapses the image cardinal to
  `#(powerset (univ.erase i)) = 2 ^ #(univ.erase i) = 2 ^ (card N - 1)` via
  `card_powerset` + `card_erase_of_mem`.

Hence `BanzhafRaw ≤ 2 ^ (card N - 1)`; normalizing by `2 ^ (card N - 1)` (positive)
gives `BanzhafIndex ≤ 1`. The player `i : N` forces `0 < card N`, so the Nat-
subtraction `card N - 1` does not underflow.

### Proof integrity (lean-merge-discipline §1 / §B)

```
✔ [8434/8435] Built CooperativeGames (15s)
Build completed successfully (8435 jobs).
=== LAKE_EXIT=0 ===
```

- `lake build CooperativeGames` → **SUCCESS firsthand** (LAKE_EXIT=0, native lake.exe)
- live tactic-sorry on `Shapley.lean`: **origin/main 0 → HEAD 0** (no proof stubbed → no regression)
- diff scope: **1 file** (`Shapley.lean` +58), pure insertion after `banzhaf_index_le_two`. **0 catalogue file touched**.
- branch: fresh from `origin/main` `94feb78e6` (0 behind / 1 ahead) — stale-base detected & re-freshed before commit (catalog-pr-hygiene rule 2).
- self-contained: only `Critical` / `critical_implies_mem` / `BanzhafRaw` / `BanzhafIndex` on main (no stacking on unmerged work).

See #4071 See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
