### PR TITLE
feat(search): Search-13 Limited Discrepancy Search (Partie 3 croissance)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/README.md
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/README.md
@@ -25,8 +25,9 @@ Cette partie occupe une position charnière. Elle **prolonge la Partie 1** (rech
 | # | Notebook | Kernel | Contenu | Durée | Prérequis |
 |---|----------|--------|---------|-------|-----------|
 | 1 | [Search-12-PatternDatabases](Search-12-PatternDatabases.ipynb) | Python 3 | Pattern Databases (Culberson & Schaeffer 1996), PDB additives (Korf & Felner 2002), 15-puzzle optimal, IDA\* | ~1h30 | [Search-3](../Part1-Foundations/Search-3-Informed.ipynb) |
+| 2 | [Search-13-LimitedDiscrepancySearch](Search-13-LimitedDiscrepancySearch.ipynb) | Python 3 | Limited Discrepancy Search (Harvey & Ginsberg 1995), sac à dos 0/1, greedy vs LDS(k) vs exhaustif | ~45min | [Search-3](../Part1-Foundations/Search-3-Informed.ipynb) |
 
-Cette partie est en croissance : d'autres techniques de recherche avancée (heuristiques à mémoire, recherche de ramification limitée, abstractions) pourront s'y ajouter.
+Les deux notebooks répondent à la même question — « l'heuristique ne suffit pas à résoudre à l'optimum » — par deux stratégies **complémentaires** : Search-12 *renforce* l'heuristique (précalcul d'une PDB plus informée), Search-13 *borne les écarts* à l'heuristique dont on dispose (parier que l'optimum est un proche voisin du chemin greedy). Cette partie reste en croissance : d'autres techniques avancées (heuristiques à mémoire, recherche anytime, abstractions) pourront s'y ajouter.
 
 ## Prérequis & environnement
 
@@ -56,6 +57,7 @@ Couverture par notebook des sources fondatrices mobilisées dans cette partie :
 | Search-12 (15-puzzle optimal) | Korf, R. E. (1985) — « Depth-First Iterative-Deepening: An Optimal Admissible Tree Search », *Artificial Intelligence* 27(1). L'article fondateur d'IDA\*, établit le 15-puzzle comme banc d'essai de la recherche à l'optimum. |
 | Search-12 (Pattern Databases) | Culberson, J. C., & Schaeffer, J. (1996) — « Searching with Pattern Databases », *Advances in Artificial Intelligence (AI'97)*. Origine des Pattern Databases par retournement du problème. |
 | Search-12 (PDB additives) | Korf, R. E., & Felner, A. (2002) — « Disjoint Pattern Database Heuristics », *Artificial Intelligence* 134(1-2). Les PDB additives disjointes — l'heuristique SOTA qui résout le 15-puzzle (puis le 24-puzzle) à l'optimum. |
+| Search-13 (Limited Discrepancy Search) | Harvey, W. D., & Ginsberg, M. L. (1995) — « Limited Discrepancy Search », *Proceedings of IJCAI*. Formalise le principe « l'optimum est un proche voisin du greedy » et l'algorithme LDS(k) qui énumère les chemins à au plus k écarts de l'heuristique. |
 
 ---
 

--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch.ipynb
@@ -1,0 +1,595 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6558d065",
+   "metadata": {},
+   "source": [
+    "# Search-13 — Recherche à écart limité (Limited Discrepancy Search)\n",
+    "\n",
+    "> **Partie 3 — Recherche avancée.** Ce notebook prolonge la Partie 3 : techniques\n",
+    "> de recherche heuristique *avancées*, au-delà des fondations de la\n",
+    "> [Partie 1](../Part1-Foundations/Search-3-Informed.ipynb) (A\\\\*, IDA\\\\*, heuristiques\n",
+    "> admissibles). Là où [Search-12](Search-12-PatternDatabases.ipynb) fabriquait une\n",
+    "> heuristique *assez informée* pour résoudre à l'optimum par précalcul, ici nous\n",
+    "> partons d'une heuristique *déjà bonne mais imparfaite* et demandons : comment\n",
+    "> trouver l'optimum **sans explorer tout l'arbre** ?\n",
+    "\n",
+    "## 1. L'idée : une bonne heuristique se trompe peu\n",
+    "\n",
+    "La recherche exhaustive (DFS sur tout l'arbre) trouve l'optimum mais coûte $2^n$\n",
+    "feuilles — prohibitif. La stratégie *greedy* (suivre aveuglément la recommandation\n",
+    "de l'heuristique) est instantanée mais **myope** : elle se contente du premier\n",
+    "chemin, parfois sous-optimal. Entre ces deux extrêmes, **Limited Discrepancy Search**\n",
+    "(Harvey & Ginsberg, 1995) exploite une intuition forte :\n",
+    "\n",
+    "> Si l'heuristique est *bonne*, la solution optimale s'écarte de **peu** de ses\n",
+    "> recommandations.\n",
+    "\n",
+    "Un **écart** (*discrepancy*) est, à un nœud, le choix d'un enfant que l'heuristique\n",
+    "ne recommande **pas** en premier (rang > 0). LDS(k) énumère exactement les chemins\n",
+    "comportant **au plus k écarts** : à k=0 c'est le greedy ; à k croissant on élargit\n",
+    "progressivement le voisinage du chemin greedy, sans jamais payer le coût exponentiel\n",
+    "de la DFS complète. C'est l'incarnation algorithmique du principe « l'optimum est un\n",
+    "voisin du greedy ». \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0cd36e5",
+   "metadata": {},
+   "source": [
+    "## 2. Le problème-banc d'essai : le sac à dos 0/1\n",
+    "\n",
+    "Le **sac à dos binaire** (*0/1 knapsack*) est NP-diff et se prête naturellement à\n",
+    "une recherche arborescente. On dispose de $n$ objets, chacun avec un poids $w_i$ et\n",
+    "une valeur $v_i$, et d'une capacité $C$. On veut maximiser la valeur totale sans\n",
+    "dépasser $C$ — en décidant, pour chaque objet, de le **prendre** ou de le **laisser**.\n",
+    "C'est un arbre de décision binaire de profondeur $n$.\n",
+    "\n",
+    "L'**heuristique gloutonne** canonique ordonne les objets par **ratio valeur/poids\n",
+    "décroissant** et, à chaque nœud, recommande de **prendre** l'objet courant s'il\n",
+    "rentre. Cette heuristique est *bonne* (les objets à fort ratio sont rarement un\n",
+    "mauvais choix) mais **imparfaite** : un objet à ratio élevé peut en *bloquer* deux\n",
+    "de ratio moyen dont la somme dépasse sa valeur — auquel cas le greedy se trompe.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3257e194",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T07:35:57.957314Z",
+     "iopub.status.busy": "2026-07-01T07:35:57.957176Z",
+     "iopub.status.idle": "2026-07-01T07:35:57.962466Z",
+     "shell.execute_reply": "2026-07-01T07:35:57.961770Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Objets dans l'ordre heuristique (ratio v/w decroissant) :\n",
+      "  A: ratio = 1.333\n",
+      "  B: ratio = 1.200\n",
+      "  C: ratio = 1.200\n",
+      "  D: ratio = 0.500\n",
+      "  E: ratio = 0.333\n",
+      "  F: ratio = 0.000\n",
+      "  G: ratio = 0.000\n",
+      "Capacite C = 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le sac a dos 0/1 : liste d'objets (nom, poids, valeur), ordonnes par RATIO valeur/poids decroissant\n",
+    "# (c'est l'ordre ou l'heuristique gloutonne les considere).\n",
+    "items = [\n",
+    "    (\"A\", 6, 8),   # ratio 1.33  <-- top ratio, MAIS poids 6 bloque la paire B+C (valeur 12 > 10)\n",
+    "    (\"B\", 5, 6),   # ratio 1.20\n",
+    "    (\"C\", 5, 6),   # ratio 1.20\n",
+    "    (\"D\", 4, 2),   # ratio 0.50\n",
+    "    (\"E\", 3, 1),   # ratio 0.33\n",
+    "    (\"F\", 2, 0),   # ratio 0.00  (objet de valeur nulle -- piege pour le greedy s'il reste de la place)\n",
+    "    (\"G\", 1, 0),   # ratio 0.00  (objet de valeur nulle -- piege pour le greedy)\n",
+    "]\n",
+    "CAPACITY = 10\n",
+    "\n",
+    "# Verifions l'ordre par ratio (l'heuristique suppose cet ordre).\n",
+    "ratios = [(name, v / w if w > 0 else float(\"inf\")) for name, w, v in items]\n",
+    "print(\"Objets dans l'ordre heuristique (ratio v/w decroissant) :\")\n",
+    "for name, r in ratios:\n",
+    "    print(f\"  {name}: ratio = {r:.3f}\")\n",
+    "print(f\"Capacite C = {CAPACITY}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d73e1e03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T07:35:57.964022Z",
+     "iopub.status.busy": "2026-07-01T07:35:57.963873Z",
+     "iopub.status.idle": "2026-07-01T07:35:57.967467Z",
+     "shell.execute_reply": "2026-07-01T07:35:57.966918Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Greedy (k=0) : valeur = 10, selection = ['A', 'D']\n",
+      "--> Le greedy prend A (poids 6, valeur 8), puis il ne reste que 4 de capacite :\n",
+      "    seul D (poids 4) y rentre. Greedy = {A, D} = 10. La paire B+C (valeur 12) est bloquee par A.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# StratEGIE GLOUTONNE (k=0) : suivre l'heuristique aveuglement -- prendre chaque objet s'il rentre.\n",
+    "def greedy_knapsack(items, capacity):\n",
+    "    selection, total_w, total_v = [], 0, 0\n",
+    "    for name, w, v in items:\n",
+    "        if total_w + w <= capacity:        # heuristique : prendre si ca rentre\n",
+    "            selection.append(name)\n",
+    "            total_w += w\n",
+    "            total_v += v\n",
+    "    return total_v, selection, \"greedy\"\n",
+    "\n",
+    "gv, gsel, _ = greedy_knapsack(items, CAPACITY)\n",
+    "print(f\"Greedy (k=0) : valeur = {gv}, selection = {gsel}\")\n",
+    "print(\"--> Le greedy prend A (poids 6, valeur 8), puis il ne reste que 4 de capacite :\")\n",
+    "print(\"    seul D (poids 4) y rentre. Greedy = {A, D} = 10. La paire B+C (valeur 12) est bloquee par A.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fa39111",
+   "metadata": {},
+   "source": [
+    "## 3. Le concept d'écart, et l'algorithme LDS(k)\n",
+    "\n",
+    "À chaque nœud, l'heuristique **recommande** une action (prendre l'objet s'il rentre,\n",
+    "sinon le laisser). Choisir l'**autre** action coûte **un écart** :\n",
+    "\n",
+    "- Objet prenable : rang 0 = **prendre** (recommande), rang 1 = **laisser** (1 ecart).\n",
+    "- Objet non prenable (trop lourd) : rang 0 = **laisser** (seule option realisable).\n",
+    "\n",
+    "`LDS(k)` descend en privilégiant l'action recommandée, et n'emprunte une branche\n",
+    "« contraire » que si le budget d'écarts `k` n'est pas épuisé. Elle énumère ainsi tous\n",
+    "les chemins à **au plus k** écarts, et retient la meilleure valeur rencontrée. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "87413e2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T07:35:57.969131Z",
+     "iopub.status.busy": "2026-07-01T07:35:57.968917Z",
+     "iopub.status.idle": "2026-07-01T07:35:57.974527Z",
+     "shell.execute_reply": "2026-07-01T07:35:57.973888Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "k | valeur | selection        | nœuds explores\n",
+      "--|--------|-----------------|----------------\n",
+      "0 |     10 | ['A', 'D']      | 8\n",
+      "1 |     12 | ['B', 'C']      | 19\n",
+      "2 |     12 | ['B', 'C']      | 34\n",
+      "3 |     12 | ['B', 'C']      | 52\n",
+      "4 |     12 | ['B', 'C']      | 73\n",
+      "5 |     12 | ['B', 'C']      | 91\n",
+      "6 |     12 | ['B', 'C']      | 98\n",
+      "7 |     12 | ['B', 'C']      | 99\n"
+     ]
+    }
+   ],
+   "source": [
+    "def lds_knapsack(items, capacity, k_max):\n",
+    "    # LDS(k_max) sur le sac a dos 0/1.\n",
+    "    # items : liste (nom, poids, valeur), ordre heuristique (meilleur ratio d'abord).\n",
+    "    # Renvoie (meilleure valeur, meilleure selection, nombre de noeuds explores).\n",
+    "    n = len(items)\n",
+    "    best = {\"value\": -1, \"sel\": None}\n",
+    "    nodes = [0]\n",
+    "\n",
+    "    def rec(i, rem_cap, val_so_far, sel, disc):\n",
+    "        nodes[0] += 1\n",
+    "        if i == n:                                   # feuille : on enregistre une solution\n",
+    "            if val_so_far > best[\"value\"]:\n",
+    "                best[\"value\"] = val_so_far\n",
+    "                best[\"sel\"] = list(sel)\n",
+    "            return\n",
+    "        name, w, v = items[i]\n",
+    "        can_take = w <= rem_cap\n",
+    "        if can_take:\n",
+    "            # Rang 0 (recommande) : PRENDRE -- n'epargne aucun ecart.\n",
+    "            sel.append(name)\n",
+    "            rec(i + 1, rem_cap - w, val_so_far + v, sel, disc)\n",
+    "            sel.pop()\n",
+    "            # Rang 1 (contraire) : LAISSER -- coute 1 ecart, si budget reste.\n",
+    "            if disc < k_max:\n",
+    "                rec(i + 1, rem_cap, val_so_far, sel, disc + 1)\n",
+    "        else:\n",
+    "            # Objet trop lourd : seule action realisable = laisser (rang 0, sans ecart).\n",
+    "            rec(i + 1, rem_cap, val_so_far, sel, disc)\n",
+    "\n",
+    "    rec(0, capacity, 0, [], 0)\n",
+    "    return best[\"value\"], best[\"sel\"], nodes[0]\n",
+    "\n",
+    "\n",
+    "# Balayage k = 0, 1, 2, ... : a chaque increment on elargit le voisinage du greedy.\n",
+    "print(\"k | valeur | selection        | nœuds explores\")\n",
+    "print(\"--|--------|-----------------|----------------\")\n",
+    "for k in range(len(items) + 1):\n",
+    "    val, sel, nd = lds_knapsack(items, CAPACITY, k)\n",
+    "    print(f\"{k} | {val:6d} | {str(sel):15s} | {nd}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2d421db",
+   "metadata": {},
+   "source": [
+    "## 4. Référence : l'optimum par énumération exhaustive\n",
+    "\n",
+    "Pour prouver que LDS atteint bien le **vrai** optimum (et non une borne locale),\n",
+    "on calcule la solution optimale par énumération exhaustive de l'arbre binaire\n",
+    "complet ($2^n$ feuilles) puis par programmation dynamique. LDS devra converger vers\n",
+    "cette valeur à mesure que $k$ croît — idéalement pour un $k$ **petit**, bien avant\n",
+    "l'énumération complète.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6beeeb9c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T07:35:57.976084Z",
+     "iopub.status.busy": "2026-07-01T07:35:57.975936Z",
+     "iopub.status.idle": "2026-07-01T07:35:57.982106Z",
+     "shell.execute_reply": "2026-07-01T07:35:57.981434Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimum (exhaustif, 2^7 = 128 feuilles) : valeur = 12, selection = ['B', 'C']\n",
+      "Optimum (DP)                                         : valeur = 12, selection = ['B', 'C']\n",
+      "nœuds explores par l'exhaustif : 128\n"
+     ]
+    }
+   ],
+   "source": [
+    "from itertools import product\n",
+    "\n",
+    "def exhaustive_knapsack(items, capacity):\n",
+    "    # Optimum exact par enumeration exhaustive (2^n) -- reference de verite.\n",
+    "    n = len(items)\n",
+    "    best_v, best_sel, nodes = -1, None, 0\n",
+    "    for bits in product([0, 1], repeat=n):          # 2^n combinaisons\n",
+    "        nodes += 1\n",
+    "        w = sum(items[i][1] for i in range(n) if bits[i])\n",
+    "        v = sum(items[i][2] for i in range(n) if bits[i])\n",
+    "        if w <= capacity and v > best_v:\n",
+    "            best_v, best_sel = v, [items[i][0] for i in range(n) if bits[i]]\n",
+    "    return best_v, best_sel, nodes\n",
+    "\n",
+    "\n",
+    "def dp_knapsack(items, capacity):\n",
+    "    # Optimum exact par programmation dynamique (pseudo-polynomial) -- 2e reference.\n",
+    "    n = len(items)\n",
+    "    # dp[c] = meilleure valeur avec capacite c\n",
+    "    dp = [0] * (capacity + 1)\n",
+    "    keep = [[False] * (capacity + 1) for _ in range(n)]\n",
+    "    for i in range(n):\n",
+    "        name, w, v = items[i]\n",
+    "        for c in range(capacity, w - 1, -1):\n",
+    "            if dp[c - w] + v > dp[c]:\n",
+    "                dp[c] = dp[c - w] + v\n",
+    "                keep[i][c] = True\n",
+    "    # Reconstruction de la selection\n",
+    "    sel, c = [], capacity\n",
+    "    for i in range(n - 1, -1, -1):\n",
+    "        if keep[i][c]:\n",
+    "            sel.append(items[i][0])\n",
+    "            c -= items[i][1]\n",
+    "    return dp[capacity], list(reversed(sel))\n",
+    "\n",
+    "\n",
+    "opt_v, opt_sel, ex_nodes = exhaustive_knapsack(items, CAPACITY)\n",
+    "dp_v, dp_sel = dp_knapsack(items, CAPACITY)\n",
+    "print(f\"Optimum (exhaustif, 2^{len(items)} = {2**len(items)} feuilles) : valeur = {opt_v}, selection = {opt_sel}\")\n",
+    "print(f\"Optimum (DP)                                         : valeur = {dp_v}, selection = {dp_sel}\")\n",
+    "print(f\"nœuds explores par l'exhaustif : {ex_nodes}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "579af77d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T07:35:57.983745Z",
+     "iopub.status.busy": "2026-07-01T07:35:57.983591Z",
+     "iopub.status.idle": "2026-07-01T07:35:57.988322Z",
+     "shell.execute_reply": "2026-07-01T07:35:57.987782Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "strategie           valeur   optimal?     nœuds   % exhaustif\n",
+      "-------------------------------------------------------------\n",
+      "greedy (k=0)            10        non         8          6.2%\n",
+      "LDS(k=0)                10        non         8          6.2%\n",
+      "LDS(k=1)                12        OUI        19         14.8%\n",
+      "LDS(k=2)                12        OUI        34         26.6%\n",
+      "LDS(k=3)                12        OUI        52         40.6%\n",
+      "LDS(k=4)                12        OUI        73         57.0%\n",
+      "LDS(k=5)                12        OUI        91         71.1%\n",
+      "LDS(k=6)                12        OUI        98         76.6%\n",
+      "LDS(k=7)                12        OUI        99         77.3%\n",
+      "exhaustif (ref)         12        OUI       128        100.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tableau comparatif : greedy vs LDS(k) vs exhaustif -- QUALITE de solution et COUT (nœuds).\n",
+    "print(f\"{'strategie':<18}{'valeur':>8}{'optimal?':>11}{'nœuds':>10}{'% exhaustif':>14}\")\n",
+    "print(\"-\" * 61)\n",
+    "ex_total = ex_nodes\n",
+    "\n",
+    "def row(label, val, nd):\n",
+    "    opt = \"OUI\" if val == opt_v else \"non\"\n",
+    "    pct = 100.0 * nd / ex_total if ex_total else 0\n",
+    "    print(f\"{label:<18}{val:>8}{opt:>11}{nd:>10}{pct:>13.1f}%\")\n",
+    "\n",
+    "gv, _, _ = greedy_knapsack(items, CAPACITY)\n",
+    "row(\"greedy (k=0)\", gv, len(items) + 1)\n",
+    "for k in range(len(items) + 1):\n",
+    "    val, _, nd = lds_knapsack(items, CAPACITY, k)\n",
+    "    row(f\"LDS(k={k})\", val, nd)\n",
+    "row(\"exhaustif (ref)\", opt_v, ex_total)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a39ab96",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le **greedy** (k=0) est **sous-optimal** (valeur 10, sélection {A, D}) : il prend A au\n",
+    "ratio le plus élevé (1,33), qui remplit 6 des 10 unités de capacité et ne laisse de la\n",
+    "place que pour D — ratant la paire B+C dont la valeur (12) est supérieure. Dès **k=1**,\n",
+    "LDS explore le chemin « laisser A » et découvre l'optimum {B, C} = 12 — pour **19 nœuds\n",
+    "seulement**, soit 14,8 % des 128 feuilles de l'exhaustif $2^7$.\n",
+    "\n",
+    "Au-delà du $k$ suffisant, LDS continue d'explorer mais **ne trouve rien de meilleur**\n",
+    "(l'optimum est déjà atteint, la valeur stagne à 12 de k=1 à k=7) : c'est le signal pour\n",
+    "arrêter. C'est précisément ce qu'exploite **Iterative LDS** (exercice 1) : incrémenter\n",
+    "$k$ jusqu'à ce que la valeur cesse de croître, sans jamais payer le $2^n$ de l'exhaustif.\n",
+    "La leçon générale tient en une phrase : **quand l'heuristique est bonne, l'optimum est un\n",
+    "proche voisin du greedy, et LDS le trouve en bornant les écarts plutôt qu'en énumérant\n",
+    "l'arbre entier**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28866dde",
+   "metadata": {},
+   "source": [
+    "## 5. Ponts avec le reste de la série\n",
+    "\n",
+    "| Direction | Lien | Relation |\n",
+    "|-----------|------|----------|\n",
+    "| ← Fondations | [Search-3 — Informed](../Part1-Foundations/Search-3-Informed.ipynb) | A\\\\*, heuristiques admissibles — LDS suppose une heuristique *ordonnante* (qui range les enfants), notion voisine |\n",
+    "| ↔ Search-12 | [Search-12 — Pattern Databases](Search-12-PatternDatabases.ipynb) | Autre voie avancée : *renforcer* l'heuristique (PDB) plutôt que *borner les écarts* (LDS). Deux réponses à « l'heuristique ne suffit pas » |\n",
+    "| → Partie 4 | [Métaheuristiques](../Part4-Metaheuristics/README.md) | LDS garde l'exigence d'optimalité (la trouve pour k assez grand) ; les métaheuristiques l'abandonnent |\n",
+    "\n",
+    "**Référence fondatrice** : Harvey, W. D., & Ginsberg, M. L. (1995) — *Limited\n",
+    "Discrepancy Search*, Proceedings of IJCAI. L'article qui formalise le principe\n",
+    "« l'optimum est un voisin du greedy » et l'algorithme LDS(k).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34731b33",
+   "metadata": {},
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "### Exercice 1 : Iterative LDS (ILDS)\n",
+    "Implémentez **ILDS** : exécutez LDS pour k=0, 1, 2, … en vous arrêtant dès que la\n",
+    "valeur **stagne** (deux increments consécutifs sans amélioration) ou que k atteint n.\n",
+    "Comparez le nombre total de nœuds explorés par ILDS à l'énumération exhaustive sur\n",
+    "cette instance.\n",
+    "- **Indice :** le critère d'arrêt naturel est « la valeur n'a pas augmenté au pas k »\n",
+    "  (l'optimum est trouvé). Attention : stagnation ponctuelle ≠ optimum assuré tant que\n",
+    "  k < n — justifiez votre critère d'arrêt.\n",
+    "- **Objectif :** mesurer le gain (ratio des nœuds ILDS / exhaustif).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "94320df2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T07:35:57.989954Z",
+     "iopub.status.busy": "2026-07-01T07:35:57.989809Z",
+     "iopub.status.idle": "2026-07-01T07:35:57.992505Z",
+     "shell.execute_reply": "2026-07-01T07:35:57.991940Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 a completer\n",
+    "# Conseil : bouclez k = 0..n, accumulez les nœuds, arretez quand la valeur cesse de croitre.\n",
+    "# Comparez le total accumule a ex_nodes (l'exhaustif calcule ci-dessus).\n",
+    "total_nodes_ilds = 0\n",
+    "print(\"Exercice 1 a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e18a6a2",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : passage à l'échelle — LDS vs exhaustif\n",
+    "Construisez une instance plus grande (par ex. n=18 objets aléatoires, capacité ~50%\n",
+    "du poids total) où le greedy est sous-optimal. Mesurez :\n",
+    "1. Le **plus petit k** pour lequel LDS atteint l'optimum (vérifié via DP).\n",
+    "2. Le **ratio de nœuds** LDS(k\\*) / exhaustif ($2^{18} = 262\\,144$ feuilles).\n",
+    "- **Indice :** pour n=18 l'exhaustif est encore calculable ( DP ou 2^18) et sert de\n",
+    "  référence. Observez comment le ratio de nœuds se dégrade quand l'heuristique est\n",
+    "  *mauvaise* (ratio aléatoire) vs *bonne* (vraie valeur/poids).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ac243985",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T07:35:57.993915Z",
+     "iopub.status.busy": "2026-07-01T07:35:57.993784Z",
+     "iopub.status.idle": "2026-07-01T07:35:57.996299Z",
+     "shell.execute_reply": "2026-07-01T07:35:57.995832Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 a completer\n",
+    "# Conseil : genere n=18 objets avec des (poids, valeur) aleatoires, calcule l'optimum par DP,\n",
+    "# puis balaye k jusqu'a l'atteindre. Affiche le ratio LDS(k*)/2**18.\n",
+    "print(\"Exercice 2 a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e219e74",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : sensibilité à la qualité de l'heuristique\n",
+    "LDS suppose une heuristique *bonne*. Refaites le balayage k=0..n mais en **perturbant\n",
+    "l'ordre** des objets : (a) ordre aléatoire, (b) ordre par valeur absolue décroissante\n",
+    "(au lieu du ratio). Pour chaque heuristique, notez le **k minimum** pour atteindre\n",
+    "l'optimum.\n",
+    "- **Indice :** plus l'heuristique est *mauvaise*, plus l'optimum s'écarte du greedy,\n",
+    "  donc plus le k nécessaire est grand — LDS y perd son avantage. C'est la limite du\n",
+    "  paradigme : LDS n'est efficace que si l'heuristique est *effectivement* bonne.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bbd8fa31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T07:35:57.997711Z",
+     "iopub.status.busy": "2026-07-01T07:35:57.997584Z",
+     "iopub.status.idle": "2026-07-01T07:35:58.000749Z",
+     "shell.execute_reply": "2026-07-01T07:35:57.999902Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 a completer\n",
+    "# Conseil : permutez `items` selon differents ordres, et pour chacun cherchez le k min.\n",
+    "# Perturbation : essayez random.shuffle(items) (avec une graine fixee pour la reproductibilite).\n",
+    "print(\"Exercice 3 a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdb6cea2",
+   "metadata": {},
+   "source": [
+    "## 7. Conclusion\n",
+    "\n",
+    "**Limited Discrepancy Search** occupe une niche précise dans le spectre de la\n",
+    "recherche heuristique. À une extrémité, le **greedy** est instantané mais myope ;\n",
+    "à l'autre, la **DFS exhaustive** est exacte mais exponentielle. LDS exploite l'idée\n",
+    "que *si l'heuristique est bonne, l'optimum est un proche voisin du greedy* : en\n",
+    "bornant le nombre d'écarts (choix contraires à la recommandation), elle trouve\n",
+    "l'optimum pour un coût bien inférieur à $2^n$, **sans renoncer à l'optimalité**\n",
+    "(contrairement aux métaheuristiques de la Partie 4).\n",
+    "\n",
+    "La limite est symétrique du avantage : LDS n'est efficace que dans la mesure où\n",
+    "l'heuristique est *effectivement* bonne — une heuristique mauvaise repousse l'optimum\n",
+    "loin du greedy, et le $k$ nécessaire devient si grand que l'énumération bornée rejoint\n",
+    "l'exhaustive (exercice 3). C'est un algorithme qui **parie sur la qualité de\n",
+    "l'heuristique**, et qui gagne ce pari précisément quand les Pattern Databases de\n",
+    "[Search-12](Search-12-PatternDatabases.ipynb) ont déjà fait leur travail de\n",
+    "*renforcement* heuristique : les deux notebooks sont complémentaires — l'un fabrique\n",
+    "une meilleure heuristique, l'autre exploite au mieux celle dont on dispose.\n",
+    "\n",
+    "> **Prochaines étapes** : LDS se généralise en **ILDS** (itération sur k) et se\n",
+    "> combine avec le *beam search* et l'élagage par borne (*branch-and-bound*). Elle\n",
+    "> s'applique à tout arbre de recherche muni d'une heuristique ordonnante :\n",
+    "> ordonnancement, planification, satisfaction de contraintes.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -207,8 +207,8 @@ Les notebooks CSP nécessitent une compréhension préalable de :
 ## Partie 3 : Recherche heuristique avancée (`Part3-Advanced/`)
 
 Techniques de recherche avancées au-delà des fondations : heuristiques
-précalculées (pattern databases), recherches à mémoire. Cette partie fait le pont
-entre les fondations ([Partie 1](Part1-Foundations/Search-3-Informed.ipynb) :
+précalculées (pattern databases), recherche à écart limité (limited discrepancy search).
+Cette partie fait le pont entre les fondations ([Partie 1](Part1-Foundations/Search-3-Informed.ipynb) :
 A\*, IDA\*, heuristiques admissibles) et les métaheuristiques composables
 ([Partie 4](Part4-Metaheuristics/README.md)), sans relever de la programmation par
 contraintes ([Partie 2](Part2-CSP/CSP-1-Fundamentals.ipynb)).
@@ -216,6 +216,7 @@ contraintes ([Partie 2](Part2-CSP/CSP-1-Fundamentals.ipynb)).
 | # | Notebook | Durée | Contenu | Prérequis |
 |---|----------|-------|---------|-----------|
 | 1 | [Search-12-PatternDatabases](Part3-Advanced/Search-12-PatternDatabases.ipynb) | ~1h30 | Pattern Databases (Culberson & Schaeffer 1996), PDB additives (Korf & Felner 2002), 15-puzzle optimal, IDA\* | Search-3 |
+| 2 | [Search-13-LimitedDiscrepancySearch](Part3-Advanced/Search-13-LimitedDiscrepancySearch.ipynb) | ~45min | Limited Discrepancy Search (Harvey & Ginsberg 1995), sac à dos 0/1, greedy vs LDS(k) vs exhaustif | Search-3 |
 
 ---
 


### PR DESCRIPTION
## Summary

New notebook **Search-13-LimitedDiscrepancySearch.ipynb** (Part3-Advanced, Python 3) — the 2nd notebook in the "Recherche heuristique avancée" part, whose README explicitly invited growth. Implements **Limited Discrepancy Search** (Harvey & Ginsberg, 1995): enumerate tree paths with at most *k* discrepancies from the greedy heuristic's recommendation.

**Complementary to Search-12.** Both answer *"the heuristic is not enough to reach the optimum"* by opposite strategies: Search-12 *strengthens* the heuristic (precompute a more-informed Pattern Database); Search-13 *bounds the discrepancies* to the heuristic at hand (parieté: the optimum is a near-neighbor of the greedy path, so enumerate only near-greedy paths).

## Prong-B — non-trivial, honest (SOTA-not-workaround, EPIC #3801)

0/1 knapsack (NP-hard) with greedy value/weight-ratio heuristic. **Dataset crafted so greedy is genuinely suboptimal** (degenerate-free): top-ratio item A (poids 6, valeur 8) fills capacity and blocks the pair B+C (valeur 12 > 10).

**Verified by execution** (`nbconvert --execute`, python3 kernel, exit 0):
```
strategie     valeur  optimal?  nœuds  % exhaustif
greedy (k=0)     10     non        8    6.2%     <-- SUBOPTIMAL
LDS(k=1)         12     OUI       19   14.8%     <-- OPTIMUM
exhaustif(ref)   12     OUI      128  100.0%     (2^7 = 128)
```
- LDS reaches the true optimum (confirmed by exhaustive enumeration AND dynamic programming) at **k=1**, exploring **19 nodes** = 14.8% of the 128 exhaustive leaves.
- Value plateaus at 12 for k≥1 → the natural ILDS stop-signal (exercice 1).

## Validation

- Executed end-to-end: 8/8 code cells `execution_count` 1–8, **0 errors**, 24 KB committed with outputs (C.2).
- **0 voluntary-error patterns** (`raise NotImplementedError` / `assert False` / `1/0`): C.1-safe stubs (`print("Exercice a completer")`).
- **3 exercises** (ILDS, scaling n=18, heuristic-sensitivity) — convention `>=3 exercises/notebook`.
- **Prose written AFTER dumping outputs** (C110/C118 lesson): "Lecture du résultat" cites the actual numbers (greedy=10, LDS(k=1)=12, 19 nodes, 14.8%). No pre-written claim left unverified.
- Standard library only (`itertools`, no deps) — consistent with Search-12.

## Files

| File | Change |
|------|--------|
| `Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch.ipynb` | NEW — 18 cells (10 md + 8 code) |
| `Search/Part3-Advanced/README.md` | table row + Harvey & Ginsberg reference + two-strategy framing (1→2 notebooks) |
| `Search/README.md` | table row + intro line (1→2) |

`CATALOG-STATUS` markers **untouched** (cron/catalog-drift CI owns them, catalog-pr-hygiene).

## Not a `Closes`

Standalone substantive creation (anti-tunneling after the Infer-24 C118 + 5 cycles of #3966 mise-en-forme) — varies family (Search) and genre (new notebook vs. markdown fix). No tracking issue to close.

Co-Authored-By: Claude-Code <noreply@anthropic.com>