### PR TITLE
docs(z3): NB-06b Mermaid overview RecipeML corpus -> Z3-solved menu (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06b_RecipeML_Corpus.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06b_RecipeML_Corpus.ipynb
@@ -34,6 +34,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d3d0c260",
+   "metadata": {},
+   "source": [
+    "### Vue d'ensemble : d'un corpus XML externe a un menu resolu par Z3\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    X[\"Corpus RecipeML\\n(XML culinaire externe)\"]\n",
+    "    X -->|\"parsing\"| D[\"Classes de domaine C#\\n(7 recettes : entrees/plats/desserts)\"]\n",
+    "    D -->|\"data fusion\"| B[\"Selection booleenne Z3\\n1 variable par recette\"]\n",
+    "    B -->|\"MkITE\"| N[\"Agregation nutritionnelle\\nconditionnelle (sans allergene)\"]\n",
+    "    N --> P[\"Plan multi-jours int de int\\nDistinct sur indices du corpus\"]\n",
+    "    P --> S[\"Menu equilibre resolu\"]\n",
+    "    style B fill:#c8f7c5\n",
+    "    style N fill:#c8f7c5\n",
+    "    style P fill:#c8f7c5\n",
+    "    style X fill:#f7e3c5\n",
+    "```\n",
+    "\n",
+    "Le notebook part d'une **source externe structuree** (RecipeML) et la fait remonter\n",
+    "jusqu'au solveur : parsing en classes C#, **fusion** vers des variables Z3 booleennes,\n",
+    "agregation nutritionnelle conditionnelle (`MkITE`), puis extension a un **plan multi-jours**\n",
+    "avec non-repetition (`Distinct`). L'enjeu : l'elegance declarative du DSL Z3.Linq face a des donnees reelles."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "095cf0db",


### PR DESCRIPTION
## Résumé

Ajoute un diagramme Mermaid (pipeline LR) rendu en tête du notebook `06b_RecipeML_Corpus.ipynb`, qui visualise le flux de données depuis une **source externe structurée** jusqu'au solveur :

`Corpus RecipeML (XML)` → `parsing` → `classes de domaine C#` → `fusion` → `sélection booléenne Z3 (1 var/recette)` → `agrégation nutritionnelle conditionnelle (MkITE)` → `plan multi-jours int[][] (Distinct)` → `menu équilibré résolu`.

Le diagramme rend visible l'enjeu du notebook : l'élégance déclarative du DSL Z3.Linq appliquée à des **données réelles externes**.

## Validation

- Modification **markdown-only** : insertion d'une cellule à la position 1.
- Outputs d'exécution **préservés** (exception règle C.2).
- Diff `+27 / -0` (aucune suppression, aucun churn d'output).
- Submodule `Automata` non stagé (USER-PARKÉ #2979).

Part of #4212 (finition éditoriale — diagrammes Mermaid série Z3). Avec cette PR, **tous les notebooks de la série Z3 disposent d'un diagramme d'aperçu Mermaid**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)