### PR TITLE
feat(lean): minimax_lean Concavity — Sion analytical hyps (4/4 proven, glue iter 1+2)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import Minimax.ZeroSum
+import Minimax.Concavity
 
 /-!
 # minimax_lean — bilinéarité du payoff pour le théorème minimax de von Neumann
@@ -30,6 +31,11 @@ ces quatre hypothèses.
   additivité + homogénéité en chaque variable (`payoff_add_in_x`, `payoff_smul_in_x`,
   `payoff_add_in_y`, `payoff_smul_in_y`), continuité jointe et restreinte
   (`continuous_payoff`, `continuous_payoff_in_x`, `continuous_payoff_in_y`). **0 sorry.**
+- `Minimax/Concavity.lean` — **itération 1 du glue Sion** : concavité/cvxicité du
+  payoff sur les simplexes (`payoff_concave_in_x`, `payoff_convex_in_x`, et en `y`),
+  puis quasi-concavité/quasi-convexité via les ponts Mathlib
+  (`payoff_quasiconcave_in_y`, `payoff_quasiconvex_in_x`) — 2 des 4 hyps de
+  `Sion.exists_isSaddlePointOn'`. **0 sorry.**
 
 ## Milestone suivant (OPEN — documenté, non sorry-stubbé)
 

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax.lean
@@ -31,25 +31,31 @@ ces quatre hypothèses.
   additivité + homogénéité en chaque variable (`payoff_add_in_x`, `payoff_smul_in_x`,
   `payoff_add_in_y`, `payoff_smul_in_y`), continuité jointe et restreinte
   (`continuous_payoff`, `continuous_payoff_in_x`, `continuous_payoff_in_y`). **0 sorry.**
-- `Minimax/Concavity.lean` — **itération 1 du glue Sion** : concavité/cvxicité du
+- `Minimax/Concavity.lean` — **glue Sion (itérations 1 & 2)** : concavité/cvxicité du
   payoff sur les simplexes (`payoff_concave_in_x`, `payoff_convex_in_x`, et en `y`),
   puis quasi-concavité/quasi-convexité via les ponts Mathlib
-  (`payoff_quasiconcave_in_y`, `payoff_quasiconvex_in_x`) — 2 des 4 hyps de
-  `Sion.exists_isSaddlePointOn'`. **0 sorry.**
+  (`payoff_quasiconcave_in_y`, `payoff_quasiconvex_in_x`) — itération 1 : 2 des 4 hyps
+  analytiques de `Sion.exists_isSaddlePointOn'`. **Itération 2** : semi-continuité
+  dérivée de la continuité (`payoff_lowerSemicontinuous_in_x`,
+  `payoff_upperSemicontinuous_in_y`) — les **2 hyps restantes**.
+  **Les 4 hyps analytiques sont désormais prouvées. 0 sorry.**
 
 ## Milestone suivant (OPEN — documenté, non sorry-stubbé)
 
-Le câblage explicite de `Sion.exists_isSaddlePointOn'` sur `stdSimplex ℝ m ×
-stdSimplex ℝ n` (compacité/convexité des simplexes + dérivation des
-quasi-convexité/quasi-concavité depuis l'affinité + LSC/USC depuis la continuité) est
-le **milestone ouvert** de l'issue #4054 : il n'est **pas** comblé par `sorry` mais
-laissé comme étape de formalisation à venir, honnêtement signalé.
+Les **4 hyps analytiques** de `Sion.exists_isSaddlePointOn'` (quasi-convexité en `x`,
+quasi-concavité en `y`, semi-continuité inférieure en `x`, supérieure en `y`) sont
+désormais **prouvées 0 sorry** dans `Concavity.lean`. Reste le **milestone ouvert** de
+l'issue #4054 : les instances topologiques `Pi`-sur-`ℝ`, la non-vacuité des simplexes
+(`stdSimplex`, faits Mathlib), et l'**application finale** réunissant les 4 hyps avec
+`isCompact_stdSimplex`/`convex_stdSimplex` vers `Sion.exists_isSaddlePointOn'`. Non
+comblé par `sorry`, laissé comme étape de formalisation à venir, honnêtement signalé.
 -/
 
 namespace MinimaxLean
 
-/-- Statut : `Minimax/ZeroSum.lean` entièrement 0-sorry. Bilinéarité + continuité du
-payoff prouvées. L'application finale de Sion sur les simplexes est le milestone OPEN. -/
+/-- Statut : `Minimax/ZeroSum.lean` + `Concavity.lean` entièrement 0-sorry. Bilinéarité
++ continuité du payoff, et les 4 hyps analytiques de Sion prouvées. Reste le câblage
+topologique final (instances Pi/ℝ + non-vacuité + application `Sion.minimax'`). -/
 abbrev Status : Prop := True
 
 end MinimaxLean

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/Concavity.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/Concavity.lean
@@ -1,0 +1,83 @@
+import Mathlib
+import Minimax.ZeroSum
+
+/-!
+# Minimax.Concavity — concavité/cvxicité du payoff (itération 1 du glue Sion)
+
+Le théorème minimax de **Sion** (cas classique) requiert, pour le payoff
+`f = payoff A` sur les simplexes `X = stdSimplex ℝ m`, `Y = stdSimplex ℝ n` :
+- `f(x, ·)` **quasi-concave** en `y` pour tout `x` ;
+- `f(·, y)` **quasi-convexe** en `x` pour tout `y`.
+
+Or le payoff est **linéaire** (donc affine) en chaque variable séparément — c'est
+la bilinéarité prouvée dans `ZeroSum.lean` (`payoff_add_in_x`, `payoff_smul_in_x`,
+`payoff_add_in_y`, `payoff_smul_in_y`). Une fonction linéaire est à la fois
+**concave et convexe** (l'inégalité de Jensen tient avec **égalité**). Ce module
+formalise ce fait : `payoff A · y` est `ConcaveOn`/`ConvexOn` sur le simplexe, et
+idem en `y`, puis (itération 2) dérive les `QuasiconcaveOn`/`QuasiconvexOn` exacts
+requis par `Sion.exists_isSaddlePointOn'`.
+
+C'est l'**itération 1 du glue Sion** (milestone #4054) : via les ponts Mathlib
+`ConcaveOn.quasiconcaveOn` / `ConvexOn.quasiconvexOn`, on obtient 2 des 4 hyps de
+Sion. L'application finale (compacité `isCompact_stdSimplex` + semi-continuité
+depuis `continuous_payoff` + ceci) reste le milestone OPEN documenté. Module
+**entièrement 0-sorry**.
+-/
+
+namespace MinimaxLean
+
+open Finset Set
+
+variable {m n : Type*} [Fintype m] [Fintype n]
+variable (A : PayoffMatrix m n)
+
+/-- Le payoff est **concave en `x`** sur le simplexe (linéarité ⟹ concavité,
+l'inégalité de Jensen tenant avec égalité : `payoff_smul_in_x` donne la multiplication
+scalaire `a * payoff A x y`, et `smul_eq_mul` normalise le `•` du but `ConcaveOn`). -/
+theorem payoff_concave_in_x (y : n → ℝ) :
+    ConcaveOn ℝ (stdSimplex ℝ m) fun x => payoff A x y := by
+  refine ⟨convex_stdSimplex ℝ m, ?_⟩
+  intro x _hx x' _hx' a b _ha _hb _hab
+  dsimp only
+  rw [payoff_add_in_x, payoff_smul_in_x, payoff_smul_in_x, smul_eq_mul, smul_eq_mul]
+
+/-- Le payoff est **convexe en `x`** sur le simplexe (une fonction linéaire est à
+la fois concave et convexe). -/
+theorem payoff_convex_in_x (y : n → ℝ) :
+    ConvexOn ℝ (stdSimplex ℝ m) fun x => payoff A x y := by
+  refine ⟨convex_stdSimplex ℝ m, ?_⟩
+  intro x _hx x' _hx' a b _ha _hb _hab
+  dsimp only
+  rw [payoff_add_in_x, payoff_smul_in_x, payoff_smul_in_x, smul_eq_mul, smul_eq_mul]
+
+/-- Le payoff est **concave en `y`** sur le simplexe. -/
+theorem payoff_concave_in_y (x : m → ℝ) :
+    ConcaveOn ℝ (stdSimplex ℝ n) fun y => payoff A x y := by
+  refine ⟨convex_stdSimplex ℝ n, ?_⟩
+  intro y _hy y' _hy' a b _ha _hb _hab
+  dsimp only
+  rw [payoff_add_in_y, payoff_smul_in_y, payoff_smul_in_y, smul_eq_mul, smul_eq_mul]
+
+/-- Le payoff est **convexe en `y`** sur le simplexe. -/
+theorem payoff_convex_in_y (x : m → ℝ) :
+    ConvexOn ℝ (stdSimplex ℝ n) fun y => payoff A x y := by
+  refine ⟨convex_stdSimplex ℝ n, ?_⟩
+  intro y _hy y' _hy' a b _ha _hb _hab
+  dsimp only
+  rw [payoff_add_in_y, payoff_smul_in_y, payoff_smul_in_y, smul_eq_mul, smul_eq_mul]
+
+/-- **Quasi-concavité en `y`** (itération 2 du glue Sion) : via le pont Mathlib
+`ConcaveOn.quasiconcaveOn`, requis par `Sion.exists_isSaddlePointOn'`
+(hypothèse `f(x, ·)` quasi-concave). -/
+theorem payoff_quasiconcave_in_y (x : m → ℝ) :
+    QuasiconcaveOn ℝ (stdSimplex ℝ n) fun y => payoff A x y :=
+  (payoff_concave_in_y A x).quasiconcaveOn
+
+/-- **Quasi-convexité en `x`** (itération 2 du glue Sion) : via le pont Mathlib
+`ConvexOn.quasiconvexOn`, requis par `Sion.exists_isSaddlePointOn'`
+(hypothèse `f(·, y)` quasi-convexe). -/
+theorem payoff_quasiconvex_in_x (y : n → ℝ) :
+    QuasiconvexOn ℝ (stdSimplex ℝ m) fun x => payoff A x y :=
+  (payoff_convex_in_x A y).quasiconvexOn
+
+end MinimaxLean

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/Concavity.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/Concavity.lean
@@ -22,6 +22,15 @@ C'est l'**itération 1 du glue Sion** (milestone #4054) : via les ponts Mathlib
 Sion. L'application finale (compacité `isCompact_stdSimplex` + semi-continuité
 depuis `continuous_payoff` + ceci) reste le milestone OPEN documenté. Module
 **entièrement 0-sorry**.
+
+**Itération 2** : dérive les 2 hyps de **semi-continuité** de Sion
+(`LowerSemicontinuousOn` en `x`, `UpperSemicontinuousOn` en `y`) depuis
+`continuous_payoff_in_x` / `continuous_payoff_in_y` (`ZeroSum.lean`) via les ponts
+`Continuous.lowerSemicontinuous` / `Continuous.upperSemicontinuous` puis
+`.lowerSemicontinuousOn` / `.upperSemicontinuousOn`. Les **4 hyps analytiques** de
+Sion sont désormais prouvées (quasi-concave/quasi-convexe + LSC/USC) ; reste le
+milestone OPEN : instances `Pi`-sur-`ℝ` + `stdSimplex` non-vide + application
+finale `Sion.minimax'`.
 -/
 
 namespace MinimaxLean
@@ -79,5 +88,33 @@ theorem payoff_quasiconcave_in_y (x : m → ℝ) :
 theorem payoff_quasiconvex_in_x (y : n → ℝ) :
     QuasiconvexOn ℝ (stdSimplex ℝ m) fun x => payoff A x y :=
   (payoff_convex_in_x A y).quasiconvexOn
+
+/-! ## Itération 2 — semi-continuité (2 hyps Sion restantes)
+
+Les 4 hyps analytiques de `Sion.minimax'` (`Mathlib/Topology/Sion.lean`) :
+- `hfy' : ∀ y ∈ Y, QuasiconvexOn ℝ X (f · y)` — **prouvée** (`payoff_quasiconvex_in_x`) ;
+- `hfx' : ∀ x ∈ X, QuasiconcaveOn ℝ Y (f x ·)` — **prouvée** (`payoff_quasiconcave_in_y`) ;
+- `hfy : ∀ y ∈ Y, LowerSemicontinuousOn (f · y) X` — **prouvée ci-dessous** ;
+- `hfx : ∀ x ∈ X, UpperSemicontinuousOn (f x ·) Y` — **prouvée ci-dessous**.
+
+Une fonction continue est à la fois semi-continue inférieurement et
+supérieurement (`Continuous.lowerSemicontinuous` / `Continuous.upperSemicontinuous`),
+et la restriction à une partie passe via `.lowerSemicontinuousOn` /
+`.upperSemicontinuousOn`. Le payoff est continu en chaque variable
+(`continuous_payoff_in_x` / `continuous_payoff_in_y`), d'où les deux hyps. -/
+
+/-- **Semi-continuité inférieure en `x`** (itération 2) : `f(·, y)` est
+`LowerSemicontinuousOn` sur le simplexe — continuité ⟹ LSC, requis par
+`Sion.minimax'` (hyp `hfy : ∀ y ∈ Y, LowerSemicontinuousOn (f · y) X`). -/
+theorem payoff_lowerSemicontinuous_in_x (y : n → ℝ) :
+    LowerSemicontinuousOn (fun x => payoff A x y) (stdSimplex ℝ m) :=
+  (continuous_payoff_in_x A y).lowerSemicontinuous.lowerSemicontinuousOn (stdSimplex ℝ m)
+
+/-- **Semi-continuité supérieure en `y`** (itération 2) : `f(x, ·)` est
+`UpperSemicontinuousOn` sur le simplexe — continuité ⟹ USC, requis par
+`Sion.minimax'` (hyp `hfx : ∀ x ∈ X, UpperSemicontinuousOn (f x ·) Y`). -/
+theorem payoff_upperSemicontinuous_in_y (x : m → ℝ) :
+    UpperSemicontinuousOn (fun y => payoff A x y) (stdSimplex ℝ n) :=
+  (continuous_payoff_in_y A x).upperSemicontinuous.upperSemicontinuousOn (stdSimplex ℝ n)
 
 end MinimaxLean

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/README.md
@@ -40,8 +40,9 @@ Ce premier livrable établit le **cœur formel** documenté de la preuve — la
 
 - **Toolchain** : `leanprover/lean4:v4.31.0-rc1` + Mathlib4 (`v4.31.0-rc1`)
 - **Sorry** : **0** sur tout le module. L'additivité + l'homogénéité du payoff en
-  chaque variable, ainsi que la continuité (jointe et restreinte), sont entièrement
-  prouvées.
+  chaque variable, la continuité (jointe et restreinte), et la concavité/cvxicité
+  du payoff sur les simplexes (+ dérivation des quasi-convexité/quasi-concavité de
+  Sion) sont entièrement prouvées.
 - **Build** : `lake build Minimax` (dépend de Mathlib4)
 - **CI** : `.github/workflows/lean-minimax.yml` (`sorry-filter-mode: standalone-tactic`,
   baseline `0`)
@@ -105,6 +106,24 @@ flowchart TD
   `continuous_payoff_in_x` / `continuous_payoff_in_y` (une variable fixée, via
   `fun_prop`).
 
+## Ce qui est formalisé (`Minimax/Concavity.lean`, 0 sorry) — itération 1 du glue Sion
+
+La **concavité/cvxicité du payoff** sur les simplexes — première moitié du câblage
+des hypothèses de Sion, dérivée de la bilinéarité ci-dessus :
+
+- **Concavité + cvxicité en `x`** : `payoff_concave_in_x`, `payoff_convex_in_x`
+  (`ConcaveOn`/`ConvexOn ℝ (stdSimplex ℝ m)`). Une fonction linéaire est à la fois
+  concave et convexe : l'inégalité de Jensen `a · f x + b · f x' ≤ f (a · x + b · x')`
+  tient avec **égalité** (le payoff se développe par `payoff_add_in_x` +
+  `payoff_smul_in_x`), le domaine convexe venant de `convex_stdSimplex`.
+- **Concavité + cvxicité en `y`** : `payoff_concave_in_y`, `payoff_convex_in_y`
+  (analogue sur `stdSimplex ℝ n`).
+- **Quasi-concavité / quasi-convexité** (itération 2, **hyps exactes de Sion**) :
+  `payoff_quasiconcave_in_y` (`f(x, ·)` quasi-concave, via le pont
+  `ConcaveOn.quasiconcaveOn`) et `payoff_quasiconvex_in_x` (`f(·, y)` quasi-convexe,
+  via `ConvexOn.quasiconvexOn`). **Ces deux hyps de `Sion.exists_isSaddlePointOn'`
+  sont désormais prouvées.**
+
 > **Note de formalisation** — `Finset.mul_sum` (factorisation à GAUCHE dans la somme)
   vs `Finset.sum_mul` (factorisation à DROITE) : l'homogénéité `c · ∑ f = ∑ c · f`
   requiert `Finset.mul_sum`, pas `sum_mul`. La distributivité de l'additivité dépend
@@ -114,12 +133,19 @@ flowchart TD
 ## Milestone suivant (OPEN — documenté, non sorry-stubbé)
 
 Le câblage explicite de `Sion.exists_isSaddlePointOn'` sur
-`stdSimplex ℝ m × stdSimplex ℝ n` est le **milestone ouvert** de l'issue #4054 :
-compacité/convexité/non-vacuité des simplexes (`stdSimplex`), dérivation des
-`QuasiconvexOn`/`QuasiconcaveOn` depuis l'affinité, et des
-`LowerSemicontinuousOn`/`UpperSemicontinuousOn` depuis la continuité. Il est
-**honnêtement signalé comme étape à venir** dans l'umbrella `Minimax.lean`
-(`Status : Prop := True`) — jamais comblé par `sorry`.
+`stdSimplex ℝ m × stdSimplex ℝ n` est le **milestone ouvert** de l'issue #4054.
+**Progrès réalisé** (`Minimax/Concavity.lean`) : la dérivation des
+`QuasiconvexOn`/`QuasiconcaveOn` depuis l'affinité est **désormais prouvée**
+(`payoff_quasiconvex_in_x`, `payoff_quasiconcave_in_y`) — soit 2 des 4 hyps de
+Sion. **Reste ouvert** : compacité/non-vacuité des simplexes (`stdSimplex`,
+faits Mathlib `isCompact_stdSimplex`/convexité/non-vacuité à référencer), dérivation
+des `LowerSemicontinuousOn`/`UpperSemicontinuousOn` depuis `continuous_payoff`, et
+l'**application finale** de `Sion.exists_isSaddlePointOn'` réunissant les quatre
+hyps. C'est honnêtement signalé comme étape à venir dans l'umbrella `Minimax.lean`
+(`Status : Prop := True`) — jamais comblé par `sorry`. Le TODO de l'en-tête de
+Mathlib `Topology/Sion.lean` (« Spell out the particular case of von Neumann
+theorem ») confirme qu'il s'agit d'un travail de formalisation en cours
+**en amont dans Mathlib lui-même**.
 
 ## Référence
 

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/README.md
@@ -40,9 +40,9 @@ Ce premier livrable établit le **cœur formel** documenté de la preuve — la
 
 - **Toolchain** : `leanprover/lean4:v4.31.0-rc1` + Mathlib4 (`v4.31.0-rc1`)
 - **Sorry** : **0** sur tout le module. L'additivité + l'homogénéité du payoff en
-  chaque variable, la continuité (jointe et restreinte), et la concavité/cvxicité
-  du payoff sur les simplexes (+ dérivation des quasi-convexité/quasi-concavité de
-  Sion) sont entièrement prouvées.
+  chaque variable, la continuité (jointe et restreinte), la concavité/cvxicité du
+  payoff sur les simplexes, et les **4 hyps analytiques de Sion** (quasi-convexité,
+  quasi-concavité, semi-continuité inf./sup.) sont entièrement prouvées.
 - **Build** : `lake build Minimax` (dépend de Mathlib4)
 - **CI** : `.github/workflows/lean-minimax.yml` (`sorry-filter-mode: standalone-tactic`,
   baseline `0`)
@@ -106,10 +106,10 @@ flowchart TD
   `continuous_payoff_in_x` / `continuous_payoff_in_y` (une variable fixée, via
   `fun_prop`).
 
-## Ce qui est formalisé (`Minimax/Concavity.lean`, 0 sorry) — itération 1 du glue Sion
+## Ce qui est formalisé (`Minimax/Concavity.lean`, 0 sorry) — glue Sion (itérations 1 & 2)
 
-La **concavité/cvxicité du payoff** sur les simplexes — première moitié du câblage
-des hypothèses de Sion, dérivée de la bilinéarité ci-dessus :
+Les **4 hyps analytiques** de `Sion.exists_isSaddlePointOn'`, dérivées de la
+bilinéarité ci-dessus :
 
 - **Concavité + cvxicité en `x`** : `payoff_concave_in_x`, `payoff_convex_in_x`
   (`ConcaveOn`/`ConvexOn ℝ (stdSimplex ℝ m)`). Une fonction linéaire est à la fois
@@ -118,11 +118,21 @@ des hypothèses de Sion, dérivée de la bilinéarité ci-dessus :
   `payoff_smul_in_x`), le domaine convexe venant de `convex_stdSimplex`.
 - **Concavité + cvxicité en `y`** : `payoff_concave_in_y`, `payoff_convex_in_y`
   (analogue sur `stdSimplex ℝ n`).
-- **Quasi-concavité / quasi-convexité** (itération 2, **hyps exactes de Sion**) :
+- **Quasi-concavité / quasi-convexité** (itération 1, **hyps exactes de Sion**) :
   `payoff_quasiconcave_in_y` (`f(x, ·)` quasi-concave, via le pont
   `ConcaveOn.quasiconcaveOn`) et `payoff_quasiconvex_in_x` (`f(·, y)` quasi-convexe,
-  via `ConvexOn.quasiconvexOn`). **Ces deux hyps de `Sion.exists_isSaddlePointOn'`
-  sont désormais prouvées.**
+  via `ConvexOn.quasiconvexOn`).
+- **Semi-continuité** (itération 2, **2 hyps restantes de Sion**) :
+  `payoff_lowerSemicontinuous_in_x` (`f(·, y)` semi-continue inférieurement, via
+  `Continuous.lowerSemicontinuous.lowerSemicontinuousOn` depuis
+  `continuous_payoff_in_x`) et `payoff_upperSemicontinuous_in_y` (`f(x, ·)`
+  semi-continue supérieurement, via
+  `Continuous.upperSemicontinuous.upperSemicontinuousOn` depuis
+  `continuous_payoff_in_y`). Une fonction continue est à la fois LSC et USC.
+
+**Les 4 hyps analytiques de `Sion.exists_isSaddlePointOn'` (quasi-convexité en `x`,
+quasi-concavité en `y`, semi-continuité inf. en `x`, sup. en `y`) sont désormais
+toutes prouvées 0 sorry.**
 
 > **Note de formalisation** — `Finset.mul_sum` (factorisation à GAUCHE dans la somme)
   vs `Finset.sum_mul` (factorisation à DROITE) : l'homogénéité `c · ∑ f = ∑ c · f`
@@ -134,14 +144,15 @@ des hypothèses de Sion, dérivée de la bilinéarité ci-dessus :
 
 Le câblage explicite de `Sion.exists_isSaddlePointOn'` sur
 `stdSimplex ℝ m × stdSimplex ℝ n` est le **milestone ouvert** de l'issue #4054.
-**Progrès réalisé** (`Minimax/Concavity.lean`) : la dérivation des
-`QuasiconvexOn`/`QuasiconcaveOn` depuis l'affinité est **désormais prouvée**
-(`payoff_quasiconvex_in_x`, `payoff_quasiconcave_in_y`) — soit 2 des 4 hyps de
-Sion. **Reste ouvert** : compacité/non-vacuité des simplexes (`stdSimplex`,
-faits Mathlib `isCompact_stdSimplex`/convexité/non-vacuité à référencer), dérivation
-des `LowerSemicontinuousOn`/`UpperSemicontinuousOn` depuis `continuous_payoff`, et
-l'**application finale** de `Sion.exists_isSaddlePointOn'` réunissant les quatre
-hyps. C'est honnêtement signalé comme étape à venir dans l'umbrella `Minimax.lean`
+**Progrès réalisé** (`Minimax/Concavity.lean`, itérations 1 & 2) : les **4 hyps
+analytiques** de Sion sont **désormais prouvées** — `payoff_quasiconvex_in_x`,
+`payoff_quasiconcave_in_y` (itération 1, depuis l'affinité) +
+`payoff_lowerSemicontinuous_in_x`, `payoff_upperSemicontinuous_in_y` (itération 2,
+depuis la continuité). **Reste ouvert** : les instances topologiques `Pi`-sur-`ℝ`
+requises par `Sion.minimax'`, la non-vacuité des simplexes (`stdSimplex`, fait
+Mathlib), et l'**application finale** réunissant les 4 hyps analytiques avec
+`isCompact_stdSimplex`/`convex_stdSimplex` vers `Sion.exists_isSaddlePointOn'`. C'est
+honnêtement signalé comme étape à venir dans l'umbrella `Minimax.lean`
 (`Status : Prop := True`) — jamais comblé par `sorry`. Le TODO de l'en-tête de
 Mathlib `Topology/Sion.lean` (« Spell out the particular case of von Neumann
 theorem ») confirme qu'il s'agit d'un travail de formalisation en cours


### PR DESCRIPTION
## Summary

Adds `Minimax/Concavity.lean` proving the payoff `payoff A x y` is **both `ConcaveOn` and `ConvexOn`** on `stdSimplex ℝ m` (in x) and `stdSimplex ℝ n` (in y). A linear function satisfies Jensen's inequality with **equality**, so it is both concave and convex. Derived from the bilinearity lemmas already proven in `ZeroSum.lean` (#4054 phase-1).

Then (iteration 2) obtains the **exact Sion hypotheses** via Mathlib bridges:
- `payoff_quasiconcave_in_y` — `f(x, ·)` quasiconcave → **1 of Sion's 4 hyps ✓**
- `payoff_quasiconvex_in_x` — `f(·, y)` quasiconvex → **2 of Sion's 4 hyps ✓**

This is **iteration 1 of the "multi-iter Sion glue" deep-queue grain** (ai-01 steer 2026-06-24). Firsthand verification (G.1, against the old OPEN verdict): `stdSimplex` compactness/convexity/non-emptiness are **proven Mathlib facts** (`isCompact_stdSimplex`, `convex_stdSimplex`) — referenced, not reproven — making the glue **more tractable than the old note suggested**. The Sion `QuasiconvexOn`/`QuasiconcaveOn` derivation from affinity is now **done**.

### Why this is measurable progress (not a "DONE")
Sion's `exists_isSaddlePointOn'` needs 4 hypotheses. This PR proves 2 (the convexity-side: `QuasiconvexOn` in x + `QuasiconcaveOn` in y). **Remaining OPEN** (honestly documented, not sorry-stubbed): `LowerSemicontinuousOn`/`UpperSemicontinuousOn` from `continuous_payoff` + the final `Sion.exists_isSaddlePointOn'` application. The Mathlib `Topology/Sion.lean` TODO ("Spell out the particular case of von Neumann theorem") confirms this is ongoing formalization **upstream in Mathlib itself**.

### Theorems (all 0-sorry)
- `payoff_concave_in_x`, `payoff_convex_in_x` (in x); `payoff_concave_in_y`, `payoff_convex_in_y` (in y)
- `payoff_quasiconcave_in_y` (via `ConcaveOn.quasiconcaveOn`), `payoff_quasiconvex_in_x` (via `ConvexOn.quasiconvexOn`)

**Key Lean insight**: the `ConcaveOn`/`ConvexOn` goal has `(fun x => ...) (...)` beta-redexes that `rw` won't reduce — `dsimp only` beta-reduces first, then the linearity `rw` chain (`payoff_add_in_x`, `payoff_smul_in_x`, `smul_eq_mul`) renders the goal `E ≤ E`, closed by `rw` reflexivity. Domain convexity = `convex_stdSimplex ℝ m/n` (Mathlib).

## Validation (§B Lean PR)

| Check | Result |
|-------|--------|
| `grep -c sorry` before/after | before 0 → **after 0** standalone-tactic (single "sorry" = prose "0-sorry", CI-exempt per lean-minimax.yml) |
| Lake build | `lake build Minimax` **SUCCESS 8495 jobs**, 0 error, 0 warning |
| Proof integrity | 0 standalone-tactic sorry → no sorryAx (axioms `[propext, Classical.choice, Quot.sound]`) |
| Anti-regression | `ZeroSum.lean` (7 bilinearity/continuity lemmas) **intact**; new module only |

Build log excerpt (local, post-edit):
```
✔ [8494/8494] Built Minimax.Concavity (294s)
Build completed successfully (8495 jobs).
```

## Files (3, +123/-8, atomic)
- `Minimax/Concavity.lean` (NEW, 83 lines)
- `Minimax.lean` (+6) — umbrella import + status-doc line
- `README.md` (+42/-8) — new "Concavity.lean" section + Milestone progress update (2/4 Sion hyps done)

Part of #4054 (Sion glue milestone, measurable progress). See #4054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)