### PR TITLE
fix(genai): repair post-reorg paths/links in Image leaf READMEs (01-4, 01-5)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo_README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo_README.md
@@ -105,7 +105,7 @@ Le notebook est organisé en **7 sections progressives** (15 cellules total):
 1. **Cloner/Télécharger** le notebook :
    ```bash
    git clone https://github.com/MyIA/CoursIA.git
-   cd CoursIA/MyIA.AI.Notebooks/GenAI/01-Images-Foundation
+   cd CoursIA/MyIA.AI.Notebooks/GenAI/Image/01-Foundation
    ```
 
 2. **Installer dépendances** :
@@ -268,7 +268,7 @@ Le notebook gère automatiquement les erreurs courantes :
    - Hugging Face : [stabilityai/sdxl-turbo](https://huggingface.co/stabilityai/sdxl-turbo)
 
 3. **Documentation GenAI** :
-   - [Services et API GenAI](../../../../docs/genai-services.md)
+   - [Services et API GenAI](../../../../docs/genai/genai-services.md)
 
 ### Tutoriels Supplémentaires
 

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit_README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit_README.md
@@ -77,7 +77,7 @@ jupyter notebook
 ```
 
 Naviguez vers:  
-`MyIA.AI.Notebooks/GenAI/01-Images-Foundation/01-5-Qwen-Image-Edit.ipynb`
+`MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb`
 
 ### 2. Exécuter Séquentiellement
 
@@ -272,7 +272,7 @@ pip install Pillow
 ### Notebooks Associés
 
 - **`01-4-Forge-SD-XL-Turbo.ipynb`**: Génération images Stable Diffusion (comparaison API)
-- **`01-Images-Foundation/`**: Série complète notebooks GenAI images
+- **`Image/01-Foundation/`**: Série complète notebooks GenAI images
 
 ---
 
@@ -330,11 +330,11 @@ Le notebook contient un template workflow `workflow_exercice` avec:
 ### Contact Formation
 
 - **Email**: support-formation@myia.io
-- **Documentation GenAI** : [Services et architecture GenAI](../../../../docs/genai-services.md)
+- **Documentation GenAI** : [Services et architecture GenAI](../../../../docs/genai/genai-services.md)
 
 ### Issues Connues
 
-Consultez les rapports de tests dans les [archives GenAI](../../../../docs/genai-services.md).
+Consultez les rapports de tests dans les [archives GenAI](../../../../docs/genai/genai-services.md).
 
 ---
 


### PR DESCRIPTION
## Scope

Fixes **2 classes of post-reorg link drift** in the GenAI Image leaf READMEs (`Image/01-Foundation/*_README.md`). These leaf READMEs were written before the multi-modal reorg (when `GenAI/01-Images-Foundation/` existed) and never updated. Two bugs per file:

1. **Stale post-reorg paths** — references to the defunct `GenAI/01-Images-Foundation/` directory (now `GenAI/Image/01-Foundation/`).
2. **Broken doc links** — `docs/genai-services.md` (the file moved to `docs/genai/genai-services.md` during the docs/ reorg; the relative depth is correct but the `genai/` segment is missing → resolves to a non-existent file).

## What changed (6 surgical fixes, 2 files)

`+6 / -6` (2 files), pure path/link fixes, no prose change.

| File | Line | Before | After |
|------|------|--------|-------|
| `01-4-Forge-SD-XL-Turbo_README.md` | L108 | `cd .../GenAI/01-Images-Foundation` | `cd .../GenAI/Image/01-Foundation` |
| `01-4-Forge-SD-XL-Turbo_README.md` | L271 | `(../../../../docs/genai-services.md)` | `(../../../../docs/genai/genai-services.md)` |
| `01-5-Qwen-Image-Edit_README.md` | L80 | `GenAI/01-Images-Foundation/01-5-...ipynb` | `GenAI/Image/01-Foundation/01-5-...ipynb` |
| `01-5-Qwen-Image-Edit_README.md` | L275 | `**\`01-Images-Foundation/\`**` | `**\`Image/01-Foundation/\`**` |
| `01-5-Qwen-Image-Edit_README.md` | L333 | `(../../../../docs/genai-services.md)` | `(../../../../docs/genai/genai-services.md)` |
| `01-5-Qwen-Image-Edit_README.md` | L337 | `(../../../../docs/genai-services.md)` | `(../../../../docs/genai/genai-services.md)` |

## G.1 — grounded firsthand

All 6 fixes verified against the filesystem:
- `docs/genai/genai-services.md` EXISTS (the target that was unreachable).
- `MyIA.AI.Notebooks/GenAI/Image/01-Foundation/` EXISTS (the corrected `cd` target); `01-5-Qwen-Image-Edit.ipynb` lives there.
- Depth `../../../../` from `Image/01-Foundation/` is correct (4 levels up to repo root). The bug was the missing `genai/` segment, not the depth.
- These are the **only 2 `*_README.md` leaf docs in all of GenAI** (`find GenAI -name '*_README.md'` = exactly these 2), so the cohort is bounded — no hidden sibling files missed.

## Scope honesty (G.1 — what is deliberately NOT in this PR)

1. **`GenAI/INDEX.md` carries the same 2 bug-classes** (4 stale `Images-*` paths L115/120/125/130 + 1 broken `genai-services.md` L792) — but INDEX.md is a **structurally-stale document** (title "GenAI Images Ecosystem", "18 Notebooks" claim vs 60+ actual, DALL-E 3 throughout post-retirement, last updated 2026-03-08, pre-multi-modal-reorg structure). Fixing 5 links inside a document that's rotten at the structural level is putting lipstick on it. The right call (full refresh vs archive in favor of the cross-modal top-level README #4339 + per-series READMEs) is a **coordinator decision** — flagged here, not silently folded into a path-fix PR.

2. **`scripts/check_docs_links.py` coverage gap** — `find_scan_files()` (L114-118) collects only files named exactly `README.md`, so it ignores `INDEX.md` and `*_README.md`. That's why `--check` reports "0 pre-existing broken links" while 5+ actually exist in these files. Extending the checker to scan `INDEX.md` + `*_README.md` would surface 45 broken links across the repo (mostly stale-notebook refs in root `INDEX.md`, multi-domain) — a separate, larger PR (infra/docs-tooling), not folded here.

3. **01-5 L337 prose**: the link text "archives GenAI" now points to `genai-services.md` (the GenAI services doc), which is semantically loose (the text says "archives", the target is not an archive; the real `docs/_archives/suivis/genai-image/` doesn't exist). The PATH is now valid (broken→resolves), but the wording remains loose — a prose nit, out of scope for a path-fix PR.

4. **Pre-existing markdown-lint warnings** (MD022/MD031/MD032 blanks-around-headings/lists/fences) flagged by the IDE across these files are unrelated to the 6 edited lines — a markdown-formatting pass is a separate PR.

## Vérification

- **Diff** : `+6 / -6` (2 files), pure path/link fixes.
- **Catalog byte-identical to main** : 0 catalog file touched (catalog-pr-hygiene HARD 1).
- **CATALOG-STATUS marker** : N/A (leaf READMEs carry no marker) / 0 in diff.
- **Rebase frais** : base == origin/main (`a5a6ad2f2`, post-#4339) (catalog-pr-hygiene HARD 2).
- **Fixed links resolve** : both `docs/genai/genai-services.md` and `Image/01-Foundation/` exist on disk (verified).
- **Docs-only** : no notebook touched → no re-exec (C.2 markdown exception). These leaf READMEs are standalone `.md` (not notebook cells).
- **Residual bugs in leaf cohort** : 0 (grep for `Images-*` and `docs/genai-services.md` in `Image/**/*_README.md` returns empty).

## Lineage

Defensible pickup from deep-queue po-2023 after items #1-5 (GenAI fil-rouge Mermaid pattern, complete + merged) and item #6 (#3801 Axe-2 SOTA census — triaged SOTA-OK, see dashboard). Honest G.9 deferral: the Axe-2 top candidate (`04-5-LiveCoding`) was SOTA-OK firsthand (real OpenAI HTTP 200 OK in canonical source; the flagged "fabrication" was in a non-committed `_output.ipynb` papermill artifact), so no manufactured repair PR. This leaf-README post-reorg-coherence fix is the concrete, bounded, verifiable deliverable of the cycle.

See #3801 (Epic Axe-2 SOTA registry — census documented)
