### PR TITLE
fix(ml): demote Indice hint-asides to inline bold in Day5/6/7 Labs (EPIC #3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab10-File-Analyzer.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab10-File-Analyzer.ipynb
@@ -768,7 +768,7 @@
   {
    "cell_type": "markdown",
    "id": "e9f5fe9c",
-   "source": "## Exercice : Resume LLM avec Analyse Guidee\n\nUtilisez le FileAnalyzer pour generer un resume LLM guide par une question metier. L'objectif est de comprendre comment la question influence la qualite et la pertinence du resume genere.\n\n### Objectifs\n1. Creer un nouveau fichier CSV avec des donnees de type different (ex: scores d'etudiants)\n2. Analyser le fichier avec le FileAnalyzer\n3. Comparer les resumes LLM avec et sans question guidee\n\n### Indice\n- `analyzer.generate_llm_summary(meta)` pour un resume general\n- `analyzer.generate_llm_summary(meta, question=\"Votre question\")` pour un resume guide\n- Observez comment la question oriente l'analyse du LLM",
+   "source": "## Exercice : Resume LLM avec Analyse Guidee\n\nUtilisez le FileAnalyzer pour generer un resume LLM guide par une question metier. L'objectif est de comprendre comment la question influence la qualite et la pertinence du resume genere.\n\n### Objectifs\n1. Creer un nouveau fichier CSV avec des donnees de type different (ex: scores d'etudiants)\n2. Analyser le fichier avec le FileAnalyzer\n3. Comparer les resumes LLM avec et sans question guidee\n\n**Indice :**\n- `analyzer.generate_llm_summary(meta)` pour un resume general\n- `analyzer.generate_llm_summary(meta, question=\"Votre question\")` pour un resume guide\n- Observez comment la question oriente l'analyse du LLM",
    "metadata": {}
   },
   {
@@ -790,7 +790,7 @@
   {
    "cell_type": "markdown",
    "id": "4c30cfbc",
-   "source": "## Exercice : Extension Multi-Format du FileAnalyzer\n\nEtendez le FileAnalyzer pour supporter un format supplementaire : les fichiers texte (`.txt`). L'objectif est d'extraire des statistiques basiques (nombre de lignes, de mots, de caracteres) et de generer un resume structure.\n\n### Objectifs\n1. Ajouter le format `.txt` au dictionnaire `SUPPORTED`\n2. Implementer `analyze_txt(self, path)` dans une classe heritee\n3. Tester sur un fichier texte de test\n\n### Indice\n- Ouvrez le fichier avec `open(path, 'r', encoding='utf-8')`\n- Comptez les mots avec `len(text.split())` et les lignes avec `text.count('\\n')`\n- Retournez un `FileMetadata` avec les statistiques extraites",
+   "source": "## Exercice : Extension Multi-Format du FileAnalyzer\n\nEtendez le FileAnalyzer pour supporter un format supplementaire : les fichiers texte (`.txt`). L'objectif est d'extraire des statistiques basiques (nombre de lignes, de mots, de caracteres) et de generer un resume structure.\n\n### Objectifs\n1. Ajouter le format `.txt` au dictionnaire `SUPPORTED`\n2. Implementer `analyze_txt(self, path)` dans une classe heritee\n3. Tester sur un fichier texte de test\n\n**Indice :**\n- Ouvrez le fichier avec `open(path, 'r', encoding='utf-8')`\n- Comptez les mots avec `len(text.split())` et les lignes avec `text.count('\\n')`\n- Retournez un `FileMetadata` avec les statistiques extraites",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
@@ -901,7 +901,7 @@
   {
    "cell_type": "markdown",
    "id": "634904e2",
-   "source": "## Exercice : Amelioration du Prompt du Planner\n\nLe parseur du Planner utilise des expressions regulieres pour extraire les etapes. L'objectif est d'ameliorer le prompt et/ou le parseur pour augmenter le taux de succes de l'extraction.\n\n### Objectifs\n1. Analyser pourquoi le Planner extrait parfois 0 etapes\n2. Proposer un prompt plus robuste avec des instructions plus strictes\n3. Implementer un parseur de fallback (ex: detecter les puces `-` ou `*`)\n\n### Indice\n- Le format actuel exige `REASONING:` et `STEPS:` avec des numeros `1.`\n- Un fallback pourrait chercher des lignes commencant par `- ` ou `* `\n- Testez votre version amelioree sur les memes questions que le Planner original",
+   "source": "## Exercice : Amelioration du Prompt du Planner\n\nLe parseur du Planner utilise des expressions regulieres pour extraire les etapes. L'objectif est d'ameliorer le prompt et/ou le parseur pour augmenter le taux de succes de l'extraction.\n\n### Objectifs\n1. Analyser pourquoi le Planner extrait parfois 0 etapes\n2. Proposer un prompt plus robuste avec des instructions plus strictes\n3. Implementer un parseur de fallback (ex: detecter les puces `-` ou `*`)\n\n**Indice :**\n- Le format actuel exige `REASONING:` et `STEPS:` avec des numeros `1.`\n- Un fallback pourrait chercher des lignes commencant par `- ` ou `* `\n- Testez votre version amelioree sur les memes questions que le Planner original",
    "metadata": {}
   },
   {
@@ -923,7 +923,7 @@
   {
    "cell_type": "markdown",
    "id": "7828bf97",
-   "source": "## Exercice : Analyseur d'Erreurs pour l'Executor\n\nL'Executor retourne des messages d'erreur Python (KeyError, NameError, etc.). L'objectif est de creer un composant `ErrorAnalyzer` qui classifie les erreurs et genere un contexte de correction automatique pour la boucle iterative.\n\n### Objectifs\n1. Classifier les erreurs les plus frequentes du code genere par le LLM\n2. Creer un dictionnaire de correspondance erreur -> correction\n3. Integrer l'ErrorAnalyzer dans la boucle du DSStarAgent\n\n### Indice\n- Erreurs frequentes : `KeyError` (mauvais nom de colonne), `NameError` (variable non definie), `AttributeError` (methode inexistante)\n- Pour chaque type, proposez une correction automatique (ex: suggerer les noms de colonnes proches)\n- Utilisez `difflib.get_close_matches()` pour suggerer des noms de colonnes similaires",
+   "source": "## Exercice : Analyseur d'Erreurs pour l'Executor\n\nL'Executor retourne des messages d'erreur Python (KeyError, NameError, etc.). L'objectif est de creer un composant `ErrorAnalyzer` qui classifie les erreurs et genere un contexte de correction automatique pour la boucle iterative.\n\n### Objectifs\n1. Classifier les erreurs les plus frequentes du code genere par le LLM\n2. Creer un dictionnaire de correspondance erreur -> correction\n3. Integrer l'ErrorAnalyzer dans la boucle du DSStarAgent\n\n**Indice :**\n- Erreurs frequentes : `KeyError` (mauvais nom de colonne), `NameError` (variable non definie), `AttributeError` (methode inexistante)\n- Pour chaque type, proposez une correction automatique (ex: suggerer les noms de colonnes proches)\n- Utilisez `difflib.get_close_matches()` pour suggerer des noms de colonnes similaires",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -882,7 +882,7 @@
   {
    "cell_type": "markdown",
    "id": "4c070bc1",
-   "source": "## Exercice : Amelioration du Verifier avec Critères Metier\n\nLe Verifier actuel est generique (SUCCESS / NEEDS_REFINEMENT). L'objectif est de creer un Verifier specialise qui evalue la qualite des resultats selon des criteres metier precis (exhaustivite, precision numerique, format de sortie).\n\n### Objectifs\n1. Definir 3 criteres de qualite pour les analyses de donnees\n2. Implementer un `BusinessVerifier` avec scoring\n3. Comparer les verdicts du Verifier generique vs. le BusinessVerifier\n\n### Indice\n- Criteres possibles : presence de chiffres dans le resultat, longueur minimale, mots-cles attendus\n- Attribuez un score 0-1 par critere et un seuil global de validation\n- Testez sur les memes questions que le pipeline original",
+   "source": "## Exercice : Amelioration du Verifier avec Critères Metier\n\nLe Verifier actuel est generique (SUCCESS / NEEDS_REFINEMENT). L'objectif est de creer un Verifier specialise qui evalue la qualite des resultats selon des criteres metier precis (exhaustivite, precision numerique, format de sortie).\n\n### Objectifs\n1. Definir 3 criteres de qualite pour les analyses de donnees\n2. Implementer un `BusinessVerifier` avec scoring\n3. Comparer les verdicts du Verifier generique vs. le BusinessVerifier\n\n**Indice :**\n- Criteres possibles : presence de chiffres dans le resultat, longueur minimale, mots-cles attendus\n- Attribuez un score 0-1 par critere et un seuil global de validation\n- Testez sur les memes questions que le pipeline original",
    "metadata": {}
   },
   {
@@ -904,7 +904,7 @@
   {
    "cell_type": "markdown",
    "id": "2ef15b04",
-   "source": "## Exercice : Generation de Rapport Automatique\n\nCreez un generateur de rapport Markdown qui consolide les resultats de plusieurs analyses DS-STAR en un document structure. L'objectif est de produire un rapport avec table des matieres, sections par question et tableau recapitulatif.\n\n### Objectifs\n1. Implementer un `ReportGenerator` qui collecte les resultats du pipeline\n2. Generer un rapport Markdown avec sections formatees\n3. Inclure un tableau recapitulatif des questions, statuts et iterations necessaires\n\n### Indice\n- Utilisez des f-strings pour construire le Markdown dynamiquement\n- Structurez en sections : titre, context, resultats par question, synthese\n- Incluez un tableau avec `| Question | Statut | Iterations |`",
+   "source": "## Exercice : Generation de Rapport Automatique\n\nCreez un generateur de rapport Markdown qui consolide les resultats de plusieurs analyses DS-STAR en un document structure. L'objectif est de produire un rapport avec table des matieres, sections par question et tableau recapitulatif.\n\n### Objectifs\n1. Implementer un `ReportGenerator` qui collecte les resultats du pipeline\n2. Generer un rapport Markdown avec sections formatees\n3. Inclure un tableau recapitulatif des questions, statuts et iterations necessaires\n\n**Indice :**\n- Utilisez des f-strings pour construire le Markdown dynamiquement\n- Structurez en sections : titre, context, resultats par question, synthese\n- Incluez un tableau avec `| Question | Statut | Iterations |`",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb
@@ -678,7 +678,7 @@
   {
    "cell_type": "markdown",
    "id": "a35146b7",
-   "source": "## Exercice : Comparaison de Sources Academiques\n\nCreez une fonction qui compare les resultats de recherche provenant de sources differentes (arXiv vs. Papers With Code) et identifie les modeles qui apparaissent dans les deux sources.\n\n### Objectifs\n1. Executer une recherche sur arXiv et sur Papers With Code pour la meme tache\n2. Identifier les modeles communs aux deux sources (intersection)\n3. Classer les modeles par nombre d'occurrences et pertinence\n\n### Indice\n- Utilisez `web_searcher.search_arxiv(task)` et `web_searcher.search_papers_with_code(task)`\n- Comparez les titres en utilisant la similarite de chaines (`difflib.SequenceMatcher`)\n- Les modeles presents dans les deux sources sont generalement plus fiables",
+   "source": "## Exercice : Comparaison de Sources Academiques\n\nCreez une fonction qui compare les resultats de recherche provenant de sources differentes (arXiv vs. Papers With Code) et identifie les modeles qui apparaissent dans les deux sources.\n\n### Objectifs\n1. Executer une recherche sur arXiv et sur Papers With Code pour la meme tache\n2. Identifier les modeles communs aux deux sources (intersection)\n3. Classer les modeles par nombre d'occurrences et pertinence\n\n**Indice :**\n- Utilisez `web_searcher.search_arxiv(task)` et `web_searcher.search_papers_with_code(task)`\n- Comparez les titres en utilisant la similarite de chaines (`difflib.SequenceMatcher`)\n- Les modeles presents dans les deux sources sont generalement plus fiables",
    "metadata": {}
   },
   {
@@ -700,7 +700,7 @@
   {
    "cell_type": "markdown",
    "id": "c08509e3",
-   "source": "## Exercice : Evaluation de la Qualite du Code Genere\n\nLe `SOTACodeGenerator` produit du code initial a partir des modeles SOTA trouves. L'objectif est de creer un evaluateur automatique qui verifie la qualite de ce code avant de l'utiliser.\n\n### Objectifs\n1. Implementer des verifications statiques (imports valides, variables definies, pas de syntax errors)\n2. Verifier la presence d'etapes essentielles (chargement, preprocessing, entrainement, evaluation)\n3. Generer un score de completude du code\n\n### Indice\n- `ast.parse(code)` pour verifier la syntaxe Python sans executer\n- Cherchez des mots-cles : `import`, `fit`, `predict`, `score`, `print`\n- Un code ML complet devrait contenir au minimum : chargement de donnees + entrainement + evaluation",
+   "source": "## Exercice : Evaluation de la Qualite du Code Genere\n\nLe `SOTACodeGenerator` produit du code initial a partir des modeles SOTA trouves. L'objectif est de creer un evaluateur automatique qui verifie la qualite de ce code avant de l'utiliser.\n\n### Objectifs\n1. Implementer des verifications statiques (imports valides, variables definies, pas de syntax errors)\n2. Verifier la presence d'etapes essentielles (chargement, preprocessing, entrainement, evaluation)\n3. Generer un score de completude du code\n\n**Indice :**\n- `ast.parse(code)` pour verifier la syntaxe Python sans executer\n- Cherchez des mots-cles : `import`, `fit`, `predict`, `score`, `print`\n- Un code ML complet devrait contenir au minimum : chargement de donnees + entrainement + evaluation",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb
@@ -825,7 +825,7 @@
   {
    "cell_type": "markdown",
    "id": "4ec2b89e",
-   "source": "## Exercice : Impact du Feature Engineering sur l'Importance\n\nCreez un pipeline ML avec des blocs de feature engineering specifiques et analysez comment l'ablation de chaque bloc de features affecte l'importance estimee par le LLM.\n\n### Objectifs\n1. Definir 3 blocs de features (original, ratio, polynomial)\n2. Analyser l'importance estimee de chaque bloc\n3. Rédiger un rapport comparatif des resultats d'ablation\n\n### Indice\n- Bloc 1: features originales (`age`, `tenure`, `monthly_charges`)\n- Bloc 2: features ratio (`charges_per_month = total_charges / tenure`)\n- Bloc 3: features polynomiales (`age_squared`, `tenure_log`)\n- Observez quel bloc le LLM estime le plus important et pourquoi",
+   "source": "## Exercice : Impact du Feature Engineering sur l'Importance\n\nCreez un pipeline ML avec des blocs de feature engineering specifiques et analysez comment l'ablation de chaque bloc de features affecte l'importance estimee par le LLM.\n\n### Objectifs\n1. Definir 3 blocs de features (original, ratio, polynomial)\n2. Analyser l'importance estimee de chaque bloc\n3. Rédiger un rapport comparatif des resultats d'ablation\n\n**Indice :**\n- Bloc 1: features originales (`age`, `tenure`, `monthly_charges`)\n- Bloc 2: features ratio (`charges_per_month = total_charges / tenure`)\n- Bloc 3: features polynomiales (`age_squared`, `tenure_log`)\n- Observez quel bloc le LLM estime le plus important et pourquoi",
    "metadata": {}
   },
   {
@@ -847,7 +847,7 @@
   {
    "cell_type": "markdown",
    "id": "c4fbd7c7",
-   "source": "## Exercice : Strategie d'Ensemble par Ablation\n\nUtilisez l'ablation pour determiner la meilleure strategie d'ensemble (voting, stacking, blending) pour un pipeline ML. L'objectif est de comparer les approches d'ensemble et de choisir la plus adaptee.\n\n### Objectifs\n1. Definir 3 strategies d'ensemble dans un pipeline ML\n2. Appliquer l'ablation pour comparer leur importance relative\n3. Recommander la meilleure strategie avec justification\n\n### Indice\n- Voting : `VotingClassifier` avec plusieurs modeles\n- Stacking : `StackingClassifier` avec meta-learner\n- Blending : predictions sur un validation set\n- L'ablation permet de determiner si l'ensemble apporte reellement un gain vs. un seul modele",
+   "source": "## Exercice : Strategie d'Ensemble par Ablation\n\nUtilisez l'ablation pour determiner la meilleure strategie d'ensemble (voting, stacking, blending) pour un pipeline ML. L'objectif est de comparer les approches d'ensemble et de choisir la plus adaptee.\n\n### Objectifs\n1. Definir 3 strategies d'ensemble dans un pipeline ML\n2. Appliquer l'ablation pour comparer leur importance relative\n3. Recommander la meilleure strategie avec justification\n\n**Indice :**\n- Voting : `VotingClassifier` avec plusieurs modeles\n- Stacking : `StackingClassifier` avec meta-learner\n- Blending : predictions sur un validation set\n- L'ablation permet de determiner si l'ensemble apporte reellement un gain vs. un seul modele",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
@@ -720,7 +720,7 @@
   {
    "cell_type": "markdown",
    "id": "c1ebaf8a",
-   "source": "## Exercice : Exploration du Dataset Simule\n\nAvant de lancer le pipeline MLE-STAR, il est essentiel d'explorer les donnees pour comprendre leur structure et identifier les problemes potentiels. L'objectif est d'analyser le dataset synthetique genere par le KaggleSimulator.\n\n### Objectifs\n1. Explorer le dataset avec les methodes pandas (head, describe, info, value_counts)\n2. Identifier les distributions et les correlations entre variables\n3. Detecter les problemes potentiels (valeurs manquantes, desequilibre des classes, outliers)\n\n### Indice\n- `df.describe()` pour les statistiques descriptives\n- `df['target'].value_counts()` pour verifier l'equilibre des classes\n- `df.corr()` pour les correlations entre variables numeriques",
+   "source": "## Exercice : Exploration du Dataset Simule\n\nAvant de lancer le pipeline MLE-STAR, il est essentiel d'explorer les donnees pour comprendre leur structure et identifier les problemes potentiels. L'objectif est d'analyser le dataset synthetique genere par le KaggleSimulator.\n\n### Objectifs\n1. Explorer le dataset avec les methodes pandas (head, describe, info, value_counts)\n2. Identifier les distributions et les correlations entre variables\n3. Detecter les problemes potentiels (valeurs manquantes, desequilibre des classes, outliers)\n\n**Indice :**\n- `df.describe()` pour les statistiques descriptives\n- `df['target'].value_counts()` pour verifier l'equilibre des classes\n- `df.corr()` pour les correlations entre variables numeriques",
    "metadata": {}
   },
   {
@@ -742,7 +742,7 @@
   {
    "cell_type": "markdown",
    "id": "7f39a45c",
-   "source": "## Exercice : Iteration de Raffinement du Pipeline MLE-STAR\n\nAppliquez un cycle d'iteration complete du pipeline MLE-STAR : analysez le code genere, identifiez les ameliorations prioritaires et genere une version raffinee.\n\n### Objectifs\n1. Recuperer le code genere par le pipeline MLE-STAR\n2. Appliquer l'analyseur d'ablation pour identifier le bloc le plus critique\n3. Generer une version amelioree du code et comparer les differences\n\n### Indice\n- Utilisez `MLEStarAblation` pour analyser le code genere\n- Concentrez-vous sur le bloc avec l'importance la plus elevee\n- Comparez le code original et raffine pour identifier les changements concrets",
+   "source": "## Exercice : Iteration de Raffinement du Pipeline MLE-STAR\n\nAppliquez un cycle d'iteration complete du pipeline MLE-STAR : analysez le code genere, identifiez les ameliorations prioritaires et genere une version raffinee.\n\n### Objectifs\n1. Recuperer le code genere par le pipeline MLE-STAR\n2. Appliquer l'analyseur d'ablation pour identifier le bloc le plus critique\n3. Generer une version amelioree du code et comparer les differences\n\n**Indice :**\n- Utilisez `MLEStarAblation` pour analyser le code genere\n- Concentrez-vous sur le bloc avec l'importance la plus elevee\n- Comparez le code original et raffine pour identifier les changements concrets",
    "metadata": {}
   },
   {
@@ -764,7 +764,7 @@
   {
    "cell_type": "markdown",
    "id": "5b880b8f",
-   "source": "## Exercice : Evaluation et Comparaison de Modeles\n\nApres avoir explore les donnees et iterer sur le code MLE-STAR, il est crucial d'evaluer rigoureusement plusieurs modeles pour selectionner le plus performant.\n\n### Objectifs\n1. Entrainer au moins deux modeles differents sur les donnees simulees\n2. Comparer leurs performances avec la metrique AUC-ROC\n3. Visualiser les courbes ROC pour analyser les compromis\n\n### Indice\n- Utilisez `sklearn.metrics.roc_auc_score` et `roc_curve`\n- `LogisticRegression` et `RandomForestClassifier` sont de bons candidats pour commencer\n- `plt.plot(fpr, tpr)` pour la courbe ROC",
+   "source": "## Exercice : Evaluation et Comparaison de Modeles\n\nApres avoir explore les donnees et iterer sur le code MLE-STAR, il est crucial d'evaluer rigoureusement plusieurs modeles pour selectionner le plus performant.\n\n### Objectifs\n1. Entrainer au moins deux modeles differents sur les donnees simulees\n2. Comparer leurs performances avec la metrique AUC-ROC\n3. Visualiser les courbes ROC pour analyser les compromis\n\n**Indice :**\n- Utilisez `sklearn.metrics.roc_auc_score` et `roc_curve`\n- `LogisticRegression` et `RandomForestClassifier` sont de bons candidats pour commencer\n- `plt.plot(fpr, tpr)` pour la courbe ROC",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb
@@ -793,7 +793,7 @@
   {
    "cell_type": "markdown",
    "id": "4255aeec",
-   "source": "## Exercice : Comparaison NL2SQL vs NL2Py sur Requetes Complexes\n\nTestez les deux modes de traduction (SQL et Python) sur des requetes de complexite croissante et analysez les forces et faiblesses de chaque approche.\n\n### Objectifs\n1. Definir 5 questions de complexite croissante (simple, jointure, agregation, sous-requete, analytique)\n2. Traduire chaque question en SQL et en Python\n3. Comparer la qualite, la precision et la robustesse des deux traductions\n\n### Indice\n- SQL est generalement meilleur pour les jointures et agregations\n- Python est plus flexible pour les analyses statistiques et visualisations\n- Observez a partir de quel niveau de complexite chaque approche commence a echouer",
+   "source": "## Exercice : Comparaison NL2SQL vs NL2Py sur Requetes Complexes\n\nTestez les deux modes de traduction (SQL et Python) sur des requetes de complexite croissante et analysez les forces et faiblesses de chaque approche.\n\n### Objectifs\n1. Definir 5 questions de complexite croissante (simple, jointure, agregation, sous-requete, analytique)\n2. Traduire chaque question en SQL et en Python\n3. Comparer la qualite, la precision et la robustesse des deux traductions\n\n**Indice :**\n- SQL est generalement meilleur pour les jointures et agregations\n- Python est plus flexible pour les analyses statistiques et visualisations\n- Observez a partir de quel niveau de complexite chaque approche commence a echouer",
    "metadata": {}
   },
   {
@@ -815,7 +815,7 @@
   {
    "cell_type": "markdown",
    "id": "f11a3ddb",
-   "source": "## Exercice : Validation et Correction Automatique du SQL Genere\n\nLes requetes SQL generees par le LLM peuvent contenir des erreurs (noms de colonnes inexacts, jointures manquantes, syntaxe incorrecte). L'objectif est de creer un validateur SQL qui detecte et corrige automatiquement ces problemes.\n\n### Objectifs\n1. Implementer une verification des noms de tables et colonnes contre le schema\n2. Detecter les jointures manquantes entre tables\n3. Proposer des corrections automatiques pour les erreurs detectees\n\n### Indice\n- Comparez les identifiants dans le SQL avec les noms du schema\n- Si une colonne est utilisee sans le prefix de table, suggerez la bonne table\n- Les jointures manquantes se detectent quand une clause WHERE ou SELECT reference une colonne d'une table non jointe",
+   "source": "## Exercice : Validation et Correction Automatique du SQL Genere\n\nLes requetes SQL generees par le LLM peuvent contenir des erreurs (noms de colonnes inexacts, jointures manquantes, syntaxe incorrecte). L'objectif est de creer un validateur SQL qui detecte et corrige automatiquement ces problemes.\n\n### Objectifs\n1. Implementer une verification des noms de tables et colonnes contre le schema\n2. Detecter les jointures manquantes entre tables\n3. Proposer des corrections automatiques pour les erreurs detectees\n\n**Indice :**\n- Comparez les identifiants dans le SQL avec les noms du schema\n- Si une colonne est utilisee sans le prefix de table, suggerez la bonne table\n- Les jointures manquantes se detectent quand une clause WHERE ou SELECT reference une colonne d'une table non jointe",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
@@ -900,7 +900,7 @@
   {
    "cell_type": "markdown",
    "id": "8ba2e35c",
-   "source": "## Exercice : Benchmark du Pipeline avec Differentes Configurations\n\nTestez le pipeline DS-STAR avec differentes configurations de parametres (nombre d'iterations, temperature du LLM, longueur du contexte) et mesurez l'impact sur la qualite des resultats.\n\n### Objectifs\n1. Definir 3 configurations avec des parametres differents\n2. Executer le pipeline sur la meme question pour chaque configuration\n3. Comparer les resultats (succes, nombre d'iterations, qualite de l'output)\n\n### Indice\n- Configuration 1: `max_iterations=1`, temperature=0.1 (conservateur)\n- Configuration 2: `max_iterations=3`, temperature=0.3 (equilibre)\n- Configuration 3: `max_iterations=2`, temperature=0.7 (creatif)\n- Mesurez le taux de succes et le nombre moyen d'iterations pour chaque config",
+   "source": "## Exercice : Benchmark du Pipeline avec Differentes Configurations\n\nTestez le pipeline DS-STAR avec differentes configurations de parametres (nombre d'iterations, temperature du LLM, longueur du contexte) et mesurez l'impact sur la qualite des resultats.\n\n### Objectifs\n1. Definir 3 configurations avec des parametres differents\n2. Executer le pipeline sur la meme question pour chaque configuration\n3. Comparer les resultats (succes, nombre d'iterations, qualite de l'output)\n\n**Indice :**\n- Configuration 1: `max_iterations=1`, temperature=0.1 (conservateur)\n- Configuration 2: `max_iterations=3`, temperature=0.3 (equilibre)\n- Configuration 3: `max_iterations=2`, temperature=0.7 (creatif)\n- Mesurez le taux de succes et le nombre moyen d'iterations pour chaque config",
    "metadata": {}
   },
   {
@@ -941,7 +941,7 @@
     "2. Implementer un `SafeReportGenerator` qui n'utilise que les donnees injectees\n",
     "3. Comparer les rapports genere par les deux versions\n",
     "\n",
-    "### Indice\n",
+    "**Indice :**\n",
     "- Le prompt actuel demande \"genere un rapport\" sans fournir les resultats concrets\n",
     "- Injectez les outputs reels dans le prompt avec une instruction stricte \"n'invente aucun chiffre\"\n",
     "- Ajoutez un avertissement \"Si tu n'as pas de donnees pour une section, indique 'Donnees non disponibles'\""


### PR DESCRIPTION
## Summary

EPIC **#3966** — hierarchy normalization (aside-demotion). Continues the `### Indice`/`### Etape N`/`### Note` hint-aside → `**Indice :**` inline-bold convention (user #4127), same pattern as merged **#4703** (Day4-Foundations).

Applied to **ML `DataScienceWithAgents/AgenticDataScience`** labs **Day5 / Day6 / Day7** (the residual H3 hint-asides flagged repo-wide by `scripts/notebook_tools/scan_md_hierarchy.py`).

## Changes

- **17** `### Indice` H3 hint-asides → `**Indice :**` inline bold+colon
- **8 labs**:
  - Day5-DS-Star: Lab10-File-Analyzer, Lab11-Planner-Coder-Loop, Lab12-DS-Star-Workshop
  - Day6-MLE-Star: Lab13-Web-Search-SOTA, Lab14-Ablation-Refinement, Lab15-Kaggle-Challenge
  - Day7-Production: Lab16-Data-Science-Agent, Lab17-Final-Project

## Validation

- `git diff --stat`: **8 files, 17 insertions, 17 deletions**
- Every changed line mentions `Indice` (verified: 0 non-Indice changed lines)
- **Markdown-cell source strings only** — 0 code cells touched, all `outputs` + `execution_count` preserved (C.2 markdown-only exception: no re-execution needed)
- Re-scan after fix: **0 / 8 labs flagged**
- JSON structure preserved (raw-text `.replace()` with `chr(92)` backslash to avoid C102 source-list/string churn)

See #3966 (partial — ML DataScienceWithAgents labs). Companion to merged #4703 (Day4-Foundations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)