### PR TITLE
docs(qc): FR-backfill PCA-StatArbitrage project README (#3870, Phase 0.5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage/README.en.md
@@ -1,0 +1,39 @@
+# PCA-StatArbitrage
+
+**Asset class:** US Equities (top 100 by dollar volume)
+**Cloud project ID:** `33281920` (`1630-baseline-PCAStatArbitrage`, IBKR + aligned 2018-2025; main.py = canonical + date parameterization only)
+
+## Description
+
+QC Cloud-compatible PCA statistical arbitrage using sklearn PCA instead of numpy/scipy. Fits principal components to the log-price panel of a top-100 US-equity universe, regresses each name on the PCA factors, and trades the residual z-scores as a contrarian mean-reversion signal (long the z<-1.5 tail, weights proportional to z-deviation, full monthly rotation via `set_holdings(liquidate=True)`).
+
+**Consolidated from PCA-StatArb** (statsmodels version, not QC Cloud compatible) and **ML-PCA-StatArb** (identical code with extra comments).
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage"`
+**QC Cloud:** Deployed (see Cloud project ID above). The `main.py` committed here is the canonical copy with `set_brokerage_model(IBKR, MARGIN)` (real fees); the 2015-2024 hardcoded dates are the author default.
+
+## Backtest Metrics
+
+| Metric | Value | Window / fees |
+|--------|-------|---------------|
+| Method | sklearn PCA + OLS residual mean-reversion | — |
+| Rebalance | Monthly (full rotation, `set_holdings liquidate=True`) | — |
+| Universe | Top 100 US equities by dollar volume | — |
+| Sharpe | **0.205** | 2018-2025, IBKR real fees (#1630-aligned) |
+| CAGR | 6.76% | 2018-2025, IBKR |
+| MaxDD | 31.8% | 2018-2025, IBKR |
+| PSR | 1.4% (noise-level) | 2018-2025, IBKR |
+| Sharpe (prior) | 0.399 | 2015-2024, IBKR (author window) |
+| Sharpe (no-fee control) | 0.205 (byte-identical) | 2018-2025, no brokerage |
+
+**#1630 caveat (verified 2026-06-23).** The catalog 0.40 does not survive #1630 alignment: 0.399 -> **0.205** (-49%, PSR 1.4% = noise). Two findings: **(a) the drop is a WINDOW-effect, not fee** -- the README 0.399 was already an IBKR number, so the degradation is the aligned window's 2024-25 Mag7-momentum melt-up, structurally hostile to contrarian PCA mean-reversion (oversold residual names keep falling, winners keep winning); **(b) the strategy is fee-IMMUNE** -- a hardcoded no-brokerage clone of the identical logic (backtest `63fce57d`) returns byte-identical 0.205, so removing the brokerage changes nothing at 3-decimal precision. This refutes the pre-run "monthly full-rotation => fee-vulnerable" prediction and extends the #1630 discriminator regime-3 near-immune class (fee-homogeneity of the US-equity basket dominates over per-event turnover; cf EMA-Cross-Stocks IBKR 0.991 = no-brokerage 0.991). Full analysis: `docs/qc/qc-comparative-backtests.md` finding #40 (See #1630).
+
+## Files
+
+- `main.py` — Strategy (sklearn PCA + OLS mean-reversion, consolidated from PCA-StatArb + ML-PCA-StatArb, IBKR brokerage).
+
+## References
+
+- Avellaneda, M. & Lee, J.-H. (2010), *Statistical Arbitrage in the US Equities Market*. (PCA residual mean-reversion framework.)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage/README.md
@@ -1,39 +1,39 @@
 # PCA-StatArbitrage
 
-**Asset class:** US Equities (top 100 by dollar volume)
-**Cloud project ID:** `33281920` (`1630-baseline-PCAStatArbitrage`, IBKR + aligned 2018-2025; main.py = canonical + date parameterization only)
+**Classe d'actifs :** Actions US (top 100 par volume en dollars)
+**ID projet Cloud :** `33281920` (`1630-baseline-PCAStatArbitrage`, IBKR + aligné 2018-2025 ; `main.py` = canonique + paramétrage des dates uniquement)
 
 ## Description
 
-QC Cloud-compatible PCA statistical arbitrage using sklearn PCA instead of numpy/scipy. Fits principal components to the log-price panel of a top-100 US-equity universe, regresses each name on the PCA factors, and trades the residual z-scores as a contrarian mean-reversion signal (long the z<-1.5 tail, weights proportional to z-deviation, full monthly rotation via `set_holdings(liquidate=True)`).
+Arbitrage statistique par PCA compatible QC Cloud utilisant la PCA de sklearn au lieu de numpy/scipy. Ajuste les composantes principales sur le panneau des log-prix d'un univers top 100 actions US, régresse chaque titre sur les facteurs PCA, et trade les z-scores résiduels comme signal contrarien de retour à la moyenne (long sur la queue z<-1.5, pondérations proportionnelles à la déviation du z, rotation mensuelle complète via `set_holdings(liquidate=True)`).
 
-**Consolidated from PCA-StatArb** (statsmodels version, not QC Cloud compatible) and **ML-PCA-StatArb** (identical code with extra comments).
+**Consolidé depuis PCA-StatArb** (version statsmodels, non compatible QC Cloud) et **ML-PCA-StatArb** (code identique avec commentaires supplémentaires).
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage"`
-**QC Cloud:** Deployed (see Cloud project ID above). The `main.py` committed here is the canonical copy with `set_brokerage_model(IBKR, MARGIN)` (real fees); the 2015-2024 hardcoded dates are the author default.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage"`
+**QC Cloud :** Déployé (voir ID projet Cloud ci-dessus). Le `main.py` commité ici est la copie canonique avec `set_brokerage_model(IBKR, MARGIN)` (frais réels) ; les dates 2015-2024 codées en dur sont celles par défaut de l'auteur.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Value | Window / fees |
-|--------|-------|---------------|
-| Method | sklearn PCA + OLS residual mean-reversion | — |
-| Rebalance | Monthly (full rotation, `set_holdings liquidate=True`) | — |
-| Universe | Top 100 US equities by dollar volume | — |
-| Sharpe | **0.205** | 2018-2025, IBKR real fees (#1630-aligned) |
-| CAGR | 6.76% | 2018-2025, IBKR |
-| MaxDD | 31.8% | 2018-2025, IBKR |
-| PSR | 1.4% (noise-level) | 2018-2025, IBKR |
-| Sharpe (prior) | 0.399 | 2015-2024, IBKR (author window) |
-| Sharpe (no-fee control) | 0.205 (byte-identical) | 2018-2025, no brokerage |
+| Métrique | Valeur | Fenêtre / frais |
+|----------|--------|-----------------|
+| Méthode | sklearn PCA + OLS résiduel mean-reversion | — |
+| Rééquilibrage | Mensuel (rotation complète, `set_holdings liquidate=True`) | — |
+| Univers | Top 100 actions US par volume en dollars | — |
+| Sharpe | **0.205** | 2018-2025, IBKR frais réels (#1630-aligné) |
+| CAGR | 6.76 % | 2018-2025, IBKR |
+| MaxDD | 31.8 % | 2018-2025, IBKR |
+| PSR | 1.4 % (niveau bruit) | 2018-2025, IBKR |
+| Sharpe (précédent) | 0.399 | 2015-2024, IBKR (fenêtre auteur) |
+| Sharpe (contrôle sans frais) | 0.205 (byte-identical) | 2018-2025, sans brokerage |
 
-**#1630 caveat (verified 2026-06-23).** The catalog 0.40 does not survive #1630 alignment: 0.399 -> **0.205** (-49%, PSR 1.4% = noise). Two findings: **(a) the drop is a WINDOW-effect, not fee** -- the README 0.399 was already an IBKR number, so the degradation is the aligned window's 2024-25 Mag7-momentum melt-up, structurally hostile to contrarian PCA mean-reversion (oversold residual names keep falling, winners keep winning); **(b) the strategy is fee-IMMUNE** -- a hardcoded no-brokerage clone of the identical logic (backtest `63fce57d`) returns byte-identical 0.205, so removing the brokerage changes nothing at 3-decimal precision. This refutes the pre-run "monthly full-rotation => fee-vulnerable" prediction and extends the #1630 discriminator regime-3 near-immune class (fee-homogeneity of the US-equity basket dominates over per-event turnover; cf EMA-Cross-Stocks IBKR 0.991 = no-brokerage 0.991). Full analysis: `docs/qc/qc-comparative-backtests.md` finding #40 (See #1630).
+**Caveat #1630 (vérifié 2026-06-23).** Le 0.40 du catalogue ne survit pas à l'alignement #1630 : 0.399 -> **0.205** (-49 %, PSR 1.4 % = bruit). Deux constats : **(a) la chute est un effet de FENÊTRE, pas de frais** — le 0.399 du README était déjà un chiffre IBKR, donc la dégradation vient de la montée en momentum Mag7 2024-25 de la fenêtre alignée, structurellement hostile à la mean-reversion PCA contrarienne (les noms résiduels oversold continuent de tomber, les gagnants continuent de gagner) ; **(b) la stratégie est IMMUNE aux frais** — un clone sans brokerage codé en dur de la logique identique (backtest `63fce57d`) retourne un 0.205 byte-identical, donc retirer le brokerage ne change rien à 3 décimales près. Ceci réfute la prédiction pré-run « rotation mensuelle complète => vulnérable aux frais » et étend la classe regime-3 near-immune du discriminateur #1630 (l'homogénéité des frais du panier actions US domine sur le turnover par événement ; cf EMA-Cross-Stocks IBKR 0.991 = no-brokerage 0.991). Analyse complète : `docs/qc/qc-comparative-backtests.md` finding #40 (See #1630).
 
-## Files
+## Fichiers
 
-- `main.py` — Strategy (sklearn PCA + OLS mean-reversion, consolidated from PCA-StatArb + ML-PCA-StatArb, IBKR brokerage).
+- `main.py` — Stratégie (sklearn PCA + OLS mean-reversion, consolidé depuis PCA-StatArb + ML-PCA-StatArb, brokerage IBKR).
 
-## References
+## Références
 
-- Avellaneda, M. & Lee, J.-H. (2010), *Statistical Arbitrage in the US Equities Market*. (PCA residual mean-reversion framework.)
+- Avellaneda, M. & Lee, J.-H. (2010), *Statistical Arbitrage in the US Equities Market*. (Framework de mean-reversion résiduelle PCA.)


### PR DESCRIPTION
## Summary

FR-backfill of the hand-written **PCA-StatArbitrage** project README (Phase 0.5 of #1650, rule #3870). Genuine **#1630-audit key-strategy** doc — fee-immunity verified 2026-06-23 (byte-identical no-fee control backtest `63fce57d`), window-effect-vs-fee finding (0.399 -> 0.205 = Mag7 momentum, not turnover), Avellaneda-Lee framework — not an auto-gen project stub.

## Protocol (readme-french-first HARD 2)

- `git mv README.md` -> `README.en.md` (original EN preserved verbatim — **byte-identical to HEAD**, preservation CONFIRMED)
- new `README.md` in FR, same structure / tables / metrics / #1630 audit caveat
- strategy name kept in EN (`PCA-StatArbitrage`), prose in FR (66 accented chars)
- **0 catalog markers touched** (`COURSE_CATALOG.generated.*` byte-identical to `main`)

## Diff

- 2 files: `README.en.md` (new, = old EN), `README.md` (rewritten FR)
- +63 / -24

## Verification (G.1)

- Preservation: `git show HEAD:.../README.md | diff - .../README.en.md` -> byte-identical
- Accents: 66 accented chars (genuine FR)
- Catalog: no `CATALOG`/`generated` files in diff
- Scope: atomic, one project, no unrelated changes

Fourth grain of the residual 27-hand-written-EN-README #3870 queue (after RiskParity #4504 MERGED, Corrective-AI #4506 MERGED, PairsTrading #4509 OPEN).

G.1 intercept this cycle: ML-FinBERT-Sentiment was misflagged as EN candidate (FR chars=2) — firsthand read shows it is **already in FR**, so skipped (avoids a bogus PR).

See #3870, #1650 Phase 0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)