### PR TITLE
fix(pymc-1): demote exercise hint/step H1 asides to blockquote (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
@@ -444,8 +444,8 @@
     "2. Les tracer sur le meme graphique\n",
     "3. Lequel est le plus sensible au prior ? Pourquoi cela importe-t-il quand `n` est petit ?\n",
     "\n",
-    "# Indice : posterior = Beta(alpha + k, beta + n - k). Comparez les ecarts-types\n",
-    "# scipy.stats.beta(a, b).std() donne l'ecart-type. Le prior informe \"resserre\" le posterior."
+    "> **Indice :** posterior = Beta(alpha + k, beta + n - k). Comparez les ecarts-types\n",
+    "> scipy.stats.beta(a, b).std() donne l'ecart-type. Le prior informe \"resserre\" le posterior."
    ]
   },
   {
@@ -952,10 +952,10 @@
     "3. Afficher la posterior mediane de cette 7eme piece et la comparer a son MLE (`0.0`)\n",
     "4. Que vaut le shrinkage ? La piece est-elle vraiment estimee a 0 % ?\n",
     "\n",
-    "# Indice : posterior analytique impossible ici (modele hierarchique) -> MCMC obligatoire.\n",
-    "# Etape 1 : etendre les donnees avec np.append(n_obs, 3) et np.append(heads, 0)\n",
-    "# Etape 2 : re-definir le pm.Model() non-centre : logit(theta_i) = mu + sigma * z_i\n",
-    "# Etape 3 : extraire la mediane de theta_7 via np.median(trace.posterior['theta'][..., 6])"
+    "> **Indice :** posterior analytique impossible ici (modele hierarchique) -> MCMC obligatoire.\n",
+    "> **Etape 1 :** etendre les donnees avec np.append(n_obs, 3) et np.append(heads, 0)\n",
+    "> **Etape 2 :** re-definir le pm.Model() non-centre : logit(theta_i) = mu + sigma * z_i\n",
+    "> **Etape 3 :** extraire la mediane de theta_7 via np.median(trace.posterior['theta'][..., 6])"
    ]
   },
   {


### PR DESCRIPTION
## What

Fix the exact hierarchy pathology the user flagged in EPIC #3966: in `PyMC-1-Setup.ipynb`, two exercise markdown cells (12 and 20) had their hint/step asides written as `#` **H1 headings**, so they rendered in the **largest font** -- bigger than the `## Exercice` title itself. Verbatim user complaint: *« les indices donnés aux exercices apparaissent comme les éléments de police la plus grande alors que ça devrait être l'inverse »*.

## Changes — 6 lines, markdown-only (6 ins / 6 del)

Demoted per [`docs/reference/notebook-formatting.md`](docs/reference/notebook-formatting.md) §1.2 (an aside indice/étape/objectif **JAMAIS** en `#`/`##` → bold-inline or blockquote).

**cell 12** (`## Exercice : Influence du prior sur le posterior`):
- `# Indice : posterior = Beta(...)` → `> **Indice :** posterior = Beta(...)`
- `# scipy.stats.beta(a, b).std() ...` → `> scipy.stats.beta(a, b).std() ...`  (hint continuation)

**cell 20** (`## Exercice : Predire une piece eparse (partial pooling)`):
- `# Indice : ...` → `> **Indice :** ...`
- `# Etape 1 : ...` → `> **Etape 1 :** ...`
- `# Etape 2 : ...` → `> **Etape 2 :** ...`
- `# Etape 3 : ...` → `> **Etape 3 :** ...`

Each cell's hints now form a single **blockquote block** with bold labels — a discrete aside, smaller than the exercise title.

## Validation

- `python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb` : **1/1 flagged → 0/1 flagged** (clean). Was MULTI-H1 (7 H1) + 4 H1-DEEP + 4 HINT-AS-HEADING on cells 12/20; now the only H1 is the legit title in cell 0.
- **Markdown-source only** (6 ins / 6 del): 0 code cell, 0 output, 0 `execution_count` changed → **no re-execution needed** (C.2 markdown exception).
- Text kept **verbatim** — no accent or wording changes (those are a separate #2876 grain, kept out of scope to stay typo/anti-reg-safe).
- JSON re-parsed OK after the edit.

Same grain pattern as #4691 (genai-audio H4 asides → bold-inline). Single notebook, atomic.

No self-merge — awaiting ai-01 review/merge.

Co-Authored-By: Claude-Code <noreply@anthropic.com>