### PR TITLE
docs(qc): FR backfill composite-c2-equityfactor README (#3870, Phase 0.5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/composite-c2-equityfactor/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/composite-c2-equityfactor/README.en.md
@@ -1,0 +1,56 @@
+# composite-c2-equityfactor
+
+**Asset class:** Equities (US large-cap, fundamental selection)
+
+**Cloud project ID:** 32981222
+
+## Description
+
+C4.2 Equity Factor Composite (v12) using the Alpha Framework with fine fundamental universe selection. Two-stage selection: coarse filter (top 200 by dollar volume) then fine filter (top 25 by market cap). Generates signals from four factor alpha models: Value (P/E, P/B ratios), Quality (ROE, debt-to-equity), LowVolatility (realized volatility), and Momentum (price momentum). Portfolio construction via MeanVariancePCM (weekly rebalance, 65% max exposure, 18% sector cap). Risk management via SectorCapRiskModel (max 10% sector weight, max 0.8 beta). Execution via TWAP (6 slices, 10-minute window). Caches fundamental data for performance.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm composite-c2-equityfactor/main.py
+```
+
+### QC Cloud
+Create a new project, upload all `.py` files, compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Alpha Framework (4 factors + MeanVar PCM) | Weekly | Top 25 by market cap, 65% max exposure, sector cap 18%, TWAP 6-slice |
+
+### Aligned baseline (2018-2025)
+
+Standardized #1630 window (2018-01-01 to 2025-01-01, 1761 tradeable dates), backtested on QC Cloud with post-#2801 real fees.
+
+| Metric | Catalog (2015-2025) | Aligned (2018-2025) |
+|--------|---------------------|---------------------|
+| Sharpe Ratio | 0.543 | **0.574** |
+| CAGR | 10.010% | 11.942% |
+| Max Drawdown | 18.800% | 18.600% |
+| PSR | 16.822% | 25.765% |
+
+Backtest `8eecba32` (aligned) / `3173f8b39` (catalog `c2-equityfactor-post2801`), project 32981222.
+
+The strongest COMP (composite-framework) backbone baseline verified to date: Sharpe 0.574 is the highest among the Alpha Framework composites tested on the aligned window, and near Tier-1 territory (>0.5). It **holds and slightly improves** over the catalog window (0.543 to 0.574, PSR 16.8% to 25.8%) — genuinely robust, not period-overfit. This contrasts sharply with the sibling `composite-c1-multiasset` (Sharpe 0.258): both share the Alpha Framework scaffold, but factor investing on a fine-fundamental top-25 large-cap US stock universe (Value/Quality/LowVol/Momentum + MeanVariancePCM) dramatically outperforms static 5-ETF multi-asset rotation (3-alpha momentum ensemble + RiskParityPCM). The component alpha/PCM choice and stock-level fundamental universe matter far more than the framework wiring itself. Promoted Tier 4 (Untested) to Tier 2 (Historique). `totalOrders=0` in the MCP wrapper is an extraction artifact (CAGR 11.9% implies real trades).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Composite equity factor algorithm orchestrating universe selection, alphas, PCM, risk, and execution |
+| `alpha_models.py` | Four factor models: Value, Quality, LowVolatility, and Momentum |
+| `portfolio_construction.py` | MeanVariancePCM with weekly rebalance, sector caps, and exposure limits |
+| `risk_management.py` | SectorCapRiskModel with max sector weight and beta constraints |
+| `execution.py` | TWAP execution model (6 slices, 10-minute window) |
+
+## References
+
+- [QuantConnect Alpha Framework](https://www.quantconnect.com/docs/v2/writing-algorithms/algorithm-framework)
+- [QuantConnect Fine Fundamental Selection](https://www.quantconnect.com/docs/v2/writing-algorithms/universes/fundamental)
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/composite-c2-equityfactor/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/composite-c2-equityfactor/README.md
@@ -1,14 +1,14 @@
 # composite-c2-equityfactor
 
-**Asset class:** Equities (US large-cap, fundamental selection)
+**Classe d'actifs :** Actions (large-cap US, sélection fondamentale)
 
-**Cloud project ID:** 32981222
+**Cloud project ID :** 32981222
 
 ## Description
 
-C4.2 Equity Factor Composite (v12) using the Alpha Framework with fine fundamental universe selection. Two-stage selection: coarse filter (top 200 by dollar volume) then fine filter (top 25 by market cap). Generates signals from four factor alpha models: Value (P/E, P/B ratios), Quality (ROE, debt-to-equity), LowVolatility (realized volatility), and Momentum (price momentum). Portfolio construction via MeanVariancePCM (weekly rebalance, 65% max exposure, 18% sector cap). Risk management via SectorCapRiskModel (max 10% sector weight, max 0.8 beta). Execution via TWAP (6 slices, 10-minute window). Caches fundamental data for performance.
+Composite Equity Factor C4.2 (v12) utilisant l'Alpha Framework avec sélection d'univers fine fondamentale. Sélection en deux étapes : filtre coarse (top 200 par dollar volume) puis filtre fine (top 25 par capitalisation boursière). Génère des signaux à partir de quatre modèles alpha factoriels : Value (ratios P/E, P/B), Quality (ROE, dette/fonds propres), LowVolatility (volatilité réalisée) et Momentum (momentum de prix). Construction de portefeuille via MeanVariancePCM (rééquilibrage hebdomadaire, 65 % d'exposition max, plafond sectoriel 18 %). Gestion du risque via SectorCapRiskModel (poids sectoriel max 10 %, beta max 0.8). Exécution via TWAP (6 tranches, fenêtre de 10 minutes). Met en cache les données fondamentales pour la performance.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,40 +16,40 @@ lean backtest --algorithm composite-c2-equityfactor/main.py
 ```
 
 ### QC Cloud
-Create a new project, upload all `.py` files, compile and run a backtest.
+Créer un nouveau projet, uploader tous les fichiers `.py`, compiler et lancer un backtest.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Alpha Framework (4 factors + MeanVar PCM) | Weekly | Top 25 by market cap, 65% max exposure, sector cap 18%, TWAP 6-slice |
+| Méthode | Rééquilibrage | Paramètres clés |
+|---------|---------------|-----------------|
+| Alpha Framework (4 facteurs + PCM MeanVar) | Hebdomadaire | Top 25 par capitalisation, exposition max 65 %, plafond sectoriel 18 %, TWAP 6 tranches |
 
-### Aligned baseline (2018-2025)
+### Baseline alignée (2018-2025)
 
-Standardized #1630 window (2018-01-01 to 2025-01-01, 1761 tradeable dates), backtested on QC Cloud with post-#2801 real fees.
+Fenêtre #1630 standardisée (2018-01-01 à 2025-01-01, 1761 dates tradables), backtestée sur QC Cloud avec frais réels post-#2801.
 
-| Metric | Catalog (2015-2025) | Aligned (2018-2025) |
-|--------|---------------------|---------------------|
+| Métrique | Catalogue (2015-2025) | Alignée (2018-2025) |
+|----------|-----------------------|---------------------|
 | Sharpe Ratio | 0.543 | **0.574** |
-| CAGR | 10.010% | 11.942% |
-| Max Drawdown | 18.800% | 18.600% |
-| PSR | 16.822% | 25.765% |
+| CAGR | 10.010 % | 11.942 % |
+| Max Drawdown | 18.800 % | 18.600 % |
+| PSR | 16.822 % | 25.765 % |
 
-Backtest `8eecba32` (aligned) / `3173f8b39` (catalog `c2-equityfactor-post2801`), project 32981222.
+Backtest `8eecba32` (alignée) / `3173f8b39` (catalogue `c2-equityfactor-post2801`), projet 32981222.
 
-The strongest COMP (composite-framework) backbone baseline verified to date: Sharpe 0.574 is the highest among the Alpha Framework composites tested on the aligned window, and near Tier-1 territory (>0.5). It **holds and slightly improves** over the catalog window (0.543 to 0.574, PSR 16.8% to 25.8%) — genuinely robust, not period-overfit. This contrasts sharply with the sibling `composite-c1-multiasset` (Sharpe 0.258): both share the Alpha Framework scaffold, but factor investing on a fine-fundamental top-25 large-cap US stock universe (Value/Quality/LowVol/Momentum + MeanVariancePCM) dramatically outperforms static 5-ETF multi-asset rotation (3-alpha momentum ensemble + RiskParityPCM). The component alpha/PCM choice and stock-level fundamental universe matter far more than the framework wiring itself. Promoted Tier 4 (Untested) to Tier 2 (Historique). `totalOrders=0` in the MCP wrapper is an extraction artifact (CAGR 11.9% implies real trades).
+La baseline COMP (composite-framework) la plus robuste vérifiée à ce jour : le Sharpe 0.574 est le plus élevé parmi les composites Alpha Framework testés sur la fenêtre alignée, et proche du territoire Tier-1 (>0.5). Il **se maintient et s'améliore légèrement** sur la fenêtre catalogue (0.543 à 0.574, PSR 16.8 % à 25.8 %) — véritablement robuste, non sur-ajusté à la période. Cela contraste fortement avec la stratégie sœur `composite-c1-multiasset` (Sharpe 0.258) : les deux partagent l'échafaudage Alpha Framework, mais l'investissement factoriel sur un univers d'actions US large-cap top-25 par fondamentaux (Value/Quality/LowVol/Momentum + MeanVariancePCM) surperforme de manière spectaculaire la rotation statique multi-actifs à 5 ETF (ensemble momentum 3-alpha + RiskParityPCM). Le choix des alphas composantes/PCM et l'univers d'actions au niveau fondamental comptent bien plus que le câblage du framework lui-même. Promu Tier 4 (Untested) vers Tier 2 (Historique). `totalOrders=0` dans le wrapper MCP est un artefact d'extraction (le CAGR 11.9 % implique des trades réels).
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | Composite equity factor algorithm orchestrating universe selection, alphas, PCM, risk, and execution |
-| `alpha_models.py` | Four factor models: Value, Quality, LowVolatility, and Momentum |
-| `portfolio_construction.py` | MeanVariancePCM with weekly rebalance, sector caps, and exposure limits |
-| `risk_management.py` | SectorCapRiskModel with max sector weight and beta constraints |
-| `execution.py` | TWAP execution model (6 slices, 10-minute window) |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Algorithme composite equity factor orchestrant la sélection d'univers, les alphas, le PCM, le risque et l'exécution |
+| `alpha_models.py` | Quatre modèles factoriels : Value, Quality, LowVolatility et Momentum |
+| `portfolio_construction.py` | MeanVariancePCM avec rééquilibrage hebdomadaire, plafonds sectoriels et limites d'exposition |
+| `risk_management.py` | SectorCapRiskModel avec poids sectoriel max et contraintes de beta |
+| `execution.py` | Modèle d'exécution TWAP (6 tranches, fenêtre de 10 minutes) |
 
-## References
+## Références
 
 - [QuantConnect Alpha Framework](https://www.quantconnect.com/docs/v2/writing-algorithms/algorithm-framework)
 - [QuantConnect Fine Fundamental Selection](https://www.quantconnect.com/docs/v2/writing-algorithms/universes/fundamental)


### PR DESCRIPTION
Epic #1650 Phase 0.5 (rule [readme-french-first](../../.claude/rules/readme-french-first.md) HARD 2). FR backfill of the **composite-c2-equityfactor** strategy README — grain from the #3870 deep-queue.

## Summary

Alpha Framework composite: fine fundamental universe selection (coarse top 200 by dollar volume -> fine top 25 by market cap), 4 factor alpha models (Value P/E P/B, Quality ROE debt-to-equity, LowVolatility realized vol, Momentum), MeanVariancePCM weekly rebalance (65% max exposure, 18% sector cap), SectorCapRiskModel (max 10% sector, 0.8 beta), TWAP execution (6 slices, 10-min window).

- **git mv README.md -> README.en.md** (EN preserved byte-identical verbatim — verified `git show HEAD:README.md | diff - README.en.md` = empty)
- **new FR README.md** — same structure/tables/metrics/robustness-analysis/files-table/references, strategy name kept EN, prose FR (69 accented chars, fresh translation, grammar verified)
- **0 catalog markers touched** (`COURSE_CATALOG.generated.*` untouched — catalog = automation property, cf [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md))

## Metrics preserved — strongest COMP backbone (#1630)

| Window | Sharpe | CAGR | MaxDD | PSR |
|--------|--------|------|-------|-----|
| Catalog (2015-2025) | 0.543 | 10.010% | 18.800% | 16.822% |
| Aligned (2018-2025) | **0.574** | 11.942% | 18.600% | 25.765% |

This is the **strongest COMP (composite-framework) backbone baseline verified to date** — genuinely robust (holds/improves 0.543->0.574, PSR 16.8%->25.8%, not period-overfit), near Tier-1 territory (>0.5). Contrasts with sibling `composite-c1-multiasset` (Sharpe 0.258) sharing the same Alpha Framework scaffold. Robustness caveat preserved in FR.

## Verification (G.1)

- [x] G.1 firsthand: README = genuine hand-written EN (3516 chars, aligned-baseline table, robustness analysis vs c1-multiasset, files table, references) — not auto-gen stub, not already-FR
- [x] HARD 2 EN byte-identical: `git show HEAD:README.md | diff - README.en.md` = empty
- [x] 0 catalog markers touched
- [x] Atomic 2-file diff (+83/-27)
- [x] Grammar verified + **typo caught & fixed** (`momententum` -> `momentum`, leçon #4502): `se maintient et s'améliore`/`surperforme`/`comptent`/`implique` (present), `réalisée`/`vérifiée` (participles fem.), `Promu` (participle masc.)

## Test plan

- [ ] markdown render OK (MD060 table-pipe warnings are cosmetic, same style as EN original, not enforced by repo CI)
- [ ] ai-01 merge

See #3870