### PR TITLE
docs(qc): FR backfill Sector-ML-Classification README (#3870)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Sector-ML-Classification/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Sector-ML-Classification/README.en.md
@@ -1,0 +1,64 @@
+# Sector ML Classification
+
+**Status**: 🔄 Research Phase - Based on HandsOnAITrading Book
+
+## Description
+
+Sector rotation strategy using Machine Learning (Random Forest) to classify US sectors into buy/hold/avoid categories.
+
+### Strategy Overview
+
+- **11 Sector ETFs**: XLK, XLF, XLV, XLE, XLY, XLP, XLI, XLB, XLU, XLRE, XLC
+- **ML Classification**: Random Forest with 3 classes (BUY, HOLD, AVOID)
+- **Monthly Rebalancing**: Top 3 sectors classified as "BUY" (equal-weight)
+- **Features**: Technical indicators from QC-Py-18 (Feature Engineering)
+
+### Key Features
+
+- **Random Forest Classifier**: sklearn.ensemble.RandomForestClassifier
+  - Handles non-linear relationships
+  - Feature importance analysis
+  - Robust to overfitting
+
+- **Feature Engineering** (from QC-Py-18):
+  - Momentum indicators (RSI, MACD)
+  - Trend indicators (SMA, EMA)
+  - Volatility measures (ATR, Bollinger Bands)
+
+- **Universe**: 11 GICS Sector ETFs (SPDR sector spiders)
+
+## Sector ETFs
+
+| Ticker | Sector | Description |
+|--------|--------|-------------|
+| XLK | Technology | Tech giants (AAPL, MSFT, NVDA) |
+| XLF | Financials | Banks, insurance |
+| XLV | Healthcare | Pharma, medical devices |
+| XLE | Energy | Oil, gas companies |
+| XLY | Consumer Disc | Retail, autos, luxury |
+| XLP | Consumer Staples | Essentials, food, beverages |
+| XLI | Industrials | Manufacturing, aerospace |
+| XLB | Materials | Chemicals, mining |
+| XLU | Utilities | Power, water, gas |
+| XLRE | Real Estate | REITs, property |
+| XLC | Communication | Telecom, media, internet |
+
+## Files
+
+- `main.py`: QC algorithm with Random Forest classifier
+- `research.ipynb`: Research notebook with feature engineering and model training
+- `config.json`: Project configuration
+
+## References
+
+- **Book**: Hands-On AI Trading (ML Classification chapter)
+- **Related Notebook**: QC-Py-19-ML-Supervised-Classification.ipynb
+- **Concept**: Sector Rotation based on ML predictions
+
+## Status
+
+Research phase. Performance metrics and backtesting results to be determined.
+
+---
+
+**Note**: Sector rotation adds diversification beyond single-asset strategies.

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Sector-ML-Classification/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Sector-ML-Classification/README.md
@@ -1,64 +1,64 @@
 # Sector ML Classification
 
-**Status**: 🔄 Research Phase - Based on HandsOnAITrading Book
+**Statut** : 🔄 Phase de recherche — basé sur le livre HandsOnAITrading.
 
 ## Description
 
-Sector rotation strategy using Machine Learning (Random Forest) to classify US sectors into buy/hold/avoid categories.
+Stratégie de rotation sectorielle utilisant le Machine Learning (Random Forest) pour classer les secteurs US en catégories buy/hold/avoid.
 
-### Strategy Overview
+### Vue d'ensemble de la stratégie
 
-- **11 Sector ETFs**: XLK, XLF, XLV, XLE, XLY, XLP, XLI, XLB, XLU, XLRE, XLC
-- **ML Classification**: Random Forest with 3 classes (BUY, HOLD, AVOID)
-- **Monthly Rebalancing**: Top 3 sectors classified as "BUY" (equal-weight)
-- **Features**: Technical indicators from QC-Py-18 (Feature Engineering)
+- **11 ETF sectoriels** : XLK, XLF, XLV, XLE, XLY, XLP, XLI, XLB, XLU, XLRE, XLC
+- **Classification ML** : Random Forest à 3 classes (BUY, HOLD, AVOID)
+- **Rééquilibrage mensuel** : les 3 premiers secteurs classés « BUY » (équi-pondéré)
+- **Features** : indicateurs techniques issus de QC-Py-18 (Feature Engineering)
 
-### Key Features
+### Caractéristiques principales
 
-- **Random Forest Classifier**: sklearn.ensemble.RandomForestClassifier
-  - Handles non-linear relationships
-  - Feature importance analysis
-  - Robust to overfitting
+- **Classifieur Random Forest** : `sklearn.ensemble.RandomForestClassifier`
+  - Gère les relations non-linéaires
+  - Analyse de l'importance des features
+  - Robuste au surajustement
 
-- **Feature Engineering** (from QC-Py-18):
-  - Momentum indicators (RSI, MACD)
-  - Trend indicators (SMA, EMA)
-  - Volatility measures (ATR, Bollinger Bands)
+- **Feature Engineering** (issu de QC-Py-18) :
+  - Indicateurs de momentum (RSI, MACD)
+  - Indicateurs de tendance (SMA, EMA)
+  - Mesures de volatilité (ATR, bandes de Bollinger)
 
-- **Universe**: 11 GICS Sector ETFs (SPDR sector spiders)
+- **Univers** : 11 ETF sectoriels GICS (SPDR sector spiders)
 
-## Sector ETFs
+## ETF sectoriels
 
-| Ticker | Sector | Description |
-|--------|--------|-------------|
-| XLK | Technology | Tech giants (AAPL, MSFT, NVDA) |
-| XLF | Financials | Banks, insurance |
-| XLV | Healthcare | Pharma, medical devices |
-| XLE | Energy | Oil, gas companies |
-| XLY | Consumer Disc | Retail, autos, luxury |
-| XLP | Consumer Staples | Essentials, food, beverages |
-| XLI | Industrials | Manufacturing, aerospace |
-| XLB | Materials | Chemicals, mining |
-| XLU | Utilities | Power, water, gas |
-| XLRE | Real Estate | REITs, property |
-| XLC | Communication | Telecom, media, internet |
+| Ticker | Secteur | Description |
+|--------|---------|-------------|
+| XLK | Technologie | Géants tech (AAPL, MSFT, NVDA) |
+| XLF | Finances | Banques, assurance |
+| XLV | Santé | Pharma, dispositifs médicaux |
+| XLE | Énergie | Pétrole, gaz |
+| XLY | Discrétionnaire | Retail, autos, luxe |
+| XLP | Produits de base | Essentiels, alimentation, boissons |
+| XLI | Industriels | Manufacturing, aéronautique |
+| XLB | Matériaux | Chimie, mines |
+| XLU | Services publics | Électricité, eau, gaz |
+| XLRE | Immobilier | REIT, propriété |
+| XLC | Communication | Télécom, média, internet |
 
-## Files
+## Fichiers
 
-- `main.py`: QC algorithm with Random Forest classifier
-- `research.ipynb`: Research notebook with feature engineering and model training
-- `config.json`: Project configuration
+- `main.py` : algorithme QC avec classifieur Random Forest
+- `research.ipynb` : notebook de recherche avec feature engineering et entraînement du modèle
+- `config.json` : configuration du projet
 
-## References
+## Références
 
-- **Book**: Hands-On AI Trading (ML Classification chapter)
-- **Related Notebook**: QC-Py-19-ML-Supervised-Classification.ipynb
-- **Concept**: Sector Rotation based on ML predictions
+- **Livre** : Hands-On AI Trading (chapitre ML Classification)
+- **Notebook associé** : QC-Py-19-ML-Supervised-Classification.ipynb
+- **Concept** : rotation sectorielle basée sur des prédictions ML
 
-## Status
+## Statut
 
-Research phase. Performance metrics and backtesting results to be determined.
+Phase de recherche. Les métriques de performance et les résultats de backtest restent à déterminer.
 
 ---
 
-**Note**: Sector rotation adds diversification beyond single-asset strategies.
+**Note** : la rotation sectorielle ajoute de la diversification au-delà des stratégies mono-actif.


### PR DESCRIPTION
## Summary

Phase 0.5 FR backfill (#1650) of the **Sector-ML-Classification** README — research-phase strategy doc (sector rotation using Random Forest ML to classify 11 US GICS sector ETFs into BUY/HOLD/AVOID, monthly rebalancing, features from QC-Py-18).

Follows `readme-french-first` HARD 2 protocol:
- `git mv README.md -> README.en.md` (original EN preserved **byte-identical verbatim** — golden set + future Phase 3 deliverable)
- New `README.md` written in **French** (43 accented chars, fresh translation not mechanical find-replace)
- Strategy name + tickers + code identifiers kept EN (`Sector ML Classification`, `XLK`/`XLF`/..., `RandomForestClassifier`, `BUY`/`HOLD`/`AVOID`, `RSI`/`MACD`/`SMA`/`EMA`/`ATR`); prose in FR

## Verification

- `git show HEAD:.../README.md | diff - README.en.md` → **empty (byte-identical preservation OK)**
- Accent count: 43 accented chars
- G.1 grammar check (#4502 lesson): no `sous-estime`/`sous-estimé` verb/participle regression — translation is FR-fresh
- 0 catalog markers touched (`COURSE_CATALOG.generated.*` byte-identical to main)
- Atomic: 2 files (`A README.en.md` + `M README.md`), +106/-42
- markdown-only edit (exception C.2 — no re-execution needed); MD060 warnings = cosmetic table-pipe spacing identical to EN original (HARD 2 structure preservation), non-enforced by repo CI

## Scope

Markdown-only documentation translation. No code, no notebook, no catalog regeneration (left to `catalog-cron.yml`).

See #3870 (Part of #1650 Phase 0.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)