### PR TITLE
docs(genai): Mermaid AgentGroupChat SK-10 (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb
@@ -84,6 +84,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f6a10e4a",
+   "metadata": {},
+   "source": [
+    "### Schema : conversation d'agents et etat du notebook\n",
+    "\n",
+    "Trois agents collaborent en sequence (Admin -> Coder -> Reviewer), chacun faisant progresser l'etat partage du notebook (specified -> implemented -> tested -> validated).\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    subgraph AGC[\"AgentGroupChat\"]\n",
+    "      A[\"AdminAgent (Markdown)\"] --> C[\"CoderAgent (Code)\"] --> R[\"ReviewerAgent (Validation)\"]\n",
+    "    end\n",
+    "    A --> NS[\"NotebookState : specified -> implemented -> tested -> validated\"]\n",
+    "    C --> NS\n",
+    "    R --> NS\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Configuration du Projet\n",


### PR DESCRIPTION
## Resume

Ajoute un diagramme **Mermaid rendu** au notebook GenAI `10-SemanticKernel-NotebookMaker.ipynb`, la ou la structure n'etait decrite qu'en **ASCII box-drawing** (jamais dessinee comme graphe). Grain Epic #4212.

- **Schema** : AgentGroupChat (Admin/Coder/Reviewer) + etat du notebook.
- **Markdown-only** -> **C.2-exempt** : aucune cellule code modifiee, pas de re-execution kernel/GPU requise.
- **Fidelite** : noeuds et arcs repris **verbatim** du bloc ASCII present dans le notebook.
- **Catalogue byte-identical** a origin/main ; diff surgical (~+20 lignes, 1 cellule markdown).
- Labels Mermaid quotes (`X["..."]`) pour eviter les collisions de forme.

See #4212

> Mode degrade (cluster Paris OFFLINE) : PR CLEAN OPEN, merge en attente du retour d'ai-01.