### PR TITLE
docs(cross-series): README français + correction de 2 erreurs factuelles matching-cv (See #1650, #2651)

### DIFF
--- a/MyIA.AI.Notebooks/cross-series/README.en.md
+++ b/MyIA.AI.Notebooks/cross-series/README.en.md
@@ -1,0 +1,13 @@
+# Cross-Series Projects
+
+Showcase projects that span multiple pedagogical series (Search, SymbolicAI, GenAI, Probas, etc.) and demonstrate cross-domain integration.
+
+## Projects
+
+| Project | Description | Domains |
+|---------|-------------|---------|
+| [matching-cv/](matching-cv/) | Flask web app comparing 3 CV-to-job matching algorithms (Gale-Shapley, semantic similarity, hybrid RAG) | Search, GenAI, SymbolicAI |
+
+## Purpose
+
+These projects serve as capstone examples showing how concepts from different teaching modules combine into real applications. Each project is self-contained with its own README, requirements, and tests.

--- a/MyIA.AI.Notebooks/cross-series/README.md
+++ b/MyIA.AI.Notebooks/cross-series/README.md
@@ -1,13 +1,33 @@
-# Cross-Series Projects
+# Projets cross-séries
 
-Showcase projects that span multiple pedagogical series (Search, SymbolicAI, GenAI, Probas, etc.) and demonstrate cross-domain integration.
+Ce répertoire rassemble des **projets transversaux** qui mobilisent simultanément plusieurs séries pédagogiques du cursus (Search, GameTheory, GenAI, ML, SymbolicAI, Probas…). Là où chaque série enseigne *une* famille de techniques, un projet cross-séries montre comment **les combiner** sur une application concrète de bout en bout.
 
-## Projects
+## Pourquoi des projets cross-séries ?
 
-| Project | Description | Domains |
-|---------|-------------|---------|
-| [matching-cv/](matching-cv/) | Flask web app comparing 3 CV-to-job matching algorithms (Gale-Shapley, semantic similarity, hybrid RAG) | Search, GenAI, SymbolicAI |
+Les séries du cours isolent volontairement les concepts pour les rendre enseignables : on apprend la recherche dans `Search/`, l'appariement et les jeux dans `GameTheory/`, les embeddings et le RAG dans `GenAI/`, le matching supervisé dans `ML/`. Mais une application réelle ne respecte pas ces frontières — elle assemble ce qui marche, d'où qu'il vienne.
 
-## Purpose
+Ces projets servent donc d'**exemples-capstones** : chacun est autonome (son propre README, ses dépendances, ses tests) et illustre une **intégration multi-domaines** que les notebooks mono-série ne peuvent pas montrer seuls. L'objectif n'est pas d'introduire de nouveaux concepts, mais de **rejouer plusieurs concepts déjà vus** dans un même système, et de comparer leurs comportements sur un problème commun.
 
-These projects serve as capstone examples showing how concepts from different teaching modules combine into real applications. Each project is self-contained with its own README, requirements, and tests.
+## Projets
+
+| Projet | Description | Séries mobilisées |
+|--------|-------------|-------------------|
+| [matching-cv/](matching-cv/) | Application web Flask qui compare trois algorithmes d'appariement CV ↔ fiche de poste : mots-clés (baseline), similarité sémantique par embeddings, et appariement stable de Gale-Shapley. | GameTheory, GenAI, ML |
+
+## Focus — `matching-cv` : trois lectures d'un même problème
+
+Le projet [`matching-cv/`](matching-cv/) prend un problème unique — apparier des CV de consultants à des fiches de poste — et le résout de **trois façons**, chacune ancrée dans une série différente. C'est précisément ce contraste qui en fait un projet cross-séries :
+
+| Algorithme | Principe | Série d'origine |
+|------------|----------|-----------------|
+| **Simple (mots-clés)** | Comptage des mots-clés partagés entre CV et offre — une baseline transparente. | **ML** / `Search` (matching par recherche lexicale, baseline de classification) |
+| **Sémantique (meilleur score)** | Embeddings OpenAI `text-embedding-3-small` (via Semantic Kernel), similarité cosinus, cache vectoriel ChromaDB. | **GenAI** (embeddings, vector store) |
+| **Sémantique (stable)** | Appariement *stable* par l'algorithme de Gale-Shapley (variante Hospital-Resident) sur les scores sémantiques. | **GameTheory** (appariement stable ; cf. `GameTheory/` 15x et `social_choice_lean/`) |
+
+La leçon transversale est que **le « meilleur » appariement dépend du critère** : le meilleur score individuel (algorithme 2) n'est pas le même que l'appariement globalement stable au sens de Gale-Shapley (algorithme 3), où aucune paire candidat/poste n'a intérêt à se ré-apparier. Comparer les deux sur les mêmes données rend visible la différence entre *optimisation locale* et *stabilité globale*.
+
+> **Note pédagogique.** `matching-cv` a été produit sous orchestration automatisée comme extension d'un atelier élémentaire ; sa trace d'orchestration n'a pas été conservée. Sa valeur tient à l'**illustration** de l'intégration cross-séries plus qu'à un déroulé pas-à-pas — voir son [README dédié](matching-cv/README.md) et son [introduction](matching-cv/docs/INTRODUCTION.md) pour le détail.
+
+---
+
+*Version anglaise d'origine préservée : [README.en.md](README.en.md) (Epic #1650, Phase 0.5).*


### PR DESCRIPTION
## Résumé

Le README index de `MyIA.AI.Notebooks/cross-series/` était un **stub anglais de 80 mots** qui décrivait **inexactement** son unique projet `matching-cv`. Cette PR le bascule en français (Epic #1650 Phase 0.5) en corrigeant deux erreurs factuelles et en l'enrichissant d'une vraie narration pédagogique cross-séries (#2651).

## Erreurs factuelles corrigées (vérifiées contre la source)

Ground truth lue sur `origin/main:cross-series/matching-cv/` (README projet + `app/`) :

| Champ | Index (faux) | Réalité du projet | Source |
|-------|--------------|-------------------|--------|
| Algorithme 3 | « hybrid RAG » | Appariement **stable de Gale-Shapley** (variante Hospital-Resident) | README matching-cv + `app/matching.py` |
| Domaines | « Search, GenAI, SymbolicAI » | **GameTheory, GenAI, ML** | tableau « Connexions cross-series » du projet |

## Contenu (français, #1650 + #2651)

- `README.en.md` : **original anglais préservé verbatim** (golden set Phase 0.5).
- `README.md` (nouveau, FR) :
  - section *« Pourquoi des projets cross-séries ? »* (capstones intégratifs vs notebooks mono-série) ;
  - focus `matching-cv` avec le **mapping exact algorithme → série d'origine** (mots-clés→ML/Search, embeddings+ChromaDB→GenAI, Gale-Shapley→GameTheory) ;
  - leçon transversale *optimisation locale (meilleur score) vs stabilité globale (Gale-Shapley)* ;
  - note pédagogique honnête sur la valeur limitée du projet (trace d'orchestration non conservée, telle que documentée par le projet lui-même).

## Vérifications

- Faits vérifiés contre `origin/main:cross-series/matching-cv/` (README + `app/`).
- **0 marqueur `CATALOG-STATUS`** touché (le stub n'en avait pas ; aucun ajouté).
- Tous les liens relatifs résolus (`matching-cv/`, `matching-cv/README.md`, `matching-cv/docs/INTRODUCTION.md`, `README.en.md`).
- Branche basée sur `origin/main` frais (worktree isolé), aucune collision (aucune PR ouverte ne touche `cross-series/`).

Contribution partielle aux Epics #1650 (bascule FR) et #2651 (prose pédagogique README). Pas de `Closes` (epics au long cours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)