### PR TITLE
docs(qc): FR-backfill 4 volatility strategy READMEs (#3870)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/README.en.md
@@ -1,0 +1,43 @@
+# VIX-TermStructure
+
+**Asset class:** Volatility (SVXY)
+**Cloud project ID:** None (local only)
+**Status:** ARCHIVED (Sharpe ceiling +0.05)
+
+## Description
+
+VIX term structure strategy using SVXY (short-volatility ETF).
+Signals based on the spread between VIX spot and VIX3M (3-month VIX futures).
+Goes long SVXY when term structure is in contango (VIX < VIX3M), flat in backwardation.
+
+**Archived because:** Structural ceiling at Sharpe +0.05. Short-vol strategies suffer from
+asymmetric payoffs (small gains, rare catastrophic losses). The 2018 Volmageddon event
+demonstrates the structural risk. See ARCHIVE.md for full ceiling analysis.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure"`
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | +0.05 |
+| Strategy | Long SVXY in contango |
+| Signal | VIX vs VIX3M spread |
+| Risk | Volmageddon tail risk |
+
+## Files
+
+- `main.py` - Strategy (v4.1, VIX term structure contango signal)
+- `research.ipynb` - VIX spread analysis and regime testing
+
+## References
+
+- Simon & Campasano (2014), "The VIX Fix"
+- ARCHIVE.md - Full iteration history and structural ceiling analysis

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/README.md
@@ -1,43 +1,43 @@
 # VIX-TermStructure
 
-**Asset class:** Volatility (SVXY)
-**Cloud project ID:** None (local only)
-**Status:** ARCHIVED (Sharpe ceiling +0.05)
+**Classe d'actifs :** Volatilité (SVXY)
+**Cloud project ID :** None (local only)
+**Statut :** ARCHIVED (plafond Sharpe +0.05)
 
 ## Description
 
-VIX term structure strategy using SVXY (short-volatility ETF).
-Signals based on the spread between VIX spot and VIX3M (3-month VIX futures).
-Goes long SVXY when term structure is in contango (VIX < VIX3M), flat in backwardation.
+Stratégie de term structure VIX utilisant SVXY (ETF short-volatility).
+Signaux basés sur le spread entre le VIX spot et le VIX3M (futures VIX à 3 mois).
+Prend position long SVXY quand la term structure est en contango (VIX < VIX3M), à plat en backwardation.
 
-**Archived because:** Structural ceiling at Sharpe +0.05. Short-vol strategies suffer from
-asymmetric payoffs (small gains, rare catastrophic losses). The 2018 Volmageddon event
-demonstrates the structural risk. See ARCHIVE.md for full ceiling analysis.
+**Archivée car :** Plafond structurel à Sharpe +0.05. Les stratégies short-vol souffrent de
+paiements asymétriques (petits gains, pertes catastrophiques rares). L'événement Volmageddon de 2018
+démontre le risque structurel. Voir ARCHIVE.md pour l'analyse complète du plafond.
 
-## How to Run
+## Comment exécuter
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure"`
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure"`
 ```bash
 lean backtest --project .
 ```
 
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour exécuter.
 
-## Backtest Metrics (2015-2026)
+## Métriques de backtest (2015-2026)
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | +0.05 |
-| Strategy | Long SVXY in contango |
-| Signal | VIX vs VIX3M spread |
-| Risk | Volmageddon tail risk |
+| Stratégie | Long SVXY en contango |
+| Signal | Spread VIX vs VIX3M |
+| Risque | Risque de queue Volmageddon |
 
-## Files
+## Fichiers
 
-- `main.py` - Strategy (v4.1, VIX term structure contango signal)
-- `research.ipynb` - VIX spread analysis and regime testing
+- main.py - Stratégie (v4.1, signal contango term structure VIX)
+- research.ipynb - Analyse du spread VIX et test de régimes
 
-## References
+## Références
 
 - Simon & Campasano (2014), "The VIX Fix"
-- ARCHIVE.md - Full iteration history and structural ceiling analysis
+- ARCHIVE.md - Historique complet des itérations et analyse du plafond structurel

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/README.en.md
@@ -1,0 +1,53 @@
+# Vol-Ensemble-Conservative
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** See `config.json` (local-id: 818573377)
+
+## Description
+
+Conservative ensemble volatility forecasting combining GARCH(1,1) and HAR-RV models on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Uses the maximum of the two volatility forecasts (conservative approach). Targets 8% annualized volatility (half the normal 16% target). Applies SMA200 regime filter with 50% position reduction in bear markets, and SMA50 for trade direction. Weekly rebalance. Most conservative of the three volatility strategies.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Vol-Ensemble-Conservative/main.py
+```
+
+### QC Cloud
+Open the cloud project (local-id: 818573377), compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Ensemble GARCH+HAR (conservative max) | Weekly | Vol target 8%, SMA200 regime (-50% bear), SMA50 direction, 500-day window |
+
+### Aligned baseline (2018-2025)
+
+Standardized #1630 backbone run (QC Cloud project `33248352`, backtest `db77ae49`).
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.265 |
+| CAGR | 6.142% |
+| Max Drawdown | 10.40% |
+| Probabilistic Sharpe Ratio | 13.6% |
+| Tradeable dates | 1761 |
+
+Interpretation: MaxDD 10.40% = tightest backbone baseline yet (beats Vol-GARCH-Target 10.80%, GlobalMacro-Regime 22.8%, HAR-RV-J-Kelly 37.1%). Positive Sharpe 0.265 but below single-GARCH Vol-GARCH-Target (0.325): the conservative overlay (max-of-ensemble HAR+GARCH forecast, half vol-target 8%, SMA200 regime -50% bear, SMA50 direction) tightened the drawdown at the cost of return, and the HAR component did not add risk-adjusted value over GARCH alone. Promoted Tier 4 -> 2 (Historique). totalOrders = 0 = wrapper extraction artifact (CAGR 6.14% implies real trades).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Conservative ensemble volatility targeting (max of GARCH + HAR) with regime filter |
+| `config.json` | Project configuration (local-id) |
+| `research.ipynb` | Research notebook with ensemble model comparison and conservative parameter analysis |
+
+## References
+
+- Bollerslev, T. (1986). *Generalized Autoregressive Conditional Heteroskedasticity*. Journal of Econometrics.
+- Corsi, F. (2009). *A Simple Approximate Long-Memory Model of Realized Volatility*. Journal of Financial Econometrics.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/README.md
@@ -1,14 +1,14 @@
 # Vol-Ensemble-Conservative
 
-**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+**Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**Cloud project ID:** See `config.json` (local-id: 818573377)
+**Cloud project ID :** Voir `config.json` (local-id : 818573377)
 
 ## Description
 
-Conservative ensemble volatility forecasting combining GARCH(1,1) and HAR-RV models on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Uses the maximum of the two volatility forecasts (conservative approach). Targets 8% annualized volatility (half the normal 16% target). Applies SMA200 regime filter with 50% position reduction in bear markets, and SMA50 for trade direction. Weekly rebalance. Most conservative of the three volatility strategies.
+Ensemble conservateur de prévision de volatilité combinant les modèles GARCH(1,1) et HAR-RV sur six actifs (SPY, EFA, EEM, TLT, GLD, DBC). Utilise le maximum des deux prévisions de volatilité (approche conservatrice). Cible 8 % de volatilité annualisée (la moitié de la cible normale de 16 %). Applique un filtre de régime SMA200 avec réduction de position de 50 % en marché baissier, et une SMA50 pour la direction des trades. Rebalance hebdomadaire. La plus conservatrice des trois stratégies de volatilité.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,38 +16,38 @@ lean backtest --algorithm Vol-Ensemble-Conservative/main.py
 ```
 
 ### QC Cloud
-Open the cloud project (local-id: 818573377), compile and run a backtest.
+Ouvrir le projet cloud (local-id : 818573377), compiler et lancer un backtest.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Ensemble GARCH+HAR (conservative max) | Weekly | Vol target 8%, SMA200 regime (-50% bear), SMA50 direction, 500-day window |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| Ensemble GARCH+HAR (max conservateur) | Hebdomadaire | Vol target 8 %, régime SMA200 (-50 % baissier), direction SMA50, fenêtre 500 jours |
 
-### Aligned baseline (2018-2025)
+### Baseline alignée (2018-2025)
 
-Standardized #1630 backbone run (QC Cloud project `33248352`, backtest `db77ae49`).
+Exécution dorsale standardisée #1630 (projet QC Cloud `33248352`, backtest `db77ae49`).
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 0.265 |
-| CAGR | 6.142% |
-| Max Drawdown | 10.40% |
-| Probabilistic Sharpe Ratio | 13.6% |
-| Tradeable dates | 1761 |
+| CAGR | 6.142 % |
+| Max Drawdown | 10.40 % |
+| Probabilistic Sharpe Ratio | 13.6 % |
+| Dates négociables | 1761 |
 
-Interpretation: MaxDD 10.40% = tightest backbone baseline yet (beats Vol-GARCH-Target 10.80%, GlobalMacro-Regime 22.8%, HAR-RV-J-Kelly 37.1%). Positive Sharpe 0.265 but below single-GARCH Vol-GARCH-Target (0.325): the conservative overlay (max-of-ensemble HAR+GARCH forecast, half vol-target 8%, SMA200 regime -50% bear, SMA50 direction) tightened the drawdown at the cost of return, and the HAR component did not add risk-adjusted value over GARCH alone. Promoted Tier 4 -> 2 (Historique). totalOrders = 0 = wrapper extraction artifact (CAGR 6.14% implies real trades).
+Interprétation : MaxDD 10.40 % = baseline dorsale la plus serrée à ce jour (bat Vol-GARCH-Target 10.80 %, GlobalMacro-Regime 22.8 %, HAR-RV-J-Kelly 37.1 %). Sharpe positif 0.265 mais inférieur au GARCH seul Vol-GARCH-Target (0.325) : l'overlay conservateur (prévision max-de-l'ensemble HAR+GARCH, demi vol-target 8 %, régime SMA200 -50 % baissier, direction SMA50) a serré le drawdown au prix du rendement, et la composante HAR n'a pas apporté de valeur ajustée du risque au-delà du GARCH seul. Promue Tier 4 -> 2 (Historique). totalOrders = 0 = artefact d'extraction du wrapper (CAGR 6.14 % implique des trades réels).
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | Conservative ensemble volatility targeting (max of GARCH + HAR) with regime filter |
-| `config.json` | Project configuration (local-id) |
-| `research.ipynb` | Research notebook with ensemble model comparison and conservative parameter analysis |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Vol-targeting d'ensemble conservateur (max de GARCH + HAR) avec filtre de régime |
+| `config.json` | Configuration du projet (local-id) |
+| `research.ipynb` | Notebook de recherche avec comparaison des modèles d'ensemble et analyse des paramètres conservateurs |
 
-## References
+## Références
 
 - Bollerslev, T. (1986). *Generalized Autoregressive Conditional Heteroskedasticity*. Journal of Econometrics.
 - Corsi, F. (2009). *A Simple Approximate Long-Memory Model of Realized Volatility*. Journal of Financial Econometrics.
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/README.en.md
@@ -1,0 +1,57 @@
+# Vol-GARCH-Target
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** See `config.json` (local-id: 209093652)
+
+## Description
+
+GARCH(1,1) volatility targeting strategy on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Each asset targets 10% annualized volatility with position sizes adjusted by the GARCH forecast. Uses SMA200 for trend direction (long in uptrend, reduce in downtrend). Model is refit every 22 trading days on a 500-day training window. Weekly rebalance on Mondays.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Vol-GARCH-Target/main.py
+```
+
+### QC Cloud
+Open the cloud project (local-id: 209093652), compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| GARCH(1,1) vol targeting | Weekly (Monday) | Vol target 10%, SMA200 trend, 500-day window, refit every 22 days |
+
+### Aligned baseline (2018-2025)
+
+Verified on QC Cloud (project 33245149, backtest `a0f7a5b59e878becd574612b85791d51`).
+
+| Period | Sharpe | CAGR | MaxDD | PSR |
+|--------|--------|------|-------|-----|
+| 2018-2025 (aligned) | 0.325 | 6.97% | 10.80% | 14.9% |
+
+The strategy's strength is risk control, not return. MaxDD 10.80% is the tightest of
+the backbone baselines to date (cf GlobalMacro-Regime 22.8%, HAR-RV-J-Kelly 37.1%,
+Cloud-VolTargeting single-asset 38.2%) -- the GARCH(1,1) variance forecast, the 30%
+per-asset cap and the SMA200 trend filter combine into genuine risk budgeting that
+holds drawdowns in check. Sharpe 0.325 is positive but modest, and PSR 14.9% is
+non-significant. Notably it beats Cloud-VolTargeting (single-asset SPY, realized-vol,
+150% clamp) on both Sharpe (0.325 vs 0.207) and MaxDD (10.8% vs 38.2%): GARCH
+forecasting plus multi-asset diversification outperforms a naive realized-vol single
+asset with a leverage clamp. Promoted Tier 4 (Untested) to Tier 2 (Historique). See
+the comparative-backtests doc for the cross-strategy table.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | GARCH(1,1) volatility targeting with SMA200 trend filter on 6 multi-asset ETFs |
+| `config.json` | Project configuration (local-id) |
+| `research.ipynb` | Research notebook with GARCH model analysis and parameter exploration |
+
+## References
+
+- Bollerslev, T. (1986). *Generalized Autoregressive Conditional Heteroskedasticity*. Journal of Econometrics.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/README.md
@@ -1,14 +1,14 @@
 # Vol-GARCH-Target
 
-**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+**Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**Cloud project ID:** See `config.json` (local-id: 209093652)
+**Cloud project ID :** Voir `config.json` (local-id : 209093652)
 
 ## Description
 
-GARCH(1,1) volatility targeting strategy on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Each asset targets 10% annualized volatility with position sizes adjusted by the GARCH forecast. Uses SMA200 for trend direction (long in uptrend, reduce in downtrend). Model is refit every 22 trading days on a 500-day training window. Weekly rebalance on Mondays.
+Stratégie de vol-targeting GARCH(1,1) sur six actifs (SPY, EFA, EEM, TLT, GLD, DBC). Chaque actif cible 10 % de volatilité annualisée avec des tailles de position ajustées par la prévision GARCH. Utilise une SMA200 pour la direction de la tendance (long en tendance haussière, réduction en tendance baissière). Le modèle est ré-estimé tous les 22 jours de bourse sur une fenêtre d'apprentissage de 500 jours. Rebalance hebdomadaire le lundi.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,42 +16,33 @@ lean backtest --algorithm Vol-GARCH-Target/main.py
 ```
 
 ### QC Cloud
-Open the cloud project (local-id: 209093652), compile and run a backtest.
+Ouvrir le projet cloud (local-id : 209093652), compiler et lancer un backtest.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| GARCH(1,1) vol targeting | Weekly (Monday) | Vol target 10%, SMA200 trend, 500-day window, refit every 22 days |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| Vol-targeting GARCH(1,1) | Hebdomadaire (lundi) | Vol target 10 %, tendance SMA200, fenêtre 500 jours, ré-estimation tous les 22 jours |
 
-### Aligned baseline (2018-2025)
+### Baseline alignée (2018-2025)
 
-Verified on QC Cloud (project 33245149, backtest `a0f7a5b59e878becd574612b85791d51`).
+Vérifiée sur QC Cloud (projet 33245149, backtest `a0f7a5b59e878becd574612b85791d51`).
 
-| Period | Sharpe | CAGR | MaxDD | PSR |
-|--------|--------|------|-------|-----|
-| 2018-2025 (aligned) | 0.325 | 6.97% | 10.80% | 14.9% |
+| Période | Sharpe | CAGR | MaxDD | PSR |
+|---------|--------|------|-------|-----|
+| 2018-2025 (alignée) | 0.325 | 6.97 % | 10.80 % | 14.9 % |
 
-The strategy's strength is risk control, not return. MaxDD 10.80% is the tightest of
-the backbone baselines to date (cf GlobalMacro-Regime 22.8%, HAR-RV-J-Kelly 37.1%,
-Cloud-VolTargeting single-asset 38.2%) -- the GARCH(1,1) variance forecast, the 30%
-per-asset cap and the SMA200 trend filter combine into genuine risk budgeting that
-holds drawdowns in check. Sharpe 0.325 is positive but modest, and PSR 14.9% is
-non-significant. Notably it beats Cloud-VolTargeting (single-asset SPY, realized-vol,
-150% clamp) on both Sharpe (0.325 vs 0.207) and MaxDD (10.8% vs 38.2%): GARCH
-forecasting plus multi-asset diversification outperforms a naive realized-vol single
-asset with a leverage clamp. Promoted Tier 4 (Untested) to Tier 2 (Historique). See
-the comparative-backtests doc for the cross-strategy table.
+La force de la stratégie est le contrôle du risque, pas le rendement. Un MaxDD de 10.80 % est le plus serré des baselines dorsales à ce jour (cf GlobalMacro-Regime 22.8 %, HAR-RV-J-Kelly 37.1 %, Cloud-VolTargeting mono-actif 38.2 %) — la prévision de variance GARCH(1,1), le plafond de 30 % par actif et le filtre de tendance SMA200 se combinent en un véritable budget de risque qui contient les drawdowns. Le Sharpe de 0.325 est positif mais modeste, et le PSR de 14.9 % est non significatif. Notablement, elle bat Cloud-VolTargeting (mono-actif SPY, vol réalisée, clamp 150 %) à la fois sur le Sharpe (0.325 vs 0.207) et le MaxDD (10.8 % vs 38.2 %) : la prévision GARCH plus la diversification multi-actifs surperforme une naïve vol réalisée mono-actif avec clamp de levier. Promue Tier 4 (Untested) vers Tier 2 (Historique). Voir le doc comparative-backtests pour la table cross-strategy.
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | GARCH(1,1) volatility targeting with SMA200 trend filter on 6 multi-asset ETFs |
-| `config.json` | Project configuration (local-id) |
-| `research.ipynb` | Research notebook with GARCH model analysis and parameter exploration |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Vol-targeting GARCH(1,1) avec filtre de tendance SMA200 sur 6 ETF multi-actifs |
+| `config.json` | Configuration du projet (local-id) |
+| `research.ipynb` | Notebook de recherche avec analyse du modèle GARCH et exploration des paramètres |
 
-## References
+## Références
 
 - Bollerslev, T. (1986). *Generalized Autoregressive Conditional Heteroskedasticity*. Journal of Econometrics.
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/README.en.md
@@ -1,0 +1,36 @@
+# VolTarget-Momentum
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** 30784745
+
+## Description
+
+Rank-based allocation on six risky assets (SPY, EFA, EEM, TLT, GLD, DBC) with BND as a defensive safe harbor. v5 best variant achieved Sharpe 0.65, CAGR 14.72%. Uses SMA200 plus 6-month and 12-month momentum filters for asset selection. Targets 15% annualized volatility using 60-day realized volatility for position sizing, with leverage constrained to 0.3-1.5x. Monthly rebalance.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm VolTarget-Momentum/main.py
+```
+
+### QC Cloud
+Open the cloud project (ID: 30784745), compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Rank-based vol targeting + momentum | Monthly | Vol target 15%, 60-day realized vol, leverage 0.3-1.5x, SMA200 + 6m/12m momentum |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Volatility targeting with momentum filters and rank-based allocation on 6 risky + 1 defensive asset |
+| `config.json` | Project configuration (cloud-id, organization-id, language) |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/README.md
@@ -1,14 +1,14 @@
 # VolTarget-Momentum
 
-**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+**Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**Cloud project ID:** 30784745
+**Cloud project ID :** 30784745
 
 ## Description
 
-Rank-based allocation on six risky assets (SPY, EFA, EEM, TLT, GLD, DBC) with BND as a defensive safe harbor. v5 best variant achieved Sharpe 0.65, CAGR 14.72%. Uses SMA200 plus 6-month and 12-month momentum filters for asset selection. Targets 15% annualized volatility using 60-day realized volatility for position sizing, with leverage constrained to 0.3-1.5x. Monthly rebalance.
+Allocation basée sur un ranking de six actifs risqués (SPY, EFA, EEM, TLT, GLD, DBC) avec BND comme refuge défensif (safe harbor). La variante v5 best a atteint un Sharpe de 0.65 et un CAGR de 14.72 %. Utilise SMA200 plus des filtres de momentum 6 mois et 12 mois pour la sélection des actifs. Cible 15 % de volatilité annualisée en utilisant la volatilité réalisée sur 60 jours pour le dimensionnement des positions, avec levier contraint entre 0.3 et 1.5x. Rebalance mensuelle.
 
-## How to Run
+## Comment exécuter
 
 ### Lean CLI
 ```bash
@@ -16,21 +16,21 @@ lean backtest --algorithm VolTarget-Momentum/main.py
 ```
 
 ### QC Cloud
-Open the cloud project (ID: 30784745), compile and run a backtest.
+Ouvrir le projet cloud (ID : 30784745), compiler et lancer un backtest.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Rank-based vol targeting + momentum | Monthly | Vol target 15%, 60-day realized vol, leverage 0.3-1.5x, SMA200 + 6m/12m momentum |
+| Méthode | Rebalance | Paramètres clés |
+|---------|-----------|-----------------|
+| Vol-targeting basé sur ranking + momentum | Mensuelle | Vol target 15 %, vol réalisée 60 jours, levier 0.3-1.5x, SMA200 + momentum 6m/12m |
 
-## Files
+## Fichiers
 
-| File | Description |
-|------|-------------|
-| `main.py` | Volatility targeting with momentum filters and rank-based allocation on 6 risky + 1 defensive asset |
-| `config.json` | Project configuration (cloud-id, organization-id, language) |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Volatility targeting avec filtres momentum et allocation basée sur ranking sur 6 actifs risqués + 1 défensif |
+| `config.json` | Configuration du projet (cloud-id, organization-id, language) |
 
-## References
+## Références
 
-- [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- [Documentation QuantConnect](https://www.quantconnect.com/docs/)


### PR DESCRIPTION
## Summary

Traduction en français de **4 READMEs de stratégies de volatilité QuantConnect** (famille thématique cohérente, **#1650 Phase 0.5**). L'original anglais est préservé byte-identique en `README.en.md` (golden set futur) ; un nouveau `README.md` en français conserve la même structure, liens, et métriques.

Variation de sous-thème vs #4718 (HandsOn ML) et #4694 (ranking) — **FR ≠ typo #3968**, conformément au steer coordinateur (« varie, ne tunnelise pas »).

## Changements (8 fichiers : 4 renames EN + 4 nouveaux FR)

| Projet | Stratégie | Métriques clés |
|--------|-----------|----------------|
| Vol-GARCH-Target | GARCH(1,1) vol-targeting multi-asset | Sharpe 0.325 / CAGR 6.97 % / MaxDD 10.80 % |
| Vol-Ensemble-Conservative | Ensemble GARCH+HAR conservateur | Sharpe 0.265 / CAGR 6.142 % / MaxDD 10.40 % |
| VolTarget-Momentum | Vol-targeting basé sur ranking + momentum | Sharpe 0.65 / CAGR 14.72 % |
| VIX-TermStructure | Term structure VIX (SVXY) | **ARCHIVED** — plafond Sharpe +0.05 |

## Validation

- [x] **Golden set EN préservé** : les 4 `README.en.md` sont **byte-identiques** aux `README.md` d'`origin/main` (vérifié par sha256, règle [readme-french-first](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/readme-french-first.md) §2 — pas de traduction destructive).
- [x] **Métriques/IDs préservés** dans la FR : Sharpe/CAGR/MaxDD/PSR, Cloud project IDs (30784745, 33245149, 33248352, local-ids 209093652/818573377), tickers (SPY/EFA/EEM/TLT/GLD/DBC/BND/SVXY), références académiques (Bollerslev, Corsi, Simon & Campasano), balise de statut `ARCHIVED`.
- [x] **Catalogue intact** : aucun churn `COURSE_CATALOG.*` vs `origin/main` (règle [catalog-pr-hygiene](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/catalog-pr-hygiene.md) — le cron/ci-drift gère l'inscription).
- [x] **Pas de collision** : derniers commits sur ces READMEs = backbone alignment (#3993/#3971) + doc-add (#1372/#1397), anciens.
- [x] Avertissements MD060 (table-column-style) hérités de la structure EN originale — conservés fidèles (règle readme-french-first : préserver la structure).

See #3870
Part of #1650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
