### PR TITLE
docs(mgs): fix count-drift post-MGS-19 (18->19 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
@@ -37,7 +37,7 @@ MetaGeneticSharp vise le point que les autres n'occupent pas : **l'expressivité
 
 ## Notebooks
 
-Cette partie se compose de dix-huit notebooks .NET Interactive (C#), hébergés dans ce répertoire et consommant le sous-module voisin [`MetaGeneticSharp/`](../MetaGeneticSharp/) :
+Cette partie se compose de dix-neuf notebooks .NET Interactive (C#), hébergés dans ce répertoire et consommant le sous-module voisin [`MetaGeneticSharp/`](../MetaGeneticSharp/) :
 
 | # | Notebook | Concept clé | Primitives introduites | Durée |
 |---|----------|-------------|------------------------|-------|

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -444,7 +444,7 @@ Search/
 │       └── App-18-HyperparameterTuning.ipynb
 │
 ├── MetaGeneticSharp/                      # Sous-module : metaheuristiques composables sur GeneticSharp (jsboige/MetaGeneticSharp)
-├── Part4-Metaheuristics/                  # Partie 4 (side track C# .NET 9) : README + 18 notebooks MGS-1..18 (moteur, composition, composés, benchmarks, TSP, paysages, biais central, synergie d'îles, alignement d'axes, paysages dé-biaisés, synergie conditionnelle, analyse de paysage FDC, sélection d'algorithme No-Free-Lunch, contrôle de paramètres, banc CEC consolidé ; consomment le sous-module)
+├── Part4-Metaheuristics/                  # Partie 4 (side track C# .NET 9) : README + 19 notebooks MGS-1..19 (moteur, composition, composés, benchmarks, TSP, paysages, biais central, synergie d'îles, alignement d'axes, paysages dé-biaisés, synergie conditionnelle, analyse de paysage FDC, sélection d'algorithme No-Free-Lunch, contrôle de paramètres, banc CEC consolidé, démontage du recuit ; consomment le sous-module)
 │
 ├── CSPs_Intro.ipynb                       # Ancien notebook (conserve)
 ├── GeneticSharp-EdgeDetection.ipynb       # Ancien notebook (conserve)


### PR DESCRIPTION
## Contexte

#4683 (MGS-19 — `MetropolisReinsertion` démonté du compound SA) a été merged, portant la Partie 4 à **19 notebooks**. Deux comptes en **prose** sont restés à 18 — ma livraison avait mis à jour la line 5, la table, la section 19, le parcours et la Mermaid du README Part4, mais deux emplacements avaient été manqués.

## Changements (2 lignes, prose uniquement)

| Fichier | Avant | Après |
|---------|-------|-------|
| `Part4-Metaheuristics/README.md` line 40 | « se compose de **dix-huit** notebooks » | « **dix-neuf** » |
| `Search/README.md` line 447 (arborescence) | « **18** notebooks MGS-**1..18** (…banc CEC consolidé ; …) » | « **19** notebooks MGS-**1..19** (…banc CEC consolidé, **démontage du recuit** ; …) » |

## Non touché (volontaire)

- **Bloc `<!-- CATALOG-STATUS -->`** (`breakdown: Part4-Metaheuristics=18`) — artefact généré appartenant à l'automatisation ; régénéré sur `main` par le cron `catalog-cron.yml` / la CI `catalog-drift.yml` (cf [.claude/rules/catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md) HARD 1). Laisser byte-identique à `main`.
- **Sous-module `MetaGeneticSharp`** — aucun bump (commit `c850418206` inchangé, #3103).

## Vérification

- `git diff --stat` : 2 fichiers, 2 insertions / 2 délétions (cohérent avec l'intention, [anti-regression](.claude/rules/anti-regression.md)).
- Dead-link check : tous les liens `MGS-N-*.ipynb` du README Part4 pointent vers un fichier existant ; les 19 notebooks MGS sont référencés dans la table.
- Pas de catalogue churn sur la branche (prose hors bloc CATALOG).

See #1203
See #4683

🤖 Generated with [Claude Code](https://claude.com/claude-code)