### PR TITLE
Add: Mermaid diagram (McCarthy axioms) to Z3 notebook 03 - Array Theory

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/03_Array_Theory.ipynb
@@ -260,6 +260,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4d2d05a2",
+   "metadata": {},
+   "source": [
+    "### Vue d'ensemble : les axiomes de McCarthy\n",
+    "\n",
+    "Le diagramme ci-dessous illustre les deux axiomes fondamentaux avant de les voir en code :\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    subgraph G [\"Axiomes de McCarthy\"]\n",
+    "        A[\"Array a\"] -->|\"Store(a, i, v)\"| B[\"Array a'\"]\n",
+    "        B -->|\"Select(a', i)\"| R1[\"= v — axiome 1\\nRead-after-Write\"]\n",
+    "        B -->|\"Select(a', j≠i)\"| R2[\"= Select(a, j) — axiome 2\\npositions non modifiées\"]\n",
+    "    end\n",
+    "    style R1 fill:#c8f7c5\n",
+    "    style R2 fill:#c8f7c5\n",
+    "```\n",
+    "\n",
+    "**Lecture** : `Store(a, i, v)` produit un nouveau tableau `a'` identique à `a` sauf en position `i`.\n",
+    "`Select(a', i)` retourne `v` (axiome 1) ; en toute autre position `j`, il retourne `Select(a, j)` (axiome 2)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e5f6a7b4",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

- Adds a Mermaid `flowchart LR` diagram to **NB-03 Array Theory** illustrating the two McCarthy axioms
- Diagram placed after the section 1 intro, before the first code example — provides visual grounding before the API walk-through
- Color-coded result nodes: green for both axiom outcomes
- Markdown-only change: no code cell modified, existing execution outputs preserved (rule C.2 exception applies)

## Validation

- +24 lines markdown cell insertion, 0 deletions
- `notebook_tools.py validate`: OK
- Automata submodule NOT staged

Part of #4212 (finition editoriale Mermaid, Z3 series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)