### PR TITLE
docs(probas): reframe Infer.NET<->PyMC contrast on facts (supersedes #4622)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -4,7 +4,7 @@
 
 Programmation probabiliste avec Microsoft Infer.NET : une série de 24 notebooks allant des fondamentaux aux modèles relationnels avancés, incluant une section complète sur la théorie de la décision (MDPs, indice de Gittins, puis les **bandits bayésiens** via Thompson Sampling), l'**inférence causale** (do-calculus de Pearl) en clôture, et des preuves formelles Lean 4.
 
-**À qui s'adresse cette série** : étudiants en IA, développeurs .NET souhaitant maîtriser l'inférence probabiliste exacte, et data scientists intéressés par les graphes de facteurs. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en probabilités avancées : les concepts sont introduits progressivement.
+**À qui s'adresse cette série** : étudiants en IA, développeurs .NET souhaitant maîtriser l'inférence probabiliste par message passing, et data scientists intéressés par les graphes de facteurs. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en probabilités avancées : les concepts sont introduits progressivement.
 
 ## Pourquoi cette sous-série
 
@@ -42,7 +42,7 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 2. **Interpréter** les distributions postérieures (moyenne, variance, intervalles de crédibilité)
 3. **Lire** un graphe de facteurs et comprendre le flux de messages
 4. **Appliquer** la théorie de la décision bayésienne (utilité espérée, EVPI, MDPs)
-5. **Comparer** l'inférence exacte (Infer.NET) et approchée (PyMC) sur les mêmes modèles
+5. **Comparer** deux familles d'algorithmes sur les mêmes modèles : le message passing sur graphe de facteurs (Infer.NET, EP par défaut) et l'échantillonnage MCMC (PyMC, NUTS par défaut)
 
 ## Vue d'ensemble
 
@@ -1116,7 +1116,7 @@ Consultez le [Glossaire](Infer-Glossary.md) pour les définitions des termes tec
 
 | Série | Lien | Relation |
 | --- | --- | --- |
-| [PyMC](../PyMC/) | Même 20 modèles en Python/NUTS | Comparaison inférence exacte vs MCMC |
+| [PyMC](../PyMC/) | Même 20 modèles en Python/NUTS | Message passing (EP) vs MCMC (NUTS) |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML.NET](../../ML/ML.Net/) | TP prévision de ventes | Combine ML.NET + Infer.NET |
 | [Search/CSP](../../Search/Part2-CSP/) | CSP-5 (Optimization) | Programmation par contraintes et probabilités |
@@ -1128,18 +1128,18 @@ Consultez le [Glossaire](Infer-Glossary.md) pour les définitions des termes tec
 
 Cette série vous a fait parcourir l'arc complet de la programmation probabiliste en .NET : des **fondamentaux** (variables `Variable<T>`, `InferenceEngine`, compilation Roslyn — [Infer-1-Setup](Infer-1-Setup.ipynb) à [Infer-3-Factor-Graphs](Infer-3-Factor-Graphs.ipynb)) aux **modèles relationnels avancés** (réseaux bayésiens, IRT, TrueSkill, LDA, HMM, recommandation — notebooks 4 à 12), jusqu'à la **théorie de la décision** (utilité espérée, EVPI/EVSI, MDPs, bandits — notebooks 14 à 20) et son **capstone formel** en Lean 4 ([Infer-20b-Lean-Gittins](Infer-20b-Lean-Gittins.ipynb)). Trois acquis clés :
 
-- **Penser en factor graphs et message passing** — l'inférence Infer.NET est **déterministe** : EP (rapide, par défaut), VMP (converge sur les modèles complexes), Gibbs (exact asymptotiquement). Les factor graphs (rendus via `FactorGraphHelper` et Graphviz) exposent la *structure* du modèle, pas seulement ses posteriors.
-- **Lire et choisir son algorithme d'inférence** — contrairement à un échantillonneur générique, Infer.NET **compile un algorithme dédié par modèle** (reflection + Roslyn). Vous savez désormais quand ce déterminisme analytique (modèles conjugués) est avantageux, et quand il faut céder la place à MCMC.
+- **Penser en factor graphs et message passing** — Infer.NET propose trois moteurs sur le graphe de facteurs : EP (message passing déterministe, rapide, par défaut, approximatif), VMP (déterministe, converge sur les modèles complexes) et Gibbs (échantillonnage, exact asymptotiquement). Les factor graphs (rendus via `FactorGraphHelper` et Graphviz) exposent la *structure* du modèle, pas seulement ses posteriors.
+- **Lire et choisir son algorithme d'inférence** — contrairement à un échantillonneur générique, Infer.NET **compile un algorithme dédié par modèle** (reflection + Roslyn). Vous savez désormais quand le message passing déterministe (EP/VMP) sur modèles conjugués et structurés est avantageux, et quand il faut céder la place à MCMC.
 - **Relier inference et décision, jusqu'à la preuve** — les notebooks 14 à 20 ferment la boucle (un posterior est l'**input** d'une politique optimale sous incertitude), et Infer-20b pousse la rigueur jusqu'à la **preuve formelle Lean 4** de l'indice de Gittins.
 
 ### Prochaines étapes
 
-- **Le double regard MCMC** — le port [PyMC](../PyMC/) reprend les **20 mêmes modèles** en NUTS : alterner chaque jumeau pour comparer message passing (déterministe) et échantillonnage MCMC (stochastique) sur des modèles identiques.
+- **Le double regard MCMC** — le port [PyMC](../PyMC/) reprend les **20 mêmes modèles** en NUTS : alterner chaque jumeau pour comparer le message passing sur graphe de facteurs (Infer.NET, EP par défaut) et l'échantillonnage MCMC (PyMC, NUTS) sur des modèles identiques.
 - **Le capstone ML.NET** — [ML.NET](../../ML/ML.Net/) combine ML.NET et Infer.NET (TP de prévision de ventes) : une mise en pratique où l'incertitude bayésienne complète une pipeline ML classique.
 - **Les ponts latéraux** — [Search/Part2-CSP](../../Search/Part2-CSP/) (CSP-5, optimisation sous contraintes) et le [glossaire](Infer-Glossary.md) prolongent la modélisation déclarative.
 
 ### Le fil rouge
 
-Le fil rouge de cette série est le **déterminisme analytique** : là où MCMC (PyMC) échantillonne, Infer.NET **propage les messages** sur le factor graph et compile un solveur dédié. Ce déterminisme a un prix — la **conjugaison** des distributions — qui achète la rapidité, l'exactitude analytique et la lisibilité structurelle. Le capstone Lean 4 (Infer-20b) élève ce fil rouge jusqu'à la **preuve formelle** : l'indice de Gittins n'est plus seulement calculé, il est *démontré*. Maîtriser Infer.NET, c'est savoir quand la structure d'un modèle mérite un raisonnement exact plutôt qu'une exploration stochastique.
+Le fil rouge de cette série est la **compilation d'un algorithme d'inférence dédié** : à partir du modèle déclaratif, Infer.NET génère (via Roslyn) un solveur spécialisé qui **propage des messages** sur le graphe de facteurs. Ses moteurs par défaut — EP et VMP — exploitent la **conjugaison** des distributions pour des mises à jour déterministes en forme close, rapides et sans diagnostics de convergence ; un moteur de **Gibbs** (échantillonnage) prend le relais quand la conjugaison fait défaut. Là où PyMC fait tourner un échantillonneur MCMC générique sur une densité compilée, Infer.NET compile l'algorithme lui-même. Le capstone Lean 4 (Infer-20b) élève ce fil rouge jusqu'à la **preuve formelle** : l'indice de Gittins n'est plus seulement calculé, il est *démontré*. Maîtriser Infer.NET, c'est savoir quand la structure d'un modèle se prête au message passing sur graphe de facteurs plutôt qu'à l'échantillonnage MCMC de PyMC.
 
 Bonne exploration de la programmation probabiliste et de la théorie de la décision !

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -14,13 +14,13 @@ Cette série couvre les **mêmes modèles** que la série [Infer.NET](../Infer/)
 
 | Aspect | Infer.NET (C#) | PyMC (Python) |
 |--------|----------------|---------------|
-| **Moteur** | Message passing (EP/VMP) | Échantillonnage MCMC (NUTS) |
-| **Résultats** | Deterministes, analytiques | Stochastiques, convergents |
-| **Flexibilité** | Modèles conjugués | Presque tout modèle |
+| **Moteur** | Message passing : EP (défaut), VMP, Gibbs | Échantillonnage : NUTS (défaut), ADVI |
+| **Posterior (défaut)** | Analytique, déterministe (EP/VMP) | Échantillons MCMC, convergents (NUTS) |
+| **Point fort** | Modèles conjugués et structurés | Presque tout modèle continu |
 | **Diagnostics** | Factor graphs | ArviZ (trace, ESS, R-hat) |
 | **Ecosysteme** | .NET | NumPy/Pandas/Matplotlib |
 
-Avoir les deux approches sur les mêmes modèles permet de comprendre les **compromis** entre inférence exacte et approchee, une compétence clé pour tout praticien.
+Aucune des deux librairies n'est purement déterministe ou purement stochastique — Infer.NET propose aussi un échantillonneur de **Gibbs**, PyMC une inférence variationnelle (**ADVI**) — mais leur moteur *par défaut* incarne deux familles d'algorithmes : le message passing sur graphe de facteurs (Infer.NET/EP) et l'échantillonnage MCMC (PyMC/NUTS). Avoir les deux sur les mêmes modèles permet de comprendre ce **compromis**, une compétence clé pour tout praticien.
 
 ```mermaid
 flowchart LR
@@ -33,7 +33,7 @@ flowchart LR
     P2 --> D2["Factor graph"]
 ```
 
-Le **même** modèle probabiliste (à gauche) se résout par deux moteurs radicalement différents : l'échantillonnage MCMC de PyMC (stochastique, convergent, flexible) ou le message passing d'Infer.NET (déterministe, analytique, restreint aux conjugués). La série parcourt les 20 mêmes modèles des deux côtés pour rendre ce compromis **visible**.
+Le **même** modèle probabiliste (à gauche) se résout par deux moteurs *par défaut* radicalement différents : l'échantillonnage MCMC de PyMC (NUTS, piloté par gradient, flexible sur les modèles continus) ou le message passing d'Infer.NET (EP, rapide sur les modèles conjugués et structurés ; VMP et Gibbs prennent le relais au-delà). La série parcourt les 20 mêmes modèles des deux côtés pour rendre ce compromis **visible**.
 
 ## Quand le MCMC devient nécessaire : modèles hiérarchiques et partial pooling
 
@@ -249,7 +249,7 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 
 | Série | Lien | Relation |
 |-------|------|----------|
-| [Infer.NET](../Infer/) | Mêmes modèles en C# / message passing | Comparaison MCMC vs inférence exacte |
+| [Infer.NET](../Infer/) | Mêmes modèles en C# / message passing | MCMC (NUTS) vs message passing (EP) |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML](../../ML/) | Pipeline ML classique | PyMC comme alternative bayésienne |
 | [QuantConnect](../../QuantConnect/) | Strategies de trading | Modèles bayésiens appliques au trading |
@@ -261,7 +261,7 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 Cette série vous a fait passer des **fondamentaux de l'inférence bayésienne** (priors, postérieurs, échantillonnage NUTS avec [PyMC-1-Setup](PyMC-1-Setup.ipynb) à [PyMC-3-Factor-Graphs](PyMC-3-Factor-Graphs.ipynb)) à des **modèles relationnels avancés** (réseaux bayésiens, IRT, TrueSkill, LDA, HMM, recommandation — notebooks 4 à 12), en suivant le même chemin que la série [Infer.NET](../Infer/) mais avec un **moteur d'inférence radicalement différent**. Trois acquis cles :
 
 - **Lire et diagnostiquer une chaine MCMC** — `pm.sample()` ne suffit pas ; ArviZ (`r_hat < 1.05`, `ess_bulk > 400`, trace plots, divergences) est devenu votre réflexe systématique, et [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) votre référence pour les pannes de convergence.
-- **Choisir le bon moteur selon le modèle** — vous savez desormais **quand** MCMC (PyMC, presque tout modèle, stochastique) est préférable au **message passing** (Infer.NET, conjugué, déterministe), et inversement. Ce compromis exact/approche est une compétence de praticien.
+- **Choisir le bon moteur selon le modèle** — vous savez desormais **quand** l'échantillonnage MCMC (PyMC/NUTS, piloté par gradient, flexible sur presque tout modèle continu) est préférable au **message passing** sur graphe de facteurs (Infer.NET/EP, rapide sur les modèles conjugués et structurés), et inversement. Arbitrer entre ces deux familles d'algorithmes est une compétence de praticien.
 - **Relier inférence et décision** — les notebooks 14 à 20 (utilité espérée, EVPI/EVSI, MDPs, bandits) ferment la boucle : un posterior n'est pas une fin, c'est l'**input** d'une politique de décision optimale sous incertitude.
 
 ### Prochaines étapes
@@ -272,4 +272,4 @@ Cette série vous a fait passer des **fondamentaux de l'inférence bayésienne**
 
 ### Le fil rouge
 
-Le fil rouge de cette série est le **double regard** sur les 20 mêmes modèles : PyMC (MCMC, Python) vs Infer.NET (message passing, C#). Chaque notebook jumeau vous donne non pas une implémentation de plus, mais la **comparaison directe** des deux paradigmes d'inférence — le déterminisme analytique d'un côté, la flexibilité stochastique de l'autre. Maitriser ce compromis, c'est savoir choisir l'outil qui correspond à la structure du modèle et au besoin en incertitude, plutot que d'appliquer un moteur par défaut.
+Le fil rouge de cette série est le **double regard** sur les 20 mêmes modèles : PyMC (MCMC/NUTS, Python) vs Infer.NET (message passing, C#). Chaque notebook jumeau vous donne non pas une implémentation de plus, mais la **comparaison directe** des deux paradigmes d'inférence — le message passing compilé sur graphe de facteurs d'un côté, l'échantillonnage MCMC piloté par gradient de l'autre. Maitriser ce compromis, c'est savoir choisir l'outil qui correspond à la structure du modèle et au besoin en incertitude, plutot que d'appliquer un moteur par défaut.


### PR DESCRIPTION
## Contexte

Recadrage **factuel** du contraste Infer.NET ↔ PyMC dans les READMEs des deux séries jumelles, suite à ton rejet du framing de #4622 (2026-06-29) :

> « Infer supporte plusieurs techniques d'inférence dont Gibbs, donc le framing Infer =/= echantillonnage stochastique n'est toujours pas bon. »

Cette PR **remplace #4622** et corrige l'axe de comparaison sur des faits vérifiés dans le code des séries elles-mêmes, pas des impressions.

## Faits (vérifiés firsthand dans les notebooks)

| | Infer.NET | PyMC |
|---|---|---|
| Moteurs **réellement utilisés** dans la série | EP (108 réf.), VMP (97), **Gibbs (24, dont `GibbsSampling`)** | NUTS (347), **ADVI (25)**, Metropolis |
| Ce qui est **compilé** | un *algorithme d'inférence dédié* par modèle (Roslyn) | la *densité + gradients* (PyTensor → C/Numba/JAX), pilotée par un échantillonneur générique |

Conséquences sur le framing antérieur (tous deux faux) :
- **« exacte vs approchée »** : faux dans les deux sens — EP (défaut) est *approximatif*, MCMC est *exact asymptotiquement*.
- **« Infer déterministe vs PyMC stochastique »** : faux — Infer.NET a Gibbs (échantillonnage stochastique), PyMC a ADVI (variationnel déterministe). **Aucune lib n'est purement l'un ou l'autre.**
- **« compilé vs non-compilé »** : faux — les deux compilent (différemment, cf tableau).

## Ce que fait la PR

- Le déterminisme n'est plus affirmé de la *librairie* mais scopé à ses **moteurs par défaut (EP/VMP)** ; **Gibbs** est nommé comme échantillonnage partout.
- **ADVI** nommé côté PyMC ; ajout explicite : *« Aucune des deux librairies n'est purement déterministe ou purement stochastique »*.
- L'axe réel = **deux familles d'algorithmes** (message passing sur graphe de facteurs vs échantillonnage MCMC) + **ce que chacun compile**.
- « restreint aux conjugués » corrigé (VMP/Gibbs vont au-delà).
- Les paragraphes déjà factuels (Infer L11/L31 : « EP rapide mais approximatif », « Gibbs exact asymptotiquement », « approche compilée contraste avec l'échantillonnage MCMC générique ») sont **conservés** — les lignes-résumé sont désormais alignées dessus.

15 insertions / 15 deletions, 2 fichiers (READMEs uniquement), aucun marqueur catalogue touché.

See #4610. Supersedes #4622.
