### PR TITLE
docs(genai): FT-05 — rendered Mermaid du routing Mixture-of-Experts (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb
@@ -1251,6 +1251,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "m0eft05r",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend cette architecture **Mixture of Experts** sous forme de\n",
+    "graphe : un routeur dirige chaque requete vers l'expert specialise du bon domaine.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    IN([\"Entree (prompt)\"]) --> R{\"Routeur / Classifieur\"}\n",
+    "    R -->|\"domaine = technique\"| EA[\"Expert A<br/>(Tech)\"]\n",
+    "    R -->|\"domaine = cuisine\"| EB[\"Expert B<br/>(Cuisine)\"]\n",
+    "    classDef route fill:#f8d7da,stroke:#842029,color:#58151c\n",
+    "    classDef exp fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef in fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    class R route\n",
+    "    class EA,EB exp\n",
+    "    class IN in\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Contrairement au *model merging* (qui fond les poids en un seul modele),\n",
+    "> le **routing** conserve tous les experts intacts et en **selectionne dynamiquement**\n",
+    "> un par requete. Le **routeur** est un petit classifieur qui detecte le domaine ; ici\n",
+    "> il opere sur les embeddings du modele de base, tandis que les MoE a grande echelle\n",
+    "> (Mixtral, Switch Transformer) apprennent leur routeur par retropropagation. L'interet :\n",
+    "> n'activer qu'une fraction des parametres a chaque appel (calcul *creux*).\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "e3f4a5bc",


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : l'architecture MoE (Entree -> Routeur/Classifieur -> Expert A Tech / Expert B Cuisine) etait en ASCII, jamais rendue comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+30/-1).
- nbformat 4, no-BOM, `json.dump(indent=1)`, 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).