### PR TITLE
docs(genai): SK-Filters — rendered Mermaid du pipeline de filtres (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb
@@ -55,6 +55,37 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f1lt3r04",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend ce pipeline de **filtres** sous forme de graphe : chaque\n",
+    "filtre s'intercale a un point precis du cycle requete -> reponse.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    U([\"User Request\"]) --> PF[\"Prompt Filter<br/>(modifie le prompt)\"]\n",
+    "    PF --> LLM[\"LLM Call\"]\n",
+    "    LLM --> AIF[\"Auto-Invoke Filter<br/>(controle les appels de fonction)\"]\n",
+    "    AIF --> FF[\"Function Filter<br/>(avant/apres chaque fonction)\"]\n",
+    "    FF --> R([\"Response\"])\n",
+    "    classDef filt fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef io fill:#d1e7dd,stroke:#0f5132,color:#0a3622\n",
+    "    classDef core fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    class PF,AIF,FF filt\n",
+    "    class LLM core\n",
+    "    class U,R io\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Les *filtres* de Semantic Kernel sont des intercepteurs qui s'executent\n",
+    "> a des points de jonction du pipeline : le **Prompt Filter** peut reecrire le prompt\n",
+    "> avant l'appel au LLM ; l'**Auto-Invoke Filter** arbitre si/comment les appels de\n",
+    "> fonction proposes par le modele sont executes ; le **Function Filter** entoure\n",
+    "> l'execution de chaque fonction (logging, validation, court-circuit). C'est le point\n",
+    "> d'ancrage de l'**observabilite** et de la **gouvernance** sans modifier le code metier.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "c0002df7",


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : le pipeline de filtres (User -> Prompt Filter -> LLM -> Auto-Invoke Filter -> Function Filter -> Response) etait en ASCII, jamais rendu comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+31/-0).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).