### PR TITLE
docs(search): sync root README index tables with actual notebook content

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -11,7 +11,7 @@ maturity: PRODUCTION=51, BETA=9
 
 Tout problème d'IA, du plus simple jeu de plateau à la planification logistique industrielle, se réduit à un même défi : explorer un espace de solutions possibles pour trouver la meilleure. Cette série vous apprend à maîtriser cette exploration, depuis les algorithmes classiques (BFS, A*, Minimax) jusqu'aux techniques avancées (CSP, métaheuristiques, hybridation LLM). Le fil rouge est la **réduction de l'espace de recherche** : comment passer d'une exploration aveugle exponentielle à une résolution intelligemment guidée.
 
-Le parcours couvre quatre grands piliers. Les **fondements** formalisent les espaces d'états et couvrent les algorithmes de recherche non informée, informée, locale, génétique, adversariale et MCTS. La **programmation par contraintes** (CSP) introduit un changement de paradigme : au lieu d'explorer, on réduit les domaines par propagation. Les **applications** (20 notebooks) illustrent chaque concept sur des problèmes réels adaptés de projets étudiants. Enfin, les **métaheuristiques et l'hybridation** relient la recherche à l'optimisation continue et aux LLMs.
+Le parcours couvre quatre grands piliers. Les **fondements** formalisent les espaces d'états et couvrent les algorithmes de recherche non informée, informée, locale, génétique, adversariale et MCTS. La **programmation par contraintes** (CSP) introduit un changement de paradigme : au lieu d'explorer, on réduit les domaines par propagation. Les **applications** (21 notebooks) illustrent chaque concept sur des problèmes réels adaptés de projets étudiants. Enfin, les **métaheuristiques et l'hybridation** relient la recherche à l'optimisation continue et aux LLMs.
 
 **À qui s'adresse cette série** : étudiants en informatique (L3-M2), ingénieurs logiciel confrontés à des problèmes d'optimisation, et candidats à des entretiens techniques. Les notebooks Python ne nécessitent que Python 3.10+ avec `ortools` et `deap`. Les side tracks C# (edge detection, portefeuille, et la [Partie 4 — métaheuristiques composables](Part4-Metaheuristics/README.md) au-dessus de GeneticSharp) requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en algorithmique avancée : les concepts sont introduits depuis les espaces d'états.
 
@@ -60,7 +60,7 @@ La Phase 2 change de paradigme : au lieu d'explorer un espace, on le réduit. CS
 
 ### Phase 3 : Applications et frontières (Applications + notebooks avancés, ~18h)
 
-Les 20 notebooks d'applications illustrent chaque concept sur des cas réels : planification d'infirmiers (CSP-4), ordonnancement d'atelier (CSP-4), optimisation de portefeuille (métaheuristiques), TSP et VRP (routing), démineur et Wordle (CSP + théorie de l'information), Picross (couverture exacte). Les notebooks avancés de la Part 1 (programmation linéaire Search-9, automates symboliques Search-10, métaheuristiques Search-11) et de la Part 2 (contraintes souples CSP-7, temporelles CSP-8, distribuées CSP-9) complètent le panorama. L'ensemble est enrichi par des ponts vers les autres séries : Sudoku (DLX, automates), SymbolicAI (Z3, planification), GameTheory (Minimax, MCTS), et RL (MCTS + DQN).
+Les 21 notebooks d'applications illustrent chaque concept sur des cas réels : planification d'infirmiers (CSP-4), ordonnancement d'atelier (CSP-4), optimisation de portefeuille (métaheuristiques), TSP et VRP (routing), démineur et Wordle (CSP + théorie de l'information), Picross (couverture exacte). Les notebooks avancés de la Part 1 (programmation linéaire Search-9, automates symboliques Search-10, métaheuristiques Search-11) et de la Part 2 (contraintes souples CSP-7, temporelles CSP-8, distribuées CSP-9) complètent le panorama. L'ensemble est enrichi par des ponts vers les autres séries : Sudoku (DLX, automates), SymbolicAI (Z3, planification), GameTheory (Minimax, MCTS), et RL (MCTS + DQN).
 
 ```mermaid
 flowchart LR
@@ -123,6 +123,10 @@ Side track C# .NET 9 (cf. [Search-5](Part1-Foundations/Search-5-GeneticAlgorithm
 | 8 | MGS-8 LandscapeExplorer | Visualiser la surface de fitness (heatmaps, trajectoire de convergence) |
 | 9 | MGS-9 EverestRelief | Relief terrestre réel comme paysage de fitness (DEM, flipbook) |
 | 10 | MGS-10 CenterBias | Biais central vs robustesse au déplacement (banc Kudella 2022) |
+| 11 | MGS-11 IslandSynergy | Synergie d'îles complémentaires (verdict mesuré) |
+| 12 | MGS-12 AxisAlignment | Biais d'alignement d'axes (rotation) |
+| 13 | MGS-13 LandscapeDebias | Pourquoi la rotation casse la séparabilité (visuel) |
+| 14 | MGS-14 IslandSynergyFound | Une synergie d'îles *trouvée* (et un cas négatif) |
 
 ### Applications
 
@@ -146,6 +150,7 @@ Side track C# .NET 9 (cf. [Search-5](Part1-Foundations/Search-5-GeneticAlgorithm
 | App-16 | Crossword | Mots croisés : backtracking, OR-Tools, génération |
 | App-17 | VRP-Logistics | Vehicle Routing : SA, GA, ACO, CP-SAT |
 | App-18 | HyperparameterTuning | Optimisation bayésienne de hyperparams : Optuna vs GA vs PSO |
+| App-19 | ProceduralGeneration-WFC | Génération procédurale : Wave Function Collapse via CP-SAT |
 
 ---
 
@@ -219,6 +224,7 @@ Problèmes du monde réel adaptés de projets étudiants.
 | 9 | [App-11-Picross](Applications/CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : speedup 27Mx CP-SAT vs naïve | Projet étudiant |
 | 10 | [App-15-SportsScheduling](Applications/CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, équité, déplacements | Projet étudiant |
 | 11 | [App-16-Crossword-CSP](Applications/CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croisés : backtracking, OR-Tools, génération | Projet étudiant |
+| 12 | [App-19-ProceduralGeneration-WFC](Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb) | ~45 min | Génération procédurale : Wave Function Collapse via CP-SAT | Projet étudiant |
 
 ### Applications Hybrides / Métaheuristiques (`Applications/Hybrid/`)
 


### PR DESCRIPTION
## Summary

Le `Search/README.md` racine avait pris du retard : ses tables d'apport pédagogique (MGS + Applications) et les comptes de prose ne reflétaient plus le contenu des notebooks réellement présents sur `main`, alors que la structure-section interne (ligne 420) et le bloc CATALOG-STATUS étaient déjà à jour. Dérive interne (root lagged behind its own structure section + the authoritative sub-READMEs).

## Dérives corrigées (toutes vérifiées firsthand contre le ground truth du worktree)

| # | Dérive | Avant | Après | Ground truth |
|---|--------|-------|-------|--------------|
| 1 | Table MGS "Partie 4" | lignes MGS-1..10 | MGS-1..14 | `Part4-Metaheuristics/` contient 14 notebooks MGS-1..14 (Glob confirmé) |
| 2 | Table Applications (résumé) | App-1..18 | App-1..19 | `App-19-ProceduralGeneration-WFC.ipynb` existe |
| 3 | Table Applications CSP (détaillée) | 11 lignes | 12 lignes (+App-19) | App-19 vit dans `Applications/CSP/` |
| 4 | Prose compte "20 notebooks" (x2) | 20 | 21 | CATALOG-STATUS = `Applications=21` ; count files CSP=12+Hybrid=7+Search=2=21 |

## Apports MGS-11..14 (depuis Part4-README authoritative)

- **MGS-11 IslandSynergy** — Synergie d'îles complémentaires (verdict mesuré)
- **MGS-12 AxisAlignment** — Biais d'alignement d'axes (rotation)
- **MGS-13 LandscapeDebias** — Pourquoi la rotation casse la séparabilité (visuel)
- **MGS-14 IslandSynergyFound** — Une synergie d'îles *trouvée* (et un cas négatif)

## Why this is needed

Les notebooks MGS-11..14 (#4076/#4081/#4097/#4110) et App-19 ont atterri sur main, mais seul le roster texte de la structure-section + le catalogue ont été mis à jour à l'époque — les tables d'apport par-notebook ont été oubliées. Un lecteur du README racine voyait "14 notebooks MGS" annoncé dans la prose/structure mais seulement 10 dans la table = incohérence pédagogique.

## Validation

- **Markdown-only** — exception C.2 (pas de re-exec, outputs précédents valides).
- **CATALOG-STATUS byte-identique** (déjà correct, non touché) — règle catalog-pr-hygiene respectée.
- **Liens vérifiés non-morts** : `Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb` confirmé existant (firsthand Glob) avant d'ajouter le lien.
- **Base fraîche** : worktree depuis `origin/main`, 1 sujet atomique.
- Diff : 1 fichier, +8/-2.

See #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
