### PR TITLE
feat(symbolicai): Argument_Analysis Dung_AF_Semantics — from-scratch grounded/preferred/stable (Python)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb
@@ -1,0 +1,659 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a27c319",
+   "metadata": {},
+   "source": [
+    "# Argumentation abstraite de Dung — sémantiques grounded, preferred, stable\n",
+    "\n",
+    "> **Notebook fondationnel** (non-agentique) de la série *Argument_Analysis*.\n",
+    "> Il précède et éclaire l'aperçu de [2-formal §6](Argument_Analysis_Agentic-2-formal.ipynb)\n",
+    "> et l'utilisation du solveur Tweety dans [Tweety-5](../Tweety/Tweety-5-Abstract-Argumentation.ipynb).\n",
+    "\n",
+    "## Pourquoi ce notebook\n",
+    "\n",
+    "Le notebook [2-formal §6](Argument_Analysis_Agentic-2-formal.ipynb) invoque la sémantique\n",
+    "*grounded* de Dung via le solveur Tweety (JVM) comme une boîte noire : on appelle\n",
+    "`SimpleGroundedReasoner`, on récupère une extension. Mais **que calcule exactement ce\n",
+    "solveur, et pourquoi existe-t-il plusieurs sémantiques concurrentes (grounded, preferred,\n",
+    "stable) qui ne donnent pas toujours le même verdict ?**\n",
+    "\n",
+    "Ce notebook répond à cette question en **construisant les sémantiques de zéro**, en pur\n",
+    "Python standard, sans JVM ni solveur externe. L'objectif n'est pas de remplacer Tweety\n",
+    "(moins performant, non utilisable en production sur de grands graphes) mais de **rendre\n",
+    "transparent** ce que le solveur fait — de façon à ce que l'appel `getModels(theory)` du\n",
+    "notebook 2-formal cesse d'être magique.\n",
+    "\n",
+    "**Référence** : Dung, *On the Acceptability of Arguments and its Fundamental Role in\n",
+    "Nonmonotonic Reasoning, Logic Programming and n-Person Games* (Artificial Intelligence,\n",
+    "1995). Le formalisme y est introduit dans sa forme la plus abstraite, indépendante de\n",
+    "toute structure interne des arguments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca7dc61a",
+   "metadata": {},
+   "source": [
+    "## 1. Cadre d'argumentation abstrait (Dung 1995)\n",
+    "\n",
+    "Un **abstract argumentation framework** (AF) est un couple $F = \\langle A, R \\rangle$ où :\n",
+    "\n",
+    "- $A$ est un ensemble fini d'**arguments** (des symboles opaques — on ne s'intéresse pas à leur contenu interne, seulement à qui attaque qui) ;\n",
+    "- $R \\subseteq A \\times A$ est une relation d'**attaque** : $(a, b) \\in R$ se lit « $a$ attaque $b$ ».\n",
+    "\n",
+    "L'abstraction est délibérée : la théorie de Dung porte sur la *structure du débat*\n",
+    "(graphe d'attaque), pas sur le sens des arguments. Deux débats aux graphes identiques\n",
+    "reçoivent le même verdict d'acceptabilité, quelle que soit leur matière. C'est cette\n",
+    "abstraction qui rend les sémantiques calculables et comparables.\n",
+    "\n",
+    "Implémentons le cadre :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6d9498dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF(args=['a', 'b'], attacks=[a->b, b->a])\n",
+      "Attaquants de a : {'b'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from itertools import chain, combinations\n",
+    "\n",
+    "\n",
+    "class AF:\n",
+    "    \"\"\"Cadre d'argumentation abstrait de Dung : <args, attacks>.\"\"\"\n",
+    "\n",
+    "    def __init__(self, args, attacks):\n",
+    "        self.args = set(args)\n",
+    "        self.attacks = set(attacks)  # ensemble de couples (attaquant, attaque)\n",
+    "\n",
+    "    def attackers(self, x):\n",
+    "        \"\"\"Arguments qui attaquent directement x.\"\"\"\n",
+    "        return {a for (a, b) in self.attacks if b == x}\n",
+    "\n",
+    "    def __repr__(self):\n",
+    "        att = \", \".join(f\"{a}->{b}\" for (a, b) in sorted(self.attacks))\n",
+    "        return f\"AF(args={sorted(self.args)}, attacks=[{att}])\"\n",
+    "\n",
+    "\n",
+    "# Un petit exemple ludique pour démarrer : a et b s'attaquent mutuellement.\n",
+    "af0 = AF({\"a\", \"b\"}, {(\"a\", \"b\"), (\"b\", \"a\")})\n",
+    "print(af0)\n",
+    "print(\"Attaquants de a :\", af0.attackers(\"a\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fc08552",
+   "metadata": {},
+   "source": [
+    "## 2. De la conflictualité à l'admissibilité\n",
+    "\n",
+    "Toute la théorie repose sur une chaîne de définitions emboîtées. Chaque notion prépare\n",
+    "la suivante.\n",
+    "\n",
+    "### 2.1 Sans conflit interne\n",
+    "\n",
+    "Un ensemble $S$ est **sans conflit** (*conflict-free*) si aucun de ses membres n'en\n",
+    "attaque un autre : $\\nexists a, b \\in S$ tels que $(a, b) \\in R$.\n",
+    "\n",
+    "C'est la condition minimale de cohérence : un ensemble qui se contredit n'est pas\n",
+    "une position défendable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "28c8a349",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a,b se battent -> {a,b} sans conflit ? False\n",
+      "{a} seul  -> sans conflit ? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "def is_conflict_free(af, S):\n",
+    "    \"\"\"True si aucun argument de S n'en attaque un autre dans S.\"\"\"\n",
+    "    S = set(S)\n",
+    "    for (a, b) in af.attacks:\n",
+    "        if a in S and b in S:\n",
+    "            return False\n",
+    "    return True\n",
+    "\n",
+    "\n",
+    "print(\"a,b se battent -> {a,b} sans conflit ?\", is_conflict_free(af0, {\"a\", \"b\"}))\n",
+    "print(\"{a} seul  -> sans conflit ?\", is_conflict_free(af0, {\"a\"}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "738a0b4f",
+   "metadata": {},
+   "source": [
+    "### 2.2 Défait et défendu\n",
+    "\n",
+    "Pour aller plus loin que la simple absence de conflit, il faut formaliser la notion de\n",
+    "**défense** :\n",
+    "\n",
+    "- $S$ **défait** un argument $x$ (noté $S \\rightsquigarrow x$) si au moins un membre de $S$\n",
+    "  attaque $x$ : $\\exists a \\in S, (a, x) \\in R$.\n",
+    "- $S$ **défend** un argument $x$ si $S$ défait *tous* les attaquants de $x$ :\n",
+    "  $\\forall b$ tel que $(b, x) \\in R$, $S$ défait $b$.\n",
+    "\n",
+    "Autrement dit : $x$ est défendu par $S$ si toute attaque contre $x$ est contrée par une\n",
+    "attaque venant de $S$. C'est le cœur du raisonnement argumentatif — on accepte un\n",
+    "argument non parce qu'il est vrai, mais parce qu'on peut le *protéger*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "54e65cd6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dans af0, {a} défend-il a ? True\n",
+      "  (a est attaqué par b ; {a} défait-il b ? a->b : True )\n"
+     ]
+    }
+   ],
+   "source": [
+    "def defeats(af, S, x):\n",
+    "    \"\"\"True si S défait x (au moins un membre de S attaque x).\"\"\"\n",
+    "    return any((a, x) in af.attacks for a in S)\n",
+    "\n",
+    "\n",
+    "def defends(af, S, x):\n",
+    "    \"\"\"True si S défend x : tout attaquant de x est défait par S.\"\"\"\n",
+    "    return all(defeats(af, S, b) for b in af.attackers(x))\n",
+    "\n",
+    "\n",
+    "print(\"Dans af0, {a} défend-il a ?\", defends(af0, {\"a\"}, \"a\"))\n",
+    "print(\"  (a est attaqué par b ; {a} défait-il b ? a->b :\", (\"a\", \"b\") in af0.attacks, \")\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94dfe4f8",
+   "metadata": {},
+   "source": [
+    "### 2.3 Admissible\n",
+    "\n",
+    "Un ensemble $S$ est **admissible** s'il est sans conflit *et* si chacun de ses membres\n",
+    "est défendu par $S$ :\n",
+    "\n",
+    "$$S \\text{ admissible} \\iff S \\text{ sans conflit} \\;\\land\\; \\forall a \\in S, \\; S \\text{ défend } a$$\n",
+    "\n",
+    "L'admissibilité capture l'idée d'une position **auto-cohérente et auto-défendable** :\n",
+    "aucune contradiction interne, et chaque membre résiste aux attaques extérieures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0ae12905",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{∅} admissible ? True\n",
+      "{a} admissible ? True\n",
+      "{b} admissible ? True\n",
+      "{a b} admissible ? False\n"
+     ]
+    }
+   ],
+   "source": [
+    "def is_admissible(af, S):\n",
+    "    \"\"\"True si S est admissible : sans conflit et chacun de ses membres est défendu.\"\"\"\n",
+    "    S = set(S)\n",
+    "    if not is_conflict_free(af, S):\n",
+    "        return False\n",
+    "    return all(defends(af, S, a) for a in S)\n",
+    "\n",
+    "\n",
+    "for cand in [set(), {\"a\"}, {\"b\"}, {\"a\", \"b\"}]:\n",
+    "    print(f\"{{{' '.join(sorted(cand)) or '∅'}}} admissible ? {is_admissible(af0, cand)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09112f90",
+   "metadata": {},
+   "source": [
+    "## 3. Les trois sémantiques\n",
+    "\n",
+    "L'admissibilité définit un *spectre* d'ensembles acceptables. Les **sémantiques**\n",
+    "sélectionnent, parmi les ensembles admissibles, ceux qui méritent d'être appelés\n",
+    "« extensions » (le verdict final). Dung en définit trois principales, qui encodent des\n",
+    "**attitudes de raisonnement distinctes** :\n",
+    "\n",
+    "| Sémantique | Attitude | Définition |\n",
+    "|------------|----------|------------|\n",
+    "| **Grounded** | *sceptique* (le strict minimum certain) | L'unique extension complète minimale ; obtenue par point fixe : on part de $\\emptyset$ et on ajoute itérativement tout argument défendu. |\n",
+    "| **Preferred** | *crédule* (le maximum défendable) | Les extensions complètes **maximales** (par inclusion) ; il peut y en avoir plusieurs, incompatibles entre elles. |\n",
+    "| **Stable** | *auto-suffisante* (elle statut sur tout) | Une extension admissible qui **défait tout argument extérieur** : $\\forall x \\notin S, S \\rightsquigarrow x$. |\n",
+    "\n",
+    "Ces trois sémantiques ne sont pas redondantes : elles répondent à la question\n",
+    "« quels arguments accepter ? » sous trois régimes de prudence différents. Le théorème\n",
+    "central de Dung garantit l'inclusion **grounded $\\subseteq$ preferred**, mais **stable\n",
+    "peut ne pas exister**, et **preferred peut compter plusieurs extensions incompatibles**.\n",
+    "\n",
+    "Implémentons les trois par énumération (la théorie garantit que pour un AF fini, le nombre\n",
+    "d'extensions est fini ; l'énumération des $2^{|A|}$ sous-ensembles reste tractable pour\n",
+    "les petits graphes pédagogiques)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d8c99e8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def powerset(args):\n",
+    "    \"\"\"Tous les sous-ensembles de args, par taille croissante.\"\"\"\n",
+    "    args = list(args)\n",
+    "    return list(chain.from_iterable(\n",
+    "        combinations(args, r) for r in range(len(args) + 1)\n",
+    "    ))\n",
+    "\n",
+    "\n",
+    "def grounded(af):\n",
+    "    \"\"\"Extension grounded : point fixe à partir de l'ensemble vide.\n",
+    "\n",
+    "    On ajoute itérativement tout argument défendu par l'ensemble courant, jusqu'à\n",
+    "    ce qu'aucun ajout ne soit plus possible. Le résultat est unique (théorème de Dung).\n",
+    "    \"\"\"\n",
+    "    S = set()\n",
+    "    changed = True\n",
+    "    while changed:\n",
+    "        changed = False\n",
+    "        for x in af.args:\n",
+    "            if x not in S and defends(af, S, x):\n",
+    "                S.add(x)\n",
+    "                changed = True\n",
+    "    return frozenset(S)\n",
+    "\n",
+    "\n",
+    "def preferred(af):\n",
+    "    \"\"\"Extensions preferred : ensembles admissibles maximaux par inclusion.\"\"\"\n",
+    "    adm = [frozenset(S) for S in powerset(af.args) if is_admissible(af, S)]\n",
+    "    # maximal : aucun autre admissible ne le contient strictement\n",
+    "    return [a for a in adm if not any(a < b for b in adm)]\n",
+    "\n",
+    "\n",
+    "def stable(af):\n",
+    "    \"\"\"Extensions stables : admissibles qui défont tout argument hors de l'extension.\"\"\"\n",
+    "    out = []\n",
+    "    for S in powerset(af.args):\n",
+    "        S = set(S)\n",
+    "        if is_admissible(af, S) and all(\n",
+    "            defeats(af, S, x) for x in af.args if x not in S\n",
+    "        ):\n",
+    "            out.append(frozenset(S))\n",
+    "    return out\n",
+    "\n",
+    "\n",
+    "def resume(af, label=\"\"):\n",
+    "    \"\"\"Calcule et affiche les trois sémantiques d'un AF.\"\"\"\n",
+    "    g = grounded(af)\n",
+    "    p = preferred(af)\n",
+    "    s = stable(af)\n",
+    "    print(f\"=== {label or af} ===\")\n",
+    "    print(f\"  grounded  : {{{', '.join(sorted(g)) or '∅'}}}   (unique, sceptique)\")\n",
+    "    print(f\"  preferred : {[sorted('{' + ','.join(sorted(e)) + '}') and '{' + ','.join(sorted(e)) + '}' for e in p]}   ({len(p)} ext., crédule)\")\n",
+    "    if s:\n",
+    "        print(f\"  stable    : {[ '{' + ','.join(sorted(e)) + '}' for e in s]}   ({len(s)} ext.)\")\n",
+    "    else:\n",
+    "        print(f\"  stable    : AUCUNE (pas d'extension stable)\")\n",
+    "    print()\n",
+    "    return g, p, s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a86dbeb",
+   "metadata": {},
+   "source": [
+    "## 4. Le cas canonique : grounded $\\neq$ preferred $\\neq$ stable\n",
+    "\n",
+    "Pour que l'écart entre les trois sémantiques soit **visible**, il faut un AF assez riche\n",
+    "pour que les trois attitudes divergent. Considérons :\n",
+    "\n",
+    "$$F = \\langle \\{a, b, c, d\\}, \\; \\{(a,b), (b,a), (c,c)\\} \\rangle$$\n",
+    "\n",
+    "- **$a$ et $b$ s'attaquent mutuellement** : ni l'un ni l'autre n'est attaqué par un tiers,\n",
+    "  aucun n'est défendu « gratuitement ». Ce sont des **arguments flottants** — on peut en\n",
+    "  accepter un (si l'on prend parti) mais pas les deux (ils se contredisent).\n",
+    "- **$c$ s'attaque lui-même** : un argument auto-réfuté ne peut *jamais* appartenir à un\n",
+    "  ensemble sans conflit (il violerait la cohérence minimale).\n",
+    "- **$d$ est isolé** : non attaqué, il sera accepté partout (point de référence stable).\n",
+    "\n",
+    "Cet AF est **non trivial** précisément parce qu'aucune sémantique ne se réduit à une\n",
+    "évidence : on ne peut pas « prendre tous les non-attaqués » (ça donnerait $\\{d\\}$ en\n",
+    "ignorant les flottements) ni « tout ce qui se défend » (ça mélangerait $a$ et $b$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "57166655",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF(args=['a', 'b', 'c', 'd'], attacks=[a->b, b->a, c->c])\n",
+      "\n",
+      "=== F = <{a,b,c,d}, {(a,b),(b,a),(c,c)}> ===\n",
+      "  grounded  : {d}   (unique, sceptique)\n",
+      "  preferred : ['{b,d}', '{a,d}']   (2 ext., crédule)\n",
+      "  stable    : AUCUNE (pas d'extension stable)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# AF canonique : flottement a/b + auto-attaque c + isolé d\n",
+    "af1 = AF(\n",
+    "    args={\"a\", \"b\", \"c\", \"d\"},\n",
+    "    attacks={(\"a\", \"b\"), (\"b\", \"a\"), (\"c\", \"c\")},\n",
+    ")\n",
+    "print(af1)\n",
+    "print()\n",
+    "g1, p1, s1 = resume(af1, \"F = <{a,b,c,d}, {(a,b),(b,a),(c,c)}>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "768cc765",
+   "metadata": {},
+   "source": [
+    "### Lecture du verdict\n",
+    "\n",
+    "Les trois sémantiques donnent des résultats **différents** sur ce graphe :\n",
+    "\n",
+    "| Sémantique | Résultat | Interprétation |\n",
+    "|------------|----------|----------------|\n",
+    "| **Grounded** | $\\{d\\}$ | Seul $d$ est *certainement* acceptable : il est le seul non attaqué. On refuse de trancher entre $a$ et $b$ (aucun n'est défendu sans prendre parti), et $c$ s'exclut de lui-même. Attitude sceptique : on n'accepte que l'incontestable. |\n",
+    "| **Preferred** | $\\{a, d\\}$ **et** $\\{b, d\\}$ | Deux positions maximales défendables, **incompatibles** : soit on accepte $a$ (qui défait $b$), soit $b$ (qui défait $a$). Attitude crédule : on admet chaque position auto-défendable maximale, même s'il en existe une contradictoire. |\n",
+    "| **Stable** | *(aucune)* | Aucune extension stable n'existe. Pourquoi ? Une extension stable devrait défaire *tout* argument extérieur. Mais $c$ n'est attaqué par personne d'autre que lui-même : aucun argument ne peut le défaire « de l'extérieur », donc aucune extension stable ne peut le statuer. Le graphe porte un argument « indécidable de l'extérieur » → la sémantique stable échoue à exister. |\n",
+    "\n",
+    "C'est précisément le théorème de Dung rendu visible :\n",
+    "- **grounded $\\subset$ preferred** ($\\{d\\} \\subset \\{a,d\\}$) ;\n",
+    "- **preferred $\\ne$ stable** (preferred existe, stable n'existe pas) ;\n",
+    "- la sémantique **stable n'est pas garantie d'existence** — c'est sa fragilité théorique,\n",
+    "  et la raison pour laquelle les solveurs pratiques (Tweety inclus) calculent en priorité\n",
+    "  grounded et preferred."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "22f3ecfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grounded == {d} ? True\n",
+      "preferred == {{a,d},{b,d}} ? True\n",
+      "stable existe ? False\n",
+      "\n",
+      ">>> grounded ⊊ preferred : True\n",
+      ">>> preferred existe ET stable n'existe pas (divergence) : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Vérification programmatique : les trois sémantiques divergent bien.\n",
+    "print(\"grounded == {d} ?\", set(g1) == {\"d\"})\n",
+    "print(\"preferred == {{a,d},{b,d}} ?\",\n",
+    "      set(frozenset(e) for e in p1) == {frozenset({\"a\", \"d\"}), frozenset({\"b\", \"d\"})})\n",
+    "print(\"stable existe ?\", bool(s1))\n",
+    "print()\n",
+    "print(\">>> grounded ⊊ preferred :\", set(g1) < set(next(iter(p1))))\n",
+    "print(\">>> preferred existe ET stable n'existe pas (divergence) :\", bool(p1) and not bool(s1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8939a3a6",
+   "metadata": {},
+   "source": [
+    "## 5. Retour au solveur Tweety\n",
+    "\n",
+    "Maintenant que les sémantiques sont transparentes, relisons l'appel du notebook\n",
+    "[2-formal §6](Argument_Analysis_Agentic-2-formal.ipynb) :\n",
+    "\n",
+    "```python\n",
+    "reasoner_d = SimpleGroundedReasoner()\n",
+    "models = reasoner_d.getModels(theory)   # Collection<Extension>\n",
+    "```\n",
+    "\n",
+    "`getModels` renvoie la collection des extensions selon la sémantique du *reasoner*. Pour\n",
+    "`SimpleGroundedReasoner`, c'est exactement le point fixe calculé par notre fonction\n",
+    "`grounded` ci-dessus — une seule extension, la plus prudente. Les *reasoners*\n",
+    "`SimplePreferredReasoner` et `SimpleCompleteReasoner` implémentent les autres colonnes\n",
+    "du tableau. Le pont JPype ne fait rien d'autre qu'appeler, en JVM, l'algorithme que nous\n",
+    "venons de reconstruire à la main.\n",
+    "\n",
+    "**Ce que ce notebook apporte** au-delà de Tweety-5 : la compréhension de l'algorithme,\n",
+    "pas seulement son usage. C'est la différence entre *invoquer* un vérificateur formel\n",
+    "(le pipeline agentique de la série) et *comprendre* ce qu'il calcule (ce notebook).\n",
+    "\n",
+    "> Pour les preuves formelles des théorèmes d'inclusion et d'existence (grounded est\n",
+    "> l'extension complète minimale, stable peut être vide), voir le notebook Lean\n",
+    "> [Tweety-5b](../Tweety/Tweety-5b-Lean-Argumentation.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7600fb71",
+   "metadata": {},
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "Les trois exercices suivants approfondissent la théorie. Ils sont laissés **incomplets**\n",
+    "par construction (stub) : à vous de les remplir. Le notebook s'exécute de bout en bout\n",
+    "même non complété — vos implémentations remplaceront les `pass` / `return None`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9b9ae8b",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Complétude vs admissibilité\n",
+    "\n",
+    "Une extension **complète** est admissible *et* contient tout argument qu'elle défend :\n",
+    "$S$ complète $\\iff$ $S$ admissible et $\\forall x \\in A$, si $S$ défend $x$ alors $x \\in S$.\n",
+    "La grounded est l'unique complète minimale, les preferred sont les complètes maximales.\n",
+    "\n",
+    "**Objectif** : implémenter `is_complete(af, S)` et vérifier que la grounded et les\n",
+    "preferred de `af1` sont bien complètes (mais qu'un admissible non-maximal comme $\\{a\\}$\n",
+    "ne l'est pas — pourquoi ?).\n",
+    "\n",
+    "*Indice* : un argument défendu mais absent de $S$ suffit à le disqualifier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "06d2d66c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exercice 1 : compléter cette fonction\n",
+    "def is_complete(af, S):\n",
+    "    \"\"\"True si S est complet : admissible ET contient tout argument qu'il défend.\"\"\"\n",
+    "    # Etape 1 : vérifier l'admissibilité (déjà disponible : is_admissible).\n",
+    "    # Etape 2 : pour tout x défendu par S, x doit appartenir à S.\n",
+    "    # TODO etudiant\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "# Test (à décommenter une fois complété) :\n",
+    "# print(\"grounded complet ?\", is_complete(af1, set(g1)))\n",
+    "# print(\"preferred complet ?\", all(is_complete(af1, set(e)) for e in p1))\n",
+    "# print(\"{a} (admissible non-maximal) complet ?\", is_complete(af1, {\"a\"}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89855824",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Un AF où la sémantique stable existe\n",
+    "\n",
+    "Sur `af1`, la sémantique stable n'existait pas (à cause de l'auto-attaque de $c$).\n",
+    "Construisez un AF **sans auto-attaque ni cycle impair** où la stable existe *et* coïncide\n",
+    "avec la preferred.\n",
+    "\n",
+    "**Objectif** : définir `af2` et vérifier que `stable(af2) == preferred(af2)` (même\n",
+    "collection d'extensions).\n",
+    "\n",
+    "*Indice* : un AF acyclique (les arguments forment un DAG d'attaque) admet toujours une\n",
+    "unique extension stable, qui coïncide avec la grounded et la preferred."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "11c1592c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exercice 2 : définir un AF où stable == preferred\n",
+    "af2 = AF(\n",
+    "    args=set(),       # TODO etudiant : choisir args\n",
+    "    attacks=set(),    # TODO etudiant : choisir attacks (sans auto-attaque)\n",
+    ")\n",
+    "# Test (à décommenter une fois complété) :\n",
+    "# g2, p2, s2 = resume(af2, \"af2 (votre AF)\")\n",
+    "# print(\"stable == preferred ?\",\n",
+    "#       set(s2) == set(p2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf787ad7",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Étiquetage IN / OUT / UNDEC\n",
+    "\n",
+    "Les sémantiques admettent une formulation équivalente en **étiquetages** : chaque\n",
+    "argument reçoit l'étiquette IN (accepté), OUT (rejeté) ou UNDEC (indécidable), avec les\n",
+    "règles : (i) $x$ est OUT si un IN l'attaque ; (ii) $x$ est IN si tous ses attaquants sont\n",
+    "OUT. Le labeling grounded de `af1` devrait donner $d$=IN, $c$=OUT (auto-attaqué), et\n",
+    "$a, b$=UNDEC (le flottement non tranché).\n",
+    "\n",
+    "**Objectif** : implémenter `grounded_labeling(af)` renvoyant un dict `{arg: \"IN\"/\"OUT\"/\"UNDEC\"}`,\n",
+    "et vérifier qu'il est cohérent avec `grounded(af)` (IN $=$ l'extension grounded, du moins\n",
+    "quand aucun argument n'est UNDEC dans la grounded).\n",
+    "\n",
+    "*Indice* : OUT = attaqué par un IN ; IN = non attaqué, ou tous ses attaquants OUT ;\n",
+    "UNDEC = ni IN ni OUT (le reste). Itérez jusqu'à stabilisation, comme pour le point fixe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "128716c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exercice 3 : compléter le labeling grounded\n",
+    "def grounded_labeling(af):\n",
+    "    \"\"\"Renvoie {arg: 'IN'|'OUT'|'UNDEC'} selon le labeling grounded.\"\"\"\n",
+    "    labels = {a: \"UNDEC\" for a in af.args}\n",
+    "    # Etape 1 : IN = argument dont tous les attaquants sont OUT (ou sans attaquant).\n",
+    "    # Etape 2 : OUT = argument attaqué par au moins un IN.\n",
+    "    # Etape 3 : itérer jusqu'au point fixe (comme grounded).\n",
+    "    # TODO etudiant\n",
+    "    return labels\n",
+    "\n",
+    "\n",
+    "# Test (à décommenter une fois complété) :\n",
+    "# lab = grounded_labeling(af1)\n",
+    "# print(\"Labeling grounded de af1 :\", lab)\n",
+    "# print(\"Cohérent avec grounded={d} ?\", set(a for a, l in lab.items() if l == \"IN\") == set(g1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7a83721",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a reconstruit, de zéro et en Python standard, les trois sémantiques\n",
+    "fondatrices de l'argumentation abstraite de Dung :\n",
+    "\n",
+    "- **Grounded** — l'unique extension complète minimale, attitude sceptique.\n",
+    "- **Preferred** — les extensions complètes maximales, attitude crédule (potentiellement\n",
+    "  multiples et incompatibles).\n",
+    "- **Stable** — les extensions admissibles qui statuent sur tout argument extérieur ;\n",
+    "  **non garantie d'existence**.\n",
+    "\n",
+    "Le cas canonique $\\langle \\{a,b,c,d\\}, \\{(a,b),(b,a),(c,c)\\} \\rangle$ a montré les trois\n",
+    "verdicts diverger simultanément : grounded $= \\{d\\}$, preferred $= \\{\\{a,d\\}, \\{b,d\\}\\}$,\n",
+    "stable inexistante. C'est la richesse structurelle qui justifie l'existence de trois\n",
+    "sémantiques plutôt qu'une seule : aucune ne capte à elle seule toutes les nuances de\n",
+    "l'acceptabilité argumentative.\n",
+    "\n",
+    "### Prochaines étapes\n",
+    "\n",
+    "- **Utiliser le solveur** : [Tweety-5](../Tweety/Tweety-5b-Lean-Argumentation.ipynb)\n",
+    "  applique ces sémantiques via TweetyProject (JVM) sur des AF plus grands, où l'énumération\n",
+    "  exhaustive devient prohibitif. Le notebook [2-formal §6](Argument_Analysis_Agentic-2-formal.ipynb)\n",
+    "  en fait usage dans le pipeline agentique.\n",
+    "- **Prouver les théorèmes** : [Tweety-5b-Lean](../Tweety/Tweety-5b-Lean-Argumentation.ipynb)\n",
+    "  formalise en Lean les inclusions ($\\text{grounded} \\subseteq \\text{preferred}$) et les\n",
+    "  conditions d'existence de la sémantique stable.\n",
+    "- **Argumentation structurée** : le formalisme abstrait de Dung ignore le contenu des\n",
+    "  arguments. ASPIC+, ABA et DeLP (accessibles via Tweety) reconstruisent la relation\n",
+    "  d'attaque à partir d'une logique sous-jacente — la série [Tweety](../Tweety/) les explore."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "papermill": {
+   "input_path": "Argument_Analysis_Dung_AF_Semantics.ipynb",
+   "output_path": "Argument_Analysis_Dung_AF_Semantics.ipynb"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -53,6 +53,7 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | 3* | [Agentic-3-orchestration_agent](Argument_Analysis_Agentic-3-orchestration_agent.ipynb) | *(legacy)* Orchestration multi-agents (semantic_kernel) | Coordination |
 | 4 | [Agentic-4-capstone](Argument_Analysis_Agentic-4-capstone.ipynb) | Capstone : baseline 0-shot vs pipeline intégral, verdicts convergents + value-gates VG-1..VG-4 | Intégration |
 | 5 | [Agentic-5-jtms](Argument_Analysis_Agentic-5-jtms.ipynb) | Truth Maintenance System déterministe (Doyle 1979) : étiquetage IN/OUT, cascade de rétractation, détection d'odd loops — pur stdlib Python | Raisonnement non-monotone |
+| Dung | [Dung_AF_Semantics](Argument_Analysis_Dung_AF_Semantics.ipynb) | Sémantiques grounded / preferred / stable reconstruites de zéro en pur Python (cas canonique où les trois divergent) | Fondation argumentation abstraite |
 | UI | [UI_configuration](Argument_Analysis_UI_configuration.ipynb) | Interface utilisateur widgets | Interaction |
 | Exec | [Executor](Argument_Analysis_Executor.ipynb) | Orchestrateur principal | Exécution |
 
@@ -67,6 +68,7 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | **2-pl_agent** *(legacy)* | Convertir les arguments informels en formules propositionnelles et les vérifier via SAT | 60 min |
 | **3-orchestration** | Composer les agents précédents en pipeline coordonné avec rapport de sortie structuré | 50 min |
 | **5-jtms** | Construire un moteur de croyances non-monotones (étiquetage IN/OUT, cascade de rétractation, détection d'odd loops) en pur stdlib Python, sans LLM ni solveur externe | 40 min |
+| **Dung_AF_Semantics** | Reconstruire les sémantiques grounded, preferred et stable de l'argumentation abstraite de Dung de zéro en pur Python (sans JVM) sur un cas où les trois divergent | 35 min |
 | **UI_configuration** | Créer une interface interactive (ipywidgets) pour piloter le pipeline en mode exploratoire | 30 min |
 | **Executor** | Exécuter le pipeline complet en mode batch (Papermill/MCP) avec configuration .env | 20 min |
 
@@ -218,7 +220,7 @@ BATCH_MODE=false
 
 ```
 Argument_Analysis/
-├── *.ipynb                    # 6 notebooks
+├── *.ipynb                    # notebooks pédagogiques (pipeline agentique + Dung)
 ├── .env / .env.example        # Configuration
 ├── install_jdk_portable.py    # Installation JDK
 ├── data/                      # Données (taxonomie sophismes)
@@ -261,7 +263,7 @@ Le pipeline mobilise un vocabulaire issu de trois traditions — la rhétorique 
 | **Logique propositionnelle (PL)** | Logique des connecteurs (∧, ∨, →, ¬) sans quantificateurs ; vérifiée via un modus ponens dans Tweety. | 2-formal §3 |
 | **Logique du premier ordre (FOL)** | PL étendue des quantificateurs (∀, ∃) et prédicats. Exige une *signature* déclarée (constantes, prédicats) avant toute requête. | 2-formal §4 |
 | **Logique modale** | Logique du *possible* (◇) et du *nécessaire* (□), utile pour les arguments portant sur la contingence ou l'obligation. | 2-formal §5 |
-| **Argumentation de Dung** | Cadre abstrait où les arguments s'attaquent mutuellement ; la sémantique *grounded* calcule l'ensemble des arguments défendables. | 2-formal §6 |
+| **Argumentation de Dung** | Cadre abstrait où les arguments s'attaquent mutuellement ; la sémantique *grounded* calcule l'ensemble des arguments défendables. Les sémantiques *preferred* et *stable* étendent ce verdict sous différentes attitudes (crédule, auto-suffisante). | Dung_AF_Semantics, 2-formal §6 |
 | **Belief set** | Ensemble de formules formalisant l'état de croyance déduit du texte ; c'est ce que le solveur manipule et interroge. | 2-formal |
 | **SAT** | Problème de satisfaisabilité : existe-t-il une valuation rendant un ensemble de formules cohérent ? Cœur de la validation Tweety. | 2-formal |
 | **Fail-loud** | Principe de conception : le pipeline échoue bruyamment plutôt que de *simuler* un verdict (jamais de sortie fictive si la JVM ou le solveur manque). | 2-formal |


### PR DESCRIPTION
## Summary

New foundation notebook **`Argument_Analysis_Dung_AF_Semantics.ipynb`** reconstructing Dung (1995) abstract argumentation semantics in **pure Python stdlib** — the white-box complement to the Tweety/JVM black-box used in `2-formal §6` and `Tweety-5`.

Dispatched by ai-01 (#2137 deep-queue step 1: "notebook AF Dung non-trivial où grounded≠preferred≠stable"). Honors the Prong-B spec.

## Why (verified firsthand, NOT a duplicate)

Before building, audited the existing Dung coverage to avoid duplicating (lesson from the Planners false-saturation this session):

| Existing | Covers Dung? | Gap |
|----------|-------------|-----|
| `2-formal §6` | grounded **only**, via Tweety/JVM, as a stub exercise ("Exercice à compléter") | no preferred/stable, no from-scratch |
| `Tweety-5-Abstract-Argumentation` | all 4 semantics, **but delegates to Tweety JVM** (`uses_tweety_jvm=True`, `from_scratch_solver=False`) | black-box, algorithm opaque |
| `Tweety-5b-Lean` | formal Lean proofs | different paradigm |

**No pure-Python from-scratch solver existed** → genuine gap. This notebook makes the solver algorithm transparent (so `SimpleGroundedReasoner.getModels()` in `2-formal` ceases to be magic).

## Prong-B (non-trivial problem)

Canonical AF `⟨{a,b,c,d}, {(a,b),(b,a),(c,c)}⟩` where all three semantics **diverge**:
- **grounded** = `{d}` (unique, skeptical)
- **preferred** = `{{a,d},{b,d}}` (2 maximal admissible, credulous)
- **stable** = **NONE** (self-attacking `c` cannot be defeated externally → stable semantics fails to exist)

This exercises the engine's distinctive capacity (semantic divergence) rather than a degenerate case where SOTA reduces to trivial baseline. Verified programmatically: `grounded ⊊ preferred` and `preferred exists ∧ stable ∄`.

## Content

- 24 cells (10 code, 14 markdown)
- Concepts: abstract AF → conflict-free → defeated/defended → admissible → grounded/preferred/stable (point-fixe + énumération)
- **3 exercises** (≥3 convention): (1) complete vs admissible; (2) construct AF where stable==preferred; (3) IN/OUT/UNDEC labeling

## Validation (C.2 / H.1)

- Executed end-to-end via MCP jupyter (python3 kernel): **10/10 cells succeeded, 0 errors**
- C.1 clean: no `raise NotImplementedError` / `assert False` / `1/0` (stubs use `return None` + `# TODO etudiant`)
- C.2 clean: all 10 code cells have `execution_count` populated + outputs committed
- Stop & Repair: outputs are real kernel output (no hand-editing); `metadata.papermill.input/output_path` normalized to basename (only allowed manual normalization)
- No machine paths leaked in outputs (verified `grep`)

## README update (4 edits)

- +row in Notebooks table (Dung, Fondation argumentation abstraite)
- +row in "Ce que chaque notebook apporte"
- structure tree: `# 6 notebooks` → `# notebooks pédagogiques (pipeline agentique + Dung)`
- Dung concept pointer: cross-ref `Dung_AF_Semantics, 2-formal §6` + note on preferred/stable

**CATALOG-STATUS marker byte-identical** (catalog belongs to automation — cron/CI handles the count).

## Lane note for ai-01

The dispatch's step 1a (câblage du sous-module Argumentum) is **mechanically blocked** on `myia-po-2025`: `D:/Argumentum` is not accessible on this machine (it's `ai-01`/`po-2024`'s workspace), consistent with the user's 21/06 comment that the submodule is po-2024's lane. This notebook (Python, Argument_Analysis series = my lane) honors the dispatch's step-1b Prong-B spec without depending on the submodule. Blocker + lane question signaled in DM `msg-20260628T155355-kd8rxl`.

See #2137 (epic stays open — submodule + remaining steps pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)