### PR TITLE
docs(social_choice_lean): 2 concept Mermaid diagrams (4 results map + Arrow 4-step) + fix orphan fence

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
@@ -17,6 +17,24 @@ MechanismDesign, SortedListCounting) sont **FORMAL-CERTIFIED** (0 sorry). Voir
 
 ## Théorèmes formalisés
 
+*Les quatre résultats fondateurs formalisés (0 sorry, 7 modules) — de l'impossibilité de
+Arrow et du paradoxe de Sen jusqu'au théorème de l'électeur médian et à la véridicité de
+l'enchère de Vickrey :*
+
+```mermaid
+flowchart TD
+    FW["Framework  <i>Basic · Framework</i><br/>PrefOrder réflexif-total-transitif<br/>Profile · SWF · weak_pareto · ind_of_irr_alts · is_dictatorship"]
+    ARROW["Arrow — impossibilité<br/>faible-Pareto + IIA ⟹ dictature<br/><i>Geanakoplos 2005, profils maketop/makebot</i>"]
+    SEN["Sen — paradoxe libéral<br/>Pareto + libéralisme minimal ⟹ contradiction<br/><i>décisivité bidirectionnelle</i>"]
+    VOTE["Vote<br/>Condorcet unique · électeur médian · Split Cycle · Banks"]
+    VICK["Mécanismes — Vickrey<br/>second prix véridique · premier prix non-véridique"]
+
+    FW --> ARROW
+    FW --> SEN
+    FW --> VOTE
+    FW -.->|"théorie des incitations"| VICK
+```
+
 ### 0. DominikPeters/SocialChoiceLean (référence externe)
 
 Un dépôt de référence majeur pour la formalisation du choix social en Lean 4 :
@@ -43,8 +61,6 @@ Résultats formalisés par Peters :
 | Règle de vote | `SCC ι σ` (types fixés) | `VotingRule` (polymorphe sur V, A) |
 | Toolchain | `v4.30.0-rc2` | `v4.27.0-rc1` (pin commit `d679d950`) |
 
-```
-
 ### 1. Théorème d'Impossibilité d'Arrow (Arrow's Impossibility Theorem)
 
 **Dans `SocialChoice/Arrow.lean`** :
@@ -60,6 +76,20 @@ Résultats formalisés par Peters :
   2. **Existence du pivot** : Chaque alternative a un individu pivot
   3. **Troisième étape** : Les pivots deviennent des dictateurs sur les paires non-b
   4. **Quatrième étape** : La dictature partielle s'étend à une dictature complète
+
+*La preuve en quatre étapes de Geanakoplos (2005), des profils manipulés `maketop`/`makebot`
+jusqu'à la dictature complète — chaque étape décharge la suivante :*
+
+```mermaid
+flowchart TD
+    EXT["extremal_lemma<br/>tous placent b en haut/bas ⟹ société aussi<br/><i>via maketop_rel / makebot_rel</i>"]
+    PIV["pivot_exists<br/>chaque alternative b a un individu pivot<br/><i>transition collective→individuelle</i>"]
+    PDEX["pivot_is_dictator_except_b<br/>le pivot de b est dictateur sur les paires ≠ b<br/><i>par IIA + extremal_lemma</i>"]
+    FULL["partial_dictator_is_full_dictator<br/>dictateur partiel ⟹ dictateur complet<br/><i>2 pivots coïncident sur b</i>"]
+    ARROW["arrow · no_perfect_swf<br/>SWF (Pareto+IIA, ≥3 alt.) = dictature  <b>✓</b>"]
+
+    EXT --> PIV --> PDEX --> FULL --> ARROW
+```
 
 ### 2. Paradoxe de la Libéralité de Sen (Sen's Liberal Paradox)
 


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the `social_choice_lean` README, turning the four foundational social-choice results and the Arrow impossibility proof structure from prose-only into visual. `social_choice_lean` is a Lean lake of the GameTheory series (scope **#3978**): it formalizes Arrow's impossibility theorem, Sen's liberal paradox, voting theory (Condorcet/median voter/Split Cycle/Banks) and Vickrey truthfulness, 0 sorry across 7 modules (76 theorems). Its README was rigorous but had zero diagrams; it is one of several Lean lakes outside the #4038 set still without a concept diagram after the #4212 finition sweep. This also fixes a pre-existing orphan ``` fence in the same file (see below).

## Diagram 1 — Four foundational results

Placed at the top of the "Théorèmes formalisés" section. A map of the four formalized results branching from the Framework (`PrefOrder`, `Profile`, `SWF`, `weak_pareto`, `ind_of_irr_alts`, `is_dictatorship`): **Arrow** (Pareto+IIA ⟹ dictatorship), **Sen** (Pareto + minimal liberalism ⟹ contradiction), **Voting** (unique Condorcet, median voter, Split Cycle, Banks), **Mechanism design** (Vickrey truthful, first-price not).

## Diagram 2 — Arrow 4-step Geanakoplos proof

Placed after the Arrow theorem structure. Shows the proof skeleton from Geanakoplos (2005): `extremal_lemma` (all place b top/bottom ⟹ society too, via `maketop_rel`/`makebot_rel`) → `pivot_exists` (each alternative has a pivot individual) → `pivot_is_dictator_except_b` (pivot is dictator on pairs ≠ b, via IIA + extremal_lemma) → `partial_dictator_is_full_dictator` (two pivots coincide on b) → `arrow` / `no_perfect_swf` (SWF with Pareto+IIA and ≥3 alternatives is a dictatorship).

## Pre-existing orphan fence fix (same file, rendering correctness)

The baseline README had a **stray orphan ```` ``` ````** (right after the Peters "Différences de framework" table, with no matching opener), giving an **odd fence count of 5**. Left in place, it would have swallowed the second mermaid block's opening fence and broken its rendering on GitHub. Removing it yields an even fence count (8) with **no content loss** (the -2 deletions are the orphan fence line + its trailing blank line). This is a 1-line typo fix on a docs file, not proof/code — no anti-regression concern.

## G.1 firsthand (not propagation)

All symbols cited verified present in the Lean source firsthand on `origin/main`:
- `Profile` (Framework.lean L23), `SWF` (L26), `weak_pareto` (L31), `ind_of_irr_alts` (L36), `is_dictatorship` (L46)
- `extremal_lemma` (Arrow.lean L199), `pivot_exists` (L279), `pivot_is_dictator_except_b` (L408), `partial_dictator_is_full_dictator` (L592), `arrow` (L679), `no_perfect_swf` (L697)
- `maketop_rel` / `makebot_rel` (Framework.lean)
- `sen_impossibility` (Sen.lean L66), `book_paradox_demonstrates_sen` (L293)
- `condorcet_winner_unique` (Voting.lean L113), `median_voter_theorem` (L452), `split_cycle_condorcet` (L532), `banks_set_condorcet` (L690)
- `vickrey_truthful_bidder0` (MechanismDesign.lean L35)

## Hygiene

- **+32 / −2** (the −2 is the orphan fence + blank line, no content loss), docs-only (**0 .lean** touched).
- FR-first (README is French; diagrams in French).
- Fences balanced: 8 markers = 4 pairs (2 new mermaid + 1 pre-existing ```text + 1 pre-existing ```bash).
- Catalog-STATUS byte-identical to main (catalog-pr-hygiene rule 1).
- Base fresh (0 behind / 0 ahead at branch creation).

Lineage: ai-01 deep-queue NUIT po-2026 (continuation of the Mermaid-coverage margin found c.112). #3978 driver ("décrire l'état formel réel").

See #3978

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
