### PR TITLE
Add: Sudoku-7b-Lean-Propagation (native lean4-wsl companion, 5th native)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -330,6 +330,7 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 5 | PSO | Essaim de particules : convergence collective, vitesse, position |
 | 6 | AIMA CSP | CSP académique : variables, domaines, contraintes, MRV, AC-3 |
 | 7 | Norvig | Propagation de Norvig : élimination des candidats + recherche efficace |
+| 7b | [Sudoku-7b-Lean-Propagation](Sudoku-7b-Lean-Propagation.ipynb) | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la soundness de la propagation (naked/hidden single, clé de voûte `peer_excludes_value`) dans le lake `sudoku_lean`, `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) |
 | 8 | Human Stratégies | 13 techniques humaines : naked/hidden singles, pairs, pointing, box/line |
 | 9 | Graph Coloring | Formulation graphe : nx.sudoku_graph(), coloration DSATUR |
 | 10 | OR-Tools | CP-SAT industriel : modèle déclaratif, contraintes globales, parallélisme |

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7b-Lean-Propagation.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7b-Lean-Propagation.ipynb
@@ -1,0 +1,841 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "47ad92f4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005733,
+     "end_time": "2026-06-27T00:23:50.117283+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:23:50.111550+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Sudoku-7b — Soundness de la propagation de contraintes (companion formel natif)\n",
+    "\n",
+    "Ce notebook est le **companion formel** du lake [`sudoku_lean`](../sudoku_lean/),\n",
+    "dont la lib `Sudoku` prouve la **soundness des règles de propagation** d'un Sudoku\n",
+    "(*naked single*, *hidden single*) : ces règles, utilisées par tous les solveurs\n",
+    "(backtracking, OR-Tools, .NET), **ne retirent aucune solution valide** — elles\n",
+    "n'éliminent que des affectations impossibles. Résultat central de la série Sudoku\n",
+    "(issue #4055), avec **zéro `sorry`**.\n",
+    "\n",
+    "L'idée : une cellule affectée **exclut sa valeur** de toutes ses cellules *paires*\n",
+    "(clé de voûte `peer_excludes_value`). De là dérivent par l'absurde les deux règles\n",
+    "de propagation, qui ne perdent donc jamais une solution.\n",
+    "\n",
+    "## Convention de vérification — `#check` *natif* dans le kernel Lean\n",
+    "\n",
+    "Ce notebook est un **notebook Lean natif** (kernel `lean4-wsl`) : il `import`e les\n",
+    "modules du lake directement et le compilateur Lean rend les signatures **dans le\n",
+    "notebook**. C'est rendu possible par l'UNLOCK (patch `lean4_jupyter` + jonction\n",
+    "Mathlib #2611).\n",
+    "\n",
+    "> ⚠️ À l'exécution, la première cellule (`import`) peut prendre **~3 min** :\n",
+    "> le kernel charge les oleans Mathlib via la jonction NTFS. Les suivantes sont\n",
+    "> instantanées."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5261f8fd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003245,
+     "end_time": "2026-06-27T00:23:50.126795+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:23:50.123550+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Import des modules du lake `sudoku_lean`\n",
+    "\n",
+    "Le lake est structuré en 2 modules (`Basic`, `Propagation`) sous le namespace\n",
+    "`Sudoku`. On importe les 2 modules (la config `submodules` du lake ne build pas\n",
+    "l'umbrella racine — on cible directement les modules qui portent les définitions)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e0da954f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T00:23:50.135006Z",
+     "iopub.status.busy": "2026-06-27T00:23:50.134828Z",
+     "iopub.status.idle": "2026-06-27T00:28:10.353841Z",
+     "shell.execute_reply": "2026-06-27T00:28:10.352974Z"
+    },
+    "papermill": {
+     "duration": 260.362738,
+     "end_time": "2026-06-27T00:28:10.493404+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:23:50.130666+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Sudoku<span class=\"bp\">.</span>Basic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Sudoku<span class=\"bp\">.</span>Propagation</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>Sudoku</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"import Sudoku.Basic\\nimport Sudoku.Propagation\\nopen Sudoku\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "import Sudoku.Basic\n",
+       "import Sudoku.Propagation\n",
+       "open Sudoku\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"import Sudoku.Basic\\nimport Sudoku.Propagation\\nopen Sudoku\"}\n",
+       "Raw output:\n",
+       "{\"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import Sudoku.Basic\n",
+    "import Sudoku.Propagation\n",
+    "open Sudoku"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d61c858",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006737,
+     "end_time": "2026-06-27T00:28:10.516897+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:10.510160+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Preuve sans `sorry` — `#print axioms`\n",
+    "\n",
+    "La clé de voûte `peer_excludes_value` et les deux théorèmes de soundness qui en dérivent\n",
+    "(`naked_single_sound`, `hidden_single_sound`) ne dépendent que de **deux axiomes**\n",
+    "(`propext`, `Quot.sound`) — pas de `sorryAx` et pas même de `Classical.choice` — ce qui\n",
+    "prouve que la preuve est **complète** (0 sorry) et **constructive** (par l'absurde via\n",
+    "`Classical.em`, dérivable de `propext` + `Quot.sound`). Le lemme `full_house_present`\n",
+    "(pigeonhole) utilise `Classical.choice` (`card_image_of_injOn`), donc 3 axiomes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d8b1d009",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T00:28:10.533588Z",
+     "iopub.status.busy": "2026-06-27T00:28:10.533184Z",
+     "iopub.status.idle": "2026-06-27T00:28:10.756353Z",
+     "shell.execute_reply": "2026-06-27T00:28:10.755407Z"
+    },
+    "papermill": {
+     "duration": 0.236222,
+     "end_time": "2026-06-27T00:28:10.757064+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:10.520842+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>peer_excludes_value</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Sudoku<span class=\"bp\">.</span>peer_excludes_value&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>naked_single_sound</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Sudoku<span class=\"bp\">.</span>naked_single_sound&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>hidden_single_sound</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Sudoku<span class=\"bp\">.</span>hidden_single_sound&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#print axioms peer_excludes_value\\n#print axioms naked_single_sound\\n#print axioms hidden_single_sound\", \"env\": 0}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sudoku.peer_excludes_value' depends on axioms: [propext, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sudoku.naked_single_sound' depends on axioms: [propext, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sudoku.hidden_single_sound' depends on axioms: [propext, Quot.sound]\"}],\r\n",
+       " \"env\": 1}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#print axioms peer_excludes_value\n",
+       "──────▶  'Sudoku.peer_excludes_value' depends on axioms: [propext, Quot.sound]\n",
+       "#print axioms naked_single_sound\n",
+       "──────▶  'Sudoku.naked_single_sound' depends on axioms: [propext, Quot.sound]\n",
+       "#print axioms hidden_single_sound\n",
+       "──────▶  'Sudoku.hidden_single_sound' depends on axioms: [propext, Quot.sound]\n",
+       "--% env 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#print axioms peer_excludes_value\\n#print axioms naked_single_sound\\n#print axioms hidden_single_sound\", \"env\": 0}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sudoku.peer_excludes_value' depends on axioms: [propext, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sudoku.naked_single_sound' depends on axioms: [propext, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Sudoku.hidden_single_sound' depends on axioms: [propext, Quot.sound]\"}],\r\n",
+       " \"env\": 1}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#print axioms peer_excludes_value\n",
+    "#print axioms naked_single_sound\n",
+    "#print axioms hidden_single_sound"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64d6846c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002972,
+     "end_time": "2026-06-27T00:28:10.763807+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:10.760835+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. La structure de contraintes abstraite d'un Sudoku\n",
+    "\n",
+    "Le module `Sudoku/Basic.lean` formalise un Sudoku de façon **abstraite** : tout CSP\n",
+    "« à portées toutes-distinctes ». Le 9×9 concret (lignes, colonnes, blocs) en est une\n",
+    "instance, non un cas spécial — les théorèmes de soundness valent pour toute structure\n",
+    "de ce type.\n",
+    "\n",
+    "- `Scopes ι = Finset (Finset ι)` — un ensemble fini de **portées** (chacune un `Finset` de cellules).\n",
+    "- `Solution ι V = ι → V` — une affectation complète (une valeur par cellule).\n",
+    "- `AllDistinctOn σ s` — `σ` est **toutes-distinctes sur `s`** (injectivité de `σ` sur `s`).\n",
+    "- `IsSolution scopes σ` — `σ` est toutes-distinctes sur **chacune** des portées (invariant fondamental).\n",
+    "- `IsPeer scopes c c'` — `c'` est une **paire** de `c` (distinctes, partagent une portée).\n",
+    "- `PresentIn σ s v` — la valeur `v` est présente dans la portée `s`.\n",
+    "\n",
+    "Le lemme `full_house_present` (pigeonhole) : une portée « pleine maison »\n",
+    "(`s.card = card V`) porte toute valeur dans toute solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3dc831b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T00:28:10.772203Z",
+     "iopub.status.busy": "2026-06-27T00:28:10.772052Z",
+     "iopub.status.idle": "2026-06-27T00:28:10.994387Z",
+     "shell.execute_reply": "2026-06-27T00:28:10.993405Z"
+    },
+    "papermill": {
+     "duration": 0.227639,
+     "end_time": "2026-06-27T00:28:10.994922+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:10.767283+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Scopes</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>Scopes<span class=\"bp\">.</span>{u_3}<span class=\"w\"> </span>(ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_3)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_3</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Solution</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>Solution<span class=\"bp\">.</span>{u_3,<span class=\"w\"> </span>u_4}<span class=\"w\"> </span>(ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_3)<span class=\"w\"> </span>(V<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_4)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>(max<span class=\"w\"> </span>u_3<span class=\"w\"> </span>u_4)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AllDistinctOn</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>AllDistinctOn<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{V<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>(σ<span class=\"w\"> </span>:<span class=\"w\"> </span>Solution<span class=\"w\"> </span>ι<span class=\"w\"> </span>V)<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>ι)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IsSolution</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>IsSolution<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{V<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>(scopes<span class=\"w\"> </span>:<span class=\"w\"> </span>Scopes<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(σ<span class=\"w\"> </span>:<span class=\"w\"> </span>Solution<span class=\"w\"> </span>ι<span class=\"w\"> </span>V)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IsPeer</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>IsPeer<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(scopes<span class=\"w\"> </span>:<span class=\"w\"> </span>Scopes<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(c<span class=\"w\"> </span>c&#39;<span class=\"w\"> </span>:<span class=\"w\"> </span>ι)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>PresentIn</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>PresentIn<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{V<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>(σ<span class=\"w\"> </span>:<span class=\"w\"> </span>Solution<span class=\"w\"> </span>ι<span class=\"w\"> </span>V)<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(v<span class=\"w\"> </span>:<span class=\"w\"> </span>V)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>full_house_present</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>full_house_present<span class=\"bp\">.</span>{u_3,<span class=\"w\"> </span>u_4}<span class=\"w\"> </span>{ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_3}<span class=\"w\"> </span>{V<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_4}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>ι]<span class=\"w\"> </span>[DecidableEq<span class=\"w\"> </span>ι]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>V]\n",
+       "<span class=\"w\">  </span>[DecidableEq<span class=\"w\"> </span>V]<span class=\"w\"> </span>(σ<span class=\"w\"> </span>:<span class=\"w\"> </span>Solution<span class=\"w\"> </span>ι<span class=\"w\"> </span>V)<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(v<span class=\"w\"> </span>:<span class=\"w\"> </span>V)<span class=\"w\"> </span>(hcard<span class=\"w\"> </span>:<span class=\"w\"> </span>s<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>Fintype<span class=\"bp\">.</span>card<span class=\"w\"> </span>V)\n",
+       "<span class=\"w\">  </span>(hAD<span class=\"w\"> </span>:<span class=\"w\"> </span>AllDistinctOn<span class=\"w\"> </span>σ<span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span>PresentIn<span class=\"w\"> </span>σ<span class=\"w\"> </span>s<span class=\"w\"> </span>v</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check Scopes\\n#check Solution\\n#check AllDistinctOn\\n#check IsSolution\\n#check IsPeer\\n#check PresentIn\\n#check full_house_present\", \"env\": 1}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Sudoku.Scopes.{u_3} (ι : Type u_3) : Type u_3\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.Solution.{u_3, u_4} (ι : Type u_3) (V : Type u_4) : Type (max u_3 u_4)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.AllDistinctOn.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (σ : Solution ι V) (s : Finset ι) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.IsSolution.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (scopes : Scopes ι) (σ : Solution ι V) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.IsPeer.{u_1} {ι : Type u_1} (scopes : Scopes ι) (c c' : ι) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.PresentIn.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (σ : Solution ι V) (s : Finset ι) (v : V) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.full_house_present.{u_3, u_4} {ι : Type u_3} {V : Type u_4} [Fintype ι] [DecidableEq ι] [Fintype V]\\n  [DecidableEq V] (σ : Solution ι V) (s : Finset ι) (v : V) (hcard : s.card = Fintype.card V)\\n  (hAD : AllDistinctOn σ s) : PresentIn σ s v\"}],\r\n",
+       " \"env\": 2}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check Scopes\n",
+       "──────▶  Sudoku.Scopes.{u_3} (ι : Type u_3) : Type u_3\n",
+       "#check Solution\n",
+       "──────▶  Sudoku.Solution.{u_3, u_4} (ι : Type u_3) (V : Type u_4) : Type (max u_3 u_4)\n",
+       "#check AllDistinctOn\n",
+       "──────▶  Sudoku.AllDistinctOn.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (σ : Solution ι V) (s : Finset ι) : Prop\n",
+       "#check IsSolution\n",
+       "──────▶  Sudoku.IsSolution.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (scopes : Scopes ι) (σ : Solution ι V) : Prop\n",
+       "#check IsPeer\n",
+       "──────▶  Sudoku.IsPeer.{u_1} {ι : Type u_1} (scopes : Scopes ι) (c c' : ι) : Prop\n",
+       "#check PresentIn\n",
+       "──────▶  Sudoku.PresentIn.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (σ : Solution ι V) (s : Finset ι) (v : V) : Prop\n",
+       "#check full_house_present\n",
+       "──────▶  Sudoku.full_house_present.{u_3, u_4} {ι : Type u_3} {V : Type u_4} [Fintype ι] [DecidableEq ι] [Fintype V]\n",
+       "  [DecidableEq V] (σ : Solution ι V) (s : Finset ι) (v : V) (hcard : s.card = Fintype.card V)\n",
+       "  (hAD : AllDistinctOn σ s) : PresentIn σ s v\n",
+       "--% env 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check Scopes\\n#check Solution\\n#check AllDistinctOn\\n#check IsSolution\\n#check IsPeer\\n#check PresentIn\\n#check full_house_present\", \"env\": 1}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Sudoku.Scopes.{u_3} (ι : Type u_3) : Type u_3\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.Solution.{u_3, u_4} (ι : Type u_3) (V : Type u_4) : Type (max u_3 u_4)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.AllDistinctOn.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (σ : Solution ι V) (s : Finset ι) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.IsSolution.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (scopes : Scopes ι) (σ : Solution ι V) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.IsPeer.{u_1} {ι : Type u_1} (scopes : Scopes ι) (c c' : ι) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.PresentIn.{u_1, u_2} {ι : Type u_1} {V : Type u_2} (σ : Solution ι V) (s : Finset ι) (v : V) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.full_house_present.{u_3, u_4} {ι : Type u_3} {V : Type u_4} [Fintype ι] [DecidableEq ι] [Fintype V]\\n  [DecidableEq V] (σ : Solution ι V) (s : Finset ι) (v : V) (hcard : s.card = Fintype.card V)\\n  (hAD : AllDistinctOn σ s) : PresentIn σ s v\"}],\r\n",
+       " \"env\": 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check Scopes\n",
+    "#check Solution\n",
+    "#check AllDistinctOn\n",
+    "#check IsSolution\n",
+    "#check IsPeer\n",
+    "#check PresentIn\n",
+    "#check full_house_present"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "932b1bb3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00352,
+     "end_time": "2026-06-27T00:28:11.003833+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.000313+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : modéliser un CSP à portées toutes-distinctes\n",
+    "\n",
+    "| Symbole Lean | Lecture |\n",
+    "|-------------|---------|\n",
+    "| `Scopes ι` | ensemble fini de portées (`Finset (Finset ι)`) |\n",
+    "| `Solution ι V` | affectation : une valeur par cellule (`ι → V`) |\n",
+    "| `AllDistinctOn σ s` | `σ` injective sur la portée `s` |\n",
+    "| `IsSolution scopes σ` | `σ` valide sur toutes les portées |\n",
+    "| `IsPeer scopes c c'` | `c'` paire de `c` (partagent une portée) |\n",
+    "| `full_house_present` | portée pleine maison ⟹ toute valeur présente (pigeonhole) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01bc3ef8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004104,
+     "end_time": "2026-06-27T00:28:11.011626+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.007522+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. La clé de voûte et la soundness des règles de propagation\n",
+    "\n",
+    "Le module `Sudoku/Propagation.lean` prouve la **soundness** des deux règles canoniques\n",
+    "de propagation, à partir d'une unique clé de voûte :\n",
+    "\n",
+    "- **`peer_excludes_value`** (clé de voûte) : une cellule `c` portant `v` **exclut `v`**\n",
+    "  de toute paire `c'` (`σ c' ≠ v`). Preuve : `c` et `c'` partagent une portée ; `σ`\n",
+    "  toutes-distinctes dessus ⟹ `σ c = σ c'` impliquerait `c = c'`, contredisant `c ≠ c'`.\n",
+    "- **`naked_single_sound`** : si toutes les valeurs sauf `v` sont déjà portées par des\n",
+    "  paires de `c`, alors `σ c = v` (par l'absurde via `peer_excludes_value`).\n",
+    "- **`hidden_single_sound`** : si `v` est présente dans la portée `s` et exclue de toute\n",
+    "  autre cellule de `s`, alors `σ c = v` où `c` est l'unique cellule possible.\n",
+    "\n",
+    "Ces règles **ne retirent aucune solution valide** : elles identifient des valeurs\n",
+    "**forcées**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a2e84718",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T00:28:11.019324Z",
+     "iopub.status.busy": "2026-06-27T00:28:11.019176Z",
+     "iopub.status.idle": "2026-06-27T00:28:11.234739Z",
+     "shell.execute_reply": "2026-06-27T00:28:11.233958Z"
+    },
+    "papermill": {
+     "duration": 0.220145,
+     "end_time": "2026-06-27T00:28:11.235301+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.015156+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>peer_excludes_value</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>peer_excludes_value<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{V<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>ι]<span class=\"w\"> </span>[DecidableEq<span class=\"w\"> </span>ι]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>V]\n",
+       "<span class=\"w\">  </span>[DecidableEq<span class=\"w\"> </span>V]<span class=\"w\"> </span>(scopes<span class=\"w\"> </span>:<span class=\"w\"> </span>Scopes<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(σ<span class=\"w\"> </span>:<span class=\"w\"> </span>Solution<span class=\"w\"> </span>ι<span class=\"w\"> </span>V)<span class=\"w\"> </span>(hσ<span class=\"w\"> </span>:<span class=\"w\"> </span>IsSolution<span class=\"w\"> </span>scopes<span class=\"w\"> </span>σ)<span class=\"w\"> </span>(c<span class=\"w\"> </span>c&#39;<span class=\"w\"> </span>:<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(v<span class=\"w\"> </span>:<span class=\"w\"> </span>V)\n",
+       "<span class=\"w\">  </span>(hpeer<span class=\"w\"> </span>:<span class=\"w\"> </span>IsPeer<span class=\"w\"> </span>scopes<span class=\"w\"> </span>c<span class=\"w\"> </span>c&#39;)<span class=\"w\"> </span>(hcv<span class=\"w\"> </span>:<span class=\"w\"> </span>σ<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>v)<span class=\"w\"> </span>:<span class=\"w\"> </span>σ<span class=\"w\"> </span>c&#39;<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span>v</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>naked_single_sound</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>naked_single_sound<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{V<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>ι]<span class=\"w\"> </span>[DecidableEq<span class=\"w\"> </span>ι]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>V]\n",
+       "<span class=\"w\">  </span>[DecidableEq<span class=\"w\"> </span>V]<span class=\"w\"> </span>(scopes<span class=\"w\"> </span>:<span class=\"w\"> </span>Scopes<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(σ<span class=\"w\"> </span>:<span class=\"w\"> </span>Solution<span class=\"w\"> </span>ι<span class=\"w\"> </span>V)<span class=\"w\"> </span>(hσ<span class=\"w\"> </span>:<span class=\"w\"> </span>IsSolution<span class=\"w\"> </span>scopes<span class=\"w\"> </span>σ)<span class=\"w\"> </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(v<span class=\"w\"> </span>:<span class=\"w\"> </span>V)\n",
+       "<span class=\"w\">  </span>(hcover<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(w<span class=\"w\"> </span>:<span class=\"w\"> </span>V),<span class=\"w\"> </span>w<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span>v<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>c&#39;,<span class=\"w\"> </span>IsPeer<span class=\"w\"> </span>scopes<span class=\"w\"> </span>c<span class=\"w\"> </span>c&#39;<span class=\"w\"> </span><span class=\"bp\">∧</span><span class=\"w\"> </span>σ<span class=\"w\"> </span>c&#39;<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>w)<span class=\"w\"> </span>:<span class=\"w\"> </span>σ<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>v</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>hidden_single_sound</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Sudoku<span class=\"bp\">.</span>hidden_single_sound<span class=\"bp\">.</span>{u_1,<span class=\"w\"> </span>u_2}<span class=\"w\"> </span>{ι<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>{V<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>ι]<span class=\"w\"> </span>[DecidableEq<span class=\"w\"> </span>ι]<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>V]\n",
+       "<span class=\"w\">  </span>[DecidableEq<span class=\"w\"> </span>V]<span class=\"w\"> </span>(scopes<span class=\"w\"> </span>:<span class=\"w\"> </span>Scopes<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(σ<span class=\"w\"> </span>:<span class=\"w\"> </span>Solution<span class=\"w\"> </span>ι<span class=\"w\"> </span>V)<span class=\"w\"> </span>(hσ<span class=\"w\"> </span>:<span class=\"w\"> </span>IsSolution<span class=\"w\"> </span>scopes<span class=\"w\"> </span>σ)<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(<span class=\"bp\">_</span>hs<span class=\"w\"> </span>:<span class=\"w\"> </span>s<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>scopes)\n",
+       "<span class=\"w\">  </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>ι)<span class=\"w\"> </span>(v<span class=\"w\"> </span>:<span class=\"w\"> </span>V)<span class=\"w\"> </span>(<span class=\"bp\">_</span>hcs<span class=\"w\"> </span>:<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s)<span class=\"w\"> </span>(hvin<span class=\"w\"> </span>:<span class=\"w\"> </span>PresentIn<span class=\"w\"> </span>σ<span class=\"w\"> </span>s<span class=\"w\"> </span>v)\n",
+       "<span class=\"w\">  </span>(hexcl<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>c&#39;<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s,<span class=\"w\"> </span>c&#39;<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>c&#39;&#39;,<span class=\"w\"> </span>IsPeer<span class=\"w\"> </span>scopes<span class=\"w\"> </span>c&#39;<span class=\"w\"> </span>c&#39;&#39;<span class=\"w\"> </span><span class=\"bp\">∧</span><span class=\"w\"> </span>σ<span class=\"w\"> </span>c&#39;&#39;<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>v)<span class=\"w\"> </span>:<span class=\"w\"> </span>σ<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>v</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check peer_excludes_value\\n#check naked_single_sound\\n#check hidden_single_sound\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.peer_excludes_value.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\\n  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (c c' : ι) (v : V)\\n  (hpeer : IsPeer scopes c c') (hcv : σ c = v) : σ c' ≠ v\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.naked_single_sound.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\\n  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (c : ι) (v : V)\\n  (hcover : ∀ (w : V), w ≠ v → ∃ c', IsPeer scopes c c' ∧ σ c' = w) : σ c = v\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.hidden_single_sound.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\\n  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (s : Finset ι) (_hs : s ∈ scopes)\\n  (c : ι) (v : V) (_hcs : c ∈ s) (hvin : PresentIn σ s v)\\n  (hexcl : ∀ c' ∈ s, c' ≠ c → ∃ c'', IsPeer scopes c' c'' ∧ σ c'' = v) : σ c = v\"}],\r\n",
+       " \"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check peer_excludes_value\n",
+       "──────▶  Sudoku.peer_excludes_value.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\n",
+       "  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (c c' : ι) (v : V)\n",
+       "  (hpeer : IsPeer scopes c c') (hcv : σ c = v) : σ c' ≠ v\n",
+       "#check naked_single_sound\n",
+       "──────▶  Sudoku.naked_single_sound.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\n",
+       "  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (c : ι) (v : V)\n",
+       "  (hcover : ∀ (w : V), w ≠ v → ∃ c', IsPeer scopes c c' ∧ σ c' = w) : σ c = v\n",
+       "#check hidden_single_sound\n",
+       "──────▶  Sudoku.hidden_single_sound.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\n",
+       "  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (s : Finset ι) (_hs : s ∈ scopes)\n",
+       "  (c : ι) (v : V) (_hcs : c ∈ s) (hvin : PresentIn σ s v)\n",
+       "  (hexcl : ∀ c' ∈ s, c' ≠ c → ∃ c'', IsPeer scopes c' c'' ∧ σ c'' = v) : σ c = v\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check peer_excludes_value\\n#check naked_single_sound\\n#check hidden_single_sound\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.peer_excludes_value.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\\n  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (c c' : ι) (v : V)\\n  (hpeer : IsPeer scopes c c') (hcv : σ c = v) : σ c' ≠ v\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.naked_single_sound.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\\n  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (c : ι) (v : V)\\n  (hcover : ∀ (w : V), w ≠ v → ∃ c', IsPeer scopes c c' ∧ σ c' = w) : σ c = v\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Sudoku.hidden_single_sound.{u_1, u_2} {ι : Type u_1} {V : Type u_2} [Fintype ι] [DecidableEq ι] [Fintype V]\\n  [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V) (hσ : IsSolution scopes σ) (s : Finset ι) (_hs : s ∈ scopes)\\n  (c : ι) (v : V) (_hcs : c ∈ s) (hvin : PresentIn σ s v)\\n  (hexcl : ∀ c' ∈ s, c' ≠ c → ∃ c'', IsPeer scopes c' c'' ∧ σ c'' = v) : σ c = v\"}],\r\n",
+       " \"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check peer_excludes_value\n",
+    "#check naked_single_sound\n",
+    "#check hidden_single_sound"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b9f7b21",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004419,
+     "end_time": "2026-06-27T00:28:11.245146+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.240727+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : la propagation ne perd aucune solution\n",
+    "\n",
+    "| Théorème | Conclusion |\n",
+    "|----------|-----------|\n",
+    "| `peer_excludes_value` | cellule affectée exclut sa valeur de ses paires (clé de voûte) |\n",
+    "| `naked_single_sound` | un seul candidat `v` restant ⟹ `σ c = v` |\n",
+    "| `hidden_single_sound` | `v` n'a qu'une cellule possible dans `s` ⟹ `σ c = v` |\n",
+    "\n",
+    "### Les jalons laissés ouverts (honnêtement)\n",
+    "\n",
+    "La **réduction Sudoku ⇔ couverture exacte** (Knuth, 4 familles de contraintes) et la\n",
+    "**complétude** des règles (suffisent-elles à résoudre tout Sudoku ? non en général —\n",
+    "d'où le backtracking) sont des jalons naturels **laissés ouverts**, délibérément non\n",
+    "`sorry`-backed : la lib reste entièrement `sorry`-free. Le résultat « 17 indices\n",
+    "minimum » est hors scope (calcul massif, non formalisable)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1e8b905",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003592,
+     "end_time": "2026-06-27T00:28:11.252859+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.249267+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. La chaîne causale complète\n",
+    "\n",
+    "Les deux modules composent une chaîne unique, de la structure abstraite à la soundness :\n",
+    "\n",
+    "1. **`Basic`** — `Scopes`/`Solution`/`AllDistinctOn`/`IsSolution`/`IsPeer`/`PresentIn`\n",
+    "   + `full_house_present` (pigeonhole : portée pleine maison ⟹ toute valeur présente).\n",
+    "2. **`Propagation`** — `peer_excludes_value` (clé de voûte) ⟶ `naked_single_sound` +\n",
+    "   `hidden_single_sound` (soundness des deux règles, par l'absurde)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50a0621d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00382,
+     "end_time": "2026-06-27T00:28:11.260441+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.256621+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exemple guidé et exercices\n",
+    "\n",
+    "### Exercice 1 — Paires et exclusion de candidats (Python)\n",
+    "\n",
+    "Ancrez l'intuition : modélisez un mini-Sudoku comme un ensemble de portées, et\n",
+    "implémentez `is_peer` (deux cellules sont paires si distinctes ET partagent une portée)\n",
+    "puis `eliminate` (une cellule affectée exclut sa valeur de tous ses pairs).\n",
+    "\n",
+    "```python\n",
+    "def is_peer(scopes, c, cprime):\n",
+    "    # c et cprime sont paires : distincts ET partagent au moins une portee\n",
+    "    if c == cprime:\n",
+    "        return False\n",
+    "    # TODO etudiant : existe-t-il une portee s contenant a la fois c et cprime ?\n",
+    "    return None  # TODO\n",
+    "\n",
+    "def eliminate(scopes, candidates, c, v):\n",
+    "    # c porte v : retirer v des candidats de tous les pairs de c\n",
+    "    # TODO etudiant : pour chaque paire c' de c, retirer v de candidates[c']\n",
+    "    return None  # TODO\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4675fdda",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003919,
+     "end_time": "2026-06-27T00:28:11.268653+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.264734+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Une cellule n'est pas sa propre paire (Lean)\n",
+    "\n",
+    "Prouvez qu'une cellule n'est jamais paire d'elle-même : `¬ IsPeer scopes c c`.\n",
+    "Indice : `IsPeer` exige `c ≠ c'` (première conjonction). Si `c = c'`, cette conjonction\n",
+    "est fausse.\n",
+    "\n",
+    "```lean\n",
+    "-- TODO etudiant : remplacer le sorry\n",
+    "-- example : ¬ IsPeer scopes c c := by\n",
+    "--   intro h\n",
+    "--   exact h.1 rfl\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e1054a5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003942,
+     "end_time": "2026-06-27T00:28:11.276553+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.272611+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Naked single et hidden single (Python)\n",
+    "\n",
+    "Mettez en évidence la différence entre les deux règles sur un mini-Sudoku (candidats =\n",
+    "ensemble de valeurs possibles par cellule). Implémentez `naked_single` (une cellule\n",
+    "n'a plus qu'un candidat) et `hidden_single` (une valeur n'a qu'une seule cellule\n",
+    "possible dans une portée). Vérifiez que les deux réduisent les candidats sans perte.\n",
+    "\n",
+    "```python\n",
+    "def naked_single(candidates):\n",
+    "    # Naked single : une cellule dont le seul candidat restant est v doit valoir v\n",
+    "    # TODO etudiant : retourne {cell: v} pour les cellules a candidat unique\n",
+    "    return None  # TODO\n",
+    "\n",
+    "def hidden_single(candidates, scopes):\n",
+    "    # Hidden single : une valeur n'allant que dans une cellule d'une portee y va\n",
+    "    # TODO etudiant : pour chaque portee et valeur, si une seule cellule peut la porter\n",
+    "    return None  # TODO\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8310b99",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003432,
+     "end_time": "2026-06-27T00:28:11.283856+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T00:28:11.280424+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce companion **natif** exhibe la preuve formelle 0-sorry de la soundness de la\n",
+    "propagation de contraintes Sudoku dans le kernel Lean lui-même : `#check` et\n",
+    "`#print axioms` rendent les signatures et les axiomes réels produits par le\n",
+    "compilateur, sans intermédiaire Python.\n",
+    "\n",
+    "La clé de voûte `peer_excludes_value` fonde les deux règles `naked_single_sound` et\n",
+    "`hidden_single_sound` : la propagation **ne retire aucune solution valide**, elle\n",
+    "n'élimine que des affectations qu'aucune solution n'utilise. C'est le fondement formel\n",
+    "des solveurs Sudoku (backtracking, OR-Tools, .NET) enseignés dans la série.\n",
+    "\n",
+    "**Jalons ouverts** : la réduction à la couverture exacte (Knuth) et la complétude des\n",
+    "règles ne sont pas formalisées ; la lib reste sorry-free."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Lean 4 (WSL)",
+   "language": "lean4",
+   "name": "lean4-wsl"
+  },
+  "language_info": {
+   "codemirror_mode": "python",
+   "file_extension": ".lean",
+   "mimetype": "text/x-lean4",
+   "name": "lean4"
+  },
+  "papermill": {
+   "duration": 395.672045,
+   "end_time": "2026-06-27T00:28:11.830294+00:00",
+   "exception": null,
+   "input_path": "Sudoku-7b-Lean-Propagation.ipynb",
+   "output_path": "Sudoku-7b-Lean-Propagation.ipynb",
+   "start_time": "2026-06-27T00:21:36.158249+00:00"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

**Sudoku-7b-Lean-Propagation.ipynb** — the **pur-Lean native** companion for the lake [`sudoku_lean`](../sudoku_lean/) (lib `Sudoku`: **soundness of constraint propagation** — naked single / hidden single rules, **0 sorry**). This is the format the user mandates: a notebook Lean natif lisible, NOT the #4384 Python→Lean companion that shells `lake env lean` and manipulates strings.

This is the **5th native companion** (after #4393 sensitivity, #4397 minimax, #4399 argumentation, #4400 planning), proving the UNLOCK (#4390, merged) is reproducible across lakes. It **supersedes the python3 #4384** in format (closes #4384).

| Route | Notebook | Method |
|-------|----------|--------|
| Computation (existing) | Sudoku-7 (Python/C#) | Norvig propagation, backtracking solveurs |
| Companion (this PR) | **Sudoku-7b (native Lean)** | **kernel `lean4-wsl`, `import Sudoku.*` + `#check` + `#print axioms` rendered in-kernel** |

## What the notebook shows (real Lean, zero Python)

4 code cells, kernel `lean4-wsl`:

- `import Sudoku.{Basic,Propagation}` `open Sudoku` → OK (2 submodules; `globs := #[.submodules `Sudoku]` does not build the root umbrella)
- `#print axioms peer_excludes_value` / `naked_single_sound` / `hidden_single_sound` → **[propext, Quot.sound]** (2 axioms — constructive, no `Classical.choice`, 0 sorry)
- `#check Scopes`/`Solution`/`AllDistinctOn`/`IsSolution`/`IsPeer`/`PresentIn`/`full_house_present` (module `Basic`: abstract CSP « à portées toutes-distinctes », `Scopes ι = Finset (Finset ι)`, full-house pigeonhole)
- `#check peer_excludes_value` (clé de voûte: affected cell excludes its value from all peers) / `naked_single_sound` / `hidden_single_sound` (soundness of the two propagation rules, by contradiction)
- Pedagogical arc faithful to #4384: Basic (structure) → Propagation (clé de voûte + 2 soundness theorems) → causal chain → 3 exercises (markdown pseudo-code stubs, C.1)

## Why native and not the #4384 python3 companion

PR #4384 (python3 + `lake env lean --stdin`) is *honest* but the user finds a "Python→Lean companion that loads the lake and manipulates countless strings" **hard to read**. This PR delivers the proof exhibited **in the Lean kernel itself** — `#check` and `#print axioms` render the real compiler output in-kernel, no string manipulation.

## Verification (C.2, executed WITH outputs, 4/4 code cells, 0 errors)

| Check | Result |
|-------|--------|
| `lake build Sudoku` | **SUCCESS** (exit=0, junction #2611 rc1, 8502 jobs) |
| Papermill execute (lean4-wsl kernel) | **4/4 code cells, 0 errors, 0 cells without output** (duration ~396s, import cell 133s = rc1 cold-start) |
| Native `#check` | pillar signatures rendered in-kernel (Scopes, AllDistinctOn, peer_excludes_value, naked_single_sound, hidden_single_sound) |
| `#print axioms` | propagation theorems **[propext, Quot.sound]** (2 axioms, 0 sorry); `full_house_present` [propext, Classical.choice, Quot.sound] (3, verified via `lake env lean`) |
| C.1 (no voluntary error) | 0 `raise NotImplementedError`/`assert False`/`1/0` |
| sorry count (lake sources, COMPLETE tactic-pattern) | 0 (lean-merge-discipline) |
| `metadata.papermill.input/output_path` | normalized to basename (metadata-only, C.2-exempt) |

**Execution note**: run the notebook from the `sudoku_lean/` directory (papermill `--cwd <sudoku_lean>` + `--start-timeout 300`). The first cell (`import`) takes ~2-3 min (Mathlib load via junction + rc1 `lake env` re-verify); the rest are instant.

## Dependency: REQUIRES the UNLOCK (#4390, MERGED) to run natively

The notebook is a *lean4-wsl* kernel that imports a Mathlib lake — works only with PR #4390's `lean4_jupyter/repl.py` patch + matched repl (`repl-4.31.0-rc1`, rc1 toolchain) + wrapper v6. **#4390 is MERGED**. The junction (rc1 cluster `d568c8c0`) is applied locally via `scripts/lean/setup_shared_mathlib.ps1`.

The rc1-TIMEOUT gotcha (c.129, general for all rc1 lakes): junctioned Mathlib "has local changes" makes `lake env` re-verify for ~111-125s, exceeding the patched `launch()` 60s timeout → fallback to broken `lake env repl` → empty kernel buffer. Fix: `launch()` LEAN_PATH-capture timeout 60→240s. Applied live to `repl.py` (`.bak.c129` backup); the reproducible installer `scripts/lean/setup_native_lean4_import.py` has the matching edit — a separate tiny follow-up PR or fold into #4394, **not mixed here** (atomicity).

Durability: the repl.py patch is a pip-package edit (lost on `pip install`); #4394 tracks the durable fork/PR upstream.

## Atomicity

Single-subject PR (one new companion notebook + 1 README nav line `7b`). Docs-only on the lake (0 `.lean` touched). Fresh base from `origin/main` (0 behind / 0 ahead at push). Staging explicit (`git add <notebook> <README>`), pre-existing mods excluded.

Closes #4384 (supersedes the python3 companion in format). See #4390 (UNLOCK, merged), See #4393 (1st native — sensitivity) + #4397 (2nd — minimax) + #4399 (3rd — argumentation) + #4400 (4th — planning, the proven patterns), See #4394 (durable fork follow-up), See #4046/#4038 (lake roadmap), See #2611 (Mathlib junction).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
