### PR TITLE
docs(tweety): 2 concept Mermaid diagrams (MLN spectrum + Dung semantics)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -164,6 +164,42 @@ Chaque notebook introduit un concept ou cadre théorique spécifique. Le tableau
 | 9 | Preferences | Agrégation de préférences (Borda, Condorcet) + théorie du vote |
 | 10 | MLN | Pont symbolique/statistique : FOL + poids, marginales, exceptions (pingouin) |
 
+## Concepts clés en images
+
+Deux concepts phares de la série, rendus visuels plutôt qu'en prose seule.
+
+### Le pont symbolique/statistique (notebook 10 — MLN)
+
+Un **Markov Logic Network** fait varier le « degré de logique » d'une formule via son poids `w`. À une extrémité (`w → ∞`), on retrouve la **logique classique** (un seul monde violant rend la base inconsistante) ; à l'autre (`w = 0`), la **statistique pure** (tous les mondes équiprobables). Le **paradoxe du pingouin** illustre comment ce spectre résout des cas qu'aucune des deux extrêmes ne sait traiter seule :
+
+```mermaid
+flowchart LR
+    LOGIC["<b>Logique classique</b><br/>FOL stricte<br/><i>w → ∞ (règle dure)</i><br/>un seul monde violant = ⊥"]
+    MLN["<b>Markov Logic Network</b><br/>P(world) ∝ exp(Σ wᵢ · nᵢ)<br/>chaque formule FOL = une contrainte <i>souple</i>"]
+    STAT["<b>Statistique pure</b><br/>mondes équiprobables<br/><i>w = 0 (aucune contrainte)</i>"]
+    LOGIC -.->|"poids croissant"| MLN
+    MLN -.->|"poids décroissant"| STAT
+    PENG(["<b>Paradoxe du pingouin</b> — discrimine les deux extrêmes<br/>Flies(tweety) = 0.00 : l'exception stricte « pingouin ⇒ ¬vole » l'emporte<br/>Flies(robin)  = 0.79 : la règle pondérée « oiseau ⇒ vole » seule, sans exception"])
+    MLN --> PENG
+```
+
+### La hiérarchie des sémantiques de Dung (notebook 5)
+
+Les sémantiques de Dung s'emboîtent par spécialisation. Partant de l'**admissibilité**, on resserre progressivement les conditions (défendre tout ce que l'on contient, puis maximalité, puis attaque de l'extérieur), ce qui engendre la chaîne **grounded → complete → preferred → stable** :
+
+```mermaid
+flowchart TD
+    ADM["<b>Admissible</b><br/>S défend chaque argument qu'elle contient"]
+    COMP["<b>Complete</b><br/>admissible <b>+</b> contient tout ce qu'elle défend"]
+    GRO["<b>Grounded</b><br/>la complete <i>minimale</i><br/>(point fixe de Knaster–Tarski, toujours unique)"]
+    PREF["<b>Preferred</b><br/>les complete <i>maximales</i> (au moins une)"]
+    STAB["<b>Stable</b><br/>preferred attaquant tout argument extérieur<br/>(peut ne pas exister pour certains AF)"]
+    ADM --> COMP
+    COMP --> GRO
+    COMP --> PREF
+    PREF --> STAB
+```
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Résumé

Ajoute **2 diagrammes de concept Mermaid** au README Tweety (nouvelle section « Concepts clés en images »), rendant deux concepts phares de la série visuels plutôt qu'en prose seule. **Epic #4212** (finition éditoriale, famille Tweety).

## Diagrammes

**1. Pont symbolique/statistique** (notebook 10 — MLN) — le spectre des poids :
- `w → ∞` (strict) = **logique classique** (un monde violant = inconsistance)
- `w` fini = **MLN** (`P(world) ∝ exp(Σ wᵢ·nᵢ)`, contrainte souple)
- `w = 0` = **statistique pure** (mondes équiprobables)
- Le **paradoxe du pingouin** comme cas discriminant : `Flies(tweety)=0.00` (exception stricte l'emporte) vs `Flies(robin)=0.79` (règle pondérée seule).

**2. Hiérarchie des sémantiques de Dung** (notebook 5) — la chaîne de spécialisation :
`admissible → complete → {grounded (min, point fixe Knaster-Tarski), preferred (max) → stable}`.

## Anti-duplication (G.1 firsthand)

Le README Tweety avait déjà 2 blocs Mermaid :
- Ligne 62 : le **parcours d'apprentissage en 5 phases** (structure pédagogique).
- Ligne 421 : un **exemple d'attaque Dung à 3 nœuds** (instance d'AF).

Aucun des deux n'était un diagramme de *concept* au sens #4212 (mécanisme/théorème rendu visuel). Les 2 nouveaux sont additifs et non-redondants : le spectre MLN et la hiérarchie des sémantiques (qui complète l'exemple d'attaque en montrant la *taxonomie* des sémantiques, pas juste une instance).

## Conformité

| Critère | Preuve |
|---------|--------|
| **Pattern #4212** | flowchart conceptuel, labels quoted `<b>`/`<br/>`/`<i>` — idiom identique aux PRs récents (kelly #4324, planning_lean #4328, gametheory #4329) |
| **catalog-pr-hygiene 1** | marqueur `CATALOG-STATUS` **byte-identique** à `origin/main` |
| **Enrichissement** | +36 lignes, **0 suppression** (pure insertion) |
| **Atomic** | 1 fichier (README), 1 sujet (visuels concept Tweety) |
| **Base fraîche** | branche depuis `origin/main` (post-#4414 MLN mergé) |
| **Scope** | README seul stagé ; submodule SMT/Automata #2979 NON touché |

## Liens

Complète le capstone Tweety-10-MLN (#4414 mergé). See #4212 (Part of #4208).

🤖 Generated with [Claude Code](https://claude.com/claude-code)