### PR TITLE
feat(hashlife): P2 influence-cone corollary (P4-independent, sorry 4->4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -697,6 +697,57 @@ theorem step_light_cone (t : Nat) (g₁ g₂ : Grid) (p : Int × Int)
     have h_tri : manhattan p r ≤ manhattan p q + manhattan q r := manhattan_triangle p q r
     omega
 
+/-! ## P2 corollary. Influence cone (light cone of influence)
+
+`step_light_cone` is the **cone of dependence**: to know the state of `p`
+after `t` generations, it suffices to know the cells of `g` within Manhattan
+distance `2*t` of `p`. Its contrapositive is the **cone of influence**: a live
+cell of `g` outside Manhattan distance `2*t` of `p` cannot make `p` live at
+generation `t`. Equivalently, if `p` is live after `t` generations, some live
+cell of `g` must lie within Manhattan distance `2*t` — the live region can
+expand toward the MacroCell boundary by at most `2*t` per `t` generations.
+
+This is the sorry-free, P4-independent geometric fact underpinning the
+`BoxAssezGrand`-preservation argument for P5.2 (the recursion's padding
+hypothesis is preserved because the jump of `jumpSize` generations expands the
+live region by at most `2*jumpSize`, within the margin `n`). -/
+
+/-- `isAlive` on the empty grid is always `false` (no cell is live). -/
+theorem isAlive_empty (p : Int × Int) : isAlive ([] : Grid) p = false := by
+  simp [isAlive]
+
+/-- `sortDedup` of the empty list is empty (empty `mergeSort`, empty `dedup`). -/
+theorem sortDedup_nil : sortDedup ([] : List (Int × Int)) = [] := by
+  simp [sortDedup]
+
+/-- The empty grid is a fixed point of `step` (no live cells → no births). -/
+theorem step_empty : step ([] : Grid) = [] := by
+  simp [step, candidates, sortDedup_nil]
+
+/-- `evolve` of the empty grid is empty (the fixed point iterated). -/
+theorem evolve_empty (t : Nat) : evolve t ([] : Grid) = [] := by
+  induction t with
+  | zero => simp [evolve_zero]
+  | succ k ih => simp [evolve_succ, step_empty, ih]
+
+/-- **Influence cone (contrapositive form)**: if no live cell of `g` lies in
+    `lightCone p (2*t)`, then `evolve t g` is dead at `p`. Proof: `g` then
+    agrees with the empty grid on the cone, so `step_light_cone` equates
+    `evolve t g` to `evolve t ∅` (which is dead everywhere) at `p`.
+
+    This is the directly-usable form for the `BoxAssezGrand`-preservation
+    argument: outside the live region (margin ≥ `n`), the cone is all-dead, so
+    `evolve t` cannot bring a boundary cell to life within `t < n/2` generations. -/
+theorem evolve_dead_of_cone_dead (t : Nat) (g : Grid) (p : Int × Int)
+    (h : ∀ q ∈ lightCone p (2 * t), isAlive g q = false) :
+    isAlive (evolve t g) p = false := by
+  have hagree : ∀ q ∈ lightCone p (2 * t),
+      isAlive g q = isAlive ([] : Grid) q := by
+    intro q hq
+    rw [h q hq, isAlive_empty]
+  have heq := step_light_cone t g ([] : Grid) p hagree
+  rw [heq, evolve_empty, isAlive_empty]
+
 /-! ## P3. Padding correctness
 
 `padCenter2 c` places `c` (assuming `c.level ≥ 1`) inside a level-`(k+2)`


### PR DESCRIPTION
## Summary

Sorry-stable additive grain for lane **#3846** (Conway Hashlife GOL sorry elimination). Adds the sorry-free, **P4-independent** geometric fact underpinning the `BoxAssezGrand`-preservation argument for **P5.2** (`p5_large_n_jump`).

Follows ai-01's binding design-gate **(a) STRENGTHEN** (msg `uakd1l`, 2026-06-28): `box_assez_grand` is real/non-vacuous, used as the P5 precondition. This grain is the sorry-free geometry for the padding-preservation sub-claim of `p5_large_n_jump`.

## New theorems (`Conway/Life/HashlifeCorrectness.lean`, P2-corollary block after `step_light_cone`, L699-760)

- `isAlive_empty` : `isAlive [] p = false`
- `sortDedup_nil` : `sortDedup [] = []`
- `step_empty`    : `step [] = []` (empty grid is a `step` fixed point)
- `evolve_empty`  : `evolve t [] = []`
- **`evolve_dead_of_cone_dead`** : `(∀ q ∈ lightCone p (2*t), isAlive g q = false) → isAlive (evolve t g) p = false`

`evolve_dead_of_cone_dead` is the **contrapositive of `step_light_cone`** (the cone of dependence): if no live cell of `g` lies in `lightCone p (2*t)`, then `evolve t g` is dead at `p` — the live region can expand toward the MacroCell boundary by at most `2*t` per `t` generations. Proved via `step_light_cone` with the empty grid as the all-dead reference (`g` agrees with `[]` on the cone).

This is the geometric fact the P5.2 recursion needs: a jump of `jumpSize` generations expands the live region by at most `2*jumpSize`, within the margin `n` guaranteed by the strengthened `BoxAssezGrand`.

## Lean PR checklist (pr-review-discipline §B)

1. **`grep -c sorry` before/after** (token grep regex `^\s*sorry\s*$|:= by sorry|:= sorry\b|exact sorry|^\s*· sorry`, exclude `.lake`):
   - before: **4** (P4.4 S3+S4 + glue + 2×P5)
   - after: **4** (stable, +0 net). No new sorry. All 4 at pre-existing lines (2212, 2250, 2567, 2576); the new block L699-760 compiles with **no "declaration uses sorry" warning**.
2. **Lake build SUCCESS**: `lake build Conway.Life.HashlifeCorrectness` → **EXIT 0** (3320 jobs, Mathlib junction `54f98fd6` rc2, `lake.exe` Windows-side). CI will re-confirm.
3. **Proof integrity**: `evolve_dead_of_cone_dead` transitively depends only on `step_light_cone` (PROVEN, sorry-free) + empty-grid lemmas (`simp`-proven) → **no `sorryAx`**. The Lean compiler emits a "declaration uses `sorry`" warning for any declaration that transitively uses sorry; none is emitted for the new block.
4. **No prover Python refactor** — N/A.

## Anti-regression

+51 insertions, 0 deletions. All new theorems; no existing proof touched. Sorry count unchanged.

See #3846

Co-Authored-By: Claude-Code <noreply@anthropic.com>
