### PR TITLE
docs(planners): resync README count 13→14 for 5b-Lean-Relaxation (#4400 missed)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -13,7 +13,7 @@ Cette série de notebooks introduit la **Planification Automatique**, une branch
 
 La planification répond à une question différente de celle de l'apprentissage : non pas « que prédire ? » mais « **que faire ?** ». À partir d'un modèle du monde — un état initial, des actions avec leurs préconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mène au but. C'est une technologie éprouvée : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirigé des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activités des rovers martiens). Le langage **PDDL** a standardisé la manière de décrire ces problèmes, donnant naissance à tout un écosystème de solveurs comparables. La planification connaît aujourd'hui un regain d'intérêt avec les LLMs, comme moyen de doter les modèles de langage d'une capacité d'action vérifiable et orientée vers un but.
 
-**13 notebooks** | **5 parties** | **~8h**
+**14 notebooks** | **5 parties** | **~8h**
 
 **À qui s'adresse cette série** : étudiants en IA, ingénieurs en robotique et logistique, développeurs souhaitant intégrer la planification symbolique dans leurs applications. Aucun prérequis en planification : les concepts sont introduits progressivement depuis les fondements STRIPS jusqu'aux approches neuro-symboliques modernes.
 
@@ -21,7 +21,7 @@ La planification répond à une question différente de celle de l'apprentissage
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 13 (1 setup + 3 foundation + 3 classical + 3 advanced + 3 neuro-symbolic) |
+| Notebooks | 14 (1 setup + 3 foundation + 4 classical dont 1 companion Lean + 3 advanced + 3 neuro-symbolic) |
 | Durée totale | ~8h |
 | Langage | Python 3.9+ |
 | Kernel | Python 3 |
@@ -49,7 +49,7 @@ La série débute par le notebook Setup (0) qui configure automatiquement l'envi
 
 ### Phase 2 : Planification Classique (Notebooks 4-6, ~3h)
 
-Les notebooks 4 à 6 constituent le cœur technique de la série. Le notebook 4 (Fast-Downward) présente l'architecture en trois étapes de Fast Downward (translator PDDL→SAS+, preprocessor C++, search C++) et montre comment l'exécuter via Docker et unified-planning. Les algorithmes de recherche (A*, Greedy, EHC) y sont testés sur Blocks World et Logistics. Le notebook 5 (Heuristics) approfondit la théorie : classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), comparaison expérimentale des heuristiques sur le nombre de nœuds expansés, et guide de sélection. Le notebook 6 (Domains) couvre les domaines standards de l'IPC (Blocks World, Logistics, Gripper, Satellite) avec des problèmes de complexité croissante. À l'issue, vous pouvez configurer un planificateur optimal, choisir l'heuristique adéquate, et modéliser n'importe quel domaine IPC.
+Les notebooks 4 à 6 constituent le cœur technique de la série. Le notebook 4 (Fast-Downward) présente l'architecture en trois étapes de Fast Downward (translator PDDL→SAS+, preprocessor C++, search C++) et montre comment l'exécuter via Docker et unified-planning. Les algorithmes de recherche (A*, Greedy, EHC) y sont testés sur Blocks World et Logistics. Le notebook 5 (Heuristics) approfondit la théorie : classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), comparaison expérimentale des heuristiques sur le nombre de nœuds expansés, et guide de sélection. Le notebook **5b** (Lean-Relaxation) est un **companion natif** au kernel Lean 4 : il prouve formellement, sans `sorry`, l'admissibilité de la relaxation $h^{+} \leq h^{*}$ dans le lake `planning_lean` — la certification mathématique de la propriété que le notebook 5 constate empiriquement. Le notebook 6 (Domains) couvre les domaines standards de l'IPC (Blocks World, Logistics, Gripper, Satellite) avec des problèmes de complexité croissante. À l'issue, vous pouvez configurer un planificateur optimal, choisir l'heuristique adéquate, et modéliser n'importe quel domaine IPC.
 
 ### Phase 3 : Approches Avancees (Notebooks 7-9, ~3h)
 
@@ -121,6 +121,7 @@ SymbolicAI/Planners/
 ├── 02-Classical/
 │   ├── Planners-4-Fast-Downward.ipynb   # A*, heuristiques
 │   ├── Planners-5-Heuristics.ipynb      # h-add, h-max, h-FF
+│   ├── Planners-5b-Lean-Relaxation.ipynb # Companion Lean 4 : preuve h+ <= h*
 │   └── Planners-6-Domains.ipynb         # Domaines classiques
 ├── 03-Advanced/
 │   ├── Planners-7-OR-Tools.ipynb        # CP-SAT
@@ -163,6 +164,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 3 | State-Space | Explosion combinatoire $O(2^n)$, nécessité des heuristiques, graphe d'états |
 | 4 | Fast-Downward | Architecture 3 étapes (translator/preprocessor/search), A* vs Greedy vs EHC via Docker |
 | 5 | Heuristics | Classification admissible/non-admissible : $h^{add}$, $h^{max}$, $h^{FF}$, LM-cut, comparaison expérimentale |
+| 5b | Lean-Relaxation | Companion **natif** (kernel Lean 4) : preuve formelle 0-sorry de l'admissibilité de la relaxation ($h^{+} \leq h^{*}$) dans le lake `planning_lean`, `#check` + `#print axioms` in-kernel |
 | 6 | Domains | Domaines IPC standards (Blocks, Logistics, Gripper, Satellite), complexité croissante |
 | 7 | OR-Tools | CP-SAT, programmation par contraintes, modélisation de scheduling, contraintes alldifferent |
 | 8 | Temporal | PDDL 2.1, durées d'actions, parallélisme, contraintes temporelles, ordonnancement |


### PR DESCRIPTION
## Contexte

`SymbolicAI/Planners/` (leaf README, partition po-2025:CoursIA-2 dans #3975) avait un **drift de comptage** : la PR #4400 a ajouté `Planners-5b-Lean-Relaxation.ipynb` (4e companion Lean4 natif) mais le compte prose du README n'a pas été resynchronisé.

> Note : le scope #3975 orthographie le dossier « Planning/ » (singulier) — le chemin réel est **Planners/** (pluriel).

## Preuve du drift (grounded firsthand)

| Source | Valeur |
|--------|--------|
| Filesystem (`find ... *.ipynb`) | **14** notebooks |
| CATALOG-STATUS marker (`pedagogical_count`) | **14** |
| Header prose L16 | ~~13~~ (drift) |
| Stats table L24 | ~~13 (1+3+3+3+3)~~ (drift) |
| « Contenu détaillé » table | row **5b manquante** |
| ASCII « Structure » tree | nœud **5b manquant** |

→ Le marker généré (automation) était déjà à 14, mais la prose curée était restée à 13.

## Changements (5, tous dans `Planners/README.md`)

1. **L16** header : `13 notebooks` → `14 notebooks`
2. **L24** stats table : `13 (1 setup + 3 foundation + 3 classical + 3 advanced + 3 neuro-symbolic)` → `14 (1 setup + 3 foundation + 4 classical dont 1 companion Lean + 3 advanced + 3 neuro-symbolic)`
3. **L165** « Contenu détaillé » table : ajout row 5b ( Lean-Relaxation : companion natif Lean 4, preuve 0-sorry de h⁺ ≤ h\* dans `planning_lean`)
4. **L121** ASCII « Structure » tree : ajout nœud 5b
5. **L52** Phase 2 prose : ajout d'une phrase décrivant 5b (certification formelle de la propriété que le notebook 5 constate empiriquement)

## Validation

- `git diff --stat` : 1 fichier, 5 insertions, 3 déletions — diff cohérent avec l'intention (resync prose, pas refactor)
- **CATALOG-STATUS marker byte-identique** (vérifié : 0 ligne du diff touche le marker) — le catalogue appartient à l'automation (cron `catalog-cron.yml` + `catalog-drift.yml` par-PR), pas régénéré à la main (cf [.claude/rules/catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md))
- Branche fraîche depuis `origin/main` (HEAD `088861711`) — pas de base stale
- Markdown-only, pas de notebook touché → pas de re-exécution requise (exception C.2 : modifs uniquement markdown)

## Périmètre

Atomique : 1 fichier, 1 sujet (resync compte 5b). Pas de bundle forcé — les READMEs feuilles frères (Tweety/SemanticWeb/SmartContracts/Sudoku/GameTheory/CaseStudies/Search) ne présentent pas de drift de compte prose évident (aucun claim « N notebooks » en prose à resynchroniser).

See #3975 (contribution partielle à l'Epic leaf READMEs — partition SymbolicAI non-Lean, po-2025:CoursIA-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)