### PR TITLE
feat(lean): UNLOCK native lean4-wsl Mathlib import (wrapper v6 + repl.py patch + setup script)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/lean4-kernel-wrapper.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/lean4-kernel-wrapper.py
@@ -17,13 +17,15 @@ v6 changes:
    picks up its LEAN_PATH, enabling in-kernel imports of lake modules. Falls
    back to ~/lean-projects/notebook_context (stub lake) when none is found.
 
-NOTE (native-import probe, 2026-06): even with the lake cwd detected, a native
-lean4-wsl kernel CANNOT import a Mathlib lake today — `lake env repl` clobbers
-the repl's sysroot (repl loses Init, `#check Nat` -> "Unknown identifier"),
-unlike `lake env lean` (the compiler) which resolves its sysroot natively. The
-working verification channel for Mathlib lakes remains `lake env lean --stdin`
-(python3 kernel + subprocess, see Lean-12b sensitivity companion #4388). See
-docs/reference/wsl-kernels-detail.md for the full evidence-cited probe.
+NOTE (native-import probe, 2026-06, c.126→c.127): this wrapper detects the lake
+workspace cwd, which is necessary but NOT sufficient for native Mathlib import —
+`lake env repl` (lean4_jupyter.repl:52) clobbers the repl's sysroot (repl loses
+Init, `#check Nat` -> "Unknown identifier"). The COMPLETE fix is in
+scripts/lean/setup_native_lean4_import.py: it patches lean4_jupyter's launch()
+to run the repl binary DIRECT (not via `lake env`) with the lake's LEAN_PATH,
+which makes native lean4-wsl import of a Mathlib lake WORK (proven on
+sensitivity_lean: real `#check huang_degree_theorem` + `#print axioms` in-kernel,
+0 sorry). See docs/reference/wsl-kernels-detail.md § "Native import ... VERDICT (a)".
 """
 import sys
 import subprocess

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/lean4-kernel-wrapper.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/lean4-kernel-wrapper.py
@@ -1,12 +1,29 @@
 #!/usr/bin/env python3
 r"""
-Lean 4 Jupyter Kernel Wrapper for WSL
+Lean 4 Jupyter Kernel Wrapper for WSL (v6)
 
 This script converts Windows paths to WSL paths and launches the lean4_jupyter kernel.
 It handles various path formats that VSCode/Jupyter might pass:
 - Standard Windows paths: C:\Users\...
 - Tilde shorthand: ~\AppData\... or ~/AppData/...
 - Mangled paths (backslashes eaten): c:UsersjsboiAppData...
+
+v6 changes:
+1. Mangled-path regex now covers BOTH AppData/Roaming (jupyter kernelspec) AND
+   AppData/Local/Temp (nbconvert connection files) — the kernel no longer dies
+   with PermissionError under nbconvert/papermill execution.
+2. find_lake_root(): chdir to the nearest lakefile.lean/.toml ancestor so that
+   `lake env repl` (lean4_jupyter.repl:52) detects the real lake workspace and
+   picks up its LEAN_PATH, enabling in-kernel imports of lake modules. Falls
+   back to ~/lean-projects/notebook_context (stub lake) when none is found.
+
+NOTE (native-import probe, 2026-06): even with the lake cwd detected, a native
+lean4-wsl kernel CANNOT import a Mathlib lake today — `lake env repl` clobbers
+the repl's sysroot (repl loses Init, `#check Nat` -> "Unknown identifier"),
+unlike `lake env lean` (the compiler) which resolves its sysroot natively. The
+working verification channel for Mathlib lakes remains `lake env lean --stdin`
+(python3 kernel + subprocess, see Lean-12b sensitivity companion #4388). See
+docs/reference/wsl-kernels-detail.md for the full evidence-cited probe.
 """
 import sys
 import subprocess
@@ -43,20 +60,24 @@ def convert_windows_path(path):
         return f'/mnt/c/Users/jsboi/{rest}'
 
     # Check for mangled path FIRST (backslashes eaten): c:UsersjsboiAppData...
-    # This happens when VSCode passes paths through certain shells
+    # This happens when VSCode passes paths through certain shells. nbconvert
+    # connection files live under AppData/Local/Temp (NOT AppData/Roaming, where
+    # the kernelspec lives), so the regex must cover BOTH subdirs + Temp/tmp.
     if len(path) >= 2 and path[1] == ':':
         # Detect mangled path: has Users immediately after drive letter without separator
         if path[2:].startswith('Users') and '\\' not in path and '/' not in path[2:]:
-            match = re.match(r'([a-zA-Z]):Users([a-z0-9_]+)AppDataRoaming(.+)', path, re.IGNORECASE)
+            match = re.match(
+                r'([a-zA-Z]):Users([a-z0-9_]+)AppData(Roaming|Local)(.+)', path, re.IGNORECASE)
             if match:
                 drive = match.group(1).lower()
                 user = match.group(2)
-                rest = match.group(3)
-                # Re-insert slashes at known boundaries
-                rest = rest.replace('jupyter', '/jupyter').replace('runtime', '/runtime')
-                rest = rest.replace('kernel-', '/kernel-')
+                subdir = match.group(3).capitalize()  # Roaming | Local
+                rest = match.group(4)
+                # Re-insert slashes at known segment boundaries
+                for sep in ['jupyter', 'runtime', 'kernel-', 'Temp', 'tmp']:
+                    rest = rest.replace(sep, '/' + sep)
                 rest = rest.lstrip('/')
-                return f'/mnt/{drive}/Users/{user}/AppData/Roaming/{rest}'
+                return f'/mnt/{drive}/Users/{user}/AppData/{subdir}/{rest}'
 
         # Standard Windows path with proper separators (C:\... or C:/...)
         # Use wslpath for proper conversion
@@ -72,6 +93,29 @@ def convert_windows_path(path):
         return f'/mnt/{drive}/{rest}'
 
     return path
+
+
+def find_lake_root(start_dir):
+    """Walk up from start_dir to find the nearest directory containing a
+    lakefile.lean (the lake workspace root). Returns None if not found.
+
+    When the kernel is launched from inside a lake project, chdir-ing to its
+    root lets `lake env repl` (lean4_jupyter.repl:52) detect the workspace and
+    pick up its LEAN_PATH, so in-kernel imports can resolve lake modules.
+    """
+    d = os.path.abspath(start_dir)
+    for _ in range(12):
+        try:
+            if os.path.isfile(os.path.join(d, 'lakefile.lean')) or \
+               os.path.isfile(os.path.join(d, 'lakefile.toml')):
+                return d
+        except OSError:
+            break
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    return None
 
 
 def main():
@@ -116,7 +160,20 @@ def main():
     # Set up environment with CLEAN PATH (not inheriting polluted Windows PATH)
     # The Windows PATH causes issues because it contains spaces and special chars
     os.environ['PATH'] = '/home/jesse/.elan/bin:/home/jesse/.lean4-venv/bin:/usr/local/bin:/usr/bin:/bin'
-    os.chdir(os.path.expanduser('~'))
+
+    # chdir to the lake workspace root (detected from the inherited cwd) so that
+    # `lake env repl` (lean4_jupyter.repl:52) detects the lake and picks up its
+    # LEAN_PATH, enabling in-kernel imports of lake modules. Falls back to the
+    # stub notebook_context lake when no lakefile is found nearby.
+    inherited_cwd = os.getcwd()
+    lake_root = find_lake_root(inherited_cwd)
+    if lake_root:
+        target_cwd = lake_root
+        log(f"Lake detected: chdir {inherited_cwd} -> {target_cwd}")
+    else:
+        target_cwd = os.path.expanduser('~/lean-projects/notebook_context')
+        log(f"No lakefile near {inherited_cwd} -> stub cwd {target_cwd}")
+    os.chdir(target_cwd)
     log(f"PATH set (clean): {os.environ['PATH']}")
     log(f"cwd: {os.getcwd()}")
     log(f"About to launch kernel with args: {args}")

--- a/docs/reference/wsl-kernels-detail.md
+++ b/docs/reference/wsl-kernels-detail.md
@@ -75,19 +75,30 @@ Windows (Jupyter)                  WSL (Ubuntu)
 
 Le wrapper Python v6 `~/.lean4-kernel-wrapper.py` (source dans le dépôt : `MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/lean4-kernel-wrapper.py`) gère la conversion Windows→WSL des paths, les permissions NTFS, et la détection du lake workspace. v6 = (1) regex mangled-path couvre `AppData/Roaming` (kernelspec) ET `AppData/Local/Temp` (fichiers de connexion nbconvert — le kernel ne meurt plus sous nbconvert/papermill), (2) `find_lake_root()` chdir vers le `lakefile.lean`/`.toml` ancêtre le plus proche pour que `lake env repl` détecte le lake. L'ancien wrapper bash `~/lean4-jupyter-wrapper.sh` est **OBSOLETE** — ne pas l'utiliser. Scripts de setup sous-jacents (orchestrés par `setup_lean4_all.py`) : `MyIA.AI.Notebooks/GameTheory/scripts/setup_wsl_lean4.sh` (WSL : elan, Lean 4 stable, venv `~/.lean4-venv`, lean4_jupyter, REPL), `setup_lean4_kernel.ps1` (registration `%APPDATA%/jupyter/kernels/lean4-wsl/`), `SymbolicAI/Lean/scripts/validate_lean_setup.py` (`--wsl`/`--windows`), notebook `SymbolicAI/Lean/Lean-1-Setup.ipynb`.
 
-### Native import d'un lake Mathlib en kernel `lean4-wsl` — VERDICT (b) (probe 2026-06)
+### Native import d'un lake Mathlib en kernel `lean4-wsl` — VERDICT (a) PROUVÉ (probe 2026-06, c.127)
 
 **Objectif** : un companion notebook **pur-Lean** (kernel natif) qui `import` un lake Mathlib (#4038) et `#check` ses théorèmes — alternative lisible au pattern python3 + `lake env lean --stdin` (companion Lean-12b sensitivity #4388).
 
-**Verdict : (b) non-faisable en l'état**, avec cause racine identifiée (evidence-cited) :
+**Verdict final : (a) FAISABLE** — un kernel `lean4-wsl` lancé dans un lake workspace nativement `import` le lake Mathlib et rend les signatures `#check` IN-kernel (Alectryon HTML), zéro Python.
 
-1. **Gap repl-toolchain (résolu)** : `~/.elan/bin/repl` est verrouillé à **stable v4.30.0** ; les lakes #4038 sont **rc1 (v4.31.0-rc1)** ou **rc2 (v4.30.0-rc2)**. Un repl rc2 matché se BUILD (`leanprover-community/repl` tag `v4.30.0-rc2`, 24 jobs SUCCESS) et charge la stdlib **lancé directement** (`#check Nat` → OK).
-2. **`lake env repl` casse le sysroot (bloqueur)** : lean4_jupyter hardcode `pexpect.spawn("lake env repl")` (`repl.py:52`). Sous `lake env`, le repl **perd Init** (`#check Nat` → "Unknown identifier"), alors que lancé directement il marche. Asymétrie : `lake env lean` (le compilateur, pattern #4388) résout son sysroot nativement ; `lake env repl` (kernel) non.
-3. **Oleans Mathlib non-flat** : la jonction #2611 fournit les oleans Mathlib dans un layout de cache non-standard (absents de `.lake/build/lib/lean/`) — `lake build` les trouve via le mécanisme de cache lake, mais les assembler sur un `LEAN_PATH` plat pour le repl demande une investigation.
+**Cause racine (probe c.126 → fix c.127)** : lean4_jupyter hardcode `pexpect.spawn("lake env repl")` (`repl.py:52`). Sous `lake env`, le repl **perd son sysroot** (ne trouve plus `Init` → `#check Nat` = "Unknown identifier"). Asymétrie : `lake env lean` (le compilateur) résout son sysroot nativement ; `lake env repl` non. **Fix** : lancer le repl binary **directement** (pas via `lake env`) avec `LEAN_PATH` capturé de `lake env` (= sysroot toolchain + deps + oleans Mathlib jonctionnés + lake build). Preuve firsthand (notebook natif exécuté dans `sensitivity_lean`, kernel Lean pur, 184s = import Mathlib réel) :
 
-**Fix path (travail infra dédié, gate user/ai-01)** : patcher `lean4_jupyter` `repl.py` pour lancer le repl **directement** (pas via `lake env`) avec `LEAN_PATH` = sysroot toolchain + `lake env print-paths` + oleans Mathlib jonctionnés. Demande aussi un repl binaire par toolchain (rc1, rc2) + un dispatcher `~/.elan/bin/repl`.
+- `import Sensitivity` → OK
+- `#check Sensitivity.huang_degree_theorem` → signature réelle : `huang_degree_theorem {m : ℕ} (H : Set (Sensitivity.Q m.succ)) (hH : ...) : ∃ q ∈ H, √(↑m + 1) ≤ ↑(H ∩ q.adjacent).toFinset.card`
+- `#check Sensitivity.f_squared` → `(f n) ((f n) v) = ↑n • v`
+- `#print axioms Sensitivity.huang_degree_theorem` → **depends on axioms: [propext, Classical.choice, Quot.sound]** (0 sorry, pas de `sorryAx`)
 
-**Plafond accepté aujourd'hui** : kernel natif `lean4-wsl` pour lakes **sans Mathlib** (lean_game_defs, companions 16d/16e/GT-15b, c.118-119) ; pattern **python3 + `lake env lean --stdin`** (companion #4388) pour les lakes Mathlib — python3-string mais importe le VRAI lake avec `#check` réel.
+**Prérequis** : (1) le wrapper v6 (`find_lake_root` chdir vers le lakefile ancêtre) pour que le kernel hérite le cwd du lake, (2) un repl binaire matchant la toolchain du lake (`~/.elan/bin/repl` est stable-locked ; rc1/rc2 lakes ont besoin d'un repl matché), (3) le patch `lean4_jupyter/repl.py` `launch()`. Le script `scripts/lean/setup_native_lean4_import.py` automatise le patch (idempotent + backup) + le build de repl par toolchain (`build-repl v4.30.0-rc2` / `v4.31.0-rc1`).
+
+**Setup** :
+
+```powershell
+python scripts/lean/setup_native_lean4_import.py status        # état patch + repl toolchains
+python scripts/lean/setup_native_lean4_import.py build-repl v4.30.0-rc2   # build+install repl matché (~2 min)
+python scripts/lean/setup_native_lean4_import.py patch         # patch repl.py (idempotent)
+```
+
+**Note durabilité (gate ai-01/user)** : le patch modifie le package pip `lean4_jupyter` (perdu au prochain `pip install`). Solution durable = fork lean4_jupyter ou PR upstream. Le script rend le patch reproductible (idempotent, backup `.bak.native`), mais c'est un débloqueur local, pas une solution upstream.
 
 ### Diagnostic manuel (commandes)
 

--- a/docs/reference/wsl-kernels-detail.md
+++ b/docs/reference/wsl-kernels-detail.md
@@ -65,14 +65,29 @@ Test : `python scripts/lean/tests/test_lean_kernel_check.py` (4 cas : ancien bas
 
 ```
 Windows (Jupyter)                  WSL (Ubuntu)
-   kernel.json ──────────────────> ~/.lean4-kernel-wrapper.py (v5)
+   kernel.json ──────────────────> ~/.lean4-kernel-wrapper.py (v6)
    %APPDATA%/jupyter/                ↓
      kernels/lean4-wsl/            ~/.lean4-venv/bin/python3 -m lean4_jupyter
-                                    cd ~/lean-projects/notebook_context
-                                    REPL: ~/.elan/bin/repl
+                                    chdir: lakefile ancêtre le plus proche
+                                          (fallback ~/lean-projects/notebook_context)
+                                    REPL: ~/.elan/bin/repl  (via `lake env repl`)
 ```
 
-Le wrapper Python v5 `~/.lean4-kernel-wrapper.py` gère la conversion Windows→WSL des paths et les permissions NTFS. L'ancien wrapper bash `~/lean4-jupyter-wrapper.sh` est **OBSOLETE** — ne pas l'utiliser. Scripts de setup sous-jacents (orchestrés par `setup_lean4_all.py`) : `MyIA.AI.Notebooks/GameTheory/scripts/setup_wsl_lean4.sh` (WSL : elan, Lean 4 stable, venv `~/.lean4-venv`, lean4_jupyter, REPL), `setup_lean4_kernel.ps1` (registration `%APPDATA%/jupyter/kernels/lean4-wsl/`), `SymbolicAI/Lean/scripts/validate_lean_setup.py` (`--wsl`/`--windows`), notebook `SymbolicAI/Lean/Lean-1-Setup.ipynb`.
+Le wrapper Python v6 `~/.lean4-kernel-wrapper.py` (source dans le dépôt : `MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/lean4-kernel-wrapper.py`) gère la conversion Windows→WSL des paths, les permissions NTFS, et la détection du lake workspace. v6 = (1) regex mangled-path couvre `AppData/Roaming` (kernelspec) ET `AppData/Local/Temp` (fichiers de connexion nbconvert — le kernel ne meurt plus sous nbconvert/papermill), (2) `find_lake_root()` chdir vers le `lakefile.lean`/`.toml` ancêtre le plus proche pour que `lake env repl` détecte le lake. L'ancien wrapper bash `~/lean4-jupyter-wrapper.sh` est **OBSOLETE** — ne pas l'utiliser. Scripts de setup sous-jacents (orchestrés par `setup_lean4_all.py`) : `MyIA.AI.Notebooks/GameTheory/scripts/setup_wsl_lean4.sh` (WSL : elan, Lean 4 stable, venv `~/.lean4-venv`, lean4_jupyter, REPL), `setup_lean4_kernel.ps1` (registration `%APPDATA%/jupyter/kernels/lean4-wsl/`), `SymbolicAI/Lean/scripts/validate_lean_setup.py` (`--wsl`/`--windows`), notebook `SymbolicAI/Lean/Lean-1-Setup.ipynb`.
+
+### Native import d'un lake Mathlib en kernel `lean4-wsl` — VERDICT (b) (probe 2026-06)
+
+**Objectif** : un companion notebook **pur-Lean** (kernel natif) qui `import` un lake Mathlib (#4038) et `#check` ses théorèmes — alternative lisible au pattern python3 + `lake env lean --stdin` (companion Lean-12b sensitivity #4388).
+
+**Verdict : (b) non-faisable en l'état**, avec cause racine identifiée (evidence-cited) :
+
+1. **Gap repl-toolchain (résolu)** : `~/.elan/bin/repl` est verrouillé à **stable v4.30.0** ; les lakes #4038 sont **rc1 (v4.31.0-rc1)** ou **rc2 (v4.30.0-rc2)**. Un repl rc2 matché se BUILD (`leanprover-community/repl` tag `v4.30.0-rc2`, 24 jobs SUCCESS) et charge la stdlib **lancé directement** (`#check Nat` → OK).
+2. **`lake env repl` casse le sysroot (bloqueur)** : lean4_jupyter hardcode `pexpect.spawn("lake env repl")` (`repl.py:52`). Sous `lake env`, le repl **perd Init** (`#check Nat` → "Unknown identifier"), alors que lancé directement il marche. Asymétrie : `lake env lean` (le compilateur, pattern #4388) résout son sysroot nativement ; `lake env repl` (kernel) non.
+3. **Oleans Mathlib non-flat** : la jonction #2611 fournit les oleans Mathlib dans un layout de cache non-standard (absents de `.lake/build/lib/lean/`) — `lake build` les trouve via le mécanisme de cache lake, mais les assembler sur un `LEAN_PATH` plat pour le repl demande une investigation.
+
+**Fix path (travail infra dédié, gate user/ai-01)** : patcher `lean4_jupyter` `repl.py` pour lancer le repl **directement** (pas via `lake env`) avec `LEAN_PATH` = sysroot toolchain + `lake env print-paths` + oleans Mathlib jonctionnés. Demande aussi un repl binaire par toolchain (rc1, rc2) + un dispatcher `~/.elan/bin/repl`.
+
+**Plafond accepté aujourd'hui** : kernel natif `lean4-wsl` pour lakes **sans Mathlib** (lean_game_defs, companions 16d/16e/GT-15b, c.118-119) ; pattern **python3 + `lake env lean --stdin`** (companion #4388) pour les lakes Mathlib — python3-string mais importe le VRAI lake avec `#check` réel.
 
 ### Diagnostic manuel (commandes)
 

--- a/scripts/lean/setup_native_lean4_import.py
+++ b/scripts/lean/setup_native_lean4_import.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Unlock native lean4-wsl import of Mathlib lakes (patch lean4_jupyter repl.py).
+
+BACKGROUND
+----------
+The lean4-wsl Jupyter kernel launches its REPL via ``lake env repl``
+(``lean4_jupyter/repl.py:Lean4ReplWrapper.launch``). Under ``lake env`` the REPL
+binary loses its sysroot (it cannot find ``Init``), so ``#check Nat`` returns
+"Unknown identifier" and importing a Mathlib lake is impossible in-kernel.
+``lake env lean`` (the compiler) does NOT have this problem (pattern #4388), but
+that route is python3 + subprocess, which the user finds hard to read.
+
+FIX
+---
+Patch ``launch()`` to run the REPL binary *directly* (not via ``lake env``) with
+``LEAN_PATH`` captured from ``lake env`` (sysroot + deps + junctioned Mathlib +
+lake build dir). With this, a lean4-wsl kernel launched inside a lake workspace
+natively ``import``s the lake and renders ``#check`` signatures in-kernel (real
+Alectryon HTML output), zero Python. The fallback ``lake env repl`` is kept for
+Mathlib-free stub lakes (lean_game_defs, notebook_context).
+
+A matched REPL binary is required per lake toolchain (``~/.elan/bin/repl`` is
+stable-locked; rc1/rc2 lakes need a matched REPL — see ``build-repl``).
+
+USAGE
+-----
+    python scripts/lean/setup_native_lean4_import.py status        # what's patched/installed
+    python scripts/lean/setup_native_lean4_import.py patch         # patch repl.py (idempotent, backup)
+    python scripts/lean/setup_native_lean4_import.py build-repl v4.30.0-rc2
+    python scripts/lean/setup_native_lean4_import.py --check
+
+Probe evidence (2026-06, sensitivity_lean): ``import Sensitivity`` +
+``#check huang_degree_theorem`` in a lean4-wsl kernel render the real signature,
+``#print axioms`` -> [propext, Classical.choice, Quot.sound] (0 sorry). See
+docs/reference/wsl-kernels-detail.md.
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+WSL_DISTRO = "Ubuntu"
+# Canonical matched-REPL install paths (one per toolchain tag).
+REPL_TOOLCHAIN_TAGS = {
+    "v4.30.0-rc2": "repl-4.30.0-rc2",
+    "v4.31.0-rc1": "repl-4.31.0-rc1",
+}
+# Marker present in repl.py once patched (idempotency check).
+PATCH_MARKER = "_find_lake_root"
+
+REPL_PY_PATCH = '''    @staticmethod
+    def _find_lake_root(start='.'):
+        d = os.path.abspath(start)
+        for _ in range(12):
+            if os.path.isfile(os.path.join(d, 'lakefile.lean')) or \\
+               os.path.isfile(os.path.join(d, 'lakefile.toml')):
+                return d
+            p = os.path.dirname(d)
+            if p == d:
+                return None
+            d = p
+        return None
+
+    @staticmethod
+    def _repl_for_toolchain(lake_root):
+        """Pick a REPL binary matching the lake's toolchain.
+        ``~/.elan/bin/repl`` is stable-locked; rc1/rc2 lakes need a matched REPL
+        (built via ``setup_native_lean4_import.py build-repl <tag>``)."""
+        default = os.path.expanduser('~/.elan/bin/repl')
+        # toolchain tag -> canonical matched-REPL name (inlined; keep in sync
+        # with REPL_TOOLCHAIN_TAGS in setup_native_lean4_import.py).
+        mapping = {'v4.30.0-rc2': 'repl-4.30.0-rc2',
+                   'v4.31.0-rc1': 'repl-4.31.0-rc1'}
+        try:
+            tc_file = os.path.join(lake_root, 'lean-toolchain')
+            tc = open(tc_file).read().strip() if os.path.isfile(tc_file) else ''
+        except OSError:
+            tc = ''
+        elan_bin = os.path.expanduser('~/.elan/bin')
+        for tag, name in mapping.items():
+            if tag in tc:
+                p = os.path.join(elan_bin, name)
+                if os.path.isfile(p):
+                    return p
+        return default
+
+    @classmethod
+    def launch(cls):
+        """Native-import path: launch the REPL binary DIRECT (not via ``lake env``)
+        with the lake's LEAN_PATH when running inside a lake workspace. ``lake env
+        repl`` clobbers the REPL sysroot (loses Init); direct launch with
+        LEAN_PATH=sysroot+deps+Mathlib restores native Mathlib-lake import."""
+        try:
+            lake_root = cls._find_lake_root(os.getcwd())
+            if lake_root:
+                import subprocess as _sp
+                out = _sp.run(
+                    ['lake', 'env', 'python3', '-c',
+                     'import os; print(os.environ.get("LEAN_PATH",""))'],
+                    capture_output=True, text=True, timeout=60, cwd=lake_root,
+                    env={**os.environ,
+                         'PATH': os.path.expanduser('~/.elan/bin') + ':/usr/local/bin:/usr/bin:/bin'}
+                ).stdout
+                lean_path = '\\n'.join(
+                    l for l in out.splitlines() if 'local changes' not in l).strip()
+                repl_bin = cls._repl_for_toolchain(lake_root)
+                if lean_path and os.path.isfile(repl_bin):
+                    env = {**os.environ, 'LEAN_PATH': lean_path,
+                           'PATH': os.path.expanduser('~/.elan/bin') + ':/usr/local/bin:/usr/bin:/bin'}
+                    return pexpect.spawn(repl_bin, echo=False, encoding='utf-8',
+                                         codec_errors='replace', env=env)
+        except Exception:
+            pass
+        return pexpect.spawn("lake env repl",
+                             echo=False, encoding='utf-8', codec_errors='replace')
+'''
+
+REPL_PY_ORIGINAL = '''    @classmethod
+    def launch(cls):
+        return pexpect.spawn("lake env repl",
+                             echo=False, encoding='utf-8', codec_errors='replace')'''
+
+
+def _wsl(cmd, timeout=120):
+    """Run a command inside WSL, return CompletedProcess."""
+    full = ["wsl.exe", "-d", WSL_DISTRO, "--", "bash", "-lc", cmd]
+    return subprocess.run(full, capture_output=True, text=True, timeout=timeout)
+
+
+def _find_repl_py():
+    """Locate lean4_jupyter/repl.py inside the WSL lean4 venv."""
+    r = _wsl("ls /home/*/.lean4-venv/lib/python3.*/site-packages/lean4_jupyter/repl.py "
+             "2>/dev/null | head -1", timeout=30)
+    path = r.stdout.strip()
+    return path or None
+
+
+def cmd_status():
+    rp = _find_repl_py()
+    print("== native lean4-wsl Mathlib import — status ==")
+    if not rp:
+        print("lean4_jupyter/repl.py: NOT FOUND (lean4 venv missing?)")
+        return 1
+    print("repl.py:", rp)
+    r = _wsl(f"grep -q '{PATCH_MARKER}' {rp} && echo PATCHED || echo UNPATCHED", timeout=20)
+    print("patch state:", r.stdout.strip())
+    print("matched REPL binaries:")
+    for tag, name in REPL_TOOLCHAIN_TAGS.items():
+        rr = _wsl(f"test -f ~/.elan/bin/{name} && echo '  {name}: present' "
+                  f"|| echo '  {name}: MISSING (run: build-repl {tag})'", timeout=15)
+        print(rr.stdout.strip())
+    return 0
+
+
+def cmd_patch():
+    rp = _find_repl_py()
+    if not rp:
+        print("ERROR: lean4_jupyter/repl.py not found", file=sys.stderr)
+        return 1
+    # Idempotency: already patched?
+    r = _wsl(f"grep -q '{PATCH_MARKER}' {rp} && echo yes || echo no", timeout=20)
+    if r.stdout.strip() == "yes":
+        print("repl.py already patched (idempotent) — nothing to do.")
+        return 0
+    # Backup.
+    _wsl(f"cp {rp} {rp}.bak.native 2>/dev/null", timeout=20)
+    # Write the patcher to a temp file and run it inside WSL (avoids the
+    # bash -lc quoting nightmare of a multi-line python -c with apostrophes).
+    import tempfile, os
+    patcher = (
+        "import sys\n"
+        f"p = {rp!r}\n"
+        "src = open(p, encoding='utf-8').read()\n"
+        "if '_find_lake_root' in src:\n"
+        "    print('already'); sys.exit(0)\n"
+        "OLD = " + repr(REPL_PY_ORIGINAL) + "\n"
+        "NEW = " + repr(REPL_PY_PATCH) + "\n"
+        "if OLD not in src:\n"
+        "    print('ERROR: original launch() block not found (upstream changed)'); sys.exit(2)\n"
+        "open(p, 'w', encoding='utf-8').write(src.replace(OLD, NEW, 1))\n"
+        "print('PATCHED')\n"
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, encoding="utf-8") as f:
+        f.write(patcher)
+        tmp_win = f.name
+    # Convert Windows temp path -> WSL path and copy into /tmp.
+    win_drive = tmp_win[0].lower()
+    tmp_unix_src = "/mnt/" + win_drive + tmp_win[2:].replace("\\", "/")
+    tmp_wsl = "/tmp/_lean4_native_patcher.py"
+    _wsl(f"cp '{tmp_unix_src}' {tmp_wsl}", timeout=20)
+    os.unlink(tmp_win)
+    r = _wsl(f"/home/*/.lean4-venv/bin/python3 {tmp_wsl}", timeout=40)
+    out = (r.stdout or r.stderr or "").strip()
+    _wsl(f"rm -f {tmp_wsl}", timeout=10)
+    print("patch:", out)
+    # Compile check.
+    rc = _wsl(f"/home/*/.lean4-venv/bin/python3 -m py_compile {rp} && echo OK", timeout=30)
+    print("py_compile:", (rc.stdout or rc.stderr or "").strip())
+    return 0 if ("PATCHED" in out or "already" in out) else 1
+
+
+def cmd_build_repl(tag):
+    if tag not in REPL_TOOLCHAIN_TAGS:
+        print(f"ERROR: unknown tag {tag}. Known: {list(REPL_TOOLCHAIN_TAGS)}", file=sys.stderr)
+        return 1
+    name = REPL_TOOLCHAIN_TAGS[tag]
+    cmds = (
+        f"export PATH=/home/*/.elan/bin:/usr/local/bin:/usr/bin:/bin; "
+        f"mkdir -p ~/repl-build && cd ~/repl-build && "
+        f"if [ ! -d repl ]; then git clone --depth 1 https://github.com/leanprover-community/repl.git; fi && "
+        f"cd repl && git checkout {tag} 2>&1 | tail -1 && "
+        f"lake clean >/dev/null 2>&1; lake build repl 2>&1 | tail -3; "
+        f"if [ -f .lake/build/bin/repl ]; then cp .lake/build/bin/repl ~/.elan/bin/{name} "
+        f"&& echo INSTALLED-{name}; else echo BUILD-FAILED; fi"
+    )
+    print(f"building repl {tag} -> ~/.elan/bin/{name} (this takes a few minutes)...")
+    r = _wsl(cmds, timeout=600)
+    print(r.stdout.strip()[-800:])
+    return 0 if f"INSTALLED-{name}" in r.stdout else 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("command", nargs="?", choices=["status", "patch", "build-repl"],
+                    default="status")
+    ap.add_argument("tag", nargs="?", help="toolchain tag for build-repl (e.g. v4.30.0-rc2)")
+    ap.add_argument("--check", action="store_true", help="alias for status")
+    args = ap.parse_args()
+    if args.check or args.command == "status":
+        return cmd_status()
+    if args.command == "patch":
+        return cmd_patch()
+    if args.command == "build-repl":
+        if not args.tag:
+            print("ERROR: build-repl requires a tag", file=sys.stderr)
+            return 1
+        return cmd_build_repl(args.tag)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## ⚠️ UPDATED c.127 — VERDICT INVERTED (b)→(a) PROVEN: native lean4-wsl Mathlib import WORKS

> **Important**: the original body of this PR (c.126) concluded native import was **(b) non-feasible**, blocked by `lake env repl` clobbering the repl sysroot. **c.127 proves that wrong** — the fix path I identified c.126 actually works. Do NOT communicate (b) to the user.

## What this PR now delivers (c.127)

A complete **UNLOCK**: the wrapper v6 cwd fix (c.126) + a `lean4_jupyter/repl.py` patch + a matched-repl-per-toolchain setup script, together make a **native lean4-wsl kernel natively `import` a Mathlib lake and render `#check` signatures in-kernel (zero Python)** — exactly the *pur-Lean lisible* format the user mandates.

### Proof firsthand (native lean4-wsl notebook, kernel Lean pur, 184s = real Mathlib import)

Run inside `sensitivity_lean`:

- `import Sensitivity` → OK
- `#check Sensitivity.huang_degree_theorem` → real signature: `huang_degree_theorem {m : ℕ} (H : Set (Sensitivity.Q m.succ)) (hH : H.toFinset.card ≥ 2^m+1) : ∃ q ∈ H, √(↑m+1) ≤ ↑(H ∩ q.adjacent).toFinset.card`
- `#check Sensitivity.f_squared` → `(f n) ((f n) v) = ↑n • v`
- `#print axioms Sensitivity.huang_degree_theorem` → **depends on axioms: [propext, Classical.choice, Quot.sound]** (0 sorry, no `sorryAx`)

## Root cause (probe c.126) + fix (c.127)

lean4_jupyter hardcodes `pexpect.spawn("lake env repl")` (`repl.py:52`). Under `lake env` the repl binary loses its sysroot (cannot find `Init` → `#check Nat` = "Unknown identifier"). `lake env lean` (the compiler, pattern #4388) does NOT have this problem. **Fix**: launch the repl binary **direct** (not via `lake env`) with `LEAN_PATH` captured from `lake env` (= sysroot + deps + junctioned Mathlib + lake build). Requires:
1. wrapper v6 `find_lake_root()` chdir to the lake root (c.126, this branch)
2. a repl binary matching the lake's toolchain (`~/.elan/bin/repl` is stable-locked; rc1/rc2 lakes need a matched repl)
3. the `lean4_jupyter/repl.py` `launch()` patch

## Files

| File | Change |
|------|--------|
| `MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/lean4-kernel-wrapper.py` | v6 (c.126): AppDataLocalTemp regex + `find_lake_root()` chdir. docstring NOTE updated (b)→(a) pointing at the complete fix. |
| `scripts/lean/setup_native_lean4_import.py` | **NEW** (c.127): idempotent `lean4_jupyter/repl.py` patch (backup `.bak.native`, fallback `lake env repl` for Mathlib-free stub lakes) + `build-repl <tag>` (matched repl for v4.30.0-rc2 / v4.31.0-rc1, ~2 min) + `status`. |
| `docs/reference/wsl-kernels-detail.md` | verdict section rewritten (b)→(a) PROVEN + setup commands + firsthand evidence. |

```powershell
python scripts/lean/setup_native_lean4_import.py status                    # patch + matched repl state
python scripts/lean/setup_native_lean4_import.py build-repl v4.30.0-rc2    # build+install matched repl (~2 min)
python scripts/lean/setup_native_lean4_import.py patch                     # patch repl.py (idempotent, backup)
```

## Verification

- Setup script: `status`/`patch`/`build-repl` tested; patch **idempotent** (2nd run → "already patched"), `py_compile` clean.
- Native notebook re-executed **twice** end-to-end (4/4 0 errors, real `#check`/`#print axioms` output): manual patch c.126, then script patch c.127 (reproducibility confirmed).
- Wrapper v6 fixes regression-tested (4 asserts PASS): AppDataLocalTemp + AppDataRoaming regex + find_lake_root sensitivity_lean/None.

## Durability note (gate ai-01/user)

The patch modifies the **pip-installed** `lean4_jupyter` package (lost on next `pip install`). The script makes it reproducible (idempotent + backup `.bak.native`), but a durable fix = a `lean4_jupyter` fork or PR upstream. This is a **local deblocker surfaced, not decided**.

## Implication for the 6 HELD companion PRs

#4373 (minimax), #4376 (argumentation), #4380 (planning), #4384 (sudoku), #4386 (infer-14b), #4388 (sensitivity) — all python3-string. **With this unlock, they become convertible to pur-Lean native** (the user's preferred format). PR #4388 (python3 + `lake env lean`) is no longer the ceiling.

Anti-régression: 3 files, +271/−14, no `.lean`/notebooks touched (test notebook cleaned up), no pre-existing mods staged (explicit `git add`).

See #4388 (sensitivity companion — convertible to native with this unlock), See #1618 (lean4-wsl setup), See #4038 (Lean lakes roadmap), See #2611 (Mathlib junction).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
