### PR TITLE
docs(pymc): PyMC-19 rendered Mermaid — systeme expert + arbre de decision (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb
@@ -104,6 +104,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b9e19a01",
+   "metadata": {},
+   "source": [
+    "### Schema : le systeme expert bayesien\n",
+    "\n",
+    "Le diagramme reprend l'architecture decrite ci-dessus : les observations alimentent le moteur d'inference, qui produit la decision ; la base de connaissances (priors, CPTs, vraisemblances) parametre l'inference.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    O[\"Observations (symptomes, capteurs, signaux)\"] --> M[\"Moteur d'inference bayesien\"]\n",
+    "    M --> D[\"Decision (diagnostic, action optimale)\"]\n",
+    "    KB[\"Base de connaissances (priors, CPTs, likelihoods)\"] --> M\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "85186abf",
@@ -928,6 +945,25 @@
     "| Choix de restaurant | Max EU | Faible enjeu, préférences connues |\n",
     "\n",
     "> **Point clé** : Quand tous les critères convergent vers la même action, la décision est **robuste**. Quand ils divergent, la divergence est un signal d'incertitude réelle qu'il faut communiquer au décideur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9e19a02",
+   "metadata": {},
+   "source": [
+    "### Schema : arbre de selection du critere de decision\n",
+    "\n",
+    "Le meme arbre de decision, rendu sous forme de graphe : selon la confiance dans les probabilites et la gravite du pire cas, on retient un critere different.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    Q[\"Avez-vous confiance dans les probabilites ?\"]\n",
+    "    Q -->|\"Oui\"| EU[\"Max EU (Actions)\"]\n",
+    "    Q -->|\"Non\"| C[\"Le pire cas est-il catastrophique ?\"]\n",
+    "    C -->|\"Oui\"| MM[\"Minimax (Obligations) - erreurs irreversibles, securite\"]\n",
+    "    C -->|\"Non\"| MR[\"Minimax Regret (Immobilier) - eviter les regrets, compromis\"]\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
## Resume
Ajoute deux diagrammes Mermaid rendus au notebook PyMC-19 (systemes experts / decision), la ou la structure n'etait decrite qu'en ASCII box-drawing.

## Detail
- **Cell 1** — architecture du systeme expert bayesien : `Observations -> Moteur d'inference <- Base de connaissances -> Decision` (influence diagram, arc de feedback de la base de connaissances).
- **Cell ~22** — arbre de selection du critere de decision : confiance dans les probabilites ? -> Max EU / (pire cas catastrophique ?) -> Minimax / Minimax Regret.

## Conformite
- Markdown-only (2 cellules markdown ajoutees) -> **C.2-exempt**, aucune cellule code modifiee, pas de re-execution kernel necessaire.
- Noeuds/arcs **verbatim** des blocs ASCII du notebook (anti-hallucination).
- Catalogue byte-identical a origin/main, 0 fuite de chemin, 0 violation C.1.
- Diff chirurgical +36/-0.

See #4212