### PR TITLE
docs(genai): Image-Orchestration — rendered Mermaid du workflow (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb
@@ -86,6 +86,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0rch032w",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend cette orchestration sous forme de graphe : une chaine\n",
+    "principale Model A -> Model B et une branche **parallele** Model C.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    P[\"Prompt\"] --> A[\"Model A\"] --> B[\"Model B\"] --> O([\"Output\"])\n",
+    "    A --> C[\"Model C<br/>(parallele)\"]\n",
+    "    classDef orch fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef io fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef out fill:#d1e7dd,stroke:#0f5132,color:#0a3622\n",
+    "    class A,B,C orch\n",
+    "    class P io\n",
+    "    class O out\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** L'**orchestrateur de workflow** enchaine plusieurs modeles : ici le\n",
+    "> **prompt** alimente `Model A`, dont la sortie part a la fois vers `Model B` (chaine\n",
+    "> sequentielle, jusqu'a l'`Output`) et vers `Model C` execute **en parallele**. Ce\n",
+    "> patron -- *fan-out* puis *fan-in* -- permet de combiner des modeles specialises\n",
+    "> (ex. generation + upscaling + variation) sans les faire dependre l'un de l'autre\n",
+    "> quand ce n'est pas necessaire.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "cell-1",


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : l'orchestration (Prompt -> Model A -> Model B -> Output ; Model A -> Model C parallele) etait en ASCII, jamais rendue comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+28/-0).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).