### PR TITLE
fix(search): corrige 5 labels de cross-ref périmés dans Search-9-LinearProgramming

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
@@ -44,7 +44,7 @@
     "- **PuLP documentation** : https://coin-or.github.io/pulp/\n",
     "- **Solver** : CBC (Coin-OR Branch and Cut), inclus par defaut\n",
     "- **Theorie** : Algorithme du simplexe, theoreme de dualite\n",
-    "- **Notebook connexe** : [Search-App-7-PortfolioOptimization](../Applications/Hybrid/App-10-Portfolio.ipynb)"
+    "- **Notebook connexe** : [App-10-Portfolio](../Applications/Hybrid/App-10-Portfolio.ipynb)"
    ]
   },
   {
@@ -2700,9 +2700,9 @@
     "- Scheduling et ordonnancement\n",
     "\n",
     "**Notebooks connexes** :\n",
-    "- [Search-App-7-PortfolioOptimization](../Applications/Hybrid/App-10-Portfolio.ipynb) - PL pour la finance\n",
+    "- [App-10-Portfolio](../Applications/Hybrid/App-10-Portfolio.ipynb) - PL pour la finance\n",
     "- [Search-App-8-SupplyChain](../Applications/CSP/App-4-JobShopScheduling.ipynb) - Chaines d'approvisionnement\n",
-    "- [Sudoku-12-ConstraintProgramming](../../Sudoku/Sudoku-10-ORTools-Python.ipynb) - PLNE pour CSP\n",
+    "- [Sudoku-10-ORTools-Python](../../Sudoku/Sudoku-10-ORTools-Python.ipynb) - PLNE pour CSP\n",
     "\n",
     "**References** :\n",
     "- Bertsimas, D., & Tsitsiklis, J. N. (1997). *Introduction to Linear Optimization*. Athena Scientific.\n",
@@ -2714,8 +2714,8 @@
     "**Navigation** : [<< DancingLinks](Search-8-DancingLinks.ipynb) | [Index](../README.md) | [SymbolicAutomata >>](Search-10-SymbolicAutomata.ipynb)\n",
     "\n",
     "**Series connexes** :\n",
-    "- [Sudoku-3-ORTools](../../Sudoku/Sudoku-10-ORTools-Python.ipynb) - Constraint Programming\n",
-    "- [Search-App-7-PortfolioOptimization](../Applications/Hybrid/App-10-Portfolio.ipynb) - PL pour la finance"
+    "- [Sudoku-10-ORTools-Python](../../Sudoku/Sudoku-10-ORTools-Python.ipynb) - Constraint Programming\n",
+    "- [App-10-Portfolio](../Applications/Hybrid/App-10-Portfolio.ipynb) - PL pour la finance"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

[Search-9-LinearProgramming.ipynb](MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb) portait des résidus d'une ancienne renumérotation : **5 labels markdown citaient des numéros de notebook faux**. Même famille de bug que #4302 / #4304 / #4308 (cycles 62-64).

## Les 5 corrections (non-ambiguës, label rendu cohérent avec le lien existant)

| Cellule | Label avant | Label après | Lien cible (existe) | Preuve concept |
|---|---|---|---|---|
| 0 | `[Search-App-7-PortfolioOptimization]` | `[App-10-Portfolio]` | `App-10-Portfolio.ipynb` | Portfolio=finance, « PL pour la finance » matche |
| 46 | `[Search-App-7-PortfolioOptimization]` | `[App-10-Portfolio]` | (idem) | |
| 46 | `[Sudoku-12-ConstraintProgramming]` | `[Sudoku-10-ORTools-Python]` | `Sudoku-10-ORTools-Python.ipynb` | Sudoku-12 = Z3 (cycle 60), ORTools=Sudoku-10, « Constraint Programming » matche |
| 46 | `[Sudoku-3-ORTools]` | `[Sudoku-10-ORTools-Python]` | (idem) | Sudoku-3 = Genetic, ORTools=Sudoku-10 |
| 46 | `[Search-App-7-PortfolioOptimization]` (dup) | `[App-10-Portfolio]` | (idem) | |

**Non-ambigu** : label et lien = même concept (Portfolio/finance, ORTools/CP), juste un numéro/identité de label différent du fichier cible → le fichier (qui existe) est l'autorité.

## Validation G.1 (read firsthand)

- Cells 0/46 = markdown (exec_count=None).
- Cibles confirmées existantes : `App-10-Portfolio.ipynb`, `App-4-JobShopScheduling.ipynb`, `Sudoku-10-ORTools-Python.ipynb`.
- Confirmé Sudoku-3=Genetic (`Sudoku-3-Genetic-Csharp.ipynb`), Sudoku-12=Z3 (cycle 60 fix L671).

## Finding ambigu LAISSÉ INTACT (G.9 — out of scope)

Cellule 46 contient aussi `[App-8-SupplyChain](../Applications/CSP/App-4-JobShopScheduling.ipynb) - Chaines d'approvisionnement`. **Investigation G.1** :
- `find *upply* *chain*` dans Search = **0 notebook supply-chain** (le seul hit = faux positif path `astar_lean/lean-toolchain`).
- App-8 réel = **`App-8-MiniZinc.ipynb`** (pas SupplyChain).
- App-4-JobShopScheduling = H1 « Job-Shop Scheduling / Ordonnancement ».

Donc label number(8) **+** name(SupplyChain) **+** desc(« Chaines d'approvisionnement ») sont **TOUS** incohérents avec le lien (App-4=JobShop). Corriger juste le numéro serait absurde (SupplyChain ≠ JobShop — concepts distincts : ordonnancement d'atelier vs réseau logistique). Corriger le nom+desc = **réécriture éditoriale**, pas un fix mécanique de label. **Laissé intact**, tracker pour cycle séparé. C'est la prudence cycle 62 (cell 89 Search-10) / cycle 57 (framing).

## Catalogue & atomicité

- **1 sujet = 1 PR** : cohérence des cross-refs d'1 notebook.
- **Markdown-only** → exception C.2, **pas de re-exec**.
- **Form-preserving** round-trip (+6/-6, **0 churn** papermill/outputs ET 0 string→list normalization).
- **Base fraîche** origin/main, 1 fichier, ≠ mes 3 autres PRs open (Search-8/Search-10) → aucun conflit.

## Deep-queue fidelity (anti-idle, règle 4)

Notebooks Tier 1 restants (notebook par notebook, G.5 1/cycle, G.1 firsthand avant edit) : Sudoku-1 (4), Sudoku-4 (2), Sudoku-14 (1), Sudoku-18 (5, framing à vérifier — comparison table), GameTheory-4c (1, GT-18 inexistant max=17) + Tier 2 cross-series (22 occurrences `Search-6/7/8`→`CSP-1/2/3`, relabel sémantique). → lane non-idle.

See #3975