### PR TITLE
feat(lean): PacLearning SampleExpect — empirical expectation framework (iter-2 brique 2b/3)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning.lean
@@ -2,6 +2,7 @@ import Mathlib
 import PacLearning.Data
 import PacLearning.Sample
 import PacLearning.Concentration
+import PacLearning.SampleExpect
 
 /-!
 # PacLearning — théorie PAC (Valiant 1984), module classe finie, Lean 4
@@ -60,16 +61,24 @@ nécessité — le résultat mathématique est le vrai Hoeffding. Par briques at
   `sampleWeight_sum_one` (`∑ S, sampleWeight D S = 1` via Fubini discret
   `sum_pow'` puis `D.sum_one`). C'est le cadre probabiliste requis pour parler
   de tirages i.i.d. `S ∼ D^m`.
-- `PacLearning/Concentration.lean` (ce livrable, **brique 2a/3 livrée**) —
+- `PacLearning/Concentration.lean` (**brique 2a/3 livrée**) —
   espérance `expect` (`∑ x, D.weight x · g x`) + linéarité, espérance des
   constantes, pont `trueError_eq_expect`, et **inégalité de Markov** en
   ℝ-weight (`markov_ineq` : `D-weight {x | t ≤ g x} ≤ E[g]/t` via
   `Finset.filter` + `Finset.sum_mul` + `mul_le_mul_of_nonneg_left`). Pose les
-  fondations de la méthode de Chernoff (brique 2b/3).
-- **Brique 2b/3 — OPEN** : concentration de Hoeffding-for-Bernoulli,
-  `ℙ_S [ |empError − trueError| > ε ] ≤ 2·exp(−2mε²)` (Markov + `log t ≤ t − 1`
-  sur les indicateurs `𝟙[h(S i) ≠ f(S i)]`, self-contained, réutilisant
-  `expect` et `markov_ineq` de la brique 2a/3).
+  fondations de la méthode de Chernoff (brique 2c/3).
+- `PacLearning/SampleExpect.lean` (ce livrable, **brique 2b/3 livrée**) —
+  espérance empirique `sampleExpect D g = ∑ S, sampleWeight D S · g S` sur
+  l'espace des échantillons `Fin n → X` (prolongement de `expect` au produit
+  `D^m`), avec **linéarité**, **normalisation** `sampleExpect_const`
+  (`E_{S∼D^m}[c] = c` via `sampleWeight_sum_one`), non-négativité et monotonie.
+  Cadre requis par toute inégalité de concentration sur l'échantillon.
+- **Brique 2c/3 — OPEN** : concentration de Hoeffding-for-Bernoulli,
+  `ℙ_S [ |empError − trueError| > ε ] ≤ 2·exp(−2mε²)`. Préalable : la
+  **marginalisation coordonnée** `sampleExpect_coord` (`E_{S∼D^m}[g(S i)] =
+  E_D[g]`, via `Finset.sum_prod_piFinset`) puis l'**estimateur non-biaisé**
+  `sampleExpect_empError_eq_trueError` (`E_S[empError] = trueError`), puis la
+  méthode Chernoff (Markov + `log t ≤ t − 1` sur les indicateurs).
 - **Brique 3/3 — OPEN** : `pac_finite_class_bound`, `m ≥ (1/ε)(ln|H| + ln(1/δ))`
   (union bound sur `H` fini, `Finset.sum_le_*`). Le théorème phare de Valiant.
 
@@ -85,10 +94,12 @@ nécessité — le résultat mathématique est le vrai Hoeffding. Par briques at
 namespace PacLearning
 
 /-- Statut : itération 1 livrée (modèle + propriétés élémentaires 0-sorry) ;
-itération 2 en cours — **briques 1/3 + 2a/3 livrées** (`Sample.lean` : distribution
-produit `D^m` + normalisation ; `Concentration.lean` : `expect`, `markov_ineq`).
-Briques 2b/3 (Hoeffding-for-Bernoulli self-contained) et 3/3
-(`pac_finite_class_bound` union bound) documentées OPEN. -/
+itération 2 en cours — **briques 1/3, 2a/3, 2b/3 livrées** (`Sample.lean` :
+distribution produit `D^m` + normalisation ; `Concentration.lean` : `expect`,
+`markov_ineq` ; `SampleExpect.lean` : `sampleExpect` + linéarité/normalisation).
+Briques 2c/3 (marginalisation coordonnée + estimateur non-biaisé +
+Hoeffding-for-Bernoulli) et 3/3 (`pac_finite_class_bound` union bound)
+documentées OPEN. -/
 abbrev Status : Prop := True
 
 end PacLearning

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/SampleExpect.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/SampleExpect.lean
@@ -1,0 +1,102 @@
+import Mathlib
+import PacLearning.Data
+import PacLearning.Sample
+import PacLearning.Concentration
+
+/-!
+# PacLearning.SampleExpect — espérance empirique sur l'espace des échantillons
+
+Sous-module de `PacLearning` : la **brique 2b/3** d'iter-2. On prolonge le cadre
+d'espérance de `Concentration.lean` (qui définissait `expect D g` sur `X`) vers
+l'**espace des échantillons** `Fin n → X` muni de la distribution produit `D^m`
+(voir `Sample.lean`). L'espérance empirique d'une fonction `g : (Fin n → X) → ℝ`
+est la somme pondérée
+
+    sampleExpect D g = ∑ S, sampleWeight D S · g S.
+
+## Ce livrable (brique 2b/3) — le cadre d'espérance empirique
+
+On pose `sampleExpect` et ses propriétés **élémentaires (entièrement prouvées)** : non-négativité
+(`sampleExpect_nonneg`), linéarité (`sampleExpect_linear`), et surtout la
+**normalisation** `sampleExpect_const` (`E_{S∼D^m}[constante c] = c`, via
+`sampleWeight_sum_one` — `D^m` est bien une distribution de probabilité). Plus la
+**monotonie** (`sampleExpect_mono`). C'est le prolongement naturel de `expect`
+vers l'espace produit, cadre requis par toute inégalité de concentration sur
+l'échantillon.
+
+## Briques 2c/3 et 3/3 — OPEN (documentées comme travail futur, pas de stub)
+
+Les résultats plus profonds nécessitent la **marginalisation d'une coordonnée**
+sous le produit `D^m` (le bloc-clé), qu'on escompte via le lemme Mathlib
+`Finset.sum_prod_piFinset` (`∑_{f ∈ piFinset} ∏_i g i (f i) = ∏_i ∑_j g i j`,
+avec un `g` portant le facteur à la coordonnée d'intérêt) :
+
+- **Marginalisation** `sampleExpect_coord` : `E_{S∼D^m}[g (S i)] = E_D[g]`.
+- **Estimateur non-biaisé** `sampleExpect_empError_eq_trueError` :
+  `E_{S∼D^m}[empError f h S] = trueError D f h` (par linéarité + marginalisation ;
+  l'erreur empirique est centrée sur l'erreur vraie).
+- **Hoeffding-for-Bernoulli** : `ℙ_S [ |empError − trueError| ≥ ε ] ≤
+  2·exp(−2nε²)` (méthode Chernoff : Markov sur `exp(t·(X̄−μ))` + `log t ≤ t−1`).
+
+Ces briques suivent en itérations dédiées (la formalisation de la
+marginalisation coordonnée-par-coordonnée sur les types Pi est subtile). On
+reste dans le style **ℝ-weight pédagogique** (pas de `ℝ≥0∞` / `Measure`).
+-/
+
+namespace PacLearning
+
+open Finset
+
+variable {X : Type*} [Fintype X]
+variable (D : Distribution X)
+
+/-- **Espérance empirique** de `g : (Fin n → X) → ℝ` sous la distribution produit
+`D^m` : somme pondérée `∑ S, sampleWeight D S · g S`. C'est le prolongement de
+`expect` (sur `X`) à l'espace des échantillons. -/
+noncomputable def sampleExpect {n : ℕ} (g : (Fin n → X) → ℝ) : ℝ :=
+  ∑ S : Fin n → X, sampleWeight D S * g S
+
+variable {D}
+
+/-- L'espérance empirique d'une fonction positive est positive : somme de poids
+positifs (`sampleWeight ≥ 0`) fois `g ≥ 0`. -/
+theorem sampleExpect_nonneg {n : ℕ} {g : (Fin n → X) → ℝ} (hg : ∀ S, 0 ≤ g S) :
+    0 ≤ sampleExpect D g := by
+  dsimp only [sampleExpect]
+  apply sum_nonneg
+  intro S _
+  exact mul_nonneg (sampleWeight_nonneg (D := D) S) (hg S)
+
+/-- L'espérance empirique est linéaire en `g` : `E[a·g₁ + b·g₂] = a·E[g₁] + b·E[g₂]`
+(car `∑` l'est). Le facteur `a` (resp. `b`) est ramené à gauche dans chaque
+produit scalaire pondéré, puis `← mul_sum` le sort de la somme. -/
+theorem sampleExpect_linear {n : ℕ} {g₁ g₂ : (Fin n → X) → ℝ} (a b : ℝ) :
+    sampleExpect D (fun S ↦ a * g₁ S + b * g₂ S) =
+      a * sampleExpect D g₁ + b * sampleExpect D g₂ := by
+  dsimp only [sampleExpect]
+  simp only [mul_add, Finset.sum_add_distrib]
+  simp only [show ∀ S, sampleWeight D S * (a * g₁ S) = a * (sampleWeight D S * g₁ S) from
+               fun _ => by ring,
+             show ∀ S, sampleWeight D S * (b * g₂ S) = b * (sampleWeight D S * g₂ S) from
+               fun _ => by ring]
+  rw [← Finset.mul_sum, ← Finset.mul_sum]
+
+/-- **Normalisation** : l'espérance empirique de la fonction constante `c` vaut
+`c` (la masse totale des échantillons vaut `1` par `sampleWeight_sum_one`).
+C'est le fait que `D^m` est une distribution de probabilité, transposé aux
+espérances. -/
+theorem sampleExpect_const (n : ℕ) (c : ℝ) :
+    sampleExpect D (fun _ : Fin n → X ↦ c) = c := by
+  dsimp only [sampleExpect]
+  rw [← Finset.sum_mul, sampleWeight_sum_one n, one_mul]
+
+/-- **Monotonie** de l'espérance empirique : si `g ≤ g'` point par point, alors
+`E[g] ≤ E[g']` (somme pondérée de poids positifs). -/
+theorem sampleExpect_mono {n : ℕ} {g g' : (Fin n → X) → ℝ}
+    (h : ∀ S, g S ≤ g' S) : sampleExpect D g ≤ sampleExpect D g' := by
+  dsimp only [sampleExpect]
+  apply sum_le_sum
+  intro S _
+  exact mul_le_mul_of_nonneg_left (h S) (sampleWeight_nonneg (D := D) S)
+
+end PacLearning


### PR DESCRIPTION
## Summary

iter-2 **brique 2b/3** of the `learning_theory_lean` PacLearning module. Extends the expectation framework from `Concentration.lean` (`expect` on `X`) to the **sample space** `Fin n → X` under the product distribution `D^m`. This is the framework required by any concentration inequality on the sample (Hoeffding-for-Bernoulli, brique 2c/3). Follows the multi-brique decomposition: 1/3 Sample (#4419) → 2a/3 Concentration (#4436 merged) → **2b/3 SampleExpect (this)** → 2c/3 Hoeffding → 3/3 PAC union bound.

New file `PacLearning/SampleExpect.lean` (0-sorry):
- `sampleExpect D g := ∑ S, sampleWeight D S * g S` (noncomputable) — the analog of `expect` for the product measure `D^m`.
- `sampleExpect_nonneg`, `sampleExpect_linear` (`E[a·g₁+b·g₂] = a·E[g₁]+b·E[g₂]`), `sampleExpect_mono`.
- **`sampleExpect_const`**: `E_{S∼D^m}[c] = c` via `sampleWeight_sum_one` — proves `D^m` is a probability distribution, transposed to expectations.

Umbrella `PacLearning.lean`: adds `import PacLearning.SampleExpect`, updates the iter-2 brique list + `Status` abbrev (1/3, 2a/3, 2b/3 shipped).

## Validation (real, not keywords)

- **`lake build PacLearning` SUCCESS** — 8496 jobs, exit 0, `Built PacLearning.SampleExpect`.
- **sorry-baseline strictly net-zéro** — 0 real `sorry` tactic; `git diff origin/main` adds **0 new 'sorry' lines** (the umbrella's pre-existing '0-sorry' prose kept untouched; new SampleExpect prose rephrased to avoid the literal word, per the standalone-tactic prose lesson).
- The marginalization `sampleExpect_coord` + unbiased estimator `sampleExpect_empError_eq_trueError` + Hoeffding bound are documented **OPEN** (brique 2c/3), not stub-backed — honest scoping per G.3.

## Honest scoping — why framework now, marginal next

The headline results (unbiased estimator `E_S[empError]=trueError`, then Hoeffding `P[|empError−trueError|≥ε]≤2exp(−2nε²)`) need the **coordinate marginalization** `sampleExpect_coord : E_{S∼D^m}[g(S i)] = E_D[g]`. This uses `Finset.sum_prod_piFinset` (`∑_{f ∈ piFinset} ∏_i g i (f i) = ∏_i ∑_j g i j`) with an index-dependent `g` carrying the factor at coordinate `i`, plus the bare-Fintype-sum ↔ piFinset normalization — a substantive formalization that warrants a dedicated iteration rather than a rushed stub. This PR ships the certain 0-sorry framework; the marginal + estimator + Hoeffding is the explicit next brique (2c/3).

## Durable lessons (Lean v4.31.0-rc1)

- **`sampleExpect_const {n}` with a constant-function body leaves `n` unsynthable** — the constant `fun _ ↦ c` does not pin the `Fin n → X` domain → make `n` EXPLICIT: `sampleExpect_const (n : ℕ) (c : ℝ)`, function annotated `fun _ : Fin n → X ↦ c`.
- **Cross-module lemma calls keep section-variable binders implicit** — `sampleWeight_nonneg` (defined in Sample.lean under `variable {D}`) takes `D` implicit → call `sampleWeight_nonneg (D := D) S`; `sampleWeight_sum_one` needs explicit `n`.

See #4293 (roadmap Lean #4038). Part of the iter-2 multi-brique PAC module.

Co-Authored-By: Claude <noreply@anthropic.com>