### PR TITLE
docs(z3): NB-01 Mermaid pipeline diagram Z3.Linq (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/01_Linq2Z3_Intro.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/01_Linq2Z3_Intro.ipynb
@@ -235,6 +235,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "### Architecture de la pipeline Z3.Linq\n",
+    "\n",
+    "Le diagramme ci-dessous illustre le chemin complet d'une contrainte LINQ jusqu'à l'objet C# résultat :\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    L[\"Lambda .Where(x => ...)\"] --> V[\"ExpressionVisitor\"]\n",
+    "    V --> E[\"BoolExpr Z3\"]\n",
+    "    E --> S[\"Solveur SMT\"]\n",
+    "    S -- SAT --> M[\"Modèle Z3\"]\n",
+    "    S -- UNSAT --> N[\"null\"]\n",
+    "    M --> T[\"Objet .NET T\"]\n",
+    "```\n",
+    "\n",
+    "**Point clé** : l'`ExpressionVisitor` traduit chaque nœud de l'arbre AST C# (`BinaryExpression`, `MemberAccess`, opérateurs arithmétiques) en son équivalent Z3. C'est cette couche qui rend la déclaration de contraintes **déclarative** plutôt qu'impérative — on exprime *quoi*, pas *comment*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d7e56662",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

- Ajoute un diagramme Mermaid `flowchart LR` dans le notebook `01_Linq2Z3_Intro.ipynb` illustrant la **pipeline Z3.Linq** : Lambda `.Where(...)` → `ExpressionVisitor` → `BoolExpr Z3` → Solveur SMT → Modèle/null → Objet `.NET T`
- Insertion en cellule markdown (position 3), après la section « Qu'est-ce que Z3.Linq ? », avant « Exemple court »
- Aucun notebook existant dans la série Z3 n'avait de diagramme Mermaid (#4212 finition)

## Conformité

- **Markdown-only** → C.2 exempt (outputs des cellules code préservés, aucune re-exec)
- `scan_md_hierarchy` : **0/1 flaggé** (H3 cohérent avec cellules adjacentes, aucun HINT-AS-HEADING)
- **CATALOG byte-identical** (pas de régénération catalogue)
- +22 insertions / 0 suppression, 1 fichier

## Test plan

- [ ] Vérifier rendu Mermaid dans GitHub preview du notebook
- [ ] scan_md_hierarchy 0/1 confirmé
- [ ] C.1 clean (pas de raise/assert/1/0)

See #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)