### PR TITLE
fix(genai-audio): normalize papermill output_path to basename (#3436, Audio)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb
@@ -1939,7 +1939,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/01-4-whisper-reexec.ipynb",
+   "output_path": "01-4-whisper-reexec.ipynb",
    "parameters": {
     "BATCH_MODE": "true",
     "notebook_mode": "batch",

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb
@@ -5240,7 +5240,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/chatterbox_reexec.ipynb",
+   "output_path": "chatterbox_reexec.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb
@@ -1715,7 +1715,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "02-2-XTTS-Voice-Cloning.ipynb",
-   "output_path": "d:/tmp/audio_02-2_out.ipynb",
+   "output_path": "audio_02-2_out.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-6-MIDI-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-6-MIDI-Generation.ipynb
@@ -2074,7 +2074,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-6-MIDI-Generation.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/audio_batch2_02_6.ipynb",
+   "output_path": "audio_batch2_02_6.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb
@@ -2085,7 +2085,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/audio_batch2_02_7.ipynb",
+   "output_path": "audio_batch2_02_7.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb
@@ -2244,7 +2244,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/audio_batch2_02_8.ipynb",
+   "output_path": "audio_batch2_02_8.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb
@@ -2183,7 +2183,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/audio_batch2_03_1.ipynb",
+   "output_path": "audio_batch2_03_1.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
@@ -1988,7 +1988,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/audio_batch2_03_2.ipynb",
+   "output_path": "audio_batch2_03_2.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb
@@ -1925,7 +1925,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/audio_batch2_04_2.ipynb",
+   "output_path": "audio_batch2_04_2.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb
@@ -2056,7 +2056,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/audio_batch2_04_3.ipynb",
+   "output_path": "audio_batch2_04_3.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb
@@ -1153,7 +1153,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/audio_batch2_04_8.ipynb",
+   "output_path": "audio_batch2_04_8.ipynb",
    "parameters": {},
    "start_time": "2026-05-26T18:05:10.539383",
    "version": "2.6.0"


### PR DESCRIPTION
## Scope — po-2023 GenAI turf for #3436 (Audio sub-family)

Continuation of ai-01 c.36 dispatch ("1 sous-famille/cycle"). **GenAI/Audio** = sub-family 2/5. 11 notebooks committed machine-local absolute paths in `metadata.papermill.output_path`. This PR normalizes each to its basename.

| Group | Notebooks | Leaked `output_path` prefix |
|-------|-----------|------------------------------|
| 01-Foundation | 01-4-Whisper-Local | `C:/Users/jsboi/AppData/Local/Temp/01-4-whisper-reexec.ipynb` |
| 02-Advanced | 02-1-Chatterbox, 02-2-XTTS, 02-6-MIDI, 02-7-Song, 02-8-Expressive-TTS | `AppData/Local/Temp/...` + `d:/tmp/audio_02-2_out.ipynb` |
| 03-Orchestration | 03-1-Multi-Model, 03-2-Pipeline | `AppData/Local/Temp/audio_batch2_...` |
| 04-Applications | 04-2-Transcription, 04-3-Music-Composition, 04-8-Lecture-Analytique | `AppData/Local/Temp/audio_batch2_...` |

## Why tolerated (not a cell-output scrub) — secrets-hygiene rule 6

`metadata.papermill.output_path` is **notebook metadata, not a cell output**. A machine-local path leaks the worker's filesystem layout (AppData/Temp, `d:/tmp`); normalizing to basename is the ONLY tolerated path fix. It does **not** falsify execution — the real outputs stay byte-identical. Re-exec would re-leak a different path, so source-side normalization is correct.

## Surgical method (C.3-safe)

Raw-JSON text replacement (not `json.dump` re-dump) → only the `output_path` value changes; source cells, committed outputs, and all other metadata byte-identical. Diff: **+11/-11** (one line per notebook). Strict check: zero added lines other than `output_path`. JSON re-parses valid; code-cell/png counts unchanged per notebook.

Mirrors Video (#4389, 4 notebooks) and po-2025 Python turf (#4385, 2 notebooks) — same method, same verdict.

## Queue remaining (#3436 GenAI)

Video 4 ✅ (#4389) · **Audio 11 ✅ (this PR)** · SemanticKernel 6 · 00-GenAI-Environment 4 · FineTuning 3 · Image 1.

See #3436