### PR TITLE
docs(genai): add cross-modal Mermaid map to GenAI top-level README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -221,6 +221,20 @@ Les sous-domaines ne sont pas isolés. Un projet final typique enchaîne :
 
 C'est ce parcours d'intégration qui différencie une démonstration jouet d'un produit déployable.
 
+Le schéma ci-dessous visualise ce fil rouge transverse : les quatre modalités génératives (Texte, Image, Audio, Video) produisent le contenu, puis SemanticKernel orchestre le tout en agents autonomes et Playwright-OWUI valide l'interface utilisateur finale.
+
+```mermaid
+flowchart LR
+    T["Texte<br/>script structuré"]
+    I["Image<br/>illustrations"]
+    A["Audio<br/>narration + musique"]
+    V["Video<br/>assemblage A/V"]
+    S["SemanticKernel<br/>orchestration agents"]
+    P["Playwright-OWUI<br/>tests E2E"]
+    Prod["Produit déployable"]
+    T --> I --> A --> V --> S --> P --> Prod
+```
+
 ## FAQ
 
 ### Faut-il un GPU pour cette série ?


### PR DESCRIPTION
## Summary

Visualizes the existing **"Fil rouge transverse"** section (L211-222) of the GenAI top-level README: a `flowchart LR` showing the 6-step cross-modal pipeline that turns a script into a deployable product.

```
Texte → Image → Audio → Video → SemanticKernel → Playwright-OWUI → Produit déployable
```

Each node captures the series' role in the integration pipeline:
- **Texte** — script structuré (function calling, structured outputs)
- **Image** — illustrations (DALL-E / FLUX / Qwen Image Edit)
- **Audio** — narration (Kokoro/OpenAI TTS) + fond musical (MusicGen)
- **Video** — assemblage A/V (HunyuanVideo, Demucs sync)
- **SemanticKernel** — orchestration agents autonomes
- **Playwright-OWUI** — tests E2E interface
- **Produit déployable** — sortie du parcours d'intégration

This **completes** the fil-rouge Mermaid pattern across the GenAI family: Video (#4322), Image (#4330), Audio (#4335), and now the top-level cross-modal map that ties them together with Texte, SemanticKernel and Playwright-OWUI.

## G.1 ground-truth (0 invention)

All **7 nodes** map the exact steps already enumerated in the "Fil rouge transverse" numbered list (L215-220 of the README). Mermaid labels are plain text (no markdown links inside), so no new links to break.

## Verifications

- **+14/0 pure additive** (1 file)
- **Catalog byte-identical to main** — no `COURSE_CATALOG.generated.*` churn
- **CATALOG-STATUS marker untouched** (0 in diff)
- **Fresh rebase** — branch from `origin/main` (`8a996f90f`)
- **Exactly 1 Mermaid block** (no duplication)
- **Docs-only** → C.2 markdown exception, no notebook re-exec needed
- **FR-first** (per `readme-french-first.md`)

Lineage: ai-01 deep-queue NUIT po-2023, item #3 (GenAI top-level README cross-modal Mermaid).

See #4212 (GenAI-dogfood visuals)
See #3801 (Epic Axe-2 SOTA registry)