### PR TITLE
docs(probas): 'inference exacte vs MCMC' -> message passing deterministe vs sampling (See #4610)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -4,7 +4,7 @@
 
 Programmation probabiliste avec Microsoft Infer.NET : une série de 24 notebooks allant des fondamentaux aux modèles relationnels avancés, incluant une section complète sur la théorie de la décision (MDPs, indice de Gittins, puis les **bandits bayésiens** via Thompson Sampling), l'**inférence causale** (do-calculus de Pearl) en clôture, et des preuves formelles Lean 4.
 
-**À qui s'adresse cette série** : étudiants en IA, développeurs .NET souhaitant maîtriser l'inférence probabiliste exacte, et data scientists intéressés par les graphes de facteurs. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en probabilités avancées : les concepts sont introduits progressivement.
+**À qui s'adresse cette série** : étudiants en IA, développeurs .NET souhaitant maîtriser l'inférence probabiliste par message passing, et data scientists intéressés par les graphes de facteurs. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en probabilités avancées : les concepts sont introduits progressivement.
 
 ## Pourquoi cette sous-série
 
@@ -42,7 +42,7 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 2. **Interpréter** les distributions postérieures (moyenne, variance, intervalles de crédibilité)
 3. **Lire** un graphe de facteurs et comprendre le flux de messages
 4. **Appliquer** la théorie de la décision bayésienne (utilité espérée, EVPI, MDPs)
-5. **Comparer** l'inférence exacte (Infer.NET) et approchée (PyMC) sur les mêmes modèles
+5. **Comparer** l'inférence par message passing déterministe (Infer.NET) et l'échantillonnage MCMC (PyMC) sur les mêmes modèles
 
 ## Vue d'ensemble
 
@@ -1116,7 +1116,7 @@ Consultez le [Glossaire](Infer-Glossary.md) pour les définitions des termes tec
 
 | Série | Lien | Relation |
 | --- | --- | --- |
-| [PyMC](../PyMC/) | Même 20 modèles en Python/NUTS | Comparaison inférence exacte vs MCMC |
+| [PyMC](../PyMC/) | Même 20 modèles en Python/NUTS | Comparaison message passing déterministe vs MCMC |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML.NET](../../ML/ML.Net/) | TP prévision de ventes | Combine ML.NET + Infer.NET |
 | [Search/CSP](../../Search/Part2-CSP/) | CSP-5 (Optimization) | Programmation par contraintes et probabilités |
@@ -1140,6 +1140,6 @@ Cette série vous a fait parcourir l'arc complet de la programmation probabilist
 
 ### Le fil rouge
 
-Le fil rouge de cette série est le **déterminisme analytique** : là où MCMC (PyMC) échantillonne, Infer.NET **propage les messages** sur le factor graph et compile un solveur dédié. Ce déterminisme a un prix — la **conjugaison** des distributions — qui achète la rapidité, l'exactitude analytique et la lisibilité structurelle. Le capstone Lean 4 (Infer-20b) élève ce fil rouge jusqu'à la **preuve formelle** : l'indice de Gittins n'est plus seulement calculé, il est *démontré*. Maîtriser Infer.NET, c'est savoir quand la structure d'un modèle mérite un raisonnement exact plutôt qu'une exploration stochastique.
+Le fil rouge de cette série est le **déterminisme analytique** : là où MCMC (PyMC) échantillonne, Infer.NET **propage les messages** sur le factor graph et compile un solveur dédié. Ce déterminisme a un prix — la **conjugaison** des distributions — qui achète la rapidité, l'exactitude analytique et la lisibilité structurelle. Le capstone Lean 4 (Infer-20b) élève ce fil rouge jusqu'à la **preuve formelle** : l'indice de Gittins n'est plus seulement calculé, il est *démontré*. Maîtriser Infer.NET, c'est savoir quand la structure d'un modèle se prête au message passing déterministe plutôt qu'à une exploration stochastique.
 
 Bonne exploration de la programmation probabiliste et de la théorie de la décision !

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -20,7 +20,7 @@ Cette série couvre les **mêmes modèles** que la série [Infer.NET](../Infer/)
 | **Diagnostics** | Factor graphs | ArviZ (trace, ESS, R-hat) |
 | **Ecosysteme** | .NET | NumPy/Pandas/Matplotlib |
 
-Avoir les deux approches sur les mêmes modèles permet de comprendre les **compromis** entre inférence exacte et approchee, une compétence clé pour tout praticien.
+Avoir les deux approches sur les mêmes modèles permet de comprendre les **compromis** entre message passing déterministe (Infer.NET) et échantillonnage stochastique (PyMC), une compétence clé pour tout praticien.
 
 ```mermaid
 flowchart LR
@@ -249,7 +249,7 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 
 | Série | Lien | Relation |
 |-------|------|----------|
-| [Infer.NET](../Infer/) | Mêmes modèles en C# / message passing | Comparaison MCMC vs inférence exacte |
+| [Infer.NET](../Infer/) | Mêmes modèles en C# / message passing | Comparaison MCMC vs message passing déterministe |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML](../../ML/) | Pipeline ML classique | PyMC comme alternative bayésienne |
 | [QuantConnect](../../QuantConnect/) | Strategies de trading | Modèles bayésiens appliques au trading |
@@ -261,7 +261,7 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 Cette série vous a fait passer des **fondamentaux de l'inférence bayésienne** (priors, postérieurs, échantillonnage NUTS avec [PyMC-1-Setup](PyMC-1-Setup.ipynb) à [PyMC-3-Factor-Graphs](PyMC-3-Factor-Graphs.ipynb)) à des **modèles relationnels avancés** (réseaux bayésiens, IRT, TrueSkill, LDA, HMM, recommandation — notebooks 4 à 12), en suivant le même chemin que la série [Infer.NET](../Infer/) mais avec un **moteur d'inférence radicalement différent**. Trois acquis cles :
 
 - **Lire et diagnostiquer une chaine MCMC** — `pm.sample()` ne suffit pas ; ArviZ (`r_hat < 1.05`, `ess_bulk > 400`, trace plots, divergences) est devenu votre réflexe systématique, et [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) votre référence pour les pannes de convergence.
-- **Choisir le bon moteur selon le modèle** — vous savez desormais **quand** MCMC (PyMC, presque tout modèle, stochastique) est préférable au **message passing** (Infer.NET, conjugué, déterministe), et inversement. Ce compromis exact/approche est une compétence de praticien.
+- **Choisir le bon moteur selon le modèle** — vous savez desormais **quand** MCMC (PyMC, presque tout modèle, stochastique) est préférable au **message passing** (Infer.NET, conjugué, déterministe), et inversement. Ce compromis déterministe/stochastique est une compétence de praticien.
 - **Relier inférence et décision** — les notebooks 14 à 20 (utilité espérée, EVPI/EVSI, MDPs, bandits) ferment la boucle : un posterior n'est pas une fin, c'est l'**input** d'une politique de décision optimale sous incertitude.
 
 ### Prochaines étapes


### PR DESCRIPTION
## Contexte

Correction du framing imprecis « **inference exacte** (Infer.NET) vs MCMC **approche** (PyMC) » dans les READMEs probabilistes. Origine : correction user lors de #4609 (pont do-calculus), tracee dans **#4610** (gardee hors-scope de #4609 pour eviter le scope creep).

Le moteur **par defaut** d'Infer.NET est **Expectation Propagation (EP)**, qui est **approche** en general (exact uniquement sur les reseaux sans boucle / poly-arbres). Le propre tableau des 3 moteurs du README Infer le reconnait deja. L'axe honnete est **message passing deterministe (EP/VMP) vs echantillonnage stochastique (MCMC/Gibbs)**, pas *exact vs approche*.

## Changements (markdown-only, FR-first)

**`Probas/Infer/README.md`** (4 lignes)
- L7 — audience : « inference probabiliste **exacte** » -> « par message passing »
- L45 — objectif : « inference **exacte** (Infer.NET) et approchee (PyMC) » -> « message passing deterministe (Infer.NET) et echantillonnage MCMC (PyMC) »
- L1119 — table series liees : « Comparaison inference **exacte** vs MCMC » -> « message passing deterministe vs MCMC »
- L1143 — conclusion : « merite un raisonnement **exact** » -> « se prete au message passing deterministe »

**`Probas/PyMC/README.md`** (3 lignes)
- L23 — intro : « compromis entre inference **exacte** et approchee » -> « entre message passing deterministe (Infer.NET) et echantillonnage stochastique (PyMC) »
- L252 — table series liees : « Comparaison MCMC vs inference **exacte** » -> « MCMC vs message passing deterministe »
- L264 — conclusion : « Ce compromis **exact**/approche » -> « Ce compromis deterministe/stochastique »

## Note G.1 (relecture firsthand)

#4610 listait **5** lignes ; 2 instances supplementaires de la **meme** imprecision (Infer **L7**, PyMC **L23**) trouvees a la relecture et corrigees pour la coherence -> **7** lignes au total.

## Nuancier correct PRESERVE

Les mentions **qualifiees** et justes de « exact » sont intactes : Gibbs « exact asymptotiquement » (L11/L17/L25/L1067/L1131), EP « approximatif », « calcul exact » NP-difficile (L815), « Exact (gaussiennes) » (L543), « exactitude analytique » liee a la conjugaison (L1143).

## Scope / hygiene

- **Markdown-only**, 2 fichiers, +7/-7. Aucun notebook, aucun code, aucune sortie touchee (C.2/C.3 sans objet).
- **catalog / CATALOG-STATUS byte-identiques** a main (ces sous-series READMEs n'ont pas de marqueur).
- **Hors-scope (territoire po-2024)** : la cellule markdown « Constellation causale » d'`Infer-22.ipynb` (#4605) porte la meme imprecision (« inference exacte (EP/VMP) ») -> a corriger cote po-2024 (cf #4610 acceptance box 3). **PR partielle** -> `See #4610` (n'epuise pas l'issue).

`See #4610`. `See #4208`.

> po-2025:CoursIA — cycle autonomie nuit degradee. Pas de self-merge (ai-01 review/merge).