### PR TITLE
docs(gametheory): GT-17 rendered Mermaid — architecture NFSP (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
@@ -916,6 +916,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e17a0b03",
+   "metadata": {},
+   "source": [
+    "### Schema : l'architecture NFSP\n",
+    "\n",
+    "Le diagramme reprend la combinaison decrite ci-dessus : le RL Network (meilleure reponse) et le SL Network (strategie moyenne) produisent respectivement Q(s,a) et pi(a|s), agreges par la politique epsilon-greedy.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    RL[\"RL Network (Best Response)\"] --> Q[\"Q(s, a)\"]\n",
+    "    SL[\"SL Network (Avg Strategy)\"] --> PI[\"pi(a|s)\"]\n",
+    "    Q --> EG[\"epsilon-greedy: eta * pi + (1 - eta) * BR(Q)\"]\n",
+    "    PI --> EG\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ex-fp-convergence-md",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Resume
Diagramme Mermaid rendu de l'architecture NFSP (Neural Fictitious Self-Play) du notebook GameTheory-17, la ou elle n'etait dessinee qu'en ASCII box-drawing.

## Detail
`RL Network (Best Response) -> Q(s,a)` et `SL Network (Avg Strategy) -> pi(a|s)`, les deux agreges par la politique `epsilon-greedy: eta*pi + (1-eta)*BR(Q)` (noeud de fusion, graphe non lineaire — verbatim de l'ASCII du notebook).

## Conformite
- Markdown-only (1 cellule) -> **C.2-exempt**, aucune cellule code touchee, pas de re-exec.
- Noeuds/arcs verbatim (anti-hallucination), labels quotes, catalogue byte-identical, 0 fuite, 0 C.1.
- Diff chirurgical +19/-1 (le -1 = reflow accolade finale).

See #4212