### PR TITLE
docs(z3): NB-02b Mermaid overview Array vs Constants encoding modes (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02b_Sudoku_Modes_Comparison.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/02b_Sudoku_Modes_Comparison.ipynb
@@ -23,6 +23,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bd398b0e",
+   "metadata": {},
+   "source": [
+    "### Vue d'ensemble : un meme Sudoku, deux modes d'encodage des collections\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    G[\"Meme grille Sudoku 4x4\\n(int de int)\"]\n",
+    "    G --> M1[\"Mode Array (defaut)\"]\n",
+    "    G --> M2[\"Mode Constants\"]\n",
+    "    M1 --> A1[\"1 seule ArrayExpr Z3\\n+ Select / Store\\n(theorie des tableaux)\"]\n",
+    "    M2 --> C1[\"1 constant Z3 par cellule\\nCells_0_0, Cells_0_1, ...\"]\n",
+    "    A1 --> S[\"Solution valide\\n(carre latin)\"]\n",
+    "    C1 --> S\n",
+    "    S --> CH[\"CollectionHandling\\ndesormais cable bout-en-bout\\n(dead code ressuscite)\"]\n",
+    "    style M1 fill:#c8f7c5\n",
+    "    style A1 fill:#c8f7c5\n",
+    "    style M2 fill:#cfe3ff\n",
+    "    style C1 fill:#cfe3ff\n",
+    "```\n",
+    "\n",
+    "Les **deux modes** resolvent le **meme** `int[][]` et convergent vers une solution valide.\n",
+    "Le mode `Array` (vert) encode la grille avec une seule `ArrayExpr` ; le mode `Constants` (bleu)\n",
+    "cree un symbole Z3 par cellule. C'est la demonstration directe que l'enum `CollectionHandling`\n",
+    "est desormais **vivante** et fonctionnelle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "62647528",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Résumé

Ajoute un diagramme Mermaid rendu en tête du notebook `02b_Sudoku_Modes_Comparison.ipynb`, qui visualise la **même grille Sudoku 4x4** résolue par les deux modes d'encodage des collections du fork `Z3.Linq` :

- **Mode `Array`** (défaut, en vert) : une seule `ArrayExpr` Z3 + `Select`/`Store` (théorie des tableaux)
- **Mode `Constants`** (en bleu) : un constant Z3 par cellule (`Cells_0_0`, …)

Les deux convergent vers une solution valide (carré latin), démonstration directe que l'enum `CollectionHandling` — historiquement du *dead code* — est désormais câblée bout-en-bout. Le diagramme complète le tableau comparatif déjà présent dans la cellule d'introduction.

## Validation

- Modification **markdown-only** : insertion d'une cellule à la position 1.
- Outputs d'exécution **préservés** (exception règle C.2).
- Diff `+29 / -0` (aucune suppression, aucun churn d'output).
- Submodule `Automata` non stagé (USER-PARKÉ #2979).

Part of #4212 (finition éditoriale — diagrammes Mermaid série Z3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)