### PR TITLE
docs(genai): Video LTX-2 READMEs quant accuracy (INT4/NF4 -> fp8-cast/GGUF Q4)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/README.md
@@ -23,7 +23,7 @@ Ce module explore les modèles de génération vidéo de pointe : HunyuanVideo, 
 | 2 | [02-2-LTX-Video-Lightweight](02-2-LTX-Video-Lightweight.ipynb) | Génération légère LTX | Local GPU | ~8GB |
 | 3 | [02-3-Wan-Video-Generation](02-3-Wan-Video-Generation.ipynb) | Génération Wan | Local GPU | ~10GB |
 | 4 | [02-4-SVD-Image-to-Video](02-4-SVD-Image-to-Video.ipynb) | SVD (Image → Vidéo) | ComfyUI | ~10GB |
-| 5 | [02-5-LTX2-Audiovisual](02-5-LTX2-Audiovisual.ipynb) | LTX-2 audio+vidéo conjoint (22B) | Local GPU | ~16-24GB (INT4/NF4) |
+| 5 | [02-5-LTX2-Audiovisual](02-5-LTX2-Audiovisual.ipynb) | LTX-2 audio+vidéo conjoint (22B) | Local GPU | ~14-24GB (fp8-cast natif, GGUF Q4 en prod) |
 
 ## Prérequis
 
@@ -78,7 +78,7 @@ pip install -r requirements-comfyui.txt
 
 ### LTX-2 (Lightricks, audiovisuel conjoint)
 - **Spécialité** : Génération **vidéo + audio synchronisés** en une passe (premier DiT audio-video fondationnel)
-- **Paramètres** : 22B (quantization INT4/NF4 obligatoire sur 24GB)
+- **Paramètres** : 22B (quantization obligatoire : `fp8-cast` natif borderline sur 24 GB, GGUF Q4 en production ~14 GB)
 - **VRAM** : ~16-24GB
 - **Licence** : LTX-2 Community (non-OSI, seuil commercial)
 

--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -31,7 +31,7 @@ On ne peut pas créer ce qu'on ne comprend pas. Ce niveau pose les bases techniq
 
 ### 02-Advanced - Générer du mouvement à partir de texte ou d'images
 
-Ce niveau explore les modèles génératifs vidéo : HunyuanVideo pour la qualité cinématographique (malgré ses 24 GB de VRAM), LTX-Video pour la génération rapide sur des configurations modestes, Wan pour les prompts multilingues, et Stable Video Diffusion pour animer une image existante. Chaque modèle a ses forces et ses limites — le but est de les connaître pour choisir le bon outil au bon moment. Le notebook 02-5 introduit en outre LTX-2 (Lightricks 22B), le seul modèle de la série qui génère vidéo **et audio synchronisés** en une seule passe de diffusion (quantization INT4/NF4 obligatoire, 20+ GB VRAM).
+Ce niveau explore les modèles génératifs vidéo : HunyuanVideo pour la qualité cinématographique (malgré ses 24 GB de VRAM), LTX-Video pour la génération rapide sur des configurations modestes, Wan pour les prompts multilingues, et Stable Video Diffusion pour animer une image existante. Chaque modèle a ses forces et ses limites — le but est de les connaître pour choisir le bon outil au bon moment. Le notebook 02-5 introduit en outre LTX-2 (Lightricks 22B), le seul modèle de la série qui génère vidéo **et audio synchronisés** en une seule passe de diffusion (quantization obligatoire : `fp8-cast` via ltx-pipelines — borderline sur 24 GB — ou GGUF Q4 via ComfyUI en production, ~14-24 GB VRAM).
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -95,7 +95,7 @@ Le fil rouge de cette série est la création d'un pipeline de vidéo pédagogiq
 | **LTX-Video** | 02-2 | GPU ~8 GB VRAM |
 | **Wan 2.1/2.2** | 02-3 | GPU ~10 GB VRAM |
 | **SVD** | 02-4 | GPU ~10 GB VRAM |
-| **LTX-2 (Lightricks)** | 02-5 | GPU ~16-24 GB VRAM (INT4/NF4) |
+| **LTX-2 (Lightricks)** | 02-5 | GPU ~14-24 GB VRAM (GGUF Q4 / fp8-cast) |
 | **ComfyUI Video** | 03-3 | Docker, nodes vidéo |
 | **OpenAI Sora 2** | 04-3 | `OPENAI_API_KEY` |
 


### PR DESCRIPTION
## Summary

Bottom-up doc accuracy for the GenAI **Video** family (#3974 leaf READMEs), after the LTX-2 audiovisual work (#2891 DONE via PR #3209).

The Video leaf READMEs claimed **"INT4/NF4 obligatoire"** for LTX-2 (22B). This is factually wrong and is corrected here to the accurate two-path reality.

## G.1 firsthand grounding (not propagation)

The `02-5-LTX2-Audiovisual.ipynb` notebook **contradicts the READMEs**. Verified against notebook source:

- `ltx-pipelines` 1.0.0 supports **ONLY** `fp8-cast` / `fp8-scaled-mm` as quantization policy — `int4_nf4` / `int8` / `nf4` **DO NOT EXIST** in ltx-pipelines (notebook code comment, lines 113-115; bitsandbytes INT4/NF4 is NOT wired in).
- `fp8-cast` = ~22 GB, **borderline OOM on RTX 3090** (24 GB, ~2 GB left for activations on 97 frames).
- The **production path** (the one that generated the real A/V committed in #3209) is **ComfyUI + GGUF Q4** (~14 GB, comfortable on 3090). `unsloth/LTX-2.3-GGUF`.

So "INT4/NF4 obligatoire" was wrong for **both** paths. The READMEs now state the real situation: `fp8-cast` via ltx-pipelines (borderline) **or** GGUF Q4 via ComfyUI (production).

## Changes (4 occurrences, 2 files, docs-only)

| File | Location | Before -> After |
|------|----------|-----------------|
| `Video/README.md` | 02-Advanced prose | `(INT4/NF4 obligatoire, 20+ GB)` -> `(fp8-cast via ltx-pipelines — borderline 24 GB — ou GGUF Q4 via ComfyUI en production, ~14-24 GB)` |
| `Video/README.md` | tech table | `~16-24 GB VRAM (INT4/NF4)` -> `~14-24 GB VRAM (GGUF Q4 / fp8-cast)` |
| `Video/02-Advanced/README.md` | notebooks table | `~16-24GB (INT4/NF4)` -> `~14-24GB (fp8-cast natif, GGUF Q4 en prod)` |
| `Video/02-Advanced/README.md` | tech-keys | `(quantization INT4/NF4 obligatoire sur 24GB)` -> `(quantization obligatoire : fp8-cast natif borderline 24 GB, GGUF Q4 en production ~14 GB)` |

VRAM range corrected `~16-24 -> ~14-24 GB` (GGUF Q4 low end). Filename links preserved. No emojis.

## Validation

- `git diff --stat`: 2 files, 4 insertions / 4 deletions (balanced, no churn).
- 0 residual `INT4/NF4` in the 2 READMEs (grep).
- Catalog byte-identical to main (`COURSE_CATALOG.generated.{json,md}` clean).
- Branch off fresh `origin/main` (0 behind).
- No GPU consumed.

## Out of scope (principle 3 — separate pass)

The `02-5` notebook **itself** carries the same stale `INT4/NF4` claims in its intro/tables (lines 51, 384, 474, 1317) that contradict its own corrected code (lines 94-116, 518, 657, 747-755). That is a notebook markdown-only edit (C.2 exception, no re-exec) — **not bundled here** to keep this PR README-only/atomic and to avoid touching the notebook that has its real `#3209` A/V output committed. Flagged for a separate notebook-accuracy pass.

See #3974