### PR TITLE
fix(sudoku): corrige 1 label de cross-ref périmé dans Sudoku-14-BDD (C#)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -3068,7 +3068,7 @@
     "\n",
     "- **[Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb)** - Automates compiles vers Z3\n",
     "- [Sudoku-12-Z3](Sudoku-12-Z3-Csharp.ipynb) - Z3 SMT direct\n",
-    "- [Search-12-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) - Theorie approfondie\n",
+    "- [Search-10-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) - Theorie approfondie\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
Suite de la deep-queue fidelity (notebook-side cross-ref numbering), per steer ai-01 cycle-E (continue 1 notebook/cycle). `See #3975`.

## Changement
1 label markdown (cell 38) cite `Search-12-SymbolicAutomata` alors que sa cible de lien porte le bon numéro `Search-10-SymbolicAutomata.ipynb`. La cible de lien = vérité.

## G.1 firsthand (lu les fichiers/H1 réels)
- Cible `Search-10-SymbolicAutomata.ipynb` existe, H1 « Automates Symboliques avec Z3 » = SymbolicAutomata (correct).
- Aucun `Search-12-SymbolicAutomata` n'existe dans Part1-Foundations (le label pointe vers rien).
- Le seul `Search-12` existant = `Search-12-PatternDatabases.ipynb` (Part3-Advanced, sujet/répertoire différents, mon notebook cycle 59) — pas ce que le lien Part1 référence.
- Donc la cible du lien est correcte ; seul le NUMÉRO du label était faux (le nom SymbolicAutomata est confirmé correct).

## Fix
`[Search-12-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb)` → `[Search-10-SymbolicAutomata](...)` (cell 38).

## Note Sudoku-18 (cycle 68 investigation)
J'ai aussi investigué `Sudoku-18-Comparison-Python.ipynb` (5 « findings » du scan cycle 64). **G.1 firsthand (leçon cycle 57) = FAUX POSITIF confirmé** : cell 4 est une table de comparaison avec **ranking local délibéré 1-7** (labels [Sudoku-N] suivent l'ordre des solveurs listés en cell 1, pas des refs série). `[Sudoku-1]`→Backtracking et `[Sudoku-7]`→Norvig coïncident par accident ; `[Sudoku-2]`→Genetic(fichier 3), `[Sudoku-5]`→DancingLinks(fichier 2) = rang ≠ numéro fichier. **Corriger = casser le ranking délibéré** (anti-pattern #1214 find-replace aveugle). Laisser intact.

## Validation
- Markdown-only (exception C.2, pas de re-exec).
- Form-preserving round-trip : +1/-1, **0 churn** (outputs / execution_count / papermill / source-form intacts).
- Base fraîche `origin/main`, fichier ≠ mes autres PRs → aucun conflit.
- Même pattern éprouvé que #4302/#4304/#4308/#4311/#4317/#4321.