### PR TITLE
docs(claw-systems): NanoClaw stale OpenRouter → backend Claudish (#4428)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/configs/nanoclaw.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/configs/nanoclaw.env.example
@@ -4,15 +4,26 @@
 # === TELEGRAM (required) ===
 TELEGRAM_BOT_TOKEN=
 
-# === LLM (required - choose one) ===
-# Option A: OpenRouter (recommended for beginners)
-OPENROUTER_API_KEY=
-MODEL_NAME=openai/gpt-4o-mini
+# === Backend LLM (required) ===
+# NanoClaw parle le wire Anthropic. En production il consomme Claudish, le proxy
+# multi-providers du cluster (voir Vibe-Coding/Claudish/docs/Claudish-Proxy.md).
+# Claudish route vers le provider budgete du tier demande (GLM Coding Plan,
+# vLLM Qwen, ou Anthropic natif) — NanoClaw n'a pas a connaitre le provider reel.
+ANTHROPIC_BASE_URL=https://models.myia.io
+ANTHROPIC_AUTH_TOKEN=
 
-# Option B: Local LLM (Ollama, vLLM, etc.)
-# LLM_BASE_URL=http://localhost:11434/v1
-# MODEL_NAME=llama3
-# OPENROUTER_API_KEY=not-needed
+# Tier cible (un seul nom suffit ; Claudish fait la traduction vers le provider) :
+#   glm-5.2            = Sonnet-tier (GLM via Claudish) — defaut
+#   qwen3.6-35b-a3b    = Haiku-tier (vLLM Qwen self-hoste)
+#   claude-opus-4-8    = Opus-tier (Anthropic natif)
+MODEL_NAME=glm-5.2
+
+# --- Alternative : provider compatible Anthropic EN DIRECT (dev / bypass Claudish) ---
+# De-commenter pour court-circuiter Claudish (ex. couche de compat z.ai,
+# meme pattern que 06-Hermes-Deploy). On perd concurrence + never-hang + 529 + observabilite.
+# ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+# ANTHROPIC_AUTH_TOKEN=<your-zai-api-key>
+# MODEL_NAME=glm-5.2
 
 # === ASR (optional - for voice messages) ===
 ASR_ENDPOINT=https://whisper-api.myia.io/v1/audio/transcriptions

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/03-NanoClaw-Deploy.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/03-NanoClaw-Deploy.md
@@ -1,5 +1,7 @@
 # NanoClaw - Guide de Deploiement
 
+> **Backend LLM** : NanoClaw consomme le proxy **Claudish** (voir [`Vibe-Coding/Claudish/docs/Claudish-Proxy.md`](../Claudish/docs/Claudish-Proxy.md)), qui route vers 3 providers budgetés selon le tier — **pas** OpenRouter en direct. La configuration ci-dessous reflete cet agencement de production.
+
 ## Prerequis
 
 | Outil | Version | Usage |
@@ -8,10 +10,10 @@
 | Docker Compose | v2+ | Orchestration |
 | curl | any | Tests API |
 
-### Tokens requis
+### Tokens / acces requis
 
 1. **Telegram Bot Token** : Creer via [@BotFather](https://t.me/BotFather) sur Telegram
-2. **OpenRouter API Key** : [openrouter.ai](https://openrouter.ai) — route vers GPT-4o, Claude, etc.
+2. **Acces Claudish** : `ANTHROPIC_BASE_URL` du proxy (ex. `https://models.myia.io`) + une clé d'auth (`ANTHROPIC_AUTH_TOKEN`). Claudish route ensuite vers le provider du tier demande — voir le guide Claudish pour les providers sous-jacents (GLM Coding Plan / vLLM Qwen / Anthropic natif).
 3. **ASR Bearer Token** (optionnel) : Si `whisper-api.myia.io` requiert une authentification
 
 ## Installation
@@ -30,18 +32,24 @@ Creer le fichier `.env` a partir du template :
 cp nanoclaw.env.example .env
 ```
 
-Editer `.env` avec vos tokens :
+Editer `.env` avec vos acces :
 
 ```env
 # OBLIGATOIRE
 TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
-OPENROUTER_API_KEY=sk-or-v1-...
+
+# Backend LLM = Claudish (proxy Anthropic-compatible multi-providers)
+ANTHROPIC_BASE_URL=https://models.myia.io
+ANTHROPIC_AUTH_TOKEN=<claudish-token>
+# Tier cible (Claudish remappe vers le provider budgete du tier) :
+MODEL_NAME=glm-5.2
 
 # OPTIONNEL
 ASR_ENDPOINT=https://whisper-api.myia.io/v1/audio/transcriptions
-MODEL_NAME=openai/gpt-4o-mini
 SYSTEM_PROMPT=Tu es NanoClaw, un assistant autonome.
 ```
+
+> **Note sur `MODEL_NAME`** : NanoClaw parle le wire Anthropic via Claudish. Envoyer un nom de modele du tier voulu (`glm-5.2` = Sonnet-tier via GLM, `claude-opus-4-8` = Opus-tier Anthropic natif, `qwen3.6-35b-a3b` = Haiku-tier vLLM). Claudish gere la traduction vers le provider reel — NanoClaw n'a pas a connaitre GLM, vLLM ou Anthropic en direct. Voir la section « Connecter un bot » de `Claudish-Proxy.md`.
 
 ### 3. Lancer le service
 
@@ -85,15 +93,32 @@ Si la transcription echoue :
 
 ## Configuration avancee
 
-### Modele local (alternative a OpenRouter)
+### Changer de tier / de modele
 
-Si un LLM local est disponible (Ollama, vLLM) :
+Le tier se change en une ligne via `MODEL_NAME`, sans toucher au transport :
 
 ```env
-LLM_BASE_URL=http://localhost:11434/v1
-MODEL_NAME=llama3
-OPENROUTER_API_KEY=not-needed
+# Sonnet-tier (GLM via Claudish) — defaut, bon rapport qualite/cout
+MODEL_NAME=glm-5.2
+
+# Haiku-tier (vLLM Qwen self-hoste) — leger, rapide
+MODEL_NAME=qwen3.6-35b-a3b
+
+# Opus-tier (Anthropic natif) — reflexion lourde
+MODEL_NAME=claude-opus-4-8
 ```
+
+### Bypass Claudish (provider en direct)
+
+En dev, on peut court-circuiter Claudish et pointer un provider compatible Anthropic en direct (ex. la couche de compat z.ai, meme pattern que le module [06-Hermes-Deploy](06-Hermes-Deploy-s6-Overlay.md)) :
+
+```env
+ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+ANTHROPIC_AUTH_TOKEN=<zai-api-key>
+MODEL_NAME=glm-5.2
+```
+
+> En production, preferer Claudish : il ajoute le controle de concurrence, le never-hang (priorite #1), la conversion overload 529 + Retry-After, et l'observabilite (captures, surveillance trafic). Voir `Claudish-Proxy.md` §6.
 
 ### Subdomain et HTTPS
 
@@ -136,7 +161,9 @@ services:
 | Symptome | Cause probable | Resolution |
 |----------|---------------|------------|
 | Bot ne repond pas | Token Telegram invalide | Verifier via BotFather |
-| Erreur LLM 401 | API key OpenRouter | Verifier cle + credits |
+| Erreur LLM 401 | Clé Claudish / `ANTHROPIC_AUTH_TOKEN` | Verifier la cle + que `ANTHROPIC_BASE_URL` pointe le proxy |
+| Erreur LLM 404 sur `/chat/completions` | NanoClaw envoie du wire OpenAI au lieu d'Anthropic | Claudish ne sert que le wire Anthropic — verifier que NanoClaw utilise le transport Anthropic (voir `Claudish-Proxy.md` §5, lecon Hermes) |
+| Slug modele 404 (`glm-5-2`) | Tiret au lieu du point | Utiliser `glm-5.2` (point), pas `glm-5-2` |
 | Timeout ASR | whisper-api down | `curl whisper-api.myia.io/health` |
 | Container restart loop | `.env` manquant | Verifier `docker logs nanoclaw` |
 


### PR DESCRIPTION
## Contexte

Directive ai-01 (DM `msg-20260628T141303-bi0xb0`, décision `(b)` DM `msg-20260628T132325-mjxvvk`) : le stale OpenRouter dans Claw-Systems est à corriger en PR atomique **après** le merge de la stack Claw (PR-B #4503 + PR-C #4507), pour ne pas recasser les liens qu'hermes avait réparés. Stack mergée 14:02Z → gate levée.

NanoClaw's deploy doc + env template pointaient encore vers OpenRouter comme backend LLM par défaut, alors qu'en production les bots consomment Claudish (proxy Anthropic-compatible multi-providers), pas OpenRouter direct.

## Changements

- **`03-NanoClaw-Deploy.md`** : backend = Claudish (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` + nom de modèle du tier). Nouvelle section « Changer de tier » (`glm-5.2` / `qwen3.6` / `opus` via une ligne `MODEL_NAME`) + bypass dev (z.ai compat direct). Troubleshooting couvre désormais le gotcha wire-Anthropic-only + le piège de slug `glm-5.2` (leçon Hermes).
- **`nanoclaw.env.example`** : remplace les options OpenRouter/local par le bloc de config Claudish + une alternative provider-direct commentée. Placeholders uniquement, aucun secret réel.

Aligné sur `Vibe-Coding/Claudish/docs/Claudish-Proxy.md` (router 3 providers gc@/vllm/anthropic-native + trick nom Claude).

## Frontière (collision-discipline)

Scope strict : **03 + configs uniquement**.
- `02-NanoClaw-Architecture.md` = **déjà corrigé par #4539** (l'unique mention restante y est du cadrage historique v1 exact, à garder).
- `README.md` (4 mentions OpenRouter) = **déféréré** à un follow-up **après merge de #4539** (NanoClaw y consolide le README) → 0 conflit.

## Vérifs
- 0 token/clé littéral (placeholders `<claudish-token>`, `<your-zai-api-key>` uniquement).
- 0 OpenRouter stale (la seule mention est le cadrage intro « pas OpenRouter en direct »).
- Base `origin/main` frais (`5f5daf7b6`), atomique, 1 sujet.

See #4428. Review/merge ai-01.