### PR TITLE
docs(qc): FR backfill 4 HandsOn strategy READMEs (#3870 batch6)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML/README.en.md
@@ -1,0 +1,32 @@
+# Dividend-Harvesting-ML (HandsOn Ex06)
+
+**Asset class:** US Equities (QQQ 100)
+**Cloud project ID:** None (local only)
+
+## Description
+
+DecisionTreeRegressor dividend prediction. Predicts dividend yield using fundamental ratios. Buys top-10 predicted high-dividend stocks quarterly.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.468 |
+| CAGR | 12.66% |
+| Max Drawdown | 30.6% |
+| Model | DecisionTreeRegressor |
+| Rebalance | Quarterly |
+
+## Files
+
+- main.py - Strategy (v1.0, dividend yield prediction)
+- research.ipynb - Dividend feature analysis
+## References
+
+- Hands-On AI Trading, Section 06, Example 06
+

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML/README.md
@@ -1,32 +1,32 @@
 # Dividend-Harvesting-ML (HandsOn Ex06)
 
-**Asset class:** US Equities (QQQ 100)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions US (QQQ 100)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-DecisionTreeRegressor dividend prediction. Predicts dividend yield using fundamental ratios. Buys top-10 predicted high-dividend stocks quarterly.
+Prédiction de dividendes par `DecisionTreeRegressor`. Prédit le rendement des dividendes à partir de ratios fondamentaux. Achète trimestriellement les 10 actions à dividendes élevés les mieux prédites.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour exécuter.
 
-## Backtest Metrics
+## Métriques du backtest
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 0.468 |
 | CAGR | 12.66% |
 | Max Drawdown | 30.6% |
-| Model | DecisionTreeRegressor |
-| Rebalance | Quarterly |
+| Modèle | DecisionTreeRegressor |
+| Rebalancement | Trimestriel |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (v1.0, dividend yield prediction)
-- research.ipynb - Dividend feature analysis
-## References
+- main.py - Stratégie (v1.0, prédiction de rendement de dividendes)
+- research.ipynb - Analyse des caractéristiques de dividendes
 
-- Hands-On AI Trading, Section 06, Example 06
+## Références
 
+- Hands-On AI Trading, Section 06, Exemple 06

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet/README.en.md
@@ -1,0 +1,30 @@
+# ML-FX-SVM-Wavelet (HandsOn Ex05)
+
+**Asset class:** Forex (4 pairs: EURUSD, AUDUSD, USDJPY, USDCAD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+SVR + Wavelet decomposition on G10 FX pairs. Uses pywt wavelet denoising on price series, then SVR to predict returns.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | SVR + Wavelet (pywt) |
+| Universe | 4 G10 FX pairs |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, SVR + wavelet)
+- research.ipynb - Wavelet decomposition analysis
+## References
+
+- Hands-On AI Trading, Section 06, Example 05
+

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet/README.md
@@ -1,30 +1,30 @@
 # ML-FX-SVM-Wavelet (HandsOn Ex05)
 
-**Asset class:** Forex (4 pairs: EURUSD, AUDUSD, USDJPY, USDCAD)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Forex (4 paires : EURUSD, AUDUSD, USDJPY, USDCAD)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-SVR + Wavelet decomposition on G10 FX pairs. Uses pywt wavelet denoising on price series, then SVR to predict returns.
+SVR + décomposition en ondelettes sur les paires FX du G10. Utilise le débruitage par ondelettes (`pywt`) sur les séries de prix, puis un SVR pour prédire les rendements.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour exécuter.
 
-## Backtest Metrics
+## Métriques du backtest
 
-| Metric | Value |
-|--------|-------|
-| Model | SVR + Wavelet (pywt) |
-| Universe | 4 G10 FX pairs |
-| Rebalance | Monthly |
+| Métrique | Valeur |
+|----------|--------|
+| Modèle | SVR + Ondelettes (pywt) |
+| Univers | 4 paires FX du G10 |
+| Rebalancement | Mensuel |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (v1.0, SVR + wavelet)
-- research.ipynb - Wavelet decomposition analysis
-## References
+- main.py - Stratégie (v1.0, SVR + ondelettes)
+- research.ipynb - Analyse de la décomposition en ondelettes
 
-- Hands-On AI Trading, Section 06, Example 05
+## Références
 
+- Hands-On AI Trading, Section 06, Exemple 05

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending/README.en.md
@@ -1,0 +1,32 @@
+# ML-Reversion-Trending (HandsOn Ex03)
+
+**Asset class:** US Equities/ETF (5 assets)
+**Cloud project ID:** None (local only)
+
+## Description
+
+GradientBoostingClassifier mean-reversion-in-trending. Uses Bollinger Band width, RSI, and return lags to predict next-day direction.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.375 |
+| CAGR | 8.44% |
+| Max Drawdown | 24.4% |
+| Model | GradientBoostingClassifier |
+| Rebalance | Weekly |
+
+## Files
+
+- main.py - Strategy (v1.0, GBM reversion/trending)
+- research.ipynb - Regime detection and model comparison
+## References
+
+- Hands-On AI Trading, Section 06, Example 03
+

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending/README.md
@@ -1,32 +1,32 @@
 # ML-Reversion-Trending (HandsOn Ex03)
 
-**Asset class:** US Equities/ETF (5 assets)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions/ETF US (5 actifs)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-GradientBoostingClassifier mean-reversion-in-trending. Uses Bollinger Band width, RSI, and return lags to predict next-day direction.
+Mean-reversion-en-régime-tendance par `GradientBoostingClassifier`. Utilise la largeur des bandes de Bollinger, le RSI et les rendements décalés pour prédire la direction du lendemain.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour exécuter.
 
-## Backtest Metrics
+## Métriques du backtest
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 0.375 |
 | CAGR | 8.44% |
 | Max Drawdown | 24.4% |
-| Model | GradientBoostingClassifier |
-| Rebalance | Weekly |
+| Modèle | GradientBoostingClassifier |
+| Rebalancement | Hebdomadaire |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (v1.0, GBM reversion/trending)
-- research.ipynb - Regime detection and model comparison
-## References
+- main.py - Stratégie (v1.0, GBM reversion/tendance)
+- research.ipynb - Détection de régime et comparaison de modèles
 
-- Hands-On AI Trading, Section 06, Example 03
+## Références
 
+- Hands-On AI Trading, Section 06, Exemple 03

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning/README.en.md
@@ -1,0 +1,31 @@
+# ML-Trend-Scanning (HandsOn Ex01)
+
+**Asset class:** US Equities/ETF (SPY, TLT, GLD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+RandomForestClassifier trend-scanning. Predicts next-day direction using lagged returns, volatility, and volume features on a 3-asset universe. Monthly rebalance.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.292 |
+| Model | RandomForestClassifier |
+| Universe | SPY, TLT, GLD |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, RandomForest trend scanning)
+- research.ipynb - Feature engineering and model evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 01
+

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning/README.md
@@ -1,31 +1,31 @@
 # ML-Trend-Scanning (HandsOn Ex01)
 
-**Asset class:** US Equities/ETF (SPY, TLT, GLD)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions/ETF US (SPY, TLT, GLD)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-RandomForestClassifier trend-scanning. Predicts next-day direction using lagged returns, volatility, and volume features on a 3-asset universe. Monthly rebalance.
+Scanning de tendance par `RandomForestClassifier`. Prédit la direction du lendemain à partir de caractéristiques de rendements décalés (lagged returns), de volatilité et de volume, sur un univers de 3 actifs. Ré-équilibrage mensuel.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour exécuter.
 
-## Backtest Metrics
+## Métriques du backtest
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 0.292 |
-| Model | RandomForestClassifier |
-| Universe | SPY, TLT, GLD |
-| Rebalance | Monthly |
+| Modèle | RandomForestClassifier |
+| Univers | SPY, TLT, GLD |
+| Rebalancement | Mensuel |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (v1.0, RandomForest trend scanning)
-- research.ipynb - Feature engineering and model evaluation
-## References
+- main.py - Stratégie (v1.0, scanning de tendance RandomForest)
+- research.ipynb - Feature engineering et évaluation du modèle
 
-- Hands-On AI Trading, Section 06, Example 01
+## Références
 
+- Hands-On AI Trading, Section 06, Exemple 01


### PR DESCRIPTION
## Summary

FR backfill de 4 READMEs de stratégies QuantConnect (exemples **HandsOn du livre *Hands-On AI Trading* Section 06**) dans le cadre de **#3870 Phase 0.5** (backfill manuel FR des READMEs EN).

Pattern appliqué (rule `readme-french-first.md` HARD 2) :
- `git mv README.md -> README.en.md` (original EN **byte-identical**, md5 verified 4/4)
- nouveau `README.md` en français (même structure, mêmes métriques, code blocks `lean backtest` intacts, `CATALOG-STATUS` inchangé)

## Stratégies francisées (Section 06 — HandsOn)

| Stratégie | Exemple | Modèle | Univers | Sharpe |
|-----------|---------|--------|---------|--------|
| ML-Trend-Scanning | Ex01 | RandomForestClassifier | SPY, TLT, GLD | 0.292 |
| ML-Reversion-Trending | Ex03 | GradientBoostingClassifier | 5 ETFs | 0.375 |
| ML-FX-SVM-Wavelet | Ex05 | SVR + Wavelet (pywt) | 4 paires FX G10 | — |
| Dividend-Harvesting-ML | Ex06 | DecisionTreeRegressor | QQQ 100 | 0.468 |

## Conformité

- **EN préservé** : `README.en.md` = original EN byte-identical (`md5sum` verified 4/4 — preuve de préservation, non suppression).
- **H2 parity** : `git mv` (séparateur point `README.en.md`, standard i18n Phase 3 de #1650).
- **Catalogue byte-identique** : `COURSE_CATALOG.generated.json/md` inchangés sur la branche (rule `catalog-pr-hygiene.md` HARD 1).
- **0 code/notebook touché** : diff = 8 fichiers docs uniquement (4 renames EN + 4 nouveaux FR), +191/-66.
- **1 domaine QC FR**, sous G.4 (atomique).
- Aucun Cloud ID à préserver sur ces 4 stratégies (local-only).

Deep-queue ai-01 (msg-nxzqhs step 1 résiduel #3870) — poursuite du backfill FR des READMEs QC (~50 candidats EN-only).

See #3870