### PR TITLE
fix(genai-audio): demote 'Indice' asides H1->bold-inline, clear MULTI-H1, 02-5 (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb
@@ -1333,7 +1333,7 @@
     "\n",
     "Un gateway TTS doit choisir le meilleur modele selon les caracteristiques de la demande (langue, qualite, latence). Implementez une fonction de routage.\n",
     "\n",
-    "# Indice : Definir des criteres de selection (langue supportee, qualite requise) et retourner le nom du modele.\n"
+    "**Indice : Definir des criteres de selection (langue supportee, qualite requise) et retourner le nom du modele.**\n"
    ]
   },
   {
@@ -1394,7 +1394,7 @@
     "\n",
     "Mesurer la latence reelle de chaque endpoint TTS avec un mecanisme de retry en cas d'echec.\n",
     "\n",
-    "# Indice : Utiliser time.time() pour mesurer chaque appel et implementer un compteur de retry.\n"
+    "**Indice : Utiliser time.time() pour mesurer chaque appel et implementer un compteur de retry.**\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Contribution à **#3966** (scan typo-hierarchy GenAI). **Dernier notebook de la famille Audio** : le cas le plus délicat du rollout (MULTI-H1 + H1-DEEP + HINT-AS-HEADING entrelacés). Suite de #4712 (02-6), #4707 (04-8), #4709 (04-9), #4691/#4696/#4698/#4704 (04-10/11/12/13).

## Changement (1 fichier, +2/-2)

**`Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb`** — **5 flags cleared en un seul fix**. Les 5 provenaient de **2 asides « Indice » d'exercice écrits en H1** (cells 27, 29, sous `### Exercice 2`/`### Exercice 3`) :

\`\`\`diff
- # Indice : Definir des criteres de selection (langue supportee, qualite requise) et retourner le nom du modele.
+ **Indice :** Definir des criteres de selection (langue supportee, qualite requise) et retourner le nom du modele.
```

Ces 2 H1 parasites faisaient que le notebook avait **3 H1** (titre cell 1 + 2 indices) → flags MULTI-H1 + 2× H1-DEEP + 2× HINT-AS-HEADING. Après fix : H1 count 3→1, seuls les 5 flags disparaissent.

## Piège de scanner évité (G.9)

Mon grep naïf a vu `# Utilisation` en cell 24 et aurait pu le « corriger » à tort. Vérification firsthand : c'est un **commentaire Python à l'intérieur d'un bloc code fenced** (```python). Le scanner `scan_md_hierarchy.py` le **correctement ignore** (tracking de fence `FENCE_RE`). **Laissé intact** — ce n'est pas un heading markdown.

## Conformité

- **Markdown-only** : cellules markdown, 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé) — élément [4] modifié in-place
- **Contenu préservé** : texte des indices inchangé (seul le markup `#` → `**`)
- **Rescan post-fix** : `scan_md_hierarchy.py 02-5` → 0/1 flagged ✓

## Scope

\`See #3966\`. La famille **GenAI/Audio est maintenant entièrement drained** (02-5/02-6 + 04-8 à 04-13). Au prochain cycle : transition vers #3974 (GenAI feuilles) ou #3801 axe-2. 1 fichier = atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>