### PR TITLE
fix(genai): scrub path-leak in 03-2 Video-Workflow-Orchestration (tqdm IProgress + abs .env path)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb
@@ -134,18 +134,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
-      "Helpers GenAI importes\n",
-      "Orchestration de Pipelines Video\n",
-      "Date : 2026-06-25 15:00:46\n",
-      "Mode : batch\n",
-      "Pipeline : text_image_video\n",
-      "Image : gpt-image-1, Video : svd\n",
-      "Upscale : True\n"
-     ]
+     "name": "stdout",
+     "text": "WARNING: .env non trouve, utilisation variables environnement\nHelpers GenAI importes\nOrchestration de Pipelines Video\nDate : 2026-06-28 22:41:22\nMode : batch\nPipeline : text_image_video\nImage : gpt-image-1, Video : svd\nUpscale : True\n"
     }
    ],
    "source": [
@@ -166,6 +157,7 @@
     "\n",
     "warnings.filterwarnings('ignore', category=DeprecationWarning)\n",
     "warnings.filterwarnings('ignore', category=FutureWarning)\n",
+    "warnings.filterwarnings('ignore', message='.*IProgress not found.*')  # tqdm/ipywidgets: evite le leak du chemin conda dans stderr\n",
     "\n",
     "# Import helpers GenAI\n",
     "# Chargement robuste de la configuration .env\n",
@@ -178,7 +170,7 @@
     "    env_path = current_path / \".env\"\n",
     "    if env_path.exists():\n",
     "        load_dotenv(env_path)\n",
-    "        print(f\".env charge depuis: {env_path}\")\n",
+    "        print(f\".env charge depuis: {env_path.name}\")\n",
     "        env_loaded = True\n",
     "        break\n",
     "    current_path = current_path.parent\n",
@@ -254,50 +246,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
-      "\n",
-      "--- VERIFICATION API ---\n",
-      "========================================\n",
-      "OPENAI_API_KEY : configure\n",
-      "\n",
-      "--- VERIFICATION GPU ---\n",
-      "========================================\n"
-     ]
+     "name": "stdout",
+     "text": "WARNING: .env non trouve, utilisation variables environnement\n\n--- VERIFICATION API ---\n========================================\nOPENAI_API_KEY : configure\n\n--- VERIFICATION GPU ---\n========================================\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "GPU : NVIDIA GeForce RTX 3090\n",
-      "VRAM totale : 24.0 GB\n",
-      "VRAM libre : 24.0 GB\n",
-      "CUDA : 12.6\n",
-      "\n",
-      "--- VERIFICATION DEPENDANCES ---\n",
-      "========================================\n"
-     ]
+     "name": "stdout",
+     "text": "GPU : NVIDIA GeForce RTX 3090\nVRAM totale : 24.0 GB\nVRAM libre : 24.0 GB\nCUDA : 12.6\n\n--- VERIFICATION DEPENDANCES ---\n========================================\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\.conda\\envs\\bonsai\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "diffusers : v0.38.0\n",
-      "imageio : v2.37.3\n",
-      "\n",
-      "Device : cuda\n",
-      "Pipeline active : True\n"
-     ]
+     "text": "diffusers : v0.38.0\nimageio : v2.37.3\n\nDevice : cuda\nPipeline active : True\n"
     }
    ],
    "source": [
@@ -312,7 +273,7 @@
     "    env_path = current_path / \".env\"\n",
     "    if env_path.exists():\n",
     "        load_dotenv(env_path)\n",
-    "        print(f\".env charge depuis: {env_path}\")\n",
+    "        print(f\".env charge depuis: {env_path.name}\")\n",
     "        env_loaded = True\n",
     "        break\n",
     "    current_path = current_path.parent\n",


### PR DESCRIPTION
## Scope

Fix path-leak in `03-2-Video-Workflow-Orchestration.ipynb` — continuation of the #3436 GenAI path-leak fleet sweep.

## Root cause (verified firsthand)

The notebook leaked the local conda env path in two ways:

1. **tqdm stderr leak** — `import diffusers` triggers a tqdm `TqdmWarning: IProgress not found` on stderr, carrying the absolute conda env path (`C:\...\envs\bonsai\Lib\site-packages\tqdm\auto.py:21`). Root cause: `ipywidgets` missing in the execution env (tqdm falls back to a text bar, emitting the path).
2. **Absolute `.env` path print** — setup + env cells printed `.env charge depuis: {env_path}` with an absolute machine path (latent leak, surfaces when `.env` is found).

## Fix (3 source changes)

- **cell-setup**: `warnings.filterwarnings('ignore', message='.*IProgress not found.*')` — defensive filter (leak-free on any env, even without ipywidgets).
- **cell-setup + cell-env**: `.env` path printed as basename (`{env_path.name}`) instead of absolute path.

Plus **env repair** (rule F): installed `ipywidgets` in the `bonsai` kernel env — fixes the root cause so the warning is no longer emitted.

## Validation

- Re-executed cells 0-5 only (surgical scope; pipelines, exercises and stats cells byte-identical to `origin/main`).
- **0 path-leak** (canonical scanner exit 0), **13/13 code cells executed, 0 errors**.
- C.1 clean (no `raise NotImplementedError`/`assert False`/`1/0`).
- Stop & Repair respected: fixed the cause (missing dep + source filter) + re-executed; no hand-edit of cell outputs.

## Out of scope (separate grain)

While re-executing, observed `AttributeError: 'LTXPipeline' object has no attribute 'enable_vae_slicing'` (diffusers 0.38 API drift) caught gracefully in pipeline-2 + batch cells. Pre-existing, untouched here (one-subject-per-PR).

See #3436.
