### PR TITLE
docs(genai): add Phase 3 tts-gateway auth-flip to #16 runbook (deblocked by #4566)

### DIFF
--- a/docs/genai/auth-flip-runbook.md
+++ b/docs/genai/auth-flip-runbook.md
@@ -8,7 +8,9 @@ blocage USER — désormais **RECOVERABLE-COORD** (ai-01 a ajouté `TTS_GATEWAY_
 au schéma `SECRET_KEYS` via PR #4566 + délégué le bootstrap au value-holder
 po-2023 qui héberge la gateway). Procédure couverte **Phase 3** ci-dessous.
 **Statut** : greenlight ai-01 2026-06-14 17:14Z — Claudish + Qdrant ;
-**greenlight tts-gateway 2026-06-28** (post-merge #4566).
+**tts-gateway EXECUTÉ 2026-06-28** (post-merge #4566, flip vérifié firsthand :
+`/v1/models` 401→200 avec clé, endpoint public `tts-multi.myia.io` sécurisé).
+Claudish + Qdrant restent à exécuter.
 **Caveat scope** : Claudish + Qdrant vivent dans d'**autres repos** (`claudish`,
 `roo-extensions`) — le flip y est une **op manuelle** admin. `tts-gateway` est le
 seul des 3 dont le compose est **dans CoursIA** (`docker-configurations/services/tts-multi/`)
@@ -229,12 +231,25 @@ exposé publiquement** (`tts-multi.myia.io` via IIS).
    grep -c "TTS_GATEWAY_API_KEY" docker-configurations/services/tts-multi/.env  # → 1
    grep -c "TTS_GATEWAY_API_KEY" MyIA.AI.Notebooks/GenAI/.env                    # → 1
    ```
-3. **Recréer la gateway** (applique API_KEY + bind 127.0.0.1) :
+3. **Rebuild + recréer la gateway** (applique API_KEY + bind 127.0.0.1) :
    ```bash
-   cd /d/Dev/CoursIA/docker-configurations/services/tts-multi && docker compose up -d --force-recreate tts-gateway
+   cd /d/Dev/CoursIA/docker-configurations/services/tts-multi && docker compose up -d --no-deps --build --force-recreate tts-gateway
    docker port tts-gateway  # doit maintenant afficher 127.0.0.1:8196 (pas 0.0.0.0)
    ```
-4. **Vérifier la preuve** (401 sans clé, 200 avec) :
+
+   > ⚠️ **★★★ stale-image trap (vérifié firsthand 2026-06-28)** : `--force-recreate` **SEUL ne
+   > reconstruit PAS l'image** — il réutilise l'image existante. Or l'image tts-gateway
+   > était **built AVANT** que le code `setup_auth` soit ajouté à `gateway/app.py` →
+   > `/app/app.py` dans le container n'avait AUCUNE référence à `setup_auth`/`API_KEY` →
+   > l'auth restait **OFF silencieusement** (`/v1/models` retournait 200 au lieu de 401,
+   > logs container vides). **Diagnostic** : `docker exec tts-gateway sh -c 'grep -c
+   > setup_auth /app/app.py'` → `0` = image stale. **Fix** : `docker compose build
+   --no-deps tts-gateway` (rebuild depuis le source courant) puis recreate. Le flag
+   `--build` dans la commande ci-dessus fait les deux. `--no-deps` évite de tenter de
+   démarrer tts-tada (non-déployé). Le service utilise `build:` (image locale), pas
+   `image:` — tout changement au source `gateway/app.py` exige un rebuild.
+
+4. **Vérifier la preuve** (401 sans clé, 200 avec clé, 401 mauvaise clé) :
    ```bash
    # Sans clé : doit devenir 401 APRÈS flip (200 avant).
    curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8196/v1/models
@@ -242,6 +257,10 @@ exposé publiquement** (`tts-multi.myia.io` via IIS).
    curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8196/health
    # Avec clé : 200.
    curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $(grep TTS_GATEWAY_API_KEY /d/Dev/CoursIA/.secrets/master.env | cut -d= -f2)" http://localhost:8196/v1/models
+   # Mauvaise clé : 401 (confirme que le gate ne fait pas que vérifier la présence du header).
+   curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer wrongkey" http://localhost:8196/v1/models
+   # Logs container doivent confirmer : "Bearer token authentication ENABLED".
+   docker logs tts-gateway 2>&1 | grep -i "authentication ENABLED"
    ```
 5. **Vérifier le notebook consommateur** : re-exécuter `02-5-Multi-Model-TTS-Gateway.ipynb`
    (kernel `mcp-jupyter-py310`, `--cwd` le dossier du notebook) → doit toujours

--- a/docs/genai/auth-flip-runbook.md
+++ b/docs/genai/auth-flip-runbook.md
@@ -1,16 +1,18 @@
 # Runbook — Flip d'authentification des services exposés (#16 P2)
 
 **Issue** : #16 — Sécurisation des services IA exposés.
-**Scope** : activation de l'authentification (Bearer/proxy-key) sur les 2 services
-LAN-exposés **cross-machine** non authentifiés : `claudish-proxy` (:3000) et
-`myia-qdrant` (:6333). `tts-gateway` (P1) est un blocage USER séparé (secret
-manuel), non couvert ici.
-**Statut** : greenlight ai-01 2026-06-14 17:14Z — **Claudish d'abord**, puis Qdrant.
-**Caveat scope** : les 2 compose vivent dans d'**autres repos** (`claudish`,
-`roo-extensions`), pas CoursIA. Le flip est une **op manuelle** exécutée par
-l'admin (fenêtre roo-extensions ou session dédiée) sur `po-2023`. Ce document
-fournit le **runbook + validation** ; l'édition des composes n'a pas lieu dans
-ce dépôt.
+**Scope** : activation de l'authentification (Bearer/proxy-key) sur les services
+LAN-exposés non authentifiés : `claudish-proxy` (:3000), `myia-qdrant` (:6333) et
+`tts-gateway` (:8196). **Mise à jour 2026-06-28** : `tts-gateway` (P1) était un
+blocage USER — désormais **RECOVERABLE-COORD** (ai-01 a ajouté `TTS_GATEWAY_API_KEY`
+au schéma `SECRET_KEYS` via PR #4566 + délégué le bootstrap au value-holder
+po-2023 qui héberge la gateway). Procédure couverte **Phase 3** ci-dessous.
+**Statut** : greenlight ai-01 2026-06-14 17:14Z — Claudish + Qdrant ;
+**greenlight tts-gateway 2026-06-28** (post-merge #4566).
+**Caveat scope** : Claudish + Qdrant vivent dans d'**autres repos** (`claudish`,
+`roo-extensions`) — le flip y est une **op manuelle** admin. `tts-gateway` est le
+seul des 3 dont le compose est **dans CoursIA** (`docker-configurations/services/tts-multi/`)
+→ flip exécutable par un worker via le flux canonical `master.env` + `render_envs.py`.
 
 > Référence d'analyse : [service-security-audit.md](service-security-audit.md)
 > (bindings, blast-radius, mécanisme d'auth disponible). Ce runbook en est la
@@ -152,6 +154,112 @@ deviennent noop. Aucune collection perdue (Qdrant garde ses données).
    playbook rollback).
 2. **Qdrant** (blast maximal = exige Step 0 propagation `QDRANT_API_KEY` sur
    toutes les machines AVANT le flip serveur).
+3. **tts-gateway** (blast le plus contenu — consommateurs GenAI uniquement, tous
+   key-aware ; mais **seul exposé publiquement** via `tts-multi.myia.io` →
+   priorité de sécurité la plus haute une fois deblocked). Exécutable dès merge
+   #4566.
+
+---
+
+## Phase 3 — tts-gateway (deblocked 2026-06-28, compose dans CoursIA)
+
+**Différence clé vs Phase 1/2** : le compose est **dans ce dépôt**, le secret est
+**partagé** (notebooks GenAI le lisent) → flux canonical `master.env` +
+`render_envs.py` (pas d'édition manuelle de `.env`). C'est aussi le **seul des 3
+exposé publiquement** (`tts-multi.myia.io` via IIS).
+
+### Mécanisme (vérifié `docker-configurations/services/tts-multi/gateway/app.py`)
+
+- `app.py:20-26` : la gateway monte `/app/shared/auth_middleware.py` (bind-mount
+  `../shared` → `/app/shared`, `docker-compose.yml:31-34`) **s'il existe**, et
+  appelle `setup_auth(app)` dans un `try/except` (`app.py:50-54`) — exception →
+  log "running without auth" (dégrade silencieusement en ouvert).
+- `auth_middleware.py:40-54` (`docker-configurations/services/shared/`) : lit
+  `API_KEY`. **Vide** → `_AUTH_ENABLED = False` → "Auth middleware NOT installed -
+  API is open" (état actuel live). **Non-vide** → `BearerAuthMiddleware` monté sur
+  **tous les paths sauf** `/health`, `/docs`, `/openapi.json`, `/redoc`, `/admin/*`
+  (`_PUBLIC_PATHS`, `auth_middleware.py:92`). Comparaison **timing-safe**
+  `secrets.compare_digest` (`:74`, `:127`) — **déjà durci** (contrairement à Claudish).
+- `docker-compose.yml:26` : `API_KEY=${TTS_GATEWAY_API_KEY:-}` → propage la var.
+  Vide = pas d'auth. **Le flip = provisionner la valeur + redémarrer, 0 changement
+  de code.**
+
+### Bonus hardening : bind `127.0.0.1` (compose) vs `0.0.0.0` (live)
+
+- `docker-compose.yml:18` : `"127.0.0.1:${TTS_GATEWAY_PORT:-8196}:8000"` (localhost-only).
+- **Live (vérifié 2026-06-28 `docker port tts-gateway`)** : `0.0.0.0:8196` — le
+  conteneur est **stale** (démarré d'un compose antérieur à la correction). Le
+  `--force-recreate` du flip applique **les deux** corrections en une fois :
+  activation de l'auth **et** bind localhost-only (LAN → ne peut plus être atteint
+  directement hors localhost + proxy IIS).
+
+### Blast-radius (vérifié firsthand 2026-06-28, G.1)
+
+| Consommateur | Lit la clé ? | Impact post-flip |
+|--------------|--------------|------------------|
+| Notebooks GenAI (`qwen_tts_client.py:54`) | ✅ `os.getenv("TTS_GATEWAY_API_KEY") or os.getenv("KOKORO_API_KEY")` (fallback Kokoro) | 0 si `GenAI/.env` propagé |
+| Helper GenAI (`genai_service.py:164-166`) | ✅ special-case tts-gateway → `TTS_GATEWAY_API_KEY` | 0 |
+| Claudish (`D:\Dev\claudish\{apps,packages,scripts,skills,docs}`) | ❌ 0 référence réelle (`8196` = faux positif `膖` unicode dans `dist/`) | 0 |
+| NanoClaw | ❌ dépendance ASR (whisper/qwen-asr), pas TTS | 0 |
+| Autres machines (po-2024/2025/2026) | ❌ QC/Lean/ML, ne lancent pas GenAI Audio | 0 |
+
+**Verdict blast-radius : LOW, contenu à GenAI sur po-2023, tous key-aware.**
+
+### Pre-flight
+
+1. **#4566 merged** : `TTS_GATEWAY_API_KEY` ∈ `SECRET_KEYS` dans
+   `scripts/secrets/render_envs.py` (sinon `render_envs.py` ne propage pas la clé).
+2. **Générer la clé forte** (jamais commitée/in dashboard) :
+   ```bash
+   python -c "import secrets; print(secrets.token_urlsafe(32))"  # ≥43 chars URL-safe
+   ```
+
+### Procédure de flip (sur `po-2023`, post-merge #4566)
+
+1. **Bootstrap master.env** (gitignoré, source unique) — append d'une ligne
+   (sans lire les autres valeurs du fichier) :
+   ```bash
+   printf '\nTTS_GATEWAY_API_KEY=%s\n' "$(python -c 'import secrets; print(secrets.token_urlsafe(32))')" \
+     >> /d/Dev/CoursIA/.secrets/master.env
+   grep -c "TTS_GATEWAY_API_KEY" /d/Dev/CoursIA/.secrets/master.env  # → 1 (count, pas la valeur)
+   ```
+2. **Render + vérifier la propagation** :
+   ```bash
+   cd /d/Dev/CoursIA && python scripts/secrets/render_envs.py
+   grep -c "TTS_GATEWAY_API_KEY" docker-configurations/services/tts-multi/.env  # → 1
+   grep -c "TTS_GATEWAY_API_KEY" MyIA.AI.Notebooks/GenAI/.env                    # → 1
+   ```
+3. **Recréer la gateway** (applique API_KEY + bind 127.0.0.1) :
+   ```bash
+   cd /d/Dev/CoursIA/docker-configurations/services/tts-multi && docker compose up -d --force-recreate tts-gateway
+   docker port tts-gateway  # doit maintenant afficher 127.0.0.1:8196 (pas 0.0.0.0)
+   ```
+4. **Vérifier la preuve** (401 sans clé, 200 avec) :
+   ```bash
+   # Sans clé : doit devenir 401 APRÈS flip (200 avant).
+   curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8196/v1/models
+   # Healthcheck (public path) reste 200 — confirme UP.
+   curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8196/health
+   # Avec clé : 200.
+   curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $(grep TTS_GATEWAY_API_KEY /d/Dev/CoursIA/.secrets/master.env | cut -d= -f2)" http://localhost:8196/v1/models
+   ```
+5. **Vérifier le notebook consommateur** : re-exécuter `02-5-Multi-Model-TTS-Gateway.ipynb`
+   (kernel `mcp-jupyter-py310`, `--cwd` le dossier du notebook) → doit toujours
+   produire l'embed kokoro (la clé est lue via `GenAI/.env`).
+
+### Rollback tts-gateway (instantané)
+
+Vider `TTS_GATEWAY_API_KEY=` dans `master.env` + `render_envs.py` +
+`docker compose up -d --force-recreate tts-gateway` → `API_KEY` vide →
+`_AUTH_ENABLED=False` → retour no-auth. Aucune donnée perdue.
+
+> ⚠️ **Exposition publique** : `tts-multi.myia.io` (IIS → `localhost:8196`) est le
+> **seul des 3 services proxifié sur Internet**. Une fois le flip fait, toute requête
+> publique sans Bearer → 401. C'est précisément l'objectif (#16), mais cela signifie
+> aussi qu'un consommateur externe non-mis-à-jour casserait immédiatement — d'où la
+> vérification blast-radius ci-dessus (GenAI-only, tous key-aware).
+
+---
 
 ## Durcissement futur (P3, basse priorité)
 


### PR DESCRIPTION
## Summary

Extends the `#16` security auth-flip runbook (`docs/genai/auth-flip-runbook.md`) with a verified **Phase 3 — tts-gateway** section. The runbook previously excluded tts-gateway ("blocage USER séparé, non couvert ici") — **that exclusion is now stale**: ai-01 deblocked it on 2026-06-28 by adding `TTS_GATEWAY_API_KEY` to the `SECRET_KEYS` schema (PR #4566) and delegating the bootstrap to po-2023 (value-holder hosting the gateway).

This is the **prep work** for the delegated tts-gateway flip: the procedure is verified firsthand and documented so the flip is fast/safe/reproducible once #4566 merges. The live flip itself is gated on #4566 (ai-01's own unmerged PR) — not executed this cycle.

## What's verified firsthand (G.1)

- **Mechanism** (`gateway/app.py:20-54`, `shared/auth_middleware.py:40-54`): the gateway mounts `shared/auth_middleware.py` and calls `setup_auth(app)` in try/except. Empty `API_KEY` → `_AUTH_ENABLED=False` → degrades silently to no-auth. **Live state confirmed**: `docker exec tts-gateway printenv API_KEY` = empty → gateway running open. Non-empty → `BearerAuthMiddleware` on all paths except `/health,/docs,/openapi.json,/redoc,/admin/*`, comparison **timing-safe** (`secrets.compare_digest`, L74/L127 — already hardened, unlike Claudish). Flip = provision value + restart, **0 code change**.
- **Bonus hardening**: compose binds `127.0.0.1:8196` (`docker-compose.yml:18`) but the **live container is stale at `0.0.0.0:8196`** (LAN-exposed) — `docker port` confirmed. The `--force-recreate` applies **both** corrections: auth activation **and** localhost-only bind.
- **Blast-radius LOW**: only GenAI notebook clients consume it, all key-aware — `qwen_tts_client.py:54` (`TTS_GATEWAY_API_KEY or KOKORO_API_KEY` fallback), `genai_service.py:164-166` (special-case). Claudish has **0 real refs** (`8196` grep hit = `膖` unicode in minified `dist/index.js`). NanoClaw is ASR-only (whisper/qwen-asr), not TTS. Other machines don't run GenAI Audio.

## Content added (Phase 3)

Mechanism walkthrough, 127.0.0.1-vs-0.0.0.0 stale-container hardening, blast-radius table (4 consumers verified), pre-flight (incl. `secrets.token_urlsafe(32)` keygen), step-by-step flip procedure (master.env bootstrap → `render_envs.py` → `docker compose up -d --force-recreate tts-gateway` → proof curls 401/200/200 → notebook consumer re-exec), instant rollback, public-exposure note (only service proxied on Internet via `tts-multi.myia.io`).

Also: header scope/status updated (2→3 services, 2026-06-28 tts-gateway greenlight), Phase 3 rollback heading disambiguated (MD024).

## Verification

- 1 file, +118/-10, docs-only, FR-primary.
- Diff is exactly the Phase 3 addition + header scope tweak + rollback heading disambiguation (verified `git diff` — no other files touched, no catalog churn).
- Isolated on a fresh branch off `origin/main` (`49a554bc4`), committed atomically (one subject — tts-gateway #16 security).

## Scope

Docs-only extension of an existing runbook. `See #16` (not `Closes` — the live flip is partial: procedure documented, execution gated on #4566 merge).