### PR TITLE
docs(qc): FR-first backfill 3 ML project READMEs (#3976, preserve .en.md)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/README.en.md
@@ -1,0 +1,25 @@
+# ML-Ensemble
+
+**Asset class:** US Equities (30 large-cap stocks)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Ensemble ML strategy combining Ridge regression, Random Forest, and Gradient Boosting on a 30-stock universe. Weekly rebalance with monthly retraining. Uses lagged returns as features for direction prediction.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Models | Ridge + RF + GradientBoosting ensemble |
+| Universe | 30 large-cap stocks |
+| Rebalance | Weekly |
+
+## Files
+
+- main.py - Strategy (269L, MLEnsembleAlgorithm)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/README.md
@@ -1,25 +1,25 @@
 # ML-Ensemble
 
-**Asset class:** US Equities (30 large-cap stocks)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions US (30 grandes capitalisations)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-Ensemble ML strategy combining Ridge regression, Random Forest, and Gradient Boosting on a 30-stock universe. Weekly rebalance with monthly retraining. Uses lagged returns as features for direction prediction.
+Stratégie ML d'ensemble combinant la régression Ridge, le Random Forest et le Gradient Boosting sur un univers de 30 actions. Rebalancement hebdomadaire avec ré-entraînement mensuel. Utilise les rendements décalés comme variables explicatives pour la prédiction de direction.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour l'exécuter.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Value |
-|--------|-------|
-| Models | Ridge + RF + GradientBoosting ensemble |
-| Universe | 30 large-cap stocks |
-| Rebalance | Weekly |
+| Métrique | Valeur |
+|----------|--------|
+| Modèles | Ensemble Ridge + Random Forest + Gradient Boosting |
+| Univers | 30 grandes capitalisations |
+| Rebalancement | Hebdomadaire |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (269L, MLEnsembleAlgorithm)
+- `main.py` — Stratégie (269 lignes, `MLEnsembleAlgorithm`)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment/README.en.md
@@ -1,0 +1,29 @@
+# ML-FinBERT-Sentiment (HandsOn Ex19)
+
+**Asset class:** US Equities (top 10 tech)
+**Cloud project ID:** None (local only)
+
+## Description
+
+FinBERT sentiment analysis on financial text. Requires TensorFlow and model weights unavailable in QC Cloud.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | FinBERT (HuggingFace) |
+| Note | Requires local Lean execution with TF |
+
+## Files
+
+- main.py - Strategy (v1.0, FinBERT sentiment)
+- research.ipynb - Sentiment model evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 19
+

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment/README.md
@@ -1,29 +1,29 @@
 # ML-FinBERT-Sentiment (HandsOn Ex19)
 
-**Asset class:** US Equities (top 10 tech)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions US (top 10 tech)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-FinBERT sentiment analysis on financial text. Requires TensorFlow and model weights unavailable in QC Cloud.
+Analyse de sentiment FinBERT sur du texte financier. Nécessite TensorFlow et les poids du modèle, indisponibles sur QC Cloud.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour l'exécuter.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Value |
-|--------|-------|
-| Model | FinBERT (HuggingFace) |
-| Note | Requires local Lean execution with TF |
+| Métrique | Valeur |
+|----------|--------|
+| Modèle | FinBERT (HuggingFace) |
+| Note | Nécessite une exécution Lean locale avec TensorFlow |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (v1.0, FinBERT sentiment)
-- research.ipynb - Sentiment model evaluation
-## References
+- `main.py` — Stratégie (v1.0, sentiment FinBERT)
+- `research.ipynb` — Évaluation du modèle de sentiment
 
-- Hands-On AI Trading, Section 06, Example 19
+## Références
 
+- *Hands-On AI Trading*, Section 06, Exemple 19

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/README.en.md
@@ -1,0 +1,25 @@
+# ML-Regression
+
+**Asset class:** US Equities (20 large-cap stocks)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Ridge regression strategy predicting next-day returns on a 20-stock universe. Uses lagged open-close returns as features. Bi-weekly rebalance with monthly retraining. Selects top-N stocks by predicted return.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | Ridge regression |
+| Universe | 20 large-cap stocks |
+| Rebalance | Biweekly |
+
+## Files
+
+- main.py - Strategy (227L, MLRegressionAlgorithm)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/README.md
@@ -1,25 +1,25 @@
 # ML-Regression
 
-**Asset class:** US Equities (20 large-cap stocks)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions US (20 grandes capitalisations)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-Ridge regression strategy predicting next-day returns on a 20-stock universe. Uses lagged open-close returns as features. Bi-weekly rebalance with monthly retraining. Selects top-N stocks by predicted return.
+Stratégie de régression Ridge prédisant les rendements du jour suivant sur un univers de 20 actions. Utilise les rendements open-close décalés comme variables explicatives. Rebalancement bi-hebdomadaire avec ré-entraînement mensuel. Sélectionne les meilleures actions (`top-N`) selon le rendement prédit.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour l'exécuter.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Value |
-|--------|-------|
-| Model | Ridge regression |
-| Universe | 20 large-cap stocks |
-| Rebalance | Biweekly |
+| Métrique | Valeur |
+|----------|--------|
+| Modèle | Régression Ridge |
+| Univers | 20 grandes capitalisations |
+| Rebalancement | Bi-hebdomadaire |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (227L, MLRegressionAlgorithm)
+- `main.py` — Stratégie (227 lignes, `MLRegressionAlgorithm`)


### PR DESCRIPTION
## What

FR-first backfill of 3 QuantConnect ML project leaf READMEs (#1650 Phase 0.5 / **#3976 famille QC**), preserving English originals verbatim as `README.en.md`.

- `projects/ML-Regression` — Ridge, 20 stocks
- `projects/ML-Ensemble` — Ridge + RF + GradientBoosting, 30 stocks
- `projects/ML-FinBERT-Sentiment` — FinBERT (HandsOn Ex19)

## Why

#3976 (READMEs feuilles — QuantConnect) is explicitly **Owner: po-2024:CoursIA**. Driver: FR-first + reflect verified state. Backlog-pickup this cycle (no fresh ai-01 steer — RooSync MCP down post-Windows-update, see blocker below). Atomic tranche of the ML-* family (1 PR / sub-series, per #3976 constraints).

## How (readme-french-first HARD 2)

For each project:
1. `git mv README.md README.en.md` (preserve EN original)
2. Write new `README.md` in French (faithful translation: same structure, sections, file refs)

**Faithful = no invented content.** The EN stubs carry only meta-info (asset class, model, universe, rebalance) — no Sharpe/CAGR claims. I translated exactly what exists; I did NOT fabricate baseline metrics (#1630 baselines require per-project verification I did not do from memory this cycle — left for a dedicated metrics tranche, verify-before-claiming).

## Verification

- `README.en.md` byte-identical to `HEAD:README.md` for all 3 (preservation proof, diff = empty)
- Line-count parity EN vs FR: 25/25, 25/25, 29/29 (structure preserved)
- No CATALOG-STATUS blocks on these stubs (catalog-pr-hygiene safe)
- Branche fraîche from `origin/main`

## Scope / next

- This PR: 3 ML-* projects (bounded atomic tranche).
- Remaining #3976 feuilles: ~7 more ML-* projects + other QC project families + research/README + Python/README. Multi-cycle effort, picked up at compte-goutte.
- Diversité note: this is my 2nd QC-mechanics cycle (after papermill #4418); next cycle I vary per ai-01 diversité mandate.

See #3973
See #3976
