### PR TITLE
docs(readme): front-door IIT blurb resync to the ICT extension + causality fil rouge

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -37,7 +37,7 @@ Dernière mise à jour : 2026-06-11
 
 **[CaseStudies](CaseStudies/README.md)** — Des études de cas interdisciplinaires où plusieurs séries convergent sur un même problème : diagnostic médical assisté par LLM, planification oncologique, analyse de sentiments.
 
-**[IIT](IIT/README.md)** — La plus spéculative : la théorie de l'information intégrée et la mesure Phi (PyPhi) appliquées à des réseaux logiques — où l'on calcule, littéralement, des candidats quantitatifs à une mesure de la conscience.
+**[IIT](IIT/README.md)** — La plus spéculative : la théorie de l'information intégrée et la mesure Phi (PyPhi) appliquées à des réseaux logiques — où l'on calcule, littéralement, des candidats quantitatifs à une mesure de la conscience. La série prolonge le Phi *statique* vers les **trajectoires** causales avec l'extension **ICT** (*Integrated Causal Trajectories*) : tri auto-organisé comme morphogenèse, émergence causale multi-échelles (Hoel, *Causal Emergence 2.0*). Elle rejoint ainsi le fil rouge **causalité** du dépôt, où le même opérateur `do(·)` de Pearl s'instancie à travers quatre paradigmes — symbolique (Tweety), message passing (Infer.NET), MCMC (PyMC) et théorie de l'information (ICT).
 
 ### Progression pedagogique
 
@@ -156,7 +156,7 @@ Les notebooks les plus exigeants, mais ceux où le dépôt dit ce qu'il a de plu
 3. **[Search](Search/README.md) avancé** - métaheuristiques, programmation linéaire, automates symboliques, CSP souples/temporels/distribués, et les applications réelles (planification d'horaires, ordonnancement, routage).
 4. **[GenAI / Orchestration + Applications](GenAI/README.md)** - Semantic Kernel, les **[CaseStudies](CaseStudies/README.md)** interdisciplinaires, les ateliers de vibe-coding.
 5. **[QuantConnect / projects](QuantConnect/README.md)** - le portefeuille de stratégies ML avancées (GARCH, Kelly, ensembles).
-6. **[IIT](IIT/README.md)** - la mesure Phi (PyPhi) sur des réseaux logiques : la frontière la plus spéculative.
+6. **[IIT](IIT/README.md)** - la mesure Phi (PyPhi) sur des réseaux logiques, prolongée vers les trajectoires causales et l'émergence multi-échelles (extension ICT) : la frontière la plus spéculative.
 
 ### Parcours thématiques
 


### PR DESCRIPTION
## Contexte

Le README catalogue **de tête** ([MyIA.AI.Notebooks/README.md](MyIA.AI.Notebooks/README.md)) décrivait encore IIT comme du **Phi statique** uniquement (« la mesure Phi (PyPhi) sur des réseaux logiques »). Cette prose **précède** deux ajouts substantiels mergés fin juin que la porte d'entrée du dépôt ne reflète pas :

- l'**extension ICT** (*Integrated Causal Trajectories*, **Epic #4588**) — ICT-1/2/3/5/6 livrés ;
- le **pont causalité cross-paradigmes** (#4609) — le même opérateur `do(·)` de Pearl à travers 4 séries.

L'en-tête du README porte d'ailleurs encore « Dernière mise à jour : 2026-06-11 ».

## Changement — resync ascendant (#3973), prose curée uniquement

Complément **front-door** au fix du README *feuille* IIT du cycle précédent (#4623) :

- **Blurb famille** (section « Vue d'ensemble ») : IIT prolonge désormais le Phi statique vers les **trajectoires** causales via ICT (tri auto-organisé comme morphogenèse, émergence causale multi-échelles, Hoel *Causal Emergence 2.0*), et rejoint le **fil rouge causalité** du dépôt (do() instancié dans 4 paradigmes : symbolique Tweety / message passing Infer.NET / MCMC PyMC / théorie de l'information ICT).
- **Entrée Niveau 3** : extension ICT signalée brièvement.

## Conformité

- **Prose curée seulement**, diff `+2/-2`, 1 fichier.
- **Marqueur `CATALOG-STATUS` (et sa ligne `breakdown:` auto-gérée) intouchés** — vérifié absent du diff ; aucune régénération de catalogue sur la branche.
- **0 notebook touché** ; le sous-arbre `SMT/Z3.Linq` (lane sœur CoursIA-2) **non touché** (frontière respectée).
- Claims **ancrés** : les 4 paradigmes proviennent de la table « Ponts causaux » du README IIT (#4609) ; ICT = Epic #4588.

See #3973 (READMEs resync ascendant). Refs #4588 (Epic ICT), #4609 (pont do-calculus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)