### PR TITLE
docs(genai): SK-MCP — rendered Mermaid de l'architecture MCP (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
@@ -165,6 +165,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "mcp5k08c",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend cette architecture **MCP** sous forme de graphe : plusieurs\n",
+    "frameworks clients consomment un meme ensemble de serveurs d'outils standardises.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    SK[\"Semantic Kernel<br/>MCP Client\"] --> SRV\n",
+    "    LC[\"LangChain<br/>MCP Client\"] --> SRV\n",
+    "    AG[\"AutoGen<br/>MCP Client\"] --> SRV\n",
+    "    SRV[\"MCP Servers<br/>Filesystem / GitHub / Database / Custom...\"]\n",
+    "    classDef client fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef server fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    class SK,LC,AG client\n",
+    "    class SRV server\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Le **Model Context Protocol** standardise la facon dont un agent accede a\n",
+    "> des outils externes : n'importe quel **client** conforme (Semantic Kernel, LangChain,\n",
+    "> AutoGen...) peut consommer n'importe quel **serveur MCP** (filesystem, GitHub, base de\n",
+    "> donnees, serveurs maison) sans integration sur-mesure. C'est l'equivalent, pour les\n",
+    "> outils d'agents, de ce que USB a ete pour les peripheriques : un connecteur commun qui\n",
+    "> decouple les clients des fournisseurs de capacites.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "63080987",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : l'architecture MCP (clients SK/LangChain/AutoGen -> MCP Servers Filesystem/GitHub/DB) etait en ASCII, jamais rendue comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+28/-0).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).