### PR TITLE
docs(qc): FR-first backfill 4 Cloud-* project READMEs (#3870 Phase 0.5, preserve .en.md)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-MeanReversion-Sectors/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-MeanReversion-Sectors/README.en.md
@@ -1,0 +1,35 @@
+# Cloud-MeanReversion-Sectors
+
+**Asset class:** Equities (GICS sector ETFs)
+
+**Cloud project ID:** N/A
+
+## Description
+
+RSI(14) mean reversion strategy on 11 GICS sector ETFs (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC). Three variants with increasing sophistication: v1 uses raw RSI oversold/overbought signals; v2 adds SMA200 regime filtering (only trade in bull markets); v3 incorporates stop-loss rules. Scans daily 30 minutes after market open.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-MeanReversion-Sectors/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| RSI Mean Reversion (3 variants) | Daily scan | RSI period 14, SMA200 regime filter (v2+), stop-loss (v3) |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Mean reversion algorithm with 3 variants (RSI, +regime filter, +stop-loss) on 11 sector ETFs |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-MeanReversion-Sectors/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-MeanReversion-Sectors/README.md
@@ -1,14 +1,14 @@
 # Cloud-MeanReversion-Sectors
 
-**Asset class:** Equities (GICS sector ETFs)
+**Classe d'actifs :** Actions (ETF sectoriels GICS)
 
-**Cloud project ID:** N/A
+**ID projet Cloud :** N/A
 
 ## Description
 
-RSI(14) mean reversion strategy on 11 GICS sector ETFs (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC). Three variants with increasing sophistication: v1 uses raw RSI oversold/overbought signals; v2 adds SMA200 regime filtering (only trade in bull markets); v3 incorporates stop-loss rules. Scans daily 30 minutes after market open.
+Stratégie de retour à la moyenne basée sur le RSI(14) sur 11 ETF sectoriels GICS (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC). Trois variantes de sophistication croissante : v1 utilise des signaux bruts de survente/surachat du RSI ; v2 ajoute un filtre de régime SMA200 (ne trader qu'en marché haussier) ; v3 incorpore des règles de stop-loss. Scan quotidien 30 minutes après l'ouverture du marché.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,20 +16,20 @@ lean backtest --algorithm Cloud-MeanReversion-Sectors/main.py
 ```
 
 ### QC Cloud
-Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+Créer un nouveau projet, téléverser `main.py`, compiler et lancer un backtest (défaut : 2015-01-01 au 2024-12-31).
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| RSI Mean Reversion (3 variants) | Daily scan | RSI period 14, SMA200 regime filter (v2+), stop-loss (v3) |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| Retour à la moyenne RSI (3 variantes) | Scan quotidien | RSI période 14, filtre de régime SMA200 (v2+), stop-loss (v3) |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | Mean reversion algorithm with 3 variants (RSI, +regime filter, +stop-loss) on 11 sector ETFs |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Algorithme de retour à la moyenne avec 3 variantes (RSI, +filtre de régime, +stop-loss) sur 11 ETF sectoriels |
 
-## References
+## Références
 
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-RiskParity-Composite/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-RiskParity-Composite/README.en.md
@@ -1,0 +1,36 @@
+# Cloud-RiskParity-Composite
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Tactical rotation across six asset classes (SPY, TLT, GLD, EFA, EEM, DBC) using a dual filter: price above SMA200 AND positive 6-month momentum. Assets passing both filters receive equal weight. Rebalances every 30 days. Inspired by AQR's Hurst, Ooi, and Pedersen (2014) approach to trend-following with risk parity allocation.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-RiskParity-Composite/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Dual-filter Risk Parity | 30 days | SMA200 + 6-month momentum, equal weight among passing assets |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Risk parity rotation with SMA200 + momentum dual filter on 6 multi-asset ETFs |
+
+## References
+
+- Hurst, B., Ooi, Y.H., Pedersen, L.H. (2014). *A Century of Evidence on Trend-Following Investing*. AQR.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-RiskParity-Composite/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-RiskParity-Composite/README.md
@@ -1,14 +1,14 @@
 # Cloud-RiskParity-Composite
 
-**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+**Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**Cloud project ID:** N/A
+**ID projet Cloud :** N/A
 
 ## Description
 
-Tactical rotation across six asset classes (SPY, TLT, GLD, EFA, EEM, DBC) using a dual filter: price above SMA200 AND positive 6-month momentum. Assets passing both filters receive equal weight. Rebalances every 30 days. Inspired by AQR's Hurst, Ooi, and Pedersen (2014) approach to trend-following with risk parity allocation.
+Rotation tactique à travers six classes d'actifs (SPY, TLT, GLD, EFA, EEM, DBC) en utilisant un double filtre : prix au-dessus du SMA200 ET momentum positif sur 6 mois. Les actifs passant les deux filtres reçoivent une pondération égale. Rebalance tous les 30 jours. Inspiré de l'approche de trend-following avec allocation en parité de risque de Hurst, Ooi et Pedersen (2014) chez AQR.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,21 +16,21 @@ lean backtest --algorithm Cloud-RiskParity-Composite/main.py
 ```
 
 ### QC Cloud
-Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+Créer un nouveau projet, téléverser `main.py`, compiler et lancer un backtest (défaut : 2015-01-01 au 2024-12-31).
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Dual-filter Risk Parity | 30 days | SMA200 + 6-month momentum, equal weight among passing assets |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| Parité de risque à double filtre | 30 jours | SMA200 + momentum 6 mois, pondération égale entre les actifs retenus |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | Risk parity rotation with SMA200 + momentum dual filter on 6 multi-asset ETFs |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Rotation parité de risque avec double filtre SMA200 + momentum sur 6 ETF multi-actifs |
 
-## References
+## Références
 
-- Hurst, B., Ooi, Y.H., Pedersen, L.H. (2014). *A Century of Evidence on Trend-Following Investing*. AQR.
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- Hurst, B., Ooi, Y.H., Pedersen, L.h. (2014). *A Century of Evidence on Trend-Following Investing*. AQR.
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.en.md
@@ -1,0 +1,35 @@
+# Cloud-SectorRotation-Momentum
+
+**Asset class:** Equities, Bonds, Commodities (ETF rotation)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Momentum-weighted trend following on a 5-ETF universe (QQQ, SPY, EFA, GLD, IWM) with SHY as the defensive cash equivalent. Uses a dual filter (price above SMA200 AND positive 6-month momentum) to select trending assets, then allocates proportionally to their rate-of-change (ROC) momentum scores. Rebalances every 21 trading days.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-SectorRotation-Momentum/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Momentum-weighted trend following | 21 days | SMA200 + 6m momentum dual filter, ROC proportional weighting |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Sector rotation with momentum-weighted allocation and dual trend filter |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.md
@@ -1,14 +1,14 @@
 # Cloud-SectorRotation-Momentum
 
-**Asset class:** Equities, Bonds, Commodities (ETF rotation)
+**Classe d'actifs :** Actions, Obligations, Matières premières (rotation d'ETF)
 
-**Cloud project ID:** N/A
+**ID projet Cloud :** N/A
 
 ## Description
 
-Momentum-weighted trend following on a 5-ETF universe (QQQ, SPY, EFA, GLD, IWM) with SHY as the defensive cash equivalent. Uses a dual filter (price above SMA200 AND positive 6-month momentum) to select trending assets, then allocates proportionally to their rate-of-change (ROC) momentum scores. Rebalances every 21 trading days.
+Trend-following pondéré par momentum sur un univers de 5 ETF (QQQ, SPY, EFA, GLD, IWM) avec SHY comme équivalent cash défensif. Utilise un double filtre (prix au-dessus du SMA200 ET momentum positif sur 6 mois) pour sélectionner les actifs en tendance, puis alloue proportionnellement à leurs scores de momentum mesurés par taux de variation (ROC). Rebalance tous les 21 jours de bourse.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,20 +16,20 @@ lean backtest --algorithm Cloud-SectorRotation-Momentum/main.py
 ```
 
 ### QC Cloud
-Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+Créer un nouveau projet, téléverser `main.py`, compiler et lancer un backtest (défaut : 2015-01-01 au 2024-12-31).
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Momentum-weighted trend following | 21 days | SMA200 + 6m momentum dual filter, ROC proportional weighting |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| Trend-following pondéré par momentum | 21 jours | Double filtre SMA200 + momentum 6 mois, pondération proportionnelle au ROC |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | Sector rotation with momentum-weighted allocation and dual trend filter |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Rotation sectorielle avec allocation pondérée par momentum et double filtre de tendance |
 
-## References
+## Références
 
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.en.md
@@ -1,0 +1,35 @@
+# Cloud-VolTargeting
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Volatility targeting strategy with three variants. v1 targets 12% annualized volatility on SPY alone using realized vol scaling. v2 extends to a multi-asset portfolio (SPY, QQQ, IEF, GLD) with equal risk contribution targeting 10% annualized vol. v3 adds a 126-day momentum filter to the multi-asset approach. Monthly rebalance across all variants.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-VolTargeting/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Vol targeting (3 variants) | Monthly | Vol target 10-12%, momentum filter 126 days (v3), equal risk contribution (v2/v3) |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Volatility targeting algorithm with 3 variants (single-asset, multi-asset ERC, +momentum) |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.md
@@ -1,14 +1,14 @@
 # Cloud-VolTargeting
 
-**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+**Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**Cloud project ID:** N/A
+**ID projet Cloud :** N/A
 
 ## Description
 
-Volatility targeting strategy with three variants. v1 targets 12% annualized volatility on SPY alone using realized vol scaling. v2 extends to a multi-asset portfolio (SPY, QQQ, IEF, GLD) with equal risk contribution targeting 10% annualized vol. v3 adds a 126-day momentum filter to the multi-asset approach. Monthly rebalance across all variants.
+Stratégie de ciblage de volatilité avec trois variantes. v1 cible 12 % de volatilité annualisée sur SPY seul via une mise à l'échelle par volatilité réalisée. v2 étend à un portefeuille multi-actifs (SPY, QQQ, IEF, GLD) avec une contribution en risque égale ciblant 10 % de volatilité annualisée. v3 ajoute un filtre de momentum sur 126 jours à l'approche multi-actifs. Rebalance mensuelle pour toutes les variantes.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,20 +16,20 @@ lean backtest --algorithm Cloud-VolTargeting/main.py
 ```
 
 ### QC Cloud
-Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+Créer un nouveau projet, téléverser `main.py`, compiler et lancer un backtest (défaut : 2015-01-01 au 2024-12-31).
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Vol targeting (3 variants) | Monthly | Vol target 10-12%, momentum filter 126 days (v3), equal risk contribution (v2/v3) |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| Ciblage de volatilité (3 variantes) | Mensuelle | Cible de vol 10-12 %, filtre momentum 126 jours (v3), contribution en risque égale (v2/v3) |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | Volatility targeting algorithm with 3 variants (single-asset, multi-asset ERC, +momentum) |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Algorithme de ciblage de volatilité avec 3 variantes (actif unique, multi-actifs ERC, +momentum) |
 
-## References
+## Références
 
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)


### PR DESCRIPTION
## Summary

Francise 4 QC Cloud-* strategy project READMEs to French per readme-french-first HARD 2 (Phase 0.5 of #1650):

- `Cloud-MeanReversion-Sectors` — RSI(14) mean reversion on 11 GICS sector ETFs
- `Cloud-RiskParity-Composite` — tactical rotation, dual SMA200+momentum filter (AQR Hurst/Ooi/Pedersen 2014)
- `Cloud-SectorRotation-Momentum` — momentum-weighted trend-following on 5 ETFs + SHY
- `Cloud-VolTargeting` — vol-targeting, 3 variants (single-asset / multi-asset ERC / +momentum)

## Method (readme-french-first HARD 2)

1. `git mv README.md README.en.md` — EN original preserved **byte-identical** (verified: `git show HEAD:README.md` diff vs `.en.md` = empty for all 4).
2. New `README.md` in French: same structure, same links/anchors, faithful translation, **0 invented metrics** (all numbers copied verbatim from EN — RSI period 14, SMA200, vol target 10-12%, 126-day momentum, 21/30-day rebalance, etc.).

## Validation

- **EN preservation**: byte-identical, all 4 ✓
- **Line parity**: 35/35, 36/36, 35/35, 35/35 (FR faithful to EN structure)
- **Scope**: markdown-only (8 files: 4 `.en.md` preserved + 4 new FR `.md`). Zero code touched, zero catalog markers (READMEs don't carry CATALOG-STATUS).
- **No re-execution** (C.2 N/A — these are `.md` files, not notebooks).
- +202/-61, atomic single-family tranche.

## Context — backlog pickup (not phantom)

ai-01 steer \"#2801->#1630 baselines\" pointed at **CLOSED** issues (phantom, verified firsthand G.1 — both #1630 and #2801 are CLOSED, baselines consolidated in `docs/qc/qc-comparative-backtests.md`). Pivoted to **#3870 Phase 0.5** (FR backfill of EN READMEs — perenne rollout, coordinator-discipline règle 4.3 \"never-empty\"). Scan found **98 QC project READMEs genuinely EN-only** (repo-wide family); this PR = the coherent Cloud-* family tranche.

See #3870 (Phase 0.5 partial contribution). See #1650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)