### PR TITLE
chore: gitignore SymbolicAI notebook execution artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -451,6 +451,15 @@ MyIA.AI.Notebooks/GenAI/Audio/04-Applications/voice_casting_output/*.wav
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/benchmark_output/*.mp3
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/benchmark_output/*.wav
 
+# SymbolicAI notebook execution artifacts (regenerable, kept local, not committed)
+# Generated on notebook execution (matplotlib savefig / pyvis save). They are NOT
+# displayed inline nor embedded in committed cell outputs, so versioning them is
+# unnecessary. They were removed as "stray files" 3 times (9f7aaff77, 6eac572b2,
+# b22c0e3f9) and keep reappearing on re-execution; gitignoring is the durable fix.
+MyIA.AI.Notebooks/SymbolicAI/Lean/signing_matrix_A4.png
+MyIA.AI.Notebooks/SymbolicAI/Lean/hypercube_q3.png
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/output_kg_recent.html
+
 # Tweety runtime dependencies (downloaded by notebook)
 # Note: Les binaires PRECIEUX sont maintenant versionnés (voir exceptions positives ci-dessous)
 MyIA.AI.Notebooks/SymbolicAI/resources/


### PR DESCRIPTION
## Summary

Gitignore 3 untracked files that pollute `git status` and are not needed in version control:
- `MyIA.AI.Notebooks/SymbolicAI/Lean/signing_matrix_A4.png` (Lean-12, matplotlib `savefig`)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/hypercube_q3.png` (Lean-12, matplotlib `savefig`)
- `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/output_kg_recent.html` (SW-11, pyvis Exercice 6)

## Why gitignore (and not commit)

An earlier diagnosis ("notebooks broken — missing assets") was **wrong**, verified against source (G.1):
- The references are `plt.savefig(...)` / pyvis `save` calls + one `stdout` line — **not** `display(Image(...))`, not `IFrame(...)`, not markdown `![](...)`, and **not embedded in any committed cell output**. The notebooks render fine without these files.
- The two PNGs were **deliberately removed as "stray files" 3 times** (`9f7aaff77`, `6eac572b2`, `b22c0e3f9`); the HTML was **never tracked**. Committing them would revert that decision.
- They regenerate on every notebook execution, so they keep reappearing. Gitignoring the specific paths is the durable fix.

## Scope

- Adds 9 lines to `.gitignore` under a new `# SymbolicAI notebook execution artifacts` section (same pattern as the existing `# GenAI Audio - generated outputs` block).
- **No blanket `*.png`** — 1620 PNGs are intentionally tracked elsewhere in the repo. Only these 3 specific paths are ignored.
- Does not touch the catalog, notebooks, or any other file.

## Verification

```
$ git check-ignore <each of the 3 files>   # → IGNORED (all 3)
$ git status -s                              # → only .gitignore modified
$ git diff --stat                            # → .gitignore | 9 +++++++++ (1 file)
```

Base fresh from `origin/main` (0/0 ahead/behind). No issue to close (chore).
