### PR TITLE
docs(qc): FR backfill 4 strategy READMEs (#3870, Phase 0.5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/README.en.md
@@ -1,0 +1,29 @@
+# AdaptiveAssetAllocation
+
+**Asset class:** US Equities/ETF (diversified)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Top-4 ETFs by 6-month momentum with minimum-variance portfolio optimization. Selects from SPY, QQQ, TLT, GLD, EFA, IWM.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | 6M momentum + min-variance |
+| Universe | 6 ETFs (top 4) |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (iter2c, adaptive allocation)
+
+## References
+
+- Faber (2007), A Quantitative Approach to Tactical Asset Allocation

--- a/MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/README.md
@@ -1,29 +1,29 @@
 # AdaptiveAssetAllocation
 
-**Asset class:** US Equities/ETF (diversified)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions/ETF US (diversifié)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-Top-4 ETFs by 6-month momentum with minimum-variance portfolio optimization. Selects from SPY, QQQ, TLT, GLD, EFA, IWM.
+Top-4 ETFs par momentum 6 mois avec optimisation de portefeuille à variance minimum. Sélection parmi SPY, QQQ, TLT, GLD, EFA, IWM.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour exécuter.
 
-## Backtest Metrics
+## Métriques du backtest
 
-| Metric | Value |
-|--------|-------|
-| Method | 6M momentum + min-variance |
-| Universe | 6 ETFs (top 4) |
-| Rebalance | Monthly |
+| Métrique | Valeur |
+|----------|--------|
+| Méthode | Momentum 6M + variance min. |
+| Univers | 6 ETFs (top 4) |
+| Rebalancement | Mensuel |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (iter2c, adaptive allocation)
+- main.py - Stratégie (iter2c, allocation adaptative)
 
-## References
+## Références
 
 - Faber (2007), A Quantitative Approach to Tactical Asset Allocation

--- a/MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum/README.en.md
@@ -1,0 +1,30 @@
+# BlackLitterman-Momentum
+
+**Asset class:** US Equities/ETF (multi-asset)
+**Cloud project ID:** 29816300
+
+## Description
+
+Black-Litterman portfolio with multi-window momentum views (1M, 3M, 6M, 12M). BL optimization produces final weights.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum"`
+
+**QC Cloud:** Deployed as project 29816300.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | Black-Litterman + momentum views |
+| Lookbacks | 1M, 3M, 6M, 12M |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, BL momentum)
+
+## References
+
+- Black & Litterman (1992), Global Portfolio Optimization

--- a/MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum/README.md
@@ -1,30 +1,30 @@
 # BlackLitterman-Momentum
 
-**Asset class:** US Equities/ETF (multi-asset)
-**Cloud project ID:** 29816300
+**Classe d'actifs :** Actions/ETF US (multi-actifs)
+**ID projet Cloud :** 29816300
 
 ## Description
 
-Black-Litterman portfolio with multi-window momentum views (1M, 3M, 6M, 12M). BL optimization produces final weights.
+Portefeuille Black-Litterman avec vues de momentum multi-fenêtres (1M, 3M, 6M, 12M). L'optimisation BL produit les poids finaux.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum"`
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum"`
 
-**QC Cloud:** Deployed as project 29816300.
+**QC Cloud :** Déployé en tant que projet 29816300.
 
-## Backtest Metrics
+## Métriques du backtest
 
-| Metric | Value |
-|--------|-------|
-| Method | Black-Litterman + momentum views |
+| Métrique | Valeur |
+|----------|--------|
+| Méthode | Black-Litterman + vues momentum |
 | Lookbacks | 1M, 3M, 6M, 12M |
-| Rebalance | Monthly |
+| Rebalancement | Mensuel |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (v1.0, BL momentum)
+- main.py - Stratégie (v1.0, BL momentum)
 
-## References
+## Références
 
 - Black & Litterman (1992), Global Portfolio Optimization

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC/README.en.md
@@ -1,0 +1,30 @@
+# DynamicVIXSpyRegime-QC
+
+**Asset class:** US Equities (SPY)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Strategy Library clone. VIX-based regime detection on SPY switching between aggressive and defensive positioning.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 1.72 |
+| CAGR | 29.76% |
+| Source | QC Strategy Library clone |
+| Note | Metrics from original library, not locally reproduced |
+
+## Files
+
+- main.py - Strategy (QC Library clone)
+
+## References
+
+- QuantConnect Strategy Library

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC/README.md
@@ -1,30 +1,30 @@
 # DynamicVIXSpyRegime-QC
 
-**Asset class:** US Equities (SPY)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions US (SPY)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-QC Strategy Library clone. VIX-based regime detection on SPY switching between aggressive and defensive positioning.
+Clone de la QC Strategy Library. Détection de régime basée sur le VIX sur SPY, alternant entre positionnement agressif et défensif.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour exécuter.
 
-## Backtest Metrics
+## Métriques du backtest
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 1.72 |
 | CAGR | 29.76% |
-| Source | QC Strategy Library clone |
-| Note | Metrics from original library, not locally reproduced |
+| Source | Clone QC Strategy Library |
+| Note | Métriques de la bibliothèque originale, non reproduites localement |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (QC Library clone)
+- main.py - Stratégie (clone QC Library)
 
-## References
+## Références
 
 - QuantConnect Strategy Library

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/README.en.md
@@ -1,0 +1,39 @@
+# HAR-RV-Kelly
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** See `config.json` (local-id: 230839018)
+
+## Description
+
+HAR-RV (Heterogeneous Autoregressive Realized Variance, Corsi 2009) model for forecasting 5-day realized variance on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Uses the Kelly Criterion at 1/4 fraction for position sizing based on the HAR forecast. Includes 5-day momentum direction. Model refit via OLS every 22 days on a 500-day rolling window. Weekly rebalance.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm HAR-RV-Kelly/main.py
+```
+
+### QC Cloud
+Open the cloud project (local-id: 230839018), compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| HAR-RV + Kelly Criterion | Weekly | Kelly fraction 1/4, 5-day forecast, OLS refit every 22 days, 500-day window |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | HAR-RV volatility forecasting with Kelly Criterion sizing on 6 multi-asset ETFs |
+| `config.json` | Project configuration (local-id) |
+| `research.ipynb` | Research notebook with HAR-RV model analysis and Kelly fraction exploration |
+
+## References
+
+- Corsi, F. (2009). *A Simple Approximate Long-Memory Model of Realized Volatility*. Journal of Financial Econometrics.
+- Kelly, J.L. (1956). *A New Interpretation of Information Rate*. Bell System Technical Journal.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/README.md
@@ -1,14 +1,14 @@
 # HAR-RV-Kelly
 
-**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+**Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**Cloud project ID:** See `config.json` (local-id: 230839018)
+**ID projet Cloud :** Voir `config.json` (local-id : 230839018)
 
 ## Description
 
-HAR-RV (Heterogeneous Autoregressive Realized Variance, Corsi 2009) model for forecasting 5-day realized variance on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Uses the Kelly Criterion at 1/4 fraction for position sizing based on the HAR forecast. Includes 5-day momentum direction. Model refit via OLS every 22 days on a 500-day rolling window. Weekly rebalance.
+Modèle HAR-RV (Heterogeneous Autoregressive Realized Variance, Corsi 2009) pour prévoir la variance réalisée à 5 jours sur six actifs (SPY, EFA, EEM, TLT, GLD, DBC). Utilise le critère de Kelly à fraction 1/4 pour le dimensionnement des positions basé sur la prévision HAR. Inclut la direction du momentum à 5 jours. Ré-ajustement du modèle par OLS tous les 22 jours sur une fenêtre glissante de 500 jours. Rebalancement hebdomadaire.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,23 +16,23 @@ lean backtest --algorithm HAR-RV-Kelly/main.py
 ```
 
 ### QC Cloud
-Open the cloud project (local-id: 230839018), compile and run a backtest.
+Ouvrir le projet cloud (local-id : 230839018), compiler et lancer un backtest.
 
-## Backtest Metrics
+## Métriques du backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| HAR-RV + Kelly Criterion | Weekly | Kelly fraction 1/4, 5-day forecast, OLS refit every 22 days, 500-day window |
+| Méthode | Rebalancement | Paramètres clés |
+|---------|---------------|-----------------|
+| HAR-RV + Critère de Kelly | Hebdomadaire | Fraction Kelly 1/4, prévision 5 jours, ré-ajustement OLS tous les 22 jours, fenêtre 500 jours |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | HAR-RV volatility forecasting with Kelly Criterion sizing on 6 multi-asset ETFs |
-| `config.json` | Project configuration (local-id) |
-| `research.ipynb` | Research notebook with HAR-RV model analysis and Kelly fraction exploration |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Prévision de volatilité HAR-RV avec dimensionnement par critère de Kelly sur 6 ETFs multi-actifs |
+| `config.json` | Configuration du projet (local-id) |
+| `research.ipynb` | Notebook de recherche avec analyse du modèle HAR-RV et exploration de la fraction Kelly |
 
-## References
+## Références
 
 - Corsi, F. (2009). *A Simple Approximate Long-Memory Model of Realized Volatility*. Journal of Financial Econometrics.
 - Kelly, J.L. (1956). *A New Interpretation of Information Rate*. Bell System Technical Journal.


### PR DESCRIPTION
## Summary

Continues the **#3870** FR-backfill of QC strategy READMEs (Epic **#1650 Phase 0.5**, rule `readme-french-first.md` HARD 2). Same mechanic as #4587 (prior 4 sub-strategy batch): `git mv README.md -> README.en.md` (EN original preserved verbatim) + new FR `README.md` (same structure/anchors, metrics + Cloud IDs preserved, code blocks untouched). Separator = point (`README.en.md`).

## Strategies (4)

| Strategy | Method | Cloud ID |
|----------|--------|----------|
| AdaptiveAssetAllocation | 6M momentum + min-variance, 6 ETFs (top 4) | None (local) |
| BlackLitterman-Momentum | BL + multi-window momentum (1M/3M/6M/12M) | **29816300** |
| DynamicVIXSpyRegime-QC | VIX regime clone, Sharpe 1.72 / CAGR 29.76% | None (local) |
| HAR-RV-Kelly | Corsi 2009 HAR-RV + Kelly 1/4 fraction, 6 multi-asset ETFs | local-id **230839018** |

## Verification

| Check | Result |
|-------|--------|
| EN snapshots byte-identical to origin/main (md5) | 4/4 IDENTICAL |
| H2 parity EN(.en.md) vs FR(README.md) | 5/5, 5/5, 5/5, 5/5 |
| Cloud IDs preserved | 29816300 (BlackLitterman x2), 230839018 (HAR-RV-Kelly x2) |
| Code blocks (lean backtest commands + paths) | untouched |
| `COURSE_CATALOG.generated.*` | byte-identical (CATALOG-STATUS unchanged) |

## Scope

4 QC strategy READMEs, same family as #4587 (#3870 strategy catalog). Diff: 8 files (4 renamed EN->.en.md + 4 new FR), +187/-59. One domain (QC FR-backfill), under G.4 thresholds.

See #3870.