### PR TITLE
docs(pymc): restore French accents + grammar in series README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -4,11 +4,11 @@
 
 Port Python de la série Infer.NET couvrant l'inférence bayésienne avec PyMC (NUTS, échantillonnage MCMC), des fondamentaux aux modèles relationnels avancés, incluant une section complète sur la théorie de la décision et une clôture sur l'**inférence causale** (do-calculus de Pearl, opérateur `pm.do`).
 
-**A qui s'adresse cette série** : praticiens Python, data scientists et étudiants souhaitant maîtriser l'inférence bayésienne moderne avec l'écosystème PyMC/ArviZ. Aucun prérequis en C# ou Infer.NET : chaque notebook est autonome.
+**À qui s'adresse cette série** : praticiens Python, data scientists et étudiants souhaitant maîtriser l'inférence bayésienne moderne avec l'écosystème PyMC/ArviZ. Aucun prérequis en C# ou Infer.NET : chaque notebook est autonome.
 
 ## Pourquoi cette série
 
-PyMC est le framework d'inférence bayésienne le plus utilise en Python pour la modélisation probabiliste appliquee. La ou scikit-learn fournit des predictions ponctuelles, PyMC produit des **distributions postérieures complètes** qui quantifient l'incertitude de chaque paramètre.
+PyMC est le framework d'inférence bayésienne le plus utilisé en Python pour la modélisation probabiliste appliquée. Là où scikit-learn fournit des prédictions ponctuelles, PyMC produit des **distributions postérieures complètes** qui quantifient l'incertitude de chaque paramètre.
 
 Cette série couvre les **mêmes modèles** que la série [Infer.NET](../Infer/) (des fondamentaux à l'inférence causale) mais avec un moteur d'inférence radicalement différent :
 
@@ -18,13 +18,13 @@ Cette série couvre les **mêmes modèles** que la série [Infer.NET](../Infer/)
 | **Posterior (défaut)** | Analytique, déterministe (EP/VMP) | Échantillons MCMC, convergents (NUTS) |
 | **Point fort** | Modèles conjugués et structurés | Presque tout modèle continu |
 | **Diagnostics** | Factor graphs | ArviZ (trace, ESS, R-hat) |
-| **Ecosysteme** | .NET | NumPy/Pandas/Matplotlib |
+| **Écosystème** | .NET | NumPy/Pandas/Matplotlib |
 
 Aucune des deux librairies n'est purement déterministe ou purement stochastique — Infer.NET propose aussi un échantillonneur de **Gibbs**, PyMC une inférence variationnelle (**ADVI**) — mais leur moteur *par défaut* incarne deux familles d'algorithmes : le message passing sur graphe de facteurs (Infer.NET/EP) et l'échantillonnage MCMC (PyMC/NUTS). Avoir les deux sur les mêmes modèles permet de comprendre ce **compromis**, une compétence clé pour tout praticien.
 
 ```mermaid
 flowchart LR
-    M["Modèle probabiliste<br/>prior + vraisemblance<br/>+ données observées"] --> FORK{"Moteur<br/>d'inference"}
+    M["Modèle probabiliste<br/>prior + vraisemblance<br/>+ données observées"] --> FORK{"Moteur<br/>d'inférence"}
     FORK -->|"MCMC / NUTS"| PYMC["<b>PyMC</b><br/>échantillonnage stochastique<br/>presque tout modèle"]
     FORK -->|"message passing"| INFER["<b>Infer.NET</b><br/>EP/VMP déterministe<br/>modèles conjugués"]
     PYMC --> P1["Posterior :<br/>distribution complète"]
@@ -53,12 +53,12 @@ La série illustre ce fil rouge sur plusieurs notebooks, chacun sur un cas non-c
 
 ## Objectifs d'apprentissage
 
-A l'issue de cette série, vous serez capable de :
+À l'issue de cette série, vous serez capable de :
 
 1. **Construire** un modèle probabiliste avec PyMC (définition du prior, vraisemblance, échantillonnage)
 2. **Diagnostiquer** la convergence MCMC avec ArviZ (R-hat, ESS, trace plots, divergences)
 3. **Comparer** message passing (Infer.NET) vs MCMC (PyMC) sur le même modèle
-4. **Appliquer** l'inférence bayésienne a des problèmes concrets (ranking, classification, recommandation)
+4. **Appliquer** l'inférence bayésienne à des problèmes concrets (ranking, classification, recommandation)
 5. **Intégrer** inférence probabiliste et théorie de la décision (EVPI, MDPs, bandits)
 
 ## Vue d'ensemble
@@ -68,7 +68,7 @@ A l'issue de cette série, vous serez capable de :
 | 1 | [PyMC-1-Setup](PyMC-1-Setup.ipynb) | 15 min | Installation, Beta-Bernoulli, modèle hiérarchique non-centré |
 | 2 | [PyMC-2-Gaussian-Mixtures](PyMC-2-Gaussian-Mixtures.ipynb) | 50 min | Postérieurs, mélanges, Dirichlet |
 | 3 | [PyMC-3-Factor-Graphs](PyMC-3-Factor-Graphs.ipynb) | 45 min | Inférence discrète, Monty Hall |
-| 4 | [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) | 55 min | CPT, D-separation, causalite |
+| 4 | [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) | 55 min | CPT, D-separation, causalité |
 | 5 | [PyMC-5-Skills-IRT](PyMC-5-Skills-IRT.ipynb) | 60 min | IRT, DINA, many-to-many |
 | 6 | [PyMC-6-TrueSkill](PyMC-6-TrueSkill.ipynb) | 55 min | Ranking, online learning, équipes |
 | 7 | [PyMC-7-Classification](PyMC-7-Classification.ipynb) | 50 min | Classification bayésienne, tests A/B |
@@ -95,7 +95,7 @@ A l'issue de cette série, vous serez capable de :
 
 ```mermaid
 flowchart TD
-    P1["<b>Fondamentaux</b> (1-3)<br/>inference, distributions, discrete"]
+    P1["<b>Fondamentaux</b> (1-3)<br/>inférence, distributions, discrète"]
     P2["<b>Modèles classiques</b> (4-6)<br/>réseaux bayésiens · IRT · TrueSkill"]
     P3["<b>Classification & sélection</b> (7-8)<br/>A/B tests · evidence · ARD"]
     P4["<b>Modèles avancés</b> (9-12)<br/>LDA · crowdsourcing · HMM · reco"]
@@ -109,19 +109,19 @@ flowchart TD
     class P6 decision;
 ```
 
-Le socle d'inférence (1-12) se suit en sequence ; le notebook **13 (Debugging)** est transversal — à consulter dès qu'une chaîne MCMC dysfonctionne, à n'importe quelle étape. La **théorie de la décision** (14-20, surlignée) forme un fil rouge autonome : elle peut se suivre seule si l'inférence bayésienne est déjà acquise. Le détail notebook-par-notebook figure dans la [Vue d'ensemble](#vue-densemble) ci-dessus.
+Le socle d'inférence (1-12) se suit en séquence ; le notebook **13 (Debugging)** est transversal — à consulter dès qu'une chaîne MCMC dysfonctionne, à n'importe quelle étape. La **théorie de la décision** (14-20, surlignée) forme un fil rouge autonome : elle peut se suivre seule si l'inférence bayésienne est déjà acquise. Le détail notebook-par-notebook figure dans la [Vue d'ensemble](#vue-densemble) ci-dessus.
 
 ## Installation
 
 ```bash
-# Environnement dedie (recommande)
+# Environnement dédié (recommandé)
 conda create -n pymc-env python=3.12
 conda activate pymc-env
 
-# Dependances principales
+# Dépendances principales
 pip install pymc arviz pandas numpy scipy matplotlib
 
-# Verification
+# Vérification
 python -c "import pymc; print(f'PyMC {pymc.__version__}')"
 ```
 
@@ -136,7 +136,7 @@ jupyter kernelspec list  # doit afficher pymc-env
 
 - Python 3.10+ (3.12 recommandé)
 - Connaissance de base en probabilités et statistiques
-- Familiarite avec Python et Jupyter notebooks
+- Familiarité avec Python et Jupyter notebooks
 - Optionnel : avoir suivi la série [Infer.NET](../Infer/) pour la comparaison message passing vs MCMC
 
 ## Quel parcours choisir
@@ -152,7 +152,7 @@ Notebooks 1-3 (fondations) puis 7-8 (classification/sélection) puis 9-12 (modè
 
 ### Parcours théorie de la décision (~7h)
 
-Notebooks 14-20 en sequence. Ce parcours couvre l'utilité espérée, la valeur de l'information et les MDPs avec un moteur MCMC.
+Notebooks 14-20 en séquence. Ce parcours couvre l'utilité espérée, la valeur de l'information et les MDPs avec un moteur MCMC.
 
 1. [PyMC-14](PyMC-14-Decision-Utility-Foundations.ipynb) -> axiomes VNM
 2. [PyMC-15](PyMC-15-Decision-Utility-Money.ipynb) -> aversion au risque
@@ -161,7 +161,7 @@ Notebooks 14-20 en sequence. Ce parcours couvre l'utilité espérée, la valeur 
 
 ### Parcours comparatif Infer.NET vs PyMC (~15h)
 
-Alterner chaque notebook PyMC avec son équivalent [Infer.NET](../Infer/).Comparer les implémentations (message passing vs MCMC) sur les mêmes modèles pour comprendre les compromis.
+Alterner chaque notebook PyMC avec son équivalent [Infer.NET](../Infer/). Comparer les implémentations (message passing vs MCMC) sur les mêmes modèles pour comprendre les compromis.
 
 ### Parcours rapide (~2h)
 
@@ -171,7 +171,7 @@ Alterner chaque notebook PyMC avec son équivalent [Infer.NET](../Infer/).Compar
 
 ### `ModuleNotFoundError: pymc`
 
-PyMC n'est pas present dans le kernel Jupyter actif. Installer les dépendances puis vérifier le kernel :
+PyMC n'est pas présent dans le kernel Jupyter actif. Installer les dépendances puis vérifier le kernel :
 
 ```bash
 pip install pymc arviz
@@ -187,7 +187,7 @@ PyMC 5.x requiert un compilateur C pour les extensions natives. Solution :
 conda install -c conda-forge pymc
 
 # Option 2 : installer les build tools Visual Studio
-# Telecharger depuis https://visualstudio.microsoft.com/visual-cpp-build-tools/
+# Télécharger depuis https://visualstudio.microsoft.com/visual-cpp-build-tools/
 # Cocher "Desktop development with C++"
 ```
 
@@ -196,27 +196,27 @@ conda install -c conda-forge pymc
 - Vérifier les priors : des priors trop larges causent des explorations inutiles
 - Augmenter `target_accept` : `pm.sample(target_accept=0.95)` (défaut 0.8)
 - Utiliser `init="advi"` pour une initialisation plus robuste
-- Reduire `draws` et `tune` (ex. 500/500 au lieu de 1000/1000) si la compilation C (PyTensor) est disponible mais le temps de calcul reste prohibitif
+- Réduire `draws` et `tune` (ex. 500/500 au lieu de 1000/1000) si la compilation C (PyTensor) est disponible mais le temps de calcul reste prohibitif
 - Consulter [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) pour les diagnostics complets
 
 ### ArviZ affiche des divergences
 
-Les divergences indiquent que l'échantillonneur n'a pas explore correctement certaines régions de l'espace postérieur. Actions :
+Les divergences indiquent que l'échantillonneur n'a pas exploré correctement certaines régions de l'espace postérieur. Actions :
 
 1. `az.plot_trace(trace)` -> vérifier le mélange des chaînes
 2. `az.summary(trace)` -> vérifier que `r_hat < 1.05` et `ess_bulk > 400`
-3. Reparametriser le modèle (centrage, log-transform ; paramétrisation centered vs non-centered — voir [PyMC-2-Gaussian-Mixtures](PyMC-2-Gaussian-Mixtures.ipynb) et [PyMC-13-Debugging](PyMC-13-Debugging.ipynb))
+3. Reparamétriser le modèle (centrage, log-transform ; paramétrisation centered vs non-centered — voir [PyMC-2-Gaussian-Mixtures](PyMC-2-Gaussian-Mixtures.ipynb) et [PyMC-13-Debugging](PyMC-13-Debugging.ipynb))
 4. Augmenter le nombre de tirages : `pm.sample(draws=4000, tune=2000)`
 
 ### Erreur "SamplingError: Initial evaluation of model failed"
 
-Le prior et la vraisemblance sont incompatibles avec les données observés. Vérifier :
+Le prior et la vraisemblance sont incompatibles avec les données observées. Vérifier :
 
-- Les valeurs observés sont dans le support du prior (pas de valeurs négatives pour une distribution Gamma)
+- Les valeurs observées sont dans le support du prior (pas de valeurs négatives pour une distribution Gamma)
 - Les dimensions correspondent (pas de shape mismatch)
 - Les priors ne sont pas trop restrictifs
 
-### Comment passer de Infer.NET a PyMC ?
+### Comment passer de Infer.NET à PyMC ?
 
 La série suit le même ordre que [Infer.NET](../Infer/). Les concepts se correspondent :
 
@@ -243,7 +243,7 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 - [PyMC Documentation](https://www.pymc.io/projects/docs/en/stable/)
 - [ArviZ Documentation](https://python.arviz.org/)
 - [Bayesian Methods for Hackers](https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers)
-- [Statistical Rethinking (McElreath)](https://xcelab.net/rm/statistical-rethinking/) — livre de référence pour l'inférence bayésienne appliquee
+- [Statistical Rethinking (McElreath)](https://xcelab.net/rm/statistical-rethinking/) — livre de référence pour l'inférence bayésienne appliquée
 
 ## Ponts inter-séries
 
@@ -252,24 +252,24 @@ Ce port Python est le pendant de la série [Infer.NET](../Infer/) (C# / .NET Int
 | [Infer.NET](../Infer/) | Mêmes modèles en C# / message passing | MCMC (NUTS) vs message passing (EP) |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML](../../ML/) | Pipeline ML classique | PyMC comme alternative bayésienne |
-| [QuantConnect](../../QuantConnect/) | Strategies de trading | Modèles bayésiens appliques au trading |
+| [QuantConnect](../../QuantConnect/) | Stratégies de trading | Modèles bayésiens appliqués au trading |
 
 ## Conclusion / Prochaines étapes
 
 ### Ce que vous avez appris
 
-Cette série vous a fait passer des **fondamentaux de l'inférence bayésienne** (priors, postérieurs, échantillonnage NUTS avec [PyMC-1-Setup](PyMC-1-Setup.ipynb) à [PyMC-3-Factor-Graphs](PyMC-3-Factor-Graphs.ipynb)) à des **modèles relationnels avancés** (réseaux bayésiens, IRT, TrueSkill, LDA, HMM, recommandation — notebooks 4 à 12), en suivant le même chemin que la série [Infer.NET](../Infer/) mais avec un **moteur d'inférence radicalement différent**. Trois acquis cles :
+Cette série vous a fait passer des **fondamentaux de l'inférence bayésienne** (priors, postérieurs, échantillonnage NUTS avec [PyMC-1-Setup](PyMC-1-Setup.ipynb) à [PyMC-3-Factor-Graphs](PyMC-3-Factor-Graphs.ipynb)) à des **modèles relationnels avancés** (réseaux bayésiens, IRT, TrueSkill, LDA, HMM, recommandation — notebooks 4 à 12), en suivant le même chemin que la série [Infer.NET](../Infer/) mais avec un **moteur d'inférence radicalement différent**. Trois acquis clés :
 
-- **Lire et diagnostiquer une chaine MCMC** — `pm.sample()` ne suffit pas ; ArviZ (`r_hat < 1.05`, `ess_bulk > 400`, trace plots, divergences) est devenu votre réflexe systématique, et [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) votre référence pour les pannes de convergence.
-- **Choisir le bon moteur selon le modèle** — vous savez desormais **quand** l'échantillonnage MCMC (PyMC/NUTS, piloté par gradient, flexible sur presque tout modèle continu) est préférable au **message passing** sur graphe de facteurs (Infer.NET/EP, rapide sur les modèles conjugués et structurés), et inversement. Arbitrer entre ces deux familles d'algorithmes est une compétence de praticien.
+- **Lire et diagnostiquer une chaîne MCMC** — `pm.sample()` ne suffit pas ; ArviZ (`r_hat < 1.05`, `ess_bulk > 400`, trace plots, divergences) est devenu votre réflexe systématique, et [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) votre référence pour les pannes de convergence.
+- **Choisir le bon moteur selon le modèle** — vous savez désormais **quand** l'échantillonnage MCMC (PyMC/NUTS, piloté par gradient, flexible sur presque tout modèle continu) est préférable au **message passing** sur graphe de facteurs (Infer.NET/EP, rapide sur les modèles conjugués et structurés), et inversement. Arbitrer entre ces deux familles d'algorithmes est une compétence de praticien.
 - **Relier inférence et décision** — les notebooks 14 à 20 (utilité espérée, EVPI/EVSI, MDPs, bandits) ferment la boucle : un posterior n'est pas une fin, c'est l'**input** d'une politique de décision optimale sous incertitude.
 
 ### Prochaines étapes
 
 - **Approfondir la théorie de la décision** — [Infer-16-Décision-Multi-Attribute](../Infer/Infer-16-Decision-Multi-Attribute.ipynb) et [Infer-20-Décision-Sequential](../Infer/Infer-20-Decision-Sequential.ipynb) reprennent ces modèles en message passing pour comparer les deux moteurs sur les mêmes problèmes.
-- **Aller plus loin en inférence bayésienne** — *Statistical Rethinking* (McElreath, cite en Ressources) est le prolongement natural de cette série pour les modèles hiérarchiques et la réflexion épistémologique sur les priors.
-- **Appliquer au trading et au ML** — les ponts vers [QuantConnect](../../QuantConnect/) et [ML](../../ML/) ouvrent la mise en production : modèles bayésiens de stratégie, régression logistique bayésienne, incertitude calibrée en prediction.
+- **Aller plus loin en inférence bayésienne** — *Statistical Rethinking* (McElreath, cité en Ressources) est le prolongement naturel de cette série pour les modèles hiérarchiques et la réflexion épistémologique sur les priors.
+- **Appliquer au trading et au ML** — les ponts vers [QuantConnect](../../QuantConnect/) et [ML](../../ML/) ouvrent la mise en production : modèles bayésiens de stratégie, régression logistique bayésienne, incertitude calibrée en prédiction.
 
 ### Le fil rouge
 
-Le fil rouge de cette série est le **double regard** sur les 20 mêmes modèles : PyMC (MCMC/NUTS, Python) vs Infer.NET (message passing, C#). Chaque notebook jumeau vous donne non pas une implémentation de plus, mais la **comparaison directe** des deux paradigmes d'inférence — le message passing compilé sur graphe de facteurs d'un côté, l'échantillonnage MCMC piloté par gradient de l'autre. Maitriser ce compromis, c'est savoir choisir l'outil qui correspond à la structure du modèle et au besoin en incertitude, plutot que d'appliquer un moteur par défaut.
+Le fil rouge de cette série est le **double regard** sur les 20 mêmes modèles : PyMC (MCMC/NUTS, Python) vs Infer.NET (message passing, C#). Chaque notebook jumeau vous donne non pas une implémentation de plus, mais la **comparaison directe** des deux paradigmes d'inférence — le message passing compilé sur graphe de facteurs d'un côté, l'échantillonnage MCMC piloté par gradient de l'autre. Maîtriser ce compromis, c'est savoir choisir l'outil qui correspond à la structure du modèle et au besoin en incertitude, plutôt que d'appliquer un moteur par défaut.


### PR DESCRIPTION
## What

Complete the **Probas-family French accent rollout** on the last untouched sub-series README — `Probas/PyMC/README.md`. The sibling READMEs were already done: Infer (#4502) and top-level Probas (#4685). PyMC was the remaining one, with glaring unambiguous debt (`A qui`, `utilise`, `appliquee`, `La ou`, `predictions`, `Ecosysteme`, `cles`, `Maitriser`, …).

## Changes — 37 corrections, all in-line (31 ins / 31 del, structure intact)

- **Accents**: `A qui`->`À qui`, `utilise`->`utilisé`, `appliquee`->`appliquée`, `La ou`->`Là où`, `predictions`->`prédictions`, `Ecosysteme`->`Écosystème`, `causalite`->`causalité`, `cles`->`clés`, `chaine`->`chaîne`, `desormais`->`désormais`, `Maitriser`->`Maîtriser`, `plutot`->`plutôt`, `Familiarite`, `Dependances`, `Verification`, `Telecharger`, `Reduire`, `Reparametriser`, `present`, `explore`->`exploré`, `cite`->`cité`, prepositions `a`->`à` (x3).
- **Grammar agreement**: `données/valeurs observés`->`observées` (feminine plural past participle).
- **EN->FR**: `prolongement natural`->`naturel`.
- **Typo**: missing space `.Comparer`->`. Comparer`.
- **Mermaid labels** (safe - `é` inside quoted labels): `d'inference`->`d'inférence`, `inference/discrete`->`inférence/discrète`.
- **Bash comments** (FR instructional text, commands untouched): `dedie/recommande`->`dédié/recommandé`, `Dependances`->`Dépendances`, `Verification`->`Vérification`, `Telecharger`->`Télécharger`.

## Preserved (untaged)

- All `.ipynb` filenames, code blocks (`pm.do`, `target_accept`, `az.plot_trace`, `r_hat`, `draws`/`tune`), the `pm.sample()` / `az.summary()` snippets.
- The **nuanced Infer<->PyMC framing at L23** - *"Infer.NET propose aussi un échantillonneur de **Gibbs**, PyMC une inférence variationnelle (**ADVI**)"* - intentionally kept (neither library is purely deterministic/stochastic).
- No `CATALOG-STATUS` block in this file. 0 notebooks touched (C.3).

## Validation

- Curated-phrase script with NFD idempotence guard (`strip_accents(new) == strip_accents(old)`) for the 32 pure-accent pairs - catches any base-letter drift. 5 non-pure-accent fixes (case, spacing, EN->FR, 2 agreement) applied via separate surgical Edits.
- Full `git diff` reviewed line-by-line: 0 over-correction (`ou`=conjunction and `a`=verb-avoir kept where correct).

## Note

A prior local commit on this branch (never PR-ed) targeted an **older version** of this README (pre-rewrite: ASCII tree, `Resultats/Deterministes` table). Main has since fully rewritten the file (mermaid diagrams, causale section). That stale branch was discarded and this PR rebuilt fresh off current `origin/main` to avoid a revert/conflict.

No self-merge - awaiting ai-01 review/merge.

Co-Authored-By: Claude-Code <noreply@anthropic.com>