### PR TITLE
feat(hashlife): centralCorrect_mem — 4th whnf-bypass technique (sorry 4->4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1787,6 +1787,43 @@ def centralCorrect (c : MacroCell) (j : Nat) : Prop :=
   (hashlifeResultAux (j + 2) c).toGrid ((2^j : Nat), (2^j : Nat)) =
     restrictGridTo (evolve (2^j) (c.toGrid (0, 0))) (2^j : Int) (2^(j+1))
 
+/-- **The whnf-wall bypass (4th abstraction technique, c.153).**
+
+    `centralCorrect c j` is a *grid equality*. To reason about pointwise
+    membership `p ∈ (hashlifeResultAux (j+2) c).toGrid off` WITHOUT whnf-reducing
+    the `hashlifeResultAux` term (the wall that blocked c.138–c.140), apply
+    `p ∈ ·` to both sides of the equality by **congruence** (`congrArg`), then
+    `Iff.of_eq`. This substitutes the `hashlifeResultAux` term *syntactically* —
+    it is never unfolded. The four previous techniques (opaque-binder helper
+    c.139, `inductive cellWf` c.142, plain `def centralCorrect` c.139,
+    `set m := k-1` c.147) all work *around* the wall by hiding hRA behind an
+    opaque binder; this one crosses it by congruence, which is exactly what
+    G2/G3 need (they must inspect the *membership* of the composed result, not
+    just its level/wf).
+
+    Instantiated with `mem_restrictGridTo`, this is the **G1 reduction**
+    (membership of a sub-cell whose `centralCorrect` is known, e.g. `q_j` via
+    `ih`) in one sorry-free step. The residual wall is **G3 assembly** (how
+    `(hashlifeResultAux (k+2) c).toGrid off` decomposes into the four
+    `(hashlifeResultAux (k+1) q_j).toGrid off_j` — the `toCellsAux` walk on an
+    `hRA` that unfolds), which remains to be bridged. This lemma is the
+    `p4_succ_membership` analogue of the P4.3 gate lemma (`hashlifeResultAux_
+    level_cellWf`, c.142): sorry-stable infrastructure that unlocks the next
+    attack. -/
+theorem centralCorrect_mem (c : MacroCell) (j : Nat) (p : Int × Int)
+    (h : centralCorrect c j) :
+    p ∈ (hashlifeResultAux (j + 2) c).toGrid ((2^j : Nat), (2^j : Nat)) ↔
+      isAlive (evolve (2^j) (c.toGrid (0, 0))) p = true ∧
+      (2^j : Int) ≤ p.1 ∧ p.1 < (2^j : Int) + 2^(j+1) ∧
+      (2^j : Int) ≤ p.2 ∧ p.2 < (2^j : Int) + 2^(j+1) := by
+  have hb : p ∈ (hashlifeResultAux (j + 2) c).toGrid ((2^j : Nat), (2^j : Nat)) ↔
+      p ∈ restrictGridTo (evolve (2^j) (c.toGrid (0, 0))) (2^j : Int) (2^(j+1)) :=
+    Iff.of_eq (congrArg (fun g : Grid => p ∈ g) h)
+  rw [hb, mem_restrictGridTo]
+  refine ⟨fun ⟨Hm, h1, h2, h3, h4⟩ => ⟨?_, h1, h2, h3, h4⟩,
+          fun ⟨H, h1, h2, h3, h4⟩ => ⟨?_, h1, h2, h3, h4⟩⟩ <;>
+    simp_all [isAlive]
+
 /-- **P4.2 helper (c.139 workaround).** The `ih` *application*
     `ih (node nw_se ne_sw sw_ne se_nk) (k-1) ...` diverges on `whnf` when it
     appears inline inside `p4_wave1_ih`'s body, because there the four


### PR DESCRIPTION
## Summary

Sorry-stable infrastructure lemma for lane **#3846** (Conway Hashlife GOL sorry elimination). Adds the **4th whnf-bypass technique** that unlocks G2 of the P4.4 sub-cell-coverage argument. This is the `p4_succ_membership` analogue of the P4.3 gate lemma (`hashlifeResultAux_level_cellWf`, c.142 → consumed in c.143).

Companion to #4574 (P5 infra, separate insertion point). Both touch `HashlifeCorrectness.lean` at distant locations (#4574 after `step_light_cone` L700; this one after `centralCorrect` L1786) — rebase at merge is trivial.

## The finding — 4th whnf-bypass technique

`centralCorrect c j` is a **grid equality**:
```
(hashlifeResultAux (j+2) c).toGrid (2^j, 2^j) = restrictGridTo (evolve 2^j (c.toGrid 0 0)) 2^j 2^(j+1)
```

To reason about pointwise membership `p ∈ (hashlifeResultAux (j+2) c).toGrid off` **without whnf-reducing** the `hashlifeResultAux` term (the wall that blocked c.138–c.140, 8M-heartbeat divergence), apply `p ∈ ·` to both sides of the equality by **congruence** (`congrArg`), then `Iff.of_eq`. This substitutes the `hashlifeResultAux` term *syntactically* — it is never unfolded.

The four prior techniques all work *around* the wall by hiding `hRA` behind an opaque binder:
- opaque-binder helper (c.139 `p4_wave1_ih_step`)
- `inductive cellWf` opaque (c.142)
- plain `def centralCorrect` (c.139)
- `set m := k-1` opaque predecessor (c.147)

This 4th one **crosses** the wall by congruence — exactly what G2/G3 need, because they must inspect the **membership** of the composed result (not just its level/wf, which is all the prior techniques could reach).

**Confirmed empirically**: a minimal probe (`congrArg (fun g => p ∈ g) h` + `Iff.of_eq`) compiles **EXIT 0 with no whnf/heartbeat/timeout signature**. The wall is bypassed, not hit.

## Why sorry-stable (4→4, not 4→3)

`p4_succ_membership` needs `centralCorrect c k`, which is its **conclusion** (the inductive step at level `k`), not a hypothesis — `ih : ∀ c' j, j < k → ...` does not cover the current level. So `centralCorrect_mem` serves **G2** (membership of the **sub-cells** `q_j` via `ih q_j (k-1)`), but the residual wall is **G3 assembly**: how `(hashlifeResultAux (k+2) c).toGrid off` decomposes into the four `(hashlifeResultAux (k+1) q_j).toGrid off_j` — the `toCellsAux` walk on an `hRA` that unfolds. That remains to be bridged.

This lemma is the **gate that unlocks the next attack** — same shape as c.142 (gate lemma, sorry-stable +0) → c.143 (consumed it, sorry 5→4).

## Lean PR checklist (pr-review-discipline §B)

1. **`grep -c sorry` before/after** (token grep, exclude `.lake`): **4 → 4** (stable, +0 net). No new sorry. The new `centralCorrect_mem` has **no "declaration uses sorry" warning** → transitively sorry-free.
2. **Lake build SUCCESS**: `lake build Conway.Life.HashlifeCorrectness` → **EXIT 0** (3320 jobs). CI will re-confirm.
3. **Proof integrity**: `centralCorrect_mem` depends only on `congrArg` + `Iff.of_eq` + `mem_restrictGridTo` + `simp [isAlive]` → **no `sorryAx`**.
4. **No prover Python refactor** — N/A.

## Anti-regression

+37 insertions, 0 deletions. New theorem only; no existing proof touched. Sorry count unchanged.

See #3846

Co-Authored-By: Claude-Code <noreply@anthropic.com>
