### PR TITLE
docs(owui-tour): "Tour de la plateforme" — parcours découverte (Epic #4433)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/README.md
@@ -1,0 +1,250 @@
+# Tour de la plateforme Open WebUI
+
+[← Documentation GenAI](../../README.md) | [↑ Open-WebUI](../README.md) | [Série QA Playwright-OWUI](../Playwright-OWUI/README.md)
+
+> **Parcours découverte.** Ce tour guidé présente, fonctionnalité par
+> fonctionnalité, *à quoi sert Open WebUI et comment on l'utilise*. Il est le
+> pendant « utilisateur » de la [série QA Playwright-OWUI](../Playwright-OWUI/README.md)
+> qui, elle, *teste* la même plateforme de bout en bout. On apprend ici à se
+> servir de l'outil ; on apprend là-bas à en garantir la qualité.
+
+---
+
+## À qui s'adresse ce tour ?
+
+À toute personne qui découvre Open WebUI : étudiant·e d'un cours hébergé sur la
+plateforme, futur·e administrateur·rice d'une instance, ou ingénieur·e qui veut
+comprendre les surfaces du produit avant d'écrire des tests dessus. Aucun
+prérequis technique pour les sections 1 à 5 ; la section 6 (administration et
+multi-tenant) suppose un compte administrateur et une curiosité pour
+l'architecture.
+
+## Comment lire ce tour
+
+Chaque section suit le même rythme :
+
+1. **Ce que c'est** — la fonctionnalité en deux phrases.
+2. **Comment s'en servir** — la séquence de gestes concrets.
+3. **Capture** — une image annotée du résultat (voir la note ci-dessous).
+4. **Exercice** *(certaines sections)* — une manipulation à faire soi-même.
+
+> **Note sur les captures.** Les images de ce tour sont produites de façon
+> **reproductible** par un script Playwright ([`capture/`](capture/)) qui vise un
+> **tenant de démonstration** dédié, avec un compte non-administrateur, des
+> données fictives, et le masquage (`mask`) des zones sensibles. Tant que le
+> tenant de démonstration n'est pas en ligne, les emplacements de capture sont
+> indiqués par `📷 Capture à venir` et le dossier [`assets/`](assets/) reste un
+> gabarit. **Aucune capture ne montre d'URL réelle de tenant, d'e-mail nominatif,
+> de clé ni de jeton.**
+
+---
+
+## Sommaire
+
+| # | Section | Ce qu'on y découvre |
+|---|---------|---------------------|
+| 1 | [Connexion & première vue](#1--connexion--première-vue) | Se connecter, la fenêtre de chat |
+| 2 | [Le chat IA](#2--le-chat-ia--modèles-streaming-multimodal) | Modèles, streaming, pièces jointes |
+| 3 | [Le Workspace](#3--le-workspace--modèles-prompts-outils-rag) | Modèles personnalisés, prompts, outils, RAG |
+| 4 | [Canaux & collaboration](#4--canaux--collaboration) | Échanges en équipe, bots |
+| 5 | [Notes & autres surfaces](#5--notes--autres-surfaces) | Prise de notes, historique, paramètres |
+| 6 | [Administration & multi-tenant](#6--administration--multi-tenant) | Panneau admin, RBAC, isolation des tenants |
+
+---
+
+## 1 — Connexion & première vue
+
+**Ce que c'est.** Le point d'entrée de la plateforme : une page de connexion,
+puis l'espace de conversation où tout se passe.
+
+**Comment s'en servir.**
+
+1. Ouvrez l'URL de votre instance dans un navigateur (par ex.
+   `https://votre-instance.exemple`).
+2. Saisissez votre e-mail et votre mot de passe, puis validez. Selon la
+   configuration, l'inscription peut être ouverte, sur invitation, ou déléguée à
+   un fournisseur d'identité (LDAP, OAuth, SAML).
+3. Vous arrivez sur l'écran de chat : une zone de saisie au centre, l'historique
+   des conversations à gauche, le sélecteur de modèle en haut.
+
+> 📷 Capture à venir — `01-connexion.png` (page de connexion, champs masqués) et
+> `01-premiere-vue.png` (écran de chat vide), générées via [`capture/`](capture/).
+
+---
+
+## 2 — Le chat IA : modèles, streaming, multimodal
+
+**Ce que c'est.** Le cœur du produit : converser avec un modèle de langage. Open
+WebUI unifie derrière une seule interface des modèles très différents — locaux
+(Ollama, vLLM) ou distants (OpenAI, Mistral, Anthropic, OpenRouter…).
+
+**Comment s'en servir.**
+
+1. Dans le sélecteur en haut, choisissez un modèle. Son nom indique souvent le
+   fournisseur (préfixe) et la taille.
+2. Tapez votre message et envoyez. La réponse s'affiche **en streaming**,
+   mot à mot, plutôt que d'un bloc — utile pour les longues réponses.
+3. Joignez un fichier (icône trombone) : image pour un modèle *vision*, document
+   pour le résumer ou l'interroger.
+4. Reprenez une réponse, régénérez-la, ou comparez deux modèles côte à côte selon
+   les options offertes par votre instance.
+
+> 📷 Capture à venir — `02-chat-streaming.png` (réponse en cours de streaming) et
+> `02-selecteur-modele.png` (liste des modèles), masquage du nom d'utilisateur.
+
+### Exercice 1 — Prendre le chat en main
+
+Ouvrez une conversation, posez une question ouverte, puis **changez de modèle en
+cours de conversation** et reposez la même question. Comparez : longueur,
+ton, vitesse de streaming. Notez quel modèle vous semble le mieux adapté à votre
+besoin et pourquoi. *(Objectif : comprendre que le choix du modèle change le
+résultat, et que l'interface rend ce choix immédiat.)*
+
+---
+
+## 3 — Le Workspace : modèles, prompts, outils, RAG
+
+**Ce que c'est.** L'atelier où l'on *personnalise* la plateforme sans écrire de
+code : créer ses propres assistants, ses prompts réutilisables, brancher des
+outils, et constituer des bases de connaissances interrogeables (RAG).
+
+**Comment s'en servir.**
+
+- **Modèles personnalisés.** Partez d'un modèle de base, ajoutez un *system
+  prompt*, une description, une icône : vous obtenez un assistant spécialisé
+  (« Tuteur Python », « Relecteur juridique »…) réutilisable et partageable.
+- **Prompts.** Enregistrez des invites fréquentes sous un raccourci (`/resume`,
+  `/plan`…) pour les rappeler en un mot dans le chat.
+- **Outils & serveurs MCP.** Donnez au modèle la capacité d'agir : appeler une
+  API, exécuter du code, consulter une source externe via le protocole MCP.
+- **Bases de connaissances (RAG).** Téléversez des documents ; la plateforme les
+  découpe, les vectorise et les rend interrogeables. Le modèle cite alors vos
+  documents dans ses réponses.
+
+> 📷 Capture à venir — `03-workspace-modele.png`, `03-base-connaissances.png`
+> (données fictives uniquement).
+
+### Exercice 2 — Créer un assistant RAG
+
+1. Créez une **base de connaissances** et téléversez-y 2 ou 3 documents fictifs
+   (notes de cours, fiche produit imaginaire…).
+2. Créez un **modèle personnalisé** avec un *system prompt* du type « Tu réponds
+   uniquement à partir des documents fournis et tu cites tes sources ».
+3. Rattachez la base au modèle, puis posez-lui une question dont la réponse est
+   dans un document. Vérifiez qu'il **cite** le bon document.
+
+*(Objectif : relier modèle, prompt et RAG — la chaîne qui transforme un chat
+généraliste en assistant ancré sur vos données.)*
+
+---
+
+## 4 — Canaux & collaboration
+
+**Ce que c'est.** Des espaces de discussion partagés, façon messagerie d'équipe,
+où des humains et des **bots** (assistants automatiques) échangent dans un fil
+commun.
+
+**Comment s'en servir.**
+
+1. Ouvrez la section *Canaux* et rejoignez (ou créez) un canal.
+2. Écrivez dans le fil ; les membres voient les messages en temps réel.
+3. Mentionnez un bot configuré pour lui poser une question : il répond dans le
+   canal, visible de tous.
+
+> 📷 Capture à venir — `04-canal.png` (fil de discussion, avatars et noms
+> masqués).
+
+---
+
+## 5 — Notes & autres surfaces
+
+**Ce que c'est.** Autour du chat, la plateforme offre des surfaces utilitaires :
+prise de **notes**, historique et recherche des conversations, dossiers, et
+**paramètres** personnels (langue, thème, raccourcis, voix).
+
+**Comment s'en servir.**
+
+- **Notes** — rédigez et conservez des notes, éventuellement assistées par le
+  modèle.
+- **Historique** — retrouvez, renommez, classez en dossiers et archivez vos
+  conversations.
+- **Paramètres** — changez la langue de l'interface (multilingue), le thème
+  clair/sombre, activez la synthèse ou la reconnaissance vocale.
+
+> 📷 Capture à venir — `05-parametres.png` (panneau de paramètres, identité
+> masquée).
+
+### Exercice 3 — Personnaliser son espace
+
+Changez la **langue** de l'interface, basculez le **thème**, créez un **dossier**
+et rangez-y une conversation. Puis enregistrez un **prompt** réutilisable et
+rappelez-le par son raccourci dans le chat. *(Objectif : se rendre maître de son
+environnement de travail — l'ergonomie fait partie de la qualité perçue d'une
+plateforme.)*
+
+---
+
+## 6 — Administration & multi-tenant
+
+**Ce que c'est.** La face cachée : le **panneau d'administration** (utilisateurs,
+groupes, rôles, connecteurs de modèles, réglages globaux) et l'architecture
+**multi-tenant** qui permet de faire cohabiter plusieurs établissements sur une
+même infrastructure, chacun isolé des autres.
+
+> **Cette section est volontairement *schématisée*.** Pour ne rien divulguer
+> d'une instance réelle, l'administration et le multi-tenant sont présentés par
+> des **diagrammes** plutôt que par des captures de panneaux réels. Voir
+> **[`architecture.md`](architecture.md)** pour :
+> - le schéma de **déploiement multi-tenant** (tenants isolés, infrastructure
+>   partagée) ;
+> - le modèle de **contrôle d'accès (RBAC)** : utilisateurs → groupes → droits ;
+> - le **flux RAG** (document → extraction → vectorisation → récupération) ;
+> - le **flux outils/MCP**.
+
+**Comment s'en servir (côté admin).**
+
+1. Le panneau d'administration liste les **utilisateurs** (rôle : admin, user,
+   pending) et permet de les promouvoir, suspendre ou supprimer.
+2. Les **groupes** rassemblent des utilisateurs pour leur accorder des droits
+   collectifs (accès à tel modèle, telle base de connaissances).
+3. Les **connecteurs** déclarent les fournisseurs de modèles (URL, type) ; les
+   secrets associés ne vivent **jamais** dans un support pédagogique — voir la
+   section sécurité ci-dessous.
+
+### Exercice 4 — Cartographier les accès (sur schéma)
+
+À partir du diagramme RBAC de [`architecture.md`](architecture.md), décrivez le
+chemin d'autorisation qui permet à un·e étudiant·e du « Tenant A » d'accéder à un
+modèle réservé à son groupe, **sans** pouvoir accéder aux données du « Tenant B ».
+Identifiez le point exact où l'isolation est garantie. *(Objectif : comprendre
+que le multi-tenant n'est pas « plusieurs serveurs » mais une isolation
+logique — c'est précisément ce que la [série QA](../Playwright-OWUI/README.md)
+module 5 vérifie par des tests.)*
+
+---
+
+## Sécurité — aucun secret dans ce tour
+
+Conformément à la [politique du dossier ombrelle](../README.md#sécurité--pas-de-secret-dans-les-supports) :
+pas d'URL de tenant réel, pas d'e-mail nominatif, pas de clé d'API ni de jeton,
+pas de mot de passe. Les captures s'appuient sur un **tenant de démonstration**
+(compte non-admin, données fictives, masquage Playwright). Les identifiants et
+URL de démonstration vivent dans un `.env` **non commité** ; seuls les
+`*.env.example` documentent les variables attendues. Voir
+[`capture/README.md`](capture/README.md).
+
+---
+
+## Et ensuite ?
+
+- Pour **tester** ce que vous venez de découvrir, passez à la
+  [série QA Playwright-OWUI](../Playwright-OWUI/README.md) : vous y écrirez des
+  tests end-to-end qui vérifient automatiquement chacune de ces surfaces.
+- Pour **comprendre l'infrastructure** qui sert les modèles de cette plateforme,
+  voir le chapitre [LLMs locaux & serving](../../Texte/LLMs-Locaux-Serving/README.md).
+
+---
+
+*Tour de la plateforme — parcours découverte (Epic #4433, sous #4427). FR-first.
+Statut : narratif disponible ; captures live à générer une fois le tenant de
+démonstration en ligne.*

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/architecture.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/architecture.md
@@ -1,0 +1,160 @@
+# Architecture — administration & multi-tenant (schémas)
+
+[← Tour de la plateforme](README.md) | [↑ Open-WebUI](../README.md)
+
+> Cette page présente la face « administration » d'Open WebUI par des
+> **diagrammes** plutôt que par des captures de panneaux réels. C'est un choix
+> délibéré : on explique le *fonctionnement* (isolation, droits, flux de données)
+> sans rien divulguer d'une instance de production. Tous les noms (tenants,
+> services) sont **génériques** ; aucune URL, IP ou identité réelle n'y figure.
+
+---
+
+## 1. Déploiement multi-tenant
+
+Le multi-tenant ne signifie pas « plusieurs serveurs séparés ». C'est une
+**isolation logique** : chaque établissement (« tenant ») dispose de sa propre
+application et de sa propre base de données, mais plusieurs services
+d'infrastructure sont **mutualisés** pour réduire les coûts et la maintenance.
+
+```mermaid
+flowchart TB
+    U1([Utilisateurs Tenant A]) --> RP
+    U2([Utilisateurs Tenant B]) --> RP
+    UN([Utilisateurs Tenant N]) --> RP
+
+    RP[Reverse proxy / TLS] --> A
+    RP --> B
+    RP --> N
+
+    subgraph APPS[Applications isolées - une par tenant]
+        A[Open WebUI - Tenant A]
+        B[Open WebUI - Tenant B]
+        N[Open WebUI - Tenant N]
+    end
+
+    subgraph INFRA[Infrastructure partagee]
+        PG[(Base de donnees<br/>une par tenant)]
+        RD[(Cache / sessions)]
+        EX[Extraction documents]
+        VDB[(Base vectorielle<br/>RAG)]
+        LLM[Backends modeles<br/>locaux et distants]
+    end
+
+    A --> PG
+    B --> PG
+    N --> PG
+    A --> RD
+    B --> RD
+    N --> RD
+    A --> EX
+    A --> VDB
+    A --> LLM
+    B --> VDB
+    B --> LLM
+    N --> VDB
+    N --> LLM
+```
+
+**Point clé — où est l'isolation ?** Chaque application ne « voit » que **sa**
+base de données. Deux tenants peuvent partager le moteur de base de données et la
+base vectorielle, mais leurs données restent séparées par des bases (ou des
+espaces) distincts. L'isolation est garantie au niveau applicatif **et** au
+niveau du stockage — c'est exactement ce point que le module 5 de la
+[série QA](../Playwright-OWUI/README.md) vérifie par des tests automatisés.
+
+---
+
+## 2. Contrôle d'accès (RBAC)
+
+Les droits ne sont pas attachés individuellement à chaque utilisateur : ils
+passent par des **groupes** et des **octrois d'accès** (*access grants*). C'est ce
+qui rend l'administration tenable à l'échelle.
+
+```mermaid
+flowchart LR
+    User[Utilisateur] -->|membre de| Group[Groupe]
+    User -->|role| Role{Role<br/>admin / user / pending}
+    Group -->|octroi d'acces| Grant[Access grant]
+    Grant -->|autorise| Res[Ressource<br/>modele, base de connaissances, outil]
+
+    Role -. admin .-> Admin[Panneau d'administration<br/>gestion users / groupes / connecteurs]
+```
+
+- Un **rôle** détermine ce qu'on peut faire globalement (un *admin* accède au
+  panneau d'administration ; un *user* non).
+- Un **groupe** rassemble des utilisateurs ; on accorde un droit **au groupe**,
+  et tous ses membres en héritent.
+- Un **access grant** relie un groupe (ou « tout le monde ») à une ressource
+  précise. C'est le maillon qui répond à la question « qui a le droit de voir ce
+  modèle / cette base de connaissances ? ».
+
+---
+
+## 3. Flux RAG (génération augmentée par récupération)
+
+Quand on téléverse un document dans une base de connaissances, il suit une chaîne
+de traitement avant de pouvoir être « cité » par le modèle :
+
+```mermaid
+flowchart LR
+    Doc[Document televerse] --> Extract[Extraction du texte]
+    Extract --> Chunk[Decoupage en passages]
+    Chunk --> Embed[Vectorisation<br/>modele d'embedding]
+    Embed --> Store[(Base vectorielle)]
+
+    Q[Question de l'utilisateur] --> EmbedQ[Vectorisation de la question]
+    EmbedQ --> Search[Recherche par similarite]
+    Store --> Search
+    Search --> Ctx[Passages pertinents]
+    Ctx --> Prompt[Assemblage du prompt<br/>question + passages]
+    Prompt --> Model[Modele de langage]
+    Model --> Ans[Reponse avec citations]
+```
+
+La qualité d'un assistant RAG dépend de chaque maillon : extraction fidèle,
+découpage pertinent, bon modèle d'embedding, et récupération qui ramène les *bons*
+passages. C'est l'objet de l'[exercice 2](README.md#exercice-2--créer-un-assistant-rag)
+du tour.
+
+---
+
+## 4. Flux outils & MCP
+
+Un modèle « outillé » peut **agir** : au lieu de seulement répondre, il décide
+d'appeler un outil (une API, un calcul, une recherche) exposé via le protocole
+**MCP** (Model Context Protocol), puis intègre le résultat à sa réponse.
+
+```mermaid
+sequenceDiagram
+    participant U as Utilisateur
+    participant M as Modele
+    participant S as Serveur d'outils (MCP)
+    participant E as Service externe
+
+    U->>M: Question necessitant une action
+    M->>S: Appel d'outil (nom + arguments)
+    S->>E: Requete (API, calcul, recherche...)
+    E-->>S: Resultat
+    S-->>M: Resultat de l'outil
+    M-->>U: Reponse integrant le resultat
+```
+
+Du point de vue de la sécurité, les outils élargissent la surface d'action du
+modèle : c'est puissant, mais cela demande de contrôler *quels* outils sont
+exposés et *à qui* (via le RBAC de la section 2).
+
+---
+
+## Sécurité — rappel
+
+Aucun de ces schémas ne contient d'URL réelle, d'IP, de nom de tenant de
+production, d'identité ni de secret. Les noms sont des **placeholders**
+pédagogiques. Les valeurs réelles (connecteurs, clés, hôtes) vivent dans des
+fichiers `.env` non commités côté infrastructure — jamais dans un support de
+cours. Voir la [politique du dossier ombrelle](../README.md#sécurité--pas-de-secret-dans-les-supports).
+
+---
+
+*Architecture — Tour de la plateforme (Epic #4433, sous #4427). FR-first.
+Diagrammes Mermaid (rendus nativement par GitHub).*

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/assets/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/assets/README.md
@@ -1,0 +1,38 @@
+# Captures du Tour de la plateforme
+
+[← Tour de la plateforme](../README.md)
+
+Ce dossier accueille les **captures d'écran annotées** du
+[tour](../README.md), générées de façon reproductible par le script
+[`../capture/tour-captures.spec.ts`](../capture/).
+
+> **Statut : gabarit.** Les images ne sont pas encore présentes : elles seront
+> produites une fois le **tenant de démonstration** en ligne (compte non-admin,
+> données fictives, masquage des zones sensibles). En attendant, le tour indique
+> chaque emplacement par `📷 Capture à venir`.
+
+## Fichiers attendus
+
+| Fichier | Section du tour |
+|---------|-----------------|
+| `01-connexion.png` | 1 — page de connexion (champs masqués) |
+| `01-premiere-vue.png` | 1 — écran de chat |
+| `02-selecteur-modele.png` | 2 — liste des modèles |
+| `02-chat-streaming.png` | 2 — réponse en streaming |
+| `03-workspace-modele.png` | 3 — modèle personnalisé |
+| `03-base-connaissances.png` | 3 — base de connaissances (RAG) |
+| `04-canal.png` | 4 — fil de discussion d'un canal |
+| `05-parametres.png` | 5 — paramètres personnels |
+
+## Règles
+
+- **Aucune** capture ne doit montrer d'URL de tenant réel, d'e-mail nominatif, de
+  clé d'API, de jeton ni de mot de passe.
+- Chaque PNG est **relu en revue de PR** avant fusion.
+- Régénérer les images après toute montée de version de l'interface (voir
+  [`../capture/README.md`](../capture/README.md)).
+
+---
+
+*Assets — Tour de la plateforme (Epic #4433, sous #4427). FR-first. Gabarit en
+attente du tenant de démonstration.*

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/.env.example
@@ -1,0 +1,15 @@
+# Tenant de DÉMONSTRATION pour la génération des captures du tour.
+# Copiez ce fichier en `.env` (non commité — `*.env` est ignoré par le dépôt)
+# et renseignez les valeurs localement. NE JAMAIS commiter de vraies valeurs.
+#
+# Contraintes :
+#   - tenant de démonstration dédié (jamais une instance de production) ;
+#   - compte NON-ADMINISTRATEUR ;
+#   - données fictives uniquement.
+
+# URL du tenant de démonstration (ex. https://demo.exemple)
+DEMO_OWUI_URL=
+
+# Compte non-admin de démonstration
+DEMO_OWUI_EMAIL=
+DEMO_OWUI_PASSWORD=

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/README.md
@@ -1,0 +1,73 @@
+# Génération reproductible des captures du Tour
+
+[← Tour de la plateforme](../README.md)
+
+Ce dossier contient le script qui **génère** les captures d'écran du
+[tour](../README.md), de façon **reproductible** et **sans fuite de secret**.
+Les images produites atterrissent dans [`../assets/`](../assets/).
+
+> **Statut.** Le script vise un **tenant de démonstration** dédié, qui n'est pas
+> encore en ligne au moment où ce chapitre est écrit (en attente de
+> provisionnement). Tant que les variables d'environnement ne sont pas
+> renseignées, le script se **met en pause automatiquement** (`test.skip`) — il ne
+> s'exécute donc jamais, et n'échoue jamais, en intégration continue.
+
+## Pourquoi un script plutôt que des captures à la main ?
+
+- **Reproductibilité** : on régénère toutes les images d'un coup quand
+  l'interface change (montée de version, refonte UI).
+- **Anti-fuite par construction** : le masquage (`mask` de Playwright) est appliqué
+  à *chaque* capture, plutôt que de compter sur un floutage manuel a posteriori.
+- **Cohérence** : même fenêtre, même zoom, mêmes données fictives partout.
+
+## Principe anti-fuite
+
+1. **Tenant de démonstration** dédié — jamais une instance de production.
+2. **Compte non-administrateur** — la session de capture n'a pas les droits
+   d'admin (les vues admin sensibles restent schématisées dans
+   [`../architecture.md`](../architecture.md), pas capturées).
+3. **Données fictives** uniquement dans le tenant de démonstration.
+4. **Masquage** (`mask`) des zones sensibles (identité, e-mail) sur chaque image.
+5. **Revue des PNG en PR** avant fusion — relecture humaine des images générées.
+
+## Configuration
+
+Les identifiants et l'URL du tenant de démonstration vivent dans un fichier
+`.env` **non commité** (le dépôt ignore `*.env`). Copiez le gabarit et
+renseignez-le localement :
+
+```bash
+cp .env.example .env
+# puis éditez .env avec l'URL et le compte non-admin du tenant de démo
+```
+
+Variables attendues (voir [`.env.example`](.env.example)) :
+
+| Variable | Rôle |
+|----------|------|
+| `DEMO_OWUI_URL` | URL du tenant de démonstration |
+| `DEMO_OWUI_EMAIL` | E-mail du compte **non-admin** de démonstration |
+| `DEMO_OWUI_PASSWORD` | Mot de passe de ce compte |
+
+## Exécution (une fois le tenant de démo en ligne)
+
+Depuis la racine du projet Playwright de la série QA (qui fournit déjà
+`@playwright/test`) :
+
+```bash
+# charge le .env puis lance uniquement le script de capture
+npx playwright test 00-Tour-Plateforme/capture/tour-captures.spec.ts
+```
+
+Les images sont écrites dans [`../assets/`](../assets/). Vérifiez-les visuellement
+avant de les commiter.
+
+> **Note sélecteurs.** Les sélecteurs du script sont volontairement robustes
+> (rôles ARIA, libellés multilingues) mais devront être **confirmés contre la
+> version live** du tenant de démonstration — comme pour la série QA, l'interface
+> peut dériver d'une version à l'autre. Cette confirmation fait partie de l'étape
+> « captures live » (différée).
+
+---
+
+*Capture — Tour de la plateforme (Epic #4433, sous #4427). FR-first. 0 secret commité.*

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/tour-captures.spec.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/tour-captures.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Captures du « Tour de la plateforme » — utilitaire de génération, PAS un test QA.
+ * -----------------------------------------------------------------------------
+ * Ce script produit, de façon reproductible, les images annotées du tour
+ * (../assets/*.png) en visitant un TENANT DE DÉMONSTRATION dédié avec un compte
+ * NON-ADMINISTRATEUR et des données fictives.
+ *
+ * Anti-fuite (voir capture/README.md) :
+ *   - tenant de démonstration uniquement (jamais une instance de production) ;
+ *   - compte non-admin → pas d'accès aux panneaux d'administration sensibles ;
+ *   - masquage (`mask`) des zones d'identité sur CHAQUE capture ;
+ *   - identifiants/URL lus depuis un .env NON commité (placeholders ci-dessous).
+ *
+ * Exécution différée : tant que les variables d'environnement du tenant de démo
+ * ne sont pas fournies, tout le fichier est `skip` — il ne s'exécute donc jamais,
+ * et n'échoue jamais, en intégration continue.
+ */
+import { test, type Page, type Locator } from '@playwright/test';
+import path from 'node:path';
+
+const URL = process.env.DEMO_OWUI_URL;
+const EMAIL = process.env.DEMO_OWUI_EMAIL;
+const PASSWORD = process.env.DEMO_OWUI_PASSWORD;
+
+// Dossier de sortie : ../assets relativement à ce fichier.
+const ASSETS = path.resolve(__dirname, '..', 'assets');
+
+// Sans tenant de démo configuré, on ne fait rien (pas d'exécution en CI).
+const configured = Boolean(URL && EMAIL && PASSWORD);
+test.skip(
+  !configured,
+  'Tenant de démonstration non configuré — voir 00-Tour-Plateforme/capture/README.md',
+);
+
+/**
+ * Zones sensibles masquées sur toutes les captures. Les sélecteurs sont
+ * volontairement larges (rôles ARIA + libellés multilingues) et devront être
+ * confirmés contre la version live du tenant de démonstration.
+ */
+function sensitiveZones(page: Page): Locator[] {
+  return [
+    page.locator('[data-tour-mask]'), // points de masquage explicites si présents
+    page.getByRole('button', { name: /account|compte|profil|profile/i }),
+    page.getByText(/@/), // adresses e-mail visibles
+  ];
+}
+
+async function capture(page: Page, fileName: string): Promise<void> {
+  await page.screenshot({
+    path: path.join(ASSETS, fileName),
+    mask: sensitiveZones(page),
+    animations: 'disabled',
+  });
+}
+
+async function signIn(page: Page): Promise<void> {
+  await page.goto(URL!);
+  await page.getByPlaceholder(/email/i).fill(EMAIL!);
+  await page.getByPlaceholder(/password|mot de passe/i).fill(PASSWORD!);
+  await page
+    .getByRole('button', { name: /sign in|se connecter|connexion|log in/i })
+    .click();
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('Tour de la plateforme — captures (tenant démo)', () => {
+  // 1 — page de connexion (avant authentification, champs masqués).
+  test('01 — page de connexion', async ({ page }) => {
+    await page.goto(URL!);
+    await capture(page, '01-connexion.png');
+  });
+
+  test.describe('après connexion', () => {
+    test.beforeEach(async ({ page }) => {
+      await signIn(page);
+    });
+
+    // 1 — première vue (écran de chat).
+    test('01 — première vue', async ({ page }) => {
+      await capture(page, '01-premiere-vue.png');
+    });
+
+    // 2 — chat : sélecteur de modèle + réponse en streaming.
+    test('02 — chat & modèles', async ({ page }) => {
+      await page
+        .getByRole('button', { name: /select a model|choisir un modèle|model/i })
+        .first()
+        .click()
+        .catch(() => {}); // tolérant : la capture vaut même si l'ouverture échoue
+      await capture(page, '02-selecteur-modele.png');
+      await page.keyboard.press('Escape').catch(() => {});
+      await capture(page, '02-chat-streaming.png');
+    });
+
+    // 3 — Workspace : modèles personnalisés + bases de connaissances.
+    test('03 — workspace', async ({ page }) => {
+      await page
+        .getByRole('link', { name: /workspace|espace de travail/i })
+        .first()
+        .click()
+        .catch(() => {});
+      await page.waitForLoadState('networkidle');
+      await capture(page, '03-workspace-modele.png');
+      await page
+        .getByRole('link', { name: /knowledge|connaissance/i })
+        .first()
+        .click()
+        .catch(() => {});
+      await page.waitForLoadState('networkidle');
+      await capture(page, '03-base-connaissances.png');
+    });
+
+    // 4 — Canaux.
+    test('04 — canaux', async ({ page }) => {
+      await page
+        .getByRole('link', { name: /channel|canal|canaux/i })
+        .first()
+        .click()
+        .catch(() => {});
+      await page.waitForLoadState('networkidle');
+      await capture(page, '04-canal.png');
+    });
+
+    // 5 — Paramètres personnels.
+    test('05 — paramètres', async ({ page }) => {
+      await page
+        .getByRole('button', { name: /account|compte|profil|profile/i })
+        .first()
+        .click()
+        .catch(() => {});
+      await page
+        .getByRole('menuitem', { name: /settings|paramètres/i })
+        .first()
+        .click()
+        .catch(() => {});
+      await capture(page, '05-parametres.png');
+    });
+  });
+});

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/README.md
@@ -31,16 +31,20 @@ garantit la qualité*.
 
 | Parcours | Angle | Format | État |
 |----------|-------|--------|------|
-| **Tour de la plateforme** | « À quoi sert Open WebUI et comment l'utilise-t-on ? » | Markdown pédagogique + captures d'écran annotées | 🚧 En construction (Epic #4433) |
+| **[Tour de la plateforme](00-Tour-Plateforme/README.md)** | « À quoi sert Open WebUI et comment l'utilise-t-on ? » | Markdown pédagogique + captures d'écran annotées | 🟡 Narratif disponible — captures live à venir (Epic #4433) |
 | **[Série QA Playwright-OWUI](Playwright-OWUI/README.md)** | « Comment teste-t-on une plateforme GenAI de bout en bout ? » | Notebooks + specs Playwright (5 modules) | ✅ Disponible |
 
-### Tour de la plateforme *(à venir)*
+### [Tour de la plateforme](00-Tour-Plateforme/README.md)
 
 Un parcours narratif qui présente chaque grande fonctionnalité d'Open WebUI
-(chat, RAG, outils, administration, multi-tenant…) accompagné de captures
-d'écran commentées montrant *comment* on s'en sert. Les captures sont produites
-de façon reproductible et **sans fuite de secret** (comptes de démonstration,
-données fictives, masquage des champs sensibles).
+(chat, RAG, outils, administration, multi-tenant…) montrant *comment* on s'en
+sert, avec une page [`architecture.md`](00-Tour-Plateforme/architecture.md) qui
+**schématise** l'administration et le multi-tenant (diagrammes Mermaid) plutôt
+que d'exposer des panneaux réels. Le **narratif et les schémas sont disponibles** ;
+les captures d'écran seront produites de façon reproductible et **sans fuite de
+secret** (tenant de démonstration, compte non-admin, données fictives, masquage
+des champs sensibles) une fois le tenant de démonstration en ligne — voir
+[`00-Tour-Plateforme/capture/`](00-Tour-Plateforme/capture/).
 
 ### Série QA Playwright-OWUI
 


### PR DESCRIPTION
## Quoi

Nouveau parcours **« Tour de la plateforme »** sous
`MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/` — le pendant
« utilisateur » de la série QA Playwright-OWUI (jalon P2.5 de l'Epic #4433,
sous l'ombrelle #4427).

### Contenu
- **`README.md`** — tour guidé FR, 6 sections (connexion, chat IA, Workspace/RAG,
  canaux, notes & paramètres, administration & multi-tenant) + **4 exercices**.
- **`architecture.md`** — la face « admin » **schématisée** par 4 diagrammes
  Mermaid (déploiement multi-tenant, RBAC, flux RAG, flux outils/MCP) au lieu de
  captures de panneaux réels. Rendu natif GitHub.
- **`capture/`** — script Playwright **reproductible** (`tour-captures.spec.ts`)
  qui génère les captures depuis un **tenant de démonstration** (compte non-admin,
  données fictives, `mask` des zones sensibles). Exécution **différée** (`test.skip`
  tant que le `.env` n'est pas fourni → jamais exécuté/échoué en CI) + `README.md`
  + `.env.example`.
- **`assets/`** — gabarit de galerie (captures en attente du tenant de démo).
- **umbrella `Open-WebUI/README.md`** — ligne « Tour » passée de 🚧 à
  *narratif disponible*, avec lien vers le parcours.

## Choix de format : Markdown (pas notebook)

Conforme au README ombrelle fusionné (#4586) qui décrit le Tour comme
« Markdown pédagogique + captures d'écran annotées », et au précédent
vllm-story (chapitre narratif markdown). Aucun `.ipynb` →
`notebook-execution-required.yml` sans objet ; aucune édition de
`COURSE_CATALOG.generated.*` → `catalog-guard.yml` sans objet.

## Sécurité — 0 secret
- Aucune URL de tenant réel, e-mail nominatif, clé, jeton ni mot de passe :
  **placeholders uniquement**. Scan local OK.
- Identifiants de démo lus depuis un `.env` **non commité** (`*.env` ignoré) ;
  seul `.env.example` (valeurs vides) est commité.
- Captures live **différées** jusqu'à la mise en ligne du tenant de démonstration.
- Marqueurs `CATALOG-STATUS` **laissés à l'automatisation** (cron) — non touchés.

## Gouvernance #4427 (HARD)
- Plan validé utilisateur **avant** rédaction ✅
- Worktree isolé `docs/owui-tour-plateforme` ✅
- PR **atomique** (1 jalon) ✅
- **Pas de self-merge** — @ai-01, à toi la review + le merge. 🙏

## Validation locale
- Tous les liens markdown internes résolus (cross-dir + ancres GitHub) ✅
- Diff = uniquement le nouveau dossier + 1 ligne du README ombrelle ✅
- Rebase propre sur `main` (0 conflit) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
