### PR TITLE
docs(causal): pont do-calculus entre les 4 series causales (Tweety-11 / Infer-22 / PyMC-22 / ICT-5)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -322,6 +322,59 @@ Les notebooks ICT-1, ICT-3 à ICT-7 (trajectoires de $\Phi$, agrégation chimér
 multi-échelles, pont tri → PyPhi, signatures scale-free) sont sur la feuille de route de
 [ICT-0-Framing](ICT-0-Framing.md).
 
+## Ponts causaux : le do-calculus de Pearl à travers les paradigmes
+
+Quatre séries du dépôt abordent la **causalité** — non pas la corrélation, mais la question
+« que se passe-t-il si j'**interviens** ? ». Elles le font dans des paradigmes radicalement
+différents (logique symbolique, inférence bayésienne par message passing, MCMC, théorie de l'information),
+et pourtant elles partagent **le même noyau** : l'opérateur `do(·)` de Judea Pearl et son
+**échelle de la causalité** à trois barreaux.
+
+**L'échelle de la causalité (ladder of causation)** :
+
+| Barreau | Question | Formalisme | Exemple canonique |
+|---------|----------|------------|-------------------|
+| **L1 — Association** | « Que voit-on ? » | `P(Y \| X)` | observer le baromètre baisser prédit la pluie |
+| **L2 — Intervention** | « Que se passe-t-il si on agit ? » | `P(Y \| do(X))` | *forcer* le baromètre à baisser ne fait **pas** pleuvoir |
+| **L3 — Contrefactuel** | « Qu'aurait-il fallu ? » | `P(Y_x \| X', Y')` | « l'herbe aurait-elle été mouillée si on avait coupé l'arrosage ? » |
+
+Le saut **L1 → L2** est le cœur du do-calculus : `do(X=x)` **mutile** le graphe causal — il coupe
+les arcs entrants de `X`, brisant les chemins de confusion — de sorte que
+`P(Y|do(X)) ≠ P(Y|X)` dès qu'un confondeur existe.
+
+**Le même opérateur, quatre instanciations** :
+
+| Paradigme | Notebook | Instanciation de `do(·)` | Résultat-signature |
+|-----------|----------|---------------------------|--------------------|
+| **Symbolique** (logique propositionnelle, Java/Tweety) | [Tweety-11-Causal](../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | `scm.intervene(p, b)` → nouveau SCM dont l'équation de `p` devient une constante | `P(rain\|drops)=True ≠ P(rain\|do(drops))=False` (baromètre) |
+| **Bayésien par message passing** (Infer.NET, EP/VMP — Gibbs disponible) | [Infer-22](../Probas/Infer/Infer-22-Causal-Inference.ipynb) | mutilation de graphe `Variable.Bernoulli(1.0)` ; backdoor / front-door | paradoxe de Simpson résolu, identifiabilité par ajustement |
+| **Bayésien MCMC** (PyMC) | [PyMC-22](../Probas/PyMC/PyMC-22-Causal-Inference.ipynb) | opérateur natif `pm.do(model, {X:x})` ; backdoor / front-door | contrefactuel par abduction (postérieur sur les exogènes) |
+| **Théorie de l'information / émergence** (ICT) | [ICT-5-CausalEmergence](ICT-5-CausalEmergence.ipynb) | distribution d'intervention `p(C)` **uniforme** sur les états = `do(X_t = x)` appliqué à tout le micro-état | quelle **échelle** « fait » le plus de travail causal (EI / CP) |
+
+**Le pont le plus profond — ICT-5 lève le do-calculus au niveau des échelles.** Dans la théorie
+de l'émergence causale (Hoel, *Causal Emergence 2.0* ; Jansma & Hoel, *Engineering Emergence*,
+2025), l'**information effective** (EI) et la *causal primitive* (`CP = déterminisme −
+dégénérescence`, équivalente à l'`effectiveness`) se calculent en plaçant le système sous une
+**distribution d'intervention** `p(C)` — par défaut **uniforme sur les états**. C'est exactement
+`do(X_t = x)` de Pearl, appliqué uniformément : on ne *regarde* pas la dynamique, on la *sonde*
+en forçant chaque état d'entrée. Mesurer « combien de travail causal fait un mécanisme »
+**exige** donc l'opérateur `do`, tout comme définir un effet causal l'exige chez Pearl.
+L'**émergence** apparaît quand une description **macro** (gros-grain) réalise *plus* de travail
+causal que le micro — l'`effectiveness` monte sous coarse-graining.
+
+**Parcours de lecture conseillé** : commencer par le **symbolique qualitatif**
+([Tweety-11](../SymbolicAI/Tweety/Tweety-11-Causal.ipynb)) pour *voir* `observe` vs `do` sans
+nombres ; passer au **quantitatif distributionnel** ([Infer-22](../Probas/Infer/Infer-22-Causal-Inference.ipynb)
+message passing, [PyMC-22](../Probas/PyMC/PyMC-22-Causal-Inference.ipynb) MCMC) pour *calculer* les effets
+et lever le paradoxe de Simpson ; finir par l'**information-théorique**
+([ICT-5](ICT-5-CausalEmergence.ipynb)) où le même `do` mesure le travail causal **à travers les
+échelles**.
+
+**Articles d'ancrage** : Pearl, *Causality* (2009) ; Hoel, *Causal Emergence 2.0*
+(arXiv:2503.13395) ; Jansma & Hoel, *Engineering Emergence* (arXiv:2510.02649).
+
+*Voir #4208 (surfaçage des différenciants du dépôt) et l'Epic ICT #4588.*
+
 ## Licence
 
 Voir la licence du repository principal.

--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -874,6 +874,8 @@ Prolongement naturel de la théorie de la décision séquentielle : après les M
 
 **Positionnement** : le notebook [Infer-4](Infer-4-Bayesian-Networks.ipynb) n'abordait la causalité qu'en deux cellules isolées. Infer-22 en fait un traitement dédié et **distributionnel** : les effets causaux sont **calculés** par le moteur d'inférence Infer.NET via mutilation de graphe, là où le jumeau symbolique [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) raisonne en Java propositionnel, et où [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) démontre `P(Cloudy|do(Rain))` en MCMC.
 
+**Ponts causaux** : Infer-22 est le maillon **distributionnel par message passing** (Infer.NET, EP/VMP) d'un pont à quatre paradigmes autour du `do(·)` de Pearl — le jumeau symbolique [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) (Java propositionnel), le jumeau MCMC [PyMC-22](../PyMC/PyMC-22-Causal-Inference.ipynb), et la lecture par l'émergence causale [ICT-5](../../IIT/ICT-5-CausalEmergence.ipynb), où la distribution d'intervention `p(C)` uniforme **est** `do(X_t = x)`. Vue d'ensemble : le [README IIT](../../IIT/README.md), section « Ponts causaux : le do-calculus de Pearl à travers les paradigmes ».
+
 **Applications** : baromètre (confondeur), diagnostic médical (paradoxe de Simpson), tabac-cancer (front-door), requêtes contrefactuelles.
 
 ---

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-22-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-22-Causal-Inference.ipynb
@@ -874,37 +874,7 @@
    "cell_type": "markdown",
    "id": "c0961fd6",
    "metadata": {},
-   "source": [
-    "## 11. Synthese\n",
-    "\n",
-    "| Niveau | Question | Operateur | Methode PyMC |\n",
-    "|--------|----------|-----------|--------------|\n",
-    "| **1 Association** | Que voit-on ? | `P(Y|X)` | `pm.observe` (conditionnement) / enumeration `evidence=` |\n",
-    "| **2 Intervention** | Que se passe-t-il si on agit ? | `P(Y|do(X))` | **`pm.do`** : mutile le graphe (coupe les arcs entrants) / `do_vars=` |\n",
-    "| **3 Contrefactuel** | Que se serait-il passe ? | `P(Y_x|X',Y')` | Abduction (posterieur) + prediction dans le graphe mutile |\n",
-    "\n",
-    "| Adjustment | Quand | Formule |\n",
-    "|------------|-------|---------|\n",
-    "| **Backdoor** | Confondeur `U` **observe** | `P(Y|do(X)) = Somme_u P(Y|X,u)P(u)` |\n",
-    "| **Front-door** | Confondeur non observe, mediateur `M` observe | `P(Y|do(X)) = Somme_m P(M=m|X) Somme_x' P(Y|M=m,x')P(x')` |\n",
-    "\n",
-    "### Ce qu'il faut retenir\n",
-    "\n",
-    "- **`P(Y|X) != P(Y|do(X))`** : l'observation est biaisee par les confondeurs. Conditionner (`pm.observe`) ne calcule **pas** l'effet causal — il faut **`pm.do`**, qui mutile le graphe.\n",
-    "- **`pm.do` est un operateur natif de PyMC** : la ou Infer.NET demande une mutilation manuelle (forcer une variable sans parent), PyMC traite l'intervention comme une **transformation de modele** de premiere classe. La difference visible entre observation et intervention (0.656 vs 0.310) prouve que le `do()` fait un travail structurel (Prong-B).\n",
-    "- **Backdoor et front-door rendent l'effet causal identifiable** a partir de donnees observationnelles, sous conditions graphiques — formalisees par le do-calculus (Pearl 1995), complet (Shpitser & Pearl 2006).\n",
-    "\n",
-    "### Pour aller plus loin\n",
-    "\n",
-    "- **Pont message passing** : [Infer-22-Causal-Inference](../Infer/Infer-22-Causal-Inference.ipynb) calcule les memes effets en Infer.NET (EP/VMP), avec mutilation manuelle.\n",
-    "- **Pont symbolique** : [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) traite le `do()` et les contrefactuels en Java/Tweety (raisonnement propositionnel).\n",
-    "- **Pont Python** : [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) demontre la meme distinction `P(Cloudy|Rain)` vs `P(Cloudy|do(Rain))`.\n",
-    "- **References** : Pearl (2000) *Causality* ; Pearl, Glymour & Jewell (2016) *Causal Inference in Statistics : A Primer* ; Shpitser & Pearl (2006) *Identification of Conditional Interventional Effects*.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "[← PyMC-20-Decision-Sequential](PyMC-20-Decision-Sequential.ipynb) | [Retour a la serie](README.md)"
-   ]
+   "source": "## 11. Synthese\n\n| Niveau | Question | Operateur | Methode PyMC |\n|--------|----------|-----------|--------------|\n| **1 Association** | Que voit-on ? | `P(Y|X)` | `pm.observe` (conditionnement) / enumeration `evidence=` |\n| **2 Intervention** | Que se passe-t-il si on agit ? | `P(Y|do(X))` | **`pm.do`** : mutile le graphe (coupe les arcs entrants) / `do_vars=` |\n| **3 Contrefactuel** | Que se serait-il passe ? | `P(Y_x|X',Y')` | Abduction (posterieur) + prediction dans le graphe mutile |\n\n| Adjustment | Quand | Formule |\n|------------|-------|---------|\n| **Backdoor** | Confondeur `U` **observe** | `P(Y|do(X)) = Somme_u P(Y|X,u)P(u)` |\n| **Front-door** | Confondeur non observe, mediateur `M` observe | `P(Y|do(X)) = Somme_m P(M=m|X) Somme_x' P(Y|M=m,x')P(x')` |\n\n### Ce qu'il faut retenir\n\n- **`P(Y|X) != P(Y|do(X))`** : l'observation est biaisee par les confondeurs. Conditionner (`pm.observe`) ne calcule **pas** l'effet causal — il faut **`pm.do`**, qui mutile le graphe.\n- **`pm.do` est un operateur natif de PyMC** : la ou Infer.NET demande une mutilation manuelle (forcer une variable sans parent), PyMC traite l'intervention comme une **transformation de modele** de premiere classe. La difference visible entre observation et intervention (0.656 vs 0.310) prouve que le `do()` fait un travail structurel (Prong-B).\n- **Backdoor et front-door rendent l'effet causal identifiable** a partir de donnees observationnelles, sous conditions graphiques — formalisees par le do-calculus (Pearl 1995), complet (Shpitser & Pearl 2006).\n\n### Pour aller plus loin — le meme do-calculus, d'autres paradigmes\n\nCe notebook traite le `do()` en **probabiliste MCMC + enumeration exacte** (`pm.do`). Le **meme operateur** structure trois autres series du depot, chacune dans un paradigme different :\n\n- **Symbolique (Java/Tweety)** : [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) — `do()` et contrefactuels par raisonnement **propositionnel** (`scm.intervene`), sans probabilites.\n- **Bayesien par message passing (Infer.NET)** : [Infer-22-Causal-Inference](../Infer/Infer-22-Causal-Inference.ipynb) — memes effets **calcules** par message passing (EP/VMP par defaut, Gibbs aussi disponible), avec mutilation du graphe. Ce message passing est *exact* sur ces reseaux discrets sans boucle, mais c'est une inference **approchee** en general — a la difference de l'enumeration exhaustive de ce notebook.\n- **Theorie de l'information / emergence (ICT)** : [ICT-5-CausalEmergence](../../IIT/ICT-5-CausalEmergence.ipynb) — l'intervention `do(X_t = x)` devient une **distribution uniforme** `p(C)` sur les etats ; le do-calculus y mesure *a quelle echelle* la causalite est la plus effective (EI / CP).\n- **Pre-requis Python** : [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) demontre la meme distinction `P(Cloudy|Rain)` vs `P(Cloudy|do(Rain))`.\n\n> **Synthese transversale** : voir le [README IIT](../../IIT/README.md), section **« Ponts causaux : le do-calculus de Pearl a travers les paradigmes »**, qui aligne l'echelle de Pearl (association -> intervention -> contrefactuel) sur les quatre instanciations de l'operateur `do`.\n\n- **References** : Pearl (2000) *Causality* ; Pearl, Glymour & Jewell (2016) *Causal Inference in Statistics : A Primer* ; Shpitser & Pearl (2006) *Identification of Conditional Interventional Effects*.\n\n---\n\n[← PyMC-20-Decision-Sequential](PyMC-20-Decision-Sequential.ipynb) | [Retour a la serie](README.md)"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -89,6 +89,8 @@ A l'issue de cette série, vous serez capable de :
 
 > **Numérotation** : le notebook **22** porte ce numéro par **parité** avec son jumeau C# [Infer-22-Causal-Inference](../Infer/Infer-22-Causal-Inference.ipynb). Le sujet d'Infer-21 (Thompson Sampling) est, côté Python, **intégré dans** [PyMC-20-Decision-Sequential](PyMC-20-Decision-Sequential.ipynb) (section bandits bayésiens MCMC) — d'où l'absence d'un PyMC-21 distinct.
 
+> **Ponts causaux** : [PyMC-22](PyMC-22-Causal-Inference.ipynb) est le maillon **MCMC** d'un pont à quatre paradigmes autour du `do(·)` de Pearl — le jumeau **message passing** en C# [Infer-22](../Infer/Infer-22-Causal-Inference.ipynb) (Infer.NET, EP/VMP), le jumeau symbolique [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb), et la lecture par l'émergence causale [ICT-5](../../IIT/ICT-5-CausalEmergence.ipynb). Vue d'ensemble : le [README IIT](../../IIT/README.md), section « Ponts causaux : le do-calculus de Pearl à travers les paradigmes ».
+
 ## Progression Pédagogique
 
 ```mermaid

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -196,6 +196,16 @@ flowchart TD
 
 La signature du do-calculus — **P(rain | drops) ≠ P(rain | do(drops))** — est exactement ce que la logique classique (notebooks 1-4) et les MLN (notebook 10) restent **incapables d'exprimer** : ils ne connaissent que l'association.
 
+### Ponts causaux — le do-calculus au-delà du symbolique
+
+Tweety raisonne sur le do-calculus en **logique propositionnelle** : `do(X)` y est *qualitatif* — un atome forcé, un SCM réécrit, une réponse vrai/faux. C'est idéal pour *voir* la différence entre `observe` et `do` sans nombres, mais Tweety **ne chiffre pas** un effet causal ni ne lève quantitativement un paradoxe de Simpson. Les séries probabilistes du dépôt reprennent **exactement ce notebook** avec des distributions :
+
+- [Infer-22-Causal-Inference](../../Probas/Infer/Infer-22-Causal-Inference.ipynb) — le **jumeau distributionnel par message passing** : `P(Y|do(X))` calculé par mutilation de graphe en Infer.NET (EP/VMP), ajustements backdoor / front-door, paradoxe de Simpson résolu numériquement.
+- [PyMC-22-Causal-Inference](../../Probas/PyMC/PyMC-22-Causal-Inference.ipynb) — la version **MCMC** avec l'opérateur natif `pm.do` et le contrefactuel par abduction.
+- [ICT-5-CausalEmergence](../../IIT/ICT-5-CausalEmergence.ipynb) — le même `do` monte d'un cran : à **quelle échelle** un système fait-il le plus de travail causal ?
+
+Vue d'ensemble des quatre paradigmes : le [README IIT](../../IIT/README.md), section « Ponts causaux : le do-calculus de Pearl à travers les paradigmes ».
+
 ## Quick Start
 
 ```bash

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal.ipynb
@@ -825,6 +825,12 @@
     "\n",
     "*Notebook 11/11 de la série TweetyProject — capstone de synthèse sur le raisonnement causal.*"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "773b01a6",
+   "source": "## 7. Aller plus loin — le même do-calculus, d'autres paradigmes\n\nTweety traite la causalité en **logique propositionnelle** : `do(X)` y est *qualitatif* — un atome forcé, un SCM réécrit, une réponse vrai/faux. C'est idéal pour *voir* la différence entre `observe` et `do` sans se noyer dans les nombres, mais Tweety **ne chiffre pas** un effet causal (« de combien la probabilité de pluie change-t-elle ? ») ni ne lève quantitativement un paradoxe de Simpson. Les séries probabilistes du dépôt reprennent **exactement ce notebook** avec des distributions :\n\n- **[Infer-22 — Inférence Causale](../../Probas/Infer/Infer-22-Causal-Inference.ipynb)** : le jumeau **distributionnel par message passing**. `P(Y|do(X))` calculé par mutilation de graphe en Infer.NET (inférence par propagation de messages — EP/VMP par défaut, Gibbs aussi disponible), ajustements **backdoor** et **front-door**, paradoxe de Simpson résolu numériquement.\n- **[PyMC-22 — Inférence Causale](../../Probas/PyMC/PyMC-22-Causal-Inference.ipynb)** : la version **MCMC**, avec l'opérateur natif `pm.do(model, {X:x})` et le **contrefactuel par abduction** (postérieur sur les variables exogènes).\n- **[ICT-5 — Émergence Causale](../../IIT/ICT-5-CausalEmergence.ipynb)** : le même `do` monte d'un cran — la distribution d'intervention uniforme `p(C)` *est* `do(X_t = x)` appliqué à tout le micro-état, et mesure à **quelle échelle** un système réalise le plus de travail causal (émergence).\n\n> **Vue d'ensemble des quatre paradigmes** : la section « Ponts causaux : le do-calculus de Pearl à travers les paradigmes » du [README IIT](../../IIT/README.md) cartographie comment le symbolique (ce notebook), le bayésien par message passing, le MCMC et la théorie de l'information instancient le même opérateur `do(·)`.",
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Resume

Pont **markdown-only** (0 re-exec) reliant les **quatre series** du depot qui instancient l'operateur `do(·)` de Pearl, chacune dans un paradigme different. Pattern jumeau de #4589 (RL <-> GenAI).

Hub dans `IIT/README.md` (ancre sur ICT-5) + cross-refs reciproques dans les READMEs Tweety / Infer / PyMC + cellules markdown de cloture "Aller plus loin" dans Tweety-11 et PyMC-22.

## Fichiers (6, markdown uniquement)

| Fichier | Changement |
|---------|-----------|
| `MyIA.AI.Notebooks/IIT/README.md` | **Section hub** "Ponts causaux : le do-calculus de Pearl a travers les paradigmes" (echelle L1/L2/L3 + table "meme operateur, 4 instanciations" + deep-link emergence ICT-5) |
| `MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md` | Sous-section reciproque "Ponts causaux" |
| `MyIA.AI.Notebooks/Probas/Infer/README.md` | Paragraphe reciproque "Ponts causaux" |
| `MyIA.AI.Notebooks/Probas/PyMC/README.md` | Blockquote reciproque "Ponts causaux" |
| `MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal.ipynb` | 1 cellule **markdown** de cloture (forward-pointer 4 paradigmes) |
| `MyIA.AI.Notebooks/Probas/PyMC/PyMC-22-Causal-Inference.ipynb` | 1 cellule **markdown** de cloture augmentee (ICT-5 + hub) |

## Conformite

- **C.2 / C.3** : seules des **cellules markdown** modifiees dans les 2 notebooks ; **aucun** `outputs` / `execution_count` touche (verifie : 0 ligne output/exec_count dans le diff). Pas de re-exec necessaire.
- **Catalog** : `COURSE_CATALOG.generated.*` et marqueurs `CATALOG-STATUS` **byte-identical** a main (le cron reconcilie).
- **FR-first** ; liens relatifs reciproques verifies.
- **Framing honnete d'Infer.NET** : "bayesien par **message passing**" (EP/VMP par defaut, Gibbs disponible). Le message passing est *exact* sur ces reseaux discrets sans boucle mais reste **approche** en general — la distinction Infer-22 vs PyMC-22 est *message passing vs MCMC*, **pas** exact vs approche.

## Coordination

- **Collision Infer-22 resolue** : #4605 (po-2024) a ete merge **notebook-only** (section "Constellation causale" dans le `.ipynb`), sans toucher le README Infer-22. Ma PR touche **uniquement** le README d'Infer-22 cote Probas/Infer + etend la carte a **4 paradigmes** (ajoute ICT-5 / emergence).
- Suivi separe a prevoir (hors scope ici) : le framing series-level "inference exacte (Infer.NET) vs MCMC" est imprecis (EP, le defaut, est approche) — a corriger dans une PR dediee + signaler le "inference exacte (EP/VMP)" de #4605.

See #4208 (surfacage des differenciants du depot) ; ref Epic ICT #4588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)