### PR TITLE
fix(search): corrige le label de cross-ref Z3 périmé dans Search-10-SymbolicAutomata

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "### Prerequis\n",
     "- [Search-1-StateSpace](Search-1-StateSpace.ipynb) - Notion d'espace d'etats\n",
-    "- [SymbolicAI/Sudoku-4-Z3](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3\n",
+    "- [Sudoku-12-Z3-Python](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3\n",
     "\n",
     "### Duree estimee : 2 heures"
    ]
@@ -4054,7 +4054,7 @@
     "**Navigation** : [Index](../README.md) | [Suivant >>](../Applications/CSP/App-1-NQueens.ipynb)\n",
     "\n",
     "**Series connexes** : \n",
-    "- [SymbolicAI/SymbolicAI/Sudoku-4-Z3](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3\n",
+    "- [Sudoku-12-Z3-Python](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3\n",
     "- [Sudoku-13-SymbolicAutomata-Csharp](../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) - Sudoku solver par automates symboliques"
    ]
   },


### PR DESCRIPTION
## Summary

Follow-up du finding différé explicitement signalé dans #4302 (cycle 62, laissé intact alors comme « ambigu »). Deux cellules markdown de [Search-10-SymbolicAutomata.ipynb](MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) citaient :

```
[SymbolicAI/Sudoku-4-Z3](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3       # cell 0
[SymbolicAI/SymbolicAI/Sudoku-4-Z3](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases  # cell 89 (path doublon)
```

Le **label** (`SymbolicAI/Sudoku-4-Z3`) est un relicat d'une ancienne organisation et est **incohérent** avec le **lien cible** (`Sudoku-12-Z3-Python.ipynb`).

## L'ambiguïté RÉSOLUE par investigation G.1 firsthand (leçon cycle 57)

Contrairement aux 3 corrections non-ambiguës de #4302 (label et lien = même notebook), ici le label et le lien pointaient vers **des séries différentes** → j'ai dû déterminer l'intention réelle avant de corriger :

| Vérif firsthand | Résultat |
|---|---|
| `Sudoku-4*` existe-t-il dans la série Sudoku ? | Oui : **`Sudoku-4-SimulatedAnnealing`** (C# + Python) — **pas Z3**. Rien ne correspond au label "Sudoku-4-Z3". |
| `Sudoku-12-Z3-Python.ipynb` existe-t-il ? | Oui. H1 = **« Z3 SMT Solver (Python) »** = exactement le texte du lien « Bases de Z3 ». |
| Que dit le README Sudoku ? | Sudoku-12 = Z3 (confirmé cycle 60, fix L671 « 11=Choco, 12=Z3 »). |

**Conclusion H1 (lien correct, label périmé)** : le notebook cible `Sudoku-12-Z3-Python.ipynb` est bien le bon (« Bases de Z3 »), le label `SymbolicAI/Sudoku-4-Z3` est un relicat (Sudoku-4-était-Z3, ou une série SymbolicAI/Sudoku fusionnée dans Sudoku). Le label est rendu cohérent avec le lien cible réel. Bonus : corrige le path doublon `SymbolicAI/SymbolicAI/` en cellule 89.

## Les 2 corrections

| Cellule | Avant | Après |
|---|---|---|
| 0 (« À retenir ») | `[SymbolicAI/Sudoku-4-Z3](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3` | `[Sudoku-12-Z3-Python](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3` |
| 89 (« Series connexes ») | `[SymbolicAI/SymbolicAI/Sudoku-4-Z3](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3` | `[Sudoku-12-Z3-Python](../../Sudoku/Sudoku-12-Z3-Python.ipynb) - Bases de Z3` |

## Catalogue & atomicité

- **1 sujet = 1 PR** : cohérence du label d'1 cross-ref Z3 (2 occurrences) dans 1 notebook.
- **Markdown-only** (cellules markdown) → exception C.2, **pas de re-exec**.
- **0 churn outputs/metadata** : round-trip JSON chirurgical, diff = exactement +2/-2 (papermill metadata + outputs intacts, vérifié dans le diff).
- **Distinct de #4302** (numbering) : lignes disjointes → **aucun conflit**. Les 2 PRs sont indépendantes.
- **Base fraîche** : branche depuis `origin/main` (post-merge #4281/#4288/#4291/#4298), 1 fichier.

## Pourquoi pas dans #4302

Signalé explicitement dans le body #4302 comme « ambigu (laissé intact G.9, cycle séparé) » — l'investigation G.1 (existerait-il un Sudoku-4-Z3 ? que contient réellement Sudoku-12-Z3-Python ?) était nécessaire avant de corriger, ce qui dépassait le scope du fix numbering purement mécanique de #4302. Séparation honnête (G.5/G.9).

See #3975