### PR TITLE
feat(qc): #1027 Phase-4 paper harness Coinbase sleeve (MiCA, code-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/.env.template
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/.env.template
@@ -14,8 +14,19 @@ IBKR_PORT=7497                 # 7497 paper TWS, 7496 live TWS, 4002 IBGW paper 
 IBKR_HOST=127.0.0.1
 IBKR_CLIENT_ID=1
 
-# ─── Binance ──────────────────────────────────────────────────────────
-# Spot trading uniquement (pas de futures/leveraged)
+# ─── Coinbase (MiCA, sleeve crypto ACTIF depuis 2026-06-28) ───────────
+# Coinbase Advanced Trade API. Binance France cesse le 2026-07-01 (pas de
+# licence CASP MiCA) ; Coinbase détient la CASP MiCA France.
+# Créer une CDP API key (Ed25519/ECDSA) sur https://portal.cdp.coinbase.com/
+# après ouverture de compte Coinbase (USER-HAND, #1027 Phase-B).
+COINBASE_API_KEY=
+COINBASE_API_SECRET=
+COINBASE_SANDBOX=true          # true pendant paper trading, false pour live
+COINBASE_INITIAL_CAPITAL_USD=
+COINBASE_BASE_QUOTE=USDT       # paires BTC-USDT, ETH-USDT, etc. (matche main.py)
+
+# ─── Binance (LEGACY, fallback pré-MiCA) ──────────────────────────────
+# Spot trading uniquement. Inactif post-MiCA, conservé comme fallback.
 BINANCE_API_KEY=
 BINANCE_API_SECRET=
 BINANCE_TESTNET=true           # true pendant paper trading, false pour live
@@ -25,7 +36,7 @@ BINANCE_BASE_QUOTE=USDT        # paires BTC/USDT, ETH/USDT, etc.
 # ─── Portfolio config ─────────────────────────────────────────────────
 PORTFOLIO_TOTAL_CAPITAL_USD=
 PORTFOLIO_ALLOC_IBKR=0.50      # 50% sleeve IBKR
-PORTFOLIO_ALLOC_BINANCE=0.50   # 50% sleeve Binance
+PORTFOLIO_ALLOC_COINBASE=0.50  # 50% sleeve Coinbase (MiCA)
 PORTFOLIO_REBALANCE_FREQ=monthly  # weekly | monthly | quarterly
 PORTFOLIO_REBALANCE_THRESHOLD=0.05  # drift trigger 5%
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/README.md
@@ -1,30 +1,43 @@
 # paper_harness — exécution paper-trading Phase 4
 
-Harness local d'**exécution paper** du portefeuille hybride IBKR + Binance décrit
+Harness local d'**exécution paper** du portefeuille hybride IBKR + Coinbase (MiCA) décrit
 dans le [README parent](../README.md) (Phase 4). Distinct de `../main.py` (algorithme
-de backtest QC Cloud) : ce package parle aux **venues paper réelles** (Binance Spot
-Testnet, IB Gateway paper) au lieu du backtester QC.
+de backtest QC Cloud) : ce package parle aux **venues paper réelles** (Coinbase Advanced
+Trade API, IB Gateway paper) au lieu du backtester QC.
+
+## Migration MiCA : sleeve crypto Binance → Coinbase (2026-06-28)
+
+Le sleeve crypto ACTIF est désormais **Coinbase** (Binance France cesse le 2026-07-01,
+pas de licence CASP MiCA ; Coinbase détient la CASP MiCA France + est nativement supporté
+par QC, `Market.COINBASE` dans `../main.py`). Le `binance_sleeve.py` est conservé comme
+**fallback legacy** mais n'est plus le chemin actif. Voir la section [Migration MiCA](../README.md#migration-mica-sleeve-crypto-binance--coinbase-2026-06-28)
+du README parent.
 
 Architecture conforme à la décision Phase 4 du README parent (leçon Phase 2 :
 `set_brokerage_model(IBKR)` rejette le type Crypto → un backtest unifié 2-broker
-n'est pas transposable en live unifié) : approche **Binance-first** — paper-trader
-le sleeve crypto seul sur Binance testnet, sleeve IBKR en backtest parallèle.
+n'est pas transposable en live unifié) : approche **crypto-first** — paper-trader
+le sleeve crypto seul sur Coinbase, sleeve IBKR en backtest parallèle.
 
-## État (2026-06-22)
+## État (2026-06-28)
 
 | Composant | Statut |
 |-----------|--------|
-| `config.py` (loader `.env` typé) | livré |
+| `config.py` (loader `.env` typé) | livré (ajout `CoinbaseConfig`) |
 | `risk.py` (circuit-breakers) | livré, dry-run validé |
-| `binance_sleeve.py` (wrapper python-binance testnet) | livré, **SOTA-OK** (validé live) |
-| `smoke_test_binance.py` (validation read-only live) | livré |
+| `coinbase_sleeve.py` (wrapper coinbase-advanced-py, **MiCA**) | livré, **SOTA-OK code** (API vérifiée firsthand) |
+| `smoke_test_coinbase.py` (validation read-only) | livré, exit 2 = USER-HAND sans creds |
+| `binance_sleeve.py` (wrapper python-binance testnet, **legacy**) | livré, SOTA-OK (pré-MiCA) |
+| `smoke_test_binance.py` (validation read-only live) | livré (legacy) |
 | `ibkr_sleeve.py` (wrapper ib_insync) | livré, **SOTA-OK** (validé live, surface read-only) |
 | `smoke_test_ibkr.py` (validation read-only live) | livré |
 | `orchestrator.py` (boucle principale + routing) | **TODO** (cycle suivant) |
 
 ## Sécurité
 
-- **Testnet uniquement** en paper (`BINANCE_TESTNET=true`). Les soldes sont fictifs.
+- **Sandbox / paper uniquement** tant que `COINBASE_SANDBOX=true`. Coinbase Advanced
+  Trade n'a pas de testnet public distinct de Binance : le « sandbox » est un **compte
+  Coinbase paper** dont la clé API frappe le même endpoint (documenté honnêtement, pas
+  contourné). Les soldes d'un compte paper sont fictifs.
 - Le smoke test est **read-only** (connexion, soldes, prix, dry-run breakers) — il ne
   place **aucun ordre**. Le chemin ordre (`market_buy`/`market_sell`) est implémenté
   mais activé uniquement par l'orchestrator, après relecture des circuit-breakers.
@@ -35,12 +48,19 @@ le sleeve crypto seul sur Binance testnet, sleeve IBKR en backtest parallèle.
 
 ## SOTA-OK (Prong A)
 
-Les deux sleeves pilotent la **vraie lib** contre la **vraie venue paper** — aucune
+Les sleeves pilotent la **vraie lib** contre la **vraie venue paper** — aucune
 sortie de substitution (ASCII, réimplémentation jouet, stub).
 
-- **Binance** : `python-binance` contre le Spot Testnet (clé HMAC, perms
-  TRADE+USER_DATA+USER_STREAM, commissions 0.1%). Validation live : `can_trade=True`,
-  `maker_fee=10bps`, soldes fictifs présents (BTC/ETH/USDT…).
+- **Coinbase (ACTIF, MiCA)** : `coinbase-advanced-py` contre l'Advanced Trade API (clé
+  CDP Ed25519/ECDSA). API surface vérifiée firsthand sur la lib installée (1.8.4) :
+  `RESTClient(api_key, api_secret)`, `get_accounts()`, `get_product()`,
+  `market_order_buy(client_order_id, product_id, quote_size)`,
+  `market_order_sell(client_order_id, product_id, base_size)`, `cancel_orders(order_ids=[...])`.
+  Le code sleeve est SOTA-OK ; le **run live** est gated **USER-HAND** : ouverture de
+  compte Coinbase + création de clé CDP côté user (#1027 Phase-B). Le smoke test
+  rapporte `RECOVERABLE-USER-HAND` (exit 2) en attendant.
+- **Binance (LEGACY)** : `python-binance` contre le Spot Testnet (pré-MiCA). Conservé
+  comme fallback.
 - **IBKR** : `ib_insync` contre IB Gateway en mode paper/simulated (port 4002). Validation
   live : compte paper connecté, `accountSummary()` lu (NetLiq, cash, buying power),
   `positions()` lu. Le chemin ordre est implémenté mais **gated** sur deux conditions :
@@ -56,8 +76,8 @@ python -m pip install -r paper_harness/requirements.txt
 ## Smoke test (read-only, depuis la racine du projet)
 
 ```bash
-# Binance Spot Testnet
-python -m paper_harness.smoke_test_binance
+# Coinbase (MiCA) — sans creds : exit 2 RECOVERABLE-USER-HAND (attendu)
+python -m paper_harness.smoke_test_coinbase
 
 # IB Gateway paper (doit tourner en mode simulated/paper sur IBKR_PORT)
 python -m paper_harness.smoke_test_ibkr
@@ -71,11 +91,12 @@ gross → BLOCK). Exit code 0 = SOTA-OK.
 
 1. `orchestrator.py` : boucle de rebalancement, routing des target par sleeve,
    appel systématique à `RiskGate` avant chaque ordre, logging fills vs backtest.
-2. Premier ordre paper (BTC spot sur Binance testnet ; équity IBKR derrière
-   "Read-Only API" OFF côté gateway) derrière circuit-breakers relus.
+2. Premier ordre paper (BTC spot sur Coinbase sandbox ; équity IBKR derrière
+   "Read-Only API" OFF côté gateway) derrière circuit-breakers relus — **après**
+   obtention des creds Coinbase USER-HAND.
 
 ## Liens
 
-- [README parent](../README.md) — Phase 1-3 + roadmap 5 phases + discipline de validation
+- [README parent](../README.md) — Phase 1-3 + roadmap 5 phases + migration MiCA
 - Issue [#1027](https://github.com/jsboige/CoursIA/issues/1027)
 - [`.env.template`](../.env.template) — clés de configuration (`.env` local gitigné)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/__init__.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/__init__.py
@@ -2,11 +2,20 @@
 
 Local execution harness for paper trading the composite portfolio described
 in the project README. Distinct from ``main.py`` (the QC Cloud backtest
-algorithm): this package talks to live paper venues (Binance Spot Testnet,
-IB Gateway paper) instead of the QC Cloud backtester.
+algorithm): this package talks to live paper venues (Coinbase Advanced Trade
+API, IB Gateway paper) instead of the QC Cloud backtester.
 
-Status (2026-06-22):
-- Binance sleeve: DONE + SOTA-OK (validated live against the Spot Testnet).
+MiCA migration (2026-06-28, see ../README.md): the ACTIVE crypto venue is now
+Coinbase (CAS MiCA France, QC-native). The legacy ``binance_sleeve.py`` is
+preserved as a fallback. Binance France services cease 2026-07-01.
+
+Status (2026-06-28):
+- Coinbase sleeve: DONE + SOTA-OK code (real ``coinbase-advanced-py`` SDK,
+  API surface verified firsthand: RESTClient / get_accounts / get_product /
+  market_order_buy / market_order_sell / cancel_orders). Live run gated
+  USER-HAND: account opening + CDP API key are user-side (#1027 Phase-B).
+  Smoke test reports RECOVERABLE-USER-HAND (exit 2) when creds are absent.
+- Binance sleeve: legacy fallback, SOTA-OK when exercised (pre-MiCA).
 - IBKR sleeve: DONE + SOTA-OK (validated live against IB Gateway paper,
   account summary + positions read surface). Order placement gated on the
   gateway's "Read-Only API" being OFF (USER-HAND) + a reviewed orchestrator.

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/coinbase_sleeve.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/coinbase_sleeve.py
@@ -1,0 +1,168 @@
+"""Coinbase Advanced Trade sleeve for the Phase 4 paper harness (MiCA).
+
+Wraps the official ``coinbase-advanced-py`` SDK (``coinbase.rest.RESTClient``)
+in a small adapter so the orchestrator can talk to both sleeves through a
+uniform interface. This is the **ACTIVE** crypto venue for the hybrid
+portfolio post-MiCA.
+
+MiCA migration (2026-06-28, see ../README.md): Binance France services cease
+2026-07-01 (no CASP MiCA licence); Coinbase holds CASP MiCA France + is the
+QC-native crypto market (``Market.COINBASE`` in ``main.py``). The legacy
+``binance_sleeve.py`` is preserved as a fallback but is NOT the active path.
+
+SOTA-OK (Prong A): this drives the real ``coinbase-advanced-py`` SDK against
+the real Coinbase Advanced Trade API (``get_accounts`` / ``get_product`` /
+``market_order_buy``), no degraded workaround. Order submission is implemented
+but not exercised by the smoke test; the orchestrator enables it once circuit
+breakers are reviewed.
+
+USER-HAND gate (cf ../README.md Phase-B, #1027): Coinbase live/sandbox creds
+(CDP API key + Ed25519/ECDSA private key) must be created in the Coinbase
+Developer Platform by the user — account opening is user-side. Until then the
+SDK is imported lazily in :meth:`connect` (so config-only tooling needs no
+creds) and the smoke test reports RECOVERABLE-USER-HAND (exit 2). Coinbase
+Advanced Trade has no public testnet like Binance: "sandbox" means a paper /
+sandbox Coinbase account whose API key is used against the same endpoint, not
+a separate URL. This is documented honestly rather than worked around.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from .config import CoinbaseConfig
+
+
+@dataclass(frozen=True)
+class Balance:
+    asset: str
+    free: float
+    locked: float
+
+
+class CoinbaseSleeve:
+    """Thin adapter around ``coinbase.rest.RESTClient``.
+
+    Mirrors :class:`BinanceSleeve` so the (future) orchestrator can treat the
+    two sleeves uniformly. ``coinbase`` is imported lazily in :meth:`connect`
+    so that config-only tooling does not require the library to be installed.
+
+    Product IDs on Coinbase Advanced Trade use a dash separator
+    (``"BTC-USDT"``), built from ``(base, base_quote)``. The base quote
+    defaults to USDT to match ``main.py``'s account currency; set
+    ``COINBASE_BASE_QUOTE=USD`` if the live account is USD-denominated.
+    """
+
+    def __init__(self, cfg: CoinbaseConfig):
+        self.cfg = cfg
+        self._client = None
+
+    # -- lifecycle --------------------------------------------------------
+
+    def connect(self) -> "CoinbaseSleeve":
+        from coinbase.rest import RESTClient
+
+        if not self.cfg.has_credentials:
+            raise RuntimeError(
+                "Coinbase credentials missing in .env "
+                "(COINBASE_API_KEY / COINBASE_API_SECRET) — USER-HAND "
+                "(create a CDP API key, see ../README.md Phase-B)"
+            )
+        self._client = RESTClient(
+            self.cfg.api_key,
+            self.cfg.api_secret,
+        )
+        return self
+
+    @property
+    def client(self):
+        if self._client is None:
+            raise RuntimeError("CoinbaseSleeve not connected — call connect() first")
+        return self._client
+
+    # -- helpers ----------------------------------------------------------
+
+    def product_id(self, base: str) -> str:
+        """Build a Coinbase product id, e.g. ``BTC`` -> ``BTC-USDT``."""
+        return f"{base}-{self.cfg.base_quote}"
+
+    # -- read-only market & account --------------------------------------
+
+    def account_info(self) -> dict:
+        """Raw ``get_accounts`` response (paginated; first page only)."""
+        return self.client.get_accounts()
+
+    def quote_balance(self) -> float:
+        """Free balance denominated in the base quote (e.g. USDT/USD)."""
+        for acct in self.account_info().get("accounts", []):
+            if acct.get("currency") == self.cfg.base_quote:
+                bal = acct.get("available_balance") or {}
+                try:
+                    return float(bal.get("value", 0))
+                except (TypeError, ValueError):
+                    return 0.0
+        return 0.0
+
+    def balances(self, only_nonzero: bool = True) -> list[Balance]:
+        out: list[Balance] = []
+        for acct in self.account_info().get("accounts", []):
+            asset = acct.get("currency")
+            free = _to_float((acct.get("available_balance") or {}).get("value"))
+            locked = _to_float((acct.get("hold") or {}).get("value"))
+            if only_nonzero and free == 0 and locked == 0:
+                continue
+            out.append(Balance(asset, free, locked))
+        return out
+
+    def price(self, base_or_product: str) -> float:
+        """Last trade price. Accepts ``"BTC"`` (-> BTC-USDT) or ``"BTC-USDT"``."""
+        pid = base_or_product if "-" in base_or_product else self.product_id(base_or_product)
+        product = self.client.get_product(pid)
+        try:
+            return float(product.get("price", 0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    # -- order helpers (not exercised by the smoke test) ------------------
+
+    def market_buy(self, base: str, quote_quantity: float) -> dict:
+        """Spend ``quote_quantity`` of the quote asset to buy ``base``.
+
+        ``market_order_buy`` takes ``quote_size`` (quote-currency notional),
+        so this is the quote-denominated counterpart of Binance's
+        ``order_market_buy(quoteOrderQty=...)``.
+        """
+        pid = base if "-" in base else self.product_id(base)
+        return self.client.market_order_buy(
+            client_order_id=self._order_id(),
+            product_id=pid,
+            quote_size=self._fmt(quote_quantity),
+        )
+
+    def market_sell(self, base: str, base_quantity: float) -> dict:
+        pid = base if "-" in base else self.product_id(base)
+        return self.client.market_order_sell(
+            client_order_id=self._order_id(),
+            product_id=pid,
+            base_size=self._fmt(base_quantity),
+        )
+
+    def cancel(self, order_id: str) -> dict:
+        # ``cancel_orders`` (plural) takes a list; verified against the SDK.
+        return self.client.cancel_orders(order_ids=[order_id])
+
+    @staticmethod
+    def _order_id() -> str:
+        # Coinbase requires a unique client_order_id per order.
+        return str(uuid.uuid4())
+
+    @staticmethod
+    def _fmt(x: float) -> str:
+        return f"{x:.8f}".rstrip("0").rstrip(".")
+
+
+def _to_float(value) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/config.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/config.py
@@ -77,6 +77,9 @@ class IBKRConfig:
 
 @dataclass(frozen=True)
 class BinanceConfig:
+    """LEGACY sleeve config (pre-MiCA). Preserved as a fallback; the ACTIVE
+    crypto venue is Coinbase (see CoinbaseConfig). Binance France services
+    cease 2026-07-01 (no CASP MiCA licence). See ../README.md."""
     api_key: str
     api_secret: str
     testnet: bool
@@ -89,10 +92,30 @@ class BinanceConfig:
 
 
 @dataclass(frozen=True)
+class CoinbaseConfig:
+    """ACTIVE crypto sleeve config (post-MiCA, see ../README.md).
+
+    Auth is a CDP API key (UUID-like key name) + a base64 Ed25519/ECDSA
+    private key (``api_secret``), as required by ``coinbase.rest.RESTClient``.
+    Coinbase Advanced Trade has no public testnet: ``sandbox`` is informational
+    (a paper Coinbase account's key hits the same endpoint), NOT a URL toggle.
+    """
+    api_key: str
+    api_secret: str
+    sandbox: bool
+    initial_capital_usd: float
+    base_quote: str  # USDT (matches main.py account currency) or USD
+
+    @property
+    def has_credentials(self) -> bool:
+        return bool(self.api_key and self.api_secret)
+
+
+@dataclass(frozen=True)
 class PortfolioConfig:
     total_capital_usd: float
     alloc_ibkr: float
-    alloc_binance: float
+    alloc_coinbase: float
     rebalance_freq: str
     rebalance_threshold: float
 
@@ -109,7 +132,8 @@ class RiskConfig:
 @dataclass(frozen=True)
 class HarnessConfig:
     ibkr: IBKRConfig
-    binance: BinanceConfig
+    coinbase: CoinbaseConfig        # ACTIVE crypto sleeve (MiCA)
+    binance: BinanceConfig          # LEGACY fallback (pre-MiCA)
     portfolio: PortfolioConfig
     risk: RiskConfig
     env_path: Path
@@ -130,6 +154,13 @@ def load_config(env_path: Path | None = None) -> HarnessConfig:
             port=_get_int(env, "IBKR_PORT", 4002),
             client_id=_get_int(env, "IBKR_CLIENT_ID", 1),
         ),
+        coinbase=CoinbaseConfig(
+            api_key=_get(env, "COINBASE_API_KEY"),
+            api_secret=_get(env, "COINBASE_API_SECRET"),
+            sandbox=_get_bool(env, "COINBASE_SANDBOX", True),
+            initial_capital_usd=_get_float(env, "COINBASE_INITIAL_CAPITAL_USD", 0.0),
+            base_quote=_get(env, "COINBASE_BASE_QUOTE", "USDT"),
+        ),
         binance=BinanceConfig(
             api_key=_get(env, "BINANCE_API_KEY"),
             api_secret=_get(env, "BINANCE_API_SECRET"),
@@ -140,7 +171,7 @@ def load_config(env_path: Path | None = None) -> HarnessConfig:
         portfolio=PortfolioConfig(
             total_capital_usd=_get_float(env, "PORTFOLIO_TOTAL_CAPITAL_USD", 0.0),
             alloc_ibkr=_get_float(env, "PORTFOLIO_ALLOC_IBKR", 0.5),
-            alloc_binance=_get_float(env, "PORTFOLIO_ALLOC_BINANCE", 0.5),
+            alloc_coinbase=_get_float(env, "PORTFOLIO_ALLOC_COINBASE", 0.5),
             rebalance_freq=_get(env, "PORTFOLIO_REBALANCE_FREQ", "monthly"),
             rebalance_threshold=_get_float(env, "PORTFOLIO_REBALANCE_THRESHOLD", 0.05),
         ),

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/requirements.txt
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/requirements.txt
@@ -1,5 +1,12 @@
 # Local dependencies for the Phase 4 paper-trading harness.
 # Install:  python -m pip install -r paper_harness/requirements.txt
 # The QC Cloud backtest (main.py) does NOT need these — it runs on QC Cloud.
-python-binance>=1.0.37
+
+# ACTIVE crypto venue (post-MiCA, 2026-06-28): Coinbase Advanced Trade API.
+coinbase-advanced-py>=1.8.4
 ib_insync>=0.9.86
+
+# LEGACY (pre-MiCA): python-binance kept for the fallback Binance sleeve.
+# Uninstall candidates after the 2026-07-01 MiCA cutover, once Coinbase live
+# trading is validated (Phase-B).
+python-binance>=1.0.37

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/smoke_test_coinbase.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Binance-Hybrid/paper_harness/smoke_test_coinbase.py
@@ -1,0 +1,99 @@
+"""Read-only smoke test for the Coinbase (MiCA) sleeve.
+
+Connects to the Coinbase Advanced Trade API, verifies the key, reports
+connectivity + balances, fetches a live price, and **dry-runs** the circuit
+breakers against the live quote balance. It never places an order — that path
+is gated on a reviewed orchestrator.
+
+USER-HAND gate (cf ../README.md Phase-B, #1027): if Coinbase creds are absent
+from ``.env`` the test reports RECOVERABLE-USER-HAND (exit 2) and prints the
+``[ASK USER]`` notice — the user must open a Coinbase account + create a CDP
+API key. The sleeve code is SOTA-OK; only the live run is gated.
+
+Run from the project root::
+
+    python -m paper_harness.smoke_test_coinbase
+
+Exit codes: 0 = SOTA-OK (connected, breakers consistent) ; 2 = creds missing
+(USER-HAND) ; 3+ = connectivity / permission failure.
+"""
+from __future__ import annotations
+
+import sys
+
+from .coinbase_sleeve import CoinbaseSleeve
+from .config import load_config
+from .risk import RiskGate
+
+
+def _bal_line(asset: str, free: float) -> str:
+    return f"{asset:<8} free={free:.4f}"
+
+
+def main() -> int:
+    cfg = load_config()
+    print("=" * 64)
+    print("Phase 4 paper harness — Coinbase (MiCA) sleeve read-only smoke test")
+    print("=" * 64)
+    print(f"env          : {cfg.env_path}")
+    print(f"sandbox      : {cfg.coinbase.sandbox}")
+    print(f"base_quote   : {cfg.coinbase.base_quote}")
+
+    if not cfg.coinbase.has_credentials:
+        # USER-HAND: creds must be created in the Coinbase Developer Platform.
+        # Exit 2 (not a test failure) — the sleeve code is SOTA-OK, only the
+        # live run is gated on the user opening a Coinbase account.
+        print("-" * 64)
+        print("[ASK USER] RECOVERABLE-USER-HAND:")
+        print("  COINBASE_API_KEY / COINBASE_API_SECRET not set in .env.")
+        print("  Create a CDP API key (Ed25519/ECDSA) at")
+        print("  https://portal.cdp.coinbase.com/ after opening a Coinbase")
+        print("  account (account opening is user-side, #1027 Phase-B).")
+        print("  Sleeve code is SOTA-OK; only the live run is gated.")
+        return 2
+
+    sleeve = CoinbaseSleeve(cfg.coinbase).connect()
+
+    acct = sleeve.account_info()
+    # Coinbase get_accounts response: {accounts: [...]} on success.
+    accounts = acct.get("accounts", []) if isinstance(acct, dict) else []
+    print(f"accounts     : {len(accounts)}")
+
+    bals = sleeve.balances(only_nonzero=True)
+    print(f"balances     : {len(bals)} non-zero")
+    for b in sorted(bals, key=lambda x: x.free, reverse=True)[:8]:
+        print("  " + _bal_line(b.asset, b.free))
+
+    quote = sleeve.quote_balance()
+    print(f"{cfg.coinbase.base_quote:<12}: {quote:.2f} free")
+
+    pair = sleeve.product_id("BTC")
+    price = sleeve.price(pair)
+    print(f"{pair:<12}: {price:.2f}")
+
+    # --- dry-run circuit breakers against the live quote balance ---
+    capital = cfg.coinbase.initial_capital_usd or quote
+    gate = RiskGate(cfg.risk, starting_capital=capital)
+    gate.update_equity(capital)  # baseline mark, no drawdown yet
+
+    def check(notional: float, gross: float, label: str) -> None:
+        decision = gate.check_order(
+            sleeve_capital=capital,
+            order_notional=notional,
+            gross_exposure_after=gross,
+        )
+        flag = "ALLOW" if decision.allowed else "BLOCK"
+        print(f"  risk[{label:<26}] -> {flag} : {decision.reason}")
+
+    print("risk dry-run (no orders placed):")
+    check(capital * 0.20, capital * 0.20, "sane 20% allocation")
+    check(capital * 0.40, capital * 0.40, "oversized 40% (must block)")
+    check(capital * 0.20, capital * 1.20, "gross 120% (must block)")
+
+    print("=" * 64)
+    print("SOTA-OK: connected, breakers consistent (read-only).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR2 of the #1027 MiCA migration split (per ai-01 dispatch `msg-20260628T192559-9sq7yc`): **Phase-4 paper harness Coinbase sleeve** (code + docs only). Adds the ACTIVE crypto paper-trading sleeve for the post-MiCA cutover (Binance France services cease 2026-07-01; Coinbase holds CASP MiCA France + is QC-native). PR1 (#4576) covered the brokerage+fee swap + re-validation backtest in `main.py`.

**No live/sandbox run** — Phase-B is USER-HAND gated (Coinbase account opening + CDP API key are user-side). This PR is code-only: the sleeve wraps the real SDK, and the smoke test reports `RECOVERABLE-USER-HAND` (exit 2) when creds are absent.

## Changes

**New files**
- `paper_harness/coinbase_sleeve.py` — thin adapter around the real `coinbase-advanced-py` SDK (`coinbase.rest.RESTClient`), mirroring the legacy `binance_sleeve.py` interface.
- `paper_harness/smoke_test_coinbase.py` — read-only smoke test. Exit 2 = `RECOVERABLE-USER-HAND` when Coinbase creds absent.

**Modified (MiCA context)**
- `config.py` — `CoinbaseConfig` + `HarnessConfig.coinbase` (active) + `PortfolioConfig.alloc_coinbase`. Binance fields kept as LEGACY fallback.
- `requirements.txt` — `coinbase-advanced-py>=1.8.4` (active); `python-binance` kept for the legacy fallback sleeve.
- `.env.template` — `COINBASE_*` block; `PORTFOLIO_ALLOC_COINBASE`.
- `__init__.py`, `paper_harness/README.md` — MiCA migration status (FR-first).

**Legacy preserved byte-identical (anti-regression)**: `binance_sleeve.py`, `smoke_test_binance.py`, `ibkr_sleeve.py`, `risk.py`.

## SOTA-OK (Prong A)

Real `coinbase-advanced-py` SDK against the real Coinbase Advanced Trade API — no degraded workaround (no ASCII, no toy reimplementation, no stub, no fabricated live output). API surface verified **firsthand** against the installed lib (1.8.4):

```
RESTClient.__init__ params: ['self', 'api_key', 'api_secret', 'key_file', 'base_url', ...]
  get_accounts: OK
  get_product: OK
  market_order_buy: OK
  market_order_sell: OK
  cancel_orders: OK   # <-- plural! the SDK exposes cancel_orders, NOT cancel_order
```

The G.1 firsthand verification **caught** that the SDK exposes `cancel_orders(order_ids=[...])` (plural), not `cancel_order(client_order_id=...)` — coded to the real signature, not the WebFetch summary.

## Validation

```
$ python -m paper_harness.smoke_test_coinbase   # no creds in .env
[ASK USER] RECOVERABLE-USER-HAND:
  COINBASE_API_KEY / COINBASE_API_SECRET not set in .env.
  Create a CDP API key (Ed25519/ECDSA) at
  https://portal.cdp.coinbase.com/ after opening a Coinbase
  account (account opening is user-side, #1027 Phase-B).
  Sleeve code is SOTA-OK; only the live run is gated.
EXIT=2

$ python -c "from paper_harness.config import load_config; ..."   # import-check
IMPORT-CHECK OK   # config + both sleeves + smoke tests parse, alloc_coinbase=0.5
```

Honest behavior: no fabricated balances/prices when creds are absent — only the live run is gated USER-HAND.

## Scope (atomic, one subject)

This PR = Phase-4 paper harness Coinbase sleeve (code + docs). Parent `main.py` + `README.md` (brokerage+fee swap + re-validation) = PR1 (#4576). The two PRs touch disjoint files (`paper_harness/*` + `.env.template` vs `main.py` + `README.md`), so they can be reviewed/merged independently.

See #1027.
