### PR TITLE
docs(kelly_lean): 2 concept Mermaid diagrams (optimality pipeline + tangent-bound proof)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/README.md
@@ -19,6 +19,23 @@ Kelly Jr., *A New Interpretation of Information Rate*, BSTJ (1956). Voir l'issue
 [#4052](https://github.com/jsboige/CoursIA/issues/4052) (roadmap Lean
 [#4038](https://github.com/jsboige/CoursIA/issues/4038), Tier 2).
 
+*Le théorème, du pari brut jusqu'à l'unicité du maximiseur — la chaîne causale des
+symboles Lean formant le résultat :*
+
+```mermaid
+flowchart TD
+    BET["Pari de Bernoulli Bet β<br/><i>p gain, b cote, q = 1 − p</i>"]
+    W["Multiplicateurs de richesse<br/>W_win(f) = 1 + b·f ; W_lose(f) = 1 − f"]
+    G["Croissance espérée composée<br/>g(f) = p·log W_win(f) + q·log W_lose(f)"]
+    STAR["Fraction de Kelly<br/>f* = (b·p − q) / b"]
+    OPT["kelly_optimal : g(f) ≤ g(f*)<br/><i>f* maximise la log-croissance</i>"]
+    UNIQ["kelly_unique : f ≠ f* ⟹ g(f) < g(f*)<br/><i>sur-pari et sous-pari strictement sous-optimaux</i>"]
+
+    BET --> W --> G
+    G -->|"condition du 1er ordre g'(f*) = 0"| STAR
+    STAR --> OPT -.-> UNIQ
+```
+
 ## Stratégie de preuve
 
 On évite la concavité abstraite (`StrictConcaveOn`) et l'on prouve `g(f) ≤ g(f*)`
@@ -42,6 +59,24 @@ L'**unicité** suit de la version stricte `log t < t − 1` : si `f ≠ f*`, les
 multiplicateurs de richesse diffèrent (injectivité de `f ↦ 1 + b·f` et
 `f ↦ 1 − f`), donc au moins un rapport diffère de 1, l'inégalité est stricte, et
 `g(f) < g(f*)`.
+
+*La mécanique de preuve, réduite à son squelette — la tangente du log, la majoration
+clé et la condition du premier ordre qui la neutralise :*
+
+```mermaid
+flowchart TD
+    TAN["Tangente du log en 1<br/>log t ≤ t − 1 ; <i>strict si t ≠ 1</i>"]
+    RAP["Rapports de multiplicateurs<br/>W_win(f) / W_win(f*) ; W_lose(f) / W_lose(f*)"]
+    KEY["Majoration clé : g(f) − g(f*) ≤ (f − f*)·g'(f*)<br/><i>growth_diff_le</i>"]
+    FOC["Condition du 1er ordre g'(f*) = 0<br/><i>growthGrad_kelly_zero</i>"]
+    OPT["g(f) ≤ g(f*) — kelly_optimal"]
+    STRICT["Cas strict t ≠ 1<br/>au moins un rapport ≠ 1"]
+    UNIQ["g(f) < g(f*) — kelly_unique"]
+
+    TAN -->|"appliquée à chaque rapport"| RAP --> KEY
+    FOC -.-> KEY --> OPT
+    TAN -.-> STRICT --> UNIQ
+```
 
 ## Modules
 


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the `kelly_lean` README, turning the Kelly optimality theorem and its direct tangent-bound proof from prose-only into visual. `kelly_lean` is the flagship Lean theorem of the QuantConnect position-sizing series (roadmap **#4038**, Tier 2, issue **#4052**): it proves `f* = (b·p − q)/b` uniquely maximizes expected log-growth `g(f) = p·log(1+bf) + q·log(1−f)`, 0 sorry. Its README was rigorous (full proof strategy via the log tangent `log t ≤ t − 1`, modules table, honest open-milestone scoping) but had zero diagrams; this brings it to the same standard as the sibling lakes after the **#4212** finition sweep (coop #4275, minimax #4278, sensitivity #4283, calibration #4287, finiteness #4296, lean_game_defs #4299, IIT #4303, astar #4316, argumentation #4320).

## Diagram 1 — Optimality pipeline

Placed after the intro. Shows the causal chain from the raw Bernoulli bet (`Bet`, p/b, q=1−p) through the wealth multipliers `W_win(f) = 1 + b·f` / `W_lose(f) = 1 − f`, the expected log-growth `g(f) = p·log W_win + q·log W_lose`, the first-order condition `g'(f*) = 0` yielding `f* = (b·p − q)/b`, to the two flagship theorems `kelly_optimal` (`g(f) ≤ g(f*)`) and `kelly_unique` (strict for `f ≠ f*`).

## Diagram 2 — Tangent-bound proof mechanism

Placed after the proof-strategy section. Reduces the proof to its skeleton: the log tangent `log t ≤ t − 1` (strict for `t ≠ 1`) applied to the wealth-multiplier ratios yields the **key bound** `g(f) − g(f*) ≤ (f − f*)·g'(f*)` (`growth_diff_le`), which the first-order condition `g'(f*) = 0` (`growthGrad_kelly_zero`) neutralizes to `g(f) ≤ g(f*)` (`kelly_optimal`); the strict tangent case gives `kelly_unique`.

## G.1 firsthand (not propagation)

All symbols cited in the diagrams verified present in the Lean source firsthand on `origin/main`:
- `Bet` (Bet.lean L25), `q` (L35), `winWealth = 1+bf` (L47), `loseWealth = 1−f` (L54), `Feasible = (−1/b, 1)` (L71)
- `growth` (Growth.lean L30), `growthGrad` (L37)
- `kellyFrac = (bp−q)/b` (Kelly.lean L42), `growthGrad_kelly_zero` (L73), `growth_diff_le` (L84), `kelly_optimal` (L128), `kelly_unique` (L136)

## Hygiene

- Pure insertion **+35 / 0 deletions**, docs-only (**0 .lean** touched) — no anti-regression concern.
- FR-first (README is French; diagrams in French).
- Fences balanced: 3 code blocks total (1 pre-existing bash + 2 new mermaid).
- Catalog-STATUS byte-identical to main (catalog-pr-hygiene rule 1).
- Base fresh (0 behind / 0 ahead at branch creation).

See #4052

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
