### PR TITLE
docs(genai): add fil-rouge Mermaid diagram to Image README (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -157,6 +157,35 @@ Le fil rouge de cette série est la création d'un système de visuels pédagogi
 
 4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Content-Generation.ipynb) applique le pipeline au contenu éducatif. Les notebooks [examples/](examples/) montrent des cas d'usage par domaine (histoire, sciences, littérature).
 
+Le schéma ci-dessous résume comment les niveaux s'articulent pour construire un générateur de visuels pédagogiques : du prompt cloud one-shot (niveau 1) au workflow ComfyUI multi-modèles orienté production (niveau 4), en passant par l'édition fine (niveau 2) et l'orchestration (niveau 3).
+
+```mermaid
+flowchart TD
+    subgraph N1["1 · Générer de base — 01-Foundation"]
+        A1["01-1 gpt-image-1 : API cloud"]
+        A2["01-2 GPT-5 Image : API cloud"]
+        A3["01-3 : bases PIL / OpenCV"]
+        A4["01-4 SD XL Turbo : ComfyUI"]
+        A5["01-5 Qwen Image Edit : local"]
+    end
+    subgraph N2["2 · Éditer & pousser la qualité — 02-Advanced"]
+        B1["02-1 Qwen Edit : édition fine"]
+        B2["02-2 FLUX : génération haute qualité"]
+        B3["02-4 Z-Image/Lumina : rapide"]
+        B4["02-5 Bonsai : quantization ternaire ~7 GB"]
+    end
+    subgraph N3["3 · Orchestrer — 03-Orchestration"]
+        C1["03-1 : comparer qualité / coût"]
+        C2["03-2 : pipeline gén→édit→upscale"]
+        C3["03-3 : perf & quantization"]
+    end
+    subgraph N4["4 · Produire — 04-Applications"]
+        D1["04-1 : contenu éducatif"]
+        D2["examples/ : cas par domaine"]
+    end
+    N1 --> N2 --> N3 --> N4
+```
+
 ## FAQ
 
 ### gpt-image-1 : qualité et suivi du prompt


### PR DESCRIPTION
## Scope

Ajoute un diagramme d'architecture Mermaid au README de la série **Image** (#4212 GenAI-dogfood visuals, deep-queue NUIT po-2023 #1). Réplique le pattern du diagramme Video fusionné (#4322). La série Image décrit son « fil rouge » — *construire un générateur de contenu visuel éducatif* — uniquement en prose (section « Recette », 4 paragraphes numérotés). Un schéma visuel récapitulatif aide à saisir l'articulation des 4 niveaux d'un coup d'œil.

## Ce qui change

+29 insertions, 0 suppression, 1 fichier (`MyIA.AI.Notebooks/GenAI/Image/README.md`). Pur additif : un bloc `mermaid flowchart TD` inséré comme **recap visuel APRÈS la liste détaillée** (convention pédagogique : le détail en prose, puis le diagramme qui cristallise), avant `## FAQ`.

Le diagramme montre les 4 niveaux du fil rouge comme des briques qui s'assemblent :
- **1 · Générer de base** (01-Foundation) : gpt-image-1 + GPT-5 Image (API cloud), bases PIL/OpenCV, SD XL Turbo + Qwen Image Edit (local)
- **2 · Éditer & pousser la qualité** (02-Advanced) : Qwen Edit, FLUX, Z-Image/Lumina, Bonsai ternaire ~7 GB
- **3 · Orchestrer** (03-Orchestration) : comparaison qualité/coût, pipeline gén→édit→upscale, perf & quantization
- **4 · Produire** (04-Applications) : contenu éducatif + cas par domaine (examples/)

+ la flèche de progression `N1 → N2 → N3 → N4`.

## G.1 — ground-truth (chaque nœud mappe un notebook réel, 0 invention)

Tous les nœuds du diagramme sont vérifiés firsthand contre la structure réelle du README (tables de notebooks + section « Recette » + FAQ, lues sur origin/main) :

| Nœud diagramme | Notebook référencé (lien déjà dans le README) |
|----------------|------------------------------------------------|
| 01-1 gpt-image-1 | `01-Foundation/01-1-OpenAI-DALL-E-3.ipynb` (Recette L152 + table L43) |
| 01-2 GPT-5 Image | `01-Foundation/01-2-GPT-5-Image-Generation.ipynb` (table L44) |
| 01-3 bases PIL/OpenCV | `01-Foundation/01-3-Basic-Image-Operations.ipynb` (table L45) |
| 01-4 SD XL Turbo | `01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb` (Recette L152 + table L46) |
| 01-5 Qwen Image Edit | `01-Foundation/01-5-Qwen-Image-Edit.ipynb` (Recette L152 + table L47) |
| 02-1 Qwen Edit | `02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb` (Recette L154 + table L57) |
| 02-2 FLUX | `02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb` (Recette L154 + table L58) |
| 02-4 Z-Image/Lumina | `02-Advanced/02-4-Z-Image-Lumina2.ipynb` (Recette L154 + table L60) |
| 02-5 Bonsai ternaire | `02-Advanced/02-5-Bonsai-Image-Ternary.ipynb` (Recette L154 + table L61) |
| 03-1 comparer | `03-Orchestration/03-1-Multi-Model-Comparison.ipynb` (Recette L156 + table L71) |
| 03-2 pipeline | `03-Orchestration/03-2-Workflow-Orchestration.ipynb` (Recette L156 + table L72) |
| 03-3 perf & quantization | `03-Orchestration/03-3-Performance-Optimization.ipynb` (table L73 + FAQ L239) |
| 04-1 contenu éducatif | `04-Applications/04-1-Educational-Content-Generation.ipynb` (Recette L158 + table L83) |
| examples/ cas par domaine | `examples/{history-geography,literature-visual,science-diagrams}.ipynb` (Recette L158 + table L96-98) |

Note honnête (G.1) : la prose « Recette » de Image nomme explicitement 03-1 et 03-2 mais pas 03-3. Le nœud 03-3 (perf & quantization) est fondé sur la **table de structure** (L73) et la **FAQ** (L239, qui référence 03-3 pour la quantization), pas sur la prose Recette. C'est un notebook réel, non inventé.

Aucune étape de pipeline inventée : le diagramme ne fait que visualiser la progression déjà décrite en prose + table.

## Vérification

- **Diff** : `+29 / 0` (1 fichier), pur additif.
- **Catalogue byte-identical à main** : 0 fichier catalogue touché (catalog-pr-hygiene HARD 1).
- **Marqueur `CATALOG-STATUS`** : 0 occurrence dans le diff (untouched).
- **Rebase frais** : base == origin/main (`8a996f90f`, inclut #4322 fusionné) (catalog-pr-hygiene HARD 2).
- **Aucun bloc Mermaid préexistant** dans ce README (compte = 1 après ajout) → pas de duplication (règle « Pas de duplication »).
- **Syntaxe Mermaid** : standard (`flowchart TD` + `subgraph` + labels `[...]` quotés + edges `-->`), identique au pattern du PR Mermaid Lean de po-2026 + au diagramme Video #4322 (fusionné, rendu). mmdc non installé localement → syntaxe validée par conformité au pattern éprouvé.
- **Docs-only** : pas de notebook touché → pas de re-exec (C.2 exception markdown-only). FR-first (prose + labels en français).

## Lineage

Item #4212 (GenAI-dogfood visuals) du deep-queue NUIT po-2023 cycle-E d'ai-01. Réplique directe du pattern #4322 (Video README fil-rouge Mermaid, fusionné). Même famille éditoriale que les diagrammes Mermaid Lean de po-2026, appliquée aux READMEs GenAI.

See #4212 (GenAI-dogfood visuals)
See #3801 (Epic Axe-2 SOTA registry)
