### PR TITLE
feat(ict): ICT-6 pont tri -> TPM -> emergence causale CE 2.0 (See #4588)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-0-Framing.md
+++ b/MyIA.AI.Notebooks/IIT/ICT-0-Framing.md
@@ -75,13 +75,15 @@ IIT/
 ├── ICT-2-SelfSortingMorphogenesis.ipynb   # ✅ premier livrable (#4588)
 ├── ICT-3-RobustnessDelayedGratification.ipynb  # ✅ étude quantitative
 ├── ICT-5-CausalEmergence.ipynb            # ✅ émergence causale micro/macro (vrai pyphi.macro)
-├── ICT-4/6/7-*.ipynb                       # à venir
+├── ICT-6-SortingToTPM-CausalEmergence.ipynb  # ✅ pont tri → TPM → émergence causale (CE 2.0)
+├── ICT-4/7-*.ipynb                         # à venir
 └── ict/
-    ├── self_sorting.py     # ✅ modèle vue-cellule (Cell, SelfSortingArray, scheduler)
-    ├── sorting_metrics.py  # ✅ sortedness, monotonie, inversions, agrégation, recovery
-    ├── trajectories.py     # ✅ évolution d'états, attracteurs, trajectoire de Φ, événements
-    ├── distances.py        # à venir : distances entre états / structures / trajectoires
-    ├── tpm_estimation.py   # à venir : pont simulation → chaîne de Markov → TPM
+    ├── self_sorting.py      # ✅ modèle vue-cellule (Cell, SelfSortingArray, scheduler)
+    ├── sorting_metrics.py   # ✅ sortedness, monotonie, inversions, agrégation, recovery
+    ├── trajectories.py      # ✅ évolution d'états, attracteurs, trajectoire de Φ, événements
+    ├── causal_emergence.py  # ✅ CE 2.0 (Hoel 2025) : primitives causales, apportionnement, EC
+    ├── tpm_estimation.py    # ✅ pont simulation → chaîne de Markov → TPM (état-à-état)
+    ├── distances.py         # à venir : distances entre états / structures / trajectoires
     └── ...
 ```
 
@@ -95,7 +97,7 @@ IIT/
 | **ICT-3** | [Robustesse & délai de gratification](ICT-3-RobustnessDelayedGratification.ipynb) — étude quantitative : dégradation gracieuse, distributions de récupération, comptage du délai de gratification | ✅ |
 | ICT-4 | Tableaux chimériques & agrégation émergente — le jeu de règles riche du papier (« kin ») | à venir |
 | **ICT-5** | [Émergence causale](ICT-5-CausalEmergence.ipynb) — $\Phi$ et information effective aux échelles micro/macro, recherche de coarse-graining (vrai `pyphi.macro`), émergence discriminante (Jansma & Hoel) | ✅ |
-| ICT-6 | Pont tri → TPM — transformer les simulations en chaînes de Markov analysables par PyPhi | à venir |
+| **ICT-6** | [Pont tri → TPM](ICT-6-SortingToTPM-CausalEmergence.ipynb) — chaîne de Markov estimée depuis les trajectoires de tri, émergence causale multi-échelles (CE 2.0 *scale-free*, au-delà de la borne de taille de PyPhi) | ✅ |
 | ICT-7 | Signatures scale-free & fractales | à venir |
 
 ## Principe méthodologique

--- a/MyIA.AI.Notebooks/IIT/ICT-6-SortingToTPM-CausalEmergence.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-6-SortingToTPM-CausalEmergence.ipynb
@@ -1,0 +1,1205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ict6-title",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005429,
+     "end_time": "2026-06-29T10:57:58.646011+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:58.640582+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# ICT-6 — Du tri a la chaine de Markov : emergence causale d'une morphogenese (CE 2.0)\n",
+    "\n",
+    "> Serie **ICT** (*Integrated Causal Trajectories*), Epic #4588. Voir le [cadrage ICT-0](ICT-0-Framing.md).\n",
+    "> Ce notebook construit le **pont tri -> TPM** annonce dans la feuille de route : il transforme les\n",
+    "> trajectoires de [self-sorting d'ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb) en une **chaine de\n",
+    "> Markov** etat-a-etat, puis y mesure l'**emergence causale** avec l'outillage moderne de\n",
+    "> *Causal Emergence 2.0* (Erik Hoel, [arXiv:2503.13395](https://arxiv.org/abs/2503.13395), 2025)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003401,
+     "end_time": "2026-06-29T10:57:58.654913+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:58.651512+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Pourquoi ICT-6 ? La limite de PyPhi, et ce qui passe a l'echelle\n",
+    "\n",
+    "[ICT-5](ICT-5-CausalEmergence.ipynb) a mesure l'emergence causale avec le **vrai** module\n",
+    "`pyphi.macro` : il enumere les regroupements (coarse-grain) d'un petit reseau et cherche l'echelle\n",
+    "ou $\\Phi$ (ou l'information effective) est maximale. C'est rigoureux, mais **borne** : PyPhi devient\n",
+    "inutilisable au-dela de ~6 noeuds (l'espace d'etats explose en $2^n$, et le calcul de $\\Phi$ est\n",
+    "super-exponentiel).\n",
+    "\n",
+    "Or le systeme qui nous interesse — le **tableau qui se trie lui-meme** d'ICT-2 — a un espace d'etats\n",
+    "qui depasse vite cette limite : pour $n$ elements distincts, il y a $n!$ configurations possibles.\n",
+    "On ne peut donc pas le donner tel quel a PyPhi.\n",
+    "\n",
+    "**Idee d'ICT-6.** On n'a pas besoin de $\\Phi$ pour parler d'emergence causale. Il suffit d'une\n",
+    "**matrice de transition etat-a-etat** (une chaine de Markov) et des primitives causales de Hoel\n",
+    "(determinisme, degenerescence, *effectiveness*, information effective). Le module\n",
+    "[`ict.causal_emergence`](ict/causal_emergence.py) opere directement sur une telle matrice $n \\times n$ :\n",
+    "il **passe a l'echelle** la ou PyPhi cale. Le chainon manquant est l'**estimation de la TPM a partir\n",
+    "des trajectoires simulees**, fournie par [`ict.tpm_estimation`](ict/tpm_estimation.py).\n",
+    "\n",
+    "Le fil du notebook :\n",
+    "\n",
+    "1. rejouer une morphogenese par tri (rappel d'ICT-2) ;\n",
+    "2. **estimer une chaine de Markov** a partir de nombreuses trajectoires (`tpm_estimation`) ;\n",
+    "3. mesurer le **profil causal micro** (chaque permutation = un etat) ;\n",
+    "4. montrer qu'un macro *intuitif* (le niveau de tri) **ne suffit pas** ;\n",
+    "5. laisser l'**apportionnement glouton** de CE 2.0 trouver l'echelle reellement emergente ;\n",
+    "6. quantifier la **complexite emergente** EC — a quel point le travail causal est *distribue* entre echelles.\n",
+    "\n",
+    "> **Provenance / licence.** Le module `ict.causal_emergence` est une **reimplementation independante**\n",
+    "> ecrite a partir des equations de l'article de Hoel (2025) et de la litterature canonique de\n",
+    "> l'emergence causale (Hoel, Albantakis & Tononi, PNAS 2013). Le depot de reference\n",
+    "> `github.com/jessescool/Causal-Emergence-2.0` ne porte **aucune licence** : son code n'est pas\n",
+    "> reutilise, il est seulement cite a des fins de comparaison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ict6-setup",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:57:58.663603Z",
+     "iopub.status.busy": "2026-06-29T10:57:58.663064Z",
+     "iopub.status.idle": "2026-06-29T10:57:59.241249Z",
+     "shell.execute_reply": "2026-06-29T10:57:59.241249Z"
+    },
+    "papermill": {
+     "duration": 0.584532,
+     "end_time": "2026-06-29T10:57:59.242730+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:58.658198+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numpy 2.4.4\n",
+      "algotypes disponibles : ('bubble', 'insertion')\n",
+      "primitives CE 2.0 : ['determinism', 'degeneracy', 'specificity', 'effectiveness', 'effective_information', 'greedy_apportionment', 'emergent_complexity']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Imports et configuration ---\n",
+    "import sys, os\n",
+    "sys.path.insert(0, os.path.abspath(\".\"))  # le package `ict/` est a cote de ce notebook\n",
+    "\n",
+    "import random\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from ict.self_sorting import SelfSortingArray, ALGOTYPES\n",
+    "from ict import sorting_metrics as sm\n",
+    "from ict import tpm_estimation as TE\n",
+    "from ict import causal_emergence as CE\n",
+    "\n",
+    "plt.rcParams[\"figure.figsize\"] = (8, 4)\n",
+    "plt.rcParams[\"axes.grid\"] = True\n",
+    "\n",
+    "print(\"numpy\", np.__version__)\n",
+    "print(\"algotypes disponibles :\", ALGOTYPES)\n",
+    "print(\"primitives CE 2.0 :\", [f for f in (\"determinism\", \"degeneracy\", \"specificity\",\n",
+    "      \"effectiveness\", \"effective_information\", \"greedy_apportionment\", \"emergent_complexity\")])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-recall-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003631,
+     "end_time": "2026-06-29T10:57:59.249953+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.246322+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Rappel — un systeme qui se trie lui-meme\n",
+    "\n",
+    "Dans [ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb), chaque element du tableau est une **cellule\n",
+    "autonome** : elle ne voit que sa voisine et applique une regle locale (`bubble` regarde a droite,\n",
+    "`insertion` regarde a gauche). L'ordre global n'est impose par personne — il **emerge** des decisions\n",
+    "locales. Le tri devient une **trajectoire** dans l'espace des configurations : exactement l'objet\n",
+    "d'etude de la serie ICT.\n",
+    "\n",
+    "Rejouons une trajectoire et regardons sa **sortedness** (degre de tri, dans $[0, 1]$) monter au fil\n",
+    "des activations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ict6-recall-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:57:59.257097Z",
+     "iopub.status.busy": "2026-06-29T10:57:59.257097Z",
+     "iopub.status.idle": "2026-06-29T10:57:59.261808Z",
+     "shell.execute_reply": "2026-06-29T10:57:59.261808Z"
+    },
+    "papermill": {
+     "duration": 0.009767,
+     "end_time": "2026-06-29T10:57:59.262837+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.253070+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "configuration initiale : [3, 1, 5, 0, 4, 2]  sortedness = 0.467\n",
+      "configuration finale   : [0, 1, 2, 3, 4, 5]  sortedness = 1.0\n",
+      "nombre de pas enregistres : 21  | swaps : 8\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Une morphogenese par tri : 6 cellules 'bubble', depart melange, scheduler asynchrone seede.\n",
+    "demo = SelfSortingArray([3, 1, 5, 0, 4, 2], seed=1)\n",
+    "demo.run(max_steps=500)\n",
+    "\n",
+    "vals = demo.probe.values\n",
+    "print(\"configuration initiale :\", vals[0],  \" sortedness =\", round(sm.sortedness(vals[0]), 3))\n",
+    "print(\"configuration finale   :\", vals[-1], \" sortedness =\", round(sm.sortedness(vals[-1]), 3))\n",
+    "print(\"nombre de pas enregistres :\", len(vals) - 1, \" | swaps :\", demo.probe.swaps)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ict6-recall-plot",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:57:59.270896Z",
+     "iopub.status.busy": "2026-06-29T10:57:59.270896Z",
+     "iopub.status.idle": "2026-06-29T10:57:59.459812Z",
+     "shell.execute_reply": "2026-06-29T10:57:59.459812Z"
+    },
+    "papermill": {
+     "duration": 0.194055,
+     "end_time": "2026-06-29T10:57:59.460890+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.266835+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEEAAAFeCAYAAABq2QE9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAdHVJREFUeJzt3Qd4VEXbBuAnvZBCSUISOgIC0qQKSIfQROw0KQqoCEiRFnpoIaCAAoKg9CoiotJ7kSbNj450JI2akELq/tc737f5k5BACBvO2exzX9chuye7Z2dnspzZ98y8Y2UwGAwgIiIiIiIiIsrlrLUuABERERERERHRi8AgCBERERERERFZBAZBiIiIiIiIiMgiMAhCRERERERERBaBQRAiIiIiIiIisggMghARERERERGRRWAQhIiIiIiIiIgsAoMgRERERERERGQRGAQhIiIiIiIiIovAIAhRLrd7925YWVmpn+bsyJEjsLe3x/Xr15/62OLFi6Nbt27ITeT9yPvS0rVr19Tf0qJFi1L2DRs2DLVq1dK0XERElDvklj4LEekbgyBET3Dq1Cm89957KFasGBwdHVGoUCE0a9YMM2fONHm9TZo0Cb/++ivbIxMjRoxAhw4dVFvQ89u4cSPGjh373Mfp378//v77b/z2229sFiIiDUhgWgIHR48eZf3nAqY6P2fFgQMH1Gs9ePDghbwekV4wCEL0hBND9erV1Re8nj17YtasWejRowesra3xzTffmLzeGATJ3MmTJ7F9+3Z89tln/Hs1YScrICDgmZ4jAajY2Fh07tw5ZZ+3tzfatm2Lr776im1DRETPpX79+uo8Iz8tVXbOz8/T15XXYhCELI2t1gUg0quJEyfC3d0df/31F/LmzZvmd+Hh4SZ5DYPBgEePHsHJyckkx8utFi5ciKJFi+K1116DnkVHRyNPnjzIbRITE5GcnKymI8mIqPQ++OADvP/++7hy5QpKliypSRmJiEif5PwRHx+f4fkjPbnQlJXH6fH8SETmgyNBiDJx+fJlvPLKK48FQISXl9djJ8Hx48fjpZdegoODg8rdMHz4cMTFxaV5nOx/4403sGXLFjXKRIIf33//vRrGKl+gFy9erG7Lljqnxa1bt/Dxxx+jYMGC6vhSrgULFjxWrn///RdvvfWW+iIuZRwwYMBjZRANGzZEhQoVcPbsWTRq1AjOzs5qqs+UKVMee6w8f8yYMShVqpR67SJFimDIkCGPHXfbtm14/fXXVX25uLjg5ZdfVnWQmkwjkrLL6+XLl0/VwYoVK576NyjThBo3bqzqJX0QacKECShcuLA6pryXM2fOZHgMucohUzek/PI+5P0EBQWpzktqd+/eVSMd3Nzc1Hvp2rWrGg2UPheGtI+8T/k7adWqFVxdXdGpUyf1OznmjBkz1HuVzpy026effor79+8/9b0a36+0jzxXfq5bty7Dx2X3daTss2fPVreNf2/GujXm/ZCRHXJs49+0/K1klBNENG3aVP1cv359lt4fERHlLOM5SvoP0i+Q256enhg0aBCSkpLUYxISEpA/f3589NFHjz0/MjJSnVfk8c/aH5DzRJ8+fbB8+XJ1fpLHbt68Wf1u1apVqFatmjpnynm2YsWKaUbXZpYTZM2aNep50m/y8PDAhx9+qN7bs75no6eVIyNPOj+K8+fPqynUUqdSd9LHST9VVOpcRl6ULl1aPaZAgQKq7yR9qKedn4W8dp06ddTzpC7kPfz888+PldXYBsb+hLHvaGwHIdNgBg8erG6XKFEi5bXkfRotW7Yspd7lfbVv3x43b95M81r//PMP3n33XTUyVN6T9MnkcREREU+sTyItcSQI0ROG/h88eBCnT59WJ5AnkWkyEsCQk9+XX36Jw4cPIzAwEOfOnXvsC+yFCxdUbgv5sirTbCRYsHTpUnWMmjVr4pNPPlGPk5OrCAsLUyMgjCc0OaFv2rQJ3bt3V50U+WIvZPhokyZNcOPGDXzxxRfw9fVVx925c2eGZZYvyi1atMA777yjruTLSXTo0KGqI9CyZcuUL9lvvvkm9u/fr8pVrlw5lSdl+vTpuHjxYkoOEwk8SHCnUqVKGDdunDrZXrp0CX/++WfK682fP1+VS+qoX79+agTMf/7zH1VXHTt2zLRupTMj76lq1aqP/W706NEqCCJBCNmOHz8OPz8/dcUptZiYGDRo0EAdS+pdRpXIEFB/f3+EhISozozx/bZp00YlYe3VqxfKli2rvthLICQjEvxq3ry56sBIx0QCMUJeQwIF0rGU93z16lU1nerEiROqTuzs7DJ9v1u3blWdifLly6u/IQnKyHGkU5Fedl9HnhccHKw6XfI3ktnoG2kjaXdpT+n8pA8YGcmIKfl7ldeUwBsREWlPvvjLOUqSV8s5SqaVfv311+r/aznHyTni7bffxi+//KIuyKQezSDndwluyJfZZ+kPGEnf46efflL9FglayEUgOedI/0f6KnIRQkg/Sc4d0i/IjPE8V6NGDXVelH6RBCzkeXK+S32x6mnvWWS3HE86P0o/qG7duuqCkiQMl4tR8v4lGLN27VpVz8bAg7wHY59P+nGSy0X6L5Jz7mnnZ3nf0g5y0UX6OhLMkZGYf/zxB1q3bp3msdJW0raff/65CvZ8++23qn8hfSoJokj/T9pu5cqVqh2lnYT0M40jokeNGqX6iFLe27dvq4tZMlXJWO9SBqlv+Vvp27evCoRIX0vKIxefpH9ApEsGIsrQ1q1bDTY2NmqrXbu2YciQIYYtW7YY4uPj0zzu5MmTBvko9ejRI83+QYMGqf07d+5M2VesWDG1b/PmzY+9Xp48eQxdu3Z9bH/37t0NPj4+hjt37qTZ3759e4O7u7shJiZG3Z8xY4Y69k8//ZTymOjoaEOpUqXU/l27dqXsb9Cggdq3ZMmSlH1xcXEGb29vw7vvvpuyb+nSpQZra2vDvn370rz23Llz1fP//PNPdX/69Onq/u3btzP9a2rbtq3hlVdeMTyr7du3q2P//vvvafaHh4cb7O3tDa1btzYkJyen7B8+fLh6fOq6HD9+vKrfixcvpjnGsGHDVPveuHFD3V+7dq16rtSlUVJSkqFx48Zq/8KFC1P2y/FlnxwjNakr2b98+fI0+6XNM9qfXpUqVVR7P3jwIM3fojxX/n5M9Tq9e/dWj0vv6tWrar+bm5uq44x+l7oejPz8/AzlypV74msSEZHpyf/J8n/zX3/99dg5aty4cWke++qrrxqqVauWcl/6NRmdY1u1amUoWbLkM/cHhNyXx545cybNY/v166fOLYmJiZm+F+mrpO6zSJ/Ly8vLUKFCBUNsbGzK4/744w/1uNGjRz/ze85KOTLypPNjkyZNDBUrVjQ8evQoZZ/0TerUqWMoXbp0yr7KlSurfkt2zs/C2OczkvqRupF+SmryfOkjXbp0KWXf33//rfbPnDkzZd/UqVPVPnlvqV27dk31jyZOnJhm/6lTpwy2trYp+0+cOKGev2bNmie+JyK94XQYokxIRF5GgkjEXaZDyFQRiXZLlD/18EZJYCUGDhyY5vkyIkRs2LAhzX4ZcijHyWKQUl1BkNEJcvvOnTspmxxDhhrK1QNjOXx8fNRICyMZmWAcWZKeDBOV4aRGcgVIrkpIXofUw0/lao+MiEj92jI1RezatUv9NF6FkVETmY0WkMfIdB3JsfIsZCSEkOkzqcnVHbkCIVceUg8VNY6MSU3eR7169dQxUr8PmcYhV4327t2rHifDROXKmIzQST0/uXfv3pmWz3hlKfVryZUP+ftJ/VoynFTq3FhnGZFRKZIEVkaepL56IseSkSGmep2skKtFxqtBWWGsWyIi0o/0CcXlXJj6PC/ncxkBsHr16jQjRWUkQrt27Z65P2Akoy/Tn7ekHyBTf41TP7JCRklIHjYZzZA6V4iMepCypO9jZeU9Z6ccTzo/3rt3T418kRETDx8+TKkb6b9IX02mixin7shry6gR2ZcdqXPISTtJP1Den7EvmJr0cYyjioWM1pWpP6nrIjMygkT6c/KeUre3jPSQqTzG9jb2VWSat4y6JTIXDIIQPYEMvZQTgZxoZIqETJ+QE5wEGoxzQK9fv66+KMsc2dTkRCEnO/l9+iBIVsnQQxlOOG/ePHXCTb0Z5/Aak7TK60gZ0ufNkOk2GZHpFekfK19kU+eTkJO0nKzTv3aZMmXSvLZ0lGQYqAyXlLwUMnxWhoGmDojIVBv5ci6BFjmBSmAh9XSZp/nvhY3/Z6xXOVZqUr70ARN5HxLgSP8+jLksUtehBJKM01qM0retka2t7WPTVOS1pFMiOVnSv15UVNQTk+pm9p4yasfneZ2seJa/U2P7pP97IiIi7UjQIH0wO/15Xs5j8qVeLmIYc3tIv0dyV6QOgmS1P/Ckc4gEMuTxMuVWzp2S6yx1joonnRcz6stIECR9Hysr7zk75XjSe5Ppv3IOlKkj6etHcqikrh+ZMiz9Onl9mX4sOTlkanBWyTQTmSIt71Om4chrzJkzJ8P8GzL1N730dZEZaW95T9IfSf+eZOqQ8f1IXchFwB9++EEF0yToIzlNmA+E9I45QYiyQEZJSEBENjlxSQBCrooYT24iq18An2UlGGMQQUZsZJaXQiL72WFjY/PUYIO8vpykp02bluFjJSma8T3JaAq5MiBXZaQzIVeV5AqR5LiQ15IrSJIPRU7g8nsZ4fLdd9+pvB5PWgpO5q2KrCYVzYi8DxkxIQncMmLsxD0rmQssAbD0ryWBCUkIl5FnGV3xJDn9Os+6YpG0j3E+MRERaS+z83x6cuFCcoJIvjHJYSEXMSTAULly5WfuDzzpHCLnLBntKKMG5LVkk/waXbp0UXnVXtR7ft5ypH9vxr6aJGDNbKSv8WKK5NOQhOoSdJL+kQQPJB/H3Llz1YWkJ9m3b58anSzHkP6TXLSR0atS9oySzGeln5cZeU/Sr5W6yeg4clHLSHKuSEJX43uSHGWS9+TQoUMZ5jMj0gMGQYiekWT7Nk5dMCZQlZOFRM3li76RJO6SaL/8PisyCqLIF1lJZiVTNoyjFjIjryNJXNNfkZfAQ3bJMEqZCiTJw54W5JFggDxONukkTZo0CSNGjFCBEWPZJVGYXFmSTaaySFIuSbwlI2wyWxJPOmJCkn6mf79C6j31sqwyeiZ9wETeh4yOyEodSnllSGfq0SBylSer5LVkqo6MjHnWQELq95Re+nZ8ntcRph61Ie2TusNMRETmQb5UyxdquXghib5laoecv7PbH3jaRSWZ4iub9J1kVIYEYGQURUajLo3nRTkHGqfeGMm+rPaxnrccT2Lsg0hA4mn9DGFckUc26ZtI/UvCVGMQJLP6lYtH0leS4I1chDGSIEh2ZfZa0t7Sn5SRHlm5UCQBMtlGjhypEs9L30QCO5K8nkiPOB2GKBPyZTijaLkxB4hxaKasSiKMK4wYGa+WpM/WnRkJEEjQJDWJvsswVTnxSYAjPfnCbyTlkIziqZdKky/zMpUmu2QuqMxjlZVd0pPVaGROrXE+bHpVqlRRP43Da425PVJ3QGS+sNSxDLvNjORgkStMMi84NeloSIdDMpWnbqf07WB8H5LfRToO6UmdyyovQq7gSFlSv1/pHBmXq8sKeS0JWsmSyenJ66Rv49SkEyr1JleiUg8llXnLxulXpngd49+beNrjskLKKle2ZNk+IiIyL3IRQ6b5/v7772pFEjmHpJ4K8yz9gSdJ3w+Q1zWOZk2/zG7qC08yckO+UKd+jIxQkGkZWe1jPW85nkTK17BhQxVEMV4gy6yvlv61ZUSFBF1Sv25m52fpE0rQIvVyv7KcbfqVeZ5FZq8lF6nk9WSkbvq+sNw3vg9Z3cbYhzKSYIjUaXbqkuhF4UgQokxIwk0JIsiyZjIaQUYuSHRbrpTIUm/GnBxy9VumqkiwQU4ikgxM8ofIF1kZVtqoUaMs1bEktJQr+xI8keVtJfouS7xNnjxZBWTktiTslMCBBB0kCZY83hiAkN/J8qgynPPYsWPqC7V0ZtLnt3gWnTt3VsNiJcmYlEEi+3LyPX/+vNovQQXpoMgcV5kOI50RuSojc0VlqKYMg5SrSkKWrpU8KXIMyRsinRcprzxHRrs8Sdu2bdVSw6lHucgoGRl6KkMuZXleCQLJkm3SMUo/LUPm3EoyW3mcDNmUupYOmyzvJ0Ej6UTIc6S9JGeJJLWV0R/S7vI8Yx1n5eqXtL8scSflkuG28r4lWCOjO2QKlSxvlzp5bXryPKkTqTeZpyyvLYGeV155RV0xMtXrSB0IGbYqwR/p7BiXQnxW8ncobSPtRERE5keCHnKukWm+8iU29cjWZ+kPPImMdJBzmozokP6B5POQ15Tgf/rXM5LzmixjK30uOe/J0rbGJXKlL5adZdmzU46nkYslct6WupP+mIwOkXLKBRhJCi+jaIT04SRgIudgGREiF3ikHyJLCT/t/Cx9A+kjtmjRAh07dlR9LXldCaI8S16R1IyvJSN/5DWkvmV0jIwEkVEcMlJX+kjSP5K+moz6lP6YJN2XPpiMGpKyyzK9MmJEAiLS9zRexCPSLa2XpyHSq02bNhk+/vhjQ9myZQ0uLi5qqTFZbrZv376GsLCwNI9NSEgwBAQEGEqUKGGws7MzFClSxODv759mqTQhS5xmtjTa+fPnDfXr1zc4OTk9tsSrvJ4smSbHlePLUrayHNu8efPSHOP69euGN9980+Ds7Gzw8PBQy8AZl0xNv0RuRsvVymumXobVuPxaUFCQeryDg4MhX758aqk5eb8RERHqMTt27FBL4Pr6+qp6kp8dOnRIsyTt999/r95fgQIF1HFeeuklw+DBg1OO8STHjx9X7yH90nyyfK2UQ5aUlXpr2LCh4fTp0+o9pF9u+OHDh6pNpA2ljFI/snTdV199lWbZY1nmt2PHjgZXV1e1BHG3bt3U0n/y+qtWrUpTV7LsbmakbaSepFxyLFk6T5ZZDg4Ofur7laV6ZblZqafy5csbfvnllwzb5nleR5YGlL9lT09Pg5WVVcpyfMYlAGXZvPQyWyK3Xbt2htdff/2p74uIiF7cErkZnaPGjBmT4fKrspyr9DHkdxMmTMjwdbLSHxByDOmzpPfzzz+r5dRlyVs5DxctWtTw6aefGkJCQjJdItdo9erVaqlbed38+fMbOnXqZPj333/TPCar7zkr5cjIk86P4vLly4YuXbqoPpr01QoVKmR444031OsZSd3WrFnTkDdvXnXelj6mLDebuh+S2flZ/Pjjj2rJXakHea60fUZtmlkbZNQ/Gj9+vCqrLGucfrlc6Y/I+V3qVTZ5TTnuhQsX1O+vXLmi+srSp3N0dFRt06hRI8P27dufWJdEWrOSf7QOxBARPY3MQ5YRMnKF4UWToaYyImj//v3q6hf9v9DQUDVqadWqVRwJQkRERES6xyAIEZmFw4cPo169emq6R3YToWWFzG1OnWhUhvvKVBMZsipf+LOThDQ3GzZsmBoOK1PAiIiIiIj0jkEQIqJ0c4UlEFK7dm2V1OuXX35RuWBktRuZG0tEREREROaLQRAiolRWrFih1ryXxKiPHj1SCcd69eqVJmkZERERERGZJwZBiIiIiIiIiMgiWGtdACIiIiIiIiKiF4FBECIiIiIiIiKyCLawMMnJyQgODoarqyusrKy0Lg4REZHFMRgMePjwoVr22to6d1yPYf+CiIjIPPoXFhcEkQBIkSJFtC4GERGRxbt58yYKFy6cK+qB/QsiIiLz6F9oGgTZu3cvpk6dimPHjiEkJATr1q3DW2+99cTn7N69GwMHDsSZM2dUMGPkyJHo1q1bll9TRoAYK8bNzQ2mkpCQgK1bt8LPzw92dnYmOy6ZDttI39g++sc20jdzap/IyEh1Djeek3MD9i8slzl99iwR20f/2Eb6lpAL+xeaBkGio6NRuXJlfPzxx3jnnXee+virV6+idevW+Oyzz7B8+XLs2LEDPXr0gI+PD5o3b56l1zROgZEAiKmDIM7OzuqYev/jsFRsI31j++gf20jfzLF9ctO0VPYvLJc5fvYsCdtH/9hG+paQC/sXmgZBWrZsqbasmjt3LkqUKIGvv/5a3S9Xrhz279+P6dOnZzkIQkRERERERESWyayykR08eBBNmzZNs0+CH7KfiIiITGvLtS0Yd3CcSjRGRERElBuYVWLU0NBQFCxYMM0+uS9zf2JjY+Hk5PTYc+Li4tRmJI81DuuRzVSMxzLlMcm02Eb6xvbRP7aR5bRPsiEZ807Nw7zT89T9ap7V4FfMD6bCcyURERFpxayCINkRGBiIgICAx/ZLcheZ22Rq27ZtM/kxybTYRvrG9tE/tlHubp94QzzWxqzFmYQz6n5dh7qIPx2PjWc2mqiEQExMjMmORURERJRrgyDe3t4ICwtLs0/uS5KWjEaBCH9/f7WaTPqMsZLd1tSJUaXj2axZM7NJGGNp2Eb6xvbRP7ZR7m+f0OhQDNg7ABcSLsDW2hYjaoxA25famrysxlGZRERERC+aWQVBateujY0b016Jkg6f7M+Mg4OD2tKTDmJOBCty6rhkOmwjfWP76B/bKHe2z8nwk+i/qz/uPrqL/I75Mb3hdFQtWDXHyqg3SUlJGDt2LJYtW6am3/r6+qJbt24YOXJkrlrFhoiIyNJpGgSJiorCpUuX0iyBe/LkSeTPnx9FixZVozhu3bqFJUuWqN/L0rizZs3CkCFD1LK6O3fuxE8//YQNGzZo+C6IiIjM22+Xf8PYA2ORkJyAMvnKYGbjmfB18YUlCQoKwpw5c7B48WK88sorOHr0KD766CO4u7vjiy++0Lp4RERElBuCINLBaNSoUcp947SVrl27YtGiRQgJCcGNGzdSfi/L40rAY8CAAfjmm29QuHBh/PDDD1wel4iIKBuSkpPwzfFvsPDMQnW/cZHGCKwXCGc70+fM0rsDBw6gbdu2aN26tbpfvHhxrFy5EkeOHNG6aERERJRbgiANGzZ84rJ7EgjJ6DknTpzI4ZIRERHlblHxURi6byj2/rtX3f+k0ifoXaU3rK2sYYnq1KmDefPm4eLFiyhTpgz+/vtv7N+/H9OmTcvw8S9q9bmQkaPg+89F3Nq4CdYmnJZjX7o08vfpDStry2xvU+LKWfrG9tE/tpG+JZjRKqhZLaNZ5QQhIiKi53cz8ib67uyLyxGX4WDjgPF1x6NliZYWXbXDhg1TgYyyZcvCxsZG5QiZOHEiOnXqpOnqcyV274ZLRARicQ6mFL17Ny6EheJB3bomPa4l48pZ+sb20T+2kb5tM4NVULO6+hyDIERERBbkSMgRDNwzEBFxEfBy8sI3jb9BBY8KsHSSY2z58uVYsWKFygkiOcr69++vEqTKNF2tVp97kJiIM8eOo1z5cio4Ywrxly8jYtlyFNyyFdU//hj2L71kkuNaKq6cpW9sH/1jG+lbghmtgprV1ecYBCEiIrIQP134CYGHA5FoSESFAhVUAMTL2UvrYunC4MGD1WiQ9u3bq/sVK1bE9evX1YiPjIIgL2r1ubxvvokIW1vkb9XKZMeVqciJ164jev9+hA8fgeKrVsLK3t4kx7ZkXDlL39g++sc20jc7M1gFNavl40RQIiKiXE5WfZl4aCLGHxqvAiAy9WVhi4UMgKQbQmudLj+GjLxITk5GbiNL/vpMnAgbd3c8OnsWt7/7TusiERERvTAMghAREeViMu2l1/ZeWHVhlbrfr2o/BNULgqOto9ZF05U2bdqoHCCyCt21a9ewbt06lRT17bffRm5kV9AL3uPGqdt3581HzHEmnSciIsvAIAgREVEudeXBFXTc0BGHQw7DydYJ3zT6Bj0q9lAjASitmTNn4r333sPnn3+OcuXKYdCgQfj0008xfvz4XFtVbs394N62LZCcjOChQ5EcHa11kYiIiHIcgyBERES50L5/96HTxk648fAGfPP4YmnLpWhctLHWxdItV1dXzJgxQ+UBiY2NxeXLlzFhwgTY5/JcGQVHjoCtrw8Sbt5E2OQgrYtDRESU4xgEISIiykUk6eWSM0vQZ2cfRCVEoapXVax8YyVezv+y1kUjHbJxdYXv5MmSKAQP1qzBw507tS4SERFRjmIQhIiIKJeQpKcBhwMw9ehUJBuS8U7pd/CD3w/I75hf66KRjuWpWRP5P/pI3Q4ZOQqJd+9qXSQiIqIcwyVyiYgo15Av/ufvnUdMQgwsTXxiPBZELcCNiBuwtrLG4OqD0alcJ+b/oCzx7N9PLZkbd/EiQkaNRuHZs/i3Q0REuRKDIERElCtExUdhyN4h2HdrHyyZi50LvmrwFeoWqqt1UciMWNvbw3fqFFx7731E7dyJiLVrkfe997QuFhERkckxCEJERGbvZuRN9N3ZF5cjLsPe2h6FXAvBEnOB2MTYYIrfFJTxKKN1ccgMOb78shoREj71K4ROCoRzzZqwL1pU62IRERGZFIMgRERk1o6EHMHAPQMRERcBLycvfNv4W7zi8QosTUJCAjZu3IgS7iW0LgqZsfzduiFq127EHD2K4KHDUGzZUljZ2GhdLCIiIpNhYlQiIjJbq8+vxqfbPlUBkAoFKqhVUCwxAEJkKhLw8A2aDOs8eRB74gTu/vAjK5eIiHIVBkGIiMjsJCQnYMKhCZhweIJaEaVViVZY2GIhvJy9tC4akdmzK1QIBUeNVLdvz5yJR2fPal0kIiIik2EQhIiIzIqM+ui1rRdWX1gNK1ihX9V+mFxvMhxtHbUuGlGu4d62LVz9/IDERNwaMgTJjx5pXSQiIiKTYBCEiIjMxpUHV9BhQwccDj0MJ1snzGg0Az0q9uBSnkQmZmVlBe+AsbDx9ED8pcsInzaNdUxERLkCgyBERGQW9v27D502dsLNhzdRyKUQlrVahsZFG2tdLKJcyzZfPvhOnKhu31+yFNEHDmhdJCIioufGIAgREel+6dfFZxajz84+iEqIQlWvqljRegXK5OMysEQ5zaV+feTt0F7dDvYfjqSICFY6ERGZNQZBiIhIt+KT4jHqz1H46uhXSDYk493S7+IHvx+Q3zG/1kUjshgFBw+GfbFiSAwLQ+i48VoXh4iI6LkwCEJERLp0J/YOum/pjvWX18PayhrDag7DmNpjYGdjp3XRiCyKtbMzfKcEATY2iNywARF/bNC6SERERNnGIAgREenO+XvnVQLUk7dPwtXOFXOazEGncp2YAJVII06VK8Pjs8/U7dBx45AQGsq2ICIis8QgCBER6cr269vRZVMXhEaHophbMSxvvRx1CtXRulhEFs/js0/hWKkSkiMjEezvD0NyssXXCRERmR8GQYiISDcJUOf+PRcDdg9AbGIsavvUxvJWy1HCvYTWRSMiWTbXzg6+QZNh5eiImIOHcH/ZctYLERGZHQZBiIhIcxL0GLx3MGafnK3uy9SX75p+B3cHd62LRkSpOJQogYJDh6jb4V9/jbhLl1g/RERkVhgEISIiTcm0l26bu2HLtS2wtbJVyU8lCaqttS1bhkiH8rZvjzz16sEQF4dbQ4bAEB+vdZGIiIiyjEEQIiLSzH9u/0clQD179yzyOeTDfL/5eK/Me2wReuGKFy+uEu+m33r37s3WSEfqxWfiBNi4uyPu7Dncnv0d64iIiMwGL7MREWVRSFQI/Pf74/Sd0xZbZ0lJSRi/erzJjhefFA8DDCiVtxRmNp6Jwq6FTXZsomfx119/qb9vo9OnT6NZs2Z4//33WZEZsPPygve4cbjVrx/uzp8Plwb14Vy1KuuKiIh0j0EQIqIsOBl+Ev129cO9R/csvr4SkxJNWgeNizTGpHqTkMcuj8XXLWnH09Mzzf3JkyfjpZdeQoMGDTQrk965NfdDVNu2iFi/HsFDh6HEunWwceHnmIiI9I1BECKip1h/aT0CDgYgITkBZfKVwcTXJ8LN3s3i6i0hMQG7du1Co0aNYGdrZ5Jj2lnbwdM57ZdPIq3Fx8dj2bJlGDhwoJr6kZG4uDi1GUVGRqqfCQkJajMV47FMeUxTyj90CKKPHEHCzZsInTQRXgEBsDR6byNLx/bRP7aRviWY0f9xWS0jgyBERJlISk7CjOMzsOjMInW/SdEmmPT6JDjbOVtkncmJJZ91Pvjm8YWdnWmCIER69Ouvv+LBgwfo1q1bpo8JDAxEQAZf+Ldu3QpnZ9P/H7Ft2zboldObbVB43nxE/rIO51xdEV2+PCyRntuI2D7mgJ8hfdtmBv/HxcTEZOlxDIIQEWUgKj4KQ/YOwb5b+9T9Typ9gt5VesPaivmkiXK7H3/8ES1btoSvr2+mj/H391cjRVKPBClSpAj8/Pzg5uZm0uCjdDwlP4meg4934uPxYOEiFP39dxT56CPYFigAS2EubWSp2D76xzbStwQz+j/OOCrzaRgEISJK52bkTfTZ2QdXIq7AwcYB4+uOR8sSLVlPRBbg+vXr2L59O3755ZcnPs7BwUFt6UkHMSc6iTl1XFMpOGAAYv88gLiLF3Fn3HgUnj0r06lEuZXe28jSsX30j22kb3Zm8H9cVsvHS5pERKkcCTmCDhs7qACIl5MXFrdYzAAIkQVZuHAhvLy80Lp1a62LYlas7e3hO3UKrOzsELVzJyLWrtW6SERERBliEISI6H9Wn1+NT7d9ioi4CFQoUAEr31iJVzxeYf0QWYjk5GQVBOnatStsbTlY9lk5vvwyPPv3V7dDJwUi/saNHGglIiKi58MgCBFZPFn1ZcKhCZhweAISDYloVaIVFrZYCC9nL4uvGyJLItNgbty4gY8//ljropit/N26wrlGDRhiYtSyuYakJK2LRERElAaDIERk0WTUR69tvbD6wmp1v1/VfphcbzIcbR21LhoRvWCS1NRgMKBMmTKs+2yysrGB7+RAWOfJg9gTJ3B3/g+sSyIi0hUGQYjIYl15cAUdNnTA4dDDcLJ1wjeNvkGPij0sLpkfEZEp2RUqhIKjRqrbt2fNQuyZM6xgIiLSDQZBiMgi7ft3Hzpt7ISbD2/CN48vlrZcisZFG2tdLCKiXMG9bVu4+vkBiYkIHjIUyY8eaV0kIiIihUEQIrIoMtR98ZnFagncqIQoVPWqqhKgvpz/Za2LRkSUa8iIOu+AsbDx9ED85csInzZN6yIREREpDIIQkcWIT4rHqD9H4aujXyHZkIx3S7+LH/x+QH7H/FoXjYgo17HNlw++Eyeq2/eXLEX0gQNaF4mIiEj7IMjs2bNRvHhxODo6olatWjhy5MgTHz9jxgy8/PLLcHJyQpEiRTBgwAA84hBLInqKO7F30H1Ld6y/vB7WVtYYWmMoxtQeAzsbO9YdEVEOcalfH3k7tFe3g/2HIykignVNRESWGwRZvXo1Bg4ciDFjxuD48eOoXLkymjdvjvDw8Awfv2LFCgwbNkw9/ty5c/jxxx/VMYYPH/7Cy05E5uPCvQvouKEjTt4+CVc7V3zX5Dt8WP5DJkAlInoBCg4eDPtixZAYFobQceNZ50REZLlBkGnTpqFnz5746KOPUL58ecydOxfOzs5YsGBBho8/cOAA6tati44dO6rRI7KUXYcOHZ46eoSILNeO6zvQeVNnhESHoJhbMSxvvRx1C9XVulhERBbD2tkZvlOCABsbRG7YgIg/NmhdJCIismC2Wr1wfHw8jh07Bn9//5R91tbWaNq0KQ4ePJjhc+rUqYNly5apoEfNmjVx5coVbNy4EZ07d870deLi4tRmFBkZqX4mJCSozVSMxzLlMcm02EaW1T6SAPXHMz/iu/98p+6/5v0aJr8+GW72bvyc6qSNyHLbxxzKSKblVLkyPD77DHdmz0bouHFwrl4Ndt7erGYiIrKcIMidO3eQlJSEggULptkv98+fP5/hc2QEiDzv9ddfV19wEhMT8dlnnz1xOkxgYCACAgIe279161Y16sTUtm3bZvJjkmmxjXJ/+8Qb4rEuZh1OJZxS92vb10aL2BbYv32/CUpI/Azpmzm0T0xMjNZFIA14fPYpovbuxaNTpxDs74+iP/4IK2vN09MREZGF0SwIkh27d+/GpEmT8N1336kkqpcuXUK/fv0wfvx4jBo1KsPnyEgTyTuSeiSIJFSVqTRubm4mvaolHc9mzZrBzo6JFvWIbWQZ7RMeE44BewfgXMI52FrZYliNYXin1DsmLaul4mdI38ypfYyjMsmyWNnZwTcoCFffeQcxBw/h/rLlyN8l89G8REREuSoI4uHhARsbG4SFhaXZL/e9MxkeKYEOmfrSo0cPdb9ixYqIjo7GJ598ghEjRqjpNOk5ODioLT3pIOZEJzGnjkumwzbKve1z6vYp9NvVD7djbyOvQ15MazgNNbxrmLyMlo6fIX0zh/bRe/ko5ziULAGvIYMRNm48wr/+Gnnq1IZDqVKsciIiemE0G4Nob2+PatWqYceOHSn7kpOT1f3atWtnOnw2faBDAilCpscQkeXacGUDum3upgIgpfKWwsrWKxkAISLSoXwdOiBPvXowxMUheMhQGOLjtS4SERFZEE0nYso0lfnz52Px4sVqydtevXqpkR2yWozo0qVLmsSpbdq0wZw5c7Bq1SpcvXpVDfuV0SGy3xgMISLLkmxIxoxjMzBs3zDEJ8ejYeGGWNZqGQq7Fta6aERElAErKyv4TJwAG3d3PDp7Frdn/zeBNRERUa7PCdKuXTvcvn0bo0ePRmhoKKpUqYLNmzenJEu9ceNGmpEfI0eOVCdO+Xnr1i14enqqAMjEiRM1fBdEpJXohGgV/Nh9c7e6371Cd/R9tS9srBkUJSLSMzsvL3iPG4db/frh7vz5cGlQH85Vq2pdLCIisgCaJ0bt06eP2jJLhJqara0txowZozYismz/PvwXfXf2xaUHl2BvbY+xdcaizUtttC4WERFlkVtzP0S1bYuI9esRPHQYSqxbBxuXPKw/IiLKUVyXjIjMztHQo+i4oaMKgHg4eWBhi4UMgBARmaGCI0fA1tcHCTdvIjxostbFISIiC8AgCBGZlbUX16Lntp64H3cf5fKXUwlQK3lW0rpYRESUDTaurvCdPFkSheDBmp/xcOdO1iMREeUoBkGIyCwkJici6EgQxh4cq243L94ci1suhneejJfUJiIi85CnZk3k/19S/JCRo5B4967WRSIiolyMQRAi0r2IuAh8vv1zLDu3TN3vXaU3ptafCidbJ62LRkREJuDZvx8cypRB0r17CBk1GgaDgfVKREQ5gkEQItK1axHX8OHGD3Ew5KAKekxrOA2fVf5MrRRFRGRKsvLchx9+iAIFCsDJyQkVK1bE0aNHWckvgLW9PXynToGVnR2idu5ExNq1rHciIsoRDIIQkW4duHUAHTd2xLXIa2ray5KWS9CsWDOti0VEudD9+/dRt25d2NnZYdOmTTh79iy+/vpr5MuXT+uiWQzHl19WI0JE6KRAxN+4oXWRiIgoF9J8iVwiovRkGPSK8ysw5a8pSDYko4pnFUxvNF2tBENElBOCgoJQpEgRLFy4MGVfiRIlWNkvWP5u3RC1azdijh5Vy+YWW7YUVjY2bAciIjIZBkGISFcSkhIw8a+JWPvPf4dCt32pLUbXHg17G3uti0ZEudhvv/2G5s2b4/3338eePXtQqFAhfP755+jZs2eGj4+Li1ObUWRkpPqZkJCgNlMxHsuUx9Q7zwnjcePd9xB74gTCv/8e+TNpA72wxDYyJ2wf/WMb6VuCGf0fl9UyMghCRLoRnRyNXrt64Xj4cVhbWWNgtYHoUr4L838QUY67cuUK5syZg4EDB2L48OH466+/8MUXX8De3h5du3Z97PGBgYEICAh4bP/WrVvh7Oxs8vJt27YNlsStdSt4/7QGd2fNxgkJOhUqBL2ztDYyN2wf/WMb6ds2M/g/LiYmJkuPYxCEKJvik+Kx8+ZORMb99+ofPZ+ExATMjZqLB5EP4GLngqD6QahfuD6rlYheiOTkZFSvXh2TJk1S91999VWcPn0ac+fOzTAI4u/vrwImqUeCyHQaPz8/uLm5mfSqlnQ8mzVrpvKVWApDy5YIvXcP0dt3oNQfG1Bk9SpYOzpCjyy1jcwF20f/2Eb6lmBG/8cZR2U+DYMgRNlwN/YuBuwegBPhcn2KTKmwS2HMajILL+V9iRVLRC+Mj48Pypcvn2ZfuXLlsDaTVUocHBzUlp50EHOik5hTx9Uz3/HjceXk30i4cgX3Z86E9/Dh0DNLbCNzwvbRP7aRvtmZwf9xWS0fgyBEz+jCvQvou7MvQqJD4Grnipo+NVmHJroKGxsei0nNJ8HTxZN1SkQvlKwMc+HChTT7Ll68iGLFirElNGKbLx98J07AzU8/w/0lS+HasCHy1KnD9iAioufCIAjRM9hxfQf89/sjNjEWxdyKYWbjmSjhztUDTDXUbuPGjcjrkJd/k0T0wg0YMAB16tRR02E++OADHDlyBPPmzVMbacelQQPkbd8OD1atRrD/cJT8bT1s3N3ZJERElG3W2X8qkWUt2fr939+j/+7+KgDyms9rWN5qOQMgRES5RI0aNbBu3TqsXLkSFSpUwPjx4zFjxgx06tRJ66JZvIJDhsC+WDEkhoUhdNx4i68PIiJ6PhwJQvQUjxIfYfSfo7Hp2iZ1v1O5ThhUfRBsrfnxISLKTd544w21kb5YOzvDd0oQrnXshMgNG+DSqBHc32itdbGIiMhMcSQI0ROERYeh2+ZuKgBia2WL0bVHY1jNYQyAEBERvUBOlSvD47PP1O3QceOQEBrK+iciomxhEIQoE6dun0KHDR1w5u4Zladint88vF/mfdYXERGRBjw++xSOFSsiOTISwf7+MCQnsx2IiOiZMQhClIENVzaoESC3Y2+jVN5SWNl6JWp412BdERERacTKzg6+QUGwcnREzMFDuL9sOduCiIieGYMgRKkkG5Lx7fFvMWzfMMQnx6Nh4YZY2nIpCrsWZj0RERFpzKFkCXgNGaxuh3/9NeIuXdK6SEREZGYYBCH6n+iEaPTf1R/zT81X97tX6I4ZjWbAxd6FdURERKQT+Tp0QJ7XX4chLg7BQ4bCEB+vdZGIiMiMMAhCBOBW1C103tQZu27ugr21PSa9Pgn9q/WHjbUN64eIiEhHrKys4DNxImzc3fHo7Fnc/u47rYtERERmhEEQsnjHwo6hwx8d8M/9f1DAsQAWtFiANi+1sfh6ISIi0iu7gl7wDghQt+/Om4+Y4ye0LhIREZkJBkHIov3yzy/osbUH7sfdR7n85bDqjVWo7FlZ62IRERHRU7i1aA73tm8CyckIHjoUSVHRrDMiInoqBkHIIiUmJyLoSBDGHBijbjcv3hyLWy6Gdx5vrYtGREREWVRw5EjY+vog4eZNhAdNZr0REdFTMQhCFudh/EP02dEHy84tU/d7V+mNqfWnwsnWSeuiERER0TOwcXWFb+BkSRSCB2t+xsOdO1l/RET0RAyCkEW5k3QHXbd2xZ/Bf6qgx7SG0/BZ5c9UkjUiIiIyP3lq1UT+bt3U7ZCRo5B4967WRSIiIh2z1boARBmJSYjBg7gHJq2cs7fPYm7UXDwyPFLTXr5t9C3KFSjHBiAiIjJzngP6I/rPPxF38SJCRo1G4dmzeIGDiIgyxCAI6c7GKxsx9uBYxCbG5sjxK3lUwjeNv4GHk0eOHJ+IiF6MxYsXw8PDA61bt1b3hwwZgnnz5qF8+fJYuXIlihUrxqawENb29vCdOgXX3nsfUTt3ImLtWuR97z2ti0VERDrE6TCkG8mGZHx7/FsM3TdUBUDsre3haONoss3Z1hk17GtgXpN5DIAQEeUCkyZNgpPTf/M5HTx4ELNnz8aUKVNUYGTAgAFaF49eMMeXX4Zn/37qduikQMTfuME2ICKix3AkCOlm+ov/Pn/svPnfhGYfV/gYX7z6BWysbUz2GgkJCdi4cSPsbexNdkwiItLOzZs3UapUKXX7119/xbvvvotPPvkEdevWRcOGDdk0Fkhyg0Tt2o2Yo0cRPHQYii1bCisb0/UliIjI/HEkCGnuVtQtdN7UWQVA7KztMOn1SRhQbYBJAyBERJT7uLi44O7/kmBu3boVzZo1U7cdHR0RG5szUypJ3yTg4TN5Mqzz5EHsiRO4+8OPWheJiIh0hkEQ0tTxsOPo8EcHXLx/EQUcC2Bhi4Vo81IbtgoRET2VBD169OihtosXL6JVq1Zq/5kzZ1C8eHHWoIWyL1wIBUeOVLdvz5yJR2fPal0kIiLKjUGQBw9Mu5IH5X6//PMLum/tjvtx91EufzmsemMVKntW1rpYRERkJiQHSO3atXH79m2sXbsWBQoUUPuPHTuGDh06aF080pD7W23hKiODEhNxa/AQJD96xPYgIqLs5wQJCgpSV1jatWun7n/wwQeq8+Ht7a1yLlSuzC+ylLnE5ERMOzYNS88uVfebFWuGCXUnwNnOmdVGRERZljdvXsyaNeux/QEBAaxFC2dlZQXvcQGIOXEC8ZcvI3zaNHgPH651sYiIyFxHgsydOxdFihRRt7dt26a2TZs2oWXLlhg8eLCpy0i5SGR8JPrs6JMSAPm88uf4qsFXDIAQEVG2R6JKPpBly5ZhyZIlKdvSpf89z2TV2LFj1Rfn1FvZsmXZKmbMNl8++E6coG7fX7IU0QcOaF0kIiIy15EgoaGhKUGQP/74Q40E8fPzU6NDatWqZeoyUi5xPfK6CoBci7ymlqyd+PpE+BX307pYRERkpn7//Xd06tQJUVFRcHNzU4ELI7nduXPnZzreK6+8gu3bt6fct7XlInrmzqVBA+Rt3w4PVq1GsP9wlPxtPWzc3bUuFhERmdtIkHz58qll6cTmzZvRtGlTddtgMCApKcm0JaRc4WDwQXTc0FEFQAo6F8SSlksYACEioufy5Zdf4uOPP1ZBEBkRcv/+/ZTt3r17z3w8CXrI1F7j5uHhwRbKBQoOGQK7YkWRGBaG0HHjtS4OERFpLFuXON555x107NgRpUuXVkvTyTQYceLECZQqVcrUZSQzJoGxledXYspfU5BkSEIlz0r4ptE38HBix5KIiJ7PrVu38MUXX8DZ2TQ5pf755x/4+vqqJXYl4WpgYCCKFi2a4WPj4uLUZhQZGal+JiQkqM1UjMcy5TEtjp0dCk6ahH+7dEXkhg0w2FjD2s10o0EMVoC9hwfbSKf4GdI/tpG+JZjReSirZcxWEGT69Olq6ouMBpkyZQpcXFzU/pCQEHz++efZOSTlQgnJCQg8HIg1F9eo+2++9CZG1x4NBxsHrYtGRES5QPPmzXH06FGULFnyuY8l03kXLVqEl19+WfVnJLlqvXr1cPr0abi6uj72eAmQZJSAVfKTmCook5rkX6PnU6BRQxTYvgMPf/vd5FVZyN0dO9zzItnJ0eTHJtPgZ0j/2Eb6ts0MzkMxMTE5FwSxs7PDoEGDHts/YMCA7ByOcqH7j+5j4O6BOBp2FFawwoBqA9DtlW5p5msTERE9j9atW6uE7GfPnkXFihVV/yS1N998M8vHMo5qFZUqVVJBkWLFiuGnn35C9+7dH3u8v78/Bg4cmGYkiORLkxxpkp/ElFe1pOPZrFmzx94fPRuDnx8iVq9G0p07Jq26yI2bgOBgVP7rL/hMDmSz6Aw/Q/rHNtK3BDM6DxlHZeZIEGTx4sVqnqx0PsSQIUMwb948lC9fHitXrlSdBrJcl+5fQp+dfXAr6hby2OVBUL0gNCjSQOtiERFRLtOzZ0/1c9y4cY/9ToLuz5OnTJbfLVOmDC5dupTh7x0cHNSWnnQQc6KTmFPHtSh2dvDs1s3kh3Vu0EBNtYnesAGxzZrCrUULk78GPT9+hvSPbaRvdmZwHspq+bKVGHXSpElwcnJStw8ePIjZs2eraTESGHnW0SDyXJlaI/Nv5arLkSNHnvh4SXzWu3dv+Pj4qM6HdFA2btyYnbdBOWDPzT34cNOHKgBS2KUwlrVcxgAIERHliOTk5Ey3503ULslWL1++rPobRE/iVKUK7jVqqG6HjhmLhLBwVhgRkY5lKwgiuUCMCVB//fVXvPvuu/jkk0/U/Nh9+/Zl+TirV69WQ0nHjBmD48ePo3Llymp+b3h4xieP+Ph4NQzn2rVr+Pnnn3HhwgXMnz8fhQoVys7bIBMnQF1wegH67uyL6IRo1PCugRWtV6BUPibKJSIi/ZNpvnv27FF9jAMHDuDtt9+GjY0NOnTooHXRyAzcbdoUDuXLIykiAiEjRqh+ERER5aIgiCRClVVhjAnAJDAhZDRHbGxslo8zbdo0NZT1o48+UlNp5s6dq5KJLViwIMPHy35Z8k4CL3Xr1lUjSBo0aKCCJ6SduKQ4jNg/AtOPTYcBBrxf5n183+x75HPMx2YhIqIcJYGLNm3aqIszskkekGe5IGP077//qoCHJEb94IMPUKBAARw6dAienp45Um7KZWxsUDBwEqwcHBC9fz/ur1ypdYmIiMiUOUEk6NGjRw+8+uqruHjxIlq1aqX2nzlzRgUmskJGdRw7dkwlFjOytrZG06ZN1RSbjPz2229qyTqZDrN+/XrVMZGleocOHaqu1mSES9jlrDuxd/Dl3i9x6u4p2FjZYFC1Qfig9AdAEpCQpK9llMxpeSdLxPbRP7aRvplT+5iqjMuWLVMXUt555x21VK74888/0aRJE7XSi/QRsmrVqlUmKRNZLvuSJeE1aBDCJk5E+JSpyPNabTiULKF1sYiIyBRBEMnjMXLkSDUtZu3atepqiZCgRlaHjd65c0fN1y1YsGCa/XL//PnzGT7nypUr2LlzJzp16qTygEiyMlmSVzpTMqUmI1zCLucEJwZjWfQyRBoi4WjliPbO7eF6yRWbLm2CnpnD8k6WjO2jf2wjfctNS9g9zcSJE1VOstT5yCQYIiNNx48f/0xBECJTyNepI6J27UL0gQMIHjIExVeugJXOEwkSEVka2+xmTJ81a9Zj+wMCApCTJNGZl5eXWolGRn5Uq1YNt27dwtSpUzMNgnAJu5yx7cY2LDi4AI8Mj1DcrThm1J+Bom5FoWfmtLyTJWL76B/bSN9y4xJ2TyMXR2QqTHoyJWb48OEmeQ2iZ2FlbQ2fwEm48mZbPDp9GnfmzIXnF31ZiURE5h4EETLf9vvvv1cdkDVr1qjkpEuXLkWJEiXw+uuvP/X5spKMBDLCwsLS7Jf73t7eGT5HMrRLxy711Jdy5cohNDRUTa+xt7d/7Dlcws60kg3JmPv3XMz5e466X7dQXUypPwVu9m4wF+awvJMlY/voH9tI38yhfUxVviJFimDHjh0pydqNtm/frn5HpAW7ggXhM2Y0bg38Ene+/x4u9eupFWSIiMiME6PKFBhZxUWWyZVVXSTvhoiIiFDL52aFBCxkJId0XlKP9JD7kvcjI5IMVabAyOOMJCeJBEcyCoCQacUkxGDQnkEpAZAu5btgduPZZhUAISKi3OPLL79U01969eqlLsTI9tlnn6F///5qtRcirbi1agW3N94AkpJwa+hQJJtoChgREWkUBJkwYYJayUWWp019NUeCFBIUySpZHleOsXjxYpw7d051YqKjo1WSM9GlS5c0iVPl97I6TL9+/VTwY8OGDSroIolSKWeFRoei2+Zu2HZ9G2ytbTGuzjgMrjEYNtYZJ6QlIiLKadIvkISmp06dUoEP2U6fPo3Vq1fj008/ZQOQprxHjYSttzcSrt9A2JQpbA0iInOeDnPhwgXUr1//sf3u7u548OBBlo/Trl073L59G6NHj1ZTWqpUqYLNmzenJEu9ceOGWjHGSIa2btmyRSVAq1SpkpqCIwERWR2Gcs7J8JPov6s/7j66i/yO+TG94XRULViVVU5ERJp7++231UakNzbu7vANnIQbH32MB6tWw7VRI7g0aKB1sYiILF62giCSs0OmpaRfDnf//v0oWbLkMx2rT58+asvI7t27H9snU2UOHTr0jCWm7Prt8m8Ye2AsEpITUCZfGcxsPBO+Lr6sUCIiIqKnyFO7NvJ37YJ7i5cgeMRIlPz9N9jmy8d6IyIyt+kwPXv2VCMwDh8+DCsrKwQHB2P58uVq/q0MTSXzl5SchGlHp2HE/hEqANK4SGMsbbmUARAiItJU/vz5cefOHXU7X7586n5mG5EeeA4YAPtSLyHpzh2Ejh4Ng8GgdZGIiCxatkaCDBs2TCUnbdKkCWJiYtTUGFmFRYIgfftyGTBzFxUfhaH7hmLvv3vV/U8qfYLeVXrD2ipbMTMiIiKTmT59OlxdXVNuy8UYIj2zdnREoSlTcLVdezzcth0Rv65H3rff0rpYREQWK1tBEOlwjBgxAoMHD1bTYqKiolC+fHm4uLiYvoT0Qt2MvIm+O/vicsRlONg4YHzd8WhZoiVbgYiIdKFr164pt7t166ZpWYiyyrF8eXj27Yvb06YhbMIEONeoAfvChViBREQaeK5L+7IsrQQ/atasyQBILnAk5Ag6bOygAiBeTl5Y1GIRAyBERKRbsiKdrAxjtH79erz11lsYPnw44uPjNS0bUXoFun8Mp6pVkRwdjeBhQ2FISmIlERGZSxBElrEdNWoU6tSpg1KlSqlkqKk3Mj8/XfgJn277FBFxEahQoAJWvrESFTwqaF0sIiKiTMkyuBcvXlS3r1y5oladc3Z2xpo1azBkyBDWHOmKlY0NfIMmw9rZGbFHj+HeokVaF4mIyCJlazpMjx49sGfPHnTu3Bk+Pj6cj2vGJOnplCNTsOrCKnVfpr6MqzMOjraOWheNiIjoiSQAUqVKFXVbAh8NGjTAihUr8Oeff6J9+/aYMWMGa5B0xb5IERQcMRwhI0YifMY3yFO3LhzLltW6WEREFiVbQZBNmzZhw4YNqFu3rulLRC+MjPr4cs+XOBxyWN3vV7UfulfozqAWERGZBVllQxK1i+3bt+ONN95Qt4sUKZKyggyR3ri/8w4e7tyFqB07EDx4CIr/vAbWDg5aF4uIyGJkazqMcUk6Ml9XHlxBxw0dVQDEydYJ3zT6Bj0q9mAAhIiIzEb16tUxYcIELF26VI1Qbd26tdp/9epVFCxYUOviEWW6wIDPuADYFCiAuH/+we0Z37CmiIj0HgQZP348Ro8erZbHJfOz79996LSxE248vAHfPL5Y2nIpGhdtrHWxiIiInolMd5HkqH369FGr1kmeMvHzzz+rvGVEemVboAB8xo9XtyU3SPSh/47KJSIinU6H+frrr3H58mV1laV48eKws7NL83vpkJA+hw0vObsE045NQ7IhGVW9qmJ6o+nI78hRPUREZF6SkpLw4MED7N27V41QTW3q1KmwsbHRrGxEWeHauBHyvv8+HqxZg2B/f5T8bT1sXF1ZeUREegyCyPJzZF7ik+Ix7uA4rL+8Xt1/p/Q7GFlrJOxs0gawiIiIzIEEOfz8/HDu3LnHgiCOjkzuTeah4LChiD50CAk3byJswgT4BgVpXSQiolwvW0GQMWPGmL4klGPuxt5F/139cfL2SVhbWWNQ9UH4sNyHzP9BRERmrUKFCmpp3BIlSmhdFKJssc6TRwU+rn/4ISLW/waXRo3g1qIFa5OISG85Qch8XLh3AR02dFABEFc7V3zX5Dt0Lt+ZARAiIjJ7khR10KBB+OOPPxASEoLIyMg0W3ZNnjxZnSf79+9v0vISZcS56qso8ElPdTt0zFgkhIWzooiI9DASRIaaSocgK+7du/c8ZSIT2XF9B/z3+yM2MRbF3IphZuOZKOHOq2VERJQ7tGrVSv1888030/RRJAeW3Je8Ic/qr7/+wvfff49KlSqZtKxET+LZuzei9+3HozNnEDJiBIrMn8cLVkREWgdBJAO70d27d9XVl+bNm6N27dpq38GDB7FlyxaMGjUqZ0pKWSadv3n/mYdZJ2ep+6/5vIavGnwFdwd31iIREeUau3btMunxoqKi0KlTJ8yfP1/1c4heFCs7O/hOCcLVd95F9P79uL9yJfJ37MgGICLSMgjStWvXlNvvvvsuxo0bp5akM/riiy8wa9YsbN++HQMGDDB9SSlLZNTHmD/HYNO1Tep+p3KdVA4QW+tspX8hIiLSrQYNGpj0eL1790br1q3RtGlTBkHohXN46SV4DRqEsIkTET5lKhJDwwDrrI3CpswlJyXD7d49GFq2ZDURkZKtb8Yy4iMog+zVLVq0wLBhw7JzSDKBsOgwfLHrC5y9exa2VrYY/tpwvF/mfdYtERHlWvv27VPTVyRB6po1a1CoUCEsXbpUJUt9/fXXs3ycVatW4fjx42o6TFbExcWpzciYgyQhIUFtpmI8limPSaZlyjZy+eB9RO7cidiDB3F33jwTlI6EN4D7L7+M/B3as0J0iP/P6VuCGZ2HslrGbAVBChQogPXr1+PLL79Ms1/2ye/oxTt1+xT67eqH27G3kdchL6Y1nIYa3jXYFERElGutXbsWnTt3VlNYJIBhDEpERERg0qRJ2LhxY5aOc/PmTfTr1w/btm3L8vK6gYGBCAgIeGz/1q1b4ezsDFOTspG+maqNbJo2QT4He1jF6/8LhzmwjYyA6+kzuDN1Ko7FxyHB01PrIlEm+P+cvm0zg/NQTExMzgVB5KTfo0cP7N69G7Vq1VL7Dh8+jM2bN6t5tPRibbiyAaP/HI345HiUyltKJUAt7FqYzUBERLma5O2YO3cuunTpokZyGNWtW/eZprMcO3YM4eHhqFq1aso+Saq6d+9eNdVXgis2NjZpnuPv74+BAwemGQlSpEgR+Pn5wc3NDaa8qiUdz2bNmsHOzs5kxyXou40++MA0xyHEx8XhfLv2cL58GWW3bEHhJUtgZctp4nrC/+f0LcGMzkNZXRkuW/8DdOvWDeXKlcO3336LX375Re2T+/v3708JilDOSzYkY+aJmfjh1A/qfsPCDTG5/mTkscvD6iciolzvwoULqF+//mP73d3d8eDBgywfp0mTJjh16lSafR999BHKli2LoUOHPhYAEQ4ODmpLTzqIOdFJzKnjkumwjfQr9IP3UWrWbMSdOo2IBQvUajykP/wM6ZudGZyHslq+bIdBJdixfPny7D6dnlN0QjT89/lj183/ZsbvXqE7+r7aFzbWj3fUiIiIciNvb29cunQJxYsXT7NfLsqULFkyy8dxdXVFhQoV0uzLkyePmuKbfj8RmZ/EvHnhOWI4wob54853c+BSvz6cKlbUulhEpBHr7D7x8uXLGDlyJDp27KiGkIpNmzbhzJkzpiwfZeBW1C103tRZBUDsre0x6fVJ6F+tPwMgRERkUXr27KlyeciUXCsrKwQHB6sLNIMGDUKvXr20Lh4R6YhLq1Zwa9VS5rohePAQJMfGal0kIjKnIMiePXtQsWJF1emQpGRRUVFq/99//40xY8aYuoyUytHQo+jwRwf8c/8feDh5YGGLhWjzUhvWERERWRxZkU4uxsh0FumLyNQYyVn26aefom/fvs91bMl7NmPGDJOVlYi0JYFS79GjYevlhfhr1xA+9Ss2CZGFss5up0MSjkmCFHt7+5T9jRs3xqFDh0xZPkpl7cW16LmtJ+7H3Ue5/OWwsvVKVPKsxDoiIiKL/VIzYsQI3Lt3D6dPn1Z9kNu3b2P8+PFaF42IdMgmb174BE5St++vWIGoffu0LhIRmUsQRJKHvf3224/t9/Lywp07d0xRLkolMTkRQUeCMPbgWHW7efHmWNxyMbzzyKrnRERElmnZsmVqOTy5IFO+fHnUrFkTLi4uWheLiHTMpW5d5OvcWd0OGT4Ciffva10kIjKHIEjevHkREhLy2P4TJ06gUKFCpigX/U9kfCR67+iNZeeWqfu9q/TG1PpT4WTrxDoiIiKLNmDAAHUBRqbEbNy4US1rS0T0NF5fDoR9yZJIvH0boWMDYDAYWGlEFiRbq8O0b99eLRm3Zs0aNRQ1OTkZf/75p0pE1qVLF1iiE+EncDHhItyD3WFrorXH45PiMf3YdFyLvKaCHhNfn4hmxZqZ5NhERETmTi7IbN68GStXrsQHH3wAZ2dnvP/+++jUqRPq1KmjdfGISKesHR3hO2UKrrVvj4dbtiDyt9/g3rat1sUiohckW9/WJ02ahN69e6NIkSLqqosMQZWfciVGVoyxRIFHA3Ep+hKW7F5i8mPLtJeZjWeibP6yJj82ERGRuZKLDm+88YbaZFrMunXrsGLFCjRq1AiFCxdWK9kREWXEqcIr8OzTG7dnfIPQ8RPgXL067DiincgiZCsIInNv58+fj9GjR6v8IJKR/dVXX0Xp0qVhqUq4lUDMwxi4ubmp0TGmUtytOIbUHKJWgiEiIqKMySiQ5s2b4/79+7h+/TrOnTvHqiKiJyrQoweidu9B7MmTCB7mj6KLF8HKOlvZAogotwdBxo0bp6a+yEgQ2YxiY2MxdepUFRyxNEGvB6n5yK1atoKdnZ3WxSEiIrIIxhEgy5cvx44dO1S/pEOHDvj555+1LhoR6ZyVrS18gybjytvvIOavv3Bv0WIU+PgjrYtFRDksW6HOgIAANfojo46I/I6IiIgop0mOMkmMKglSS5Ysid27d+PSpUtqidyyZTmFlIiezr5YMRQcNlTdvj19Oh5duMhqI8rlsjUSRDIoZzTl4++//0b+/PlNUS4iIiKiJ7KxscFPP/2kpsHIbSKi7Mj7/vuI2rkLUbt3I3jIEBRf8xOs7e1ZmUS51DMFQfLly6eCH7KVKVMmTSBEEqPK6JDPPvssJ8pJRERElIZMgSEiel7yncZnwnhcafMm4i5cwJ1vv4XXoEGsWKJc6pmCIDNmzFCjQD7++GM17cXd3T1NstTixYujdu3aOVFOIiIiosdIHhDZwsPDkZycnOZ3CxYsYI0RUZbYenjAZ/w4/NunL+7+uAAuDRrAuUYN1h6RpQdBunbtisTERBUtbdy4cZqkqEREREQvklyQkWTt1atXh4+Pj0lXZyMiy+PatCnc330HEWt/QfDQYSjx23rYuLhoXSwi0joniK2tLXr16sWl54iIiEhTc+fOxaJFi9C5c2e2BBGZREH/4Yg5fAQJ//6LsAkT4Ts5kDVLlMtka3WYmjVr4sSJE6YvDREREVEWxcfHo06dOqwvIjIZG5c88J0SBFhbI+LXXxG5ZStrlyiXyVYQ5PPPP8eXX36JWbNm4eDBg/jPf/6TZiMiIiLKaT169MCKFStY0URkUs5Vq6JAjx7qduiYMUgID2cNE1n6Ernt27dXP7/44ouUfTIP17h0rqwUQ0RERJSTHj16hHnz5mH79u2oVKkS7Ozs0vx+2rRpbAAiyhbPPr0RtW8f4s6dQ8jIkSjy/ffMO0RkyUGQq1evmr4kRERERM9ARp9WqVJF3T59+nSa3zFJKhE9Dyt7exSaEoSr776H6L378GD1auT734VgIjJv2QqCFCtWzPQlISIiInoGu3btYn0RUY5xKF0aXl8ORFjgZIQFTYFzrVpwKFGCNU5kiTlBxOXLl9G3b180bdpUbTI1RvZlx+zZs1G8eHE4OjqiVq1aOHLkSJaet2rVKnWl56233srW6xIREREREWUmX+fOcH7tNRhiY9WyuYbERFYWkSUGQbZs2YLy5curYIXMwZXt8OHDeOWVV7Bt27ZnOtbq1asxcOBAjBkzBsePH0flypXRvHlzhD8lAdG1a9cwaNAg1KtXLztvgYiIiMzQO++8g8jIyJTbT9qexZw5c1R/xs3NTW21a9fGpk2bcuhdEJG5sLK2hm/gJFi7uuLRf/6DO99/r3WRiEiLIMiwYcMwYMAAFfiQpGOyye3+/ftj6NChz3QseW7Pnj3x0UcfqcDK3Llz4ezsjAULFmT6HEm82qlTJwQEBKBkyZLZeQtERERkhtzd3VPyfcjtJ23PonDhwpg8eTKOHTuGo0ePonHjxmjbti3OnDmTQ++EiMyFnY8PvEePVrfvfDcHsadOaV0kInrROUHOnTuHn3766bH9H3/8MWbMmJHl48THx6vOhr+/f8o+a2trNb1Glt7NzLhx4+Dl5YXu3btj3759T3yNuLg4tRkZrx4lJCSozVSMxzLlMcm02Eb6xvbRP7aRvplT+zxPGRcuXJjh7efVpk2bNPcnTpyoRoccOnRIjXQlIsvm9kZrRO3aiciNmxA8eAhK/LIW1s7OWheLiF5UEMTT0xMnT55E6dKl0+yXfRKcyKo7d+6oUR0FCxZMs1/unz9/PsPn7N+/Hz/++KN6rawIDAxUI0bS27p1qxpxYmrPOh2IXjy2kb6xffSPbaRv5tA+MTEx0DPpm6xZswbR0dFqWgwRkYxAk9EgMUePIf7aNYRNnQqfMWNYMUSWEgSR6SuffPIJrly5gjp16qh9f/75pxpG+uWXXyKnPHz4EJ07d8b8+fPh4eGRpefIKBPJOZJ6JEiRIkXg5+en5vya8qqWdDybNWsGOzs7kx2XTIdtpG9sH/1jG+mbObWPcVSm3pw6dUoFPR49egQXFxesW7dOTdXNCEeakjmOwrJEJm2fPHngNX48gj/9FA9WroJTvXrIw/yE+mojsuj2SchiGbMVBBk1ahRcXV3x9ddfp0xlKVSokBpxIavEZJUEMmxsbBAWFpZmv9z39vZ+7PGy+owkRE09ZDU5Ofm/b8TWFhcuXMBLL72U5jkODg5qS086iDnRScyp45LpsI30je2jf2wjfTOH9tFr+V5++WU10jQiIgI///wzunbtij179mQYCOFIUzLHUViWzJTt41m3DvL9eQA3hw7DtQH9kZwnj8mObcn4GdK3bblopGm2giByheTTTz9VyVFldMbVq1exY8cOlC1bNiVZWVbY29ujWrVq6rnGZW4lqCH3+/Tp89jj5fhylSa1kSNHqjJ88803aoQHERERUXZIv6RUqVLqtvRP/vrrL9W/+D6D1SA40pTMcRSWJcqJ9klu3Bg3P2gHXL2KygcPwvvrr5/pOxDlfBuRZbZPZBZHmmYrCCLZ0mXpuc8++0zNm5WpJVIhkuNDVnvp1atXlo8lU1XkSkv16tVRs2ZNlVhV5uDKajGiS5cuapSJXHFxdHREhQoV0jw/b9686mf6/URERETPQy7MpE6unhpHmpI5jsKyZCZtHzs7FJo6Fdfat0f0tu2I3bQJ7m3bmubYFoyfIX2zM4P/47JavmwtkXv8+HHU+9/8NxkuKolMr1+/jiVLluDbb799pmO1a9cOX331FUaPHo0qVaqoYaibN29OSZZ648YNhISEZKeYRERElMvJyNF79+4993FkZMfevXvVtFsZdSr3d+/ejU6dOpmknESUuzhVeAWefXqr26HjJyDh1i2ti0REWWSd3bk2khPEuMqKjAqRpW1fe+01FQzJTgdGnidXWw4fPoxatWql/E46IIsWLcr0ufK7X3/9NTtvg4iIiMzQv//+m3J7xYoViIqKUrcrVqyImzdvZuuY4eHhavSp5AVp0qSJmgqzZcsWNfyXiCgjBXr0gFOVKkiOikLwMH8Y/perkIhyYRBE5stK4EE6GtJBkOkwxg6EKVdcISIiIsooR1ixYsXQsWNHlafMGPiQURzZzV7/448/qufLBRnpz2zfvp0BECJ6IitbW/gGTYaVszNi/voL9xYtZo0R5dYgiExdGTRoEIoXL65GbchycsZRIa+++qqpy0hERESU4sGDB1izZo1KXip5O1q1aoUyZcqoAIZcnEm/6hwRUU6xL1YMBYcNVbdvT5+ORxcusrKJcmMQ5L333lO5Oo4eParydxjJ8NHp06ebsnxEREREachoD0mm/uWXX8LJyQknTpzAwoULYWNjgwULFqBEiRJqWgsR0YuQ9/334dKwIQwJCQgeMgTJ8fGseCIdy9bqMMLb21ttqUmHhIiIiCgnycpwkky9bt26iI+PR2xsrLpta2uL1atXq1XlJKcHEdGLIMvj+kwYjytt3kTchQu48+238Bo0iJVPlJtGghARERFp5datWxg5cqRapjYxMVFNi5FV6yQgIivYyReS119/nQ1ERC+MrYcHfMaPU7fv/rhA5QghIn1iEISIiIjMioeHB9q0aYPAwEA4OzurUR99+/ZVwQ/JWebu7o4GDRpoXUwisjCuTZvC/d13AIMBwUOHIel/K1cRkb4wCEJERERmTYIeH3zwAezs7LBz505cvXoVn3/+udbFIiILVNB/OOwKF0ZCcDDCJk7SujhElAEGQYiIiMhs/ec//0HhwoXVbVk2VwIhkrOsXbt2WheNiCyQjUse+E4JAqytEbFuHSK3btW6SESUDoMgREREZLaKFCkCa+v/dmdOnz6t7hMRacm5alUU6NFD3Q4dPQaJt2+zQYh0hEEQIiIiIiIiE/Ls0xsO5coh6cEDBI8YAYPBwPol0gkGQYiIiIiIiEzIyt4ehaYEqZ/Re/fhwerVrF8inWAQhIiIiIiIyMQcSpeG15cD1e2woCmIu3qVdUykAwyCEBERERER5YB8nTvD+bXXYIiNVcvmGhITWc9EGmMQhIiIiIiIKAdYWVvDN3ASrF1d8eg//8Gd779nPRNpjEEQIiIiIiKiHGLn4wPv0aPV7TvfzUHsqVOsayINMQhCRERERESUg9zeaA23Vi2BpCQEDx6C5NhY1jeRRhgEISIiIiIiykFWVlZqNIitlxfir11D+NSvWN9EGmEQhIiIiIiIKIfZ5M0Ln8BJ6vb9FSsQtW8f65xIAwyCEBERERERvQAudesi34cfqtshw0cg8f591jvRC8YgCBERERER0Qvi9eVA2JcsicTbtxE6NgAGg4F1T/QCMQhCREREFi8wMBA1atSAq6srvLy88NZbb+HChQsWXy9ElANfwJyc4DtlCmBri4dbtiDy999ZzUQvEIMgREREZPH27NmD3r1749ChQ9i2bRsSEhLg5+eH6Ohoi68bIjI9pwqvwLNPb3U7dNx4JAQHs5qJXhDbF/VCRERERHq1efPmNPcXLVqkRoQcO3YM9evX16xcRJR7FejRA1G79yD25EkED/NH0UULYWXNa9REOY1BECIiIqJ0IiIi1M/8+fOzbogoR1jZ2sI3aDKuvP0OYo4cUflBHEqXtrjaTkpKQt6zZ/Dg/gPY2NiY5JhWdnZwa9kCNu7uJjke5S4MghARERGlkpycjP79+6Nu3bqoUKFChnUTFxenNqPIyEj1U6bRyGYqxmOZ8phkWmwjfdN7+1j5+sJj8CDcDhiHBz/9BEvlBeDOb6bNjRKxaSN8583j6Jpc/hlKLatlZBCEiIiIKBXJDXL69Gns37//iYlUAwICHtu/detWODs7m7w+JU8J6RvbSN903T5OTsjXojkcgkO0Lkmu4XLuHGIPH8HBESPxoN7rWhcnV9im58/Q/8TExGTpcQyCEBEREf1Pnz598Mcff2Dv3r0oXLhwpvXi7++PgQMHphkJUqRIEZVM1c3NzaRXtaTj2axZM9jZ2bGddIhtpG9m0z6tW8NS5UQbRfy0BrfHj0fBrVtRrfvHcChVyiTHtUQJ5vIZSjUq82kYBCEiIiKLZzAY0LdvX6xbtw67d+9GiRIlnlgnDg4OaktPOog50UnMqeOS6bCN9I3tY1ltVKBjB8Ts3YPoPXsRPnwESqxeBSt7e5Mc21LZmcF5KKvlY/phIiIisngyBWbZsmVYsWIFXF1dERoaqrbY2FiLrxsiInNjZWUF3wkTYJM3L+LOncPtWbO1LhLpCIMgREREZPHmzJmjVoRp2LAhfHx8UrbVq1dbfN0QEZkjW09PeI/7b+6muz/8gJhjx7QuEukEgyBERERk8WQ6TEZbt27dLL5uiIjMlZufH9zffluW/ULwkKFIiorSukikAwyCEBERERERUa5UcMRw2Pn6IuHWLYQFBmpdHNIBBkGIiIiIiIgoV7JxcYFv0GRJFIKItb/g4fbtWheJNMYgCBEREREREeVazjVqoED3j9XtkFGjkXjnjtZFIg0xCEJERERERES5mscXX8ChbFkk3b+PkJGjVN4nskwMghAREREREVGuZm1vD98pQbCys0PU7t14sGaN1kUijTAIQkRERERERLmeY5ky8Bw4UN0OmxyE+OvXtS4SaYBBECIiIiIiIrII+bt2gXOtWjDExCB46DAYEhO1LhK9YAyCEBERERERkUWwsraGb+AkWLu4IPbkSdz94Qeti0QvGIMgREREREREZDHsfH3hPXqUun171mzEnj6jdZHI0oIgs2fPRvHixeHo6IhatWrhyJEjmT52/vz5qFevHvLly6e2pk2bPvHxRERERERERKm5tWkD1xYtgMREBA8ZguTYWFaQhdA8CLJ69WoMHDgQY8aMwfHjx1G5cmU0b94c4eHhGT5+9+7d6NChA3bt2oWDBw+iSJEi8PPzw61bt1542YmIiIiIiMj8WFlZwXvMaNh6eiL+yhWEfz1N6yKRpQRBpk2bhp49e+Kjjz5C+fLlMXfuXDg7O2PBggUZPn758uX4/PPPUaVKFZQtWxY//PADkpOTsWPHjhdediIiIiIiIjJPtvnywWfSJHX7/rJliNr/p9ZFotweBImPj8exY8fUlJaUAllbq/syyiMrYmJikJCQgPz58+dgSYmIiIiIiCi3can3OvJ17KhuhwwfjqQHD7QuEuUwW2jozp07SEpKQsGCBdPsl/vnz5/P0jGGDh0KX1/fNIGU1OLi4tRmFBkZqX5K4EQ2UzEey5THJNNiG+kb20f/2Eb6Zk7tYw5lJCIiy+E1eBCiDxxA/LVrCAkIQKFp09R0GcqdNA2CPK/Jkydj1apVKk+IJFXNSGBgIAICAh7bv3XrVjXtxtS2bdtm8mOSabGN9I3to39sI30zh/aRUZxERER6Ye3kBN+pU3CtfQc83LQZkY2bwL3NG1oXi3JjEMTDwwM2NjYICwtLs1/ue3t7P/G5X331lQqCbN++HZUqVcr0cf7+/irxauqRIMZkqm5ubjDlVS3peDZr1gx2dnYmOy6ZDttI39g++sc20jdzah/jqEwiIiK9cKpYER6f98KdmbMQOm4cnKtXg52Pj9bFotwWBLG3t0e1atVUUtO33npL7TMmOe3Tp0+mz5syZQomTpyILVu2oHr16k98DQcHB7WlJx3EnOgk5tRxyXTYRvrG9tE/tpG+mUP76L18RERkmTw+/RRRe/fi0d//QbD/cBRd8COsrDVfS4RMTPMWlVEa8+fPx+LFi3Hu3Dn06tUL0dHRarUY0aVLFzWawygoKAijRo1Sq8cUL14coaGhaouKitLwXRAREREREZE5s7K1RaGgIFg5OSHm0CHcX7pU6yJRbgyCtGvXTk1tGT16tFr29uTJk9i8eXNKstQbN24gJCQk5fFz5sxRq8q899578PHxSdnkGERERERERETZZV+8OAoOHapuh389DXH//MPKzGU0D4IImfpy/fp1tYrL4cOHUatWrZTfSdLTRYsWpdy/du0aDAbDY9vYsWM1Kj0RERGZu71796JNmzZqxTlZEeDXX3/VukhERKSRvO0+QJ4G9WGIj8etIUPVT8o9dBEEISIiItKSTMWtXLkyZs+ezYYgIrJwEgz3nTABNnnzIu7cOdyexXNDbmLWS+QSERERmULLli3VRkREJGw9PeE9LgC3vuiHuz/8AJcG9eFcrRorJxdgEISIiIiIiIgoHTc/P0S9/TYi1q1D8JChagldS5OUlASnf/9FbsIgCBEREdEzkjxmshlFRkaqnwkJCWozFeOxTHlMMi22kb6xffRP721UYMhgRB8+jIRbtxAyYiQsUREAEWXKwL15c+hZVv+GGAQhIiIiekaBgYEICAh4bP/WrVvh7Oxs8vrctm2byY9JpsU20je2j/7puY0c3nsX+XfshFVSEiyNbVQUHP/9FyFjxuLQgwdIcnWFXsXExGTpcQyCEBERET0jf39/DBw4MM1IkCJFisDPzw9ubm4mvaolXwyaNWsGOzs7tpMOsY30je2jf2bTRj17whLFR0fjn7ffhkNIKCru3QefWTNV4lg9Mo7KfBoGQYiIiIiekYODg9rSkw58TnTic+q4ZDpsI31j++gf20in8uRBSLv2KD57NmL27kX0ul+Rr90H0KOsnie5RC4RERFZvKioKJw8eVJt4urVq+r2jRs3LL5uiIjIssX7eKNAv37qdtjkyYi/fh3mjEEQIiIisnhHjx7Fq6++qjYhU13k9ujRoy2+boiIiPJ2/hDOtWrBEBurVsoxJCaabaUwCEJEREQWr2HDhjAYDI9tixYtsvi6ISIisrK2hm/gJFi7uCD2779xd/58s60UBkGIiIiIiIiI6InsfH3hPXqUun179neIPXUa5ohBECIiIiIiIiJ6Krc2beDaogWQmIjgoUORHBsLc8MgCBERERERERE9lSyP6z1mNGw9PRF/5QrCv54Gc8MgCBERERERERFliW2+fPCZNEndvr9sGaL2/wlzwiAIEREREREREWWZS73Xka9jR3U7ZPhwJD14AHPBIAgRERERERERPROvwYNgX6IEEsPDERIQoFZVMwcMghARERERERHRM7F2coLvlCmArS0ebtqMyD/+gDlgEISIiIiIiIiInplTxQrw+LyXuh06bjwSgoOhdwyCEBEREREREVG2eHzyCRwrV0Lyw4cI9h8OQ3Iy9IxBECIiIiIiIiLKFitbWxQKCoKVkxNiDh/GvSVLoGcMghARERERERFRttkXL46CQ4eq27enTcejixehVwyCEBEREREREdFzydvuA+RpUB+G+HgEDxmK5Ph46BGDIERERERERET0XKysrOA7YQJs8uZF3PnzuDNzFvSIQRAiIiIiIiIiem62np7wHhegbt/94QfEHDsGvWEQhIiIiIiIiIhMws3PD+5vvw0YDGpaTFJUFPSEQRAiIiIiIiIiMpmCI4bDrlAhJNy6hbDAQOgJgyBEREREREREZDI2Li7wDZosiUIQsfYXPNy+HXrBIAgRERERERERmZRz9eoo0KO7uh0yajQS79yBHjAIQkREREREREQm59G3LxzKlkXS/fsIGTkKBoMBWmMQhIiIiOh/Zs+ejeLFi8PR0RG1atXCkSNHWDdERETZZG1vD98pQbCys0PU7t14sGYNtMYgCBERERGA1atXY+DAgRgzZgyOHz+OypUro3nz5ggPD2f9EBERZZNjmTLwHDhQ3Q6bHIT469ehJQZBiIiIiABMmzYNPXv2xEcffYTy5ctj7ty5cHZ2xoIFC1g/REREzyF/1y5wrlULhpgYtWyuITERWmEQhIiIiCxefHw8jh07hqZNm/5/J8naWt0/ePCgxdcPERHR87CytoZv4CRYu7gg9u+/cXf+fGjFVrNXJiIiItKJO3fuICkpCQULFkyzX+6fP3/+scfHxcWpzSgyMlL9TEhIUJupGI9lymOSabGN9I3to39sIwtqH09PeA4fjrDhw3F79ndwqF0bjq+8AlPJahkZBCEiIiJ6RoGBgQgICHhs/9atW9UUGlPbtm2byY9JpsU20je2j/6xjSykfayt4FOpEmAwYPfZs0g2YX6QmJiYLD2OQRAiIiKyeB4eHrCxsUFYWFiaupD73t7ej9WPv7+/SqKaeiRIkSJF4OfnBzc3N5Ne1ZKOZ7NmzWBnZ2fx7aRHbCN9Y/voH9vI8trH0KwZYGcHKysrmJJxVObTMAhCREREFs/e3h7VqlXDjh078NZbb6n6SE5OVvf79OnzWP04ODioLT3pIOZEsCKnjkumwzbSN7aP/rGNLKh97HLmfJbV8jEIQkRERASokR1du3ZF9erVUbNmTcyYMQPR0dFqtRgiIiLKHRgEISIiIgLQrl073L59G6NHj0ZoaCiqVKmCzZs3P5YslYiIiMwXgyBERERE/yNTXzKa/kJERES5g7XWBSAiIiIiIiIispggyOzZs1G8eHE4OjqiVq1aOHLkyBMfv2bNGpQtW1Y9vmLFiti4ceMLKysRERERERERmSfNgyCrV69WicjGjBmD48ePo3LlymjevDnCw8MzfPyBAwfQoUMHdO/eHSdOnFAZ3GU7ffr0Cy87EREREREREZkPzYMg06ZNQ8+ePVXm9fLly2Pu3LlwdnbGggULMnz8N998gxYtWmDw4MEoV64cxo8fj6pVq2LWrFkvvOxEREREREREZD40DYLEx8fj2LFjaNq06f8XyNpa3T948GCGz5H9qR8vZORIZo8nIiIiIiIiItJ8dZg7d+4gKSnpsaXn5P758+czfI4sWZfR42V/RuLi4tRmFBERoX7eu3cPCQkJMBU5VkxMDO7evQs7OzuTHZdMh22kb2wf/WMb6Zs5tc/Dhw/VT4PBgNzC+F4iIyNzpF3luHpvV0vFNtI3to/+sY30LcGMzkPGc/DT+he5foncwMBABAQEPLa/RIkSmpSHiIiI/j8Y4u7uniuqwxjYKVKkiNZFISIismgPn9K/0DQI4uHhARsbG4SFhaXZL/e9vb0zfI7sf5bH+/v7q8SrRsnJyWoUSIECBWBlZQVTRp2k43Pz5k24ubmZ7LhkOmwjfWP76B/bSN/MqX3kCo10UHx9fZFbyHuRund1dWX/wsKY02fPErF99I9tpG+RubB/oWkQxN7eHtWqVcOOHTvUCi/GIIXc79OnT4bPqV27tvp9//79U/Zt27ZN7c+Ig4OD2lLLmzcvcor8Yej9j8PSsY30je2jf2wjfTOX9sktI0BS5zQrXLgwLL1dLRnbSN/YPvrHNtI3t1zUv9B8OoyM0ujatSuqV6+OmjVrYsaMGYiOjlarxYguXbqgUKFCalqL6NevHxo0aICvv/4arVu3xqpVq3D06FHMmzdP43dCRERERERERHqmeRCkXbt2uH37NkaPHq2Sm1apUgWbN29OSX5648YNdXXFqE6dOlixYgVGjhyJ4cOHo3Tp0vj1119RoUIFDd8FEREREREREemd5kEQIVNfMpv+snv37sf2vf/++2rTE5lyM2bMmMem3pB+sI30je2jf2wjfWP75E5sV/1jG+kb20f/2Eb65pALv+daGXLT+nRERERERERERJn4/3kmRERERERERES5GIMgRERERERERGQRGAQhIiIiIiIiIovAIIiJzJ49G8WLF4ejoyNq1aqFI0eOmOrQ9BzGjh0LKyurNFvZsmVZpxrau3cv2rRpA19fX9UesrpTapKmSFaL8vHxgZOTE5o2bYp//vlHs/Jamqe1T7du3R77TLVo0UKz8loaWS6+Ro0acHV1hZeXF9566y1cuHAhzWMePXqE3r17o0CBAnBxccG7776LsLAwzcpMz4f9C31i/0J/2L/QN/Yv9C3QwvoXDIKYwOrVqzFw4ECVNff48eOoXLkymjdvjvDwcFMcnp7TK6+8gpCQkJRt//79rFMNRUdHq8+IdOwzMmXKFHz77beYO3cuDh8+jDx58qjPk/zHS9q3j5CgR+rP1MqVK9k0L8iePXtUB+TQoUPYtm0bEhIS4Ofnp9rNaMCAAfj999+xZs0a9fjg4GC88847bCMzxP6FvrF/oS/sX+gb+xf6tsfS+heyOgw9n5o1axp69+6dcj8pKcng6+trCAwMZNVqbMyYMYbKlStrXQzKhPwXtG7dupT7ycnJBm9vb8PUqVNT9j148MDg4OBgWLlyJetR4/YRXbt2NbRt25ZtoRPh4eGqnfbs2ZPyebGzszOsWbMm5THnzp1Tjzl48KCGJaXsYP9Cv9i/0Df2L/SN/Qv9C8/l/QuOBHlO8fHxOHbsmBqyb2Rtba3uHzx48HkPTyYgUylkaH/JkiXRqVMn3Lhxg/WqU1evXkVoaGiaz5O7u7uaYsbPk37s3r1bDZV8+eWX0atXL9y9e1frIlmsiIgI9TN//vzqp5yP5OpN6s+QTAEsWrQoP0Nmhv0L/WP/wnywf2Ee2L/Qj4hc3r9gEOQ53blzB0lJSShYsGCa/XJfvsyRtuTL86JFi7B582bMmTNHnQTr1auHhw8fsml0yPiZ4edJv2QqzJIlS7Bjxw4EBQWp4ZAtW7ZU/w/Si5WcnIz+/fujbt26qFChQspnyN7eHnnz5k3zWJ6TzA/7F/rG/oV5Yf9C/9i/0I9kC+hf2GpdAKKcJF/OjCpVqqQ6LcWKFcNPP/2E7t27s/KJnlH79u1TblesWFF9rl566SV19aZJkyaszxdI5u6ePn2aeY6INMD+BZFpsX+hH70toH/BkSDPycPDAzY2No9lxpX73t7ez3t4MjGJXpYpUwaXLl1i3eqQ8TPDz5P5kGlm8v8gP1MvVp8+ffDHH39g165dKFy4cJrPkEyjePDgQZrH85xkfti/MC/sX+gb+xfmh/0LbfSxkP4FgyDPSYYFVatWTQ0NTz2ESO7Xrl37eQ9PJhYVFYXLly+r5VdJf0qUKKH+I039eYqMjFSrxPDzpE///vuvygnCz9SLIfnkpIOybt067Ny5U31mUpPzkZ2dXZrPkCxxJ7mQ+BkyL+xfmBf2L/SN/Qvzw/7Fi2WwsP4Fp8OYgCyP27VrV1SvXh01a9bEjBkz1HJCH330kSkOT89h0KBBaNOmjZoCI8s4yTLGMnKnQ4cOrFcNO4qpRw1InpaTJ0+qxEuSXEnmIE6YMAGlS5dW/wGPGjVKJbaV9cpJ2/aRLSAgQK0LL8EqCSgOGTIEpUqVUssY04sZorpixQqsX78erq6uKfNwJYGwk5OT+ilT/eS8JO3l5uaGvn37qg7Ka6+9xiYyM+xf6Bf7F/rD/oW+sX+hb70trX+h9fI0ucXMmTMNRYsWNdjb26sl7Q4dOqR1kchgMLRr187g4+Oj2qVQoULq/qVLl1g3Gtq1a5daTiv9JkuvGpfJHTVqlKFgwYJqadwmTZoYLly4wDbTQfvExMQY/Pz8DJ6enmqZtGLFihl69uxpCA0NZfu8IBm1jWwLFy5MeUxsbKzh888/N+TLl8/g7OxsePvttw0hISFsIzPF/oU+sX+hP+xf6Bv7F/oGC+tfWMk/WgdiiIiIiIiIiIhyGnOCEBEREREREZFFYBCEiIiIiIiIiCwCgyBEREREREREZBEYBCEiIiIiIiIii8AgCBERERERERFZBAZBiIiIiIiIiMgiMAhCRERERERERBaBQRAiIiIiIiIisggMghARERERERGRRWAQhIiIiIiIiIgsAoMgRERERERERGQRGAQhIt1o2LAh+vTpozZ3d3d4eHhg1KhRMBgM6vdLly5F9erV4erqCm9vb3Ts2BHh4eEpz79//z46deoET09PODk5oXTp0li4cKGG74iIiIi0xv4FEaXGIAgR6crixYtha2uLI0eO4JtvvsG0adPwww8/qN8lJCRg/Pjx+Pvvv/Hrr7/i2rVr6NatW8pzJWBy9uxZbNq0CefOncOcOXNUIIWIiIgsG/sXRGRkZTBeYiUi0sGVGhnZcebMGVhZWal9w4YNw2+//aaCG+kdPXoUNWrUwMOHD+Hi4oI333xTBT0WLFigQemJiIhIj9i/IKLUOBKEiHTltddeSwmAiNq1a+Off/5BUlISjh07hjZt2qBo0aJqSkyDBg3UY27cuKF+9urVC6tWrUKVKlUwZMgQHDhwQLP3QURERPrB/gURGTEIQkRm4dGjR2jevDnc3NywfPly/PXXX1i3bp36XXx8vPrZsmVLXL9+HQMGDEBwcDCaNGmCQYMGaVxyIiIi0iv2L4gsD4MgRKQrhw8fTnP/0KFDKsHp+fPncffuXUyePBn16tVD2bJl0yRFNZKkqF27dsWyZcswY8YMzJs37wWWnoiIiPSI/QsiMmIQhIh0Raa2DBw4EBcuXMDKlSsxc+ZM9OvXT02Bsbe3V/evXLmi8oRIktTURo8ejfXr1+PSpUsqr8gff/yBcuXKafZeiIiISB/YvyAiI9uUW0REOtClSxfExsaiZs2asLGxUQGQTz75ROUJWbRoEYYPH45vv/0WVatWxVdffaWSoRpJkMTf31+tGiNL5MqIEckRQkRERJaN/QsiMuLqMESkq+ztktRUprEQERERsX9BRKbG6TBEREREREREZBEYBCEiIiIiIiIii8DpMERERERERERkETgShIiIiIiIiIgsAoMgRERERERERGQRGAQhIiIiIiIiIovAIAgRERERERERWQQGQYiIiIiIiIjIIjAIQkREREREREQWgUEQIiIiIiIiIrIIDIIQERERERERkUVgEISIiIiIiIiIYAn+DwE8t74a8hmLAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1100x360 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Courbes de tri le long de la trajectoire (rappel ICT-2)\n",
+    "sortedness = sm.sortedness_curve(vals)\n",
+    "inversions = sm.inversions_curve(vals)\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 3.6))\n",
+    "ax1.plot(sortedness, color=\"tab:green\")\n",
+    "ax1.set_title(\"Sortedness (degre de tri)\")\n",
+    "ax1.set_xlabel(\"pas\"); ax1.set_ylabel(\"sortedness\"); ax1.set_ylim(0, 1.02)\n",
+    "ax2.plot(inversions, color=\"tab:red\")\n",
+    "ax2.set_title(\"Inversions restantes\")\n",
+    "ax2.set_xlabel(\"pas\"); ax2.set_ylabel(\"# inversions\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-recall-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002997,
+     "end_time": "2026-06-29T10:57:59.467845+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.464848+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "La trajectoire descend de facon **monotone non triviale** : la sortedness monte vers 1, les inversions\n",
+    "tombent vers 0, mais pas en ligne droite (le scheduler asynchrone choisit une cellule au hasard a chaque\n",
+    "pas, donc certains pas sont « a vide »). C'est cette **dynamique stochastique** qui, agregee sur de\n",
+    "nombreuses trajectoires, va devenir une chaine de Markov : un etat de tri donne ne mene pas toujours au\n",
+    "meme etat suivant, et c'est precisement ce bruit qui rend la question de l'echelle interessante."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-tpm-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003516,
+     "end_time": "2026-06-29T10:57:59.475382+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.471866+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. De la trajectoire a la chaine de Markov\n",
+    "\n",
+    "**Micro-etat = la configuration complete** (le tuple des valeurs, p.ex. `(3, 1, 0, 2)`). Pour $n = 4$\n",
+    "valeurs distinctes, il y a $4! = 24$ micro-etats possibles.\n",
+    "\n",
+    "Une seule trajectoire ne suffit pas a estimer des *probabilites* de transition : avec une graine\n",
+    "fixee, la dynamique est deterministe. On **agrege donc de nombreuses trajectoires** issues de departs\n",
+    "varies et de graines variees. Depuis un meme micro-etat, des cellules differentes sont activees selon\n",
+    "la graine — d'ou des etats suivants differents, donc des transitions reellement **stochastiques**.\n",
+    "\n",
+    "`ict.tpm_estimation.tpm_from_trajectories` compte ces transitions et renvoie une TPM **ligne-stochastique**\n",
+    "$P[i, j] = \\Pr(\\text{etat suivant} = j \\mid \\text{etat courant} = i)$, avec un mapping etat -> indice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ict6-tpm-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:57:59.484670Z",
+     "iopub.status.busy": "2026-06-29T10:57:59.484670Z",
+     "iopub.status.idle": "2026-06-29T10:57:59.503684Z",
+     "shell.execute_reply": "2026-06-29T10:57:59.503684Z"
+    },
+    "papermill": {
+     "duration": 0.026421,
+     "end_time": "2026-06-29T10:57:59.505710+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.479289+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trajectoires agregees : 240\n",
+      "micro-etats observes  : 24 / 24 permutations possibles\n",
+      "forme de la TPM       : (24, 24)\n",
+      "verif : chaque ligne somme a 1 ? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "def collect_trajectories(n=4, algotypes=None, frozen=None,\n",
+    "                         n_starts=40, seeds=6, max_steps=400, seed_shuffle=0):\n",
+    "    '''Agrege des trajectoires de self-sorting (micro-etats = tuples de valeurs).\n",
+    "\n",
+    "    Pour chaque depart melange (n_starts), on rejoue le tri sous plusieurs graines\n",
+    "    (seeds) : le scheduler asynchrone seede produit des transitions stochastiques.\n",
+    "    Retourne une liste de trajectoires, chacune = liste de tuples d'etats.'''\n",
+    "    base = list(range(n))\n",
+    "    rng = random.Random(seed_shuffle)\n",
+    "    trajs = []\n",
+    "    for _ in range(n_starts):\n",
+    "        start = base[:]\n",
+    "        rng.shuffle(start)\n",
+    "        for s in range(seeds):\n",
+    "            arr = SelfSortingArray(start[:], algotypes=algotypes, frozen=frozen, seed=s)\n",
+    "            arr.run(max_steps=max_steps)\n",
+    "            trajs.append([tuple(v) for v in arr.probe.values])\n",
+    "    return trajs\n",
+    "\n",
+    "trajs = collect_trajectories(n=4)\n",
+    "tpm_micro, mapping = TE.tpm_from_trajectories(trajs, unseen=\"self\")\n",
+    "\n",
+    "print(\"trajectoires agregees :\", len(trajs))\n",
+    "print(\"micro-etats observes  :\", len(mapping), \"/ 24 permutations possibles\")\n",
+    "print(\"forme de la TPM       :\", tpm_micro.shape)\n",
+    "print(\"verif : chaque ligne somme a 1 ?\", np.allclose(tpm_micro.sum(axis=1), 1.0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ict6-tpm-plot",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:57:59.516621Z",
+     "iopub.status.busy": "2026-06-29T10:57:59.515622Z",
+     "iopub.status.idle": "2026-06-29T10:57:59.638355Z",
+     "shell.execute_reply": "2026-06-29T10:57:59.638355Z"
+    },
+    "papermill": {
+     "duration": 0.128841,
+     "end_time": "2026-06-29T10:57:59.639454+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.510613+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjMAAAHqCAYAAADxi8+4AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAVYhJREFUeJzt3Qm8TPX7wPHn2u61XUv2XSmlLEWEpCJafv3S9hMVIa0kKkt2skRJiyUVKpFKlPLTaqmQLCk/UUooOyHLtd3zfz1fzfxn7p257txz5p6Zez7vXid3zsycOXPmzMwzz/f5fr8JlmVZAgAAEKdyub0DAAAAdhDMAACAuEYwAwAA4hrBDAAAiGsEMwAAIK4RzAAAgLhGMAMAAOIawQwAAIhrBDMAACCuEczAlt9//10SEhJk6tSpOf5Ijho1Ss4//3xJTU0VL4n31/jKK6+Ue+65x+3dQBbt3btXChYsKPPmzeMYIiyCmSjSL4DMLAsXLvR/YfiW3LlzS6VKleTmm2+W77//PuR277333pCP27dvX/9t9uzZE82nGNcGDRoUdMwLFCggNWrUkH79+snBgweDbquXn376aenVq5fkyhX522b8+PG2goFt27aZ/U17LnjNkSNHzHHQ94xbnHgt9ItZt4EzH5OzzjrLfNb179+fw4Ww8oS/Cna9+eabQZffeOMN+eyzz9Ktv+CCC+To0aPm7zZt2sj1118vp06dkp9++kkmTJgg//3vf2XZsmVSp04d/32SkpJk1qxZ5ksyX758QdubMWOGuT4lJSXqL2LlypXNvufNm1filR7jQoUKyaFDh+TTTz+VYcOGyZdffinffPONCXLU5MmT5eTJk+b1yQp9nUqUKJHlDIF+gQ4ePFiqVKkSdB5kh1h6jTWY0ePgy7i4wYnXQr+4x40bR0CTyWPywAMPyAsvvGDel1dffXXWXzzkWAQzUXTXXXcFXdaARIOZtOuVZmbUJZdcEnR948aN5d///rf5wn355Zf966+99lr58MMPTaBz0003+dcvWbJENm3aJLfeeqsJdqJNv+w1cHLC4cOHTTo5u912220m0PB9aOqxe//9983r1bBhQ7N+ypQp5nVw6rnGEydfY8Q3Dei1mTXtD6ho0x98F110kcluEswgFJqZYpzvjasBSqDy5cvLFVdcIdOnTw9a/9Zbb0nNmjXNGz+Sppaff/7ZBFFFihSRkiVLmpSuTqi+detWEywlJydLmTJl5Nlnn81UPcX69evlP//5j9lW/vz5pXr16qb5K+3jrlu3Ttq2bSvFihWTyy+/3P+BOXToUDnnnHMkMTHR/AJ+8skn5dixY2d8PidOnDCPvX37dnHqmOu/P/zwgzRv3jzdbfWDfezYsXLhhReaL/zSpUvL/fffL3/99Zf/Nrr///vf/2TRokX+Ji1fVmHfvn3y+OOPm9dMs0N6nK+77jpZs2aN//7apHLppZeavzt06ODfRkbNVn///bc8+uij5rH1GJYqVUquueYaWbVqVdB+hcoU6b4FZj3SvsbPPPOMubx58+Z09+3Tp4/5ovM9/6+++kpuv/1202Sq+1GxYkXp3r27PxPpo/uhz//PP/+UVq1amb/13NFjo1lK337oOqWZEd9xcLK5Rh+/Y8eO5nXU/dXXVbNymX0tMvN89blqBkIFNnOeif5wadq0qRQuXNicJ7ofad//7777rtStW9e85zRA1/e0PqeMXt/A/dJzIu3rrq+3nuO+96O+Z48fPy4DBgwwj6WfGfojpEmTJrJgwYKgbQZuY9KkSf5t6L5/9913ER0TPX/nzp1rPpeAtMjMxLhff/3V326clgYB3bp1M80j+uGvQYB+mPXo0SPiJqbWrVubXz8jR46Ujz/+WJ566ikpXry4yQbpl7vWi2igpF8u+kGkgVQ4+sWvH2zaLHHfffeZD0h9HvpBpE04gfSD/9xzz5Xhw4f7P6S0ffz11183GZPHHntMvv32WxkxYoRpdps9e3aGz0M/uPV5tG/fPss1KmmPuWa7fFmztDRw0cfRL7ZHHnnEBD4vvfSSrF692jRT6THQL4KuXbua18gX0OmXpfrtt99kzpw55jhUrVpVdu7caY65fmnpl0a5cuXM8xkyZIj58tDjqcdWNWrUKOxz0AzTe++9J126dDF1QFpE+fXXX5tjGOp5REKD1J49e8o777wjTzzxRNB1uq5FixYmOFV6PmrT0IMPPmiO5/Lly+XFF1+UP/74w1wXSIOWli1bSoMGDcyX3+eff26CZ/0C1PtrIKMZSv1ba8luueUWc79atWqJE/TYX3bZZeZLVI+bPp4GEJ06dTI1Uxocnum1yMzz1XNGm6pCNTmHo+eYBlkaXGnAWLRoUXOOzZ8/33wO+G6j56G+P/X9os/n+eefN+eh3lbvkxWaldTPE32+Gojo54Iej1dffdU0u3bu3NkEz6+99pp5/fQ5p21+06BLb6PPXY+vFtPr66fnv75HMnNMNHB67rnnzA+DzP5Yg4dYyDYPP/ywfluHvG7Tpk3musGDB1u7d++2duzYYS1cuNC6+OKLzfpZs2b5b6uXdVv79u2z8uXLZ7355ptm/ccff2wlJCRYv//+uzVw4EBzO91WRny3u++++/zrTp48aVWoUMFsa+TIkf71f/31l5U/f36rffv26fZ7ypQp/nVXXHGFVbhwYWvz5s1Bj5Wamprucdu0aRN0m++//96sv/fee4PWP/7442b9l19+meHz8e1P4D6e6blv2LDBHCe978svv2wlJiZapUuXtg4fPmxu169fP3O7v//+O+j+X331lVn/1ltvBa2fP39+uvUXXnih1bRp03T7kJKSYp06dSrdc9B9GDJkiH/dd999l+44Z6RIkSLmHMlI5cqVQx4n3c/AfQ31Gjds2NCqW7du0P2WL19ubvfGG2/41x05ciTd9keMGGHOrcDzQ/dD7xv4nJWe/4GPo6+T3k5fu8zS55KZ86FTp05W2bJlrT179gStv+OOO8zx9D2XjF6LzD7fjD4L0tq/f795PzVo0MA6evRoyPfU8ePHrVKlSlkXXXRR0G0++ugj8zgDBgwI+/r66DHScyLt656cnGzt2rUr6Lb6GXHs2LGgdfr5oO+bjh07ptvGWWedZT6vfD744AOzfu7cuZk+JkuWLDHXz5w5M4OjBa+imSnGDBw40Pwi1CYdTQVrlkCzIr5foYH016/WzmjBr+/Xj/5C1ILNSAX2jNKeVPXq1TOZEv1V6qO/7LS5SH9NhbN7925ZvHix+RWpqfZAoVLpmkEI5Ot+qdmlQJqhUZo1yohmgXS/I8nK6HPSY66ZEf2FWK1aNfM42rtJaVYjT548JrMSSH9pa4pd09/aa8y36C9IvW3alHso+kvX1ztKMxP6WHpf3afAJqFI6WulGS39tRsNmslbuXKlP4ulZs6caZ5PYA2XNncE1kTp8dFzVF8jzRac6XzQzEdG55tTdH+0xuzGG280fwe+npptOHDgQKZej0ifb2ZotkKzGr17905Xu+R7T61YsUJ27dolDz30UNBtbrjhBjOcwJneNxnRGjJf817gZ4SvbkabWrW5VDPD+rkR6jjp+eLL1ilfRiuS19Z3f3poIhSamWKMpnK1yUG/4PQLSdPK+gURjqaY7777btmyZYtprtD0bVakDTz0S1o/FH2FsYHr9Qs3HN+HU2bTwBpABNI6DH3uGlAE0uBOj0eoOg279EtMaxA03V2hQgXTrJEZv/zyi/mS03qUUPTL5Uz0i0CbArS3kzZR+epDwjUtZpaeB9rUpjUbGlxpD7l27drJ2WefLU7Qc1QDTg1gtJ5Jv6w1uNN6Hz2WPnpeapOMFqsH1hEpPXaB9HxL+6WpX2Bp7xcNGoTv37/f1HXoktXXM5Lnm1m+gDGj95TvfaFBcFoazGgTY1alfY/6aFOwNgNqjZrWqmV0+7SfL77AJJLX1tcMnZn6IngPwUyM0fqRUIWm4WgPGw129ItLC2S1niEr9JdWZtYpJwvwAn/JBsrODyyt/0kbtAXSoEJ/deqvYy2+DAxENJDRWqJQ0n4xh6K1QlpsrZksLXrWegQN5rQ+w87gfHoe6K9frTHS7uajR482GT7tpaUBR0bHWAOqcK+9j9by6Pa1RkaDGe35pV/k+hiB29Gslf5q1/F59EtVC0W1rkkLPtM+vzM9ZjT59kULZvW9FMqZanMifb5u0dc91Hs4MJA+03t02rRp5jlpsbbWTen7QF8/rdUJzNY5+VniC3wyeq/Cuwhm4px+0OgHin646JeU22903y//tWvXZun+2kSmH/qa9dBiSx8tZtRfzllpQrNLv5SUZk4Cv9A0g6NFqtp9PlxQ5hMucNAi3auuusoUTwbS5xr4WmYluCtbtqxpdtBFswpa+KsF2L5gRn8d6+OE+pWfmQyONh3otjds2GAyNNosp800Pj/++KPpJae/4DUrFNhsklXRCnI18NRAVb/Qz/RjItw+RPJ8I3kevkyhvqfSZix9fO8LfS3Sdl3WdYHvG33dQzXvRJL11PNWzxENjgOfizaTZ9WZjomvd2Hg5wLgQ81MDqA9jPRDJBZGyNQvBc10aHdW/aUe6a8wbQ5R2gMo0JgxY/w1ANHump2Wb6wZrUtIm/3QLz/NqKSlmZzAQEF/oYcKHPQXa9rjos01abvT+sbfCbWNtHSf0jZp6C9nzaYEdm/XL0nNqGg3W5+PPvrIdMfPbC2F7r/WbOk+/+tf/woaJ8j3azzw+enf2qyWVb46pswch0jovvrGZgoViGsz1Jlei0iebySvp/YO00BLsx5peyn6HktrVfQ1njhxYtBrrL2xtAdb4PtGX3d9jwQ+Jx0KQHs9ZVao56o1WkuXLpWsOtMx0RotbebWpncgLTIzOUDt2rXNEit0pE4dM0YzAVoDpG3oOt6EFiGeaQh4fR6a5te6Bf1Q0y7K2tVTf+1qBkqzGNHump2W/gLVegXNwmhzkI/umxYM65eMPi/90tG6G80q6Ze7folp93KldSvarVi7vOuva/3i0V/QGgBoV1/tUquFovrrXput0mZG9AtIa4b0y0q/2PSDX7swh6pP0OYwrf3Rx9bjqQXFuu86rkfgOEFa9K2/sLWIXAMzbR7QDF9ma4b0OejroYGmPqZmatJmtHRbGmzr66K1NBos2KmB0QyYdjXXTNB5551nmuX0tXGiq64OS6BF23pctbuxPo42GWlBqx4//Tuj1yKS56vng9Lu/FpgrMHBHXfcEXK/dDvaJVlfL+127RuXSQMQ7Qau7w0977SJT88jPS+1y7Sva7YWxetYNz56Dutrpo+rBf6atdPnokFC2mk8wtHzVrMy2kVeAyXNmug29JjpUBFZcaZjohkuzfxRM4OQ3O5O5SWZ6Zo9evToM27H1zU7I5F2zU57O+2mWbBgwXS31y6d2s047X6n7aa6du1a6+abb7aKFi1qJSUlWdWrV7f69++fqf07ceKE6aJetWpVK2/evFbFihWtPn36mG7MZ5KVrtlnOkZqzJgxVqFChUJ2vZ00aZLpPqzd1rULbc2aNa2ePXta27Zt899Gu9rfcMMN5np9TF/XWH1Ojz32mOkSrPdv3LixtXTp0pDdZ7U7a40aNaw8efJk2E1bu8w+8cQTVu3atc3j6euof48fPz7dbZ999lmrfPnypiu4PvaKFSsy1TXb55VXXjHX6eOk7Tas1q1bZzVv3twcuxIlSlidO3e21qxZk2574c4332uUtouuHm8dliAz3bQz2zVb7dy507y39JzTc69MmTJWs2bNzGucmdcis89XuzZ37drVKlmypOm2nZmP4g8//NBq1KiROU+0u3T9+vWtGTNmBN1Guy1rd3Z9PYsXL27deeed1h9//JFuW9OmTbPOPvtscwzr1KljffLJJ2G7Zof6TNIu4cOHDze318fSx9Ru4JFsI+1rl9Ex+emnn8zlzz///IzHCd6UoP8LHeYA8NFmG82WaC+hwO7qiH06xIFmJ+J11m+IKYjXIR+0qYnMDEKhZgbIBG2r11FvtVdQrPRKAbxAh4LQ0Ya1iZZABuGQmQGQo5GZAXI+MjMAACCuEcwAyNF0pmvqZYDQtBZJe4np0A3ajKcjyWfmPaW9VXXAVu2dGQvvL4IZAAA86vDhw2YIh3HjxmXq9toNX7vj67AMOiSFFmfrsAGffPKJuImaGQAAIJqZ0SlQdEyvcHSqDh0zLHBwSR0PSMcFmz9/vmtHMccPmqc9T3TmYB3cikp4AEBW6UgmOkCkNsn4Zrt3go7sHDgStxP7mZBmeghtEspo0uLM0lGe0075oYMcaobGTTk+mNFARmcOBgDACTrlh46y7VQgU7Vqedmx4/QI004oVKhQupGYdcqbQYMG2d72jh07pHTp0kHr9LKOHn306NEzzlMXLTk+mPHNcvx5ow5SME++dNen5sslmzs2kcqTv5Jcx8OPH7J09+kp6+3o8dMo8YKkpPwyefIr0rFjZ0lJOer27sQ9jifHM5Z56/w0AxH7v1ecoBkZDWR+3/yOJCefnnvMjoMHj0iVyv8xAZdOheHjRFYmluX4YMaXatNAplCoYCZPbjN5XaE8iZIr9VTY7eTP7cSJEJ0Zf2PxmOsxPX3svfGco4njyfGMZd47P9M34TghuVCSJBdyIKuRevpHuQYygcGMU8qUKWPm/Qqkl/Wx3MrKeCKYAQAg5mkQ4sTo4qnRHaG8YcOGMm/evKB1OgmorndTXHTN1i5jOrdKUlKSmZ1WZ1EGAAD2aG2NdrHWxdf1Wv/esmWLudynTx9p166d//YPPPCA/Pbbb2Z6l/Xr18v48ePlnXfeCZqZ3Q0xH8zMnDlTevToYYqXVq1aZfrDa+W0TlsPAECOysw4sURgxYoVcvHFF5tF6fet/j1gwABzefv27f7ARlWtWtV0zdZsjH4fP/vss2buLP1edlPMNzONGTNGOnfuLB06dDCXJ06caA7k5MmTpXfv3m7vHgAAcT13mWVpYXNooUb31fusXr1aYklMZ2a0ylunfA/s0659+/Wy9nUHACBH0IDCqcWDYjozs2fPHjl16lTIPu3aVhfKsWPHzOKjfd99XbC151JaqXlzB/0bTkKi/bjPzUrv7OR7nl55vtHG8eR4xjIvnZ+awUhJORydjadaDhUAW+JFMR3MZMWIESNk8ODB6dbrWDLafTCczZ2aZLjdMg7s2wyZJl6iY0+A4xmrOD85npE6cuSItG3bNgpnI3J0MFOiRAnJnTt3yD7t2tc9FK281gKmwMyMjgCsg+LpWDJpaUZGA5nKr30luU6ciuqged3XjRYv0F9ovkG0dERIcDxjCecnxzOrMqot8UrX7FgV08FMvnz5pG7duvLFF1/4J77SuZb0cpcuXULeJ9z8Ezq6b0aD4mkgk+t4+OutY/ZPEK99sevz9dpzjiaOJ8czlnnj/CSYiVUxHcwozbK0b99e6tWrJ/Xr15exY8eaKct9vZsAAIC3xXww07p1a9m9e7fp864TXNWpU8dMM562KBgAgLhFM1PODmaUNimFa1YCAADeFhfBDAAAOZrlUAGwRQEwAABwQYKVahYntuNFnsnMNFysY54khOymOeOBK+WyRa9mWIl/rK/9sQW+2tnX9jam7x5mexsAAOQknglmAACIWRQA20IwAwCA28x0Bg6MY5PqzekMYnqiSQAAgDMhMwMAgNtoZrKFYAYAALcRzNhCMxMAAIhrZGYAAHCbzsjtxBgxFgXAAAAAcYfMDAAAbqNmxhaCGQAA3MY4M7ZQAAwAAOIamRkAANxGM5MtBDMAALhNezJpQOPEdjyIZiYAABDXyMwAAOCyhNRUszixHS8iMwMAAOIamZlMShw23fbBPnHyc9vbmJ5nmO1tAABicQRgB0bvtbw5AjDBDAAAbqM3ky00MwEAgLhGZgYAALeRmbGFYAYAALcxnYEtNDMBAIC4RmYGAAC30cxkC8EMAAAx0cyU6sx2PIhmJgAAENfIzAAA4DYGzbOFzAwAAIhrZGYAAHAbBcC2EMwAABALzUxOFO9aFAADAADEHTIzAAC4jWYmWwhmAABwG8GMLfRmAgAAcY3MTDa6qcSntrdxcsw9tu6fp8dU2/sAAHAYE03aQjADAIDbrNTTixPb8SCamQAAQFwjMwMAgNtoZrKFzAwAAIhrZGYAAHAbXbNtIZgBAMBtNDPZQjMTAACIa2RmAACIicyMA92qU7050STBDAAAbqOZyRaamQAAQFwjMwMAgOscGgFYGAEYAAAg7pCZAQDAbdTM2EIwAwCA2whmbKEAGAAAxDUyM9lo3v5RtrfRelgfW/ef3+AJ2/vwwoaEDK/Pm5Tb/NuiyKNyIvFU1I4FAOQYTGdgC8EMAABuo5nJFpqZAABAXCMzAwCA28jM2EIwAwCA26iZsYVmJgAAENfIzAAA4DbLOr04sR0PIjMDAADiGpkZAADcRgGwLQQzAAC4jWDGFpqZAADwuHHjxkmVKlUkKSlJGjRoIMuXL8/w9mPHjpXq1atL/vz5pWLFitK9e3dJSUkRt5CZAQDAbVbq6e7ZTmwnQjNnzpQePXrIxIkTTSCjgUrLli1lw4YNUqpUqXS3nz59uvTu3VsmT54sjRo1kp9//lnuueceSUhIkDFjxogbyMwAABArzUxOLBHSAKRz587SoUMHqVGjhglqChQoYIKVUJYsWSKNGzeWtm3bmmxOixYtpE2bNmfM5kQTwQwAADnMwYMHg5Zjx46FvN3x48dl5cqV0rx5c/+6XLlymctLly4NeR/Nxuh9fMHLb7/9JvPmzZPrr79e3EIzEwAAbtPWoSxkVUJuR8TUsQQaOHCgDBo0KN3N9+zZI6dOnZLSpUsHrdfL69evD/kQmpHR+11++eViWZacPHlSHnjgAXnyySfFLQQzAADksN5MW7duleTkZP/qxMREccrChQtl+PDhMn78eFNjs3HjRunWrZsMHTpU+vfvL24gmAEAIIdJTk4OCmbCKVGihOTOnVt27twZtF4vlylTJuR9NGC5++675d577zWXa9asKYcPH5b77rtP+vbta5qpshvBTDYadt4A29vo+/MQW/eftdf2LsiWGztmeP2pvHlkjXbda7RXcp84GfI2leba3w8AyCmsVMssTmwnEvny5ZO6devKF198Ia1atTLrUlNTzeUuXbqEvM+RI0fSBSwaECltdnIDwQwAAB7Wo0cPad++vdSrV0/q169vumZrpkV7N6l27dpJ+fLlZcSIEebyjTfeaHpAXXzxxf5mJs3W6HpfUJPdCGYAAPDwRJOtW7eW3bt3y4ABA2THjh1Sp04dmT9/vr8oeMuWLUGZmH79+pkxZfTfP//8U0qWLGkCmWHDholbCGYAAPD4dAZdunQJ26ykBb+B8uTJY3pH6RIrGGcGAADEtZgOZrRPvKayApfzzz/f7d0CACDHjACcE8R8M9OFF14on3/+eVB6CwCAHIVZs22J+chAg5dwfd0BAABiPpj55ZdfpFy5cmZa8oYNG5quYZUqVQp7e51/InAOCp2TQiUl5TfNVGnp9OWB/0ZTrkT7rXrZsZ9nouPIZHx97qB/Y/V5xIvsPEe9gOPJ8cwqHUMlJeWwRAWZGVsSLLdGuMmE//73v3Lo0CGpXr26bN++XQYPHmy6ga1du1YKFy4cts5GbxdqynKdBRQAgKzQweJ0XqIDBw5kanTdzNAf3EWKFJG/nr5HkvPns7+9o8elWK+pju5jPIjpYCat/fv3S+XKlc1gPZ06dcp0ZkYn3EpKKhg2MzN58ivSsWNnOXr0aFT3f0C1Xra3MWTj0+K2ddfdneH1mpFZ26a5XDTjc8l94lTI29T475tR2rucJzvPUS/geHI87WZmohHM7BvZXpKTHAhmUo5L8d6vey6YiflmpkBFixaV8847z4w2GI5OphVqQq2UFP0SSB/M+OiXRLS/KFKP/TOdqQ2x8GUWboqC9Lc7Ffa2sfA84k12nKNewvHkeEYuir/9aWbKuV2z09Imp19//VXKli3r9q4AAIAYEdPBzOOPPy6LFi2S33//XZYsWSI333yzmfehTZs2bu8aAADOYZyZnNvM9Mcff5jAZe/evWbuh8svv1yWLVtm/gYAIMegmSnnBjNvv/2227sAAABiXEwHMwAAeIKLs2bnBJ4JZvqf00uScieFHchOu01n1Nuo789DbO+DE9uIBZXmTj5j19cZ7Vqa7tfhet8MqDbA9n78sO+47W3M2TfS9jYAwC4r9fTixHa8KKYLgAEAAM7EM5kZAABiFgXAtpCZAQAAcY3MDAAAbiMzYwvBDAAALqMA2B6amQAAQFwjMwMAgNt0fBhtanJiOx5EMAMAgNt0fBgnxohJFU+imQkAAMQ1MjMAALjMSrXM4sR2vIhgBgAAt9HMZAvNTAAAIK6RmQEAwG3aOuREC5ElnkRmBgAAxDUyMwAAuIwCYHsIZgAAcBsFwLZ4JpgZ+uvTIpKQbn3+/PllhkyTIRuflqNHj4a9/2eXPW57H65Z9oztbeQUQzYOsb2NOfV629/GPtubAAC4zDPBDAAAsYqJJu0hmAEAwG00M9lCbyYAABDXyMwAAOAympnsITMDAADiGpkZAADcZv1TN+PEdjyIYAYAAJdZ1unFie14Ec1MAAAgrpGZAQDAZRQA20MwAwCA2xhnxhaamQAAQFwjMwMAgMtoZrKHYAYAAJfRm8kempkAAEBcIzMDAIDbUhNOL05sx4PIzAAAgLhGZiaTrln2THRfCUSs1YqRto/anHq9bW9j6m+2NyFz9tl/Lq1LPGnr/jP3DLe9DwCyhgJgewhmAABwmWUlmMWJ7XhRxM1MQ4YMkSNHjqRbf/ToUXMdAABATAczgwcPlkOHDqVbrwGOXgcAALLWzOTE4kURNzNZliUJCenTWGvWrJHixYs7tV8AAHhrnBkHAhHLo7NmZzqYKVasmAlidDnvvPOCAppTp06ZbM0DDzwQrf0EAACwF8yMHTvWZGU6duxompOKFCnivy5fvnxSpUoVadiwYWY3BwAA/kEBcDYFM+3btzf/Vq1aVRo1aiR58+a1+dAAAAAu1Mw0bdpUUlNT5eeff5Zdu3aZvwNdccUVDuwWAAAekpogFiMAZ18ws2zZMmnbtq1s3rzZNDsF0joarZ8BAACZx0ST2RzMaJFvvXr15OOPP5ayZcuG7NkEAAAQs8HML7/8Iu+9955Uq1YtOnsEAIDHUACczYPmNWjQQDZu3GjzYQEAgI/Wyzi1eFHEmZmuXbvKY489Jjt27JCaNWum69VUq1YtJ/cPAADA2WDm1ltvNf/qeDM+WjfjGxmYAmAAACJDAXA2BzObNm2y+ZAAACAQNTPZHMxUrlzZ5kMCAAC4GMz4rFu3TrZs2SLHjx8PWv/vf//bif0CskWrFSNtb+PVWv1sb+NfFcJvIyHxdJ3+Sxc9Idax8DPR3fvDU5ITlCtqf+DNbfsXO7IvQHZJTU0wixPb8aKIg5nffvtNbr75Zvnxxx/9tTLKN94MNTMAACCmu2Z369bNzM+kUxkUKFBA/ve//8nixYvNQHoLFy6Mzl4CAOCBAmAnFi+KODOzdOlS+fLLL6VEiRKSK1cus1x++eUyYsQIeeSRR2T16tXR2VMAAHIoCoCzOTOjzUiFCxc2f2tAs23bNn9h8IYNG2zuDgAAQJQzMxdddJGsWbPGNDXpaMCjRo2SfPnyyaRJk+Tss8/m+AMAECEyM9mcmenXr5+kpp7uUTFkyBAz7kyTJk1k3rx58sILL9jcHQAAvCfVSnBsyYpx48ZJlSpVJCkpySQqli9fnuHt9+/fLw8//LCZcDoxMVHOO+88EwfETWamZcuW/r91ssn169fLvn37pFixYsygDQBAnJk5c6b06NFDJk6caAKZsWPHmu96LR0pVapUutvrkCzXXHONuU4nni5fvrxs3rxZihYtKnERzJw4cULy588v33//vWlu8ilevHg09g0AAE9wapJIKwvbGDNmjHTu3Fk6dOhgLmtQ8/HHH8vkyZOld+/e6W6v6zWJsWTJEv/8jJrViZtmJt3pSpUqMZYMAAAx3DX74MGDQcuxY8dCPq5mWVauXCnNmzf3r9NeynpZey+H8uGHH0rDhg1NM1Pp0qVNcmP48OGuxgYR18z07dtXnnzySROVAQCA2FOxYkUpUqSIf9HhU0LZs2ePCUI0KAmkl3fs2BF28FxtXtL7aZ1M//795dlnn5WnnnoqfmpmXnrpJdm4caOUK1fOdMcuWLBg0PWrVq1ycv8AAMjxUiXrxbtpt6O2bt0qycnJ/vVapOsU7QSk9TLaizl37txSt25d+fPPP2X06NEycOBAiYtgplWrVtHZEwAA4Ijk5OSgYCYcHS9OA5KdO3cGrdfLZcqUCXkf7cGkZSd6P58LLrjAZHK02UqHa4n5YMatqAsAgJzKrXFm8uXLZzIrX3zxhT9ZoZkXvdylS5eQ92ncuLFMnz7d3E7ra9TPP/9sghw3Apks1cwAAABnWQ6NMWNlISDSbtmvvPKKvP766/LTTz/Jgw8+KIcPH/b3bmrXrp306dPHf3u9Xutmda5GDWK055MWAGtBsFsizsxoFOabITsUZs0GACB+tG7dWnbv3i0DBgwwTUV16tSR+fPn+4uCt2zZ4s/A+IqLP/nkE+nevbvUqlXLjDOjgU2vXr3iJ5iZPXt2urFndHJJjegGDx7s5L4BAOAJbk9n0KVLl7DNSgsXLky3TrtmL1u2TOzSGhudSeCcc86RPHkiDkn8Ir7nTTfdlG7dbbfdJhdeeKEZRbBTp05Z3hlE361n/X+qMKtm7Q3dxc+r7v3BfnfE40PuCnvdiVx55DOpLXfctEXypp7MYD8kR9i2f7HbuwBkO50kKNWh7cSDI0eOSNeuXU0iRGlzlc7vqOs00xNqsL5sqZm57LLLTMEQAABARrQGRyet1qyPzgflo4P1aWIkUlnP6QQ4evSomWRSoykAABBfzUzZbc6cOSZo0URIYB2utvL8+uuv0Q9m0k4oaVmW/P3331KgQAGZNm1axDsAAAC8Zffu3SEnsdReVBl1MnIsmNHZNANphXPJkiXNTJsa6ERi8eLFZsRAnRdi+/btprg4cFA+DZR0XBvtMqbTjWvf9gkTJsi5554b6W4DABCzUi1xZgRgS+JCvXr1TJdurZFRvgDm1VdfNcXFUQ9m2rdvL07RCKx27drSsWNHueWWW9JdP2rUKNN8pQVCVatWNfM/6LTk69atC2pjAwAgnnmtmWn48OFy3XXXme/zkydPyvPPP2/+1pm4Fy1alD01M5olee2118zgOr42Lg1IdDKrSOgT0SUUzcpoFqhfv37+HlRvvPGG6feubW133HFHVnYdAAC47PLLL5fvv/9eRo4cKTVr1pRPP/1ULrnkEjNTt16OejCzYsUKkx3Jnz+/1K9f36wbM2aMDBs2zL8zTtB+5zp4T+C05BosaXOWPtlwwYxOcx441blOfa6SkvKHbIfT5xH4b06XN8l+B7YzHSuvHVMnaPfrcE7+c53v33A43pnD+eksLx1P/ZGdknI4is1MzmwnXujYMlpG4oQES1+dCDRp0kSqVatmdsA3wI2miO69914zLbjWwWRpRxISgmpmNNWkNTLbtm0z8z34/Oc//zG3Ddd1a9CgQSEH79N5JLRIGQCArI6N0rZtWzlw4ECmJnHMDP3BrT/Uv7r8QSmUx/7M1odOHpMmX09wdB+jQSep1FrZtEXAe/fuNesinU0gS5mZwEDGbCRPHunZs6cp6ImFvus6z0TgiaJDL3fs2DlsZmby5FfM9drFPKe7qfj/H5us+mDfmAyv99oxdcKevq3DXqcZmQU1rpOr1v1X8mQwaF6JYZGPzeBFnJ8cz6yK8Lc/snAstWUlK5NVRhzMaKSn8zScf/75Qeu3bt0qhQsXFqf4ph7XacgDMzN6WeeNCCcxMdEsaaWk6Jdq+MIo/dL1whfviRT740Nm9jh55Zg6IaORfX00kMnodhzryHB+OssbxzN6wUyqJJjFie3EMu3UozS5oD2XChUq5L9OszHaupM2vohKMKMTUumUBc8884w0atTIrPvmm2/kiSeekDZt2ohTtPeSBjQ6qrAveNEsy7fffmtm7AQAIKfQRIUTiR8rxpNHzz33nD8zM3HiRNPc5KMZmSpVqpj1UQ9mNIjRiEqnBNdaGZU3b14TYGhVciQOHTokGzduDCr61erm4sWLS6VKleTRRx+Vp556yowr4+uaXa5cuaCxaAAAQHzQ73l11VVXyfvvvx/x+HSOBTMaOWl/8BEjRviHHNaK5KwU12r9jT4hH1+ti45lM3XqVFOHo2PR3HfffaY7uHbl0mnJGWMGAJCT6IB5zgyalyDxYMGCBY5uL+JgRiuktV1LsyeBfcH37dtnCoEjqZ6+8sorMyyo0gzQkCFDzAIAAOJXjx49ZOjQoVKwYMGgjjqh6JAvUQ1mdHyXG2+8UR566KGg9e+88458+OGHMm/evEg3CQCAp1kOFQBbMVwAvHr1ajlx4oT/73CyZW4mLcANFTFplqVv374R7wAAAF7nhQLgBQFNS643M2kfcF/hbyCNtnJ+t7z4N2vvCLd3ASG8Naty+OOSmEuKXSTyzocVRY6F71o/6vwBto5tz/U05wY6r9htYtfPf71nexsAohDM6BQGkyZNkhdffDFovXalqlu3bqSbAwDA87xQAHxLiAmlw9GeTlENZrSrtM6XtGbNGmnWrJlZp2PBfPfdd2ZuJgAAEHmti5XDa2aKRDgZdVSDGZ0vSSd6HD16tCn61aHBa9WqZWbR1vFgAAAA0poyZYrETDCjdETet956y/m9AQDAg7w4a7brwQwAAHCOF2pmLrnkElOWoqP+XnzxxRl2wV61alVE2yaYAQAAUXfTTTf5J4J2eloighkAAFzmhQLggQMHhvzbCQQzAADAFTpH408//WT+rlGjRpaHeMkV6R06duwof//9d7r1OiGkXgcAALJWAOzEEg/++OMPadKkiRm7rlu3bma59NJLzYTSel3Ug5nXX3895Ei/uu6NN96IeAcAAPA6XzOTE0s8uPfee83MAZqV0YmqddG/U1NTzXVRa2Y6ePCgmeFaF83MJCUl+a/TWbR1gslSpUpFvAMAAMBbFi1aJEuWLJHq1av71+nfOruAZmyiFswULVrUdKPS5bzzzkt3va4fPHhwxDsAAIDXeW2cmYoVK/pn0A6kyZFy5cpFL5jRGS41K3P11VfLrFmzpHjx4v7r8uXLJ5UrV87SDgAA4HVeGGcmkM4i0LVrVxk3bpzUq1fPXwystTPPPPOMRC2Yadq0qfl306ZNJqLKlSvichsAAOBRxYoVCxooTzsONWjQQPLkOR2KnDx50vytnYkiHYcm4q7ZmoFRR44ckS1btsjx48eDrtd5mgAAQOZp65ATLURWDB/0sWPHRm3bEQczu3fvlg4dOsh///vfkNdrexei58ZivWzdf+5fTzu2L3BOhzXDwl6nk7nOkGny0I/PhOxJ6JQTo9rb3kbenq9LTvHzX++5vQtAjtK+vf3PmHAibit69NFHZf/+/fLtt9+aD9n58+eb7to6Y/aHH34Ynb0EACAH0y7VvroZO4sVJ12zA6WkpJge04FL1DMzX375pXzwwQemYEfrZrTZ6ZprrpHk5GQZMWKE3HDDDRHvBAAAXpb6z+LEduKB1sv06tVL3nnnHdm7d6/tVp5cWdkB33gyWsyjzU6qZs2aEc9yCQAAvKdnz54mOTJhwgQz+eSrr75qhnfRXtFZGYA34syMDmqzYcMGqVKlitSuXVtefvll8/fEiROlbNmyEe8AAABeZ2kTkQPdqq046Zo9d+5cE7RceeWVpg5XB8qrVq2aae1566235M4774xuMKN9wLdv3+6f9fLaa681D6xjzUydOjXSzQEA4Hlea2bat2+fnH322eZvLVPRy0rnZnrwwQcj3l7Ewcxdd93l/1tnt9y8ebOsX79eKlWqJCVKlIh4BwAAgLecffbZZtw6jR3OP/98Uzujk05qxkZnHIhUxDUzQ4YMMWPM+BQoUEAuueQSKViwoLkOAABExmuzZnfo0EHWrFlj/u7du7cZCVjnfOzevbs88cQT0c/MaIHOAw88YIKYQBrg6HUDBgyIeCcAAPAyp2a8tuKka7YGLT7Nmzc3M2ZrJyKtm8nK4LsRBzM6P1PgcMQ+GmEFztcEAACQGdqRSJesyhPpnAq+WbMDAxrtD37o0CGTsQEAAJHx2qzZ6osvvpDnnnvOZGXUBRdcYAbm1UxN1IIZnVNBszI6AZQ2JxUpUsR/nfZk0oiqYcOGEe8AAADwlvHjx5ve0bfddpv5Vy1btkyuv/56E+A8/PDD0QlmfHMqVK1aVRo3buyf5RIAANjjtZqZ4cOHm6ClS5cu/nWPPPKIiS/0ukiDmYh7MzVt2tR0x+7Xr5+0adNGdu3aZdbrxJP/+9//It0cAACe57XeTPv37zfj1KXVokULOXDgQMTbiziYWbRokZm6QCeafP/9902tjK8AWAfRAwAAyMi///1vmT17drr1Ovfjv/71L4lUxG1F2h/8qaeekh49ekjhwoX966+++mp56aWXIt4BAAC8zgsFwC+88IL/7xo1asiwYcNk4cKF/npbrZn55ptv5LHHHot+MPPjjz/K9OnT063XySf37NkT8Q4AAOB1XqiZee6559L1kl63bp1ZfHT038mTJ5tSlqgGM/pAOjeTFgIHWr16tZQvXz7SzSFCc/96mmP2jwZFIp+/I61vD0zgeP5jwMTKto/F67X72t5G+zXDbG8DQOzR6QuiJeKamTvuuEN69eolO3bsMGPNpKammrTQ448/Lu3atYvOXgIAkINZDhX/WjHczBSODvuiS7YGM9plSieFqlixoin+1XavK664Qho1ahRxWggAAJye7dqpJV688cYbpkNR/vz5zaLTGLz55ptZ2lbEzUw6QN4rr7xi5mDS+hkNaC6++GI599xzs7QDAADAW8aMGSP9+/c348zo2DLq66+/NjMJaP1t4NxNmZHlke80M6MLAACwx7ISzGKX5cA2ssOLL74oEyZMCCpP0e7aF154oQwaNCjiYCbiZiYAAAA7tCORlqekpev0ukgRzAAA4DKv1cxUq1ZN3nnnnXTrZ86cmaWyFSZYAgDAZV4YNC+QTljdunVrWbx4sb9mRntG60zaoYKcMyEzAwAAstWtt94qy5cvlxIlSsicOXPMon/ruptvvjl7MjNfffWVvPzyy/Lrr7/Ke++9ZwbL0+5UOpDe5ZdfnpVNAgDgWZpQcSKpYknsO3HihNx///2mN9O0adMc2WbEmZlZs2ZJy5YtTZ9wHfX32LFjZr3Ocqlj0AAAgKw0MyU4sEjMy5s3r4klnBRxMKOTTE6cONGMNaM75KNtXqtWrXJ05wAAQM7TqlUr07TklIibmTZs2GBG/E2rSJEisn//fqf2CwAAz/BSM5PSHktDhgwxRb9169aVggULSqBHHnlEohrMlClTRjZu3ChVqlQJWq8j95199tmRbg4AAHjMa6+9ZiauXrlypVkC6byPUQ9mOnfuLN26dTNTdOsDbtu2TZYuXWommtRiHgAAEBmvdc3eFDCDtm+SSY0psq1mpnfv3tK2bVtp1qyZmZdJm5zuvfdeU5nctWvXLO8IAABe5bVB83zZmYsuukiSkpLMon+/+uqrkhURZ2Y0curbt6888cQTprnJN3N2oUKFsrQDAADAWwYMGGAmm9QkSMOGDc06beXROZm2bNli6mmiGsxoF+xTp05J8eLFTRDjs2/fPsmTJ48kJydHukkgS749MIEj56ARv0X24REtXzWObIK5ULYdTQp/Zb7TCemptXuIHA//O7b1qhG29wPILG1p+ae1xRYrTpqZdJJJ7RXdpk2boIkma9WqZQKcSIOZiJuZ7rjjDnn77bfTrdfhh/U6AAAQGUsSJNWBxZL4mDVbB86rV69euvXas+nkyZMRby/iYObbb7+Vq666Kt36K6+80lwHAADiy7hx40wvZa1dadCggZlWIDM0uaHlJzpuTCTuvvtuk51Ja9KkSXLnnXdKpCJuZtIRf0NFTRplHT16NOIdAADA69xsZpo5c6b06NHDDIirgczYsWPNSP86rlypUqXC3u/33383PZmbNGmS5QLgTz/9VC677DJzWRMiWi/Trl07sz8+WlvjeGamfv36JnJKSw+CpocAAED89GYaM2aMGXalQ4cOphZWv88LFChghmAJR2tnNYOis19nZYy5tWvXyiWXXCIlS5Y08zzqohNN6jq9TqdL0uX777+PTmZGpzNo3ry5rFmzxnTPVjpl93fffWciLAAAEB+OHz9uBq3r06ePf12uXLnM97z2LgpHC3Q1a9OpUycz+XSkFixYIE6KOJjROZj0CY4ePdoU/eqEk1p9rOkiHZ4YAAC4O2jewYMHg9YnJiaaJa09e/aYLEvp0qWD1uvl9evXh3wMHfFfv/MzmzXJDhEHM6pOnTry1ltvOb83AADAtooVKwZdHjhwoAwaNMj2dv/++29TvKvdqrVZKK6CGY3wfOPHpI320mKcGQAA3J1ocuvWrUHfx6GyMkoDkty5c8vOnTuD1utlnYsxLa1t0cLfG2+80b8uNfV0pY6ONadFw+ecc47EZDBTrFgx2b59u2kf04mhQs2foHMr6HpNVwEAAPeamZKTkzOVXMiXL5/pvKO1r77u1Rqc6OUuXbqku/35558vP/74Y9C6fv36mYzN888/ny4jFFPBzJdffmlG/I1G0Q4AAHBPjx49pH379mYQO+2xrF2zDx8+bHo3Ke0qXb58eRkxYoR/DqVAmuRQadfHXDDTtGnTkH8DAID4HmemdevWsnv3bjNf0o4dO0xd7Pz58/1FwTr2i/ZwimWZCmZ++OGHTG9QezYBAIDMc2rG69Qs3k+blEI1K6mFCxdmeN+pU6dKXAQzGqVpPYyvLiYj1MwAAIDslKm80aZNm+S3334z/86aNUuqVq0q48eP94/Qp39r9bJeBwAAslYA7MTiRZnKzFSuXNn/9+233y4vvPCCXH/99UFNS1rB3L9//4gnmwIAwOuc7prtNRFX9GiXLM3MpKXr1q1b59R+AQAARGcE4AsuuMB0z3r11VdN/3Tf3A66Tq9Dznd90Z4ZXp83Kbf5t0WRR+VEYuhxh+btHxWVfUP8a/LNc7a3cXLMPWGvO5GQRz4RkX+33il5rZPhN7LK9m4Aro0z4zURBzM6m6aO/FehQgV/zyXt7aSFwXPnzo3GPgIAADgXzOiAOloMrHMz+Sah0j7qbdu2lYIFC0a6OQAAPM+SBLPYZTmwjXiUpYkmNWi57777nN8bAAA8yHKoicgSb8pSMPPLL7+YaQ127drln2DKR0cQzKzFixfL6NGjZeXKlWbup9mzZwf1hrrnnnvk9ddfD7pPy5YtzciEAAAAWQpmdNrvBx980My0qTNqBg6ip39HEszo3A+1a9eWjh07yi233BLyNtdee61MmTLljDN/AgAQrygAzuZg5qmnnpJhw4ZJr169bD60yHXXXWeWjGjwEmoacgAAcgrGmcnmcWb++usvM3BedtE5IUqVKiXVq1c3GaG9e/dm22MDAIAcmJnRQObTTz+VBx54QKJNm5i0+UkH5Pv111/lySefNJmcpUuXSu7cp8cySevYsWNm8Tl48KD5Nykpf8h5pfLnzx/0L87MN45M+OtzBf0bCsc78zhHI6djyYRz8p/rfP+e6bgjY146P3V+wpSUw1HZNs1M9iRY+upEQAfHGzNmjNxwww1Ss2ZNyZs3b9D1jzzySNZ2JCEhXQFwWtolXOeA+vzzz6VZs2YhbzNo0CAZPHhwuvXTp0+XAgUKZGnfAAA4cuSIGYbkwIEDkpyc7MgB0R/cRYoUkR5VnpTEXEm2t3csNUXG/D7c0X3MkcFMqKkM/BtLSDABR7SCGVWyZElTt3P//fdnOjOj80YlJRUMm5mZPPkV6dixsxw9ejRL++41OrJvRjQjc9fYS2Tao6vkREroCek/PTA2SnuX83CORm7f8DvDXqcZmS+qXCPNfv9M8mQwAnDxJ9/KwiN7j5fOT19mJhrBTPcqfRwLZp77fYTngpmIm5l05my3/PHHH6ZmpmzZshkWDIfq8ZSSom+y8IMJ6Zswp78RnRJuioJ0t0tJlRMpoW/LsY4c52jmZThNwT80kMnodpyjkfHG+Rm9UVxoZnJhnBmnHDp0SDZu3BgUKH3//fdSvHhxs2hz0a233mp6M2nNTM+ePaVatWpmrBkAAIBMBzM9evSQoUOHmpF/9e+MaD1NZq1YsUKuuuqqoMdR7du3lwkTJpg5n3TQvP3790u5cuWkRYsWZj8YawYAkJPQNTsbgpnVq1fLiRMn/H+HE6omJSNXXnmlaYMM55NPdG5bAAByNpqZsiGY0akLQv0NAADg6ZoZAACgPaVOL3ZZHp1pkmAGEZu3f9QZu2p2kGmm+3XO792Qc0yp3df2NjqsGSaxIE+PqRmenzNmXGe6Xmd0fn53RdbGzAp06eIXbG8D3qCDWKQ6tB0ving6AwAAgFhCZgYAAJdRAGwPmRkAABDXyMwAAOA2hwqAhQJgAADgBgqA7aGZCQAAxDWamQAAcBnjzNhDMAMAgMtoZrKHZiYAABDXyMwAAOAynXQ5o4mXI9mOF5GZAQAAcY3MDAAALmMEYHsIZgAAcJk2DjFmXtbRzAQAAOIamRkAAFxGM5M9BDMAALiMYMYeghm44taz+tjexqy9IxzZF5zWYc0wDkWASxe/YPt4HB9yl+1t5BswzfY2gJyOYAYAgJgoAHZgnBnxJoIZAABcRjOTPfRmAgAAcY3MDAAALmPWbHvIzAAAgLhGZgYAAJdp8W+qIwXAlngRwQwAAC6jmckempkAAEBcIzMDAIDLUv9ZnNiOFxHMAADgMsuyzOLEdryIZiYAABDXyMwAAOAyRgC2h2AGAACXpTrUNTvVo12zaWYCAABxjcwMAACxMGu2A0kVS7yJzAwAAIhrZGbgill7R3DkEVKr4r1tH5k5+0bGxNHNN2Ca7W3Mq9/T9jYmbcyVI45nTkbNjD0EMwAAxMJ0Bg5tx4toZgIAAHGNzAwAAC6jmckeghkAAFyWajk0zozlzXYmmpkAAEBcIzMDAIDLrH/+c2I7XkRmBgAAxDUyMwAAuEzzKakObceLCGYAAHAZvZnsoZkJAADENTIzAAC4zLIcKgC2vNnQRDADAIDLaGayh2YmAAAQ18jMAADgMjIz9pCZAQDAZacnM3BmyYpx48ZJlSpVJCkpSRo0aCDLly8Pe9tXXnlFmjRpIsWKFTNL8+bNM7x9diCYAQDAw2bOnCk9evSQgQMHyqpVq6R27drSsmVL2bVrV8jbL1y4UNq0aSMLFiyQpUuXSsWKFaVFixby559/ils808zUIPk+yZOQmG59vqTc5t/Lku+T4/lOhb3/Nwdeiur+AThtzr6Rtg/FMxf0D3tdQuLp33BPVe8p1rHwv2If/2loTLwk1y8fFdXjkRlz9tneBcRwM9OYMWOkc+fO0qFDB3N54sSJ8vHHH8vkyZOld+/e6W7/1ltvBV1+9dVXZdasWfLFF19Iu3btxA1kZgAA8Kjjx4/LypUrTVORT65cucxlzbpkxpEjR+TEiRNSvHhxcYtnMjMAAHglM3Pw4MGg9YmJiWZJa8+ePXLq1CkpXbp00Hq9vH79+kw9Zq9evaRcuXJBAVF2IzMDAIDLUh38T2kdS5EiRfzLiBEjJBpGjhwpb7/9tsyePdsUD7uFzAwAADnM1q1bJTk52X85VFZGlShRQnLnzi07d+4MWq+Xy5Qpk+FjPPPMMyaY+fzzz6VWrVriJjIzAAC4zEqwxEpIdWCxzPY0kAlcwgUz+fLlk7p165riXZ/U1FRzuWHDhmH3d9SoUTJ06FCZP3++1KtXT9xGZgYAAJdZDtXMWFnYhnbLbt++vQlK6tevL2PHjpXDhw/7ezdpD6Xy5cv7m6qefvppGTBggEyfPt2MTbNjxw6zvlChQmZxA8EMAAAe1rp1a9m9e7cJUDQwqVOnjsm4+IqCt2zZYno4+UyYMMH0grrtttuCtqPj1AwaNEjcQDADAIDLtHA3IYuj9wbyFQBHqkuXLmYJN0heoN9//11iDcEMAAAuszMVQSAnthGPKAAGAABxjcwMAAAuS01IlYQE95qZ4h2ZGQAAENfIzAAA4PEC4HhHMAMAgMsIZuyhmQkAAMQ1z2Rmvj04SUQS0q3Pfzy/dJMrZNnBSXL06FFX9g2Asx7/aWjY6/Lnzy8zZJr02zAq6u/5hyv0t72NcX+Efy5OHI/MeK5G+OeRkHj6N/GI83uKdSx8E8e3u+03f7y9e5jkVHTNtsczwQwAALEqVU5JgpxyZDteRDMTAACIa2RmAABwmU4Q6cwIwJZ4kauZGZ2B89JLL5XChQtLqVKlpFWrVrJhw4ag26SkpMjDDz8sZ511lpmN89Zbb5WdO3e6ts8AACC2uBrMLFq0yAQqy5Ytk88++0xOnDghLVq0MFOP+3Tv3l3mzp0r7777rrn9tm3b5JZbbnFztwEAcHwEYKcWL3K1mUmnGA80depUk6FZuXKlXHHFFXLgwAF57bXXZPr06XL11Veb20yZMkUuuOACEwBddtllLu05AABOFwDbzy+kUgDsPg1eVPHixc2/GtRotqZ58+b+25x//vlSqVIlWbp0qWv7CQAAYkfMFACnpqbKo48+Ko0bN5aLLrrIrNuxY4fky5dPihYtGnTb0qVLm+tCOXbsmFl8Dh48aP5NSsovCQkhxpnJnz/oX9jHMXUWxzN+j2fuJPu/tGPhs8k3lkzI6/LlCvo3nDxJEvfHwrIsSUn5/zIIZ6U6UgAsTGfgLq2dWbt2rXz99de2i4oHDx6cbv3kya9IgQIFwt5Pr4ezOKYcz1gWL+fn1TJN4kHlPqd/hIZTxYHHuM3lY3HkyBFp27ZtVLadaun4MLkc2o73xERmpkuXLvLRRx/J4sWLpUKFCv71ZcqUkePHj8v+/fuDsjPam0mvC6VPnz7So0ePoMxMxYoVpWPHzmEzM/qhptczArAzOKbO4njG7/HsXL6n7W288ucocZuO7huOZmQ0kNk8Yq1Yx8NnFlbssZ91mLXnGXE7M4PYlMftE6Nr164ye/ZsWbhwoVStWjXo+rp160revHnliy++MF2ylXbd3rJlizRs2DDkNhMTE82SVkqKfmilD2Z89EONYMZZHFOOp9fPz1Mp9r/AY+FzKaNpCvy3OZ6a4e1O5ohjEb1ghukM4jiY0aYl7an0wQcfmLFmfHUwRYoUMb+e9N9OnTqZTIsWBScnJ5vgRwMZejIBAHIKS06J5UAzk+XR3kyuBjMTJkww/1555ZVB67X79T333GP+fu655yRXrlwmM6OFvS1btpTx48e7sr8AACD2uN7MdCZJSUkybtw4swAAkBOlml5IqQ5tx3uYaBIAAMS1mOjNBACAlzHRpD0EMwAc06p4b9vbmLNvpMSCXlUH2N7G05uGSE7Qfd3QsNdpZ40ZMk36rB+VYW+jZy7ob3s/3t4tOZZlaQFwgiPb8SKamQAAQFwjMwMAgMsoALaHYAYAgJgYZ8aBZiahmQkAACDukJkBAMBlluXMrNmW5c1xZghmAABwGTUz9tCbCQAAxDUyMwAAuIxxZuwhMwMAAOIamRkAAFzGdAb2EMwAABATvZmcmM4gVbyIZiYAABDXyMwAAOA6HQHYme14EcEMAAAuO908RDNTVtHMBAAA4hqZGQAAXEZmxh6CGXjakHMH2N7GgF+GOLIvOcGcfSMlp3h6E6+rT4WizcIep6SkvObf8kWaSkriibC3e/ynobZfk1bFe4ubTljH5OO/nnF1HxAawQwAADEwN1OCEzUz4s2u2QQzAAC4jGYmeygABgAAcY3MDAAAMTDRZCxtJ94QzAAAEANzM2nljDPb8R6amQAAQFwjMwMAgMucmiDS8uhEkwQzAAC4jGDGHpqZAABAXCMzAwCAy5wa7M7y6KB5ZGYAAEBcIzMDAIDLqJmxh2AGAACXEczYQzMTAACIa2RmAABwnVOFu6niRQQzAAC4jGYmewhm4GkDfhni9i4gB5tXv6ftbVy/fJS47Y/9X4S9Ln/+/CLSWf48sEiOHj0a1f2Ys2+kq6/JkVOp8vFK27uAKCCYAQDAZYwzYw8FwAAAIK6RmQEAwGWWZTlSvGuZ7XgPwQwAAK47JSIJDmzHEi+imQkAAMQ1MjMAAMRE12z7mRmLZiYAAOAOZ4IZoZkJAAAg/tDMBACA2xxqZhKamQAAgBssh5qHLJqZAAAA4g9dswEAcF2qg0vkxo0bJ1WqVJGkpCRp0KCBLF++PMPbv/vuu3L++eeb29esWVPmzZsnbiKYAQDAw2bOnCk9evSQgQMHyqpVq6R27drSsmVL2bVrV8jbL1myRNq0aSOdOnWS1atXS6tWrcyydu1acQvBDAAArrNOF+/aXSTy2psxY8ZI586dpUOHDlKjRg2ZOHGiFChQQCZPnhzy9s8//7xce+218sQTT8gFF1wgQ4cOlUsuuUReeuklcQvBDAAArrMc+U8iDGaOHz8uK1eulObNm/vX5cqVy1xeunRpyPvo+sDbK83khLt9dsjxXbP/fzREK+z1R44c+ed23pzTwmkcU45nLMvO8/PIqWMObCW2P5fi7f1u5zXx3Td6o+w6t92DBw8GXU5MTDRLWnv27JFTp05J6dKlg9br5fXr14fc9o4dO0LeXte7xsrhtm7d6nuHsXAMOAc4BzgHOAdsnwP6veKUo0ePWmXKlHH0vCxUqFC6dQMHDgz5+H/++ae5fsmSJUHrn3jiCat+/foh75M3b15r+vTpQevGjRtnlSpVynJLjs/MlCtXTrZu3SqFCxeWhISEkNFrxYoVzW2Sk5Nd2cechmPK8YxlnJ8cz6zSjMzff/9tvlecor2BNm3aZJp7nNzPhDTfd6GyMqpEiRKSO3du2blzZ9B6vVymTJmQ99H1kdw+O+T4YEbb/ipUqHDG22kgQzDjLI4pxzOWcX5yPLOiSJEiDh+50wGNLm7Ily+f1K1bV7744gvTI0mlpqaay126dAl5n4YNG5rrH330Uf+6zz77zKx3S44PZgAAQHjaLbt9+/ZSr149qV+/vowdO1YOHz5sejepdu3aSfny5WXEiBHmcrdu3aRp06by7LPPyg033CBvv/22rFixQiZNmiRuIZgBAMDDWrduLbt375YBAwaYIt46derI/Pnz/UW+W7ZsMa0cPo0aNZLp06dLv3795Mknn5Rzzz1X5syZIxdddJFrz8HzwYy2I+pAQeHaExE5jqmzOJ4cz1jG+ZkzdOnSJWyz0sKFC9Otu/32280SKxK0CtjtnQAAAMgqBs0DAABxjWAGAADENYIZAAAQ1zwfzEQ67TlCGzRokBmkKXDR6eGReYsXL5Ybb7zRDMilx097BwTS8jbtbVC2bFnJnz+/mRvll19+4RBn8Xjec8896c5ZnTwPoWm33EsvvdQMQFqqVCkzJsmGDRuCbpOSkiIPP/ywnHXWWVKoUCG59dZb0w2uBkSDp4OZSKc9R8YuvPBC2b59u3/5+uuvOWQR0HEd9BzUADuUUaNGyQsvvGBmtP3222+lYMGC5nzVLxBEfjyVBi+B5+yMGTM4lGEsWrTIBCrLli0zA6SdOHFCWrRoYY6zT/fu3WXu3Lny7rvvmttv27ZNbrnlFo4pos/yMJ134uGHH/ZfPnXqlFWuXDlrxIgRru5XPNJ5P2rXru32buQY+tacPXu2/3JqaqqZv2X06NH+dfv377cSExOtGTNmuLSX8Xs8Vfv27a2bbrrJtX2Kd7t27TLHddGiRf7zUefseffdd/23+emnn8xtli5d6uKewgs8m5nJyrTnyJg2eWhK/+yzz5Y777zTDLQEZ+jcLTqYVeD5qsOqa9Mo52vW6fgZ2mRSvXp1efDBB2Xv3r2OvF5ecODAAfNv8eLFzb/6earZmsBzVJuaK1WqxDmKqPNsMJPRtOeuTmMep/RLderUqWbUyAkTJpgv3yZNmphJ2WCf75zkfHWONjG98cYbZo6Zp59+2jSLXHfddeZzARnTuXt0Xp7GjRv7R33Vc1Tn+SlatGjQbflMRXbw/AjAcIZ+CfjUqlXLBDeVK1eWd955Rzp16sRhRsy54447/H/XrFnTnLfnnHOOydY0a9bM1X2LdVo7s3btWuriEDM8m5nJyrTnyDz9dXbeeefJxo0bOWwO8J2TnK/Ro82j+rnAOZsxHfL+o48+kgULFkiFChWCzlFtvt+/f3/Q7flMRXbwbDATOO25j2/aczenMc8pDh06JL/++qvpRgz7qlatar4sAs/XgwcPml5NnK/O+OOPP0zNDOdsaFpHrYHM7Nmz5csvvzTnZCD9PM2bN2/QOapdt7V2jnMU0ebpZqYzTXuOzHv88cfNmB7atKTdMbW7u2a+2rRpw2GMIAAMzApo3dH3339vCiy1iFJrFJ566ikzQ61+kfTv398UXOt4H4jseOoyePBgMw6KBokaePfs2VOqVatmursjdNOSzpT8wQcfmLFmfHVcWoiu4x7pv9qkrJ+renyTk5Ola9euJpC57LLLOKSILsvjXnzxRatSpUpWvnz5TFftZcuWub1Lcal169ZW2bJlzXEsX768ubxx40a3dyuuLFiwwHRjTbtoF2Jf9+z+/ftbpUuXNl2ymzVrZm3YsMHt3Y7L43nkyBGrRYsWVsmSJU134sqVK1udO3e2duzY4fZux6xQx1KXKVOm+G9z9OhR66GHHrKKFStmFShQwLr55put7du3u7rf8AZmzQYAAHHNszUzAAAgZyCYAQAAcY1gBgAAxDWCGQAAENcIZgAAQFwjmAEAAHGNYAYAAMQ1ghkAABDXCGaAf1x55ZVmygA7fv/9d0lISDDD5iudgVkvp518D/9v0KBBUqdOHQ4JgCwjmAH+8f7778vQoUMdPR6NGjWS7du3m3lr3DJ16lQzi3mksisQ03m9AicnzC763ObMmZPtjwvAeZ6eaBIIpJPjRWN2dp3IEOEVKlTILACQVWRmgDDNTFWqVJHhw4dLx44dzSzBOnP1pEmTgo7X8uXL5eKLL5akpCQz+/rq1avPmN345ptvzGMVKFBAihUrZmZp/uuvv8x1qampMmLECDMrts5EXLt2bXnvvfcyfI2OHTtmshvly5eXggULSoMGDczj+h5fZ4E/cOCA2Q9dtFlHvfnmm2af9blpwNW2bVvZtWuXv7nsqquuMn/rPur97rnnnpCPv3nzZjNjut5OH//CCy+UefPmhc0KaTZEtxeqmenTTz81xzJtNqhbt25y9dVXm7/37t1rZmPX56vHsGbNmjJjxoyg2+vxfeSRR8xM2Bqk6vPzPW/fa6tuvvlmsy++ywDiE8EMkIFnn33WH6Q89NBD8uCDD8qGDRvMdYcOHZJ//etfUqNGDVm5cqX5stSgIiNaS9OsWTNzn6VLl8rXX39tAoFTp06Z6zWQeeONN2TixInyv//9T7p37y533XWXLFq0KOw2u3TpYrb19ttvyw8//CC33367XHvttfLLL7+YZq6xY8dKcnKyae7SxbePJ06cMM1qa9asMQGGBjC+gKVixYoya9Ys87c+X73f888/H/LxH374YRNQLV68WH788Ud5+umns5xp0WOjwY/vsZUem5kzZ8qdd95pLqekpEjdunXl448/lrVr18p9990nd999twksA73++usmuPr2229l1KhRMmTIEPnss8/Mdd999535d8qUKea5+S4DiFNuT9sNxIqmTZta3bp181+uXLmyddddd/kvp6amWqVKlbImTJhgLr/88svWWWedZR09etR/G71O31arV682lxcsWGAu//XXX+ZymzZtrMaNG4d8/JSUFKtAgQLWkiVLgtZ36tTJ3C+UzZs3W7lz57b+/PPPoPXNmjWz+vTpY/6eMmWKVaRIkTM+/++++87s699//x1y38OpWbOmNWjQoJDXhXrs2bNnm+36DBw40Kpdu7b/sr4GV199tf/yJ598YiUmJma4HzfccIP12GOPBb2Wl19+edBtLr30UqtXr17+y7oPui8A4h81M0AGatWq5f9bmyO0ucLXFPPTTz+Z67VZxKdhw4ZnzMxo5iSUjRs3ypEjR+Saa64JWn/8+HHTlBWKZkI0c3HeeecFrddMyVlnnZXhvviySZqZ0WYubeJSW7ZsMZmjzNLmHM1YaRNR8+bN5dZbbw06bpHSDMxll10m27Ztk3Llyslbb70lN9xwg7+5Sp+vNv+988478ueff5rjo89Xm5wCpd2HsmXL+l87ADkLwQyQgbx58wZd1oDG96WfFVoHE442WyltPtF6kECJiYlh75M7d24TmOi/gTJq6jl8+LCp1dFFg4WSJUuaIEYva3AQiXvvvdfcT/dbAxptKtPmua5du0quXLk0BRN0e23eysill14q55xzjmk20yBp9uzZpvbGZ/To0abJS5vPtF5Gm5K01intfjv92gGIXQQzQBZdcMEFpohWazh82Zlly5ZleB/NFmg35MGDB6e7TrMhGrRoUNG0adNM7YNmbDRToRmHJk2ahO1R5avJ8Vm/fr0ppB05cqSpj1ErVqxIdz+V9r6h6DYeeOABs/Tp00deeeUVE8xokPT333+b4EmDDuUbg+dM2RkNsipUqGACIs3MBBZQ33TTTaaWSGmA8vPPP0eUTfIFO5l5bgBiHwXAQBZp7x/9td+5c2dZt26d6cHzzDPPZHgf/aLXYlMtJtZiXQ0qJkyYIHv27DG9irQ4V4t+tXj1119/lVWrVsmLL75oLoeizUv6xd+uXTszTs6mTZtMIaxmRzRTorSnjmZwNIjSx9GmLO2ZpcGKbvu3336TDz/8MN0YO5UrVzbP76OPPpLdu3f7M0dpaVbkk08+MY+t+7tgwQIT6CntWaXNP08++aR5PtOnTw/KsoSjz0m3NWzYMLntttuCMlPnnnuuKeRdsmSJaeq7//77ZefOnRIpPS56THbs2OHvTQYgPhHMAFmkzThz5841dSuaIenbt6/pyZMRDT60KUbrVOrXr29qbD744APJk+d0klQDiv79+5tgRAMC7ZWkQYl21Q5He+RoMPPYY49J9erVpVWrViZg0oBFaY8mzZi0bt3aZEq0Z4/+q0HFu+++azIamqFJG4hpU5dmkHr37i2lS5c2vaZC0eyG9mjy7a8+x/Hjx5vrtFv0tGnTTKDn60Id2EU6nGrVqpnjowGfrxeTT79+/eSSSy4xTVvaBVvrmPQ5R0qbwjQo0qxSuJokAPEhQauA3d4JAACArCIzAwAA4hrBDAAAiGsEMwAAIK4RzAAAgLhGMAMAAOIawQwAAIhrBDMAACCuEcwAAIC4RjADAADiGsEMAACIawQzAAAgrhHMAAAAiWf/B1QCi7lKlJLeAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 600x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Visualisation de la chaine de Markov micro (24 x 24)\n",
+    "fig, ax = plt.subplots(figsize=(6, 5))\n",
+    "im = ax.imshow(tpm_micro, cmap=\"magma\", vmin=0, vmax=1)\n",
+    "ax.set_title(\"TPM micro : P(etat suivant | etat courant)\")\n",
+    "ax.set_xlabel(\"indice etat suivant\"); ax.set_ylabel(\"indice etat courant\")\n",
+    "fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label=\"probabilite\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-tpm-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005093,
+     "end_time": "2026-06-29T10:57:59.649163+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.644070+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "La matrice est **creuse et directionnelle** : depuis un etat donne, le tri ne peut qu'**enlever** une\n",
+    "inversion (jamais en ajouter), donc chaque ligne ne charge que quelques etats « plus tries ». L'etat\n",
+    "parfaitement trie est **absorbant** (auto-transition de probabilite 1, `unseen=\"self\"`) : c'est le point\n",
+    "fixe de la morphogenese. Cette structure de flot vers un attracteur unique est typique des dynamiques\n",
+    "de developpement — et c'est sur elle qu'on va lire l'emergence causale."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-micro-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004999,
+     "end_time": "2026-06-29T10:57:59.658180+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.653181+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Le profil causal micro\n",
+    "\n",
+    "Sous une **intervention uniforme** sur les etats (le `do` de Hoel : on force le systeme dans chaque\n",
+    "etat avec la meme probabilite et on regarde l'effet), on calcule :\n",
+    "\n",
+    "- **determinisme** $= 1 - \\langle H(E\\mid c)\\rangle / \\log_2 n$ — a quel point chaque etat-cause\n",
+    "  determine son effet (1 = transitions certaines) ;\n",
+    "- **degenerescence** $= 1 - H(E\\mid C) / \\log_2 n$ — a quel point des causes differentes convergent\n",
+    "  vers les memes effets ;\n",
+    "- **specificite** $= 1 - \\text{degenerescence}$ ;\n",
+    "- **effectiveness** $= \\text{determinisme} - \\text{degenerescence}$ — grandeur causale *scale-free*\n",
+    "  dans $[0, 1]$ ;\n",
+    "- **information effective** $\\text{EI} = \\text{effectiveness} \\times \\log_2 n$ (en bits)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ict6-micro-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:57:59.667729Z",
+     "iopub.status.busy": "2026-06-29T10:57:59.667729Z",
+     "iopub.status.idle": "2026-06-29T10:57:59.674038Z",
+     "shell.execute_reply": "2026-06-29T10:57:59.672755Z"
+    },
+    "papermill": {
+     "duration": 0.011999,
+     "end_time": "2026-06-29T10:57:59.674038+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.662039+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Profil causal MICRO (24 etats)\n",
+      "----------------------------------\n",
+      "  determinism            : 0.7472\n",
+      "  degeneracy             : 0.0302\n",
+      "  specificity            : 0.9698\n",
+      "  effectiveness          : 0.7170\n",
+      "  effective_information  : 3.2876\n"
+     ]
+    }
+   ],
+   "source": [
+    "prof = CE.causal_profile(tpm_micro)\n",
+    "print(\"Profil causal MICRO (24 etats)\")\n",
+    "print(\"-\" * 34)\n",
+    "for k in (\"determinism\", \"degeneracy\", \"specificity\", \"effectiveness\", \"effective_information\"):\n",
+    "    print(f\"  {k:22s} : {float(prof[k]):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-micro-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005085,
+     "end_time": "2026-06-29T10:57:59.684220+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.679135+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Le micro-niveau est **assez deterministe** (le tri ne disperse pas beaucoup : depuis un etat, peu\n",
+    "d'etats suivants sont possibles) et **tres specifique** (peu de degenerescence : les effets renseignent\n",
+    "bien sur la cause). L'effectiveness micro sert de **reference** : la question de l'emergence est de\n",
+    "savoir si une description plus *grossiere* (macro) fait **plus** de travail causal que celle-ci."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-naive-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005182,
+     "end_time": "2026-06-29T10:57:59.693387+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.688205+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Un macro « intuitif » ne suffit pas\n",
+    "\n",
+    "Quel macro-etat choisir ? L'intuition souffle : le **niveau de tri** (le nombre d'inversions, de 0 a\n",
+    "$\\binom{n}{2} = 6$ pour $n = 4$). Regroupons toutes les permutations de meme nombre d'inversions en un\n",
+    "seul macro-etat et estimons la chaine de Markov **a ce niveau**.\n",
+    "\n",
+    "> On re-etiquette chaque etat de trajectoire par son nombre d'inversions, puis on reestime la TPM :\n",
+    "> meme pont (`tpm_estimation`), mais sur des etats macro."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ict6-naive-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:57:59.704394Z",
+     "iopub.status.busy": "2026-06-29T10:57:59.704394Z",
+     "iopub.status.idle": "2026-06-29T10:57:59.714583Z",
+     "shell.execute_reply": "2026-06-29T10:57:59.713567Z"
+    },
+    "papermill": {
+     "duration": 0.016731,
+     "end_time": "2026-06-29T10:57:59.714583+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.697852+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "effectiveness MICRO (24 etats)            : 0.7170\n",
+      "effectiveness MACRO 'niveau de tri' (7 etats) : 0.6825\n",
+      "gain du macro intuitif                    : -0.0345\n",
+      "\n",
+      "emergence causale obtenue par ce macro ? NON\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Macro intuitif : regrouper les etats par niveau d'inversions (sortedness level)\n",
+    "trajs_lvl = [[sm.inversion_count(list(s)) for s in traj] for traj in trajs]\n",
+    "tpm_lvl, lvl_map = TE.tpm_from_trajectories(trajs_lvl, unseen=\"self\")\n",
+    "\n",
+    "eff_micro = CE.effectiveness(tpm_micro)\n",
+    "eff_lvl = CE.effectiveness(tpm_lvl)\n",
+    "\n",
+    "print(f\"effectiveness MICRO (24 etats)            : {eff_micro:.4f}\")\n",
+    "print(f\"effectiveness MACRO 'niveau de tri' ({tpm_lvl.shape[0]} etats) : {eff_lvl:.4f}\")\n",
+    "print(f\"gain du macro intuitif                    : {eff_lvl - eff_micro:+.4f}\")\n",
+    "print(\"\\nemergence causale obtenue par ce macro ?\", \"OUI\" if eff_lvl > eff_micro else \"NON\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-naive-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003521,
+     "end_time": "2026-06-29T10:57:59.723823+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.720302+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Le macro intuitif ECHOUE** : regrouper par niveau de tri *baisse* l'effectiveness. La raison est\n",
+    "instructive — en oubliant *quelle* inversion subsiste, on rend les transitions **plus floues** (un meme\n",
+    "niveau de tri peut descendre vers plusieurs niveaux selon la permutation exacte). C'est exactement la\n",
+    "lecon d'honnetete d'[ICT-5](ICT-5-CausalEmergence.ipynb) : **l'emergence n'est pas automatique**, et un\n",
+    "coarse-graining « evident » peut tout aussi bien *detruire* de l'information causale. Il faut une methode\n",
+    "qui **cherche** la bonne echelle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-greedy-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005119,
+     "end_time": "2026-06-29T10:57:59.734340+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.729221+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Apportionnement glouton — trouver l'echelle emergente\n",
+    "\n",
+    "CE 2.0 ne se contente pas d'une echelle : il construit un **chemin d'echelles** micro -> macro. A chaque\n",
+    "pas, `greedy_apportionment` essaie toutes les fusions de paires d'etats et retient celle qui **maximise**\n",
+    "l'effectiveness a l'echelle plus grossiere. La construction de macro-etat sous intervention uniforme\n",
+    "(`merge_states`) somme les colonnes (arriver dans l'un *ou* l'autre) et moyenne les lignes (intervenir\n",
+    "sur le macro tire uniformement parmi ses micro-constituants).\n",
+    "\n",
+    "> **Pourquoi l'effectiveness et pas l'EI en bits ?** L'EI $= \\text{eff} \\times \\log_2 n$ est *penalisee*\n",
+    "> par le retrecissement de $\\log_2 n$ au coarse-graining : elle baisse mecaniquement meme quand la\n",
+    "> structure causale s'ameliore. L'**effectiveness**, scale-free, est la grandeur que l'article apportionne\n",
+    "> le long du chemin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ict6-greedy-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:57:59.746421Z",
+     "iopub.status.busy": "2026-06-29T10:57:59.745365Z",
+     "iopub.status.idle": "2026-06-29T10:58:00.330935Z",
+     "shell.execute_reply": "2026-06-29T10:58:00.329335Z"
+    },
+    "papermill": {
+     "duration": 0.592941,
+     "end_time": "2026-06-29T10:58:00.330935+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:57:59.737994+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chemin d'echelles (micro -> macro) :\n",
+      " taille  effectiveness   EI (bits)  determinisme   delta_cp\n",
+      "------------------------------------------------------------\n",
+      "     24         0.7170      3.2876        0.7472           \n",
+      "     23         0.7217      3.2649        0.7501    +0.0047\n",
+      "     22         0.7253      3.2345        0.7518    +0.0036\n",
+      "     21         0.7289      3.2015        0.7548    +0.0036\n",
+      "     20         0.7313      3.1605        0.7568    +0.0024\n",
+      "     19         0.7341      3.1183        0.7578    +0.0028\n",
+      "     18         0.7357      3.0679        0.7573    +0.0016\n",
+      "     17         0.7382      3.0172        0.7571    +0.0024\n",
+      "     16         0.7404      2.9615        0.7573    +0.0022\n",
+      "     15         0.7420      2.8988        0.7590    +0.0016\n",
+      "     14         0.7456      2.8386        0.7629    +0.0036\n",
+      "     13         0.7484      2.7694        0.7629    +0.0028\n",
+      "     12         0.7500      2.6887        0.7641    +0.0016\n",
+      "     11         0.7525      2.6031        0.7637    +0.0025\n",
+      "     10         0.7535      2.5030        0.7636    +0.0010\n",
+      "      9         0.7547      2.3923        0.7668    +0.0012\n",
+      "      8         0.7582      2.2746        0.7698    +0.0035\n",
+      "      7         0.7638      2.1442        0.7761    +0.0056\n",
+      "      6         0.7734      1.9991        0.7850    +0.0096\n",
+      "      5         0.7933      1.8420        0.8024    +0.0199\n",
+      "      4         0.8152      1.6305        0.8194    +0.0219\n",
+      "      3         0.8256      1.3085        0.8296    +0.0103\n",
+      "\n",
+      "effectiveness : micro = 0.7170  ->  macro le plus grossier = 0.8256\n",
+      "emergence causale (macro > micro) ? OUI  (+0.1085)\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = CE.greedy_apportionment(tpm_micro)  # primitive par defaut = effectiveness\n",
+    "\n",
+    "print(\"Chemin d'echelles (micro -> macro) :\")\n",
+    "print(f\"{'taille':>7} {'effectiveness':>14} {'EI (bits)':>11} {'determinisme':>13} {'delta_cp':>10}\")\n",
+    "print(\"-\" * 60)\n",
+    "for s in res[\"scales\"]:\n",
+    "    d = \"\" if s[\"delta_cp\"] is None else f\"{s['delta_cp']:+.4f}\"\n",
+    "    print(f\"{s['size']:>7} {s['effectiveness']:>14.4f} {s['effective_information']:>11.4f}\"\n",
+    "          f\" {s['determinism']:>13.4f} {d:>10}\")\n",
+    "\n",
+    "eff_vals = [s[\"effectiveness\"] for s in res[\"scales\"]]\n",
+    "print(f\"\\neffectiveness : micro = {eff_vals[0]:.4f}  ->  macro le plus grossier = {eff_vals[-1]:.4f}\")\n",
+    "print(f\"emergence causale (macro > micro) ? {'OUI' if max(eff_vals) > eff_vals[0] else 'NON'}\"\n",
+    "      f\"  (+{max(eff_vals) - eff_vals[0]:.4f})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ict6-greedy-plot",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:58:00.353824Z",
+     "iopub.status.busy": "2026-06-29T10:58:00.352822Z",
+     "iopub.status.idle": "2026-06-29T10:58:00.540039Z",
+     "shell.execute_reply": "2026-06-29T10:58:00.540039Z"
+    },
+    "papermill": {
+     "duration": 0.19975,
+     "end_time": "2026-06-29T10:58:00.541315+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.341565+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEEAAAFyCAYAAAAat8RwAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAs/dJREFUeJzs3Qd4U9UbBvC3i5bVsvcGAcvegoCobARxsBwMcYsLJw4Q9xbXHzeKiAwVFQdTWbJkqey9yx4FSqG0+T/vCbckadKmpW2S5v09TyC5ubm5uSfNvfe753xfiM1ms0FEREREREREJI8L9fUKiIiIiIiIiIjkBgVBRERERERERCQoKAgiIiIiIiIiIkFBQRARERERERERCQoKgoiIiIiIiIhIUFAQRERERERERESCgoIgIiIiIiIiIhIUFAQRERERERERkaCgIIiIiIiIiIiIBAUFQcQ4efIkbr/9dpQpUwYhISF46KGHzPT9+/fjxhtvRPHixc30UaNG5doW+/LLL817bt++Xa0UgNh2Q4YMybbl8XvAZfJ7YXnuuefMtOz2+uuvo3bt2khJScn2ZUv2/73PmTPHvJb/B7onn3wSLVq08PVqiOTpY5u8IKf2f9ntjTfeQLVq1RAWFoaGDRuaaefOncPjjz+OihUrIjQ0FD179sy19XF3LBHounbtijvuuCPN/nTZsmUZvrZdu3bmlh2SkpJMm/7vf/9DXhTIx7WSloIgeZj1I+jptnjx4tR5X375ZTP/Pffcg6+//hq33nqrmf7www9j+vTpGDZsmJneuXPnbF9PvvePP/6Y7csVyYr4+Hi89tpreOKJJ8zBmUhu4knaP//8g59//lkbXoJeZk7m3PF0bBMoEhISzElRoAZ4Z8yYYYIdl19+OcaMGWPag7744gsTHOFFtq+++soca2a38ePH5+qFO29PeD3dXn311dR5GZSoW7euV8v966+/zHbmMUt22Lt3r/nOrVq1KtOvjYiIwNChQ/HSSy8hMTExW9ZHJKeE59iSxW88//zzqFq1aprpNWrUSL3/xx9/4LLLLsOIESOc5uH0a6+9Fo8++miOrR93itwRul4J4MFK3759ERkZmWPvLeKKB2e8StWvXz9tnFx0MX/vbdu2xenTp5EvXz4EOl6x5m/um2++iR49evh6dUQCmqdjm0AKgowcOdLcd71a/8wzz5ieY/6+/Xkx4fPPP3f6feb08uXL45133smx92YQZPXq1Wl6/1SuXNnsL3jC7gs8tmDPDVeNGjXK0vIYTLr66qudjukzgwEU1yAIv3NVqlRJ7bmTGYMGDTLfS27/2267LUvrJJIbFAQJAl26dEHTpk3TnefAgQOIjY11O71IkSLwBXad5E0kN/FqFU8+o6Ki/PaguECBAvB3p06dQsGCBXPl750H2f7WXrt37zafv2jRopl+be/evdGrVy9s3brVdCMXkazxdGyTVQyQc5ikPwRcw8PDzc3ft3/+/PnTbC9fHluy14Uv9xeNGzfGLbfcki3L4nb89ddf8dFHH2V5Gdn9XWa7duzY0fTAUhBE/Jn6egc5ayz9tm3bzA+p1S3P6oJqs9nw4Ycfpk63HDt2zETXOfaPV24ZgeYQAtccCnz87rvvol69emanU7JkSTOkxuraymXyZIndIa33GDhwoNscAddcc43HE4KWLVumCfSMGzcOTZo0MTvgYsWKmavMu3btcprH6nK4du1aXHnllebkklcnmBPC1ZkzZ8zVJH5WfmZ+dnbz5HRHM2fOROvWrc2OoFChQqhVqxaeeuopp3nef/991KlTx7wfT5K47oyae8LcLDzYsa4IOdqwYYPZTh988EHqmEzOd8kll5htznwuXB+uV0ayq10dcagTtzGXx888bdq0NPPs2bPH7CxLly6dOh97ZGSVN23vDv8O/v33X7Rv3z7Nc958Zh4gv/DCC6hevbr5HLySwrZ3/Y789NNP6NatG8qVK2fm4/x8XXJystvv5/Lly01vB35frO8S37dTp04oUaKE+Zzs7eV6wMF1Zndgbk+uM7fvXXfdhaNHj3q1HXm17IEHHjDvUbhwYRMcYlvx+8busq5jWPl3dNNNN5nvNL9zxO3Jv2n+7XId2NOB63n48OEMc4Jw+/HvfsGCBWjevLl5PZczduzYDHOCZOZve8eOHeazMWhRqlSp1GGAF5NnZNasWaZ9b775Zvz555/mt9Rb1veP3xMRccbfE+5b+VvEHqS8z99j9li1fkM9HdtYvy88eRw8eLD5TeTvSoMGDcxxiLvhC+yVxd9R63edvynWb97GjRvNCW1MTIxZh2effdb8rXN/wx5d0dHR5jfvrbfeclr22bNnMXz4cLOf4mv529OmTRvzW+H4/lwmcZ9ufQbrt9dd7gBv90He/rZ64s2+hevGiwo8xnM9tuTnXLNmTep063c2M/us33//HVdccYXZN3E7N2vWLPU4ir//bHf+tlvvwc/sLg8D25ePOa8rDgVnkMDx/ZcsWWL2/Ww37le4DhyS4gv8jGxzd8cs1kUTbj8eB3Ib9e/fP822dMwJwnbgdrR6dDi2G23atAk33HCD+U6zfSpUqGCOr44fP+60zA4dOpjv1pEjRzyuu45rc+e4VtJhkzxrzJgxPOq2zZo1y3bw4EGn26FDh8w8+/bts3399de2EiVK2Bo2bGju87Z69WrzP1/foUOH1Ol06tQpW/369W3Fixe3PfXUU7aPPvrI1r9/f1tISIjtwQcfdFqHgQMHmmV06dLFNmrUKNubb75pu/baa23vv/++eZ7LjIyMtLVp0yb1PRYuXOi0/tu2bTOPx44dax4vXbrU6T22b99upr/xxhup01588UWzPn369LH973//s40cOdJ8xipVqtiOHj2aOt8VV1xhK1eunK1ixYpm3TnvVVddZZb322+/pc6XnJxs69ixo61AgQK2hx56yPbxxx/bhgwZYgsPDzefx8Ltli9fPlvTpk1t7777rtk2jz76qK1t27ap83zyySdm+TfeeKNZDucbPHiw7YEHHki3PblesbGxaabzs4WFhZm2JLYJP/sdd9xh+/TTT21vvfWWrV+/frZXX3013eVnZ7sSn2/QoIGtbNmythdeeMHMV61aNbMNre8fcb0rVKhg2uD555+3jR492tajRw/z+nfeeSd1Pn4POI3fC8uIESPMNEfetr0748aNM8v7999/0zznzWceMGBAatt++OGHZvvxcc+ePZ2Wxce9e/c231l+3l69epn5+F1xxO9nmTJlbCVLlrTdf//95vvy448/2vbv328rWrSorWbNmmYZbOenn37adumllzq9/vbbbzffUX4X2J5PPPGErWDBgrZmzZrZzp49a8sI15Hrdeutt5rPw8dsU07jtndtB34/uU243Tk/cTvx75tty+8+v0v58+e3NW/e3JaSkpK6DNe/d6pcubKtVq1attKlS5vv5AcffGBr3LixaV/+rVn+/PNP81r+n9m/7ZMnT5rvJdfpySefNG3LdbM+p+MyM2PPnj22xx57zLQfl8P34Hdz9+7dXr2+Ro0athtuuCFL7y2SV1i/C3///bfT72xUVJStTp06tttuu838hvJvhfPx7zy9Yxv+vSckJJjfyoiICNvDDz9se++998xvFF/Pv3/XfQ5/1/j3y30o90k7duxI/c3jsrl/5ft269bNTHv77bfN79Y999xjpl9++eVm+ty5c1OXzeMw7huHDh1q1v/11183r+E6rVy50szDdeVzfO11112X+hn++ecfj/s/b/dB3v62euLNvoXryu3KYzzXY8vatWub/b413Tp+8Xafxe8F17Vu3bq2l156yXxWvpb7KpoxY4ZpG7a/9R5TpkxxeyzB9uSy2Aau2O5sV8vs2bPNMV7Lli3NsRW/Dzxu4rQlS5aku82s9+UxiesxOW9JSUlO+y9+v71pBx6zefq7qVevnmkDfsfvu+8+W2hoqDkeddz38r14I7YD99V87Z133pm67bZs2WI7c+aMrWrVqma/yn3ZZ599Zj4L24bH4Y4WLFhgljF16tR011/HtTl/XCueKQiSh1k/gu5u3Cm57hAdf+gtnJc/nI54Qsud0saNG52m8wSCJ+M7d+40j//44w/zencn944/wFwWd9ye1t86KTp+/LhZ70ceecRpPu64+OPAHRnxx5jrwR2jo//++8/sXB2n84ef78EAi4U/9DxxcTwB4U6AO4/58+c7LZM7ab7+r7/+Mo+5Q+Rj7tA84UmiNzs3VzwB5rL5ORzxAI07EgtP3ty1ZUayu105Dw8MNm/enDqNB2+c7hg4YACIB4OOgRHq27evLSYmxhywehsEyUzbu/PMM8+Y5Z04ccJpujefedWqVWYeHpQ4YmCD07kMi/WZHN11110mQJSYmJjm+8nvmSMezLmeGLjid5XzfPPNN07Tp02b5na6q+XLl5v5GPRzFwxyFwThyYArd5/122+/NfPPmzcvwyCI63wHDhxI8zvgKQjizd82D2Q5H4NLltOnT5uD9IsJglh4YPvTTz+ZkxCe4PD72bVrV9sPP/yQbiCKQVfXoJZIsPEUBOE0nqw5atSoka1JkyYZHtsw0MHXM+ht4d8iT2wLFSpki4+Pd9rnREdHm98dR9ZvHk8ULefOnTMn9jwecbzowJMUBlkdj3M4L3+PHHE+BiUY2LHwWML199Z1HSyZ2Qd5+9t6sfsWfmYeV7hyd5Lv7XKPHTtmK1y4sK1Fixbmt9rTMQjbnZ/TlbtjCba963eHF9wc9yFc9iWXXGLr1KmT0/twH8fgAC8Ypsd6X0+3RYsWpbt93GndunWa9Xb8u+FzjvsZHi9zOvdJ7oIgxL811+1DDM5x+uTJkzNcr71795p5X3vttXTn03Ftzh/XimcaDhMEOJyFQyEcb+xGmFWTJ0823TbZ5f3QoUOpN3bHY1fUefPmmfm+//57043OXUKyrJR/Ylc+5jeZNGmSU9fyiRMnmsRnlSpVMo9/+OEH06WS4+od14/d9zhExLG7KbErreP4THZ9ZPdQjsd3/MyXXnqpKZvquMyrrrrKPG8t0xrjym7snsqrch7mC/j7778z9fmvv/56MySGn9fCpF/smtunTx+n5bObKbst+rpd+Vp2y7XUr1/ftKO1bdmOXF737t3Nfcf35VAPdrFcsWKF158hs23vikM0uI35nXDkzWf+7bffzP/MjO7okUceSe22amF3RsuJEyfMOnLbs+vq+vXrnV7PLs3slurI+p798ssvZviTp/Zkd112S3XcFuxOyc+X0bawhi3de++9TtPvv/9+j6+5++6700xz/KzMFs914N8redO2HM/PbWNh93AOMXP8+/TEm79tfk4Ok3FMQspuvo7lBi8Gv09c9pQpU8zfPYeXsds1/57Zlfixxx5z24bW36GIePd7w98Jb34X+FvNfYJj8msmyeTQP5bUnTt3rtP87P5vDUtxxfK7FuY04tBW7ss41Mbx99r1N4vzWrkYuM/isAEOa+DrM7PPc/1c3u6DLua39WL3LRe7XB7Dcr/J5JuuuT2yWlqUx1Acdrply5bUaTzW4v6Xw5qI1VJ4XMUhnzxWsNaPw32YmJTHSJ6O+xzdeeedaY7JectK7hquR3p5p/hejglgWSWJ+yTru5IZbBviUFEeq6THWqeM9mE6rs3541rxzL8zKkm24EF/RolRM4M7AY7z93RQwLG2xJ0Jx8Rz7Fp24Y6KOSYWLVqEVq1amffgjsuxDBrXjwch/HFwxzUjOE9EXHec/AHnZ3Rc5rp16zL8zFy/zz77zBwYcQfNHSN/5Fn9xiq3yjJmzBfAdmHODSaQ4k6VJeTSw7wMXB6DQBzza+2kuUPjezhWA+JOu2bNmiYnAseusvIGAxC53a5WYMp121pjUg8ePGjykHzyySfmlt77eiOzbe8tbz4zT2zZxq4Z2rmj4kGw43hjBqmY2Z8Z8lmS15Hr2FqeoLsmLuMYZB6Yc5w4s+tzPC/HxvN7ZFVX4bbgspjjIr3tynmY+8PC9+LntD6Pa2Wp9DLQu6tCxYN7rueECRPStKXrZ83Kdyg93vxt83MyUOc6nzeZ9jmu33XMM/9+PCV4ZVvwhIQBFv7P3wqOR3/66afTJAnk9zirB/QieZ2Vlykrvwv8m+c+wrUEOi90WM9n9Lvm6feJJ4pcN+6vXae75kFiDhLmCmHg2zEQmt77pScz+yB36+7tNvR235JZ3i7XClR4W0LWG0xEzeARj6mYQ4W/vwzK8MIbL9xY60cDBgzwuByuf0bJsPnd85TDIyvSyzfleizEYFLZsmWdcm95i99LbqO3334b33zzjQmgMcBv5cRxt04Z7cN0XOu741pREESygBFJRuqZFNQdnnznFPYYYCIqBgIYBOH/3OlzB+a4fvzhZW8Xdycjrlf5PZ2wOO5YuEwmxOSPvztMJGpd9ebVAEZmedWFV5m5U2WPEZYh43vxQIvJTHkVn8+zl8H//vc/kyTNXeJTR0yExF4BvCLB0mX8/AyMOB5wMYEmDxLYG4XvyRMtnigze7jjVavcaNeMtq111YQ7UU8HFhkFbxxltu1dMXkYr8bxKhOTrWVFRjt9Bn0YxOCBFQNWPAHnQTOv/jFA5nolybEnheN7fPfdd1i8eDGmTp1qrsww2SgPqDmNn5PL4cEkD1bcsU4gHnzwQaeEgFy3rCYDdbeuvHqxcOFC0+OB31lr3Ric8+aqmTd/nznxWm/wczHpqiMmYrQS8Lm+J7crE/7yb569Yvi3y79J6yDbEU9EXE+kRMQuNyvHuftdS289vPndYZJDJnhl8Jq/jfyt5uteeeUVp94IWeFt8DSrv4/e7lsyK6eW6w1e5OBJPY+pGAThfnTnzp2m557j+lklaT2Vjs3oGCO78ZjF20Tn2YHHGPzeWseX7D3F7yy3Fy86WKx18mYfpuPanD2uFc/UE0QyjSdt7DKaUSSb8/HkjFdK07uCnpmrncygzozmjNAzIMEAA3dc3IE5vi934oxaZ1dAhsv8559/zElLRuvLoAzn443r+PLLL5srvQyMWNuMn4O9Rnjj1WT25HjppZdMJvL0SrfxgImZvq0hMcxMz9e44vZmsIQ3thUDI8wkn14QJLvb1Rs8qGGwgcNtsuPKyMW2PYc7WSeyjsEXbz5z5cqVzc6KUXvriqKVAZ2BDz5PPBHmFUF2cWS7WPiemcVhJbzxu8Os+KxEwh4XbGeuM3scsYdRegfxDHo5DhmxrmJZn4fr5XgFYvPmzV6vHw+EZs+ebYJ7DPJZMjtUKyfxc3JImWvPC28+JytKuFZd4lVXR7zixiATs+vzPg8U2QuE3eXdBUss3O5cvohk/988e4Px982xN4g1FNH6rc5JDGKzGgv3A46/O65DLjNzfOTtPuhiebtvyanlWkNsORw4vR57me1Jx+MxDv/kRSoeY/GCGy+8ub4vg9bZ2ZPjYvCYhUF1T/hdcAzU8xgvLi4OXbt2zfJ24wVB3tiblRcC2F68yPbiiy+mOZ5x/B56ouPa9OXEOY3YKSeIZBqv7HI4Ck8KXXFHyyvpxO76/MN117vB8UoDAwJ8XWZ2VHv37jU9HBiYcMyHQQwoMFrK93W9osHHrl1Svf3MLMf36aefpnmOQwk4JpTclQOzrhhYJepc35/DDzgWlOvmKb+DhV1amSuDVyt4ssvXcgfiyHX5jBLzQMG1RF5Ot6s32E5cHnfiPKBxxeEymXGxbc9Sy+Ra6tebz2wdVDgOzSKr9xBL4pIVyXdcPwbC2BsoM8EF18/n+j1jezK4ZA2dcsS2tP7m+N3jAZ114/hr4veMXNeL5Z295e6zuttGvsTPyb/tn3/+OXUae2m4+1t3xYCR47bjzQpi/vfff+YxT3QYpGrUqJHpHcZACNskvQAIu1TzajB7u4lI9uJv9b59+5zya/E3kb9t3F+yN1xOc/fbyNKr3Ac74ok4eXOM5O0+6GJ5u2/JqeVyCDEvnrAHAn+r0zu29GbIpeN+nu3y7bffmgttvODGZVi4b+QJKYcwMphwsccr2YHHLDwe8JTHhcOMHY8rR48ebbYlh/l4Yn1m13bk0F3rONDCYAgDia7HlxymzmCKdUyVHh3Xpi8nzmnETj1BggC7ULkmWyQeYPMAPbPYdZMnDNxBsFscdwwMAvCgn1c3eJDPLnCMPjMXxXvvvWei0Vb39/nz55vnhgwZYpbH1zP6zx01e3Qw2tmiRYt0d/TcAT766KOpJ9GOuJNiRJo9JLguDBJwfkammZyQiaL42szg52DggYnY2KODkW/urLldOZ2BA+Zd4fAGDofhwQavunAMK08iefW3devWqTtwXi3mMkqXLm1yjXzwwQfmNd4MwWDQh1fuuVyewLnmEuBJLXNEcLuy1wJP6Nku1vbOrXb11quvvmq2KducuRK4/gwmcXgIvxfp1Zl3dbFtz78HjjPm+3J4icWbz8yr9hzSw4MOa8jL0qVLTS8Arod1NYZ/dzx55rzsSsoDha+//jpTASQuk+1/3XXXmc/M4Ts8aecVKutAmO/PXkM8UOTwKX7vOHaU688DvHfffdfkqvGE7c+/LR5QcyfLHidMGMjeR95eZeP6sLfL66+/bg7EmN+EXWiz0uslp3Ab8e+PSRI5NIjjpdkd2wpmZDUvBw8CrUSobGtP49zd4feP3wcrIZ+IZB/uBz7++GOzn+PfKQOS3Mf99ddf5vcuq0MhM4P7WfYC4W849/38TeTVdO7/HE+w2SOC0xiw4VVg7tO5j3KXD8PbfdDFuth9y8Uul/sVDvFlj8dmzZqZXFjcp/KiGBN2WsM7uQ/jdmMeC87HAJdjzw5X/I3mNuKxKPeprhfYeLLPi28MINSpU8f0tOU+jUF0HsNwvTg8NSM8tuFwKFfcl3sTNHDE7w7zwnGfwe+1K15gYa9kBpjYw4XHDTwWdUwE7m49eFzJ7yP/FhgU4fEZty+PdTj8nN9FBkR47OLuOJw9JHmMy+E63tBxrWc5cU4j56VTOUbycIlc15JMmSmRSywhOmzYMFuNGjVMGVTWq27VqpXtzTffdCrHxTJwb7zxhik3yflKlixp69Kliym/aVm/fr2pW84Scnw/q4ycu5KZlptvvtk81759e4+f//vvvzflw1iejTeuAz/Lhg0bMixDxnVwLa3Gz8VyX5yfZeSKFi1qyo+xXjfL91o15FkCl3XU+Xn5P8uGOpadZUkwfl7WdudyqlevbnvsscdSl5ERlu+ztpVjiT/HeuLNmze3FSlSxMzHz80SWumV48yJdvX03eF2dS2JvH//fjNvxYoVTRlRljG9+uqrbZ988knqPN6UyM1M23vy9ttvmzKJrqVdvfnMLIfK7wPL5fFz8PNwezqWvSWWVL7ssstM+/A78vjjj9umT5/utsyru+/nihUrzPeqUqVK5jtUqlQp2zXXXGNbtmxZmnm5Dfk95XuxrGC9evXM+7GEXUZOnTpltluxYsXMNmGZV25DrqdjCUirHdyVht69e7ftuuuuM99Hljzu1atXavk8x7KPnkrkuvtdci3p56lErrd/21u3bjXvw23EdmWJSH6HuMzFixfbsuLkyZO2rOrTp4/5/ooEO08lct2VXXW3P/D0G8J9zqBBg8w+jr/n/F10LQlq7XP4u+/pvVx/87wtCcsSqy+//LJZP/6Gs7zvL7/84vb3aeHCheY3nOvp+Lvp7vN6uw/y9rc1Pd7sWzJTIjczy6Wff/7ZHJ9wPpYx5nEPy687/gbfdNNNZt/D7WRtV3fHEpZPP/3UPMf3dS2/61gq9vrrr089huNye/fubY7/LqZEruNxkbclcqlHjx7meMnd383cuXNNGWcer3IfzmPnw4cPZ9jmLKEbGxtrSrBa24r7SZZv5jFrVFSUOS648sorbbNmzXJ6LUsY87v62Wef2byl49qcPa4V90L4jxUQEREJduw+yx4h7L3gWOZQ7HiFjkM7eCWLOUjyKl4Rfvjhh01vDl7tyy3sps/ecBzupp4gIiKSHvZIZe9f9kz2VEEkt/edPH7ikM7szBkjkt0UBBERccEhDGPGjDEJM13LKAYT5rtxPYhhF3J2gWW3TKsqUl77nBxnzkAPh7xZw39yC0trs3Qyu7GLiIhkhEN0OOzam1xWOYnDXjl8g/sxJpkV8WcKgoiIiFtMxMUx8xwnzXHHzC/EmzWmPi8dQFaqVMkkl2VPIPZyWbNmjckNwvHmIiIiIpJ3KAgiIiJuMbkZAyHsEcNkfQwUMEEsSz4zKJJXsPsuE96xdwt7fzARIUsHuybGExEREZHApyCIiIiIiIiIiASF4B3sLiIiIiIiIiJBRUEQEREREREREQkKeWdQdzZKSUnB3r17UbhwYYSEhPh6dURERAKOzWbDiRMnzL40Ojpa+9MM6NhDREQke449ypUrl26FRwVB3GAAJK+UfhQREfE1Vt1hIEQ807GHiIhI9ti1a5cpHe2JgiBu8KoVsVpAz549ERERkU3NIRdbf3zGjBno2LGj2sRPqE38k9rF/wRjm8THx5sLCjwQsfar4pmOPfxTMP7t+ju1if9Rm/ifYG2T+PPHHhkddygI4oY1BKZAgQLmylUwfXH8/Y9ZbeJf1Cb+Se3if4K5TTQUxjs69vBPwfy366/UJv5HbeJ/gr1NQjJIaaHEqCIiIiIiIiISFBQEEREREREREZGgoCCIiIiIiIiIiAQF5QS5CMnJyWa8leQObuvw8HAkJiaabS85g+MGw8LCtHlFRERERCTPURAki/WH9+3bh2PHjmV/i0i6271MmTKm0kBGyW7k4hQpUsRsa21nERERERHJSxQEyQIrAFKqVCmTdVcnirkjJSUFJ0+eRKFChRAaqpFcORVoSkhIwIEDB8zjsmXL5sj7iIj/SE6xYem2IzhwIhGlCkehedViCAtVoDngpSQDOxYCJ/cDhUoDlVsBoerlJyIioiBIJnEYhhUAKV68uL5BuRwEOXv2LKKiohQEyUH58+c3/zMQwu+5hsaI5F3TVsdh5NS1iDuemDqtbEwURnSPRee6CoIGrLU/A9OeAOL3XpgWXQ7o/BoQ28OXayYiIuJzupyeSVYOEPYAEcmrrO+3ct6I5O0AyD3jVjgFQGjf8UQznc9LgAZAJvV3DoBQfJx9Op8XEREJYgqCZJGGwEhepu+3SN4fAsMeIDY3z1nT+DznkwAbAsMeIOm17LQn7fNlZdnb5gP/fWf/PyvLEBER8QMaDiMiIhJkmAPEtQeI6+kyn+d8Latr6GfAYA4Q1x4gTmxA/B5gx19A1bbeL1fDa0REJA9RTxBJ9ddff6FevXqmRGrPnj09TssJAwcOzNHlByptFxHJCUyCmp3ziZ9gElRvjLsR+Kg1MGkAMPsFYNV4YNdS4NRhZsh2nlfDa0REJI9RTxBJNXToUDRs2BC///67qcDiadrF2L59O6pWrYqVK1ea5VreffddU5lEnGm7iEhOYBWY7JwvUIwePdrcuC+iOnXqYPjw4ejSpYvb+T/99FOMHTsWq1evNo+bNGmCl19+Gc2bN3cKVn/11VdOr+vUqROmTZuGXMcqMN5IPgPs+89+cxVVBCheHSheAyhaFVj6cTrDa0Lsw2tqd1PlGRERCRgKgkiqLVu24O6770aFChXSnZYTYmJi1BI5sF2Y2JS9eEREHLEMbunCkdh/4ozbDcMCuWVi7OVy8xLuy1599VVccsklJvDO4MW1115rAvMMiLiaM2cO+vXrh1atWpnKZK+99ho6duyINWvWoHz58qnzde7cGWPGjEl9HBkZCZ9gGVxWgWESVLeBixD787f8ABzdDhzeDBzZYv//8FYgfjeQeAzYs9x+y5A1vGYhULVN5tZVJXxFRMRHNBwmiMrLvvLKK6YXBkugNmjQAN999515jlfEmAjz8OHDuO2228z9L7/80u004hUxXjVjz5DSpUvj1ltvxaFDh5ze6/XXX0eNGjXMgWClSpXw0ksvmef4/tSoUSOzzHbt2qUZ9vHJJ5+gXLlyZjmO+PyQIUNSH//0009o3LixOTCtVq0aRo4ciXPnzqU+z+V/9tlnuO6660y1Ex70/vyzc1b8jD4LtxGHA3GbsSRy+/btcerUqdSDY14NLFiwIIoUKYLLL78cO3bscLv9rW08adIktGnTxiyvWbNm2LhxI/7++280bdrUrAPX5eDBgx6Hw6S3ba33mDhxIq644gqzXb755hvzmueff94c/PM17IHjkyuUIuI3Umw2xBSI8BgAIZbJDQu1HuUN3bt3R9euXc3+oGbNmub3k7+9ixcvdjs/f0Pvvfde87tZu3Zts0/hb+rs2bOd5uNva5kyZVJvRYsWhU+EhtnL4BqubXf+cedXgVK1gVqdgVZDgGveAQZMBYauAZ6KA+5ZCPT+Grh6BFD5cu/e95eHgd+fAFZ9C+xfCyRf2Be7xSE2o+oCX10DfD/Y/j8fq3KNiIjkAvUECRIMgIwbNw4fffSROfibN28ebrnlFpQsWRKtW7dGXFwcatWqZU6W+/Tpg8KFC5srW47T2Cvh2LFjuOqqq3D77bfjnXfewenTp/HEE0+gd+/e+OOPP8x7DRs2zHQh5vPWstevX2+eW7p0qQkczJo1y1x1y5cvX5p17dWrF+6//378+eefuPrqq820I0eOYPr06SaIQPPnz0f//v3x3nvvmaACe6zceeed5rkRI0akLouBEQYN3njjDbz//vu4+eabTaCiWLFiGX4WrjevAPL1DKScOHHCvC+vHjLYwuDEHXfcgW+//RZnz541ny2jqipct1GjRpngBYNLN910k9nWHPbCQA3fm12z2V3bnfS2reXJJ5/EW2+9ZQJNDIRw2Xz88ccfm2lffPEFevToYa5k8rsgIsHn+alrsXH/SUSGh6JwVDgOnTyb+hx7gDAA0rluWeRlycnJmDx5sglst2zZ0qvXJCQkmB523Ic4YlC8VKlSJvjB/cqLL75oAufpOXPmjLlZ4uPjU+9fVHnyS7og5IYxCJvxFEJOXEiSaosuh+QOL8F2SRe+gfvXhkQAxWrab5cAIWUbIZxJVDNyeJP9Zr1XeBRsperAVqY+bGUbmP9RsjYQlg8h639B2PeDTC8Sxz2m7XwJ3+QbxsBW+xr4C6stVDLef6hN/I/axP8Ea5skefl5FQTJRjxJPnnypNM0noTyoIgnzY5X+C1ly9oPMtn7wLXR2LuAPQZ4gOZ4cES8csWTZ2/wIItjmBl4sA702HNiwYIF5sSYvQZ45Yon8Ax08D6xh4PrNOvkmsuz8KS6YsWKplcDPw9Puj/44AMMGDDAPF+9enVzwk4MuhAPDq1luuL2Yo+I8ePHpwZB2COjRIkSJuBhBTd4sm+9Bz/PCy+8gMcff9wpCMKeFAxkENeZQRMGKxjg4Tqm91nYlmy366+/HpUrVzbPs1eIFZQ5fvw4rrnmGvP56NJLL82wLR599FEzVpwefPBBs268osheJDR48ODUHjfuvl/pbVvLQw89ZNbZ8uabb5rgTt++fc1jdudmgInBmA8//DDDdRaRvGXc4h34evEOMGb7wU2NcVXtUqYKDJOgMgcIh8DktR4gjv777z+zL0xMTDT70ilTpiA2Ntar1/K3lD0V2SvQwv0Jf3PZ05EB+aeeesrswxYtWoSwsLB0L05wX+bOzJkzcXFCgeovo/jJDYhKOobEiCI4XKgWsDUU2Pqb94uxpaBjRDFEJR1J06/EPM1jjPAYrCnXGzGnd6LI6e2ISdiBiHOJCNm7HODtvJSQMMRHVkChs/vSBEAoBDazvLM/D8XMLZzgX52VL75NJLupTfyP2sT/BFubJCQkeDWfgiDZaPny5Zg7d67TNJ408+CIQQwO83BlnbBzaMfu3budnmPvg/r165sr9kxM6oiBC2soSUY2b95svhAdOnRwms7eCwwCZMY///xjTqDdJUnlwR97VzDoYgUvsoo9NtjL4n//+5/pZswuyeyNEhoamroerFxjDQWxrurxoJaflb0qiNvPwqBOdHQ0Dhw44NVn4bhvfg62IQMXfHzjjTeaIA2vAjLAwuncrjwgZi8OK6jlieP6cPiNY2DFmmatn6t169Z5tW05tMbC793evXtTgywWPubnF5HgsnjrYTz38xpz/9GOtdAh1v47FExlcNnDcdWqVSaQzQA7g8rcd2cUCGEukQkTJpheH7zAYbECzNbvOX/nGaDmfOn9XrNnH5OPO/5eMwhP3K9kTz6ni+9REcI4//eDzqdBvZBnxApjhF/7Luo79tywpSDp6DaE7PsXIXH/2P/f9y9CE4+hSOKO9N8LQIGkI+hWtwhslZ0D/L7CC1Q8ici+NpGLpTbxP2oT/xOsbRLv0nHAEwVBshGzxvPgypF1oMSTb2u4hjtMzOauJwhx2Ih1YGTJTKUWq3fKr7/+6pTILSvJ27gsjqlmbwJXDABs3boV2YHvwWEnXGfmzuAwFPZCcVwPXkFz7PFgcTw4df2jZ88WK9dIRp+FV/D447Fw4ULMmDHDDKd5+umnsWTJEnPFj0nwHnjgAZNfg3k4nnnmGTP/ZZdd5vFzOa6PNXTGdZprLhQLewV5g8EeERFXu44k4J5xy3EuxYbuDcrh3nb2XmzBhsMwmVfJ2m8zLxN72bFnpCfsUccgCHtUOgaz3WHPRPZc5AWI9IIg3P962gdzv+A3B631rgPYo2XaE0D8heE1IUyw2vlVhMf2SPua0rXttwa97Y9Z/e3YTmDJaGCx++GejsKnPQ7U7ASUbwqUbwLEVOAO0qeJVv2qTcRQm/gftYn/CbY2ifDysyoIko04PMXTEJXw8PB0ewnwgCm9k9qLObHl1S0eaO3cudP0ILkYTET6/fffo0qVKuYzuWKOCZ6sc4gHc224snKAsNdGehjIYICDPUB4IMngEt/biu7x/oYNG1IPZHPis1hBCfaa4I25Ojgshl2nrat37EnDG6/osXs1h/CkFwS5GBltW3cYfGPXbfaacWx7PnYs8SgiedvJM+dw+1fLcDQhCfXKx+D1G+pnmMMoWDDw7JibwxXzQrHXIfNSOfa084S9OplUPKOegQGFgQ6Wwc1qkIHftaKVgVrdvAqC4NBG+83C92MwJPXWGIhyqJ7GhKouQRpTBYdJYt0FaUREJKj5fMAlcxLwJJQnvS1atDD5GtLDPAY8IebJIHtHPPzww2YIhOMYW/YcYDCCScqYvJIny8GM24K5KLitWA6QQz1WrFhhejbwcWbcd999Jh8Gc1nw6hmXxQPDQYMGmcAG25FjppmbY+zYseZ5Zt3//PPPzevZJmw79p7Yv3+/6Y6c3pAY9gRhng7ed8SABJfP3iAcLsShIuymzN4Y2fVZ2OOD+UKWLVtmAkg//PCDyevC3B/btm0zgQ+O+WaiVfYU2bRpk1d5QbIqo23ryWOPPWZ6u7C3Cv8WmEuFXcGZk0RE8r6UFBuGTlyFDftPoGThSHzSvwny58u+K+SBhL/bTAzOalrMDcLHHLZi7WOYcJvTLPztfPbZZ81+iMcq+/btMzerhyX/528sf4u5TAap2bOTAXor/1OewYAHy+DWu9H+f1Z6WVglfN1mGKEQe8CjxwdA09uAsg2A0HB74GXDb8AfLwBf9wRerQR80AyYcjfw8wPApFudAyB0PtGqKs6IiIhf9QThSRmvqLNiCQMgDHDwoIEnajxZdsWr7DyB48FIq1atTPJK5mXg1ay3337bzMNxvTy5ZSCESS2ZoIy5HNauXRvUwwSYNJRJSRkk4pAVDrVhTwhun8ywehXwZJzblVfP2DuCieGsfB08YGTPCgYqmI+CV8Puvvtu8xynMzkpK87weSY65QGoO8ywz9wb/D6wioojfk9++eUXsxwepLLrE8sXettDwpvPwl4UPFjm95I9UPgch+Qw4R0DOKzKwiCSdcWP37u77roLOSm9besJh+ww2PTII4+YfCPsGcRSwaoMIxIcRs3aiBlr9yNfWCg+vrUJysZ4N7QuL+JvIAMdrKzFpN8c2sLgt5UziwFva19GrNTF/FnMB+Waz+u5554zwyb//fdfsy9gTizuV7g/4T43s8NNg4JVwpfBCRMIuZBjJDUw0vVNe++NxrfaHyedBuL+BfYsA/YsB3YvA47tSNtbJA17FhNMe9LeiyUbh8aIiEhgC7Ex8YKPMPDBYAWrXVhdUtm7g+VRGexwNWTIEHPFn1daLDyx4xV7Vjpxh1fuGVBhcKRt27ZerRdPeHlwxKALD3wcxxax1wl7ATAnhGPuCcl5/H6wbRiccDxIlezn7feceWx+++03dO3aNajGG/o7tYv/8VWb/PLvXgwZv9Lcf6tXA9zQpEKuvbe1L2UQlr/bkvVjjzzH7fCV8ibHiFfDV04dsgdE1kwB/vk24/k7vQw0ux0Iz3xgSr+n/kdt4n/UJv4nWNsk3stjD5/1BOGVFVZTcex2yhNbVtngEAN32Ptj3LhxZsgM8xmwRwMb99Zbz18tcMMabsEeBSIiIsFi9Z7jeHSyvQrUnW2r5WoARCRHc4wULGFPnHrmhHdBkOlPAbNfACq3BKq1s99K1+OBZ/qvS0lGyI4FKH9kEUJ2RAPV2qpHiYhIHuCzIMihQ4dM3gWrTKiFjznMwB0OieDrWrdubSqHcLgLhwJ4GtLBngMPPfSQSWpZt25dj+vCYRCOSdEcS+u4VmzhY743l+2piofkDKvTkrX9Jedw+3I78/vO7t6eWH8frn8n4ltqF/+T221y6OQZ3P7V30hMSkHbS4pj6NXVc/3vVL8L4lWOkYvB4Ik3oooAiceALX/Yb5S/GFC17YWgSLGqbnurhMfvhUmHu2O0kq2KiOQRAVUdhrkjmKjyf//7nxlKw6ohTO7IsbfMleCKORpWr17tcaiMhXkymGDTHZY8dcR8DGXKlDHJ0NibRXLfiRMntNlzGL/bp0+fNjlRGGzMiOvfifgHtUtwtsm5FOD9NWHYdzIEpaJs6FJkP6ZP+x25LSEhIdffU4KMlWiVSVCd8otYQuzPP/ivPX/ItrnA1jnA9gXA6SPA2h/tNypS6UJAJCkR+Om+tMu0kq32HquqMyIiAcxnQRCWhOUVZiaYdMTHDDK4w0AHh75YyS/r1auHU6dO4c4778TTTz/tlCeC+UOYOJMncRUqpN8FmENyrJKnVk8Q5iYhJktzzQmya9cuFCpUSDlBchl7JjAAwmo3Ku2Ys/g9ZxUf5tHJKCcIT+pc/07Et9Quwdsm/J18csoabD+5F9FR4Rh3VwtULeGbpOCOvSpFfJZolXlGwsKB0rH222X3AMlJwJ4V9oAIb7uXAsd2AivG2m8eKdmqiEhe4LMgSL58+dCkSROT5JRlbK0u+HzMAIanq0quCTGtrvqOQyWYWHXKlCmm5wgTO2aEGdw9ZXHnwarjASuH8PAEnOuh5Jy5yxoCY21/yTncvtzOrt9/T7ydT3KX2iX42uTzBdvww8q9CA0BPripMWqWLQJf0W+C5Fp+EfbMSJNotZznRKthEUClFvZbuyeAMyeBnYvsAZH1vwBHt6fzhjYgfo89n8nFDucREZHgGw7D3hcDBgxA06ZNTaJTliJlz45BgwaZ51nGrnz58ma4CnXv3t2Uwm3UqFHqcBj2DuF0KxjCITDMrP7TTz+ZHgP79u0z05kllle2s4tyUkhepu+3SOCZt/EgXvp1rbn/dLdYtK1Z0terJBIYiVYjCwGXdLDfyjUCvh+c8WtmPw80GQBUuxKIKe/d+6QkZ30dRUQkbwRB+vTpY0rYDh8+3AQrGjZsiGnTpqUmS925c6fTFf9nnnnGXJ3m/3v27EHJkiVNAOSll15KnWf06NHm/3bt2jm915gxYzBw4MBs6cHCddq7d695fz7W0IzcOzFnrgoO1VBPkJzBnlTcxvy75Dbm91tE/N/WgycxZPwKpNiA3k0r4LbLq/h6lUQCL9FqZpKtcggNb1SiFlD9KvutyuVAvoJelgVmb5XXlF9ERCTYEqNy6Iun4S8czuKalHTEiBHm5ok1LCan8MSQQ2zi4uJMIERyD9uWyTrZo0eBp5xVoEABVKpUScEmkQBw/HQSbh+7DPGJ59CkclG80LOufiNFcjLZKkv0Nh5gHz6zdwVwaIP9tmQ0EMqhNpcB1a+0B0XKNLAPsTF5S5RoVUTEH/g8CBKIeHWcJ4ismsEcIZJ7iQWZ6JbJOjXWPOdwaBkDjgo0ifin5BQblm47ggMnElGiUCQ+nrsFWw+eQrmYKHx0SxNEhqt7vUiOJlvt9ra998bVzwIJR4Bt84CtfwKb/wCO7wS2z7ffOGQmqihwLtFDQEWJVkVEfEFBkCzKTNJIyb6TcwaeWK1E211EgtG01XEYOXUt4o7zpOqCiLAQfNK/KUoWdp/kW0RyKNlqgWJAnZ72G3sjH9kKbPkD2PKnPTiSeDSDN1OiVRGR3KYgiIiISIAEQO4Zt8Lt9eSkZBt2H01A3fIxPlgzkTzofLLVc1vnYdX86WjYphPCq7VNP5FpSAhQvLr91vwOeyneeW8Ac1/L+P1OcPiNiIjkBtUZFRERCYAhMOwB4inrFTvp83nOJyLZJDQMtsqtsadYS/N/piu5sBRvFS+Ttf76CDD1QWDzbHvwREREcox6goiIiPg55gBxHQLjiKEPPs/5WlYvnqvrJiIXk2iVQoAz8cDyL+23qCL2kr+X9rAnWA33MMxNJXdFRLJEQRARERE/xySo2TmfiPhRotUbxwD5Y+xldFlJ5tRBYNU39lu+wkCtzvaASI32QL4C9teo5K6ISJYpCCIiIuLnShWOytb5RMQPE62ypG63t4Cdi+xBjnVTgRN7gf8m228RBYBLOgDR5YHFo1VyV0QkixQEERER8XPNqxZD2Zgoj0NieD25TEyUmU9E/DfRKnYsBE7uBwqVtg+Vcc0zwsdVWttvDJDsWQas/ckeFGH5Xd73SCV3RUS8ocSoIiIifi4sNAQjuse6fe58h3rzPOcTET/FAEfVNkC9G+3/Z5RoNTQUqNgc6PQS8NC/wJ1zgLq9vC+5KyIibikIIiIiEgA6xJZB0QIRaaazB8joWxqjc92yPlkvEckFLL9brpE9P4g3/p0InDyQ02slIhKQNBxGREQkACzYfAhHE5IQHRWO929qhGMJSSYHCIfAqAeISJDgMBpvrPzanli1Uisg9lrg0u5AtAKlIiKkIIiIiEgAmPT3LvP/dY3K44qapXy9OiLilyV3Q4DIwkCx6kDcSmDHAvvt98eAii3OB0R6AEUqpn2pSu6KSJBQEERERMTPHTl1FjPW7jP3ezdzc/IiIsHBm5K7135oT8R6bOf5KjM/A7uWXLhNfwoo19geEOF8xaqp5K6IBBXlBBEREfFzU1buQVKyDXXLR6NOuRhfr07AGj16NOrXr4/o6Ghza9myJX7//fd0XzN58mTUrl0bUVFRqFevHn777Ten5202G4YPH46yZcsif/78aN++PTZt2pTDn0SCmlVy13V4C3uIcLpVcrdIJaDVEGDwDGDoOqDL60Dly+3Bkr0rgFkjgPcaAaPqA5NudS7fS+xtwmALAykiInmIgiAiIiJ+jCfZ1lCYPs0q+Xp1AlqFChXw6quvYvny5Vi2bBmuuuoqXHvttVizZo3b+RcuXIh+/fph8ODBWLlyJXr27Gluq1evTp3n9ddfx3vvvYePPvoIS5YsQcGCBdGpUyckJrovZyySLRjoeGg1MOAX4IbP7f8/9N+FAIgrBkha3AUM+g14ZAPQ7W2g6hX2U4FjOzy8yfleJtOetA+VERHJIxQEERER8WP/7D6ODftPIDI8FD0alPP16gS07t27o2vXrrjkkktQs2ZNvPTSSyhUqBAWL17sdv53330XnTt3xmOPPYZLL70UL7zwAho3bowPPvggNUA1atQoPPPMMyaYwl4mY8eOxd69e/Hjjz/m8qeToJPZkruWwqWBZoOBAT8DfcZlMLNK7opI3qMgiIiIiB+b+PdO83/XemURkz9tiVzJmuTkZEyYMAGnTp0yw2LcWbRokRne4oi9PDidtm3bhn379jnNExMTgxYtWqTOI+LXzp32br7pw4D/vgPOJuT0GomI5DglRhUREfFTCWfPYeo/rAIB9G6qhKjZ4b///jNBDw5XYS+QKVOmIDY21u28DHCULu1ckpSPOd163prmaR5Pzpw5Y26W+Pj41PtJSUlZ+GSSE6y2yKttEpK/uHcnA/v+A74fDFu+grDVugYpdXvBViUTvU+yUV5vk0CkNvE/wdomSV5+XgVBRERE/NSv/8bh5JlzqFy8AC6rVszXq5Mn1KpVC6tWrcLx48fx3XffYcCAAZg7d67HQEhOeeWVVzBy5Ei3z82cOTNX10UylmfbxJaCjhHFEJV0xKot4/w0A3bhMdhR/ApUOLoIBc8eRMh/ExH630QkhhfB7mItsatoK8TnrwSEuFmCLQXFT25AVNIxJEYUweFCtYCQ7OmInmfbJICpTfxPsLVJQoJ3vdUUBBEREfFTk5btSu0FEuLuBEMyLV++fKhRo4a536RJE/z9998m98fHH3+cZt4yZcpg//79TtP4mNOt561prA7jOE/Dhg3TXY9hw4Zh6NChTj1BKla09/bp0KEDIiI09MlfriryJCIvt0lIdQDfDzIBjxCHkru282GR8GvfRbXa1zAJDs7t+Rsh/01G6LofEXX6KGoc+N3cbCVrm94hKXVuAGIq2Je7/heEzXgKIScuVJ2xFS6H5I4vw8blZVEwtEmgUZv4n2Btk3iHXpXpURBERETED205eBJ/bz+K0BDghsb2kwrJfikpKU7DUhxx2Mzs2bPx0EMPpU7jQaWVQ6Rq1aomEMJ5rKAHD8BYJeaee+5J930jIyPNzR0esAbTQWsgyNNtUu86ICwMmPaEU5ncEFaU6fwqwh0rzlS93H7r+jqweRbw70Rgw+8IObgeYX++YG6o3BooWQtY9sWFCjPWMk/EIfz7Qc6lfLMoT7dJgFKb+J9ga5MILz+rgiAiIiJ+3AukXa1SKBMT5evVyRPY+6JLly6oVKkSTpw4gfHjx2POnDmYPn26eb5///4oX768GapCDz74IK644gq89dZb6Natm0mkytK6n3zyiXmevXMYIHnxxRdNxRkGRZ599lmUK1fOlNIVCRgMSNTuBuxYCJzcDxQqDVRu5TnnR3g+oHZX+y3xOLD2J+DfScD2+cCOBfabW/b+JqbsLt/PBzlFREQUBBEREfEzSckp+H75HnO/TzMlRM0uBw4cMIGOuLg4U8WFJW0ZAGF3Ydq5cydCQy/kK2jVqpUJlLAE7lNPPWUCHSx9W7du3dR5Hn/8cVNh5s4778SxY8fQunVrTJs2DVFRClxJgJbczayoGKBxf/vt2C5g3hvAiq+8K7ublfcTEblICoKIiIj4mT/XH8Chk2dQolAkrqpdyterk2d8/vnn6T7PXiGuevXqZW6esDfI888/b24iQa9IRaBq2wyCIOc5DL0REclN2ZOeWURERLLNxL/tQ2FuaFweEWHaVYtIAOFQGm9MGwb8+Qpw3N7rTUQkt+jISkRExI/sj0/EnxsOmPu9mmoojIgEGOYSYVJVt0V3z2OZ3NOHgbmvAqPqAt/2AzbNBFKSc3NNRSRIKQgiIiLiR75bvhspNqBp5aKoUaqQr1dHRCTzuUU6v3b+gWsghI9Z8uoz4IbPgSptAFsKsOE34JsbgfcaAvPeBE44l6ZOlZKMkB0LUP7IIvO/giYikhXKCSIiIuInbDYbJp+vCtNbCVFFJJCrzbAMrkvZXdNDpPOrF8rj1rsROLgRWD4GWDUeOLYT+OMFYM4r9uoxTW8DqrQFmLB47c9meeHxe9GUr90x+vzyXrvocrsiElwUBBEREfETS7YdwfbDCSiYLwzd6pX19eqIiOR82d2SNYHOrwBXDwfW/Ags+wLYvdRedpe3YtWBCs2AfyeeL7HrID4OmNTfHnBRIEREvKQgiIiIiJ+YdD4havcG5VAwUrtoEQmisrsR+YGG/ey3favtvUP+mQgc2WK/ucWgSAgw7Ul7wMU1wCIi4oZygoiIiPiB+MQk/LY6ztzvo6EwIhLMytQFur0FPLIeaDkkg5ltQPwee48TEREvKAgiIiLiB35etReJSSmoWboQGlYs4uvVERHxvchCQLlG3s17wh5EFhHJiIIgIiIifmDi+aEwvZtWREhIOqUlRUSCCXOJeGPaMOCPl4Cj23N6jUQkwCkIIiIi4mNr98bjvz3HEREWgusbV/D16oiI+A8mU2UVmDTldh2FAAmHgHmvA+82AMZeC/z3HZCUmIsrKiKBQlnXREREfGzS+bK4HWJLo1jBfL5eHRER/8FkpyyDyyowJhDiWCHmfGDkhs/t01d+DWydc+EWVQRo0BdodKs9z4irlOSMq9eISJ6jIIiIiIgPJSYlY8rKPalDYURExAXL37IM7rQngPi9F6azh0jnVy+Ux613o304zMpvgFXf2BOmLvnIfmNukcb9gbo3AFExwNqfPSzvNZXbFcnjFAQRERHxoRlr9+P46SSUi4lCm0tKqi1ERNxhoKN2N5zbOg+r5k9HwzadEF6tbdqeG0WrAFc9DbR7EtjyJ7DiK2DD78DelfbbtKeA8k2AHQvSvkd8nL3HCQMuVmBFRPIcn+cE+fDDD1GlShVERUWhRYsWWLp0abrzjxo1CrVq1UL+/PlRsWJFPPzww0hMTLyoZYqIiPjKpPMJUW9sUgFhoUqIKiLiUWgYbJVbY0+xlub/dIeu8LlL2gN9vgaGrgM6vgiUqAWcO+0+AGKcH2oz7Un7UBkRyZN8GgSZOHEihg4dihEjRmDFihVo0KABOnXqhAMHDridf/z48XjyySfN/OvWrcPnn39ulvHUU09leZkiIiK+sutIAhZsPgQWg+mloTAiIjmjUEmg1f3AfUuArm9mMLPNPoyGuUJEJE/yaRDk7bffxh133IFBgwYhNjYWH330EQoUKIAvvvjC7fwLFy7E5Zdfjptuusn09OjYsSP69evn1NMjs8sUERHxlcnLd5v/L69eAhWLFVBDiIjkJEac8xf1bt4TcWoLkTzKZzlBzp49i+XLl2PYsGGp00JDQ9G+fXssWrTI7WtatWqFcePGmaBH8+bNsXXrVvz222+49dZbs7xMOnPmjLlZ4uPjU+8nJSVd9GeV7GG1hdrEf6hN/JPaJTDaJDnFhkl/7zT3b2hUNs/9tuW1zyMieQSrwHhj1kjg7Cl7dZmI/Dm9ViISDEGQQ4cOITk5GaVLO/8Q8fH69evdvoY9QPi61q1bw2az4dy5c7j77rtTh8NkZZn0yiuvYOTIkW6fmzlzZhY+neQktYn/UZv4J7WLf7fJuqMh2BcfhgJhNiTvXInfdq9EXpKQkODrVRARSYtlcFkFhklQncrtOgoB4ncDvzwE/PEC0Ox2+61QKW1RkTwgoKrDzJkzBy+//DL+97//mYSnmzdvxoMPPogXXngBzz77bJaXy54jzCPi2BOESVepQ4cOiIiIyJb1l4u/qsgTCLWJ/1Cb+Ce1S2C0ye8T/gGwHzc0q4xru9VGXuPYq1JExG8wYSrL4LIKDIMdToGQ88mpr/sYSDgELP4IOL4TmPsasGAUUL830PI+oNSlvlp7EQnkIEiJEiUQFhaG/fv3O03n4zJlyrh9DQMdHPpy++23m8f16tXDqVOncOedd+Lpp5/O0jIpMjLS3NzhwaqCIP5FbeJ/1Cb+Se3iv21y+OQZzF5vT9jdr3nlPLmfyYufSUTyCJa/ZRncaU8A8XsvTGcPkc6vXiiP2/wuYP1UYOEHwJ5lwMqv7bca7e3BkGpX2vOMWFhRhglVT+63D7thr5P0KtiISHAFQfLly4cmTZpg9uzZ6Nmzp5mWkpJiHg8ZMsRj11rm+HDEoAdxeExWlikiIpLbpqzcg6RkG+qVj0FsuWg1gIhIbmOgo3a39IMWYeFAneuA2J7ArqXAoveBdb8Am2fZb6Vi7cGQer2AjdM9BFVeuxBUERG/4NPhMByCMmDAADRt2tQkOh01apTp2cHKLtS/f3+UL1/e5Oyg7t27m+ovjRo1Sh0Ow94hnG4FQzJapoiIiC8xaD9p2S5zv08z+9BLERHxAQY8qrbJeD729qjUwn47shVY8jGw4mvgwFrgp/uAacOAM26GADLvCIfdsNeJAiEifsOnJXL79OmDN998E8OHD0fDhg2xatUqTJs2LTWx6c6dOxEXd6E81TPPPINHHnnE/M/yt4MHD0anTp3w8ccfe71MERERX1q16xg27j+JqIhQ9GhYTo2Ri3hRpVmzZihcuDBKlSpleo1u2LAh3de0a9cOISEhaW7dunVLnWfgwIFpnu/cuXMufCIRyXXFqgFdXgOGrgHajwQKlXUfADHO5xuZ9qR9qIyI+AWfJ0blMBVPQ1WYCNVReHg4RowYYW5ZXaaIiIgvWb1AutYti+go5c3ITXPnzsV9991nAiGsMMfqch07dsTatWtRsGBBt6/54YcfcPbs2dTHhw8fRoMGDdCrVy+n+Rj0GDNmTOpjT7nGRCSPyF8UaP0QULYB8LV9GL57NiB+j33YjTe9TkQk7wdBREREgsWpM+fw8yr7ePHeGgqT69gz1NGXX35peoQsX74cbdu2dfuaYsWKOT2eMGECChQokCYIwqBHeknYRSSPSjjs3XzMOyIifkFBEBERkVzy+5r9OHU2GVWKF0CLqs4n15L7jh8/7jbQkZ7PP/8cffv2TdNzhL1XGVApWrQorrrqKrz44osoXry4x+WcOXPG3NyVFGZJZfEPVluoTfyHv7VJSP7iXp1QJa/+ESkVWgKFSiGv8bc2keBtkyQvP6+CICIiIrnku+V7zP+9mlY0eSPEd1g97qGHHsLll1+OunXrevWapUuXYvXq1SYQ4joU5vrrr0fVqlWxZcsWM8ymS5cuWLRoUWridnf5SUaOHOn2uZkzZ2bhE0lOUpv4H79pE1sKOkYUQ1TSEYR4yArC6WEbpsK2aTq2luyEzaW6Iinc/RC8QOY3bSJB2yYJCQlezacgiIiISC7YfxpYvvMYQkOAG5tU0Db3MeYGYUBjwYIFXr+GwY969eqZ6nOO2DPEwufr16+P6tWrm94hV199tdtlDRs2zFS0c+wJUrGivVpQhw4dEBGhfDH+clWRJxFqE//hj20SUh3A94POBzxsDgEQe1gkufUjCNkyC+Fxq1Bz/1RccnweUi4bgpRmdwD5CiHQ+WObBLtgbZN4h16V6VEQREREJAclp9iwZNsR/LjdXpCtXc2SKB0dpW3uQ0ye/ssvv2DevHmoUMG7gNSpU6dMPpDnn38+w3mrVauGEiVKYPPmzR6DIMwh4il5Kg9Yg+mgNRCoTfyPX7VJvesA9vqa9gQQb8/7RCHR5YDOryKM5XGvfgZY/yvw50sIObAWYXNeQtjfnwBtHgGaDAIiAn+/4FdtIkHZJhFeflYFQURERHLItNVxGDl1LeKOJ6ZWpV+565iZ3rluWW33XGaz2XD//fdjypQpppcGh694a/LkySaHxy233JLhvLt37zZVZMqWVRuLBA0GOmp3s1eBYRLUQqWByq2A0PND4jgE8tJrgFpdgNU/mGAIjm6zl89d+D5wxRNAw5uAMJeTOJbW9bRMEckSBUFERERyAAMd94xb4dAx2u5YQpKZPvqWxgqE+GAIzPjx4/HTTz+hcOHC2Ldvn5keExOD/Pnzm/v9+/dH+fLlTc4O16EwPXv2TJPs9OTJkya3xw033GCqwzAnyOOPP44aNWqgU6dOufjpRMTnGJzIqAwu56nfC6jTE1j1DTDnNXsJ3akPAH+NAq58GqhzPRAaCqz9OU3vEpjeJa/Zgy4ikiX2y1IiIiKSrUNg2APENQBC1jQ+z/kk94wePdpUhGnXrp3ppWHdJk6cmDrPzp07ERcX5/S6DRs2mNwhgwcPTrNMJj79999/0aNHD9SsWdPM06RJE8yfP9/jcBcREdPjo8lA4IGVQKdXgAIlgCNbge8HAx+1BmY+B0zq7xwAofg4+3QGSEQkS9QTREREJJst3Xbk/BAY9xj64POcr2V1z2VUJfuHw2SEw2Rc1apVy+Nr2YNk+vTp2bJ+IhKEmAuk5b1A4/7AktHAX+8DB9bYb26drzfDYTQcfqOhMSKZpp4gIiIi2ezAicRsnU9ERPK4yEJA28eAB1cBdXtlMLPNPoSGuUJEJNMUBBEREclmpQpHZet8IiISJAoUA2p19m5eJksVkUxTEERERCSbNa9aDGVjPAc4QgDzPOcTERFxwiow2TmfiDhREERERCSbhYWGYET3WI8BEOLznE9ERMQJy+CyCkzqHsPD3mTvSuDcGW08kUxSEERERCQHlInJ72F6lMrjioiIZ0x2yjK4hqdAiA2Y+SzwQTNg9ffM/KwtKuIlBUFERERywFcLt5v/r2tYDuNua4r+lySb/xc8cRU61y2rbS4iIp7F9gB6jwWiXfYX0eWBXl8BPd4HCpUBju0AvrsN+Kw9sGORtqiIF1QiV0REJJsdPHEGv/y719wfeHlVxJYpiMPrbGhRtZiGwIiIiPeBEJbBZRUYJkFlDhAOlbHK4ta9AVj4AfDXu8CeZcCYzkDta4D2I4ESNbSVRTxQTxAREZFs9u3SnUhKtqFRpSJoULGItq+IiGQNAx5V2wD1brT/bwVAKF9BoN0TwAMrgSYDgZBQYP0vwP9aAL89Bpw6pK0u4oaCICIiItkoKTkF4xbvMPcHtqqibSsiIjmrcGmg+7vAPQuBSzoBKeeApZ8A7zUC5r8NJJ2+MG9KMrBtPvDfd/b/+VgkyGRpOMyuXbsQEhKCChUqmMdLly7F+PHjERsbizvvvDO711FERCRg/L56Hw6cOIOShSPRRbk/REQkt5S6FLh5ErB1LjDjGWDfv8DskcDfnwNXPwuE5wemPwnE24drGqxCwySsHHojEiSy1BPkpptuwp9//mnu79u3Dx06dDCBkKeffhrPP/98dq+jiIhIwCVEval5JeQLV4dLERHJZdWuAO6cC1z3MRBdAYjfDUy5C5jc3zkAQvFxwKT+wNqf1UwSNLJ0dLZ69Wo0b97c3J80aRLq1q2LhQsX4ptvvsGXX36Z3esoIiISEFbvOY7lO44iPDQEN7eo5OvVERGRYBUaCjToC9y/DLh6ePqldmnakxoaI0EjS0GQpKQkREZGmvuzZs1Cjx727lO1a9dGXFxc9q6hiIhIgPjyfC+QrvXKolR0lK9XR0REgl1EfqBC8wvBDrdsQPweexUakSCQpSBInTp18NFHH2H+/PmYOXMmOnfubKbv3bsXxYsXz+51FBER8XuHT57Bz/9YZXGVEFVERPwEy+tm53wiwRgEee211/Dxxx+jXbt26NevHxo0aGCm//zzz6nDZERERILJhL934ey5FNSvEINGKosrIiL+olBp7+aLisnpNREJ3OowDH4cOnQI8fHxKFq0aOp0VoYpUKBAdq6fiIiI3zvnUBZ3QMsqpoKaiIiIX6jcyl4FhklQ0xsW88vDQI/3gOpX5ebaiQRGT5DTp0/jzJkzqQGQHTt2YNSoUdiwYQNKlSqV3esoIiLi12as3Y+444koXjAfrmlQ1terIyIickFomL0MruEapD//uEBx4Pgu4OvrgB/vBRKOaAtKnpWlIMi1116LsWPHmvvHjh1DixYt8NZbb6Fnz54YPXp0dq+jiIhIQCRE7de8EiLDw3y9OiIiIs5iewC9xwLRLoF69hDp/TXw4D9A87vsQZFV3wAftgDWTAFs6SVUFQmiIMiKFSvQpk0bc/+7775D6dKlTW8QBkbee++97F5HERERv7UuLh5Ltx1BGMviXqayuCIi4seBkIdWAwN+AW743P7/Q//Zp0cWBrq+Dtw2HShREzh1AJg8EJh4y/lhNCJBHgRJSEhA4cKFzf0ZM2bg+uuvR2hoKC677DITDBEREQkWX53vBdK5bhmUjcnv69URERFJf2hM1TZAvRvt//Oxo0otgLsXAG0fB0LDgfW/2HuFLP9SvUIkuIMgNWrUwI8//ohdu3Zh+vTp6Nixo5l+4MABREdHZ/c6ioiI+KWjp87ix1V7zP2BrVQWV0RE8oDwSOCqp4E75wLlGgNnjgNTHwS+6g4c3uLrtRPxTRBk+PDhePTRR1GlShVTErdly5apvUIaNWp08WslIiISACYu24XEpBTElo1G08oXqqWJiIgEvDJ1gdtnAR1fAsLzA9vnA6NbAX+9CySfs8+TkoyQHQtQ/sgi8z8fi+TJIMiNN96InTt3YtmyZaYniOXqq6/GO++8k53rJyIi4peSU2z4etGO1F4gKovr/1555RU0a9bMDOllNTsmdGdlu/R8+eWXpm0db1FRUU7z2Gw2c4GobNmyyJ8/P9q3b49Nmzbl8KcREckFHC7Taghw70KgalvgXCIwczjw2dXAwg+AUXURPq4nmu4Ybf7nY6z9WU0jeS8IQmXKlDEHETNnzjQlc4kHFrVr187O9RMREfFLs9btx55jp1G0QAR6NCzn69URL8ydOxf33XcfFi9ebI5fkpKSzJDeU6dOpfs6DvWNi4tLvbnmP3v99ddNYviPPvoIS5YsQcGCBdGpUyckJiaqXUQkbyhWDej/M9DjAyAyBohbBcx4Gojf6zwfk6hO6q9AiPi18Ky86PDhw+jduzf+/PNPc0WEVzuqVauGwYMHo2jRoqZcroiISDAkRO3TrBKiIlQWNxBMmzYtTS8P9ghZvnw52rZt6/F1PNbhxR932Atk1KhReOaZZ3DttdeaaayWx8p5zJ/Wt2/fbP4UIiI+EhICNL4VqH4V8H5je6+QNFhSNwSY9iRQu1vaxKsigRoEefjhhxEREWGGxFx66aWp0/v06YOhQ4cqCCIiInnaxv0nsHDLYYSGALeoLG7AOn78uPm/WLFi6c538uRJVK5cGSkpKWjcuDFefvll1KlTxzy3bds27Nu3zwyBscTExKBFixZYtGiRxyDImTNnzM0SHx+fep89VMQ/WG2hNvEfahPfCzm4EeFuAyAWGxC/B+e2zoOtcutcXDMJ9r+TJC8/b5aCIEyAylwgFSpUcJp+ySWXqESuiIgETS+QjrFlUKFoAV+vjmQBAxoPPfQQLr/8ctStW9fjfLVq1cIXX3yB+vXrm6DJm2++iVatWmHNmjXmOIgBEGLPD0d8bD3nKT/JyJEj3T7HoTriX9Qm/kdt4jtMgtrUi/lWzZ+OPWsuBHgl9wXb30lCQkLOBUE4drZAgbQHfUeOHEFkZGSmlvXhhx/ijTfeMAcKDRo0wPvvv28qzrjTrl07M57XVdeuXfHrr7+mXq158sknTRdUDtupWrUqHnjgAdx9992ZWi8RERF3jick4YcV9rK4A1QWN1ev7vBYgQc4JUuWzLD3RkaYG2T16tVYsGBBuvOxAp5VBY8YAGEv2I8//hgvvPBClt9/2LBhpvesY0+QihUrmvsdOnQwPW7FP753PIlQm/gPtYnvheyIBnaMznC+hq07oUEV9QTxhWD9O4l36FWZ7UGQNm3amPGu1s6fY2V5RYWJwa688kqvlzNx4kRzAMBEYuw2yjG1TCTGTO0co+vqhx9+wNmzZ1MfM8jBwEmvXr1Sp3F5f/zxB8aNG2dK+LLXyr333oty5cqhR48eWfm4IiIiqSYv34XTScmoVbowLqt2cSfikr4TJ06Y/fmECROwdOlScwzAHBw87mAvDCY1vfPOO01i9swYMmQIfvnlF8ybNy9Nr9aM8GCyUaNG2Lx5s3ls5QrZv3+/qQ5j4eOGDRt6XA4vGnm6cMT3CKaD1kCgNvE/ahMfqtYWiC5nT4JqcoC4F77iC6BCQyC/Ssj7SrD9nUR4+VmzVB2GwY5PPvkEXbp0MQckjz/+uOlKyoOJ1157zevlvP3227jjjjswaNAgxMbGmmAIe5iw26k7vOrDgw3rxugW53cMgixcuBADBgwwvUYYBOHBEQMlPHgSERG52LK4Y8+XxWUvEJXFzTk8RuB+fMyYMSbfBnt4rlq1Chs3bjS5NkaMGIFz586ZQEjnzp29KknLAAoDIFOmTDEXTNhbNLOSk5Px33//pQY8uAwek8yePdvpShSrxDj2IBERyTOY7LSzdc4X4vLk+cchocC6n4HRlwPb0+9xJ5LbshQEYcCDByGtW7c2mdA5POb666/HypUrUb16da+WweAJs7E7JhILDQ01j3lw443PP//cJBxjKTrHbqo///wz9uzZYw52WMGG68qDJBERkYsxZ8MB7DySgOiocPRspLK4Oenvv/82F1d4EePZZ581PUXr1auHGjVqmGGzt912mwmQcIhMz549MX/+fK+GwLBnyfjx41G4cGHzWt5Onz6dOk///v3NUBXL888/b3qVbt26FStWrMAtt9xi8p/dfvvt5nkGwphb5MUXXzTHHwyQcBnsgcr1EhHJk2J7AL3HAtEXesAZ7CHS+2vg9ln2srrxe4AvrwFmjQSSgytJp/ivLA2HsTKfP/3001l+40OHDpmrKe4Sia1fvz7D1/OgiGN5GQhxxJwi7P3B7q3h4eEmsPLpp5+mW/pOGdoDQ7BmOfZnahP/pHbJOWP+2mb+79WkPCJCbF7/HgVjm1zsZ/3222+9mo9DSrzN+zV6tH0MO3uLOmIwZeDAgeY+K9/x2MFy9OhR02uVwZKiRYuiSZMmptcpe7Ba2COWF4R4/HHs2DFzkYjleKOiorxaLxGRgA2E1O5mqsAwCWrDNp0QzqEyVlncu+YD054AVo4DFrwNbP0TuOFzoLh3F81F/C4Iwp08AxEHDhww+UAc8QpITmPwg1eEXJOoMgiyePFiczWG5ex4FYlXfnhFxrHXiSNlaA8swZblOBCoTfyT2iV77T8NLNgcjhDYUD5hC377bYvaJBsytGcFh5twOAsrtzBJqbfYQzQjc+bMcXr8zjvvmFt62BuEPUZ4ExEJKqFhpgwuq8A0YDlcKwBCkYWAaz8EarQHpj4I7F0JfNQG6PIa0OgW/nj6cs0liGUpCDJ16lTcfPPNphJLdHS005ho3vcmCFKiRAmEhYWZxGGO+NhKMuYJr7YwSZrrwQa7sz711FNmrG+3bt3MNJa04xhilrTzFARRhvbAEKxZjv2Z2sQ/qV1yxshf1gHYhatql8Kt1zdSm2RThnZv9O7d2/ToZD4P7uubNm2K7du3m6AGjwduuOGGbHsvERHJZnWuAyo0A364C9ixAPh5CLB5FtB9lJKmSuAEQR555BEzFvfll192WyrXG/ny5TNdSplIzBozyx4lfMyDnPRMnjzZDGHhuFzXA3/eHLuxEoMtrr1VHClDe2AJtizHgUBt4p/ULtnnRGISpqzca+4Purxaln+DgqlNsvNzslenNQSXFzoY/GCP1K+++srk4lAQRETEz8VUAAb8DPw1CvjzZWDtj8Duv4HrPwFURlcCITEqk44+8MADWQ6AOJazZb4OHsSsW7cO99xzj+nlwWox7pKTOQ6FYeCkePHiTtPZK+WKK67AY489Zrqzbtu2DV9++aUp53vddddd1LqKiEjw+m75bpw6m4wapQrh8hrO+x7JecePHzcV4oi5Nhj04DEIe316UxVGRET8AIfKtHkEGDzDc9LUlGRg23zgv+/s//OxiD/0BGGG9mXLlqFatWoX9eZ9+vTBwYMHMXz4cJNwrGHDhubgxkqW6pqcjDZs2IAFCxaYTO3usFssAyccrnPkyBGTF+Sll17yOmmaiIiIoxTHsrgtK6ssrg9UrFjRVI5jIITHCdzXW0lLlXxURCTAlG/iJmnqHKBBP+Cvd4B4e8/L1GozLMfLJKwivgyC8MoLe1usXbvWJCd17fLao4f3X1IOffE0/MU1ORkxCVp6ic2YT4RZ3kVERLLDvE0Hse3QKRSODMf1jStoo/oAS9Dy4kahQoXMxQ2ruguHyfA4REREAkyapKkr7DdX8XHApP72crwKhIgvgyAsFUfusqAzMSpL34qIiOQFXy3cbv7v1bQiCkZmuaiaXIR7770XLVq0MD1EmRzb6iXKHqns7SkiIgGcNLVcY+CDpkDyWTcz8OJ3CDDtSVOO16n6jEhu5gRhklFPNwVAREQkr2APkD83HDRV/Pq3rOzr1QlavOjCUrjM78XeIJarrroKs2bN8um6iYjIRTq200MAxGKz5w/ZsVCbWnwXBHGUmJiYPWsiIiLiZ8YusvcCaVezJKqUKOjr1QlaI0eOxMmTJ9NMT0hIMM+JiEgAO7k/e+cTyYkgCHt7vPDCCyhfvry5IrN161Yz/dlnnzWVW0RERALdqTPn8N2y3eb+gFZVfL06QY25wDjc1tU///yTWjVGREQCVKHS2TufSE4EQTj+lqVnX3/9deTLly91et26dfHZZ59lZZEiIiJ+5YcVu3HizDlULVEQbS8p6evVCUpFixY1QQ4GQGrWrGnuW7eYmBiTH6R3796+Xk0REbkYlVvZq8Aw94cnIWFARH5tZ8kWWcrwNnbsWHzyySe4+uqrnUrPNmjQAOvXr8+eNRMREfGB5BQblm47jA/+3Gwe33JZJYSGpnNgJjlm1KhRphfIbbfdZoa9MPBh4UWYKlWqoGXLlmoBEZFAxmSnLIPLKjAmEOKmEqgtGRjTBej0MtDsdlbj8MWaSjAHQfbs2YMaNWqkmc7EqElJSdmxXiIiIrlu2uo4jJy6FnHHL+S7+mTeVpQvkh+d65ZVi+SyAQMGmP+rVq2KVq1aISIiQm0gIpIXsfwty+BOewKI33thenR54KpngXVTgQ2/Ar89CuxcBHR/F4gs7Ms1lmALgsTGxmL+/PmoXNk5U/53332HRo0aZde6iYiI5GoA5J5xK9JcfzoQf8ZMH31LYwVCclF8fDyio6PNfR5bnD592tzcseYTEZEAD4SwDC6rwDAJKnOAcKgMe4o06Ass+gCYOQJY/T0Q9689aFI61tdrLcESBBk+fLi5OsMeIez98cMPP2DDhg1mmMwvv/yS/WspIiKSw0Ng2APETQdcM42dbvl8h9gyCNPQmFzLBxIXF4dSpUqhSJEibhOjWglTmbBdRETyAAY8qrZJO537gFb3AxWaAZMHAYc3AZ9eBVzzNtDwJl+sqQRbEOTaa6/F1KlT8fzzz6NgwYImKNK4cWMzjUnKREREAsnSbUechsC4C4Twec7XsnrxXF23YPXHH3+kVn75888/fb06IiLiDypdBtw9H/jhDmDLH8CP99h7jnR9Q4lTJWeDINSmTRvMnDkzqy8XERHxGwdOJGbrfHLxrrjiCrf3RUQkyBUsAdz8HTD/LeDPl4GVXwN7VwK9vgJKpM1bKZItJXJvv/12zJkzJysvFRER8TulCkdl63yS/Y4ePYo333wTgwcPNre33noLR44c0aYWEQnWYTNXPA70/xEoWBLYvxr4pB2wZoqv10zyahDk4MGD6Ny5MypWrIjHHnsMq1atyv41ExERySUb98en+zyzUZSNiULzqvbhGZK75s2bZ8rhvvfeeyYYwhvvs2oMnxMRkSBVrR1w13ygUivg7Alg8kDgt8eBc2d9vWaS14IgP/30k0lW9uyzz+Lvv/9GkyZNUKdOHbz88svYvn179q+liIhIDpm+Zh+em7o29bFr+k3r8YjusUqK6iP33Xcf+vTpg23btplk7Lxt3boVffv2Nc+JiEgQiy4LDJgKXP6Q/fHSj4ExnYFjO+2PU5KBbfOB/76z/8/HEtSyFASxsrbfeeedZljMjh07MHDgQHz99deoUUPjsEREJDAs33EUD3y7EjYb0K95RYy+uTHKxDgPeeFjlcf1rc2bN+ORRx5BWFhY6jTeHzp0qHlORESCXFg40GEk0G8iEFUE2LMc+KgNMGskMKou8NU1wPeD7f/z8dqffb3GEoiJUS1JSUlYtmwZlixZYnqBlC5dOnvWTEREJAdtPXgSt3/1N86cS8FVtUvhhWvrIjwsFB3rlDFVYJgElTlAOARGZXF9ixXo1q1bh1q1ajlN57QGDRr4bL1ERMTP1OoM3DXPPixm7wpgwdtp54mPAyb1B3qPBWJ7+GItJVB7grBc3R133GGCHuwFEh0djV9++QW7d+/O3jUUERHJZgxwDBizFEcTktCgQgw+uKmRCYAQAx4sg3ttw/LmfwVAfOPff/9NvT3wwAN48MEHTWLUBQsWmBvvP/zww+bmrVdeeQXNmjVD4cKFUapUKfTs2RMbNmxI9zWffvqpqYjHHrC8tW/fHkuXLnWah8dBISEhTjfmThMRER8oWhkY+BuQr2A6he8BTHtSQ2OCVJZ6gpQvX95kZOcO/pNPPkH37t0RGRmZ/WsnIiKSzU6dOYfBXy7DriOnUbl4AXw+sBkK5LvojpGSzRo2bGiCCTaOVTrv8ccfTzPfTTfdZPKFeGPu3LkmhwgDIefOncNTTz2Fjh07Yu3atShY0P3BMof99uvXD61atUJUVBRee+0185o1a9aY4yELj4nGjBmT+ljHRSIiPrRnGXD2VDoz2ID4PcCOhUDVNrm4YuIPsnTU99xzz6FXr14oUqRI9q+RiIhIDklKTsG936zAf3uOo1jBfPhqUHOUKKQgvj9iEtTsNm3aNKfHX375pekRsnz5crRt29bta7755hunx5999hm+//57zJ49G/3793cKepQpUybb11lERLLg5P7snU/ylCwFQTgMRkREJJCwR8FTP/yHuRsPIioiFJ8PaIoqJTx1lRVfq1y5co6/x/Hjx83/xYp5X/o4ISHB5ENzfQ17jDCgwiEzV111FV588UUUL14829dZRES8UKh09s4nwRkEuf76680VE+b+4P30sHSdiIiIP3ln1iZMXr4boSHAhzc1RqNKRX29SpKOxYsX47LLLvM6MMGeI3Xq1PF6m6akpOChhx7C5Zdfjrp163r9uieeeALlypUzuUEch8Lw2Khq1arYsmWLGWbTpUsXLFq0yKmijaMzZ86YmyU+Pj71PoMs4h+stlCb+A+1if/xyzYp1wzhhcsBJ+IQYuUAcWGLKIBzpRtwxZHX+GWb5AJvP6/XQZCYmBgzNpcYCLHui4iI+Ltvl+7Ee7M3mfsv9KyLqy/VlR9/d+utt6JatWq4/fbb0bVrV7c5O5jLY9y4cSYXB3N1ZCYIwtwgq1evNklWvfXqq69iwoQJptcH84NY+vbtm3q/Xr16qF+/PqpXr27mu/rqqz0maR05cqTb52bOnOn1OknuUJv4H7WJ//G3Nilb4gY0O/G+CYE4nrlaIZGQpAQc/197/F31AZwNL4y8yN/aJKfxoki2BkEck32xR4iIiEgg+GP9fjzz42pzf8iVNXBzi5wfZiEXjwGO0aNH45lnnjHJT2vWrGl6YDD4cPToUaxfvx4nT57EddddhxkzZpjgg7eGDBliKtrNmzcPFSpU8Oo1rEbDIMisWbNMkCM9DN6UKFECmzdv9hgEGTZsGIYOHerUE6RixYrmfocOHRAREeH155GcvarIkwi1if9Qm/gf/22Trkhe3wRhM54CTuy9MDm6PFLq9UHosk9R4uQGdN71Bs71GQ+UqIm8wn/bJGc59qrM9pwgHOvKIS+uiVH5piw398cff2RlsSIiItnqn13HcN83K5GcYsMNjSvgkY555wAnr+NBG0vj8rZs2TLTY2PHjh04ffo0GjRoYErjXnnllZnK58G8MPfffz+mTJliemlw+Io3Xn/9dbz00kuYPn06mjZtmuH8u3fvxuHDh1G2bFmP8zCRqqcKMvzswXTQGgjUJv5HbeJ//LJN6l0H1OlhrwLDJKiFSiOkciuEhYYBDfoA43sj5Nh2RHzZBej9JVD9KuQlftkmOcjbz5qlIAgPHM6ePZtmemJiIubPn5+VRYqIiGSrHYdP4bYv/8bppGS0uaQEXr2hnoZyBigGHrwJPngzBGb8+PH46aefULhwYezbty91yG/+/PnNfVZ8YelbDlchDrMZPny4eV2VKlVSX1OoUCFzY28UDmu54YYbTHUY5gRhKd8aNWqgU6dOF73OIiJykRjwcFcGt1Rt4I4/gAk3A7sWA+NuBLq8BjRXEZC8LlNBkH///depm6p1IEDJycmm9BwPHERERHzp8MkzGPDFUhw+dRZ1ykVj9C1NEBEWqkYJchxeQ+3atUsz5HfgwIHm/s6dOxEaGur0Gl74ufHGG51eM2LECDz33HMm8SmPj7766iscO3bMDNnp2LEjXnjhBY89PURExE8ULAEM+BmY+iDwz7fAb48ChzYBnV4GwrLUX0ACQKZatmHDhuYqGm8cEuOKV1Hef//97Fw/ERGRTDl9NhmDv1qG7YcTUL5IfowZ2AyFInUgI/bhMN70dnW0ffv2dOfnsQ+HyYiISIAKjwR6jrbnBJk9Elj6MXB4M9BrDBAV4+u1kxyQqaNClp/jAQQTfi1duhQlS5ZMfS5fvnwoVaqUx1JwIiIi2Y25PpZuO4IDJxJRqnAUGlcqgvu/XYFVu46hSIEIfHVbc5SKvlDFQ0RERCQNVj5tMxQoXgP44U5gy2zg847ATROBolW0wfKYTAVBKle2Z9RPSUnJqfURERHxyrTVcRg5dS3ijiemTiuQLwwJZ5MRGR6Kz/o3RY1ShbQ1RURExDuxPYAiFYFv+wEH1wOfXgX0+Qao3FJbMA/J0gBpJgv74osv0kznNCYQExERyekAyD3jVjgFQIgBEBrYqgqaVvG+aoiIiIiIUa6RPWFq2QZAwmFgbA/gnwnaOHlIlgZJf/zxxyZLuqs6deqgb9++eOKJJ7Jj3URERNwOgWEPkPSyO/z8z1483rk2wkJDtAUD2HvvvefVfCyjKyIikm2iywGDfgem3AWsm2r//+AG4KpnmWHKqeQuKreyV6CRvB0EYVWYsmXLppnOHCFxcXHZsV4iIiJuMQeIaw8QV3ye87WsXlxbMYC98847Gc7DZO0KgoiISLbLVxDoNRb480Vg/lvAgreBbfOA+D3AiTjngEnn1+xDaSTvBkEqVqyIv/76C1WrVnWazmksDSciIpJTmAQ1O+cT/8WE7CIiIj7DkulXD7dXjvnpPmDPsrTzxMcBk/oDvccqEJKXc4LccccdeOihhzBmzBjs2LHD3JgP5OGHHzbPiYiI5BRWgcnO+URERETSVa8XEFXEw5PnB+hOexJIsecmkzwYBHnssccwePBg3HvvvaZcLm/333+/6Y46bNiw7F9LERERAEdOncW3S3ekuy2YBaRsTBSaV1Vi1EDXtWtXHD9+PPXxq6++imPHjqU+Pnz4MGJjY320diIiEjSYAyThUDoz2OzDZDif5M3hMBx/yyowzz77LNatW4f8+fPjkksuQWRkZPavoYiIBD2bzYbf/tuH4T+txuFTZ02gg9ddrP9T90/n/x/RPVZJUfOA6dOn48yZM6mPX375ZfTu3RtFitivxp07dw4bNmzw4RqKiEhQYBLU7JxPAi8I4pgg9ciRI2jbtq0JgPAglQESERGR7MLcHsN/XINpa/aZxzVLF8IbNzZA3PHTpkqMY5LUMjFRJgDSuW7a5N0SeHhckd5jERGRXMEqMNk5nwTecBh2P7366qtRs2ZN01XVqgjDITKPPPJIppb14YcfokqVKoiKikKLFi2wdOlSj/O2a9fOBFlcb926dXOaj71TevTogZiYGBQsWBDNmjXDzp07s/JRRUTER3jCO2XlbnR8Z54JgISHhuCBqy/B1Ptbo0HFIibQseCJq/DtHZfh3b4Nzf98rACIiIiIZCuWwWUVmNQ+p24wZwjnk7wZBGEC1IiICBNYKFCgQOr0Pn36YNq0aV4vZ+LEiRg6dChGjBiBFStWoEGDBujUqRMOHDjgdv4ffvjBBFys2+rVqxEWFoZevXqlzrNlyxa0bt0atWvXxpw5c/Dvv/+aYTsMsoiISGBgL4/BXy3DwxP/wbGEJNQpF42fh7TG0A41ERkeljpfWGiIKYN7bcPy5n8+lrzDutjhOk1ERCRXhYbZy+Da90Tu50k8Bvw1KjfXSnJzOMyMGTPMON0KFSo4TWdeEFaK8dbbb79tqskMGjTIPP7oo4/w66+/mkozTz75ZJr5ixVzTnI3YcIEE4RxDII8/fTTpnfK66+/njqtevXqmfp8IiLiu94fE//ehZd+XYcTZ84hX1goHmx/Ce5sWw0RYVmK20uAfx8GDhyYmnMsMTERd999t+nlSY75QkRERHJUbA97GdxpTwDxey9Mjy4PVGgKrP0JmP08kBgPtH+OUXs1SF4Kgpw6dcqpB4iF+UG8TY569uxZLF++3KmaTGhoKNq3b49FixZ5tYzPP/8cffv2TT0YSklJMUGUxx9/3PQoWblyJapWrWreo2fPnh6Xw4MoxwOp+Pj41PtJSUlerYvkPKst1Cb+Q23inwK1XXYfPY2nf1yDhVuPmMcNK8bglZ51UKNUIVNyLimAy84FaptcjOz4rAMGDHB6fMstt6SZp3///hf9PiIiIl4HQmp3s1eBYRJU5gDhEBj2FPnrPWDms/beIInHgW5v2adL3giCtGnTBmPHjsULL7yQ2jWVAQj2vrjyyiu9WsahQ4eQnJyM0qWdk8fw8fr16zN8PXOHcDgMAyEWDqM5efKkKaH34osvmgo2HJ5z/fXX488//8QVV1zhdlmvvPIKRo4c6fa5mTNnevV5JPeoTfyP2sQ/+WO7pNiALfEhiE8CoiOA6tH2RJcL9oVg6s5QnE0JQUSIDd0qpeCKsoexcdk8bETe4Y9tklMSEhIuehljxozJlnURERHJNgxsVG2TdvrlDwBRMcDUB4HlY4Az8cB1HwNhEdr4eSEIwmAHE6MuW7bM9Ohgz4s1a9aYniB//fUXcgODH/Xq1UPz5s1TpzEQQ9dee63JW0INGzbEwoULzVAbT0EQ9hRhbhLHniAVK1Y09zt06GDyn4h/XFXkCYTaxH+oTfyTv7bL9DX78cpv67Ev/kLPuxKF8iEmfzi2HLSfMDerUhQv94xFleL2Hn55hb+2SU5y7FUpIiISFJoMACILAz/cCaz+HjhzEuj9FRCR39drJhcbBKlbty42btyIDz74AIULFza9L9jb4r777kPZst6VJSxRooRJarp/v3MtZT4uU6ZMhsNxmA/k+eefT7PM8PBwxMbGOk2/9NJLsWDBAo/L4xAeT8N4eLAaLAesgUJt4n/UJv7Jn9pl2uo43D/hH7gWOD108qy55QsPxbPdLsXNLSojNA8nN/WnNslpwfI5RUREnNS93h4ImXgrsGk6MO4GoN8EICpaG8pPeJ1ljkEO66oOh8Kw2gqTkE6aNAm//fabGX7ibQCE8uXLhyZNmmD27NlOPTn4uGXLlum+dvLkySaHh+vYYC6T5XA3bNjgNJ0Bm8qVK3u9biIikn2SU2wYOXVtmgCIoyL5I3BTHg+AiIiISJC4pANw6w9AZDSw4y/gq+7AqcO+XivJbBDkl19+MT0wiNVcjh8/jovFISiffvopvvrqK6xbtw733HOPeQ+rWgyTnTkmTnUcCsNEp8WLF0/z3GOPPWZK73K5mzdvNr1Vpk6dinvvvfei11dERDJv6bYjiDuemO48B06cMfOJiIiI5AlMmDpgKlCgOBC3ChjTxbmqjPj/cJjatWubgAQTn7JkHXuAREe779Ljbab2Pn364ODBgxg+fDj27dtn8ncwkamVLHXnzp2mYowj9vLg0BaW6XXnuuuuM/k/mOz0gQceQK1atfD999+jdevW3n5UERHJJnHHT+PLhdu9mvfAifQDJSIiIiIBpVxDYNA04OuewKENwBedgFt/BIpX9/WaBTWvgyCjR4/GI488YkrQshrMM888Y/53xWmZKVc3ZMgQc3Nnzpw5aaYxqMEgTHpuu+02cxMRkdyXkmLDwi2H8fXi7Zi17oAZDuONUoWjcnzdRERERHJVyZrAbdOAsdcCR7bae4TcOgUoXUcN4e9BkMsvvxyLFy8299k7g3k2SpUqlZPrJiIiAeR4QhImL9+F8Ut2Yush+/BJal6lKDYeOGmedxcOYTi9TEwUmlctlqvrKyIiIpIrilSy9wgZdz2wfzUwpitw83dAxWZqgEBJjDpmzBhTFUZERPI29uJYtOUwflq1x/zvrlfHf7uP4/Hv/kGLV2bhxV/XmQBIochwDGhZGTMebotJd7fCq9fXM/O69h+0Ho/oHoswJUWVHMahskygzmMYXshhfjHXZOqeErJzWDCTwterV88khHfEHqoc2ssE8fnz50f79u2xadOmHPwkIiIScAqXBgb+AlRoDiQes/cM2ToHSEkGts0H/vvO/j8fi3/0BLESozIPCIeadOnSxezoRUQkb2JZW1Z1cUxqWjYmygQs2tUqhan/7MW4xTvwz+4LibJrlymMW1tWRs+G5VEw8sIupnPdshh9S+M0yytzfnl8XiSnzZ07F/fdd58JhJw7dw5PPfUUOnbsiLVr16JgwYJuX7Nw4UL069fPBFCuueYajB8/3gRPVqxYgbp165p5Xn/9dbz33nsm0XvVqlXx7LPPolOnTma5DJyIiIgY+Yvah8JMvNkeAGH5XFaQOe2QHD66HND5NSC2hzZaXkyMKiIi/hsAuWfcijTDVxjAuHvcChTIF4aEs/YrFfnCQtG1XhkT/GhcqajbfFHEQEeH2DKmCgyToDIHCIfAqAeI5BYmX3f05Zdfmh4hy5cvR9u2bd2+5t1330Xnzp1N9Tl64YUXMHPmTFN9jonYeUw0atQokyvt2muvNfOMHTvWJHn/8ccf0bdv31z4ZCIiEjAiCwE3TbLnBtmz3DkAQvFxwKT+QO+xCoT4OgjCHT1L2mZ3YlQREck+HK6yZNsRLD8UguLbjqBljVKZDjJwGeyxkV46UwZAyheJwi2XVUHvphVQvFCkV8vmurSsnra8uYgvHD9u78VUrJjnfDSLFi0yxz+O2MuDAQ7atm2bqXDHITCWmJgYtGjRwrzWUxDkzJkz5maxhhxTUlLSRXwqyU5WW6hN/IfaxP+oTbIgxYbw8+Vy0x6l2WDj1GlP4lz1jkBomNrES97+VnsdBGnVqpUSo4qIBMzwlTCM3bQsdfiKN8NNTiQmYfuhBMxcu89pyIonr9/YAJfXKJFNay+Su1JSUvDQQw+ZxO/WsBZ3GOBgrw5HfMzp1vPWNE/zuMPhNSNHjnT7HHuaiH9Rm/gftYn/UZt4r/iJdWh9Is7j8yG8FBW/B0smj8LhwpeqTbyUkJCQvUEQR7zqwURivDKydetWkzCsfPny+Prrr81Y2NatW2dlsSIiQYU9LrJraIin4Sv7jiea6czHwUDIyTPnsP3QKWw7dAo7DvP/BGw/bL9/6OTZTL3noZMXrmKLBBrmBlm9ejUWLFjgk/fnEGPHHibsCVKxYkVzv0OHDoiIiPDJeknaq4o8sVOb+A+1if9Rm2ReyJrTwOaM57usbhXY6nRVm3jJsVdltgdBli1bhltvvRU333yzSQxmdedkt9KXX345TdZ0ERHxPuloZpOEpjd8xZp2/7crER21GodPpR/oKFEoH4oVzIeN+09m+L4M3IgEoiFDhpiE7/PmzUOFChXSnbdMmTLYv3+/0zQ+5nTreWsaq8M4ztOwYUOPy42MjDQ3dxgAURDEv6hN/I/axP+oTTIhprxXs4VzvosIigdbm0R4+VmzFAR58cUXTY4Q5v6YMGFC6nR2KeVzIiJy8b023GESxiOnzmLPsdPYc/S0+f/v7UcyHL6SlGxLDYAUL5gPVUoURJXivBUw96uWKIjKxQugcFSECaq0fu0Psz7uAish56u6sOeKSCDh38/999+PKVOmYM6cOab3akZatmyJ2bNnm6EzFvYM4HTiMhgI4TxW0INXopYsWYJ77rknBz+NiIgErMqt7FVgmATVUxa2qCL2+STbZSkIwqEw7rKoMxHYsWPHsmO9RETypIx6bTDAMPynNSiSPx/i4i8EOvYcS8SeownYeywRp5OyVj/+0Y610L9VZURHpR8l55Ac9khhQIbr47iu1mAdPq+qLhKIQ2BY4vann35C4cKFU3N28Pglf/785j4v8HCIL3N20IMPPogrrrgCb731Frp162Yu/rBH7CeffJKaEJ4BEl4EuuSSS1JL5JYrV86U0hUREUmDyU5ZBpdVYNIcbZ2XeAz451ug0S3agP4QBOEVj82bN6NKlSpO0zmutlq1atm1biIieQ5zgKTXa4O7wAMnzqDvp4vTXU6pwpEoXzQ/yhfJDxbqmvqP5+RaliaVi2YYALGwJwp7pLgO2SmTxSE7Iv5g9OjR5v927do5TR8zZgwGDhxo7u/cuROhoaFOieEZOGFVvKeeesoEOlgZxjGZ6uOPP45Tp07hzjvvNBeDmBuN5XijojRkTEREPIjtYS+DO+0J4HylGCO6PFAqFtg8E/hpCBASBjTsp83o6yDIHXfcYa6MfPHFF+YKyN69e00ZuEcffdRc/RARkbSSklOwaMshrzYNh6zULF04NdDB/ysUyY9yRfKjbJEoRIaHOfUuWbb9aLYPX2Ggo0NsmWxL3iriD8NhMsJhMq569eplbp7wWOj55583NxERkUwFQmp3A3YsBE7uBwqVtg+BCQkFfn0EWPY58OM99p4j9Xtrw/oyCPLkk0+a0nJXX321KUPDoTFM7sUgCMfaiojkRVmp5nLwxBnM2XAAczYcxLxNB3Ei8ZxX7/XBTY3Rsnpxr+bNyeErfI236yEiIiIimcQAR9U2aad3fROwJQPLvwSm3GUPjNS7UZvXV0EQXvF4+umn8dhjj5lhMSdPnkRsbCwKFSqUHeskIhKw1VxSUmz4d89x/LGegY8D+Hf3caflFC0QYXJ6JCaluH2fi+m1oeErIiIiInkEh2Z2ewdIOQesHAf8cKc9YFLnOl+vWXAGQSz58uUzwQ8RkWCu5vJmrwbIFx6KP9cfwNyNB9OUoa1XPgZX1iqJK2uXQv0KRTBz7T7zOmRzrw1r+MqizQcwY/4SdGzTAi1rlNLwFREREZFADYR0f59X2YB/xgPfDbbnCOEwGvFNEEREJNirudAjk/9xml44MhxtapZAu1ql0K5WSTN0Jrd6bTB40qJqMRxeZzP/K3+HiIiISIAHQq79wD405t+JwHeD7AlVmUtEskRBEBHJs7KSwyOz1VwsFYpGoVu9cibw0bRKUUSEXagu4Y6SjoqIiIiIVzgMpudoICUZWP0dMGkA0GccUKuzNmAWKAgiIkGdw8M1aLL98Cms3RuPdXHxWBsXjxU7j3r1fo91qo1rG5bP1Doq6aiIiIiIeB0Iue5je4+QNVOASbcCfccDl3TQBswkBUFEJOhyeHAoSptLSmL9vhOpwQ4GPjbsO2GSlmaF65AXEREREZFsFRYOXP+pvUfIup+BCTcD/cYDNdprQ2eCgiAiEnQ5PO4bv9LM505URChql4lGbLloXFo2GrVKF8b9367AgfgzbpeZ1WouIiIiIiKZFhYB3PgFMHkgsP6X84GQCUD1K7UxvaQgiIjkKd7k8LACIKWjI02gI7asPeDBwEeV4gXT5A0Z2aOO6UESks3VXEREREREshYIGQNM6g9s/B34th9w8ySgalttTC8oCCIieUJKis3k7xg9Z7NX87/Usy5uvqyyV/PmZDUXEREREZFMC88H9P4KmHgLsGkGML4PcPNkoFJLhOxYgPJHFiFkRzRQra09n4ikUhBERAI68LFy11H88m8cfv9vH/bFZ1zFxVKtZKFMvZequYiIiIiIXwmPBHp/DUy4CdgyG/j6eiCyMMITDqEpn98xGoguB3R+DYjt4eu19RsKgohIQJW0tQc+juFXBj5Wxzn1zCgcGY72l5bCnI0HcSwhKdtzeKiai4iIiIj4lYgooO83wGftgf2rgYQzzs/Hx9mHzfQeq0DIeQqCiIjfl7TtVKfMhcDHf3HY6zBPochwdIgtjW71yqJNzRKIDA9LrQ6jHB4iIiIikueF5QMSDnt4kpcFQ4BpTwK1u2lojIIgIuLPJW0ZELl73AoUK5APRxLOpk4vmC/MHvioXw5tLimBqAjncY7K4SEiIiIiQWPHQuBEXDoz2ID4Pfb5qrZBsFNPEBHx25K2FgZACkSEokOdMuharyyuqFkyTeDDlXJ4iIiIiEhQOLk/e+fL4xQEERG/L2lLo29tgitqlsrUspXDQ0RERETyvEKls3e+PC7U1ysgIsFr99EEfLZgq1fzMtGpiIiIiIi4qNzKXgXGZMTzILq8fT5RTxARyV02mw0LtxzGlwu3Y/a6/UhJbxyMA1aLERERERERF6Fh9jK4rAKTpjTAeW0fVVLU89QTRERyxakz5/D1ou3o8M483PzZEsxcaw+AtKpeDEULRHiMW4ecrxKTlZK2IiIiIiJBIbaHvQxudFnn6WER9v//mQAkn/PJqvkb5QQRkSwnNF2y7QiWHwpB8W1H0LJGKZODw9XWgycxdtEOfL98N06csf/wFsgXhhsaV8CAVpVRo1RhlbQVEREREcmOQEjtbji3dR5WzZ+Ohm06IbxoJeCTdsCuJcCcV4Crnw367awgiIhkqaQtK7rYE5qGYeymZaa3xojusaYqS0qKDXM2HsCXC3dg3saDqa+rWqIg+resjBuaVEB01PmotEraioiIiIhkj9Aw2Cq3xp418WhQuTUQEQF0HwV8dxsw/y2galug2hVBvbUVBBGRTAdA7hm3Is1Iw33HE830GxqXx9LtR7HzSIKZHhICXFWrFPq3qoI2NUog1E1vEVJJWxERERGRHFD3BmDrXGDFV8APdwB3/wUUKhm0m1o5QUQkU0Ng2APEXS5T2/nbdyv2mABIdFQ47mhTFXMebYfPBzbDFTVLegyAuJa0vbZhefO/u+E1IiIXY968eejevTvKlSuHkJAQ/Pjjj+nOP3DgQDOf661OnTqp8zz33HNpnq9du7YaSkRE/EfnV4GStYGT+4Ef7wFSUhCsFAQRCaIAxqIth/HTqj3mfz7OrKXbjpwfApM+Bj8WP3U1nu4Wi8rFC2ZxjUVEst+pU6fQoEEDfPjhh17N/+677yIuLi71tmvXLhQrVgy9evVymo9BEcf5FixYoOYTERH/ka8AcOMXQHgUsHkmsPh/CFYaDiMSdDk87BxzeHjCQMm2Q6ewNi4ea/fGY86GA169X93yMSiQTz8vIuJ/unTpYm7eiomJMTcLe44cPXoUgwYNcpovPDwcZcqUydZ1FRERyVal6wCdXgZ+HQrMeg6o3Aoo3zjoNrJfnKXwaswbb7yBffv2masz77//Ppo3b+523nbt2mHu3Llppnft2hW//vprmul33303Pv74Y7zzzjt46KGHcmT9RQI5h8foWxqbQAhL2K7fd8IEPNadD3qs3xePxKTMd5UrVTgq29ZfRMSffP7552jfvj0qV67sNH3Tpk1miE1UVBRatmyJV155BZUqVfK4nDNnzpibJT4+PvV+UlJSDq29ZJbVFmoT/6E28T9qkwBrkwa3ImzLnwhdPxW2727DucF/AJGFkRd4+1vt8yDIxIkTMXToUHz00Udo0aIFRo0ahU6dOmHDhg0oVapUmvl/+OEHnD17NvXx4cOHTeDEtVsqTZkyBYsXLzYHJSLBKKMcHvTQxFUo+/t6bD+SAJubGfNHhKF22cKILRtt/h81cxOOnDrrdpnM4FEmJgrNqxbL7o8iIuJze/fuxe+//47x48c7Tefxy5dffolatWqZoTAjR45EmzZtsHr1ahQu7P7AkkESzufOzJkzc2T9JevUJv5HbeJ/1CaB0yYREV3RLmIhChzdhn2f34QVle+2VzMIcAkJ9sIMfh8Eefvtt3HHHXekditlMIQ9Or744gs8+eSTaebnOFxHEyZMQIECBdIEQfbs2YP7778f06dPR7du3XL4U4j4J29yeLCnx7bD9h+MUoUjEVsu2gQ8rP+Z08MxQWnJQpGmBwmnOAZCrDk4xEYJTUUkL/rqq69QpEgR9OzZ02m64/Ca+vXrm6AIe4pMmjQJgwcPdrusYcOGmYtAjj1BKlasaO536NABESxpKH5xVZEnEWoT/6E28T9qk8Bsk5DGlWEb2x0Vjy5C2ctvgq1BPwQ6x16VfhsEYY+O5cuXmwMBS2hoqOlmumjRIq+7pfbt2xcFC15IvpiSkoJbb70Vjz32mFP2dk/UJTUwBFtXO/biWLbjKA6cOGOCE00rF/U6uLDraAIWbTmCySv2eDX/nW2qYFCryihRKDLNcynJ55CSfOHx1bVK4P2+DfDib+uxL/5CV+4yMZF4uktt83ywtJG/Cra/lUAQjG2S1z6rzWYzF2h4fJEvX75052WgpGbNmti8ebPHeSIjI83NHR6wKgjiX9Qm/kdt4n/UJgHWJlUvB658CvjjBYRPfwKofBlQsiYCmbf7Tp8GQQ4dOoTk5GSULl3aaTofr1+/PsPXL1261HQ1ZSDE0WuvvWYSlD3wwANerYe6pAaWYOhq98/hEPywPRTHzl4IehTJZ8P1VVLQoHjagSjxZ4FN8SHYeNx+O3Imc93Z8h3egqXzPB+su/NELLAlPgTxSUB0BFA9+hSSdyzHbzsytRjJQcHwtxJogqlNvO2SGiiYj4xBDU89OxydPHkSW7ZsMQETERERv9X6YWDbPGDbXOC7QcDts4GIvJ/bz+fDYS4Ggx/16tVzSqLKniUsZ7dixQqEeDmuSV1SA0OwdLWbvmY/xiz6J03OjeNnQzBmY5jphdGyWjEs3X4Ui7YewaKth7HpwCmnecNDQ9CgQgxaVC2KCX/vxtGEpHRyeERiSJ+2WRrCEixtEmjULv4nGNvE2y6puY0BCsceGtu2bcOqVavMcFsmMuUxAYfUjh07Ns0xB4e51K1bN80yH330UXTv3t0MgWHekBEjRiAsLAz9+gV+12IREcnDQsOA6z8BRl8O7F8NzHwW6PoG8jqfBkFKlChhDhL279/vNJ2PMyozd+rUKZMP5Pnnn3eaPn/+fBw4cMApIzt7mzzyyCMm6er27dvTLEtdUgNLXu5qxyEwL/2+Id1Epg9P/hfnkm3O+ThCYPJ3tKpeHK1qlEDzKsVQMNL+512/YtEMcnjUQVRk+l27g7lNApnaxf8EU5v46+dctmwZrrzyytTHVl6OAQMGmOSmTGy6c+dOp9ccP34c33//vbnI4s7u3btNwIPJ2kuWLInWrVubxOy8LyIi4tcKlwGu+wj45kZg6SdA1SuAS69BXubTIAjH1DZp0gSzZ89OTTLGfB58PGTIkHRfO3nyZJPL45ZbbnGazq6nzCniiNVmON1KvioSyIlMk5LtoYxqJQqiVY3iuLx6CVxWrTiKFnQfyGD5W5bBZZUYx2WziguTmPJ5EZFg0a5dO5PfwxMGQlzFxMSkO7yHF2VEREQC1iUdgJZDgEUfAD/dB5RrCMRUQF7l8+EwvALDqy9NmzY1w1rYW4O9PKyARf/+/VG+fHmTt8O1WyoDJ8WLF3eazseu03g1ij1LWLpOxF/FJyZhxtp9Xs07skcsBrSq6vWyGejoEFvGBFkOnEhEqcL2Mraq4iIiIiIiIrh6BLDjL2DvSuD724EBvwBhPg8X5Aiff6o+ffrg4MGDGD58OPbt24eGDRti2rRpqclS2SWVFWMcbdiwAQsWLMCMGTN8tNYi7oeyZCbIwCuR6/edwJwNB/HnhgNYvuOoWYY3apaOznQTcF1aVncOEIqIiIiIiCA8H3DjF8BHbYGdi4B5r9urx+RBPg+CEIe+eBr+MmfOnDTT2KMjva6srtzlARHJTtNWx6UZblLWzXCTk2fOYcGmQ5iz4YAJfuyLdx76Uq1EAeyPP4NTZx1q0qZJZGoPsIiIiIiIiGSbYtWA7qOA7wcDc18HqrQBqrbJcxvYL4IgIoEeAGHiUdew3L7jiWb6s9fE4lxKCv5cfxDLdhxJzelBURGhJqdHu1ol0a5WKVQsViB1efCYyDRWw1hERERERCT71bsR2PonsHIc8MMdwN1/AQXzVm9yBUFELgKHr7AHSHrVXJ7/Za3T9KolCqYGPVpULYaoiDCn55XIVEREREREfKbL68CupcChjcBP9wJ9vrEPkTm5HyhUGqjcyl5eN0ApCCJBKbP5OzxZsvVwhtVcqEGFGPRsVN4EPhgEyYgSmYqIiIiIiE/kK2jPD/Lp1cDGacDr1YAzxy88H10O6PwaENsjIBtIQRAJOt7m73B19lwKNh04gTV747F2bzxW7zmO/3Yf8+o9b2tdFdc2LJ+p9VQiUxERERER8Yky9YAGfYEVXzkHQCg+DpjUH+g9NiADIQqCSFDJKH/H6Fsam0DIqTPnsC4u3gQ81uw9bv7ftP8kzianZOl92dtEREREREQkIKQkA5tneniSZ1MhwLQngdrdAm5ojIIgEjS8yd/x0MRVKDttPbYfToC7AkTRUeGoUy4GdcpFo075aNQuE41BY/7G/vhEt8tVNRcREREREQk4OxYC8XvTmcEGxO+xzxdgFWQUBJGgwRwgGeXvSExKwbZDCeZ+6ejICwGP8/9XKJofISHOuUOe6xFrepFwqqq5iIiIiIhIwDu5P3vn8yMKgkhQSEpOwbyNB72a9+4rquP2NlVRolCkV/OrmouIiIiIiOQphUpn73x+REEQybOYyPSvLYfw+39xmLF2P44lJHn1uitqlvQ6AGJRNRcREREREckzKreyV4FhElRPA//5POcLMAqCSMDk81iy7QiWHwpB8W1H0LJGKbclbc+cS8aCTYfw23/7MHPtPsQnnkt9rnjBCJxOSkHC2WS373Gx+TtUzUVERERERPKE0DB7GVxWgUkz8P+8zq8GXFJUUhBEAqykbRjGblrmVNI2MSkZ803gIw6z1u7HiTMXAh8lC0eiS90y6FK3rAluMDDC/B2k/B0iIiIiIiIesPwty+BOe8IlSWoIcP2nAVkelxQEkYAtaXv3uBVoVqUo1sWdwEmHwAcTmjLo0bVeWTSpXNSpx4jyd4iIiIiIiHiJgQ6WwbWqxcwcDpzcB5w6gEClIIgEdEnbv7cfNf+zZ4g98FEGjSsVRaiboTIW5e8QERERERHxEoe8WGVwzyUCUx8A/noPaDoYiIhCoFEQRPzW0m2HMyxpS89fWwe3tKicbuDDlfJ3iIiIiIiIZFKDfsDc14D4PcCqb4BmgxFoQn29AiKOjp9OMtVcnvjuXzPcxRsx+SMyFQARERERERGRLAjPB7R6wH7/r1FAsncVOP2JeoJIjg1lWbrtCA6cSESpwvaKK+6quaSk2LBmbzzmbjyAuRsPYsXOY+a1mcHli4iIiIiISC5o3B+Y/yZwbCfw33dAw34BtdkVBJEcruZi51jN5fDJM6aaC4Me8zYexOFTZ51eX71kQVxRsxTaXFICw374F/vjz3iqTH1RJW1FREREREQkk/IVAFreB8x6DljwNlC/DxAaOINMFASRXKnmwoAIh7dULl4AO48kwOYwQ8F8Ybi8RglcUask2l5SEhWLFUh97rkedczyXCtTW31KGFhx18NEREREREREckjTwcCCd4BDG4F1PwN1egbMpg6ccI0EdDUXy47D9gBIbNlo3NOuOibceRlWDu+IT/o3xc0tKjsFQBxL2rLHhyM+5nQ+LyIi4q158+ahe/fuKFeuHEJCQvDjjz+mO/+cOXPMfK63ffv2Oc334YcfokqVKoiKikKLFi2wdOlSNYqIiORdUdFAi7vt9+e9Caer3H5OPUEk2zAHiDfVXEbf3Bhd6nkfvLBK2i7afAAz5i9BxzYt0LJGKfUAERGRTDt16hQaNGiA2267Dddff73Xr9uwYQOio6NTH5cqVSr1/sSJEzF06FB89NFHJgAyatQodOrUybzGcT4REZE8pcXdwMIPgP3/AZtmADU7IRCoJ4hcNJvNhr82H8LLv631av6zySmZfg8OeWlRtRialLCZ/zUERkREsqJLly548cUXcd1112XqdQxmlClTJvUW6jD2+e2338Ydd9yBQYMGITY21gRDChQogC+++EKNJCIieVeBYkCz2wKuN4iCIJJlJxKT8NXC7Wj/9lzc/NkS/Lcn3qvXqZqLiIgEmoYNG6Js2bLo0KED/vrrr9TpZ8+exfLly9G+ffvUaQyQ8PGiRYt8tLYiIiK5pOX9QFgksHspsH1+QGx2DYeRTNt84ATGLtqB75fvxqmzyanJTa9rXB7TVu/D4ZNnVc1FRETyBAY+2LOjadOmOHPmDD777DO0a9cOS5YsQePGjXHo0CEkJyejdOnSTq/j4/Xr13tcLpfFmyU+/sKFhKSkpBz6NJJZVluoTfyH2sT/qE2CvE2iiiG04S0IW/45Uua+geQKLeEr3n5eBUEkNakpc3ocOJFoemo0dxlyci45BbPWHcDYRduxcMthp3K2A1pVwXWNyqNwVARa1yihai4iIpJn1KpVy9wsrVq1wpYtW/DOO+/g66+/zvJyX3nlFYwcOdLtczNnzszyciVnqE38j9rE/6hNgrdN8p+tg/YIQ+j2eVgw+T0cLVgDvpCQkODVfAqCiClry6oujklNy8ZEmfKzTasUw8S/d+GbxTuw9/zzjI20v7S0CX60ql7cZMl3rebiurwy55enai4iIhLomjdvjgULFpj7JUqUQFhYGPbv3+80Dx8zd4gnw4YNM8lUHXuCVKxY0dznkJuIiIgcW3/J3FVFnkSoTfyH2sT/qE38j0/aJGwZ8O94tE5ZjOSuD8AXHHtVpkdBkCDHAMg941akGb7CAMbd41YgPDQE51LszxYrmA99m1XEzZdVRvki+TOs5pJezxIREZFAtWrVKjNMhvLly4cmTZpg9uzZ6Nmzp5mWkpJiHg8ZMsTjMiIjI83NHR6wKgjiX9Qm/kdt4n/UJkHeJm0fAf6bgNDNMxB6eD1Qph5ym7efVUGQIB8Cwx4b6eXwZQCkfoUYDGhZBd3ql0VURJhXy2bAo2X14tm2riIiItnh5MmT2Lx5c+rjbdu2maBGsWLFUKlSJdNDY8+ePRg7dqx5nuVuq1atijp16iAxMdHkBPnjjz8wY8aM1GWwR8eAAQNM3hD2EuFrWIqX1WJERESCQokaQJ3rgNXfA/PfAnp9CX+lIEgQY08NxyErngzrcqkCGiIikicsW7YMV155Zepja0gKgxhffvkl4uLisHPnTqfqL4888ogJjLDsbf369TFr1iynZfTp0wcHDx7E8OHDsW/fPlNJZtq0aWmSpYqIiORpbR6xB0HW/AhcuQkocQn8kYIgQSolxYZ5Gw96NS+HtIiIiOQFrOxis3nuA8lAiKPHH3/c3DLCoS/pDX8RERHJ80rXAWp1BTb8Bix4B+j5P/ijUF+vgOSu46eT8MWCbbj67bkYPXeLV69hTg8RERERERGRdLV51P7/PxOAozvgj9QTJEisi4vH2EU78OPKPTidlGymFcoXhhSWEjprf+wq5HxVFyY1FREREREREUlXhSZAtXbA1jnAX+8C17wNf6MgSB6WlJyCaav34etFO7B0+5HU6bVKF8atLSvjukblMX/TQVMdhhw7B1t1XFjWVlVdRERERERExOveIAyCrBwHXPE4UNhzyXhfUBAkgCu7eCpBuz8+EeOX7MT4pTtx8MQZM43Pda5TxgQ/WlQthpCQkNRytqNvaWyqxDgmSWUPEAZA+LyIiIiIiIiIV6q0BipeBuxaDCx8H+j0EvyJgiABaNrqOLdBi5uaV8KGfScwfc0+U9qWShaORL/mlcxznMcdBjo6xJbxGFQRERERERER8QovuLd9FPjmRmDZGHvVmAL+k2JBQZAADIBw+IprXvt9xxPx9syNqY+bVSmK/i2roFOdMsgXnnH+WwY8WlYvngNrLCIiIiIiIkGlRnugbAMg7h9g8WjgqqfhL1QdJsCGwLAHiOfCfkCBfGGYOqQ1Jt/dCt0blPMqACIiIiIiIiKSrb1B2AOElnwMJB6Hv/CLM+QPP/wQVapUQVRUFFq0aIGlS5d6nLddu3Ymn4XrrVu3bub5pKQkPPHEE6hXrx4KFiyIcuXKoX///ti7dy8CHYerOA6BcYeVXk6eOZdr6yQiIiIiIiKSRu3uQIlawJnjwN+fwV/4PAgyceJEDB06FCNGjMCKFSvQoEEDdOrUCQcOHHA7/w8//IC4uLjU2+rVqxEWFoZevXqZ5xMSEsxynn32WfM/59+wYQN69OiBQHYuOQVTVu72al7m9RARERERERHxmdBQoM1Q+/1F/wPOJvhFY/g8CPL222/jjjvuwKBBgxAbG4uPPvoIBQoUwBdffOF2/mLFiqFMmTKpt5kzZ5r5rSBITEyMmda7d2/UqlULl112GT744AMsX74cO3fuRKCx2Wz4Y/1+dH53PiYt8y4IwsSmIiIiIiIiIj5V90agSGUg4RCw4iu/aAyfBkHOnj1rghPt27e/sEKhoebxokWLvFrG559/jr59+5qhL54cP37cDJkpUqQIAsnqPcdx82dLcNuXy7D5wEkUyR+O6KhweKrZwullY+yVXURERERERER8KiwcaP2w/f5f7wHnzgR3dZhDhw4hOTkZpUuXdprOx+vXr8/w9cwdwuEwDIR4kpiYaHKE9OvXD9HR0W7nOXPmjLlZ4uPjU+8zx0huY96Pd2Ztwo//xMFmg0luOrBlJdzVpioWbT2C+yf8YwIejglSrcDI011qISX5HFKSkedYbeGLNhH31Cb+Se3if4KxTYLps4qIiEg6Gt4EzH0dOLEX+OdboMlA+FJAl8hl8IMJUJs3b+7xAIzDYjikZPTo0R6X88orr2DkyJFun+PQmtySeA6YtTcUc/aGIMlmD2s0KZGCayqdQ7Fzm7Hgz81m2qCaIfhheyiOnb3QJyQmnw3XV0lB8o7l+G0H8rTcbBPxjtrEP6ld/E8wtQlzdImIiIggPBJodT8wfRiw4B2g4S32HiLBGAQpUaKESWq6f/9+p+l8zHwf6Tl16hQmTJiA559/Pt0AyI4dO/DHH3947AVCw4YNM8lZHXuCVKxY0dzv0KEDIiIikNNJTyct34P3/tiCw6fOmmnNqhTFk51qon6FmDTzdwXweIoNy3YcxYETZ1CqcCSaVi6KsFBPA2XyBrYpTyByo03EO2oT/6R28T/B2CaOvSpFREQkyDUZAMx/Ezi6HVj9PdCgT3AGQfLly4cmTZpg9uzZ6Nmzp5mWkpJiHg8ZMiTd106ePNkMYbnllls8BkA2bdqEP//8E8WLF093WZGRkebmDg9WL/aANTnFZsrbsmoLk5YyZwcDFvakpwfw8m/rsOXgKTNvtRIF8WSX2ugQW9rkMfGEa9S6pvMwomCRHW0i2Utt4p/ULv4nmNokWD6niIiIeCFfQaDlfcDs54H5bwGFywKnDgCFSgOVWwGhYQia4TDsgTFgwAA0bdrUDGsZNWqU6eXBajHUv39/lC9f3gxZcR0Kw8CJa4CDAZAbb7zRlMf95ZdfTM6Rffv2pVaWYeAlN01bHYeRU9eaPB8WJi8d1KoK/txwEIu2HravW8F8eKj9JejXvBIiwnxetEdEREREREQk+zS7HZj7JnBoAzC2+4Xp0eWAzq8BsT0QFEGQPn364ODBgxg+fLgJVjRs2BDTpk1LTZbKsrasGONow4YNWLBgAWbMmJFmeXv27MHPP/9s7nNZjtgrpF27dsjNAMg941Y4JTAlBkRe/t2e+JVJTwe3rop72lVHdJSumomIiIiIiEgetHUucM5NzrD4OGBSf6D32FwJhPg8CEIc+uJp+MucOXPSTKtVq5YZSuJOlSpVPD6XmzgEhj1A0luT/BFhmPZQG1Qu7rm8r4iIiIiIiEhAS0kGpj3h4UmeNYcA054EanfL8aExfhEE8efM9uydEh5u30xRUVEoWrQozp07Z3qvuCpbtmxq6d/lWw/ibPxhFD+f1uOELRJnEY5IJKFQiD35Kc4B67fsRCGUMsN6mA/FNUkslSpVyiSQPXLkiFMpXypcuDAKFSqE06dP49ixY07Pcb1Llixp7sfFxblNTMsx23wdX++oYMGCJpks34/v64g9c6yeOlxfrrcjDjtijhUmxePQJkf58+dHkSJFzLAlbidP25Dbl9vZdZ3o5MmTpvSxI74f35fDnw4cOJBmuVxfrvfhw4dx9uz57X8ePyeX7W4bcvtwO3nahty+3M5Hjx5Ns05sF7aPu23I9mS7etqG/D5w6Ja7bVigQAHExMS43YbMI2MlFXa3Dfn95feY2/DEiRNOz1nfb0/bkMvl8h23IZfPvxPeuE78//jx406v4+fg52Fw0hqa5u777W4bWt9vTufznr7fXK5r8NP6fnN9XKtUWN9vfg5+Hk/fb24Hbg93329uP25Hd9vQm98I1/Kh/Lvg3wfb2zWhpLUNvf2NsNqF24XrEyy/EdY2dPf99vVvBF/nuk/J678Rrq8XERGRILZjIRC/N50ZbED8Hvt8Vdvk6KooCJKOzZs3Y/fu3amPWY73+uuvNwedn3zySZr5R4wYYf7/6aefzOt6RF14bu7ZqtiaXBxVw46iZb6dqdMX/74OB6tXNwleecDqbrmPPvqoOQCfPn06Nm7c6PRcx44d0bJlS2zduhXfffddmgPSu+66KzWHiuvJ3D333GMOsufNm4eVK1c6PXf55Zejffv25qD+q6++cnqOB+1WNZ1vvvkmzYEuc7ywR87SpUvx119/OT3XqFEj9OjRw5zQun5WHvQ/88wz5v4PP/yQ5oT5uuuuM/+vWbPGJM91VLNmTfTr18+cLLvbhk8++aQ5Cfr999+xZcsWp+e6dOli8tEwke6UKVOcnqtQoQIGDx5s7rtb7v33329OrDjU6r///nN67oorrjDDr3bt2mW2kyOeSDzwwAPm/tixY9OcpN92222mQtGiRYuwePFip+eYP6dbt27m5MZ1nXhSxGpHVvJg1xPxvn37mp5UbG9WTXIUGxuLXr16mRMqd5/16aefNidvU6dONVWXHNWoUQPNmjXD+vXrzfOOKleujIEDB5rvn7vlPvzww+Ykc9asWVi7dq3Tc1dddRXatGlj3o/VoFxPLu+9915zf8yYMWlOXO+8805zwsyhc8uWLXN67rLLLkOnTp3MyeUXX3yR5gTyscceM/f5nq7Bl5tvvtl83uXLl2Pu3LlOz2X2N8L1+12/fn3z/eb31FH1LP5G8H4w/UYwH1SdOnXM36LrcElf/0bwu8L2cGyfvP4b4RrUFBERkSB2cn/2zncRQmz+MHbEz/AEhlfRPvvsM3MCkdWeIE9NuXBS7LYnCICXr6uHptXVE8TbniAMNrRt21Y9QfzgKi9x+QwydO3aVT1B/KwnCNuldevW6gniJz1B+H1goI9tEkw9QRhQYW+s9MrUi/Oxx/jx401AT9V1/AP/jn777Tezn1Ob+Ae1if9Rm/gfv2yTbfOBr67JeL4Bv2S5J4i1L83o2EM9QdLBA0ke1Ll+cXgAa53MuMMD4vbFiuO52Xux73iiU16QM4jAGVsERzyhTEwU2jetbcrlEg/A01suD+A94ckTb56kt1yefPHmDk8c0nut1eXdHX7xPH35uE3TW67VRd+RddLIEwceiLvDE4f0lpteueSL2Yae1sfftqGF25C3i92GbBP+nfBGjvdd8eQoq9uQJ1/pvdY6qXOHP4S8ucOTyPSWa52EusOTV97c8eY3whOebFtDv1x5+xthtYvj71cw/EZk9/fb1cVuQ0/7lLy6DT19j0VERCQIVW5lrwLDJKhuM2eG2J/nfDlMtVhzCAMbI7rHmvvn04Kksh7zeSsAIiIiIjmPw7u6d++OcuXKmeDsjz/+mO78HHrVoUMHEzRiwInDyzj0zNFzzz1nluV4q127dg5/EhERkQASGmYvg5veGXLnV3M8KapZlRx/hyDWuW5ZjL6lsenx4YiPOZ3Pi4iISO7h8KEGDRrgww8/9DpowiAIuxUzF9CVV15pgiiueXKYj4ZDoqwbh6SJiIiIA5a/ZRncaJfzYPYAyaXyuKThMDmMgY4OsWWwdNsRHDiRiFKFo9C8ajH1ABEREfEBJrrlzVujRo1yevzyyy+b5MZMAMtEvo7D4NIbmiciIiKwBzpYBpdVYJgEtVBp+xCYXOgBYlEQJBdwyEvL6p7HmYuIiEhgYJJaJn11zdPF6kEcYsMcRhwy88orr6BSpUoel8OEuI5l7x0TIrsmThbfsdpCbeI/1Cb+R23ifwKiTSpcduF+cor9dpG8/bwKgoiIiIh46c033zTVc3r37p06rUWLFvjyyy9NNRwOhRk5cqQp77169WqPCZQZJOF87sycOVPt4WfUJv5HbeJ/1Cb+J9jaJCEhwav5FAQRERER8QLL1zJwweEwjtWjHIfX1K9f3wRFKleujEmTJmHw4MFulzVs2DAMHTrUqSdIxYoVzX3mIPGbkoZBjlcVeRKhNvEfahP/ozbxP8HaJvEOvSrToyCIiIiISAYmTJiA22+/HZMnT0b79u3TnZclkWvWrInNmzd7nIelkXlzhweswXTQGgjUJv5HbeJ/1Cb+J9jaJMLLz6rqMCIiIiLp+PbbbzFo0CDzf7du3TLcVhwus2XLFpQtqypwIiIi/kY9QURERCRoMEDh2ENj27ZtWLVqlUl0ykSmHKayZ88ejB07NnUIzIABA/Duu++aYS779u0z0/Pnz4+YmBhz/9FHHzVlczkEZu/evRgxYgTCwsLQr18/H31KERER8URBEDdsNltqYhWOKwqmLkT+PrZNbeJf1Cb+Se3if4KxTaxxufyfyUFDQkLgD5YtW4Yrr7wy9bGVl4OBDiY3ZWLTnTt3pj7/ySef4Ny5c7jvvvvMzWLNT7t37zYBj8OHD6NkyZJo3bo1Fi9ebO57S8ce/ikY/3b9ndrE/6hN/E+wtkn8+WMPa5/qSYgtozmCEA9mrORkIiIicnGOHz+O6OhobUYde4iIiOS4Xbt2oUKFCh6fVxDEjZSUFGzYsAGxsbFmA+rAzT9YmfPVJv5DbeKf1C7+JxjbhNdYTpw4YXqB8DP7S08Qf6VjD/8UjH+7/k5t4n/UJv4nWNvEdv7Yo1y5cggN9Zz+VMNh3OAGK1++vLnPL00wfXECgdrE/6hN/JPaxf8EW5tYOTMkYzr28G/B9rcbCNQm/kdt4n+CsU1ivDj2UHUYEREREREREQkKCoKIiIiIiIiISFBQEMSDyMhIU+KO/4t/UJv4H7WJf1K7+B+1ieh7Epj0t+t/1Cb+R23if9Qm6VNiVBEREREREREJCuoJIiIiIiIiIiJBQUEQEREREREREQkKCoKIiIiIiIiISFAI6iDIK6+8gmbNmqFw4cIoVaoUevbsiQ0bNjjN065dO4SEhDjd7r77bp+tc17nTZskJibivvvuQ/HixVGoUCHccMMN2L9/v8/WORjMmzcP3bt3R7ly5czfwI8//uj0/MCBA9P8nXTu3Nln6xsMMmoTm82G4cOHo2zZssifPz/at2+PTZs2+Wx9g9Fzzz2X5u+idu3avl4t8TEde/gfHXv4Jx17+B8de/g/HXt4J6iDIHPnzjUn04sXL8bMmTORlJSEjh074tSpU07z3XHHHYiLi0u9vf766z5b57zOmzZ5+OGHMXXqVEyePNnMv3fvXlx//fU+Xe+8jtu/QYMG+PDDDz3Ow6CH49/Jt99+m6vrGGwyahP+Tr333nv46KOPsGTJEhQsWBCdOnUyQUTJPXXq1HH6u1iwYIE2f5DTsYf/0bGHf9Kxh//RsUdg0LGHF2yS6sCBAzZukrlz56ZOu+KKK2wPPvigtpKftMmxY8dsERERtsmTJ6fOs27dOjPPokWL1E65gNt6ypQpTtMGDBhgu/baa7X9/aRNUlJSbGXKlLG98cYbqdP4txMZGWn79ttvfbSWwWfEiBG2Bg0a+Ho1xM/p2MP/6NjD/+jYw//o2MM/6djDO0HdE8TV8ePHzf/FihVzmv7NN9+gRIkSqFu3LoYNG4aEhAQfrWHwcW2T5cuXm94h7NpvYffySpUqYdGiRT5bTwHmzJljhjDVqlUL99xzDw4fPqzN4iPbtm3Dvn37nP5OYv7f3r3HVF2/ARx/EEFBBRUNSBMvaGmCNbrIFKwxr5PE/AORLW0ut6zsBlkaOS/Zuq3amn/oHM7N6zRWUXMzw8rL1lrhNVFYSm1QzsJW1rzwac+z3zk/jnJzK84Xvu/XduR8r3wvfo/Pefx8nk98vNx///08Jx1MuyBpl6Xhw4dLYWGh1NbWdvQhwOOIPbyH2KPzIPbwDmIP7yD2aFv3dqzjC42NjfLMM8/IhAkTLNkRMG/ePElJSbEg9ujRo7J06VKrUfHBBx+E9Xj9ek/0i110dLT07ds3ZN3ExERbhvDQrjDaJWnYsGFSU1Mjy5Ytk+nTp9sX7sjISG5LBws8C/pcNMVz0rE06bRp0yZLDGpXmJUrV0pWVpYcP37c6h4BxB7eQ+zReRB7eAuxhzcQe7QPSZD/0ToUGphe31970aJFwfdpaWlWZDAnJ8e+6I0YMaKdlxn/5j2B98ydOzfkOUlPT7fnQ/+HRp8XwI80ERigz4QGJppU37lzpyxcuDCsxwZvIPbwHmKPzoPYA7gRsUf70B1GRJ588kkpLy+XiooKGTx4cKsXTINYVV1d3c5LjH/zniQlJcnly5eloaEhZH0dHUaXwRu06b92IeM5CY/As3D9qEk8J+GlLdhGjRrFcwFD7OE9xB6dG7FHeBF7eBOxR/N8nQTRmj76D15ZWZl8/vnn1pS/LZWVlfZTW4Sg4+9JRkaGREVFyb59+4LztHuS9rPPzMzklnjETz/9ZDVBeE7CQ58bDUaaPie///67jRLDcxI+f/zxh7Ui5LnwN2IP7yH26BqIPcKL2MObiD2a193vTR63bt0qH374ofXPDvRl0wKCMTExFqzq8hkzZkhCQoLVBNHhWbOzs61pMzr+nuhPbUb+3HPPWbHUuLg4eeqpp+yL3fjx47kl/+EHaNNWHVr8ShOCeg/0pbUO5syZY1+89bl54YUXJDU11YZkRcffEy0UrPV01qxZIyNHjrTApKSkxGob5eXlcUs6SFFRkeTm5loXGB3Ke8WKFVYjp6CggHvgY8Qe3kPs4U3EHt5D7OF9xB7t5HxMT7+5V2lpqS2vra112dnZrn///ja0ZGpqqisuLnYXL14M96H79p6ov/76yy1evNj169fPxcbGutmzZ7u6urqwHndXV1FR0ex90aFxL1265KZMmeIGDhxowxenpKS4xx57zNXX14f7sH17TwLD5JaUlLjExET7/MrJyXFVVVXhPmxfyc/Pd8nJyS46OtoNGjTIpqurq8N9WAgzYg/vIfbwJmIP7yH28D5ij/aJ0D/amzABAAAAAADorHxdEwQAAAAAAPgHSRAAAAAAAOALJEEAAAAAAIAvkAQBAAAAAAC+QBIEAAAAAAD4AkkQAAAAAADgCyRBAAAAAACAL5AEAQAAAAAAvkASBAAAAAAA+AJJEABy/vx5iY6Olj///FOuXLkivXr1ktraWt9fmf3790tERIQ0NDTc1LU4e/asbVdZWen7awgAwPWIO5pH3AF0DJIgAOTw4cMybtw4S358++230r9/fxkyZEinuDKXL18O9yEAAICbQNwBIJxIggCQQ4cOyYQJE+xKHDhwIPi+NQsWLJC8vDxZu3atJCYmSt++fWXVqlVy9epVKS4utkTK4MGDpbS0NGS7pUuXyqhRoyQ2NlaGDx8uJSUl1vqkqY8//ljuvfde6dmzpwwYMEBmz54dXDZ06FBZvXq1PPLIIxIXFyeLFi2y+bt375Y777xTevToYeu8/fbbbZ5DY2OjvPbaazJs2DCJiYmxRNCuXbuCrTkefPBBe9+vXz9r2aHnrPbs2SMTJ060c05ISJCZM2dKTU1NcL+6P3X33Xfbdg888EDwf3juu+8+Szbptnqdz507x99AAICvEHcQdwBh5QD40rlz51x8fLy9oqKiXM+ePe19dHS069Gjh71//PHHW9x+/vz5rk+fPu6JJ55wp06dchs3bnT6kTJ16lT36quvutOnT7vVq1fbvn/88cfgdjrv4MGD7ocffnAfffSRS0xMdK+//npweXl5uYuMjHSvvPKKO3nypKusrHRr164NLk9JSXFxcXHurbfectXV1fb65ptvXLdu3dyqVatcVVWVKy0tdTExMfazNWvWrHF33HGH27Nnj6upqbH19dz379/vrl696nbv3m3npPusq6tzDQ0Ntt2uXbts2ZkzZ9x3333ncnNzXVpamrt27Zot//rrr227zz77zLa7cOGCu3Llil3ToqIiO2Y9t02bNtl9AACgqyPuIO4AvIIkCOBT+qVcExFHjhyxRIX+1C/nvXv3dl988YUtO3/+fKtJEE1IBL74q9tvv91lZWUFpzWR0KtXL7dt27YW9/Pmm2+6jIyM4HRmZqYrLCxscX39nXl5eSHz5s2b5yZPnhwyr7i42I0ZM6bF/fz9998uNjbWHTp0KGT+woULXUFBgb2vqKiwZMZvv/3mWqPXSdc7duyYTeu102lNkARoIkTnaYIFAAC/Ie4g7gC8gu4wgE91797duo2cOnXKup6kp6dLfX29dW3Jzs62ZdoVpTXa/aRbt/9/jOi2aWlpwenIyEjrLvLLL78E5+3YscO6gSQlJUnv3r3l5ZdfDinCqsVEc3JyWv2999xzT8j0999/f0MXHp0+c+aMXLt2Tb766iv7XYHXli1bpLq6Wi5duiSTJ08OWbZ58+aQri3N0f0WFBRYdx7tkqPXSrVWTFa7B2l3mqlTp0pubq689957UldX1+rvAQCgqyDuIO4AvKJ7uA8AQHhoAkPrUWg9Dq2NoQkAreehL32fkpIiJ06caHUfUVFRIdNa/6K5ebr/QCG0wsJCWblypSUD4uPjZfv27SH1O7Q2R1u0psbN0KRJ05FaNFlz8uRJe//JJ5/IoEGDQtbXuiKt0SSGXp8NGzbIrbfeauc3duzYNou0an2UJUuWWE0RTQZpAmjv3r0yfvz4mzofAAA6G+IO4g7AK0iCAD716aefWgJEW1288cYbkpGRIXPnzrXWCtOmTbshmfFvFULT5MHy5cuD864vDKotUvbt2yePPvpou/c7evRoOXjwYMg8ndYCrNoaRRMrqampIcvHjBljyQ5tvTFp0qRm96vDBittTRJw4cIFqaqqsgRIVlZWsJhsW9sFaLFUfb300kuSmZkpW7duJQkCAOjyiDuIOwCvIAkC+JQmI7T7y88//yyzZs2yFhva8mPOnDmSnJz8n/zOkSNHWtJBW39oFxxthVFWVhayzooVKywxM2LECEvKaMsUDZx0VJmWPP/887Y/HTUmPz/fWpy8//77sm7duha36dOnjxQVFcmzzz5rLTl0tJeLFy9a8kS7uMyfP9+ukV6X8vJymTFjhiVTdKQY7eKzfv16u056Pi+++GLIvm+55RZbV1t86Ag5OsrNr7/+ats89NBD1npEEynarUZHuQEAoKsj7iDuADwj3EVJAISPFiydOHGivf/yyy9dampqu7fVwqizZs0KmTdp0iT39NNP31DI9J133gkpWJqQkGAFWPPz822ZjprSlI68ctddd9lINQMGDHAPP/xwi/sL0BFbtBCqFnkdMmSIFVxtS2Njo3v33XetoKtuN3DgQBvdRgvDBuiIM0lJSS4iIsLOWe3du9eNHj3aRpJJT0+3Yqf6cVpWVhbcbsOGDe62226zUWv0utTX11tB1+TkZDsvPQ8dAadpYVkAALoy4g7iDsALIvSPcCdiAAAAAAAA/muMDgMAAAAAAHyBJAgAAAAAAPAFkiAAAAAAAMAXSIIAAAAAAABfIAkCAAAAAAB8gSQIAAAAAADwBZIgAAAAAADAF0iCAAAAAAAAXyAJAgAAAAAAfIEkCAAAAAAA8AWSIAAAAAAAwBdIggAAAAAAAPGDfwD9WAASR+Z/pgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1100x380 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# L'effectiveness MONTE au coarse-graining (emergence) ; l'EI en bits DESCEND (log2 n)\n",
+    "sizes = [s[\"size\"] for s in res[\"scales\"]]\n",
+    "effs = [s[\"effectiveness\"] for s in res[\"scales\"]]\n",
+    "eis = [s[\"effective_information\"] for s in res[\"scales\"]]\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 3.8))\n",
+    "ax1.plot(sizes, effs, \"o-\", color=\"tab:blue\")\n",
+    "ax1.axhline(effs[0], ls=\"--\", color=\"gray\", lw=1, label=\"effectiveness micro\")\n",
+    "ax1.set_title(\"Effectiveness vs echelle (coarse-graining ->)\")\n",
+    "ax1.set_xlabel(\"# macro-etats\"); ax1.set_ylabel(\"effectiveness\")\n",
+    "ax1.invert_xaxis(); ax1.legend()\n",
+    "ax2.plot(sizes, eis, \"o-\", color=\"tab:orange\")\n",
+    "ax2.set_title(\"Information effective EI (bits) vs echelle\")\n",
+    "ax2.set_xlabel(\"# macro-etats\"); ax2.set_ylabel(\"EI (bits)\")\n",
+    "ax2.invert_xaxis()\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-greedy-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004533,
+     "end_time": "2026-06-29T10:58:00.550862+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.546329+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Lu **de droite a gauche** (coarse-graining), l'effectiveness **monte** continument au-dessus de sa valeur\n",
+    "micro : c'est l'**emergence causale**, decouverte automatiquement la ou notre macro intuitif avait echoue.\n",
+    "Dans le meme temps l'**EI en bits descend** — non pas parce que le systeme « perd » de la causalite, mais\n",
+    "parce que $\\log_2 n$ retrecit quand on fusionne des etats. C'est l'argument central de Hoel (2025) :\n",
+    "juger l'emergence sur l'EI en bits masque le phenomene ; la grandeur pertinente est l'effectiveness\n",
+    "*scale-free*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-ec-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004577,
+     "end_time": "2026-06-29T10:58:00.561547+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.556970+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. La complexite emergente EC\n",
+    "\n",
+    "L'article resume tout le chemin d'echelles par un seul nombre, la **complexite emergente** :\n",
+    "\n",
+    "$$\\text{EC} = \\log_2 L + H(p), \\qquad p_i = \\frac{\\Delta_i}{\\sum_k \\Delta_k},$$\n",
+    "\n",
+    "ou les $\\Delta_i$ sont les **gains** d'effectiveness le long du chemin et $L$ le nombre de transitions\n",
+    "d'echelle. EC est **maximale quand le travail causal est largement distribue** entre les echelles, et\n",
+    "**nulle** si une seule echelle porte tout le gain. C'est une signature *multi-echelles* : un systeme a\n",
+    "forte EC ne se laisse resumer par aucune echelle unique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ict6-ec-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:58:00.573358Z",
+     "iopub.status.busy": "2026-06-29T10:58:00.572358Z",
+     "iopub.status.idle": "2026-06-29T10:58:00.699437Z",
+     "shell.execute_reply": "2026-06-29T10:58:00.699437Z"
+    },
+    "papermill": {
+     "duration": 0.133321,
+     "end_time": "2026-06-29T10:58:00.700442+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.567121+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "complexite emergente EC = 8.1658\n",
+      "nombre de transitions d'echelle L = 21\n",
+      "log2(L) = 4.3923  ;  H(p) = 3.7735\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3kAAAFKCAYAAACggZb/AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZGtJREFUeJzt3Qm8jPX////3sW/Zs2YNITuRLbKXsiQi2SptFCqlBYn0aSEVEq2KSEklabGHyFoKSWTf9327/rfn+/u/5jfnnDnHmeOca+bMedxvt2HONddc85739b6uuV7Xe4tyHMcxAAAAAICIkCbUCQAAAAAAJB2CPAAAAACIIAR5AAAAABBBCPIAAAAAIIIQ5AEAAABABCHIAwAAAIAIQpAHAAAAABGEIA8AAAAAIghBHgAAAABEEII8AEnmo48+MlFRUWbr1q3Jmqvavj5Hn5dUPvnkE1O2bFmTPn16kzNnTt/y1157zZQsWdKkTZvWVKlSxXhJ3/GFF17w9DMRGebPn2/Lj/4PxfF0pRo2bGgfXufXF198kaznw+T6Xrfeeqvp2bNnotKUUDoX6b0p2ezZs022bNnM/v37Q50UINkR5AGp1JYtW0zv3r1NmTJlTJYsWeyjfPnyplevXub33383KY0uQIoXL56o927YsMF0797dXHvttWbChAlm/PjxdvmPP/5onnrqKVO3bl3z4YcfmuHDhydxqo2ZNWsWgVwKcerUKbuvEhI4haPJkyebUaNGmZTIDURTat4np8WLF9tz1dNPP+35Z+ucOGPGDJNStGjRwpQqVcq8/PLLoU4KkOzSJf9HAAg3M2fONHfddZdJly6d6dy5s6lcubJJkyaNDXamT59u3nnnHRsEFitWLKjtdunSxXTs2NFkzJjRpCS6cLx06ZJ588037QWAa+7cuTZf3n//fZMhQ4Zk+WwFeWPGjAkY6J0+fdruI4RPkDdkyBD73MtapsS46aabbPnxL7cK8tatW2f69u0bbV0d51pXtdhIedTaoHHjxtHOXV4GeXfeeadp06aNSSkefPBB8+STT9pj+aqrrgp1coBkw9UDkMps3rzZBmK6sJszZ44pWLBgtNdfeeUVM3bsWBvcBEtNGvVIafbt22f/92+m6S7PnDlzsgV4l5MpU6aQfG5qdubMGbu/E1P+Yzp58qTJmjWrCQWlP6HlRzVklLWUSeeo7777zowbNy7USUkx2rVrZx599FEzbdo0c++994Y6OUCyobkmkMq8+uqr9uJTzQ9jBniimqPHHnvMFClSxLdMzTfVnFF903QxWKBAAfvjePDgwcv291ATyttuu8388ssvpmbNmvb92s7EiRMTlN4jR47Yz86RI4cNwrp162aXJdSnn35qqlevboO13Llz2wB3+/bt0dI3ePBg+/zqq6/29YPT/8oj5ZWex+yzdLntupYtW2b7y+TKlcte8FeqVMnWGIq+l2rxxP0M/z4v/n3y1FdIfy9YsCDWZ7z77rv2NdXSuFQrqzvsSpvyvEaNGuabb74JuL/U3Ovxxx+3319pbNu2bcA+K99//72pX7++XUd3wFu2bGn+/PPPaOvs2bPH9OjRw1xzzTW2RldlrHXr1tHKxIoVK0zz5s1N3rx5bf6VKFEiQRdbbllS0zT1j9T3UhNj1T77O3TokL1TX7FiRdv/Jnv27OaWW24xa9euDdgPa8qUKeb55583hQsXts2Wjx07FuuzlX7lj6gGwN1X7v7RvtRn6SaK9rfyR7XksmjRItO+fXtTtGhRmyc6tvr162drz/y529i5c6etGdFzfaa+y8WLF6OtqzSr/Olz9P30Xd1y5f/d3OaNqnlUMPDff//50u42b46rT55qst39rWNP+3H9+vXR1nGPlX/++cemX+vpWFUZUM1nQqh5tJpKqyzoHKH8SqiElHPROUN5ru+sfaDy2bVrV3PgwIFo66lG/6WXXrKva3uqIdN3C3Rcq+mfvqvKTIMGDexxlBhnz5615yDVxLnlQ83EtfxytE8vXLhgmjRpEus1HZuNGjWy+arvM2zYMPv9AknIsR2T9rvOjx9//LGvTKkMiMrZI488Yq677jr7+Xny5LHHQGL7a+t8q7KhvNa5VDXVOg8Ee26QfPny2fPw119/nai0ACkFNXlAKmyqqYuJWrVqJfg9P/30k/n333/thZsCPP3468JM///666+X7YyviyRdiN133302SPvggw/sxYAuUq+//vo43+c4jr2wVID40EMPmXLlypmvvvrKbiMhdLE2cOBA06FDB3P//ffbwOXtt9+2FwirV6+2F6Tqo6SAU9tVM1VdWOsCQHmk77h8+XLz3nvv2e3VqVMnwdt1800XHgp0+vTpY/NOF8naB/pbzYZ27dpl19PAL/HRRZfS9vnnn9sLSn9Tp061+VihQgX7t/aL+hEqaBkwYIC9cNP7FDh8+eWXNojzp7vaunDShaYuwpQn6q+p7bqUPuW7gjPV9uoCXvlVr149+53dgEF3yfX52qaWqaZB32/btm2+v5s1a2aDF6VNeaXPDHQxFsimTZtsU2OVB6VHgbguHjWgQtOmTe06KqvqJ6TlCiD37t1rA2Hl219//WUKFSoUbZtDhw61tXcKpnRhHajmVunV93344Ydt/t1xxx12ucqKSxfbyh/lyeuvv24vSEU1BsovvVcXuypTKi87duywr/lTMKdt6PjUNn7++WczYsQIGwTp/aL87NSpkw1AtC9E5UpBhspVIM8995w5evSo/cw33njDLlN5ios+V4GxbsgokFNAqjSrXK1atSpW/1cdC8pr9XXS6zpmdDHtpi8uagqt40DHlpqRat+1atXKBm3+N5oCSWg5P3HihA1glEe6mVCtWjUb3CkYVH7oZoPrf//7n60FVVlQfummmIJ1BXX+wa/yRucvHTNaX+VQAZUCVAUjCaWgS99X57gHHnjAnuP++OMPu4/+/vvvy/Z3W7JkiS1TMZvW62bLzTffbMukmzc6nyngiimhx3ag9+n8p++rtIvKqfz22282bbr5pQBTx7i2qZsNOgbdYyMhdFNFZVBl5MUXX7THp/aH9oPOJcGcG1zadympLyGQKA6AVOPo0aOODvs2bdrEeu3w4cPO/v37fY9Tp075XvN/7vrss8/sthYuXOhb9uGHH9plW7Zs8S0rVqxYrPX27dvnZMyY0XniiSfiTe+MGTPse1999VXfsgsXLjj169e3y/V5cdm6dauTNm1a56WXXoq2/I8//nDSpUsXbfngwYPt9vS9/XXr1s3JmjVrorardJYoUcJ+f+Wtv0uXLvme9+rVy352IFqutLk6derk5MuXz27btXv3bidNmjTOiy++6FvWuHFjp2LFis6ZM2eifWadOnWc0qVLx9pfTZo0iZamfv362e945MgR+/fx48ednDlzOj179oyWvj179jg5cuTwLdf31PZee+01Jy5fffWVXee3335zguWWpS+//DJamS5YsKBTtWpV3zJ974sXL0Z7r8qkypx/Ps2bN89ur2TJkgHLeEwqHzH3iX9Z0WsDBgyI9Vqgbb/88stOVFSU899//8Xahn8aRd+tevXqvr/79OnjZM+ePVo5iMn9bvrf1bJlS5uHMSlvYh5PVapUsWXt4MGDvmVr1661Za1r166xjp1777032jbbtm3r5MmTx4nPuXPn7Gfos86ePetbPn78eLvNBg0axPv+hJbzQYMG2e1Nnz491jbccu/mV7ly5aKl5c0337TLdXy762vbzZs3j3bMaB/reG/atGm850N9J//v9cknn9g8XbRoUbR0jRs3zr538eLF8eZBvXr1opUNV9++fe37ly1bFu28q+PVP00JPbb997U/nR9VbhNS5pcuXWrfP3HiRCehNm3aZPNH5SnmMe2f/wk9N7iGDx9u19+7d2+C0wKkNDTXBFIRtxlaoDv4usOq2gr34TYjFP+7v+qzpLvgN954o/1bd+0vR81mdCfdpe2rGY/u2l9uUBI1H3VrMER9/lRLdDmqGdJdctUwKL3uQ7VppUuXNvPmzbvsNq5ku7oDrsFrVDsRs69fYoch111q1YT5jzCoZpxKj15zmyrqDrfSd/z4cV/61LRWd+p1t1vNAf3pLrx/mrSvVKOkJlduzZGau6n2yP87a1+oxsn9zm7/RaXv8OHDAb+DmxeqzTx//nzQeaBaOP+aSDVVVLM75bdqL0RN3tw+dfoe+u4q8ypzgcqr7voHquFIDP+y6vLftpq3Ke9UK6E4XumOSTUR/rQ//I8V5aG2o/2SHHbv3m3WrFlja9tVo+ZSraVqRHRcJiTNyvdATV/9m+2qPOu9/rWnbvPs+ARTzlWrp8GlYtZgBzoW1VrBPy3uecvNf+WLtn333Xfbz3I/V/tDNasLFy6Ms0lkIKrJVe2dpm/xP7ZUKyiXO08pDaqFj0n7SOdo/1pFnXfdJsSuhB7bwfIv8zrOlU61jlDZTchvhku1bcrPQYMGxeonG3PfJeTc4HLzLGZzXSCS0FwTSEXckcTUfCkmNWfTxZKatt1zzz2xLqjUZEb9gNxBSlxq0nQ56osUk35k4woEXAoy1NQxZlCqi/XL0YWYLqIVeAWS2JEEE7pd9c0StwllUnD7AKkZpS4oRc/VB0VTYbhNY5U+NSfVIxDtQzVxi2v/uBdA7v7Rdxb3wjMmXUy5wZWaez3xxBMmf/789iJTzVV1oaUgWNRkUk06VZ7UJE03F9S8ThfNCRmVVReKMS/u3O+uJmH6HHekVA0gpEDbvz+bmrbFpGaGSUE3JNQ0LSY1VdVFqpoHxizzMY8f9SVy+/7Fdayor5OaJarJoPajmqwp2FH5SApucB/oOFNA8sMPP8QaVCa+MuSWj7g+J+axpGNIzUTjE0w517GoMpcQCT0W4msyrn0aKPAKRNtTM9KY+9z/O1zO/1X6x87bQE3yY+7ThB7bwVLzXjXdVZNJBdv+aUzIb4ZL+07BnW4UJsW5weWmJ6XP+wfEhyAPSEUUICho8h+gw+VeEATqGK8LSPWv6N+/vw0oFHTpQloXlQm5ax3XiJuBLk6SitKlH3ANKBDo8+PrjxSK7SaEgiAFROo/qABGAbn6YfnP3+fuD/UpUo1GIDGHWr/c/nG3qT44/hdKLv9pHlRzefvtt9s78AoGdAGuiz3VulStWtU34bT6cn777bd2HfWTUr8zLUuK/FN+6HO1XfW3U22ULhSVtkDlNalq8fxrEF0KMFX7pRslmsdMNTYKjnThqxqrmOlJyOi06uumGiXlncqhHrqYVjCtQTBCwetjPDHlPCESeixo2gKdCwMJpgxrexo0Z+TIkQFfv1y/RN20uNzNsst9fkKP7WCotYXKpI652rVr298eHfvqoxdMTWdycfPMvz8mEGkI8oBURgN4aFAEDf6QkAEC9GOoqRZU86LaiJh3gJOTO82Dah79L5w2btx42fdqAABdmKmWxr2bmxQSul13AAIF1IFGvnMFeydZzTJ1Ia98UQ2A0uI21RS3BkS1IfF9bjDc76LgIiHb1PqqzdND5UQXwwriNEKeS7V8emgQG83fpmZkqinWQA4JqcHxzzcNUCHuABEKIjXohAb18KdmaVdyUZeYu/4aREPp0z5TEOa60qaWalKoYFoPXTSrdk+18Qpu4wpuEpp+dxCPQMeZRrNUHibF1BDu56iM+NckqXmfamDVxDIuwZRzlcdAN7au5FhQDVdSHF/ankZ9Vc18YsqXbhqoOWqgvA10jo65T4M9tmOKK806BlXbqePev6l/MCMju+lT+dZgLXEF1cGcG1wqXyrHcdWgApGAPnlAKqOhuTWymWo5VBN0uTvv7p3tmMs1AmNy01D0Gh1Oo7L514xolL/L0eiHSruC05hp198xp39IqIRuVyP4KRBUPsW8sPF/n3uxnNCLH12IqWZKzTT1UKDu39xQF2tqAqkLfvWtiinQ1AiXo5oSXdSqhixQPzp3mxqVTxdyMS/S1EzYHQ5eNw1i5pt78ZaQIeM1GqlqMl3q86XRUbUNtyZC+yfmZ6jvU8y+iMFyRwQM5kI10PGj5/7THQQrZtlV7aE7ymd8eaiylpCmcqrtV34qMPX/rgqUNES9jsukoOkOdJGtOd7OnTvnW66pHC6Xx8GUczXVVCDlX24SW9OoURlVpjXyaaBm78EeX2oloXI5YcKEgE0e1Sw2Pqol0zEVs3+z9pFqxnUzzz9tkyZNStSxHV+ZCrSvAh2DOm/HnArkctRyQeVbo2rGrAGMuf2EnBtcK1eutHkHRDJq8oBURv1fVHOijvbqn6EaFN0x1w+m7m7qNf2oun2LdAGgqQE0lLguAtTHRRd6Wje5qZZCQ6RrCHA1I3XnPUrIhaouxDQv1DPPPGPfq4sFBRtKty4ENNiImnoFK6HbVR4qONV30EWGBnTQxbNqQjT0u5rauReNorkJdcGliyM1aYqLai4UaKrWSxeAutiMSYPmaPhzNQPr2bOnrfVQQL906VI7ZHzM+eIuR2VA36VLly42eFX6dHGuvmaap0v7aPTo0fauuWokdOGqfaWmXsoTfbb7nRQ4qKmpBkhQXqofqC5w9RkJCR5Ue6qpODREu/r9aToObV9Nw1zqB6iLQuW5BjhRbZoubi/Xz+ty1KxT30vBtdKhYFt9LuPrd6maFn1PlQldzOt7qublSprYqbZTzT9V+6XjVP2vdAGtcqY+c3FRWVPaNSfiDTfcYGvHVT4DUXNE9fnThbDy251CQc3u3LkBr5TKso4lTaGg76IaaR1H2pcJ2VcJLedqZq6aJQ2nr5tbygfln/pIKsCMr8YwJh3XagmhvNG0JSpjOidq32qQEu1fNUNOKB1T6l+pwWf0fh1LCoR0ntBynScUDMfXMkPHmaa8cKcxcG/mqQmmmtRrWg13CgXV8Gne02CP7bgoL/XZam6qgU90w0lN/3UM6vNVXnTMaJ9ovUB9YuOjWmlN/6Fm1xoER+c+NYvW8a/PU1PwYM4Nbj9H5UGvXr2CSguQ4oR6eE8AofHPP/84Dz/8sFOqVCknU6ZMTubMmZ2yZcs6Dz30kLNmzZpo6+7YscMOYa2htjWsdvv27Z1du3bFGk4+rikUNHR7TDGHEo+LhnDv0qWLHTJen63nq1evvuwUCi4Nqa1hxjXUtx76jpq2YOPGjYmaQiGY7covv/xih1W/6qqr7HqVKlVy3n77bd/rGgb/0Ucfda6++mo7pL7/aTmu4fp/+ukn+5rW3759e8D0bd682Q51X6BAASd9+vRO4cKFndtuu8354osvYu2vmNMZBBp+312uoeO1H1Rmrr32Wqd79+7OihUr7OsHDhyweaC80HfVerVq1XI+//xz3zZWrVplp4IoWrSondJAQ+grXe424uOWpR9++MHmo96vz5o2bVq09TSkvqbn0PDpKtd169a1w7fHLHPu94z5/vgsWbLEDlmfIUOGaPsnvrLy119/2WkqsmXL5uTNm9cOS6/pCGKW4bi2EXPoeu3DZs2a2bxTOpSXDz74oJ1OI759eOLECefuu++2x7Fec6dTCDSFgvz8888275SHOv5uv/12+10CpS3msRPoXBCXsWPH2ukHtD9r1Khhp1tJ6PkhIeXcPY/07t3bvq48u+aaa2x+q8zGVxbiyhudg+644w47TYTSrbzs0KGDM2fOnHjzIND30lQSr7zyinP99dfbbeXKlcuWsSFDhthpAC6nVatWdjqJmH7//Xf7WTpW9b2HDh3qvP/++wH3y+WO7bimUNiwYYNz00032TKi19zpFDSdSo8ePWx5V7nXtrWu8inQlAuX88EHH9ipENz80ffSeTDYc4O88847TpYsWZxjx44FnQ4gJYnSP6EONAEAuBz1q1GtmaZfAPB/NAG7mq6q9i+uUX8jXTDnBg0ApfzS6L5AJKNPHgAAQAqlZoyaRkNN6hG/2bNn2wFp1NweiHT0yQMAAEjBNI1GShNzgvJAfWDVpy8pqY9ioAFzgEhEkAcAAABPaSCq+GgKBo20CiBx6JMHAAAAT2m0zfho9EyNzAkgcQjyAAAAACCCMPAKAAAAAEQQ+uQl0qVLl8yuXbvsJMhRUVFJu1cAAAAAIAbNfnf8+HHbpDlNmrjr6wjyEkkBXpEiRRL7dgAAAABIlO3bt5trrrkmztcJ8hJJNXhuBmfPnt2kVOfPnzc//vijnWMnffr0pIV8obxwHHF+4bzL7xG/jVwzcD3FdWaYOnbsmK1ocmORuBDkJZLbRFMBXkoP8rJkyWK/QzgEeaSFfKG8cBxxfuG8y+8Rv40p6Zoh3NJDWsI/X5LC5bqLMfAKAAAAAEQQgjwAAAAAiCAEeQAAAAAQQQjyAAAAACCCEOQBAAAAQAQhyAMAAACACEKQBwAAAAARhCAPAAAAACIIk6EDAAAAiNeYh+YGnUNR6RxTuKkxE/otNM6F+CfvjqnXuEbskStATR4AAAAARBCCPAAAAACIIAR5AAAAABBBCPIAAAAAIIIQ5AEAAABABCHIAwAAAIAIQpAHAAAAABGEIA8AAAAAIghBHgAAAABEEII8AAAAAIggBHkAAAAAEEEI8gAAAAAgghDkAQAAAEAECYsgb8yYMaZ48eImU6ZMplatWmb58uXxrj9t2jRTtmxZu37FihXNrFmzfK+dP3/ePP3003Z51qxZTaFChUzXrl3Nrl27om3j0KFDpnPnziZ79uwmZ86c5r777jMnTpxItu8IAAAAAKkiyJs6dap5/PHHzeDBg82qVatM5cqVTfPmzc2+ffsCrr9kyRLTqVMnG5StXr3atGnTxj7WrVtnXz916pTdzsCBA+3/06dPNxs3bjStWrWKth0FeH/++af56aefzMyZM83ChQvNAw884Ml3BgAAAICIDfJGjhxpevbsaXr06GHKly9vxo0bZ7JkyWI++OCDgOu/+eabpkWLFqZ///6mXLlyZujQoaZatWpm9OjR9vUcOXLYwK1Dhw7muuuuMzfeeKN9beXKlWbbtm12nfXr15vZs2eb9957z9Yc1qtXz7z99ttmypQpsWr8AAAAACAlCWmQd+7cORt8NWnS5P8lKE0a+/fSpUsDvkfL/dcX1fzFtb4cPXrUREVF2WaZ7jb0vEaNGr51tE199rJly5LgmwEAAABAaKQzIXTgwAFz8eJFkz9//mjL9feGDRsCvmfPnj0B19fyQM6cOWP76KmJp/rfudvIly9ftPXSpUtncufOHed2zp49ax+uY8eO+foA6pFSuWkPh+9AWsgXygvHEecXzrv8HvHbmNKuGcItPcmVlqh0TvDvSetE+z8YSZ3+82G0j65EQtMf5ThO8LmeRNQ0snDhwrafXe3atX3Ln3rqKbNgwYKAtWoZMmQwH3/8sQ3aXGPHjjVDhgwxe/fujZUJ7dq1Mzt27DDz58/3BXnDhw+321BfPX8K/LSdhx9+ONbnvvDCC/a1mCZPnmyblwIAAABActL4I3fffbdtqejGNmFXk5c3b16TNm3aWMGZ/i5QoEDA92h5QtZXgKd+ef/995+ZO3dutEzQujEHdrlw4YIdcTOuz33mmWfsADH+NXlFihQxzZo1izeDw53ySX0YmzZtatKnT09ayBfKC8cR5xfOu/we8dvINUOYXE9N6Lcw6Peo1qxQo5Nm19ysxrkYFdR7e75xU4pIS0o/rq+E25rwckIa5KlWrnr16mbOnDl2hEy5dOmS/bt3794B36MaP73et29f3zLtMP+aQDfA27Rpk5k3b57JkydPrG0cOXLE9gfU54sCQX22BmIJJGPGjPYRkwpJSi4o4fg9SAv5QnnhOOL8wnk3HPB7RL6Eusw4F6IS/96LUUG/P760h1NaIuW4ToyEpj2kQZ6odqxbt252EJSaNWuaUaNGmZMnT9rRNkVz3KlJ58svv2z/7tOnj2nQoIEZMWKEadmypR0Rc8WKFWb8+PG+AO/OO++00ydoagT1+XP72anPnQJLjcqpETo1qqdG89R7FFR27NjRzqsHAAAAAClVyIO8u+66y+zfv98MGjTIBmNVqlSx0xu4g6to2gONeumqU6eO7Qf3/PPPm2effdaULl3azJgxw1SoUMG+vnPnTvPNN9/Y59qWP9XqNWzY0D6fNGmSDewaN25st6++e2+99ZaH3xwAAAAAIjDIEwVbcTXP1IApMbVv394+AilevLhJyFgyqtVTsAgAAAAAkSTkk6EDAAAAAJIOQR4AAAAARBCCPAAAAACIIAR5AAAAABBBCPIAAAAAIIIQ5AEAAABABCHIAwAAAIAIQpAHAAAAABGEIA8AAAAAIghBHgAAAABEkCsO8o4dO2ZmzJhh1q9fnzQpAgAAAAB4F+R16NDBjB492j4/ffq0qVGjhl1WqVIl8+WXXyY+JQAAAAAA74O8hQsXmvr169vnX331lXEcxxw5csS89dZbZtiwYVeeIgAAAACAd0He0aNHTe7cue3z2bNnm3bt2pksWbKYli1bmk2bNiU+JQAAAAAA74O8IkWKmKVLl5qTJ0/aIK9Zs2Z2+eHDh02mTJmuPEUAAAAAgERLF+wb+vbtazp37myyZctmihUrZho2bOhrxlmxYsXEpwQAAAAA4H2Q98gjj5iaNWua7du3m6ZNm5o0af6vMrBkyZL0yQMAAACAlBbkiUbU1EMuXrxo/vjjD1OnTh2TK1eupE4fAAAAACA5++Spueb777/vC/AaNGhgqlWrZvvqzZ8/P9jNAQAAAABCGeR98cUXpnLlyvb5t99+a7Zs2WI2bNhg+vXrZ5577rmkTBsAAAAAILmDvAMHDpgCBQrY57NmzTLt27c3ZcqUMffee69ttgkAAAAASEFBXv78+c1ff/1lm2pqCgUNviKnTp0yadOmTY40AgAAAACSa+CVHj16mA4dOpiCBQuaqKgo06RJE7t82bJlpmzZssFuDgAAAAAQyiDvhRdeMBUqVLBTKKipZsaMGe1y1eINGDAgKdMGAAAAAPBiCoU777zT/n/mzBnfsm7duiVmUwAAAACAUPbJU1+8oUOHmsKFC5ts2bKZf//91y4fOHCgb2oFAAAAAEAKCfJeeukl89FHH5lXX33VZMiQwbdcTTjfe++9pE4fAAAAACA5g7yJEyea8ePHm86dO0cbTVNz52m+PAAAAABACgrydu7caUqVKhVr+aVLl8z58+eTKl0AAAAAAC+CvPLly5tFixbFWv7FF1+YqlWrJiYNAAAAAIBQja45aNAgO5KmavRUezd9+nSzceNG24xz5syZSZUuAAAAAIAXNXmtW7c23377rfn5559N1qxZbdC3fv16u6xp06aJSQMAAAAAIJTz5NWvX9/89NNPSZUGAAAAAEAogzw5d+6c2bdvn22y6a9o0aJJkS4AAAAAgBdB3qZNm8y9995rlixZEm254zgmKirKTpYOAAAAAEghQV737t1NunTp7CArBQsWtIEdAAAAACCFBnlr1qwxK1euNGXLlk2eFAEAAAAAvJ0n78CBAyapjBkzxhQvXtxkypTJ1KpVyyxfvjze9adNm2YDTK1fsWJFM2vWrGiva0qHZs2amTx58thaRgWlMTVs2NC+5v946KGHkuw7AQAAAECKCfJeeeUV89RTT5n58+ebgwcPmmPHjkV7BGPq1Knm8ccfN4MHDzarVq0ylStXNs2bN7cDugSifoCdOnUy9913n1m9erVp06aNfaxbt863zsmTJ029evVsOuPTs2dPs3v3bt/j1VdfDSrtAAAAABARzTWbNGli/2/cuPEVD7wycuRIG2z16NHD/j1u3Djz3XffmQ8++MAMGDAg1vpvvvmmadGihenfv7/9e+jQoXYqh9GjR9v3SpcuXez/W7dujfezs2TJYgoUKJDgtAIAAABARAZ58+bNS5IP1hQM6tv3zDPP+JalSZPGBpFLly4N+B4tV82fP9X8zZgxI+jPnzRpkvn0009toHf77bebgQMH2sAPAAAAAFJVkNegQYMk+WD161OtX/78+aMt198bNmwI+J49e/YEXF/Lg3H33XebYsWKmUKFCpnff//dPP3002bjxo22P19czp49ax8ut2nq+fPn7SOlctMeDt+BtJAvlBeOI84vnHf5PeK3MaVdMyRneqLSOcG/J60T7f9gxJf+cEpLJJSZxEpo+qMctbMM0qJFi8y7775r/v33XzsQSuHChc0nn3xiSpQoYfvDJcSuXbvs+9TPrnbt2r7l6u+3YMECs2zZsljvyZAhg/n4449tvzzX2LFjzZAhQ8zevXujravmmkqP+u5VqVIl3rTMnTvXNj/9559/zLXXXhtwnRdeeMF+TkyTJ0+mBhAAAABAsjt16pStsDp69KjJnj170tXkffnll7bfW+fOne1gKW7tlj5o+PDhsUa7jEvevHlN2rRpYwVn+juuvnJaHsz6CaVRPSW+IE/NSv2biqomr0iRInYkz/gyOCXcDVC/xqZNm5r06dOTFvKF8sJxxPmF8y6/R/w2cs0QJtdTE/otDPo9qjUr1Oik2TU3q3EuBjefdc83bkoRaUnpx/WVSOhAl0EHecOGDbODnHTt2tVMmTLFt7xu3br2tYRSrVz16tXNnDlz7AiZcunSJft37969A75HNX56vW/fvr5l2ln+NYGJ4U6zoMnd45IxY0b7iEmFJCUXlHD8HqSFfKG8cBxxfuG8Gw74PSJfQl1mnAtRiX/vxaig3x9f2sMpLZFyXCdGQtMedJCnvms33RQ7ss6RI4c5cuRIUNtSzVi3bt1MjRo1TM2aNc2oUaPsFAjuaJsKJNWk8+WXX7Z/9+nTx/YJHDFihGnZsqUNMlesWGHGjx/v2+ahQ4fMtm3bbHNQN72i2j49Nm/ebJtY3nrrrXYuPfXJ69evn/1OlSpVCjY7AAAAACCsBB3kKVBSs0ZNYO7vl19+MSVLlgxqW3fddZfZv3+/GTRokB08RX3nZs+e7RtcRcGaRtx01alTxwZozz//vHn22WdN6dKl7ciaFSpU8K3zzTff+IJE6dixo/1fc/GpX51qEH/++WdfQKkml+3atbPbBAAAAIBUF+RpXjvVqGkuO82LpxozTW3w5JNP2mkIgqWmmXE1z9SE6zG1b9/ePuLSvXt3+4iLgjoN7AIAAAAAkSjoIE+TlKvvnEaj1OguauaovmoK8h599NHkSSUAAAAAIHmCPNXePffcc6Z///622eaJEydM+fLlTbZs2YLdFAAAAAAgif2/Dm8J9Omnn9oaPPVtU3CnAVMI8AAAAAAghQZ5GokyX758dhI+zYl38eLF5EkZAAAAACD5g7zdu3fbqQvUbLNDhw52brlevXqZJUuWBP/pAAAAAIDQBnnp0qUzt912m5k0aZLZt2+feeONN8zWrVvNzTffbK699tqkTR0AAAAAIHkHXvGXJUsW07x5c3P48GHz33//mfXr11/J5gAAAAAAXtfkiQZeUU3erbfeagoXLmwnFm/btq35888/rzQ9AAAAAAAva/I6duxoZs6caWvx1CdPE6DXrl37StIAAAAAAAhVkJc2bVrz+eef22aaeg4AAAAASMFBnpppAgAAAABScJD31ltvmQceeMBkypTJPo/PY489llRpAwAAAAAkR5CnaRI6d+5sgzw9j4vmziPIAwAAAIAwD/K2bNkS8DkAAAAAIIVPofDiiy/aKRRiOn36tH0NAAAAAJCCgrwhQ4aYEydOxFquwE+vAQAAAABSUJDnOI7texfT2rVrTe7cuZMqXQAAAACA5JxCIVeuXDa406NMmTLRAr2LFy/a2r2HHnooMWkAAAAAAHgd5I0aNcrW4t177722WWaOHDl8r2XIkMEUL17c1K5dO6nSBQAAAABIziCvW7du9v8SJUqYunXrmnTpgp5HHQAAAAAQbn3yTp48aebMmRNr+Q8//GC+//77pEoXAAAAAMCLIG/AgAG2D15Masqp1wAAAAAAKSjI27Rpkylfvnys5WXLljX//PNPUqULAAAAAOBFkKcBV/79999YyxXgZc2aNTFpAAAAAACEKshr3bq16du3r9m8eXO0AO+JJ54wrVq1Sqp0AQAAAAC8CPJeffVVW2On5pkaaVOPcuXKmTx58pjXX389MWkAAAAAACSRdIlprrlkyRLz008/mbVr15rMmTObSpUqmZtuuimp0gQAAAAASKRETXYXFRVlmjVrZgO7jBkz2r8BAAAAACmwuealS5fM0KFDTeHChU22bNnMli1b7PKBAwea999/PznSCAAAAABIriBv2LBh5qOPPrJ98zJkyOBbXqFCBfPee+8FuzkAAAAAQCiDvIkTJ5rx48ebzp07m7Rp0/qWV65c2WzYsCEp0wYAAAAASO4gb+fOnaZUqVIBm3GeP38+2M0BAAAAAEIZ5JUvX94sWrQo1vIvvvjCVK1aNanSBQAAAADwYnTNQYMGmW7dutkaPdXeTZ8+3WzcuNE245w5c2Zi0gAAAAAACFVNXuvWrc23335rfv75ZzspuoK+9evX22VNmzZNqnQBAAAAAJKrJu+tt94yDzzwgMmUKZPZtm2bqVevnp0MHQAAAACQAmvyHn/8cXPs2DH7vESJEmb//v3JnS4AAAAAQHIFeYUKFTJffvml+e+//4zjOGbHjh22Ri/QI1hjxowxxYsXt7WEtWrVMsuXL493/WnTppmyZcva9StWrGhmzZoV7XX1EWzWrJnJkyePiYqKMmvWrIm1jTNnzphevXrZdTShe7t27czevXuDTjsAAAAApMgg7/nnnzd9+/Y1JUuWtIHTDTfcYGv0/B8K1PR/MKZOnWprCQcPHmxWrVpl59pr3ry52bdvX8D1lyxZYjp16mTuu+8+s3r1atOmTRv7WLdunW+dkydP2uakr7zySpyf269fP9uHUAHjggULzK5du8wdd9wRVNoBAAAAIMX2yVN/PAVXqsmrVKmSHXRFtWBXauTIkaZnz56mR48e9u9x48aZ7777znzwwQdmwIABsdZ/8803TYsWLUz//v3t30OHDrV9A0ePHm3fK126dLH/b926NeBnHj161Lz//vtm8uTJplGjRnbZhx9+aMqVK2d+/fVXc+ONN17x9wIAAACQPMY8NDfo90Slc0zhpsZM6LfQOBeignpvr3H/FzNEXE2eBl5Jnz69qVChgg2IateubWvdAj0S6ty5c2blypWmSZMm/y8xadLYv5cuXRrwPVruv76o5i+u9QPRZ2rSdv/tqPln0aJFg9oOAAAAAKTYmjw1qezYsaPtB3fvvfeaW265xWTOnPmKPvjAgQPm4sWLJn/+/NGW6+8NGzYEfM+ePXsCrq/lCaV1M2TIYHLmzBnUds6ePWsfLncgGgWMeqRUbtrD4TuQFvKF8sJxxPmF8y6/R/w2prRrhuRMj2qfgn5PWifa/8GIL/2kJTwktIylC2bglVtvvdU38IoGLwlENWKR6OWXXzZDhgyJtfzHH380WbJkMSldOE2JQVrIF8oLxxHnF8674YDfI/Il1GVGzQsTq1Cjk0G/J+aAhqTl8vnitVOnTiVdkKeBVx599FHTu3dv38ArMSn402uqnUuIvHnzmrRp08Ya1VJ/FyhQIOB7tDyY9ePahpqKHjlyJFpt3uW288wzz9gaTf+avCJFitiRPLNnz25SKt0N0AlJE9mrSS5pIV8oLxxHnF847/J7xG8j1wzhcT2l/mPBUg2eArxdc7Ma52Jwfc96vnETaQkyX7zmtiYM24FX1GSyevXqZs6cOXaETLl06ZL9W8FkIOoLqNc10qdLB5SWJ5Q+UweftqOpE2Tjxo12+of4tpMxY0b7iEnbCnVwlBTC6XuQFvKF8sJxxPmF82444PeIfAl1mQl2gJBo770YFfT740s7aQkPCS1fCQry5KqrrvINvFK3bt2AAU+wVDPWrVs3U6NGDVOzZk0zatQoOwWCO9pm165dTeHChW1TSenTp49p0KCBGTFihGnZsqWZMmWKWbFihRk/frxvm4cOHbIBm6ZFcAM4US2dHjly5LBTMOizc+fObWvhVEupAI+RNQEAAACkdAkO8lwKytTU8ZNPPjGbN2+20xkoWNI8dxq8REFZQt11111m//79ZtCgQXbQkypVqpjZs2f7BldRsKYRN1116tSxUx+o+eizzz5rSpcubWbMmGGDT9c333zjCxJFA8aI5uJ74YUX7PM33njDblc1eRpMRSN0jh07NtisAAAAQIRheH6kyiDv999/t9MPqEZMc9FpnjsFedOnT7dB2cSJE4PanppmxtU8c/78+bGWtW/f3j7i0r17d/uIj0YJHTNmjH0AAAAAQCRJ0Dx5/vr162eDqE2bNtlgyaWRNxcuDL5zKAAAAAAghDV5MfvAudRMM5j56gAAAAAAYVCTpwFXAg3d+ffff5urr746qdIFAAAAAPAiyGvVqpV58cUXfbOta2489cV7+umnfVMSAAAAAABSSJCn6QtOnDhh8uXLZ06fPm2nNChVqpSdYuGll15KnlQCAAAAAJKnT55G1dQE5IsXLzZr1661AV+1atXsiJsAAAAAgBQW5Lk0IboeAAAAAIAU3FwTAAAAABC+CPIAAAAAIIIQ5AEAAABABCHIAwAAAIAIkuiBV+TMmTPm3Llz0ZZlz579StMEAAAAAPCqJu/UqVOmd+/edp68rFmzmly5ckV7AAAAAABSUJDXv39/M3fuXPPOO++YjBkzmvfee88MGTLEFCpUyEycODF5UgkAAAAASJ7mmt9++60N5ho2bGh69Ohh6tevb0qVKmWKFStmJk2aZDp37hzsJgEAAAAAoarJO3TokClZsqSv/53+lnr16pmFCxcmVboAAAAAAF4EeQrwtmzZYp+XLVvWfP75574avpw5cyYmDQAAAACAUAV5aqK5du1a+3zAgAFmzJgxJlOmTKZfv362vx4AAAAAIAX1yVMw52rSpInZsGGDWblype2XV6lSpaROHwAAAAAgOWvyNOjK2bNnfX9rwJU77rjDNt1kdE0AAAAASIHNNY8ePRpr+fHjx+1rAAAAAIAUFOQ5jmOioqJiLd+xY4fJkSNHUqULAAAAAJCcffKqVq1qgzs9GjdubNKl+39vvXjxoh1xs0WLFolJAwAAAADA6yCvTZs29v81a9aY5s2bm2zZsvley5AhgylevLhp165dUqULAAAAAJCcQd7gwYPt/wrm7rrrLjttAgAAAAAghU+h0K1bt+RJCQAAAADAmyAvV65cAQdbCeTQoUNXmiYAAAAAQHIGeaNGjUrs9gEAAAAA4Rbk0UQTAAAAACJ0njzZvHmzef75502nTp3Mvn377LLvv//e/Pnnn0mdPgAAAABAcgZ5CxYsMBUrVjTLli0z06dPNydOnLDL165d6xuBEwAAAACQQoK8AQMGmGHDhpmffvrJzo/natSokfn111+TOn0AAAAAgOQM8v744w/Ttm3bWMvz5ctnDhw4EOzmAAAAAAChDPJy5sxpdu/eHWv56tWrTeHChZMqXQAAAAAAL4K8jh07mqefftrs2bPHzp136dIls3jxYvPkk0+arl27JiYNAAAAAIBQBXnDhw83ZcuWNUWKFLGDrpQvX97cdNNNpk6dOnbETQAAAABAmM+T50+DrUyYMMEMHDjQrFu3zgZ6VatWNaVLl06eFAIAACBijXlobtDviUrnmMJNjZnQb6FxLkQF/f5e4xoF/R4g4ufJk6JFi5pbb73VdOjQ4YoDvDFjxpjixYubTJkymVq1apnly5fHu/60adNsbaLW13QOs2bNiva64zhm0KBBpmDBgiZz5symSZMmZtOmTdHW0eepuan/43//+98VfQ8AAAAASBE1eY8//niCNzhy5MigEjB16lS7/XHjxtkAb9SoUaZ58+Zm48aNdsTOmJYsWWInYX/55ZfNbbfdZiZPnmzatGljVq1aZSpUqGDXefXVV81bb71lPv74Y1OiRAlb66ht/vXXXzYwdL344oumZ8+evr+vuuqqoNIOAAAAACkyyNPImf4UUF24cMFcd9119u+///7bpE2b1lSvXj3oBCgoVKDVo0cP+7eCve+++8588MEHdk6+mN58803TokUL079/f/v30KFD7Zx9o0ePtu9VLZ4CRfUPbN26tV1n4sSJJn/+/GbGjBl24Bj/oK5AgQJBpxkAAAAAUnRzzXnz5vket99+u2nQoIHZsWOHDfb02L59u7n55ptNy5Ytg/rwc+fOmZUrV9rmlL4EpUlj/166dGnA92i5//qiWjp3/S1bttiRP/3XyZEjh60ljLlNNc/MkyeP7VP42muv2cAVAAAAAFLVwCsjRowwP/74o8mVK5dvmZ4PGzbMNGvWzDzxxBMJ3pYmT7948aKtZfOnvzds2BDwPQrgAq2v5e7r7rK41pHHHnvMVKtWzeTOnds2AX3mmWfs/H9xNTc9e/asfbiOHTtm/z9//rx9pFRu2sPhO5AW8oXywnHE+YXzLr9Hqe+3UYOoBP2etE60/4MV33fwOj2kJWXni9cSmpYoR+0bg6Amjt9++61p2LBhtOWq5WvVqpU5fvx4gre1a9cuO4G6gqzatWv7lj/11FNmwYIFZtmyZQFH91RfO/XLc40dO9YMGTLE7N27126rbt26dtsaeMWlAWI0uIr6AAai5qEPPvigHS00Y8aMsV5/4YUX7GfEpD6BWbJkSfB3BgAAAIDEOHXqlLn77rvN0aNHTfbs2ZOuJq9t27a2/5xq9GrWrGmXKRhTH7k77rgjqG3lzZvX9uVTcOZPf8fVV07L41vf/V/L/IM8/V2lSpU406LmnGquuXXrVl9fQ3+q6fMfgEY1eZorULWX8WVwuNPdAPVpbNq0qUmfPj1pIV8oLxxHnF847/J7xG+jp9cMmgYhWKqNKdTopNk1N6txLgY/hULPN24Km/SQlpSdL15zWxNeTtBBngY3efLJJ20E6VYXpkuXztx33322X1swVCunwVrmzJljR8iUS5cu2b979+4d8D2q8dPrffv29S3TCcetCdRomgr0tI4b1CkzFIg+/PDDcaZlzZo1tj9goBE9RbV7gWr4dJILdXCUFMLpe5AW8oXywnHE+YXzbjjg98ibfEnMPHe+916MStT740u/1+khLSk7X7yW0LQEHeSpaaKaRyqg27x5s1127bXXmqxZswafyv9/eoZu3bqZGjVq2JpBjYx58uRJ32ibXbt2tU06NWWC9OnTxw78oppEDfQyZcoUs2LFCjN+/Hj7uppkKgBUH0HN3+dOoVCoUCFfIKkBWBT0abAYNT/V3/369TP33HNPtL6GKY3Xk4kykSgAAAAQfoIO8lwK6ipVqnTFCbjrrrvM/v377eTlGhhFtW+zZ8/2DZyybds2W8PmqlOnju0HpykSnn32WRvIaWoEd448t0+fAsUHHnjAHDlyxNSrV89u050jTzVyCg7Vz06DqSgQVJAXzHyAAAAAABBRQV5SUtPMuJpnzp8/P9ay9u3b20dcVJunic71CESjav76669XkGIAAAAASMHz5AEAAAAAUgaCPAAAAACIIAR5AAAAABBBCPIAAAAAIIIQ5AEAAABABCHIAwAAAIAIQpAHAAAAABEkLObJAwAgocY8NDfozIpK55jCTY2Z0G+hcS5EBfXeXuMasXMAACkKQR4i/iIsnNICAEA44LcRiGw01wQAAACACEKQBwAAAAARhCAPAAAAACIIQR4AAAAARBCCPAAAAACIIAR5AAAAABBBmEIBSKUYPhvgOAIARCZq8gAAAAAgghDkAQAAAEAEobkmAABIUjQHB4DQIsgDPMSFT/hjHwEAgJSO5poAAAAAEEGoyQOAMEWtIgAASAxq8gAAAAAgghDkAQAAAEAEIcgDAAAAgAhCkAcAAAAAEYSBVwCEHAOMAAAAJB2CPADAZRGIhz/2EQDARXNNAAAAAIggBHkAAAAAEEForgkAAOABmtQC8Ao1eQAAAAAQQajJAwAAEYvaMwCpETV5AAAAABBBCPIAAAAAIIIQ5AEAAABABCHIAwAAAIAIQpAHAAAAABEkLIK8MWPGmOLFi5tMmTKZWrVqmeXLl8e7/rRp00zZsmXt+hUrVjSzZs2K9rrjOGbQoEGmYMGCJnPmzKZJkyZm06ZN0dY5dOiQ6dy5s8mePbvJmTOnue+++8yJEyeS5fsBAAAAQKoJ8qZOnWoef/xxM3jwYLNq1SpTuXJl07x5c7Nv376A6y9ZssR06tTJBmWrV682bdq0sY9169b51nn11VfNW2+9ZcaNG2eWLVtmsmbNard55swZ3zoK8P7880/z008/mZkzZ5qFCxeaBx54wJPvDAAAAAARG+SNHDnS9OzZ0/To0cOUL1/eBmZZsmQxH3zwQcD133zzTdOiRQvTv39/U65cOTN06FBTrVo1M3r0aF8t3qhRo8zzzz9vWrdubSpVqmQmTpxodu3aZWbMmGHXWb9+vZk9e7Z57733bM1hvXr1zNtvv22mTJli1wMAAACAlCqkk6GfO3fOrFy50jzzzDO+ZWnSpLHNK5cuXRrwPVqumj9/qqVzA7gtW7aYPXv22G24cuTIYYM5vbdjx472fzXRrFGjhm8dra/PVs1f27ZtY33u2bNn7cN19OhRX7PP8+fPm3Bw5lLwzU2jLjjm1KlT5swFY5xLUUG99+DBg6SFfKG8cBxxfuG8y+8Rv40p6poh3NJDWlJ2vnjt+PHjvoqteDkhtHPnTqXOWbJkSbTl/fv3d2rWrBnwPenTp3cmT54cbdmYMWOcfPny2eeLFy+229y1a1e0ddq3b+906NDBPn/ppZecMmXKxNr21Vdf7YwdOzbg5w4ePNhulwd5QBmgDFAGKAOUAcoAZYAyQBmgDJgQ5sH27dvjjbNCWpOXkqi20b8G8dKlS7YWL0+ePCYqKvg7SOHi2LFjpkiRImb79u12EBrSQr5QXjiOOL9w3uX3iN9Grhm4nuI6MzypBk+1eYUKFYp3vZAGeXnz5jVp06Y1e/fujbZcfxcoUCDge7Q8vvXd/7VMo2v6r1OlShXfOjEHdrlw4YIN2uL63IwZM9qHPzX5jBQK8EId5LlIC/lCeeE44vzCeTcc8HtEvlBmOJbCkbqihfXAKxkyZDDVq1c3c+bMiVZDpr9r164d8D1a7r++aIRMd/0SJUrYQM1/HdVWqa+du47+P3LkiO0P6Jo7d679bPXdAwAAAICUKuTNNdUEslu3bnYQlJo1a9qRMU+ePGlH25SuXbuawoULm5dfftn+3adPH9OgQQMzYsQI07JlSzsi5ooVK8z48ePt62o62bdvXzNs2DBTunRpG/QNHDjQVmlqqgXRqJwaoVOjemo0Tw2c0rt3bzsoy+WqPgEAAAAgnIU8yLvrrrvM/v377eTlGhVTTSo1vUH+/Pnt69u2bbOjXrrq1KljJk+ebKdIePbZZ20gp5E1K1So4FvnqaeesoGi5r1TjZ2mSNA2NXm6a9KkSTawa9y4sd1+u3bt7Nx6qY2aoGqOwphNUUkL+UJ54Tji/MJ5l98jfhu5ZuB6iuvMlClKo6+EOhEAAAAAgAiZDB0AAAAAkHQI8gAAAAAgghDkAQAAAEAEIcgDAAAAgAhCkAcAAAAAEYQgLxX6+uuvzTfffGOfa9L4xx57zIwdO9ZOBu8lfd5HH31kXnrpJfPbb79Fe82dFzEcaO5Gr82aNcs8/PDDplWrVvbx0EMPme+++87zdAAAQmPfvn1m9erV5vfffzfHjx8Pi91w4sQJOzfxwYMHPf9s5UO4Onr0qFm5cqU5dOhQqJNiDhw4YBYuXGh2795twsHPP/9swsWhMNg/XmIKhVSmV69edl7Cs2fPmquuuspoBg1NEj9z5kyTI0cOT+cKvP/++82ZM2dMjRo17NyHtWvXNm+88Yadt7BatWpm1apVJhwULVrUztfolUceecTuo3vuuccULlzYLtu5c6ed2zFPnjzmnXfeMV46duyYnWdSaUibNq2dm7J58+bR5q/0yrJly0y+fPlMiRIlzC+//GJ+/fVXc91115nbb7/d03ToOGndurUpVqyYCbXTp0/beS7d/aEbN2vWrDHlypUzt956q6dp0XnFf87N77//3t7Auf766+1cpKE2bNgwO8dqKBw+fNieb3Pnzm2P70WLFtmyq7zx2r///msvAHWezZw5s2/5Tz/9ZJo2bWrCgY71WrVqeb6PfvzxR3uuk0KFCtlzXa5cuTwPZvr27Wt27dpltm7dam644QZ74a7fyjfffNOWIa98/PHHpn///ubqq682r732munXr5/9Dfjrr7/MkCFDTJcuXTxLS7p06ew5t0OHDnaOZc2rHCqdOnUyb7/9tsmbN6+9KatrKx3LGzZssOeZjh07epYW7YNPPvnEdwxrjmiVGV1D6YZ5+/btPUuL8sKfznm61nv//fft317+Ji1dutTeLNdv47hx48zAgQPNjh077I2Kzz77zM67HfE0Tx5Sj4oVK9r/z58/7+TNm9f+LxcuXPC95pVKlSr5nuvz+/bt69xyyy3O8ePHnSpVqnialquvvjrgQ3mULl06T9NSunTpOF8rVaqUp2n59NNPnRtvvNF58MEHneuuu87p3r27c//99zuVK1d2Vq9e7Wla+vTp49StW9epVauW89xzzzkNGzZ0XnvtNadly5a27HgpR44cTvHixW3evPHGG87OnTudUNFxdPjwYft8+PDhzs0332zz5fbbb3eeeOIJT9NStWpV3/ORI0c6DRo0cMaMGePcdtttzrPPPutpWvr37x/t8eSTTzo5c+b0/e2lCRMmOCVKlLCPsWPH2nL8yCOPOBUqVLCveentt992ypYt67Ru3dopWbKkM3369ID7L9SKFCni6ee999579hzXr18/e/zoofOK8kqveemGG25wNm/ebJ/rPNupUyf7/LPPPnNatWrlaVpURg8cOOBs3brVyZ49u7Nt2za7/ODBg/Y1L+m64J9//rHnOT0vU6aMM3DgQGfdunWO1/y/u36T3N8AnYv9r2284H+9VK9ePefvv/+2z/fs2eP5tZSul2699VanR48e9npBj2zZstn/tczr4+iPP/5wfv31VydPnjzOsmXL7HItq127tpMaEOSlMro4d915553RXvP6xKQf1IsXL0ZbpgvCatWq2QtoLxUtWtSeEAO55pprPE1LjRo1nFmzZsVaPnPmTKd69eqepkWB/+nTp+3zQ4cOOY0aNbLPN2zY4NSsWdPTtFx//fXOpUuXbHp0wj5z5ozvBkEoLjZk8eLF9kJQF6T169d3Ro8eHWc5Si7ly5f3PVf5OHv2rH2uY8vrGzf+FxQ6jo8dO2afK01e76NixYo5HTt2dD7++GPno48+sg/dtHGfe0n74dSpU/bCOGvWrM6+ffvs8iNHjkQ7J3tB++HEiRP2uS7Y69SpYy+axesLwvbt2wd86LdJ+eQlBQxuvvjTTcf4brwlB//jVuc8/+C7XLlyIUmLzif58+eP9prXx3TMmxAKZoYOHWrTqN8HL+l6ae/evfa5zv3nzp3z7S//c7LX+aLrB39eH9Nr1qyxQd6IESPsb7Po5lYoVPH77jGPm3C6oZWc0oW6JhHeKl++vK2qzpYtm5k2bZpvuZojZs2a1dO0qIndvHnzTOPGjaM1VVRzDDVV8ZKaN6gaP3/+/LFe69Gjh6dpmTp1qnn66adtEwc1z3Tbkd94441mypQpnvebVBNN0f9Hjhyxz9XM7OTJk8ZrFy5csE0Cz58/b5v6qmngxYsX7cNLUVFR9n8199BDzYzVfPTzzz+3zWS8bN6rMrtkyRKbDjUvU7Mu/R+KPjzaJ+vXr7flRvtETcIlQ4YMvnLkFaVD/X2//fZb22SpVKlStnlZt27djNfUzEzNIvVQOtT0TdRE3i1LXh5D7rm+SJEi9hzctWtXc99999nXvO6ro2Zm+j3ypxvQ6lPkJe0HHTMxfwe1zOt9pGaIav7XqFEj24e+Xr16vqbZXvedV1o6d+5sTp06ZdOj36VbbrnFNgsvU6aMp2lRufCnZqNqfq2Hmkl66fXXX7fXLmq2qTxSM2fli5phq6uF18171Y1B+aPyqqbYBQsWNOfOnfP8t7Fy5cp2/AAd18ofXcuEivN/FVn2+FXTWpeOIeVNakCfPFj6cdeFs3//DISe27ndDfa8ph8yBZbqLzl//nw7SE/Pnj1tnyL1SVNw4RUFUmPGjLE/Wk888YTtR6ofeaVB7fyHDh3qWVqqVq1qB0QIxP1R8Yr67HTv3t0GUrpAVbCpvjsatEFBTosWLTxLy8033xztb/W11cWGyrH6NmnABq/9888/5sknn7Q3JlSW//vvP8/ToMBfF3+ZMmWyAzQouBPdcKtfv36cZSk56Fh55pln7Of6GzBggHn11Vc9DSLuuOMOe0PvpptuivWaLprVv8grOp/ovFKhQgVfX2jd+Pvzzz/NiBEjzG233eZZWnQBOn78eHujolKlSjYA140CBVp79uwxJUuW9CwtOt8q0NQ5TYOAqa+kjmvdIFAgGjNAT076DWrYsKEJF7rpqbzYtGmTvYZSuVEe6WZ6uKRPZUi/36Gg/vwvvPCCHZBmwYIFnn/+woUL7bk35nXtli1bfH0XIx1BXiqku4GqGXJ/yFz6MfN6EIBwGgAgnPIlnNKybt06+0Ohix8N5hFKqqUSdXbXD5hqAnSx4fUADW5teDjRQAj+Fxv6cfO69iy+C0XVwGbJkiVkadCIwhqoZ/jw4Z5/tgK77Nmzxwr+FYgr6NS+8vLcIoFu6GnAkZjnnNRE5XT58uV2wBNRjXjNmjXD5jgCgKCEur0ovDVt2jSncOHCth+I2rGrQ2qo2iiH0wAA4ZQv4ZSW+IRysJFwTov//go18iX88yWc0kLZDb99pD5e+o3866+/QpaGcEyL+sDpN9IdTCOUyJfwz5dLYZQWLxHkpTI6KboDQ6xYscJ2Vp40aVJIOuiG0wAA4ZQv4ZSWcBr9Lj6khXyhvHAcReL55bvvvrMDg2l04VALp7RMnTrVDn5y7733hjop5EsKyJfvwigtXmLglVRG/e7cwUWqV69u2yy3bdvW9ltJzQMAhFO+hFNannrqqYDLdYNITdBSa1o0T1NcafF6slXyJfzzJZzSQtkN/33kb8KECebDDz+0832pz6T63pIWY9577z3z0Ucf2fnoQt18Ppz2EfkS/vvISwR5qYxGYNJITOrMLZpUVf3fNOKclntJE1prMAJ3AAAddBoYQQMAqO9Zas2XcEqLJl7X4CsaMCKm9OnTp9q0hNOogORL+OdLOKWFshv++8il/urqt65RLTVgjkbE1kiXqT0tmzdvtqNIagAs3bT49NNPzUMPPRSStJAv4Z8vu8MoLZ4LdVUivLV9+3Zn9+7dAV/75ZdfPE2L5o3SI5AdO3ak2nwJp7Q0btzYWbRoUZzzHKbWtLRt29ZZsGBBwNeaNGniaVrIl/DPl3BKC2U3/PeR66WXXnJef/113wTODRo0CEk6wi0tAwYMcN599137/N9//401N5yXyJfwz5eXwigtXmN0TYQNDQ2tZopeN0lE3DQXnu5ih0PThnBKSzghX8I/X8IpLeEknPIlnNLitgooW7asnSLGnUJHc6WqBYGmjkmtaVFXDk2HsnbtWl9LCs3H9tprr9lRur1EvoR/vjhhlJZQSBPqBCB0NOdOzpw5bfOdUFM/Js39o/l4Qi2c8iXUaVGfyXC56AmntIQT8iX88yWc0hJOwilfwiktouaII0eOjDZHqpqUxpwQPLWlRXMIfvnll9Gayn/wwQe+fuxeIl/CP1+Oh1FaQoEgLxX77LPPTJUqVeykq6GmuyqabPbdd98NdVLCKl/CKS0aEEZp0TxSoRZOaQl1IO6PfAn/fAmntFB2w3cfaV7Fli1bRpvAWX3QypQpk6rTork2tW9cixcvNsWKFQvJ/I7kS/jnS/YwSksoEOSlYu+//759aBJld5LpUNGoR2+99ZZNx7Zt20KalnDKl3BKy1dffWXvfoVDIB5OaQmnQJx8Cf98Cae0UHbDfx+52rVrZ8JFOKXl0UcfNeGCfAn/fGkXRmnxAkFeKqX27JkzZzbXXnut6dKlix2KOFR++eUXeyeuQIECpkePHjaoCZVwypdwSov/0MzaXxqymrSEXyAeTvuIfAmMfRT++RJOaXGFU/My0kK+UF5SBoK8VEpzhtx///32uYbmD2UAoR/Unj172ud33323vbscqh+RcMqXcEpLoCGrSUt4BeLhtI/Il8DYR+GfL+GSlmPHjpnPP//cvPHGG7aVi+bxu3TpUkjSsmzZMtvMTRT4durUyXz77beep+Obb74xp0+fjrYsVLWtSof//pgzZ44dln/WrFkm1NatW2f30cqVK004uOOOO0L22YcPH/bNXbt//37z3HPPeT5FV0iFenhPeE/TFpQoUcI5e/asb1nr1q2d+fPne56Ww4cPO9dee61z8eJF37LOnTs7M2fOTNX5Ek5pCbchq8MpLb169XImT55sn2vai+uvvz5kaSFfwj9fwiktlN3w3Ueffvqpc+ONNzoPPvignb6he/fuzv333+9UrlzZWb16tadp6dOnj1O3bl2nVq1aznPPPec0bNjQee2115yWLVs6ffv29TQtmTNndq6++mqnY8eOzldffRXt99FrlSpVstcvMnz4cOfmm2+2+XL77bc7TzzxhKdpadSoke/5pEmT7O9Q//79nerVqztvv/22p2nR5/o/nnzySSdnzpy+v700YcIEex2lx9ixY205fuSRR5wKFSrY11IDgrxU6Ny5c87evXujLTt69Kh9pGbhlC/hlJbz5887JUuWdI4fPx7tR2XlypWpOi3hFIiTL+GfL+GUFspueO+jihUrOqdPn7bPDx065LuI37Bhg1OzZk1P06KA4dKlSzY9efLkcc6cOWOXX7hwwV4se6lKlSrOiRMn7I21Nm3aOPnz53e6dOlibwpr33mpfPnyvucKptzfAd2w1v7zOl9cKh/uPLsqx16npVixYjYI//jjj52PPvrIPvLmzet77qWKFSvac93BgwedrFmzOvv27bPLjxw5Ym+YpAYEeXA+//zzsMmFUaNGOeEinPIllGk5efJkrLvHW7du9XzC+nBLSzgF4uRL+OdLOKWFshve+0iBlfaR6HxSrVq1aK+FIi26MM6ePbv9XxTUlCtXztO0VK1aNdrfx44dcz755BNbe1agQAFP06Kau8WLF9vn+vydO3fa58ofrwMrBSwKZhQAx6x59g8AvaB0qMb3zjvvdDZt2mSX6WZoKFT1Ky8xgzqv8yVUCPIQ68QZSqQl/PPll19+ccJFOKUlnG4KkC/hny/hlBbKbnjtIzX7U+1Q7969bW3Z+PHj7XLVRNSuXdvTtIwcOdJ2qShevLht+te8eXObLgWezz//vKdpie/C3Ouba1u2bHEaNGjgNG3a1NYqqraqRYsWNl9mz57tee2ZAintI/2/a9cuX01eqGqsFOCpZctTTz3lFC1aNCRpqFGjhq9G3L054eZLagnyovRPqPsFIrTUwXz16tVhsRtIS/jnS7Vq1cyqVatMOCAt5AvlheMoEs8vGjxj/fr1pkKFCqZcuXImlNxRg/PmzWuOHDli5wQtUqSIqVWrlqfp+Pvvv8NufjONqrxp0yZz4cIFO1ffDTfcYNKmTWvCgebB3Lt3rylRokTI0qDBcn799VczfPhwzz/76NGjdp68qKioaMv37dtn/vvvP7uvIl26UCcAoReKUbLiEi6jQYVbvoRTWsLpvhBpIV8oLxxHkXh+UXCnRzhQcOfKmTOnufPOO0OSjnAL8KR8+fL2EY40cXwoAzxp1aqVfYRCjhw5Ai7Ply+ffaQG1OSlQl9//bW9s6EDT8P+6u+yZcuahx56yKRJ4+2sGvPnzzc7d+40DRs2tHfBXB9//LGdNiAcjBo1yvTt29fTz9QwzArslDdSqFAhc/vtt5uWLVuaUFu+fLmpWbOmCQfhlJYdO3aYa665xoQD8iX88yWc0kLZDf99BADBIshLZXr16mXnCjl79qy56qqr7J3KNm3amJkzZ9q7HpqPxyuar2Tx4sWmSpUq5rvvvrNpc4OpcGqGV7RoUbNt2zbPPu+RRx6x++iee+7xBb4K9iZNmmTy5Mlj3nnnHeMlNUX56quvbBrUDKV06dJ2Dh7d0fXS+fPnzfTp003BggXNTTfdZCZPnmyWLFlirrvuOvPggw+aDBkyeJYWHSetW7c2xYoVM6Gm+asKFChg5+vTvE0ffvihWbNmjW3ipfkn06dP71ladF7JmDGj7+/vv//e/Pbbb+b666837dq1M6GmG1njxo0L2dyBurlWqVIl28Rr9uzZ9ubarbfe6nla/v33X7N79257nlW5cf3000+madOmJhx8+eWXnpcZzZ+l38KYN9dUfgEgpSHIS2V0gfH777/b9uO6WNYPfbp06czFixdtvy+95mVa1M9MgYMmn+3Ro4cNYsaOHWtq1KjhaR+0uKruFQSrD4ICDC+bpKjvQSAKsBR0eWXEiBFm7ty5pn79+vaCXftMAYUm6dVrTZo08Swtd999t90fJ0+etO3sFdBoklXVRmviYAXBXlGAmytXLpsXd911l500WReEoaAmXStWrDCZMmUyTzzxhO1voABUteQ6rlQr7hX/mzOaxFmtBJQ3btl56aWXPEuLPtefyo4Cq1tuucX+rTLslWHDhtkbWTrv6pjRua1x48bmhx9+MDfffLO94eWV0aNHmzFjxtibI3/88Yd5/fXXTdu2bU1qv7nm7qOOHTtGu7k2ZcoUG4gPHDjQs7QAQJII9cgv8Jb/SEsa4jbm5J5e0iSvMWkkpmbNmjllypTxNC0a/WnPnj0BX7vmmms8HxFq1qxZsZZrLiCNuOb18NnuRPUapap+/fr2uebh8bq8uMNSa34mDZetuZtcXqfFHZlLQ2hrQuAiRYrYvBk9enSc5Si5lC1bNs5RWEOVL6JR5jTEuTvcutdzamnyZs3XNHfuXDt34bx582y50XOv5zJ0jyMNL65h6DXUuWjOMa+HW9d+cD9/27ZtTp06dexkzuL1iHM33HBDwIfOgRkzZvQ0LaVLl452TnHpfFOqVClP0wIAScHbDlgIOXUQPnHihH0+bdo033LdMc2aNaunaalevbr58ccfoy175ZVX7F1lNSfy0gMPPGD7pQSiGkYvTZ061XzwwQf2brJqPypWrGj7eqkZnu4qe0nNy9zycvjwYXPmzBn7XDVYqpXwmmpV9+zZY06fPm127drlG0HLy5pWcUfrqlOnjq2x0vGj0cM2btzo+YhdqpFRmXGPb9XOyNatW20tvZdUPjQioJq9qXWAmoSLmtJ6PeLc0qVLbW2Z9ov6Gqvfr5omNmjQwD68pCazSoM+XzWv7rlWTVu97get49b9fI2QOG/ePNuU9L777vP8mNZx8+6779rfopiP3Llze5oWlVE1o41J5dm/CTIApBhJEioiRdHd5JiTu54/f975/fffwyIt8scff4RNWtatWxeStGzfvt05cOCAfYQqLZ9++qlTsmRJ57bbbrNz8Hz99de++Zrat2/vaVomT57sFCpUyD6+/PJLO1+T0qVa2LFjx3qalvhqPALVBiSngwcPOvfcc4+dmLhevXpOhgwZbO3eTTfd5KxcudLTtDRs2DDaw52vSWXY61po16FDh5yHH37Y1up5XSvv0r7Q3Ewx7d+/P9bkxcntlltucRYuXBhr+dNPP+1ERdkeHJ7p1auXs2TJkoCvde/e3dO0LFu2zNYiqgZak1vroZpxLdNrAJDSEOSlMl988YVTuHBh22xTzYR+/fXXkE24TVoCmzZtmt1HCiRCvY/cC/Tly5fbi2V//ukKBd2Y+O2332wg4XVaAl2whzpfNBnwmjVrnBUrVtjmtKFMS6Amb3FdzHtl9erVzjvvvBNW+aJ9FijgSu4bSHoEsmjRIidchGof6XyiY0gP9yZFuJQXAAgGQV4qo+DO7TOkHzH1FZk0aVJI+mOQlvDPl/ioH1q4IC3kC+WF4yg1nF8AIKGYDD2VUd+l/Pnz+/rELVy40PaB++eff3z9jEgL+RLXCIUu3SA6dOiQp+WFtJAvlBeOo9RwfgGApECQl8poqgBNk6ABPUSd2zU3kiYe93L6BNKSMvLl559/Np988onJli1brAsf3SAgLeQL5YXjiPMLAIQfgrxURhfsMUfc06hin332menduzdpIV+i0YiEGiFRk4/H5AahXiEt5AvlheMoNZxfACApMBk6AAAAAEQQ5skDAAAAgAhCkAcAAAAAEYQgDwAAAAAiCEEeAAAAAEQQgjwAQIJoLs0ZM2bEu0737t1NmzZtPMnR999/3zRr1syTzwLi89dff5lrrrnGnDx5kowCEBYI8gAgTGlY9759+5pwsXv3bnPLLbfY51u3brVB35o1a6Kt8+abb5qPPvoo2dNy5swZM3DgQDN48OCAr1+6dMlkz57d/P333/bvMmXKJMncjgkJdAMpXry4GTVqlIkEXgbyKUX58uXNjTfeaEaOHBnqpACARZAHACmYJqa/cOGCJ59VoEABkzFjxnjXyZEjh8mZM2eyp+WLL76wQVzdunUDvr5u3TqTKVMmG9zt3bvX/Pfff+aGG25I9nQhfjt27LBlNpxcvHjR3hS4Uj169DDvvPOOZ8cjAMSHIA8AwrS2ZMGCBbZmTLVHeqj2bP78+fb5999/b6pXr26Drl9++cVs3rzZtG7d2uTPn99ky5bNBjQ///xzrNqk4cOHm3vvvddO/Fy0aFEzfvx43+vnzp0zvXv3NgULFrQBUrFixczLL78csBarRIkS9v+qVava5ap1DFTLc/bsWfPYY4+ZfPny2W3Wq1fP/Pbbb77X3e8zZ84cU6NGDZMlSxZTp04ds3HjxnjzZ8qUKeb222+P8/UlS5bY7YjyR+nMnDnzZfP966+/NtWqVbNpLVmypBkyZIjvol35J23btrVpdv++XN4rbxRk9uvXz7cvRcv0HXLlymWyZs1qrr/+ejNr1qw40/bJJ5/YPNK+U8B99913m3379tnXFKSouaCCDH+rV682adKksZ8lqmmqWLGi/bwiRYqYRx55xJw4ccK3vmphFaT/8MMPply5cvb7tGjRwtbiygsvvGA+/vhjm0/ud9E+TCjVvipfVQP777//Jvh9CckD//L03Xff2UnMtR9Vw6agP+Z3/Oabb2wNnI6hbdu22bL65JNPmsKFC9v8qVWrVrTvdrn91bRpU3Po0CF73AJAyDkAgLBz5MgRp3bt2k7Pnj2d3bt328eFCxecefPmqRrEqVSpkvPjjz86//zzj3Pw4EFnzZo1zrhx45w//vjD+fvvv53nn3/eyZQpk/Pff//5tlmsWDEnd+7czpgxY5xNmzY5L7/8spMmTRpnw4YN9vXXXnvNKVKkiLNw4UJn69atzqJFi5zJkyf73q/P/eqrr+zz5cuX279//vlnmzalQbp16+a0bt3a957HHnvMKVSokDNr1iznzz//tK/nypXLt777fWrVquXMnz/frlO/fn2nTp068eZPjhw5nClTpgRcrkfGjBmdDBky2OfKh/Tp09vnLVu2jHOb+t7Zs2d3PvroI2fz5s02f4sXL+688MIL9vV9+/bZtH744Yf2O+tvuVze67tec801zosvvujbl6K0NG3a1Pn999/t53377bfOggUL4kzf+++/b/NR6y5dutSWj1tuucX3+pNPPunUq1cv2nueeOKJaMveeOMNZ+7cuc6WLVucOXPmONddd53z8MMP+17Xd1NeNWnSxPntt9+clStXOuXKlXPuvvtu+/rx48edDh06OC1atPB9l7NnzzoJdezYMfs9GjRoYMue9rX+1vKEuFweuOVJadb+U97edtttdj+eO3cu2ndUGVu8eLEt/ydPnnTuv/9+u0zlQMeVjgeVI+3ThO4vlePBgwcnOD8AILkQ5AFAmNKFcJ8+faItcy9iZ8yYcdn3X3/99c7bb78dLci75557fH9funTJyZcvn/POO+/Yvx999FGnUaNGdnkg/kGeggT9vXr16mjr+Ad5J06csBfTkyZN8r2uC20Ffa+++mq076Ng0fXdd9/ZZadPnw6YjsOHD9vXdTEek9L177//2kDy+++/t3+XLl3apkHP3QArkMaNGzvDhw+PtuyTTz5xChYsGDAPgs17BVj+Klas6AsgE0NBmNKjwEu0L6KionzB5cWLF53ChQv79m8g06ZNc/LkyeP7WwGQtqkgx6WbAvnz5/f9HTOQTyzdSBg6dKhTpkwZJ0uWLE7nzp1tYBZX+UtIHrjlyf8GgILszJkzO1OnTo32HRWcu5RnadOmdXbu3BmrTDzzzDMJ3l9t27Z1unfvnuD0A0ByobkmAKRAarLmT03u1NRMTezUFE3N7NavX2+boflTEzaXmrWpyZvb3E1NLTWQynXXXWebWP74449XlEY1Yzx//ny0fnPp06c3NWvWtGmLK11qLir+zfD8nT592v6vpngxqQnl/v37bbNPNTNMly6d2bVrl2nXrp19Td83LmvXrjUvvviizTv30bNnT9tU8dSpU3G+L6F5H5PyeNiwYTZ/1Hzx999/j3f9lStX2uaCamar5ooNGjSwy93PqVKlik3D5MmT7d9qNqg8bN++vW8bakbauHFj2yRR2+jSpYs5ePBgtO+nvLv22muj7Y+49kVcJk2aFC0fFy1aFGsdNQd+/vnnbdPcsWPH2iagGi316NGjic4DV+3atX3Pc+fObcu0f5nLkCFDtDL3xx9/2L556sPpn27locpxQveXmgTHV1YAwCsEeQCQAqlPkD8FGV999ZXtc6cLagVr6nulfnb+FGT5U6DnDjqhvmhbtmwxQ4cOtYFUhw4dzJ133unBt4meLrfPWlyDYeTJk8euc/jw4WjLNfKnLsxvuukms2fPHvu8dOnS9qJb79Hf8VGwpj54yjv3oYv/TZs2BQwog837mO6//37bL02Blj5Hgfvbb78dcF0Nzd+8eXM72IwCKPVr1GeK/+d07tzZF+TpfwW6+u6iPp233XabDW6+/PJLGzCNGTMm1jYClZFgB0tp1apVtHyMeVNCDhw4YL+vgn4F040aNbLp0uA9V5IHCaFgzC1n7r5PmzatzRP/dCswVL/YhO4v9cm7+uqrg0oLACSHdMmyVQDAFVNtg2oXEmLx4sW2Jk6DgrgXrbqoD5YuoO+66y77UICnIEEXrqoNiZk2iS99qg3Sekqbam1ENXu6OL+SqSG0TQ2YobnJ/OfJe++992xw2q1bN3PHHXfYwVAUgJUtW9ZeoF+OglzVKpUqVSrOdRQAxfzOCcn7uPalBj956KGH7OOZZ54xEyZMMI8++mis9TZs2GBr3P73v//Z98iKFStiraeBSFQ7pmBFI5COGzfO95qWKXAeMWKEHYxFPv/8c5Mc5VK1bHrEpMFNNOCJBlCZPXu2HbxEeaeBUi4XHCU0D+TXX3+1tX2imwGaSkO1nHHRwDz6TqqxrF+/fpzrXW5/aYAXr26MAEB8qMkDgDCl5oXLli2zAYNqPeIb5l01VtOnT7e1D2p2qIv9YIeF18iLn332mb2Y1kXxtGnTbPPGQFMiaLRM1YboQl1TFARqYqfaxocfftj079/frqegTDU2qlm77777zJVQjY5GzfSnJojKMzWjU5CnYE3PFezpeXzBmwwaNMhMnDjR1ub9+eefthZHo3gqaHJp+xoJVDWFbk1iQvJe79M8fTt37rT7UhToahRL1Z6uWrXKzJs3L85ARAGLgivVHKk2SYGSalxj0udoVFHlr4IW1ai59P0VZLvbUKDlHwQmlJvHCoj1XbTNhNJongqKlGcK0DT6Z58+fRJU+5XQPBA1u9V+UtClIDJv3rzxzu2nZpqqBe3atavdl9ony5cvt6PLKgBNyP7Scar926RJkwTnBwAkm2Tr7QcAuCIbN250brzxRjtohE7XGjjEHVhCg4/402s333yzXVcjZI4ePTrWwC2BBv+oXLmybzTA8ePHO1WqVHGyZs1qR5nUoBOrVq2Kc9CRCRMm2M/SKIn6rECDcmjwFA3okjdvXjtSYd26de3InK5A30cDiLjfNy4ahVPfVaOQ+tOIixrJUrZv324H9HBHVUyI2bNn2xEWtW3lQc2aNW2+uL755hunVKlSTrp06Wx+JjTvlS6NiKo8cH96e/fu7Vx77bV22dVXX+106dLFOXDgQJxp00inGiVS62tUSaUl0OA3Y8eOtcu7du0aaxsjR460A8korc2bN3cmTpwYLf81KIlGIfWnfe5/uaBRRTXKZLZs2exy7cOE0qiu58+fdxLrcnnglieNfKnBbzTCqvbh2rVrfdsI9B1F5WTQoEF2+xowSPmkgVQ0mmZC9pcG7VGeAkA4iNI/yRdCAgCQPDSgiJpYqtkcIJrX7uabb7a1rIFqoJOL+gSqdlL9IP0HGgKAUKG5JgAgRXrttdcuO5gK4AWN7vnss88S4AEIG9TkAQCAiBCqmjwACDcEeQAAAAAQQWiuCQAAAAARhCAPAAAAACIIQR4AAAAARBCCPAAAAACIIAR5AAAAABBBCPIAAAAAIIIQ5AEAAABABCHIAwAAAIAIQpAHAAAAACZy/H/8WbrpsoRa2gAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 900x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ec = res[\"emergent_complexity\"]\n",
+    "deltas = res[\"deltas\"]\n",
+    "print(f\"complexite emergente EC = {ec:.4f}\")\n",
+    "print(f\"nombre de transitions d'echelle L = {len(deltas)}\")\n",
+    "print(f\"log2(L) = {np.log2(len(deltas)):.4f}  ;  H(p) = {ec - np.log2(len(deltas)):.4f}\")\n",
+    "\n",
+    "# Ou se concentre le travail causal le long du chemin ?\n",
+    "fig, ax = plt.subplots(figsize=(9, 3.4))\n",
+    "trans_sizes = [s[\"size\"] for s in res[\"scales\"][1:]]  # taille apres chaque fusion\n",
+    "ax.bar(range(len(deltas)), deltas, color=\"tab:purple\")\n",
+    "ax.set_xticks(range(len(deltas)))\n",
+    "ax.set_xticklabels([f\"{a}->{b}\" for a, b in zip(trans_sizes[:-1] + [trans_sizes[-1]], trans_sizes)],\n",
+    "                   rotation=90, fontsize=7)\n",
+    "ax.set_title(\"Gain d'effectiveness par transition d'echelle (delta_cp)\")\n",
+    "ax.set_xlabel(\"transition (# etats avant -> apres)\"); ax.set_ylabel(\"delta effectiveness\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-ec-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005507,
+     "end_time": "2026-06-29T10:58:00.710950+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.705443+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Le travail causal n'est **pas** porte par une seule fusion : les gains $\\Delta$ se repartissent sur tout\n",
+    "le chemin, avec une concentration vers les **echelles les plus grossieres** (les dernieres fusions, qui\n",
+    "condensent les regimes de tri). D'ou une EC elevee : la morphogenese par tri possede une organisation\n",
+    "causale **reellement multi-echelles**, qu'aucune description unique — ni micro, ni le « niveau de tri »\n",
+    "intuitif — ne capture a elle seule."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-exercises-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00551,
+     "end_time": "2026-06-29T10:58:00.721466+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.715956+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Trois exercices pour manipuler le pont tri -> TPM -> emergence. Les cellules de code sont des **squelettes\n",
+    "a completer** : elles s'executent telles quelles (elles affichent un rappel et renvoient `None`) sans\n",
+    "casser le notebook. Reutilisez `collect_trajectories`, `TE.tpm_from_trajectories` et le module `CE`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-ex1-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006197,
+     "end_time": "2026-06-29T10:58:00.733317+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.727120+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — L'effectiveness micro depend-elle de la taille ?\n",
+    "\n",
+    "Faites varier la taille du tableau $n \\in \\{3, 4, 5\\}$ et mesurez l'**effectiveness micro** de la TPM\n",
+    "estimee pour chaque taille. L'effectiveness micro monte-t-elle, descend-elle, ou reste-t-elle stable\n",
+    "quand le systeme grandit ?\n",
+    "\n",
+    "- *Indice 1* : `collect_trajectories(n=...)` accepte deja le parametre de taille.\n",
+    "- *Indice 2* : ne lancez **pas** `greedy_apportionment` pour $n = 5$ (120 etats : trop couteux) — ici on\n",
+    "  ne demande que l'effectiveness micro, qui est immediate.\n",
+    "- *Etape* : pour chaque `n`, collecter -> `TE.tpm_from_trajectories` -> `CE.effectiveness`, puis tracer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ict6-ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:58:00.746599Z",
+     "iopub.status.busy": "2026-06-29T10:58:00.746093Z",
+     "iopub.status.idle": "2026-06-29T10:58:00.750974Z",
+     "shell.execute_reply": "2026-06-29T10:58:00.749932Z"
+    },
+    "papermill": {
+     "duration": 0.012415,
+     "end_time": "2026-06-29T10:58:00.752068+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.739653+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 - a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def effectiveness_vs_size(sizes=(3, 4, 5)):\n",
+    "    '''Renvoie {n: effectiveness_micro} pour chaque taille de tableau.'''\n",
+    "    results = {}  # n -> effectiveness micro\n",
+    "    # TODO etudiant :\n",
+    "    #   for n in sizes:\n",
+    "    #       trajs_n = collect_trajectories(n=n)\n",
+    "    #       tpm_n, _ = TE.tpm_from_trajectories(trajs_n, unseen=\"self\")\n",
+    "    #       results[n] = CE.effectiveness(tpm_n)\n",
+    "    #   ... puis tracer results ...\n",
+    "    print(\"Exercice 1 - a completer\")\n",
+    "    return None\n",
+    "\n",
+    "effectiveness_vs_size()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-ex2-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006072,
+     "end_time": "2026-06-29T10:58:00.764134+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.758062+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Un tableau chimerique change-t-il l'emergence ?\n",
+    "\n",
+    "Un tableau **chimerique** melange les algotypes (`bubble` *et* `insertion`). Construisez-en un (p.ex.\n",
+    "alternance `[\"bubble\", \"insertion\", \"bubble\", \"insertion\"]` pour $n = 4$), estimez sa TPM, lancez\n",
+    "`greedy_apportionment`, et comparez son **EC** et son **meilleur effectiveness macro** a ceux du bubble pur\n",
+    "calcules plus haut. Le melange de regles renforce-t-il ou affaiblit-il la signature multi-echelles ?\n",
+    "\n",
+    "- *Indice* : `collect_trajectories(n=4, algotypes=[\"bubble\", \"insertion\", \"bubble\", \"insertion\"])`.\n",
+    "- *Comparer a* : `res[\"emergent_complexity\"]` et `max(s[\"effectiveness\"] for s in res[\"scales\"])`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ict6-ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:58:00.777498Z",
+     "iopub.status.busy": "2026-06-29T10:58:00.777498Z",
+     "iopub.status.idle": "2026-06-29T10:58:00.782843Z",
+     "shell.execute_reply": "2026-06-29T10:58:00.781769Z"
+    },
+    "papermill": {
+     "duration": 0.013902,
+     "end_time": "2026-06-29T10:58:00.783932+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.770030+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 - a completer"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def emergence_chimerique():\n",
+    "    '''Compare l'emergence d'un tableau chimerique au bubble pur (res calcule plus haut).'''\n",
+    "    # TODO etudiant :\n",
+    "    #   algos = [\"bubble\", \"insertion\", \"bubble\", \"insertion\"]\n",
+    "    #   trajs_c = collect_trajectories(n=4, algotypes=algos)\n",
+    "    #   tpm_c, _ = TE.tpm_from_trajectories(trajs_c, unseen=\"self\")\n",
+    "    #   res_c = CE.greedy_apportionment(tpm_c)\n",
+    "    #   comparer res_c[\"emergent_complexity\"] et max(eff) a ceux de `res`\n",
+    "    print(\"Exercice 2 - a completer\")\n",
+    "    return None\n",
+    "\n",
+    "emergence_chimerique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-ex3-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005749,
+     "end_time": "2026-06-29T10:58:00.795781+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.790032+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — La robustesse preserve-t-elle l'emergence ?\n",
+    "\n",
+    "ICT-2/ICT-3 ont montre que le systeme **se trie quand meme** avec une cellule defectueuse (`frozen`,\n",
+    "mode `passive` : elle n'agit pas mais reste deplacable). Cette robustesse morphogenetique se traduit-elle\n",
+    "dans le **profil d'emergence causale** ? Ajoutez une cellule gelee (p.ex. `frozen=[False, True, False, False]`),\n",
+    "estimez la TPM, et comparez determinisme micro + EC au cas sain.\n",
+    "\n",
+    "- *Indice* : `collect_trajectories(n=4, frozen=[False, True, False, False])`.\n",
+    "- *Reflexion* : une cellule passagere ajoute-t-elle du bruit (baisse du determinisme) ou laisse-t-elle\n",
+    "  l'organisation multi-echelles intacte ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ict6-ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T10:58:00.808313Z",
+     "iopub.status.busy": "2026-06-29T10:58:00.807313Z",
+     "iopub.status.idle": "2026-06-29T10:58:00.812622Z",
+     "shell.execute_reply": "2026-06-29T10:58:00.811463Z"
+    },
+    "papermill": {
+     "duration": 0.011822,
+     "end_time": "2026-06-29T10:58:00.812622+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.800800+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 - a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def emergence_robustesse():\n",
+    "    '''Compare emergence avec une cellule frozen passive au cas sain.'''\n",
+    "    # TODO etudiant :\n",
+    "    #   frozen = [False, True, False, False]\n",
+    "    #   trajs_f = collect_trajectories(n=4, frozen=frozen)\n",
+    "    #   tpm_f, _ = TE.tpm_from_trajectories(trajs_f, unseen=\"self\")\n",
+    "    #   comparer CE.causal_profile(tpm_f) et CE.greedy_apportionment(tpm_f)[\"emergent_complexity\"]\n",
+    "    #   au cas sain (tpm_micro / res)\n",
+    "    print(\"Exercice 3 - a completer\")\n",
+    "    return None\n",
+    "\n",
+    "emergence_robustesse()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict6-conclusion",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005952,
+     "end_time": "2026-06-29T10:58:00.824576+00:00",
+     "exception": false,
+     "start_time": "2026-06-29T10:58:00.818624+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a construit le **pont** annonce dans la feuille de route ICT : des **trajectoires** de\n",
+    "morphogenese par tri (ICT-2) a une **chaine de Markov** etat-a-etat (`ict.tpm_estimation`), puis a une\n",
+    "analyse d'**emergence causale** (`ict.causal_emergence`, d'apres Hoel 2025).\n",
+    "\n",
+    "Ce qu'on retient :\n",
+    "\n",
+    "- **CE 2.0 passe a l'echelle la ou PyPhi cale.** En travaillant sur une TPM etat-a-etat plutot que sur\n",
+    "  $\\Phi$, on analyse des espaces d'etats ($n!$ permutations) hors de portee de `pyphi.macro` ([ICT-5](ICT-5-CausalEmergence.ipynb)).\n",
+    "- **L'emergence n'est pas automatique.** Le macro « intuitif » (niveau de tri) *baisse* l'effectiveness ;\n",
+    "  c'est l'**apportionnement glouton** qui trouve l'echelle reellement emergente.\n",
+    "- **L'effectiveness, pas l'EI en bits.** L'effectiveness *scale-free* monte au coarse-graining (emergence) ;\n",
+    "  l'EI descend a cause de $\\log_2 n$ — d'ou la mesure choisie par l'article.\n",
+    "- **EC quantifie la distribution multi-echelles** du travail causal : la morphogenese par tri a une EC\n",
+    "  elevee, signature qu'aucune echelle unique ne la resume.\n",
+    "\n",
+    "**Suite — [ICT-7](ICT-0-Framing.md) : signatures scale-free & fractales.** Si le travail causal se\n",
+    "distribue sur de nombreuses echelles (EC elevee), la distribution des gains $\\Delta$ suit-elle une loi de\n",
+    "puissance ? ICT-7 cherchera ces signatures *scale-free* sur des systemes plus grands. Pour relier ce\n",
+    "niveau d'echelles au **do-calculus** (la meme intervention uniforme `do` levee au niveau des\n",
+    "**echelles**), voir le pont d'[ICT-5](ICT-5-CausalEmergence.ipynb).\n",
+    "\n",
+    "> **Verdict SOTA (#3801).** SOTA-OK : le notebook execute le **vrai** modele de self-sorting\n",
+    "> (Zhang, Goldstein & Levin 2025) et la **vraie** reimplementation de CE 2.0 (Hoel 2025) sur une\n",
+    "> dynamique reelle ; aucune sortie n'est fabriquee. Le probleme est non-degenere — l'emergence est\n",
+    "> *decouverte* (effectiveness 0.72 -> > 0.82) la ou un macro naif echoue.\n",
+    "\n",
+    "### Voir aussi\n",
+    "\n",
+    "- [ICT-0 — cadrage de la serie](ICT-0-Framing.md) — feuille de route, articles fondateurs.\n",
+    "- [ICT-2 — self-sorting morphogenesis](ICT-2-SelfSortingMorphogenesis.ipynb) — le systeme source.\n",
+    "- [ICT-5 — emergence causale (pyphi.macro)](ICT-5-CausalEmergence.ipynb) — l'approche bornee complementaire.\n",
+    "- Erik Hoel, *Causal Emergence 2.0*, [arXiv:2503.13395](https://arxiv.org/abs/2503.13395), 2025."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (coursia-ml-training)",
+   "language": "python",
+   "name": "coursia-ml-training"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 4.55908,
+   "end_time": "2026-06-29T10:58:01.072161+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "ICT-6-SortingToTPM-CausalEmergence.ipynb",
+   "output_path": "ict6_out.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-29T10:57:56.513081+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

Nouveau notebook **ICT-6** (gap concept de la roadmap Epic #4588) : applique le toolkit **CE 2.0** (`ict/causal_emergence.py` + `ict/tpm_estimation.py`, mergés via #4606) au système de **tri auto-organisé** d'ICT-2, via le pont *trajectoires → TPM état-à-état*.

C'est le passage « photographie → film » de la série : on transforme une dynamique simulée en chaîne de Markov, puis on cherche l'échelle causale émergente avec l'outillage scale-free de Hoel — **au-delà de la borne de taille de PyPhi** (l'espace des permutations fait `n!` états).

## Arc pédagogique

1. Rappel du tri auto-organisé (ICT-2) — sortedness / inversions.
2. Pont **trajectoires → TPM micro** état-à-état (24 états observés, heatmap).
3. Profil causal micro (déterminisme / dégénérescence / effectiveness).
4. Macro « intuitif » par niveau de tri — **ÉCHOUE** : l'effectiveness baisse.
5. **Apportionnement glouton** — TROUVE l'émergence (eff↑, EI en bits↓).
6. Complexité émergente EC.
7. Trois exercices.

## Résultats réels (papermill, env `coursia-ml-training`, 0 erreur, outputs C.2)

| Échelle | effectiveness | verdict |
|---|---|---|
| micro (24 états) | **0.7170** | référence |
| macro naïf (niveau de tri) | 0.6825 | émergence **NON** (gain −0.0345) |
| apportionnement glouton (3 états) | **0.8256** | émergence **OUI** (+0.1085) |

EI en bits qui **baisse** 3.29 → 1.31 le long du chemin glouton (illustration *effectiveness scale-free* vs *EI en bits*). Complexité émergente **EC = 8.1658** (L=21).

## Conformité

- **SOTA-OK** : vraie simulation self-sorting (`ict.self_sorting`) + vrai toolkit CE 2.0 réimplémenté depuis [arXiv:2503.13395](https://arxiv.org/abs/2503.13395) (aucun code de repo non-licencié), aucune sortie fabriquée, runtime ~5 s.
- **Prong B (non-trivialité)** : l'émergence n'est PAS automatique — le macro « intuitif » la rate, seul l'apportionnement systématique la révèle. Point d'enseignement fort.
- **C.2** : 13 cellules code exécutées, `execution_count` non-null, 4 plots PNG réels.
- **C.1 / #2161** : 3 exercices stub (`print` + `return None`, aucun `raise`).
- **C.3** : seuls les 2 fichiers source modifiés sont commités (notebook + `ICT-0-Framing.md`). Catalogue non touché (laissé à l'automatisation).
- `metadata.papermill.input/output_path` normalisés en basename.

`See #4588` (contribution partielle à l'Epic ICT — l'Epic reste ouverte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)