### PR TITLE
docs(genai): restore French diacritics in Vibe-Coding sub-READMEs (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/README.md
@@ -1,39 +1,39 @@
 # Notebooks Interactifs Claude CLI
 
-Cette serie de notebooks Jupyter permet d'apprendre et d'experimenter avec Claude Code en ligne de commande (`claude -p "..."`).
+Cette série de notebooks Jupyter permet d'apprendre et d'expérimenter avec Claude Code en ligne de commande (`claude -p "..."`).
 
-## Prerequis
+## Prérequis
 
-Avant d'executer ces notebooks, assurez-vous d'avoir :
+Avant d'exécuter ces notebooks, assurez-vous d'avoir :
 
-1. **Claude Code CLI installe** :
+1. **Claude Code CLI installé** :
    ```bash
    claude --version
    ```
 
-2. **OpenRouter configure** (ou Anthropic directement) :
+2. **OpenRouter configuré** (ou Anthropic directement) :
    ```bash
    claude /status
    ```
 
-3. **Python 3.9+** avec les dependances :
+3. **Python 3.9+** avec les dépendances :
    ```bash
    pip install jupyter ipykernel
    ```
 
 ## Notebooks Disponibles
 
-| Notebook | Duree | Niveau | Description |
+| Notebook | Durée | Niveau | Description |
 |----------|-------|--------|-------------|
-| [01-Claude-CLI-Bases](01-Claude-CLI-Bases.ipynb) | 20 min | Debutant | Installation, premiere commande, formats de sortie |
-| [02-Claude-CLI-Sessions](02-Claude-CLI-Sessions.ipynb) | 25 min | Debutant | Gestion des conversations et sessions |
-| [03-Claude-CLI-References](03-Claude-CLI-References.ipynb) | 25 min | Intermediaire | @-mentions, contexte fichiers, CLAUDE.md |
-| [04-Claude-CLI-Agents](04-Claude-CLI-Agents.ipynb) | 30 min | Intermediaire | Agents Explore, Plan, subagents |
-| [05-Claude-CLI-Automatisation](05-Claude-CLI-Automatisation.ipynb) | 30 min | Avance | Pipelines, scripts, hooks |
+| [01-Claude-CLI-Bases](01-Claude-CLI-Bases.ipynb) | 20 min | Débutant | Installation, premiere commande, formats de sortie |
+| [02-Claude-CLI-Sessions](02-Claude-CLI-Sessions.ipynb) | 25 min | Débutant | Gestion des conversations et sessions |
+| [03-Claude-CLI-References](03-Claude-CLI-References.ipynb) | 25 min | Intermédiaire | @-mentions, contexte fichiers, CLAUDE.md |
+| [04-Claude-CLI-Agents](04-Claude-CLI-Agents.ipynb) | 30 min | Intermédiaire | Agents Explore, Plan, subagents |
+| [05-Claude-CLI-Automatisation](05-Claude-CLI-Automatisation.ipynb) | 30 min | Avancé | Pipelines, scripts, hooks |
 
-**Duree totale estimee : 2h10**
+**Durée totale estimée : 2h10**
 
-## Structure du Repertoire
+## Structure du Répertoire
 
 ```
 notebooks/
@@ -71,19 +71,19 @@ jupyter lab
 
 ### Mode Simulation (Sans API)
 
-Si vous n'avez pas de cle API configuree, les notebooks peuvent fonctionner en mode simulation. Definissez la variable dans la premiere cellule :
+Si vous n'avez pas de clé API configurée, les notebooks peuvent fonctionner en mode simulation. Definissez la variable dans la premiere cellule :
 
 ```python
 SIMULATION_MODE = True
 ```
 
-Les appels a Claude seront simules avec des reponses d'exemple.
+Les appels a Claude seront simules avec des réponses d'exemple.
 
-## Couts API
+## Coûts API
 
-Chaque execution de cellule consomme des tokens. Estimation par notebook :
+Chaque exécution de cellule consomme des tokens. Estimation par notebook :
 
-| Notebook | Tokens estimes | Cout approximatif* |
+| Notebook | Tokens estimés | Coût approximatif* |
 |----------|---------------|-------------------|
 | 01-Bases | ~2,000 | ~$0.01 |
 | 02-Sessions | ~3,000 | ~$0.02 |
@@ -91,7 +91,7 @@ Chaque execution de cellule consomme des tokens. Estimation par notebook :
 | 04-Agents | ~8,000 | ~$0.05 |
 | 05-Automatisation | ~10,000 | ~$0.06 |
 
-*Basé sur les tarifs OpenRouter avec GLM-4.7-Flash. Les couts varient selon le modele utilise.
+*Basé sur les tarifs OpenRouter avec GLM-4.7-Flash. Les coûts varient selon le modèle utilise.
 
 ## Module Helpers
 
@@ -121,29 +121,29 @@ stdout, stderr, code = run_claude_command("/sessions")
 
 ## Fichiers Exemples
 
-Le repertoire `examples/` contient des fichiers pour les exercices des notebooks 03-05 :
+Le répertoire `examples/` contient des fichiers pour les exercices des notebooks 03-05 :
 
 - **sample_project/** : Mini-projet Python avec structure standard
 - **CLAUDE.md** : Exemple de fichier de contexte projet
 
-## Resolution de Problemes
+## Résolution de Problèmes
 
 ### "claude: command not found"
 
-1. Verifiez l'installation : `where.exe claude` (Windows) ou `which claude` (macOS/Linux)
-2. Ajoutez Claude au PATH si necessaire
-3. Redemarrez votre terminal/VS Code
+1. Vérifiez l'installation : `where.exe claude` (Windows) ou `which claude` (macOS/Linux)
+2. Ajoutez Claude au PATH si nécessaire
+3. Redémarrez votre terminal/VS Code
 
 ### "Authentication failed"
 
-1. Verifiez les variables d'environnement :
+1. Vérifiez les variables d'environnement :
    ```bash
    echo $ANTHROPIC_BASE_URL
    echo $ANTHROPIC_AUTH_TOKEN
    ```
 2. Consultez [INSTALLATION-CLAUDE-CODE.md](../docs/INSTALLATION-CLAUDE-CODE.md)
 
-### Timeout lors de l'execution
+### Timeout lors de l'exécution
 
 Certaines commandes peuvent prendre du temps. Augmentez le timeout :
 
@@ -154,10 +154,10 @@ stdout, stderr, code = run_claude("Question complexe", timeout=120)
 ## Ressources
 
 - [Guide Installation](../docs/INSTALLATION-CLAUDE-CODE.md)
-- [Modeles Alternatifs OpenRouter](../docs/INSTALLATION-CLAUDE-CODE.md#modeles-alternatifs-via-openrouter)
+- [Modèles Alternatifs OpenRouter](../docs/INSTALLATION-CLAUDE-CODE.md#modeles-alternatifs-via-openrouter)
 - [Cheat Sheet](../docs/CHEAT-SHEET.md)
 - [Documentation Officielle Claude Code](https://docs.claude.com/code)
 
 ---
 
-*Ces notebooks font partie de la serie Vibe-Coding du cours GenAI.*
+*Ces notebooks font partie de la série Vibe-Coding du cours GenAI.*

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/README.md
@@ -2,29 +2,29 @@
 
 [← Vibe-Coding](../README.md) | [↑ ..](../README.md)
 
-Les **Claw systems** sont des plateformes d'agents IA autonomes, conteneurisees et self-hosted. Contrairement aux assistants de codage (Claude Code, Roo Code) qui assistent un developpeur en temps reel, les Claw systems deployent des agents qui operent de maniere autonome via des interfaces comme Telegram.
+Les **Claw systems** sont des plateformes d'agents IA autonomes, conteneurisées et self-hosted. Contrairement aux assistants de codage (Claude Code, Roo Code) qui assistent un développeur en temps réel, les Claw systems deployent des agents qui opèrent de manière autonome via des interfaces comme Telegram.
 
 ## Pourquoi une section Claw ?
 
 | Aspect | Claude Code / Roo Code | Claw Systems |
 |--------|------------------------|--------------|
-| **Paradigme** | Assistance au developpeur | Agent autonome |
+| **Paradigme** | Assistance au développeur | Agent autonome |
 | **Interface** | CLI / VS Code | Telegram, API, Web |
 | **Execution** | Session interactive | Service persistant (Docker) |
-| **Utilisateur** | Developpeur | Utilisateur final |
+| **Utilisateur** | Développeur | Utilisateur final |
 | **Orchestration** | Agent unique | Multi-agents possible |
 
-Les Claw systems representent l'evolution naturelle : de l'assistant qui ecrit du code a l'agent qui execute des taches de maniere autonome.
+Les Claw systems représentent l'évolution naturelle : de l'assistant qui écrit du code a l'agent qui exécuté des tâches de manière autonome.
 
-## Ecosysteme
+## Écosystème
 
 ### NanoClaw
 
-Agent leger conteneurise avec interface Telegram.
+Agent léger conteneurisé avec interface Telegram.
 
 - **Architecture** : Conteneur Docker + API LLM (OpenRouter/local) + Telegram Bot API
-- **Deploiement** : Docker Compose sur serveur (ai-01)
-- **Fonctionnalites** : Chat, transcription vocale (ASR), skills personnalisables
+- **Déploiement** : Docker Compose sur serveur (ai-01)
+- **Fonctionnalités** : Chat, transcription vocale (ASR), skills personnalisables
 - **Code source** : roo-extensions#1318
 
 **Pipeline de production :**
@@ -41,9 +41,9 @@ Utilisateur Telegram
 
 ### OpenClaw
 
-Plateforme multi-agents open source (en developpement).
+Plateforme multi-agents open source (en développement).
 
-- Orchestration de plusieurs agents specialises
+- Orchestration de plusieurs agents spécialisés
 - Cluster management
 - Workflows autonomes
 
@@ -69,7 +69,7 @@ Claw-Systems/
 | ASR Whisper | Transcription vocale | po-2023 | `whisper-api.myia.io` |
 | LLM | Raisonnement | OpenRouter / local | API |
 
-## Prerequis
+## Prérequis
 
 - **Docker** + Docker Compose
 - **Telegram Bot Token** (via @BotFather)
@@ -79,8 +79,8 @@ Claw-Systems/
 ## Liens
 
 - [Architecture NanoClaw](docs/NanoClaw-Architecture.md)
-- [Guide de deploiement](docs/NanoClaw-Deploy.md)
-- [Integration ASR](docs/ASR-Integration.md)
+- [Guide de déploiement](docs/NanoClaw-Deploy.md)
+- [Intégration ASR](docs/ASR-Integration.md)
 - [Vibe-Coding parent](../README.md)
 
 ---


### PR DESCRIPTION
## Scope

**#2876 — restore French diacritics in 2 GenAI/Vibe-Coding sub-READMEs**: `Claw-Systems/README.md` (0% accented) and `Claude-Code/notebooks/README.md` (1% accented). Mirrors the established #2876 cadence: #4353 (00-Env), #4355/#4359 (Audio), #4361 (Image), #4369 (Video), #4403 (Vibe-Coding top), #4405 (Playwright-OWUI), #4406 (CaseStudies).

## Method (verified accent-only)

Placeholder masking (code fences, inline code, link URLs, CATALOG-STATUS) → curated FR word→accented mapping (word-boundary) → restore. **4 gates per file (all PASS)**:

1. `deaccent(old) == deaccent(new)` via NFD + strip category Mn → accent-only PROVEN.
2. Link URLs byte-identical.
3. Code-fence backtick parity preserved.
4. CATALOG-STATUS byte-identical.

Diff: `2 files, +42/-42` (perfectly symmetric).

## Notes

- **`developpement`** here is **FR double-p ASCII** (`developpement`→`développement` = accent-only, VALID) — unlike the EN word `development` of #4406 which was a spelling/language change (out of accent-only scope).
- **Proper-noun compounds** (Claw Systems, NanoClaw, OpenClaw, Claude Code, Claude CLI) are preserved: these have no accent target, so the word-boundary regex never touched them (the edge-case lesson from #4406 "Medical-Chatbot" did not apply here, but the awareness did).

## Residuals in protected regions (correctly preserved, documented honestly)

- **`Integration`** (Claw-Systems L58): inside a ` ```text ` file-tree code fence (inline comment), plus the filename `ASR-Integration.md` (proper-noun).
- **`modeles`** (Claude-Code/notebooks L157): inside a link URL anchor `#modeles-alternatifs-via-openrouter` (HTML identifier — accenting would break the link). The display text `Modèles` is accented.

## C.2 compliance

Markdown-only edit (no notebook cells, no execution) → C.2 markdown exception applies.

See #2876