### PR TITLE
ci(lean): add lean-finiteness.yml regression CI for finiteness_lean (baseline 0)

### DIFF
--- a/.github/workflows/lean-finiteness.yml
+++ b/.github/workflows/lean-finiteness.yml
@@ -1,0 +1,42 @@
+name: Lean CI (finiteness_lean)
+
+# CI for finiteness_lean (MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean) —
+# Brzozowski symbolic derivatives and the finiteness theorem (1964), the
+# theoretical basis for non-backtracking regex termination (.NET
+# RegexOptions.NonBacktracking). Autonome project (no Mathlib dependency).
+# Issue #3111 (merged, 0 sorry); this is the Lean angle of #2978.
+#
+# sorry-filter-mode=standalone-tactic, baseline=0: the module is entirely
+# sorry-free (verified firsthand 2026-06-25, `lake build Finiteness` SUCCESS
+# 4 jobs, 0 standalone-tactic sorry). standalone-tactic counts only standalone
+# `sorry` tokens (never prose false-positives). See lean-build.yml.
+#
+# Gap in coverage: finiteness_lean was the only COMPLETE 0-sorry Lean lake
+# without a regression workflow (cooperative_games_lean / stable_marriage_lean
+# are covered by lean-game-theory.yml; this one had no CI at all).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean
+      display-name: finiteness_lean
+      sorry-baseline: "0"
+      sorry-filter-mode: standalone-tactic


### PR DESCRIPTION
## What

Add a dedicated regression CI workflow (`lean-finiteness.yml`) for `finiteness_lean` — Brzozowski symbolic derivatives and the finiteness theorem (the Lean angle of #2978, merged 0-sorry in #3111).

## Why (gap in coverage)

`finiteness_lean` was the **only COMPLETE 0-sorry Lean lake without any regression CI**:
- `cooperative_games_lean` / `stable_marriage_lean` → covered by `lean-game-theory.yml`
- every other 0-sorry lake has its own `lean-*.yml`
- `finiteness_lean` had **no CI at all** (the only mention of "finiteness" in `.github/workflows/` was a comment in `lean-sudoku.yml`)

This closes the coverage gap so any future sorry-sneak-in or build break in `finiteness_lean` is caught by CI.

## How

Modeled exactly on [`lean-sudoku.yml`](https://github.com/jsboige/CoursIA/blob/main/.github/workflows/lean-sudoku.yml) (identical profile): reusable `lean-build.yml`, `sorry-filter-mode: standalone-tactic`, `sorry-baseline: "0"`.

## Verification (lean-merge-discipline §1, firsthand 2026-06-25)

| Check | Result |
|-------|--------|
| `lake build Finiteness` | **SUCCESS** (4 jobs, `Build completed successfully`) |
| standalone-tactic sorry (exact CI grep) | **0** |
| Toolchain | `v4.30.0-rc2` |
| Mathlib | **none** (autonome project — fast build, no cache needed) |
| YAML + param parity vs `lean-sudoku.yml` | keys match, same reusable workflow ✓ |

The `info: true`/`false` lines in the build log are intentional `#eval` outputs in `Finiteness/Basic.lean`, not errors.

## Scope

CI-only change (one new workflow file, 42 lines). No `.lean` change. The CI it adds claims baseline-0 build success, so the verification above backs that claim (G.1).

See #2978 — partial (adds CI coverage; the #2978 lean deliverable itself was merged in #3111).
