### PR TITLE
docs(ml): Lab11 rendered Mermaid — boucle Planner-Coder-Verifier (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
@@ -67,6 +67,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d11a0b01",
+   "metadata": {},
+   "source": [
+    "### Schema : la boucle Planner-Coder-Verifier\n",
+    "\n",
+    "Chaque etape transforme l'entree de la precedente ; le Verifier conclut sur un succes ou declenche un nouvel essai (retry).\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    Q[\"Question\"] --> P[\"PLANNER (genere le Plan)\"]\n",
+    "    P --> C[\"CODER (genere le Code)\"]\n",
+    "    C --> E[\"EXECUTOR (produit le Result)\"]\n",
+    "    E --> V[\"VERIFIER\"]\n",
+    "    V --> SR[\"Success / Retry\"]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-2",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume
Diagramme Mermaid rendu de la boucle Planner-Coder-Verifier (Lab11 DS-Star), la ou elle n'etait dessinee qu'en ASCII.

## Detail
`Question -> PLANNER -> CODER -> EXECUTOR -> VERIFIER -> Success / Retry` (verbatim de l'ASCII du notebook).

## Conformite
- Markdown-only (1 cellule) -> **C.2-exempt**, aucune cellule code touchee.
- Noeuds/arcs verbatim (anti-hallucination), catalogue byte-identical, 0 fuite, 0 C.1.

See #4212