### PR TITLE
docs(genai): restore French diacritics in Audio Foundation README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
@@ -2,9 +2,9 @@
 
 [← Documentation Audio](../README.md) | [↑ ..](../README.md) | [→ Audio Advanced](../02-Advanced/)
 
-Ce module couvre les fondamentaux du traitement audio par IA : reconnaissance vocale (STT), synthese vocale (TTS), et operations audio de base.
+Ce module couvre les fondamentaux du traitement audio par IA : reconnaissance vocale (STT), synthèse vocale (TTS), et opérations audio de base.
 
-**Dans le cadre du fil rouge podcast** : avant de produire un episode, il faut maitriser les deux briques essentielles -- faire parler la machine (TTS) et comprendre la parole humaine (STT). [01-1](01-1-OpenAI-TTS-Intro.ipynb) et [01-2](01-2-OpenAI-Whisper-STT.ipynb) couvrent les API cloud (rapides a mettre en oeuvre), tandis que [01-4](01-4-Whisper-Local.ipynb) et [01-5](01-5-Kokoro-TTS-Local.ipynb) passent en local GPU pour l'autonomie et le controle. [01-3](01-3-Basic-Audio-Operations.ipynb) donne les bases techniques (spectrogrammes, MFCC) utiles pour comprendre ce que manipulent les modeles.
+**Dans le cadre du fil rouge podcast** : avant de produire un épisode, il faut maîtriser les deux briques essentielles -- faire parler la machine (TTS) et comprendre la parole humaine (STT). [01-1](01-1-OpenAI-TTS-Intro.ipynb) et [01-2](01-2-OpenAI-Whisper-STT.ipynb) couvrent les API cloud (rapides à mettre en oeuvre), tandis que [01-4](01-4-Whisper-Local.ipynb) et [01-5](01-5-Kokoro-TTS-Local.ipynb) passent en local GPU pour l'autonomie et le contrôle. [01-3](01-3-Basic-Audio-Operations.ipynb) donne les bases techniques (spectrogrammes, MFCC) utiles pour comprendre ce que manipulent les modèles.
 
 ## Vue d'ensemble
 
@@ -12,7 +12,7 @@ Ce module couvre les fondamentaux du traitement audio par IA : reconnaissance vo
 |-------------|--------|
 | Notebooks | 5 |
 | Kernel | Python 3 |
-| Duree estimee | ~3-4h |
+| Durée estimée | ~3-4h |
 | GPU requis | 0-10GB |
 
 ## Notebooks


### PR DESCRIPTION
Restaure les accents sur la prose d'intro du README per-level **Audio 01-Foundation** (`synthèse`, `opérations`, `épisode`, `maîtriser`, `contrôle`, `modèles`, `Durée estimée`).

Miroir de **#4345** (Sudoku, mergée) et des #4351/#4353 : rétablissement purement diacritique, PR accent-only atomique.

## Preuve accent-only (byte-réversible)
- `deaccent(old) == deaccent(new)` → **2759 == 2759 chars identiques** (`unicodedata.normalize('NFD')` + filtre catégorie `Mn`)
- Lignes préservées : **59/59** (0 dérive structurelle)
- `diff --stat` : 1 fichier, 3 insertions, 3 deletions
- BOM byte-identical préservé (`232030` = no BOM, comme origin/main)
- Placeholders / URLs / env-vars / model-IDs intacts

## Scope respecté (greenlight ai-01 #2876)
- **Accent-only** (0 sémantique, 0 restructure) — trivialement auditable (byte-diff = diacritiques seulement)
- **Catalogue byte-identique** à main (0 fichier catalogue touché)
- Base fraîche `origin/main` `065b87db3`
- Markdown-only → exception C.2 (outputs n/a)

## Hors scope (documenté honnêtement, pas touché)
- Avertissements markdown-lint pré-existants (MD060 table-style, MD022/031 blanks-around, MD047 trailing-newline) : structurels, pas diacritiques → sujet séparé.
- Literal « oeuvre » (L7) : préservé tel quel (ligature `œ` hors accent-only).

See #2876 (partiel, epic repo-wide).