### PR TITLE
fix(genai-texte): demote Indice/Etape hint-asides from H1 to inline bold in OWUI Native API (EPIC #3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/20_OWUI_Native_API.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/20_OWUI_Native_API.ipynb
@@ -469,10 +469,10 @@
     "\n",
     "Ecrire une fonction `capacites(config)` qui prend le dictionnaire renvoye par `GET /api/config` et renvoie un **verdict lisible** : quelles features sont activees (`websocket`, `signup`, `ldap`), quel est le mode d'authentification (builtin / OAuth / header de confiance).\n",
     "\n",
-    "# Indice : le sous-dictionnaire `config[\"features\"]` contient les drapeaux booleens.\n",
-    "# Etape 1 : extraire `features` puis tester chaque cle avec `.get(key, False)`.\n",
-    "# Etape 2 : construire une liste de chaines \"active\"/\"inactive\" par feature.\n",
-    "# Etape 3 : le mode d'auth = \"header de confiance\" si `auth_trusted_header` vrai, sinon \"builtin\"."
+    "**Indice :** le sous-dictionnaire `config[\"features\"]` contient les drapeaux booleens.\n",
+    "- **Etape 1 :** extraire `features` puis tester chaque cle avec `.get(key, False)`.\n",
+    "- **Etape 2 :** construire une liste de chaines \"active\"/\"inactive\" par feature.\n",
+    "- **Etape 3 :** le mode d'auth = \"header de confiance\" si `auth_trusted_header` vrai, sinon \"builtin\"."
    ]
   },
   {
@@ -521,9 +521,9 @@
     "\n",
     "Ecrire `sonde(url_tenant)` qui ping `GET /health` **et** `GET /api/version` d'un tenant OWUI quelconque, et renvoie un resume compact `(ok: bool, version: str)`. Bonus : l'appliquer a un second tenant (ex `https://epf.open-webui.myia.io`) et comparer les versions.\n",
     "\n",
-    "# Indice : reutiliser `http_get` defini en §0 ; gerer le cas ou le tenant est injoignable (status 0).\n",
-    "# Etape 1 : deux appels (health, version) via http_get sur le meme tenant.\n",
-    "# Etape 2 : ok = (status health == 200) ; version = payload version.get(\"version\")."
+    "**Indice :** reutiliser `http_get` defini en §0 ; gerer le cas ou le tenant est injoignable (status 0).\n",
+    "- **Etape 1 :** deux appels (health, version) via http_get sur le meme tenant.\n",
+    "- **Etape 2 :** ok = (status health == 200) ; version = payload version.get(\"version\")."
    ]
   },
   {
@@ -571,9 +571,9 @@
     "\n",
     "Ecrire `modeles_authentifies(token)` qui renvoie le nombre de modeles exposes via `GET /api/v1/models` si le jeton est valide, et le string `\"RECOVERABLE-MACHINE\"` si le jeton est `None`. La signature est volontairement identique au code de la §2 — l'objectif est de formaliser le **pattern defensif reutilisable**.\n",
     "\n",
-    "# Indice : la cellule models-auth-code (§2) contient deja la logique ; l'exercice = l'encapsuler proprement.\n",
-    "# Etape 1 : si token is None -> retourner \"RECOVERABLE-MACHINE\".\n",
-    "# Etape 2 : sinon http_get(\"/api/v1/models\", token=token) -> retourner len(payload) si liste."
+    "**Indice :** la cellule models-auth-code (§2) contient deja la logique ; l'exercice = l'encapsuler proprement.\n",
+    "- **Etape 1 :** si token is None -> retourner \"RECOVERABLE-MACHINE\".\n",
+    "- **Etape 2 :** sinon http_get(\"/api/v1/models\", token=token) -> retourner len(payload) si liste."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Correction de la pathologie **HINT-AS-HEADING** dans **GenAI/Texte/20_OWUI_Native_API.ipynb** (EPIC #3966, cross-lane pick, nouvelle famille pour po-2024 — casse le tunnel .NET). Les cellules d'exercice `### Exercice N` (H3, 20 px) contenaient leurs indices/étapes écrits en **H1** (`# Indice :`, `# Etape N :` = 29 px) — **plus gros que le titre H3 de l'exercice qui les contient**. C'est exactement la pathologie signalée par le user : *« les indices donnés aux exercices apparaissent comme les éléments de police la plus grande alors que ça devrait être l'inverse »*.

Même pattern + même fix que MGS-15 ([#4693](https://github.com/jsboige/CoursIA/pull/4693)) : `### Exercice` (H3) > `# Indice`/`# Etape` (H1).

## Changement (typo-only, anti-regression-safe)

1 notebook, 3 cellules (17, 19, 21), 10 hint-asides H1 démotes :

| Avant (H1, 29 px) | Après (convention #4127 + #4693) |
|-------------------|----------------------------------|
| `# Indice : <texte>` | `**Indice :** <texte>` (gras inline) |
| `# Etape N : <texte>` | `- **Etape N :** <texte>` (liste + gras) |

**Seul le marqueur de heading change** (`# ` → `**` … ` :**` / `- **`). Le texte pédagogique est préservé verbatim (directive §4 : « changer le niveau d'un heading n'est pas changer le contenu pédagogique »). Les sections structurelles (`### Exercice N`, le titre du notebook `# 20. OWUI ...`) sont **préservées**. Markdown-only → pas de re-exec (exception C.2).

## Vérification

**Scanner source-level** (`scan_md_hierarchy.py`) :
```
AVANT : MULTI-H1 (11 H1) + H1-DEEP x10 + HINT-AS-HEADING x10
APRÈS : 0/1 notebooks flagged
```
Les 11 H1 se décomposaient en : 1 titre légitime (cell 0) + 10 hint-asides d'exercice (cells 17/19/21). La démotions des 10 asides résout MULTI-H1 (11→1), H1-DEEP et HINT-AS-HEADING simultanément.

**Diff réel** :
```
1 file changed, 10 insertions(+), 10 deletions(-)
- "# Indice : ..."   ->  "**Indice :** ..."
- "# Etape N : ..."  ->  "- **Etape N :** ..."
0 changement code-cell / execution_count / outputs  (markdown-only)
```
Source format `list` + `indent=1` préservés (pas de churn C102). Texte pédagogique verbatim (accents `§`, backticks, guillemets préservés).

## Collision

git log récent sur 20_OWUI = création/companion `f4a13a118` (#4544, ai-01/po-2023). **Aucune** mise-en-forme hint-aside récente, **aucun PR OPEN** touchant ce notebook (po-2023 actif sur genai-**audio** #4691, pas Texte). Claim-first posté sur dashboard CoursIA-2. 1 éditeur/notebook respecté.

## Scope

- 1 fichier, +10/-10. Atomique (un sujet = fix HINT-AS-HEADING dans GenAI/Texte/OWUI).
- Branche fresh `origin/main`. Convention #4127 (user) + #4693 (MGS-15, pattern identique).
- Aucun notebook code touché. Aucun submodule. Aucun CATALOG.

See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
