### PR TITLE
fix(gametheory): source-leak cell 3 GT-1-Setup (print basename, #3962)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -93,10 +93,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Systeme d'exploitation: Linux\n",
-      "Version Python: 3.12.3\n",
-      "Repertoire de travail: /mnt/d/dev/CoursIA\n",
-      "Executable Python: /home/jesse/coursia-wsl/bin/python3\n"
+      "Systeme d'exploitation: Windows\n",
+      "Version Python: 3.13.12\n",
+      "Repertoire de travail: GameTheory\n",
+      "Executable Python: python.exe\n"
      ]
     }
    ],
@@ -119,8 +119,8 @@
     "\n",
     "print(f\"Systeme d'exploitation: {OS_NAME}\")\n",
     "print(f\"Version Python: {PYTHON_VERSION.major}.{PYTHON_VERSION.minor}.{PYTHON_VERSION.micro}\")\n",
-    "print(f\"Repertoire de travail: {os.getcwd()}\")\n",
-    "print(f\"Executable Python: {sys.executable}\")"
+    "print(f\"Repertoire de travail: {os.path.basename(os.getcwd())}\")\n",
+    "print(f\"Executable Python: {os.path.basename(sys.executable)}\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixes the **source-leak** flagged out-of-scope in PR #4573 (GT-1-Setup renumber). Cell 3 (env-detection) printed `sys.executable` and `os.getcwd()` directly, embedding a machine path in committed outputs:

```
Executable Python: /home/jesse/coursia-wsl/bin/python3
Repertoire de travail: /mnt/d/dev/CoursIA
```

Per **secrets-hygiene rule 6 (case C source-leak)** + **Stop & Repair**: fix the CAUSE (print basename) and re-execute — never hand-edit the output.

## Fix

**Source** (cell 3):
```python
print(f"Repertoire de travail: {os.getcwd()}")
  -> print(f"...: {os.path.basename(os.getcwd())}")
print(f"Executable Python: {sys.executable}")
  -> print(f"...: {os.path.basename(sys.executable)}")
```

**Re-execution**: Papermill kernel `python3` (nashpy 0.0.43), `--cwd` = notebook dir, 66/66 cells, 0 errors. **Surgically injected ONLY cell 3's clean outputs** (`GameTheory` / `python.exe`) into the committed notebook — all other cells keep their committed outputs (avoids ~586 lines of cross-env churn).

## Diff

```
1 file changed, 7 insertions(+), 7 deletions(-)
```
All changes confined to cell 3 (2 source lines + 4 output lines).

## Transparent note (incidental platform change)

Re-exec ran on Windows/py3.13 (committed outputs were from WSL/py3.12), so cell 3's OS/version output lines changed incidentally (`Linux`->`Windows`, `3.12.3`->`3.13.12`). The cell-3 output is a **real, coherent, 0-error execution** reflecting the source fix — pedagogically fine for a platform-detection cell (the point is to show whatever env runs it).

## Verification

- 0 errors, `ec` 1..20 contiguous, 0 `NotImplementedError` (C.1 clean)
- 0 path-leak markers in final outputs
- 0 secret markers
- nbformat valid
- Diff confined to cell 3 (atomic)

Separate PR from #4573 (renumber touches cells 61/62, different cells, low rebase-conflict risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)