### PR TITLE
feat(argumentation): notebook sémantiques de classement (h-Categoriser + fardeau)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ranking_Semantics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ranking_Semantics.ipynb
@@ -1,0 +1,641 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ea1ca9ca",
+   "metadata": {},
+   "source": [
+    "# Argumentation graduée — sémantiques de classement (h-Categoriser & fardeau)\n",
+    "\n",
+    "Dans le notebook compagnon [`Argument_Analysis_Dung_AF_Semantics`](Argument_Analysis_Dung_AF_Semantics.ipynb),\n",
+    "les sémantiques de Dung (fondée, préférée, stable) répondent par **oui ou non** : un argument est\n",
+    "*dans* une extension, ou il n'y est pas. C'est une vision **tout-ou-rien** de l'acceptabilité.\n",
+    "\n",
+    "Les **sémantiques de classement** (*ranking-based / gradual semantics*) répondent à une question plus fine :\n",
+    "*« à quel point » cet argument est-il acceptable ?* Elles attribuent à chaque argument une **force\n",
+    "numérique** et en déduisent un **ordre**. Deux arguments tous deux « rejetés » au sens de Dung peuvent\n",
+    "ainsi être **départagés** : celui qui subit trois attaques est plus faible que celui qui n'en subit qu'une.\n",
+    "\n",
+    "Ce notebook présente deux méthodes déterministes, calculables à la main :\n",
+    "\n",
+    "| Méthode | Principe | Référence |\n",
+    "|---------|----------|-----------|\n",
+    "| **h-Categoriser** | point fixe $\\mathrm{Cat}(a) = \\dfrac{1}{1 + \\sum_{b \\to a} \\mathrm{Cat}(b)}$ | Besnard & Hunter 2001 ; convergence : Pu et al. 2014 |\n",
+    "| **Fardeau** (*burden-based*) | suite $\\mathrm{Bur}^{i}(a) = 1 + \\sum_{b \\to a} \\tfrac{1}{\\mathrm{Bur}^{i-1}(b)}$, comparée lexicographiquement | Amgoud & Ben-Naim 2013 |\n",
+    "\n",
+    "> Tout est en **Python standard** (pas de dépendance) : les calculs sont reproductibles et déterministes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4ead78c",
+   "metadata": {},
+   "source": [
+    "## 1. Le cadre d'argumentation (rappel)\n",
+    "\n",
+    "On réutilise exactement la structure `AF` $\\langle \\text{args}, \\text{attacks}\\rangle$ du notebook Dung :\n",
+    "un ensemble d'arguments et un ensemble d'attaques (couples *attaquant → attaqué*)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b68e1873",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.285481Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.283793Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.344457Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.340385Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF(args=['a', 'b', 'e', 'y', 'z1', 'z2', 'z3'], attacks=[y->a, z1->b, z2->b, z3->b])\n",
+      "  attaquants de e : aucun\n",
+      "  attaquants de a : ['y']\n",
+      "  attaquants de b : ['z1', 'z2', 'z3']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from itertools import combinations\n",
+    "\n",
+    "\n",
+    "class AF:\n",
+    "    \"\"\"Cadre d'argumentation abstrait de Dung : <args, attacks>.\"\"\"\n",
+    "\n",
+    "    def __init__(self, args, attacks):\n",
+    "        self.args = set(args)\n",
+    "        self.attacks = set(attacks)  # ensemble de couples (attaquant, attaque)\n",
+    "\n",
+    "    def attackers(self, x):\n",
+    "        \"\"\"Arguments qui attaquent directement x.\"\"\"\n",
+    "        return {a for (a, b) in self.attacks if b == x}\n",
+    "\n",
+    "    def __repr__(self):\n",
+    "        att = \", \".join(f\"{a}->{b}\" for (a, b) in sorted(self.attacks))\n",
+    "        return f\"AF(args={sorted(self.args)}, attacks=[{att}])\"\n",
+    "\n",
+    "\n",
+    "# Exemple fil rouge : e n'est pas attaque, a subit 1 attaque, b en subit 3.\n",
+    "af = AF(\n",
+    "    args={\"e\", \"a\", \"b\", \"y\", \"z1\", \"z2\", \"z3\"},\n",
+    "    attacks={(\"y\", \"a\"), (\"z1\", \"b\"), (\"z2\", \"b\"), (\"z3\", \"b\")},\n",
+    ")\n",
+    "print(af)\n",
+    "for x in [\"e\", \"a\", \"b\"]:\n",
+    "    print(f\"  attaquants de {x} : {sorted(af.attackers(x)) or 'aucun'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92dce9c4",
+   "metadata": {},
+   "source": [
+    "## 2. h-Categoriser : un point fixe d'acceptabilité\n",
+    "\n",
+    "L'idée de Besnard & Hunter (2001) : la force d'un argument **décroît** avec la force cumulée de ses\n",
+    "attaquants. Formellement, on cherche un vecteur $\\mathrm{Cat} : \\text{args} \\to (0, 1]$ tel que\n",
+    "\n",
+    "$$\\mathrm{Cat}(a) \\;=\\; \\frac{1}{1 + \\displaystyle\\sum_{b \\,\\to\\, a} \\mathrm{Cat}(b)}.$$\n",
+    "\n",
+    "- Un argument **non attaqué** a une force de $1$ (somme vide au dénominateur).\n",
+    "- Plus ses attaquants sont **nombreux** ou **forts**, plus sa force baisse vers $0$.\n",
+    "\n",
+    "On calcule ce point fixe par **itération** à partir de $\\mathrm{Cat}^{(0)} \\equiv 1$. Pu et al. (2014) ont\n",
+    "prouvé que cette itération **converge** sur tout AF fini (même cyclique)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "174b0bf9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.359462Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.358298Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.372260Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.370820Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Convergence en 2 iterations.\n",
+      "\n",
+      "  Cat(y) = 1.0000\n",
+      "  Cat(z3) = 1.0000\n",
+      "  Cat(z1) = 1.0000\n",
+      "  Cat(e) = 1.0000\n",
+      "  Cat(z2) = 1.0000\n",
+      "  Cat(a) = 0.5000\n",
+      "  Cat(b) = 0.2500\n"
+     ]
+    }
+   ],
+   "source": [
+    "def h_categoriser(af, tol=1e-12, max_iter=10_000):\n",
+    "    \"\"\"Calcule le classement h-Categoriser par iteration de point fixe.\n",
+    "\n",
+    "    Renvoie (cat, n_iter) ou cat[a] in (0, 1] est la force de a (plus grand = plus fort).\n",
+    "    \"\"\"\n",
+    "    cat = {a: 1.0 for a in af.args}\n",
+    "    for it in range(1, max_iter + 1):\n",
+    "        nxt = {a: 1.0 / (1.0 + sum(cat[b] for b in af.attackers(a))) for a in af.args}\n",
+    "        delta = max((abs(nxt[a] - cat[a]) for a in af.args), default=0.0)\n",
+    "        cat = nxt\n",
+    "        if delta < tol:\n",
+    "            return cat, it\n",
+    "    return cat, max_iter\n",
+    "\n",
+    "\n",
+    "cat, n_iter = h_categoriser(af)\n",
+    "print(f\"Convergence en {n_iter} iterations.\\n\")\n",
+    "for a in sorted(af.args, key=lambda a: cat[a], reverse=True):\n",
+    "    print(f\"  Cat({a}) = {cat[a]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a27c51",
+   "metadata": {},
+   "source": [
+    "### Lecture du classement\n",
+    "\n",
+    "Le classement induit (force décroissante) départe finement les arguments :\n",
+    "\n",
+    "- les **non attaqués** (`e`, `y`, `z1`, `z2`, `z3`) sont au sommet à $1{,}0$ ;\n",
+    "- `a`, attaqué une seule fois par `y` (de force $1$), vaut $\\tfrac{1}{1+1} = 0{,}5$ ;\n",
+    "- `b`, attaqué **trois** fois, vaut $\\tfrac{1}{1+3} = 0{,}25$.\n",
+    "\n",
+    "Donc `a` est **strictement mieux classé** que `b`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41a3ded9",
+   "metadata": {},
+   "source": [
+    "## 3. Contraste avec la sémantique fondée de Dung\n",
+    "\n",
+    "Calculons la sémantique **fondée** (grounded) sur le même AF — le plus petit point fixe de la\n",
+    "fonction caractéristique $F(S) = \\{a \\mid S \\text{ défend } a\\}$ (rappel du notebook compagnon)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e8ae785b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.374740Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.374619Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.380619Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.380087Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extension fondee : ['e', 'y', 'z1', 'z2', 'z3']\n",
+      "\n",
+      "  a : statut Dung = OUT  |  force h-Cat = 0.5000\n",
+      "  b : statut Dung = OUT  |  force h-Cat = 0.2500\n"
+     ]
+    }
+   ],
+   "source": [
+    "def grounded_extension(af):\n",
+    "    \"\"\"Plus petit point fixe de la fonction caracteristique (semantique fondee de Dung).\"\"\"\n",
+    "    def defends(S, x):\n",
+    "        return all(any((c, b) in af.attacks for c in S) for b in af.attackers(x))\n",
+    "\n",
+    "    S = set()\n",
+    "    while True:\n",
+    "        nxt = {a for a in af.args if defends(S, a)}\n",
+    "        if nxt == S:\n",
+    "            return S\n",
+    "        S = nxt\n",
+    "\n",
+    "\n",
+    "g = grounded_extension(af)\n",
+    "print(\"Extension fondee :\", sorted(g))\n",
+    "print()\n",
+    "# Statut Dung : IN si dans l'extension, OUT si attaque par l'extension, sinon UNDEC.\n",
+    "def dung_status(af, g, x):\n",
+    "    if x in g:\n",
+    "        return \"IN\"\n",
+    "    if any((c, x) in af.attacks for c in g):\n",
+    "        return \"OUT\"\n",
+    "    return \"UNDEC\"\n",
+    "\n",
+    "for x in [\"a\", \"b\"]:\n",
+    "    print(f\"  {x} : statut Dung = {dung_status(af, g, x)}  |  force h-Cat = {cat[x]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d347c6c",
+   "metadata": {},
+   "source": [
+    "### Le verdict\n",
+    "\n",
+    "`a` et `b` ont **le même statut** dans la sémantique fondée : tous deux **OUT** (rejetés, car attaqués\n",
+    "par des arguments acceptés). Dung ne les distingue pas.\n",
+    "\n",
+    "La sémantique de classement, elle, **les départage** : `a` ($0{,}5$) $\\succ$ `b` ($0{,}25$). C'est\n",
+    "précisément la valeur ajoutée des sémantiques graduées — une granularité que le tout-ou-rien ne capture pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "082f3d7f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.382435Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.382203Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.386004Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.385426Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Meme statut Dung (a, b tous deux OUT) ? True\n",
+      "h-Categoriser les departe (Cat(a) > Cat(b)) ? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verification programmatique du contraste.\n",
+    "print(\"Meme statut Dung (a, b tous deux OUT) ?\",\n",
+    "      dung_status(af, g, \"a\") == dung_status(af, g, \"b\") == \"OUT\")\n",
+    "print(\"h-Categoriser les departe (Cat(a) > Cat(b)) ?\", cat[\"a\"] > cat[\"b\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "332cd6d7",
+   "metadata": {},
+   "source": [
+    "## 4. Sémantique du fardeau (*burden-based*)\n",
+    "\n",
+    "Amgoud & Ben-Naim (2013) proposent une autre construction. On définit une **suite** de nombres de\n",
+    "fardeau, à partir de $\\mathrm{Bur}^{0}(a) = 1$ :\n",
+    "\n",
+    "$$\\mathrm{Bur}^{i}(a) \\;=\\; 1 + \\sum_{b \\,\\to\\, a} \\frac{1}{\\mathrm{Bur}^{i-1}(b)}.$$\n",
+    "\n",
+    "Un fardeau **plus faible** signifie un argument **plus fort**. Le classement compare les\n",
+    "**vecteurs** $\\big(\\mathrm{Bur}^{1}(a), \\mathrm{Bur}^{2}(a), \\dots\\big)$ de façon **lexicographique**\n",
+    "(le premier pas qui les départage tranche)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1f0e1d7b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.387468Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.387297Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.392184Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.391522Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classement par fardeau (du plus fort au plus faible) :\n",
+      "  1. y   -> Bur^1..3 = (1.000, 1.000, 1.000)\n",
+      "  2. z3  -> Bur^1..3 = (1.000, 1.000, 1.000)\n",
+      "  3. z1  -> Bur^1..3 = (1.000, 1.000, 1.000)\n",
+      "  4. e   -> Bur^1..3 = (1.000, 1.000, 1.000)\n",
+      "  5. z2  -> Bur^1..3 = (1.000, 1.000, 1.000)\n",
+      "  6. a   -> Bur^1..3 = (2.000, 2.000, 2.000)\n",
+      "  7. b   -> Bur^1..3 = (4.000, 4.000, 4.000)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def burden_numbers(af, steps=8):\n",
+    "    \"\"\"Renvoie {a: (Bur^1, ..., Bur^steps)} (Bur^0 = 1 pour tous).\"\"\"\n",
+    "    bur = {a: 1.0 for a in af.args}\n",
+    "    seq = {a: [] for a in af.args}\n",
+    "    for _ in range(steps):\n",
+    "        nxt = {a: 1.0 + sum(1.0 / bur[b] for b in af.attackers(a)) for a in af.args}\n",
+    "        for a in af.args:\n",
+    "            seq[a].append(nxt[a])\n",
+    "        bur = nxt\n",
+    "    return {a: tuple(seq[a]) for a in af.args}\n",
+    "\n",
+    "\n",
+    "def burden_rank(af, steps=8):\n",
+    "    \"\"\"Classement par fardeau : fardeau lexicographiquement plus petit = plus fort.\"\"\"\n",
+    "    bn = burden_numbers(af, steps)\n",
+    "    return sorted(af.args, key=lambda a: bn[a]), bn\n",
+    "\n",
+    "\n",
+    "order, bn = burden_rank(af)\n",
+    "print(\"Classement par fardeau (du plus fort au plus faible) :\")\n",
+    "for rank, a in enumerate(order, 1):\n",
+    "    print(f\"  {rank}. {a:3} -> Bur^1..3 = ({bn[a][0]:.3f}, {bn[a][1]:.3f}, {bn[a][2]:.3f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72f47e71",
+   "metadata": {},
+   "source": [
+    "### Accord des deux méthodes\n",
+    "\n",
+    "Sur cet AF, fardeau et h-Categoriser s'accordent sur l'essentiel : `a` reste mieux classé que `b`,\n",
+    "et les non-attaqués dominent. Les deux familles satisfont des **principes** communs (Amgoud & Ben-Naim) :\n",
+    "\n",
+    "- **Abstraction** : le classement ne dépend que de la structure du graphe (renommer les arguments ne change rien).\n",
+    "- **Indépendance** : des composantes non connectées du graphe n'interfèrent pas.\n",
+    "- **Contre-transitivité** : *plus d'attaquants (ou des attaquants plus forts) ⇒ plus faible.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "257f835e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.394615Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.394449Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.397541Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.397135Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "h-Cat : a avant b ? True\n",
+      "Fardeau : a avant b ? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Les deux methodes s'accordent sur a > b.\n",
+    "hcat_order = sorted(af.args, key=lambda a: cat[a], reverse=True)\n",
+    "print(\"h-Cat : a avant b ?\", hcat_order.index(\"a\") < hcat_order.index(\"b\"))\n",
+    "print(\"Fardeau : a avant b ?\", order.index(\"a\") < order.index(\"b\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03913705",
+   "metadata": {},
+   "source": [
+    "## 5. Le cas cyclique : convergence garantie\n",
+    "\n",
+    "Sur un cycle $a \\leftrightarrow b$, le tout-ou-rien de Dung laisse les deux arguments **indécidés**\n",
+    "(UNDEC). h-Categoriser, lui, converge vers une valeur **finie** identique pour les deux, solution de\n",
+    "$x = \\tfrac{1}{1+x}$, soit le nombre d'or inverse $\\tfrac{\\sqrt{5}-1}{2} \\approx 0{,}618$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f04ed499",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.398729Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.398583Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.402165Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.401729Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF cyclique a<->b : convergence en 29 iterations.\n",
+      "  Cat(a) = 0.618034, Cat(b) = 0.618034\n",
+      "  Valeur theorique (sqrt(5)-1)/2 = 0.618034\n",
+      "  Statut Dung (fonde) des deux : UNDEC (extension fondee = vide )\n"
+     ]
+    }
+   ],
+   "source": [
+    "af_cycle = AF({\"a\", \"b\"}, {(\"a\", \"b\"), (\"b\", \"a\")})\n",
+    "cat_cyc, it_cyc = h_categoriser(af_cycle)\n",
+    "phi_inv = (5 ** 0.5 - 1) / 2\n",
+    "print(f\"AF cyclique a<->b : convergence en {it_cyc} iterations.\")\n",
+    "print(f\"  Cat(a) = {cat_cyc['a']:.6f}, Cat(b) = {cat_cyc['b']:.6f}\")\n",
+    "print(f\"  Valeur theorique (sqrt(5)-1)/2 = {phi_inv:.6f}\")\n",
+    "print(\"  Statut Dung (fonde) des deux : UNDEC (extension fondee =\",\n",
+    "      sorted(grounded_extension(af_cycle)) or \"vide\", \")\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "602531ba",
+   "metadata": {},
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "> Les cellules ci-dessous sont des **squelettes à compléter**. Le notebook s'exécute de bout en bout\n",
+    "> même si vous ne les complétez pas (elles renvoient `None` par défaut)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6faa832e",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Départage strict\n",
+    "\n",
+    "Complétez `is_strictly_stronger(cat, a, b)` : renvoyer `True` si `a` est **strictement** mieux classé\n",
+    "que `b` selon le vecteur `cat` de h-Categoriser, `False` sinon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2ff9970c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.403383Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.403231Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.406349Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.405911Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a strictement > b ? None\n",
+      "b strictement > a ? None\n"
+     ]
+    }
+   ],
+   "source": [
+    "def is_strictly_stronger(cat, a, b):\n",
+    "    # TODO : comparer cat[a] et cat[b]\n",
+    "    # Indice : \"strictement mieux classe\" = force strictement superieure.\n",
+    "    return None  # remplacez par votre comparaison\n",
+    "\n",
+    "\n",
+    "# Test attendu (une fois complete) : True, puis False.\n",
+    "print(\"a strictement > b ?\", is_strictly_stronger(cat, \"a\", \"b\"))\n",
+    "print(\"b strictement > a ?\", is_strictly_stronger(cat, \"b\", \"a\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4301b3ac",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Construire un cas de départage\n",
+    "\n",
+    "Définissez un AF `af_ex2` à **4 arguments** dans lequel h-Categoriser **départage** deux arguments que\n",
+    "la sémantique fondée déclare tous deux rejetés (OUT).\n",
+    "\n",
+    "*Indice : reprenez le motif de la section 3 — un argument attaqué une fois, un autre attaqué deux fois,\n",
+    "par des arguments non attaqués.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "50919e28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.407491Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.407353Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.410255Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.409868Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO : construire af_ex2 = AF({...}, {...})\n",
+    "af_ex2 = None  # remplacez par votre cadre\n",
+    "\n",
+    "if af_ex2 is not None:\n",
+    "    c2, _ = h_categoriser(af_ex2)\n",
+    "    print(\"Forces h-Cat :\", {a: round(v, 3) for a, v in c2.items()})\n",
+    "else:\n",
+    "    print(\"Exercice 2 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "624197bd",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Détecter la convergence du fardeau\n",
+    "\n",
+    "Complétez `burden_converged(af, steps, tol)` : renvoyer `True` si, sur l'AF donné, le **dernier** pas\n",
+    "de la suite de fardeau ne diffère du précédent que de moins de `tol` pour **tous** les arguments.\n",
+    "\n",
+    "*Indice : `burden_numbers(af, steps)` renvoie les vecteurs ; comparez les deux dernières composantes.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "66a0121b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-28T23:28:05.411622Z",
+     "iopub.status.busy": "2026-06-28T23:28:05.411521Z",
+     "iopub.status.idle": "2026-06-28T23:28:05.414172Z",
+     "shell.execute_reply": "2026-06-28T23:28:05.413744Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fardeau convergent sur l'AF fil rouge ? None\n"
+     ]
+    }
+   ],
+   "source": [
+    "def burden_converged(af, steps=8, tol=1e-6):\n",
+    "    # TODO : comparer les deux derniers pas de chaque vecteur de fardeau\n",
+    "    # bn = burden_numbers(af, steps) ; bn[a] est un tuple de longueur steps.\n",
+    "    return None  # remplacez par votre test de convergence\n",
+    "\n",
+    "\n",
+    "print(\"Fardeau convergent sur l'AF fil rouge ?\", burden_converged(af))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83eda8c1",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "- Les sémantiques **de classement** raffinent le tout-ou-rien de Dung en attribuant une **force\n",
+    "  numérique** à chaque argument, ce qui **départage** des arguments de même statut.\n",
+    "- **h-Categoriser** ($\\mathrm{Cat}(a) = 1/(1+\\sum_{b\\to a}\\mathrm{Cat}(b))$) est un point fixe qui\n",
+    "  **converge** sur tout AF fini, y compris cyclique.\n",
+    "- La sémantique du **fardeau** classe par comparaison **lexicographique** d'une suite de nombres.\n",
+    "- Les deux respectent des **principes** structurels (abstraction, indépendance, contre-transitivité).\n",
+    "\n",
+    "Pour aller plus loin : la bibliothèque **Tweety** (`org.tweetyproject.arg.rankings`) implémente ces\n",
+    "sémantiques et bien d'autres (Categoriser, Burden, Discussion-based, Tuples\\*, Matt & Toni). Voir aussi\n",
+    "le notebook compagnon [`Argument_Analysis_Dung_AF_Semantics`](Argument_Analysis_Dung_AF_Semantics.ipynb)\n",
+    "pour les sémantiques d'extension.\n",
+    "\n",
+    "**Références.**\n",
+    "- P. Besnard, A. Hunter (2001). *A logic-based theory of deductive arguments*. Artificial Intelligence.\n",
+    "- L. Amgoud, J. Ben-Naim (2013). *Ranking-based semantics for argumentation frameworks*. SUM.\n",
+    "- F. Pu, J. Luo, Y. Zhang, G. Luo (2014). *Argument ranking with categoriser function*. KSEM (convergence).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -54,6 +54,7 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | 4 | [Agentic-4-capstone](Argument_Analysis_Agentic-4-capstone.ipynb) | Capstone : baseline 0-shot vs pipeline intégral, verdicts convergents + value-gates VG-1..VG-4 | Intégration |
 | 5 | [Agentic-5-jtms](Argument_Analysis_Agentic-5-jtms.ipynb) | Truth Maintenance System déterministe (Doyle 1979) : étiquetage IN/OUT, cascade de rétractation, détection d'odd loops — pur stdlib Python | Raisonnement non-monotone |
 | Dung | [Dung_AF_Semantics](Argument_Analysis_Dung_AF_Semantics.ipynb) | Sémantiques grounded / preferred / stable reconstruites de zéro en pur Python (cas canonique où les trois divergent) | Fondation argumentation abstraite |
+| Rank | [Ranking_Semantics](Argument_Analysis_Ranking_Semantics.ipynb) | Sémantiques de classement (h-Categoriser, fardeau) en pur Python : force numérique départageant des arguments de même statut Dung | Argumentation graduée |
 | UI | [UI_configuration](Argument_Analysis_UI_configuration.ipynb) | Interface utilisateur widgets | Interaction |
 | Exec | [Executor](Argument_Analysis_Executor.ipynb) | Orchestrateur principal | Exécution |
 
@@ -69,6 +70,7 @@ Le contexte de recherche actuel rend cette compétence particulièrement pertine
 | **3-orchestration** | Composer les agents précédents en pipeline coordonné avec rapport de sortie structuré | 50 min |
 | **5-jtms** | Construire un moteur de croyances non-monotones (étiquetage IN/OUT, cascade de rétractation, détection d'odd loops) en pur stdlib Python, sans LLM ni solveur externe | 40 min |
 | **Dung_AF_Semantics** | Reconstruire les sémantiques grounded, preferred et stable de l'argumentation abstraite de Dung de zéro en pur Python (sans JVM) sur un cas où les trois divergent | 35 min |
+| **Ranking_Semantics** | Calculer la *force* numérique d'un argument (h-Categoriser par point fixe, fardeau par comparaison lexicographique) et départager des arguments que Dung déclare indistinctement rejetés — pur stdlib Python | 35 min |
 | **UI_configuration** | Créer une interface interactive (ipywidgets) pour piloter le pipeline en mode exploratoire | 30 min |
 | **Executor** | Exécuter le pipeline complet en mode batch (Papermill/MCP) avec configuration .env | 20 min |
 
@@ -264,6 +266,7 @@ Le pipeline mobilise un vocabulaire issu de trois traditions — la rhétorique 
 | **Logique du premier ordre (FOL)** | PL étendue des quantificateurs (∀, ∃) et prédicats. Exige une *signature* déclarée (constantes, prédicats) avant toute requête. | 2-formal §4 |
 | **Logique modale** | Logique du *possible* (◇) et du *nécessaire* (□), utile pour les arguments portant sur la contingence ou l'obligation. | 2-formal §5 |
 | **Argumentation de Dung** | Cadre abstrait où les arguments s'attaquent mutuellement ; la sémantique *grounded* calcule l'ensemble des arguments défendables. Les sémantiques *preferred* et *stable* étendent ce verdict sous différentes attitudes (crédule, auto-suffisante). | Dung_AF_Semantics, 2-formal §6 |
+| **Sémantique de classement** | Approche *graduée* : au lieu d'un verdict tout-ou-rien, chaque argument reçoit une *force* numérique (h-Categoriser, fardeau) qui induit un ordre — départageant des arguments de même statut Dung. | Ranking_Semantics |
 | **Belief set** | Ensemble de formules formalisant l'état de croyance déduit du texte ; c'est ce que le solveur manipule et interroge. | 2-formal |
 | **SAT** | Problème de satisfaisabilité : existe-t-il une valuation rendant un ensemble de formules cohérent ? Cœur de la validation Tweety. | 2-formal |
 | **Fail-loud** | Principe de conception : le pipeline échoue bruyamment plutôt que de *simuler* un verdict (jamais de sortie fictive si la JVM ou le solveur manque). | 2-formal |
@@ -318,6 +321,8 @@ Le titre annonce l'analyse d'arguments. Mais le geste que cette série enseigne 
 | Modgil & Prakken, "The ASPIC+ Framework for Structured Argumentation" (2014) | Argumentation structurée |
 | Alchourron, Gardenfors & Makinson, "On the Logic of Theory Change" (1985) | Révision de croyances AGM |
 | Besnard & Hunter, *Elements of Argumentation* (2008) | Cadre général argumentation |
+| Besnard & Hunter, "A logic-based theory of deductive arguments" (2001) | Fonction h-Categoriser (classement) |
+| Amgoud & Ben-Naim, "Ranking-based semantics for argumentation frameworks" (2013) | Sémantique du fardeau, principes de classement |
 | Walton, *Argumentation Schemes for Presumptive Reasoning* (1996) | Taxonomie des sophismes |
 
 ### Ressources en ligne


### PR DESCRIPTION
## Résumé

Nouveau notebook **`Argument_Analysis_Ranking_Semantics.ipynb`** : les sémantiques **de classement** (*ranking-based / gradual*), complément du notebook compagnon `Dung_AF_Semantics` (sémantiques d'extension). Là où Dung répond *oui/non* (un argument est dans une extension ou non), les sémantiques graduées attribuent une **force numérique** et **départagent** des arguments de même statut.

Pur **stdlib Python**, déterministe, réutilise le modèle `AF` du notebook Dung.

## Contenu pédagogique (FR)

- **h-Categoriser** (Besnard & Hunter 2001) : point fixe `Cat(a) = 1/(1+Σ Cat(attaquants))`, convergence prouvée (Pu et al. 2014). Inclut le cas cyclique `a↔b` → nombre d'or inverse `(√5−1)/2 ≈ 0.618`.
- **Sémantique du fardeau** (Amgoud & Ben-Naim 2013) : suite `Bur^i` comparée lexicographiquement.
- **Contraste explicite avec Dung (grounded)** : sur le même AF, `a` et `b` sont tous deux **OUT** (rejetés), mais le classement les départage (`Cat(a)=0.5 > Cat(b)=0.25` ; fardeau `a=2.0 < b=4.0`).
- **3 exercices** stubs conformes C.1 (`return None` / `af_ex2 = None`, jamais `NotImplementedError`).

## Validation

- Exécuté de bout en bout via `nbconvert` (kernel `python3`) : **0 erreur, 0 `execution_count` null**, outputs réels (C.2).
- Valeurs vérifiées : h-Cat (a=0.5, b=0.25), fardeau (a=2.0, b=4.0), cycle = 0.618034 (= théorie), Dung (a/b OUT, départagés).
- README : notebook ajouté aux tables (Notebooks, "Ce que chaque notebook apporte", Concepts clés) + 2 références académiques. **Marqueurs `CATALOG-STATUS` inchangés** (régén par cron/CI, cf catalog-pr-hygiene).
- Branche fraîche depuis `origin/main`. Aucun fichier de catalogue touché. Submodules SMT/Automata + SMT/Z3.Linq **non stagés**.

See #2137

🤖 Generated with [Claude Code](https://claude.com/claude-code)