### PR TITLE
docs(ml): 02-ML-Cours README — diagramme Mermaid de l'arc pédagogique (6 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
@@ -23,6 +23,27 @@ La thèse est volontairement classique : on ne peut évaluer ce qu'un agent gén
 | [2.5-Biais-Variance-CV-ROC](2.5-Biais-Variance-CV-ROC.ipynb) | Compromis biais-variance, validation croisée, ROC/AUC | **ROC + coût du seuil** : faux négatifs vs faux positifs | réel `load_breast_cancer` |
 | [2.6-Clustering-KMeans-PCA](2.6-Clustering-KMeans-PCA.ipynb) | Apprentissage non supervisé : KMeans + ACP | **Structure retrouvée sans étiquettes** (PCA 2D + reconstruction) | réel `load_digits` |
 
+## L'arc pédagogique
+
+Le fil rouge de la série : on pose le **workflow**, on ouvre les **boîtes noires** (descente de gradient, fonction de lien), on élargit la **famille de modèles** (linéaire/logistique, arbres, ensembles), on formalise l'**évaluation** (biais-variance, validation croisée, ROC), puis on bascule en **non supervisé** (clustering, ACP). Chaque notebook rend visible un concept-phare distinct.
+
+```mermaid
+flowchart TD
+    subgraph SUP["Apprentissage supervisé (2.1 à 2.5)"]
+      direction TB
+      A["2.1 - Workflow ML<br/>split, fit, predict, évaluer<br/>surapprentissage visible (sweep max_depth)"]
+      B["2.2 - Descente de gradient<br/>ouvrir la boîte noire de fit()<br/>3 learning rates : lent / bon / divergeant"]
+      C["2.3 - Régression linéaire et logistique<br/>OLS vs MLE<br/>droite vs sigmoïde sur mêmes labels"]
+      D["2.4 - Arbres, forêts, ensembles<br/>au-delà du linéaire<br/>réduction de variance (frontière lisse)"]
+      E["2.5 - Biais-variance, CV, ROC<br/>évaluer rigoureusement<br/>ROC + coût du seuil (FN vs FP)"]
+      A --> B --> C --> D --> E
+    end
+    subgraph UNSUP["Apprentissage non supervisé (2.6)"]
+      F["2.6 - Clustering et ACP<br/>travailler sans étiquettes<br/>structure retrouvée (PCA 2D + reconstruction)"]
+    end
+    E -. "plus d'étiquettes" .-> F
+```
+
 ## Pédagogie
 
 Chaque notebook suit les mêmes conventions :


### PR DESCRIPTION
## Summary

**Lane #4212 (po-2025 — ML/Python).** Ajoute un diagramme Mermaid au README de la série [`02-ML-Cours`](MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md) : une recap visuelle de l'arc pédagogique des 6 notebooks, du workflow supervisé jusqu'au non supervisé. Suite de la lane #4212 « fil-rouge Mermaid » (po-2026 = Lean, po-2023 = GenAI, po-2025 = ML/Python).

## Changement (+21/-0, 1 fichier, docs-only)

Nouvelle section **`## L'arc pédagogique`** insérée APRÈS la table « Vue d'ensemble » (recap visuel de l'arc) et AVANT « Pédagogie ». Un bloc `flowchart TD` avec deux sous-graphes :
- **Apprentissage supervisé (2.1 → 2.5)** : la chaîne linéaire Workflow → Descente de gradient → Régression lin./log. → Arbres/ensembles → Biais-variance/CV/ROC.
- **Apprentissage non supervisé (2.6)** : Clustering & ACP, relié par un arc pointillé (« plus d'étiquettes ») marquant la bascule supervisé → non supervisé.

## G.1 firsthand (chaque nœud mappe un notebook réel + son concept-phare documenté)

Chaque nœud reprend exactement le **concept-phare** de la table « Vue d'ensemble » existante (lue sur `origin/main`) — 0 invention :
- 2.1 surapprentissage visible (sweep `max_depth`) · 2.2 trois learning rates · 2.3 OLS vs MLE (droite vs sigmoïde) · 2.4 réduction de variance · 2.5 ROC + coût du seuil · 2.6 structure retrouvée sans étiquettes.

## Validation

- **Docs-only** (§E) : pas de re-exec. +21/-0 = passe le seuil ≥20 lignes.
- **Fences balancées** : 1 bloc `mermaid` (ouverture + fermeture), vérifié `grep -c '```'` = 2.
- **0 churn catalogue** : ce README de série ne porte pas de marqueur `CATALOG-STATUS` (réservé aux READMEs de famille) → rien à préserver.
- **FR-first**, syntaxe Mermaid standard (pattern éprouvé po-2026 #4275/#4278/#4296 ; mmdc non installé → conformité au pattern, rendu GitHub).
- **Base fraîche** : worktree off `origin/main` (`8a996f90f`), rebase 0/0.

See #4212 · See #3973
