### PR TITLE
docs(genai): restore French diacritics in Playwright-OWUI READMEs (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/01-decouverte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/01-decouverte/README.md
@@ -1,36 +1,36 @@
-# Module 01 - Decouverte de Playwright & Open WebUI
+# Module 01 - Découverte de Playwright & Open WebUI
 
-> **Format** : Ce module utilise des fichiers TypeScript `.spec.ts` (pas des Jupyter Notebooks). Le fichier `01-decouverte.spec.ts` contient les tests commentes qui servent d'exercices pratiques. Ouvrez-le dans VS Code, lisez les commentaires, puis lancez les tests pour les voir s'executer.
+> **Format** : Ce module utilise des fichiers TypeScript `.spec.ts` (pas des Jupyter Notebooks). Le fichier `01-decouverte.spec.ts` contient les tests commentés qui servent d'exercices pratiques. Ouvrez-le dans VS Code, lisez les commentaires, puis lancez les tests pour les voir s'exécuter.
 
-## Objectifs pedagogiques
+## Objectifs pédagogiques
 
 A la fin de ce module, vous serez capable de :
 
 - Installer Playwright et comprendre son architecture
-- Ecrire un premier test E2E sur une application web reelle
+- Écrire un premier test E2E sur une application web réelle
 - Comprendre la structure d'un projet de tests Playwright
-- Naviguer dans Open WebUI avec des selecteurs robustes
-- Lancer les tests en mode headed (avec navigateur visible) pour deboguer
+- Naviguer dans Open WebUI avec des sélecteurs robustes
+- Lancer les tests en mode headed (avec navigateur visible) pour déboguer
 
-## Prerequis
+## Prérequis
 
 - Node.js 18+ installe
 - Une instance Open WebUI accessible (fournie par l'enseignant ou locale)
 - VS Code avec l'extension Playwright recommandee
 - Fichier `.env` configure (voir `.env.example` a la racine)
 
-## Duree estimee
+## Durée estimée
 
 **2 a 3 heures**
 
 ## Contenu du module
 
-### Partie theorique
+### Partie théorique
 
 **Pourquoi Playwright ?**
 - Framework de test E2E par Microsoft, multi-navigateurs (Chromium, Firefox, WebKit)
 - Auto-wait intelligent : attend automatiquement que les elements soient visibles/cliquables
-- Mode trace et video pour le debogage
+- Mode trace et video pour le débogage
 - API simple et TypeScript-native
 
 **Architecture d'un projet Playwright :**
@@ -43,7 +43,7 @@ projet/
 └── .auth/                  # Etat authentifie sauvegarde
 ```
 
-**Selecteurs — par ordre de preference :**
+**Sélecteurs — par ordre de préférence :**
 1. **IDs** : `#chat-input` — Les plus stables
 2. **Roles ARIA** : `button[aria-label="..."]` — Accessibles et resilients
 3. **getByRole/getByText** : Semantiques, recommandes par Playwright
@@ -55,14 +55,14 @@ Le fichier `01-decouverte.spec.ts` contient 4 exercices progressifs :
 
 | Test | Description | Concepts |
 |------|-------------|----------|
-| Connexion reussie | Verifier qu'on arrive sur la page principale | `goto()`, `toBeVisible()`, storageState |
-| Selecteur de modeles | Ouvrir le dropdown et compter les modeles | `click()`, `locator()`, `count()` |
-| Menu utilisateur | Ouvrir le menu et verifier les options | `getByRole()`, regex multilingue |
+| Connexion réussie | Vérifier qu'on arrive sur la page principale | `goto()`, `toBeVisible()`, storageState |
+| Sélecteur de modèles | Ouvrir le dropdown et compter les modèles | `click()`, `locator()`, `count()` |
+| Menu utilisateur | Ouvrir le menu et vérifier les options | `getByRole()`, regex multilingue |
 | Premier screenshot | Capturer la page pour documentation | `screenshot()`, artefacts |
 
-### Exercices supplementaires
+### Exercices supplémentaires
 
-1. **Modifier un selecteur** : Remplacez un selecteur CSS par un `getByRole()` equivalent
+1. **Modifier un sélecteur** : Remplacez un sélecteur CSS par un `getByRole()` equivalent
 2. **Ajouter un test** : Verifiez que le bouton "Nouveau Chat" est visible
 3. **Mode debug** : Lancez `npm run test:debug` et utilisez le Playwright Inspector
 
@@ -91,6 +91,6 @@ npm run report
 ## Points cles a retenir
 
 - Playwright attend automatiquement les elements (auto-wait) — pas besoin de `sleep()`
-- `storageState` permet de reutiliser une session authentifiee sans se reconnecter a chaque test
-- Preferez les selecteurs semantiques (roles, labels) aux selecteurs CSS fragiles
+- `storageState` permet de réutiliser une session authentifiee sans se reconnecter a chaque test
+- Préférez les sélecteurs semantiques (roles, labels) aux sélecteurs CSS fragiles
 - Le mode `--headed` est indispensable pour comprendre ce que fait le test visuellement

--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/02-navigation-authentification/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/02-navigation-authentification/README.md
@@ -1,29 +1,29 @@
 # Module 02 - Navigation & Authentification
 
-> **Format** : Fichier TypeScript `.spec.ts` avec tests commentes. Ouvrez `02-navigation-auth.spec.ts` dans VS Code, lisez les commentaires pedagogiques, puis lancez avec `npm run test:module2`.
+> **Format** : Fichier TypeScript `.spec.ts` avec tests commentés. Ouvrez `02-navigation-auth.spec.ts` dans VS Code, lisez les commentaires pédagogiques, puis lancez avec `npm run test:module2`.
 
-## Objectifs pedagogiques
+## Objectifs pédagogiques
 
 A la fin de ce module, vous serez capable de :
 
 - Comprendre le mecanisme d'authentification par storageState
 - Tester un formulaire de login complet (email + mot de passe)
 - Naviguer entre les differentes sections d'Open WebUI
-- Ecrire un setup fixture reutilisable
-- Gerer les redirections et les etats de chargement
+- Écrire un setup fixture réutilisable
+- Gérer les redirections et les états de chargement
 
-## Duree estimee
+## Durée estimée
 
 **2 a 3 heures**
 
 ## Contenu du module
 
-### Partie theorique
+### Partie théorique
 
 **Authentification dans Playwright :**
 Le pattern standard est de s'authentifier UNE SEULE FOIS, puis de sauvegarder
-l'etat du navigateur (cookies, localStorage, sessionStorage) dans un fichier JSON.
-Tous les tests suivants chargent cet etat — pas besoin de se re-connecter.
+l'état du navigateur (cookies, localStorage, sessionStorage) dans un fichier JSON.
+Tous les tests suivants chargent cet état — pas besoin de se re-connecter.
 
 ```
 1. auth.setup.ts  →  Login via formulaire  →  Sauvegarde .auth/owui.json
@@ -44,8 +44,8 @@ Tous les tests suivants chargent cet etat — pas besoin de se re-connecter.
 
 | Test | Description | Concepts |
 |------|-------------|----------|
-| Login UI complet | Remplir le formulaire et verifier la redirection | `fill()`, `waitForURL()` |
-| Session persistante | Verifier que le storageState fonctionne | storageState, cookies |
+| Login UI complet | Remplir le formulaire et vérifier la redirection | `fill()`, `waitForURL()` |
+| Session persistante | Vérifier que le storageState fonctionne | storageState, cookies |
 | Navigation admin | Acceder au panneau admin | `goto()`, assertions localisees |
 | Navigation workspace | Parcourir les sections workspace | Routes SvelteKit |
 | Page de settings | Acceder aux reglages | `getByRole('link')` |

--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/03-chat-streaming/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/03-chat-streaming/README.md
@@ -1,41 +1,41 @@
 # Module 03 - Tests de Chat & Streaming LLM
 
-> **Format** : Fichier TypeScript `.spec.ts` avec tests commentes. Ouvrez `03-chat-streaming.spec.ts` dans VS Code. C'est le module le plus riche — il couvre les defis uniques du test d'applications d'IA generative.
+> **Format** : Fichier TypeScript `.spec.ts` avec tests commentés. Ouvrez `03-chat-streaming.spec.ts` dans VS Code. C'est le module le plus riche — il couvre les defis uniques du test d'applications d'IA générative.
 
-## Objectifs pedagogiques
+## Objectifs pédagogiques
 
 A la fin de ce module, vous serez capable de :
 
-- Tester une interface de chat avec un editeur rich text (TipTap)
-- Gerer le streaming de reponses LLM (tokens progressifs)
-- Implementer des patterns d'attente adaptes aux IA generatives
-- Ecrire des assertions sur du contenu genere par IA (non deterministe)
-- Utiliser `test.skip()` pour gerer les services indisponibles
+- Tester une interface de chat avec un éditeur rich text (TipTap)
+- Gérer le streaming de réponses LLM (tokens progressifs)
+- Implementer des patterns d'attente adaptes aux IA génératives
+- Écrire des assertions sur du contenu généré par IA (non deterministe)
+- Utiliser `test.skip()` pour gérer les services indisponibles
 
-## Duree estimee
+## Durée estimée
 
 **3 heures**
 
 ## Contenu du module
 
-### Partie theorique
+### Partie théorique
 
 **Le defi du test E2E avec des LLMs :**
-Tester une application d'IA generative pose des defis uniques :
+Tester une application d'IA générative pose des defis uniques :
 
-1. **Non-determinisme** : Le meme prompt peut donner des reponses differentes
-2. **Latence variable** : De 2s (GPT-4.1-mini) a 2min (modele local en reflexion)
+1. **Non-determinisme** : Le même prompt peut donner des réponses differentes
+2. **Latence variable** : De 2s (GPT-4.1-mini) a 2min (modèle local en reflexion)
 3. **Streaming** : Les tokens arrivent progressivement, le DOM change en continu
-4. **Disponibilite** : Les services LLM peuvent etre temporairement indisponibles
+4. **Disponibilite** : Les services LLM peuvent être temporairement indisponibles
 
 **Solutions implementees :**
 - Assertions souples : `toContain('hello')` au lieu de `toBe('Hello from GPT')`
-- Timeouts genereux : 120s par test, polling toutes les secondes
+- Timeouts généreux : 120s par test, polling toutes les secondes
 - Skip gracieux : `test.skip(!response, 'Service indisponible')`
 - Helper `waitForResponse()` : Attend que le contenu soit stable
 
-**L'editeur TipTap :**
-Open WebUI utilise TipTap (un editeur ProseMirror) au lieu d'un `<textarea>`.
+**L'éditeur TipTap :**
+Open WebUI utilise TipTap (un éditeur ProseMirror) au lieu d'un `<textarea>`.
 Consequence : `fill()` ne fonctionne pas ! Il faut utiliser `keyboard.type()`.
 
 ```typescript
@@ -52,12 +52,12 @@ await page.keyboard.press('Enter');
 
 | Test | Description | Concepts |
 |------|-------------|----------|
-| Chat cloud | Envoyer un message a un modele cloud | `keyboard.type()`, TipTap |
-| Chat local | Tester un modele local (vLLM) | `test.skip()`, resilience |
-| Streaming | Verifier que le texte apparait progressivement | `waitForFunction()`, polling |
-| Markdown | Verifier le rendu des blocs de code | Selecteurs CSS imbriques |
-| Regenerer | Tester le bouton "Regenerer la reponse" | Boutons localises, regex |
-| Editer | Modifier un message envoye | Workflow multi-etapes |
+| Chat cloud | Envoyer un message a un modèle cloud | `keyboard.type()`, TipTap |
+| Chat local | Tester un modèle local (vLLM) | `test.skip()`, resilience |
+| Streaming | Vérifier que le texte apparait progressivement | `waitForFunction()`, polling |
+| Markdown | Vérifier le rendu des blocs de code | Sélecteurs CSS imbriques |
+| Régénérer | Tester le bouton "Régénérer la réponse" | Boutons localises, regex |
+| Éditer | Modifier un message envoyé | Workflow multi-étapes |
 
 ## Commandes
 
@@ -69,6 +69,6 @@ npx playwright test --grep "03" --headed
 ## Points cles a retenir
 
 - TipTap = `keyboard.type()`, JAMAIS `fill()` pour le chat input
-- Les reponses LLM sont non-deterministes → assertions souples
-- `test.skip()` est votre ami pour gerer les services down
-- Le polling (`waitForFunction()`) est preferable a `waitForTimeout()`
+- Les réponses LLM sont non-deterministes → assertions souples
+- `test.skip()` est votre ami pour gérer les services down
+- Le polling (`waitForFunction()`) est préférable a `waitForTimeout()`

--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/04-rag-tools-avances/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/04-rag-tools-avances/README.md
@@ -1,27 +1,27 @@
-# Module 04 - RAG, Outils MCP & Fonctionnalites avancees
+# Module 04 - RAG, Outils MCP & Fonctionnalites avancées
 
-> **Format** : Fichier TypeScript `.spec.ts` avec tests commentes. Ouvrez `04-rag-tools.spec.ts` dans VS Code. Certains tests dependent de la configuration de l'instance (KBs, outils MCP, canaux) — les tests non-applicables seront automatiquement skipped.
+> **Format** : Fichier TypeScript `.spec.ts` avec tests commentés. Ouvrez `04-rag-tools.spec.ts` dans VS Code. Certains tests dependent de la configuration de l'instance (KBs, outils MCP, canaux) — les tests non-applicables seront automatiquement skipped.
 
-## Objectifs pedagogiques
+## Objectifs pédagogiques
 
 A la fin de ce module, vous serez capable de :
 
-- Tester l'integration RAG (Retrieval-Augmented Generation) avec des knowledge bases
+- Tester l'integration RAG (Retrieval-Augmented Génération) avec des knowledge bases
 - Interagir avec les outils MCP (Model Context Protocol) via Playwright
 - Tester la fonctionnalite Channels (canaux de discussion de groupe)
-- Ecrire des tests plus complexes combinant navigation et interactions
-- Gerer les interactions conditionnelles (elements optionnels)
+- Écrire des tests plus complexes combinant navigation et interactions
+- Gérer les interactions conditionnelles (elements optionnels)
 
-## Duree estimee
+## Durée estimée
 
 **3 heures**
 
 ## Contenu du module
 
-### Partie theorique
+### Partie théorique
 
 **RAG dans Open WebUI :**
-Le RAG (Retrieval-Augmented Generation) enrichit les reponses du LLM avec des documents.
+Le RAG (Retrieval-Augmented Génération) enrichit les réponses du LLM avec des documents.
 Dans OWUI (v0.8.8+), on "attache" une Knowledge Base (KB) au chat via le bouton `+`
 puis "Joindre une connaissance" :
 
@@ -35,11 +35,11 @@ Clic sur le bouton "+" dans la barre de chat
 ```
 
 > **Note historique** : Avant v0.8.8, le raccourci `#` dans le chat input
-> declenchait un popup de selection de KB. Ce raccourci a ete remplace.
+> déclenchait un popup de selection de KB. Ce raccourci a été remplacé.
 
 **Outils MCP :**
-Le Model Context Protocol (MCP) permet d'etendre les capacites du LLM
-avec des outils externes (recherche web, execution de code, etc.).
+Le Model Context Protocol (MCP) permet d'etendre les capacités du LLM
+avec des outils externes (recherche web, exécution de code, etc.).
 Depuis v0.8.8+, les outils sont accessibles via un bouton icone (engrenages)
 dans la barre de chat, qui ouvre un menu avec : Outils, Recherche Web, Image, Code.
 
@@ -52,11 +52,11 @@ ou par URL directe `/channels/{id}`.
 
 | Test | Description | Concepts |
 |------|-------------|----------|
-| RAG — menu "+" | Attacher une KB via "Joindre une connaissance" | Menus, selecteurs |
-| RAG — chat avec KB | Poser une question avec KB attachee | Workflow multi-etapes |
-| MCP — menu outils | Verifier la presence des outils (bouton engrenages) | Selecteurs positionnels |
-| MCP — activer outils | Ouvrir le selecteur d'outils | Dialogs, menus |
-| MCP — recherche web | Declencher une recherche via outil | Toggles, tests fonctionnels |
+| RAG — menu "+" | Attacher une KB via "Joindre une connaissance" | Menus, sélecteurs |
+| RAG — chat avec KB | Poser une question avec KB attachee | Workflow multi-étapes |
+| MCP — menu outils | Vérifier la presence des outils (bouton engrenages) | Sélecteurs positionnels |
+| MCP — activer outils | Ouvrir le sélecteur d'outils | Dialogs, menus |
+| MCP — recherche web | Déclencher une recherche via outil | Toggles, tests fonctionnels |
 | Channels — naviguer | Acceder a un canal via API + URL directe | API + navigateur combines |
 | Channels — poster | Envoyer un message dans un canal | TipTap dans un autre contexte |
 
@@ -71,6 +71,6 @@ npx playwright test --grep "04" --headed
 
 - Les KBs s'attachent via le bouton `+` → "Joindre une connaissance" (v0.8.8+)
 - Les outils MCP sont optionnels — utilisez `test.skip()` si absents
-- Les canaux utilisent le meme editeur TipTap que le chat principal
+- Les canaux utilisent le même éditeur TipTap que le chat principal
 - Combiner API (pour obtenir les IDs) + navigateur (pour tester l'UI) = tests robustes en headless
-- Les selecteurs positionnels (`nth(1)`) sont un dernier recours quand il n'y a pas d'aria-label stable
+- Les sélecteurs positionnels (`nth(1)`) sont un dernier recours quand il n'y a pas d'aria-label stable

--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/05-multi-tenant-ci/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/05-multi-tenant-ci/README.md
@@ -1,24 +1,24 @@
 # Module 05 - Multi-tenant, API Testing & CI/CD
 
-> **Format** : Fichier TypeScript `.spec.ts` avec tests commentes. Ouvrez `05-api-multi-tenant.spec.ts` dans VS Code. Ce module utilise l'API REST (pas le navigateur) pour la plupart des tests. Configurez `OWUI_TENANT2_*` dans `.env` pour activer les tests multi-tenant.
+> **Format** : Fichier TypeScript `.spec.ts` avec tests commentés. Ouvrez `05-api-multi-tenant.spec.ts` dans VS Code. Ce module utilise l'API REST (pas le navigateur) pour la plupart des tests. Configurez `OWUI_TENANT2_*` dans `.env` pour activer les tests multi-tenant.
 
-## Objectifs pedagogiques
+## Objectifs pédagogiques
 
 A la fin de ce module, vous serez capable de :
 
 - Tester des APIs REST directement avec Playwright (sans navigateur)
 - Comprendre l'architecture multi-tenant d'Open WebUI
-- Verifier l'isolation des donnees entre tenants
-- Valider le partage de ressources (KBs, modeles) entre instances
+- Vérifier l'isolation des donnees entre tenants
+- Valider le partage de ressources (KBs, modèles) entre instances
 - Integrer les tests Playwright dans un pipeline CI/CD
 
-## Duree estimee
+## Durée estimée
 
 **3 a 4 heures**
 
 ## Contenu du module
 
-### Partie theorique
+### Partie théorique
 
 **Tests API vs Tests UI :**
 Playwright n'est pas limite aux interactions navigateur.
@@ -38,28 +38,28 @@ expect(users.length).toBeGreaterThan(0);
 **Quand utiliser l'API vs le navigateur :**
 | Scenario | Approche |
 |----------|----------|
-| Verifier un rendu visuel | Navigateur (page) |
+| Vérifier un rendu visuel | Navigateur (page) |
 | Comparer des donnees entre instances | API (request) |
 | Tester l'authentification | Les deux |
-| Verifier la performance | API + metrics |
+| Vérifier la performance | API + metrics |
 
 **Architecture multi-tenant :**
 Chaque "tenant" est une instance independante d'Open WebUI :
-- Base de donnees PostgreSQL separee
-- Configuration independante (modeles, fonctions, users)
-- Certaines ressources partagees (KBs via Qdrant, modeles LLM)
+- Base de donnees PostgreSQL séparée
+- Configuration independante (modèles, fonctions, users)
+- Certaines ressources partagees (KBs via Qdrant, modèles LLM)
 
 ### Partie pratique
 
 | Test | Description | Concepts |
 |------|-------------|----------|
 | Auth API | Login via API, obtenir un token JWT | `request.post()`, JWT |
-| Modeles API | Lister les modeles via API | `request.get()`, headers |
+| Modèles API | Lister les modèles via API | `request.get()`, headers |
 | KBs API | Lister les knowledge bases via API | Pagination API |
 | Multi-tenant auth | Authentification sur deux instances | Isolation |
-| KB partagees | Verifier le partage de KBs | Comparison cross-tenant |
-| Modeles identiques | Verifier la parite des modeles | Assertions en boucle |
-| Isolation donnees | Verifier l'isolation des users | Securite multi-tenant |
+| KB partagees | Vérifier le partage de KBs | Comparison cross-tenant |
+| Modèles identiques | Vérifier la parite des modèles | Assertions en boucle |
+| Isolation donnees | Vérifier l'isolation des users | Sécurité multi-tenant |
 
 ## Commandes
 
@@ -104,4 +104,4 @@ jobs:
 2. **Retries** : Activer 1-2 retries en CI (reseaux instables)
 3. **Rapports** : Toujours uploader le rapport HTML comme artefact
 4. **Timeouts** : Augmenter les timeouts en CI (machines plus lentes)
-5. **Screenshots** : `only-on-failure` pour le debogage post-mortem
+5. **Screenshots** : `only-on-failure` pour le débogage post-mortem

--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/README.md
@@ -1,4 +1,4 @@
-# Playwright-OWUI - Tests E2E pedagogiques pour Open WebUI
+# Playwright-OWUI - Tests E2E pédagogiques pour Open WebUI
 
 <!-- CATALOG-STATUS
 series: GenAI-Playwright-OWUI
@@ -9,16 +9,16 @@ maturity:
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Vibe-Coding](../Vibe-Coding/README.md)
 
-Serie pedagogique complete pour apprendre **Playwright** (framework de tests E2E) en testant une application reelle : **Open WebUI**, une plateforme de chat IA generative.
+Serie pédagogique complète pour apprendre **Playwright** (framework de tests E2E) en testant une application réelle : **Open WebUI**, une plateforme de chat IA générative.
 
-> **Format particulier** : Contrairement aux autres sous-domaines GenAI qui utilisent des Jupyter Notebooks (.ipynb), cette serie utilise des **fichiers TypeScript (.spec.ts)** executes par Playwright. Chaque module contient un `README.md` avec la theorie et les explications, et un fichier `.spec.ts` avec les tests commentes qui servent d'exercices pratiques. Les tests sont auto-documentes : chaque test contient des commentaires pedagogiques expliquant les concepts, et des exercices supplementaires a completer par l'etudiant.
+> **Format particulier** : Contrairement aux autres sous-domaines GenAI qui utilisent des Jupyter Notebooks (.ipynb), cette série utilise des **fichiers TypeScript (.spec.ts)** exécutés par Playwright. Chaque module contient un `README.md` avec la théorie et les explications, et un fichier `.spec.ts` avec les tests commentés qui servent d'exercices pratiques. Les tests sont auto-documentés : chaque test contient des commentaires pédagogiques expliquant les concepts, et des exercices supplémentaires a compléter par l'étudiant.
 
-## Pourquoi cette serie ?
+## Pourquoi cette série ?
 
-Cette serie se distingue des tutoriels Playwright classiques par son sujet :
+Cette série se distingue des tutoriels Playwright classiques par son sujet :
 - On ne teste pas un simple formulaire ou une todo-list
-- On teste une **vraie application de production** avec des **modeles d'IA generative**
-- Les defis sont reels : streaming, non-determinisme, latence variable, multi-tenant
+- On teste une **vraie application de production** avec des **modèles d'IA générative**
+- Les defis sont réels : streaming, non-determinisme, latence variable, multi-tenant
 
 ## Structure
 
@@ -55,17 +55,17 @@ Playwright-OWUI/
 
 ## Modules
 
-### Module 01 — Decouverte de Playwright & OWUI (2-3h)
-*Niveau Debutant*
+### Module 01 — Découverte de Playwright & OWUI (2-3h)
+*Niveau Débutant*
 
 - Installation et configuration de Playwright
-- Premier test : verifier le chargement de la page
-- Selecteurs CSS, ARIA, et semantiques
+- Premier test : vérifier le chargement de la page
+- Sélecteurs CSS, ARIA, et semantiques
 - Mode headed et screenshots
 - **4 tests + exercices**
 
 ### Module 02 — Navigation & Authentification (2-3h)
-*Niveau Debutant+*
+*Niveau Débutant+*
 
 - Pattern d'authentification par storageState
 - Navigation entre les sections d'OWUI (admin, workspace, channels)
@@ -74,17 +74,17 @@ Playwright-OWUI/
 - **8 tests + exercices**
 
 ### Module 03 — Chat & Streaming LLM (3h)
-*Niveau Intermediaire*
+*Niveau Intermédiaire*
 
-- L'editeur TipTap : `keyboard.type()` vs `fill()`
+- L'éditeur TipTap : `keyboard.type()` vs `fill()`
 - Gestion du streaming (polling, waitForFunction)
 - Assertions sur du contenu non-deterministe
 - Skip gracieux pour services indisponibles
-- Actions sur les messages (regenerer, editer)
+- Actions sur les messages (régénérer, éditer)
 - **7 tests + exercices**
 
-### Module 04 — RAG, Outils MCP & Fonctionnalites avancees (3h)
-*Niveau Intermediaire+*
+### Module 04 — RAG, Outils MCP & Fonctionnalites avancées (3h)
+*Niveau Intermédiaire+*
 
 - RAG : attacher une Knowledge Base via le raccourci #
 - Outils MCP (Model Context Protocol) : recherche web
@@ -145,9 +145,9 @@ cp .env.example .env
 
 | Variable | Description | Module |
 |----------|-------------|--------|
-| `OWUI_CLOUD_MODEL` | Modele cloud pour les tests de chat | 03 |
-| `OWUI_LOCAL_MODEL` | Modele local (vLLM/Ollama) | 03 |
-| `OWUI_PERSONA_MODEL` | Modele persona/custom | 03 |
+| `OWUI_CLOUD_MODEL` | Modèle cloud pour les tests de chat | 03 |
+| `OWUI_LOCAL_MODEL` | Modèle local (vLLM/Ollama) | 03 |
+| `OWUI_PERSONA_MODEL` | Modèle persona/custom | 03 |
 | `OWUI_TENANT2_*` | Instance secondaire (multi-tenant) | 05 |
 
 ### 4. Verification
@@ -190,10 +190,10 @@ npm run report
 
 | Concept | Module | Description |
 |---------|--------|-------------|
-| Selecteurs | 01 | IDs, ARIA, getByRole, getByText |
-| storageState | 01-02 | Session authentifiee reutilisable |
+| Sélecteurs | 01 | IDs, ARIA, getByRole, getByText |
+| storageState | 01-02 | Session authentifiee réutilisable |
 | Auto-wait | 01 | Playwright attend automatiquement |
-| TipTap/fill() | 03 | keyboard.type() pour editeurs rich text |
+| TipTap/fill() | 03 | keyboard.type() pour éditeurs rich text |
 | Streaming | 03 | Polling et waitForFunction |
 | test.skip() | 03-04 | Skip gracieux pour services indisponibles |
 | API testing | 05 | APIRequestContext sans navigateur |
@@ -202,8 +202,8 @@ npm run report
 
 ## Pieges courants et solutions
 
-Ces pieges ont ete decouverts lors de la validation initiale de la suite de tests.
-Ils sont documentes ici car ils sont representatifs de vrais problemes
+Ces pieges ont été découverts lors de la validation initiale de la suite de tests.
+Ils sont documentés ici car ils sont representatifs de vrais problemes
 rencontres lors du test E2E d'applications web modernes.
 
 ### 1. Modal "Quoi de neuf" (Changelog)
@@ -219,9 +219,9 @@ await page.goto('/');
 await dismissModals(page);
 ```
 
-### 2. Editeur TipTap (fill() ne fonctionne pas)
+### 2. Éditeur TipTap (fill() ne fonctionne pas)
 
-**Probleme** : Open WebUI utilise TipTap/ProseMirror au lieu d'un `<textarea>`. La methode `fill()` de Playwright ne declenche pas les evenements necessaires.
+**Probleme** : Open WebUI utilise TipTap/ProseMirror au lieu d'un `<textarea>`. La methode `fill()` de Playwright ne déclenche pas les evenements necessaires.
 
 **Solution** : Toujours utiliser `keyboard.type()` pour saisir du texte dans le chat :
 
@@ -237,7 +237,7 @@ await page.keyboard.type('Bonjour', { delay: 10 });
 
 **Probleme** : L'endpoint `/api/v1/auths/signin` a un rate limit strict (~2 min entre appels). Si chaque test fait son propre login, on atteint rapidement le 429.
 
-**Solution** : S'authentifier UNE FOIS dans `beforeAll()` et reutiliser le token :
+**Solution** : S'authentifier UNE FOIS dans `beforeAll()` et réutiliser le token :
 
 ```typescript
 let token = '';
@@ -254,7 +254,7 @@ test('...', async ({ request }) => {
 
 **Probleme** : Certaines APIs (knowledge bases, functions) retournent du HTML au lieu de JSON quand le reverse proxy intercepte la requete ou la redirige.
 
-**Solution** : Verifier le Content-Type avant de parser, et utiliser `test.skip()` si l'API n'est pas disponible en JSON.
+**Solution** : Vérifier le Content-Type avant de parser, et utiliser `test.skip()` si l'API n'est pas disponible en JSON.
 
 ## Liens utiles
 
@@ -265,15 +265,15 @@ test('...', async ({ request }) => {
 
 ## Origine
 
-Cette serie pedagogique a ete creee dans le cadre du cycle GenAI CoursIA,
+Cette série pédagogique a été créée dans le cadre du cycle GenAI CoursIA,
 en complement des ateliers Vibe-Coding (Claude Code et Roo Code).
-Elle utilise les tests E2E reels du projet Open WebUI comme base pedagogique.
+Elle utilise les tests E2E réels du projet Open WebUI comme base pédagogique.
 
 ## FAQ
 
 ### `npm install` echoue ou Playwright ne trouve pas Chromium
 
-Playwright (utilise dans les modules [01](01-decouverte/) a [05](05-multi-tenant-ci/)) requiert Node.js 18+ et telecharge Chromium (~200 Mo). Si erreur :
+Playwright (utilise dans les modules [01](01-decouverte/) a [05](05-multi-tenant-ci/)) requiert Node.js 18+ et télécharge Chromium (~200 Mo). Si erreur :
 
 ```bash
 # Verifier Node.js
@@ -286,9 +286,9 @@ npx playwright install chromium
 npx playwright install-deps chromium
 ```
 
-Si vous etes derriere un proxy ou firewall, telecharger manuellement : `PLAYWRIGHT_DOWNLOAD_HOST=https://proxy.example.com npx playwright install chromium`. Le module [01](01-decouverte/) couvre la configuration pas-a-pas.
+Si vous êtes derrière un proxy ou firewall, télécharger manuellement : `PLAYWRIGHT_DOWNLOAD_HOST=https://proxy.example.com npx playwright install chromium`. Le module [01](01-decouverte/) couvre la configuration pas-a-pas.
 
-### Les tests echouent avec "Timeout exceeded" sur le chat
+### Les tests échouent avec "Timeout exceeded" sur le chat
 
 Le module [03](03-chat-streaming/) teste le chat avec un LLM reel via streaming. Les timeouts sont elonges (30-60s) mais les LLM lents ou surcharges peuvent les depasser. Mitigation :
 
@@ -300,13 +300,13 @@ test('chat reponse', { tag: '@slow' }, async ({ page }) => {
 });
 ```
 
-- Verifier que l'instance OWUI est accessible : `curl $OWUI_URL/api/v1/models`
-- Le streaming utilise `page.waitForFunction()` — si le modele ne stream pas, le poll tourne en boucle.
+- Vérifier que l'instance OWUI est accessible : `curl $OWUI_URL/api/v1/models`
+- Le streaming utilise `page.waitForFunction()` — si le modèle ne stream pas, le poll tourne en boucle.
 - Le module [03](03-chat-streaming/) explique les strategies d'assertion sur du contenu non-deterministe.
 
-### Peut-on utiliser cette serie sans instance Open WebUI ?
+### Peut-on utiliser cette série sans instance Open WebUI ?
 
-Partiellement. Les modules [01](01-decouverte/) (navigation, selecteurs) et [05](05-multi-tenant-ci/) (API testing) fonctionnent sur toute application web. Les modules [02](02-navigation-authentification/) a [04](04-rag-tools-avances/) sont specifiques a OWUI (auth, chat, RAG).
+Partiellement. Les modules [01](01-decouverte/) (navigation, sélecteurs) et [05](05-multi-tenant-ci/) (API testing) fonctionnent sur toute application web. Les modules [02](02-navigation-authentification/) a [04](04-rag-tools-avances/) sont spécifiques a OWUI (auth, chat, RAG).
 
 Pour une instance locale rapide :
 
@@ -322,35 +322,35 @@ Le module [01](01-decouverte/) explique comment pointer Playwright vers votre in
 
 ### Les tests du module 04 (RAG/MCP) sont tous skip
 
-Le module [04](04-rag-tools-avances/) teste les Knowledge Bases, les outils MCP et les channels. Les 5 skips dans les resultats de validation viennent de fonctionnalites non configurees sur l'instance OWUI :
+Le module [04](04-rag-tools-avances/) teste les Knowledge Bases, les outils MCP et les channels. Les 5 skips dans les résultats de validation viennent de fonctionnalités non configurées sur l'instance OWUI :
 
-- **Knowledge Bases** : necessitent un upload prealable de documents via l'interface OWUI.
-- **Outils MCP** : le serveur MCP doit etre configure dans les parametres OWUI (Admin > Tools).
+- **Knowledge Bases** : nécessitent un upload prealable de documents via l'interface OWUI.
+- **Outils MCP** : le serveur MCP doit être configure dans les parametres OWUI (Admin > Tools).
 - **Channels** : fonctionnalite collaborative qui requiert plusieurs utilisateurs actifs.
 
-Pour activer ces tests, configurer les fonctionnalites correspondantes dans OWUI et decommenter les `test.skip()` dans [04-rag-tools.spec.ts](04-rag-tools-avances/04-rag-tools.spec.ts).
+Pour activer ces tests, configurer les fonctionnalités correspondantes dans OWUI et decommenter les `test.skip()` dans [04-rag-tools.spec.ts](04-rag-tools-avances/04-rag-tools.spec.ts).
 
-### Quelle difference entre cette serie et les ateliers Vibe-Coding ?
+### Quelle différence entre cette série et les ateliers Vibe-Coding ?
 
-| Critere | Playwright-OWUI | Vibe-Coding |
+| Critère | Playwright-OWUI | Vibe-Coding |
 |---------|-----------------|-------------|
-| **Focus** | Tests E2E automatises | Developpement assiste par IA |
+| **Focus** | Tests E2E automatises | Développement assiste par IA |
 | **Langage** | TypeScript (.spec.ts) | Naturel (prompt engineering) |
 | **Outil** | Playwright | Claude Code / Roo Code |
-| **Public** | Testeurs QA, dev backend | Developeurs, debutants |
-| **Non-determinisme** | Gere (streaming, LLM) | N/A |
+| **Public** | Testeurs QA, dev backend | Developeurs, débutants |
+| **Non-determinisme** | Gère (streaming, LLM) | N/A |
 
-Les deux series sont complementaires : Vibe-Coding ([README](../Vibe-Coding/README.md)) couvre le developpement assiste par IA, tandis que Playwright-OWUI couvre la validation automatisee des interfaces generees.
+Les deux series sont complementaires : Vibe-Coding ([README](../Vibe-Coding/README.md)) couvre le développement assiste par IA, tandis que Playwright-OWUI couvre la validation automatisee des interfaces generees.
 
-### Comment adapter les tests a une autre application OWUI (version ou config differente) ?
+### Comment adapter les tests a une autre application OWUI (version ou config différente) ?
 
-Les selecteurs CSS et les patterns d'auth sont stables entre OWUI v0.8.x et v0.9.x. Si votre instance differe :
+Les sélecteurs CSS et les patterns d'auth sont stables entre OWUI v0.8.x et v0.9.x. Si votre instance diffère :
 
-1. **Selecteurs** : verifier avec le mode debug (`npx playwright test --debug`) que les selecteurs dans [helpers/selectors.ts](helpers/selectors.ts) correspondent a votre version.
+1. **Sélecteurs** : vérifier avec le mode debug (`npx playwright test --debug`) que les sélecteurs dans [helpers/selectors.ts](helpers/selectors.ts) correspondent a votre version.
 2. **Labels multilingues** : OWUI v0.9+ a change certains labels. Adapter dans les tests ou utiliser `getByRole()` (plus robuste que `getByText()`).
-3. **Nouvelles fonctionnalites** : OWUI v0.9.1 ajoute Calendar, Automations, Desktop app. Ce sont de bons candidats pour des exercices bonus (voir `WHATS-NEW-v0.9.1.md`).
+3. **Nouvelles fonctionnalités** : OWUI v0.9.1 ajoute Calendar, Automations, Desktop app. Ce sont de bons candidats pour des exercices bonus (voir `WHATS-NEW-v0.9.1.md`).
 
-Le module [01](01-decouverte/) enseigne les selecteurs robustes (`getByRole`, `getByTestId`) qui resistent aux changements d'UI.
+Le module [01](01-decouverte/) enseigne les sélecteurs robustes (`getByRole`, `getByTestId`) qui resistent aux changements d'UI.
 
 ---
 


### PR DESCRIPTION
## Scope

**#2876 — restore French diacritics in the 6 GenAI/Playwright-OWUI READMEs** (top-level + 5 per-level sub-READMEs). Virgin terrain (0% accented, French prose written in ASCII). Mirrors the established #2876 cadence: #4353 (00-Env), #4355/#4359 (Audio), #4361 (Image), #4369 (Video), #4403 (Vibe-Coding).

The Playwright-OWUI **READMEs are French**; the `.spec.ts` notebook files are TypeScript (out of scope for accent restoration — they are code, with French in comments, not documentation prose).

## Method (verified accent-only)

Python script (`scratchpad/accent_playwright_owui.py`, adapted from the proven #4403 Vibe-Coding method) with **placeholder masking** protects the regions that must NOT change, then applies a curated French word→accented mapping (word-boundary) to the remaining prose, then restores:

| Protected region | Handling |
|---|---|
| Link URLs `](...)` | masked → restored verbatim |
| Inline code `` `...` `` | masked → restored verbatim |
| Code fences ` ``` ... ``` ` | masked → restored verbatim |
| `<!-- CATALOG-STATUS -->` block | masked → restored verbatim |

Then **4 verification gates** per file (all PASS):

1. **`deaccent(old) == deaccent(new)`** via `unicodedata.normalize("NFD")` + strip category `Mn` → **True**. Proves ONLY diacritics were added; no base letter changed.
2. **CATALOG-STATUS byte-identical** → True (or no block present).
3. **Link URLs byte-identical** (old vs new) → True (filesystem dirs untouched).
4. **Code-fence backtick parity preserved** → True (orphan-fence check, `mermaid-fence-balance-bidirectional` lesson).

Diff: `6 files changed, +141 insertions(-), -141 deletions(-)` — perfectly symmetric (pure accent additions). **+227 accented chars** added across the 6 READMEs.

## Out-of-scope (documented honestly, not snuck in)

- **Words with no accent in French** (correctly left as-is): `navigateur`, `configurer`/`Configurez`, `installer`, `utiliser`/`utilise`, `fonctionne(nt)`, `variable`, `rapidement`, `particulier`, `complet` (masc), `chaque`, `serez`/`seront`, `Valider`, etc. These are not missing accents — French spells them without diacritics.
- **Context-dependent verb/pp forms** (ambiguous, skipped): tokens where the FR form varies by context and a blind word-boundary replace would risk corruption (e.g. `teste` = "il/elle teste" present vs "testé" past participle). Only unambiguous occurrences were handled.
- **Residuals in protected regions**: `modeles`/`selecteurs`/`editeur`/`Theorie`/`Deja` appearing inside file-tree code fences, bash comments (`# ...`), or inline code (`etudiant@ecole.fr`) are correctly preserved — they are code, not documentation prose.

## C.2 compliance

Markdown-only edit (no notebook cells, no execution) → C.2 markdown exception applies.

See #2876