### PR TITLE
feat(lean): conway P4.4 S2 boundary-leak PROVEN — window_cone_in_domain (sorry 4 stable)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1981,11 +1981,12 @@ of milestones with clear interfaces (the same methodology that isolated
 - **S1 (CLOSED — `evolve_add` below)** : function-iteration composition.
   `evolve (a + b) g = evolve a (evolve b g)`. Pure `step^[·]` arithmetic, no
   `hashlifeResultAux`, no whnf wall — proven.
-- **S2 (sub-sorry)** : boundary does not leak — for `p` in the centered window
-  `[2^k, 2^k + 2^(k+1))²`, the light cone `lightCone p (2^k)` (radius of
-  `evolve 2^(k-1)`, via `step_light_cone`) stays inside the domain covered by
-  `c.toGrid (0,0)`. Geometric (manhattan bounds), consumes the already-proven
-  `mem_lightCone_of_manhattan_le`.
+- **S2 (CLOSED — `window_cone_in_domain` below)** : boundary does not leak —
+  for `p` in the centered window `[2^k, 2^k + 2^(k+1))²`, the light cone
+  `lightCone p (2^k)` (radius of `evolve 2^(k-1)`, via `step_light_cone`) stays
+  inside the domain covered by `c.toGrid (0,0)`. Pure Manhattan arithmetic, no
+  `hashlifeResultAux`, no whnf wall — proven (`manhattan_deviation` Nat→Int
+  bridge + power-normalization + pure-Int `linarith`).
 - **S3 (sub-sorry)** : sub-cell coverage — the quadrant super-cell `q_j` whose
   centered region contains `p` agrees with `c.toGrid` on that light cone, so
   `evolve 2^(k-1) (c.toGrid) p = evolve 2^(k-1) (q_j.toGrid) p` by
@@ -1994,9 +1995,10 @@ of milestones with clear interfaces (the same methodology that isolated
   `centralCorrect q_j (k-1)` facts from P4.3 (`p4_wave2_ih`) to conclude the
   pointwise membership agreement that `p4_succ_membership` needs.
 
-Until S2–S4 are closed, `p4_half_steps_compose` remains the `True` placeholder
-(it is consumed by `p4_succ_membership` only structurally); closing each
-sub-sorry shrinks the open surface without touching the others. -/
+Until S3–S4 are closed, `p4_half_steps_compose` remains the `True` placeholder
+(it is consumed by `p4_succ_membership` only structurally); S1 (composition)
+and S2 (no-leak) are now closed, so the remaining open surface is the
+sub-cell-coverage + assembly argument (S3, S4). -/
 
 /-- **S1** (CLOSED): `evolve (a + b) g = evolve a (evolve b g)`.
 
@@ -2010,6 +2012,84 @@ theorem evolve_add (a b : Nat) (g : Grid) :
   | zero => simp [evolve_zero]
   | succ n ih =>
     rw [Nat.succ_add, evolve_succ, evolve_succ, ih]
+
+/-- **S2 helper**: lift the `Nat` `manhattan` bound to per-coordinate `Int.abs`
+    bounds. Isolated from `window_cone_in_domain` below so the cone/window
+    reasoning works purely in `Int`: `omega` closes the `Nat.natAbs` goals here
+    in isolation, but splits the `Nat` `2^k` atom from its `(2^k : Int)` cast
+    when both appear in one goal (a known `omega` limitation on mixed
+    `Nat`/`Int` atoms). -/
+private theorem manhattan_deviation (p q : Int × Int) (R : Nat)
+    (h : manhattan p q ≤ R) : |p.1 - q.1| ≤ (R : Int) ∧ |p.2 - q.2| ≤ (R : Int) := by
+  -- Isolate the Nat `manhattan`/`natAbs` → `Int.abs` lifting from the
+  -- power/window reasoning, so `window_cone_in_domain` below works purely in
+  -- `Int` (omega handles `Int.abs` + powers cleanly, but struggles when
+  -- `Nat.natAbs` and `Int.abs` of the same term share a goal).
+  unfold manhattan at h
+  have h1' : Int.natAbs (p.1 - q.1) ≤ R := by omega
+  have h2' : Int.natAbs (p.2 - q.2) ≤ R := by omega
+  refine ⟨?_, ?_⟩
+  · rw [Int.abs_eq_natAbs]; exact_mod_cast h1'
+  · rw [Int.abs_eq_natAbs]; exact_mod_cast h2'
+
+/-- **S2** (CLOSED): the light cone does not leak out of the MacroCell domain.
+
+    For a point `p` in the centered window `[2^k, 2^k + 2^(k+1))²` (the region
+    the Hashlife result covers), any cell `q` within Manhattan distance `2^k`
+    of `p` — i.e. any cell in the light cone `lightCone p (2^k)` (radius `2^k`
+    is exactly the cone radius of `evolve 2^(k-1)` via `step_light_cone`) —
+    stays inside the full MacroCell domain `[0, 2^(k+2))²`.
+
+    This is the geometric core of the "boundary does not leak" half of P4.4:
+    it is why the wave-2 super-cells, each computing `evolve 2^(k-1)` on its
+    own grid, nonetheless agree with the global `evolve 2^k` on the centered
+    window — every cell that could influence a centered point is still within
+    the MacroCell's recorded domain. No `hashlifeResultAux`, no whnf wall —
+    pure Manhattan arithmetic over `Int`, reusing `manhattan` (L85). The proof
+    bridges via `manhattan_deviation`, proves the power facts `2^(k+1) = 2·2^k`
+    and `2^(k+2) = 4·2^k` in pure `Nat` (rw + `Nat.pow_succ`), rewrites them in
+    so everything is linear in the single atom `2^k`, and closes with `linarith`
+    (`omega` loses the positivity of `2^k` under the multiplicative atoms). -/
+private theorem window_cone_in_domain (k : Nat) (p q : Int × Int)
+    (hp1_lo : (2^k : Int) ≤ p.1) (hp1_hi : p.1 < 2^k + 2^(k+1))
+    (hp2_lo : (2^k : Int) ≤ p.2) (hp2_hi : p.2 < 2^k + 2^(k+1))
+    (hc : manhattan p q ≤ 2^k) :
+    (0 : Int) ≤ q.1 ∧ q.1 < 2^(k+2) ∧ (0 : Int) ≤ q.2 ∧ q.2 < 2^(k+2) := by
+  -- Bridge the Nat `manhattan` bound to per-coordinate `Int` abs bounds, then
+  -- unpack abs into linear inequalities (linarith does not split `|x|`).
+  obtain ⟨hq1, hq2⟩ := manhattan_deviation p q (2^k) hc
+  -- `manhattan_deviation` types its bound as `↑(2^k)` (Nat cast of the Nat
+  -- radius), but the window hypotheses below use the native-Int `(2^k : Int)`
+  -- (`HPow`). These are the same value but distinct terms, so `linarith` would
+  -- see two unrelated atoms. Normalize via `Nat.cast_pow` to a single atom.
+  have hk_pow : (↑((2:Nat)^k) : Int) = (2^k : Int) := Nat.cast_pow 2 k
+  rw [hk_pow] at hq1 hq2
+  obtain ⟨hq1lo, hq1hi⟩ := abs_le.mp hq1
+  obtain ⟨hq2lo, hq2hi⟩ := abs_le.mp hq2
+  -- Power facts proven in pure Nat (rw only — omega splits the Nat `2^k` from
+  -- `Nat.pow_succ` against the `(2^k : Int)` casts in scope), lifted to Int.
+  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := by
+    have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
+      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
+    exact_mod_cast h
+  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := by
+    have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
+      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
+    have h2 : (2 : Nat)^(k+2) = 2 * (2 : Nat)^(k+1) := by
+      rw [show (k + 2 : Nat) = Nat.succ (k + 1) from rfl, Nat.pow_succ, Nat.mul_comm]
+    have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
+    exact_mod_cast h
+  -- Rewrite every power occurrence into a multiple of the single atom `2^k`,
+  -- so the goal reduces to pure linear `Int` arithmetic in `2^k`. `linarith`
+  -- (not `omega`) closes it: omega loses the positivity of `2^k` when juggling
+  -- the `2^(k+1)`/`2^(k+2)` multiplicative atoms (counterexample: `2^k ≤ -1`),
+  -- while `linarith` treats `2^k` as a plain linear variable, and the bounds
+  -- `0 ≤ q.i`, `q.i < 4·2^k` follow from `p.i ∈ [2^k, 3·2^k)` and
+  -- `|p.i - q.i| ≤ 2^k` with no sign assumption.
+  rw [hpe1] at hp1_hi hp2_hi
+  rw [hpe2]
+  refine ⟨?_, ?_, ?_, ?_⟩
+  all_goals linarith
 
 /-- **P4.4** (compositional, hardest): the two half-steps compose — wave 1
     (advancing `2^(k-1)` generations) followed by wave 2 (another `2^(k-1)`)


### PR DESCRIPTION
## Summary

Close the **second P4.4 balisage milestone (S2)** — the boundary-leak geometric lemma, continuing the user-mandated decomposition of the research-level P4.4 composition into attackable sub-goals. This serves ai-01's steer (next grain toward glue `p4_succ_membership` closure): the glue's remaining `sorry` is the pointwise form of the light-cone composition, whose **tractable geometric core** is exactly S2.

**Delivered (S2, CLOSED):** for a point `p` in the centered window `[2^k, 2^k + 2^(k+1))²`, any cell `q` within Manhattan distance `2^k` of `p` (i.e. in the cone of radius `2^k` = the cone of `evolve 2^(k-1)` via `step_light_cone`) stays inside the MacroCell domain `[0, 2^(k+2))²`. This is why wave-2 super-cells agree with the global `evolve 2^k` on the centered window. **Pure Manhattan arithmetic — no `hashlifeResultAux`, no whnf wall, sorry count unchanged.**

## Two-lemma proof structure

| Lemma | Role |
|-------|------|
| `manhattan_deviation p q R` | helper: lifts the `Nat` `manhattan p q ≤ R` bound to per-coordinate `Int.abs` bounds. Isolates the `Nat.natAbs`→`Int.abs` lift so the cone/window reasoning below is pure `Int`. |
| `window_cone_in_domain k p q` | the S2 lemma (`2^k`-direct): consumes `manhattan_deviation`, normalizes the cast, proves the power facts in pure `Nat`, rewrites all powers to multiples of `2^k`, closes with `linarith`. |

## Three elaboration subtleties (each handled inline, documented)

1. **`omega` loses positivity of `2^k` under multiplicative atoms.** Counterexample: when `2^k`, `2^(k+1)`, `2^(k+2)` all appear, omega assigns `2^k ≤ -1` (it can't propagate the multiplicative chain). Fix: prove the power facts in pure `Nat` (`rw [Nat.pow_succ, Nat.mul_comm]` + `ring`), rewrite them into the hypotheses/goal so everything is linear in the single atom `2^k`, then **`linarith`** (treats `2^k` as a plain linear variable; the bounds `0 ≤ q.i`, `q.i < 4·2^k` follow from `p.i ∈ [2^k, 3·2^k)` + `|p.i − q.i| ≤ 2^k` with no sign assumption).

2. **Native-Int `(2^k : Int)` vs Nat-cast `↑(2^k)` are distinct terms.** The window hypotheses use `(2^k : Int)` (native `Int` `HPow`); `manhattan_deviation`'s `(R : Int)` bound instantiates to `↑(2^k)` (`Nat.cast`). Same value, different terms → `linarith` would see two atoms. Fix: `have hk_pow : (↑((2:Nat)^k) : Int) = (2^k : Int) := Nat.cast_pow 2 k` then `rw [hk_pow]` (the `exact` form closes the defeq residual that `rw [Nat.cast_pow]` alone leaves).

3. **Power facts proven in pure `Nat`, lifted via `exact_mod_cast`.** `omega`-on-powers splits the `Nat` `2^k` from `Nat.pow_succ` against the `(2^k : Int)` casts. The `rw`-in-pure-`Nat`-then-`exact_mod_cast` path avoids that.

## Balisage progress (S1+S2 CLOSED, S3/S4 remain)

| Sub | Statement | Status |
|-----|-----------|--------|
| **S1** `evolve_add` | `evolve (a+b) g = evolve a (evolve b g)` — composition | ✅ CLOSED (#4534, merged) |
| **S2** `window_cone_in_domain` | cone of radius `2^k` around a centered point ⊆ MacroCell domain | ✅ **CLOSED** (this PR) |
| **S3** sub-cell coverage | quadrant `q_j` agrees with `c.toGrid` on the cone → `evolve 2^(k-1)` matches at `p` via `step_light_cone` | ⏳ sub-sorry (whnf-hard) |
| **S4** assemble | combine S1+S2+S3 with four `centralCorrect q_j (k-1)` from P4.3 (#4524) → pointwise agreement `p4_succ_membership` needs | ⏳ sub-sorry (whnf-hard core) |

S3/S4 are the genuine whnf-hard composition core (they manipulate `hashlifeResultAux` results → opaque-binder isolation needed), reserved for dedicated multi-cycle effort per ai-01 steer. S1+S2 are the no-whnf geometric+arithmetic foundation.

## §B Lean review payload

| Item | Value |
|------|-------|
| `grep -c sorry` before | 4 |
| `grep -c sorry` after  | 4 |
| Net Δ | **+0** (S2 is fully proven — no new sorry, no regression) |
| `lake build Conway.Life.HashlifeCorrectness` | **EXIT 0** |
| Axiom check | 0 `sorry`/`sorryAx` in new code; standard Mathlib axioms only |
| Diff | pure addition (`manhattan_deviation` helper + `window_cone_in_domain` lemma + section-docstring S2 status update; 0 deletions on proofs) |

Sorry regex (token grep, authoritative per G.2): `^\s*sorry\s*$|:= by sorry|:= sorry\b|exact sorry|^\s*· sorry`. The 4 remaining sorrows: `p4_half_steps_compose` (P4.4 placeholder, now 2/4 balisage milestones closed), `p4_succ_membership` glue, and the two P5 lemmas.

## Scope (honest, G.3)

- ✅ **Proven**: `manhattan_deviation` (helper) + `window_cone_in_domain` (S2) — the second closed P4.4 milestone.
- ⏳ **Not done**: S3/S4 (sub-cell coverage + assembly) — the whnf-hard core, multi-cycle. The glue `p4_succ_membership` and P4.4 itself remain. The honest finding: the glue's remaining `sorry` is the pointwise form of S3+S4, not more tractable than P4.4 — S2 is the genuine forward progress this cycle.
- Builds on #4534 (S1 `evolve_add`, merged) and #4524 (P4.3 centralCorrect, merged), both on `main`.

See #3846
