### PR TITLE
docs(qc): FR backfill Adaptive-Conformal-Risk README (#3870, Phase 0.5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk/README.en.md
@@ -1,0 +1,37 @@
+# Adaptive-Conformal-Risk
+
+**Asset class:** US Equities/ETF (multi-factor)
+**Cloud project IDs:** `29841071` (original, ECE-student no-fee 2015-2026) · `33278416` (`1630-baseline-AdaptiveConformalRisk`, IBKR + aligned 2018-2025)
+**Source:** ECE student project (El Bakkali, Gr02), adapted for the ESGF pool — Issue #238.
+
+## Description
+
+Adaptive Conformal Inference (ACI) risk overlay on multi-factor momentum. Implements the ACI algorithm (Gibbs & Candès, 2021) as a dynamic risk-management overlay: online alpha-adjustment widens/narrows the conformal prediction interval in response to recent coverage violations, and position size is set inversely to the interval width — wider interval (more uncertainty) means a smaller position. Applied over a 15-stock, 5-sector large-cap universe with a 15% volatility target and monthly rebalancing.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk"`
+**QC Cloud:** Deployed (see Cloud project IDs above). The `main.py` committed here is the canonical copy with `set_brokerage_model(IBKR, MARGIN)` (real fees).
+
+## Backtest Metrics
+
+| Metric | Value | Window / fees |
+|--------|-------|---------------|
+| Method | ACI risk overlay + 3-window multi-factor momentum | — |
+| Rebalance | Monthly (daily ACI alpha update) | — |
+| Sharpe | **0.449** | 2018-2025, IBKR real fees (#1630-aligned) |
+| CAGR | 11.5% | 2018-2025, IBKR |
+| MaxDD | 22.5% | 2018-2025, IBKR |
+| PSR | 12.5% (non-significant) | 2018-2025, IBKR |
+| Sharpe (prior, no-fee) | 0.604 | 2015-2026, default fee model (negligible) |
+
+**#1630 caveat (verified 2026-06-23).** Two findings: (a) the low-turnover monthly rebalance + ACI vol-targeting make the overlay **fee-resistant** (0.449 with IBKR is only modestly below the 0.604 no-fee figure, and much of that gap is the harder aligned window) — confirming the #1630 *realized-turnover* discriminator; (b) **but the universe is Mag7-heavy** (AAPL/MSFT/NVDA/AMZN/TSLA = 5 of 7 Mag7), so the Sharpe is substantially Mag7 survivorship drift rather than the marginal value of the conformal overlay (same caveat class as EMATrend). Full analysis: `docs/qc/qc-comparative-backtests.md` finding #38 (See #1630).
+
+## Files
+
+- `main.py` — Strategy (ACI overlay + multi-factor momentum, IBKR brokerage).
+
+## References
+
+- Gibbs, I. & Candès, E. (2021), *Adaptive Conformal Inference Under Distribution Shift*. (The ACI online-alpha algorithm implemented here.)
+- Romano, Y., Patterson, E. & Candès, E. (2020), *Conformalized Quantile Regression*. (Conformal-prediction interval framework.)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk/README.md
@@ -1,37 +1,37 @@
 # Adaptive-Conformal-Risk
 
-**Asset class:** US Equities/ETF (multi-factor)
-**Cloud project IDs:** `29841071` (original, ECE-student no-fee 2015-2026) · `33278416` (`1630-baseline-AdaptiveConformalRisk`, IBKR + aligned 2018-2025)
-**Source:** ECE student project (El Bakkali, Gr02), adapted for the ESGF pool — Issue #238.
+**Classe d'actifs :** Actions/ETF US (multi-facteurs)
+**Cloud project IDs :** `29841071` (original, étudiant ECE sans frais 2015-2026) · `33278416` (`1630-baseline-AdaptiveConformalRisk`, IBKR + aligné 2018-2025)
+**Source :** Projet étudiant ECE (El Bakkali, Gr02), adapté pour le pool ESGF — Issue #238.
 
 ## Description
 
-Adaptive Conformal Inference (ACI) risk overlay on multi-factor momentum. Implements the ACI algorithm (Gibbs & Candès, 2021) as a dynamic risk-management overlay: online alpha-adjustment widens/narrows the conformal prediction interval in response to recent coverage violations, and position size is set inversely to the interval width — wider interval (more uncertainty) means a smaller position. Applied over a 15-stock, 5-sector large-cap universe with a 15% volatility target and monthly rebalancing.
+Couche de risque *Adaptive Conformal Inference* (ACI) sur du momentum multi-facteurs. Implémente l'algorithme ACI (Gibbs & Candès, 2021) comme surcouche dynamique de gestion du risque : l'ajustement en ligne de l'alpha élargit/rétreint l'intervalle de prédiction conforme en réponse aux violations de couverture récentes, et la taille de position est fixée de manière inversement proportionnelle à la largeur de l'intervalle — un intervalle plus large (plus d'incertitude) signifie une position plus petite. Appliqué sur un univers de 15 grandes capitalisations réparties sur 5 secteurs, avec une cible de volatilité de 15 % et un rééquilibrage mensuel.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk"`
-**QC Cloud:** Deployed (see Cloud project IDs above). The `main.py` committed here is the canonical copy with `set_brokerage_model(IBKR, MARGIN)` (real fees).
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk"`
+**QC Cloud :** Déployé (voir les Cloud project IDs ci-dessus). Le `main.py` commité ici est la copie canonique avec `set_brokerage_model(IBKR, MARGIN)` (frais réels).
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Value | Window / fees |
-|--------|-------|---------------|
-| Method | ACI risk overlay + 3-window multi-factor momentum | — |
-| Rebalance | Monthly (daily ACI alpha update) | — |
-| Sharpe | **0.449** | 2018-2025, IBKR real fees (#1630-aligned) |
-| CAGR | 11.5% | 2018-2025, IBKR |
-| MaxDD | 22.5% | 2018-2025, IBKR |
-| PSR | 12.5% (non-significant) | 2018-2025, IBKR |
-| Sharpe (prior, no-fee) | 0.604 | 2015-2026, default fee model (negligible) |
+| Métrique | Valeur | Fenêtre / frais |
+|----------|--------|-----------------|
+| Méthode | Couche de risque ACI + momentum multi-facteurs à 3 fenêtres | — |
+| Rééquilibrage | Mensuel (mise à jour alpha ACI quotidienne) | — |
+| Sharpe | **0.449** | 2018-2025, IBKR frais réels (#1630-aligned) |
+| CAGR | 11.5 % | 2018-2025, IBKR |
+| MaxDD | 22.5 % | 2018-2025, IBKR |
+| PSR | 12.5 % (non significatif) | 2018-2025, IBKR |
+| Sharpe (préalable, sans frais) | 0.604 | 2015-2026, modèle de frais par défaut (négligeable) |
 
-**#1630 caveat (verified 2026-06-23).** Two findings: (a) the low-turnover monthly rebalance + ACI vol-targeting make the overlay **fee-resistant** (0.449 with IBKR is only modestly below the 0.604 no-fee figure, and much of that gap is the harder aligned window) — confirming the #1630 *realized-turnover* discriminator; (b) **but the universe is Mag7-heavy** (AAPL/MSFT/NVDA/AMZN/TSLA = 5 of 7 Mag7), so the Sharpe is substantially Mag7 survivorship drift rather than the marginal value of the conformal overlay (same caveat class as EMATrend). Full analysis: `docs/qc/qc-comparative-backtests.md` finding #38 (See #1630).
+**Caveat #1630 (vérifié 2026-06-23).** Deux constats : (a) le rééquilibrage mensuel à faible rotation + le vol-targeting ACI rendent la couverture **résistante aux frais** (0.449 avec IBKR n'est que modérément inférieur à 0.604 sans frais, et une bonne part de cet écart tient à la fenêtre alignée plus exigeante) — ce qui confirme le discriminateur *realized-turnover* du #1630 ; (b) **mais l'univers est lourd en Mag7** (AAPL/MSFT/NVDA/AMZN/TSLA = 5 des 7 Mag7), donc le Sharpe relève pour l'essentiel de la dérive de survivance Mag7 plutôt que de la valeur marginale de la couche conforme (même classe de caveat qu'EMATrend). Analyse complète : `docs/qc/qc-comparative-backtests.md` finding #38 (See #1630).
 
-## Files
+## Fichiers
 
-- `main.py` — Strategy (ACI overlay + multi-factor momentum, IBKR brokerage).
+- `main.py` — Stratégie (couche ACI + momentum multi-facteurs, brokerage IBKR).
 
-## References
+## Références
 
-- Gibbs, I. & Candès, E. (2021), *Adaptive Conformal Inference Under Distribution Shift*. (The ACI online-alpha algorithm implemented here.)
-- Romano, Y., Patterson, E. & Candès, E. (2020), *Conformalized Quantile Regression*. (Conformal-prediction interval framework.)
+- Gibbs, I. & Candès, E. (2021), *Adaptive Conformal Inference Under Distribution Shift*. (L'algorithme ACI d'alpha en ligne implémenté ici.)
+- Romano, Y., Patterson, E. & Candès, E. (2020), *Conformalized Quantile Regression*. (Cadre des intervalles de prédiction conforme.)


### PR DESCRIPTION
Epic #1650 Phase 0.5 (rule [readme-french-first](../../.claude/rules/readme-french-first.md) HARD 2). FR backfill of the **Adaptive-Conformal-Risk** strategy README — grain from the #3870 deep-queue.

## Summary

Operational README: ACI (Adaptive Conformal Inference) risk overlay (Gibbs & Candès 2021) on multi-factor momentum. 15-stock / 5-sector large-cap universe, 15% vol target, monthly rebalance.

- **git mv README.md -> README.en.md** (EN preserved byte-identical verbatim — verified `git show HEAD:README.md | diff - README.en.md` = empty)
- **new FR README.md** — same structure/tables/metrics/references, strategy name kept EN, prose FR (65 accented chars, fresh translation, grammar verified)
- **0 catalog markers touched** (`COURSE_CATALOG.generated.*` untouched — catalog = automation property, cf [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md))

## Backtest metrics preserved

| Metric | Value |
|--------|-------|
| Sharpe | **0.449** (IBKR 2018-2025 aligned) / 0.604 (no-fee prior) |
| CAGR | 11.5% |
| MaxDD | 22.5% |
| PSR | 12.5% (non-significant) |

The #1630 caveat (fee-resistant via low turnover + ACI vol-targeting, **but Mag7 survivorship drift**: AAPL/MSFT/NVDA/AMZN/TSLA = 5 of 7 Mag7) is preserved in FR.

## Verification (G.1)

- [x] G.1 firsthand: README = genuine hand-written EN (2613 chars, metrics table, references) — not auto-gen stub, not already-FR
- [x] HARD 2 EN byte-identical: `git show HEAD:README.md | diff - README.en.md` = empty
- [x] 0 catalog markers touched
- [x] Atomic 2-file diff (+60/-23)
- [x] Grammar: `adapté` (participle agreeing with "Projet" masc. sg.), "Comment exécuter" (infinitive section) — verified

## Test plan

- [ ] markdown render OK (MD060 table-pipe warnings are cosmetic, same style as EN original, not enforced by repo CI)
- [ ] ai-01 merge

See #3870