### PR TITLE
docs(infer): Infer-22 add ICT-5 (4th causal paradigm) to constellation bridge

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-22-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-22-Causal-Inference.ipynb
@@ -27,7 +27,7 @@
     "|-----------|---------|\n",
     "| [Infer-21-Thompson-Sampling](Infer-21-Thompson-Sampling.ipynb) | (fin de la serie) |\n",
     "\n",
-    "> **Pont inter-series (constellation causale)** : le do-calculus de Pearl se decline en **trois paradigmes** dans ce depot, et ce notebook en est le versant **probabiliste distributionnel** (.NET/Infer.NET) -- les effets causaux y sont **calcules** par mutilation de graphe. Le jumeau **Python/PyMC** porte les memes exemples (barometre, Sprinkler) via l'operateur natif `pm.do` : voir [PyMC-22-Causal-Inference](../PyMC/PyMC-22-Causal-Inference.ipynb), ainsi que la demo historique `P(Cloudy|do(Rain))` dans [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb). Enfin, le traitement **symbolique** (Java/Tweety, raisonneur contrefactuel propositionnel) est dans [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb). La section **Constellation causale** en fin de notebook cartographie ces trois implementations.\n"
+    "> **Pont inter-series (constellation causale)** : le do-calculus de Pearl se decline en **plusieurs paradigmes** dans ce depot, et ce notebook en est le versant **probabiliste distributionnel** (.NET/Infer.NET) -- les effets causaux y sont **calcules** par mutilation de graphe. Le jumeau **Python/PyMC** porte les memes exemples (barometre, Sprinkler) via l'operateur natif `pm.do` : voir [PyMC-22-Causal-Inference](../PyMC/PyMC-22-Causal-Inference.ipynb), ainsi que la demo historique `P(Cloudy|do(Rain))` dans [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb). Enfin, le traitement **symbolique** (Java/Tweety, raisonneur contrefactuel propositionnel) est dans [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb). La section **Constellation causale** en fin de notebook cartographie ces quatre implementations (y compris l'emergence causale a l'echelle, [ICT-5](../../IIT/ICT-5-CausalEmergence.ipynb)).\n"
    ]
   },
   {
@@ -1519,15 +1519,16 @@
    "id": "infer22-constell-bridge",
    "metadata": {},
    "source": [
-    "## Constellation causale -- le do-calculus en trois paradigmes\n",
+    "## Constellation causale -- le do-calculus en quatre paradigmes\n",
     "\n",
-    "Le do-calculus de Pearl (1995, 2000) est un **calcul formel independant du langage** : les trois regles d'identification d'un effet causal ne dependent pas de l'implementation. Ce depot le met en oeuvre dans **trois paradigmes** distincts, qui choisissent chacun ce qu'ils **calculent** versus ce sur quoi ils **raisonnent**.\n",
+    "Le do-calculus de Pearl (1995, 2000) est un **calcul formel independant du langage** : les trois regles d'identification d'un effet causal ne dependent pas de l'implementation. Ce depot le met en oeuvre dans **quatre paradigmes** distincts, qui choisissent chacun ce qu'ils **calculent** versus ce sur quoi ils **raisonnent**.\n",
     "\n",
     "| Paradigme | Moteur / langage | Idiome du `do(X)` | Notebook | Ce qu'il apporte |\n",
     "|-----------|------------------|-------------------|----------|------------------|\n",
     "| **Probabiliste distributionnel** | Infer.NET (C#) | **Mutilation de graphe** : `Variable.Bernoulli(1.0)` force la valeur et coupe l'arc parent | ce notebook | Effet causal **calcule** par inférence exacte (EP/VMP) sur le graphe mutile |\n",
     "| **Probabiliste (transformation)** | PyMC (Python) | Operateur natif `pm.do` : l'intervention est une **transformation de modele de premiere classe** | [PyMC-22](../PyMC/PyMC-22-Causal-Inference.ipynb) | `do` rebranche comme un operateur du langage probabiliste |\n",
     "| **Symbolique propositionnel** | Tweety (Java) | **Raisonneur contrefactuel** : logique classique, preuves argumentatives (pas de probabilites) | [Tweety-11](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | Raisonnement **qualitatif** : \"X cause-t-il Y ?\" sans chiffres |\n",
+    "| **Emergence causale (echelle)** | PyPhi (Python) | **Intervention sur la partition** : `do_coarse_grain` / `do_blackbox` force une echelle macro et mesure l'information effective (EI) | [ICT-5-CausalEmergence](../../IIT/ICT-5-CausalEmergence.ipynb) | Le `do` s'applique a l'**echelle** : quelle description (micro vs macro) est causalement la plus forte (Hoel 2013, Jansma & Hoel 2025) |\n",
     "\n",
     "**Valeurs croisees (verification inter-paradigme).** Sur le **meme** exemple du barometre (confondeur `BassePression -> {Barometre, Storm}`), les deux versants probabilistes **recoupent** exactement :\n",
     "\n",
@@ -1538,7 +1539,9 @@
     "\n",
     "L'effondrement de la correlation (`0,656 -> 0,310`) lorsqu'on passe de l'observation a l'intervention est le **signal que le moteur fait un vrai travail causal** (mutilation, pas une simple lecture de CPT) -- et les deux moteurs, malgre leurs idiomes differents (mutilation Infer.NET vs `pm.do` PyMC), convergent vers les memes valeurs. Sur le reseau Sprinkler, `P(Cloudy|Rain)=0,800` vs `P(Cloudy|do(Rain))=0,500` (sec 4 ici, et [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) sec 8).\n",
     "\n",
-    "**Ce qu'il faut retenir.** Trois implementations, **un seul do-calculus**. Le paradigme Infer.NET met l'accent sur la **structure** (mutiler le graphe = une operation que le moteur d'inference execute) ; PyMC met l'accent sur la **composabilite** (`do` comme transformation de modele) ; Tweety met l'accent sur le **raisonnement** (causalite sans nombres). Choisir l'un ou l'autre, c'est choisir ce que l'on veut : des probabilites exactes, du sampling flexible, ou des preuves qualitatives."
+    "**L'angle ICT (emergence causale).** Le quatrieme paradigme, [ICT-5-CausalEmergence](../../IIT/ICT-5-CausalEmergence.ipynb), deplace la question : au lieu d'intervenir sur une **variable** (`do(X=x)`), il intervient sur l'**echelle de description** (`do_coarse_grain`) et mesure quelle partition (micro vs macro) maximise l'**information effective**. C'est le meme operateur d'intervention de Pearl, applique a la granularite du modele plutot qu'a la valeur d'un noeud -- d'ou l'expression *emergence causale* (la macro peut etre causalement plus forte que la micro).\n",
+    "\n",
+    "**Ce qu'il faut retenir.** Quatre implementations, **un seul do-calculus**. Le paradigme Infer.NET met l'accent sur la **structure** (mutiler le graphe = une operation que le moteur d'inference execute) ; PyMC met l'accent sur la **composabilite** (`do` comme transformation de modele) ; Tweety met l'accent sur le **raisonnement** (causalite sans nombres) ; ICT (PyPhi) met l'accent sur l'**echelle** (intervenir sur la partition, pas sur la variable). Choisir l'un ou l'autre, c'est choisir ce que l'on veut : des probabilites exactes, du sampling flexible, des preuves qualitatives, ou identifier la bonne echelle de description."
    ]
   },
   {


### PR DESCRIPTION
## Contexte

**Follow-up de #4605** (mergé \`8be251539\`, version 3-paradigmes). Per steer ai-01 (\`cbmil8\`) : la constellation causale inclut **ICT-5-CausalEmergence** (Jansma & Hoel 2025) comme 4e paradigme, le plus distinct conceptuellement — il applique l'opérateur d'intervention de Pearl à l'**échelle de description** (\`do_coarse_grain\` / \`do_blackbox\` sur une partition macro, mesurant l'Effective Information) plutôt qu'à la valeur d'une variable. Le bridge merged était incomplet sans lui.

> Note de transparence : cet ajout ICT-5 avait été rédigé pour #4605 (commit \`3f5ac2ab6\`), mais le commit a atterri **après** le merge d'ai-01 au commit 3-paradigmes (collision de timing, 11:22 merge vs 11:55 push). Récupéré ici sur une branche fraîche depuis \`origin/main\`.

## Changements (constellation cell + cell 0, markdown-only)

- **Title + intro** : « trois paradigmes » → « quatre paradigmes ».
- **4e ligne au tableau** : ICT-5 / PyPhi, idiome = intervention sur la partition (\`do_coarse_grain\`), apport = « quelle échelle est causalement la plus forte » (Hoel 2013).
- **Nouveau paragraphe « L'angle ICT »** : le do-operator passe de l'intervention-sur-variable à l'intervention-sur-échelle (émergence causale : la macro peut être causalement plus forte que la micro).
- **Takeaway** : « Trois » → « Quatre implémentations » + ajoute la dimension échelle.
- **Cell 0 Pont** : « trois » → « plusieurs » + forward-ref « quatre implémentations (y compris ICT-5) » pour cohérence.

## Validation

- **C.2/C.3 exception markdown** : cellules code non touchées (exec_count 1..14 intacts), comparaison cross-langage non exécutable en Infer.NET → pas de re-exec.
- Lien ICT-5 vérifié sur \`origin/main\` (\`../../IIT/ICT-5-CausalEmergence.ipynb\`).
- Base fraîche \`origin/main\`, +7/-4 diff, catalogue byte-identique, submodule intact.

## Verdict SOTA (#3801)

**SOTA-OK.** Bridge éditorial markdown, aucun workaround. Pas de Prong-B (pas un problème de solveur).

See #4208 (partial — bridge éditorial, l'Epic reste ouvert).