### PR TITLE
docs(qc): 2 concept Mermaid diagrams - Algorithm Framework + validation pipeline

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -83,6 +83,20 @@ Gestion du risque professionnelle, types d'ordres avancés, analyse approfondie 
 
 Architecture modulaire QuantConnect pour stratégies scalables (Alpha, Portfolio Construction, Execution, Risk).
 
+```mermaid
+flowchart LR
+    U["Universe Selection<br/>quels actifs ?"] --> A["Alpha Model<br/>quels signaux ?"]
+    A --> PC["Portfolio Construction<br/>quelles tailles ?"]
+    PC --> E["Execution<br/>quels ordres ?"]
+    E --> R["Risk Management<br/>quels filtres ?"]
+    R -. "ajustement temps reel" .-> U
+    style A fill:#e1f5ff
+    style PC fill:#e8f5e9
+    style R fill:#fff3e0
+```
+
+Le flux de données traverse cinq modules Découplables : l'**Universe** sélectionne les actifs, l'**Alpha** produit les signaux directionnels, la **Portfolio Construction** transforme les signaux en tailles cibles, l'**Execution** route les ordres, et le **Risk Management** filtre/ajuste en continu. Chaque module est remplaçable indépendamment — c'est ce qui permet de composer une stratégie complexe sans réécrire l'ensemble.
+
 | # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 13 | [QC-Py-13-Alpha-Models](Python/QC-Py-13-Alpha-Models.ipynb) | 75 min | Algorithm Framework intro, Alpha models, insights |
@@ -438,6 +452,26 @@ Après completion de cette série, vous maîtriserez :
 ## Stratégies Vérifiées — Baselines Comparatives
 
 Les 50+ projets du dossier `projects/` ont été backtestés sur des périodes standardisées via QC Cloud API. Le tableau ci-dessous présente les **meilleures performances vérifiées** (Sharpe, CAGR, MaxDD, PSR) : [catalogue complet](../../docs/qc/qc-comparative-backtests.md).
+
+```mermaid
+flowchart TD
+    BT["Backtest in-sample<br/>(Sharpe brut)"] --> WF["Walk-forward<br/>5-fold"]
+    WF --> OOS["Out-of-sample strict<br/>(fenetre alignee 2018-2025)"]
+    OOS --> MS["Multi-seed<br/>0/1/7/42/99"]
+    MS --> PSR{"PSR > 50% ?"}
+    PSR -->|"oui"| FEES["Test frais reels<br/>5bps equity / 10bps crypto"]
+    PSR -->|"non"| ART["Artefact :<br/>edge illusoire"]
+    FEES --> VERD{"Sharpe net<br/>survit aux frais ?"}
+    VERD -->|"oui"| KEEP["Strategie robuste"]
+    VERD -->|"non"| DROP["Edge evapore"]
+    style PSR fill:#fff3e0
+    style VERD fill:#fff3e0
+    style KEEP fill:#e8f5e9
+    style ART fill:#ffebee
+    style DROP fill:#ffebee
+```
+
+Le **fil rouge** de la série : un Sharpe spectaculaire en backtest court est presque toujours un artefact. La validation ci-dessus — walk-forward, OOS strict aligné, multi-seed, PSR > 50%, puis test des frais réels — est ce qui sépare une stratégie robuste d'une illusion statistique. Les stratégies du tableau Top 5 ci-dessous sont celles qui ont survécu à ce pipeline.
 
 ### Top 5 stratégies (Sharpe aligned, 2018-2025)
 


### PR DESCRIPTION
## Summary

Add **two concept Mermaid diagrams** to the QuantConnect series README, turning two prose-only concepts into visual. Follows the editorial-finition pattern established this week by #4347 (conway_cgt_lean), #4349 (grothendieck_lean), #4350 (erc20_lean) — applied here to the **QC family** (po-2024 turf, #3976).

The QC series README was text-heavy (tables + prose only, zero diagrams). These two diagrams visualize the concepts that are hardest to convey in prose alone:

### 1. Algorithm Framework pipeline (Phase 4 section)

The five decoupled modules — **Universe Selection → Alpha Model → Portfolio Construction → Execution → Risk Management** — with the real-time feedback loop back to Universe. This is THE central modularity concept taught in QC-Py-13/14, previously described only as "Architecture modulaire QuantConnect pour stratégies scalables".

### 2. Backtest validation pipeline (Stratégies Vérifiées section)

The methodological-rigor flow that is the series' **fil rouge**: walk-forward 5-fold → OOS strict (aligned 2018-2025) → multi-seed (0/1/7/42/99) → **PSR > 50% gate** → real-fee test (5bps equity / 10bps crypto) → Sharpe-net verdict, branching to "stratégie robuste" vs "edge illusoire/évaporé". Visualizes the honesty discipline the 36 verified baselines (#1630) embody.

## Validation

- **Markdown-only** (C.2 exempt — README, no notebook outputs).
- **Fence parity preserved**: 10 fences (even), 2 `mermaid` blocks — no orphan-fence corruption (cf c.113 orphan-fence lesson).
- **CATALOG-STATUS byte-identical** (catalogue = automation property, never hand-regenerated on a feature branch, cf catalog-pr-hygiene rule).
- FR-first prose, no emojis (code-style rule).
- `git diff --stat`: **1 file, +34/-0** — pure addition, no prose removed/rewritten.
- Fresh base `origin/main` (`68761cedf`).

See #4212 (finition éditoriale — visuels Mermaid, famille-partitionné)
See #3973 / #3976 (README feuilles ascendantes, QuantConnect owner po-2024)

Co-Authored-By: Claude <noreply@anthropic.com>