### PR TITLE
docs(texte): add missing notebook 20 (OWUI Native API) to Tier 5 table (#3974)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -69,6 +69,7 @@ Le notebook 12 introduit en Python pur les quatre moteurs d'inférence au moment
 | 17 | `17_Native_Reasoning_vs_Scaling.ipynb` | Raisonnement natif (deepseek-r1, reasoning tokens) vs scaling hand-rolled (BoN), comparaison cost-normalisée en tokens | 60 min |
 | 18 | `18_Semantic_Kernel_Plugins.ipynb` | Moteurs exposés en plugins Semantic Kernel (`@kernel_function`) composables via le kernel (pont série SemanticKernel) | 60 min |
 | 19 | `19_OWUI_Orchestration.ipynb` | Orchestration sans code via Open WebUI v0.9.0 (Automations RRULE / Task Management / Calendar) ; trois niveaux d'abstraction (produit OWUI vs LangGraph vs CrewAI) ; migration async 0.8→0.9 ; skeleton API OpenAI-compatible avec graceful skip (`OWUI_API_KEY`) | 60 min |
+| 20 | `20_OWUI_Native_API.ipynb` | Compagnon du 19 : introspection de la **vraie surface API native** OWUI v0.9.6 (routes REST auth-free : santé/version/config ; couche authentifiée Bearer) via `urllib` standard ; graceful skip honnête si `OWUI_API_KEY` absente (Stop & Repair, pas de sortie fabriquée) | 60 min |
 
 ## Prérequis
 


### PR DESCRIPTION
## Contexte

Instance de l'issue **#3974** (feuilles-READMEs ascendantes, rollout pérenne famille-partitionné). Survey firsthand des READMEs GenAI : la série **Texte** énumérait notebooks 1-19 dans sa table Tier 5, alors que **20 notebooks** existent sur disque. Le `20_OWUI_Native_API.ipynb` n'était référencé nulle part (`grep -c = 0`).

## Changement

+1 ligne dans la table Tier 5 de \`Texte/README.md\` : ajoute la ligne pour le notebook 20, compagnon thématique du 19.

**Description sourcée depuis le notebook lui-même** (premières cellules markdown lues firsthand), pas de contenu fabriqué :
- 19 = orchestration via l'endpoint OpenAI-compatible \`/api/chat/completions\`
- 20 = introspection de la **vraie surface API native OWUI v0.9.6** (routes REST auth-free : santé/version/config ; couche authentifiée Bearer) via \`urllib\` standard
- Graceful skip honnête si \`OWUI_API_KEY\` absente (Stop & Repair, mandat SOTA RECOVERABLE-USER-HAND — pas de sortie fabriquée)

## Vérifications

- \`find Texte -maxdepth 1 -name '*.ipynb' ! -name '*_output.ipynb'\` → **20 notebooks** (1_OpenAI_Intro … 20_OWUI_Native_API)
- Markdown-only, **0 re-execution** (prose README uniquement, règle C.2/C.3)
- **CATALOG-STATUS byte-identique** (off-limits, propriété de l'automation — règle catalog-pr-hygiene)
- Aucun count prose « 19 notebooks » à bump (la table est le seul inventaire ; +1 ligne suffit)
- FR-first, no-emojis (code-style)
- Scope atomique : 1 fichier, +1 ligne

## Scope

\`See #3974\` (contribution partielle — rollout pérenne famille-partitionné, n'épuise pas la fille GenAI). Survey GenAI complet : les autres sous-séries (Audio 30, Image 20, Video 17, SemanticKernel 20, CaseStudies 4, FineTuning 5, PostTraining 7, Vibe-Coding 5, Open-WebUI) sont **clean** (counts/tables matchent le disque). Open-WebUI/Playwright-OWUI = WIP by-design (#4433), non touché.

Co-Authored-By: Claude-Code <noreply@anthropic.com>