### PR TITLE
docs(qc): FR-backfill ranking research trio (TFT/Mamba/GraphSAGE) READMEs (#3870, Phase 0.5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/README.en.md
@@ -1,0 +1,42 @@
+# GraphSAGE-MultiAsset-Ranking
+
+**Type:** Research (no deployable algorithm, research-only notebook)
+
+**Asset class:** Equities (large-cap US stocks)
+
+**Cloud project ID:** N/A (research-only, no deployable algorithm)
+
+## Description
+
+Research notebook applying GraphSAGE (Hamilton, Ying, and Leskovec 2017) graph neural network for cross-asset direction prediction on 8 large-cap US stocks (JPM, JNJ, XOM, PG, UNP, V, HD, BA). Constructs a correlation-based graph with threshold 0.5 to capture inter-asset dependencies. Walk-forward 5-fold validation across 4 seeds with 10bps transaction costs. Verdict: INCONCLUSIVE (insufficient statistical evidence to confirm or reject the approach).
+
+## How to Run
+
+### Lean CLI
+Not applicable (research-only notebook, no `main.py`).
+
+### QC Cloud
+Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch Geometric.
+
+### Local
+```bash
+papermill research.ipynb output.ipynb
+```
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| GraphSAGE cross-asset ranking | N/A (research) | Correlation threshold 0.5, walk-forward 5-fold x 4 seeds, 10bps T-cost |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `research.ipynb` | Research notebook with GraphSAGE model, correlation graph construction, and walk-forward validation |
+| `_generate_research.py` | Script that generates the research notebook |
+
+## References
+
+- Hamilton, W., Ying, Z., Leskovec, J. (2017). *Inductive Representation Learning on Large Graphs*. NeurIPS.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/README.md
@@ -1,42 +1,42 @@
 # GraphSAGE-MultiAsset-Ranking
 
-**Type:** Research (no deployable algorithm, research-only notebook)
+**Type :** Recherche (notebook de recherche only, pas d'algorithme déployable)
 
-**Asset class:** Equities (large-cap US stocks)
+**Classe d'actifs :** Actions (large-caps US)
 
-**Cloud project ID:** N/A (research-only, no deployable algorithm)
+**Cloud project ID :** N/A (recherche only, pas d'algorithme déployable)
 
 ## Description
 
-Research notebook applying GraphSAGE (Hamilton, Ying, and Leskovec 2017) graph neural network for cross-asset direction prediction on 8 large-cap US stocks (JPM, JNJ, XOM, PG, UNP, V, HD, BA). Constructs a correlation-based graph with threshold 0.5 to capture inter-asset dependencies. Walk-forward 5-fold validation across 4 seeds with 10bps transaction costs. Verdict: INCONCLUSIVE (insufficient statistical evidence to confirm or reject the approach).
+Notebook de recherche appliquant le réseau de neurones sur graphe GraphSAGE (Hamilton, Ying et Leskovec 2017) à la prédiction de direction cross-asset sur 8 large-caps US (JPM, JNJ, XOM, PG, UNP, V, HD, BA). Construit un graphe basé sur les corrélations avec un seuil de 0.5 pour capturer les dépendances inter-actifs. Validation walk-forward 5-fold sur 4 seeds avec coûts de transaction 10bps. Verdict : INCONCLUSIVE (preuves statistiques insuffisantes pour confirmer ou rejeter l'approche).
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
-Not applicable (research-only notebook, no `main.py`).
+Non applicable (notebook de recherche only, pas de `main.py`).
 
 ### QC Cloud
-Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch Geometric.
+Non applicable. Exécuter le notebook de recherche localement avec Python 3.10+ et PyTorch Geometric.
 
 ### Local
 ```bash
 papermill research.ipynb output.ipynb
 ```
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| GraphSAGE cross-asset ranking | N/A (research) | Correlation threshold 0.5, walk-forward 5-fold x 4 seeds, 10bps T-cost |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| GraphSAGE ranking cross-asset | N/A (recherche) | Seuil de corrélation 0.5, walk-forward 5-fold x 4 seeds, T-cost 10bps |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `research.ipynb` | Research notebook with GraphSAGE model, correlation graph construction, and walk-forward validation |
-| `_generate_research.py` | Script that generates the research notebook |
+| Fichier | Description |
+|---------|-------------|
+| `research.ipynb` | Notebook de recherche avec modèle GraphSAGE, construction du graphe de corrélation et validation walk-forward |
+| `_generate_research.py` | Script qui génère le notebook de recherche |
 
-## References
+## Références
 
 - Hamilton, W., Ying, Z., Leskovec, J. (2017). *Inductive Representation Learning on Large Graphs*. NeurIPS.
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Mamba-Crypto-Ranking/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Mamba-Crypto-Ranking/README.en.md
@@ -1,0 +1,42 @@
+# Mamba-Crypto-Ranking
+
+**Type:** Research (no deployable algorithm, research-only notebook)
+
+**Asset class:** Crypto (BTC-USD, ETH-USD)
+
+**Cloud project ID:** N/A (research-only, no deployable algorithm)
+
+## Description
+
+Research notebook evaluating Mamba (Selective State Space Model, Gu and Dao 2023) for crypto direction prediction (BTC-USD, ETH-USD). Compares Mamba (d_model=64, d_state=8, 1 layer, 80 epochs) against DLinear and TFT-Lite baselines. Pure PyTorch implementation with walk-forward validation. Verdict: Mamba INCONCLUSIVE (Sharpe 0.000, outputs NaN during training), DLinear NO BEATS, TFT-Lite NO BEATS.
+
+## How to Run
+
+### Lean CLI
+Not applicable (research-only notebook, no `main.py`).
+
+### QC Cloud
+Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch.
+
+### Local
+```bash
+papermill research.ipynb output.ipynb
+```
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Mamba SSM | N/A (research) | d_model=64, d_state=8, 1 layer, 80 epochs, walk-forward 5-fold x 4 seeds |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `research.ipynb` | Research notebook with Mamba model implementation, comparison vs DLinear/TFT-Lite baselines |
+| `_generate_research.py` | Script that generates the research notebook |
+
+## References
+
+- Gu, A., Dao, T. (2023). *Mamba: Linear-Time Sequence Modeling with Selective State Spaces*. arXiv.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Mamba-Crypto-Ranking/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Mamba-Crypto-Ranking/README.md
@@ -1,42 +1,42 @@
 # Mamba-Crypto-Ranking
 
-**Type:** Research (no deployable algorithm, research-only notebook)
+**Type :** Recherche (notebook de recherche only, pas d'algorithme déployable)
 
-**Asset class:** Crypto (BTC-USD, ETH-USD)
+**Classe d'actifs :** Crypto (BTC-USD, ETH-USD)
 
-**Cloud project ID:** N/A (research-only, no deployable algorithm)
+**Cloud project ID :** N/A (recherche only, pas d'algorithme déployable)
 
 ## Description
 
-Research notebook evaluating Mamba (Selective State Space Model, Gu and Dao 2023) for crypto direction prediction (BTC-USD, ETH-USD). Compares Mamba (d_model=64, d_state=8, 1 layer, 80 epochs) against DLinear and TFT-Lite baselines. Pure PyTorch implementation with walk-forward validation. Verdict: Mamba INCONCLUSIVE (Sharpe 0.000, outputs NaN during training), DLinear NO BEATS, TFT-Lite NO BEATS.
+Notebook de recherche évaluant Mamba (Selective State Space Model, Gu et Dao 2023) pour la prédiction de direction crypto (BTC-USD, ETH-USD). Compare Mamba (d_model=64, d_state=8, 1 couche, 80 epochs) aux baselines DLinear et TFT-Lite. Implémentation pure PyTorch avec validation walk-forward. Verdict : Mamba INCONCLUSIVE (Sharpe 0.000, outputs NaN durant l'entraînement), DLinear NO BEATS, TFT-Lite NO BEATS.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
-Not applicable (research-only notebook, no `main.py`).
+Non applicable (notebook de recherche only, pas de `main.py`).
 
 ### QC Cloud
-Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch.
+Non applicable. Exécuter le notebook de recherche localement avec Python 3.10+ et PyTorch.
 
 ### Local
 ```bash
 papermill research.ipynb output.ipynb
 ```
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Mamba SSM | N/A (research) | d_model=64, d_state=8, 1 layer, 80 epochs, walk-forward 5-fold x 4 seeds |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| Mamba SSM | N/A (recherche) | d_model=64, d_state=8, 1 couche, 80 epochs, walk-forward 5-fold x 4 seeds |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `research.ipynb` | Research notebook with Mamba model implementation, comparison vs DLinear/TFT-Lite baselines |
-| `_generate_research.py` | Script that generates the research notebook |
+| Fichier | Description |
+|---------|-------------|
+| `research.ipynb` | Notebook de recherche avec implémentation du modèle Mamba, comparaison vs baselines DLinear/TFT-Lite |
+| `_generate_research.py` | Script qui génère le notebook de recherche |
 
-## References
+## Références
 
 - Gu, A., Dao, T. (2023). *Mamba: Linear-Time Sequence Modeling with Selective State Spaces*. arXiv.
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/README.en.md
@@ -1,0 +1,42 @@
+# TFT-Crypto-Ranking
+
+**Type:** Research (no deployable algorithm, research-only notebook)
+
+**Asset class:** Crypto (BTC-USD, ETH-USD)
+
+**Cloud project ID:** N/A (research-only, no deployable algorithm)
+
+## Description
+
+Research notebook applying the Temporal Fusion Transformer (TFT, Lim et al. 2021) for crypto cross-sectional ranking (BTC vs ETH direction prediction). Uses 26 features (11 BTC-specific + 11 ETH-specific + 4 cross-asset). Architecture includes Variable Selection Network (VSN), Gated Residual Network (GRN), LSTM encoder, and multi-head attention. Walk-forward 5-fold validation across 4 seeds with 10bps transaction costs. DLinear baseline achieved Sharpe 0.742. Verdict: INCONCLUSIVE (z=1.33, insufficient for BEATS threshold).
+
+## How to Run
+
+### Lean CLI
+Not applicable (research-only notebook, no `main.py`).
+
+### QC Cloud
+Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch.
+
+### Local
+```bash
+papermill research.ipynb output.ipynb
+```
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| TFT cross-sectional ranking | N/A (research) | 26 features, VSN+GRN+LSTM+attention, walk-forward 5-fold x 4 seeds, 10bps T-cost |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `research.ipynb` | Research notebook with TFT model for crypto ranking, feature engineering, and walk-forward validation |
+| `_generate_research.py` | Script that generates the research notebook |
+
+## References
+
+- Lim, B. et al. (2021). *Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting*. International Journal of Forecasting.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/README.md
@@ -1,42 +1,42 @@
 # TFT-Crypto-Ranking
 
-**Type:** Research (no deployable algorithm, research-only notebook)
+**Type :** Recherche (notebook de recherche only, pas d'algorithme déployable)
 
-**Asset class:** Crypto (BTC-USD, ETH-USD)
+**Classe d'actifs :** Crypto (BTC-USD, ETH-USD)
 
-**Cloud project ID:** N/A (research-only, no deployable algorithm)
+**Cloud project ID :** N/A (recherche only, pas d'algorithme déployable)
 
 ## Description
 
-Research notebook applying the Temporal Fusion Transformer (TFT, Lim et al. 2021) for crypto cross-sectional ranking (BTC vs ETH direction prediction). Uses 26 features (11 BTC-specific + 11 ETH-specific + 4 cross-asset). Architecture includes Variable Selection Network (VSN), Gated Residual Network (GRN), LSTM encoder, and multi-head attention. Walk-forward 5-fold validation across 4 seeds with 10bps transaction costs. DLinear baseline achieved Sharpe 0.742. Verdict: INCONCLUSIVE (z=1.33, insufficient for BEATS threshold).
+Notebook de recherche appliquant le Temporal Fusion Transformer (TFT, Lim et al. 2021) au ranking crypto cross-sectional (prédiction de direction BTC vs ETH). Utilise 26 features (11 spécifiques BTC + 11 spécifiques ETH + 4 cross-asset). L'architecture inclut un Variable Selection Network (VSN), un Gated Residual Network (GRN), un encodeur LSTM et une multi-head attention. Validation walk-forward 5-fold sur 4 seeds avec coûts de transaction 10bps. La baseline DLinear atteint Sharpe 0.742. Verdict : INCONCLUSIVE (z=1.33, insuffisant pour le seuil BEATS).
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
-Not applicable (research-only notebook, no `main.py`).
+Non applicable (notebook de recherche only, pas de `main.py`).
 
 ### QC Cloud
-Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch.
+Non applicable. Exécuter le notebook de recherche localement avec Python 3.10+ et PyTorch.
 
 ### Local
 ```bash
 papermill research.ipynb output.ipynb
 ```
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| TFT cross-sectional ranking | N/A (research) | 26 features, VSN+GRN+LSTM+attention, walk-forward 5-fold x 4 seeds, 10bps T-cost |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| TFT ranking cross-sectional | N/A (recherche) | 26 features, VSN+GRN+LSTM+attention, walk-forward 5-fold x 4 seeds, T-cost 10bps |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `research.ipynb` | Research notebook with TFT model for crypto ranking, feature engineering, and walk-forward validation |
-| `_generate_research.py` | Script that generates the research notebook |
+| Fichier | Description |
+|---------|-------------|
+| `research.ipynb` | Notebook de recherche avec modèle TFT pour ranking crypto, feature engineering et validation walk-forward |
+| `_generate_research.py` | Script qui génère le notebook de recherche |
 
-## References
+## Références
 
 - Lim, B. et al. (2021). *Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting*. International Journal of Forecasting.
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)


### PR DESCRIPTION
## Quoi

Francisation des READMEs de la **famille ranking research** (3 notebooks QuantConnect, authentiquement en anglais) :
- **TFT-Crypto-Ranking** — Temporal Fusion Transformer (Lim et al. 2021), ranking crypto cross-sectional BTC/ETH
- **Mamba-Crypto-Ranking** — Selective State Space Model (Gu & Dao 2023), prédiction de direction crypto
- **GraphSAGE-MultiAsset-Ranking** — GNN (Hamilton et al. 2017), prédiction cross-asset sur 8 large-caps US

## Pourquoi

Phase 0.5 #1650 : backfill FR des READMEs pédagogiques EN avant la localisation scriptée. Trio choisi pour cohérence (même structure parallèle « research-only notebook », même template de fichier). Sélectionné après classification firsthand des 75 project READMEs EN-only (5 déjà FR, ~65 vrais candidats EN répartis sur plusieurs cycles).

## Mécanique (rule `readme-french-first.md` HARD 2)

- `git mv README.md README.en.md` → EN original **préservé byte-identique** (golden set Phase 3, livrable préservé).
- Nouveau `README.md` FR : même structure (H2/ancres/liens), Cloud project IDs, métriques (Sharpe 0.742 / 0.000, verdicts INCONCLUSIVE/NO BEATS), commandes (`papermill research.ipynb output.ipynb`) et **citations académiques préservées**.
- Pas de régénération catalogue sur la branche (`catalog-pr-hygiene`) — marqueurs `CATALOG-STATUS` inchangés.

## Validation firsthand

- H2 parity **5/5** sur les 3 fichiers (EN vs FR).
- `.en.md` **byte-identical** au `README.md` de HEAD (diff = 0) pour les 3.
- 0 EN prose-leak dans le FR (stopwords/sentence-starters anglais : clean).
- Aucune fuite de terme technique : TFT, VSN, GRN, LSTM, Mamba SSM, GraphSAGE, DLinear, walk-forward, seeds, bps — conservés.

## Scope atomique

6 fichiers (3 renames `git mv` + 3 nouveaux FR), +180/-54. 0 notebook touché, 0 catalogue, 0 metadata. Base `origin/main` fraîche.

See #1650
See #3870

🤖 Generated with [Claude Code](https://claude.com/claude-code)