### PR TITLE
docs(z3): NB-02 Mermaid overview explicit vs implicit Sudoku encoding (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02_Sudoku_Theorem_vs_Array.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02_Sudoku_Theorem_vs_Array.ipynb
@@ -48,6 +48,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "360fa043",
+   "metadata": {},
+   "source": [
+    "### Vue d'ensemble : deux strategies de modelisation du meme Sudoku\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    P[\"Grille Sudoku 9x9\\n(81 cellules)\"]\n",
+    "    P --> E[\"Approche 1 — Theoreme explicite\"]\n",
+    "    P --> I[\"Approche 2 — Modele implicite par arrays\"]\n",
+    "    E --> E1[\"81 proprietes nommees\\nCell11, Cell12, ..., Cell99\"]\n",
+    "    E1 --> E2[\"Contraintes ecrites une par une\\nverbeux, non generalisable\"]\n",
+    "    I --> I1[\"1 propriete List-Int Cells\\nindexee par lambdas + closures\"]\n",
+    "    I1 --> I2[\"Boucles generent les contraintes\\ncompact, extensible 16x16\"]\n",
+    "    E2 --> Z[\"Z3.Linq -> formules SMT\\nsolveur Z3\"]\n",
+    "    I2 --> Z\n",
+    "    Z --> S[\"Solution (assignation valide)\"]\n",
+    "    style I fill:#c8f7c5\n",
+    "    style I1 fill:#c8f7c5\n",
+    "    style I2 fill:#c8f7c5\n",
+    "    style E fill:#f7e3c5\n",
+    "```\n",
+    "\n",
+    "Les deux approches produisent **le meme resultat**, mais le **modele implicite** (en vert)\n",
+    "est celui qui se generalise — il fonde tous les notebooks Sudoku avances de la serie.\n",
+    "L'enjeu pedagogique de ce notebook est la **transition** de l'une vers l'autre."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "setup-markdown-intro",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Résumé

Ajoute un diagramme Mermaid rendu en tête du notebook `02_Sudoku_Theorem_vs_Array.ipynb`, qui contraste les **deux stratégies de modélisation** que le notebook enseigne :

- **Approche 1 — théorème explicite** : 81 propriétés nommées (`Cell11`..`Cell99`), verbeux, non généralisable.
- **Approche 2 — modèle implicite par arrays** : une seule `List<int> Cells` indexée par lambdas + closures, compact et extensible (16x16).

Le modèle implicite (mis en vert) est celui qui se généralise et fonde tous les notebooks Sudoku avancés de la série. Le diagramme rend visible la **transition pédagogique clé** que ce notebook met en scène.

## Validation

- Modification **markdown-only** : insertion d'une cellule à la position 1 (après objectifs, avant configuration).
- Outputs d'exécution **préservés** (exception règle C.2 — pas de re-exécution nécessaire).
- Diff `+30 / -0` (aucune suppression, aucun churn d'output).
- Submodule `Automata` non stagé (USER-PARKÉ #2979).
- Diagramme Mermaid se rend nativement sur GitHub.

Part of #4212 (finition éditoriale — diagrammes Mermaid série Z3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)