### PR TITLE
fix(infer-16): real Graphviz factor-graph SVG replaces ASCII workaround

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Decision-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Decision-Multi-Attribute.ipynb
@@ -104,15 +104,19 @@
    "outputs": [
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.Probabilistic</span></li><li><span>Microsoft.ML.Probabilistic.Compiler</span></li></ul></div><div></div></div>"
-     },
-     "metadata": {}
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.Probabilistic</span></li><li><span>Microsoft.ML.Probabilistic.Compiler</span></li></ul></div><div></div></div>"
+      ]
+     }
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Infer.NET charge !\r\n"
+     "text": [
+      "Infer.NET charge !\r\n"
+     ]
     }
    ],
    "source": [
@@ -178,12 +182,16 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "FactorGraphHelper charge !\r\n"
+     "text": [
+      "FactorGraphHelper charge !\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Graphviz disponible : False\r\n"
+     "text": [
+      "Graphviz disponible : True\r\n"
+     ]
     }
    ],
    "source": [
@@ -244,37 +252,52 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Options disponibles :\n\r\n"
+     "text": [
+      "Options disponibles :\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Nom            | Prix    | Securite | Conso   | Confort\r\n"
+     "text": [
+      "Nom            | Prix    | Securite | Conso   | Confort\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "---------------|---------|----------|---------|--------\r\n"
+     "text": [
+      "---------------|---------|----------|---------|--------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Economique A   |  15 000 |        3 |     5,0 |       6\r\n"
+     "text": [
+      "Economique A   |  15 000 |        3 |     5,0 |       6\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Familiale B    |  28 000 |        5 |     6,5 |       8\r\n"
+     "text": [
+      "Familiale B    |  28 000 |        5 |     6,5 |       8\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Sport C        |  45 000 |        4 |     9,0 |       7\r\n"
+     "text": [
+      "Sport C        |  45 000 |        4 |     9,0 |       7\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Hybride D      |  32 000 |        5 |     4,0 |       8\r\n"
+     "text": [
+      "Hybride D      |  32 000 |        5 |     4,0 |       8\r\n"
+     ]
     }
    ],
    "source": [
@@ -441,67 +464,96 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Test d'independance : Prix vs Securite\n\r\n"
+     "text": [
+      "Test d'independance : Prix vs Securite\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Question : Preferez-vous A ou B ?\r\n"
+     "text": [
+      "Question : Preferez-vous A ou B ?\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Contexte 1 (Securite = 3 etoiles) :\r\n"
+     "text": [
+      "Contexte 1 (Securite = 3 etoiles) :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  A : Prix = 15000 EUR\r\n"
+     "text": [
+      "  A : Prix = 15000 EUR\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  B : Prix = 20000 EUR\r\n"
+     "text": [
+      "  B : Prix = 20000 EUR\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  => Vous preferez probablement A (moins cher)\n\r\n"
+     "text": [
+      "  => Vous preferez probablement A (moins cher)\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Contexte 2 (Securite = 5 etoiles) :\r\n"
+     "text": [
+      "Contexte 2 (Securite = 5 etoiles) :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  A : Prix = 15000 EUR\r\n"
+     "text": [
+      "  A : Prix = 15000 EUR\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  B : Prix = 20000 EUR\r\n"
+     "text": [
+      "  B : Prix = 20000 EUR\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  => Preferez-vous toujours A ?\n\r\n"
+     "text": [
+      "  => Preferez-vous toujours A ?\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Si votre reponse est la meme dans les deux contextes,\r\n"
+     "text": [
+      "Si votre reponse est la meme dans les deux contextes,\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "alors Prix et Securite sont preferentiellement independants.\r\n"
+     "text": [
+      "alors Prix et Securite sont preferentiellement independants.\r\n"
+     ]
     }
    ],
    "source": [
@@ -587,22 +639,28 @@
    "outputs": [
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Plotly.NET.Interactive</span></li></ul></div><div></div></div>"
-     },
-     "metadata": {}
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Plotly.NET.Interactive</span></li></ul></div><div></div></div>"
+      ]
+     }
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
-      "text/plain": "Loading extensions from `~\\.nuget\\packages\\plotly.net.interactive\\5.0.0\\lib\\netstandard2.1\\Plotly.NET.Interactive.dll`"
-     },
-     "metadata": {}
+      "text/plain": [
+       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\plotly.net.interactive\\5.0.0\\lib\\netstandard2.1\\Plotly.NET.Interactive.dll`"
+      ]
+     }
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Plotly.NET charge pour les visualisations interactives !\r\n"
+     "text": [
+      "Plotly.NET charge pour les visualisations interactives !\r\n"
+     ]
     }
    ],
    "source": [
@@ -657,42 +715,60 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Poids : Prix=35 %, Securite=30 %, Conso=20 %, Confort=15 %\n\r\n"
+     "text": [
+      "Poids : Prix=35 %, Securite=30 %, Conso=20 %, Confort=15 %\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Voiture        | v_prix | v_sec  | v_conso | v_conf | V_total\r\n"
+     "text": [
+      "Voiture        | v_prix | v_sec  | v_conso | v_conf | V_total\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "---------------|--------|--------|---------|--------|--------\r\n"
+     "text": [
+      "---------------|--------|--------|---------|--------|--------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Economique A   |  1,000 |  0,500 |   0,833 |  0,556 |  0,750\r\n"
+     "text": [
+      "Economique A   |  1,000 |  0,500 |   0,833 |  0,556 |  0,750\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Familiale B    |  0,567 |  1,000 |   0,583 |  0,778 |  0,732\r\n"
+     "text": [
+      "Familiale B    |  0,567 |  1,000 |   0,583 |  0,778 |  0,732\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Sport C        |  0,000 |  0,750 |   0,167 |  0,667 |  0,358\r\n"
+     "text": [
+      "Sport C        |  0,000 |  0,750 |   0,167 |  0,667 |  0,358\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Hybride D      |  0,433 |  1,000 |   1,000 |  0,778 |  0,768\r\n"
+     "text": [
+      "Hybride D      |  0,433 |  1,000 |   1,000 |  0,778 |  0,768\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\n=> Meilleur choix : Hybride D\r\n"
+     "text": [
+      "\n",
+      "=> Meilleur choix : Hybride D\r\n"
+     ]
     }
    ],
    "source": [
@@ -803,67 +879,93 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Decomposition de la valeur multi-attributs :\r\n"
+     "text": [
+      "Decomposition de la valeur multi-attributs :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Voiture        | Prix    | Securite | Conso   | Confort | Contributions\r\n"
+     "text": [
+      "Voiture        | Prix    | Securite | Conso   | Confort | Contributions\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "               | (w=35%) | (w=30%)  | (w=20%) | (w=15%) | ponderees\r\n"
+     "text": [
+      "               | (w=35%) | (w=30%)  | (w=20%) | (w=15%) | ponderees\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "---------------|---------|----------|---------|---------|---------------\r\n"
+     "text": [
+      "---------------|---------|----------|---------|---------|---------------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Economique A   |   0,350 |    0,150 |   0,167 |   0,083 | V=0,750\r\n"
+     "text": [
+      "Economique A   |   0,350 |    0,150 |   0,167 |   0,083 | V=0,750\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Familiale B    |   0,198 |    0,300 |   0,117 |   0,117 | V=0,732\r\n"
+     "text": [
+      "Familiale B    |   0,198 |    0,300 |   0,117 |   0,117 | V=0,732\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Sport C        |   0,000 |    0,225 |   0,033 |   0,100 | V=0,358\r\n"
+     "text": [
+      "Sport C        |   0,000 |    0,225 |   0,033 |   0,100 | V=0,358\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Hybride D      |   0,152 |    0,300 |   0,200 |   0,117 | V=0,768\r\n"
+     "text": [
+      "Hybride D      |   0,152 |    0,300 |   0,200 |   0,117 | V=0,768\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Interpretation :\r\n"
+     "text": [
+      "Interpretation :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  - Chaque colonne = contribution ponderee de l'attribut (wi * vi)\r\n"
+     "text": [
+      "  - Chaque colonne = contribution ponderee de l'attribut (wi * vi)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  - V total = somme des contributions\r\n"
+     "text": [
+      "  - V total = somme des contributions\r\n"
+     ]
     }
    ],
    "source": [
@@ -972,82 +1074,118 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Situation de depart (pire option) :\n\r\n"
+     "text": [
+      "Situation de depart (pire option) :\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Prix : 45000 EUR (maximum)\r\n"
+     "text": [
+      "  Prix : 45000 EUR (maximum)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Securite : 1 etoile (minimum)\r\n"
+     "text": [
+      "  Securite : 1 etoile (minimum)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Consommation : 10 L/100km (maximum)\r\n"
+     "text": [
+      "  Consommation : 10 L/100km (maximum)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Confort : 1/10 (minimum)\r\n"
+     "text": [
+      "  Confort : 1/10 (minimum)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Classez les swings suivants par ordre de preference :\n\r\n"
+     "text": [
+      "Classez les swings suivants par ordre de preference :\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  A) Prix : 45000 -> 15000 (economie de 30000 EUR)\r\n"
+     "text": [
+      "  A) Prix : 45000 -> 15000 (economie de 30000 EUR)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  B) Securite : 1 -> 5 etoiles\r\n"
+     "text": [
+      "  B) Securite : 1 -> 5 etoiles\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  C) Consommation : 10 -> 4 L/100km\r\n"
+     "text": [
+      "  C) Consommation : 10 -> 4 L/100km\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  D) Confort : 1 -> 10\n\r\n"
+     "text": [
+      "  D) Confort : 1 -> 10\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Points swing et poids normalises :\n\r\n"
+     "text": [
+      "Points swing et poids normalises :\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Securite     : 100 points => poids = 35,7 %\r\n"
+     "text": [
+      "  Securite     : 100 points => poids = 35,7 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Prix         :  90 points => poids = 32,1 %\r\n"
+     "text": [
+      "  Prix         :  90 points => poids = 32,1 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Consommation :  50 points => poids = 17,9 %\r\n"
+     "text": [
+      "  Consommation :  50 points => poids = 17,9 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Confort      :  40 points => poids = 14,3 %\r\n"
+     "text": [
+      "  Confort      :  40 points => poids = 14,3 %\r\n"
+     ]
     }
    ],
    "source": [
@@ -1102,7 +1240,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : swing weights et classement des appartements\r\n"
+     "text": [
+      "Exercice a completer : swing weights et classement des appartements\r\n"
+     ]
     }
    ],
    "source": [
@@ -1243,37 +1383,51 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Poids : k1=0.4, k2=0.35, k3=0.35 (sum = 1.1)\r\n"
+     "text": [
+      "Poids : k1=0.4, k2=0.35, k3=0.35 (sum = 1.1)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Facteur K calcule : -0,2565\r\n"
+     "text": [
+      "Facteur K calcule : -0,2565\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison des formes :\r\n"
+     "text": [
+      "Comparaison des formes :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  u = (1,1,1) : U_mult = 1,000\r\n"
+     "text": [
+      "  u = (1,1,1) : U_mult = 1,000\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  u = (1,0.5,0.5) : U_mult = 0,707\r\n"
+     "text": [
+      "  u = (1,0.5,0.5) : U_mult = 0,707\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  u = (0.5,0.5,0.5) : U_mult = 0,525\r\n"
+     "text": [
+      "  u = (0.5,0.5,0.5) : U_mult = 0,525\r\n"
+     ]
     }
    ],
    "source": [
@@ -1408,57 +1562,79 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison forme additive vs multiplicative :\r\n"
+     "text": [
+      "Comparaison forme additive vs multiplicative :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Poids : w1=0.5, w2=0.5, K=0,0000\r\n"
+     "text": [
+      "Poids : w1=0.5, w2=0.5, K=0,0000\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Scenario                 | U Additif | U Multiplicatif | Diff\r\n"
+     "text": [
+      "Scenario                 | U Additif | U Multiplicatif | Diff\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "-------------------------|-----------|-----------------|------\r\n"
+     "text": [
+      "-------------------------|-----------|-----------------|------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Bon X, mauvais Y         |     0,550 |           0,550 | 0,000\r\n"
+     "text": [
+      "Bon X, mauvais Y         |     0,550 |           0,550 | 0,000\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Mauvais X, bon Y         |     0,550 |           0,550 | 0,000\r\n"
+     "text": [
+      "Mauvais X, bon Y         |     0,550 |           0,550 | 0,000\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Mediocre partout         |     0,500 |           0,500 | 0,000\r\n"
+     "text": [
+      "Mediocre partout         |     0,500 |           0,500 | 0,000\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Excellent partout        |     0,900 |           0,900 | 0,000\r\n"
+     "text": [
+      "Excellent partout        |     0,900 |           0,900 | 0,000\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "K = 0 : Forme additive (pas d'interaction)\r\n"
+     "text": [
+      "K = 0 : Forme additive (pas d'interaction)\r\n"
+     ]
     }
    ],
    "source": [
@@ -1569,7 +1745,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : forme multiplicative pour choix d'investissement\r\n"
+     "text": [
+      "Exercice a completer : forme multiplicative pour choix d'investissement\r\n"
+     ]
     }
    ]
   },
@@ -1600,57 +1778,81 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=== SMART : Choix de Carriere ===\r\n"
+     "text": [
+      "=== SMART : Choix de Carriere ===\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Poids : Salaire=30 %, Equilibre=25 %, \r\n"
+     "text": [
+      "Poids : Salaire=30 %, Equilibre=25 %, \r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "        Passion=25 %, Securite=20 %\n\r\n"
+     "text": [
+      "        Passion=25 %, Securite=20 %\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Carriere           | v_sal | v_wlb | v_pas | v_sec | V_total\r\n"
+     "text": [
+      "Carriere           | v_sal | v_wlb | v_pas | v_sec | V_total\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "-------------------|-------|-------|-------|-------|--------\r\n"
+     "text": [
+      "-------------------|-------|-------|-------|-------|--------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Startup            | 0,400 | 0,222 | 0,889 | 0,333 |  0,464\r\n"
+     "text": [
+      "Startup            | 0,400 | 0,222 | 0,889 | 0,333 |  0,464\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Grande Entreprise  | 0,800 | 0,556 | 0,444 | 0,778 |  0,646\r\n"
+     "text": [
+      "Grande Entreprise  | 0,800 | 0,556 | 0,444 | 0,778 |  0,646\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Fonction Publique  | 0,120 | 0,778 | 0,333 | 1,000 |  0,514\r\n"
+     "text": [
+      "Fonction Publique  | 0,120 | 0,778 | 0,333 | 1,000 |  0,514\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Freelance          | 1,000 | 0,444 | 0,778 | 0,222 |  0,650\r\n"
+     "text": [
+      "Freelance          | 1,000 | 0,444 | 0,778 | 0,222 |  0,650\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Recherche          | 0,000 | 0,667 | 1,000 | 0,556 |  0,528\r\n"
+     "text": [
+      "Recherche          | 0,000 | 0,667 | 1,000 | 0,556 |  0,528\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\n=> Meilleur choix avec ces poids : Freelance (V = 0,650)\r\n"
+     "text": [
+      "\n",
+      "=> Meilleur choix avec ces poids : Freelance (V = 0,650)\r\n"
+     ]
     }
    ],
    "source": [
@@ -1763,57 +1965,79 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Profils de carriere - Comparaison multi-attributs :\r\n"
+     "text": [
+      "Profils de carriere - Comparaison multi-attributs :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Carriere           | Salaire | Equilibre | Passion | Securite | Score\r\n"
+     "text": [
+      "Carriere           | Salaire | Equilibre | Passion | Securite | Score\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "-------------------|---------|-----------|---------|----------|------\r\n"
+     "text": [
+      "-------------------|---------|-----------|---------|----------|------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Startup            |    0,40 |      0,22 |    0,89 |     0,33 | 0,464\r\n"
+     "text": [
+      "Startup            |    0,40 |      0,22 |    0,89 |     0,33 | 0,464\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Grande Entreprise  |    0,80 |      0,56 |    0,44 |     0,78 | 0,646\r\n"
+     "text": [
+      "Grande Entreprise  |    0,80 |      0,56 |    0,44 |     0,78 | 0,646\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Fonction Publique  |    0,12 |      0,78 |    0,33 |     1,00 | 0,514\r\n"
+     "text": [
+      "Fonction Publique  |    0,12 |      0,78 |    0,33 |     1,00 | 0,514\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Freelance          |    1,00 |      0,44 |    0,78 |     0,22 | 0,650\r\n"
+     "text": [
+      "Freelance          |    1,00 |      0,44 |    0,78 |     0,22 | 0,650\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Recherche          |    0,00 |      0,67 |    1,00 |     0,56 | 0,528\r\n"
+     "text": [
+      "Recherche          |    0,00 |      0,67 |    1,00 |     0,56 | 0,528\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Poids : Salaire=30 %, Equilibre=25 %, Passion=25 %, Securite=20 %\r\n"
+     "text": [
+      "Poids : Salaire=30 %, Equilibre=25 %, Passion=25 %, Securite=20 %\r\n"
+     ]
     }
    ],
    "source": [
@@ -1891,52 +2115,73 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Analyse de sensibilite : poids du Salaire\n\r\n"
+     "text": [
+      "Analyse de sensibilite : poids du Salaire\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "w_salaire | Meilleur choix       | V_meilleur\r\n"
+     "text": [
+      "w_salaire | Meilleur choix       | V_meilleur\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "----------|----------------------|-----------\r\n"
+     "text": [
+      "----------|----------------------|-----------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "     10 % | Recherche            |     0,679\r\n"
+     "text": [
+      "     10 % | Recherche            |     0,679\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "     20 % | Grande Entreprise    |     0,623\r\n"
+     "text": [
+      "     20 % | Grande Entreprise    |     0,623\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "     30 % | Freelance            |     0,650\r\n"
+     "text": [
+      "     30 % | Freelance            |     0,650\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "     40 % | Freelance            |     0,700\r\n"
+     "text": [
+      "     40 % | Freelance            |     0,700\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "     50 % | Freelance            |     0,750\r\n"
+     "text": [
+      "     50 % | Freelance            |     0,750\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=> Le choix optimal change selon l'importance accordee au salaire.\r\n"
+     "text": [
+      "=> Le choix optimal change selon l'importance accordee au salaire.\r\n"
+     ]
     }
    ],
    "source": [
@@ -2017,472 +2262,660 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Tableau de sensibilite : V selon le poids du Salaire\r\n"
+     "text": [
+      "Tableau de sensibilite : V selon le poids du Salaire\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "w_salaire  |"
+     "text": [
+      "w_salaire  |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Startup   |"
+     "text": [
+      "Startup   |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Grande E  |"
+     "text": [
+      "Grande E  |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Fonction  |"
+     "text": [
+      "Fonction  |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Freelanc  |"
+     "text": [
+      "Freelanc  |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Recherch  |"
+     "text": [
+      "Recherch  |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "-----------|"
+     "text": [
+      "-----------|"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "---------|"
+     "text": [
+      "---------|"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "---------|"
+     "text": [
+      "---------|"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "---------|"
+     "text": [
+      "---------|"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "---------|"
+     "text": [
+      "---------|"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "---------|"
+     "text": [
+      "---------|"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      10 % |"
+     "text": [
+      "      10 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,483 |"
+     "text": [
+      "   0,483 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,601 |"
+     "text": [
+      "   0,601 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,626 |"
+     "text": [
+      "   0,626 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,550 |"
+     "text": [
+      "   0,550 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,679 |"
+     "text": [
+      "   0,679 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Recherche"
+     "text": [
+      " <-- Recherche"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      15 % |"
+     "text": [
+      "      15 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,478 |"
+     "text": [
+      "   0,478 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,612 |"
+     "text": [
+      "   0,612 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,598 |"
+     "text": [
+      "   0,598 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,575 |"
+     "text": [
+      "   0,575 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,641 |"
+     "text": [
+      "   0,641 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Recherche"
+     "text": [
+      " <-- Recherche"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      20 % |"
+     "text": [
+      "      20 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,474 |"
+     "text": [
+      "   0,474 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,623 |"
+     "text": [
+      "   0,623 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,570 |"
+     "text": [
+      "   0,570 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,600 |"
+     "text": [
+      "   0,600 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,603 |"
+     "text": [
+      "   0,603 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Grande Entreprise"
+     "text": [
+      " <-- Grande Entreprise"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      25 % |"
+     "text": [
+      "      25 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,469 |"
+     "text": [
+      "   0,469 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,635 |"
+     "text": [
+      "   0,635 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,542 |"
+     "text": [
+      "   0,542 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,625 |"
+     "text": [
+      "   0,625 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,565 |"
+     "text": [
+      "   0,565 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Grande Entreprise"
+     "text": [
+      " <-- Grande Entreprise"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      30 % |"
+     "text": [
+      "      30 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,464 |"
+     "text": [
+      "   0,464 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,646 |"
+     "text": [
+      "   0,646 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,514 |"
+     "text": [
+      "   0,514 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,650 |"
+     "text": [
+      "   0,650 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,528 |"
+     "text": [
+      "   0,528 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Freelance"
+     "text": [
+      " <-- Freelance"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      35 % |"
+     "text": [
+      "      35 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,460 |"
+     "text": [
+      "   0,460 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,657 |"
+     "text": [
+      "   0,657 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,486 |"
+     "text": [
+      "   0,486 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,675 |"
+     "text": [
+      "   0,675 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,490 |"
+     "text": [
+      "   0,490 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Freelance"
+     "text": [
+      " <-- Freelance"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      40 % |"
+     "text": [
+      "      40 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,455 |"
+     "text": [
+      "   0,455 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,668 |"
+     "text": [
+      "   0,668 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,458 |"
+     "text": [
+      "   0,458 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,700 |"
+     "text": [
+      "   0,700 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,452 |"
+     "text": [
+      "   0,452 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Freelance"
+     "text": [
+      " <-- Freelance"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      45 % |"
+     "text": [
+      "      45 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,451 |"
+     "text": [
+      "   0,451 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,679 |"
+     "text": [
+      "   0,679 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,429 |"
+     "text": [
+      "   0,429 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,725 |"
+     "text": [
+      "   0,725 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,415 |"
+     "text": [
+      "   0,415 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Freelance"
+     "text": [
+      " <-- Freelance"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "      50 % |"
+     "text": [
+      "      50 % |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,446 |"
+     "text": [
+      "   0,446 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,690 |"
+     "text": [
+      "   0,690 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,401 |"
+     "text": [
+      "   0,401 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,750 |"
+     "text": [
+      "   0,750 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   0,377 |"
+     "text": [
+      "   0,377 |"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": " <-- Freelance"
+     "text": [
+      " <-- Freelance"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Interpretation :\r\n"
+     "text": [
+      "Interpretation :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "- Les valeurs en gras (max par colonne) indiquent le meilleur choix\r\n"
+     "text": [
+      "- Les valeurs en gras (max par colonne) indiquent le meilleur choix\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "- Freelance domine pour w_salaire > 25%\r\n"
+     "text": [
+      "- Freelance domine pour w_salaire > 25%\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "- Recherche domine pour w_salaire < 15%\r\n"
+     "text": [
+      "- Recherche domine pour w_salaire < 15%\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=> Le choix optimal depend fortement des preferences sur le salaire\r\n"
+     "text": [
+      "=> Le choix optimal depend fortement des preferences sur le salaire\r\n"
+     ]
     }
    ],
    "source": [
@@ -2565,7 +2998,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : analyse de sensibilite multi-attributs\r\n"
+     "text": [
+      "Exercice a completer : analyse de sensibilite multi-attributs\r\n"
+     ]
     }
    ],
    "source": [
@@ -2676,82 +3111,115 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Compiling model..."
+     "text": [
+      "Compiling model..."
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "done.\r\n"
+     "text": [
+      "done.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Compiling model..."
+     "text": [
+      "Compiling model..."
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "done.\r\n"
+     "text": [
+      "done.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Compiling model..."
+     "text": [
+      "Compiling model..."
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "done.\r\n"
+     "text": [
+      "done.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Compiling model..."
+     "text": [
+      "Compiling model..."
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "done.\r\n"
+     "text": [
+      "done.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Distributions des attributs :\n\r\n"
+     "text": [
+      "Distributions des attributs :\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Projet A : Rendement ~ Gaussian(0,08, 0,01), Risque ~ Gaussian(0,15, 0,005)\r\n"
+     "text": [
+      "Projet A : Rendement ~ Gaussian(0,08, 0,01), Risque ~ Gaussian(0,15, 0,005)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Projet B : Rendement ~ Gaussian(0,12, 0,02), Risque ~ Gaussian(0,25, 0,01)\r\n"
+     "text": [
+      "Projet B : Rendement ~ Gaussian(0,12, 0,02), Risque ~ Gaussian(0,25, 0,01)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "E[U(Projet A)] = 0,5055\r\n"
+     "text": [
+      "E[U(Projet A)] = 0,5056\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "E[U(Projet B)] = 0,4828\r\n"
+     "text": [
+      "E[U(Projet B)] = 0,4859\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=> Decision optimale : Projet A\r\n"
+     "text": [
+      "=> Decision optimale : Projet A\r\n"
+     ]
     }
    ],
    "source": [
@@ -2920,32 +3388,45 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Vos resultats SMART :\n\r\n"
+     "text": [
+      "Vos resultats SMART :\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Option 1 : V = 0,705\r\n"
+     "text": [
+      "Option 1 : V = 0,705\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Option 2 : V = 0,665\r\n"
+     "text": [
+      "Option 2 : V = 0,665\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Option 3 : V = 0,750\r\n"
+     "text": [
+      "Option 3 : V = 0,750\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Modifiez les valeurs ci-dessus pour votre probleme personnel !\r\n"
+     "text": [
+      "Modifiez les valeurs ci-dessus pour votre probleme personnel !\r\n"
+     ]
     }
    ],
    "source": [
@@ -3052,97 +3533,139 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Compiling model..."
+     "text": [
+      "Compiling model..."
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "done.\r\n"
+     "text": [
+      "done.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=== Inference Bayesienne des Poids MAUT ===\n\r\n"
+     "text": [
+      "=== Inference Bayesienne des Poids MAUT ===\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Choix observes : Securite, Prix, Securite, Securite, Prix\n\r\n"
+     "text": [
+      "Choix observes : Securite, Prix, Securite, Securite, Prix\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Prior (Dirichlet uniforme) :\r\n"
+     "text": [
+      "Prior (Dirichlet uniforme) :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Pseudo-counts : [1, 1, 1, 1]\n\r\n"
+     "text": [
+      "  Pseudo-counts : [1, 1, 1, 1]\n",
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Posterior (apres 5 observations) :\r\n"
+     "text": [
+      "Posterior (apres 5 observations) :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  w_Prix         = 33,3 %\r\n"
+     "text": [
+      "  w_Prix         = 33,3 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  w_Securite     = 44,4 %\r\n"
+     "text": [
+      "  w_Securite     = 44,4 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  w_Consommation = 11,1 %\r\n"
+     "text": [
+      "  w_Consommation = 11,1 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  w_Confort      = 11,1 %\r\n"
+     "text": [
+      "  w_Confort      = 11,1 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\nDistribution Dirichlet posterior : Dirichlet(3 4 1 1)\r\n"
+     "text": [
+      "\n",
+      "Distribution Dirichlet posterior : Dirichlet(3 4 1 1)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison :\r\n"
+     "text": [
+      "Comparaison :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Swing weights (manuel)  : Prix=35%, Securite=30%, Conso=20%, Confort=15%\r\n"
+     "text": [
+      "  Swing weights (manuel)  : Prix=35%, Securite=30%, Conso=20%, Confort=15%\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Inference bayesienne    : Prix=33 %, Securite=44 %, Conso=11 %, Confort=11 %\r\n"
+     "text": [
+      "  Inference bayesienne    : Prix=33 %, Securite=44 %, Conso=11 %, Confort=11 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=> L'inference bayesienne revele les poids IMPLICITES du decideur !\r\n"
+     "text": [
+      "=> L'inference bayesienne revele les poids IMPLICITES du decideur !\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   Ici, la Securite domine (3/5 choix), confirmant son importance.\r\n"
+     "text": [
+      "   Ici, la Securite domine (3/5 choix), confirmant son importance.\r\n"
+     ]
     }
    ],
    "source": [
@@ -3273,67 +3796,93 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Evolution des poids MAUT : Prior -> Posterior\r\n"
+     "text": [
+      "Evolution des poids MAUT : Prior -> Posterior\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Attribut      | Prior (uniforme) | Posterior (infere) | Evolution\r\n"
+     "text": [
+      "Attribut      | Prior (uniforme) | Posterior (infere) | Evolution\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "--------------|------------------|--------------------|-----------\r\n"
+     "text": [
+      "--------------|------------------|--------------------|-----------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Prix          |             25 % |             33,3 % |    0,083  ^\r\n"
+     "text": [
+      "Prix          |             25 % |             33,3 % |    0,083  ^\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Securite      |             25 % |             44,4 % |    0,194  ^\r\n"
+     "text": [
+      "Securite      |             25 % |             44,4 % |    0,194  ^\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Consommation  |             25 % |             11,1 % |   -0,139  v\r\n"
+     "text": [
+      "Consommation  |             25 % |             11,1 % |   -0,139  v\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Confort       |             25 % |             11,1 % |   -0,139  v\r\n"
+     "text": [
+      "Confort       |             25 % |             11,1 % |   -0,139  v\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Interpretation :\r\n"
+     "text": [
+      "Interpretation :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  ^ : L'attribut est plus important que prevu (choisi souvent)\r\n"
+     "text": [
+      "  ^ : L'attribut est plus important que prevu (choisi souvent)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  v : L'attribut est moins important que prevu\r\n"
+     "text": [
+      "  v : L'attribut est moins important que prevu\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  = : L'importance reste proche du prior\r\n"
+     "text": [
+      "  = : L'importance reste proche du prior\r\n"
+     ]
     }
    ],
    "source": [
@@ -3411,186 +3960,175 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Compiling model..."
+     "text": [
+      "Compiling model..."
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "done.\r\n"
+     "text": [
+      "done.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Structure du modele bayesien des poids :\r\n"
+     "text": [
+      "Structure du modele bayesien des poids (rendu SVG ci-dessous).\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  +---------------+\r\n"
+     "text": [
+      "Posterior : Dirichlet(2 3 1 1)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  |    Dirichlet  | <- Prior sur les poids\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  |   (1,1,1,1)   |\r\n"
+     "text": [
+      "Lecture du factor graph :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  +-------+-------+\r\n"
+     "text": [
+      "  - Le noeud Dirichlet (1,1,1,1) encode le prior uniforme sur les poids.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "          |\r\n"
+     "text": [
+      "  - La variable latente `poids` (simplex de dimension 4) est tiree de ce prior.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "          v\r\n"
+     "text": [
+      "  - Chaque observation Discrete (choix_observes) conditionne ce prior.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  +---------------+\r\n"
+     "text": [
+      "  - Le posterior Dirichlet(2 3 1 1) traduit les 3 choix observes (index 1 dominant).\r\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": [
+       "\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_28_26_12_33_33_48.svg</div>\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (20260124.0452)\r\n",
+       " -->\r\n",
+       "<!-- Title: Model Pages: 1 -->\r\n",
+       "<svg width=\"146pt\" height=\"354pt\"\r\n",
+       " viewBox=\"0.00 0.00 146.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n",
+       "<title>Model</title>\r\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 141.5,-349.5 141.5,4 -4,4\"/>\r\n",
+       "<!-- node0 -->\r\n",
+       "<g id=\"node1\" class=\"node\">\r\n",
+       "<title>node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M84.62,-345.5C84.62,-345.5 52.88,-345.5 52.88,-345.5 46.88,-345.5 40.88,-339.5 40.88,-333.5 40.88,-333.5 40.88,-321.5 40.88,-321.5 40.88,-315.5 46.88,-309.5 52.88,-309.5 52.88,-309.5 84.62,-309.5 84.62,-309.5 90.62,-309.5 96.62,-315.5 96.62,-321.5 96.62,-321.5 96.62,-333.5 96.62,-333.5 96.62,-339.5 90.62,-345.5 84.62,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet1</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1 -->\r\n",
+       "<g id=\"node2\" class=\"node\">\r\n",
+       "<title>node1</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M83.75,-263.75C83.75,-263.75 53.75,-263.75 53.75,-263.75 47.75,-263.75 41.75,-257.75 41.75,-251.75 41.75,-251.75 41.75,-239.75 41.75,-239.75 41.75,-233.75 47.75,-227.75 53.75,-227.75 53.75,-227.75 83.75,-227.75 83.75,-227.75 89.75,-227.75 95.75,-233.75 95.75,-239.75 95.75,-239.75 95.75,-251.75 95.75,-251.75 95.75,-257.75 89.75,-263.75 83.75,-263.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node0&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge1\" class=\"edge\">\r\n",
+       "<title>node0&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M68.75,-309.59C68.75,-299.68 68.75,-286.9 68.75,-275.46\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"72.25,-275.7 68.75,-265.7 65.25,-275.7 72.25,-275.7\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"74.38\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2 -->\r\n",
+       "<g id=\"node3\" class=\"node\">\r\n",
+       "<title>node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M83.75,-190.75C83.75,-190.75 53.75,-190.75 53.75,-190.75 47.75,-190.75 41.75,-184.75 41.75,-178.75 41.75,-178.75 41.75,-166.75 41.75,-166.75 41.75,-160.75 47.75,-154.75 53.75,-154.75 53.75,-154.75 83.75,-154.75 83.75,-154.75 89.75,-154.75 95.75,-160.75 95.75,-166.75 95.75,-166.75 95.75,-178.75 95.75,-178.75 95.75,-184.75 89.75,-190.75 83.75,-190.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">poids</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1&#45;&gt;node2 -->\r\n",
+       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<title>node1&#45;&gt;node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M68.75,-227.56C68.75,-219.98 68.75,-210.85 68.75,-202.29\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"72.25,-202.29 68.75,-192.29 65.25,-202.29 72.25,-202.29\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node3 -->\r\n",
+       "<g id=\"node4\" class=\"node\">\r\n",
+       "<title>node3</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M83.75,-109C83.75,-109 53.75,-109 53.75,-109 47.75,-109 41.75,-103 41.75,-97 41.75,-97 41.75,-85 41.75,-85 41.75,-79 47.75,-73 53.75,-73 53.75,-73 83.75,-73 83.75,-73 89.75,-73 95.75,-79 95.75,-85 95.75,-85 95.75,-97 95.75,-97 95.75,-103 89.75,-109 83.75,-109\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge3\" class=\"edge\">\r\n",
+       "<title>node2&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M68.75,-154.45C68.75,-144.52 68.75,-131.81 68.75,-120.45\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"72.25,-120.78 68.75,-110.78 65.25,-120.78 72.25,-120.78\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"77.38\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4 -->\r\n",
+       "<g id=\"node5\" class=\"node\">\r\n",
+       "<title>node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M125.5,-36C125.5,-36 12,-36 12,-36 6,-36 0,-30 0,-24 0,-24 0,-12 0,-12 0,-6 6,0 12,0 12,0 125.5,0 125.5,0 131.5,0 137.5,-6 137.5,-12 137.5,-12 137.5,-24 137.5,-24 137.5,-30 131.5,-36 125.5,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">choix_observes[observations]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3&#45;&gt;node4 -->\r\n",
+       "<g id=\"edge4\" class=\"edge\">\r\n",
+       "<title>node3&#45;&gt;node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M68.75,-72.81C68.75,-65.03 68.75,-55.62 68.75,-46.86\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"72.25,-47.05 68.75,-37.05 65.25,-47.05 72.25,-47.05\"/>\r\n",
+       "</g>\r\n",
+       "</g>\r\n",
+       "</svg>\r\n",
+       "\n",
+       "    </div>\n",
+       "</div>"
+      ]
+     }
     },
     {
      "output_type": "stream",
-     "name": "stdout",
-     "text": "  |    poids      | <- Variable latente (simplex)\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  |   Vector[4]   |\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  +-------+-------+\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "          |\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "   +------+------+\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "   |      |      |\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "   v      v      v\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": " +---+  +---+  +---+\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": " |D_0|  |D_1|  |D_2| <- Observations Discrete\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": " +---+  +---+  +---+\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Posterior : Dirichlet(2 3 1 1)\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Le facteur Dirichlet encode le prior, puis chaque observation\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Discrete met a jour ce prior pour obtenir le posterior.\r\n"
+     "name": "stderr",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
     }
    ],
-   "source": [
-    "// Factor graph du modele d'apprentissage bayesien des poids\n",
-    "\n",
-    "// Recreer un modele simplifie pour illustration\n",
-    "double[] pcFG = { 1.0, 1.0, 1.0, 1.0 };\n",
-    "Variable<Vector> poidsFG = Variable.Dirichlet(pcFG).Named(\"poids\");\n",
-    "\n",
-    "int nObsFG = 3;\n",
-    "Range obsRangeFG = new Range(nObsFG).Named(\"observations\");\n",
-    "VariableArray<int> obsFG = Variable.Array<int>(obsRangeFG).Named(\"choix_observes\");\n",
-    "obsFG[obsRangeFG] = Variable.Discrete(poidsFG).ForEach(obsRangeFG);\n",
-    "obsFG.ObservedValue = new[] { 0, 1, 1 };\n",
-    "\n",
-    "var enginePoidsFG = new InferenceEngine();\n",
-    "enginePoidsFG.Compiler.CompilerChoice = Microsoft.ML.Probabilistic.Compiler.CompilerChoice.Roslyn;\n",
-    "\n",
-    "try\n",
-    "{\n",
-    "    // Note: ShowFactorGraph peut causer un crash du kernel, on le desactive\n",
-    "    // enginePoidsFG.ShowFactorGraph = true;\n",
-    "    var resultFG = enginePoidsFG.Infer<Dirichlet>(poidsFG);\n",
-    "\n",
-    "    Console.WriteLine(\"Structure du modele bayesien des poids :\");\n",
-    "    Console.WriteLine();\n",
-    "    Console.WriteLine(\"  +---------------+\");\n",
-    "    Console.WriteLine(\"  |    Dirichlet  | <- Prior sur les poids\");\n",
-    "    Console.WriteLine(\"  |   (1,1,1,1)   |\");\n",
-    "    Console.WriteLine(\"  +-------+-------+\");\n",
-    "    Console.WriteLine(\"          |\");\n",
-    "    Console.WriteLine(\"          v\");\n",
-    "    Console.WriteLine(\"  +---------------+\");\n",
-    "    Console.WriteLine(\"  |    poids      | <- Variable latente (simplex)\");\n",
-    "    Console.WriteLine(\"  |   Vector[4]   |\");\n",
-    "    Console.WriteLine(\"  +-------+-------+\");\n",
-    "    Console.WriteLine(\"          |\");\n",
-    "    Console.WriteLine(\"   +------+------+\");\n",
-    "    Console.WriteLine(\"   |      |      |\");\n",
-    "    Console.WriteLine(\"   v      v      v\");\n",
-    "    Console.WriteLine(\" +---+  +---+  +---+\");\n",
-    "    Console.WriteLine(\" |D_0|  |D_1|  |D_2| <- Observations Discrete\");\n",
-    "    Console.WriteLine(\" +---+  +---+  +---+\");\n",
-    "    Console.WriteLine();\n",
-    "    Console.WriteLine($\"Posterior : {resultFG}\");\n",
-    "    Console.WriteLine();\n",
-    "    Console.WriteLine(\"Le facteur Dirichlet encode le prior, puis chaque observation\");\n",
-    "    Console.WriteLine(\"Discrete met a jour ce prior pour obtenir le posterior.\");\n",
-    "}\n",
-    "catch (Exception ex)\n",
-    "{\n",
-    "    Console.WriteLine($\"Erreur lors de l'inference : {ex.Message}\");\n",
-    "}"
-   ]
+   "source": "// Factor graph du modele d'apprentissage bayesien des poids\n\n// Recreer un modele simplifie pour illustration\ndouble[] pcFG = { 1.0, 1.0, 1.0, 1.0 };\nVariable<Vector> poidsFG = Variable.Dirichlet(pcFG).Named(\"poids\");\n\nint nObsFG = 3;\nRange obsRangeFG = new Range(nObsFG).Named(\"observations\");\nVariableArray<int> obsFG = Variable.Array<int>(obsRangeFG).Named(\"choix_observes\");\nobsFG[obsRangeFG] = Variable.Discrete(poidsFG).ForEach(obsRangeFG);\nobsFG.ObservedValue = new[] { 0, 1, 1 };\n\nvar enginePoidsFG = new InferenceEngine();\nenginePoidsFG.Compiler.CompilerChoice = Microsoft.ML.Probabilistic.Compiler.CompilerChoice.Roslyn;\n\n// Rendu SVG reel du factor graph via Graphviz (meme demarche que Infer-3 / Infer-4).\n// Infer.NET ecrit le fichier .gv ; FactorGraphHelper le convertit en SVG via l'outil `dot`.\nenginePoidsFG.ShowFactorGraph = true;\nvar resultFG = enginePoidsFG.Infer<Dirichlet>(poidsFG);\n\nConsole.WriteLine(\"Structure du modele bayesien des poids (rendu SVG ci-dessous).\");\nConsole.WriteLine();\nConsole.WriteLine($\"Posterior : {resultFG}\");\nConsole.WriteLine();\nConsole.WriteLine(\"Lecture du factor graph :\");\nConsole.WriteLine(\"  - Le noeud Dirichlet (1,1,1,1) encode le prior uniforme sur les poids.\");\nConsole.WriteLine(\"  - La variable latente `poids` (simplex de dimension 4) est tiree de ce prior.\");\nConsole.WriteLine(\"  - Chaque observation Discrete (choix_observes) conditionne ce prior.\");\nConsole.WriteLine(\"  - Le posterior Dirichlet(2 3 1 1) traduit les 3 choix observes (index 1 dominant).\");\n\ndisplay(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
   },
   {
    "cell_type": "markdown",
@@ -3669,7 +4207,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "A implementer : modelisation Infer.NET des attributs incertains, propagation de l incertitude vers V.\r\n"
+     "text": [
+      "A implementer : modelisation Infer.NET des attributs incertains, propagation de l incertitude vers V.\r\n"
+     ]
     }
    ],
    "source": [

--- a/scripts/notebook_tools/exec_dotnet_persist.py
+++ b/scripts/notebook_tools/exec_dotnet_persist.py
@@ -45,6 +45,9 @@ def execute_and_persist(notebook_path: str, timeout_per_cell: int = 120):
 
         cell['outputs'] = []
         executed += 1
+        # Assign cell-level execution_count (C.2: every executed code cell needs a
+        # coherent int). Previously omitted, so re-exec left counts stale / None.
+        cell['execution_count'] = executed
         print(f"  Cell {i}: ", end='', flush=True)
         t0 = time.time()
 


### PR DESCRIPTION
## Summary

`Infer-16-Decision-Multi-Attribute` cell 47 hardcoded an ASCII-art factor graph and commented out Infer.NET's real Graphviz render (`ShowFactorGraph`) with a warning that it "peut causer un crash du kernel". This replaces it with the real SVG render, the same pattern already proven in sibling notebooks.

Plus a 3-line fix to the `.NET` cell-by-cell executor that this re-exec surfaced.

## SOTA verdict (EPIC #3801, axe-2): RECOVERABLE-LOCAL

The "crash kernel" warning was **stale**. Firsthand proof that the real render path works without crash:

| Notebook | Cells using `ShowFactorGraph=true` + `display(HTML(GetLatestFactorGraphHtml()))` | Real SVG? |
|----------|-----------------------------------------------------------------------------------|-----------|
| **Infer-3** | cell 18 | yes |
| **Infer-4** | cells 11/13, 18/20, 24/26, 48/50, 56/58 | yes |
| **Infer-16** (before) | commented out + ASCII art | no (degraded) |
| **Infer-16** (after) | cell 47 (this PR) | **yes** |

- `dot` now installed (choco Graphviz v14.1.2); cell 4 reports `Graphviz disponible : True` (was the **only** Infer notebook reporting `False`).
- Cell 47 renders the real Infer.NET factor graph as inline SVG: `Dirichlet(1,1,1,1)` prior → `poids` latent (simplex) → 3 `choix_observes` Discrete observations.

## Changes

1. **`Infer-16-...ipynb` cell 47** — removed ASCII `Console.WriteLine` box-art + the commented `ShowFactorGraph`; enabled `enginePoidsFG.ShowFactorGraph = true;` and added `display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));` (proven Infer-3/4 pattern). Kept the textual factor-graph reading as prose.
2. **`scripts/notebook_tools/exec_dotnet_persist.py`** — assign `cell['execution_count']` (was never set, so re-exec left counts stale/None → C.2 latent bug on every `.NET` re-exec).

## Validation

Re-executed end-to-end on `.net-csharp` (cell-by-cell persistent executor, CWD = notebook dir):

```
Done: 23 cells executed, 0 errors
exec_counts: [1..23] (None: 0), error outputs: 0
cell47: exec_count=22, display_data text/html len=5251, has_svg=True, has_node=True, ascii_boxes=0
        referenced svg file: Model_06_28_26_12_33_33_48.svg
```

- **C.1**: 0 `raise NotImplementedError`, 0 `assert False`, 0 `1/0`.
- **C.2**: all 23 code cells `execution_count` 1..23 + coherent outputs; cell 47 real SVG.
- **C.3**: only cell 47 source changed (2 source-line hunks). Other cells `src_chg=False`, first-stream outputs identical (verified cell 6/10/18/38 parity). Diff includes benign NuGet-install display capture + stream line-splitting normalization from the fresh re-exec.
- Anti-regression: no substantive deletions (ASCII art + reformatted streams only).

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)