### PR TITLE
feat(ci): golden-set — ajoute la série RL (rl_4 bandits, 7/7 certifié, manifest-only)

### DIFF
--- a/scripts/notebook_tools/golden_set.yml
+++ b/scripts/notebook_tools/golden_set.yml
@@ -83,6 +83,21 @@ notebooks:
     kernel: python3
     rationale: "Current-best learning (AIMA Ch.19) ; module local aima_knowledge vendorise dans reference/ (suivi git) ; stdlib uniquement, random.seed(42) deterministe ; prouve que le packaging local resolve via cwd=notebook.parent par defaut."
 
+  # --- RL : apprentissage par renforcement, fondations tabulaires (serie RL) ---
+  # Bandits multi-bras (epsilon-greedy / UCB / Thompson) : le coin SOBRE de la
+  # serie RL, AVANT l'arrivee de gymnasium (rl_5) et torch/stable-baselines3
+  # (rl_1, rl_6+). Dependances = numpy + matplotlib UNIQUEMENT (toutes deux
+  # pinnees dans golden_set.lock.txt), 0 env de simulation, 0 GPU, 0 reseau.
+  # Aleatoire entierement seede via np.random.default_rng(seed=42) -> sortie
+  # deterministe. Certifie end-to-end par Papermill (39 cellules, 20 code, 0
+  # erreur, 5 figures, ~12 s sur CPU, kernel coursia-ml-training = snapshot du
+  # lock). Premiere serie RL au golden-set (objectif ~1/serie de #4209).
+  - path: MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
+    series: RL
+    title: "RL-4 - Bandits multi-bras (epsilon-greedy / UCB / Thompson, exploration vs exploitation)"
+    kernel: python3
+    rationale: "Coin sobre de la serie RL (numpy + matplotlib seuls, avant gymnasium/torch) ; default_rng(seed=42) deterministe ; dilemme exploration-exploitation rendu visible (regret cumule par strategie) ; certifie Papermill ~12 s CPU, 0 erreur."
+
 # -----------------------------------------------------------------------------
 # Candidats DEFERRES (v3+) : a certifier quand le lockfile etendra sa couverture.
 #   - Probas/PyMC-* : MCMC non deterministe (sortie stochastique) -> politesse


### PR DESCRIPTION
## Résumé

Étend le golden-set certifié reproductible (H.7 P3) à la **série RL**, jusqu'ici non représentée, via son notebook le plus sobre : **bandits multi-bras** (`rl_4_multi_armed_bandits.ipynb`, ε-greedy / UCB / Thompson). Golden-set : **6/6 → 7/7**.

Addition **manifest-only** dans `scripts/notebook_tools/golden_set.yml` — aucune cellule du notebook n'est touchée, aucun champ `cwd`, lockfile inchangé. Suit exactement le pattern de **PR #4331** (extension SL-1).

## Pourquoi `rl_4` plutôt qu'un autre notebook RL

| Critère d'admission golden-set | rl_4 |
|---|---|
| (1) kernel python3 pur | ✅ |
| (2) deps couvertes par `golden_set.lock.txt` | ✅ **numpy + matplotlib UNIQUEMENT** (déjà pinnés) — 0 ajout au lock |
| (3) exec < 600 s CPU, 0 erreur, 0 secret | ✅ ~12 s |
| (4) sortie déterministe | ✅ `np.random.default_rng(seed=42)` |

C'est le **coin tabulaire** de la série RL, *avant* l'arrivée de `gymnasium` (rl_5) et de `torch` / `stable-baselines3` (rl_1, rl_6+). 0 env de simulation, 0 GPU, 0 réseau.

## Certification Papermill (réelle)

Kernel `coursia-ml-training` (= snapshot du lockfile), `cwd=notebook.parent` :

- **39 cellules** exécutées, 20 cellules code
- **0 erreur**, 0 sortie d'erreur
- **5 figures** (regret cumulé / récompense moyenne par stratégie)
- **~12 s** sur CPU, end-to-end

Conformité C.1 vérifiée : stubs d'exercice en `pass` / TODO, **0** `raise NotImplementedError` / `assert False` / `1/0`.

## Portée

- 1 fichier modifié : `scripts/notebook_tools/golden_set.yml` (+15 lignes, commentaire + entrée)
- Marqueurs CATALOG-STATUS : aucun touché
- Le notebook lui-même n'est PAS re-committé (pas de cellule source modifiée — règle C.3)

See #4208 (Wave-1 Axe A — fiabilisation exécutable), partial of #4209 (golden-set, parent fermé par #4319)