### PR TITLE
feat(argumentation): 5-jtms deterministic Truth Maintenance System notebook (#2137)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-5-jtms.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-5-jtms.ipynb
@@ -1,0 +1,734 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5b9ec6d8",
+   "metadata": {},
+   "source": [
+    "# Argument_Analysis_Agentic-5-jtms : Truth Maintenance System (JTMS) deterministe\n",
+    "\n",
+    "**Navigation** : [<< 4-capstone](./Argument_Analysis_Agentic-4-capstone.ipynb) | [README](./README.md) | [Tweety ->](../Tweety/README.md)\n",
+    "\n",
+    "Le rung [2-formal](./Argument_Analysis_Agentic-2-formal.ipynb) delegue la **preuve logique** a un solveur externe (Tweety, JVM/JPype) : une fois une formule etablie, elle le reste. C'est le regime **monotone** -- la verite ne se retracte pas.\n",
+    "\n",
+    "Mais l'analyse argumentative reelle est **non-monotone** : un nouvel element (un sophisme detecte sur une premisse, un temoin discredite) peut invalider une conclusion auparavant tenue pour vraie. Maintenir un etat de croyance coherent sous de telles revisions est precisement le probleme qu'un **Truth Maintenance System** (Doyle, 1979 ; McAllester, de Kleer) resout. Ce rung implemente un JTMS **from scratch** en pur stdlib Python : croyances, justifications IN/OUT, propagation par point fixe, detection de circularite (odd loops) et cascade de retractation.\n",
+    "\n",
+    "Aucun LLM, aucune JVM, aucun solveur externe : l'objet pedagogique est la **mecanique** du raisonnement non-monotone -- la brique algorithmique sur laquelle s'appuient la revision de croyances AGM et les semantiques d'argumentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8f2d44b",
+   "metadata": {},
+   "source": [
+    "## 1. Introduction : raisonnement non-monotone et maintien de croyances\n",
+    "\n",
+    "En logique **monotone** (modus ponens, SAT), ajouter un fait ne retire jamais une conclusion : si `p, p => q |- q`, alors `q` reste etabli quoi qu'on ajoute ensuite. C'est le regime du rung [2-formal](./Argument_Analysis_Agentic-2-formal.ipynb).\n",
+    "\n",
+    "Le raisonnement **non-monotone** casse cette garantie. Un exemple concret :\n",
+    "\n",
+    "1. « Un expert affirme que X est vrai. » (premisse P)\n",
+    "2. « Si un expert affirme X, alors X est vrai. » (regle)\n",
+    "3. Donc **X est vrai** (conclusion C, derivee de P).\n",
+    "\n",
+    "Puis un detecteur de sophismes signale que la premisse P est un **appel a l'autorite** : P est discreditee. La conclusion C doit alors etre **retractee** -- alors meme qu'elle avait ete correctement derivee. C'est une revision, pas une erreur de logique.\n",
+    "\n",
+    "Un **JTMS** (Justification-based Truth Maintenance System) maintient un tel etat de croyance revisable. Chaque croyance est etiquetee **IN** (activement soutenue) ou **OUT** (non soutenue). Les etiquettes se recalculent par propagation dans un graphe de **justifications**. Retracter une croyance fondatrice declenche une **cascade** : toutes les croyances qui en dependaient basculent OUT a leur tour.\n",
+    "\n",
+    "| Concept | Definition | Role dans ce rung |\n",
+    "|---------|-----------|-------------------|\n",
+    "| **Croyance (belief)** | Un noeud du graphe, etiquete IN ou OUT | Unite de raisonnement |\n",
+    "| **Justification** | Regle : `conclusion` est IN ssi tout `in_list` est IN et tout `out_list` est OUT | Lien de support |\n",
+    "| **Premisse** | Croyance IN inconditionnellement (justification vide) | Fondation |\n",
+    "| **Etiquetage** | Calcul du statut IN/OUT de chaque croyance | Point fixe monotone |\n",
+    "| **Cascade** | Retracter une croyance -> bascule de ses dependants | Propagation non-monotone |\n",
+    "| **Odd loop** | Cycle de support positif (A soutient B soutient A) | Anomalie a detecter |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8c30582",
+   "metadata": {},
+   "source": [
+    "## 2. Le modele de donnees : croyances et justifications IN/OUT\n",
+    "\n",
+    "Une **justification** est un triplet :\n",
+    "\n",
+    "- `in_list` : liste de croyances qui doivent toutes etre **IN** ;\n",
+    "- `out_list` : liste de croyances qui doivent toutes etre **OUT** ;\n",
+    "- `conclusion` : la croyance soutenue.\n",
+    "\n",
+    "La justification est **valide** ssi ses deux conditions tiennent simultanement. Une croyance est IN des qu'**au moins une** de ses justifications est valide. Une **premisse** est une justification aux listes vides : sa conclusion est IN sans condition (le point d'ancrage du raisonnement).\n",
+    "\n",
+    "La cellule ci-dessous definit le moteur JTMS complet (modele de donnees + etiquetage + retractation + detection de circularite). Les sections suivantes demontrent chaque mecanisme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1393e2fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.597188Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.596949Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.612910Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.612294Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Moteur JTMS charge (Justification, JTMS).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [2] - Le moteur JTMS complet (pur stdlib, 0 dependance externe)\n",
+    "from dataclasses import dataclass, field\n",
+    "from typing import List, Dict, Set\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class Justification:\n",
+    "    \"\"\"Une regle de support : `conclusion` est IN ssi\n",
+    "    tout in_list est IN et tout out_list est OUT.\"\"\"\n",
+    "    conclusion: str\n",
+    "    in_list: List[str] = field(default_factory=list)\n",
+    "    out_list: List[str] = field(default_factory=list)\n",
+    "\n",
+    "\n",
+    "class JTMS:\n",
+    "    \"\"\"Justification-based Truth Maintenance System (Doyle 1979, well-founded).\n",
+    "\n",
+    "    Les croyances vivent dans un ensemble de noms (str). Les justifications\n",
+    "    forment un graphe oriente. L'etiquetage est un point fixe monotone :\n",
+    "    toutes les croyances partent OUT, puis sont promues IN quand une\n",
+    "    justification valide est trouvee, jusqu'a stabilite.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self.beliefs: Set[str] = set()\n",
+    "        self.justifications: List[Justification] = []\n",
+    "\n",
+    "    def add_belief(self, name: str) -> None:\n",
+    "        self.beliefs.add(name)\n",
+    "\n",
+    "    def add_premise(self, name: str) -> None:\n",
+    "        \"\"\"Une premisse = croyance IN inconditionnellement (listes vides).\"\"\"\n",
+    "        self.add_belief(name)\n",
+    "        self.justifications.append(Justification(name, [], []))\n",
+    "\n",
+    "    def add_justification(self, conclusion: str,\n",
+    "                          in_list: List[str] = None,\n",
+    "                          out_list: List[str] = None) -> None:\n",
+    "        in_list = in_list or []\n",
+    "        out_list = out_list or []\n",
+    "        self.add_belief(conclusion)\n",
+    "        for b in in_list + out_list:\n",
+    "            self.add_belief(b)\n",
+    "        self.justifications.append(Justification(conclusion, in_list, out_list))\n",
+    "\n",
+    "    # --- Etiquetage (well-founded, point fixe monotone) ---\n",
+    "    def label(self) -> Dict[str, str]:\n",
+    "        \"\"\"Calcule le statut IN/OUT de chaque croyance.\n",
+    "\n",
+    "        Monotone : on ne fait que des transitions OUT -> IN, le nombre de\n",
+    "        croyances borne les iterations -> convergence garantie. Les odd loops\n",
+    "        (cycles de support positif) ne sont jamais promus -> restent OUT.\n",
+    "        \"\"\"\n",
+    "        status = {b: \"OUT\" for b in self.beliefs}\n",
+    "        changed = True\n",
+    "        while changed:\n",
+    "            changed = False\n",
+    "            for b in self.beliefs:\n",
+    "                if status[b] != \"IN\":\n",
+    "                    for j in self.justifications:\n",
+    "                        if j.conclusion == b and \\\n",
+    "                           all(status[x] == \"IN\" for x in j.in_list) and \\\n",
+    "                           all(status[x] == \"OUT\" for x in j.out_list):\n",
+    "                            status[b] = \"IN\"\n",
+    "                            changed = True\n",
+    "                            break\n",
+    "        return status\n",
+    "\n",
+    "    # --- Retractation (declenche la cascade au prochain label) ---\n",
+    "    def retract(self, name: str) -> None:\n",
+    "        \"\"\"Retire toutes les justifications dont la conclusion est `name`.\n",
+    "        Les croyances qui en dependaient perdront leur support -> basculent OUT\n",
+    "        au prochain etiquetage (cascade non-monotone).\"\"\"\n",
+    "        self.justifications = [j for j in self.justifications if j.conclusion != name]\n",
+    "\n",
+    "    # --- Detection de circularite (odd loops) ---\n",
+    "    def find_circular(self) -> Set[str]:\n",
+    "        \"\"\"Croyances OUT dont le seul support est un cycle positif (odd loop).\n",
+    "\n",
+    "        On construit le graphe de dependance POSITIVE (on ignore le out_list,\n",
+    "        car un odd loop est un cycle de soutiens mutuels), on en calcule les\n",
+    "        composantes fortement connexes (Tarjan), et on signale les croyances\n",
+    "        OUT appartenant a un cycle non trivial (ou une auto-boucle).\n",
+    "        \"\"\"\n",
+    "        st = self.label()\n",
+    "        deps = {b: set() for b in self.beliefs}\n",
+    "        for j in self.justifications:\n",
+    "            for x in j.in_list:\n",
+    "                deps[j.conclusion].add(x)\n",
+    "\n",
+    "        index_counter = [0]\n",
+    "        stack = []\n",
+    "        on_stack = set()\n",
+    "        index = {}\n",
+    "        lowlink = {}\n",
+    "        sccs = []\n",
+    "\n",
+    "        def strongconnect(v):\n",
+    "            index[v] = lowlink[v] = index_counter[0]\n",
+    "            index_counter[0] += 1\n",
+    "            stack.append(v)\n",
+    "            on_stack.add(v)\n",
+    "            for w in deps[v]:\n",
+    "                if w not in index:\n",
+    "                    strongconnect(w)\n",
+    "                    lowlink[v] = min(lowlink[v], lowlink[w])\n",
+    "                elif w in on_stack:\n",
+    "                    lowlink[v] = min(lowlink[v], index[w])\n",
+    "            if lowlink[v] == index[v]:\n",
+    "                comp = []\n",
+    "                while True:\n",
+    "                    w = stack.pop()\n",
+    "                    on_stack.discard(w)\n",
+    "                    comp.append(w)\n",
+    "                    if w == v:\n",
+    "                        break\n",
+    "                sccs.append(comp)\n",
+    "\n",
+    "        for v in self.beliefs:\n",
+    "            if v not in index:\n",
+    "                strongconnect(v)\n",
+    "\n",
+    "        circular = set()\n",
+    "        for comp in sccs:\n",
+    "            is_cycle = len(comp) > 1 or (len(comp) == 1 and comp[0] in deps[comp[0]])\n",
+    "            if is_cycle and all(st[b] == \"OUT\" for b in comp):\n",
+    "                circular.update(comp)\n",
+    "        return circular\n",
+    "\n",
+    "    def summary(self) -> str:\n",
+    "        st = self.label()\n",
+    "        lines = [f\"  {b:20s} = {st[b]}\" for b in sorted(self.beliefs)]\n",
+    "        circ = self.find_circular()\n",
+    "        if circ:\n",
+    "            lines.append(f\"  --- circularite detectee : {sorted(circ)}\")\n",
+    "        return \"\\n\".join(lines)\n",
+    "\n",
+    "\n",
+    "print(\"Moteur JTMS charge (Justification, JTMS).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc628304",
+   "metadata": {},
+   "source": [
+    "## 3. L'algorithme d'etiquetage : un point fixe monotone\n",
+    "\n",
+    "L'etiquetage `label()` suit un schema classique de semantique bien-fondee (well-founded) :\n",
+    "\n",
+    "1. **Initialisation** : toutes les croyances sont OUT.\n",
+    "2. **Promotion** : une croyance devient IN si l'une de ses justifications est valide (tout son `in_list` est IN, tout son `out_list` est OUT).\n",
+    "3. **Iteration** : on repete jusqu'a ce qu'aucune promotion n'ait lieu (point fixe).\n",
+    "\n",
+    "L'etape 2 ne fait **que** des transitions OUT -> IN. Comme le nombre de croyances est fini, le processus converge necessairement. C'est cette monotonicite qui garantit la terminaison **et** qui laisse les odd loops a OUT (un cycle de soutiens mutuels ne possede pas de fondation independante, donc aucune croyance du cycle n'est jamais promue).\n",
+    "\n",
+    "Construisons une chaine lineaire : la premisse `A` soutient `B`, qui soutient `C`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b08ccc29",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.614514Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.614343Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.617103Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.616660Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chaine A -> B -> C :\n",
+      "  A                    = IN\n",
+      "  B                    = IN\n",
+      "  C                    = IN\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [4] - Etiquetage sur une chaine lineaire acyclique\n",
+    "t = JTMS()\n",
+    "t.add_premise(\"A\")                          # A = premisse (IN inconditionnel)\n",
+    "t.add_justification(\"B\", in_list=[\"A\"])     # B IN ssi A IN\n",
+    "t.add_justification(\"C\", in_list=[\"B\"])     # C IN ssi B IN\n",
+    "\n",
+    "print(\"Chaine A -> B -> C :\")\n",
+    "print(t.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56d54347",
+   "metadata": {},
+   "source": [
+    "### Interpretation : etiquetage acyclique\n",
+    "\n",
+    "**Sortie attendue** : `A = IN`, `B = IN`, `C = IN`. La propagation est partie de la premisse `A` (IN inconditionnel), a promu `B` (sa justification `A` est IN), puis `C` (sa justification `B` est devenu IN), et s'est stabilisee au point fixe.\n",
+    "\n",
+    "C'est exactement un **modus ponens en chaine**, mais execute par un moteur de maintien de croyances plutot que par un solveur SAT. La difference essentielle apparaitra en section 4 : ici, retirer `A` n'est pas une operation interdite -- elle declenche une cascade."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2ce0a6e",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : branchez une alternative (disjonction de soutiens)\n",
+    "\n",
+    "**Contexte** : une croyance peut avoir **plusieurs** justifications. Elle devient IN des que l'**une d'elles** est valide. C'est le support disjonctif (OR).\n",
+    "\n",
+    "**Objectif** : ajoutez une deuxieme justification a `C` : `C` est IN ssi `D` est IN, ou `D` est une nouvelle premisse. Verifiez que si vous retractez `B` (section 4), `C` reste IN grace a `D`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8e35fa22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.618445Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.618322Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.620774Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.620261Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (JTMS) : support disjonctif\n",
+    "# TODO etudiant : ajoutez une premisse 'D' et une justification 'C <- D',\n",
+    "# puis affichez le summary. Etape 1 : declarez D. Etape 2 : reliez C a D.\n",
+    "# Indice : t.add_premise(\"D\") puis t.add_justification(\"C\", in_list=[\"D\"])\n",
+    "resultat = None  # TODO etudiant : t.summary()\n",
+    "print(resultat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53677ac8",
+   "metadata": {},
+   "source": [
+    "## 4. Retractation et cascade : le coeur non-monotone\n",
+    "\n",
+    "La mecanique non-monotone se revele quand on **retracte** une croyance. `retract(name)` retire toutes les justifications dont la conclusion est `name` -- la croyance perd alors tout support direct. Au prochain `label()`, les croyances qui dependaient (transitivement) de `name` perdent a leur tour leur support et basculent OUT : c'est la **cascade**.\n",
+    "\n",
+    "C'est l'ecart fondamental avec la logique monotone du rung 2-formal : la, une formule etablie l'etait pour toujours ; ici, retracter une fondation **defait** les conclusions qui en descendaient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2c203908",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.622243Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.622064Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.624928Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.624478Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AVANT retractation :\n",
+      "  A                    = IN\n",
+      "  B                    = IN\n",
+      "  C                    = IN\n",
+      "\n",
+      "APRES retractation de A :\n",
+      "  A                    = OUT\n",
+      "  B                    = OUT\n",
+      "  C                    = OUT\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [6] - Cascade de retractation\n",
+    "t = JTMS()\n",
+    "t.add_premise(\"A\")\n",
+    "t.add_justification(\"B\", in_list=[\"A\"])\n",
+    "t.add_justification(\"C\", in_list=[\"B\"])\n",
+    "\n",
+    "print(\"AVANT retractation :\")\n",
+    "print(t.summary())\n",
+    "\n",
+    "t.retract(\"A\")        # on retire le soutien direct de A\n",
+    "print(\"\\nAPRES retractation de A :\")\n",
+    "print(t.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "074431bb",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la cascade\n",
+    "\n",
+    "**Sortie attendue** : avant retractation, `A=B=C=IN`. Apres, `A=B=C=OUT`. Retirer le soutien de `A` a fait chuter `B` (qui ne tenait qu'a `A`), puis `C` (qui ne tenait qu'a `B`). Le graphe s'est re-etiquete de fondation en sommet.\n",
+    "\n",
+    "C'est precisement la mecanique qu'il faut pour l'analyse argumentative : quand une premisse est discreditee (par exemple un appel a l'autorite detecte), les conclusions qui s'appuyaient dessus doivent tomber **automatiquement**, sans qu'on ait a re-deriver la chaine a la main."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8995f9de",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : predisez la cascade avant de l'executer\n",
+    "\n",
+    "**Contexte** : un graphe en diamant -- `D` soutient `B` et `C`, qui soutiennent tous deux `E`.\n",
+    "\n",
+    "**Objectif** : avant de lancer le code, notez sur papier le statut de `B`, `C`, `E` apres retractation de `D`. Puis codez-le et verifiez."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "14ef8030",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.626303Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.626193Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.629068Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.628272Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (JTMS) : graphe en diamant, predisez puis verifiez\n",
+    "# TODO etudiant : construisez A(premisse) -> B,C -> E, retractez A, affichez.\n",
+    "# Etape 1 : t.add_premise(\"A\"). Etape 2 : B et C depuis A. Etape 3 : E depuis B et C.\n",
+    "# Etape 4 : t.retract(\"A\"). Etape 5 : print(t.summary()).\n",
+    "# Indice : E a une seule justification in_list=[B, C] (conjonction) ->\n",
+    "#           des que B ou C tombe, E tombe aussi.\n",
+    "resultat = None  # TODO etudiant\n",
+    "print(resultat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4f8167a",
+   "metadata": {},
+   "source": [
+    "## 5. Detection de circularite : les odd loops\n",
+    "\n",
+    "Un piege subtil du raisonnement non-monotone est la **circularite de support** : si `A` n'est soutenu que par `B`, et `B` que par `A`, aucune des deux croyances n'a de fondation independante. C'est un **odd loop** (boucle etrangere).\n",
+    "\n",
+    "L'algorithme monotone de la section 3 le gere **silencieusement** : ni `A` ni `B` n'est jamais promu, donc les deux restent OUT. Mais il est crucial de le **detecter** et de le signaler : une croyance OUT « par manque de fondation » (un fait absent) et une croyance OUT « par circularite » (un defaut de structure) ne signifient pas la meme chose. La seconde revele une anomalie de modelisation qu'il faut corriger.\n",
+    "\n",
+    "`find_circular()` construit le graphe des soutiens positifs, en extrait les composantes fortement connexes (algorithme de Tarjan) et signale les croyances OUT appartenant a un cycle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6e652608",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.630547Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.630370Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.633210Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.632680Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Odd loop A <-> B :\n",
+      "  A                    = OUT\n",
+      "  B                    = OUT\n",
+      "  --- circularite detectee : ['A', 'B']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [8] - Odd loop et sa detection\n",
+    "o = JTMS()\n",
+    "o.add_justification(\"A\", in_list=[\"B\"])    # A IN ssi B IN\n",
+    "o.add_justification(\"B\", in_list=[\"A\"])    # B IN ssi A IN  -> cycle A<->B\n",
+    "\n",
+    "print(\"Odd loop A <-> B :\")\n",
+    "print(o.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bc83a75",
+   "metadata": {},
+   "source": [
+    "### Interpretation : pourquoi la circularite casse le raisonnement\n",
+    "\n",
+    "**Sortie attendue** : `A = OUT`, `B = OUT`, suivis de `--- circularite detectee : ['A', 'B']`. L'etiquetage a laisse les deux croyances OUT (aucune fondation), et la detection a marque la paire comme circulaire.\n",
+    "\n",
+    "Comparez avec une croyance simplement « non soutenue » (une premisse absente) : elle est OUT elle aussi, mais **non** marquee circulaire. Distinguer ces deux causes d'OUT est la valeur ajoutee de `find_circular` : la circularite est un defaut de **modelisation** (le graphe est mal construit), pas un defaut de **fait** (une information manque). Un moteur TMS industriel rejette un jeu de justifications contenant un odd loop plutot que de l'accepter silencieusement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d548a856",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : construisez un odd loop de taille 3\n",
+    "\n",
+    "**Contexte** : un cycle de longueur 3 -- `A <- B`, `B <- C`, `C <- A` -- est lui aussi un odd loop non trivial.\n",
+    "\n",
+    "**Objectif** : construisez-le, verifiez que les trois croyances sont OUT et que `find_circular()` les signale toutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c4b46207",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.634473Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.634356Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.636740Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.636250Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (JTMS) : odd loop de taille 3\n",
+    "# TODO etudiant : A <- B, B <- C, C <- A. Affichez le summary.\n",
+    "# Etape 1-3 : trois add_justification formant le cycle. Etape 4 : print(t.summary()).\n",
+    "# Indice : la detection doit retourner {'A','B','C'}.\n",
+    "resultat = None  # TODO etudiant\n",
+    "print(resultat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "369b7e8b",
+   "metadata": {},
+   "source": [
+    "## 6. Application : detecter un sophisme et propager la retractation\n",
+    "\n",
+    "C'est la demonstration qui relie ce rung a la vocation de la serie. On modelise un argument simple :\n",
+    "\n",
+    "- **Premisse** : `expert_claims_X` -- « un expert affirme que X est vrai » (un appel a l'autorite potentiel).\n",
+    "- **Regle** : si l'expert affirme X, alors `X_is_true`.\n",
+    "- **Regle** : si X est vrai, alors on `decide_X`.\n",
+    "\n",
+    "L'etiquetage initial place les trois croyances IN. Puis un detecteur de sophismes (le rung [1-informal](./Argument_Analysis_Agentic-1-informal.ipynb) le fait sur du texte reel) identifie la premisse comme un **appel a l'autorite**. On retracte `expert_claims_X` ; la cascade defait `X_is_true` puis `decide_X`. La conclusion tombe sans intervention manuelle sur la chaine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d7e707ce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.638192Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.638062Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.641219Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.640704Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AVANT detection du sophisme :\n",
+      "  X_is_true            = IN\n",
+      "  decide_X             = IN\n",
+      "  expert_claims_X      = IN\n",
+      "\n",
+      "APRES retractation de l'autorite (cascade) :\n",
+      "  X_is_true            = OUT\n",
+      "  decide_X             = OUT\n",
+      "  expert_claims_X      = OUT\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [10] - Detecter un sophisme (appel a l'autorite) -> retracter -> propager\n",
+    "t = JTMS()\n",
+    "t.add_premise(\"expert_claims_X\")                        # « un expert affirme X »\n",
+    "t.add_justification(\"X_is_true\", in_list=[\"expert_claims_X\"])\n",
+    "t.add_justification(\"decide_X\", in_list=[\"X_is_true\"])\n",
+    "\n",
+    "print(\"AVANT detection du sophisme :\")\n",
+    "print(t.summary())\n",
+    "\n",
+    "# Le detecteur de sophismes (rung 1-informal) signale expert_claims_X\n",
+    "# comme un APPEL A L'AUTORITE -> on retracte la croyance compromise.\n",
+    "t.retract(\"expert_claims_X\")\n",
+    "\n",
+    "print(\"\\nAPRES retractation de l'autorite (cascade) :\")\n",
+    "print(t.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abe98117",
+   "metadata": {},
+   "source": [
+    "### Interpretation : du sophisme a la retractation\n",
+    "\n",
+    "**Sortie attendue** : avant, `expert_claims_X = X_is_true = decide_X = IN`. Apres, les trois sont OUT. La detection d'un seul sophisme a suffit a invalider la conclusion et la decision, parce que le graphe de justifications encodait explicitement **qui depend de qui**.\n",
+    "\n",
+    "C'est la promesse du raisonnement non-monotone outille : la detection d'un sophisme n'est pas une simple etiquette posée sur un texte, c'est un **evenement** qui se propage dans l'etat de croyance et defait ce qui n'etait soutenu que par le sophisme. La section suivante verse cet etat dans le conteneur partage de la serie."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c506112a",
+   "metadata": {},
+   "source": [
+    "## 7. Pont vers l'etat partage\n",
+    "\n",
+    "Les croyances etiquetees par le JTMS alimentent le meme **conteneur partage** que tous les rungs enrichissent : l'etat `UnifiedAnalysisState` du module `argumentation_lib` (une sous-classe de `RhetoricalAnalysisState` qui ajoute, entre autres, un champ `jtms_beliefs`). Le rung 1 y ecrit ses detections informelles, le rung 2 y attache des verdicts formels, le rung 3 y depose le resultat orchestre, et ce rung (5) y verse les croyances non-monotones du JTMS. Aucun LLM requis : on remplit l'etat a partir de notre moteur deterministe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1f503561",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T11:31:55.642527Z",
+     "iopub.status.busy": "2026-06-26T11:31:55.642369Z",
+     "iopub.status.idle": "2026-06-26T11:31:55.649595Z",
+     "shell.execute_reply": "2026-06-26T11:31:55.649106Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Croyances JTMS versees dans l'etat partage :\n",
+      "  jtms_1: {'name': 'X_is_true', 'valid': True, 'justifications': [['expert_claims_X']]}\n",
+      "  jtms_2: {'name': 'decide_X', 'valid': True, 'justifications': [['X_is_true']]}\n",
+      "  jtms_3: {'name': 'expert_claims_X', 'valid': True, 'justifications': [[]]}\n",
+      "Total : 3 croyances non-monotones dans l'etat.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule [12] - Pont : verser les croyances JTMS dans UnifiedAnalysisState\n",
+    "from argumentation_lib._shared_state import UnifiedAnalysisState\n",
+    "\n",
+    "# On reconstruit un JTMS propre (etat IN, avant toute retractation)\n",
+    "t = JTMS()\n",
+    "t.add_premise(\"expert_claims_X\")\n",
+    "t.add_justification(\"X_is_true\", in_list=[\"expert_claims_X\"])\n",
+    "t.add_justification(\"decide_X\", in_list=[\"X_is_true\"])\n",
+    "\n",
+    "etat = UnifiedAnalysisState(initial_text=\"Argument modele pour le pont JTMS\")\n",
+    "status = t.label()\n",
+    "for nom, statut in status.items():\n",
+    "    soutiens = [j.in_list for j in t.justifications if j.conclusion == nom]\n",
+    "    etat.add_jtms_belief(name=nom, valid=(statut == \"IN\"), justifications=soutiens)\n",
+    "\n",
+    "print(\"Croyances JTMS versees dans l'etat partage :\")\n",
+    "for bid, bdata in etat.jtms_beliefs.items():\n",
+    "    print(f\"  {bid}: {bdata}\")\n",
+    "print(f\"Total : {len(etat.jtms_beliefs)} croyances non-monotones dans l'etat.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4bc4cdb",
+   "metadata": {},
+   "source": [
+    "## 8. Conclusion et recapitulatif\n",
+    "\n",
+    "Ce rung a ouvert la **boite noire** du raisonnement non-monotone. La le rung [2-formal](./Argument_Analysis_Agentic-2-formal.ipynb) deleguait a un solveur externe, ici on a **construit** le moteur qui maintient un etat de croyance revisable : etiquetage par point fixe monotone, cascade de retractation, detection de circularite.\n",
+    "\n",
+    "### Tableau recapitulatif\n",
+    "\n",
+    "| Mecanisme | Ce qu'il fait | Pourquoi ca compte |\n",
+    "|-----------|---------------|--------------------|\n",
+    "| **Etiquetage IN/OUT** | Point fixe monotone sur le graphe de justifications | Distingue le soutenu du non-soutenu, converge toujours |\n",
+    "| **Cascade de retractation** | Retirer une fondation defait ses dependants | C'est l'essence du non-monotone : retracter != erreur de logique |\n",
+    "| **Detection d'odd loop** | Signale les cycles de support positif | Distingue « manque de fait » et « defaut de modelisation » |\n",
+    "\n",
+    "### Ce que vous avez appris\n",
+    "\n",
+    "- Un **JTMS** modelise des croyances reliees par des justifications IN/OUT, etiquetees par un calcul de point fixe.\n",
+    "- **Retracter** une croyance declenche une **cascade** qui defait les conclusions non-monotones -- exactement ce qu'il faut quand un sophisme discredite une premisse.\n",
+    "- Les **odd loops** (cycles de soutiens mutuels) sont des anomalies structurelles qu'un bon moteur detecte plutot que d'accepter silencieusement.\n",
+    "\n",
+    "### Prochaines etapes\n",
+    "\n",
+    "- **Revision de croyances AGM** : le JTMS est la brique algorithmique sur laquelle s'appuient les operations de revision (Alchourron, Gardenfors & Makinson, 1985). La serie **[Tweety](../Tweety/)** implemente ces operations dans le solveur (notebook 4).\n",
+    "- **Semantiques d'argumentation** : l'etiquetage IN/OUT est l'ancetre des etiquetages de Dung (IN/OUT/UNDECIDED). Le rung [2-formal](./Argument_Analysis_Agentic-2-formal.ipynb) section 6 les revisite via le solveur Tweety.\n",
+    "- **Preuve formelle** : la correction de l'algorithme de point fixe (terminaison, caracterisation well-founded) se formalise. La serie **[Lean](../Lean/)** est le cadre naturel pour cette formalisation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -52,6 +52,7 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | 3 | [Agentic-3-orchestration](Argument_Analysis_Agentic-3-orchestration.ipynb) | Orchestration : mini-DAG déterministe vs conversationnel (state-driven) | Coordination |
 | 3* | [Agentic-3-orchestration_agent](Argument_Analysis_Agentic-3-orchestration_agent.ipynb) | *(legacy)* Orchestration multi-agents (semantic_kernel) | Coordination |
 | 4 | [Agentic-4-capstone](Argument_Analysis_Agentic-4-capstone.ipynb) | Capstone : baseline 0-shot vs pipeline intégral, verdicts convergents + value-gates VG-1..VG-4 | Intégration |
+| 5 | [Agentic-5-jtms](Argument_Analysis_Agentic-5-jtms.ipynb) | Truth Maintenance System déterministe (Doyle 1979) : étiquetage IN/OUT, cascade de rétractation, détection d'odd loops — pur stdlib Python | Raisonnement non-monotone |
 | UI | [UI_configuration](Argument_Analysis_UI_configuration.ipynb) | Interface utilisateur widgets | Interaction |
 | Exec | [Executor](Argument_Analysis_Executor.ipynb) | Orchestrateur principal | Exécution |
 
@@ -65,6 +66,7 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | **2-formal** | Vérifier des arguments en logique propositionnelle, du premier ordre et modale avec le solveur réel Tweety (JVM/JPype), apéru Dung — mode fail-loud, jamais simulé | 45 min |
 | **2-pl_agent** *(legacy)* | Convertir les arguments informels en formules propositionnelles et les vérifier via SAT | 60 min |
 | **3-orchestration** | Composer les agents précédents en pipeline coordonné avec rapport de sortie structuré | 50 min |
+| **5-jtms** | Construire un moteur de croyances non-monotones (étiquetage IN/OUT, cascade de rétractation, détection d'odd loops) en pur stdlib Python, sans LLM ni solveur externe | 40 min |
 | **UI_configuration** | Créer une interface interactive (ipywidgets) pour piloter le pipeline en mode exploratoire | 30 min |
 | **Executor** | Exécuter le pipeline complet en mode batch (Papermill/MCP) avec configuration .env | 20 min |
 


### PR DESCRIPTION
## Summary

Adds `Argument_Analysis_Agentic-5-jtms.ipynb` — rung 5 of the Argument_Analysis series: a pure-stdlib Python implementation of a **Justification-based Truth Maintenance System** (Doyle 1979). This is the authentic non-gated grain scoped after eliminating option (b) firsthand (see context below).

**Greenlight**: ai-01 dispatch 2026-06-26 12:51Z (DM, HIGH, verified gh firsthand) — `(c) notebook mini-JTMS deterministe from scratch`.

## What the notebook does

A real non-monotonic reasoning engine (0 LLM, 0 JVM, 0 solver — pur stdlib), demonstrating three mechanisms that exercise a non-degenerate algorithm (Prong B):

| Mechanism | What | Why it's non-trivial |
|---|---|---|
| **IN/OUT labeling** | Monotone fixpoint: start all OUT, promote to IN when a justification holds (all `in_list` IN, all `out_list` OUT) | Converges guaranteed (finite OUT->IN transitions); odd loops stay OUT because no independent foundation |
| **Retraction cascade** | `retract(name)` drops justifications concluding `name`; relabeling flips transitively-dependent beliefs to OUT | This *is* non-monotonicity: retracting a foundation undoes derived conclusions without manual re-derivation |
| **Odd-loop detection** | Tarjan SCC on the positive-support graph flags beliefs OUT *because* they sit in a mutual-support cycle | Distinguishes "missing fact" (OUT) from "modeling defect" (circular OUT) — a real TMS rejects odd loops rather than accepting them silently |

**Application demo** (§6): model an argument (expert claims X → X is true → decide X). The informal fallacy detector flags the premise as appeal-to-authority → retract it → the conclusion `X_is_true` and decision `decide_X` cascade to OUT automatically. This is the pedagogical payoff: a detected fallacy is an *event* that propagates through the belief state.

**Bridge** (§7): verses labeled beliefs into `UnifiedAnalysisState.jtms_beliefs` (the subclass extending `RhetoricalAnalysisState` with the JTMS field) — the shared container all rungs populate. No LLM needed.

## Validation (H.1)

- **Execution**: `jupyter nbconvert --execute --inplace` (kernel `python3`, timeout 180s), cwd = notebook dir (for `argumentation_lib` import). **0 errors.** Writes 32913 bytes.
- **C.2**: all 9 code cells have `execution_count` 1-9 + coherent outputs (verified).
- **C.1**: `grep -nE "raise NotImplementedError|assert False|1/0"` → **0 matches**. Exercises are stubs (`result = None  # TODO etudiant`).
- **3 exercises** (Exercice 1 support disjonctif, Exercice 2 diamond graph cascade prediction, Exercice 3 size-3 odd loop) cohabit with worked examples.
- **CATALOG-STATUS marker**: byte-identical (diff = +2 prose rows in notebook/competency tables only).
- **Unit-tested the JTMS engine** before notebook authoring: acyclic chain (all IN), cascade after retract (all OUT), odd loop (stays OUT + detected), mixed graph (premise IN + odd loop flagged) — 4/4 test cases pass.

## SOTA verdict (EPIC #3801, Prong A/B)

- **Prong A — SOTA-OK**: pur stdlib Python IS the appropriate tool for an *algorithmic concept* (TMS mechanics). No workaround, no degraded output, no external solver needed — the concept IS the implementation.
- **Prong B — non-degenerate**: the three mechanisms (fixpoint labeling, cascade, Tarjan SCC) are real algorithms with real complexity, not BFS-vs-A* triviality. Removing any one of them breaks the engine.

## Context: why this grain, not option (b)

Option (b) "adapt `_state_manager_plugin` JTMS to deterministic" was **eliminated firsthand** (G.1, documented to `argumentation_lib` memory):
1. `_state_manager_plugin.py` is a layer of **33 `@kernel_function` wrappers** (SK-only) — its sole role is the decorator exposing methods as LLM-callable tools. Nothing to "adapt" (like adapting a menu to be deterministic).
2. The 5 JTMS methods (L370-656) all start with `raise ImportError("JTMS not available in CoursIA pedagogical mode")` — the JTMS code below is **dead unreachable**, referencing `JTMSSession` (not present in repo).
3. In `_shared_state.py`, "JTMS" is a flat dict store + a `jtms_retraction_chain` field declared but never populated. **No real TMS machinery existed in the repo.**

So the only authentic non-gated grain was to *create* a real TMS from scratch — this PR.

## Files

- `Argument_Analysis_Agentic-5-jtms.ipynb` (NEW, 25 cells, executed with outputs)
- `README.md` (+2 prose rows: notebook table + competency table; CATALOG-STATUS byte-identical)

See #2137

🤖 Generated with [Claude Code](https://claude.com/claude-code)