### PR TITLE
docs(lean): conway G.1 diagnostic — box_assez_grand is vacuously always-true

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -249,6 +249,42 @@ theorem box_assez_grand_mono_n (g : Grid) {n m : Nat}
   · -- `max 2 (natCeilLog2 (side + 2*m)) ≥ 2`.
     exact Nat.le_max_left _ _
 
+/-- **Diagnostic (G.1 finding, c.148)**: `box_assez_grand g n = true` for ALL
+    grids `g` and all padding amounts `n`.
+
+    The level chosen by the definition, `k := max 2 (natCeilLog2 target)` with
+    `target := (gridBoundingBox g).2 + 2*n`, always satisfies both conjuncts:
+    `2^k ≥ target` (since `natCeilLog2_pow_ge` gives `2^(natCeilLog2 target) ≥
+    target`, and `max 2 (natCeilLog2 _) ≥ natCeilLog2 _` only raises the
+    exponent) and `k ≥ 2` (trivially, `max 2 _`). The two conjunct proofs are
+    exactly those of `box_assez_grand_mono_n` above, which also do not use the
+    `h`/`hle` hypotheses for the inequalities themselves.
+
+    **Consequence** — the `BoxAssezGrand g n` hypothesis in `p5_inductive_step`,
+    `p5_large_n_jump`, and `hashlife_correct` is **vacuous**: it holds for every
+    grid and every `n`, so it carries no information. The real content of those
+    theorems is the unconditional `evolveHashlifeFast n g = evolve n g` equality
+    (which remains gated on P4). This reframes the P5 plan: the "preservation
+    through jump" sub-claim (L2372-2382) is trivially true, and the padding
+    guarantee the predicate was meant to provide — that no live cell can reach
+    the MacroCell boundary within `n` generations — is NOT actually enforced by
+    the current `box_assez_grand` definition. That is a latent defect to surface
+    to the lane owner (ai-01), not a sorry to close here. -/
+theorem box_assez_grand_always_true (g : Grid) (n : Nat) :
+    box_assez_grand g n = true := by
+  unfold box_assez_grand
+  simp only [Bool.and_eq_true, decide_eq_true_eq]
+  set side := (gridBoundingBox g).2
+  refine ⟨?_, Nat.le_max_left _ _⟩
+  -- `2 ^ (max 2 (natCeilLog2 (side + 2*n))) ≥ side + 2*n`, unconditionally:
+  -- `natCeilLog2_pow_ge` + `max` only raises the exponent. Mirrors the first
+  -- conjunct of `box_assez_grand_mono_n` (which needs no hypothesis either).
+  have hnc : 2 ^ natCeilLog2 (side + 2 * n) ≥ side + 2 * n :=
+    natCeilLog2_pow_ge (side + 2 * n)
+  have hexp : natCeilLog2 (side + 2 * n) ≤ max 2 (natCeilLog2 (side + 2 * n)) :=
+    Nat.le_max_right _ _
+  exact le_trans hnc (Nat.pow_le_pow_right (by norm_num : 1 ≤ 2) hexp)
+
 /-! ## P0. Light-cone warm-up lemmas (prover ramp)
 
 Elementary facts about `manhattan` and `lightCone` that feed the **base case**


### PR DESCRIPTION
## Summary

A SDDD grounding of the P5 frame (ai-01 deep-queue: "P4 → **P5** → Knot") surfaced a **verified G.1 finding**: `box_assez_grand`, as currently defined, is true for EVERY grid and EVERY `n`. The `BoxAssezGrand g n` hypothesis in `p5_inductive_step`, `p5_large_n_jump`, and `hashlife_correct` is therefore **vacuous**. This is a diagnostic PR (no sorrow closed, sorry count unchanged) — it surfaces the finding as a proven lemma for the lane owner and reframes the P5 plan.

## What is proven

`box_assez_grand_always_true (g : Grid) (n : Nat) : box_assez_grand g n = true` — proven with **no hypotheses**.

**Why always true.** The definition computes `target := side + 2*n`, `k := max 2 (natCeilLog2 target)`, then checks `2^k ≥ target && k ≥ 2`. Both conjuncts hold unconditionally:
- `2^k ≥ target`: `natCeilLog2_pow_ge` gives `2^(natCeilLog2 target) ≥ target` (proven L205), and `max 2 (natCeilLog2 _) ≥ natCeilLog2 _` only raises the exponent.
- `k ≥ 2`: trivially, `max 2 _ ≥ 2`.

**Independent corroboration**: the existing `box_assez_grand_mono_n` (L226) proves its two conjuncts without using its `h`/`hle` hypotheses for the inequalities themselves — confirming the predicate never depends on the inputs in the way its name implies.

## Consequences for the lane (reframes P5)

1. The "preservation through jump" sub-claim (L2372-2382: `BoxAssezGrand g n → … → BoxAssezGrand g' (n − jumpSize …)`) is **trivially true** — the conclusion holds for any grid. A dedicated P5-preservation proof would be filler, not forward progress.
2. The padding guarantee `box_assez_grand` was meant to provide (no live cell reaches the MacroCell boundary within `n` generations — the GoL light-cone bound the docstring advertises) is **NOT enforced** by the current definition. This is a latent defect: the predicate should relate padding `n` to the grid's actual live-cell light cone, not merely assert a power-of-two level covers the bounding box.
3. The real content of `hashlife_correct` / `p5_inductive_step` is the unconditional `evolveHashlifeFast n g = evolve n g`, still gated on the P4 inductive step (unchanged).

## Decision for the lane owner (ai-01)

(a) Strengthen `box_assez_grand` to a meaningful light-cone predicate (relate padding to the grid's live-cell cone), or (b) accept the unconditional statement and drop the `BoxAssezGrand` hypothesis. This PR takes no position — it only surfaces the verified finding so the decision is made deliberately, not by accident.

## §B Lean review payload

| Item | Value |
|------|-------|
| `grep -c sorry` before | 4 |
| `grep -c sorry` after  | 4 |
| Net Δ | **+0** (diagnostic lemma, not a sorrow close) |
| `lake build Conway.Life.HashlifeCorrectness` | **EXIT 0** |
| Axiom check | 0 `sorry`/`sorryAx` in new code; standard Mathlib axioms only |
| Diff | pure addition (one theorem + docstring); 0 deletions |

Sorry regex (token grep, authoritative per G.2): `^\s*sorry\s*$|:= by sorry|:= sorry\b|exact sorry|^\s*· sorry`.

## Scope (honest, G.3)

- ✅ **Proven + verified**: `box_assez_grand` is vacuously always-true (proven unconditionally; corroborated by inspecting `box_assez_grand_mono_n`).
- ⏳ **Decision deferred to ai-01**: strengthen the predicate vs. drop the hypothesis — no position taken, finding surfaced.
- This is **not** a balisage milestone (no P4.4 sub-piece closed). It is a diagnostic that prevents a futile P5-preservation dispatch (G.9: the grain I was about to attempt would have been filler).

See #3846
