### PR TITLE
fix(ml): demote Indice hint-asides to inline bold in Day4-Foundations Labs (EPIC #3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb
@@ -881,7 +881,7 @@
   {
    "cell_type": "markdown",
    "id": "4e32bd65",
-   "source": "## Exercice : Chat Multi-Tours avec Contexte Data Science\n\nUtilisez l'interface `chat()` du client LLM pour construire une conversation specialisee en data science. L'objectif est de simuler un assistant qui guide un utilisateur dans son analyse de donnees etapes par etapes.\n\n### Objectifs\n1. Construire un historique de conversation avec 3 echanges\n2. Utiliser un system prompt specialise data science\n3. Observer comment le contexte precedent influence les reponses\n\n### Indice\n- Utilisez `client.chat(messages)` avec une liste de dictionnaires `{\"role\": \"user\"/\"assistant\", \"content\": \"...\"}`\n- Commencez par un message system via le premier element de la liste",
+   "source": "## Exercice : Chat Multi-Tours avec Contexte Data Science\n\nUtilisez l'interface `chat()` du client LLM pour construire une conversation specialisee en data science. L'objectif est de simuler un assistant qui guide un utilisateur dans son analyse de donnees etapes par etapes.\n\n### Objectifs\n1. Construire un historique de conversation avec 3 echanges\n2. Utiliser un system prompt specialise data science\n3. Observer comment le contexte precedent influence les reponses\n\n**Indice :**\n- Utilisez `client.chat(messages)` avec une liste de dictionnaires `{\"role\": \"user\"/\"assistant\", \"content\": \"...\"}`\n- Commencez par un message system via le premier element de la liste",
    "metadata": {}
   },
   {
@@ -903,7 +903,7 @@
   {
    "cell_type": "markdown",
    "id": "b6a501b2",
-   "source": "## Exercice : Exploration des Parametres de Generation\n\nExperimentez avec les parametres `temperature` et `max_tokens` pour comprendre leur impact sur la qualite des reponses d'un agent. L'objectif est de trouver les parametres optimaux pour differentes taches d'agent.\n\n### Objectifs\n1. Tester 3 valeurs de temperature (0.1, 0.7, 1.5) sur un prompt technique\n2. Observer l'impact de `max_tokens` sur la longueur des reponses\n3. Determiner les parametres ideaux pour du code generation vs. du texte creatif\n\n### Indice\n- `client.generate(prompt, temperature=0.1, max_tokens=100)` pour controler la generation\n- Temperature basse = reponses deterministes (ideal pour du code)\n- Temperature haute = reponses creatives (ideal pour du brainstorming)",
+   "source": "## Exercice : Exploration des Parametres de Generation\n\nExperimentez avec les parametres `temperature` et `max_tokens` pour comprendre leur impact sur la qualite des reponses d'un agent. L'objectif est de trouver les parametres optimaux pour differentes taches d'agent.\n\n### Objectifs\n1. Tester 3 valeurs de temperature (0.1, 0.7, 1.5) sur un prompt technique\n2. Observer l'impact de `max_tokens` sur la longueur des reponses\n3. Determiner les parametres ideaux pour du code generation vs. du texte creatif\n\n**Indice :**\n- `client.generate(prompt, temperature=0.1, max_tokens=100)` pour controler la generation\n- Temperature basse = reponses deterministes (ideal pour du code)\n- Temperature haute = reponses creatives (ideal pour du brainstorming)",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
@@ -949,7 +949,7 @@
   {
    "cell_type": "markdown",
    "id": "6f136d57",
-   "source": "## Exercice : Tool Personnalise pour l'Agent\n\nAjoutez un nouveau tool `detect_outliers(column, method='iqr')` a l'agent `EnhancedDataAgent`. Ce tool doit detecter les valeurs aberrantes dans une colonne numerique et retourner le nombre d'outliers et leurs indices.\n\n### Objectifs\n1. Implementer une fonction `detect_outliers` utilisant la methode IQR (Interquartile Range)\n2. L'integrer dans le namespace de `_execute_code`\n3. Tester l'agent sur la colonne `price` du DataFrame de ventes\n\n### Indice\n- IQR = Q3 - Q1. Un outlier est une valeur < Q1 - 1.5*IQR ou > Q3 + 1.5*IQR\n- Ajoutez votre fonction dans le dictionnaire `namespace` de `_execute_code`\n- N'oubliez pas de mentionner le tool dans `_get_system_prompt`",
+   "source": "## Exercice : Tool Personnalise pour l'Agent\n\nAjoutez un nouveau tool `detect_outliers(column, method='iqr')` a l'agent `EnhancedDataAgent`. Ce tool doit detecter les valeurs aberrantes dans une colonne numerique et retourner le nombre d'outliers et leurs indices.\n\n### Objectifs\n1. Implementer une fonction `detect_outliers` utilisant la methode IQR (Interquartile Range)\n2. L'integrer dans le namespace de `_execute_code`\n3. Tester l'agent sur la colonne `price` du DataFrame de ventes\n\n**Indice :**\n- IQR = Q3 - Q1. Un outlier est une valeur < Q1 - 1.5*IQR ou > Q3 + 1.5*IQR\n- Ajoutez votre fonction dans le dictionnaire `namespace` de `_execute_code`\n- N'oubliez pas de mentionner le tool dans `_get_system_prompt`",
    "metadata": {}
   },
   {
@@ -971,7 +971,7 @@
   {
    "cell_type": "markdown",
    "id": "14654e9c",
-   "source": "## Exercice : Robustesse du Code Generation\n\nTestez la robustesse de l'agent face a des questions ambigues ou mal formulees. L'objectif est d'identifier les limites du systeme de generation de code et de proposer des strategies d'amelioration du prompt systeme.\n\n### Objectifs\n1. Poser 3 questions volontairement ambigues a l'agent\n2. Analyser les erreurs generees et les classer par type\n3. Proposer une amelioration du prompt systeme pour chaque type d'erreur\n\n### Indice\n- Types d'ambiguite : noms de colonnes inexacts, questions vagues, demandes impossibles\n- Observez si le LLM demande des clarifications ou s'il devine et se trompe",
+   "source": "## Exercice : Robustesse du Code Generation\n\nTestez la robustesse de l'agent face a des questions ambigues ou mal formulees. L'objectif est d'identifier les limites du systeme de generation de code et de proposer des strategies d'amelioration du prompt systeme.\n\n### Objectifs\n1. Poser 3 questions volontairement ambigues a l'agent\n2. Analyser les erreurs generees et les classer par type\n3. Proposer une amelioration du prompt systeme pour chaque type d'erreur\n\n**Indice :**\n- Types d'ambiguite : noms de colonnes inexacts, questions vagues, demandes impossibles\n- Observez si le LLM demande des clarifications ou s'il devine et se trompe",
    "metadata": {}
   },
   {


### PR DESCRIPTION
## Summary

Correction de la pathologie **HINT-AS-HEADING** dans **ML/DataScienceWithAgents, Day4-Foundations** (EPIC #3966, cross-lane pick). Lab8-ADK-Introduction et Lab9-First-ADK-Agent ont chacun 2 cellules markdown d'exercice de la forme `## Exercice` > `### Objectifs` > `### Indice`. Le `### Indice` (H3) rendait l'indice en **section navigable du TOC**, alors que selon la convention repo-wide établie par [#4127](https://github.com/jsboige/CoursIA/pull/4127) (Sudoku) et [#4691](https://github.com/jsboige/CoursIA/pull/4691) (genai), un indice doit être un label inline bold `**Indice :**` (annotation de corps), pas un heading.

## Changement (typo-only, anti-regression-safe)

2 notebooks, 4 asides démotes, **convention EXACTE de #4127/#4691** (`**Indice :**` inline bold + deux-points) :

| Notebook | Cellules | Avant (H3 heading) | Après (inline bold) |
|----------|----------|--------------------|---------------------|
| Lab8-ADK-Introduction | 25, 27 | `### Indice` ×2 | `**Indice :**` ×2 |
| Lab9-First-ADK-Agent | 25, 27 | `### Indice` ×2 | `**Indice :**` ×2 |

**Seul le marqueur de heading change** (`### ` → `**` … ` :**`). Le texte pédagogique est préservé verbatim (directive §4). La **section structurelle sœur** `### Objectifs` est **préservée** — c'est une vraie sous-section (liste d'objectifs), pas un hint. Markdown-only → pas de re-exec (exception C.2).

## Note technique

Ces notebooks ML stockent le `source` des cellules en **STRING** (pas en list). Le fix utilise `re.sub` avec `re.MULTILINE` sur la string, en préservant le format string au re-dump (pas de conversion list→string = pas de churn C102).

## Vérification

**Scanner source-level** (`scan_md_hierarchy.py`) :
```
AVANT : 2/2 notebooks flagged (Lab8 cells 25,27 + Lab9 cells 25,27 — ### Indice)
APRÈS : 0/2 notebooks flagged
```

**Diff réel** :
```
2 files changed, 4 insertions(+), 4 deletions(-)
"### Indice\n"  ->  "**Indice :**\n"   (heading-only, pas de churn CRLF)
0 changement code-cell / execution_count / outputs  (markdown-only)
```
`### Objectifs` préservé dans les 4 cellules. Source format `str` préservé.

## Collision

git log récent ML/AgenticDataScience = Mermaid (#4497/#4498 by jsboige) + scrubbing + anchors. **Aucune** mise-en-forme hint-aside par po-2025 (po-2025 est sur tests/accents/SymbolicLearning). ML est large (17 Labs), 1-éditeur/notebook + claim-first posté sur dashboard.

## Scope

- 2 fichiers, +4/-4. Atomique (un sujet = fix HINT-AS-HEADING Indice dans Day4-Foundations Labs).
- Branche fresh `origin/main`. Suit la convention #4127/#4691.
- Aucun notebook code touché. Aucun submodule. Aucun CATALOG.

See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
