### PR TITLE
feat(ml): 2.5-Biais-Variance-CV-ROC (bias/variance, k-fold CV, ROC/AUC) — See #4174

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -1,0 +1,1133 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a50c0001",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019877,
+     "end_time": "2026-06-25T11:44:22.141434+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:22.121557+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 2.5 — Biais, variance, validation croisée et courbe ROC\n",
+    "\n",
+    "**Navigation** : [<< 2.4-Arbres-Forets-Ensembles](2.4-Arbres-Forets-Ensembles.ipynb) | [2.6-Clustering-KMeans-PCA >>](2.6-Clustering-KMeans-PCA.ipynb) | [Index](../README.md)\n",
+    "\n",
+    "**Kernel** : Python 3\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Les notebooks précédents (2.1 et 2.4) ont rendu le **surapprentissage** visible : un arbre profond affiche une accuracy d'entraînement proche de 1.0 tandis que son score de test s'effondre, et les méthodes d'ensemble (2.4) réduisent cet écart. Ce phénomène n'est pas un bug : c'est la manifestation concrète d'un compromis fondamental, le **compromis biais-variance**. Nous le formalisons ici, puis nous outillons pour le maîtriser : la **validation croisée** donne une estimation fiable de la performance (au lieu d'un seul découpage aléatoire source de bruit), et la **courbe ROC** avec l'**AUC** évaluent un classifieur au-delà de la seule accuracy, en exposant la structure des erreurs (faux positifs vs faux négatifs).\n",
+    "\n",
+    "### Objectifs d'apprentissage\n",
+    "\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "1. Décomposer l'erreur de généralisation en **biais** et **variance** et reconnaître chaque régime (sous- et sur-apprentissage).\n",
+    "2. Utiliser la **validation croisée k-fold** pour obtenir une estimation fiable des performances, plutôt qu'un seul découpage entraînement/test.\n",
+    "3. Lire une **courbe ROC** et interpréter l'**AUC** comme métrique indépendante du seuil de décision.\n",
+    "4. Choisir un **seuil de décision** adapté au coût relatif des faux positifs et des faux négatifs.\n",
+    "\n",
+    "### Prérequis\n",
+    "\n",
+    "- Notebook 2.1 (surapprentissage rendu visible, train/test split, métriques).\n",
+    "- Notebook 2.3 (régression logistique, sigmoïde).\n",
+    "- Notebook 2.4 (arbres, forêts aléatoires, réduction de variance par ensembles).\n",
+    "\n",
+    "> **Référence.** Geman, S., Bienenstock, É. & Doursat, R. (1992), *Neural Networks and the Bias/Variance Dilemma*, Neural Computation 4(1):1-58. La décomposition biais-variance formalise l'arbitrage fondamental : un modèle trop simple a un biais élevé (sous-apprentissage), un modèle trop complexe a une variance élevée (surapprentissage)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a50c0002",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:22.182879Z",
+     "iopub.status.busy": "2026-06-25T11:44:22.181874Z",
+     "iopub.status.idle": "2026-06-25T11:44:25.634277Z",
+     "shell.execute_reply": "2026-06-25T11:44:25.627499Z"
+    },
+    "papermill": {
+     "duration": 3.479595,
+     "end_time": "2026-06-25T11:44:25.640281+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:22.160686+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Configuration OK : 2.5 - Biais, variance, validation croisee et ROC\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et imports pour le notebook 2.5\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from sklearn.datasets import load_breast_cancer\n",
+    "from sklearn.model_selection import train_test_split, cross_val_score, cross_validate\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.metrics import accuracy_score, roc_curve, roc_auc_score, confusion_matrix\n",
+    "\n",
+    "np.random.seed(42)\n",
+    "print(\"Configuration OK : 2.5 - Biais, variance, validation croisee et ROC\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0003",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007193,
+     "end_time": "2026-06-25T11:44:25.677505+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:25.670312+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le compromis biais-variance\n",
+    "\n",
+    "L'erreur de généralisation d'un modèle se décompose en trois termes :\n",
+    "\n",
+    "$$\\text{Erreur} = \\underbrace{\\text{Biais}^2}_{\\text{erreur systématique}} + \\underbrace{\\text{Variance}}_{\\text{sensibilité à l'échantillon}} + \\underbrace{\\text{bruit irréductible}}_{\\text{non modélisable}}$$\n",
+    "\n",
+    "- Le **biais** mesure l'erreur systématique d'un modèle trop rigide : une régression linéaire appliquée à des données non-linéaires **sous-apprend** (*underfitting*). Ses prédictions sont cohérentes d'un échantillon à l'autre, mais systématiquement à côté.\n",
+    "- La **variance** mesure la sensibilité du modèle à l'échantillon d'entraînement : un arbre très profond **mémorise** les données (*overfitting*). Changez quelques lignes du jeu d'entraînement et sa frontière de décision change du tout au tout.\n",
+    "\n",
+    "On ne peut pas minimiser les deux simultanément avec une seule complexité de modèle : c'est le **dilemme** de Geman et al. (1992). Image mentale : une **règle rigide** (biais élevé, variance faible) face à une **nouille flexible** (biais faible, variance élevée). La bonne complexité se trouve entre les deux — et la validation croisée (section 3) sert justement à la repérer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a50c0004",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:25.695929Z",
+     "iopub.status.busy": "2026-06-25T11:44:25.694886Z",
+     "iopub.status.idle": "2026-06-25T11:44:25.722530Z",
+     "shell.execute_reply": "2026-06-25T11:44:25.721867Z"
+    },
+    "papermill": {
+     "duration": 0.03924,
+     "end_time": "2026-06-25T11:44:25.723651+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:25.684411+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dimensions X : (569, 30) | nombre de variables : 30\n",
+      "Entraînement : 398 lignes | Test : 171 lignes\n",
+      "Classes (0 = malin, 1 = benin) dans y : [212 357]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Chargement du jeu de donnees breast_cancer (classification binaire)\n",
+    "cancer = load_breast_cancer()\n",
+    "X = cancer.data\n",
+    "y = cancer.target\n",
+    "\n",
+    "# Decoupage entraînement/test stratifie (meme proportion de classes dans chaque sous-ensemble)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.3, random_state=42, stratify=y\n",
+    ")\n",
+    "\n",
+    "print(f\"Dimensions X : {X.shape} | nombre de variables : {X.shape[1]}\")\n",
+    "print(f\"Entraînement : {X_train.shape[0]} lignes | Test : {X_test.shape[0]} lignes\")\n",
+    "print(f\"Classes (0 = malin, 1 = benin) dans y : {np.bincount(y)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0005",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004024,
+     "end_time": "2026-06-25T11:44:25.731675+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:25.727651+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Comparer plusieurs modèles (biais vs variance en pratique)\n",
+    "\n",
+    "Comparons trois modèles de complexité croissante sur le **même** découpage entraînement/test :\n",
+    "\n",
+    "- **Régression logistique** : frontière linéaire → biais potentiellement élevé, variance faible.\n",
+    "- **Forêt aléatoire** : moyenne de nombreux arbres → variance réduite (cf. notebook 2.4).\n",
+    "- **Arbre de décision profond** : un seul arbre non limité → variance élevée, mémorisation de l'entraînement.\n",
+    "\n",
+    "Attention : la comparaison ci-dessous repose sur un **unique découpage**. Or la performance mesurée sur un seul ensemble de test est **bruitée** — elle dépend de quelles lignes sont tombées dans le test. La section 3 (validation croisée) corrigera ce défaut."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a50c0006",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:25.744766Z",
+     "iopub.status.busy": "2026-06-25T11:44:25.744766Z",
+     "iopub.status.idle": "2026-06-25T11:44:26.847649Z",
+     "shell.execute_reply": "2026-06-25T11:44:26.846517Z"
+    },
+    "papermill": {
+     "duration": 1.110889,
+     "end_time": "2026-06-25T11:44:26.848656+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:25.737767+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele                 |   train |    test |   ecart\n",
+      "-------------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regression logistique  |   0.967 |   0.942 |   0.026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Foret aleatoire        |   1.000 |   0.936 |   0.064\n",
+      "Arbre profond          |   1.000 |   0.918 |   0.082\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ajustement de 3 modeles et comparaison train vs test\n",
+    "# L'ecart (train - test) revele la variance : un modele qui memorise a train proche de 1.0\n",
+    "# mais un test nettement plus bas.\n",
+    "modeles = [\n",
+    "    (\"Regression logistique\", LogisticRegression(max_iter=1000)),\n",
+    "    (\"Foret aleatoire\", RandomForestClassifier(n_estimators=100, random_state=42)),\n",
+    "    (\"Arbre profond\", DecisionTreeClassifier(random_state=42)),\n",
+    "]\n",
+    "\n",
+    "print(f\"{'Modele':22s} | {'train':>7s} | {'test':>7s} | {'ecart':>7s}\")\n",
+    "print(\"-\" * 55)\n",
+    "for nom, modele in modeles:\n",
+    "    modele.fit(X_train, y_train)\n",
+    "    acc_train = accuracy_score(y_train, modele.predict(X_train))\n",
+    "    acc_test = accuracy_score(y_test, modele.predict(X_test))\n",
+    "    print(f\"{nom:22s} | {acc_train:7.3f} | {acc_test:7.3f} | {acc_train - acc_test:7.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0007",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005006,
+     "end_time": "2026-06-25T11:44:26.858656+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:26.853650+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : identifier le modèle à plus forte variance\n",
+    "\n",
+    "À partir du tableau affiché ci-dessus (ou en recalculant), repérez quel modèle présente le **plus grand écart** entre accuracy d'entraînement et accuracy de test. Ce gap `train - test` est l'indice le plus direct d'une variance élevée : le modèle ajuste trop finement l'échantillon d'entraînement pour bien généraliser.\n",
+    "\n",
+    "Indices :\n",
+    "- # Etape 1 : pour chaque `(nom, modele)` dans `modeles`, recalculer `acc_train` et `acc_test` (comme dans la cellule précédente).\n",
+    "- # Etape 2 : former la liste `ecarts` des différences `acc_train - acc_test`.\n",
+    "- # Etape 3 : récupérer l'indice du maximum avec `np.argmax(ecarts)`, puis `modeles[indice_max][0]` pour le nom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a50c0008",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:26.869630Z",
+     "iopub.status.busy": "2026-06-25T11:44:26.868593Z",
+     "iopub.status.idle": "2026-06-25T11:44:26.875055Z",
+     "shell.execute_reply": "2026-06-25T11:44:26.873638Z"
+    },
+    "papermill": {
+     "duration": 0.011421,
+     "end_time": "2026-06-25T11:44:26.875055+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:26.863634+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : modele a plus forte variance = None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : trouver le modele avec le plus grand ecart train-test (variance la plus elevee)\n",
+    "# TODO etudiant : pour chaque modele dans modeles, calculer l'ecart (train_acc - test_acc)\n",
+    "ecarts = None  # TODO etudiant : remplacer (liste des ecarts train-test pour chaque modele)\n",
+    "# TODO etudiant : indice du modele avec le plus grand ecart\n",
+    "indice_max = None  # TODO etudiant : remplacer (np.argmax(ecarts))\n",
+    "nom_max_variance = None  # TODO etudiant : remplacer (modeles[indice_max][0])\n",
+    "print(f\"Exercice 1 a completer : modele a plus forte variance = {nom_max_variance}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0009",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00503,
+     "end_time": "2026-06-25T11:44:26.886017+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:26.880987+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Validation croisée k-fold\n",
+    "\n",
+    "Un seul découpage entraînement/test donne une estimation **bruitée** de la performance : deux `random_state` différents produisent des scores différents. La **validation croisée k-fold** réduit cette incertitude en découpant les données en *k* plis de taille égale, puis en entraînant sur *k-1* plis et en testant sur le pli restant, en faisant tourner les rôles. On obtient ainsi *k* scores, dont la **moyenne ± l'écart-type** est une estimation bien plus fiable.\n",
+    "\n",
+    "Notez bien la nuance : la validation croisée traite la variance de l'**évaluation** (l'incertitude sur le score mesuré), qui est distincte de la variance du **modèle** (section 1). Les deux se combinent, mais on les combat différemment.\n",
+    "\n",
+    "> **Référence.** Stone, M. (1974), *Cross-Validatory Choice and Assessment of Statistical Predictions*, Journal of the Royal Statistical Society. Series B (Methodological) 36(2):111-147. La validation croisée y est posée comme la méthode de référence pour estimer l'erreur de généralisation sans sacrifier de données à un unique ensemble de test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a50c000a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:26.897806Z",
+     "iopub.status.busy": "2026-06-25T11:44:26.896797Z",
+     "iopub.status.idle": "2026-06-25T11:44:28.569887Z",
+     "shell.execute_reply": "2026-06-25T11:44:28.568741Z"
+    },
+    "papermill": {
+     "duration": 1.680078,
+     "end_time": "2026-06-25T11:44:28.570887+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:26.890809+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scores par fold : [0.939 0.939 0.974 0.947 0.965]\n",
+      "Moyenne : 0.953\n",
+      "Ecart-type : 0.014\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Validation croisee 5-fold de la regression logistique sur l'ensemble des donnees\n",
+    "scores_cv = cross_val_score(LogisticRegression(max_iter=1000), X, y, cv=5)\n",
+    "\n",
+    "print(\"Scores par fold :\", np.round(scores_cv, 3))\n",
+    "print(f\"Moyenne : {scores_cv.mean():.3f}\")\n",
+    "print(f\"Ecart-type : {scores_cv.std():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c000b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004904,
+     "end_time": "2026-06-25T11:44:28.580926+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:28.576022+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Comparer les modèles par validation croisée\n",
+    "\n",
+    "Évaluons maintenant les **trois** modèles par validation croisée 5-fold sur l'ensemble des données, et comparons les scores moyens (avec l'écart-type comme barre d'incertitude). C'est la démarche **principielle** pour choisir un modèle : non pas un seul découpage arbitraire, mais une estimation accompagnée de son incertitude."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a50c000c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:28.594225Z",
+     "iopub.status.busy": "2026-06-25T11:44:28.593116Z",
+     "iopub.status.idle": "2026-06-25T11:44:31.559657Z",
+     "shell.execute_reply": "2026-06-25T11:44:31.559041Z"
+    },
+    "papermill": {
+     "duration": 2.973963,
+     "end_time": "2026-06-25T11:44:31.561178+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:28.587215+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele                 |   moyenne | ecart-type\n",
+      "--------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regression logistique  |     0.953 |      0.014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Foret aleatoire        |     0.956 |      0.023\n",
+      "Arbre profond          |     0.917 |      0.024\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Comparaison des 3 modeles par validation croisee\n",
+    "print(f\"{'Modele':22s} | {'moyenne':>9s} | {'ecart-type':>10s}\")\n",
+    "print(\"-\" * 50)\n",
+    "for nom, modele in modeles:\n",
+    "    sc = cross_val_score(modele, X, y, cv=5)\n",
+    "    print(f\"{nom:22s} | {sc.mean():9.3f} | {sc.std():10.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c000d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006002,
+     "end_time": "2026-06-25T11:44:31.574297+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:31.568295+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : le nombre de folds\n",
+    "\n",
+    "Le choix de *k* n'est pas anodin. Recalculez le score de validation croisée de la régression logistique avec **`cv=10`** au lieu de 5 et comparez la moyenne à celle de `scores_cv` (cv=5, cellule précédente). Un *k* plus grand utilise davantage de données pour l'entraînement (plis de test plus petits) : la moyenne a tendance à être légèrement optimiste, mais le coût de calcul augmente.\n",
+    "\n",
+    "Indices :\n",
+    "- # Etape 1 : appeler `cross_val_score(LogisticRegression(max_iter=1000), X, y, cv=10)`.\n",
+    "- # Etape 2 : stocker le résultat dans `scores_cv10` puis `moyenne_cv10 = np.mean(scores_cv10)`.\n",
+    "- # Etape 3 : comparer à `scores_cv.mean()` (cv=5)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a50c000e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:31.592419Z",
+     "iopub.status.busy": "2026-06-25T11:44:31.591325Z",
+     "iopub.status.idle": "2026-06-25T11:44:31.597782Z",
+     "shell.execute_reply": "2026-06-25T11:44:31.596769Z"
+    },
+    "papermill": {
+     "duration": 0.017455,
+     "end_time": "2026-06-25T11:44:31.598880+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:31.581425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : moyenne cv=10 = None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : recalculer le score CV de la regression logistique avec cv=10\n",
+    "# TODO etudiant : cross_val_score avec cv=10 sur la regression logistique (X, y)\n",
+    "scores_cv10 = None  # TODO etudiant : remplacer\n",
+    "# TODO etudiant : comparer la moyenne a celle de scores_cv (cv=5)\n",
+    "moyenne_cv10 = None  # TODO etudiant : remplacer (np.mean(scores_cv10))\n",
+    "print(f\"Exercice 2 a completer : moyenne cv=10 = {moyenne_cv10}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c000f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006309,
+     "end_time": "2026-06-25T11:44:31.612194+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:31.605885+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Au-delà de l'accuracy : faux positifs et faux négatifs\n",
+    "\n",
+    "L'accuracy globale masque le **type** d'erreurs commises. Or dans un diagnostic de cancer du sein, un **faux négatif** (manquer une tumeur maligne) est bien plus coûteux qu'un faux positif (faire passer un examen complémentaire à un patient sain). Nous avons besoin de la **matrice de confusion** et de la **courbe ROC** pour voir la structure des erreurs, pas seulement leur nombre agrégé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a50c0010",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:31.628190Z",
+     "iopub.status.busy": "2026-06-25T11:44:31.628190Z",
+     "iopub.status.idle": "2026-06-25T11:44:32.274603Z",
+     "shell.execute_reply": "2026-06-25T11:44:32.273968Z"
+    },
+    "papermill": {
+     "duration": 0.65754,
+     "end_time": "2026-06-25T11:44:32.276729+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:31.619189+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAHqCAYAAADyPMGQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgJpJREFUeJzt3QW4VNX3N/BFd3dJioR0l4B0itIlIN2ClCAtISAgSogIiNKdgoAg0pLSnUpKd533+a7f/8w7d+7cy8xler6f5xm402f2nJmzZu+1145kGIYhRERERPRakV9/EyIiIiJi4ERERETkBPY4ERERETmIgRMRERGRgxg4ERERETmIgRMRERGRgxg4ERERETmIgRMRERGRgxg4ERERETmIgRPR/xk0aJBEihRJbt68yTbxALQ12jyYZMiQQZo3b+7tzQg4ZcqU0ZMvmjlzpu7r58+f9/amkIswcCKvOHPmjLRt21YyZcokMWPGlPjx40uJEiXkm2++kcePHwf0u2J+kZqnqFGjSpo0afSA+s8//9i9D1ZG+vnnn+W9996ThAkTSuzYsSVXrlwyZMgQefjwYZjPtXTpUqlSpYokTZpUokePLqlTp5Z69erJ77//7vKAwHw9kSNH1m3E9rVp00Z27dolwWT79u0aEN65c8fbm0JEbhDVHQ9KFJ7Vq1dL3bp1JUaMGPLxxx/Lu+++K8+ePZOtW7dKz5495ciRIzJ16tSAb0QEPRkzZpQnT57Izp07NaBCGxw+fFiDSdPLly+lUaNGsmDBAilVqpQelBE4/fnnnzJ48GBZuHChbNiwQVKkSBEi0Prkk0/0MfPlyyfdu3eXlClTypUrVzSYKleunGzbtk2KFy/usteTN29e+eyzz/Tv+/fvy7Fjx3TbfvjhB+nWrZuMHTs2xO0RICNoDMTACe8LAmEEkNZOnDihgSUFj6ZNm0qDBg30+44CBBb5JfKUs2fPGnHjxjWyZctm/Pvvv6GuP3XqlDF+/HiPviEPHjzQ/wcOHIgFr40bN2649flmzJihz/PXX3+FuLx37956+fz580NcPnz4cL28R48eoR5rxYoVRuTIkY3KlSuHuHz06NF6n08//dR49epVqPvNmjXL2LVrl8teU/r06Y1q1aqFuvzRo0dGrVq1dFsmTZpkBAOz7c+dO+ftTfE72FexzzirdOnSeiLyBAZO5FHt2rXTg8q2bdscuv3z58+NIUOGGJkyZTKiR4+uB+jPP//cePLkSYjb4TER+NjC7Zs1axYqaNm8ebPRvn17I1myZEbChAlDBE7Hjh0z6tata8SLF89InDix0aVLF+Px48ehHvvnn3828ufPb8SMGdNIlCiRUb9+fePixYsRDpxWrVqllyNQMuEggsfOmjWrtoU9LVq00Pvt2LHDch9sN4LTFy9eGJ4QVuAE9+/f1+1JkyZNiCDO9j07f/68vid4rWhT3KdOnTp2A5CDBw8a7733nt4Ojzt06FBj+vTpoQIWc7v+/PNPo1ChQkaMGDGMjBkzGj/99FOoxzxz5ow+H9o7VqxYRpEiRfQ9sTVhwgQjR44cehvsOwUKFDBmz54dYh+yPZnbZLs/wu3btzXAxXXYx/F6mjZt6lAAj30Qr8vcllKlShnr1q2zXL9s2TKjatWqRqpUqfSx8TnC58l2v0DQkTNnTuPIkSNGmTJl9PFSp05tfPXVV6GeE58FvM63335b2zNlypTGhx9+aJw+fdpym5cvXxrjxo3TdsJtkidPbrRp08a4detWiMcy35+1a9dqO+K2uF94vv/+e30deO/x2rds2RIqcDI/Y7b7zqZNm/Ry/B+ee/fuGV27drW8J/ieKF++vLF3794Qt9u5c6dRqVIlI378+Npm2Ce3bt0a4jb2tsWZ/ZJ8D/uMyaNWrlypeU2ODhG1atVKBgwYIPnz55dx48ZJ6dKlZcSIEdr1/SY6dOggR48e1cfu06dPiOuQA4ThMzxP1apVZcKECZqrY23YsGE6zPj222/rENSnn34qGzdu1BykiOa2mMmjiRIlslyGobvbt2/rUF1Yw1rYDli1apXlPrdu3dL7RIkSRbwtbty48uGHH2r+Fto8LH/99ZcOc+G9RZu3a9dO2xRJv48ePbLcDo9TtmxZHdL9/PPPdRhw9uzZmh9nz+nTp6VOnTpSoUIF+frrr7V9MYyG+5uuXbum++S6det038D7i32gZs2aOrRpwrBjly5dJEeOHDJ+/HgdksMQpZnH9dFHH0nDhg31b+yvyEvDKVmyZHa37cGDBzr8+u2330rFihX1NeB1Hz9+XC5fvhxuu+K5MQwULVo0HfbF+XTp0oXIX8NQLdofQ7V47AIFCtjd5wH7WeXKlSVPnjzaTtmyZZPevXvLr7/+GmLYuHr16vpceCzcrmvXrnL37l0dYjYhfxHD7mbeYosWLfQ9qlSpkjx//jzU8CXaDO8Pbov2DMuPP/6oj41h51GjRunj4z26dOmSuBLeg8mTJ0vt2rVl0qRJ0qNHD4kVK5YOP5vQzvi837t3TwYOHCjDhw/Xz/77778vu3fvfu1zOLJfko/yduRGwePu3bv6y+uDDz5w6PYHDhzQ27dq1SrE5RiywuW///57hHucSpYsGepXt9lbULNmzRCXd+jQQS9HL4fZMxIlShRj2LBhIW536NAhI2rUqKEut2Vuw4YNG7RX4dKlS8aiRYv0Vy1+eeK8CcOWuO3SpUvDfDz8isdtPvroIz3/zTffvPY+nuxxAvQiYJuWL18e5ntmb4gGvWi4HYYWTZ07dzYiRYpk7N+/33LZf//9pz1U9n7Z4zL0SpiuX7+u7fzZZ59ZLkOPD26HHgDrnjL0AmTIkEF7UAD7LnpmIjpUZ7s/DhgwQG+7ZMmSULe1N8RqPaSNIVr09JjbZu9+9tq0bdu2RuzYsUP02qK3xradnz59qr1JtWvXtlxm9uqNHTs2zO1FG+I2Zi+cCb1Ktpeb7w+ue51nz55pz1XevHl120xTp07Vx3Blj1OCBAmMjh07hnk9Xit63NDbZNve2GcqVKgQ7rY4ul+Sb2KPE3kMfplBvHjxHLr9mjVr9H/8WrZmJiAjyTyiWrduHWZvTMeOHUOc79y5c4jtWbJkibx69Up7plC6wDzhVzB6oDZt2uTQNpQvX157ItBLgF+eceLEkRUrVkjatGktt0GS9evazLzObF9n29kT0Oth/XrswS96E3ol/vvvP8mSJYsmWO/bt89y3dq1a6VYsWIheiYSJ04sjRs3tvu46B1Cr44Jbf7OO+/I2bNnLZfhvS1cuLCULFkyxDajpxE9gWZPGbYFPUHoHXOFxYsXaw8PeuRsYYZiWJYtW6b7IHqPbJPNre9n3aZoe+ynaAv04KFXyxpeb5MmTSznMQsTbWLdTthezNA0PxP2nhcTAhIkSKA9KdafD/RQ4TlsPx+YIIGeqNfZs2ePXL9+XXuDsG0m9NLg+VwJ7zN6Ef/991+71x84cEBOnTqlvbrYT83XiBmumHixZcsWfX/C48h+Sb4p8Ka0kM9CyYHXHTytXbhwQQ8KOHhaQ4CCLzZcH1H4sg4Lgh9rmTNn1u0wh9LwhYkOE9vbmTB04oiJEydK1qxZdZhj+vTp+mVrO/PGDH7CazPb4MrZdrbnxo0bOixjwgHPDH4iAkNS1ttoD2bZYXh0xowZOhz3v06p/0EbmfC+I3CyZbufmN56661Ql2FYBENT1o9ZpEiRULfLnj275XrM/sTQFWYwIqDA82F4DQdPDBlFtCwHhoMicj/skzj4hgfDPl988YUOK5kBtb02BQTstsEa2unvv/8O8bw4uIc3GxKfDzx28uTJ7V6P4MfRz6I18/Nu+7nD5w3D/66EYcBmzZrpjxoEfBiyx5C4+Tx4jYDbhAVtYD3sHpH9knwTAyfyGBzQUUfIOhfCEeH98n4d64O/Netf4s4+P35J4jLkftjrtXI0wMDBt2DBgvp3rVq1tLcDB2HkfJiPYR64cfDCbewxD2zmQRS5KXDo0KEw7/M6hQoVChGYIofjTYpVmu95WMENoBcDQRPyxRAYoRcB7Yycp9f9eg9PWD2L1oGZo/B+4P1BPhl6vtADgxwY9Pwg78eXIN8GOYH43CEHCj8AUOYCvXcIAG3b1FXthMdF0IScJnts872c+Sy+6XdGWN8HttCbjN4g5Lf99ttvMnr0aPnqq6+0txl10cy2w+Vh5WS97nvAlfsleRYDJ/IoJJaiRtOOHTvs9hpYS58+vX5B4dedGUCYibw4KOB6619qtknZqA2FukXOwvNZ/wpGEie2A0UeAQcgfLnhNugxcgV8iaK3BUnP3333nSV5F8EUetfmzJkj/fr1s/tlO2vWLEvbmvdBe8ydO1f69u0boQRxHPSsC5G+yS969DbhAIRf79bvo61FixbpL3gkypqQoG37vuJ9x3tiy95ljsJjIiCyZQ5nWe9rGFKtX7++nrCPISEcyeRIVEdg4kygj33J2R8S5v2wT2IIMawD9+bNm3UYCQd7JDGbzp075/TzWT8vhrAwlBpWzypug1459MK5Migy3wN8PpGAbcK24DVhyNNk9vTY7jvO9FKnSpVKJwrghF4yTFDB+4zACa8REJRiyJ2CC3OcyKN69eqlBx7MlkMAZAtDAebsKHSPA2YvWTMLKVarVs1yGb7IMNRlDQGao78wbYfQrGHGE+ALE3CgRDCCHgbbX4c4j4NVRGD2GHqh8HoRMAAKXWJGDw7qCJxsIc8LM6eQI1K0aFHLfdCjgBlA+N/eL9hffvkl3Jk/OOjhgGCeIho4IfjCzC/M8sP2hxdUoE1ttxVtb/se4rUi8EaeiQmPH1YPhyOwr6E98Lgm5KtgH0LAbPbm2b63yLXBddhuc7YY9m9wZHYlhukOHjwYYuaeIz0P6EnEUB16kmx7jsz7mQGz9eMg0EMPWURhe5HLg+A+rO1Fbw3es6FDh4a6zYsXLyI86xS9s+itmjJlir4OE/Z/28c0Axvr7wRskyOFdXE722FM9KCht/zp06d6HsN3eI4xY8ZYhqFth7opcLHHiTwKXzboPcGvdfQ+WFcOx1R0JJaaa3nhFyR6IPBlZw474OD2008/6YEDvTMmBGJIGsUXO5JScTDC1HIksjoLv14xxRlTs3EgRZCBITTzFy1ew5dffqk9DMh7wrYgdwf3wwEQCcUIdiICU7hRVR0HA7weQO/T/v37dagA24PXiF/yKDuAbUM7ok1sHwf5Lei9QTIuks+RG3b16lVNLEY7or1dCXlJ2B7AwQS9IXg/8ZxI6Mc08vCgxwxT9zFEh2AErxU9F0mSJAkVfON58D5jeA+ByrRp0zRnBAFURIZ20cbooUNwjHIDSDZHm+I9xXCcmYCNnCa0IwJLVGpHcIogAkG8mb+FgyogUMQwI3pmatSoYQmobN8n9LThPUeld9wXrwGTBBAgWPeiWMOQJx4fwQmGlBDMIz8OSes4wKP3EuUV0POCzxBeE9oF7fsmQ0H4vKKHExM2sA/huRFg4n1Cz8wHH3ygn1O819gGBLdoM7QBeoqwP+CHEfZHZ+Ex8LnDY6PHCd8heH8wvGsb2OfMmVN/SOAzivbE+zlv3jwN3F4HuYHI98I2ov0x5IbXh7Y1e0OxP2Cfw/6C50K5BSybhM8APm/oiULpFQpQ3p7WR8Hp5MmTRuvWrXWqNwrModhkiRIljG+//TbENGkUfRw8eLBO8Y0WLZqRLl06uwUwMSUblbeTJk2qU60xTRgF+cIqR2BbfNK6HMHRo0e1ECK2CcUQO3XqZLcA5uLFi7WsQZw4cfSEgpOYwnzixIlwX3t424DXkTlzZj1Zl0vA5bgf2gjF9lD8D9Pi0TZm5XN7UOagYsWKOlUfpRJQCBGFOlEA1JXM6dU4oVQAthHbh/c4rArltuUIUAgSxTzxHqK6PN7D48eP2y0aiVIEKPaI6dtp06Y1RowYoYUp8ZhXr159bZkEe5WmzQKYKCSJ9i1cuHCoApgovogih0mSJNHnxvvUs2dPLbVhDQU5UcgSJQNeVwATpRSwj+H2+Czg9eA2N2/efG27ozxAvnz5dFuwr+I1rV+/3nI9Cs0WLVrUUtCyV69eWiDTdkq+WQDTFrYD22wNU+779etn+UyiZAHaDe1nDWUCUNQSz43PUq5cufT5rVcMeF0ZC3tQgR7PjddcsGBBuwUwAduDopW4XYoUKYy+fftq27yuHAFKHeA9zZMnj243Ptv4217le+yHKANi7g94PfXq1TM2btzoUAFMW6yA7h8i4R9vB29ERG8KSeXff/+99nb5QuFPIgpMzHEiIr9jnbhu5h5hGAqJ8QyaiMidmONERH4HMzKRTI/8LkwywFIcqFPUv39/b28aEQU4Bk5E5HcwCw5J1Zg4gKRnTBVH8GQ97Z6IyB2Y40RERETkIOY4ERERETmIgRMRERGRg4IuxwlVdrHiNYrVvckaaERERBQYUJkJxU9RQNYseBuWoAucEDRhzSwiIiIia5cuXdLK8eEJusDJXBYBjYOy+O7o0cI6RVhT6XVRK7Hd/R33d7Z9sOE+H5jtjnIm6FQxY4TwBF3gZA7PIWhyV+CEBVrx2AycPIft7h1sd+9h27Pdg8krDx1bHUnhYZcIERERkYMYOBERERE5iIETERERkYMYOBERERE5iIETERERkYMYOBERERE5iIETERERkYMYOBERERE5iIETERERkYMYOBERERE5iIETERERkT8ETlu2bJEaNWpI6tSpdX2YZcuWvfY+mzdvlvz580uMGDEkS5YsMnPmTI9sKxEREZFXA6eHDx9Knjx5ZOLEiQ7d/ty5c1KtWjUpW7asHDhwQD799FNp1aqVrFu3zu3bSkRERBTVm01QpUoVPTlqypQpkjFjRvn666/1fPbs2WXr1q0ybtw4qVSpkhu3lIiIiMjPcpx27Ngh5cuXD3EZAiZcTkRERIHp5cuX4iu82uPkrKtXr0qKFClCXIbz9+7dk8ePH0usWLFC3efp06d6MuG28OrVKz25Gh7TMAy3PLavWXPoiozbcEoePn3h7U0R4//aPnLkyBLJ2xsTRNjubPtgw33e8x7fuCin5gyVtFXaSNb8JWVFpxIufw5njtl+FThFxIgRI2Tw4MGhLr9x44Y8efLELY1/9+5dDZ5wEA9ko9celwu3Xd+GREREpucPnsmTO9fk/K/TJH7GfHL9+nVxtfv37wdm4JQyZUq5du1aiMtwPn78+HZ7m+Dzzz+X7t27h+hxSpcunSRLlkzv547ACTME8fiBHjg9fXlY/48cSSR5vBhe3Rb+CmS7Bxvu82z3QGYYhh5LVfwsEr/pEImR9C1JmSiOJE+e3OXPFzNmzMAMnIoVKyZr1qwJcdn69ev18rCgbAFOthDUuCuwwZvtzsf3Hf/bqZPHiyk7+5bz6pYgYMWvEHygAr/dfQfbnW0fbLjPu9+VK1ekcePGMmDAAClTpoxe9urV+279jnfmMb16hHnw4IGWFcDJLDeAvy9evGjpLfr4448tt2/Xrp2cPXtWevXqJcePH5dJkybJggULpFu3bl57DUREROQamCmPWo2bNm2SNm3a+FRSuE8ETnv27JF8+fLpCTCkhr8RZZpRpxlEAUoRrF69WnuZUP8JZQmmTZvGUgRERER+PjT3zTffaJ1GTATLmTOnrFq1SqJEiSK+xqtDdeiCQ2OFxV5VcNxn//79bt4yIiIi8tToU6tWrWT+/Pl6vmHDhjJ16lSJGzeuT74BfpXjRK63+u8rMnb9CXn41Pnu0Ov3OaOOiIgi7tatW1KqVCk5evSoRI0aVUeSOnfu/P8Tw30QA6cgh6DpzI2Hb/QYcWL4XlcqERH5vkSJEknevHnl9u3bsnDhQilRwvU1mlyNgVOQM3ua/ldSwPHpmNZB02cV33HDlhERUSB68eKF1lHEUBx6ljAshzpKKDnkDxg4BflwnDnc5gslBYiIKLBdu3ZNc5hQR3HJkiVaBiBOnDh68hcMnIKAI8NxHG4jIiJ32rFjh9StW1f++ecfDZROnDgh2bNn97tGZ+AUBF43HMfhNiIichfDMGTixIlacuj58+eSLVs27W3yx6AJGDgF0ew3DscREZEnPXz4UNq2bSuzZ8/W83Xq1JHp06dLvHjx/PaNYODkJzj7jYiI/E29evV0qTQUshw1apSu9OHLpQYcwcDJT3D2GxER+ZsBAwbI4cOHZdasWVK6dGkJBAyc/AyH24iIyFe9fPlSDh48qOvNQZEiReTUqVMSPXp0CRRcRp6IiIje2M2bN6Vy5cpaxPLAgQOWywMpaAIGTkRERPRGdu/erb1MGzZs0NpMFy5cCNgWZeBEREREES41MGXKFF1v7tKlS/L222/Lrl275IMPPgjYFmWOk59V+CYiIvIFjx8/lvbt28tPP/2k5z/88EOZMWOGJEiQQAIZAycfwgrfRETkL6ZNm6ZBE4bmRowYIT179vT7UgOOYODkQ1jhm4iI/EWHDh10WO6TTz6R999/X4IFAycfxJIDRETki6UGpk6dKi1atJCYMWNqUctffvlFgg2Tw4mIiChc//33n1SrVk17mbp06RLUrcUeJyIiIgrT3r17pXbt2lpiIFasWPLee+8FdWuxx4mIiIjs+vHHH7WgJYKmzJkzy86dO6VJkyZB3VoMnIiIiCiEJ0+eSKtWrfT09OlTqVGjhuzZs0dy584d9C3FwImIiIhCuHbtmixZskTLCwwbNkyWLVsmCRMmZCsxx4mIiIhspU+fXubNm6d/V6xYkQ1khcnhREREQe7Vq1fas1SgQAGpWrWqXsaAyT4GTkREREHs9u3b0rRpU1m9erUOx506dUqSJk3q7c3yWQyciIiIgtSBAwe01MDZs2e1qOW4ceMYNL0GAyciIqIgNGvWLGnbtq3OoMuYMaMsXrxY8uXL5+3N8nmcVUdERBRkS6e0b99emjVrpkFTlSpVtNQAgybHMHAiIiIKIlhjDsngKDUwaNAgWbVqlSROnNjbm+U3OFRHREQUBBAsRY78v/6SCRMmSMOGDaVMmTLe3iy/wx4nIiKiAA+YRowYoYv0YpgOYsSIwaApgtjjREREFKDu3r2ruUzLly/X8/j/o48+8vZm+TUGTkRERAHo0KFDGiSdPn1aokePLhMnTmTQ5AIMnIiIiALM7NmzpU2bNvLo0SN56623ZNGiRVKoUCFvb1ZAYI4TERFRAEE+U5MmTTRoqlChguzdu5dBkwsxcCIiIgogWGsuduzY8sUXX8ivv/7KSuAuxqE6IiIiP3f9+nVJnjy5/p0nTx7Na0qVKpW3NysgsceJiIjITxmGIWPGjJEMGTLIzp07LZczaHIfBk5ERER+6N69e1K3bl3p2bOnPH78WNeaI/fjUB0REZGfOXr0qJYWOHHihESLFk0rgWPBXnI/Bk5ERER+ZP78+dKyZUt5+PChpE2bVksNFClSxNubFTQYOBEREfmJjRs3SoMGDfTv999/X+bNmyfJkiXz9mYFFQZOREREfgLBEobosmbNKkOHDpWoUXkY9zS2OBERkQ/DbLlcuXJJnDhxJFKkSLJgwQKJEiWKtzcraHFWHRERkY+WGhg/fryULFlSl0/BeWDQ5F3scSIiIvIxDx48kFatWmkiuOn58+e6WC95FwMnIiIiH3L8+HGpXbu2lhxADtO4ceOkY8eOOkxH3sfAiYiIyEegiGXz5s21xyl16tSycOFCKV68uLc3i6wwcPKg1X9fkbHrT8jDpy/tXn/9/hNPbg4REfkQBEvoWcL/pUuX1mG6FClSeHuzyAYDJw9C0HTmxsPX3i5ODM6WICIKNnHjxtVgafXq1TJ8+HCWGvBRDJw8yOxpihxJJHm8mGEGTZ9VfMeTm0VERF6yfft2uXnzptSsWVPPo6cJJ/JdDJy8AEHTzr7lvPHURETkA1BaYOLEidKtWzeJGTOm/PXXX5ItWzZvbxY5gIETERGRB2GNOSzIO3v2bD1ftWpVXXOOAjhwunjxoly4cEEePXqka+TkzJlTYsSI4fqtIyIiCiCnTp3SJVMOHz6shSxHjx4tn376KUsNBGLgdP78eZk8ebIuKHj58mVLBVNAQa5SpUppZVPUnogcmQXJiYiIrC1fvlw+/vhjuXfvnqRMmVITwd977z02kp9xKMLp0qWL5MmTR86dOydffvmlFuW6e/euPHv2TK5evSpr1qzRkvADBgyQ3Llz61gtERER/X9btmzRoAnHy3379jFoCuQeJywsePbsWUmSJEmo65InT66rNeM0cOBAWbt2rVy6dEkKFSrkju0lIiLySyNHjpQMGTJIu3btJFq0aN7eHHJnj9OIESPsBk32VK5cWcdviYiIgtnu3bulQYMGusYcIFjq3LkzgyY/x2QkIiIiF0IO8JQpUzT3F3lMX331Fds32Ibq8uXL53DGP8ZtiYiIghFmm3fo0EF++uknPY8RGOQJU5AFTrVq1XL/lhAREfmxM2fO6MzygwcP6uxy5DT16NGDpQaCMXBC0jcRERHZ9/vvv2vQdOfOHZ00hdI9ZcuWZXMFoAjlOGHHmDZtmnz++edy69YtyxDdP//84+rtIyIi8nlp0qSRly9fSrFixfR4yKApcDkdOP3999+SNWtWTXYbM2aMBlGwZMkSDaSchbV6MD0Ta/UUKVJEZyGEZ/z48fLOO+9IrFixJF26dLrOz5MnT5x+XiIiojdhzpYDHJc2b96sJwRRFLicDpy6d+8uzZs317LxCHZMWGsHxb2cgdkGeDwMBSJCR5HNSpUqyfXr1+3efs6cOdKnTx+9/bFjx+THH3/Ux+jbt6+zL4OIiCjC9uzZo4vyYojOlD9/fl1JgwKb04ETqoJjcUJbiLBRRdwZY8eOldatW0uLFi0kR44cOn0zduzYMn36dLu33759u5QoUUIaNWqkvVQVK1aUhg0bvraXioiIyFWwOC9KDaAwdP/+/UMsQUaBz+lFfrGYL0rG2zp58qQu+OsoLNeyd+/eEMN7mIVQvnx52bFjh937FC9eXH755RcNlAoXLqw7LZZ7adq0aZjP8/TpUz2ZzG1/9eqVnlwNj4kPkf3HNj9cYV1P7ml3che2u/ew7T0PaSGdOnWSGTNm6PmaNWvq3/juYfDk3/u7M4/rdOCEHWXIkCGyYMECPY/6ThcvXpTevXvrjAJH3bx5UxPpUqRIEeJynD9+/Ljd+6CnCffDOj9owBcvXmjp+vCG6lD1fPDgwaEuv3Hjhltyo9D4WMcP22e72PHL/3tj8H9Yw5Hk+nYn92G7ew/b3rOwlFjLli3l0KFD+h3Tq1cvrQKOTgB+n/v//n7//n33BU5ff/211KlTR6dbPn78WEqXLq1DdJhJMGzYMHEnJN0NHz5cJk2apInkp0+flq5du8rQoUO1u9Qe9Gghj8q6xwlJ5egdix8/vlveXASTeHzbNzfK/53H/2g/8ky7k/uw3b2Hbe856BzAcmKYRZ40aVL57rvvtKOA3zWBs79b52y7PHBKkCCBrF+/XrZu3aoz7B48eKAJcRhicwZ2vihRosi1a9dCXI7zKVOmtHsfBEcYlmvVqpWez5Urlzx8+FDatGkj/fr1s9uYGFrEyRZu666dHm+u/cc3q6//73ryVLuTO7HdvYdt7xnp06eXKlWqaEoKRltwkOV3TWDt7848ptOBkwnDZThFFGYeFChQQDZu3GipTI6IEucxhhxWKftQvThRouj/HF8mIiJXQe8SjjcJEybUA/bUqVP1eIOFejk0F9wiFLYhuKlevbpkzpxZT/h7w4YNTj8OhtB++OEHXdMH5QXat2+vPUiYZQcff/xxiOTxGjVqyOTJk7Ui67lz57TnC71QuNwMoIiIiN7E/v37pWDBgtKsWTNL0jBmfNsbvaDg43SPE/KLkFeEPCf8Dzt37tQ6TuPGjZOOHTs6/Fj169fXJO0BAwZonlTevHll7dq1loRxjCtb9zB98cUXGvnjf1Qpx1gngiZ351YREVFwmDlzpv6INycP4diUOnVqb28W+ZBIhpNjXGnTptUilLbDaagAjsRtX192BcnhyNNCdr67ksPRjYvkb9thxaLDN8rVe08kZfyYsrNvOZc/dzALr92J7R6IuM+7FsrWdOnSRYfkAJ0BKH+TKFEitnsQ7O/3nIgNnH52LLGC2QW2UIwST0hERORPMLqBgpYImjCqgZI7K1euDBU0EUUocEIdp6VLl4a6fPny5ZrrRERE5C8w6PLhhx/qqhiJEyfWosrInWXPNbksxwlLoyCnCDWVULvJzHHatm2bfPbZZzJhwgTLbdHtSURE5KvQw4RJR59++qmuh4rlvIhcGjhhYV10Xx49elRPJkzZxHXWOyMDJyIi8jVIOcEivWb9QSzhhR//OG4RuTxwQhkAIiIif4TCzR999JFOZMK6qJjNDQyayFFvlJrOhQ2JiMhfYJZc0aJF5cyZM1r2houCk8cCJwzJvfvuu1p2Hif8PW3atAhtABERkTthIV6U0MGSXVhjtVKlSrJ3715dLozI7UN1KFY5duxYXRXaTA5Hd2e3bt10SiemcRIREfmCy5cvS926dXUSE2DG3MCBA7naBHkucMLsAyyT0rBhwxAlCnLnzq3BFAMnIiLypeE5BE2YwPTzzz+zbA55PnB6/vy5ruFjCwv2vnjx4s23iIiIyEV69uwp165d06E6rK1K5PEcJ4wRo9fJFiquNm7c+I03iIiI6E2WzsCyYOZac1gAHuuoMmgir/U4mcnhv/32m85OgF27dml+08cffyzdu3e33A65UERERJ5w5MgRLTVw8uRJrdU0ZcoUNjx5P3A6fPiwZSYCpnRC0qRJ9YTrTKyJQUREnjJv3jxp2bKlPHr0SBejb9GiBRuffCNw2rRpk3u2hIiIKAJ5t8hj+uabb/R8uXLlZO7cuZIsWTK2JfleAUwiIiJv+ffff6Vs2bKWoOnzzz+XdevWMWgi38txwho/CxYs0LwmFBaztmTJEldtGxERUZhw/Dl27JjEjx9fZs2aJR988AFbi3yvxwnjyMWLF9eddenSpdpNioS833//XRIkSOCerSQiIrKRIUMG/bGOH/MMmshnA6fhw4fr1M6VK1dK9OjRtYv0+PHjUq9ePXnrrbfcs5VERBT07t+/Lw0aNJDVq1db2qJ06dLy9ttvB33bkA8HTphJV61aNf0bgdPDhw91Bh2WXEEtJyIiIlfDKEeRIkVk/vz58sknn+jsOSK/CJwSJUqkUT+kSZPGUoIANTO4IxMRkastWrRIChcurMFT6tSpNU0kduzYbGjyj8Dpvffek/Xr1+vfWDixa9eu0rp1a127DtNAiYiIXAHLePXo0UOPNQ8ePJAyZcrIvn37NM+WyG9m1X333XeWUvb9+vWTaNGiyfbt26V27dryxRdfuGMbiYgoyOA4U7lyZfnjjz/0PGo1Icc2atQITQYncpmozkb/q1atkkqVKun5yJEj65pARERErhQzZkzJli2b7N27V2bOnKk/zon8bqgOkX67du0sPU5ERESuYhhGiFxZzNrG0ByDJvLrHCck6B04cMA9W0NEREEJM7QbN24sNWvWlJcvX+plMWLEYKkB8jlODxZ36NBBunfvLpcuXZICBQpInDhxQlyfO3duV24fEREFuJMnT2qvEmZpY2Rj586dUqJECW9vFpFrAicUH4MuXbpYLkMdJ3Sx4n/zlwIREdHroLRA8+bN5d69e5IyZUpdzotBEwVU4HTu3Dn3bAkREQUNTDbCTOyvvvpKz5csWVKDplSpUnl704hcGzilT5/e2bsQERGF0L59e5k2bZr+jZUnEEChvA1RwCWHExERvanOnTtL8uTJdQmVsWPHMmgiv8FKYkRE5HbIgz169KjkzJnTMpEIqR9cOoX8DXuciIjIrVCbCQngefPm1ZUmTAyayB8xcCIiIrc5c+aMFCtWTGbNmqW9TubC8ET+ikN1RETkFliiq0mTJnL37l1LPhMW6iUKuh6natWqyZUrV0L9TUREhHp+/fv3lxo1amjQhB4nLJ3CoImCNnDasmWLPH78ONTfREREixYtki+//NIye27z5s2SJk0aNgwFBA7VERGRS9WrV09Wr14tlSpV0vXniAIJAyciInpj8+bNk+rVq0vcuHF1+S0kgxMFIs6qIyKiCEOqRsuWLaVhw4bSqlUrnTlHFMjY40RERBGCApa1a9eW/fv3S+TIkbVOE1GgY+BERERO+/XXXzV/6fbt25I0aVIdqitXrhxbkgIeh+qIiMhhr169ksGDB2spGgRNhQsX1lIDDJooWEQocEqfPr1lQUbrv4mIKLD9999/MnnyZM1lat++vZakSZcunbc3i8i3h+qsS+azfD4RUfBIliyZLFiwQPObmjVr5u3NIfI45jgREVG4ZsyYIfHixZM6dero+ffee09PRMGIgRMREdn15MkT6dq1q0ydOlXixIkjBQoUkIwZM7K1KKgxcCIiolAuXLigPUx79uzRgpZ9+vTRnFaiYMfAiYiIQli/fr0WtEQieOLEiWXOnDm6fAoRsRwBERFZGT58uAZJCJoKFiyopQYYNBG5oY7TlStXpFOnTq56OCIi8gLUZkKpgdatW8uff/7J4TmiNxmqO3LkiGzatEmiR4+uq18nTJhQbt68KcOGDZMpU6ZIpkyZnHk4IiLyAQiUkMcEI0aMkFKlSknNmjW9vVlE/t3jtGLFCsmXL5906dJF2rVrp124CKKyZ88ux44dk6VLl2pgRURE/uOXX36RihUryrNnz/R81KhRGTQRuSJw+vLLL6Vjx45y7949GTt2rJw9e1aDqDVr1sjatWulcuXKjj4UERF5GQIlfKc3bdpUNmzYID/++KO3N4kosAKnEydO6Icsbty40rlzZ10Je9y4cVKoUCH3biEREbnU5cuXpXTp0jJp0iQ9P3DgQGnTpg1bmciVOU7379+X+PHj699RokSRWLFiMaeJiMjP/P7779KgQQO5ceOG5qnOnj1bqlat6u3NIgrM5PB169ZJggQJLCtkb9y4MdRadUwoJCLyTTNnzpSWLVvq93fevHll8eLF/AFM5M7AyXZBx7Zt24Y4j1kZL1++dHYbiIjIA4oXL67pFh999JEO02HkgIjcFDjhFwoREflfXaZEiRLp31mzZpWDBw9qbSaz/AARubkA5tOnT+Xhw4fO3o2IiDxs7ty5GiQhrcKUIUMGBk1EngickEhYpUoV7eZFknjRokXl9OnTb/LcRETkplIDXbt2lUaNGunEnmnTprGdiTwdOPXu3VsOHDggQ4YMkTFjxsidO3e0JD8REfmOf//9V8qWLSsTJkzQ83379tUil0Tk4RwnrJaNGRnmYo/Vq1fXquEYuosRI4aLNoeIiCLqjz/+kPr168u1a9d0BvSsWbM405nIWz1O+BWTJ08ey/m3335bAyYs7vsmJk6cqGPuMWPGlCJFisju3bvDvT16ulCIM1WqVPr8SHZE9XIiomCGpO9y5cpp0JQrVy7Zs2cPgyYib5cjQOFL2/NYHDKi5s+fL927d9cFghE0jR8/Xnu0UKU8efLkdsftK1SooNctWrRI0qRJIxcuXNAibkREwSx37tya04Tv5O+//15ix47t7U0iCu7ACR9G9O5YT2F98OCBLvyL5VdMt27dcvjJseYd8qRatGih5xFArV69WqZPny59+vQJdXtcjsffvn27RIsWTS9DbxURUTA6efKkRI8eXRInTqzfzVhvDov0stQAkQ8ETjNmzHDpE6P3aO/evfL5559bLkMAVr58edmxY4fd+6xYsUKKFSumQ3XLly+XZMmS6S8sJK7b9oYREQWyBQsWaBXw999/X78P8f1p/qAkIh8InDJmzKhVZ/FrxhVu3rypVcZTpEgR4nKcP378uN37nD17VtdZaty4seY1oRxChw4d5Pnz57pIpT1IXsfJdO/ePUtBT3cU9cRjonfO/mObw5phXU/uaXdyF7a75+H7Dj84sci62fOP7zVzLVFyL+7zgdnuzjyuw1EQprciEdxe7pGn4IXh+adOnao9TAUKFJB//vlHRo8eHWbgNGLECBk8eLDdulRPnjxxyzbevXtX32DrIUx4+X9vDP6/fv26y587mIXX7sR2DxT43sBSVzt37tTzrVq1kv79++t3mTu+zyg0ftcEZruj3plbcpxcKWnSpBr8YAaINZxPmTKl3ftgJh26oq2H5VAS4erVqzr0h7F+W/hlhgR0E36ZpUuXTof53PELDW8u8gvw+LZvbpT/O4//vRmABqLw2p3Y7oFg27ZtWmoAP2DjxYun+UwlS5bkPu9h/K4JzHbHzH5HOTXu5sqEQwQ56DHCUgC1atWyNAzOd+rUye59SpQoIXPmzNHbmQ2H5EgEVPaCJkDJAnt1pnB/dx1g0U72H99sv/9dT55qd3IntrtnhucwiQZBU86cOWXx4sVaEgY9UNznPY/7fOC1uzOP6VTg1Lx589cWu1yyZInDj4eeoGbNmknBggWlcOHCWo4A6+CZs+w+/vhjLTmA4TZo3769fPfdd7qUQOfOneXUqVMyfPhw6dKlizMvg4jIr6CnHevO4fsPte+w9BXz+Yi8w6nACd3DsWLFctmTo9sZuUYDBgzQ4ba8efPK2rVrLQnjFy9eDBEFYoht3bp10q1bN61ZgqAKQRRm1RERBRL0ph8+fFg++ugjPV+oUCH56aefvL1ZREHPqcAJax+5OjcHw3JhDc1t3rw51GUoR2AmRhIRBaKlS5dqbzxyN1G3Ln/+/N7eJCL6Pw4P6rGgGhGRe7148UKL/6KXCbN8kMKAHE4i8h1em1VHRET/HxK9GzRoIJs2bbLkgI4cOZJFLYn8NXDChxll/YmIyLWQflCnTh2tSxcnThxdXqpevXpsZiJ/HaqbN2+elC5d2qGq4ZcuXdJ6I0RE5BhMekHQlC1bNvnrr78YNBH5e+A0efJkLTQ5atQoOXbsWKjrUc0TS6Bg3TgkMf7333/u2FYiooCE6t8Yltu9e7d+1xKRnwdOf/zxh3z11Veyfv16effdd7XiNoqv5cqVS9KmTStJkiSRTz75RN566y2dPluzZk33bzkRkZ/COptNmzaVx48f63mUXUFZFZR8IaIAyXFCMIQTFufdunWrXLhwQT/0WDolX758emLFZiKi8K1YsUKL+6KnHt+f5mK9RBSAdZwAH3RziRQKbc2hKzJ67XF5+vKw1RIr/3P9PhfhJApWL1++1MXIhw0bpueLFy8uPXr08PZmEZG7AycK37gNp+TC7fADpDgx/v8ixUQU+NBTjxxQpDsAlokaPXp0mGtsEpHvYuDkYg+fvtD/I0cSSR4vpt2g6bOK77j6aYnIRx04cEDTHDDjOHbs2DJt2jRp2LChtzeLiCKIgZObJI8XQ3b2LeeuhyciP5EoUSJ59OiRTqjBIuiYYENE/ouBExGRG/KZokT535B8+vTpdfFyBE4JEiRgWxMFy1p14X1BoCv69u3brtkiIiI/dvbsWV1jbuXKlZbLChYsyKCJKFgDp08//VR+/PFHS9CEiuIoepkuXTrZvHmzO7aRiMgvoBBwgQIFZN++fbrWHBbtJaIgD5wWLVokefLk0b/xi+rcuXNy/Phx6datm/Tr188d20hE5BelBqpVqyZ37tyRIkWKyO+//+7QMlVEFOCBE6bVpkyZ0vLrqm7dupI1a1atHH7o0CF3bCMRkc/CElPVq1eXIUOG6PkOHTroagvohSeiwON04JQiRQo5evSo/sJCwmOFChX0cswaMZMhiYiCAXI7MTSH78JYsWLJrFmzZOLEiRIjRgxvbxoRuYnT/cgtWrTQlbtTpUolkSJFkvLly+vlu3bt0pW9iYiCqdRA1apV5bfffpPFixdb0hiIKHA5HTgNGjRIF/e9ePGiDtOZv6zQ29SnTx93bCMRkc948uSJ9rAnTpxYz2OtOazbmTBhQm9vGhH5SuCEL4iTJ0/qOnXIZfrmm29CreLdrFkzd20jEZFPwOLmtWvX1tIC69at0+Rv/Hjk0BxR8HAox+nZs2dy7949/funn37SX1xERMEEgRJKr+zdu1dr150+fdrbm0REvtrjVKxYMalVq5YmQRqGoQtUIhHSnunTp7t6G4mIvObVq1cybNgwLTeA7z8Us0RZFlQEJ6Lg41Dg9Msvv+g4/pkzZzQh/O7du+x1IqKgmDXXtGlTWb16tZ5v06aNpirEjBl6AW8iCg5RHS1BMHLkSP07Y8aM8vPPP0uSJEncvW1ERF7VqFEjLTWAHKZJkyZpjicRBTenZ9WhUjgRUTAYNWqUXLp0SeszIb+JiMihwGnChAnaRY3uafwdHuQ/ERH5o6dPn8qOHTukTJkyeh6lV/7++2+JHPmN10MnomAKnJDf1LhxYw2c8HdYkP/EwImI/BF6lurUqaML9GLJlOLFi+vlDJqIyOnAyXp4jkN1RBRoNm7cKA0aNNC1OFEN/MGDB97eJCLyUU73P2MhS1TNtYXKueYil0RE/gDlBTDxpWLFiho05cuXT+s04TwRkUsCp8GDB9v9NYZgCtcREfkDlFX56KOP5PPPP9daTc2bN5dt27bpzGEiIpcFTviFhlwmWwcPHrSs3URE5Ovmz58vy5Ytk+jRo8v333+vxXvDKuxLROR0OQKM+yNgwilr1qwhgqeXL19qL1S7du0cfTgiIq9q3bq1HDlyRJo0aSKFChXiu0FErg2cxo8fr71NKACHITkscmnCL7YMGTLo0ixERL4Ia26OHj1aZ/5ikXL8+EMVcCIitwROzZo10/8x/o9putGiRXPqiYiIvOWff/6RevXqyfbt27UuE4bpiIjcFjjdu3dP4sePr39j1glm0OFkj3k7IiJfsHnzZqlfv75cv35de8oxNEdE5NbACflNV65ckeTJk0vChAntJoebSePIdyIi8jZ8J3399dfSp08f/V7KnTu3LF68WLJkyeLtTSOiQA+cfv/9d8uMuU2bNrl7m4iI3gh6yZGPiUAJmjZtKlOmTJHYsWOzZYnI/YFT6dKl7f5NROSLHj58qDWZkIuJBHDM+LXXU05E5PY6TmvXrpWtW7dazk+cOFHy5s0rjRo1ktu3bzu9AURErpYqVSrtbdqyZYu0b9+eQRMReS9w6tmzp3aDw6FDh6R79+5StWpVXcMOfxMRedrz58/1+8d6thxm/xYtWpRvBhF5pxyBCQFSjhw59G/8oqtRo4YMHz5cVxRHAEVE5EmYuIJZc3/++afEjRtX3n//fUmWLBnfBCLyjR4nFLs0F/ndsGGDZTFMJI+bPVFERJ6AtIH8+fNr0IRSKD///DODJiLyrR6nkiVLapd4iRIlZPfu3Zau8ZMnT0ratGndsY1ERKFKDSDpG6kDL168kJw5c8qSJUt0OSgiIp/qcfruu+8katSosmjRIpk8ebKkSZNGL//111+lcuXK7thGIiKLV69e6WSUbt26adDUsGFD2bVrF4MmIvLNHqe33npLVq1aFerycePGuWqbiIjCFDlyZEmXLp3+gEOBy86dO3PWHBH5buAEqMK7bNkyOXbsmJ5HN3nNmjUlSpQort4+IiLLIr3IsQRMSEFPE5aAIiLy6cDp9OnTOnsOi2a+8847etmIESP0F+Dq1aslc+bM7thOIgpSGI7r27evFrTEygUIntDbxKCJiPwix6lLly4aHF26dElLEOB08eJFyZgxo15HROQq165dkwoVKsjo0aNl+/btsmbNGjYuEflXj9Mff/whO3futKxdB0mSJJGRI0fqTDsiIlfYsWOH1K1bV3u3UZ9pxowZUqtWLTYuEflXj1OMGDHk/v37oS5/8OCBJf+AiOhNSg1g9i7WxUTQlC1bNi19UqdOHTYqEflf4FS9enVp06aNTv/FFxxO6IHCIppIECciehODBg3SmXJYRgXBEoKm7Nmzs1GJyD8DpwkTJmiOU7FixSRmzJh6whBdlixZtCAdEdGbaNKkiQ7/o9TAggULJF68eGxQIvLfHKeECRPK8uXL5dSpU1qOIFKkSPprEIETEVFEnDlzxjIj9+2339bzCRIkYGMSkf/3OJnw5YYFfjF0x6CJiCJaE65fv35a2gRrX5oYNBFRQAVOP/74o7z77ruWoTr8PW3aNNdvHREFrJs3b+oyTShmiQAKC/YSEQXcUN2AAQNk7NixmryJPCdz2jDWjUI9pyFDhrhjO4kogJiz5FAPLnbs2PpjrEGDBt7eLCIi1wdOWNj3hx9+0OUOTJhNlzt3bg2mGDgRUVgwC3fq1KlaLBdLqGTNmlWWLFmiyzYREQXkUB2mCBcsWDDU5QUKFNClEYiIwrJ582YtXYKg6cMPP5S//vqLQRMRBXbg1LRpU+11soVfkY0bN3bVdhFRACpTpoy0atVKRo0aJYsXL5b48eN7e5OIiNw7VAfIR/jtt9+kaNGieh7FMJHf9PHHH0v37t0tt0MuFBEFN3xXFCpUSBIlSqTlS/AjC/8TEQVF4HT48GHJnz+//o1aK5A0aVI94ToTvxiJghtmyiHnEaeqVavKypUrJXLkyPxuIKLgCpw2bdrkni0hooDx33//6dD9unXr9HyGDBk0kELgREQUdEN1RERh2bt3r9SuXVsuXLggsWLF0qE5LKNCRBQIfOLn38SJE/UXKYppFilSRGu8OGLevHna7V+rVi23byMROZb/iLUrETRhCRUsAM6giYgCidcDp/nz52tC+cCBA2Xfvn2SJ08eqVSpkly/fj3c+50/f1569OghpUqV8ti2ElHYHjx4IEOHDpWnT59qbbc9e/ZofTciokDi9cAJM+9at24tLVq0kBw5csiUKVO0kvD06dPDvA9yJZA/MXjwYMmUKZNHt5eI7IsbN66WGBgxYoQsXbpUFwQnIgo0Xs1xQhE85EN8/vnnlsuQPFq+fHldxiUsmKWTPHlyadmypfz555/hPgd+/eJkunfvnv7/6tUrPbmaYfW/Ox6f7ENboyo129yzfv31Vzl37pwWtYR8+fLpyXxPyH24z3sH2z0w292Zx3U6cPrpp5+09EC1atX0fK9evTT5E71Fc+fOlfTp0zu1yCd6j1KkSBHicpw/fvy43ftgIVDkURw4cMCh58CvX/RM2bpx44Y8efJEXO3Vy1eW/1833EgubPdXr+Tu3bv6weLMLc+09/jx42XMmDESLVo0yZYtmy72TZ7Dfd472O6B2e737993X+CElczNyuHoFUJi97hx42TVqlW60C/WnXIXvDBULsdaeQjeHIHeLOuinOhxSpcunSRLlswtVYsjR4ls+R+9YuS5DxUmCuB9ZeDkXrdv39Zit2vWrNHz9evX1wW/MYOOPIf7vHew3QOz3TE5zW2BE1Yzz5Ili/69bNkynXbcpk0bnUmD5RScgeAnSpQocu3atRCX43zKlClD3R4FN5EUXqNGjVDda1GjRpUTJ07oTB5rMWLE0JMtNLw7Gj+S1f88gHsWPlTuel/pf9DTi8/82bNn9YsGP5xQ3BJBE9vd87jPewfbPfDa3ZnHjByRBFAUtzOXUqhQoYL+jS/Rx48fO/VY0aNH18WBN27cGCIQwnn8grWF4YBDhw7pl7d5wuydsmXL6t/oSSIi95g1a5Z+LhE0ZcyYUbZv3y7NmzdncxNRUHG6xwmBEhbpRALoyZMn9dcmHDlyRGsxOQvDaM2aNZOCBQtK4cKFNW/i4cOHOssOMCSQJk0azVVCcGabR2HO3GF+BZF7obcXeYH4zP/yyy+69hwTwIko2DgdOKFr/osvvtAhO0w9TpIkiV6O2XENGzZ0egOQH4FE7QEDBsjVq1clb968snbtWkvCOBYP5hAAkffhc4+hcHzO+ZkkomAVyUCKehBBcniCBAk0O98dyeFFh2+Qq/eeSsr4MWRn3/Iuf3yyDz0fmMWIhHwe1F1jw4YNMmrUKFm+fHmYid9sd+9h27Pdg8krN3/HOxMbONTj9Pfff+tQGDYWf4eHlYKJ/P8L6quvvtIeJvyN4AmV/YmIyMHACcNnGEZDpIe/kdlu3VFlnsf/qMtERP7pzp07mnO4YsUKPf/JJ59I7969vb1ZRET+FTihMjBqJ5h/E1HgwYzVjz76SE6fPq0lPL777judCEJERE4GTtbVwJ2pDE5E/rN0CuozoaTIW2+9pRM/MNOViIhctFbd0aNHdcYb1puzhrpKRORfcubMqYtrlypVSmbPnu1wZX4iomDjdOCE4ncffvihdutb5zrhb2COE5F/ePDggRa0BfQyoaAlyg2gmj8REdnn9Jy+rl27atVgTAvEL1QUvtyyZYt262/evNnZhyMiL9i0aZMunYRSA6asWbMyaCIicnXghIV9hwwZol355poxJUuW1MreXbp0cfbhiMiD0EM8evRoKV++vK4JOXbs2BAzZImIyMWBE4bi4sWLp38jePr3338tSeNYZJeIfBMKvNWpU0d69eql9ZmwnBGSws1hdiIickOOEwphHjx4UIfrihQposXxsFjv1KlTJVOmTM4+HBF5ACZzoNQAftxEixZNJkyYIG3btmXQRETk7sAJ1YSxCC9gyK569eo6Ewdr1s2fP9/ZhyMiN8O6klhAG5/btGnTyqJFi/RHDxEReSBwqlSpkuVvJJceP35cbt26pSuls8ufyPekS5dOq4Gjt2nu3LmWYrZEROTmwOn58+e62OeBAwd0yM6UOHHiCDw1EbnLlStXdIYclkmCcePG6XmWGiAi8mByOHIjUO+FtZqIfNeff/4p+fPnlwYNGsiLFy/0MuQhMmgiIvLCrLp+/fpJ3759dXiOiHwHygqgZ6ls2bK6KPeNGzfk5s2b3t4sIqLgznHCwp9YBDR16tRagiBOnDghrt+3b58rt4+IHHD//n1dkHfBggV6vlGjRjrT1fbzSUREHg6catWq9YZPSUSuhAkaKDVw7NgxiRo1qvY6dezYkZM1iIh8IXAaOHCgO7aDiCI4PNe0aVMNmtALvHDhQilevDjbkojIV3KcMBzANemIfANKgMycOVOqVaumw+QMmoiIfCxwQsJp5cqVtTZMz549tYo4EXkO1phbsmSJ5XzOnDll1apVkiJFCr4NRES+FjhhNXXUiOnfv7/89ddfOu0ZX9zDhw+X8+fPu2criUht375dP3P169eXbdu2sVWIiHw9cAJUCW/Tpo0O2V24cEGaN28uP//8s1YSJyL35DJ9++23Urp0aV1Y++2339ZljoiIyA8CJ+tK4nv27JFdu3ZpbxOHCohcD2vMNWnSRLp06aIFLevVqye7d++WbNmysbmJiPwhcNq0aZO0bt1aAyX0NsWPH19zLC5fvuz6LSQKYidPnpSiRYvKnDlztPL32LFjZd68eRI3blxvbxoRUVByuhxBmjRptGo4EsRRYK9GjRoSI0YM92wdUZD79ddf5fDhw5IyZUotblmqVClvbxIRUVBzOnAaNGiQ1K1bVxImTOieLSIiCwzP3bt3T8uApEqVii1DRORvQ3UYomPQROQeKPeBiRdYQsWs04QZrAyaiIj8tMeJiNwDkyzq1KmjuYJPnz6Vn376iU1NRBRIs+qIyDWlBqZMmaL5SwiasmbNKr169WLTEhH5IAZORF706NEjnZnavn17Le/x4YcfamFZFJUlIiLfw6E6Ii9B7bNatWrpskWRI0eWkSNHSo8ePTSviYiIAqjHCVXCS5Qooauxo3I4jB8/XpdjISLHxIwZU65fvy7JkiWTDRs26NqPDJqIiAIscJo8ebJ0795dqlatKnfu3JGXL1/q5Zhph+CJiMLPZzKhNtPKlStl3759UrZsWTYbEVEgBk5YL+uHH36Qfv36aSVjU8GCBeXQoUOu3j6igPHff/9JlSpVZO7cuZbLChQoIGnTpvXqdhERkRsDp3Pnzkm+fPlCXY7q4VhTi4hCw5qOCJLWrVunRS35WSEiCpLAKWPGjHLgwIFQl69du1ayZ8/uqu0iChjTpk3TnEDkA2bJkkU2btwoceLE8fZmERGRJ2bVIb+pY8eO8uTJE83XwCrtGHoYMWKEHiCI6H8eP34snTp1kunTp+v5mjVralFLVt4nIgqiwAlrZsWKFUu++OILrUHTqFEjnV33zTffSIMGDdyzlUR+Bj8sUNBy7969Wmrgyy+/lN69e+vfREQUZHWcGjdurCcETg8ePJDkyZO7fsuI/LzUQLly5XR4Dj2y5cuX9/YmERGRC7zRz9/YsWMzaCL6P69evZLbt29b2mPYsGFa3JJBExFRkPU4YRado4X5UJOGKNjcunVLmjZtqiUH/vjjD51lGjVqVB3GJiKiIAucsCyEde7GpEmTJEeOHFKsWDG9bOfOnXLkyBHp0KGD+7aUyEft379fateuraU6MESHHw/mZ4OIiIIwcBo4cGCI5HDUoRk6dGio21y6dMn1W0jkw2bMmKE/GPCDAqU6lixZInnz5vX2ZhERka/kOC1cuFA+/vjjUJc3adJEFi9e7KrtIvJpT58+lbZt28onn3yiQVO1atV0Bh2DJiKiwOZ04IRSBNu2bQt1OS7DMAVRMGjXrp1MnTpVc//Q+7pixQpJlCiRtzeLiIh8rRzBp59+Ku3bt9c8jsKFC+tlu3bt0iJ//fv3d8c2EvkcrNW4ZcsWzferVKmStzeHiIh8NXDq06ePZMqUSQte/vLLL3oZllpBrke9evXcsY1EPlFqAJMgihcvruexdMqJEyd05hwREQWPCH3rI0BikETB4s6dO5rXt2rVKl2TsWLFino5gyYiouDDn8tE4fj777/lo48+kjNnzmhtpuvXr7O9iIiCGBfOIgoDhqKLFi2qQVP69Ol1AgRmjxIRUfBi4ERk49mzZ9KpUyetBP748WNN/kapgQIFCrCtiIiCHAMnIhsrV66UiRMn6t8DBgyQ1atXS5IkSdhORETkfI4Tiv2FVa/pypUrkipVKjYr+TXkNKHsRrly5aR69ere3hwiIvLnHqf8+fPLgQMHQl2OquG5c+d21XYReYxhGFqPCQv1Aopajhs3jkETERG9eeBUpkwZTZj96quv9PzDhw+lefPmmg/St29fZx+OyKvu3bsnderUkY4dO2riN+o1ERERuWyoDr/MsS4XFvtFXRsMz8WNG1d2794t7777Llua/MaRI0d0WO7kyZMSPXp0+eCDD7S3iYiIyKV1nKpUqaIHnMmTJ2sRQCTTMmgifzJv3jxp2bKlPHr0SNKlSyeLFi2yLCFERETksqE61LQpVqyY9jatW7dOevXqJTVr1tT/nz9/7uzDEXkU9lEkfjds2FCDpvLly2upAQZNRETklsApb968kjFjRjl48KBUqFBBvvzyS9m0aZMsWbKEBx/yeQ8ePJBly5bp38jJwxIqyZIl8/ZmERFRIOc4IRHcGhY+3b9/v/6SJ/JliRIl0hmgly9f1pwmIiIitwZOtkGTKV68ePLjjz86+3BEbi81MH78eIkfP77mNAEqgLMKOBEReSRwmjVrVpjXYUZSWIEVkafdv39fZ38uWLBAZ82hlEbmzJn5RhARkecCp65du4ZKtkWSLQ5MsWPHjlDghOUtRo8eLVevXpU8efLIt99+G2a+1A8//KDB2+HDh/U8eg6GDx/O/CoK4dixY1K7dm39P1q0aDJ27FjJlCkTW4mIiDybHH779u0QJyTbnjhxQkqWLClz5851egPmz58v3bt3l4EDB8q+ffs0cMKiqtevX7d7+82bN+uMKCSk79ixQ6eSV6xYUf755x+nn5sCk1laAEFTmjRp5I8//tACl6zRREREPrHI79tvvy0jR44M1RvlCPQEtG7dWlq0aCE5cuSQKVOmaM/V9OnT7d5+9uzZ0qFDB53dly1bNpk2bZpWe964caMLXgn5uz59+kjdunU1oC9btqwG4yifQURE5DOBE6AQ5r///uvUfZ49e6Y1dFBLx7JBkSPrefQmOQLDhBguTJw4sdPbTIEHkxQAdcV+++03SZ48ubc3iYiIgjnHacWKFaFmLWHZle+++05KlCjh1GPdvHlTXr58KSlSpAhxOc4fP37cocfo3bu3pE6dOkTwZe3p06d6sl6bDNBL5Y51yQyr/7numWdgH8IwHPZF7A/vvfeelCpVSq/je+BeaF+0O9vZ89j23sF2D8x2d+ZxnQ6catWqFeI8DlgoIPj+++/L119/LZ6E4UEsnYG8p5gxY9q9zYgRI2Tw4MGhLr9x44Y8efLE5dv06uUry/9h5WmRa+BDhBIYyGlCbSb0YOKyd955h23vIfiyuXv3rrY7eovJc9j23sF2D8x2xyxstwVOroz2kiZNKlGiRJFr166FuBznU6ZMGe59x4wZo4HThg0bJHfu3GHe7vPPP9fkc+seJySUI9hDbR9XixwlsuV/DhO5z8OHD6VNmzYaOAMqgGP9RLyvPIB7Dr4PzB9PbHfPYtt7B9s9MNs9rM4Xly3y6yooYYByAkjsNnuyzETvTp06hXm/UaNGybBhw3StvIIFC4b7HDFixNCTLTS8Oxo/ktX/PJC4x8mTJ7XUAEpSILcOQXS7du20F9Fd7yuFDV9mbHfvYNuz3YNJJDd+1zjzmBEKnLBcBXKdLl68qMMjtrPknIHeoGbNmmkAhCnkqPKM3gTMsoOPP/5Yp5RjyA2++uorGTBggMyZM0cyZMigtZ8gbty4eqLAtnTpUmnevLn2HKJXcuHChVoKgzk2RETkCU4HTugNqlmzphYTRAL3u+++K+fPn9dxx/z58zu9AfXr19eeAgRDCIJQZgDDLmbCOIIz60hw8uTJGqzVqVMnxOOgDtSgQYOcfn7yH99//732LAGSv1EDLFWqVN7eLCIiCiJOB07IGerRo4cmXGPqN5JykcvTuHFjqVy5coQ2AsNyYQ3NIfHbGoI0Ck5Vq1bV8e0mTZpozyMqghMREfl04IRqzGaFcOSXPH78WIfIhgwZoqvNt2/f3h3bSUEKw8Jp06bVv5HUf/ToUZ1UQERE5A1OZ1jFiRPHkteEYZIzZ86EqMtE5AoY+p00aZIuyrts2TLL5QyaiIjILwIn9Cghabto0aKydetWy9DJZ599pjPcPvnkE72O6E2hGjwmDGB9OQTptkVXiYiIfD5wQk4TAifMmitSpIjlsnLlymmSLma4oRgh0ZtADybWlvv555+1xtfo0aO5XxERkf/lOGHoBDCbznrYDovyErnCypUrpWnTplodFhMOEJCXKVOGjUtERP6ZHI7iU0TucOjQIS1zAcWLF5cFCxZo/S4iIiK/DZyyZs362uDp1q1bb7pNFIRy5colnTt31r9RCRxV5YmIiPw6cEJOU4IECdy3NRRU9uzZo6UGzHUJUTWey6UQEVHABE4NGjTgwrX0xpAvN23aNC16ikRwLNSMmmAMmoiIKGBm1TG/iVwBBVNbtmwpbdq00VIDCRMmlCdPnrBxiYgosAInc1YdUUSdO3dOSpQoITNmzNDeJSzcvGTJEi7OTEREgTdUx9Xn6U38+uuvup7h7du3tfr3vHnztAYYERFRQK9VR+SsFy9eaIV5BE0onrpw4UJdd46IiCjg16ojchYSvxctWiRdu3aVP/74g0ETERH5LQZO5Bb79u3TXCZTjhw5tNxAjBgx2OJEROS3OFRHLoeAqX379jpEh6KpSAgnIiIKBOxxIpdBWQGUGfjkk0/k6dOnUqVKFe1pIiIiChQMnMglLly4IKVKlZIffvhBa34NHTpUli9fLokSJWILExFRwOBQHb2x9evXS8OGDeW///6TxIkTy5w5c6RSpUpsWSIiCjgMnOiNHT58WIOmggUL6uy59OnTs1WJiCggMXCiN/bpp59q9e+mTZtKzJgx2aJERBSwmONETjt48KBUq1ZN7t27p+eR09S6dWsGTUREFPAYOJFTZs2aJcWKFZM1a9ZI37592XpERBRUGDiRQ1BeoEOHDtKsWTN5/PixVK5cWQYPHszWIyKioMLAiV7r0qVLUrp0aZk8ebIOyw0cOFBWrVolSZIkYesREVFQYXI4hWv37t2az3Tz5k1JmDChzJ49W6pWrcpWIyKioMTAicKF0gLRo0eXvHnzyuLFiyVTpkxsMSIiCloMnMju0ilmWYEUKVLIxo0bNYCKFSsWW4uIiIIac5woVDHL3Llz65CcKVu2bAyaiIiIGDiRtblz50qRIkXk1KlT8uWXX8qLFy/YQERERFbY40Ty7Nkz6dKlizRq1EgePXok5cuXlz///FOiRuVILhERkTUGTkHu33//lbJly8q3336r51HUcu3atZI0aVJvbxoREZHPYZdCELtz544UKFBArl69KvHjx5eff/5Zatas6e3NIj/y8uVLef78uU4oiByZv8M86dWrV2x7L2C7+2e7R4sWTaJEieKSbWHgFMRQl6lFixZazHLJkiWSJUsWb28S+QnDMDTgvn37tn6h3b9/X4ujkmffA7a957Hd/bfdccxLmTLlG39XMXAKMtjpHjx4IKlSpdLzQ4cOlS+++EJix47t7U0jP4KgCT2WyZMn1zpf+DXHwMnzBxJM4EAuItue7R7ojDfY33Ff5O9ev35dz5vHv4hi4BREjh07Jh999JEOy23ZskVixIihXZcMmsjZ4TkzaEqcODEP3l7CwIntHkyMN/yhYNYhRPCE7643GbZjUkKQWLhwoRQuXFiOHz8u//zzj1y4cMHbm0R+CnkGwICbiPyJ+Z1lfodFFAOnAIcdpHv37lKvXj0dosMMun379knWrFm9vWnk5zg8RETB+J3FwCnA81DKlSsn48aN0/O9evWS3377TbspiShwnD9/Xg8KBw4ccOvzNG/eXGrVquXSx5w5c6Ym7b6JDBkyyPjx48VXvPfeezJnzhxvb0ZQmTJlitSoUcMjz8XAKYBhxhwKWcaLF08X6P3qq69Y1JKCGg78CDBwQkJ7xowZ9QcFpjj7s3Tp0smVK1fk3XffFX9Tv359OXny5BsFWX/99Ze0adNGfMGKFSvk2rVr0qBBg1DXjRgxQnNrRo8eHeq6QYMG6WLqjgTFyPeZOnWqrvQQN25cbZOCBQtq8IgkaHe5ePGiVKtWTYe88AO8Z8+er11hAiMcFSpU0G1MkiSJvk8Y/bB9//AjH7dJlCiRVKpUSQ4ePBjiNuvWrZOSJUtqjm6yZMmkdu3a2jamTz75RJ8Lxzx3Y+AUwL777jspUaKE7pRICicikcqVK2uQcfbsWe2N/f7772XgwIFuT6jHVGp3wcEY06z9sdo/knbftBccB1JfybmbMGGC/mi1V2to+vTpGqjj/zfRtGlT+fTTT+WDDz6QTZs2aVDVv39/Wb58uY4quGsfRtD07Nkz2b59u/z0008ayA4YMCDcAstYiQKlbnbt2qXFlY8cOaI/YEwIovCZfOutt/Q2W7du1R/7CJ7MXKRz585pT2eZMmVk//79GkTdvHkzxHENs3ux+gXa3+2MIHP37l0DLxv/u0ORYeuN9L1X6f+edv/+fWPp0qUhLnv16pURDF6+fGlcuXJF/yf3evz4sXH06FH9H/vXs2fP/GY/a9asmfHBBx+EuOyjjz4y8uXLZzmPfWj48OFGhgwZjJgxYxq5c+c2Fi5cGOI+y5cvN7JkyWLEiBHDKFOmjDFz5kz9Xrl9+7ZeP2PGDCNBggR6u+zZsxtRokQxzp07Zzx58sT47LPPjNSpUxuxY8c2ChcubGzatMnyuOfPnzeqV69uJEyYUK/PkSOHsXr1ar3u1q1bRqNGjYykSZPqduH5f/jhB217PDaef//+/ZbH2rx5s1GoUCEjevToRsqUKY3evXsbz58/t1xfunRpo3PnzkbPnj2NRIkSGSlSpDAGDhzoVPvh9eAxkiVLpm1RokQJY/fu3RFqK9OBAwf0dnHjxjXixYtn5M+f3/jrr7+0nXA/65O5venTpzfGjRtneYyTJ08apUqV0udE+//22296e/P70XwscxsAbYfL0JamP//80yhZsqS2d9q0afW14ns2rH3++vXrRqRIkYzDhw+Hug7vR5o0afS+eP+3bdsW4nq8ljx58oS6n+17O3/+fD2/bNmyULfFNt25c8dwhzVr1hiRI0c2rl69arls8uTJRvz48Y2nT5/avc/3339vJE+ePMT38t9//63bf+rUKT2P9xbnL168GOZt8PmLGjWq7m9mu69YsULbGu1p+uOPP3R/f/To0Wu/u94kNmCPU4A4ceKEdtsiArf+xcEEXqKwHT58WH8949eq9XDKrFmzNGcCv467desmTZo0kT/++MPy67dOnTr6CxjDCW3btpV+/fqFemwMmWB4fNq0afo46FXp1KmT7NixQ+bNmyd///231K1bV39tY2Ft6Nixozx9+lTLhRw6dEjvj6EYQI/C0aNH5ddff9XSIpMmTdKhD3swc7Zq1apSqFAh3cbJkyfLjz/+qIt3W0OvQZw4cfSX/qhRo2TIkCGyfv16h3cZ9J4gDQCPg2ES9Cygp+DWrVtOtZW1xo0bS9q0abWnfO/evdKnTx8dVi1evLgORWGoBj2GOPXo0SPU/dGzh+9BvKd4XXgfe/fuLc46c+aMvjcYEsJ7NX/+fO0N6dy5c5j3wfXo+cqePXuo69D+DRs21NeC/3E+ImbPni3vvPOO9jbZwvd9ggQJwrwv9qXwTu3atQvzvthvc+XKJSlSpLBchvf63r17un/bg30Z74N175tZFgBtBXgt2I/RHujNevz4sf6NNkTuGmCFCzwG9jP0fN29e1dXukBvFtrThOFKDB3ifXcn/+vXpVBQ9RtdnyhuicJe+CIk8rQa326VG/efevx5k8WLISs7l3T49qiUj4MEvmDxxY4vZAxrA84PHz5cNmzYIMWKFdPLMmXKpF/yGNIrXbq0/o8vezNPBX8jABs2bFiI58EwA4KbPHnyWPJDZsyYof+nTp1aL8OBH8MXuBzPi+twoMYBynxuE67Lly+fHhwgffr0YeaX4HmR94TXhYNptmzZdNgEAQSGVswDWe7cuS3DlG+//bbefuPGjZqT8joPHz7UgAzDNVWqVNHLfvjhBw28cOBD/oujbWUNrxP3xTab22VCUIDXg2HJsOC9Q9kVDOeY7Yy2NbfRUQigEcRhSMzcDgwDYR/A/2ZAaw1lXhBY2A7TIbhYtGiRBh+AQLxUqVLyzTff2H2c8CDIRjtGxOsmDyAoDW+ykXXQBOZ5XGfP+++/r7O68f537dpV9xkEwoDAFzAst3nzZg2uUZDZbGu8f+bQM3IRcR75cB06dNDgCZ/PNWvWhHg+BK3YR9xdboeBkx/DlyZ+veGXojmTA7+KwvtSIXIXBE1X7/l+kjVKcuCAjy9x5DjhyxnBCpw+fVp7imwDB/wSRtBi9u6iJ8caaqTZwi9tBCYm9CDhC9+2FAiCNbPnqEuXLtK+fXvtNcavaWyX+Ri4HOfRs1OxYkXtcbD3vIAeKRxYrHucke+IfJLLly9rPglYbx/gh5dZXdmRHhkEh3hcE379Y5vw/M60lTUcaFu1amXpUUCvXObMmcVReG4EjWbQBGYQ7Az0kKGnCT08tst+oCfNDG6tobckZsyYoS6fO3euvgYziEYSOAJffF+3bNnSqe3CNkSUp5fVypkzp/YS4T39/PPPNRcP+7h1cIk2QxtgP0I74TMyZswYzadCryN6qBCYIakcASeCWezH+AGA3kwE6tb7OW7vzgR5YODkp/DlhlkbSAwE7JgjR44M0W1J5OmeH394XvTImgcQJOniYIYeEnx5m7N9Vq9eLWnSpAlxP1Tadwa+wK2/0PHYOHBg+Mm2arHZ64CAAcMfeH4ET+j1+Prrr3V4CD0m+CWNX9k4WCCoQDCF6yPK9vsC2+vOJHZHYHYZknzRBhiWRI8YhjY//PBDlz2HedC2DkJsiyLi/cLQIg701nAf66DMWtKkSXX9RlvYvzCcZZ28j3bG/mcGTujtwRCULVTpB3MIDoE3etQi4nW9WwhMMLRpD36Q7969O8RlmD1oXhcWvJc44bb47GEfGzt2rKU3FWUbMDsOvXHm+4LLMLsOye44zk2cOFFfP45xZuXwX375RQNkDMsVLVrU8nwYJsZkAXdi4OSn0L2PoAk7Ij58KHBJ5E3ODJf5CnxR9+3bV3944Ms9R44cGiBhuAhDMvZgmMR2iAC/jF8HPVb4NY0fPRimCQsOBsg1wQm/0jH8ZebV4IDQrFkzPWFqNnKM7AVOyA9B7hEO8mbwtm3bNh0WQf6QK6AHBb1qeFz0npjBB9rCHN6KaFshOMAJ+WXIB8JQJgInPB/aMDx47ZcuXdKhIHNNsp07d4a4jXlgxW1wgLY3jJU/f37NKbPtpTGX/gjrPTYXvzYfFz2Ne/bs0eEoLFFkfYDHLDEEQRiWRFuhNxABhvWQGHoY0Ytl9hJiP0UwgaDCNs8J24ZhwbDynN5kqA69dhhivf5/S5YAAnjcB5+b1zFfE45XeD1mry56h/A5tP6RYZ43g3jzNtbMHx/WgT56QVFaxOwddhsjyATSrLpBgwbpDAHirDpPCrRZdZhphtlOo0eP1vP9+vUzkiRJorO/Tp8+bezdu9eYMGGCnoezZ88a0aJFM3r16mWcOHFCZzlhxhW+V8wZTbYzxUyNGzfW2XqLFy/Wx9m1a5fO4Fu1apVe37VrV2Pt2rV6HZ63SJEiRr169fS6/v3760wqzDTCrC3MvsOsOXuz6i5fvqyz8jp27GgcO3ZM74fZeNaz5jCrDs9nDW2DNnK0/XB/zBD79ddfjSNHjuj1mKGHGYARaSvMhsI2Y9YbZhhu3brVyJw5s94fMBMN992wYYNx48YN4+HDh6Fm1WEGF2YjVqhQQWfobdmyxShQoECIWXXYZ9OlS2fUrVtXZ+Ch/d95550Qs+oOHjxoxIoVS7cH7YrboR07dOgQ5j7/4sULnWG4cuXKEG2E99EezKrs0aOHZT/MmTOnUbZsWX2dZ86c0dlkqVKl0hmRJjxv/fr1dduGDRums9LQVnjO999/P9TMalfBa3v33XeNihUrartiP8Vr/fzzzy23wf6MdsT+Z/r22291X8b7/9133+l2f/PNN5brsX9i9mP79u31ewX7dpMmTXSf+Pfff/U2Gzdu1Bl0AwYM0MfB41WqVEnfd+sZdNiXMmXKFOZrcNWsOgZOfhI44Quie/fuxs2bN136uIGC5Qg8J9ACJxgxYoQeBB48eKCvZfz48XoAwEEfl+NLGlOdw5pij2nZ+NI1v5DDCpzQVvjyR/CEx8ZB8cMPP9Tp19CpUycNFPC4eN6mTZtaPvNDhw7VqfU48CROnFhfBw4ib1KO4E0DJ7xeTNFHUOZoOYLw2grT2hs0aKBBDbYbQRnaxPpA165dOw1swytHgHZBGQE8RtasWfUgbx04AYKyXLlyaakBlC5AkGJbjgCvBQEYSiPEiRNHS1N8+eWX4e7zCPLwGszXg20dNWqU3dt+9dVXOl3fnFL/zz//aBu/9dZb+j4jABw5cmSIKffm9x3aEe8vAmSUBEBwiIAkrKn4roAArUqVKrpteM9RWsN6nzLLPFi3IfZh7K94L9B+s2bNCvW4KBeBfQf7AQJvBIA7duwIcZs5c+YYefPm1fcBn42aNWtq0GUNQR0+y+4OnCLhHwkiZjcmxpLD65aMqKLDN8jVe08lZfwYsrNveZc8JhJWMb0WXb7Vq1eXlStXuuRxAwm6a80uZHuF58h10BWO5FjMdMGw1pusWB4oMISB3BAMEfnLavHB1FaANlq6dOkbLxnzunbHUB2SojHEZg5h0pt7Xbsjhwyz+FCFPqyhSuvvLtskfmdiA+Y4+TiU7//444/1zcQYMabpEpF3Ybo/ZothNhxyfDDdGjWaiG2FRGkkgyNPjoGT5yBfDfXXwqtj5SoMnHwUEiAxm8Ssd4LibwsXLgxzNgcReQ5q6aCYJBJ8kbT72WefaSI3sa3A1Qsh0+thlqmnMHDyQf/995/OJDEr+GI6LH7RWlc3JiLvQf0nnMh/2irIslLIjRg4+SCM3yKvCVVQsVwDgigiIiLyPgZOPsL8NYSgCbU+kMSIOhXvvvuutzeNiIiI/g+nH/kAlJz/5JNPtNCdCdWMGTQRERH5FgZOXnb27FlN/MZCmai26+g6UUREROR5DJy8CEsRFChQQMvgYwkArNpulrInIiIi38PAyYulBrD6MxZwLFKkiBZLQ/EuIiIi8l1MDvdChWsszIiVv6FDhw66UrSzK68TERGR57HHydMNHjmyrjIdK1YsrXI6ceJEBk1EFKZBgwZJ3rx5X9tC/fv3lzZt2rAlHXDz5k1Ni7h8+TLbi5zGwMlD7t+/b/kbFYb//vtvadq0qaeenohEpHnz5narOm/evFlLgWDo3B9hfbRvvvlG+vXrF+q6HTt2aGkTpAY487ozZMgg48ePD3HZpk2bpGrVqrrUDOrM5ciRQ6um//PPP+IuWF+sY8eO+pxx48aV2rVry7Vr1177PuN1WZ8qV65suT5p0qS6lBVSJoicxcDJzfChb926tZQsWVIePXr0v0aPHFmyZMni7qcmIj/y/PnzCN8XhXIxO9fe2mhYN61z586yZcsW+ffffyP8HN9//70ua4G12BYvXixHjx7VxXqxjubXX38t7tKtWzdd2BxLTv3xxx/6GrDo+esgUML6ZeZp7ty5Ia5v0aKFzJ49W5fNIfK7wAnDVfh1g9WKkSi9e/fucG+PD1C2bNn09rly5dLZab7owoULGjDhS+3QoUOyceNGb28SkVs9fPgwzBN+RDh6W9Q2c+S27l72KE2aNNqzgu8Z2wPvokWL9HIMu6M3BEGFuU1//fWXVKhQQXs2sOho6dKldQKINfSCTJ48WWrWrClx4sSxrEs5cuRIXdA7Xrx40rJly1DtZs+8efOkRo0aoS5/8OCBzJ8/X9q3b689Tih7EhEY0sLSTzhNnz5dypQpo9/Z7733nn6/DRgwQNwBQRkCP+SBYvIMZiHPmDFDtm/fLjt37gz3vsgbRZBnnhIlShTi+pw5c+ranyg2TORXgRM+1N27d9cuU3yxoPBjpUqVwqxnhA8MvtDwhbJ//37tdsfp8OHD4kvunPpL8ufPL3v37tUv1bVr19r9YiMKJBhKCeuEIRZryDEJ67ZVqlQJcVscpO3dzl0QrOAgjUkc+G5B7hCG1s0fdejBwPcQCtceO3ZMh7zQC2KuAICh+WbNmsnWrVv1AP/222/rEJf1kL2Zv/Thhx/qDys81oIFC/Sy4cOHy549eyRVqlQyadKkcLcVPSbo/SlYsGCo6/B4+JH5zjvvSJMmTTToiciabfix+uzZM+nVq5fd6xMmTBjmffFehrdfIIAJC74/0RNnvYArXg8WVsYQZHjwnmAfw2tH4Ihg2FbhwoXlzz//DPdxiEIxvKxw4cJGx44dLedfvnxppE6d2hgxYoTd29erV8+oVq1aiMuKFClitG3b1qHnu3v3Lr419H93KDx0nZGgZGNDIkXS5ylYsKBx/vx5tzwXGSH2mytXruj/5F6PHz82jh49qv+/evXKePbsmf4P2OfDOlWtWjXE48SOHTvM25YuXTrEbZMmTWr3ds5q1qyZESVKFCNOnDghTjFjxtTHu337dpj3xffOZ599pn/v3btXb+/oZxv7Zbx48YyVK1daLsP9P/300xC3K1asmNGhQ4dQ32958uQJ9Zhm2+/bt08f6+LFi6FuU7x4cWP8+PH69/Pnz7UdN23aZLkef4f1utOnT2+MGzdO/27fvr0RP358IyIuX75snDp1KsxTeG04e/ZsI3r06KEuL1SokNGrV68w7zd37lxj+fLlxt9//20sXbrUyJ49u97nxYsXIW7XrVs3o0yZMk69Htt9njzDFe1u/d31JrGBV8sR4BcMflEgWdqE/B/8ugjr1wQuRw+VNfRQLVu2zO7tnz59qifTvXv3LGUBcHK1S+tnyN2t8/Rv5DYhuRJDiu54Lvr/0L44FrGdPdfWZs+F9f+2PSrWkKBs3dsRXoIvvgesb3vu3Dm7t4tI70nZsmVD9eLs2rVLe5TM14Vaa+j1QU8LEp/xXYXvEQzb4frcuXNLuXLldKgO3z8YlqtTp45lOAiv7YsvvtCcHPSe4/GQ44jhe+ttRq+W9Xn0XrVt2zbEZUWLFtXeE3uvFZeZw5oYmrK+zYkTJ7SHbMmSJXo52r9evXo69IWhQ+v2s34/bR/f/FxhaDEi7Y3hsNcJ63Ft9zF722ZP/fr1LX9j6Sq8T8grRXI73jcTvpvxvjj7usLbLnKfN2136/3Z9ljhzLEjqrenhOILBeP51nD++PHjYc4esXd7XG7PiBEjZPDgwaEuv3HjhkO5A85KVqi6XD+wUdK931SGDOmpgZoZrJH7YKdHPgQ+FDjokvtg6ATt/eLFC/0bn2HAgfV19chwH5Mrbmt9G0dgu5GThKE/awhozMfDadSoUTJhwgQZM2aMHniRg9SjRw/9zjCfE7mV+CG3fv16+fbbbzVQwtBcxowZdZgOQ0NImsawErYf+UDW9zcP3LavAe1pfZn5ZW97OzPAQw6V+Z1mnceDtS9xH+RpWd8H2zJu3Di9H14XYFtthz4x0w55VngMBB34fF26dEmHD52BFAW0S1jQPgcPHrR7HVZUQNCKY4X1cCACUwzDOfr+4zmQb3by5ElL0Gi+blzuzH5ktru5z5NnuKLd8T7jOwDve7Ro0UJcF96PvqArgIneLOseKgQx6dKl0w9k/PjxXf586d56S6J+Ol1SJUnA5VM8yPxFjPeVgZN74eCPL5moUaNavnxsv4R8FfYNnLDt1tAbA7gcJ+QlIWkbAZC5f506dUqn31vfF8EQTshLQjCG2V/4vkEuJia9mHmNCDhw8Ld9bjyv9fns2bNrbhNmfJnQa4R923abrXN+8F2GoADbZx4gMGMMgV/FihVD3B45VehJa9eund4X24TAJXPmzCHW0ESghOvxvOipQqkDJGkj6LKFICusPCckj9sm+1vDvhPWa0MOEq5Hz52ZI4eetIsXL0qJEiXCvJ+95HYcLBFEWt8HuWEIpBx9HNvtJs97k3bH+4z9HXnH+NFizfZ8uI8jXoRIH18ctl32OI9ZEPbgcmduj19X9n6tml+grraiUwntmsevIR7APQsHF3e9r/T/oX3N2jhmu1v/7w9st9X6NeCEZG7MmkOPEnpxEDDgewaBCa7H0B5mySIowWcd59HjY16P+//yyy9SqFAh/bHWs2dP7emybjfr5zN17dpVaxDhfggMEPwcOXJEMmXKFGqb8Qvc3OeR3rBt2zYNigBJ7bdv35ZWrVpZeqRMCECQJI6EaQRcuA1603BAwpAWgrzevXvrECG2Ac+BHhsETJ06ddKgGTWQECgiIEEhX/RWhVWSIG3atBF+nxCMYSIQakXhYIftRWkFFBHGyYQAD6MLeP2YSYhRBrxOHBfOnDmjSe3oNUOJArMdMUSHVBEMyTqz75rt7m/7vL8zXNDu5ufN3nHCmeOGV48w0aNH1zF+62n6+GWH89YfCmu43HZaP7rKw7o9EZGzMOyGWbHIX8LUexyArQtn4gCOukiYKZc1a1a9PQIHczYg8ogQuOAxkDuFafyOLOCN3BxUAMeBHt+NGEJEgPM6CH5QksDM08DzI5iyDZoAAQV6tVCEF1A4Ez1rCJYwww2BG3K40HtmfYDC8lC//fab5nwhQEGwgudFWyDwchcEbNWrV9ftRu8e3gvkbVlDLxR6yAA/xvHa0GOI9waBF9oSs+esf0QvX75cA8JSpUq5bdspQBleNm/ePCNGjBjGzJkzNdu9TZs2RsKECY2rV6/q9U2bNjX69Oljuf22bduMqFGjGmPGjDGOHTtmDBw40IgWLZpx6NAhn5hVx9ld3sF2941ZdeQ51m2PE2aNzZkzh2+BgzBbEbP23qTdyXM4q87mFxa6uFFADQneWJMJNY/MBHCMZVt3oaE67pw5c/QXXt++fbVLHDPqkMBJRBSM0DM0depUrQdFr4d8M9TdQi0uImdFQiQnQQT5Bui+RreuO5LD0VXOHCfPY7t7Njkc5QEwewxDH0hERtIl8z08y5xpx7ZnuwcDwwX7u/V3l20yuDOxAbNoiYiIiBzEwImIiIjIQQyciChCgmyUn4j8nOGi7ywGTkQUoQJ0qINDROQvzO+sNy1eGvCVw4nItVAnB4UJMQkCv+BQjw1fREwO9ywmh3sH293/2h33RdCE7yx8d5krBUQUAycicppZqR9fRJjRaFYTJ88xFytl23sW291/2x1BU1irjDiDgRMROQ1fXFjsFcsmof4alsPgUjeeZS5WyrZnuweDV2+4v6NX/E17mkwMnIgowvBFhC8k1ERh4OT5Awnb3vPY7t7hS+3O5HAiIiIiBzFwIiIiInIQAyciIiIiB0UN1gJYWJfGXeOw9+/f94lx2GDCdme7Bxvu82z3YPLKzcdWMyZwpEhm0AVOaHhIly6dtzeFiIiIfCxGwGK/4YlkBNm6CYha//33X4kXL55b6s4gakVQdunSpdeusExsd3/H/Z1tH2y4zwdmuyMUQtCUOnXq1/ZoBV2PExokbdq0bn8evLEMnDyP7e4dbHfvYduz3YNJfDceW1/X02RiEg4RERGRgxg4ERERETmIgZOLxYgRQwYOHKj/k+ew3b2D7e49bHu2ezCJ4UPH1qBLDiciIiKKKPY4ERERETmIgRMRERGRgxg4ERERETmIgVMETJw4UTJkyKCl34sUKSK7d+8O9/YLFy6UbNmy6e1z5cola9asicjTBj1n2v2HH36QUqVKSaJEifRUvnz5175P5Jr93TRv3jwtMlurVi02rYfa/s6dO9KxY0dJlSqVJtFmzZqV3zceaPfx48fLO++8I7FixdIijd26dZMnT55E5KmD1pYtW6RGjRpagBLfG8uWLXvtfTZv3iz58+fXfT1Lliwyc+ZMj2wrqmWSE+bNm2dEjx7dmD59unHkyBGjdevWRsKECY1r167Zvf22bduMKFGiGKNGjTKOHj1qfPHFF0a0aNGMQ4cOsd3d2O6NGjUyJk6caOzfv984duyY0bx5cyNBggTG5cuX2e5ubHfTuXPnjDRp0hilSpUyPvjgA7a5B9r+6dOnRsGCBY2qVasaW7du1fdg8+bNxoEDB9j+bmz32bNnGzFixND/0ebr1q0zUqVKZXTr1o3t7oQ1a9YY/fr1M5YsWYIJa8bSpUvDvf3Zs2eN2LFjG927d9dj67fffqvH2rVr1xruxsDJSYULFzY6duxoOf/y5UsjderUxogRI+zevl69eka1atVCXFakSBGjbdu2EXm/gpaz7W7rxYsXRrx48YyffvrJjVsZeCLS7mjr4sWLG9OmTTOaNWvGwMlDbT958mQjU6ZMxrNnzyL6lBSBdsdt33///RCX4WBeokQJtmcEORI49erVy8iZM2eIy+rXr29UqlTJcDcO1Tnh2bNnsnfvXh32sV7CBed37Nhh9z643Pr2UKlSpTBvT65pd1uPHj2S58+fS+LEidnEbm73IUOGSPLkyaVly5Zsaw+2/YoVK6RYsWI6VJciRQp59913Zfjw4fLy5Uu+D25s9+LFi+t9zOG8s2fP6vBo1apV2e5u5M1ja9CtVfcmbt68qV9C+FKyhvPHjx+3e5+rV6/avT0uJ/e1u63evXvr2LntB41c2+5bt26VH3/8UQ4cOMCm9XDb44D9+++/S+PGjfXAffr0aenQoYP+YEDhQHJPuzdq1EjvV7JkSV0o9sWLF9KuXTvp27cvm9yNwjq2YjHgx48fa76Zu7DHiQLeyJEjNVF56dKlmuxJ7oGVxZs2baqJ+UmTJmUze9irV6+0p2/q1KlSoEABqV+/vvTr10+mTJnC98KNkKCMnr1JkybJvn37ZMmSJbJ69WoZOnQo2z1AscfJCTgYRIkSRa5duxbicpxPmTKl3fvgcmduT65pd9OYMWM0cNqwYYPkzp2bzevGdj9z5oycP39eZ8ZYH8whatSocuLECcmcOTPfAze0PWAmXbRo0fR+puzZs+svcwxBRY8enW3vhnbv37+//mBo1aqVnsfM6YcPH0qbNm00cMVQH7leWMfW+PHju7W3CfiOOgFfPPglt3HjxhAHBpxHboE9uNz69rB+/fowb0+uaXcYNWqU/upbu3atFCxYkE3r5nZHyY1Dhw7pMJ15qlmzppQtW1b/xjRtck/bQ4kSJXR4zgxW4eTJkxpQMWhyX7sjf9I2ODKDV65o5j5ePba6Pf08AKeqYurpzJkzdQpkmzZtdKrq1atX9fqmTZsaffr0CVGOIGrUqMaYMWN0WvzAgQNZjsAD7T5y5EidUrxo0SLjypUrltP9+/fffCcIIs62uy3OqvNc21+8eFFnjnbq1Mk4ceKEsWrVKiN58uTGl19++QZbEXycbXd8p6Pd586dq1Pkf/vtNyNz5sw6o5och+9mlI/BCaHJ2LFj9e8LFy7o9WhztL1tOYKePXvqsRXlZ1iOwIehXsRbb72lB2ZMXd25c6flutKlS+vBwtqCBQuMrFmz6u0xfXL16tVe2Orgavf06dPrh8/2hC85cl+722Lg5Nm23759u5Y7wYEfpQmGDRum5SHIfe3+/PlzY9CgQRosxYwZ00iXLp3RoUMH4/bt22x2J2zatMnud7bZ1vgfbW97n7x58+r7hP19xowZhidEwj/u79ciIiIi8n/McSIiIiJyEAMnIiIiIgcxcCIiIiJyEAMnIiIiIgcxcCIiIiJyEAMnIiIiIgcxcCIiIiJyEAMnIiIiIgcxcCKiCBk0aJDkzZv3jVoP9XexGGrixIklUqRIuqZdoNq8ebO+xjt37oR7uwwZMsj48eMt57FIb4UKFSROnDiSMGHCCD//e++9J3PmzBFPwuLCeD179uzx6PMSuRMDJyIfg4NreCcELIECCzDPnDlTVq1aJVeuXJF3331XAlXx4sX1NSZIkEDP43XbC4T++usvDSZN48aN0/shqMSivRGxYsUKXTm+QYMGlssQ0NjuW2nTprV7PYK2/Pnzy8KFCy3XYz80r8eitljEGdt969atEIvm9ujRQ3r37h2h7SbyRQyciHwMDpLmCT0P8ePHD3EZDkSB4syZM5IqVSoNKlKmTClRo0aVQIUgAq8RgUZ4kiVLJrFjxw7RRgUKFJC3335bkidPHqHnnjBhgrRo0UIiRw75lT9kyJAQ+9b+/fvtXo/LCxUqJPXr15ft27dbrs+ZM6def/HiRZkxY4YGwu3btw/xGI0bN5atW7fKkSNHIrTtRL6GgRORj8HB1TyhdwIHWvP8w4cP9UCUIkUKiRs3rh7MNmzYEOL+uP2yZctCXIaeDfRwwKxZs/S+p06dslzfoUMHyZYtmzx69CjM7Ro5cqQ+b7x48aRly5by5MmTULeZNm2aZM+eXWLGjKmPN2nSpDAfr3nz5tK5c2c96GKb0cMBOPiWLFlStzlJkiRSvXp1DR7CG/JCbwwuO3/+vJ7/5JNPJHfu3PL06VPLkFG+fPnk448/DnN7ypQpI506ddIT2j1p0qTSv39/HU403b59Wx8jUaJEGtxUqVIlRDteuHBBatSoodejlwaBxZo1a0JtN/5GIHP37t1QPYnWQ3X4e/Hixfqe4TZoM2wPbvvWW29JjBgxJHXq1NKlS5cwX9eNGzfk999/1+2yhffSen9D0Gbv+qxZs8rEiRMlVqxYsnLlSsv1CHRxfZo0aaR8+fJSt25dWb9+fYjHQFuUKFFC5s2bF+Y2EvkTBk5EfuTBgwdStWpV2bhxo/YCVK5cWQ+ICD4chQM/HgMB2IsXL2T16tUa8MyePTtET4e1BQsW6MF6+PDhmq+CXiLboAj3HzBggAwbNkyOHTumt0Xg8dNPP9l9zG+++UZ7NDA8hF4LDFEBgsPu3bvr8+B1opfkww8/lFevXjnVw4LH6dOnj57v16+fBizfffdduPfDtiIY2L17t27f2LFjtW1MCFywXRj62rFjhwYxaMvnz5/r9R07dtRgbcuWLXLo0CH56quvNEi1hR42295Eez2JaBO8x/Xq1dPbYJsQSGH47vvvv9egDUFyrly5wnxN6O3B+4qA9k2gXaJFi6ZBqD0IWtetW6c9a7YKFy4sf/755xs9P5HPMIjIZ82YMcNIkCBBuLfJmTOn8e2331rO42O9dOnSELfBY+CxTLdu3TLSpk1rtG/f3kiRIoUxbNiwcJ+jWLFiRocOHUJcVqRIESNPnjyW85kzZzbmzJkT4jZDhw7V+4Zl3LhxRvr06cN97hs3buhrOnTokJ7ftGmTnr99+7blNvv379fLzp07Z7ls+/btRrRo0Yz+/fsbUaNGNf78889wn6d06dJG9uzZjVevXlku6927t14GJ0+e1OfYtm2b5fqbN28asWLFMhYsWKDnc+XKZQwaNMju49tud1jvLdoD7WL64IMPjGbNmlnOf/3110bWrFmNZ8+eGY7AY2XKlMnu80SPHt2IEyeO5fTNN9/Y3Y6nT58aw4cP1+1ftWqVXjZw4EAjcuTIer+YMWPqdTiNHTs21HPhcTNkyODQ9hL5OvY4EflZjxN6JtB7gKEs9Gagd8eZHidz+OTHH3+UyZMnS+bMmS09M2HBcxQpUiTEZcWKFbP8jd4dDKdhCA/bZJ6+/PLLEMNsjkAvSsOGDSVTpkzaI2MO4Tn7GrF9aKuhQ4fKZ599psN/r1O0aNEQOUh4DGzPy5cvtQ3Q62LdDhhKfOedd/Q6wJAZXjOGpgYOHCh///23uBqGwx4/fqzt07p1a1m6dKn2HIYFt8XQqT09e/bUYU7zZDuUiaRuvI/osULvGYZrq1WrZrkerx33Q88YblupUiUdfrWFIb7whoGJ/AkDJyI/gkAAB0oMg2HoAwctDNNYD5/gwG+dlwPmUJI1DCdhNhSGgBD4vGlABz/88EOIA/Hhw4dl586dTj0Whh4xMwuPtWvXLj2B+RrNBGfr12jv9WFob9u2bfoaT58+LZ7QqlUrOXv2rDRt2lSH6goWLCjffvutS58Ds9dOnDihQ6UISJCfhlID9toAkKuF3KywrsuSJYvlZDvLzwysLl++rI9hOzsOw3K4H2ZDIqhCWw8ePDjU8+D9tM2fIvJXDJyI/AgCAeTZIOcHARMSc82EaBMOUAiGTOgxsf21j5lR6EFAoi96FJAQHR70cJkBjMk6IELSOJKUETRYH4hxypgxo8Ov77///tOg4IsvvpBy5crp89oe9M0DsPVrtFf/afTo0XL8+HH5448/NOEcs75ex95rxGw2BATYFvTsWN/G3N4cOXKECGzatWsnS5Ys0Z4uBID2IOhAT1ZEIGBCgIlcLiSaI98KgZo9SIpHLaiwgqfwmIGVI7MBAe/bmDFj5N9//w1xOQJobAdRIGDgRORHcBDHARmBwsGDB6VRo0ahkqbff/99TYJG8jgSmXEQR1Kv6f79+9ojgmElzApDUvf8+fNl0aJFYT5v165dZfr06Rp8oJYQhqFsp5ejp2HEiBF6MMdtcCDH7ZFg7cwQIoa/pk6dqr1EmA2GRHFrOJAjOEGyOoJCJLd//fXXIW6D145EdSR2Y9gM24DXgMAuPBgOxPMhGJo7d672FuF+Ztt/8MEHOjyGhGu0f5MmTXRGGS6HTz/9VBOkz507J/v27ZNNmzaFmZSNIUj01CEB/ubNmw4PZWF2JIZZEYzg9fzyyy8aSKVPn97u7RGwIABC0O1uGNrEbEb0iFpD72jFihXd/vxEnsDAiciPIABAcIFZWehxQE4JChNaQxCBwKJUqVIaWGF4z3q2HAIBTJU3D27oucLfbdu2lX/++cfu86J+D2bI9erVS2sKYdq9bb0eDFMhUEGwhMcsXbq0HuSd6XHCMBymre/du1eHf7p166Y9R9YQBCKoQW8SDtLoOUNekQllEhDQoGfOnIKPwoxly5bVgDG8Xh7k+CAnCLPAMEMObWVdjBKvDa8fJRIQJGC4EOUGzMAUj437IVjCbDhM4w+rJAPeQwS1aFv0oo0aNcqhNsJwGnqxEBDi9aMcBXoOEXDag94ylD5AgOwJeM+wH1y6dEnPozcMZRfq1KnjkecncrdIyBB3+7MQEfk41HHCEjLWy50ECgzVoaYUesHC6plyFwSGefLkkb59+3r0eYnchT1OREQBDjlKGN5zdmbim0JCP3of0QtFFCgCd30DIiKyqFWrlsdbAwnwSBgnCiQcqiMiIiJyEIfqiIiIiBzEwImIiIjIQQyciIiIiBzEwImIiIjIQQyciIiIiBzEwImIiIjIQQyciIiIiBzEwImIiIjIQQyciIiIiMQx/w8pyVjt540L0wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 600x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Courbe ROC et AUC de la regression logistique sur l'ensemble de test\n",
+    "meilleur_modele = LogisticRegression(max_iter=1000)\n",
+    "meilleur_modele.fit(X_train, y_train)\n",
+    "\n",
+    "# Probabilites predites pour la classe 1 (benin)\n",
+    "proba_test = meilleur_modele.predict_proba(X_test)[:, 1]\n",
+    "\n",
+    "# Courbe ROC et AUC\n",
+    "fpr, tpr, seuils = roc_curve(y_test, proba_test)\n",
+    "auc_score = roc_auc_score(y_test, proba_test)\n",
+    "\n",
+    "plt.figure(figsize=(6, 5))\n",
+    "plt.plot(fpr, tpr, label=f\"Regression logistique (AUC = {auc_score:.3f})\", linewidth=2)\n",
+    "plt.plot([0, 1], [0, 1], \"k--\", label=\"Hasard (AUC = 0.5)\")\n",
+    "plt.xlabel(\"Taux de faux positifs (FPR)\")\n",
+    "plt.ylabel(\"Taux de vrais positifs (TPR = rappel)\")\n",
+    "plt.title(\"Courbe ROC - Diagnostic cancer du sein\")\n",
+    "plt.legend(loc=\"lower right\")\n",
+    "plt.grid(alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0011",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007022,
+     "end_time": "2026-06-25T11:44:32.290848+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:32.283826+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. La courbe ROC et l'AUC\n",
+    "\n",
+    "La courbe **ROC** (*Receiver Operating Characteristic*) trace le **TPR** (taux de vrais positifs, c'est-à-dire le rappel) en fonction du **FPR** (taux de faux positifs) pour **tous** les seuils de décision possibles. Plus la courbe se rapproche du coin supérieur gauche, meilleur est le classifieur. La diagonale correspond à un classifieur aléatoire (AUC = 0.5).\n",
+    "\n",
+    "L'**AUC** (aire sous la courbe) se lit comme la **probabilité que le modèle classe un exemple positif au-dessus d'un exemple négatif** tirés au hasard. Elle est **indépendante du seuil** de décision, contrairement à l'accuracy : c'est ce qui en fait une métrique équitable pour comparer deux classifieurs dont les seuils par défaut pourraient différer.\n",
+    "\n",
+    "> **Référence.** Bradley, A.P. (1997), *The Use of the Area Under the ROC Curve in the Evaluation of Machine Learning Algorithms*, Pattern Recognition 30(6):1145-1159. L'AUC (aire sous la courbe ROC) y est établie comme métrique robuste, indépendante du seuil de décision, pour comparer des classifieurs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a50c0012",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:32.310810Z",
+     "iopub.status.busy": "2026-06-25T11:44:32.310810Z",
+     "iopub.status.idle": "2026-06-25T11:44:32.316892Z",
+     "shell.execute_reply": "2026-06-25T11:44:32.315836Z"
+    },
+    "papermill": {
+     "duration": 0.017292,
+     "end_time": "2026-06-25T11:44:32.317899+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:32.300607+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : AUC = 0.988 => None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : interpreter l'AUC\n",
+    "# TODO etudiant : l'AUC mesure la probabilite que le modele classe un positif au-dessus d'un negatif\n",
+    "# TODO etudiant : reprendre auc_score (cellule precedente) et le comparer a 0.5 (hasard)\n",
+    "verdict_auc = None  # TODO etudiant : remplacer par une chaine, ex \"excellent (>0.9)\" ou \"correct (0.7-0.9)\" ou \"faible (<0.7)\"\n",
+    "print(f\"Exercice 3 a completer : AUC = {auc_score:.3f} => {verdict_auc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0013",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008549,
+     "end_time": "2026-06-25T11:44:32.334480+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:32.325931+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Choisir un seuil de décision\n",
+    "\n",
+    "Par défaut, un classifieur comme la régression logistique prédit la classe 1 dès que la probabilité estimée dépasse **0.5**. Ce seuil n'a rien de magique. En médecine, on peut vouloir le **baisser** (ex. 0.3) pour rattraper davantage de cas positifs, quitte à déclencher plus de fausses alarmes ; ou au contraire le **monter** si le coût d'un faux positif est élevé. Se déplacer le long de la courbe ROC, c'est exactement **échanger du TPR contre du FPR**. Le bon point de fonctionnement dépend du coût relatif des erreurs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a50c0014",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:32.353509Z",
+     "iopub.status.busy": "2026-06-25T11:44:32.352514Z",
+     "iopub.status.idle": "2026-06-25T11:44:32.365902Z",
+     "shell.execute_reply": "2026-06-25T11:44:32.364875Z"
+    },
+    "papermill": {
+     "duration": 0.023502,
+     "end_time": "2026-06-25T11:44:32.367010+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:32.343508+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seuil = 0.5 (par defaut)\n",
+      "[[ 56   8]\n",
+      " [  2 105]]\n",
+      "\n",
+      "Seuil = 0.3 (plus sensible aux positifs)\n",
+      "[[ 56   8]\n",
+      " [  0 107]]\n",
+      "\n",
+      "Interpretation : la matrice de confusion s'organise en\n",
+      "[[vrais negatifs, faux positifs], [faux negatifs, vrais positifs]].\n",
+      "Un seuil plus bas reduit les faux negatifs mais augmente les faux positifs :\n",
+      "c'est exactement le compromis decrit par la courbe ROC.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Matrices de confusion a deux seuils differents pour le meme modele\n",
+    "proba = meilleur_modele.predict_proba(X_test)[:, 1]\n",
+    "pred_05 = (proba >= 0.5).astype(int)\n",
+    "pred_03 = (proba >= 0.3).astype(int)\n",
+    "\n",
+    "print(\"Seuil = 0.5 (par defaut)\")\n",
+    "print(confusion_matrix(y_test, pred_05))\n",
+    "print(\"\\nSeuil = 0.3 (plus sensible aux positifs)\")\n",
+    "print(confusion_matrix(y_test, pred_03))\n",
+    "print(\"\\nInterpretation : la matrice de confusion s'organise en\")\n",
+    "print(\"[[vrais negatifs, faux positifs], [faux negatifs, vrais positifs]].\")\n",
+    "print(\"Un seuil plus bas reduit les faux negatifs mais augmente les faux positifs :\")\n",
+    "print(\"c'est exactement le compromis decrit par la courbe ROC.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0015",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007119,
+     "end_time": "2026-06-25T11:44:32.383110+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:32.375991+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Synthèse : quel modèle, quelle métrique ?\n",
+    "\n",
+    "Trois leçons à retenir :\n",
+    "\n",
+    "1. **Biais vs variance** : un modèle trop simple sous-apprend (biais élevé), un modèle trop complexe surapprend (variance élevée). La bonne complexité minimise l'erreur de généralisation, pas l'erreur d'entraînement.\n",
+    "2. **Estimation fiable** : la validation croisée k-fold remplace le découpage unique par une moyenne ± écart-type, quantifiant l'incertitude de l'évaluation.\n",
+    "3. **Choix de métrique** : l'accuracy suffit sur des données équilibrées et des coûts symétriques. Dès qu'une classe est rare ou qu'un type d'erreur coûte plus cher, on passe à l'**AUC** (seuil-indépendant) et on **choisit son seuil** selon le coût des faux positifs / faux négatifs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a50c0016",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-25T11:44:32.404469Z",
+     "iopub.status.busy": "2026-06-25T11:44:32.403462Z",
+     "iopub.status.idle": "2026-06-25T11:44:35.749365Z",
+     "shell.execute_reply": "2026-06-25T11:44:35.748314Z"
+    },
+    "papermill": {
+     "duration": 3.357242,
+     "end_time": "2026-06-25T11:44:35.750362+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:32.393120+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAG4CAYAAAC5CgR7AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAacBJREFUeJzt3Qm8jPX///+XfV+yL8lWkawRCakoIVuSKGuUQllK9jWUCi22slSkJCIlhVAiPpFKIkshuwrZt/nfnu/f/5rvzDlzjnM42xyP++02nJm55pprZq655nW936/3653C5/P5DAAAAAgzKRN7AwAAAIDLQSALAACAsEQgCwAAgLBEIAsAAICwRCALAACAsEQgCwAAgLBEIAsAAICwRCALAACAsEQgCwAAgLBEIAsgQRQpUsTatm3Lu51I7/fy5cstRYoU7v9LufPOO90lLg0ePNg9f3IVm/c3saxdu9bSpk1rO3fuDNpP7r//fktsDz/8sD300EOJvRkIQwSywBXavn27PfHEE1asWDFLnz69Zc2a1apVq2avvfaanTp1ivcXV42TJ0+6gDUpB3NXs379+lmLFi2scOHCCfacCu5DXV588cWg5Z5//nmbM2eO/fTTTwm2bUgeUif2BgDh7PPPP7dmzZpZunTprHXr1la6dGk7e/asrVy50p577jn79ddf7a233krszUwStmzZYilTcu6cWO644w53YqUWufgMZIcMGeL+jtii279/f+vdu7clVwnx/l6JDRs22JIlS2zVqlUJ/tz33HOPOz4GqlChQqTrlSpVsldffdXee++9BN5ChDMCWeAy/fHHH647TK0bX3/9teXPn99/X+fOnW3btm0u0E2OLl686AJ2tUDHlIL9q9n58+fd+5ZYgY5OImLzecW11KlTu0ty3ccT+/29lGnTptl1111nt912W4I/94033miPPvroJZdTasGgQYNs/Pjxljlz5gTZNoQ/mkeAyzRq1Cg7fvy4TZkyJSiI9Vx//fX2zDPPBAUyw4YNs+LFi7ugTrlpffv2tTNnzgQ9zstZU/esWigyZMhgZcqU8XfXzp07113Xj2bFihXtxx9/DHq88iL1I7Bjxw6rU6eOZcqUyQoUKGBDhw41n88XtOwrr7xit99+u+XMmdM9j9b38ccfR3ot6grs0qWLvf/++3bzzTe77V+0aFGs1hExZ/PcuXOu9e6GG25wr0WPr169ui1evDjocTpJqFGjhnsd2bNnt0aNGtlvv/0WMv9SJw96Di2XLVs2a9eunWslvBS1Hqo1fd26de616HUULVrUJk6cGLScApuBAwe616j1a5u0bcuWLQta7s8//3Tbo/dm7Nix/s9806ZNIZ9fz33XXXeFDKYKFixoDz74oP+2mL7fMc3hVI+Btk/rqly5sn377beRHhuT163XnDt3bve3PlevC1mfTVQ5srH9TqinQ9uo/UWpPDFtudP7qFQf73uj7bzvvvvshx9+iNE+ru9Y3bp1XdqQvlu1atWy77///pLv79atW61p06aWL18+97zXXnutO/k9evRo0GNnzJjh3lt9Bjly5HDL7N69O9LrWLNmjdtufQYZM2a0mjVr2nfffRej92DevHl29913xyhP+d1333UnHepViitqrT59+vQlW25PnDgR6RgARMsH4LIULFjQV6xYsRgv36ZNG0WRvgcffNA3btw4X+vWrd31xo0bBy1XuHBhX4kSJXz58+f3DR482DdmzBj3XJkzZ/bNmDHDd9111/lefPFFd8mWLZvv+uuv9124cCHoedKnT++74YYbfK1atfK9+eabvvvvv98914ABA4Ke69prr/U99dRTbpnRo0f7Kleu7Jb77LPPgpbTbTfddJMvd+7cviFDhrjt//HHH2O1Dr0ubZunb9++vhQpUvg6duzoe/vtt32vvvqqr0WLFu51eRYvXuxLnTq178Ybb/SNGjXKPXeuXLl811xzje+PP/7wLzdo0CD3nBUqVPA98MADvvHjx/s6dOjgbuvVq9clP5uaNWv6ChQo4MuTJ4+vS5cuvtdff91XvXp19/gpU6b4lzt06JD7XHr06OGbMGGC2yZ9VmnSpPG/H6Jt02NLlSrl9hG9Jn2OO3fuDPn8Q4cO9aVMmdK3b9++oNtXrFjh1jN79uxYf2YR3+9ly5a55fS/Z/Lkye6222+/3b3mbt26+bJnz+62We9JbF738ePH3X1aX5MmTXzTp093l59++inoM7qS70TevHndfqPXfsstt7j9Z+PGjZf8fNu2bevWW7duXd/YsWN9r7zyiq9Ro0a+N95445L7uNafKVMm9/qHDRvmPsuiRYv60qVL5/v++++jfH/PnDnjltN+9cILL7j3Wuu99dZbfX/++af/cbpPr6N58+Zuv/X28SJFivj+/fdf/3JLly71pU2b1le1alX3XdH+VLZsWXfbmjVron39f/31l9s2fcYR6b2tX7++//qkSZPc9vTr1y9ouX/++cftB5e6nDhxIuhxel69f1qn9x6///77Ibfz3LlzvgwZMvh69uwZ7esBAhHIApfh6NGj7qCsH8OY2LBhg1tewVWgZ5991t3+9ddfB/2w6LZVq1b5b/vyyy/dbTrIBwZD+tGJGJx4wUHXrl39t128eNH9WOlHTz82npMnTwZtz9mzZ32lS5f23X333UG3a30KtH799ddIry2m64gYWJUrVy7oBzSU8uXLu+Dy77//9t+mwEjboqDH4wVJ7du3D3q8AqqcOXP6LkVBmx6vAMGjQMR7fr0mOX/+vLs9kIINBViBz+0FslmzZvUdPHjwks+/ZcsWt3xgYCUKWHUCE/geX+77HTHQ0uP02vQaA1/TW2+95ZYLDGRj+rq1b+mx+jwiihjIXs534ptvvvHfpvdVweSlgh6tR499+umnI92n78Wl9nEF1frebN++3X/b3r17fVmyZPHdcccdUb6/CoIjnoREpIA2VapUvuHDhwfd/ssvv7gTOO92badOTOvUqRO0zdoXFCzfc8890b4HS5YscduyYMGCaAPZ1157zQWcCthDLad1XOoS8bPXSZJOHubPn+9OdLSvajkF7aHopFUnHEBMkVoAXIZjx465/7NkyRKj5RcuXOj+79GjR9DtPXv2dP9HzKUtVaqUVa1a1X+9SpUq7n91DSrPLeLtSiOISN2kEbtN1UWsAR8edWV6/v33X9flqS7j9evXR1qfujG1XRHFZh2B1P2vwXDqfg1l3759boCKUgXU3eopW7as64L03tNAnTp1Crqu7fj777/9n1d01JWq6hMe5bLq+sGDB13KgaRKlcqf46ru6n/++cd1jysFJNTrVbey191+qRzC8uXL26xZs/y3XbhwwaUMNGjQIOg9vtz3OyJ1q+u16T0LzNvV+62u60Cxfd3x9Z3Q6/TofS1RokTIfT+QRsJr/1fuZUQRu9kj7uP6DL766itr3LixS2XwKJWoZcuWLtUhqn3Lew+//PLLKNNblCak91O5oYcPH/ZflIqglBsvdUPfA31P9Jzan73l1A2vNIdvvvnGrScqeoxcc8010aZKKRXqpZdecgPzIlLKhbr8L3WJOKhLqQ9ab8OGDd2+pu+SUmmUQhKqqou2Ua8NiKnwybwHkhDlysl///0Xo+VVt1GDQZQ3G0g/WAroAus6SmCwGvijWKhQoZC3K6AJpOcK/OH1giUvl9Hz2Wef2QsvvOB+KAPzEkPl0SlnNJTYrCOQcnaV76rt0g+bcv9atWrlAlXx3hMFKxHddNNNLkDQD7nyNaN637wfbr0/3mcWFeURB64r4nvmDZJR/qBGVm/evNnl+Ub3/kT1noXSvHlz9+O+Z88elxerXEsFmro9Lt7viLz3VwFToDRp0kTad2L7uhPiO+F9vhH3/VDl8fTZBp4MRSXiazl06JALQqPaBxU8KpdVObWh1qUgffTo0S4IVBCuYE6DnrzvrYJTNQZH/AwCPwtvOWnTpk2U264TmugCVYmYI+9ZsWKFO3FQCayo8mJVUjAu6IRIJ9VeUKu8+IjbmJzrDSPuEcgCl0FBkX4cN27cGKvHxfQArRaw2Nwe1Q9UdDSoRz+sKhukUcJqZdIPp0Y3z5w5M9LygS2Bl7uOQHqMgoz58+e7Vq/JkyfbmDFj3ACrDh062OWIy/cnFA3KUYulWuj0g58nTx73nCNHjnSvJSbvWVQUsPbp08dmz55t3bp1s48++sgFPArw4+L9TsjXnZDfibj6bGP7ecWEAn+9b94+/vTTT7v3TAPFNPBLgbBe/xdffBHy9Xkj973W1pdfftm13IcS3Sh/DQyUqIJ+BeJHjhyx6dOnu16IUCcnCurVQn0p2o5LVRzwTsjVsh+RtjGqwB4IhUAWuEwaRa0R36tXrw5KAwhFJbr0Y6SWFbXkeA4cOOB+QOK6QLmeS12uXoui/P777/4R4F6Xq0ZSq2UzsDSWgqKYutJ1qJVMlQV0UQUIBWga3a5A1ntPVH82IrUK5sqVK1IL6pXYu3dvpBbeiO+ZuvrVWqku4cAALFS3dWwpeNCIfKUXqMVKz6HAMfB9jYvPzOO9v9onlbLiUWurSsuVK1fOf1tMX3dsWtIS6juhigh6vxQ0xaRVNpDSF1QdIKp9UC3KEXtJIlKlBF3UXa8armrZ1MmaWtW1bQrE9dkHfldDvQbvBLp27doWWyVLlnT/63MNRd8lfcZqHVWqglImdKIe6NZbb43USh6K9gmvUkVUvHSQiGk3SldRC7dO1oCYIkcWuEy9evVyQY+CLv34RqSWKpX8kXr16rn/VYopkLodpX79+nH+Obz55pv+v/VjqetqvdMPlagFSIFHYCuLutBVpiemrmQdXt6eR6046mb2usvV2qjWJ3VpK7DxqBVcrVveexpX9CM6adIk/3XlE+u6fmxVGkm8VrPAVkCVRNLJTFxQq6xa66ZOneryBCOmFcTFZ+ZRfqtem4IqvVbPO++8E/R+e88bk9etoE8iPj6UhPpOKE9Z2+1N1BCb1ly97nvvvde1qAam5Oj7rhZwBX5Rpawod1b7VCAFtAp+vX38gQcecM+hbYu4LbrufUe0/ymYVek1nfCFai2NjlJVFHAHlhuLSC3Eyp9X3qpy0CN+Py8nRzbUdikdS5+5gmfve+VReTqV6FJ5OSCmaJEFLpN+WPRjpmBDLUqBM3up5UVdxF7dVLVuKb9NLbj6kdegEs17riBNrW6haoheCbXaqQamnlMDwtR1qRw45WB6rSAKFBQ0qOtag0iUjzlu3DgXTP78888xep4rWYcG1ah+q37M1FKmH1m1CgUOUlNXqup3qsX7sccecz+yb7zxhutyv1SrT2ypBUoDXRSwqHVMLaPKQ9Vn5uUqqhVerZJNmjRxr10tXAoE9VpCBRixpUE/zz77rLvoPYnY+hYXn5lHr0mtgupKVous9mO9HrXuRsyRjenrVte8btN7p/dQr0HfCV0iSqjvhNaj3OvXX3/dtf7qvVNLsNI0dF/g/haK3iMFaApan3rqKTcoUCc4CkY1QCoqqn+sdWvmP70XCmrVda/AVcG1dwzR+pVSov1Or1sDSPX+fvLJJ/b444+7fUHBr1Jv9F1QGoB6MBScKp9aA8IUTC9YsCDa16F8dK0zuhxU7Uc6SdT3UjWo9Rq8QP1ycmS1b+okSwMWleOsAZw6Sdu1a5d7LyJODqL3WSdDCqSBGItxfQMAIf3++++uFqrqPqpMj8ryVKtWzZVSOn36dFCNRNWIVLkc1d8sVKiQr0+fPkHLhKrr6NHXtXPnzkG3eWWeXn75Zf9tKrmkuo0qF3Tvvff6MmbM6MokqSxOYL1ZUY1UlfVRGaOSJUv6pk2bFrLeZ6jnju06IpaDUv1M1UBV3VKVFdNjVW7IK3UVWDpI76eWUTmrBg0a+DZt2hS0jPd8gaXFRNui2wNrzoaiUlM333yz74cffnB1OlWHV9ureqWBVPpoxIgR7j69XtWtVf1WvS7dFt3nElN6raHKUl3p+x2qjqyoDJJXF7VSpUquxJXej8DyWzF93aKycRUrVnTfhcByTKG28Uq/ExG3MyoqH6bPQu+Xtku1YlXiad26dTHax9evX+9KX6kUmr5Pd911V1B5vFDv744dO1xpsuLFi7v9KUeOHO5x2p8jmjNnjqtbrO+tLtpObYvKsgVSSS/VSVZJOX0Oel8eeughV2P2UvQatH3ffvvtJd9b1aX1yotFLPcWG1999ZUrDZYvXz73+eq7rmNSVNtbpUoV36OPPnrZz4erUwr9E/OwF0BSp1ZgtWzGRQvh1UItUOrKj+3gPSCcKK1IPQ9qDU1q1Ptxyy23uHJuUQ1oA0IhRxYAgKvAiBEjXNpHTAZtJbQXX3zRTcVMEIvYIkcWAICrgPLlAwf2JSUffvhhYm8CwhQtsgAAAAhLiRrIalo9jWZUzo5GUcakhIxmu1EejWooaoSlSsWEGimpuo8aua0zUI2EDaTyHp07d3ZFolXyRyNIQ5VPAsKRvhPkx8aOjivkxwJA+EnUQFbFx1WCRYFnTKgkiUq/qGSKEsM1+41qeKrYtUf5P5oWUEWZlTSu9auMiMrUeLp37+5Klag8kqbmUyF01fMDAABA+EgyVQvUIqsad6qjFxXNA61amIEtJw8//LCrQaiamaIWWM1A4hWDV71AFYLu2rWr9e7d281HrTqaqv+pxHJvhhbVAVVxb28+dQAAACRtYTXYS4FmxALham1Vy6woiX3dunWuuLRHhaT1GG8GGt2vKRgD16Pp+1SsObpAVsWvvdlYvABZUx4qPSE20zICAAAgampj1SxwSj1VHJdsAtn9+/db3rx5g27TdU0FqBl//v33Xzd1Y6hl1OrqrUOziWTPnj3SMrovKiNHjgw5xSEAAADi3u7du930yckmkE1MauVV7q1HKQpqxdWbHNVc2wAAAIgdNVAqLVRTNl9KWAWy+fLli1RdQNcVSGqOb81hrUuoZfRYbx1KQVBebWCrbOAyoahKgi4R6bkJZAEAAOJWTFI3w6qObNWqVW3p0qVBty1evNjdLkoZqFixYtAyymXVdW8Z3Z8mTZqgZbZs2WK7du3yLwMAAICkL1FbZFXrctu2bUHltVRWK0eOHK7bXt35e/bssffee8/d36lTJ1eNoFevXta+fXv7+uuv7aOPPnKVDDzq/m/Tpo1VqlTJKleubGPHjnVlvtq1a+fuz5Ytmz322GNuOT2PWlNV0UBBLBULAAAAwkeiBrI//PCDqwnr8XJQFYiqqPu+fftcS6mnaNGiLmhVHdjXXnvNJQBPnjzZVS7wNG/e3A4dOmQDBw50g7c0b7NKcwUOABszZowbBaeJEFSJQI8fP358gr1uAAAAJKM6suGYiKzWXQ36IkcWAAAg4WOssMqRBQAAADwEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEupE3sDAACXZ9++fe4S1/Lnz+8uAJDUEcgCQJiaNGmSDRkyJM7XO2jQIBs8eHCcrxcA4hqBLACEqSeeeMIaNmwY7TKnTp2y6tWru79XrlxpGTJkuOR6aY0FEC4SPZAdN26cvfzyy7Z//34rV66cvfHGG1a5cuWQy547d85Gjhxp7777ru3Zs8dKlChhL730kt13333+ZYoUKWI7d+6M9NinnnrKPZfceeedtmLFikg/CBMnTozz1wcA8SUmKQAnTpzw/12+fHnLlCkTHwiAZCNRB3vNmjXLevTo4bqx1q9f7wLZOnXq2MGDB0Mu379/f9eVpmB306ZN1qlTJ2vSpIn9+OOP/mX+97//+fPGdFm8eLG7vVmzZkHr6tixY9Byo0aNiudXCwAAgLiUwufz+SyRVKlSxW699VZ788033fWLFy9aoUKFrGvXrta7d+9IyxcoUMD69etnnTt39t/WtGlT11U2Y8aMkM/RrVs3++yzz2zr1q2WIkUKf4usWibGjh172dt+7Ngxy5Ytmx09etSyZs162esBgPikFtnMmTO7v48fP06LLIAkLzYxVqK1yJ49e9bWrVtntWvX/r+NSZnSXV+9enXIx5w5c8bSp08fdJuCWOV9RfUcCnDbt2/vD2I977//vuXKlctKly5tffr0sZMnT0a7vXpuvbGBFwAAAFyFObKHDx+2CxcuWN68eYNu1/XNmzeHfIzSDkaPHm133HGHFS9e3JYuXWpz58516wll3rx5duTIEWvbtm3Q7S1btrTChQu7Ft6ff/7Znn/+eduyZYtbV1SUmxsfo4MBAAAQpoO9YuO1115zua0lS5Z0LawKZtu1a2dTp04NufyUKVOsbt26LmAN9Pjjj/v/LlOmjBssUatWLdu+fbtbZyhqtVU+r0ctskqDAAAAQOJItNQCdeunSpXKDhw4EHS7rufLly/kY3Lnzu1aWZXzpcoEarlV7lexYsUiLav7lyxZYh06dIhRrq5s27YtymXSpUvn8jQCLwAAALgKA9m0adNaxYoVXXqAR4O9dL1q1arRPlZ5sgULFrTz58/bnDlzrFGjRpGWmTZtmuXJk8fq169/yW3ZsGGD+5/aiQAAAOEjUVML1FXfpk0bq1SpkqsdqyoCam1VuoC0bt3aBazKT5U1a9a4+rGqOKD/NfOMgt9evXoFrVe3KZDVulOnDn6JSh+YOXOm1atXz3LmzOlyZLt37+7ybsuWLZuArx4AAABhG8g2b97cDh06ZAMHDnQTIihAXbRokX8A2K5du1wlA8/p06ddLdkdO3a4lAIFo9OnT7fs2bMHrVcpBXqsqhWEagnW/V7QrDxXlfDSegEAABA+ErWObDijjiyAcEAdWQDhJizqyAIAAABXgkAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGEpUevIApdj37597hLXNLMbs7sBABA+CGQRdiZNmmRDhgyJ8/UOGjTIzRYHAADCA4Esws4TTzxhDRs2jHaZU6dOWfXq1d3fK1eutAwZMlxyvbTGAgAQXghkEXZikgKg2Yw8mvo4U6ZMCbBlAAAgITHYCwAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYSl1Ym8AAMTGQ7Oe5A2LhfOnz/n/bvXxM5Y6fRrev1j4qPkE3i8gCaNFFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhKdGrFowbN85efvll279/v5UrV87eeOMNq1y5cshlz507ZyNHjrR3333X9uzZYyVKlLCXXnrJ7rvvPv8ygwcPtiFDhgQ9Tstt3rzZf/306dPWs2dP+/DDD+3MmTNWp04dGz9+vOXNm9eSqgY95yf2JoSV8+dO+/9+sM9nljpN+kTdnnCz4NVGib0JAAAk7RbZWbNmWY8ePWzQoEG2fv16F8gqqDx48GDI5fv372+TJk1ywe6mTZusU6dO1qRJE/vxxx+Dlrv55ptt3759/svKlSuD7u/evbstWLDAZs+ebStWrLC9e/faAw88EK+vFQAAAMkokB09erR17NjR2rVrZ6VKlbKJEydaxowZberUqSGXnz59uvXt29fq1atnxYoVsyeffNL9/eqrrwYtlzp1asuXL5//kitXLv99R48etSlTprjnvvvuu61ixYo2bdo0W7VqlX3//ffx/poBAAAQ5oHs2bNnbd26dVa7du3/25iUKd311atXh3yM0gDSpw/uIs6QIUOkFtetW7dagQIFXLD7yCOP2K5du/z36TmVohD4vCVLlrTrrrsuyuf1nvvYsWNBFwAAAFyFgezhw4ftwoULkfJSdV35sqEo7UAtqQpUL168aIsXL7a5c+e69AFPlSpV7J133rFFixbZhAkT7I8//rAaNWrYf//95+7XutOmTWvZs2eP8fOKcnOzZcvmvxQqVOgK3wEAAABcNVULXnvtNbvhhhtcC6qC0S5duri0BLXkeurWrWvNmjWzsmXLusB34cKFduTIEfvoo4+u6Ln79Onj0hK8y+7du+PgFQEAACDsAlnlraZKlcoOHDgQdLuuK681lNy5c9u8efPsxIkTtnPnTleJIHPmzC6FICpqeb3xxhtt27Zt7rrWrbQGBbcxfV5Jly6dZc2aNegCAACAMAlkf/vtN1dhQIOkihcvbvnz53ctn23atLGZM2e6PNKYUouqBlotXbrUf5vSBXS9atWq0T5WebIFCxa08+fP25w5c6xRo6hLBR0/fty2b9/utlX0nGnSpAl63i1btrg82ks9LwAAAMIskFVpLA2OqlChghtYpTzUbt262bBhw+zRRx81n89n/fr1cwOsVNc1pgGtSm+9/fbbri6sgmRVIVBrq9IFpHXr1q5L37NmzRqXE7tjxw779ttvXf1YBb+9evXyL/Pss8+6klp//vmnq0Sg8lxq+W3RooW7X/mtjz32mHvuZcuWucFfej4Fsbfddlts3z8AAAAk5QkRmjZtas8995x9/PHHkQZJBdKof+WxqhyWymRdSvPmze3QoUM2cOBAN9CqfPnybpCWNwBMraSB+a+ayEC1ZBXIKqVApbdUkitwm/766y8XtP79998uFaF69equrJb+9owZM8atV68rcEIEAAAAJLNA9vfff3fd8ZeiVk1dVN4qpjRgS5dQli9fHnS9Zs2abiKE6Gi2rktRaoJmFNMFAAAAyTi1IKogVi2ksVkeAAAASLSqBcpJVW6sBlupe1/d/DJgwAA3YxYAAACQJAPZF154wU04MGrUKFd5wFO6dGmbPHlyXG8fAAAAEDeB7HvvvWdvvfWWm/pV1QA85cqVc3VdAQAAgCQZyO7Zs8euv/76kCkHsRnkBQAAACRoIFuqVClXwzUileZSnVkAAAAgyZTfCqSar5rJSy2zaoXVBAWaGUspB5999ln8bCUAAABwpYGspoNdsGCBDR061DJlyuQC21tuucXdds8998R2dQAAAFds37597hLXNMW9N809kkEgKzVq1LDFixfH/dYAAABchkmTJtmQIUPi/L0bNGiQDR48mM8kOQWycvbsWTt48KBLLwh03XXXxcV2AQAAxNgTTzxhDRs2jHaZU6dOuanrZeXKlZYhQ4ZLrpfW2GQWyG7dutXat29vq1atCrrd5/NZihQp7MKFC3G5fQAAAHGSAnDixAn/3+XLl3cpkrjKAtm2bdta6tSp3cAu7TAKXgEAAIAkH8hu2LDB1q1bZyVLloyfLQIu4fTxf+zMiX+jXeb8+bP+v48e/MNSp/6/Weiiki7TNZY+cw7efwAAkmsgqzqyhw8fjp+tAWJg589f2tbvZ8X4vVo9q0+MlrvhtuZW4vYWfAYAACTXQPall16yXr162YgRI6xMmTKWJk2aoPuzZs0al9sHRFK4bB3LV7xynL8zapEFAADJOJCtXbu2+79WrVpBtzPYCwlF3f+kAAAAgFgHssuWLeNdAwAAQPgFsjVr1oyfLQEAAADie0KEI0eO2Nq1a0NOiNC6devLWSUAAAAQv4HsggUL7JFHHrHjx4+7gV2BdWT1N4EsAAAAEkLK2D6gZ8+ebmYvBbJqmf3333/9l3/++Sd+thIAAAC40hbZPXv22NNPP20ZM2aM7UMBAHHo1L8n7PSRk9Euc+HMef/fR/48bKnSXfqwnz57RstwDVN3AkiGgWydOnXshx9+sGLFisXPFgEAYmTHkk22ac66GL9bywbPj9FypZpWtJub3cqnACD5BbL169e35557zjZt2hRyQoSGDRvG5fYBAKJQrHYpK1CpSJy/P2qRBYBkGch27NjR/T906NBI92mw14ULF+JmywAA0VL3PykAAK5msQ5kI5bbAgAAAMKiakGg06dPx92WAAAAAPEZyCp1YNiwYVawYEHLnDmz7dixw90+YMAAmzJlSmxXBwAAACRMIDt8+HB75513bNSoUZY2bVr/7aVLl7bJkydf3lYAAAAA8R3Ivvfee/bWW2+52b1SpUrlv71cuXK2efPm2K4OAAAASJhAVhMiXH/99SEHgZ07d+7ytgIAAACI70C2VKlS9u2330a6/eOPP7YKFSrEdnU2btw4K1KkiKVPn96qVKlia9eujXJZBcoq+1W8eHG3vFqBFy1aFLTMyJEj7dZbb7UsWbJYnjx5rHHjxrZly5agZe68805XKizw0qlTp1hvOwAAAMKo/NbAgQOtTZs2rmVWrbBz5851gaJSDj777LNYrWvWrFnWo0cPmzhxogtix44d62YO0/oUhEbUv39/mzFjhr399ttWsmRJ+/LLL61Jkya2atUqfxC9YsUK69y5swtmz58/b3379rV7773XTeCQKVOmoHq4gbVwmXIXAAAgmbfINmrUyBYsWGBLlixxgaEC299++83dds8998RqXaNHj3YBZbt27VxLrwJaBZRTp04Nufz06dNdYFqvXj03Re6TTz7p/n711Vf9y6iFtm3btnbzzTe7FlsNTNu1a5etWxc8jaOeJ1++fP5L1qxZY/tWAAAAIJxaZKVGjRq2ePHiK3ris2fPuuCyT58+/ttSpkxptWvXttWrV4d8zJkzZ1xKQaAMGTLYypUro3yeo0ePuv9z5MgRdPv777/vWncVxDZo0MCVD4uuVVbPrYvn2LFjMXiVAAAASDItskor+Oabb674iQ8fPuxq0ubNmzfodl3fv39/yMco7UCtuFu3bnVpDQqmldqwb9++kMtrmW7dulm1atVceTBPy5YtXRC7bNkyF0irpffRRx+NdnuVe5stWzb/pVChQpf1ugEAAJBILbJq4VSraeHChV1KgAJbTY6QEF577TWXiqD8WA3Q0qAvbUNUqQjKld24cWOkFtvHH3/c/3eZMmUsf/78VqtWLdu+fbtbZygKeJXPG9giSzALAAAQRi2y8+bNcwO9lJ+qwVqqOFC3bl1XtSA25bdy5crl6tAeOHAg6HZdV3d/KLlz53bPf+LECdu5c6erW6vZxZQvG1GXLl3c4DO1ul577bXRbosGmsm2bduiXCZdunQujzbwAgAAgDAKZL2AUq2TP/30k61Zs8bVlW3VqpUVKFDAunfv7rr+L0WzglWsWNGWLl0alAqg61WrVo32scqTVSuwqhLMmTPHDUDz+Hw+F8R+8skn9vXXX1vRokUvuS0bNmxw/6tlFgAAAMk4kPUoN1V5qrqodVUVBH755RdXgWDMmDGXfLyCYZXSevfdd13lA7XyqrVV6QLSunXroMFgCpqVE7tjxw5Xy/a+++5zwW+vXr2C0gmU/zpz5kxXS1b5trqcOnXK3a/0gWHDhrmBZn/++ad9+umn7nnuuOMOK1u27JW8HQAAAEjKObJKH1DwN23aNPvqq69c8KcBVRpA5XW3qzW0ffv2rnU2Os2bN7dDhw65El4KNsuXL+/KZ3kDwFQ2S5UMPKdPn3a1ZBXIKqVAgbMGamXPnt2/zIQJE/yTHgTS9qosl1qCVTpMNWsVNCvPtWnTpm69AAAASMaBrLrf1QraokULNwuXgs+I7rrrrqDgMjpKA9AllOXLlwddr1mzppvYIDpKLYiOAldNmgAAAICrLJBVykCzZs0i1XMNpCD2jz/+uNJtAwAAAOIukNWgLs9ff/3l/r9UVQAAAAAg0Qd7Ka1g6NChblIA1ZLVRS2wGkCl+wAAAIAk2SLbr18/mzJlir344otuxizRhAODBw92g7GGDx8eH9sJAAAAXFkgq1JZkydPtoYNG/pvU+UC1XV96qmnCGQBAACQNFML/vnnHzdFbES6TfcBAAAASbJFtly5cvbmm2/a66+/HnS7btN9AAAgYXzXqClvdSycOn/e//fqh1pahtSxDoOuatXmz7GkJtaf4KhRo6x+/fpuUgFvKtnVq1fb7t27beHChfGxjQAAAMCVpxZoUoLff//dmjRpYkeOHHGXBx54wLZs2WI1atSI7eoAAACAy3JZbeoFChRgUBcAAADCL5BVma2ff/7ZDh48GKl2bGA1AwAAACDJBLKLFi2y1q1b2+HDhyPdlyJFCrtw4UJcbRsAAAAQdzmyXbt2tWbNmtm+fftca2zghSAWAAAASTaQPXDggPXo0cPy5s0bP1sEAAAAxEcg++CDD9ry5ctj+zAAAAAgcXNkNfGBUgu+/fZbK1OmjKVJkybo/qeffjoutw8AAACIm0D2gw8+sK+++srSp0/vWmY1wMujvwlkAQAAkCQD2X79+tmQIUOsd+/eljJlrDMTAAAAgDgR60j07Nmz1rx5c4JYAAAAhFcg26ZNG5s1a1b8bA0AAAAQX6kFqhU7atQo+/LLL61s2bKRBnuNHj06tqsEAAAA4j+Q/eWXX6xChQru740bNwbdFzjwCwAAAEhSgeyyZcviZ0sAAACAWKDsAAAAAJJvINupUyf766+/YrRCDQR7//33r3S7AAAAgCtPLcidO7fdfPPNVq1aNWvQoIFVqlTJChQo4CZF+Pfff23Tpk22cuVK+/DDD93tb731VkxWCwAAAMRvIDts2DDr0qWLTZ482caPH+8C10BZsmSx2rVruwD2vvvuu/ytAQAAAOJ6sFfevHndrF66qBV2165ddurUKcuVK5cVL16cigUAAABI2lUL5JprrnEXAAAAILFQtQAAAABhiUAWAAAAYSnRA9lx48ZZkSJFXAWEKlWq2Nq1a6Nc9ty5czZ06FCXk6vly5UrZ4sWLYr1Ok+fPm2dO3e2nDlzWubMma1p06Z24MCBeHl9AAAASIaBrGrO9ujRwwYNGmTr1693gWmdOnXs4MGDIZfv37+/TZo0yd544w1XOUH1bZs0aWI//vhjrNbZvXt3W7Bggc2ePdtWrFhhe/futQceeCBBXjMAAAASOJBV7diJEyfasWPH4uipzUaPHm0dO3a0du3aWalSpdz6M2bMaFOnTg25/PTp061v375Wr149K1asmD355JPu71dffTXG6zx69KhNmTLFLXf33XdbxYoVbdq0abZq1Sr7/vvv4+y1AQAAIIkEsmrZ7NWrl+XPn99atWply5cvv6InPnv2rK1bt87Vn/VvTMqU7vrq1atDPubMmTMuXSBQhgwZ3GQMMV2n7leKQuAyJUuWtOuuuy7K5/WeW0F84AUAAABhEMiqFXP//v0u/3T37t1Wq1Ytu/76623EiBG2Z8+eWD/x4cOH7cKFC64+bSBd1/OEohQBtaRu3brVLl68aIsXL7a5c+favn37YrxO/Z82bVrLnj17jJ9XRo4cadmyZfNfChUqFOvXDAAAgETKkVUXfdu2bV1r7O+//24PP/ywy1nVwKr69eu7oDI+vfbaa3bDDTe4FlQFo5ptTCkEanWNb3369HFpCd5FwTwAAAASz2VHgKoc8MILL9iff/5pH3zwgcsvbdasWYwfrxnBUqVKFalagK7ny5cv5GNy585t8+bNsxMnTtjOnTtt8+bNruqA8mVjuk79rxSEI0eOxPh5JV26dJY1a9agCwAAABLPFTVlqmVWLbS6qEtfg6xiSi2qGmi1dOlS/21KF9D1qlWrRvtY5ckWLFjQzp8/b3PmzLFGjRrFeJ26P02aNEHLbNmyxU25e6nnBQAAQBhPUfvXX3/ZO++84y47duywGjVq2Pjx411rrAZexYbKZLVp08ZVRKhcubKNHTvWtbYqXUBat27tAlblp8qaNWtcPm758uXd/4MHD3aBqgahxXSdym997LHH3HI5cuRwLatdu3Z1Qextt90W27cDAAAAST2Q/eijj1wJK7Vk5smTxwWL7du3dwO+Llfz5s3t0KFDNnDgQDfQSgGqJjjwBmuplTQw/1UTGaiWrAJopRSo9JZKcgUO3LrUOmXMmDFuvZoIQdUINIhMwTgAAADCRwqfz+eLyYLqtteALrVmKoBMiAFWSZnKb6l1VwO/EiJftkHP+fH+HIBnwav/L10nKXpo1pOJvQm4inzUfIIlZd81aprYmxBWTp0/b/cs/NT9vbheQ8uQOtYd01e1avPnJLkYK3VsUgrUEgsAAAAkBTFuVlW5qbvuuivkRACKmHXfTz/9FNfbBwAAAFxZIKtpYBWshmriVfPvPffcYy+//HJMVwcAAAAkTCCrigGNGzeO8v4GDRrYqlWrrmxrAAAAgBiKcY6syl1lyZIlyvtVRcCbKhYAACAhHT59yv4+fTraZc5cuOD/e+vRI5YuVapLrjdn+vSWK33syosiCQaymlVLEwcULVo05P2aZUszawEAACS0+X/+YdN+3xzj5Z/67psYLdfuxpL2WMlSV7BlSBKBbO3atW348OF23333RbpPFbx0n5YBAABIaI2KFLXq+fLH+XrVIotkEMhqIgJN71qlShXr2bOnlShRwt8Sq4Fgv//+u5vtCwAAIKGp+58UgKtPjAPZ4sWL25IlS6xt27b28MMPW4oUKfytsaVKlbLFixdf0SxfAAAAQGzEakqLSpUq2caNG23Dhg22detWF8TeeOONbhpYAAAAICFd1txsClwJXgEAABAWdWQBAACApIRAFgAAAGGJQBYAAABhiUAWAAAAV0cgW6RIERs6dKjt2rUrfrYIAAAAiI9Atlu3bjZ37lwrVqyY3XPPPfbhhx/amTNnYrsaAAAAIOEDWdWRXbt2rd10003WtWtXy58/v3Xp0sXWr19/ZVsDAAAAxHeO7C233GKvv/667d271wYNGmSTJ0+2W2+91dWXnTp1qpssAQAAAEhSEyLIuXPn7JNPPrFp06a56Wlvu+02e+yxx+yvv/6yvn37uulsZ86cGbdbCwAAAFxuIKv0AQWvH3zwgaVMmdJat25tY8aMsZIlS/qXadKkiWudBQAAAJJMIKsAVYO8JkyYYI0bN7Y0adJEWqZo0aL28MMPx9U2AgAAAFceyO7YscMKFy4c7TKZMmVyrbYAAABAkhnsdfDgQVuzZk2k23XbDz/8EFfbBQAAAMRtINu5c2fbvXt3pNv37Nnj7gMAAACSZCC7adMmV3orogoVKrj7AAAAgCQZyKZLl84OHDgQ6fZ9+/ZZ6tSXXc0LAAAAiN9A9t5777U+ffrY0aNH/bcdOXLE1Y5VNQMAAAAgIcS6CfWVV16xO+64w1UuUDqBaMravHnz2vTp0+NjGwEAAIArD2QLFixoP//8s73//vv2008/WYYMGaxdu3bWokWLkDVlAQAAgPhwWUmtqhP7+OOPx/3WAAAAAPGVI+tRhYJFixbZp59+GnSJrXHjxlmRIkUsffr0VqVKFVu7dm20y48dO9ZKlCjhWoILFSpk3bt3t9OnT/vv17pSpEgR6RJYGuzOO++MdH+nTp1ive0AAAAIs5m9mjRpYr/88osLAH0+n7tdf8uFCxdivK5Zs2ZZjx49bOLEiS6IVZBap04d27Jli+XJkyfS8jNnzrTevXvb1KlT7fbbb7fff//d2rZt65579OjRbpn//e9/QduwceNGNwitWbNmQevq2LGjDR061H89Y8aMsX0rAAAAEE4tss8884wVLVrUzfCl4O/XX3+1b775xipVqmTLly+P1boUfCqgVI5tqVKlXECrdSpQDWXVqlVWrVo1a9mypWt5VQUF5eYGtuLmzp3b8uXL57989tlnVrx4catZs2bQuvQ8gctlzZo1tm8FAAAAwimQXb16tWvJzJUrl6VMmdJdqlevbiNHjrSnn346xus5e/asrVu3zmrXrv1/G5Mypbuu5whFrbB6jBe4qnV44cKFVq9evSifY8aMGda+fXt/i7FHg9X0GkqXLu3KiZ08eTLa7T1z5owdO3Ys6AIAAIAwSi1Qt32WLFnc3woE9+7d63JWVY5LKQExdfjwYbcule0KpOubN28O+Ri1xOpxCpyV0nD+/HmX26oatqHMmzfP1bhV+kHE9Wh7CxQo4CowPP/8827b586dG+X2KlAfMmRIjF8fAAAAklggqxZMld1SeoHyWkeNGmVp06a1t956y4oVK2bxSakLI0aMsPHjx7vn3rZtm0t1GDZsmA0YMCDS8lOmTLG6deu6gDVQYMWFMmXKWP78+a1WrVq2fft2l4YQilptlc/rUYusBpsBAAAgTALZ/v3724kTJ9zfSjG4//77rUaNGpYzZ043eCum1JqbKlWqSNPd6rpyVkNRsNqqVSvr0KGDPwjVtigw7devn0tN8OzcudOWLFkSbSurR0GxKDCOKpDV1Ly6AAAAIEwDWVUV8Fx//fUuDeCff/6xa665JlIeanTUiluxYkVbunSpNW7c2N128eJFd71Lly4hH6M81sBgVRQMi1c9wTNt2jRX+aB+/fqX3BbNTCZqmQUAAEAyDGTPnTvn6rcq8FOKgSdHjhyX9eTqqm/Tpo2reFC5cmVXfkstrKpiIK1bt3YziSk/VRo0aOAqHWhqXC+1QK20ut0LaL2AWIGs1p06dfBLVPqAynhpgJhakZUjq1q0mna3bNmyl/U6AAAAkMQDWU1Be91118WqVmx0mjdvbocOHbKBAwfa/v37rXz58m6SBW8A2K5du4JaYJXWoFZf/b9nzx5XaktB7PDhw4PWq5QCPVbVCkK1BOt+L2hWnmvTpk3dOgEAABA+Uvgi9slfggZQKe90+vTpl90SmxxosFe2bNns6NGjCVKDtkHP+fH+HIBnwauNkuyb8dCsJxN7E3AV+aj5BEvKvmvUNLE3AVeRavPnJLkYK9Y5sm+++abr0lclAJWwypQpU9D969evj/0WAwAAALEU60DWG5gFAAAAhFUgO2jQoPjZEgAAACA+p6gFAAAAwrJFVlUEoqsXG1cVDQAAAIA4DWQ/+eSTSLVlf/zxR3v33XdtyJAhsV0dAAAAkDCBbKNGkcvyPPjgg3bzzTe7KWofe+yxy9sSAAAAIDFyZG+77TY3vSwAAAAQNoHsqVOn7PXXX3fTyQIAAABJMrXgmmuuCRrspYnB/vvvP8uYMaPNmDEjrrcPAAAAiJtAdsyYMUGBrKoY5M6d26pUqeKCXAAAACBJBrJt27aNny0BAAAA4jNHdtq0aTZ79uxIt+s2leACAAAAkmQgO3LkSMuVK1ek2/PkyWMjRoyIq+0CAAAA4jaQ3bVrlxUtWjTS7YULF3b3AQAAAEkykFXL688//xzp9p9++sly5swZV9sFAAAAxG0g26JFC3v66adt2bJlduHCBXf5+uuv7ZlnnrGHH344tqsDAAAAEqZqwbBhw+zPP/+0WrVqWerU/+/hFy9etNatW5MjCwAAgKQbyKZNm9ZmzZplL7zwgm3YsMEyZMhgZcqUcTmyAAAAQJINZD033HCDuwAAAABhkSPbtGlTe+mllyLdPmrUKGvWrFlcbRcAAAAQt4HsN998Y/Xq1Yt0e926dd19AAAAQJIMZI8fP+7yZCNKkyaNHTt2LK62CwAAAIjbQFYDuzTYK6IPP/zQSpUqFdvVAQAAAAkz2GvAgAH2wAMP2Pbt2+3uu+92ty1dutQ++OADmz179uVtBQAAABDfgWyDBg1s3rx5rmbsxx9/7MpvlS1b1pYsWWI1a9aM7eoAAACAhCu/Vb9+fXeJaOPGjVa6dOnL2xIAAAAgPnNkI/rvv//srbfessqVK1u5cuWudHUAAABA/AayKrWlaWnz589vr7zyisuX/f777y93dQAAAED8pRbs37/f3nnnHZsyZYortfXQQw/ZmTNnXM4sFQsAAACQJFtkNcirRIkS9vPPP9vYsWNt79699sYbb8Tv1gEAAABXGsh+8cUX9thjj9mQIUPcQK9UqVJZXBg3bpwVKVLE0qdPb1WqVLG1a9dGu7yCaAXUqpZQqFAh6969u50+fdp//+DBgy1FihRBl5IlSwatQ8t37tzZcubMaZkzZ3bT7h44cCBOXg8AAACSWCC7cuVKN7CrYsWKLuB888037fDhw1f05JpYoUePHjZo0CBbv369GyxWp04dO3jwYMjlZ86cab1793bL//bbby7FQevo27dv0HI333yz7du3z3/RtgdS8LtgwQJX93bFihWudVm1cQEAAJAMA9nbbrvN3n77bRcYPvHEE24mrwIFCtjFixdt8eLFLsiNrdGjR1vHjh2tXbt2Lsd24sSJljFjRps6dWrI5VetWmXVqlWzli1bulbce++911q0aBGpFTd16tSWL18+/yVXrlz++44ePeoCYD23BqgpMJ82bZpbN4PVAAAAknHVgkyZMln79u1dK+cvv/xiPXv2tBdffNHy5MljDRs2jPF6zp49a+vWrbPatWv/38akTOmur169OuRjbr/9dvcYL3DdsWOHLVy40OrVqxe03NatW12QXaxYMXvkkUds165d/vv0+HPnzgU9r1IPrrvuuiifVzSoTQPcAi8AAAAI0zqyylUdNWqU/fXXX26K2thQWsKFCxcsb968QbfruqojhKKW2KFDh1r16tUtTZo0Vrx4cbvzzjuDUguU9qDKCosWLbIJEybYH3/8YTVq1PC3GGvdadOmtezZs8f4eWXkyJGWLVs2/0X5uQAAAAjjCRFEA78aN25sn376qcWn5cuXu6lxx48f73Jq586da59//rkNGzbMv0zdunWtWbNmbtpc5duqxfbIkSP20UcfXdFz9+nTx6UleJfdu3fHwSsCAABAgk5RGxeUt6oAOGK1AF1XXmsoAwYMsFatWlmHDh3c9TJlytiJEyfs8ccft379+rnUhIjU8nrjjTfatm3b3HWtW2kNCm4DW2Wje15Jly6duwAAACAZtcheDnXva6DV0qVL/bdp4JiuV61aNeRjTp48GSlY9cqA+Xy+kI85fvy4bd++3c1AJnpOpSUEPu+WLVtcHm1UzwsAAICkJ9FaZEWlt9q0aWOVKlWyypUruxqxamFVFQPRFLgFCxZ0+anepAyqNlChQgWXC6tWVrXS6nYvoH322Wfd9cKFC7uyWirVpftU3UCU36p6uHruHDlyWNasWa1r164uiFVlBgAAAISHRA1kmzdvbocOHbKBAwe6gVbly5d3g7S8AWBqJQ1sge3fv7+b4ED/79mzx3Lnzu2C1uHDh/uX0cAzBa1///23u18Dw1RWS397xowZ49ariRBUjUC5tMq7BQAAQPhI4YuqTx7RUvktte5q4JdadeNbg57z+USQYBa82ijJvtsPzXoysTcBV5GPmk+wpOy7Rk0TexNwFak2f06Si7ESLUcWAAAAuBIEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEuJHsiOGzfOihQpYunTp7cqVarY2rVro11+7NixVqJECcuQIYMVKlTIunfvbqdPn/bfP3LkSLv11lstS5YslidPHmvcuLFt2bIlaB133nmnpUiRIujSqVOneHuNAAAASGaB7KxZs6xHjx42aNAgW79+vZUrV87q1KljBw8eDLn8zJkzrXfv3m753377zaZMmeLW0bdvX/8yK1assM6dO9v3339vixcvtnPnztm9995rJ06cCFpXx44dbd++ff7LqFGj4v31AgAAIO6ktkQ0evRoF1C2a9fOXZ84caJ9/vnnNnXqVBewRrRq1SqrVq2atWzZ0l1XS26LFi1szZo1/mUWLVoU9Jh33nnHtcyuW7fO7rjjDv/tGTNmtHz58sXjqwMAAECybJE9e/asCy5r1679fxuTMqW7vnr16pCPuf32291jvPSDHTt22MKFC61evXpRPs/Ro0fd/zly5Ai6/f3337dcuXJZ6dKlrU+fPnby5Mlot/fMmTN27NixoAsAAACuwhbZw4cP24ULFyxv3rxBt+v65s2bQz5GLbF6XPXq1c3n89n58+ddbmtgakGgixcvWrdu3VwrrgLWwPUULlzYChQoYD///LM9//zzLo927ty5UW6vcm+HDBly2a8XAAAAySi1ILaWL19uI0aMsPHjx7uBYdu2bbNnnnnGhg0bZgMGDIi0vHJlN27caCtXrgy6/fHHH/f/XaZMGcufP7/VqlXLtm/fbsWLFw/53Gq1VT6vRy2yGmwGAACAqyyQVbd+qlSp7MCBA0G363pUuasKVlu1amUdOnTwB6EaxKXAtF+/fi41wdOlSxf77LPP7JtvvrFrr7022m1RUCwKjKMKZNOlS+cuAAAAuMpzZNOmTWsVK1a0pUuXBqUC6HrVqlVDPkZ5rIHBqigYFqUaeP8riP3kk0/s66+/tqJFi15yWzZs2OD+V8ssAAAAwkOiphaoq75NmzZWqVIlq1y5sqsRqxZWr4pB69atrWDBgi4/VRo0aOAqHVSoUMGfWqBWWt3uBbRKJ1CZrvnz57tasvv373e3Z8uWzdWeVfqA7tcAsZw5c7ocWdWiVUWDsmXLJuK7AQAAgLAJZJs3b26HDh2ygQMHuoCzfPnyrnyWNwBs165dQS2w/fv3d5MX6P89e/ZY7ty5XRA7fPhw/zITJkzwT3oQaNq0ada2bVvXErxkyRJ/0Kw816ZNm7p1AgAAIHyk8Hl98ogVDfZSK6/Ke2XNmjXe370GPefH+3MAngWvNkqyb8ZDs55M7E3AVeSj5v+vcSSp+q5R08TeBFxFqs2fk+RirESfohYAAAC4HASyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAIS4keyI4bN86KFCli6dOntypVqtjatWujXX7s2LFWokQJy5AhgxUqVMi6d+9up0+fjtU6tXznzp0tZ86cljlzZmvatKkdOHAgXl4fAAAAkmEgO2vWLOvRo4cNGjTI1q9fb+XKlbM6derYwYMHQy4/c+ZM6927t1v+t99+sylTprh19O3bN1brVPC7YMECmz17tq1YscL27t1rDzzwQIK8ZgAAACSDQHb06NHWsWNHa9eunZUqVcomTpxoGTNmtKlTp4ZcftWqVVatWjVr2bKla3G99957rUWLFkEtrpda59GjR10ArOXuvvtuq1ixok2bNs2t+/vvv0+w1w4AAIArk9oSydmzZ23dunXWp08f/20pU6a02rVr2+rVq0M+5vbbb7cZM2a4wLVy5cq2Y8cOW7hwobVq1SrG69T9586dc7d5SpYsadddd51b5rbbbgv53GfOnHEXjwJiOXbsmCWEc2dOJsjzAAm5X1+OcyfPJvYm4CqSlL8LcuLcucTeBFxFjiXQ98F7Hp/Pl3QD2cOHD9uFCxcsb968Qbfr+ubNm0M+Ri2xelz16tXdizt//rx16tTJn1oQk3Xu37/f0qZNa9mzZ4+0jO6LysiRI23IkCGRbleeLpDcZBuX2FsAJA3Z2ofuIQSuStmyJejT/ffff5btEs+ZaIHs5Vi+fLmNGDHCxo8f7wZxbdu2zZ555hkbNmyYDRgwIF6fW628yr31XLx40f755x83YCxFihTx+ty4/DM6nWjs3r3bsmbNytuIqxbfBYDvQzhRY6WC2AIFClxy2UQLZHPlymWpUqWKVC1A1/PlyxfyMQpWlUbQoUMHd71MmTJ24sQJe/zxx61fv34xWqf+VwrCkSNHglplo3teSZcunbsEitiqi6RJQSyBLMB3AeC3IXxcqiU20Qd7qXtfA62WLl0a1Mqp61WrVg35mJMnT7qc10AKXL3oPSbr1P1p0qQJWmbLli22a9euKJ8XAAAASU+iphaoq75NmzZWqVIlN3hLNWLVwqqKA9K6dWsrWLCgy0+VBg0auGoDFSpU8KcWqJVWt3sB7aXWqQj/sccec8vlyJHDtdR17drVBbFRDfQCAABA0pOogWzz5s3t0KFDNnDgQDfQqnz58rZo0SL/YC21kga2wPbv39/lo+r/PXv2WO7cuV0QO3z48BivU8aMGePWq4kQVIlAdWaVd4vkRakgqiccMSUEuNrwXQD4PiRXKXwxqW0AAAAAJDGJPkUtAAAAcDkIZAEAABCWCGQBAAAQlghkAQAAkiiVEUXUCGQBAACSmH379lnGjBlt5cqVib0pSRqBLJDMXbhwwV08FCpBUqV9U/sq+yiuZtr/z58/72YbzZMnj3333XeJvUlJGoEskMxpshBd1D2lqZhVixlISoGrR/um9lX9r3rghw8fTtTtAxLjO6H9P3Xq1O7/2rVr2xdffEF6QTQIZIFkbsaMGW5q5kKFCrkJQyZPnmz//fdfYm8WrhJ//PGH3XzzzfbXX39FCl69wNWj/XLEiBF23XXXWalSpdzsjpqdEUhu9D0Ilfuq78SxY8ds+vTp7lhdo0YN+/nnn90ET0iCM3sBuHw6CAbOfCd79+51t6lLSpYvX+4Ohg0bNrSHHnrIvvzyS3vzzTftn3/+sV69evnP/oH4omnBNQ24/o8YvKrVtV+/fpYpUyY34+Lnn39us2fPtlGjRrlpwzUro27PlSuXPfroo3xICPtjtvb/wEtEW7dutfvvv9/9XbNmTVu3bp0LbDdt2mQFChRIhK1O+miRBZI4L18wsAtWFLAGntErp+rOO++0wYMH+2+bNm2alSxZ0k3Ve9NNN7mAVoMH3njjDTt16hRBLOKc9snAHNccOXJYp06dLEuWLO66pgUfPXq03XHHHfbhhx+66cZvueUWl0ag/fKFF16whx9+2LXKlilTxrXSvv322/QiIOzpmO0Frxs2bHD7+4oVK4KO4wMGDLC8efO6vNi33nrLnegpT1aNEAiNFlkgCZg0aZKlT5/etTp5rVVei6t34PNu97qkOnTo4PKo9COv2/R3o0aN7Ouvv3bLqStX3VFqnW3ZsqUtXbrUzp07Z2XLlrXnn3+eIBZxyttfI/YSyJIlS6xLly62efNmf862fqjTpUvnWmCzZ89up0+fth9//NHmz59vI0eOdN2puv3uu+92+6+WBZKSr776yubMmWO33XabtWvXzn8Sp2N2qO/Bp59+6hokfvrpJ5fypUYFncD16dPH9Vro8WqRbdy4seuFkAceeMD1rC1evNjOnj1radOmTYRXmrTRIgskIu9MfMuWLe6gFsg7EOoH/YcffrD333/fta7u3LnTBQK5c+f2B62ee+65xy1/8OBBu/baa10rlgJYtYrpwKmDpA6KCioUOAOxtWPHDve/flQj7q/qFVi4cKFrSQrM6VNr7O+//+5+wHXCVaFCBcucObM98sgjLliVI0eOWOXKlV3Lk4IC7afbtm1zuYJ169blBxxJykcffeT206NHj7r92fsO6Nis/0+cOGHbt2+P9BiNU/jll1/csVvHavU+jB8/3v3977//uuO6N8jR64W799577bfffrPdu3cnwitN+ghkgQSmAMA7IKmFVNTV2qxZs6CBL3/++adVqlTJqlWr5u5//fXXXSurAlm577773EAa1Rr0Wm3LlSvnAuJly5a568WLF3fBr7qnFOTmzJnT3a7cQ+UjCqWOEFMKKq+//nr3d8SWoQ8++MCKFSvm0ggmTpzoclw/++wzd1+JEiXc4xYsWOCuK21A++b69ev9j9d+W7RoUbvmmmvssccec+kGeg6lwMybN88FtkBi846XOh4rl1XpMeXLlw9qdVVKjNIDdExX75eO0aIeNwW5Ok7rOyA9e/Z0Aevq1atdg0PhwoVdw4Z4vwc6vuu3QieCiIxAFohDlwoKdcatQVdt27Z119VdqlZZ5Q2qe8n74ZdXX33VHcCU5K8BW3qcWrz+97//uedRzqsCU3VvidajA6FSB1SuRdq0aWMnT550B1TlYqlrV4NnNBLca1ljsBci0r4Uqp6rRlAruFQ3qFpP1e2vEyvt1zrZUjforl27XDeoltUJlIq5q9X19ttv9588aT+tXr26ffPNN/7vTdasWa1Hjx7u8U2aNHEtVgpetQ7tr9r3gcT6LkR04403ulZS7bPq4VLvl1pghw4d6noQFHQ+8cQTNnfuXHv22WfdY2699VaXMqDeCE/BggUtf/78LmdW34NatWq5v5Vy41H6gnzyyScJ8prDjg/AFdu3b59v2bJl7u/z58+7/y9cuOA7d+5cpGVHjRrly5cvn69r166+YsWK+QYMGOBuz5s3r+/ZZ5/1nThxwl2/7rrrfG+88UbQY+vWreu77777fMePH3fPU79+fd8DDzzgv/+///7z3Xvvvb4KFSr4Ll686G5bu3atr0mTJr5y5cr5MmfO7O57/fXXfYcPH+aTR6w0a9bMlyJFCl/hwoV9L730km/Dhg3u9rlz5/oKFizo++mnn/zL7tixw1e9enVf//793fX333/flz59et/Zs2fd9RkzZviyZs3qO3LkiP/7IgsXLvS1bNnSV7p0ad8111zja9CggW/evHm+06dP82kh0Wn/nTlzpvseaH8uX768b9KkSe726dOn+7Jnz+77559//Mt/9NFHbrk//vjDXa9WrZrv8ccf9+/30r17d9/dd9/t+/333931zp07+3Lnzu1r2LChr2rVqr4nn3zSN3bsWF/Pnj39vy/4PwSywBU6efKkr1u3br6mTZtGucyff/7pgl0dqBSw6iBYq1Ytd+DT7dK+fXsXmO7Zs8cdCCtWrOgbOnSou+/UqVPu/7feessd4LZu3equT5s2zZcxY0bfd999565/9dVXvptuusmt/7fffgvahs2bN4cMrHH10UmOfhC94DGir7/+2v146odU+9yBAwfc7du2bXO362Qo0PLly32pU6f2/fvvv/4TKK2/RYsWvkcffdQFodpn06VL51u6dKn/BCt//vwuKBDtm95jtfzevXvj9T0APPoeePueeH8rONVJlAJPNTjo5Ey2bNniTrhSpkzp++abb/yP69ixo/vOqEHB89dff/mKFCniGg/k+eef991+++2+TZs2+ZdZsGCBO27PmjXLXVdDhdbfqlUr38svv+z/jUBopBYAVzhQK0OGDC4N4OOPPw66X/X/lMivXCnlCyp3St1K6iZSgXh1PylnSt2sohlclBul/FmlHGgZ5U0F5iMqz/Dvv/92KQKiFIXSpUtb+/btXT5t9+7dbdy4ce7/iDmMylPUQBtvylpyY5M3DTZ5/PHH3WA/Cfy8vVquEUdWa8CVuvKfeuoply5www03uG59r4ar8lo18ESDVVTb0qOBhdq31J2qdeu74c0mp9w+/a3qGUp78b4nKimkfdLbl72ZjET7v7pbgYQQWB1m1apVLh1L3xcdV7t16+a+S0p1UWqA7ldagY7fXt63UsNEA7WU063xDR6lEWg/13fGG9uggZCBA8FU9UDP7w2gVF1lrf+9995zaQleXfBQKQ4gtQCIlehasXRmvn79eve3WrAefvhhd3b+7bff+n755Rd30eN1tt6mTRtfjRo13LJeV6taoNQ9O2XKlKDWVq/1VVq3bu1aW4cNG+ZaguXQoUOua+vVV18NWhZXN+1npUqV8rVr185dD9xvta8pbeWJJ55w+5vXgqS0lvHjx/tbnuTXX391+9y6devc9e3bt7sUlfnz5we1XimNQL0Su3fvdtf379/vu+GGG3w9evTwt7g+/fTTrgvV2x5v3wcS69it1k99BzZu3OirXbu2a2XVsfq9995zx+MlS5b4vxuNGjVyPWlqkfVSAG699VbXEyFa9uabb3bfIY/WpZ4H9b553wMd14cPHx7UChxq23SbtjtwOURGagFwmZTz9MUXX/i7j3RAUw6rLF682P3Yez/+gXlNOjhNmDDB5f95P+TeQaxy5cq+Ll26uIOr3HHHHb7ixYv7evfu7QKSfv36uZxY5U1Fl+PqdR3j6qHPPGL36JAhQ9z+412XH3/80eX16aIfYv3wKq/ay9k7c+aM79ixY+7k6K677vLlypXLBbIDBw70/6AraFUQLF66itJatC59D0aOHOm6T2vWrBmUIqB1A4np6NGj/lQtWblypTtWX3/99S4PVfu+aP9W0Bq4j3/55ZdurMEHH3zg3+eV/6q0LS8l5rnnnvNlypTJ9/bbb/tWr17t0g2UF6sGB48aN7xjfKCoGkkQPVILgBiMUJXjx4+76V3VNaTZV9R9r6oAovQAlWJRrUxRKoEqCqhbSLUGhwwZ4sq1qB6surHUxar/vdQBr9tXsx39+uuv/q4p1Y7VCHF1D+v5O3bs6MobqZvKK+niCUwXiDiHPZInfd7e/upNeRm4D6gygKpTBJZoU2krdVtq8gHtz99++61LCVDJLM/AgQNdLVhNkam6rtrnlBqjygEqk1W/fn1XdkhdpOqGVWUNlXfzisOrkoYqGkyZMiUoRYBi7kho+n6oLquqB6jkVZEiRVzKjSbkkEKFClmdOnXcsV91jb0Z6NSdrwoagWlkOq4rdcCr86rvh75XXlkspcRoMg9VMVClGX0n9JswYsQI/wQH+n7qe6n0gYhCTaKAGLhEoAskO2ol1cAqtZrG9CxYy6grSKO11TKlM3d1F2nwitcyqq7WLFmy+EeeqoqBulJ79erlnu/aa691rVQamKUWAbW+ajCM17qrlq5Fixa5dWiwTXTbohayqVOnxtE7gqTmclpmNLhPPQRe1QtRN78GB77zzjv+1th69eq5fVOtQtov1Yqq/Un7qWjfS5MmjWt98mi0tHoQlFYgBw8edC26asXSY5XyEjjABYhv6nG6VK+TegDuv/9+Vx1GPV2qnPHZZ5/57rzzTl/RokV9u3btcj0Vffr0cd+TQLNnz/alTZvWX4HA69FQxZnJkyf7l9P34KGHHoo0kJYBWgmHQBZXDe9ApB9wjbpW96cEHgyV46RR2bpoVLVHP9LqQgrMfdJoVgWy3qjrn3/+2f2we6NTI3anKtewZMmSvjfffNNffqhQoUKuioG6otRdpW30yrREpAOlV4JIJbjeffddcqeSMS83LrpKEzqJUr60cvn0Q3zjjTe6QNU7EVL3pX7IGzdu7K4rgNWy2pd1UvbII4+4H/edO3f616kTLQWnXnep9uvbbrvN3aa8bY9O2FSB4O+//47HdwGImVB5pDohHDdunNt31ajg0XFUx94XXnjB3wiRIUMGV10m8LulZRQAK+AVNR4UKFDAt2LFCv9yOp4rhSeq72lMAm5cGQJZXJU5UjqDVq3KQKp3qR933acffgWpChZFBy4Fqcp58ijBXwNXmjdv7m+lUp1NL09Wg7EUDKuFTHlXr7zyiq9SpUpBA2k0QGzVqlUx3naS/q8OaiHSfnip2qlqYX3mmWdc65H2Df3gqpVVpdu8H/IxY8b4cubM6a6rdUktUapbGZH2Sy9vr2zZsq6Oq3Jh1Zo1Z84c3+DBg/21koGEyvkO7J3wAkLtpzoBU/6pGiS8AYahjo86ZqdKlcrls4q3Pg241XgDBawaJKv93Guo8MYuqHFBjQ/qPVO+rL5HClqjei4kDhIykOwonym60lKaQUhlhDTdq5eL+v3339u7777rphOcNWuWm0FFZVdefvlll9eqEluaOnPr1q1BZVVUjkUzF4k3e5HmzBblqGqWl7vuusvlCU6aNMnlTmkaTo9mP1Lelbfdl8IsXMkzh8/77L3Zq1TGZ+/evfbOO++42YE061soyvdTDvWDDz7oymGtWbPG9uzZYxs3bnRlrZRzpymO//nnH5d7rX1Y+XnKi9WsWd7zaiYhld3ycrY1JaxyaZWzralnNWPXoEGD7M4770yw9wXJm3KrJapjtZfzrX1Yy2jf1DFV+7L292HDhrnbVRZLedna30MdHzVtsvJgtY+Ll1OucQrbtm1z3znlr1asWNHlgwdS+UTle2v8g3K+9Z1R/ri3fR5mnUtcBLIIe/9/z4L/gBhYEzAi74dbc2Gr9p+mexX9r4EoOnB5VKNVBzhNt1mqVCkXuCrg9ajupQbRKOD4448/LE2aNK5eoK5rIIHWp8FZmsJQUxkq6d8bHBZx+73txtUnsJ6r9inVb9XUrdqHdGKlE65bbrkl5GN18qSTsr59+7r52/UjqxMlrXPZsmX+H3LN3+5Nf/zCCy+4H3btiwoI9IOu2rDaX73537UOncgNHz7cTUULxJUDBw64usQ6qRcdh71jYGBQq+OogkgNINQ+3Lp1a3d///793f6tAVZvv/22W0b7q/b9Q4cORXo+7+RNg730XDpOezWTdfKnOt8awKi63RrQKN4you+KBvfqO6aa3aHoe4vEwy8nwp535u4Frzpr/uijj9yI6lDLin70dfDSpAXewUrLp0+f3n/GrqLXGsGqUd9egWodVGfOnOkOiGvXrnWTE8iiRYvc/zoYqhVNj5WGDRta8+bN3foDR5iH2iYkT95JVmCLu/f30aNHbdq0ae6EZ9SoUa61ScGpTqjKly/vWkU///xza9asWZTr14+5ehBeeukl1xswYcIENzmGvgei9aklVYXbRcGqCq2rIob2U1XfUNWBwP0WiC86pmbLls1f4UXHXB0DFVQGHgvHjBljHTp0cBNyqOKLqmzoe6NescaNG7tGhGeeecYFqTrpUzDptfIGUlCq6gHqrdAEB5p0RsGvfiM6d+7sltFJ3EMPPWQLFy6MsoWYSWSSsERKaQCipNxT1WUN5A16CZWXpJzXTz/91PfJJ5+4guzKY9J0f8rvCxzEEkg5UJo6U7mwyrtSjpRGans5gF4eldYROEhAUxWqLqcqFmiQlmptKi9Wkx8EPi4QtQERuN+tWbPG/a36qqrTqn21U6dOrtakJjDwBlkp17VBgwb+ASgR931vv1It2CpVqvhv12DGrFmzutw+r6KG9lN9L9gXER+iG8wUahCU9scSJUq4MQSaglX7pgYq6m/v2K9juiq9eJVdRLmwGsyowVuqHqCBjBrMFXE67oh++uknV3VD4xn0GE1IoEobgbVdEb5okUWSo5xStVIF0pm6N4Wlul7VLeTZuXOnyyNU14/yTXWmrlZT3a7Wqoh0xq2z9JIlS7puLrVGaapBdaG++OKLLs1AXb3KfVXKgLpePaq7qRza1157zU0xqLqDarH1agR6+VyBZ/WkDIQ/r0U1qjxm3R6YJxf4+Wsf0r6kuqzqAu3Zs6dr3VFLqKZp1f6nVlQto5Z/5VWL8q3VS6AWpIjrDNyvlGet3gFNTazc1qlTp7rn0OOULyvqllXtS/ZFxIfoalYHdrsrB1WtoeoV0L6vfV25reohUL3t8ePH23PPPeeWVTe+pj4OXLfqdas+t3JiVeNVvQyaTlnHcqUVhEotEPWIFSxY0PU46DuiKWc1JsI7bnuYtjtMJXYkDURsbQqsg+nRqH/NaqXSJyqJoqlfNSOLR2fZOnsPrN2n0dx16tTxbdu2Leg5vFapBQsWuLJCXk1ArU8zEamlQI/LkSOHaxWLOI2m9xwaUa4R4Rrt6rWyIfnTyP9Zs2b5Z8KKyJsZyKOWf1XD0OxZql2sGsIqWaV9VtNgbtq0yffUU0+5ihZqaWrVqpXbtzRlpsrEeeXcomtNVcUN7bfqKejWrZsrF8csWkgIOq6q10r1VL2ShYHHc/WUvfTSS26KVtXIVh1utZCqJ0tl4LypjkW1i/Ud0L4vOv7Wr1/fPx23aDpZlZpTRQGvdrFacTt06OBKGoai707Xrl3dd8y7rpZieiiSB1pkkWgCW7ECc6O83FW1vHp09qzBKpohRUn7OqNWK5OX43rTTTe5ygBezqqoooBabr0qAoEzHolaWpU/qNwp0ehuJftrFLhadpWbqJmJAhP/RaO4NYJVgwTUMtu7d2+Xk4jkS4OvlK+nFiK1JCk3LzAHW/uYWucLFChg9erVc62v3uw/ypNW7qsGXNWuXdvlBOq69lXl7Ok29SJotiHlDap1SjMEKd9a+7RGa+u7otZU5WaHoooCapXVABnlFmpgIrNoISFo31VLqI61ytP+77///MdYHXM1KEvHSOVkq5qGZjnU4NkbbrjB7dMNGjTwL6tBhzqufvHFF+42LafviR7n0XdGAxXVo9G0aVN33NaYB/WMqeU1FD2PKnDo90J56bqulmJ6KJIHAlkkmFBdo163k7pf1cWqH2wl7CsI1cAqjwJGJezrAKagUYn6Cih0u1SpUsU9Vt1UHi2n9XuBrHdw9f5X95amIZSzZ8/6S3NpAIACA3VfBfK6lRXE6mDqpR5ooA4HxORLJdg0WEqpJOq+VxUB/XirQoXoR1z7i068dOKjH0xVBlA5K9GgLf3Aat/yaN9TsKmpXvUDrJMz7UdKcVE6gHdCpgGGmo5Y+5yC21deeSXkNmo/D1w/kFC0r+o4qCmLxStP5R1rvZM3Te2t/V6/A9pfdaKmrv1Vq1a5Zc+dO+evKKN93ksvUEPC+vXrg5ZRCpgGMyqI1UBIVZPRNN767kVFqWMKfr11IBlJ7CZhJG/quolqIIAGtajrKFeuXL48efK4aTC9wta1a9f2tW3b1v29YcMG18X69ttvB3VbqctVsxSJCsGr22jo0KFBz6Gi8roEdk0FiqrgvLaZbid4g0406O/DDz/079OB1DWqguve9K3aPzXbm7pI9+/f727TJBnt2rULmsZVhdw1cFBpCt5+qFndNLhFxd5F6QGff/65268XLlzIB4IkZ8+ePe4Yrn1b03/rb82Q6NGgRqWDaSCXeKla//vf/9zEG7179w5K27njjjtcmoDo90DTeusYHhMcs69OtMgiXqmlUsn6SiHQGbNqsqrrSdT9qtao2bNnu0kH1MqptAKvJUqFrtUKqjqAam1SK1hgi6rO1nWb0gzU4qWzfRW4DkxJ0O3q8gpVikvUyhVxcFbE2p64uikFRYOwvFYh7RfqLv3444/ddRVaV6ural16+6daWtVj4NVuVSuTBh+q5crz9NNPu0Lr+l8TDqhXQb0I6vr01qX0AKUqqI6lvhNAUqPUF+3/GnylesedOnVyg2wDJ4rRvq3jf+DxW/u4Bl/pd0AltpRuo4G0+p4ojUeUyqM63EpNCMUraUgt7qsbv9S4YtHV11NXv3KgdDDTqFTlnaorSgGsAlX9kKvbVnlRyofSqFRRd9Tu3btdbpQCVOUXKk8xsFtIQbFyo7xcRBWGVw6UglmPAgCNlA2cTSuiwBq0QETa93RRjUntlwpQVVlDo6+9/UcjqQNzsVUrU6kHXv610lSOHz/uT33Rd0Ynbaodu2TJEhfAtmrVyp3Q6TsSMa0FSGq8Y76O0zq+6/jtjVfQsdpLg1Fagb433qxxXjqZjvUKgJXWpfxufad69erlcsUDxxwoD7ZChQoht0HfPTU6cPy+ujEdBWLFOwMOLKnilUfRmbTOqnVw0oFFA1OmT5/ucl5VzFrBgIJOHcC0HuVIadpWnbnrPh0MFZiq5UmtYJqmU7MT6W8NpNGZfosWLdzMLmp1VWDRsmVL91jRWXyTJk3cVIMeFd72tpuDHS6X9ku1rmpf1EAUtSapp8C7T8Gn8vR0v/YztU6pwLsGa4kCU+37+jFXTp/3nVGLq3oWopoxCEiqvOOpTsg0nqFmzZouINV03t4kBTq+qzSicllPnz7tGhp0fNZviL4D+g3QDIpaRvmy3piFiLzBjkAo7BmIEW+gk1fPNZC6kdTiqR/0J5980ho1auS6+0Xdr2px1QhVBbQa1a0zdB3s1BqlVig9Tj/omh1L3ayqASs6GHrdURrNqoFdWocGDWhmFx0c9XiPuqlUbSDUAY8gFldCP7hFihRx+5x+iHWC5LVI6TZ1qWpwl1r/FbBqMKL2VVXWEAW0gwcPdq1NQHLy66+/uhMxHXu1/6t+sVf9RXW31eCg478CXm8KWO8YreP4G2+84R7vBbGhevgIYhGdFEqUjXYJXHW8nNFQBw/9OKtFVAGmWks1gluVBHRGrdZRtUJp/naNENW0gpqkQGVXlGOollqdhSvg1NSbCmoD6YxdAavyohTMTpw40RW71qQFap0VrV+pCVGlCtDyivigygRq8VcKgSYciEi9D+o1UPks5cGqd0HF3pVOAyRnShtQIKo818BjsHK99Zug8Q0qKaepZZX+pXEJMf29AWKC1AJEqrEaKmdU+ag6KCnxXgcoBa76sdZ15bmq219BpvKl9KOuFimlAQwbNswl+isAVkCqQTIqNaRBWprFRbNoaUCWWmjVPaVgVkGuqGVXpYjUguvRQdErM6Qzd21n4AGQllfEB51I6UdYrU/aj5XTHUg/zhqoov1brbVaFkjuvKDV64HzUgZE3wMd673A1cuhjYgxCrhSBLJXoVCtlt51tbAquFRXkLrw33nnHXfGrYORcgIVfGpaQLWuilpHlfengVsa7KKBMJoyU61RGqmtg5oC0kDKY1Xhdm+iA/3466LcWdVwVa6V1x2rQPhypkUE4pqmwVTXqHJhtU9H/B5pf1SKAXC10OBbNVIoPSzUMdmrCkMDA+ITgWwymwveO5BEPHgE3h/qoKKDkWYrUuCqOd41L7WCTf1oK5DV4BZVD1BxagWxWp8OYvrh1qhrFYTX7UobiJhDq8ExCkr1WOVQqev11Vdfdfcpx7VOnTruQKj1R6Rt5owdSYFyYfUd0YAu4ccZVzuNbdCgrujwPUF8I5ANc17A6pUhEdVNVbd/oMD71YKq6xq04k2/Om/ePDcqWwOuatWq5QJOlb5Sd79yYpUbqLxXVSEIPIgpAFUqgX7kveoBXvCqvEINdlH9TaUaqKqBAmIN6NJALlHaQeBr8Uanegc/8qaQlAZ86QIgGFUFkJgY7JUMaJS0Ak5VCFBCvUZXP/TQQ+6ikiai3FPNg62EfOWjKuhUGoCKUSvfT4OyFLyqPIpHCfqapEDrV2D8ySefuIFdXm1Xj1psvUFfSidQPq3O0jX4RVMCKs9V69B9oQJTup4AAMDlYJhgmFPwqSR6zXyi3FSN9FdLq+a7Vg0/z4oVK9xgFLWMKmXggw8+cKkBam2VgwcPuuD01KlT/seoBVZBr1cCS62pCn71nKJC1qJR3JonXsupyoBaXrVeleISpSmo5VZBrAYD6BKIricAAHA5aJENcxpFra76O+64w+WpiqoHaFpLBarezEKaAlODt1THUrNqLV++3F544QVXgUCtuBrEpdlYVNvVG8ilXFYFx5qZa8KECS7YVbUCTTGrvFhNOxuYD6vn9SoKAAAAxDdaZMOcBlepHqu6+z379++3TZs2ubJWCi5FU2NqQgHVX9V0f2qt1UArjcJWtQC1viq3VuVSPMqlVeutgl6vnIoGgqmVVgKDWKUHeEGsAtyIra4AAABxjRbZZGD48OEuP1ajqVXG6rfffnOtsTNmzHC1XxVUdunSxeW4arCWuvmVIhBx2tkpU6a4dADVhFXtVgXDatlVnqtaYzXgi6R+AACQVNAimwwoJ1YFqTVQ6/nnn3dTxioF4Ntvv3UDrVStQC2uSiPQQDAviFWwq0FiynFVnqoeozxa5bgqiO3WrZvddNNNrnSWph0U5bkqmGVCOAAAkNhokU0Gdu3a5XJfS5Qo4dIHRIGm5rHWLESarEDzXKuslvJhNSBLaQKqLqA82J49e1rz5s39pbgCab2aIGH+/Pkh67wCAAAkFgLZZEKtqQpoVZUgS5Ys7ja10qolVi22Sj/QzFyTJ092AayWVWD76KOPWqVKlfzr0RSzSkFQbVjVlFW+rQaRqZQXAABAUkIgm0y8/vrrLoh9+eWXrWrVqq40liYsUHWBrl272v333+/uk4jVBgIpgFULraohaD3KsS1dunQCvxoAAIBLI5BNJlRZQGW4Hn74YTe5gQZvKTdW/6s2bObMmYOWV56rN3CL2bMAAEA4YoraZEJTZzZs2NCfJuBNR6v/FcRGnD2LABYAAIQ7WmQBAAAQlii/lcwwEQEAALha0CILAACAsESLLAAAAMISgSwAAADCEoEsAAAAwhKBLAAAAMISgSwAAADCEoEsAAAAwhKBLAAAAMISgSwAAADCEoEsAAAAwhKBLAAAACwc/X9VQM+gKcfbBAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 700x450 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Synthese visuelle : scores CV (moyenne +/- ecart-type) des 3 modeles\n",
+    "noms = []\n",
+    "moyennes = []\n",
+    "ecarts_types = []\n",
+    "for nom, modele in modeles:\n",
+    "    sc = cross_val_score(modele, X, y, cv=5)\n",
+    "    noms.append(nom)\n",
+    "    moyennes.append(sc.mean())\n",
+    "    ecarts_types.append(sc.std())\n",
+    "\n",
+    "plt.figure(figsize=(7, 4.5))\n",
+    "plt.bar(range(len(noms)), moyennes, yerr=ecarts_types, capsize=8,\n",
+    "        color=[\"#4c72b0\", \"#55a868\", \"#c44e52\"])\n",
+    "plt.xticks(range(len(noms)), noms, rotation=15)\n",
+    "plt.ylabel(\"Accuracy CV (moyenne)\")\n",
+    "plt.title(\"Comparaison par validation croisee (k=5)\")\n",
+    "plt.ylim(0.8, 1.0)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0017",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012005,
+     "end_time": "2026-06-25T11:44:35.769465+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:35.757460+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion et transition\n",
+    "\n",
+    "Nous avons formalisé le **compromis biais-variance** entrevu empiriquement en 2.1 et 2.4, puis outillé son évaluation : la **validation croisée k-fold** pour une estimation fiable (moyenne ± écart-type plutôt qu'un seul découpage bruité), et la **courbe ROC** avec l'**AUC** pour juger un classifieur au-delà de l'accuracy et choisir un **seuil de décision** adapté au coût des erreurs.\n",
+    "\n",
+    "Le dernier notebook de la série (`2.6-Clustering-KMeans-PCA`) quitte l'apprentissage supervisé pour l'apprentissage **non supervisé** : clustering (**KMeans**) et réduction de dimension (**PCA**), sans étiquettes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c0018",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008007,
+     "end_time": "2026-06-25T11:44:35.785464+00:00",
+     "exception": false,
+     "start_time": "2026-06-25T11:44:35.777457+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## References\n",
+    "\n",
+    "1. Geman, S., Bienenstock, É. & Doursat, R. (1992). *Neural Networks and the Bias/Variance Dilemma*. Neural Computation 4(1):1-58. — Décomposition biais-variance, l'arbitrage fondamental.\n",
+    "2. Stone, M. (1974). *Cross-Validatory Choice and Assessment of Statistical Predictions*. Journal of the Royal Statistical Society. Series B 36(2):111-147. — La validation croisée comme estimation fiable de l'erreur de généralisation.\n",
+    "3. Bradley, A.P. (1997). *The Use of the Area Under the ROC Curve in the Evaluation of Machine Learning Algorithms*. Pattern Recognition 30(6):1145-1159. — L'AUC, métrique seuil-indépendante pour comparer des classifieurs.\n",
+    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §7.10-7.11. — Validation croisée et compromis biais-variance.\n",
+    "5. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `cross_val_score`, `roc_curve`, `roc_auc_score`, `confusion_matrix`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 16.173901,
+   "end_time": "2026-06-25T11:44:36.237693+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "2.5-Biais-Variance-CV-ROC.ipynb",
+   "output_path": "2.5-Biais-Variance-CV-ROC.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-25T11:44:20.063792+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Epic **#4174** — notebook **5 of 6** of the `02-ML-Cours/` series. Notebooks 2.1/2.4 made overfitting and variance reduction *visible*; this notebook **formalizes** the phenomenon: the **bias-variance tradeoff**, **cross-validation** (k-fold) for a reliable performance estimate instead of a single noisy split, and the **ROC curve / AUC** for evaluating a classifier beyond raw accuracy (false negatives vs false positives matter in cancer diagnosis). The conceptual phare is the **ROC curve** — a single accuracy number hides the *type* of errors; the ROC curve + AUC expose the full threshold-independent quality of the classifier.

## Deliverable

**New file:** `MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb`. `See #4174` (partial — 5 of 6 notebooks).

## Notebook structure (24 cells: 13 markdown, 11 code)

1. **Intro (FR)** — navigation (←2.4, →2.6), objectifs, citation Geman, Bienenstock & Doursat 1992 (bias/variance dilemma).
2. **Setup/imports** — sklearn CV + ROC + metrics, breast_cancer.
3. **§1 Le compromis biais-variance** — ERROR = BIAS² + VARIANCE + noise; the dilemma.
4–5. **§2 Comparer 3 modèles** — `cancer`/`X`/`y`/split (cell 3); `modeles` (LogReg/RF/Arbre), train+test accuracy, the train≈1.0 variance of the deep tree.
6–7. **Exercice 1** (C.1) — identify the model with the largest train-test gap (highest variance) from `modeles`.
8–9. **§3 Validation croisée k-fold** — `scores_cv = cross_val_score(..., cv=5)`; mean ± std. Citation Stone 1974.
10–11. **§4 Comparer par CV** — CV scores for all 3 models.
12–13. **Exercice 2** (C.1) — recompute CV with `cv=10`, compare to `scores_cv` (cv=5).
14–15. **§5/§6 Au-delà de l'accuracy + ROC** (concept-phare) — `meilleur_modele` (LogReg), `fpr`/`tpr`/`seuils`, `auc_score`, ROC curve plotted. Citation Bradley 1997.
16–17. **Exercice 3** (C.1) — interpret the AUC value (excellent/correct/weak).
18–19. **§7 Choisir un seuil** — confusion matrices at threshold 0.5 vs 0.3, the FN/FP tradeoff.
20–21. **§8 Synthèse** — bar chart of CV scores (mean ± std error bars) for the 3 models.
22. **Conclusion + transition** → 2.6 (unsupervised: clustering + PCA).
23. **`## References`** (numbered): Geman/Bienenstock/Doursat 1992, Stone 1974, Bradley 1997, Hastie/Tibshirani/Friedman 2009, Pedregosa 2011.

## Concept-phare / SOTA Prong B (#3801)

**ROC curve + threshold cost.** Accuracy is a single number that hides the *type* of errors. In breast-cancer diagnosis a false negative (missing a malignant tumor) is far costlier than a false positive. The notebook plots the full ROC curve (TPR vs FPR across all thresholds) + the AUC (real value 0.988 — excellent, threshold-independent), then demonstrates that *lowering* the decision threshold (0.5 → 0.3) trades more false positives for fewer false negatives — the cost-driven threshold choice a single accuracy metric cannot express. This is the non-trivial demonstration of why AUC/threshold-aware evaluation exists; a single `accuracy_score` call would not reveal it.

## Validation (HARD, all green)

- **Execution réelle (C.2)**: papermill `coursia-ml-training`, kernel `python3`, cwd=notebook dir → **24/24 cells, 0 errors**. `execution_count` 1→11 set on all 11 code cells, all with outputs (ROC curve, confusion matrices text, CV bar chart). Real AUC = **0.988** printed in the Exercice 3 stub output.
- **3 exercices C.1**: cells 7/13/17, numbered **Exercice 1 → 2 → 3 in order**, stubbed `= None  # TODO etudiant` + final `print("Exercice N a completer : ...")` (run end-to-end with stubs uncompleted — verified the `None` outputs appear). **0** `raise NotImplementedError` / `assert False` / `1/0`.
- **Worked examples coexist**: cells 3/5/9/11/15/19/21 solved (NOT stubbed — anti-regression-safe).
- **Variable-name consistency G.1** (anti-2.3/2.4-mismatch): every exercise stub references only earlier-defined names — cell 7 (`modeles` cell 5), cell 13 (`scores_cv` cell 9 + `X`/`y` cell 3), cell 17 (`auc_score` cell 15). AST-verified end-to-end run with stubs uncompleted; 0 NameError at runtime (papermill confirms 0 errors). `ast.parse` OK on all 11 code cells.
- **No output leak**: 0 machine paths / secrets in committed outputs; `metadata.papermill.input/output_path` = bare basenames.
- **JSON**: nbformat 4.5, `indent=1`, UTF-8 **no BOM**, `source` as list-of-line-strings, cell `id` 8-hex unique, kernelspec `python3`/`Python 3`.
- **Catalogue**: `COURSE_CATALOG.generated.{json,md}` byte-identical to main.

See #4174

---
*Epic #4174 series: 2.1, 2.2, 2.3, 2.4 (all MERGED), 2.5 (this PR). Next: 2.6-Clustering-KMeans-PCA (the last notebook — unsupervised KMeans + PCA), then the final `02-ML-Cours/README.md` FR PR.*
