### PR TITLE
docs(erc20_lean): 2 concept Mermaid diagrams (state machine + transfer preservation proof mechanism)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/README.md
@@ -32,6 +32,23 @@ série SmartContract.
 
 ## Approche : machine à états finie
 
+*La machine à états — l'état porte l'invariant `supplyInvariant`, et trois transitions gardées le préservent ; toute trace atteignable l'hérite par induction :*
+
+```mermaid
+flowchart TD
+    S["<b>State n</b><br/><i>balances : Address n → ℕ</i><br/>totalSupply : ℕ"]
+    INV["<b>supplyInvariant s</b><br/>∑ a, balances a = totalSupply"]
+    S --- INV
+    MINT["<b>mint</b><br/>crédite dst + amount<br/>offre + amount<br/>⟹ invariant préservé"]
+    BURN["<b>burn</b> <i>(garde solde ≥ amount)</i><br/>débite src − amount<br/>offre − amount<br/>⟹ invariant préservé"]
+    TR["<b>transfer</b> <i>(garde solde ≥ amount, src ≠ dst)</i><br/>− amount à src, + amount à dst<br/>offre inchangée<br/>⟹ invariant préservé"]
+    S --> MINT & BURN & TR
+    OP["<b>Op n s s'</b><br/><i>inductif</i> : une des 3 transitions"]
+    REACH["<b>Reachable n s s'</b><br/><i>inductif</i> : fermeture réflexive-transitive"]
+    MINT & BURN & TR --> OP --> REACH
+    REACH -.->|"reachable_preserves_invariant<br/>(induction sur la trace)"| INV
+```
+
 Plutôt que de modéliser un langage de contrat complet (gaz, stockage Merkle,
 reentrancy), on isole le **cœur mathématique** de la conservation : une machine à
 états finie dont l'invariant est `Σ balances = totalSupply`, et trois transitions
@@ -58,6 +75,18 @@ gardées.
 L'ingrédient technique clé est l'**extraction additive** d'un point d'une somme
 finie (`∑ a ∈ s, f a = f a₀ + ∑ a ∈ s \ {a₀}, f a`), qui évite de distribuer la
 soustraction tronquée de `ℕ` sur la somme.
+
+*Mécanisme de `transfer_preserves_supply` (0 `sorry`) — extraire `src` puis `dst` de la somme des nouveaux soldes, le delta net s'annule :*
+
+```mermaid
+flowchart LR
+    SPLIT["<b>sum_univ_split</b><br/>∑ a, balances a =<br/>f a₀ + ∑ a ≠ a₀, f a<br/><i>(extraction additive)</i>"]
+    NEW["<b>nouveaux soldes</b><br/>src : − amount<br/>dst : + amount"]
+    DELTA["<b>delta net = 0</b><br/>(− amount) + (+ amount)"]
+    CONC["<b>somme inchangée</b><br/>= totalSupply inchangé<br/>(transfer ne touche pas l'offre)"]
+    SPLIT --> NEW --> DELTA --> CONC
+    CONC -.->|"transfer_preserves_supply"| OK["<b>invariant préservé</b>"]
+```
 
 ## Modules
 


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the `erc20_lean` README, turning the finite-state-machine model (with its conservation invariant) and the `transfer_preserves_supply` proof mechanism from prose-only into visual. `erc20_lean` is the **first Lean lake of the SmartContract series** (scope **#3978** / issue [#4047](https://github.com/jsboige/CoursIA/issues/4047) / roadmap [#4038](https://github.com/jsboige/CoursIA/issues/4038)): it formalizes the **founding conservation invariant of an ERC-20 fungible token** (`Σ balances = totalSupply`), proving it is preserved by every standard operation (`transfer`/`mint`/`burn`) — **0 sorry** across all 4 source files, confirmed firsthand. Its README was rigorous (full model table, 5 theorems, honest phases/roadmap with unchecked allowances/gas phases) but had zero diagrams. This is the **last Lean lake in my lane without a concept diagram** — completing the Mermaid-coverage long tail; the next track is the greenlighted companion-notebook work (`astar_lean`, [ACK ai-01 sweep 02:11Z]).

## Diagram 1 — Finite-state machine + invariant

Placed at the top of the "## Approche : machine à états finie" section. `State n` (`balances : Address n → ℕ`, `totalSupply`) carries `supplyInvariant s := ∑ a, balances a = totalSupply`. Three guarded transitions — `mint` (crédite + amount, offre + amount), `burn` (garde solde ≥ amount, débite − amount, offre − amount), `transfer` (garde solde ≥ amount, src ≠ dst, déplacement neutre) — each preserve the invariant. The inductive `Op n s s'` (one of the 3 transitions) lifts to `Reachable n s s'` (reflexive-transitive closure), and `reachable_preserves_invariant` inherits the invariant over any trace by induction.

## Diagram 2 — `transfer_preserves_supply` proof mechanism

Placed after the additive-extraction paragraph in the Modèle section. The key ingredient **`sum_univ_split`** (extract a point from a finite sum) lets us separate `src` and `dst` in the new-balances sum; the **net delta** `(−amount at src) + (+amount at dst) = 0`, so the sum is unchanged, equal to the untouched `totalSupply` — hence `transfer_preserves_supply` (0 `sorry`).

## G.1 firsthand (not propagation)

All symbols cited verified in the actual Lean source on `origin/main` with exact line numbers:
- `State` (State.lean **L23**), `supplyInvariant` (**L33**)
- `mint` / `burn` / `transfer` (Ops.lean **L24 / L30 / L38**)
- `sum_univ_split` (Invariant.lean **L36** — the additive-extraction key ingredient), `transfer_preserves_supply` (**L93**)
- `Op` (**L141** inductive), `op_preserves_invariant` (**L152**), `Reachable` (**L162** inductive), `reachable_preserves_invariant` (**L169**)

Diagrams use plain-text labels (**0 new markdown links**, **0 new external URLs** — nothing new to check-links-verify).

## Hygiene

- Pure insertion **+29 / 0 deletions**, docs-only (**0 .lean** touched) — no anti-regression concern.
- FR-first (README is French; diagrams in French).
- Fence balance: baseline **4** (1 pre-existing `lean` block + 1 pre-existing `bash` block) + 4 (2 new mermaid) = **8 even** — baseline already even, no orphan-fence issue.
- Catalog-STATUS byte-identical to main (catalog-pr-hygiene rule 1).
- Base fresh (0 behind / 0 ahead at branch creation).

Lineage: ai-01 deep-queue NUIT po-2026, Mermaid-coverage long-tail continuation — **completes the long tail** (last lake in my lane). #3978 driver ("décrire l'état formel réel"). Next track: greenlighted companion-notebook `astar_lean` (proven theorem ↔ executable Lean-kernel demo, multi-cycle).

See #3978 · See #4047 (erc20_lean issue)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
