### PR TITLE
docs(infer): Infer-22 constellation bridge -- PyMC-22 cross-ref + 3-paradigm causal map

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-22-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-22-Causal-Inference.ipynb
@@ -27,7 +27,7 @@
     "|-----------|---------|\n",
     "| [Infer-21-Thompson-Sampling](Infer-21-Thompson-Sampling.ipynb) | (fin de la serie) |\n",
     "\n",
-    "> **Pont inter-series** : le traitement causal **symbolique** (Java/Tweety, raisonneur contrefactuel propositionnel) est dans [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb). Le jumeau **Python/PyMC** (demo `P(Cloudy|do(Rain))`) est dans [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb). Ce notebook en est le versant **probabiliste distributionnel** : les effets causaux sont **calcules** par le moteur d'inference Infer.NET, pas seulement declares.\n"
+    "> **Pont inter-series (constellation causale)** : le do-calculus de Pearl se decline en **trois paradigmes** dans ce depot, et ce notebook en est le versant **probabiliste distributionnel** (.NET/Infer.NET) -- les effets causaux y sont **calcules** par mutilation de graphe. Le jumeau **Python/PyMC** porte les memes exemples (barometre, Sprinkler) via l'operateur natif `pm.do` : voir [PyMC-22-Causal-Inference](../PyMC/PyMC-22-Causal-Inference.ipynb), ainsi que la demo historique `P(Cloudy|do(Rain))` dans [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb). Enfin, le traitement **symbolique** (Java/Tweety, raisonneur contrefactuel propositionnel) est dans [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb). La section **Constellation causale** en fin de notebook cartographie ces trois implementations.\n"
    ]
   },
   {
@@ -1512,6 +1512,33 @@
     "// Etape 2 : coder des CPT produisant un renversement\n",
     "// Etape 3 : montrer P(Y|X) agrege != P(Y|do(X)) et expliquer le mecanisme\n",
     "Console.WriteLine(\"Exercice 4 a completer : concevoir un paradoxe de Simpson (renversement agrege vs conditionnel).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "infer22-constell-bridge",
+   "metadata": {},
+   "source": [
+    "## Constellation causale -- le do-calculus en trois paradigmes\n",
+    "\n",
+    "Le do-calculus de Pearl (1995, 2000) est un **calcul formel independant du langage** : les trois regles d'identification d'un effet causal ne dependent pas de l'implementation. Ce depot le met en oeuvre dans **trois paradigmes** distincts, qui choisissent chacun ce qu'ils **calculent** versus ce sur quoi ils **raisonnent**.\n",
+    "\n",
+    "| Paradigme | Moteur / langage | Idiome du `do(X)` | Notebook | Ce qu'il apporte |\n",
+    "|-----------|------------------|-------------------|----------|------------------|\n",
+    "| **Probabiliste distributionnel** | Infer.NET (C#) | **Mutilation de graphe** : `Variable.Bernoulli(1.0)` force la valeur et coupe l'arc parent | ce notebook | Effet causal **calcule** par inférence exacte (EP/VMP) sur le graphe mutile |\n",
+    "| **Probabiliste (transformation)** | PyMC (Python) | Operateur natif `pm.do` : l'intervention est une **transformation de modele de premiere classe** | [PyMC-22](../PyMC/PyMC-22-Causal-Inference.ipynb) | `do` rebranche comme un operateur du langage probabiliste |\n",
+    "| **Symbolique propositionnel** | Tweety (Java) | **Raisonneur contrefactuel** : logique classique, preuves argumentatives (pas de probabilites) | [Tweety-11](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | Raisonnement **qualitatif** : \"X cause-t-il Y ?\" sans chiffres |\n",
+    "\n",
+    "**Valeurs croisees (verification inter-paradigme).** Sur le **meme** exemple du barometre (confondeur `BassePression -> {Barometre, Storm}`), les deux versants probabilistes **recoupent** exactement :\n",
+    "\n",
+    "| Quantite | Infer.NET (ce notebook, sec 3) | PyMC-22 |\n",
+    "|----------|-------------------------------|---------|\n",
+    "| `P(Storm | Barometre baisse)` (observation) | **0,656** | **0,656** |\n",
+    "| `P(Storm | do(Barometre baisse))` (intervention) | **0,310** | **0,310** |\n",
+    "\n",
+    "L'effondrement de la correlation (`0,656 -> 0,310`) lorsqu'on passe de l'observation a l'intervention est le **signal que le moteur fait un vrai travail causal** (mutilation, pas une simple lecture de CPT) -- et les deux moteurs, malgre leurs idiomes differents (mutilation Infer.NET vs `pm.do` PyMC), convergent vers les memes valeurs. Sur le reseau Sprinkler, `P(Cloudy|Rain)=0,800` vs `P(Cloudy|do(Rain))=0,500` (sec 4 ici, et [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) sec 8).\n",
+    "\n",
+    "**Ce qu'il faut retenir.** Trois implementations, **un seul do-calculus**. Le paradigme Infer.NET met l'accent sur la **structure** (mutiler le graphe = une operation que le moteur d'inference execute) ; PyMC met l'accent sur la **composabilite** (`do` comme transformation de modele) ; Tweety met l'accent sur le **raisonnement** (causalite sans nombres). Choisir l'un ou l'autre, c'est choisir ce que l'on veut : des probabilites exactes, du sampling flexible, ou des preuves qualitatives."
    ]
   },
   {


### PR DESCRIPTION
## Contexte

**Mandat user bridge** (via dispatch ai-01 `ta9xvo`/`yp0oq4`) : Infer-22 est l'**anchor .NET** d'une constellation de séries causales que le user veut bridger autour du do-calculus de Pearl. La constellation a **évolué** depuis la création du notebook : `PyMC-22-Causal-Inference` (PR #4593, le jumeau Python dédié portant les mêmes exemples via `pm.do` natif) était absent du « Pont inter-series » (seuls Tweety-11 + PyMC-4 y figuraient).

## Reframing (Règle 5.2 — grounding firsthand)

Le notebook était **déjà saturé en contenu causal** : `do()` §3.2 (mutilation `Bernoulli(1.0)`), échelle de causation §1/§3/§9, backdoor §5, Prong-B `obs 0,656 ≠ do 0,310`. Ajouter un 2e exemple `do()` ou exercice ladder = **doublon**. Le grain réel non-doublon **est le mandat bridge lui-même** : cartographier les 3 paradigmes.

## Changements (NOTEBOOK uniquement — `.ipynb`)

Collision-avoidance HARD respectée : moi = `.ipynb` ; po-2025:CoursIA = README Infer-22 « Ponts causaux ». Fichiers disjoints.

- **Cell 0** : « Pont inter-series » enrichi → nomme les 3 paradigmes + forward-ref de la nouvelle section Constellation (PyMC-22 ajouté).
- **Nouvelle cellule markdown** « Constellation causale — le do-calculus en trois paradigmes » insérée avant §11 Synthèse :
  - Tableau comparatif Infer.NET (mutilation de graphe) / PyMC (`pm.do` natif) / Tweety (symbolique propositionnel) — idiome, notebook, apport.
  - **Vérification inter-paradigme** : baromètre `P(Storm|Baro)=0,656` vs `P(Storm|do(Baro))=0,310` IDENTIQUES entre Infer.NET (§3) et PyMC-22 — preuve que les deux moteurs convergent malgré des idiomes différents. Sprinkler `0,800/0,500` (§4 + PyMC-4 §8).
  - Takeaway : trois implémentations, un seul do-calculus.

## Validation

- **C.2/C.3 exception markdown** : comparaison cross-langage pas exécutable en Infer.NET → pas de re-exec, outputs précédents valides (cellules code exec_count 1..14 + outputs **intacts**, non touchés).
- 31 cellules (14 code + 17 md), JSON valide, `source` préservé comme list (**diff minimal +29/-2**, zéro churn format).
- Liens relatifs vérifiés sur `origin/main` : PyMC-22 ✓, PyMC-4 ✓, Tweety-11 ✓.
- Catalogue byte-identique, submodule `c8504182` intact, base fraîche `origin/main`.

## Verdict SOTA (#3801)

**SOTA-OK.** Le moteur Infer.NET était déjà le vrai solveur probabiliste ; cette PR ajoute de la prose pédagogique de bridge, **aucun workaround, aucune sortie dégradée**. Pas de Prong-B (pas un nouveau problème de solveur).

See #4208 (partial — bridge éditorial, l'Epic reste ouvert).