### PR TITLE
docs(notebooks): #3966 hierarchy — demote hint-as-heading asides to bold inline (C# sub-lot)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -163,7 +163,7 @@
     "| **Nashpy** | Jeux matriciels 2 joueurs | Notebooks 1-6 : Nash pur/mixte |\n",
     "| **OpenSpiel** | Framework DeepMind | Notebooks 7-15 : CFR, MCTS, jeux extensifs |\n",
     "\n",
-    "### Note sur OpenSpiel\n",
+    "**Note sur OpenSpiel :**\n",
     "\n",
     "OpenSpiel est le framework de DeepMind pour la recherche en theorie des jeux. Il necessite une compilation C++ et **n'a pas de wheels pre-compiles pour Windows**.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-14-IslandSynergyFound.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-14-IslandSynergyFound.ipynb
@@ -241,7 +241,7 @@
     "tags": []
    },
    "source": [
-    "## Rappel — le verdict négatif de MGS-11\n",
+    "**Rappel — le verdict négatif de MGS-11 :**\n",
     "\n",
     "MGS-11 comparait trois archipels *à migration par défaut* (`SmallMigrationRate` ≈ 0.045, période 10 générations) :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -59,7 +59,7 @@
     "- **Bryant, R. E.** - \"Graph-Based Algorithms for Boolean Function Manipulation\" (1986)\n",
     "- **Somenzi, F.** - \"Binary Decision Diagrams\" (1999)\n",
     "\n",
-    "## Note sur l'approche\n",
+    "**Note sur l'approche :**\n",
     "\n",
     "> **⚠️ Important** : Ce notebook implemente une approche \"pure\" automata avec BDD/MDD, sans utiliser Z3. Cette approche est moins performante que Z3 mais illustre la theorie des automates symboliques de manière plus authentique."
    ]


### PR DESCRIPTION
Part of #3966, issue #3968 (mise-en-forme / hierarchie typographique, 261 notebooks). Sub-lot **po-2024:CoursIA-2 active-edit partition** (MGS = ma lane explicite ; Sudoku-14-BDD-Csharp + GameTheory-1-Setup = notebooks que j'edite activement, cycles 68/69, lots #3968 .NET stalled chez po-2025).

## Changements (typo-level only)

Demote les asides `hint-as-heading` en **gras inline**, per #3994 demonstrator (`# Objectif` -> `**Objectif :**`) :

| Notebook | Avant | Apres | Type |
|----------|-------|-------|------|
| MGS-14-IslandSynergyFound | `## Rappel — le verdict negatif de MGS-11` | `**Rappel — ... :**` | recap aside |
| Sudoku-14-BDD-Csharp | `## Note sur l'approche` | `**Note sur l'approche :**` | note aside |
| GameTheory-1-Setup | `### Note sur OpenSpiel` | `**Note sur OpenSpiel :**` | note aside |

**TYPO-LEVEL ONLY** : aucun changement de texte/contenu/labeling (anti-regression + exercise-example-labeling). Uniquement le niveau de heading. Surgical raw-text replace du token quoted-string (zero json round-trip churn).

## Validation

- `scan_md_hierarchy.py` : **0/1 residual** sur MGS-14 + Sudoku-14-BDD-Csharp (HINT resolu). **MGS family fully clean (0/14)**.
- **GameTheory-1-Setup** : residual `[H1-DEEP]` = **SCANNER FALSE POSITIVE** — le notebook a exactement UN H1 (`# GameTheory-1-Setup` en cell 1 = le titre legitime) ; cell 0 est un blockquote nav, donc l'heuristique flag le titre legitime comme "deep". Pas un 2e H1 competiteur. Laisse intact (G.9 : ne pas "corriger" un non-issue ; le demote detruirait le vrai titre).
- **C.2** : markdown-only (seules des cellules markdown, pas de cellule code touchee — verifie `git diff | grep source/outputs/execution_count` = 0). Pas de re-exec.
- **CATALOG byte-identical** (`grep -c CATALOG-STATUS` = 0).
- 3 fichiers, +3/-3. Base fraiche origin/main `e04fd12b0`.

See #3968