### PR TITLE
docs(z3): demote hint-as-heading asides to bold inline (#3968)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02b_Sudoku_Modes_Comparison.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02b_Sudoku_Modes_Comparison.ipynb
@@ -424,7 +424,7 @@
    "id": "e382c909",
    "metadata": {},
    "source": [
-    "### Indice pédagogique : quand utiliser quel mode ?\n",
+    "**Indice pédagogique — quand utiliser quel mode ?**\n",
     "\n",
     "- **`Array`** : quand on veut un modèle compact ou qu'on manipule des index symboliques (ex. « existe-t-il un index `k` tel que… »). C'est aussi le seul mode qui supporte nativement le `int[][]` imbriqué via la théorie des tableaux.\n",
     "- **`Constants`** : quand on veut qu'apparaissent dans le solver des symboles nommés explicites (`Cells_2_3 = 4`), par exemple pour inspecter le modèle, pour enseigner la notion d'inconnue, ou quand la taille de la collection est fixe et petite.\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
@@ -744,7 +744,7 @@
     "\n",
     "On étend au plan multi-jours du notebook 06b section 4 : un `int[][]` (3 jours x 2 créneaux) peuplé d'indices de recettes dans le corpus, avec contrainte de non-répétition des déjeuners via `Z3Methods.Distinct` en mode `CollectionHandling.Array`.\n",
     "\n",
-    "### Rappel technique : modèle de soumission .NET Interactive\n",
+    "**Rappel technique — modèle de soumission .NET Interactive**\n",
     "\n",
     "> La cellule ci-dessous regroupe **dans le même bloc** la déclaration des bornes (`entLo`, `pltLo`, etc.), la construction du théorème `Where(...)`, **et** l'appel `.Solve()`. C'est un choix de **lisibilité** : bornes et contraintes se lisent d'un seul tenant.\n",
     ">\n",


### PR DESCRIPTION
## Résumé

Corrige 2 notebooks Z3 flaggés par `scan_md_hierarchy.py` (`[HINT-AS-HEADING]`) dans le cadre de l'Epic **#3968** (hiérarchie typographique, Part of #3966). Les asides (`# Indice` / `# Rappel`) rendus à la même taille que les titres de section sont ramenés en **gras inline**.

## Changements (heading-level ONLY)

| Notebook | Cell | Avant | Après |
|----------|------|-------|-------|
| `02b_Sudoku_Modes_Comparison` | `e382c909` | `### Indice pédagogique : quand utiliser quel mode ?` | `**Indice pédagogique — quand utiliser quel mode ?**` |
| `06c_Meal_Planner_Visualization` | `sec4-title` | `### Rappel technique : modèle de soumission .NET Interactive` | `**Rappel technique — modèle de soumission .NET Interactive**` |

## Validation

| Critère | Preuve |
|---------|--------|
| **#3968 directive** | aside `### Indice`/`### Rappel` → bold inline (directive A « gras inline `**Indice :**` ») |
| **Re-scan** | `scan_md_hierarchy.py SMT` = **0/16 résiduel** (findings éliminés) |
| **Anti-regression #3968 INTERDIT** | diff = heading-level **ONLY** (grep confirme : les 2 seules lignes modifiées sont les lignes de heading, zéro delta de contenu/texte) |
| **Pas de stub/relabel** | aucun exercice/example touché (exercise-example-labeling respecté) |
| **C.2 exception** | markdown-only → outputs préservés (8/8 et 9/9 code cells `execution_count` intact, non-exec=0) |
| **Scope** | 2 notebooks Z3 ; submodule SMT/Automata #2979 NON touché |

## Contexte coordination

Suite au redirect ai-01 (post-#2137 Phase 3 COMPLETE) : #2876 accents = turf PROPRE firsthand (6 READMEs AA+SMT scannés, 0 accent légitime manquant — tous faux positifs = termes techniques ou mots FR valides sans accent). Pivot vers #3968 (vieille issue figée, ma turf SymbolicAI = 43 notebooks flaggés initialement, dont 3 résiduels non-Lean sur ma partition : 2 Z3 + 1 AA `_agent`). Cette PR = lot Z3. Le variant AA `_agent` sera traité séparément (risque SK-gated isolé).

Part of #3968

🤖 Generated with [Claude Code](https://claude.com/claude-code)