### PR TITLE
docs(readme): resync ascendant #3973 — Search Partie 4 (MGS-15..18) + GameTheory companions Lean (5b, 11b)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -102,6 +102,7 @@ flowchart TD
 | 9 | [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb) | Python | Induction arrière, mille-pattes, escalade | 55 min |
 | 10 | [GameTheory-10-ForwardInduction-SPE](GameTheory-10-ForwardInduction-SPE.ipynb) | Python | Induction avant, SPE, menaces crédibles | 60 min |
 | 11 | [GameTheory-11-BayesianGames](GameTheory-11-BayesianGames.ipynb) | Python | Jeux bayésiens, information incomplète | 55 min |
+| 11b | [GameTheory-11b-Lean-BayesianGamesExt](GameTheory-11b-Lean-BayesianGamesExt.ipynb) | Lean 4 | Companion natif : théorème de Vickrey (enchère au second prix) prouvé 0-sorry dans le lake `lean_game_defs_ext` (module Bayesian, sans Mathlib) | 50 min |
 | 12 | [GameTheory-12-ReputationGames](GameTheory-12-ReputationGames.ipynb) | Python | Jeux de réputation, signaling | 50 min |
 
 ### Partie 3 : Algorithmes et applications avancées (Notebooks 13-17)
@@ -162,6 +163,7 @@ Chaque notebook adopte la même trame pédagogique — introduction motivée, pl
 | 4b | Lean-NashExistence | ~20 | 3 | **COMPLET** |
 | 4c | NashExistence-Python | ~20 | 2 | **COMPLET** |
 | 5 | ZeroSum-Minimax | ~25 | 3 | **COMPLET** |
+| 5b | Lean-Minimax | ~20 | 3 | **COMPLET** |
 | 6 | EvolutionTrust | ~40 | 3 | **COMPLET** |
 | 7 | ExtensiveForm | ~30 | 3 | **COMPLET** |
 | 8 | CombinatorialGames | ~17 | 3 | **NOUVEAU** |
@@ -170,6 +172,7 @@ Chaque notebook adopte la même trame pédagogique — introduction motivée, pl
 | 9 | BackwardInduction | ~35 | 3 | **COMPLET** |
 | 10 | ForwardInduction-SPE | ~35 | 3 | **COMPLET** |
 | 11 | BayesianGames | ~30 | 3 | **COMPLET** |
+| 11b | Lean-BayesianGamesExt | ~35 | - | **COMPLET** |
 | 12 | ReputationGames | ~30 | 3 | **COMPLET** |
 | 13 | ImperfectInfo-CFR | ~45 | 3 | **COMPLET** |
 | 14 | DifferentialGames | ~35 | 3 | **COMPLET** |
@@ -221,7 +224,9 @@ Chaque notebook introduit un concept ou un modèle spécifique. Le tableau ci-de
 |---|----------|-------------------|
 | 2b | Lean-Definitions | Formalisation Game2x2, stratégies mixtes, Nash en Lean |
 | 4b | Lean-NashExistence | Brouwer, Kakutani, preuve existence Nash |
+| 5b | Lean-Minimax | Théorème minimax (von Neumann/Sion) prouvé 0-sorry, lake `minimax_lean` |
 | 8b | Lean-CombinatorialGames | PGame Mathlib, Nim formel, Sprague-Grundy |
+| 11b | Lean-BayesianGamesExt | Théorème de Vickrey (enchère au second prix) prouvé 0-sorry, lake `lean_game_defs_ext` |
 | 15b | Lean-CooperativeGames | Axiomes Shapley formels, Core, Bondareva-Shapley |
 
 ### Side tracks Python (approfondissement)

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -111,6 +111,8 @@ Chaque notebook introduit un concept ou algorithme spécifique. Le tableau ci-de
 
 Side track C# .NET 9 (cf. [Search-5](Part1-Foundations/Search-5-GeneticAlgorithms.ipynb), [Search-11](Part1-Foundations/Search-11-Metaheuristics.ipynb)) : reconstruire et **composer** les métaheuristiques au-dessus de GeneticSharp plutôt que d'en importer une boîte noire.
 
+La série se lit en trois temps : **MGS-1 à 7** bâtissent le moteur et la grammaire de composition (jusqu'aux composés publiés et au TSP) ; **MGS-8 à 14** visualisent les paysages de fitness et mesurent la robustesse aux biais des bancs CEC (décalage, rotation, synergie d'îles) ; **MGS-15 à 18** referment la série sur l'**analyse quantitative de paysage** et la **méta-stratégie** — choisir l'optimiseur selon le paysage (No-Free-Lunch), adapter ses paramètres en cours de route, et confronter le portefeuille au protocole CEC complet.
+
 | # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
 | 1 | MGS-1 Introduction | Moteur autonome `MetaGeneticAlgorithm` au-dessus de GeneticSharp |
@@ -127,6 +129,10 @@ Side track C# .NET 9 (cf. [Search-5](Part1-Foundations/Search-5-GeneticAlgorithm
 | 12 | MGS-12 AxisAlignment | Biais d'alignement d'axes (rotation) |
 | 13 | MGS-13 LandscapeDebias | Pourquoi la rotation casse la séparabilité (visuel) |
 | 14 | MGS-14 IslandSynergyFound | Une synergie d'îles *trouvée* (et un cas négatif) |
+| 15 | MGS-15 LandscapeAnalysis | Corrélation fitness-distance (FDC, Jones & Forrest 1995) : le nombre derrière la heatmap, prédire la difficulté d'un paysage |
+| 16 | MGS-16 AlgorithmSelection | No-Free-Lunch (Wolpert & Macready 1997) + cadre de Rice : features de paysage → recommandation d'optimiseur, validée sur un paysage inconnu (Rosenbrock) |
+| 17 | MGS-17 ParameterControl | Adapter les paramètres *pendant* la course (taxonomie d'Eiben : réglage vs contrôle) — la seconde réponse au No-Free-Lunch |
+| 18 | MGS-18 CecBanc | Banc CEC consolidé : combiner décalage (MGS-10) et rotation (MGS-12) — robuste à chaque biais séparément l'est-il au biais combiné ? |
 
 ### Applications
 
@@ -438,7 +444,7 @@ Search/
 │       └── App-18-HyperparameterTuning.ipynb
 │
 ├── MetaGeneticSharp/                      # Sous-module : metaheuristiques composables sur GeneticSharp (jsboige/MetaGeneticSharp)
-├── Part4-Metaheuristics/                  # Partie 4 (side track C# .NET 9) : README + 14 notebooks MGS-1..14 (moteur, composition, composés, benchmarks, TSP, paysages, biais central, synergie d'îles, alignement d'axes, paysages dé-biaisés, synergie conditionnelle ; consomment le sous-module)
+├── Part4-Metaheuristics/                  # Partie 4 (side track C# .NET 9) : README + 18 notebooks MGS-1..18 (moteur, composition, composés, benchmarks, TSP, paysages, biais central, synergie d'îles, alignement d'axes, paysages dé-biaisés, synergie conditionnelle, analyse de paysage FDC, sélection d'algorithme No-Free-Lunch, contrôle de paramètres, banc CEC consolidé ; consomment le sous-module)
 │
 ├── CSPs_Intro.ipynb                       # Ancien notebook (conserve)
 ├── GeneticSharp-EdgeDetection.ipynb       # Ancien notebook (conserve)


### PR DESCRIPTION
## Resume

Resynchronisation ascendante (#3973) des tableaux d'enumeration de deux README de serie qui avaient derive derriere l'evolution du depot. **Markdown-only**, marqueurs `CATALOG-STATUS` byte-identiques, **aucun notebook touche**.

### Search/README.md — Partie 4 (Metaheuristiques composables)
Le tableau s'arretait a MGS-14 alors que `Part4-Metaheuristics/` contient MGS-1..18 (le README profond `Part4-Metaheuristics/README.md` etait deja a jour ; seul le README de serie **parent** avait derive — gap ascendant typique). Ajout des 4 notebooks manquants :
- **MGS-15 LandscapeAnalysis** — correlation fitness-distance (FDC, Jones & Forrest 1995)
- **MGS-16 AlgorithmSelection** — No-Free-Lunch (Wolpert & Macready 1997) + cadre de Rice
- **MGS-17 ParameterControl** — taxonomie d'Eiben (reglage vs controle)
- **MGS-18 CecBanc** — banc CEC consolide (biais combine decalage+rotation)

\+ phrase d'arc en 3 temps (moteur -> paysages/biais -> analyse/meta-strategie) ; arbre de fichiers 14 -> 18.

### GameTheory/README.md — companions Lean 4
Deux companions Lean recents absents des tables de navigation :
- **11b-Lean-BayesianGamesExt** (theoreme de Vickrey, lake `lean_game_defs_ext`) — etait absent de **toutes** les tables ; ajoute au tableau Partie 2, au Statut de maturite, et au resume "Side tracks Lean 4".
- **5b-Lean-Minimax** — present dans le tableau Partie 1 mais absent du Statut de maturite et du resume Lean 4 ; ajoute.

## Verification
- Gap trouve par survey read-only (sous-agent sonnet) + **cross-check G.1 manuel** : le survey avait un **faux positif sur IIT** (il pretendait ICT-4 absent ; il est bien dans la table ligne 332) — ecarte. La famille Search Partie 4 et les companions GameTheory sont confirmes par grep direct + listing disque.
- Comptages verifies par lecture des notebooks : 5b = 19 cellules / 3 exercices ; 11b = 36 cellules / 0 exercice (companion Lean pur -> exception #2161, represente `-` comme la ligne Setup).
- Descriptions fideles aux cellules markdown des notebooks ; claims `0-sorry` **transcrites** des notebooks et des descriptions existantes du README (pas de nouvelle verification de preuve).
- `git diff` : 2 fichiers, 12 insertions / 1 deletion, **0 marqueur CATALOG-STATUS touche, 0 notebook**.

Docs-only ; aucune execution requise (C.2/C.3 non implicites). FR-first (READMEs deja francais).

See #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)