### PR TITLE
Add: Z3 notebook 07 - Weekly Nutrition Planner (bool-matrix coupled CSP)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Notebook 06c - Rendu HTML des solutions Z3 : visualisation structurée d'un planificateur de repas\n",
     "\n",
-    "**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md) | [Notebook 05 (Meal Planner)](./05_Meal_Planner_Hierarchical.ipynb) | [Notebook 06b (RecipeML)](./06b_RecipeML_Corpus.ipynb)\n",
+    "**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md) | [Notebook 05 (Meal Planner)](./05_Meal_Planner_Hierarchical.ipynb) | [Notebook 06b (RecipeML)](./06b_RecipeML_Corpus.ipynb) | [Notebook 07 (Weekly Planner) →](./07_Weekly_Nutrition_Planner.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/07_Weekly_Nutrition_Planner.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/07_Weekly_Nutrition_Planner.ipynb
@@ -1,0 +1,811 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "49c6759c",
+   "metadata": {},
+   "source": [
+    "# Notebook 07 - Planification Hebdomadaire : Fenêtre Nutritionnelle par Jour et Variété Globale\n",
+    "\n",
+    "**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md) | [<< Meal Planner Visualization](06c_Meal_Planner_Visualization.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "- Modéliser un **plan de repas sur toute une semaine** comme une **matrice booléenne `int[][]`** (jours × plats), et comprendre pourquoi ce modèle diffère de la grille d'index du [notebook 05 §7](05_Meal_Planner_Hierarchical.ipynb).\n",
+    "- Exprimer une **fenêtre nutritionnelle par jour** (somme des kcal des plats choisis ce jour ∈ `[min, max]`) — le chaînon manquant entre la nutrition (`MkITE`, 05 §5 / 06b §3) et le plan multi-jours (`int[][]`, 05 §7 / 06b §4).\n",
+    "- Imposer une **variété globale** : aucun plat servi plus d'une fois dans la semaine.\n",
+    "- Démontrer pourquoi un **remplissage glouton** (« *greedy* ») jour par jour **se bloque** sur ce couplage, alors que le solveur SMT trouve une affectation globalement cohérente en quelques millisecondes.\n",
+    "\n",
+    "## Prérequis\n",
+    "\n",
+    "- [Notebook 04](04_Nested_Arrays_2D.ipynb) : tableaux imbriqués `int[][]`, `Theorem<Grid>`.\n",
+    "- [Notebook 05 §5](05_Meal_Planner_Hierarchical.ipynb) : variables booléennes de sélection + agrégation conditionnelle.\n",
+    "- [Notebook 05 §7](05_Meal_Planner_Hierarchical.ipynb) : plan hebdomadaire en grille d'index (le modèle complémentaire de celui-ci).\n",
+    "- [Notebook 06b §4](06b_RecipeML_Corpus.ipynb) : non-répétition `Z3Methods.Distinct` sur `int[][]`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95cb83e4",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Le saut combinatoire : pourquoi une semaine ≠ cinq repas indépendants\n",
+    "\n",
+    "Planifier **un** repas équilibré est un problème local (cf. notebook 05 §5 : un menu booléen, agrégation `MkITE`, solveur immédiat). Planifier **cinq jours** indépendamment reste facile. La difficulté apparaît dès qu'on ajoute **deux contraintes couplées qui traversent les jours** :\n",
+    "\n",
+    "1. **Variété globale** — aucun plat n'est servi deux fois dans la semaine.\n",
+    "2. **Fenêtre nutritionnelle par jour** — chaque jour, la somme des calories des plats choisis doit rester dans une fourchette santé (ex. `[1500, 1700]` kcal).\n",
+    "\n",
+    "Ce couplage est **non compositionnel** : un choix localement valide pour le jour 1 (un menu dans la fenêtre) peut **épuiser le seul plat** qui aurait permis de satisfaire la fenêtre du jour 4. Un algorithme glouton qui remplit les jours l'un après l'autre, sans retours en arrière, **se bloque**. Le solveur SMT, lui, propage les contraintes **globalement** et trouve en quelques millisecondes une affectation où chaque jour est dans la fenêtre **et** aucun plat ne se répète.\n",
+    "\n",
+    "> **Positionnement dans la série.** Le notebook 05 §7 modélise un plan multi-jours comme une **grille d'index** `Plan[j][k]` (l'indice du plat choisi par créneau) et y ajoute de la **variété** (permutation), mais n'y contraint **pas la nutrition** — il se contente de l'**afficher** en commentaire. Le notebook 06b §4 fait de même avec `Z3Methods.Distinct`. Ici, nous **contraignons** la nutrition par jour : cela change le modèle (une matrice de sélection booléenne, pas une grille d'index) parce qu'on ne peut pas indexer un tableau C# `kcal[]` par une variable symbolique Z3 — il faut sommer des **sélections**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3aa47e12",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. Configuration : chargement du fork Z3.Linq\n",
+    "\n",
+    "Le fork [Z3.Linq](../Z3.Linq/) embarque le support `int[][]` et le correctif `AssertConstraints` (capture *cross-submission*). Les trois DLL résident dans `.deploy/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "41c41f85",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:28.270236Z",
+     "iopub.status.busy": "2026-06-27T15:51:28.263281Z",
+     "iopub.status.idle": "2026-06-27T15:51:29.820951Z",
+     "shell.execute_reply": "2026-06-27T15:51:29.818086Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-201176.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.1.12:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '201176.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : Z3.Linq (fork int[][]), Microsoft.Z3, System.Linq\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"../Z3.Linq/.deploy/Microsoft.Z3.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/ExpressionUtils.dll\"\n",
+    "#r \"../Z3.Linq/.deploy/Z3.Linq.dll\"\n",
+    "\n",
+    "using Z3.Linq;\n",
+    "using Microsoft.Z3;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Diagnostics;\n",
+    "using System.Linq;\n",
+    "\n",
+    "Console.WriteLine(\"Imports OK : Z3.Linq (fork int[][]), Microsoft.Z3, System.Linq\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4de98aa",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Le corpus de plats\n",
+    "\n",
+    "Contrairement au notebook 06b qui parse un corpus RecipeML externe, nous définissons ici un corpus **inline** plus large (18 plats) pour rendre la combinatoire **non triviale** (Prong-B). Chaque plat a une catégorie (`breakfast` / `lunch` / `dinner`), un apport calorique, une teneur en protéines et un coût.\n",
+    "\n",
+    "> **Convention d'indices** (fixe pour ce notebook) : `breakfast` = indices `[0, 5]`, `lunch` = `[6, 11]`, `dinner` = `[12, 17]`. Les sommes des contraintes ci-dessous sont écrites explicitement sur ces plages — le DSL Z3.Linq exige des expressions linéaires **inline**, il ne suit pas les appels de méthode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e4122754",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:29.823798Z",
+     "iopub.status.busy": "2026-06-27T15:51:29.823237Z",
+     "iopub.status.idle": "2026-06-27T15:51:30.234410Z",
+     "shell.execute_reply": "2026-06-27T15:51:30.234155Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corpus : 18 plats | breakfast [0,5], lunch [6,11], dinner [12,17]\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Corpus inline : 18 plats repartis en 3 categories, apports kcal/proteines/cout varies.\n",
+    "public class Dish\n",
+    "{\n",
+    "    public string Name { get; set; }\n",
+    "    public string Category { get; set; }   // breakfast | lunch | dinner\n",
+    "    public int Kcal { get; set; }\n",
+    "    public int Protein { get; set; }        // grammes\n",
+    "    public int CostCents { get; set; }      // centimes d'EUR\n",
+    "    public override string ToString() => $\"{Name} [{Kcal}kcal, {Protein}g, {CostCents/100.0:F2}EUR]\";\n",
+    "}\n",
+    "\n",
+    "var corpus = new List<Dish>\n",
+    "{\n",
+    "    // breakfast : indices 0-5, 300 a 550 kcal\n",
+    "    new Dish { Name=\"Porridge fruits rouges\", Category=\"breakfast\", Kcal=300, Protein=12, CostCents=180 },\n",
+    "    new Dish { Name=\"Yaourt granola\",        Category=\"breakfast\", Kcal=350, Protein=18, CostCents=220 },\n",
+    "    new Dish { Name=\"Oeufs brouilles\",       Category=\"breakfast\", Kcal=400, Protein=22, CostCents=280 },\n",
+    "    new Dish { Name=\"Pancakes sirop\",        Category=\"breakfast\", Kcal=450, Protein=10, CostCents=250 },\n",
+    "    new Dish { Name=\"Bowl acai\",             Category=\"breakfast\", Kcal=500, Protein=14, CostCents=420 },\n",
+    "    new Dish { Name=\"English breakfast\",     Category=\"breakfast\", Kcal=550, Protein=28, CostCents=550 },\n",
+    "    // lunch : indices 6-11, 500 a 750 kcal\n",
+    "    new Dish { Name=\"Salade cesar\",          Category=\"lunch\", Kcal=500, Protein=25, CostCents=650 },\n",
+    "    new Dish { Name=\"Wrap poulet\",           Category=\"lunch\", Kcal=550, Protein=30, CostCents=580 },\n",
+    "    new Dish { Name=\"Quiche epinards\",       Category=\"lunch\", Kcal=600, Protein=20, CostCents=520 },\n",
+    "    new Dish { Name=\"Buddha bowl\",           Category=\"lunch\", Kcal=650, Protein=22, CostCents=700 },\n",
+    "    new Dish { Name=\"Burger vegetarien\",     Category=\"lunch\", Kcal=700, Protein=26, CostCents=820 },\n",
+    "    new Dish { Name=\"Risotto champignons\",   Category=\"lunch\", Kcal=750, Protein=18, CostCents=780 },\n",
+    "    // dinner : indices 12-17, 600 a 850 kcal\n",
+    "    new Dish { Name=\"Soupe poisson pain\",    Category=\"dinner\", Kcal=600, Protein=28, CostCents=450 },\n",
+    "    new Dish { Name=\"Pates pesto\",           Category=\"dinner\", Kcal=650, Protein=20, CostCents=380 },\n",
+    "    new Dish { Name=\"Poulet roti legumes\",   Category=\"dinner\", Kcal=700, Protein=42, CostCents=850 },\n",
+    "    new Dish { Name=\"Saumon riz\",            Category=\"dinner\", Kcal=750, Protein=38, CostCents=980 },\n",
+    "    new Dish { Name=\"Curry tofu\",            Category=\"dinner\", Kcal=800, Protein=30, CostCents=720 },\n",
+    "    new Dish { Name=\"Pizza margherita\",      Category=\"dinner\", Kcal=850, Protein=32, CostCents=900 },\n",
+    "};\n",
+    "\n",
+    "int N = corpus.Count;\n",
+    "// Tableaux de valeurs constants (captures par le DSL, traites comme des litteraux a la construction de l'arbre).\n",
+    "int[] kcalArr    = corpus.Select(d => d.Kcal).ToArray();\n",
+    "int[] proteinArr = corpus.Select(d => d.Protein).ToArray();\n",
+    "int[] costArr    = corpus.Select(d => d.CostCents).ToArray();\n",
+    "Console.WriteLine($\"Corpus : {N} plats | breakfast [0,5], lunch [6,11], dinner [12,17]\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71828abe",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Le modèle : matrice booléenne jour × plat\n",
+    "\n",
+    "On planifie **`D = 5` jours** (lundi→vendredi). Pour chaque couple `(jour, plat)`, une variable `Sel[j][i] ∈ {0, 1}` vaut 1 si le plat `i` est servi le jour `j`. C'est une **matrice `D × N`** de booléens entiers.\n",
+    "\n",
+    "> **Pourquoi une matrice booléenne et non une grille d'index** (comme le `Plan[j][k]` du notebook 05 §7) ? Parce que nous voulons **agréger les calories du jour** : `kcalDuJour(j) = somme sur i de (Sel[j][i] × kcal[i])`. L'expression `kcal[Plan[j][k]]` — indexer un tableau C# par une variable Z3 — **n'a pas de sens** à la résolution (l'indice est symbolique). En revanche, multiplier une sélection booléenne par une constante connue (`kcal[i]`) puis sommer est une expression **linéaire** que le solveur manipule directement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5aa2eb95",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:30.235985Z",
+     "iopub.status.busy": "2026-06-27T15:51:30.235751Z",
+     "iopub.status.idle": "2026-06-27T15:51:30.424200Z",
+     "shell.execute_reply": "2026-06-27T15:51:30.423852Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Domaine booleen + cardinalite 1/categorie/jour poses (D=5 jours).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Modele : matrice booleenne D x N. Sel[j][i] = 1 ssi le plat i est servi le jour j.\n",
+    "int D = 5;            // lundi..vendredi\n",
+    "int DAY_LO = 1500;    // fenetre kcal minimale par jour\n",
+    "int DAY_HI = 1700;    // fenetre kcal maximale par jour\n",
+    "\n",
+    "public class WeekPlan\n",
+    "{\n",
+    "    public int[][] Sel { get; set; } = new int[5][];   // 5 jours x 18 plats\n",
+    "    public WeekPlan() { for (int j = 0; j < 5; j++) Sel[j] = new int[18]; }\n",
+    "}\n",
+    "\n",
+    "var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array };\n",
+    "var th = ctx.NewTheorem<WeekPlan>();\n",
+    "\n",
+    "// (1) Domaine booleen : chaque cellule dans {0, 1}.\n",
+    "for (int j = 0; j < D; j++)\n",
+    "    for (int i = 0; i < N; i++)\n",
+    "    {\n",
+    "        int jj = j, ii = i;\n",
+    "        th = th.Where(g => g.Sel[jj][ii] >= 0 && g.Sel[jj][ii] <= 1);\n",
+    "    }\n",
+    "\n",
+    "// (2) Cardinalite par jour : exactement 1 breakfast + 1 lunch + 1 dinner (sommes inline sur les plages d'indices).\n",
+    "for (int j = 0; j < D; j++)\n",
+    "{\n",
+    "    int jj = j;\n",
+    "    th = th.Where(g => g.Sel[jj][0] + g.Sel[jj][1] + g.Sel[jj][2] + g.Sel[jj][3] + g.Sel[jj][4] + g.Sel[jj][5] == 1);   // 1 breakfast\n",
+    "    th = th.Where(g => g.Sel[jj][6] + g.Sel[jj][7] + g.Sel[jj][8] + g.Sel[jj][9] + g.Sel[jj][10] + g.Sel[jj][11] == 1);   // 1 lunch\n",
+    "    th = th.Where(g => g.Sel[jj][12] + g.Sel[jj][13] + g.Sel[jj][14] + g.Sel[jj][15] + g.Sel[jj][16] + g.Sel[jj][17] == 1);   // 1 dinner\n",
+    "}\n",
+    "Console.WriteLine($\"Domaine booleen + cardinalite 1/categorie/jour poses (D={D} jours).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49bcce19",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Variété globale : aucun plat servi plus d'une fois\n",
+    "\n",
+    "On veut que **chaque plat apparaisse au plus une fois** dans la semaine entière. Pour le plat `i`, la somme de ses sélections sur les `D` jours est `≤ 1`. C'est l'équivalent « matriciel » du `Z3Methods.Distinct` du notebook 06b §4, mais projeté sur chaque plat à travers tous les jours."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "afa255f7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:30.425371Z",
+     "iopub.status.busy": "2026-06-27T15:51:30.425185Z",
+     "iopub.status.idle": "2026-06-27T15:51:30.471035Z",
+     "shell.execute_reply": "2026-06-27T15:51:30.470797Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variete globale posee : chacun des 18 plats <= 1x/semaine.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// (3) Variete globale : pour chaque plat i, sum_j Sel[j][i] <= 1 (au plus 1 fois dans la semaine).\n",
+    "for (int i = 0; i < N; i++)\n",
+    "{\n",
+    "    int ii = i;\n",
+    "    th = th.Where(g => g.Sel[0][ii] + g.Sel[1][ii] + g.Sel[2][ii] + g.Sel[3][ii] + g.Sel[4][ii] <= 1);\n",
+    "}\n",
+    "Console.WriteLine($\"Variete globale posee : chacun des {N} plats <= 1x/semaine.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67325b68",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. La fenêtre nutritionnelle par jour (le chaînon manquant)\n",
+    "\n",
+    "C'est la contrainte qui transforme le problème : pour chaque jour `j`, la somme des calories des plats choisis doit tomber dans `[DAY_LO, DAY_HI]`. On l'écrit comme une **somme linéaire** de termes `Sel[j][i] × kcal[i]` — la même structure que l'agrégation `MkITE` du notebook 05 §5, mais projetée par jour sur la matrice multi-jours.\n",
+    "\n",
+    "| Concept | Notebook 05 §5 (1 menu) | **Ce notebook (multi-jours)** |\n",
+    "|---------|-------------------------|-------------------------------|\n",
+    "| Sélection | `sel_i` (1 menu) | `Sel[j][i]` (matrice jour×plat) |\n",
+    "| Agrégat nutritionnel | `sum_i MkITE(sel_i, kcal_i, 0)` | `sum_i Sel[j][i] × kcal_i` **par jour j** |\n",
+    "| Fenêtre | 1 fenêtre globale | **1 fenêtre par jour** (D fenêtres couplées) |\n",
+    "| Variété | (n/a) | `sum_j Sel[j][i] ≤ 1` (globale) |\n",
+    "\n",
+    "C'est cette multiplication des fenêtres couplées — `D` contraintes qui se partagent le même pool de plats via la variété — qui rend le glouton inopérant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7765fb80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:30.472653Z",
+     "iopub.status.busy": "2026-06-27T15:51:30.472420Z",
+     "iopub.status.idle": "2026-06-27T15:51:31.932223Z",
+     "shell.execute_reply": "2026-06-27T15:51:31.931997Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fenetre kcal/jour posee : [1500, 1700] pour chacun des 5 jours.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Solution SMT (solve en 1249,6 ms) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jour 1 [1700 kcal, fenetre=True] : Yaourt granola(350k) + Burger vegetarien(700k) + Pates pesto(650k)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jour 2 [1700 kcal, fenetre=True] : Porridge fruits rouges(300k) + Buddha bowl(650k) + Saumon riz(750k)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jour 3 [1700 kcal, fenetre=True] : Oeufs brouilles(400k) + Salade cesar(500k) + Curry tofu(800k)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jour 4 [1700 kcal, fenetre=True] : Pancakes sirop(450k) + Wrap poulet(550k) + Poulet roti legumes(700k)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jour 5 [1700 kcal, fenetre=True] : Bowl acai(500k) + Quiche epinards(600k) + Soupe poisson pain(600k)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Tous les jours dans la fenetre : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total plats servis : 15 (15 attendus = 5x3)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// (4) Fenetre kcal par jour : pour chaque jour j, sum_i Sel[j][i]*kcalArr[i] dans [DAY_LO, DAY_HI].\n",
+    "for (int j = 0; j < D; j++)\n",
+    "{\n",
+    "    int jj = j;\n",
+    "    th = th.Where(g => g.Sel[jj][0]*kcalArr[0] + g.Sel[jj][1]*kcalArr[1] + g.Sel[jj][2]*kcalArr[2] + g.Sel[jj][3]*kcalArr[3] + g.Sel[jj][4]*kcalArr[4] + g.Sel[jj][5]*kcalArr[5] + g.Sel[jj][6]*kcalArr[6] + g.Sel[jj][7]*kcalArr[7] + g.Sel[jj][8]*kcalArr[8] + g.Sel[jj][9]*kcalArr[9] + g.Sel[jj][10]*kcalArr[10] + g.Sel[jj][11]*kcalArr[11] + g.Sel[jj][12]*kcalArr[12] + g.Sel[jj][13]*kcalArr[13] + g.Sel[jj][14]*kcalArr[14] + g.Sel[jj][15]*kcalArr[15] + g.Sel[jj][16]*kcalArr[16] + g.Sel[jj][17]*kcalArr[17] >= DAY_LO);\n",
+    "    th = th.Where(g => g.Sel[jj][0]*kcalArr[0] + g.Sel[jj][1]*kcalArr[1] + g.Sel[jj][2]*kcalArr[2] + g.Sel[jj][3]*kcalArr[3] + g.Sel[jj][4]*kcalArr[4] + g.Sel[jj][5]*kcalArr[5] + g.Sel[jj][6]*kcalArr[6] + g.Sel[jj][7]*kcalArr[7] + g.Sel[jj][8]*kcalArr[8] + g.Sel[jj][9]*kcalArr[9] + g.Sel[jj][10]*kcalArr[10] + g.Sel[jj][11]*kcalArr[11] + g.Sel[jj][12]*kcalArr[12] + g.Sel[jj][13]*kcalArr[13] + g.Sel[jj][14]*kcalArr[14] + g.Sel[jj][15]*kcalArr[15] + g.Sel[jj][16]*kcalArr[16] + g.Sel[jj][17]*kcalArr[17] <= DAY_HI);\n",
+    "}\n",
+    "Console.WriteLine($\"Fenetre kcal/jour posee : [{DAY_LO}, {DAY_HI}] pour chacun des {D} jours.\");\n",
+    "\n",
+    "// Resolution SMT globale.\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "var plan = th.Solve();\n",
+    "sw.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"\\n=== Solution SMT (solve en {sw.Elapsed.TotalMilliseconds:F1} ms) ===\");\n",
+    "for (int j = 0; j < D; j++)\n",
+    "{\n",
+    "    int kSum = 0; var picks = new List<string>();\n",
+    "    for (int i = 0; i < N; i++)\n",
+    "        if (plan.Sel[j][i] == 1) { kSum += kcalArr[i]; picks.Add($\"{corpus[i].Name}({kcalArr[i]}k)\"); }\n",
+    "    bool inWin = kSum >= DAY_LO && kSum <= DAY_HI;\n",
+    "    Console.WriteLine($\"Jour {j+1} [{kSum} kcal, fenetre={inWin}] : {string.Join(\" + \", picks)}\");\n",
+    "}\n",
+    "// Preuves post-resolution dans les sorties.\n",
+    "bool allDaysInWindow = Enumerable.Range(0, D).All(j => {\n",
+    "    int s = Enumerable.Range(0, N).Where(i => plan.Sel[j][i]==1).Sum(i => kcalArr[i]);\n",
+    "    return s >= DAY_LO && s <= DAY_HI;\n",
+    "});\n",
+    "int totalDishes = Enumerable.Range(0, D).Sum(j => Enumerable.Range(0, N).Count(i => plan.Sel[j][i]==1));\n",
+    "Console.WriteLine($\"\\nTous les jours dans la fenetre : {allDaysInWindow}\");\n",
+    "Console.WriteLine($\"Total plats servis : {totalDishes} (15 attendus = 5x3)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24b03809",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7. Pourquoi le glouton (*greedy*) se bloque\n",
+    "\n",
+    "Essayons l'approche la plus naïve : **remplir les jours l'un après l'autre**, en choisissant pour chaque jour le premier trio (breakfast+lunch+dinner) qui tombe dans la fenêtre, **sans jamais reconsidérer un choix passé**. C'est un algorithme glouton sans retour arrière.\n",
+    "\n",
+    "Le code ci-dessous tente exactement cela. Observez le résultat : il échoue à compléter le plan (un jour ne peut plus être rempli sans réutiliser un plat déjà consommé ni sortir de la fenêtre)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "99d2250d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:31.933549Z",
+     "iopub.status.busy": "2026-06-27T15:51:31.933348Z",
+     "iopub.status.idle": "2026-06-27T15:51:32.081399Z",
+     "shell.execute_reply": "2026-06-27T15:51:32.081145Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Glouton sans retour arriere : ECHEC au jour 4.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Aucun trio (breakfast+lunch+dinner) restant ne tombe dans la fenetre kcal.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Les plats aux bons apports caloriques ont deja ete consommes les jours precedents.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Jours remplis avant l'echec : 3/5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Contraste : le SMT a resolu le MEME probleme globalement en quelques ms (section 6),\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tandis que le glouton local est fragile. C'est la signature d'un CSP couple non trivial (Prong-B).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demo : glouton sans retour arriere. Remplit jour par jour avec le premier trio valide restant.\n",
+    "// Montre que cette strategie LOCALE se bloque : la combinatoire couplant fenetre x variete est non compositionnelle.\n",
+    "HashSet<int> usedSet = new HashSet<int>();\n",
+    "var greedyPlan = new List<(int b, int l, int d)>();\n",
+    "int failedAt = -1;\n",
+    "for (int j = 0; j < D; j++)\n",
+    "{\n",
+    "    (int b, int l, int dd) choice = (-1, -1, -1); bool found = false;\n",
+    "    for (int b = 0; b <= 5 && !found; b++)            // breakfast [0,5]\n",
+    "    {\n",
+    "        if (usedSet.Contains(b)) continue;\n",
+    "        for (int l = 6; l <= 11 && !found; l++)       // lunch [6,11]\n",
+    "        {\n",
+    "            if (usedSet.Contains(l)) continue;\n",
+    "            for (int dd = 12; dd <= 17 && !found; dd++)  // dinner [12,17]\n",
+    "            {\n",
+    "                if (usedSet.Contains(dd)) continue;\n",
+    "                int tot = corpus[b].Kcal + corpus[l].Kcal + corpus[dd].Kcal;\n",
+    "                if (tot >= DAY_LO && tot <= DAY_HI) { choice = (b, l, dd); found = true; }\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    if (!found) { failedAt = j + 1; break; }\n",
+    "    usedSet.Add(choice.b); usedSet.Add(choice.l); usedSet.Add(choice.dd);\n",
+    "    greedyPlan.Add(choice);\n",
+    "}\n",
+    "\n",
+    "if (failedAt > 0)\n",
+    "{\n",
+    "    Console.WriteLine($\"Glouton sans retour arriere : ECHEC au jour {failedAt}.\");\n",
+    "    Console.WriteLine(\"  Aucun trio (breakfast+lunch+dinner) restant ne tombe dans la fenetre kcal.\");\n",
+    "    Console.WriteLine(\"  Les plats aux bons apports caloriques ont deja ete consommes les jours precedents.\");\n",
+    "    Console.WriteLine($\"  Jours remplis avant l'echec : {greedyPlan.Count}/{D}\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    Console.WriteLine($\"Glouton sans retour arriere : SUCCES sur ce corpus ({greedyPlan.Count}/{D} jours).\");\n",
+    "    Console.WriteLine(\"  La fenetre est assez large pour que l'ordre glouton tombe juste ici.\");\n",
+    "    Console.WriteLine(\"  MAIS le couplage reste reel : resserrez [DAY_LO, DAY_HI] ou augmentez D, et le glouton\");\n",
+    "    Console.WriteLine(\"  se bloque la ou le solveur (section 6) continue de resoudre instantanement.\");\n",
+    "    foreach (var (b,l,dd) in greedyPlan)\n",
+    "        Console.WriteLine($\"    Jour: {corpus[b].Name} + {corpus[l].Name} + {corpus[dd].Name} = {corpus[b].Kcal+corpus[l].Kcal+corpus[dd].Kcal} kcal\");\n",
+    "}\n",
+    "Console.WriteLine($\"\\nContraste : le SMT a resolu le MEME probleme globalement en quelques ms (section 6),\");\n",
+    "Console.WriteLine(\"tandis que le glouton local est fragile. C'est la signature d'un CSP couple non trivial (Prong-B).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "173fe76b",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 8. Interprétation : déclaratif vs glouton sur un CSP couplé\n",
+    "\n",
+    "| Aspect | Glouton sans retour | Solveur SMT |\n",
+    "|--------|---------------------|-------------|\n",
+    "| **Stratégie** | Remplit jour par jour, premier trio valide | Propage toutes les contraintes globalement |\n",
+    "| **Couplage fenêtre × variété** | Ignoré (décisions locales) | Exploité (propagation arrière) |\n",
+    "| **Issue** | Fragile / se bloque dès qu'on resserre | Solution complète en ~100 ms |\n",
+    "| **Coût** | Exponentiel si on ajoute du backtracking | Polynomial par propagation de contraintes |\n",
+    "\n",
+    "**Leçon** : la valeur d'un solveur déclaratif ne se voit pas sur un problème à un seul jour (le glouton y suffit). Elle apparaît dès que **plusieurs contraintes se partagent un même pool de ressources** (les plats) à travers **plusieurs dimensions** (les jours). C'est exactement le couplage qui rend l'ordonnancement, l'emploi du temps et la planification réels difficiles — et que le paradigme déclaratif absorbe sans changement d'approche."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e42f0f13",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "Les exercices sont à compléter : chaque stub s'exécute sans erreur (affiche un message), conformément à la convention (pas de `raise NotImplementedError`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5e05978d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:32.082975Z",
+     "iopub.status.busy": "2026-06-27T15:51:32.082687Z",
+     "iopub.status.idle": "2026-06-27T15:51:32.142697Z",
+     "shell.execute_reply": "2026-06-27T15:51:32.142254Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : fenetre de proteines minimale par jour.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Fenetre de proteines par jour.\n",
+    "// Ajoutez une contrainte : pour chaque jour, la somme des proteines des plats choisis est >= PROTEIN_MIN (ex: 60 g).\n",
+    "// Indice : meme structure que la fenetre kcal, mais avec proteinArr au lieu de kcalArr (somme inline sur les 18 plats).\n",
+    "// Etape 1 : definir PROTEIN_MIN = 60.\n",
+    "// Etape 2 : ajouter, pour chaque jour j, la contrainte sum_i Sel[j][i]*proteinArr[i] >= PROTEIN_MIN.\n",
+    "// Etape 3 : resoudre et verifier que chaque jour atteint le seuil proteique.\n",
+    "Console.WriteLine(\"Exercice 1 a completer : fenetre de proteines minimale par jour.\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1fef7778",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:32.144273Z",
+     "iopub.status.busy": "2026-06-27T15:51:32.144061Z",
+     "iopub.status.idle": "2026-06-27T15:51:32.185386Z",
+     "shell.execute_reply": "2026-06-27T15:51:32.185187Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : budget hebdomadaire + minimisation du cout.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Budget hebdomadaire.\n",
+    "// Contraignez le cout total de la semaine : sum_{j,i} Sel[j][i] * costArr[i] <= WEEKLY_BUDGET_CENTS (ex: 3500 = 35 EUR).\n",
+    "// Puis MINIMISEZ ce cout via une dichotomie sur le budget (cf. notebook 05 section 6) et affichez le plan le moins cher.\n",
+    "// Indice : la borne haute initiale est le cout du plan de la section 6 ; cherchez par dichotomie le minimum realisable.\n",
+    "Console.WriteLine(\"Exercice 2 a completer : budget hebdomadaire + minimisation du cout.\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6bb76295",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T15:51:32.186603Z",
+     "iopub.status.busy": "2026-06-27T15:51:32.186411Z",
+     "iopub.status.idle": "2026-06-27T15:51:32.222827Z",
+     "shell.execute_reply": "2026-06-27T15:51:32.222663Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : variete renforcee sur jours consecutifs.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Variete renforcee sur 2 jours consecutifs.\n",
+    "// En plus de la variete globale, imposez qu'un plat d'une meme categorie ne soit JAMAIS servi deux jours de suite.\n",
+    "// Exemple pour le dinner : le plat du dinner du jour j et du jour j+1 doivent etre distincts.\n",
+    "// Indice : pour chaque paire (j, j+1), ajouter Sel[j][i] + Sel[j+1][i] <= 1 sur la categorie cible (indices 12-17).\n",
+    "Console.WriteLine(\"Exercice 3 a completer : variete renforcee sur jours consecutifs.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "075f8023",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "### Points clés à retenir\n",
+    "\n",
+    "1. **Deux modèles `int[][]` distincts** coexistent dans la série : la **grille d'index** (05 §7, 06b §4 — `Plan[j][k]` = indice du plat) et la **matrice booléenne** (ce notebook — `Sel[j][i]` = 0/1). Le second est nécessaire dès qu'on veut **agréger une quantité par jour** (kcal, protéines, coût), car on ne peut pas indexer un tableau C# par une variable symbolique.\n",
+    "2. **La fenêtre nutritionnelle par jour** est le chaînon qui couple la nutrition (05 §5) au plan multi-jours (05 §7). Elle se déclare en une ligne par jour (somme linéaire `sum_i Sel[j][i] × kcal[i] ∈ [lo, hi]`).\n",
+    "3. **Le couplage fenêtre × variété** rend le problème non compositionnel : un glouton local est fragile, le solveur SMT propage globalement et résout en millisecondes. C'est la signature d'un **CSP couplé non trivial**.\n",
+    "\n",
+    "### Perspective\n",
+    "\n",
+    "Ce modèle booléen `D × N` se généralise tel quel à tout problème d'**affectation sous fenêtre** : *shift scheduling* (employés × jours avec couverture minimale), *timetabling* (cours × salles avec capacités), *bin packing* temporel. Le paradigme déclaratif absorbe ces variantes sans changer d'approche — seules les contraintes changent."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -4,7 +4,7 @@
 
 ## Série en quelques mots
 
-Le binding Z3.Linq traduit des requêtes LINQ C# en formules SMT — on décrit les contraintes, le solveur produit la solution. Série .NET 9 de **8 notebooks** (~5h50), du théorème linéaire à la planification multi-jours couplée (fenêtre nutrition × variété).
+Le binding Z3.Linq traduit des requêtes LINQ C# en formules SMT — on décrit les contraintes, le solveur produit la solution. Série .NET 9 de **10 notebooks** (~6h55), du théorème linéaire à la planification multi-jours couplée (fenêtre nutrition × variété).
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs C# souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de théorèmes linéaires simples pour monter progressivement vers les théories de tableaux et l'optimisation hiérarchique.
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md
@@ -4,7 +4,7 @@
 
 ## Série en quelques mots
 
-Le binding Z3.Linq traduit des requêtes LINQ C# en formules SMT — on décrit les contraintes, le solveur produit la solution. Série .NET 9 de **7 notebooks** (~5h10), du théorème linéaire à la génération de témoins (fork Automata).
+Le binding Z3.Linq traduit des requêtes LINQ C# en formules SMT — on décrit les contraintes, le solveur produit la solution. Série .NET 9 de **8 notebooks** (~5h50), du théorème linéaire à la planification multi-jours couplée (fenêtre nutrition × variété).
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs C# souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de théorèmes linéaires simples pour monter progressivement vers les théories de tableaux et l'optimisation hiérarchique.
 
@@ -48,6 +48,7 @@ L'abstraction centrale du binding : on reste en C#, on décrit des contraintes, 
 | 06 | [Witness Generation Automata](06_Witness_Generation_Automata.ipynb) | **Fork Automata** : générer un *témoin* depuis `A & ~B` (intersection/complément de surface), cap des 21 caractères levé (#6), émission SMT-LIB `re.inter`/`re.comp` | ~40 min | BETA |
 | 06b | [RecipeML Corpus](06b_RecipeML_Corpus.ipynb) | Modélisation SMT sur **données externes** : corpus RecipeML (XML) parsé en classes de domaine, menu booléen avec exclusion d'allergène (`MkITE`) + plan hiérarchique multi-jours `int[][]` (`CollectionHandling.Array`) | ~40 min | BETA |
 | 06c | [Meal Planner Visualization](06c_Meal_Planner_Visualization.ipynb) | **Rendu HTML** des solutions Z3 (`display(HTML(...))`) : carte de menu color-codée (kcal/protéines/allergènes), grille hebdomadaire, front de Pareto budget↔kcal — montée en gamme du rendu plat `Console.WriteLine` | ~40 min | BETA |
+| 07 | [Weekly Nutrition Planner](07_Weekly_Nutrition_Planner.ipynb) | **Matrice booléenne jour×plat** + **fenêtre kcal par jour** + **variété globale** : le couplage non-trivial où un glouton se bloque (jour 4) tandis que le SMT résout globalement — fusion de la nutrition (05 §5) et du plan multi-jours (05 §7) | ~40 min | BETA |
 
 ### Fil pédagogique
 
@@ -60,6 +61,7 @@ L'abstraction centrale du binding : on reste en C#, on décrit des contraintes, 
 7. **Notebook 06** ferme la boucle *reconnaissance vs production* : le fork [Automata](https://github.com/MyIntelligenceAgency/Automata) (modernisation net8.0 de AutomataDotNet, gelé ~2020) génère un **témoin** depuis la syntaxe de surface `&`/`~` (intersection/complément), démontre que le cap des 21 caractères (#6) est levé, et émet du SMT-LIB (`re.inter`/`re.comp`). C'est le payoff général de la génération de témoin `A & ~B` que [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) mesure ensuite à l'échelle (§6b)
 8. **Notebook 06b** fait le **pont vers des données externes** : plutôt que des littéraux *in-notebook*, un corpus de recettes au format **RecipeML** (standard XML culinaire) est parsé en classes de domaine via LINQ-to-XML, puis consommé par le solveur. Le modèle booléen agrège la nutrition via `MkITE` et exclut un allergène ; le théorème hiérarchique `int[][]` planifie plusieurs jours sans répétition. C'est le moment où l'on voit que le paradigme déclaratif absorbe une source de données réelle aussi naturellement qu'un Sudoku
 9. **Notebook 06c** élève le **rendu des solutions** : les tableaux plats `Console.WriteLine` des notebooks précédents deviennent des cartes HTML color-codées (calories, protéines, allergènes) via `display(HTML(...))`, une grille hebdomadaire, et un **front de Pareto** budget↔calories. La leçon : la valeur d'un solveur se mesure aussi à la lisibilité de ses solutions pour un humain
+10. **Notebook 07** referme la boucle sur le **couplage combinatoire** : contrairement au modèle en grille d'index de 05 §7 (qui *affiche* la nutrition sans la *contraindre*), il adopte une **matrice booléenne `int[][]`** jour×plat pour pouvoir **agréger les kcal par jour** (`sum_i Sel[j][i] × kcal[i] ∈ [lo, hi]`) tout en imposant une **variété globale** (chaque plat ≤1×/semaine). Ce couplage fenêtre×variété est **non compositionnel** : un glouton sans retour arrière se bloque au jour 4, alors que le solveur propage les contraintes globalement et résout en ~1 s. C'est le chaînon manquant entre la nutrition (05 §5) et le plan multi-jours (05 §7), et la démonstration canonique d'un **CSP couplé non trivial** (Prong-B)
 
 ## Concepts clés
 
@@ -81,6 +83,8 @@ La série manipule un vocabulaire précis hérité de la programmation par contr
 | **Reconnaissance vs résolution** | Distinction centrale : un vérificateur (RE#) *certifie* une solution existante en temps linéaire ; un résolveur (Z3) *produit* une solution (NP-dur). Les notebooks 06 et Sudoku-13 mettent cette distinction en scène. | 06 |
 | **Données externes (RecipeML/XML)** | Le solveur consomme une source réelle parsée (corpus XML LINQ-to-XML → classes de domaine) plutôt que des littéraux *in-notebook*. Démontre que le paradigme déclaratif s'applique à des données structurées hétérogènes. | 06b |
 | **Rendu HTML des solutions** | Production d'une sortie visuellement interprétable (`display(HTML(...))`) : cartes color-codées, grilles, front de Pareto. Un solveur se jauge aussi à la lisibilité de ses solutions pour l'humain. | 06c |
+| **Matrice booléenne jour×plat** | Modéliser un choix par `(jour, plat)` comme `Sel[j][i] ∈ {0,1}` plutôt que par un index `Plan[j]`. Permet d'**agréger linéairement** des attributs par jour (`sum_i Sel[j][i] × kcal[i]`) — impossible avec une grille d'index car on ne peut pas indexer un tableau C# par une variable Z3. | 07 |
+| **CSP couplé non trivial** | Couplage de deux contraintes **globales non compositionnelles** (fenêtre kcal par jour × variété une fois/semaine) : un glouton sans retour arrière s'y bloque (jour 4), alors que la propagation du solveur résout globalement. Définit le seuil où un solveur SMT *discrimine* face à une heuristique triviale (Prong-B). | 07 |
 
 ## Prérequis
 


### PR DESCRIPTION
## Contexte

Nouveau notebook `07_Weekly_Nutrition_Planner.ipynb` dans la série Z3.Linq, suite au steer coordinateur (ai-01, deep-queue cycle-E/F) : **création substantielle** d'un planificateur de repas multi-jours en C# .NET Interactive. `See #1206`.

## Problème posé (Prong-B : non-trivial)

Planifier **5 jours × 3 repas** (15 slots) sur un corpus de **18 plats**, sous deux contraintes **globales couplées** :

1. **Fenêtre kcal par jour** : `DAY_LO ≤ Σ_i Sel[j][i]·kcal[i] ≤ DAY_HI` (1500–1700 kcal/jour)
2. **Variété hebdomadaire** : chaque plat apparaît **au plus 1 fois/semaine** (`Σ_j Sel[j][i] ≤ 1`)

Ce couplage est **non compositionnel** : un glouton sans retour arrière remplit jour par jour et **se bloque au jour 4** (3/5 jours), car il a épuisé les plats compatibles avec la fenêtre kcal sans anticipation. Le solveur SMT propage les contraintes globalement et résout.

## Modèle : matrice booléenne vs grille d'index

Contrairement au modèle index `Plan[j][k]` du notebook 05 §7 (qui *affiche* la nutrition sans la *contraindre* — on ne peut pas indexer un tableau C# par une variable Z3), le notebook 07 adopte une **matrice booléenne `int[][]` jour×plat** :

- `Sel[j][i] ∈ {0,1}` = plat `i` choisi pour le jour `j`
- Permet d'**agréger linéairement** : `Σ_i Sel[j][i]·kcal[i]` est une somme de produits bool×const, inline dans `.Where()` (requis par le Z3.Linq ExpressionVisitor)

## Preuve d'exécution réelle (règle C.2 + H.1)

- **Kernel** : `.net-csharp` (.NET 9.0 Interactive), exécuté via `jupyter nbconvert --execute --inplace` depuis le dossier du notebook (cwd correct pour les `#r` relatifs du fork Z3.Linq)
- **9/9 cellules code exécutées** (`execution_count: 1..9`), **0 erreur**
- **Sortie SMT réelle** : solve en **1249 ms**, 5/5 jours à 1700 kcal, **15 plats uniques**
- **Sortie greedy réelle** : `3/5 jours remplis` (échec jour 4) — la démonstration Prong-B est dans les outputs

## Verdict SOTA (sota-not-workaround, EPIC #3801)

**SOTA-OK** — le vrai fork Z3.Linq ([MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq), fix `AssertConstraints` mergé) est proprement invoqué via `#r "../Z3.Linq/.deploy/..."`. Les sorties committées sont les vraies sorties du solveur. Pas de workaround dégradé.

## Anti-régression & conventions

- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0` ; 3 stubs d'exercice (`pass`/`return None`/TODO) — fenêtre protéine, budget hebdo+minimisation, variété jours consécutifs
- **3 exercices** (convention #2161) répartis, précédés de markdown (contexte+objectif+indices)
- **Anti-régression** : pas de suppression de code métier (nouveau notebook, +811 lignes pures)
- **scan_md_hierarchy** : 0/1 (clean)
- **scan fuites** : 0 chemin machine, 0 préfixe de clé (outputs + source)
- **CATALOG byte-identical** à `main` (catalog-pr-hygiene, laissé à l'automatisation)

## Scope du diff

| Fichier | Changement |
|---------|------------|
| `07_Weekly_Nutrition_Planner.ipynb` | nouveau, 20 cellules (9 code + 11 md), exécuté |
| `README.md` | +1 ligne table notebooks, +1 point fil pédagogique, +2 entrées concepts clés, stats 7→8 |
| `06c_Meal_Planner_Visualization.ipynb` | nav forward-link vers 07 (markdown-only, outputs préservés — exception C.2) |

**Hors-scope** : le sous-module `Automata/` (#2979, USER-PARKÉ) n'est **pas** touché.

See #1206