### PR TITLE
docs(sudoku): corrige 2 références de notebook périmées dans Conclusion/parcours

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -668,7 +668,7 @@ Commencez par **Sudoku-0 (Environment)** pour comprendre les structures de donne
 
 ### Si vous voulez comparer les paradigmes
 
-Suivez l'ordre numerique : 0-5 (exhaustif et metaheuristiques), puis 6-12 (CSP et symbolique), puis 16-18 (data-driven). Le notebook **18 (Comparison)** synthetise toutes les approches en un benchmark comparatif.
+Suivez l'ordre numerique : 0-5 (exhaustif et metaheuristiques), puis 6-12 (CSP et symbolique), puis 13-15 (automates symboliques, BDD, inférence probabiliste), puis 16-18 (data-driven). Le notebook **18 (Comparison)** synthetise toutes les approches en un benchmark comparatif.
 
 ### Si vous venez du C# / .NET
 
@@ -694,7 +694,7 @@ La thèse pratique est honnête : il n'existe pas de « meilleur solveur » dans
 
 - **Approfondir la programmation par contraintes** : la série [Search](../Search/README.md) généralise les techniques vues ici (propagation, CSP, MRV) à une famille beaucoup plus large de problèmes d'optimisation et de satisfaction — le Sudoku n'était qu'un cas particulier.
 - **Passer à la résolution symbolique formelle** : Z3/SMT, introduit comme un solveur parmi d'autres, devient un outil de **vérification formelle** dans [SymbolicAI](../SymbolicAI/README.md) — preuve de théorèmes, vérification de programmes, contrats intelligents.
-- **Rejoindre l'inférence probabiliste** : les solveurs NumPyro et Infer.NET utilisés ici (notebooks 11-12) sont l'avant-goût de [Probas](../Probas/README.md), où la modélisation probabiliste devient un langage à part entière.
+- **Rejoindre l'inférence probabiliste** : les solveurs NumPyro et Infer.NET utilisés ici (notebook 15) sont l'avant-goût de [Probas](../Probas/README.md), où la modélisation probabiliste devient un langage à part entière.
 - Pour la pratique : reprenez le notebook 18 (Comparison) et ajoutez votre propre solveur hybride — par exemple une approche CP-guided qui utilise un réseau de neurones pour ordonner les variables. C'est l'exercice le plus formateur pour saisir comment combiner garantie et généralisation.
 
 ### Le fil rouge


### PR DESCRIPTION
## Summary

Deux **erreurs factuelles** dans le README Sudoku, découvertes via scan G.1 (drift `#3975 feuilles READMEs`, grain 3 deep-queue ai-01 cycle-C sur ma partition Sudoku/GameTheory-non-Lean).

| # | Où | Avant (FAUX) | Après | Ground truth vérifié firsthand |
|---|----|--------|-------|--------------|
| 1 | Conclusion L697 | « NumPyro et Infer.NET utilisés ici **(notebooks 11-12)** » | « **(notebook 15)** » | Sudoku-15 = Infer.NET (Csharp) + NumPyro (Python) ; 11 = Choco, 12 = Z3 |
| 2 | Parcours L671 | « ordre numérique : 0-5, puis 6-12, puis **16-18** » | ajoute « **puis 13-15 (automates symboliques, BDD, inférence probabiliste)** » | Sudoku-13/14/15 existent et étaient ignorés du parcours suggéré |

## Why this is needed

Un lecteur suivant le parcours « comparer les paradigmes » croyait que les notebooks 13-15 n'existaient pas (omission), et la Conclusion pointait vers les mauvais notebooks (11-12 Choco/Z3 au lieu de 15 Infer) pour l'inférence probabiliste. Incohérence pédagogique entre la prose et le contenu réel des notebooks.

## Validation

- **Markdown-only** — exception C.2 (pas de re-exec, pas de cellule code touchée).
- **CATALOG-STATUS byte-identique** (0 ligne marker dans le diff — règle catalog-pr-hygiene).
- **Aucun lien mort ajouté** : notebook 15 confirmé existant firsthand ().
- **Base fraîche** : worktree depuis `origin/main` (HEAD = origin/main, 0/0).
- **Atomique** : 1 fichier, +2/-2, un seul sujet (stale refs prose Conclusion/parcours). Fichier différent de #4281/#4288 (Search) → aucun conflit.
- **Scope tenu (G.5/G.9)** : seules les 2 erreurs factuelles **certaines** corrigées. Table « Miroir C#/Python » (L377, sous-ensemble curated, matrix complète L349 ailleurs) et CATALOG root=21 (artifact généré, cron gère) laissés intacts.

See #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)
