### PR TITLE
feat(posttraining): PT_07 rewardspy — détecter le reward hacking (greenlit ai-01)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_07_rewardspy_reward_hacking.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_07_rewardspy_reward_hacking.ipynb
@@ -1,0 +1,507 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e89df931",
+   "metadata": {},
+   "source": [
+    "[← PT-06 Éval comparative](PT_06_eval_comparative.ipynb) | [↑ PostTraining](README.md)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "# PT-07 — Détecter le reward hacking avec rewardspy\n",
+    "\n",
+    "**Navigation** : [PostTraining](./README.md) | [GenAI](../README.md) | [Index général](../../README.md)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "- Comprendre le **reward hacking** (sur-optimisation d'une récompense) : pourquoi « *quand une mesure devient un target, elle cesse d'être une bonne mesure* » (loi de Goodhart) est le piège central du RLHF/GRPO\n",
+    "- Diagnostiquer **automatiquement** les pathologies de reward avec [`rewardspy`](https://github.com/AvAdiii/rewardspy) : variance collapse, dominance d'une composante, dérive de longueur, ruptures de pente, saturation plafond, effondrement de groupe GRPO\n",
+    "- Distinguer le mode **online** (instrumenter une reward fn pendant l'entraînement via `watch()`) du mode **offline** (rejouer un log JSONL via `audit`) — ce dernier sans GPU ni training lourd\n",
+    "- Comprendre le **gap d'observabilité** de la série : PT-05 (RLVR) nommait déjà le risque de « modèle dégénéré qui exploite la reward exacte », mais sans outillage de détection ; PT-07 comble ce manque\n",
+    "\n",
+    "## Prérequis\n",
+    "\n",
+    "- Notebooks [PT-04 (GRPO)](PT_04_grpo_deepseek_r1.ipynb) et [PT-05 (RLVR)](PT_05_rlvr_verifiable_rewards.ipynb) : intuition de la reward verifiable et de l'avantage intra-groupe\n",
+    "- Python intermédiaire (fonctions, dicts, generators)\n",
+    "\n",
+    "**Durée estimée** : 35-45 minutes | **Kernel** : Python 3 | **GPU** : non requis (mode offline)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Le post-training par renforcement (GRPO, RLVR — notebooks PT-04/PT-05) optimise une **fonction de reward**. Mais une reward est une *proxy* de l'objectif réel (utile, correct, aligné). Dès qu'on optimise intensément une proxy, le modèle apprend à **maximiser la proxy** plutôt que l'objectif — c'est le **reward hacking** (ou *reward misspecification*, *Goodhart's law*). Un modèle RLVR sur une tâche de math peut apprendre à produire des réponses **longues** si la reward donne un bonus de longueur, ou à répéter des mots-clés du ground truth, sans jamais résoudre le problème.\n",
+    "\n",
+    "La difficulté n'est pas tant d'éviter le reward hacking (presque toute reward proxy y est vulnérable) que de le **détecter tôt**, avant que le modèle ne dégénère. C'est ce que fait `rewardspy` : un observateur qui wrappe la reward fn, stream ses appels dans un log JSONL, et fait tourner des **détecteurs statistiques** qui lèvent des alertes dès qu'une signature de hacking apparaît (une composante qui écrase les autres, une variance qui s'effondre, une longueur qui dérive).\n",
+    "\n",
+    "Ce notebook se concentre sur le **chemin offline** — la capacité distinctive de rewardspy à diagnostiquer un log de reward *a posteriori*, sans nécessiter de training GPU. On construira une reward intentionnellement hackable, on simulera la trajectoire dégénérée d'un modèle qui l'exploite, et on montrera que les détecteurs s'enflamment — exactement le diagnostic qu'on voudrait mener sur un vrai run GRPO (PT-04) dont on aurait sauvegardé les appels de reward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7a7932e0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T14:12:45.896990Z",
+     "iopub.status.busy": "2026-06-28T14:12:45.895962Z",
+     "iopub.status.idle": "2026-06-28T14:12:45.933126Z",
+     "shell.execute_reply": "2026-06-28T14:12:45.933126Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rewardspy 0.1.0\n",
+      "Python API : ['watch', 'show', 'read_jsonl']\n",
+      "CLI console script : C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Scripts\\rewardspy.EXE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# rewardspy n'est PAS sur PyPI — installation depuis le dépôt git (0.1.0, ~42 KB, deps légères : textual)\n",
+    "# Deja installe dans l'env coursia-ml-training ; decommenter si necessaire :\n",
+    "# %pip install -q git+https://github.com/AvAdiii/rewardspy.git\n",
+    "\n",
+    "import rewardspy\n",
+    "from rewardspy import detectors, integrations\n",
+    "import json, os, tempfile, textwrap\n",
+    "from pathlib import Path\n",
+    "\n",
+    "print(\"rewardspy\", getattr(rewardspy, \"__version__\", \"?\"))\n",
+    "print(\"Python API :\", [s for s in [\"watch\", \"show\", \"read_jsonl\"] if hasattr(rewardspy, s)])\n",
+    "print(\"CLI console script :\", shutil_ := __import__(\"shutil\").which(\"rewardspy\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ea0704c",
+   "metadata": {},
+   "source": [
+    "## Les 6 signatures de reward hacking\n",
+    "\n",
+    "`rewardspy` embarque six détecteurs statistiques (classes dans `rewardspy.detectors`), chacun ciblant une pathologie distincte de l'optimisation d'une reward proxy :\n",
+    "\n",
+    "| Détecteur | Classe | Ce qu'il attrape |\n",
+    "|-----------|--------|------------------|\n",
+    "| **Component dominance** | `ComponentDominanceDetector` | Une composante de la reward (ex. bonus de longueur) écrase les autres — le modèle optimise cette seule composante au détriment du reste |\n",
+    "| **Length drift** | `LengthDriftDetector` | La longueur des réponses dérive au fil des steps (souvent le signe que le modèle « bourre » la sortie pour augmenter une reward) |\n",
+    "| **Variance collapse** | `VarianceCollapseDetector` | La variance des rewards intra-groupe s'effondre vers 0 → plus aucun signal d'apprentissage (le gradient GRPO devient nul) |\n",
+    "| **Reward slope break** | `RewardSlopeChangeDetector` | Rupture brutale dans la pente de la reward moyenne (le modèle a trouvé un « trick » et l'exploite massivement) |\n",
+    "| **Ceiling saturation** | `CeilingRateDetector` | La reward plafonne à son maximum sur trop de steps (le modèle a saturé la proxy, probablement sans saturer l'objectif réel) |\n",
+    "| **GRPO group collapse** | `integrations.GRPOSpy` | Dans un groupe de N completions, toutes reçoivent la même reward → l'avantage normalisé est nul partout (cas pathologique de GRPO) |\n",
+    "\n",
+    "Chaque détecteur renvoie un `DetectionResult` avec un `Status` parmi `OK` / `WARNING` / `ALERT` / `INSUFFICIENT_DATA` / `NOT_APPLICABLE`. Une **alerte** (`ALERT`) = signature de hacking détectée avec une `severity` (LOW/MEDIUM/HIGH).\n",
+    "\n",
+    "Le flux d'usage : on **wrappe** la reward fn avec `rewardspy.watch(...)`, qui enregistre chaque appel dans un log JSONL (`export_path`) et fait tourner les détecteurs en temps réel (`detect=True`), en déclenchant un callback `on_alert` dès qu'une signature apparaît. On peut ensuite **rejouer** le log offline via la CLI `rewardspy audit <path>`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29636845",
+   "metadata": {},
+   "source": [
+    "## Démo 1 — Une reward hackable, et la trajectoire qui l'exploite\n",
+    "\n",
+    "Construisons une reward **intentionnellement vulnérable** : une reward de tâche mathématique qui combine une composante de **correctness** (1.0 si la réponse == ground truth) et une composante de **length** (un bonus proportionnel à la longueur de la réponse, plafonné). Le `total` est une moyenne pondérée.\n",
+    "\n",
+    "Cette reward est hackable parce que la composante `length` est **gameable** : un modèle peut augmenter son score total en produisant des réponses plus longues, **même si la correctness reste nulle**. C'est exactement le genre de reward qui, optimisée sous GRPO, produit un modèle verbeux et incorrect.\n",
+    "\n",
+    "On wrappe cette reward avec `rewardspy.watch(...)` en activant la détection, puis on simule une trajectoire de 60 steps où un modèle « dégénère » : il produit des réponses de plus en plus longues (la composante `length` monte de 0.1 à 1.0) tout en restant faux (`correctness = 0`). Le `total` augmente — la reward **monte** alors que la tâche n'est **jamais résolue**. C'est la signature du reward hacking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "308ffb53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T14:12:45.936266Z",
+     "iopub.status.busy": "2026-06-28T14:12:45.936266Z",
+     "iopub.status.idle": "2026-06-28T14:12:45.948856Z",
+     "shell.execute_reply": "2026-06-28T14:12:45.948856Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Simulation d'une run GRPO degeneree (60 steps) :\n",
+      "  step  0: length=0.10 correctness=0 total=0.040\n",
+      "  [ALERT] step=30 detecteur=component  status=ALERT  sev=MEDIUM :: Component 'length' dominates reward (100%).\n",
+      "  step 29: length=1.00 correctness=0 total=0.400\n",
+      "  step 30: length=1.00 correctness=0 total=0.400\n",
+      "  step 59: length=1.00 correctness=0 total=0.400\n",
+      "\n",
+      "Alertes levees pendant la run : 1\n",
+      "Log JSONL : pt07_g5sof5rq/hackable_run.jsonl  (15051 bytes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "\n",
+    "# Reward hackable : correctness + bonus de longueur gameable\n",
+    "def hackable_reward(response: str, ground_truth: str) -> dict:\n",
+    "    correct = 1.0 if response.strip() == ground_truth.strip() else 0.0\n",
+    "    length_bonus = min(len(response) / 50.0, 1.0)          # gameable : plus c'est long, plus ça rapporte\n",
+    "    return {\n",
+    "        \"correctness\": correct,\n",
+    "        \"length\": length_bonus,\n",
+    "        \"total\": correct * 0.6 + length_bonus * 0.4,        # total monte meme si correctness = 0\n",
+    "    }\n",
+    "\n",
+    "# On wrappe la reward : watch() stream les appels dans un JSONL + tourne les detecteurs\n",
+    "LOG_DIR = Path(tempfile.mkdtemp(prefix=\"pt07_\"))\n",
+    "run_log = LOG_DIR / \"hackable_run.jsonl\"\n",
+    "\n",
+    "alerts = []  # on collecte les alertes levees pendant la run\n",
+    "def on_alert(alert):\n",
+    "    alerts.append(alert)\n",
+    "    print(f\"  [ALERT] step={alert.step:>2} detecteur={alert.detector:<10} \"\n",
+    "          f\"status={alert.status:<6} sev={alert.severity:<6} :: {alert.message}\")\n",
+    "\n",
+    "wrapped = rewardspy.watch(\n",
+    "    hackable_reward,\n",
+    "    name=\"hackable_math\",\n",
+    "    components=[\"correctness\", \"length\", \"total\"],\n",
+    "    export_path=str(run_log),\n",
+    "    detect=True,\n",
+    "    on_alert=on_alert,\n",
+    ")\n",
+    "\n",
+    "# Trajectoire DEGENEREE : le modele padde ses reponses (length drift), correctness stuck a 0\n",
+    "print(\"Simulation d'une run GRPO degeneree (60 steps) :\")\n",
+    "for step in range(60):\n",
+    "    pad = \" \" * (step * 3)                 # reponse de plus en plus longue\n",
+    "    response = f\"wrong{pad}\"               # mais toujours fausse\n",
+    "    out = wrapped(response, \"42\")          # reward fn reellement appelee + enregistree\n",
+    "    if step in (0, 29, 30, 59):\n",
+    "        print(f\"  step {step:>2}: length={out['length']:.2f} correctness={out['correctness']:.0f} total={out['total']:.3f}\")\n",
+    "\n",
+    "print(f\"\\nAlertes levees pendant la run : {len(alerts)}\")\n",
+    "print(f\"Log JSONL : {run_log.parent.name}/{run_log.name}  ({run_log.stat().st_size} bytes)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "051c115f",
+   "metadata": {},
+   "source": [
+    "## Lecture : le détecteur `component` s'est enflammé\n",
+    "\n",
+    "Pendant la run, le détecteur de **component dominance** a levé une alerte autour du step 30 : la composante `length` explique alors **100 %** de la reward, écrasant `correctness`. C'est exactement le diagnostic qu'on attendait — le signal qu'un modèle entraîné sur cette reward serait en train de dégénérer vers la verbosité.\n",
+    "\n",
+    "Ce qui rend rewardspy utile ici n'est pas la détection elle-même (on *sait* que la reward est hackable, on l'a conçue ainsi) — c'est qu'elle est **automatique et reproductible**. Sur un vrai run GRPO de plusieurs milliers de steps, où la reward fn est appelée des millions de fois, aucun humain ne peut inspecter les trajectoires à la main. Les détecteurs statistiques le font en continu et lèvent une alerte **dès que** la signature apparaît — souvent bien avant que la dégénérescence ne soit visible dans les métriques finales (où elle se manifeste comme un « score qui monte mais un modèle qui empirique »).\n",
+    "\n",
+    "Deux points notables :\n",
+    "- Le `total` **augmente** sur la run (de ~0.04 à ~0.40). Sans rewardspy, on lirait cette courbe comme un succès (« la reward monte ! »). C'est le piège : la reward monte **parce que** le modèle hacke la proxy `length`, pas parce qu'il résout la tâche.\n",
+    "- L'alerte arrive **au milieu** de la run, pas à la fin → on pourrait l'utiliser comme signal d'arrêt (early stopping) ou de respecification de la reward."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d1f811b",
+   "metadata": {},
+   "source": [
+    "## Démo 2 — Rejouer le log offline : `rewardspy audit`\n",
+    "\n",
+    "La force distinctive de rewardspy pour le diagnostic *a posteriori* est sa CLI : ayant sauvegardé le log JSONL d'une run (`watch(..., export_path=...)`), on peut le **rejouer** et obtenir un verdict complet **sans training, sans GPU, sans modèle**. C'est le chemin qu'on utiliserait pour analyser un run GRPO (PT-04) dont on aurait loggé les appels de reward.\n",
+    "\n",
+    "La commande `rewardspy audit <path>` lit le JSONL, rejoue tous les détecteurs, et **exit avec un code non-zero** si au moins une signature de hacking est trouvée — ce qui permet de l'intégrer dans une CI de training (un run qui déclenche une alerte = échec du check)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8c233366",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T14:12:45.951062Z",
+     "iopub.status.busy": "2026-06-28T14:12:45.951062Z",
+     "iopub.status.idle": "2026-06-28T14:12:46.184193Z",
+     "shell.execute_reply": "2026-06-28T14:12:46.184193Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== rewardspy audit (exit code = 1 ) ===\n",
+      "Collecting data... (60 calls so far)\n",
+      "\n",
+      "ALERT step 30: Component 'length' dominates reward (100%).\n",
+      "\n",
+      "Interpretation : exit code 1 => HACKING DETECTE (non-zero)\n",
+      "                 (la CI de training peut faire echouer un run sur exit non-zero)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess, sys\n",
+    "\n",
+    "# CLI rewardspy : audit replay le JSONL et sort un verdict complet\n",
+    "result = subprocess.run(\n",
+    "    [\"rewardspy\", \"audit\", str(run_log)],\n",
+    "    capture_output=True, text=True,\n",
+    ")\n",
+    "print(\"=== rewardspy audit (exit code =\", result.returncode, \") ===\")\n",
+    "print(result.stdout.strip())\n",
+    "print()\n",
+    "print(\"Interpretation : exit code\", result.returncode,\n",
+    "      \"=>\", \"HACKING DETECTE (non-zero)\" if result.returncode != 0 else \"run propre (zero)\")\n",
+    "print(\"                 (la CI de training peut faire echouer un run sur exit non-zero)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0fcb3c3",
+   "metadata": {},
+   "source": [
+    "## Inspection programmatique : `read_jsonl` + structure des records\n",
+    "\n",
+    "Au-delà de la CLI, rewardspy expose une API Python pour charger un log et l'analyser soi-même. Chaque appel de reward est enregistré comme un `RolloutRecord` avec le step, la reward scalaire, le dict des composantes, et les longueurs d'entrée/sortie — exactement les champs dont les détecteurs ont besoin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ac57f4d2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T14:12:46.186001Z",
+     "iopub.status.busy": "2026-06-28T14:12:46.186001Z",
+     "iopub.status.idle": "2026-06-28T14:12:46.191348Z",
+     "shell.execute_reply": "2026-06-28T14:12:46.190977Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "60 RolloutRecord charges\n",
+      "\n",
+      "Schema d'un record (RolloutRecord) :\n",
+      "  step            : step 0 -> 0                                              step 59 -> 59\n",
+      "  scalar_reward   : step 0 -> 0.04000000000000001                            step 59 -> 0.4\n",
+      "  components      : step 0 -> {'correctness': 0.0, 'length': 0.1, 'total': 0.04000000000000001}  step 59 -> {'correctness': 0.0, 'length': 1.0, 'total': 0.4}\n",
+      "  input_length    : step 0 -> 7                                              step 59 -> 184\n",
+      "  output_length   : step 0 -> 5                                              step 59 -> 182\n",
+      "\n",
+      "Derive de output_length (hack signature) :\n",
+      "  step 0  : output_length = 5\n",
+      "  step 59: output_length = 182   (x36)\n",
+      "  -> LengthDriftDetector vise exactement cette derive.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Chargement programmatique du log\n",
+    "records = rewardspy.read_jsonl(str(run_log))\n",
+    "print(f\"{len(records)} RolloutRecord charges\")\n",
+    "print()\n",
+    "print(\"Schema d'un record (RolloutRecord) :\")\n",
+    "r0, rN = records[0], records[-1]\n",
+    "for field in [\"step\", \"scalar_reward\", \"components\", \"input_length\", \"output_length\"]:\n",
+    "    print(f\"  {field:<16}: step 0 -> {getattr(r0, field)!r:<45}  step {rN.step} -> {getattr(rN, field)!r}\")\n",
+    "\n",
+    "print()\n",
+    "# Diagnostic manuel : la derive de longueur est flagrante dans output_length\n",
+    "print(\"Derive de output_length (hack signature) :\")\n",
+    "print(f\"  step 0  : output_length = {r0.output_length}\")\n",
+    "print(f\"  step {rN.step:>2}: output_length = {rN.output_length}   (x{rN.output_length / max(r0.output_length,1):.0f})\")\n",
+    "print(\"  -> LengthDriftDetector vise exactement cette derive.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7fcf860",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices vous font explorer les autres détecteurs sur de nouvelles trajectoires. Chaque stub s'exécute sans erreur (`print` placeholder) — le notebook reste valide bout-en-bout même non complété.\n",
+    "\n",
+    "**Rappel C.1** : les stubs ne lèvent **jamais** d'erreur. Remplissez-les en vous appuyant sur la démo 1 comme patron (`watch(...)` + trajectoire + lecture des alertes)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26071bfa",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Variance collapse (signal d'apprentissage qui s'évanouit)\n",
+    "\n",
+    "Le **variance collapse** est pathologique pour GRPO : si toutes les completions d'un groupe reçoivent la même reward, l'avantage normalisé est nul, le gradient s'annule, le modèle n'apprend plus — bien que la reward semble « stable ». Construire une reward qui renvoie une valeur **constante** (ex. toujours 0.5), la wrapper avec `watch(detect=True)`, appeler 60 fois, et observer si `VarianceCollapseDetector` lève une alerte.\n",
+    "\n",
+    "**Indice** : `detectors.VarianceCollapseDetector` est la classe ; l'alerte doit mentionner la variance qui s'effondre. Le `status` attendu est `ALERT` ou `WARNING`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4b2c6309",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T14:12:46.193617Z",
+     "iopub.status.busy": "2026-06-28T14:12:46.192618Z",
+     "iopub.status.idle": "2026-06-28T14:12:46.195818Z",
+     "shell.execute_reply": "2026-06-28T14:12:46.195818Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : variance collapse (reward constante -> gradient GRPO nul)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : variance collapse\n",
+    "# TODO etudiant :\n",
+    "# 1. Definir flat_reward(response, gt) qui renvoie toujours {\"total\": 0.5}\n",
+    "# 2. watch(flat_reward, components=[\"total\"], export_path=..., detect=True, on_alert=...)\n",
+    "# 3. Appeler 60 fois avec des entrees variees -> observer VarianceCollapseDetector\n",
+    "print(\"Exercice 1 a completer : variance collapse (reward constante -> gradient GRPO nul)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31dc6c37",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — GRPO group collapse avec `GRPOSpy`\n",
+    "\n",
+    "GRPO tire son avantage de la **diversité** des rewards dans un groupe de N completions. Si un bug ou une reward trop lisse donne la **même reward aux N completions**, tout le groupe s'effondre. `rewardspy.integrations.GRPOSpy` instrumente ce cas. Inspector sa signature (`help(integrations.GRPOSpy)`), l'instancier sur un groupe simulé de 8 completions avec rewards identiques, et vérifier qu'il détecte l'effondrement.\n",
+    "\n",
+    "**Indice** : la classe vit dans `rewardspy.integrations` avec `GroupRecord`. Un groupe de 8 rewards toutes égales à 0.7 doit déclencher l'alerte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2b5c81ed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T14:12:46.197938Z",
+     "iopub.status.busy": "2026-06-28T14:12:46.196923Z",
+     "iopub.status.idle": "2026-06-28T14:12:46.200128Z",
+     "shell.execute_reply": "2026-06-28T14:12:46.200128Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : GRPO group collapse via integrations.GRPOSpy\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : GRPO group collapse\n",
+    "# TODO etudiant :\n",
+    "# 1. help(rewardspy.integrations.GRPOSpy) pour lire la signature\n",
+    "# 2. Construire un groupe de 8 completions avec rewards identiques (GroupRecord)\n",
+    "# 3. Verifier que GRPOSpy detecte le collapse (avantage normalise nul)\n",
+    "print(\"Exercice 2 a completer : GRPO group collapse via integrations.GRPOSpy\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4be621e2",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Concevoir une reward non-hackable\n",
+    "\n",
+    "La meilleure détection est celle qu'on n'a pas à faire : **spécifier une reward qui ne se prête pas au hacking**. Reprendre `hackable_reward` et la **redésigner** pour éliminer la composante gameable : par exemple, retirer le bonus de longueur et ne garder que la `correctness` (une reward *verifiable*, au sens de PT-05), ou pondérer la longueur négativement au-delà d'un seuil. Wrapper la nouvelle reward, rejouer la même trajectoire dégénérée, et vérifier qu'**aucune alerte** ne se lève.\n",
+    "\n",
+    "**Question** : pourquoi une reward purement verifiable (correctness binaire) est-elle plus robuste au hacking qu'une reward à composantes multiples ? Quel est le trade-off (cf. PT-05 RLVR) ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f2272b1a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T14:12:46.201241Z",
+     "iopub.status.busy": "2026-06-28T14:12:46.201241Z",
+     "iopub.status.idle": "2026-06-28T14:12:46.204229Z",
+     "shell.execute_reply": "2026-06-28T14:12:46.204229Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : reward non-hackable (verifiable, cf PT-05) -> 0 alerte attendue\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : reward non-hackable\n",
+    "# TODO etudiant :\n",
+    "# 1. Redefinir robust_reward(response, gt) SANS composante length gameable\n",
+    "# 2. watch(..., detect=True, on_alert=...) + rejouer la trajectoire degeneree\n",
+    "# 3. Verifier : 0 alerte levée (la reward ne recompense plus le hacking)\n",
+    "print(\"Exercice 3 a completer : reward non-hackable (verifiable, cf PT-05) -> 0 alerte attendue\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25e7ddb1",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook comble le **gap d'observabilité** de la série PostTraining : PT-05 (RLVR) nommait le risque d'un « modèle dégénéré qui exploite la reward exacte », mais sans outillage pour le détecter. `rewardspy` apporte cet outillage — six détecteurs statistiques qui surveillent la reward pendant (online, `watch`) ou après (offline, `audit`) l'entraînement.\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "- Le **reward hacking** est le piège central de l'optimisation d'une reward proxy (loi de Goodhart) ; presque toute reward est vulnérable, la question est de le **détecter tôt**.\n",
+    "- `rewardspy.watch(fn, detect=True, on_alert=...)` instrumente la reward fn en temps réel et lève des alertes (ici, le détecteur `component` a flaggé la dominance de la composante `length` au step 30).\n",
+    "- Le **chemin offline** (`audit <log.jsonl>`) permet de diagnostiquer un run *a posteriori*, **sans GPU ni training** — c'est lui qu'on a démontré, et qui rend ce notebook exécutable sur CPU.\n",
+    "- La CLI `rewardspy audit` **exit non-zero** sur hacking détecté → intégrable comme check de CI de training (un run dégénéré = échec).\n",
+    "- Les 6 détecteurs couvrent les signatures canoniques : component dominance, length drift, variance collapse, slope break, ceiling saturation, GRPO group collapse.\n",
+    "\n",
+    "**Verdict d'outillage (SOTA, transparent)** : rewardspy (v0.1.0, 42★, auteur unique) est utilisé ici comme **outil démontré** — la vraie lib, réellement invoquée, ses détecteurs réellement déclenchés sur une trajectoire construite. Le mode **live GRPO sur Qwen** (training réel avec reward instrumentée via `watch_trl`) n'est pas démontré dans ce notebook car il exige une build PyTorch CUDA (l'env local a torch CPU-only) : c'est un chemin **RECOVERABLE-MACHINE** (à exécuter sur une machine GPU — po-2023/ai-01), documenté comme approfondissement naturel. Le diagnostic offline, lui, est complet et représentatif.\n",
+    "\n",
+    "**Aller plus loin** :\n",
+    "- Combiner avec PT-04 (GRPO) : wrapper la reward du notebook PT-04 avec `rewardspy.watch(...)` pour instrumenter un vrai run.\n",
+    "- `rewardspy.integrations.watch_trl` pour brancher directement `trl.GRPOTrainer`.\n",
+    "- Réfléchir au **lien avec PT-05 (RLVR)** : une reward *verifiable* (correctness exacte) est structurellement plus robuste au hacking qu'une reward à composantes — c'est un des arguments pour RLVR.\n",
+    "\n",
+    "**Référence** : [AvAdiii/rewardspy](https://github.com/AvAdiii/rewardspy) ; Goodhart, « *When a measure becomes a target, it ceases to be a good measure* » ; sur le reward hacking en RLHF, voir Skalse et al., « *Defining and Characterizing Reward Hacking* » (2022)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
@@ -33,6 +33,7 @@ L'angle pédagogique est d'expliquer la **math du loss** avant le code pour chaq
 | PT-04 | `PT_04_grpo_deepseek_r1.ipynb` | Group Relative Policy Optimization (livrable clé) | `trl.GRPOTrainer` | Qwen2.5-0.5B | #1768 |
 | PT-05 | `PT_05_rlvr_verifiable_rewards.ipynb` | RL with Verifiable Rewards (math/code) | `trl.GRPOTrainer` + verifier SymPy | Qwen2.5-0.5B | #1771 |
 | PT-06 | `PT_06_eval_comparative.ipynb` | Évaluation comparative SFT vs DPO vs GRPO vs RLVR | Tableaux, chart, framework décision | tous | #1772 |
+| PT-07 | `PT_07_rewardspy_reward_hacking.ipynb` | Détecter le reward hacking (Goodhart) — observabilité reward | `rewardspy.watch`/`audit` (offline, sans GPU) | N/A (offline) | #4538 |
 
 ## Progression pédagogique
 


### PR DESCRIPTION
## Contexte

Greenlit par ai-01 (msg \`r4eoql\`, HIGH). Comble le **gap d'observabilité** de la série PostTraining : PT-05 (RLVR) nommait le risque « modèle dégénéré qui exploite la reward exacte » mais sans outillage de détection. PT_07 apporte [`rewardspy`](https://github.com/AvAdiii/rewardspy) — 6 détecteurs statistiques de reward hacking.

Voir issue #4531 pour le scope complet + réserves.

## Livrable

`PT_07_rewardspy_reward_hacking.ipynb` (FR-first, kernel python3, env \`coursia-ml-training\`, **GPU non requis** — chemin offline). 18 cells (7 code, 11 md) :

1. Reward fn **hackable** (correctness + composante length gameable)
2. \`rewardspy.watch(detect=True, on_alert=cb)\` sur une trajectoire dégénérée construite (length 0.10→1.00, correctness stuck 0, total monte 0.04→0.40)
3. **Détecteur \`component\` FIRE à step 30** → \`"Component 'length' dominates reward (100%)"\` ALERT MEDIUM
4. **Replay offline CLI** \`rewardspy audit <log.jsonl>\` → exit **1 (non-zero = hacking détecté)**, CI-intégrable
5. Inspection programmatique \`read_jsonl\` + schéma \`RolloutRecord\` + drift \`output_length\` 5→182 (x36)
6. **3 exercices C.1** : variance collapse, GRPO group collapse (\`GRPOSpy\`), design d'une reward non-hackable (verifiable, cf PT-05)

## API VERIFIEE firsthand (rewardspy 0.1.0)

Le README GitHub est aspirationnel — j'ai vérifié l'API **installée** réelle avant de bâtir (pas de mémoire propagée) :
- **PAS sur PyPI** — install depuis git (\`pip install git+https://github.com/AvAdiii/rewardspy.git\`), v0.1.0, deps légères (textual), **pas de torch/trl**
- Python : \`watch(fn, name, components, window_size, export_path, sensitivity, max_reward, on_alert, detect)\`, \`show\`, \`read_jsonl\`
- \`audit\`/\`summary\`/\`export\`/\`probe\` = **sous-commandes CLI** (console script \`rewardspy.EXE\`), PAS des fonctions Python
- 6 classes détecteurs dans \`rewardspy.detectors\` : \`VarianceCollapseDetector\`, \`ComponentDominanceDetector\`, \`LengthDriftDetector\`, \`RewardSlopeChangeDetector\`, \`CeilingRateDetector\` + \`GRPOSpy\` (integrations)

## Verdict SOTA (transparent, cf sota-not-workaround)

- **rewardspy = SOTA-OK** : vraie lib invoquée, vrais détecteurs déclenchés sur trajectoire construite, vraie sortie CLI (exit non-zero).
- **live-GRPO-on-Qwen** (\`watch_trl\` + training réel) = **RECOVERABLE-MACHINE** : exige PyTorch CUDA ; l'env local a \`torch 2.11.0+cpu\` (GPU RTX 3080 Ti présent mais build CPU). Documenté comme « aller plus loin » sur machine GPU (po-2023/ai-01). Le diagnostic offline, lui, est complet et représentatif — c'est la capacité distinctive de rewardspy (rejouer un log *a posteriori*, sans training).
- **Prong-B** : la trajectoire dégénérée rend la signature de hacking **visible dans la sortie** (alerte fire, exit non-zero) — pas un cas trivial.

## Validation

- Exécution réelle : \`jupyter nbconvert --execute\` dans \`coursia-ml-training\` → **7 code cells, exec_count 1-7, 0 erreur**
- Sorties : alerte component-dominance step 30 (ALERT MEDIUM) + audit exit 1 + drift output_length x36 — tous vérifiés
- **Chemins machine normalisés** au basename (\`pt07_xxx/hackable_run.jsonl\`, pas de leak \`C:\Users\...\`) — règle secrets-hygiene 6/A (source corrigée + re-exec, pas de scrub manuel)
- Stubs exercices : \`print\` placeholder, aucune erreur (C.1)

## Suivi

README PostTraining 6→7 (row PT-07) = commit follow-up sur cette branche une fois le numéro de PR connu.

See #4531 (issue), #1742 (PostTraining tracker), #1454 (Epic). Ne ferme pas l'Epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)