### PR TITLE
fix(casestudies): scrub absolute papermill output_path - 3 notebooks (See #3436)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
@@ -2494,7 +2494,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Diagnostic-Medical.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search_papermill/Diagnostic-Medical-solution.ipynb",
+   "output_path": "Diagnostic-Medical.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T20:39:17.230704+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
@@ -1080,7 +1080,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Oncology-Planning.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search_papermill/Oncology-Planning-solution.ipynb",
+   "output_path": "Oncology-Planning.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T20:38:35.778889+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
@@ -703,7 +703,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "Oncology-Planning.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search_papermill/Oncology-Planning-student.ipynb",
+   "output_path": "Oncology-Planning.ipynb",
    "parameters": {},
    "start_time": "2026-06-05T20:39:55.974576+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Scope

**#3436 repo-wide — top-level CaseStudies family.** Scrub absolute machine-leak `output_path` from 3 CaseStudies notebooks via the canonical merged tool `scripts/notebook_tools/scrub_papermill_paths.py`. Advances the repo-wide #3436 scope (originally 360 notebooks / 643 paths) beyond the GenAI partition.

## Notebooks (3)

| Notebook | Leak |
|---|---|
| CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb | `C:/Users/jsboi/AppData/Local/Temp/search_papermill/Diagnostic-Medical-solution.ipynb` |
| CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb | `C:/Users/jsboi/AppData/Local/Temp/search_papermill/Oncology-Planning-solution.ipynb` |
| CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb | `C:/Users/jsboi/AppData/Local/Temp/search_papermill/Oncology-Planning-student.ipynb` |

All 3 verified **committed on origin/main** (0 working-tree diff) → genuine in-scope, not transient re-exec drift.

## Validation

- `python scripts/notebook_tools/scrub_papermill_paths.py --apply MyIA.AI.Notebooks/CaseStudies` → 3 fixed.
- `--scan ... --check` → `0 notebook(s) with 0 path(s)`, **exit 0**.
- Surgical: `3 files changed, 3 insertions(+), 3 deletions(-)` — symmetric, metadata-only.
- C.2-exempt (`metadata.papermill.output_path`, not a cell output — the only tolerated path normalization, `secrets-hygiene.md` rule 6). Catalog byte-identical.

## Repo-wide #3436 remainder (after this PR)

After GenAI (PR #4401) + CaseStudies (this PR), remaining families: **QuantConnect** + **SymbolicAI** + **Search** + **GameTheory** — other workers' families (po-2024/po-2026), metadata-only non-conflicting but left to their owners to avoid git churn collision.

See #3436
