### PR TITLE
docs(genai): add fil-rouge Mermaid diagram to Audio README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -177,6 +177,35 @@ Le fil rouge de cette série est la création d'un podcast généré par IA. Voi
 
 4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Audio-Content.ipynb) applique le pipeline à la narration de cours. [04-2](04-Applications/04-2-Transcription-Pipeline.ipynb) gère la transcription batch pour les épisodes longs. [04-4](04-Applications/04-4-Audio-Video-Sync.ipynb) synchronise avec la piste vidéo si le podcast a une composante visuelle.
 
+Le schéma ci-dessous résume comment les niveaux s'articulent pour construire un podcast automatisé : de la synthèse et reconnaissance vocales one-shot (niveau 1) au pipeline STT→LLM→TTS assemblé puis déployé en production (niveaux 3-4), en passant par le clonage vocal et l'identité sonore (niveau 2).
+
+```mermaid
+flowchart TD
+    subgraph N1["1 · Parler & comprendre — 01-Foundation"]
+        A1["01-1 OpenAI TTS : API cloud"]
+        A2["01-5 Kokoro : TTS local léger"]
+        A3["01-2 Whisper STT : API cloud"]
+        A4["01-4 Whisper : transcription locale"]
+    end
+    subgraph N2["2 · Voix & musique — 02-Advanced"]
+        B1["02-2 XTTS : clonage vocal"]
+        B2["02-3 MusicGen : jingle & fond sonore"]
+        B3["02-4 Demucs : séparation de sources"]
+        B4["02-8 FishAudio : TTS expressif"]
+    end
+    subgraph N3["3 · Orchestrer — 03-Orchestration"]
+        C1["03-1 : benchmark STT / TTS"]
+        C2["03-2 : pipeline STT→LLM→TTS"]
+        C3["03-3 : Realtime Voice API"]
+    end
+    subgraph N4["4 · Produire — 04-Applications"]
+        D1["04-1 : narration de cours"]
+        D2["04-2 : transcription batch"]
+        D3["04-4 : sync audio-vidéo"]
+    end
+    N1 --> N2 --> N3 --> N4
+```
+
 ## FAQ
 
 ### GPU OOM pendant un notebook TTS/STT local


### PR DESCRIPTION
## Summary

Replicates the merged Video README pattern (#4322) and the Image README pattern (#4330) on the **Audio** series: a `flowchart TD` visual recap of the 4-level fil rouge (**construire un podcast automatisé**), inserted after the detailed Recette numbered list, before the FAQ.

The 4 levels appear as bricks assembling into the final pipeline:
- **N1 · Parler & comprendre** (01-Foundation): OpenAI TTS, Kokoro, Whisper STT cloud + local
- **N2 · Voix & musique** (02-Advanced): XTTS clonage, MusicGen, Demucs, FishAudio expressif
- **N3 · Orchestrer** (03-Orchestration): benchmark, pipeline STT→LLM→TTS, Realtime API
- **N4 · Produire** (04-Applications): narration cours, transcription batch, sync A/V

## G.1 ground-truth (0 invention)

All **14 diagram nodes** map a real notebook already linked elsewhere in the README (structure tables L44-96 + Recette L172-178):
- 01-1, 01-5, 01-2, 01-4 (N1) · 02-2, 02-3, 02-4, 02-8 (N2) · 03-1, 03-2, 03-3 (N3) · 04-1, 04-2, 04-4 (N4)

Mermaid labels are plain text (no markdown links inside), so no new links to break.

## Verifications

- **+29/0 pure additive** (1 file), identical shape to #4322 / #4330
- **Catalog byte-identical to main** — no `COURSE_CATALOG.generated.*` churn
- **CATALOG-STATUS marker untouched** (0 in diff)
- **Fresh rebase** — branch from `origin/main` (`8a996f90f`)
- **Exactly 1 Mermaid block** (no duplication)
- **Docs-only** → C.2 markdown exception, no notebook re-exec needed
- **FR-first** (per `readme-french-first.md`)

Lineage: ai-01 deep-queue NUIT po-2023, item #2 (Audio README fil-rouge Mermaid).

See #4212 (GenAI-dogfood visuals)
See #3801 (Epic Axe-2 SOTA registry)