### PR TITLE
fix(genai-ft): normalize papermill input/output_path to basename (#3436, FineTuning)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb
@@ -1557,8 +1557,8 @@
    "end_time": "2026-05-24T02:10:22.454077",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\GenAI\\FineTuning\\FT-02-QLoRA-Quantization.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/ft-02-output.ipynb",
+   "input_path": "FT-02-QLoRA-Quantization.ipynb",
+   "output_path": "ft-02-output.ipynb",
    "parameters": {},
    "start_time": "2026-05-24T02:06:35.231730",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb
@@ -1618,8 +1618,8 @@
    "end_time": "2026-05-24T08:32:46.756442",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/FT-03-output.ipynb",
+   "input_path": "FT-03-Supervised-FineTuning-SFT.ipynb",
+   "output_path": "FT-03-output.ipynb",
    "parameters": {},
    "start_time": "2026-05-24T08:28:45.026139",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb
@@ -1601,8 +1601,8 @@
    "end_time": "2026-05-24T09:48:24.360907",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/ft04_output.ipynb",
+   "input_path": "FT-04-RLHF-DPO.ipynb",
+   "output_path": "ft04_output.ipynb",
    "parameters": {},
    "start_time": "2026-05-24T09:46:13.299908",
    "version": "2.6.0"


### PR DESCRIPTION
## Scope — po-2023 GenAI turf for #3436 (FineTuning sub-family)

Continuation of ai-01 c.36 dispatch (1 sous-famille/cycle). **GenAI/FineTuning** = sub-family 5/6. 3 notebooks, each with 2 non-basename `metadata.papermill` paths. Re-scanned with a **broad pattern** (leçon c.39 — narrow regex missed relative-prefix entries).

### Per-notebook: 2 categories (honest G.1 distinction)

| Notebook | Machine-leak `output_path` | Relative-prefix `input_path` |
|----------|----------------------------|------------------------------|
| FT-02-QLoRA-Quantization | `C:/Users/jsboi/AppData/Local/Temp/ft-02-output.ipynb` | `MyIA.AI.Notebooks\GenAI\FineTuning\FT-02-QLoRA-Quantization.ipynb` |
| FT-03-Supervised-FineTuning-SFT | `C:/Users/jsboi/AppData/Local/Temp/FT-03-output.ipynb` | `MyIA.AI.Notebooks\GenAI\FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb` |
| FT-04-RLHF-DPO | `C:/Users/jsboi/AppData/Local/Temp/ft04_output.ipynb` | `MyIA.AI.Notebooks\GenAI\FineTuning/FT-04-RLHF-DPO.ipynb` |

- The 3 **output_path** = true machine-path leaks (the #3436 target — reveal worker filesystem layout).
- The 3 **input_path** = relative-path prefixes (not machine reveals), some with Windows backslashes. Normalized to basename for papermill-metadata consistency — `input_path` normalization is explicitly in #3436 scope (po-2025 PR #4385 fixed input+output for Z3-05).

## Tolerated normalization (secrets-hygiene rule 6)

`metadata.papermill.{input,output}_path` is **notebook metadata, not a cell output**. Normalizing to basename does not falsify execution — real outputs stay byte-identical.

## Surgical method (C.3-safe)

Raw-JSON text replacement (Windows-backslash-aware: converts `\` and `/` separators before basename) → only path values change. Diff: **+6/-6**. Strict check: zero changed lines other than `input_path`/`output_path`. JSON re-parses valid for all 3.

## Queue remaining (#3436 GenAI)

Video 4 ✅ (#4389) · Audio 11 ✅ (#4391) · SK 6 ✅ (#4392) · 00-Env 6 ✅ (#4395) · **FineTuning 3 ✅ (this PR)** · Image 1.

See #3436