### PR TITLE
docs(lean-game-defs): aerate curriculum map + 2 Mermaid concept diagrams (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/README.md
@@ -51,6 +51,28 @@ import Mathlib.SetTheory.Game.Nim
 
 Ces projets ne dépendent **pas** de `lean_game_defs/` à la compilation — ils vendorent leurs propres définitions adaptées à leurs obligations de preuve. `lean_game_defs/` est la couche **introductive** utilisée par les notebooks d'enseignement.
 
+*Architecture en couches — la couche de définitions introductive (ce module, sans
+preuves) vs. les projets Lake qui portent les preuves formelles (chacun vendore ses
+propres définitions) :*
+
+```mermaid
+flowchart TD
+    NOTEBOOKS["Notebooks d'enseignement<br/><i>copier-coller les définitions</i>"]
+    INTRO["lean_game_defs/<br/><b>couche introductive</b><br/>définitions uniquement · 0 sorry · cœur Lean<br/>(ce module)"]
+    PROJ["Projets Lake — preuves formelles<br/>chacun vendore ses définitions adaptées"]
+    SC["social_choice_lean/<br/>Arrow · Sen · électeur médian"]
+    COOP["cooperative_games_lean/<br/>Shapley · Cœur · Banzhaf"]
+    SM["stable_marriage_lean/<br/>Gale-Shapley"]
+    CGT["conway_cgt_lean/<br/>surréels · nimbers (via Mathlib)"]
+
+    NOTEBOOKS -->|"copier-coller"| INTRO
+    INTRO -.->|"inspire / ne compile pas avec"| PROJ
+    PROJ --> SC
+    PROJ --> COOP
+    PROJ --> SM
+    PROJ --> CGT
+```
+
 ## Voir aussi
 
 - [GameTheory/README.md](../README.md) — Vue d'ensemble de la série (tracks OpenSpiel + Lean)
@@ -76,6 +98,25 @@ d'Arrow ([SocialChoice.lean](SocialChoice.lean)), jeux bayésiens et signalisati
 ([Bayesian.lean](Bayesian.lean)), et minimisation du regret / CFR
 ([Regret.lean](Regret.lean)). Chaque fichier correspond à un notebook d'enseignement
 spécifique et est autonome.
+
+*La carte du curriculum — six fichiers, du jeu sous forme normale jusqu'au CFR, chacun
+rattaché à son notebook pédagogique source :*
+
+```mermaid
+flowchart LR
+    BASIC["Basic.lean<br/>NormalFormGame · FiniteGame · Game2x2<br/><i>16-Lean-Definitions</i>"]
+    NASH["Nash.lean<br/>meilleure réponse · Nash pur/mixte<br/>dominance stricte<br/><i>16-Lean-Definitions</i>"]
+    COMB["Combinatorial.lean<br/>GameTree · minimax · détermination<br/><i>18-CombinatorialGames</i>"]
+    SC["SocialChoice.lean<br/>Preference · axiomes d'Arrow<br/><i>19-SocialChoice</i>"]
+    BAY["Bayesian.lean<br/>BayesianGame · Nash bayésien · poker de Kuhn<br/><i>11-Bayesian · 13-CFR</i>"]
+    REG["Regret.lean<br/>CumulativeRegret · CFR · FictitiousPlay<br/><i>13-CFR · 17-MultiAgent-RL</i>"]
+
+    BASIC --> NASH
+    NASH --> COMB
+    NASH --> SC
+    NASH --> BAY
+    BAY --> REG
+```
 
 ### Comment elle est utilisée
 


### PR DESCRIPTION
docs(lean-game-defs): aerate curriculum map + 2 Mermaid concept diagrams (#4212)

Add two concept diagrams to the lean_game_defs README (the introductory
definitions layer for the Lean GameTheory track): (1) a curriculum map showing
the six reference files (Basic -> Nash -> Combinatorial/SocialChoice/Bayesian ->
Regret) each tied to its source teaching notebook, and (2) a layered-architecture
diagram clarifying that this module is the 0-sorry intro definitions layer
(copy-pasted into notebooks) while the formal-proof projects (social_choice_lean,
cooperative_games_lean, stable_marriage_lean, conway_cgt_lean) each vendor their
own adapted definitions. Pure insertions, FR-first, all 6 files + key structures
(NormalFormGame/FiniteGame/Game2x2, bestResponse/NashEquilibrium,
CumulativeRegret/CFRState) verified present on origin/main (G.1 firsthand). No
Lean file touched, no proof impact. See #4208 #4212.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
