### PR TITLE
fix(genai-sk): normalize papermill output_path to basename (#3436, SemanticKernel)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
@@ -794,7 +794,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "09-SemanticKernel-Building-CLR.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/SK-09_py.ipynb",
+   "output_path": "SK-09_py.ipynb",
    "parameters": {},
    "start_time": "2026-05-09T23:04:01.648273",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/Notebook-Generated.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/Notebook-Generated.ipynb
@@ -1138,7 +1138,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/SemanticKernel/Notebook-Generated.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pile-commune-c32/Notebook-Generated.ipynb",
+   "output_path": "Notebook-Generated.ipynb",
    "parameters": {},
    "start_time": "2026-05-13T08:24:47.850436",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/Notebook-Template.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/Notebook-Template.ipynb
@@ -314,7 +314,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/SemanticKernel/Notebook-Template.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/pile-commune-c32/Notebook-Template.ipynb",
+   "output_path": "Notebook-Template.ipynb",
    "parameters": {},
    "start_time": "2026-05-13T08:24:47.836600",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/Workbook-Template-Python.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/Workbook-Template-Python.ipynb
@@ -464,7 +464,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Workbook-Template-Python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/SK-wtp_output.ipynb",
+   "output_path": "SK-wtp_output.ipynb",
    "parameters": {},
    "start_time": "2026-05-09T22:52:01.916049",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/Workbook-Template.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/Workbook-Template.ipynb
@@ -345,7 +345,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Workbook-Template.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/SK-wt_output.ipynb",
+   "output_path": "SK-wt_output.ipynb",
    "parameters": {},
    "start_time": "2026-05-09T22:51:18.391358",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-python.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-python.ipynb
@@ -1532,7 +1532,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/SK-fort-boyard_v2.ipynb",
+   "output_path": "SK-fort-boyard_v2.ipynb",
    "parameters": {},
    "start_time": "2026-05-09T23:26:42.918574",
    "version": "2.6.0"


### PR DESCRIPTION
## Scope — po-2023 GenAI turf for #3436 (SemanticKernel sub-family)

Continuation of ai-01 c.36 dispatch (1 sous-famille/cycle). **GenAI/SemanticKernel** = sub-family 3/5. 6 notebooks committed machine-local absolute paths in `metadata.papermill.output_path`. This PR normalizes each to its basename.

| Notebook | Leaked `output_path` |
|----------|----------------------|
| 09-SemanticKernel-Building-CLR | `C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/SK-09_py.ipynb` |
| Notebook-Generated | `C:/Users/jsboi/AppData/Local/Temp/pile-commune-c32/Notebook-Generated.ipynb` |
| Notebook-Template | `C:/Users/jsboi/AppData/Local/Temp/pile-commune-c32/Notebook-Template.ipynb` |
| Workbook-Template-Python | `C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/SK-wtp_output.ipynb` |
| Workbook-Template | `C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/SK-wt_output.ipynb` |
| fort-boyard-python | `C:/Users/jsboi/AppData/Local/Temp/forensic_t17_genAI/SK-fort-boyard_v2.ipynb` |

## Tolerated normalization (not a scrub) — secrets-hygiene rule 6

`metadata.papermill.output_path` is **notebook metadata, not a cell output**. Machine-local paths leak the worker's filesystem layout (AppData/Temp, forensic_t17_genAI, pile-commune-c32 dirs). Normalizing to basename is the ONLY tolerated path fix — real outputs stay byte-identical, execution is not falsified. Re-exec would re-leak a different path, so source-side normalization is correct.

## Surgical method (C.3-safe)

Raw-JSON text replacement → only `output_path` value changes; everything else byte-identical. Diff: **+6/-6**. Strict check: zero added lines other than `output_path`. JSON re-parses valid for all 6. Mirrors Video #4389, Audio #4391, po-2025 #4385.

## Queue remaining (#3436 GenAI)

Video 4 ✅ (#4389) · Audio 11 ✅ (#4391) · **SemanticKernel 6 ✅ (this PR)** · 00-GenAI-Environment 4 · FineTuning 3 · Image 1.

See #3436