### PR TITLE
fix(sudoku): demote residual H2/H3 hint-asides to inline bold (EPIC #3966)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -2477,7 +2477,7 @@
     "   - Y a-t-il des puzzles ou un solveur \"explose\" en operations meme s'il est rapide ?\n",
     "   - Le nombre d'operations est-il un bon predicteur du temps de resolution ?\n",
     "\n",
-    "### Indice pour le comptage des eliminations Norvig\n",
+    "**Indice pour le comptage des eliminations Norvig :**\n",
     "\n",
     "Dans `ProfiledNorvigSolver._eliminate`, incrementez `self.elimination_count` au debut de la methode (apres avoir initialise ce compteur dans `__init__`). Le comptage doit inclure les appels no-op.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
@@ -1579,7 +1579,7 @@
     "2. La fonction `count_solutions(puzzle, max_count=10)` construit la matrice DLX et lance la recherche exhaustive\n",
     "3. Les tests verifient : une grille a solution unique, une grille sous-contrainte (plusieurs solutions), et une grille invalide (zero solution)\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Pour la grille vide (81 cases vides), le nombre de Sudokus valides est de **6 670 903 752 021 072 936 960**. L'implementation s'arrete rapidement grace au parametre `max_count`."
    ]
@@ -1696,7 +1696,7 @@
     "2. Implementez la fonction `solve_nqueens(n)` qui utilise `DancingLinks` pour trouver toutes les solutions\n",
     "3. Affichez les solutions pour N = 4, N = 8 et comparez avec les nombres theoriques connus\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Pour simplifier, commencez par ignorer les diagonales et utilisez uniquement les contraintes de ligne et de colonne (couverture exacte stricte : 2N colonnes, N^2 lignes). Verifiez ensuite que les solutions obtenues respectent aussi les diagonales. Le nombre de solutions pour N=8 est 92 (solutions distinctes), et pour N=4 c'est 2."
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -1430,7 +1430,7 @@
     "3. La fitness ne compte que les erreurs de lignes et de colonnes (les blocs sont corrects par construction)\n",
     "4. On compare les performances avec `PermutationGeneticSolver` sur les memes puzzles\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Chaque bloc 3x3 a 9 cellules. Si k cellules sont fixes, il reste (9-k)! permutations possibles pour les valeurs manquantes. Pour un puzzle facile (~ 40 cellules fixes reparties dans 9 blocs), le nombre de permutations par bloc est typiquement entre 1 et 120.\n",
     "\n",
@@ -1659,11 +1659,11 @@
     "3. Lancez le benchmark sur les memes puzzles et comparez avec le solveur original\n",
     "4. Affichez les courbes de convergence des deux solveurs cote a cote\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "PyGAD permet de definir une fonction de croisement personnalisee via le parametre `crossover_type`. La fonction doit prendre `(parents, offspring_size, ga_instance)` et retourner les enfants. Utilisez `numpy.random.choice([0, 1], size=num_genes)` pour decider quel parent contribue chaque gene.\n",
     "\n",
-    "### TODO\n",
+    "**TODO :**\n",
     "\n",
     "Completez la classe ci-dessous :"
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
@@ -1707,7 +1707,7 @@
     "| Pres du but (90%) | 2 | 20 | 0.925 |\n",
     "| Erreur nulle (100%) | 0 | 20 | 0.950 |\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "La formule est un interpolation lineaire : plus l'erreur baisse (bonne progression), plus on augmente le ratio de workers. Utilisez `max()` et `min()` pour borner le resultat."
    ]
   },
@@ -1946,7 +1946,7 @@
     "\n",
     "Le PSO hybride devrait avoir moins de redemarrages et etre plus fiable sur les puzzles difficiles.\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "La stagnation se detecte en comptant les epochs sans amelioration de `best_error`. Lorsque ce compteur depasse `stagnation_limit`, appliquer la recherche locale et reinitialiser le compteur."
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -1221,7 +1221,7 @@
     "\n",
     "3. Comparer les performances de Welsh-Powell vs MRV sur les puzzles difficiles\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "\n",
     "Le degre actuel d'un sommet non colorie est le nombre de ses voisins qui sont egalement non colories. Plus ce degre est eleve, plus le sommet est contraint et doit etre colorie prioritairement.\n",
     "\n",


### PR DESCRIPTION
## Summary

Correction de la pathologie **HINT-AS-HEADING** résiduelle (niveaux H2/H3) dans la famille **Sudoku-Python** (EPIC #3966). Le passage **#4127** du user (Jean-Sylvain Boige, 2026-06-24) avait déjà démote les hint-as-**H1** headings vers inline bold sur 7 notebooks Sudoku. Cette PR traite le **résiduel H2/H3 tail** que le scanner `scan_md_hierarchy.py` flaggait encore : des `### Indice` / `### TODO` rendus en titres de section (H3, proéminents, dans le TOC) à l'intérieur de `## Exercice`, alors qu'ils devraient être des labels inline bold selon la directive [`docs/reference/notebook-formatting.md`](docs/reference/notebook-formatting.md) §1.2.

C'est exactement la pathologie du mandat user #3966 : *« les indices donnés aux exercices apparaissent comme les éléments de police la plus grande alors que ça devrait être l'inverse »*.

## Changement (typo-only, anti-regression-safe)

5 notebooks, 9 aside-headings démotes, **convention EXACTE de #4127** (`**Indice :**` inline bold + deux-points) :

| Notebook | Cellules | Avant (H3/H2 heading) | Après (inline bold) |
|----------|----------|----------------------|---------------------|
| Sudoku-2-DancingLinks | 28, 30 | `### Indice` ×2 | `**Indice :**` ×2 |
| Sudoku-3-Genetic | 24, 26 | `### Indice` ×2, `### TODO` | `**Indice :**` ×2, `**TODO :**` |
| Sudoku-5-PSO | 35, 41 | `### Indice` ×2 | `**Indice :**` ×2 |
| Sudoku-9-GraphColoring | 24 | `### Indice` | `**Indice :**` |
| Sudoku-18-Comparison | 55 | `### Indice pour le comptage...` | `**Indice pour le comptage des eliminations Norvig :**` |

**Seul le marqueur de heading change** (`### ` → `**` … ` :**`). Le texte pédagogique est préservé à l'identique (directive §4 : « changer le niveau d'un heading n'est pas changer le contenu pédagogique »). Les **sections structurelles H3 sœurs** (`### Enonce`, `### Contexte`, `### Objectif`, `### Resultats attendus`, `### Strategie`) sont **préservées** — seul l'aside (Indice/TODO) est démote. Markdown-only → pas de re-exec (exception C.2).

## Vérification

**Scanner source-level** (`scan_md_hierarchy.py`) — famille Sudoku :
```
AVANT : [HINT-AS-HEADING] 9 flags (5 notebooks × Indice/TODO)
APRÈS : 1/33 notebooks flagged (uniquement Sudoku-15 cell 31, exclusion structurale — voir ci-dessous)
```

**Diff réel** (vérification render-level, directive §3) :
```
5 files changed, 9 insertions(+), 9 deletions(-)
"### Indice\n"  ->  "**Indice :**\n"   (heading lines only, pas de churn CRLF)
0 changement code-cell / execution_count / outputs  (markdown-only)
```
La pathologie est corrigée de manière déterministe : un `<p><strong>Indice :</strong></p>` (16 px, body) ne peut plus être rendu en `<h3>` (20 px, section proéminente dans le TOC).

## Non touché (grounded firsthand)

- **Sudoku-15-Infer-Python cell 31 `## Indice`** = **exclusion structurale** : la cellule a une hiérarchie H2 plate (`## Exercice` / `## Enonce` / `## Questions` / `## Indice` tous au même niveau H2). Démoter uniquement `## Indice` laisserait des siblings structurels incohérents — c'est un problème de hiérarchie structurelle au-delà de la démotion surgical d'aside (même classe d'exclusion que le nav-banner GameTheory-1-Setup et le `## Rappel` de MGS-19). Hors scope typo §4.
- **Sections structurelles** (`### Enonce`, `### Objectif`, `### Resultats attendus`, etc.) = **PRESERVÉES** : ce sont de vraies sous-sections, pas des asides (le scanner ne les flagge pas — « enonce »/« objectif » ne sont pas dans `HINT_RE`).

## Scope

- 5 fichiers, +9/-9. Atomique (un sujet = fix HINT-AS-HEADING résiduel H2/H3 dans la famille Sudoku-Python).
- Branche fresh `origin/main`. Suit la convention #4127 du user (extension au résiduel tail).
- Aucun notebook C#/Python code touché. Aucun submodule. Aucun CATALOG.

See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
