### PR TITLE
fix(smartcontracts): invoke real solc SMTChecker in SC-14 (Stop & Repair, #3801)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -3,39 +3,29 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "d0f799a5",
+   "id": "088216f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.672272Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.672017Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.677532Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.676997Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.156799Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.156619Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.160657Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.159853Z"
     },
     "papermill": {
-     "duration": 0.010297,
-     "end_time": "2026-06-03T07:41:13.678078+00:00",
+     "duration": 0.008906,
+     "end_time": "2026-06-26T11:58:55.161226+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.667781+00:00",
+     "start_time": "2026-06-26T11:58:55.152320+00:00",
      "status": "completed"
     },
     "tags": [
      "injected-parameters"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BATCH_MODE = true\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Parameters\n",
-    "BATCH_MODE = \"true\"\n",
-    "\n",
-    "print(f\"BATCH_MODE = {BATCH_MODE}\")\n"
+    "BATCH_MODE = \"true\"\n"
    ]
   },
   {
@@ -43,10 +33,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.002154,
-     "end_time": "2026-06-03T07:41:13.682787+00:00",
+     "duration": 0.002645,
+     "end_time": "2026-06-26T11:58:55.166888+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.680633+00:00",
+     "start_time": "2026-06-26T11:58:55.164243+00:00",
      "status": "completed"
     },
     "tags": []
@@ -79,10 +69,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.00208,
-     "end_time": "2026-06-03T07:41:13.687065+00:00",
+     "duration": 0.002764,
+     "end_time": "2026-06-26T11:58:55.172521+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.684985+00:00",
+     "start_time": "2026-06-26T11:58:55.169757+00:00",
      "status": "completed"
     },
     "tags": []
@@ -101,16 +91,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.692163Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.691990Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.695386Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.694844Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.179715Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.179544Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.185260Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.184260Z"
     },
     "papermill": {
-     "duration": 0.006991,
-     "end_time": "2026-06-03T07:41:13.696082+00:00",
+     "duration": 0.010231,
+     "end_time": "2026-06-26T11:58:55.185996+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.689091+00:00",
+     "start_time": "2026-06-26T11:58:55.175765+00:00",
      "status": "completed"
     },
     "tags": []
@@ -166,10 +156,10 @@
    "id": "7cb61525",
    "metadata": {
     "papermill": {
-     "duration": 0.004494,
-     "end_time": "2026-06-03T07:41:13.703065+00:00",
+     "duration": 0.003124,
+     "end_time": "2026-06-26T11:58:55.192376+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.698571+00:00",
+     "start_time": "2026-06-26T11:58:55.189252+00:00",
      "status": "completed"
     },
     "tags": []
@@ -201,10 +191,10 @@
    "id": "cell-3",
    "metadata": {
     "papermill": {
-     "duration": 0.00206,
-     "end_time": "2026-06-03T07:41:13.707447+00:00",
+     "duration": 0.003091,
+     "end_time": "2026-06-26T11:58:55.198595+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.705387+00:00",
+     "start_time": "2026-06-26T11:58:55.195504+00:00",
      "status": "completed"
     },
     "tags": []
@@ -223,16 +213,16 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.712944Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.712667Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.716114Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.715431Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.206348Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.206136Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.210098Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.209172Z"
     },
     "papermill": {
-     "duration": 0.007022,
-     "end_time": "2026-06-03T07:41:13.716655+00:00",
+     "duration": 0.008844,
+     "end_time": "2026-06-26T11:58:55.210792+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.709633+00:00",
+     "start_time": "2026-06-26T11:58:55.201948+00:00",
      "status": "completed"
     },
     "tags": []
@@ -308,10 +298,10 @@
    "id": "zggas8edupp",
    "metadata": {
     "papermill": {
-     "duration": 0.002137,
-     "end_time": "2026-06-03T07:41:13.720958+00:00",
+     "duration": 0.003429,
+     "end_time": "2026-06-26T11:58:55.217673+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.718821+00:00",
+     "start_time": "2026-06-26T11:58:55.214244+00:00",
      "status": "completed"
     },
     "tags": []
@@ -326,16 +316,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.726476Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.726236Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.730040Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.729190Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.225439Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.225257Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.229070Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.228358Z"
     },
     "papermill": {
-     "duration": 0.007349,
-     "end_time": "2026-06-03T07:41:13.730567+00:00",
+     "duration": 0.008587,
+     "end_time": "2026-06-26T11:58:55.229661+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.723218+00:00",
+     "start_time": "2026-06-26T11:58:55.221074+00:00",
      "status": "completed"
     },
     "tags": []
@@ -465,10 +455,10 @@
    "id": "aa7fbf0f",
    "metadata": {
     "papermill": {
-     "duration": 0.002218,
-     "end_time": "2026-06-03T07:41:13.735093+00:00",
+     "duration": 0.003302,
+     "end_time": "2026-06-26T11:58:55.236532+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.732875+00:00",
+     "start_time": "2026-06-26T11:58:55.233230+00:00",
      "status": "completed"
     },
     "tags": []
@@ -496,10 +486,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.00225,
-     "end_time": "2026-06-03T07:41:13.739627+00:00",
+     "duration": 0.002968,
+     "end_time": "2026-06-26T11:58:55.242652+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.737377+00:00",
+     "start_time": "2026-06-26T11:58:55.239684+00:00",
      "status": "completed"
     },
     "tags": []
@@ -518,16 +508,16 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.745066Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.744900Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.747758Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.747223Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.249534Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.249313Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.252267Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.251724Z"
     },
     "papermill": {
-     "duration": 0.006412,
-     "end_time": "2026-06-03T07:41:13.748268+00:00",
+     "duration": 0.007426,
+     "end_time": "2026-06-26T11:58:55.252924+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.741856+00:00",
+     "start_time": "2026-06-26T11:58:55.245498+00:00",
      "status": "completed"
     },
     "tags": []
@@ -591,10 +581,10 @@
    "id": "1559224e",
    "metadata": {
     "papermill": {
-     "duration": 0.002277,
-     "end_time": "2026-06-03T07:41:13.752882+00:00",
+     "duration": 0.002856,
+     "end_time": "2026-06-26T11:58:55.258736+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.750605+00:00",
+     "start_time": "2026-06-26T11:58:55.255880+00:00",
      "status": "completed"
     },
     "tags": []
@@ -622,16 +612,16 @@
    "id": "8cad6e96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.758815Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.758639Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.762232Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.761706Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.266003Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.265751Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.269982Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.269306Z"
     },
     "papermill": {
-     "duration": 0.007432,
-     "end_time": "2026-06-03T07:41:13.762755+00:00",
+     "duration": 0.008809,
+     "end_time": "2026-06-26T11:58:55.270537+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.755323+00:00",
+     "start_time": "2026-06-26T11:58:55.261728+00:00",
      "status": "completed"
     },
     "tags": []
@@ -651,7 +641,7 @@
       "    mapping(address => uint256) public balances;\n",
       "    uint256 public totalDeposits;\n",
       "\n",
-      "    /// @custom:Invariant totalDeposits == sum(balances)\n",
+      "    /// @custom:invariant totalDeposits == sum(balances)\n",
       "    function deposit() external payable {\n",
       "        balances[msg.sender] += msg.value;\n",
       "        totalDeposits += msg.value;\n",
@@ -694,7 +684,7 @@
     "    mapping(address => uint256) public balances;\n",
     "    uint256 public totalDeposits;\n",
     "\n",
-    "    /// @custom:Invariant totalDeposits == sum(balances)\n",
+    "    /// @custom:invariant totalDeposits == sum(balances)\n",
     "    function deposit() external payable {\n",
     "        balances[msg.sender] += msg.value;\n",
     "        totalDeposits += msg.value;\n",
@@ -732,10 +722,10 @@
    "id": "712bd485",
    "metadata": {
     "papermill": {
-     "duration": 0.002394,
-     "end_time": "2026-06-03T07:41:13.767687+00:00",
+     "duration": 0.00307,
+     "end_time": "2026-06-26T11:58:55.276977+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.765293+00:00",
+     "start_time": "2026-06-26T11:58:55.273907+00:00",
      "status": "completed"
     },
     "tags": []
@@ -764,16 +754,16 @@
    "id": "6d3830e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.773574Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.773282Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.777315Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.776663Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.283617Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.283472Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.568436Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.567547Z"
     },
     "papermill": {
-     "duration": 0.007777,
-     "end_time": "2026-06-03T07:41:13.777852+00:00",
+     "duration": 0.289314,
+     "end_time": "2026-06-26T11:58:55.569262+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.770075+00:00",
+     "start_time": "2026-06-26T11:58:55.279948+00:00",
      "status": "completed"
     },
     "tags": []
@@ -783,109 +773,131 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Compilation avec SMTChecker ===\n",
-      "\n",
-      "$ solc VaultSMT.sol\n",
-      "\n",
-      "Sortie attendue (contrat correct) :\n",
-      "\n",
-      "Warning: Assertion checker does not yet implement this type of call.\n",
-      "  --> VaultSMT.sol:25:9:\n",
-      "   |\n",
-      "25 |         payable(msg.sender).transfer(amount);\n",
-      "   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "\n",
-      "Info: Assertion check succeeded.\n",
-      "  --> VaultSMT.sol:21:9:\n",
-      "   |\n",
-      "21 |         assert(balances[msg.sender] >= 0);\n",
-      "   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "\n",
-      "Info: Assertion check succeeded.\n",
-      "  --> VaultSMT.sol:30:9:\n",
-      "   |\n",
-      "30 |         assert(totalDeposits >= 0);\n",
-      "   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "\n",
-      "==================================================\n",
-      "\n",
-      "=== Cas avec bug intentionnel ===\n",
-      "\n",
-      "Code buggy :\n",
-      "\n",
-      "// Bug : reentrancy non protegee\n",
-      "function withdrawBuggy(uint256 amount) external {\n",
-      "    require(balances[msg.sender] >= amount);\n",
-      "    payable(msg.sender).transfer(amount);  // Transfer AVANT mise a jour\n",
-      "    balances[msg.sender] -= amount;         // Etat incoherent ici\n",
-      "    totalDeposits -= amount;\n",
-      "}\n",
-      "\n",
-      "Sortie SMTChecker (detection du bug) :\n",
-      "\n",
-      "Warning: Assertion violation happens here.\n",
-      "  --> VaultSMT.sol:XX:9:\n",
-      "   |\n",
-      "XX |         assert(balances[msg.sender] >= 0);\n",
-      "   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "Counterexample:\n",
-      "  msg.sender = 0x1, amount = 100, balances[0x1] = 100\n",
-      "  After transfer: balances[0x1] still 100 (not yet decremented)\n",
-      "  Reentrant call could drain funds before state update.\n",
+      "=== Contrat VaultSMT (sain) ===\n",
+      "$ solc.exe --model-checker-engine all sc14_smtcheck.sol\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: Solver z3 was selected for SMTChecker but it is not available.\n",
+      "\n",
+      "Warning: The SMTChecker pragma has been deprecated and will be removed in the future. Please use the \"model checker engine\" compiler setting to activate the SMTChecker instead. If the pragma is enabled, all engines will be used.\n",
+      " --> sc14_smtcheck.sol:4:1:\n",
+      "  |\n",
+      "4 | pragma experimental SMTChecker;\n",
+      "  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "\n",
+      "Warning: CHC analysis was not possible since no Horn solver was found and enabled. The accepted solvers for CHC are Eldarica and z3.\n",
+      "\n",
+      "Warning: BMC analysis was not possible since no SMT solver was found and enabled. The accepted solvers for BMC are cvc5 and z3.\n",
+      "\n",
+      "[code de sortie solc : 0]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "============================================================\n",
+      "\n",
+      "=== Contrat VaultBuggy (reentrancy) ===\n",
+      "$ solc.exe --model-checker-engine all sc14_smtcheck.sol\n",
+      "\n",
+      "Warning: Solver z3 was selected for SMTChecker but it is not available.\n",
+      "\n",
+      "Warning: The SMTChecker pragma has been deprecated and will be removed in the future. Please use the \"model checker engine\" compiler setting to activate the SMTChecker instead. If the pragma is enabled, all engines will be used.\n",
+      " --> sc14_smtcheck.sol:4:1:\n",
+      "  |\n",
+      "4 | pragma experimental SMTChecker;\n",
+      "  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "\n",
+      "Warning: CHC analysis was not possible since no Horn solver was found and enabled. The accepted solvers for CHC are Eldarica and z3.\n",
+      "\n",
+      "Warning: BMC analysis was not possible since no SMT solver was found and enabled. The accepted solvers for BMC are cvc5 and z3.\n",
+      "\n",
+      "[code de sortie solc : 0]\n"
      ]
     }
    ],
    "source": [
-    "# Sortie reelle du compilateur Solidity avec SMTChecker\n",
-    "# (reproduit depuis la documentation Solidity et des tests reels)\n",
-    "print(\"=== Compilation avec SMTChecker ===\\n\")\n",
-    "print(\"$ solc VaultSMT.sol\\n\")\n",
-    "print(\"Sortie attendue (contrat correct) :\\n\")\n",
-    "print(\"\"\"Warning: Assertion checker does not yet implement this type of call.\n",
-    "  --> VaultSMT.sol:25:9:\n",
-    "   |\n",
-    "25 |         payable(msg.sender).transfer(amount);\n",
-    "   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+    "# Invocation REELLE du compilateur Solidity avec SMTChecker\n",
+    "# (Stop & Repair : la version precedente hardcodait une sortie supposee \"reelle\".\n",
+    "#  On invoque maintenant le vrai binaire solc et on affiche sa sortie effective.\n",
+    "#  Le .sol est ecrit en chemin relatif (cwd) pour garder une sortie propre, sans\n",
+    "#  chemin machine - regle secrets-hygiene case A : on corrige la source, jamais la sortie.)\n",
+    "import subprocess, os, shutil\n",
     "\n",
-    "Info: Assertion check succeeded.\n",
-    "  --> VaultSMT.sol:21:9:\n",
-    "   |\n",
-    "21 |         assert(balances[msg.sender] >= 0);\n",
-    "   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+    "def _locate_solc() -> str:\n",
+    "    \"\"\"Localise le binaire solc installe (solcx, puis PATH).\"\"\"\n",
+    "    try:\n",
+    "        import solcx\n",
+    "        if hasattr(solcx, \"get_executable\"):\n",
+    "            return solcx.get_executable(\"0.8.28\")\n",
+    "        # solcx ancienne API : construire le chemin depuis le dossier d'installation\n",
+    "        bin_dir = os.path.join(solcx.get_solcx_install_folder(), \"solc-v0.8.28\")\n",
+    "        for name in (\"solc.exe\", \"solc\"):\n",
+    "            cand = os.path.join(bin_dir, name)\n",
+    "            if os.path.isfile(cand):\n",
+    "                return cand\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    return shutil.which(\"solc\") or \"solc\"\n",
     "\n",
-    "Info: Assertion check succeeded.\n",
-    "  --> VaultSMT.sol:30:9:\n",
-    "   |\n",
-    "30 |         assert(totalDeposits >= 0);\n",
-    "   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-    "\"\"\")\n",
+    "def run_smtchecker(contract_code: str, label: str) -> None:\n",
+    "    \"\"\"Invoque le vrai solc avec le model checker SMT et affiche sa sortie reelle.\"\"\"\n",
+    "    rel_path = \"sc14_smtcheck.sol\"\n",
+    "    with open(rel_path, \"w\", encoding=\"utf-8\") as f:\n",
+    "        f.write(contract_code)\n",
+    "    try:\n",
+    "        solc_bin = _locate_solc()\n",
+    "        print(f\"=== {label} ===\")\n",
+    "        print(f\"$ {os.path.basename(solc_bin)} --model-checker-engine all {rel_path}\\n\")\n",
+    "        try:\n",
+    "            res = subprocess.run(\n",
+    "                [solc_bin, \"--model-checker-engine\", \"all\", rel_path],\n",
+    "                capture_output=True, text=True, timeout=120,\n",
+    "            )\n",
+    "        except FileNotFoundError:\n",
+    "            print(\"[solc introuvable : installer solc (solcx install_solc 0.8.28) pour executer SMTChecker]\")\n",
+    "            return\n",
+    "        # SMTChecker emet ses diagnostics (warnings/contre-exemples) sur stderr\n",
+    "        diag = (res.stderr + (\"\\n\" + res.stdout if res.stdout.strip() else \"\")).strip()\n",
+    "        print(diag if diag else \"(compilation reussie, aucun diagnostique)\")\n",
+    "        print(f\"\\n[code de sortie solc : {res.returncode}]\")\n",
+    "    finally:\n",
+    "        if os.path.exists(rel_path):\n",
+    "            os.unlink(rel_path)\n",
     "\n",
-    "print(\"=\" * 50)\n",
-    "print(\"\\n=== Cas avec bug intentionnel ===\\n\")\n",
+    "# 1) Contrat sain : checks-effects-interactions respecte (etat mis a jour AVANT le transfer)\n",
+    "run_smtchecker(vault_smt_code, \"Contrat VaultSMT (sain)\")\n",
     "\n",
-    "buggy_code = \"\"\"\n",
-    "// Bug : reentrancy non protegee\n",
-    "function withdrawBuggy(uint256 amount) external {\n",
-    "    require(balances[msg.sender] >= amount);\n",
-    "    payable(msg.sender).transfer(amount);  // Transfer AVANT mise a jour\n",
-    "    balances[msg.sender] -= amount;         // Etat incoherent ici\n",
-    "    totalDeposits -= amount;\n",
+    "# 2) Contrat buggy : reentrancy (transfer AVANT mise a jour de l'etat)\n",
+    "vault_buggy_code = \"\"\"\n",
+    "// SPDX-License-Identifier: MIT\n",
+    "pragma solidity ^0.8.28;\n",
+    "pragma experimental SMTChecker;\n",
+    "contract VaultBuggy {\n",
+    "    mapping(address => uint256) public balances;\n",
+    "    uint256 public totalDeposits;\n",
+    "    function deposit() external payable {\n",
+    "        balances[msg.sender] += msg.value;\n",
+    "        totalDeposits += msg.value;\n",
+    "    }\n",
+    "    function withdraw(uint256 amount) external {\n",
+    "        require(balances[msg.sender] >= amount, \"Insufficient balance\");\n",
+    "        payable(msg.sender).transfer(amount);  // BUG : transfer AVANT mise a jour\n",
+    "        balances[msg.sender] -= amount;\n",
+    "        totalDeposits -= amount;\n",
+    "        assert(balances[msg.sender] >= 0);\n",
+    "    }\n",
     "}\n",
     "\"\"\"\n",
-    "print(\"Code buggy :\\n\" + buggy_code)\n",
-    "\n",
-    "print(\"Sortie SMTChecker (detection du bug) :\\n\")\n",
-    "print(\"\"\"Warning: Assertion violation happens here.\n",
-    "  --> VaultSMT.sol:XX:9:\n",
-    "   |\n",
-    "XX |         assert(balances[msg.sender] >= 0);\n",
-    "   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-    "Counterexample:\n",
-    "  msg.sender = 0x1, amount = 100, balances[0x1] = 100\n",
-    "  After transfer: balances[0x1] still 100 (not yet decremented)\n",
-    "  Reentrant call could drain funds before state update.\n",
-    "\"\"\")"
+    "print(\"\\n\" + \"=\" * 60 + \"\\n\")\n",
+    "run_smtchecker(vault_buggy_code, \"Contrat VaultBuggy (reentrancy)\")"
    ]
   },
   {
@@ -893,10 +905,10 @@
    "id": "4437cfa5",
    "metadata": {
     "papermill": {
-     "duration": 0.002453,
-     "end_time": "2026-06-03T07:41:13.782848+00:00",
+     "duration": 0.003695,
+     "end_time": "2026-06-26T11:58:55.576962+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.780395+00:00",
+     "start_time": "2026-06-26T11:58:55.573267+00:00",
      "status": "completed"
     },
     "tags": []
@@ -904,7 +916,9 @@
    "source": [
     "### Interpretation : SMTChecker vs Certora\n",
     "\n",
-    "**Resultat obtenu** : Deux approches complementaires pour la verification formelle.\n",
+    "**Resultat obtenu** : invocation reelle du binaire solc (`--model-checker-engine all`) sur les deux contrats. Sur ce build solc (Windows statique), **aucun solveur SMT (z3/cvc5) n'est lie au binaire** : SMTChecker signale `Solver z3 was selected ... but it is not available` et `CHC/BMC analysis was not possible since no SMT solver was found`. Les contrats compilent, mais l'analyse formelle ne s'est **pas executee** ici.\n",
+    "\n",
+    "**Verdict (EPIC #3801, axe-2 SOTA) : RECOVERABLE-MACHINE.** Le vrai outil SOTA (solc SMTChecker) fonctionne sur un binaire solc compile avec z3 — typiquement le binaire statique Linux de soliditylang.org ou `apt install solc z3`. Sur cette machine (solc Windows sans z3 lie, WSL sans solc), le contre-exemple reel n'est pas atteignable ; il faut re-executer sur une machine Linux+z3 pour le voir.\n",
     "\n",
     "| Aspect | SMTChecker | Certora Prover |\n",
     "|--------|------------|----------------|\n",
@@ -912,12 +926,9 @@
     "| **Langage** | Solidity (`assert`) | CVL (spec separee) |\n",
     "| **Cout** | Gratuit | Commercial |\n",
     "| **Couverture** | Limitations (boucles) | Tres complet |\n",
+    "| **Dependance** | Solveur z3/cvc5 lie au binaire solc | Solveur SMT interne |\n",
     "\n",
-    "**Points cles** :\n",
-    "- SMTChecker utilise des solveurs SMT (Z3, CVC5) pour verifier les `assert()` de maniere exhaustive\n",
-    "- Le code buggy avec reentrancy est detecte automatiquement : le model checker trouve un contre-exemple\n",
-    "- L'ordre des operations est critique : `transfer` AVANT `decrement` cree une fenetre de reentrancy\n",
-    "- Le pattern correct est \"checks-effects-interactions\" : mettre a jour l'etat AVANT les appels externes"
+    "**Forme attendue du contre-exemple** (reference, d'apres la documentation Solidity — *non produite par cette execution car solveur absent*) : pour `VaultBuggy`, SMTChecker genererait un `Counterexample` montrant qu'apres le `transfer` et avant le `decrement`, `balances[msg.sender]` reste incoherent avec `totalDeposits` — fenetre de reentrancy exploitable. Le pattern correct est \"checks-effects-interactions\" : mettre a jour l'etat AVANT les appels externes, ce que fait `VaultSMT`."
    ]
   },
   {
@@ -925,10 +936,10 @@
    "id": "fca07f44",
    "metadata": {
     "papermill": {
-     "duration": 0.002571,
-     "end_time": "2026-06-03T07:41:13.788034+00:00",
+     "duration": 0.003165,
+     "end_time": "2026-06-26T11:58:55.583571+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.785463+00:00",
+     "start_time": "2026-06-26T11:58:55.580406+00:00",
      "status": "completed"
     },
     "tags": []
@@ -936,7 +947,7 @@
    "source": [
     "**Interpretation** : SMTChecker explore symboliquement toutes les executions possibles du contrat. Quand une assertion peut echouer, il produit un **contre-exemple concret** montrant les valeurs d'entree qui declenchent le bug. C'est plus puissant que les tests fuzzy (qui echantillonnent) car la verification est exhaustive.\n",
     "\n",
-    "Dans l'exemple reentrancy, le model checker detecte que l'ordre `transfer` puis `decrement` cree une fenetre ou `balances[msg.sender]` est incoherent avec `totalDeposits`. Le fix est le pattern checks-effects-interactions : mettre a jour l'etat **avant** le transfer externe."
+    "**Caveat execution** : comme detaille dans la cellule precedente, sur ce build solc sans solveur SMT lie, l'analyse n'a pas pu tourner. La detection decrite ici est la *forme attendue* du resultat SMTChecker, atteignable en re-executant sur un solc compile avec z3 (Linux). Pour le contrat `VaultBuggy` (ou le `transfer` precede le `decrement`), le model checker trouverait que cet ordre cree une fenetre ou `balances[msg.sender]` est incoherent avec `totalDeposits`. Le fix est le pattern checks-effects-interactions : mettre a jour l'etat **avant** le transfer externe."
    ]
   },
   {
@@ -944,10 +955,10 @@
    "id": "c5dd69b6",
    "metadata": {
     "papermill": {
-     "duration": 0.00258,
-     "end_time": "2026-06-03T07:41:13.793248+00:00",
+     "duration": 0.003117,
+     "end_time": "2026-06-26T11:58:55.589943+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.790668+00:00",
+     "start_time": "2026-06-26T11:58:55.586826+00:00",
      "status": "completed"
     },
     "tags": []
@@ -977,16 +988,16 @@
    "id": "7c784dbc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.801158Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.800863Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.804585Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.803999Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.598218Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.597915Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.602231Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.601553Z"
     },
     "papermill": {
-     "duration": 0.009412,
-     "end_time": "2026-06-03T07:41:13.805116+00:00",
+     "duration": 0.00934,
+     "end_time": "2026-06-26T11:58:55.602872+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.795704+00:00",
+     "start_time": "2026-06-26T11:58:55.593532+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1051,10 +1062,10 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.002493,
-     "end_time": "2026-06-03T07:41:13.810338+00:00",
+     "duration": 0.004176,
+     "end_time": "2026-06-26T11:58:55.611461+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.807845+00:00",
+     "start_time": "2026-06-26T11:58:55.607285+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1073,16 +1084,16 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.816516Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.816329Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.820060Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.819433Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.620404Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.620180Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.624470Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.623726Z"
     },
     "papermill": {
-     "duration": 0.007743,
-     "end_time": "2026-06-03T07:41:13.820617+00:00",
+     "duration": 0.009724,
+     "end_time": "2026-06-26T11:58:55.625068+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.812874+00:00",
+     "start_time": "2026-06-26T11:58:55.615344+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1178,10 +1189,10 @@
    "id": "65a6a29d",
    "metadata": {
     "papermill": {
-     "duration": 0.002604,
-     "end_time": "2026-06-03T07:41:13.825964+00:00",
+     "duration": 0.00391,
+     "end_time": "2026-06-26T11:58:55.633042+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.823360+00:00",
+     "start_time": "2026-06-26T11:58:55.629132+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1213,16 +1224,16 @@
    "id": "eeec98bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.832045Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.831863Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.835108Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.834572Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.642062Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.641842Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.645741Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.644973Z"
     },
     "papermill": {
-     "duration": 0.007207,
-     "end_time": "2026-06-03T07:41:13.835648+00:00",
+     "duration": 0.009464,
+     "end_time": "2026-06-26T11:58:55.646461+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.828441+00:00",
+     "start_time": "2026-06-26T11:58:55.636997+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1276,10 +1287,10 @@
    "id": "cell-10",
    "metadata": {
     "papermill": {
-     "duration": 0.002619,
-     "end_time": "2026-06-03T07:41:13.840958+00:00",
+     "duration": 0.004022,
+     "end_time": "2026-06-26T11:58:55.654574+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.838339+00:00",
+     "start_time": "2026-06-26T11:58:55.650552+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1296,16 +1307,16 @@
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:13.847073Z",
-     "iopub.status.busy": "2026-06-03T07:41:13.846844Z",
-     "iopub.status.idle": "2026-06-03T07:41:13.850175Z",
-     "shell.execute_reply": "2026-06-03T07:41:13.849705Z"
+     "iopub.execute_input": "2026-06-26T11:58:55.664011Z",
+     "iopub.status.busy": "2026-06-26T11:58:55.663765Z",
+     "iopub.status.idle": "2026-06-26T11:58:55.668140Z",
+     "shell.execute_reply": "2026-06-26T11:58:55.667308Z"
     },
     "papermill": {
-     "duration": 0.007196,
-     "end_time": "2026-06-03T07:41:13.850670+00:00",
+     "duration": 0.0101,
+     "end_time": "2026-06-26T11:58:55.668834+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.843474+00:00",
+     "start_time": "2026-06-26T11:58:55.658734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1382,10 +1393,10 @@
    "id": "4bd27141",
    "metadata": {
     "papermill": {
-     "duration": 0.002467,
-     "end_time": "2026-06-03T07:41:13.855751+00:00",
+     "duration": 0.004072,
+     "end_time": "2026-06-26T11:58:55.677181+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.853284+00:00",
+     "start_time": "2026-06-26T11:58:55.673109+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1399,10 +1410,10 @@
    "id": "cell-12",
    "metadata": {
     "papermill": {
-     "duration": 0.002351,
-     "end_time": "2026-06-03T07:41:13.860484+00:00",
+     "duration": 0.004152,
+     "end_time": "2026-06-26T11:58:55.685395+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.858133+00:00",
+     "start_time": "2026-06-26T11:58:55.681243+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1450,10 +1461,10 @@
    "id": "17645a92",
    "metadata": {
     "papermill": {
-     "duration": 0.002313,
-     "end_time": "2026-06-03T07:41:13.865151+00:00",
+     "duration": 0.00384,
+     "end_time": "2026-06-26T11:58:55.693112+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.862838+00:00",
+     "start_time": "2026-06-26T11:58:55.689272+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1461,7 +1472,7 @@
    "source": [
     "## Resume et perspectives\n",
     "\n",
-    "Ce notebook a introduit la verification formelle des smart contracts, une approche qui complete les tests unitaires et le fuzz testing en apportant des preuves mathematiques exhaustives. Nous avons explore le langage CVL (Certora Verification Language) pour ecrire des invariants (conservation des tokens, non-negativite des soldes) et des regles de comportement sur un contrat Vault, puis decouvert SMTChecker, l'alternative native et gratuite integree au compilateur Solidity. La detection automatique d'une vulnerabilite de reentrancy par le model checker a illustre la puissance de l'approche : un contre-exemple concret est genere quand une assertion peut etre violee.\n",
+    "Ce notebook a introduit la verification formelle des smart contracts, une approche qui complete les tests unitaires et le fuzz testing en apportant des preuves mathematiques exhaustives. Nous avons explore le langage CVL (Certora Verification Language) pour ecrire des invariants (conservation des tokens, non-negativite des soldes) et des regles de comportement sur un contrat Vault, puis decouvert SMTChecker, l'alternative native et gratuite integree au compilateur Solidity. La demonstration du contrat VaultBuggy a illustre la puissance de l'approche : SMTChecker produit un contre-exemple concret quand une assertion peut etre violee — sous reserve de disposer d'un binaire solc lie a un solveur SMT (z3), absent de ce build Windows (verdict RECOVERABLE-MACHINE : re-executer sur Linux+z3).\n",
     "\n",
     "La verification formelle reste un investissement significatif en temps et en expertise, mais elle est indispensable pour les contrats critiques qui securisent des milliards de dollars en valeur verrouillee (DeFi, bridges, protocoles de gouvernance). Les outils evoluent rapidement : Certora Prover pour les specifications expressives en CVL, Halmos pour l'execution symbolique sur l'EVM, et SMTChecker pour les assertions natives sans dependance externe. La complementarite avec les tests classiques (foundry test, fuzz testing, invariant testing) definit une strategie de validation multicouche ou chaque methode couvre les angles morts des autres.\n",
     "\n",
@@ -1473,10 +1484,10 @@
    "id": "a915a288",
    "metadata": {
     "papermill": {
-     "duration": 0.002369,
-     "end_time": "2026-06-03T07:41:13.870037+00:00",
+     "duration": 0.003988,
+     "end_time": "2026-06-26T11:58:55.700858+00:00",
      "exception": false,
-     "start_time": "2026-06-03T07:41:13.867668+00:00",
+     "start_time": "2026-06-26T11:58:55.696870+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1504,20 +1515,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.017249,
-   "end_time": "2026-06-03T07:41:14.004862+00:00",
+   "duration": 3.121494,
+   "end_time": "2026-06-26T11:58:56.281121+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SC-14-Formal-Verification.ipynb",
-   "output_path": "SC-14-Formal-Verification.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\03-Foundry-Testing\\SC-14-Formal-Verification.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\03-Foundry-Testing\\SC-14-Formal-Verification_output.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },
-   "start_time": "2026-06-03T07:41:11.987613+00:00",
+   "start_time": "2026-06-26T11:58:53.159627+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Contexte — EPIC #3801 axe-2 SOTA

Audit SmartContracts (27 notebooks). **SC-14-Formal-Verification** contenait une **sortie fabriquee** : la cellule `6d3830e4` hardcodait un "Counterexample" SMTChecker via des `print()`, **sans jamais invoquer solc**. Violation axe-2 Prong-A (workaround degrade fabrique au lieu de l'outil SOTA reel).

## Fix — Stop & Repair (invoquer le vrai outil, jamais scrubber)

Remplacement de la fabrication par une **invocation reelle** du SOTA tool via `subprocess.run([solc, "--model-checker-engine", "all", ...])` sur les deux contrats (sain `VaultSMT` + buggy `VaultBuggy`).

### Sortie reelle de solc (capture du re-exec, kernel python3)

```
=== Contrat VaultSMT (sain) ===
$ solc.exe --model-checker-engine all sc14_smtcheck.sol

Warning: Solver z3 was selected for SMTChecker but it is not available.
Warning: The SMTChecker pragma has been deprecated ...
Warning: CHC analysis was not possible since no Horn solver was found ...
Warning: BMC analysis was not possible since no SMT solver was found ...
[code de sortie solc : 0]
```

Meme sortie pour `VaultBuggy`. **Aucun chemin machine** dans l'output (le `.sol` est ecrit en chemin relatif cwd → solc echo `sc14_smtcheck.sol`), conformement a secrets-hygiene rule 6 case A (correctif source, pas de scrub).

### Verdict — RECOVERABLE-MACHINE

Le vrai outil SOTA (solc SMTChecker) fonctionne sur un binaire solc lie a z3. Ce build (Windows statique `0.8.28+commit.7893614a.Windows.msvc`) **n'a pas de z3 lie** → l'analyse ne s'execute pas, solc le dit honnetement. Le contre-exemple reel est atteignable en re-executant sur Linux+z3 (`apt install solc z3`). La **forme attendue** du contre-exemple reste presentee, clairement labelisee "reference (non produite par cette execution car solveur absent)".

### Bug de compilation surfacé par l'outil réel

L'invocation reelle a revele un bug que la fabrication masquait : `vault_smt_code` utilisait `@custom:Invariant` (I majuscule), rejete par solc 0.8.28 (`Invalid character in custom tag @custom:Invariant. Only lowercase letters and "-" are permitted.`). Corrige en `@custom:invariant` (regle NatSpec custom-tag). Le contrat sain compile desormais proprement.

## Preuves de validation (criteres notebook PR)

| Critere | Preuve |
|---------|--------|
| **D.1 Papermill exec** | `notebook_tools.py execute ... --kernel python3` → SUCCESS, 5.2s |
| **D.2 0 NotImplementedError** | `grep -E "raise NotImplementedError\|assert False\|1/0"` → 0 hit |
| **D.3 exec_count + outputs** | 11/11 code cells `execution_count` set, 0 error outputs (C.2) |
| **D.4 anti-regression** | +260/-249 = enrichissement (insertions > deletions); les deletions = strings fabriques retires |
| **Stop & Repair** | Cause corrigee (solc invoque) + re-exec reel ; 0 hand-edit de sortie |
| **CATALOG** | byte-identique a main (non touche) |

## Cellules modifiees (5)

- `8cad6e96` (code) — `@custom:Invariant` → `@custom:invariant` (fix compilation)
- `6d3830e4` (code) — fabrication → vraie invocation solc subprocess + `_locate_solc` robuste (old+new solcx API)
- `4437cfa5` (markdown) — verdict RECOVERABLE-MACHINE honnete
- `fca07f44` (markdown) — detection presentee comme forme attendue (non executee)
- `17645a92` (recap) — retrait de l'affirmation "detection automatique a illustre"

See #3801
