### PR TITLE
feat(ict): CE 2.0 toolkit -- causal_emergence + tpm_estimation modules (See #4588)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ict/__init__.py
@@ -13,5 +13,11 @@ Premier jalon livre : le modele de morphogenese minimale par tri auto-organise
 
 from .self_sorting import Cell, Probe, SelfSortingArray, ALGOTYPES
 from . import sorting_metrics
+from . import trajectories
+from . import causal_emergence
+from . import tpm_estimation
 
-__all__ = ["Cell", "Probe", "SelfSortingArray", "ALGOTYPES", "sorting_metrics"]
+__all__ = [
+    "Cell", "Probe", "SelfSortingArray", "ALGOTYPES",
+    "sorting_metrics", "trajectories", "causal_emergence", "tpm_estimation",
+]

--- a/MyIA.AI.Notebooks/IIT/ict/causal_emergence.py
+++ b/MyIA.AI.Notebooks/IIT/ict/causal_emergence.py
@@ -1,0 +1,348 @@
+"""Causal Emergence 2.0 : quantifier la complexite emergente multi-echelles.
+
+Reimplementation pedagogique inspiree de :
+
+    Erik Hoel, "Causal Emergence 2.0: Quantifying emergent complexity",
+    arXiv:2503.13395, 2025.
+
+ainsi que de la construction canonique de macro-echelle (coarse-graining sous
+intervention) de :
+
+    Hoel, Albantakis & Tononi, "Quantifying causal emergence shows that macro
+    can beat micro", PNAS 2013 ;
+    Erik Hoel, "When the map is better than the territory", Entropy 2017.
+
+Note de provenance / licence
+----------------------------
+Le depot de reference https://github.com/jessescool/Causal-Emergence-2.0
+(implementation accompagnant l'article) ne porte AUCUNE licence : son code
+n'est donc pas reutilisable. Ce module est une reimplementation INDEPENDANTE,
+ecrite a partir des equations de l'article et de la litterature canonique de
+l'emergence causale (et non a partir de ce code). Le depot est cite ici comme
+implementation de reference, a des fins de comparaison pedagogique uniquement.
+
+Place dans la serie ICT
+-----------------------
+La serie ICT est passee de la *photographie* (Phi a un instant, ICT-1) au
+*film* (trajectoires causales, ICT-2/3) puis a l'emergence causale canonique
+par coarse-graining maximisant une mesure causale (ICT-5, via ``pyphi.macro``).
+Le present module apporte l'outillage *moderne* du second pilier de la serie :
+au lieu de chercher l'unique macro-echelle qui maximise une mesure causale, on
+**apportionne** la causalite le long d'un *chemin* d'echelles (micro -> macro)
+et l'on mesure a quel point le travail causal d'un systeme est *distribue*
+entre ses echelles -- la "complexite emergente" EC de l'article.
+
+Contrairement a PyPhi (limite en pratique a ~6 noeuds), ce module n'opere que
+sur une matrice de transition etat-a-etat (n x n, numpy) : il passe donc a
+l'echelle sur des systemes que PyPhi ne peut pas traiter (interet direct pour
+ICT-6, ou l'on branche les trajectoires de tri-morphogenese d'ICT-2 via
+``ict.tpm_estimation``).
+
+Format des TPM
+--------------
+Ici une TPM est une matrice **etat-a-etat** ``(n, n)``, ligne-stochastique :
+``tpm[i, j]`` = P(etat suivant = j | etat courant = i). C'est le format naturel
+d'une chaine de Markov sur n macro-etats, distinct du format state-by-node de
+PyPhi utilise par ``ict.trajectories`` (voir ``ict.tpm_estimation`` pour le
+pont entre les deux representations).
+
+Definitions (article + litterature canonique)
+----------------------------------------------
+Sous une intervention uniforme sur les n etats (le ``do`` de Hoel) :
+  - determinisme (suffisance)   : det = 1 - <H(E|c)> / log2(n)
+  - degenerescence              : deg = 1 - H(E|C) / log2(n)
+  - specificite (necessite)     : spec = 1 - deg
+  - effectiveness (normalisee)  : eff = det - deg                  (dans [0, 1])
+  - information effective (bits): EI  = eff * log2(n)
+ou E|c est la ligne de la TPM pour l'etat-cause c, et E|C la distribution
+d'effet marginale (moyenne des lignes sous intervention uniforme).
+
+Dependances : bibliotheque standard + numpy.
+Reference : ICT-0 (cadrage de la serie), Epic #4588.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+
+
+# --------------------------------------------------------------- validation
+def validate_tpm(tpm, tol: float = 1e-6) -> np.ndarray:
+    """Verifie qu'une matrice est une TPM etat-a-etat valide et la retourne.
+
+    Conditions : carree ``(n, n)``, sans valeur negative, chaque ligne sommant
+    a 1 (a ``tol`` pres). Leve ``ValueError`` sinon.
+    """
+    m = np.asarray(tpm, dtype=float)
+    if m.ndim != 2 or m.shape[0] != m.shape[1]:
+        raise ValueError(f"TPM doit etre carree (n, n), recu {m.shape}")
+    if np.any(m < -tol):
+        raise ValueError("TPM contient des probabilites negatives")
+    sums = m.sum(axis=1)
+    if not np.allclose(sums, 1.0, atol=max(tol, 1e-9)):
+        raise ValueError(f"lignes non normalisees a 1 : sommes = {sums}")
+    return m
+
+
+# --------------------------------------------------------------- entropie
+def _entropy_bits(p) -> float:
+    """Entropie de Shannon en bits d'une distribution, avec 0*log2(0) = 0."""
+    p = np.asarray(p, dtype=float)
+    nz = p[p > 0]
+    if nz.size == 0:
+        return 0.0
+    return float(-np.sum(nz * np.log2(nz)))
+
+
+# --------------------------------------------------------------- primitives causales
+def determinism(tpm) -> float:
+    """Determinisme (suffisance) : ``1 - <H(E|c)> / log2(n)``.
+
+    Mesure a quel point chaque etat-cause determine son effet : 1.0 si chaque
+    ligne de la TPM est un Dirac (transition certaine), plus bas si les
+    transitions sont bruitees. La moyenne est prise sous intervention uniforme.
+    """
+    m = validate_tpm(tpm)
+    n = m.shape[0]
+    if n < 2:
+        return 1.0
+    mean_row_entropy = float(np.mean([_entropy_bits(m[i]) for i in range(n)]))
+    return 1.0 - mean_row_entropy / np.log2(n)
+
+
+def degeneracy(tpm) -> float:
+    """Degenerescence : ``1 - H(E|C) / log2(n)``.
+
+    ``E|C`` est la distribution d'effet *marginale* sous intervention uniforme
+    (moyenne des lignes de la TPM). Elevee quand des causes differentes
+    convergent vers les memes effets (l'effet renseigne peu sur la cause).
+    """
+    m = validate_tpm(tpm)
+    n = m.shape[0]
+    if n < 2:
+        return 0.0
+    marginal = m.mean(axis=0)
+    return 1.0 - _entropy_bits(marginal) / np.log2(n)
+
+
+def specificity(tpm) -> float:
+    """Specificite (necessite) : ``1 - degeneracy``. Voir ``degeneracy``."""
+    return 1.0 - degeneracy(tpm)
+
+
+def effectiveness(tpm) -> float:
+    """Effectiveness normalisee : ``determinism - degeneracy`` (dans [0, 1]).
+
+    Quantite causale *scale-free* (independante du nombre d'etats) : c'est la
+    primitive naturellement apportionnee le long d'un chemin d'echelles, car
+    elle n'est pas penalisee par le retrecissement de ``log2(n)`` au
+    coarse-graining (contrairement a l'EI en bits).
+    """
+    m = validate_tpm(tpm)
+    return determinism(m) - degeneracy(m)
+
+
+def effective_information(tpm) -> float:
+    """Information effective ``EI = effectiveness * log2(n)`` (en bits).
+
+    Mesure causale canonique (Hoel/Tononi) : equivaut a la divergence KL
+    moyenne entre la ligne de chaque etat et la distribution d'effet marginale,
+    sous intervention uniforme (``EI = H(E|C) - <H(E|c)>``).
+    """
+    m = validate_tpm(tpm)
+    n = m.shape[0]
+    if n < 2:
+        return 0.0
+    return effectiveness(m) * np.log2(n)
+
+
+def causal_profile(tpm) -> dict:
+    """Profil causal complet d'une TPM (toutes les primitives de l'article)."""
+    m = validate_tpm(tpm)
+    n = int(m.shape[0])
+    det = determinism(m)
+    deg = degeneracy(m)
+    eff = det - deg
+    return {
+        "n": n,
+        "determinism": det,
+        "degeneracy": deg,
+        "specificity": 1.0 - deg,
+        "effectiveness": eff,
+        "effective_information": eff * np.log2(n) if n > 1 else 0.0,
+    }
+
+
+# --------------------------------------------------------------- coarse-graining
+def initial_labels(n: int) -> list:
+    """Etiquettes initiales : chaque macro-etat contient un seul micro-etat."""
+    return [(k,) for k in range(n)]
+
+
+def merge_labels(labels: list, i: int, j: int) -> list:
+    """Met a jour les etiquettes apres fusion des positions ``i`` et ``j``.
+
+    Le macro-etat resultant herite des deux ensembles de micro-etats ; il prend
+    la position ``min(i, j)``, l'autre position est retiree.
+    """
+    a, b = sorted((i, j))
+    new = list(labels)
+    new[a] = tuple(sorted(set(new[a]) | set(new[b])))
+    del new[b]
+    return new
+
+
+def merge_states(tpm, i: int, j: int) -> np.ndarray:
+    """Fusionne les etats ``i`` et ``j`` en un macro-etat (coarse-graining).
+
+    Construction canonique de l'emergence causale (Hoel 2013) sous intervention
+    uniforme :
+
+      1. fusion des COLONNES : la probabilite d'arriver dans le macro-etat est
+         la SOMME des colonnes des deux micro-etats (arriver dans ``i`` OU dans
+         ``j``) ;
+      2. fusion des LIGNES : l'effet du macro-etat est la MOYENNE des lignes des
+         deux micro-etats (l'intervention sur le macro tire uniformement parmi
+         ses micro-constituants) ;
+      3. renormalisation defensive des lignes.
+
+    Retourne une TPM ``(n-1, n-1)``. Le macro-etat occupe la position
+    ``min(i, j)``.
+    """
+    m = validate_tpm(tpm)
+    n = m.shape[0]
+    if not (0 <= i < n and 0 <= j < n) or i == j:
+        raise ValueError(f"indices invalides pour fusion : i={i}, j={j}, n={n}")
+    a, b = sorted((i, j))
+    # 1) fusion des colonnes : P(arriver dans le macro) = P(->a) + P(->b)
+    cols = m.copy()
+    cols[:, a] = m[:, a] + m[:, b]
+    cols = np.delete(cols, b, axis=1)
+    # 2) fusion des lignes : effet du macro = moyenne des deux micro-effets
+    cols[a] = 0.5 * (cols[a] + cols[b])
+    macro = np.delete(cols, b, axis=0)
+    # 3) renormalisation defensive (les lignes doivent deja sommer a 1)
+    row_sums = macro.sum(axis=1, keepdims=True)
+    row_sums[row_sums == 0] = 1.0
+    return macro / row_sums
+
+
+# --------------------------------------------------------------- apportionment glouton
+def greedy_apportionment(tpm, primitive: Callable = effectiveness,
+                         eps: float = 1e-9) -> dict:
+    """Construit un chemin d'echelles micro -> macro par fusion gloutonne.
+
+    A chaque pas, on essaie toutes les fusions de paires d'etats et l'on retient
+    celle qui MAXIMISE la primitive causale (``effectiveness`` par defaut) a
+    l'echelle plus grossiere. On enregistre la valeur de la primitive et le gain
+    ``delta_cp`` par rapport a l'echelle precedente. On s'arrete des qu'aucune
+    fusion n'ameliore la primitive (gain < ``eps``), ou qu'il ne reste qu'un
+    etat.
+
+    NB methodologique (honnete). L'article construit la trajectoire d'echelles
+    valides de facon plus rigoureuse (recherche d'un point d'arrivee a gain
+    total maximal, puis plus long chemin consistant). La variante GLOUTONNE
+    implementee ici est la forme pratique usuelle ; elle ne garantit PAS
+    l'optimalite globale du chemin. La primitive par defaut est l'effectiveness
+    normalisee (la grandeur "scale-free" derriere les primitives causales de
+    l'article), et non l'EI en bits qui, penalisee par ``log2(n)``, masque
+    souvent l'emergence sous coarse-graining.
+
+    Retourne un dict :
+      - ``scales`` : liste de pas, chacun ``{size, value, determinism,
+        specificity, effectiveness, effective_information, labels, merged,
+        delta_cp}``. Le premier pas est la micro-echelle (``merged`` et
+        ``delta_cp`` valent None) ;
+      - ``deltas`` : liste des ``delta_cp`` positifs le long du chemin ;
+      - ``emergent_complexity`` : EC calculee sur ``deltas`` (cf
+        ``emergent_complexity``).
+    """
+    m = validate_tpm(tpm)
+    n = m.shape[0]
+    labels = initial_labels(n)
+
+    def _step(matrix, merged, delta):
+        prof = causal_profile(matrix)
+        return {
+            "size": prof["n"],
+            "value": float(primitive(matrix)),
+            "determinism": prof["determinism"],
+            "specificity": prof["specificity"],
+            "effectiveness": prof["effectiveness"],
+            "effective_information": prof["effective_information"],
+            "labels": list(labels),
+            "merged": merged,
+            "delta_cp": delta,
+        }
+
+    scales = [_step(m, None, None)]
+    deltas: list = []
+    cur = m
+    cur_val = float(primitive(m))
+
+    while cur.shape[0] > 1:
+        sz = cur.shape[0]
+        best = None  # (value, i, j, macro_tpm)
+        for i in range(sz):
+            for j in range(i + 1, sz):
+                cand = merge_states(cur, i, j)
+                val = float(primitive(cand))
+                if best is None or val > best[0]:
+                    best = (val, i, j, cand)
+        val, i, j, cand = best
+        delta = val - cur_val
+        if delta < eps:
+            break  # plus aucune fusion n'ameliore : on s'arrete (emergence epuisee)
+        labels = merge_labels(labels, i, j)
+        scales.append(_step(cand, (i, j), delta))
+        deltas.append(delta)
+        cur, cur_val = cand, val
+
+    return {
+        "scales": scales,
+        "deltas": deltas,
+        "emergent_complexity": emergent_complexity(deltas),
+    }
+
+
+# --------------------------------------------------------------- complexite emergente
+def emergent_complexity(deltas) -> float:
+    """Complexite emergente ``EC = log2(L) - sum_i p_i log2(p_i)`` (Hoel 2025).
+
+    ``deltas`` = gains de primitive causale (``delta_cp`` positifs) le long du
+    chemin d'echelles ; ``p_i = delta_i / sum(delta)`` est la contribution
+    relative de chaque transition d'echelle, ``L`` le nombre de transitions.
+
+    Equivaut a ``log2(L) + H(p)`` ou ``H(p)`` est l'entropie des contributions :
+    EC est donc maximale quand le travail causal est *largement distribue* entre
+    les echelles (cf l'abstract de Hoel 2025), et nulle si une seule echelle
+    porte tout le gain (``L <= 1``).
+    """
+    d = np.asarray([float(x) for x in deltas if x > 0], dtype=float)
+    L = int(d.size)
+    if L <= 1:
+        return 0.0
+    p = d / d.sum()
+    return float(np.log2(L) - np.sum(p * np.log2(p)))
+
+
+# --------------------------------------------------------------- presentation
+def apportionment_table(result: dict) -> list:
+    """Reduit un resultat d'apportionment a un tableau lisible (pour notebook).
+
+    Chaque ligne : ``(taille, effectiveness, EI_bits, det, spec, delta_cp)``,
+    arrondie a 4 decimales. Utile pour un affichage tabulaire dans ICT-6/ICT-7.
+    """
+    rows = []
+    for s in result["scales"]:
+        rows.append((
+            s["size"],
+            round(s["effectiveness"], 4),
+            round(s["effective_information"], 4),
+            round(s["determinism"], 4),
+            round(s["specificity"], 4),
+            None if s["delta_cp"] is None else round(s["delta_cp"], 4),
+        ))
+    return rows

--- a/MyIA.AI.Notebooks/IIT/ict/tpm_estimation.py
+++ b/MyIA.AI.Notebooks/IIT/ict/tpm_estimation.py
@@ -1,0 +1,156 @@
+"""Estimation de TPM a partir de trajectoires observees (pont vers CE 2.0).
+
+Ce module construit une matrice de transition **etat-a-etat** (le format de
+``ict.causal_emergence``) a partir de *trajectoires* discretes -- typiquement
+les suites de configurations produites par les modeles de la serie ICT
+(self-sorting arrays d'ICT-2, reseaux booleens d'ICT-1). C'est le pont qui
+permet de soumettre une dynamique simulee a l'analyse d'emergence causale
+d'ICT-6/ICT-7, sans la borne de taille de PyPhi.
+
+Trois entrees principales :
+  - ``tpm_from_transitions`` : une liste de transitions explicites
+    ``(s_t, s_{t+1})`` ;
+  - ``tpm_from_trajectory`` : une suite d'etats consecutifs ;
+  - ``tpm_from_trajectories`` : plusieurs trajectoires agregees.
+
+Les etats peuvent etre n'importe quel label hachable (entier, tuple,
+chaine...). Les lignes jamais observees sont par defaut *self-absorbantes*
+(``unseen="self"`` : l'etat se repete, on n'invente pas de transition) ;
+``unseen="uniform"`` produit une ligne uniforme a la place.
+
+Un pont supplementaire (``flat_tpm_from_sbn``) convertit une TPM state-by-node
+deterministe (format PyPhi de ``ict.trajectories``) en TPM etat-a-etat, pour
+analyser les reseaux booleens d'ICT-1 avec l'outillage CE 2.0 et comparer avec
+``pyphi.macro`` (ICT-5).
+
+Dependances : bibliotheque standard + numpy.
+Reference : ICT-0 (cadrage de la serie), Epic #4588.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import numpy as np
+
+
+# --------------------------------------------------------------- indexation des etats
+def state_index_map(states: Iterable) -> dict:
+    """Associe chaque label d'etat distinct a un index ``0..k-1``.
+
+    L'ordre des index suit l'ordre de PREMIERE apparition dans ``states``, ce
+    qui rend la TPM reproductible et lisible.
+    """
+    mapping: dict = {}
+    for s in states:
+        if s not in mapping:
+            mapping[s] = len(mapping)
+    return mapping
+
+
+def _normalize_counts(counts: np.ndarray, unseen: str = "self") -> np.ndarray:
+    """Normalise une matrice de comptes en TPM ligne-stochastique.
+
+    ``unseen`` gere les lignes de somme nulle (etats jamais quittes / observes
+    sans successeur) : ``"self"`` (defaut) place une auto-transition, "uniform"
+    repartit uniformement.
+    """
+    n = counts.shape[0]
+    tpm = counts.astype(float).copy()
+    row_sums = tpm.sum(axis=1)
+    for i in range(n):
+        if row_sums[i] <= 0:
+            if unseen == "uniform":
+                tpm[i] = np.full(n, 1.0 / n)
+            elif unseen == "self":
+                tpm[i] = 0.0
+                tpm[i, i] = 1.0
+            else:
+                raise ValueError(f"unseen inconnu : {unseen!r} (self|uniform)")
+        else:
+            tpm[i] = tpm[i] / row_sums[i]
+    return tpm
+
+
+# --------------------------------------------------------------- estimation
+def tpm_from_transitions(transitions, mapping: Optional[dict] = None,
+                         unseen: str = "self"):
+    """TPM empirique a partir de transitions ``(s_t, s_{t+1})``.
+
+    Retourne ``(tpm, mapping)`` ou ``mapping`` associe chaque label d'etat a son
+    index de ligne/colonne. Si ``mapping`` est fourni, il est reutilise (tous
+    les labels rencontres DOIVENT y figurer) ; sinon il est construit a partir
+    des etats observes.
+    """
+    pairs = [(a, b) for a, b in transitions]
+    if mapping is None:
+        labels = []
+        for a, b in pairs:
+            labels.append(a)
+            labels.append(b)
+        mapping = state_index_map(labels)
+    n = len(mapping)
+    counts = np.zeros((n, n), dtype=float)
+    for a, b in pairs:
+        if a not in mapping or b not in mapping:
+            raise KeyError(f"etat absent du mapping fourni : {a!r} ou {b!r}")
+        counts[mapping[a], mapping[b]] += 1.0
+    return _normalize_counts(counts, unseen), mapping
+
+
+def tpm_from_trajectory(states, mapping: Optional[dict] = None,
+                        unseen: str = "self"):
+    """TPM empirique a partir d'une suite d'etats consecutifs.
+
+    Les transitions sont les paires adjacentes ``(states[t], states[t+1])``.
+    Retourne ``(tpm, mapping)``.
+    """
+    seq = list(states)
+    transitions = list(zip(seq, seq[1:]))
+    return tpm_from_transitions(transitions, mapping, unseen)
+
+
+def tpm_from_trajectories(trajectories, mapping: Optional[dict] = None,
+                          unseen: str = "self"):
+    """TPM empirique agregeant PLUSIEURS trajectoires (transitions poolees).
+
+    Le mapping (s'il n'est pas fourni) couvre l'union des etats de toutes les
+    trajectoires, dans l'ordre de premiere apparition. Retourne ``(tpm,
+    mapping)``.
+    """
+    all_transitions = []
+    if mapping is None:
+        labels = []
+        for traj in trajectories:
+            seq = list(traj)
+            labels.extend(seq)
+            all_transitions.extend(zip(seq, seq[1:]))
+        mapping = state_index_map(labels)
+    else:
+        for traj in trajectories:
+            seq = list(traj)
+            all_transitions.extend(zip(seq, seq[1:]))
+    return tpm_from_transitions(all_transitions, mapping, unseen)
+
+
+# --------------------------------------------------------------- pont state-by-node
+def flat_tpm_from_sbn(sbn_tpm, n_nodes: int) -> np.ndarray:
+    """Convertit une TPM state-by-node DETERMINISTE en TPM etat-a-etat.
+
+    Utilise ``ict.trajectories.deterministic_successor`` : chaque etat va vers
+    son successeur deterministe avec probabilite 1, dans l'indexation
+    little-endian de PyPhi (``state_index``). Pratique pour analyser les
+    reseaux booleens d'ICT-1 avec l'outillage CE 2.0 et les comparer a
+    ``pyphi.macro`` (ICT-5).
+
+    Retourne une TPM ``(2**n_nodes, 2**n_nodes)``.
+    """
+    from . import trajectories as T
+
+    size = 2 ** n_nodes
+    tpm = np.zeros((size, size), dtype=float)
+    for state in T.all_states(n_nodes):
+        i = T.state_index(state)
+        nxt = T.deterministic_successor(sbn_tpm, state)
+        tpm[i, T.state_index(nxt)] = 1.0
+    return tpm

--- a/MyIA.AI.Notebooks/IIT/tests/test_causal_emergence.py
+++ b/MyIA.AI.Notebooks/IIT/tests/test_causal_emergence.py
@@ -1,0 +1,177 @@
+"""Tests du module ict.causal_emergence (stdlib + numpy, sans PyPhi).
+
+Verifie les primitives causales (determinisme / degenerescence / specificite /
+effectiveness / EI) sur des TPM dont les valeurs sont connues analytiquement,
+puis le coarse-graining, l'apportionment glouton et la complexite emergente.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict import causal_emergence as CE  # noqa: E402
+
+
+# --------------------------------------------------------------- TPM de reference
+def identity_tpm(n):
+    """TPM identite : chaque etat se repete (det=1, deg=0, EI=log2(n))."""
+    return np.eye(n)
+
+
+def uniform_tpm(n):
+    """TPM uniforme : chaque ligne est uniforme (det=0, eff=0, EI=0)."""
+    return np.full((n, n), 1.0 / n)
+
+
+def block_noise_tpm():
+    """Systeme a 4 etats avec emergence causale.
+
+    Deux blocs {0,1} et {2,3} ; a l'interieur d'un bloc la dynamique est
+    bruitee (uniforme sur l'autre bloc), mais au niveau MACRO (2 etats) les
+    blocs alternent de facon deterministe. L'effectiveness passe de 0.5 (micro)
+    a 1.0 (macro) : emergence.
+    """
+    return np.array([
+        [0.0, 0.0, 0.5, 0.5],
+        [0.0, 0.0, 0.5, 0.5],
+        [0.5, 0.5, 0.0, 0.0],
+        [0.5, 0.5, 0.0, 0.0],
+    ])
+
+
+# --------------------------------------------------------------- validation
+def test_validate_rejects_non_square():
+    try:
+        CE.validate_tpm(np.zeros((2, 3)))
+        assert False, "aurait du lever ValueError"
+    except ValueError:
+        pass
+
+
+def test_validate_rejects_unnormalized_rows():
+    try:
+        CE.validate_tpm(np.array([[0.5, 0.2], [0.0, 1.0]]))
+        assert False, "aurait du lever ValueError"
+    except ValueError:
+        pass
+
+
+# --------------------------------------------------------------- primitives
+def test_identity_is_maximally_causal():
+    n = 4
+    tpm = identity_tpm(n)
+    assert abs(CE.determinism(tpm) - 1.0) < 1e-9
+    assert abs(CE.degeneracy(tpm) - 0.0) < 1e-9
+    assert abs(CE.specificity(tpm) - 1.0) < 1e-9
+    assert abs(CE.effectiveness(tpm) - 1.0) < 1e-9
+    assert abs(CE.effective_information(tpm) - np.log2(n)) < 1e-9
+
+
+def test_uniform_has_no_causal_information():
+    tpm = uniform_tpm(4)
+    assert abs(CE.determinism(tpm) - 0.0) < 1e-9
+    assert abs(CE.effectiveness(tpm) - 0.0) < 1e-9
+    assert abs(CE.effective_information(tpm) - 0.0) < 1e-9
+
+
+def test_ei_equals_marginal_minus_mean_entropy():
+    # EI = H(marginal) - <H(rows)>, definition KL-moyenne, doit egaler eff*log2(n)
+    tpm = block_noise_tpm()
+    m = CE.validate_tpm(tpm)
+    marginal = m.mean(axis=0)
+    mean_row_H = np.mean([CE._entropy_bits(m[i]) for i in range(4)])
+    kl_form = CE._entropy_bits(marginal) - mean_row_H
+    assert abs(CE.effective_information(tpm) - kl_form) < 1e-9
+
+
+def test_block_noise_micro_effectiveness_is_half():
+    # chaque ligne uniforme sur 2 etats : H=1 bit, det=1-1/2=0.5 ; marginal
+    # uniforme sur 4 -> deg=0 -> eff=0.5
+    tpm = block_noise_tpm()
+    assert abs(CE.effectiveness(tpm) - 0.5) < 1e-9
+
+
+# --------------------------------------------------------------- coarse-graining
+def test_merge_reduces_size_and_stays_stochastic():
+    tpm = block_noise_tpm()
+    macro = CE.merge_states(tpm, 0, 1)
+    assert macro.shape == (3, 3)
+    assert np.allclose(macro.sum(axis=1), 1.0)
+
+
+def test_merge_labels_bookkeeping():
+    labels = CE.initial_labels(4)
+    labels = CE.merge_labels(labels, 0, 1)
+    assert labels[0] == (0, 1)
+    assert len(labels) == 3
+    labels = CE.merge_labels(labels, 1, 2)  # fusionne (2,) et (3,) en positions 1,2
+    assert (2, 3) in labels
+    assert len(labels) == 2
+
+
+def test_merge_invalid_indices():
+    tpm = identity_tpm(3)
+    for bad in [(0, 0), (0, 3), (-1, 1)]:
+        try:
+            CE.merge_states(tpm, *bad)
+            assert False, f"aurait du lever ValueError pour {bad}"
+        except ValueError:
+            pass
+
+
+# --------------------------------------------------------------- apportionment
+def test_identity_has_no_emergence():
+    # systeme deja maximalement causal : aucune fusion n'ameliore l'effectiveness
+    res = CE.greedy_apportionment(identity_tpm(4))
+    assert len(res["scales"]) == 1          # micro-echelle seule
+    assert res["deltas"] == []
+    assert res["emergent_complexity"] == 0.0
+
+
+def test_block_noise_shows_emergence():
+    tpm = block_noise_tpm()
+    res = CE.greedy_apportionment(tpm)
+    micro_eff = res["scales"][0]["effectiveness"]
+    macro_eff = res["scales"][-1]["effectiveness"]
+    # le macro est strictement plus causal que le micro : emergence
+    assert macro_eff > micro_eff + 1e-6
+    # le macro final est l'alternateur 2-etats (effectiveness = 1.0)
+    assert res["scales"][-1]["size"] == 2
+    assert abs(macro_eff - 1.0) < 1e-9
+    # tous les gains enregistres sont positifs
+    assert all(d > 0 for d in res["deltas"])
+    assert res["emergent_complexity"] > 0.0
+
+
+def test_scales_sizes_strictly_decreasing():
+    res = CE.greedy_apportionment(block_noise_tpm())
+    sizes = [s["size"] for s in res["scales"]]
+    assert all(b < a for a, b in zip(sizes, sizes[1:]))
+
+
+# --------------------------------------------------------------- complexite emergente
+def test_emergent_complexity_edge_cases():
+    assert CE.emergent_complexity([]) == 0.0
+    assert CE.emergent_complexity([1.0]) == 0.0           # une seule echelle
+    assert CE.emergent_complexity([-1.0, -2.0]) == 0.0    # aucun gain positif
+
+
+def test_emergent_complexity_uniform_vs_concentrated():
+    # L=2 : repartition uniforme -> EC = log2(2) + H([.5,.5]) = 1 + 1 = 2
+    assert abs(CE.emergent_complexity([1.0, 1.0]) - 2.0) < 1e-9
+    # L=4 uniforme -> EC = log2(4) + H(unif_4) = 2 + 2 = 4
+    assert abs(CE.emergent_complexity([1.0, 1.0, 1.0, 1.0]) - 4.0) < 1e-9
+    # concentre (moins distribue) -> EC plus faible a L egal
+    assert CE.emergent_complexity([3.0, 1.0]) < CE.emergent_complexity([1.0, 1.0])
+
+
+# --------------------------------------------------------------- presentation
+def test_apportionment_table_shape():
+    res = CE.greedy_apportionment(block_noise_tpm())
+    table = CE.apportionment_table(res)
+    assert len(table) == len(res["scales"])
+    assert table[0][-1] is None       # delta_cp du micro = None
+    assert all(len(row) == 6 for row in table)

--- a/MyIA.AI.Notebooks/IIT/tests/test_tpm_estimation.py
+++ b/MyIA.AI.Notebooks/IIT/tests/test_tpm_estimation.py
@@ -1,0 +1,92 @@
+"""Tests du module ict.tpm_estimation (pont trajectoires -> TPM, stdlib+numpy)."""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict import tpm_estimation as E  # noqa: E402
+from ict import causal_emergence as CE  # noqa: E402
+from ict import trajectories as T  # noqa: E402
+
+
+# --------------------------------------------------------------- indexation
+def test_state_index_map_first_appearance_order():
+    mapping = E.state_index_map(["b", "a", "b", "c", "a"])
+    assert mapping == {"b": 0, "a": 1, "c": 2}
+
+
+# --------------------------------------------------------------- estimation
+def test_tpm_from_trajectory_deterministic_cycle():
+    # cycle deterministe 0 -> 1 -> 2 -> 0 ...
+    states = [0, 1, 2, 0, 1, 2, 0]
+    tpm, mapping = E.tpm_from_trajectory(states)
+    assert mapping == {0: 0, 1: 1, 2: 2}
+    expected = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]], dtype=float)
+    assert np.allclose(tpm, expected)
+    # un cycle deterministe est maximalement causal (effectiveness = 1)
+    assert abs(CE.effectiveness(tpm) - 1.0) < 1e-9
+
+
+def test_tpm_from_transitions_counts_probabilities():
+    # depuis 0 : deux fois vers 1, une fois vers 2 -> [0, 2/3, 1/3]
+    transitions = [(0, 1), (0, 1), (0, 2), (1, 1), (2, 2)]
+    tpm, mapping = E.tpm_from_transitions(transitions)
+    i0 = mapping[0]
+    assert abs(tpm[i0, mapping[1]] - 2.0 / 3.0) < 1e-9
+    assert abs(tpm[i0, mapping[2]] - 1.0 / 3.0) < 1e-9
+    assert np.allclose(tpm.sum(axis=1), 1.0)
+
+
+def test_unseen_self_absorbing():
+    # etat 1 jamais quitte (aucune transition sortante) -> auto-transition
+    transitions = [(0, 1)]
+    mapping = {0: 0, 1: 1}
+    tpm, _ = E.tpm_from_transitions(transitions, mapping, unseen="self")
+    assert abs(tpm[1, 1] - 1.0) < 1e-9
+    assert np.allclose(tpm.sum(axis=1), 1.0)
+
+
+def test_unseen_uniform():
+    transitions = [(0, 1)]
+    mapping = {0: 0, 1: 1}
+    tpm, _ = E.tpm_from_transitions(transitions, mapping, unseen="uniform")
+    assert np.allclose(tpm[1], [0.5, 0.5])
+
+
+def test_tpm_from_trajectories_pools_transitions():
+    trajs = [[0, 1, 0], [0, 1, 1]]
+    tpm, mapping = E.tpm_from_trajectories(trajs)
+    # depuis 0 : deux fois vers 1 -> P(0->1)=1 ; depuis 1 : une fois 0, une fois 1
+    assert abs(tpm[mapping[0], mapping[1]] - 1.0) < 1e-9
+    assert abs(tpm[mapping[1], mapping[0]] - 0.5) < 1e-9
+    assert abs(tpm[mapping[1], mapping[1]] - 0.5) < 1e-9
+
+
+def test_unknown_label_with_fixed_mapping_raises():
+    try:
+        E.tpm_from_transitions([(0, 9)], mapping={0: 0, 1: 1})
+        assert False, "aurait du lever KeyError"
+    except KeyError:
+        pass
+
+
+# --------------------------------------------------------------- pont state-by-node
+def test_flat_tpm_from_sbn_matches_andor_network():
+    # meme reseau AND/OR a 3 noeuds que test_trajectories
+    flat = np.array([
+        [0, 0, 0], [0, 0, 1], [1, 0, 1], [1, 0, 0],
+        [1, 1, 0], [1, 1, 1], [1, 1, 1], [1, 1, 0],
+    ])
+    sbn = np.zeros((2, 2, 2, 3))
+    for idx, state in enumerate(T.all_states(3)):
+        sbn[state] = flat[idx]
+    tpm = E.flat_tpm_from_sbn(sbn, 3)
+    assert tpm.shape == (8, 8)
+    assert np.allclose(tpm.sum(axis=1), 1.0)
+    # reseau deterministe -> chaque ligne est un Dirac -> determinisme = 1
+    assert abs(CE.determinism(tpm) - 1.0) < 1e-9
+    # (1,0,0) [index 1] -> (0,0,1) [index 4]
+    assert tpm[1, 4] == 1.0


### PR DESCRIPTION
## Resume

Fondation de l'outillage **Causal Emergence 2.0** pour la serie ICT (Epic #4588) : deux modules Python dans le package `ict` + 23 tests. PR **library-only** (zero notebook, zero catalogue), atomique, base commune des futurs notebooks ICT-6/ICT-7.

Reponse a l'investigation du depot https://github.com/jessescool/Causal-Emergence-2.0 (accompagnant l'article de Hoel) : il **modernise le 2e pilier** de la serie (emergence causale) sans en redefinir les premisses (verrouillees par ICT-0-Framing). Verdict : **complementaire** au bridge do-calculus (axe orthogonal : "quelle echelle a le pouvoir causal" [Hoel] vs "effet d'une intervention" [Pearl]).

## Provenance / licence (HARD)

Le depot de reference **ne porte aucune licence** -> code non reutilisable. Ces modules sont une **reimplementation independante depuis les equations de l'article** (Hoel, *Causal Emergence 2.0: Quantifying emergent complexity*, arXiv:2503.13395, 2025) + la litterature canonique (Hoel/Albantakis/Tononi PNAS 2013 pour le coarse-graining). Le depot jessescool est **uniquement credite** comme implementation de reference (comparaison pedagogique).

## Pourquoi c'est cle pour ICT-6/7

PyPhi est limite en pratique a ~6 noeuds. CE 2.0 opere sur une **TPM etat-a-etat n x n** (numpy seul, sans borne) : on peut donc brancher les trajectoires de tri-morphogenese d'ICT-2 (`tpm_estimation`) et passer a l'echelle la ou ICT-5 (`pyphi.macro`) sature.

## Contenu

**`ict/causal_emergence.py`** (stdlib + numpy) :
- primitives sous intervention uniforme : `determinism`, `degeneracy`, `specificity`, `effectiveness` (det-deg), `effective_information` (eff*log2 n), `causal_profile`
- `merge_states` : coarse-graining canonique (somme colonnes / moyenne lignes / renorm) + `merge_labels`
- `greedy_apportionment` : chemin glouton micro->macro (primitive=`effectiveness` par defaut, scale-free). **NB honnete** : variante gloutonne, non globalement optimale contrairement a la trajectoire rigoureuse de l'article (documente dans le docstring)
- `emergent_complexity` : `EC = log2(L) - sum p_i log2 p_i` (= log2 L + H(p))
- `apportionment_table` pour affichage notebook

**`ict/tpm_estimation.py`** (pont vers ICT-6) : `tpm_from_transitions` / `_trajectory` / `_trajectories` (TPM empirique depuis trajectoires) ; `flat_tpm_from_sbn` (pont depuis le format state-by-node PyPhi de `ict.trajectories`).

## Demonstration (block-noise 4 etats)

```
n=4 eff=0.5000 EI=1.0000  (micro)
n=3 eff=0.5794            delta=+0.0794   labels [(0,1),(2,),(3,)]
n=2 eff=1.0000 EI=1.0000  delta=+0.4206   labels [(0,1),(2,3)]  <- alternateur macro maximal
EC = 1.6313
```
Effectiveness micro 0.5 -> macro 1.0 : **emergence reelle**, quantifiee par EC=1.63 (travail causal distribue entre les 2 etapes de coarse-graining).

## Validation

- `pytest tests/ -q` -> **40 passed** (env conda `coursia-ml-training`, Python 3.12) : 15 `test_causal_emergence` + 8 `test_tpm_estimation` nouveaux, **0 regression** sur `self_sorting`/`trajectories`.
- Primitives verifiees analytiquement (identite : eff=1, EI=log2 n ; uniforme : eff=0 ; `EI == H(marginal) - <H(rows)>`).

## Suite (Epic #4588, GO user donne)

PR suivantes : notebook **ICT-7** (CE 2.0 sur systemes canoniques + comparaison `pyphi.macro` d'ICT-5), notebook **ICT-6** (CE 2.0 sur le self-sorting d'ICT-2 via le pont), renumerotation du framing/Epic, puis bridge do-calculus mettant a jour les **fins** de Tweety-11 / Infer-22 / PyMC-22.

See #4588

🤖 Reimplementation independante depuis l'article (aucun code du depot non-license repris).