### PR TITLE
fix(gametheory): renumber orphan Exercice 3 -> 2 in GT-1-Setup (#2299 followup)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -2473,7 +2473,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Jeu de la Poule Mouillee (Chicken Game)\n",
+    "### Exercice 2 : Jeu de la Poule Mouillee (Chicken Game)\n",
     "\n",
     "Le jeu de la **Poule Mouillee** (ou Chicken Game) est un jeu d'anti-coordination classique.\n",
     "Deux conducteurs foncent l'un vers l'autre. Chacun peut :\n",
@@ -2526,7 +2526,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 : Jeu de la Poule Mouillee (Chicken Game)\n",
+    "# Exercice 2 : Jeu de la Poule Mouillee (Chicken Game)\n",
     "\n",
     "# Exercice: Definir les matrices de gains A_chicken et B_chicken (np.array)\n",
     "# A_chicken[i,j] = gain du joueur Ligne quand Ligne joue i et Colonne joue j\n",


### PR DESCRIPTION
## Summary

Restores exercise numbering consistency in `GameTheory-1-Setup.ipynb` section 7 ("Autres jeux classiques").

PR #2299 correctly relabeled the middle item from **"Exercice 2" -> "Exemple guide"** (content-based: Pierre-Feuille-Ciseaux is a full worked solution = example, not exercise). But the subsequent **"Exercice 3 : Jeu de la Poule Mouillee"** was never renumbered, leaving an orphan gap:

```
Exercice 1 : Stag Hunt
Exemple guide : Pierre-Feuille-Ciseaux   <- was Exercice 2, correctly relabeled by #2299
Exercice 3 : Poule Mouillee              <- ORPHAN, should be 2
```

Students seeing "Exercice 1, Exemple guide, Exercice 3" reasonably ask where Exercice 2 went. This renumbers the orphan to **Exercice 2** (markdown header + code comment), closing the gap.

## Diff

```
1 file changed, 3 insertions(+), 3 deletions(-)
- "### Exercice 3 : Jeu de la Poule Mouillee (Chicken Game)"
+ "### Exercice 2 : Jeu de la Poule Mouillee (Chicken Game)"
- "# Exercice 3 : Jeu de la Poule Mouillee (Chicken Game)"
+ "# Exercice 2 : Jeu de la Poule Mouillee (Chicken Game)"
```

## Surgical edit (no re-exec) - rationale

The change is **comment/header-only and output-neutral**. I re-executed the notebook twice via Papermill (kernel `python3`, nashpy 0.0.43) to **verify 0 errors / clean run**, then reverted to the committed outputs.

Why not ship the re-exec? Committed outputs are from WSL/Python 3.12; re-executing on Windows/Python 3.13 regenerates matplotlib figures + pip messages with **586 lines of non-semantic churn**. Keeping the committed outputs preserves a coherent, minimal diff (3 lines). The source change does not affect outputs (it's a comment), so committed outputs remain valid: `ec` 1..20 contiguous, 0 errors, 0 `NotImplementedError` (C.1).

## Out of scope (pre-existing, tracked separately)

The env-detection cell (cell 3) prints `sys.executable` / `os.getcwd()`, which embeds a machine path (`/home/jesse/coursia-wsl/bin/python3`) in committed outputs. This is **pre-existing** (not introduced by this diff) and out of scope - fixing it cleanly requires a same-env re-exec. Will track as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)