### PR TITLE
docs(cooperative-games): aerate veto-theory + 2 Mermaid concept diagrams (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
@@ -49,6 +49,25 @@ d'indice de pouvoir pour les types de joueurs canoniques.
 - **`MinimalWinning G S`** — coalition gagnante irréductible (`v S = 1 ∧ ∀ T ⊂ S, v T = 0`) :
   le noyau des coalitions clés dont le poids atteint juste le quota.
 
+*Du jeu pondéré au jeu décisif — comment ces prédicats s'empilent :*
+
+```mermaid
+flowchart TD
+    WVG["WeightedVotingGame G<br/><i>jeu à quota pondéré</i>"]
+    SG["SimpleGame G<br/>v(S) ∈ {0, 1}"]
+    MG["MonotoneGame G<br/>S ⊆ T ⟹ v(S) ≤ v(T)"]
+    PG["ProperGame G<br/>v(S)=1 ⟹ v(Sᶜ)=0"]
+    StG["StrongGame G<br/>v(S)=0 ⟹ v(Sᶜ)=1"]
+    SDG["SelfDualGame G<br/>Proper ∧ Strong — jeu décisif"]
+
+    WVG -->|"weighted_voting_game_simple"| SG
+    SG --> MG
+    WVG -->|"2·quota &gt; Σ poids"| PG
+    WVG -->|"2·quota ≤ Σ poids"| StG
+    PG --> SDG
+    StG --> SDG
+```
+
 ### Taxonomie des joueurs
 
 - **`VetoPlayer G i`** — appartient à toute coalition gagnante (`∀ S, v S = 1 → i ∈ S`).
@@ -60,6 +79,26 @@ d'indice de pouvoir pour les types de joueurs canoniques.
   (`dictator_banzhaf_pos`) et n'est pas un dummy (`dictator_not_dummy`).
 - **`DummyPlayer G i`** — ne change jamais la valeur d'une coalition ; son indice de
   Banzhaf brut est nul (`dummy_banzhaf_raw_zero`).
+
+*Qui implique qui, et ce que chaque type de joueur dit de son indice de Banzhaf
+(flèches pleines = implication positive, pointillées = exclusion) :*
+
+```mermaid
+flowchart LR
+    Dict["Dictator G i<br/>v({i})=1 ∧ VetoPlayer"]
+    Veto["VetoPlayer G i<br/>∈ toute coalition gagnante"]
+    Dummy["DummyPlayer G i<br/>ne change jamais v(S)"]
+    BI0["BanzhafIndex &gt; 0"]
+    BRpos["BanzhafRaw &gt; 0"]
+    BR0["BanzhafRaw = 0"]
+
+    Dict -->|"implique"| Veto
+    Dict -.->|"dictator_not_dummy"| Dummy
+    Veto -.->|"veto_not_dummy"| Dummy
+    Dict -->|"dictator_banzhaf_pos"| BI0
+    Veto -->|"veto_banzhaf_raw_pos<br/>(grand coalition gagne)"| BRpos
+    Dummy -->|"dummy_banzhaf_raw_zero"| BR0
+```
 
 ### Théorèmes d'indice de pouvoir
 


### PR DESCRIPTION
## Finition éditoriale — `cooperative_games_lean/README.md` : aérer la théorie des jeux de vote + 2 diagrammes Mermaid

See #4212 (#4208) — **finition éditoriale, family-partitioned**, livraison partielle
pour la famille `cooperative_games_lean` (ma lane, README resynced #4264).

### Livré (pur ajout, 0 suppression)

La section « Théorie des jeux de vote simples » (issue de #4264) était un mur de
texte dense. Deux **diagrammes de concept Mermaid versionnables** + leads italiques
d'orientation (aération) :

| Diagramme | Cartographie |
|-----------|--------------|
| **Hiérarchie des prédicats** | `WeightedVotingGame → SimpleGame → MonotoneGame` + duaux `ProperGame`/`StrongGame → SelfDualGame` (jeu décisif), avec les théorèmes-ponts étiquetant les arêtes (`weighted_voting_game_simple`, quota `2·quota > Σ poids` vs `≤`) |
| **Taxonomie des joueurs → indice de pouvoir** | `Dictator → Veto` (implication), exclusions pointillées (`dictator_not_dummy`, `veto_not_dummy`), arêtes vers les théorèmes d'indice (`dictator_banzhaf_pos`, `veto_banzhaf_raw_pos`, `dummy_banzhaf_raw_zero`) |

### Acceptance #4212 (1 famille)

- [x] **Prose aérée** — intertitres / leads italiques / respirations avant chaque diagramme
- [x] **≥1 diagramme** — 2 diagrammes Mermaid de concept (versionnables)
- [ ] Visuel GenAI — **délibérément omis** : po-2023 est « en tête sur les visuels » (#4212),
  je me concentre sur la dimension Mermaid + prose pour éviter la collision cross-lane

### Preuve d'intégrité (G.1 firsthand)

- **Aucun fichier Lean touché** — docs-only, zéro impact preuve
- **15 symboles des diagrammes vérifiés présents sur `origin/main`** `Shapley.lean`
  (WeightedVotingGame/SimpleGame/MonotoneGame/ProperGame/StrongGame/SelfDualGame/
  VetoPlayer/Dictator/DummyPlayer + weighted_voting_game_simple/dictator_banzhaf_pos/
  veto_banzhaf_raw_pos/dictator_not_dummy/veto_not_dummy/dummy_banzhaf_raw_zero)
- **Anti-régression** : pur `+39 insertions`, zéro suppression — toute la prose #4264 préservée
- **FR-first** maintenu (règle readme-french-first)
- Branche fraîche depuis `origin/main` (0 behind / 1 ahead)

See #4208 #4212 #4264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
