### PR TITLE
feat(lean): PacLearning sampleExpect_prod_coord — independence product (iter-2 brique 2c/3-hoeffding-3/5)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning.lean
@@ -82,7 +82,13 @@ nécessité — le résultat mathématique est le vrai Hoeffding. Par briques at
   redonne `D`. **Et l'estimateur non-biaisé** `sampleExpect_empError_eq_trueError`
   (`E_{S∼D^m}[empError] = trueError`, par linéarité + `sampleExpect_coord`
   coordonnée-par-coordonnée) : l'erreur empirique est centrée sur l'erreur vraie.
-  Cadre requis par la concentration de Hoeffding.
+  **Et la factorisation d'un produit (indépendance i.i.d.)** `sampleExpect_prod_coord`
+  (`E_{S∼D^m}[∏_i h (S i)] = ∏_i E_D[h]`, même squelette `Fintype.prod_sum` que
+  `sampleExpect_coord` mais sans `if` — toutes les coordonnées portent `h`) :
+  ingrédient-clé de la concentration de Hoeffding (brique 3/5), il donne la
+  **MGF d'une somme = produit des MGFs** (`h = exp(t·ind)` ⟹
+  `E_S[exp(t·∑_i ind(S_i))] = ∏_i E_D[exp(t·ind)]`). Cadre requis par la
+  concentration de Hoeffding.
 - **Brique 2c/3-restante — OPEN** : concentration de Hoeffding-for-Bernoulli,
   `ℙ_S [ |empError − trueError| > ε ] ≤ 2·exp(−2mε²)` (méthode Chernoff : Markov
   sur `exp(t·(X̄−μ))` + `log t ≤ t − 1` sur les indicateurs).
@@ -122,7 +128,8 @@ combinatoire (UnionBound) livrée**
 (`Sample.lean` : distribution produit `D^m` + normalisation ; `Concentration.lean` :
 `expect`, `markov_ineq` ; `SampleExpect.lean` : `sampleExpect` + linéarité/normalisation
 + **marginalisation coordonnée `sampleExpect_coord`** + **estimateur non-biaisé
-`sampleExpect_empError_eq_trueError`** ; `UnionBound.lean` : `sampleProb` +
+`sampleExpect_empError_eq_trueError`** + **factorisation produit (indépendance
+i.i.d.) `sampleExpect_prod_coord`** ; `UnionBound.lean` : `sampleProb` +
 **union bound (Bornes de Boole) `sampleProb_union_bound`** ; `MGF.lean` :
 **réduction algébrique de la MGF centrée `expect_exp_centered_eq`** (première
 sous-brique de Hoeffding : `E_D[exp(t(ind−μ))] = μ·exp(t(1−μ)) + (1−μ)·exp(−tμ)`,

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/SampleExpect.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/SampleExpect.lean
@@ -154,6 +154,43 @@ theorem sampleExpect_coord {n : ℕ} (g : X → ℝ) (i : Fin n) :
   rw [Finset.prod_eq_single_of_mem i (Finset.mem_univ _) (fun b _ hb ↦ if_neg hb),
       if_pos rfl]
 
+/-- **Factorisation d'un produit (indépendance i.i.d.)** : l'espérance (sous le
+produit `D^m`) d'une fonction de la forme `∏_i h (S i)` — produit de fonctions
+une-coordonnée, i.i.d. par construction de la distribution produit `D^m` — se
+factorise en le produit des espérances `∏_i E_D[h]`. C'est la **brique 3/5
+d'Hoeffding** (indépendance produit) : pour `h = exp(t · ind)`, elle donne
+`E_S[exp(t · ∑_i ind(S_i))] = E_S[∏_i exp(t·ind(S_i))] = ∏_i E_D[exp(t·ind)]`,
+c.-à-d. la **MGF d'une somme = produit des MGFs** — ingrédient-clé de la
+concentration bilatérale de Hoeffding.
+
+Preuve : même squelette que `sampleExpect_coord` — on porte `h` sur chaque
+coordonnée via `g' j x = w x · h x`, de sorte que
+`∏_j g' j (S j) = (∏_j w (S j)) · (∏_j h (S j))` (`Finset.prod_mul_distrib`),
+puis `Fintype.prod_sum` échange produit-de-sommes et somme-de-produits :
+`∑_S ∏_j g' j (S j) = ∏_j ∑_x g' j x = ∏_j E_D[h]`. Plus simple que
+`sampleExpect_coord` : sans `if` (toutes les coordonnées portent `h`), donc pas
+de réduction `Finset.prod_eq_single_of_mem`. -/
+theorem sampleExpect_prod_coord {n : ℕ} (h : X → ℝ) :
+    sampleExpect D (fun S : Fin n → X ↦ ∏ i, h (S i)) = ∏ _ : Fin n, expect D h := by
+  dsimp only [sampleExpect, sampleWeight]
+  -- `g'` porte `h` sur chaque coordonnée : `g' j x = w x · h x`.
+  let g' : Fin n → X → ℝ := fun j x ↦ D.weight x * h x
+  -- (1) `∏_j g' j (S j) = (∏_j w (S j)) * ∏_j h (S j)` : `prod_mul_distrib` sépare.
+  have hprod : ∀ S : Fin n → X,
+      ∏ j, g' j (S j) = (∏ j, D.weight (S j)) * ∏ j, h (S j) := by
+    intro S
+    simp only [g', Finset.prod_mul_distrib]
+  -- (2) Le summand `(∏_j w (S j)) * ∏_j h (S j)` coïncide point par point avec `∏_j g' j (S j)`.
+  rw [Finset.sum_congr rfl (fun S _ ↦ (hprod S).symm)]
+  -- (3) Produit de sommes = somme de produits (`Fintype.prod_sum`) :
+  -- `∑_S ∏_j g' j (S j) = ∏_j ∑_x g' j x`.
+  rw [← Fintype.prod_sum (κ := fun _ : Fin n ↦ X) g']
+  -- (4) `∑_x g' j x = ∑_x w x · h x = E_D[h]` (indépendant de `j`).
+  have hsum : ∀ j, ∑ x, g' j x = expect D h := by
+    intro j
+    simp only [g', expect]
+  simp only [hsum]
+
 /-- **Linéarité en une somme indicée** : l'espérance empirique d'une somme de
 fonctions est la somme des espérances (Fubini discret : `∑_S w S · (∑_i F i S) =
 ∑_i ∑_S w S · F i S` via `Finset.mul_sum` puis `Finset.sum_comm`). Réutilisé par


### PR DESCRIPTION
## Livrable — brique 2c/3-hoeffding-3/5 (indépendance produit)

Nouveau lemme `sampleExpect_prod_coord` dans `PacLearning/SampleExpect.lean` :

```
sampleExpect D (fun S : Fin n → X ↦ ∏ i, h (S i)) = ∏ _ : Fin n, expect D h
```

**Factorisation d'un produit sous la mesure produit `D^m`** : l'espérance d'une fonction
produit `∏_i h (S i)` (i.i.d. par construction de `D^m`) se factorise en le produit des
espérances. C'est la **brique 3/5 de la décomposition Hoeffding** (indépendance produit) :
pour `h = exp(t · ind)`, elle donne `E_S[exp(t · ∑_i ind(S_i))] = ∏_i E_D[exp(t · ind)]`
(**MGF d'une somme = produit des MGFs**), ingrédient-clé de la concentration bilatérale.

### Indépendance du OPEN 2b/5

Purement algébrique/combinatoire (même squelette `Fintype.prod_sum` que
`sampleExpect_coord` mais sans `if`). Indépendante de la borne MGF générale `2b/5`
(documentée OPEN dans #4530) — avance le chemin critique du flagship sans blocage.

### Preuve

Même squelette que `sampleExpect_coord` : `g' j x = w x · h x` porte `h` sur chaque
coordonnée ; `Finset.prod_mul_distrib` sépare ; `Fintype.prod_sum` échange
produit-de-sommes ↔ somme-de-produits ; `∑_x g' j x = E_D[h]`. Plus simple que
son aînée : sans `if` → pas de `Finset.prod_eq_single_of_mem`.

### Validation (règle B, 4 éléments)

1. **`grep -c sorry` avant/après** : `SampleExpect.lean` 0→0, `PacLearning.lean` 4→4
   (les 4 sont "0-sorry" pré-existants sur main dans la prose docstring ; net-zéro).
2. **Lake build SUCCESS** : `lean PacLearning/SampleExpect.lean` exit 0 (0 erreur,
   0 warning) via vrai checker `lean.exe` + olean Mathlib v4.31.0-rc1 courants.
   ⚠️ **WDAC bloque `lake.exe` localement** (os error 4551) → validation via `lean.exe`.
   **ai-01 : confirmer `lake build PacLearning` SUCCESS au merge.**
3. **Proof integrity** : `#print axioms` = `[propext, Classical.choice, Quot.sound]` —
   **pas de `sorryAx`**.
4. **Refactor prover** : N/A.

### Stack PAC iter-2

- #4512 UnionBound (MERGED) ; #4516 Hoeffding-Chernoff-1/5 (OPEN) ;
  #4525 MGF-2a/5 (OPEN) ; #4530 BernoulliMGF-2b/5-partial (OPEN) ;
  **cette PR sampleExpect_prod_coord-3/5** — indépendante, fresh origin/main (0 behind).

See #4293
