### PR TITLE
docs(sudoku_lean): 2 concept Mermaid diagrams (abstract CSP model + soundness deduction from keystone)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/README.md
@@ -31,6 +31,26 @@ de valeurs `V` (tous deux finis), et un ensemble de **portées** `Scopes` (chacu
 est une **instance**, non un cas spécial — les théorèmes valent pour toute structure de
 ce type.
 
+*La pyramide abstraite du modèle : les types de base `ι`/`V` et les portées `Scopes`
+portent l'invariant toutes-distinctes `IsSolution`, dont découlent les deux outils de
+propagation `IsPeer` et `PresentIn` :*
+
+```mermaid
+flowchart TD
+    TYPES["Types de base<br/>cellules ι, valeurs V  <i>(finis)</i>"]
+    SCOPES["Scopes = Finset (Finset ι)<br/>portées toutes-distinctes"]
+    AD["AllDistinctOn σ s<br/><i>σ injective sur la portée s</i>"]
+    SOL["IsSolution scopes σ<br/><i>invariant fondamental : toutes-distinctes sur chaque portée</i>"]
+    PEER["IsPeer scopes c c'<br/><i>c, c' distinctes partageant une portée</i>"]
+    PRES["PresentIn σ s v<br/><i>v apparaît dans la portée s</i>"]
+    INST["9×9 concret<br/>27 portées (9 lignes · 9 colonnes · 9 blocs)<br/><i>instance, non cas spécial</i>"]
+
+    TYPES --> SCOPES --> AD --> SOL
+    SOL --> PEER
+    SOL --> PRES
+    SOL -.-> INST
+```
+
 **`Sudoku/Basic.lean`** — primitives :
 - `Scopes` (= `Finset (Finset ι)`), `Solution` (= `ι → V`).
 - `AllDistinctOn σ s` — `σ` injective sur la portée `s` (aucune valeur répétée).
@@ -51,6 +71,21 @@ ce type.
 Chaque théorème se réduit à la clé de voûte `peer_excludes_value` par un argument par
 l'absurde : un candidat « exclu » apparaîtrait sur une paire, ce que la clé de voûte
 interdit.
+
+*La déduction sound, de la clé de voûte jusqu'aux deux règles canoniques — chacune
+réduite à `peer_excludes_value` par l'absurde :*
+
+```mermaid
+flowchart TD
+    INVAR["IsSolution scopes σ<br/><i>toutes-distinctes par portée</i>"]
+    KEY["peer_excludes_value  <b>— clé de voûte</b><br/>c porte v ∧ c' paire de c  ⟹  σ c' ≠ v<br/><i>partagent une portée ⟹ σ c = σ c' ⟹ c = c'</i>"]
+    NAKED["naked_single_sound<br/><i>toutes valeurs ≠ v portées par des paires de c</i><br/>⟹ σ c = v"]
+    HIDDEN["hidden_single_sound<br/><i>v présente en s, exclue ailleurs dans s</i><br/>⟹ σ c = v (unique restante)"]
+
+    INVAR --> KEY
+    KEY -->|"absurde : candidat exclu apparaîtrait sur une paire"| NAKED
+    KEY -->|"absurde : idem sur la cellule restante"| HIDDEN
+```
 
 ## Ce qui est délibérément ouvert (non sorry-backed)
 


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the `sudoku_lean` README, turning the abstract CSP model and the propagation soundness deduction from prose-only into visual. `sudoku_lean` is the Lean lake of the Sudoku series (roadmap **#4038**, Tier 2, issue **#4055**): it proves that the two canonical constraint-propagation rules — `naked_single` and `hidden_single` — are **sound** (eliminate no valid solution), via the keystone `peer_excludes_value`, 0 sorry. Its README was rigorous (full abstract-CSP model, proof sketch reducing both rules to the keystone, honest open-milestone scoping) but had zero diagrams; this brings it to the same standard as the sibling lakes after the **#4212** finition sweep (coop #4275, minimax #4278, sensitivity #4283, calibration #4287, finiteness #4296, lean_game_defs #4299, IIT #4303, astar #4316, argumentation #4320, kelly #4324, planning #4328). **This completes the #4212 finition sweep over all #4038 Lean lakes** — sudoku_lean was the last lake with a detailed README but zero diagrams (learning_theory_lean excluded: CoursIA-2 rename #4293).

## Diagram 1 — Abstract CSP model pyramid

Placed after the model description. Shows the type pyramid: base types cells `ι` / values `V` (finite) and `Scopes = Finset (Finset ι)` (all-distinct scopes) carry `AllDistinctOn σ s` (`σ` injective on scope `s`), which yields the fundamental invariant `IsSolution scopes σ` (all-distinct on every scope); from it derive the two propagation tools `IsPeer` (two cells sharing a scope) and `PresentIn` (value appears in a scope). The concrete 9×9 (27 scopes: 9 rows, 9 cols, 9 blocks) is shown as an **instance**, not a special case.

## Diagram 2 — Soundness deduction from the keystone

Placed after the Propagation.lean description. Shows how both canonical rules reduce to the keystone `peer_excludes_value`: from `IsSolution`, `peer_excludes_value` (cell `c` carrying `v` and `c'` a peer of `c` ⟹ `σ c' ≠ v`, because they share a scope ⟹ `σ c = σ c'` ⟹ `c = c'`); then `naked_single_sound` and `hidden_single_sound` each follow **by contradiction** (an excluded candidate would reappear on a peer, which the keystone forbids).

## G.1 firsthand (not propagation)

All symbols cited in the diagrams verified present in the Lean source firsthand on `origin/main`:
- `AllDistinctOn` (Basic.lean L34), `IsSolution` (L40), `IsPeer` (L50), `PresentIn` (L56)
- `peer_excludes_value` (Propagation.lean L40, **keystone**), `naked_single_sound` (L64), `hidden_single_sound` (L87)

## Hygiene

- Pure insertion **+35 / 0 deletions**, docs-only (**0 .lean** touched) — no anti-regression concern.
- FR-first (README is French; diagrams in French).
- Fences balanced: 3 code blocks total (1 pre-existing bash + 2 new mermaid).
- Catalog-STATUS byte-identical to main (catalog-pr-hygiene rule 1).
- Base fresh (0 behind / 0 ahead at branch creation).

Lineage: ai-01 deep-queue NUIT po-2026 item #1 (`[CLAIMED]`).

See #4055

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
