### PR TITLE
style(semanticweb): fix heading hierarchy in RDF.Net-Legacy (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "# Introduction au web sémantique avec RDF.Net\n",
+    "\n",
     "**Navigation** : [Index](../SemanticWeb/README.md)\n",
     "\n",
     "> **DEPRECIE** : Ce notebook monolithique a ete remplace par la serie **[SemanticWeb](../SemanticWeb/README.md)** (13 notebooks, ~10h).\n",
@@ -41,8 +43,6 @@
     "tags": []
    },
    "source": [
-    "# Introduction au web sémantique avec RDF.Net\n",
-    "\n",
     "## A. Présentation des technologies utilisées\n",
     "\n",
     "### 1. RDF\n",
@@ -8260,7 +8260,7 @@
     "tags": []
    },
    "source": [
-    "### Note sur la section Virtuoso\n",
+    "**Note sur la section Virtuoso :**\n",
     "\n",
     "La cellule suivante tente de se connecter a **Virtuoso**, un Triple Store serveur.\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb
@@ -8260,7 +8260,7 @@
     "tags": []
    },
    "source": [
-    "**Note sur la section Virtuoso :**\n",
+    "### Note sur la section Virtuoso\n",
     "\n",
     "La cellule suivante tente de se connecter a **Virtuoso**, un Triple Store serveur.\n",
     "\n",


### PR DESCRIPTION
## Summary

Markdown-only heading-hierarchy fix in the deprecated monolithic `RDF.Net-Legacy/RDF.Net.ipynb` notebook (missed by the prior SemanticWeb #3966 pass #3987).

### H1-DEEP (cell 1 -> cell 0) — title promoted to first markdown cell
The notebook title `# Introduction au web sémantique avec RDF.Net` sat in **cell 1**, after the nav/deprecation banner (cell 0 had no H1). Convention ([docs/reference/notebook-formatting.md](docs/reference/notebook-formatting.md) §1.1): **a single `#` H1 = the title, in the first markdown cell**; everything else starts at `##`. Sibling notebooks (SW-1, SW-10) follow this pattern.

Fix: move the title H1 (+ blank line) from the top of cell 1 to the top of cell 0, before the nav banner. Cell 1 now starts at `## A. Présentation des technologies utilisées`. **This is the genuine hierarchy bug.**

### NOT changed (reverted) — cell 163 'Note sur la section Virtuoso'
An initial revision also demoted cell 163 `### Note sur la section Virtuoso` to inline bold. **Reverted** after po-2024 (C117, 2026-07-01) independently grounded this cell and classified it as a documented scanner **false-positive class** ('keyword aside on a real section'). The cell is a substantive informational section (intro paragraph + 'Pourquoi cette section est optionnelle' + 'Alternative pour tester Trinity' + 'Message d'erreur attendu' code block + advanced-users callout) — not a brief exercise-hint callout. The scanner's known FP class explicitly names `Note`/`Rappel` as over-triggers on real sections. Left as `###`.

`scan_md_hierarchy` therefore still flags this notebook 1/1 — but the remaining flag is the acknowledged FP above. The H1-DEEP (the real bug) is fixed.

## Validation
- `scan_md_hierarchy.py` : H1-DEEP flag cleared (cell 1 title was the flagged H1-DEEP; now in cell 0).
- Markdown-only : **no code cells touched** (verified — 0 `raise NotImplementedError`/`assert False`/`1/0` across all 174 cells), **no re-execution needed** (C.2 exception for markdown-only edits).
- `git diff` vs main : 1 file, only the title H1 relocated (cell1 -> cell0). Surgical — byte-identical JSON round-trip verified before edit, zero collateral formatting churn.

## Scope
Atomic, single notebook, single family, markdown-only. Touches no code, no submodules, no catalogue.

See #3966

Co-Authored-By: Claude <noreply@anthropic.com>