### PR TITLE
docs(genai): restore French diacritics in CaseStudies sub-READMEs (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/README.md
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/README.md
@@ -2,16 +2,16 @@
 
 [← CaseStudies](../README.md) | [↑ GenAI](../../README.md)
 
-Analyse et visualisation de donnees avec generation d'images hybrides Barbie/Shrek.
+Analyse et visualisation de données avec génération d'images hybrides Barbie/Shrek.
 
 ## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
 | Notebooks | 1 |
-| Difficulte | Intermédiaire |
-| Duree | ~1-2h |
-| Theme | Analyse de donnees visuelles |
+| Difficulté | Intermédiaire |
+| Durée | ~1-2h |
+| Thème | Analyse de données visuelles |
 
 ## Notebook
 
@@ -21,11 +21,11 @@ Analyse et visualisation de donnees avec generation d'images hybrides Barbie/Shr
 
 ## Technologies
 
-- **Python** : Analyse de donnees
-- **OpenAI DALL-E** : Generation d'images
+- **Python** : Analyse de données
+- **OpenAI DALL-E** : Génération d'images
 - **PIL** : Manipulation d'images
 
-## Prerequis
+## Prérequis
 
 ```bash
 pip install pandas matplotlib seaborn openai jupyter
@@ -33,4 +33,4 @@ pip install pandas matplotlib seaborn openai jupyter
 
 ---
 
-*Projet etudiant - Janvier 2026*
+*Projet étudiant - Janvier 2026*

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/README.md
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/README.md
@@ -2,16 +2,16 @@
 
 [← CaseStudies](../README.md) | [↑ GenAI](../../README.md)
 
-Jeu interactif Fort Boyard utilisant des modeles de langage pour generer des enigmes et gerer les interactions.
+Jeu interactif Fort Boyard utilisant des modèles de langage pour générer des énigmes et gérer les interactions.
 
 ## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
 | Notebooks | 1 |
-| Difficulte | Intermédiaire |
-| Duree | ~1-2h |
-| Theme | Jeu interactif IA |
+| Difficulté | Intermédiaire |
+| Durée | ~1-2h |
+| Thème | Jeu interactif IA |
 
 ## Notebook
 
@@ -22,9 +22,9 @@ Jeu interactif Fort Boyard utilisant des modeles de langage pour generer des eni
 ## Technologies
 
 - **Python** : Logique de jeu
-- **OpenAI GPT** : Generation d'enigmes et dialogues
+- **OpenAI GPT** : Génération d'énigmes et dialogues
 
-## Prerequis
+## Prérequis
 
 ```bash
 pip install openai jupyter
@@ -32,4 +32,4 @@ pip install openai jupyter
 
 ---
 
-*Projet etudiant - Janvier 2026*
+*Projet étudiant - Janvier 2026*

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/README.md
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/README.md
@@ -1,38 +1,38 @@
-# Medical-Chatbot - Chatbot medical
+# Medical-Chatbot - Chatbot médical
 
 [← CaseStudies](../README.md) | [↑ GenAI](../../README.md)
 
-Chatbot medical intelligent utilisant des agents IA pour l'assistance aux patients.
+Chatbot médical intelligent utilisant des agents IA pour l'assistance aux patients.
 
 ## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
 | Notebooks | 1 |
-| Difficulte | Avance |
-| Duree | ~2-3h |
-| Theme | Sante et assistance medicale |
+| Difficulté | Avancé |
+| Durée | ~2-3h |
+| Thème | Santé et assistance médicale |
 
 ## Notebook
 
 | # | Notebook | Description |
 |---|----------|-------------|
-| 1 | [medical_chatbot](medical_chatbot.ipynb) | Chatbot medical intelligent |
+| 1 | [medical_chatbot](medical_chatbot.ipynb) | Chatbot médical intelligent |
 
 ## Technologies
 
 - **Python** : Interface de development
 - **Semantic Kernel** : Orchestration d'agents
-- **OpenAI** : Modeles de langage
+- **OpenAI** : Modèles de langage
 
-## Prerequis
+## Prérequis
 
 ```bash
 pip install openai pandas scikit-learn semantic-kernel
 ```
 
-**Important** : Ce chatbot est un outil d'assistance et ne remplace pas un professionnel de sante.
+**Important** : Ce chatbot est un outil d'assistance et ne remplace pas un professionnel de santé.
 
 ---
 
-*Projet etudiant - Janvier 2026*
+*Projet étudiant - Janvier 2026*

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/README.md
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/README.md
@@ -1,31 +1,31 @@
-# Recipe-Maker - Generateur de recettes
+# Recipe-Maker - Générateur de recettes
 
 [← CaseStudies](../README.md) | [↑ GenAI](../../README.md)
 
-Generateur automatise de recettes culinaires utilisant des agents IA.
+Générateur automatisé de recettes culinaires utilisant des agents IA.
 
 ## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
 | Notebooks | 1 |
-| Difficulte | Intermédiaire |
-| Duree | ~1-2h |
-| Theme | Intelligence culinaire |
+| Difficulté | Intermédiaire |
+| Durée | ~1-2h |
+| Thème | Intelligence culinaire |
 
 ## Notebook
 
 | # | Notebook | Description |
 |---|----------|-------------|
-| 1 | [receipe_maker](receipe_maker.ipynb) | Generateur automatise de recettes culinaires |
+| 1 | [receipe_maker](receipe_maker.ipynb) | Générateur automatisé de recettes culinaires |
 
 ## Technologies
 
-- **Python** : Traitement de donnees, generation de texte
+- **Python** : Traitement de données, génération de texte
 - **Semantic Kernel** : Orchestration d'agents
-- **OpenAI** : Modeles de langage
+- **OpenAI** : Modèles de langage
 
-## Prerequis
+## Prérequis
 
 ```bash
 pip install openai pandas numpy semantic-kernel
@@ -33,4 +33,4 @@ pip install openai pandas numpy semantic-kernel
 
 ---
 
-*Projet etudiant - Janvier 2026*
+*Projet étudiant - Janvier 2026*


### PR DESCRIPTION
## Scope

**#2876 — restore French diacritics in 4 GenAI/CaseStudies sub-READMEs** (Medical-Chatbot, Barbie-Schreck, Recipe-Maker, Fort-Boyard). Virgin terrain (0-1 accented chars each). Mirrors the established #2876 cadence: #4353 (00-Env), #4355/#4359 (Audio), #4361 (Image), #4369 (Video), #4403 (Vibe-Coding), #4405 (Playwright-OWUI).

## Method (verified accent-only)

Placeholder masking (code fences, inline code, link URLs, CATALOG-STATUS) → curated FR word→accented mapping (word-boundary) → restore. **4 gates per file (all PASS)**:

1. `deaccent(old) == deaccent(new)` via NFD + strip category Mn → accent-only PROVEN.
2. Link URLs byte-identical.
3. Code-fence backtick parity preserved.
4. CATALOG-STATUS byte-identical.

Diff: `4 files, +35/-35` (perfectly symmetric, pure accent additions).

## Edge-case handled — H1 proper-noun compound

The H1 title `# Medical-Chatbot - Chatbot medical` contains the **directory/project name** "Medical-Chatbot" (a proper-noun identifier matching the filesystem folder). A naive word-boundary `medical`→`médical` first matched inside the compound (`Medical-Chatbot`→`Médical-Chatbot`). Reverted to keep the proper-noun byte-identical to origin/main, accenting **only** the descriptive adjective (`Chatbot medical`→`Chatbot médical`). Same principle as URL/dir preservation. The other 3 titles (Barbie-Schreck, Recipe-Maker, Fort-Boyard) are brand/proper nouns with no accent target — untouched.

## Out-of-scope (documented honestly, not snuck in)

- **`development`** (Medical-Chatbot line 24): English word in French prose; correct FR is `développement` but that is a **spelling/language change** (en→fr + double-p), not accent-only (fails the `deaccent` gate). Belongs in a separate translation PR.
- **`remplace`** (Medical-Chatbot "ne remplace pas"): present-tense verb — no accent in that form (NOT the past participle `remplacé`).
- **Words with no accent in FR**: `hybride`, `recettes`, `statistique`, `visuelle`, `technologies`, `interactif`, `intelligent`, `interface`, `professionnel`.

## C.2 compliance

Markdown-only edit (no notebook cells, no execution) → C.2 markdown exception applies.

See #2876