### PR TITLE
feat(GameTheory): GameTheory-5b native companion — minimax_lean via Sion (2nd native)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-5b-Lean-Minimax.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-5b-Lean-Minimax.ipynb
@@ -1,0 +1,901 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0cdf5409",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00448,
+     "end_time": "2026-06-26T21:50:33.798088+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:50:33.793608+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-5b — Théorème minimax de von Neumann (companion formel natif)\n",
+    "\n",
+    "Ce notebook est le **companion formel** du lake [`minimax_lean`](../minimax_lean/),\n",
+    "dont la lib `Minimax` prouve le **théorème minimax de von Neumann** (1928) pour les\n",
+    "jeux finis à somme nulle — via le **minimax de Sion** (Mathlib `Topology.Sion`) — avec\n",
+    "**zéro `sorry`**.\n",
+    "\n",
+    "$$\\max_x \\min_y\\, x^{T} A\\, y \\;=\\; \\min_y \\max_x\\, x^{T} A\\, y$$\n",
+    "\n",
+    "(`x` parcourt le simplexe des stratégies mixtes du joueur-ligne, `y` celui du\n",
+    "joueur-colonne, `A` est la matrice de gains `m × n`).\n",
+    "\n",
+    "## Convention de vérification — `#check` *natif* dans le kernel Lean\n",
+    "\n",
+    "Ce notebook est un **notebook Lean natif** (kernel `lean4-wsl`) : il `import`e le lake\n",
+    "directement et le compilateur Lean rend les signatures **dans le notebook**. C'est rendu\n",
+    "possible par l'UNLOCK (patch `lean4_jupyter` + jonction Mathlib #2611).\n",
+    "\n",
+    "> ⚠️ À l'exécution, la première cellule (`import`) peut prendre **~3 min** :\n",
+    "> le kernel charge les oleans Mathlib via la jonction NTFS. Les suivantes sont\n",
+    "> instantanées."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f909d59f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002686,
+     "end_time": "2026-06-26T21:50:33.804861+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:50:33.802175+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Import des modules du lake `minimax_lean`\n",
+    "\n",
+    "Le lake `minimax_lean` est structuré en 3 modules (`ZeroSum`, `Concavity`,\n",
+    "`SionApplication`) sous le namespace `MinimaxLean`. On importe les 3 modules\n",
+    "(l'umbrella racine n'est pas buildée par la config `submodules` du lake — on\n",
+    "cible donc directement les modules qui portent les définitions)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3e1df1aa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T21:50:33.811633Z",
+     "iopub.status.busy": "2026-06-26T21:50:33.811456Z",
+     "iopub.status.idle": "2026-06-26T21:54:47.763278Z",
+     "shell.execute_reply": "2026-06-26T21:54:47.762311Z"
+    },
+    "papermill": {
+     "duration": 254.047724,
+     "end_time": "2026-06-26T21:54:47.855247+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:50:33.807523+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Minimax<span class=\"bp\">.</span>ZeroSum</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Minimax<span class=\"bp\">.</span>Concavity</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Minimax<span class=\"bp\">.</span>SionApplication</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>MinimaxLean</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"import Minimax.ZeroSum\\nimport Minimax.Concavity\\nimport Minimax.SionApplication\\nopen MinimaxLean\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "import Minimax.ZeroSum\n",
+       "import Minimax.Concavity\n",
+       "import Minimax.SionApplication\n",
+       "open MinimaxLean\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"import Minimax.ZeroSum\\nimport Minimax.Concavity\\nimport Minimax.SionApplication\\nopen MinimaxLean\"}\n",
+       "Raw output:\n",
+       "{\"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import Minimax.ZeroSum\n",
+    "import Minimax.Concavity\n",
+    "import Minimax.SionApplication\n",
+    "open MinimaxLean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07855da9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0069,
+     "end_time": "2026-06-26T21:54:47.873312+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:47.866412+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Preuve sans `sorry` — `#print axioms`\n",
+    "\n",
+    "Le théorème phare `exists_saddle_point_payoff` ne dépend que des **3 axiomes\n",
+    "standards de Lean** (`propext`, `Classical.choice`, `Quot.sound`) — pas de\n",
+    "`sorryAx` — ce qui prouve que la preuve est **complète** (0 sorry)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9aac24c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T21:54:47.884373Z",
+     "iopub.status.busy": "2026-06-26T21:54:47.884200Z",
+     "iopub.status.idle": "2026-06-26T21:54:48.119695Z",
+     "shell.execute_reply": "2026-06-26T21:54:48.118728Z"
+    },
+    "papermill": {
+     "duration": 0.243961,
+     "end_time": "2026-06-26T21:54:48.120364+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:47.876403+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>MinimaxLean<span class=\"bp\">.</span>exists_saddle_point_payoff</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>MinimaxLean<span class=\"bp\">.</span>exists_saddle_point_payoff&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#print axioms MinimaxLean.exists_saddle_point_payoff\", \"env\": 0}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'MinimaxLean.exists_saddle_point_payoff' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 1}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#print axioms MinimaxLean.exists_saddle_point_payoff\n",
+       "──────▶  'MinimaxLean.exists_saddle_point_payoff' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "--% env 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#print axioms MinimaxLean.exists_saddle_point_payoff\", \"env\": 0}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'MinimaxLean.exists_saddle_point_payoff' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 1}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#print axioms MinimaxLean.exists_saddle_point_payoff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22ae23c8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003634,
+     "end_time": "2026-06-26T21:54:48.129023+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.125389+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Matrice de gains, stratégies mixtes, payoff bilinéaire\n",
+    "\n",
+    "Le module `Minimax/ZeroSum.lean` pose le cadre combinatoire :\n",
+    "\n",
+    "- `PayoffMatrix m n = Matrix m n ℝ` — les gains du joueur-ligne ($A_{ij}$ quand $i$ joue ligne $i$, $j$ colonne $j$).\n",
+    "- `payoff A x y = Σ_{(i,j)} x_i · A_{ij} · y_j` — le **payoff espéré bilinéaire** sous les stratégies mixtes $x$ (lignes) et $y$ (colonnes).\n",
+    "\n",
+    "La représentation comme **somme unique sur le produit** $m × n$ rend la bilinéarité\n",
+    "immédiate (`sum_add_distrib` / `sum_mul` en une étape), et la continuité découle\n",
+    "de la continuité des opérations algébriques sur `ℝ`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "97316e51",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T21:54:48.138018Z",
+     "iopub.status.busy": "2026-06-26T21:54:48.137859Z",
+     "iopub.status.idle": "2026-06-26T21:54:48.356490Z",
+     "shell.execute_reply": "2026-06-26T21:54:48.355668Z"
+    },
+    "papermill": {
+     "duration": 0.224696,
+     "end_time": "2026-06-26T21:54:48.356922+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.132226+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>PayoffMatrix</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>PayoffMatrix<span class=\"bp\">.</span>{u_3,<span class=\"w\"> </span>u_4}<span class=\"w\"> </span>(m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_3)<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_4)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>(max<span class=\"w\"> </span>u_3<span class=\"w\"> </span>u_4)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>payoff</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>payoff<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]<span class=\"w\"> </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)\n",
+       "<span class=\"w\">  </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>payoff_add_in_x</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>payoff_add_in_x<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]<span class=\"w\"> </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)\n",
+       "<span class=\"w\">  </span>(x<span class=\"w\"> </span>x&#39;<span class=\"w\"> </span>:<span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>(x<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>x&#39;)<span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>x<span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>x&#39;<span class=\"w\"> </span>y</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>continuous_payoff_in_x</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>continuous_payoff_in_x<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]\n",
+       "<span class=\"w\">  </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)<span class=\"w\"> </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>Continuous<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>x<span class=\"w\"> </span>y</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check PayoffMatrix\\n#check payoff\\n#check payoff_add_in_x\\n#check continuous_payoff_in_x\", \"env\": 1}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.PayoffMatrix.{u_3, u_4} (m : Type u_3) (n : Type u_4) : Type (max u_3 u_4)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n) (x : m → ℝ)\\n  (y : n → ℝ) : ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_add_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n)\\n  (x x' : m → ℝ) (y : n → ℝ) : payoff A (x + x') y = payoff A x y + payoff A x' y\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.continuous_payoff_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (y : n → ℝ) : Continuous fun x => payoff A x y\"}],\r\n",
+       " \"env\": 2}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check PayoffMatrix\n",
+       "──────▶  MinimaxLean.PayoffMatrix.{u_3, u_4} (m : Type u_3) (n : Type u_4) : Type (max u_3 u_4)\n",
+       "#check payoff\n",
+       "──────▶  MinimaxLean.payoff.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n) (x : m → ℝ)\n",
+       "  (y : n → ℝ) : ℝ\n",
+       "#check payoff_add_in_x\n",
+       "──────▶  MinimaxLean.payoff_add_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n)\n",
+       "  (x x' : m → ℝ) (y : n → ℝ) : payoff A (x + x') y = payoff A x y + payoff A x' y\n",
+       "#check continuous_payoff_in_x\n",
+       "──────▶  MinimaxLean.continuous_payoff_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\n",
+       "  (A : PayoffMatrix m n) (y : n → ℝ) : Continuous fun x => payoff A x y\n",
+       "--% env 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check PayoffMatrix\\n#check payoff\\n#check payoff_add_in_x\\n#check continuous_payoff_in_x\", \"env\": 1}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.PayoffMatrix.{u_3, u_4} (m : Type u_3) (n : Type u_4) : Type (max u_3 u_4)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n) (x : m → ℝ)\\n  (y : n → ℝ) : ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_add_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n)\\n  (x x' : m → ℝ) (y : n → ℝ) : payoff A (x + x') y = payoff A x y + payoff A x' y\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.continuous_payoff_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (y : n → ℝ) : Continuous fun x => payoff A x y\"}],\r\n",
+       " \"env\": 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check PayoffMatrix\n",
+    "#check payoff\n",
+    "#check payoff_add_in_x\n",
+    "#check continuous_payoff_in_x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a6bc454",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004463,
+     "end_time": "2026-06-26T21:54:48.365258+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.360795+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : bilinéarité et continuité du payoff\n",
+    "\n",
+    "| Symbole Lean | Lecture |\n",
+    "|--------------|---------|\n",
+    "| `PayoffMatrix m n` | $A \\in \\mathbb{R}^{m \\times n}$, matrice de gains |\n",
+    "| `payoff A x y` | $\\sum_{i,j} x_i A_{ij} y_j$, espérance du gain |\n",
+    "| `payoff_add_in_x` | additivité en $x$ (moitié de la linéarité) |\n",
+    "| `continuous_payoff_in_x` | continuité en $x$ (borne pour la semi-continuité) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cff2f00",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004077,
+     "end_time": "2026-06-26T21:54:48.373442+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.369365+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Concavité, convexité et les quatre hypothèses de Sion\n",
+    "\n",
+    "Le module `Minimax/Concavity.lean` déroule le **glue analytique** : du payoff\n",
+    "bilinéaire, on dérive les **quatre hypothèses** exigées par\n",
+    "`Sion.exists_isSaddlePointOn'` (Mathlib `Topology.Sion`) :\n",
+    "\n",
+    "- **quasi-convexité en $x$** : `payoff_quasiconvex_in_x` (via `ConvexOn.quasiconvexOn`),\n",
+    "- **quasi-concavité en $y$** : `payoff_quasiconcave_in_y` (via `ConcaveOn.quasiconcaveOn`),\n",
+    "- **semi-continuité inf. en $x$** : `payoff_lowerSemicontinuous_in_x`,\n",
+    "- **semi-continuité sup. en $y$** : `payoff_upperSemicontinuous_in_y`.\n",
+    "\n",
+    "Une fonction affine est à la fois concave et convexe (Jensen avec égalité), et la\n",
+    "continuité entraîne les deux semi-continuités."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1f138fa8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T21:54:48.381692Z",
+     "iopub.status.busy": "2026-06-26T21:54:48.381559Z",
+     "iopub.status.idle": "2026-06-26T21:54:48.595470Z",
+     "shell.execute_reply": "2026-06-26T21:54:48.594519Z"
+    },
+    "papermill": {
+     "duration": 0.21885,
+     "end_time": "2026-06-26T21:54:48.595979+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.377129+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>payoff_concave_in_x</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>payoff_concave_in_x<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]<span class=\"w\"> </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)\n",
+       "<span class=\"w\">  </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ConcaveOn<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>(stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>m)<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>x<span class=\"w\"> </span>y</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>payoff_quasiconvex_in_x</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>payoff_quasiconvex_in_x<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]\n",
+       "<span class=\"w\">  </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)<span class=\"w\"> </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>QuasiconvexOn<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>(stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>m)<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>x<span class=\"w\"> </span>y</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>payoff_quasiconcave_in_y</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>payoff_quasiconcave_in_y<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]\n",
+       "<span class=\"w\">  </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>QuasiconcaveOn<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>(stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>n)<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>x<span class=\"w\"> </span>y</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>payoff_lowerSemicontinuous_in_x</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>payoff_lowerSemicontinuous_in_x<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]\n",
+       "<span class=\"w\">  </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)<span class=\"w\"> </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>LowerSemicontinuousOn<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>x<span class=\"w\"> </span>y)<span class=\"w\"> </span>(stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>m)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>payoff_upperSemicontinuous_in_y</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>payoff_upperSemicontinuous_in_y<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]\n",
+       "<span class=\"w\">  </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>UpperSemicontinuousOn<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>payoff<span class=\"w\"> </span>A<span class=\"w\"> </span>x<span class=\"w\"> </span>y)<span class=\"w\"> </span>(stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>n)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check payoff_concave_in_x\\n#check payoff_quasiconvex_in_x\\n#check payoff_quasiconcave_in_y\\n#check payoff_lowerSemicontinuous_in_x\\n#check payoff_upperSemicontinuous_in_y\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_concave_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n)\\n  (y : n → ℝ) : ConcaveOn ℝ (stdSimplex ℝ m) fun x => payoff A x y\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_quasiconvex_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (y : n → ℝ) : QuasiconvexOn ℝ (stdSimplex ℝ m) fun x => payoff A x y\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_quasiconcave_in_y.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (x : m → ℝ) : QuasiconcaveOn ℝ (stdSimplex ℝ n) fun y => payoff A x y\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_lowerSemicontinuous_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (y : n → ℝ) : LowerSemicontinuousOn (fun x => payoff A x y) (stdSimplex ℝ m)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_upperSemicontinuous_in_y.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (x : m → ℝ) : UpperSemicontinuousOn (fun y => payoff A x y) (stdSimplex ℝ n)\"}],\r\n",
+       " \"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check payoff_concave_in_x\n",
+       "──────▶  MinimaxLean.payoff_concave_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n)\n",
+       "  (y : n → ℝ) : ConcaveOn ℝ (stdSimplex ℝ m) fun x => payoff A x y\n",
+       "#check payoff_quasiconvex_in_x\n",
+       "──────▶  MinimaxLean.payoff_quasiconvex_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\n",
+       "  (A : PayoffMatrix m n) (y : n → ℝ) : QuasiconvexOn ℝ (stdSimplex ℝ m) fun x => payoff A x y\n",
+       "#check payoff_quasiconcave_in_y\n",
+       "──────▶  MinimaxLean.payoff_quasiconcave_in_y.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\n",
+       "  (A : PayoffMatrix m n) (x : m → ℝ) : QuasiconcaveOn ℝ (stdSimplex ℝ n) fun y => payoff A x y\n",
+       "#check payoff_lowerSemicontinuous_in_x\n",
+       "──────▶  MinimaxLean.payoff_lowerSemicontinuous_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\n",
+       "  (A : PayoffMatrix m n) (y : n → ℝ) : LowerSemicontinuousOn (fun x => payoff A x y) (stdSimplex ℝ m)\n",
+       "#check payoff_upperSemicontinuous_in_y\n",
+       "──────▶  MinimaxLean.payoff_upperSemicontinuous_in_y.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\n",
+       "  (A : PayoffMatrix m n) (x : m → ℝ) : UpperSemicontinuousOn (fun y => payoff A x y) (stdSimplex ℝ n)\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check payoff_concave_in_x\\n#check payoff_quasiconvex_in_x\\n#check payoff_quasiconcave_in_y\\n#check payoff_lowerSemicontinuous_in_x\\n#check payoff_upperSemicontinuous_in_y\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_concave_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] (A : PayoffMatrix m n)\\n  (y : n → ℝ) : ConcaveOn ℝ (stdSimplex ℝ m) fun x => payoff A x y\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_quasiconvex_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (y : n → ℝ) : QuasiconvexOn ℝ (stdSimplex ℝ m) fun x => payoff A x y\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_quasiconcave_in_y.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (x : m → ℝ) : QuasiconcaveOn ℝ (stdSimplex ℝ n) fun y => payoff A x y\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_lowerSemicontinuous_in_x.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (y : n → ℝ) : LowerSemicontinuousOn (fun x => payoff A x y) (stdSimplex ℝ m)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.payoff_upperSemicontinuous_in_y.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n]\\n  (A : PayoffMatrix m n) (x : m → ℝ) : UpperSemicontinuousOn (fun y => payoff A x y) (stdSimplex ℝ n)\"}],\r\n",
+       " \"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check payoff_concave_in_x\n",
+    "#check payoff_quasiconvex_in_x\n",
+    "#check payoff_quasiconcave_in_y\n",
+    "#check payoff_lowerSemicontinuous_in_x\n",
+    "#check payoff_upperSemicontinuous_in_y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4e6d3a9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007569,
+     "end_time": "2026-06-26T21:54:48.610711+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.603142+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : du bilinéaire aux quatre hypothèses de Sion\n",
+    "\n",
+    "| Théorème | Conclusion | Rôle dans Sion |\n",
+    "|----------|-----------|----------------|\n",
+    "| `payoff_concave_in_x` | `ConcaveOn ℝ (stdSimplex ℝ m) (· ↦ payoff A · y)` | affine ⟹ concave |\n",
+    "| `payoff_quasiconvex_in_x` | `QuasiconvexOn …` | hyp `hfy'` |\n",
+    "| `payoff_quasiconcave_in_y` | `QuasiconcaveOn …` | hyp `hfx'` |\n",
+    "| `payoff_lowerSemicontinuous_in_x` | `LowerSemicontinuousOn …` | hyp `hfy` |\n",
+    "| `payoff_upperSemicontinuous_in_y` | `UpperSemicontinuousOn …` | hyp `hfx` |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5555296f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005398,
+     "end_time": "2026-06-26T21:54:48.621267+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.615869+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Théorème phare : existence du point-selle (von Neumann)\n",
+    "\n",
+    "Le module `Minimax/SionApplication.lean` câble les 4 hyps analytiques avec les faits\n",
+    "topologiques de Mathlib sur `stdSimplex` (compacité, convexité, non-vacuité) pour\n",
+    "conclure via `Sion.exists_isSaddlePointOn` : **il existe un point-selle**\n",
+    "$(a, b) \\in \\mathrm{stdSimplex}(\\mathbb{R}, m) \\times \\mathrm{stdSimplex}(\\mathbb{R}, n)$.\n",
+    "\n",
+    "C'est exactement le théorème minimax de von Neumann : les stratégies mixtes optimales\n",
+    "existent, et la valeur du jeu vérifie l'égalité minimax."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6dcc878f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T21:54:48.634772Z",
+     "iopub.status.busy": "2026-06-26T21:54:48.634618Z",
+     "iopub.status.idle": "2026-06-26T21:54:48.843558Z",
+     "shell.execute_reply": "2026-06-26T21:54:48.842873Z"
+    },
+    "papermill": {
+     "duration": 0.217584,
+     "end_time": "2026-06-26T21:54:48.844330+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.626746+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>stdSimplex_nonempty_m</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>stdSimplex_nonempty_m<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[DecidableEq<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Nonempty<span class=\"w\"> </span>m]<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>(stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>m)<span class=\"bp\">.</span>Nonempty</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>MinimaxLean<span class=\"bp\">.</span>exists_saddle_point_payoff</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> MinimaxLean<span class=\"bp\">.</span>exists_saddle_point_payoff<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{m<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>n]<span class=\"w\"> </span>[DecidableEq<span class=\"w\"> </span>m]\n",
+       "<span class=\"w\">  </span>[DecidableEq<span class=\"w\"> </span>n]<span class=\"w\"> </span>[Nonempty<span class=\"w\"> </span>m]<span class=\"w\"> </span>[Nonempty<span class=\"w\"> </span>n]<span class=\"w\"> </span>(A<span class=\"w\"> </span>:<span class=\"w\"> </span>PayoffMatrix<span class=\"w\"> </span>m<span class=\"w\"> </span>n)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∃</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>m,<span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>n,<span class=\"w\"> </span>IsSaddlePointOn<span class=\"w\"> </span>(stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>m)<span class=\"w\"> </span>(stdSimplex<span class=\"w\"> </span>ℝ<span class=\"w\"> </span>n)<span class=\"w\"> </span>(payoff<span class=\"w\"> </span>A)<span class=\"w\"> </span>a<span class=\"w\"> </span>b</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check stdSimplex_nonempty_m\\n#check MinimaxLean.exists_saddle_point_payoff\", \"env\": 3}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.stdSimplex_nonempty_m.{u_1} {m : Type u_1} [Fintype m] [DecidableEq m] [Nonempty m] :\\n  (stdSimplex ℝ m).Nonempty\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.exists_saddle_point_payoff.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] [DecidableEq m]\\n  [DecidableEq n] [Nonempty m] [Nonempty n] (A : PayoffMatrix m n) :\\n  ∃ a ∈ stdSimplex ℝ m, ∃ b ∈ stdSimplex ℝ n, IsSaddlePointOn (stdSimplex ℝ m) (stdSimplex ℝ n) (payoff A) a b\"}],\r\n",
+       " \"env\": 4}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check stdSimplex_nonempty_m\n",
+       "──────▶  MinimaxLean.stdSimplex_nonempty_m.{u_1} {m : Type u_1} [Fintype m] [DecidableEq m] [Nonempty m] :\n",
+       "  (stdSimplex ℝ m).Nonempty\n",
+       "#check MinimaxLean.exists_saddle_point_payoff\n",
+       "──────▶  MinimaxLean.exists_saddle_point_payoff.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] [DecidableEq m]\n",
+       "  [DecidableEq n] [Nonempty m] [Nonempty n] (A : PayoffMatrix m n) :\n",
+       "  ∃ a ∈ stdSimplex ℝ m, ∃ b ∈ stdSimplex ℝ n, IsSaddlePointOn (stdSimplex ℝ m) (stdSimplex ℝ n) (payoff A) a b\n",
+       "--% env 4\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check stdSimplex_nonempty_m\\n#check MinimaxLean.exists_saddle_point_payoff\", \"env\": 3}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.stdSimplex_nonempty_m.{u_1} {m : Type u_1} [Fintype m] [DecidableEq m] [Nonempty m] :\\n  (stdSimplex ℝ m).Nonempty\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"MinimaxLean.exists_saddle_point_payoff.{u_1, u_2} {m : Type u_1} {n : Type u_2} [Fintype m] [Fintype n] [DecidableEq m]\\n  [DecidableEq n] [Nonempty m] [Nonempty n] (A : PayoffMatrix m n) :\\n  ∃ a ∈ stdSimplex ℝ m, ∃ b ∈ stdSimplex ℝ n, IsSaddlePointOn (stdSimplex ℝ m) (stdSimplex ℝ n) (payoff A) a b\"}],\r\n",
+       " \"env\": 4}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check stdSimplex_nonempty_m\n",
+    "#check MinimaxLean.exists_saddle_point_payoff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ceb1b92f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003497,
+     "end_time": "2026-06-26T21:54:48.852853+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.849356+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le câblage final vers von Neumann\n",
+    "\n",
+    "`exists_saddle_point_payoff` fournit `∃ a ∈ stdSimplex ℝ m, ∃ b ∈ stdSimplex ℝ n,\n",
+    "IsSaddlePointOn (stdSimplex ℝ m) (stdSimplex ℝ n) (payoff A) a b`. Le point-selle\n",
+    "$(a, b)$ réalise simultanément le maximum en $x$ et le minimum en $y$ : c'est\n",
+    "l'égalité $\\max_x \\min_y x^T A y = \\min_y \\max_x x^T A y$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1d2e09e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00361,
+     "end_time": "2026-06-26T21:54:48.860446+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.856836+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. La chaîne causale complète\n",
+    "\n",
+    "Les trois modules composent une chaîne unique, de la bilinéarité au point-selle :\n",
+    "\n",
+    "1. **`ZeroSum`** — `payoff` bilinéaire ($\\sum_{i,j} x_i A_{ij} y_j$) + continuité.\n",
+    "2. **`Concavity`** — du bilinéaire aux 4 hyps de Sion (quasi-convexité/concavité + semi-continuités).\n",
+    "3. **`SionApplication`** — câblage avec `stdSimplex` (compact convexe non vide) + `Sion.exists_isSaddlePointOn` ⟹ **point-selle ⟹ von Neumann**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a98ecf62",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003746,
+     "end_time": "2026-06-26T21:54:48.867609+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.863863+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "### Exercice 1 — Valeur d'un jeu à point-selle pur (Python)\n",
+    "\n",
+    "Avant le formalisme, ancrez l'intuition : pour une matrice $A$ qui admet un point-selle\n",
+    "**pur** (une entrée qui est à la fois le max de sa colonne et le min de sa ligne), la\n",
+    "valeur du jeu est cette entrée. *Complétez* la fonction (en Python, hors du kernel Lean).\n",
+    "\n",
+    "```python\n",
+    "def pure_saddle_value(A):\n",
+    "    # TODO etudiant : pour chaque entree A[i][j], verifier si elle est\n",
+    "    # le min de sa ligne ET le max de sa colonne. Retourner sa valeur.\n",
+    "    return None  # TODO\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed197ab9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003727,
+     "end_time": "2026-06-26T21:54:48.875660+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.871933+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Homogénéité du payoff en $y$\n",
+    "\n",
+    "Le payoff est homogène en $y$ : `payoff A x (c • y) = c * payoff A x y`. Formalisez\n",
+    "cette linéarité (sur papier puis tentez en Lean).\n",
+    "\n",
+    "```lean\n",
+    "-- TODO etudiant : formaliser payoff_smul_in_y\n",
+    "-- example (A : PayoffMatrix m n) (c : ℝ) (x : m → ℝ) (y : n → ℝ) :\n",
+    "--     payoff A x (c • y) = c * payoff A x y := by sorry\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01b459ef",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003269,
+     "end_time": "2026-06-26T21:54:48.882150+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.878881+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Un jeu sans point-selle pur\n",
+    "\n",
+    "Le jeu pierre-feuille-ciseaux (matrice antisymétrique) n'a **pas** de point-selle pur :\n",
+    "il faut des stratégies mixtes. Donnez la matrice et justifiez (sur papier) pourquoi\n",
+    "aucune entrée n'est simultanément max de colonne et min de ligne.\n",
+    "\n",
+    "```python\n",
+    "# TODO etudiant : matrice RPS 3x3 + justification (markdown) de l'absence de point-selle pur\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ad4c2b1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004149,
+     "end_time": "2026-06-26T21:54:48.889828+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T21:54:48.885679+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce companion **natif** exhibe la preuve formelle 0-sorry du théorème minimax de von\n",
+    "Neumann dans le kernel Lean lui-même : `#check` et `#print axioms` rendent les\n",
+    "signatures et les axiomes réels produits par le compilateur, sans intermédiaire Python.\n",
+    "\n",
+    "La sensitivity conjecture de Huang a son companion natif ; ici c'est le minimax de von\n",
+    "Neumann (1928) — l'un des résultats fondateurs de la théorie des jeux — qui est\n",
+    "formellement résolu via le minimax de Sion.\n",
+    "\n",
+    "**Jalon ouvert** : l'unicité de la valeur du jeu (et son calcul explicite sur une\n",
+    "matrice donnée) n'est pas formalisée dans le lake ; la lib reste sorry-free."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Lean 4 (WSL)",
+   "language": "lean4",
+   "name": "lean4-wsl"
+  },
+  "language_info": {
+   "codemirror_mode": "python",
+   "file_extension": ".lean",
+   "mimetype": "text/x-lean4",
+   "name": "lean4"
+  },
+  "papermill": {
+   "input_path": "GameTheory-5b-Lean-Minimax.ipynb",
+   "output_path": "GameTheory-5b-Lean-Minimax.ipynb"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -88,6 +88,7 @@ flowchart TD
 | 4b | [GameTheory-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) | Lean 4 | Brouwer, Kakutani, preuve existence Nash | 55 min |
 | 4c | [GameTheory-4c-NashExistence-Python](GameTheory-4c-NashExistence-Python.ipynb) | Python | Illustrations numériques point fixe | 35 min |
 | 5 | [GameTheory-5-ZeroSum-Minimax](GameTheory-5-ZeroSum-Minimax.ipynb) | Python | Théorème minimax, LP primal/dual, Von Neumann | 40 min |
+| 5b | [GameTheory-5b-Lean-Minimax](GameTheory-5b-Lean-Minimax.ipynb) | Lean 4 | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de von Neumann dans le lake `minimax_lean` (Sion), `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) | 45 min |
 | 6 | [GameTheory-6-EvolutionTrust](GameTheory-6-EvolutionTrust.ipynb) | Python | Tournoi Axelrod, tit-for-tat, replicator dynamics | 65 min |
 
 ### Partie 2 : Jeux dynamiques et raisonnement stratégique (Notebooks 7-12)


### PR DESCRIPTION
## Summary

**GameTheory-5b-Lean-Minimax.ipynb** — the **pur-Lean native** companion for the lake [`minimax_lean`](minimax_lean/) (lib `Minimax`: von Neumann minimax theorem for finite zero-sum games, via **Sion** — Mathlib `Topology.Sion`, **0 sorry**). This is the format the user mandates: a notebook Lean natif lisible, NOT the #4373 Python→Lean companion that shells `lake env lean` and manipulates strings.

This is the **2nd native companion** (after #4393 sensitivity), proving the UNLOCK (PR #4390) is reproducible across lakes. It **supersedes the python3 #4373** in format (closes #4373).

| Route | Notebook | Method |
|-------|----------|--------|
| Computation (existing) | GameTheory-5-ZeroSum-Minimax (Python) | minimax numérique, LP primal/dual |
| Companion (this PR) | **GameTheory-5b (native Lean)** | **kernel `lean4-wsl`, `import Minimax` + `#check` + `#print axioms` rendered in-kernel** |

## What the notebook shows (real Lean, zero Python)

5 code cells, kernel `lean4-wsl`:

- `import Minimax` `open MinimaxLean` → OK
- `#print axioms MinimaxLean.exists_saddle_point_payoff` → **[propext, Classical.choice, Quot.sound]** (0 sorry, no `sorryAx`)
- `#check PayoffMatrix` / `#check payoff` / `#check payoff_add_in_x` / `#check continuous_payoff_in_x` (module `ZeroSum`: bilinear payoff)
- `#check payoff_concave_in_x` / `payoff_quasiconvex_in_x` / `payoff_quasiconcave_in_y` / `payoff_lowerSemicontinuous_in_x` / `payoff_upperSemicontinuous_in_y` (module `Concavity`: the 4 Sion hypotheses)
- `#check MinimaxLean.exists_saddle_point_payoff` (flagship: ∃ saddle point on stdSimplex via `Sion.exists_isSaddlePointOn`)
- Pedagogical arc faithful to #4373: ZeroSum (bilinearity) → Concavity (4 Sion hyps) → SionApplication (flagship) → causal chain → 3 exercises (markdown pseudo-code stubs, C.1)

## Why native and not the #4373 python3 companion

PR #4373 (python3 + `lake env lean --stdin`) is *honest* but the user finds a "Python→Lean companion that loads the lake and manipulates countless strings" **hard to read**. This PR delivers the proof exhibited **in the Lean kernel itself** — `#check` and `#print axioms` render the real compiler output in-kernel, no string manipulation.

## Verification (C.2, executed WITH outputs, 5/5 code cells, 0 errors)

| Check | Result |
|-------|--------|
| `lake build Minimax` | **SUCCESS** (exit=0, junction #2611 rc1 + deps built) |
| Papermill execute (lean4-wsl kernel) | **5/5 code cells, 0 errors, 0 cells without output** |
| Native `#check` | pillar signatures rendered in-kernel (PayoffMatrix, payoff, 4 Sion-hyp theorems, flagship exists_saddle_point_payoff) |
| `#print axioms` | **[propext, Classical.choice, Quot.sound]** → 0 sorry |
| C.1 (no voluntary error) | 0 `raise NotImplementedError`/`assert False`/`1/0` |
| `metadata.papermill.input/output_path` | normalized to basename (metadata-only, C.2-exempt) |

**Execution note**: run the notebook from the `minimax_lean/` directory (or anywhere the UNLOCK patch #4390 + junction #2611 rc1 is active). The first cell (`import`) takes ~3 min (Mathlib load via junction); the rest are instant.

## Dependency: REQUIRES the UNLOCK (#4390, MERGED) to run natively

The notebook is a *lean4-wsl* kernel that imports a Mathlib lake — works only with PR #4390's `lean4_jupyter/repl.py` patch + matched repl (`repl-4.31.0-rc1`, rc1 toolchain) + wrapper v6. **#4390 is MERGED** (`50ec8f586`). The junction (rc1 cluster `d568c8c0`) is applied locally via `scripts/lean/setup_shared_mathlib.ps1`.

Durability: the repl.py patch is a pip-package edit (lost on `pip install`); #4394 tracks the durable fork/PR upstream (follow-up, NOT a blocker).

## rc1 lakes need a launch() timeout bump (60→240s)

Diagnosed firsthand this cycle: for rc1 lakes with the junctioned Mathlib, `lake env` re-verifies the junction ("has local changes" warning) and takes **~111-125s** — exceeding the patched `launch()`'s 60s timeout → fallback to the broken `lake env repl` path → empty kernel buffer. The fix: bump the `launch()` LEAN_PATH-capture timeout from 60s to 240s (the LEAN_PATH IS captured correctly, just slowly). Applied locally to the live `repl.py` (`.bak.c129` backup). The reproducible installer `scripts/lean/setup_native_lean4_import.py` has the matching edit (1 line + comment) — a separate tiny follow-up PR or fold into #4394, **not mixed here** (atomicity). This is the general fix for ALL rc1 conversions (argumentation/planning/sudoku/decision_theory), which have the same junctioned-Mathlib characteristic.

## Atomicity

Single-subject PR (one new companion notebook + 1 README nav line `5b`). Docs-only on the lake (0 `.lean` touched). Fresh base from `origin/main` (0 behind / 0 ahead at creation). Staging explicit (`git add <notebook> <README>`), pre-existing mods excluded.

Closes #4373 (supersedes the python3 companion in format). See #4390 (UNLOCK, merged), See #4393 (1st native companion — sensitivity, the proven pattern), See #4394 (durable fork follow-up), See #4054/#4038 (lake roadmap), See #2611 (Mathlib junction).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
