### PR TITLE
docs(qc): FR backfill Framework_Composite_FamaFrenchAllWeather README (#3870, Phase 0.5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_FamaFrenchAllWeather/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_FamaFrenchAllWeather/README.en.md
@@ -1,0 +1,99 @@
+# Framework Composite - FamaFrench + AllWeather
+
+## Description
+
+Composite strategy combining two complementary approaches via QuantConnect Algorithm Framework:
+
+1. **FamaFrench (20% slice)**: Factor ETF rotation (VLUE, MTUM, SIZE, QUAL, USMV)
+   - Risk-adjusted momentum (return/volatility over 3/6/12 months)
+   - Skip-month (exclude last month to avoid short-term reversal)
+   - Top-2 factors by risk-adjusted momentum
+   - Quarterly rebalancing
+
+2. **AllWeather (80% slice)**: Static multi-asset allocation (SPY 30%, IEF 30%, GLD 30%, XLP 10%)
+   - Ray Dalio-inspired "All Weather" portfolio (simplified, no TLT)
+   - Drift rebalancing (3% threshold)
+   - Monthly rebalancing
+
+## Key Design Principle
+
+**NO overlap between universes**: Factor ETFs (equity factors) vs traditional assets (equities/bonds/gold). This creates true diversification:
+- FamaFrench: Equity factor exposure (value, momentum, size, quality, low-vol)
+- AllWeather: Macro allocation (stocks, bonds, gold, defensive)
+
+**Important**: FamaFrench uses risk-adjusted momentum ONLY (no SMA200 filter). AllWeather handles defense through its static allocation.
+
+## Files
+
+- `main.py`: Algorithm setup with CompositeAlpha and MultiStrategyPCM
+- `alpha_models.py`: FamaFrenchAlpha and AllWeatherAlpha classes
+- `portfolio_construction.py`: MultiStrategyPCM for capital allocation per strategy
+- `quantbook.ipynb`: Research notebook with backtest analysis
+
+## Performance
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | **0.588** |
+| CAGR | 9.9% |
+| Max Drawdown | 17.1% |
+| Period | 2010-2026 |
+
+### Aligned baseline (2018-2025)
+
+Standardized #1630 window (2018-01-01 to 2025-01-01, 1761 tradeable dates), backtested on QC Cloud with post-#2801 real fees.
+
+| Metric | README headline (2010-2026 sweep) | Catalog (2015-2025) | **Aligned (2018-2025)** |
+|--------|-----------------------------------|---------------------|-------------------------|
+| Sharpe | 0.588 | 0.472 | **0.338** |
+| CAGR | 9.9% | 7.226% | 6.578% |
+| MaxDD | 17.1% | 13.1% | 13.1% |
+| PSR | — | 35.0% | 22.9% |
+
+Aligned backtest `e9ac7c66` (1761 tradeable dates, Completed) / catalog backtest `70415edc` (`FF20_AW80_2015_2025_extended`, 2766 dates). `totalOrders=0` is an MCP wrapper extraction artifact (CAGR 6.6% implies real trades); QC-computed statistics are reliable.
+
+**Period-overfitting caveat**: the strong headline figures do NOT survive alignment to the standardized 2018-2025 window. The README headline Sharpe 0.588 (2010-2026 sweep) drops to **0.338** (-42%), and the separately-run OOS 2023-2026 figure (Sharpe 0.684, PSR 87.5% — backtest `b08c8956`, only 835 tradeable dates) collapses to 0.338 / PSR 22.9% on the full aligned window: the 87.5% PSR was a small-OOS-sample artifact, not a robust statistical edge. On the aligned window the 80% AllWeather sleeve (mostly static SPY/IEF/GLD/XLP) drags the composite below the standalone FamaFrench rotation (Sharpe 0.445, #72), though it buys tight drawdown control (MaxDD 13.1%, among the tighter backbones). Promoted Tier 4 (Untested) to Tier 2 (Historique).
+
+## Allocation Sweep Results
+
+| Allocation | Sharpe | CAGR | Max DD |
+|------------|--------|------|--------|
+| FF20/AW80 | **0.588** | 9.9% | 17.1% |
+| FF40/AW60 | 0.564 | 10.5% | 19.3% |
+| FF50/AW50 | 0.539 | 10.8% | 21.7% |
+| FF60/AW40 | 0.512 | 11.2% | 24.1% |
+
+**Winner**: FF20/AW80 (best risk-adjusted returns)
+
+## Component Strategies
+
+| Strategy | Sharpe | CAGR | Max DD |
+|----------|--------|------|--------|
+| FamaFrench v3.0 | 0.540 | 12.1% | 24.2% |
+| AllWeather | 0.667 | 9.3% | 16.4% |
+| **Composite (FF20/AW80)** | **0.588** | **9.9%** | **17.1%** |
+
+The composite achieves better risk-adjusted returns than FamaFrench alone with lower drawdown.
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `ff_allocation` | 0.20 | FamaFrench slice (0.20 = 20%) |
+| `aw_allocation` | 0.80 | AllWeather slice (0.80 = 80%) |
+
+## Backtest Period
+
+2010-01-01 to 2026-03-10 (covers bull, bear, and sideways regimes)
+
+## Deployment
+
+- **Project ID**: 28882145
+- **Organization**: Jean-Sylvain Boige (Researcher PAID)
+- **Status**: ✅ Deployed and backtested
+
+## References
+
+- **FamaFrench**: Factor ETF rotation with risk-adjusted momentum
+- **AllWeather**: Multi-asset static allocation (no TLT)
+- **SESSION5_PATTERNS.md**: AlphaModel Framework pedagogical guide

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_FamaFrenchAllWeather/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_FamaFrenchAllWeather/README.md
@@ -2,98 +2,98 @@
 
 ## Description
 
-Composite strategy combining two complementary approaches via QuantConnect Algorithm Framework:
+Stratégie composite combinant deux approches complémentaires via le QuantConnect Algorithm Framework :
 
-1. **FamaFrench (20% slice)**: Factor ETF rotation (VLUE, MTUM, SIZE, QUAL, USMV)
-   - Risk-adjusted momentum (return/volatility over 3/6/12 months)
-   - Skip-month (exclude last month to avoid short-term reversal)
-   - Top-2 factors by risk-adjusted momentum
-   - Quarterly rebalancing
+1. **FamaFrench (tranche 20 %)** : Rotation d'ETF factoriels (VLUE, MTUM, SIZE, QUAL, USMV)
+   - Momentum ajusté du risque (rendement/volatilité sur 3/6/12 mois)
+   - Skip-month (exclure le dernier mois pour éviter le retournement court terme)
+   - Top-2 facteurs par momentum ajusté du risque
+   - Rééquilibrage trimestriel
 
-2. **AllWeather (80% slice)**: Static multi-asset allocation (SPY 30%, IEF 30%, GLD 30%, XLP 10%)
-   - Ray Dalio-inspired "All Weather" portfolio (simplified, no TLT)
-   - Drift rebalancing (3% threshold)
-   - Monthly rebalancing
+2. **AllWeather (tranche 80 %)** : Allocation statique multi-actifs (SPY 30 %, IEF 30 %, GLD 30 %, XLP 10 %)
+   - Portefeuille « All Weather » inspiré de Ray Dalio (simplifié, sans TLT)
+   - Rééquilibrage par dérive (seuil 3 %)
+   - Rééquilibrage mensuel
 
-## Key Design Principle
+## Principe de conception clé
 
-**NO overlap between universes**: Factor ETFs (equity factors) vs traditional assets (equities/bonds/gold). This creates true diversification:
-- FamaFrench: Equity factor exposure (value, momentum, size, quality, low-vol)
-- AllWeather: Macro allocation (stocks, bonds, gold, defensive)
+**PAS de chevauchement entre univers** : ETF factoriels (facteurs actions) vs actifs traditionnels (actions/obligations/or). Cela crée une vraie diversification :
+- FamaFrench : exposition aux facteurs actions (value, momentum, size, quality, low-vol)
+- AllWeather : allocation macro (actions, obligations, or, défensif)
 
-**Important**: FamaFrench uses risk-adjusted momentum ONLY (no SMA200 filter). AllWeather handles defense through its static allocation.
+**Important** : FamaFrench utilise le momentum ajusté du risque UNIQUEMENT (pas de filtre SMA200). AllWeather gère la défense via son allocation statique.
 
-## Files
+## Fichiers
 
-- `main.py`: Algorithm setup with CompositeAlpha and MultiStrategyPCM
-- `alpha_models.py`: FamaFrenchAlpha and AllWeatherAlpha classes
-- `portfolio_construction.py`: MultiStrategyPCM for capital allocation per strategy
-- `quantbook.ipynb`: Research notebook with backtest analysis
+- `main.py` : Configuration de l'algorithme avec CompositeAlpha et MultiStrategyPCM
+- `alpha_models.py` : Classes FamaFrenchAlpha et AllWeatherAlpha
+- `portfolio_construction.py` : MultiStrategyPCM pour l'allocation de capital par stratégie
+- `quantbook.ipynb` : Notebook de recherche avec analyse de backtest
 
 ## Performance
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | **0.588** |
-| CAGR | 9.9% |
-| Max Drawdown | 17.1% |
-| Period | 2010-2026 |
+| CAGR | 9.9 % |
+| Max Drawdown | 17.1 % |
+| Période | 2010-2026 |
 
-### Aligned baseline (2018-2025)
+### Baseline alignée (2018-2025)
 
-Standardized #1630 window (2018-01-01 to 2025-01-01, 1761 tradeable dates), backtested on QC Cloud with post-#2801 real fees.
+Fenêtre #1630 standardisée (2018-01-01 à 2025-01-01, 1761 dates tradables), backtestée sur QC Cloud avec frais réels post-#2801.
 
-| Metric | README headline (2010-2026 sweep) | Catalog (2015-2025) | **Aligned (2018-2025)** |
-|--------|-----------------------------------|---------------------|-------------------------|
+| Métrique | Headline README (sweep 2010-2026) | Catalogue (2015-2025) | **Alignée (2018-2025)** |
+|----------|-----------------------------------|-----------------------|-------------------------|
 | Sharpe | 0.588 | 0.472 | **0.338** |
-| CAGR | 9.9% | 7.226% | 6.578% |
-| MaxDD | 17.1% | 13.1% | 13.1% |
-| PSR | — | 35.0% | 22.9% |
+| CAGR | 9.9 % | 7.226 % | 6.578 % |
+| MaxDD | 17.1 % | 13.1 % | 13.1 % |
+| PSR | — | 35.0 % | 22.9 % |
 
-Aligned backtest `e9ac7c66` (1761 tradeable dates, Completed) / catalog backtest `70415edc` (`FF20_AW80_2015_2025_extended`, 2766 dates). `totalOrders=0` is an MCP wrapper extraction artifact (CAGR 6.6% implies real trades); QC-computed statistics are reliable.
+Backtest aligné `e9ac7c66` (1761 dates tradables, Completed) / backtest catalogue `70415edc` (`FF20_AW80_2015_2025_extended`, 2766 dates). `totalOrders=0` est un artefact d'extraction du wrapper MCP (le CAGR 6.6 % implique des trades réels) ; les statistiques calculées par QC sont fiables.
 
-**Period-overfitting caveat**: the strong headline figures do NOT survive alignment to the standardized 2018-2025 window. The README headline Sharpe 0.588 (2010-2026 sweep) drops to **0.338** (-42%), and the separately-run OOS 2023-2026 figure (Sharpe 0.684, PSR 87.5% — backtest `b08c8956`, only 835 tradeable dates) collapses to 0.338 / PSR 22.9% on the full aligned window: the 87.5% PSR was a small-OOS-sample artifact, not a robust statistical edge. On the aligned window the 80% AllWeather sleeve (mostly static SPY/IEF/GLD/XLP) drags the composite below the standalone FamaFrench rotation (Sharpe 0.445, #72), though it buys tight drawdown control (MaxDD 13.1%, among the tighter backbones). Promoted Tier 4 (Untested) to Tier 2 (Historique).
+**Caveat de sur-ajustement de période** : les chiffres headline solides ne survivent PAS à l'alignement sur la fenêtre standardisée 2018-2025. Le Sharpe headline du README 0.588 (sweep 2010-2026) chute à **0.338** (-42 %), et le chiffre OOS 2023-2026 séparément (Sharpe 0.684, PSR 87.5 % — backtest `b08c8956`, seulement 835 dates tradables) s'effondre à 0.338 / PSR 22.9 % sur la fenêtre alignée complète : le PSR 87.5 % était un artefact de petit échantillon OOS, pas un avantage statistique robuste. Sur la fenêtre alignée, le sleeve AllWeather 80 % (largement statique SPY/IEF/GLD/XLP) tire le composite sous la rotation FamaFrench autonome (Sharpe 0.445, #72), bien qu'il achète un contrôle serré du drawdown (MaxDD 13.1 %, parmi les backbones les plus serrés). Promu Tier 4 (Untested) vers Tier 2 (Historique).
 
-## Allocation Sweep Results
+## Résultats du sweep d'allocation
 
 | Allocation | Sharpe | CAGR | Max DD |
 |------------|--------|------|--------|
-| FF20/AW80 | **0.588** | 9.9% | 17.1% |
-| FF40/AW60 | 0.564 | 10.5% | 19.3% |
-| FF50/AW50 | 0.539 | 10.8% | 21.7% |
-| FF60/AW40 | 0.512 | 11.2% | 24.1% |
+| FF20/AW80 | **0.588** | 9.9 % | 17.1 % |
+| FF40/AW60 | 0.564 | 10.5 % | 19.3 % |
+| FF50/AW50 | 0.539 | 10.8 % | 21.7 % |
+| FF60/AW40 | 0.512 | 11.2 % | 24.1 % |
 
-**Winner**: FF20/AW80 (best risk-adjusted returns)
+**Gagnant** : FF20/AW80 (meilleurs rendements ajustés du risque)
 
-## Component Strategies
+## Stratégies composantes
 
-| Strategy | Sharpe | CAGR | Max DD |
-|----------|--------|------|--------|
-| FamaFrench v3.0 | 0.540 | 12.1% | 24.2% |
-| AllWeather | 0.667 | 9.3% | 16.4% |
-| **Composite (FF20/AW80)** | **0.588** | **9.9%** | **17.1%** |
+| Stratégie | Sharpe | CAGR | Max DD |
+|-----------|--------|------|--------|
+| FamaFrench v3.0 | 0.540 | 12.1 % | 24.2 % |
+| AllWeather | 0.667 | 9.3 % | 16.4 % |
+| **Composite (FF20/AW80)** | **0.588** | **9.9 %** | **17.1 %** |
 
-The composite achieves better risk-adjusted returns than FamaFrench alone with lower drawdown.
+Le composite atteint de meilleurs rendements ajustés du risque que FamaFrench seul, avec un drawdown plus faible.
 
-## Parameters
+## Paramètres
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `ff_allocation` | 0.20 | FamaFrench slice (0.20 = 20%) |
-| `aw_allocation` | 0.80 | AllWeather slice (0.80 = 80%) |
+| Paramètre | Défaut | Description |
+|-----------|--------|-------------|
+| `ff_allocation` | 0.20 | Tranche FamaFrench (0.20 = 20 %) |
+| `aw_allocation` | 0.80 | Tranche AllWeather (0.80 = 80 %) |
 
-## Backtest Period
+## Période de backtest
 
-2010-01-01 to 2026-03-10 (covers bull, bear, and sideways regimes)
+2010-01-01 à 2026-03-10 (couvre les régimes haussier, baissier et latéral)
 
-## Deployment
+## Déploiement
 
-- **Project ID**: 28882145
-- **Organization**: Jean-Sylvain Boige (Researcher PAID)
-- **Status**: ✅ Deployed and backtested
+- **Project ID** : 28882145
+- **Organization** : Jean-Sylvain Boige (Researcher PAID)
+- **Statut** : ✅ Déployé et backtesté
 
-## References
+## Références
 
-- **FamaFrench**: Factor ETF rotation with risk-adjusted momentum
-- **AllWeather**: Multi-asset static allocation (no TLT)
-- **SESSION5_PATTERNS.md**: AlphaModel Framework pedagogical guide
+- **FamaFrench** : Rotation d'ETF factoriels avec momentum ajusté du risque
+- **AllWeather** : Allocation statique multi-actifs (sans TLT)
+- **SESSION5_PATTERNS.md** : Guide pédagogique AlphaModel Framework

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MomentumRegime-AdaptiveWeights/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MomentumRegime-AdaptiveWeights/README.en.md
@@ -1,0 +1,55 @@
+# MomentumRegime-AdaptiveWeights
+
+**Asset class:** US Equities (SPY/QQQ/IEF/GLD)
+**Cloud project ID:** 31524424
+**Baseline:** Framework_Composite_MomentumRegime (Sharpe 0.185, CAGR 4.73%)
+
+## Description
+
+Adaptive-weight variant of Framework_Composite_MomentumRegime.
+Shifts allocation toward SectorMomentum (85/15 vs baseline 60/40),
+expands momentum universe to include QQQ, and favors shorter-term lookbacks.
+
+## Backtest Results
+
+| Metric | Baseline (T60/RS40) | This Variant (T85/RS15) | Delta |
+|--------|---------------------|--------------------------|-------|
+| Sharpe Ratio | 0.185 | **-0.74** | -0.925 |
+| CAGR | 4.73% | 1.76% | -2.97pp |
+| Max Drawdown | - | 4.4% | - |
+| Net Profit | - | 21.1% | - |
+| Beta (vs SPY) | - | 0.081 | - |
+| Total Orders | - | 403 | - |
+| Win Rate | - | 71% | - |
+
+**Verdict: NO BEATS.** Negative Sharpe ratio. The 85/15 shift destroyed value.
+
+## Analysis
+
+The variant dramatically underperforms the baseline. Root causes:
+
+1. **Over-concentration on SectorMomentum**: At 85% weight, SectorMomentum
+   dominates allocations. When its monthly signal flips (common with short-term
+   lookbacks 0.5/0.2/0.2/0.1), the portfolio churns between assets.
+
+2. **QQQ addition dilutes signal quality**: Adding QQQ to SectorMomentum's
+   universe creates a 4-way race where the best-scored asset rotates frequently,
+   generating unnecessary turnover.
+
+3. **Low beta (0.081)**: The strategy spends most time in defensive assets (IEF/GLD)
+   despite bull market conditions, suggesting SectorMomentum's composite scoring
+   with short-term bias overweights transient pullbacks.
+
+4. **RegimeSwitching at 15%**: Too small to matter. The regime-switching safety net
+   that protects in bear/sideways markets is effectively disabled.
+
+## Files
+
+- main.py - Strategy (T85/RS15 allocation)
+- alpha_models.py - SectorMomentum + RegimeSwitching alpha models
+- portfolio_construction.py - MultiStrategyPCM portfolio construction
+
+## References
+
+- Hands-On AI Trading, Section 06
+- Baseline: Framework_Composite_MomentumRegime

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MomentumRegime-AdaptiveWeights/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MomentumRegime-AdaptiveWeights/README.md
@@ -1,55 +1,57 @@
 # MomentumRegime-AdaptiveWeights
 
-**Asset class:** US Equities (SPY/QQQ/IEF/GLD)
-**Cloud project ID:** 31524424
-**Baseline:** Framework_Composite_MomentumRegime (Sharpe 0.185, CAGR 4.73%)
+**Classe d'actifs :** Actions US (SPY/QQQ/IEF/GLD)
+**Cloud project ID :** 31524424
+**Baseline :** Framework_Composite_MomentumRegime (Sharpe 0.185, CAGR 4.73 %)
 
 ## Description
 
-Adaptive-weight variant of Framework_Composite_MomentumRegime.
-Shifts allocation toward SectorMomentum (85/15 vs baseline 60/40),
-expands momentum universe to include QQQ, and favors shorter-term lookbacks.
+Variante à poids adaptatifs de Framework_Composite_MomentumRegime.
+Décale l'allocation vers SectorMomentum (85/15 contre 60/40 pour la baseline),
+élargit l'univers de momentum pour inclure QQQ et privilégie des lookbacks plus courts.
 
-## Backtest Results
+## Résultats de backtest
 
-| Metric | Baseline (T60/RS40) | This Variant (T85/RS15) | Delta |
-|--------|---------------------|--------------------------|-------|
+| Métrique | Baseline (T60/RS40) | Cette variante (T85/RS15) | Delta |
+|----------|---------------------|---------------------------|-------|
 | Sharpe Ratio | 0.185 | **-0.74** | -0.925 |
-| CAGR | 4.73% | 1.76% | -2.97pp |
-| Max Drawdown | - | 4.4% | - |
-| Net Profit | - | 21.1% | - |
+| CAGR | 4.73 % | 1.76 % | -2.97 pp |
+| Max Drawdown | - | 4.4 % | - |
+| Net Profit | - | 21.1 % | - |
 | Beta (vs SPY) | - | 0.081 | - |
 | Total Orders | - | 403 | - |
-| Win Rate | - | 71% | - |
+| Win Rate | - | 71 % | - |
 
-**Verdict: NO BEATS.** Negative Sharpe ratio. The 85/15 shift destroyed value.
+**Verdict : NO BEATS.** Sharpe ratio négatif. Le décalage 85/15 a détruit de la valeur.
 
-## Analysis
+## Analyse
 
-The variant dramatically underperforms the baseline. Root causes:
+La variante sous-performe dramatiquement la baseline. Causes profondes :
 
-1. **Over-concentration on SectorMomentum**: At 85% weight, SectorMomentum
-   dominates allocations. When its monthly signal flips (common with short-term
-   lookbacks 0.5/0.2/0.2/0.1), the portfolio churns between assets.
+1. **Sur-concentration sur SectorMomentum** : à 85 % de poids, SectorMomentum
+   domine les allocations. Quand son signal mensuel s'inverse (fréquent avec des
+   lookbacks courts 0.5/0.2/0.2/0.1), le portefeuille navigue entre les actifs.
 
-2. **QQQ addition dilutes signal quality**: Adding QQQ to SectorMomentum's
-   universe creates a 4-way race where the best-scored asset rotates frequently,
-   generating unnecessary turnover.
+2. **L'ajout de QQQ dilue la qualité du signal** : ajouter QQQ à l'univers de
+   SectorMomentum crée une course à 4 où l'actif au meilleur score tourne fréquemment,
+   générant un turnover inutile.
 
-3. **Low beta (0.081)**: The strategy spends most time in defensive assets (IEF/GLD)
-   despite bull market conditions, suggesting SectorMomentum's composite scoring
-   with short-term bias overweights transient pullbacks.
+3. **Beta faible (0.081)** : la stratégie passe l'essentiel du temps dans des actifs
+   défensifs (IEF/GLD) malgré des conditions de marché haussier, ce qui suggère que le
+   scoring composite de SectorMomentum, avec un biais court terme, surpondère les
+   replis transitoires.
 
-4. **RegimeSwitching at 15%**: Too small to matter. The regime-switching safety net
-   that protects in bear/sideways markets is effectively disabled.
+4. **RegimeSwitching à 15 %** : trop faible pour compter. Le filet de sécurité de
+   commutation de régime qui protège en marché baissier/latéral est effectivement
+   désactivé.
 
-## Files
+## Fichiers
 
-- main.py - Strategy (T85/RS15 allocation)
-- alpha_models.py - SectorMomentum + RegimeSwitching alpha models
-- portfolio_construction.py - MultiStrategyPCM portfolio construction
+- main.py - Stratégie (allocation T85/RS15)
+- alpha_models.py - Modèles alpha SectorMomentum + RegimeSwitching
+- portfolio_construction.py - Construction de portefeuille MultiStrategyPCM
 
-## References
+## Références
 
 - Hands-On AI Trading, Section 06
-- Baseline: Framework_Composite_MomentumRegime
+- Baseline : Framework_Composite_MomentumRegime


### PR DESCRIPTION
Epic #1650 Phase 0.5 (rule [readme-french-first](../../.claude/rules/readme-french-first.md) HARD 2). FR backfill of the **Framework_Composite_FamaFrenchAllWeather** strategy README — grain from the #3870 deep-queue.

## Summary

Composite strategy backbone: FamaFrench factor ETF rotation (20% slice: VLUE/MTUM/SIZE/QUAL/USMV, risk-adjusted momentum, skip-month, top-2 quarterly) + AllWeather static multi-asset (80% slice: SPY/IEF/GLD/XLP, Ray Dalio inspired, drift rebalance 3%). Note: this strategy is also an **IBKR sleeve backbone of the #1027 double portfolio**.

- **git mv README.md -> README.en.md** (EN preserved byte-identical verbatim — verified `git show HEAD:README.md | diff - README.en.md` = empty)
- **new FR README.md** — same structure/tables/metrics/caveats/parameters/references, strategy name kept EN, prose FR (74 accented chars, fresh translation, grammar verified)
- **0 catalog markers touched** (`COURSE_CATALOG.generated.*` untouched — catalog = automation property, cf [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md))

## Metrics preserved

| Window | Sharpe | CAGR | MaxDD |
|--------|--------|------|-------|
| Headline (2010-2026) | 0.588 | 9.9% | 17.1% |
| Aligned (2018-2025, #1630) | **0.338** | 6.578% | 13.1% |

The period-overfitting caveat is preserved in FR (PSR 87.5% was a small-OOS-sample artifact collapsing to 22.9% on the full aligned window).

## Verification (G.1)

- [x] G.1 firsthand: README = genuine hand-written EN (4383 chars, aligned-baseline table, sweep results, component strategies, period-overfitting caveat) — not auto-gen stub, not already-FR
- [x] HARD 2 EN byte-identical: `git show HEAD:README.md | diff - README.en.md` = empty
- [x] 0 catalog markers touched
- [x] Atomic 2-file diff (+161/-62)
- [x] Grammar verified: `implique`/`survivent`/`chute`/`s'effondre`/`tire`/`achète`/`atteint` (present), `Promu` (participle masc.)

## Test plan

- [ ] markdown render OK (MD060/MD032 warnings are cosmetic — table-pipe spacing, blank lines around lists — same style as EN original, not enforced by repo CI)
- [ ] ai-01 merge

See #3870