### PR TITLE
docs(claw-systems): 02-NanoClaw-Architecture → vrai v2 + consolidation README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/README.md
@@ -30,7 +30,7 @@ Cette section adopte la convention pédagogique CoursIA standard : français-d'a
 
 Agent autonome minimaliste, conteneurisé, avec interface Telegram (texte + vocal).
 
-- **Architecture** : Conteneur Docker + API LLM (OpenRouter ou local) + Telegram Bot API + Whisper ASR pour le vocal
+- **Architecture (v2)** : un **hôte Node** orchestrant des **conteneurs d'agents par session**, hôte et agents ne communiquant **que** par des bases SQLite ; LLM via le Claude Agent SDK, interface Telegram, Whisper ASR pour le vocal — détail dans [02-NanoClaw-Architecture.md](docs/02-NanoClaw-Architecture.md)
 - **Déploiement** : Docker Compose, originellement sur ai-01 (cluster CoursIA)
 - **Fonctionnalités** : Chat, transcription vocale, skills personnalisables (function calling)
 - **Code source de référence** : roo-extensions issue #1318
@@ -78,7 +78,7 @@ L'enchaînement recommandé pour suivre le répertoire de bout en bout :
 |-------|--------|--------------------------------|
 | 1 | [00 — Philosophie Agentic Engineering](docs/00-Philosophie-Agentic-Engineering.md) | Poser le cadre. Sans le « pourquoi », le « comment » des modules suivants paraît arbitraire. |
 | 2 | [01 — OpenClaw / Origines Steinberger](docs/01-OpenClaw-Steinberger-Origins.md) | Comprendre **d'où viennent** ces idées (récit founder, MoltBook, leçons douloureuses). |
-| 3 | [02 — Architecture NanoClaw](docs/02-NanoClaw-Architecture.md) | Le plus simple des trois systèmes — c'est par là qu'on commence à mettre les mains dedans. |
+| 3 | [02 — Architecture NanoClaw](docs/02-NanoClaw-Architecture.md) | Le plus simple des trois systèmes — c'est par là qu'on commence à mettre les mains dedans. Compagnon : [M1 — « tout est message »](docs/M1-tout-est-message.md) pour le récit du principe fondateur. |
 | 4 | [03 — NanoClaw Deploy](docs/03-NanoClaw-Deploy.md) | Le déployer effectivement (Docker Compose, Telegram, ASR). |
 | 5 | [04 — ASR Integration](docs/04-ASR-Integration.md) | Approfondissement sur la transcription vocale (Whisper auto-hébergé). |
 | 6 | [05 — Architecture Hermes](docs/05-Hermes-Architecture.md) | Passer à un système plus complexe : fork upstream, drift isolé, MCPs, cron. |
@@ -88,18 +88,6 @@ L'enchaînement recommandé pour suivre le répertoire de bout en bout :
 | 10 | [09 — Patterns & Anti-Patterns](docs/09-Patterns-Anti-Patterns.md) *(draft, co-écrit)* | Les leçons apprises en production — incidents, fixes, règles d'or. |
 
 Une fois ce parcours terminé, un lecteur devrait être capable de **déployer NanoClaw lui-même** sans surprise majeure, **comprendre ce qu'il faut déployer pour un Hermes-like** sans devoir tout réinventer, et — surtout — **anticiper les incidents** plutôt que les découvrir.
-
-## Parcours NanoClaw v2 (en modules)
-
-> Cette série documente le **NanoClaw v2 réel**, tel qu'il tourne en production sur le cluster : un hôte Node unique orchestrant des conteneurs d'agents **par session**, où l'hôte et les agents ne communiquent **que** par des bases SQLite. Elle actualise progressivement les fiches `docs/NanoClaw-*.md`, qui décrivent un modèle conceptuel antérieur. Format **hybride** : une progression pédagogique en modules, chaque module ancré dans des décisions et des incidents de production réels.
-
-| Module | Sujet | Statut |
-|--------|-------|--------|
-| [M1 · Le modèle « tout est message »](docs/M1-tout-est-message.md) | Principe fondateur (zéro IPC), modèle d'entités, deux bases par session | ✅ disponible |
-| M2 · Architecture v2 | Hôte Node, conteneurs par session, détail des deux bases + base centrale | 🔜 à venir |
-| M3 · Déploiement Windows réel | Service, build du conteneur, vault de secrets, montages | 🔜 à venir |
-| M4 · Vivre en production | La chaîne de patches : incidents réels → correctifs | 🔜 à venir |
-| M5 · Coordination multi-bots | Intercom, mentions, patterns et anti-patterns (co-écrit) | 🔜 à venir |
 
 ## Structure
 
@@ -112,7 +100,7 @@ Claw-Systems/
 │   ├── 02-NanoClaw-Architecture.md                    # Archi NanoClaw
 │   ├── 03-NanoClaw-Deploy.md                          # Deploy NanoClaw
 │   ├── 04-ASR-Integration.md                          # Whisper auto-hébergé
-│   ├── M1-tout-est-message.md                         # Parcours NanoClaw v2 — Module 1 (NanoClaw)
+│   ├── M1-tout-est-message.md                         # Récit « tout est message » — companion de 02 (NanoClaw)
 │   ├── 05-Hermes-Architecture.md                      # Archi Hermes
 │   ├── 06-Hermes-Deploy-s6-Overlay.md                 # Deploy Hermes
 │   ├── 07-Hermes-Cluster-Coordinator-Role.md          # Rôle coordinateur cluster
@@ -164,7 +152,7 @@ Les Claw systems sont conçus pour fonctionner **avec ou sans le cluster CoursIA
 
 ## Liens — internes au cours
 
-- [Parcours NanoClaw v2 — M1 : « tout est message »](docs/M1-tout-est-message.md) — module NanoClaw (rédigé par NanoClaw, ai-01)
+- [M1 — Le modèle « tout est message »](docs/M1-tout-est-message.md) — récit du principe fondateur de NanoClaw v2, companion de [02 — Architecture NanoClaw](docs/02-NanoClaw-Architecture.md) (rédigé par NanoClaw, ai-01)
 - [Vibe-Coding parent](../README.md) — section englobante (Claude-Code, Roo-Code, Claw-Systems)
 - [Claude-Code](../Claude-Code/) — pendant assistant interactif (5 modules, 13-16h)
 - [Roo-Code](../Roo-Code/) — pendant assistant interactif VS Code-natif (5 modules)

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/02-NanoClaw-Architecture.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/02-NanoClaw-Architecture.md
@@ -1,135 +1,222 @@
-# NanoClaw - Architecture Technique
+# NanoClaw v2 — Architecture technique
 
-## Vue d'ensemble
+[← Claw-Systems](../README.md) | [↑ ..](../README.md)
 
-NanoClaw est un agent IA autonome leger, conteneurise dans Docker, avec une interface Telegram. Il combine un LLM (via OpenRouter ou local) avec des tools/skills pour executer des taches sans supervision humaine continue.
+> Ce chapitre décrit le **NanoClaw v2 réel**, tel qu'il tourne en production sur le
+> cluster CoursIA (le bot **ClusterManager** sur la machine `ai-01`, accessible par
+> Telegram). Le *principe fondateur* — « tout est message » — est raconté en récit
+> dans [M1 — Le modèle « tout est message »](M1-tout-est-message.md) ; ce document-ci
+> en donne l'**architecture technique** : les processus, les bases de données, et le
+> cycle de vie d'une requête. Lire M1 d'abord si vous voulez le « pourquoi » ; ce
+> chapitre est le « comment ».
 
-## Composants
+## De la v1 à la v2 : pourquoi une réécriture
+
+Les premières versions de NanoClaw suivaient le modèle classique des bots LLM : **une
+seule boucle agentique**, dans **un seul conteneur**, qui écoute Telegram, appelle un
+LLM (via OpenRouter ou un modèle local), exécute des outils, et répond. Simple, mais
+fragile dès qu'on veut **plusieurs conversations isolées**, **plusieurs agents** aux
+personnalités distinctes, ou une **frontière de sécurité** nette entre ce que voit un
+utilisateur et ce que voit un autre.
+
+NanoClaw **v2** est une réécriture *from scratch* qui inverse la structure : au lieu
+d'un agent monolithique, on a **un hôte Node unique** qui orchestre des **conteneurs
+d'agents éphémères, un par session**. L'hôte ne raisonne pas — il route. Les agents ne
+routent pas — ils raisonnent. Et entre les deux, **rien ne circule qui ne soit un
+message** écrit dans une base SQLite.
+
+| | v1 (modèle conceptuel antérieur) | v2 (production réelle) |
+|---|---|---|
+| **Topologie** | 1 conteneur = 1 agent | 1 hôte Node + N conteneurs (1 par session) |
+| **Communication hôte↔agent** | en-process (même boucle) | **uniquement** via 2 bases SQLite par session |
+| **Isolation** | aucune (un seul espace) | par session + par groupe d'agents |
+| **Plateformes** | Telegram | adaptateurs de canal (Telegram, Discord, Slack, …) installés par skill |
+| **Secrets** | variables d'environnement | injectés par requête via le vault OneCLI |
+
+## Le principe fondateur : « tout est message »
+
+La décision structurante de la v2 tient en une phrase : **il n'y a ni IPC, ni file
+watcher, ni pipe stdin entre l'hôte et le conteneur.** Les **deux bases SQLite** d'une
+session sont la **seule** surface d'entrée/sortie entre les deux mondes.
+
+Un message Telegram entrant devient une ligne dans une base. La réponse de l'agent
+devient une ligne dans une autre base. Le « réveil » d'un conteneur est un message. Un
+redémarrage planifié est un message. Une question en attente d'approbation est un
+message. Cette uniformité est ce qui rend le système **observable** (tout est dans
+SQLite, inspectable à froid), **rejouable**, et **robuste aux crashs** (un conteneur
+qui meurt ne perd rien — l'état durable est dans les bases, pas dans sa mémoire).
+
+> Le récit de *pourquoi* ce choix — et ce qu'il coûte — est dans
+> [M1 — Le modèle « tout est message »](M1-tout-est-message.md).
+
+## Le modèle d'entités
+
+Avant de router un message, il faut savoir **qui** parle, **où**, et **à quel agent**.
+La v2 modélise cela par une chaîne d'entités, du concret (un humain sur une plateforme)
+vers l'abstrait (une session de conteneur) :
 
 ```
-┌─────────────────────────────────────────────┐
-│                 Docker Host                  │
-│  ┌────────────────────────────────────────┐  │
-│  │          NanoClaw Container            │  │
-│  │                                        │  │
-│  │  ┌──────────┐    ┌──────────────────┐  │  │
-│  │  │  Telegram │    │   Agent Loop     │  │  │
-│  │  │  Bot API  │───→│                  │  │  │
-│  │  │  Polling  │    │  1. Receive msg   │  │  │
-│  │  └──────────┘    │  2. ASR si vocal   │  │  │
-│  │                   │  3. LLM call       │  │  │
-│  │  ┌──────────┐    │  4. Tool exec      │  │  │
-│  │  │  Skills/ │    │  5. Reply          │  │  │
-│  │  │  Tools   │←───│                  │  │  │
-│  │  └──────────┘    └──────┬───────────┘  │  │
-│  │                         │               │  │
-│  └─────────────────────────┼───────────────┘  │
-│                            │                  │
-│              ┌─────────────┼─────────────┐    │
-│              ▼             ▼             ▼    │
-│     OpenRouter     whisper-api      Outils   │
-│     (LLM API)     (ASR po-2023)    locaux    │
-└──────────────────────────────────────────────┘
+users                 «<canal>:<handle>» — une identité de plateforme (kind, display_name)
+  ↓  appartiennent à
+messaging_groups      un chat / canal sur une plateforme (instance = adaptateur)
+  ↕  reliés N-à-N via messaging_group_agents (session_mode, trigger_rules, priorité)
+agent_groups          un agent : workspace, mémoire, CLAUDE.md, personnalité, config conteneur
+  ↓  produisent
+sessions              (agent_group + messaging_group + thread_id) → un conteneur dédié
 ```
 
-## Agent Loop
+Le **privilège** est porté par l'utilisateur (`owner` / `admin`, global ou *scopé* à un
+groupe d'agents), pas par le groupe d'agents. Trois niveaux d'isolation sont possibles
+entre canaux : `agent-shared`, `shared`, ou agents séparés. Une **session** est
+l'intersection d'un agent, d'un canal, et d'un fil de discussion : c'est **l'unité de
+conteneur** et, de fait, l'unité d'isolation à l'exécution.
 
-Le coeur de NanoClaw est une boucle agentique :
+## Vue d'ensemble du flux
 
-1. **Polling Telegram** : Le bot ecoute les messages entrants (texte ou vocal)
-2. **Pre-processing** :
-   - Si message vocal : transcrire via `whisper-api.myia.io` (faster-whisper large-v3-turbo)
-   - Si texte : passer directement a l'etape suivante
-3. **Appel LLM** : Envoyer le message + historique + system prompt au modele
-4. **Tool calling** : Si le LLM demande un tool, l'executer et renvoyer le resultat
-5. **Reponse** : Envoyer la reponse finale via Telegram
+Le trajet complet d'un message, de la plateforme à la réponse :
 
-## Skills System
-
-Les skills sont des outils declaratifs que l'agent peut invoquer :
-
-```yaml
-skills:
-  - name: web_search
-    description: "Recherche web pour des informations actuelles"
-    type: api_call
-
-  - name: code_execute
-    description: "Execute du code Python dans un sandbox"
-    type: subprocess
-
-  - name: file_read
-    description: "Lit un fichier du workspace"
-    type: filesystem
+```
+  Utilisateur Telegram
+        │  (message texte / vocal)
+        ▼
+  Adaptateur de canal  ──────────────►  HÔTE (un seul process Node)
+        │                                     │
+        │                              router.ts : messaging_group → agent_group → session
+        │                                     │
+        │                                     ▼   écrit
+        │                              ┌──────────────┐
+        │                              │  inbound.db  │  messages_in (+ réveille le conteneur)
+        │                              └──────┬───────┘
+        │                                     │  lit (poll)
+        │                                     ▼
+        │                       CONTENEUR (par session, runtime Bun)
+        │                         agent-runner : poll → Claude Agent SDK → outils → réponse
+        │                                     │  écrit
+        │                              ┌───────▼──────┐
+        │                              │ outbound.db  │  messages_out, session_state
+        │                              └──────┬───────┘
+        │                                     │  lit (poll)
+        ◄─────────────────────────────  delivery.ts : livre via l'adaptateur
+  Réponse Telegram
 ```
 
-Chaque skill est expose au LLM via le schema function calling d'OpenAI. L'agent decide quand et comment les utiliser.
+Points-clés : **l'hôte ne parle jamais directement au conteneur** (il écrit dans
+`inbound.db` et lit `outbound.db`) ; **le conteneur ne parle jamais directement à
+l'hôte** (il lit `inbound.db` et écrit `outbound.db`). Le réveil lui-même n'est pas un
+signal système : c'est une nouvelle ligne dans `messages_in`.
 
-## Configuration
+## Le split two-DB par session
 
-### Variables d'environnement
+Chaque session possède **deux** fichiers SQLite sous
+`data/v2-sessions/<session_id>/` :
 
-```env
-# Telegram
-TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+| Fichier | Écrit par | Lu par | Contenu principal |
+|---------|-----------|--------|-------------------|
+| `inbound.db` | **hôte** | conteneur | `messages_in`, routing, destinations, `pending_questions`, `processing_ack` |
+| `outbound.db` | **conteneur** | hôte | `messages_out`, `session_state` |
 
-# LLM
-OPENROUTER_API_KEY=sk-or-v1-...
-MODEL_NAME=openai/gpt-4o-mini
+La règle invariante : **exactement un écrivain par fichier**. C'est ce qui évite toute
+contention de verrou entre deux montages (l'hôte et le conteneur voient les mêmes
+fichiers via des montages séparés). Deux garde-fous concrets en découlent :
 
-# ASR
-ASR_ENDPOINT=https://whisper-api.myia.io/v1/audio/transcriptions
-ASR_API_KEY=optional-bearer-token
+- **Parité des `seq`** : l'hôte numérote ses messages avec des `seq` **pairs**, le
+  conteneur avec des `seq` **impairs**. Impossible de collisionner sur un numéro de
+  séquence, même en écriture concurrente sur des fichiers distincts.
+- **Le heartbeat est un *touch* de fichier**, pas une écriture en base. Le conteneur
+  prouve qu'il est vivant en touchant `/workspace/.heartbeat` ; l'hôte lit la *mtime*.
+  Aucune transaction SQLite n'est nécessaire pour le battement de cœur — donc aucune
+  contention parasite.
 
-# Agent
-SYSTEM_PROMPT="Tu es un assistant utile..."
-MAX_TOKENS=4096
-TEMPERATURE=0.7
+Cette séparation est *load-bearing* : elle est aussi ce qui rend le système
+inspectable. Pour une requête ad hoc depuis un skill ou un script, on passe par le
+wrapper en arbre plutôt que par le binaire `sqlite3` :
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2-sessions/<session_id>/inbound.db \
+  "SELECT seq, role, substr(content,1,60) FROM messages_in ORDER BY seq DESC LIMIT 5"
 ```
 
-### Docker Compose (template)
+## La base centrale
 
-```yaml
-services:
-  nanoclaw:
-    image: nanoclaw:latest
-    container_name: nanoclaw
-    restart: unless-stopped
-    env_file: nanoclaw.env
-    volumes:
-      - ./workspace:/app/workspace
-    ports:
-      - "8080:8080"  # Health check / metrics
-```
+Tout ce qui n'est **pas** par-session vit dans une base centrale unique,
+`data/v2.db` : `users`, `user_roles`, `agent_groups`, `messaging_groups`, le câblage
+(`messaging_group_agents`), `pending_approvals`, `user_dms`, les tables du pont Chat
+SDK, et `schema_version`. Les migrations sont versionnées sous `src/db/migrations/`.
 
-## Endpoints ASR
+On a donc un **modèle à trois bases** : une base centrale (l'état partagé) et, par
+session, une paire entrée/sortie (le flux de messages). Aucune de ces bases n'est
+partagée en écriture entre deux processus.
 
-Le service de transcription vocale est heberge sur po-2023 :
+## Le runtime : deux mondes, un seul canal
 
-| Endpoint | Modele | Latence typique |
-|----------|--------|-----------------|
-| `POST /v1/audio/transcriptions` | faster-whisper large-v3-turbo | 2-5s (30s audio) |
+L'hôte et le conteneur n'exécutent **pas le même runtime**, et ne partagent **aucun
+module** :
 
-Format de requete (compatible OpenAI Whisper API) :
+| | Hôte | Conteneur (agent-runner) |
+|---|---|---|
+| **Runtime** | Node | Bun |
+| **Gestionnaire de paquets** | pnpm | bun |
+| **Rôle** | routage, livraison, *sweep*, cycle de vie des conteneurs | poll, appel LLM, exécution d'outils |
+| **LLM** | — | via le **Claude Agent SDK** (abstraction de provider) |
 
-```python
-import requests
+Le conteneur est piloté par le **Claude Agent SDK**, derrière une abstraction de
+provider (le provider `claude` est intégré ; d'autres, comme OpenCode, s'installent
+depuis la branche `providers`). Le **modèle** est configurable par groupe d'agents (via
+la config conteneur en base, ou `.env`) : en production sur `ai-01`, ClusterManager
+tourne sous **GLM-5.2**, avec une fenêtre de condensation plafonnée à 250k tokens. La
+config runtime par groupe (provider, modèle, paquets, serveurs MCP, montages) vit dans
+la table `container_configs` et est **matérialisée** en `groups/<folder>/container.json`
+au moment du *spawn*, pour que le *runner* de conteneur puisse la lire.
 
-response = requests.post(
-    "https://whisper-api.myia.io/v1/audio/transcriptions",
-    files={"file": open("voice.ogg", "rb")},
-    data={"model": "large-v3-turbo", "language": "fr"}
-)
-transcription = response.json()["text"]
-```
+> Hôte et conteneur ne communiquent **que** par les bases de session. Il n'y a aucun
+> appel de fonction, aucun socket, aucun module commun entre les deux arbres de code —
+> c'est la traduction concrète de « tout est message ».
 
-## Deploiement
+## Les secrets : le vault OneCLI
 
-Voir [NanoClaw-Deploy.md](NanoClaw-Deploy.md) pour le guide complet de deploiement.
+Aucune clé d'API, token OAuth, ou credential ne transite par une variable
+d'environnement ni par le contexte de chat. Les secrets sont gérés par le **gateway
+OneCLI** et **injectés dans le conteneur au moment de la requête**. Le conteneur
+apprend à utiliser ce proxy via un *skill* dédié (`onecli-gateway`), qui lui enseigne
+notamment à **ne jamais demander de credentials bruts**. Conséquence pratique : un
+`401` sur une API dont la clé *est* pourtant dans le vault signale en général un agent
+en mode `selective` plutôt qu'un secret manquant (voir
+[03-NanoClaw-Deploy.md](03-NanoClaw-Deploy.md)).
+
+## Les canaux : des adaptateurs installés par skill
+
+Le tronc commun NanoClaw ne livre **aucun** adaptateur de canal spécifique : le dépôt
+est l'**infrastructure** (registre, pont Chat SDK), et les adaptateurs réels
+(Telegram, Discord, Slack, WhatsApp, …) vivent sur une branche `channels` et sont
+copiés en place par des skills `/add-<canal>` idempotents. Même logique pour les
+providers non-Claude (branche `providers`). On garde ainsi un tronc minimal et on
+n'embarque que ce dont une installation a besoin.
 
 ## Points de vigilance
 
-- **Rate limiting** : OpenRouter a des limites par plan. Monitorer l'utilisation.
-- **Contexte conversation** : Limiter l'historique envoyé au LLM pour controlling les couts.
-- **Messages vocaux** : Les fichiers OGG Telegram doivent etre convertis avant ASR si le endpoint l'exige.
-- **Securite** : Le bot token Telegram ne doit jamais etre commité. Utiliser des secrets Docker ou `.env` non versionné.
+- **Un seul écrivain par base.** Ne jamais faire écrire l'hôte dans `outbound.db` ni le
+  conteneur dans `inbound.db` — c'est l'invariant qui tient tout le modèle.
+- **Les logs du conteneur sont éphémères** (`--rm`). Si un agent échoue silencieusement
+  *dans* le conteneur, il n'y a pas de log persistant : c'est `messages_in` /
+  `messages_out` qu'on inspecte pour savoir où la chaîne s'est interrompue.
+- **`journal_mode=DELETE`** sur les bases de session est *load-bearing* pour la
+  visibilité cross-montage — ne pas le passer en WAL.
+- **Sécurité.** Le token de bot ne doit jamais être commité ; les credentials passent
+  par le vault, pas par `.env` versionné.
+
+## Pour aller plus loin
+
+- [03-NanoClaw-Deploy.md](03-NanoClaw-Deploy.md) — déployer NanoClaw (service, build du
+  conteneur, vault de secrets, montages).
+- [04-ASR-Integration.md](04-ASR-Integration.md) — la transcription vocale (Whisper
+  auto-hébergé).
+- [08-Multi-Bot-Coordination.md](08-Multi-Bot-Coordination.md) — comment plusieurs
+  Claws coexistent (intercom, mentions, anti-collision).
+- [09-Patterns-Anti-Patterns.md](09-Patterns-Anti-Patterns.md) — les leçons de
+  production (incidents réels → correctifs).
+
+## Liens
+
+- [M1 — Le modèle « tout est message »](M1-tout-est-message.md) — le récit du principe fondateur
+- [Architecture Hermes](05-Hermes-Architecture.md) — le second Claw system du cluster
+- [Claw-Systems (README)](../README.md)


### PR DESCRIPTION
## Contexte

Exécution de la **décision ai-01 du 2026-06-28** (déconfliction #4428, option **(a)** : source unique de vérité) — une fois **PR-C #4507 mergée**, NanoClaw (ai-01) actualise sa partie. Tracker #4428 / Epic #4427.

Le répertoire portait jusqu'ici **deux framings parallèles** de l'architecture NanoClaw : la fiche `02-NanoClaw-Architecture.md` (modèle **v1-ish** — OpenRouter, boucle agentique unique, function-calling OpenAI) **et** une table « Parcours NanoClaw v2 (M1-M5) » dans le README (le vrai v2). Cette PR fond les deux en une seule source.

## Changements

**`docs/02-NanoClaw-Architecture.md`** — réécriture vers le **vrai v2** tel qu'il tourne en prod (ClusterManager, ai-01) :
- hôte Node unique orchestrant des **conteneurs d'agents par session** ;
- principe **« tout est message »** (zéro IPC / watcher / stdin) ;
- **split two-DB** par session (inbound/outbound, un seul écrivain, parité seq pair/impair, heartbeat = touch fichier) ;
- **base centrale** `data/v2.db` (modèle à 3 bases) ;
- modèle d'entités `users → messaging_groups → agent_groups → sessions` ;
- runtime **Bun + Claude Agent SDK**, modèle GLM-5.2 / condensation 250k en prod ;
- secrets via **vault OneCLI** (injection par requête) ; canaux installés par skill.

**`README.md`** — consolidation en TOC unique :
- retrait de la table parallèle « Parcours NanoClaw v2 (en modules) » (M1-M5) ;
- **M1 conservé** et reste discoverable : référencé comme **compagnon-récit de 02** dans le parcours 00-09 (étape 3), l'arbre de structure, et les liens internes ;
- correction du bullet d'archi NanoClaw qui décrivait encore la v1.

## Points pour le reviewer (ai-01)

1. **Sort de M1** — j'ai choisi de **conserver** `M1-tout-est-message.md` comme récit-compagnon de 02 (scopes distincts : M1 = le *pourquoi* narratif, 02 = le *comment* technique), plutôt que de le fondre+supprimer. C'est l'option réversible. **Si tu préfères fondre M1 dans 02 et `git rm` le fichier** (source vraiment unique), c'est un follow-up trivial — dis-le et je l'ouvre.
2. **Résidus OpenRouter dans le README** — la table « Infrastructure de référence » et les « Prérequis » mentionnent encore OpenRouter pour NanoClaw. Laissés **intentionnellement** (le README cadre les composants comme remplaçables) ; `02` est désormais la source autoritaire v2. À trancher si tu veux que je les aligne aussi.

## Vérifications
- `python scripts/check_docs_links.py --check --quiet` → **EXIT 0** (aucun lien mort — la porte qui avait HELD PR-A #4437).
- Secret sweep sur les fichiers modifiés → clean.
- UTF-8 **no-BOM**, accents intacts.
- `git diff --stat` : 2 fichiers, +205 / -130.

Review/merge par **ai-01** (pas de self-merge).
