### PR TITLE
docs(astar_lean): 2 concept Mermaid diagrams (f-bound optimality + heuristic hierarchy)

### DIFF
--- a/MyIA.AI.Notebooks/Search/astar_lean/README.md
+++ b/MyIA.AI.Notebooks/Search/astar_lean/README.md
@@ -77,6 +77,24 @@ C'est la borne en `f` en chaque nœud — le mécanisme exact d'optimalité de A
 le pas via `le_trans`. Le fait clé : un suffixe d'un chemin allant au but va encore au
 but (`suffix_pathFrom`).
 
+*Mécanisme de la borne en `f` — pourquoi l'admissibilité garantit l'optimalité de A\** :*
+
+```mermaid
+flowchart TD
+    WG["Graphe pondéré WeightedGraph V<br/>arêtes edge : V → V → ℝ≥0 (non-négatives)"]
+    PATH["Chemin start → goal<br/>PathFrom start goal p · coût pathCost p"]
+    HADM["Heuristique admissible<br/>Admissible h hStar : ∀ n, h n ≤ hStar n"]
+    BOUND["Borne en f en chaque nœud<br/>h(p.get i) ≤ pathCost(p.drop i)<br/><i>admissible_implies_optimal (phase 1)</i>"]
+    STAR["A* déploie le nœud de f = g + h minimal"]
+    OPT["Chemin optimal renvoyé<br/>jamais au-delà de la frontière du coût optimal"]
+
+    WG --> PATH
+    PATH --> HADM
+    HADM --> BOUND
+    BOUND --> STAR
+    STAR --> OPT
+```
+
 ## Consistance ⟹ admissibilité (téléscopage) — phase 2
 
 ```lean
@@ -143,6 +161,27 @@ indépendamment du chemin spécifique. La formalisation de la **« non-ré-expan
 elle-même** (modélisation de la file de priorité, open/closed sets, terminaison) est la
 **phase 4** (cf #4048) — on prouve ici le **lemme mathématique central** qui en est la
 cause exacte, pas l'algorithme complet.
+
+*Synthèse — hiérarchie des propriétés d'heuristique : la consistance (forte, locale par
+arc) garantit à la fois l'optimalité (via l'admissibilité qu'elle entraîne) ET
+l'efficacité (monotonie de `f`) ; l'admissibilité seule garantit l'optimalité mais
+autorise des ré-expansions :*
+
+```mermaid
+flowchart TD
+    CONS["Heuristique consistante<br/>Consistent G h : h n ≤ edge n n' + h n'<br/><i>locale par arc (relaxation de Bellman)</i>"]
+    TELE["consistent_implies_path_bound<br/><i>téléscopage le long du chemin</i><br/>h(start) ≤ pathCost(p)"]
+    ADM["Heuristique admissible<br/>Admissible h hStar : h n ≤ hStar n<br/><i>globale</i>"]
+    OPT["admissible_implies_optimal<br/><i>phase 1 — borne en f</i><br/>chemin optimal garanti"]
+    MONO["consistent_implies_f_monotone<br/><i>phase 3 — f = g + h croissante</i>"]
+    EFF["Efficacité<br/>aucun nœud jamais ré-expansé"]
+
+    CONS --> TELE
+    TELE --> ADM
+    ADM --> OPT
+    CONS --> MONO
+    MONO --> EFF
+```
 
 ## Construction
 


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the `astar_lean` README, turning the optimality mechanism and the admissible/consistent heuristic hierarchy from prose-only into visual. Directly serves the SOTA mandate **#3801** (the BFS-vs-A* grief this lake was created to answer): the diagrams make *visible* the exact property that distinguishes A* from BFS.

`astar_lean` is part of roadmap **#4038** (Lean, one flagship theorem per series). Its README was already rigorous (3 phases, 0-sorry proofs, honest scoping) but had zero diagrams; the sibling lakes' READMEs (#4275 coop, #4278 minimax, #4283 sensitivity, #4287 calibration, #4296 finiteness, #4299 lean_game_defs) all carry concept diagrams after the #4212 finition sweep — this brings astar_lean to the same standard.

## Diagram 1 — Why A* is optimal: the f-bound

Placed after the `admissible_implies_optimal` theorem. Shows the causal chain: `Admissible` (h ≤ hStar) ⟹ per-node bound `h(p.get i) ≤ pathCost(p.drop i)` ⟹ A* deploys the minimal-`f` node ⟹ never crosses the optimal-cost frontier ⟹ optimal path.

## Diagram 2 — Heuristic property hierarchy

Synthesis after phase 3. Shows `Consistent` (local per-arc, Bellman relaxation) ⟹ `Admissible` (via path telescoping, `consistent_implies_path_bound`) ⟹ optimality (`admissible_implies_optimal`); and `Consistent` ⟹ `f`-monotone (`consistent_implies_f_monotone`) ⟹ no re-expansion. Makes explicit that **consistency = optimality + efficiency**, while **admissibility = optimality only** — the exact pedagogical distinction of A*.

## G.1 firsthand (not propagation)

All symbols cited in the diagrams verified present in the Lean source firsthand:
- `Admissible h hStar` (Heuristic.lean L30), `Consistent G h` (L37)
- `admissible_implies_optimal` (Optimality.lean L76)
- `consistent_implies_path_bound` (Consistency.lean L55), `consistent_implies_f_monotone` (L123)
- `WeightedGraph V` (Graph.lean L20), `pathCost` (L33), `PathFrom` (L50)

## Hygiene

- Pure insertion **+39 / 0 deletions**, docs-only (**0 .lean** touched) — no anti-regression concern.
- FR-first (the README is French; diagrams in French).
- Fences balanced: 7 code blocks total (5 pre-existing + 2 new mermaid).
- Catalog-STATUS byte-identical to main (catalog-pr-hygiene rule 1).
- Base fresh (0 behind / 0 ahead at branch creation).

See #4048

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
