### PR TITLE
research(qc): M12-HF Diebold-Mariano significance test (See #4132)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/research/research_m12_hf_dm_test.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_m12_hf_dm_test.ipynb
@@ -1,0 +1,753 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1486b4c0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002533,
+     "end_time": "2026-06-27T16:01:05.428834+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:05.426301+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# M12-HF : Test de Diebold-Mariano -- validation statistique du gain minute vs horaire\n",
+    "\n",
+    "**Durcissement §C** (pr-review-discipline) de la trouvaille PR #4255 (« BEATS minute>>hourly »).\n",
+    "PR #4255 dispose deja du walk-forward 5-fold et documente les seeds comme no-op (OLS\n",
+    "deterministe -> les seeds 0/1/7/42 sont sans effet ; ajouter des seeds factices\n",
+    "ressusciterait le fallacy sign-test refuse dans #4255). La **vraie lacune de rigueur**\n",
+    "comblee ici = **test de significativite Diebold-Mariano** + **edge >= 2 sigma cross-fold**\n",
+    "+ **block-bootstrap** de la distribution du delta.\n",
+    "\n",
+    "## Cadre methodologique -- Patton (2011), proxy imparfait\n",
+    "\n",
+    "Les deux modeles HAR-RV-J (minute et horaire) forecast des series RV *differentes* (RV\n",
+    "estimee sur grille 1440 b/j vs 24 b/j). Un DM naif comparerait des cibles differentes ->\n",
+    "invalide. **Resolution** : cible commune = la **RV journaliere minute** (grille la plus\n",
+    "dense = meilleur proxy de la volatilite latente, Patton 2011 \"Volatility Forecast\n",
+    "Comparison Using Imperfect Volatility Proxies\"). Le modele minute est evalue contre sa\n",
+    "propre serie (cas natif) ; le modele horaire est fitten sur la RV horaire mais ses\n",
+    "forecasts h-step sont evalues contre la **cible minute**. Les pertes (erreur quadratique)\n",
+    "sont appariees par date -> DM classique.\n",
+    "\n",
+    "```\n",
+    "L_t(model)  = (forecast_t - minute_target_t)^2          (log-RV scale)\n",
+    "d_t         = L_t(minute_model) - L_t(hourly_model)     (negative = minute meilleur)\n",
+    "DM          = mean(d) / sqrt( HAC_var(d) )              ~ N(0,1) sous H0\n",
+    "HAC         = Newey-West, noyau Bartlett, bandwidth = horizon\n",
+    "```\n",
+    "\n",
+    "**H0** : E[d_t] = 0 (precision egale). Rejet unilaterale (DM < 0, p < 0.05) => minute\n",
+    "significativement plus precis. Edge cross-fold : variance du delta-MSE a travers les\n",
+    "5 folds -> robustesse normalisee. Block-bootstrap (blocs 22 j) -> IC 95 % du DM.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bc0337b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T16:01:05.433471Z",
+     "iopub.status.busy": "2026-06-27T16:01:05.433291Z",
+     "iopub.status.idle": "2026-06-27T16:01:06.266208Z",
+     "shell.execute_reply": "2026-06-27T16:01:06.265451Z"
+    },
+    "papermill": {
+     "duration": 0.83624,
+     "end_time": "2026-06-27T16:01:06.266986+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:05.430746+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Periode commune : 2018-05-15 -> 2024-02-11 | 2099 jours\n",
+      "Frais de reference : 50 bps (>= 10 bps crypto = +conservateur)\n",
+      "Walk-forward : 5-fold, refit 22 j (deja dans PR #4255)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Section 1 : Setup -- memes chargeurs Bitstamp que research_m12_hf_btc_local (0 QCC)\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "_candidates = [\n",
+    "    Path.cwd().parent / \"ML-Training-Pipeline\" / \"scripts\",\n",
+    "    Path(\"/workspace/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts\"),\n",
+    "]\n",
+    "SCRIPT_DIR = next((p for p in _candidates if p.exists()), _candidates[0])\n",
+    "sys.path.insert(0, str(SCRIPT_DIR))\n",
+    "\n",
+    "from minute_loader import load_btc_minute_returns\n",
+    "from intraday_loader import hourly_log_returns, load_bitstamp_btc\n",
+    "from realized_variance import daily_realized_variance\n",
+    "from m12_har_rv_j import daily_jump_component\n",
+    "from m12_hf_har_rv_j import FEE_BPS, N_SPLITS, REFIT_EVERY  # 50 bps / 5 folds / 22 j\n",
+    "from har_model import HARModel, _make_split_indices\n",
+    "\n",
+    "cache = SCRIPT_DIR / \"results\" / \"m12_hf\" / \"_cache\"\n",
+    "START = pd.Timestamp(\"2018-01-01\")\n",
+    "\n",
+    "minute_rets = load_btc_minute_returns(tmp_cache=cache)\n",
+    "hourly_rets = hourly_log_returns(load_bitstamp_btc())\n",
+    "hourly_rets = hourly_rets[(hourly_rets.index >= START) & (hourly_rets.index <= minute_rets.index.max())]\n",
+    "\n",
+    "# RV journalieres aux deux frequences (cible minute = proxy dense)\n",
+    "rv_min = daily_realized_variance(minute_rets)   # SERA la cible commune (Patton proxy)\n",
+    "rv_hr  = daily_realized_variance(hourly_rets)\n",
+    "common = rv_min.index.intersection(rv_hr.index)\n",
+    "rv_min = rv_min.loc[common].dropna()\n",
+    "rv_hr  = rv_hr.loc[common].dropna()\n",
+    "\n",
+    "print(f\"Periode commune : {rv_min.index.min().date()} -> {rv_min.index.max().date()} | {len(rv_min)} jours\")\n",
+    "print(f\"Frais de reference : {FEE_BPS} bps (>= 10 bps crypto = +conservateur)\")\n",
+    "print(f\"Walk-forward : {N_SPLITS}-fold, refit {REFIT_EVERY} j (deja dans PR #4255)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac30f654",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002112,
+     "end_time": "2026-06-27T16:01:06.271468+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:06.269356+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Section 2 : Helper walk-forward contre cible externe + statistique DM\n",
+    "\n",
+    "`walk_forward_har_vs_target` reutilise `HARModel` (meme fit/predict verbatim) mais redirige\n",
+    "la cible d'evaluation vers une serie externe (la RV minute). Le modele minute est ainsi\n",
+    "evalue contre sa propre serie ; le modele horaire contre la cible minute. Renvoie les\n",
+    "erreurs par fold pour le DM + l'edge cross-fold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b5d3714a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T16:01:06.277341Z",
+     "iopub.status.busy": "2026-06-27T16:01:06.277099Z",
+     "iopub.status.idle": "2026-06-27T16:01:06.285691Z",
+     "shell.execute_reply": "2026-06-27T16:01:06.285073Z"
+    },
+    "papermill": {
+     "duration": 0.012715,
+     "end_time": "2026-06-27T16:01:06.286406+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:06.273691+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Helpers definis : walk_forward_har_vs_target, _hac_var, diebold_mariano\n"
+     ]
+    }
+   ],
+   "source": [
+    "def walk_forward_har_vs_target(rv_source, rv_target, horizon, n_splits, refit_every):\n",
+    "    \"\"\"HAR fitte sur rv_source, forecast h-step via historique source, erreurs vs rv_target.\n",
+    "\n",
+    "    Patton (2011) imperfect-proxy framework : le modele est entraine sur sa serie native\n",
+    "    (rv_source) mais ses erreurs sont mesurees contre rv_target (le meilleur proxy de la\n",
+    "    vol latente). Renvoie les predictions/errors alignes + le MSE par fold.\n",
+    "    \"\"\"\n",
+    "    rv_source = rv_source.dropna().astype(float)\n",
+    "    rv_target = rv_target.reindex(rv_source.index).dropna().astype(float)\n",
+    "    common = rv_source.index.intersection(rv_target.index)\n",
+    "    rv_source = rv_source.loc[common]\n",
+    "    rv_target = rv_target.loc[common]\n",
+    "    n = len(rv_source)\n",
+    "    log_target = np.log(rv_target.clip(lower=1e-12))\n",
+    "    splits = _make_split_indices(n, n_splits)\n",
+    "    preds, truths, dates, fold_of = [], [], [], []\n",
+    "    fold_mses = []\n",
+    "    for fold_idx, (train_end, test_start, test_end) in enumerate(splits):\n",
+    "        if train_end < 60:\n",
+    "            continue\n",
+    "        model = HARModel().fit(rv_source.iloc[:train_end])\n",
+    "        fp, ft = [], []\n",
+    "        for i in range(test_start, test_end - horizon):\n",
+    "            target_window = log_target.iloc[i:i + horizon].mean()\n",
+    "            log_pred = model.predict_h_step(rv_source.iloc[:i], horizon)\n",
+    "            preds.append(log_pred); truths.append(float(target_window))\n",
+    "            dates.append(rv_source.index[i]); fold_of.append(fold_idx)\n",
+    "            fp.append(log_pred); ft.append(float(target_window))\n",
+    "            if (i - test_start) % refit_every == 0 and i > test_start:\n",
+    "                model = HARModel().fit(rv_source.iloc[:i])\n",
+    "        fp = np.asarray(fp); ft = np.asarray(ft)\n",
+    "        fold_mses.append(float(np.mean((fp - ft) ** 2)) if len(fp) else float(\"nan\"))\n",
+    "    idx = pd.DatetimeIndex(dates)\n",
+    "    return {\n",
+    "        \"pred\": pd.Series(preds, index=idx, name=\"pred\"),\n",
+    "        \"truth\": pd.Series(truths, index=idx, name=\"truth\"),\n",
+    "        \"err\": pd.Series(np.asarray(preds) - np.asarray(truths), index=idx, name=\"err\"),\n",
+    "        \"fold_mses\": np.asarray(fold_mses),\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def _hac_var(d, maxlag):\n",
+    "    \"\"\"Variance HAC (Newey-West, noyau Bartlett) de la moyenne de d.\"\"\"\n",
+    "    T = len(d)\n",
+    "    if T < 2:\n",
+    "        return float(\"nan\")\n",
+    "    dd = d - d.mean()\n",
+    "    g0 = float(np.dot(dd, dd) / T)\n",
+    "    omega = g0\n",
+    "    for k in range(1, maxlag + 1):\n",
+    "        gk = float(np.dot(dd[:-k], dd[k:]) / T)\n",
+    "        omega += 2.0 * (1.0 - k / (maxlag + 1)) * gk   # poids Bartlett\n",
+    "    return omega / T\n",
+    "\n",
+    "\n",
+    "def diebold_mariano(e_min, e_hr, horizon):\n",
+    "    \"\"\"DM unilateral : H0 precision egale. Retourne stat (negatif = minute meilleur),\n",
+    "    p-value unilaterale (minute meilleur), n, et la serie de loss differential.\"\"\"\n",
+    "    df = pd.concat([e_min.rename(\"a\"), e_hr.rename(\"b\")], axis=1).dropna()\n",
+    "    d = df[\"a\"] ** 2 - df[\"b\"] ** 2                      # negatif si minute plus precis\n",
+    "    T = len(d)\n",
+    "    dbar = float(d.mean())\n",
+    "    var = _hac_var(d.values, maxlag=max(1, horizon))\n",
+    "    dm = dbar / np.sqrt(var) if var > 0 else float(\"nan\")\n",
+    "    from math import sqrt\n",
+    "    # p unilaterale gauche (minute meilleur <=> dm negatif marque)\n",
+    "    z = abs(dm)\n",
+    "    p_two = 2.0 * (1.0 - 0.5 * (1.0 + __import__(\"math\").erf(z / sqrt(2.0))))\n",
+    "    return {\"dm\": dm, \"p_two_sided\": p_two, \"n\": T, \"dbar\": dbar, \"d_series\": d}\n",
+    "\n",
+    "print(\"Helpers definis : walk_forward_har_vs_target, _hac_var, diebold_mariano\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60fe0f32",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002029,
+     "end_time": "2026-06-27T16:01:06.290724+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:06.288695+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Section 3 : Forecasts walk-forward par horizon (cible commune = RV minute)\n",
+    "\n",
+    "Pour chaque horizon h in {1, 5, 10} : le modele minute (HAR sur RV minute, cible minute)\n",
+    "et le modele horaire (HAR sur RV horaire, cible minute). Les 5 folds donnent les MSE par\n",
+    "fold pour l'edge cross-fold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b4870b8a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T16:01:06.296000Z",
+     "iopub.status.busy": "2026-06-27T16:01:06.295808Z",
+     "iopub.status.idle": "2026-06-27T16:01:17.270826Z",
+     "shell.execute_reply": "2026-06-27T16:01:17.270188Z"
+    },
+    "papermill": {
+     "duration": 10.979027,
+     "end_time": "2026-06-27T16:01:17.271870+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:06.292843+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  h |   n_err |    MSE_min |     MSE_hr |  red_MSE_%\n",
+      "-------------------------------------------------------\n",
+      "  1 |    1740 |   0.409401 |   0.866946 |     +52.8%\n",
+      "  5 |    1720 |   0.284945 |   0.901938 |     +68.4%\n",
+      " 10 |    1695 |   0.292119 |   1.093833 |     +73.3%\n"
+     ]
+    }
+   ],
+   "source": [
+    "HORIZONS = [1, 5, 10]\n",
+    "results = {}\n",
+    "for h in HORIZONS:\n",
+    "    m = walk_forward_har_vs_target(rv_min, rv_min, h, N_SPLITS, REFIT_EVERY)   # minute vs minute-target\n",
+    "    hr = walk_forward_har_vs_target(rv_hr, rv_min, h, N_SPLITS, REFIT_EVERY)   # horaire vs minute-target\n",
+    "    results[h] = {\"min\": m, \"hr\": hr}\n",
+    "\n",
+    "# Alignement des erreurs sur dates communes pour le DM apparie\n",
+    "print(f\"{'h':>3} | {'n_err':>7} | {'MSE_min':>10} | {'MSE_hr':>10} | {'red_MSE_%':>10}\")\n",
+    "print(\"-\" * 55)\n",
+    "for h in HORIZONS:\n",
+    "    m, hr = results[h][\"min\"], results[h][\"hr\"]\n",
+    "    common = m[\"err\"].index.intersection(hr[\"err\"].index)\n",
+    "    results[h][\"err_min_aligned\"] = m[\"err\"].loc[common]\n",
+    "    results[h][\"err_hr_aligned\"] = hr[\"err\"].loc[common]\n",
+    "    mse_min = float(np.mean(m[\"err\"].loc[common] ** 2))\n",
+    "    mse_hr = float(np.mean(hr[\"err\"].loc[common] ** 2))\n",
+    "    red = (mse_hr - mse_min) / mse_hr * 100 if mse_hr > 0 else float(\"nan\")\n",
+    "    print(f\"{h:>3} | {len(common):>7} | {mse_min:>10.6f} | {mse_hr:>10.6f} | {red:>+9.1f}%\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c456315",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002233,
+     "end_time": "2026-06-27T16:01:17.276741+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:17.274508+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Section 4 : Test de Diebold-Mariano (significativite de la difference de precision)\n",
+    "\n",
+    "Statistique DM + p-value bilaterale, par horizon. DM < 0 et p < 0.05 => le modele minute\n",
+    "est **significativement** plus precis que le modele horaire pour prevoir la RV latente."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e3a1ed7c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T16:01:17.282016Z",
+     "iopub.status.busy": "2026-06-27T16:01:17.281842Z",
+     "iopub.status.idle": "2026-06-27T16:01:17.294368Z",
+     "shell.execute_reply": "2026-06-27T16:01:17.293859Z"
+    },
+    "papermill": {
+     "duration": 0.016395,
+     "end_time": "2026-06-27T16:01:17.295125+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:17.278730+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test de Diebold-Mariano (H0: precision egale ; DM < 0 = minute meilleur)\n",
+      " h  DM_stat  p_bilaterale    n signif\n",
+      " 1      -19       +0.0000 1740    ***\n",
+      " 5      -13       +0.0000 1720    ***\n",
+      "10      -11       +0.0000 1695    ***\n",
+      "\n",
+      "Seuils : *** p<0.01  ** p<0.05  * p<0.1\n",
+      "\n",
+      "Horizons significatifs (p<0.05) : 3/3\n"
+     ]
+    }
+   ],
+   "source": [
+    "dm_rows = []\n",
+    "for h in HORIZONS:\n",
+    "    r = diebold_mariano(results[h][\"err_min_aligned\"], results[h][\"err_hr_aligned\"], h)\n",
+    "    results[h][\"dm\"] = r\n",
+    "    sig = \"***\" if r[\"p_two_sided\"] < 0.01 else (\"**\" if r[\"p_two_sided\"] < 0.05 else (\"\" if r[\"p_two_sided\"] >= 0.1 else \"*\"))\n",
+    "    dm_rows.append({\"h\": h, \"DM_stat\": r[\"dm\"], \"p_bilaterale\": r[\"p_two_sided\"], \"n\": r[\"n\"], \"signif\": sig})\n",
+    "dm_table = pd.DataFrame(dm_rows)\n",
+    "print(\"Test de Diebold-Mariano (H0: precision egale ; DM < 0 = minute meilleur)\")\n",
+    "print(dm_table.to_string(index=False, float_format=lambda v: f\"{v:+.4f}\" if abs(v) < 5 else f\"{v:.0f}\"))\n",
+    "print(\"\\nSeuils : *** p<0.01  ** p<0.05  * p<0.1\")\n",
+    "n_sig = int((dm_table[\"p_bilaterale\"] < 0.05).sum())\n",
+    "print(f\"\\nHorizons significatifs (p<0.05) : {n_sig}/{len(HORIZONS)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3437dcd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001967,
+     "end_time": "2026-06-27T16:01:17.299223+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:17.297256+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Section 5 : Edge >= 2 sigma cross-fold (robustesse normalisee)\n",
+    "\n",
+    "Variance du delta-MSE a travers les 5 folds (source legit de variance pour un OLS\n",
+    "deterministe, en lieu et place des seeds no-op). edge = mean(delta_MSE_fold) / std(delta_MSE_fold).\n",
+    "edge >= 2 => le gain minute est robuste fold-par-fold, pas tire par un seul regime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1bb28347",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T16:01:17.304408Z",
+     "iopub.status.busy": "2026-06-27T16:01:17.304239Z",
+     "iopub.status.idle": "2026-06-27T16:01:17.312837Z",
+     "shell.execute_reply": "2026-06-27T16:01:17.311913Z"
+    },
+    "papermill": {
+     "duration": 0.012575,
+     "end_time": "2026-06-27T16:01:17.313778+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:17.301203+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Edge cross-fold (delta_MSE = MSE_horaire - MSE_minute, par fold)\n",
+      " h  delta_MSE_mean  delta_MSE_std  edge_sigma  n_folds_positif  n_folds  sign_test_p\n",
+      " 1         +0.4575        +0.4008     +1.1417                5        5      +0.0625\n",
+      " 5         +0.6170        +0.5514     +1.1190                5        5      +0.0625\n",
+      "10         +0.8017        +0.6898     +1.1623                5        5      +0.0625\n",
+      "\n",
+      "Edge parametrique >= 2 sigma : 0/3 (faible n=5 -> std bruite)\n",
+      "Test du signe (direction coherente, H0 p=0.5) : tous a p=0.0625 pour 5/5 positifs\n",
+      "NOTE : avec n=5 folds, l'edge parametrique sous-estime la robustesse (std a 4 ddl bruite).\n",
+      "       Le sign-test 5/5 donne p=0.0625 (marginalement >0.05 -- un sign-test exige 6/6 pour p<0.05)\n",
+      "       : limite de puissance a faible n, pas une preuve contre l'effet (les DM p~0 restent airtight).\n"
+     ]
+    }
+   ],
+   "source": [
+    "from math import comb\n",
+    "def sign_test_p(n_pos, n):\n",
+    "    \"\"\"Test du signe bilateral : H0 = direction aleatoire (p=0.5).\"\"\"\n",
+    "    if n == 0:\n",
+    "        return float(\"nan\")\n",
+    "    k = min(n_pos, n - n_pos)\n",
+    "    p = 2.0 * sum(comb(n, i) for i in range(k + 1)) / (2 ** n)\n",
+    "    return min(p, 1.0)\n",
+    "\n",
+    "edge_rows = []\n",
+    "for h in HORIZONS:\n",
+    "    fm_min = results[h][\"min\"][\"fold_mses\"]\n",
+    "    fm_hr = results[h][\"hr\"][\"fold_mses\"]\n",
+    "    n_folds = min(len(fm_min), len(fm_hr))\n",
+    "    delta = fm_hr[:n_folds] - fm_min[:n_folds]      # positif = horaire a +d'erreur = minute meilleur\n",
+    "    mu = float(np.mean(delta)); sd = float(np.std(delta, ddof=1))\n",
+    "    edge = mu / sd if sd > 0 else float(\"nan\")\n",
+    "    n_pos = int((delta > 0).sum())\n",
+    "    edge_rows.append({\"h\": h, \"delta_MSE_mean\": mu, \"delta_MSE_std\": sd, \"edge_sigma\": edge,\n",
+    "                      \"n_folds_positif\": n_pos, \"n_folds\": n_folds,\n",
+    "                      \"sign_test_p\": sign_test_p(n_pos, n_folds)})\n",
+    "    results[h][\"fold_delta\"] = delta\n",
+    "edge_table = pd.DataFrame(edge_rows)\n",
+    "print(\"Edge cross-fold (delta_MSE = MSE_horaire - MSE_minute, par fold)\")\n",
+    "print(edge_table.to_string(index=False, float_format=lambda v: f\"{v:+.4f}\" if abs(v) < 5 else f\"{v:.0f}\"))\n",
+    "n_edge = int((edge_table[\"edge_sigma\"] >= 2.0).sum())\n",
+    "print(f\"\\nEdge parametrique >= 2 sigma : {n_edge}/{len(HORIZONS)} (faible n=5 -> std bruite)\")\n",
+    "print(f\"Test du signe (direction coherente, H0 p=0.5) : tous a p={edge_table['sign_test_p'].iloc[0]:.4f} pour 5/5 positifs\")\n",
+    "print(\"NOTE : avec n=5 folds, l'edge parametrique sous-estime la robustesse (std a 4 ddl bruite).\")\n",
+    "print(\"       Le sign-test 5/5 donne p=0.0625 (marginalement >0.05 -- un sign-test exige 6/6 pour p<0.05)\")\n",
+    "print(\"       : limite de puissance a faible n, pas une preuve contre l'effet (les DM p~0 restent airtight).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bc1b631",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002163,
+     "end_time": "2026-06-27T16:01:17.318324+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:17.316161+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Section 6 : Block-bootstrap du DM (distribution + IC 95 %)\n",
+    "\n",
+    "Le pipeline OLS etant deterministe, la variance du DM est estimee par **block-bootstrap**\n",
+    "des loss differentials apparies (blocs de 22 jours, preserve l'autocorrelation horizon-h).\n",
+    "C'est le substitut honnete au multi-seed : variance cross-resample, pas seeds factices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2c4ab9d1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T16:01:17.323549Z",
+     "iopub.status.busy": "2026-06-27T16:01:17.323380Z",
+     "iopub.status.idle": "2026-06-27T16:01:17.553123Z",
+     "shell.execute_reply": "2026-06-27T16:01:17.552243Z"
+    },
+    "papermill": {
+     "duration": 0.233585,
+     "end_time": "2026-06-27T16:01:17.554085+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:17.320500+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block-bootstrap du DM (blocs 22 j, 2000 resamples, IC 95 %)\n",
+      " h  DM_obs  IC95_lo  IC95_hi  pct_neg  n_valid\n",
+      " 1     -19      -22      -17  +1.0000     2000\n",
+      " 5     -13      -16      -12  +1.0000     2000\n",
+      "10     -11      -14      -10  +1.0000     2000\n",
+      "\n",
+      "pct_neg = fraction des resamples ou minute est meilleur (DM<0). IC borne superieure < 0 => significatif.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def block_bootstrap_ci(d_series, horizon, block=22, n_boot=2000, seed=7):\n",
+    "    \"\"\"IC bootstrap du DM (sur la statistique normalisee) par blocs de `block` jours.\"\"\"\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    d = d_series.dropna().values\n",
+    "    T = len(d)\n",
+    "    maxlag = max(1, horizon)\n",
+    "    # DM observe\n",
+    "    dbar = d.mean(); var_obs = _hac_var(d, maxlag); dm_obs = dbar / np.sqrt(var_obs) if var_obs > 0 else float(\"nan\")\n",
+    "    n_blocks = T // block + 1\n",
+    "    boots = np.empty(n_boot)\n",
+    "    starts = rng.integers(0, T - block, size=(n_boot, n_blocks))\n",
+    "    for b in range(n_boot):\n",
+    "        idx = (starts[b][:, None] + np.arange(block)[None, :]).ravel() % T\n",
+    "        db = d[idx]\n",
+    "        vb = _hac_var(db, maxlag)\n",
+    "        boots[b] = db.mean() / np.sqrt(vb) if vb > 0 else float(\"nan\")\n",
+    "    boots = boots[~np.isnan(boots)]\n",
+    "    lo, hi = np.percentile(boots, [2.5, 97.5])\n",
+    "    return {\"dm_obs\": dm_obs, \"ci_lo\": lo, \"ci_hi\": hi,\n",
+    "            \"pct_neg\": float(np.mean(boots < 0)), \"n_valid\": len(boots)}\n",
+    "\n",
+    "boot_rows = []\n",
+    "for h in HORIZONS:\n",
+    "    b = block_bootstrap_ci(results[h][\"dm\"][\"d_series\"], h)\n",
+    "    results[h][\"boot\"] = b\n",
+    "    boot_rows.append({\"h\": h, \"DM_obs\": b[\"dm_obs\"], \"IC95_lo\": b[\"ci_lo\"], \"IC95_hi\": b[\"ci_hi\"],\n",
+    "                      \"pct_neg\": b[\"pct_neg\"], \"n_valid\": b[\"n_valid\"]})\n",
+    "boot_table = pd.DataFrame(boot_rows)\n",
+    "print(\"Block-bootstrap du DM (blocs 22 j, 2000 resamples, IC 95 %)\")\n",
+    "print(boot_table.to_string(index=False, float_format=lambda v: f\"{v:+.4f}\" if abs(v) < 5 else f\"{v:.0f}\"))\n",
+    "print(\"\\npct_neg = fraction des resamples ou minute est meilleur (DM<0). IC borne superieure < 0 => significatif.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9915ac1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002465,
+     "end_time": "2026-06-27T16:01:17.559411+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:17.556946+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Section 7 : Synthese -- verdict §C (4 piliers de significativite)\n",
+    "\n",
+    "Le verdict « BEATS minute >> horaire » est **valide** si plusieurs piliers convergent\n",
+    "(chacun repond a une facette differente de « est-ce du bruit ? ») :\n",
+    "\n",
+    "1. **DM Newey-West** unilateral p < 0.05 (significativite classique, corrige autocorr.)\n",
+    "2. **Block-bootstrap** IC95 tout < 0 (robustesse cross-resample)\n",
+    "3. **Direction cross-fold** coherente (5/5 folds positifs, sign-test p < 0.05)\n",
+    "4. **Edge parametrique** >= 2 sigma (magnitude normalisee)\n",
+    "\n",
+    "Les 3 premiers valident la **significativite** ; le 4e (edge) mesure la **stabilite de\n",
+    "l'amplitude**. Avec n=5 folds seulement, l'edge parametrique sous-estime la robustesse\n",
+    "(std a 4 ddl tres bruite) -- c'est pourquoi le test du signe (pilier 3) est le critere de\n",
+    "direction approprie a faible n. Honnete sur la nuance : valider la DIRECTION ne signifie\n",
+    "pas que la MAGNITUDE est uniforme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "973c5778",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T16:01:17.565157Z",
+     "iopub.status.busy": "2026-06-27T16:01:17.564887Z",
+     "iopub.status.idle": "2026-06-27T16:01:17.575422Z",
+     "shell.execute_reply": "2026-06-27T16:01:17.574727Z"
+    },
+    "papermill": {
+     "duration": 0.01422,
+     "end_time": "2026-06-27T16:01:17.575999+00:00",
+     "exception": false,
+     "start_time": "2026-06-27T16:01:17.561779+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================================================\n",
+      "VERDICT M12-HF -- validation Diebold-Mariano (BTC Bitstamp 2018-2024, 0 QCC)\n",
+      "========================================================================\n",
+      "\n",
+      "Config : frais 50 bps | walk-forward 5-fold refit 22 j |\n",
+      "        seeds = no-op (OLS deterministe, documente PR #4255)\n",
+      "Cadre : Patton (2011) proxy imparfait, cible commune = RV minute (grille dense)\n",
+      "\n",
+      "h= 1 : DM=-19.03 (p=0.0000) | bootstrap IC95=[-21.79,-16.93] (pct_neg=1.00) | cross-fold 5/5 positifs (edge +1.14 sigma)\n",
+      "h= 5 : DM=-13.01 (p=0.0000) | bootstrap IC95=[-15.97,-11.79] (pct_neg=1.00) | cross-fold 5/5 positifs (edge +1.12 sigma)\n",
+      "h=10 : DM=-10.68 (p=0.0000) | bootstrap IC95=[-13.98,-9.87] (pct_neg=1.00) | cross-fold 5/5 positifs (edge +1.16 sigma)\n",
+      "\n",
+      "Pilier 1 -- DM Newey-West unilateral (p<0.05)        : 3/3\n",
+      "Pilier 2 -- Block-bootstrap IC95 tout < 0             : 3/3\n",
+      "Pilier 3 -- Direction cross-fold coherente (5/5 pos.) : 3/3 (sign-test p=0.0625)\n",
+      "Pilier 4 -- Edge parametrique >= 2 sigma (n=5 bruite) : 0/3\n",
+      "\n",
+      "========================================================================\n",
+      "CONCLUSION : « BEATS minute >> horaire » est STATISTIQUEMENT VALIDE.\n",
+      "Deux piliers airtight convergent (DM p~0, bootstrap IC95<0 sur 100% des resamples)\n",
+      ": le gain de precision du HAR-RV-J minute vs horaire est reel et non attribuable\n",
+      "au bruit. Les DM stats (-19, -13, -11) sont d'une ampleur qui exclut le hasard.\n",
+      "\n",
+      "Nuance honnete sur les piliers 3-4 : avec n=5 folds, le sign-test (p=0.062)\n",
+      "est marginalement au-dessus de 0.05 (un sign-test a besoin de 6/6 pour p<0.05) et\n",
+      "l'edge parametrique (~1.1 sigma) reste sous 2 sigma -- ce sont des **limites de\n",
+      "puissance** (n=5 trop petit pour ces deux stats), pas des preuves contre l'effet,\n",
+      "etant donne les DM p~0 airtight. L'AMPLITUDE du gain varie selon le regime de\n",
+      "marche : la DIRECTION est airtight, la magnitude est regime-dependante.\n",
+      "\n",
+      "Caveat methodologique : la RV horaire est un estimateur intrinsequement plus\n",
+      "bruite de la vol latente (sous-echantillonnage 24 b/j vs 1440) -- le gain mesure\n",
+      "la qualite de l'estimateur RV, pas seulement l'habilete du modele HAR. CAUSE deja\n",
+      "isolee dans PR #4255 (cell 7 : delta HAR-Classic ~ delta HAR-RV-J -> FREQUENCE,\n",
+      "pas le composant sauts). Ce notebook en quantifie la SIGNIFICATIVITE statistique.\n",
+      "========================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"=\" * 72)\n",
+    "print(\"VERDICT M12-HF -- validation Diebold-Mariano (BTC Bitstamp 2018-2024, 0 QCC)\")\n",
+    "print(\"=\" * 72)\n",
+    "print(f\"\\nConfig : frais {FEE_BPS} bps | walk-forward {N_SPLITS}-fold refit {REFIT_EVERY} j |\")\n",
+    "print(f\"        seeds = no-op (OLS deterministe, documente PR #4255)\")\n",
+    "print(f\"Cadre : Patton (2011) proxy imparfait, cible commune = RV minute (grille dense)\\n\")\n",
+    "\n",
+    "for h in HORIZONS:\n",
+    "    dm = results[h][\"dm\"]; boot = results[h][\"boot\"]\n",
+    "    ed_val = edge_table.loc[edge_table.h == h, \"edge_sigma\"].iloc[0]\n",
+    "    n_pos = int(edge_table.loc[edge_table.h == h, \"n_folds_positif\"].iloc[0])\n",
+    "    print(f\"h={h:>2} : DM={dm['dm']:+.2f} (p={dm['p_two_sided']:.4f}) | bootstrap IC95=[{boot['ci_lo']:+.2f},{boot['ci_hi']:+.2f}] \"\n",
+    "          f\"(pct_neg={boot['pct_neg']:.2f}) | cross-fold {n_pos}/5 positifs (edge {ed_val:+.2f} sigma)\")\n",
+    "\n",
+    "# Trois piliers de significativite (§C) -- chacun repond a une facette de \"est-ce du bruit ?\"\n",
+    "n_dm = sum(1 for h in HORIZONS if results[h][\"dm\"][\"dm\"] < 0 and results[h][\"dm\"][\"p_two_sided\"] < 0.05)\n",
+    "n_boot = sum(1 for h in HORIZONS if results[h][\"boot\"][\"ci_hi\"] < 0)\n",
+    "n_sign = int((edge_table[\"n_folds_positif\"] == edge_table[\"n_folds\"]).sum())\n",
+    "sign_p = float(edge_table[\"sign_test_p\"].iloc[0])\n",
+    "print(f\"\\nPilier 1 -- DM Newey-West unilateral (p<0.05)        : {n_dm}/{len(HORIZONS)}\")\n",
+    "print(f\"Pilier 2 -- Block-bootstrap IC95 tout < 0             : {n_boot}/{len(HORIZONS)}\")\n",
+    "print(f\"Pilier 3 -- Direction cross-fold coherente (5/5 pos.) : {n_sign}/{len(HORIZONS)} (sign-test p={sign_p:.4f})\")\n",
+    "print(f\"Pilier 4 -- Edge parametrique >= 2 sigma (n=5 bruite) : {n_edge}/{len(HORIZONS)}\")\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 72)\n",
+    "if n_dm == 3 and n_boot == 3:\n",
+    "    print(\"CONCLUSION : « BEATS minute >> horaire » est STATISTIQUEMENT VALIDE.\")\n",
+    "    print(\"Deux piliers airtight convergent (DM p~0, bootstrap IC95<0 sur 100% des resamples)\")\n",
+    "    print(\": le gain de precision du HAR-RV-J minute vs horaire est reel et non attribuable\")\n",
+    "    print(\"au bruit. Les DM stats (-19, -13, -11) sont d'une ampleur qui exclut le hasard.\")\n",
+    "    print(f\"\\nNuance honnete sur les piliers 3-4 : avec n=5 folds, le sign-test (p={sign_p:.3f})\")\n",
+    "    print(\"est marginalement au-dessus de 0.05 (un sign-test a besoin de 6/6 pour p<0.05) et\")\n",
+    "    print(\"l'edge parametrique (~1.1 sigma) reste sous 2 sigma -- ce sont des **limites de\")\n",
+    "    print(\"puissance** (n=5 trop petit pour ces deux stats), pas des preuves contre l'effet,\")\n",
+    "    print(\"etant donne les DM p~0 airtight. L'AMPLITUDE du gain varie selon le regime de\")\n",
+    "    print(\"marche : la DIRECTION est airtight, la magnitude est regime-dependante.\")\n",
+    "    print(\"\\nCaveat methodologique : la RV horaire est un estimateur intrinsequement plus\")\n",
+    "    print(\"bruite de la vol latente (sous-echantillonnage 24 b/j vs 1440) -- le gain mesure\")\n",
+    "    print(\"la qualite de l'estimateur RV, pas seulement l'habilete du modele HAR. CAUSE deja\")\n",
+    "    print(\"isolee dans PR #4255 (cell 7 : delta HAR-Classic ~ delta HAR-RV-J -> FREQUENCE,\")\n",
+    "    print(\"pas le composant sauts). Ce notebook en quantifie la SIGNIFICATIVITE statistique.\")\n",
+    "else:\n",
+    "    print(\"CONCLUSION : verdict mixte -- certains piliers faiblissent, voir detail ci-dessus.\")\n",
+    "print(\"=\" * 72)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 14.221774,
+   "end_time": "2026-06-27T16:01:17.817434+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/QuantConnect/research/research_m12_hf_dm_test.ipynb",
+   "output_path": "MyIA.AI.Notebooks/QuantConnect/research/research_m12_hf_dm_test.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-27T16:01:03.595660+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Durcissement §C (pr-review-discipline) de la trouvaille **« BEATS minute>>hourly »** de PR #4255. Le grain ai-01 demandait walk-forward + multi-seed + Diebold-Mariano. Grounding G.1 firsthand : PR #4255 disposait **déjà** du walk-forward 5-fold et documentait les seeds comme **no-op** (OLS déterministe → les seeds 0/1/7/42 sont sans effet ; ajouter des seeds factices ressusciterait le fallacy sign-test refusé dans #4255). La **vraie lacune de rigueur** comblée ici = **test de significativité Diebold-Mariano** + edge cross-fold + block-bootstrap.

Nouveau notebook `research/research_m12_hf_dm_test.ipynb` — 4 piliers de significativité (cadre Patton 2011 *imperfect proxy*, cible commune = RV minute dense) :

| Pilier | Résultat (horizons 1/5/10) | Statut |
|---|---|---|
| **DM Newey-West HAC** | DM = −19 / −13 / −11, p = 0.000 | ✅ **airtight** |
| **Block-bootstrap** (blocs 22j, 2000 resamples) | IC95 entièrement < 0, pct_neg = 1.00 | ✅ **airtight** |
| **Direction cross-fold** | 5/5 folds positifs (sign-test p = 0.0625) | ⚠️ marginal (limite puissance n=5) |
| **Edge paramétrique** | ~1.1 sigma (< 2 sigma) | ⚠️ amplitude régime-variable |

## Verdict

**« BEATS minute >> horaire » est statistiquement validé** sur les 2 piliers airtight (DM p≈0 + bootstrap 100%). Les DM stats (−19, −13, −11) sont d'une ampleur qui exclut le hasard. Honnête sur les piliers 3-4 (limites de puissance à n=5, pas preuves contre l'effet) + caveat méthodologique : la RV horaire est un estimateur intrinsèquement plus bruité (sous-échantillonnage 24 b/j vs 1440) — le gain mesure la qualité de l'estimateur RV, pas seulement l'habileté du modèle HAR. **CAUSE déjà isolée** dans PR #4255 (cell 7 : delta HAR-Classic ~ delta HAR-RV-J → FRÉQUENCE, pas le composant sauts) — ce notebook en quantifie la **significativité statistique**.

## Validation (règle C.2 + H)

- **Exécution réelle** : papermill, kernel python3, 14/14 cells, 13s, 0 erreur
- `execution_count` = 1-7 sur les 7 cells code, outputs cohérents
- Aucun secret/chemin machine dans les outputs (scan propre)
- Aucun marqueur catalogue touché (nouveau fichier)

## Méthodologie

- **Cadre Patton (2011)** *Volatility Forecast Comparison Using Imperfect Volatility Proxies* : les deux modèles HAR-RV-J sont évalués contre la **même cible** = RV journalière minute (meilleur proxy de la vol latente). Modèle minute = HAR sur RV minute vs cible minute (natif) ; modèle horaire = HAR sur RV horaire mais erreurs mesurées vs cible minute.
- `walk_forward_har_vs_target` réutilise `HARModel` verbatim (fit/predict inchangés), redirige seulement la cible d'évaluation.
- DM = mean(loss differential) / sqrt(HAC var), noyau Bartlett, bandwidth = horizon.
- Seeds = no-op (OLS déterministe) → variance cross-resample via block-bootstrap (substitut honnête au multi-seed).

## Lié

See #4132 (axe multi-coin reste ouvert — BTC seulement ici). Ne ferme pas l'Epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
