### PR TITLE
docs(genai): SK-VectorStores — rendered Mermaid du RAG vectoriel (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
@@ -164,6 +164,39 @@
   },
   {
    "cell_type": "markdown",
+   "id": "vec70r05",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend ce pipeline RAG vectoriel sous forme de graphe :\n",
+    "l'**indexation** (Documents -> Vector Store) et la **recherche** (Query -> similitude\n",
+    "-> contexte).\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    D([\"Documents\"]) --> E[\"Embeddings\"] --> VS[(\"Vector Store<br/>Qdrant ou autre\")]\n",
+    "    Q([\"Query : Qu'est-ce que X ?\"]) --> EQ[\"Embedding Query<br/>[0.2, 0.4, ...]\"]\n",
+    "    EQ --> SIM[\"Recherche de similitude\"]\n",
+    "    VS --> SIM\n",
+    "    SIM --> TOPK[\"Top-K documents pertinents\"]\n",
+    "    TOPK --> CTX([\"Contexte pour le LLM\"])\n",
+    "    classDef idx fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef gen fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef io fill:#d1e7dd,stroke:#0f5132,color:#0a3622\n",
+    "    class D,E,VS idx\n",
+    "    class EQ,SIM,TOPK gen\n",
+    "    class Q,CTX io\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** A l'indexation, chaque **document** est converti en **embedding** (vecteur\n",
+    "> dense) et stocke dans un **vector store** (Qdrant ici). A la requete, la **question**\n",
+    "> est encodee dans le meme espace, puis une **recherche de similitude** (cosinus / dot\n",
+    "> product) ramene les **Top-K** passages les plus proches -- qui forment le **contexte**\n",
+    "> injecte au LLM. Tout repose sur le fait que proximite vectorielle approxime proximite\n",
+    "> semantique.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3d2f3cba",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : le pipeline RAG vectoriel (Documents -> Embeddings -> Vector Store ; Query -> similitude -> Top-K -> contexte LLM) etait en ASCII, jamais rendu comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+33/-0).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).