### PR TITLE
docs(genai): restore French diacritics in Image series READMEs (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/README.md
@@ -4,7 +4,7 @@
 
 Ce module couvre les fondamentaux de la génération d'images par IA : modèles cloud, ComfyUI, et opérations de base.
 
-**Dans le cadre du fil rouge contenu visuel educatif** : avant de produire des visuels, il faut savoir generer une image a partir d'un texte. [01-1](01-1-OpenAI-DALL-E-3.ipynb) et [01-2](01-2-GPT-5-Image-Generation.ipynb) couvrent les API cloud (simples et immediates). [01-4](01-4-Forge-SD-XL-Turbo.ipynb) et [01-5](01-5-Qwen-Image-Edit.ipynb) passent en local via ComfyUI pour le controle fin. [01-3](01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation (PIL, OpenCV) utiles pour comprendre ce que font les modeles.
+**Dans le cadre du fil rouge contenu visuel éducatif** : avant de produire des visuels, il faut savoir générer une image à partir d'un texte. [01-1](01-1-OpenAI-DALL-E-3.ipynb) et [01-2](01-2-GPT-5-Image-Generation.ipynb) couvrent les API cloud (simples et immédiates). [01-4](01-4-Forge-SD-XL-Turbo.ipynb) et [01-5](01-5-Qwen-Image-Edit.ipynb) passent en local via ComfyUI pour le contrôle fin. [01-3](01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation (PIL, OpenCV) utiles pour comprendre ce que font les modèles.
 
 ## Vue d'overview
 
@@ -12,7 +12,7 @@ Ce module couvre les fondamentaux de la génération d'images par IA : modèles 
 |-------------|--------|
 | Notebooks | 5 |
 | Kernel | Python 3 |
-| Duree estimee | ~3-4h |
+| Durée estimée | ~3-4h |
 | GPU requis | 0-29GB |
 
 ## Notebooks

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
@@ -4,7 +4,7 @@
 
 Ce module explore les modèles de pointe : Qwen Image Edit avancé, FLUX, SD 3.5, Z-Image/Lumina, et la quantification extrême (Bonsai ternaire 1.58-bit).
 
-**Dans le cadre du fil rouge contenu visuel educatif** : un visuel de qualite demande des outils precis. [02-1](02-1-Qwen-Image-Edit-2509.ipynb) edite une image existante pour corriger ou enrichir un diagramme. [02-2](02-2-FLUX-1-Advanced-Generation.ipynb) genere des images haute qualite. [02-4](02-4-Z-Image-Lumina2.ipynb) offre une generation rapide pour le prototypage iteratif. [02-5](02-5-Bonsai-Image-Ternary.ipynb) aborde la quantification ternaire 1.58-bit : un modèle 4B compressé à ~4 GB qui se genere en ~2s, parfait pour deployer la generation d'images sur du materiel modeste (formation, demos) sans sacrifier la qualite.
+**Dans le cadre du fil rouge contenu visuel éducatif** : un visuel de qualité demande des outils précis. [02-1](02-1-Qwen-Image-Edit-2509.ipynb) édite une image existante pour corriger ou enrichir un diagramme. [02-2](02-2-FLUX-1-Advanced-Generation.ipynb) génère des images haute qualité. [02-4](02-4-Z-Image-Lumina2.ipynb) offre une génération rapide pour le prototypage itératif. [02-5](02-5-Bonsai-Image-Ternary.ipynb) aborde la quantification ternaire 1.58-bit : un modèle 4B compressé à ~4 GB qui se génère en ~2s, parfait pour déployer la génération d'images sur du matériel modeste (formation, demos) sans sacrifier la qualité.
 
 ## Vue d'overview
 
@@ -12,7 +12,7 @@ Ce module explore les modèles de pointe : Qwen Image Edit avancé, FLUX, SD 3.5
 |-------------|--------|
 | Notebooks | 5 |
 | Kernel | Python 3 |
-| Duree estimee | ~5-7h |
+| Durée estimée | ~5-7h |
 | GPU requis | 5-29GB |
 
 ## Notebooks

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
@@ -4,7 +4,7 @@
 
 Ce module couvre l'orchestration de plusieurs modèles, les workflows complexes, et l'optimisation de performance.
 
-**Dans le cadre du fil rouge contenu visuel educatif** : en production, un seul modele ne suffit pas. [03-1](03-1-Multi-Model-Comparison.ipynb) compare les modeles pour choisir le meilleur selon le contexte. [03-2](03-2-Workflow-Orchestration.ipynb) assemble des pipelines (generation, edition, upscaling). [03-3](03-3-Performance-Optimization.ipynb) optimise les performances pour le deploiement.
+**Dans le cadre du fil rouge contenu visuel éducatif** : en production, un seul modèle ne suffit pas. [03-1](03-1-Multi-Model-Comparison.ipynb) compare les modèles pour choisir le meilleur selon le contexte. [03-2](03-2-Workflow-Orchestration.ipynb) assemble des pipelines (génération, édition, upscaling). [03-3](03-3-Performance-Optimization.ipynb) optimise les performances pour le déploiement.
 
 ## Vue d'overview
 
@@ -12,7 +12,7 @@ Ce module couvre l'orchestration de plusieurs modèles, les workflows complexes,
 |-------------|--------|
 | Notebooks | 3 |
 | Kernel | Python 3 |
-| Duree estimee | ~3-5h |
+| Durée estimée | ~3-5h |
 | GPU requis | Variable |
 
 ## Notebooks

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/README.md
@@ -4,7 +4,7 @@
 
 Ce module présente des cas d'usage concrets et des workflows de production pour la génération d'images.
 
-**Dans le cadre du fil rouge contenu visuel educatif** : ce niveau met en oeuvre les workflows complets. [04-1](04-1-Educational-Content-Generation.ipynb) automatise la creation de visuels pedagogiques (brief texte vers images). [04-2](04-2-Creative-Workflows.ipynb) gere les workflows creatifs. [04-3](04-3-Production-Integration.ipynb) integre le pipeline en production.
+**Dans le cadre du fil rouge contenu visuel éducatif** : ce niveau met en oeuvre les workflows complets. [04-1](04-1-Educational-Content-Generation.ipynb) automatise la création de visuels pédagogiques (brief texte vers images). [04-2](04-2-Creative-Workflows.ipynb) gère les workflows créatifs. [04-3](04-3-Production-Integration.ipynb) intègre le pipeline en production.
 
 ## Vue d'overview
 
@@ -12,7 +12,7 @@ Ce module présente des cas d'usage concrets et des workflows de production pour
 |-------------|--------|
 | Notebooks | 4 |
 | Kernel | Python 3 |
-| Duree estimee | ~4-6h |
+| Durée estimée | ~4-6h |
 | GPU requis | 0-14GB |
 
 ## Notebooks


### PR DESCRIPTION
Restaure les accents sur les **4 READMEs Image per-level** (01-Foundation, 02-Advanced, 03-Orchestration, 04-Applications). Drift concentré dans les paragraphes d'intro (éducatif, génère/édite, modèles, déploiement, qualité, matériel) + ligne de table « Duree estimee ». Miroir de **#4345** (accent-only atomique).

## Preuve accent-only (byte-réversible, par fichier)
| Fichier | deaccent(old)==(new) | lignes | BOM |
|---|---|---|---|
| 01-Foundation | ✓ IDENTICAL | 61/61 | byte-identical |
| 02-Advanced | ✓ IDENTICAL | 93/93 | byte-identical |
| 03-Orchestration | ✓ IDENTICAL | 76/76 | byte-identical |
| 04-Applications | ✓ IDENTICAL | 92/92 | byte-identical |

Méthode : `unicodedata.normalize('NFD')` + filtre catégorie `Mn`. `diff --stat` : 4 fichiers, 8 insertions, 8 suppressions. Markdown-only (C.2 exception). Catalogue byte-identique (0 fichier CATALOG touché).

## Scope respecté (greenlight ai-01 #2876)
- **Accent-only** (0 sémantique, 0 restructure)
- Base fraîche `origin/main` `9ef0eb45c`
- 1 famille (Image), 1 feature (accents) — sous seuil composite G.4

## Hors scope (documenté honnêtement)
- **« Vue d'overview »** (heading L9, les 4 fichiers) : « overview » est un mot anglais, pas un diacritique → changer en « ensemble » = swap sémantique, sujet séparé.
- **« met en oeuvre »** (04-Applications L7) : literal « oeuvre » conservé tel quel (pas « œuvre ») — la ligature `œ` (U+0153) n'est pas un accent (NFD ne la décompose pas), même traitement que « coeur » (#4359).
- Avertissements markdown-lint pré-existants (MD060/031) : structurels, pas diacritiques.

See #2876 (partiel, epic repo-wide).