### PR TITLE
feat(lean): perceptron_lean Tightness — Novikoff bound is sharp (n·γ²=R² witness on ℂ)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron.lean
@@ -2,6 +2,7 @@ import Mathlib
 import Perceptron.Data
 import Perceptron.Perceptron
 import Perceptron.Convergence
+import Perceptron.Tightness
 
 /-!
 # learning_theory_lean — convergence du Perceptron (théorème de Novikoff)
@@ -19,6 +20,9 @@ La preuve est **géométrique élémentaire et entièrement 0-sorry** :
   `PerceptronRun` (données séparables + trace d'erreurs).
 - `Perceptron/Convergence.lean` — Lemme A `⟨wₖ,u⟩ ≥ kγ`, Lemme B `‖wₖ‖² ≤ kR²`,
   Cauchy–Schwarz ⟹ **`novikoff_mistake_bound`** : `n·γ² ≤ R²`.
+- `Perceptron/Tightness.lean` — **saturation de la borne** : un témoin concret sur
+  `ℂ` (`n=2`, `γ=1`, `R=√2`) atteignant l'égalité `n·γ² = R²`
+  (`novikoff_bound_is_sharp`) ⟹ la borne `(R/γ)²` est optimale.
 
 Référence : A. B. J. Novikoff, *On convergence proofs for perceptrons*, Symposium
 on the Mathematical Theory of Automata, Polytechnic Institute of Brooklyn (1962).

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Tightness.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Tightness.lean
@@ -1,0 +1,157 @@
+import Mathlib
+import Perceptron.Perceptron
+import Perceptron.Convergence
+
+/-!
+# Saturation de la borne de Novikoff — un témoin serrant (sharpness)
+
+> **Résultat.** La borne de Novikoff `n · γ² ≤ R²` (autrement dit
+> `n ≤ (R/γ)²` mises à jour) est **optimale** : on exhibe une exécution valide du
+> perceptron, sur `ℂ` vu comme espace préhilbertien réel de dimension 2, qui
+> **sature** la borne — `n · γ² = R²` exactement. Une constante universelle
+> strictement plus petite que `1` devant `(R/γ)²` ne saurait donc majorer le
+> nombre d'erreurs sur toutes les exécutions séparables.
+
+**Témoin géométrique.** Deux points `x₀ = 1 + I`, `x₁ = 1 − I` (demi-droites à
+±45°), tous deux d'étiquette `+1`, séparés par le vecteur unitaire `u = 1` avec
+marge `γ = 1`, chacun de norme `‖xₖ‖ = √2` (donc `R = √2`). La première mise à
+jour fait `w₁ = x₀ = 1 + I` ; au deuxième pas,
+`⟪w₁, x₁⟫ = ⟨1 + I, 1 − I⟩ = 0` (les deux demi-droites sont orthogonales) :
+`x₁` est exactement sur la frontière de décision de `w₁`, donc la mise à jour est
+une erreur. On obtient alors `n · γ² = 2 · 1 = 2 = (√2)² = R²` : **égalité** — la
+borne est atteinte, donc serrée.
+
+L'espace `ℂ` porte l'instance `InnerProductSpace ℝ ℂ` ; le produit scalaire réel
+se déplie par `⟪w, z⟫_ℝ = (z · conj w).re` (`Complex.inner` +
+`Complex.starRingEnd_apply`), i.e. `w.re · z.re + w.im · z.im`, et les normes par
+`‖z‖² = Complex.normSq z = z.re² + z.im²` (`Complex.normSq_eq_norm_sq`,
+`Complex.normSq_apply`).
+
+Ce module est **entièrement sorry-free** : il s'agit d'un résultat de *sharpness*
+concret (égalité atteinte), distinct du théorème de borne universelle
+`novikoff_mistake_bound` (inégalité) démontré dans `Convergence.lean`.
+-/
+
+open scoped InnerProductSpace
+
+open Complex
+
+namespace Perceptron
+
+/-- Produit scalaire réel sur `ℂ` déplié en coordonnées : `⟪w, z⟫ = w.re·z.re +
+w.im·z.im` (lemme utilitaire pour les calculs concrets du témoin). -/
+theorem complex_inner_re (w z : ℂ) : ⟪w, z⟫_ℝ = w.re * z.re + w.im * z.im := by
+  rw [Complex.inner, Complex.mul_re, Complex.conj_re, Complex.conj_im]
+  ring
+
+/-- Les points `xₖ` du témoin : `x₀ = 1 + I`, `xₖ = 1 − I` pour `k ≥ 1`
+(deux demi-droites à ±45° du plan complexe). -/
+def witnessPts : ℕ → ℂ
+  | 0 => 1 + I
+  | _ + 1 => 1 - I
+
+/-- Les étiquettes du témoin : toutes `+1`. -/
+def witnessLbl : ℕ → ℝ := fun _ => 1
+
+/-- `‖xₖ‖² = 2` pour tout `k` (les deux demi-droites ont même norme `√2`). -/
+theorem witnessPts_norm_sq (k : ℕ) : ‖witnessPts k‖ ^ 2 = 2 := by
+  rcases k with rfl | k
+  · rw [show ‖witnessPts 0‖ ^ 2 = Complex.normSq (witnessPts 0) from
+          (Complex.normSq_eq_norm_sq _).symm,
+        Complex.normSq_apply, witnessPts]
+    norm_num [Complex.add_re, Complex.add_im, I_re, I_im]
+  · rw [show ‖witnessPts (k + 1)‖ ^ 2 = Complex.normSq (witnessPts (k + 1)) from
+          (Complex.normSq_eq_norm_sq _).symm,
+        Complex.normSq_apply, witnessPts]
+    norm_num [Complex.sub_re, Complex.sub_im, I_re, I_im]
+
+/-- La marge `⟪u, xₖ⟫ = ⟨1, xₖ⟩ = 1` pour tout `k` (égale à `γ`). -/
+theorem witness_margin_inner (k : ℕ) : ⟪(1 : ℂ), witnessPts k⟫_ℝ = 1 := by
+  rw [complex_inner_re]
+  rcases k with rfl | k
+  · rw [witnessPts]
+    norm_num [Complex.add_re, Complex.add_im, I_re, I_im]
+  · rw [witnessPts]
+    norm_num [Complex.sub_re, Complex.sub_im, I_re, I_im]
+
+/-- Le produit scalaire « d'erreur » `⟪1 + I, 1 − I⟫ = 0` (orthogonalité des deux
+demi-droites) — cœur de la deuxième mise à jour. -/
+theorem witness_cross_inner : ⟪(1 + I : ℂ), 1 - I⟫_ℝ = 0 := by
+  rw [complex_inner_re]
+  norm_num [Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im, I_re, I_im]
+
+/-- Après la première mise à jour, `w₁ = x₀ = 1 + I`. -/
+theorem witness_w1 : perceptronWeights witnessPts witnessLbl 1 = 1 + I := by
+  rw [perceptronWeights_succ, perceptronWeights_zero, zero_add]
+  show witnessLbl 0 • witnessPts 0 = 1 + I
+  rw [show witnessLbl 0 = 1 from rfl, show witnessPts 0 = (1 + I : ℂ) from rfl]
+  exact one_smul _ _
+
+theorem witness_lbl : ∀ k < (2 : ℕ), witnessLbl k ^ 2 = 1 := by
+  intro k _
+  rw [show witnessLbl k = 1 from rfl]
+  norm_num
+
+theorem witness_rad : ∀ k < (2 : ℕ), ‖witnessPts k‖ ≤ Real.sqrt 2 := by
+  intro k _
+  have h := witnessPts_norm_sq k
+  have hnn : 0 ≤ ‖witnessPts k‖ := norm_nonneg _
+  calc ‖witnessPts k‖
+      = Real.sqrt (‖witnessPts k‖ ^ 2) := (Real.sqrt_sq hnn).symm
+    _ = Real.sqrt 2 := by rw [h]
+    _ ≤ Real.sqrt 2 := le_refl _
+
+theorem witness_margin : ∀ k < (2 : ℕ),
+    (1 : ℝ) ≤ witnessLbl k * ⟪(1 : ℂ), witnessPts k⟫_ℝ := by
+  intro k _
+  rw [show witnessLbl k = 1 from rfl, one_mul]
+  linarith [witness_margin_inner k]
+
+theorem witness_mistake : ∀ k < (2 : ℕ),
+    witnessLbl k * ⟪perceptronWeights witnessPts witnessLbl k, witnessPts k⟫_ℝ ≤ 0 := by
+  intro k _
+  have h01 : k = 0 ∨ k = 1 := by omega
+  rcases h01 with rfl | rfl
+  · rw [perceptronWeights_zero, inner_zero_left, show witnessLbl 0 = 1 from rfl]
+    norm_num
+  · rw [witness_w1, show witnessLbl 1 = 1 from rfl, one_mul,
+        show witnessPts 1 = (1 - I : ℂ) from rfl]
+    linarith [witness_cross_inner]
+
+/-- L'exécution saturante : `n = 2` points de `ℂ`, séparés par `u = 1` avec marge
+`γ = 1`, de rayon `R = √2`, atteignant `n · γ² = R²`. -/
+noncomputable def tightnessRun : PerceptronRun ℂ :=
+  { n := 2,
+    pts := witnessPts,
+    lbl := witnessLbl,
+    u := 1,
+    R := Real.sqrt 2,
+    γ := 1,
+    hR := Real.sqrt_nonneg _,
+    hγ := one_pos,
+    hUnit := norm_one,
+    hLbl := witness_lbl,
+    hRad := witness_rad,
+    hMargin := witness_margin,
+    hMistake := witness_mistake }
+
+/-- Le témoin atteint la borne **avec égalité** : `n · γ² = R²`. -/
+theorem tightnessRun_saturates :
+    (tightnessRun.n : ℝ) * tightnessRun.γ ^ 2 = tightnessRun.R ^ 2 := by
+  have hn : tightnessRun.n = 2 := rfl
+  have hγ : tightnessRun.γ = 1 := rfl
+  have hR : tightnessRun.R = Real.sqrt 2 := rfl
+  rw [hn, hγ, hR]
+  rw [show (Real.sqrt 2 : ℝ) ^ 2 = 2 from Real.sq_sqrt (by norm_num)]
+  norm_num
+
+/-- **La borne de Novikoff est serrée.** Il existe une exécution valide (sur `ℂ`)
+qui l'atteint avec égalité `n · γ² = R²`. Puisque `novikoff_mistake_bound` donne
+l'inégalité universelle `n · γ² ≤ R²` et que l'égalité est atteinte par
+`tightnessRun`, aucune borne de la forme `n · γ² ≤ c · R²` avec `c < 1` n'est
+universellement valable : la constante `1` (devant `(R/γ)²`) est optimale. -/
+theorem novikoff_bound_is_sharp :
+    ∃ run : PerceptronRun ℂ, (run.n : ℝ) * run.γ ^ 2 = run.R ^ 2 :=
+  ⟨tightnessRun, tightnessRun_saturates⟩
+
+end Perceptron

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/README.md
@@ -9,14 +9,17 @@ classifieur correct.
 C'est le **premier théorème Lean de la série ML** (aucun lake Lean en ML
 auparavant, roadmap #4038 Tier 2). La preuve est **géométrique élémentaire et
 entièrement 0-sorry** : deux inégalités de croissance du vecteur de poids `wₖ`,
-combinées par Cauchy–Schwarz, donnent la borne.
+combinées par Cauchy–Schwarz, donnent la borne. Le module `Tightness` montre en
+outre que cette borne est **serrée** (atteinte avec égalité par un témoin concret
+sur `ℂ`).
 
 ## Statut
 
 - **Toolchain** : `leanprover/lean4:v4.31.0-rc1` + Mathlib4 (`v4.31.0-rc1`)
 - **Sorry** : **0** sur tout le module. La borne `novikoff_mistake_bound`
   (`n · γ² ≤ R²`), le Lemme A d'alignement (`⟪wₖ, u⟫ ≥ kγ`) et le Lemme B de norme
-  (`‖wₖ‖² ≤ kR²`) sont entièrement prouvés.
+  (`‖wₖ‖² ≤ kR²`) sont entièrement prouvés, ainsi que le **serrage**
+  `novikoff_bound_is_sharp` (témoin sur `ℂ` atteignant l'égalité `n·γ² = R²`).
 - **Build** : `lake build Perceptron` (dépend de Mathlib4)
 
 ## Ce qui est formalisé
@@ -49,6 +52,18 @@ celle de `⟨w, u⟩`.
   `⟪wₙ, u⟫ ≤ ‖wₙ‖ · ‖u‖ = ‖wₙ‖` (avec `‖u‖ = 1`) donne `n · γ ≤ ‖wₙ‖`, donc
   `(n · γ)² ≤ ‖wₙ‖² ≤ n · R²`, i.e. **`n · γ² ≤ R²`**.
 
+### Serrage de la borne (sharpness)
+
+- **`novikoff_bound_is_sharp`** (`Tightness.lean`) : la borne `(R/γ)²` est
+  **optimale** — on exhibe une exécution valide sur `ℂ` (espace préhilbertien réel
+  de dimension 2) qui l'**atteint avec égalité** `n · γ² = R²`. Deux points
+  `x₀ = 1 + I`, `x₁ = 1 − I` (demi-droites orthogonales), tous deux d'étiquette
+  `+1`, séparés par `u = 1` avec marge `γ = 1`, de norme `‖xₖ‖ = √2` (donc
+  `R = √2`), et `n = 2` : on a `n · γ² = 2 = (√2)² = R²`. Puisque l'inégalité
+  universelle `≤ R²` et l'égalité du témoin coexistent, aucune borne de la forme
+  `n · γ² ≤ c · R²` avec `c < 1` n'est valable sur toutes les exécutions : la
+  constante `1` devant `(R/γ)²` est la meilleure possible.
+
 La preuve ne dépend d'aucune hypothèse de dimension : tout vient de la structure
 d'espace préhilbertien réel (`InnerProductSpace ℝ V`), de la commutativité du
 produit scalaire réel, de Cauchy–Schwarz (`real_inner_le_norm`) et du développement
@@ -62,6 +77,7 @@ Mathlib.
 | `Perceptron/Data.lean` | 0 | Espace préhilbertien réel, `norm_sq_eq_inner_self`, développement `norm_add_sq_eq` (`‖a+b‖² = ‖a‖² + 2⟪a,b⟫ + ‖b‖²`), étiquettes `±1` (`IsLabel`, `LabeledPoint`). |
 | `Perceptron/Perceptron.lean` | 0 | Suite des poids `perceptronWeights` (`w₀ = 0`, `w_{k+1} = wₖ + yₖ · xₖ`), structure `PerceptronRun` (données séparables + trace d'erreurs + invariants de marge/rayon). |
 | `Perceptron/Convergence.lean` | 0 | Lemme A `align_growth` (`⟪wₖ,u⟫ ≥ kγ`), Lemme B `norm_bound` (`‖wₖ‖² ≤ kR²`), Cauchy–Schwarz ⟹ **`novikoff_mistake_bound`** (`n · γ² ≤ R²`). |
+| `Perceptron/Tightness.lean` | 0 | **Saturation de la borne** : témoin concret sur `ℂ` (`x₀ = 1+I`, `x₁ = 1−I`, séparés par `u = 1`, `n = 2`, `γ = 1`, `R = √2`) atteignant l'égalité `n·γ² = R²` ⟹ **`novikoff_bound_is_sharp`** (la borne `(R/γ)²` est optimale — aucune constante `< 1` ne l'améliore). Utilitaire `complex_inner_re` (produit scalaire réel de `ℂ` en coordonnées). |
 | `Perceptron.lean` | 0 | Imports parapluie + doc de statut. |
 
 ## Build


### PR DESCRIPTION
## Summary

Adds `Perceptron/Tightness.lean` proving the Novikoff bound `n·γ² ≤ R²` (from `Convergence.lean`, shipped #4140) is **sharp/optimal**: an explicit `PerceptronRun ℂ` witness saturates it with **equality** `n·γ² = R²`. Since the universal inequality `≤ R²` and the witness's equality coexist, no bound `n·γ² ≤ c·R²` with `c < 1` can hold universally — the constant `1` in front of `(R/γ)²` is the best possible.

This is ai-01's GREENLIGHT'd margin-tightness grain of the deep-queue (#4051 steer 2026-06-24: *"vraie tentative research bornée (construire adversarial Ω((R/γ)²) updates, OU documenter INTRINSIC honnêtement)"*). The n=2 witness achieving equality is a sharpness result — the bound is **attained**, hence tight.

### Witness (geometric)

On `ℂ` as the 2D real inner product space: two points `x₀ = 1+I`, `x₁ = 1−I` (±45° half-lines, **orthogonal**), both label `+1`, separator `u = 1`, margin `γ = 1`, `‖xₖ‖ = √2` (so `R = √2`), `n = 2`.
- Update 1: `w₁ = x₀ = 1+I`.
- Update 2: `⟪w₁, x₁⟫ = ⟨1+I, 1−I⟩ = 0` (orthogonality) → `x₁` is exactly on `w₁`'s decision boundary → mistake.
- **Saturation**: `n·γ² = 2·1 = 2 = (√2)² = R²`. ∎

### Theorems (all 0-sorry)
- `novikoff_bound_is_sharp : ∃ run : PerceptronRun ℂ, (run.n : ℝ) * run.γ^2 = run.R^2`
- `tightnessRun_saturates : (tightnessRun.n : ℝ) * tightnessRun.γ^2 = tightnessRun.R^2`
- `complex_inner_re` (utility: real inner product on ℂ in coordinates `w.re·z.re + w.im·z.im`), `witnessPts_norm_sq`, `witness_margin_inner`, `witness_cross_inner`, `witness_w1`.

`ℂ` was chosen as the formalization target (vs ℝ×ℝ / EuclideanSpace) because the `InnerProductSpace ℝ ℂ` instance resolves via the Mathlib umbrella, avoiding the missing `Mathlib.Analysis.InnerProductSpace.Prod` olean in the shared cache (canonical v4.31.0-rc1 cache shared by 10 projects — cannot rebuild).

## Validation (§B Lean PR)

| Check | Result |
|-------|--------|
| `grep -c sorry` before/after | before 0 → **after 0** standalone-tactic (the single "sorry" mention is prose "sorry-free", explicitly CI-exempt) |
| Lake build | `lake build Perceptron` **SUCCESS 8497 jobs**, 0 error, 0 warning |
| Proof integrity | 0 standalone-tactic sorry → cannot depend on `sorryAx` (axioms: `[propext, Classical.choice, Quot.sound]`) |
| Anti-regression | new module only; `Perceptron/Data.lean`, `Perceptron.lean` (defs), `Convergence.lean` (Novikoff) **untouched** |

Build log excerpt (local, post-edit):
```
✔ [8496/8496] Built Perceptron.Tightness (288s)
Build completed successfully (8497 jobs).
```

## Files (3, +179/-2, atomic — one subject)
- `Perceptron/Tightness.lean` (NEW, 157 lines) — the sharpness module
- `Perceptron.lean` (+4) — umbrella import + status-doc line
- `README.md` (+20/-2) — table row + "Serrage de la borne" section + intro/status update

Complementary to #4051 (the lake + `novikoff_mistake_bound` were shipped in #4140; this PR adds the optimality/sharpness result). See #4051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)