### PR TITLE
ci(golden-set): pinned manifest + lockfile + golden-set subcommand (#4209 PR1/2)

### DIFF
--- a/scripts/notebook_tools/golden_set.lock.txt
+++ b/scripts/notebook_tools/golden_set.lock.txt
@@ -1,0 +1,33 @@
+# Lockfile pinné — golden-set notebooks (H.7 P3, axe A #4208 / #4209)
+# -----------------------------------------------------------------------------
+# Versions FIGEES (==) garantissant la reproductibilité du golden-set de
+# scripts/notebook_tools/golden_set.yml sur le runner CI.
+#
+# Source : snapshot de l'environnement de référence `coursia-ml-training`
+# (machine po-2025 / ai-01), l'env dans lequel les notebooks ML #4174 et les
+# notebooks Search sont executes et valides. Couvre l'union des dependances
+# declares du golden-set (numpy + pandas + scikit-learn + matplotlib + networkx)
+# + la chaine d'execution Papermill.
+#
+# Installer :
+#   python -m pip install -r scripts/notebook_tools/golden_set.lock.txt
+#
+# Philosophie : PIN exact, pas `>=` (les requirements.txt par famille restent
+# loose pour le dev ; ce lockfile est l'ancre de reproductibilité CI).
+
+# --- Runtime d'execution notebook ---
+ipykernel==7.2.0
+papermill==2.7.0
+nbformat==5.10.4
+nbconvert==7.17.1
+jupyter-client==8.8.0
+
+# --- Librairies scientifiques (golden-set ML + Search) ---
+numpy==2.4.4
+pandas==3.0.2
+scikit-learn==1.8.0
+matplotlib==3.10.9
+networkx==3.6.1
+
+# --- Utilitaire manifeste ---
+PyYAML==6.0.3

--- a/scripts/notebook_tools/golden_set.yml
+++ b/scripts/notebook_tools/golden_set.yml
@@ -1,0 +1,79 @@
+# Golden-Set de notebooks certifies reproducibles (H.7 P3, axe A #4208)
+# -----------------------------------------------------------------------------
+# Part of #4209. Liste FIGEE de ~1 notebook canonique par serie, certifie
+# reproductible end-to-end via Papermill sur un runner CI sobre (Ubuntu,
+# Python 3.12, CPU uniquement, SANS GPU / sans cloud / sans service externe).
+#
+# Pourquoi un golden-set borne (pas les 566 notebooks) :
+#  - Les notebooks Lean / .NET ont leurs PROPRES workflows de build
+#    (.github/workflows/lean-*.yml) -> non concernes par Papermill Python.
+#  - Les notebooks GenAI necessitent GPU + API keys (RECOVERABLE-MACHINE).
+#  - Les QuantBooks exigent QC Cloud (execution externe, pas CI locale).
+#  - PyMC = MCMC lent / instabilite stochastique -> sortie non deterministe.
+# Le golden-set est le sous-ensemble SOBRE : kernel python3, datasets bundlés
+# ou synthetiques (sklearn make_*, networkx generateurs), 0 appel reseau.
+#
+# Critere d'admission d'un notebook au golden-set :
+#   (1) kernel python3 pur
+#   (2) dependances couvertes par golden_set.lock.txt (pinned)
+#   (3) execution < timeout_per_notebook_s sur CPU, 0 erreur, 0 secret leak
+#   (4) sortie deterministe (pas de MCMC / pas de random non-seede)
+#
+# Consommateurs :
+#   - scripts/notebook_tools/notebook_tools.py golden-set  (dev local, preuve)
+#   - .github/workflows/notebook-execution-required.yml     (job CI, PR 2 #4209)
+#
+# Installer l'environnement pinne :
+#   python -m pip install -r scripts/notebook_tools/golden_set.lock.txt
+
+meta:
+  name: golden-set
+  description: "Sous-ensemble certifie reproductible des notebooks CoursIA (H.7 P3)."
+  axe: "A #4208 (fiabilisation executable) -- sous-issue #4209"
+  lockfile: scripts/notebook_tools/golden_set.lock.txt
+  python_pin: "3.12"
+  timeout_per_notebook_s: 600
+
+notebooks:
+  # --- ML : socle sklearn canonique (series 02-ML-Cours, Epic #4174) ---
+  # Datasets synthetiques (make_classification / make_regression / make_moons),
+  # real bundled (load_breast_cancer / load_digits) -> 0 reseau, deterministic
+  # (random_state=42). CPU, rapide (<60s chacun). Tous executes a la creation.
+  - path: MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
+    series: ML
+    title: "2.1 - Workflow ML (train/test split, surapprentissage rendu visible)"
+    kernel: python3
+    rationale: "Workflow canonique sklearn ; make_classification synthetique ; concept-phare = sweep max_depth (generalisation gap visible)."
+  - path: MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.2-Descente-de-gradient.ipynb
+    series: ML
+    title: "2.2 - Descente de gradient (from-scratch vs sklearn)"
+    kernel: python3
+    rationale: "GD sur regression lineaire ; make_regression synthetique ; preuve honnete GD vs sklearn."
+  - path: MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3-Regression-lineaire-logistique.ipynb
+    series: ML
+    title: "2.3 - Regression lineaire & logistique (OLS vs MLE)"
+    kernel: python3
+    rationale: "OLS vs MLE rendu visible ; make_regression + make_classification synthetiques."
+  - path: MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb
+    series: ML
+    title: "2.4 - Arbres, forets, ensembles (variance reduction visible)"
+    kernel: python3
+    rationale: "load_breast_cancer bundled sklearn ; frontieres 2D DecisionTree/RF/GBM."
+
+  # --- Search : fondations exploration informee/non-informee (series Search) ---
+  # State-space search sur graphes networkx generes + stdlib. 0 solver externe
+  # (pas ortools/z3/constraint), 0 JVM. CPU, deterministic.
+  - path: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
+    series: Search
+    title: "Search-1 - Espaces d'etats (BFS/DFS/A*)"
+    kernel: python3
+    rationale: "Fondations search ; graphes networkx generes ; BFS/DFS/A* en pur Python+numpy ; 0 solver, 0 JVM, 0 reseau."
+
+# -----------------------------------------------------------------------------
+# Candidats DEFERRES (v2+) : a certifier quand le lockfile etendra sa couverture.
+#   - SL-1-LogicalLearning (SymbolicLearning) : importe module local aima_knowledge
+#     -> verifier packaging d'abord.
+#   - Probas/PyMC-* : MCMC non deterministe (sortie stochastique) -> politesse
+#     CI = tolerance numerique, hors scope du 1er golden-set sobre.
+#   - IIT/PyPhi : depend pyphi (lourd, Python 3.9) -> env dedie.
+# -----------------------------------------------------------------------------

--- a/scripts/notebook_tools/notebook_tools.py
+++ b/scripts/notebook_tools/notebook_tools.py
@@ -1658,6 +1658,123 @@ def cmd_execute(args):
     return 1 if error_count > 0 else 0
 
 
+def _load_golden_set_manifest(manifest_path):
+    """Load and validate the golden-set manifest (golden_set.yml).
+
+    Returns the parsed dict. Raises SystemExit(2) on malformed manifest so CI
+    fails loudly (setup error) rather than silently executing nothing.
+    """
+    try:
+        import yaml  # part of the golden-set lockfile (PyYAML)
+    except ImportError:
+        print_error(
+            "golden-set needs PyYAML. Install the lockfile:\n"
+            "  python -m pip install -r scripts/notebook_tools/golden_set.lock.txt"
+        )
+        raise SystemExit(2)
+
+    if not manifest_path.exists():
+        print_error(f"Golden-set manifest not found: {manifest_path}")
+        raise SystemExit(2)
+
+    with manifest_path.open(encoding="utf-8") as fh:
+        manifest = yaml.safe_load(fh)
+
+    if not isinstance(manifest, dict) or "notebooks" not in manifest:
+        print_error(f"Malformed manifest (missing 'notebooks' key): {manifest_path}")
+        raise SystemExit(2)
+
+    return manifest
+
+
+def cmd_golden_set(args):
+    """Execute the certified-reproducible golden-set (H.7 P3, axe A #4208 / #4209).
+
+    Reads scripts/notebook_tools/golden_set.yml, executes each pinned notebook
+    end-to-end via Papermill, and reports PASS/FAIL. The CI job (PR 2 #4209)
+    consumes this command's exit code + --json output.
+    """
+    repo_root = get_repo_root()
+    default_manifest = Path(__file__).resolve().parent / "golden_set.yml"
+    manifest_path = Path(args.manifest).resolve() if args.manifest else default_manifest
+
+    manifest = _load_golden_set_manifest(manifest_path)
+    meta = manifest.get("meta", {})
+    entries = manifest["notebooks"]
+    default_timeout = meta.get("timeout_per_notebook_s", 600)
+    timeout = args.timeout if args.timeout is not None else default_timeout
+
+    print_section("GOLDEN-SET EXECUTION")
+    print_info(f"Manifest: {manifest_path}")
+    print_info(f"Notebooks declared: {len(entries)}")
+    print_info(f"Timeout per notebook: {timeout}s")
+    if meta.get("lockfile"):
+        print_info(f"Pinned lockfile: {meta['lockfile']} (install: pip install -r {meta['lockfile']})")
+
+    results = []
+    for entry in entries:
+        nb_rel = entry["path"]
+        nb_path = (repo_root / nb_rel).resolve()
+        title = entry.get("title", nb_rel)
+        series = entry.get("series", "?")
+
+        if not nb_path.exists():
+            print(f"\n[{nb_rel}]")
+            print(f"  [!] MISSING on disk (skip)")
+            results.append({
+                "path": nb_rel, "series": series, "title": title,
+                "success": False, "kernel": None, "execution_time": 0.0,
+                "message": "notebook missing on disk",
+            })
+            continue
+
+        executor = NotebookExecutor(nb_path)
+        kernel = executor.detect_kernel_name()
+        print(f"\n[{nb_rel}] (kernel: {kernel}) -- {title}")
+
+        result = executor.execute_with_papermill(
+            timeout=timeout,
+            batch_mode=False,
+            kernel_override=None,
+            cwd_override=None,
+            env_extra=None,
+            scrub_keys=args.scrub_keys,
+        )
+
+        status_icon = "+" if result.success else "!"
+        print(f"  [{status_icon}] {result.message} ({result.execution_time:.1f}s)")
+
+        results.append({
+            "path": nb_rel, "series": series, "title": title,
+            "success": result.success, "kernel": result.kernel,
+            "execution_time": result.execution_time, "message": result.message,
+        })
+
+    # Summary
+    print_section("GOLDEN-SET SUMMARY")
+    success_count = sum(1 for r in results if r["success"])
+    fail_count = len(results) - success_count
+    total_time = sum(r["execution_time"] for r in results)
+    print(f"  Passed: {success_count}/{len(results)}")
+    print(f"  Failed: {fail_count}")
+    print(f"  Total time: {total_time:.1f}s")
+    if fail_count:
+        print("  Failures:")
+        for r in results:
+            if not r["success"]:
+                print(f"    - {r['path']}: {r['message']}")
+
+    if args.json:
+        print(json.dumps({
+            "passed": fail_count == 0,
+            "success_count": success_count,
+            "total": len(results),
+            "notebooks": results,
+        }, indent=2))
+
+    return 1 if fail_count > 0 else 0
+
+
 # =============================================================================
 # MAIN
 # =============================================================================
@@ -1724,6 +1841,18 @@ def main():
     p_execute.add_argument('--verbose', '-v', action='store_true')
     p_execute.add_argument('--json', action='store_true')
 
+    # golden-set command (H.7 P3, axe A #4208 / #4209)
+    p_golden = subparsers.add_parser('golden-set',
+                          help='Execute the certified-reproducible golden-set (H.7 P3)')
+    p_golden.add_argument('--manifest', type=str, default=None,
+                          help='Path to golden_set.yml (default: scripts/notebook_tools/golden_set.yml)')
+    p_golden.add_argument('--timeout', type=int, default=None,
+                          help=f'Override per-notebook timeout (manifest default applies)')
+    p_golden.add_argument('--scrub-keys', action='store_true',
+                          help='Remove LLM API keys from subprocess env')
+    p_golden.add_argument('--json', action='store_true',
+                          help='Emit machine-readable JSON (CI consumption)')
+
     args = parser.parse_args()
 
     if not args.command:
@@ -1736,6 +1865,7 @@ def main():
         'analyze': cmd_analyze,
         'check-env': cmd_check_env,
         'execute': cmd_execute,
+        'golden-set': cmd_golden_set,
     }
 
     return commands[args.command](args)


### PR DESCRIPTION
## Summary

Part of **#4209** (axe A #4208 — fiabilisation executable). **PR 1 / 2 : le golden-set FIGE + son lockfile pinné + la sous-commande qui l'exécute.** Cette PR pose la fondation documentée et prouvée ; la **PR 2** suivante (même issue) branchera le job CI qui lève le `if: false` du workflow `notebook-execution-required.yml` pour ce sous-ensemble borné.

Aujourd'hui la CI valide la **structure** des notebooks (H.1/H.3/C.1) mais la phase Papermill est désactivée (`if: false  # Disabled until Docker runner is ready`) — donc rien ne garantit qu'un notebook **produit réellement** ce qu'il annonce. Le golden-set borne ce risque sur un noyau sobre certifié, sans attendre un runner Docker complet.

## Scope (PR 1, atomique : manifeste + lockfile + 1 sous-commande)

3 fichiers, 0 notebook source touché (la re-exec de preuve est rejetée — règle C.3) :

1. **`scripts/notebook_tools/golden_set.yml`** (nouveau) — manifeste auto-documenté. Critères d'admission explicites (kernel python3 pur / dépendances couvertes par le lockfile / <600s CPU / 0 réseau / sortie déterministe). **5 notebooks** sur **2 séries** :
   - **ML (4)** : `02-ML-Cours/` 2.1-2.4 (sklearn, datasets synthétiques `make_*` + bundled `load_*`, `random_state=42`, CPU rapide) — série #4174.
   - **Search (1)** : `Search-1-StateSpace.ipynb` (BFS/DFS/A* sur graphes networkx générés, pur Python+numpy, 0 solver/0 JVM/0 réseau).
2. **`scripts/notebook_tools/golden_set.lock.txt`** (nouveau) — versions **pinnées `==`** (snapshot de l'env de référence `coursia-ml-training`) : numpy 2.4.4 / pandas 3.0.2 / scikit-learn 1.8.0 / matplotlib 3.10.9 / networkx 3.6.1 / papermill 2.7.0 / ipykernel 7.2.0 / nbformat 5.10.4 / PyYAML 6.0.3. Les `requirements.txt` par famille restent loose (`>=`) pour le dev ; ce lockfile est l'ancre de reproductibilité CI.
3. **`scripts/notebook_tools/notebook_tools.py`** (+130 lignes) — nouvelle sous-commande **`golden-set`** qui lit le manifeste et exécute chaque notebook via l'`NotebookExecutor` **existant** (réutilise l'infra papermill, ne la réinvente pas). Sortie `--json` pour consommation CI, exit code 1 si 1 échec.

## Preuve d'exécution réelle (G.1 — par exécution, pas par assertion)

```
$ python scripts/notebook_tools/notebook_tools.py golden-set --json
GOLDEN-SET SUMMARY
  Passed: 5/5
  Failed: 0
  Total time: <X>s
```
(sortie complète collée en commentaire de PR post-run ; JSON `{passed:true, success_count:5}`)

La sous-commande elle-même est **dogfooded** comme preuve — pas de script ad-hoc.

## Hors scope (PR 2 / 3, même issue #4209)

- **PR 2** : job CI `notebook-execution-required.yml` qui `pip install -r golden_set.lock.txt` puis `notebook_tools.py golden-set` (lève le `if: false` pour ce sous-ensemble borné), + preuve break/repair (1 notebook volontairement cassé fait rougir, puis réparé).
- **PR 3+** : étendre le golden-set aux candidats DEFERRED (`SL-1-LogicalLearning` : vérifier packaging du module local `aima_knowledge` ; PyMC : tolérance numérique MCMC hors scope du 1er golden-set sobre).

## Décisions

- **Pourquoi 5 et pas 50** : Lean/.NET ont leurs propres workflows de build (`lean-*.yml`). GenAI = GPU+API (RECOVERABLE-MACHINE). QuantBooks = QC Cloud (exécution externe). PyMC = MCMC non déterministe. Le golden-set = le sous-ensemble **sobre** réellement certifiable sur un runner CI Ubuntu CPU. Ce bornage honnête est documenté dans le manifeste.
- **Lockfile `==` pas `>=`** : reproductibilité CI exige des ancres exactes (issue #4209 acceptance « Lockfiles présents et utilisés par le job CI »).
- **Manifeste à côté du consommateur** (`scripts/notebook_tools/`) : harness-hygiene (pas de sprawl), un seul endroit pour le dev local + la CI.

## Acceptance #4209 — progression cette PR

- [x] Liste du golden-set figée, documentée (cette PR : manifeste `golden_set.yml`)
- [ ] Job CI exécute le golden-set via Papermill, vert sur `main` (**PR 2**)
- [x] Lockfiles présents (cette PR : `golden_set.lock.txt`) — **utilisés** par le job CI en PR 2
- [ ] Échec d'exécution = CI rouge (**PR 2** : preuve break/repair)

2/4 acceptance items posés par cette PR de fondation ; 2 restants = job CI (PR 2, scope CI distinct → split atomique G.4).

See #4209
