### PR TITLE
docs(conway_cgt_lean): 2 concept Mermaid diagrams (type hierarchy + Mathlib CGT removal migration)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/README.md
@@ -29,9 +29,36 @@ dépréciés dans la PR Mathlib [#28063](https://github.com/leanprover-community
 code CGT de Mathlib. Cette visite oriente les apprenants vers le lieu où vit
 désormais la TJC.
 
+*La migration qui motive ce dépôt — des modules CGT de Mathlib vers le dépôt amont :*
+
+```mermaid
+flowchart LR
+    M["<b>Mathlib (retiré)</b><br/><i>SetTheory.Surreal / PGame /<br/>Game / Nimber</i><br/>8 modules"]
+    D["<b>#28063</b><br/>dépréciation<br/>(août 2025)"]
+    R["<b>#35550</b><br/>retrait<br/>(février 2026)"]
+    U["<b>vihdzp/combinatorial-games</b><br/><i>nouveau foyer de la TJC</i><br/>même autrice · Apache-2.0<br/>15+ modules"]
+    T["<b>conway_cgt_lean</b><br/><i>visite #check · 0 sorry</i><br/>dépendance Lake<br/>(non vendorisée)"]
+    M --> D --> R -.->|"remplacé par"| U -->|"expose via #check"| T
+```
+
 ## Ce que la visite couvre
 
 Le fichier importe les modules amont et exhibe leurs résultats clés :
+
+*La hiérarchie de types de la visite — du pré-jeu concret `IGame` aux deux destinations `Surreal` (jeux numériques) et `Nimber` (jeux impartiaux) :*
+
+```mermaid
+flowchart TD
+    IG["<b>IGame</b><br/><i>pré-jeu concret</i><br/>left / right : Set IGame"]
+    G["<b>Game</b><br/><i>quotient par ≈</i><br/>Antisymmetrization IGame (· ≤ ·)<br/>AddCommGroupWithOne · PartialOrder"]
+    S["<b>Surreal</b><br/><i>jeux numériques quotientés</i><br/>LinearOrder · CommRing<br/>= corps ordonné complet"]
+    N["<b>Nimber</b><br/><i>ordinaux, arithmétique de nim</i><br/>add_def (mex) · Field caractéristique 2"]
+    IG -->|"Game.mk"| G
+    G -->|"Surreal.mk (Numeric)"| S
+    G -.->|"jeux impartiaux<br/>Sprague-Grundy"| N
+    S --- SIM["<b>théorème de simplicité</b><br/><i>equiv_of_forall_not_fits</i><br/>outil de calcul des valeurs"]
+    S -.->|"Dyadic.toIGame<br/>NatOrdinal.toSurreal"| EMB["plongements<br/>dyadique + ordinal"]
+```
 
 ### 1. Jeux combinatoires
 - **`IGame`** (pré-jeux) : représentation concrète par ensembles d'options


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the `conway_cgt_lean` README, turning the type-construction hierarchy and the "why this repo exists" (Mathlib CGT removal → upstream) narrative from prose-only into visual. `conway_cgt_lean` is a Lean lake of the GameTheory series (scope **#3978**): it is a `#check`-based **tour** (0 sorry, 169-line `CGTTour.lean`) of [`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games), imported as a Lake dependency. It is **genuinely distinct** from `conway_lean` (Game of Life / Hashlife): it covers **combinatorial game theory** — surreal numbers, nimbers, the Sprague-Grundy theorem — the math that now lives upstream after Mathlib removed its CGT modules in Feb 2026. Its README was rigorous (full migration narrative, type hierarchy, Mathlib-vs-upstream comparison table) but had zero diagrams. It is one of the last Lean lakes (after the #4212 finition sweep for the #4038 set) still without a concept diagram.

## Diagram 1 — Type construction hierarchy

Placed at the top of the "Ce que la visite couvre" section. Maps the construction pipeline: **`IGame`** (concrete pre-game, `left`/`right : Set IGame`) → **`Game`** (quotient by ≈, `Antisymmetrization IGame (· ≤ ·)`, `AddCommGroupWithOne` + `PartialOrder`) → branches to **`Surreal`** (Numeric quotient, `LinearOrder` + `CommRing` = complete ordered field) and **`Nimber`** (impartial games via Sprague-Grundy, `add_def` mex, `Field` characteristic 2). Side nodes: the **simplicity theorem** (`IGame.Fits.equiv_of_forall_not_fits`, key computation tool) and the **dyadic/ordinal embeddings** (`Dyadic.toIGame`, `NatOrdinal.toSurreal`).

## Diagram 2 — Mathlib CGT removal migration

Placed in the "Pourquoi ce dépôt existe" section. Shows the migration timeline: **Mathlib CGT modules** (`SetTheory.Surreal`/`PGame`/`Game`/`Nimber`, 8 modules) → deprecation **#28063** (Aug 2025) → removal **#35550** (Feb 2026) → **`vihdzp/combinatorial-games`** (same author Violeta Hernandez Palacios, Apache-2.0, 15+ modules, new CGT home) → **this repo** (visit via `#check`, 0 sorry, Lake dependency **not vendored**).

## G.1 firsthand (not propagation)

Every type, instance and theorem cited in the diagrams is `#check`'d in the actual source `CGTTour.lean` with exact line numbers on `origin/main`:
- `Game` := `Antisymmetrization IGame (· ≤ ·)` (L66), `@Game.mk` / `AddCommGroupWithOne Game` / `PartialOrder Game` (L71-73)
- `@Surreal.mk` (L94), `LinearOrder Surreal` (L95), `@IGame.Fits.equiv_of_forall_not_fits` (L96), `CommRing Surreal` (L105)
- `@Dyadic.toIGame` (L113), `@NatOrdinal.toSurreal` (L119)
- `@Nimber.add_def` (L140), `Field Nimber` (L150)

External links verified reachable: PR [#28063](https://github.com/leanprover-community/mathlib4/pull/28063), PR [#35550](https://github.com/leanprover-community/mathlib4/pull/35550), [`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games) — all HTTP 200. Diagram labels are plain-text (**0 new markdown links**).

## Hygiene

- Pure insertion **+27 / 0 deletions**, docs-only (**0 .lean** touched) — no anti-regression concern.
- FR-first (README is French; diagrams in French).
- Fence balance: baseline **2** (1 pre-existing bash block) + 4 (2 new mermaid) = **6 even** — baseline was already even, no orphan-fence issue (unlike social_choice c.113).
- Catalog-STATUS byte-identical to main (catalog-pr-hygiene rule 1).
- Base fresh (0 behind / 0 ahead at branch creation).

Lineage: ai-01 deep-queue NUIT po-2026, continuation of the Mermaid-coverage margin (Lean lakes with substantive READMEs but 0 diagrams). #3978 driver ("décrire l'état formel réel"). Lakes Lean 0-Mermaid remaining in my lane after this: `grothendieck_lean`, `erc20_lean`.

See #3978

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
