### PR TITLE
fix(mgs): MGS-15 hint-as-heading hierarchy -- exercise asides out of H1 (EPIC #3966)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb
@@ -519,9 +519,9 @@
     "\n",
     "Calculez la FDC de `GriewankFitness` (dimension 2, N=600) en réutilisant `SampleLandscape` et `Fdc`. *Indice* : Griewank a une structure particulière (beaucoup de local optima qui se annulent loin de l'optimum). Prédisez d'abord la valeur attendue, puis vérifiez.\n",
     "\n",
-    "# Etape 1 : instancier GriewankFitness\n",
-    "# Etape 2 : SampleLandscape(f, dim=2, N=600)\n",
-    "# Etape 3 : Fdc(samples) — comparez à Sphere/Rastrigin/Ackley"
+    "- **Etape 1 :** instancier GriewankFitness\n",
+    "- **Etape 2 :** SampleLandscape(f, dim=2, N=600)\n",
+    "- **Etape 3 :** Fdc(samples) — comparez à Sphere/Rastrigin/Ackley"
    ]
   },
   {
@@ -561,9 +561,9 @@
     "\n",
     "La difficulté d'un paysage **croît avec la dimension** (fléau de la dimensionalité). Mesurez comment la FDC de `RastriginFitness` évolue en dimension 2, 5, 10. *Conjecture* : la FDC baisse quand la dimension augmente (les bassins locaux deviennent plus nombreux et plus trompeurs).\n",
     "\n",
-    "# Etape 1 : boucler sur dims = {2, 5, 10}\n",
-    "# Etape 2 : pour chaque dim, SampleLandscape + Fdc\n",
-    "# Etape 3 : observer la décroissance — confirme-t-elle la conjecture ?"
+    "- **Etape 1 :** boucler sur dims = {2, 5, 10}\n",
+    "- **Etape 2 :** pour chaque dim, SampleLandscape + Fdc\n",
+    "- **Etape 3 :** observer la décroissance — confirme-t-elle la conjecture ?"
    ]
   },
   {
@@ -602,7 +602,7 @@
     "\n",
     "Un paysage **trompeur** (deceptive) est celui où la fitness pousse *loin* de l'optimum global (FDC négative ou quasi-nulle alors que le paysage *semble* guidé). Construisez un contre-exemple : prenez `SphereFitness` et comparez sa FDC à celle d'une fonction où l'optimum global est au **coin** de la boîte (ex. Schwefel, dont l'optimum est loin de l'origine). *Question* : la distance-à-l'origine reste-t-elle une bonne référence de difficulté quand l'optimum n'est pas à l'origine ?\n",
     "\n",
-    "# Indice : pour Schwefel, l'optimum global n'est PAS à l'origine — la FDC (distance-à-l'origine) devient trompeuse."
+    "**Indice :** pour Schwefel, l'optimum global n'est PAS à l'origine — la FDC (distance-à-l'origine) devient trompeuse."
    ]
   },
   {
@@ -925,7 +925,7 @@
     "\n",
     "`RosenbrockFitness` a une structure célèbre : une **vallée courbe et plate** qui mène à l'optimum, encadrée de **parois très raides**. Sa FDC est intermédiaire, mais son autocorrélation raconte une autre histoire. Prédisez son $\\rho_1$ (élevé ? faible ?), puis vérifiez avec `RandomWalk` + `AutocorrLag1` (dim 2, 5000 pas).\n",
     "\n",
-    "# Indice : la marche moyenne mélange deux régimes — la vallée (lisse, ρ₁ haut) et les parois (raides, ρ₁ bas). Le ρ₁ moyen reflète ce mélange."
+    "**Indice :** la marche moyenne mélange deux régimes — la vallée (lisse, ρ₁ haut) et les parois (raides, ρ₁ bas). Le ρ₁ moyen reflète ce mélange."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Correction de la pathologie de hiérarchie typographique **HINT-AS-HEADING** dans **MGS-15-LandscapeAnalysis.ipynb** (EPIC #3966, rollout par famille Search/Part4-Metaheuristics). Les asides d'exercice (`# Etape N`, `# Indice`) étaient écrits en H1 — rendus à **29 px**, **plus gros que la section `### Exercice N` (H3, 20 px)** qui les contient. C'est exactement la pathologie que le user a signalée : *« les indices donnés aux exercices apparaissent comme les éléments de police la plus grande alors que ça devrait être l'inverse »*.

## Changement (typo-only, anti-regression-safe)

4 cellules (9, 11, 13, 20), 8 lignes, application stricte de la directive [`docs/reference/notebook-formatting.md`](docs/reference/notebook-formatting.md) §1.2 :

| Avant (H1, 29 px) | Après (directive §1.2) |
|-------------------|------------------------|
| `# Etape 1 : instancier GriewankFitness` | `- **Etape 1 :** instancier GriewankFitness` |
| `# Etape 2 : SampleLandscape(f, dim=2, N=600)` | `- **Etape 2 :** SampleLandscape(f, dim=2, N=600)` |
| `# Etape 3 : Fdc(samples) — comparez à …` | `- **Etape 3 :** Fdc(samples) — comparez à …` |
| `# Indice : pour Schwefel, …` | `**Indice :** pour Schwefel, …` |

**Seul le marqueur de heading change** (`# ` → `- **` / `**`). Le texte pédagogique est préservé à l'identique (directive §4 : « changer le niveau d'un heading n'est pas changer le contenu pédagogique »). Markdown-only → pas de re-exec (exception C.2).

## Vérification

**Scanner source-level** (`scan_md_hierarchy.py`) — MGS-15 :
```
AVANT : [MULTI-H1] 9 H1  +  [H1-DEEP] x8  +  [HINT-AS-HEADING] x8
APRÈS : 0/1 notebooks flagged
```

**Rendu nbconvert → HTML** (vérification render-level, directive §3) :
```
<h1> count : 9 -> 1   (seul le titre du notebook reste en H1)
<h2> count : 7        (sections, inchangées)
<h3> count : 4        (### Exercice 1-4, inchangées)
anciens '# Etape' -> rendus en <li><strong> (items de liste), plus en <h1>
```
La pathologie est corrigée de manière déterministe : un `<li>` ne peut plus être à 29 px quand le titre est H1. (La mesure Playwright `getComputedStyle(fontSize)` or §3 est le pipeline ai-01 ; cet audit structurel HTML est concluant.)

## Non touché (grounded firsthand)

- **MGS-19 cell 1 `## Rappel — le critère de Metropolis`** = **FALSE POSITIVE** : « Rappel » est une vraie section H2 qui introduit le concept central du notebook, pas un aside. Le keyword du scanner over-trigger.
- **GameTheory H1-DEEP** (`GameTheory-1-Setup`, `SocialChoice/01-Arrow`) = **pattern structurel nav-banner** : cell 0 = bannière de navigation (blockquote), cell 1 = titre H1 + contenu. Un seul H1 (le titre), pas la pathologie ciblée. Corriger nécessiterait de fusionner les cellules (restructuration, au-delà du scope typo) → hors scope.

## Scope

- 1 fichier, +8/-8. Atomique (un sujet = fix HINT-AS-HEADING dans la famille Search/Part4-Metaheuristics).
- Branche fresh `origin/main`. Submodule MGS non touché.

See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
