### PR TITLE
fix(search,z3): normalize papermill metadata paths to basename (#3436, po-2025 turf)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb
@@ -892,7 +892,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MGS-11-IslandSynergy.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local/Temp/MGS-11_out.ipynb",
+   "output_path": "MGS-11_out.ipynb",
    "parameters": {},
    "start_time": "2026-06-23T16:29:43.719589+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
@@ -1952,8 +1952,8 @@
    "end_time": "2026-06-23T17:06:34.004928+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\05_Meal_Planner_Hierarchical.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\05_Meal_Planner_Hierarchical_output.ipynb",
+   "input_path": "05_Meal_Planner_Hierarchical.ipynb",
+   "output_path": "05_Meal_Planner_Hierarchical_output.ipynb",
    "parameters": {},
    "start_time": "2026-06-23T17:06:28.975928+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Scope — po-2025 turf for #3436

Two **Python** notebooks that I merged this cycle committed machine-local absolute paths in `metadata.papermill.input_path` / `output_path`. This PR normalizes both fields to basename.

| Notebook | Leaked field | Introduced by |
|----------|--------------|---------------|
| `Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb` | `output_path` = `C:\Users\jsboi\AppData\Local/Temp/MGS-11_out.ipynb` | #4076 |
| `SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb` | `input_path` + `output_path` = `D:\dev\CoursIA-2\...` | #4078 |

## Why this is the tolerated normalization (not a scrub)

Per **secrets-hygiene rule 6**, the ONLY manual normalizations tolerated are:
1. `metadata.papermill.input/output_path` → basename — this is **notebook metadata, NOT a cell output**.
2. Quantbook QC outputs.

This PR uses exactly normalization (1). It is **NOT** a cell-output scrub (Stop & Repair does not apply — there is no erroneous cell output to fix). The cell outputs, sources, and `execution_count` are all **byte-identical** to what #4076/#4078 real-committed.

## C.2 exemption

Metadata-only change. Outputs are already real (committed by the original papermill execution in #4076/#4078). No re-execution needed — re-executing would churn timestamps across every cell (`papermill-metadata-churn` anti-pattern) for zero pedagogical benefit. Analogous to the markdown-only C.2 exemption.

## Proof

```
diff: 2 files changed, 3 insertions(+), 3 deletions(-)
```
- Exactly 3 path lines changed, nothing else.
- Both notebooks re-parsed as **valid JSON** after edit.
- All 4 path fields now basename, **0 machine markers** remain.
- MGS-11: 7/7 code cells with outputs + exec_count intact.
- Z3-05: 12/12 code cells with outputs + exec_count intact.

## Committed-scope breakdown (investigated firsthand, JSON-parsed)

#3436's "201 notebooks" headline conflates canonical notebooks with `_output.ipynb` artifacts. The real committed scope:

| Family | Canonical leaking | Lane owner |
|--------|------------------|------------|
| GenAI | 74 | po-2023 |
| QuantConnect | 42 | po-2024 |
| CaseStudies | 3 | cross-turf (to assign) |
| **Search** | **1 (MGS-11)** | **po-2025 (this PR)** |
| **SymbolicAI** | **1 (Z3-05)** | **po-2025 (this PR)** |
| **Total canonical** | **121** | |

- **80 `*_output.ipynb` / `output/` artifacts are ALL untracked** (gitignored local papermill runs) — never committed, out of scope.

po-2025 takes only its own turf (anti-shopping-cart G.5). The other lanes' leaks (GenAI, QC) are theirs to normalize family-by-family.

See #3436
See #3435

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
