### PR TITLE
fix(search): relabel Search-6 cross-ref to CSP-1 in Search-5 nav (Tier-2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
@@ -3354,7 +3354,7 @@
     "\n",
     "### Pour aller plus loin\n",
     "\n",
-    "- **Notebook suivant** : [Search-6-CSP-Fundamentals](../Part2-CSP/CSP-1-Fundamentals.ipynb) - Problemes de satisfaction de contraintes\n",
+    "- **Notebook suivant** : [CSP-1-Fondamentaux](../Part2-CSP/CSP-1-Fundamentals.ipynb) - Problemes de satisfaction de contraintes\n",
     "- **Applications** : [App-9 Edge Detection](../PyGad-EdgeDetection.ipynb), [App-10 Portfolio](../Portfolio_Optimization_GeneticSharp.ipynb)\n",
     "- **References** :\n",
     "  - Goldberg, D. *Genetic Algorithms in Search, Optimization, and Machine Learning*, 1989\n",


### PR DESCRIPTION
## Summary

Per **[GREENLIGHT ai-01 cycle-F 22:27Z]**: Tier-2 cross-series relabel format **(a)**. Final Tier-2 item — completes **#4336** (CSP intra-nav) + **#4337** (Sudoku series).

`Search-5-GeneticAlgorithms` "Notebook suivant" navigation cites `[Search-6-CSP-Fundamentals]` but links to `CSP-1-Fundamentals.ipynb` — relic from before CSP was split out of `Search/` into `Part2-CSP/`. Label made consistent with its link target (ground truth).

## G.1 firsthand

- Target `CSP-1-Fundamentals.ipynb` H1 = "Fondamentaux des CSP" → `[CSP-1-Fondamentaux]`
- Cell prose "Problèmes de satisfaction de contraintes" converges with CSP-1 ✓

## Validation

- Markdown-only (C.2 exception). Replace-text-direct, **+1/-1, 0 churn**. JSON valid. CATALOG byte-identical.

See #3975