### PR TITLE
docs(ml): Lab8-ADK rendered Mermaid — pipeline MLE-STAR (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb
@@ -775,6 +775,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c8a08b01",
+   "metadata": {},
+   "source": [
+    "#### Schema : le pipeline MLE-STAR\n",
+    "\n",
+    "Les agents s'enchainent comme dans le schema ASCII ci-dessus : le Verifier recoit a la fois le plan (du Planner) et le resultat d'execution (de l'Executor).\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    FA[\"File Analyzer\"] --> P[\"Planner\"]\n",
+    "    P --> C[\"Coder\"]\n",
+    "    P --> V[\"Verifier\"]\n",
+    "    C --> E[\"Executor\"]\n",
+    "    E --> V\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "g1lnduqr33c",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume
Diagramme Mermaid rendu du pipeline MLE-STAR (Lab8 Agentic Data Science), la ou il n'etait dessine qu'en ASCII box-drawing.

## Detail
`File Analyzer -> Planner -> Coder/Verifier ; Coder -> Executor -> Verifier` — le Verifier recoit a la fois le plan et le resultat d'execution (graphe non lineaire, verbatim de l'ASCII du notebook).

## Conformite
- Markdown-only (1 cellule) -> **C.2-exempt**, aucune cellule code touchee.
- Noeuds/arcs verbatim (anti-hallucination), catalogue byte-identical, 0 fuite, 0 C.1.

See #4212