### PR TITLE
feat(infer): Infer-22 mediation analysis (Controlled Direct Effect via double do())

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-22-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-22-Causal-Inference.ipynb
@@ -20,6 +20,7 @@
     "- Calculer l'effet causal via **backdoor** et **front-door adjustment**\n",
     "- Reconnaitre le **paradoxe de Simpson** et le resoudre causalement\n",
     "- Aborder le **contrefactuel** (Niveau 3 de l'echelle de Pearl)\n",
+    "- **Decomposer** un effet en part directe et indirect (mediation, section 8)\n",
     "\n",
     "## Navigation\n",
     "\n",
@@ -204,7 +205,7 @@
       "text/html": [
        "\n",
        "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_28_26_15_15_22_50.svg</div>\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_29_26_12_25_36_48.svg</div>\n",
        "    <div style=\"max-width: 800px; overflow: auto;\">\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
@@ -1251,10 +1252,215 @@
   },
   {
    "cell_type": "markdown",
+   "id": "infer22-mediation-intro",
+   "metadata": {},
+   "source": [
+    "## 8. Mediation -- effet direct et effet indirect\n",
+    "\n",
+    "La front-door (section 6) identifie l'**effet total** de X sur Y en passant par le mediateur M. Mais elle ne dit pas **combien** de cet effet transite par M (chemin indirect `X -> M -> Y`) versus le chemin **direct** (`X -> Y`). C'est la question de la **mediation** : decomposer l'effet total en une part mediee et une part directe.\n",
+    "\n",
+    "On definit le **Controlled Direct Effect** (CDE) : l'effet de X sur Y quand on **fige** le mediateur a une valeur m par une seconde intervention `do(M=m)` :\n",
+    "\n",
+    "$$ \\mathrm{CDE}(m) = P(Y{=}1 \\mid do(X{=}1), do(M{=}m)) - P(Y{=}1 \\mid do(X{=}0), do(M{=}m)) $$\n",
+    "\n",
+    "Si l'effet total `TE = P(Y|do(X=1)) - P(Y|do(X=0))` est superieur au CDE, la difference capte la part qui passe **par le mediateur** (effet indirect). C'est une **double mutilation** de graphe -- le meme operateur `do()` qu'en section 3.2, applique deux fois.\n",
+    "\n",
+    "**Exemple.** X = suivre un programme de formation, M = competences acquises, Y = obtenir une promotion. La formation peut mener a la promotion de deux facons : directement (effet de signal / diplome) ou indirectement (les competences declenchent la promotion)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "infer22-mediation-code",
+   "metadata": {},
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Mediation : X=formation, M=competences, Y=promotion\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Effet total        TE     = P(Y|do(X=1))           - P(Y|do(X=0))           = 0,460\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Effet direct CDE   a M=0  = P(Y|do(X=1),do(M=0))   - P(Y|do(X=0),do(M=0))   = 0,300\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Effet direct CDE   a M=1  = P(Y|do(X=1),do(M=1))   - P(Y|do(X=0),do(M=1))   = 0,200\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  -> part mediee (indirect) ~= TE - CDE(M=0) = 0,160  (chemin via les competences)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// MEDIATION : X (formation) -> M (competences) -> Y (promotion), plus chemin direct X -> Y.\n",
+    "// CPTs connus. Effet total (TE) + Controlled Direct Effect (CDE) en figeant M par do(M).\n",
+    "\n",
+    "// P(Y=1 | do(X=x)) -- effet TOTAL (M libre : capte chemin direct + indirect via M)\n",
+    "double PY_doX(bool xVal) {\n",
+    "    var x = Variable.New<bool>().Named(\"x\"); x.ObservedValue = xVal;\n",
+    "    var m = Variable.New<bool>().Named(\"m\");\n",
+    "    using (Variable.If(x))    { m.SetTo(Variable.Bernoulli(0.80)); }  // formation -> competences\n",
+    "    using (Variable.IfNot(x)) { m.SetTo(Variable.Bernoulli(0.20)); }\n",
+    "    var y = Variable.New<bool>().Named(\"y\");\n",
+    "    using (Variable.If(x)) {\n",
+    "        using (Variable.If(m))    { y.SetTo(Variable.Bernoulli(0.90)); }  // formation + competences\n",
+    "        using (Variable.IfNot(m)) { y.SetTo(Variable.Bernoulli(0.60)); }  // formation seule (signal)\n",
+    "    }\n",
+    "    using (Variable.IfNot(x)) {\n",
+    "        using (Variable.If(m))    { y.SetTo(Variable.Bernoulli(0.70)); }  // competences sans formation\n",
+    "        using (Variable.IfNot(m)) { y.SetTo(Variable.Bernoulli(0.30)); }  // baseline\n",
+    "    }\n",
+    "    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;\n",
+    "    return e.Infer<Bernoulli>(y).GetProbTrue();\n",
+    "}\n",
+    "\n",
+    "// P(Y=1 | do(X=x), do(M=m)) -- CDE : on FIGE le mediateur (double mutilation)\n",
+    "double PY_doX_doM(bool xVal, bool mVal) {\n",
+    "    var x = Variable.New<bool>().Named(\"x\"); x.ObservedValue = xVal;\n",
+    "    var m = Variable.New<bool>().Named(\"m\"); m.ObservedValue = mVal;  // do(M) fige le mediateur\n",
+    "    var y = Variable.New<bool>().Named(\"y\");\n",
+    "    using (Variable.If(x)) {\n",
+    "        using (Variable.If(m))    { y.SetTo(Variable.Bernoulli(0.90)); }\n",
+    "        using (Variable.IfNot(m)) { y.SetTo(Variable.Bernoulli(0.60)); }\n",
+    "    }\n",
+    "    using (Variable.IfNot(x)) {\n",
+    "        using (Variable.If(m))    { y.SetTo(Variable.Bernoulli(0.70)); }\n",
+    "        using (Variable.IfNot(m)) { y.SetTo(Variable.Bernoulli(0.30)); }\n",
+    "    }\n",
+    "    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;\n",
+    "    return e.Infer<Bernoulli>(y).GetProbTrue();\n",
+    "}\n",
+    "\n",
+    "double TE   = PY_doX(true) - PY_doX(false);\n",
+    "double CDE0 = PY_doX_doM(true, false) - PY_doX_doM(false, false);\n",
+    "double CDE1 = PY_doX_doM(true, true)  - PY_doX_doM(false, true);\n",
+    "\n",
+    "Console.WriteLine(\"Mediation : X=formation, M=competences, Y=promotion\");\n",
+    "Console.WriteLine($\"  Effet total        TE     = P(Y|do(X=1))           - P(Y|do(X=0))           = {TE:F3}\");\n",
+    "Console.WriteLine($\"  Effet direct CDE   a M=0  = P(Y|do(X=1),do(M=0))   - P(Y|do(X=0),do(M=0))   = {CDE0:F3}\");\n",
+    "Console.WriteLine($\"  Effet direct CDE   a M=1  = P(Y|do(X=1),do(M=1))   - P(Y|do(X=0),do(M=1))   = {CDE1:F3}\");\n",
+    "Console.WriteLine($\"  -> part mediee (indirect) ~= TE - CDE(M=0) = {TE - CDE0:F3}  (chemin via les competences)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "infer22-mediation-interp",
+   "metadata": {},
+   "source": [
+    "**Lecture.** L'effet total de la formation sur la promotion vaut **0,460** (46 points de probabilite). Mais quand on fige les competences acquises (`do(M=0)`, \"formation sans competences\"), l'effet direct retombe a **0,300**. La difference **0,160** est la part **mediee** : ce que la formation apporte a la promotion *via* les competences. Le CDE a `M=1` (0,200) est encore plus bas, car `do(M=1)` place tout le monde en position \"competent\", ou la formation ajoute moins.\n",
+    "\n",
+    "**Ce que montre la cellule.** La front-door (section 6) donnait l'effet total via le mediateur ; la mediation **decompose** cet effet. C'est le meme operateur `do()`, applique deux fois (double mutilation) -- l'inference exacte Infer.NET rend TE et CDE calculables separement et comparables. **Non-trivialite** : l'effet direct (0,300) differe de l'effet total (0,460) de facon **visible**, preuve que le mediateur porte une part reelle de l'effet -- dans un SCM degenere sans chemin indirect, TE egalerais exactement CDE."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cb4121b7afaf",
    "metadata": {},
    "source": [
-    "## 8. Le do-calculus (regles de Pearl)\n",
+    "## 9. Le do-calculus (regles de Pearl)\n",
     "\n",
     "Pearl (1995) a demontre que **toute** quantite causale identifiable peut etre calculee a partir de trois regles de reecriture, qui transforment des expressions avec `do()` en expressions observationnelles (sans `do()`). Soit `G_X` le graphe mutile (arcs entrants de `X` supprimes) et `G_{underline{X}}` le graphe ou les arcs sortants de `X` sont supprimes :\n",
     "\n",
@@ -1274,7 +1480,7 @@
    "id": "b3037c01b965",
    "metadata": {},
    "source": [
-    "## 9. Niveau 3 — Contrefactuel (capstone)\n",
+    "## 10. Niveau 3 — Contrefactuel (capstone)\n",
     "\n",
     "Le niveau 3 de l'echelle de Pearl repond aux questions **contrefactuelles** : *\"Sachant qu'un patient a pris le medicament ET a gueri, aurait-il gueri SANS medicament ?\"*\n",
     "\n",
@@ -1290,7 +1496,7 @@
    "cell_type": "code",
    "id": "7300698aebb9",
    "metadata": {},
-   "execution_count": 10,
+   "execution_count": 11,
    "outputs": [
     {
      "output_type": "stream",
@@ -1405,7 +1611,7 @@
    "id": "6ce82fcee37a",
    "metadata": {},
    "source": [
-    "## 10. Exercices\n",
+    "## 11. Exercices\n",
     "\n",
     "Quatre exercices pour ancrer le do-calculus. Chaque stub s'execute sans erreur (`Console.WriteLine`) ; a vous de completer le code entre les `// TODO`.\n",
     "\n",
@@ -1421,7 +1627,7 @@
    "cell_type": "code",
    "id": "eb5112fe221d",
    "metadata": {},
-   "execution_count": 11,
+   "execution_count": 12,
    "outputs": [
     {
      "output_type": "stream",
@@ -1446,7 +1652,7 @@
    "cell_type": "code",
    "id": "b1ec24f8fe8a",
    "metadata": {},
-   "execution_count": 12,
+   "execution_count": 13,
    "outputs": [
     {
      "output_type": "stream",
@@ -1470,7 +1676,7 @@
    "cell_type": "code",
    "id": "deeb4d1f5bc6",
    "metadata": {},
-   "execution_count": 13,
+   "execution_count": 14,
    "outputs": [
     {
      "output_type": "stream",
@@ -1494,7 +1700,7 @@
    "cell_type": "code",
    "id": "1f39b5a055ca",
    "metadata": {},
-   "execution_count": 14,
+   "execution_count": 15,
    "outputs": [
     {
      "output_type": "stream",
@@ -1546,7 +1752,7 @@
    "id": "41d4daeba16c",
    "metadata": {},
    "source": [
-    "## 11. Synthese\n",
+    "## 12. Synthese\n",
     "\n",
     "| Niveau | Question | Operateur | Methode Infer.NET |\n",
     "|--------|----------|-----------|-------------------|\n",


### PR DESCRIPTION
## Summary

Ajoute la section **8. Mediation -- effet direct et effet indirect** au notebook Infer-22, répondant au greenlight coordinateur (ai-01 `mm89bg`) pour une **extension methodologique** (mediation analysis / instrumental variables).

**Pivot IV -> mediation (documente).** IV en Infer.NET exigerait du parameter-learning ou un Wald post-hoc (pas natif). La **mediation** (Controlled Direct Effect via double `do()`) est l'idiome **natif** d'Infer.NET -- requete conditionnelle sur un SCM a CPTs connus, exactement comme la cellule front-door §6. C'est aussi l'extension **logique** : la front-door donne l'effet *total* via le mediateur ; la mediation *decompose* cet effet.

### Concept

Le **Controlled Direct Effect** fige le mediateur par une seconde intervention :

```
CDE(m) = P(Y=1 | do(X=1), do(M=m)) - P(Y=1 | do(X=0), do(M=m))
```

Si `TE > CDE`, la difference capte la part qui passe **par le mediateur** (effet indirect). C'est une **double mutilation de graphe** -- le meme operateur `do()` qu'en §3.2, applique deux fois.

**Exemple** : X=formation, M=competences, Y=promotion.

## Prong-A : vrai outil SOTA (SOTA-OK)

Vrai moteur Infer.NET (`InferenceEngine` + `CompilerChoice.Roslyn`, EP/VMP). Chaque requete (TE, CDE(M=0), CDE(M=1)) construit un SCM frais avec `Variable.New<bool>` + `.ObservedValue` + CPT via `Variable.If/IfNot` -- le meme idiome que les cellules front-door §6 et contrefactuel §9. Pas de workaround, pas de sampling manuel, pas de reimplementation.

## Prong-B : probleme non-trivial (PROVEN)

L'effet direct **differencier** visiblement de l'effet total dans la sortie committee :

| Quantite | Valeur calculee |
|----------|-----------------|
| Effet total `TE` | **0,460** |
| Effet direct `CDE(M=0)` (competences figees absentes) | **0,300** |
| Effet direct `CDE(M=1)` (competences figees presentes) | **0,200** |
| Part mediee (indirect) `TE - CDE(M=0)` | **0,160** |

**Non-trivialite** : l'effet direct (0,300) differe de l'effet total (0,460) de facon visible -> le mediateur porte une part **reelle** de l'effet. Dans un SCM degenere sans chemin indirect, on aurait exactement `TE == CDE`. La difference 0,160 est la preuve que le moteur fait un travail causal reel (double mutilation), pas une simple lecture de CPT.

## Execution reelle (C.2)

Re-exec end-to-end `.net-csharp` via `scripts/notebook_tools/exec_dotnet_persist.py` :
```
Done: 15 cells executed, 0 errors, saved to Infer-22-Causal-Inference.ipynb
```
- **15 cellules code**, `execution_count` 1..15 (int), 0 erreur.
- Sortie committee = vraie sortie Infer.NET (y compris le spam `Compiling model...` authentique du moteur).
- **C.1** : `grep -ciE "raise NotImplementedError|assert False|1/0"` = **0**.

## Scope

- 1 fichier : `Infer-22-Causal-Inference.ipynb` (+217/-11).
- Sections 8-11 renumerotees en 9-12 (cle cell-id, pas d'XREF cross-section a toucher -- les "section 8"/"sec 8" existantes pointent vers PyMC-4, cross-notebook).
- Bullet mediation ajoute aux Objectifs (cell 0).
- README **non touche** (propriete po-2025:CoursIA, collision-avoidance). Le count "22 notebooks" est inchange (section ajoutee dans un notebook existant, pas de nouveau notebook).
- Catalogue **byte-identique** a `main`. Submodule MGS sans drift.

## Issue tracking

`See #3801` (axe-2 SOTA, partial -- registre des grains real-engine + non-trivial).
`See #4533` (Infer-22 causal/do-calculus notebook Epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)