### PR TITLE
fix(ict): GrayScott.run record_every echantillonne aux multiples exacts (#4588)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ict/reaction_diffusion.py
+++ b/MyIA.AI.Notebooks/IIT/ict/reaction_diffusion.py
@@ -134,21 +134,32 @@ class GrayScott:
         """Integre ``steps`` pas. Retourne ``(U, V, snapshots)``.
 
         Si ``record_every > 0``, ``snapshots`` est la liste des champs ``V``
-        captures tous les ``record_every`` pas (pour les courbes temporelles et
-        les animations) ; sinon ``snapshots`` vaut ``None``.
+        captures (pour les courbes temporelles et les animations) ; sinon
+        ``snapshots`` vaut ``None`` et ``include_initial`` est sans effet.
 
-        Si ``include_initial`` est vrai (et ``record_every > 0``), l'etat ``V``
-        **avant le premier pas** (t = 0) est insere en tete de ``snapshots``. Par
-        defaut la capture commence apres le premier pas : pour une courbe de
-        recuperation qui part de l'etat ablate exact, passer ``include_initial=True``
-        garantit que le point de depart de la trajectoire est bien l'instant 0.
+        Echantillonnage temporel — convention exacte (verrouillee par les tests).
+        On capture aux **multiples exacts** de ``record_every`` : aux instants
+        ``record_every, 2*record_every, ...``, **instant final ``steps`` inclus**
+        lorsqu'il est multiple de ``record_every``. Si ``include_initial`` est vrai,
+        l'etat **avant le premier pas** (instant 0) est insere en tete ; la
+        trajectoire est alors regulierement espacee a partir de 0, et
+        ``snapshots[i]`` correspond *exactement* a l'instant ``i*record_every``.
+        C'est la convention qu'attend :func:`ict.agency.time_to_recover`, qui
+        convertit l'indice ``i`` en nombre de pas via ``i*record_every`` — d'ou
+        l'importance de l'alignement exact pour les signaux temporels (ICT-11/12).
+
+        Ancrer une courbe de recuperation a l'etat ablate exact demande donc
+        ``record_every > 0`` **et** ``include_initial=True``.
         """
         snapshots: Optional[List[np.ndarray]] = [] if record_every > 0 else None
         if snapshots is not None and include_initial:
-            snapshots.append(V.copy())
+            snapshots.append(V.copy())  # instant 0, avant tout pas
         for t in range(steps):
             U, V = self.step(U, V)
-            if snapshots is not None and (t % record_every == 0):
+            # apres ce pas, (U, V) est l'etat a l'instant t+1 : on capture aux
+            # multiples exacts de record_every (echantillonnage regulier, instant
+            # final inclus si steps % record_every == 0), pas a t+1 = 1, R+1, ...
+            if snapshots is not None and ((t + 1) % record_every == 0):
                 snapshots.append(V.copy())
         return U, V, snapshots
 

--- a/MyIA.AI.Notebooks/IIT/tests/test_reaction_diffusion.py
+++ b/MyIA.AI.Notebooks/IIT/tests/test_reaction_diffusion.py
@@ -105,6 +105,27 @@ def test_run_include_initial_prepends_t0():
     assert none_snaps is None
 
 
+def test_run_snapshot_timing_is_regular():
+    # Convention exacte : captures aux multiples de record_every, instant final
+    # inclus (steps multiple de record_every), pas decalees a 1, R+1, 2R+1...
+    # Avec include_initial, snapshots[i] == instant i*record_every : c'est la
+    # grille reguliere qu'attend agency.time_to_recover (i -> i*record_every).
+    gs = rd.GrayScott()
+    U, V = gs.seed(n=32, rng=np.random.default_rng(7))
+    steps, rec = 100, 20
+    _, V_end, snaps_i = gs.run(
+        U.copy(), V.copy(), steps=steps, record_every=rec, include_initial=True
+    )
+    # instants 0, 20, 40, 60, 80, 100 -> steps//rec + 1 captures
+    assert len(snaps_i) == steps // rec + 1
+    # le dernier instantane EST l'etat final retourne (l'instant `steps` est capture)
+    assert np.array_equal(snaps_i[-1], V_end)
+    # sans include_initial : instants 20..100 -> steps//rec captures, dernier = etat final
+    _, V_end2, snaps = gs.run(U.copy(), V.copy(), steps=steps, record_every=rec)
+    assert len(snaps) == steps // rec
+    assert np.array_equal(snaps[-1], V_end2)
+
+
 def test_pure_diffusion_conserves_mass():
     # la diffusion pure (bords periodiques) conserve la masse totale
     f = np.random.default_rng(5).standard_normal((24, 24)) + 5.0


### PR DESCRIPTION
## Contexte

Retour de revue (ChatGPT) sur **ICT-9** (`See #4588`, strate 2 de la serie ICT). Le seul point technique souleve : la semantique temporelle de `GrayScott.run(record_every, include_initial)` est ambigue/decalee.

## Le bug

Dans `ict/reaction_diffusion.py`, la capture se faisait sur `t % record_every == 0` *apres* le pas (ou `(U,V)` est deja a l'instant `t+1`). Avec `record_every=20, include_initial=True`, les instantanes tombaient aux instants **0, 1, 21, 41, ...** (off-by-one + quasi-doublon au depart) et **l'instant final `steps` n'etait jamais capture**, au lieu de la grille reguliere **0, 20, 40, ..., steps**.

C'est une **incoherence interne** : `ict.agency.time_to_recover` convertit deja l'indice `i` en pas via `i*record_every` — il *presuppose* donc la grille reguliere a partir de 0. Le notebook ICT-9 inline d'ailleurs la bonne convention (`(t+1) % REC == 0`) et la documente ("comme le ferait `modele.run(..., include_initial=True)`"). Cette PR fait honorer ce contrat a `run()` lui-meme.

## Le fix

- **`run()`** capture quand `(t+1) % record_every == 0` : multiples exacts, **instant final inclus** si `steps` en est multiple. Avec `include_initial=True`, `snapshots[i]` correspond *exactement* a l'instant `i*record_every`.
- **Docstring** : convention exacte explicitee + alignement avec `time_to_recover` (important pour les signaux temporels plus fins d'ICT-11/12, comme le notait la revue).
- **Test** `test_run_snapshot_timing_is_regular` : verrouille la grille reguliere (espacement + capture de l'etat final).

## Pas de changement de notebook (volontaire)

La trajectoire de tete d'ICT-9 **inline deja** la bonne convention (elle enregistre des scalaires `structure(...)`, pas des champs) ; le chemin `run(record_every=...)` n'est exerce **que par les tests**. Donc **sorties de cellules inchangees**, et le `ttr = 2400 pas` rapporte (calcule via le loop inline correct) **reste valide**. C3 respecte : aucun notebook source modifie -> aucune re-exec/commit de notebook.

## Validation

- Suite IIT : **124 passed** (123 + 1 nouveau) en local, conda `coursia-ml-training`.
- Anti-regression : fix a insertions dominantes (+42/-10), aucune preuve/implementation supprimee.

`See #4588`

🤖 Generated with [Claude Code](https://claude.com/claude-code)