### PR TITLE
fix(search): corrige 5 labels de cross-ref périmés dans Search-8-DancingLinks

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "- **Original paper** : Knuth, D. E. (2000). *Dancing Links*. arXiv:cs/0011047\n",
     "- **Applications** : Sudoku, N-Queens, Pentominoes, Exact Cover\n",
-    "- **Notebook connexe** : [Sudoku-5-DancingLinks](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)"
+    "- **Notebook connexe** : [Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)"
    ]
   },
   {
@@ -1973,7 +1973,7 @@
     "3. L'extraction de la solution DLX vers une grille resolue\n",
     "\n",
     "Cette implementation complete est presentee dans le notebook dedie :\n",
-    "**[Sudoku-5-DancingLinks](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)**\n",
+    "**[Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)**\n",
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
@@ -3153,8 +3153,8 @@
     "### Pour aller plus loin\n",
     "\n",
     "- **Papier original** : Knuth, D. E. (2000). *Dancing Links*. [arXiv:cs/0011047](https://arxiv.org/abs/cs/0011047)\n",
-    "- **Notebook Sudoku** : [Sudoku-5-DancingLinks](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)\n",
-    "- **Notebook suivant** : [Search-11-LinearProgramming](Search-9-LinearProgramming.ipynb) - Programmation lineaire\n",
+    "- **Notebook Sudoku** : [Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)\n",
+    "- **Notebook suivant** : [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) - Programmation lineaire\n",
     "- **Applications** : [App-11-Picross](../Applications/CSP/App-11-Picross.ipynb) - DLX pour Picross"
    ]
   },
@@ -3177,7 +3177,7 @@
     "**Navigation** : [<< Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)\n",
     "\n",
     "**Series connexes** : \n",
-    "- [Sudoku-5-DancingLinks](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb) - Application complete pour Sudoku\n",
+    "- [Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb) - Application complete pour Sudoku\n",
     "- [Search-App-11-Picross](../Applications/CSP/App-11-Picross.ipynb) - DLX pour Picross"
    ]
   },


### PR DESCRIPTION
## Summary

[Search-8-DancingLinks.ipynb](MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb) portait des résidus d'une ancienne renumérotation : **5 labels markdown citaient des numéros de notebook faux** tandis que leurs liens cibles (qui existent) portent le bon numéro. Même famille de bug que #4302 / #4304 (cycle 62-63, Search-10).

Surfacé par un **scan systématique des cross-refs internes** de ma partition (.NET : Search + Sudoku + GameTheory-non-Lean, 112 notebooks, 600 liens markdown) — scan read-heavy délégué à sous-agent, jugement gardé.

## Les 5 corrections (non-ambiguës, label rendu cohérent avec le lien existant)

| Cellule | Label avant | Label après | Lien cible (existe) |
|---|---|---|---|
| 0 | `[Sudoku-5-DancingLinks]` | `[Sudoku-2-DancingLinks-Python]` | `Sudoku/Sudoku-2-DancingLinks-Python.ipynb` |
| 36 | `[Sudoku-5-DancingLinks]` | `[Sudoku-2-DancingLinks-Python]` | (idem) |
| 55 | `[Sudoku-5-DancingLinks]` | `[Sudoku-2-DancingLinks-Python]` | (idem) |
| 55 | `[Search-11-LinearProgramming]` | `[Search-9-LinearProgramming]` | `Search-9-LinearProgramming.ipynb` |
| 56 | `[Sudoku-5-DancingLinks]` | `[Sudoku-2-DancingLinks-Python]` | (idem) |

**Non-ambigu** : label et lien = même série, juste un numéro de label différent du numéro de lien → le fichier cible (qui existe) est l'autorité. Le `Search-11-LinearProgramming`→`Search-9` est **identique** au bug corrigé dans Search-10 (#4302).

## Validation G.1 (read firsthand)

- Lu les cellules 0/36/55/56 directement : toutes **markdown** (exec_count=None).
- Confirmé `Sudoku-2-DancingLinks-Python.ipynb` existe (série Sudoku, DancingLinks).
- Confirmé `Search-9-LinearProgramming.ipynb` existe, H1 = "Search-9-LinearProgramming : Programmation Lineaire et Simplexe".

## Laisser intact (G.9 — pas de sur-correction)

La cellule 0/56 contient aussi `[<< Metaheuristiques](Search-11-Metaheuristics.ipynb)` (nav « précédent »). C'est un **label de sujet** (pas de numéro), et l'intention d'ordre pédagogique est ambiguë (DancingLinks=Search-8 entre Metaheuristics=Search-11 et LinearProgramming=Search-9 — relict possible d'ancien ordre, mais pas une incohérence numéro/label claire). Laissée intacte.

## Catalogue & atomicité

- **1 sujet = 1 PR** : cohérence des cross-refs d'1 notebook.
- **Markdown-only** (cellules markdown) → exception C.2, **pas de re-exec**.
- **Diff byte-for-byte minimal** : round-trip JSON **form-preserving** (préserve source string vs list) → exactement +5/-5, **0 churn** (papermill metadata + outputs + structure string→list intacts, vérifié dans le diff).
- **Base fraîche** : branche depuis `origin/main`, 1 fichier, ≠ mes 2 autres PRs open (#4302/#4304 sur Search-10) → aucun conflit.

## Contexte — deep-queue fidelity (anti-idle, règle 4)

Le scan systématique a trouvé **46 findings** au total sur ma partition (24 same-series number mismatches + 22 cross-series `Search-6/7/8`→`CSP-1/2/3` legacy). Cette PR = **1er fix atomique** (notebook Search-8). Les notebooks restants (Search-9, Sudoku-1/4/14/18, GameTheory-4c + Tier 2 cross-series) sont traités **notebook par notebook** dans les cycles suivants (G.5 anti-shopping-cart, 1 notebook/cycle), chacun vérifié G.1 firsthand avant edit. Partitions Part3/Part4/Applications/GameTheory(racine) = CLEAN.

See #3975