### PR TITLE
docs(z3): NB-06 Mermaid pipeline diagram A & ~B automata (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb
@@ -313,6 +313,35 @@
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "### Pipeline du motif `A & ~B` — vue d'ensemble\n",
+    "\n",
+    "Le diagramme ci-dessous illustre comment deux expressions régulières se combinent pour produire un témoin via l'intersection et le complément :\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    subgraph G1 [\"Construction des automates\"]\n",
+    "        A[\"Regex A\"] --> DFA_A[\"DFA(A)\"]\n",
+    "        B[\"Regex B\"] --> DFA_B[\"DFA(B)\"]\n",
+    "        DFA_B --> COMP[\"~DFA(B) — Complément\"]\n",
+    "    end\n",
+    "    subgraph G2 [\"Opération A & ~B\"]\n",
+    "        DFA_A --> INT[\"DFA(A) ∩ ~DFA(B)\"]\n",
+    "        COMP --> INT\n",
+    "    end\n",
+    "    INT --> W[\"Témoin w ← GenerateMember\"]\n",
+    "    W --> V[\"Vérifié par RE#\"]  \n",
+    "    style W fill:#c8f7c5\n",
+    "    style V fill:#c8f7c5\n",
+    "```\n",
+    "\n",
+    "**Pourquoi ça fonctionne** : les langages réguliers sont fermés sous l'intersection (`&`) et le complément (`~`). Le résultat `A & ~B` est donc **lui-même régulier** — un automate fini existe pour le représenter, et `GenerateMember` peut en extraire un mot accepté (le témoin)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "82374f96",


### PR DESCRIPTION
## Summary

- Ajoute un diagramme Mermaid `flowchart TB` dans `06_Witness_Generation_Automata.ipynb` illustrant le **pipeline du motif `A & ~B`** :
  - Regex A → DFA(A) et Regex B → DFA(B) → ~DFA(B) (Complément)
  - DFA(A) ∩ ~DFA(B) → Témoin via `GenerateMember` → Vérifié par RE#
- Insertion en cellule markdown (position 7), après la section « Pourquoi `&` et `~` marchent » (fermeture des langages réguliers), avant le premier exemple de code
- NB-06 était le seul notebook Z3 à couvrir les automates — un diagramme de pipeline manquait clairement (#4212 finition)

## Conformité

- **Markdown-only** → C.2 exempt (outputs des cellules code préservés, aucune re-exec)
- `scan_md_hierarchy` : **0/1 flaggé** (H3 cohérent avec cellules adjacentes, aucun HINT-AS-HEADING)
- **CATALOG byte-identical**
- +29 insertions / 0 suppression, 1 fichier

## Test plan

- [ ] Vérifier rendu Mermaid dans GitHub preview
- [ ] scan_md_hierarchy 0/1 confirmé
- [ ] C.1 clean (pas de raise/assert/1/0)

See #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)