### PR TITLE
feat(lean): PacLearning BernoulliMGF — log-MGF 2nd derivative ≤ 1/4 (iter-2 brique 2b/5-étape2)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/BernoulliMGF.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/BernoulliMGF.lean
@@ -44,7 +44,14 @@ travail d'analyse dédié (cycle futur), pas un stub non prouvé.
 
 - 1/5 Chernoff-Markov (`chernoff_ineq`) — PR #4516
 - 2a/5 MGF réduction algébrique (`expect_exp_centered_eq`) — PR #4525
-- **2b/5 borne analytique** — CETTE PR (ingrédients + cas symétrique prouvés, général OPEN)
+- **2b/5 borne analytique** — Cette PR (ingrédients + cas symétrique prouvés, général OPEN) :
+  - **2b/5-étape2 LIVRÉE** : cœur analytique de Hoeffding prouvé — dérivée du log-MGF
+    `φ'(t) = q(t)` (moyenne tiltée), `q ∈ [0,1]`, et **2e dérivée `φ''(t) = q(t)(1−q(t)) ≤ 1/4`**
+    (variance tiltée, via `bernoulli_var_le` inconditionnelle). C'est l'ingrédient exact
+    de Hoeffding : la variance d'une v.a. bornée dans [0,1] est ≤ (plage/2)² = 1/4.
+  - **2b/5-restant OPEN** : borne finale `MGF ≤ exp(t²/8)` depuis `φ''≤1/4` (pas Taylor/
+    convexity : `K(t) = φ(t) − tμ` a `K(0)=K'(0)=0`, `K''≤1/4` ⟹ `K(t)≤t²/8`), nécessite
+    le machinery `convexOn_univ_of_deriv2_nonneg` + `(deriv^[2] f)` qui timeout sur `simp`.
 - 3/5 indépendance produit (MGF d'une somme = produit des MGF) — OPEN
 - 4/5 optimisation `t = 4ε` — OPEN
 - 5/5 concentration bilatérale — OPEN
@@ -102,5 +109,96 @@ theorem bernoulli_mgf_half_le (t : ℝ) :
   have hle := Real.cosh_le_exp_half_sq (t / 2)
   rw [show (t / 2) ^ 2 / 2 = t ^ 2 / 8 from by ring] at hle
   exact hle
+
+/-! ## Brique 2b/5-étape2 — dérivée du log-MGF (moyenne tiltée) et borne analytique
+
+Ingrédient analytique de la borne générale `bernoulli_mgf_le` (encore OPEN). On
+établit la structure dérivée du **log-MGF non-centré** `φ(t) = log((1−μ) + μ·exp t)` :
+
+  φ'(t) = q(t) := μ·exp t / ((1−μ) + μ·exp t)   (« moyenne tiltée », ∈ [0,1] pour μ ∈ [0,1])
+  φ''(t) = q(t)·(1 − q(t)) ≤ 1/4                 (« variance tiltée », ingrédient exact de Hoeffding)
+
+La borne `φ'' ≤ 1/4` est le **cœur analytique** de Hoeffding (toute la difficulté de la
+concentration réside là : la variance d'une v.a. bornée dans [0,1] est ≤ (plage/2)² = 1/4).
+La borne finale `MGF ≤ exp(t²/8)` suit par convexité/Taylor (K(t) := φ(t) − tμ a K(0)=K'(0)=0
+et K'' = φ'' ≤ 1/4 ⟹ K(t) ≤ t²/8) — étape documentée OPEN (reste le pas Taylor/convexité).
+-/
+
+/-- **Positivité du dénominateur du log-MGF** : pour `μ ∈ [0,1]` et tout `t`,
+    `(1−μ) + μ·exp t > 0`. En effet, c'est une somme pondérée (`μ` et `1−μ`) de termes
+    `≥ 0` dont au moins un est strictement `> 0` (cas `μ < 1` : `1−μ > 0` ; cas `μ = 1` :
+    `μ·exp t = exp t > 0`). C'est la condition de domaine du log-MGF. -/
+theorem bernoulli_logmgf_denom_pos (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    0 < (1 - μ) + μ * Real.exp t := by
+  have h1mu : 0 ≤ 1 - μ := sub_nonneg.mpr hμ2
+  have hmexp : 0 ≤ μ * Real.exp t := mul_nonneg hμ (le_of_lt (Real.exp_pos t))
+  by_cases hμ1 : μ = 1
+  · -- μ = 1 : (1−μ) = 0, donc somme = 0 + exp t = exp t > 0.
+    subst hμ1; simp [Real.exp_pos]
+  · -- μ < 1 : (1−μ) > 0, donc somme = (terme ≥ 0) + (terme > 0) > 0.
+    have h1mu_pos : 0 < 1 - μ := lt_of_le_of_ne h1mu (fun heq => hμ1 (by linarith))
+    linarith
+
+/-- **Dérivée du log-MGF de Bernoulli** : pour `μ ∈ [0,1]` et le log-MGF non-centré
+    `φ(t) = log((1−μ) + μ·exp t)`, la dérivée est la « moyenne tiltée »
+    `q(t) = μ·exp t / ((1−μ) + μ·exp t)`. Preuve : `HasDerivAt.log` (chaîne sur `log`)
+    + `hasDerivAt_exp` + `const_mul` + `const_add`, le dénominateur étant `≠ 0`
+    via `bernoulli_logmgf_denom_pos`. -/
+theorem bernoulli_logmgf_deriv (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    deriv (fun s => Real.log ((1 - μ) + μ * Real.exp s)) t =
+      μ * Real.exp t / ((1 - μ) + μ * Real.exp t) := by
+  apply HasDerivAt.deriv
+  apply HasDerivAt.log
+  · exact HasDerivAt.const_add _ (HasDerivAt.const_mul _ (hasDerivAt_exp t))
+  · exact ne_of_gt (bernoulli_logmgf_denom_pos μ t hμ hμ2)
+
+/-- **La moyenne tiltée est dans [0,1]** : pour `μ ∈ [0,1]`, `q(t) = μ·exp t/((1−μ)+μ·exp t)
+    ∈ [0,1]`. C'est la « probabilité a posteriori » que `ind = 1` sous la loi tiltée de
+    paramètre `t` — toujours une probabilité valide. -/
+theorem bernoulli_tilted_mean_mem_Icc (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    μ * Real.exp t / ((1 - μ) + μ * Real.exp t) ∈ Set.Icc (0 : ℝ) 1 := by
+  rw [Set.mem_Icc]
+  have hDpos : 0 < (1 - μ) + μ * Real.exp t := bernoulli_logmgf_denom_pos μ t hμ hμ2
+  refine ⟨?_, ?_⟩
+  · -- 0 ≤ μ·exp t / D  (numérateur ≥ 0, dénominateur > 0).
+    exact div_nonneg (mul_nonneg hμ (le_of_lt (Real.exp_pos t))) (le_of_lt hDpos)
+  · -- μ·exp t / D ≤ 1  ⟺  μ·exp t ≤ (1−μ) + μ·exp t  ⟺  0 ≤ (1−μ)  (vrai car μ ≤ 1).
+    rw [div_le_iff₀ hDpos, one_mul]
+    exact le_add_of_nonneg_left (sub_nonneg.mpr hμ2)
+
+/-- **Dérivée de la moyenne tiltée (= 2e dérivée du log-MGF)** : pour `q(t) =
+    μ·exp t/((1−μ)+μ·exp t)` (la moyenne tiltée, = `φ'`), on a `q'(t) = q(t)·(1−q(t))`
+    (« variance tiltée »). C'est la 2e dérivée `φ''(t)` du log-MGF non-centré. Preuve :
+    règle du quotient `HasDerivAt.div` sur `num = μ·exp t` (numérateur) et `D = (1−μ)+μ·exp t`
+    (dénominateur, tous deux de dérivée `μ·exp t`), puis fermeture algébrique
+    (`field_simp` + `ring`) : la forme quotient `μ·exp t·(D − μ·exp t)/D²` se réduit à
+    `q(t)·(1−q(t))` car `D − μ·exp t = 1−μ`. -/
+theorem bernoulli_tilted_mean_deriv (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    deriv (fun s => μ * Real.exp s / ((1 - μ) + μ * Real.exp s)) t =
+      μ * Real.exp t / ((1 - μ) + μ * Real.exp t) *
+        (1 - μ * Real.exp t / ((1 - μ) + μ * Real.exp t)) := by
+  have hDpos : 0 < (1 - μ) + μ * Real.exp t := bernoulli_logmgf_denom_pos μ t hμ hμ2
+  have hDne : (1 - μ) + μ * Real.exp t ≠ 0 := ne_of_gt hDpos
+  have hnum : HasDerivAt (fun s => μ * Real.exp s) (μ * Real.exp t) t :=
+    HasDerivAt.const_mul μ (hasDerivAt_exp t)
+  have hD : HasDerivAt (fun s => (1 - μ) + μ * Real.exp s) (μ * Real.exp t) t :=
+    HasDerivAt.const_add _ (HasDerivAt.const_mul _ (hasDerivAt_exp t))
+  have hdiv : HasDerivAt (fun s => μ * Real.exp s / ((1 - μ) + μ * Real.exp s))
+      ((μ * Real.exp t * ((1 - μ) + μ * Real.exp t) - μ * Real.exp t * (μ * Real.exp t)) /
+        ((1 - μ) + μ * Real.exp t) ^ 2) t :=
+    HasDerivAt.div hnum hD hDne
+  rw [HasDerivAt.deriv hdiv]
+  field_simp
+
+/-- **La variance tiltée est ≤ 1/4 (= borne de Hoeffding)** : la 2e dérivée du log-MGF
+    non-centré `φ''(t) = q(t)·(1−q(t))` satisfait `≤ 1/4` — le **cœur analytique** de
+    Hoeffding. La borne `x·(1−x) ≤ 1/4` est **inconditionnelle** (vraie ∀ `x ∈ ℝ`, via la
+    complétion du carré `(x − 1/2)² ≥ 0`), donc s'applique à `x = q(t)` sans hypothèse de
+    domaine. C'est l'ingrédient exact qui, combiné à Taylor/convexité (`K(t) = φ(t) − tμ`
+    avec `K(0) = K'(0) = 0`), donne la borne finale `MGF ≤ exp(t²/8)` (étape OPEN). -/
+theorem bernoulli_logmgf_second_deriv_le (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    deriv (fun s => μ * Real.exp s / ((1 - μ) + μ * Real.exp s)) t ≤ 1 / 4 := by
+  rw [bernoulli_tilted_mean_deriv μ t hμ hμ2]
+  exact bernoulli_var_le _
 
 end PacLearning


### PR DESCRIPTION
## Summary

The **analytic core of Hoeffding**, proven — iter-2 brique 2b/5-étape2. For the uncentered Bernoulli log-MGF `φ(t) = log((1−μ) + μ·exp t)` with `μ ∈ [0,1]`:

    φ'(t) = q(t) := μ·exp t / ((1−μ) + μ·exp t)        (tilted mean, ∈ [0,1])
    φ''(t) = q(t)·(1 − q(t)) ≤ 1/4                      (tilted variance — Hoeffding's heart)

The bound **φ'' ≤ 1/4 is the irreducible analytic fact** underlying all of Hoeffding: the variance of a bounded r.v. in [0,1] is ≤ (range/2)² = 1/4. It follows from `bernoulli_var_le` (the *unconditional* `x·(1−x) ≤ 1/4` via square-completion `(x−1/2)² ≥ 0`), applied to `q(t)`.

## 5 new lemmas (0 sorry)

| Lemma | Statement | Proof |
|-------|-----------|-------|
| `bernoulli_logmgf_denom_pos` | `0 < (1−μ)+μ·exp t` for μ∈[0,1] | case μ=1 (simp) / μ<1 (`linarith` from `0<1−μ, 0≤μ·exp t`) |
| `bernoulli_logmgf_deriv` | `φ'(t) = q(t)` | `HasDerivAt.log` + `hasDerivAt_exp` + `const_mul` + `const_add` |
| `bernoulli_tilted_mean_mem_Icc` | `q(t) ∈ [0,1]` | `div_nonneg` + `div_le_iff₀` |
| `bernoulli_tilted_mean_deriv` | `q'(t) = q(t)(1−q(t))` | `HasDerivAt.div` (quotient rule) + `field_simp` |
| `bernoulli_logmgf_second_deriv_le` | `φ''(t) ≤ 1/4` | `bernoulli_var_le` (unconditional) |

## Why this matters

`φ'' ≤ 1/4` is the genuine mathematical content of Hoeffding's lemma. Without it, no concentration; with it, the rest is standard convexity. This PR delivers the **hard analytic part** — the variance-of-tilted-Bernoulli bound — proven cleanly via `HasDerivAt` (avoiding `iteratedDeriv` / `deriv^[2]` which times out on `simp`, per the documented 2b/5 OPEN).

## OPEN — the convexity step

The final bound `bernoulli_mgf_le` (`MGF ≤ exp(t²/8)`) remains OPEN. It needs the Taylor/convexity step: `K(t) = φ(t) − tμ` (centered log-MGF) has `K(0) = K'(0) = 0` and `K'' = φ'' ≤ 1/4`, hence `K(t) ≤ t²/8` (a convex quadratic upper bound). This step requires the `convexOn_univ_of_deriv2_nonneg` + `(deriv^[2] f)` machinery, which is heavy and times out — left as a dedicated next iteration. The analytic heart is proven here.

## Validation (Lean PR body, 4 elements)

1. **sorry diff**: `BernoulliMGF.lean` = **0 sorry** (standalone-tactic AND prose — no "sorry" anywhere). Net-zero vs origin/main (0=0).
2. **Lake build SUCCESS**: `lake build PacLearning` → 8501 jobs, exit 0.
3. **Proof integrity**: `#print axioms bernoulli_logmgf_second_deriv_le / _tilted_mean_deriv / _logmgf_deriv` → `[propext, Classical.choice, Quot.sound]` (**no sorryAx**).
4. N/A (no Python prover refactor).

Self-contained (`import Mathlib` only), fresh branch from origin/main, no stacking.

See #4293 (epic PAC, agnostic Hoeffding route).

Co-Authored-By: Claude <noreply@anthropic.com>