### PR TITLE
fix(rl-12): normalize stale worktree path in papermill metadata (See #3436)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb
@@ -1084,8 +1084,8 @@
    "end_time": "2026-06-29T18:07:54.698535+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:/dev/_wt/rl12-0d3717920/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb",
-   "output_path": "d:/dev/_wt/rl12-0d3717920/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb",
+   "input_path": "rl_12_distributional_rl.ipynb",
+   "output_path": "rl_12_distributional_rl.ipynb",
    "parameters": {},
    "start_time": "2026-06-29T18:05:36.300389+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Contexte

**#3436** (papermill-paths repo-wide sweep) -- partition **Python** (ownership familial po-2025). Un notebook committe un chemin de worktree machine stale dans ses metadatas papermill.

## Livrable

`RL/rl_12_distributional_rl.ipynb` portait `metadata.papermill.{input,output}_path` pointant vers `d:/dev/_wt/rl12-0d3717920/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb` -- artefact de l'execution en worktree isole lors de la creation du notebook (cycle RL precedent, commit `0d3717920`). Normalisation au **basename** `rl_12_distributional_rl.ipynb`.

## Methode (conforme Stop & Repair / secrets-hygiene §6)

`metadata.papermill.input/output_path` est de la **metadata notebook** (PAS une sortie de cellule). La regle secrets-hygiene §6 explicite : la mettre au basename est la **normalisation toleree**, ce n'est PAS un scrub d'output. Aucune cell output touchee, aucun scrub, **aucune re-exec necessaire** (le contenu pedagogique est intact : C.2 OK 12/12 outputs 0 erreur, 3 exercices #2161, prose riche).

- Replace textuel chirurgical des 2 occurrences du path (le path stale n'apparait QUE dans ces 2 metadatas -- verifie, 0 occurrence dans cell source/outputs).
- Format `indent=1` (nbformat) preserve, **0 churn** (diff = 2 lignes : les 2 paths).

## Audit partition Python (axe #3436)

Scan repo-wide de **tous** les notebooks Python (ML / RL / IIT / Search / SymbolicLearning / GameTheory-Py) sur deux axes :
1. `metadata.papermill.{input,output}_path` avec chemin absolu
2. artefacts worktree stale (`d:/dev/_wt/`, `/d/dev/wt`, etc.) dans metadata + cell source + cell outputs

**Resultat : rl_12 est le SEUL notebook Python fuyant** (2 hits dans metadata, 0 ailleurs). La partition Python de po-2025 est quasi-parfaite sur ce front.

## Restant (hors partition, signale)

1 autre leak repo-wide : `SymbolicAI/Lean/Lean-18-Search-AStar-Optimality.ipynb` -- turf **po-2026** (frontiere specialisation Lean, non touche). A dispatcher au retour de po-2026.

## Scope

1 fichier, +2/-2 (metadata seule). **Pas de self-merge** (mandat user 2026-06-30 : ai-01 merge au retour).

See #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)