### PR TITLE
docs(genai): Mermaid arbre de decision post-training PT-06 (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_06_eval_comparative.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_06_eval_comparative.ipynb
@@ -226,6 +226,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b2e06d1c",
+   "metadata": {},
+   "source": [
+    "### Arbre de decision : quelle methode de post-entrainement ?\n",
+    "\n",
+    "Le meme arbre de selection, rendu sous forme de graphe : a chaque objectif correspond la methode adaptee (et son notebook).\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    Q[\"Quel est votre objectif ?\"]\n",
+    "    Q --> S[\"Alignement sur un style / format specifique\"] --> SFT[\"SFT (PT-02)\"]\n",
+    "    Q --> D[\"Correction de comportements indesirables (donnees humaines)\"] --> DPO[\"DPO (PT-03)\"]\n",
+    "    Q --> G[\"Optimisation d'une metrique objective (general)\"] --> GRPO[\"GRPO (PT-04)\"]\n",
+    "    Q --> R[\"Domaine a reponse exacte verifiable (math, code)\"] --> RLVR[\"RLVR (PT-05)\"]\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "aa756193",


### PR DESCRIPTION
## Resume

Ajoute un diagramme **Mermaid rendu** au notebook GenAI `PT_06_eval_comparative.ipynb`, la ou la structure n'etait decrite qu'en **ASCII box-drawing** (jamais dessinee comme graphe). Grain Epic #4212.

- **Schema** : arbre de decision post-entrainement (SFT/DPO/GRPO/RLVR).
- **Markdown-only** -> **C.2-exempt** : aucune cellule code modifiee, pas de re-execution kernel/GPU requise.
- **Fidelite** : noeuds et arcs repris **verbatim** du bloc ASCII present dans le notebook.
- **Catalogue byte-identical** a origin/main ; diff surgical (~+20 lignes, 1 cellule markdown).
- Labels Mermaid quotes (`X["..."]`) pour eviter les collisions de forme.

See #4212

> Mode degrade (cluster Paris OFFLINE) : PR CLEAN OPEN, merge en attente du retour d'ai-01.