### PR TITLE
fix(qc): normalize papermill metadata paths to basename (46 notebooks) (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/ML-Research-Template.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/ML-Research-Template.ipynb
@@ -856,7 +856,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "ML-Research-Template.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/ml-research-template-test.ipynb",
+   "output_path": "ML-Research-Template.ipynb",
    "parameters": {},
    "start_time": "2026-05-16T15:57:32.022418+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m11e_ensemble_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m11e_ensemble_research.ipynb
@@ -658,8 +658,8 @@
    "end_time": "2026-06-17T23:26:57.776992+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m11e_ensemble_research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m11e_ensemble_research_output.ipynb",
+   "input_path": "m11e_ensemble_research.ipynb",
+   "output_path": "m11e_ensemble_research.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T23:26:52.885499+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m12_har_rv_j_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m12_har_rv_j_research.ipynb
@@ -536,8 +536,8 @@
    "end_time": "2026-06-17T18:32:04.248598+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m12_har_rv_j_research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m12_har_rv_j_research_output.ipynb",
+   "input_path": "m12_har_rv_j_research.ipynb",
+   "output_path": "m12_har_rv_j_research.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T18:32:00.383282+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m15_lstm_rv_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m15_lstm_rv_research.ipynb
@@ -555,8 +555,8 @@
    "end_time": "2026-06-17T19:27:41.975808+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m15_lstm_rv_research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m15_lstm_rv_research_output.ipynb",
+   "input_path": "m15_lstm_rv_research.ipynb",
+   "output_path": "m15_lstm_rv_research.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T19:27:38.161894+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m4_dlinear_vol_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m4_dlinear_vol_research.ipynb
@@ -471,8 +471,8 @@
    "end_time": "2026-06-17T20:30:31.998740+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m4_dlinear_vol_research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m4_dlinear_vol_research_output.ipynb",
+   "input_path": "m4_dlinear_vol_research.ipynb",
+   "output_path": "m4_dlinear_vol_research.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T20:30:27.576093+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m5_hmm_regime_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m5_hmm_regime_research.ipynb
@@ -621,8 +621,8 @@
    "end_time": "2026-06-17T22:31:23.778456+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m5_hmm_regime_research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m5_hmm_regime_research_output.ipynb",
+   "input_path": "m5_hmm_regime_research.ipynb",
+   "output_path": "m5_hmm_regime_research.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T22:31:19.809441+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m9_tft_vol_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m9_tft_vol_research.ipynb
@@ -593,8 +593,8 @@
    "end_time": "2026-06-17T21:30:03.615664+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m9_tft_vol_research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\m9_tft_vol_research_output.ipynb",
+   "input_path": "m9_tft_vol_research.ipynb",
+   "output_path": "m9_tft_vol_research.ipynb",
    "parameters": {},
    "start_time": "2026-06-17T21:30:00.029565+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
@@ -666,8 +666,8 @@
    "end_time": "2026-05-26T13:39:46.006717+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "c:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\research_l4_decision_transformer.ipynb",
-   "output_path": "c:/dev/CoursIA/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb",
+   "input_path": "research_l4_decision_transformer.ipynb",
+   "output_path": "research_l4_decision_transformer.ipynb",
    "parameters": {},
    "start_time": "2026-05-26T13:39:39.891890+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
@@ -4404,8 +4404,8 @@
    "end_time": "2026-05-12T23:13:39.672380",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-18-ML-Features-Engineering.ipynb",
-   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-18-ML-Features-Engineering_output.ipynb",
+   "input_path": "QC-Py-18-ML-Features-Engineering.ipynb",
+   "output_path": "QC-Py-18-ML-Features-Engineering.ipynb",
    "parameters": {},
    "start_time": "2026-05-12T23:13:30.936864",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
@@ -2105,8 +2105,8 @@
    "end_time": "2026-04-30T14:09:46.664673",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-32-RL-DQN-Trading.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-32-RL-DQN-Trading_output.ipynb",
+   "input_path": "QC-Py-32-RL-DQN-Trading.ipynb",
+   "output_path": "QC-Py-32-RL-DQN-Trading.ipynb",
    "parameters": {},
    "start_time": "2026-04-30T14:00:59.807623",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
@@ -2135,8 +2135,8 @@
    "end_time": "2026-06-18T03:48:04.721368+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-33-RL-PPO-Trading.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-33-RL-PPO-Trading_output.ipynb",
+   "input_path": "QC-Py-33-RL-PPO-Trading.ipynb",
+   "output_path": "QC-Py-33-RL-PPO-Trading.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
@@ -1076,8 +1076,8 @@
    "end_time": "2026-04-28T17:28:01.166349",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-40-PaperTrading-Binance.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-40-PaperTrading-Binance_output.ipynb",
+   "input_path": "QC-Py-40-PaperTrading-Binance.ipynb",
+   "output_path": "QC-Py-40-PaperTrading-Binance.ipynb",
    "parameters": {},
    "start_time": "2026-04-28T17:27:58.766585",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
@@ -1011,8 +1011,8 @@
    "end_time": "2026-04-28T17:29:30.673906",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-41-PaperTrading-IBKR.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-41-PaperTrading-IBKR_output.ipynb",
+   "input_path": "QC-Py-41-PaperTrading-IBKR.ipynb",
+   "output_path": "QC-Py-41-PaperTrading-IBKR.ipynb",
    "parameters": {},
    "start_time": "2026-04-28T17:29:27.588159",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
@@ -1146,8 +1146,8 @@
    "end_time": "2026-05-12T23:47:43.074843",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-01-FinBERT-Sentiment.ipynb",
-   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-01-FinBERT-Sentiment_output.ipynb",
+   "input_path": "QC-Py-Cloud-01-FinBERT-Sentiment.ipynb",
+   "output_path": "QC-Py-Cloud-01-FinBERT-Sentiment.ipynb",
    "parameters": {},
    "start_time": "2026-05-12T23:47:40.988413",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-ML-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-ML-Classification.ipynb
@@ -725,8 +725,8 @@
    "end_time": "2026-04-28T16:10:23.159089",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-02-ML-Classification.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-02-ML-Classification_output.ipynb",
+   "input_path": "QC-Py-Cloud-02-ML-Classification.ipynb",
+   "output_path": "QC-Py-Cloud-02-ML-Classification.ipynb",
    "parameters": {},
    "start_time": "2026-04-28T16:10:17.781688",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-DualMomentum.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-DualMomentum.ipynb
@@ -533,8 +533,8 @@
    "end_time": "2026-06-11T23:38:12.120280+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-03-DualMomentum.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-03-DualMomentum_output.ipynb",
+   "input_path": "QC-Py-Cloud-03-DualMomentum.ipynb",
+   "output_path": "QC-Py-Cloud-03-DualMomentum.ipynb",
    "parameters": {},
    "start_time": "2026-06-11T23:38:08.553085+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb
@@ -894,8 +894,8 @@
    "end_time": "2026-06-12T02:48:07.277471+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-03-Risk-Parity.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-03-Risk-Parity_output.ipynb",
+   "input_path": "QC-Py-Cloud-03-Risk-Parity.ipynb",
+   "output_path": "QC-Py-Cloud-03-Risk-Parity.ipynb",
    "parameters": {},
    "start_time": "2026-06-12T02:48:00.739864+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb
@@ -803,8 +803,8 @@
    "end_time": "2026-04-28T16:10:55.534683",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-04-RL-DQN-Trading.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-04-RL-DQN-Trading_output.ipynb",
+   "input_path": "QC-Py-Cloud-04-RL-DQN-Trading.ipynb",
+   "output_path": "QC-Py-Cloud-04-RL-DQN-Trading.ipynb",
    "parameters": {},
    "start_time": "2026-04-28T16:10:54.126976",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb
@@ -705,8 +705,8 @@
    "end_time": "2026-04-28T16:11:08.670998",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-05-MLP-Forecasting.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\Python\\QC-Py-Cloud-05-MLP-Forecasting_output.ipynb",
+   "input_path": "QC-Py-Cloud-05-MLP-Forecasting.ipynb",
+   "output_path": "QC-Py-Cloud-05-MLP-Forecasting.ipynb",
    "parameters": {},
    "start_time": "2026-04-28T16:11:06.735090",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/deep_research_optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/deep_research_optimization.ipynb
@@ -692,8 +692,8 @@
    "end_time": "2026-04-23T16:45:28.638234",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ESGF-2026\\examples\\Sector-Momentum\\deep_research_optimization.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ESGF-2026\\examples\\Sector-Momentum\\deep_research_optimization_output.ipynb",
+   "input_path": "deep_research_optimization.ipynb",
+   "output_path": "deep_research_optimization.ipynb",
    "parameters": {},
    "start_time": "2026-04-23T16:45:07.004241",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/research_robustness.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/research_robustness.ipynb
@@ -1224,8 +1224,8 @@
    "end_time": "2026-04-23T16:14:52.044922",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ESGF-2026\\examples\\Sector-Momentum\\research_robustness.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ESGF-2026\\examples\\Sector-Momentum\\research_robustness_output.ipynb",
+   "input_path": "research_robustness.ipynb",
+   "output_path": "research_robustness.ipynb",
    "parameters": {},
    "start_time": "2026-04-23T16:14:35.962773",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Alpha-Correlation-Analysis/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Alpha-Correlation-Analysis/quantbook.ipynb
@@ -1801,8 +1801,8 @@
    "end_time": "2026-06-01T00:17:45.773117+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Alpha-Correlation-Analysis\\quantbook.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Alpha-Correlation-Analysis\\quantbook_output.ipynb",
+   "input_path": "quantbook.ipynb",
+   "output_path": "quantbook.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T00:17:38.036244+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-EMA-Cross/research_robustness.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-EMA-Cross/research_robustness.ipynb
@@ -1006,8 +1006,8 @@
    "end_time": "2026-06-01T00:01:09.762757+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\CSharp-BTC-EMA-Cross\\research_robustness.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\CSharp-BTC-EMA-Cross\\research_robustness_output.ipynb",
+   "input_path": "research_robustness.ipynb",
+   "output_path": "research_robustness.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T00:01:03.344887+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/research_robustness.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/research_robustness.ipynb
@@ -977,8 +977,8 @@
    "end_time": "2026-05-31T23:31:35.400795+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\CSharp-CTG-Momentum\\research_robustness.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\CSharp-CTG-Momentum\\research_robustness_output.ipynb",
+   "input_path": "research_robustness.ipynb",
+   "output_path": "research_robustness.ipynb",
    "parameters": {},
    "start_time": "2026-05-31T23:31:26.986869+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-LSTM-Prediction/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-LSTM-Prediction/research.ipynb
@@ -1287,8 +1287,8 @@
    "end_time": "2026-05-11T21:20:57.131460+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Crypto-LSTM-Prediction\\research.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Crypto-LSTM-Prediction\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-11T21:12:47.988371+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC/research.ipynb
@@ -1468,8 +1468,8 @@
    "end_time": "2026-05-04T01:37:26.171467+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\DynamicVIXSpyRegime-QC\\research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\DynamicVIXSpyRegime-QC\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-04T01:18:37.541942+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Ensemble-DLinear-TFT/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Ensemble-DLinear-TFT/research.ipynb
@@ -988,8 +988,8 @@
    "end_time": "2026-05-12T06:11:21.244784+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Ensemble-DLinear-TFT\\research.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Ensemble-DLinear-TFT\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-12T06:06:56.873012+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/research.ipynb
@@ -1013,8 +1013,8 @@
    "end_time": "2026-05-03T23:35:23.381504+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\FamaFrench\\research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\FamaFrench\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-03T23:34:58.727842+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/research.ipynb
@@ -1582,8 +1582,8 @@
    "end_time": "2026-05-25T22:02:04.273338+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\ForexCarry\\research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\ForexCarry\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-25T22:01:34.641385+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb
@@ -879,8 +879,8 @@
    "end_time": "2026-06-01T00:08:25.512462+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Framework_Composite_EMATrend\\quantbook_composite_research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Framework_Composite_EMATrend\\quantbook_composite_research_output.ipynb",
+   "input_path": "quantbook_composite_research.ipynb",
+   "output_path": "quantbook_composite_research.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T00:08:18.923742+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Gaussian-Direction-Classifier/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Gaussian-Direction-Classifier/research.ipynb
@@ -918,8 +918,8 @@
    "end_time": "2026-05-11T21:22:14.089333+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Gaussian-Direction-Classifier\\research.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Gaussian-Direction-Classifier\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-11T21:20:13.222848+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/research.ipynb
@@ -1350,8 +1350,8 @@
    "end_time": "2026-05-11T22:58:57.706659+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\GraphSAGE-MultiAsset-Ranking\\research.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\GraphSAGE-MultiAsset-Ranking\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-11T22:50:44.156808+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/LSTM-Forecasting/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/LSTM-Forecasting/research.ipynb
@@ -647,8 +647,8 @@
    "end_time": "2026-05-03T22:30:31.362240+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\LSTM-Forecasting\\research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\LSTM-Forecasting\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-03T22:30:15.619146+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/research.ipynb
@@ -1533,8 +1533,8 @@
    "end_time": "2026-05-04T01:46:03.717277+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\ML-RandomForest\\research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\ML-RandomForest\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-04T01:18:37.542316+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/research.ipynb
@@ -1578,8 +1578,8 @@
    "end_time": "2026-05-04T01:57:36.163244+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\ML-XGBoost\\research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\ML-XGBoost\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-04T01:18:37.542121+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Mamba-Crypto-Ranking/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Mamba-Crypto-Ranking/research.ipynb
@@ -1404,8 +1404,8 @@
    "end_time": "2026-05-12T06:11:38.724622+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Mamba-Crypto-Ranking\\research.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Mamba-Crypto-Ranking\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-12T06:04:27.990664+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-Optimization-ML/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-Optimization-ML/research.ipynb
@@ -1557,7 +1557,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-Optimization-ML/research.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/poml_test.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T11:41:46.634141+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_piotroski_fscore.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_piotroski_fscore.ipynb
@@ -372,8 +372,8 @@
    "end_time": "2026-06-01T00:32:50.666796+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Research-Executor\\research_piotroski_fscore.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Research-Executor\\research_piotroski_fscore_output.ipynb",
+   "input_path": "research_piotroski_fscore.ipynb",
+   "output_path": "research_piotroski_fscore.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T00:32:46.549088+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_puppies_of_dow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_puppies_of_dow.ipynb
@@ -267,8 +267,8 @@
    "end_time": "2026-06-01T00:32:41.873955+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Research-Executor\\research_puppies_of_dow.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Research-Executor\\research_puppies_of_dow_output.ipynb",
+   "input_path": "research_puppies_of_dow.ipynb",
+   "output_path": "research_puppies_of_dow.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T00:32:38.020939+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_volatility_regime_ml.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_volatility_regime_ml.ipynb
@@ -467,8 +467,8 @@
    "end_time": "2026-06-01T00:32:33.200349+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Research-Executor\\research_volatility_regime_ml.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Research-Executor\\research_volatility_regime_ml_output.ipynb",
+   "input_path": "research_volatility_regime_ml.ipynb",
+   "output_path": "research_volatility_regime_ml.ipynb",
    "parameters": {},
    "start_time": "2026-06-01T00:32:29.444726+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/research.ipynb
@@ -1259,8 +1259,8 @@
    "end_time": "2026-04-23T23:40:30.264910",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\RiskParity\\research.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\RiskParity\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-04-23T23:40:17.066927",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/research.ipynb
@@ -1165,8 +1165,8 @@
    "end_time": "2026-05-11T22:42:25.377111+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\TFT-Crypto-Ranking\\research.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\TFT-Crypto-Ranking\\research_output.ipynb",
+   "input_path": "research.ipynb",
+   "output_path": "research.ipynb",
    "parameters": {},
    "start_time": "2026-05-11T22:34:33.635730+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_composite_ff_aw.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_composite_ff_aw.ipynb
@@ -1667,8 +1667,8 @@
    "end_time": "2026-06-25T00:57:12.635387+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_composite_ff_aw.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_composite_ff_aw_output.ipynb",
+   "input_path": "research_composite_ff_aw.ipynb",
+   "output_path": "research_composite_ff_aw.ipynb",
    "parameters": {},
    "start_time": "2026-06-25T00:53:06.305762+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_quality_lowvol.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_quality_lowvol.ipynb
@@ -1028,8 +1028,8 @@
    "end_time": "2026-06-24T23:02:39.211364+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_quality_lowvol.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_quality_lowvol_output.ipynb",
+   "input_path": "research_quality_lowvol.ipynb",
+   "output_path": "research_quality_lowvol.ipynb",
    "parameters": {},
    "start_time": "2026-06-24T23:02:27.497876+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_risk_parity.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_risk_parity.ipynb
@@ -1440,8 +1440,8 @@
    "end_time": "2026-06-24T23:54:14.130621+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_risk_parity.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_risk_parity_output.ipynb",
+   "input_path": "research_risk_parity.ipynb",
+   "output_path": "research_risk_parity.ipynb",
    "parameters": {},
    "start_time": "2026-06-24T23:53:56.423530+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_rl_ppo.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_rl_ppo.ipynb
@@ -1203,8 +1203,8 @@
    "end_time": "2026-06-18T00:57:27.072557+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_rl_ppo.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\research\\research_rl_ppo_output.ipynb",
+   "input_path": "research_rl_ppo.ipynb",
+   "output_path": "research_rl_ppo.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },


### PR DESCRIPTION
## What

Scrub absolute machine-local paths from `metadata.papermill.input_path` / `output_path` across the **QuantConnect family** (46 canonical notebooks, 92 paths).

Leaked paths: `C:\dev\CoursIA\...`, `D:\CoursIA\...`, `D:\dev\CoursIA-2\...`, `C:/Users/jsboi/AppData/Local/Temp/...`.

## Why (#3436, famille QC)

Grain ai-01 (msg 26/06 19:25): QC merge queue vidée, #3845/#3164 EXHAUSTED firsthand, next grain = #3436 papermill path-leak **famille QC** (mon turf). G.1 firsthand: `scrub_papermill_paths.py --scan QuantConnect` = **47 notebooks / 92 absolute paths** (real, not 0 → PR, not fallback).

## How (dedicated tool, no re-invention)

`scripts/notebook_tools/scrub_papermill_paths.py --apply MyIA.AI.Notebooks/QuantConnect` — text-level surgical replace (absolute → basename), byte-identical except the path. **metadata-only edit, NOT a cell-output scrub** (secrets-hygiene rule 6: `metadata.papermill` is the *only* tolerated manual normalization; quantbook QC exception is about cell outputs, not metadata).

## Verification (G.1 + C.3)

- Re-scan `QuantConnect` = **0 defects** (`scrub_papermill_paths.py --scan`)
- Staged diff grep: **0 non-papermill-path lines** changed (every `+`/`-` line is an `input_path`/`output_path` value) → no source cell, no output, no other metadata touched
- Symmetric `+90/-90`, 46 files. One 47th notebook had the absolute path only in the working tree (HEAD already clean) → restored to committed state, no diff.
- C.3-exempt: metadata-only normalization, **no Papermill re-execution** (unlike C.3's concern, source cells are byte-identical).

## Out of scope (reported, not touched)

Repo-wide `--scan-all --check` shows **7 more defects** outside QuantConnect (SymbolicAI/Search/GameTheory) = other lanes (po-2023/po-2026 turf). Not touched here (atomic QC-only, anti-collision). Flagged to ai-01 for routing.

See #3436
