### PR TITLE
docs(playwright-owui): P1 — notebook chapeau 00-Parcours-QA-OWUI.ipynb (#4433)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/00-Parcours-QA-OWUI.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/00-Parcours-QA-OWUI.ipynb
@@ -1,0 +1,566 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Parcours QA-OWUI — Notebook chapeau de la mission\n",
+    "\n",
+    "> **Phase 1 de la refonte #4433.** Ce notebook est le **poste de pilotage** du parcours : il porte la narration de la mission, inventorie et orchestre la suite de tests E2E (Playwright) depuis ses cellules, apprend à interpréter les résultats, et propose des exercices exécutables. Le cadrage complet (fil rouge, carte de mission, capstone, acquis d'apprentissage) est dans **[00-Parcours-QA-OWUI.md](./00-Parcours-QA-OWUI.md)**.\n",
+    "\n",
+    "[← Documentation GenAI](../README.md) | [Série Playwright-OWUI](./README.md) | [Cadrage de la mission](./00-Parcours-QA-OWUI.md)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Comment lire ce notebook.** Les cellules de code sont **pur-Python (bibliothèque standard)** : elles s'exécutent sans navigateur ni instance Open WebUI en ligne, et restent reproductibles partout. La seule cellule qui appelle l'outillage Node (`npx playwright test --list`) le fait **hors-ligne** — elle *liste* les tests sans les exécuter — et se rabat proprement sur un inventaire de fichiers si les dépendances ne sont pas installées.\n",
+    "\n",
+    "> **Pas de claim de version.** Lister les tests n'est pas les exécuter. La **revalidation réelle** de la suite contre Open WebUI **v0.9.6** est l'objet de la Phase 3 et du projet de certification final (capstone). Tant qu'elle n'est pas faite, ce notebook ne porte **aucune affirmation de compatibilité v0.9.6**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s1-fil-rouge",
+   "metadata": {},
+   "source": [
+    "## 1. Le fil rouge — « QA Engineer d'une flotte GenAI multi-tenant »\n",
+    "\n",
+    "Tu rejoins l'équipe SRE/QA d'un hébergeur de plateformes d'IA générative. La flotte compte plusieurs instances **Open WebUI** en production, partagées par des écoles différentes (multi-tenant). Ta mission, au fil des cinq modules : **valider de bout en bout cette flotte**, depuis la prise en main de l'outillage jusqu'à la **certification d'une montée de version critique**.\n",
+    "\n",
+    "À la fin, tu sais répondre à la seule question qui compte un jour de mise en production : **« Peut-on livrer, oui ou non ? »** — c'est le projet de certification (*capstone*) qui clôt le parcours.\n",
+    "\n",
+    "Chaque module est **une étape de la mission**, pas un chapitre de manuel. Ce notebook chapeau te donne la vue d'ensemble ; chaque module a ensuite sa propre matière (tests `.spec.ts` réels + README)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "setup",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T12:40:28.860857Z",
+     "iopub.status.busy": "2026-06-28T12:40:28.860857Z",
+     "iopub.status.idle": "2026-06-28T12:40:28.886577Z",
+     "shell.execute_reply": "2026-06-28T12:40:28.886039Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Poste de pilotage QA-OWUI\n",
+      "Serie detectee : Playwright-OWUI\n",
+      "Modules : 01-decouverte, 02-navigation-authentification, 03-chat-streaming, 04-rag-tools-avances, 05-multi-tenant-ci\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule 1 — Mise en place (pur-Python, bibliothèque standard uniquement).\n",
+    "from pathlib import Path\n",
+    "import os, re, json, shutil, subprocess\n",
+    "\n",
+    "# La série Playwright-OWUI = le dossier qui contient playwright.config.ts.\n",
+    "# Le notebook est exécuté depuis son propre dossier (cwd = dossier du notebook).\n",
+    "def trouver_racine_serie(depart):\n",
+    "    for d in [depart, *depart.parents]:\n",
+    "        if (d / \"playwright.config.ts\").exists():\n",
+    "            return d\n",
+    "    return depart\n",
+    "\n",
+    "SERIE = trouver_racine_serie(Path.cwd())\n",
+    "MODULES = sorted(p for p in SERIE.iterdir() if p.is_dir() and re.match(r\"^\\d\\d-\", p.name))\n",
+    "\n",
+    "print(\"Poste de pilotage QA-OWUI\")\n",
+    "print(\"Serie detectee :\", SERIE.name)          # nom seul, jamais de chemin absolu (anti-fuite)\n",
+    "print(\"Modules :\", \", \".join(m.name for m in MODULES))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s2-carte",
+   "metadata": {},
+   "source": [
+    "## 2. Carte de la mission\n",
+    "\n",
+    "Cinq étapes, de l'interface visible vers l'industrialisation API-first — exactement le chemin d'un ingénieur QA qui passe du test exploratoire manuel à une suite qui tourne sans navigateur en intégration continue.\n",
+    "\n",
+    "| Module | Étape de la mission | Focus Playwright |\n",
+    "|--------|---------------------|------------------|\n",
+    "| **01 — Découverte** | Prends en main la plateforme et ton outillage | sélecteurs, auto-wait, screenshots |\n",
+    "| **02 — Navigation & Auth** | Sécurise ton accès et explore l'admin | `storageState`, RBAC, multilingue |\n",
+    "| **03 — Chat & Streaming** | Valide le cœur métier : le chat IA en streaming | non-déterminisme, polling, skip gracieux |\n",
+    "| **04 — RAG, outils & canaux** | Certifie les fonctions avancées | flux complexes, tests conditionnels |\n",
+    "| **05 — Multi-tenant & CI/CD** | Certifie l'isolation et industrialise en CI | API-first, isolation, GitHub Actions |\n",
+    "\n",
+    "La cellule suivante interroge l'outillage pour dresser l'inventaire **réel** des tests, étape par étape."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "catalog-list",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T12:40:28.889087Z",
+     "iopub.status.busy": "2026-06-28T12:40:28.889087Z",
+     "iopub.status.idle": "2026-06-28T12:40:30.540146Z",
+     "shell.execute_reply": "2026-06-28T12:40:30.539144Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Listing tests:\n",
+      "  [owui-setup] › fixtures\\auth.setup.ts:18:1 › authenticate\n",
+      "  [owui] › 01-decouverte\\01-decouverte.spec.ts:46:3 › 01 — Decouverte : Premiers pas avec Playwright › connexion reussie — la page principale se charge\n",
+      "  [owui] › 01-decouverte\\01-decouverte.spec.ts:68:3 › 01 — Decouverte : Premiers pas avec Playwright › le selecteur de modeles liste les modeles disponibles\n",
+      "  [owui] › 01-decouverte\\01-decouverte.spec.ts:101:3 › 01 — Decouverte : Premiers pas avec Playwright › le menu utilisateur est accessible\n",
+      "  [owui] › 01-decouverte\\01-decouverte.spec.ts:133:3 › 01 — Decouverte : Premiers pas avec Playwright › capturer un screenshot de la page principale\n",
+      "  [owui] › 02-navigation-authentification\\02-navigation-auth.spec.ts:34:3 › 02 — Navigation & Authentification › la session authentifiee est valide et persistante\n",
+      "  [owui] › 02-navigation-authentification\\02-navigation-auth.spec.ts:56:3 › 02 — Navigation & Authentification › acceder au panneau admin — liste des utilisateurs\n",
+      "  [owui] › 02-navigation-authentification\\02-navigation-auth.spec.ts:77:3 › 02 — Navigation & Authentification › acceder aux reglages admin\n",
+      "  [owui] › 02-navigation-authentification\\02-navigation-auth.spec.ts:96:3 › 02 — Navigation & Authentification › workspace — lister les bases de connaissances\n",
+      "  [owui] › 02-navigation-authentification\\02-navigation-auth.spec.ts:112:3 › 02 — Navigation & Authentification › workspace — lister les modeles personnalises\n",
+      "  [owui] › 02-navigation-authentification\\02-navigation-auth.spec.ts:125:3 › 02 — Navigation & Authentification › workspace — lister les prompts\n",
+      "  [owui] › 02-navigation-authentification\\02-navigation-auth.spec.ts:139:3 › 02 — Navigation & Authentification › workspace — lister les fonctions\n",
+      "  [owui] › 02-navigation-authentification\\02-navigation-auth.spec.ts:153:3 › 02 — Navigation & Authentification › acceder a la section Channels\n",
+      "  [owui] › 03-chat-streaming\\03-chat-streaming.spec.ts:45:3 › 03 — Chat & Streaming LLM › chat avec modele cloud — reponse basique\n",
+      "  [owui] › 03-chat-streaming\\03-chat-streaming.spec.ts:63:3 › 03 — Chat & Streaming LLM › chat avec modele local (skip si indisponible)\n",
+      "  [owui] › 03-chat-streaming\\03-chat-streaming.spec.ts:114:3 › 03 — Chat & Streaming LLM › streaming — le message assistant apparait avant la fin\n",
+      "  [owui] › 03-chat-streaming\\03-chat-streaming.spec.ts:135:3 › 03 — Chat & Streaming LLM › rendu markdown — blocs de code formates\n",
+      "  [owui] › 03-chat-streaming\\03-chat-streaming.spec.ts:162:3 › 03 — Chat & Streaming LLM › regenerer une reponse\n",
+      "  [owui] › 03-chat-streaming\\03-chat-streaming.spec.ts:188:3 › 03 — Chat & Streaming LLM › editer un message utilisateur\n",
+      "  [owui] › 03-chat-streaming\\03-chat-streaming.spec.ts:221:3 › 03 — Chat & Streaming LLM › persona — reponse structuree dans le role configure\n",
+      "  [owui] › 04-rag-tools-avances\\04-rag-tools.spec.ts:49:3 › 04a — Knowledge Bases (RAG) › attacher une knowledge base via le menu +\n",
+      "  [owui] › 04-rag-tools-avances\\04-rag-tools.spec.ts:83:3 › 04a — Knowledge Bases (RAG) › chat avec KB attachee — reponse enrichie par les documents\n",
+      "  [owui] › 04-rag-tools-avances\\04-rag-tools.spec.ts:172:3 › 04b — Outils MCP (Model Context Protocol) › menu outils MCP accessible (si configure)\n",
+      "  [owui] › 04-rag-tools-avances\\04-rag-tools.spec.ts:198:3 › 04b — Outils MCP (Model Context Protocol) › ouvrir le selecteur d outils MCP\n",
+      "  [owui] › 04-rag-tools-avances\\04-rag-tools.spec.ts:228:3 › 04b — Outils MCP (Model Context Protocol) › recherche web via outils (si disponible)\n",
+      "  [owui] › 04-rag-tools-avances\\04-rag-tools.spec.ts:280:3 › 04c — Channels (canaux de discussion) › acceder aux canaux de discussion\n",
+      "  [owui] › 04-rag-tools-avances\\04-rag-tools.spec.ts:318:3 › 04c — Channels (canaux de discussion) › poster un message dans un canal\n",
+      "  [owui] › 05-multi-tenant-ci\\05-api-multi-tenant.spec.ts:70:3 › 05a — Tests API (tenant principal) › login via API — token JWT valide\n",
+      "  [owui] › 05-multi-tenant-ci\\05-api-multi-tenant.spec.ts:88:3 › 05a — Tests API (tenant principal) › lister les modeles disponibles via API\n",
+      "  [owui] › 05-multi-tenant-ci\\05-api-multi-tenant.spec.ts:104:3 › 05a — Tests API (tenant principal) › lister les knowledge bases via API\n",
+      "  [owui] › 05-multi-tenant-ci\\05-api-multi-tenant.spec.ts:122:3 › 05a — Tests API (tenant principal) › lister les fonctions installees via API\n",
+      "  [owui] › 05-multi-tenant-ci\\05-api-multi-tenant.spec.ts:171:3 › 05b — Multi-tenant : Isolation & Partage › les deux tenants sont accessibles\n",
+      "  [owui] › 05-multi-tenant-ci\\05-api-multi-tenant.spec.ts:187:3 › 05b — Multi-tenant : Isolation & Partage › knowledge bases partagees entre tenants\n",
+      "  [owui] › 05-multi-tenant-ci\\05-api-multi-tenant.spec.ts:212:3 › 05b — Multi-tenant : Isolation & Partage › modeles custom identiques sur les deux tenants\n",
+      "  [owui] › 05-multi-tenant-ci\\05-api-multi-tenant.spec.ts:237:3 › 05b — Multi-tenant : Isolation & Partage › isolation des donnees — bases utilisateurs separees\n",
+      "Total: 35 tests in 6 files\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule 2 — Orchestration : inventorier la suite depuis le notebook.\n",
+    "# On lance `npx playwright test --list` : cela *liste* les tests collectes par\n",
+    "# Playwright SANS les executer (aucune instance Open WebUI requise, hors-ligne).\n",
+    "# Si l'outillage Node n'est pas installe, on se rabat sur un inventaire de fichiers.\n",
+    "def lister_tests_via_playwright(serie):\n",
+    "    if shutil.which(\"npx\") is None or not (serie / \"node_modules\").exists():\n",
+    "        return None  # dependances absentes -> fallback\n",
+    "    try:\n",
+    "        proc = subprocess.run(\n",
+    "            \"npx playwright test --list\",\n",
+    "            cwd=str(serie), capture_output=True, text=True, timeout=180, shell=True,\n",
+    "        )\n",
+    "    except Exception as e:\n",
+    "        print(\"Orchestration indisponible :\", type(e).__name__)\n",
+    "        return None\n",
+    "    sortie = (proc.stdout or \"\") + (proc.stderr or \"\")\n",
+    "    # Anti-fuite : neutraliser tout chemin absolu eventuel (racine maison / checkout).\n",
+    "    for absolu in {str(serie), str(Path.home())}:\n",
+    "        sortie = sortie.replace(absolu, \".\")\n",
+    "    return sortie if proc.returncode == 0 else None\n",
+    "\n",
+    "listing = lister_tests_via_playwright(SERIE)\n",
+    "if listing:\n",
+    "    print(listing.strip())\n",
+    "else:\n",
+    "    print(\"Dependances Node absentes — installe-les pour l'inventaire detaille :\")\n",
+    "    print(\"    npm install && npx playwright install chromium\")\n",
+    "    print(\"(Le reste du notebook fonctionne sans Node : on se rabat sur les fichiers .spec.ts.)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "catalog-table",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T12:40:30.541648Z",
+     "iopub.status.busy": "2026-06-28T12:40:30.541648Z",
+     "iopub.status.idle": "2026-06-28T12:40:30.555160Z",
+     "shell.execute_reply": "2026-06-28T12:40:30.554598Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source : npx playwright test --list (tests reellement collectes) \n",
+      "\n",
+      "Module  Etape de la mission                     Tests\n",
+      "--------------------------------------------------------\n",
+      "01      Prise en main de l'outillage            4\n",
+      "02      Acces securise & admin                  8\n",
+      "03      Coeur metier : chat streaming           7\n",
+      "04      Fonctions avancees (RAG/MCP/canaux)     7\n",
+      "05      Multi-tenant & CI/CD (API-first)        8\n",
+      "--------------------------------------------------------\n",
+      "Total                                           34\n",
+      "(+ 1 test d'authentification 'owui-setup', execute en prealable)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule 3 — Construire la carte tests <-> etapes de mission.\n",
+    "ETAPES = {\n",
+    "    \"01\": \"Prise en main de l'outillage\",\n",
+    "    \"02\": \"Acces securise & admin\",\n",
+    "    \"03\": \"Coeur metier : chat streaming\",\n",
+    "    \"04\": \"Fonctions avancees (RAG/MCP/canaux)\",\n",
+    "    \"05\": \"Multi-tenant & CI/CD (API-first)\",\n",
+    "}\n",
+    "\n",
+    "def catalogue_depuis_listing(listing):\n",
+    "    # Parse la sortie `--list` : compte les tests par module (prefixe NN-).\n",
+    "    par_module = {}\n",
+    "    for ligne in listing.splitlines():\n",
+    "        m = re.search(r\"(\\d\\d)-[^\\\\/]*[\\\\/][^\\s]*\\.spec\\.ts\", ligne)\n",
+    "        if m:\n",
+    "            par_module[m.group(1)] = par_module.get(m.group(1), 0) + 1\n",
+    "    return par_module\n",
+    "\n",
+    "if listing:\n",
+    "    counts = catalogue_depuis_listing(listing)\n",
+    "    source = \"npx playwright test --list (tests reellement collectes)\"\n",
+    "else:\n",
+    "    counts = {m.name[:2]: len(list(m.glob(\"*.spec.ts\"))) for m in MODULES}\n",
+    "    source = \"inventaire de fichiers .spec.ts (mode hors-ligne)\"\n",
+    "\n",
+    "print(\"Source :\", source, \"\\n\")\n",
+    "print(f\"{'Module':<8}{'Etape de la mission':<40}{'Tests'}\")\n",
+    "print(\"-\" * 56)\n",
+    "total = 0\n",
+    "for code in sorted(ETAPES):\n",
+    "    n = counts.get(code, 0); total += n\n",
+    "    print(f\"{code:<8}{ETAPES[code]:<40}{n}\")\n",
+    "print(\"-\" * 56)\n",
+    "print(f\"{'Total':<48}{total}\")\n",
+    "\n",
+    "setup_n = sum(1 for l in (listing or \"\").splitlines() if \"owui-setup\" in l)\n",
+    "if setup_n:\n",
+    "    print(f\"(+ {setup_n} test d'authentification 'owui-setup', execute en prealable)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s3-lancer",
+   "metadata": {},
+   "source": [
+    "## 3. Lancer la suite contre une vraie instance\n",
+    "\n",
+    "L'inventaire ci-dessus *liste* les tests. Pour les **exécuter** contre une instance Open WebUI, il faut :\n",
+    "\n",
+    "1. **Configurer l'accès** — copier `.env.example` vers `.env` et y mettre l'URL + les identifiants de ton instance de cours. Le fichier `.env` est ignoré par Git : **aucun secret n'entre dans le dépôt**.\n",
+    "2. **Installer l'outillage** — `npm install` puis `npx playwright install chromium`.\n",
+    "3. **Exécuter** — toute la suite ou un module ciblé :\n",
+    "\n",
+    "```bash\n",
+    "npx playwright test                 # toute la suite\n",
+    "npx playwright test --grep '03'     # un module (ici 03 — Chat & Streaming)\n",
+    "npx playwright test --headed        # avec navigateur visible (débogage)\n",
+    "npx playwright show-report          # rapport HTML interactif\n",
+    "```\n",
+    "\n",
+    "> **Ce notebook chapeau ne déclenche pas l'exécution réelle** : elle requiert une instance accessible et des identifiants, et son résultat dépend de la version déployée. Le **vrai run de bout en bout** — et son interprétation go/no-go — est le projet de certification final. Ici, on apprend d'abord à **lire** ce qu'un run produit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s4-resultats",
+   "metadata": {},
+   "source": [
+    "## 4. Lire et interpréter les résultats — le cœur du métier\n",
+    "\n",
+    "Un run de tests ne se résume pas à « vert / rouge ». Le travail de QA, c'est de **qualifier** chaque résultat :\n",
+    "\n",
+    "- **Succès** — le comportement est conforme.\n",
+    "- **Échec réel** — une régression : l'application ne fait plus ce qu'elle devrait.\n",
+    "- **Skip légitime** — un service optionnel n'est pas configuré (ex. modèle local, second tenant). **Ce n'est pas une régression** : la raison du skip doit être lisible.\n",
+    "- **Flake** — un test instable (réponse LLM lente, surcharge passagère) qui passe au *retry*. À distinguer d'un échec réel.\n",
+    "\n",
+    "La cellule suivante illustre cette qualification sur un **exemple de rapport** (format simplifié du rapport JSON de Playwright). C'est exactement le raisonnement attendu dans le rapport de certification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "interpret",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T12:40:30.557754Z",
+     "iopub.status.busy": "2026-06-28T12:40:30.557232Z",
+     "iopub.status.idle": "2026-06-28T12:40:30.571240Z",
+     "shell.execute_reply": "2026-06-28T12:40:30.570231Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Qualification du run (exemple) :\n",
+      "  succes                 3\n",
+      "  flake a investiguer    1\n",
+      "  skip legitime          2\n",
+      "  echec reel             1\n",
+      "\n",
+      "A investiguer (echecs reels) :\n",
+      "  x 02 > acceder au panneau admin -- bouton 'menu' introuvable (drift DOM ?)\n",
+      "\n",
+      "Skips (a justifier dans le rapport) :\n",
+      "  ~ 03 > chat modele local -- OWUI_LOCAL_MODEL non defini\n",
+      "  ~ 04 > recherche web via outils -- outils MCP non configures\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule 4 — Qualifier un rapport de run (exemple illustratif).\n",
+    "# Format simplifie du rapport JSON Playwright (`--reporter=json`), reduit aux\n",
+    "# champs utiles pour la decision. AUCUN run reel n'est lance ici : c'est un\n",
+    "# echantillon didactique pour apprendre a interpreter.\n",
+    "rapport_exemple = [\n",
+    "    {\"test\": \"01 > connexion reussie\",            \"status\": \"passed\",  \"retries\": 0},\n",
+    "    {\"test\": \"01 > selecteur de modeles\",         \"status\": \"passed\",  \"retries\": 0},\n",
+    "    {\"test\": \"03 > chat cloud reponse basique\",   \"status\": \"passed\",  \"retries\": 1},   # passe au 2e essai\n",
+    "    {\"test\": \"03 > chat modele local\",            \"status\": \"skipped\", \"reason\": \"OWUI_LOCAL_MODEL non defini\"},\n",
+    "    {\"test\": \"04 > recherche web via outils\",     \"status\": \"skipped\", \"reason\": \"outils MCP non configures\"},\n",
+    "    {\"test\": \"05 > isolation des donnees\",        \"status\": \"passed\",  \"retries\": 0},\n",
+    "    {\"test\": \"02 > acceder au panneau admin\",     \"status\": \"failed\",  \"reason\": \"bouton 'menu' introuvable (drift DOM ?)\"},\n",
+    "]\n",
+    "\n",
+    "def qualifier(r):\n",
+    "    if r[\"status\"] == \"failed\":\n",
+    "        return \"echec reel\"\n",
+    "    if r[\"status\"] == \"skipped\":\n",
+    "        return \"skip legitime\"\n",
+    "    if r[\"status\"] == \"passed\" and r.get(\"retries\", 0) > 0:\n",
+    "        return \"flake a investiguer\"\n",
+    "    return \"succes\"\n",
+    "\n",
+    "resume = {\"succes\": 0, \"flake a investiguer\": 0, \"skip legitime\": 0, \"echec reel\": 0}\n",
+    "for r in rapport_exemple:\n",
+    "    resume[qualifier(r)] += 1\n",
+    "\n",
+    "print(\"Qualification du run (exemple) :\")\n",
+    "for k, v in resume.items():\n",
+    "    print(f\"  {k:<22} {v}\")\n",
+    "\n",
+    "echecs = [r for r in rapport_exemple if qualifier(r) == \"echec reel\"]\n",
+    "skips = [r for r in rapport_exemple if r[\"status\"] == \"skipped\"]\n",
+    "print(\"\\nA investiguer (echecs reels) :\")\n",
+    "for r in echecs:\n",
+    "    print(f\"  x {r['test']} -- {r.get('reason', '?')}\")\n",
+    "print(\"\\nSkips (a justifier dans le rapport) :\")\n",
+    "for r in skips:\n",
+    "    print(f\"  ~ {r['test']} -- {r.get('reason', '?')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercices",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices ci-dessous sont **pur-Python** : tu les complètes puis tu réexécutes la cellule. Chaque cellule fournie **s'exécute déjà sans erreur** (elle renvoie une valeur « à compléter ») — à toi de remplacer le `TODO` pour obtenir le bon résultat. Les vérifications affichent un diagnostic ; elles ne lèvent pas d'exception."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex1",
+   "metadata": {},
+   "source": [
+    "## Exercice 1 — Compter les tests d'un module\n",
+    "\n",
+    "Complète `tests_du_module(code)` pour qu'elle renvoie le **nombre de tests** du module donné (`\"01\"`..`\"05\"`), en réutilisant l'inventaire `counts` construit plus haut. Pense au cas d'un module absent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T12:40:30.572244Z",
+     "iopub.status.busy": "2026-06-28T12:40:30.572244Z",
+     "iopub.status.idle": "2026-06-28T12:40:30.586936Z",
+     "shell.execute_reply": "2026-06-28T12:40:30.585876Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Module 01 : a completer\n",
+      "Module 03 : a completer\n",
+      "Module 05 : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def tests_du_module(code):\n",
+    "    # TODO : renvoie le nombre de tests du module `code` a partir de `counts`.\n",
+    "    #        Indice : counts est un dict { \"01\": n, ... }. Gere le cas absent.\n",
+    "    return -1  # valeur \"a completer\" (placeholder neutre)\n",
+    "\n",
+    "for code in [\"01\", \"03\", \"05\"]:\n",
+    "    n = tests_du_module(code)\n",
+    "    etat = \"a completer\" if n < 0 else f\"{n} tests\"\n",
+    "    print(f\"Module {code} : {etat}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex2",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 — Qualifier un résultat de test\n",
+    "\n",
+    "Complète `classer(status, retries, reason)` pour renvoyer l'une des quatre catégories du §4 : `\"succes\"`, `\"echec reel\"`, `\"skip legitime\"`, `\"flake a investiguer\"`. Inspire-toi de la fonction `qualifier` ci-dessus, mais à partir des champs bruts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T12:40:30.589556Z",
+     "iopub.status.busy": "2026-06-28T12:40:30.589043Z",
+     "iopub.status.idle": "2026-06-28T12:40:30.602018Z",
+     "shell.execute_reply": "2026-06-28T12:40:30.601447Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "passed   retries=0 -> a determiner\n",
+      "passed   retries=2 -> a determiner\n",
+      "skipped  retries=0 -> a determiner\n",
+      "failed   retries=0 -> a determiner\n"
+     ]
+    }
+   ],
+   "source": [
+    "def classer(status, retries=0, reason=\"\"):\n",
+    "    # TODO : renvoie \"succes\" / \"echec reel\" / \"skip legitime\" / \"flake a investiguer\".\n",
+    "    return \"a determiner\"\n",
+    "\n",
+    "cas = [\n",
+    "    (\"passed\", 0, \"\"),                 # attendu : succes\n",
+    "    (\"passed\", 2, \"\"),                 # attendu : flake a investiguer\n",
+    "    (\"skipped\", 0, \"service absent\"),  # attendu : skip legitime\n",
+    "    (\"failed\", 0, \"selecteur casse\"),  # attendu : echec reel\n",
+    "]\n",
+    "for status, retries, reason in cas:\n",
+    "    print(f\"{status:<8} retries={retries} -> {classer(status, retries, reason)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex3",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 — Trancher : go / no-go\n",
+    "\n",
+    "Le capstone te demande un verdict. Complète `verdict(echecs_reels, skips, total)` selon une règle simple et défendable, par exemple : **NO-GO** s'il y a au moins un échec réel ; **GO conditionnel** s'il n'y a pas d'échec mais des skips à justifier ; **GO** sinon. Tu peux raffiner la règle — l'important est de pouvoir l'expliquer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T12:40:30.604034Z",
+     "iopub.status.busy": "2026-06-28T12:40:30.604034Z",
+     "iopub.status.idle": "2026-06-28T12:40:30.617384Z",
+     "shell.execute_reply": "2026-06-28T12:40:30.616810Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "echecs=0 skips=0 total=34 -> a trancher\n",
+      "echecs=0 skips=5 total=34 -> a trancher\n",
+      "echecs=2 skips=3 total=34 -> a trancher\n"
+     ]
+    }
+   ],
+   "source": [
+    "def verdict(echecs_reels, skips, total):\n",
+    "    # TODO : renvoie \"GO\", \"GO conditionnel\" ou \"NO-GO\" selon ta regle.\n",
+    "    return \"a trancher\"\n",
+    "\n",
+    "scenarios = [\n",
+    "    (0, 0, 34),   # tout vert\n",
+    "    (0, 5, 34),   # des skips, pas d'echec\n",
+    "    (2, 3, 34),   # des echecs reels\n",
+    "]\n",
+    "for e, s, t in scenarios:\n",
+    "    print(f\"echecs={e} skips={s} total={t} -> {verdict(e, s, t)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "conclusion",
+   "metadata": {},
+   "source": [
+    "## Et après ? — du parcours au capstone\n",
+    "\n",
+    "Tu as maintenant la carte de la mission, l'inventaire réel de la suite, et la grille de lecture des résultats. La suite :\n",
+    "\n",
+    "1. **Modules 01 → 05** — chaque étape a sa matière : des tests `.spec.ts` réels (le moteur) et un README qui guide. Ouvre-les dans l'ordre de la mission.\n",
+    "2. **Capstone** — le **rapport de certification go/no-go** d'une montée de version, contre **deux tenants**. Le gabarit détaillé est dans le [cadrage de la mission](./00-Parcours-QA-OWUI.md).\n",
+    "\n",
+    "> **Reproductibilité (C.3).** Toutes les cellules de ce notebook se réexécutent à l'identique. La cellule d'orchestration affiche l'inventaire **réel** si l'outillage Node est installé (`npm install`), sinon un inventaire de fichiers — dans les deux cas sans erreur et sans instance en ligne. La revalidation contre **Open WebUI v0.9.6** reste l'objet de la Phase 3.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Phase 1 — refonte pédagogique #4433 (Part of #4427). Notebook chapeau, FR-first.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## P1 — Notebook chapeau (refonte pédagogique Playwright-OWUI #4433, Part of #4427)

Suite de **P0** (cadrage `00-Parcours-QA-OWUI.md`, PR #4456 mergée). Cette PR ajoute le **notebook chapeau** : le poste de pilotage de la mission « QA Engineer d'une flotte GenAI multi-tenant ».

### Contenu (1 fichier, atomique)
`MyIA.AI.Notebooks/GenAI/Playwright-OWUI/00-Parcours-QA-OWUI.ipynb` — 17 cellules :
1. **Narration** du fil rouge + carte de mission (renvoie au cadrage P0).
2. **Orchestration réelle depuis une cellule** : `npx playwright test --list` lancé hors-ligne (exit 0, **35 tests collectés**, chemins relatifs uniquement). Se rabat proprement sur un inventaire de fichiers `.spec.ts` si Node absent → la cellule ne lève jamais d'erreur.
3. **Carte tests ⇄ étapes de mission** parsée depuis la sortie réelle (4/8/7/7/8 = 34 tests + 1 auth setup).
4. **Interprétation des résultats** : qualification succès / échec réel / skip légitime / flake — exactement la grille du rapport de certification (capstone).
5. **3 exercices pur-Python exécutables** (`## Exercice 1/2/3`).

### Conformité
- **FR-first** (accents complets).
- **C.1** — stubs d'exercices sans erreur volontaire (s'exécutent et renvoient un placeholder « à compléter »).
- **C.2** — notebook **exécuté**, outputs **réels** commités, **0 scrub** (Stop&Repair, aucune édition manuelle d'output). 7 cellules code, exec_count 1–7, **0 erreur**.
- **C.3** — reproductibilité documentée : cellules pur-Python rejouables ; l'orchestration affiche l'inventaire réel (Node présent) ou un inventaire de fichiers (Node absent), sans erreur dans les deux cas.
- **0 secret** — scan de sortie vide (pas de chemin absolu, pas de credential) ; `.env`/`.auth`/`node_modules` ignorés par Git.
- **CATALOG-STATUS NON touché** (auto-only) → **intégration au catalogue déférée à P4**.
- **Aucun claim de compatibilité v0.9.6** — la revalidation réelle reste la **Phase 3**.

### Phases restantes
P2 (couche notebook ×5 modules) · P3 (revalidation v0.9.6) · P4 (intégration catalogue + fil rouge transverse).

cc @ai-01 (myia-ai-01:CoursIA) — review + merge séquentiel.