### PR TITLE
docs(probas): reframe 'inférence exacte (Infer.NET) vs MCMC' — message passing déterministe vs échantillonnage (#4610)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -42,7 +42,7 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 2. **Interpréter** les distributions postérieures (moyenne, variance, intervalles de crédibilité)
 3. **Lire** un graphe de facteurs et comprendre le flux de messages
 4. **Appliquer** la théorie de la décision bayésienne (utilité espérée, EVPI, MDPs)
-5. **Comparer** l'inférence exacte (Infer.NET) et approchée (PyMC) sur les mêmes modèles
+5. **Comparer** l'inférence par message passing déterministe (Infer.NET) et l'échantillonnage MCMC stochastique (PyMC) sur les mêmes modèles
 
 ## Vue d'ensemble
 
@@ -1116,7 +1116,7 @@ Consultez le [Glossaire](Infer-Glossary.md) pour les définitions des termes tec
 
 | Série | Lien | Relation |
 | --- | --- | --- |
-| [PyMC](../PyMC/) | Même 20 modèles en Python/NUTS | Comparaison inférence exacte vs MCMC |
+| [PyMC](../PyMC/) | Même 20 modèles en Python/NUTS | Comparaison message passing déterministe vs MCMC |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML.NET](../../ML/ML.Net/) | TP prévision de ventes | Combine ML.NET + Infer.NET |
 | [Search/CSP](../../Search/Part2-CSP/) | CSP-5 (Optimization) | Programmation par contraintes et probabilités |
@@ -1140,6 +1140,6 @@ Cette série vous a fait parcourir l'arc complet de la programmation probabilist
 
 ### Le fil rouge
 
-Le fil rouge de cette série est le **déterminisme analytique** : là où MCMC (PyMC) échantillonne, Infer.NET **propage les messages** sur le factor graph et compile un solveur dédié. Ce déterminisme a un prix — la **conjugaison** des distributions — qui achète la rapidité, l'exactitude analytique et la lisibilité structurelle. Le capstone Lean 4 (Infer-20b) élève ce fil rouge jusqu'à la **preuve formelle** : l'indice de Gittins n'est plus seulement calculé, il est *démontré*. Maîtriser Infer.NET, c'est savoir quand la structure d'un modèle mérite un raisonnement exact plutôt qu'une exploration stochastique.
+Le fil rouge de cette série est le **déterminisme analytique** : là où MCMC (PyMC) échantillonne, Infer.NET **propage les messages** sur le factor graph et compile un solveur dédié. Ce déterminisme a un prix — la **conjugaison** des distributions — qui achète la rapidité, la forme analytique close des mises à jour et la lisibilité structurelle. Le capstone Lean 4 (Infer-20b) élève ce fil rouge jusqu'à la **preuve formelle** : l'indice de Gittins n'est plus seulement calculé, il est *démontré*. Maîtriser Infer.NET, c'est savoir quand la structure d'un modèle mérite un raisonnement déterministe par message passing plutôt qu'une exploration stochastique.
 
 Bonne exploration de la programmation probabiliste et de la théorie de la décision !

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -20,7 +20,7 @@ Cette série couvre les **mêmes modèles** que la série [Infer.NET](../Infer/)
 | **Diagnostics** | Factor graphs | ArviZ (trace, ESS, R-hat) |
 | **Ecosysteme** | .NET | NumPy/Pandas/Matplotlib |
 
-Avoir les deux approches sur les mêmes modèles permet de comprendre les **compromis** entre inférence exacte et approchee, une compétence clé pour tout praticien.
+Avoir les deux approches sur les mêmes modèles permet de comprendre les **compromis** entre message passing déterministe (EP/VMP) et échantillonnage stochastique (MCMC/NUTS), une compétence clé pour tout praticien.
 
 ```mermaid
 flowchart LR
@@ -249,7 +249,7 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 
 | Série | Lien | Relation |
 |-------|------|----------|
-| [Infer.NET](../Infer/) | Mêmes modèles en C# / message passing | Comparaison MCMC vs inférence exacte |
+| [Infer.NET](../Infer/) | Mêmes modèles en C# / message passing | Comparaison MCMC vs message passing déterministe |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML](../../ML/) | Pipeline ML classique | PyMC comme alternative bayésienne |
 | [QuantConnect](../../QuantConnect/) | Strategies de trading | Modèles bayésiens appliques au trading |
@@ -261,7 +261,7 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 Cette série vous a fait passer des **fondamentaux de l'inférence bayésienne** (priors, postérieurs, échantillonnage NUTS avec [PyMC-1-Setup](PyMC-1-Setup.ipynb) à [PyMC-3-Factor-Graphs](PyMC-3-Factor-Graphs.ipynb)) à des **modèles relationnels avancés** (réseaux bayésiens, IRT, TrueSkill, LDA, HMM, recommandation — notebooks 4 à 12), en suivant le même chemin que la série [Infer.NET](../Infer/) mais avec un **moteur d'inférence radicalement différent**. Trois acquis cles :
 
 - **Lire et diagnostiquer une chaine MCMC** — `pm.sample()` ne suffit pas ; ArviZ (`r_hat < 1.05`, `ess_bulk > 400`, trace plots, divergences) est devenu votre réflexe systématique, et [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) votre référence pour les pannes de convergence.
-- **Choisir le bon moteur selon le modèle** — vous savez desormais **quand** MCMC (PyMC, presque tout modèle, stochastique) est préférable au **message passing** (Infer.NET, conjugué, déterministe), et inversement. Ce compromis exact/approche est une compétence de praticien.
+- **Choisir le bon moteur selon le modèle** — vous savez desormais **quand** MCMC (PyMC, presque tout modèle, stochastique) est préférable au **message passing** (Infer.NET, conjugué, déterministe), et inversement. Ce compromis déterministe/stochastique (message passing vs sampling) est une compétence de praticien.
 - **Relier inférence et décision** — les notebooks 14 à 20 (utilité espérée, EVPI/EVSI, MDPs, bandits) ferment la boucle : un posterior n'est pas une fin, c'est l'**input** d'une politique de décision optimale sous incertitude.
 
 ### Prochaines étapes


### PR DESCRIPTION
## Summary

Several Probas-series READMEs framed Infer.NET as doing **« inférence exacte »** opposed to PyMC's MCMC (**« approchée »**). That's imprecise: Infer.NET's *default* engine is **Expectation Propagation (EP)**, which is **approximate** in general (exact only on loop-free / Gaussian models). The README's own 3-engine table already says so (EP « rapide mais approximatif », VMP « sous-estime l'incertitude », Gibbs « exact asymptotiquement »).

The honest axis is **message passing déterministe (EP/VMP)** vs **échantillonnage stochastique (MCMC/NUTS)** — not exact vs approximate.

## Changes (markdown-only, 6 lines)

**`Probas/Infer/README.md`**
- L45 — objective bullet: « inférence exacte (Infer.NET) et approchée (PyMC) » → message passing déterministe vs échantillonnage MCMC stochastique
- L1119 — table: « Comparaison inférence exacte vs MCMC » → « message passing déterministe vs MCMC »
- L1143 — « l'exactitude analytique » → « la forme analytique close des mises à jour » ; « un raisonnement exact » → « un raisonnement déterministe par message passing »

**`Probas/PyMC/README.md`**
- L23 — « compromis entre inférence exacte et approchée » → message passing déterministe vs échantillonnage stochastique *(same-class as the flagged lines; fixed for coherence)*
- L252 — table: « Comparaison MCMC vs inférence exacte » → « MCMC vs message passing déterministe »
- L264 — « Ce compromis exact/approche » → « Ce compromis déterministe/stochastique (message passing vs sampling) »

## Preserved (correctly-qualified, left untouched)
- Infer README L11 — 3-engine nuancier (EP approximatif / VMP sous-estime / Gibbs exact asymptotiquement).
- Infer README L543 — EP vs VMP table row « Exactitude | Exact (gaussiennes) | Approximation » — this is exactly the *qualified* form the issue endorses.

## Out of scope
- `Infer/Infer-22-Causal-Inference.ipynb` « Constellation causale » cell (added by #4605) carries the same imprecision but is po-2024 territory — flagged in #4610 for a coordinated markdown-only follow-up, not touched here.

## Validation
- Markdown-only; no notebook re-exec needed. CATALOG-STATUS markers untouched. FR-first preserved. Submodule pointers (Automata/Z3.Linq) intentionally excluded from this PR.

Closes #4610
See #4208