### PR TITLE
docs(qc): demote 4 PARTIE H1 to H2 — QC-Py-07-Futures-Forex MULTI-H1 (#3968)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "---\n",
     "\n",
-    "# PARTIE 1 : FUTURES (40 min)\n",
+    "## PARTIE 1 : FUTURES (40 min)\n",
     "\n",
     "---\n",
     "\n",
@@ -911,7 +911,7 @@
    "source": [
     "---\n",
     "\n",
-    "# PARTIE 2 : FOREX (35 min)\n",
+    "## PARTIE 2 : FOREX (35 min)\n",
     "\n",
     "---\n",
     "\n",
@@ -1476,7 +1476,7 @@
    "source": [
     "---\n",
     "\n",
-    "# PARTIE 3 : LEVERAGE ET RISK MANAGEMENT (20 min)\n",
+    "## PARTIE 3 : LEVERAGE ET RISK MANAGEMENT (20 min)\n",
     "\n",
     "---\n",
     "\n",
@@ -1924,7 +1924,7 @@
    "source": [
     "---\n",
     "\n",
-    "# PARTIE 4 : STRATEGIE COMPLETE (20 min)\n",
+    "## PARTIE 4 : STRATEGIE COMPLETE (20 min)\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Summary

Resout le **MULTI-H1** (5 H1 → 1 H1) sur `QC-Py-07-Futures-Forex.ipynb` (**#3968**, part of **#3966**) : les 4 `# PARTIE N` (cells 3/35/53/69) passent de **H1** à **H2**. Après fix, **un seul H1 reste** (cell 0, le titre du notebook) — c'est l'invariant central de #3968.

Compagnon atomique de #4719 (4 notebooks HINT-AS-HEADING) — QC-Py-07 a un pattern distinct (MULTI-H1) d'où la PR séparée (G.4).

## Changements (4 headings, typo SEULEMENT)

| Cell | Avant | Après |
|------|-------|-------|
| 3  | `# PARTIE 1 : FUTURES (40 min)` | `## PARTIE 1 : FUTURES (40 min)` |
| 35 | `# PARTIE 2 : FOREX (35 min)` | `## PARTIE 2 : FOREX (35 min)` |
| 53 | `# PARTIE 3 : LEVERAGE ET RISK MANAGEMENT (20 min)` | `## PARTIE 3 : …` |
| 69 | `# PARTIE 4 : STRATEGIE COMPLETE (20 min)` | `## PARTIE 4 : …` |

**Aucun changement de texte** — seul le niveau de heading (H1 → H2). La hiérarchie interne (H2 sections numérotées + H3 sous-sections) est volontairement laissée intacte (transformation typo-only minimale, la cascade complète serait hors-scope).

## Commentaires Python dans code blocks — NON modifiés (vérification G.1)

Le scanner `scan_md_hierarchy.py` flaggue 5 H1 mais **ignore correctement** les `# ...` à l'intérieur des fenced code blocks (`FENCE_RE` guard, lignes 18-21/44-50). Les commentaires Python suivants sont du **code**, pas des headings — les transformer en `**...**` casserait le code Python (anti-regression + Stop & Repair) :

- cell 12 : `# Syntaxe: SetFilter(...)`, `# Ou avec jours specifiques`, `# Filtrage avance avec lambda`
- cell 17 : `# Indices`, `# Energie`, `# Metaux`, `# Taux d'interet`, `# Agriculture`
- cell 18 : `# Dans OnData(self, slice):`
- cell 59 : `# Reduire le leverage (plus conservateur)`, `# Ou via BuyingPowerModel`

## Validation (acceptance #3968)

- [x] `scan_md_hierarchy.py` : **0 finding résiduel** (MULTI-H1 + 4 H1-DEEP résolus).
- [x] **Diff = 4 insertions / 4 délétions exactement**, chaque ligne est un `# PARTIE` → `## PARTIE`. Aucun delta de contenu.
- [x] **Markdown-only → règle C.2 exception** : aucune cellule code/output touchée.
- [x] **Format préservé byte-pour-byte** : remplacement textuel ciblé (pas de round-trip JSON, qui aurait converti les escape sequences `—`/`«` de l'original `ensure_ascii=True`). indent=1, LF, pas de trailing newline (original).

See #3968
Part of #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
