### PR TITLE
docs(genai): Mermaid sous-agents Claude Code CC-04 (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/04-Claude-CLI-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/04-Claude-CLI-Agents.ipynb
@@ -166,6 +166,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a4c04e1b",
+   "metadata": {},
+   "source": [
+    "### Schema : delegation aux sous-agents\n",
+    "\n",
+    "Le Claude principal coordonne et delegue les sous-taches a des sous-agents specialises.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    P[\"Claude Principal (coordonne les taches complexes)\"]\n",
+    "    P --> E[\"Explore Agent\"]\n",
+    "    P --> Pl[\"Plan Agent\"]\n",
+    "    P --> G[\"General Agent\"]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d5baab2b",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume

Ajoute un diagramme **Mermaid rendu** au notebook GenAI Vibe-Coding `04-Claude-CLI-Agents.ipynb`, la ou la structure n'etait decrite qu'en **ASCII box-drawing**. Grain Epic #4212.

- **Schema** : delegation Claude principal -> sous-agents (Explore/Plan/General).
- **Markdown-only** -> **C.2-exempt** : aucune cellule code modifiee.
- **Fidelite** : noeuds/arcs repris **verbatim** du bloc ASCII present dans le notebook.
- **Catalogue byte-identical** ; diff surgical ; labels Mermaid quotes.

See #4212

> Mode degrade (cluster Paris OFFLINE) : PR CLEAN OPEN, merge en attente du retour d'ai-01.