### PR TITLE
feat(ci): extend golden-set to SL-1-LogicalLearning (6/6 certified, manifest-only)

### DIFF
--- a/scripts/notebook_tools/golden_set.yml
+++ b/scripts/notebook_tools/golden_set.yml
@@ -69,11 +69,23 @@ notebooks:
     kernel: python3
     rationale: "Fondations search ; graphes networkx generes ; BFS/DFS/A* en pur Python+numpy ; 0 solver, 0 JVM, 0 reseau."
 
+  # --- SymbolicLearning : apprentissage symbolique (serie SymbolicLearning) ---
+  # current-best hypothesis (AIMA Ch.19). Importe le module local aima_knowledge
+  # (vendorise dans reference/, suivi git) via sys.path.insert(0,"reference") ->
+  # exige cwd = repertoire parent du notebook. NotebookExecutor execute DEJA par
+  # defaut avec cwd = notebook.parent (papermill --cwd), donc l'import relatif
+  # resolve SANS champ cwd dedie (verifie empiriquement, PR3 #4209). Kernel
+  # python3, dependances STDLIB uniquement (random/sys/time/typing, 0 lib
+  # scientifique), random.seed(42) -> sortie deterministe.
+  - path: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+    series: SymbolicLearning
+    title: "SL-1 - Apprentissage logique (current-best hypothesis, ref. aima-python)"
+    kernel: python3
+    rationale: "Current-best learning (AIMA Ch.19) ; module local aima_knowledge vendorise dans reference/ (suivi git) ; stdlib uniquement, random.seed(42) deterministe ; prouve que le packaging local resolve via cwd=notebook.parent par defaut."
+
 # -----------------------------------------------------------------------------
-# Candidats DEFERRES (v2+) : a certifier quand le lockfile etendra sa couverture.
-#   - SL-1-LogicalLearning (SymbolicLearning) : importe module local aima_knowledge
-#     -> verifier packaging d'abord.
+# Candidats DEFERRES (v3+) : a certifier quand le lockfile etendra sa couverture.
 #   - Probas/PyMC-* : MCMC non deterministe (sortie stochastique) -> politesse
-#     CI = tolerance numerique, hors scope du 1er golden-set sobre.
+#     CI = tolerance numerique, hors scope du golden-set sobre.
 #   - IIT/PyPhi : depend pyphi (lourd, Python 3.9) -> env dedie.
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**PR3 du golden-set #4209 (axe A #4208).** Étend le golden-set certifié-reproductible de **5 → 6 notebooks** en admettant **`SL-1-LogicalLearning`** (SymbolicLearning) — premier candidat DEFERRED promu au noyau certifié. C'est le 1er item de la deep-queue ai-01 nuit (22:26Z) pour po-2025, déblocé par le merge de #4319 (#4209 CLOSED).

## Changement (manifest-only, 1 fichier, +14/-3)

`scripts/notebook_tools/golden_set.yml` :
- Ajoute l'entrée **SL-1** (série `SymbolicLearning`, kernel `python3`) dans la liste certifiée.
- Retire SL-1 des candidats DEFERRED (v2+ → v3+ ; ne reste que PyMC + IIT/PyPhi).
- **Aucun notebook source touché** (C.3) : les 6 notebooks du golden-set ont été ré-exécutés pour preuve mais leurs churn de sortie restent **unstaged** (re-exec Papermill, 0 cellule source modifiée).

## Preuve d'exécution réelle (G.1 — par exécution, pas par assertion)

```
$ python scripts/notebook_tools/notebook_tools.py golden-set --json
EXIT=0
{"passed": true, "success_count": 6, "total": 6, ...}
  2.1-Workflow-ML            SUCCESS  19.3s
  2.2-Descente-de-gradient   SUCCESS  15.9s
  2.3-Regression             SUCCESS  15.1s
  2.4-Arbres-Forets          SUCCESS  20.1s
  Search-1-StateSpace        SUCCESS   9.3s
  SL-1-LogicalLearning       SUCCESS   6.9s   <- nouveau
```

Env `coursia-ml-training` (sklearn 1.8.0, papermill 2.7.0, python 3.12). Le job CI `golden-set-execute` (#4319 MERGED) consommera ce manifeste et exécutera ces 6 notebooks sur le runner Ubuntu CPU.

## Décision clé (G.1 — découverte firsthand plus simple que prévu)

La deep-queue ai-01 disait « support champ `cwd` ». **G.1 firsthand : le champ `cwd` n'est PAS nécessaire.** `SL-1` fait `sys.path.insert(0, "reference"); from aima_knowledge import ...`. Or `NotebookExecutor.execute_with_papermill` exécute **déjà par défaut** avec `cwd = notebook.parent` (`abs_cwd = (cwd_override or self.path.parent).resolve()`, papermill `--cwd`). Le sous-répertoire `reference/aima_knowledge.py` (vendored AIMA, **suivi git** vérifié `git ls-files`) vit à côté du notebook → l'import relatif **resolve sans configuration dédiée**. Prouvé empiriquement : SL-1 passe avec `cwd_override=None` (le défaut). PR manifest-only, pas de modification du code.

## Critères d'admission (tous satisfaits)

| # | Critère | SL-1 |
|---|---------|------|
| 1 | kernel python3 pur | ✓ stdlib uniquement (`random`/`sys`/`time`/`typing`) |
| 2 | deps couvertes par `golden_set.lock.txt` | ✓ 0 lib scientifique (numpy/pandas/sklearn inutiles) ; ipykernel/papermill/nbformat déjà lockés |
| 3 | exec < 600s CPU, 0 erreur, 0 leak | ✓ 6.9s, SUCCESS, 0 erreur |
| 4 | sortie déterministe | ✓ `random.seed(42)` (10 occurrences, tout usage random seedé) |

## Scope

- **In scope** : admettre SL-1 au golden-set certifié (manifest-only).
- **Out of scope (DEFERRED v3+)** : PyMC (tolérance MCMC — sortie stochastique), IIT/PyPhi (pyphi lourd, Python 3.9, env dédié).

See #4209
