### PR TITLE
fix(genai): 00-1 smoke-test markdown doc-consistency dall-e-3 -> gpt-image-1

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-1-Environment-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-1-Environment-Setup.ipynb
@@ -447,15 +447,18 @@
     "Apres avoir verifie la configuration statique, nous allons tester la capacite reelle de l'API a generer du contenu.\n",
     "\n",
     "**Principe du test** :\n",
-    "- Envoyer une requete de generation d'image simple a l'API OpenRouter\n",
+    "- Envoyer une requete de generation d'image simple a l'API OpenAI (Direct)\n",
     "- Verifier que la requete aboutit (status HTTP 200)\n",
-    "- Recuperer l'URL de l'image generee si successful\n",
+    "- Recuperer l'image generee, encodee en base64 (`b64_json`)\n",
     "\n",
-    "**Attention** : Ce test consomme des credits API (~$0.04 pour DALL-E 3). Pour des tests repetitifs sans cout, vous pouvez desactiver le test avec `test_generation=False` dans les parametres Papermill.\n",
+    "> **Pourquoi OpenAI Direct et non OpenRouter ?** OpenRouter est un routeur de *chat-completion* : il n'expose pas d'endpoint `/images/generations` (un appel image renvoie 404). La generation d'images se valide donc via l'API OpenAI directe avec **gpt-image-1** (le modele image actuel d'OpenAI ; dall-e-3 est retire). Contrairement a dall-e-3, gpt-image-1 retourne l'image encodee en **base64** (`b64_json`), pas une URL.\n",
     "\n",
-    "**Modele utilise** : `openai/dall-e-3` via OpenRouter  \n",
+    "**Attention** : Ce test consomme des credits API (~$0.01 pour gpt-image-1 en qualite low). Pour des tests repetitifs sans cout, vous pouvez desactiver le test avec `test_generation=False` dans les parametres Papermill.\n",
+    "\n",
+    "**Modele utilise** : `gpt-image-1` via OpenAI Direct  \n",
     "**Prompt** : \"A simple test image: colorful abstract shapes\"  \n",
-    "**Resolution** : 1024x1024 pixels\n"
+    "**Resolution** : 1024x1024 pixels  \n",
+    "**Qualite** : low (cout minimal pour un smoke test de validation)\n"
    ]
   },
   {
@@ -615,12 +618,14 @@
     "\n",
     "| Aspect | Details |\n",
     "|--------|---------|\n",
-    "| API testee | OpenRouter (openai/dall-e-3) |\n",
+    "| API testee | OpenAI Direct (gpt-image-1) |\n",
     "| Prompt | \"A simple test image: colorful abstract shapes\" |\n",
     "| Resolution | 1024x1024 pixels |\n",
-    "| Cout estime | ~$0.04 par generation |\n",
+    "| Qualite | low (cout minimal) |\n",
+    "| Format retour | base64 (b64_json) |\n",
+    "| Cout estime | ~$0.01 par generation |\n",
     "\n",
-    "> **Note technique** : Ce test consomme des credits API. Pour des tests repetitifs sans cout, desactivez le test avec `test_generation=False` dans les parametres Papermill.\n"
+    "> **Note technique** : Ce test consomme des credits API. Pour des tests repetitifs sans cout, desactivez le test avec `test_generation=False` dans les parametres Papermill. Si seule l'API OpenRouter est configuree, la generation d'images est signalee comme non testee (OpenRouter = chat-completion uniquement).\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Doc-consistency completion for `00-1-Environment-Setup.ipynb`, part of the GenAI Axe-2 `dall-e-3 -> gpt-image-1` migration (#3801).

`cell8` and `cell10` (markdown) still described the **pre-migration** smoke test — *"API OpenRouter"*, *"`openai/dall-e-3` via OpenRouter"*, *"Recuperer l'URL de l'image"*, *"~$0.04 pour DALL-E 3"* — but `cell9` (migrated in #4260) now routes image generation via **OpenAI Direct** with **`gpt-image-1`** (quality `low`, size 1024x1024, returns **`b64_json`** base64, not a URL). The markdown was stale on three counts (provider, model, return format + cost).

Thorough accurate rewrite grounded in a firsthand read of `cell9` (G.1):

- **Test principle**: OpenAI Direct, HTTP 200, base64 (`b64_json`) instead of URL.
- **Added pedagogical note** "Pourquoi OpenAI Direct et non OpenRouter ?" — explains OpenRouter is chat-completion only (no `/images/generations` endpoint → 404), `dall-e-3` retired, `gpt-image-1` returns base64. Helps students understand the routing.
- **Cost**: ~$0.01 for `gpt-image-1` quality `low` (was ~$0.04 DALL-E 3).
- **Model block**: `gpt-image-1` via OpenAI Direct (+ `Qualite: low` line).
- **Result table**: "OpenAI Direct (gpt-image-1)" + added `Qualite` and `Format retour` rows; cost ~$0.01.

## Validation (H / C rules)

- **Markdown-only edit** (`cell8`, `cell10`, both `execution_count: null`) -> **C.2 exception**: no re-execution required; `#4260`'s committed code-cell outputs remain valid and coherent.
- **No code cell touched** — `cell9` (the smoke test) is byte-identical; verified via diff hunk audit (only the two markdown regions changed).
- **0 `raise NotImplementedError` / `assert False` / `1/0`** in the file (C.1 — unchanged, none introduced).
- **Diff**: `1 file changed, 13 insertions(+), 8 deletions(-)` — surgical, no metadata/format churn (trailing newline matches `origin/main`).
- No secrets, no machine-path leaks introduced (markdown prose only).

## Out of scope (not touched)

- `cell9` explanatory comments already correctly reference the migration (`dall-e-3 retire`, `gpt-image-1`, `b64_json`) — left as-is.
- `00-3` intro markdown handled separately in #4265.

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
