### PR TITLE
docs(semanticweb): add W3C standards layered-stack Mermaid to SemanticWeb README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -17,7 +17,22 @@ Le Web Sémantique est la promesse d'un Web où les machines comprennent la sign
 
 Le Web Sémantique a traversé des cycles de hype et de désillusion. En 2001, Tim Berners-Lee en faisait la couverture de *Scientific American*. En 2010, les données liées semblaient une niche académique. En 2024, GraphRAG (Microsoft) a montré que les graphes de connaissances RDF pouvaient ancrer les LLMs sur des faits vérifiables : le Web Sémantique devenait un garde-fou pour l'IA générative.
 
-Cette série couvre le spectre complet parce que les briques s'articulent : RDF définit les données, SPARQL les interroge, RDFS/OWL structurent le raisonnement, SHACL valide la qualité, JSON-LD ponte vers le Web, RDF-Star ajoute la provenance, et les KG+LLMs ferment la boucle. Chaque standard est une couche qui s'appuie sur les précédentes.
+Cette série couvre le spectre complet parce que les briques s'articulent : RDF définit les données, SPARQL les interroge, RDFS/OWL structurent le raisonnement, SHACL valide la qualité, JSON-LD ponte vers le Web, RDF-Star ajoute la provenance, et les KG+LLMs ferment la boucle. Chaque standard est une couche qui s'appuie sur les précédentes :
+
+```mermaid
+flowchart BT
+    RDF["<b>RDF</b><br/>définir les données"]
+    RDF --> SPARQL["<b>SPARQL</b><br/>interroger"]
+    RDF --> RDFS["<b>RDFS / OWL</b><br/>raisonner"]
+    RDF --> SHACL["<b>SHACL</b><br/>valider"]
+    RDF --> JSONLD["<b>JSON-LD</b><br/>pont vers le Web"]
+    RDF --> RDFSTAR["<b>RDF-Star</b><br/>provenance"]
+    RDFS --> KG["<b>Graphe de connaissances</b>"]
+    SHACL --> KG
+    JSONLD --> KG
+    RDFSTAR --> KG
+    KG --> GRAG["<b>GraphRAG</b><br/>ancrer les LLMs"]
+```
 
 La série propose délibérément deux stacks : **.NET C#** (SW-1 à SW-7) pour les fondations avec dotNetRDF (typed, performant, intégré à l'écosystème CoursIA), et **Python** (SW-8 à SW-13) pour les standards modernes et l'IA. Les sidetracks Python (SW-2b, 4b, 5b, 7b) offrent un miroir des notebooks C# en Python.
 


### PR DESCRIPTION
## Summary

Add a GitHub-native concept diagram to the `SymbolicAI/SemanticWeb/` README, anchoring its central thesis visually.

The README argues that the W3C Semantic Web standards are not independent tools but a **layered stack** where each builds on the previous (`chaque standard est une couche qui s'appuie sur les précédentes`), but never *shows* the stack. The new Mermaid diagram (bottom-up flowchart) visualizes exactly that articulation: RDF (define data) is the foundation; SPARQL, RDFS/OWL, SHACL, JSON-LD, RDF-Star each add a distinct capability (query, reason, validate, bridge to Web, provenance) and converge into the Knowledge Graph, which GraphRAG then anchors to LLMs.

## Why this is authentic (Prong B), not decoration

- Every node label carries the standard's **exact role** from the README prose (line 20: *RDF définit les données, SPARQL les interroge, RDFS/OWL structurent le raisonnement, SHACL valide la qualité, JSON-LD ponte vers le Web, RDF-Star ajoute la provenance*).
- The **bottom-up orientation** (BT) makes the \« layered stack » claim literal — RDF at the base, GraphRAG at the top.
- Concept is genuinely **non-trivial**: a 7-standard W3C architecture with convergence semantics (multiple standards feed the KG, GraphRAG closes the loop with LLMs). Not a trivial 2-box diagram.

## Scope

- Single file, markdown-only, +16 / -1 (the -1 is the thesis sentence changing terminal `.` → `:` to introduce the diagram).
- Placement: right after the articulation thesis (line 20), before the two-stacks description — the diagram illustrates the claim exactly where it is made.
- 1 authentic diagram (Prong B elegance).

## Anti-regression / hygiene

- Pure additive (the only line change is the introducing colon).
- `CATALOG-STATUS` marker **byte-identical** (verified: 0 marker line in the diff — edit is ~30 lines below the marker).
- No notebook touched, no code touched, no outputs touched.
- Mermaid labels quoted (`["..."]`), `<b>`/`<br/>` for formatting, slash in `RDFS / OWL` safe — all GitHub-native rendering.
- Partition: `SymbolicAI/SemanticWeb` = po-2025 per #3975 (SymbolicAI non-Lean). G.1 verified ai-01 has not attributed this family to any other worker.

See #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)