### PR TITLE
docs(iit): cadrage strate 2 ICT (ICT-8) + feuille de route a jour (See #4588)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-0-Framing.md
+++ b/MyIA.AI.Notebooks/IIT/ICT-0-Framing.md
@@ -160,6 +160,7 @@ IIT/
 ├── ICT-5-CausalEmergence.ipynb            # ✅ émergence causale micro/macro (vrai pyphi.macro)
 ├── ICT-6-SortingToTPM-CausalEmergence.ipynb  # ✅ pont tri → TPM → émergence causale (CE 2.0)
 ├── ICT-7-ScaleFreeSignatures.ipynb        # ✅ signatures scale-free & criticalité (loi de Borel τ=3/2)
+├── ICT-8-AttractorLandscapesEWS.ipynb     # ✅ strate 2 : paysages d'attracteurs + early-warning signals
 └── ict/
     ├── self_sorting.py      # ✅ modèle vue-cellule (Cell, SelfSortingArray, scheduler)
     ├── kin_sorting.py       # ✅ règles enrichies : réparation bidirectionnelle + affinité kin
@@ -168,6 +169,8 @@ IIT/
     ├── causal_emergence.py  # ✅ CE 2.0 (Hoel 2025) : primitives causales, apportionnement, EC
     ├── tpm_estimation.py    # ✅ pont simulation → chaîne de Markov → TPM (état-à-état)
     ├── scale_free.py        # ✅ diagnostic scale-free (MLE de Hill, KS, choix de xmin, branchement)
+    ├── bistable.py          # ✅ strate 2 : modèle de pâturage de May, potentiel effectif, bifurcation pli
+    ├── early_warning.py     # ✅ strate 2 : variance/AR1 roulantes, τ de Kendall, amincissement, détrendage
     ├── distances.py         # à venir : distances entre états / structures / trajectoires
     └── ...
 ```
@@ -184,6 +187,40 @@ IIT/
 | **ICT-5** | [Émergence causale](ICT-5-CausalEmergence.ipynb) — $\Phi$ et information effective aux échelles micro/macro, recherche de coarse-graining (vrai `pyphi.macro`), émergence discriminante (Jansma & Hoel) | ✅ |
 | **ICT-6** | [Pont tri → TPM](ICT-6-SortingToTPM-CausalEmergence.ipynb) — chaîne de Markov estimée depuis les trajectoires de tri, émergence causale multi-échelles (CE 2.0 *scale-free*, au-delà de la borne de taille de PyPhi) | ✅ |
 | **ICT-7** | [Signatures scale-free & criticalité](ICT-7-ScaleFreeSignatures.ipynb) — détecter une signature sans échelle *sans se faire avoir* (MLE de Hill, choix de $x_{\min}$, KS, comparaison de modèles à la Clauset et al.) ; étalon critique (branchement, exposant $3/2$) vs tri auto-organisé qui *paraît* à queue lourde mais possède une échelle caractéristique (la taille), révélée par effondrement d'échelle | ✅ |
+| **ICT-8** | [Paysages d'attracteurs & signaux précurseurs](ICT-8-AttractorLandscapesEWS.ipynb) — **strate 2**. Modèle de pâturage de May (1977), bistabilité + bifurcation pli ; *early-warning signals* (Scheffer 2009) : potentiel effectif, valeur propre → 0, variance ↑, autocorrélation ↑ (τ de Kendall), avec la leçon de protocole *sans complaisance* (amincir, détrendre) | ✅ |
+| **ICT-9** | Agence & régénération réaction-diffusion (Gray-Scott) — **strate 2**. Un système qui **répare** sa forme vers un point de consigne intrinsèque après ablation, démontré *par contraste* avec la simple diffusion | 🚧 planifié |
+
+## Strate 2 — du tri transparent à la morphogenèse dynamique
+
+La **strate 1** (ICT-1 à ICT-7) a fait du **tri auto-organisé** un marche-pied idéal : tout y est
+calculable, les trajectoires sont enregistrables, et des compétences réelles (robustesse, délai de
+gratification, agrégation « kin ») y apparaissent. Mais ce banc d'essai bute sur **trois limites**
+dès qu'on veut voir émerger l'**agence** et l'**organisation générative** :
+
+1. un **attracteur global unique**, dont le but (le tableau trié) est **imposé de l'extérieur** ;
+2. **aucun point de consigne intrinsèque** — rien que le système « cherche » de lui-même ;
+3. **pas de hiérarchie génératrice** — la richesse multi-échelle de la strate 1 est *analytique*
+   (on la lit dans les TPM), pas **produite** par la dynamique.
+
+La **strate 2** ouvre la *morphogenèse dynamique* sur des substrats dont le **paysage
+d'attracteurs est engendré par la dynamique elle-même**, et lève ces limites une à une :
+
+- **ICT-8** (bifurcation pli + *early-warning signals*) lève les limites **1** et **3** : un vrai
+  paysage à **plusieurs bassins** séparés par un col, une **bifurcation** qui crée et détruit des
+  attracteurs, et une hiérarchie naturelle (les deux bassins forment un gros-grain à deux
+  macro-états, branché sur la causal emergence d'ICT-5/6). Le substrat — le modèle de pâturage de
+  May, canonique des EWS (Scheffer 2009 ; Dakos 2012) — porte la narration *« les deux tressées »* :
+  chaque image métaphorique (la vallée qui s'aplatit, la mémoire du danger, l'alerte avant la
+  bascule) est **adossée à une grandeur mesurée**, et la leçon *sans complaisance* montre qu'une
+  mesure naïve **fabrique ou masque** le signal — la métaphore n'est créditée que par la rigueur du
+  protocole.
+- **ICT-9** (réaction-diffusion régénérante, type Gray-Scott) lèvera la limite **2** : l'**agence**
+  comme capacité à **maintenir et réparer sa propre forme** vers un *point de consigne intrinsèque*,
+  démontrée *par contraste* — la réaction répare là où la simple diffusion dissout (l'analogue
+  dynamique du « sans liberté, pas d'agrégation » d'ICT-4).
+
+C'est la même discipline que la strate 1 (exécuter, mesurer, narrer le résultat réel) appliquée à
+une dynamique qui, cette fois, **génère** son propre paysage de buts plutôt que de le recevoir.
 
 ## Principe méthodologique
 

--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -313,18 +313,36 @@ mesures, PyPhi pour les calculs IIT stricts), et s'ouvre sur deux articles fonda
 comme morphogenèse minimale (Zhang, Goldstein & Levin, 2025) et l'ingénierie de l'émergence
 multi-échelle (Jansma & Hoel, 2025).
 
+La série progresse en **deux strates**. La **strate 1** (ICT-0 à ICT-7) prend le **tri
+auto-organisé** comme banc d'essai entièrement transparent : trajectoires enregistrables,
+compétences inattendues réelles, pont vers la causal emergence. Elle bute toutefois sur trois
+limites — un **attracteur global unique**, un **but imposé de l'extérieur**, une **hiérarchie non
+générative**. La **strate 2** (ICT-8+) ouvre la *morphogenèse dynamique* sur des systèmes dont le
+paysage d'attracteurs est **engendré par la dynamique** (bifurcation, réaction-diffusion), levant
+ces limites une à une.
+
+### Strate 1 — le tri auto-organisé (transparent et calculable)
+
 | Document | Contenu |
 |----------|---------|
 | [ICT-0-Framing](ICT-0-Framing.md) | Cadrage de la série : de l'état à la trajectoire, articles fondateurs, feuille de route |
 | [ICT-1-PhiTrajectories](ICT-1-PhiTrajectories.ipynb) | Trajectoires de $\Phi$ : paysage de $\Phi$, suivi de $\Phi$ le long d'un attracteur (pulsations) et robustesse aux perturbations — la photographie IIT mise en mouvement, avec le vrai PyPhi |
 | [ICT-2-SelfSortingMorphogenesis](ICT-2-SelfSortingMorphogenesis.ipynb) | Le tri auto-organisé comme morphogenèse : trajectoire dans le morphospace, robustesse aux cellules défectueuses, délai de gratification, auto-réparation, impasses chimériques |
 | [ICT-3-RobustnessDelayedGratification](ICT-3-RobustnessDelayedGratification.ipynb) | Robustesse & délai de gratification, étude quantitative : dégradation gracieuse face aux cellules défectueuses, distributions de récupération, comptage du délai de gratification |
+| [ICT-4-ChimericArraysKinAggregation](ICT-4-ChimericArraysKinAggregation.ipynb) | Tableaux chimériques & agrégation émergente : réparation bidirectionnelle (guérit l'impasse d'ICT-2) puis affinité « kin », mesurée honnêtement (sans degrés de liberté, pas d'agrégation) |
 | [ICT-5-CausalEmergence](ICT-5-CausalEmergence.ipynb) | Émergence causale : $\Phi$ et information effective aux échelles micro/macro, recherche systématique du coarse-graining (vrai `pyphi.macro`), émergence discriminante (Jansma & Hoel, 2025) |
 | [ICT-6-SortingToTPM-CausalEmergence](ICT-6-SortingToTPM-CausalEmergence.ipynb) | Pont tri → TPM : chaîne de Markov estimée depuis les trajectoires de tri d'ICT-2, puis émergence causale multi-échelles avec l'outillage *Causal Emergence 2.0* (Hoel, 2025) au-delà de la borne de taille de PyPhi |
+| [ICT-7-ScaleFreeSignatures](ICT-7-ScaleFreeSignatures.ipynb) | Signatures scale-free & criticalité : détecter une loi de puissance *sans se faire avoir* (MLE de Hill, choix de $x_{\min}$, KS, à la Clauset et al.) ; étalon critique (branchement, exposant $3/2$) vs tri qui *paraît* sans échelle mais possède une taille caractéristique |
 
-Restent sur la feuille de route de [ICT-0-Framing](ICT-0-Framing.md) : **ICT-4** (tableaux
-chimériques & agrégation émergente — le jeu de règles riche « kin » du papier) et **ICT-7**
-(signatures scale-free & fractales).
+### Strate 2 — morphogenèse dynamique (paysages d'attracteurs)
+
+| Document | Contenu |
+|----------|---------|
+| [ICT-8-AttractorLandscapesEWS](ICT-8-AttractorLandscapesEWS.ipynb) | Paysages d'attracteurs & signaux précurseurs — *les deux tressées*. Modèle de pâturage de May (1977), système canonique des *early-warning signals* (Scheffer 2009). Bistabilité entre deux états positifs alternatifs, bifurcation pli, catastrophe = changement de régime. Chaque image (vallée qui s'aplatit, mémoire du danger, alerte) adossée à une mesure réelle (potentiel effectif, valeur propre → 0, variance ↑, autocorrélation ↑, τ de Kendall). Lève l'attracteur unique + ouvre une hiérarchie générative |
+
+Reste sur la feuille de route de [ICT-0-Framing](ICT-0-Framing.md) : **ICT-9** — l'**agence** comme
+régénération vers un *point de consigne intrinsèque* (morphogenèse réaction-diffusion : un système
+qui répare sa forme après ablation, démontré par contraste avec la simple diffusion).
 
 ## Ponts causaux : le do-calculus de Pearl à travers les paradigmes
 


### PR DESCRIPTION
## Résumé

Documente l'ouverture de la **strate 2** de la série ICT (morphogenèse dynamique, ICT-8 mergé en #4643) et **corrige la feuille de route devenue obsolète**. Docs-only, aucun notebook touché.

### `ICT-0-Framing.md`
- **Nouvelle section « Strate 2 — du tri transparent à la morphogenèse dynamique »** : explicite les **3 limites** du tri auto-organisé (attracteur global unique, but extrinsèque, hiérarchie non générative) et comment **ICT-8** lève #1+#3 et **ICT-9** lèvera #2. Narration *« les deux tressées »* + leçon de protocole *sans complaisance*.
- Arbre d'architecture : ajout `ICT-8-AttractorLandscapesEWS.ipynb` + `ict/bistable.py` + `ict/early_warning.py`.
- Feuille de route : lignes **ICT-8** (livré ✅) et **ICT-9** (planifié 🚧).

### `README.md` (série IIT)
- Section ICT scindée en **strate 1** (tri, ICT-0…7) et **strate 2** (ICT-8+).
- **Ajout des lignes ICT-4 et ICT-7** : tous deux livrés mais absents du tableau — la doc était **obsolète**.
- Ligne **ICT-8** (paysages d'attracteurs + *early-warning signals*).
- Remplacement de la note « restent ICT-4/ICT-7 » (fausse : les deux sont livrés) par le forward-look **ICT-9**.

### Conformité
- Docs FR (readme-french-first ✓). Bloc **`CATALOG-STATUS` inchangé** (catalogue = propriété de l'automatisation, catalog-pr-hygiene ✓). Aucun fichier catalogue touché.

See #4588

🤖 Generated with [Claude Code](https://claude.com/claude-code)