### PR TITLE
docs(claw-systems): README NanoClaw stale OpenRouter → Claudish (#4428)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/README.md
@@ -43,7 +43,7 @@ Utilisateur Telegram
   → Message vocal/texte
   → NanoClaw (Docker)
     → ASR (whisper-api.myia.io) si vocal
-    → LLM (OpenRouter / local)
+    → LLM via Claudish (proxy → GLM / Qwen / Anthropic)
     → Skills (outils configurés)
   → Réponse Telegram
 ```
@@ -120,18 +120,18 @@ Claw-Systems/
 | **NanoClaw** | Agent autonome Telegram | ai-01 (cluster) | Bot Telegram |
 | **Hermes** | Gateway Telegram + cluster coordinator | po-2026 (cluster) | Bot Telegram + dashboards |
 | **ASR Whisper** | Transcription vocale (faster-whisper large-v3-turbo) | po-2023 (cluster) | `whisper-api.myia.io` |
-| **LLM principal NanoClaw** | Raisonnement | OpenRouter ou local | API OpenAI-compatible |
+| **LLM principal NanoClaw** | Raisonnement | Claudish (proxy multi-providers) | wire Anthropic → GLM-5.2 / Qwen / Opus selon le tier |
 | **LLM principal Hermes** | Raisonnement | z.ai (provider natif `"zai"`) | `glm-5.2` via `/api/coding/paas/v4` |
 | **MCP roo-state-manager** | Dashboards + sessions | po-2026 (Hermes) | mcp-remote → proxy LAN (port 9090) |
 
-Les Claw systems sont conçus pour fonctionner **avec ou sans le cluster CoursIA**. Tous les éléments sont remplaçables : OpenRouter peut remplacer z.ai pour Hermes (au prix de la perte du modèle GLM-5.2), Telegram peut être remplacé par n'importe quelle plateforme (Discord, Slack, WhatsApp, Signal — Hermes upstream supporte les six), Whisper auto-hébergé peut être remplacé par l'API Whisper d'OpenAI.
+Les Claw systems sont conçus pour fonctionner **avec ou sans le cluster CoursIA**. Tous les éléments sont remplaçables : NanoClaw consomme le LLM via **Claudish**, un proxy Anthropic-compatible qui peut basculer entre GLM, Qwen et Anthropic d'un simple changement de `MODEL_NAME` (voir [`Claudish/docs/Claudish-Proxy.md`](../Claudish/docs/Claudish-Proxy.md)) ; Hermes, qui parle z.ai natif en direct, peut basculer vers OpenRouter (au prix de la perte du modèle GLM-5.2), Telegram peut être remplacé par n'importe quelle plateforme (Discord, Slack, WhatsApp, Signal — Hermes upstream supporte les six), Whisper auto-hébergé peut être remplacé par l'API Whisper d'OpenAI.
 
 ## Prérequis
 
 **Pour NanoClaw** :
 - **Docker** + Docker Compose (v20.10+ / v2+)
 - **Telegram Bot Token** (via [@BotFather](https://t.me/BotFather) sur Telegram)
-- **OpenRouter API key** ou LLM local (Ollama, vLLM)
+- **Accès Claudish** (proxy LLM multi-providers) : `ANTHROPIC_BASE_URL` + clé d'auth — voir [03-NanoClaw-Deploy.md](docs/03-NanoClaw-Deploy.md) et [`Claudish/docs/Claudish-Proxy.md`](../Claudish/docs/Claudish-Proxy.md)
 - Accès à un endpoint ASR (`whisper-api.myia.io` ou autre service compatible OpenAI Whisper)
 
 **Pour Hermes** :


### PR DESCRIPTION
## Contexte

Follow-up de **#4545** (03 + configs, **MERGED** 15:16Z). La partie README était **déférée post-merge #4539** (NanoClaw y consolidait le README) pour éviter les conflits. #4539 est maintenant **MERGED** → gate ouvert, je corrige les 4 mentions restantes.

Directive : ai-01 `(b)` (DM `msg-20260628T141303-bi0xb0`) + frontière précisée par nanoclaw (16:45Z) : « 4 mentions L46/123/127/134 restent ta cible ; 02 = fait, n'y touche pas ».

## Changements (README.md seul, 4 lignes)

| Ligne | Avant | Après |
|-------|-------|-------|
| **L46** (diagramme pipeline) | `LLM (OpenRouter / local)` | `LLM via Claudish (proxy → GLM / Qwen / Anthropic)` |
| **L123** (table tech) | `OpenRouter ou local \| API OpenAI-compatible` | `Claudish (proxy multi-providers) \| wire Anthropic → GLM-5.2 / Qwen / Opus selon le tier` |
| **L127** (remplaçabilité) | OpenRouter comme seule alternative LLM | Enrichi : Claudish comme couche d'abstraction NanoClaw (switch de tier 1 ligne `MODEL_NAME`) ; Hermes garde z.ai natif + OpenRouter en alternative documentée |
| **L134** (prérequis) | `OpenRouter API key` | `Accès Claudish (ANTHROPIC_BASE_URL + clé d'auth)` |

## Notes éditoriales

- **L127 enrichi, pas effacé** : la phrase de remplaçabilité restait pédagogiquement valide (OpenRouter = alternative Hermes). Je l'ai complétée pour mentionner Claudish comme couche d'abstraction NanoClaw, au lieu de la casser.
- **L'unique mention « OpenRouter » restante** (L127) = alternative Hermes, intentionnelle et correcte, pas du stale.
- `02-NanoClaw-Architecture.md` = **non touché** (déjà corrigé par #4539).

## Vérifs
- Base `origin/main` frais (post-#4539, post-#4545).
- 0 token littéral. Atomique, 1 sujet, 1 fichier.
- Lien vers `Claudish/docs/Claudish-Proxy.md` (résout, déjà merged).

See #4428. Review/merge ai-01. Ferme le stale OpenRouter Claw-Systems (15 occurrences → 0 stale, 1 mention alternative intentionnelle).