### PR TITLE
feat(lean): PacLearning unbiased estimator — E_S[empError] = trueError (iter-2 brique 2c/3)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning.lean
@@ -75,12 +75,13 @@ nécessité — le résultat mathématique est le vrai Hoeffding. Par briques at
   **Et la marginalisation d'une coordonnée** `sampleExpect_coord`
   (`E_{S∼D^m}[g(S i)] = E_D[g]`, brique-clé via `Fintype.prod_sum` +
   `prod_eq_single_of_mem`) : marginaliser une coordonnée du produit `D^m`
-  redonne `D`. Cadre requis par l'estimateur non-biaisé puis Hoeffding.
-- **Brique 2c/3 — OPEN** : concentration de Hoeffding-for-Bernoulli,
-  `ℙ_S [ |empError − trueError| > ε ] ≤ 2·exp(−2mε²)`. Préalable : l'**estimateur
-  non-biaisé** `sampleExpect_empError_eq_trueError` (`E_S[empError] = trueError`
-  par linéarité + `sampleExpect_coord`), puis la méthode Chernoff (Markov +
-  `log t ≤ t − 1` sur les indicateurs).
+  redonne `D`. **Et l'estimateur non-biaisé** `sampleExpect_empError_eq_trueError`
+  (`E_{S∼D^m}[empError] = trueError`, par linéarité + `sampleExpect_coord`
+  coordonnée-par-coordonnée) : l'erreur empirique est centrée sur l'erreur vraie.
+  Cadre requis par la concentration de Hoeffding.
+- **Brique 2c/3-restante — OPEN** : concentration de Hoeffding-for-Bernoulli,
+  `ℙ_S [ |empError − trueError| > ε ] ≤ 2·exp(−2mε²)` (méthode Chernoff : Markov
+  sur `exp(t·(X̄−μ))` + `log t ≤ t − 1` sur les indicateurs).
 - **Brique 3/3 — OPEN** : `pac_finite_class_bound`, `m ≥ (1/ε)(ln|H| + ln(1/δ))`
   (union bound sur `H` fini, `Finset.sum_le_*`). Le théorème phare de Valiant.
 
@@ -96,12 +97,12 @@ nécessité — le résultat mathématique est le vrai Hoeffding. Par briques at
 namespace PacLearning
 
 /-- Statut : itération 1 livrée (modèle + propriétés élémentaires 0-sorry) ;
-itération 2 en cours — **briques 1/3, 2a/3, 2b/3, 2c/3-partiel livrées**
+itération 2 en cours — **briques 1/3, 2a/3, 2b/3, 2c/3 livrées**
 (`Sample.lean` : distribution produit `D^m` + normalisation ; `Concentration.lean` :
 `expect`, `markov_ineq` ; `SampleExpect.lean` : `sampleExpect` + linéarité/normalisation
-+ **marginalisation coordonnée `sampleExpect_coord`**). Briques 2c/3-restantes
-(estimateur non-biaisé + Hoeffding-for-Bernoulli) et 3/3
-(`pac_finite_class_bound` union bound) documentées OPEN. -/
++ **marginalisation coordonnée `sampleExpect_coord`** + **estimateur non-biaisé
+`sampleExpect_empError_eq_trueError`**). Briques restantes : Hoeffding-for-Bernoulli
+(2c/3 concentration) et 3/3 (`pac_finite_class_bound` union bound) documentées OPEN. -/
 abbrev Status : Prop := True
 
 end PacLearning

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/SampleExpect.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/SampleExpect.lean
@@ -37,13 +37,22 @@ else 1)`, de sorte que `∏_j g' j (S j) = (∏_j w (S j)) · g (S i)`
 `∑_S ∏_j g' j (S j) = ∏_j ∑_x g' j x`, et ce produit vaut
 `(∑_x w·g) · (∑_x w)^{n−1} = E_D[g] · 1` (`D.sum_one`).
 
+## Ce livrable — estimateur non-biaisé (brique 2c/3)
+
+On prouve l'**estimateur non-biaisé** `sampleExpect_empError_eq_trueError`
+(`E_{S∼D^m}[empError f h S] = trueError D f h`) : l'erreur empirique, moyennée sur
+les tirages i.i.d., coïncide avec l'erreur vraie (elle est **centrée** dessus).
+C'est le second pilier de la concentration de Hoeffding. Preuve : `empError S =
+n⁻¹ · (∑_i ind(S_i))` (`ind = 1_{h≠f}`) ; on sort le scalaire (`sampleExpect_smul`),
+on distribue la somme (`sampleExpect_sum`), puis chaque indicateur marginalise en
+`E_D[ind] = trueError` via `sampleExpect_coord` + `trueError_eq_expect` ;
+`∑_i trueError = n · trueError` (`sum_const`), et `field_simp` annule `n⁻¹·n`.
+
 ## Briques restantes — OPEN (documentées comme travail futur, pas de stub)
 
-- **Estimateur non-biaisé** `sampleExpect_empError_eq_trueError` :
-  `E_{S∼D^m}[empError f h S] = trueError D f h` (par linéarité + `sampleExpect_coord`
-  coordonnée-par-coordonnée ; l'erreur empirique est centrée sur l'erreur vraie).
 - **Hoeffding-for-Bernoulli** : `ℙ_S [ |empError − trueError| ≥ ε ] ≤
   2·exp(−2nε²)` (méthode Chernoff : Markov sur `exp(t·(X̄−μ))` + `log t ≤ t−1`).
+- **Borne finale** `pac_finite_class_bound` (brique 3/3, union bound sur `H` fini).
 
 Ces briques suivent en itérations dédiées. On reste dans le style
 **ℝ-weight pédagogique** (pas de `ℝ≥0∞` / `Measure`).
@@ -144,6 +153,72 @@ theorem sampleExpect_coord {n : ℕ} (g : X → ℝ) (i : Fin n) :
   -- (5) `∏_j (if j = i then expect D g else 1) = expect D g` : un seul non-trivial.
   rw [Finset.prod_eq_single_of_mem i (Finset.mem_univ _) (fun b _ hb ↦ if_neg hb),
       if_pos rfl]
+
+/-- **Linéarité en une somme indicée** : l'espérance empirique d'une somme de
+fonctions est la somme des espérances (Fubini discret : `∑_S w S · (∑_i F i S) =
+∑_i ∑_S w S · F i S` via `Finset.mul_sum` puis `Finset.sum_comm`). Réutilisé par
+l'estimateur non-biaisé `sampleExpect_empError_eq_trueError`. -/
+theorem sampleExpect_sum {ι : Type*} [Fintype ι] {n : ℕ} (F : ι → ((Fin n → X) → ℝ)) :
+    sampleExpect D (fun S ↦ ∑ i, F i S) = ∑ i, sampleExpect D (F i) := by
+  dsimp only [sampleExpect]
+  simp only [Finset.mul_sum]
+  exact Finset.sum_comm
+
+/-- **Linéarité en un facteur scalaire** : `E[c · g] = c · E[g]` (le scalaire sort
+de la somme pondérée via `Finset.mul_sum`). Réutilisé par l'estimateur non-biaisé
+(pour sortir le facteur `1/n` de l'erreur empirique). -/
+theorem sampleExpect_smul {n : ℕ} (c : ℝ) (g : (Fin n → X) → ℝ) :
+    sampleExpect D (fun S ↦ c * g S) = c * sampleExpect D g := by
+  dsimp only [sampleExpect]
+  simp only [show ∀ S, sampleWeight D S * (c * g S) = c * (sampleWeight D S * g S) from
+               fun _ ↦ by ring]
+  rw [← Finset.mul_sum]
+
+/-- **Estimateur non-biaisé** : l'espérance (sous `D^m`) de l'erreur empirique
+égale l'erreur vraie. C'est le fait que `empError` est un estimateur **non-biaisé**
+de `trueError` : en moyenne sur les tirages `S ∼ D^m`, l'erreur empirique coïncide
+avec l'erreur vraie (elle est **centrée** sur `trueError`).
+
+Preuve : `empError S = (∑_i 1_{h(S_i)≠f(S_i)}) / n = n⁻¹ · (∑_i ind (S i))`. Par
+`sampleExpect_smul` (sortir le `n⁻¹`), `sampleExpect_sum` (linéarité), puis
+`sampleExpect_coord` (chaque indicateur marginalise en `E_D[ind] = trueError` via
+`trueError_eq_expect`), on obtient
+`E_S[empError] = n⁻¹ · (∑_i trueError) = n⁻¹ · (n · trueError) = trueError`. -/
+theorem sampleExpect_empError_eq_trueError {n : ℕ} (f h : Hypothesis X) (hn : 0 < n) :
+    sampleExpect D (fun S : Fin n → X ↦ empError f h S) = trueError D f h := by
+  -- Indicateur de mauvaise classification d'une instance.
+  let ind : X → ℝ := fun x ↦ if h x ≠ f x then 1 else 0
+  -- (1) `empError f h S = (n:ℝ)⁻¹ · (∑ i, ind (S i))` (réécriture du `1/n`).
+  have h_emp : ∀ S : Fin n → X,
+      empError f h S = (n : ℝ)⁻¹ * (∑ i : Fin n, ind (S i)) := by
+    intro S
+    dsimp only [empError, ind]
+    field_simp
+  -- (2) Per-coordinate marginal : `E_S[ind (S i)] = E_D[ind]` (sampleExpect_coord,
+  -- D implicite → named arg `(D := D)` car D n'apparaît que dans le goal).
+  have h_coord : ∀ i : Fin n, sampleExpect D (fun S ↦ ind (S i)) = expect D ind := by
+    intro i
+    exact sampleExpect_coord (D := D) ind i
+  -- (3) `expect D ind = trueError D f h`.
+  have h_true : expect D ind = trueError D f h := (trueError_eq_expect (D := D) f h).symm
+  -- (4) `n > 0` (en ℝ) pour le field_simp final.
+  have hnreal : (0 : ℝ) < n := mod_cast hn
+  calc sampleExpect D (fun S : Fin n → X ↦ empError f h S)
+      = sampleExpect D (fun S ↦ (n : ℝ)⁻¹ * (∑ i : Fin n, ind (S i))) := by
+          simp only [h_emp]
+    _ = (n : ℝ)⁻¹ * sampleExpect D (fun S ↦ ∑ i : Fin n, ind (S i)) := by
+          rw [sampleExpect_smul]
+    _ = (n : ℝ)⁻¹ * ∑ i : Fin n, sampleExpect D (fun S ↦ ind (S i)) := by
+          rw [sampleExpect_sum]
+    _ = (n : ℝ)⁻¹ * ∑ i : Fin n, expect D ind := by
+          congr 1
+          exact Finset.sum_congr rfl (fun i _ ↦ h_coord i)
+    _ = (n : ℝ)⁻¹ * ∑ i : Fin n, trueError D f h := by rw [h_true]
+    _ = (n : ℝ)⁻¹ * (n * trueError D f h) := by
+          congr 1
+          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+    _ = trueError D f h := by
+          field_simp
 
 end PacLearning
 


### PR DESCRIPTION
## Summary

Advances PAC iter-2 (#4293). Ships the **second keystone** of the Hoeffding concentration bound: the empirical error is an **unbiased estimator** of the true error.

```
E_{S∼D^m}[empError f h S] = trueError D f h
```

Averaging `empError` over the i.i.d. draws `S ∼ D^m` recovers the true misclassification mass — the empirical error is **centered** on the true error. This is the prerequisite for Hoeffding (concentration around the mean) and thus for the flagship `pac_finite_class_bound`.

Stacked on #4450 (`sampleExpect_coord`, now merged on main — this PR is a clean single commit rebased onto `origin/main`).

## Two reusable linearity lemmas + the estimator

- `sampleExpect_sum : E_S[∑_i F i S] = ∑_i E_S[F i S]` — Fubini / `Finset.sum_comm`
- `sampleExpect_smul : E_S[c · g S] = c · E_S[g S]` — scalar out via `Finset.mul_sum`
- `sampleExpect_empError_eq_trueError` — the unbiased estimator

## Proof (0 sorry)

```
empError S = (∑_i ind(S_i)) / n = n⁻¹ · (∑_i ind(S_i))   where ind = 1_{h≠f}
  → sampleExpect_smul pulls out the (n:ℝ)⁻¹ scalar
  → sampleExpect_sum distributes over the index sum
  → sampleExpect_coord (#4450) marginalizes each coordinate indicator
      to E_D[ind] = trueError (via trueError_eq_expect)
  → ∑ of n copies of constant trueError = n · trueError (sum_const)
  → field_simp cancels n⁻¹ · n = 1 (n > 0 hypothesis)
```

## Validation (Lean PR discipline §B)

| Check | Result |
|-------|--------|
| `grep -c sorry` avant (origin/main) | `0` source (1 prose `"pas sorry-backed"` Data.lean, pre-existing) |
| `grep -c sorry` après | `0` source (same prose mention, unchanged) |
| `lake build PacLearning` | **SUCCESS, 8497 jobs, 0 error** (only pre-existing iter-1 `unusedSectionVars` linter warnings on Data.lean) |
| Sorry-baseline filter `grep "sorry"\|grep -viE "sorries\|sorry.s"` | **net-zéro vs origin/main** |
| Build tactic | pure `rw`/`simp`/`field_simp`/`calc` (no `sorry`/`admit`) |

```
$ lake build PacLearning
...
✔ [8496/8496] Built PacLearning.SampleExpect (56s)
Build completed successfully (8497 jobs)
```

## Scope

- 3 theorems added (`sampleExpect_sum`, `sampleExpect_smul`, `sampleExpect_empError_eq_trueError`), +66 lines, single file.
- Honest scoping (G.3): Hoeffding concentration itself
  `P[|empError − trueError| ≥ ε] ≤ 2·exp(−2nε²)` (Chernoff method: Markov on `exp(t·(X̄−μ))` + `log t ≤ t − 1`) remains **documented OPEN** — not sorry-backed.

## Multi-brique status

1/3 Sample (#4419 merged) → 2a/3 Concentration (#4436 merged) → 2b/3 SampleExpect framework (#4444 merged) → 2c/3-partial coord marginal (#4450 merged) → **2c/3 unbiased estimator (#4451 this)** → Hoeffding OPEN → 3/3 `pac_finite_class_bound` (flagship, OPEN).

See #4293

🤖 Generated with [Claude Code](https://claude.com/claude-code)