### PR TITLE
docs(qc): restore French diacritics in partner-course-quant-trading templates (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/advanced/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/advanced/README.md
@@ -1,8 +1,8 @@
-# Template Avance - Machine Learning sur BTC
+# Template Avancé - Machine Learning sur BTC
 
 ## Description
 
-Ce template implemente une strategie de trading algorithmique sur BTCUSDT utilisant un modele de Machine Learning (RandomForestClassifier) pour predire la direction du prix. Le modele est entraine directement dans l'algorithme et re-entraine mensuellement pour s'adapter aux conditions de marche.
+Ce template implémente une stratégie de trading algorithmique sur BTCUSDT utilisant un modèle de Machine Learning (RandomForestClassifier) pour prédire la direction du prix. Le modèle est entraîné directement dans l'algorithme et ré-entraîne mensuellement pour s'adapter aux conditions de marché.
 
 ## Pipeline ML
 
@@ -31,39 +31,39 @@ Prediction quotidienne
 Execution sur Binance Cash
 ```
 
-## Persistance du modele (ObjectStore)
+## Persistance du modèle (ObjectStore)
 
-Le modele entraine est sauvegarde dans l'ObjectStore de QuantConnect via `pickle`. Cela permet de :
+Le modèle entraîné est sauvegardé dans l'ObjectStore de QuantConnect via `pickle`. Cela permet de :
 
-- **Reprendre** un backtest sans re-entrainer depuis zero
-- **Deployer** un modele entraine en backtest vers le live trading
-- **Sauvegarder automatiquement** a la fin du backtest et a chaque re-entrainement
+- **Reprendre** un backtest sans ré-entraîner depuis zéro
+- **Deployer** un modèle entraîné en backtest vers le live trading
+- **Sauvegarder automatiquement** à la fin du backtest et à chaque ré-entraînement
 
-## Concepts cles abordes
+## Concepts clés abordés
 
 | Concept | Description |
 |---------|-------------|
-| **Feature engineering** | Transformation d'indicateurs techniques en features ML normalisees |
+| **Feature engineering** | Transformation d'indicateurs techniques en features ML normalisées |
 | **sklearn dans QC** | Utilisation de RandomForestClassifier dans l'environnement QuantConnect |
-| **ObjectStore** | Persistance de modeles serialises entre executions |
-| **Re-entrainement programme** | `Schedule.On` pour adapter le modele au regime de marche |
-| **Warmup** | Periode d'initialisation des indicateurs avant le trading |
+| **ObjectStore** | Persistance de modèles sérialisés entre exécutions |
+| **Ré-entraînement programmé** | `Schedule.On` pour adapter le modèle au régime de marché |
+| **Warmup** | Période d'initialisation des indicateurs avant le trading |
 
-## Modifications suggerees
+## Modifications suggérées
 
-Pour aller plus loin, les etudiants peuvent :
+Pour aller plus loin, les étudiants peuvent :
 
-1. **Ajouter des features** : ADX, ATR, Bollinger Bands, volume, volatilite historique
-2. **Essayer d'autres modeles** : `XGBClassifier` (xgboost), `SVC` (sklearn), ou un ensemble de modeles
-3. **Ajouter des positions short** : Vendre a decouvert quand la prediction est baissiere (necessite Margin account)
-4. **Walk-forward optimization** : Entrainer sur les N derniers mois, tester sur le mois suivant, puis avancer la fenetre
-5. **Gestion du risque** : Stop-loss, take-profit, taille de position variable selon la confiance du modele
-6. **Decalage temporel** : Predire le label de J+1 avec les features de J (voir avertissement ci-dessous)
+1. **Ajouter des features** : ADX, ATR, Bollinger Bands, volume, volatilité historique
+2. **Essayer d'autres modèles** : `XGBClassifier` (xgboost), `SVC` (sklearn), ou un ensemble de modèles
+3. **Ajouter des positions short** : Vendre à découvert quand la prédiction est baissière (nécessite Margin account)
+4. **Walk-forward optimization** : Entraîner sur les N derniers mois, tester sur le mois suivant, puis avancer la fenêtre
+5. **Gestion du risque** : Stop-loss, take-profit, taille de position variable selon la confiance du modèle
+6. **Décalage temporel** : Predire le label de J+1 avec les features de J (voir avertissement ci-dessous)
 
 ## Avertissements importants
 
-**Overfitting** : Un modele trop complexe (trop d'arbres, profondeur illimitee) apprendra le bruit du marche plutot que les vrais signaux. La performance en backtest sera excellente mais catastrophique en live. Toujours valider sur des donnees hors echantillon.
+**Overfitting** : Un modèle trop complexe (trop d'arbres, profondeur illimitée) apprendra le bruit du marché plutôt que les vrais signaux. La performance en backtest sera excellente mais catastrophique en live. Toujours valider sur des données hors échantillon.
 
-**Lookahead bias** : Dans ce template simplifie, les features et le label sont calcules a partir des memes donnees du jour J. En production, il faut s'assurer que la prediction utilise uniquement des donnees disponibles AVANT la prise de decision. Decaler les labels d'un jour (predire J+1 avec les features de J) est la correction standard.
+**Lookahead bias** : Dans ce template simplifié, les features et le label sont calculés à partir des mêmes données du jour J. En production, il faut s'assurer que la prédiction utilise uniquement des données disponibles AVANT la prise de decision. Décaler les labels d'un jour (prédire J+1 avec les features de J) est la correction standard.
 
-**Data snooping** : Tester de nombreuses combinaisons de features/hyperparametres sur le meme jeu de donnees augmente le risque de trouver des patterns aleatoires. Utiliser un jeu de validation separe.
+**Data snooping** : Tester de nombreuses combinaisons de features/hyperparamètres sur le même jeu de données augmente le risque de trouver des patterns aléatoires. Utiliser un jeu de validation séparé.

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/intermediate/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/intermediate/README.md
@@ -1,13 +1,13 @@
-# Template Intermediaire - Strategie Momentum avec Alpha Framework
+# Template Intermédiaire - Stratégie Momentum avec Alpha Framework
 
 ## Description
 
-Ce template implemente une **strategie de momentum ranking** sur les actions du S&P 500.
-L'algorithme selectionne les 100 plus gros composants du SPY par ponderation,
-calcule leur momentum sur 90 jours, et investit de maniere egale dans ceux
-dont le momentum est positif. Un trailing stop a 5 % protege chaque position.
+Ce template implémente une **stratégie de momentum ranking** sur les actions du S&P 500.
+L'algorithme sélectionne les 100 plus gros composants du SPY par pondération,
+calcule leur momentum sur 90 jours, et investit de maniere égale dans ceux
+dont le momentum est positif. Un trailing stop à 5 % protège chaque position.
 
-**Periode de backtest** : Janvier 2021 - Decembre 2024
+**Période de backtest** : Janvier 2021 - Décembre 2024
 **Capital initial** : 100 000 USD (compte marge Interactive Brokers)
 **Rebalancement** : Mensuel (premier jour de bourse du mois)
 
@@ -15,17 +15,17 @@ dont le momentum est positif. Un trailing stop a 5 % protege chaque position.
 
 ## Concepts de l'Alpha Framework
 
-QuantConnect decompose une strategie en 4 modules independants,
+QuantConnect décompose une stratégie en 4 modules indépendants,
 ce qui permet de modifier un composant sans toucher aux autres :
 
-| Module | Role | Classe utilisee |
+| Module | Role | Classe utilisée |
 |--------|------|-----------------|
 | **AlphaModel** | Generer des signaux (Insights) haussiers/baissiers | `MomentumAlphaModel` (custom, MomentumPercent 90j) |
 | **PortfolioConstructionModel** | Convertir les Insights en allocations cibles | `EqualWeightingPortfolioConstructionModel` |
 | **RiskManagementModel** | Ajuster ou liquider des positions selon le risque | `TrailingStopRiskManagementModel(0.05)` |
-| **ExecutionModel** | Envoyer les ordres au marche | `ImmediateExecutionModel` |
+| **ExecutionModel** | Envoyer les ordres au marché | `ImmediateExecutionModel` |
 
-### Flux de donnees
+### Flux de données
 
 ```
 Donnees de marche
@@ -53,16 +53,16 @@ ExecutionModel  -->  Ordres envoyes au courtier
 
 ---
 
-## Modifications suggerees
+## Modifications suggérées
 
-Voici des pistes pour personnaliser et ameliorer la strategie :
+Voici des pistes pour personnaliser et améliorer la stratégie :
 
-### 1. Modifier la periode de lookback
+### 1. Modifier la période de lookback
 Changer `lookback=90` dans `MomentumAlphaModel` (ex: 60, 120 ou 252 jours).
-Un lookback plus court reagit plus vite mais genere plus de turnover.
+Un lookback plus court réagit plus vite mais génère plus de turnover.
 
 ### 2. Ajouter un filtre RSI
-Combiner le momentum avec un filtre RSI pour eviter d'acheter des titres
+Combiner le momentum avec un filtre RSI pour éviter d'acheter des titres
 en zone de surachat :
 
 ```python
@@ -76,14 +76,14 @@ if indicator.current.value > 0 and self.rsi[symbol].current.value < 70:
 
 ### 3. Filtrage sectoriel
 Utiliser `security.Fundamentals.AssetClassification.MorningstarSectorCode`
-pour concentrer la strategie sur certains secteurs (technologie, sante, etc.)
+pour concentrer la stratégie sur certains secteurs (technologie, santé, etc.)
 ou pour diversifier en limitant le nombre de titres par secteur.
 
-### 4. Changer le modele de construction de portefeuille
+### 4. Changer le modèle de construction de portefeuille
 Remplacer `EqualWeightingPortfolioConstructionModel` par :
-- `InsightWeightingPortfolioConstructionModel` : pondere par la magnitude des Insights
+- `InsightWeightingPortfolioConstructionModel` : pondère par la magnitude des Insights
 - `MeanVarianceOptimizationPortfolioConstructionModel` : optimisation Markowitz
-- `RiskParityPortfolioConstructionModel` : parite de risque (voir exemple Sector-Momentum)
+- `RiskParityPortfolioConstructionModel` : parité de risque (voir exemple Sector-Momentum)
 
 ### 5. Ajuster le trailing stop
 Modifier le seuil de 5 % ou combiner avec `MaximumDrawdownPercentPerSecurity(0.10)`
@@ -94,18 +94,18 @@ pour une gestion du risque en couches.
 ## Concepts QC couverts par ce template
 
 - **Universe Selection** : filtrage dynamique via `universe.etf()` et callback de filtre
-- **Alpha Framework** : les 4 modules (Alpha, PCM, Risk, Execution)
-- **Indicateurs integres** : `MomentumPercent` (MOMP) avec enregistrement automatique
-- **Insights** : signaux avec direction, duree (`Expiry.END_OF_MONTH`) et confiance
-- **ScheduledEvent** : declenchement periodique (`date_rules.month_start`)
-- **Warm-up** : periode de chauffe pour initialiser les indicateurs avant le trading
-- **BrokerageModel** : simulation realiste Interactive Brokers avec frais et marge
+- **Alpha Framework** : les 4 modules (Alpha, PCM, Risk, Exécution)
+- **Indicateurs intégrés** : `MomentumPercent` (MOMP) avec enregistrement automatique
+- **Insights** : signaux avec direction, durée (`Expiry.END_OF_MONTH`) et confiance
+- **ScheduledEvent** : déclenchement périodique (`date_rules.month_start`)
+- **Warm-up** : période de chauffe pour initialiser les indicateurs avant le trading
+- **BrokerageModel** : simulation réaliste Interactive Brokers avec frais et marge
 
 ---
 
 ## Pour aller plus loin
 
 - Consulter les notebooks `QC-Py-17` (Alpha Framework) et `QC-Py-19` (Risk Management)
-- Etudier l'exemple `Sector-Momentum` pour le momentum dual avec parite de risque
+- Etudier l'exemple `Sector-Momentum` pour le momentum dual avec parité de risque
 - Etudier l'exemple `Trend-Following` pour combiner plusieurs indicateurs
 - Documentation officielle : https://www.quantconnect.com/docs/v2/writing-algorithms/algorithm-framework

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/starter/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/templates/starter/README.md
@@ -2,43 +2,43 @@
 
 ## Description
 
-Ce template implemente une strategie de **croisement de moyennes mobiles exponentielles (EMA)** sur le Bitcoin (BTCUSDT) via Binance.
+Ce template implémente une stratégie de **croisement de moyennes mobiles exponentielles (EMA)** sur le Bitcoin (BTCUSDT) via Binance.
 
 **Principe :**
-- Quand l'EMA rapide (12 periodes) passe **au-dessus** de l'EMA lente (26 periodes), c'est un **golden cross** : on achete.
+- Quand l'EMA rapide (12 périodes) passe **au-dessus** de l'EMA lente (26 périodes), c'est un **golden cross** : on achète.
 - Quand l'EMA rapide passe **en dessous** de l'EMA lente, c'est un **death cross** : on vend.
 
-Le backtest couvre la periode du 1er janvier 2023 au 31 decembre 2024, avec un capital initial de 10 000 USDT et des donnees horaires.
+Le backtest couvre la période du 1er janvier 2023 au 31 décembre 2024, avec un capital initial de 10 000 USDT et des données horaires.
 
 ## Utilisation
 
-1. Connectez-vous a [QuantConnect](https://www.quantconnect.com/)
+1. Connectez-vous à [QuantConnect](https://www.quantconnect.com/)
 2. Create a new Python project in your course organization
 3. Copiez le contenu de `main.py` dans le fichier principal du projet
-4. Lancez un backtest pour observer les resultats
-5. Analysez les metriques : Sharpe Ratio, drawdown, nombre de trades
+4. Lancez un backtest pour observer les résultats
+5. Analysez les métriques : Sharpe Ratio, drawdown, nombre de trades
 
 ## Concepts QC couverts
 
 | Concept | Description | Ligne(s) |
 |---------|-------------|----------|
-| `AddCrypto` | Ajouter un actif crypto avec marche et resolution | `Initialize` |
-| `Resolution.Hour` | Granularite des donnees (ici bougies horaires) | `Initialize` |
-| `self.EMA(...)` | Creer un indicateur Moyenne Mobile Exponentielle | `Initialize` |
-| `SetWarmUp` | Prechauffer les indicateurs avant de trader | `Initialize` |
-| `SetHoldings` | Allouer un pourcentage du portefeuille a un actif | `OnData` |
+| `AddCrypto` | Ajouter un actif crypto avec marché et résolution | `Initialize` |
+| `Resolution.Hour` | Granularité des données (ici bougies horaires) | `Initialize` |
+| `self.EMA(...)` | Créer un indicateur Moyenne Mobile Exponentielle | `Initialize` |
+| `SetWarmUp` | Préchauffer les indicateurs avant de trader | `Initialize` |
+| `SetHoldings` | Allouer un pourcentage du portefeuille à un actif | `OnData` |
 | `Liquidate` | Vendre toute la position sur un actif | `OnData` |
-| `Portfolio[symbol].Invested` | Verifier si on detient une position | `OnData` |
-| `SetBenchmark` | Definir un indice de reference pour comparer la performance | `Initialize` |
-| `OnOrderEvent` | Recevoir les notifications d'execution des ordres | `OnOrderEvent` |
+| `Portfolio[symbol].Invested` | Vérifier si on détient une position | `OnData` |
+| `SetBenchmark` | Définir un indice de référence pour comparer la performance | `Initialize` |
+| `OnOrderEvent` | Recevoir les notifications d'exécution des ordres | `OnOrderEvent` |
 
-## Modifications suggerees
+## Modifications suggérées
 
-Voici des pistes pour ameliorer et personnaliser cette strategie :
+Voici des pistes pour améliorer et personnaliser cette stratégie :
 
-### Niveau 1 - Parametrage
-- Changer les periodes EMA : essayer (5, 20), (20, 50) ou (50, 200)
-- Modifier la resolution : `Resolution.Daily` au lieu de `Resolution.Hour`
+### Niveau 1 - Paramétrage
+- Changer les périodes EMA : essayer (5, 20), (20, 50) ou (50, 200)
+- Modifier la résolution : `Resolution.Daily` au lieu de `Resolution.Hour`
 - Tester un autre actif : remplacer `"BTCUSDT"` par `"ETHUSDT"` ou `"SOLUSDT"`
 
 ### Niveau 2 - Filtres supplementaires
@@ -47,15 +47,15 @@ Voici des pistes pour ameliorer et personnaliser cette strategie :
   self.rsi = self.RSI(self.btc, 14, Resolution.Hour)
   # Dans OnData : ajouter "and self.rsi.Current.Value < 70" a la condition d'achat
   ```
-- Ajouter un **filtre de volume** : ne trader que si le volume est superieur a la moyenne
-- Implementer un **stop-loss** a -5% pour limiter les pertes
+- Ajouter un **filtre de volume** : ne trader que si le volume est supérieur à la moyenne
+- Implémenter un **stop-loss** à -5% pour limiter les pertes
 
 ### Niveau 3 - Gestion de position
 - Utiliser `SetHoldings(self.btc, 0.5)` pour n'investir que 50% du capital
-- Trader sur **plusieurs cryptos** en meme temps (BTC + ETH + SOL)
-- Ajouter un **trailing stop** qui suit le prix a la hausse
+- Trader sur **plusieurs cryptos** en même temps (BTC + ETH + SOL)
+- Ajouter un **trailing stop** qui suit le prix à la hausse
 
 ### Niveau 4 - Evaluation
-- Comparer les resultats avec differents parametres dans un tableau
+- Comparer les résultats avec différents paramètres dans un tableau
 - Analyser le **Sharpe Ratio** et le **Maximum Drawdown** de chaque variante
-- Expliquer pourquoi certains parametres fonctionnent mieux que d'autres
+- Expliquer pourquoi certains paramètres fonctionnent mieux que d'autres


### PR DESCRIPTION
## Summary

Restore French diacritics in the 3 `QuantConnect/partner-course-quant-trading/templates/` READMEs (`starter` / `intermediate` / `advanced`) — virgin FR-ASCII terrain, part of the repo-wide #2876 accent-restoration effort (family pivot after GenAI terrain was exhausted).

Part of #2876. Complements the GenAI accent PRs already merged (#4353/#4355/#4359/#4361/#4369/#4403/#4405/#4406/#4407). See #2876 (partial — QuantConnect family).

## Method — verified accent-only (4 gates per file, all PASS)

Reusable #2876 script (`scratchpad/accent_qc_partner.py`):
1. **Placeholder-mask** code fences (``` ``` ```), inline `` `code` ``, link URLs `](…)`, `CATALOG-STATUS`, and the stray EN instruction line, **before** applying the mapping.
2. **Apply** curated FR word-boundary (`\b…\b`) mapping on remaining prose.
3. **Restore** placeholders.
4. **4 gates** (all PASS, 3 files × 4):
   - `deaccent(old) == deaccent(new)` via `unicodedata.normalize("NFD")` + strip category `Mn` → **proof accent-only** (only combining diacritics added, zero base-letter change).
   - `CATALOG-STATUS` byte-identical.
   - Link URLs byte-identical.
   - Code-fence backtick parity preserved.

**Signature**: `+74 / -74`, perfectly symmetric (char delta = 0 — accents are single codepoints, add no length).

## Context-verified firsthand (resolves ambiguities the gate cannot catch)

The deaccent gate proves *accent-only* but NOT *grammatically correct verb/pp form*. Read all 3 files + `grep` to resolve:
- `genere` → **génère** (present "génère plus de turnover", NOT pp *généré*).
- `re-entraine mensuellement` → **ré-entraîne** (present verb, not pp).
- `est entraine` / `modele entraine` → **entraîné** (pp masc).
- **Hyphenated `re-entrain*` family mapped FIRST** so `\bentraine\b` cannot match its inner part inside the compound (proper-noun-compound lesson from #4406/c.48 applied).

## Honest exclusions (out of accent-only scope)

| Item | Reason |
|------|--------|
| `development` (EN word in FR prose) | → `développement` = base-letter/language change, **fails** the deaccent gate (like `aggrege`/`modeaux`) = spelling-fix scope, not #2876 |
| EN stray line "Create a new Python project…" (starter L16) | EN instruction = #1650 translation scope; its article "a" was **masked** so the FR prep rule `\ba\b`→`à` could not corrupt it — left byte-identical |
| Words with no FR accent | left as-is: backtest, moyenne, indicateur (sg), frais, transaction, portefeuille, allocation, cours, bougie, actif, valider, analyser, calcule (present), observer, marche-verb |
| `a` inside ```` ```python ```` comment (starter L48) | protected code-fence content, left byte-identical (correct masking) |

The 8 French preposition `a`→`à` in prose were fixed (with the EN line masked); only the EN article + the in-fence comment remain as residuals.

## Validation

- `python scratchpad/accent_qc_partner.py` → `all_ok=True`, 4 gates × 3 files PASS.
- Markdown-only change (no notebooks, no code, no catalog) — check-links + gitleaks + catalog-unchanged expected green.
- Base: fresh `origin/main`.

Co-Authored-By: Claude <noreply@anthropic.com>