### PR TITLE
docs(pymc): resync README — fil rouge #3801 modèles hiérarchiques / MCMC nécessaire

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -35,6 +35,22 @@ flowchart LR
 
 Le **même** modèle probabiliste (à gauche) se résout par deux moteurs radicalement différents : l'échantillonnage MCMC de PyMC (stochastique, convergent, flexible) ou le message passing d'Infer.NET (déterministe, analytique, restreint aux conjugués). La série parcourt les 20 mêmes modèles des deux côtés pour rendre ce compromis **visible**.
 
+## Quand le MCMC devient nécessaire : modèles hiérarchiques et partial pooling
+
+Un modèle conjugué simple (Beta-Bernoulli, Normal-Normal) admet une **postérieure analytique** : le MCMC est alors redondant — un `numpy.random` bien placé reproduit la même distribution, et des diagnostics parfaits (R-hat ≈ 1.000, ESS ≈ 8000) ne prouvent rien d'autre que la facilité du problème. La valeur distinctive de PyMC n'apparaît que sur des modèles **sans solution analytique**, là où le couple (prior, vraisemblance observée) définit une postérieure jointe que seul l'échantillonnage peut explorer.
+
+Le cas paradigmatique est le **modèle hiérarchique à effets aléatoires** : plusieurs groupes (sites, pièces, patients, workers) partagent une moyenne de population et une dispersion, et chaque groupe « emprunte » de l'information aux autres. C'est le **partial pooling**. Sa signature visible est le **shrinkage** — les groupes sous-échantillonnés sont tirés vers la moyenne de population plutôt qu'estimés isolément à zéro, un comportement qu'aucune mise à jour conjuguée indépendante ne reproduit.
+
+La série illustre ce fil rouge sur plusieurs notebooks, chacun sur un cas non-conjugué distinct :
+
+- [PyMC-1-Setup](PyMC-1-Setup.ipynb) — introduction : du Beta-Bernoulli conjugué (où MCMC = prior) à un modèle hiérarchique non-centré sur plusieurs pièces, où le shrinkage devient visible.
+- [PyMC-11-Sequences](PyMC-11-Sequences.ipynb) — HMM à états cachés : la vraisemblance de mélange (`NormalMixture`) marginalise l'assignation discrète pour garder un NUTS pur sur les paramètres continus.
+- [PyMC-14-Decision-Utility-Foundations](PyMC-14-Decision-Utility-Foundations.ipynb) — diagnostic multi-sites : un portefeuille de groupes hétérogènes où le partial pooling régularise les estimations à faible effectif.
+- [PyMC-17-Decision-Networks](PyMC-17-Decision-Networks.ipynb) — états latents : prévalence réelle d'un phénomène observé via un test imparfait (inversion d'état caché, non-conjuguée).
+- [PyMC-19-Decision-Expert-Systems](PyMC-19-Decision-Expert-Systems.ipynb) — recette de référence : paramétrisation **non-centrée** (offsets de Neal) qui évite le funnel et stabilise la convergence.
+
+> **Leçon technique récurrente** : sur ces modèles, la **paramétrisation non-centrée** `θ = μ + σ · z` (avec `z ~ Normal(0,1)`) est souvent indispensable. Elle découple l'estimation de la moyenne de celle de la dispersion et évite le *funnel de Neal* — une pathologie géométrique qui piège l'échantillonneur quand la dispersion inter-groupes est faible. Le réflexe naïf « augmenter `target_accept` » **aggrave** alors les divergences ; c'est la reparamétrisation, pas la tolérance, qui débloque la convergence. Voir [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) pour les diagnostics associés.
+
 ## Objectifs d'apprentissage
 
 A l'issue de cette série, vous serez capable de :
@@ -49,7 +65,7 @@ A l'issue de cette série, vous serez capable de :
 
 | # | Notebook | Durée | Concepts |
 |---|----------|-------|----------|
-| 1 | [PyMC-1-Setup](PyMC-1-Setup.ipynb) | 15 min | Installation, premier modèle Beta-Bernoulli |
+| 1 | [PyMC-1-Setup](PyMC-1-Setup.ipynb) | 15 min | Installation, Beta-Bernoulli, modèle hiérarchique non-centré |
 | 2 | [PyMC-2-Gaussian-Mixtures](PyMC-2-Gaussian-Mixtures.ipynb) | 50 min | Postérieurs, mélanges, Dirichlet |
 | 3 | [PyMC-3-Factor-Graphs](PyMC-3-Factor-Graphs.ipynb) | 45 min | Inférence discrète, Monty Hall |
 | 4 | [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) | 55 min | CPT, D-separation, causalite |
@@ -59,13 +75,13 @@ A l'issue de cette série, vous serez capable de :
 | 8 | [PyMC-8-Model-Selection](PyMC-8-Model-Selection.ipynb) | 45 min | Evidence, Bayes factors, ARD |
 | 9 | [PyMC-9-Topic-Models](PyMC-9-Topic-Models.ipynb) | 60 min | LDA, Dirichlet, documents-topics-mots |
 | 10 | [PyMC-10-Crowdsourcing](PyMC-10-Crowdsourcing.ipynb) | 55 min | Workers, communautés, agrégation de labels |
-| 11 | [PyMC-11-Sequences](PyMC-11-Sequences.ipynb) | 65 min | HMM, séries temporelles, motifs |
+| 11 | [PyMC-11-Sequences](PyMC-11-Sequences.ipynb) | 65 min | HMM, mélange `NormalMixture`, séries temporelles |
 | 12 | [PyMC-12-Recommenders](PyMC-12-Recommenders.ipynb) | 60 min | Factorisation de matrices, recommandation |
 | 13 | [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) | 45 min | Troubleshooting, diagnostics NUTS, convergence |
-| 14 | [PyMC-14-Décision-Utility-Foundations](PyMC-14-Decision-Utility-Foundations.ipynb) | 50 min | Loteries, axiomes VNM, utilité espérée |
+| 14 | [PyMC-14-Décision-Utility-Foundations](PyMC-14-Decision-Utility-Foundations.ipynb) | 50 min | Loteries, axiomes VNM, diagnostic hiérarchique multi-sites |
 | 15 | [PyMC-15-Décision-Utility-Money](PyMC-15-Decision-Utility-Money.ipynb) | 45 min | Paradoxe St-Petersbourg, CARA, CRRA |
 | 16 | [PyMC-16-Décision-Multi-Attribute](PyMC-16-Decision-Multi-Attribute.ipynb) | 50 min | MAUT, SMART, swing weights |
-| 17 | [PyMC-17-Décision-Networks](PyMC-17-Decision-Networks.ipynb) | 55 min | Diagrammes d'influence, politique optimale |
+| 17 | [PyMC-17-Décision-Networks](PyMC-17-Decision-Networks.ipynb) | 55 min | Diagrammes d'influence, prévalence à test imparfait (état latent) |
 | 18 | [PyMC-18-Décision-Value-Information](PyMC-18-Decision-Value-Information.ipynb) | 45 min | EVPI, EVSI, valeur de l'information |
 | 19 | [PyMC-19-Décision-Expert-Systems](PyMC-19-Decision-Expert-Systems.ipynb) | 50 min | Systèmes experts, Minimax, regret |
 | 20 | [PyMC-20-Décision-Sequential](PyMC-20-Decision-Sequential.ipynb) | 60 min | MDPs, bandits, POMDPs |


### PR DESCRIPTION
## Contexte — #3974 (READMEs feuilles, owner po-2025:CoursIA)

Driver de l'issue : « Refléter l'état courant réel : enrichissements PyMC/axe-2 #3801 ». Le README PyMC ne mentionnait pas le fil conducteur #3801 (SOTA Prong-B) qui traverse désormais 5 notebooks.

## G.1 — drift vérifié firsthand sur origin/main frais (worktree off 75d2f7693)

| Notebook | hier_kw | observed= | pm.sample | Verdict |
|----------|---------|-----------|-----------|---------|
| PyMC-1 | 17 | 4 | 6 | modèle hiérarchique non-centré (#4423) |
| PyMC-11 | 10 | 1 | 1 | NormalMixture HMM (#4098) |
| PyMC-14 | 23 | 2 | 4 | diagnostic hiérarchique multi-sites (#4100) |
| PyMC-17 | 10 | 3 | 2 | prévalence/test imparfait (#4107) |
| PyMC-19 | 35 | 2 | 2 | recette canonique non-centrée (#3991) |

(PyMC-18 délibérément **non mentionné** : son fix #4513 est en attente de merge — `observed=0` sur main, dégénéré.)

## Changements (FR-first, contenu informatif pas décompte)

1. **Nouvelle section** « Quand le MCMC devient nécessaire : modèles hiérarchiques et partial pooling » — explique pourquoi le MCMC est redondant sur un conjugué (posterior=prior, R-hat trivial) et nécessaire sur les modèles sans solution analytique ; signature du shrinkage ; pointe vers les 5 notebooks ci-dessus ; leçon technique non-centrage/funnel de Neal (le réflexe naïf « augmenter target_accept » aggrave les divergences).
2. **Table Concepts** mise à jour pour PyMC-1/11/14/17.

## Qualité

- Marqueurs `CATALOG-STATUS` **inchangés** (catalog-pr-hygiene règle 1).
- Diff atomique : +20/-4, 1 fichier. 0 secret, 0 lien cassé.
- README = markdown-only (exception C.2, pas de re-exec).
- Coquille « réflexe naïf » corrigée (masculin).

See #3973 (partiel — Epic READMEs feuilles ascendant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)