### PR TITLE
docs(vibe-coding): section Mémoire Sémantique Qdrant (infra de grounding) — #4432

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/README.md
@@ -1,0 +1,109 @@
+# Mémoire Sémantique Qdrant - Infrastructure de Grounding
+
+[← Vibe-Coding](../README.md) | [↑ ..](../README.md)
+
+Les sections [Claude Code](../Claude-Code/), [Roo Code](../Roo-Code/) et [Claw Systems](../Claw-Systems/) décrivent des **front-ends d'agents** : les interfaces par lesquelles un humain (ou un bot) pilote un assistant de codage. Cette section documente la couche d'en dessous : le **backend de mémoire sémantique** qui donne à ces agents une mémoire long-terme et les ancre dans des faits vérifiables plutôt que dans des suppositions.
+
+Concrètement, c'est le récit d'une infrastructure réelle, opérée en continu sur un cluster de machines de développement : une base de données vectorielle [Qdrant](https://qdrant.tech/) qui indexe l'historique des conversations d'agents et le code des dépôts, interrogée à chaque tâche pour retrouver « ce qui a déjà été dit, écrit, décidé ». Le contenu est volontairement honnête sur les incidents traversés (pertes de données, dérives de montage disque, sauvegardes à moitié câblées) : ces pannes sont la matière pédagogique la plus utile.
+
+> Avertissement de scope : ce répertoire documente le **backend mémoire/recherche** (Qdrant, embeddings, indexation, grounding). Les architectures d'agents autonomes sont couvertes par [Claw Systems](../Claw-Systems/), et l'assurance qualité des notebooks par leurs sections respectives. Tous les exemples sont **anonymisés** : aucune clé d'API, aucun secret, aucune adresse interne réelle.
+
+## Pourquoi une section Mémoire Sémantique ?
+
+| Aspect | Front-ends agents (Claude/Roo/Claw) | Mémoire sémantique (cette section) |
+|--------|-------------------------------------|-------------------------------------|
+| **Rôle** | Exécuter la tâche demandée | Fournir le contexte vérifié à l'agent |
+| **Question posée** | « Comment fais-je X ? » | « Qu'a-t-on déjà fait autour de X ? » |
+| **Objet** | LLM + outils | Base vectorielle + embeddings + indexation |
+| **Horizon mémoire** | La session courante | L'historique complet du cluster |
+| **Échec typique** | Mauvaise édition de code | Hallucination faute de contexte |
+| **Persistance** | Éphémère (le contexte se résume) | Durable (sur disque, sauvegardée) |
+
+Un assistant de codage sans mémoire externe ré-explore le même terrain à chaque session, re-pose des questions déjà tranchées, et finit par **halluciner** un état du projet qui n'existe plus. La mémoire sémantique répond à ce manque : elle transforme des milliers de conversations et de fichiers en un index interrogeable par le sens, pas seulement par les mots-clés.
+
+## Écosystème
+
+Quatre briques coopèrent pour former la chaîne de grounding :
+
+1. **Qdrant** — le moteur de recherche vectorielle (écrit en Rust). Il stocke des *points* (un vecteur + une charge utile JSON) regroupés en *collections*, et répond à des requêtes de plus proches voisins via un index HNSW.
+2. **Le service d'embeddings** — un modèle auto-hébergé (`qwen3-4b-awq`, 2560 dimensions) qui transforme un texte en vecteur. Il a remplacé une API commerciale propriétaire (1536 dimensions), coûteuse et fermée.
+3. **Le serveur MCP `roo-state-manager`** — le pont entre les agents et Qdrant. Il indexe les conversations et les dépôts, et expose des outils de recherche (`codebase_search`, `roosync_search`) directement dans l'agent.
+4. **La flotte d'agents** — Claude Code et Roo Code, sur plusieurs machines, qui produisent le contenu indexé *et* le consomment via les outils de recherche.
+
+## Schéma du pipeline
+
+```text
+   Conversations d'agents          Dépôts de code
+   (Claude Code, Roo Code)         (fichiers source)
+            │                             │
+            └──────────────┬──────────────┘
+                           ▼
+              Découpage en fragments (chunking)
+                           ▼
+              Service d'embeddings (qwen3-4b-awq, 2560d)
+                           ▼
+              Qdrant — upsert dans une collection
+              (vecteur + payload : source, date, type…)
+                           ▼
+   ┌───────────────────────────────────────────────┐
+   │  Requête de l'agent : codebase_search(...)     │
+   │   texte → embedding → recherche HNSW → top-k   │
+   └───────────────────────────────────────────────┘
+                           ▼
+              Fragments pertinents réinjectés
+              dans le contexte de l'agent (grounding)
+```
+
+## Structure
+
+```text
+Memoire-Semantique-Qdrant/
+├── README.md                              # Ce fichier — cadrage et vue d'ensemble
+├── docs/
+│   ├── 01-Pourquoi-Memoire-Semantique.md  # Le besoin : grounding, SDDD, RAG
+│   ├── 02-Infrastructure-Qdrant.md        # Le déploiement : Docker, WSL2, quantization
+│   ├── 03-Utilisation-MCP-Indexation.md   # L'usage : MCP, indexation, recherche
+│   └── 04-Incidents-et-Lecons.md          # Les pannes réelles et ce qu'elles enseignent
+└── configs/
+    ├── docker-compose.qdrant.example.yml  # Template Docker Compose (anonymisé)
+    ├── qdrant.production.example.yaml      # Config moteur (HNSW, quantization, limites)
+    └── qdrant.env.example                  # Variables d'environnement (placeholders)
+```
+
+## Parcours de lecture
+
+| Document | Vous y apprendrez | Niveau |
+|----------|-------------------|--------|
+| [01 - Pourquoi la mémoire sémantique](docs/01-Pourquoi-Memoire-Semantique.md) | Pourquoi une base vectorielle, ce qu'est le grounding, la méthode SDDD | Débutant+ |
+| [02 - Infrastructure Qdrant](docs/02-Infrastructure-Qdrant.md) | Déployer Qdrant en Docker, le stockage WSL2, la quantization TurboQuant, l'anti-split-brain | Intermédiaire |
+| [03 - Utilisation et indexation](docs/03-Utilisation-MCP-Indexation.md) | Brancher un agent via MCP, indexer code et conversations, requêter par le sens | Intermédiaire |
+| [04 - Incidents et leçons](docs/04-Incidents-et-Lecons.md) | Diagnostiquer une dérive de montage, une perte de données, durcir les sauvegardes | Avancé |
+
+## Infrastructure requise
+
+| Composant | Rôle | Empreinte indicative |
+|-----------|------|----------------------|
+| Qdrant (Docker) | Base vectorielle | 1 conteneur, RAM selon volume (dizaines de Go) |
+| Service d'embeddings | Texte → vecteur | 1 modèle ~4B en VRAM, ou API |
+| Serveur MCP | Pont agent ↔ Qdrant | Process Node, léger |
+| Stockage dédié | Données Qdrant | Disque virtuel isolé (VHDX/volume), proportionnel au corpus |
+
+## Prérequis
+
+- **Docker** + Docker Compose.
+- Notions de **base de données vectorielle** et de **plongements** (embeddings) — couvertes dans le [document 01](docs/01-Pourquoi-Memoire-Semantique.md).
+- Pour reproduire l'usage avec un agent : une installation [Claude Code](../Claude-Code/) ou [Roo Code](../Roo-Code/) et le serveur MCP correspondant.
+- Pour la partie infrastructure avancée (document 02/04) : familiarité avec WSL2 sous Windows, ou un hôte Linux équivalent.
+
+## Liens
+
+- [Pourquoi la mémoire sémantique](docs/01-Pourquoi-Memoire-Semantique.md)
+- [Infrastructure Qdrant](docs/02-Infrastructure-Qdrant.md)
+- [Utilisation et indexation](docs/03-Utilisation-MCP-Indexation.md)
+- [Incidents et leçons](docs/04-Incidents-et-Lecons.md)
+- [Documentation Qdrant officielle](https://qdrant.tech/documentation/)
+- [Vibe-Coding (parent)](../README.md)
+
+---
+
+*Section Mémoire Sémantique Qdrant - Juin 2026*

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/configs/docker-compose.qdrant.example.yml
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/configs/docker-compose.qdrant.example.yml
@@ -1,0 +1,98 @@
+# Template Docker Compose - Qdrant production (ANONYMISE)
+# ------------------------------------------------------
+# Exemple pedagogique derive d'une configuration reelle. A adapter :
+#   - le bind de volume (section `volumes`) doit pointer vers VOTRE stockage monte ;
+#   - la cle d'API se met dans un fichier `.env` NON versionne (voir qdrant.env.example) ;
+#   - aucune valeur sensible ne doit figurer dans ce fichier.
+#
+# Demarrer :  docker compose -f docker-compose.qdrant.example.yml up -d
+# Sante    :  curl http://localhost:6333/healthz
+
+services:
+  qdrant:
+    # Version EPINGLEE (jamais ':latest' en production : un tag mouvant peut
+    # sauter de version au prochain pull et casser le format de quantization).
+    # TurboQuant (quantization 4 bits) requiert le moteur >= 1.18.0.
+    image: qdrant/qdrant:v1.18.2
+    container_name: qdrant_production
+    restart: always
+
+    # Periode de grace a l'arret pour un flush propre des donnees.
+    stop_grace_period: 60s
+
+    # GARDE-FOU ANTI-SPLIT-BRAIN (sentinelle).
+    # La sentinelle vit SUR le disque de donnees (/qdrant/storage/.qdrant_vhdx_sentinel).
+    # Si le bind se resout vers un repertoire vide (disque non monte), la sentinelle
+    # est absente -> exit 1, au lieu de servir un index vide et de "reindexer dans le vide".
+    # `exec ./entrypoint.sh` garde l'entrypoint d'origine comme PID 1 (arret gracieux preserve).
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        if [ ! -f /qdrant/storage/.qdrant_vhdx_sentinel ]; then
+          echo "[SENTINEL] FATAL: sentinelle absente -- disque non monte. Refus de demarrer." >&2
+          exit 1
+        fi
+        echo "[SENTINEL] OK: sentinelle presente, demarrage Qdrant."
+        exec ./entrypoint.sh
+
+    # La cle d'API et les variables sensibles vivent ICI, hors du fichier compose.
+    env_file:
+      - .env            # cf. qdrant.env.example (NE PAS versionner le vrai .env)
+
+    environment:
+      - QDRANT__SERVICE__MAX_REQUEST_SIZE_MB=32
+      - QDRANT__SERVICE__GRPC_TIMEOUT_MS=60000
+      - QDRANT__LOG_LEVEL=INFO
+      - QDRANT__TELEMETRY_DISABLED=true
+
+    ports:
+      - "6333:6333"     # HTTP / REST
+      - "6334:6334"     # gRPC
+
+    volumes:
+      # ADAPTER : ces chemins doivent pointer vers VOTRE stockage monte (disque dedie).
+      # Exemple generique ci-dessous -- remplacer par le chemin reel de l'hote.
+      - "${QDRANT_STORAGE_PATH:-./qdrant_data/storage}:/qdrant/storage"
+      - "${QDRANT_SNAPSHOTS_PATH:-./qdrant_data/snapshots}:/qdrant/snapshots"
+      - ./qdrant.production.example.yaml:/qdrant/config/production.yaml
+
+    deploy:
+      resources:
+        limits:
+          memory: 60G    # marge large au-dessus de l'empreinte reelle
+          cpus: '12'
+        reservations:
+          memory: 24G
+          cpus: '4'
+
+    # Healthcheck HTTP reel (detecte un freeze, pas seulement un crash).
+    # L'image n'a ni curl ni wget mais a bash : on utilise /dev/tcp.
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 10 bash -c 'exec 3<>/dev/tcp/localhost/6333; echo -e \"GET /healthz HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n\" >&3; timeout 5 cat <&3; exec 3>&-' | grep -q 'healthz check passed'"]
+      interval: 30s
+      timeout: 15s
+      retries: 5
+      # IMPORTANT : assez long pour couvrir la recovery a froid d'un gros index
+      # (plusieurs minutes). Trop court, l'autoheal tue le conteneur avant la fin
+      # de la recovery -> boucle de redemarrage.
+      start_period: 600s
+
+  # Autoheal : redemarre le conteneur si le healthcheck echoue plusieurs fois
+  # (Docker Compose hors-swarm ne redemarre pas les conteneurs "unhealthy").
+  autoheal:
+    image: willfarrell/autoheal
+    container_name: qdrant_autoheal
+    restart: always
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=all
+      - AUTOHEAL_INTERVAL=60
+      - AUTOHEAL_START_PERIOD=300
+      - AUTOHEAL_DEFAULT_STOP_TIMEOUT=60
+    volumes:
+      - //var/run/docker.sock:/var/run/docker.sock
+
+# RAPPELS :
+# - Ne jamais utiliser `--remove-orphans` si deux instances partagent le meme nom
+#   de projet Compose : cela supprimerait les conteneurs de l'autre instance.
+# - Resoudre le disque de donnees par son LABEL, jamais par sa lettre de peripherique.

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/configs/qdrant.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/configs/qdrant.env.example
@@ -1,0 +1,25 @@
+# Variables d'environnement Qdrant (TEMPLATE)
+# --------------------------------------------
+# Copier ce fichier en `.env` et renseigner les valeurs. Le `.env` reel
+# NE DOIT JAMAIS etre versionne (l'ajouter au .gitignore) ni affiche dans un log.
+#
+#   cp qdrant.env.example .env
+#   # puis editer .env avec la vraie cle
+
+# Cle d'API du service Qdrant (convention Qdrant : double tiret bas pour les
+# variables imbriquees). Generer une chaine longue et aleatoire ; NE PAS reutiliser
+# une cle d'un autre service. Laisser vide desactive l'authentification (a eviter).
+QDRANT__SERVICE__API_KEY=<votre-cle-api-aleatoire>
+
+# Chemins de l'hote vers le stockage monte (disque dedie). Adapter a votre machine.
+# Resoudre le disque par son LABEL au montage, jamais par sa lettre de peripherique.
+QDRANT_STORAGE_PATH=/chemin/vers/qdrant_data/storage
+QDRANT_SNAPSHOTS_PATH=/chemin/vers/qdrant_data/snapshots
+
+# --- Service d'embeddings (exemple ; depend de votre deploiement) ---
+# URL et cle du service qui transforme un texte en vecteur. Pour un modele
+# auto-heberge, pointer vers son endpoint local ; pour une API, mettre l'URL fournie.
+EMBEDDING_API_URL=http://localhost:8000/v1
+EMBEDDING_API_KEY=<votre-cle-embeddings>
+EMBEDDING_MODEL=qwen3-4b-awq
+EMBEDDING_DIM=2560

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/configs/qdrant.production.example.yaml
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/configs/qdrant.production.example.yaml
@@ -1,0 +1,68 @@
+# Configuration Qdrant - Production (TEMPLATE PEDAGOGIQUE)
+# --------------------------------------------------------
+# Reglages tires d'une configuration en production pour un gros volume de
+# vecteurs (millions de points, 2560 dimensions). Les valeurs sont alignees
+# avec les limites Docker du fichier docker-compose.qdrant.example.yml
+# (60 Go RAM / 12 CPU). Aucune valeur ci-dessous n'est sensible.
+#
+# Rappel important : la quantization (TurboQuant 4 bits) et les payload indexes
+# se configurent PAR COLLECTION via l'API, pas dans ce fichier global.
+
+log_level: INFO
+
+storage:
+  storage_path: /qdrant/storage
+  snapshots_path: /qdrant/snapshots
+  on_disk_payload: true
+
+  wal:
+    # Marge WAL pour les upserts frequents.
+    wal_capacity_mb: 512
+
+  performance:
+    # Aligne avec la limite Docker `cpus: '12'`.
+    max_search_threads: 12
+    # Reduit volontairement pour eviter la contention optimiseur vs ecritures
+    # (cause classique de freeze sous charge d'indexation concurrente).
+    max_optimization_threads: 4
+
+  optimizers:
+    # Intervalle de flush : plus long = moins de pression I/O pendant les writes.
+    flush_interval_sec: 10
+    # Auto-detection du nombre de segments.
+    default_segment_number: 0
+    # Plafonne la taille d'un segment (eviter les segments geants).
+    max_segment_size_kb: 512000
+    # Bascule sur memmap au-dela de ce seuil.
+    memmap_threshold_kb: 250000
+    # CLE : indexer des ~1000 points au lieu de faire un balayage complet O(n).
+    # Une valeur trop haute laisse les petites collections non indexees.
+    indexing_threshold_kb: 6000
+    # Nettoyage des vecteurs supprimes (vacuum).
+    deleted_threshold: 0.2
+    vacuum_min_vector_number: 1000
+
+  hnsw_index:
+    # Index HNSW sur disque pour economiser la RAM.
+    on_disk: true
+    # m : nombre de connexions par noeud (qualite vs memoire).
+    m: 32
+    # ef_construct : taille de la liste dynamique a la construction (qualite vs temps).
+    ef_construct: 200
+    # Legerement sous le max CPU pour laisser respirer les threads de recherche.
+    max_indexing_threads: 10
+
+service:
+  # Pool de workers API, aligne avec la limite Docker CPU.
+  max_workers: 12
+  # Protege contre les requetes HTTP volumineuses.
+  max_request_size_mb: 32
+  # Evite qu'une requete gRPC bloque indefiniment.
+  grpc_timeout_ms: 60000
+  enable_cors: true
+
+# NOTES :
+# - Aligner ce fichier avec les limites du docker-compose (RAM / CPU).
+# - La somme des threads (workers + search + optim + indexing) peut depasser le
+#   nombre de coeurs : c'est tolere, mais surveiller la contention sous charge.
+# - Quantization et payload indexes : voir la doc 02 et l'API de collection.

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/docs/01-Pourquoi-Memoire-Semantique.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/docs/01-Pourquoi-Memoire-Semantique.md
@@ -1,0 +1,84 @@
+# 01 - Pourquoi la mémoire sémantique ?
+
+[← Mémoire Sémantique Qdrant](../README.md) | [→ Infrastructure Qdrant](02-Infrastructure-Qdrant.md)
+
+Ce document explique le **besoin** auquel répond une base de données vectorielle dans un système d'agents de codage. Avant de déployer quoi que ce soit (document 02), il faut comprendre *pourquoi* on le déploie.
+
+## 1. Le problème : un agent n'a pas de mémoire
+
+Un assistant de codage comme Claude Code ou Roo Code raisonne dans une **fenêtre de contexte** limitée. Tout ce qui n'y tient pas est, du point de vue de l'agent, inexistant. Concrètement, cela produit trois pathologies récurrentes :
+
+- **L'amnésie inter-sessions.** À chaque nouvelle session, l'agent repart de zéro. Une décision d'architecture prise hier, un bug déjà diagnostiqué la semaine dernière, un script déjà écrit : rien de tout cela n'est « su » par défaut.
+- **La re-exploration coûteuse.** Faute de mémoire, l'agent relit les mêmes fichiers, repose les mêmes questions, refait les mêmes recherches. C'est lent et cela consomme des jetons.
+- **L'hallucination par manque d'ancrage.** Privé du contexte réel, le modèle comble les trous par des plausibilités. Il « se souvient » d'une fonction qui a été renommée, propose une approche déjà testée et rejetée, ou affirme un état du projet périmé.
+
+La mémoire sémantique attaque ces trois problèmes en donnant à l'agent un **magasin externe et durable** qu'il peut interroger à la demande : l'historique des conversations et le code des dépôts, indexés de telle sorte qu'une question en langage naturel retrouve les fragments pertinents.
+
+## 2. Pourquoi « sémantique » et pas juste `grep` ?
+
+La recherche lexicale (`grep`, `Ctrl+F`, `LIKE '%mot%'`) cherche des **suites de caractères**. Elle est rapide, exacte et irremplaçable quand on connaît le terme précis. Mais elle est aveugle au **sens** :
+
+- Une recherche `grep "limitation de débit"` ne trouvera pas un passage qui parle de *rate limiting*, de *throttling* ou de *quota d'appels* — pourtant le même concept.
+- À l'inverse, `grep "base"` ramènera la base de données, la base d'un cas récursif, la classe de base et le camp de base, sans distinction.
+
+La recherche **sémantique** compare des *significations*. Chaque texte est projeté dans un espace vectoriel où la proximité géométrique reflète la proximité de sens. « Limiter le nombre de requêtes par seconde » et « rate limiting » y tombent côte à côte, même sans aucun mot commun.
+
+Les deux approches sont **complémentaires**, pas concurrentes. Une bonne méthodologie d'agent croise systématiquement :
+
+- le **lexical** (`grep`, `glob`) quand on connaît le symbole exact,
+- le **sémantique** (recherche vectorielle) quand on cherche un concept, une intention, « le truc qui faisait à peu près ça ».
+
+## 3. Plongements et similarité : l'idée en une page
+
+Un **plongement** (*embedding*) est un vecteur de nombres réels — par exemple 2560 dimensions dans notre infrastructure — produit par un modèle de langage entraîné pour que des textes de sens proche aient des vecteurs proches.
+
+```text
+"limiter les requêtes par seconde"  →  [0.12, -0.04, 0.88, ... ]  (2560 nombres)
+"throttling des appels API"          →  [0.11, -0.05, 0.86, ... ]  (vecteur voisin)
+"recette de la tarte aux pommes"     →  [-0.7,  0.33, 0.01, ... ]  (vecteur éloigné)
+```
+
+La **similarité** entre deux vecteurs se mesure le plus souvent par le **cosinus** de l'angle qui les sépare (1 = identique, 0 = sans rapport). Rechercher, c'est donc : embarquer la requête, puis trouver les *k* points de la base dont le vecteur est le plus proche. Sur des millions de points, un balayage exhaustif serait trop lent ; c'est pourquoi Qdrant utilise un index approché **HNSW** (détaillé au [document 02](02-Infrastructure-Qdrant.md)).
+
+C'est le socle du motif **RAG** (*Retrieval-Augmented Generation*) : au lieu de tout demander au modèle de mémoire, on **récupère** d'abord les fragments pertinents dans la base vectorielle, puis on les **injecte** dans le contexte pour que la génération soit ancrée sur des faits réels.
+
+## 4. La base vectorielle comme mémoire d'une flotte
+
+Dans notre cas, plusieurs machines de développement exécutent des agents en continu. Chacune produit des conversations, des décisions, des diagnostics. Tout est indexé dans une collection centrale (nommée ici `roo_tasks_semantic_index`). Le résultat est une **mémoire partagée** :
+
+- Un agent sur la machine A peut retrouver, par le sens, ce qu'un agent sur la machine B a résolu trois jours plus tôt.
+- Les leçons d'incidents (cf. [document 04](04-Incidents-et-Lecons.md)) deviennent interrogeables : « comment a-t-on récupéré la dernière dérive de montage ? ».
+- Le code de dizaines de dépôts est indexé séparément, de sorte que `codebase_search` retrouve l'implémentation d'un concept sans connaître le nom du fichier.
+
+C'est cette mutualisation qui justifie d'investir dans une infrastructure robuste : la base n'est pas un cache jetable, c'est un actif. D'où l'importance des sauvegardes et des garde-fous anti-corruption décrits plus loin.
+
+## 5. SDDD : ancrer le travail dans trois sources
+
+La méthode que nous appliquons s'appelle **SDDD** (*Semantic-Documentation-Driven-Design*). Son principe : ne jamais agir sur une seule source d'information, mais **croiser trois ancrages** avant toute tâche significative.
+
+| Ancrage | Source | Outil typique |
+|---------|--------|---------------|
+| **Technique** | Le code, qui fait foi | lecture de fichiers, `grep`, `git` |
+| **Conversationnel** | L'historique des échanges | navigation dans les conversations indexées |
+| **Sémantique** | La recherche par le sens | `codebase_search`, recherche vectorielle |
+
+Deux pratiques en découlent :
+
+- **Le motif « serre-livres » (bookend).** On lance une recherche sémantique *au début* d'une tâche (pour ne pas refaire ce qui existe et trouver la doc afférente) et *à la fin* (pour vérifier que le travail est retrouvable et la documentation à jour).
+- **Le scepticisme.** Une information non vérifiée n'est jamais propagée telle quelle. On qualifie ce que l'on rapporte : vérifié dans le code, rapporté par une source, ou supposé.
+
+La mémoire sémantique n'est donc pas un gadget : c'est l'outil qui rend l'ancrage *conversationnel* et *sémantique* possible à l'échelle d'un historique que personne ne pourrait relire à la main.
+
+## 6. Ce qu'il faut retenir
+
+- Un agent de codage est, par construction, **amnésique** au-delà de sa fenêtre de contexte.
+- Une base vectorielle lui fournit une **mémoire externe, durable et interrogeable par le sens**.
+- La recherche sémantique **complète** la recherche lexicale, elle ne la remplace pas.
+- À l'échelle d'une flotte, cette mémoire devient un **actif partagé** qu'il faut traiter avec le sérieux qu'on accorde à une base de production (sauvegardes, garde-fous).
+- La méthode **SDDD** opérationnalise tout cela : croiser technique, conversationnel et sémantique, en serre-livres, avec scepticisme.
+
+---
+
+Document suivant : [02 - Infrastructure Qdrant](02-Infrastructure-Qdrant.md) — comment cette mémoire est concrètement déployée.
+
+[← Retour au README de la section](../README.md)

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/docs/02-Infrastructure-Qdrant.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/docs/02-Infrastructure-Qdrant.md
@@ -1,0 +1,145 @@
+# 02 - Infrastructure Qdrant
+
+[← 01 Pourquoi](01-Pourquoi-Memoire-Semantique.md) | [Mémoire Sémantique Qdrant](../README.md) | [→ 03 Utilisation](03-Utilisation-MCP-Indexation.md)
+
+Ce document décrit le **déploiement réel** de la base vectorielle : le moteur, son conteneur, son stockage, sa quantization, et les garde-fous qui le protègent. Les valeurs et configurations sont tirées d'une infrastructure en production ; les templates anonymisés correspondants sont dans [`configs/`](../configs/).
+
+## 1. Qdrant en deux minutes
+
+[Qdrant](https://qdrant.tech/) est un moteur de recherche vectorielle écrit en **Rust**. Son vocabulaire :
+
+- **Collection** : un ensemble de points partageant la même dimension de vecteur et la même configuration (l'équivalent d'une table).
+- **Point** : l'unité stockée = un identifiant + un **vecteur** + une **charge utile** (*payload*) JSON arbitraire (date, source, type de fragment, identifiant de tâche…).
+- **Index HNSW** (*Hierarchical Navigable Small World*) : un graphe de navigation qui rend la recherche des plus proches voisins *approchée* mais très rapide, au lieu d'un balayage exhaustif `O(n)`.
+- **Payload index** : un index secondaire sur un champ de la charge utile, pour filtrer efficacement (par exemple « seulement les points dont `source = claude` et `date > ...` »).
+
+Qdrant expose deux API : **REST** (HTTP, port 6333) et **gRPC** (port 6334, plus rapide pour les gros volumes).
+
+## 2. Deux instances Docker
+
+L'infrastructure fait tourner **deux** conteneurs Qdrant distincts, pour isoler les charges :
+
+| Instance | Ports (REST/gRPC) | Stockage | Usage |
+|----------|-------------------|----------|-------|
+| **Production** | 6333 / 6334 | Disque virtuel dédié (VHDX) | Mémoire de la flotte, charge lourde |
+| **Étudiants** | 6335 / 6336 | Volumes Docker | Travaux pratiques, charge légère |
+
+Les deux sont pilotés par Docker Compose. Le moteur est **épinglé à une version précise** (`qdrant/qdrant:v1.18.2`) plutôt qu'à un tag mouvant comme `:latest`. C'est une décision délibérée : un `:latest` peut sauter de version au prochain `pull` et introduire un changement de comportement non désiré. Épingler, c'est rendre les mises à niveau **explicites et réversibles** (cf. [document 04](04-Incidents-et-Lecons.md), montée de version).
+
+Commandes de base :
+
+```bash
+# Démarrer la production
+docker compose -f docker-compose.production.yml up -d
+
+# Vérifier la santé
+curl http://localhost:6333/healthz       # production
+curl http://localhost:6335/healthz       # étudiants
+
+# Lister les collections (l'authentification est détaillée plus bas)
+curl -H "api-key: $QDRANT__SERVICE__API_KEY" http://localhost:6333/collections
+```
+
+> Piège opérationnel : ne jamais utiliser `--remove-orphans` quand deux instances partagent le même nom de projet Compose — cela supprimerait les conteneurs de l'autre instance.
+
+## 3. Le service d'embeddings
+
+Qdrant **ne calcule pas** les vecteurs : il les stocke et les compare. Le calcul est délégué à un service d'embeddings séparé.
+
+Notre infrastructure utilise un modèle **auto-hébergé**, `qwen3-4b-awq`, qui produit des vecteurs de **2560 dimensions**. Il a remplacé une API commerciale propriétaire (1536 dimensions), pour deux raisons :
+
+- **Coût** : facturer chaque embedding d'un corpus de plusieurs millions de fragments réindexés en continu devient prohibitif.
+- **Souveraineté** : un modèle local évite d'envoyer l'intégralité des conversations et du code à un tiers.
+
+Conséquence structurante : **changer de modèle d'embeddings change la dimension des vecteurs**, donc impose de **recréer toutes les collections** et de tout réindexer. La dimension est un contrat figé à la création de la collection ; on ne migre pas un index 1536d vers 2560d, on le reconstruit.
+
+## 4. Le stockage : un disque virtuel dédié (WSL2 VHDX)
+
+Sur l'hôte Windows, Qdrant tourne dans Docker via WSL2. Les données de production ne vivent **pas** sur le système de fichiers de la distribution Linux par défaut, mais sur un **disque virtuel dédié** (un fichier VHDX, monté dans WSL2 et identifié par un *label* de système de fichiers, ici `qdrant-e`).
+
+Pourquoi cette séparation :
+
+- **Isolation** : les données Qdrant ne sont pas mêlées au reste de la distribution ; on peut les sauvegarder, déplacer ou compacter indépendamment.
+- **Capacité** : un VHDX peut être placé sur un disque secondaire spacieux, loin du disque système.
+
+Mais cette architecture introduit un **risque majeur** : si le VHDX n'est pas monté au démarrage du conteneur, le point de montage Docker se résout vers un répertoire **vide** de la distribution par défaut. Qdrant démarre alors sur un magasin vide — et, s'il continue d'indexer, écrit dans le vide pendant que les vraies données restent inaccessibles. C'est exactement le mécanisme d'une perte de données réelle (cf. [document 04](04-Incidents-et-Lecons.md)). La règle d'or qui en découle :
+
+> **On résout le disque par son *label*, jamais par sa lettre de périphérique.** Les lettres (`/dev/sde`, `/dev/sdf`, `/dev/sdg`…) sont **instables** d'un redémarrage à l'autre ; le label, lui, est stable.
+
+Deux garde-fous protègent ce montage — la sentinelle anti-split-brain (section 6) et un *watchdog* de remontage automatique (section 7).
+
+## 5. La quantization TurboQuant : 8× plus compact, sans perte
+
+Un vecteur de 2560 dimensions en virgule flottante 32 bits pèse ~10 Ko. Multiplié par des centaines de milliers de points, la RAM nécessaire pour garder l'index « chaud » explose. La **quantization** compresse les vecteurs pour la recherche, tout en gardant les originaux pour affiner les résultats.
+
+Nous utilisons **TurboQuant 4 bits** (disponible à partir du moteur 1.18.0) avec l'option `always_ram: true`. Les faits mesurés sur notre collection principale :
+
+- **Compression 8×** des vecteurs gardés en RAM.
+- **Rappel de score `recall@10 = 1.0`** par rapport à la recherche exacte : aucun voisin de qualité inférieure n'est introduit. Autrement dit, **zéro perte de qualité** observable à ce niveau de bits.
+- Empreinte RAM de l'ordre de quelques Go pour des centaines de milliers de points — négligeable face à la limite du conteneur.
+
+Deux subtilités importantes :
+
+- Le **ré-affinage** (*rescore*) est un **paramètre de requête** (`params.quantization.rescore`), pas une propriété de la collection. Les vecteurs originaux en pleine précision sont conservés, ce qui permet à tout moment d'obtenir un résultat exact avec `params.quantization.ignore=true` — pratique pour mesurer le rappel après coup.
+- La migration vers TurboQuant se fait par un simple `PATCH` de la configuration de quantization ; l'optimiseur re-quantize les segments existants en arrière-plan. **Mais on ne touche jamais une collection précieuse sans sauvegarde préalable vérifiée** (cf. [document 04](04-Incidents-et-Lecons.md)).
+
+## 6. Le garde-fou anti-split-brain (sentinelle)
+
+Pour empêcher le scénario « démarrer sur un magasin vide », l'`entrypoint` du conteneur de production contient une **porte logique** : il vérifie la présence d'un fichier sentinelle qui vit **sur le VHDX** (`/qdrant/storage/.qdrant_vhdx_sentinel`). Si ce fichier est absent — c'est-à-dire si le point de montage pointe vers le répertoire vide au lieu du VHDX — le conteneur **refuse de démarrer** (`exit 1`) au lieu de servir un index vide.
+
+```bash
+# Extrait simplifié de l'entrypoint (voir configs/docker-compose.qdrant.example.yml)
+if [ ! -f /qdrant/storage/.qdrant_vhdx_sentinel ]; then
+  echo "[SENTINEL] FATAL: VHDX non monte. Refus de demarrer." >&2
+  exit 1
+fi
+echo "[SENTINEL] OK: sentinelle presente, demarrage."
+exec ./entrypoint.sh
+```
+
+Le principe se résume en une phrase : **on ne réindexe pas dans le vide**. Mieux vaut un service en panne, bruyant et visible, qu'un service en apparence sain qui corrompt silencieusement la mémoire. Ce garde-fou a fait ses preuves en production sur une vraie dérive de montage : panne franche, zéro perte de données. À ne jamais contourner en supprimant la sentinelle pour « forcer » le démarrage.
+
+## 7. Le watchdog de remontage
+
+Un second garde-fou complète la sentinelle : une tâche planifiée vérifie périodiquement (toutes les deux minutes) que le bon disque est monté — **en vérifiant le label, pas un simple compte de collections** (un répertoire vide peut contenir des restes trompeurs). En cas de dérive, elle remonte le VHDX et relance proprement le conteneur.
+
+Deux leçons de conception y sont gravées :
+
+- La remédiation doit avoir un **auto-délai** (*self-timeout*) : un appel système bloqué (par exemple une commande WSL qui pend) ne doit pas figer le watchdog pendant des heures.
+- Le remontage doit se faire **dans le bon espace de noms** : Docker résout les montages depuis l'espace de noms du processus d'init de la distribution, pas depuis une session WSL fraîche.
+
+Le détail de ces mécanismes et des incidents qui les ont motivés est dans le [document 04](04-Incidents-et-Lecons.md).
+
+## 8. Limites de ressources et anti-freeze
+
+La configuration vise un équilibre entre débit et stabilité. Les points saillants (template complet dans [`configs/qdrant.production.example.yaml`](../configs/qdrant.production.example.yaml)) :
+
+| Paramètre | Valeur | Raison |
+|-----------|--------|--------|
+| RAM (limite Docker) | 60 Go | Marge large au-dessus de l'empreinte réelle |
+| CPU (limite Docker) | 12 cœurs | Parallélisme des recherches |
+| `max_indexing_threads` | 10 | Sous le max CPU, pour laisser respirer les recherches |
+| `max_optimization_threads` | 4 | Éviter la contention optimiseur vs écritures |
+| `indexing_threshold_kb` | 6000 | Indexer dès ~1000 points (sinon balayage complet) |
+| HNSW `on_disk` | true | Économiser la RAM |
+| `grpc_timeout_ms` | 60000 | Éviter les requêtes bloquantes éternelles |
+
+Côté conteneur, un **healthcheck** envoie une vraie requête HTTP `/healthz` toutes les 30 s (il détecte un *freeze*, pas seulement un crash), et un conteneur **autoheal** redémarre Qdrant après plusieurs échecs. Détail crucial : la **période de grâce au démarrage** (`start_period`) doit être assez longue pour couvrir la recovery à froid (plusieurs minutes sur un gros index) ; trop courte, l'autoheal tue le conteneur avant la fin de la recovery et provoque une boucle de redémarrage.
+
+## 9. Authentification
+
+Chaque instance a sa propre clé d'API, stockée dans un fichier d'environnement (`.env`) **jamais versionné**. La variable se nomme `QDRANT__SERVICE__API_KEY` (double tiret bas, convention Qdrant pour les variables imbriquées). Règle absolue : **on ne lit la clé que dans une variable, on ne l'affiche jamais** dans un log ou une sortie de commande. Le template [`configs/qdrant.env.example`](../configs/qdrant.env.example) ne contient que des placeholders.
+
+## 10. Ce qu'il faut retenir
+
+- Qdrant **stocke et compare** des vecteurs ; le **calcul** des embeddings est externe.
+- Le moteur est **épinglé** à une version précise — les mises à niveau sont explicites et réversibles.
+- Le stockage sur disque virtuel dédié apporte de l'isolation mais crée un **risque de dérive de montage**, neutralisé par la résolution **par label**, la **sentinelle** et le **watchdog**.
+- **TurboQuant 4 bits** offre une compression 8× sans perte de qualité mesurable.
+- Les garde-fous (sentinelle, healthcheck, autoheal, période de grâce) privilégient toujours **l'échec visible** à la corruption silencieuse.
+
+---
+
+Document suivant : [03 - Utilisation et indexation](03-Utilisation-MCP-Indexation.md).
+
+[← Retour au README de la section](../README.md)

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/docs/03-Utilisation-MCP-Indexation.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/docs/03-Utilisation-MCP-Indexation.md
@@ -1,0 +1,108 @@
+# 03 - Utilisation et indexation
+
+[← 02 Infrastructure](02-Infrastructure-Qdrant.md) | [Mémoire Sémantique Qdrant](../README.md) | [→ 04 Incidents et leçons](04-Incidents-et-Lecons.md)
+
+Une base vectorielle déployée (document 02) ne sert à rien tant qu'elle n'est ni **alimentée** ni **interrogée**. Ce document décrit comment l'agent s'y connecte (MCP), comment le contenu y est indexé, et comment on l'interroge efficacement.
+
+## 1. Le pont MCP : brancher l'agent sur Qdrant
+
+Un agent de codage ne parle pas directement à Qdrant. Il passe par un **serveur MCP** (*Model Context Protocol*), qui expose des outils de recherche et d'indexation directement dans l'agent, comme s'il s'agissait de fonctions natives.
+
+Dans notre infrastructure, ce pont est assuré par un serveur MCP maison (`roo-state-manager`) qui, entre autres :
+
+- indexe les **conversations** des agents et le **code** des dépôts dans Qdrant ;
+- expose des outils de recherche (`codebase_search`, `roosync_search`) que l'agent appelle pendant une tâche ;
+- gère la coordination multi-machines (hors scope de ce document).
+
+Pour un usage plus simple, l'écosystème propose aussi un **serveur MCP Qdrant officiel** (`mcp-server-qdrant`), qui suffit à exposer deux outils génériques — `qdrant-store` (indexer un fragment) et `qdrant-find` (rechercher) — sur une collection existante. C'est un bon point de départ pour des travaux pratiques.
+
+```jsonc
+// Exemple de configuration MCP (extrait — clé en placeholder)
+{
+  "mcpServers": {
+    "qdrant": {
+      "command": "uvx",
+      "args": ["mcp-server-qdrant"],
+      "env": {
+        "QDRANT_URL": "http://localhost:6333",
+        "QDRANT_API_KEY": "<votre-cle-api>",
+        "COLLECTION_NAME": "code_search",
+        "EMBEDDING_MODEL": "sentence-transformers/all-MiniLM-L6-v2"
+      }
+    }
+  }
+}
+```
+
+## 2. Comment le contenu est indexé
+
+L'indexation transforme du texte brut en points interrogeables. Le pipeline est toujours le même (cf. schéma du [README](../README.md)) :
+
+1. **Collecte** — on récupère la matière : transcriptions de conversations, fichiers source d'un dépôt.
+2. **Découpage** (*chunking*) — on segmente en fragments de taille raisonnable. Trop gros, le vecteur devient flou (il « moyenne » trop de sens) ; trop petit, on perd le contexte. Un découpage par échange (question + réponse) ou par bloc logique (fonction, classe) fonctionne bien.
+3. **Embedding** — chaque fragment passe dans le service d'embeddings (document 02) et devient un vecteur de 2560 dimensions.
+4. **Upsert** — le vecteur est inséré dans Qdrant avec sa **charge utile** : la source, l'horodatage, le type de fragment, l'identifiant de tâche… Ces champs serviront à filtrer.
+
+Deux familles de collections cohabitent dans notre déploiement :
+
+- **La mémoire conversationnelle** (`roo_tasks_semantic_index`) : l'historique des échanges d'agents. C'est l'actif **irremplaçable** — on ne peut pas le régénérer.
+- **Les index de code** (une collection par dépôt, préfixées `ws-*`) : le code indexé. Ils sont **régénérables** : en cas de perte, on relance l'indexation du dépôt.
+
+Cette distinction guide les priorités de sauvegarde (document 04) : on protège d'abord l'irremplaçable.
+
+## 3. Interroger par le sens
+
+Côté agent, la recherche se résume à un appel d'outil. L'outil embarque la requête, lance la recherche HNSW dans Qdrant, et renvoie les *k* fragments les plus proches.
+
+```text
+codebase_search(
+  query     = "rate limiting for embedding requests",
+  workspace = "C:/dev/mon-projet",
+  limit     = 15
+)
+→ renvoie les 15 fragments de code les plus proches du concept,
+  avec leur fichier, leur score, et un extrait.
+```
+
+Pour la mémoire conversationnelle, l'outil équivalent (`roosync_search`) accepte deux modes :
+
+- **`semantic`** — recherche vectorielle (par le sens), avec repli automatique si l'index n'est pas disponible ;
+- **`text`** — recherche lexicale dans le cache (par les mots).
+
+## 4. Bonnes pratiques de requête
+
+L'expérience a dégagé quelques règles qui changent radicalement la qualité des résultats :
+
+- **Interroger dans la langue du code.** Le code et ses commentaires sont majoritairement en anglais. Une requête sémantique en anglais, avec le vocabulaire du domaine (`authentication middleware`, `connection pool`, `retry with backoff`), tombe bien plus juste qu'une paraphrase en langage naturel.
+- **Chercher un concept, pas une chaîne exacte.** Si vous connaissez le symbole exact, utilisez `grep` ; la recherche sémantique brille sur l'intention (« le truc qui limite les appels »).
+- **Toujours passer le workspace explicitement.** Ne pas compter sur une auto-détection : nommer le dépôt cible évite des résultats hors-sujet.
+- **Procéder par passes.** Une requête large d'abord, puis affiner : restreindre à un sous-répertoire, basculer sur `grep` pour le terme exact repéré, ou reformuler avec un autre angle.
+
+## 5. Le motif « serre-livres » en pratique
+
+Comme vu au [document 01](01-Pourquoi-Memoire-Semantique.md), la méthode SDDD recommande d'encadrer chaque tâche significative par deux recherches sémantiques :
+
+- **Au début** — pour ne pas réinventer ce qui existe : « ce problème a-t-il déjà été résolu ? où est la doc afférente ? qui a travaillé dessus ? ».
+- **À la fin** — pour vérifier que le nouveau travail est **retrouvable** (indexé) et que la documentation trouvée au début a été mise à jour.
+
+Ce simple réflexe évite une grande partie des doublons et des régressions : on construit *sur* la mémoire plutôt que de la contourner.
+
+## 6. Filtrer avec les payload indexes
+
+La recherche pure par similarité peut être affinée par des **filtres** sur la charge utile, à condition que les champs concernés soient indexés. Dans notre collection, des payload indexes existent sur l'horodatage, la source (`claude`, `roo`…), le type de fragment et l'identifiant de tâche. On peut ainsi demander « les fragments sémantiquement proches de X, **et** provenant de Claude, **et** postérieurs à telle date ». Sans payload index, un tel filtre forcerait un balayage coûteux ; avec, il reste rapide.
+
+> Note de prudence opérationnelle : avant toute suppression en masse de points (par exemple pour purger des doublons), **profiler d'abord**. Certaines combinaisons de champs ne sont pas indexées, et une purge mal ciblée peut être lente ou destructrice. Le drain asynchrone des suppressions peut prendre du temps avant que l'espace soit réellement récupéré.
+
+## 7. Ce qu'il faut retenir
+
+- L'agent parle à Qdrant via un **serveur MCP** ; un serveur officiel simple existe pour démarrer.
+- L'indexation suit toujours **collecte → découpage → embedding → upsert** avec une charge utile riche.
+- On sépare la **mémoire conversationnelle** (irremplaçable) des **index de code** (régénérables).
+- Une bonne requête est **en anglais, conceptuelle, ciblée sur un workspace, et procède par passes**.
+- Le motif **serre-livres** (recherche au début et à la fin d'une tâche) est le réflexe qui rentabilise la mémoire.
+
+---
+
+Document suivant : [04 - Incidents et leçons](04-Incidents-et-Lecons.md) — ce que les pannes nous ont appris.
+
+[← Retour au README de la section](../README.md)

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/docs/04-Incidents-et-Lecons.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/docs/04-Incidents-et-Lecons.md
@@ -1,0 +1,104 @@
+# 04 - Incidents et leçons
+
+[← 03 Utilisation](03-Utilisation-MCP-Indexation.md) | [Mémoire Sémantique Qdrant](../README.md)
+
+Ce document est le plus utile de la section, parce qu'il est le plus honnête. Une infrastructure ne s'apprend pas dans son état idéal mais dans ses pannes : ce qui a cassé, pourquoi, et ce qu'on a changé pour que cela ne recommence pas. Chaque incident ci-dessous est réel (les dates sont conservées pour l'authenticité) ; tout identifiant sensible est généralisé.
+
+## 1. La perte de données par dérive de montage
+
+**Ce qui s'est passé (mi-mai 2026).** Le disque virtuel (VHDX) hébergeant les données de production s'est retrouvé **non monté**. Le point de montage Docker s'est alors résolu vers un répertoire **vide** de la distribution Linux par défaut. Qdrant a démarré sur ce magasin vide, sans erreur apparente — et la collection principale a été **recréée à vide**. La mémoire conversationnelle, patiemment accumulée, n'était plus servie.
+
+**L'aggravation.** Au moment précis de l'incident, **il n'existait aucune sauvegarde**. Un script de sauvegarde *existait* pourtant sur le disque — mais il n'avait **jamais été planifié** : ses derniers logs dataient de plusieurs mois. Le filet de sécurité était à moitié construit (voir section 3).
+
+**La récupération.** Une copie périmée du système de fichiers a permis, via `rsync`, de récupérer une partie des points (de l'ordre de quelques centaines de milliers). Mais une partie de l'historique a été définitivement perdue.
+
+**Les leçons.**
+
+- **Une sauvegarde n'existe que si elle s'est exécutée récemment.** La présence d'un script ne prouve rien ; seule la présence de **sauvegardes datées et vérifiées** compte.
+- **Un service en apparence sain peut corrompre silencieusement.** Démarrer à vide sans erreur est pire qu'un crash : la panne est invisible jusqu'à ce qu'on cherche une donnée disparue.
+- C'est cet incident qui a fait naître la **sentinelle anti-split-brain** (document 02) : « on ne réindexe pas dans le vide ».
+
+## 2. La dérive de montage, mécanique et remédiation
+
+L'incident de la section 1 n'était pas un accident isolé : la dérive de montage s'est reproduite. En la diagnostiquant à répétition, on a appris sa mécanique exacte.
+
+**Pourquoi elle survient.** Le montage du VHDX dans WSL2 peut être perdu **en cours de fonctionnement** (pas seulement au démarrage), par exemple si une opération WSL retire le disque. Docker continue alors de servir l'ancien point de montage, désormais cassé.
+
+**Les pièges du diagnostic.**
+
+- **Les lettres de périphérique sont instables.** Le même disque peut apparaître `/dev/sde`, puis `/dev/sdg`, puis `/dev/sdf` à travers les redémarrages. Résoudre par la lettre conduit tôt ou tard à monter le mauvais disque. **Toujours résoudre par le *label*** (`qdrant-e`).
+- **Compter les collections ne suffit pas à valider un montage.** Le répertoire vide « leftover » peut contenir des restes trompeurs et passer un test naïf « nombre de collections > 0 ». La vérification correcte porte sur le **label du périphérique** réellement monté.
+- **Un simple `restart` ne suffit pas.** Seul un **`compose down` puis `up`** (recréation du conteneur) force une **nouvelle résolution** des points de montage. Un `restart` réutilise le montage figé au moment de la création.
+- **L'espace de noms compte.** Docker résout les montages depuis l'espace de noms du processus d'init de la distribution. Monter depuis une session WSL fraîche ne suffit pas ; il faut entrer dans le bon espace de noms.
+
+**La remédiation, maintenant automatisée.** Une tâche planifiée (watchdog) vérifie le label toutes les deux minutes et, en cas de dérive, remonte le disque puis recrée le conteneur. Détail défensif appris à la dure : cette remédiation a un **auto-délai** (*self-timeout*), car un appel WSL ou Docker bloqué pouvait autrefois figer toute la chaîne pendant des heures.
+
+**Le verdict positif.** La sentinelle (document 02) a été **prouvée en production** lors d'une vraie dérive : le conteneur a refusé de démarrer, panne franche et visible, **zéro perte de données**. Le garde-fou a fonctionné exactement comme prévu.
+
+## 3. La sauvegarde à moitié câblée : « consolider n'est pas archiver »
+
+**Le piège.** Un script de sauvegarde consolidé existait, fonctionnel, testé… mais sans **tâche planifiée** pour le déclencher. Sur le disque, tout avait l'air en ordre. Dans les faits, plus aucune sauvegarde ne tournait depuis des mois. Le symptôme révélateur : des logs de sauvegarde abondants jusqu'à une date, puis **plus rien**.
+
+**La leçon générale.** Pour toute opération de sûreté, vérifier **deux choses indépendantes** :
+
+1. le **script** existe et fonctionne ;
+2. un **ordonnanceur** le déclenche réellement (et ses exécutions récentes ont réussi).
+
+Un script sans planification est un filet de sécurité à moitié construit — il donne l'illusion de la protection sans la fournir.
+
+**Ce qui a été durci ensuite.** La sauvegarde canonique a reçu deux garde-fous :
+
+- **Garde anti-poison** : si la collection contient moins d'un seuil de points (signe d'un état vide ou corrompu), la sauvegarde **avorte** et **ne fait pas tourner la rotation** — pour ne pas écraser de bonnes sauvegardes avec une mauvaise.
+- **Garde de taille** : si la nouvelle sauvegarde est anormalement plus petite que la plus grosse existante, la rétention est **suspendue** par précaution.
+
+Les sauvegardes sont écrites en **deux endroits** (un stockage hors-site et un disque local), avec une rétention quotidienne et hebdomadaire **par destination**. La restauration, elle, est **sûre par défaut** : elle téléverse dans une collection nommée sans jamais toucher aux volumes ; l'option destructive (recréer la collection) est explicite et séparée.
+
+## 4. La résurrection de la VM WSL
+
+**Ce qui s'est passé (début juin 2026).** Lors d'une opération de maintenance, l'intégration Docker/WSL s'est cassée. Les remèdes habituels (`wsl --shutdown`, quitter/relancer Docker) **échouaient tous** — la machine virtuelle WSL2 refusait de mourir.
+
+**La cause.** Le **watchdog de montage** (section 2), qui s'exécute toutes les deux minutes, **ressuscitait la VM** à chaque tentative d'arrêt : à peine arrêtée, il la relançait pour vérifier le montage. Course infernale entre l'opérateur qui éteint et le watchdog qui rallume.
+
+**La leçon, devenue procédure.**
+
+- **Désactiver le watchdog *d'abord***, avant toute opération sur WSL.
+- **Quitter complètement Docker Desktop avant** tout `wsl --shutdown` / `--mount` / `--unmount`, et le relancer après.
+- **Vérifier que la VM est réellement éteinte** (aucun processus `vmmem`/`vmmemWSL`) avant de relancer.
+- Puis seulement : remonter le disque, et **ré-armer le watchdog**.
+
+Un mécanisme d'auto-réparation est précieux, mais il faut savoir le **mettre en pause** pendant qu'on opère manuellement la ressource qu'il surveille — sinon il combat l'opérateur.
+
+## 5. Une opération réussie, par contraste : la migration TurboQuant
+
+Toutes les interventions ne sont pas des désastres. La migration de la collection principale vers la quantization **TurboQuant 4 bits** (document 02) illustre la **bonne** manière de toucher à une ressource précieuse :
+
+1. **Sauvegarde vérifiée d'abord.** Un instantané a été pris **avant** de toucher au moteur, et validé octet par octet sur les deux destinations.
+2. **Montée de moteur explicite.** Le moteur est passé à une version épinglée (TurboQuant exige le moteur ≥ 1.18.0), via recréation propre du conteneur. La sentinelle a confirmé le bon montage, l'intégralité des points était intacte.
+3. **Test sur cobaye.** La syntaxe du `PATCH` a été dé-risquée sur une **collection jetable** avant de toucher la vraie.
+4. **Migration et mesure.** Le `PATCH` appliqué, l'optimiseur a re-quantizé les segments en arrière-plan. Un **banc de rappel** a confirmé `recall@10 = 1.0` : zéro perte de qualité.
+
+Le contraste avec les sections 1 à 4 est la leçon : **sauvegarde préalable + test sur cobaye + mesure de validation** transforment une opération risquée en routine sereine.
+
+## 6. La montée de version, explicite et réversible
+
+La montée d'une version mineure du moteur (un correctif de sécurité, sans changement cassant ni migration) a suivi le même esprit : épingler la nouvelle version précise plutôt qu'un tag mouvant, recréer proprement, valider en direct (nombre de collections, points de la collection principale, quantization intacte, sentinelle OK). Parce que la version est épinglée, la manœuvre est **réversible** : revenir en arrière, c'est ré-épingler l'ancienne version. C'est tout l'intérêt de bannir `:latest` en production.
+
+## 7. La compaction du disque virtuel (dette différée, assumée)
+
+Tous les chantiers ne sont pas urgents. Un VHDX **ne se réduit pas tout seul** quand on supprime des données : le fichier conserve sa taille maximale historique. Sur notre hôte, le disque virtuel occupait plusieurs centaines de Go de plus que les données réelles. La compaction (hors-ligne) récupérerait cet espace — mais elle exige d'arrêter proprement Qdrant et de manipuler WSL.
+
+La décision a été de **différer** cette opération à une fenêtre calme et surveillée, plutôt que de la lancer sous pression. C'est aussi une leçon d'ops : **une dette connue, bornée et planifiée n'est pas une urgence** ; la traiter au mauvais moment crée plus de risque qu'elle n'en résout (voir section 4 sur les opérations WSL).
+
+## 8. Méta-leçons
+
+En filigrane de tous ces incidents, quelques principes transversaux :
+
+- **L'échec visible vaut mieux que la corruption silencieuse.** Tous les garde-fous (sentinelle, gardes de sauvegarde, healthcheck) sont construits pour **s'arrêter bruyamment** plutôt que continuer dans le doute.
+- **Vérifier deux faits indépendants.** Un script *et* sa planification. Un montage *et* son label. Une sauvegarde *et* sa date.
+- **Sauvegarder avant, mesurer après.** Aucune opération sur une ressource irremplaçable sans instantané préalable vérifié et validation postérieure.
+- **Connaître l'interaction entre couches.** Beaucoup de pannes venaient de l'interface Windows / WSL2 / Docker, pas de Qdrant lui-même. Un automatisme (watchdog) peut entrer en conflit avec une opération manuelle.
+- **L'honnêteté est un outil.** Documenter les pertes réelles, pas seulement les succès, est ce qui a permis de construire les garde-fous. Ce document en est l'application.
+
+---
+
+[← Retour au README de la section](../README.md) · [↑ Vibe-Coding](../../README.md)

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -18,6 +18,7 @@ Vibe-Coding/
 ├── Claude-Code/          # Ateliers Claude Code (5 modules)
 ├── Roo-Code/             # Ateliers Roo Code (5 modules + avances)
 ├── Claw-Systems/         # Agents IA autonomes (NanoClaw, OpenClaw)
+├── Memoire-Semantique-Qdrant/   # Backend mémoire sémantique (Qdrant, grounding)
 └── docs/                 # Documentation commune et introductions
 ```
 
@@ -95,6 +96,20 @@ Plateformes d'agents IA conteneurisés, self-hosted, opérant de manière autono
 | [ASR Integration](Claw-Systems/docs/ASR-Integration.md) | Transcription vocale Whisper |
 
 **Cas d'usage** : Agent Telegram avec transcription vocale, orchestration multi-agents, déploiement production.
+
+## Mémoire Sémantique Qdrant - Infrastructure de Grounding
+
+Le **backend de mémoire sémantique** qui donne aux agents de codage une mémoire long-terme et les ancre dans des faits vérifiables (grounding) : une base de données vectorielle Qdrant qui indexe conversations et code, interrogée par le sens. Là où les sections ci-dessus décrivent les front-ends agents, celle-ci documente l'infrastructure qui les alimente -- avec les incidents d'ops réels (dérives de montage, pertes de données, durcissement des sauvegardes) comme matière pédagogique.
+
+| Document | Description |
+|----------|-------------|
+| [README](Memoire-Semantique-Qdrant/README.md) | Vue d'ensemble, pipeline, écosystème |
+| [Pourquoi la mémoire sémantique](Memoire-Semantique-Qdrant/docs/01-Pourquoi-Memoire-Semantique.md) | Grounding, SDDD, RAG, sémantique vs lexical |
+| [Infrastructure Qdrant](Memoire-Semantique-Qdrant/docs/02-Infrastructure-Qdrant.md) | Docker, stockage WSL2, quantization TurboQuant, anti-split-brain |
+| [Utilisation et indexation](Memoire-Semantique-Qdrant/docs/03-Utilisation-MCP-Indexation.md) | MCP, indexation code + conversations, requêtes |
+| [Incidents et leçons](Memoire-Semantique-Qdrant/docs/04-Incidents-et-Lecons.md) | War-stories d'ops : dérive de montage, perte de données, sauvegardes |
+
+**Cas d'usage** : donner à un assistant de codage une mémoire interrogeable par le sens, partagée entre machines, robuste aux pannes.
 
 ## Documentation commune
 


### PR DESCRIPTION
## Mémoire Sémantique Qdrant — infrastructure de grounding (#4432, Part of #4427)

Nouvelle section documentaire sous `GenAI/Vibe-Coding/Memoire-Semantique-Qdrant/`, **plan validé par le user** (relais ai-01, GO 2026-06-27). Documente la **couche backend** de mémoire sémantique / grounding qui alimente les front-ends agents (Claude Code / Roo Code / Claw Systems). Frontière de scope tranchée par ai-01 : backend mémoire/recherche, **PAS** les front-ends bots (#4428) ni la QA E2E OWUI (#4433).

### Contenu (8 fichiers, ~741 lignes + référence README parent)

- `README.md` — cadrage, table comparative front-ends vs mémoire, écosystème, schéma du pipeline, parcours de lecture, infra requise.
- `docs/01-Pourquoi-Memoire-Semantique.md` — amnésie des agents, sémantique vs lexical, embeddings & similarité, RAG, mémoire de flotte, méthode SDDD.
- `docs/02-Infrastructure-Qdrant.md` — Qdrant (collections/points/HNSW), 2 instances Docker, service d'embeddings, stockage WSL2 VHDX, TurboQuant 4 bits, sentinelle anti-split-brain, watchdog de remontage, limites & anti-freeze, authentification.
- `docs/03-Utilisation-MCP-Indexation.md` — pont MCP, pipeline d'indexation, requête sémantique, bonnes pratiques, motif serre-livres, payload indexes.
- `docs/04-Incidents-et-Lecons.md` — war-stories d'ops réels : perte par dérive de montage + récupération, mécanique de la dérive, sauvegarde à moitié câblée (« consolider ≠ archiver »), résurrection de la VM WSL, migration TurboQuant réussie (contraste), montée de version, compaction différée, méta-leçons.
- `configs/` — 3 templates **anonymisés** : `docker-compose.qdrant.example.yml` (sentinelle commentée), `qdrant.production.example.yaml` (HNSW/quantization/limites), `qdrant.env.example` (placeholders).

### Conformité pipeline #4427

- **FR-first**, accents corrects, **no-emojis**.
- **Secrets anonymisés** : scan automatique vert — 0 clé API, 0 token, 0 IP LAN, 0 chemin machine absolu. Placeholders uniquement dans `configs/`.
- **CATALOG-STATUS inchangé** (`pedagogical_count: 5`) — section doc, non comptée (comme Claw-Systems). Catalogue non régénéré à la main.
- **Liens relatifs** : tous vérifiés (0 cassé), y compris la référence ajoutée dans `Vibe-Coding/README.md`.
- **PR atomique** : 1 sujet (la section), bien sous le seuil de découpe ~3000 lignes.

### Note collision

La référence dans `Vibe-Coding/README.md` est ajoutée dans une **nouvelle section isolée** (après Claw-Systems, avant Documentation commune) — surface de collision minimale avec les PRs en vol (#4437, doc Claudish).

Review + merge à ta main, ai-01. Jalons reportés sur le dashboard workspace-CoursIA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
