### PR TITLE
docs(genai): SK-Agents — rendered Mermaid du function-calling (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
@@ -1103,6 +1103,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5ka6ent3",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend cette sequence d'**appel de fonction** sous forme de\n",
+    "graphe : le LLM detecte qu'il faut un outil, l'invoque, puis synthetise la reponse\n",
+    "finale a partir du resultat.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    U([\"User : What is the special soup ?\"]) --> L1[\"LLM (gpt-4o)<br/>1. Analyse 2. Identifie get_specials() 3. Tool call\"]\n",
+    "    L1 --> P[\"MenuPlugin.get_specials()<br/>retourne : Special Soup: Clam Chowder...\"]\n",
+    "    P --> L2[\"LLM (gpt-4o)<br/>4. Synthetise la reponse\"]\n",
+    "    L2 --> A([\"The special soup is...\"])\n",
+    "    classDef llm fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef tool fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef io fill:#d1e7dd,stroke:#0f5132,color:#0a3622\n",
+    "    class L1,L2 llm\n",
+    "    class P tool\n",
+    "    class U,A io\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Le *function calling* se deroule en deux passes du LLM autour d'un\n",
+    "> appel d'outil : a la **premiere** passe, le modele analyse la question et decide\n",
+    "> d'appeler `get_specials()` (il ne repond pas directement) ; le **plugin** s'execute\n",
+    "> et renvoie une donnee factuelle ; a la **seconde** passe, le LLM integre ce resultat\n",
+    "> pour formuler une reponse en langage naturel. C'est ce cycle *raisonner -> agir ->\n",
+    "> observer -> repondre* qui distingue un **agent** d'un simple appel de completion.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2fe75ad9",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : la sequence d'appel de fonction (User -> LLM tool call -> MenuPlugin.get_specials() -> LLM synthese -> reponse) etait en ASCII, jamais rendue comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+31/-0).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).