### PR TITLE
docs(z3): NB-05 Mermaid overview data fusion -> hierarchical theorem (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05_Meal_Planner_Hierarchical.ipynb
@@ -34,6 +34,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "54012956",
+   "metadata": {},
+   "source": [
+    "### Vue d'ensemble : de la fusion de donnees au theoreme hierarchique\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    DB[\"Base nutritionnelle\\n(donnees externes : calories, prix, ...)\"]\n",
+    "    DB -->|\"data fusion LINQ\"| V[\"Variables Z3\\n(selection de plats)\"]\n",
+    "    V --> A1[\"Approche 1\\nSelection par index\\n+ contraintes lineaires\"]\n",
+    "    V --> A2[\"Approche 2\\nContraintes nutritionnelles\\npar enumeration\"]\n",
+    "    V --> A3[\"Approche 3\\nVariables booleennes\\n(modele de selection)\"]\n",
+    "    A1 --> O[\"Optimisation\\nmenu le moins cher (dichotomie)\"]\n",
+    "    A2 --> O\n",
+    "    A3 --> O\n",
+    "    O --> H[\"Theoreme hierarchique\\nobjets Z3 imbriques\"]\n",
+    "    style H fill:#c8f7c5\n",
+    "    style O fill:#cfe3ff\n",
+    "    style DB fill:#f7e3c5\n",
+    "```\n",
+    "\n",
+    "Le notebook progresse de la **fusion de donnees** (nutrition externe vers variables Z3)\n",
+    "a travers trois approches de modelisation, puis l'**optimisation** dichotomique,\n",
+    "pour culminer sur le **theoreme hierarchique** (en vert) — des modeles Z3 a objets imbriques."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "03094998",


### PR DESCRIPTION
## Résumé

Ajoute un diagramme Mermaid rendu en tête du notebook `05_Meal_Planner_Hierarchical.ipynb`, qui visualise l'**arc pédagogique** du notebook :

- **Fusion de données** : base nutritionnelle externe → variables Z3 (via LINQ)
- **Trois approches** de modélisation : sélection par index + contraintes linéaires ; contraintes nutritionnelles par énumération ; variables booléennes
- **Optimisation** : menu le moins cher par dichotomie
- **Théorème hiérarchique** (mis en vert) : modèles Z3 à objets imbriqués — le point de convergence du notebook

## Validation

- Modification **markdown-only** : insertion d'une cellule à la position 1 (après objectifs, avant configuration).
- Outputs d'exécution **préservés** (exception règle C.2 — pas de re-exécution).
- Diff `+28 / -0` (aucune suppression, aucun churn d'output).
- Submodule `Automata` non stagé (USER-PARKÉ #2979).

Part of #4212 (finition éditoriale — diagrammes Mermaid série Z3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)