### PR TITLE
fix(sudoku): relabel Search-6/7/8 cross-refs to CSP-1/2/3 (Tier-2)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -25,7 +25,7 @@
     "2. **Comprendre** l'exploration en profondeur et le retour arriere\n",
     "3. **Analyser** les performances du backtracking selon la difficulte des puzzles\n",
     "\n",
-    "**Duree estimee** : ~7 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [Search-6 CSP Fundamentals](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour la theorie du backtracking\n",
+    "**Duree estimee** : ~7 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour la theorie du backtracking\n",
     "\n",
     "---\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "### Duree estimee : 50 minutes\n",
     "\n",
-    "**Voir aussi** : [Search-6-CSP-Fundamentals](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour les bases de CSP\n",
+    "**Voir aussi** : [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour les bases de CSP\n",
     "\n",
     "---\n",
     "\n",
@@ -1885,8 +1885,8 @@
     "**Navigation** : [<< Sudoku-9 Graph Coloring C#](Sudoku-9-GraphColoring-Csharp.ipynb) | [Index](README.md) | [Sudoku-11 Choco C# >>](Sudoku-11-Choco-Csharp.ipynb)\n",
     "\n",
     "**Voir aussi** : \n",
-    "- [Search-6-CSP-Fundamentals](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) - Fondamentaux CSP\n",
-    "- [Search-7-CSP-Consistency](../Search/Part2-CSP/CSP-2-Consistency.ipynb) - Propagation de contraintes\n",
+    "- [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) - Fondamentaux CSP\n",
+    "- [CSP-2-Consistance](../Search/Part2-CSP/CSP-2-Consistency.ipynb) - Propagation de contraintes\n",
     "- [App-1-NQueens](../Search/Applications/CSP/App-1-NQueens.ipynb) - Autre application CSP"
    ]
   }

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -26,7 +26,7 @@
     "3. Comparer les performances d'un solveur industriel avec le backtracking\n",
     "4. Utiliser la contrainte AllDifferent pour modéliser des problèmes combinatoires\n",
     "\n",
-    "**Duree estimee** : ~10 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [Search-8 CSP Advanced](../Search/Part2-CSP/CSP-3-Advanced.ipynb)\n",
+    "**Duree estimee** : ~10 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [CSP-3-Avance](../Search/Part2-CSP/CSP-3-Advanced.ipynb)\n",
     "\n",
     "---\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb
@@ -1806,7 +1806,7 @@
     "| [Sudoku-10-ORTools](./Sudoku-10-ORTools-Python.ipynb) | CP-SAT vs Choco: deux approches CP differentes |\n",
     "| [Sudoku-6-AIMA-CSP](./Sudoku-6-AIMA-CSP-Python.ipynb) | Theorie des CSP et backtracking |\n",
     "| [Sudoku-12-Z3](./Sudoku-12-Z3-Python.ipynb) | SMT solving vs Constraint Programming |\n",
-    "| [Search-6-CSP-Fundamentals](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) | Fondements theoriques des CSP |\n",
+    "| [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) | Fondements theoriques des CSP |\n",
     "\n",
     "---\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "### Voir aussi\n",
     "\n",
-    "- [Search-8-CSP-Advanced](../Search/Part2-CSP/CSP-3-Advanced.ipynb) - Contraintes globales avancees\n",
+    "- [CSP-3-Avance](../Search/Part2-CSP/CSP-3-Advanced.ipynb) - Contraintes globales avancees\n",
     "- [SymbolicAI](../SymbolicAI/README.md) - Serie complete sur l'IA symbolique avec Z3\n",
     "\n",
     "## Introduction a Z3\n",
@@ -1403,7 +1403,7 @@
     "**Navigation** : [<< Sudoku-11 Choco C#](Sudoku-11-Choco-Csharp.ipynb) | [Index](README.md) | [Sudoku-13 Symbolic Automata C# >>](Sudoku-13-SymbolicAutomata-Csharp.ipynb)\n",
     "\n",
     "**Voir aussi** : \n",
-    "- [Search-8-CSP-Advanced](../Search/Part2-CSP/CSP-3-Advanced.ipynb) - Contraintes globales avancees\n",
+    "- [CSP-3-Avance](../Search/Part2-CSP/CSP-3-Advanced.ipynb) - Contraintes globales avancees\n",
     "- [SymbolicAI](../SymbolicAI/README.md) - Serie sur l'IA symbolique et Z3"
    ]
   }

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -369,7 +369,7 @@
        "2. **Comprendre** l'exploration en profondeur et le retour arriere\n",
        "3. **Analyser** les performances du backtracking selon la difficulte des puzzles\n",
        "\n",
-       "**Duree estimee** : ~7 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [Search-6 CSP Fundamentals](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour la theorie du backtracking\n",
+       "**Duree estimee** : ~7 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour la theorie du backtracking\n",
        "\n",
        "---\n",
        "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
@@ -33,7 +33,7 @@
     "### Duree estimee : 20 minutes\n",
     "\n",
     "### Liens\n",
-    "- Voir [Search-7 CSP Consistency](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour la theorie de la propagation de contraintes\n",
+    "- Voir [CSP-2-Consistance](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour la theorie de la propagation de contraintes\n",
     "- [Article original de Peter Norvig (2006)](http://norvig.com/sudoku.html)\n"
    ]
   },
@@ -1462,7 +1462,7 @@
     "### Pour aller plus loin\n",
     "\n",
     "- **Techniques de propagation avancees** : paires nues, triples nus, X-wing, swordfish (voir Exercice 1)\n",
-    "- **Theorie de la propagation** : voir [Search-7 CSP Consistency](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour une presentation formelle de l'arc-consistance et des algorithmes AC-3, MAC\n",
+    "- **Theorie de la propagation** : voir [CSP-2-Consistance](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour une presentation formelle de l'arc-consistance et des algorithmes AC-3, MAC\n",
     "- **Comparaison avec les solveurs specialises** : OR-Tools (Sudoku-10) et Dancing Links (Sudoku-2) utilisent des mecanismes differents mais reposent aussi sur la propagation de contraintes\n",
     "\n",
     "### Ressources\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
@@ -2500,7 +2500,7 @@
     "---\n",
     "\n",
     "**Voir aussi** :\n",
-    "- [Search-7-CSP-Consistency](../Search/Part2-CSP/CSP-2-Consistency.ipynb) - Propagation de contraintes\n",
+    "- [CSP-2-Consistance](../Search/Part2-CSP/CSP-2-Consistency.ipynb) - Propagation de contraintes\n",
     "- [Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) - Propagation de Norvig\n",
     "\n",
     "---\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
@@ -1837,7 +1837,7 @@
     "|----------|-----------------|\n",
     "| [Sudoku-6-AIMA-CSP](./Sudoku-6-AIMA-CSP-Csharp.ipynb) | CSP = coloration avec variables/domaines/contraintes |\n",
     "| [Sudoku-7-Norvig](./Sudoku-7-Norvig-Csharp.ipynb) | Propagation similaire a la reduction de domaine |\n",
-    "| [Search-6-CSP-Fundamentals](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) | Theorie generale des CSP |\n",
+    "| [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) | Theorie generale des CSP |\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Summary

Per **[GREENLIGHT ai-01 cycle-F 22:27Z]**: Tier-2 cross-series relabel — format **(a)** (French H1-based labels, per the greenlight examples `[CSP-1-Fondamentaux]` / `[CSP-2-Consistance]` / `[CSP-3-Avance]`).

The **Sudoku series** notebooks reference the **Part2-CSP** sub-series with stale `Search-6/7/8-CSP-*` labels — relics from before CSP was split out of `Search/`. The **link target filenames** already carry the correct `CSP-1/2/3` identity = **ground truth**. This PR makes the labels consistent with their own links. (Companion to #4336 which did the CSP intra-nav.)

## G.1 firsthand verification

**Target H1** verified cycle 67 + 70:
- `CSP-1-Fundamentals.ipynb` → H1 "Fondamentaux des CSP" → `[CSP-1-Fondamentaux]`
- `CSP-2-Consistency.ipynb` → H1 "Propagation de Contraintes et Consistance" → `[CSP-2-Consistance]`
- `CSP-3-Advanced.ipynb` → H1 "CSP Avance" (NO accent) → `[CSP-3-Avance]`

**Framing converges** (leçon cycle 57 — verify intent, not just existence). Each Sudoku cell's descriptive prose matches its CSP target, confirming the relabel is mechanical-safe (not the find-replace hazard of #1214):
- Sudoku-9 "Théorie générale des CSP" → CSP-1 ✓
- Sudoku-7 "théorie de la propagation de contraintes / arc-consistance, AC-3, MAC" → CSP-2 ✓
- Sudoku-12 "Contraintes globales avancées" → CSP-3 ✓
- (all 13 occurrences checked)

## Changes — 13 labels across 9 notebooks

| Notebook | Count |
|----------|-------|
| Sudoku-10-ORTools-Csharp | 3 |
| Sudoku-7-Norvig-Csharp | 2 |
| Sudoku-12-Z3-Csharp | 2 |
| Sudoku-1/4/8/9/11 + Sudoku-10-ORTools-Python | 1 each |

Two label formats coexist and are both fixed: hyphenated (`[Search-6-CSP-Fundamentals]`) and spaced (`[Search-6 CSP Fundamentals]`).

## Validation

- **Markdown-only** (C.2 exception — no re-exec)
- **Replace-text-direct** (byte-format preserved; lesson cycle 70 — avoids json round-trip churn)
- **Diff: +13/-13, 0 churn** (every changed line is a pure label swap; link targets + surrounding prose byte-identical)
- JSON validity confirmed (9 notebooks load before+after)
- **Residual scan: 0** remaining `Search-N → CSP-N` markdown links in `Sudoku/`
- **CATALOG byte-identical** (not touched)
- One coherent subject: Tier-2 relabel across Sudoku series (under G.4 thresholds)

See #3975