### PR TITLE
docs(qcpy-32): add inline DQN anchors (Double DQN, Dueling) 2e-passe (See #3164)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
@@ -712,7 +712,8 @@
     "- **Replay buffer** : 100K transitions, echantillonnage uniforme\n",
     "- **Target network** : Update soft (tau=0.005) vers le reseau online\n",
     "- **Epsilon-greedy** : Decay exponentiel de 1.0 a 0.05 sur 50K pas\n",
-    "- **Gradient clipping** : max_norm=10 pour stabilite"
+    "- **Gradient clipping** : max_norm=10 pour stabilite",
+    "\n> *Ancre savante -- van Hasselt, H., Guez, A. & Silver, D. (2016), « Deep Reinforcement Learning with Double Q-learning », AAAI Conference on Artificial Intelligence, arXiv:1509.06461. Origine du Double DQN (decouplage selection/evaluation de l'action pour reduire la surestimation des Q-values). Voir aussi References academiques.*\n"
    ]
   },
   {
@@ -865,7 +866,8 @@
     "sans avoir a calculer la valeur de chaque action pour chaque etat.\n",
     "\n",
     "- **Value stream** : Estime la valeur de l'etat (combien vaut cette situation de marche)\n",
-    "- **Advantage stream** : Estime l'avantage de chaque action relative a la moyenne"
+    "- **Advantage stream** : Estime l'avantage de chaque action relative a la moyenne",
+    "\n> *Ancre savante -- Wang, Z., Schaul, T., Hessel, M. et al. (2016), « Dueling Network Architectures for Deep Reinforcement Learning », ICML, arXiv:1511.06581. Origine de l'architecture Dueling (decomposition Q(s,a) = V(s) + A(s,a) separant valeur d'etat et avantage de l'action). Voir aussi References academiques.*\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

2nd-pass citation grain on **QC-Py-32-RL-DQN-Trading**. The 1st pass (#3784) added a rich "References academiques" section (cell 44, 6 canonical RL papers) but taught **Double DQN** (cell 16) and **Dueling DQN** (cell 20) in dedicated body cells WITHOUT an inline scholarly anchor at the point of teaching. Same 2e-passe pattern as QC-Py-22 #4157 / QC-Py-23 #4139 / QC-Py-23b #4197.

## Changes

Adds 2 inline footnotes (markdown-additive, list-direct append — preserves source-list structure per the cell-7-mash lesson #3735):

| Cell | Concept | Anchor |
|------|---------|--------|
| 16 `### Double DQN` | Double DQN (selection/evaluation decoupling) | van Hasselt, Guez & Silver (2016), AAAI, arXiv:1509.06461 |
| 20 `### Interpretation` (Dueling) | Dueling architecture Q(s,a)=V(s)+A(s,a) | Wang, Schaul, Hessel et al. (2016), ICML, arXiv:1511.06581 |

Both papers are **ALREADY in the References academiques section** (cell 44, textbook-grade, web-verified in QC-Py-34/35) — this is pure inline cross-reference at the teaching point, NOT a new citation. Brings QC-Py-32 to the same inline-anchor standard as QC-Py-33/34/35.

## Validation

- **Code cells sha1 byte-identical** to origin/main (0 code cell touched).
- md[16] +1 element / md[20] +1 element (appended footnote, list-direct, no join+resplit).
- Cell count + sequence unchanged.
- `notebook_tools validate`: 0 errors, 0 warnings.
- Catalogue byte-identical (no churn).
- Branch fresh from origin/main (0 behind).

See #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
