### PR TITLE
docs(genai): Video README fil-rouge pipeline Mermaid diagram (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -74,6 +74,35 @@ Le fil rouge de cette série est la création d'un pipeline de vidéo pédagogiq
 
 4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Video-Generation.ipynb) applique le pipeline au contenu éducatif. [04-4](04-Applications/04-4-Production-Video-Pipeline.ipynb) assemble le système bout-en-bout. Le notebook [04-4-Audio-Video-Sync](../Audio/04-Applications/04-4-Audio-Video-Sync.ipynb) de la série Audio synchronise la vidéo avec l'audio généré.
 
+Le schéma ci-dessous résume comment les quatre niveaux du fil rouge s'articulent : chaque niveau apporte une brique (comprendre → générer → orchestrer → produire) qui s'assemble dans le pipeline final 04-4, lui-même synchronisé à l'audio par la série Audio.
+
+```mermaid
+flowchart TD
+    subgraph N1["1 · Comprendre — 01-Foundation"]
+        A1["01-1 : bases ffmpeg / moviepy"]
+        A2["01-2 / 01-3 : décomposition en scènes, Q&A"]
+        A3["01-4 : surcadrage ESRGAN + interpolation RIFE"]
+    end
+    subgraph N2["2 · Générer — 02-Advanced"]
+        B1["02-1 HunyuanVideo : qualité cinématographique"]
+        B2["02-3 Wan : rapide, multilingue"]
+        B3["02-4 SVD : animer une image"]
+        B4["02-5 LTX-2 : vidéo + audio conjoints"]
+    end
+    subgraph N3["3 · Orchestrer — 03-Orchestration"]
+        C1["03-1 : comparer les modèles"]
+        C2["03-2 : pipeline texte → image → vidéo"]
+        C3["03-3 : workflows ComfyUI natifs"]
+    end
+    subgraph N4["4 · Produire — 04-Applications"]
+        D1["04-1 : vidéo éducative automatique"]
+        D2["04-4 : pipeline bout-en-bout"]
+        D3["Audio/04-4 : synchronisation A/V"]
+    end
+    N1 --> N2 --> N3 --> N4
+    D2 -. "audio" .-> D3
+```
+
 ## Ce que vous saurez faire
 
 - **Comprendre** une séquence vidéo : décomposition en scènes, Q&A sur le contenu, analyse temporelle


### PR DESCRIPTION
## Scope

Ajoute un diagramme d'architecture Mermaid au README de la série **Video** (#4212 GenAI-dogfood visuals, item po-2033 #3 du deep-queue ai-01). La série Video décrit son « fil rouge » — *construire un pipeline texte vers vidéo pédagogique* — uniquement en prose (section « Recette », 4 paragraphes numérotés). Un schéma visuel récapitulatif aide à saisir l'articulation des 4 niveaux d'un coup d'œil.

## Ce qui change

+29 insertions, 0 suppression, 1 fichier (`MyIA.AI.Notebooks/GenAI/Video/README.md`). Pur additif : un bloc `mermaid flowchart TD` inséré comme **recap visuel APRÈS la liste détaillée** (convention pédagogique : le détail en prose, puis le diagramme qui cristallise), avant `## Ce que vous saurez faire`.

Le diagramme montre les 4 niveaux du fil rouge comme des briques qui s'assemblent :
- **1 · Comprendre** (01-Foundation) : bases ffmpeg/moviepy, compréhension scènes+Q&A, enhancement ESRGAN+RIFE
- **2 · Générer** (02-Advanced) : HunyuanVideo, Wan, SVD, LTX-2 (audio+vidéo)
- **3 · Orchestrer** (03-Orchestration) : comparaison, pipeline texte→image→vidéo, ComfyUI
- **4 · Produire** (04-Applications) : vidéo éducative, pipeline bout-en-bout, sync A/V

+ les flèches de progression `N1 → N2 → N3 → N4` et une flèche pointillée « audio » du pipeline final (04-4) vers la sync Audio/04-4.

## G.1 — ground-truth (chaque nœud mappe un notebook réel, 0 invention)

Tous les nœuds du diagramme sont vérifiés firsthand contre la section « Recette » existante (lignes 69-75 du README, lues sur origin/main) :

| Nœud diagramme | Notebook référencé (lien déjà dans le README) |
|----------------|------------------------------------------------|
| 01-1 bases ffmpeg/moviepy | `01-Foundation/01-1-Video-Operations-Basics.ipynb` |
| 01-2 / 01-3 scènes Q&A | `01-2-GPT-5-Video-Understanding`, `01-3-Qwen-VL-Video-Analysis` |
| 01-4 ESRGAN+RIFE | `01-4-Video-Enhancement-ESRGAN.ipynb` |
| 02-1..02-5 | HunyuanVideo / Wan / SVD / LTX-2 |
| 03-1..03-3 | comparaison / texte→image→vidéo / ComfyUI |
| 04-1, 04-4, Audio/04-4 | éducative / bout-en-bout / sync A/V |

Aucune étape de pipeline inventée : le diagramme ne fait que visualiser la progression déjà décrite en prose.

## Vérification

- **Diff** : `+29 / 0` (1 fichier), pur additif.
- **Catalogue byte-identical à main** : 0 fichier catalogue touché (catalog-pr-hygiene HARD 1).
- **Marqueur `CATALOG-STATUS`** : untouched (0 ligne du diff).
- **Aucun bloc Mermaid préexistant** dans ce README → pas de duplication (vérifié au scan, règle « Pas de duplication »).
- **Syntaxe Mermaid** : standard (`flowchart TD` + `subgraph` + labels `[...]` quotés + edges `-->` / `-. text .->`), identique au pattern des PR Mermaid Lean de po-2026 (#4275/#4278/#4296/#4299/#4303, toutes merged/rendered). mmdc non installé localement → syntaxe validée par conformité au pattern éprouvé.
- **Docs-only** : pas de notebook touché → pas de re-exec (C.2). FR-first (prose + labels en français).

## Lineage

Item #4212 (GenAI-dogfood visuals) du deep-queue po-2023 cycle-D d'ai-01. Partition GenAI = po-2023 (po-2026 tient la partition Lean/SymbolicAI — pas de collision). Même famille éditoriale que les diagrammes Mermaid Lean de po-2026, appliquée aux READMEs GenAI.

See #4212 (GenAI-dogfood visuals)
See #3801 (Epic Axe-2 SOTA registry)
