### PR TITLE
docs(claudish): Phase B — Roo routing note + 3 war-stories (#4445)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
@@ -123,7 +123,7 @@ Au-delà du routing de base, le fork `jsboige/claudish` ajoute ce qui fait tourn
 | Avancée | Rôle |
 |---------|------|
 | **Never-hang (priorité #1)** | Un flux se termine **toujours**, même si le provider coupe mid-stream ou renvoie du vide. Un agent bloqué est jugé pire qu'une erreur propre. |
-| **Overload 529** | Un 429 « quota » (que le client peut interrompre en stoppant le tour) est converti en `529 overloaded_error` + `Retry-After`, pour que le client **réessaie** au lieu d'abandonner. |
+| **Overload 529** | Un 429 de **surcharge transitoire** (ou 503) est converti en `529 overloaded_error` + `Retry-After`, pour que le client **réessaie** au lieu d'abandonner ; le 429 « quota » reste distinct (passe tel quel). |
 | **Contrôle de concurrence** | `LocalModelQueue` (cap GPU) + `ConcurrencyLimiter` (cap provider remote), indépendants par provider (voir §3). |
 | **Interception web search** | Les appels `web_search` des providers sont interceptés et servis via SearXNG (MCP) — ne bloque jamais l'agent (dégradation gracieuse en texte). |
 | **Support `/compact` non-streaming** | Les requêtes `stream:false` (condensation de contexte) sont rebufferisées en un message JSON, pas en SSE. |
@@ -138,7 +138,7 @@ Ces trois épisodes, extraits de l'historique du fork `jsboige/claudish`, illust
 
 ### 7.1 Architecture par soustraction — le no-fallback (24/06/2026)
 
-Au démarrage, claudish enchaînait les providers en fallback : si GLM rate-limitait, il basculait sur Qwen, puis Anthropic. **Le problème** : cette bascule se faisait à l'insu de l'agent, en plein milieu d'une conversation — changeant la qualité du modèle et le coût d'un tour sur l'autre, de façon invisible et imprévisible. Pire, le chemin fallback vers Qwen (GPU maison) a grippé le backend à plusieurs reprises (concurrence non bornée sur des contextes longs = famine GPU).
+Au démarrage, claudish enchaînait les providers en fallback : si GLM rate-limitait, il basculait sur Qwen. **Le problème** : cette bascule se faisait à l'insu de l'agent, en plein milieu d'une conversation — changeant la qualité du modèle et le coût d'un tour sur l'autre, de façon invisible et imprévisible. Pire, le chemin fallback vers Qwen (GPU maison) a grippé le backend à plusieurs reprises (concurrence non bornée sur des contextes longs = famine GPU).
 
 **La décision** n'a pas été d'ajouter du code pour mieux orchestrer les bascules, mais de **le retirer** : suppression de `defaultProvider`, une seule entrée par chaîne. Depuis, sur un burst claudish **backoff** puis réessaie le *même* provider ; sur une panne franche il **fail-hard** (erreur explicite). *Leçon : un fallback silencieux est une dégradation cachée. Mieux vaut une erreur visible qu'une dérive de qualité invisible — et un chemin de code en moins est un bug en moins.*
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
@@ -2,7 +2,7 @@
 
 > Sources : [github.com/MadAppGang/claudish](https://github.com/MadAppGang/claudish) (upstream) · [github.com/jsboige/claudish](https://github.com/jsboige/claudish) (déploiement MyIA) · [claudish.com](https://claudish.com)
 
-Ce document décrit **Claudish** tel qu'il est déployé sur le cluster MyIA : un proxy compatible avec l'API Anthropic qui fait tourner Claude Code, les agents autonomes et les bots sur **n'importe quel fournisseur de modèles**. Il explique le principe, le router à 3 providers, la façon de connecter un bot, et les avancées du fork.
+Ce document décrit **Claudish** tel qu'il est déployé sur le cluster MyIA : un proxy compatible avec l'API Anthropic qui fait tourner Claude Code, les agents autonomes et les bots sur **n'importe quel fournisseur de modèles**. Il explique le principe, le router à 3 providers, la façon de connecter un agent (Claude Code) et un bot, les avancées du fork, et les war-stories qui ont forgé son design.
 
 ---
 
@@ -87,6 +87,16 @@ $env:ANTHROPIC_MODEL = "glm-5.2"          # tier Sonnet → Z.AI GLM
 
 C'est tout. Claude Code croit parler à Anthropic ; claudish route en réalité vers GLM/Qwen/Anthropic selon le modèle demandé.
 
+### Et Roo Code ?
+
+**Non, Roo Code ne passe pas par claudish.** Les deux outils ne se sont jamais croisés : Roo *déclinait* pile au moment où claudish *émergeait*. Roo s'est donc toujours configuré en **OpenRouter direct** (via l'UI Fournisseurs), et n'a jamais eu besoin du proxy. En pratique, le trafic du proxy est à **100 % du `claude-cli/*`** (Claude Code, le SDK, les bots) — aucune signature Roo, Cline ou OpenRouter.
+
+La raison technique : claudish ne sert que le **wire Anthropic** (`POST /v1/messages`). Un appel OpenAI-style `/chat/completions` renvoie `404`. Roo étant orienté wire OpenAI-compat, il ne peut pas consommer claudish tel quel.
+
+> **Piège de télémétrie** : si vous voyez `cc_entrypoint=claude-vscode` dans les captures de trafic, c'est **Claude Code lancé depuis VS Code**, pas Roo Code. Les deux sont des extensions VS Code différentes ; ne pas les confondre.
+
+**Perspective (successeur Zoo)** : le remplaçant de Roo, **Zoo Code**, est amené à router par claudish — via son provider Anthropic pointé sur `models.myia.io` + un nom de modèle Claude remappé (le même pattern cross-bot que la leçon Hermes ci-dessous). Ce sera une **configuration par poste**, pas une feature du proxy. À suivre côté turf `roo-extensions`.
+
 ---
 
 ## 5. Connecter un bot — le trick du nom Claude (leçon Hermes)
@@ -97,7 +107,7 @@ Deux approches, du plus simple au plus invasif :
 
 | Option | Quoi faire | Quand |
 |--------|------------|-------|
-| ⭐ **Remap de nom (recommandée)** | Le bot envoie un **nom de modèle Claude** (ex. `claude-sonnet-4-6`). Claudish le remappe vers le modèle budgeté du tier (`glm-5.2` via `gc@`) selon le profil actif. **1 ligne de config côté bot, aucun patch de wire.** | Le bot sait juste poster un `model` dans sa requête Anthropic. |
+| **Remap de nom (recommandée)** | Le bot envoie un **nom de modèle Claude** (ex. `claude-sonnet-4-6`). Claudish le remappe vers le modèle budgeté du tier (`glm-5.2` via `gc@`) selon le profil actif. **1 ligne de config côté bot, aucun patch de wire.** | Le bot sait juste poster un `model` dans sa requête Anthropic. |
 | Patch du wire | Faire parler le bot Anthropic natif (messages/tools au format Anthropic) | Le bot a déjà une intégration Anthropic, ou on contrôle son code. |
 
 > **Leçon Hermes (juin 2026)** : le bot Hermes bloquait le routing. Le fix n'a **pas** été de patcher le wire du bot, mais simplement de lui faire envoyer un nom Claude — claudish s'occupe du reste via le `modelMap` du profil. C'est le pattern réutilisable pour tout bot qui s'intègre au cluster.
@@ -122,7 +132,35 @@ Au-delà du routing de base, le fork `jsboige/claudish` ajoute ce qui fait tourn
 
 ---
 
-## 7. Variables d'environnement clés
+## 7. War-stories — trois leçons du fork en production
+
+Ces trois épisodes, extraits de l'historique du fork `jsboige/claudish`, illustrent pourquoi le proxy est conçu *comme il l'est*. Chacun porte une leçon transférable au-delà de claudish.
+
+### 7.1 Architecture par soustraction — le no-fallback (24/06/2026)
+
+Au démarrage, claudish enchaînait les providers en fallback : si GLM rate-limitait, il basculait sur Qwen, puis Anthropic. **Le problème** : cette bascule se faisait à l'insu de l'agent, en plein milieu d'une conversation — changeant la qualité du modèle et le coût d'un tour sur l'autre, de façon invisible et imprévisible. Pire, le chemin fallback vers Qwen (GPU maison) a grippé le backend à plusieurs reprises (concurrence non bornée sur des contextes longs = famine GPU).
+
+**La décision** n'a pas été d'ajouter du code pour mieux orchestrer les bascules, mais de **le retirer** : suppression de `defaultProvider`, une seule entrée par chaîne. Depuis, sur un burst claudish **backoff** puis réessaie le *même* provider ; sur une panne franche il **fail-hard** (erreur explicite). *Leçon : un fallback silencieux est une dégradation cachée. Mieux vaut une erreur visible qu'une dérive de qualité invisible — et un chemin de code en moins est un bug en moins.*
+
+### 7.2 Never-hang — le proxy qui crash déguisé en bug de stream (commit `8afe19d`, 14/06/2026)
+
+Le symptôme : un gel récurrent sur un workflow CoursIA réel (portage d'un fichier `.cs`, sur `po-2025`). Côté client, cela ressemblait à un bug de lifecycle de stream — messages d'erreur « Content block not found », sockets fermées.
+
+**La cause racine** était tout autre : un block `server_tool_use` de Z.AI déclenchait un handler qui lisait une variable d'index déclarée avec `let` dans un bloc `try` interne, alors que la closure vivait dans le scope externe → `ReferenceError` → **crash du process** → restart du conteneur. Le client ne voyait qu'une socket morte, pas le plantage.
+
+**La leçon transférable** : *un proxy qui crash produit des symptômes de socket-close qui imitent un bug de lifecycle de stream. Quand un client « freeze », il faut **grep les exceptions dans les logs du proxy** avant de partir chasser des race conditions côté stream.* C'est la motivation de la priorité #1 du fork — **never-hang** : un flux se termine *toujours*, même si le provider coupe mid-stream. Un agent bloqué est jugé pire qu'une erreur propre.
+
+### 7.3 Résilience — overload GLM convertie en HTTP 529 (commit `67a5dd0`)
+
+Quand Z.AI est en surcharge, il renvoie du `429` (ou `503`). Un `429` brut, c'est un code « quota » que le client interprète souvent comme *arrêt* — il abandonne le tour au lieu de réessayer. Or une surcharge transitoire de Z.AI se résout typiquement en quelques minutes.
+
+**Le fix** : claudish distingue la surcharge transitoire du quota épuisé, convertit la première en `529 overloaded_error` avec un `Retry-After`, et applique un **backoff patient** (~5 min, 6 retries, schedule 5/10/20/40/80/150 s) côté proxy avant de rendre la main. Le client reçoit un `529` (signal « réessaie ») plutôt qu'un `429` (signal « arrête »). Validé en production : **36 épisodes de surcharge convertis en 529 sur une fenêtre, zéro `429` atteint un client.**
+
+*Leçon : les codes HTTP sont sémantiques (`429` ≠ `529`), et un client bien élevé réessaie sur `529`. Le dogfooding — tester ses propres fixes en prod sur le cluster — a révélé un chemin non couvert (le 429 HTTP-direct) que les tests unitaires n'avaient pas attrapé.*
+
+---
+
+## 8. Variables d'environnement clés
 
 | Variable | Effet |
 |----------|-------|
@@ -136,18 +174,18 @@ Au-delà du routing de base, le fork `jsboige/claudish` ajoute ce qui fait tourn
 
 ---
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
 | Symptôme | Cause | Fix |
 |----------|-------|-----|
-| `404` sur `/chat/completions` | Le bot parle wire OpenAI ; claudish ne sert que l'wire Anthropic | Option ⭐ : envoyer un nom de modèle Claude (remap), ou faire parler le bot Anthropic |
+| `404` sur `/chat/completions` | Le bot parle wire OpenAI ; claudish ne sert que l'wire Anthropic | Option recommandée : envoyer un nom de modèle Claude (remap), ou faire parler le bot Anthropic |
 | `404` ou erreur de routing sur `glm-5-2` | Slug erroné (tiret au lieu du point) | Utiliser `glm-5.2` |
 | `503` intermittents côté IIS | Congestion du proxy (longs streams empilés sur un provider plafonné) | Vérifier les caps `providerConcurrency` ; le backoff/limiter doit lisser la rafale |
 | Agent qui « freeze » (socket closed) | Flux non terminé proprement | Ne devrait plus arriver (never-hang) — si oui, c'est un bug à reporter |
 
 ---
 
-## 9. Liens & lectures
+## 10. Liens & lectures
 
 - **Upstream** : [MadAppGang/claudish](https://github.com/MadAppGang/claudish) — code source, README, docs.
 - **Déploiement MyIA** : `jsboige/claudish` (fork), serveur `po-2023`, passerelle `models.myia.io`.
@@ -156,4 +194,4 @@ Au-delà du routing de base, le fork `jsboige/claudish` ajoute ce qui fait tourn
 
 ---
 
-*Section Claudish — Juin 2026. Proxy Anthropic-compatible multi-providers du cluster MyIA : un format wire en entrée, trois providers budgetés en sortie, jamais de bascule silencieuse.*
+*Section Claudish — Juillet 2026. Proxy Anthropic-compatible multi-providers du cluster MyIA : un format wire en entrée, trois providers budgetés en sortie, jamais de bascule silencieuse.*


### PR DESCRIPTION
## Contexte

**Phase B** de l'issue **#4445** (Doc Claudish — Vibe-Coding/Claudish). **Phase A déjà mergée** (PR #4453 : structure sous-série + ce doc 9 sections + config example). La Phase B complète les axes (3) Utilisation et (4) War-stories de l'acceptance.

**Matériel firsthand fourni et validé par le mainteneur Claudish** (sessions workspace-claudish 01:45Z + 01:52Z, **validé user**) : preuve trafic live (100% claude-cli), commits git-attestés du fork (`8afe19d`, `67a5dd0`), leçons opérationnelles. Rédigé en fidélité stricte (règle #3164 — documenter une filiation attestée, jamais fabriquer).

## Changements (1 fichier, +45/-7)

### Section 4 — nouvelle sous-section « Et Roo Code ? » (axe B1)

Documente pourquoi **Roo Code ne passe pas par Claudish** :
- Roo = **OpenRouter direct** (croisement de timeline sunset/sunrise, jamais eu besoin du proxy)
- Claudish ne sert que le **wire Anthropic** (`/chat/completions` → 404) ; Roo orienté OpenAI-compat
- Preuve : trafic proxy 100% `claude-cli/*`, zéro signature Roo
- **Piège de télémétrie** : `cc_entrypoint=claude-vscode` = Claude Code dans VS Code, ≠ Roo Code
- Perspective forward : le successeur **Zoo Code** routera par Claudish (provider Anthropic + nom modèle Claude remappé, pattern Hermes)

### Section 7 (nouvelle) — « War-stories — trois leçons du fork en production »

3 leçons distinctes, git-attestées (swap appliqué sur recommandation maintainer : `wedge vLLM` → `never-hang`, wedge relégué en sous-point capacité) :

| § | War-story | Commit | Leçon |
|---|-----------|--------|-------|
| 7.1 | no-fallback routing | 2026-06-24 | archi par soustraction (retirer du code > ajouter) |
| 7.2 | `server_tool_use` scope crash / never-hang | `8afe19d` | un proxy qui crash imite un bug de stream → grep les exceptions avant de chasser les race conditions |
| 7.3 | overload GLM → HTTP 529 | `67a5dd0` | codes sémantiques (429 ≠ 529), backoff patient, dogfooding |

### Conformité

- Renumérotation sections suivantes (7→8 env vars, 8→9 troubleshooting, 9→10 liens) — headings consécutifs vérifiés
- **2 emojis `⭐` retirés** (règle code-style no-emojis, pré-existants Phase A)
- FR-first, no-emojis, **0 secret** (seul `<clé claudish>` placeholder existant de Phase A)
- **Markdown-only** → 0 re-execution (C.2)

## Grounding (anti-fabrication #3164)

- Commit `8afe19d` vérifié dans le fork `jsboige/claudish` : « fix(anthropic-sse): fix proxy crash on server_tool_use blocks (scope bug + ordering) »
- Commit `67a5dd0` : overload→529, 36 épisodes validés en prod le 26/06 (preuve trafic maintainer)
- Le mainteneur (source-of-truth du fork) a validé le matériel ET le swap ; relecture du texte rédigé en cours (sur cette PR)

## Scope

\`See #4445\` (contribution Phase B — l'issue reste ouverte tant que la relecture fidélité mainteneur n'est pas actée). 1 fichier = 1 sujet = 1 PR atomique (G.4/G.5). Phase A (#4453) non dupliquée.

**Demande au coordinateur** : merger après relecture fidélité du mainteneur Claudish (ping sur workspace-claudish).

Co-Authored-By: Claude-Code <noreply@anthropic.com>