### PR TITLE
docs(finiteness): aerate Brzozowski derivatives + 2 Mermaid concept diagrams (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
@@ -23,6 +23,29 @@ est l'expression `D_a(r)` qui reconnaît exactement les mots `w` tels que
 calcule le **matching sans reculer** (non-backtracking) : un mot `w` est reconnu
 par `r` ssi la dérivée de `r` par `w` est *nullable* (reconnaît le mot vide ε).
 
+*Comment la dérivée de Brzozowski reconnaît un mot caractère par caractère, sans
+jamais reculer (chaque étape = une fonction de `Basic.lean`) :*
+
+```mermaid
+flowchart LR
+    R["Regex r<br/><i>empty / eps / char /<br/>concat / union / star</i>"]
+    W["Mot w = a₁ a₂ … aₙ"]
+    D1["D_a₁(r)<br/>deriv"]
+    D2["D_a₂(D_a₁(r))<br/>deriv itérée"]
+    Dn["D_w(r) = derivWord"]
+    NUL["nullable (D_w r) ?"]
+    ACC["accepts r w = vrai<br/><i>mot reconnu, sans reculer</i>"]
+    REJ["accepts r w = faux"]
+
+    R --> D1
+    W --> D1
+    D1 --> D2
+    D2 --> Dn
+    Dn --> NUL
+    NUL -->|"oui (reconnaît ε)"| ACC
+    NUL -->|"non"| REJ
+```
+
 Le **théorème de finitude** (Brzozowski 1964) : l'ensemble des dérivées itérées
 d'une expression régulière est **fini** modulo l'équivalence ACI (Associativité,
 Commutativité, Idempotence) des unions. C'est cette finitude qui garantit la
@@ -31,6 +54,28 @@ terminaison et la complexité linéaire de :
 - .NET `RegexOptions.NonBacktracking` (PLDI 2023),
 - **RE#** (POPL 2025, Varatalu/Veanes/Ernits),
 - SymPy.
+
+*Pourquoi les dérivées itérées restent en nombre fini — la clé de la terminaison
+et de la complexité linéaire des moteurs modernes :*
+
+```mermaid
+flowchart TD
+    R0["Regex r fixée"]
+    DERIVS["Ensemble des dérivées itérées<br/>D_w(r) pour tous les mots w"]
+    ACI["Quotient par équivalence ACI<br/><i>Associativité · Commutativité · Idempotence des unions</i>"]
+    FIN["Théorème de finitude (Brzozowski 1964)<br/>nombre FINI de classes d'équivalence"]
+    TERM["Termination garantie<br/>l'espace des dérivées ne grandit pas indéfiniment"]
+    LIN["Complexité linéaire O(|w|)<br/>une dérivée par caractère, sans backtracking"]
+    ENGINES["Moteurs non-backtracking<br/>.NET NonBacktracking · RE# · SymPy"]
+
+    R0 --> DERIVS
+    DERIVS --> ACI
+    ACI --> FIN
+    FIN --> TERM
+    FIN --> LIN
+    TERM --> ENGINES
+    LIN --> ENGINES
+```
 
 ## Modules
 


### PR DESCRIPTION
docs(finiteness): aerate Brzozowski derivatives + 2 Mermaid concept diagrams (#4212)

Add two concept diagrams to the finiteness_lean README (Brzozowski symbolic
derivatives): (1) the derivation mechanism showing how deriv maps a Regex r plus
a word w = a1..an through D_a1(r) -> D_a2(...) -> derivWord -> nullable check ->
accepts without backtracking, and (2) the finiteness theorem showing how the
iterated derivatives quotiented by ACI equivalence (Associativity/Commutativity/
Idempotence of unions) form a FINITE set, which forces termination and linear
O(|w|) complexity in real non-backtracking engines (.NET NonBacktracking, RE#,
SymPy). Pure insertions, FR-first, all symbols verified present on origin/main
Finiteness/Basic.lean (G.1 firsthand): Regex alpha inductive (empty/eps/char/
concat/union/star), nullable, deriv, derivWord, accepts. No Lean file touched,
no proof impact. See #4208 #4212 #2978.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
