### PR TITLE
fix(qcpy06): ground options strategy backtest tables in real QC Cloud (#3845)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -891,7 +891,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "> **Resultats backtest QC Cloud** : CoveredCallStrategy (2023, $50k) — 26 ordres, Net Profit +12.9%, Sharpe 0.608, CAGR 13.0%, MaxDD 6.1%, Win Rate 57%. Performance solide : premium regulier + appreciation du sous-jacent SPY en 2023. MaxDD maitrise (6.1%). Strategie de revenu confirmee.",
+   "source": "> **Resultats backtest QC Cloud** : CoveredCallStrategy (2023, $50k) — 26 ordres, Net Profit +12.9%, Sharpe 0.608, CAGR 13.0%, MaxDD 6.1%, Win Rate 57%. Performance solide : premium regulier + appreciation du sous-jacent SPY en 2023. MaxDD maitrise (6.1%). Strategie de revenu confirmee.\n\n*Backtest QC Cloud verifie 2023 (projet 33409983, bt 86b0191aa6dc0d1c981d4b3c07bbda51) : Sharpe 0.608 / CAGR 13.016% / MaxDD 6.100% / 250 dates / PSR 66.8% (ground-truth QC Cloud). Ordres (26), Net Profit +12.9% et Win Rate 57% : valeurs descriptives de l'auteur (totalOrders et totalNetProfit non exposes par le wrapper API).*",
    "metadata": {}
   },
   {
@@ -1073,7 +1073,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "> **Resultats backtest QC Cloud** : ProtectivePutStrategy (2023 H1, $60k) — 13 ordres, Net Profit +8.1%, Sharpe 1.362, CAGR 17.0%, MaxDD 2.2%, Win Rate 33%. Excelle protection : MaxDD tres faible (2.2%) grace au put de couverture. Sharpe eleve car volatilite reduite. Le cout du put limite le gain mais protege efficacement.",
+   "source": "> **Resultats backtest QC Cloud** : ProtectivePutStrategy (2023 H1, $60k) — 13 ordres, Net Profit +8.1%, Sharpe 1.362, CAGR 17.0%, MaxDD 2.2%, Win Rate 33%. Excelle protection : MaxDD tres faible (2.2%) grace au put de couverture. Sharpe eleve car volatilite reduite. Le cout du put limite le gain mais protege efficacement.\n\n*Backtest QC Cloud verifie 2023 H1 (projet 33409983, bt 7d2ef26535e035cad14467ea3ded7a64) : Sharpe 1.362 / CAGR 16.968% / MaxDD 2.200% / 124 dates / PSR 86.1% (ground-truth QC Cloud). Ordres (13), Net Profit +8.1% et Win Rate 33% : valeurs descriptives de l'auteur (totalOrders et totalNetProfit non exposes par le wrapper API).*",
    "metadata": {}
   },
   {
@@ -1206,7 +1206,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "> **Resultats backtest QC Cloud** : BullCallSpreadStrategy (2023 H1, $10k) — 4 ordres, Net Profit +0.37%, Sharpe -3.2, CAGR 0.7%, MaxDD 0.7%, Win Rate 67%. Spread unique execute (Long Call ATM + Short Call OTM). Gain marginal, Sharpe negatif indique un rendement inferieur au risk-free.",
+   "source": "> **Resultats backtest QC Cloud** : BullCallSpreadStrategy (2023 H1, $10k) — 4 ordres, Net Profit +0.37%, Sharpe -3.2, CAGR 0.7%, MaxDD 0.7%, Win Rate 67%. Spread unique execute (Long Call ATM + Short Call OTM). Gain marginal, Sharpe negatif indique un rendement inferieur au risk-free.\n\n*Backtest QC Cloud verifie 2023 H1 (projet 33409983, bt d6128b1a11e2123562634da90711ec77) : Sharpe -3.2 / CAGR 0.748% / MaxDD 0.700% / 124 dates / PSR 29.6% (ground-truth QC Cloud). Ordres (4), Net Profit +0.37% et Win Rate 67% : valeurs descriptives de l'auteur (totalOrders et totalNetProfit non exposes par le wrapper API).*",
    "metadata": {}
   },
   {


### PR DESCRIPTION
## Summary

#3845 (QC-Py fabricated backtest tables sweep) — deep-queue #1. The 3 suspect tables in **QC-Py-06-Options-Trading** (cells 28/33/36: `CoveredCallStrategy`, `ProtectivePutStrategy`, `BullCallSpreadStrategy`) presented backtest metrics **without QC Cloud citations**. G.1 firsthand verification shows they are **honest-but-uncited**, not fabricated: every claimed Sharpe/CAGR/MaxDD matches a real QC Cloud backtest exactly. This PR adds the missing `bt-id` citations.

## Ground-truth (verified 2026-06-26 via `qc-mcp-lite` `read_backtest`, projet 33409983)

| Cell | Strategy | bt-id | Markdown claim | Real Sharpe | Real CAGR | Real MaxDD | dates | PSR |
|------|----------|-------|----------------|-------------|-----------|------------|-------|-----|
| 28 | CoveredCall 2023 ($50k) | `86b0191a…` | 0.608 / 13.0% / 6.1% | **0.608** | **13.016%** | **6.100%** | 250 | 66.8% |
| 33 | ProtectivePut 2023 H1 ($60k) | `7d2ef265…` | 1.362 / 17.0% / 2.2% | **1.362** | **16.968%** | **2.200%** | 124 | 86.1% |
| 36 | BullCallSpread 2023 H1 ($10k) | `d6128b1a…` | -3.2 / 0.7% / 0.7% | **-3.2** | **0.748%** | **0.700%** | 124 | 29.6% |

**Verdict: 3/3 match.** Markdown metrics are accurate; only the `bt-id` citation was missing.

## Change

Each cell gets an additive citation footnote (markdown-only, original blockquote preserved verbatim):

> *Backtest QC Cloud verifie 2023 (projet 33409983, bt …) : Sharpe … / CAGR … / MaxDD … / N dates / PSR … (ground-truth QC Cloud). Ordres, Net Profit et Win Rate : valeurs descriptives de l'auteur (totalOrders et totalNetProfit non exposes par le wrapper API).*

The footnote honestly scopes what is ground-truth (Sharpe/CAGR/MaxDD/dates/PSR) vs. what are author descriptive values (order counts, Net Profit, Win Rate — `totalOrders` always returns 0 and `totalNetProfit` returns `-` in the wrapper API, so these cannot be independently verified).

## Validation

- `nbformat.validate` → **VALID** (54 cells)
- Code cells **byte-identical** before/after (markdown-only edit; C.2 exception — no re-execution needed)
- C.1 scan → **0 violations** (`raise NotImplementedError` / `assert False` / `1/0`)
- `git diff --stat` → 1 file, +3/-3 (only the 3 markdown source strings)
- Catalogue **byte-identical** to origin/main (no churn — left to the cron/CI)
- Surgical text replacement (no `json` round-trip; round-trip reformats unrelated cells)

## Pattern

Matches the user's established precedent (#3849 QC-Py-09, #3860 QC-Py-14/16): deploy → run real QC Cloud backtests → align markdown to ground-truth. Since metrics matched, this adds citations rather than replacing values.

See #3845
