### PR TITLE
docs(genai): restore French diacritics in QUICKSTART (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/QUICKSTART.md
+++ b/MyIA.AI.Notebooks/GenAI/QUICKSTART.md
@@ -1,22 +1,22 @@
-# GenAI - Guide de Demarrage Rapide
+# GenAI - Guide de Démarrage Rapide
 
-## Configuration en 2 minutes (Mode Remote - Etudiants)
+## Configuration en 2 minutes (Mode Remote - Étudiants)
 
-> **Note** : Ce guide est pour le **mode REMOTE** - vous utilisez les services heberges par l'enseignant via myia.io. Pas besoin de GPU local.
+> **Note** : Ce guide est pour le **mode REMOTE** - vous utilisez les services hébergés par l'enseignant via myia.io. Pas besoin de GPU local.
 
-### Etape 1 : Copier la configuration
+### Étape 1 : Copier la configuration
 
 ```bash
 cd MyIA.AI.Notebooks/GenAI
 cp .env.example .env
 ```
 
-### Etape 2 : Configurer les tokens
+### Étape 2 : Configurer les tokens
 
 Ouvrez le fichier `.env` et configurez :
 
 ```bash
-# Mode Remote (par defaut) - NE PAS MODIFIER
+# Mode Remote (par défaut) - NE PAS MODIFIER
 LOCAL_MODE=false
 
 # Token ComfyUI (fourni par l'enseignant) - format bcrypt $2b$12$...
@@ -24,28 +24,28 @@ COMFYUI_API_TOKEN=<token_fourni>
 COMFYUI_AUTH_TOKEN=<token_fourni>
 QWEN_API_TOKEN=<token_fourni>
 
-# OpenRouter (gratuit - creer compte sur https://openrouter.ai)
+# OpenRouter (gratuit - créer compte sur https://openrouter.ai)
 OPENROUTER_API_KEY=<votre_cle_openrouter>
-# OU utiliser la cle cours si fournie
+# OU utiliser la clé cours si fournie
 OPENAI_API_KEY=<cle_cours_ou_openrouter>
 OPENAI_BASE_URL=https://openrouter.ai/api/v1
 ```
 
-### Etape 3 : Tester la connexion aux services
+### Étape 3 : Tester la connexion aux services
 
 ```bash
 # Test rapide des services myia.io (curl)
 curl -s -w "\n%{http_code}" "https://qwen-image-edit.myia.io/" | tail -1
 curl -s -w "\n%{http_code}" "https://turbo.stable-diffusion-webui-forge.myia.io/sdapi/v1/options" | tail -1
 curl -s -w "\n%{http_code}" "https://z-image.myia.io/health" | tail -1
-# Reponse attendue : 200 (ou 401 pour ComfyUI si token requis)
+# Réponse attendue : 200 (ou 401 pour ComfyUI si token requis)
 ```
 
-**Note** : Les scripts `scripts/genai-stack/validate_*.py` sont concus pour le mode LOCAL uniquement.
+**Note** : Les scripts `scripts/genai-stack/validate_*.py` sont conçus pour le mode LOCAL uniquement.
 
 ---
 
-## Services Disponibles (Fevrier 2026)
+## Services Disponibles (Février 2026)
 
 | Service | URL | Status | Notebooks |
 | ------- | --- | ------ | --------- |
@@ -74,9 +74,9 @@ curl -s -w "%{http_code}" "https://z-image.myia.io/health"
 
 ### OpenRouter (LLMs - gratuit)
 
-- `01-1-OpenAI-DALL-E-3.ipynb` - Generation d'images via API
+- `01-1-OpenAI-DALL-E-3.ipynb` - Génération d'images via API
 - `01-2-GPT-5-Image-Generation.ipynb` - Vision multimodale
-- `01-3-Basic-Image-Operations.ipynb` - Operations de base
+- `01-3-Basic-Image-Operations.ipynb` - Opérations de base
 
 **Config requise :**
 
@@ -88,8 +88,8 @@ OPENAI_CHAT_MODEL_ID=meta-llama/llama-3.2-3b-instruct:free
 
 ### SD Forge Turbo (SDXL)
 
-- `01-4-Forge-SD-XL-Turbo.ipynb` - Generation rapide SDXL
-- `02-3-Stable-Diffusion-3-5.ipynb` - SD avance
+- `01-4-Forge-SD-XL-Turbo.ipynb` - Génération rapide SDXL
+- `02-3-Stable-Diffusion-3-5.ipynb` - SD avancé
 
 **Config requise :**
 
@@ -97,10 +97,10 @@ OPENAI_CHAT_MODEL_ID=meta-llama/llama-3.2-3b-instruct:free
 FORGE_API_URL=https://turbo.stable-diffusion-webui-forge.myia.io
 ```
 
-### ComfyUI Qwen (Edition d'images)
+### ComfyUI Qwen (Édition d'images)
 
 - `01-5-Qwen-Image-Edit.ipynb` - Introduction Qwen
-- `02-1-Qwen-Image-Edit-2509.ipynb` - Edition avancee
+- `02-1-Qwen-Image-Edit-2509.ipynb` - Édition avancée
 
 **Config requise :**
 
@@ -111,7 +111,7 @@ COMFYUI_AUTH_TOKEN=<token_fourni>
 
 ### Z-Image Lumina (Text-to-Image)
 
-- `02-4-Z-Image-Lumina2.ipynb` - Generation haute qualite
+- `02-4-Z-Image-Lumina2.ipynb` - Génération haute qualité
 
 **Config requise :**
 
@@ -121,17 +121,17 @@ ZIMAGE_API_URL=https://z-image.myia.io
 
 ---
 
-## Depannage
+## Dépannage
 
 ### Erreur 401 Unauthorized (ComfyUI)
 
-- Verifiez que le token est correct dans `.env`
+- Vérifiez que le token est correct dans `.env`
 - Le token doit commencer par `$2b$12$...` (hash bcrypt)
 
 ### Erreur de connexion
 
-- Verifiez votre connexion internet
-- Les services myia.io sont accessibles depuis l'exterieur
+- Vérifiez votre connexion internet
+- Les services myia.io sont accessibles depuis l'extérieur
 
 ### Module not found
 
@@ -139,22 +139,22 @@ ZIMAGE_API_URL=https://z-image.myia.io
 pip install python-dotenv requests pillow openai
 ```
 
-### Variable d'environnement non trouvee
+### Variable d'environnement non trouvée
 
-- Verifiez que le fichier `.env` existe dans `MyIA.AI.Notebooks/GenAI/`
-- Relancez le kernel Jupyter apres modification du `.env`
+- Vérifiez que le fichier `.env` existe dans `MyIA.AI.Notebooks/GenAI/`
+- Relancez le kernel Jupyter après modification du `.env`
 
 ---
 
-## Mode Local (Deploiement Docker)
+## Mode Local (Déploiement Docker)
 
-Si vous souhaitez deployer les services sur votre propre machine (GPU requis) :
+Si vous souhaitez déployer les services sur votre propre machine (GPU requis) :
 
 1. Consultez le notebook `00-GenAI-Environment/00-6-Local-Docker-Deployment.ipynb`
 2. Configurez `LOCAL_MODE=true` dans `.env`
 3. Les URLs basculent automatiquement vers localhost
 
-**Prerequis mode local :**
+**Prérequis mode local :**
 
 - Docker Desktop avec support GPU NVIDIA
 - GPU avec 8-20GB+ VRAM selon le service
@@ -164,16 +164,16 @@ Si vous souhaitez deployer les services sur votre propre machine (GPU requis) :
 
 ## Pour aller plus loin
 
-- **Documentation complete** : [README.md](README.md)
-- **Deploiement local** : `00-GenAI-Environment/00-6-Local-Docker-Deployment.ipynb`
+- **Documentation complète** : [README.md](README.md)
+- **Déploiement local** : `00-GenAI-Environment/00-6-Local-Docker-Deployment.ipynb`
 - **Validation stack locale** : `python scripts/genai-stack/validate_stack.py`
 
 ---
 
 ## Contact
 
-En cas de probleme persistant, contacter l'enseignant avec :
+En cas de problème persistant, contacter l'enseignant avec :
 
 1. Le message d'erreur complet
 2. Le notebook concerne
-3. Le resultat des tests curl ci-dessus
+3. Le résultat des tests curl ci-dessus


### PR DESCRIPTION
## Scope

Restaure les diacritiques français manquants dans le guide d'onboarding `GenAI/QUICKSTART.md` (greenlight scoped ai-01 #2876, miroir du pattern #4345 Sudoku mergé). Le QUICKSTART était massivement non-accentué (~30 mots en drift : Demarrage, Etudiants, Etape×3, defaut, creer, cle×2, Fevrier, Generation×2, Operations, Edition×2, qualite, Depannage, Verifiez×2, exterieur, trouvee, Deploiement×2, deployer, Prerequis, complete, probleme, resultat, …).

## Preuve accent-only (rigoureuse)

`deaccent(old) == deaccent(new)` : **4694 == 4694 caracteres identiques** apres suppression des diacritiques combinants (unicodedata NFD + filtre Mn). **Zero changement semantique ou structurel** — chaque difference est un accent ajoute. Byte-diffable, trivialement reversible.

- Placeholders (`<token_fourni>`, `<cle_cours_ou_openrouter>`, `<VOTRE_TOKEN>`), URLs, noms de variables d'environnement et model IDs : **intacts**.
- 0 cellule notebook touchee -> exception C.2 (markdown-only).

## Contraintes respectees (greenlight ai-01)

- **Accent-only** (0 semantique, 0 restructure) — comme #4345. OK
- **Mermaid separe** (non bundled) — cette PR est accents uniquement. OK
- Catalogue byte-identique a main (0 fichier catalogue touche, HARD 1). OK
- Base fraiche origin/main (`065b87db3`, HARD 2). OK
- `See #2876` (livraison partielle epic repo-wide, HARD 4). OK

## Contexte

ai-01 a REVERSE son hold c.18 sur QUICKSTART (G.9 reversal sur evidence) : l'audit firsthand (drift uniforme + typo « modeaux ») refute l'hypothese « ASCII intentionnel » ; du francais non-accentue dans un doc d'onboarding FR = drift, pas une feature. Blast-radius faible (accent-only byte-reversible).

See #2876