### PR TITLE
feat(qc): migrate #1027 crypto sleeve Binance→Coinbase + native CoinbaseFeeModel (MiCA)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/README.md
@@ -29,6 +29,74 @@ Stratégie composite multi-broker associant un sleeve actions/ETFs (IBKR compte 
 | Crypto-MultiCanal | BTC/ETH + alts | (à benchmarker) | 30% |
 | HAR-RV-J vol-target BTC (M12) | BTC, Kelly capé 0.5 | M12 BEATS (p=7.9e-7) | 20% |
 
+> **Note (2026-06-28)** : le sleeve crypto ci-dessus est décrit dans sa version Binance
+> d'origine (avant migration MiCA). L'état courant du code est **Coinbase** — voir la
+> section [Migration MiCA](#migration-mica-sleeve-crypto-binance--coinbase-2026-06-28)
+> ci-dessous.
+
+## Migration MiCA : sleeve crypto Binance → Coinbase (2026-06-28)
+
+**Contexte réglementaire.** Les services Binance France cessent le **2026-07-01** (pas de
+licence CASP MiCA). Coinbase détient la licence CASP MiCA France et est nativement supporté
+par QuantConnect (`Market.COINBASE`, données depuis janvier 2015, 860+ paires). Le sleeve
+crypto du portefeuille hybride est migré Binance → Coinbase. Le sleeve IBKR (equities) est
+inchangé. See #1027.
+
+### Changements de code
+
+| Aspect | Avant (Binance) | Après (Coinbase) |
+|--------|-----------------|------------------|
+| Marché crypto | `Market.BINANCE` | `Market.COINBASE` |
+| Tickers | `BTCUSDT`, `ETHUSDT`, … (USDT-quoted) | `BTCUSD`, `ETHUSD`, … (USD-quoted) |
+| Fee crypto | `PercentFeeModel(0.001)` hardcodé (10bps) | `CoinbaseFeeModel()` natif (maker 0.6% / taker 0.8%) |
+| Devise compte | `USDT` | `USDT` (inchangé — voir finding ci-dessous) |
+| Paramètre | — | `crypto_fee_bps` (override flat bps pour isoler l'effet fee) |
+
+Le `CoinbaseFeeModel()` natif applique le barème réaliste Coinbase Advanced-1 (maker 0.6% /
+taker 0.8%). Comme `set_holdings()` émet des ordres **market**, le taux **taker 0.8% (80bps)**
+s'applique par défaut — bien plus cher que les 10bps Binance. Le paramètre `crypto_fee_bps`
+permet de surcharger avec un `PercentFeeModel` flat pour isoler l'effet fee pur (ex. `10`
+reproduit le barème Binance sur les données Coinbase).
+
+### Finding technique : `USD` casse le backtest (0 trades)
+
+Avec `Market.COINBASE` + `add_crypto("BTCUSD")` + `set_account_currency("USD")`, le backtest
+produit **0 trade** (le warmup ne se termine jamais — la comptabilité de cash-settlement
+entre en collision quand la devise du compte égale la devise de cotation BTCUSD = USD, et
+`is_warming_up` reste `True` → `rebalance()` retourne immédiatement). `set_account_currency("USDT")`
+restaure les trades (QC convertit automatiquement la cotation USD → compte USDT, exactement
+comme la version Binance canonique convertit l'USD equity → USDT). Vérifié firsthand : la
+version Binance canonique sur le même projet QC donne Sharpe 0.908 (le projet fonctionne),
+donc le coupable est bien la combinaison `USD` + `Market.COINBASE`, pas une défaillance du
+projet. `CoinbaseBrokerageModel` n'impose aucune devise de compte (lu dans la source Lean) —
+c'est une subtilité de couche de settlement, pas une contrainte du modèle de brokerage.
+
+### Analyse fee-switch (fenêtre 2018-2025, sleeve 50/50)
+
+| Config | Source données | Fee crypto | Sharpe | CAGR | MaxDD | PSR | Backtest |
+|--------|-----------------|-----------|--------|------|-------|-----|----------|
+| Référence Binance (avant) | Binance | 10bps | **0.908** | 29.1% | 38.5% | 42.7% | `db1cabdb` |
+| Coinbase, fee Binance | Coinbase | 10bps | **0.399** | 10.9% | 39.8% | 8.1% | `a2e9df89` |
+| Coinbase, fee intermédiaire | Coinbase | 60bps | 0.373 | 10.4% | 40.3% | 7.0% | `e5f96562` |
+| Coinbase, fee natif (défaut) | Coinbase | ~80bps taker | 0.362 | 10.1% | 40.5% | 6.6% | `7bef8b7f` |
+
+`totalOrders=0` dans le wrapper MCP est un artefact d'extraction connu (le CAGR 10% implique
+des trades réels) — les statistiques QC sont fiables.
+
+**Décomposition des effets** (isolation par fee constant d'un côté, data constante de l'autre) :
+
+- **Effet data-source** (Binance@10 → Coinbase@10, fee constant à 10bps) : Sharpe **0.908 → 0.399 = −0.51 (−56%)**. **Effet dominant.** Le différentiel de prix historique BTC/alts entre Binance et Coinbase sur 2018-2025 (liquidité, spreads, disponibilité des alts dans le basket MultiCanal) dégrade le Sharpe bien plus que le fee.
+- **Effet fee** (Coinbase@10 → Coinbase natif ~80bps taker, data Coinbase constante) : Sharpe **0.399 → 0.362 = −0.04 (−9%)**. **Modéré.** Le turnover du sleeve crypto est faible (3 stratégies mensuelles, dont 2 — EMA-Cross-Crypto et HAR-RV-VolTarget — passent souvent en cash), ce qui limite l'impact du fee malgré un barème 8× plus élevé.
+
+**Verdict honnête.** La migration MiCA coûte ~0.55 de Sharpe (0.908 → 0.362, −60%), mais **~93% de
+cette dégradation vient du changement de source de données**, pas de l'augmentation du fee
+Coinbase (souvent pointé du doigt, mais qui ne coûte que ~0.04). Le Sharpe 0.362 reste viable
+mais sous le target 1.0-1.3 du README — la migration MiCA est une contrainte réglementaire
+(continuité du service après le 2026-07-01), pas un gain de performance. Le sleeve crypto
+reste dominé par le BTC (seul BTC/ETH ont des données continues pleine fenêtre sur QC) ;
+la valeur ajoutée du basket MultiCanal et du HAR-RV-VolTarget est à ré-évaluer sous données
+Coinbase en Phase 3.
+
 ## Roadmap 5 phases
 
 ### Phase 1 — Research notebook agrégé (S1)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/main.py
@@ -5,10 +5,12 @@ from AlgorithmImports import *
 
 # ===========================================================================
 # Reality models: explicit transaction costs (README Phase 2 cost basis).
-# The default brokerage (required because IBKR rejects Crypto securities)
-# applies no meaningful fee, so without these models the backtest is
-# optimistic. Mirrors the repo's SpreadSlippageModel idiom.
-#   5bps equity commission + 10bps crypto commission + 5bps slippage.
+# Equities use an explicit 5bps PercentFeeModel (the default brokerage applies
+# no meaningful fee, so without it the backtest is optimistic -- mirrors the
+# repo's SpreadSlippageModel idiom). The crypto sleeve uses the NATIVE
+# CoinbaseFeeModel (realistic Coinbase Advanced-1 tier: maker 0.6% / taker 0.8%)
+# by default; set crypto_fee_bps to a flat bps value to override with
+# PercentFeeModel (fee-switch isolation). 5bps slippage on both sleeves.
 # ===========================================================================
 
 class PercentFeeModel(FeeModel):
@@ -40,7 +42,7 @@ class PercentSlippageModel:
 
 
 # ===========================================================================
-# Portfolio Hybride IBKR (50%) + Binance (50%) - Phase 2
+# Portfolio Hybride IBKR (50%) + Coinbase (50%) - Phase 2 (MiCA migration)
 # ---------------------------------------------------------------------------
 # Unified backtest 2018-2025 aggregating 8 sub-strategies via a direct composite
 # rebalance. The 8 signal rules are transposed verbatim from the Phase 1 research
@@ -57,22 +59,43 @@ class PercentSlippageModel:
 #
 # Brokerage: the DEFAULT model (no set_brokerage_model), because IBKR margin
 # REJECTS Crypto ("Unsupported security type: Crypto"). The default authorizes
-# both equities and crypto; explicit PercentFeeModel/PercentSlippageModel apply
-# the README cost basis. Account currency USDT so the Binance sleeve settles.
+# both equities and crypto; the explicit PercentFeeModel/PercentSlippageModel
+# (equities) + CoinbaseFeeModel (crypto) apply the README cost basis.
+#
+# Account currency USDT (NOT USD). Findings firsthand (2026-06-28): with
+# Market.COINBASE + add_crypto("BTCUSD") + set_account_currency("USD"), the
+# backtest produces 0 trades (warmup never completes -- cash-settlement
+# bookkeeping collides when the account currency equals the BTCUSD quote
+# currency USD). set_account_currency("USDT") restores trades (QC auto-converts
+# USD quote -> USDT account, exactly like the Binance canonical converts equity
+# USD -> USDT). CoinbaseBrokerageModel enforces NO account currency, so this is
+# a settlement-layer subtlety, not a brokerage-model constraint.
+#
+# MiCA migration (2026-06-28): crypto sleeve migrated Binance -> Coinbase.
+# Binance France services cease 2026-07-01 (no CASP MiCA licence); Coinbase
+# holds CASP MiCA France + is QC-native. Coinbase Crypto Price Data on QC covers
+# 860+ pairs since January 2015 (full 2018-2025 window covered).
 #
 # See #1027.
 # ===========================================================================
 
 
-class PortfolioHybridIBKRBinance(QCAlgorithm):
+class PortfolioHybridIBKRCoinbase(QCAlgorithm):
     """Phase 2/3 unified backtest, 8 research-faithful sub-strategies, monthly.
 
     Phase 3 adds two backtest parameters (no code duplication across runs):
-    - ``ibkr_alloc`` (default 0.50): IBKR sleeve fraction; Binance = 1 - ibkr_alloc.
+    - ``ibkr_alloc`` (default 0.50): IBKR sleeve fraction; crypto = 1 - ibkr_alloc.
       Drives the allocation sweep (60/40, 50/50, 40/60).
     - ``start`` / ``end`` (default 2018-01-01 / 2025-06-01, format YYYY-MM-DD):
       date window, so the OOS strict test (2023-2025) runs on the SAME code as
       the in-sample (2018-2025) without a forked algorithm.
+
+    MiCA migration adds:
+    - ``crypto_fee_bps`` (default unset = native CoinbaseFeeModel, realistic
+      Coinbase Advanced-1 maker 0.6% / taker 0.8%; set_holdings emits MARKET
+      orders so the 0.8% taker rate applies). Set to a flat bps value (e.g. 10)
+      to override with PercentFeeModel and isolate the pure fee effect (10
+      reproduces the Binance basis on Coinbase data). See README MiCA section.
     """
 
     # Intra-sleeve weights (research allocation WITHIN each sleeve, fixed).
@@ -85,14 +108,16 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
         "AllWeather":      0.15,
         "EMA-Cross-Alpha": 0.10,
     }
-    INTRA_BINANCE = {
+    INTRA_COINBASE = {
         "EMA-Cross-Crypto":  0.50,
         "Crypto-MultiCanal": 0.30,
         "HAR-RV-VolTarget":  0.20,
     }
 
     IBKR_SECTORS = ["XLK", "XLF", "XLE", "XLV", "XLY", "XLI", "XLB", "XLU", "XLP"]
-    CRYPTO_TICKERS = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "ADAUSDT", "LTCUSDT", "XRPUSDT"]
+    # Coinbase pairs are USD-quoted (BTCUSD, not BTCUSDT). Only BTC/ETH have
+    # continuous full-window data on QC; the basket rule falls back gracefully.
+    CRYPTO_TICKERS = ["BTCUSD", "ETHUSD", "SOLUSD", "ADAUSD", "LTCUSD", "XRPUSD"]
 
     @staticmethod
     def _parse_date(value, default):
@@ -115,16 +140,23 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
         self.set_end_date(*end)
 
         ibkr_alloc = float(self.get_parameter("ibkr_alloc", "0.50"))
-        binance_alloc = 1.0 - ibkr_alloc
+        crypto_alloc = 1.0 - ibkr_alloc
         self.portfolio_weights = {}
         for strat, w in self.INTRA_IBKR.items():
             self.portfolio_weights[strat] = ibkr_alloc * w
-        for strat, w in self.INTRA_BINANCE.items():
-            self.portfolio_weights[strat] = binance_alloc * w
+        for strat, w in self.INTRA_COINBASE.items():
+            self.portfolio_weights[strat] = crypto_alloc * w
 
-        # Account currency USDT so the Binance crypto sleeve (BTCUSDT, ETHUSDT)
-        # settles natively. Equities (USD) auto-convert via the USD/USDT FX rate.
-        # Set BEFORE set_cash (canonical order).
+        # MiCA fee model: native CoinbaseFeeModel by default (realistic Coinbase
+        # Advanced-1 taker 0.8%). Set crypto_fee_bps to a flat bps value to
+        # override with PercentFeeModel (e.g. 10 to reproduce the Binance basis
+        # on Coinbase data, isolating the pure fee effect). None => native model.
+        raw_fee = self.get_parameter("crypto_fee_bps")
+        self.crypto_fee_bps = float(raw_fee) if raw_fee else None
+
+        # Account currency USDT (NOT USD -- see header findings). Coinbase crypto
+        # (BTCUSD) is USD-quoted; QC auto-converts USD quote -> USDT account, like
+        # the Binance canonical converts equity USD -> USDT. Set BEFORE set_cash.
         self.set_account_currency("USDT")
         self.set_cash(100000)
 
@@ -148,13 +180,20 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
             sec.set_slippage_model(PercentSlippageModel(0.0005))
             self.sector_symbols[ticker] = sec.symbol
 
-        # Binance sleeve (crypto): 10bps commission + 5bps slippage.
-        # Only BTCUSDT has continuous data over the full window on QC; the basket
-        # rule falls back to whatever has data.
+        # Coinbase sleeve (crypto): native CoinbaseFeeModel by default (realistic
+        # Coinbase Advanced-1 tier: maker 0.6% / taker 0.8% -- set_holdings emits
+        # MARKET orders so the 0.8% taker rate applies). Set crypto_fee_bps to a
+        # flat value to override with PercentFeeModel instead (used to isolate the
+        # pure fee effect: crypto_fee_bps=10 reproduces the Binance basis on the
+        # SAME Coinbase data, isolating data-source vs fee-level contributions).
+        # Only BTCUSD/ETHUSD have continuous full-window data; basket falls back.
         self.crypto_symbols = {}
         for ticker in self.CRYPTO_TICKERS:
-            sec = self.add_crypto(ticker, Resolution.DAILY, Market.BINANCE)
-            sec.set_fee_model(PercentFeeModel(0.001))
+            sec = self.add_crypto(ticker, Resolution.DAILY, Market.COINBASE)
+            if self.crypto_fee_bps is None:
+                sec.set_fee_model(CoinbaseFeeModel())
+            else:
+                sec.set_fee_model(PercentFeeModel(self.crypto_fee_bps / 10000.0))
             sec.set_slippage_model(PercentSlippageModel(0.0005))
             self.crypto_symbols[ticker] = sec.symbol
 
@@ -243,12 +282,12 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
 
     def _ema_cross_crypto(self):
         """SMA20 > SMA50 on BTC -> 100% BTC ; else cash."""
-        btc = self._close_series(self.crypto_symbols["BTCUSDT"], 60)
+        btc = self._close_series(self.crypto_symbols["BTCUSD"], 60)
         if btc is None or len(btc) < 50:
             return {}
         sma20 = float(btc.iloc[-20:].mean())
         sma50 = float(btc.iloc[-50:].mean())
-        return {self.crypto_symbols["BTCUSDT"]: 1.0} if sma20 > sma50 else {}
+        return {self.crypto_symbols["BTCUSD"]: 1.0} if sma20 > sma50 else {}
 
     def _crypto_multicanal(self):
         """Equal-weight basket of cryptos with data."""
@@ -264,7 +303,7 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
 
     def _har_rv_voltarget(self):
         """BTC weight = clip(0.15 / RV22, 0, 1), RV22 = std(returns, 22) x sqrt(252)."""
-        btc = self._close_series(self.crypto_symbols["BTCUSDT"], 30)
+        btc = self._close_series(self.crypto_symbols["BTCUSD"], 30)
         if btc is None or len(btc) < 23:
             return {}
         rets = btc.pct_change().dropna()
@@ -273,7 +312,7 @@ class PortfolioHybridIBKRBinance(QCAlgorithm):
         rv22 = float(rets.iloc[-22:].std() * (252 ** 0.5))
         if rv22 <= 0:
             return {}
-        return {self.crypto_symbols["BTCUSDT"]: min(0.15 / rv22, 1.0)}
+        return {self.crypto_symbols["BTCUSD"]: min(0.15 / rv22, 1.0)}
 
     def rebalance(self):
         if self.is_warming_up:


### PR DESCRIPTION
## Scope

MiCA migration of the hybrid portfolio crypto sleeve ahead of **Binance France service cessation (2026-07-01, no CASP licence)**. Coinbase holds CASP MiCA France + is QC-native (`Market.COINBASE`, data since Jan 2015, 860+ pairs). Sleeve IBKR (equities) unchanged. See #1027.

This is **PR1** of the ai-01-dispatched 4-delta scope (brokerage+fee swap + re-validation). PR2 (paper harness path + README rename) follows separately.

## Code changes (`main.py`)

| Aspect | Before (Binance) | After (Coinbase) |
|--------|------------------|------------------|
| Crypto market | `Market.BINANCE` | `Market.COINBASE` |
| Tickers | `BTCUSDT`, `ETHUSDT`… (USDT-quoted) | `BTCUSD`, `ETHUSD`… (USD-quoted) |
| Crypto fee | `PercentFeeModel(0.001)` hardcoded (10bps) | `CoinbaseFeeModel()` native (maker 0.6% / taker 0.8%) |
| Account currency | `USDT` | `USDT` (unchanged — see finding) |
| Param | — | `crypto_fee_bps` (flat override to isolate fee effect) |

`CoinbaseFeeModel()` native applies the realistic Coinbase Advanced-1 tier (maker 0.6% / taker 0.8%). Since `set_holdings()` emits **MARKET** orders, the **taker 0.8% (80bps)** rate applies by default. `crypto_fee_bps` overrides with a flat `PercentFeeModel` to isolate the pure fee effect.

## Finding firsthand — `USD` breaks the backtest (0 trades)

With `Market.COINBASE` + `add_crypto("BTCUSD")` + `set_account_currency("USD")`, the backtest produces **0 trades** (warmup never completes — cash-settlement bookkeeping collides when the account currency equals the BTCUSD quote currency USD, `is_warming_up` stays `True`, `rebalance()` returns immediately). Restored by keeping `set_account_currency("USDT")`.

**Verified by elimination**: the Binance canonical on the SAME QC project gives Sharpe 0.908 (project works), so the culprit is the `USD`+`COINBASE` combo. `CoinbaseBrokerageModel` enforces no account currency (read in Lean source `CoinbaseBrokerageModel.cs`) — settlement-layer subtlety, not a brokerage-model constraint.

## Re-validation backtests (2018-2025, sleeve 50/50) — §G

| Config | Source | Fee | Sharpe | CAGR | MaxDD | PSR | Backtest |
|--------|--------|-----|--------|------|-------|-----|----------|
| Binance (before) | BINANCE | 10bps | **0.908** | 29.1% | 38.5% | 42.7% | `db1cabdb` |
| Coinbase @10bps | COINBASE | 10bps | **0.399** | 10.9% | 39.8% | 8.1% | `a2e9df89` |
| Coinbase @60bps | COINBASE | 60bps | 0.373 | 10.4% | 40.3% | 7.0% | `e5f96562` |
| Coinbase native | COINBASE | ~80bps taker | 0.362 | 10.1% | 40.5% | 6.6% | `7bef8b7f` |

4 backtests via `create_compile` + `create_backtest` (qc-mcp). `totalOrders=0` is the known MCP extraction artifact (CAGR 10% implies real trades); QC stats reliable.

## Fee-switch decomposition (isolated)

- **Data-source effect** (Binance@10 → Coinbase@10, fee constant): Sharpe **0.908 → 0.399 = −0.51 (−56%)** — **DOMINANT**
- **Fee effect** (Coinbase@10 → native ~80bps taker, data constant): Sharpe **0.399 → 0.362 = −0.04 (−9%)** — moderate

**Honest verdict**: migration costs ~0.55 Sharpe (0.908 → 0.362, −60%), but **~93% of the degradation comes from the data-source change, not the (much-criticized) Coinbase fee** (which costs only ~0.04, thanks to low crypto-sleeve turnover). Sharpe 0.362 is viable but below the 1.0-1.3 README target — MiCA is a **regulatory constraint (service continuity after 2026-07-01), not a performance gain**.

## README

FR-first MiCA migration section added (USDT finding + native fee swap + before/after fee-switch table + decomposition). Project directory rename (→ `IBKR-Coinbase-Hybrid`) deferred to a later cycle per ai-01.

## Gate USER-HAND

Coinbase live creds pending (account opening user-side). This PR is **code/backtest/doc only** — no live connection. Phase-B (live paper trading) gated on creds.

See #1027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)