### PR TITLE
fix(genai-video): normalize papermill output_path to basename (#3436, Video)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb
@@ -1602,7 +1602,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "01-3-Qwen-VL-Video-Analysis.ipynb",
-   "output_path": "d:/tmp/video_01-3_out.ipynb",
+   "output_path": "video_01-3_out.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb
@@ -2025,7 +2025,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/hunyuan_reexec_1185.ipynb",
+   "output_path": "hunyuan_reexec_1185.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb
@@ -1925,7 +1925,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "02-2-LTX-Video-Lightweight.ipynb",
-   "output_path": "d:/tmp/video_02-2_out.ipynb",
+   "output_path": "video_02-2_out.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
@@ -1519,7 +1519,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "02-3-Wan-Video-Generation.ipynb",
-   "output_path": "d:/tmp/video_02-3_out.ipynb",
+   "output_path": "video_02-3_out.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },


### PR DESCRIPTION
## Scope — po-2023 GenAI turf for #3436 (Video sub-family)

Dispatched by ai-01 (c.36 deep-queue, "1 sous-famille/cycle"). 4 **GenAI/Video** notebooks committed machine-local absolute paths in `metadata.papermill.output_path`. This PR normalizes each to its basename.

| Notebook | Leaked `output_path` | Introduced by |
|----------|----------------------|---------------|
| `Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb` | `d:/tmp/video_01-3_out.ipynb` | #3801 Video axe-2 re-exec |
| `Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb` | `C:/Users/jsboi/AppData/Local/Temp/hunyuan_reexec_1185.ipynb` | #3801 re-exec (#4070 era) |
| `Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb` | `d:/tmp/video_02-2_out.ipynb` | #3801 re-exec (#4077 era) |
| `Video/02-Advanced/02-3-Wan-Video-Generation.ipynb` | `d:/tmp/video_02-3_out.ipynb` | #3801 re-exec |

## Why this is the tolerated normalization (not a cell-output scrub)

`metadata.papermill.{input,output_path}` is **notebook metadata, not a cell output** (the committed proof-of-execution). Per secrets-hygiene rule 6, normalizing it to basename is the ONLY tolerated path fix. A machine-local `output_path` here leaks the worker's filesystem layout (AppData/Temp, `d:/tmp`); it is **not** falsifying execution — the real outputs stay byte-identical. Re-exec would just re-leak a different machine path, so source-side normalization is correct.

## Surgical method (C.3-safe)

Raw-JSON text replacement (not `nbformat`/`json.dump` re-dump) — only the `output_path` value string changes; every source cell, every committed output, and all other metadata stays byte-identical. Diff: **+4/-4** (one line per notebook).

- C.2-exempt: metadata-only, 0 source cells changed, 0 committed outputs touched.
- Verified per-notebook: JSON re-parses valid; code-cell + image/png counts unchanged (e.g. 01-3 keeps its 1 PNG).
- Mirrors po-2025 PR #4385 (Python turf, same method).

## Remaining GenAI sub-families (queued, 1/cycle per ai-01)

Video 4 ✅ (this PR) · Audio 11 · SemanticKernel 6 · 00-GenAI-Environment 4 · FineTuning 3 · Image 1. Total committed GenAI leaked = 29 notebooks.

See #3436