### PR TITLE
docs(tweety): Pearl causal scale concept diagram for notebook 11

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -181,6 +181,21 @@ flowchart LR
     MLN --> PENG
 ```
 
+## L'échelle causale de Pearl (notebook 11 — Causalité)
+
+Le notebook 11 monte d'un niveau par rapport aux approches probabilistes : il distingue **corrélation** et **causalité** grâce à l'opérateur `do(X)`. Judea Pearl formalise cette distinction par une **échelle à trois niveaux**, chaque saut étant inaccessible au niveau inférieur. Le scénario du **baromètre** illustre le saut crucial entre les niveaux 1 et 2 : observer la baisse du baromètre prédit la pluie (corrélation via l'orage), mais **forcer** le baromètre à baisser ne fait pas pleuvoir (pas de causalité) :
+
+```mermaid
+flowchart TD
+    L1["<b>Niveau 1 — Association</b><br/>observe(X) → Y<br/>P(rain | drops) = <b>True</b><br/><i>corrélation : drops et rain coïncident via le confondeur storm</i>"]
+    L2["<b>Niveau 2 — Intervention</b><br/>do(X) → Y<br/>P(rain | do(drops)) = <b>False</b><br/><i>l'opérateur do ROMPT l'équation storm → drops ; drops ne porte plus d'info sur rain</i>"]
+    L3["<b>Niveau 3 — Contrefactuel</b><br/>« si X avait été différent, Y aurait-il eu lieu ? »<br/>observe(wet) ∧ ¬sprinkler → wet = <b>True</b><br/><i>twin model : rain aurait suffi à mouiller l'herbe</i>"]
+    L1 -->|"saut inaccessible à la statistique seule"| L2
+    L2 -->|"saut inaccessible à l'intervention seule"| L3
+```
+
+La signature du do-calculus — **P(rain | drops) ≠ P(rain | do(drops))** — est exactement ce que la logique classique (notebooks 1-4) et les MLN (notebook 10) restent **incapables d'exprimer** : ils ne connaissent que l'association.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Résumé

Ajoute **1 diagramme de concept Mermaid** au README Tweety pour le notebook 11 (Causalité), rendant l'échelle causale de Pearl — la thèse phare de Tweety-11-Causal — visuelle plutôt qu'en prose. **Epic #4212** (finition éditoriale). Symétrique du diagramme MLN spectrum (#4425, mergé) pour le notebook 10.

## Diagramme

**Échelle causale de Pearl** (notebook 11), 3 niveaux chacun inaccessible au précédent :
- **Niveau 1 — Association** : `observe(drops) → P(rain|drops)=True` (corrélation via confondeur storm)
- **Niveau 2 — Intervention** : `do(drops) → P(rain|do(drops))=False` (l'opérateur do **rompt** l'équation storm→drops ; drops ne porte plus d'info sur rain)
- **Niveau 3 — Contrefactuel** : `observe(wet) ∧ ¬sprinkler → wet=True` (twin model ; rain aurait suffi)

La signature **P(rain|drops) ≠ P(rain|do(drops))** = exactement ce que la logique classique (NB 1-4) et les MLN (NB 10) sont **incapables d'exprimer**.

## Justification vs saturation #4212 (transparence G.9)

Mon filon #4212 Mermaid po-2025 est **SATURÉ firsthand 17/17** (scan 2026-06-25). Cette PR ne ré-ouvre pas le filon — elle documente un **notebook NOUVEAU** : Tweety-11-Causal a été mergé via #4420 **après** le scan de saturation. C'est l'exception explicite de ma discipline : « nouveau contenu authentique ajouté au scope ».

Complétion symétrique : les 2 notebooks nouveaux (Tweety-10 MLN via #4425, Tweety-11 Causal via cette PR) ont désormais chacun leur concept phare rendu visuel. NB5 (Dung) reste intentionnellement non touché (déjà couvert par #4242).

## Conformité

| Critère | Preuve |
|---------|--------|
| **Prong B** | diagramme de concept (l'échelle causale = la thèse centrale de Tweety-11), pas décoration |
| **catalog-pr-hygiene 1** | `CATALOG-STATUS` **byte-identique** à `origin/main` |
| **Enrichissement** | +15 lignes, **0 suppression** |
| **Style local** | formules en unicode (`P(rain|drops) ≠ P(rain|do(drops))`), pas de `\$...\$` math — cohérent avec la section MLN #4425 et le reste du README Tweety |
| **Pattern #4212** | flowchart TD, labels quoted `<b>`/`<br/>`/`<i>` — idiom des PRs récents |
| **Atomic / scope** | 1 fichier README, 1 concept ; submodule SMT/Automata #2979 NON touché |

Complète le capstone Tweety-11-Causal (#4420 mergé). See #4212 (Part of #4208).

🤖 Generated with [Claude Code](https://claude.com/claude-code)