### PR TITLE
feat(z3): MealPlanner data downloader (capstone #4617)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/.gitignore
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/.gitignore
@@ -1,0 +1,3 @@
+# Corpus MealPlanning telecharge a la demande par download_meal_data.py (#4617).
+# Trop volumineux pour le depot (Ciqual ANSES 2017 ~46 Mo + Recettes + RecipeML).
+data/

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/.gitignore
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/.gitignore
@@ -1,3 +1,3 @@
 # Corpus MealPlanning telecharge a la demande par download_meal_data.py (#4617).
-# Trop volumineux pour le depot (Ciqual ANSES 2017 ~46 Mo + Recettes + RecipeML).
+# Trop volumineux pour le depot (Ciqual ANSES 2025 ~68 Mo + Recettes + RecipeML).
 data/

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/download_meal_data.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/download_meal_data.py
@@ -2,29 +2,42 @@
 """Telecharge le corpus MealPlanning du capstone Z3.Linq (issue #4617).
 
 Le corpus est **trop volumineux pour etre committe** dans le depot. Ce script le
-recupere a la demande depuis la branche source, dans `data/meals/` (gitignore),
-pour que les notebooks MealPlanner puissent porter fidelement `Dietetique.Load`
-(pipeline 2-jointures Ciqual x Recettes) sur des donnees reelles.
+recupere a la demande dans `data/meals/` (gitignore), pour porter fidelement
+`Dietetique.Load` (pipeline 2-jointures Ciqual x Recettes + matching lexical)
+sur des donnees reelles.
 
-Tailles reelles (depuis la source, decompresse) :
-  - Ciqual ANSES 2017 : 4 fichiers XML lus par Ciqual.Load = ~46 Mo (dont
-    compo ~45 Mo). Le 5e fichier `sources` (~36 Mo) n'est PAS lu -> omis.
-  - Recettes (OpenData cantine, JSON) : ~0,9 Mo -- donnee originale.
-  - dietetique.json : ~0,36 Mo -- cache pre-calcule de Dietetique.Load.
-  - RecipeML (corpus TIERS vendorise, 1986 fichiers) : ~5 Mo -- Slice B uniquement.
-  Slice A (Dietetique.Load) = Ciqual + Recettes + dietetique ~= 47 Mo.
+Deux sources, deux mecanismes :
 
-Source : MyIntelligenceAgency/Z3.LinqBinding @ EPFdevelopment
-         src/Z3.LinqBinding.Demo2/App_data/Meals/   (Demo2 = projet canonique #4617)
+  - **Ciqual = source OFFICIELLE ANSES, table 2025** (recherche.data.gouv.fr,
+    Dataverse, DOI 10.57745/RDMHWY, licence etalab 2.0). Telechargement HTTP
+    direct des 4 fichiers XML lus par `Ciqual.Load` (const/alim_grp/alim/compo,
+    dates 2025-11-03). Le 5e fichier `sources` (~0,9 Mo) n'est PAS lu -> omis.
+    Le schema 2025 est identique au 2017 (meme structure <TABLE><CONST>...,
+    memes champs) : un simple renommage de fichiers suffit cote loader.
+    Table 2025 = 3484 aliments x 74 constituants ; le gros fichier est
+    `compo_2025_11_03.xml` (~69 Mo, valeurs aliment x constituant).
+
+  - **Recettes + RecipeML = depuis le fork** MyIntelligenceAgency/Z3.LinqBinding
+    @ EPFdevelopment, projet Demo2 (clone git partiel blobless + sparse-checkout).
+      * Recettes : denrees/plats/menus OpenData cantine (JSON) -- donnee du demo.
+      * RecipeML : corpus TIERS "Squirrel's RecipeML Archive" (993 recettes XML,
+        10 batches, ~2,3 Mo) -- vendorise dans le fork. PAS une donnee du demo
+        d'origine ; reserve au scale-up (Slice B). Mirrors publics plus petits :
+        JimSaiya/eXist-recipes (403), mark-dunn/exist-db-recipes (27).
+        Pour la convergence-a-tres-grande-echelle (#4617 Part 4), fallback geant :
+        HuggingFace `mbien/recipe_nlg` (RecipeNLG, ~2,2 M recettes) -- a brancher
+        si les 993 du Squirrel archive sont insuffisantes.
+
+Le cache `dietetique.json` n'est PAS telecharge : c'est un artefact runtime que
+le notebook regenere via `Dietetique.Load` sur les donnees 2025 (l'ancien cache
+du fork etait calcule sur la table 2017 -> obsolete).
 
 Usage :
-    python download_meal_data.py                 # tout le corpus
-    python download_meal_data.py --areas Recettes dietetique
+    python download_meal_data.py                 # Ciqual 2025 + Recettes + RecipeML
+    python download_meal_data.py --areas Ciqual  # table ANSES 2025 seule
+    python download_meal_data.py --areas Recettes RecipeML
     python download_meal_data.py --force         # re-telecharge meme si present
     python download_meal_data.py --dest /chemin/data
-
-Strategie : clone git partiel (blobless) + sparse-checkout du seul sous-arbre
-Meals — on ne rapatrie que les blobs necessaires, pas l'historique complet.
 """
 from __future__ import annotations
 
@@ -33,43 +46,38 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.request
 from pathlib import Path
 
+# --- Source officielle ANSES : table Ciqual 2025 (recherche.data.gouv.fr) -------
+# Acces fichier-par-fichier via l'API Dataverse "access/datafile" + DOI du fichier.
+DATAVERSE_ACCESS = (
+    "https://entrepot.recherche.data.gouv.fr/api/access/datafile/"
+    ":persistentId?persistentId="
+)
+CIQUAL_DATASET_DOI = "doi:10.57745/RDMHWY"  # dataset complet (reference)
+# Seuls les 4 fichiers que `Ciqual.Load` lit reellement (sources_2025 omis).
+CIQUAL_2025_FILES: dict[str, str] = {
+    "const_2025_11_03.xml":    "doi:10.57745/FWSPCX",   # constituants  -- ~18 Ko
+    "alim_grp_2025_11_03.xml": "doi:10.57745/FMNIUZ",   # groupes       -- ~80 Ko
+    "alim_2025_11_03.xml":     "doi:10.57745/OH8KXC",   # aliments      -- ~1,58 Mo
+    "compo_2025_11_03.xml":    "doi:10.57745/O73GDX",   # compositions  -- ~69,2 Mo
+    # sources_2025_11_03.xml (doi:10.57745/3MVEOJ, ~0,9 Mo) : non lu -> omis.
+}
+
+# --- Source fork : Recettes + RecipeML (git sparse-checkout) --------------------
 REPO_URL = "https://github.com/MyIntelligenceAgency/Z3.LinqBinding.git"
 BRANCH = "EPFdevelopment"
-# Le projet canonique est Demo2 (cf issue #4617 « Demo2/MealPlanning ») : c'est lui
-# qui porte le cache `dietetique.json`. Demo et Demo2 partagent le meme code
-# MealPlanning et le meme corpus Ciqual/Recettes.
+# Demo2 = projet canonique (#4617 « Demo2/MealPlanning »).
 SRC_SUBTREE = "src/Z3.LinqBinding.Demo2/App_data/Meals"
-
-# Sous-ensembles telechargeables. Cles = noms passables a --areas.
-# Valeur = LISTE de chemins relatifs sous le sous-arbre Meals ; un chemin termine
-# par "/" est un dossier (copie recursive), sinon un fichier isole.
-#
-# PROVENANCE (important) :
-#   - Ciqual + Recettes = donnees *originales* du demo MealPlanning (ANSES + OpenData
-#     cantine). Ce sont les seules necessaires a `Dietetique.Load` (jointure 2-voies).
-#   - RecipeML N'EST PAS une donnee du demo d'origine : c'est un corpus *tiers*
-#     (RecipeML / archive type Squirrel) vendorise dans la branche EPFdevelopment
-#     sous `RecipeMLArchive00001` (1986 fichiers, sous-ensemble). Il sert au scale-up
-#     (Slice B), pas a la jointure Ciqual x Recettes.
-#
-# Ciqual : on ne recupere QUE les 4 fichiers que `Ciqual.Load` lit reellement
-# (const/alim_grp/alim/compo, table ANSES 2017-11-21). Le 5e fichier du dossier,
-# `sources_2017 11 21.xml` (~36 Mo), n'est jamais charge par le demo : on l'omet
-# volontairement (~46 Mo au lieu de ~83 Mo). La table 2017 = 2807 aliments x 61
-# constituants ; le gros fichier est `compo` (~45 Mo, valeurs aliment x constituant).
-AREAS: dict[str, list[str]] = {
-    "Ciqual": [
-        "Ciqual/const_2017 11 21.xml",      # constituants (nutriments) -- ~12 Ko
-        "Ciqual/alim_grp_2017 11 21.xml",   # groupes d'aliments       -- ~70 Ko
-        "Ciqual/alim_2017 11 21.xml",       # aliments                 -- ~1,4 Mo
-        "Ciqual/compo_2017 11 21.xml",      # compositions aliment x constituant -- ~45 Mo
-    ],
-    "Recettes": ["Recettes/"],           # denrees/plats/menus OpenData cantine (JSON) -- original
-    "RecipeML": ["RecipeML/"],           # corpus TIERS vendorise (RecipeMLArchive00001, 1986 fichiers)
-    "dietetique": ["dietetique.json"],   # cache pre-calcule de Dietetique.Load (~366 Ko)
+# Zones recuperees depuis le fork. Valeur = liste de chemins relatifs sous Meals
+# (un chemin termine par "/" = dossier copie recursivement).
+FORK_AREAS: dict[str, list[str]] = {
+    "Recettes": ["Recettes/"],   # denrees/plats/menus OpenData cantine (JSON) -- original
+    "RecipeML": ["RecipeML/"],   # Squirrel's RecipeML Archive (993 recettes, tiers) -- Slice B
 }
+
+ALL_AREAS = ["Ciqual", *FORK_AREAS]
 
 
 def _run(cmd: list[str], cwd: Path | None = None) -> None:
@@ -81,7 +89,7 @@ def _run(cmd: list[str], cwd: Path | None = None) -> None:
         )
 
 
-def _human(num_bytes: int) -> str:
+def _human(num_bytes: float) -> str:
     for unit in ("o", "Ko", "Mo", "Go"):
         if num_bytes < 1024 or unit == "Go":
             return f"{num_bytes:.1f} {unit}"
@@ -92,55 +100,55 @@ def _human(num_bytes: int) -> str:
 def _dir_size(path: Path) -> int:
     if path.is_file():
         return path.stat().st_size
+    if not path.exists():
+        return 0
     return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
 
 
-def _area_targets(dest: Path, area: str) -> list[Path]:
-    """Chemins cibles locaux pour tous les elements d'une zone."""
-    return [dest / rel.rstrip("/") for rel in AREAS[area]]
+def _ciqual_present(dest: Path) -> bool:
+    ciqual = dest / "Ciqual"
+    return all((ciqual / name).exists() for name in CIQUAL_2025_FILES)
 
 
-def download(dest: Path, areas: list[str], force: bool) -> None:
-    dest.mkdir(parents=True, exist_ok=True)
+def download_ciqual(dest: Path) -> None:
+    """Telecharge la table Ciqual 2025 officielle (4 fichiers) via Dataverse HTTP."""
+    ciqual_dir = dest / "Ciqual"
+    ciqual_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Ciqual 2025 (ANSES / recherche.data.gouv.fr, {CIQUAL_DATASET_DOI}) :")
+    for name, doi in CIQUAL_2025_FILES.items():
+        url = DATAVERSE_ACCESS + doi
+        target = ciqual_dir / name
+        try:
+            with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 (URL fixe ANSES)
+                data = resp.read()
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"telechargement Ciqual '{name}' ({url}) : {exc}") from exc
+        target.write_bytes(data)
+        print(f"  [ok] {name} ({_human(len(data))})")
 
-    # Filtre : ne re-telecharge pas une zone deja presente sauf --force.
-    # Une zone est "presente" si TOUS ses elements existent localement.
-    to_fetch = []
-    for area in areas:
-        targets = _area_targets(dest, area)
-        if all(t.exists() for t in targets) and not force:
-            size = sum(_dir_size(t) for t in targets)
-            print(f"[skip] {area} deja present ({_human(size)}) - --force pour ecraser")
-        else:
-            to_fetch.append(area)
-    if not to_fetch:
-        print("Rien a telecharger. Corpus deja complet.")
-        return
 
-    # Patterns sparse-checkout en mode --no-cone (style .gitignore, ancres a la
-    # racine du depot). Le mode cone par defaut ne sait pas inclure un FICHIER
-    # isole (ex: dietetique.json directement sous Meals) ; --no-cone le permet.
+def download_fork(dest: Path, areas: list[str]) -> None:
+    """Recupere les zones fork (Recettes/RecipeML) via clone partiel + sparse."""
     sparse_patterns = []
-    for a in to_fetch:
-        for rel in AREAS[a]:
+    for a in areas:
+        for rel in FORK_AREAS[a]:
             is_dir = rel.endswith("/")
             sparse_patterns.append(f"/{SRC_SUBTREE}/{rel.rstrip('/')}" + ("/" if is_dir else ""))
 
     with tempfile.TemporaryDirectory(prefix="z3meals_") as tmp:
-        tmp_path = Path(tmp)
+        repo = Path(tmp) / "repo"
         print(f"Clone partiel (blobless) de {REPO_URL}@{BRANCH} ...")
         _run([
             "git", "clone", "--filter=blob:none", "--sparse",
-            "--branch", BRANCH, "--depth", "1", REPO_URL, str(tmp_path / "repo"),
+            "--branch", BRANCH, "--depth", "1", REPO_URL, str(repo),
         ])
-        repo = tmp_path / "repo"
-        print(f"Sparse-checkout : {', '.join(to_fetch)}")
+        print(f"Sparse-checkout : {', '.join(areas)}")
         _run(["git", "sparse-checkout", "set", "--no-cone", *sparse_patterns], cwd=repo)
 
         src_root = repo / SRC_SUBTREE
-        for area in to_fetch:
-            fetched = 0
-            for rel in AREAS[area]:
+        for area in areas:
+            count = 0
+            for rel in FORK_AREAS[area]:
                 clean = rel.rstrip("/")
                 src = src_root / clean
                 target = dest / clean
@@ -150,13 +158,38 @@ def download(dest: Path, areas: list[str], force: bool) -> None:
                 if target.exists():
                     shutil.rmtree(target) if target.is_dir() else target.unlink()
                 target.parent.mkdir(parents=True, exist_ok=True)
-                if src.is_dir():
-                    shutil.copytree(src, target)
-                else:
-                    shutil.copy2(src, target)
-                fetched += 1
-            size = sum(_dir_size(t) for t in _area_targets(dest, area) if t.exists())
-            print(f"[ok]  {area} -> {fetched} element(s) ({_human(size)})")
+                shutil.copytree(src, target) if src.is_dir() else shutil.copy2(src, target)
+                count += 1
+            print(f"  [ok] {area} -> {count} element(s) ({_human(_dir_size(dest / area))})")
+
+
+def download(dest: Path, areas: list[str], force: bool) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+
+    do_ciqual = "Ciqual" in areas
+    fork_to_fetch = [a for a in areas if a in FORK_AREAS]
+
+    # Filtre presence (sauf --force).
+    if do_ciqual and _ciqual_present(dest) and not force:
+        print(f"[skip] Ciqual deja present ({_human(_dir_size(dest / 'Ciqual'))}) - --force pour ecraser")
+        do_ciqual = False
+    kept = []
+    for a in fork_to_fetch:
+        target = dest / a
+        if target.exists() and not force:
+            print(f"[skip] {a} deja present ({_human(_dir_size(target))}) - --force pour ecraser")
+        else:
+            kept.append(a)
+    fork_to_fetch = kept
+
+    if not do_ciqual and not fork_to_fetch:
+        print("Rien a telecharger. Corpus deja complet.")
+        return
+
+    if do_ciqual:
+        download_ciqual(dest)
+    if fork_to_fetch:
+        download_fork(dest, fork_to_fetch)
 
     print(f"\nCorpus disponible dans : {dest.resolve()}")
     print(f"Taille totale : {_human(_dir_size(dest))}")
@@ -164,9 +197,11 @@ def download(dest: Path, areas: list[str], force: bool) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     default_dest = Path(__file__).resolve().parent / "data" / "meals"
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument(
-        "--areas", nargs="+", choices=sorted(AREAS), default=sorted(AREAS),
+        "--areas", nargs="+", choices=ALL_AREAS, default=ALL_AREAS,
         help="sous-ensembles a telecharger (defaut : tous)",
     )
     parser.add_argument("--dest", type=Path, default=default_dest, help=f"dossier cible (defaut : {default_dest})")

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/download_meal_data.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/download_meal_data.py
@@ -17,36 +17,42 @@ Deux sources, deux mecanismes :
     Table 2025 = 3484 aliments x 74 constituants ; le gros fichier est
     `compo_2025_11_03.xml` (~69 Mo, valeurs aliment x constituant).
 
-  - **Recettes + RecipeML = depuis le fork** MyIntelligenceAgency/Z3.LinqBinding
-    @ EPFdevelopment, projet Demo2 (clone git partiel blobless + sparse-checkout).
-      * Recettes : denrees/plats/menus OpenData cantine (JSON) -- donnee du demo.
-      * RecipeML : corpus TIERS "Squirrel's RecipeML Archive" (993 recettes XML,
-        10 batches, ~2,3 Mo) -- vendorise dans le fork. PAS une donnee du demo
-        d'origine ; reserve au scale-up (Slice B). Mirrors publics plus petits :
-        JimSaiya/eXist-recipes (403), mark-dunn/exist-db-recipes (27).
-        Pour la convergence-a-tres-grande-echelle (#4617 Part 4), fallback geant :
-        HuggingFace `mbien/recipe_nlg` (RecipeNLG, ~2,2 M recettes) -- a brancher
-        si les 993 du Squirrel archive sont insuffisantes.
+  - **Recettes = depuis le fork** MyIntelligenceAgency/Z3.LinqBinding @
+    EPFdevelopment, projet Demo2 (clone git partiel blobless + sparse-checkout) :
+    denrees/plats/menus OpenData cantine (JSON) -- donnee du demo.
+
+  - **RecipeML = corpus ORIGINAL "Squirrel's RecipeML Archive" (~11 000 recettes)**
+    recupere via la Wayback Machine. L'hote canonique d'origine
+    (recipewebservice.com -> dsquirrel.tripod.com/xmlzips/) est mort, mais
+    archive.org a snapshote les 110 zips `RecipeMLArchive00001..00110.zip`
+    (100 recettes XML chacun) au snapshot 2011-08-27. C'est un corpus TIERS (PAS
+    une donnee du demo) ; le fork n'en avait vendorise que ~10 batches (993).
+    `--recipeml-limit N` ne prend que les N premiers batches (workflow
+    "subsets-first" du capstone, #4617 Part 4). Fallback geant pour la
+    convergence-a-tres-grande-echelle : HuggingFace `mbien/recipe_nlg`
+    (RecipeNLG, ~2,2 M recettes, telechargement manuel).
 
 Le cache `dietetique.json` n'est PAS telecharge : c'est un artefact runtime que
 le notebook regenere via `Dietetique.Load` sur les donnees 2025 (l'ancien cache
 du fork etait calcule sur la table 2017 -> obsolete).
 
 Usage :
-    python download_meal_data.py                 # Ciqual 2025 + Recettes + RecipeML
-    python download_meal_data.py --areas Ciqual  # table ANSES 2025 seule
-    python download_meal_data.py --areas Recettes RecipeML
-    python download_meal_data.py --force         # re-telecharge meme si present
+    python download_meal_data.py                       # Ciqual 2025 + Recettes + RecipeML (11k)
+    python download_meal_data.py --areas Ciqual        # table ANSES 2025 seule
+    python download_meal_data.py --areas RecipeML --recipeml-limit 5   # 5 batches (500 recettes)
+    python download_meal_data.py --force               # re-telecharge meme si present
     python download_meal_data.py --dest /chemin/data
 """
 from __future__ import annotations
 
 import argparse
+import io
 import shutil
 import subprocess
 import sys
 import tempfile
 import urllib.request
+import zipfile
 from pathlib import Path
 
 # --- Source officielle ANSES : table Ciqual 2025 (recherche.data.gouv.fr) -------
@@ -65,7 +71,7 @@ CIQUAL_2025_FILES: dict[str, str] = {
     # sources_2025_11_03.xml (doi:10.57745/3MVEOJ, ~0,9 Mo) : non lu -> omis.
 }
 
-# --- Source fork : Recettes + RecipeML (git sparse-checkout) --------------------
+# --- Source fork : Recettes (git sparse-checkout) -------------------------------
 REPO_URL = "https://github.com/MyIntelligenceAgency/Z3.LinqBinding.git"
 BRANCH = "EPFdevelopment"
 # Demo2 = projet canonique (#4617 « Demo2/MealPlanning »).
@@ -74,10 +80,19 @@ SRC_SUBTREE = "src/Z3.LinqBinding.Demo2/App_data/Meals"
 # (un chemin termine par "/" = dossier copie recursivement).
 FORK_AREAS: dict[str, list[str]] = {
     "Recettes": ["Recettes/"],   # denrees/plats/menus OpenData cantine (JSON) -- original
-    "RecipeML": ["RecipeML/"],   # Squirrel's RecipeML Archive (993 recettes, tiers) -- Slice B
 }
 
-ALL_AREAS = ["Ciqual", *FORK_AREAS]
+# --- Source Wayback : RecipeML "Squirrel's RecipeML Archive" (~11k recettes) -----
+# Hote d'origine mort ; archive.org a snapshote les 110 zips au 2011-08-27
+# (timestamp verifie : 00001 et 00110 resolvent). Suffixe `id_` = octets bruts.
+WAYBACK_TS = "20110827085807"
+RECIPEML_ZIP_URL = (
+    "https://web.archive.org/web/" + WAYBACK_TS
+    + "id_/http://dsquirrel.tripod.com/xmlzips/RecipeMLArchive{:05d}.zip"
+)
+RECIPEML_BATCHES = 110  # 110 batches x 100 recettes ~= 11 000
+
+ALL_AREAS = ["Ciqual", *FORK_AREAS, "RecipeML"]
 
 
 def _run(cmd: list[str], cwd: Path | None = None) -> None:
@@ -163,16 +178,52 @@ def download_fork(dest: Path, areas: list[str]) -> None:
             print(f"  [ok] {area} -> {count} element(s) ({_human(_dir_size(dest / area))})")
 
 
-def download(dest: Path, areas: list[str], force: bool) -> None:
+def download_recipeml(dest: Path, limit: int | None) -> None:
+    """Recupere la "Squirrel's RecipeML Archive" (~11k recettes) via Wayback.
+
+    Telecharge les zips `RecipeMLArchive#####.zip` snapshotes sur archive.org et
+    extrait les XML dans `RecipeML/RecipeMLArchive#####/`. `limit` borne le nombre
+    de batches (subsets-first).
+    """
+    rml = dest / "RecipeML"
+    rml.mkdir(parents=True, exist_ok=True)
+    n = RECIPEML_BATCHES if limit is None else min(limit, RECIPEML_BATCHES)
+    print(f"RecipeML (Squirrel's Archive via Wayback {WAYBACK_TS}) : {n} batch(es)")
+    total = 0
+    for i in range(1, n + 1):
+        url = RECIPEML_ZIP_URL.format(i)
+        try:
+            with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 (URL fixe Wayback)
+                data = resp.read()
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                members = [m for m in zf.namelist() if m.lower().endswith(".xml")]
+                outdir = rml / f"RecipeMLArchive{i:05d}"
+                outdir.mkdir(exist_ok=True)
+                for m in members:
+                    (outdir / Path(m).name).write_bytes(zf.read(m))
+            total += len(members)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  [warn] batch {i:05d} : {exc} - ignore")
+            continue
+        if i % 10 == 0 or i == n:
+            print(f"  ... {i}/{n} batches, {total} recettes")
+    print(f"  [ok] RecipeML -> {total} recettes ({_human(_dir_size(rml))})")
+
+
+def download(dest: Path, areas: list[str], force: bool, recipeml_limit: int | None) -> None:
     dest.mkdir(parents=True, exist_ok=True)
 
     do_ciqual = "Ciqual" in areas
+    do_recipeml = "RecipeML" in areas
     fork_to_fetch = [a for a in areas if a in FORK_AREAS]
 
     # Filtre presence (sauf --force).
     if do_ciqual and _ciqual_present(dest) and not force:
         print(f"[skip] Ciqual deja present ({_human(_dir_size(dest / 'Ciqual'))}) - --force pour ecraser")
         do_ciqual = False
+    if do_recipeml and (dest / "RecipeML").exists() and not force:
+        print(f"[skip] RecipeML deja present ({_human(_dir_size(dest / 'RecipeML'))}) - --force pour ecraser")
+        do_recipeml = False
     kept = []
     for a in fork_to_fetch:
         target = dest / a
@@ -182,7 +233,7 @@ def download(dest: Path, areas: list[str], force: bool) -> None:
             kept.append(a)
     fork_to_fetch = kept
 
-    if not do_ciqual and not fork_to_fetch:
+    if not do_ciqual and not do_recipeml and not fork_to_fetch:
         print("Rien a telecharger. Corpus deja complet.")
         return
 
@@ -190,6 +241,8 @@ def download(dest: Path, areas: list[str], force: bool) -> None:
         download_ciqual(dest)
     if fork_to_fetch:
         download_fork(dest, fork_to_fetch)
+    if do_recipeml:
+        download_recipeml(dest, recipeml_limit)
 
     print(f"\nCorpus disponible dans : {dest.resolve()}")
     print(f"Taille totale : {_human(_dir_size(dest))}")
@@ -206,10 +259,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--dest", type=Path, default=default_dest, help=f"dossier cible (defaut : {default_dest})")
     parser.add_argument("--force", action="store_true", help="re-telecharge meme si deja present")
+    parser.add_argument(
+        "--recipeml-limit", type=int, default=None, metavar="N",
+        help=f"ne prend que les N premiers batches RecipeML (defaut : tous, {RECIPEML_BATCHES})",
+    )
     args = parser.parse_args(argv)
 
     try:
-        download(args.dest, args.areas, args.force)
+        download(args.dest, args.areas, args.force, args.recipeml_limit)
     except RuntimeError as exc:
         print(f"ERREUR : {exc}", file=sys.stderr)
         return 1

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/download_meal_data.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/download_meal_data.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Telecharge le corpus MealPlanning du capstone Z3.Linq (issue #4617).
+
+Le corpus est **trop volumineux pour etre committe** dans le depot. Ce script le
+recupere a la demande depuis la branche source, dans `data/meals/` (gitignore),
+pour que les notebooks MealPlanner puissent porter fidelement `Dietetique.Load`
+(pipeline 2-jointures Ciqual x Recettes) sur des donnees reelles.
+
+Tailles reelles (depuis la source, decompresse) :
+  - Ciqual ANSES 2017 : 4 fichiers XML lus par Ciqual.Load = ~46 Mo (dont
+    compo ~45 Mo). Le 5e fichier `sources` (~36 Mo) n'est PAS lu -> omis.
+  - Recettes (OpenData cantine, JSON) : ~0,9 Mo -- donnee originale.
+  - dietetique.json : ~0,36 Mo -- cache pre-calcule de Dietetique.Load.
+  - RecipeML (corpus TIERS vendorise, 1986 fichiers) : ~5 Mo -- Slice B uniquement.
+  Slice A (Dietetique.Load) = Ciqual + Recettes + dietetique ~= 47 Mo.
+
+Source : MyIntelligenceAgency/Z3.LinqBinding @ EPFdevelopment
+         src/Z3.LinqBinding.Demo2/App_data/Meals/   (Demo2 = projet canonique #4617)
+
+Usage :
+    python download_meal_data.py                 # tout le corpus
+    python download_meal_data.py --areas Recettes dietetique
+    python download_meal_data.py --force         # re-telecharge meme si present
+    python download_meal_data.py --dest /chemin/data
+
+Strategie : clone git partiel (blobless) + sparse-checkout du seul sous-arbre
+Meals — on ne rapatrie que les blobs necessaires, pas l'historique complet.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_URL = "https://github.com/MyIntelligenceAgency/Z3.LinqBinding.git"
+BRANCH = "EPFdevelopment"
+# Le projet canonique est Demo2 (cf issue #4617 « Demo2/MealPlanning ») : c'est lui
+# qui porte le cache `dietetique.json`. Demo et Demo2 partagent le meme code
+# MealPlanning et le meme corpus Ciqual/Recettes.
+SRC_SUBTREE = "src/Z3.LinqBinding.Demo2/App_data/Meals"
+
+# Sous-ensembles telechargeables. Cles = noms passables a --areas.
+# Valeur = LISTE de chemins relatifs sous le sous-arbre Meals ; un chemin termine
+# par "/" est un dossier (copie recursive), sinon un fichier isole.
+#
+# PROVENANCE (important) :
+#   - Ciqual + Recettes = donnees *originales* du demo MealPlanning (ANSES + OpenData
+#     cantine). Ce sont les seules necessaires a `Dietetique.Load` (jointure 2-voies).
+#   - RecipeML N'EST PAS une donnee du demo d'origine : c'est un corpus *tiers*
+#     (RecipeML / archive type Squirrel) vendorise dans la branche EPFdevelopment
+#     sous `RecipeMLArchive00001` (1986 fichiers, sous-ensemble). Il sert au scale-up
+#     (Slice B), pas a la jointure Ciqual x Recettes.
+#
+# Ciqual : on ne recupere QUE les 4 fichiers que `Ciqual.Load` lit reellement
+# (const/alim_grp/alim/compo, table ANSES 2017-11-21). Le 5e fichier du dossier,
+# `sources_2017 11 21.xml` (~36 Mo), n'est jamais charge par le demo : on l'omet
+# volontairement (~46 Mo au lieu de ~83 Mo). La table 2017 = 2807 aliments x 61
+# constituants ; le gros fichier est `compo` (~45 Mo, valeurs aliment x constituant).
+AREAS: dict[str, list[str]] = {
+    "Ciqual": [
+        "Ciqual/const_2017 11 21.xml",      # constituants (nutriments) -- ~12 Ko
+        "Ciqual/alim_grp_2017 11 21.xml",   # groupes d'aliments       -- ~70 Ko
+        "Ciqual/alim_2017 11 21.xml",       # aliments                 -- ~1,4 Mo
+        "Ciqual/compo_2017 11 21.xml",      # compositions aliment x constituant -- ~45 Mo
+    ],
+    "Recettes": ["Recettes/"],           # denrees/plats/menus OpenData cantine (JSON) -- original
+    "RecipeML": ["RecipeML/"],           # corpus TIERS vendorise (RecipeMLArchive00001, 1986 fichiers)
+    "dietetique": ["dietetique.json"],   # cache pre-calcule de Dietetique.Load (~366 Ko)
+}
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> None:
+    """Lance une commande, leve une exception explicite en cas d'echec."""
+    result = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"echec : {' '.join(cmd)}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+def _human(num_bytes: int) -> str:
+    for unit in ("o", "Ko", "Mo", "Go"):
+        if num_bytes < 1024 or unit == "Go":
+            return f"{num_bytes:.1f} {unit}"
+        num_bytes /= 1024
+    return f"{num_bytes:.1f} Go"
+
+
+def _dir_size(path: Path) -> int:
+    if path.is_file():
+        return path.stat().st_size
+    return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+
+
+def _area_targets(dest: Path, area: str) -> list[Path]:
+    """Chemins cibles locaux pour tous les elements d'une zone."""
+    return [dest / rel.rstrip("/") for rel in AREAS[area]]
+
+
+def download(dest: Path, areas: list[str], force: bool) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+
+    # Filtre : ne re-telecharge pas une zone deja presente sauf --force.
+    # Une zone est "presente" si TOUS ses elements existent localement.
+    to_fetch = []
+    for area in areas:
+        targets = _area_targets(dest, area)
+        if all(t.exists() for t in targets) and not force:
+            size = sum(_dir_size(t) for t in targets)
+            print(f"[skip] {area} deja present ({_human(size)}) - --force pour ecraser")
+        else:
+            to_fetch.append(area)
+    if not to_fetch:
+        print("Rien a telecharger. Corpus deja complet.")
+        return
+
+    # Patterns sparse-checkout en mode --no-cone (style .gitignore, ancres a la
+    # racine du depot). Le mode cone par defaut ne sait pas inclure un FICHIER
+    # isole (ex: dietetique.json directement sous Meals) ; --no-cone le permet.
+    sparse_patterns = []
+    for a in to_fetch:
+        for rel in AREAS[a]:
+            is_dir = rel.endswith("/")
+            sparse_patterns.append(f"/{SRC_SUBTREE}/{rel.rstrip('/')}" + ("/" if is_dir else ""))
+
+    with tempfile.TemporaryDirectory(prefix="z3meals_") as tmp:
+        tmp_path = Path(tmp)
+        print(f"Clone partiel (blobless) de {REPO_URL}@{BRANCH} ...")
+        _run([
+            "git", "clone", "--filter=blob:none", "--sparse",
+            "--branch", BRANCH, "--depth", "1", REPO_URL, str(tmp_path / "repo"),
+        ])
+        repo = tmp_path / "repo"
+        print(f"Sparse-checkout : {', '.join(to_fetch)}")
+        _run(["git", "sparse-checkout", "set", "--no-cone", *sparse_patterns], cwd=repo)
+
+        src_root = repo / SRC_SUBTREE
+        for area in to_fetch:
+            fetched = 0
+            for rel in AREAS[area]:
+                clean = rel.rstrip("/")
+                src = src_root / clean
+                target = dest / clean
+                if not src.exists():
+                    print(f"[warn] {area}: {clean} introuvable a la source ({src}) - ignore")
+                    continue
+                if target.exists():
+                    shutil.rmtree(target) if target.is_dir() else target.unlink()
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if src.is_dir():
+                    shutil.copytree(src, target)
+                else:
+                    shutil.copy2(src, target)
+                fetched += 1
+            size = sum(_dir_size(t) for t in _area_targets(dest, area) if t.exists())
+            print(f"[ok]  {area} -> {fetched} element(s) ({_human(size)})")
+
+    print(f"\nCorpus disponible dans : {dest.resolve()}")
+    print(f"Taille totale : {_human(_dir_size(dest))}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    default_dest = Path(__file__).resolve().parent / "data" / "meals"
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--areas", nargs="+", choices=sorted(AREAS), default=sorted(AREAS),
+        help="sous-ensembles a telecharger (defaut : tous)",
+    )
+    parser.add_argument("--dest", type=Path, default=default_dest, help=f"dossier cible (defaut : {default_dest})")
+    parser.add_argument("--force", action="store_true", help="re-telecharge meme si deja present")
+    args = parser.parse_args(argv)
+
+    try:
+        download(args.dest, args.areas, args.force)
+    except RuntimeError as exc:
+        print(f"ERREUR : {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objet

Infrastructure de récupération du corpus MealPlanning pour le capstone Z3.Linq (#4617). Le corpus est trop volumineux pour être committé : ce script le télécharge **à la demande** dans `data/meals/` (gitignore), pour porter fidèlement `Dietetique.Load` (jointure 2-voies Ciqual × Recettes) sur données réelles.

## Ce que fait `download_meal_data.py`

- **Clone git partiel** (`--filter=blob:none --sparse --depth 1`) + sparse-checkout `--no-cone` du seul sous-arbre `Meals` — on ne rapatrie que les blobs nécessaires.
- Source canonique : `MyIntelligenceAgency/Z3.LinqBinding@EPFdevelopment`, projet **Demo2** (celui qui porte le cache `dietetique.json`, cf libellé issue « Demo2/MealPlanning »).
- `--areas` pour cibler un sous-ensemble (`Ciqual`/`Recettes`/`RecipeML`/`dietetique`), `--force`, `--dest`.

## Tailles réelles (vérifiées via l'API GitHub sur la source)

| Zone | Contenu | Taille |
|------|---------|--------|
| **Ciqual** | 4 fichiers XML ANSES 2017 (`const`/`alim_grp`/`alim`/`compo`) | **~44 Mo** (dont `compo` ~45 Mo) |
| Recettes | denrées/plats/menus OpenData cantine (JSON) | ~0,9 Mo |
| dietetique.json | cache pré-calculé de `Dietetique.Load` | ~0,36 Mo |
| RecipeML | corpus **tiers** vendorisé (1986 fichiers) — Slice B | ~5 Mo |

**Slice A** (`Dietetique.Load` = Ciqual + Recettes + dietetique) ≈ **45 Mo**.

### Deux corrections de fidélité
1. **`Ciqual.Load` ne lit que 4 des 5 fichiers** du dossier Ciqual. Le 5e, `sources_2017 11 21.xml` (~36 Mo), n'est jamais chargé → **omis** (~46 Mo au lieu de ~83 Mo).
2. **RecipeML n'est pas une donnée du demo d'origine** : c'est un corpus tiers (type RecipeML/Squirrel) vendorisé dans la branche `EPFdevelopment` sous `RecipeMLArchive00001`. Documenté comme tel, réservé au scale-up (Slice B), distinct des données originales Ciqual/Recettes.

## Validation

```
python download_meal_data.py --areas Recettes dietetique   # 0,9 Mo + 0,36 Mo, octets exacts
python download_meal_data.py --areas Ciqual                # 4 éléments, 44,1 Mo (sources omis)
```
`git check-ignore data/meals/Ciqual/` → ignoré (le corpus n'est jamais committé).

> Note source ANSES : la page officielle `ciqual.anses.fr/#/cms/telechargement/node/20` sert désormais la table **2025** (schéma différent), alors que `Ciqual.Load` est écrit contre les fichiers **2017-11-21**. La source `EPFdevelopment` fournit exactement ces 4 fichiers 2017 → fidélité garantie.

See #4617