### PR TITLE
docs(ml-pipeline): 2 concept Mermaid diagrams - training pipeline + Ladder #1409 verdicts (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -35,6 +35,29 @@ S1 long-horizon sweep a également produit **8 BEATS multi-coin sur 16** (XRP h=
 
 ## Architecture
 
+Le pipeline enchaîne ingestion → features → entraînement (4 familles de modèles) → validation walk-forward → checkpointing reproductible. Chaque étape est découplée et cache ses sorties (Parquet, `.pt`+`metadata.json`) pour permettre itérations rapides sans relancer l'amont.
+
+```mermaid
+flowchart TD
+    DATA["Donnees OHLCV<br/>yfinance / Binance / QC lean-cli"] --> FE["Feature Engineering<br/>features.py (cache Parquet)"]
+    FE --> DS["Dataset V2<br/>panier + cross-asset + labels regime"]
+    DS --> TRAIN{"Famille de modele"}
+    TRAIN -->|"Core direction"| C["RF / XGBoost / LSTM / DQN"]
+    TRAIN -->|"Advanced"| A["MoE / PatchTST / iTransformer / Mamba / DT"]
+    TRAIN -->|"Volatilite & regime"| V["GARCH+DL / HMM / HAR-RV-J (M12)"]
+    TRAIN -->|"Graph"| G["GCN / GAT / MTGNN / ST-GAT"]
+    C & A & V & G --> WF["Validation walk-forward<br/>5-fold expanding, 4-seed"]
+    WF --> VERD{"Verdict BEATS / NO BEATS<br/>(sign-test, p<0.05, win>=60%)"}
+    VERD --> CKPT["Checkpoint<br/>model.pt + metadata.json"]
+    VERD -.-> NO["NO BEATS<br/>(documente honnetement)"]
+    CKPT --> REG["REGISTRY.md"]
+    style VERD fill:#fff3e0
+    style CKPT fill:#e8f5e9
+    style NO fill:#ffebee
+```
+
+Ci-dessous, l'arborescence des scripts qui implémente ce pipeline.
+
 ```
 scripts/
   # --- Data & Features ---
@@ -426,6 +449,30 @@ Note : dry-run utilise des données aléatoires synthétiques. FAILS baseline es
 ## Ladder #1409 — Verdicts finaux (2026-06-12, COMPLETE)
 
 Évaluation systématique d'approches de génération de signaux de trading, 7 disciplines strictes (walk-forward 5-fold expanding, multi-seed >= 4, univers anti-FAANG, coûts tx explicites + 50bps stress, Sharpe déflaté, verdict honnête).
+
+La leçon centrale du ladder n'est pas le score d'un modèle isolé mais le contraste entre **deux paradigmes de formulation du signal** : prédire la **direction/action discrète** (Buy/Hold/Sell) vs prédire le **rendement futur continu** puis seuiller. Le graphe ci-dessous résume pourquoi seul le paradigme action-based survit au seuil BEATS face au buy-and-hold 2015-2025 (Sharpe 1.15).
+
+```mermaid
+flowchart LR
+    subgraph PARA["Deux paradigmes de signal"]
+        direction TB
+        P1["Paradigme action<br/>RF / DT / DQN"]
+        P2["Paradigme prevision<br/>PatchTST / LSTM / Transformer"]
+    end
+    P1 --> ACT["Sortie = action discrete<br/>(Buy / Hold / Sell)"]
+    P2 --> RET["Sortie = rendement<br/>(regression continue)"]
+    ACT --> TR1["Trading direct"]
+    RET --> TH["Seuillage / conversion<br/>en position"]
+    TH --> TR2["Trading differe"]
+    TR1 --> RES1["L4 DT : 24/26 seeds BEATS<br/>Sharpe net > buy-hold 1.15"]
+    TR2 --> RES2["PatchTST : 0/26 seeds BEATS<br/>Signal noye dans le bruit"]
+    style P1 fill:#e8f5e9
+    style P2 fill:#ffebee
+    style RES1 fill:#c8e6c9
+    style RES2 fill:#ffcdd2
+```
+
+L'écart de performance n'est pas un hasard : un classifieur d'action capture la **non-linéarité directionnelle** qu'un régresseur de rendement lisse et perd dans le seuillage. D'où le verdict consolidé — un seul BEATS (DT action-based), tout le reste NO BEATS (rendement/forecast).
 
 | Rung | Modèle | Approche | Verdict | Métrique clé | Doc |
 |------|-------|----------|---------|--------------|-----|


### PR DESCRIPTION
Add two concept Mermaid diagrams to the ML-Training-Pipeline README, turning two prose-only concepts into visual. Pattern from #4347 conway_cgt_lean / #4349 grothendieck_lean / #4350 erc20_lean / #4379 QC README, applied to the ML-Training-Pipeline family.

## Summary

1. **ML training pipeline** (`## Architecture` section): the decoupled flow — OHLCV ingestion → Feature Engineering (Parquet cache) → Dataset V2 → 4 model families (Core / Advanced / Volatility-regime / Graph) → walk-forward 5-fold expanding 4-seed → BEATS/NO BEATS verdict → checkpoint (`.pt` + `metadata.json`) → `REGISTRY.md`. The pipeline structure is THE central concept of the series, previously described only in prose + a directory tree.

2. **Ladder #1409 verdicts** (`## Ladder #1409` section): the action-based vs forecast-based paradigm contrast that is the ladder's central finding — DT action-based BEATS 24/26 seeds vs PatchTST forecast-based 0/26 seeds, both measured against buy-and-hold 2015-2025 (Sharpe 1.15). Visualizes why only the action paradigm survives the BEATS threshold — a comparative result that prose handles poorly.

## Validation

- **Markdown-only additions** (C.2 exempt — no notebook execution involved).
- **FR-first prose** (no "match surrounding EN": this README is already FR; new content is FR per [.claude/rules/readme-french-first.md](.claude/rules/readme-french-first.md) HARD 1).
- **No emojis** (cf code-style.md).
- **Fence parity**: 30 → 34 fences (even — no orphan-fence corruption, c.113 lesson).
- **Diff scope**: single file, +47/-0, no catalogue churn (no `CATALOG-STATUS` block in this sub-README).
- **Fresh base**: `5092abeb9` (== origin/main at branch creation).

## Scope

Single file, markdown-only, two concept diagrams. No code, no notebooks, no catalogue regeneration (catalogue = automation property, cf [catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md) HARD 1).

See #4212 (finition éditoriale — visuels Mermaid, famille-partitionné, Part of #4208).
See #3973 (README feuilles ascendantes) / #3976 (QuantConnect owner po-2024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)