### PR TITLE
docs(genai): restore French diacritics in Video series READMEs (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/README.md
@@ -4,7 +4,7 @@
 
 Ce module couvre les fondamentaux de la vidéo par IA : opérations vidéo, compréhension vidéo, et amélioration.
 
-**Dans le cadre du fil rouge pipeline video pedagogique** : avant de generer des videos, il faut savoir les analyser et les manipuler. [01-1](01-1-Video-Operations-Basics.ipynb) donne les bases techniques (ffmpeg, moviepy). [01-2](01-2-GPT-5-Video-Understanding.ipynb) et [01-3](01-3-Qwen-VL-Video-Analysis.ipynb) couvrent la comprehension video (decomposition en scenes, Q&A sur le contenu). [01-4](01-4-Video-Enhancement-ESRGAN.ipynb) ameliore la qualite visuelle. [01-5](01-5-AnimateDiff-Introduction.ipynb) introduit la generation de mouvement a partir de texte.
+**Dans le cadre du fil rouge pipeline vidéo pédagogique** : avant de générer des vidéos, il faut savoir les analyser et les manipuler. [01-1](01-1-Video-Operations-Basics.ipynb) donne les bases techniques (ffmpeg, moviepy). [01-2](01-2-GPT-5-Video-Understanding.ipynb) et [01-3](01-3-Qwen-VL-Video-Analysis.ipynb) couvrent la compréhension vidéo (décomposition en scènes, Q&A sur le contenu). [01-4](01-4-Video-Enhancement-ESRGAN.ipynb) améliore la qualité visuelle. [01-5](01-5-AnimateDiff-Introduction.ipynb) introduit la génération de mouvement à partir de texte.
 
 ## Vue d'overview
 
@@ -12,7 +12,7 @@ Ce module couvre les fondamentaux de la vidéo par IA : opérations vidéo, comp
 |-------------|--------|
 | Notebooks | 5 |
 | Kernel | Python 3 |
-| Duree estimee | ~4-6h |
+| Durée estimée | ~4-6h |
 | GPU requis | 0-12GB |
 
 ## Notebooks

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/README.md
@@ -4,7 +4,7 @@
 
 Ce module explore les modèles de génération vidéo de pointe : HunyuanVideo, LTX Video, Wan Video, et SVD.
 
-**Dans le cadre du fil rouge pipeline video pedagogique** : ce niveau fournit les modeles generatifs. [02-1](02-1-HunyuanVideo-Generation.ipynb) produit des videos haute qualite (cinematographique). [02-3](02-3-Wan-Video-Generation.ipynb) offre une generation rapide avec support multilingue. [02-4](02-4-SVD-Image-to-Video.ipynb) anime une image existante -- utile pour transformer un diagramme ou une illustration en sequence animee.
+**Dans le cadre du fil rouge pipeline vidéo pédagogique** : ce niveau fournit les modèles génératifs. [02-1](02-1-HunyuanVideo-Generation.ipynb) produit des vidéos haute qualité (cinématographique). [02-3](02-3-Wan-Video-Generation.ipynb) offre une génération rapide avec support multilingue. [02-4](02-4-SVD-Image-to-Video.ipynb) anime une image existante -- utile pour transformer un diagramme ou une illustration en séquence animée.
 
 ## Vue d'overview
 
@@ -12,7 +12,7 @@ Ce module explore les modèles de génération vidéo de pointe : HunyuanVideo, 
 |-------------|--------|
 | Notebooks | 5 |
 | Kernel | Python 3 |
-| Duree estimee | ~6-8h |
+| Durée estimée | ~6-8h |
 | GPU requis | 8-24GB |
 
 ## Notebooks

--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md
@@ -4,7 +4,7 @@
 
 Ce module couvre l'orchestration de plusieurs modèles vidéo, les workflows complexes, et l'intégration ComfyUI.
 
-**Dans le cadre du fil rouge pipeline video pedagogique** : les briques existent, il faut les assembler. [03-1](03-1-Multi-Model-Video-Comparison.ipynb) compare les modeaux pour choisir le meilleur selon le materiel et le contexte. [03-2](03-2-Video-Workflow-Orchestration.ipynb) construit le pipeline text-to-image-to-video qui constitue le coeur du generateur. [03-3](03-3-ComfyUI-Video-Workflows.ipynb) utilise ComfyUI pour des workflows natifs plus flexibles.
+**Dans le cadre du fil rouge pipeline vidéo pédagogique** : les briques existent, il faut les assembler. [03-1](03-1-Multi-Model-Video-Comparison.ipynb) compare les modeaux pour choisir le meilleur selon le matériel et le contexte. [03-2](03-2-Video-Workflow-Orchestration.ipynb) construit le pipeline text-to-image-to-video qui constitue le coeur du générateur. [03-3](03-3-ComfyUI-Video-Workflows.ipynb) utilise ComfyUI pour des workflows natifs plus flexibles.
 
 ## Vue d'overview
 
@@ -12,7 +12,7 @@ Ce module couvre l'orchestration de plusieurs modèles vidéo, les workflows com
 |-------------|--------|
 | Notebooks | 3 |
 | Kernel | Python 3 |
-| Duree estimee | ~4-6h |
+| Durée estimée | ~4-6h |
 | GPU requis | Variable |
 
 ## Notebooks

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
@@ -4,7 +4,7 @@
 
 Ce module présente des cas d'usage concrets et des workflows de production pour la génération vidéo.
 
-**Dans le cadre du fil rouge pipeline video pedagogique** : ce niveau met en oeuvre les workflows complets. [04-1](04-1-Educational-Video-Generation.ipynb) genere automatiquement du contenu video educatif a partir d'un script. [04-3](04-3-Sora-API-Cloud-Video.ipynb) explore la generation cloud via l'API Sora. [04-4](04-4-Production-Video-Pipeline.ipynb) assemble le pipeline bout-en-bout.
+**Dans le cadre du fil rouge pipeline vidéo pédagogique** : ce niveau met en oeuvre les workflows complets. [04-1](04-1-Educational-Video-Generation.ipynb) génère automatiquement du contenu vidéo éducatif à partir d'un script. [04-3](04-3-Sora-API-Cloud-Video.ipynb) explore la génération cloud via l'API Sora. [04-4](04-4-Production-Video-Pipeline.ipynb) assemble le pipeline bout-en-bout.
 
 ## Vue d'overview
 
@@ -12,7 +12,7 @@ Ce module présente des cas d'usage concrets et des workflows de production pour
 |-------------|--------|
 | Notebooks | 4 |
 | Kernel | Python 3 |
-| Duree estimee | ~6-8h |
+| Durée estimée | ~6-8h |
 | GPU requis | 0-24GB |
 
 ## Notebooks


### PR DESCRIPTION
Restaure les accents sur les **4 READMEs Video per-level** (01-Foundation, 02-Advanced, 03-Orchestration, 04-Applications). Drift dans les paragraphes d'intro (vidéo pédagogique, générer, compréhension, décomposition en scènes, modèles, qualité, matériel, générateur, génération cloud) + ligne de table « Duree estimee ». Miroir de **#4345** (accent-only atomique).

## Preuve accent-only (byte-réversible, par fichier)
| Fichier | deaccent(old)==(new) | lignes | BOM |
|---|---|---|---|
| 01-Foundation | ✓ IDENTICAL | 64/64 | byte-identical |
| 02-Advanced | ✓ IDENTICAL | 98/98 | byte-identical |
| 03-Orchestration | ✓ IDENTICAL | 77/77 | byte-identical |
| 04-Applications | ✓ IDENTICAL | 91/91 | byte-identical |

Méthode : `unicodedata.normalize('NFD')` + filtre catégorie `Mn`. `diff --stat` : 4 fichiers, 8 insertions, 8 suppressions. Markdown-only (C.2 exception). Catalogue byte-identique.

## Scope respecté (greenlight ai-01 #2876)
- **Accent-only** (0 sémantique, 0 restructure)
- Base fraîche `origin/main` `bb75525c8`
- 1 famille (Video), 1 feature — sous seuil composite G.4

## Hors scope (documenté honnêtement, pas touché)
- **« modeaux » typo** (03-Orchestration L7) : vraie typo (swap de lettres `aux`→`èles`), **pas** accent-only → laisser intact casserait la preuve `deaccent`. Correction = PR séparée. (Même pattern que « modeaux » documenté dans 00-GenAI-Environment c.25.)
- **« Vue d'overview »** (heading L9 ×4) : mot anglais, pas diacritique.
- **« coeur » / « met en oeuvre »** : literals conservés — la ligature `œ` (U+0153) n'est pas un accent (NFD ne la décompose pas), même traitement que #4359/#4361.

See #2876 (partiel, epic repo-wide).