### PR TITLE
docs(qc): FR-backfill 3 composite-framework READMEs (#3870)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/README.en.md
@@ -1,0 +1,59 @@
+# Framework_Composite_EMATrend
+
+**Asset class:** US Equities (Mag7 + mega-caps)
+**Cloud project ID:** 28911253
+
+## Description
+
+Framework composite combining EMA-Cross-Alpha (5 tech/Mag7 stocks, daily
+rebalance) with TrendStocks-Alpha (15 diversified mega-caps, weekly rebalance)
+via the QC Algorithm Framework. Target allocation: EMA70/Trend30 (sweep winner).
+
+Universe overlap: the 5 Mag7 stocks (AAPL, MSFT, GOOGL, AMZN, NVDA) are
+included in both strategies; the MultiStrategyPCM additively combines weights,
+giving Mag7 higher allocation when both strategies agree on direction.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend"`
+**QC Cloud:** Deployed as project 28911253 (IBKR margin, direct backtest).
+
+## Backtest Metrics
+
+| Metric | Catalog 2015-2025 | Aligned 2018-2025 |
+|--------|-------------------|-------------------|
+| Sharpe Ratio | 0.741 | **0.611** |
+| CAGR | — | 16.670% |
+| Max Drawdown | 28.0% | 27.9% |
+| PSR | 27.4% | 19.8% |
+
+Catalog backtest (2015-2025 full decade, EMA70/Trend30) = Sharpe 0.741
+(docstring claim was 0.867 → real 0.741, -14%). See `docs/qc/qc-comparative-backtests.md`.
+
+## Aligned baseline (2018-2025)
+
+Verified on the cohort-aligned window (2018-01-01 → 2025-01-01, 1761 tradeable
+dates), same EMA70/Trend30 winner config:
+
+- **Sharpe 0.611** (backtest `3095a263d5bd30df181ec002c0a52b72`, project 28911253)
+- CAGR 16.670%, MaxDD 27.9%, PSR 19.8%
+
+**Verdict: survives alignment with a mild drop** (0.741 → 0.611, -18%) — not a
+period-overfit collapse. Loses part of the 2015-2017 Mag7 pre-ramp and absorbs
+the 2022 Mag7 drawdown, but the trend signal holds. On the aligned window this is
+the **highest-Sharpe COMP (composite-framework) backbone verified to date**
+(edges composite-c2-equityfactor 0.574, FamaFrenchAllWeather 0.338,
+composite-c1-multiasset 0.258). Promoted Tier 4 (Untested) → Tier 2 (Historique).
+
+**Mag7 survivorship caveat:** the EMA sleeve is 100% Mag7, so the Sharpe is
+partly an artifact of Mag7 outperformance over the backtest decade. Highest
+Sharpe is not the same as the most robust constitution: composite-c2-equityfactor
+(0.574, factor-diversified across 25 stocks) is the more defensible COMP leader
+constitution-wise, while EMATrend is the higher-Sharpe but Mag7-concentrated one.
+See Key-finding #36 in `docs/qc/qc-comparative-backtests.md`.
+
+## Files
+
+- `main.py` - Strategy (EMA70/Trend30 composite, aligned 2018-2025)
+- `alpha_models.py` - EMACrossAlpha + TrendStocksAlpha
+- `portfolio_construction.py` - MultiStrategyPCM (alpha allocation blend)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/README.md
@@ -1,59 +1,61 @@
 # Framework_Composite_EMATrend
 
-**Asset class:** US Equities (Mag7 + mega-caps)
-**Cloud project ID:** 28911253
+**Classe d'actifs :** Actions US (Mag7 + méga-capitalisations)
+**Cloud project ID :** 28911253
 
 ## Description
 
-Framework composite combining EMA-Cross-Alpha (5 tech/Mag7 stocks, daily
-rebalance) with TrendStocks-Alpha (15 diversified mega-caps, weekly rebalance)
-via the QC Algorithm Framework. Target allocation: EMA70/Trend30 (sweep winner).
+Composite framework combinant EMA-Cross-Alpha (5 actions tech/Mag7, rééquilibrage
+quotidien) avec TrendStocks-Alpha (15 méga-capitalisations diversifiées, rééquilibrage
+hebdomadaire) via le QC Algorithm Framework. Allocation cible : EMA70/Trend30
+(configuration gagnante du sweep).
 
-Universe overlap: the 5 Mag7 stocks (AAPL, MSFT, GOOGL, AMZN, NVDA) are
-included in both strategies; the MultiStrategyPCM additively combines weights,
-giving Mag7 higher allocation when both strategies agree on direction.
+Chevauchement d'univers : les 5 actions Mag7 (AAPL, MSFT, GOOGL, AMZN, NVDA) sont
+présentes dans les deux stratégies ; le MultiStrategyPCM combine additivement les poids,
+donnant une allocation plus élevée aux Mag7 quand les deux stratégies concordent sur la
+direction.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend"`
-**QC Cloud:** Deployed as project 28911253 (IBKR margin, direct backtest).
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend"`
+**QC Cloud :** Déployé comme projet 28911253 (IBKR margin, backtest direct).
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Catalog 2015-2025 | Aligned 2018-2025 |
-|--------|-------------------|-------------------|
+| Métrique | Catalogue 2015-2025 | Alignée 2018-2025 |
+|----------|---------------------|-------------------|
 | Sharpe Ratio | 0.741 | **0.611** |
-| CAGR | — | 16.670% |
-| Max Drawdown | 28.0% | 27.9% |
-| PSR | 27.4% | 19.8% |
+| CAGR | — | 16.670 % |
+| Max Drawdown | 28.0 % | 27.9 % |
+| PSR | 27.4 % | 19.8 % |
 
-Catalog backtest (2015-2025 full decade, EMA70/Trend30) = Sharpe 0.741
-(docstring claim was 0.867 → real 0.741, -14%). See `docs/qc/qc-comparative-backtests.md`.
+Backtest catalogue (décennie complète 2015-2025, EMA70/Trend30) = Sharpe 0.741
+(la docstring annonçait 0.867 → réel 0.741, −14 %). Voir `docs/qc/qc-comparative-backtests.md`.
 
-## Aligned baseline (2018-2025)
+## Baseline alignée (2018-2025)
 
-Verified on the cohort-aligned window (2018-01-01 → 2025-01-01, 1761 tradeable
-dates), same EMA70/Trend30 winner config:
+Vérifiée sur la fenêtre alignée cohorte (2018-01-01 → 2025-01-01, 1761 dates
+tradables), même configuration gagnante EMA70/Trend30 :
 
-- **Sharpe 0.611** (backtest `3095a263d5bd30df181ec002c0a52b72`, project 28911253)
-- CAGR 16.670%, MaxDD 27.9%, PSR 19.8%
+- **Sharpe 0.611** (backtest `3095a263d5bd30df181ec002c0a52b72`, projet 28911253)
+- CAGR 16.670 %, MaxDD 27.9 %, PSR 19.8 %
 
-**Verdict: survives alignment with a mild drop** (0.741 → 0.611, -18%) — not a
-period-overfit collapse. Loses part of the 2015-2017 Mag7 pre-ramp and absorbs
-the 2022 Mag7 drawdown, but the trend signal holds. On the aligned window this is
-the **highest-Sharpe COMP (composite-framework) backbone verified to date**
-(edges composite-c2-equityfactor 0.574, FamaFrenchAllWeather 0.338,
-composite-c1-multiasset 0.258). Promoted Tier 4 (Untested) → Tier 2 (Historique).
+**Verdict : survit à l'alignement avec une baisse modérée** (0.741 → 0.611, −18 %) — pas
+un effondrement de sur-ajustement de période. Il perd une partie du pré-ramp Mag7 2015-2017
+et absorbe le drawdown Mag7 de 2022, mais le signal tendance tient. Sur la fenêtre alignée,
+c'est le **backbone COMP (composite-framework) au Sharpe le plus élevé vérifié à ce jour**
+(devance composite-c2-equityfactor 0.574, FamaFrenchAllWeather 0.338,
+composite-c1-multiasset 0.258). Promu Tier 4 (Untested) → Tier 2 (Historique).
 
-**Mag7 survivorship caveat:** the EMA sleeve is 100% Mag7, so the Sharpe is
-partly an artifact of Mag7 outperformance over the backtest decade. Highest
-Sharpe is not the same as the most robust constitution: composite-c2-equityfactor
-(0.574, factor-diversified across 25 stocks) is the more defensible COMP leader
-constitution-wise, while EMATrend is the higher-Sharpe but Mag7-concentrated one.
-See Key-finding #36 in `docs/qc/qc-comparative-backtests.md`.
+**Caveat de survivance Mag7 :** le sleeve EMA est 100 % Mag7, le Sharpe est donc en partie
+un artefact de la surperformance Mag7 sur la décennie backtestée. Le Sharpe le plus élevé
+ne se confond pas avec la constitution la plus robuste : composite-c2-equityfactor
+(0.574, diversifié factoriellement sur 25 actions) est le leader COMP le plus défendable
+constitution-par-constitution, tandis qu'EMATrend est celui au Sharpe le plus élevé mais
+concentré Mag7. Voir Key-finding #36 dans `docs/qc/qc-comparative-backtests.md`.
 
-## Files
+## Fichiers
 
-- `main.py` - Strategy (EMA70/Trend30 composite, aligned 2018-2025)
-- `alpha_models.py` - EMACrossAlpha + TrendStocksAlpha
-- `portfolio_construction.py` - MultiStrategyPCM (alpha allocation blend)
+- `main.py` — Stratégie (composite EMA70/Trend30, alignée 2018-2025)
+- `alpha_models.py` — EMACrossAlpha + TrendStocksAlpha
+- `portfolio_construction.py` — MultiStrategyPCM (blend d'allocation alpha)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_MomentumRegime/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_MomentumRegime/README.en.md
@@ -1,0 +1,51 @@
+# Framework Composite - MomentumSector + RegimeSwitching
+
+## Description
+
+Composite strategy combining two complementary approaches via QuantConnect Algorithm Framework:
+
+1. **SectorMomentum (60% slice)**: Dual momentum among SPY/IEF/GLD
+   - Multi-lookback composite score (1/3/6/12 months)
+   - SMA200 filter for SPY
+   - Monthly rebalancing
+
+2. **RegimeSwitching (40% slice)**: Regime-dependent strategy
+   - Bull markets: Risk-adjusted momentum on SPY/QQQ (70/30)
+   - Bear/Sideways: Mean-reversion (RSI oversold) + defensive (GLD/IEF)
+   - Regime detection via SMA50/SMA200 on SPY
+
+## Files
+
+- `main.py`: Algorithm setup with CompositeAlpha and MultiStrategyPCM
+- `alpha_models.py`: SectorMomentumAlpha and RegimeSwitchingAlpha classes
+- `portfolio_construction.py`: MultiStrategyPCM for capital allocation per strategy
+
+## Backtest Results (T60/RS40)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.185 |
+| CAGR | 4.728% |
+| Net Profit | 66.272% |
+| Max Drawdown | 11.500% |
+| Total Orders | 520 |
+| Win Rate | 73% |
+| Alpha | -0.008 |
+| Beta | 0.218 |
+| Sortino | 0.196 |
+
+**Verdict**: Underperforming. Sharpe 0.185 is well below SectorMomentum standalone (0.555).
+The RegimeSwitching component dilutes returns in the 60/40 blend. Very low beta (0.218)
+indicates the composite is too conservative.
+
+**Next steps**: Try T80/RS20 or T90/RS10 to reduce RegimeSwitching drag, or replace
+RegimeSwitching with a more aggressive bull-only variant.
+
+## Cloud IDs
+
+- Project ID: 31243821
+- Organization: d600793ee4caecb03441a09fc2d00f7f
+
+## Backtest Period
+
+2015-01-01 to 2025-12-31

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_MomentumRegime/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_MomentumRegime/README.md
@@ -2,50 +2,50 @@
 
 ## Description
 
-Composite strategy combining two complementary approaches via QuantConnect Algorithm Framework:
+Stratégie composite combinant deux approches complémentaires via le QuantConnect Algorithm Framework :
 
-1. **SectorMomentum (60% slice)**: Dual momentum among SPY/IEF/GLD
-   - Multi-lookback composite score (1/3/6/12 months)
-   - SMA200 filter for SPY
-   - Monthly rebalancing
+1. **SectorMomentum (tranche 60 %)** : Dual momentum entre SPY/IEF/GLD
+   - Score composite multi-lookback (1/3/6/12 mois)
+   - Filtre SMA200 sur SPY
+   - Rééquilibrage mensuel
 
-2. **RegimeSwitching (40% slice)**: Regime-dependent strategy
-   - Bull markets: Risk-adjusted momentum on SPY/QQQ (70/30)
-   - Bear/Sideways: Mean-reversion (RSI oversold) + defensive (GLD/IEF)
-   - Regime detection via SMA50/SMA200 on SPY
+2. **RegimeSwitching (tranche 40 %)** : Stratégie dépendante du régime
+   - Marchés haussiers : Momentum ajusté du risque sur SPY/QQQ (70/30)
+   - Marchés baissiers/latéraux : Mean-reversion (RSI survendu) + défensif (GLD/IEF)
+   - Détection de régime via SMA50/SMA200 sur SPY
 
-## Files
+## Fichiers
 
-- `main.py`: Algorithm setup with CompositeAlpha and MultiStrategyPCM
-- `alpha_models.py`: SectorMomentumAlpha and RegimeSwitchingAlpha classes
-- `portfolio_construction.py`: MultiStrategyPCM for capital allocation per strategy
+- `main.py` : Configuration de l'algorithme avec CompositeAlpha et MultiStrategyPCM
+- `alpha_models.py` : Classes SectorMomentumAlpha et RegimeSwitchingAlpha
+- `portfolio_construction.py` : MultiStrategyPCM pour l'allocation de capital par stratégie
 
-## Backtest Results (T60/RS40)
+## Résultats de backtest (T60/RS40)
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 0.185 |
-| CAGR | 4.728% |
-| Net Profit | 66.272% |
-| Max Drawdown | 11.500% |
+| CAGR | 4.728 % |
+| Net Profit | 66.272 % |
+| Max Drawdown | 11.500 % |
 | Total Orders | 520 |
-| Win Rate | 73% |
+| Win Rate | 73 % |
 | Alpha | -0.008 |
 | Beta | 0.218 |
 | Sortino | 0.196 |
 
-**Verdict**: Underperforming. Sharpe 0.185 is well below SectorMomentum standalone (0.555).
-The RegimeSwitching component dilutes returns in the 60/40 blend. Very low beta (0.218)
-indicates the composite is too conservative.
+**Verdict** : Sous-performance. Le Sharpe 0.185 est bien en dessous de SectorMomentum
+autonome (0.555). La composante RegimeSwitching dilue les rendements dans le blend 60/40.
+Le beta très faible (0.218) indique que le composite est trop conservateur.
 
-**Next steps**: Try T80/RS20 or T90/RS10 to reduce RegimeSwitching drag, or replace
-RegimeSwitching with a more aggressive bull-only variant.
+**Prochaines étapes** : Tester T80/RS20 ou T90/RS10 pour réduire la traînée du
+RegimeSwitching, ou remplacer RegimeSwitching par une variante plus agressive bull-only.
 
 ## Cloud IDs
 
-- Project ID: 31243821
-- Organization: d600793ee4caecb03441a09fc2d00f7f
+- Project ID : 31243821
+- Organization : d600793ee4caecb03441a09fc2d00f7f
 
-## Backtest Period
+## Période de backtest
 
-2015-01-01 to 2025-12-31
+2015-01-01 à 2025-12-31

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/README.en.md
@@ -1,0 +1,26 @@
+# Framework_Composite_TrendWeather
+
+**Asset class:** US Equities (ETF + stocks)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Framework composite combining TrendStocks (75%) with AllWeather (25%). Trend uses SMA200+EMA, AllWeather provides diversification.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 1.155 |
+| CAGR | 27.4% |
+| Max Drawdown | 27.7% |
+| Allocation | 75% Trend / 25% AllWeather |
+
+## Files
+
+- main.py - Strategy (v1.5, T75/AW25 composite)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/README.md
@@ -1,26 +1,27 @@
 # Framework_Composite_TrendWeather
 
-**Asset class:** US Equities (ETF + stocks)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions US (ETF + actions)
+**Cloud project ID :** Aucun (local uniquement)
 
 ## Description
 
-Framework composite combining TrendStocks (75%) with AllWeather (25%). Trend uses SMA200+EMA, AllWeather provides diversification.
+Composite framework combinant TrendStocks (75 %) avec AllWeather (25 %). La composante
+tendance utilise SMA200+EMA, AllWeather apporte la diversification.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour exécuter.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 1.155 |
-| CAGR | 27.4% |
-| Max Drawdown | 27.7% |
-| Allocation | 75% Trend / 25% AllWeather |
+| CAGR | 27.4 % |
+| Max Drawdown | 27.7 % |
+| Allocation | 75 % Trend / 25 % AllWeather |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (v1.5, T75/AW25 composite)
+- `main.py` — Stratégie (composite T75/AW25 v1.5)


### PR DESCRIPTION
## Scope

Translate 3 `Framework_Composite_*` READMEs to French per rule [#3871 / readme-french-first](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/readme-french-first.md). Same family (composite-framework backbones of the #1027 hybrid portfolio), coherent bundle. Part of **#1650 Phase 0.5** / See #3870.

## Files

| Project | Sharpe | Role |
|---------|--------|------|
| Framework_Composite_TrendWeather | 1.155 | TrendStocks 75% + AllWeather 25% |
| Framework_Composite_EMATrend | 0.611 aligned (0.741 catalog) | EMA-Cross-Alpha + TrendStocks, highest-Sharpe COMP backbone |
| Framework_Composite_MomentumRegime | 0.185 | SectorMomentum 60% + RegimeSwitching 40% (counter-example) |

## Method (rule HARD 1 + HARD 2)

- `git mv README.md → README.en.md` (byte-identical — EN preserved as golden set, md5-verified)
- New FR `README.md` written (same structure, metrics, links, caveats — pure language backfill, no content change)

## Verification

- EN originals preserved byte-identical (md5 match for all 3)
- No metrics, no links, no backtest refs changed — only language
- Secret scan: clean
- Atomique: 1 domain (composite-framework backbones), under G.4 thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)