### PR TITLE
fix(gametheory): corrige 1 label de cross-ref périmé dans GameTheory-4c-NashExistence (Python)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
@@ -1951,7 +1951,7 @@
     "\n",
     "### Voir aussi\n",
     "\n",
-    "- Companion Lean : [GameTheory-18](GameTheory-4b-Lean-NashExistence.ipynb) pour les formalisations\n",
+    "- Companion Lean : [GameTheory-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) pour les formalisations\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
Suite de la deep-queue fidelity (notebook-side cross-ref numbering), per steer ai-01 cycle-E (continue 1 notebook/cycle). `See #3975`. **Dernier Tier 1 de la deep-queue** (Sudoku-1/4/14 livrés, Sudoku-18 = faux positif).

## Changement
1 label markdown (cell 39, section « Resume ») cite `[GameTheory-18]` alors que sa cible de lien (qui existe) est `GameTheory-4b-Lean-NashExistence.ipynb`. La cible de lien = vérité.

## G.1 firsthand (lu les fichiers/H1 réels)
- Cible `GameTheory-4b-Lean-NashExistence.ipynb` existe, H1 « Théorème d'Existence de Nash (Lean) » = le companion Lean de 4c (correct).
- `GameTheory-18` **n'existe pas** (max GameTheory = 17) ; le label pointe vers rien.
- Cell 39 : « Companion Lean : [...] pour les formalisations » → la cible 4b-Lean-NashExistence EST le companion Lean de Nash existence (4 = track principal NashEquilibrium, 4b = Lean proof, 4c = ce notebook Python).
- Donc la cible du lien est correcte ; seul le NUMÉRO du label était faux (résidu d'ancienne numérotation).

## Fix
`[GameTheory-18](GameTheory-4b-Lean-NashExistence.ipynb)` → `[GameTheory-4b-Lean-NashExistence](...)` (cell 39).

## Validation
- Markdown-only (exception C.2, pas de re-exec).
- Form-preserving round-trip : +1/-1, **0 churn** (outputs / execution_count / papermill / source-form intacts).
- Base fraîche `origin/main`, fichier ≠ mes autres PRs → aucun conflit.
- Même pattern éprouvé que #4302/#4304/#4308/#4311/#4317/#4321/#4325.