### PR TITLE
docs(probas): restore missing French accents + fix typos in series README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -9,18 +9,18 @@ maturity: PRODUCTION=46, BETA=1
 
 [← Notebooks](../README.md) | [Série Infer (C#) →](Infer/README.md) | [Série PyMC (Python) →](PyMC/README.md) | [GameTheory →](../GameTheory/README.md)
 
-Le monde réel est incertain. Un diagnostic médical n'est jamais sur a 100%, un classement sportif dépend de performances intrinsèquement variables, et les données que nous collectons sont toujours bruitées ou incomplètes. La programmation probabiliste offre un cadre rigoureux pour modéliser cette incertitude : plutôt que de calculer une seule réponse, on obtient une **distribution de probabilités** qui quantifie notre confiance dans chaque résultat possible.
+Le monde réel est incertain. Un diagnostic médical n'est jamais sûr à 100%, un classement sportif dépend de performances intrinsèquement variables, et les données que nous collectons sont toujours bruitées ou incomplètes. La programmation probabiliste offre un cadre rigoureux pour modéliser cette incertitude : plutôt que de calculer une seule réponse, on obtient une **distribution de probabilités** qui quantifie notre confiance dans chaque résultat possible.
 
-Cette série couvre trois stack complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inférence exacte par message passing, **PyMC** (Python) pour l'échantillonnage MCMC moderne, et des **applications standalone** (RSA). Les 21 notebooks Infer.NET couvrent les fondements mathématiques (distributions, graphs de facteurs), les modèles classiques (réseaux bayésiens, TrueSkill, LDA, HMM), puis la théorie de la décision bayésienne — jusqu'a un compagnon **Lean 4** (Infer-20b, adossé au projet Lake `gittins_lean`) qui démontre formellement les identités d'escompte de l'indice de Gittins. Les 20 notebooks PyMC reprennent l'intégralité des modèles Infer.NET en Python avec l'échantillonnage NUTS, offrant un pont naturel vers l'écosystème data science : fondations 1-3, modèles classiques 4-13, et théorie de la décision 14-20.
+Cette série couvre trois stacks complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inférence exacte par message passing, **PyMC** (Python) pour l'échantillonnage MCMC moderne, et des **applications standalone** (RSA). Les 21 notebooks Infer.NET couvrent les fondements mathématiques (distributions, graphs de facteurs), les modèles classiques (réseaux bayésiens, TrueSkill, LDA, HMM), puis la théorie de la décision bayésienne — jusqu'à un compagnon **Lean 4** (Infer-20b, adossé au projet Lake `gittins_lean`) qui démontre formellement les identités d'escompte de l'indice de Gittins. Les 20 notebooks PyMC reprennent l'intégralité des modèles Infer.NET en Python avec l'échantillonnage NUTS, offrant un pont naturel vers l'écosystème data science : fondations 1-3, modèles classiques 4-13, et théorie de la décision 14-20.
 
 ## Pourquoi cette série
 
-La programmation probabiliste occupe une place singuliere dans la paysage de l'IA. Alors que le machine learning classique fournit des predictions ponctuelles (un score, une classe), il ne dit pas a quel point il a confiance en cette prediction. La programmation probabiliste, elle, quantifie cette incertitude de facon native.
+La programmation probabiliste occupe une place singulière dans le paysage de l'IA. Alors que le machine learning classique fournit des prédictions ponctuelles (un score, une classe), il ne dit pas à quel point il a confiance en cette prédiction. La programmation probabiliste, elle, quantifie cette incertitude de façon native.
 
-Cette série repose sur une **double approche d'inférence**, deliberatement juxtaposée :
+Cette série repose sur une **double approche d'inférence**, délibérément juxtaposée :
 
-- **Inférence exacte par message passing** (Infer.NET) : pour les modèles où les distributions postérieures peuvent être calculées exactement (ou approchées par EP/VMP). C'est la méthode des graphes de facteurs, ou les probalilites se propagent le long des arêtes comme des messages. Avantage : résultats déterministes, rapide, visualisation du graphe de facteurs. Limite : ne s'applique qu'a une famille restreinte de modèles.
-- **Inférence approchée par échantillonnage MCMC** (PyMC) : pour les modèles plus génériques ou l'inférence exacte est intractable. NUTS (No-U-Turn Sampler) explore l'espace posterior en simulant une dynamique hamiltonienne. Avantage : s'applique a presque tout modèle. Limite : results stochastiques, temps de convergence variable, diagnostic nécessaire.
+- **Inférence exacte par message passing** (Infer.NET) : pour les modèles où les distributions postérieures peuvent être calculées exactement (ou approchées par EP/VMP). C'est la méthode des graphes de facteurs, où les probabilités se propagent le long des arêtes comme des messages. Avantage : résultats déterministes, rapide, visualisation du graphe de facteurs. Limite : ne s'applique qu'à une famille restreinte de modèles.
+- **Inférence approchée par échantillonnage MCMC** (PyMC) : pour les modèles plus génériques où l'inférence exacte est intractable. NUTS (No-U-Turn Sampler) explore l'espace posterior en simulant une dynamique hamiltonienne. Avantage : s'applique à presque tout modèle. Limite : résultats stochastiques, temps de convergence variable, diagnostic nécessaire.
 
 Avoir les deux approches sur les mêmes modèles permet de comprendre leur **champ d'application** et leurs **compromis**, une connaissance cruciale pour tout praticien.
 
@@ -31,7 +31,7 @@ Au-delà de la méthodologie, cette série couvre des **applications réelles** 
 | Aspect | ML classique (déterministe) | Programmation probabiliste |
 |--------|---------------------------|--------------------------|
 | **Sortie** | Un seul résultat (ex: 0.73) | Une distribution complète (ex: N(0.73, 0.12)) |
-| **Incertaince** | Non quantifiée | Intégrée nativement (intervalles de crédibilité) |
+| **Incertitude** | Non quantifiée | Intégrée nativement (intervalles de crédibilité) |
 | **Données manquantes** | Problématique | Naturelles (variables latentes) |
 | **Combinaison de sources** | Requiert ingénierie manuelle | Probabilités conditionnelles structurées |
 | **Décisions** | Basées sur un point | Basées sur E[U] (utilité espérée) |
@@ -58,7 +58,7 @@ La différence fondatrice : le ML classique produit un **point**, la programmati
 1. **Construire** un modèle probabiliste en Infer.NET ou PyMC (définition, inférence, validation)
 2. **Interpréter** les distributions postérieures (moyenne, variance, intervalles de crédibilité)
 3. **Comparer** message passing vs MCMC sur le même modèle
-4. **Décaler** d'un problème real vers sa formulation probabiliste (variables, facteurs, observations)
+4. **Décaler** d'un problème réel vers sa formulation probabiliste (variables, facteurs, observations)
 5. **Intégrer** inférence probabiliste et théorie de la décision (maximisation d'utilité espérée)
 
 ## Parcours d'apprentissage
@@ -69,13 +69,13 @@ Le parcours commence par le notebook 1 (Setup) qui installe Infer.NET et constru
 
 ### Phase 2 : Modèles classiques (Notebooks 4-13, ~8h)
 
-Les notebooks 4 a 13 construisent des modèles de complexité croissante, chacun illustre par une application concrète : réseaux bayésiens (diagnostic médical), Item Response Theory (evaluation de compétences), TrueSkill (classement Xbox Live), classification bayésienne, sélection de modèles (Bayes Factors), LDA (topic modeling), crowdsourcing (agrégation de labels), HMM (séquences temporelles), systèmes de recommandation, et debugging. Chaque notebook est autonome mais présuppose la maîtrise des concepts des notebooks 1-3. Le notebook 13 (Debugging) est une référence pratique a consulter tout au long du parcours.
+Les notebooks 4 à 13 construisent des modèles de complexité croissante, chacun illustré par une application concrète : réseaux bayésiens (diagnostic médical), Item Response Theory (évaluation de compétences), TrueSkill (classement Xbox Live), classification bayésienne, sélection de modèles (Bayes Factors), LDA (topic modeling), crowdsourcing (agrégation de labels), HMM (séquences temporelles), systèmes de recommandation, et debugging. Chaque notebook est autonome mais présuppose la maîtrise des concepts des notebooks 1-3. Le notebook 13 (Debugging) est une référence pratique à consulter tout au long du parcours.
 
 ### Phase 3 : Décision bayésienne (Notebooks 14-20, ~7h)
 
-La seconde moitié de la série passe de l'inférence a la décision : comment choisir une action quand on ne connait que des probabilités ? Les notebooks 14-16 posent les fondations (axiomes de l'utilité, fonctions d'utilité mono- et multi-attributs). Les notebooks 17-20 appliquent ces concepts aux réseaux de décision, a la valeur de l'information parfaite et d'échantillon, aux systèmes experts robustes, et aux processus décisionnels de Markov (MDPs) — qui relient cette série a la série [RL](../RL/). Le compagnon Infer-20b (kernel Lean 4 via WSL) clôt la phase en formalisant les identités d'escompte géométrique de l'indice de Gittins dans le projet Lake [`decision_theory_lean`](decision_theory_lean/) — place a la **racine de la série** pour être visible des deux pistes (Infer.NET / PyMC) ; le théorème d'optimalité y est énoncé, sa preuve complète exigeant une formalisation des MDP qui manque encore a Mathlib.
+La seconde moitié de la série passe de l'inférence à la décision : comment choisir une action quand on ne connaît que des probabilités ? Les notebooks 14-16 posent les fondations (axiomes de l'utilité, fonctions d'utilité mono- et multi-attributs). Les notebooks 17-20 appliquent ces concepts aux réseaux de décision, à la valeur de l'information parfaite et d'échantillon, aux systèmes experts robustes, et aux processus décisionnels de Markov (MDPs) — qui relient cette série à la série [RL](../RL/). Le compagnon Infer-20b (kernel Lean 4 via WSL) clôt la phase en formalisant les identités d'escompte géométrique de l'indice de Gittins dans le projet Lake [`decision_theory_lean`](decision_theory_lean/) — place à la **racine de la série** pour être visible des deux pistes (Infer.NET / PyMC) ; le théorème d'optimalité y est énoncé, sa preuve complète exigeant une formalisation des MDP qui manque encore à Mathlib.
 
-### Parcours alternatives
+### Parcours alternatifs
 
 #### Parcours inférence comparée (Infer.NET vs PyMC, ~15h)
 
@@ -97,10 +97,10 @@ Suivez le même modèle dans les deux stacks pour comparer les approches :
 Si vous préférez commencer par les cas d'usage, suivez cet ordre :
 
 1. **TrueSkill** (Infer-6 / PyMC-6) : classement bayésien, application Xbox Live
-2. **IRT** (Infer-5 / PyMC-5) : evaluation de compétences, application GMAT
-3. **Crowdsourcing** (Infer-10 / PyMC-10) : aggregation de labels, application Mechanical Turk
+2. **IRT** (Infer-5 / PyMC-5) : évaluation de compétences, application GMAT
+3. **Crowdsourcing** (Infer-10 / PyMC-10) : agrégation de labels, application Mechanical Turk
 4. **Recommenders** (Infer-12 / PyMC-12) : factorisation matricielle bayésienne
-5. **LDA** (Infer-9 / PyMC-9) : discovery de thèmes dans des corpus textuels
+5. **LDA** (Infer-9 / PyMC-9) : découverte de thèmes dans des corpus textuels
 6. **HMM** (Infer-11 / PyMC-11) : régimes cachés en finance et traitement du signal
 
 #### Parcours décision (théorie de la décision, ~7h)
@@ -118,7 +118,7 @@ Pour les étudiants en recherche opérationnelle ou finance :
 
 #### Parcours rapide Python (standalone, ~2h)
 
-Si vous préférez Python au C#, commencez par Infer-101.ipynb (introduction standalone avec modèles Two Coins et Cyclist) puis Pyro_RSA_Hyperbole.ipynb (application a la linguistique pragmatique avec le framework RSA).
+Si vous préférez Python au C#, commencez par Infer-101.ipynb (introduction standalone avec modèles Two Coins et Cyclist) puis Pyro_RSA_Hyperbole.ipynb (application à la linguistique pragmatique avec le framework RSA).
 
 #### Parcours PyMC complet (20 notebooks, ~14h)
 
@@ -151,15 +151,15 @@ Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passi
 
 ### Si vous venez du C# / .NET
 
-**Commencez par Infer.NET.** L'API est native C# (`Variable.GaussianFromMeanAndVariance`), le compilateur Roslyn intègre au .NET Interactive gere la compilation dynamique, et la visualisation des graphes de facteurs via FactorGraphHelper offre une compréhension intuitive de la structure du modèle. C'est le choix ideal pour comprendre l'inférence exacte et le message passing.
+**Commencez par Infer.NET.** L'API est native C# (`Variable.GaussianFromMeanAndVariance`), le compilateur Roslyn intègre au .NET Interactive gère la compilation dynamique, et la visualisation des graphes de facteurs via FactorGraphHelper offre une compréhension intuitive de la structure du modèle. C'est le choix idéal pour comprendre l'inférence exacte et le message passing.
 
-**Passez a PyMC quand :** vous avez un modèle trop complexe pour Infer.NET (variables latentes discrètes a grande taille), ou vous voulez intégrer le modèle dans un pipeline Python (pandas, scikit-learn, visualisation).
+**Passez à PyMC quand :** vous avez un modèle trop complexe pour Infer.NET (variables latentes discrètes à grande taille), ou vous voulez intégrer le modèle dans un pipeline Python (pandas, scikit-learn, visualisation).
 
 ### Si vous venez du Python / data science
 
-**Commencez par PyMC.** La syntaxe `with pm.Model(): ...` est plus familiere aux data scientists, l'échantillonnage NUTS gere automatiquement les géométries complexes du posterior, et l'écosystème (arviz, pandas, matplotlib) est naturel.
+**Commencez par PyMC.** La syntaxe `with pm.Model(): ...` est plus familière aux data scientists, l'échantillonnage NUTS gère automatiquement les géométries complexes du posterior, et l'écosystème (arviz, pandas, matplotlib) est naturel.
 
-**Passez a Infer.NET quand :** vous voulez comprendre l'inférence exacte (VMP/EP) qui donne des results déterministes et rapides, ou vous etes dans un environnement .NET. La visualisation du factor graph (FactorGraphHelper) est aussi un outil pédagogique unique pour comprendre les dépendances du modèle.
+**Passez à Infer.NET quand :** vous voulez comprendre l'inférence exacte (VMP/EP) qui donne des résultats déterministes et rapides, ou vous êtes dans un environnement .NET. La visualisation du factor graph (FactorGraphHelper) est aussi un outil pédagogique unique pour comprendre les dépendances du modèle.
 
 ### Si vous ne savez pas quoi choisir
 
@@ -171,7 +171,7 @@ Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passi
 | Application concrète rapide | **Infer-6 TrueSkill** ou **Infer-9 LDA** |
 | Comparer les deux approches | Suivre la table "inférence comparée" ci-dessus |
 | Production data science | **PyMC** (écosystème Python, NUTS, arviz) |
-| Apprentissage embarque / temps réel | **Infer.NET** (compilation statique = inférence rapide) |
+| Apprentissage embarqué / temps réel | **Infer.NET** (compilation statique = inférence rapide) |
 
 ## Structure
 
@@ -179,20 +179,20 @@ Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passi
 Probas/
 ├── Infer-101.ipynb              # Introduction Python/C# (standalone)
 ├── Pyro_RSA_Hyperbole.ipynb     # Pragmatique linguistique (Python)
-├── PyMC/                # Port PyMC complet des modeles Infer.NET (20 notebooks)
+├── PyMC/                # Port PyMC complet des modèles Infer.NET (20 notebooks)
 │   ├── PyMC-1-Setup.ipynb ... PyMC-20-Decision-Sequential.ipynb
 │   └── (port en cours d'enrichissement)
-├── decision_theory_lean/        # Projet Lake (racine serie) : escompte geometrique + theoreme de Gittins ; accueillera VNM (#4049) + Dutch Book (#4050)
-└── Infer/                       # Serie complete Infer.NET (21 notebooks)
+├── decision_theory_lean/        # Projet Lake (racine série) : escompte géométrique + théorème de Gittins ; accueillera VNM (#4049) + Dutch Book (#4050)
+└── Infer/                       # Série complète Infer.NET (21 notebooks)
     ├── Infer-1-Setup.ipynb ... Infer-20-Decision-Sequential.ipynb
     ├── Infer-20b-Lean-Gittins.ipynb   # Compagnon Lean 4 (kernel WSL, -> ../decision_theory_lean)
-    ├── README.md                # Documentation detaillee de la serie
+    ├── README.md                # Documentation détaillée de la série
     └── scripts/
 ```
 
 ## Ce que chaque notebook apporte
 
-Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-dessous resume en une ligne l'apport pédagogique de chacun — au-delà du titre, c'est le **concept clé** qu'il enseigne.
+Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun — au-delà du titre, c'est le **concept clé** qu'il enseigne.
 
 ### Série Infer.NET
 
@@ -202,7 +202,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 2 | Gaussian Mixtures | Distributions continues, mélanges gaussiens, estimation de params |
 | 3 | Factor Graphs | Monty Hall + Murder Mystery : inférence discrète, Variable.If/Case |
 | 4 | Bayesian Networks | Wet Grass, CPT, D-separation, explaining away, inférence causale |
-| 5 | Skills (IRT) | Modélisation de compétences (DINA), evaluation adaptive |
+| 5 | Skills (IRT) | Modélisation de compétences (DINA), évaluation adaptative |
 | 6 | TrueSkill | Ranking bayésien, online learning, rating conservatif (mu - 3*sigma) |
 | 7 | Classification | Bayes Point Machine, classification probit, tests A/B bayésiens |
 | 8 | Model Sélection | Bayes Factors, evidence marginale, ARD (Automatic Relevance Détermination) |
@@ -216,9 +216,9 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 16 | Décision Multi-Attribute | MAUT, SMART, swing weights, décisions multi-critères |
 | 17 | Décision Networks | Diagrammes d'influence, politique optimale, inférence + décision |
 | 18 | Décision Value-Info | EVPI, EVSI, valeur de l'information, when-to-test |
-| 19 | Décision Expert-Systems | Minimax, Minimax Regret, robustesse face a l'incertitude |
+| 19 | Décision Expert-Systems | Minimax, Minimax Regret, robustesse face à l'incertitude |
 | 20 | Décision Sequential | MDPs, itération valeur/politique, bandits, POMDPs |
-| 20b | Lean Gittins | Formalisation Lean 4 : identités d'escompte prouvees, optimalité de Gittins énoncée |
+| 20b | Lean Gittins | Formalisation Lean 4 : identités d'escompte prouvées, optimalité de Gittins énoncée |
 
 ### Série PyMC
 
@@ -254,7 +254,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 
 ### Infer-101.ipynb
 
-Point d'entree accessible pour la programmation probabiliste :
+Point d'entrée accessible pour la programmation probabiliste :
 - Concepts de base (variables aléatoires, modèles probabilistes)
 - Premier modèle Infer.NET (Two Coins)
 - Exemple du cycliste (priors Gaussiens)
@@ -262,7 +262,7 @@ Point d'entree accessible pour la programmation probabiliste :
 
 ### Pyro_RSA_Hyperbole.ipynb
 
-Application avancée a la linguistique pragmatique :
+Application avancée à la linguistique pragmatique :
 - Framework RSA (Rational Speech Acts)
 - Implicatures scalaires (none/some/all)
 - Modélisation des hyperboles (prix, excitation)
@@ -270,7 +270,7 @@ Application avancée a la linguistique pragmatique :
 
 ## Série Infer.NET (21 notebooks)
 
-La série complète est documentee dans [Infer/README.md](Infer/README.md), qui fournit des descriptions detaillees de chaque notebook, les patterns Infer.NET avancés, et des exercices corriges.
+La série complète est documentée dans [Infer/README.md](Infer/README.md), qui fournit des descriptions détaillées de chaque notebook, les patterns Infer.NET avancés, et des exercices corrigés.
 
 ### Progression en 3 parties
 
@@ -305,7 +305,7 @@ Port Python complet des modèles Infer.NET, utilisant l'échantillonnage MCMC (N
 | 8 | [PyMC-8-Model-Sélection](PyMC/PyMC-8-Model-Selection.ipynb) | Sélection de modèles, Bayes Factors |
 | 9 | [PyMC-9-Topic-Models](PyMC/PyMC-9-Topic-Models.ipynb) | LDA, Dirichlet priors |
 | 10 | [PyMC-10-Crowdsourcing](PyMC/PyMC-10-Crowdsourcing.ipynb) | Agrégation de labels, workers, communautés |
-| 11 | [PyMC-11-Séquences](PyMC/PyMC-11-Sequences.ipynb) | HMM, chaines de Markov cachées, séquences temporelles |
+| 11 | [PyMC-11-Séquences](PyMC/PyMC-11-Sequences.ipynb) | HMM, chaînes de Markov cachées, séquences temporelles |
 | 12 | [PyMC-12-Recommenders](PyMC/PyMC-12-Recommenders.ipynb) | Systèmes de recommandation bayésiens, factorisation |
 | 13 | [PyMC-13-Debugging](PyMC/PyMC-13-Debugging.ipynb) | Troubleshooting MCMC, diagnostics NUTS, bonnes pratiques |
 
@@ -334,17 +334,17 @@ Port Python complet des modèles Infer.NET, utilisant l'échantillonnage MCMC (N
 
 Cette série suppose une **maîtrise de base en probabilités et statistiques** :
 
-| Concept | Utilité dans la série | Notes de revision |
+| Concept | Utilité dans la série | Notes de révision |
 |---------|---------------------|------------------|
 | Variables aléatoires (discrètes/continues) | Partout, notebook 1+ | Loi de proba, espérance, variance |
 | Distributions usuelles (Bernoulli, Gaussian, Beta, Gamma) | Notebook 1 (Beta-Bernoulli), 2 (Gaussian) | Paramètres, formes, conjugaison |
 | Probabilités conditionnelles | Notebook 3+ (Variable.If, CPT) | P(A|B), théorème de Bayes |
 | Indépendance conditionnelle | Notebook 3 (Monty Hall), 4 (D-separation) | Collider, explaining away |
-| Espérance mathématique | Partout (calcul de EU) | E[X] = sum x*P(x) ou integral |
-| Distributions conjuguees | Notebook 1 (Beta-Bernoulli), 9 (Dirichlet-Discrète) | Prior + likelihood = posterior (famille même) |
-| Integrals (niveau 1) | Notebook 2, 15 (CARA/CRRA) | Calcul d'espérance avec fonctions non-linéaires |
+| Espérance mathématique | Partout (calcul de EU) | E[X] = sum x*P(x) ou intégrale |
+| Distributions conjuguées | Notebook 1 (Beta-Bernoulli), 9 (Dirichlet-Discrète) | Prior + likelihood = posterior (famille même) |
+| Intégrales (niveau 1) | Notebook 2, 15 (CARA/CRRA) | Calcul d'espérance avec fonctions non-linéaires |
 
-**Inutile de maîtriser** : derivation multivariee, algèbre linéaire avancée (sauf pour les modèles hiérarchiques en notebook 4). Les concepts sont introduits progressivement et reexpliques dans le contexte.
+**Inutile de maîtriser** : dérivation multivariée, algèbre linéaire avancée (sauf pour les modèles hiérarchiques en notebook 4). Les concepts sont introduits progressivement et réexpliqués dans le contexte.
 
 ### Prerequisites techniques
 
@@ -371,7 +371,7 @@ pip install pyro-ppl torch matplotlib numpy
 
 | Concept | Description |
 |---------|-------------|
-| **Inférence bayésienne** | Mise a jour de croyances avec des observations |
+| **Inférence bayésienne** | Mise à jour de croyances avec des observations |
 | **Prior / Posterior** | Distribution avant/après observations |
 | **Factor Graph** | Représentation graphique de distributions jointes |
 | **Message Passing** | Algorithmes EP (Expectation Propagation), VMP |
@@ -385,8 +385,8 @@ pip install pyro-ppl torch matplotlib numpy
 
 | Domaine | Notebooks |
 |---------|-----------|
-| Jeux video | 6 (TrueSkill) |
-| Education | 5 (IRT), 14 |
+| Jeux vidéo | 6 (TrueSkill) |
+| Éducation | 5 (IRT), 14 |
 | NLP | 9 (LDA) |
 | Médecine | 4, 7, 17-19 |
 | Finance | 11, 15, 20 |
@@ -396,14 +396,14 @@ pip install pyro-ppl torch matplotlib numpy
 
 Derrière chaque modèle de la série se cache un système réel déjà en production :
 
-- **TrueSkill** (notebook 6) est l'algorithme que Microsoft utilise pour apparier des millions de joueurs sur Xbox Live : il maintient pour chaque joueur une compétence *gaussienne* (moyenne + incertitude) mise a jour après chaque partie, généralisant l'Elo des échecs aux jeux en equipe.
-- **Item Response Theory** (notebook 5) est le moteur des tests adaptatifs comme le GMAT ou le GRE : la difficulté de chaque question est calibrée probabilistiquement, et le test s'ajuste en temps réel au niveau estime du candidat.
-- **Les réseaux bayésiens** (notebooks 4, 7) fondent les systèmes d'aide au diagnostic médical (de QMR-DT aux outils modernes) et le filtrage anti-spam : ils propagent l'incertitude entre symptomes, causes et observations.
-- **LDA / topic models** (notebook 9) structurent automatiquement de grands corpus — découverte de thématiques dans des archives de presse, cartographie de la litterature scientifique, analyse de tickets support.
-- **Les HMM** (notebook 11) detectent les régimes cachés : phases de marche en finance, reconnaissance de la parole, segmentation de séquences biologiques.
+- **TrueSkill** (notebook 6) est l'algorithme que Microsoft utilise pour apparier des millions de joueurs sur Xbox Live : il maintient pour chaque joueur une compétence *gaussienne* (moyenne + incertitude) mise à jour après chaque partie, généralisant l'Elo des échecs aux jeux en équipe.
+- **Item Response Theory** (notebook 5) est le moteur des tests adaptatifs comme le GMAT ou le GRE : la difficulté de chaque question est calibrée probabilistiquement, et le test s'ajuste en temps réel au niveau estimé du candidat.
+- **Les réseaux bayésiens** (notebooks 4, 7) fondent les systèmes d'aide au diagnostic médical (de QMR-DT aux outils modernes) et le filtrage anti-spam : ils propagent l'incertitude entre symptômes, causes et observations.
+- **LDA / topic models** (notebook 9) structurent automatiquement de grands corpus — découverte de thématiques dans des archives de presse, cartographie de la littérature scientifique, analyse de tickets support.
+- **Les HMM** (notebook 11) détectent les régimes cachés : phases de marche en finance, reconnaissance de la parole, segmentation de séquences biologiques.
 - **Les systèmes de recommandation bayésiens** (notebook 12) sont la version « avec barre d'incertitude » du collaborative filtering de Netflix ou Amazon — utile pour décider quand explorer un nouvel item plutôt que d'exploiter une préférence connue.
 - **Le crowdsourcing** (notebook 10) modélise la fiabilité de chaque annotateur (Mechanical Turk, labellisation de datasets) pour reconstruire la vérité terrain malgré des votes bruités.
-- **La théorie de la décision et les MDPs** (notebooks 14-20) relient la série au controle séquentiel : gestion de stocks, maintenance predictive, et passerelle directe vers le [reinforcement learning](../RL/).
+- **La théorie de la décision et les MDPs** (notebooks 14-20) relient la série au contrôle séquentiel : gestion de stocks, maintenance prédictive, et passerelle directe vers le [reinforcement learning](../RL/).
 
 ## Installation
 
@@ -449,36 +449,36 @@ python MyIA.AI.Notebooks/Probas/Infer/scripts/test_notebooks.py --validate-only
 ### Le kernel .NET Interactive n'apparait pas dans Jupyter
 
 - Vérifiez que `dotnet interactive jupyter install` a réussi (sortie : `Kernel installed`).
-- Redémarrez Jupyter. Si le kernel persiste a ne pas apparaitre, vérifiez que .NET SDK 9.0+ est installe : `dotnet --version`.
+- Redémarrez Jupyter. Si le kernel persiste à ne pas apparaître, vérifiez que .NET SDK 9.0+ est installé : `dotnet --version`.
 - Sur Windows, les notebooks Infer.NET doivent être ouverts avec l'extension **Polyglot Notebooks** dans VS Code ou jupyterlab.
 
 ### `CompilerChoice.Roslyn` obligatoire
 
-Tous les notebooks Infer.NET utilisent `moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn`. C'est **obligatoire** dans .NET Interactive car Infer.NET compile dynamiquement le modèle en code C#. Sans Roslyn, la compilation echoue. Ce pattern est presente dans **chaque** notebook de la série (section 1 "Configuration").
+Tous les notebooks Infer.NET utilisent `moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn`. C'est **obligatoire** dans .NET Interactive car Infer.NET compile dynamiquement le modèle en code C#. Sans Roslyn, la compilation échoue. Ce pattern est présenté dans **chaque** notebook de la série (section 1 "Configuration").
 
 ### PyMC ne s'installe pas sur Windows (compilateur C manque)
 
 PyMC nécessite un compilateur C pour certaines dépendances. Sur Windows :
 - Installez **Microsoft Visual C++ Build Tools** (la version "Build Tools" suffit, pas besoin de Visual Studio complet).
 - Ou utilisez un **environnement conda** : `conda install -c conda-forge pymc`.
-- Ou utilisez un **conteneur Docker** avec une image preconfiguree.
+- Ou utilisez un **conteneur Docker** avec une image préconfigurée.
 
 ### Erreur Graphviz / FactorGraphHelper
 
-La visualisation des factor graphs nécessite **Graphviz installe**. Si `dot` n'est pas trouve :
-- Les fichiers `.gv` sont sauvegardes dans le repertoire courant.
+La visualisation des factor graphs nécessite **Graphviz installé**. Si `dot` n'est pas trouvé :
+- Les fichiers `.gv` sont sauvegardés dans le répertoire courant.
 - Vous pouvez les visualiser sur [viz-js.com](https://viz-js.com/) ou [edotor.net](https://edotor.net/).
-- Installation Graphviz Windows : telecharger depuis https://graphviz.org/download/, puis ajouter `C:\Program Files\Graphviz\bin` au PATH.
+- Installation Graphviz Windows : télécharger depuis https://graphviz.org/download/, puis ajouter `C:\Program Files\Graphviz\bin` au PATH.
 
 ### Switcher entre kernels C# et Python dans un même notebook
 
-Le notebook `Infer-101.ipynb` est le seul a mélanger les deux kernels. Il utilise le mode **polyglot** de .NET Interactive, ou chaque cellule spécifie son kernel via le tag `#kernel name`. Pour la série standard, chaque sous-série (Infer/ ou PyMC/) utilise un seul kernel.
+Le notebook `Infer-101.ipynb` est le seul à mélanger les deux kernels. Il utilise le mode **polyglot** de .NET Interactive, où chaque cellule spécifie son kernel via le tag `#kernel name`. Pour la série standard, chaque sous-série (Infer/ ou PyMC/) utilise un seul kernel.
 
-### PyMC : échantillonnage tres lent ou divergence NUTS
+### PyMC : échantillonnage très lent ou divergence NUTS
 
 - Augmentez `target_energy` et `adapt_delta` (défaut 0.8 → essai 0.95).
 - Vérifiez le `R-hat` (devrait être < 1.01 pour toutes les variables).
-- Consultez [PyMC-13-Debugging](PyMC/PyMC-13-Debugging.ipynb) pour des diagnostics detaillés (trace plots, effective sample size, tree depth).
+- Consultez [PyMC-13-Debugging](PyMC/PyMC-13-Debugging.ipynb) pour des diagnostics détaillés (trace plots, effective sample size, tree depth).
 
 ## Ressources
 


### PR DESCRIPTION
## Scope

Restore French accents and fix adjacent typos across `Probas/README.md` — **55 line-level corrections**, coherent single-file French-quality pass. See #2876 (rolling repo-wide accent rollout; partial contribution, not closing).

## What

- **Missing accents** in prose: `a`->`à` (15+ occurrences: "a la décision", "Passez a PyMC", "Mise a jour", "face a l'incertitude", ...), `e`->`è`/`é` (singuliere, deliébrément, gere, ideal, familiere, embarque, entree, echoue, presente, preconfiguree, ...), `ou`->`où` (4 occurrences), `results`->`résultats`, `detectent`->`détectent`, `chaines`->`chaînes`, `symptomes`->`symptômes`, `litterature`->`littérature`, `controle`->`contrôle`, `Jeux video`->`Jeux vidéo`, `Education`->`Éducation`, `tres`->`très`, `conjuguees`->`conjuguées`, `Integrals`->`Intégrales`, etc.
- **Coquilles** (adjacent, unambiguous): `probalilites`->`probabilités`, `Incertaince`->`Incertitude`, `discovery de thèmes`->`découverte de thèmes`.
- **Grammar** (2): `trois stack`->`trois stacks`, `Parcours alternatives`->`Parcours alternatifs`.
- **Tree-comment accents** (lines 182-189): the structure block uses Unicode box-drawing chars already, so French comments (`modeles`, `theoreme`, `geometrique`, `detaillee`, `Serie complete`, `racine serie`) are accented for consistency with the surrounding accented prose.

## Preserved (untouched)

- **Filenames/paths**: `PyMC-8-Model-Selection.ipynb`, `PyMC-11-Sequences.ipynb`, `decision_theory_lean/` — stay ASCII (link targets must match files on disk).
- **Code blocks** (bash install snippets) — stay ASCII.
- **Mermaid block labels** (e.g. "d'inference exacte" L139) — left as-is to avoid any rendering risk (cosmetic accent, not worth a mermaid-parser edge case).
- **`<!-- CATALOG-STATUS -->` block** — **byte-identical to main** (verified via diff).
- Markdown structure: 1:1 line replacement (55 ins / 55 del), no line added/removed.

## Validation

- Script with curated unique-phrase replacements + **NFD idempotence guard** (re-stripping accents of each `new` yields no further change).
- Full `git diff` reviewed line-by-line: every change is a legitimate FR accent/typo restoration, no over-correction.
- CATALOG-STATUS block diff-confirmed identical to `origin/main`.
- No notebook touched (rule C.3), no submodule staged (Automata/Z3.Linq drift is pre-existing, not mine).

## turf

po-2025:CoursIA-2 (Probas = my partition). Independent grain this cycle — Z3 consolidation #4677 (MP-1/MP-2) is hard-blocked on visitor-fix #4681 (unmerged; asked ai-01 to merge), so this French-quality PR keeps the lane producing without filler. No self-merge (ai-01 merges).

Co-Authored-By: Claude-Code <noreply@anthropic.com>