### PR TITLE
docs(lean): reflect advanced proofs in decision_theory_lean README (Wave-0 #3978)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.en.md
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.en.md
@@ -1,24 +1,45 @@
 # decision_theory_lean — Decision Theory (Lean 4)
 
 Lake **at the `Probas` series root**, formalizing canonical decision-theory
-results — visible from both series tracks (Infer.NET / PyMC). First module
-delivered: the **multi-armed bandit** problem and the **Gittins index** (Gittins
-1979, Weber 1992) — the optimal policy for the discounted infinite-horizon
-bandit. The **geometric-discount building blocks are fully proven** (PR #2911);
-the **marquee optimality theorem is stated but intractable** in the current
-Mathlib (no MDP/Bellman formalization), held as `sorry`.
+results — visible from both series tracks (Infer.NET / PyMC).
 
-Planned modules (Lean roadmap #4038): **von Neumann–Morgenstern** representation
-(#4049) and **Dutch Book / de Finetti** coherence (#4050). Lean companion notebook:
+Three modules delivered:
+
+- **Gittins** — the **multi-armed bandit** problem and the **Gittins index**
+  (Gittins 1979, Weber 1992): the optimal policy for the discounted
+  infinite-horizon bandit. The **geometric-discount building blocks are fully
+  proven** (PR #2911, + finite partial-sum companion #4252); the **marquee
+  optimality theorem is stated but intractable** in the current Mathlib (no
+  MDP/Bellman formalization), held as `sorry`.
+- **Utility** (`#4049`, `#4250`) — the **von Neumann–Morgenstern** expected-utility
+  representation. Proves **sorry-free** the **sound direction** (a utility
+  representation ⟹ rationality, i.e. the four axioms), **affine stability**
+  (cardinality), and the **strict-preference / indifference characterization**
+  (`rep_strict_iff`, `rep_indifference_iff`). The existence direction
+  (Herstein–Milnor 1953) is an **open milestone** (deliberately not `sorry`-backed).
+- **Coherence** (`#4050`, `#4193`, `#4244`) — the **de Finetti / Dutch Book**
+  coherence argument. Proves **sorry-free** the **constructive direction** (prices
+  violating inclusion–exclusion expose the agent to an explicit Dutch Book) and its
+  contrapositive; the **single-ticket case is fully closed**
+  (`single_coherent_iff_prob_bounds`); weights ⟹ single-coherent price
+  (`priceFromWeights_single_coherent`). The full reciprocal on arbitrary book sizes
+  (`coherent_iff_probability`, needs hyperplane separation / LP duality) is an
+  **open milestone** (deliberately not `sorry`-backed).
+
+Lean companion notebook:
 [`Infer/Infer-20b-Lean-Gittins.ipynb`](../Infer/Infer-20b-Lean-Gittins.ipynb).
 
 ## Status
 
 - **Toolchain**: `leanprover/lean4:v4.30.0-rc2`
-- **Sorry**: **5** — all in `GittinsTheorem.lean` (the optimality theorem + index
-  properties). `Discount.lean` = **0 sorry** (fully proven), `Basic.lean` = 0.
-- **Build**: `lake build Gittins` (depends on Mathlib4)
-- **Dependencies**: Mathlib4 (`v4.30.0-rc2`) — real analysis for the discount lemmas
+- **Sorry**: **5** — all in `Gittins/GittinsTheorem.lean` (the optimality theorem +
+  index properties). `Gittins/Discount.lean` = **0 sorry** (fully proven),
+  `Gittins/Basic.lean` = 0. The **entire `Utility` and `Coherence` modules = 0 sorry**
+  (fully proven, open milestones documented, not `sorry`-backed).
+- **Build**: `lake build Gittins Utility Coherence` (depends on Mathlib4)
+- **Dependencies**: Mathlib4 (`v4.30.0-rc2`) — real analysis for the discount lemmas,
+  the ordered and affine structure of `ℝ` for vNM, `Finset` / inclusion–exclusion for
+  de Finetti coherence
 
 ## What it formalizes
 
@@ -46,9 +67,17 @@ The formalization is split into a **proven** layer and a **stated** layer:
 | File | Lines | sorry | Content |
 |------|-------|-------|---------|
 | `Gittins/Basic.lean` | 37 | 0 | Core types — `BanditArm`, `BanditInstance` (arms + discount γ), `Policy := Nat → Nat`, `RewardHistory`, `pullCount`, `empiricalMean`. Pure Lean 4, no Mathlib. |
-| `Gittins/Discount.lean` | 68 | 0 | Geometric discounting **proven** via Mathlib real analysis: `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. |
+| `Gittins/Discount.lean` | 107 | 0 | Geometric discounting **proven** via Mathlib real analysis: `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. **Finite partial-sum companion** (PR #4252): `geometricPartialSum γ n` with `_zero`/`_succ` (telescoping recurrence) and `_closed` (closed form `(1−γ^n)/(1−γ)`). |
 | `Gittins/GittinsTheorem.lean` | 96 | 5 | The marquee theorem **stated with sorry**: `gittinsIndex`, `gittinsPolicy` (argmax), `gittins_optimality`, `gittins_index_known_arm`, `gittins_index_monotone_discount`. (`gittins_beats_greedy` is a `: True := trivial` placeholder, not a sorry.) |
 | `Gittins.lean` | 19 | 0 | Umbrella imports |
+| `Utility/Basic.lean` | 91 | 0 | vNM primitives — `Lottery` (lottery on `Fintype`), `expectation`, convex `mix`, affine expectation identities (`expectation_mix`, `expectation_add`, `expectation_smul`, `expectation_const`, `expectation_affine`). |
+| `Utility/Axioms.lean` | 65 | 0 | The **four vNM axioms** — `IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous` (mixture solvability), `IsRational`, plus `StrictPref`. |
+| `Utility/Representation.lean` | 236 | 0 | **Sound direction proven** (`rep_complete`, `rep_transitive`, `rep_independent`, `rep_continuous`, `expected_utility_rep_is_rational`) + **affine stability** (`affine_rep_is_rep`) + **strict/indifference characterization** (PR #4250: `rep_strict_iff` `StrictPref ↔ E_p > E_q`, `rep_indifference_iff`, `strict_irrefl`). Existence direction documented as open milestone. |
+| `Utility.lean` | ~30 | 0 | Umbrella imports + status doc |
+| `Coherence/Basic.lean` | 52 | 0 | Finetti primitives — `Event` (= `Finset Ω`), `Price` (= `Event Ω → ℝ`), indicator `ind`, and the keystone `ind_inclusion_exclusion`. |
+| `Coherence/DutchBook.lean` | 101 | 0 | **Constructive direction proven** (`non_additive_implies_dutch_book`, explicit stakes `(1,1,−1,−1)`/inverse) + contrapositive `coherent_on_implies_additive`. Full reciprocal (LP duality) documented as open milestone. |
+| `Coherence/Probability.lean` | 255 | 0 | **Single-ticket coherence** (PR #4193: `single_coherent_iff_prob_bounds` — iff between single-ticket coherence and probability bounds `0 ≤ q ≤ 1`, via trichotomy on stake sign + explicit Dutch Books) + **weights-to-coherence** (PR #4244: `priceFromWeights_single_coherent`). The full `coherent_iff_probability` (arbitrary book sizes) remains open. |
+| `Coherence.lean` | 33 | 0 | Umbrella imports + status doc |
 
 ## Why the optimality theorem is intractable
 

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.md
@@ -19,14 +19,19 @@ Trois modules livrés :
   l'utilité n'est déterminée qu'à transformation affine positive près). La **direction
   d'existence** (rationalité ⟹ représentation, Herstein–Milnor 1953) est documentée
   comme **jalon ouvert**.
-- **Coherence** : la **cohérence de de Finetti / Dutch Book** (`See #4050`). Le module
-  prouve **sans aucun `sorry`** la **direction constructive** du théorème de cohérence
-  (cas fini) : des prix de pari violant l'inclusion–exclusion exposent l'agent à un
-  *Dutch Book* explicite (livret de paris à perte sûre, mises concrètes `(1,1,−1,−1)`
-  ou l'inverse), via l'identité d'inclusion–exclusion des indicatrices. Sa contraposée
-  donne « cohérence ⟹ additivité ». La **réciproque** (additivité + normalisation ⟹
-  cohérence, i.e. la fonction de prix est une probabilité) nécessite la séparation
-  d'hyperplans / dualité LP et est documentée comme **jalon ouvert**.
+- **Coherence** : la **cohérence de de Finetti / Dutch Book** (`See #4050`, #4193,
+  #4244). Le module prouve **sans aucun `sorry`** la **direction constructive** du
+  théorème de cohérence (cas fini) : des prix de pari violant l'inclusion–exclusion
+  exposent l'agent à un *Dutch Book* explicite (livret de paris à perte sûre, mises
+  concrètes `(1,1,−1,−1)` ou l'inverse), via l'identité d'inclusion–exclusion des
+  indicatrices. Sa contraposée donne « cohérence ⟹ additivité ». **Le cas mono-ticket
+  est entièrement clos** (`single_coherent_iff_prob_bounds`, #4193 : la cohérence d'un
+  ticket unique équivaut aux bornes de probabilité `0 ≤ q ≤ 1`), et **des poids
+  additifs normalisés on dérive une fonction de prix mono-cohérente**
+  (`priceFromWeights_single_coherent`, #4244). La **réciproque complète** sur livrets de
+  taille arbitraire (`coherent_iff_probability`, qui fait de `q` une mesure de
+  probabilité) nécessite la séparation d'hyperplans / dualité LP en dimension finie et
+  reste un **jalon ouvert** (délibérément non `sorry`-backed).
 
 Notebook compagnon Lean :
 [`Infer/Infer-20b-Lean-Gittins.ipynb`](../Infer/Infer-20b-Lean-Gittins.ipynb).
@@ -144,7 +149,17 @@ contraposée :
     pour garantir une perte stricte.
   - `coherent_on_implies_additive` — **contraposée** : si aucun Dutch Book n'existe
     sur `(A, B, A∩B, A∪B)`, alors `q` satisfait l'inclusion–exclusion.
-- **Énoncé, jalon ouvert** (réciproque) : la direction « additivité + normalisation
+- **Prouvé** (`Probability.lean`) — le **cas mono-ticket est entièrement clos** :
+  - `single_coherent_iff_prob_bounds` (PR #4193) — **iff** entre cohérence d'un ticket
+    unique et bornes de probabilité : une fonction de prix `q` évite tout Dutch Book
+    mono-ticket **si et seulement si** `0 ≤ q(A) ≤ 1` pour tout `A`. La preuve procède
+    par trichotomie sur le signe de la mise, construisant un **Dutch Book explicite**
+    pour chaque borne violée (`q < 0`, `q > 1`, `q(∅) > 0`, `q(univ) < 1`).
+  - `priceFromWeights_single_coherent` (PR #4244) — **des poids à la cohérence** : à
+    partir de poids `p : Ω → ℝ` additifs et normalisés, la fonction de prix dérivée
+    `q A = ∑_{ω∈A} p ω` est mono-cohérente. C'est le pont « poids de probabilité ⟹
+    prix cohérent » (la moitié additive du `coherent_iff_probability` complet).
+- **Énoncé, jalon ouvert** (réciproque complète) : la direction « additivité + normalisation
   ⟹ cohérence » (le `coherent_iff_probability` complet, qui fait de `q` une mesure de
   probabilité) nécessite la **séparation d'hyperplans / dualité LP** en dimension
   finie. Elle est laissée comme **jalon naturel** et **délibérément non `sorry`-backed**
@@ -169,15 +184,16 @@ vNM, qui porte sur les *préférences* sous risque), mais purement *épistémiqu
 | Fichier | Lignes | sorry | Contenu |
 |---------|--------|-------|---------|
 | `Gittins/Basic.lean` | 37 | 0 | Types fondamentaux — `BanditArm`, `BanditInstance` (bras + actualisation γ), `Policy := Nat → Nat`, `RewardHistory`, `pullCount`, `empiricalMean`. Lean 4 pur, sans Mathlib. |
-| `Gittins/Discount.lean` | 68 | 0 | Actualisation géométrique **prouvée** via l'analyse réelle de Mathlib : `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. |
+| `Gittins/Discount.lean` | 107 | 0 | Actualisation géométrique **prouvée** via l'analyse réelle de Mathlib : `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. **Compagnon somme partielle finie** (PR #4252) : `geometricPartialSum γ n = ∑₀..n γ^k` avec `geometricPartialSum_zero`/`_succ` (récurrence télescopique) et `geometricPartialSum_closed` (forme close `(1−γ^n)/(1−γ)`). |
 | `Gittins/GittinsTheorem.lean` | 96 | 5 | Le théorème phare **énoncé avec sorry** : `gittinsIndex`, `gittinsPolicy` (argmax), `gittins_optimality`, `gittins_index_known_arm`, `gittins_index_monotone_discount`. (`gittins_beats_greedy` est un placeholder `: True := trivial`, pas un sorry.) |
 | `Gittins.lean` | 19 | 0 | Imports parapluie |
 | `Utility/Basic.lean` | 91 | 0 | Primitives vNM — `Lottery` (loterie sur `Fintype`), `expectation`, mélange convexe `mix` (preuve de validité), identités affine d'espérance (`expectation_mix`, `expectation_add`, `expectation_smul`, `expectation_const`, `expectation_affine`). |
 | `Utility/Axioms.lean` | 65 | 0 | Les **quatre axiomes vNM** — `IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous` (solvabilité des mélanges), `IsRational`, plus `StrictPref`. |
-| `Utility/Representation.lean` | 181 | 0 | **Direction saine prouvée** (`rep_complete`, `rep_transitive`, `rep_independent`, `rep_continuous`, `expected_utility_rep_is_rational`) + **stabilité affine** (`affine_rep_is_rep`). Direction d'existence documentée comme jalon ouvert. |
+| `Utility/Representation.lean` | 236 | 0 | **Direction saine prouvée** (`rep_complete`, `rep_transitive`, `rep_independent`, `rep_continuous`, `expected_utility_rep_is_rational`) + **stabilité affine** (`affine_rep_is_rep`) + **caractérisation stricte/indifférence** (PR #4250 : `rep_strict_iff` `StrictPref ↔ E_p > E_q`, `rep_indifference_iff` `(P p q ∧ P q p) ↔ E_p = E_q`, `strict_irrefl`). Direction d'existence documentée comme jalon ouvert. |
 | `Utility.lean` | ~30 | 0 | Imports parapluie + doc de statut |
 | `Coherence/Basic.lean` | 52 | 0 | Primitives de Finetti — `Event` (= `Finset Ω`), `Price` (= `Event Ω → ℝ`), indicatrice `ind`, et la clé de voûte `ind_inclusion_exclusion` (inclusion–exclusion des indicatrices). |
 | `Coherence/DutchBook.lean` | 101 | 0 | **Direction constructive prouvée** (`non_additive_implies_dutch_book`, mises explicites `(1,1,−1,−1)`/inverse) + contraposée `coherent_on_implies_additive`. Réciproque (dualité LP) documentée comme jalon ouvert. |
+| `Coherence/Probability.lean` | 255 | 0 | **Cohérence mono-ticket** (PR #4193 : `single_coherent_iff_prob_bounds` — *iff* entre cohérence d'un ticket unique et bornes de probabilité `0 ≤ q ≤ 1`, via trichotomie du signe de la mise + Dutch Books explicites pour chaque borne violée) + **des poids à la cohérence** (PR #4244 : `priceFromWeights_single_coherent` — des poids additifs normalisés on dérive une fonction de prix mono-cohérente). Le `coherent_iff_probability` complet (livrets de taille arbitraire) reste ouvert. |
 | `Coherence.lean` | 33 | 0 | Imports parapluie + doc de statut |
 
 ## Pourquoi le théorème d'optimalité est intractable


### PR DESCRIPTION
## What (#3978 Wave-0)

Reflect the advanced proofs merged into `decision_theory_lean` in its `README.md` (FR, canonical) + `README.en.md`. The READMEs had drifted behind **6 merged proof PRs** (#4108 Utility, #4150 Coherence, #4193 mono-livret, #4244 price-from-weights, #4250 Utility strict/indiff, #4252 Gittins companion).

This is task **#3978** ("READMEs feuilles — refléter les preuves avancées"), flagged **priorité ai-01** for po-2026 on the CoursIA-2 dashboard.

## Drift fixed (verified firsthand G.1)

| Area | Drift | Fix |
|------|-------|-----|
| **Coherence/Probability.lean** | 255-line, 0-sorry module **entirely omitted** from the module table | Added row: `single_coherent_iff_prob_bounds` (#4193), `priceFromWeights_single_coherent` (#4244) |
| **Coherence reciprocal claim** | Stated as open "jalon" too broadly | Refined: single-ticket case is **CLOSED** (#4193), only the full `coherent_iff_probability` (arbitrary book sizes, LP duality) is open |
| **Utility/Representation.lean** | Listed only sound + affine | Added strict/indifference characterization (#4250: `rep_strict_iff`, `rep_indifference_iff`, `strict_irrefl`); line count 181→236 |
| **Gittins/Discount.lean** | Missing #4252 companion | Added `geometricPartialSum` finite-sum companion; line count 68→107 |
| **README.en.md (most stale)** | Described the lake as "First module delivered: Gittins" with Utility/Coherence as **"Planned modules"** (both MERGED #4108/#4150) | Brought intro + Status + module table to **3-module parity** |

## Verification (lean-merge-discipline spirit, G.1 firsthand)

- `decision_theory_lean` sorry count = **5**, all in `Gittins/GittinsTheorem.lean` (verified via standalone-tactic grep)
- `Utility` + `Coherence` modules = **0 sorry** (the proofs reflected in the README)
- All 6 source PRs (#4108/#4150/#4193/#4244/#4250/#4252) = **MERGED** on main (so the README reflects real proven state, not a branch)
- No `CATALOG-STATUS` marker in either file (grep = 0)
- Module table now lists all 12 `.lean` files on disk (Probability.lean was the gap)
- **No `.lean` change** — documentation-only

## Scope

2 README files, +70/-25, single subject (decision_theory_lean README drift). FR-first (FR canonical, `.en.md` preserved-and-updated to parity).

See #3978, #3973 (parent README-ascendant epic).
