### PR TITLE
docs(sudoku): resync README count 32→33 for 7b-Lean-Propagation (#4402 missed)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -9,7 +9,7 @@ maturity: PRODUCTION=32, BETA=1
 
 [← Notebooks](../README.md) | [→ Search](../Search/README.md)
 
-Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. Les 32 notebooks (16 C#, 16 Python) sont proposés en **approche miroir C#/Python** pour permettre à chaque étudiant de choisir son langage.
+Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. Les 33 notebooks — **16 C# et 16 Python en approche miroir** (un par algorithme dans chaque langage), plus un companion Lean natif ([Sudoku-7b](Sudoku-7b-Lean-Propagation.ipynb)) — permettent à chaque étudiant de choisir son langage.
 
 **À qui s'adresse cette série** : étudiants en informatique (L2-M2) découvrant les paradigmes algorithmiques, candidats à des entretiens techniques, et enseignants cherchant un fil rouge pédagogique. Les notebooks Python ne nécessitent que Python 3.10+. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en IA : les concepts sont introduits depuis le backtracking.
 


### PR DESCRIPTION
## Contexte

`SymbolicAI/../Sudoku/` (leaf README, partition po-2025:CoursIA-2 dans #3975) — **même drift que Planners #4535** : la PR #4402 a ajouté `Sudoku-7b-Lean-Propagation.ipynb` (5e companion Lean4 natif) mais le compte prose du README n'a pas été resynchronisé.

## Preuve du drift (grounded firsthand)

| Source | Valeur |
|--------|--------|
| Filesystem (`*.ipynb`, hors `_output`/checkpoints) | **33** (16 C# + 16 Python + 1 Lean `Sudoku-7b`) |
| CATALOG-STATUS marker (`pedagogical_count`) | **33** ✓ (déjà correct) |
| Table row 7b (L333) | **présente** ✓ |
| Prose L12 (avant) | ~~« 32 notebooks (16 C#, 16 Python) »~~ (drift — le companion Lean non compté) |

→ Le marker généré + la table étaient déjà à jour, mais la prose curée était restée à 32.

## Changement (1 ligne, `Sudoku/README.md`)

**L12** : `Les 32 notebooks (16 C#, 16 Python) sont proposés en approche miroir C#/Python...` → `Les 33 notebooks — 16 C# et 16 Python en approche miroir (un par algorithme dans chaque langage), plus un companion Lean natif (Sudoku-7b) — permettent...`

Le companion Lean **n'est pas** un miroir C#/Python — le framing distingue donc le miroir (32) du total (33).

## Validation

- `git diff --stat` : 1 fichier, 1 insertion, 1 déletion — diff cohérent (resync prose)
- **CATALOG-STATUS byte-identique** (`pedagogical_count: 33`, `maturity: PRODUCTION=32, BETA=1` = 33 — automation-owned, non touché)
- **L689 « (16 + 16 notebooks) »** laissé intact — elle décrit correctement le sous-ensemble miroir spécifiquement, pas le total
- Branche fraîche depuis `origin/main` (`5f5daf7b6`) — pas de base stale
- Markdown-only → pas de re-exécution (exception C.2)

## Périmètre

Atomique : 1 fichier, 1 sujet (resync compte 7b). Même shape que #4535 (Planners 5b). SmartContracts (27 nb) vérifié CLEAN au passage (pas de drift).

See #3975 (contribution partielle à l'Epic leaf READMEs — partition Sudoku, po-2025:CoursIA-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)