### PR TITLE
fix(iit-3): demote exercise hint/step/question H1 asides to blockquote (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
@@ -382,10 +382,10 @@
     "\n",
     "Construire un réseau toy 3-nœuds où chaque nœud calcule un **AND** de ses deux entrées (et non une copie). Mesurer son `effective_info` et son $\\Phi$ dans l'état `(1,1,1)`. Comparer à EI=1.0 du réseau copy ci-dessus : un réseau AND est-il plus ou moins dégénéré ?\n",
     "\n",
-    "# Indice : TPM AND = pour chaque état courant, le prochain état du noeud i = AND de ses 2 voisins.\n",
-    "# Etape 1 : construire la TPM (8 lignes, 3 colonnes).\n",
-    "# Etape 2 : pyphi.Network(tpm_and, cm) puis pyphi.macro.effective_info(net).\n",
-    "# Etape 3 : pyphi.Subsystem(net, (1,1,1)) puis pyphi.compute.phi(sub)."
+    "> **Indice :** TPM AND = pour chaque état courant, le prochain état du noeud i = AND de ses 2 voisins.\n",
+    "> **Etape 1 :** construire la TPM (8 lignes, 3 colonnes).\n",
+    "> **Etape 2 :** pyphi.Network(tpm_and, cm) puis pyphi.macro.effective_info(net).\n",
+    "> **Etape 3 :** pyphi.Subsystem(net, (1,1,1)) puis pyphi.compute.phi(sub)."
    ]
   },
   {
@@ -432,9 +432,9 @@
     "\n",
     "Sur un réseau à 4 nœuds (ex. l'exemple canonique `pyphi.examples.macro_network()`), lister tous les regroupements possibles via `pyphi.macro.all_groupings(range(4))`. Compter combien il y en a. Quel regroupement correspond à \"tout grouper en un seul macro-nœud\" ?\n",
     "\n",
-    "# Indice : all_partitions renvoie des tuples de tuples. Le regroupement \"tout groupé\" = ((0,1,2,3),).\n",
-    "# Etape 1 : parts = list(pyphi.macro.all_partitions([0,1,2,3])).\n",
-    "# Etape 2 : len(parts) donne le nombre. Chercher celui egal a ((0,1,2,3),)."
+    "> **Indice :** all_partitions renvoie des tuples de tuples. Le regroupement \"tout groupé\" = ((0,1,2,3),).\n",
+    "> **Etape 1 :** parts = list(pyphi.macro.all_partitions([0,1,2,3])).\n",
+    "> **Etape 2 :** len(parts) donne le nombre. Chercher celui egal a ((0,1,2,3),)."
    ]
   },
   {
@@ -479,10 +479,10 @@
     "\n",
     "Sur le réseau copy 3-nœuds du §1, on a vu $\\Phi$ micro = 0. Formulez une hypothèse : si l'on coarse-graine les 3 nœuds copy en un seul macro-nœud, le $\\Phi$ macro sera-t-il strictement positif ? Construisez le macro-nœud (TPM 1-nœud identique, copie) et mesurez-le pour confirmer/réfuter.\n",
     "\n",
-    "# Indice : un macro-nœud \"copy\" a une TPM [[0.0],[1.0]] (1 noeud, self-loop), cm=[[1]].\n",
-    "# Etape 1 : macro_net = pyphi.Network(np.array([[0.0],[1.0]]), np.array([[1]])).\n",
-    "# Etape 2 : pyphi.Subsystem(macro_net, (1,)) puis pyphi.compute.phi(sub).\n",
-    "# Question : phi macro = 0 aussi ? Pourquoi (cf. interpretation §4) ?"
+    "> **Indice :** un macro-nœud \"copy\" a une TPM [[0.0],[1.0]] (1 noeud, self-loop), cm=[[1]].\n",
+    "> **Etape 1 :** macro_net = pyphi.Network(np.array([[0.0],[1.0]]), np.array([[1]])).\n",
+    "> **Etape 2 :** pyphi.Subsystem(macro_net, (1,)) puis pyphi.compute.phi(sub).\n",
+    "> **Question :** phi macro = 0 aussi ? Pourquoi (cf. interpretation §4) ?"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

EPIC **#3966** — mise-en-forme notebooks. Dans `IIT-3-CoarseGrainingMacroPhi.ipynb`, les trois cellules markdown d'exercice (14, 16, 18) avaient leurs asides (Indice/Etape/Question) écrits en `#` H1, donc rendus dans la **plus grande police** — plus gros que le titre `### Exercice N` H3 au-dessus. C'est exactement la pathologie signalée par le user : « les indices... apparaissent comme les éléments de police la plus grande alors que ça devrait être l'inverse ».

## Changement

11 lignes H1 déclassées en blockquote selon `docs/reference/notebook-formatting.md` §1.2 (asides JAMAIS en `#`/`##` → bold-inline ou blockquote) :

| cellule | exercice | H1 → blockquote |
|---------|----------|-----------------|
| 14 | Exercice 1 (information efficace) | 1 Indice + 3 Etapes |
| 16 | Exercice 2 (regroupements 4 nœuds) | 1 Indice + 2 Etapes |
| 18 | Exercice 3 (hypothèse d'émergence) | 1 Indice + 2 Etapes + 1 Question |

Les hints de chaque exercice forment maintenant un block blockquote avec labels bold — un aside discret, plus petit que le titre `### Exercice N` (hiérarchie correcte).

## Validation

- `scan_md_hierarchy.py` : **1/1 flagged → 0/1 clean**. Était 11 H1-DEEP + 11 HINT-AS-HEADING sur cellules 14/16/18 ; le seul H1 restant est le titre légitime du notebook (cellule 0).
- **Markdown-source uniquement** (11 ins / 11 del) ; 0 cellule code, 0 output, 0 execution_count, 0 cell_type modifié → pas de re-exécution (exception markdown C.2).
- Texte **verbatim** préservé (appels API pyphi, $\Phi$, nœud/œ, tableaux, guillemets) — seul le markup de heading a changé. JSON re-parsé OK.
- Les titres `### Exercice N` H3 étaient corrects et **non touchés**.

## Périmètre

- **Atomique** : 1 notebook, 11 lignes, markdown-only.
- **Non-collision** : aucun autre PR ouvert sur IIT-3.
- Même grain que #4692 (PyMC-1) et #4693 (MGS-15).

See #3966

Co-Authored-By: Claude-Code <noreply@anthropic.com>