### PR TITLE
docs(genai): Image family READMEs dall-e-3 -> gpt-image-1 consistency

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/README.md
@@ -19,7 +19,7 @@ Ce module couvre les fondamentaux de la génération d'images par IA : modèles 
 
 | # | Notebook | Contenu | Service | VRAM |
 |---|----------|---------|---------|------ |
-| 1 | [01-1-OpenAI-DALL-E-3](01-1-OpenAI-DALL-E-3.ipynb) | Génération avec DALL-E 3 | OpenAI API | 0 |
+| 1 | [01-1-OpenAI-DALL-E-3](01-1-OpenAI-DALL-E-3.ipynb) | Génération avec gpt-image-1 (DALL-E 3 retiré) | OpenAI API | 0 |
 | 2 | [01-2-GPT-5-Image-Generation](01-2-GPT-5-Image-Generation.ipynb) | Génération avec GPT-5 | OpenAI API | 0 |
 | 3 | [01-3-Basic-Image-Operations](01-3-Basic-Image-Operations.ipynb) | Opérations de base | PIL/OpenCV | 0 |
 | 4 | [01-4-Forge-SD-XL-Turbo](01-4-Forge-SD-XL-Turbo.ipynb) | Stable Diffusion XL Turbo | ComfyUI | Variable |
@@ -53,7 +53,7 @@ Accès : http://localhost:8188
 
 - **Cloud vs Local** : OpenAI (facile, API) vs ComfyUI (puissant, local)
 - **Formats** : PNG, JPEG, WebP supportés
-- **Qualité** : DALL-E 3 > GPT-5 > SD-XL Turbo
+- **Qualité** : gpt-image-1 > GPT-5 > SD-XL Turbo
 - **Flexibilité** : SD-XL Turbo plus paramétrable que les modèles cloud
 
 ## Ressources

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/README.md
@@ -50,7 +50,7 @@ pip install -r requirements-comfyui.txt
 
 ### 04-1 Educational Content Generation
 - **Objectif** : Automatiser la création de contenu pédagogique
-- **Technologies** : DALL-E 3 + GPT-4o + post-processing
+- **Technologies** : gpt-image-1 + GPT-4o + post-processing
 - **Applications** : Cours, supports de formation, illustrations
 
 ### 04-2 Creative Workflows
@@ -72,7 +72,7 @@ pip install -r requirements-comfyui.txt
 
 ### Éducation
 ```
-Texte → GPT-4o (brief) → DALL-E 3 (images) → Post-processing → Support
+Texte → GPT-4o (brief) → gpt-image-1 (images) → Post-processing → Support
 ```
 
 ### Création

--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -12,7 +12,7 @@ L'objectif fil rouge de cette série est de construire un système capable de pr
 
 À l'issue de la série, l'apprenant sait :
 
-- **Choisir la bonne modalité** : API cloud (DALL-E 3, GPT-5 Image) vs ComfyUI auto-hébergé (SD XL, FLUX, Qwen) selon le besoin (contrôle, coût, débit, données sensibles).
+- **Choisir la bonne modalité** : API cloud (gpt-image-1, GPT-5 Image) vs ComfyUI auto-hébergé (SD XL, FLUX, Qwen) selon le besoin (contrôle, coût, débit, données sensibles).
 - **Manipuler une image en code** : PIL/OpenCV pour redimensionnement, masques, compositing, conversion VAE latents <-> pixels.
 - **Concevoir un workflow ComfyUI** : graphe de nœuds (Sampler, VAE, ConditioningCombine, ModelSampling), import/export JSON, batching et seeds reproductibles.
 - **Éditer plutôt que régénérer** : Qwen Image Edit, ControlNet, inpainting (zones à régénérer dans un visuel existant) — moins coûteux et plus contrôlable que repartir de zéro.
@@ -36,11 +36,11 @@ Image/
 
 ### 01-Foundation - Modèles de base
 
-Avant de produire des visuels pédagogiques, il faut maîtriser les outils de génération. Ce niveau couvre les deux approches : API cloud (DALL-E 3, GPT-5) pour la simplicité, et modèles locaux via ComfyUI (SD XL Turbo, Qwen) pour le contrôle fin. [01-3](01-Foundation/01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation d'image (PIL, OpenCV) nécessaires pour comprendre ce que font les modèles.
+Avant de produire des visuels pédagogiques, il faut maîtriser les outils de génération. Ce niveau couvre les deux approches : API cloud (gpt-image-1, GPT-5) pour la simplicité, et modèles locaux via ComfyUI (SD XL Turbo, Qwen) pour le contrôle fin. [01-3](01-Foundation/01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation d'image (PIL, OpenCV) nécessaires pour comprendre ce que font les modèles.
 
 | Notebook | Contenu | Service |
 |----------|---------|---------|
-| [01-1-OpenAI-DALL-E-3](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) | Génération avec DALL-E 3 | OpenAI API |
+| [01-1-OpenAI-DALL-E-3](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) | Génération avec gpt-image-1 (DALL-E 3 retiré) | OpenAI API |
 | [01-2-GPT-5-Image-Generation](01-Foundation/01-2-GPT-5-Image-Generation.ipynb) | Génération avec GPT-5 | OpenAI API |
 | [01-3-Basic-Image-Operations](01-Foundation/01-3-Basic-Image-Operations.ipynb) | Opérations de base | PIL/OpenCV |
 | [01-4-Forge-SD-XL-Turbo](01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb) | Stable Diffusion XL Turbo | ComfyUI |
@@ -101,7 +101,7 @@ Applications directes par domaine : histoire-géographie (cartes, reconstitution
 
 | Technologie | Notebooks | Prérequis |
 |-------------|-----------|-----------|
-| **OpenAI DALL-E 3** | 01-1, 01-2 | `OPENAI_API_KEY` |
+| **OpenAI gpt-image-1** | 01-1, 01-2 | `OPENAI_API_KEY` |
 | **ComfyUI + Qwen** | 01-4, 01-5, 02-1 | Docker, ~29GB VRAM |
 | **ComfyUI + FLUX** | 02-2 | Docker GPU |
 | **ComfyUI + SD 3.5** | 02-3 | Docker GPU |
@@ -159,13 +159,13 @@ Le fil rouge de cette série est la création d'un système de visuels pédagogi
 
 ## FAQ
 
-### DALL-E 3 retourne des images floues ou hors-sujet
+### gpt-image-1 : qualité et suivi du prompt
 
-DALL-E 3 (notebook [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb)) interprète les prompts librement et peut simplifier les détails complexes. Mitigation :
+gpt-image-1 (notebook [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb)) offre une bonne qualité par défaut mais peut simplifier les détails complexes. Mitigation :
 
 - Structurer le prompt : `style [photographiste/illustration/3D render], sujet [précis], contexte [arrière-plan], éclairage [type]`.
-- Utiliser `size="1792x1024"` pour les compositions larges, `1024x1024` pour les portraits.
-- GPT-5 Image (notebook [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb)) offre un meilleur suivi des instructions détaillées que DALL-E 3.
+- Utiliser `size="1536x1024"` pour les compositions larges (gpt-image-1 accepte `1024x1024` / `1024x1536` / `1536x1024` / `auto`), `1024x1024` pour les portraits.
+- GPT-5 Image (notebook [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb)) offre un meilleur suivi des instructions détaillées que gpt-image-1.
 - Pour un contrôle total, passer en ComfyUI local (niveau 02+).
 
 ### ComfyUI retourne une erreur 401 ou 502
@@ -211,17 +211,17 @@ Stratégies si OOM :
 - Fermer les autres notebooks GPU avant une génération lourde.
 - Vérifier avec `nvidia-smi` et libérer avec `torch.cuda.empty_cache()`.
 
-### Quelle différence entre DALL-E 3, GPT-5 Image et ComfyUI ?
+### Quelle différence entre gpt-image-1, GPT-5 Image et ComfyUI ?
 
-| Critère | DALL-E 3 | GPT-5 Image | ComfyUI (SD/FLUX/Qwen) |
-|---------|----------|-------------|------------------------|
-| **Coût** | $0.04-0.12/image | Variable (API) | Gratuit (local) |
+| Critère | gpt-image-1 | GPT-5 Image | ComfyUI (SD/FLUX/Qwen) |
+|---------|-------------|-------------|------------------------|
+| **Coût** | Usage-based (API) | Variable (API) | Gratuit (local) |
 | **Contrôle** | Prompt seul | Prompt + instructions | Nœuds, masques, seeds |
-| **Édition** | Non | Oui (native) | Oui (inpainting, ControlNet) |
-| **Qualité** | Bonne | Excellente | Excellente (avec réglages) |
+| **Édition** | Oui (native) | Oui (native) | Oui (inpainting, ControlNet) |
+| **Qualité** | Excellente | Excellente | Excellente (avec réglages) |
 | **VRAM** | 0 (API) | 0 (API) | 10-29 GB |
 
-Pour du prototypage rapide, DALL-E 3 ou GPT-5 Image suffisent. Pour un contrôle fin, une production répétitive, ou des données sensibles, ComfyUI est indispensable.
+Pour du prototypage rapide, gpt-image-1 ou GPT-5 Image suffisent. Pour un contrôle fin, une production répétitive, ou des données sensibles, ComfyUI est indispensable.
 
 ### Comment créer un workflow ComfyUI reproductible ?
 

--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -44,7 +44,7 @@ Avant de générer la moindre image ou le moindre son, il faut configurer l'envi
 
 ### Image - Générer, éditer et orchestrer des images
 
-On commence par les fondamentaux : appeler DALL-E 3 et GPT-5 pour générer des images depuis un prompt texte, puis manipuler ces images avec PIL et OpenCV. Le niveau avancé introduit les modèles open-source hébergés localement (Qwen Image Edit pour l'édition, FLUX pour la qualité, Stable Diffusion 3.5 pour la production, Z-Image/Lumina pour l'expérimental). En orchestration, on compare les modèles entre eux et on enchaîne les workflows. Les applications métier montrent comment intégrer tout cela dans des cas réels : contenu éducatif, workflows créatifs, motifs décoratifs.
+On commence par les fondamentaux : appeler gpt-image-1 et GPT-5 pour générer des images depuis un prompt texte, puis manipuler ces images avec PIL et OpenCV. Le niveau avancé introduit les modèles open-source hébergés localement (Qwen Image Edit pour l'édition, FLUX pour la qualité, Stable Diffusion 3.5 pour la production, Z-Image/Lumina pour l'expérimental). En orchestration, on compare les modèles entre eux et on enchaîne les workflows. Les applications métier montrent comment intégrer tout cela dans des cas réels : contenu éducatif, workflows créatifs, motifs décoratifs.
 
 **Fil rouge** : construire un générateur de contenu visuel pour l'éducation (diagrammes scientifiques, illustrations pédagogiques, motifs décoratifs).
 
@@ -173,7 +173,7 @@ Les clés essentielles dans `.env` :
 
 | Variable | Usage | Requis pour |
 | ---------- | ------- | ------------- |
-| `OPENAI_API_KEY` | DALL-E 3, GPT-5, Whisper, TTS | Image, Audio, Texte |
+| `OPENAI_API_KEY` | gpt-image-1, GPT-5, Whisper, TTS | Image, Audio, Texte |
 | `ANTHROPIC_API_KEY` | Claude Vision | Video |
 | `HUGGINGFACE_TOKEN` | Modèles HF open-source | Image, Video |
 | `COMFYUI_BEARER_TOKEN` | Services locaux ComfyUI | Image (local), Video |
@@ -229,11 +229,11 @@ Non. Les notebooks Image utilisent ComfyUI hébergé sur un serveur distant (RTX
 
 ### Quels sont les coûts API attendus ?
 
-La série est conçue pour minimiser les coûts. Les notebooks Texte utilisent principalement GPT-4o-mini (~0.15$/1M input tokens) et GPT-4o (~2.50$/1M input tokens). Les notebooks Image utilisent DALL-E 3 uniquement pour les exercices (les exemples utilisent ComfyUI/Qwen gratuit). Budget estimé : **5-15$ total** pour l'ensemble de la série, sauf appels itératifs intensifs.
+La série est conçue pour minimiser les coûts. Les notebooks Texte utilisent principalement GPT-4o-mini (~0.15$/1M input tokens) et GPT-4o (~2.50$/1M input tokens). Les notebooks Image utilisent gpt-image-1 uniquement pour les exercices (les exemples utilisent ComfyUI/Qwen gratuit). Budget estimé : **5-15$ total** pour l'ensemble de la série, sauf appels itératifs intensifs.
 
-### Quelle est la différence entre ComfyUI et DALL-E ?
+### Quelle est la différence entre ComfyUI et gpt-image-1 ?
 
-**ComfyUI** est un serveur open-source hébergé localement qui exécute des modèles open-source (FLUX, SD 3.5, Qwen Image Edit). Avantages : gratuit, contrôle total sur les paramètres (seed, steps, CFG), pipelines personnalisables. **DALL-E 3** est l'API cloud d'OpenAI. Avantages : qualité élevée par défaut, simplicité d'usage (un appel API = une image). La série montre les deux et vous apprend à choisir selon le contexte.
+**ComfyUI** est un serveur open-source hébergé localement qui exécute des modèles open-source (FLUX, SD 3.5, Qwen Image Edit). Avantages : gratuit, contrôle total sur les paramètres (seed, steps, CFG), pipelines personnalisables. **gpt-image-1** est l'API cloud d'OpenAI. Avantages : qualité élevée par défaut, simplicité d'usage (un appel API = une image). La série montre les deux et vous apprend à choisir selon le contexte.
 
 ### Peut-on suivre cette série en parallèle d'une autre ?
 


### PR DESCRIPTION
## Summary

After the dall-e-3 -> gpt-image-1 migration epic (notebooks 01-1 + 04-1 already migrated; OpenAI retired dall-e-3, which now returns ERROR 400), the GenAI Image family READMEs still referenced the retired model. This PR resynchronizes the documentation **bottom-up** to match what the notebooks actually call — the leaf-level consistency sweep of #3974 (GenAI family).

**4 files, 24 insertions / 24 deletions (balanced, no content loss):**

| File | Edits |
|------|-------|
| `GenAI/README.md` | intro prose, API key table, cost FAQ, ComfyUI-vs-cloud FAQ (heading + body) |
| `Image/README.md` | learning outcomes, 01-Foundation prose, notebook table, technologies table, image-quality FAQ (size + comparison), 3-way comparison table |
| `Image/01-Foundation/README.md` | notebook table row, quality ranking |
| `Image/04-Applications/README.md` | 04-1 technologies, education workflow diagram |

## Accuracy improvements (grounded in the confirmed gpt-image-1 schema)

Beyond the model-name swap, a few lines were stale in ways the migration exposed:

- `size="1792x1024"` -> `"1536x1024"` — gpt-image-1 accepts `1024x1024` / `1024x1536` / `1536x1024` / `auto`; `1792x1024` -> HTTP 400
- **Edition: "Non" -> "Oui (native)"** — gpt-image-1 supports editing, unlike dall-e-3
- **Quality: "Bonne" -> "Excellente"** — gpt-image-1 outperforms dall-e-3
- **Cost: "$0.04-0.12/image" -> "Usage-based (API)"** — dall-e-3 per-image pricing no longer applies

## What was NOT touched (scope discipline)

- **Filename links** `[01-1-OpenAI-DALL-E-3](01-1-OpenAI-DALL-E-3.ipynb)` preserved everywhere — these are legitimate real filenames, not model claims.
- `Image/03-Orchestration/README.md` L51 ("Modèles comparés : DALL-E 3 ...") left out of scope: notebook 03-1 compares **SDXL Turbo + Z-Image** (neither dall-e-3 nor gpt-image-1), so that line is a pre-existing inaccuracy unrelated to the migration — flagged here for a separate pass.

## Verification (G.1 — firsthand, not propagation)

- `01-1-OpenAI-DALL-E-3.ipynb`: `model_name = "gpt-image-1"`, committed output `Modèle utilisé: gpt-image-1` -> doc direction **correct** (not a false claim)
- `04-1-Educational-Content-Generation.ipynb`: `model="gpt-image-1"` (the canonical file; the stale `_output.ipynb` still says dall-e-3 but is a cached artifact, irrelevant)
- `03-1-Multi-Model-Comparison.ipynb`: Forge (SDXL Turbo) + ComfyUI (Z-Image) only -> excluded from scope

## Doc-only PR (§E note)

This is a **grouped** coherent sweep (#3974 = "GenAI leaf READMEs", plural) of 4 GenAI-Image-family READMEs sharing one subject (the migration epic), not a trivial single-file edit. Catalog byte-identical to main (no markers touched).

See #3974
See #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
