### PR TITLE
docs(sc): add privacy-reconciliation convergence Mermaid to 04-Privacy-Cryptography README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/README.md
@@ -16,6 +16,19 @@ Cette quatrieme sous-serie (SC-15 a SC-17) explore la cryptographie avancee au s
 
 **Total** : 3 notebooks, ~2h35.
 
+SC-17 ne présente pas une primitive de plus : il **assemble** les preuves à divulgation nulle (SC-15) et le chiffrement homomorphe (SC-16) pour résoudre le paradoxe du vote électronique — concilier **anonymat** et **vérifiabilité**. Ce diagramme en fait la synthèse : chaque primitive assure l'une des deux propriétés opposées du paradoxe, et le capstone SC-26 les réutilisera toutes deux.
+
+```mermaid
+flowchart LR
+    SC15["SC-15 · Preuves à divulgation nulle<br/><b>prouver sans révéler</b><br/>Schnorr · Fiat-Shamir · Chaum-Pedersen"]
+    SC16["SC-16 · Chiffrement homomorphe<br/><b>calculer sans déchiffrer</b><br/>Paillier · CKKS · Shamir"]
+    SC17(("SC-17 · Vote E2E vérifiable<br/><b>anonymat + vérifiabilité</b>"))
+    SC26["SC-26 · Capstone<br/>DApp de vote complète<br/>(réutilise ZKP + Paillier)"]
+    SC15 -- "vérifiabilité<br/>(preuve de validité du bulletin)" --> SC17
+    SC16 -- "anonymat<br/>(tally sur chiffré)" --> SC17
+    SC17 --> SC26
+```
+
 ---
 
 ## Parcours d'apprentissage


### PR DESCRIPTION
## Summary

Adds a GitHub-native Mermaid concept diagram to the `04-Privacy-Cryptography` sub-series README (SC-15 → SC-17), part of the **#4212 editorial finish** (markdown-only, Prong B: authentic non-trivial concept).

## The concept (Prong B — verified firsthand)

`04-Privacy-Cryptography` is the **only** SC sub-series leaf whose structure is a genuine **convergence** with a non-trivial thesis:

- **Thesis** (README line 111): don't oppose *confidentiality* and *verifiability* as a trade-off — **reconcile them via cryptography**.
- **Structural dependency** (prereq table, line 45): `SC-17 ← SC-15 (ZKP) + SC-16 (HE)` — not just narrative.
- **The insight a diagram makes visible**: SC-17 composes **two primitives that each hide a different thing** — ZKP hides the *witness* (→ **verifiability**: a bulletin's validity is provable without revealing it), HE hides the *data* (→ **anonymity**: the tally is computed on ciphertext). Each edge in the diagram carries the property its primitive assures. The capstone SC-26 reuses both.

```mermaid
flowchart LR
    SC15["SC-15 · ZKP — prouver sans révéler"]
    SC16["SC-16 · HE — calculer sans déchiffrer"]
    SC17(("SC-17 · Vote E2E — anonymat + vérifiabilité"))
    SC15 -- "vérifiabilité" --> SC17
    SC16 -- "anonymat" --> SC17
```

## Why only this leaf (G.9 honest saturation)

The 5 remaining SC leaf READMEs (00/01/02/04/05) were assessed for an authentic Prong-B diagram:

| Leaf | Structure | Verdict |
|------|-----------|---------|
| 00-Foundations | 2-into-1 trivial funnel | WEAK (decoration) |
| 01-Solidity-Foundation | linear chain SC-3→4→5→6 | WEAK (restates prereq table) |
| 02-Solidity-Advanced | near-linear chain + orphan SC-11 | WEAK |
| **04-Privacy-Cryptography** | **convergence SC-17 ← SC-15 + SC-16** | **AUTHENTIC** ← this PR |
| 05-Alternative-Chains | 5 parallel pillars (independent comparisons) | WEAK (comparison matrix) |

Forcing a diagram on the 4 weak ones would violate sota-not-workaround Prong B (decoration, not an anchored thesis). They are honestly skipped.

## Validation

- **+13/-0**, 1 file, pure markdown addition (diagram + 2-sentence intro echoing the thesis).
- **Markdown-only exception C.2**: no source/outputs touched, no notebook re-exec needed.
- Sub-series leaf README — **no `CATALOG-STATUS` marker** (catalog-pr-hygiene HARD 1: N/A, like #4286/#4295).
- Fresh base off `origin/main` (`aa7eb9ed`), atomic (one subject), no submodule staged.

See #4212 (part of #4208 editorial-finish epic — partial contribution, not `Closes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)