### PR TITLE
docs(genai): RAG Modern — rendered Mermaid du pipeline RAG (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -509,6 +509,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ra6m0der",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend ce pipeline RAG sous forme de graphe : la phase\n",
+    "d'**indexation** (Documents -> Retrieval) et la phase de **requete/generation**\n",
+    "(Question + Retrieval -> LLM -> Reponse).\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    D[\"Documents\"] --> CH[\"Chunking\"] --> EMB[\"Embeddings\"] --> R[\"Retrieval\"]\n",
+    "    Q[\"Question\"] --> LLM[\"LLM\"]\n",
+    "    R --> LLM\n",
+    "    LLM --> REP([\"Reponse\"])\n",
+    "    classDef idx fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef gen fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef out fill:#d1e7dd,stroke:#0f5132,color:#0a3622\n",
+    "    class D,CH,EMB,R idx\n",
+    "    class Q,LLM gen\n",
+    "    class REP out\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** En amont (hors ligne), les **documents** sont decoupes en *chunks*,\n",
+    "> encodes en **embeddings** et indexes pour le **retrieval**. A la requete, la\n",
+    "> **question** declenche une recherche des passages pertinents, et le **LLM** synthetise\n",
+    "> la **reponse** en s'appuyant sur ces passages -- c'est l'apport du RAG : ancrer la\n",
+    "> generation dans des sources externes plutot que dans la seule memoire parametrique.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7328629c",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : le pipeline RAG (Documents -> Chunking -> Embeddings -> Retrieval ; Question + Retrieval -> LLM -> Reponse) etait en ASCII, jamais rendu comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+31/-1).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).