### PR TITLE
feat(lean): minimax von Neumann saddle-point via Sion (#4054 RESOLVED)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax.lean
@@ -1,6 +1,7 @@
 import Mathlib
 import Minimax.ZeroSum
 import Minimax.Concavity
+import Minimax.SionApplication
 
 /-!
 # minimax_lean — bilinéarité du payoff pour le théorème minimax de von Neumann
@@ -39,23 +40,31 @@ ces quatre hypothèses.
   dérivée de la continuité (`payoff_lowerSemicontinuous_in_x`,
   `payoff_upperSemicontinuous_in_y`) — les **2 hyps restantes**.
   **Les 4 hyps analytiques sont désormais prouvées. 0 sorry.**
+- `Minimax/SionApplication.lean` — **itération 3 du glue Sion** : non-vacuité des
+  simplexes (`stdSimplex_nonempty_m/n` via `single_mem_stdSimplex`) puis **application
+  finale** `exists_saddle_point_payoff` — le théorème de von Neumann (forme point-selle)
+  prouvé en une application de `Sion.exists_isSaddlePointOn` réunissant les 4 hyps
+  analytiques + compacité `isCompact_stdSimplex` + convexité `convex_stdSimplex` +
+  non-vacuité. Les instances topologiques `Pi`-sur-`ℝ` (`TopologicalSpace`,
+  `AddCommGroup`, `Module ℝ`, `IsTopologicalAddGroup`, `ContinuousSMul ℝ`) se
+  synthétisent depuis Mathlib. **Milestone #4054 RÉSOLU. 0 sorry.**
 
-## Milestone suivant (OPEN — documenté, non sorry-stubbé)
+## Milestone — RÉSOLU (#4054)
 
-Les **4 hyps analytiques** de `Sion.exists_isSaddlePointOn'` (quasi-convexité en `x`,
-quasi-concavité en `y`, semi-continuité inférieure en `x`, supérieure en `y`) sont
-désormais **prouvées 0 sorry** dans `Concavity.lean`. Reste le **milestone ouvert** de
-l'issue #4054 : les instances topologiques `Pi`-sur-`ℝ`, la non-vacuité des simplexes
-(`stdSimplex`, faits Mathlib), et l'**application finale** réunissant les 4 hyps avec
-`isCompact_stdSimplex`/`convex_stdSimplex` vers `Sion.exists_isSaddlePointOn'`. Non
-comblé par `sorry`, laissé comme étape de formalisation à venir, honnêtement signalé.
+Le théorème minimax de **von Neumann** (forme point-selle) est désormais **prouvé
+0-sorry** via `Minimax/SionApplication.lean` (`exists_saddle_point_payoff`) : pour toute
+matrice de gains `A` sur des types finis non vides, il existe `a ∈ Δₘ`, `b ∈ Δₙ` tels
+que `payoff A a y ≤ payoff A x b` pour tout `x ∈ Δₘ`, `y ∈ Δₙ`. Démontré en une
+application de `Sion.exists_isSaddlePointOn` (cas réel, `Topology/Sion.lean`), réunissant
+les 4 hyps analytiques de `Concavity.lean` (quasi-convexité en `x`, quasi-concavité en
+`y`, semi-continuité inf. en `x`, sup. en `y`) avec la compacité/convexité/non-vacuité
+des simplexes (faits Mathlib `isCompact_stdSimplex`/`convex_stdSimplex`/`single_mem_stdSimplex`).
 -/
 
 namespace MinimaxLean
 
-/-- Statut : `Minimax/ZeroSum.lean` + `Concavity.lean` entièrement 0-sorry. Bilinéarité
-+ continuité du payoff, et les 4 hyps analytiques de Sion prouvées. Reste le câblage
-topologique final (instances Pi/ℝ + non-vacuité + application `Sion.minimax'`). -/
+/-- Statut : le théorème minimax de von Neumann (forme point-selle) est **prouvé 0-sorry**
+via `Minimax/SionApplication.lean`. Milestone #4054 RÉSOLU. -/
 abbrev Status : Prop := True
 
 end MinimaxLean

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/SionApplication.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/SionApplication.lean
@@ -1,0 +1,73 @@
+import Mathlib
+import Minimax.ZeroSum
+import Minimax.Concavity
+
+/-!
+# Minimax.SionApplication — application finale de Sion (itération 3 du glue Sion)
+
+Ce module câble les **4 hyps analytiques** prouvées dans `Concavity.lean` (quasi-convexité
+en `x`, quasi-concavité en `y`, semi-continuité inf. en `x`, sup. en `y`) avec les faits
+topologiques de Mathlib sur `stdSimplex` (compacité `isCompact_stdSimplex`, convexité
+`convex_stdSimplex`, non-vacuité via `single_mem_stdSimplex`) pour prouver l'existence
+d'un point-selle via `Sion.exists_isSaddlePointOn` (cas réel) — le **milestone final** de #4054.
+
+Les 5 prérequis topologiques de Sion sur `E = m → ℝ` (et `F = n → ℝ`) sont
+`TopologicalSpace`, `AddCommGroup`, `Module ℝ`, `IsTopologicalAddGroup`, `ContinuousSMul ℝ` :
+ils se synthétisent depuis les instances `Pi` de Mathlib (`Pi.topologicalSpace`,
+`Pi.instAddCommGroup`, `Pi.instModule`, etc.). Ce module **itération 3** livre le fait
+auxiliaire de **non-vacuité du simplexe** puis l'**application finale**.
+
+`IsSaddlePointOn` vit au top-level (`Mathlib/Order/SaddlePoint.lean`), tandis que
+`exists_isSaddlePointOn` est dans `namespace Sion`.
+-/
+
+namespace MinimaxLean
+
+open Set
+
+variable {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
+variable [Nonempty m] [Nonempty n]
+variable (A : PayoffMatrix m n)
+
+/-- Le simplexe standard `stdSimplex ℝ m` est non vide dès que `m` est non vide :
+le Dirac `Pi.single i 1` (masse 1 sur l'indice `i`, 0 ailleurs) est un point du
+simplexe, via le lemme Mathlib `single_mem_stdSimplex`. -/
+lemma stdSimplex_nonempty_m : (stdSimplex ℝ m).Nonempty := by
+  obtain ⟨i⟩ := ‹Nonempty m›
+  exact ⟨Pi.single i 1, single_mem_stdSimplex (𝕜 := ℝ) i⟩
+
+/-- Variante en `y` : `stdSimplex ℝ n` est non vide dès que `n` est non vide. -/
+lemma stdSimplex_nonempty_n : (stdSimplex ℝ n).Nonempty := by
+  obtain ⟨i⟩ := ‹Nonempty n›
+  exact ⟨Pi.single i 1, single_mem_stdSimplex (𝕜 := ℝ) i⟩
+
+/-- **Théorème minimax de von Neumann (forme point-selle)** — le **milestone final** de
+l'issue #4054 : pour toute matrice de gains `A` sur des types finis non vides, il existe
+des stratégies mixtes `a ∈ Δₘ`, `b ∈ Δₙ` telles que `payoff A a y ≤ payoff A x b` pour
+tout `x ∈ Δₘ`, `y ∈ Δₙ` (point-selle). Démontré en une application de
+`Sion.exists_isSaddlePointOn` (cas réel, `Topology/Sion.lean` section `Real`), en réunissant :
+- compacité : `isCompact_stdSimplex ℝ` ;
+- convexité : `convex_stdSimplex ℝ` ;
+- non-vacuité : `stdSimplex_nonempty_m` / `stdSimplex_nonempty_n` (lemmes ci-dessus) ;
+- les 4 hyps analytiques de `Concavity.lean` (quasi-convexité en `x`, quasi-concavité
+  en `y`, semi-continuité inf. en `x`, sup. en `y`).
+
+Les 5 prérequis topologiques de Sion sur `E = m → ℝ` et `F = n → ℝ`
+(`TopologicalSpace`, `AddCommGroup`, `Module ℝ`, `IsTopologicalAddGroup`,
+`ContinuousSMul ℝ`) se synthétisent depuis les instances `Pi` de Mathlib. -/
+theorem exists_saddle_point_payoff :
+    ∃ a ∈ stdSimplex ℝ m, ∃ b ∈ stdSimplex ℝ n,
+      IsSaddlePointOn (stdSimplex ℝ m) (stdSimplex ℝ n) (payoff A) a b :=
+  Sion.exists_isSaddlePointOn
+    (ne_X := stdSimplex_nonempty_m)
+    (cX := convex_stdSimplex ℝ m)
+    (kX := isCompact_stdSimplex (𝕜 := ℝ) (ι := m))
+    (hfy := fun y _hy => payoff_lowerSemicontinuous_in_x A y)
+    (hfy' := fun y _hy => payoff_quasiconvex_in_x A y)
+    (cY := convex_stdSimplex ℝ n)
+    (ne_Y := stdSimplex_nonempty_n)
+    (kY := isCompact_stdSimplex (𝕜 := ℝ) (ι := n))
+    (hfx := fun x _hx => payoff_upperSemicontinuous_in_y A x)
+    (hfx' := fun x _hx => payoff_quasiconcave_in_y A x)
+
+end MinimaxLean

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/README.md
@@ -41,8 +41,9 @@ Ce premier livrable établit le **cœur formel** documenté de la preuve — la
 - **Toolchain** : `leanprover/lean4:v4.31.0-rc1` + Mathlib4 (`v4.31.0-rc1`)
 - **Sorry** : **0** sur tout le module. L'additivité + l'homogénéité du payoff en
   chaque variable, la continuité (jointe et restreinte), la concavité/cvxicité du
-  payoff sur les simplexes, et les **4 hyps analytiques de Sion** (quasi-convexité,
-  quasi-concavité, semi-continuité inf./sup.) sont entièrement prouvées.
+  payoff sur les simplexes, les **4 hyps analytiques de Sion** (quasi-convexité,
+  quasi-concavité, semi-continuité inf./sup.), et le **théorème de von Neumann
+  (forme point-selle)** sont entièrement prouvés.
 - **Build** : `lake build Minimax` (dépend de Mathlib4)
 - **CI** : `.github/workflows/lean-minimax.yml` (`sorry-filter-mode: standalone-tactic`,
   baseline `0`)
@@ -140,23 +141,49 @@ toutes prouvées 0 sorry.**
   du côté du facteur : `(x + x')` multiplie à gauche ⟹ `add_mul` ; `(y + y')`
   multiplie à droite ⟹ `mul_add`.
 
-## Milestone suivant (OPEN — documenté, non sorry-stubbé)
+## Ce qui est formalisé (`Minimax/SionApplication.lean`, 0 sorry) — itération 3 du glue Sion
 
-Le câblage explicite de `Sion.exists_isSaddlePointOn'` sur
-`stdSimplex ℝ m × stdSimplex ℝ n` est le **milestone ouvert** de l'issue #4054.
-**Progrès réalisé** (`Minimax/Concavity.lean`, itérations 1 & 2) : les **4 hyps
-analytiques** de Sion sont **désormais prouvées** — `payoff_quasiconvex_in_x`,
-`payoff_quasiconcave_in_y` (itération 1, depuis l'affinité) +
-`payoff_lowerSemicontinuous_in_x`, `payoff_upperSemicontinuous_in_y` (itération 2,
-depuis la continuité). **Reste ouvert** : les instances topologiques `Pi`-sur-`ℝ`
-requises par `Sion.minimax'`, la non-vacuité des simplexes (`stdSimplex`, fait
-Mathlib), et l'**application finale** réunissant les 4 hyps analytiques avec
-`isCompact_stdSimplex`/`convex_stdSimplex` vers `Sion.exists_isSaddlePointOn'`. C'est
-honnêtement signalé comme étape à venir dans l'umbrella `Minimax.lean`
-(`Status : Prop := True`) — jamais comblé par `sorry`. Le TODO de l'en-tête de
-Mathlib `Topology/Sion.lean` (« Spell out the particular case of von Neumann
-theorem ») confirme qu'il s'agit d'un travail de formalisation en cours
-**en amont dans Mathlib lui-même**.
+Le **théorème de von Neumann (forme point-selle)** — le milestone final de #4054,
+démontré en une application de `Sion.exists_isSaddlePointOn` :
+
+- **Non-vacuité des simplexes** : `stdSimplex_nonempty_m` / `stdSimplex_nonempty_n`
+  (le Dirac `Pi.single i 1` est un point du simplexe dès que le type d'index est non
+  vide, via `single_mem_stdSimplex (𝕜 := ℝ)`).
+- **`exists_saddle_point_payoff`** : pour toute matrice `A`, il existe `a ∈ Δₘ`, `b ∈ Δₙ`
+  tels que `payoff A a y ≤ payoff A x b` pour tout `x ∈ Δₘ`, `y ∈ Δₙ`. Câble les 4 hyps
+  analytiques (`Concavity.lean`) + compacité (`isCompact_stdSimplex (𝕜 := ℝ)`) +
+  convexité (`convex_stdSimplex ℝ`) + non-vacuité. Les instances topologiques `Pi`-sur-`ℝ`
+  se synthétisent depuis Mathlib.
+
+## Milestone — RÉSOLU (#4054)
+
+Le théorème minimax de **von Neumann** (forme point-selle) est désormais **prouvé
+0-sorry** via `Minimax/SionApplication.lean` (`exists_saddle_point_payoff`) : pour toute
+matrice de gains `A` sur des types finis non vides, il existe des stratégies mixtes
+`a ∈ Δₘ`, `b ∈ Δₙ` telles que `payoff A a y ≤ payoff A x b` pour tout `x ∈ Δₘ`,
+`y ∈ Δₙ` (point-selle).
+
+**Démonstration** — une application de `Sion.exists_isSaddlePointOn` (cas réel,
+`Mathlib/Topology/Sion.lean` section `Real`), réunissant :
+
+- **compacité** `isCompact_stdSimplex (𝕜 := ℝ)` ;
+- **convexité** `convex_stdSimplex ℝ` ;
+- **non-vacuité** `stdSimplex_nonempty_m/n` (lemmes auxiliaires via
+  `single_mem_stdSimplex (𝕜 := ℝ)` — le Dirac `Pi.single i 1` est un point du simplexe) ;
+- les **4 hyps analytiques** de `Concavity.lean` (itérations 1 & 2) :
+  `payoff_quasiconvex_in_x` + `payoff_quasiconcave_in_y` (quasi-) +
+  `payoff_lowerSemicontinuous_in_x` + `payoff_upperSemicontinuous_in_y` (semi-continuité).
+
+Les 5 prérequis topologiques de Sion sur `E = m → ℝ` et `F = n → ℝ`
+(`TopologicalSpace`, `AddCommGroup`, `Module ℝ`, `IsTopologicalAddGroup`,
+`ContinuousSMul ℝ`) se synthétisent depuis les instances `Pi` de Mathlib — l'argument
+implicit `𝕜 := ℝ` est à expliciter sur `single_mem_stdSimplex` et
+`isCompact_stdSimplex` (sinon reste en meta-var `𝕜✝`).
+
+**Note** — le TODO de l'en-tête de Mathlib `Topology/Sion.lean` (« Spell out the
+particular case of von Neumann theorem ») est un travail en cours **en amont dans
+Mathlib lui-même** : ce lake le réalise en appliquant le cadre général de Sion déjà
+prouvé, plutôt qu'en attendant une entrée dédiée dans Mathlib.
 
 ## Référence
 


### PR DESCRIPTION
## Summary

**Milestone #4054 RESOLVED** — the von Neumann minimax theorem (saddle-point form) is proven **0-sorry** via a single application of `Sion.exists_isSaddlePointOn`. New module `Minimax/SionApplication.lean`.

For any payoff matrix `A` over nonempty finite types, there exist mixed strategies `a ∈ Δₘ`, `b ∈ Δₙ` such that `payoff A a y ≤ payoff A x b` for all `x ∈ Δₘ`, `y ∈ Δₙ`.

## What's proven (0 sorry)

- **`stdSimplex_nonempty_m` / `stdSimplex_nonempty_n`** — the standard simplex is nonempty whenever the index type is (the Dirac `Pi.single i 1` is a simplex point, via `single_mem_stdSimplex (𝕜 := ℝ)`).
- **`exists_saddle_point_payoff`** (flagship) — the von Neumann saddle-point theorem. One application of `Sion.exists_isSaddlePointOn` (Real case, `Mathlib/Topology/Sion.lean` section `Real`) wiring:
  - **compactness** `isCompact_stdSimplex (𝕜 := ℝ)`
  - **convexity** `convex_stdSimplex ℝ`
  - **nonemptiness** `stdSimplex_nonempty_m/n`
  - the **4 analytical hyps** from `Concavity.lean` (iter 1+2, merged in #4305): `payoff_quasiconvex_in_x` + `payoff_quasiconcave_in_y` (quasi-) + `payoff_lowerSemicontinuous_in_x` + `payoff_upperSemicontinuous_in_y` (semi-continuity).

The 5 Sion topological prerequisites on `E = m → ℝ`, `F = n → ℝ` (`TopologicalSpace`, `AddCommGroup`, `Module ℝ`, `IsTopologicalAddGroup`, `ContinuousSMul ℝ`) **synthesize from Mathlib Pi instances** — no `haveI` needed. This realizes the Mathlib `Sion.lean` upstream TODO ("Spell out the particular case of von Neumann theorem") by applying the general Sion framework already proven upstream.

## Lean validation (rule B / lean-merge-discipline §1)

- **`lake build Minimax` SUCCESS** — `0 ^error:`, "Build completed successfully (8495 jobs)". Confirmed on a **fresh branch from origin/main** (deps #4305 iter-1+2 + #4307 rename both merged).
- **`grep -c sorry`** : **0 tactic-sorry** across `ZeroSum.lean` / `Concavity.lean` / `SionApplication.lean` (CI `standalone-tactic` baseline 0 preserved).
- **`exists_saddle_point_payoff` is a pure term-application** of a 0-sorry Mathlib theorem + 0-sorry lemmas + 0-sorry Mathlib stdSimplex facts → no `by` block → impossible to introduce `sorryAx` → axioms stay `[propext, Classical.choice, Quot.sound]`.
- **Anti-regression (G.6)** : `ZeroSum.lean` + `Concavity.lean` **byte-identical** (bilinearity + the 4 analytical hyps preserved).

## Iteration context (honest scoping G.3)

This is **itération 3** of the Sion glue, completing the milestone that was marked "OPEN glue-heavy" in the deep-queue:
- iter 1 (#4305) : 2/4 analytical hyps (quasiconvex/concave from affinity).
- iter 2 (#4305) : 4/4 analytical hyps (LSC/USC from continuity).
- **iter 3 (this PR) : the final application** `Sion.exists_isSaddlePointOn` + nonemptiness + compactness/convexity → **von Neumann saddle-point DONE**.

The `𝕜 := ℝ` implicit-arg specialization on `single_mem_stdSimplex` / `isCompact_stdSimplex` was the elaboration crux (without it, `𝕜` stays as metavar `𝕜✝`).

## Atomic

3 files (1 new `SionApplication.lean` + umbrella `Minimax.lean` docstring + `README.md`), 1 feature (Sion application), 1 domain (Lean minimax). Base `origin/main` fresh (`5ff1eeee5`).

Closes #4054 (the milestone acceptance criterion — a saddle point exists — is fully met, 0-sorry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
