### PR TITLE
fix(search): corrige la numérotation interne du notebook Search-10-SymbolicAutomata

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
@@ -14,9 +14,9 @@
     "tags": []
    },
    "source": [
-    "<< [Search-11-LinearProgramming](Search-9-LinearProgramming.ipynb) | [Index](../README.md) | [App-1-NQueens](../Applications/CSP/App-1-NQueens.ipynb) >>\n",
+    "<< [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) | [Index](../README.md) | [App-1-NQueens](../Applications/CSP/App-1-NQueens.ipynb) >>\n",
     "\n",
-    "# Search-12 : Automates Symboliques avec Z3\n",
+    "# Search-10 : Automates Symboliques avec Z3\n",
     "\n",
     "**Navigation** : [Index](../README.md) | [Suivant >>](../Applications/CSP/App-1-NQueens.ipynb)\n",
     "\n",
@@ -3505,7 +3505,7 @@
     "\n",
     "**Point cle** : Le predicat `Distinct` de Z3 verifie que toutes les variables d'une liste ont des valeurs differentes, ce qui modelise directement les contraintes Sudoku.\n",
     "\n",
-    "> **Pour aller plus loin** : Voir [Sudoku-12-SymbolicAutomata](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) pour une application complete."
+    "> **Pour aller plus loin** : Voir [Sudoku-13-SymbolicAutomata-Csharp](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) pour une application complete."
    ]
   },
   {
@@ -3606,7 +3606,7 @@
     "\n",
     "### Pour aller plus loin\n",
     "\n",
-    "- **Sudoku** : [Sudoku-12-SymbolicAutomata](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb)\n",
+    "- **Sudoku** : [Sudoku-13-SymbolicAutomata-Csharp](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb)\n",
     "- **SymbolicAI** : [SymbolicAI/SymbolicAI](../../SymbolicAI/README.md)\n",
     "- **Applications** : [App-1-NQueens](../Applications/CSP/App-1-NQueens.ipynb)"
    ]
@@ -4055,7 +4055,7 @@
     "\n",
     "**Series connexes** : \n",
     "- [SymbolicAI/SymbolicAI/Sudoku-4-Z3](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3\n",
-    "- [Sudoku-12-SymbolicAutomata](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) - Sudoku solver par automates symboliques"
+    "- [Sudoku-13-SymbolicAutomata-Csharp](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) - Sudoku solver par automates symboliques"
    ]
   },
   {


### PR DESCRIPTION
## Summary

[Search-10-SymbolicAutomata.ipynb](MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) portait des résidus d'une ancienne renumérotation (il était autrefois Search-11/Search-12). **3 labels markdown internes étaient incohérents** avec leurs liens cibles (déjà corrects), le nom de fichier, et la table du Part1 README.

Surfacé pendant le scan G.1 des feuilles READMEs de ma partition (grain #3975) — c'est un **notebook-side naming inconsistency**, pas un stale-ref README.

## Les 3 corrections (non-ambiguës, label rendu cohérent avec le lien existant)

| # | Cellule | Avant | Après | Autorité |
|---|---|---|---|---|
| 1 | cell 0 (H1) | `# Search-12 : Automates Symboliques avec Z3` | `# Search-10 : ...` | nom de fichier (`Search-10`) + Part1 README (Search-10=SymbolicAutomata). Évite aussi la **collision** avec mon Part3-Advanced `Search-12-PatternDatabases` (cycle 59) |
| 2 | cell 0 (nav précédent) | `[Search-11-LinearProgramming](Search-9-LinearProgramming.ipynb)` | `[Search-9-LinearProgramming](...)` | le **lien cible** est `Search-9-LinearProgramming.ipynb` (existe, H1 = "Search-9-LinearProgramming : Programmation Lineaire et Simplexe") |
| 3 | cell 77/79/89 (cross-ref ×3) | `[Sudoku-12-SymbolicAutomata](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb)` | `[Sudoku-13-SymbolicAutomata-Csharp](...)` | le **lien cible** est `Sudoku-13-SymbolicAutomata-Csharp.ipynb` (existe, confirmé cycle 60 fix Sudoku L671 « 13-15 = automates symboliques ») |

**Pourquoi non-ambigu** : dans les 3 cas, label et lien pointent vers le **même notebook** (juste un numéro de label différent du numéro de lien). Le lien est l'autorité car le fichier cible existe et résout → on rend le label cohérent avec le lien. Pas de jugement subjectif.

## Validation G.1 (read each target firsthand)

- Read H1 réel de `Search-9-LinearProgramming.ipynb` → confirme "Search-9-LinearProgramming : Programmation Lineaire et Simplexe".
- Confirmé `Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb` existe (nav prédécesseur = `Sudoku-12-Z3-Csharp.ipynb`).
- `git grep "Search-12"` → la seule occurrence pointant vers SymbolicAutomata était le H1 lui-même (corriger ne casse aucun cross-ref).
- Vérifié cell-types : cellules 0/77/79/89 = **markdown** (exec_count=None).

## Une inconsistance AMBIGUË laissée intacte (G.9, cycle séparé)

La même cellule 89 contient aussi : `[SymbolicAI/SymbolicAI/Sudoku-4-Z3](../../Sudoku/Sudoku-12-Z3-Python.ipynb)` — label "Sudoku-4-Z3" + série **SymbolicAI** vs lien `Sudoku-12-Z3-Python.ipynb` (série **Sudoku**). Ici label et lien pointent vers **des séries différentes** : il faut investigation pour savoir lequel était voulu (ce n'est pas un simple fix numéro/label). Laissée intacte pour ne pas sur-corriger (G.9). À traiter cycle suivant si confirmé.

## Catalogue & atomicité

- **1 sujet = 1 PR** : cohérence de numérotation interne d'1 notebook.
- **Markdown-only** (cellules markdown uniquement) → exception C.2, **pas de re-exec**.
- **0 churn outputs/metadata** : round-trip JSON chirurgical `json.dump(indent=1, ensure_ascii=False)` préserve le format d'origine (diff = exactement 5 insertions/5 suppressions, papermill metadata + outputs intégralement intacts, vérifié dans le diff).
- **Base fraîche** : branche depuis `origin/main`, 1 fichier modifié ≠ mes 4 autres PRs open (#4281/#4288/#4291/#4298) → aucun conflit.

See #3975