### PR TITLE
feat(z3): MP-2 — 05c reecrit en couche donnees Ciqual x RecipeML (matcheur cure sans faux positifs) (See #4677)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05c_Dietetique_Load_Faithful_Port.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/05c_Dietetique_Load_Faithful_Port.ipynb
@@ -2,73 +2,128 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "88b48f6b",
+   "id": "4a6c161c",
    "metadata": {
+    "papermill": {
+     "duration": 0.014271,
+     "end_time": "2026-07-01T03:28:17.469694",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:17.455423",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "# 05c — Port fidele de `Dietetique.Load` : fusion LINQ a l'echelle reelle\n",
+    "# 05c — Données réelles & externe : Ciqual × RecipeML (couche de données, 0 Z3)\n",
     "\n",
-    "> **Slice A du capstone MealPlanner** ([issue #4617](https://github.com/jsboige/CoursIA/issues/4617), `See #1206`).\n",
-    "> Source distillee : `MyIntelligenceAgency/Z3.LinqBinding@EPFdevelopment`, projet `Demo2/MealPlanning`\n",
-    "> (`PlanificateurDeMenus.cs`, `Ciqual.cs`, `Recettes.cs`).\n",
+    "> **Bloc meal-planner — notebook « Données & externe »** (cible **07** après renumérotation, cf. [Epic #4677](https://github.com/jsboige/CoursIA/issues/4677)). Il **porte à l'échelle réelle** — Ciqual complet × plusieurs milliers de recettes **RecipeML** — la couche **données** que le notebook [`06b`](06b_RecipeML_Corpus.ipynb) esquissait sur un extrait *inline* de 7 recettes. La couche **modélisation Z3** de `06b` (résolution de menu) est traitée à part : sa consolidation dans le notebook de modélisation est planifiée par l'[Epic #4677](https://github.com/jsboige/CoursIA/issues/4677) et **hors périmètre de ce notebook**.\n",
     "\n",
-    "Les notebooks [05d](05d_Hierarchical_Patient_Restrictions.ipynb) (axe **structurel**, 138 plats) et\n",
-    "[05e](05e_Meal_Planner_Convergence_Scale.ipynb) (axe **nutritionnel**, jointure lexicale anglaise) sont\n",
-    "de bonnes mises a l'echelle, mais aucun ne **porte fidelement** la couche de donnees du Demo2 d'origine :\n",
-    "la methode `Dietetique.Load`. Ce notebook comble exactement ce trou.\n",
+    "Avant qu'un solveur SMT puisse planifier un menu, il faut **charger et préparer des données réelles**. Ce notebook **ne résout rien (0 Z3)** : son livrable est la **couche de données propre** que les notebooks de modélisation et de capstone ([05d](05d_Hierarchical_Patient_Restrictions.ipynb), [05e](05e_Meal_Planner_Convergence_Scale.ipynb)) consommeront.\n",
     "\n",
-    "## Ce que `Dietetique.Load` fait reellement\n",
+    "## Deux sources, une jointure de *data fusion*\n",
     "\n",
-    "C'est un pipeline **LINQ-to-objects** qui fusionne deux sources heterogenes en un catalogue\n",
-    "nutritionnel exploitable par le solveur :\n",
+    "| Source | Rôle | Format | Ce qu'elle apporte |\n",
+    "|--------|------|--------|--------------------|\n",
+    "| **Ciqual (ANSES 2025)** | référentiel nutrition | XML | composition de 3484 aliments **par 100 g** ; noms **anglais** (`alim_nom_eng`) |\n",
+    "| **RecipeML** (archive culinaire) | corpus recettes | XML auto-décrit | `<ing>` = `<amt><qty>` + `<unit>` + `<item>` — **avec les quantités** |\n",
     "\n",
-    "1. **Ciqual ANSES** (table officielle de composition nutritionnelle, 4 fichiers XML) — ici la table\n",
-    "   **2025** (DOI 10.57745/RDMHWY, licence etalab 2.0), de schema identique a la 2017 du Demo2.\n",
-    "2. **Recettes OpenData** (denrees / plats / menus de cantine, JSON).\n",
+    "Le corpus RecipeML porte **quoi** (les ingrédients), Ciqual porte **combien** (la nutrition). Aucune clé commune ne les relie : seul un **appariement lexical approximatif** (item anglais ↔ `alim_nom_eng`) fait le pont. C'est de la **fusion de données réelle** — pas un `join` jouet.\n",
     "\n",
-    "Le pipeline enchaine :\n",
+    "## Le fil conducteur : trois obstacles que les corpus jouets masquaient\n",
     "\n",
-    "- **Deux jointures** `CONST -> COMPO -> ALIM` pour reconstituer, par constituant, la teneur de chaque aliment ;\n",
-    "- un **matcheur lexical flou** maison (`CalculeProximiteLexicale`, sac-de-mots) pour rapprocher les\n",
-    "  denrees des recettes (libelles bruts de cantine, `POIVRE GRIS MOULU K`) des aliments Ciqual (`Poivre noir`) ;\n",
-    "- une **agregation** `Zip`/`Aggregate` pour composer la teneur d'un plat a partir de celles de ses denrees ;\n",
-    "- la serialisation d'un cache `dietetique.json`.\n",
+    "1. **Pas de clé commune** → **appariement lexical flou** (sac-de-mots + index inversé). Section 3.\n",
+    "2. **Les ingrédients ont des quantités en unités culinaires** (`2 cups`, `1 teaspoon`) → il faut **normaliser en grammes** avant toute agrégation nutritionnelle. Section 5. *C'est le point que la première ébauche du planificateur à l'échelle ([05e](05e_Meal_Planner_Convergence_Scale.ipynb)) escamotait en sommant les teneurs per-100g comme si chaque ingrédient pesait 100 g.*\n",
+    "3. **La couverture d'appariement est inégale** → on **gate** les recettes par qualité de match (100 % / ≥80 % / ≥50 %) pour ne livrer au solveur qu'un sous-ensemble **propre**. Sections 6-7.\n",
     "\n",
-    "**Pourquoi c'est un bon probleme (Prong B)** : ce n'est pas un `join` jouet a 7 lignes. Les denrees de\n",
-    "cantine n'ont **aucune cle commune** avec Ciqual — seul un appariement **textuel approximatif** les relie,\n",
-    "sur 3484 aliments x ~200 denrees. C'est de la **fusion de donnees reelle**, le genre que LINQ absorbe\n",
-    "declarativement la ou un script imperatif deviendrait illisible.\n",
-    "\n",
-    "**Perimetre** : Slice A s'arrete **avant Z3** (le theoreme hierarchique + la convergence a l'echelle sont\n",
-    "les Slices C/D du capstone). Son livrable est la couche `Dietetique` fidele que le solveur consommera.\n"
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    Q[\"Ciqual ANSES 2025<br/>(XML, per-100g, EN)\"]\n",
+    "    R[\"Archive RecipeML<br/>(XML, qty/unit/item)\"]\n",
+    "    Q -->|\"XmlReader\"| QL[\"alimCompo + alim_nom_eng\"]\n",
+    "    R -->|\"XDocument\"| RL[\"recettes (item, qty, unit)\"]\n",
+    "    RL -->|\"appariement flou\"| J[\"item ↔ code Ciqual\"]\n",
+    "    RL -->|\"qty×unité→grammes\"| G[\"masse par ingrédient\"]\n",
+    "    QL --> A\n",
+    "    J --> A\n",
+    "    G --> A[\"agrégation PONDÉRÉE par la masse\"]\n",
+    "    A -->|\"gate ≥80%\"| C[\"cache JSON propre\"]\n",
+    "    C -.->|\"consommé par\"| M[\"05d capstone · 05e échelle\"]\n",
+    "    style Q fill:#f7e3c5\n",
+    "    style R fill:#f7e3c5\n",
+    "    style C fill:#c8e6f7\n",
+    "    style M fill:#eeeeee\n",
+    "```\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b626c15d",
+   "id": "e774b47c",
    "metadata": {
+    "papermill": {
+     "duration": 0.004877,
+     "end_time": "2026-07-01T03:28:17.482697",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:17.477820",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "## 0. Dependances et donnees\n",
+    "## Objectifs d'apprentissage\n",
     "\n",
-    "Le corpus (Ciqual 69 Mo + Recettes) est **trop volumineux pour le depot** : il est `.gitignore` sous\n",
-    "`data/meals/`. Recuperez-le une fois via le telechargeur livre avec le capstone :\n",
+    "- Réaliser une **jointure de data fusion** entre un corpus de recettes (RecipeML, ingrédients anglais) et une base nutritionnelle (Ciqual `alim_nom_eng`), via **rapprochement lexical flou**.\n",
+    "- Parser une structure XML réelle **avec quantités** (`<amt><qty><unit>`), et comprendre pourquoi la **normalisation en grammes** est un préalable non négociable à l'agrégation nutritionnelle.\n",
+    "- Mesurer la **couverture d'appariement** et **gate**r le corpus par qualité — le levier de montée en charge *piloté par la donnée*.\n",
+    "\n",
+    "## Prérequis\n",
+    "\n",
+    "- Notions LINQ-to-objects et LINQ-to-XML.\n",
+    "- Aucune dépendance Z3 : ce notebook est **purement data-engineering** (0 solveur)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "061c60b8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005879,
+     "end_time": "2026-07-01T03:28:17.495581",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:17.489702",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Données : Ciqual 2025 + archive RecipeML\n",
+    "\n",
+    "Les données sont volumineuses et **hors dépôt** (`data/meals/` est gitignore). Si le dossier est absent, exécutez d'abord le téléchargeur :\n",
     "\n",
     "```bash\n",
-    "python download_meal_data.py          # Ciqual 2025 + Recettes OpenData + RecipeML\n",
+    "python download_meal_data.py --ciqual --recipeml\n",
     "```\n",
     "\n",
-    "La cellule suivante resout le chemin des donnees et **echoue franchement** (fail-loud) si elles sont\n",
-    "absentes, en rappelant la commande — pas de jeu de substitution.\n"
+    "Ciqual ANSES 2025 (DOI 10.57745/RDMHWY, licence etalab 2.0) est une base **normalisée en 4 fichiers** : `const` (constituants), `alim` (aliments), `compo` (compositions, ~66 Mo) et `alim_grp` (groupes). On la lit **en flux** (`XmlReader`) pour ne garder que les **constituants contraints**. L'archive RecipeML est un ensemble de fichiers XML `<recipe>` auto-décrits."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "7de51840",
+   "id": "138bdfcd",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:17.567938Z",
+     "iopub.status.busy": "2026-07-01T03:28:17.526800Z",
+     "iopub.status.idle": "2026-07-01T03:28:19.595442Z",
+     "shell.execute_reply": "2026-07-01T03:28:19.590427Z"
+    },
+    "papermill": {
+     "duration": 2.09477,
+     "end_time": "2026-07-01T03:28:19.595442",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:17.500672",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -77,7 +132,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-193264.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-97068.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -122,12 +177,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.12:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.1.12:2050/\", \"http://172.18.16.1:2050/\", \"http://172.28.176.1:2050/\", \"http://127.0.0.1:2050/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '193264.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '97068.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -188,109 +243,70 @@
      "output_type": "display_data"
     },
     {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Newtonsoft.Json, 13.0.3</span></li></ul></div></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Donnees OK : data\\meals\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Ciqual  : 4 fichiers XML\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Recettes: 6 fichiers JSON\r\n"
+      "Donnees presentes : Ciqual, Recettes, RecipeML\r\n"
      ]
     }
    ],
    "source": [
-    "#r \"nuget: Newtonsoft.Json, 13.0.3\"\n",
+    "// ---- dependances (0 Z3 : purement data-engineering) ----\n",
     "using System;\n",
-    "using System.Collections.Generic;\n",
-    "using System.Globalization;\n",
     "using System.IO;\n",
     "using System.Linq;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Xml;\n",
     "using System.Text;\n",
+    "using System.Text.Json;\n",
     "using System.Text.RegularExpressions;\n",
-    "using System.Xml.Serialization;\n",
-    "using Newtonsoft.Json;\n",
+    "using System.Globalization;\n",
+    "using System.Diagnostics;\n",
     "\n",
-    "// Resolution robuste du dossier data/meals (relatif au notebook, avec repli remontant).\n",
-    "string ResolveDataDir()\n",
-    "{\n",
-    "    var candidates = new[]\n",
-    "    {\n",
-    "        Path.Combine(Directory.GetCurrentDirectory(), \"data\", \"meals\"),\n",
-    "        Path.Combine(Directory.GetCurrentDirectory(), \"MyIA.AI.Notebooks\", \"SymbolicAI\", \"SMT\", \"Z3\", \"data\", \"meals\"),\n",
-    "    };\n",
-    "    foreach (var c in candidates)\n",
-    "        if (Directory.Exists(Path.Combine(c, \"Ciqual\")) && Directory.Exists(Path.Combine(c, \"Recettes\")))\n",
-    "            return c;\n",
-    "    return candidates[0];\n",
-    "}\n",
-    "\n",
-    "var DataDir = ResolveDataDir();\n",
-    "var ciqualDir = Path.Combine(DataDir, \"Ciqual\");\n",
-    "var recettesDir = Path.Combine(DataDir, \"Recettes\");\n",
-    "\n",
-    "// Affichage relatif au repertoire courant (evite de fuiter un chemin machine absolu).\n",
-    "string Rel(string p) => Path.GetRelativePath(Directory.GetCurrentDirectory(), p);\n",
-    "\n",
-    "if (!Directory.Exists(ciqualDir) || !Directory.Exists(recettesDir))\n",
-    "{\n",
-    "    Console.WriteLine(\"[DONNEES ABSENTES] \" + Rel(DataDir));\n",
-    "    Console.WriteLine(\"Lancez d'abord :  python download_meal_data.py\");\n",
-    "    Console.WriteLine(\"(Ciqual ANSES 2025 + Recettes OpenData ; corpus .gitignore, ~70 Mo)\");\n",
-    "}\n",
+    "var BASE = \"data/meals\";\n",
+    "if (!Directory.Exists(Path.Combine(BASE, \"Ciqual\")) || !Directory.Exists(Path.Combine(BASE, \"RecipeML\")))\n",
+    "    Console.WriteLine(\"Donnees absentes. Lancez d'abord : python download_meal_data.py --ciqual --recipeml\");\n",
     "else\n",
-    "{\n",
-    "    Console.WriteLine(\"Donnees OK : \" + Rel(DataDir));\n",
-    "    Console.WriteLine(\"  Ciqual  : \" + Directory.GetFiles(ciqualDir, \"*.xml\").Length + \" fichiers XML\");\n",
-    "    Console.WriteLine(\"  Recettes: \" + Directory.GetFiles(recettesDir, \"*.json\").Length + \" fichiers JSON\");\n",
-    "}\n"
+    "    Console.WriteLine(\"Donnees presentes : \" + string.Join(\", \", Directory.GetDirectories(BASE).Select(Path.GetFileName)));\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "71eb4918",
+   "id": "6b6e6a56",
    "metadata": {
+    "papermill": {
+     "duration": 0.008046,
+     "end_time": "2026-07-01T03:28:19.611124",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:19.603078",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "## 1. Charger Ciqual (ANSES 2025) via `XmlSerializer`\n",
+    "## 2. Ciqual : le référentiel nutritionnel (per-100g)\n",
     "\n",
-    "Le Demo2 deserialise 4 tables XML en classes POCO. Pour Slice A, seules trois portent la fusion :\n",
-    "\n",
-    "| Table | Cle(s) | Champs utiles |\n",
-    "|-------|--------|---------------|\n",
-    "| `CONST` | `const_code` | `const_nom_fr` (nom du constituant : energie, proteines, ...) |\n",
-    "| `COMPO` | `alim_code` + `const_code` | `teneur` (valeur pour 100 g) |\n",
-    "| `ALIM`  | `alim_code` | `alim_nom_fr` (nom de l'aliment) |\n",
-    "\n",
-    "`COMPO` est le **gros fichier** (~258 000 lignes : chaque couple aliment x constituant). On garde la\n",
-    "deserialisation par `XmlSerializer` du Demo2 (fidelite), seuls les noms de fichiers passent en 2025.\n"
+    "On lit `const` (pour repérer les 5 constituants qu'on contraindra : énergie, protéines, glucides, lipides, sel), `alim` (nom anglais de chaque aliment) et `compo` (teneurs). Les teneurs Ciqual sont **toutes par 100 g** — c'est ce qui rendra la normalisation en grammes (section 5) indispensable."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "90e5b3c7",
+   "id": "b4e8ab6f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:19.627749Z",
+     "iopub.status.busy": "2026-07-01T03:28:19.627749Z",
+     "iopub.status.idle": "2026-07-01T03:28:23.154776Z",
+     "shell.execute_reply": "2026-07-01T03:28:23.153775Z"
+    },
+    "papermill": {
+     "duration": 3.536671,
+     "end_time": "2026-07-01T03:28:23.154776",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:19.618105",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -298,107 +314,165 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Constituants (CONST) : 74\r\n"
+      "Ciqual charge en 2,6s : 74 constituants, 3484 aliments, 3484 avec composition.\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Aliments    (ALIM)   : 3484\r\n"
+      "Constituants contraints (C=5) :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Compositions (COMPO) : 257816\r\n"
+      "   [327] Energie, Règlement UE N° 1169/2011 (kJ/100 g)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
+      "   [25000] Protéines, N x facteur de Jones (g/100 g)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exemple d'aliment :  Pastis  (code 1000)\r\n"
+      "   [31000] Glucides (g/100 g)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   [40000] Lipides (g/100 g)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   [10004] Sel chlorure de sodium (g/100 g)\r\n"
      ]
     }
    ],
    "source": [
-    "using System.Xml.Linq;\n",
+    "// ---- Ciqual : lecture en flux, sous-ensemble des constituants contraints ----\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "string[] WANTED = { \"Energie, Règlement\", \"Protéines, N x\", \"Glucides (g\", \"Lipides (g\", \"Sel chlorure\" };\n",
     "\n",
-    "// --- POCOs Ciqual (memes champs que Ciqual.cs, peuples par LINQ-to-XML) ---\n",
-    "// Note : XmlSerializer ne fonctionne pas sur des types definis dans une cellule .NET Interactive\n",
-    "// (l'assembly de serialisation generee bute sur les noms 'Submission#N', non CLS-compliant).\n",
-    "// On parse donc avec XDocument (LINQ-to-XML) : le pipeline de fusion en aval est inchange.\n",
-    "public class CConst { public uint const_code; public string const_nom_fr; public string const_nom_eng; }\n",
-    "public class CAlim  { public uint alim_code;  public string alim_nom_fr;  public string alim_nom_eng;  }\n",
-    "public class CCompo { public uint alim_code;  public uint const_code;      public string teneur;        }\n",
-    "\n",
-    "public class TableConstituant { public CConst[] CONST { get; set; } }\n",
-    "public class TableAliments    { public CAlim[]  ALIM  { get; set; } }\n",
-    "public class TableComposition { public CCompo[] COMPO { get; set; } }\n",
-    "\n",
-    "public class Ciqual\n",
+    "var consts = new Dictionary<string, string>();               // const_code -> nom FR\n",
+    "using (var rd = XmlReader.Create(Path.Combine(BASE, \"Ciqual/const_2025_11_03.xml\")))\n",
     "{\n",
-    "    public TableConstituant Constituants { get; set; }\n",
-    "    public TableAliments Aliments { get; set; }\n",
-    "    public TableComposition Compositions { get; set; }\n",
-    "\n",
-    "    static string Txt(XElement e, string n) => (string)e.Element(n);          // texte brut (espaces preserves, comme la source)\n",
-    "    static uint   U  (XElement e, string n) => uint.Parse(((string)e.Element(n)).Trim());\n",
-    "\n",
-    "    public static Ciqual Load(string folderPath)\n",
+    "    string code = null, fr = null, field = null;\n",
+    "    while (rd.Read())\n",
     "    {\n",
-    "        var constDoc = XDocument.Load(Path.Combine(folderPath, \"const_2025_11_03.xml\"));\n",
-    "        var alimDoc  = XDocument.Load(Path.Combine(folderPath, \"alim_2025_11_03.xml\"));\n",
-    "        var compoDoc = XDocument.Load(Path.Combine(folderPath, \"compo_2025_11_03.xml\")); // ~69 Mo\n",
-    "        return new Ciqual\n",
-    "        {\n",
-    "            Constituants = new TableConstituant { CONST = constDoc.Root.Elements(\"CONST\")\n",
-    "                .Select(e => new CConst { const_code = U(e, \"const_code\"), const_nom_fr = Txt(e, \"const_nom_fr\"), const_nom_eng = Txt(e, \"const_nom_eng\") }).ToArray() },\n",
-    "            Aliments = new TableAliments { ALIM = alimDoc.Root.Elements(\"ALIM\")\n",
-    "                .Select(e => new CAlim { alim_code = U(e, \"alim_code\"), alim_nom_fr = Txt(e, \"alim_nom_fr\"), alim_nom_eng = Txt(e, \"alim_nom_eng\") }).ToArray() },\n",
-    "            Compositions = new TableComposition { COMPO = compoDoc.Root.Elements(\"COMPO\")\n",
-    "                .Select(e => new CCompo { alim_code = U(e, \"alim_code\"), const_code = U(e, \"const_code\"), teneur = Txt(e, \"teneur\") }).ToArray() },\n",
-    "        };\n",
+    "        if (rd.NodeType == XmlNodeType.Element) { if (rd.Name == \"CONST\") { code = fr = null; } field = rd.Name; }\n",
+    "        else if (rd.NodeType == XmlNodeType.Text) { if (field == \"const_code\") code = rd.Value.Trim(); else if (field == \"const_nom_fr\") fr = rd.Value.Trim(); }\n",
+    "        else if (rd.NodeType == XmlNodeType.EndElement && rd.Name == \"CONST\") { if (code != null) consts[code] = fr ?? \"\"; }\n",
+    "    }\n",
+    "}\n",
+    "var chosenCodes = WANTED.Select(w => consts.First(c => c.Value.StartsWith(w.Substring(0, Math.Min(18, w.Length)))).Key).ToList();\n",
+    "var codeIdx = chosenCodes.Select((c, i) => (c, i)).ToDictionary(x => x.c, x => x.i);\n",
+    "int C = chosenCodes.Count;\n",
+    "\n",
+    "var alimEng = new Dictionary<string, string>();              // alim_code -> nom anglais\n",
+    "using (var rd = XmlReader.Create(Path.Combine(BASE, \"Ciqual/alim_2025_11_03.xml\")))\n",
+    "{\n",
+    "    string code = null, eng = null, field = null;\n",
+    "    while (rd.Read())\n",
+    "    {\n",
+    "        if (rd.NodeType == XmlNodeType.Element) { if (rd.Name == \"ALIM\") { code = eng = null; } field = rd.Name; }\n",
+    "        else if (rd.NodeType == XmlNodeType.Text) { if (field == \"alim_code\") code = rd.Value.Trim(); else if (field == \"alim_nom_eng\") eng = rd.Value.Trim(); }\n",
+    "        else if (rd.NodeType == XmlNodeType.EndElement && rd.Name == \"ALIM\") { if (code != null) alimEng[code] = eng ?? \"\"; }\n",
     "    }\n",
     "}\n",
     "\n",
-    "var ciqual = Ciqual.Load(ciqualDir);\n",
-    "Console.WriteLine($\"Constituants (CONST) : {ciqual.Constituants.CONST.Length}\");\n",
-    "Console.WriteLine($\"Aliments    (ALIM)   : {ciqual.Aliments.ALIM.Length}\");\n",
-    "Console.WriteLine($\"Compositions (COMPO) : {ciqual.Compositions.COMPO.Length}\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Exemple d'aliment : \" + ciqual.Aliments.ALIM[0].alim_nom_fr\n",
-    "    + \" (code \" + ciqual.Aliments.ALIM[0].alim_code + \")\");\n"
+    "decimal ParseTeneur(string s)\n",
+    "{\n",
+    "    if (s == null) return 0m;\n",
+    "    s = s.Replace(\"traces\", \"0\").Replace(\"<\", \" \").Replace(\"-\", \"0\").Replace(\",\", \".\").Trim();   // Ciqual : decimale FR + qualificatifs\n",
+    "    return decimal.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d) ? d : 0m;\n",
+    "}\n",
+    "var alimCompo = new Dictionary<string, decimal[]>();          // alim_code -> teneurs sur les constituants choisis\n",
+    "using (var rd = XmlReader.Create(Path.Combine(BASE, \"Ciqual/compo_2025_11_03.xml\")))\n",
+    "{\n",
+    "    string ac = null, cc = null, te = null, field = null;\n",
+    "    while (rd.Read())\n",
+    "    {\n",
+    "        if (rd.NodeType == XmlNodeType.Element) { if (rd.Name == \"COMPO\") { ac = cc = te = null; } field = rd.Name; }\n",
+    "        else if (rd.NodeType == XmlNodeType.Text)\n",
+    "        {\n",
+    "            if (field == \"alim_code\") ac = rd.Value.Trim();\n",
+    "            else if (field == \"const_code\") cc = rd.Value.Trim();\n",
+    "            else if (field == \"teneur\") te = rd.Value;\n",
+    "        }\n",
+    "        else if (rd.NodeType == XmlNodeType.EndElement && rd.Name == \"COMPO\")\n",
+    "        {\n",
+    "            if (cc != null && ac != null && codeIdx.ContainsKey(cc))\n",
+    "            {\n",
+    "                if (!alimCompo.TryGetValue(ac, out var v)) { v = new decimal[C]; alimCompo[ac] = v; }\n",
+    "                v[codeIdx[cc]] = ParseTeneur(te);\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "Console.WriteLine($\"Ciqual charge en {sw.Elapsed.TotalSeconds:F1}s : {consts.Count} constituants, {alimEng.Count} aliments, {alimCompo.Count} avec composition.\");\n",
+    "Console.WriteLine($\"Constituants contraints (C={C}) :\");\n",
+    "foreach (var cc in chosenCodes) Console.WriteLine($\"   [{cc}] {consts[cc].Substring(0, Math.Min(48, consts[cc].Length))}\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f19a9196",
+   "id": "9fc8a97c",
    "metadata": {
+    "papermill": {
+     "duration": 0.00825,
+     "end_time": "2026-07-01T03:28:23.171647",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:23.163397",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "## 2. Charger les Recettes (OpenData cantine) via JSON\n",
+    "## 3. La jointure de data fusion : ingrédient anglais → aliment Ciqual\n",
     "\n",
-    "Trois fichiers : `denrees*` (ingredients bruts), `plats*` (recettes), `menus*` (qui ordonne les plats\n",
-    "par creneau `ordre_plat`). On reproduit `Recettes.Load` : `Newtonsoft.Json`, et le repli `libelle_denree`\n",
-    "<- `libelle_recette` quand le libelle de denree est vide (exactement comme la source).\n"
+    "RecipeML est en **anglais** ; on matche donc contre `alim_nom_eng` (100 % renseigné en 2025), pas `alim_nom_fr` — **même langue des deux côtés**, la leçon de rapprochement survit sans pénalité de traduction. Un **index inversé** mot → aliments accélère la recherche : chaque ingrédient n'est comparé qu'aux aliments partageant au moins un mot (au lieu des ~3500). Sans cet index, la jointure serait quadratique.\n",
+    "\n",
+    "> **La normalisation *étagée* est la leçon — et la curation tue les faux positifs.** Un sac-de-mots *positionnel* naïf apparie « **White sugar** » → « **White pudding** » (les deux commencent par « white ») : faux positif classique. La correction, ci-dessous, est une petite pile de **règles métier explicables** :\n",
+    ">\n",
+    "> 1. **déaccentuation** + singularisation grossière + suppression des mots de préparation/qualificatifs (`chopped`, `large`, `fresh`…) ;\n",
+    "> 2. **aliment primaire** = ce qui précède la 1re virgule côté Ciqual (`Sugar, white` → tête = `sugar`) ;\n",
+    "> 3. **garde sur la tête-de-nom** : l'aliment candidat doit partager le **dernier mot** de l'ingrédient (le nom, pas l'adjectif) — c'est ce qui écarte « White pudding » pour « white **sugar** » ;\n",
+    "> 4. **similarité de Jaccard** (recouvrement d'ensembles, seuil 0,5), départage par nom Ciqual **le plus court** (le plus primaire) ;\n",
+    "> 5. petites tables de **synonymes** (`catsup`→`ketchup`, `baking soda`→`sodium bicarbonate`), de **composés** (`salt pepper`→ deux aliments) et de **modificateurs de forme** (`chili powder`→`chili`).\n",
+    ">\n",
+    "> Ce qui subsiste (rappel manquant, synonymes non couverts) est exactement la **matière des exercices**. Mesuré sur l'archive : couverture par occurrence ~72 % **sans faux positif** (contre ~79 % naïf mais truffé de faux positifs)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9b76e8eb",
+   "id": "fb9c15eb",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:23.191310Z",
+     "iopub.status.busy": "2026-07-01T03:28:23.191310Z",
+     "iopub.status.idle": "2026-07-01T03:28:23.843679Z",
+     "shell.execute_reply": "2026-07-01T03:28:23.843679Z"
+    },
+    "papermill": {
+     "duration": 0.664154,
+     "end_time": "2026-07-01T03:28:23.844810",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:23.180656",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -406,112 +480,219 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Denrees : 698\r\n"
+      "Demonstration du matcheur cure sur quelques items RecipeML :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Plats   : 493\r\n"
+      "   'White sugar       ' -> Sugar, white\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Menus   : 1089\r\n"
+      "   'All-purpose flour ' -> Wheat flour, type 110\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
+      "   'Baking soda       ' -> Sodium bicarbonate\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exemple de denree (libelle brut de cantine) : POIVRE GRIS MOULU K\r\n"
+      "   'Eggs              ' -> Egg, raw\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   'Butter            ' -> Butter, 80% fat minimum, unsalted\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   'Olive oil         ' -> Olive oil, extra virgin\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   'Salt pepper       ' -> Salt, white (sea, igneous or rock), no fortification\r\n"
      ]
     }
    ],
    "source": [
-    "// --- POCOs Recettes (fideles a Recettes.cs) ---\n",
-    "public class DenreeRecord { public Fields fields { get; set; }\n",
-    "    public class Fields { public string libelle_recette { get; set; } public string code_recette { get; set; } public string libelle_denree { get; set; } } }\n",
-    "public class PlatRecord { public Fields fields { get; set; }\n",
-    "    public class Fields { public string code_recette { get; set; } public string code_plat { get; set; } public string libelle_plat { get; set; } } }\n",
-    "public class MenuRecord { public Fields fields { get; set; }\n",
-    "    public class Fields { public string code_plat { get; set; } public int ordre_plat { get; set; } public string libelle_plat { get; set; } } }\n",
+    "// ---- rapprochement lexical CURÉ : normalisation étagée + index inversé + garde tête-de-nom ----\n",
+    "// Un sac-de-mots positionnel naïf matcherait « White sugar » -> « White pudding » (les deux\n",
+    "// commencent par « white ») : faux positif. La CURATION ci-dessous -- déaccentuation, aliment\n",
+    "// primaire (avant la 1re virgule côté Ciqual), garde sur la tête-de-nom, préférence au nom le\n",
+    "// plus court, petites tables de synonymes / composés / modificateurs -- élimine ces faux positifs.\n",
     "\n",
-    "public class Recettes\n",
-    "{\n",
-    "    public List<DenreeRecord> Denrees { get; set; } = new();\n",
-    "    public List<PlatRecord> Plats { get; set; } = new();\n",
-    "    public List<MenuRecord> Menus { get; set; } = new();\n",
+    "// mots à retirer (préparation, qualificatifs, mots vides) : bruit qui masque l'aliment\n",
+    "var DROP = new HashSet<string>(\n",
+    "    (\"chopped ground grated minced sliced diced melted softened packed sifted beaten cooked raw \" +\n",
+    "     \"peeled seeded finely coarsely halved quartered cubed shredded crushed crumbled drained rinsed \" +\n",
+    "     \"lightly thinly thickly cut divided fresh dried frozen canned chilled warmed uncooked prepared \" +\n",
+    "     \"unbaked mashed toasted roasted boiled steamed blanched julienned trimmed cored pitted stemmed deveined \" +\n",
+    "     \"large small medium extra whole ripe boneless skinless unsalted salted lean heavy light dark \" +\n",
+    "     \"granulated powdered confectioners all purpose self rising active instant fine coarse \" +\n",
+    "     \"of to for the with and or into pieces piece plus taste needed garnish optional about each more \" +\n",
+    "     \"as in at room temperature degrees inch thick thin long your favorite good quality such other any some few several\")\n",
+    "    .Split(' ', StringSplitOptions.RemoveEmptyEntries));\n",
     "\n",
-    "    public static Recettes Load(string folderPath)\n",
-    "    {\n",
-    "        var r = new Recettes();\n",
-    "        var ser = new JsonSerializer();\n",
-    "        List<T> ReadAll<T>(string pattern)\n",
-    "        {\n",
-    "            var acc = new List<T>();\n",
-    "            foreach (var f in Directory.GetFiles(folderPath, pattern))\n",
-    "            {\n",
-    "                using var reader = File.OpenText(f);\n",
-    "                using var jr = new JsonTextReader(reader);\n",
-    "                acc.AddRange(ser.Deserialize<List<T>>(jr));\n",
-    "            }\n",
-    "            return acc;\n",
-    "        }\n",
-    "        r.Denrees = ReadAll<DenreeRecord>(\"denrees*\");\n",
-    "        foreach (var d in r.Denrees)\n",
-    "            if (string.IsNullOrEmpty(d.fields.libelle_denree)) d.fields.libelle_denree = d.fields.libelle_recette;\n",
-    "        r.Plats = ReadAll<PlatRecord>(\"plats*\");\n",
-    "        r.Menus = ReadAll<MenuRecord>(\"menus*\");\n",
-    "        return r;\n",
+    "// synonymes US/culinaire -> vocabulaire Ciqual (clé = item normalisé complet) : la couche « métier »\n",
+    "var SYN = new Dictionary<string, string> {\n",
+    "    [\"catsup\"] = \"ketchup\", [\"scallion\"] = \"green onion\", [\"cilantro\"] = \"coriander\",\n",
+    "    [\"cornstarch\"] = \"corn starch\", [\"shortening\"] = \"vegetable fat\", [\"baking soda\"] = \"sodium bicarbonate\",\n",
+    "    [\"confectioner sugar\"] = \"icing sugar\", [\"powdered sugar\"] = \"icing sugar\", [\"bell pepper\"] = \"sweet pepper\",\n",
+    "    [\"heavy cream\"] = \"cream\", [\"whipping cream\"] = \"cream\", [\"vanilla extract\"] = \"vanilla\",\n",
+    "    [\"lemon rind\"] = \"lemon zest\", [\"lemon peel\"] = \"lemon zest\",\n",
+    "};\n",
+    "// composés = deux aliments joints par un « and/or » tombé (chacun matché séparément, puis on garde le 1er)\n",
+    "var COMPOUND = new Dictionary<string, string[]> {\n",
+    "    [\"salt pepper\"] = new[] { \"salt\", \"pepper\" }, [\"butter margarine\"] = new[] { \"butter\", \"margarine\" },\n",
+    "    [\"salt black pepper\"] = new[] { \"salt\", \"black pepper\" }, [\"oil butter\"] = new[] { \"oil\", \"butter\" },\n",
+    "};\n",
+    "\n",
+    "string Deaccent(string s) {\n",
+    "    var n = s.Normalize(NormalizationForm.FormD);\n",
+    "    var sb = new StringBuilder();\n",
+    "    foreach (var ch in n) if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark) sb.Append(ch);\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "string Singular(string t) {\n",
+    "    if (t.EndsWith(\"ies\") && t.Length > 4) return t.Substring(0, t.Length - 3) + \"y\";\n",
+    "    if (t.EndsWith(\"oes\") && t.Length > 4) return t.Substring(0, t.Length - 2);\n",
+    "    if (t.EndsWith(\"s\") && !t.EndsWith(\"ss\") && t.Length > 3) return t.Substring(0, t.Length - 1);\n",
+    "    return t;\n",
+    "}\n",
+    "List<string> Norm(string s) {\n",
+    "    s = Deaccent((s ?? \"\").ToLowerInvariant());\n",
+    "    s = Regex.Replace(s, @\"\\([^)]*\\)\", \" \");                 // retire les parenthèses : (19-oz)\n",
+    "    s = s.Split(',')[0];                                     // aliment primaire = avant la 1re virgule\n",
+    "    s = Regex.Replace(s, \"[^a-z\\\\s-]\", \" \").Replace(\"-\", \" \");\n",
+    "    var o = new List<string>();\n",
+    "    foreach (var w in s.Split(' ', StringSplitOptions.RemoveEmptyEntries)) {\n",
+    "        if (w.Length <= 1 || DROP.Contains(w)) continue;\n",
+    "        var t = Singular(w);\n",
+    "        if (t.Length > 0) o.Add(t);\n",
     "    }\n",
+    "    return o;\n",
     "}\n",
     "\n",
-    "var recettes = Recettes.Load(recettesDir);\n",
-    "Console.WriteLine($\"Denrees : {recettes.Denrees.Count}\");\n",
-    "Console.WriteLine($\"Plats   : {recettes.Plats.Count}\");\n",
-    "Console.WriteLine($\"Menus   : {recettes.Menus.Count}\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Exemple de denree (libelle brut de cantine) : \" + recettes.Denrees[0].fields.libelle_denree);\n"
+    "// index Ciqual : (code, jeu de tokens, tête-de-nom, premier mot) sur le nom EN\n",
+    "var ents = alimCompo.Keys.Where(k => alimEng.ContainsKey(k) && alimEng[k].Length > 0)\n",
+    "    .Select(k => { var t = Norm(alimEng[k]); return (code: k, toks: new HashSet<string>(t),\n",
+    "                   head: t.Count > 0 ? t[t.Count - 1] : \"\", first: t.Count > 0 ? t[0] : \"\"); })\n",
+    "    .Where(e => e.toks.Count > 0).ToList();\n",
+    "var byTok = new Dictionary<string, List<int>>();             // mot -> indices d'aliments (index inversé)\n",
+    "for (int e = 0; e < ents.Count; e++)\n",
+    "    foreach (var t in ents[e].toks) {\n",
+    "        if (!byTok.TryGetValue(t, out var l)) { l = new List<int>(); byTok[t] = l; }\n",
+    "        l.Add(e);\n",
+    "    }\n",
+    "double Jacc(HashSet<string> a, HashSet<string> b) {\n",
+    "    if (a.Count == 0 || b.Count == 0) return 0;\n",
+    "    int inter = a.Count(x => b.Contains(x));\n",
+    "    return (double)inter / (a.Count + b.Count - inter);\n",
+    "}\n",
+    "\n",
+    "// coeur : clé normalisée -> code Ciqual (garde tête-de-nom, rang jaccard puis nom le plus court, seuil 0.5)\n",
+    "string MatchKey(string key) {\n",
+    "    if (SYN.TryGetValue(key, out var syn)) key = string.Join(\" \", Norm(syn));\n",
+    "    var toks = key.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();\n",
+    "    if (toks.Count > 1 && (toks[toks.Count - 1] == \"powder\" || toks[toks.Count - 1] == \"extract\"\n",
+    "        || toks[toks.Count - 1] == \"root\") && key != \"baking powder\")\n",
+    "        toks = toks.Take(toks.Count - 1).ToList();           // retire un modificateur de forme final\n",
+    "    if (toks.Count == 0) return null;\n",
+    "    var it = new HashSet<string>(toks);\n",
+    "    var head = toks[toks.Count - 1];\n",
+    "    var cand = new HashSet<int>();\n",
+    "    foreach (var t in it) if (byTok.TryGetValue(t, out var l)) foreach (var e in l) cand.Add(e);\n",
+    "    string best = null; double bj = 0; int bfb = 0, bnl = 0; bool has = false;\n",
+    "    foreach (var e in cand) {\n",
+    "        if (!ents[e].toks.Contains(head)) continue;          // garde : l'aliment partage la tête-de-nom\n",
+    "        double j = Jacc(it, ents[e].toks);\n",
+    "        if (j < 0.5) continue;\n",
+    "        int fb = ents[e].first == head ? 1 : 0;              // bonus : l'aliment Ciqual COMMENCE par la tête\n",
+    "        int nl = -ents[e].toks.Count;                        // préférer le nom le plus court (plus primaire)\n",
+    "        if (!has || j > bj + 1e-9 || (Math.Abs(j - bj) < 1e-9 && (fb > bfb || (fb == bfb && nl > bnl)))) {\n",
+    "            bj = j; bfb = fb; bnl = nl; best = ents[e].code; has = true;\n",
+    "        }\n",
+    "    }\n",
+    "    return best;\n",
+    "}\n",
+    "var matchCache = new Dictionary<string, string>();\n",
+    "string Match(string item) {                                  // surface publique : item brut -> code Ciqual\n",
+    "    var key = string.Join(\" \", Norm(item.Split(';')[0]));\n",
+    "    if (key.Length == 0) return null;\n",
+    "    if (matchCache.TryGetValue(key, out var c)) return c;\n",
+    "    string code;\n",
+    "    if (COMPOUND.TryGetValue(key, out var parts)) code = MatchKey(string.Join(\" \", Norm(parts[0]))); // composé : 1er aliment\n",
+    "    else code = MatchKey(key);\n",
+    "    matchCache[key] = code;\n",
+    "    return code;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Demonstration du matcheur cure sur quelques items RecipeML :\");\n",
+    "foreach (var t in new[] { \"White sugar\", \"All-purpose flour\", \"Baking soda\", \"Eggs\", \"Butter\", \"Olive oil\", \"Salt pepper\" })\n",
+    "{\n",
+    "    var mcode = Match(t);\n",
+    "    Console.WriteLine($\"   '{t,-18}' -> {(mcode != null ? alimEng[mcode] : \"(aucun)\")}\");\n",
+    "}\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6804b7f2",
+   "id": "82d5c0f2",
    "metadata": {
+    "papermill": {
+     "duration": 0.008945,
+     "end_time": "2026-07-01T03:28:23.862670",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:23.853725",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "## 3. Le matcheur lexical flou `CalculeProximiteLexicale`\n",
+    "## 4. RecipeML : parsing structuré **avec quantités**\n",
     "\n",
-    "Le coeur du port. Les denrees de cantine (`POIVRE GRIS MOULU K`, `EMMENTHAL RAPE/KG+`) n'ont **aucune cle**\n",
-    "vers Ciqual (`Poivre noir`, `Emmental`). Le Demo2 les rapproche par un score **sac-de-mots** :\n",
+    "Chaque `<recipe>` porte des `<ing>` de forme `<amt><qty>…</qty><unit>…</unit></amt><item>…</item>`. On extrait le **triplet (item, quantité, unité)** — c'est la différence décisive avec l'ébauche `05e`, qui ne lisait que `<item>` et ignorait la masse.\n",
     "\n",
-    "1. `CreateSimpleList` normalise chaque chaine : majuscules, suppression des non-alphanumeriques, puis\n",
-    "   **troncature des suffixes** `S` puis `E` (pluriels / feminins grossiers), mots de longueur > 1 conserves.\n",
-    "2. `CalculeProximiteLexicale` somme, pour chaque mot de `s2` retrouve dans `s1`, un poids\n",
-    "   `1 / (2*(idx + position) + 1)` qui **decroit** avec la position du mot — un mot commun en tete pese plus\n",
-    "   qu'un mot commun en fin. Un petit malus `-(|bag1| + |bag2|)/1000` departage les chaines courtes.\n",
-    "\n",
-    "C'est volontairement simple (pas de Levenshtein, pas de TF-IDF) : l'interet pedagogique est de voir un\n",
-    "**heuristique d'appariement** se brancher dans un pipeline LINQ declaratif.\n"
+    "`ParseQty` gère les entiers, les **fractions** (`1/2`), les **quantités mixtes** (`1 1/2`), les fractions Unicode (`½`) et prend la borne basse d'une fourchette (`2-3` → `2`). Le parsing XML est **tolérant** (certains fichiers ont des `&` nus) : on retombe sur un remplacement `& → &amp;` avant d'abandonner un fichier."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8e6ed5d5",
+   "id": "64ba09d6",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:23.883645Z",
+     "iopub.status.busy": "2026-07-01T03:28:23.883645Z",
+     "iopub.status.idle": "2026-07-01T03:28:26.240669Z",
+     "shell.execute_reply": "2026-07-01T03:28:26.240669Z"
+    },
+    "papermill": {
+     "duration": 2.370161,
+     "end_time": "2026-07-01T03:28:26.241669",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:23.871508",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -519,96 +700,155 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  prox(Sucre blanc                , SUCRE SEMOULE 1KG       ) = 0,9950\r\n"
+      "RecipeML : 5215 recettes, 49565 ingredients (90% avec quantite, 76% avec unite), 21 fichiers XML irrecuperables ignores.\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  prox(Boeuf braise               , SUCRE SEMOULE 1KG       ) = -0,0050\r\n"
+      "Exemple de recette (item | qty | unite) :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  prox(Tomate, pulpe              , TOMATES CONCASSEES 5/1  ) = 0,9950\r\n"
+      "   (19-oz) crushed pineapple with juice   |     1 | can\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  prox(Emmental                   , EMMENTHAL RAPE/KG+      ) = -0,0030\r\n"
+      "   White sugar                            |     2 | cups\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Eggs                                   |     2 | \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Flour                                  |     2 | cups\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Baking soda                            |     2 | teaspoons\r\n"
      ]
     }
    ],
    "source": [
-    "static List<string> CreateSimpleList(string s)\n",
+    "// ---- ParseQty : quantite textuelle -> nombre (fractions, mixtes, unicode, fourchettes) ----\n",
+    "double ParseQty(string s)\n",
     "{\n",
-    "    var toReturn = new List<string>();\n",
-    "    foreach (var mot in s.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))\n",
+    "    if (string.IsNullOrWhiteSpace(s)) return 0;\n",
+    "    s = s.Trim().Replace(\"½\", \"1/2\").Replace(\"¼\", \"1/4\").Replace(\"¾\", \"3/4\")\n",
+    "         .Replace(\"⅓\", \"1/3\").Replace(\"⅔\", \"2/3\");\n",
+    "    int dash = s.IndexOf('-'); if (dash > 0) s = s.Substring(0, dash);           // fourchette -> borne basse\n",
+    "    double total = 0; bool any = false;\n",
+    "    foreach (var tok in s.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))\n",
     "    {\n",
-    "        var m = Regex.Replace(mot.ToUpperInvariant(), @\"\\W\", \"\");\n",
-    "        m = m.TrimEnd('S').TrimEnd('E');\n",
-    "        if (m.Length > 1) toReturn.Add(m);\n",
+    "        if (tok.Contains('/'))\n",
+    "        {\n",
+    "            var pr = tok.Split('/');\n",
+    "            if (pr.Length == 2 && double.TryParse(pr[0], NumberStyles.Any, CultureInfo.InvariantCulture, out var a)\n",
+    "                && double.TryParse(pr[1], NumberStyles.Any, CultureInfo.InvariantCulture, out var b) && b != 0)\n",
+    "            { total += a / b; any = true; }\n",
+    "        }\n",
+    "        else if (double.TryParse(tok, NumberStyles.Any, CultureInfo.InvariantCulture, out var d)) { total += d; any = true; }\n",
     "    }\n",
-    "    return toReturn;\n",
+    "    return any ? total : 0;\n",
     "}\n",
     "\n",
-    "static double CalculeProximiteLexicale(string s1, string s2)\n",
+    "// ---- parsing de l'archive : liste (item, qty, unit) par recette ----\n",
+    "var recipes = new List<(string title, List<string> cats, List<(string item, double qty, string unit)> ings)>();\n",
+    "int skipped = 0, nIng = 0, nQty = 0, nUnit = 0;\n",
+    "foreach (var f in Directory.GetFiles(Path.Combine(BASE, \"RecipeML\"), \"*.xml\", SearchOption.AllDirectories))\n",
     "{\n",
-    "    var bag1 = CreateSimpleList(s1);\n",
-    "    var bag2 = CreateSimpleList(s2);\n",
-    "    var toReturn = 0d;\n",
-    "    for (var wi = 0; wi < bag2.Count; wi++)\n",
+    "    System.Xml.Linq.XDocument doc;\n",
+    "    try { doc = System.Xml.Linq.XDocument.Load(f); }\n",
+    "    catch { try { doc = System.Xml.Linq.XDocument.Parse(File.ReadAllText(f).Replace(\"&\", \"&amp;\")); } catch { skipped++; continue; } }\n",
+    "    var title = doc.Descendants(\"title\").FirstOrDefault(x => x.Value.Trim().Length > 0)?.Value.Trim()\n",
+    "                ?? Path.GetFileNameWithoutExtension(f);\n",
+    "    var cats = doc.Descendants(\"cat\").Select(x => x.Value.Trim()).Where(x => x.Length > 0).ToList();\n",
+    "    var ings = new List<(string, double, string)>();\n",
+    "    foreach (var ing in doc.Descendants(\"ing\"))\n",
     "    {\n",
-    "        var idx = bag1.IndexOf(bag2[wi]);\n",
-    "        if (idx > -1) toReturn += 1.0 / (2.0 * (idx + wi) + 1.0);\n",
+    "        var item = ing.Element(\"item\")?.Value.Trim();\n",
+    "        if (string.IsNullOrEmpty(item)) continue;\n",
+    "        nIng++;\n",
+    "        double qty = 0; string unit = \"\";\n",
+    "        var amt = ing.Element(\"amt\");\n",
+    "        if (amt != null)\n",
+    "        {\n",
+    "            qty = ParseQty(amt.Element(\"qty\")?.Value);\n",
+    "            unit = (amt.Element(\"unit\")?.Value ?? \"\").Trim().ToLowerInvariant();\n",
+    "        }\n",
+    "        if (qty > 0) nQty++;\n",
+    "        if (unit.Length > 0) nUnit++;\n",
+    "        ings.Add((item, qty, unit));\n",
     "    }\n",
-    "    toReturn -= (bag1.Count + bag2.Count) / 1000.0;\n",
-    "    return toReturn;\n",
+    "    if (ings.Count > 0) recipes.Add((title.Length > 44 ? title.Substring(0, 44) : title, cats, ings));\n",
     "}\n",
-    "\n",
-    "// Demonstration : on score quelques paires (denree de cantine -> aliment Ciqual candidat).\n",
-    "void Demo(string denree, string aliment)\n",
-    "    => Console.WriteLine($\"  prox({aliment,-26} , {denree,-24}) = {CalculeProximiteLexicale(aliment, denree):0.0000}\");\n",
-    "Demo(\"SUCRE SEMOULE 1KG\", \"Sucre blanc\");\n",
-    "Demo(\"SUCRE SEMOULE 1KG\", \"Boeuf braise\");\n",
-    "Demo(\"TOMATES CONCASSEES 5/1\", \"Tomate, pulpe\");\n",
-    "Demo(\"EMMENTHAL RAPE/KG+\", \"Emmental\");\n"
+    "Console.WriteLine($\"RecipeML : {recipes.Count} recettes, {nIng} ingredients \" +\n",
+    "    $\"({100.0 * nQty / Math.Max(1, nIng):F0}% avec quantite, {100.0 * nUnit / Math.Max(1, nIng):F0}% avec unite), \" +\n",
+    "    $\"{skipped} fichiers XML irrecuperables ignores.\");\n",
+    "Console.WriteLine(\"Exemple de recette (item | qty | unite) :\");\n",
+    "foreach (var (it, q, u) in recipes[0].ings.Take(5)) Console.WriteLine($\"   {it,-38} | {q,5} | {u}\");\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "55be0fcf",
+   "id": "5e4bdd44",
    "metadata": {
+    "papermill": {
+     "duration": 0.009069,
+     "end_time": "2026-07-01T03:28:26.260901",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:26.251832",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "## 4. `Dietetique.Load` : les deux jointures + le matching + l'agregation `Zip`\n",
+    "## 5. Normalisation quantité → grammes (le show-stopper résolu)\n",
     "\n",
-    "On assemble maintenant le pipeline complet, **fidele a la source**. Les etapes, dans l'ordre :\n",
+    "Ciqual **ne fournit pas** de densité (74 constituants = tous des teneurs par 100 g). Le passage `(qté, unité, ingrédient) → grammes` se fait en **deux couches honnêtes** :\n",
     "\n",
-    "1. **Constituants** : projection de `CONST` sur son seul `const_nom_fr`.\n",
-    "2. **`constituantsAliments`** : pour **chaque** constituant, deux jointures `CONST ⋈ COMPO ⋈ ALIM`\n",
-    "   donnent le tableau des `(NomAliment, Teneur)` de teneur > 0. La teneur est nettoyee comme la source\n",
-    "   (`traces`->0, `<`->espace, `-`->0, culture `fr` pour la virgule decimale).\n",
-    "3. **`matchingMots`** : chaque denree distincte est appariee a l'aliment de **proximite lexicale maximale**.\n",
-    "4. **`Denrees`** : chaque denree matchee recoit le vecteur de teneurs (une valeur par constituant).\n",
-    "5. **`Plats`** : `Plats ⋈ Menus` (pour l'`ordre_plat`), puis `GroupJoin` avec les denrees du plat ; la\n",
-    "   composition d'un plat est l'**agregation `Zip`** (somme terme a terme) des compositions de ses denrees.\n",
+    "1. **unité → millilitres (volumes) ou grammes (masses)** : une petite table fixe (`cup` = 236,6 mL, `tablespoon` = 14,8 mL, `teaspoon` = 4,93 mL, `ounce` = 28,35 g, `pound` = 453,6 g…).\n",
+    "2. **millilitres → grammes** : une petite **table de densités** curée par mot-clé d'ingrédient (farine ≈ 0,53, sucre ≈ 0,85, huile ≈ 0,92, miel ≈ 1,42, eau/aqueux = 1,0 par défaut).\n",
+    "3. **items comptés** (unité *vide* : `2 Eggs`, `3 Bananas`) → une table de **poids moyen par pièce** par mot-clé (œuf ≈ 50 g, banane ≈ 120 g, gousse ≈ 5 g). Indispensable sur un corpus pâtissier où les œufs abondent.\n",
     "\n",
-    "> Le pipeline tourne en quelques dizaines de secondes (74 constituants x 258 000 compositions + ~200 x 3484\n",
-    "> appariements lexicaux). C'est le cout reel d'une fusion sur donnees brutes — borne et raisonnable.\n"
+    "Les unités **de conditionnement** restantes (`can`, `package`, `slice`…) n'ont pas de conversion fiable → masse **non calculée**. C'est une **étape de préprocessing** — et une bonne leçon de data-engineering — pas un blocage : un ingrédient apparié mais **non pesable** contribue `0` à la nutrition, honnêtement et visiblement dans les métriques (cf. exercice 2 pour élargir la couverture)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "e126229d",
+   "id": "b9415167",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:26.282119Z",
+     "iopub.status.busy": "2026-07-01T03:28:26.282119Z",
+     "iopub.status.idle": "2026-07-01T03:28:26.545488Z",
+     "shell.execute_reply": "2026-07-01T03:28:26.545488Z"
+    },
+    "papermill": {
+     "duration": 0.27606,
+     "end_time": "2026-07-01T03:28:26.546453",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:26.270393",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -616,133 +856,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dietetique.Load defini.\r\n"
+      "   2 cups       white sugar        -> 402,2 g\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2 cups       flour              -> 250,8 g\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   1 teaspoon   vanilla            -> 4,9 g\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   4 ounces     butter             -> 113,4 g\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2 (compte)   eggs               -> 100,0 g\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   1 can        crushed pineapple  -> 0,0 g   (non convertible)\r\n"
      ]
     }
    ],
    "source": [
-    "// --- Types du catalogue (fideles a PlanificateurDeMenus.cs) ---\n",
-    "public class Constituant { public string Nom { get; set; } }\n",
-    "public class DenreeImport { public string Nom { get; set; } = \"\"; public decimal[] Compositions { get; set; } }\n",
-    "public class Ingredient { public int Denree { get; set; } public decimal Quantite { get; set; } }\n",
-    "public class PlatImport { public string Nom { get; set; } public int Ordre { get; set; }\n",
-    "    public List<Ingredient> Ingredients { get; set; } = new(); public decimal[] Compositions { get; set; } }\n",
-    "\n",
-    "public class Dietetique\n",
+    "// ---- unite -> facteur (mL pour volumes, g pour masses) ; absente => non convertible ----\n",
+    "var UNIT = new Dictionary<string, (double factor, bool isMass)>\n",
     "{\n",
-    "    public List<Constituant> Constituants { get; set; }\n",
-    "    public List<DenreeImport> Denrees { get; set; }\n",
-    "    public List<PlatImport> Plats { get; set; }\n",
+    "    [\"cup\"] = (236.588, false), [\"cups\"] = (236.588, false),\n",
+    "    [\"tablespoon\"] = (14.7868, false), [\"tablespoons\"] = (14.7868, false), [\"tbsp\"] = (14.7868, false), [\"tbs\"] = (14.7868, false),\n",
+    "    [\"teaspoon\"] = (4.92892, false), [\"teaspoons\"] = (4.92892, false), [\"tsp\"] = (4.92892, false),\n",
+    "    [\"ounce\"] = (28.3495, true), [\"ounces\"] = (28.3495, true), [\"oz\"] = (28.3495, true),\n",
+    "    [\"pound\"] = (453.592, true), [\"pounds\"] = (453.592, true), [\"lb\"] = (453.592, true), [\"lbs\"] = (453.592, true),\n",
+    "    [\"gram\"] = (1, true), [\"grams\"] = (1, true), [\"g\"] = (1, true), [\"kg\"] = (1000, true), [\"kilogram\"] = (1000, true),\n",
+    "    [\"ml\"] = (1, false), [\"milliliter\"] = (1, false), [\"millilitre\"] = (1, false),\n",
+    "    [\"l\"] = (1000, false), [\"liter\"] = (1000, false), [\"litre\"] = (1000, false),\n",
+    "    [\"pint\"] = (473.176, false), [\"pt\"] = (473.176, false), [\"quart\"] = (946.353, false), [\"qt\"] = (946.353, false),\n",
+    "    [\"gallon\"] = (3785.41, false), [\"gal\"] = (3785.41, false),\n",
+    "    [\"pinch\"] = (0.36, true), [\"dash\"] = (0.6, false), [\"stick\"] = (113.0, true), [\"sticks\"] = (113.0, true),\n",
+    "};\n",
+    "// densite (g/mL) par mot-cle present dans l'item ; defaut 1.0 (eau/aqueux)\n",
+    "var DENS = new (string kw, double d)[]\n",
+    "{\n",
+    "    (\"flour\", 0.53), (\"sugar\", 0.85), (\"oil\", 0.92), (\"butter\", 0.911), (\"honey\", 1.42), (\"syrup\", 1.33),\n",
+    "    (\"milk\", 1.03), (\"cream\", 1.01), (\"water\", 1.0), (\"salt\", 1.22), (\"rice\", 0.85), (\"cocoa\", 0.52),\n",
+    "    (\"cornstarch\", 0.54), (\"oats\", 0.41),\n",
+    "};\n",
+    "double Density(string itemLower) { foreach (var (kw, d) in DENS) if (itemLower.Contains(kw)) return d; return 1.0; }\n",
+    "// items COMPTES (unite vide : \"2 Eggs\", \"3 Bananas\") -> poids moyen par piece, par mot-cle de tete\n",
+    "var COUNT = new (string kw, double g)[]\n",
+    "{\n",
+    "    (\"egg\", 50), (\"banana\", 120), (\"apple\", 180), (\"onion\", 110), (\"clove\", 5), (\"carrot\", 60),\n",
+    "    (\"potato\", 150), (\"tomato\", 120), (\"lemon\", 60), (\"lime\", 45), (\"orange\", 130), (\"garlic\", 5),\n",
+    "    (\"shallot\", 30), (\"scallion\", 15), (\"pepper\", 120),\n",
+    "};\n",
+    "double CountWeight(string itemLower) { foreach (var (kw, g) in COUNT) if (itemLower.Contains(kw)) return g; return 0; }\n",
     "\n",
-    "    public static Dietetique Load(Ciqual ciqual, Recettes recettes)\n",
-    "    {\n",
-    "        var toReturn = new Dietetique();\n",
-    "\n",
-    "        // 1. Liste des constituants (nom seul).\n",
-    "        toReturn.Constituants = ciqual.Constituants.CONST\n",
-    "            .Select(c => new Constituant { Nom = c.const_nom_fr }).ToList();\n",
-    "\n",
-    "        // 2. Deux jointures : par constituant, le tableau des (aliment, teneur>0).\n",
-    "        var fr = new CultureInfo(\"fr\");\n",
-    "        var constituantsAliments = toReturn.Constituants\n",
-    "            .Select(c => ciqual.Constituants.CONST\n",
-    "                .Where(cc => cc.const_nom_fr == c.Nom).ToArray()\n",
-    "                .Join(ciqual.Compositions.COMPO, cc => cc.const_code, compo => compo.const_code,\n",
-    "                    (cc, compo) => new\n",
-    "                    {\n",
-    "                        Teneur = decimal.Parse(compo.teneur.Replace(\"traces\", \"0\")\n",
-    "                            .Replace('<', ' ').Replace('-', '0').Trim(), fr),\n",
-    "                        CodeAlim = compo.alim_code\n",
-    "                    }).ToArray()\n",
-    "                .Join(ciqual.Aliments.ALIM, compo => compo.CodeAlim, alim => alim.alim_code,\n",
-    "                    (compo, alim) => new { NomAliment = alim.alim_nom_fr, compo.Teneur })\n",
-    "                .Where(ca => ca.Teneur > 0)\n",
-    "                .ToArray())\n",
-    "            .ToArray();\n",
-    "\n",
-    "        // 3. Denrees distinctes non vides, appariees a l'aliment de proximite lexicale maximale.\n",
-    "        var denreesFiltered = recettes.Denrees\n",
-    "            .Where(d => !string.IsNullOrEmpty(d.fields.libelle_denree))\n",
-    "            .GroupBy(d => d.fields.libelle_denree).Select(g => g.First()).ToArray();\n",
-    "\n",
-    "        var matchingMots = denreesFiltered\n",
-    "            .Select(d => new\n",
-    "            {\n",
-    "                NomDenree = d.fields.libelle_denree,\n",
-    "                NomAliment = constituantsAliments[0]\n",
-    "                    .OrderByDescending(a => CalculeProximiteLexicale(a.NomAliment, d.fields.libelle_denree))\n",
-    "                    .First().NomAliment,\n",
-    "                Proximite = constituantsAliments[0]\n",
-    "                    .Max(a => CalculeProximiteLexicale(a.NomAliment, d.fields.libelle_denree))\n",
-    "            })\n",
-    "            .Where(m => m.NomAliment != ciqual.Aliments.ALIM[0].alim_nom_fr)\n",
-    "            .ToDictionary(a => a.NomDenree, a => new { Nom = a.NomAliment, a.Proximite });\n",
-    "\n",
-    "        // 4. Vecteur de teneurs par denree matchee (une valeur par constituant).\n",
-    "        toReturn.Denrees = matchingMots\n",
-    "            .Select(d => new DenreeImport\n",
-    "            {\n",
-    "                Nom = d.Key,\n",
-    "                Compositions = constituantsAliments\n",
-    "                    .Select(ca => ca.FirstOrDefault(a => a.NomAliment == matchingMots[d.Key].Nom)?.Teneur ?? 0)\n",
-    "                    .ToArray()\n",
-    "            }).ToList();\n",
-    "\n",
-    "        // 5. Plats : jointure avec Menus (ordre), GroupJoin avec les denrees, composition par agregation Zip.\n",
-    "        var denreesFilteredAvecDoublons = recettes.Denrees\n",
-    "            .Where(d => denreesFiltered.Any(df => df.fields.libelle_denree == d.fields.libelle_denree)).ToArray();\n",
-    "\n",
-    "        var denreesPlats = recettes.Plats\n",
-    "            .Join(recettes.Menus, p => p.fields.code_plat, m => m.fields.code_plat,\n",
-    "                (p, m) => new { Plat = p, Ordre = m.fields.ordre_plat })\n",
-    "            .GroupBy(p => p.Plat.fields.libelle_plat).Select(g => g.First())\n",
-    "            .GroupJoin(denreesFilteredAvecDoublons, p => p.Plat.fields.code_recette, d => d.fields.code_recette,\n",
-    "                (plat, dp) => new { NomPlat = plat.Plat.fields.libelle_plat, Ordre = plat.Ordre, DenreesPlat = dp.ToArray() })\n",
-    "            .Where(p => p.DenreesPlat.Length > 0)\n",
-    "            .ToArray();\n",
-    "\n",
-    "        toReturn.Plats = denreesPlats.Select(pd => new PlatImport\n",
-    "        {\n",
-    "            Nom = pd.NomPlat,\n",
-    "            Ordre = pd.Ordre,\n",
-    "            Ingredients = pd.DenreesPlat.Select(dp => new Ingredient\n",
-    "            {\n",
-    "                Denree = toReturn.Denrees.FindIndex(d => d.Nom == dp.fields.libelle_denree),\n",
-    "                Quantite = 1\n",
-    "            }).Where(i => i.Denree >= 0).ToList(),\n",
-    "            Compositions = toReturn.Denrees\n",
-    "                .Where(denree => pd.DenreesPlat.Any(dp => dp.fields.libelle_denree == denree.Nom))\n",
-    "                .Select(denree => denree.Compositions)\n",
-    "                .Aggregate(new decimal[toReturn.Constituants.Count],\n",
-    "                    (c1, c2) => c1.Zip(c2, (a, b) => a + b).ToArray())\n",
-    "        }).ToList();\n",
-    "\n",
-    "        return toReturn;\n",
-    "    }\n",
+    "// (qty, unite, item) -> grammes ; unite vide => item compte (table COUNT) ; unite inconnue => 0\n",
+    "double ToGrams(double qty, string unit, string itemLower)\n",
+    "{\n",
+    "    if (qty <= 0) return 0;\n",
+    "    if (unit.Length == 0) { double cw = CountWeight(itemLower); return cw > 0 ? qty * cw : 0; }  // \"2 Eggs\" -> 100 g\n",
+    "    if (!UNIT.TryGetValue(unit, out var u)) return 0;                                             // \"1 can\" -> non convertible\n",
+    "    return u.isMass ? qty * u.factor : qty * u.factor * Density(itemLower);\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"Dietetique.Load defini.\");\n"
+    "// demonstration\n",
+    "foreach (var (q, u, it) in new[] { (2.0, \"cups\", \"white sugar\"), (2.0, \"cups\", \"flour\"),\n",
+    "    (1.0, \"teaspoon\", \"vanilla\"), (4.0, \"ounces\", \"butter\"), (2.0, \"\", \"eggs\"), (1.0, \"can\", \"crushed pineapple\") })\n",
+    "    Console.WriteLine($\"   {q} {(u.Length == 0 ? \"(compte)\" : u),-10} {it,-18} -> {ToGrams(q, u, it):F1} g\" +\n",
+    "        (ToGrams(q, u, it) == 0 ? \"   (non convertible)\" : \"\"));\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8f5d3c0c",
+   "id": "1fcfd65f",
    "metadata": {
+    "papermill": {
+     "duration": 0.011772,
+     "end_time": "2026-07-01T03:28:26.568261",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:26.556489",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "## 5. Executer la fusion, explorer le resultat, regenerer le cache\n",
+    "## 6. Agrégation nutritionnelle **pondérée par la masse** + couverture par recette\n",
     "\n",
-    "On lance le pipeline, on inspecte un echantillon, puis on serialise `dietetique.json` **en UTF-8 explicite**.\n",
-    "L'ancien cache du fork souffrait d'un defaut d'encodage (`Magn�esium`) : on **corrige la cause** (lecture\n",
-    "UTF-8 + ecriture UTF-8 sans BOM) plutot que de rafistoler la sortie.\n"
+    "Pour chaque recette : on apparie chaque `item` à Ciqual (section 3), on convertit sa quantité en grammes (section 5), et on ajoute sa contribution `teneur_per_100g × grammes / 100`. C'est la correction du biais *quantity-blind* : un gâteau avec 2 tasses de farine (~250 g) ne compte plus comme 100 g.\n",
+    "\n",
+    "On mesure aussi la **couverture d'appariement** de chaque recette = fraction de ses ingrédients appariés à Ciqual (indépendante des quantités : c'est la qualité des **noms**). Cette couverture est le critère de gating (section 7)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b781b3db",
+   "id": "8aab2456",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:26.593385Z",
+     "iopub.status.busy": "2026-07-01T03:28:26.593385Z",
+     "iopub.status.idle": "2026-07-01T03:28:27.848505Z",
+     "shell.execute_reply": "2026-07-01T03:28:27.847414Z"
+    },
+    "papermill": {
+     "duration": 1.268625,
+     "end_time": "2026-07-01T03:28:27.848505",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:26.579880",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -750,339 +990,456 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Constituants         : 74\r\n"
+      "Agregation : 5215 recettes, couverture moyenne d'appariement = 72,2%\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Denrees matchees     : 198\r\n"
+      "   couverture 100%           :   614 recettes\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Plats (avec denrees) : 138\r\n"
+      "   couverture >=80% (solveur):  2227 recettes\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
+      "   couverture >=50%          :  4701 recettes\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Denrees matchees (8 premieres, energie kJ/100g = constituant 0) :\r\n"
+      "   couverture  <50%          :   514 recettes\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  POIVRE GRIS MOULU K            -> energie     1380 kJ\r\n"
+      "Echantillon 100% apparie (energie kJ, prot g, gluc g, lip g, sel g -- PONDERE par la masse) :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SUCRE SEMOULE 1KG              -> energie     1700 kJ\r\n"
+      "   #10 Cake                                       [25886,9, 69,1, 857,5, 262,3, 1,0]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  TOMATES CONCASSEES 5/1         -> energie      419 kJ\r\n"
+      "   #1 Lemon Bars                                  [11420,5, 39,7, 581,1, 18,1, 0,8]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  EMMENTHAL RAPE/KG+             -> energie     1550 kJ\r\n"
+      "   1,2,3,4 Cake                                   [14159,5, 69,8, 673,2, 34,2, 1,4]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  PDT GRENAILLE 2K               -> energie      559 kJ\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SEL GROS POCHE 1KG             -> energie      204 kJ\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ROUX BLANC 10Kg                -> energie     1670 kJ\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CONCENTRE DE TOMATES  5/1      -> energie      419 kJ\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Plats (5 premiers : creneau ordre_plat / nom / nb ingredients) :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ordre 7 | PETALES DE FRUITS  individuels         | 2 ingredient(s)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ordre 1 | RADIS BEURRE                           | 1 ingredient(s)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ordre 3 | RIZ CAMARGUAIS                         | 8 ingredient(s)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ordre 1 | SAL MELANGE TENDRE                     | 2 ingredient(s)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ordre 5 | ANANAS SIROP MORCEAUX                  | 2 ingredient(s)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Noms contenant U+FFFD (mojibake) : 0\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cache regenere : dietetique.json (448 Ko)\r\n"
+      "   1-1-1 Cookies                                  [9464,4, 54,2, 237,8, 115,7, 2,5]\r\n"
      ]
     }
    ],
    "source": [
-    "var diet = Dietetique.Load(ciqual, recettes);\n",
-    "\n",
-    "Console.WriteLine($\"Constituants         : {diet.Constituants.Count}\");\n",
-    "Console.WriteLine($\"Denrees matchees     : {diet.Denrees.Count}\");\n",
-    "Console.WriteLine($\"Plats (avec denrees) : {diet.Plats.Count}\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Denrees matchees (8 premieres, energie kJ/100g = constituant 0) :\");\n",
-    "foreach (var d in diet.Denrees.Take(8))\n",
-    "    Console.WriteLine($\"  {d.Nom,-30} -> energie {d.Compositions[0],8:0.#} kJ\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Plats (5 premiers : creneau ordre_plat / nom / nb ingredients) :\");\n",
-    "foreach (var p in diet.Plats.Take(5))\n",
-    "    Console.WriteLine($\"  ordre {p.Ordre} | {p.Nom,-38} | {p.Ingredients.Count} ingredient(s)\");\n",
-    "\n",
-    "// Verification anti-mojibake : aucun caractere de remplacement U+FFFD.\n",
-    "int mojibake = diet.Constituants.Count(c => c.Nom.Contains('�'))\n",
-    "             + diet.Denrees.Count(d => d.Nom.Contains('�'))\n",
-    "             + diet.Plats.Count(p => p.Nom.Contains('�'));\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine($\"Noms contenant U+FFFD (mojibake) : {mojibake}\");\n",
-    "\n",
-    "// Cache UTF-8 (artefact runtime, .gitignore).\n",
-    "var savePath = Path.Combine(DataDir, \"dietetique.json\");\n",
-    "File.WriteAllText(savePath, JsonConvert.SerializeObject(diet, Formatting.Indented), new UTF8Encoding(false));\n",
-    "Console.WriteLine($\"Cache regenere : {Path.GetFileName(savePath)} ({new FileInfo(savePath).Length / 1024} Ko)\");\n"
+    "// ---- agregation ponderee + couverture par recette ----\n",
+    "var built = new List<(string title, List<string> cats, decimal[] vec, double cover, int nMatch, int nItems)>();\n",
+    "var mc = new Dictionary<string, string>();   // item -> code Ciqual (cache d'appariement)\n",
+    "foreach (var (title, cats, ings) in recipes)\n",
+    "{\n",
+    "    var vec = new decimal[C];\n",
+    "    int nMatch = 0;\n",
+    "    foreach (var (item, qty, unit) in ings)\n",
+    "    {\n",
+    "        if (!mc.TryGetValue(item, out var acode)) { acode = Match(item); mc[item] = acode; }\n",
+    "        if (acode == null) continue;\n",
+    "        nMatch++;\n",
+    "        if (!alimCompo.TryGetValue(acode, out var cv)) continue;\n",
+    "        double grams = ToGrams(qty, unit, item.ToLowerInvariant());\n",
+    "        if (grams <= 0) continue;                                  // apparie mais non pesable -> 0 nutrition\n",
+    "        for (int k = 0; k < C; k++) vec[k] += cv[k] * (decimal)(grams / 100.0);\n",
+    "    }\n",
+    "    double cover = ings.Count > 0 ? (double)nMatch / ings.Count : 0;\n",
+    "    built.Add((title, cats, vec, cover, nMatch, ings.Count));\n",
+    "}\n",
+    "int N = built.Count;\n",
+    "int b100 = 0, b90 = 0, b80 = 0, b50 = 0, blo = 0; double covSum = 0;\n",
+    "foreach (var r in built)\n",
+    "{\n",
+    "    covSum += r.cover;\n",
+    "    if (r.cover >= 1.0) b100++; else if (r.cover >= 0.9) b90++; else if (r.cover >= 0.8) b80++;\n",
+    "    else if (r.cover >= 0.5) b50++; else blo++;\n",
+    "}\n",
+    "Console.WriteLine($\"Agregation : {N} recettes, couverture moyenne d'appariement = {100.0 * covSum / N:F1}%\");\n",
+    "Console.WriteLine($\"   couverture 100%           : {b100,5} recettes\");\n",
+    "Console.WriteLine($\"   couverture >=80% (solveur): {b100 + b90 + b80,5} recettes\");\n",
+    "Console.WriteLine($\"   couverture >=50%          : {b100 + b90 + b80 + b50,5} recettes\");\n",
+    "Console.WriteLine($\"   couverture  <50%          : {blo,5} recettes\");\n",
+    "Console.WriteLine(\"Echantillon 100% apparie (energie kJ, prot g, gluc g, lip g, sel g -- PONDERE par la masse) :\");\n",
+    "foreach (var r in built.Where(x => x.cover >= 1.0 && x.vec.Any(v => v > 0)).Take(4))\n",
+    "    Console.WriteLine($\"   {r.title,-46} [{string.Join(\", \", r.vec.Select(x => Math.Round(x, 1)))}]\");\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "311b8c3e",
+   "id": "4a52d6c2",
    "metadata": {
+    "papermill": {
+     "duration": 0.01167,
+     "end_time": "2026-07-01T03:28:27.872276",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:27.860606",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "## 6. Exercices\n",
+    "## 7. Sous-ensembles gatés par qualité + cache JSON\n",
     "\n",
-    "Trois exercices autour de la **qualite de la fusion** (pas de Z3 ici — il arrive aux Slices C/D).\n",
-    "Completez les cellules : elles s'executent telles quelles (renvoient `null` / affichent un rappel) tant\n",
-    "qu'elles ne sont pas remplies.\n",
+    "Le levier de **montée en charge piloté par la donnée** : plutôt qu'un plafond arbitraire (`10 → 100 → 1000`), on livre au solveur des sous-ensembles **gatés par la qualité d'appariement**. Le sous-ensemble **solveur-usable** (≥ 80 % des ingrédients appariés) est sérialisé en cache `mealplan_cache.json` — la matière première **propre** que les notebooks de modélisation ([05d](05d_Hierarchical_Patient_Restrictions.ipynb) capstone, [05e](05e_Meal_Planner_Convergence_Scale.ipynb) échelle) consommeront, sans re-parser Ciqual ni ré-apparier.\n",
     "\n",
-    "### Exercice 1 — un matcheur alternatif (similarite de Jaccard)\n",
-    "\n",
-    "`CalculeProximiteLexicale` est positionnel. Implementez une mesure **ensembliste** : la similarite de\n",
-    "Jaccard entre les deux sacs de mots, `|bag1 ∩ bag2| / |bag1 ∪ bag2|`, puis comparez l'aliment qu'elle\n",
-    "choisit pour quelques denrees a celui du matcheur d'origine.\n",
-    "\n",
-    "- *Indice* : reutilisez `CreateSimpleList` pour produire les sacs, puis `Distinct`/`Intersect`/`Union`.\n",
-    "- *Etape 1* : ecrire `ProximiteJaccard(s1, s2)`.\n",
-    "- *Etape 2* : pour 3 denrees, afficher le meilleur aliment selon chaque mesure.\n"
+    "> Le cache vit sous `data/meals/` (gitignore) : il est **régénéré** à l'exécution, jamais commité."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a460abae",
+   "id": "97771d00",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:27.902586Z",
+     "iopub.status.busy": "2026-07-01T03:28:27.901655Z",
+     "iopub.status.idle": "2026-07-01T03:28:28.212147Z",
+     "shell.execute_reply": "2026-07-01T03:28:28.212147Z"
+    },
+    "papermill": {
+     "duration": 0.326725,
+     "end_time": "2026-07-01T03:28:28.213253",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:27.886528",
+     "status": "completed"
+    },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache ecrit : mealplan_cache.json -- 2207 recettes solveur-usables, 250 Ko.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Palier de montee en charge (pilote par la qualite, non par un plafond arbitraire) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   subset propre 100%   :   601 recettes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   subset >=80% (cache) :  2207 recettes  <- livre au solveur\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   subset >=50%         :  4627 recettes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ce cache est la couche de donnees consommee par les notebooks 05d (capstone) et 05e (echelle).\r\n"
+     ]
+    }
+   ],
    "source": [
-    "// Exercice 1 : similarite de Jaccard sur les sacs de mots.\n",
-    "static double ProximiteJaccard(string s1, string s2)\n",
+    "// ---- cache JSON du sous-ensemble solveur-usable (>=80% apparie) ----\n",
+    "var usable = built.Where(r => r.cover >= 0.8 && r.vec.Any(v => v > 0))\n",
+    "                  .Select(r => new Dictionary<string, object>\n",
+    "                  {\n",
+    "                      [\"title\"] = r.title,\n",
+    "                      [\"cats\"] = r.cats,\n",
+    "                      [\"cover\"] = Math.Round(r.cover, 3),\n",
+    "                      [\"vec\"] = r.vec.Select(x => Math.Round(x, 2)).ToArray()\n",
+    "                  }).ToList();\n",
+    "var cachePath = Path.Combine(BASE, \"mealplan_cache.json\");\n",
+    "var payload = new Dictionary<string, object>\n",
     "{\n",
-    "    // TODO etudiant : |intersection| / |union| des sacs de mots normalises.\n",
-    "    // Indice : var b1 = CreateSimpleList(s1).Distinct().ToList(); ...\n",
-    "    Console.WriteLine(\"Exercice 1 a completer\");\n",
-    "    return 0.0; // valeur neutre tant que non implemente\n",
-    "}\n",
-    "\n",
-    "// TODO etudiant : comparer, pour 3 denrees, l'aliment choisi par chaque mesure.\n"
+    "    [\"constituants\"] = chosenCodes.Select(c => consts[c]).ToArray(),\n",
+    "    [\"n_total\"] = N,\n",
+    "    [\"n_usable\"] = usable.Count,\n",
+    "    [\"recipes\"] = usable\n",
+    "};\n",
+    "File.WriteAllText(cachePath, JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = false }));\n",
+    "Console.WriteLine($\"Cache ecrit : {Path.GetFileName(cachePath)} -- {usable.Count} recettes solveur-usables, \" +\n",
+    "    $\"{new FileInfo(cachePath).Length / 1024} Ko.\");\n",
+    "Console.WriteLine(\"Palier de montee en charge (pilote par la qualite, non par un plafond arbitraire) :\");\n",
+    "Console.WriteLine($\"   subset propre 100%   : {built.Count(r => r.cover >= 1.0 && r.vec.Any(v => v > 0)),5} recettes\");\n",
+    "Console.WriteLine($\"   subset >=80% (cache) : {usable.Count,5} recettes  <- livre au solveur\");\n",
+    "Console.WriteLine($\"   subset >=50%         : {built.Count(r => r.cover >= 0.5 && r.vec.Any(v => v > 0)),5} recettes\");\n",
+    "Console.WriteLine(\"Ce cache est la couche de donnees consommee par les notebooks 05d (capstone) et 05e (echelle).\");\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d1528fee",
+   "id": "8d762fea",
    "metadata": {
+    "papermill": {
+     "duration": 0.011628,
+     "end_time": "2026-07-01T03:28:28.235885",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:28.224257",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "### Exercice 2 — auditer la qualite des appariements\n",
+    "## 8. Exercices\n",
     "\n",
-    "Tous les matches ne se valent pas : certaines denrees n'ont aucun mot commun avec Ciqual et recoivent un\n",
-    "score faible (voire negatif a cause du malus). Calculez, pour chaque denree, sa **proximite maximale**, puis\n",
-    "listez les **10 pires** appariements — ceux qu'un humain devrait revoir.\n",
+    "Trois exercices de **data-engineering** (toujours 0 Z3). Ils prolongent directement les limites mesurées ci-dessus : rappel du matcheur, couverture des unités, agrégation par catégorie."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4380e68f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011996,
+     "end_time": "2026-07-01T03:28:28.259708",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:28.247712",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — pousser le matcheur plus loin (synonymes non couverts)\n",
     "\n",
-    "- *Indice* : refaites le `Select` de `matchingMots` mais conservez le score, triez `OrderBy(Proximite)`.\n",
-    "- *Etape 1* : construire la liste `(denree, meilleurAliment, score)`.\n",
-    "- *Etape 2* : afficher les 10 plus faibles et commenter ce que le matcheur rate.\n"
+    "Le matcheur curé embarque déjà une **table de synonymes de départ** (`SYN` : `catsup`→`ketchup`, `baking soda`→`sodium bicarbonate`…). Mais la liste des **items non appariés fréquents** (à afficher : trier `mc` / `recipes` par occurrence et lister ceux sans code) révèle d'autres trous : `buttermilk`, `sherry`, `molasses`, `crisco`, `half and half`, `graham cracker`… Étendre la table `SYN` (les rediriger vers un aliment Ciqual proche), **re-appliquer** `Match`, et **re-mesurer** la couverture moyenne d'appariement (section 6) pour quantifier le gain."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "8bf4a953",
+   "id": "1c09dd0f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:28.285786Z",
+     "iopub.status.busy": "2026-07-01T03:28:28.285786Z",
+     "iopub.status.idle": "2026-07-01T03:28:28.399301Z",
+     "shell.execute_reply": "2026-07-01T03:28:28.399301Z"
+    },
+    "papermill": {
+     "duration": 0.128681,
+     "end_time": "2026-07-01T03:28:28.400385",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:28.271704",
+     "status": "completed"
+    },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : couvrir des synonymes manquants puis re-mesurer la couverture d'appariement.\r\n"
+     ]
+    }
+   ],
    "source": [
-    "// Exercice 2 : top 10 des appariements les plus faibles.\n",
-    "List<(string Denree, string Aliment, double Score)> PiresAppariements(int n)\n",
-    "{\n",
-    "    // TODO etudiant : reconstruire (denree -> meilleur aliment + score), trier croissant, prendre n.\n",
-    "    Console.WriteLine(\"Exercice 2 a completer\");\n",
-    "    return null;\n",
-    "}\n",
-    "// PiresAppariements(10) ...\n"
+    "// Exercice 1 : pousser le matcheur plus loin en couvrant des synonymes qui manquent.\n",
+    "// Indice : reperer d'abord les items non apparies frequents, p.ex.\n",
+    "//          recipes.SelectMany(r => r.ings.Select(i => i.item)).GroupBy(x => x)\n",
+    "//                 .Where(g => Match(g.Key) == null).OrderByDescending(g => g.Count()).Take(20)\n",
+    "//          puis ajouter des entrees a une COPIE de SYN et recomparer la couverture.\n",
+    "// TODO etudiant : completer la table et re-mesurer la couverture avant/apres.\n",
+    "var synonymesSup = new Dictionary<string, string>(); // ex : { [\"buttermilk\"]=\"fermented milk\", [\"molasses\"]=\"cane syrup\" }\n",
+    "\n",
+    "if (synonymesSup.Count == 0)\n",
+    "    Console.WriteLine(\"Exercice 1 a completer : couvrir des synonymes manquants puis re-mesurer la couverture d'appariement.\");\n",
+    "else\n",
+    "    Console.WriteLine($\"Table de {synonymesSup.Count} synonymes supplementaires prete -- reappliquer Match() et comparer.\");\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "be2c072d",
+   "id": "a1b4d66d",
    "metadata": {
+    "papermill": {
+     "duration": 0.012048,
+     "end_time": "2026-07-01T03:28:28.425516",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:28.413468",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "### Exercice 3 — restrictions patient (`Min`/`Max` par constituant)\n",
+    "### Exercice 2 — étendre la couverture des unités\n",
     "\n",
-    "Le Demo2 contraint les menus par des **restrictions patient** (`Min`/`Max` par constituant) — c'est la\n",
-    "matiere de la Slice C cote solveur, mais la **structure de donnees** se construit deja ici. Ecrivez une\n",
-    "fonction qui, etant donne un nom de constituant et une borne max, renvoie la liste des denrees **au-dessus**\n",
-    "de cette borne (celles qu'un regime devrait limiter).\n",
-    "\n",
-    "- *Indice* : retrouvez l'index du constituant via `diet.Constituants.FindIndex(c => c.Nom.Contains(...))`,\n",
-    "  puis filtrez `diet.Denrees` sur `d.Compositions[idx] > max`.\n",
-    "- *Etape 1* : `DenreesAuDessus(string constituant, decimal max)`.\n",
-    "- *Etape 2* : testez avec un constituant lipidique ou sodique.\n"
+    "Beaucoup d'ingrédients restent **non pesables** parce que leur unité (`can`, `package`, `clove`, `slice`, `bunch`) n'est pas dans la table `UNIT`. Ajouter des conversions plausibles (`clove` d'ail ≈ 5 g, `slice` de pain ≈ 30 g, `stick` de beurre = 113 g déjà présent), puis **compter** combien d'ingrédients gagnent une masse non nulle. Attention : certaines conversions dépendent de l'ingrédient (une « tranche » de pain ≠ une « tranche » de fromage) — documenter l'hypothèse."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e53f4949",
+   "id": "272d05ca",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:28.455161Z",
+     "iopub.status.busy": "2026-07-01T03:28:28.454151Z",
+     "iopub.status.idle": "2026-07-01T03:28:28.521082Z",
+     "shell.execute_reply": "2026-07-01T03:28:28.521082Z"
+    },
+    "papermill": {
+     "duration": 0.082721,
+     "end_time": "2026-07-01T03:28:28.522088",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:28.439367",
+     "status": "completed"
+    },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : ajouter des unites (clove, slice, bunch...) et recompter les ingredients pesables.\r\n"
+     ]
+    }
+   ],
    "source": [
-    "// Exercice 3 : denrees depassant une borne sur un constituant donne.\n",
-    "List<string> DenreesAuDessus(string constituantContient, decimal max)\n",
-    "{\n",
-    "    // TODO etudiant : index du constituant, puis filtre sur diet.Denrees[].Compositions[idx] > max.\n",
-    "    Console.WriteLine(\"Exercice 3 a completer\");\n",
-    "    return null;\n",
-    "}\n",
-    "// DenreesAuDessus(\"Sodium\", 1000m) ...\n"
+    "// Exercice 2 : etendre la table d'unites pour rendre pesables plus d'ingredients.\n",
+    "// Indice : ajouter des entrees a une copie de UNIT (clove ~5 g, slice ~30 g...) ;\n",
+    "//          re-parcourir `recipes` et compter les ToGrams(...) > 0 avant/apres.\n",
+    "// TODO etudiant : completer les unites supplementaires et recompter.\n",
+    "var unitesSup = new Dictionary<string, (double factor, bool isMass)>(); // a completer\n",
+    "\n",
+    "if (unitesSup.Count == 0)\n",
+    "    Console.WriteLine(\"Exercice 2 a completer : ajouter des unites (clove, slice, bunch...) et recompter les ingredients pesables.\");\n",
+    "else\n",
+    "    Console.WriteLine($\"{unitesSup.Count} unites supplementaires definies -- recompter les ingredients pesables.\");\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2ef46987",
+   "id": "f863656b",
    "metadata": {
+    "papermill": {
+     "duration": 0.012103,
+     "end_time": "2026-07-01T03:28:28.545710",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:28.533607",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "## Conclusion — ce que Slice A etablit\n",
+    "### Exercice 3 — profil nutritionnel moyen par catégorie\n",
     "\n",
-    "Ce notebook **porte fidelement** `Dietetique.Load` : les deux jointures `CONST ⋈ COMPO ⋈ ALIM`, le matcheur\n",
-    "lexical flou `CalculeProximiteLexicale`, et l'agregation `Zip` des compositions de plats, sur les **vraies**\n",
-    "donnees Ciqual ANSES 2025 (3484 aliments, 258 000 compositions) et Recettes OpenData. Resultat : un catalogue\n",
-    "`Dietetique` de **74 constituants, ~200 denrees, 138 plats**, serialise en `dietetique.json` propre (UTF-8,\n",
-    "zero mojibake).\n",
+    "Sur le sous-ensemble solveur-usable (`usable` ou `built` filtré à `cover ≥ 0.8`), regrouper par **catégorie RecipeML** (`cats`, ex. `Cake`, `Bread`, `Soup`) et calculer le **vecteur nutritionnel moyen** de chaque catégorie. Cela révèle la structure du corpus (les desserts ressortent-ils comme attendu ?) — utile pour équilibrer un menu au notebook de modélisation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7cdbe69d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T03:28:28.572380Z",
+     "iopub.status.busy": "2026-07-01T03:28:28.571431Z",
+     "iopub.status.idle": "2026-07-01T03:28:28.677778Z",
+     "shell.execute_reply": "2026-07-01T03:28:28.676743Z"
+    },
+    "papermill": {
+     "duration": 0.119336,
+     "end_time": "2026-07-01T03:28:28.677778",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:28.558442",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : vecteur nutritionnel moyen par categorie.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : profil nutritionnel moyen par categorie RecipeML.\n",
+    "// Indice : built.Where(r => r.cover >= 0.8).SelectMany(r => r.cats.Select(c => (c, r.vec)))\n",
+    "//          .GroupBy(x => x.c) puis moyenne composant par composant.\n",
+    "// TODO etudiant : completer l'agregation par categorie.\n",
+    "System.Collections.IEnumerable profilParCategorie = null; // remplacer par le GroupBy/Select\n",
     "\n",
-    "C'est la **couche de donnees** que les slices suivantes du capstone consommeront :\n",
+    "if (profilParCategorie is null)\n",
+    "    Console.WriteLine(\"Exercice 3 a completer : vecteur nutritionnel moyen par categorie.\");\n",
+    "else\n",
+    "    foreach (var row in profilParCategorie) Console.WriteLine(row);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f331fa9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012435,
+     "end_time": "2026-07-01T03:28:28.701358",
+     "exception": false,
+     "start_time": "2026-07-01T03:28:28.688923",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion — la couche de données du bloc meal-planner\n",
     "\n",
-    "- **Slice B** — passer le corpus RecipeML a l'echelle (subsets cures -> montee en gamme).\n",
-    "- **Slice C** — le theoreme hierarchique `Patient -> Menus[7] -> Plats[5] -> Denree` + restrictions patient\n",
-    "  (le `PlanificateurDeMenus.Create` de la source, deja ebauche en exercice 3).\n",
-    "- **Slice D** — la **convergence a l'echelle** : garder Z3 tractable quand le pool de plats grandit.\n",
+    "Ce notebook construit la **couche de données propre** du planificateur de repas, sans jamais appeler de solveur (**0 Z3**) :\n",
     "\n",
-    "La lecon transverse : LINQ absorbe **declarativement** une fusion de donnees reelle (cles absentes,\n",
-    "appariement flou, agregation vectorielle) la ou un script imperatif deviendrait un labyrinthe de boucles.\n",
-    "C'est le meme changement de paradigme — decrire *quoi*, pas *comment* — que la serie applique ensuite au\n",
-    "solveur.\n"
+    "- **Ciqual × RecipeML** fusionnés par **appariement lexical flou** (aucune clé commune) — la normalisation *étagée* est la leçon, ses limites sont les exercices.\n",
+    "- **Quantités normalisées en grammes** (unités culinaires → mL → g via densités) — ce qui rend l'**agrégation nutritionnelle pondérée par la masse** enfin honnête, là où sommer les teneurs per-100g brutes était fictif.\n",
+    "- **Sous-ensembles gatés par qualité d'appariement** (100 % / ≥80 % / ≥50 %) sérialisés en cache — le levier de **montée en charge piloté par la donnée** (des données propres de taille croissante, pas un plafond arbitraire).\n",
+    "\n",
+    "La leçon transverse est celle du **data-engineering** : les données réelles arrivent hétérogènes (référentiel per-100g, corpus culinaire impérial) et ne se joignent pas proprement ; il faut apparier, normaliser, et **mesurer la qualité** avant de livrer quoi que ce soit à un solveur. Ces structures typées sont la matière première des notebooks suivants du bloc meal-planner :\n",
+    "\n",
+    "- **Modélisation déclarative** (index/booléens, `MkITE`, exclusion d'allergène, théorème hiérarchique) ;\n",
+    "- **Capstone patient** ([05d](05d_Hierarchical_Patient_Restrictions.ipynb)) — théorème 4 niveaux + restrictions `Min`/`Max` ;\n",
+    "- **Convergence à l'échelle** ([05e](05e_Meal_Planner_Convergence_Scale.ipynb)) — garder Z3 tractable quand le sous-ensemble grandit."
    ]
   }
  ],
@@ -1098,6 +1455,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "12.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 13.864058,
+   "end_time": "2026-07-01T03:28:28.956504",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "D:\\dev\\wt-z3-mp2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\05c_Dietetique_Load_Faithful_Port.ipynb",
+   "output_path": "D:\\dev\\wt-z3-mp2\\MyIA.AI.Notebooks\\SymbolicAI\\SMT\\Z3\\05c_Dietetique_Load_Faithful_Port_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-01T03:28:15.092446",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Contexte — Epic #4677 Phase 1, PR-2 (moitie donnees de MP-2)

Reecriture de `05c_Dietetique_Load_Faithful_Port.ipynb` en **couche de donnees reelles** du bloc meal-planner (**0 Z3**), suite au **pivot dataset valide par le user 2026-07-01** :

> « Oui tu as mon go sur le framing ciqual x recipeml, meme si j'aimerais qu'on puisse pousser le matching jusqu'a plusieurs milliers de recettes au moins (ton 30+% moins les faux positifs). »

Abandon des recettes cantine Toulouse « datameal » (**sans quantites = show-stopper**, cf. commentaire pivot sur #4677) au profit de **Ciqual ANSES 2025 × RecipeML** (~5200 recettes structurees qty/unit/item).

## Ce que fait le notebook (100% .NET C#, kernel `.net-csharp`, 0 Z3)

1. **Ciqual** : 74 constituants, 3484 aliments, noms EN (`alim_nom_eng`), C=5 constituants contraints.
2. **Parsing RecipeML** : 5215 recettes / 49565 ingredients (90% avec quantite, 76% avec unite ; 21 XML irrecuperables ignores).
3. **Matcheur lexical CURE** (port de `scratchpad/match_scaled.py`) — deaccent, aliment-primaire-avant-virgule, garde **head-noun**, **Jaccard ≥ 0.5**, rang plus-court-nom, table de **synonymes/composes/strip-modificateur**. C'est la reponse directe au « moins les faux positifs » :

   | item RecipeML | matcheur **naif** (rejete) | matcheur **cure** (livre) |
   |---|---|---|
   | White sugar | ~~White pudding~~ | **Sugar, white** |
   | Butter | ~~Butter sauce prepacked~~ | **Butter, 80% fat, unsalted** |
   | Baking soda | — | **Sodium bicarbonate** (J=1.0) |
   | Salt pepper | ~~1 seul aliment~~ | **compose scinde** (Salt + Pepper) |

4. **Normalisation quantite → grammes** : unite → mL/g (cup 236.6 mL, tbsp, oz masse…), densites curees (farine 0.53, sucre 0.85, huile 0.92…), **table de comptage** (`2 eggs → 100 g` au lieu de 0 g).
5. **Agregation nutritionnelle PONDEREE PAR LA MASSE** — corrige le biais *quantity-blind* : `Cake → 69 g proteines` (et non l'absurde **774 g** du matcheur naif quantity-blind).
6. **Sous-ensembles gates par qualite d'appariement** + cache JSON : **2227 recettes solveur-usables (≥80% apparie)** serialisees dans `mealplan_cache.json`. C'est le **levier de montee en charge pilote par la donnee** (remplace le plafond arbitraire 10→100→1k) — les « plusieurs milliers de recettes » demandees.
7. **3 exercices** data-engineering (pousser les synonymes ; etendre les unites ; profil moyen par categorie), stubs C.1 qui **s'executent end-to-end**.

## Preuve d'execution reelle (C.2 / section D)

- Re-execution **reelle** hors-bande via `notebook_tools execute --kernel .net-csharp --cwd <Z3>` : **`[+] SUCCESS` — Success: 1, Failed: 0, Total time: 15.5s**.
- 10/10 cellules code avec `execution_count` non-null + `outputs` reels.
- `grep -cE "raise NotImplementedError|assert False|1/0"` = **0**.
- 3 cellules `### Exercice` (regle #2161) ; **0 Z3** (`MkSolver`/`Microsoft.Z3`/`new Context()` absents).
- Catalogue `COURSE_CATALOG.generated.*` + marqueurs `CATALOG-STATUS` **byte-identiques** a `origin/main` (non regeneres sur branche).
- Aucune cellule `# Solution`/`# Exemple resolu` supprimee (le 05c d'origine etait un port Toulouse, remplace sur **mandat user explicite**).

## Perimetre atomique — pourquoi 06b n'est PAS supprime ici

L'Epic decrit MP-2 comme `05c + 06b`. Ce PR livre la **moitie donnees** (le nouveau 05c). **La suppression de `06b` est differee a MP-1** : `06c` et `07` **dependent encore du modele booleen Z3 de `06b`** (« reprend exactement le modele booleen de 06b section 3 », « le `int[][]` de 06b section 4 », « exercice 2 du notebook 06b »). Retirer 06b maintenant orphelinerait ces references avec des redirections fausses (05c est 0 Z3, il n'a pas de modele booleen). 06b sera retire proprement **quand MP-1 absorbe 06c+07** et resout ces dependances. Sa couche « donnees » (corpus RecipeML) est **des maintenant superseder** par ce 05c a l'echelle reelle ; sa couche « modelisation Z3 » (redondante avec 05/06c per l'Epic) part avec MP-1.

Le **renommage** `05c → 07` (le filename `Faithful_Port` est desormais impropre) reste du ressort de **Phase 2** (renumber 01..18).

## Suites tracees (PRs atomiques separees)
- MP-1 (`05+07+06c` → Modelisation) : absorbe 06c/07 puis **retire 06b** + resout les cross-links.
- Recabler 05e (`Convergence_Scale`, aujourd'hui agregation quantity-blind) sur le cache `mealplan_cache.json`.
- 3 exercices Z3 de 06b (contrainte glucides / max-proteines dichotomie / menu vegetarien) → a preserver dans MP-1/MP-4.

See #4677
See #4617
See #1206

---
🤖 po-2025:CoursIA (cycle nuit autonome, mandat user 2026-06-30). **Pas de self-merge** — remise a po-2024 (coord stand-in, ai-01 DOWN).