### PR TITLE
feat(Tweety): Tweety-5b native companion — argumentation_lean grounded fixed point (3rd native)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -134,6 +134,7 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 4 | [Tweety-4-Belief-Revision](Tweety-4-Belief-Revision.ipynb) | CrMas, MUS, MaxSAT, Mesures d'incohérence | 50 min |
 | **Argumentation** |
 | 5 | [Tweety-5-Abstract-Argumentation](Tweety-5-Abstract-Argumentation.ipynb) | Dung AF, Sémantiques, CF2, Génération | 55 min |
+| 5b | [Tweety-5b-Lean-Argumentation](Tweety-5b-Lean-Argumentation.ipynb) | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de Dung dans le lake `argumentation_lean` (grounded = point fixe Knaster–Tarski), `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) | 45 min |
 | 6 | [Tweety-6-Structured-Argumentation](Tweety-6-Structured-Argumentation.ipynb) | ASPIC+, DeLP, ABA, ASP | 60 min |
 | 7a | [Tweety-7a-Extended-Frameworks](Tweety-7a-Extended-Frameworks.ipynb) | ADF, Bipolar, WAF, SAF, SetAF, Extended | 50 min |
 | 7b | [Tweety-7b-Ranking-Probabilistic](Tweety-7b-Ranking-Probabilistic.ipynb) | Ranking Semantics, Probabiliste | 40 min |

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5b-Lean-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5b-Lean-Argumentation.ipynb
@@ -1,0 +1,1187 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "00b4f9a8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006082,
+     "end_time": "2026-06-26T22:33:44.787231+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:33:44.781149+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Tweety-5b — Théorie de l'argumentation de Dung (companion formel natif)\n",
+    "\n",
+    "Ce notebook est le **companion formel** du lake [`argumentation_lean`](../argumentation_lean/),\n",
+    "dont la lib `Argumentation` prouve les résultats fondateurs de la théorie de\n",
+    "l'argumentation abstraite de Dung (1995) — **existence de l'extension grounded comme\n",
+    "point fixe de la fonction caractéristique** (Knaster–Tarski) — avec **zéro `sorry`**.\n",
+    "\n",
+    "La théorie de Dung modélise un débat comme un graphe d'arguments reliés par une\n",
+    "relation d'attaque, et définit des *sémantiques* (ensembles d'arguments cohérents et\n",
+    "« défendus ») : admissible, complète, grounded, preferred, stable.\n",
+    "\n",
+    "## Convention de vérification — `#check` *natif* dans le kernel Lean\n",
+    "\n",
+    "Ce notebook est un **notebook Lean natif** (kernel `lean4-wsl`) : il `import`e les\n",
+    "modules du lake directement et le compilateur Lean rend les signatures **dans le\n",
+    "notebook**. C'est rendu possible par l'UNLOCK (patch `lean4_jupyter` + jonction\n",
+    "Mathlib #2611).\n",
+    "\n",
+    "> ⚠️ À l'exécution, la première cellule (`import`) peut prendre **~3 min** :\n",
+    "> le kernel charge les oleans Mathlib via la jonction NTFS. Les suivantes sont\n",
+    "> instantanées."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c48670e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003688,
+     "end_time": "2026-06-26T22:33:44.795562+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:33:44.791874+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Import des modules du lake `argumentation_lean`\n",
+    "\n",
+    "Le lake est structuré en 5 modules (`Basic`, `Characteristic`, `Extensions`,\n",
+    "`Fundamental`, `Grounded`) sous les namespaces `Argumentation` / `Argumentation.AF`.\n",
+    "On importe les 5 modules (la config `submodules` du lake ne build pas l'umbrella\n",
+    "racine — on cible directement les modules qui portent les définitions)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "adb210cb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T22:33:44.803250Z",
+     "iopub.status.busy": "2026-06-26T22:33:44.803087Z",
+     "iopub.status.idle": "2026-06-26T22:37:49.149052Z",
+     "shell.execute_reply": "2026-06-26T22:37:49.147901Z"
+    },
+    "papermill": {
+     "duration": 244.37555,
+     "end_time": "2026-06-26T22:37:49.174632+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:33:44.799082+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Basic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Characteristic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Extensions</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Fundamental</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Grounded</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>Argumentation</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"import Argumentation.Basic\\nimport Argumentation.Characteristic\\nimport Argumentation.Extensions\\nimport Argumentation.Fundamental\\nimport Argumentation.Grounded\\nopen Argumentation\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "import Argumentation.Basic\n",
+       "import Argumentation.Characteristic\n",
+       "import Argumentation.Extensions\n",
+       "import Argumentation.Fundamental\n",
+       "import Argumentation.Grounded\n",
+       "open Argumentation\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"import Argumentation.Basic\\nimport Argumentation.Characteristic\\nimport Argumentation.Extensions\\nimport Argumentation.Fundamental\\nimport Argumentation.Grounded\\nopen Argumentation\"}\n",
+       "Raw output:\n",
+       "{\"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import Argumentation.Basic\n",
+    "import Argumentation.Characteristic\n",
+    "import Argumentation.Extensions\n",
+    "import Argumentation.Fundamental\n",
+    "import Argumentation.Grounded\n",
+    "open Argumentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0521d05a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004111,
+     "end_time": "2026-06-26T22:37:49.183853+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.179742+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Preuve sans `sorry` — `#print axioms`\n",
+    "\n",
+    "Le théorème phare `grounded_fixed` (point fixe de l'extension grounded) ne dépend que\n",
+    "des **3 axiomes standards de Lean** (`propext`, `Classical.choice`, `Quot.sound`) — pas\n",
+    "de `sorryAx` — ce qui prouve que la preuve est **complète** (0 sorry)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c222dd71",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T22:37:49.193616Z",
+     "iopub.status.busy": "2026-06-26T22:37:49.193358Z",
+     "iopub.status.idle": "2026-06-26T22:37:49.434881Z",
+     "shell.execute_reply": "2026-06-26T22:37:49.434091Z"
+    },
+    "papermill": {
+     "duration": 0.247833,
+     "end_time": "2026-06-26T22:37:49.435485+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.187652+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded_fixed</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded_fixed&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#print axioms AF.grounded_fixed\", \"env\": 0}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Argumentation.AF.grounded_fixed' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 1}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#print axioms AF.grounded_fixed\n",
+       "──────▶  'Argumentation.AF.grounded_fixed' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "--% env 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#print axioms AF.grounded_fixed\", \"env\": 0}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Argumentation.AF.grounded_fixed' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 1}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#print axioms AF.grounded_fixed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91f6d7f7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010005,
+     "end_time": "2026-06-26T22:37:49.454896+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.444891+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Cadre d'argumentation (Dung) — sans-conflit, défense\n",
+    "\n",
+    "Le module `Argumentation/Basic.lean` pose le cadre abstrait de Dung :\n",
+    "\n",
+    "- `AF α` — un type d'arguments `α` muni d'une relation d'attaque `attacks : α → α → Prop`.\n",
+    "- `conflictFree S` — un ensemble est **sans conflit** si aucun de ses membres n'en attaque un autre (Définition 1).\n",
+    "- `defends S a` — `a` est **défendu** par `S` si tout attaquant de `a` est contre-attaqué par un membre de `S` (Définition 3).\n",
+    "\n",
+    "La **monotonie de la défense** (`defends_mono`) est le fait combinatoire clé : si `S ⊆ T`\n",
+    "et `S` défend `a`, alors `T` défend aussi `a`. C'est la croissance de la fonction\n",
+    "caractéristique, cœur du point fixe de Dung."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6c9e3935",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T22:37:49.462227Z",
+     "iopub.status.busy": "2026-06-26T22:37:49.462077Z",
+     "iopub.status.idle": "2026-06-26T22:37:49.681675Z",
+     "shell.execute_reply": "2026-06-26T22:37:49.680781Z"
+    },
+    "papermill": {
+     "duration": 0.223854,
+     "end_time": "2026-06-26T22:37:49.682244+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.458390+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>{u_2}<span class=\"w\"> </span>(α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>conflictFree</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>conflictFree<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>defends</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>defends<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>conflictFree_empty</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>conflictFree_empty<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>conflictFree<span class=\"w\"> </span><span class=\"bp\">∅</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>defends_mono</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>defends_mono<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>T<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hST<span class=\"w\"> </span>:<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">⊆</span><span class=\"w\"> </span>T)<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}\n",
+       "<span class=\"w\">  </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>T<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check AF\\n#check AF.conflictFree\\n#check AF.defends\\n#check AF.conflictFree_empty\\n#check AF.defends_mono\", \"env\": 1}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Argumentation.AF.{u_2} (α : Type u_2) : Type u_2\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.conflictFree.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.defends.{u_1} {α : Type u_1} (af : AF α) (S : Set α) (a : α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.conflictFree_empty.{u_1} {α : Type u_1} (af : AF α) : af.conflictFree ∅\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.defends_mono.{u_1} {α : Type u_1} (af : AF α) {S T : Set α} (hST : S ⊆ T) {a : α}\\n  (hS : af.defends S a) : af.defends T a\"}],\r\n",
+       " \"env\": 2}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check AF\n",
+       "──────▶  Argumentation.AF.{u_2} (α : Type u_2) : Type u_2\n",
+       "#check AF.conflictFree\n",
+       "──────▶  Argumentation.AF.conflictFree.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\n",
+       "#check AF.defends\n",
+       "──────▶  Argumentation.AF.defends.{u_1} {α : Type u_1} (af : AF α) (S : Set α) (a : α) : Prop\n",
+       "#check AF.conflictFree_empty\n",
+       "──────▶  Argumentation.AF.conflictFree_empty.{u_1} {α : Type u_1} (af : AF α) : af.conflictFree ∅\n",
+       "#check AF.defends_mono\n",
+       "──────▶  Argumentation.AF.defends_mono.{u_1} {α : Type u_1} (af : AF α) {S T : Set α} (hST : S ⊆ T) {a : α}\n",
+       "  (hS : af.defends S a) : af.defends T a\n",
+       "--% env 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check AF\\n#check AF.conflictFree\\n#check AF.defends\\n#check AF.conflictFree_empty\\n#check AF.defends_mono\", \"env\": 1}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Argumentation.AF.{u_2} (α : Type u_2) : Type u_2\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.conflictFree.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.defends.{u_1} {α : Type u_1} (af : AF α) (S : Set α) (a : α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.conflictFree_empty.{u_1} {α : Type u_1} (af : AF α) : af.conflictFree ∅\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.defends_mono.{u_1} {α : Type u_1} (af : AF α) {S T : Set α} (hST : S ⊆ T) {a : α}\\n  (hS : af.defends S a) : af.defends T a\"}],\r\n",
+       " \"env\": 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check AF\n",
+    "#check AF.conflictFree\n",
+    "#check AF.defends\n",
+    "#check AF.conflictFree_empty\n",
+    "#check AF.defends_mono"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84702814",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004102,
+     "end_time": "2026-06-26T22:37:49.691566+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.687464+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : modélisation d'un débat\n",
+    "\n",
+    "| Symbole Lean | Lecture |\n",
+    "|--------------|---------|\n",
+    "| `AF α` | cadre d'argumentation : type `α` + relation d'attaque |\n",
+    "| `conflictFree S` | aucun membre de `S` n'en attaque un autre |\n",
+    "| `defends S a` | tout attaquant de `a` est contre-attaqué par `S` |\n",
+    "| `conflictFree_empty` | l'ensemble vide est trivialement sans conflit |\n",
+    "| `defends_mono` | la défense est monotone en l'ensemble défenseur |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bf67aa5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0043,
+     "end_time": "2026-06-26T22:37:49.700192+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.695892+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. La fonction caractéristique comme morphisme monotone\n",
+    "\n",
+    "Le module `Argumentation/Characteristic.lean` définit la **fonction caractéristique**\n",
+    "de Dung `F(S) = { a | S défend a }`, bundlée comme un **morphisme d'ordre monotone**\n",
+    "`OrderHom` sur le treillis complet `Set α`. L'extension grounded en est le **plus petit\n",
+    "point fixe** `F.lfp` — c'est le théorème phare `grounded_fixed`.\n",
+    "\n",
+    "L'identité `a ∈ F(S) ⇔ S défend a` (`mem_characteristic_iff`) rend la réécriture directe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "218f80f0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T22:37:49.709952Z",
+     "iopub.status.busy": "2026-06-26T22:37:49.709798Z",
+     "iopub.status.idle": "2026-06-26T22:37:49.934968Z",
+     "shell.execute_reply": "2026-06-26T22:37:49.934164Z"
+    },
+    "papermill": {
+     "duration": 0.230942,
+     "end_time": "2026-06-26T22:37:49.935567+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.704625+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>characteristic</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>characteristic<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span>o<span class=\"w\"> </span>Set<span class=\"w\"> </span>α</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>mem_characteristic_iff</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>mem_characteristic_iff<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>characteristic<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>characteristic_eq_defendedBy</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>characteristic_eq_defendedBy<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>af<span class=\"bp\">.</span>characteristic<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>defendedBy<span class=\"w\"> </span>S</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check AF.characteristic\\n#check AF.mem_characteristic_iff\\n#check AF.characteristic_eq_defendedBy\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.characteristic.{u_1} {α : Type u_1} (af : AF α) : Set α →o Set α\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.mem_characteristic_iff.{u_1} {α : Type u_1} (af : AF α) (S : Set α) (a : α) :\\n  a ∈ af.characteristic S ↔ af.defends S a\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.characteristic_eq_defendedBy.{u_1} {α : Type u_1} (af : AF α) (S : Set α) :\\n  af.characteristic S = af.defendedBy S\"}],\r\n",
+       " \"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check AF.characteristic\n",
+       "──────▶  Argumentation.AF.characteristic.{u_1} {α : Type u_1} (af : AF α) : Set α →o Set α\n",
+       "#check AF.mem_characteristic_iff\n",
+       "──────▶  Argumentation.AF.mem_characteristic_iff.{u_1} {α : Type u_1} (af : AF α) (S : Set α) (a : α) :\n",
+       "  a ∈ af.characteristic S ↔ af.defends S a\n",
+       "#check AF.characteristic_eq_defendedBy\n",
+       "──────▶  Argumentation.AF.characteristic_eq_defendedBy.{u_1} {α : Type u_1} (af : AF α) (S : Set α) :\n",
+       "  af.characteristic S = af.defendedBy S\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check AF.characteristic\\n#check AF.mem_characteristic_iff\\n#check AF.characteristic_eq_defendedBy\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.characteristic.{u_1} {α : Type u_1} (af : AF α) : Set α →o Set α\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.mem_characteristic_iff.{u_1} {α : Type u_1} (af : AF α) (S : Set α) (a : α) :\\n  a ∈ af.characteristic S ↔ af.defends S a\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.characteristic_eq_defendedBy.{u_1} {α : Type u_1} (af : AF α) (S : Set α) :\\n  af.characteristic S = af.defendedBy S\"}],\r\n",
+       " \"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check AF.characteristic\n",
+    "#check AF.mem_characteristic_iff\n",
+    "#check AF.characteristic_eq_defendedBy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc21ebcf",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003825,
+     "end_time": "2026-06-26T22:37:49.949815+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.945990+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : `F` est un morphisme d'ordre\n",
+    "\n",
+    "| Symbole Lean | Lecture |\n",
+    "|--------------|---------|\n",
+    "| `AF.characteristic` | `Set α →o Set α` (OrderHom monotone) |\n",
+    "| `mem_characteristic_iff` | `a ∈ F(S) ⇔ defends S a` |\n",
+    "| `characteristic_eq_defendedBy` | `F(S) = defendedBy S` (identité) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c55544a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004353,
+     "end_time": "2026-06-26T22:37:49.957866+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.953513+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Les cinq extensions et leur hiérarchie\n",
+    "\n",
+    "Le module `Argumentation/Extensions.lean` définit les **cinq sémantiques** de Dung,\n",
+    "de la plus faible à la plus forte :\n",
+    "\n",
+    "- `Admissible S` — sans conflit + défend chacun de ses membres (Définition 5).\n",
+    "- `Complete S` — admissible + contient tout argument qu'elle défend (Définition 7).\n",
+    "- `grounded` — le plus petit point fixe de `F` (Knaster–Tarski), *l'extension minimale*.\n",
+    "- `Preferred S` — extension complète **maximale** pour l'inclusion (Définition 10).\n",
+    "- `Stable S` — sans conflit + attaque tout argument hors de `S` (Définition 12)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "65ba8e9b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T22:37:49.966847Z",
+     "iopub.status.busy": "2026-06-26T22:37:49.966679Z",
+     "iopub.status.idle": "2026-06-26T22:37:50.179475Z",
+     "shell.execute_reply": "2026-06-26T22:37:50.178826Z"
+    },
+    "papermill": {
+     "duration": 0.217791,
+     "end_time": "2026-06-26T22:37:50.179953+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:49.962162+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>Admissible</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>Admissible<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>Complete</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>Complete<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>Preferred</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>Preferred<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>Stable</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>Stable<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check AF.Admissible\\n#check AF.Complete\\n#check AF.grounded\\n#check AF.Preferred\\n#check AF.Stable\", \"env\": 3}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.Admissible.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.Complete.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.grounded.{u_1} {α : Type u_1} (af : AF α) : Set α\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.Preferred.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.Stable.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"}],\r\n",
+       " \"env\": 4}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check AF.Admissible\n",
+       "──────▶  Argumentation.AF.Admissible.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\n",
+       "#check AF.Complete\n",
+       "──────▶  Argumentation.AF.Complete.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\n",
+       "#check AF.grounded\n",
+       "──────▶  Argumentation.AF.grounded.{u_1} {α : Type u_1} (af : AF α) : Set α\n",
+       "#check AF.Preferred\n",
+       "──────▶  Argumentation.AF.Preferred.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\n",
+       "#check AF.Stable\n",
+       "──────▶  Argumentation.AF.Stable.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\n",
+       "--% env 4\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check AF.Admissible\\n#check AF.Complete\\n#check AF.grounded\\n#check AF.Preferred\\n#check AF.Stable\", \"env\": 3}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.Admissible.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.Complete.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.grounded.{u_1} {α : Type u_1} (af : AF α) : Set α\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.Preferred.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.Stable.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"}],\r\n",
+       " \"env\": 4}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check AF.Admissible\n",
+    "#check AF.Complete\n",
+    "#check AF.grounded\n",
+    "#check AF.Preferred\n",
+    "#check AF.Stable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aef702ff",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003484,
+     "end_time": "2026-06-26T22:37:50.190381+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.186897+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. La Fundamental Lemma de Dung\n",
+    "\n",
+    "Le module `Argumentation/Fundamental.lean` prouve la **Fundamental Lemma** (Dung 1995,\n",
+    "Lemme 1) : si `S` est admissible et défend `a`, alors `S ∪ {a}` est admissible. C'est la\n",
+    "**clé de l'existence des extensions preferred** — elle garantit qu'on peut toujours\n",
+    "étendre une extension admissible défendable, d'où l'existence de maximaux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0b86f3a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T22:37:50.200119Z",
+     "iopub.status.busy": "2026-06-26T22:37:50.199977Z",
+     "iopub.status.idle": "2026-06-26T22:37:50.415593Z",
+     "shell.execute_reply": "2026-06-26T22:37:50.414797Z"
+    },
+    "papermill": {
+     "duration": 0.222032,
+     "end_time": "2026-06-26T22:37:50.416170+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.194138+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>fundamental_lemma</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>fundamental_lemma<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Admissible<span class=\"w\"> </span>S)\n",
+       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Admissible<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>fundamental_lemma_defends</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>fundamental_lemma_defends<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Admissible<span class=\"w\"> </span>S)\n",
+       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>(hb<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)<span class=\"w\"> </span>b</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>fundamental_lemma_defends_self</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>fundamental_lemma_defends_self<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}\n",
+       "<span class=\"w\">  </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Admissible<span class=\"w\"> </span>S)<span class=\"w\"> </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check AF.fundamental_lemma\\n#check AF.fundamental_lemma_defends\\n#check AF.fundamental_lemma_defends_self\", \"env\": 4}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.fundamental_lemma.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α} (hS : af.Admissible S)\\n  (ha : af.defends S a) : af.Admissible (insert a S)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.fundamental_lemma_defends.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a b : α} (hS : af.Admissible S)\\n  (ha : af.defends S a) (hb : af.defends S b) : af.defends (insert a S) b\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.fundamental_lemma_defends_self.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α}\\n  (hS : af.Admissible S) (ha : af.defends S a) : af.defends (insert a S) a\"}],\r\n",
+       " \"env\": 5}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check AF.fundamental_lemma\n",
+       "──────▶  Argumentation.AF.fundamental_lemma.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α} (hS : af.Admissible S)\n",
+       "  (ha : af.defends S a) : af.Admissible (insert a S)\n",
+       "#check AF.fundamental_lemma_defends\n",
+       "──────▶  Argumentation.AF.fundamental_lemma_defends.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a b : α} (hS : af.Admissible S)\n",
+       "  (ha : af.defends S a) (hb : af.defends S b) : af.defends (insert a S) b\n",
+       "#check AF.fundamental_lemma_defends_self\n",
+       "──────▶  Argumentation.AF.fundamental_lemma_defends_self.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α}\n",
+       "  (hS : af.Admissible S) (ha : af.defends S a) : af.defends (insert a S) a\n",
+       "--% env 5\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check AF.fundamental_lemma\\n#check AF.fundamental_lemma_defends\\n#check AF.fundamental_lemma_defends_self\", \"env\": 4}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.fundamental_lemma.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α} (hS : af.Admissible S)\\n  (ha : af.defends S a) : af.Admissible (insert a S)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.fundamental_lemma_defends.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a b : α} (hS : af.Admissible S)\\n  (ha : af.defends S a) (hb : af.defends S b) : af.defends (insert a S) b\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.fundamental_lemma_defends_self.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α}\\n  (hS : af.Admissible S) (ha : af.defends S a) : af.defends (insert a S) a\"}],\r\n",
+       " \"env\": 5}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check AF.fundamental_lemma\n",
+    "#check AF.fundamental_lemma_defends\n",
+    "#check AF.fundamental_lemma_defends_self"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2683094",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004258,
+     "end_time": "2026-06-26T22:37:50.428302+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.424044+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Théorème phare : le point fixe de l'extension grounded\n",
+    "\n",
+    "Le module `Argumentation/Grounded.lean` prouve le résultat central :\n",
+    "\n",
+    "- `grounded_fixed` : `F(grounded) = grounded` — l'extension grounded est un **point fixe**\n",
+    "  de la fonction caractéristique (identité de Knaster–Tarski via `OrderHom.map_lfp`).\n",
+    "- `grounded_defends_iff_mem` : `a ∈ grounded ⇔ grounded défend a`.\n",
+    "- `grounded_least_complete` : `grounded` est la **plus petite extension complète**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "73c8bb86",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T22:37:50.438439Z",
+     "iopub.status.busy": "2026-06-26T22:37:50.438288Z",
+     "iopub.status.idle": "2026-06-26T22:37:50.647317Z",
+     "shell.execute_reply": "2026-06-26T22:37:50.646581Z"
+    },
+    "papermill": {
+     "duration": 0.215011,
+     "end_time": "2026-06-26T22:37:50.647864+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.432853+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded_fixed</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded_fixed<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>characteristic<span class=\"w\"> </span>af<span class=\"bp\">.</span>grounded<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>grounded</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded_defends_iff_mem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded_defends_iff_mem<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>af<span class=\"bp\">.</span>grounded<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>grounded</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded_least_complete</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded_least_complete<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(T<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Complete<span class=\"w\"> </span>T)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>af<span class=\"bp\">.</span>grounded<span class=\"w\"> </span><span class=\"bp\">⊆</span><span class=\"w\"> </span>T</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check AF.grounded_fixed\\n#check AF.grounded_defends_iff_mem\\n#check AF.grounded_least_complete\", \"env\": 5}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.grounded_fixed.{u_1} {α : Type u_1} (af : AF α) : af.characteristic af.grounded = af.grounded\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.grounded_defends_iff_mem.{u_1} {α : Type u_1} (af : AF α) (a : α) :\\n  af.defends af.grounded a ↔ a ∈ af.grounded\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.grounded_least_complete.{u_1} {α : Type u_1} (af : AF α) (T : Set α) (h : af.Complete T) :\\n  af.grounded ⊆ T\"}],\r\n",
+       " \"env\": 6}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check AF.grounded_fixed\n",
+       "──────▶  Argumentation.AF.grounded_fixed.{u_1} {α : Type u_1} (af : AF α) : af.characteristic af.grounded = af.grounded\n",
+       "#check AF.grounded_defends_iff_mem\n",
+       "──────▶  Argumentation.AF.grounded_defends_iff_mem.{u_1} {α : Type u_1} (af : AF α) (a : α) :\n",
+       "  af.defends af.grounded a ↔ a ∈ af.grounded\n",
+       "#check AF.grounded_least_complete\n",
+       "──────▶  Argumentation.AF.grounded_least_complete.{u_1} {α : Type u_1} (af : AF α) (T : Set α) (h : af.Complete T) :\n",
+       "  af.grounded ⊆ T\n",
+       "--% env 6\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check AF.grounded_fixed\\n#check AF.grounded_defends_iff_mem\\n#check AF.grounded_least_complete\", \"env\": 5}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.grounded_fixed.{u_1} {α : Type u_1} (af : AF α) : af.characteristic af.grounded = af.grounded\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.grounded_defends_iff_mem.{u_1} {α : Type u_1} (af : AF α) (a : α) :\\n  af.defends af.grounded a ↔ a ∈ af.grounded\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Argumentation.AF.grounded_least_complete.{u_1} {α : Type u_1} (af : AF α) (T : Set α) (h : af.Complete T) :\\n  af.grounded ⊆ T\"}],\r\n",
+       " \"env\": 6}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check AF.grounded_fixed\n",
+    "#check AF.grounded_defends_iff_mem\n",
+    "#check AF.grounded_least_complete"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57320792",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00431,
+     "end_time": "2026-06-26T22:37:50.658140+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.653830+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : grounded = plus petit point fixe (Knaster–Tarski)\n",
+    "\n",
+    "| Théorème | Conclusion |\n",
+    "|----------|-----------|\n",
+    "| `grounded_fixed` | `F(grounded) = grounded` (point fixe) |\n",
+    "| `grounded_defends_iff_mem` | `a ∈ grounded ⇔ grounded défend a` |\n",
+    "| `grounded_least_complete` | `grounded ⊆ T` pour toute extension complète `T` |\n",
+    "\n",
+    "L'extension grounded est donc **la plus prudente** : exactement ce que tout argument\n",
+    "défendu itérativement à partir de l'ensemble vide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25aac6d1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003631,
+     "end_time": "2026-06-26T22:37:50.666232+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.662601+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. La chaîne causale complète\n",
+    "\n",
+    "Les cinq modules composent une chaîne unique, du cadre abstrait au point fixe :\n",
+    "\n",
+    "1. **`Basic`** — cadre `AF`, sans-conflit, défense, monotonie (`defends_mono`).\n",
+    "2. **`Characteristic`** — `F : Set α →o Set α` morphisme monotone (la croissance).\n",
+    "3. **`Extensions`** — les 5 sémantiques (Admissible → Complete → grounded → Preferred → Stable).\n",
+    "4. **`Fundamental`** — la Fundamental Lemma (étendre un admissible défendable ⟹ admissible).\n",
+    "5. **`Grounded`** — `F(grounded) = grounded` (point fixe ⟹ grounded est la plus petite complète)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60ecf40f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004654,
+     "end_time": "2026-06-26T22:37:50.675464+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.670810+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Exercices\n",
+    "\n",
+    "### Exercice 1 — Sans-conflit et défense sur un mini-cadre (Python)\n",
+    "\n",
+    "Ancrez l'intuition sur un exemple concret : un cadre à 3 arguments `{a, b, c}` où `a`\n",
+    "attaque `b` et `b` attaque `c`. Quels ensembles sont sans conflit ? Lequel défend `c` ?\n",
+    "\n",
+    "```python\n",
+    "attacks = {('a','b'), ('b','c')}\n",
+    "args = ['a', 'b', 'c']\n",
+    "def conflict_free(S, attacks):\n",
+    "    # TODO etudiant : un ensemble S est sans-conflit si aucune attaque n'a\n",
+    "    #                ses deux extremites dans S.\n",
+    "    return None  # TODO\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "683873f1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00468,
+     "end_time": "2026-06-26T22:37:50.684151+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.679471+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — L'ensemble vide est sans conflit\n",
+    "\n",
+    "Prouvez en Lean que l'ensemble vide est sans conflit (c'est un cas particulier de\n",
+    "`conflictFree_empty`, mais essayez de le refaire à la main).\n",
+    "\n",
+    "```lean\n",
+    "-- TODO etudiant : formaliser conflictFree_empty a la main\n",
+    "-- example (af : AF α) : af.conflictFree (∅ : Set α) := by sorry\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6447b07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004296,
+     "end_time": "2026-06-26T22:37:50.695651+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.691355+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Un cadre sans extension stable (contre-exemple)\n",
+    "\n",
+    "Un cycle de 3 arguments (`a` attaque `b`, `b` attaque `c`, `c` attaque `a`) n'admet\n",
+    "**pas** d'extension stable : tout ensemble sans-conflit laisse au moins un argument\n",
+    "non attaqué. Justifiez sur papier, puis proposez la formalisation Lean du contre-exemple.\n",
+    "\n",
+    "```lean\n",
+    "-- TODO etudiant : formaliser un cycle a 3 arguments et montrer l'absence d'extension stable\n",
+    "-- def threeCycle : AF (Fin 3) := ⟨fun i j => ...⟩\n",
+    "-- example : ¬ ∃ S, (threeCycle).Stable S := by sorry\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee5e472f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004124,
+     "end_time": "2026-06-26T22:37:50.704294+00:00",
+     "exception": false,
+     "start_time": "2026-06-26T22:37:50.700170+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce companion **natif** exhibe la preuve formelle 0-sorry de la théorie de l'argumentation\n",
+    "de Dung dans le kernel Lean lui-même : `#check` et `#print axioms` rendent les signatures\n",
+    "et les axiomes réels produits par le compilateur, sans intermédiaire Python.\n",
+    "\n",
+    "Le résultat phare `grounded_fixed` — l'extension grounded est le point fixe de la fonction\n",
+    "caractéristique — formalise l'un des piliers de l'argumentation computationnelle (Dung 1995),\n",
+    "via Knaster–Tarski (`OrderHom.map_lfp`).\n",
+    "\n",
+    "**Jalon ouvert** : l'existence des extensions preferred (via la Fundamental Lemma + Zorn)\n",
+    "n'est qu'esquissée dans le lake ; la lib reste sorry-free."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Lean 4 (WSL)",
+   "language": "lean4",
+   "name": "lean4-wsl"
+  },
+  "language_info": {
+   "codemirror_mode": "python",
+   "file_extension": ".lean",
+   "mimetype": "text/x-lean4",
+   "name": "lean4"
+  },
+  "papermill": {
+   "input_path": "Tweety-5b-Lean-Argumentation.ipynb",
+   "output_path": "Tweety-5b-Lean-Argumentation.ipynb"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

**Tweety-5b-Lean-Argumentation.ipynb** — the **pur-Lean native** companion for the lake [`argumentation_lean`](../argumentation_lean/) (lib `Argumentation`: Dung 1995 abstract argumentation theory — the **grounded extension as the least fixed point** of the characteristic function via Knaster–Tarski, **0 sorry**). This is the format the user mandates: a notebook Lean natif lisible, NOT the #4376 Python→Lean companion that shells `lake env lean` and manipulates strings.

This is the **3rd native companion** (after #4393 sensitivity, #4397 minimax), proving the UNLOCK (#4390, merged) is reproducible across lakes. It **supersedes the python3 #4376** in format (closes #4376).

| Route | Notebook | Method |
|-------|----------|--------|
| Computation (existing) | Tweety-5-Abstract-Argumentation (Python/Java) | Dung AF simulation, sémantiques |
| Companion (this PR) | **Tweety-5b (native Lean)** | **kernel `lean4-wsl`, `import Argumentation.*` + `#check` + `#print axioms` rendered in-kernel** |

## What the notebook shows (real Lean, zero Python)

7 code cells, kernel `lean4-wsl`:

- `import Argumentation.{Basic,Characteristic,Extensions,Fundamental,Grounded}` `open Argumentation` → OK
- `#print axioms AF.grounded_fixed` → **[propext, Classical.choice, Quot.sound]** (0 sorry, no `sorryAx`)
- `#check AF` / `AF.conflictFree` / `AF.defends` / `AF.conflictFree_empty` / `AF.defends_mono` (module `Basic`: Dung framework)
- `#check AF.characteristic` (`Set α →o Set α` OrderHom) / `mem_characteristic_iff` (module `Characteristic`)
- `#check AF.Admissible` / `AF.Complete` / `AF.grounded` / `AF.Preferred` / `AF.Stable` (module `Extensions`: 5 semantics)
- `#check AF.fundamental_lemma` / `fundamental_lemma_defends` (module `Fundamental`: Dung's Fundamental Lemma)
- `#check AF.grounded_fixed` (flagship: `F(grounded) = grounded` fixed point) / `grounded_defends_iff_mem` / `grounded_least_complete`
- Pedagogical arc faithful to #4376: Basic (framework) → Characteristic (OrderHom) → Extensions (5 semantics) → Fundamental (Fundamental Lemma) → Grounded (flagship fixed point) → causal chain → 3 exercises (markdown pseudo-code stubs, C.1)

## Why native and not the #4376 python3 companion

PR #4376 (python3 + `lake env lean --stdin`) is *honest* but the user finds a "Python→Lean companion that loads the lake and manipulates countless strings" **hard to read**. This PR delivers the proof exhibited **in the Lean kernel itself** — `#check` and `#print axioms` render the real compiler output in-kernel, no string manipulation.

## Verification (C.2, executed WITH outputs, 7/7 code cells, 0 errors)

| Check | Result |
|-------|--------|
| `lake build Argumentation` | **SUCCESS** (exit=0, junction #2611 rc1 + deps built) |
| Papermill execute (lean4-wsl kernel) | **7/7 code cells, 0 errors, 0 cells without output** |
| Native `#check` | pillar signatures rendered in-kernel (AF, conflictFree, characteristic OrderHom, fundamental_lemma, flagship grounded_fixed) |
| `#print axioms` | **[propext, Classical.choice, Quot.sound]** → 0 sorry |
| C.1 (no voluntary error) | 0 `raise NotImplementedError`/`assert False`/`1/0` |
| `metadata.papermill.input/output_path` | normalized to basename (metadata-only, C.2-exempt) |

**Execution note**: run the notebook from the `argumentation_lean/` directory (or anywhere the UNLOCK patch #4390 + junction #2611 rc1 is active). The first cell (`import`) takes ~3 min (Mathlib load via junction); the rest are instant.

## Dependency: REQUIRES the UNLOCK (#4390, MERGED) to run natively

The notebook is a *lean4-wsl* kernel that imports a Mathlib lake — works only with PR #4390's `lean4_jupyter/repl.py` patch + matched repl (`repl-4.31.0-rc1`, rc1 toolchain) + wrapper v6. **#4390 is MERGED** (`50ec8f586`). The junction (rc1 cluster `d568c8c0`) is applied locally via `scripts/lean/setup_shared_mathlib.ps1`.

Durability: the repl.py patch is a pip-package edit (lost on `pip install`); #4394 tracks the durable fork/PR upstream (follow-up, NOT a blocker).

## rc1 lakes need the launch() timeout bump (60→240s) — applied live

Diagnosed firsthand (c.129, minimax): for rc1 lakes with junctioned Mathlib, `lake env` re-verifies the junction ("has local changes") and takes ~111-125s — exceeding the patched `launch()`'s 60s timeout → fallback to broken `lake env repl` → empty kernel buffer. Fix: `launch()` LEAN_PATH-capture timeout 60→240s (the LEAN_PATH IS captured correctly, just slowly). Applied locally to the live `repl.py` (`.bak.c129` backup). The reproducible installer `scripts/lean/setup_native_lean4_import.py` has the matching edit (1 line + comment) — a separate tiny follow-up PR or fold into #4394, **not mixed here** (atomicity). The 2nd gotcha (`globs := #[.submodules 'Argumentation]` doesn't build the root umbrella) is fixed notebook-side: importing the 5 submodules directly.

## Atomicity

Single-subject PR (one new companion notebook + 1 README nav line `5b`). Docs-only on the lake (0 `.lean` touched). Fresh base from `origin/main` (0 behind / 0 ahead at creation). Staging explicit (`git add <notebook> <README>`), pre-existing mods excluded.

Closes #4376 (supersedes the python3 companion in format). See #4390 (UNLOCK, merged), See #4393 (1st native — sensitivity) + #4397 (2nd — minimax, the proven patterns), See #4394 (durable fork follow-up), See #4046/#4038 (lake roadmap), See #2611 (Mathlib junction).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
