### PR TITLE
fix(z3): real quantifier witnesses + genuine unknown in Z3-Python-05 (See #3801)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb
@@ -367,16 +367,16 @@
    "id": "nb05-exists-sat",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T08:58:00.677338Z",
-     "iopub.status.busy": "2026-06-13T08:58:00.677081Z",
-     "iopub.status.idle": "2026-06-13T08:58:00.693810Z",
-     "shell.execute_reply": "2026-06-13T08:58:00.691314Z"
+     "iopub.execute_input": "2026-06-29T10:34:10.984580Z",
+     "iopub.status.busy": "2026-06-29T10:34:10.984062Z",
+     "iopub.status.idle": "2026-06-29T10:34:10.994351Z",
+     "shell.execute_reply": "2026-06-29T10:34:10.993813Z"
     },
     "papermill": {
-     "duration": 0.022986,
-     "end_time": "2026-06-13T08:58:00.695017+00:00",
+     "duration": 0.018738,
+     "end_time": "2026-06-29T10:34:10.995401+00:00",
      "exception": false,
-     "start_time": "2026-06-13T08:58:00.672031+00:00",
+     "start_time": "2026-06-29T10:34:10.976663+00:00",
      "status": "completed"
     },
     "tags": []
@@ -386,10 +386,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Formule : Exists(x, x*x == 4)\n",
-      "Resultat : sat\n",
-      "Temoin trouve : x = None\n",
-      "Verification : None * None = None (attendu : 4)\n"
+      "Formule   : Exists(x, x*x == 4)\n",
+      "Existence : sat (un temoin existe)\n",
+      "m[x] (x lie par Exists) : None  <- aucun temoin lisible ici\n",
+      "Temoin concret (constante libre) : racine = 2\n",
+      "Verification : 2 * 2 = 4 (attendu : 4)\n"
      ]
     }
    ],
@@ -397,18 +398,27 @@
     "# Exemple satisfiable : existe-t-il un x reel tel que x*x == 4 ?\n",
     "x = Real('x')\n",
     "\n",
+    "# Etape 1 : prouver l'EXISTENCE avec le quantificateur existentiel.\n",
     "formule = Exists([x], x * x == 4)\n",
-    "print(\"Formule :\", formule)\n",
-    "\n",
     "s = Solver()\n",
     "s.add(formule)\n",
     "res = s.check()\n",
-    "print(\"Resultat :\", res)\n",
-    "if res == sat:\n",
-    "    m = s.model()\n",
-    "    temoin = m[x]\n",
-    "    print(f\"Temoin trouve : x = {temoin}\")\n",
-    "    print(f\"Verification : {temoin} * {temoin} = {temoin} (attendu : 4)\")"
+    "print(\"Formule   :\", formule)\n",
+    "print(\"Existence :\", res, \"(un temoin existe)\")\n",
+    "\n",
+    "# Piege classique : la variable x est LIEE par Exists. Elle n'apparait donc\n",
+    "# PAS dans le modele de la formule quantifiee -> m[x] vaut None, jamais un temoin.\n",
+    "print(\"m[x] (x lie par Exists) :\", s.model()[x], \" <- aucun temoin lisible ici\")\n",
+    "\n",
+    "# Etape 2 : pour OBTENIR un temoin concret, on skolemise : on reasserte la meme\n",
+    "# contrainte sur une constante LIBRE, dont la valeur est lisible dans le modele.\n",
+    "racine = Real('racine')\n",
+    "s2 = Solver()\n",
+    "s2.add(racine * racine == 4)\n",
+    "s2.check()\n",
+    "temoin = s2.model()[racine]\n",
+    "print(f\"Temoin concret (constante libre) : racine = {temoin}\")\n",
+    "print(f\"Verification : {temoin} * {temoin} =\", simplify(temoin * temoin), \"(attendu : 4)\")"
    ]
   },
   {
@@ -416,27 +426,29 @@
    "id": "nb05-exists-sat-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.005196,
-     "end_time": "2026-06-13T08:58:00.705171+00:00",
+     "duration": 0.004707,
+     "end_time": "2026-06-29T10:34:11.006377+00:00",
      "exception": false,
-     "start_time": "2026-06-13T08:58:00.699975+00:00",
+     "start_time": "2026-06-29T10:34:11.001670+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Interpretation : temoin existentiel\n",
+    "### Interpretation : prouver l'existence puis extraire le temoin\n",
     "\n",
-    "**Sortie obtenue** : Z3 trouve un temoin concret (`x = 2` ou `x = -2` selon le solveur) verifiant `x * x == 4`.\n",
+    "**Sortie obtenue** : `Exists([x], x * x == 4)` est `sat` — un temoin existe. Mais `m[x]` vaut `None` : la variable `x` est **liee** par le quantificateur, elle n'apparait donc pas dans le modele. Pour lire un temoin concret, on **skolemise** : on reasserte la contrainte sur une constante **libre** (`racine`), et `m[racine]` donne alors une racine concrete (ici `2`, Z3 pouvant renvoyer l'une des deux racines `2` ou `-2`).\n",
     "\n",
-    "| Aspect | Valeur |\n",
-    "|--------|--------|\n",
-    "| Formule | `Exists([x], x * x == 4)` |\n",
-    "| Resultat | `sat` |\n",
-    "| Temoin | `x = 2` (ou `-2`) |\n",
-    "| Verification | $2^2 = 4$ |\n",
+    "| Etape | Operation | Resultat |\n",
+    "|-------|-----------|----------|\n",
+    "| 1 | `Exists([x], x*x == 4)` puis `check()` | `sat` — l'existence est prouvee |\n",
+    "| 2 | `m[x]` sur la variable liee | `None` — aucun temoin lisible |\n",
+    "| 3 | Reasserter `racine*racine == 4` (constante libre) | `m[racine] = 2` — temoin concret |\n",
     "\n",
-    "> **Note technique** : Avec `Exists`, le solveur cherche un temoin. Avec `ForAll`, il doit raisonner sur **toutes** les valeurs. Cette difference explique pourquoi les formules existentielles sont souvent plus faciles a traiter que les formules universelles."
+    "**Points cles** :\n",
+    "1. Une variable **liee** par `Exists`/`ForAll` n'apparait **pas** dans `s.model()` : `m[x]` y vaut `None`. Le quantificateur prouve l'existence, il ne livre pas le temoin.\n",
+    "2. Pour **obtenir** le temoin, on skolemise : la meme contrainte posee sur une **constante libre** rend sa valeur lisible via `m[racine]`.\n",
+    "3. C'est la difference fondamentale entre *prouver qu'un temoin existe* (`Exists` + `sat`) et *exhiber ce temoin* (contrainte sur une constante libre)."
    ]
   },
   {
@@ -735,10 +747,10 @@
    "id": "nb05-combined-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002964,
-     "end_time": "2026-06-13T08:58:00.807092+00:00",
+     "duration": 0.003824,
+     "end_time": "2026-06-29T10:34:11.108545+00:00",
      "exception": false,
-     "start_time": "2026-06-13T08:58:00.804128+00:00",
+     "start_time": "2026-06-29T10:34:11.104721+00:00",
      "status": "completed"
     },
     "tags": []
@@ -755,11 +767,12 @@
     "### La limite de Z3 : `unknown`\n",
     "\n",
     "Z3 est puissant, mais **indecidable** sur certains fragments. Lorsque le solveur ne peut pas conclure, il repond `unknown`. Cela arrive typiquement avec :\n",
-    "- De l'arithmetic **non lineaire** sur les reels (multiplication de variables)\n",
+    "- De l'arithmetic **non lineaire entiere** (multiplication de variables sur $\\mathbb{Z}$) — indecidable en general (10e probleme de Hilbert)\n",
+    "- De l'arithmetic non lineaire reelle non bornee\n",
     "- Des quantificateurs imbriques complexes\n",
     "- Des formules hors des fragments decides\n",
     "\n",
-    "Il est important de comprendre que `unknown` ne signifie ni `sat` ni `unsat` : le solveur **abandonne**, sans conclusion. Ce n'est pas une erreur, c'est une limite fondamentale de la decision automatique."
+    "Il est important de comprendre que `unknown` ne signifie ni `sat` ni `unsat` : le solveur **abandonne**, sans conclusion. Ce n'est pas une erreur, c'est une limite fondamentale de la decision automatique. Pour eviter une recherche sans fin, on borne le solveur avec un **timeout** : au-dela du budget, Z3 renvoie `unknown` plutot que de boucler."
    ]
   },
   {
@@ -850,16 +863,16 @@
    "id": "nb05-combined-unknown",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T08:58:00.840214Z",
-     "iopub.status.busy": "2026-06-13T08:58:00.840018Z",
-     "iopub.status.idle": "2026-06-13T08:58:00.847698Z",
-     "shell.execute_reply": "2026-06-13T08:58:00.846698Z"
+     "iopub.execute_input": "2026-06-29T10:34:11.142524Z",
+     "iopub.status.busy": "2026-06-29T10:34:11.141828Z",
+     "iopub.status.idle": "2026-06-29T10:34:14.160880Z",
+     "shell.execute_reply": "2026-06-29T10:34:14.160880Z"
     },
     "papermill": {
-     "duration": 0.015687,
-     "end_time": "2026-06-13T08:58:00.848361+00:00",
+     "duration": 3.026019,
+     "end_time": "2026-06-29T10:34:14.161888+00:00",
      "exception": false,
-     "start_time": "2026-06-13T08:58:00.832674+00:00",
+     "start_time": "2026-06-29T10:34:11.135869+00:00",
      "status": "completed"
     },
     "tags": []
@@ -869,43 +882,44 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Formule (non lineaire) : ForAll(x, Exists(y, y*y == x))\n",
-      "Negation = sat\n",
-      "=> FAUSSE : contre-exemple trouve.\n",
-      "   x = (valeur du contre-exemple)\n"
+      "Probleme : a^3 + b^3 == c^3  avec a, b, c > 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : unknown\n",
+      "=> UNKNOWN : Z3 abandonne (raison : timeout).\n",
+      "   L'arithmetic non lineaire entiere est indecidable en general :\n",
+      "   ce n'est PAS un bug, mais une limite fondamentale de la decision automatique.\n"
      ]
     }
    ],
    "source": [
-    "# Cas ou Z3 repond unknown : arithmetic non lineaire complexe sur les reels\n",
-    "# Tentons de prouver une identite trigonometrique... que Z3 ne peut pas decider.\n",
-    "# Exemple plus simple : existe-t-il x, y reels tels que x*x + y*y == -1 ?\n",
-    "# ( trivialement non, mais voyons un cas plus subtil )\n",
-    "\n",
-    "# Formule : pour tout x reel, il existe y tel que y*y == x\n",
-    "# Cette formule est FAUSSE (pour x < 0, aucun y reel ne marche).\n",
-    "# Mais la nonlinearite peut pousser Z3 vers unknown.\n",
-    "x = Real('x')\n",
-    "y = Real('y')\n",
-    "\n",
-    "formule_difficile = ForAll([x], Exists([y], y * y == x))\n",
-    "print(\"Formule (non lineaire) :\", formule_difficile)\n",
+    "# Cas ou Z3 repond REELLEMENT unknown : arithmetic non lineaire entiere.\n",
+    "# Existe-t-il des entiers a, b, c > 1 tels que a^3 + b^3 == c^3 ?\n",
+    "# (Le dernier theoreme de Fermat dit non, mais cette preuve depasse Z3 :\n",
+    "#  l'arithmetic non lineaire entiere est indecidable en general.)\n",
+    "# Sans budget de temps, Z3 chercherait indefiniment -> on borne avec un timeout.\n",
+    "a, b, c = Ints('a b c')\n",
     "\n",
     "s = Solver()\n",
-    "s.add(Not(formule_difficile))\n",
-    "res = s.check()\n",
-    "print(f\"Negation = {res}\")\n",
+    "s.set(\"timeout\", 3000)  # 3 secondes ; au-dela, Z3 abandonne\n",
+    "s.add(a > 1, b > 1, c > 1, a*a*a + b*b*b == c*c*c)\n",
     "\n",
-    "if res == unsat:\n",
-    "    print(\"=> VALIDE (Z3 a decide).\")\n",
-    "elif res == sat:\n",
-    "    m = s.model()\n",
-    "    print(\"=> FAUSSE : contre-exemple trouve.\")\n",
-    "    print(\"   x =\", m.evaluate(x) if x in m else \"(valeur du contre-exemple)\")\n",
+    "print(\"Probleme : a^3 + b^3 == c^3  avec a, b, c > 1\")\n",
+    "res = s.check()\n",
+    "print(f\"Resultat : {res}\")\n",
+    "\n",
+    "if res == sat:\n",
+    "    print(\"=> Temoin trouve :\", s.model())\n",
+    "elif res == unsat:\n",
+    "    print(\"=> Aucune solution (prouve).\")\n",
     "else:\n",
-    "    print(\"=> UNKNOWN : Z3 ne peut pas conclure sur cette formule.\")\n",
-    "    print(\"   La nonlinearite (y*y) rend la decision difficile.\")\n",
-    "    print(\"   Ce n'est PAS une erreur : c'est une limite de la decision automatique.\")"
+    "    print(f\"=> UNKNOWN : Z3 abandonne (raison : {s.reason_unknown()}).\")\n",
+    "    print(\"   L'arithmetic non lineaire entiere est indecidable en general :\")\n",
+    "    print(\"   ce n'est PAS un bug, mais une limite fondamentale de la decision automatique.\")"
    ]
   },
   {
@@ -913,10 +927,10 @@
    "id": "nb05-combined-unknown-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.002423,
-     "end_time": "2026-06-13T08:58:00.853643+00:00",
+     "duration": 0.004002,
+     "end_time": "2026-06-29T10:34:14.168886+00:00",
      "exception": false,
-     "start_time": "2026-06-13T08:58:00.851220+00:00",
+     "start_time": "2026-06-29T10:34:14.164884+00:00",
      "status": "completed"
     },
     "tags": []
@@ -924,16 +938,16 @@
    "source": [
     "### Interpretation : honnetete face a `unknown`\n",
     "\n",
-    "**Sortie obtenue** : selon la version de Z3 et les heuristiques, le resultat peut etre `unsat` (Z3 decide que la formule est fausse en trouvant un contre-exemple dans la negation), `sat`, ou `unknown`.\n",
+    "**Sortie obtenue** : sur `a^3 + b^3 == c^3` (avec `a, b, c > 1`), Z3 ne tranche pas dans le budget imparti et repond `unknown` (raison : `timeout`). Le probleme — un cas du dernier theoreme de Fermat — est hors de portee de la decision automatique : l'arithmetic non lineaire entiere est indecidable en general. Le `timeout` borne la recherche ; sans lui, `check()` ne terminerait pas.\n",
     "\n",
-    "| Cas | Resultat typique | Interpretation |\n",
-    "|-----|-----------------|----------------|\n",
+    "| Theorie | Resultat typique | Interpretation |\n",
+    "|---------|-----------------|----------------|\n",
     "| Arithmetic lineaire reelle | `sat` ou `unsat` | Toujours decidable |\n",
     "| Arithmetic lineaire entiere | `sat` ou `unsat` | Decidable (Presburger) |\n",
-    "| Non lineaire simple | `sat`/`unsat` ou `unknown` | Parfois decidable |\n",
-    "| Quantificateurs + non lineaire | souvent `unknown` | Indecidable en general |\n",
+    "| Non lineaire reelle (bornee) | `sat`/`unsat` ou `unknown` | Parfois decidable |\n",
+    "| Non lineaire entiere | souvent `unknown` | Indecidable en general |\n",
     "\n",
-    "> **Note technique** : `unknown` n'est pas un echec du a un bug. C'est une **limite theorique** : par le theoreme de Godel et l'indecidabilite de l'arithmetic de Peano du premier ordre, aucun algorithme ne peut decider toutes les formules. Z3 fait de son mieux avec des heuristiques puissantes, mais certaines formules restent hors de portee. Quand cela arrive, on peut : (a) simplifier la formule, (b) limiter le domaine (passer de `Real` a `Int` borne), (c) utiliser une tactique specialisee."
+    "> **Note technique** : `unknown` n'est pas un echec du a un bug. C'est une **limite theorique** : par l'indecidabilite de l'arithmetic entiere du premier ordre (theoreme de Matiiassevitch / 10e probleme de Hilbert), aucun algorithme ne peut decider toutes les formules. Z3 fait de son mieux avec des heuristiques puissantes, mais certaines formules restent hors de portee. Quand cela arrive, on peut : (a) simplifier la formule, (b) limiter le domaine (passer a un intervalle entier borne), (c) utiliser une tactique specialisee, (d) accepter `unknown` comme reponse honnete."
    ]
   },
   {
@@ -1020,10 +1034,10 @@
    "id": "nb05-model-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002381,
-     "end_time": "2026-06-13T08:58:00.872737+00:00",
+     "duration": 0.004306,
+     "end_time": "2026-06-29T10:34:14.194017+00:00",
      "exception": false,
-     "start_time": "2026-06-13T08:58:00.870356+00:00",
+     "start_time": "2026-06-29T10:34:14.189711+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1037,7 +1051,9 @@
     "$$\n",
     "\\exists x.\\ \\forall y.\\ (y \\geq 0 \\Rightarrow x \\leq y)\n",
     "$$\n",
-    "Sur les reels, cette formule est satisfiable si `x <= 0` (n'importe quel `x` negatif ou nul est inferieur a tout `y >= 0`). Trouvons un tel modele."
+    "Sur les reels, cette formule est satisfiable si `x <= 0` (n'importe quel `x` negatif ou nul est inferieur a tout `y >= 0`).\n",
+    "\n",
+    "**Pour lire le temoin** `x`, on applique la meme technique qu'a la Section 3 : on **skolemise** le `Exists x` externe en declarant `x` comme une constante **libre**, de sorte que le `ForAll` ne porte plus que sur `y`. La valeur de `x` devient alors directement lisible dans le modele via `m[x]` (au lieu de rester un symbole non evalue si `x` etait lie par `Exists`). Trouvons un tel modele."
    ]
   },
   {
@@ -1046,16 +1062,16 @@
    "id": "nb05-model-min",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-13T08:58:00.879796Z",
-     "iopub.status.busy": "2026-06-13T08:58:00.879622Z",
-     "iopub.status.idle": "2026-06-13T08:58:00.887530Z",
-     "shell.execute_reply": "2026-06-13T08:58:00.886741Z"
+     "iopub.execute_input": "2026-06-29T10:34:14.201879Z",
+     "iopub.status.busy": "2026-06-29T10:34:14.201879Z",
+     "iopub.status.idle": "2026-06-29T10:34:14.210896Z",
+     "shell.execute_reply": "2026-06-29T10:34:14.210896Z"
     },
     "papermill": {
-     "duration": 0.012172,
-     "end_time": "2026-06-13T08:58:00.888108+00:00",
+     "duration": 0.01365,
+     "end_time": "2026-06-29T10:34:14.210896+00:00",
      "exception": false,
-     "start_time": "2026-06-13T08:58:00.875936+00:00",
+     "start_time": "2026-06-29T10:34:14.197246+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1065,35 +1081,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Formule : Exists(x, ForAll(y, Implies(y >= 0, x <= y)))\n",
+      "Contrainte sur x (temoin libre) : ForAll(y, Implies(y >= 0, x <= y))\n",
       "Resultat : sat\n",
-      "Modele trouve : x = x\n",
-      "Interpretation : x est <= a tout y >= 0\n",
-      "Verification : x <= 0.1 ? 1/10 >= x\n",
-      "Verification : x <= 0.001 ? 1/1000 >= x\n"
+      "Modele trouve : x = 0\n",
+      "Interpretation : 0 est <= a tout y >= 0 (un minorant des reels positifs)\n",
+      "Verification : 0 <= 1/10 ? True\n",
+      "Verification : 0 <= 1/1000 ? True\n"
      ]
     }
    ],
    "source": [
     "# Model checking : existe-t-il x tel que pour tout y >= 0, x <= y ?\n",
+    "# x est le temoin recherche (le \"Exists x\" externe). Pour lire sa valeur dans\n",
+    "# le modele, on le SKOLEMISE : on le declare comme constante LIBRE, et le ForAll\n",
+    "# ne porte plus que sur y. Sa valeur devient alors lisible via m[x].\n",
     "x = Real('x')\n",
     "y = Real('y')\n",
     "\n",
-    "formule = Exists([x], ForAll([y], Implies(y >= 0, x <= y)))\n",
-    "print(\"Formule :\", formule)\n",
+    "contrainte = ForAll([y], Implies(y >= 0, x <= y))\n",
+    "print(\"Contrainte sur x (temoin libre) :\", contrainte)\n",
     "\n",
     "s = Solver()\n",
-    "s.add(formule)\n",
+    "s.add(contrainte)\n",
     "res = s.check()\n",
     "print(f\"Resultat : {res}\")\n",
     "\n",
     "if res == sat:\n",
     "    m = s.model()\n",
-    "    val_x = m.evaluate(x)\n",
+    "    val_x = m[x]   # x est libre -> sa valeur est lisible dans le modele\n",
     "    print(f\"Modele trouve : x = {val_x}\")\n",
-    "    print(f\"Interpretation : {val_x} est <= a tout y >= 0\")\n",
-    "    print(f\"Verification : {val_x} <= 0.1 ? {val_x <= RealVal('1/10')}\")\n",
-    "    print(f\"Verification : {val_x} <= 0.001 ? {val_x <= RealVal('1/1000')}\")\n",
+    "    print(f\"Interpretation : {val_x} est <= a tout y >= 0 (un minorant des reels positifs)\")\n",
+    "    print(f\"Verification : {val_x} <= 1/10 ?\", is_true(simplify(val_x <= RealVal('1/10'))))\n",
+    "    print(f\"Verification : {val_x} <= 1/1000 ?\", is_true(simplify(val_x <= RealVal('1/1000'))))\n",
     "elif res == unsat:\n",
     "    print(\"=> Aucun modele : la formule est fausse.\")\n",
     "else:\n",
@@ -1105,31 +1124,31 @@
    "id": "nb05-model-min-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.002679,
-     "end_time": "2026-06-13T08:58:00.893648+00:00",
+     "duration": 0.001621,
+     "end_time": "2026-06-29T10:34:14.216826+00:00",
      "exception": false,
-     "start_time": "2026-06-13T08:58:00.890969+00:00",
+     "start_time": "2026-06-29T10:34:14.215205+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Interpretation : extraction de modele quantifie\n",
+    "### Interpretation : extraction du temoin par skolemisation\n",
     "\n",
-    "**Sortie obtenue** : Z3 trouve un modele ou `x` est inferieur ou egal a tout reel positif. La valeur exacte depend du solveur (souvent `x = 0`).\n",
+    "**Sortie obtenue** : Z3 trouve un modele ou `x = 0` — un reel inferieur ou egal a tout `y >= 0`. La valeur exacte depend du solveur, mais elle est bien **lisible** ici parce que `x` a ete declare comme constante **libre**.\n",
     "\n",
     "| Aspect | Valeur |\n",
     "|--------|--------|\n",
-    "| Formule | `Exists([x], ForAll([y], Implies(y >= 0, x <= y)))` |\n",
+    "| Question posee | $\\exists x.\\ \\forall y.\\ (y \\geq 0 \\Rightarrow x \\leq y)$ |\n",
+    "| Formule resolue (skolemisee) | `ForAll([y], Implies(y >= 0, x <= y))`, `x` libre |\n",
     "| Resultat | `sat` |\n",
-    "| Modele | `x` <= 0 (par exemple `x = 0`) |\n",
-    "| Sens | `x` est un minorant de l'ensemble des reels positifs |\n",
+    "| Modele | `x = 0` (un minorant des reels positifs) |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le model checking avec quantificateurs cherche un **temoin** pour le `Exists` tout en respectant le `ForAll`.\n",
-    "2. `m.evaluate(x)` extrait la valeur de `x` dans le modele (preferable a `m[x]` quand `x` apparait dans un quantificateur).\n",
+    "1. Le `Exists x` externe est **skolemise** : on transforme « il existe `x` » en « voici la constante `x` » (variable libre). Le `ForAll` ne porte plus que sur `y`.\n",
+    "2. Une variable **liee** par un quantificateur ne peut **pas** etre extraite du modele : `m[x]` y vaut `None` et `m.evaluate(x)` renvoie le symbole `x` non evalue. Skolemiser (constante libre) est la facon standard de rendre le temoin lisible — c'est exactement la technique de la Section 3.\n",
     "3. `Implies(y >= 0, x <= y)` restreint la contrainte universelle aux `y` positifs uniquement.\n",
-    "4. Le contraste avec la Section 4 : la, on cherchait `unsat` (preuve) ; ici, on cherche `sat` (modele)."
+    "4. Le contraste avec la Section 4 : la, on cherchait `unsat` (preuve) ; ici, on cherche `sat` (modele) et on **lit** le temoin."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Repairs three **Prong-A defects** (#3801 axis-2) in `Z3-Python-05-Quantifiers-Proofs.ipynb`: demonstration cells whose committed outputs were fabricated/empty and **contradicted their own markdown**. The real Z3 behaviour around quantifier-bound variables was being mis-taught.

| Cell | Defect (before) | Fix (after) |
|------|-----------------|-------------|
| `nb05-exists-sat` | `m[x]` on a var bound by `Exists` returns `None`, yet prose claimed witness "x = 2" | Prove existence with `Exists` (`sat`), show `m[x]` is `None` for the bound var, then **skolemize** onto a free constant `racine` -> real witness `racine = 2` (verified `2*2 = 4`) |
| `nb05-combined-unknown` | nested-quantifier formula returned a clean `sat`/`unsat`, never the advertised `unknown` | Genuinely hard **NIA** problem `a^3 + b^3 == c^3` (a,b,c>1) under a `set("timeout", 3000)` -> reliably `unknown`, `reason_unknown()=='timeout'`. Honest, reproducible demo of Z3's decidability limit (10th Hilbert problem) |
| `nb05-model-min` | `m.evaluate(x)` on a var bound by `Exists` returned the symbol `x` unevaluated; markdown claimed a concrete model | Skolemize the existential witness to a **free constant** -> `m[x] = 0` readable, verifications `True` |

The interpretation/intro markdown is updated to teach the correct **skolemization idiom** (a quantifier-bound variable has no readable witness in the model; re-assert the constraint on a free constant to extract it) and to align every "Sortie obtenue" with the real executed output.

## Validation (real execution)

- Re-executed end-to-end via **papermill** in `coursia-ml-training` (kernel `python3`), z3-solver 4.16.0.
- 12 code cells, all `execution_count` set, **0 errors**.
- Real outputs: `racine = 2` / `unknown (timeout)` / `x = 0` — match the markdown claims.
- Exercise stubs (**3**, #2161) untouched, still return `None` (C.1, no `raise NotImplementedError`/`assert False`/`1/0`).
- Metadata/timestamp churn surgically reverted on untouched cells (diff = real source + the 3 re-executed cells' outputs).
- Catalog / `CATALOG-STATUS` markers: **byte-identical to main** (not touched).

## SOTA verdict (#3801)

**SOTA-OK** — the real tool (z3-solver) is properly invoked; the committed outputs ARE Z3's genuine outputs (including a true `unknown`), no degraded/fabricated substitute. z3-solver was `RECOVERABLE-LOCAL` (pip wheel, installed in `coursia-ml-training`).

See #3801
