### PR TITLE
fix(sudoku): corrige 4 labels de cross-ref périmés dans Sudoku-1-Backtracking (C#)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Sudoku-1 : Resolution par Backtracking\n",
     "\n",
-    "**Navigation** : [<< Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | [Index](README.md) | [Sudoku-2 Genetic >>](Sudoku-3-Genetic-Csharp.ipynb)\n",
+    "**Navigation** : [<< Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | [Index](README.md) | [Sudoku-3 Genetic >>](Sudoku-3-Genetic-Csharp.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -1077,12 +1077,12 @@
     "### Prochaines etapes\n",
     "\n",
     "Dans les notebooks suivants, nous explorerons des techniques plus avancees :\n",
-    "- [Sudoku-2 Genetic](Sudoku-3-Genetic-Csharp.ipynb) : approche metaheuristique\n",
-    "- [Sudoku-3 OR-Tools](Sudoku-10-ORTools-Csharp.ipynb) : programmation par contraintes industrielle\n",
+    "- [Sudoku-3 Genetic](Sudoku-3-Genetic-Csharp.ipynb) : approche metaheuristique\n",
+    "- [Sudoku-10 OR-Tools](Sudoku-10-ORTools-Csharp.ipynb) : programmation par contraintes industrielle\n",
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | [Index](README.md) | [Sudoku-2 Genetic >>](Sudoku-3-Genetic-Csharp.ipynb)\n"
+    "**Navigation** : [<< Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | [Index](README.md) | [Sudoku-3 Genetic >>](Sudoku-3-Genetic-Csharp.ipynb)\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

[Sudoku-1-Backtracking-Csharp.ipynb](MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb) portait des résidus d'une ancienne renumérotation : **4 labels markdown citaient des numéros Sudoku faux**. Même famille de bug que #4302/#4304/#4308/#4311 (cycles 62-65).

## Les 4 corrections (non-ambiguës — le NOM descriptif confirme l'intention)

| Cellule | Label avant | Label après | Lien cible (existe) | Preuve |
|---|---|---|---|---|
| 0 (nav `>>`) | `Sudoku-2 Genetic` | `Sudoku-3 Genetic` | `Sudoku-3-Genetic-Csharp.ipynb` | Sudoku-2 = DancingLinks, Genetic = Sudoku-3 |
| 18 (li) | `Sudoku-2 Genetic` | `Sudoku-3 Genetic` | (idem) | |
| 18 (li) | `Sudoku-3 OR-Tools` | `Sudoku-10 OR-Tools` | `Sudoku-10-ORTools-Csharp.ipynb` | Sudoku-3 = Genetic, OR-Tools = Sudoku-10 |
| 18 (nav `>>` dup) | `Sudoku-2 Genetic` | `Sudoku-3 Genetic` | (idem) | |

**Non-ambigu** : le **nom descriptif** (Genetic / OR-Tools) + le **lien cible** convergent vers le même notebook. Seul le **numéro** de label était faux. Le fichier cible (qui existe) est l'autorité.

## Validation G.1 (read firsthand)

- Cells 0/18 = markdown (exec_count=None).
- Cibles confirmées existantes : `Sudoku-3-Genetic-Csharp.ipynb`, `Sudoku-10-ORTools-Csharp.ipynb`.
- Confirmé Sudoku-2 = DancingLinks, Sudoku-3 = Genetic (`ls Sudoku-2-*` / `Sudoku-3-*`), OR-Tools = Sudoku-10.

## Laisser intact (Tier 2, cross-series — [ASK ai-01])

Cellule 0 contient aussi `[Search-6 CSP Fundamentals](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb)`. C'est un cas **cross-series** (relabel `Search-6` → `CSP-1`, héritage d'une réorg où CSP-1/2/3 étaient Search-6/7/8). C'est un **changement sémantique plus large** (préfixe série, pas juste numéro) — selon ma décision cycle 64, je garde le Tier 2 (22 occurrences repo-wide) pour confirmation ai-01 avant relabel. **Laissé intact ce cycle.**

## Catalogue & atomicité

- **1 sujet = 1 PR** : cohérence des cross-refs d'1 notebook.
- **Markdown-only** (cellules markdown, .NET Interactive C# mais le fix est dans la prose markdown) → exception C.2, **pas de re-exec**.
- **Form-preserving** round-trip (+5/-5 dont trailing brace newline, **0 churn** papermill/outputs/string→list — vérifié : le 1 match churn du grep était une ligne de CONTEXTE git, pas un changement).
- **Base fraîche** origin/main, 1 fichier, ≠ mes 4 autres PRs open → aucun conflit.

## Deep-queue fidelity (anti-idle, règle 4)

Notebooks Tier 1 restants (notebook par notebook, G.5 1/cycle, G.1 firsthand) : Sudoku-4 (2), Sudoku-14 (1), Sudoku-18 (5, framing à vérifier), GameTheory-4c (1, GT-18 inexistant max=17) + Tier 2 (22 cross-series, [ASK ai-01]) + 2 findings ambigus reportés (Search-9 App-8-SupplyChain, Search-10 cell 89). Lane non-idle.

See #3975