### PR TITLE
docs(ml): 02-ML-Cours — section Conclusion / fil rouge (prose pédagogique)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
@@ -85,6 +85,20 @@ Cette série est le **référent manuel** des labs agentic qui suivent. Une fois
 
 Les citations canoniques ancrées dans la série (cellule `## References` de chaque notebook) incluent : Mitchell 1997 (généralisation), Cauchy 1847 (descente de gradient), Nelder & Wedderburn 1972 (modèles linéaires généralisés), Cox 1958 (régression logistique), Breiman et al. 1984 (CART), Breiman 2001 (forêts aléatoires), Friedman 2001 (gradient boosting), Stone 1974 (validation croisée), Bradley 1997 (AUC), MacQueen 1967 (k-means), Pearson 1901 (ACP), Cortes & Vapnik 1995 (réseaux de vecteurs supports), Cover & Hart 1967 (k plus proches voisins), Valiant 1984 (théorie PAC), Vapnik & Chervonenkis 1971 (dimension VC), Hastie/Tibshirani/Friedman 2009 (*The Elements of Statistical Learning*) et Pedregosa et al. 2011 (scikit-learn).
 
+## Conclusion — ce que vous emportez
+
+Au terme des huit chapitres, le machine learning supervisé et non supervisé n'est plus une suite d'appels `fit()` opaques mais un **paysage cartographié**. Vous savez désormais *ce que* minimise un modèle (moindres carrés ou vraisemblance), *comment* il le minimise (la descente de gradient et la sensibilité au learning rate), *pourquoi* il sur- ou sous-apprend (le compromis biais-variance), et *combien* d'exemples il faut pour généraliser (la borne PAC, la dimension VC). Vous savez aussi élargir la famille au-delà du linéaire (arbres, ensembles, SVM à noyau, k plus proches voisins), travailler sans étiquettes (clustering, ACP), et juger une décision au regard du **coût réel de ses erreurs** (courbe ROC, choix de seuil).
+
+### Le fil rouge
+
+La série s'ouvrait sur une thèse : *on ne peut juger ce qu'un agent LLM produit comme pipeline scikit-learn que si l'on sait soi-même ce que ce pipeline fait*. Ce socle vient de fournir ce référent. Là où un lab agentic vous montrera un agent appeler `RandomForestClassifier().fit(X, y)` puis afficher une AUC flatteuse, vous lisez désormais cet enchaînement d'un œil critique : la séparation train/test est-elle honnête (pas de fuite de données) ? La métrique est-elle adaptée au déséquilibre des classes ? Le seuil de décision correspond-il au coût métier des faux négatifs ? L'évaluation repose-t-elle sur une validation croisée ou sur un seul découpage chanceux ? Le socle rend l'agent **jugeable** — et c'est exactement la compétence que les tracks agentic suivants présupposent acquise.
+
+### Pour prolonger
+
+- **Approfondir la théorie** : Hastie, Tibshirani & Friedman, *The Elements of Statistical Learning* (2009) reprend et formalise l'ensemble de ces chapitres ; le [guide utilisateur scikit-learn](https://scikit-learn.org/stable/user_guide.html) (Pedregosa et al. 2011) en est le prolongement pratique direct.
+- **Exercer le jugement** : reprenez un notebook des tracks [PythonAgentsForDataScience](../PythonAgentsForDataScience/README.md) ou [AgenticDataScience](../AgenticDataScience/README.md) et confrontez le pipeline produit par l'agent aux quatre questions ci-dessus — c'est le meilleur exercice de consolidation, car il met le socle au travail.
+- **Vers le deep learning et le RL** : la descente de gradient (2.2) et la notion de capacité d'un modèle (2.8) sont les deux fondations directement réinvesties par les réseaux de neurones ; la série [RL](../../../RL/README.md) montre cette même descente de gradient à l'œuvre dans l'apprentissage par renforcement profond (DQN, PPO).
+
 ---
 
 ## Licence


### PR DESCRIPTION
## Résumé

Ajoute une section **Conclusion / fil rouge** au README de la série ML canonique [`02-ML-Cours`](MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md), pour la mettre à **parité** avec ses READMEs frères (`DataScienceWithAgents`, `ML.Net`) qui possèdent déjà une conclusion de synthèse. Contribution #2651 (prose pédagogique des READMEs).

## Contenu (français-first, additif)

La section ajoutée est **distincte** des sections existantes (« Pourquoi cette série » = motivation d'ouverture ; « Suite logique » = pointeur d'une ligne ; « Objectifs d'apprentissage » = checklist) :

- **« Ce que vous emportez »** : synthèse du paysage ML cartographié par les 8 chapitres (ce que minimise un modèle, comment, pourquoi il sur-apprend, combien d'exemples pour généraliser).
- **« Le fil rouge »** : ferme la boucle sur la thèse agentic d'ouverture — le socle rend **jugeable** un pipeline produit par un agent LLM, illustré par 4 questions critiques concrètes (fuite de données, métrique vs déséquilibre, coût du seuil, validation croisée vs découpage unique).
- **« Pour prolonger »** : théorie (ESL 2009, guide scikit-learn), exercice de jugement sur les tracks agentic, pont vers le deep learning / RL.

## Conformité

- **français-first** (readme-french-first), prose synthétique non cosmétique.
- Marqueurs `CATALOG-STATUS` et fichiers catalogue **inchangés** (ce README de sous-série n'a aucun marqueur).
- 3 liens relatifs ajoutés **vérifiés** (cibles existantes).
- Un seul fichier modifié, un seul sujet (PR atomique).

See #2651 (prose pédagogique READMEs) ; See #3974 (READMEs feuilles familles Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)