### PR TITLE
feat(infer): Infer-25 Kalman filter -- continuous-state LDS, exact EP

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-25-Kalman-Filter.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-25-Kalman-Filter.ipynb
@@ -1,0 +1,1258 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "56307ca7",
+   "metadata": {},
+   "source": [
+    "# Infer-25 — Filtre de Kalman : systèmes dynamiques linéaires gaussiens\n",
+    "\n",
+    "> **Série Infer.NET (25).** Ce notebook étend [Infer-11 (Séquences / HMM)](Infer-11-Sequences.ipynb)\n",
+    "> au cas où l'état caché est **continu**. Là où le HMM suivait une météo ou un mot\n",
+    "> discret, le **filtre de Kalman** (Kalman, 1960) suit une position, une température,\n",
+    "> un prix — toute grandeur qui évolue continûment avec du bruit. C'est l'algorithme\n",
+    "> d'estimation le plus utilisé au monde (navigation GPS, fusion de capteurs, contrôle,\n",
+    "> finance).\n",
+    "\n",
+    "**Durée estimée** : 55 minutes\n",
+    "**Prérequis** : [Infer-11 (Séquences / HMM)](Infer-11-Sequences.ipynb), [Infer-2 (Gaussian Mixtures)](Infer-2-Gaussian-Mixtures.ipynb)\n",
+    "\n",
+    "## Objectifs\n",
+    "\n",
+    "- Comprendre le **filtre de Kalman** comme l'analogue à état continu du HMM\n",
+    "- Formuler un **système dynamique linéaire gaussien** (prédiction + observation)\n",
+    "- Implémenter la **récursion de filtrage bayésien** via Infer.NET (conjugaison gaussienne)\n",
+    "- **Mesurer** l'apport du filtre : MSE filtrée < MSE brute, variance postérieure bornée\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ced128a",
+   "metadata": {},
+   "source": [
+    "## 1. Motivation : le HMM à état continu\n",
+    "\n",
+    "[Infer-11](Infer-11-Sequences.ipynb) modélisait des séquences où l'état caché était\n",
+    "**discret** (quel temps, quel mot de la phrase). Mais de nombreux systèmes suivent une\n",
+    "grandeur **continue** : position d'un mobile, température d'un four, prix d'un actif.\n",
+    "Le **filtre de Kalman** est l'équivalent exact du HMM pour l'état continu gaussien —\n",
+    "le **système dynamique linéaire gaussien** (Linear Dynamical System, LDS).\n",
+    "\n",
+    "L'état caché $x_t$ évolue linéairement avec un bruit gaussien (la *dynamique*), et on\n",
+    "l'observe à travers un autre bruit gaussien (le *capteur*) :\n",
+    "\n",
+    "$$x_t = x_{t-1} + d + \\mathcal{N}(0, Q) \\quad \\text{(équation de transition)}$$\n",
+    "$$y_t = x_t + \\mathcal{N}(0, R) \\quad \\text{(équation d'observation)}$$\n",
+    "\n",
+    "Parce que tout est **gaussien et linéaire**, l'inférence reste **exactement conjugée** :\n",
+    "le postérieur est gaussien à chaque pas, calculable en temps fermé. C'est le cas d'école\n",
+    "où Infer.NET (EP sur un modèle linéaire gaussien) résout l'inférence **de manière exacte**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a0e558bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:47:38.008976Z",
+     "iopub.status.busy": "2026-07-01T08:47:38.001526Z",
+     "iopub.status.idle": "2026-07-01T08:47:43.953318Z",
+     "shell.execute_reply": "2026-07-01T08:47:43.943127Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2048/\",\"http://172.27.64.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:58e6:e4cc:f299:db58:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '196332.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.ML.Probabilistic\"\n",
+    "#r \"nuget: Microsoft.ML.Probabilistic.Compiler\"\n",
+    "// restore Infer.NET -- isole dans sa propre cellule (convention de la serie)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "369c348b",
+   "metadata": {},
+   "source": [
+    "Configuration des espaces de noms Infer.NET. Le moteur d'inférence **EP** (Expectation\n",
+    "Propagation) résout la conjugaison gaussienne du filtre de Kalman de manière exacte.\n",
+    "On définit aussi le helper de tirage gaussien (Box-Muller) utilisé pour générer la\n",
+    "vraie trajectoire.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "309102f4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:47:43.956575Z",
+     "iopub.status.busy": "2026-07-01T08:47:43.956211Z",
+     "iopub.status.idle": "2026-07-01T08:47:45.370263Z",
+     "shell.execute_reply": "2026-07-01T08:47:45.369973Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Trajectoire generee : T=50 pas, drift=0,3, Q=0,5, R=4\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "R >> Q : le capteur est tres bruite -> le filtre a beaucoup de marge pour aider.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 premieres observations : -4,36, -3,20, -0,44, 1,49, -0,75\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.ML.Probabilistic;\n",
+    "using Microsoft.ML.Probabilistic.Distributions;\n",
+    "using Microsoft.ML.Probabilistic.Models;\n",
+    "using System;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// Helper : tirage N(0, 1) par Box-Muller (defini AVANT usage).\n",
+    "double Randn(Random r) {\n",
+    "    double u1 = 1.0 - r.NextDouble();\n",
+    "    double u2 = 1.0 - r.NextDouble();\n",
+    "    return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);\n",
+    "}\n",
+    "\n",
+    "// --- Terrain de jeu : vraie trajectoire + observations bruitees ---\n",
+    "// On suit un mobile qui derive lineairement (vitesse d constante + bruit de process Q).\n",
+    "Random rng = new Random(42);\n",
+    "int T = 50;\n",
+    "double drift = 0.3;        // d : vitesse constante (terme de pente)\n",
+    "double processVar = 0.5;   // Q : bruit de dynamique (incertitude sur l'evolution)\n",
+    "double obsVar = 4.0;       // R : bruit de capteur (observations TRES bruitees, R >> Q)\n",
+    "\n",
+    "// Vraie trajectoire cachee (INCONNUE du modele -- ground truth pour la validation)\n",
+    "double[] trueState = new double[T];\n",
+    "trueState[0] = 0.0;\n",
+    "for (int t = 1; t < T; t++)\n",
+    "    trueState[t] = trueState[t - 1] + drift + Math.Sqrt(processVar) * Randn(rng);\n",
+    "\n",
+    "// Observations bruitees (les SEULES donnees vues par le filtre)\n",
+    "double[] obs = new double[T];\n",
+    "for (int t = 0; t < T; t++)\n",
+    "    obs[t] = trueState[t] + Math.Sqrt(obsVar) * Randn(rng);\n",
+    "\n",
+    "Console.WriteLine($\"Trajectoire generee : T={T} pas, drift={drift}, Q={processVar}, R={obsVar}\");\n",
+    "Console.WriteLine($\"R >> Q : le capteur est tres bruite -> le filtre a beaucoup de marge pour aider.\");\n",
+    "Console.WriteLine($\"5 premieres observations : {string.Join(\", \", obs.Take(5).Select(v => v.ToString(\"F2\")))}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8f43f1d",
+   "metadata": {},
+   "source": [
+    "## 2. La récursion de Kalman = filtrage bayésien pas-à-pas\n",
+    "\n",
+    "Le filtre de Kalman est la **récurrence bayésienne** sur l'état continu. À chaque pas :\n",
+    "\n",
+    "1. **Prédire** — propager le postérieur précédent $p(x_{t-1} \\mid y_{1:t-1})$ à travers la\n",
+    "   dynamique : la moyenne avance de $d$, la variance augmente de $Q$ (l'incertitude croît).\n",
+    "2. **Mettre à jour** — combiner cet *a priori* avec la nouvelle observation $y_t$ par la\n",
+    "   règle de Bayes : le postérieur $p(x_t \\mid y_{1:t})$ a une variance **réduite**.\n",
+    "\n",
+    "Comme tout est gaussien-linéaire, chaque pas se réduit à une **conjugaison gaussienne**.\n",
+    "On l'exprime comme un **mini-modèle à deux variables** ($x_t$ latente, $y_t$ observée) et\n",
+    "on laisse Infer.NET inférer le postérieur — qui devient l'a priori du pas suivant.\n",
+    "\n",
+    "**Optimisation (pattern C118)** : on **compile une fois** le mini-modèle, avec la moyenne\n",
+    "et la variance de l'a priori comme variables `ObservedValue`. À chaque pas on ne fait que\n",
+    "mettre à jour ces valeurs observées puis ré-inférer — ~0,2 ms par pas au lieu de\n",
+    "recompiler (250 ms).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "37276c06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:47:45.371914Z",
+     "iopub.status.busy": "2026-07-01T08:47:45.371670Z",
+     "iopub.status.idle": "2026-07-01T08:47:47.686072Z",
+     "shell.execute_reply": "2026-07-01T08:47:47.685838Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filtrage termine : 50 pas infères par EP (conjugaison gaussienne exacte).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variance postérieure finale : 1,186   (var d'observation R = 4,0)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variance postérieure moyenne : 1,254\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Recursion du filtre de Kalman via Infer.NET (EP, conjugaison gaussienne) ---\n",
+    "InferenceEngine engine = new InferenceEngine();\n",
+    "engine.ShowProgress = false;\n",
+    "\n",
+    "// Modele lineaire gaussien compile UNE SEULE FOIS :\n",
+    "//   x  ~ N(priorMean, priorVar)        [latent, a priori du pas courant]\n",
+    "//   y  ~ N(x, obsVar)                  [observation bruitee de x]\n",
+    "// priorMean et priorVar sont des ObservedValue -> mis a jour chaque pas sans recompiler.\n",
+    "Variable<double> priorMean = Variable.New<double>().Named(\"priorMean\");\n",
+    "Variable<double> priorVar  = Variable.New<double>().Named(\"priorVar\");\n",
+    "Variable<double> x = Variable.GaussianFromMeanAndVariance(priorMean, priorVar).Named(\"x\");\n",
+    "Variable<double> y = Variable.GaussianFromMeanAndVariance(x, obsVar).Named(\"y\");\n",
+    "\n",
+    "double[] filtMean = new double[T];\n",
+    "double[] filtVar  = new double[T];\n",
+    "\n",
+    "// A priori initial : on initialise sur la 1re observation avec une grande incertitude.\n",
+    "double curMean = obs[0];\n",
+    "double curVar  = obsVar * 4.0;   // incertitude initiale large (on ne sait pas ou est le mobile)\n",
+    "\n",
+    "for (int t = 0; t < T; t++) {\n",
+    "    try {\n",
+    "        // 1. PREDIRE : propagation de la dynamique (moyenne += drift, variance += Q)\n",
+    "        double predMean = curMean + drift;\n",
+    "        double predVar  = curVar + processVar;\n",
+    "\n",
+    "        // 2. METTRE A JOUR : EP infere le postérieur exact de x sachant y = obs[t]\n",
+    "        priorMean.ObservedValue = predMean;\n",
+    "        priorVar.ObservedValue  = predVar;\n",
+    "        y.ObservedValue         = obs[t];\n",
+    "        Gaussian post = engine.Infer<Gaussian>(x);\n",
+    "        curMean = post.GetMean();\n",
+    "        curVar  = post.GetVariance();\n",
+    "    } catch (Exception ex) {\n",
+    "        Console.WriteLine($\"EXCEPTION pas {t}: {ex.Message}\");\n",
+    "        curMean = obs[t]; curVar = obsVar;\n",
+    "    }\n",
+    "    filtMean[t] = curMean;\n",
+    "    filtVar[t]  = curVar;\n",
+    "}\n",
+    "Console.WriteLine(\"Filtrage termine : 50 pas infères par EP (conjugaison gaussienne exacte).\");\n",
+    "Console.WriteLine($\"Variance postérieure finale : {filtVar[T - 1]:F3}   (var d'observation R = {obsVar:F1})\");\n",
+    "Console.WriteLine($\"Variance postérieure moyenne : {filtVar.Average():F3}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89d22de7",
+   "metadata": {},
+   "source": [
+    "## 3. Visualisation : trajectoire vraie, observations brutes, estimation filtrée\n",
+    "\n",
+    "Le graphe ASCII ci-dessous aligne, à chaque pas de temps (un pas sur deux pour la\n",
+    "lisibilité), les trois séries. Les **observations** (`.`) oscillent fortement autour de\n",
+    "la vraie trajectoire (`|`) à cause du capteur bruité ($R = 4$). L'**estimation filtrée**\n",
+    "(`#`, espérance du postérieur) lisse ce bruit et suit fidèlement la trajectoire cachée.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4ad73b83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:47:47.687748Z",
+     "iopub.status.busy": "2026-07-01T08:47:47.687497Z",
+     "iopub.status.idle": "2026-07-01T08:47:47.903880Z",
+     "shell.execute_reply": "2026-07-01T08:47:47.898869Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Echelle : -6,4 (gauche) -> 18,9 (droite), 60 colonnes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  VRAI = |   OBS = .   FILT = #\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t= 0 VRAI |||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .....\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT #####  (+-1,79)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t= 2 VRAI |||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ..............\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##########  (+-1,23)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t= 4 VRAI |||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .............\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##############  (+-1,12)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t= 6 VRAI |||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT #################  (+-1,10)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t= 8 VRAI |||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .......\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=10 VRAI |||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT #################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=12 VRAI ||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=14 VRAI ||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ......................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ####################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=16 VRAI |||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ............\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=18 VRAI ||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .............................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT #######################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=20 VRAI ||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .............................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##########################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=22 VRAI |||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ....................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ############################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=24 VRAI ||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##############################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=26 VRAI |||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ...............................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ###############################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=28 VRAI |||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ...............................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT #####################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=30 VRAI ||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ####################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=32 VRAI ||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ..............................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ####################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=34 VRAI ||||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ..................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ####################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=36 VRAI |||||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .........................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT #######################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=38 VRAI ||||||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  .......................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##########################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=40 VRAI |||||||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ....................................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##############################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=42 VRAI |||||||||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ........................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT #############################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=44 VRAI ||||||||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ..................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ##########################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=46 VRAI ||||||||||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ...............................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT #############################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "t=48 VRAI |||||||||||||||||||||||||||||||||||||||||||||||||\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     OBS  ..............................................\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     FILT ################################################  (+-1,09)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Performance du filtre (par rapport a la trajectoire VRAIE) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MSE observations brutes : 4,875   (variance de capteur R = 4,0)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MSE estimation filtree  : 1,283\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reduction d'erreur      : 73,7%   (filtre vs brut)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variance post. finale   : 1,186   (vs R = 4,0)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Visualisation ASCII + metriques honnetes ---\n",
+    "// Axe horizontal = position. On cale l'echelle sur l'ensemble des series.\n",
+    "double lo = Math.Min(trueState.Min(), obs.Min()) - 2;\n",
+    "double hi = Math.Max(trueState.Max(), obs.Max()) + 2;\n",
+    "int W = 60;\n",
+    "\n",
+    "string Bar(double v, char c) {\n",
+    "    int n = (int)Math.Round((v - lo) / (hi - lo) * W);\n",
+    "    if (n < 0) n = 0; if (n > W) n = W;\n",
+    "    return new string(c, n);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine($\"Echelle : {lo:F1} (gauche) -> {hi:F1} (droite), {W} colonnes\");\n",
+    "Console.WriteLine(\"  VRAI = |   OBS = .   FILT = #\");\n",
+    "for (int t = 0; t < T; t += 2) {\n",
+    "    Console.WriteLine($\"t={t,2} VRAI {Bar(trueState[t], '|')}\");\n",
+    "    Console.WriteLine($\"     OBS  {Bar(obs[t], '.')}\");\n",
+    "    Console.WriteLine($\"     FILT {Bar(filtMean[t], '#')}  (+-{Math.Sqrt(filtVar[t]):F2})\");\n",
+    "}\n",
+    "\n",
+    "// --- Metriques : MSE filtree vs MSE brute (par rapport a la VRAIE trajectoire) ---\n",
+    "double rawMSE = 0.0, filtMSE = 0.0;\n",
+    "for (int t = 0; t < T; t++) {\n",
+    "    rawMSE  += Math.Pow(obs[t]      - trueState[t], 2);\n",
+    "    filtMSE += Math.Pow(filtMean[t] - trueState[t], 2);\n",
+    "}\n",
+    "rawMSE  /= T;\n",
+    "filtMSE /= T;\n",
+    "\n",
+    "Console.WriteLine(\"\\n=== Performance du filtre (par rapport a la trajectoire VRAIE) ===\");\n",
+    "Console.WriteLine($\"MSE observations brutes : {rawMSE:F3}   (variance de capteur R = {obsVar:F1})\");\n",
+    "Console.WriteLine($\"MSE estimation filtree  : {filtMSE:F3}\");\n",
+    "Console.WriteLine($\"Reduction d'erreur      : {(1.0 - filtMSE / rawMSE) * 100:F1}%   (filtre vs brut)\");\n",
+    "Console.WriteLine($\"Variance post. finale   : {filtVar[T - 1]:F3}   (vs R = {obsVar:F1})\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46ac2fd4",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le filtre **réduit fortement l'erreur** : la MSE filtrée est nettement inférieure à la MSE\n",
+    "des observations brutes. Deux mécanismes sont visibles dans le graphe ASCII :\n",
+    "\n",
+    "- **Lissage** — l'estimation filtrée (`#`) varie beaucoup moins que les observations (`.`)\n",
+    "  d'un pas à l'autre : le filtre fait confiance à la dynamique ($Q$ petit) pour rejeter le\n",
+    "  bruit du capteur ($R$ grand).\n",
+    "- **Incertitude bornée** — la variance postérieure (±σ) se stabilise rapidement bien sous\n",
+    "  $R$ : après une brève phase d'initialisation, le filtre « sait » où il en est, et cette\n",
+    "  connaissance ne se dégrade pas avec le temps (équation de Riccati discrète).\n",
+    "\n",
+    "C'est précisément la situation où le filtre de Kalman *aide* : capteur bruité, dynamique\n",
+    "fiable. L'exercice 1 explore la situation limite opposée (dynamique très incertaine).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1879e2e",
+   "metadata": {},
+   "source": [
+    "## 4. Pourquoi ça marche : conjugaison exacte et borne de variance\n",
+    "\n",
+    "Le filtre de Kalman tire sa puissance d'une propriété **exacte** : tout étant gaussien et\n",
+    "linéaire, **chaque postérieur est gaussien et calculable en forme fermée**. Infer.NET (EP)\n",
+    "retrouve cette solution exacte — c'est le cas où l'inférence est *exacte*, pas approchée.\n",
+    "\n",
+    "La **règle de combinaison** est elle-même fermée : le postérieur $p(x_t \\mid y_t)$ est\n",
+    "gaussien, avec une moyenne qui est un **pondéré** entre la prédiction (où le mobile\n",
+    "*devrait* être d'après la dynamique) et l'observation (où le capteur le *voit*). Le poids\n",
+    "relatif est l'inverse des variances : on fait davantage confiance à la source la plus\n",
+    "certaine.\n",
+    "\n",
+    "- Si le capteur est **très bruité** ($R$ grand), le filtre fait confiance à la dynamique →\n",
+    "  lissage agressif, MSE fortement réduite (notre cas : $R = 4 \\gg Q = 0{,}5$).\n",
+    "- Si la dynamique est **très incertaine** ($Q$ grand), le filtre fait confiance au capteur →\n",
+    "  l'estimation colle aux observations, peu de lissage (exercice 1).\n",
+    "\n",
+    "La **borne de variance** (équation de Riccati) garantit que l'incertitude résiduelle\n",
+    "*plafonne* plutôt que d'exploser — c'est ce qui rend le filtre fiable sur le long terme.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf113a8e",
+   "metadata": {},
+   "source": [
+    "## 5. Exercices\n",
+    "\n",
+    "### Exercice 1 — Sensibilité au bruit de dynamique (Q)\n",
+    "Rejouez le filtre en balayant $Q \\in \\{0{,}01\\,;\\, 0{,}5\\,;\\, 2{,}0\\,;\\, 10{,}0\\}$ (sans\n",
+    "changer la vraie trajectoire ni $R$). Pour chaque $Q$, relevez la **MSE filtrée** et la\n",
+    "**variance postérieure moyenne**. Observez le compromis : $Q$ petit → lissage agressif\n",
+    "(le filtre ignore le capteur et suit la pente) ; $Q$ grand → le filtre colle au capteur\n",
+    "(réagit au bruit). Quel $Q$ minimise la MSE sur **cette** trajectoire ?\n",
+    "- **Indice :** le $Q$ optimal est proche de la *vraie* variance de process (ici $0{,}5$).\n",
+    "  Choisir $Q$, c'est donc faire de l'**estimation de paramètre** — le filtre suppose connu\n",
+    "  ce que vous fixez à la main.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "aa387393",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:47:47.905770Z",
+     "iopub.status.busy": "2026-07-01T08:47:47.905526Z",
+     "iopub.status.idle": "2026-07-01T08:47:47.991971Z",
+     "shell.execute_reply": "2026-07-01T08:47:47.991749Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 a completer\n",
+    "// Conseil : bouclez sur les valeurs de Q, relancez la recursion (copiez la boucle ci-dessus\n",
+    "// en parametrant processVar), stockez filtMSE pour chaque Q. Affichez le tableau Q|MSE|var.\n",
+    "Console.WriteLine(\"Exercice 1 a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0318839",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — État vectoriel (position + vitesse)\n",
+    "Le filtre ci-dessus suit une position scalaire avec une *vitesse* (`drift`) injectée\n",
+    "manuellement. Généralisez à un état **vectoriel** $x = (\\text{position}, \\text{vitesse})$\n",
+    "où $\\text{pos}_t = \\text{pos}_{t-1} + \\text{vit}_{t-1} \\cdot \\Delta t + \\text{bruit}$ et\n",
+    "$\\text{vit}_t = \\text{vit}_{t-1} + \\text{bruit}$. Utilisez `Variable.Vector` et\n",
+    "`Variable.MatrixTimesVector` d'Infer.NET.\n",
+    "- **Indice :** c'est le « vrai » filtre de Kalman matriciel. La **vitesse devient\n",
+    "  latente et estimée** (plus injectée). On observe uniquement la position\n",
+    "  ($y = \\text{pos} + \\text{bruit}$) et on infère la vitesse cachée — c'est tout l'intérêt.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0997e86a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:47:47.993689Z",
+     "iopub.status.busy": "2026-07-01T08:47:47.993424Z",
+     "iopub.status.idle": "2026-07-01T08:47:48.044391Z",
+     "shell.execute_reply": "2026-07-01T08:47:48.043938Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 a completer\n",
+    "// Conseil : etat x = Variable.Vector, transition par MatrixTimesVector(A, x[t-1]).\n",
+    "// Commencez par estimer la vitesse cachee a partir de observations de position bruitees.\n",
+    "Console.WriteLine(\"Exercice 2 a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c983a9fa",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Lissage joint (full factor graph)\n",
+    "Le filtre ci-dessus est **séquentiel** (un pas à la fois : il n'utilise que les\n",
+    "observations passées). Construisez la version **jointe** : un seul\n",
+    "`VariableArray<double> x` sur un `Range` temporel, avec\n",
+    "`x[t] = Variable.GaussianFromMeanAndVariance(x[t - 1] + drift, processVar)` dans un\n",
+    "bloc `Variable.ForEach` (**auto-référence** `x[t-1]`), toutes les observations branchées,\n",
+    "et laissez EP inférer **toutes les marginales simultanément** — c'est le **lissage**\n",
+    "(utilise aussi les observations futures).\n",
+    "- **Indice :** le lissage rétro-propage l'information, donc **MSE lissée $\\leq$ MSE filtrée**.\n",
+    "  La syntaxe d'auto-référence `x[t-1]` dans `Variable.ForEach` est délicate (cas `t == 0`\n",
+    "  à isoler avec `Variable.If`) — référez-vous aux exemples de chaînes gaussiennes Infer.NET.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1ab3b005",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:47:48.046016Z",
+     "iopub.status.busy": "2026-07-01T08:47:48.045736Z",
+     "iopub.status.idle": "2026-07-01T08:47:48.083643Z",
+     "shell.execute_reply": "2026-07-01T08:47:48.083384Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 a completer\n",
+    "// Conseil : Range t = new Range(T); VariableArray<double> x = Variable.Array<double>(t);\n",
+    "// Dans Variable.ForEach(t) : If(t==0) x[t]=prior; If(t>0) x[t]=Gaussian(x[t-1]+drift, Q).\n",
+    "// Comparez la MSE lisse (jointe) a la MSE filtree (sequentielle ci-dessus).\n",
+    "Console.WriteLine(\"Exercice 3 a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39ab8735",
+   "metadata": {},
+   "source": [
+    "## 6. Ponts avec la série\n",
+    "\n",
+    "| Direction | Lien | Relation |\n",
+    "|-----------|------|----------|\n",
+    "| ↔ Infer-11 | [Infer-11 — Séquences (HMM)](Infer-11-Sequences.ipynb) | HMM à état **discret** ↔ filtre de Kalman à état **continu** : même squelette markovien (état caché + observation), nature de l'état différente |\n",
+    "| ← Infer-2 | [Infer-2 — Gaussian Mixtures](Infer-2-Gaussian-Mixtures.ipynb) | Le Kalman repose sur la **conjugaison gaussienne** — Infer-2 en pose les bases |\n",
+    "| ↔ Infer-23 | [Infer-23 — Sparse GP](Infer-23-Sparse-Gaussian-Process.ipynb) | GP et Kalman modélisent tous deux de l'aléatoire structuré ; GP = espace fonctionnel **non-paramétrique**, Kalman = état fini **paramétrique** |\n",
+    "\n",
+    "**Référence fondatrice** : Kalman, R. E. (1960) — *A New Approach to Linear Filtering and\n",
+    "Prediction Problems*, ASME Journal of Basic Engineering 82(1). L'article fondateur du\n",
+    "filtre de Kalman — l'algorithme d'estimation le plus répandu en pratique.\n",
+    "\n",
+    "## 7. Conclusion\n",
+    "\n",
+    "Le **filtre de Kalman** est le pont entre le HMM discret d'[Infer-11](Infer-11-Sequences.ipynb)\n",
+    "et le monde continu. Sa puissance tient en trois propriétés : pour les systèmes\n",
+    "**linéaires gaussiens**, l'inférence est **exacte** (conjugaison), **récursive** (un pas à\n",
+    "la fois, en $O(T)$) et **bornée** (variance postérieure stable). Infer.NET la résout\n",
+    "naturellement via EP, qui retrouve la solution exacte sur ce cas d'école.\n",
+    "\n",
+    "La leçon générale : quand le modèle est **linéaire-gaussien**, nul besoin de méthodes\n",
+    "d'inférence approchées lourdes — la conjugaison offre une solution fermée. C'est en\n",
+    "**sortant** de ce régime (non-linéarités, distributions non gaussiennes) que les processus\n",
+    "gaussiens ([Infer-23](Infer-23-Sparse-Gaussian-Process.ipynb)) et les méthodes\n",
+    "variationnelles deviennent nécessaires. Le Kalman n'est pas un cas particulier encombrant :\n",
+    "c'est le **point de référence** par rapport auquel tous les filtres approchés se mesurent.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -74,6 +74,7 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 | 22 | [Infer-22-Causal-Inference](Infer-22-Causal-Inference.ipynb) | 65 min | do-calculus, backdoor/front-door, paradoxe de Simpson |
 | 23 | [Infer-23-Sparse-Gaussian-Process](Infer-23-Sparse-Gaussian-Process.ipynb) | 55 min | Processus gaussiens, noyau RBF, classification non-linéaire, sparse GP |
 | 24 | [Infer-24-Modeles-Hierarchiques](Infer-24-Modeles-Hierarchiques.ipynb) | 50 min | Modèles hiérarchiques, pooling partiel, shrinkage, VariableArray indexé |
+| 25 | [Infer-25-Kalman-Filter](Infer-25-Kalman-Filter.ipynb) | 55 min | Filtre de Kalman, système dynamique linéaire gaussien, conjugaison, EP exacte |
 
 **Durée totale** : ~22h
 
@@ -945,6 +946,37 @@ Cas d'école du **pooling partiel** : quand les données sont **structurées en 
 
 ---
 
+## Filtrage et séquences continues (Notebook 25)
+
+### Infer-25 : Filtre de Kalman (système dynamique linéaire gaussien)
+
+Le **filtre de Kalman** (Kalman, 1960) est l'analogue à état **continu** du HMM d'[Infer-11](Infer-11-Sequences.ipynb) : l'état caché $x_t$ (position, température, prix) évolue linéairement avec un bruit gaussien (la *dynamique*, variance $Q$), et on l'observe à travers un autre bruit gaussien (le *capteur*, variance $R$). Parce que tout est **linéaire et gaussien**, l'inférence est **exactement conjugée** : le postérieur reste gaussien à chaque pas, calculable en temps fermé — c'est le cas d'école où Infer.NET (EP) résout l'inférence de manière **exacte**, sans MCMC ni approximation variationnelle.
+
+**Durée** : 55 min | **Prérequis** : [Infer-11-Sequences](Infer-11-Sequences.ipynb) (HMM, structure markovienne), [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb) (conjugaison gaussienne)
+
+**Objectifs** :
+
+- Comprendre le filtre de Kalman comme le pendant **continu** du HMM discret
+- Formuler un **système dynamique linéaire gaussien** (équations de transition et d'observation)
+- Implémenter la **récursion de filtrage bayésien** (prédiction + mise à jour) via Infer.NET, en compilant le mini-modèle une fois et en le réutilisant via `ObservedValue`
+- **Mesurer** l'apport du filtre : MSE filtrée vs MSE brute, variance postérieure bornée (équation de Riccati)
+
+**Concepts clés** :
+
+| Concept | Formule / API | Description |
+| --------- | --------------- | ------------- |
+| Transition | `x[t] ~ N(x[t-1] + drift, Q)` | Dynamique : l'état évolue avec du bruit |
+| Observation | `y[t] ~ N(x[t], R)` | Capteur bruité de l'état caché |
+| Prédiction | propager le postérieur (variance `+= Q`) | L'incertitude croît entre deux observations |
+| Mise à jour | `engine.Infer<Gaussian>(x)` (EP) | Conjugaison : postérieur gaussien exact |
+| Borne de variance | équation de Riccati discrète | L'incertitude résiduelle plafonne (filtre fiable) |
+
+**Positionnement** : [Infer-11](Infer-11-Sequences.ipynb) couvrait le HMM à état **discret** (météo, mots) ; Infer-25 franchit le pas vers l'état **continu** — le filtre le plus utilisé au monde (navigation GPS, fusion de capteurs, contrôle, finance). La récursion pas-à-pas compile le mini-modèle linéaire-gaussien une fois (`Variable.New<double>` + `ObservedValue`), et EP retourne le postérieur exact qui sert d'a priori au pas suivant. Sur une trajectoire dérivante fortement bruitée ($R = 4 \gg Q = 0{,}5$), le filtre réduit l'erreur de **~74 %** (MSE brute 4,88 → filtrée 1,28) et borne la variance postérieure vers **1,2** (vs $R = 4$) — la signature d'un filtre qui *aide*.
+
+**Applications** : suivi de mobiles, navigation inertielle et GPS, fusion multi-capteurs, filtrage de signaux, tracking financier, estimation d'état en robotique et contrôle.
+
+---
+
 ## Prérequis
 
 - .NET 9.0 ou supérieur
@@ -1065,7 +1097,7 @@ var posterior = moteur.Infer<DistributionType>(variable);
 
 ```
 Infer/
-+-- Infer-1-Setup.ipynb ... Infer-24-Modeles-Hierarchiques.ipynb
++-- Infer-1-Setup.ipynb ... Infer-25-Kalman-Filter.ipynb
 +-- Infer-20b-Lean-Gittins.ipynb    # Companion Lean 4 (preuves formelles Gittins)
 +-- Infer-Glossary.md
 +-- FactorGraphHelper.cs          # Helper pour visualisation Graphviz


### PR DESCRIPTION
## Summary

New notebook **Infer-25-Kalman-Filter.ipynb** — the **continuous-state analog of Infer-11's discrete HMM**. The Kalman filter / Linear Dynamical System (Kalman 1960): hidden state $x_t$ evolves linearly with Gaussian dynamics ($x_t = x_{t-1} + d + \mathcal{N}(0,Q)$), observed through Gaussian sensor noise ($y_t = x_t + \mathcal{N}(0,R)$). Because everything is **linear-Gaussian**, inference is **exactly conjugate** — the case where Infer.NET (EP) solves inference **exactly**, not approximately.

- **Incremental predict-update recursion** via `engine.Infer<Gaussian>(x)`, compile-once + `ObservedValue` pattern (mini-model compiled once, prior mean/var updated per step — ~0.2ms vs 250ms rebuild, per the C118 lesson).
- **Isolated `#r "nuget:"` cell** (convention série).
- **Honest Prong-B** (SOTA): on a noisy drifting trajectory ($R=4 \gg Q=0.5$), the filter reduces error **MSE 4.88 → 1.28 (−74 %)** and bounds posterior variance **~1.2 vs R=4** (Riccati convergence). The signature of a filter that genuinely *helps*.
- **ASCII visualization** (Plotly `#r nuget` hangs in papermill per the established .NET plotting gotcha; ASCII/stream is the reliable choice — the engine genuinely ran, ASCII is only the display medium).
- **3 C.1-safe exercises**: Q-sweep (sensitivity to process noise), 2D state (position+velocity, `Variable.Vector` + `MatrixTimesVector`), joint smoothing (full factor graph, `x[t-1]` self-reference).
- README updated: table row 25 + detailed section + tree. Infer arc **23 → 25**.

## Execution proof (H.1 / C.2)

- Executed end-to-end via `jupyter nbconvert --execute --inplace` (`.net-csharp` kernel, timeout 300s).
- `execution_count`: 1–7 for all 7 code cells (none null).
- **0 errors** in outputs. **0** `raise NotImplementedError` / `assert False` / `1/0` (C.1-safe).
- **0 machine-path / secret** hits in cell outputs (scanned). No papermill metadata (nbconvert).
- Verified outputs (dumped before writing prose, C110/C118/C119 lesson):
  - `MSE observations brutes : 4,875` → `MSE estimation filtree : 1,283` → `Réduction d'erreur : 73,7 %`
  - `Variance postérieure finale : 1,186` (vs R=4,0), stabilizes at ±1,09.

## SOTA verdict (EPIC #3801)

**SOTA-OK** — the real Infer.NET engine (EP on a linear-Gaussian model) is properly invoked; the committed outputs ARE its true marginals. No degraded workaround. The problem is non-trivial (noisy tracking where the filter demonstrably beats raw measurements by 74 %), exercising the engine's exact-conjugate inference capability — not a degenerate case where SOTA equals a baseline.

## Files

- `MyIA.AI.Notebooks/Probas/Infer/Infer-25-Kalman-Filter.ipynb` (new, 18 cells)
- `MyIA.AI.Notebooks/Probas/Infer/README.md` (+33/-1: table row, detailed section, tree)

See #3801 (SOTA). Infer arc continuation (23 → 25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
