### PR TITLE
docs(casestudies): fix missing accents in CaseStudies family READMEs (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/README.md
@@ -1,4 +1,4 @@
-# Diagnostic Medical - Systeme de Diagnostic Multi-Contraintes
+# Diagnostic Medical - Système de Diagnostic Multi-Contraintes
 
 ## Vue d'ensemble
 
@@ -36,11 +36,11 @@ flowchart LR
 ```
 Diagnostic-Medical/
 ├── student/
-│   └── Diagnostic-Medical.ipynb          # Template etudiant (a completer)
+│   └── Diagnostic-Medical.ipynb          # Template étudiant (à compléter)
 ├── solution/
-│   └── Diagnostic-Medical.ipynb          # Solution de reference
+│   └── Diagnostic-Medical.ipynb          # Solution de référence
 ├── data/
-│   └── patients.csv                      # Donnees de test (10 patients)
+│   └── patients.csv                      # Données de test (10 patients)
 ├── subject.md                            # Sujet complet
 └── README.md                             # Ce fichier
 ```
@@ -114,7 +114,7 @@ student/Diagnostic-Medical.ipynb
 #### 2. Pour les Évaluateurs
 
 ```bash
-# Ouvrir le notebook corrige
+# Ouvrir le notebook corrigé
 jupyter notebook solution/Diagnostic-Medical.ipynb
 ```
 
@@ -189,7 +189,7 @@ pip install z3-solver
 
 ```bash
 # Vérifier le chemin relatif
-# Le notebook doit etre execute depuis le repertoire Diagnostic-Medical/
+# Le notebook doit être exécuté depuis le répertoire Diagnostic-Medical/
 ```
 
 #### 3. Erreur de convergence A*
@@ -231,7 +231,7 @@ self.solver.set("timeout", 5000)  # 5 secondes
 
 ### Critères d'évaluation
 
-Chaque cellule a remplir ou compléter sera évaluée pour constituer la note finale sur 20.
+Chaque cellule à remplir ou compléter sera évaluée pour constituer la note finale sur 20.
 
 **Bonus** (jusqu'à +2 points) :
 - Innovation algorithmique

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/README.md
@@ -27,11 +27,11 @@ Oncology-Planning/
 ├── README.md                           # Ce fichier
 ├── subject.md                          # Sujet complet
 ├── student/
-│   └── Oncology-Planning.ipynb         # Notebook a completer
+│   └── Oncology-Planning.ipynb         # Notebook à compléter
 ├── solution/
-│   └── Oncology-Planning.ipynb         # Solution de reference
+│   └── Oncology-Planning.ipynb         # Solution de référence
 └── data/
-    └── patients_oncology.csv           # Donnees patients
+    └── patients_oncology.csv           # Données patients
 ```
 
 ---

--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -62,15 +62,15 @@ Les deux projets reposent sur un **modèle de patient simulé** : un objet logic
 
 ```text
 CaseStudies/
-├── Diagnostic-Medical/    # Systeme de diagnostic multi-contraintes (A*, genetique, Z3)
-│   ├── student/           # Template etudiant
-│   ├── solution/          # Solution de reference
-│   └── data/              # Donnees de test
+├── Diagnostic-Medical/    # Système de diagnostic multi-contraintes (A*, génétique, Z3)
+│   ├── student/           # Template étudiant
+│   ├── solution/          # Solution de référence
+│   └── data/              # Données de test
 ├── Oncology-Planning/     # Planification oncologique (CSP, Pyro probabiliste, ontologie)
-│   ├── student/           # Template etudiant
-│   ├── solution/          # Solution de reference
-│   └── data/              # Donnees patients
-└── requirements.txt       # Dependances communes
+│   ├── student/           # Template étudiant
+│   ├── solution/          # Solution de référence
+│   └── data/              # Données patients
+└── requirements.txt       # Dépendances communes
 ```
 
 ## Projets


### PR DESCRIPTION
## Contexte

EPIC **#2876** — accents manquants dans les READMEs francophones (repo-wide, good first issue). Les READMEs CaseStudies (parent + 2 feuilles projet) avaient du français non accentué dans les commentaires de leurs blocs d'arborescence, et Diagnostic-Medical avait aussi des défauts de prose. Famille **CaseStudies non-réclamée** (≠ Probas/Sudoku/MGS/IIT déjà traités, pas partition-ambigu, pas Opus-gated).

## Changement

**18 corrections d'accents pure-ASCII** sur 3 fichiers :

| Fichier | Défauts |
|---------|---------|
| `CaseStudies/README.md` (parent, bloc arborescence) | Systeme→Système, genetique→génétique, etudiant→étudiant (×2), reference→référence (×2), Donnees→Données (×2), Dependances→Dépendances |
| `Diagnostic-Medical/README.md` (titre + arborescence + prose) | Systeme→Système, etudiant (a completer)→étudiant (à compléter), reference→référence, Donnees→Données, corrige→corrigé, etre execute→être exécuté, repertoire→répertoire, a remplir→à remplir |
| `Oncology-Planning/README.md` (bloc arborescence) | a completer→à compléter, reference→référence, Donnees→Données |

## Sécurité (invariants accent-corrector)

- Chaque mot source est **PURE ASCII** (accents manquants uniquement, pas de changement d'orthographe).
- **Garde d'idempotence** `strip_accents(new)==old` a **rejeté** `Jeun`→`Jeûne` (strip="Jeune"≠"Jeun") — correct : « Glycémie à jeun » est un français correct SANS accent sur « jeun ». Laisssé as-is.
- **Identifiants de code intacts** : `tests_automatises()`, `tester_convergence_genetique()`, `tester_validation_z3()`, etc. restent ASCII (noms de fonctions Python). Commandes pip/conda/pyro intactes.
- **Markdown uniquement** (18 ins / 18 del, remplacements 1:1, structure intacte) → pas de re-exec (exception markdown C.2).

## Périmètre

- **Atomique** : 1 sujet cohérent (accents famille CaseStudies), 3 fichiers, 18 lignes, markdown-only.
- **Non-collision** : aucun PR ouvert sur CaseStudies.
- Rotation famille (Probas→CaseStudies) pour anti-tunnel.

See #2876

Co-Authored-By: Claude-Code <noreply@anthropic.com>