### PR TITLE
Add: Infer-14b-Lean-ExpectedUtility (native lean4-wsl companion, 6th+final native)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-14b-Lean-ExpectedUtility.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-14b-Lean-ExpectedUtility.ipynb
@@ -1,0 +1,1012 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ff8c6dc9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004787,
+     "end_time": "2026-06-27T08:48:51.818235+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:48:51.813448+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Infer-14b — Théorème de représentation de von Neumann–Morgenstern (companion formel natif)\n",
+    "\n",
+    "Ce notebook est le **companion formel** du lake [`decision_theory_lean`](../decision_theory_lean/)\n",
+    "(lib `Utility`), qui prouve la **direction sound** du théorème de représentation d'utilité\n",
+    "espérée de **von Neumann–Morgenstern** : si une fonction d'utilité `u` *représente* une\n",
+    "préférence `P` (`P p q ↔ E_p[u] ≥ E_q[u]`), alors `P` est **rationnelle** (satisfait les\n",
+    "quatre axiomes vNM), avec **zéro `sorry`**.\n",
+    "\n",
+    "C'est le fondement formel du classement par espérance d'utilité — la justification\n",
+    "décisionnelle des notebooks `Infer-14` (Infer.NET) et `PyMC-14` (PyMC), où l'utilité\n",
+    "espérée est calculée sous incertitude bayésienne.\n",
+    "\n",
+    "## Convention de vérification — `#check` *natif* dans le kernel Lean\n",
+    "\n",
+    "Ce notebook est un **notebook Lean natif** (kernel `lean4-wsl`) : il `import`e les\n",
+    "modules du lake directement et le compilateur Lean rend les signatures **dans le\n",
+    "notebook**. C'est rendu possible par l'UNLOCK (patch `lean4_jupyter` + jonction\n",
+    "Mathlib #2611).\n",
+    "\n",
+    "> ⚠️ À l'exécution, la première cellule (`import`) peut prendre **~3 min** :\n",
+    "> le kernel charge les oleans Mathlib via la jonction NTFS. Les suivantes sont\n",
+    "> instantanées."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "827e74e6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003863,
+     "end_time": "2026-06-27T08:48:51.826142+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:48:51.822279+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Import des modules `Utility` du lake `decision_theory_lean`\n",
+    "\n",
+    "Le lake porte 3 libs indépendantes (`Utility`, `Gittins`, `Coherence`). On importe\n",
+    "**uniquement les 3 modules de `Utility`** (`Basic`, `Axioms`, `Representation`) — la lib\n",
+    "`Utility` est déclarée via `roots := #[`Utility]`, qui ne build **pas** l'umbrella racine\n",
+    "`Utility.olean` (on importe donc les modules directement). On évite `Gittins` (sorries\n",
+    "HOLD) et `Coherence` : le companion cible la seule lib sorry-free du théorème vNM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b526705c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T08:48:51.835439Z",
+     "iopub.status.busy": "2026-06-27T08:48:51.835227Z",
+     "iopub.status.idle": "2026-06-27T08:53:08.434753Z",
+     "shell.execute_reply": "2026-06-27T08:53:08.433669Z"
+    },
+    "papermill": {
+     "duration": 256.611868,
+     "end_time": "2026-06-27T08:53:08.441792+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:48:51.829924+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Utility<span class=\"bp\">.</span>Basic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Utility<span class=\"bp\">.</span>Axioms</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Utility<span class=\"bp\">.</span>Representation</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>Utility</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"import Utility.Basic\\nimport Utility.Axioms\\nimport Utility.Representation\\nopen Utility\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "import Utility.Basic\n",
+       "import Utility.Axioms\n",
+       "import Utility.Representation\n",
+       "open Utility\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"import Utility.Basic\\nimport Utility.Axioms\\nimport Utility.Representation\\nopen Utility\"}\n",
+       "Raw output:\n",
+       "{\"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import Utility.Basic\n",
+    "import Utility.Axioms\n",
+    "import Utility.Representation\n",
+    "open Utility"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a2b12cd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003575,
+     "end_time": "2026-06-27T08:53:08.450760+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:08.447185+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Preuve sans `sorry` — `#print axioms`\n",
+    "\n",
+    "Le théorème phare `expected_utility_rep_is_rational` (direction sound : représentation ⟹\n",
+    "rationalité) ne dépend que des **3 axiomes standards de Lean** (`propext`, `Classical.choice`,\n",
+    "`Quot.sound`) — pas de `sorryAx` — ce qui prouve que la preuve est **complète** (0 sorry)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f07f7b04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T08:53:08.458839Z",
+     "iopub.status.busy": "2026-06-27T08:53:08.458639Z",
+     "iopub.status.idle": "2026-06-27T08:53:08.853828Z",
+     "shell.execute_reply": "2026-06-27T08:53:08.852989Z"
+    },
+    "papermill": {
+     "duration": 0.400753,
+     "end_time": "2026-06-27T08:53:08.854387+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:08.453634+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>expected_utility_rep_is_rational</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Utility<span class=\"bp\">.</span>expected_utility_rep_is_rational&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#print axioms expected_utility_rep_is_rational\", \"env\": 0}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Utility.expected_utility_rep_is_rational' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 1}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#print axioms expected_utility_rep_is_rational\n",
+       "──────▶  'Utility.expected_utility_rep_is_rational' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "--% env 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#print axioms expected_utility_rep_is_rational\", \"env\": 0}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Utility.expected_utility_rep_is_rational' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 1}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#print axioms expected_utility_rep_is_rational"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "406e428c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003686,
+     "end_time": "2026-06-27T08:53:08.862819+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:08.859133+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Loteries, espérance et mélange convexe\n",
+    "\n",
+    "Le module `Utility/Basic.lean` pose les primitives de la décision dans le risque :\n",
+    "\n",
+    "- `Lottery α` — une loterie : poids non négatifs par issue, sommant à 1 (distribution à support fini sur `α`).\n",
+    "- `expectation p f` — l'espérance de `f` (typiquement une utilité) sous `p` : `∑ a, p.probs a * f a`.\n",
+    "- `mix t p r` — le mélange convexe `t • p + (1 - t) • r` (valide pour `t ∈ [0,1]`).\n",
+    "- `expectation_mix` — l'identité affine clé : `E_{mix}[f] = t·E_p[f] + (1-t)·E_r[f]` (cœur algébrique de l'indépendance).\n",
+    "- `expectation_affine` — `E_p[a·u + b] = a·E_p[u] + b` (cœur de l'unicité affine de l'utilité)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b4281842",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T08:53:08.870841Z",
+     "iopub.status.busy": "2026-06-27T08:53:08.870674Z",
+     "iopub.status.idle": "2026-06-27T08:53:09.093422Z",
+     "shell.execute_reply": "2026-06-27T08:53:09.092575Z"
+    },
+    "papermill": {
+     "duration": 0.227686,
+     "end_time": "2026-06-27T08:53:09.093970+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:08.866284+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Lottery</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>Lottery<span class=\"bp\">.</span>{u_2}<span class=\"w\"> </span>(α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2)<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>expectation</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>expectation<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>Lottery<span class=\"w\"> </span>α)<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>mix</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>mix<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(t<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(p<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span>Lottery<span class=\"w\"> </span>α)<span class=\"w\"> </span>(ht0<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>t)<span class=\"w\"> </span>(ht1<span class=\"w\"> </span>:<span class=\"w\"> </span>t<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>Lottery<span class=\"w\"> </span>α</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>expectation_mix</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>expectation_mix<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(t<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(p<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span>Lottery<span class=\"w\"> </span>α)<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(ht0<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>t)\n",
+       "<span class=\"w\">  </span>(ht1<span class=\"w\"> </span>:<span class=\"w\"> </span>t<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>expectation<span class=\"w\"> </span>(mix<span class=\"w\"> </span>t<span class=\"w\"> </span>p<span class=\"w\"> </span>r<span class=\"w\"> </span>ht0<span class=\"w\"> </span>ht1)<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>t<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>expectation<span class=\"w\"> </span>p<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>(<span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>t)<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>expectation<span class=\"w\"> </span>r<span class=\"w\"> </span>f</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>expectation_affine</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>expectation_affine<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>Lottery<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(u<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>(expectation<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>u<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>expectation<span class=\"w\"> </span>p<span class=\"w\"> </span>u<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check Lottery\\n#check expectation\\n#check mix\\n#check expectation_mix\\n#check expectation_affine\", \"env\": 1}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Utility.Lottery.{u_2} (α : Type u_2) [Fintype α] : Type u_2\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.expectation.{u_1} {α : Type u_1} [Fintype α] (p : Lottery α) (f : α → ℝ) : ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.mix.{u_1} {α : Type u_1} [Fintype α] (t : ℝ) (p r : Lottery α) (ht0 : 0 ≤ t) (ht1 : t ≤ 1) : Lottery α\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.expectation_mix.{u_1} {α : Type u_1} [Fintype α] (t : ℝ) (p r : Lottery α) (f : α → ℝ) (ht0 : 0 ≤ t)\\n  (ht1 : t ≤ 1) : expectation (mix t p r ht0 ht1) f = t * expectation p f + (1 - t) * expectation r f\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.expectation_affine.{u_1} {α : Type u_1} [Fintype α] (p : Lottery α) (a b : ℝ) (u : α → ℝ) :\\n  (expectation p fun x => a * u x + b) = a * expectation p u + b\"}],\r\n",
+       " \"env\": 2}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check Lottery\n",
+       "──────▶  Utility.Lottery.{u_2} (α : Type u_2) [Fintype α] : Type u_2\n",
+       "#check expectation\n",
+       "──────▶  Utility.expectation.{u_1} {α : Type u_1} [Fintype α] (p : Lottery α) (f : α → ℝ) : ℝ\n",
+       "#check mix\n",
+       "──────▶  Utility.mix.{u_1} {α : Type u_1} [Fintype α] (t : ℝ) (p r : Lottery α) (ht0 : 0 ≤ t) (ht1 : t ≤ 1) : Lottery α\n",
+       "#check expectation_mix\n",
+       "──────▶  Utility.expectation_mix.{u_1} {α : Type u_1} [Fintype α] (t : ℝ) (p r : Lottery α) (f : α → ℝ) (ht0 : 0 ≤ t)\n",
+       "  (ht1 : t ≤ 1) : expectation (mix t p r ht0 ht1) f = t * expectation p f + (1 - t) * expectation r f\n",
+       "#check expectation_affine\n",
+       "──────▶  Utility.expectation_affine.{u_1} {α : Type u_1} [Fintype α] (p : Lottery α) (a b : ℝ) (u : α → ℝ) :\n",
+       "  (expectation p fun x => a * u x + b) = a * expectation p u + b\n",
+       "--% env 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check Lottery\\n#check expectation\\n#check mix\\n#check expectation_mix\\n#check expectation_affine\", \"env\": 1}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Utility.Lottery.{u_2} (α : Type u_2) [Fintype α] : Type u_2\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.expectation.{u_1} {α : Type u_1} [Fintype α] (p : Lottery α) (f : α → ℝ) : ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.mix.{u_1} {α : Type u_1} [Fintype α] (t : ℝ) (p r : Lottery α) (ht0 : 0 ≤ t) (ht1 : t ≤ 1) : Lottery α\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.expectation_mix.{u_1} {α : Type u_1} [Fintype α] (t : ℝ) (p r : Lottery α) (f : α → ℝ) (ht0 : 0 ≤ t)\\n  (ht1 : t ≤ 1) : expectation (mix t p r ht0 ht1) f = t * expectation p f + (1 - t) * expectation r f\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.expectation_affine.{u_1} {α : Type u_1} [Fintype α] (p : Lottery α) (a b : ℝ) (u : α → ℝ) :\\n  (expectation p fun x => a * u x + b) = a * expectation p u + b\"}],\r\n",
+       " \"env\": 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check Lottery\n",
+    "#check expectation\n",
+    "#check mix\n",
+    "#check expectation_mix\n",
+    "#check expectation_affine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e13fadd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004207,
+     "end_time": "2026-06-27T08:53:09.103598+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.099391+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : l'algèbre de l'espérance\n",
+    "\n",
+    "| Symbole Lean | Lecture |\n",
+    "|-------------|---------|\n",
+    "| `Lottery α` | distribution à support fini (`probs`, `nonneg`, `sum_one`) |\n",
+    "| `expectation p f` | `∑ a, p.probs a * f a` |\n",
+    "| `mix t p r` | mélange convexe `t·p + (1-t)·r` |\n",
+    "| `expectation_mix` | `E_{mix}[f] = t·E_p[f] + (1-t)·E_r[f]` (affinité) |\n",
+    "| `expectation_affine` | `E_p[a·u+b] = a·E_p[u] + b` (unicité affine) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac38228d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004013,
+     "end_time": "2026-06-27T08:53:09.111027+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.107014+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Les quatre axiomes de rationalité de von Neumann–Morgenstern\n",
+    "\n",
+    "Le module `Utility/Axioms.lean` formalise les quatre axiomes qu'une préférence sur les\n",
+    "loteries doit satisfaire pour admettre une représentation en utilité espérée :\n",
+    "\n",
+    "- `Pref α = Lottery α → Lottery α → Prop` — une préférence (`P p q` se lit « `p` ≽ `q` »).\n",
+    "- `IsComplete P` — **complétude** : toute paire de loteries est comparable.\n",
+    "- `IsTransitive P` — **transitivité** : les chaînes de préférence ne cyclent pas.\n",
+    "- `IsIndependent P` — **indépendance (substitution)** : un mélange commun préserve la préférence.\n",
+    "- `IsContinuous P` — **continuité (Archimède)** : pas de loterie infiniment meilleure ; des mélanges intermédiaires existent.\n",
+    "- `IsRational P` — une préférence **rationnelle** satisfait les quatre axiomes (structure)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ebc86b51",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T08:53:09.119303Z",
+     "iopub.status.busy": "2026-06-27T08:53:09.119137Z",
+     "iopub.status.idle": "2026-06-27T08:53:09.333267Z",
+     "shell.execute_reply": "2026-06-27T08:53:09.332690Z"
+    },
+    "papermill": {
+     "duration": 0.219364,
+     "end_time": "2026-06-27T08:53:09.333751+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.114387+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Pref</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>Pref<span class=\"bp\">.</span>{u_2}<span class=\"w\"> </span>(α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2)<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IsComplete</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>IsComplete<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IsTransitive</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>IsTransitive<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IsIndependent</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>IsIndependent<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IsContinuous</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>IsContinuous<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IsRational</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>IsRational<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check Pref\\n#check IsComplete\\n#check IsTransitive\\n#check IsIndependent\\n#check IsContinuous\\n#check IsRational\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Utility.Pref.{u_2} (α : Type u_2) [Fintype α] : Type u_2\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsComplete.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsTransitive.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsIndependent.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsContinuous.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsRational.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"}],\r\n",
+       " \"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check Pref\n",
+       "──────▶  Utility.Pref.{u_2} (α : Type u_2) [Fintype α] : Type u_2\n",
+       "#check IsComplete\n",
+       "──────▶  Utility.IsComplete.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\n",
+       "#check IsTransitive\n",
+       "──────▶  Utility.IsTransitive.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\n",
+       "#check IsIndependent\n",
+       "──────▶  Utility.IsIndependent.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\n",
+       "#check IsContinuous\n",
+       "──────▶  Utility.IsContinuous.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\n",
+       "#check IsRational\n",
+       "──────▶  Utility.IsRational.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check Pref\\n#check IsComplete\\n#check IsTransitive\\n#check IsIndependent\\n#check IsContinuous\\n#check IsRational\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\": \"Utility.Pref.{u_2} (α : Type u_2) [Fintype α] : Type u_2\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsComplete.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsTransitive.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsIndependent.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsContinuous.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsRational.{u_1} {α : Type u_1} [Fintype α] (P : Pref α) : Prop\"}],\r\n",
+       " \"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check Pref\n",
+    "#check IsComplete\n",
+    "#check IsTransitive\n",
+    "#check IsIndependent\n",
+    "#check IsContinuous\n",
+    "#check IsRational"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe12aa94",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0048,
+     "end_time": "2026-06-27T08:53:09.344763+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.339963+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : les quatre piliers de la rationalité\n",
+    "\n",
+    "| Axiome | Lecture |\n",
+    "|--------|---------|\n",
+    "| `Pref α` | relation binaire sur les loteries (`p ≽ q`) |\n",
+    "| `IsComplete` | toute paire comparable |\n",
+    "| `IsTransitive` | `p ≽ q ≽ r ⟹ p ≽ r` |\n",
+    "| `IsIndependent` | `p ≽ q ⟹ mix t p r ≽ mix t q r` |\n",
+    "| `IsContinuous` | `p ≽ q ≽ r ⟹ ∃ t, mix t p r ~ q` (Archimède) |\n",
+    "| `IsRational` | satisfait les quatre (structure) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5833cba9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004093,
+     "end_time": "2026-06-27T08:53:09.353325+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.349232+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Le théorème de représentation : direction sound + stabilité affine\n",
+    "\n",
+    "Le module `Utility/Representation.lean` prouve la **direction sound** du théorème vNM :\n",
+    "si `u` représente `P`, alors `P` satisfait chacun des quatre axiomes (les axiomes se\n",
+    "réduisent à des faits élémentaires sur l'ordre et la structure affine de `ℝ`).\n",
+    "\n",
+    "- `IsExpectedUtilityRep u P` — `u` représente `P` : `P p q ↔ E_p[u] ≥ E_q[u]`.\n",
+    "- `rep_complete` / `rep_transitive` / `rep_independent` / `rep_continuous` — `u` représentée ⟹ chaque axiome.\n",
+    "- **`expected_utility_rep_is_rational`** (flagship) — `IsExpectedUtilityRep u P → IsRational P` (direction sound).\n",
+    "- `affine_rep_is_rep` — **stabilité affine** : `a·u + b` (`a > 0`) représente aussi `P` (unicité de l'utilité à transformation affine positive près).\n",
+    "- `rep_strict_iff` / `rep_indifference_iff` / `strict_irrefl` — préférence stricte et indifférence sous une représentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9368de8e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T08:53:09.362229Z",
+     "iopub.status.busy": "2026-06-27T08:53:09.362068Z",
+     "iopub.status.idle": "2026-06-27T08:53:09.582056Z",
+     "shell.execute_reply": "2026-06-27T08:53:09.581021Z"
+    },
+    "papermill": {
+     "duration": 0.225801,
+     "end_time": "2026-06-27T08:53:09.582650+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.356849+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IsExpectedUtilityRep</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>IsExpectedUtilityRep<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(u<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>rep_complete</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>rep_complete<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(u<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>IsExpectedUtilityRep<span class=\"w\"> </span>u<span class=\"w\"> </span>P)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>Utility<span class=\"bp\">.</span>IsComplete<span class=\"w\"> </span>P</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>rep_independent</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>rep_independent<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(u<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>IsExpectedUtilityRep<span class=\"w\"> </span>u<span class=\"w\"> </span>P)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>IsIndependent<span class=\"w\"> </span>P</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>expected_utility_rep_is_rational</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>expected_utility_rep_is_rational<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(u<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)\n",
+       "<span class=\"w\">  </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>IsExpectedUtilityRep<span class=\"w\"> </span>u<span class=\"w\"> </span>P)<span class=\"w\"> </span>:<span class=\"w\"> </span>IsRational<span class=\"w\"> </span>P</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>affine_rep_is_rep</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>affine_rep_is_rep<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(u<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>IsExpectedUtilityRep<span class=\"w\"> </span>u<span class=\"w\"> </span>P)\n",
+       "<span class=\"w\">  </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>a)<span class=\"w\"> </span>(b<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>:<span class=\"w\"> </span>IsExpectedUtilityRep<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>u<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>P</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>rep_strict_iff</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Utility<span class=\"bp\">.</span>rep_strict_iff<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>α]<span class=\"w\"> </span>(u<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ)<span class=\"w\"> </span>(P<span class=\"w\"> </span>:<span class=\"w\"> </span>Pref<span class=\"w\"> </span>α)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>IsExpectedUtilityRep<span class=\"w\"> </span>u<span class=\"w\"> </span>P)\n",
+       "<span class=\"w\">  </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span>Lottery<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>StrictPref<span class=\"w\"> </span>P<span class=\"w\"> </span>p<span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>expectation<span class=\"w\"> </span>p<span class=\"w\"> </span>u<span class=\"w\"> </span><span class=\"bp\">&gt;</span><span class=\"w\"> </span>expectation<span class=\"w\"> </span>q<span class=\"w\"> </span>u</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check IsExpectedUtilityRep\\n#check rep_complete\\n#check rep_independent\\n#check expected_utility_rep_is_rational\\n#check affine_rep_is_rep\\n#check rep_strict_iff\", \"env\": 3}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsExpectedUtilityRep.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.rep_complete.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P) :\\n  Utility.IsComplete P\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.rep_independent.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P) :\\n  IsIndependent P\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.expected_utility_rep_is_rational.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α)\\n  (h : IsExpectedUtilityRep u P) : IsRational P\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.affine_rep_is_rep.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)\\n  (a : ℝ) (ha : 0 < a) (b : ℝ) : IsExpectedUtilityRep (fun x => a * u x + b) P\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.rep_strict_iff.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)\\n  (p q : Lottery α) : StrictPref P p q ↔ expectation p u > expectation q u\"}],\r\n",
+       " \"env\": 4}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "#check IsExpectedUtilityRep\n",
+       "──────▶  Utility.IsExpectedUtilityRep.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) : Prop\n",
+       "#check rep_complete\n",
+       "──────▶  Utility.rep_complete.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P) :\n",
+       "  Utility.IsComplete P\n",
+       "#check rep_independent\n",
+       "──────▶  Utility.rep_independent.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P) :\n",
+       "  IsIndependent P\n",
+       "#check expected_utility_rep_is_rational\n",
+       "──────▶  Utility.expected_utility_rep_is_rational.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α)\n",
+       "  (h : IsExpectedUtilityRep u P) : IsRational P\n",
+       "#check affine_rep_is_rep\n",
+       "──────▶  Utility.affine_rep_is_rep.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)\n",
+       "  (a : ℝ) (ha : 0 < a) (b : ℝ) : IsExpectedUtilityRep (fun x => a * u x + b) P\n",
+       "#check rep_strict_iff\n",
+       "──────▶  Utility.rep_strict_iff.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)\n",
+       "  (p q : Lottery α) : StrictPref P p q ↔ expectation p u > expectation q u\n",
+       "--% env 4\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"#check IsExpectedUtilityRep\\n#check rep_complete\\n#check rep_independent\\n#check expected_utility_rep_is_rational\\n#check affine_rep_is_rep\\n#check rep_strict_iff\", \"env\": 3}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 1, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 1, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.IsExpectedUtilityRep.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) : Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.rep_complete.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P) :\\n  Utility.IsComplete P\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.rep_independent.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P) :\\n  IsIndependent P\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.expected_utility_rep_is_rational.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α)\\n  (h : IsExpectedUtilityRep u P) : IsRational P\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.affine_rep_is_rep.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)\\n  (a : ℝ) (ha : 0 < a) (b : ℝ) : IsExpectedUtilityRep (fun x => a * u x + b) P\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Utility.rep_strict_iff.{u_1} {α : Type u_1} [Fintype α] (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)\\n  (p q : Lottery α) : StrictPref P p q ↔ expectation p u > expectation q u\"}],\r\n",
+       " \"env\": 4}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check IsExpectedUtilityRep\n",
+    "#check rep_complete\n",
+    "#check rep_independent\n",
+    "#check expected_utility_rep_is_rational\n",
+    "#check affine_rep_is_rep\n",
+    "#check rep_strict_iff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ca27e4b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005307,
+     "end_time": "2026-06-27T08:53:09.594044+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.588737+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : la direction sound, prouvée entièrement\n",
+    "\n",
+    "| Théorème | Conclusion |\n",
+    "|----------|-----------|\n",
+    "| `expected_utility_rep_is_rational` | représentation ⟹ rationalité (sound, flagship) |\n",
+    "| `affine_rep_is_rep` | `a·u + b` (`a>0`) représente aussi `P` (unicité affine) |\n",
+    "| `rep_strict_iff` | `p ≻ q ⟺ E_p[u] > E_q[u]` |\n",
+    "| `rep_indifference_iff` | `p ~ q ⟺ E_p[u] = E_q[u]` |\n",
+    "\n",
+    "### Le jalon laissé ouvert (honnêtement)\n",
+    "\n",
+    "La **réciproque** — toute préférence rationnelle admet une représentation en utilité\n",
+    "espérée — est la moitié **substantielle** du théorème vNM (Herstein & Milnor, 1953). Elle\n",
+    "exige un argument de séparation / algèbre linéaire non trivial, et est laissée comme\n",
+    "jalon suivant, délibérément **non `sorry`-backed** : la lib reste entièrement sorry-free.\n",
+    "Seules les **différences** d'utilité (pas les niveaux) sont identifiées par les données\n",
+    "de choix — c'est l'unicité affine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec40e48c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005332,
+     "end_time": "2026-06-27T08:53:09.604302+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.598970+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. La chaîne causale complète\n",
+    "\n",
+    "Les trois modules composent une chaîne unique, des loteries à la rationalité :\n",
+    "\n",
+    "1. **`Basic`** — `Lottery`/`expectation`/`mix` + `expectation_mix`/`expectation_affine` (l'algèbre affine de l'espérance).\n",
+    "2. **`Axioms`** — `Pref`/les 4 axiomes/`IsRational` (le cadre de la rationalité).\n",
+    "3. **`Representation`** — `IsExpectedUtilityRep` ⟶ les 4 axiomes sous représentation ⟶ flagship `expected_utility_rep_is_rational` + stabilité affine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92be5b63",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004771,
+     "end_time": "2026-06-27T08:53:09.613820+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.609049+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Exemple guidé et exercices\n",
+    "\n",
+    "### Exercice 1 — Loteries, mélange et espérance (Python)\n",
+    "\n",
+    "Ancrez l'intuition : une loterie = dictionnaire `{issue: probabilité}` sommant à 1.\n",
+    "Implémentez `expectation` (utilité espérée) et `mix` (mélange convexe), puis vérifiez\n",
+    "que l'espérance est affine sous le mélange.\n",
+    "\n",
+    "```python\n",
+    "def expectation(lottery, utility):\n",
+    "    # Esperance de la fonction d'utilite sous la loterie\n",
+    "    # lottery : {issue: prob}, utility : {issue: float}\n",
+    "    # TODO etudiant : somme des prob * utility\n",
+    "    return None  # TODO\n",
+    "\n",
+    "def mix(t, lottery_p, lottery_r):\n",
+    "    # Mélange convexe t*p + (1-t)*r (t dans [0,1])\n",
+    "    # TODO etudiant : pour chaque issue, t*proba_p + (1-t)*proba_r\n",
+    "    return None  # TODO\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "939c955f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004653,
+     "end_time": "2026-06-27T08:53:09.622729+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.618076+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Une préférence représentée est transitive (Lean)\n",
+    "\n",
+    "Prouvez la transitivité d'une préférence représentée, **sans** utiliser `rep_transitive`.\n",
+    "Indice : sous une représentation, `P p q ⟺ E_p[u] ≥ E_q[u]`. La transitivité suit de\n",
+    "celle de `≥` sur `ℝ` (`linarith` avec les deux hypothèses décantées).\n",
+    "\n",
+    "```lean\n",
+    "-- TODO etudiant : remplacer le sorry\n",
+    "-- example (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)\n",
+    "--     (p q r : Lottery α) (hpq : P p q) (hqr : P q r) : P p r := by\n",
+    "--   sorry\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "441f4cee",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004901,
+     "end_time": "2026-06-27T08:53:09.632995+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.628094+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Pourquoi l'utilité est unique à transformation affine près (Python)\n",
+    "\n",
+    "Illustrez la stabilité affine (`affine_rep_is_rep`). Si `u` représente `P`, alors `a·u + b`\n",
+    "(`a > 0`) représente **aussi** `P` : le classement des loteries par espérance est invariant.\n",
+    "Implémentez la transformation et vérifiez que l'**ordre** des loteries est préservé\n",
+    "(mais pas les valeurs absolues — d'où le fait que seules les **différences** d'utilité\n",
+    "sont identifiées par les données de choix).\n",
+    "\n",
+    "```python\n",
+    "def affine_transform(u, a, b):\n",
+    "    # Transformee affine a*u + b (a > 0)\n",
+    "    # TODO etudiant : retourner {issue: a*val + b}\n",
+    "    return None  # TODO\n",
+    "\n",
+    "def preserves_order(lottery_p, lottery_q, u, a, b):\n",
+    "    # Si E_p[u] >= E_q[u] alors E_p[a*u+b] >= E_q[a*u+b] ?\n",
+    "    # TODO etudiant : verifier la preservation de l'ordre (a > 0)\n",
+    "    return None  # TODO\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24f5cfbd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005087,
+     "end_time": "2026-06-27T08:53:09.643075+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T08:53:09.637988+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce companion **natif** exhibe la preuve formelle 0-sorry de la direction sound du\n",
+    "théorème de représentation d'utilité espérée de von Neumann–Morgenstern dans le kernel\n",
+    "Lean lui-même : `#check` et `#print axioms` rendent les signatures et les axiomes réels\n",
+    "produits par le compilateur, sans intermédiaire Python.\n",
+    "\n",
+    "Le résultat phare `expected_utility_rep_is_rational` fonde le classement par espérance\n",
+    "d'utilité : toute préférence qu'une utilité représente est rationnelle. Combinée à la\n",
+    "stabilité affine (`affine_rep_is_rep`), c'est la justification formelle de pourquoi\n",
+    "Infer-14 et PyMC-14 rangent les décisions par espérance d'utilité, et pourquoi seules\n",
+    "les **différences** d'utilité (et non les niveaux) sont identifiées.\n",
+    "\n",
+    "**Jalon ouvert** : la réciproque (existence d'une représentation pour toute préférence\n",
+    "rationnelle, Herstein–Milnor 1953) n'est pas formalisée ; la lib reste sorry-free."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Lean 4 (WSL)",
+   "language": "lean4",
+   "name": "lean4-wsl"
+  },
+  "language_info": {
+   "codemirror_mode": "python",
+   "file_extension": ".lean",
+   "mimetype": "text/x-lean4",
+   "name": "lean4"
+  },
+  "papermill": {
+   "duration": 270.377482,
+   "end_time": "2026-06-27T08:53:10.268914+00:00",
+   "exception": null,
+   "input_path": "Infer-14b-Lean-ExpectedUtility.ipynb",
+   "output_path": "Infer-14b-Lean-ExpectedUtility.ipynb",
+   "start_time": "2026-06-27T08:48:39.891432+00:00"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -62,6 +62,7 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 | 12 | [Infer-12-Recommenders](Infer-12-Recommenders.ipynb) | 60 min | Factorisation, Click Model |
 | 13 | [Infer-13-Debugging](Infer-13-Debugging.ipynb) | 45 min | Troubleshooting, diagnostics, algorithmes |
 | 14 | [Infer-14-Decision-Utility-Foundations](Infer-14-Decision-Utility-Foundations.ipynb) | 50 min | Loteries, axiomes VNM, utilité espérée |
+| 14b | [Infer-14b-Lean-ExpectedUtility](Infer-14b-Lean-ExpectedUtility.ipynb) | 45 min | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la direction sound du théorème vNM (représentation ⟹ rationalité) dans le lake `decision_theory_lean` (lib `Utility`), `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) |
 | 15 | [Infer-15-Decision-Utility-Money](Infer-15-Decision-Utility-Money.ipynb) | 45 min | Paradoxe St-Petersbourg, CARA, CRRA |
 | 16 | [Infer-16-Decision-Multi-Attribute](Infer-16-Decision-Multi-Attribute.ipynb) | 50 min | MAUT, SMART, swing weights |
 | 17 | [Infer-17-Decision-Networks](Infer-17-Decision-Networks.ipynb) | 55 min | Diagrammes d'influence, politique optimale |


### PR DESCRIPTION
## Summary

**Infer-14b-Lean-ExpectedUtility.ipynb** — the **pur-Lean native** companion for the lake [`decision_theory_lean`](../decision_theory_lean/) (lib `Utility`: von Neumann–Morgenstern expected-utility representation, **sound direction** — representation ⟹ rationality, **0 sorry**). This is the format the user mandates: a notebook Lean natif lisible, NOT the #4386 Python→Lean companion that shells `lake env lean` and manipulates strings.

This is the **6th and final native companion** (after #4393 sensitivity, #4397 minimax, #4399 argumentation, #4400 planning, #4402 sudoku), proving the UNLOCK (#4390, merged) is reproducible across **all** the lakes of the roadmap (#4038). It **supersedes the python3 #4386** in format (closes #4386). With it, the python3→pur-Lean-native migration of all six companions is complete.

| Route | Notebook | Method |
|-------|----------|--------|
| Computation (existing) | Infer-14 (Infer.NET / Python) | Bayesian expected utility under posterior uncertainty |
| Companion (this PR) | **Infer-14b (native Lean)** | **kernel `lean4-wsl`, `import Utility.*` + `#check` + `#print axioms` rendered in-kernel** |

## What the notebook shows (real Lean, zero Python)

5 code cells, kernel `lean4-wsl`:

- `import Utility.{Basic,Axioms,Representation}` `open Utility` → OK (3 submodules; `roots := #[`Utility]` does not build the root umbrella `Utility.olean`)
- `#print axioms expected_utility_rep_is_rational` → **[propext, Classical.choice, Quot.sound]** (0 sorry)
- `#check Lottery`/`expectation`/`mix`/`expectation_mix`/`expectation_affine` (module `Basic`: lotteries, expected value, convex mixtures, affine identities)
- `#check Pref`/`IsComplete`/`IsTransitive`/`IsIndependent`/`IsContinuous`/`IsRational` (module `Axioms`: the four vNM axioms + `IsRational` structure)
- `#check IsExpectedUtilityRep`/`rep_complete`/`rep_independent`/`expected_utility_rep_is_rational` (flagship sound direction) / `affine_rep_is_rep` (affine stability) / `rep_strict_iff`
- Pedagogical arc faithful to #4386: Basic → Axioms → Representation (sound + affine stability) → causal chain → 3 exercises (markdown pseudo-code stubs, C.1)

## Why native and not the #4386 python3 companion

PR #4386 (python3 + `lake env lean --stdin`) is *honest* but the user finds a "Python→Lean companion that loads the lake and manipulates countless strings" **hard to read**. This PR delivers the proof exhibited **in the Lean kernel itself** — `#check` and `#print axioms` render the real compiler output in-kernel, no string manipulation.

## Verification (C.2, executed WITH outputs, 5/5 code cells, 0 errors)

| Check | Result |
|-------|--------|
| `lake build Utility` | **SUCCESS** (exit=0, Mathlib full compile 8323 files) |
| Papermill execute (lean4-wsl kernel) | **5/5 code cells, 0 errors, 0 cells without output** (duration ~270s, import cell 11.9s = oleans warm from build) |
| Native `#check` | pillar signatures rendered in-kernel (Lottery, expectation, mix, IsExpectedUtilityRep, flagship expected_utility_rep_is_rational) |
| `#print axioms` | `expected_utility_rep_is_rational`/`affine_rep_is_rep`/`rep_strict_iff` **[propext, Classical.choice, Quot.sound]** (0 sorry) |
| C.1 (no voluntary error) | 0 `raise NotImplementedError`/`assert False`/`1/0` |
| sorry count (lake sources, COMPLETE tactic-pattern) | 0 (lean-merge-discipline) |
| `metadata.papermill.input/output_path` | normalized to basename (metadata-only, C.2-exempt) |

**Execution note**: run the notebook from the `decision_theory_lean/` directory (papermill `--cwd <decision_theory_lean>` + `--start-timeout 300`).

## Build note — isolated mathlib rev (firsthand diagnosed, Rule F)

Unlike the 5 prior native lakes (which share cached mathlib rev `1c1dadbc` rc2 / `d568c8c0` rc1 via NTFS junction = instant), `decision_theory_lean` requires mathlib @ **isolated rev `5450b53e`** (group `[isole]` in `setup_shared_mathlib.ps1 -Scan`, no shared cache, `lake exe cache get` pulls 0 oleans). So `lake build Utility` compiles Mathlib **from scratch** (~5h, 8323 files). Additionally, the mathlib checkout was **dirty** (HEAD `571b8a8e` ≠ required `5450b53e` + 18 untracked + staged deletions → `lake build` failed `git checkout`). Fixed firsthand: `git checkout -f 5450b53e && git clean -fd` (clean), then build. `roots := #[`Utility]` does NOT build the root umbrella → import the 3 submodules directly (noted in the notebook). This is non-invasive (respects the lakefile source of truth); the alternative (align manifest → `1c1dadbc`, junctionable instantly) would touch `lakefile.lean` and require re-proving Utility 0 sorry.

## Dependency: REQUIRES the UNLOCK (#4390, MERGED) to run natively

The notebook is a *lean4-wsl* kernel that imports a Mathlib lake — works only with PR #4390's `lean4_jupyter/repl.py` patch + matched repl (`repl-4.30.0-rc2`, rc2 toolchain) + wrapper v6. **#4390 is MERGED**. The rc1-TIMEOUT gotcha (c.129) does not apply here (rc2 + warm oleans from a prior build → import cell ~12s).

Durability: the repl.py patch is a pip-package edit (lost on `pip install`); #4394 tracks the durable fork/PR upstream.

## Atomicity

Single-subject PR (one new companion notebook + 1 README nav line `14b`). Docs-only on the lake (0 `.lean` touched). Fresh base from `origin/main` (0 behind / 0 ahead at push). Staging explicit (`git add <notebook> <README>`), pre-existing mods excluded.

Closes #4386 (supersedes the python3 companion in format). See #4390 (UNLOCK, merged), See #4393 (1st) + #4397 (2nd) + #4399 (3rd) + #4400 (4th) + #4402 (5th — the proven patterns), See #4394 (durable fork follow-up), See #4046/#4038 (lake roadmap), See #2611 (Mathlib junction).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
