### PR TITLE
fix(genai-texte): move title H1 to first md cell, clear H1-DEEP, 3_Structured_Outputs (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "# 3. Structured Outputs : Sorties JSON Garanties\n",
     "**Navigation** : [Index](../../README.md) | [<< Precedent](2_PromptEngineering.ipynb) | [Suivant >>](4_Function_Calling.ipynb)\n",
     "\n",
     "## Structured Outputs : Sorties JSON Garanties avec OpenAI\n",
@@ -45,7 +46,6 @@
     "tags": []
    },
    "source": [
-    "# 3. Structured Outputs : Sorties JSON Garanties\n",
     "\n",
     "**Navigation** : [<< Precedent](2_PromptEngineering.ipynb) | [Index](../../README.md) | [Suivant >>](4_Function_Calling.ipynb)\n",
     "\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **Transition vers la famille GenAI/Texte** (GenAI/Audio drained). 3_Structured_Outputs = 1 flag H1-DEEP.

## Changement (1 fichier, +2/-2)

**`Texte/3_Structured_Outputs.ipynb`** — H1-DEEP : le titre `# 3. Structured Outputs : Sorties JSON Garanties` était en cell 1 (2e cell markdown), alors que cell 0 (1er md) ne portait que nav+intro sans H1. Le scanner exige le H1 unique dans le **premier** cell markdown (pattern canonique : cf. 1_OpenAI_Intro cell 1, 5_RAG cell 0).

Fix minimal : **déplacement de la ligne H1 en tête de cell 0** (le 1er cell md porte maintenant le titre). 1 ligne de heading repositionnée, **0 wording changé**, format `list` préservé.

\`\`\`diff
- (cell 1, src[0])  "# 3. Structured Outputs : Sorties JSON Garanties"
+ (cell 0, src[0])  "# 3. Structured Outputs : Sorties JSON Garanties"
```

## Désordre éditorial préexistant — SIGNALÉ, hors scope

Ce notebook a un désordre éditorial plus large **non touché par cette PR** (restructurer = décision éditoriale hors scope typo-hierarchy, §4) :
- Cell 0 est un bloc « intro » inséré avant le titre (nav + H2 thématique + objectifs en gras), redondant avec cell 1.
- La navigation breadcrumb et un H2 « Structured Outputs… » sont **dupliqués** entre cell 0 et cell 1.

Nettoyer ça (fusionner/supprimer la cell intro) relève d'une décision éditoriale séparée, pas du rollout typo-hierarchy. Cette PR ne corrige que le flag hiérarchique (H1-DEEP), sans toucher au contenu.

## Conformité

- **Markdown-only** : cellules markdown, 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé)
- **Contenu préservé** : 0 caractère de wording modifié, seule la position de la ligne H1 change
- **Rescan post-fix** : `scan_md_hierarchy.py 3_Structured_Outputs` → 0/1 flagged ✓

## Scope

\`See #3966\` (partial — GenAI/Texte : reste 2_PromptEngineering, 8_Reasoning_Models). 1 fichier = atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>