### PR TITLE
docs(playwright-owui): P2 jalon module-01 — notebook pédagogique (#4433)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/01-decouverte/01-Decouverte-QA-OWUI.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Playwright-OWUI/01-decouverte/01-Decouverte-QA-OWUI.ipynb
@@ -1,0 +1,553 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Module 01 — Découverte de Playwright & Open WebUI\n",
+    "\n",
+    "> **Étape 1 de la mission « QA Engineer d'une flotte GenAI multi-tenant ».**\n",
+    "> *« Prends en main la plateforme et ton outillage. »*\n",
+    "\n",
+    "Ce notebook est la **couche pédagogique** du module 01. Il raconte le module, lit le banc de tests réel (`01-decouverte.spec.ts`), en orchestre l'inventaire et propose des exercices exécutables. Le fichier `.spec.ts` reste le **moteur de test** (backend) : on ne le remplace pas, on l'enrobe.\n",
+    "\n",
+    "- ⬆️ Reviens au **notebook chapeau** : [`00-Parcours-QA-OWUI.ipynb`](../00-Parcours-QA-OWUI.ipynb) pour le fil rouge complet.\n",
+    "- 🗺️ Cadrage de la mission : [`00-Parcours-QA-OWUI.md`](../00-Parcours-QA-OWUI.md).\n",
+    "\n",
+    "> **Portabilité.** Toutes les cellules de ce notebook s'exécutent **sans navigateur ni instance Open WebUI en ligne** : elles lisent le code des tests et en dressent l'inventaire. Lancer réellement les tests E2E (contre une vraie plateforme) est documenté au §4 et fait l'objet du capstone — ici on apprend à *lire, cartographier et raisonner* sur la suite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "objectifs",
+   "metadata": {},
+   "source": [
+    "## 1. Objectifs & place dans la mission\n",
+    "\n",
+    "La mission compte cinq étapes. Tu es à la **première** : avant de certifier quoi que ce soit, il faut **prendre en main l'outillage** et comprendre comment un test E2E observe une application web réelle.\n",
+    "\n",
+    "À la fin de ce module, tu sais :\n",
+    "\n",
+    "- comprendre l'**architecture** d'un projet Playwright (config, fixtures, helpers, specs, état authentifié) ;\n",
+    "- lire un **test E2E** et reconnaître ses briques (navigation, localisation, assertion, artefact) ;\n",
+    "- choisir des **sélecteurs robustes** (ID › rôle ARIA › `getByRole` › classe CSS) ;\n",
+    "- distinguer un test **réussi / échoué / ignoré** et savoir le lancer en mode visible (`--headed`) pour déboguer.\n",
+    "\n",
+    "| Étape | Module | Ce que tu certifies |\n",
+    "|------:|--------|---------------------|\n",
+    "| **1** | **01 — Découverte (ici)** | *Mon outillage fonctionne, je sais lire un test.* |\n",
+    "| 2 | 02 — Navigation & Auth | L'accès et l'admin. |\n",
+    "| 3 | 03 — Chat & Streaming | Le cœur métier (chat IA). |\n",
+    "| 4 | 04 — RAG, outils & canaux | Les fonctions avancées. |\n",
+    "| 5 | 05 — Multi-tenant & CI/CD | L'isolation + l'industrialisation. |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "setup",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T16:58:34.635271Z",
+     "iopub.status.busy": "2026-06-28T16:58:34.635271Z",
+     "iopub.status.idle": "2026-06-28T16:58:34.646899Z",
+     "shell.execute_reply": "2026-06-28T16:58:34.645657Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Serie       : Playwright-OWUI\n",
+      "Module      : 01-decouverte\n",
+      "Banc de test: 01-decouverte.spec.ts (present)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Setup : localiser la serie et le module, SANS exposer de chemin absolu ---\n",
+    "from pathlib import Path\n",
+    "import re, shutil, subprocess\n",
+    "\n",
+    "def _redact(texte: str) -> str:\n",
+    "    # Anti-fuite : ne jamais afficher de chemin absolu (machine de l'auteur, home...).\n",
+    "    out = texte\n",
+    "    for absolu in {str(Path.cwd().resolve()), str(Path.home())}:\n",
+    "        out = out.replace(absolu, \".\")\n",
+    "        out = out.replace(absolu.replace(\"/\", \"\\\\\"), \".\")\n",
+    "    return out\n",
+    "\n",
+    "def trouver_racine_serie(depart=None) -> Path:\n",
+    "    # La racine de la serie = le dossier qui contient playwright.config.ts.\n",
+    "    p = Path(depart or Path.cwd()).resolve()\n",
+    "    for cand in [p, *p.parents]:\n",
+    "        if (cand / \"playwright.config.ts\").exists():\n",
+    "            return cand\n",
+    "    for sub in Path.cwd().resolve().rglob(\"playwright.config.ts\"):\n",
+    "        return sub.parent\n",
+    "    raise FileNotFoundError(\"playwright.config.ts introuvable depuis le dossier courant\")\n",
+    "\n",
+    "SERIE = trouver_racine_serie()\n",
+    "MODULE = SERIE / \"01-decouverte\"\n",
+    "SPEC = MODULE / \"01-decouverte.spec.ts\"\n",
+    "\n",
+    "print(\"Serie       :\", SERIE.name)\n",
+    "print(\"Module      :\", MODULE.name)\n",
+    "print(\"Banc de test:\", SPEC.name, \"(present)\" if SPEC.exists() else \"(ABSENT)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pourquoi",
+   "metadata": {},
+   "source": [
+    "## 2. Pourquoi Playwright, et comment il « voit » la page\n",
+    "\n",
+    "**Playwright** (Microsoft) pilote un vrai navigateur (Chromium/Firefox/WebKit) et exécute des scénarios comme le ferait un humain. Deux idées portent tout le module :\n",
+    "\n",
+    "1. **L'auto-wait.** Playwright attend *automatiquement* qu'un élément soit visible/cliquable avant d'agir. On n'écrit (presque) jamais de `sleep()` : on exprime une **attente sur un état** (`toBeVisible`, `toHaveText`…).\n",
+    "2. **La session réutilisée (`storageState`).** Un setup d'authentification se connecte **une fois**, sauvegarde cookies/tokens dans `.auth/owui.json`, et tous les tests repartent déjà connectés — plus rapide et plus robuste face au rate-limiting.\n",
+    "\n",
+    "**Sélecteurs — du plus robuste au plus fragile :**\n",
+    "\n",
+    "| Rang | Type | Exemple | Pourquoi |\n",
+    "|-----:|------|---------|----------|\n",
+    "| 1 | **ID** | `#chat-input` | Stable, unique. |\n",
+    "| 2 | **Rôle ARIA / label** | `button[aria-label=\"…\"]` | Accessible, résiste au restylage. |\n",
+    "| 3 | **`getByRole` / `getByText`** | `getByRole('button', { name: /menu/i })` | Sémantique, recommandé par Playwright. |\n",
+    "| 4 | **Classe CSS** | `.chat-user` | Fragile : casse au moindre refactor de style. |\n",
+    "\n",
+    "Retiens la règle : **un sélecteur doit décrire ce que l'élément *est* (son rôle), pas à quoi il *ressemble* (sa classe CSS).**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "lire_spec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T16:58:34.649420Z",
+     "iopub.status.busy": "2026-06-28T16:58:34.648419Z",
+     "iopub.status.idle": "2026-06-28T16:58:34.662015Z",
+     "shell.execute_reply": "2026-06-28T16:58:34.661017Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Theme du module : 01 — Decouverte : Premiers pas avec Playwright\n",
+      "\n",
+      "4 test(s) defini(s) dans 01-decouverte.spec.ts :\n",
+      "  1. connexion reussie — la page principale se charge\n",
+      "  2. le selecteur de modeles liste les modeles disponibles\n",
+      "  3. le menu utilisateur est accessible\n",
+      "  4. capturer un screenshot de la page principale\n",
+      "\n",
+      "4 exercice(s) embarque(s) dans les commentaires du spec.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Lire le banc de tests et en extraire la structure (sans le lancer) ---\n",
+    "texte = SPEC.read_text(encoding=\"utf-8\")\n",
+    "\n",
+    "# Titres des tests : test('....', ...) — le spec utilise des guillemets simples\n",
+    "titres = re.findall(r\"test\\('([^']+)'\", texte)\n",
+    "# Le bloc describe (le theme du module)\n",
+    "describe = re.search(r\"describe\\('([^']+)'\", texte)\n",
+    "\n",
+    "print(\"Theme du module :\", describe.group(1) if describe else \"(non trouve)\")\n",
+    "print()\n",
+    "print(f\"{len(titres)} test(s) defini(s) dans {SPEC.name} :\")\n",
+    "for i, t in enumerate(titres, 1):\n",
+    "    print(f\"  {i}. {t}\")\n",
+    "\n",
+    "# Compter les exercices embarques (commentaires // EXERCICE)\n",
+    "nb_ex = len(re.findall(r\"//\\s*EXERCICE\", texte))\n",
+    "print()\n",
+    "print(f\"{nb_ex} exercice(s) embarque(s) dans les commentaires du spec.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "anatomie",
+   "metadata": {},
+   "source": [
+    "## 3. Anatomie d'un test Playwright\n",
+    "\n",
+    "Regardons le **premier test** du module (« connexion réussie »). Sa forme est le squelette de *tous* les tests E2E :\n",
+    "\n",
+    "```ts\n",
+    "test.beforeEach(async ({ page }) => {\n",
+    "  await page.goto('/');        // 1. naviguer\n",
+    "  await dismissModals(page);   // 2. neutraliser les pop-ups (changelog, etc.)\n",
+    "});\n",
+    "\n",
+    "test('connexion reussie — la page principale se charge', async ({ page }) => {\n",
+    "  await expect(page.locator(MODEL.selectorButton))   // 3. localiser\n",
+    "        .toBeVisible({ timeout: 15_000 });            // 4. asserter (auto-wait)\n",
+    "});\n",
+    "```\n",
+    "\n",
+    "Quatre gestes reviennent partout : **naviguer → localiser → agir → asserter**. Le `beforeEach` factorise ce qui doit être vrai *avant chaque* test (ici : être sur la page d'accueil, sans modale qui bloque les clics). Le `timeout` généreux (15 s) absorbe la lenteur d'une vraie plateforme — ce n'est pas un `sleep`, c'est une **borne** sur l'auto-wait."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "inventaire_list",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T16:58:34.664436Z",
+     "iopub.status.busy": "2026-06-28T16:58:34.664436Z",
+     "iopub.status.idle": "2026-06-28T16:58:36.625556Z",
+     "shell.execute_reply": "2026-06-28T16:58:36.624557Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "returncode: 0\n",
+      "Listing tests:\n",
+      "  [owui-setup] › fixtures\\auth.setup.ts:18:1 › authenticate\n",
+      "  [owui] › 01-decouverte\\01-decouverte.spec.ts:46:3 › 01 — Decouverte : Premiers pas avec Playwright › connexion reussie — la page principale se charge\n",
+      "  [owui] › 01-decouverte\\01-decouverte.spec.ts:68:3 › 01 — Decouverte : Premiers pas avec Playwright › le selecteur de modeles liste les modeles disponibles\n",
+      "  [owui] › 01-decouverte\\01-decouverte.spec.ts:101:3 › 01 — Decouverte : Premiers pas avec Playwright › le menu utilisateur est accessible\n",
+      "  [owui] › 01-decouverte\\01-decouverte.spec.ts:133:3 › 01 — Decouverte : Premiers pas avec Playwright › capturer un screenshot de la page principale\n",
+      "Total: 5 tests in 2 files\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Inventaire REEL via Playwright : `npx playwright test --grep '01' --list` ---\n",
+    "# Liste les tests SANS les executer (--list) et SANS navigateur.\n",
+    "# Ne tourne que si npx + node_modules sont presents ; sinon repli propre.\n",
+    "def lister_tests_module(serie: Path, grep: str = \"01\"):\n",
+    "    if shutil.which(\"npx\") is None:\n",
+    "        return None, \"npx introuvable — `npm install` requis (repli : inventaire statique ci-dessus).\"\n",
+    "    if not (serie / \"node_modules\").exists():\n",
+    "        return None, \"node_modules absent — `npm install` requis (repli : inventaire statique ci-dessus).\"\n",
+    "    try:\n",
+    "        # NB: pas de guillemets autour de {grep} — cmd.exe (Windows) les traite\n",
+    "        # comme litteraux. grep est un token simple (ex. \"01\"), sans espace.\n",
+    "        r = subprocess.run(\n",
+    "            f\"npx playwright test --grep {grep} --list\",\n",
+    "            cwd=str(serie), shell=True, capture_output=True, text=True, timeout=180,\n",
+    "        )\n",
+    "        sortie = (r.stdout or \"\") + (r.stderr or \"\")\n",
+    "        return r.returncode, _redact(sortie.strip())\n",
+    "    except Exception as e:\n",
+    "        return None, f\"{type(e).__name__}: {e}\"\n",
+    "\n",
+    "code_retour, sortie = lister_tests_module(SERIE, \"01\")\n",
+    "print(\"returncode:\", code_retour)\n",
+    "print(sortie if sortie else \"(aucune sortie)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lancer",
+   "metadata": {},
+   "source": [
+    "## 4. Lancer le module (pour de vrai)\n",
+    "\n",
+    "L'inventaire ci-dessus se fait hors-ligne. Pour **exécuter** les tests contre une vraie instance Open WebUI, il faut un `.env` configuré (`OWUI_URL`, `OWUI_EMAIL`, `OWUI_PASSWORD`) — jamais commité — puis :\n",
+    "\n",
+    "```bash\n",
+    "npm install                                  # dependances\n",
+    "npx playwright install chromium              # navigateur\n",
+    "npm run test:module1                         # ce module uniquement\n",
+    "npx playwright test --grep \"01\" --headed     # navigateur VISIBLE (debug)\n",
+    "PWDEBUG=1 npx playwright test --grep \"01\" --headed   # Playwright Inspector\n",
+    "npm run report                               # rapport HTML\n",
+    "```\n",
+    "\n",
+    "> L'exécution live dépend d'une plateforme et de secrets : elle est **différée** ici (et constitue le cœur du capstone). Ce notebook reste reproductible partout, sans secret."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "selecteurs_demo",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T16:58:36.628063Z",
+     "iopub.status.busy": "2026-06-28T16:58:36.628063Z",
+     "iopub.status.idle": "2026-06-28T16:58:36.639622Z",
+     "shell.execute_reply": "2026-06-28T16:58:36.639622Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  rang 1 : #chat-input\n",
+      "  rang 2 : button[aria-label='User Menu']\n",
+      "  rang 3 : getByRole('button', { name: /menu/i })\n",
+      "  rang 4 : .chat-user\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Demonstration executable : classer des selecteurs par robustesse ---\n",
+    "# Pas de navigateur : on raisonne sur la *forme* du selecteur (le concept du para. 2).\n",
+    "RANGS = {\"id\": 1, \"role\": 2, \"getby\": 3, \"css\": 4}\n",
+    "\n",
+    "def robustesse(selecteur: str) -> int:\n",
+    "    s = selecteur.strip()\n",
+    "    if s.startswith(\"#\"):\n",
+    "        return RANGS[\"id\"]\n",
+    "    if \"aria-label\" in s or \"[role=\" in s:\n",
+    "        return RANGS[\"role\"]\n",
+    "    if s.startswith(\"getByRole\") or s.startswith(\"getByText\"):\n",
+    "        return RANGS[\"getby\"]\n",
+    "    if s.startswith(\".\") or s.startswith(\"css=\"):\n",
+    "        return RANGS[\"css\"]\n",
+    "    return 99  # inconnu\n",
+    "\n",
+    "exemples = [\"#chat-input\", \"button[aria-label='User Menu']\",\n",
+    "            \"getByRole('button', { name: /menu/i })\", \".chat-user\"]\n",
+    "for s in sorted(exemples, key=robustesse):\n",
+    "    print(f\"  rang {robustesse(s)} : {s}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interpreter",
+   "metadata": {},
+   "source": [
+    "## 5. Interpréter les résultats\n",
+    "\n",
+    "Un run renvoie, pour chaque test, un statut. Savoir les distinguer est la base du verdict go/no-go :\n",
+    "\n",
+    "- **passed** — le test a vérifié ce qu'il devait. ✅\n",
+    "- **failed** — une assertion a échoué *ou* un sélecteur n'a rien trouvé → drift d'interface possible, à investiguer.\n",
+    "- **skipped** — volontairement ignoré (service non configuré). **Un skip n'est pas une régression.**\n",
+    "- **flaky** — passe au retry après un premier échec (souvent : LLM lent, charge). À distinguer d'un vrai échec."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "qualifier",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T16:58:36.643154Z",
+     "iopub.status.busy": "2026-06-28T16:58:36.643154Z",
+     "iopub.status.idle": "2026-06-28T16:58:36.656316Z",
+     "shell.execute_reply": "2026-06-28T16:58:36.655730Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bilan module 01 (echantillon) : {'passed': 2, 'failed': 1, 'skipped': 1, 'flaky': 0}\n",
+      "Verdict provisoire : NO-GO (investiguer les failed)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Qualifier un rapport (echantillon module 01) ---\n",
+    "rapport_exemple = [\n",
+    "    {\"test\": \"connexion reussie\", \"status\": \"passed\"},\n",
+    "    {\"test\": \"selecteur de modeles\", \"status\": \"passed\"},\n",
+    "    {\"test\": \"menu utilisateur\", \"status\": \"failed\"},    # ex. : drift libelle\n",
+    "    {\"test\": \"screenshot page principale\", \"status\": \"skipped\"},\n",
+    "]\n",
+    "\n",
+    "def qualifier(rapport):\n",
+    "    n = {\"passed\": 0, \"failed\": 0, \"skipped\": 0, \"flaky\": 0}\n",
+    "    for t in rapport:\n",
+    "        n[t[\"status\"]] = n.get(t[\"status\"], 0) + 1\n",
+    "    return n\n",
+    "\n",
+    "bilan = qualifier(rapport_exemple)\n",
+    "print(\"Bilan module 01 (echantillon) :\", bilan)\n",
+    "verdict = \"GO\" if bilan[\"failed\"] == 0 else \"NO-GO (investiguer les failed)\"\n",
+    "print(\"Verdict provisoire :\", verdict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercices",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices, tous **exécutables tels quels** (ils tournent sans erreur et renvoient un placeholder). Remplace le corps de chaque fonction, ré-exécute, et compare au comportement attendu décrit plus haut."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex1_md",
+   "metadata": {},
+   "source": [
+    "## Exercice 1 — Classer un sélecteur\n",
+    "\n",
+    "Complète `rang_robustesse` pour qu'elle renvoie le rang (1 = ID le plus robuste … 4 = classe CSS la plus fragile) du sélecteur passé, **sans** réutiliser `robustesse` du §2. Appuie-toi sur la règle du §2 (rôle vs apparence)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ex1_code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T16:58:36.659832Z",
+     "iopub.status.busy": "2026-06-28T16:58:36.658832Z",
+     "iopub.status.idle": "2026-06-28T16:58:36.671989Z",
+     "shell.execute_reply": "2026-06-28T16:58:36.671412Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rang de '#chat-input' : -1\n"
+     ]
+    }
+   ],
+   "source": [
+    "def rang_robustesse(selecteur: str) -> int:\n",
+    "    # TODO : renvoyer 1 (ID), 2 (role/aria), 3 (getByRole/Text), 4 (classe CSS)\n",
+    "    # Indice : inspecte le prefixe du selecteur.\n",
+    "    return -1  # placeholder — a remplacer\n",
+    "\n",
+    "# Test rapide (doit afficher 1 une fois complete) :\n",
+    "print(\"rang de '#chat-input' :\", rang_robustesse(\"#chat-input\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex2_md",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 — Relier un test à son concept\n",
+    "\n",
+    "Complète `concept_du_test` : à partir du titre d'un test du module, renvoie le concept Playwright principal qu'il illustre (ex. `\"auto-wait\"`, `\"count\"`, `\"getByRole\"`, `\"screenshot\"`). Inspire-toi du tableau de la partie pratique du README."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ex2_code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T16:58:36.675128Z",
+     "iopub.status.busy": "2026-06-28T16:58:36.675128Z",
+     "iopub.status.idle": "2026-06-28T16:58:36.687670Z",
+     "shell.execute_reply": "2026-06-28T16:58:36.687167Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  'connexion reussie' -> a determiner\n",
+      "  'le selecteur de modeles liste les modeles disponibles' -> a determiner\n",
+      "  'le menu utilisateur est accessible' -> a determiner\n",
+      "  'capturer un screenshot' -> a determiner\n"
+     ]
+    }
+   ],
+   "source": [
+    "def concept_du_test(titre: str) -> str:\n",
+    "    # TODO : mapper un titre de test -> son concept principal\n",
+    "    # Ex : \"le selecteur de modeles liste...\" -> \"count\"\n",
+    "    return \"a determiner\"  # placeholder\n",
+    "\n",
+    "for t in [\"connexion reussie\", \"le selecteur de modeles liste les modeles disponibles\",\n",
+    "          \"le menu utilisateur est accessible\", \"capturer un screenshot\"]:\n",
+    "    print(f\"  {t!r} -> {concept_du_test(t)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex3_md",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 — L'assertion manquante\n",
+    "\n",
+    "Le TEST 1 du spec laisse un exercice en commentaire : ajouter une assertion sur le **titre** de la page. En TypeScript ce serait `await expect(page).toHaveTitle(/Open WebUI/);`. Ici, renvoie cette ligne sous forme de chaîne depuis `assertion_titre()` (on valide la *forme*, pas l'exécution navigateur)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ex3_code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T16:58:36.690678Z",
+     "iopub.status.busy": "2026-06-28T16:58:36.690678Z",
+     "iopub.status.idle": "2026-06-28T16:58:36.703746Z",
+     "shell.execute_reply": "2026-06-28T16:58:36.703242Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def assertion_titre() -> str:\n",
+    "    # TODO : renvoyer la ligne d'assertion Playwright verifiant le titre de page\n",
+    "    # Forme attendue : await expect(page).toHaveTitle(/Open WebUI/);\n",
+    "    return \"a completer\"  # placeholder\n",
+    "\n",
+    "print(assertion_titre())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "conclusion",
+   "metadata": {},
+   "source": [
+    "## Conclusion & étape suivante\n",
+    "\n",
+    "Tu sais désormais **lire** un test Playwright, **cartographier** une suite, raisonner sur les **sélecteurs** et **interpréter** un bilan — sans avoir eu besoin d'une plateforme en ligne. C'est la fondation : tout le reste de la mission s'appuie dessus.\n",
+    "\n",
+    "➡️ **Étape 2 — [Module 02 : Navigation & Authentification](../02-navigation-authentification/).** Tu y sécuriseras l'accès (`storageState`, RBAC) et exploreras l'admin.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "> **Note de reproductibilité (C.3).** Les cellules de ce notebook ont été exécutées hors-ligne : lecture du `.spec.ts`, inventaire `--list` (sans navigateur) et démonstrations pure-Python. Aucune ne requiert d'instance Open WebUI ni de secret. L'exécution **live** des tests E2E (navigateur + plateforme) est volontairement différée au capstone et sera revalidée en Phase 3 (Open WebUI v0.9.6). Aucun claim de compatibilité v0.9.6 n'est porté par ce module."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## P2 — couche notebook module 01 (« Découverte »)

Premier jalon de la **Phase 2** de la refonte pédagogique Playwright-OWUI (#4433, sous l'Epic-parapluie #4427). Ajoute `01-decouverte/01-Decouverte-QA-OWUI.ipynb` : la couche narrative + orchestration + exercices qui enrobe le banc de tests `01-decouverte.spec.ts` **conservé tel quel comme moteur de test réel** (backend).

### Contenu (19 cellules, 8 code)
- **Narration** : place du module dans la mission (étape 1/5 du fil rouge), concepts Playwright (auto-wait, `storageState`, hiérarchie de sélecteurs ID › ARIA › `getByRole` › CSS), anatomie d'un test.
- **Orchestration réelle** : lecture du `.spec.ts` (4 tests + 4 exos embarqués détectés) et inventaire `npx playwright test --grep 01 --list` exécuté **hors-ligne** (returncode 0 → 4 tests module-01 + `owui-setup`).
- **Démos pure-Python** : classement de sélecteurs par robustesse, qualification d'un rapport (passed/failed/skipped/flaky → verdict go/no-go).
- **3 exercices** `## Exercice` exécutables.

### Conformité #4427
- **C.1** — 3 stubs d'exercice exécutables sans erreur (placeholders, aucune erreur intentionnelle).
- **C.2** — notebook exécuté, **outputs réels commités, 0 scrub** (Stop&Repair re-exec, jamais d'édition manuelle des outputs).
- **C.3** — exécution **hors-ligne** documentée (pas d'instance OWUI ni de secret requis) ; revalidation **live** différée en Phase 3.
- ≥3 `## Exercice` ✓ · **0 secret** ✓ · **anti-fuite** (aucun chemin absolu : helper `_redact` + `.name`) ✓.
- **Aucun claim de compatibilité v0.9.6** (porté par P3).
- CATALOG-STATUS : non touché (markers auto-only cron/CI).

### Portée
- Atomique : **1 fichier** (le notebook). Branche `docs/playwright-owui-p2-m01` off `origin/main` frais.
- P2 se poursuit module par module (02→05) en PR atomiques séparées.

Part of #4433.
