### PR TITLE
feat(lean): conway P4.3 wave-2 IH PROVEN — sorry 5->4 (#3846, consume gate lemma #4519)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1775,6 +1775,44 @@ private theorem p4_wave1_ih_step
                                     hnw_se_w hne_sw_w hsw_ne_w hse_nw_w
   exact ih (node nw_se ne_sw sw_ne se_nw) (k - 1) (by omega) hn5.2 (by omega)
 
+/-- **P4.3 helper (c.142/c.139 pattern).** Wave-1 result facts for one sub-cell
+    `n` (a double-nine `n_i`): `n`'s level-`(k+1)` well-formedness yields, via the
+    proven preservation lemma `hashlifeResultAux_level_cellWf`, that the wave-1
+    result `hashlifeResultAux (k+1) n` has level `k` and `cellWf`. `n` is an
+    OPAQUE binder here so the `hashlifeResultAux` term in the conclusion does not
+    whnf-reduce (calling the preservation lemma inline, with `n` spelled out as a
+    `node` of grandchildren, makes the elaborator whnf the conclusion's nested
+    `hashlifeResultAux` term — divergent). -/
+private theorem wave1_result_facts (k : Nat) (hk1 : 1 ≤ k) (n : MacroCell)
+    (hn_wf : n.wf = true) (hn_lvl : n.level = k + 1) :
+    (hashlifeResultAux (k + 1) n).level = k ∧ cellWf (hashlifeResultAux (k + 1) n) := by
+  have hcn := cellWf_of_wf n hn_wf
+  exact hashlifeResultAux_level_cellWf (k + 1) n hcn hn_lvl (by omega)
+
+/-- **P4.3 helper (wave 2).** The `ih` *application*
+    `ih (node r1 r2 r4 r5) (k - 1) ...` for the NW super-cell `q_nw`
+    (`= node r1 r2 r4 r5`, the four wave-1 results `r_i`), done in a standalone
+    helper so the four `r_i` are opaque binders at the application site —
+    same whnf-isolation pattern as `p4_wave1_ih_step` (c.139). The `r_i` are
+    `hashlifeResultAux` results whose level (`k`) and `cellWf` are established
+    by the proven preservation lemma `hashlifeResultAux_level_cellWf` (c.142),
+    then bridged to `.wf = true` for the central-correctness `ih` (which is on
+    `.wf`). `q_nw` is taken as representative (the three other super-cells are
+    isomorphic, queued). -/
+private theorem p4_wave2_ih_step
+    (k : Nat) (hk1 : 1 ≤ k)
+    (r1 r2 r4 r5 : MacroCell)
+    (hr1_l : r1.level = k) (hr2_l : r2.level = k)
+    (hr4_l : r4.level = k) (hr5_l : r5.level = k)
+    (hr1_w : r1.wf = true) (hr2_w : r2.wf = true)
+    (hr4_w : r4.wf = true) (hr5_w : r5.wf = true)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j) :
+    centralCorrect (node r1 r2 r4 r5) (k - 1) := by
+  have hq := node_wf_level_of_four hr1_l hr2_l hr4_l hr5_l
+                                    hr1_w hr2_w hr4_w hr5_w
+  exact ih (node r1 r2 r4 r5) (k - 1) (by omega) hq.2 (by omega)
+
 /-- **P4.2** (IH application, wave 1): for the center sub-cell
     `n5 = node nw_se ne_sw sw_ne se_nw` of the double-nine decomposition,
     `hashlifeResultAux (k+1) n5` agrees with `evolve (2^(k-1))` on `n5`'s
@@ -1816,8 +1854,55 @@ theorem p4_wave1_ih
     (mechanical IH, structurally identical to P4.2 — may factor through a
     common helper). -/
 theorem p4_wave2_ih
-    (c : MacroCell) (k : Nat) (hwf : c.wf = true) (hk : c.level = k + 2) : True := by
-  sorry
+    (c : MacroCell) (k : Nat) (hwf : c.wf = true) (hk : c.level = k + 2) (hk1 : 1 ≤ k)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j) :
+    ∃ nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+       sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se : MacroCell,
+      c = node (node nw_nw nw_ne nw_sw nw_se)
+               (node ne_nw ne_ne ne_sw ne_se)
+               (node sw_nw sw_ne sw_sw sw_se)
+               (node se_nw se_ne se_sw se_se) ∧
+      centralCorrect
+        (node (hashlifeResultAux (k + 1) (node nw_nw nw_ne nw_sw nw_se))
+              (hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
+              (hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
+              (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw)))
+        (k - 1) := by
+  obtain ⟨nw_nw, nw_ne, nw_sw, nw_se, ne_nw, ne_ne, ne_sw, ne_se,
+          sw_nw, sw_ne, sw_sw, sw_se, se_nw, se_ne, se_sw, se_se, rfl, hgrands⟩ :=
+    p4_double_nine_shape c k hwf hk
+  obtain ⟨hnw_nw_l, hnw_nw_w, hnw_ne_l, hnw_ne_w, hnw_sw_l, hnw_sw_w, hnw_se_l, hnw_se_w,
+          hne_nw_l, hne_nw_w, hne_ne_l, hne_ne_w, hne_sw_l, hne_sw_w, hne_se_l, hne_se_w,
+          hsw_nw_l, hsw_nw_w, hsw_ne_l, hsw_ne_w, hsw_sw_l, hsw_sw_w, hsw_se_l, hsw_se_w,
+          hse_nw_l, hse_nw_w, hse_ne_l, hse_ne_w, hse_sw_l, hse_sw_w, hse_se_l, hse_se_w⟩ :=
+    hgrands
+  -- n1 = node nw_nw nw_ne nw_sw nw_se: level+wf, then preservation (c.142) -> r1 facts.
+  have hq1 := node_wf_level_of_four hnw_nw_l hnw_ne_l hnw_sw_l hnw_se_l
+                                    hnw_nw_w hnw_ne_w hnw_sw_w hnw_se_w
+  have hr1 := wave1_result_facts k hk1 (node nw_nw nw_ne nw_sw nw_se) hq1.2 hq1.1
+  -- n2 = node nw_ne ne_nw nw_se ne_sw
+  have hq2 := node_wf_level_of_four hnw_ne_l hne_nw_l hnw_se_l hne_sw_l
+                                    hnw_ne_w hne_nw_w hnw_se_w hne_sw_w
+  have hr2 := wave1_result_facts k hk1 (node nw_ne ne_nw nw_se ne_sw) hq2.2 hq2.1
+  -- n4 = node nw_sw nw_se sw_nw sw_ne
+  have hq4 := node_wf_level_of_four hnw_sw_l hnw_se_l hsw_nw_l hsw_ne_l
+                                    hnw_sw_w hnw_se_w hsw_nw_w hsw_ne_w
+  have hr4 := wave1_result_facts k hk1 (node nw_sw nw_se sw_nw sw_ne) hq4.2 hq4.1
+  -- n5 = node nw_se ne_sw sw_ne se_nw
+  have hq5 := node_wf_level_of_four hnw_se_l hne_sw_l hsw_ne_l hse_nw_l
+                                    hnw_se_w hne_sw_w hsw_ne_w hse_nw_w
+  have hr5 := wave1_result_facts k hk1 (node nw_se ne_sw sw_ne se_nw) hq5.2 hq5.1
+  refine ⟨nw_nw, nw_ne, nw_sw, nw_se, ne_nw, ne_ne, ne_sw, ne_se,
+          sw_nw, sw_ne, sw_sw, sw_se, se_nw, se_ne, se_sw, se_se, rfl, ?_⟩
+  exact p4_wave2_ih_step k hk1
+          (hashlifeResultAux (k + 1) (node nw_nw nw_ne nw_sw nw_se))
+          (hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
+          (hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
+          (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+          hr1.1 hr2.1 hr4.1 hr5.1
+          (wf_of_cellWf hr1.2) (wf_of_cellWf hr2.2)
+          (wf_of_cellWf hr4.2) (wf_of_cellWf hr5.2) ih
 
 /-- **P4.4** (compositional, hardest): the two half-steps compose — wave 1
     (advancing `2^(k-1)` generations) followed by wave 2 (another `2^(k-1)`)
@@ -1843,7 +1928,7 @@ noncomputable def p4_succ_membership
         p ∈ restrictGridTo (evolve (2^k) (c.toGrid (0, 0))) (2^k : Int) (2^(k+1)) := by
   have _h1 := p4_double_nine_shape c k hwf hk
   have _h2 := p4_wave1_ih c k hwf hk hk1 ih
-  have _h3 := p4_wave2_ih c k hwf hk
+  have _h3 := p4_wave2_ih c k hwf hk hk1 ih
   have _h4 := p4_half_steps_compose c k hwf hk
   intro p
   sorry

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1868,6 +1868,24 @@ theorem p4_wave2_ih
               (hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
               (hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
               (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw)))
+        (k - 1) ∧
+      centralCorrect
+        (node (hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
+              (hashlifeResultAux (k + 1) (node ne_nw ne_ne ne_sw ne_se))
+              (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+              (hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne)))
+        (k - 1) ∧
+      centralCorrect
+        (node (hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
+              (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+              (hashlifeResultAux (k + 1) (node sw_nw sw_ne sw_sw sw_se))
+              (hashlifeResultAux (k + 1) (node sw_ne se_nw sw_se se_sw)))
+        (k - 1) ∧
+      centralCorrect
+        (node (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+              (hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne))
+              (hashlifeResultAux (k + 1) (node sw_ne se_nw sw_se se_sw))
+              (hashlifeResultAux (k + 1) (node se_nw se_ne se_sw se_se)))
         (k - 1) := by
   obtain ⟨nw_nw, nw_ne, nw_sw, nw_se, ne_nw, ne_ne, ne_sw, ne_se,
           sw_nw, sw_ne, sw_sw, sw_se, se_nw, se_ne, se_sw, se_se, rfl, hgrands⟩ :=
@@ -1885,6 +1903,10 @@ theorem p4_wave2_ih
   have hq2 := node_wf_level_of_four hnw_ne_l hne_nw_l hnw_se_l hne_sw_l
                                     hnw_ne_w hne_nw_w hnw_se_w hne_sw_w
   have hr2 := wave1_result_facts k hk1 (node nw_ne ne_nw nw_se ne_sw) hq2.2 hq2.1
+  -- n3 = node ne_nw ne_ne ne_sw ne_se
+  have hq3 := node_wf_level_of_four hne_nw_l hne_ne_l hne_sw_l hne_se_l
+                                    hne_nw_w hne_ne_w hne_sw_w hne_se_w
+  have hr3 := wave1_result_facts k hk1 (node ne_nw ne_ne ne_sw ne_se) hq3.2 hq3.1
   -- n4 = node nw_sw nw_se sw_nw sw_ne
   have hq4 := node_wf_level_of_four hnw_sw_l hnw_se_l hsw_nw_l hsw_ne_l
                                     hnw_sw_w hnw_se_w hsw_nw_w hsw_ne_w
@@ -1893,16 +1915,60 @@ theorem p4_wave2_ih
   have hq5 := node_wf_level_of_four hnw_se_l hne_sw_l hsw_ne_l hse_nw_l
                                     hnw_se_w hne_sw_w hsw_ne_w hse_nw_w
   have hr5 := wave1_result_facts k hk1 (node nw_se ne_sw sw_ne se_nw) hq5.2 hq5.1
+  -- n6 = node ne_sw ne_se se_nw se_ne
+  have hq6 := node_wf_level_of_four hne_sw_l hne_se_l hse_nw_l hse_ne_l
+                                    hne_sw_w hne_se_w hse_nw_w hse_ne_w
+  have hr6 := wave1_result_facts k hk1 (node ne_sw ne_se se_nw se_ne) hq6.2 hq6.1
+  -- n7 = node sw_nw sw_ne sw_sw sw_se
+  have hq7 := node_wf_level_of_four hsw_nw_l hsw_ne_l hsw_sw_l hsw_se_l
+                                    hsw_nw_w hsw_ne_w hsw_sw_w hsw_se_w
+  have hr7 := wave1_result_facts k hk1 (node sw_nw sw_ne sw_sw sw_se) hq7.2 hq7.1
+  -- n8 = node sw_ne se_nw sw_se se_sw
+  have hq8 := node_wf_level_of_four hsw_ne_l hse_nw_l hsw_se_l hse_sw_l
+                                    hsw_ne_w hse_nw_w hsw_se_w hse_sw_w
+  have hr8 := wave1_result_facts k hk1 (node sw_ne se_nw sw_se se_sw) hq8.2 hq8.1
+  -- n9 = node se_nw se_ne se_sw se_se
+  have hq9 := node_wf_level_of_four hse_nw_l hse_ne_l hse_sw_l hse_se_l
+                                    hse_nw_w hse_ne_w hse_sw_w hse_se_w
+  have hr9 := wave1_result_facts k hk1 (node se_nw se_ne se_sw se_se) hq9.2 hq9.1
   refine ⟨nw_nw, nw_ne, nw_sw, nw_se, ne_nw, ne_ne, ne_sw, ne_se,
-          sw_nw, sw_ne, sw_sw, sw_se, se_nw, se_ne, se_sw, se_se, rfl, ?_⟩
-  exact p4_wave2_ih_step k hk1
-          (hashlifeResultAux (k + 1) (node nw_nw nw_ne nw_sw nw_se))
-          (hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
-          (hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
-          (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
-          hr1.1 hr2.1 hr4.1 hr5.1
-          (wf_of_cellWf hr1.2) (wf_of_cellWf hr2.2)
-          (wf_of_cellWf hr4.2) (wf_of_cellWf hr5.2) ih
+          sw_nw, sw_ne, sw_sw, sw_se, se_nw, se_ne, se_sw, se_se, rfl, ?_, ?_, ?_, ?_⟩
+  · -- q_nw = node r1 r2 r4 r5
+    exact p4_wave2_ih_step k hk1
+            (hashlifeResultAux (k + 1) (node nw_nw nw_ne nw_sw nw_se))
+            (hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
+            (hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
+            (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+            hr1.1 hr2.1 hr4.1 hr5.1
+            (wf_of_cellWf hr1.2) (wf_of_cellWf hr2.2)
+            (wf_of_cellWf hr4.2) (wf_of_cellWf hr5.2) ih
+  · -- q_ne = node r2 r3 r5 r6
+    exact p4_wave2_ih_step k hk1
+            (hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
+            (hashlifeResultAux (k + 1) (node ne_nw ne_ne ne_sw ne_se))
+            (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+            (hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne))
+            hr2.1 hr3.1 hr5.1 hr6.1
+            (wf_of_cellWf hr2.2) (wf_of_cellWf hr3.2)
+            (wf_of_cellWf hr5.2) (wf_of_cellWf hr6.2) ih
+  · -- q_sw = node r4 r5 r7 r8
+    exact p4_wave2_ih_step k hk1
+            (hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
+            (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+            (hashlifeResultAux (k + 1) (node sw_nw sw_ne sw_sw sw_se))
+            (hashlifeResultAux (k + 1) (node sw_ne se_nw sw_se se_sw))
+            hr4.1 hr5.1 hr7.1 hr8.1
+            (wf_of_cellWf hr4.2) (wf_of_cellWf hr5.2)
+            (wf_of_cellWf hr7.2) (wf_of_cellWf hr8.2) ih
+  · -- q_se = node r5 r6 r8 r9
+    exact p4_wave2_ih_step k hk1
+            (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+            (hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne))
+            (hashlifeResultAux (k + 1) (node sw_ne se_nw sw_se se_sw))
+            (hashlifeResultAux (k + 1) (node se_nw se_ne se_sw se_se))
+            hr5.1 hr6.1 hr8.1 hr9.1
+            (wf_of_cellWf hr5.2) (wf_of_cellWf hr6.2)
+            (wf_of_cellWf hr8.2) (wf_of_cellWf hr9.2) ih
 
 /-- **P4.4** (compositional, hardest): the two half-steps compose — wave 1
     (advancing `2^(k-1)` generations) followed by wave 2 (another `2^(k-1)`)


### PR DESCRIPTION
## Summary

Proves **`p4_wave2_ih`** (P4.3) — the wave-2 induction-hypothesis application — for **all four super-cells** of the double-nine, consuming the preservation lemma `hashlifeResultAux_level_cellWf` merged in #4519 (c.142). **Sorry 5 → 4.** Lane #3846 (Conway Hashlife correctness) now has P4.1, P4.2, P4.3 proven.

For the level-`(k+2)` cell `c`, `p4_wave2_ih` produces `centralCorrect q_* (k-1)` for each of:
- `q_nw = node r1 r2 r4 r5`
- `q_ne = node r2 r3 r5 r6`
- `q_sw = node r4 r5 r7 r8`
- `q_se = node r5 r6 r8 r9`

(the four super-cells built from wave-1 results `r_i = hashlifeResultAux (k+1) n_i`), under the central-correctness induction hypothesis.

This closes the wave-2 layer that P4.2's wave-1 proof (c.139, #4438) could not reach: P4.2 proves `centralCorrect n5 (k-1)` for the center sub-cell of *grandchildren*; P4.3 proves `centralCorrect q_* (k-1)` for the super-cells of wave-1 *results*, whose level (`k`) and well-formedness only the c.142 preservation lemma can establish. The four super-cells are needed because the `p4_succ_membership` glue reasons about the output `node out_nw out_ne out_sw out_se` (each `out_* = hashlifeResultAux fuel q_*`).

## Approach (reuses c.139 whnf-isolation at two layers)

- **`wave1_result_facts`**: for one sub-cell `n` (**opaque binder**), applies the global proven lemma `hashlifeResultAux_level_cellWf` to derive `(hashlifeResultAux (k+1) n).level = k ∧ cellWf (...)`. Isolating this call is required: calling the preservation lemma inline, with `n` spelled out as a `node` of grandchildren, makes the elaborator whnf the conclusion's nested `hashlifeResultAux` term (the node constructor is matched by `hashlifeResultAux`'s pattern) — divergent. The opaque binder stops it.
- **`p4_wave2_ih_step`**: applies the `centralCorrect` ih to one super-cell with the four wave-1 results as opaque binders (isomorphic to `p4_wave1_ih_step`, c.139).
- **`p4_wave2_ih` body**: obtains the 16 grandchildren from `p4_double_nine_shape`, derives all nine `n1..n9` level+wf via `node_wf_level_of_four` (all 16 grandchildren are destructured), the nine wave-1 result facts via `wave1_result_facts`, bridges `cellWf` → `.wf = true` via `wf_of_cellWf`, then delegates each super-cell to `p4_wave2_ih_step`.
- **`p4_succ_membership` call site** updated to pass `hk1`/`ih`.

## §B Lean review payload

| Item | Value |
|------|-------|
| `grep -c sorry` before | 5 |
| `grep -c sorry` after  | 4 |
| Net Δ | **−1** (the `p4_wave2_ih` placeholder is now a real theorem, all 4 super-cells) |
| `lake build Conway.Life.HashlifeCorrectness` | **EXIT 0** |
| Axiom check | 0 `sorry`/`sorryAx` in new code; standard Mathlib axioms only |
| Commits | 2: (1) P4.3 wave-2 IH proven for q_nw, (2) complete all 4 super-cells (isomorphic) |

Sorry regex (token grep, authoritative per G.2): `^\s*sorry\s*$|:= by sorry|:= sorry\b|exact sorry|^\s*· sorry`. The 4 remaining sorries: `p4_half_steps_compose` (P4.4, compositional light-cone, research-level), `p4_succ_membership` glue biconditional, and the two P5 lemmas (gated on P4 completion).

## Scope (honest, G.3)

- ✅ **Proven**: `p4_wave2_ih` for ALL four super-cells, + supporting helpers (`wave1_result_facts`, `p4_wave2_ih_step`).
- ⏳ **Not done**: P4.4 (`p4_half_steps_compose`, compositional light-cone — research-level statement design) and the `p4_succ_membership` glue remain. P5 (2 sorries) gated on P4. With all four super-cells now covered, the glue is closer (it needs `centralCorrect` for every `out_*`'s input super-cell — now available), but still gated on the half-step composition / light-cone argument.

See #3846
