### PR TITLE
docs(z3): NB-06c Mermaid overview Z3 model -> HTML render pipeline (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06c_Meal_Planner_Visualization.ipynb
@@ -36,6 +36,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4feb813b",
+   "metadata": {},
+   "source": [
+    "### Vue d'ensemble : du modele Z3 a la carte lisible par un humain\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    Z[\"Solveur Z3\\n(modele 06b inchange)\"]\n",
+    "    Z --> M[\"Solution brute\\nbool de selection, plan int de int\"]\n",
+    "    M --> P[\"Couche de presentation C#\\n(seule partie qui change)\"]\n",
+    "    P --> H[\"display(HTML(...))\\nMicrosoft.DotNet.Interactive\"]\n",
+    "    H --> R[\"Cartes HTML\\ntableaux colores, badges,\\nbarres de progression\"]\n",
+    "    style P fill:#c8f7c5\n",
+    "    style R fill:#c8f7c5\n",
+    "    style Z fill:#cfe3ff\n",
+    "```\n",
+    "\n",
+    "Le **solveur reste identique** a celui du notebook 06b ; seule la **couche de presentation** (en vert)\n",
+    "change. L'idee cle : une solution Z3 n'a de valeur operationnelle que si elle est **lisible par un humain** —\n",
+    "le rendu HTML transforme une assignation brute en carte de menu interpretable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "intro-gap",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Résumé

Ajoute un diagramme Mermaid (pipeline LR) rendu en tête du notebook `06c_Meal_Planner_Visualization.ipynb` :

`Solveur Z3` (modèle 06b inchangé) → `solution brute` → `couche de présentation C#` (seule partie qui change) → `display(HTML(...))` → `cartes HTML lisibles` (tableaux colorés, badges, barres).

Le diagramme rend visible l'idée pédagogique centrale du notebook : **le solveur reste identique**, seule la couche de présentation change ; une solution Z3 n'a de valeur opérationnelle que si elle est **lisible par un humain**.

## Validation

- Modification **markdown-only** : insertion d'une cellule à la position 1.
- Outputs d'exécution **préservés** (exception règle C.2).
- Diff `+24 / -0` (aucune suppression, aucun churn d'output).
- Submodule `Automata` non stagé (USER-PARKÉ #2979).

Part of #4212 (finition éditoriale — diagrammes Mermaid série Z3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)