### PR TITLE
docs(genai): Mermaid flux plugin->invoke SK-01 (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb
@@ -996,6 +996,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c3a01f9d",
+   "metadata": {},
+   "source": [
+    "### Schema : du plugin a l'invocation\n",
+    "\n",
+    "Le plugin (template `skprompt.txt` + reglages `config.json`) est invoque par le kernel, qui remplit le prompt, appelle le service LLM et renvoie le resultat.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    subgraph P[\"FunPlugin/Joke/\"]\n",
+    "      T[\"skprompt.txt (template)\"]\n",
+    "      C[\"config.json (execution settings)\"]\n",
+    "    end\n",
+    "    P --> I[\"kernel.invoke(joke_function, args)\"]\n",
+    "    I --> F[\"Prompt rempli\"]\n",
+    "    F --> L[\"Service LLM\"]\n",
+    "    L --> Res[\"Resultat\"]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2509cdf0",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute un diagramme **Mermaid rendu** au notebook GenAI `01-SemanticKernel-Intro.ipynb`, la ou la structure n'etait decrite qu'en **ASCII box-drawing** (jamais dessinee comme graphe). Grain Epic #4212.

- **Schema** : flux plugin -> kernel.invoke -> LLM.
- **Markdown-only** -> **C.2-exempt** : aucune cellule code modifiee, pas de re-execution kernel/GPU requise.
- **Fidelite** : noeuds et arcs repris **verbatim** du bloc ASCII present dans le notebook.
- **Catalogue byte-identical** a origin/main ; diff surgical (~+20 lignes, 1 cellule markdown).
- Labels Mermaid quotes (`X["..."]`) pour eviter les collisions de forme.

See #4212

> Mode degrade (cluster Paris OFFLINE) : PR CLEAN OPEN, merge en attente du retour d'ai-01.