### PR TITLE
fix(genai-texte): demote 'Note de mise à jour' aside H3->bold-inline, 8_Reasoning_Models (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -2238,7 +2238,7 @@
     "\n",
     "Notebook suivant : **9_Vision_Models.ipynb** (GPT-5 Vision, analyse d'images)\n",
     "\n",
-    "### Note de mise à jour\n",
+    "**Note de mise à jour**\n",
     "\n",
     "Ce notebook a été mis à jour pour utiliser exclusivement les modèles gpt-5-x. Contrairement aux versions précédentes qui comparaient des modèles distincts (o4-mini, o3-mini), cette version utilise gpt-5-mini dans deux modes différents :\n",
     "- **Mode chat** : Réponses rapides, conversations\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. Famille GenAI/Texte (suite de #4722). 8_Reasoning_Models = 1 flag HINT-AS-HEADING.

## Changement (1 fichier, +2/-2)

**`Texte/8_Reasoning_Models.ipynb`** cell 36 — 1 flag HINT-AS-HEADING :

\`\`\`diff
- ### Note de mise à jour
+ **Note de mise à jour**
```

Même pattern que #4712 (02-6 « Note technique ») : le scanner `HINT_RE` ([scan_md_hierarchy.py:23](scripts/notebook_tools/scan_md_hierarchy.py#L23)) matche `note` à **tout niveau H1-H6**. Demoter en H4 laisserait le flag → seul un non-heading (bold inline) clear. La directive [notebook-formatting §1.2](docs/reference/notebook-formatting.md) liste « note » comme aside interdit en heading. Mots préservés exactement, seul le markup `###` est retiré.

## Conformité

- **Markdown-only** : cellule markdown, 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé) — `src[47]` modifié in-place
- **Contenu préservé** : le paragraphe explicatif sous le titre est inchangé (seule la ligne de heading change)
- **Rescan post-fix** : `scan_md_hierarchy.py 8_Reasoning_Models` → 0/1 flagged ✓

## Scope

\`See #3966\` (partial — GenAI/Texte : reste 2_PromptEngineering seul). 1 fichier = atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>