### PR TITLE
docs(smartcontracts): SC-26 rendered Mermaid state machine (VotingSystem lifecycle) See #4212

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
@@ -276,6 +276,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5c26a17e",
+   "metadata": {},
+   "source": [
+    "### Schema : la machine a etats du contrat `VotingSystem`\n",
+    "\n",
+    "Le contrat de vote est une **machine a etats** (`enum Phase`) : chaque fonction\n",
+    "n'est appelable que dans la phase courante (modifier `onlyPhase`), et l'admin fait\n",
+    "progresser le cycle de vie en emettant l'event `PhaseChanged`. Le diagramme rend\n",
+    "explicite ce cycle decrit ci-dessus :\n",
+    "\n",
+    "```mermaid\n",
+    "stateDiagram-v2\n",
+    "    direction LR\n",
+    "    [*] --> Registration\n",
+    "    Registration --> Voting : PhaseChanged (admin)\n",
+    "    Voting --> Tallying : PhaseChanged (admin)\n",
+    "    Tallying --> Ended : PhaseChanged (admin)\n",
+    "    Ended --> [*]\n",
+    "    Registration : Registration -- registerVoter(address) [admin]\n",
+    "    Voting : Voting -- submitBallot(ballot, proof) + verifyProof\n",
+    "    Tallying : Tallying -- tally() decompte homomorphique Paillier\n",
+    "    Ended : Ended -- resultats verifiables on-chain\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Le contrat avance **strictement** de gauche a droite : on ne peut\n",
+    "> voter (`submitBallot`) qu'en phase `Voting`, ni decompter (`tally`) avant `Tallying`.\n",
+    "> Cette discipline d'etats est ce qui garantit, au niveau du protocole, qu'aucun\n",
+    "> bulletin ne peut etre soumis apres la cloture ni decompte avant la fin du vote --\n",
+    "> une propriete de securite **structurelle**, imposee par le code et non par la\n",
+    "> confiance dans l'administrateur.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9d0385ef",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute **un diagramme Mermaid rendu** (`stateDiagram-v2`) de la machine a etats du contrat `VotingSystem` dans **SC-26-Final-Project** (capstone Smart Contracts). Cellule **markdown uniquement** -> C.2-exempt (aucune cellule code touchee, pas de re-execution).

## Gap #4212 (verifie firsthand)

Le notebook decrit la machine a etats (`enum Phase` : Registration -> Voting -> Tallying -> Ended) **en texte uniquement** (cellules 5-6 : tableau d'elements + "pattern de state machine, 4 phases distinctes"), **sans jamais la dessiner**. Aucune cellule code ne rend la structure (verifie : 0 networkx/graphviz/mermaid sur origin/main). Le diagramme rend explicite ce cycle de vie central.

- **Verdict SOTA** : SOTA-OK (diagramme markdown rendu, contenu fidele a l'enum Phase + fonctions `registerVoter`/`submitBallot`/`tally` decrites dans le notebook).
- **Anti-hallucination** : transitions et fonctions tirees **verbatim** des cellules 5-6 (registerVoter@Registration, submitBallot+verifyProof@Voting, tally@Tallying ; transitions = event `PhaseChanged` admin via modifier `onlyPhase`).

## Validation

- nbformat 4, 28 -> 29 cellules, **1 bloc mermaid**, **0 fuite de chemin**.
- Diff surgical : 1 fichier, +35/-1 (insertion markdown indent=1 no-BOM).
- 0 cellule code modifiee -> outputs/exec_count inchanges (C.2 respectee).

See #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)