### PR TITLE
docs(genai): add fil-rouge Mermaid diagram to Texte README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -158,6 +158,35 @@ Le fil rouge de cette série est la progression de l'interaction basique avec un
 
 5. **Tier 5** (test-time scaling approfondi) : partant de [12_Test_Time_Scaling](12_Test_Time_Scaling.ipynb) (les quatre moteurs en Python pur), l'arc NB-13..18 décompose chaque facette de l'inférence au moment du test — orchestration agentique via function calling ([13](13_Agentic_Orchestration.ipynb)), mémoire persistante par similarité ([14](14_Persistent_Memory.ipynb)), Tree-of-Thoughts sur des problèmes de recherche ([15](15_Tree_of_Thoughts_Search.ipynb)), courbes de scaling de Snell ([16](16_Scaling_Test_Time_Compute.ipynb)), raisonnement natif vs scaling hand-rolled ([17](17_Native_Reasoning_vs_Scaling.ipynb)), puis intégration Semantic Kernel ([18](18_Semantic_Kernel_Plugins.ipynb)).
 
+Le schéma ci-dessous résume comment les cinq tiers s'enchaînent pour maîtriser les LLMs : du prompt one-shot (tier 1) aux patterns de production puis à l'arc test-time scaling approfondi (tiers 4-5), en passant par les sorties structurées (tier 2) et l'augmentation RAG/code interpreter (tier 3).
+
+```mermaid
+flowchart TD
+    subgraph T1["Tier 1 · Fondations"]
+        A1["1 : API OpenAI & tokens"]
+        A2["2 : Prompt engineering"]
+    end
+    subgraph T2["Tier 2 · Sorties structurées"]
+        B1["3 : Structured Outputs"]
+        B2["4 : Function Calling"]
+    end
+    subgraph T3["Tier 3 · Augmentation"]
+        C1["5-6 : RAG & PDF/Web"]
+        C2["7 : Code Interpreter"]
+    end
+    subgraph T4["Tier 4 · Avancé & production"]
+        D1["8-9 : Reasoning & Production"]
+        D2["10-11 : Local Llama & Quantization"]
+        D3["12 : Test-Time Scaling"]
+    end
+    subgraph T5["Tier 5 · Test-time scaling approfondi (ICR)"]
+        E1["13-14 : Agentic & Mémoire"]
+        E2["15-17 : ToT, Scaling, Native"]
+        E3["18 : Plugins Semantic Kernel"]
+    end
+    T1 --> T2 --> T3 --> T4 --> T5
+```
+
 ## FAQ
 
 ### Chat Completions vs Responses API — laquelle utiliser ?


### PR DESCRIPTION
## Summary

Completes the fil-rouge Mermaid pattern across the **4 generative modalities**: Video (#4322), Image (#4330), Audio (#4335), and now **Texte** with its 5 tiers. A `flowchart TD` visual recap inserted after the Recette numbered list, before the FAQ.

The 5 tiers appear as bricks chaining from prompt one-shot to the test-time scaling arc:
- **Tier 1** Fondations (1-2) → **Tier 2** Sorties structurées (3-4) → **Tier 3** Augmentation RAG/code interpreter (5-7) → **Tier 4** Avancé & production (8-12) → **Tier 5** Test-time scaling approfondi ICR (13-18)

## G.1 ground-truth (0 invention)

The 12 nodes group the 18 notebooks by their **exact tier assignments** already documented in the "Contenu détaillé" tables (L27-70) and the Recette (L151-159). Plain-text labels (no markdown links inside), so no new links to break. The README already had an ASCII parcours (L84-106); this Mermaid is the fil-rouge recap by tier, consistent with the Image/Audio/Video pattern.

## Note on deep-queue triage

Deep-queue item #4 (Texte "sub-series leaf README") was **STALE** — verified firsthand: Texte is a **flat series** (no sub-directories) and its README already has structure (5 tiers tables) + nav (header links + ASCII parcours). No leaf README to create. This PR addresses item #5 (Texte README aeration + 1 Mermaid) instead — the genuinely defensible delivery.

## Verifications

- **+29/0 pure additive** (1 file)
- **Catalog byte-identical to main** — no `COURSE_CATALOG.generated.*` churn
- **CATALOG-STATUS marker untouched** (0 in diff)
- **Fresh rebase** — branch from `origin/main` (`a5a6ad2f2`, post #4330/#4335/#4339 merges)
- **Exactly 1 Mermaid block** (no duplication)
- **Docs-only** → C.2 markdown exception, no notebook re-exec needed
- **FR-first** (per `readme-french-first.md`)

Lineage: ai-01 deep-queue NUIT po-2023, item #5 (Texte README aeration + Mermaid).

See #4212 (GenAI-dogfood visuals)
See #3801 (Epic Axe-2 SOTA registry)