### PR TITLE
docs(iit): resync README ICT section to built notebooks (ICT-1/3/5/6 live, not roadmap)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -316,11 +316,15 @@ multi-échelle (Jansma & Hoel, 2025).
 | Document | Contenu |
 |----------|---------|
 | [ICT-0-Framing](ICT-0-Framing.md) | Cadrage de la série : de l'état à la trajectoire, articles fondateurs, feuille de route |
+| [ICT-1-PhiTrajectories](ICT-1-PhiTrajectories.ipynb) | Trajectoires de $\Phi$ : appliquer la notion de trajectoire à $\Phi$ lui-même le long de l'évolution déterministe d'un système (de la *photographie* au *film*) |
 | [ICT-2-SelfSortingMorphogenesis](ICT-2-SelfSortingMorphogenesis.ipynb) | Le tri auto-organisé comme morphogenèse : trajectoire dans le morphospace, robustesse aux cellules défectueuses, délai de gratification, auto-réparation, impasses chimériques |
+| [ICT-3-RobustnessDelayedGratification](ICT-3-RobustnessDelayedGratification.ipynb) | Étude quantitative de la robustesse et du délai de gratification du tri vu-cellule (mélange d'algotypes, cellules défectueuses) |
+| [ICT-5-CausalEmergence](ICT-5-CausalEmergence.ipynb) | Émergence causale : $\Phi$ et information effective aux échelles micro/macro, recherche de coarse-graining (vrai `pyphi.macro`), émergence discriminante (Jansma & Hoel, 2025) |
+| [ICT-6-SortingToTPM-CausalEmergence](ICT-6-SortingToTPM-CausalEmergence.ipynb) | Pont tri → chaîne de Markov : TPM estimée depuis les trajectoires de tri, émergence causale multi-échelles (*Causal Emergence 2.0*, Hoel 2025) |
 
-Les notebooks ICT-1, ICT-3 à ICT-7 (trajectoires de $\Phi$, agrégation chimérique, TPM
-multi-échelles, pont tri → PyPhi, signatures scale-free) sont sur la feuille de route de
-[ICT-0-Framing](ICT-0-Framing.md).
+Restent à construire, sur la feuille de route de [ICT-0-Framing](ICT-0-Framing.md) : **ICT-4**
+(tableaux chimériques & agrégation émergente — le jeu de règles « kin » plus riche du papier de
+Zhang, Goldstein & Levin) et **ICT-7** (signatures scale-free & fractales des trajectoires causales).
 
 ## Ponts causaux : le do-calculus de Pearl à travers les paradigmes
 


### PR DESCRIPTION
## Contexte

`#3973` — resync README ascendant (principal ← feuilles). La section **« Extension : la série ICT »** du README IIT était désynchronisée des notebooks réellement présents sur `main`.

## Drift corrigé

La section affirmait : *« Les notebooks ICT-1, ICT-3 à ICT-7 … sont sur la feuille de route »* et sa table ne listait que **ICT-0-Framing** + **ICT-2**.

Or, sur `origin/main`, sont **déjà construits et exécutés** (exec_counts non-null, 0 erreur) :

| Notebook | État réel |
|----------|-----------|
| ICT-1-PhiTrajectories | ✅ sur main |
| ICT-2-SelfSortingMorphogenesis | ✅ sur main (déjà listé) |
| ICT-3-RobustnessDelayedGratification | ✅ sur main |
| ICT-5-CausalEmergence | ✅ sur main (déjà référencée dans « Ponts causaux » du même README — incohérence interne) |
| ICT-6-SortingToTPM-CausalEmergence | ✅ sur main |

Seuls **ICT-4** et **ICT-7** restent à construire (feuille de route).

## Changement

- Table « Extension » complétée : ICT-1, ICT-3, ICT-5, ICT-6 ajoutés avec une glose fidèle au H1/intro de chaque notebook.
- Phrase feuille-de-route corrigée pour ne viser qu'ICT-4 (chimériques « kin ») et ICT-7 (scale-free) — alignée sur `ICT-0-Framing.md` (qui marquait déjà ICT-5/6 ✅, ICT-4/7 « à venir »).

## Garanties

- Diff surgical : +7 / −3, une seule section.
- **CATALOG-STATUS markers inchangés** (catalog-pr-hygiene).
- Les 6 documents/notebooks liés existent tous sur `origin/main` (vérifié `git cat-file -e`).
- ICT-4/ICT-7 ne sont **pas** liés comme notebooks existants.
- FR-first (README déjà en FR).

See #4588
See #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)