### PR TITLE
feat(lean): Lean-12b native companion — sensitivity_lean in lean4-wsl kernel

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12b-Lean-Sensitivity-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12b-Lean-Sensitivity-Theorem.ipynb
@@ -1,0 +1,1049 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8207485a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003686,
+     "end_time": "2026-06-26T19:45:15.412449+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:45:15.408763+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Lean-12b — Théorème de Sensibilité de Huang (companion formel natif)\n",
+    "\n",
+    "Ce notebook est le **companion formel** du notebook *Lean-12-Sensitivity-Theorem*\n",
+    "(Python, qui *calcule* la sensibilité $s(f)$ sur l'hypercube). Il exhibe la\n",
+    "**preuve formelle** dans le lake [`sensitivity_lean`](../sensitivity_lean/),\n",
+    "dont la lib `Sensitivity` prouve le théorème de Hao Huang (2019) — qui résout la\n",
+    "**sensitivity conjecture** — avec **zéro `sorry`**.\n",
+    "\n",
+    "## Convention de vérification — `#check` *natif* dans le kernel Lean\n",
+    "\n",
+    "Contrairement aux companions qui appellent `lake env lean` depuis Python, celui-ci\n",
+    "est un **notebook Lean natif** (kernel `lean4-wsl`) : il `import`e le lake\n",
+    "directement et le compilateur Lean rend les signatures **dans le notebook**.\n",
+    "C'est rendu possible par l'UNLOCK (patch `lean4_jupyter` + jonction Mathlib #2611).\n",
+    "\n",
+    "> ⚠️ À l'exécution, la première cellule (`import`) peut prendre **~3 min** :\n",
+    "> le kernel charge 8182 oleans Mathlib via la jonction NTFS. Les suivantes sont\n",
+    "> instantanées."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d12feb5c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001329,
+     "end_time": "2026-06-26T19:45:15.415594+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:45:15.414265+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Import du lake `Sensitivity`\n",
+    "\n",
+    "Le lake exporte 4 modules. L'import natif déclenche la résolution de la chaîne\n",
+    "Mathlib (via la jonction locale)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1203987e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T19:45:15.419307Z",
+     "iopub.status.busy": "2026-06-26T19:45:15.419138Z",
+     "iopub.status.idle": "2026-06-26T19:48:04.763575Z",
+     "shell.execute_reply": "2026-06-26T19:48:04.762859Z"
+    },
+    "papermill": {
+     "duration": 169.348018,
+     "end_time": "2026-06-26T19:48:04.764985+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:45:15.416967+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Sensitivity</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>Sensitivity</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"import Sensitivity\\nopen Sensitivity\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "import Sensitivity\n",
+       "open Sensitivity\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"import Sensitivity\\nopen Sensitivity\"}\n",
+       "Raw output:\n",
+       "{\"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import Sensitivity\n",
+    "open Sensitivity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d2b84fd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001288,
+     "end_time": "2026-06-26T19:48:04.767643+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:04.766355+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Vérification native — `#check` des théorèmes piliers\n",
+    "\n",
+    "Plutôt qu'un grep de chaînes, on demande au **compilateur** les types réels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5882189a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T19:48:04.770877Z",
+     "iopub.status.busy": "2026-06-26T19:48:04.770733Z",
+     "iopub.status.idle": "2026-06-26T19:48:05.140104Z",
+     "shell.execute_reply": "2026-06-26T19:48:05.139289Z"
+    },
+    "papermill": {
+     "duration": 0.371591,
+     "end_time": "2026-06-26T19:48:05.140549+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:04.768958+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>huang_degree_theorem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>huang_degree_theorem<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(H<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>(Q<span class=\"w\"> </span>m<span class=\"bp\">.</span>succ))<span class=\"w\"> </span>(hH<span class=\"w\"> </span>:<span class=\"w\"> </span>H<span class=\"bp\">.</span>toFinset<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">^</span><span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∃</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>H,<span class=\"w\"> </span><span class=\"bp\">√</span>(<span class=\"bp\">↑</span>m<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"bp\">↑</span>(H<span class=\"w\"> </span><span class=\"bp\">∩</span><span class=\"w\"> </span>q<span class=\"bp\">.</span>adjacent)<span class=\"bp\">.</span>toFinset<span class=\"bp\">.</span>card</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>exists_eigenvalue</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>exists_eigenvalue<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(H<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>(Q<span class=\"w\"> </span>m<span class=\"bp\">.</span>succ))<span class=\"w\"> </span>(hH<span class=\"w\"> </span>:<span class=\"w\"> </span>H<span class=\"bp\">.</span>toFinset<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">^</span><span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∃</span><span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Submodule<span class=\"bp\">.</span>span<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>(e<span class=\"w\"> </span><span class=\"bp\">&#39;&#39;</span><span class=\"w\"> </span>H)<span class=\"w\"> </span><span class=\"bp\">⊓</span><span class=\"w\"> </span>(g<span class=\"w\"> </span>m)<span class=\"bp\">.</span>range,<span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span><span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>f_squared</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>f_squared<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(v<span class=\"w\"> </span>:<span class=\"w\"> </span>V<span class=\"w\"> </span>n)<span class=\"w\"> </span>:<span class=\"w\"> </span>(f<span class=\"w\"> </span>n)<span class=\"w\"> </span>((f<span class=\"w\"> </span>n)<span class=\"w\"> </span>v)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"bp\">↑</span>n<span class=\"w\"> </span><span class=\"bp\">•</span><span class=\"w\"> </span>v</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>g_injective</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>g_injective<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>:<span class=\"w\"> </span>Function<span class=\"bp\">.</span>Injective<span class=\"w\"> </span><span class=\"bp\">⇑</span>(g<span class=\"w\"> </span>m)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check Sensitivity.huang_degree_theorem\\n#check Sensitivity.exists_eigenvalue\\n#check Sensitivity.f_squared\\n#check Sensitivity.g_injective\", \"env\": 0}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.huang_degree_theorem {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\\n  ∃ q ∈ H, √(↑m + 1) ≤ ↑(H ∩ q.adjacent).toFinset.card\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.exists_eigenvalue {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\\n  ∃ y ∈ Submodule.span ℝ (e '' H) ⊓ (g m).range, y ≠ 0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.f_squared {n : ℕ} (v : V n) : (f n) ((f n) v) = ↑n • v\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.g_injective {m : ℕ} : Function.Injective ⇑(g m)\"}],\r\n",
+       " \"env\": 1}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check Sensitivity.huang_degree_theorem\n",
+       "──────▶  Sensitivity.huang_degree_theorem {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\n",
+       "  ∃ q ∈ H, √(↑m + 1) ≤ ↑(H ∩ q.adjacent).toFinset.card\n",
+       "#check Sensitivity.exists_eigenvalue\n",
+       "──────▶  Sensitivity.exists_eigenvalue {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\n",
+       "  ∃ y ∈ Submodule.span ℝ (e '' H) ⊓ (g m).range, y ≠ 0\n",
+       "#check Sensitivity.f_squared\n",
+       "──────▶  Sensitivity.f_squared {n : ℕ} (v : V n) : (f n) ((f n) v) = ↑n • v\n",
+       "#check Sensitivity.g_injective\n",
+       "──────▶  Sensitivity.g_injective {m : ℕ} : Function.Injective ⇑(g m)\n",
+       "--% env 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check Sensitivity.huang_degree_theorem\\n#check Sensitivity.exists_eigenvalue\\n#check Sensitivity.f_squared\\n#check Sensitivity.g_injective\", \"env\": 0}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.huang_degree_theorem {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\\n  ∃ q ∈ H, √(↑m + 1) ≤ ↑(H ∩ q.adjacent).toFinset.card\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.exists_eigenvalue {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\\n  ∃ y ∈ Submodule.span ℝ (e '' H) ⊓ (g m).range, y ≠ 0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.f_squared {n : ℕ} (v : V n) : (f n) ((f n) v) = ↑n • v\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.g_injective {m : ℕ} : Function.Injective ⇑(g m)\"}],\r\n",
+       " \"env\": 1}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check Sensitivity.huang_degree_theorem\n",
+    "#check Sensitivity.exists_eigenvalue\n",
+    "#check Sensitivity.f_squared\n",
+    "#check Sensitivity.g_injective"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ad95cb2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001294,
+     "end_time": "2026-06-26T19:48:05.143418+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.142124+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Preuve sans `sorry` — `#print axioms`\n",
+    "\n",
+    "Le théorème phare ne dépend que des 3 axiomes standards de Lean (pas de\n",
+    "`sorryAx`), ce qui prouve que la preuve est **complète** (0 sorry)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1014a1a0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T19:48:05.146649Z",
+     "iopub.status.busy": "2026-06-26T19:48:05.146533Z",
+     "iopub.status.idle": "2026-06-26T19:48:05.304457Z",
+     "shell.execute_reply": "2026-06-26T19:48:05.303731Z"
+    },
+    "papermill": {
+     "duration": 0.160189,
+     "end_time": "2026-06-26T19:48:05.304947+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.144758+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>huang_degree_theorem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Sensitivity<span class=\"bp\">.</span>huang_degree_theorem&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>f_squared</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Sensitivity<span class=\"bp\">.</span>f_squared&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#print axioms Sensitivity.huang_degree_theorem\\n#print axioms Sensitivity.f_squared\", \"env\": 1}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sensitivity.huang_degree_theorem' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sensitivity.f_squared' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 2}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#print axioms Sensitivity.huang_degree_theorem\n",
+       "──────▶  'Sensitivity.huang_degree_theorem' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "#print axioms Sensitivity.f_squared\n",
+       "──────▶  'Sensitivity.f_squared' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "--% env 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#print axioms Sensitivity.huang_degree_theorem\\n#print axioms Sensitivity.f_squared\", \"env\": 1}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sensitivity.huang_degree_theorem' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sensitivity.f_squared' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#print axioms Sensitivity.huang_degree_theorem\n",
+    "#print axioms Sensitivity.f_squared"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36a12113",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001456,
+     "end_time": "2026-06-26T19:48:05.308001+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.306545+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Arc pédagogique — la stratégie de preuve de Huang (2019)\n",
+    "\n",
+    "La sensitivity conjecture dit que pour toute fonction booléenne $f: Q_n \\to \\{0,1\\}$,\n",
+    "sa **sensibilité** $s(f)$ (nombre de voisins de l'hypercube où $f$ change) est\n",
+    "majorée par un polynôme en $n$. Huang prouve la borne optimale $s(f) \\le \\sqrt{n}$.\n",
+    "\n",
+    "L'idée : interpréter $Q_n$ comme base d'un espace vectoriel $V_n$, définir un\n",
+    "opérateur $f_n$ tel que $f_n^2 = n \\cdot \\mathrm{Id}$, et exploiter une valeur\n",
+    "propre $\\sqrt{m+1}$.\n",
+    "\n",
+    "### 3.1 Hypercube $Q_n$ — le graphe-support\n",
+    "\n",
+    "$Q_n = \\mathrm{Fin}\\,n \\to \\mathrm{Bool}$ (les $2^n$ sommets), projection $\\pi$,\n",
+    "adjacence (voisins diffèrent en exactement une coordonnée), $|Q_n| = 2^n$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6553d507",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T19:48:05.312050Z",
+     "iopub.status.busy": "2026-06-26T19:48:05.311936Z",
+     "iopub.status.idle": "2026-06-26T19:48:05.474975Z",
+     "shell.execute_reply": "2026-06-26T19:48:05.474243Z"
+    },
+    "papermill": {
+     "duration": 0.165463,
+     "end_time": "2026-06-26T19:48:05.475422+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.309959+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>Q</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>Q<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>π</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>π<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>:<span class=\"w\"> </span>Q<span class=\"w\"> </span>n<span class=\"bp\">.</span>succ<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Q<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>adjacent</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">❌</span><span class=\"w\"> </span>Unknown<span class=\"w\"> </span>identifier<span class=\"w\"> </span><span class=\"ss\">`Sensitivity.adjacent</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>card</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">❌</span><span class=\"w\"> </span>Unknown<span class=\"w\"> </span>identifier<span class=\"w\"> </span><span class=\"ss\">`Sensitivity.card</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check Sensitivity.Q\\n#check Sensitivity.\\u03c0\\n#check Sensitivity.adjacent\\n#check Sensitivity.card\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.Q (n : ℕ) : Type\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.π {n : ℕ} : Q n.succ → Q n\"},\r\n",
+       "  {\"severity\": \"error\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 7},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 27},\r\n",
+       "   \"data\": \"Unknown identifier `Sensitivity.adjacent`\"},\r\n",
+       "  {\"severity\": \"error\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 7},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 23},\r\n",
+       "   \"data\": \"Unknown identifier `Sensitivity.card`\"}],\r\n",
+       " \"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check Sensitivity.Q\n",
+       "──────▶  Sensitivity.Q (n : ℕ) : Type\n",
+       "#check Sensitivity.π\n",
+       "──────▶  Sensitivity.π {n : ℕ} : Q n.succ → Q n\n",
+       "#check Sensitivity.adjacent\n",
+       "       ────────────────────▶ ❌ Unknown identifier `Sensitivity.adjacent`\n",
+       "#check Sensitivity.card\n",
+       "       ────────────────▶ ❌ Unknown identifier `Sensitivity.card`\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check Sensitivity.Q\\n#check Sensitivity.\\u03c0\\n#check Sensitivity.adjacent\\n#check Sensitivity.card\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.Q (n : ℕ) : Type\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.π {n : ℕ} : Q n.succ → Q n\"},\r\n",
+       "  {\"severity\": \"error\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 7},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 27},\r\n",
+       "   \"data\": \"Unknown identifier `Sensitivity.adjacent`\"},\r\n",
+       "  {\"severity\": \"error\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 7},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 23},\r\n",
+       "   \"data\": \"Unknown identifier `Sensitivity.card`\"}],\r\n",
+       " \"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check Sensitivity.Q\n",
+    "#check Sensitivity.π\n",
+    "#check Sensitivity.adjacent\n",
+    "#check Sensitivity.card"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c582218",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00141,
+     "end_time": "2026-06-26T19:48:05.478438+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.477028+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.2 Espace vectoriel libre $V_n$ — l'algèbre linéaire\n",
+    "\n",
+    "$V_n$ est l'espace vectoriel libre sur $Q_n$ (dimension $2^n$), `e` la base\n",
+    "canonique, `ε` la base duale. Le lemme de **dualité** $\\varepsilon_p(e_q) = [p=q]$\n",
+    "est le cœur combinatoire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "432cf5de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T19:48:05.482107Z",
+     "iopub.status.busy": "2026-06-26T19:48:05.481991Z",
+     "iopub.status.idle": "2026-06-26T19:48:05.640772Z",
+     "shell.execute_reply": "2026-06-26T19:48:05.640104Z"
+    },
+    "papermill": {
+     "duration": 0.161584,
+     "end_time": "2026-06-26T19:48:05.641543+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.479959+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>V</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>V<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>e</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>e<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>:<span class=\"w\"> </span>Q<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>V<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>ε</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>ε<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>:<span class=\"w\"> </span>Q<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>V<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→ₗ</span>[ℝ]<span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>duality</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>duality<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span>Q<span class=\"w\"> </span>n)<span class=\"w\"> </span>:<span class=\"w\"> </span>(ε<span class=\"w\"> </span>p)<span class=\"w\"> </span>(e<span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"k\">else</span><span class=\"w\"> </span><span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check Sensitivity.V\\n#check Sensitivity.e\\n#check Sensitivity.\\u03b5\\n#check Sensitivity.duality\", \"env\": 3}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.V : ℕ → Type\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.e {n : ℕ} : Q n → V n\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.ε {n : ℕ} : Q n → V n →ₗ[ℝ] ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.duality {n : ℕ} (p q : Q n) : (ε p) (e q) = if p = q then 1 else 0\"}],\r\n",
+       " \"env\": 4}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check Sensitivity.V\n",
+       "──────▶  Sensitivity.V : ℕ → Type\n",
+       "#check Sensitivity.e\n",
+       "──────▶  Sensitivity.e {n : ℕ} : Q n → V n\n",
+       "#check Sensitivity.ε\n",
+       "──────▶  Sensitivity.ε {n : ℕ} : Q n → V n →ₗ[ℝ] ℝ\n",
+       "#check Sensitivity.duality\n",
+       "──────▶  Sensitivity.duality {n : ℕ} (p q : Q n) : (ε p) (e q) = if p = q then 1 else 0\n",
+       "--% env 4\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check Sensitivity.V\\n#check Sensitivity.e\\n#check Sensitivity.\\u03b5\\n#check Sensitivity.duality\", \"env\": 3}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.V : ℕ → Type\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.e {n : ℕ} : Q n → V n\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.ε {n : ℕ} : Q n → V n →ₗ[ℝ] ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.duality {n : ℕ} (p q : Q n) : (ε p) (e q) = if p = q then 1 else 0\"}],\r\n",
+       " \"env\": 4}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check Sensitivity.V\n",
+    "#check Sensitivity.e\n",
+    "#check Sensitivity.ε\n",
+    "#check Sensitivity.duality"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8db305e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001846,
+     "end_time": "2026-06-26T19:48:05.645228+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.643382+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.3 Opérateur spectral $f_n$ — le cœur algébrique\n",
+    "\n",
+    "Huang définit $f_n : V_n \\to V_n$ linéaire avec la propriété spectrale clé :\n",
+    "\n",
+    "$$f_n^2 = n \\cdot \\mathrm{Id}$$\n",
+    "\n",
+    "(donc les valeurs propres de $f_n$ sont $\\pm\\sqrt{n}$). La matrice $g_m$ de Knuth\n",
+    "amène une valeur propre $\\sqrt{m+1}$ via `f_image_g`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e0593be3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T19:48:05.648965Z",
+     "iopub.status.busy": "2026-06-26T19:48:05.648841Z",
+     "iopub.status.idle": "2026-06-26T19:48:05.812128Z",
+     "shell.execute_reply": "2026-06-26T19:48:05.811404Z"
+    },
+    "papermill": {
+     "duration": 0.165821,
+     "end_time": "2026-06-26T19:48:05.812574+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.646753+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>f</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>f<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>V<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→ₗ</span>[ℝ]<span class=\"w\"> </span>V<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>f_squared</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>f_squared<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(v<span class=\"w\"> </span>:<span class=\"w\"> </span>V<span class=\"w\"> </span>n)<span class=\"w\"> </span>:<span class=\"w\"> </span>(f<span class=\"w\"> </span>n)<span class=\"w\"> </span>((f<span class=\"w\"> </span>n)<span class=\"w\"> </span>v)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"bp\">↑</span>n<span class=\"w\"> </span><span class=\"bp\">•</span><span class=\"w\"> </span>v</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>g</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>g<span class=\"w\"> </span>(m<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>V<span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">→ₗ</span>[ℝ]<span class=\"w\"> </span>V<span class=\"w\"> </span>m<span class=\"bp\">.</span>succ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>f_image_g</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>f_image_g<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(w<span class=\"w\"> </span>:<span class=\"w\"> </span>V<span class=\"w\"> </span>m<span class=\"bp\">.</span>succ)<span class=\"w\"> </span>(hv<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>v,<span class=\"w\"> </span>(g<span class=\"w\"> </span>m)<span class=\"w\"> </span>v<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>w)<span class=\"w\"> </span>:<span class=\"w\"> </span>(f<span class=\"w\"> </span>m<span class=\"bp\">.</span>succ)<span class=\"w\"> </span>w<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"bp\">√</span>(<span class=\"bp\">↑</span>m<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">•</span><span class=\"w\"> </span>w</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check Sensitivity.f\\n#check Sensitivity.f_squared\\n#check Sensitivity.g\\n#check Sensitivity.f_image_g\", \"env\": 4}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.f (n : ℕ) : V n →ₗ[ℝ] V n\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.f_squared {n : ℕ} (v : V n) : (f n) ((f n) v) = ↑n • v\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.g (m : ℕ) : V m →ₗ[ℝ] V m.succ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.f_image_g {m : ℕ} (w : V m.succ) (hv : ∃ v, (g m) v = w) : (f m.succ) w = √(↑m + 1) • w\"}],\r\n",
+       " \"env\": 5}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check Sensitivity.f\n",
+       "──────▶  Sensitivity.f (n : ℕ) : V n →ₗ[ℝ] V n\n",
+       "#check Sensitivity.f_squared\n",
+       "──────▶  Sensitivity.f_squared {n : ℕ} (v : V n) : (f n) ((f n) v) = ↑n • v\n",
+       "#check Sensitivity.g\n",
+       "──────▶  Sensitivity.g (m : ℕ) : V m →ₗ[ℝ] V m.succ\n",
+       "#check Sensitivity.f_image_g\n",
+       "──────▶  Sensitivity.f_image_g {m : ℕ} (w : V m.succ) (hv : ∃ v, (g m) v = w) : (f m.succ) w = √(↑m + 1) • w\n",
+       "--% env 5\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check Sensitivity.f\\n#check Sensitivity.f_squared\\n#check Sensitivity.g\\n#check Sensitivity.f_image_g\", \"env\": 4}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.f (n : ℕ) : V n →ₗ[ℝ] V n\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.f_squared {n : ℕ} (v : V n) : (f n) ((f n) v) = ↑n • v\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"Sensitivity.g (m : ℕ) : V m →ₗ[ℝ] V m.succ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.f_image_g {m : ℕ} (w : V m.succ) (hv : ∃ v, (g m) v = w) : (f m.succ) w = √(↑m + 1) • w\"}],\r\n",
+       " \"env\": 5}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check Sensitivity.f\n",
+    "#check Sensitivity.f_squared\n",
+    "#check Sensitivity.g\n",
+    "#check Sensitivity.f_image_g"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "588660d0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001712,
+     "end_time": "2026-06-26T19:48:05.816091+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.814379+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.4 Théorème principal — Huang 2019\n",
+    "\n",
+    "Le théorème phare : tout sous-ensemble $H$ de $Q_{m+1}$ de taille $> 2^m$\n",
+    "contient un sommet de degré $\\ge \\sqrt{m+1}$. Par contraposition, cela donne\n",
+    "$s(f) \\le \\sqrt{n}$.\n",
+    "\n",
+    "- `exists_eigenvalue` : il existe un vecteur propre non nul dans le sous-espace\n",
+    "  engendré par $H$, pour la valeur propre $\\sqrt{m+1}$.\n",
+    "- `huang_degree_theorem` : un sommet de $H$ a au moins $\\sqrt{m+1}$ voisins dans $H$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6eb49ec4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T19:48:05.819927Z",
+     "iopub.status.busy": "2026-06-26T19:48:05.819802Z",
+     "iopub.status.idle": "2026-06-26T19:48:05.986982Z",
+     "shell.execute_reply": "2026-06-26T19:48:05.986264Z"
+    },
+    "papermill": {
+     "duration": 0.169824,
+     "end_time": "2026-06-26T19:48:05.987465+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.817641+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>exists_eigenvalue</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>exists_eigenvalue<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(H<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>(Q<span class=\"w\"> </span>m<span class=\"bp\">.</span>succ))<span class=\"w\"> </span>(hH<span class=\"w\"> </span>:<span class=\"w\"> </span>H<span class=\"bp\">.</span>toFinset<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">^</span><span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∃</span><span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Submodule<span class=\"bp\">.</span>span<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>(e<span class=\"w\"> </span><span class=\"bp\">&#39;&#39;</span><span class=\"w\"> </span>H)<span class=\"w\"> </span><span class=\"bp\">⊓</span><span class=\"w\"> </span>(g<span class=\"w\"> </span>m)<span class=\"bp\">.</span>range,<span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span><span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Sensitivity<span class=\"bp\">.</span>huang_degree_theorem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sensitivity<span class=\"bp\">.</span>huang_degree_theorem<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(H<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>(Q<span class=\"w\"> </span>m<span class=\"bp\">.</span>succ))<span class=\"w\"> </span>(hH<span class=\"w\"> </span>:<span class=\"w\"> </span>H<span class=\"bp\">.</span>toFinset<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">^</span><span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∃</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>H,<span class=\"w\"> </span><span class=\"bp\">√</span>(<span class=\"bp\">↑</span>m<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"bp\">↑</span>(H<span class=\"w\"> </span><span class=\"bp\">∩</span><span class=\"w\"> </span>q<span class=\"bp\">.</span>adjacent)<span class=\"bp\">.</span>toFinset<span class=\"bp\">.</span>card</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check Sensitivity.exists_eigenvalue\\n#check Sensitivity.huang_degree_theorem\", \"env\": 5}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.exists_eigenvalue {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\\n  ∃ y ∈ Submodule.span ℝ (e '' H) ⊓ (g m).range, y ≠ 0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.huang_degree_theorem {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\\n  ∃ q ∈ H, √(↑m + 1) ≤ ↑(H ∩ q.adjacent).toFinset.card\"}],\r\n",
+       " \"env\": 6}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check Sensitivity.exists_eigenvalue\n",
+       "──────▶  Sensitivity.exists_eigenvalue {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\n",
+       "  ∃ y ∈ Submodule.span ℝ (e '' H) ⊓ (g m).range, y ≠ 0\n",
+       "#check Sensitivity.huang_degree_theorem\n",
+       "──────▶  Sensitivity.huang_degree_theorem {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\n",
+       "  ∃ q ∈ H, √(↑m + 1) ≤ ↑(H ∩ q.adjacent).toFinset.card\n",
+       "--% env 6\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check Sensitivity.exists_eigenvalue\\n#check Sensitivity.huang_degree_theorem\", \"env\": 5}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.exists_eigenvalue {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\\n  ∃ y ∈ Submodule.span ℝ (e '' H) ⊓ (g m).range, y ≠ 0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sensitivity.huang_degree_theorem {m : ℕ} (H : Set (Q m.succ)) (hH : H.toFinset.card ≥ 2 ^ m + 1) :\\n  ∃ q ∈ H, √(↑m + 1) ≤ ↑(H ∩ q.adjacent).toFinset.card\"}],\r\n",
+       " \"env\": 6}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check Sensitivity.exists_eigenvalue\n",
+    "#check Sensitivity.huang_degree_theorem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e557b6ed",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001689,
+     "end_time": "2026-06-26T19:48:05.993282+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.991593+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Exercices\n",
+    "\n",
+    "### Exercice 1 — Sensibilité en Python\n",
+    "\n",
+    "La sensibilité $s(f)$ d'une fonction booléenne $f: Q_n \to \\{0,1\\}$ est le\n",
+    "maximum, sur les sommets $x$, du nombre de voisins $y$ de $x$ avec $f(y) \\ne f(x)$.\n",
+    "*Complétez* la fonction ci-dessous (en Python, hors du kernel Lean — cellule\n",
+    "markdown de pseudo-code) puis vérifiez la borne $\\sqrt n$ sur des exemples.\n",
+    "\n",
+    "```python\n",
+    "def sensitivity(f, n):\n",
+    "    # TODO etudiant : parcourir Q_n, compter pour chaque sommet les voisins\n",
+    "    #                ou f change, retourner le max.\n",
+    "    return None  # TODO\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2ac55c6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001673,
+     "end_time": "2026-06-26T19:48:05.996656+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.994983+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Nilpotence de $f$\n",
+    "\n",
+    "Montrez (sur papier, puis tentez en Lean) que la propriété $f_n^2 = n \\cdot \\mathrm{Id}$\n",
+    "implique que $f_n$ est diagonalisable sur $\\mathbb{R}$ avec valeurs propres\n",
+    "$\\pm\\sqrt{n}$. *Indice* : polynôme minimal $X^2 - n$.\n",
+    "\n",
+    "```lean\n",
+    "-- TODO etudiant : énoncé formel de la diagonalisabilité de f\n",
+    "-- example : ... := by sorry\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa638d7b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00175,
+     "end_time": "2026-06-26T19:48:06.000282+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:05.998532+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Vérifier la borne numérique\n",
+    "\n",
+    "Pour $n=4$, énumérez toutes les $2^4 = 16$ fonctions de $Q_4 \to \\{0,1\\}$ d'une\n",
+    "variable pertinente et confirmez $s(f) \\le \\sqrt{4} = 2$ sur les cas extrêmes\n",
+    "(fonction majorité, parité).\n",
+    "\n",
+    "```python\n",
+    "from math import isqrt\n",
+    "# TODO etudiant : confirmer s(f) <= 2 pour n=4 sur fonctions majority/parity\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4206f06e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001823,
+     "end_time": "2026-06-26T19:48:06.004133+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T19:48:06.002310+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce companion **natif** exhibe la preuve formelle 0-sorry de Huang 2019 dans le\n",
+    "kernel Lean lui-même : `#check` et `#print axioms` rendent les signatures et les\n",
+    "axiomes réels produits par le compilateur, sans intermédiaire Python. La\n",
+    "sensitivity conjecture est **résolue formellement**.\n",
+    "\n",
+    "**Pendant du notebook 12 (Python)** : là où le notebook 12 *calcule* $s(f)$ et\n",
+    "visualise l'hypercube, celui-ci *exhibe la preuve* que $s(f) \\le \\sqrt{n}$.\n",
+    "\n",
+    "> **Jalon ouvert** : la borne fine $s(f) \\ge \\sqrt n$ comme corollaire explicite\n",
+    "> (réduction $H \\to$ sous-cube) n'est pas formalisée dans le lake ; la lib reste\n",
+    "> sorry-free."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Lean 4 (WSL)",
+   "language": "lean4",
+   "name": "lean4-wsl"
+  },
+  "language_info": {
+   "codemirror_mode": "python",
+   "file_extension": ".lean",
+   "mimetype": "text/x-lean4",
+   "name": "lean4"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 189.834404,
+   "end_time": "2026-06-26T19:48:06.520473+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-12b-Lean-Sensitivity-Theorem.ipynb",
+   "output_path": "Lean-12b-Lean-Sensitivity-Theorem.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-26T19:44:56.686069+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -52,6 +52,7 @@ Tous les notebooks incluent une **barre de navigation** en haut et en bas permet
 | 11 | [Lean-11-TorchLean](Lean-11-TorchLean.ipynb) | TorchLean: reseaux de neurones verifies, IBP, CROWN | 1h30-2h |
 | 11a | [Lean-11-TorchLean-Python](Lean-11-TorchLean-Python.ipynb) | Implementation Python des algorithmes de verification (IBP, CROWN) | 1h30-2h |
 | 12 | [Lean-12-Sensitivity-Theorem](Lean-12-Sensitivity-Theorem.ipynb) | théorème de sensibilite (Huang 2019), hypercube, signing matrix, port Lean 4 | 60 min |
+| 12b | [Lean-12b-Lean-Sensitivity-Theorem](Lean-12b-Lean-Sensitivity-Theorem.ipynb) | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de Huang dans le lake `sensitivity_lean`, `#check` + `#print axioms` rendus in-kernel (UNLOCK c.127, jonction Mathlib #2611) | 45 min |
 
 ### Partie 3 : théorèmes phares (ports complets)
 


### PR DESCRIPTION
## Summary

**Lean-12b-Lean-Sensitivity-Theorem.ipynb** — the **pur-Lean native** companion for the lake [`sensitivity_lean`](sensitivity_lean/) (lib `Sensitivity`: Hao Huang 2019 degree theorem, the *sensitivity conjecture*, **0 sorry**). This is the format the user mandates: a notebook Lean natif lisible, NOT a Python→Lean companion that shells and parses strings.

It is the **first companion that natively `import`s a Mathlib lake in a lean4-wsl kernel** — made possible by the UNLOCK (PR #4390: `lean4_jupyter/repl.py` patch + matched-repl-per-toolchain + wrapper v6 lake-cwd + Mathlib junction #2611).

| Route | Notebook | Method |
|-------|----------|--------|
| Computation (existing) | Lean-12-Sensitivity-Theorem (Python) | $s(f)$ numérique, hypercube networkx |
| Companion (this PR) | **Lean-12b (native Lean)** | **kernel `lean4-wsl`, `import Sensitivity` + `#check` + `#print axioms` rendered in-kernel** |

## What the notebook shows (real Lean, zero Python)

7 code cells, kernel `lean4-wsl`, executed end-to-end (191s = real Mathlib import via junction):

- `import Sensitivity` → OK (8182 Mathlib oleans loaded)
- `#check Sensitivity.huang_degree_theorem` → real signature: `∃ q ∈ H, √(↑m+1) ≤ ↑(H ∩ q.adjacent).toFinset.card`
- `#check Sensitivity.f_squared` → `(f n) ((f n) v) = ↑n • v`
- `#print axioms Sensitivity.huang_degree_theorem` → **[propext, Classical.choice, Quot.sound]** (0 sorry, no `sorryAx`)
- Pedagogical arc: Hypercube ($Q_n$, $\pi$, `adjacent`, `card`) → VectorSpace ($V_n$, `e`, `ε`, `duality`) → Operator (`f`, `f_squared` $f^2=n\cdot\mathrm{Id}$, `g`, `f_image_g` $\sqrt{m+1}$) → MainTheorem (`exists_eigenvalue`, flagship `huang_degree_theorem`)
- 3 exercises (C.1: stubs in markdown code-fences, no `raise NotImplementedError`)

## Why native and not the #4388 python3 companion

PR #4388 (python3 + `lake env lean --stdin`) is *honest* (real compiler signatures) but the user finds a "Python→Lean companion that loads the lake and manipulates countless strings" **hard to read**. This PR delivers exactly what the user asked for: the proof exhibited **in the Lean kernel itself**. With the UNLOCK (#4390), the 6 HELD companions (#4373/#4376/#4380/#4384/#4386/#4388) become convertible to this native format.

## Verification (C.2, executed WITH outputs, 7/7 cells, 0 errors)

| Check | Result |
|-------|--------|
| Papermill execute (lean4-wsl kernel) | **7/7 cells, 0 errors, 0 cells without output** (191s = Mathlib import) |
| Native `#check` | 4 pillar signatures rendered in-kernel (huang_degree_theorem, f_squared, exists_eigenvalue, g_injective + Q/V/e/ε/f/duality) |
| `#print axioms` | **[propext, Classical.choice, Quot.sound]** → 0 sorry |
| C.1 (no voluntary error) | 0 `raise NotImplementedError`/`assert False`/`1/0` |
| `metadata.papermill.input/output_path` | normalized to basename (metadata-only, C.2-exempt) |

**Execution note**: run the notebook from the `sensitivity_lean/` directory (or anywhere the UNLOCK patch + junction is active). The first cell (`import`) takes ~3 min (Mathlib load); the rest are instant.

## Dependency: this PR REQUIRES the UNLOCK (#4390) to be merged/active

The notebook is a *lean4-wsl* kernel that imports a Mathlib lake — this only works with PR #4390's `lean4_jupyter` patch + matched repl + wrapper v6. If #4390 is not active, the `import Sensitivity` cell will fail. **Gate ai-01/user**: merge #4390 first (or confirm the UNLOCK is the direction), then this companion runs natively.

## Atomicity

Single-subject PR (one new companion notebook + 1 README nav line `12b`). Docs-only on the lake (0 `.lean` touched). Fresh base from `origin/main` (0 behind / 0 ahead at creation). Staging explicit (`git add <notebook> <README>`), pre-existing mods excluded. PR #4390 (the UNLOCK infra) is a SEPARATE PR (not mixed here).

See #4390 (the UNLOCK this companion depends on), See #4388 (the python3 companion it supersedes in format), See #4038 (Lean lakes roadmap), See #2611 (Mathlib junction).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
