### PR TITLE
chore(secrets): extend SECRET_KEYS — OWUI_API_KEY + TTS_GATEWAY_API_KEY

### DIFF
--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -73,6 +73,8 @@ SECRET_KEYS: frozenset[str] = frozenset({
     "WHISPER_API_KEY", "VLLM_API_KEY", "TTS_API_KEY",
     "QWEN_ASR_API_KEY", "MUSICGEN_API_KEY", "DEMUCS_API_KEY",
     "FUNASR_API_KEY",
+    # OWUI native API (NB-20, #417) + TTS multi-voice gateway (#16, po-2023)
+    "OWUI_API_KEY", "TTS_GATEWAY_API_KEY",
     # ComfyUI client tokens (notebook client <-> service must agree)
     "COMFYUI_VIDEO_TOKEN", "COMFYUI_API_TOKEN",
     # Session


### PR DESCRIPTION
## Extend secrets schema

Adds two **per-service client API keys** to `scripts/secrets/render_envs.py` `SECRET_KEYS` (l.65) so the centralized secrets mechanism actually manages them:

- **`OWUI_API_KEY`** — Open WebUI native API (NB-20, #417)
- **`TTS_GATEWAY_API_KEY`** — TTS multi-voice gateway (#16, po-2023)

### Root cause
`render_envs.py` l.158 (`if key not in SECRET_KEYS or not val: continue`) **silently ignores** any key absent from `SECRET_KEYS`. Both keys were missing → "seed `master.env` then `render`" could never propagate them to service `.env` files. Diagnosed by ai-01:myia-open-webui during the OWUI durable-seeding ASK; consolidated with the identical TTS gateway gap (same file, same line) into **one PR to avoid a merge collision** with a separate po-2023 PR.

### Scope & safety
- **Schema-only — zero secret value.** No `.env`, no `master.env`, no `.md` touched → catalog-guard / CATALOG-STATUS unchanged.
- `+2` insertions (one grouped entry + comment) in the existing "Per-service client API keys" block. Module compiles; `len(SECRET_KEYS)` 18 → 20; both keys assert-present.

### Post-merge bootstrap (by value-holder, separate from this PR)
- `OWUI_API_KEY` → **po-2025:CoursIA** (`render_envs.py --bootstrap`; holds value in its `Texte/.env`, runs NB-20).
- `TTS_GATEWAY_API_KEY` → **po-2023** (hosts the gateway, holds/generates the value).

See #417
See #16
