### PR TITLE
docs(genai): Video-Orchestration — rendered Mermaid du pipeline texte->image->video (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb
@@ -423,6 +423,34 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "v1de032o",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend ce pipeline texte -> image -> video sous forme de graphe.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    T[\"Texte (prompt)\"] --> I[\"DALL-E 3 / SDXL\"] --> IMG[\"Image haute qualite\"]\n",
+    "    IMG --> V[\"SVD / LTX-Video\"] --> VID([\"Video animee\"])\n",
+    "    classDef core fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef io fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef out fill:#d1e7dd,stroke:#0f5132,color:#0a3622\n",
+    "    class I,V core\n",
+    "    class IMG io\n",
+    "    class T io\n",
+    "    class VID out\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** L'orchestration video classique est en **deux temps** : un modele\n",
+    "> texte-vers-image (DALL-E 3 ou SDXL) genere d'abord une **image fixe** de haute\n",
+    "> qualite, qui sert ensuite de point de depart a un modele image-vers-video (SVD ou\n",
+    "> LTX-Video) pour produire la **sequence animee**. Separer les deux etapes laisse\n",
+    "> controler precisement le contenu (via l'image) avant d'investir le cout de\n",
+    "> generation temporelle.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "cell-pipeline1",


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : le pipeline (Texte -> DALL-E3/SDXL -> Image -> SVD/LTX-Video -> Video) etait en ASCII, jamais rendu comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+28/-0).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).