### PR TITLE
docs(qc): FR-backfill HAR-RV-J-Kelly project README (#3870, Phase 0.5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-J-Kelly/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-J-Kelly/README.en.md
@@ -1,0 +1,43 @@
+# HAR-RV-J-Kelly
+
+**Asset class:** Crypto (BTCUSDT, ETHUSDT, LTCUSDT, BCHUSDT on Binance)
+
+**Cloud project ID:** 31650567
+
+## Description
+
+HAR-RV-J (Heterogeneous Autoregressive Realized Variance with Jumps, Corsi 2009 + Andersen, Bollerslev & Diebold 2007) for forecasting 5-day realized variance on crypto assets. Extends HAR Classic with jump component from Huang-Tauchen bipower variation. Kelly 1/4 fraction for position sizing.
+
+Set parameter `use_jumps=1` for HAR-RV-J (6 features) or `use_jumps=0` for HAR Classic (3 features).
+
+## How to Run
+
+### QC Cloud
+Open cloud project 31650567, compile and run a backtest.
+
+## Backtest Metrics
+
+Verified on QC Cloud (project 31650567, Binance USDT DAILY):
+
+| Variant | Period | Sharpe | CAGR | Max DD | PSR |
+|---------|--------|--------|------|--------|-----|
+| HAR-RV-J Kelly (use_jumps=1, aligned) | 2018-01-01 → 2025-06-01 | **0.524** | 14.08% | 37.10% | 10.7% |
+| HAR-RV-J Kelly v2 (use_jumps=1) | 2020-01-01 → 2025-06-01 | 0.746 | 23.03% | 48.30% | 24.0% |
+| HAR Classic Baseline (use_jumps=0) | 2020-01-01 → 2025-06-01 | 0.642 | 27.0% | 41.1% | 15.8% |
+
+The aligned 2018-2025 row (backtest `df687834`, 2026-06-22) extends the window backward: with `train_window=500` the model accumulates through ~2018-2019 before it can forecast, so the longer period adds early-regime out-of-sample data and lowers Sharpe (0.746 → 0.524) and CAGR (23.0% → 14.1%) versus the 2020-2025 window, while *improving* MaxDD (48.3% → 37.1%) — the different coefficient path through the 2022 crypto bear produces a less-leveraged exposure. PSR 10.7% (non-significant). Promoted Tier 4 (Untested) → Tier 2 (Historique) on the aligned window; the strongest backbone baseline since GlobalMacro-Regime (0.454). See #1630.
+
+The HAR-RV-J v2 row is verified under the current Binance USDT DAILY configuration (2026-06-12, backtest `verify-har-rv-j-real-metrics`). The HAR Classic baseline retains its 2026-05-14 measurement (pre-Binance configuration); a fresh `use_jumps=0` run under the current configuration is pending for an apples-to-apples delta.
+
+> **Note:** The trade-count column was removed because the `read_backtest` MCP method does not parse the `totalOrders` field (always reports 0). The strategy trades actively — a 23% CAGR and 48% drawdown cannot arise from an all-cash book. The real order count is read from the QC Cloud web UI (*Backtests Results* treegrid, "Orders" column). See the Multi-Layer-EMA README for the full diagnostic of this MCP phantom (resolved as part of #2801 Lot 2).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | HAR-RV-J volatility forecasting with Kelly Criterion sizing on 4 crypto assets |
+
+## References
+
+- Corsi, F. (2009). *A Simple Approximate Long-Memory Model of Realized Volatility*. Journal of Financial Econometrics.
+- Andersen, T.G., Bollerslev, T., & Diebold, F.X. (2007). *Roughing It Up: Including Jump Components in the Measurement, Modeling, and Forecasting of Return Volatility*. Review of Economics and Statistics.

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-J-Kelly/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-J-Kelly/README.md
@@ -1,43 +1,44 @@
 # HAR-RV-J-Kelly
 
-**Asset class:** Crypto (BTCUSDT, ETHUSDT, LTCUSDT, BCHUSDT on Binance)
+**Classe d'actifs :** Crypto (BTCUSDT, ETHUSDT, LTCUSDT, BCHUSDT sur Binance)
 
-**Cloud project ID:** 31650567
+**ID projet Cloud :** 31650567
 
 ## Description
 
-HAR-RV-J (Heterogeneous Autoregressive Realized Variance with Jumps, Corsi 2009 + Andersen, Bollerslev & Diebold 2007) for forecasting 5-day realized variance on crypto assets. Extends HAR Classic with jump component from Huang-Tauchen bipower variation. Kelly 1/4 fraction for position sizing.
+HAR-RV-J (Heterogeneous Autoregressive Realized Variance with Jumps — variance réalisée autorégressive hétérogène avec sauts, Corsi 2009 + Andersen, Bollerslev & Diebold 2007) pour la prévision de la variance réalisée à 5 jours sur des actifs crypto. Étend le HAR Classic avec une composante de sauts dérivée de la variation bipuissance (bipower variation) de Huang-Tauchen. Fraction de Kelly 1/4 pour le dimensionnement des positions.
 
-Set parameter `use_jumps=1` for HAR-RV-J (6 features) or `use_jumps=0` for HAR Classic (3 features).
+Mettre le paramètre `use_jumps=1` pour le HAR-RV-J (6 features) ou `use_jumps=0` pour le HAR Classic (3 features).
 
-## How to Run
+## Comment exécuter
 
 ### QC Cloud
-Open cloud project 31650567, compile and run a backtest.
 
-## Backtest Metrics
+Ouvrir le projet cloud 31650567, compiler et lancer un backtest.
 
-Verified on QC Cloud (project 31650567, Binance USDT DAILY):
+## Métriques de backtest
 
-| Variant | Period | Sharpe | CAGR | Max DD | PSR |
-|---------|--------|--------|------|--------|-----|
-| HAR-RV-J Kelly (use_jumps=1, aligned) | 2018-01-01 → 2025-06-01 | **0.524** | 14.08% | 37.10% | 10.7% |
-| HAR-RV-J Kelly v2 (use_jumps=1) | 2020-01-01 → 2025-06-01 | 0.746 | 23.03% | 48.30% | 24.0% |
-| HAR Classic Baseline (use_jumps=0) | 2020-01-01 → 2025-06-01 | 0.642 | 27.0% | 41.1% | 15.8% |
+Vérifiées sur QC Cloud (projet 31650567, Binance USDT DAILY) :
 
-The aligned 2018-2025 row (backtest `df687834`, 2026-06-22) extends the window backward: with `train_window=500` the model accumulates through ~2018-2019 before it can forecast, so the longer period adds early-regime out-of-sample data and lowers Sharpe (0.746 → 0.524) and CAGR (23.0% → 14.1%) versus the 2020-2025 window, while *improving* MaxDD (48.3% → 37.1%) — the different coefficient path through the 2022 crypto bear produces a less-leveraged exposure. PSR 10.7% (non-significant). Promoted Tier 4 (Untested) → Tier 2 (Historique) on the aligned window; the strongest backbone baseline since GlobalMacro-Regime (0.454). See #1630.
+| Variante | Période | Sharpe | CAGR | Max DD | PSR |
+|----------|---------|--------|------|--------|-----|
+| HAR-RV-J Kelly (use_jumps=1, aligné) | 2018-01-01 → 2025-06-01 | **0.524** | 14.08 % | 37.10 % | 10.7 % |
+| HAR-RV-J Kelly v2 (use_jumps=1) | 2020-01-01 → 2025-06-01 | 0.746 | 23.03 % | 48.30 % | 24.0 % |
+| HAR Classic Baseline (use_jumps=0) | 2020-01-01 → 2025-06-01 | 0.642 | 27.0 % | 41.1 % | 15.8 % |
 
-The HAR-RV-J v2 row is verified under the current Binance USDT DAILY configuration (2026-06-12, backtest `verify-har-rv-j-real-metrics`). The HAR Classic baseline retains its 2026-05-14 measurement (pre-Binance configuration); a fresh `use_jumps=0` run under the current configuration is pending for an apples-to-apples delta.
+La ligne alignée 2018-2025 (backtest `df687834`, 2026-06-22) étend la fenêtre vers l'arrière : avec `train_window=500`, le modèle accumule sur ~2018-2019 avant de pouvoir prévoir, donc la période plus longue ajoute des données hors-échantillon du régime initial et abaisse le Sharpe (0.746 → 0.524) et le CAGR (23.0 % → 14.1 %) par rapport à la fenêtre 2020-2025, tout en *améliorant* le MaxDD (48.3 % → 37.1 %) — le chemin de coefficients différent à travers le bear crypto 2022 produit une exposition moins levée. PSR 10.7 % (non significatif). Promu Tier 4 (Untested) → Tier 2 (Historique) sur la fenêtre alignée ; le meilleur backbone baseline depuis GlobalMacro-Regime (0.454). See #1630.
 
-> **Note:** The trade-count column was removed because the `read_backtest` MCP method does not parse the `totalOrders` field (always reports 0). The strategy trades actively — a 23% CAGR and 48% drawdown cannot arise from an all-cash book. The real order count is read from the QC Cloud web UI (*Backtests Results* treegrid, "Orders" column). See the Multi-Layer-EMA README for the full diagnostic of this MCP phantom (resolved as part of #2801 Lot 2).
+La ligne HAR-RV-J v2 est vérifiée sous la configuration Binance USDT DAILY actuelle (2026-06-12, backtest `verify-har-rv-j-real-metrics`). La baseline HAR Classic conserve sa mesure du 2026-05-14 (configuration pré-Binance) ; un run récent `use_jumps=0` sous la configuration actuelle est en attente pour un delta apples-to-apples.
 
-## Files
+> **Note :** la colonne du nombre de trades a été retirée car la méthode MCP `read_backtest` ne parse pas le champ `totalOrders` (rapporte toujours 0). La stratégie trade activement — un CAGR de 23 % et un drawdown de 48 % ne peuvent pas provenir d'un book tout-cash. Le nombre réel d'ordres se lit sur l'interface web QC Cloud (treegrid *Backtests Results*, colonne « Orders »). Voir le README Multi-Layer-EMA pour le diagnostic complet de ce fantôme MCP (résolu dans le cadre de #2801 Lot 2).
 
-| File | Description |
-|------|-------------|
-| `main.py` | HAR-RV-J volatility forecasting with Kelly Criterion sizing on 4 crypto assets |
+## Fichiers
 
-## References
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Prévision de volatilité HAR-RV-J avec dimensionnement par critère de Kelly sur 4 actifs crypto |
+
+## Références
 
 - Corsi, F. (2009). *A Simple Approximate Long-Memory Model of Realized Volatility*. Journal of Financial Econometrics.
 - Andersen, T.G., Bollerslev, T., & Diebold, F.X. (2007). *Roughing It Up: Including Jump Components in the Measurement, Modeling, and Forecasting of Return Volatility*. Review of Economics and Statistics.


### PR DESCRIPTION
## Summary

FR-backfill of the hand-written **HAR-RV-J-Kelly** project README (Phase 0.5 of #1650, rule #3870). This is the **same HAR-RV-J model family** (Corsi 2009 + Andersen-Bollerslev-Diebold 2007) I hardened with the Diebold-Mariano significance test in PR #4452 (M12-HF track). Genuine **#1630-audit key-strategy** doc — aligned 2018-2025 window (backtest `df687834`), Tier 4 -> Tier 2 promotion, totalOrders MCP phantom note — not an auto-gen project stub.

## Protocol (readme-french-first HARD 2)

- `git mv README.md` -> `README.en.md` (original EN preserved verbatim — **byte-identical to HEAD**, preservation CONFIRMED)
- new `README.md` in FR, same structure / tables / metrics
- strategy name kept in EN (`HAR-RV-J-Kelly`), prose in FR (55 accented chars)
- **0 catalog markers touched** (`COURSE_CATALOG.generated.*` byte-identical to `main`)

## Diff

- 2 files: `README.en.md` (new, = old EN), `README.md` (rewritten FR)
- +65 / -21

## Verification (G.1)

- Preservation: `git show HEAD:.../README.md | diff - .../README.en.md` -> byte-identical
- Accents: 55 accented chars (genuine FR)
- Catalog: no `CATALOG`/`generated` files in diff
- Scope: atomic, one project, no unrelated changes

Fifth grain of the residual 27-hand-written-EN-README #3870 queue (after RiskParity #4504 MERGED, Corrective-AI #4506 MERGED, PairsTrading #4509 OPEN, PCA-StatArbitrage #4510 OPEN).

See #3870, #1650 Phase 0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)