### PR TITLE
docs(genai): Mermaid structure CodeReviewer CC-05 (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/05-Claude-CLI-Automatisation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/05-Claude-CLI-Automatisation.ipynb
@@ -969,6 +969,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a5c05e2c",
+   "metadata": {},
+   "source": [
+    "### Schema : structure de l'agent CodeReviewer\n",
+    "\n",
+    "L'agent expose deux entrees (revue d'un fichier, revue d'un projet) et un export de rapport ; la revue d'un fichier enchaine quatre verifications.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    CR[\"CodeReviewer\"]\n",
+    "    CR --> RF[\"review_file(path)\"]\n",
+    "    RF --> B[\"check: bugs\"]\n",
+    "    RF --> S[\"check: style\"]\n",
+    "    RF --> Sec[\"check: security\"]\n",
+    "    RF --> Pe[\"check: performance\"]\n",
+    "    CR --> RP[\"review_project(dir)\"]\n",
+    "    CR --> GR[\"generate_report() -> rapport Markdown\"]\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "9c796cc9",


### PR DESCRIPTION
## Resume

Ajoute un diagramme **Mermaid rendu** au notebook GenAI Vibe-Coding `05-Claude-CLI-Automatisation.ipynb`, la ou la structure n'etait decrite qu'en **ASCII box-drawing**. Grain Epic #4212.

- **Schema** : structure de l'agent CodeReviewer (review_file/review_project + 4 checks).
- **Markdown-only** -> **C.2-exempt** : aucune cellule code modifiee.
- **Fidelite** : noeuds/arcs repris **verbatim** du bloc ASCII present dans le notebook.
- **Catalogue byte-identical** ; diff surgical ; labels Mermaid quotes.

See #4212

> Mode degrade (cluster Paris OFFLINE) : PR CLEAN OPEN, merge en attente du retour d'ai-01.