### PR TITLE
docs(genai): restore French diacritics in Vibe-Coding README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -1,4 +1,4 @@
-# Vibe-Coding - Ateliers IA Generative pour le Developpement
+# Vibe-Coding - Ateliers IA Generative pour le Développement
 
 <!-- CATALOG-STATUS
 series: GenAI-Vibe-Coding
@@ -9,9 +9,9 @@ maturity: PRODUCTION=4, BETA=1
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Claude Discovery](Claude-Code/01-decouverte/README.md)
 
-Cette serie couvre les ateliers de **vibe-coding** : decrire ce que vous voulez construire en langage naturel, et l'IA ecrit le code. Deux assistants majeurs sont couverts (Claude Code et Roo Code), avec des exercices progressifs allant de la decouverte a l'automatisation avancee, plus un module d'agents autonomes (Claw Systems).
+Cette série couvre les ateliers de **vibe-coding** : décrire ce que vous voulez construire en langage naturel, et l'IA écrit le code. Deux assistants majeurs sont couverts (Claude Code et Roo Code), avec des exercices progressifs allant de la découverte a l'automatisation avancée, plus un module d'agents autonomes (Claw Systems).
 
-## Structure du repertoire
+## Structure du répertoire
 
 ```text
 Vibe-Coding/
@@ -23,23 +23,23 @@ Vibe-Coding/
 
 ## Claude Code - Ateliers
 
-Assistant de codage agentique developpe par Anthropic. Interface CLI + Extension VS Code.
+Assistant de codage agentique développé par Anthropic. Interface CLI + Extension VS Code.
 
-| Module | Nom | Duree | Niveau | Description |
+| Module | Nom | Durée | Niveau | Description |
 |--------|-----|-------|--------|-------------|
-| 01 | [Decouverte](Claude-Code/01-decouverte/) | 2-3h | Debutant | Installation, sessions, @-mentions, CLAUDE.md |
-| 02 | [Orchestration](Claude-Code/02-orchestration-taches/) | 2-3h | Debutant+ | Agents Explore/Plan, recherche web |
-| 03 | [Assistant Developpeur](Claude-Code/03-assistant-developpeur/) | 3h | Intermediaire | /commit, /review, debug, refactoring |
-| 04 | [Creation de Code](Claude-Code/04-creation-code/) | 3h | Intermediaire | Generation projet, tests, documentation |
-| 05 | [Automatisation Avancee](Claude-Code/05-automatisation-avancee/) | 3-4h | Avance | Skills, Subagents, MCP, Hooks |
+| 01 | [Découverte](Claude-Code/01-decouverte/) | 2-3h | Débutant | Installation, sessions, @-mentions, CLAUDE.md |
+| 02 | [Orchestration](Claude-Code/02-orchestration-taches/) | 2-3h | Débutant+ | Agents Explore/Plan, recherche web |
+| 03 | [Assistant Developpeur](Claude-Code/03-assistant-developpeur/) | 3h | Intermédiaire | /commit, /review, debug, refactoring |
+| 04 | [Création de Code](Claude-Code/04-creation-code/) | 3h | Intermédiaire | Génération projet, tests, documentation |
+| 05 | [Automatisation Avancée](Claude-Code/05-automatisation-avancee/) | 3-4h | Avancé | Skills, Subagents, MCP, Hooks |
 
-**Duree totale : 13-16 heures**
+**Durée totale : 13-16 heures**
 
-### Ressources supplementaires Claude Code
+### Ressources supplémentaires Claude Code
 
 - `Scripts/` - Scripts PowerShell de preparation des workspaces
 - `workspaces/` - Espaces de travail par participant
-- `docs/` - Documentation specifique Claude Code
+- `docs/` - Documentation spécifique Claude Code
 
 ### Installation Claude Code
 
@@ -54,26 +54,26 @@ $env:ANTHROPIC_AUTH_TOKEN = "sk-or-v1-VOTRE_CLE"
 
 ## Roo Code - Ateliers
 
-Framework de codage IA avec interface VS Code uniquement. Ideal pour les debutants.
+Framework de codage IA avec interface VS Code uniquement. Idéal pour les débutants.
 
 | Module | Nom | Contenu |
 |--------|-----|---------|
-| 01 | [Decouverte](Roo-Code/01-decouverte/) | Premiers pas, conversations, vision |
-| 02 | [Orchestration des taches](Roo-Code/02-orchestration-taches/) | Gestion des taches et workflows |
+| 01 | [Découverte](Roo-Code/01-decouverte/) | Premiers pas, conversations, vision |
+| 02 | [Orchestration des tâches](Roo-Code/02-orchestration-taches/) | Gestion des tâches et workflows |
 | 03 | [Assistant Pro](Roo-Code/03-assistant-pro/) | Mode assistant professionnel |
-| 04 | [Creation de contenu](Roo-Code/04-creation-contenu/) | Generation de code et contenu |
-| 05 | [Projets avances](Roo-Code/05-projets-avances/) | Projets complexes et integration |
+| 04 | [Création de contenu](Roo-Code/04-creation-contenu/) | Génération de code et contenu |
+| 05 | [Projets avancés](Roo-Code/05-projets-avances/) | Projets complexes et integration |
 
-### Ressources supplementaires Roo Code
+### Ressources supplémentaires Roo Code
 
-- `Ateliers avances/` - Modules supplementaires avances
+- `Ateliers avances/` - Modules supplémentaires avancés
 - `Corrections/` - Solutions des exercices
-- `Demo-Roo-Capabilities/` - Demonstrations des capacites Roo
+- `Demo-Roo-Capabilities/` - Démonstrations des capacités Roo
 - `Scripts/` - Scripts de preparation
 - `workspaces/` - Espaces de travail par participant
-- `docs/` - Documentation specifique Roo Code
+- `docs/` - Documentation spécifique Roo Code
 
-### Preparation de l'environnement
+### Préparation de l'environnement
 
 ```powershell
 # Creer son workspace
@@ -85,33 +85,33 @@ Framework de codage IA avec interface VS Code uniquement. Ideal pour les debutan
 
 ## Claw Systems - Agents Autonomes
 
-Plateformes d'agents IA conteneurises, self-hosted, operant de maniere autonome via Telegram et API.
+Plateformes d'agents IA conteneurisés, self-hosted, opérant de manière autonome via Telegram et API.
 
 | Document | Description |
 |----------|-------------|
 | [README](Claw-Systems/README.md) | Vue d'ensemble, comparaison avec Claude/Roo |
 | [Architecture](Claw-Systems/docs/NanoClaw-Architecture.md) | Architecture technique NanoClaw |
-| [Deploiement](Claw-Systems/docs/NanoClaw-Deploy.md) | Guide de deploiement Docker |
+| [Déploiement](Claw-Systems/docs/NanoClaw-Deploy.md) | Guide de déploiement Docker |
 | [ASR Integration](Claw-Systems/docs/ASR-Integration.md) | Transcription vocale Whisper |
 
-**Cas d'usage** : Agent Telegram avec transcription vocale, orchestration multi-agents, deploiement production.
+**Cas d'usage** : Agent Telegram avec transcription vocale, orchestration multi-agents, déploiement production.
 
 ## Documentation commune
 
-Le repertoire `docs/` contient :
+Le répertoire `docs/` contient :
 
 | Document | Description |
 |----------|-------------|
-| [INTRO-GENAI.md](docs/INTRO-GENAI.md) | Introduction pratique a l'IA generative |
+| [INTRO-GENAI.md](docs/INTRO-GENAI.md) | Introduction pratique a l'IA générative |
 | [Claude-Code/docs/](Claude-Code/docs/) | Documentation Claude Code (installation, concepts, aide-memoire) |
 | [Roo-Code/docs/](Roo-Code/docs/) | Documentation Roo Code (installation, guide) |
-| [activites/](docs/activites/) | Activites pedagogiques |
+| [activites/](docs/activites/) | Activités pédagogiques |
 | [sessions/](docs/sessions/) | Sessions de formation |
 
 ### Guides disponibles
 
 **Claude Code :**
-- `INTRO-CLAUDE-CODE.md` - Concepts et fonctionnalites
+- `INTRO-CLAUDE-CODE.md` - Concepts et fonctionnalités
 - `INSTALLATION-CLAUDE-CODE.md` - Guide d'installation avec OpenRouter
 - `CHEAT-SHEET.md` - Commandes essentielles
 - `CONCEPTS-AVANCES.md` - Skills, Subagents, Hooks, MCP
@@ -121,27 +121,27 @@ Le repertoire `docs/` contient :
 - `INSTALLATION-ROO.md` - Guide d'installation
 - `ROO-GUIDED-PATH.md` - Parcours d'apprentissage guide
 
-## Prerequis techniques
+## Prérequis techniques
 
 - **VS Code** 1.60.0+
 - **Node.js** 18+ (pour Claude Code CLI)
-- Un compte **OpenRouter** avec une cle API
+- Un compte **OpenRouter** avec une clé API
 - Connaissances de base en programmation
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette serie, vous serez capable de :
+A l'issue de cette série, vous serez capable de :
 
-1. **Decrire** un projet en langage naturel et obtenir du code fonctionnel via l'IA
+1. **Décrire** un projet en langage naturel et obtenir du code fonctionnel via l'IA
 2. **Orchestrer** des workflows multi-agents (recherche, planification, execution)
-3. **Automatiser** les taches courantes du developpeur (tests, documentation, deploiement)
-4. **Configurer** des agents autonomes conteneurises (Claw Systems)
+3. **Automatiser** les tâches courantes du développeur (tests, documentation, déploiement)
+4. **Configurer** des agents autonomes conteneurisés (Claw Systems)
 
 ## FAQ
 
 ### Claude Code ne s'installe pas ou erreur `command not found`
 
-Claude Code (modules [01](Claude-Code/01-decouverte/) a [05](Claude-Code/05-automatisation-avancee/)) s'installe via npm. Si erreur `claude: command not found` apres installation :
+Claude Code (modules [01](Claude-Code/01-decouverte/) a [05](Claude-Code/05-automatisation-avancee/)) s'installe via npm. Si erreur `claude: command not found` après installation :
 
 ```bash
 # Verifier Node.js (18+ requis)
@@ -161,18 +161,18 @@ npm config get prefix
 
 Si vous utilisez VS Code uniquement (sans CLI), l'extension Claude Code dans le Marketplace suffit. Le module [01](Claude-Code/01-decouverte/) couvre les deux modes d'installation.
 
-### Quelle difference entre Claude Code et Roo Code ?
+### Quelle différence entre Claude Code et Roo Code ?
 
-| Critere | Claude Code | Roo Code |
+| Critère | Claude Code | Roo Code |
 |---------|-------------|----------|
 | **Interface** | CLI + VS Code | VS Code uniquement |
-| **Agents paralleles** | Jusqu'a 10 simultanes | Sequentiel |
+| **Agents paralleles** | Jusqu'a 10 simultanés | Séquentiel |
 | **MCP** | Support complet | Partiel |
-| **Skills/Commands** | Ecosysteme standardise | Configuration manuelle |
+| **Skills/Commands** | Écosystème standardisé | Configuration manuelle |
 | **Courbe d'apprentissage** | Moyenne | Facile |
 | **OpenRouter** | Oui | Oui |
 
-**Recommandation** : debutants complets -> commencer par Roo Code ([module 01](Roo-Code/01-decouverte/)) ; developpeurs -> Claude Code ([module 01](Claude-Code/01-decouverte/)) offre plus de puissance. Les deux coexistent dans le meme VS Code. Voir le tableau comparatif ci-dessus pour les differences detaillees.
+**Recommandation** : débutants complets -> commencer par Roo Code ([module 01](Roo-Code/01-decouverte/)) ; développeurs -> Claude Code ([module 01](Claude-Code/01-decouverte/)) offre plus de puissance. Les deux coexistent dans le même VS Code. Voir le tableau comparatif ci-dessus pour les différences détaillées.
 
 ### Erreur d'authentification OpenRouter ou "401 Unauthorized"
 
@@ -184,15 +184,15 @@ $env:ANTHROPIC_BASE_URL    # doit etre "https://openrouter.ai/api"
 $env:ANTHROPIC_AUTH_TOKEN   # doit commencer par "sk-or-v1-..."
 ```
 
-Points frequents :
+Points fréquents :
 
-- La cle OpenRouter doit etre active sur [openrouter.ai/keys](https://openrouter.ai/keys) avec des credits disponibles.
-- Ne pas confondre cle OpenAI (`sk-...`) et cle OpenRouter (`sk-or-v1-...`) -- les deux commencent par `sk-` mais ne sont pas interchangeables.
-- Le guide d'installation ([INSTALLATION-CLAUDE-CODE.md](Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md)) detaille la configuration pas-a-pas.
+- La clé OpenRouter doit être active sur [openrouter.ai/keys](https://openrouter.ai/keys) avec des credits disponibles.
+- Ne pas confondre clé OpenAI (`sk-...`) et clé OpenRouter (`sk-or-v1-...`) -- les deux commencent par `sk-` mais ne sont pas interchangeables.
+- Le guide d'installation ([INSTALLATION-CLAUDE-CODE.md](Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md)) détaille la configuration pas-a-pas.
 
-### Les scripts PowerShell de preparation echouent
+### Les scripts PowerShell de preparation échouent
 
-Les scripts `Scripts/prepare-workspaces.ps1` et `Scripts/clean-workspaces.ps1` (references dans les modules Claude Code et Roo Code) preparent les espaces de travail individuels. Si erreur :
+Les scripts `Scripts/prepare-workspaces.ps1` et `Scripts/clean-workspaces.ps1` (references dans les modules Claude Code et Roo Code) préparent les espaces de travail individuels. Si erreur :
 
 ```powershell
 # Verifier la politique d'execution PowerShell
@@ -205,28 +205,28 @@ cd MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code
 ./Scripts/prepare-workspaces.ps1 -UserName "VotreNom"
 ```
 
-Si `UserName` contient des espaces, l'entourer de guillemets. Les workspaces sont crees dans le dossier `workspaces/` de chaque sous-repertoire (Claude Code et Roo Code separent leurs espaces).
+Si `UserName` contient des espaces, l'entourer de guillemets. Les workspaces sont créés dans le dossier `workspaces/` de chaque sous-répertoire (Claude Code et Roo Code séparent leurs espaces).
 
-### NanoClaw / OpenClaw : comment deployer un agent autonome ?
+### NanoClaw / OpenClaw : comment déployer un agent autonome ?
 
-Les Claw Systems ([README](Claw-Systems/README.md)) sont des agents IA conteneurises qui operent via Telegram et API. Pour demarrer :
+Les Claw Systems ([README](Claw-Systems/README.md)) sont des agents IA conteneurisés qui opèrent via Telegram et API. Pour demarrer :
 
 1. Lire l'[Architecture](Claw-Systems/docs/NanoClaw-Architecture.md) pour comprendre les composants (LLM, ASR Whisper, Telegram bot).
-2. Suivre le [Guide de deploiement](Claw-Systems/docs/NanoClaw-Deploy.md) pour Docker Compose.
+2. Suivre le [Guide de déploiement](Claw-Systems/docs/NanoClaw-Deploy.md) pour Docker Compose.
 3. Configurer l'[ASR Whisper](Claw-Systems/docs/ASR-Integration.md) si la transcription vocale est requise.
 
-**Prerequis** : Docker + Docker Compose, un token Telegram Bot (`@BotFather`), une cle API LLM (OpenRouter ou OpenAI). Le deploiement complet tourne sur un VPS 4 GB RAM minimum.
+**Prérequis** : Docker + Docker Compose, un token Telegram Bot (`@BotFather`), une clé API LLM (OpenRouter ou OpenAI). Le déploiement complet tourne sur un VPS 4 GB RAM minimum.
 
 ### Peut-on faire les ateliers sans OpenRouter ?
 
-Oui, partiellement. OpenRouter est le fournisseur par defaut car il aggrege plusieurs modeaux (Claude, GPT, Gemini) sous une seule cle. Alternatives :
+Oui, partiellement. OpenRouter est le fournisseur par défaut car il aggrege plusieurs modeaux (Claude, GPT, Gemini) sous une seule clé. Alternatives :
 
 - **API Anthropic directe** : `$env:ANTHROPIC_API_KEY = "sk-ant-..."` (sans `ANTHROPIC_BASE_URL`). Fonctionne avec les modeaux Claude uniquement.
-- **API OpenAI directe** : configuree via les settings Claude Code (sans OpenRouter). Modeaux GPT uniquement.
-- **Mode hors-ligne** : les modules [01](Claude-Code/01-decouverte/) et [02](Claude-Code/02-orchestration-taches/) contiennent des exercices de decouverte qui ne necessitent pas d'API (exploration de l'interface, configuration CLAUDE.md, gestion de sessions).
+- **API OpenAI directe** : configurée via les settings Claude Code (sans OpenRouter). Modeaux GPT uniquement.
+- **Mode hors-ligne** : les modules [01](Claude-Code/01-decouverte/) et [02](Claude-Code/02-orchestration-taches/) contiennent des exercices de découverte qui ne nécessitent pas d'API (exploration de l'interface, configuration CLAUDE.md, gestion de sessions).
 
-Le module [05](Claude-Code/05-automatisation-avancee/) (Skills, Subagents, MCP) necessite un LLM actif pour les demonstrations avancees.
+Le module [05](Claude-Code/05-automatisation-avancee/) (Skills, Subagents, MCP) nécessite un LLM actif pour les démonstrations avancées.
 
 ---
 
-*Version 1.0.0 - Fevrier 2026*
+*Version 1.0.0 - Février 2026*


### PR DESCRIPTION
## Scope

**#2876 — restore French diacritics in GenAI/Vibe-Coding README** (virgin terrain). Vibe-Coding/README.md was 0% accented (French prose written in ASCII: "IA Generative pour le Developpement", "decouverte a l'automatisation avancee", "Debutant/Intermediaire", "Duree", etc.). This PR restores correct French diacritics, mirroring the established #2876 cadence (#4353 00-Env, #4355/#4359 Audio, #4361 Image, #4369 Video).

## Method (verified accent-only)

Python script with **placeholder masking** protects the regions that must NOT change, then applies a curated French word→accented mapping to the remaining prose, then restores:

| Protected region | Handling |
|---|---|
| Link URLs `](...)` | masked → restored verbatim |
| Inline code `` `...` `` | masked → restored verbatim |
| Code fences ` ``` ... ``` ` | masked → restored verbatim |
| `<!-- CATALOG-STATUS -->` block | masked → restored verbatim |

Then **4 verification gates** (all PASS):

1. **`deaccent(old) == deaccent(new)`** via `unicodedata.normalize("NFD")` + strip category `Mn` → **True**. Proves ONLY diacritics were added; no base letter changed.
2. **CATALOG-STATUS block byte-identical** → True.
3. **36 link URLs byte-identical** (old vs new) → True (no path corruption: `Claude-Code/01-decouverte/` etc. untouched — filesystem dirs are unaccented).
4. **Code-fence blocks identical** → True.

Diff: `1 file changed, 58 insertions(+), 58 deletions(-)` — perfectly symmetric (pure accent additions, no net line/char change).

## Out-of-scope (documented honestly, not snuck in)

Two ASCII words are **spelling typos, not missing accents** — excluded because fixing them changes base letters (fails the accent-only gate):
- `aggrege` (line ~222) — correct FR is `agrège` (single-g + accent); source has double-g spelling error.
- `modeaux` (lines 222/224/225) — typo for `modèles`.

These belong in a separate spelling-fix PR, not under the accent-only #2876 banner.

## C.2 compliance

Markdown-only edit (no notebook cells, no execution) → C.2 markdown exception applies.

See #2876
