### PR TITLE
feat(infer): Infer-23 Sparse Gaussian Process -- prior on functions, non-linear classification (Prong-B)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-23-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-23-Sparse-Gaussian-Process.ipynb
@@ -1,0 +1,1100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Infer-23-Sparse-Gaussian-Process : Processus Gaussiens et frontieres non lineaires\n",
+    "\n",
+    "**Serie** : Programmation Probabiliste avec Infer.NET (23)\n",
+    "**Duree estimee** : 55 minutes\n",
+    "**Prerequis** : [Infer-7-Classification](Infer-7-Classification.ipynb) (Bayes Point Machine), [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Objectifs\n",
+    "\n",
+    "- Comprendre le **processus gaussien** comme une distribution sur des fonctions\n",
+    "- Construire un prior via un **noyau** (kernel RBF / squared-exponential)\n",
+    "- Implementer la **classification GP** (modele probit) sur des donnees non lineairement separables\n",
+    "- Mesurer le role du **basis set** (points induiseurs) dans l'approximation sparse\n",
+    "- Contraster avec le Bayes Point Machine (Infer-7) : frontiere lineaire vs non lineaire\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Navigation\n",
+    "\n",
+    "| Precedent | Suivant |\n",
+    "|-----------|--------|\n",
+    "| [Infer-22-Causal-Inference](Infer-22-Causal-Inference.ipynb) | _(dernier de la serie)_ |\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "\n",
+    "Cette section prepare l'environnement Infer.NET. Le processus gaussien necessite les espaces de noms `.Distributions`, `.Distributions.Kernels` (noyaux) et `.Math` (Vector)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 1,
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.Probabilistic</span></li><li><span>Microsoft.ML.Probabilistic.Compiler</span></li></ul></div><div></div></div>"
+      ]
+     }
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Infer.NET pret pour les processus gaussiens.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.ML.Probabilistic\"\n",
+    "#r \"nuget: Microsoft.ML.Probabilistic.Compiler\"\n",
+    "\n",
+    "using Microsoft.ML.Probabilistic;\n",
+    "using Microsoft.ML.Probabilistic.Distributions;\n",
+    "using Microsoft.ML.Probabilistic.Distributions.Kernels;\n",
+    "using Microsoft.ML.Probabilistic.Math;\n",
+    "using Microsoft.ML.Probabilistic.Models;\n",
+    "using Microsoft.ML.Probabilistic.Algorithms;\n",
+    "using Microsoft.ML.Probabilistic.Compiler;\n",
+    "\n",
+    "Console.WriteLine(\"Infer.NET pret pour les processus gaussiens.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Chargement du helper de visualisation des graphes de facteurs (reutilise dans toute la serie)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 2,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Graphviz disponible - les graphes de facteurs seront affiches automatiquement.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#load \"FactorGraphHelper.cs\"\n",
+    "\n",
+    "if (FactorGraphHelper.IsGraphvizAvailable())\n",
+    "    Console.WriteLine(\"Graphviz disponible - les graphes de facteurs seront affiches automatiquement.\");\n",
+    "else\n",
+    "    Console.WriteLine(\"Graphviz non installe - utilisez viz-js.com pour visualiser les fichiers .gv generes.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Motivation : au-dela de la frontiere lineaire\n",
+    "\n",
+    "[Infer-7](Infer-7-Classification.ipynb) introduisait le **Bayes Point Machine** : un classifieur qui marginalise sur tous les hyperplans separateurs. Mais un hyperplan est **lineaire** dans l'espace des features. Des qu'il faut une frontiere **courbe**, le BPM est impuissant.\n",
+    "\n",
+    "**Exemple canonique : le \"donut\".** Deux classes organisees en cercles concentriques -- la classe positive forme un anneau exterieur, la classe negative un disque interieur. Aucune droite (aucun hyperplan) ne peut separer ces deux classes, parce que chaque demi-plan coupe forcement l'une et l'autre.\n",
+    "\n",
+    "| Approche | Frontiere | Donut |\n",
+    "|----------|-----------|-------|\n",
+    "| BPM (Infer-7) | Hyperplan | **Echec** (lineaire) |\n",
+    "| GP (ce notebook) | Courbe quelconque | **Succes** (noyau RBF) |\n",
+    "\n",
+    "Le processus gaussien resout ce probleme en placant un **prior sur des fonctions** : au lieu d'inferer un vecteur de poids $\\mathbf{w}$ (qui definit un hyperplan), on infere une **fonction** $f$ tireee d'un processus gaussien, puis on classifie via un modele probit $y = \\mathbb{1}[f(\\mathbf{x}) > 0]$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Un prior sur des fonctions\n",
+    "\n",
+    "Un **processus gaussien** est defini par deux objets :\n",
+    "\n",
+    "- une **fonction moyenne** $m(\\mathbf{x})$ (souvent constante, ici nulle) ;\n",
+    "- un **noyau de covariance** $k(\\mathbf{x}, \\mathbf{x}')$ qui dit a quel point deux points sont correlles.\n",
+    "\n",
+    "Le noyau **squared-exponential** (RBF) decroche avec la distance :\n",
+    "\n",
+    "$$k(\\mathbf{x}, \\mathbf{x}') = \\exp\\left(-\\frac{\\|\\mathbf{x}-\\mathbf{x}'\\|^2}{2\\ell^2}\\right)$$\n",
+    "\n",
+    "ou $\\ell$ est la **longueur de correlation** : deux points proches ($\\|\\mathbf{x}-\\mathbf{x}'\\| \\ll \\ell$) ont des valeurs de $f$ quasi-egales ; deux points eloignes ($\\gg \\ell$) sont decorreles. C'est cette coherence locale qui produit des frontieres **lisses** plutot que du bruit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 3,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Prior GP defini.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Moyenne : ConstantFunction(0)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Noyau  : SquaredExponential (RBF)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "Covariance RBF depuis l'origine (0,0) :\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  vers 0 0 (distance 0,00) : k = 1,0000\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  vers 0,5 0 (distance 0,50) : k = 0,8825\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  vers 1 0 (distance 1,00) : k = 0,6065\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  vers 2 0 (distance 2,00) : k = 0,1353\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Le prior gaussien sur les fonctions : moyenne nulle + noyau RBF.\n",
+    "GaussianProcess gpPrior = new GaussianProcess(\n",
+    "    new ConstantFunction(0),      // moyenne m(x) = 0\n",
+    "    new SquaredExponential(0));   // noyau RBF k(x,x') = exp(-||x-x'||^2 / 2)\n",
+    "\n",
+    "Console.WriteLine(\"Prior GP defini.\");\n",
+    "Console.WriteLine($\"  Moyenne : ConstantFunction(0)\");\n",
+    "Console.WriteLine($\"  Noyau  : SquaredExponential (RBF)\");\n",
+    "\n",
+    "// Un noyau mesure la similitude entre deux points. La table ci-dessous montre\n",
+    "// la covariance RBF entre quelques points du plan -- proche de 1 quand les\n",
+    "// points coincident, decroissant vers 0 avec la distance.\n",
+    "Vector[] probes = {\n",
+    "    Vector.FromArray(0.0, 0.0),\n",
+    "    Vector.FromArray(0.5, 0.0),\n",
+    "    Vector.FromArray(1.0, 0.0),\n",
+    "    Vector.FromArray(2.0, 0.0)\n",
+    "};\n",
+    "Console.WriteLine(\"\\nCovariance RBF depuis l'origine (0,0) :\");\n",
+    "foreach (var p in probes)\n",
+    "{\n",
+    "    double d = Math.Sqrt(p[0]*p[0] + p[1]*p[1]);\n",
+    "    double cov = Math.Exp(-0.5 * d * d);\n",
+    "    Console.WriteLine($\"  vers {p} (distance {d:F2}) : k = {cov:F4}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture** : la covariance decroit exponentiellement avec la distance. Un point eloigne de 2 unites est deja quasi-decorrele de l'origine -- ses valeurs de $f$ sont donc independantes. Cette decroissance est ce qui rend le GP **local** : la frontiere ne peut pas osciller sauvagement, elle est contrainte par la coherence que le noyau impose."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Le dataset \"donut\" (non lineairement separable)\n",
+    "\n",
+    "Construisons les donnees : un disque interieur (classe negative) entoure d'un anneau (classe positive)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 4,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Dataset donut : 16 points\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Classe false (disque interieur) : 8 points\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Classe true  (anneau exterieur) : 8 points\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "Premiers points :\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x0 = 0,2864 -0,3002 -> classe False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x1 = 0,4717 0,1607 -> classe False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x2 = -0,1834 -0,3666 -> classe False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x3 = 0,2997 -0,08919 -> classe False\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Dataset \"donut\" : disque interieur (false) + anneau exterieur (true).\n",
+    "// Aucun hyperplan ne separe ces deux classes.\n",
+    "var rnd = new System.Random(7);\n",
+    "var inputsList = new System.Collections.Generic.List<Vector>();\n",
+    "var outputsList = new System.Collections.Generic.List<bool>();\n",
+    "\n",
+    "// Disque interieur : rayon ~ 0.3-0.6  => classe false\n",
+    "for (int i = 0; i < 8; i++)\n",
+    "{\n",
+    "    double r = 0.30 + 0.30 * rnd.NextDouble();\n",
+    "    double t = 2.0 * Math.PI * rnd.NextDouble();\n",
+    "    inputsList.Add(Vector.FromArray(r * Math.Cos(t), r * Math.Sin(t)));\n",
+    "    outputsList.Add(false);\n",
+    "}\n",
+    "// Anneau exterieur : rayon ~ 1.2-1.5 => classe true\n",
+    "for (int i = 0; i < 8; i++)\n",
+    "{\n",
+    "    double r = 1.20 + 0.30 * rnd.NextDouble();\n",
+    "    double t = 2.0 * Math.PI * rnd.NextDouble();\n",
+    "    inputsList.Add(Vector.FromArray(r * Math.Cos(t), r * Math.Sin(t)));\n",
+    "    outputsList.Add(true);\n",
+    "}\n",
+    "\n",
+    "Vector[] inputsDonut = inputsList.ToArray();\n",
+    "bool[] outputsDonut = outputsList.ToArray();\n",
+    "\n",
+    "Console.WriteLine($\"Dataset donut : {inputsDonut.Length} points\");\n",
+    "Console.WriteLine($\"  Classe false (disque interieur) : {outputsDonut.Count(b => !b)} points\");\n",
+    "Console.WriteLine($\"  Classe true  (anneau exterieur) : {outputsDonut.Count(b => b)} points\");\n",
+    "Console.WriteLine(\"\\nPremiers points :\");\n",
+    "for (int i = 0; i < 4; i++)\n",
+    "    Console.WriteLine($\"  x{i} = {inputsDonut[i]} -> classe {outputsDonut[i]}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pourquoi le BPM echouerait ici\n",
+    "\n",
+    "Un BPM (Infer-7) cherche un hyperplan $\\mathbf{w}^T\\mathbf{x} - b = 0$. Quelle que soit la direction $\\mathbf{w}$, la demi-droite coupe a la fois le disque interieur et l'anneau exterieur : il classera forcement faux une partie des points. La non-separabilite lineaire est totale. C'est precisement le cas ou un GP excelle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Le modele : classification GP (probit)\n",
+    "\n",
+    "On assemble le modele en suivant le meme schelet probit qu'Infer-7, mais en remplacant le score lineaire $\\mathbf{w}^T\\mathbf{x}$ par une **fonction** $f(\\mathbf{x})$ tiree du processus gaussien :\n",
+    "\n",
+    "$$y_j = \\mathbb{1}[f(\\mathbf{x}_j) + \\epsilon_j > 0], \\qquad \\epsilon_j \\sim \\mathcal{N}(0, 0.1)$$\n",
+    "\n",
+    "ou $f$ est un GP sparse (approxime sur un **basis set** de points induiseurs)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 5,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Posterior SparseGP inferer.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Basis set : 9 points induiseurs\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Modele : classification GP probit sur le donut.\n",
+    "\n",
+    "// 1. Prior sparse sur la fonction f.\n",
+    "Variable<SparseGP> prior = Variable.New<SparseGP>().Named(\"prior\");\n",
+    "Variable<IFunction> f = Variable<IFunction>.Random(prior).Named(\"f\");\n",
+    "\n",
+    "// 2. Observations.\n",
+    "VariableArray<Vector> x = Variable.Observed(inputsDonut).Named(\"x\");\n",
+    "Range j = x.Range.Named(\"j\");\n",
+    "VariableArray<bool> y = Variable.Observed(outputsDonut, j).Named(\"y\");\n",
+    "\n",
+    "// 3. Modele probit : score = f(x_j), bruite gaussien, seuil a 0.\n",
+    "Variable<double> score = Variable.FunctionEvaluate(f, x[j]);\n",
+    "y[j] = (Variable.GaussianFromMeanAndVariance(score, 0.1) > 0);\n",
+    "\n",
+    "// 4. Prior GP + basis (grille de points induiseurs couvrant le plan).\n",
+    "GaussianProcess gp = new GaussianProcess(new ConstantFunction(0), new SquaredExponential(0));\n",
+    "Vector[] basis = new Vector[] {\n",
+    "    Vector.FromArray(-1.5, -1.5), Vector.FromArray(0.0, -1.5), Vector.FromArray(1.5, -1.5),\n",
+    "    Vector.FromArray(-1.5,  0.0), Vector.FromArray(0.0,  0.0), Vector.FromArray(1.5,  0.0),\n",
+    "    Vector.FromArray(-1.5,  1.5), Vector.FromArray(0.0,  1.5), Vector.FromArray(1.5,  1.5)\n",
+    "};\n",
+    "prior.ObservedValue = new SparseGP(new SparseGPFixed(gp, basis));\n",
+    "\n",
+    "// 5. Inference EP.\n",
+    "InferenceEngine engine = new InferenceEngine(new ExpectationPropagation());\n",
+    "engine.Compiler.CompilerChoice = CompilerChoice.Roslyn;\n",
+    "engine.ShowProgress = false;\n",
+    "engine.ShowFactorGraph = true;\n",
+    "\n",
+    "SparseGP sgp = engine.Infer<SparseGP>(f);\n",
+    "Console.WriteLine(\"Posterior SparseGP inferer.\");\n",
+    "Console.WriteLine($\"  Basis set : {basis.Length} points induiseurs\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 6,
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": [
+       "\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_07_01_26_03_15_19_62.svg</div>\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
+       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
+       "<!-- Generated by graphviz version 14.1.2 (20260124.0452)\r\n",
+       " -->\r\n",
+       "<!-- Title: Model Pages: 1 -->\r\n",
+       "<svg width=\"186pt\" height=\"663pt\"\r\n",
+       " viewBox=\"0.00 0.00 186.00 663.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
+       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 659)\">\r\n",
+       "<title>Model</title>\r\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-659 182,-659 182,4 -4,4\"/>\r\n",
+       "<!-- node0 -->\r\n",
+       "<g id=\"node1\" class=\"node\">\r\n",
+       "<title>node0</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M42,-655C42,-655 12,-655 12,-655 6,-655 0,-649 0,-643 0,-643 0,-631 0,-631 0,-625 6,-619 12,-619 12,-619 42,-619 42,-619 48,-619 54,-625 54,-631 54,-631 54,-643 54,-643 54,-649 48,-655 42,-655\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"27\" y=\"-633.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">prior</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1 -->\r\n",
+       "<g id=\"node2\" class=\"node\">\r\n",
+       "<title>node1</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M42,-573.25C42,-573.25 12,-573.25 12,-573.25 6,-573.25 0,-567.25 0,-561.25 0,-561.25 0,-549.25 0,-549.25 0,-543.25 6,-537.25 12,-537.25 12,-537.25 42,-537.25 42,-537.25 48,-537.25 54,-543.25 54,-549.25 54,-549.25 54,-561.25 54,-561.25 54,-567.25 48,-573.25 42,-573.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"27\" y=\"-552.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
+       "</g>\r\n",
+       "<!-- node0&#45;&gt;node1 -->\r\n",
+       "<g id=\"edge1\" class=\"edge\">\r\n",
+       "<title>node0&#45;&gt;node1</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M27,-619.09C27,-609.18 27,-596.4 27,-584.96\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"30.5,-585.2 27,-575.2 23.5,-585.2 30.5,-585.2\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"32.62\" y=\"-593.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2 -->\r\n",
+       "<g id=\"node3\" class=\"node\">\r\n",
+       "<title>node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M42,-500.25C42,-500.25 12,-500.25 12,-500.25 6,-500.25 0,-494.25 0,-488.25 0,-488.25 0,-476.25 0,-476.25 0,-470.25 6,-464.25 12,-464.25 12,-464.25 42,-464.25 42,-464.25 48,-464.25 54,-470.25 54,-476.25 54,-476.25 54,-488.25 54,-488.25 54,-494.25 48,-500.25 42,-500.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"27\" y=\"-478.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">f</text>\r\n",
+       "</g>\r\n",
+       "<!-- node1&#45;&gt;node2 -->\r\n",
+       "<g id=\"edge2\" class=\"edge\">\r\n",
+       "<title>node1&#45;&gt;node2</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M27,-537.06C27,-529.48 27,-520.35 27,-511.79\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"30.5,-511.79 27,-501.79 23.5,-511.79 30.5,-511.79\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node3 -->\r\n",
+       "<g id=\"node4\" class=\"node\">\r\n",
+       "<title>node3</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M95.12,-418.5C95.12,-418.5 46.88,-418.5 46.88,-418.5 40.88,-418.5 34.88,-412.5 34.88,-406.5 34.88,-406.5 34.88,-394.5 34.88,-394.5 34.88,-388.5 40.88,-382.5 46.88,-382.5 46.88,-382.5 95.12,-382.5 95.12,-382.5 101.12,-382.5 107.12,-388.5 107.12,-394.5 107.12,-394.5 107.12,-406.5 107.12,-406.5 107.12,-412.5 101.12,-418.5 95.12,-418.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"71\" y=\"-397.77\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">FunctionEvaluate</text>\r\n",
+       "</g>\r\n",
+       "<!-- node2&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge3\" class=\"edge\">\r\n",
+       "<title>node2&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M36.55,-463.95C42.26,-453.6 49.63,-440.23 56.09,-428.52\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"58.97,-430.54 60.74,-420.1 52.84,-427.16 58.97,-430.54\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"58.76\" y=\"-438.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">func</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5 -->\r\n",
+       "<g id=\"node6\" class=\"node\">\r\n",
+       "<title>node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M94,-345.5C94,-345.5 48,-345.5 48,-345.5 42,-345.5 36,-339.5 36,-333.5 36,-333.5 36,-321.5 36,-321.5 36,-315.5 42,-309.5 48,-309.5 48,-309.5 94,-309.5 94,-309.5 100,-309.5 106,-315.5 106,-321.5 106,-321.5 106,-333.5 106,-333.5 106,-339.5 100,-345.5 94,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"71\" y=\"-323.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]0[j]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node3&#45;&gt;node5 -->\r\n",
+       "<g id=\"edge5\" class=\"edge\">\r\n",
+       "<title>node3&#45;&gt;node5</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M71,-382.31C71,-374.73 71,-365.6 71,-357.04\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"74.5,-357.04 71,-347.04 67.5,-357.04 74.5,-357.04\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node4 -->\r\n",
+       "<g id=\"node5\" class=\"node\">\r\n",
+       "<title>node4</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M114,-500.25C114,-500.25 84,-500.25 84,-500.25 78,-500.25 72,-494.25 72,-488.25 72,-488.25 72,-476.25 72,-476.25 72,-470.25 78,-464.25 84,-464.25 84,-464.25 114,-464.25 114,-464.25 120,-464.25 126,-470.25 126,-476.25 126,-476.25 126,-488.25 126,-488.25 126,-494.25 120,-500.25 114,-500.25\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"99\" y=\"-478.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">x[j]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node4&#45;&gt;node3 -->\r\n",
+       "<g id=\"edge4\" class=\"edge\">\r\n",
+       "<title>node4&#45;&gt;node3</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M93.06,-464.34C89.51,-454.22 84.91,-441.11 80.83,-429.48\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"84.24,-428.64 77.62,-420.37 77.63,-430.96 84.24,-428.64\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"88.55\" y=\"-438.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">x</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6 -->\r\n",
+       "<g id=\"node7\" class=\"node\">\r\n",
+       "<title>node6</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M160.62,-263.75C160.62,-263.75 61.38,-263.75 61.38,-263.75 55.38,-263.75 49.38,-257.75 49.38,-251.75 49.38,-251.75 49.38,-239.75 49.38,-239.75 49.38,-233.75 55.38,-227.75 61.38,-227.75 61.38,-227.75 160.62,-227.75 160.62,-227.75 166.62,-227.75 172.62,-233.75 172.62,-239.75 172.62,-239.75 172.62,-251.75 172.62,-251.75 172.62,-257.75 166.62,-263.75 160.62,-263.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"111\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">GaussianFromMeanAndVariance</text>\r\n",
+       "</g>\r\n",
+       "<!-- node5&#45;&gt;node6 -->\r\n",
+       "<g id=\"edge6\" class=\"edge\">\r\n",
+       "<title>node5&#45;&gt;node6</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M79.68,-309.2C84.82,-298.95 91.44,-285.75 97.27,-274.12\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"100.3,-275.88 101.66,-265.37 94.05,-272.74 100.3,-275.88\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"102.02\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n",
+       "</g>\r\n",
+       "<!-- node8 -->\r\n",
+       "<g id=\"node9\" class=\"node\">\r\n",
+       "<title>node8</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M134,-190.75C134,-190.75 88,-190.75 88,-190.75 82,-190.75 76,-184.75 76,-178.75 76,-178.75 76,-166.75 76,-166.75 76,-160.75 82,-154.75 88,-154.75 88,-154.75 134,-154.75 134,-154.75 140,-154.75 146,-160.75 146,-166.75 146,-166.75 146,-178.75 146,-178.75 146,-184.75 140,-190.75 134,-190.75\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"111\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">vdouble[]1[j]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node6&#45;&gt;node8 -->\r\n",
+       "<g id=\"edge8\" class=\"edge\">\r\n",
+       "<title>node6&#45;&gt;node8</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M111,-227.56C111,-219.98 111,-210.85 111,-202.29\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"114.5,-202.29 111,-192.29 107.5,-202.29 114.5,-202.29\"/>\r\n",
+       "</g>\r\n",
+       "<!-- node7 -->\r\n",
+       "<g id=\"node8\" class=\"node\">\r\n",
+       "<title>node7</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M166,-345.5C166,-345.5 136,-345.5 136,-345.5 130,-345.5 124,-339.5 124,-333.5 124,-333.5 124,-321.5 124,-321.5 124,-315.5 130,-309.5 136,-309.5 136,-309.5 166,-309.5 166,-309.5 172,-309.5 178,-315.5 178,-321.5 178,-321.5 178,-333.5 178,-333.5 178,-339.5 172,-345.5 166,-345.5\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"151\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0,1</text>\r\n",
+       "</g>\r\n",
+       "<!-- node7&#45;&gt;node6 -->\r\n",
+       "<g id=\"edge7\" class=\"edge\">\r\n",
+       "<title>node7&#45;&gt;node6</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M142.52,-309.59C137.39,-299.37 130.73,-286.09 124.86,-274.38\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"128.04,-272.91 120.43,-265.54 121.78,-276.05 128.04,-272.91\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"147.27\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">variance</text>\r\n",
+       "</g>\r\n",
+       "<!-- node9 -->\r\n",
+       "<g id=\"node10\" class=\"node\">\r\n",
+       "<title>node9</title>\r\n",
+       "<path fill=\"#000000\" stroke=\"black\" d=\"M126,-109C126,-109 96,-109 96,-109 90,-109 84,-103 84,-97 84,-97 84,-85 84,-85 84,-79 90,-73 96,-73 96,-73 126,-73 126,-73 132,-73 138,-79 138,-85 138,-85 138,-97 138,-97 138,-103 132,-109 126,-109\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"111\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">IsPositive</text>\r\n",
+       "</g>\r\n",
+       "<!-- node8&#45;&gt;node9 -->\r\n",
+       "<g id=\"edge9\" class=\"edge\">\r\n",
+       "<title>node8&#45;&gt;node9</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M111,-154.45C111,-144.52 111,-131.81 111,-120.45\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"114.5,-120.78 111,-110.78 107.5,-120.78 114.5,-120.78\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"112.88\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">x</text>\r\n",
+       "</g>\r\n",
+       "<!-- node10 -->\r\n",
+       "<g id=\"node11\" class=\"node\">\r\n",
+       "<title>node10</title>\r\n",
+       "<path fill=\"none\" stroke=\"none\" d=\"M126,-36C126,-36 96,-36 96,-36 90,-36 84,-30 84,-24 84,-24 84,-12 84,-12 84,-6 90,0 96,0 96,0 126,0 126,0 132,0 138,-6 138,-12 138,-12 138,-24 138,-24 138,-30 132,-36 126,-36\"/>\r\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"111\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">y[j]</text>\r\n",
+       "</g>\r\n",
+       "<!-- node9&#45;&gt;node10 -->\r\n",
+       "<g id=\"edge10\" class=\"edge\">\r\n",
+       "<title>node9&#45;&gt;node10</title>\r\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M111,-72.81C111,-65.03 111,-55.62 111,-46.86\"/>\r\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"114.5,-47.05 111,-37.05 107.5,-47.05 114.5,-47.05\"/>\r\n",
+       "</g>\r\n",
+       "</g>\r\n",
+       "</svg>\r\n",
+       "\n",
+       "    </div>\n",
+       "</div>"
+      ]
+     }
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Visualisation du graphe de facteurs du classifieur GP.\n",
+    "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du graphe\n",
+    "\n",
+    "Le graphe de facteurs montre la structure : la variable $f$ (une fonction, pas un scalaire) est connectee a chaque observation via le facteur `FunctionEvaluate`. Le prior `SparseGP` repose $f$ sur le basis de 9 points. L'EP propage les messages a travers cette chaine pour produire le posterior sur $f$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Predictions avec incertitude\n",
+    "\n",
+    "Le posterior `SparseGP` permet d'evaluer $f$ en tout nouveau point via `Marginal`. On peut ainsi tracer la **frontiere de decision** (la ou $f$ change de signe) et la **confiance** (distance a 0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 7,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Predictions sur le training set ===\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x0       0,2864 -0,3002 : f=     Gaussian(-0,7629, 0,1817) pred=False reel=False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x1        0,4717 0,1607 : f=     Gaussian(-0,6213, 0,1934) pred=False reel=False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x2      -0,1834 -0,3666 : f=      Gaussian(-0,712, 0,1868) pred=False reel=False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x3      0,2997 -0,08919 : f=     Gaussian(-0,8189, 0,1491) pred=False reel=False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x4       0,3389 -0,4371 : f=     Gaussian(-0,6468, 0,2311) pred=False reel=False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x5        0,396 -0,1793 : f=     Gaussian(-0,7287, 0,1787) pred=False reel=False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x6         0,3317 0,279 : f=     Gaussian(-0,6857, 0,1964) pred=False reel=False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x7       -0,4609 0,3261 : f=     Gaussian(-0,4564, 0,2459) pred=False reel=False\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x8        -0,7364 1,239 : f=      Gaussian(0,6383, 0,3944) pred=True reel=True\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x9         1,442 0,2286 : f=      Gaussian(0,6349, 0,1829) pred=True reel=True\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x10       -1,306 -0,5689 : f=      Gaussian(0,7163, 0,4046) pred=True reel=True\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x11        -1,241 0,1722 : f=       Gaussian(0,602, 0,3051) pred=True reel=True\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x12         1,295 0,2349 : f=      Gaussian(0,4897, 0,1892) pred=True reel=True\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x13         1,468 0,2313 : f=       Gaussian(0,657, 0,1844) pred=True reel=True\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x14       -0,2632 -1,318 : f=      Gaussian(0,3817, 0,3108) pred=True reel=True\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  x15        -0,4181 1,369 : f=       Gaussian(0,5901, 0,345) pred=True reel=True\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "Exactitude training : 16/16 = 100,0%\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Predictions sur le training set + quelques points test.\n",
+    "Console.WriteLine(\"=== Predictions sur le training set ===\");\n",
+    "int correct = 0;\n",
+    "for (int i = 0; i < outputsDonut.Length; i++)\n",
+    "{\n",
+    "    Gaussian post = sgp.Marginal(inputsDonut[i]);\n",
+    "    double postMean = post.GetMean();\n",
+    "    bool pred = postMean > 0.0;\n",
+    "    if (pred == outputsDonut[i]) correct++;\n",
+    "    Console.WriteLine($\"  x{i} {inputsDonut[i],20} : f={post,30} pred={pred} reel={outputsDonut[i]}\");\n",
+    "}\n",
+    "Console.WriteLine($\"\\nExactitude training : {correct}/{outputsDonut.Length} = {100.0*correct/outputsDonut.Length:F1}%\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 8,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Predictions sur points test ===\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "               0 0 : E[f]=-0,910 P(classe=true)=0,026\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "             0,9 0 : E[f]=-0,092 P(classe=true)=0,435\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "             1,3 0 : E[f]=+0,449 P(classe=true)=0,801\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "             0 1,4 : E[f]=+0,507 P(classe=true)=0,769\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Test sur des points nouveaux : au centre (doit etre false), a mi-rayon (incertain),\n",
+    "// sur l'anneau (doit etre true), loin (true).\n",
+    "Vector[] testPoints = {\n",
+    "    Vector.FromArray(0.0, 0.0),     // centre du disque -> false attendu\n",
+    "    Vector.FromArray(0.9, 0.0),     // entre les deux -> zone d'incertitude\n",
+    "    Vector.FromArray(1.3, 0.0),     // anneau -> true attendu\n",
+    "    Vector.FromArray(0.0, 1.4)      // anneau (haut) -> true attendu\n",
+    "};\n",
+    "Console.WriteLine(\"=== Predictions sur points test ===\");\n",
+    "foreach (var tp in testPoints)\n",
+    "{\n",
+    "    Gaussian post = sgp.Marginal(tp);\n",
+    "    double p = MMath.NormalCdf(post.GetMean() / Math.Sqrt(post.GetVariance() + 0.1));\n",
+    "    Console.WriteLine($\"  {tp,16} : E[f]={post.GetMean():+0.000;-0.000} P(classe=true)={p:F3}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Analyse\n",
+    "\n",
+    "- Le **centre** du donut est correctement classe `false` ($E[f] < 0$) bien qu'aucune donnee ne soit exactement la -- la coherence du noyau propage la classe du disque interieur vers le centre.\n",
+    "- La **zone d'incertitude** (mi-rayon, entre le disque et l'anneau) montre une probabilite proche de 0.5 : le GP sait qu'il ne sait pas.\n",
+    "- L'**anneau** est correctement `true`.\n",
+    "\n",
+    "C'est le comportement que le BPM (lineaire) ne peut pas reproduire : il n'y a pas d'hyperplan qui vaut `false` au centre et `true` tout autour. Le GP, lui, a appris une frontiere **circulaire**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Sparse : le role du basis set\n",
+    "\n",
+    "Un GP \"full\" evalue la fonction sur **tous** les points d'entrainement, ce qui coute $O(n^3)$. L'approximation **sparse** remplace ce jeu complet par un petit **basis set** de $m$ points induiseurs : le cout tombe a $O(nm^2)$, controlable par le choix de $m$.\n",
+    "\n",
+    "> La doc Infer.NET precise : *« If the basis set is exactly the set of inputs, then the distribution is equivalent to a full (non-sparse) Gaussian Process. »* Le sparse est donc un vrai continu, pas une variante degradee -- avec $m = n$ on retrouve le GP exact.\n",
+    "\n",
+    "Comparons deux tailles de basis : peu d'inducteurs (sparse agressif) vs basis = tous les inputs (full)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 9,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Sparse vs Full ===\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Sparse (basis=4 induiseurs)  : 15/16\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Full   (basis=16=inputs)     : 16/16\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "Les deux separnt le donut -- le sparse economise du calcul sans casser la separabilite.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Comparaison : basis sparse (4 points) vs basis = tous les inputs (full).\n",
+    "Vector[] basisSparse = new Vector[] {\n",
+    "    Vector.FromArray(0.0, 0.0), Vector.FromArray(1.3, 0.0),\n",
+    "    Vector.FromArray(-1.3, 0.0), Vector.FromArray(0.0, 1.3)\n",
+    "};\n",
+    "\n",
+    "GaussianProcess gp2 = new GaussianProcess(new ConstantFunction(0), new SquaredExponential(0));\n",
+    "\n",
+    "// (a) Sparse avec peu de points induiseurs.\n",
+    "Variable<SparseGP> priorSparse = Variable.New<SparseGP>().Named(\"priorSparse\");\n",
+    "Variable<IFunction> fSparse = Variable<IFunction>.Random(priorSparse).Named(\"fSparse\");\n",
+    "VariableArray<Vector> xS = Variable.Observed(inputsDonut).Named(\"xS\");\n",
+    "Range jS = xS.Range.Named(\"jS\");\n",
+    "VariableArray<bool> yS = Variable.Observed(outputsDonut, jS).Named(\"yS\");\n",
+    "Variable<double> scoreS = Variable.FunctionEvaluate(fSparse, xS[jS]);\n",
+    "yS[jS] = (Variable.GaussianFromMeanAndVariance(scoreS, 0.1) > 0);\n",
+    "priorSparse.ObservedValue = new SparseGP(new SparseGPFixed(gp2, basisSparse));\n",
+    "\n",
+    "var engSparse = new InferenceEngine(new ExpectationPropagation());\n",
+    "engSparse.Compiler.CompilerChoice = CompilerChoice.Roslyn;\n",
+    "engSparse.ShowProgress = false;\n",
+    "SparseGP sgpSparse = engSparse.Infer<SparseGP>(fSparse);\n",
+    "\n",
+    "// (b) \"Full\" : basis = tous les inputs (n = 16).\n",
+    "Variable<SparseGP> priorFull = Variable.New<SparseGP>().Named(\"priorFull\");\n",
+    "Variable<IFunction> fFull = Variable<IFunction>.Random(priorFull).Named(\"fFull\");\n",
+    "VariableArray<Vector> xF = Variable.Observed(inputsDonut).Named(\"xF\");\n",
+    "Range jF = xF.Range.Named(\"jF\");\n",
+    "VariableArray<bool> yF = Variable.Observed(outputsDonut, jF).Named(\"yF\");\n",
+    "Variable<double> scoreF = Variable.FunctionEvaluate(fFull, xF[jF]);\n",
+    "yF[jF] = (Variable.GaussianFromMeanAndVariance(scoreF, 0.1) > 0);\n",
+    "priorFull.ObservedValue = new SparseGP(new SparseGPFixed(gp2, inputsDonut));\n",
+    "\n",
+    "var engFull = new InferenceEngine(new ExpectationPropagation());\n",
+    "engFull.Compiler.CompilerChoice = CompilerChoice.Roslyn;\n",
+    "engFull.ShowProgress = false;\n",
+    "SparseGP sgpFull = engFull.Infer<SparseGP>(fFull);\n",
+    "\n",
+    "// Exactitude des deux.\n",
+    "int EvalAcc(SparseGP sgp, Vector[] xs, bool[] ys)\n",
+    "{\n",
+    "    int c = 0;\n",
+    "    for (int i = 0; i < ys.Length; i++)\n",
+    "        if ((sgp.Marginal(xs[i]).GetMean() > 0) == ys[i]) c++;\n",
+    "    return c;\n",
+    "}\n",
+    "Console.WriteLine(\"=== Sparse vs Full ===\");\n",
+    "Console.WriteLine($\"  Sparse (basis=4 induiseurs)  : {EvalAcc(sgpSparse, inputsDonut, outputsDonut)}/{outputsDonut.Length}\");\n",
+    "Console.WriteLine($\"  Full   (basis=16=inputs)     : {EvalAcc(sgpFull, inputsDonut, outputsDonut)}/{outputsDonut.Length}\");\n",
+    "Console.WriteLine(\"\\nLes deux separnt le donut -- le sparse economise du calcul sans casser la separabilite.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture : pourquoi le sparse marche ici\n",
+    "\n",
+    "Le donut est une structure **globale** (un cercle), capturable meme par peu de points induiseurs bien places. Le sparse est le plus rentable quand le signal est lisse a grande echelle (peu de degres de liberte effectifs) ; il perd en precision quand la frontiere oscille finement. Le basis set est un **biais-variance** : trop peu d'inducteurs sous-ajustent, trop = cout full sans gain.\n",
+    "\n",
+    "| Basis | Cout | Risque |\n",
+    "|-------|------|--------|\n",
+    "| Petit ($m \\ll n$) | $O(nm^2)$ economique | Sous-ajustement si frontiere fine |\n",
+    "| $m = n$ (full) | $O(n^3)$ | Exact mais cher"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "### Exercice 1 : Longueur de correlation\n",
+    "\n",
+    "Le noyau `SquaredExponential(0)` utilise une longueur de correlation par defaut. Observez comment une **longueur trop courte** (frontiere herissee, surajustement) ou **trop longue** (frontiere trop lisse, sous-ajustement) degrade la classification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : longueur de correlation du noyau\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice : influer sur la longueur de correlation du noyau.\n",
+    "// Indice : le constructeur SquaredExponential accepte des parametres de scale.\n",
+    "// Essayez plusieurs valeurs et mesurez l'exactitude training.\n",
+    "// Console.WriteLine($\"length=... : {acc}/{n}\");\n",
+    "Console.WriteLine(\"Exercice a completer : longueur de correlation du noyau\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Donut bruite\n",
+    "\n",
+    "Ajoutez du bruit aux etiquettes (quelques points du disque etiquetes `true`, et reciproquement). Le GP gere-t-il le bruit mieux qu'un classifieur deterministe ? Quantifiez la **confiance** (P proche de 0.5) sur les points contredits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : robustesse au bruit du GP\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice : flippez 2 etiquettes et re-inferez. Observez P(classe) sur les points bruites.\n",
+    "// Indice : construire un nouveau tableau outputsNoisy avec 2 valeurs inversee.\n",
+    "Console.WriteLine(\"Exercice a completer : robustesse au bruit du GP\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Donnees lineairement separables\n",
+    "\n",
+    "Construisez un dataset **lineairement** separable (deux amas de part et d'autre d'une droite). Comparez le GP au BPM (reutilisez `SimpleBPM` d'Infer-7) : sur un probleme simple, le GP est-il utile, ou le BPM suffit-il ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 12,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : GP vs BPM sur cas lineaire\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice : dataset lineairement separable -> GP vs BPM (Infer-7).\n",
+    "// Indice : deux amas centres en (-1,-1) et (+1,+1).\n",
+    "// Question : sur un cas lineaire, le GP apporte-t-il plus que le BPM ?\n",
+    "Console.WriteLine(\"Exercice a completer : GP vs BPM sur cas lineaire\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Synthese et conclusion\n",
+    "\n",
+    "### Concepts cles\n",
+    "\n",
+    "| Concept | Description |\n",
+    "|---------|-------------|\n",
+    "| **Processus gaussien** | Distribution sur des fonctions, definie par une moyenne et un noyau |\n",
+    "| **Noyau RBF** | Covariance decroissant avec la distance ; impose une coherence locale |\n",
+    "| **Classification GP** | Modele probit $y = \\mathbb{1}[f(x) > 0]$ ou $f$ est un GP |\n",
+    "| **Sparse GP** | Approximation sur un basis de $m$ points induiseurs, cout $O(nm^2)$ |\n",
+    "| **Prior sur fonctions** | Remplace le prior sur les poids du BPM -- frontieres courbes possibles |\n",
+    "\n",
+    "### GP vs BPM (Infer-7)\n",
+    "\n",
+    "| Aspect | BPM (Infer-7) | GP (Infer-23) |\n",
+    "|--------|---------------|---------------|\n",
+    "| Parametre | Vecteur de poids $\\mathbf{w}$ | Fonction $f$ |\n",
+    "| Frontiere | Hyperplan (lineaire) | Courbe quelconque |\n",
+    "| Donut | **Echec** | **Succes** |\n",
+    "| Cout | Lineaire en $n$ | $O(nm^2)$ (sparse) |\n",
+    "| Quand l'utiliser | Donnees lineairement separables | Frontieres non lineaires |\n",
+    "\n",
+    "### Distributions utilisees\n",
+    "\n",
+    "| Distribution | Role |\n",
+    "|--------------|------|\n",
+    "| `SparseGP` | Prior et posterior sur la fonction $f$ |\n",
+    "| `Gaussian` | Score bruite (probit) + marginal posterior en chaque point |\n",
+    "| `Bernoulli` | (Implicite) prediction de classe via `NormalCdf` |\n",
+    "\n",
+    "> **Lecon** : le GP est l'outil naturel quand la frontiere de decision est non lineaire ET qu'on veut une **incertitude calibree**. Pour un cas lineaire, le BPM (Infer-7) reste plus simple et plus rapide. Le procesus gaussien n'est pas un remplacement universel -- c'est un **complement** qui etend la boite a outils bayesienne au non-lineaire, au prix d'un noyau a choisir et d'un basis a calibrer."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "name": "C#"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -2,7 +2,7 @@
 
 [← Série Probas](../README.md) | [Série PyMC (Python) →](../PyMC/README.md) | [ML.NET (C#) →](../../ML/ML.Net/README.md)
 
-Programmation probabiliste avec Microsoft Infer.NET : une série de 24 notebooks allant des fondamentaux aux modèles relationnels avancés, incluant une section complète sur la théorie de la décision (MDPs, indice de Gittins, puis les **bandits bayésiens** via Thompson Sampling), l'**inférence causale** (do-calculus de Pearl) en clôture, et des preuves formelles Lean 4.
+Programmation probabiliste avec Microsoft Infer.NET : une série de 25 notebooks allant des fondamentaux aux modèles relationnels avancés, incluant une section complète sur la théorie de la décision (MDPs, indice de Gittins, puis les **bandits bayésiens** via Thompson Sampling), les **processus gaussiens** (GP sparse, frontières non-linéaires), l'**inférence causale** (do-calculus de Pearl) en clôture, et des preuves formelles Lean 4.
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs .NET souhaitant maîtriser l'inférence probabiliste par message passing, et data scientists intéressés par les graphes de facteurs. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en probabilités avancées : les concepts sont introduits progressivement.
 
@@ -72,8 +72,9 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 | 20b | [Infer-20b-Lean-Gittins](Infer-20b-Lean-Gittins.ipynb) | 45 min | Preuves formelles Lean 4, indice de Gittins, SFABP |
 | 21 | [Infer-21-Thompson-Sampling](Infer-21-Thompson-Sampling.ipynb) | 60 min | Thompson Sampling bayésien, posterior Beta-Bernoulli par le moteur, regret vs ε-greedy/UCB1 |
 | 22 | [Infer-22-Causal-Inference](Infer-22-Causal-Inference.ipynb) | 65 min | do-calculus, backdoor/front-door, paradoxe de Simpson |
+| 23 | [Infer-23-Sparse-Gaussian-Process](Infer-23-Sparse-Gaussian-Process.ipynb) | 55 min | Processus gaussiens, noyau RBF, classification non-linéaire, sparse GP |
 
-**Durée totale** : ~21h
+**Durée totale** : ~22h
 
 **Ressource complémentaire** : [Glossaire](Infer-Glossary.md) - Définitions des termes techniques
 
@@ -877,6 +878,38 @@ Prolongement naturel de la théorie de la décision séquentielle : après les M
 **Ponts causaux** : Infer-22 est le maillon **distributionnel par message passing** (Infer.NET, EP/VMP) d'un pont à quatre paradigmes autour du `do(·)` de Pearl — le jumeau symbolique [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) (Java propositionnel), le jumeau MCMC [PyMC-22](../PyMC/PyMC-22-Causal-Inference.ipynb), et la lecture par l'émergence causale [ICT-5](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb), où la distribution d'intervention `p(C)` uniforme **est** `do(X_t = x)`. Vue d'ensemble : le [README IIT](../../IIT/README.md), section « Ponts causaux : le do-calculus de Pearl à travers les paradigmes ».
 
 **Applications** : baromètre (confondeur), diagnostic médical (paradoxe de Simpson), tabac-cancer (front-door), requêtes contrefactuelles.
+
+---
+
+## Modèles Non-Linéaires (Notebook 23)
+
+### Infer-23 : Processus Gaussiens et frontières non-linéaires
+
+Prolongement naturel de la classification bayésienne : là où [Infer-7](Infer-7-Classification.ipynb) (Bayes Point Machine) trace un **hyperplan**, le processus gaussien place un **prior sur des fonctions** (noyau RBF) et infère une frontière **courbe** et **incertaine**.
+
+**Durée** : 55 min | **Prérequis** : [Infer-7-Classification](Infer-7-Classification.ipynb) (BPM, modèle probit), [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb)
+
+**Objectifs** :
+
+- Comprendre le **processus gaussien** comme une distribution sur des fonctions (moyenne + noyau de covariance)
+- Construire un prior via le **noyau squared-exponential** (RBF) et sa longueur de corrélation
+- Implémenter la **classification GP** (modèle probit `y = [f(x) > 0]`) sur des données **non-linéairement séparables**
+- Mesurer le rôle du **basis set** (points inducteurs) dans l'approximation **sparse** vs full
+- Contraster avec le **Bayes Point Machine** : frontière linéaire vs courbe, coût $O(nm^2)$ vs linéaire
+
+**Concepts clés** :
+
+| Concept | Formule / API | Description |
+| --------- | --------------- | ------------- |
+| Prior sur fonctions | `Variable<IFunction>.Random(prior)` | Distribution sur $f$, pas sur un vecteur de poids |
+| Noyau RBF | $k(x,x') = \exp(-\lVert x-x'\rVert^2 / 2\ell^2)$ | Covariance décroissant avec la distance |
+| Modèle probit | $y_j = [f(x_j) + \varepsilon_j > 0]$ | Score = fonction (non-linéaire), bruit gaussien |
+| Sparse GP | `SparseGPFixed(gp, basis)` | Approximation sur $m$ points inducteurs, coût $O(nm^2)$ |
+| Full GP | basis = inputs ($m = n$) | Équivalent au GP non-sparse, coût $O(n^3)$ |
+
+**Positionnement** : [Infer-7](Infer-7-Classification.ipynb) introduisait le **Bayes Point Machine** (hyperplan séparateur, marginalisation sur les poids). Infer-23 en est le complément **non-linéaire** : le GP infère une fonction $f$ tirée d'un processus gaussien, capable de frontières courbes. La démonstration sur un dataset « donut » (disque intérieur + anneau extérieur, **non-séparable linéairement**) prouve que le GP résout ce que le BPM ne peut pas — 16/16 sur le training, avec une incertitude calibrée (P ≈ 0.5 à mi-rayon, la zone d'indécision). La comparaison sparse (4 inducteurs) vs full (16) illustre le continuum coût-exactitude.
+
+**Applications** : classification non-linéaire, régression avec incertitude calibrée, géostatistique (krigeage), optimisation bayésienne (l'acquisition exploite le posterior GP).
 
 ---
 


### PR DESCRIPTION
## Summary

Nouveau notebook **Infer-23-Sparse-Gaussian-Process** : le pendant **non-linéaire** du Bayes Point Machine (Infer-7). Là où le BPM trace un hyperplan, le **processus gaussien** place un prior sur des fonctions (noyau RBF) et infère une frontière **courbe** et **incertaine**.

Réponse à la direction (b) "création hors-MGS substantielle" après épuisement de la deep-queue .NET (voir contexte coordination). API native Infer.NET, sujet vierge dans la série, non-doublon (BPM déjà couvert en Infer-7, GP = nouveau).

## Prong-B (problème non-dégradéré) — PROVEN

Le notebook démontre le GP sur un dataset **« donut »** (disque intérieur + anneau extérieur) qui est **non-linéairement séparable** — le cas précis où le BPM (linéaire) **échoue par construction** et le GP **réussit**. La capacité non-linéaire est **visible dans la sortie**, pas un discours.

## Résultats vérifiables (outputs réels, exécutés)

**Classification donut — training** (cell 17) :
```
Exactitude training : 16/16 = 100,0%
```
Tous les points du disque intérieur → `False`, tous les points de l'anneau → `True`. Aucun hyperplan ne peut faire ça.

**Incertitude calibrée** (cell 18, points test) :
```
               0 0 : E[f]=-0,910 P(classe=true)=0,026   <- centre, confiant False
             0,9 0 : E[f]=-0,092 P(classe=true)=0,435   <- mi-rayon, honnête ~0.5
             1,3 0 : E[f]=+0,449 P(classe=true)=0,801   <- anneau, confiant True
             0 1,4 : E[f]=+0,507 P(classe=true)=0,769   <- anneau (haut), True
```
Le GP **sait qu'il ne sait pas** à mi-rayon (P≈0.5).

**Sparse vs Full** (cell 21) :
```
  Sparse (basis=4 inducteurs)  : 15/16
  Full   (basis=16=inputs)     : 16/16
```
Le sparse n'est pas une variante dégradée — c'est un continuum (m=n = GP exact, doc Infer.NET).

**Covariance RBF** (cell 7) :
```
vers 0 0 (distance 0,00) : k = 1,0000
vers 1 0 (distance 1,00) : k = 0,6065
vers 2 0 (distance 2,00) : k = 0,1353
```

## API native Infer.NET

```csharp
Variable<SparseGP> prior = Variable.New<SparseGP>().Named("prior");
Variable<IFunction> f = Variable<IFunction>.Random(prior).Named("f");
Variable<double> score = Variable.FunctionEvaluate(f, x[j]);
y[j] = (Variable.GaussianFromMeanAndVariance(score, 0.1) > 0);
prior.ObservedValue = new SparseGP(new SparseGPFixed(gp, basis));
InferenceEngine engine = new InferenceEngine(new ExpectationPropagation());
SparseGP sgp = engine.Infer<SparseGP>(f);
Gaussian post = sgp.Marginal(inputs[i]);  // posterior en tout point
```
Code adapté de la doc officielle Infer.NET (Gaussian Process classifier). EP + Roslyn compiler. 3 moteurs EP avec `ShowProgress=false` (sorties propres, leçon durable Infer).

## Exécution (C.2)

`exec_dotnet_persist.py` kernel `.net-csharp` :
```
Done: 12 cells executed, 0 errors
```
- 12 cellules code, **0 erreurs**
- Chaque cellule : `execution_count` + `outputs` cohérents (C.2 ✓)
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1 ✓)
- 3 exercices stubs (three-exercises-per-notebook ✓) : length-scale du noyau, donut bruité, GP-vs-BPM sur données linéaires
- Graphe de facteurs rendu en SVG (cell 14, FactorGraphHelper)

## SOTA (Prong-A) — SOTA-OK

Le vrai moteur Infer.NET (`Microsoft.ML.Probabilistic`, SparseGP/IFunction/SquaredExponential) est proprement invoqué. Les outputs commités sont les **vraies sorties** du moteur EP, pas un workaround dégradé.

## README

Mise à jour (prose + table uniquement, **CATALOG-STATUS intact** — aucun marqueur dans ce README) :
- Série 24 → **25 notebooks**
- Entrée de table ligne 23 : `Infer-23 | 55 min | Processus gaussiens, noyau RBF, classification non-linéaire, sparse GP`
- Section détaillée "Modèles Non-Linéaires (Notebook 23)" avec table concepts + positionnement vs BPM
- Durée totale 21h → **22h**

## Scope

- `+1135 / -2` (1 notebook créé, 1 README enrichi). Atomique (catalog-pr-hygiene HARD 3).
- Branche fresh `origin/main` (rebase frais HARD 2).
- Submodule Search/MetaGeneticSharp NON touché (#3103 respecté).

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
