### PR TITLE
fix(lean): bump native-import LEAN_PATH capture timeout 60->240 (RC1-TIMEOUT)

### DIFF
--- a/scripts/lean/setup_native_lean4_import.py
+++ b/scripts/lean/setup_native_lean4_import.py
@@ -99,7 +99,12 @@ REPL_PY_PATCH = '''    @staticmethod
                 out = _sp.run(
                     ['lake', 'env', 'python3', '-c',
                      'import os; print(os.environ.get("LEAN_PATH",""))'],
-                    capture_output=True, text=True, timeout=60, cwd=lake_root,
+                    # timeout=240 (not 60): on rc1 lakes whose Mathlib is an NTFS
+                    # junction, `lake env` re-verifies the junction ("has local
+                    # changes") and takes ~111-125s (measured c.129). timeout=60
+                    # tripped RC1-TIMEOUT -> empty LEAN_PATH -> broken `lake env
+                    # repl` fallback -> silent kernel failure. 240s = ~2x margin.
+                    capture_output=True, text=True, timeout=240, cwd=lake_root,
                     env={**os.environ,
                          'PATH': os.path.expanduser('~/.elan/bin') + ':/usr/local/bin:/usr/bin:/bin'}
                 ).stdout


### PR DESCRIPTION
## Summary

Durable repo-side fix for the **RC1-TIMEOUT** gotcha that blocked native lean4-wsl kernel imports on rc1 lakes (firsthand diagnosed cycle 129). Bumps the LEAN_PATH-capture timeout in the patched `repl.py` template from `60` → `240` seconds.

This is the **standing tiny PR** ai-01 queued as step 1 of the native-track follow-up (msg-cav4uf: « 1. Bump installer 240s ... tiny PR, JAMAIS mixé dans une PR contenu »), explicitly prioritized *before* the #3846 Hashlife lane.

## Root cause (firsthand, c.129)

The patched `repl.py` `launch()` captures `LEAN_PATH` by running:

```python
_sp.run(['lake', 'env', 'python3', '-c',
         'import os; print(os.environ.get("LEAN_PATH",""))'],
        capture_output=True, text=True, timeout=60, cwd=lake_root, ...)
```

On **rc1 lakes whose Mathlib is an NTFS junction** (#2611 mutualisation), `lake env` detects the junction as "has local changes" and **re-verifies** it. Measured firsthand on `minimax_lean` (c.129): **~111–125s**. With `timeout=60`, this:

1. raises `TimeoutExpired` inside the `try` block,
2. which the bare `except Exception: pass` swallows,
3. so `lean_path` is never set, and `launch()` falls through to the broken `pexpect.spawn("lake env repl")` fallback,
4. which clobbers the REPL sysroot → native Mathlib import **silently broken**.

This was the exact failure on `minimax_lean` (c.129, took 4 debug iterations) and was the reason a live `timeout=240` patch was applied in-place to the pip package (lost on every `pip install`).

## Fix

`timeout=240` in the `REPL_PY_PATCHED` template — ~2× margin over the observed 111–125s ceiling. The template is the body the setup script writes into the patched `repl.py`, so freshly-patched instances are now correct without manual editing.

```diff
-                    capture_output=True, text=True, timeout=60, cwd=lake_root,
+                    # timeout=240 (not 60): rc1 lakes with NTFS-junctioned Mathlib
+                    # re-verify the junction (~111-125s, measured c.129). timeout=60
+                    # tripped RC1-TIMEOUT -> broken `lake env repl` fallback.
+                    capture_output=True, text=True, timeout=240, cwd=lake_root,
```

## Scope

| Aspect | Status |
|--------|--------|
| Files changed | 1 (`scripts/lean/setup_native_lean4_import.py`) |
| Lines | +6 / -1 |
| `.lean` / notebook touched | **No** (infra-only, atomic) |
| Python syntax | ✅ `py_compile` OK |
| Durable | ✅ repo script (PR #4390), not the pip package |

**Known limitation (documented, not fixed here).** `PATCH_MARKER` is `_find_lake_root` (unversioned), so an **already-patched** `repl.py` (carrying the old `timeout=60`) is detected as PATCHED and re-running `patch` will not refresh its body. To pick up the fix on an existing WSL kernel:
```
python scripts/lean/setup_native_lean4_import.py restore && \
python scripts/lean/setup_native_lean4_import.py patch
```
Versioning the marker to force a refresh is a reasonable follow-up but out of scope for this atomic 1-line fix.

## Why this matters now

The native companion track (6/6 complete, #4393–#4410) proved the UNLOCK reproducible across all lakes #4038. The 240s fix hardens that pipeline for **future** lakes added to the roadmap (#4038) — without it, every new rc1 lake re-trips the silent RC1-TIMEOUT and costs a debug cycle.

## Verification

- `python3 -m py_compile scripts/lean/setup_native_lean4_import.py` → **OK** (template string remains valid Python).
- Confirmed `timeout=60` is gone from the `REPL_PY_PATCHED` template (only remaining occurrence is inside the explanatory comment).
- L224 `timeout=600` (the patch-application `_wsl` call) is a separate, already-generous timeout — intentionally untouched.

See #4390 (UNLOCK), See #4394 (durable lean4_jupyter fork upstream — a *separate* concern: upstreaming the repl.py patch itself, not this timeout). Standing task ai-01 msg-cav4uf step 1.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
