### PR TITLE
docs(genai): Expressive-TTS — rendered Mermaid du pipeline 2 etages (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb
@@ -481,6 +481,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "tt502ar8",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend ce pipeline TTS en deux etages autoregressifs suivis du\n",
+    "vocodeur, sous forme de graphe.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    T[\"Texte + [tags]\"] --> S[\"Slow AR (4B)\"] --> TS[\"tokens semantiques\"]\n",
+    "    TS --> F[\"Fast AR (400M)\"] --> TA[\"tokens acoustiques\"]\n",
+    "    TA --> V[\"Vocodeur\"] --> O([\"audio 44.1kHz\"])\n",
+    "    classDef core fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef io fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef out fill:#d1e7dd,stroke:#0f5132,color:#0a3622\n",
+    "    class S,F,V core\n",
+    "    class TS,TA io\n",
+    "    class T io\n",
+    "    class O out\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Le texte (enrichi de **tags** expressifs) passe par un **gros** modele\n",
+    "> autoregressif *lent* (4B) qui produit des **tokens semantiques** -- le *quoi* dire et\n",
+    "> *comment* l'intoner -- puis par un modele *rapide* et **leger** (400M) qui les raffine\n",
+    "> en **tokens acoustiques** -- le grain fin du signal. Le **vocodeur** reconstruit enfin\n",
+    "> la forme d'onde. Decoupler un gros modele semantique d'un petit modele acoustique est\n",
+    "> le compromis classique *qualite vs latence* du TTS expressif moderne.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "731d8f15",


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : le pipeline TTS (Texte+tags -> Slow AR 4B -> tokens semantiques -> Fast AR 400M -> tokens acoustiques -> Vocodeur -> audio) etait en ASCII, jamais rendu comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+30/-0).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).