### PR TITLE
fix(csp): relabel Search-6/7/8 cross-refs to CSP-1/2/3 nav (Tier-2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# CSP-1 : Fondamentaux des CSP\n",
     "\n",
-    "**Navigation** : [<< Search-5 GeneticAlgorithms](../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | [Index](../README.md) | [Search-7 CSP-Consistency >>](CSP-2-Consistency.ipynb)\n",
+    "**Navigation** : [<< Search-5 GeneticAlgorithms](../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | [Index](../README.md) | [CSP-2-Consistance >>](CSP-2-Consistency.ipynb)\n",
     "\n",
     "## Problemes de Satisfaction de Contraintes - Fondamentaux\n",
     "\n",
@@ -2592,7 +2592,7 @@
    "source": [
     "---\n",
     "\n",
-    "**Navigation** : [<< Search-5 GeneticAlgorithms](../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | [Index](../README.md) | [Search-7 CSP-Consistency >>](CSP-2-Consistency.ipynb)\n"
+    "**Navigation** : [<< Search-5 GeneticAlgorithms](../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | [Index](../README.md) | [CSP-2-Consistance >>](CSP-2-Consistency.ipynb)\n"
    ]
   },
   {
@@ -3093,7 +3093,7 @@
    "source": [
     "### Et ensuite ?\n",
     "\n",
-    "Ce notebook a couvert les **fondamentaux** des CSP : formalisme, backtracking avec heuristiques, et utilisation de la bibliotheque `python-constraint`. Le notebook suivant, [Search-7 CSP-Consistency](CSP-2-Consistency.ipynb), introduit les techniques de **propagation de contraintes** :\n",
+    "Ce notebook a couvert les **fondamentaux** des CSP : formalisme, backtracking avec heuristiques, et utilisation de la bibliotheque `python-constraint`. Le notebook suivant, [CSP-2-Consistance](CSP-2-Consistency.ipynb), introduit les techniques de **propagation de contraintes** :\n",
     "\n",
     "- **Forward Checking** : eliminer les valeurs inconsistantes des voisins a chaque assignation\n",
     "- **Arc Consistency (AC-3)** : rendre le CSP arc-consistent avant et pendant la recherche\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# CSP-2 : Propagation de Contraintes et Consistance\n",
     "\n",
-    "**Navigation** : [<< Search-6 CSP-Fundamentals](CSP-1-Fundamentals.ipynb) | [Index](../README.md) | [Search-8 CSP-Advanced >>](CSP-3-Advanced.ipynb)\n",
+    "**Navigation** : [<< CSP-1-Fondamentaux](CSP-1-Fundamentals.ipynb) | [Index](../README.md) | [CSP-3-Avance >>](CSP-3-Advanced.ipynb)\n",
     "\n",
     "## Propagation de Contraintes et Consistance\n",
     "\n",
@@ -3106,7 +3106,7 @@
     "\n",
     "### Et ensuite ?\n",
     "\n",
-    "Le prochain notebook [Search-8-CSP-Advanced](CSP-3-Advanced.ipynb) abordera :\n",
+    "Le prochain notebook [CSP-3-Avance](CSP-3-Advanced.ipynb) abordera :\n",
     "- Les **contraintes globales** (AllDifferent, etc.) et leur propagation specialisee\n",
     "- La **recherche locale** pour les CSP (Min-Conflicts)\n",
     "- Les **CSP d'optimisation** (COP)\n",
@@ -3137,7 +3137,7 @@
     "\n",
     "Ce notebook a couvert les techniques fondamentales de propagation de contraintes pour les CSP : la **consistance de noeud** (contraintes unaires), la **consistance d'arc** avec l'algorithme AC-3, le **Forward Checking** (propagation 1 niveau) et le **MAC** (propagation complete en cascade). Les benchmarks sur les N-Reines ont montre que MAC reduit le nombre d'assignations d'un facteur 40x par rapport au backtracking pur, confirmant que l'overhead de propagation est largement compense par la reduction de l'espace explore.\n",
     "\n",
-    "Ces techniques constituent le socle des solveurs CSP industriels comme OR-Tools. Le prochain notebook [Search-8-CSP-Advanced](CSP-3-Advanced.ipynb) etendra ces concepts aux contraintes globales (AllDifferent), a la recherche locale (Min-Conflicts) et aux problemes d'optimisation (COP), avec des applications directes en ordonnancement et planification."
+    "Ces techniques constituent le socle des solveurs CSP industriels comme OR-Tools. Le prochain notebook [CSP-3-Avance](CSP-3-Advanced.ipynb) etendra ces concepts aux contraintes globales (AllDifferent), a la recherche locale (Min-Conflicts) et aux problemes d'optimisation (COP), avec des applications directes en ordonnancement et planification."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# CSP-3 : CSP Avance - Contraintes globales, OR-Tools et LNS\n",
     "\n",
-    "**Navigation** : [<< Search-7 CSP-Consistency](CSP-2-Consistency.ipynb) | [Index](../README.md) | [Applications >>](../Applications/README.md)\n",
+    "**Navigation** : [<< CSP-2-Consistance](CSP-2-Consistency.ipynb) | [Index](../README.md) | [Applications >>](../Applications/README.md)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -28,7 +28,7 @@
     "5. **Construire** un modele complet combinant contraintes globales et objectif d'optimisation\n",
     "\n",
     "### Prerequis\n",
-    "- [Search-7 CSP-Consistency](CSP-2-Consistency.ipynb) : AC-3, Forward Checking, MAC\n",
+    "- [CSP-2-Consistance](CSP-2-Consistency.ipynb) : AC-3, Forward Checking, MAC\n",
     "- Bases de Python (classes, dictionnaires, comprehensions)\n",
     "\n",
     "### Duree estimee : 50 minutes\n",


### PR DESCRIPTION
## Summary

Per **[GREENLIGHT ai-01 cycle-F 22:27Z]**: Tier-2 cross-series relabel — format **(a) filename-stem**.

The 3 **Part2-CSP** notebooks reference each other in their navigation cells with stale `Search-6/7/8` prefixes — relics from before the CSP sub-series was split out of `Search/`. The **link target filenames** already carry the correct `CSP-1/2/3` identity = **ground truth**. This PR makes the labels consistent with their own links.

## G.1 firsthand verification (link target = authority)

Verified the **actual H1** of each CSP target (cycle 67 + reconfirmed this cycle):

| Target file | H1 (authority) | New label |
|-------------|----------------|-----------|
| `CSP-1-Fundamentals.ipynb` | Fondamentaux des CSP | `[CSP-1-Fondamentaux]` |
| `CSP-2-Consistency.ipynb` | Propagation de Contraintes et Consistance | `[CSP-2-Consistance]` |
| `CSP-3-Advanced.ipynb` | CSP Avance (H1 has **no accent**) | `[CSP-3-Avance]` |

## Changes — 9 labels across 3 notebooks

**CSP-1-Fundamentals** (3): cell 0 nav-next, cell 59, cell 73 — `[Search-7 CSP-Consistency]` → `[CSP-2-Consistance]`
**CSP-2-Consistency** (4): cell 0 nav-prev `[<< Search-6 CSP-Fundamentals]` → `[<< CSP-1-Fondamentaux]` + nav-next `[Search-8 CSP-Advanced >>]` → `[CSP-3-Avance >>]`; cell 65/66 `[Search-8-CSP-Advanced]` → `[CSP-3-Avance]`
**CSP-3-Advanced** (2): cell 0 nav-prev `[<< Search-7 CSP-Consistency]` → `[<< CSP-2-Consistance]`; ressources `[Search-7 CSP-Consistency]` → `[CSP-2-Consistance]`

## Angle blind spot caught

The initial narrow scan regex (`\[(Search-\d+...)`) **missed** the `[<< Search-N ...]` nav-previous patterns (Search-N not immediately after `[`). A **broad rescan** (`\[[^\]]*Search-\d+[^\]]*\]\([^)]*CSP-\d+[^)]*\)`) surfaced 2 extra nav-prev links → fixed.

Final residual scan: **0** remaining `Search-N → CSP-N` markdown links in Part2-CSP.

## Left intact (G.9 — prose, not links)

- CSP-3 cell 1 prose: "notebooks precedents (Search-6 et Search-7)"
- CSP-3 cell 56 table row: "| Consistance | Search-7 |"

These are **prose/table mentions, not markdown links** → out of scope for a mechanical label fix; separate editorial tracker.

## Validation

- **Markdown-only** (C.2 exception — no re-execution needed)
- **Replace-text-direct** (NOT `json` round-trip): preserves exact byte-format. These CSP notebooks' original nbformat layout differs from `json.dump(indent=1)` output (Search/Sudoku were indent=1-native; CSP are not). Lesson cycle 70.
- **Diff: +8/-8, 0 churn** (pure label changes, no brace/string-list normalization)
- JSON validity confirmed (3 notebooks load)
- **CATALOG byte-identical** (not touched)
- Scope held (G.5/G.9): intra-CSP navigation = one coherent atomic subject

See #3975