### PR TITLE
docs(argumentation_lean): 2 concept Mermaid diagrams (semantics hierarchy + fixed-point mechanism)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/README.md
@@ -42,6 +42,24 @@ La **fonction caractéristique** `F(S) = { a | S défend a }` est un `OrderHom`
 monotone sur le treillis complet `(Set α, ⊆)` ; l'extension grounded en est le plus
 petit point fixe `F.lfp` (Knaster–Tarski).
 
+*Hiérarchie des cinq sémantiques de Dung — emboîtées par exigence décroissante
+(`Stable ⇒ Preferred ⇒ Complete ⇒ Admissible`), avec le `grounded` = plus petite
+extension complète :*
+
+```mermaid
+flowchart TD
+    ADM["Admissible<br/>sans conflit + défend ses membres"]
+    COMP["Complète<br/>admissible + contient tout ce qu'elle défend"]
+    PREF["Preferred<br/>extension complète maximale pour l'inclusion"]
+    STAB["Stable<br/>sans conflit + attaque tout argument extérieur"]
+    GROUNDED["Grounded<br/>plus petit point fixe de F (Knaster–Tarski)<br/>= plus PETITE extension complète"]
+
+    ADM -->|"complete_admissible"| COMP
+    COMP -->|"preferred_complete"| PREF
+    COMP -.->|"stable_complete"| STAB
+    GROUNDED -.->|"grounded_least_complete<br/>incluse dans toute complète"| COMP
+```
+
 ### Prouvé (0 sorry)
 
 - **Fundamental Lemma de Dung** (`Fundamental.lean`) : si `S` est admissible et
@@ -57,6 +75,25 @@ petit point fixe `F.lfp` (Knaster–Tarski).
   `Stable ⇒ Preferred ⇒ Complete ⇒ Admissible` (sans sorry).
 - **Lemme-clé de Dung** `F_preserves_admissible` : la fonction caractéristique
   préserve l'admissibilité (`Admissible S ⇒ Admissible (F S)`).
+
+*Le mécanisme de point fixe — comment l'extension grounded émerge de la fonction
+caractéristique `F` (monotone sur le treillis complet `(Set α, ⊆)`) par itération
+vers son plus petit point fixe (Knaster–Tarski, clé en main dans Mathlib via
+`OrderHom.lfp`) :*
+
+```mermaid
+flowchart TD
+    AF["Cadre d'argumentation AF α<br/>relation d'attaque attacks : α → α → Prop"]
+    F["Fonction caractéristique F : Set α →o Set α<br/>F(S) = défendus de S · monotone (OrderHom)"]
+    ITER["Suite itérée admissible<br/>∅ ⊂ F(∅) ⊂ F²(∅) ⊂ …<br/>chaque itéré admissible via F_preserves_admissible"]
+    LFP["grounded = F.lfp<br/>plus petit point fixe (Knaster–Tarski)"]
+    IDS["Identités prouvées 0 sorry<br/>grounded_fixed : F(grounded) = grounded<br/>grounded_defends_iff_mem : a ∈ grounded ⇔ grounded défend a<br/>grounded_least_complete : incluse dans toute complète"]
+
+    AF --> F
+    F --> ITER
+    ITER --> LFP
+    LFP --> IDS
+```
 
 ### Jalon OPEN (documenté, non sorry-backed)
 


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the `argumentation_lean` README, turning Dung's semantics hierarchy and the grounded fixed-point mechanism from prose-only into visual. `argumentation_lean` is the flagship Lean lake of the Tweety series (roadmap **#4038**, issue **#4046**) and a direct bridge to Epic **Argumentum #2137**. Its README was rigorous (5 semantics, 0-sorry Fundamental Lemma + grounded fixed-point identities, honest open-milestone scoping) but had zero diagrams; this brings it to the same standard as the sibling lakes' READMEs after the #4212 finition sweep (coop #4275, minimax #4278, sensitivity #4283, calibration #4287, finiteness #4296, lean_game_defs #4299, IIT #4303, astar #4316).

## Diagram 1 — Dung semantics hierarchy

Placed after the five-semantics table. Shows the nesting **Stable ⇒ Preferred ⇒ Complete ⇒ Admissible** (`complete_admissible`, `preferred_complete`, `stable_complete`), with the **grounded** as the *smallest* complete extension (`grounded_least_complete` — dashed inclusion into Complete).

## Diagram 2 — Fixed-point mechanism

Placed after the proved grounded identities. Shows the causal chain: AF (attack relation) → characteristic function **`F : Set α →o Set α`** (monotone OrderHom) → iterated sequence `∅ ⊂ F(∅) ⊂ F²(∅) ⊂ …` (each admissible via `F_preserves_admissible`) → **`grounded = F.lfp`** (least fixed point, Knaster–Tarski via Mathlib `OrderHom.lfp`) → proved identities (`grounded_fixed`, `grounded_defends_iff_mem`, `grounded_least_complete`).

## G.1 firsthand (not propagation)

All symbols cited in the diagrams verified present in the Lean source firsthand:
- `Admissible`/`Complete`/`grounded` (= F.lfp)/`Preferred`/`Stable` (Extensions.lean L35/40/45/50/55)
- `complete_admissible` (L63), `preferred_complete` (L67), `stable_complete` (L74)
- `grounded_fixed` (Grounded.lean L51), `grounded_defends_iff_mem` (L57), `grounded_least_complete` (L71)
- `F_preserves_admissible` (L97), `characteristic : Set α →o Set α` (Characteristic.lean L31)
- Companion notebook `Tweety-5-Abstract-Argumentation.ipynb` exists (README link valid).

## Hygiene

- Pure insertion **+37 / 0 deletions**, docs-only (**0 .lean** touched) — no anti-regression concern.
- FR-first (README is French; diagrams in French).
- Fences balanced: 3 code blocks total (1 pre-existing bash + 2 new mermaid).
- Catalog-STATUS byte-identical to main (catalog-pr-hygiene rule 1).
- Base fresh (0 behind / 0 ahead at branch creation).

See #4046

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
