### PR TITLE
fix(sudoku): corrige 2 labels de cross-ref périmés dans Sudoku-4-SimulatedAnnealing (C#)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Résolution de Sudoku par Recuit Simulé\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-9-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -3115,7 +3115,7 @@
    "source": [
     "---\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-9-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
     "\n",
     "**Voir aussi** :\n",
     "- [Search-4-LocalSearch](../Search/Part1-Foundations/Search-4-LocalSearch.ipynb) - Théorie du recuit simulé (Hill Climbing, SA, Tabu Search)\n",


### PR DESCRIPTION
Suite de la deep-queue fidelity (notebook-side cross-ref numbering), per steer ai-01 cycle-E (continue 1 notebook/cycle). `See #3975`.

## Changement
2 labels de navigation markdown (cell 0 + cell 44) citent `Sudoku-9-HumanStrategies` alors que leur cible de lien porte le bon numéro `Sudoku-8-HumanStrategies-Csharp.ipynb`. La cible de lien = vérité.

## G.1 firsthand (lu les H1 réels)
- **Sudoku-8 = HumanStrategies** (H1 : « Résolution de Sudoku par Stratégies Humaines »).
- **Sudoku-9 = GraphColoring** (H1 : « Coloration de Graphe ») ≠ HumanStrategies.
- Donc la cible du lien est correcte ; seul le NUMÉRO du label était faux (le nom HumanStrategies est confirmé correct).

## Fix
`[Sudoku-9-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)` → `[Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)` (×2).

## Validation
- Markdown-only (exception C.2, pas de re-exec).
- Form-preserving round-trip : +2/-2, **0 churn** (outputs / execution_count / papermill / source-form intacts).
- Base fraîche `origin/main`, fichier ≠ mes autres PRs → aucun conflit.
- Même pattern éprouvé que #4302/#4304/#4308/#4311/#4317.