### PR TITLE
docs(ml): add DSA sibling READMEs — fix check-links regression (#4289)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/README.md
@@ -1,0 +1,39 @@
+# 01-PythonForDataScience — Fondations NumPy & Pandas
+
+[← DataScienceWithAgents (parent)](../README.md) | [02-ML-Cours (suite) →](../02-ML-Cours/README.md)
+
+Le socle Python data science qui précède tout le reste de la formation `DataScienceWithAgents` : **NumPy** pour les tableaux et la vectorisation, **Pandas** pour les données tabulaires. Deux notebooks volontairement resserrés, pensés comme le prérequis des fondations ML canoniques (`02-ML-Cours`) et des labs agentiques (`PythonAgentsForDataScience`), là où l'on interroge un DataFrame ou l'on entraîne un modèle.
+
+## Pourquoi cette série
+
+Avant d'orchestrer des agents LLM qui *écrivent* du code data science (labs LangChain / Google ADK), il faut lire, transformer et visualiser soi-même des données. Cette série installe les deux briques indépassables : la **vectorisation** NumPy (pourquoi une opération sur un tableau est à la fois plus courte et plus rapide qu'une boucle Python) et le **DataFrame** Pandas (le conteneur tabulaire qui structure tout le travail ultérieur). Sans elles, les labs agentic sont une boîte noire ; avec elles, on comprend *ce que* l'agent manipule et *pourquoi* son code tient.
+
+## Vue d'ensemble
+
+| Notebook | Contenu | Durée |
+|----------|---------|-------|
+| [1.2-NumPy](notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb) | `ndarray`, opérations vectorisées, agrégations (`sum`, `mean`), gain de performance vs boucles | ~45 min |
+| [1.3-Pandas](notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb) | `DataFrame`, sélection de colonnes, filtrage booléen, manipulation tabulaire | ~60 min |
+
+> **Numérotation.** La série commence à `1.2` car le `1.1` d'introduction est couvert par le [README parent](../README.md). La continuité logique est `1.2` (NumPy) → `1.3` (Pandas) → [Lab 1](../PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb) (mise en pratique sur ventes synthétiques) → [02-ML-Cours 2.1](../02-ML-Cours/2.1-Workflow-ML.ipynb).
+
+## Objectifs d'apprentissage
+
+À l'issue de cette série, l'apprenant sait :
+
+1. Créer des tableaux NumPy depuis des listes Python et appliquer des opérations **vectorisées** (sans boucle explicite).
+2. Mesurer l'avantage de performance de la vectorisation NumPy sur le Python natif.
+3. Construire un DataFrame Pandas et y sélectionner des colonnes avec la notation `[]`.
+4. Filtrer des lignes par conditions booléennes et préparer un jeu de données pour l'analyse.
+
+## Prérequis
+
+- **Python 3.10+** (types hints, f-strings).
+- Bases du langage (fonctions, listes, dictionnaires). Aucune connaissance préalable de NumPy/Pandas requise.
+- Tests unitaires associés : [`tests/test_numpy_basics.py`](tests/test_numpy_basics.py), [`tests/test_pandas_basics.py`](tests/test_pandas_basics.py).
+
+## Suite logique
+
+Ces fondations posées, la formation se poursuit sur deux axes complémentaires :
+- **[02-ML-Cours](../02-ML-Cours/README.md)** — le socle scikit-learn canonique (workflow ML, descente de gradient, régression, arbres, biais-variance, clustering) qui ouvre la boîte noire de `fit()`.
+- **[PythonAgentsForDataScience](../PythonAgentsForDataScience/README.md)** — le track LangChain (7 labs) qui passe « de la data aux agents IA ».

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/README.md
@@ -1,0 +1,53 @@
+# PythonAgentsForDataScience — Track LangChain (Labs 1-7)
+
+[← DataScienceWithAgents (parent)](../README.md) | [AgenticDataScience (Google ADK) →](../AgenticDataScience/README.md)
+
+Le track **LangChain** du workshop : 7 labs répartis sur 3 jours qui mènent de la prise en main des outils data science (Journée 1) jusqu'à la construction d'un agent d'analyse de données autonome (Journée 3). C'est le compagnon opérationnel des fondations [`01-PythonForDataScience`](../01-PythonForDataScience/README.md) et [`02-ML-Cours`](../02-ML-Cours/README.md) : on y apprend à orchestrer un LLM pour qu'il accomplisse des tâches data science concrètes — analyser un appel d'offres, pré-qualifier des CVs, nettoyer des données sales, interroger un DataFrame en langage naturel.
+
+## Pourquoi cette série
+
+Le fil conducteur du workshop est un **changement de paradigme** : passer de *l'écriture* du code data science à *l'orchestration* d'agents LLM qui le produisent. Ce track introduit ce saut de façon progressive et encadrée. Chaque lab pose une question pragmatique — un agent accélère-t-il réellement cette tâche ? comment le garder sous contrôle ? — et y répond avec LangChain en gardant l'humain dans la boucle pour la validation. L'enjeu n'est pas de déléguer aveuglément, mais de comprendre *quand* un agent est légitime et *comment* le contraindre (outils, prompt, exécuteur).
+
+## Structure (3 jours, 7 labs)
+
+### Journée 1 — Fondations data science
+
+| Lab | Sujet | Concept-phare |
+|-----|-------|---------------|
+| [Lab 1 — Bases Data Science](Day1/Labs/Lab1-PythonForDataScience.ipynb) | Pandas + Matplotlib + régression linéaire sur ventes synthétiques | le socle manipulé par tous les labs suivants |
+
+### Journée 2 — Agents pour l'analyse documentaire
+
+| Lab | Sujet | Concept-phare |
+|-----|-------|---------------|
+| [Lab 2 — RFP Analysis](Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb) | d'un appel d'offres à un PoC en 1 heure | extraction structurée d'un texte libre par LLM |
+| [Lab 3 — CV Screening](Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb) | pré-qualifier des candidats avec l'IA | analyse, notation et résumé de CVs vs offre |
+
+### Journée 3 — Data wrangling & agents
+
+| Lab | Sujet | Concept-phare |
+|-----|-------|---------------|
+| [Lab 4 — Data Wrangling](Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb) | nettoyer un jeu de données « sale » réaliste | Pandas au service de la robustesse |
+| [Lab 5 — Viz & ML](Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb) | exploration visuelle puis classification scikit-learn | visualisation guidant le modèle |
+| [Lab 6 — First Agent](Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb) | construire son premier agent LangChain | les 4 composants : LLM, Outils, Prompt, Exécuteur |
+| [Lab 7 — Data Analysis Agent](Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb) | agent répondant en langage naturel sur un DataFrame | l'agent comme interface d'analyse |
+
+Chaque lab est accompagné de son propre [`README.md`](Day1/Labs/README.md) (objectifs, données fournies, exercices).
+
+## Objectifs d'apprentissage
+
+À l'issue du track, l'apprenant sait :
+
+1. Charger, nettoyer, visualiser et modéliser des données avec Pandas / Matplotlib / scikit-learn (Labs 1, 4, 5).
+2. Orchestrer un LLM avec LangChain pour extraire une information structurée d'un texte libre (Labs 2, 3).
+3. Assembler les **4 composants** d'un agent (LLM, Outils, Prompt, Exécuteur) et l'armer d'outils data science (Labs 6, 7).
+4. Distinguer les tâches où un agent apporte un gain réel de celles qu'il vaut mieux coder à la main.
+
+## Prérequis
+
+- Fondations [`01-PythonForDataScience`](../01-PythonForDataScience/README.md) (NumPy/Pandas) et idéalement [`02-ML-Cours`](../02-ML-Cours/README.md) (workflow sklearn).
+- **LangChain** + clé API OpenAI (les labs 2, 3, 6, 7 appellent un LLM).
+
+## Suite logique
+
+Une fois le track mono-agent LangChain maîtrisé, la formation monte en puissance vers les **systèmes multi-agents** : [`AgenticDataScience`](../AgenticDataScience/README.md) (Google ADK, boucles planner-coder, DS-STAR / MLE-STAR, compétitions Kaggle).


### PR DESCRIPTION
## Summary

Fixe une **régression check-links** introduite par #4289 (README série `02-ML-Cours`). Ce README lie vers `../01-PythonForDataScience/README.md` et `../PythonAgentsForDataScience/README.md`, mais les 2 dirs sibling avaient du contenu **sans README.md à leur racine** → liens cassés → check-links advisory rouge **hérité par toute PR off main récent** (signalé par po-2026 sur #4303).

## Changements (2 fichiers, +92 lignes, docs-only)

1. **`01-PythonForDataScience/README.md`** (39 lignes) — série fondations NumPy 1.2 + Pandas 1.3 : pourquoi cette série, table d'inventaire (notebook/contenu/durée), note de numérotation (1.2 d'intro couvert par parent), objectifs d'apprentissage, prérequis (Python 3.10+, tests associés), suite logique vers `02-ML-Cours` + `PythonAgentsForDataScience`.
2. **`PythonAgentsForDataScience/README.md`** (53 lignes) — track LangChain, **7 labs / 3 jours** : inventaire complet avec concept-phare (Lab 1 ventes synthétiques, Labs 2-3 RFP/CV, Labs 4-7 wrangling/viz-ML/first-agent/data-analysis-agent), objectifs, prérequis (LangChain + clé OpenAI), navigation vers `AgenticDataScience` (multi-agents).

## Validation (G.1 — links prouvés, pas supposés)

- **15/15 cibles de lien résolvent sur `origin/main`** (vérifié firsthand via `git cat-file -e` pour chaque path) — 0 lien cassé. Le fix résout directement les 2 liens `#4289` + ne casse rien.
- **Contenu grounded** : titres + objectifs lus firsthand depuis chaque Lab README + notebooks (pas inventés).
- **§E respecté** : 39 + 53 lignes, READMEs à contenu réel (pas des stubs <20 lignes).
- **Catalogue byte-identical** (0 catalog file touched).
- **FR-first** (readme-french-first) — cohérent avec le parent `DataScienceWithAgents/README.md` et `02-ML-Cours/README.md`.
- Docs-only (0 notebook, 0 code source) — pas de re-exec requise.

## Out of scope

- Le `AgenticDataScience/README.md` (déjà existant, cible OK) — non touché.
- Toute autre drift de liens ailleurs dans le repo — cette PR est atomique sur les 2 READMEs manquants de l'umbrella `DataScienceWithAgents`.

Refs #4289
