### PR TITLE
docs(iit): resync IIT README ICT table to delivered notebooks (ICT-1/3/5/6)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -316,11 +316,15 @@ multi-échelle (Jansma & Hoel, 2025).
 | Document | Contenu |
 |----------|---------|
 | [ICT-0-Framing](ICT-0-Framing.md) | Cadrage de la série : de l'état à la trajectoire, articles fondateurs, feuille de route |
+| [ICT-1-PhiTrajectories](ICT-1-PhiTrajectories.ipynb) | Trajectoires de $\Phi$ : paysage de $\Phi$, suivi de $\Phi$ le long d'un attracteur (pulsations) et robustesse aux perturbations — la photographie IIT mise en mouvement, avec le vrai PyPhi |
 | [ICT-2-SelfSortingMorphogenesis](ICT-2-SelfSortingMorphogenesis.ipynb) | Le tri auto-organisé comme morphogenèse : trajectoire dans le morphospace, robustesse aux cellules défectueuses, délai de gratification, auto-réparation, impasses chimériques |
+| [ICT-3-RobustnessDelayedGratification](ICT-3-RobustnessDelayedGratification.ipynb) | Robustesse & délai de gratification, étude quantitative : dégradation gracieuse face aux cellules défectueuses, distributions de récupération, comptage du délai de gratification |
+| [ICT-5-CausalEmergence](ICT-5-CausalEmergence.ipynb) | Émergence causale : $\Phi$ et information effective aux échelles micro/macro, recherche systématique du coarse-graining (vrai `pyphi.macro`), émergence discriminante (Jansma & Hoel, 2025) |
+| [ICT-6-SortingToTPM-CausalEmergence](ICT-6-SortingToTPM-CausalEmergence.ipynb) | Pont tri → TPM : chaîne de Markov estimée depuis les trajectoires de tri d'ICT-2, puis émergence causale multi-échelles avec l'outillage *Causal Emergence 2.0* (Hoel, 2025) au-delà de la borne de taille de PyPhi |
 
-Les notebooks ICT-1, ICT-3 à ICT-7 (trajectoires de $\Phi$, agrégation chimérique, TPM
-multi-échelles, pont tri → PyPhi, signatures scale-free) sont sur la feuille de route de
-[ICT-0-Framing](ICT-0-Framing.md).
+Restent sur la feuille de route de [ICT-0-Framing](ICT-0-Framing.md) : **ICT-4** (tableaux
+chimériques & agrégation émergente — le jeu de règles riche « kin » du papier) et **ICT-7**
+(signatures scale-free & fractales).
 
 ## Ponts causaux : le do-calculus de Pearl à travers les paradigmes
 
@@ -381,4 +385,4 @@ Voir la licence du repository principal.
 
 ---
 
-*Version 1.1.0 — Juin 2026*
+*Version 1.2.0 — Juin 2026*


### PR DESCRIPTION
## Contexte

Le README de la série **IIT** (`MyIA.AI.Notebooks/IIT/README.md`) avait dérivé : sa section *« Extension : la série ICT »* ne listait dans son tableau que **ICT-0** et **ICT-2**, et présentait **ICT-1, ICT-3 à ICT-7** comme *feuille de route*. Or **ICT-1, ICT-3, ICT-5 et ICT-6** sont des notebooks **livrés et entièrement exécutés** sur `main` (24–32 cellules chacun, tous les `code` ont un `execution_count`).

Incohérence interne notable : **ICT-5** était déjà lié comme notebook **livré** dans la section *« Ponts causaux »* juste en dessous, alors que le tableau ICT le déclarait « à venir ».

## Changement (markdown-only, aucun notebook touché)

- Ajout des 4 lignes manquantes au tableau ICT : **ICT-1** (trajectoires de Φ), **ICT-3** (robustesse & délai de gratification), **ICT-5** (émergence causale micro/macro), **ICT-6** (pont tri → TPM, CE 2.0). Contenu repris des cellules-titres de chaque notebook et du tableau canonique d'[ICT-0-Framing](MyIA.AI.Notebooks/IIT/ICT-0-Framing.md).
- Correction de la ligne « feuille de route » aux **seuls** notebooks réellement en attente : **ICT-4** (tableaux chimériques / « kin ») et **ICT-7** (signatures scale-free).
- Bump version footer `1.1.0 → 1.2.0`.

## Conformité

- **FR-first** (le README est déjà en français — pas de bascule `.en.md` nécessaire).
- **Marqueur `CATALOG-STATUS` (L3) inchangé**, aucune régénération de catalogue sur la branche.
- Diff `+8 / -4`, un seul fichier.
- Tous les liens ajoutés vérifiés : les 6 fichiers ICT existent ; ICT-4/ICT-7 absents (correctement en roadmap).

See #3974 (READMEs feuilles — familles Python, Epic #3973). Refs #4588 (Epic ICT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)