### PR TITLE
refactor(arg-shim): surface UnifiedAnalysisState in public API + align 5-jtms (#2137 Phase 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-5-jtms.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-5-jtms.ipynb
@@ -650,16 +650,16 @@
      "output_type": "stream",
      "text": [
       "Croyances JTMS versees dans l'etat partage :\n",
-      "  jtms_1: {'name': 'X_is_true', 'valid': True, 'justifications': [['expert_claims_X']]}\n",
-      "  jtms_2: {'name': 'decide_X', 'valid': True, 'justifications': [['X_is_true']]}\n",
-      "  jtms_3: {'name': 'expert_claims_X', 'valid': True, 'justifications': [[]]}\n",
+      "  jtms_1: {'name': 'decide_X', 'valid': True, 'justifications': [['X_is_true']]}\n",
+      "  jtms_2: {'name': 'expert_claims_X', 'valid': True, 'justifications': [[]]}\n",
+      "  jtms_3: {'name': 'X_is_true', 'valid': True, 'justifications': [['expert_claims_X']]}\n",
       "Total : 3 croyances non-monotones dans l'etat.\n"
      ]
     }
    ],
    "source": [
     "# Cellule [12] - Pont : verser les croyances JTMS dans UnifiedAnalysisState\n",
-    "from argumentation_lib._shared_state import UnifiedAnalysisState\n",
+    "from argumentation_lib import UnifiedAnalysisState\n",
     "\n",
     "# On reconstruit un JTMS propre (etat IN, avant toute retractation)\n",
     "t = JTMS()\n",
@@ -727,6 +727,10 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
+  },
+  "papermill": {
+   "input_path": "Argument_Analysis_Agentic-5-jtms.ipynb",
+   "output_path": "Argument_Analysis_Agentic-5-jtms.ipynb"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/__init__.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/__init__.py
@@ -35,6 +35,7 @@ from argumentation_lib._jvm_compat import (
 from argumentation_lib._shared_state import (
     ArgumentProfile,
     RhetoricalAnalysisState,
+    UnifiedAnalysisState,
 )
 
 # -- State Manager Plugin (Semantic Kernel @kernel_function wrapper) --
@@ -72,7 +73,7 @@ __all__ = [
     # jvm
     "initialize_jvm", "is_jvm_started", "shutdown_jvm",
     # state
-    "ArgumentProfile", "RhetoricalAnalysisState",
+    "ArgumentProfile", "RhetoricalAnalysisState", "UnifiedAnalysisState",
     "get_state_manager_plugin",
     # runner
     "get_analysis_runner",


### PR DESCRIPTION
## Summary

Completes the public API of the `argumentation_lib` shim so **Agentic-5-jtms** consumes it via its public surface instead of reaching into a private `_` module. Dispatched by ai-01 (msg-4qg7rv — \"refondre Argument_Analysis pour consommer un shim stable côté Python\", Phase-2 lane, submodule-independent).

## Why (grounded beforehand)

The shim exposed `RhetoricalAnalysisState` publicly but **not** its subclass `UnifiedAnalysisState`. 5-jtms cell 8 (the \"Pont : verser les croyances JTMS dans UnifiedAnalysisState\" bridge cell) therefore imported it from the private module:
```python
from argumentation_lib._shared_state import UnifiedAnalysisState   # private
```
That is precisely the \"shim not stable enough to consume cleanly\" smell: a notebook reaching past the public API into implementation internals because the API surface was incomplete.

## Change (2 files, surgical)

**`argumentation_lib/__init__.py`** — surface `UnifiedAnalysisState` publicly:
- `+` import line (`from argumentation_lib._shared_state import ... UnifiedAnalysisState`)
- `+` `__all__` entry
- Pure additive — the class already existed at `_shared_state.py:385` (subclass of the already-public `RhetoricalAnalysisState`). **Verified `argumentation_lib.UnifiedAnalysisState is argumentation_lib._shared_state.UnifiedAnalysisState`** (identity) → zero behavior change, no new code.

**`Argument_Analysis_Agentic-5-jtms.ipynb`** cell 8 — align to public API:
```python
from argumentation_lib import UnifiedAnalysisState   # public
```

## Validation (C.2 / H.1)

- **Shim imports cleanly** standalone: `argumentation_lib.UnifiedAnalysisState` resolves, same class object as the private one (anti-regression identity check).
- **5-jtms re-executed end-to-end** (MCP jupyter, python3): **9/9 cells, 0 errors** — the public import resolves and the JTMS→UnifiedAnalysisState bridge runs green.
- **Source diff = exactly 1 line** (the import, cell 8); **0 markdown changed**. All other diff hunks are legitimate C.2 output regeneration from re-exec.
- C.1 clean (no `raise NotImplementedError` / `assert False` / `1/0`), C.2 clean (all 9 code cells `execution_count` populated, outputs committed).
- Stop & Repair: outputs are real kernel output (no hand-editing); `metadata.papermill.input/output_path` normalized to basename (only allowed manual normalization).

## Scope

Atomic, C.2-clean. **0-init cell5** also reaches into `_paths` for `SYMBOLIC_AI_DIR` (already public) but its re-exec needs the full JVM + JDK 17 + 76-JAR Tweety stack — deferred to a separate assessment to keep this slice atomic and avoid a heavy-env re-exec risk.

See #2137

🤖 Generated with [Claude Code](https://claude.com/claude-code)