### PR TITLE
docs(genai): restore French diacritics in Audio series READMEs (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/README.md
@@ -2,9 +2,9 @@
 
 [← Audio Foundation](../01-Foundation/) | [↑ Audio](../README.md) | [→ Audio Orchestration](../03-Orchestration/)
 
-Ce module explore les techniques avancees : clonage vocal, generation musicale, separation de sources, et modeles TTS expressifs.
+Ce module explore les techniques avancées : clonage vocal, génération musicale, séparation de sources, et modèles TTS expressifs.
 
-**Dans le cadre du fil rouge podcast** : un podcast de qualite a besoin d'une voix coherente et d'une identite sonore. [02-2](02-2-XTTS-Voice-Cloning.ipynb) clone une voix a partir d'un echantillon pour creer un narrateur recurrent. [02-3](02-3-MusicGen-Generation.ipynb) genere le jingle et le fond musical. [02-4](02-4-Demucs-Source-Separation.ipynb) isole les pistes audio d'un mix existant (utile pour remasteriser un interview). [02-8](02-8-Expressive-TTS.ipynb) ajoute des emotions et de la prosodie pour varier le ton selon les passages.
+**Dans le cadre du fil rouge podcast** : un podcast de qualité a besoin d'une voix cohérente et d'une identité sonore. [02-2](02-2-XTTS-Voice-Cloning.ipynb) clone une voix à partir d'un échantillon pour créer un narrateur récurrent. [02-3](02-3-MusicGen-Generation.ipynb) génère le jingle et le fond musical. [02-4](02-4-Demucs-Source-Separation.ipynb) isole les pistes audio d'un mix existant (utile pour remastériser un interview). [02-8](02-8-Expressive-TTS.ipynb) ajoute des émotions et de la prosodie pour varier le ton selon les passages.
 
 ## Vue d'ensemble
 
@@ -12,7 +12,7 @@ Ce module explore les techniques avancees : clonage vocal, generation musicale, 
 |-------------|--------|
 | Notebooks | 9 |
 | Kernel | Python 3 |
-| Duree estimee | ~6-8h |
+| Durée estimée | ~6-8h |
 | GPU requis | 2-24GB |
 
 ## Notebooks

--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/README.md
@@ -2,9 +2,9 @@
 
 [← Audio Advanced](../02-Advanced/) | [↑ Audio](../README.md) | [→ Audio Applications](../04-Applications/)
 
-Ce module couvre l'orchestration de plusieurs modeles audio, les pipelines complexes, et l'API temps reel d'OpenAI.
+Ce module couvre l'orchestration de plusieurs modèles audio, les pipelines complexes, et l'API temps réel d'OpenAI.
 
-**Dans le cadre du fil rouge podcast** : les briques existent, il faut les assembler. [03-1](03-1-Multi-Model-Audio-Comparison.ipynb) compare les modeles STT et TTS pour choisir le meilleur selon le budget et la qualite vises. [03-2](03-2-Audio-Pipeline-Orchestration.ipynb) construit le pipeline STT vers LLM vers TTS qui constitue le coeur du podcast automatise. [03-3](03-3-Realtime-Voice-API.ipynb) montre l'alternative temps reel d'OpenAI pour les interactions live.
+**Dans le cadre du fil rouge podcast** : les briques existent, il faut les assembler. [03-1](03-1-Multi-Model-Audio-Comparison.ipynb) compare les modèles STT et TTS pour choisir le meilleur selon le budget et la qualité visés. [03-2](03-2-Audio-Pipeline-Orchestration.ipynb) construit le pipeline STT vers LLM vers TTS qui constitue le coeur du podcast automatisé. [03-3](03-3-Realtime-Voice-API.ipynb) montre l'alternative temps réel d'OpenAI pour les interactions live.
 
 ## Vue d'ensemble
 
@@ -12,7 +12,7 @@ Ce module couvre l'orchestration de plusieurs modeles audio, les pipelines compl
 |-------------|--------|
 | Notebooks | 3 |
 | Kernel | Python 3 |
-| Duree estimee | ~4-6h |
+| Durée estimée | ~4-6h |
 | GPU requis | 0-14GB |
 
 ## Notebooks

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/README.md
@@ -2,11 +2,11 @@
 
 [← Audio Orchestration](../03-Orchestration/) | [↑ Audio](../README.md) | [→ Video](../../Video/README.md)
 
-Ce module presente des cas d'usage concrets et des workflows de production pour l'audio generatif.
+Ce module présente des cas d'usage concrets et des workflows de production pour l'audio génératif.
 
-**Fil rouge podcast** : [04-1](04-1-Educational-Audio-Content.ipynb) automatise la narration de cours. [04-2](04-2-Transcription-Pipeline.ipynb) gere la transcription batch avec sous-titres SRT. [04-3](04-3-Music-Composition-Workflow.ipynb) compose des bandes sonores. [04-4](04-4-Audio-Video-Sync.ipynb) synchronise l'audio avec la video.
+**Fil rouge podcast** : [04-1](04-1-Educational-Audio-Content.ipynb) automatise la narration de cours. [04-2](04-2-Transcription-Pipeline.ipynb) gère la transcription batch avec sous-titres SRT. [04-3](04-3-Music-Composition-Workflow.ipynb) compose des bandes sonores. [04-4](04-4-Audio-Video-Sync.ipynb) synchronise l'audio avec la vidéo.
 
-**Fil rouge audiobook (Epic #1028)** : [04-6](04-6-Audiobook-Pipeline.ipynb) a [04-12](04-12-Compilation-Audio.ipynb) forment un pipeline agentique 5-pass complet : benchmark des voix, analyse litteraire, casting vocal, annotation prosodique, generation TTS et compilation finale. [04-13](04-13-Audiobook-FishAudio-S2Pro.ipynb) etend le pipeline avec FishAudio S2-Pro, 29 tags prosodiques officiels et validation WER.
+**Fil rouge audiobook (Epic #1028)** : [04-6](04-6-Audiobook-Pipeline.ipynb) a [04-12](04-12-Compilation-Audio.ipynb) forment un pipeline agentique 5-pass complet : benchmark des voix, analyse littéraire, casting vocal, annotation prosodique, génération TTS et compilation finale. [04-13](04-13-Audiobook-FishAudio-S2Pro.ipynb) étend le pipeline avec FishAudio S2-Pro, 29 tags prosodiques officiels et validation WER.
 
 ## Vue d'ensemble
 
@@ -14,44 +14,44 @@ Ce module presente des cas d'usage concrets et des workflows de production pour 
 |-------------|--------|
 | Notebooks | 13 |
 | Kernel | Python 3 |
-| Duree estimee | ~8-12h |
+| Durée estimée | ~8-12h |
 | GPU requis | 0-14GB |
 
 ## Notebooks
 
-### Workflows generaux
+### Workflows généraux
 
 | # | Notebook | Contenu | Service | VRAM |
 |---|----------|---------|---------|------|
 | 1 | [04-1-Educational-Audio-Content](04-1-Educational-Audio-Content.ipynb) | Narration automatique de cours | Mixed | ~10 GB |
 | 2 | [04-2-Transcription-Pipeline](04-2-Transcription-Pipeline.ipynb) | Batch transcription, sous-titres SRT | Mixed | ~12 GB |
-| 3 | [04-3-Music-Composition-Workflow](04-3-Music-Composition-Workflow.ipynb) | Creation musicale multi-etapes | Local GPU | ~14 GB |
+| 3 | [04-3-Music-Composition-Workflow](04-3-Music-Composition-Workflow.ipynb) | Création musicale multi-étapes | Local GPU | ~14 GB |
 | 4 | [04-4-Audio-Video-Sync](04-4-Audio-Video-Sync.ipynb) | Synchronisation audio-video | Mixed | ~10 GB |
 | 5 | [04-5-LiveCoding-LLM-Music](04-5-LiveCoding-LLM-Music.ipynb) | Strudel.cc + LLM, live coding musical | OpenAI API | 0 |
 
 ### Pipeline Audiobook Agentique (Epic #1028)
 
-Pipeline complet de 7 notebooks pour generer un audiobook a partir d'un texte litteraire, avec selection de voix, annotation prosodique et compilation finale.
+Pipeline complet de 7 notebooks pour générer un audiobook à partir d'un texte littéraire, avec sélection de voix, annotation prosodique et compilation finale.
 
 | # | Notebook | Pass | Contenu | Service | VRAM |
 | --- | ---------- | ------ | --------- | --------- | ------ |
 | 6 | [04-6-Audiobook-Pipeline](04-6-Audiobook-Pipeline.ipynb) | P0 | Pipeline audiobook orchestrateur | Mixed | ~10 GB |
-| 7 | [04-7-TTS-Voice-Benchmark](04-7-TTS-Voice-Benchmark.ipynb) | P0 | Benchmark comparatif des modeles TTS | Kokoro + OpenAI | ~2 GB |
-| 8 | [04-8-Lecture-Analytique](04-8-Lecture-Analytique.ipynb) | P1 | Analyse litteraire, segmentation dialogues/narration | OpenAI API | 0 |
+| 7 | [04-7-TTS-Voice-Benchmark](04-7-TTS-Voice-Benchmark.ipynb) | P0 | Benchmark comparatif des modèles TTS | Kokoro + OpenAI | ~2 GB |
+| 8 | [04-8-Lecture-Analytique](04-8-Lecture-Analytique.ipynb) | P1 | Analyse littéraire, segmentation dialogues/narration | OpenAI API | 0 |
 | 9 | [04-9-Voice-Casting](04-9-Voice-Casting.ipynb) | P2 | Attribution de voix par personnage, casting vocal | OpenAI API | 0 |
 | 10 | [04-10-Annotation-Prosodique](04-10-Annotation-Prosodique.ipynb) | P3 | Tags prosodiques FishAudio S2-Pro | OpenAI API | 0 |
-| 11 | [04-11-Generation-TTS](04-11-Generation-TTS.ipynb) | P4 | Generation audio Kokoro multi-voix | Kokoro TTS | ~2 GB |
-| 12 | [04-12-Compilation-Audio](04-12-Compilation-Audio.ipynb) | P5 | Concatenation FFmpeg + normalisation loudness | FFmpeg | 0 |
+| 11 | [04-11-Generation-TTS](04-11-Generation-TTS.ipynb) | P4 | Génération audio Kokoro multi-voix | Kokoro TTS | ~2 GB |
+| 12 | [04-12-Compilation-Audio](04-12-Compilation-Audio.ipynb) | P5 | Concaténation FFmpeg + normalisation loudness | FFmpeg | 0 |
 | 13 | [04-13-Audiobook-FishAudio-S2Pro](04-13-Audiobook-FishAudio-S2Pro.ipynb) | Full | Pipeline v4 FishAudio S2-Pro, 29 tags prosodiques, validation WER | FishAudio + Whisper | ~2 GB |
 
 **Flux du pipeline audiobook** :
 
 ```text
-P0 Benchmark voix → P1 Analyse litteraire → P2 Casting vocal
-    → P3 Annotation prosodique → P4 Generation TTS → P5 Compilation finale
+P0 Benchmark voix → P1 Analyse littéraire → P2 Casting vocal
+    → P3 Annotation prosodique → P4 Génération TTS → P5 Compilation finale
 ```
 
-## Prerequis
+## Prérequis
 
 ### API Keys
 ```bash
@@ -59,7 +59,7 @@ P0 Benchmark voix → P1 Analyse litteraire → P2 Casting vocal
 OPENAI_API_KEY=sk-...
 ```
 
-### Dependances
+### Dépendances
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-audio.txt
@@ -86,17 +86,17 @@ Audio brut -> STT -> Correction -> Enhance -> TTS -> Podcast final
 ### Musique
 
 ```text
-Texte -> MusicGen -> Edition MIDI -> Post-production -> Export
+Texte -> MusicGen -> Édition MIDI -> Post-production -> Export
 ```
 
 ### Audiobook Agentique (Epic #1028)
 
 ```text
-Texte litteraire -> Benchmark voix (P0)
+Texte littéraire -> Benchmark voix (P0)
     -> Segmentation dialogue/narration (P1)
     -> Casting vocal par personnage (P2)
     -> Annotation prosodique [whisper][shout][cold] (P3)
-    -> Generation TTS multi-voix Kokoro (P4)
+    -> Génération TTS multi-voix Kokoro (P4)
     -> FFmpeg concat + loudnorm (P5)
     -> Audiobook final MP3
 ```


### PR DESCRIPTION
Restaure les accents sur les **3 READMEs Audio per-level restants** (02-Advanced, 03-Orchestration, 04-Applications). Complète la couverture Audio per-level (#4355 = 01-Foundation). Miroir de **#4345** (accent-only atomique).

## Preuve accent-only (byte-réversible, par fichier)
| Fichier | deaccent(old)==(new) | lignes | BOM |
|---|---|---|---|
| 02-Advanced | ✓ IDENTICAL | 80/80 | byte-identical |
| 03-Orchestration | ✓ IDENTICAL | 76/76 | byte-identical |
| 04-Applications | ✓ IDENTICAL | 108/108 | byte-identical |

Méthode : `unicodedata.normalize('NFD')` + filtre catégorie `Mn`. `diff --stat` : 3 fichiers, 24 insertions, 24 suppressions. Markdown-only (C.2 exception).

## Scope respecté (greenlight ai-01 #2876)
- **Accent-only** (0 sémantique, 0 restructure)
- **Catalogue byte-identique** (0 fichier CATALOG touché)
- Base fraîche `origin/main` `9ef0eb45c`
- 1 famille (Audio), 1 feature (accents) — sous seuil composite G.4

## Hors scope (documenté honnêtement)
- **Literal « coeur »** (03-Orchestration L7) : laissé tel quel (pas « cœur ») car la ligature `œ` (U+0153) **n'est pas un accent** (NFD ne la décompose pas) → casserait la preuve `deaccent`. Même traitement que « oeuvre » (L7). Correction = PR séparée (ligature, pas diacritique).
- Avertissements markdown-lint pré-existants (MD060/022/031/032/047) : structurels, pas diacritiques → sujet séparé.

See #2876 (partiel, epic repo-wide).