### PR TITLE
fix(lean): prove P4.2 wave-1 IH via helper workaround (sorry 6->5) (#3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1496,15 +1496,73 @@ theorem p4_double_nine_shape
     nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
     sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se k hk hwf
 
-/-- **P4.2** (IH application, wave 1): for each of the nine sub-cells `n_i`
-    of `c`, `hashlifeResultAux (k+1) n_i` agrees with `evolve (2^(k-1))` on
-    `n_i`'s centered window. This is the induction hypothesis applied to the
-    level-`(k+1)` sub-cell `n_i` (whose level is `k+1 = (k-1)+2`). Difficulty:
-    P4.2 (mechanical IH instantiation; the statement shape matches
-    `hashlifeResult_central_correct` at level `k-1`). -/
+/-- The central-correctness statement, abstracted as a named predicate.
+    Quoting it as `centralCorrect c j` (instead of the unfolded `2^j`-indexed
+    Grid equality) stops the elaborator from running `whnf` on
+    `hashlifeResultAux (j+2) c.toGrid` while checking the `ih` argument type of
+    `p4_wave1_ih`; that reduction diverges (it pattern-matches `c`, a free
+    variable). Unlike the c.138 `@[irreducible]` variant, a plain `def` still
+    allows defeq at the `hashlifeResult_central_correct` -> `p4_succ_membership`
+    threading boundary (c.139). -/
+def centralCorrect (c : MacroCell) (j : Nat) : Prop :=
+  (hashlifeResultAux (j + 2) c).toGrid ((2^j : Nat), (2^j : Nat)) =
+    restrictGridTo (evolve (2^j) (c.toGrid (0, 0))) (2^j : Int) (2^(j+1))
+
+/-- **P4.2 helper (c.139 workaround).** The `ih` *application*
+    `ih (node nw_se ne_sw sw_ne se_nk) (k-1) ...` diverges on `whnf` when it
+    appears inline inside `p4_wave1_ih`'s body, because there the four
+    grandchildren are free variables tied into a 16-grandchild / 32-fact local
+    context (post `p4_double_nine_shape` obtain). Moving the application into
+    this standalone helper makes `nw_se` etc. opaque binders at the application
+    site, which is enough to stop the divergence (minimal-repro probe
+    `WhnfProbe.lean`, arm 4 diverges / arm 6 compiles). -/
+private theorem p4_wave1_ih_step
+    (k : Nat) (hk1 : 1 ≤ k)
+    (nw_se ne_sw sw_ne se_nw : MacroCell)
+    (hnw_se_l : nw_se.level = k) (hne_sw_l : ne_sw.level = k)
+    (hsw_ne_l : sw_ne.level = k) (hse_nw_l : se_nw.level = k)
+    (hnw_se_w : nw_se.wf = true) (hne_sw_w : ne_sw.wf = true)
+    (hsw_ne_w : sw_ne.wf = true) (hse_nw_w : se_nw.wf = true)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j) :
+    centralCorrect (node nw_se ne_sw sw_ne se_nw) (k - 1) := by
+  have hn5 := node_wf_level_of_four hnw_se_l hne_sw_l hsw_ne_l hse_nw_l
+                                    hnw_se_w hne_sw_w hsw_ne_w hse_nw_w
+  exact ih (node nw_se ne_sw sw_ne se_nw) (k - 1) (by omega) hn5.2 (by omega)
+
+/-- **P4.2** (IH application, wave 1): for the center sub-cell
+    `n5 = node nw_se ne_sw sw_ne se_nw` of the double-nine decomposition,
+    `hashlifeResultAux (k+1) n5` agrees with `evolve (2^(k-1))` on `n5`'s
+    centered window. This is the induction hypothesis (passed in explicitly by
+    `p4_succ_membership`, breaking the cyclic back-reference to
+    `hashlifeResult_central_correct`) applied to the level-`(k+1)` sub-cell
+    `n5` (whose level is `k+1 = (k-1)+2`). The `ih` application is delegated to
+    `p4_wave1_ih_step` (c.139 workaround for the whnf divergence). -/
 theorem p4_wave1_ih
-    (c : MacroCell) (k : Nat) (hwf : c.wf = true) (hk : c.level = k + 2) : True := by
-  sorry
+    (c : MacroCell) (k : Nat) (hwf : c.wf = true) (hk : c.level = k + 2) (hk1 : 1 ≤ k)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j) :
+    ∃ nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+       sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se : MacroCell,
+      c = node (node nw_nw nw_ne nw_sw nw_se)
+               (node ne_nw ne_ne ne_sw ne_se)
+               (node sw_nw sw_ne sw_sw sw_se)
+               (node se_nw se_ne se_sw se_se) ∧
+      centralCorrect (node nw_se ne_sw sw_ne se_nw) (k - 1) := by
+  obtain ⟨nw_nw, nw_ne, nw_sw, nw_se, ne_nw, ne_ne, ne_sw, ne_se,
+          sw_nw, sw_ne, sw_sw, sw_se, se_nw, se_ne, se_sw, se_se, rfl, hgrands⟩ :=
+    p4_double_nine_shape c k hwf hk
+  obtain ⟨hnw_nw_l, hnw_nw_w, hnw_ne_l, hnw_ne_w, hnw_sw_l, hnw_sw_w, hnw_se_l, hnw_se_w,
+          hne_nw_l, hne_nw_w, hne_ne_l, hne_ne_w, hne_sw_l, hne_sw_w, hne_se_l, hne_se_w,
+          hsw_nw_l, hsw_nw_w, hsw_ne_l, hsw_ne_w, hsw_sw_l, hsw_sw_w, hsw_se_l, hsw_se_w,
+          hse_nw_l, hse_nw_w, hse_ne_l, hse_ne_w, hse_sw_l, hse_sw_w, hse_se_l, hse_se_w⟩ :=
+    hgrands
+  refine ⟨nw_nw, nw_ne, nw_sw, nw_se, ne_nw, ne_ne, ne_sw, ne_se,
+          sw_nw, sw_ne, sw_sw, sw_se, se_nw, se_ne, se_sw, se_se, rfl, ?_⟩
+  exact p4_wave1_ih_step k hk1 nw_se ne_sw sw_ne se_nw
+          hnw_se_l hne_sw_l hsw_ne_l hse_nw_l
+          hnw_se_w hne_sw_w hsw_ne_w hse_nw_w ih
+
 
 /-- **P4.3** (IH application, wave 2): for each of the four super-cells
     `q_*` built from the wave-1 results `r_i`, `hashlifeResultAux (k+1) q_*`
@@ -1533,11 +1591,13 @@ theorem p4_half_steps_compose
     the four sub-lemmas are proven, this function produces the
     `∀ p, p ∈ ... ↔ p ∈ ...` hypothesis that `p4_ext_bridge` consumes. -/
 noncomputable def p4_succ_membership
-    (c : MacroCell) (k : Nat) (hwf : c.wf = true) (hk : c.level = k + 2) :
+    (c : MacroCell) (k : Nat) (hwf : c.wf = true) (hk : c.level = k + 2) (hk1 : 1 ≤ k)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j) :
     ∀ p, p ∈ (hashlifeResultAux (k + 2) c).toGrid ((2^k : Nat), (2^k : Nat)) ↔
         p ∈ restrictGridTo (evolve (2^k) (c.toGrid (0, 0))) (2^k : Int) (2^(k+1)) := by
   have _h1 := p4_double_nine_shape c k hwf hk
-  have _h2 := p4_wave1_ih c k hwf hk
+  have _h2 := p4_wave1_ih c k hwf hk hk1 ih
   have _h3 := p4_wave2_ih c k hwf hk
   have _h4 := p4_half_steps_compose c k hwf hk
   intro p
@@ -1566,15 +1626,27 @@ theorem hashlifeResult_central_correct (c : MacroCell) (k : Nat)
     let resultGrid := result.toGrid ((2^k : Nat), (2^k : Nat))
     let expected := evolve (2^k) (c.toGrid (0, 0))
     resultGrid = restrictGridTo expected (2^k : Int) (2^(k+1)) := by
-  -- P4 TARGET: central Hashlife correctness, by induction on level.
-  -- Base case k = 0 holds in full generality (shape lemmas + 2^16
-  -- native_decide). `p4_ext_bridge` discharges the canonical-list
-  -- bookkeeping of the remaining arm: the goal left is the pointwise
-  -- membership biconditional, where the light-cone (P2) and double-nine
-  -- decomposition arguments live.
-  cases k with
-  | zero => exact hashlifeResult_central_correct_base c hwf hk
-  | succ k => exact p4_ext_bridge c (k + 1) (p4_succ_membership c (k + 1) hwf hk)
+  -- P4 TARGET: central Hashlife correctness, by STRONG induction on the level
+  -- index `k`. The motive quantifies over `c` (reverted before induction) so
+  -- the induction hypothesis `ih` ranges over every MacroCell at a smaller
+  -- level (not just a fixed `c`): this is required because the recursive step
+  -- applies the IH to the double-nine *sub-cells* `n_i` of `c`, which are
+  -- MacroCells distinct from `c` itself. A plain `cases k` exposes no such
+  -- cross-cell IH, which (c.137) forced `p4_wave1_ih` to stay a vacuous `True`
+  -- placeholder to avoid a forbidden mutual-recursion cycle. Threading `ih`
+  -- down through `p4_succ_membership` -> `p4_wave1_ih` breaks that cycle (c.138),
+  -- and the c.139 helper `p4_wave1_ih_step` makes the `ih` application compile.
+  revert c hwf hk
+  induction k using Nat.strongRecOn with
+  | ind n ih =>
+    intro c hwf hk
+    cases n with
+    | zero => exact hashlifeResult_central_correct_base c hwf hk
+    | succ k =>
+      have hk1 : 1 ≤ k + 1 := by omega
+      exact p4_ext_bridge c (k + 1)
+        (p4_succ_membership c (k + 1) hwf hk hk1
+          (fun c' j hj hc'w hc'l => ih j hj c' hc'w hc'l))
 
 /-! ## P4 witnesses: base case k=0 (native_decide)
 


### PR DESCRIPTION
## Summary

Eliminate one sorry in the GOL Hashlife correctness module (`#3846`): convert `p4_wave1_ih` from the vacuous `: True := by sorry` placeholder into a real, non-vacuous theorem proving the wave-1 induction hypothesis for the **center** sub-cell `n5 = node nw_se ne_sw sw_ne se_nw`. sorry **6 → 5**.

This resolves the **second** of two obstacles documented for P4.2 (c.137/138): the c.138 strong-induction restructure broke the cyclic dependency (obstacle 1) but hit a whnf divergence on the `ih` *application* (obstacle 2, unresolved). This PR breaks obstacle 2 via a helper workaround (c.139).

## What was proven

`p4_wave1_ih` now states and proves: for a well-formed level-`(k+2)` cell `c`, `∃` the sixteen depth-2 grandchildren such that `c = node(...)` and `centralCorrect (node nw_se ne_sw sw_ne se_nw) (k - 1)` — i.e. the wave-1 IH holds for the center sub-cell `n5` (whose level is `k+1 = (k-1)+2`).

## Three coupled changes

1. **`centralCorrect` predicate** (plain `def`, **not** `@[irreducible]`). Quoting the `2^j`-indexed Grid equality as `centralCorrect c j` stops the elaborator from running `whnf` on `hashlifeResultAux (j+2) c.toGrid` while checking the `ih` argument *type* of `p4_wave1_ih` — that reduction diverges (it pattern-matches the free variable `c`). The c.138 `@[irreducible]` variant blocked the defeq bridge at the `hashlifeResult_central_correct → p4_succ_membership` threading boundary (c.139 finding); a plain `def` keeps the type-elaboration benefit while allowing defeq there.

2. **`p4_wave1_ih_step` helper** (c.139 workaround). The `ih` application `ih (node nw_se ne_sw sw_ne se_nw) (k-1) ...` diverges on `whnf` when inline in `p4_wave1_ih`'s body (the four grandchildren are free vars tied into a 16-grandchild / 32-fact local context post `p4_double_nine_shape` obtain). Moving the application into this standalone helper makes `nw_se` etc. opaque binders at the application site — enough to stop the divergence. Validated by a throwaway minimal-repro probe (`WhnfProbe.lean`: arm 4 = inline → diverges; arm 6 = via helper → compiles; deleted before commit).

3. **`hashlifeResult_central_correct`** restructured to **strong induction** (`Nat.strongRecOn`, motive quantified over `c` via `revert`), so the IH ranges over every MacroCell at a smaller level (required because the recursive step applies the IH to the double-nine sub-cells `n_i` of `c`, distinct from `c` itself). The IH is threaded down through `p4_succ_membership` (new `ih` argument) into `p4_wave1_ih`. The `ih` bound is `j < k` (matching what `Nat.strongRecOn` produces: `m < n`), **not** `j < k+1` (off-by-one that blocked the first attempt).

## Honest scope (G.3)

This proves the IH for the **representative center sub-cell `n5`** only. The other eight `n_i` (4 corners + 4 edge midpoints) are **structurally identical** — same `node_wf_level_of_four` + same `ih` instantiation, differing only in which four of the sixteen grandchildren they group. They follow by the identical proof and are queued behind this representative. The compositional half of wave 1 (light-cone locality, `p4_half_steps_compose` = P4.4) stays open.

## Verification (lean-merge-discipline §B)

- `lake build Conway.Life.HashlifeCorrectness`: **SUCCESS (exit 0)**, junction mathlib `54f98fd6` rc2 (warm, shared cache — not a from-scratch build).
- `grep -c sorry` before/after: **6 → 5** (authoritative token grep, including the bullet `· sorry` in `p5_inductive_step`; the `declaration uses sorry` warnings are NOT used as the delta — they are unreliable under incremental caching).
- 0 axiom added: the proof term is pure composition of existing theorems (`p4_double_nine_shape`, `node_wf_level_of_four`, and the `ih` hypothesis).

1 file changed (`Conway/Life/HashlifeCorrectness.lean`, +91/-19). Base fresh from `origin/main` (0/0 ahead/behind). `See #3846` (partial — wave-1 center sub-cell; the lane has 5 sorries remaining: P4.3, P4.4, glue, P5.1, P5.2).
