### PR TITLE
Add: Mermaid diagram (flat vs nested 2D encoding) to Z3 notebook 04 - Nested Arrays 2D

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/04_Nested_Arrays_2D.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/04_Nested_Arrays_2D.ipynb
@@ -42,6 +42,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6c6341fa",
+   "metadata": {},
+   "source": [
+    "### Vue d'ensemble : deux stratégies d'encodage d'une grille 2D\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    subgraph S1 [\"Stratégie 1 — Flat (indice linéarisé)\"]\n",
+    "        G1[\"Cellule (i, j)\"] -->|\"index = i × W + j\"| A1[\"Array Int-Int\\n1 tableau plat\"]\n",
+    "    end\n",
+    "    subgraph S2 [\"Stratégie 2 — Nested int-int (ce notebook)\"]\n",
+    "        G2[\"Cellule (i, j)\"] -->|\"ligne = tableau de W entiers\"| Rows[\"Array Int-Array-Int-Int\\nArray de lignes\"]\n",
+    "        Rows -->|\"Select(row_i, j)\"| Elem[\"Élément Grid-i-j\"]\n",
+    "    end\n",
+    "    style A1 fill:#f0e6ff\n",
+    "    style Rows fill:#c8f7c5\n",
+    "    style Elem fill:#c8f7c5\n",
+    "```\n",
+    "\n",
+    "Ce notebook utilise la **Stratégie 2** (`int[][]`) via `Theorem<Grid>` —\n",
+    "plus lisible pour les contraintes ligne/colonne/bloc que l'encodage plat."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2bc581d3",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary

- Adds a Mermaid `flowchart TB` diagram to **NB-04 Nested Arrays 2D** showing the two canonical strategies for encoding a 2D grid in SMT
- Diagram placed after the intro section 'Deux encodages canoniques d'une grille 2D', providing visual contrast before the code walk-through
- Strategy 1 (flat, linearized index) vs Strategy 2 (int[][], this notebook) — color-coded
- Markdown-only change: no code cell modified, existing execution outputs preserved (rule C.2 exception)

## Validation

- +25 lines markdown cell insertion, 0 deletions
- Automata submodule NOT staged

Part of #4212 (finition editoriale Mermaid, Z3 series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)