### PR TITLE
docs(genai): Mermaid pile CLR Python/.NET SK-09 (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
@@ -73,6 +73,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e5a09f3f",
+   "metadata": {},
+   "source": [
+    "### Schema : pile d'interoperabilite Python -> .NET\n",
+    "\n",
+    "Le diagramme montre l'imbrication des couches : Python (Jupyter) charge `pythonnet`, qui demarre le runtime CLR .NET, lequel expose l'assembly `MyIA.AI.Notebooks.dll`.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    subgraph PY[\"Python (Jupyter)\"]\n",
+    "      subgraph PN[\"pythonnet (clr)\"]\n",
+    "        subgraph CLR[\"CLR Runtime (.NET)\"]\n",
+    "          DLL[\"MyIA.AI.Notebooks.dll : AutoInvokeSKAgentsNotebookUpdater + Semantic Kernel C#\"]\n",
+    "        end\n",
+    "      end\n",
+    "    end\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6302befe",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute un diagramme **Mermaid rendu** au notebook GenAI `09-SemanticKernel-Building-CLR.ipynb`, la ou la structure n'etait decrite qu'en **ASCII box-drawing** (jamais dessinee comme graphe). Grain Epic #4212.

- **Schema** : pile d'interoperabilite Python -> pythonnet -> CLR -> dll.
- **Markdown-only** -> **C.2-exempt** : aucune cellule code modifiee, pas de re-execution kernel/GPU requise.
- **Fidelite** : noeuds et arcs repris **verbatim** du bloc ASCII present dans le notebook.
- **Catalogue byte-identical** a origin/main ; diff surgical (~+20 lignes, 1 cellule markdown).
- Labels Mermaid quotes (`X["..."]`) pour eviter les collisions de forme.

See #4212

> Mode degrade (cluster Paris OFFLINE) : PR CLEAN OPEN, merge en attente du retour d'ai-01.