### PR TITLE
docs(sc): correct stale 03 "replis statiques" contrast in 01-README (#3765 #3921)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/README.md
@@ -72,7 +72,7 @@ Solidity supporte l'heritage multiple avec le mot-cle `is`, les interfaces pour 
 
 - **Lancer `anvil` avant l'execution** : chaque notebook se connecte a un noeud local. Sans `anvil` actif, les cellules de deploiement echouent en `ConnectionRefusedError`.
 - **`py-solc-x` telecharge le compilateur** au premier appel (`solcx.install_solc`) ; le versioning se fait via `foundry-lib/` au niveau de la serie.
-- Les outputs committes proviennent d'executions reelles sur `anvil` : les adresses de contrat, les gas utilises et les receipts sont authentiques (contrairement aux notebooks des sous-series 03/05 qui, pour certains, s'appuient sur des replis statiques disclosees).
+- Les outputs committes proviennent d'executions reelles sur `anvil` : les adresses de contrat, les gas utilises et les receipts sont authentiques. La sous-serie 03 (Foundry) execute elle aussi `forge` pour de vrai (SC-12 re-execute la suite Foundry, SC-13 lance un fuzz qui decouvre un contre-exemple d'overflow) ; seuls certains notebooks restent en repli disclose quand l'outil est verrouille par acces commercial (SC-14 Certora) ou depend d'un CLI externe non installe (sous-serie 05 : Vyper / Bitcoin Script / Move / Rust).
 
 ---
 


### PR DESCRIPTION
## Contexte

Suite logique de **#4323** (03-Foundry-Testing prose-sync). Driver **#3975** + **axe-2 #3801**.

Le README `01-Solidity-Foundation` (puce « Points de vigilance », L75) contrastait ses outputs anvil authentiques contre :

> contrairement aux notebooks des sous-series **03/05** qui, pour certains, s'appuient sur des replis statiques disclosees

Cette claim est **désormais fausse pour la sous-série 03**, exactement à cause des PR que #4323 reflète :

- **SC-12** re-exécute la suite Foundry avec `forge` sur le PATH (**#3765 MERGED**)
- **SC-13** lance un `forge test --fuzz-runs` réel qui **découvre un contre-exemple d'overflow** (**#3921 MERGED**)

Donc 03 n'est plus « replis statiques » — et le README de 01 contredit désormais le README de 03 (que #4323 vient de rendre cohérent). Cohérence cross-fichier.

## Changement

Puce L75 réécrite avec précision honnête (G.9) :
- **03 (Foundry) exécute `forge` pour de vrai** (SC-12 / SC-13)
- Restent en repli **disclosed** : **SC-14** (Certora = accès commercial) et **sous-série 05** (CLI externes Vyper/Bitcoin/Move/Rust non installés = RECOVERABLE-LOCAL/USER-HAND)

Aucune fausse claim « tout est réel » — SC-14 Certora et 05 restent honnêtement disclosed.

## Validation

- **G.1 firsthand** : #3765/#3921 vérifiés MERGED ; contenu des READMEs 01/03/05 lu directement (L75 01, L82-84 03-README post-#4323, L83-86 05).
- **Markdown-only** (exception C.2 — pas de re-exec).
- **Chirurgical** : +1/-1, 1 fichier, 1 puce. Style sans-accents local préservé.
- **0 catalogue touché** (feuille sub-series sans marqueur `CATALOG-STATUS`).

`See #3975` (contribution au rollout feuilles-READMEs, suite de #4323).

🤖 Generated with [Claude Code](https://claude.com/claude-code)