### PR TITLE
docs(grothendieck_lean): 2 concept Mermaid diagrams (23-module trajectory + sheaf vertical construction)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -23,6 +23,20 @@ La formalisation couvre **23 modules (Parties 1-23, 3182 lignes, 0 sorry)**,
 importés dans l'ordre par le parapluie `Grothendieck.lean`. Chaque module se
 numérote lui-même via son en-tête (`Grothendieck tribute — Part N`).
 
+*La trajectoire pédagogique des 23 modules — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski et carte Mathlib en ancrage :*
+
+```mermaid
+flowchart LR
+    T1["<b>Sites & cribles</b><br/><i>Parties 1·6·8·11·12·16</i><br/>topologies de Grothendieck<br/>pullback_id · pullback_monotone"]
+    T2["<b>Faisceaux & séparation</b><br/><i>7·9·10·17</i><br/>préfaisceau séparé<br/>transfert le long de J₁ ≤ J₂"]
+    T3["<b>Faisceautisation</b><br/><i>13·14</i><br/>foncteur faisceau associé<br/>exactitude à gauche (LeftExact)"]
+    T4["<b>Points & conservateurs</b><br/><i>15·19</i><br/>foncteurs fibres<br/>familles conservatrices"]
+    T5["<b>Cohomologie</b><br/><i>20·21·22·23</i><br/>Ext · Mayer-Vietoris · Čech"]
+    T1 --> T2 --> T3 --> T4 --> T5
+    S["<b>Schémas & site de Zariski</b><br/><i>Parties 2·3</i><br/>foncteur Spec<br/>zariski_topology_eq"] -.->|"ancre géométrique"| T1
+    MM["<b>Carte Mathlib</b><br/><i>Partie 4</i><br/>index #check"] -.->|"ancre bibliothèque"| T3
+```
+
 | Partie | Fichier | Contenu | Lignes |
 |--------|---------|---------|--------|
 | 1 | `Grothendieck/CategoryAndSites.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 106 |
@@ -106,6 +120,22 @@ Les modules tracent un chemin cohérent : **sites et cribles** (Parties 1, 6, 8,
 conservatrices** (15, 19) → **cohomologie des faisceaux, Mayer-Vietoris et Čech**
 (20-23), avec **schémas et site de Zariski** (2, 3) et une **carte Mathlib** (4)
 ancrant la visite à la bibliothèque qu'elle indexe.
+
+*La construction verticale « faisceau » — chaque couche bâtie sur la précédente, de la donnée du site jusqu'à la cohomologie :*
+
+```mermaid
+flowchart TD
+    SITE["<b>Site</b><br/><i>catégorie + topologie de Grothendieck</i><br/>(Partie 1)"]
+    PSH["<b>Préfaisceau</b><br/><i>objets Cᵒᵖ → Type*</i>"]
+    SEP["<b>Préfaisceau séparé</b><br/>unicité du recollement"]
+    SH["<b>Faisceau</b><br/>existence + unicité du recollement"]
+    SHIF["<b>Faisceautisation</b><br/><i>foncteur faisceau associé</i><br/>Partie 13 — exactitude à gauche (Partie 14)"]
+    COH["<b>Cohomologie des faisceaux</b><br/>Parties 20-23<br/>Ext · Mayer-Vietoris · Čech"]
+    SITE --> PSH --> SEP --> SH
+    SHIF -.->|"produit un faisceau<br/>depuis un préfaisceau"| SH
+    SH --> COH
+    TR["<b>Transfert de faisceau</b><br/>le long de J₁ ≤ J₂<br/>(Partie 7)"] -.-> SH
+```
 
 ### Le périmètre, honnêtement
 


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the `grothendieck_lean` README, turning the 23-module pedagogical trajectory and the vertical sheaf-theory construction from prose-only into visual. `grothendieck_lean` is a Lean lake of the SymbolicAI/Lean series (scope **#3978**): a pedagogical **"hommage"** — 23 modules, 3182 lines, **0 sorry, 0 added axiom** (confirmed firsthand across all 23 `.lean` files) — indexing how Grothendieck's mathematical language (sites, sieves, sheaves, sheafification, points, cohomology) already lives in Mathlib 4. Its README was rigorous (full 23-module table, honest scope section, Mac Lane–Moerdijk / SGA 4 / Stacks references) but had zero diagrams. One of the last two Lean lakes (after the #4212 finition sweep for the #4038 set, and conway_cgt_lean #4347 in-flight) still without a concept diagram.

## Diagram 1 — 23-module pedagogical trajectory

Placed at the top of the "## Structure" section, before the module table. A left-to-right map of the 5-theme progression (drawn from the Conclusion's "La trajectoire" prose): **Sites & cribles** (1·6·8·11·12·16) → **Faisceaux & séparation** (7·9·10·17) → **Faisceautisation** left-exact (13·14) → **Points & conservateurs** (15·19) → **Cohomologie** (20-23), with **Schémas & site de Zariski** (2·3) anchoring geometrically and the **carte Mathlib** (4) anchoring to the library.

## Diagram 2 — Sheaf vertical construction

Placed after the trajectory prose in the Conclusion. The foundational stack: **Site** (catégorie + topologie de Grothendieck) → **Préfaisceau** → **Préfaisceau séparé** (unicité du recollement) → **Faisceau** (existence + unicité), with **faisceautisation** (Part 13, exactitude à gauche Part 14) producing a sheaf from a presheaf, **transfert de faisceau** (Part 7, along J₁ ≤ J₂), and **cohomologie des faisceaux** (Parts 20-23) built on top.

## G.1 firsthand (not propagation)

All symbols cited verified in the actual Lean source on `origin/main`:
- **`zariski_topology_eq`** (ZariskiSite.lean **L50**) — the concrete-pretopology = abstract-GrothendieckTopology bridge theorem. **Note**: the README table mistyped this camelCase (`zariskiTopology_eq`); the real decl is snake_case, cited correctly in the diagram.
- **`pullback_id` / `pullback_pullback` / `pullback_bot` / `pullback_monotone`** (SieveLattice.lean, Part 6 sieve pullback identities) — all confirmed.
- **`Scheme.Spec`** functor (SchemesTour.lean **L44**, `CommRingCatᵒᵖ ⥤ Scheme`).
- The unverified name **`homeoOfIso`** (README table Part 2, not found as a decl) is **NOT cited** — G.1 discipline (no propagation of unverified claims).

Diagrams use plain-text labels (**0 new markdown links**, **0 new external URLs** — nothing new to check-links-verify).

## Hygiene

- Pure insertion **+30 / 0 deletions**, docs-only (**0 .lean** touched) — no anti-regression concern.
- FR-first (README is French; diagrams in French).
- Fence balance: baseline **2** (1 pre-existing bash block) + 4 (2 new mermaid) = **6 even** — baseline already even, no orphan-fence issue (unlike social_choice c.113).
- Catalog-STATUS byte-identical to main (catalog-pr-hygiene rule 1).
- Base fresh (0 behind / 0 ahead at branch creation).

Lineage: ai-01 deep-queue NUIT po-2026, Mermaid-coverage long-tail continuation (#3978 driver "décrire l'état formel réel"). Lakes Lean 0-Mermaid remaining in my lane after this: `erc20_lean` (1) — then the greenlighted companion-notebook track (`astar_lean`, [ACK ai-01 sweep 02:11Z]).

See #3978

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
