### PR TITLE
docs(genai): TTS-Gateway — rendered Mermaid du routage multi-moteur (#4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb
@@ -303,6 +303,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6a7eway5",
+   "metadata": {},
+   "source": [
+    "Le diagramme ci-dessous rend le **routage de la gateway** TTS sous forme de graphe :\n",
+    "un point d'entree unique dispatche vers trois moteurs selon le prefixe d'URL.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    GW([\"Gateway<br/>(Port 8196)\"]) --> K[\"/v1/audio/speech<br/>Kokoro TTS (default)\"]\n",
+    "    GW --> T[\"/tada/v1/audio/speech<br/>TADA 3B ML\"]\n",
+    "    GW --> Q[\"/qwen/v1/audio/speech<br/>Qwen3 TTS\"]\n",
+    "    classDef gw fill:#d1e7dd,stroke:#0f5132,color:#0a3622\n",
+    "    classDef eng fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    class GW gw\n",
+    "    class K,T,Q eng\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** La **gateway** expose une API unique (port 8196) et **route** chaque\n",
+    "> requete vers le moteur TTS approprie selon le **prefixe de chemin** : `/v1/...` vers\n",
+    "> Kokoro (defaut), `/tada/...` vers TADA 3B ML, `/qwen/...` vers Qwen3 TTS. Ce patron de\n",
+    "> *reverse proxy applicatif* permet d'offrir une interface OpenAI-compatible homogene\n",
+    "> tout en multiplexant plusieurs backends specialises derriere une seule adresse.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b160458c",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute un **diagramme Mermaid rendu** juste apres le schema ASCII existant.

- **Gap #4212** : le routage de la gateway (port 8196 -> Kokoro / TADA 3B / Qwen3 TTS selon prefixe URL) etait en ASCII, jamais rendu comme graphe.
- **Fidele** : noeuds/arcs repris **verbatim** du schema ASCII du notebook (aucune hallucination).
- **Markdown-only -> C.2-exempt** : aucune cellule code modifiee, pas de re-exec. Diff chirurgical (+27/-1).
- nbformat 4, no-BOM, json.dump(indent=1), 0 fuite, catalogue byte-identical.

See #4212

> Contexte : Paris OFFLINE depuis 2026-06-27, po-2025 = seul survivant. PR CLEAN OPEN (merge bloque jusqu'au retour d'ai-01).