### PR TITLE
feat(casestudies): CC3 SmartGrid solver layers -- CP-SAT + Bayesian + multi-objectif

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/solution/SmartGrid-Energy.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/solution/SmartGrid-Energy.ipynb
@@ -71,10 +71,10 @@
    "id": "c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:55:03.484579Z",
-     "iopub.status.busy": "2026-07-01T08:55:03.484328Z",
-     "iopub.status.idle": "2026-07-01T08:55:03.599467Z",
-     "shell.execute_reply": "2026-07-01T08:55:03.597999Z"
+     "iopub.execute_input": "2026-07-01T10:21:33.636366Z",
+     "iopub.status.busy": "2026-07-01T10:21:33.636186Z",
+     "iopub.status.idle": "2026-07-01T10:21:33.765086Z",
+     "shell.execute_reply": "2026-07-01T10:21:33.764198Z"
     }
    },
    "outputs": [
@@ -174,10 +174,10 @@
    "id": "c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:55:03.603391Z",
-     "iopub.status.busy": "2026-07-01T08:55:03.602746Z",
-     "iopub.status.idle": "2026-07-01T08:55:03.610763Z",
-     "shell.execute_reply": "2026-07-01T08:55:03.609400Z"
+     "iopub.execute_input": "2026-07-01T10:21:33.767783Z",
+     "iopub.status.busy": "2026-07-01T10:21:33.767498Z",
+     "iopub.status.idle": "2026-07-01T10:21:34.421767Z",
+     "shell.execute_reply": "2026-07-01T10:21:34.420801Z"
     }
    },
    "outputs": [
@@ -185,24 +185,88 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dispatch CP-SAT : None\n"
+      "Dispatch CP-SAT (min cout) - statut: OPTIMAL\n",
+      "  H0: Charbon=270MW, Hydro=150MW\n",
+      "  H1: Charbon=310MW, Hydro=150MW\n",
+      "  H2: Charbon=290MW, Hydro=150MW\n",
+      "  H3: Charbon=340MW, Hydro=150MW\n",
+      "  H4: Charbon=330MW, Hydro=150MW\n",
+      "  H5: Charbon=280MW, Hydro=150MW\n",
+      "  Cout objectif: 63600.0\n"
      ]
     }
    ],
    "source": [
-    "# Partie 1 : modele CP-SAT du dispatch (implementation cycle suivant)\n",
-    "def solve_dispatch_cp(network: PowerNetwork):\n",
-    "    \"\"\"Resout le unit commitment par programmation par contraintes.\n",
+    "# Partie 1 : modele CP-SAT du dispatch (unit commitment)\n",
+    "from ortools.sat.python import cp_model\n",
     "\n",
-    "    Renvoie un dict {hour: {plant_name: production_mw}} minimisant le cout total\n",
-    "    sous contraintes de capacite et d'equilibre offre/demande.\n",
+    "\n",
+    "def solve_dispatch_cp(network, cost_weights=None):\n",
+    "    \"\"\"Resout le unit commitment par programmation par contraintes (CP-SAT).\n",
+    "\n",
+    "    Pour chaque heure et centrale pilotable : binaire on (activee) + entier\n",
+    "    p (production MW). Contraintes : equilibre offre/demande nette + bornes\n",
+    "    de capacite (pmin <= p <= pmax quand active). Objectif pondere : on peut\n",
+    "    minimiser le cout (couts variables) ou le CO2 (facteurs d'emission).\n",
+    "\n",
+    "    Renvoie un dict {hour: {plant_name: production_mw}}, '_cost', '_status'.\n",
+    "    cost_weights = (w_cost, w_co2) : poids de chaque terme dans l'objectif.\n",
     "    \"\"\"\n",
-    "    result = None  # TODO etudiant : implementer avec ortools.sat.python.cp_model\n",
+    "    if cost_weights is None:\n",
+    "        cost_weights = (1.0, 0.0)\n",
+    "    H = len(network.demand_mw)\n",
+    "    plants = network.plants\n",
+    "    model = cp_model.CpModel()\n",
+    "\n",
+    "    on, p = {}, {}\n",
+    "    for h in range(H):\n",
+    "        for i, plant in enumerate(plants):\n",
+    "            on[(h, i)] = model.NewBoolVar(f'on_{h}_{i}')\n",
+    "            p[(h, i)] = model.NewIntVar(0, int(plant.pmax), f'p_{h}_{i}')\n",
+    "\n",
+    "    for h in range(H):\n",
+    "        nd = int(round(network.net_demand(h)))\n",
+    "        model.Add(sum(p[(h, i)] for i in range(len(plants))) == nd)\n",
+    "        for i, plant in enumerate(plants):\n",
+    "            model.Add(p[(h, i)] >= int(plant.pmin) * on[(h, i)])\n",
+    "            model.Add(p[(h, i)] <= int(plant.pmax) * on[(h, i)])\n",
+    "\n",
+    "    w_cost, w_co2 = cost_weights\n",
+    "    # Objectif pondere cout+CO2. NB : on plie les poids DANS chaque terme et on somme\n",
+    "    # via cp_model.LinearExpr.Sum (jamais `poids * SumArray` ni le builtin sum()) : quand\n",
+    "    # un poids vaut 0, `0 * IntVar` produit un IntConstant(0) (objet) qu'on ne peut pas\n",
+    "    # additionner a une SumArray (__radd__ attend un float). Sum() accepte une liste\n",
+    "    # melangeant IntAffine et IntConstant sans probleme.\n",
+    "    wc, wco2 = int(round(w_cost)), int(round(w_co2))\n",
+    "    objective_terms = []\n",
+    "    for h in range(H):\n",
+    "        for i, plant in enumerate(plants):\n",
+    "            objective_terms.append(wc * int(round(plant.cost_per_mw)) * p[(h, i)])\n",
+    "            objective_terms.append(wco2 * int(round(plant.co2_per_mw)) * p[(h, i)])\n",
+    "    model.Minimize(cp_model.LinearExpr.Sum(objective_terms))\n",
+    "\n",
+    "    solver = cp_model.CpSolver()\n",
+    "    solver.parameters.max_time_in_seconds = 10.0\n",
+    "    status = solver.Solve(model)\n",
+    "    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):\n",
+    "        return None\n",
+    "    result = {}\n",
+    "    for h in range(H):\n",
+    "        result[h] = {plants[i].name: solver.Value(p[(h, i)]) for i in range(len(plants))}\n",
+    "    result['_cost'] = round(solver.ObjectiveValue(), 1)\n",
+    "    result['_status'] = solver.StatusName(status)\n",
     "    return result\n",
     "\n",
     "\n",
     "dispatch = solve_dispatch_cp(net)\n",
-    "print('Dispatch CP-SAT :', dispatch)\n"
+    "if dispatch:\n",
+    "    print('Dispatch CP-SAT (min cout) - statut:', dispatch['_status'])\n",
+    "    for h in range(len(net.demand_mw)):\n",
+    "        prod = ', '.join(f'{k}={v}MW' for k, v in dispatch[h].items() if v > 0)\n",
+    "        print(f'  H{h}: {prod}')\n",
+    "    print(f'  Cout objectif: {dispatch[\"_cost\"]}')\n",
+    "else:\n",
+    "    print('Aucune solution faisable (capacite < demande)')\n"
    ]
   },
   {
@@ -226,10 +290,10 @@
    "id": "c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:55:03.614348Z",
-     "iopub.status.busy": "2026-07-01T08:55:03.613886Z",
-     "iopub.status.idle": "2026-07-01T08:55:03.620773Z",
-     "shell.execute_reply": "2026-07-01T08:55:03.619146Z"
+     "iopub.execute_input": "2026-07-01T10:21:34.424621Z",
+     "iopub.status.busy": "2026-07-01T10:21:34.424293Z",
+     "iopub.status.idle": "2026-07-01T10:21:34.428667Z",
+     "shell.execute_reply": "2026-07-01T10:21:34.427717Z"
     }
    },
    "outputs": [],
@@ -260,10 +324,10 @@
    "id": "c10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:55:03.624599Z",
-     "iopub.status.busy": "2026-07-01T08:55:03.624112Z",
-     "iopub.status.idle": "2026-07-01T08:55:03.631314Z",
-     "shell.execute_reply": "2026-07-01T08:55:03.629969Z"
+     "iopub.execute_input": "2026-07-01T10:21:34.431789Z",
+     "iopub.status.busy": "2026-07-01T10:21:34.431534Z",
+     "iopub.status.idle": "2026-07-01T10:21:34.440208Z",
+     "shell.execute_reply": "2026-07-01T10:21:34.439383Z"
     }
    },
    "outputs": [
@@ -271,29 +335,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "H0: risque de defaillance estime a None\n",
-      "H1: risque de defaillance estime a None\n",
-      "H2: risque de defaillance estime a None\n",
-      "H3: risque de defaillance estime a None\n",
-      "H4: risque de defaillance estime a None\n",
-      "H5: risque de defaillance estime a None\n"
+      "Risque de defaillance (capacite pilotable = 800 MW) :\n",
+      "  H0: demande nette moyenne 420 MW, incertitude +/-15 MW -> risque 6.86e-142\n",
+      "  H1: demande nette moyenne 460 MW, incertitude +/-12 MW -> risque 6.72e-177\n",
+      "  H2: demande nette moyenne 440 MW, incertitude +/-10 MW -> risque 4.18e-284\n",
+      "  H3: demande nette moyenne 490 MW, incertitude +/-12 MW -> risque 1.87e-147\n",
+      "  H4: demande nette moyenne 480 MW, incertitude +/-25 MW -> risque 8.20e-38\n",
+      "  H5: demande nette moyenne 430 MW, incertitude +/-30 MW -> risque 3.00e-35\n"
      ]
     }
    ],
    "source": [
-    "# Partie 2 : modele bayesien de l'incertitude (implementation cycle suivant)\n",
-    "def failure_risk(network: PowerNetwork, hour: int) -> float:\n",
-    "    \"\"\"Probabilite que la demande nette (aleatoire) depasse la capacite pilotable.\n",
+    "# Partie 2 : modele bayesien de l'incertitude renouvelable\n",
+    "from math import sqrt, erfc\n",
     "\n",
-    "    Modele l'ecart offre/demande comme une gaussienne (demande - renouvelable)\n",
-    "    et calcule P(ecart > capacite pilotable disponible).\n",
+    "\n",
+    "def failure_risk(network, hour):\n",
+    "    \"\"\"Probabilite que la demande nette reelle depasse la capacite pilotable.\n",
+    "\n",
+    "    Modele : la production renouvelable reelle ~ N(mean, std). La demande nette\n",
+    "    reelle = demande - renouvelable_reelle ~ N(net_demand, renewable_std).\n",
+    "    Risque = P(demande nette reelle > capacite pilotable totale), calcule via\n",
+    "    la survivor function d'une gaussienne : SF(z) = 0.5 * erfc(z / sqrt(2)).\n",
     "    \"\"\"\n",
-    "    risk = None  # TODO etudiant : implementer (gaussienne, scipy.stats.norm.sf)\n",
-    "    return risk\n",
+    "    mean_net = network.net_demand(hour)\n",
+    "    std = network.renewable_forecast_std[hour]\n",
+    "    capacity = network.total_capacity()\n",
+    "    if std <= 0:\n",
+    "        return 1.0 if mean_net > capacity else 0.0\n",
+    "    z = (capacity - mean_net) / std\n",
+    "    return 0.5 * erfc(z / sqrt(2))\n",
     "\n",
     "\n",
+    "print('Risque de defaillance (capacite pilotable =', net.total_capacity(), 'MW) :')\n",
     "for h in range(len(net.demand_mw)):\n",
-    "    print(f'H{h}: risque de defaillance estime a {failure_risk(net, h)}')\n"
+    "    r = failure_risk(net, h)\n",
+    "    print(f'  H{h}: demande nette moyenne {net.net_demand(h):.0f} MW, '\n",
+    "          f'incertitude +/-{net.renewable_forecast_std[h]} MW -> risque {r:.2e}')\n"
    ]
   },
   {
@@ -314,10 +392,10 @@
    "id": "c12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:55:03.635116Z",
-     "iopub.status.busy": "2026-07-01T08:55:03.634580Z",
-     "iopub.status.idle": "2026-07-01T08:55:03.641483Z",
-     "shell.execute_reply": "2026-07-01T08:55:03.640054Z"
+     "iopub.execute_input": "2026-07-01T10:21:34.442912Z",
+     "iopub.status.busy": "2026-07-01T10:21:34.442694Z",
+     "iopub.status.idle": "2026-07-01T10:21:34.447207Z",
+     "shell.execute_reply": "2026-07-01T10:21:34.446173Z"
     }
    },
    "outputs": [],
@@ -348,25 +426,51 @@
    "id": "c14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:55:03.644566Z",
-     "iopub.status.busy": "2026-07-01T08:55:03.644136Z",
-     "iopub.status.idle": "2026-07-01T08:55:03.651372Z",
-     "shell.execute_reply": "2026-07-01T08:55:03.649619Z"
+     "iopub.execute_input": "2026-07-01T10:21:34.449774Z",
+     "iopub.status.busy": "2026-07-01T10:21:34.449387Z",
+     "iopub.status.idle": "2026-07-01T10:21:34.457951Z",
+     "shell.execute_reply": "2026-07-01T10:21:34.456993Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Score multi-objectif du dispatch min-cout (ref non normalise): 1.137\n"
+     ]
+    }
+   ],
    "source": [
-    "# Partie 3 : optimisation multi-objectif (implementation cycle suivant)\n",
-    "def multi_objective_score(dispatch, network: PowerNetwork, weights=(1.0, 1.0, 1.0)):\n",
-    "    \"\"\"Score = a*cout_normalise + b*co2_normalise + c*risque_normalise.\"\"\"\n",
-    "    score = None  # TODO etudiant : normaliser chaque objectif puis combiner\n",
-    "    return score\n",
+    "# Partie 3 : score multi-objectif (cout + CO2 + risque)\n",
+    "def dispatch_metrics(dispatch, network):\n",
+    "    \"\"\"Calcule cout total, CO2 total et risque max d'un dispatch CP-SAT.\"\"\"\n",
+    "    if dispatch is None:\n",
+    "        return {'cost': float('inf'), 'co2': float('inf'), 'max_risk': 1.0}\n",
+    "    cost = co2 = 0.0\n",
+    "    for h in range(len(network.demand_mw)):\n",
+    "        for plant in network.plants:\n",
+    "            prod = dispatch[h].get(plant.name, 0)\n",
+    "            cost += prod * plant.cost_per_mw\n",
+    "            co2 += prod * plant.co2_per_mw\n",
+    "    risks = [failure_risk(network, h) for h in range(len(network.demand_mw))]\n",
+    "    return {'cost': cost, 'co2': co2, 'max_risk': max(risks)}\n",
     "\n",
     "\n",
-    "def pareto_front(network: PowerNetwork, weights_grid=None):\n",
-    "    \"\"\"Explore le front de Pareto en variant les poids (a, b, c).\"\"\"\n",
-    "    front = None  # TODO etudiant : boucler sur weights_grid, collecter les dispatches optimaux\n",
-    "    return front\n"
+    "def multi_objective_score(dispatch, network, weights=(1.0, 1.0, 1.0), norms=None):\n",
+    "    \"\"\"Score = w_c*cout_norm + w_co2*co2_norm + w_r*risque_norm dans [0,1] (0=meilleur).\"\"\"\n",
+    "    m = dispatch_metrics(dispatch, network)\n",
+    "    if norms is None:\n",
+    "        norms = {'cost': m['cost'] or 1.0, 'co2': m['co2'] or 1.0, 'max_risk': 1.0}\n",
+    "    wc, wco2, wr = weights\n",
+    "    return (wc * (m['cost'] / max(norms['cost'], 1e-9))\n",
+    "            + wco2 * (m['co2'] / max(norms['co2'], 1e-9))\n",
+    "            + wr * (m['max_risk'] / max(norms['max_risk'], 1e-9)))\n",
+    "\n",
+    "\n",
+    "score_min_cost = multi_objective_score(dispatch, net, weights=(1.0, 1.0, 1.0),\n",
+    "                                       norms={'cost': 200000, 'co2': 2000000, 'max_risk': 1.0})\n",
+    "print(f'Score multi-objectif du dispatch min-cout (ref non normalise): {score_min_cost:.3f}')\n"
    ]
   },
   {
@@ -387,10 +491,10 @@
    "id": "c16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:55:03.654731Z",
-     "iopub.status.busy": "2026-07-01T08:55:03.654156Z",
-     "iopub.status.idle": "2026-07-01T08:55:03.659915Z",
-     "shell.execute_reply": "2026-07-01T08:55:03.658674Z"
+     "iopub.execute_input": "2026-07-01T10:21:34.460555Z",
+     "iopub.status.busy": "2026-07-01T10:21:34.460348Z",
+     "iopub.status.idle": "2026-07-01T10:21:34.464775Z",
+     "shell.execute_reply": "2026-07-01T10:21:34.463843Z"
     }
    },
    "outputs": [],
@@ -420,19 +524,67 @@
    "id": "c18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:55:03.663166Z",
-     "iopub.status.busy": "2026-07-01T08:55:03.662672Z",
-     "iopub.status.idle": "2026-07-01T08:55:03.667882Z",
-     "shell.execute_reply": "2026-07-01T08:55:03.666747Z"
+     "iopub.execute_input": "2026-07-01T10:21:34.467830Z",
+     "iopub.status.busy": "2026-07-01T10:21:34.467446Z",
+     "iopub.status.idle": "2026-07-01T10:21:34.520648Z",
+     "shell.execute_reply": "2026-07-01T10:21:34.519847Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Analyse comparative des strategies de dispatch :\n",
+      "Strategie                   Cout (EUR)     CO2 (kg)   Risque max    Score\n",
+      "---------------------------------------------------------------------------\n",
+      "Economique (min cout)            63600      1638000     3.00e-35    1.596\n",
+      "Ecologique (min CO2)            106800       918000     3.00e-35    1.560\n",
+      "Compromis (pondere)             106800       918000     3.00e-35    1.560\n",
+      "\n",
+      "Strategie optimale (score multi-objectif minimal) : Ecologique (min CO2)\n"
+     ]
+    }
+   ],
    "source": [
-    "# Partie 4 : analyse comparative (implementation cycle suivant)\n",
-    "def comparative_analysis(network: PowerNetwork):\n",
-    "    \"\"\"Compare CP-SAT pur vs multi-objectif vs Pareto sur cout/CO2/fiabilite/equite.\"\"\"\n",
-    "    analysis = None  # TODO etudiant : produire le tableau + graphique radar\n",
-    "    return analysis\n"
+    "# Partie 4 : analyse comparative des strategies de dispatch\n",
+    "def comparative_analysis(network):\n",
+    "    \"\"\"Compare 3 strategies CP-SAT (economique, ecologique, compromis).\"\"\"\n",
+    "    eco = solve_dispatch_cp(network, cost_weights=(1.0, 0.0))    # min cout\n",
+    "    green = solve_dispatch_cp(network, cost_weights=(0.0, 1.0))  # min CO2\n",
+    "    comp = solve_dispatch_cp(network, cost_weights=(1.0, 3.0))   # compromis\n",
+    "\n",
+    "    m_eco = dispatch_metrics(eco, network)\n",
+    "    m_green = dispatch_metrics(green, network)\n",
+    "    m_comp = dispatch_metrics(comp, network)\n",
+    "    norms = {\n",
+    "        'cost': max(m_eco['cost'], m_green['cost'], 1.0),\n",
+    "        'co2': max(m_eco['co2'], m_green['co2'], 1.0),\n",
+    "        'max_risk': max(m_eco['max_risk'], m_green['max_risk'], 1e-9),\n",
+    "    }\n",
+    "    s_eco = multi_objective_score(eco, network, weights=(1.0, 1.0, 1.0), norms=norms)\n",
+    "    s_green = multi_objective_score(green, network, weights=(1.0, 1.0, 1.0), norms=norms)\n",
+    "    s_comp = multi_objective_score(comp, network, weights=(1.0, 1.0, 1.0), norms=norms)\n",
+    "\n",
+    "    table = {}\n",
+    "    for name, d, m, s in [('Economique (min cout)', eco, m_eco, s_eco),\n",
+    "                          ('Ecologique (min CO2)', green, m_green, s_green),\n",
+    "                          ('Compromis (pondere)', comp, m_comp, s_comp)]:\n",
+    "        table[name] = {'cout_EUR': round(m['cost']), 'co2_kg': round(m['co2']),\n",
+    "                       'risque_max': m['max_risk'], 'score': round(s, 3)}\n",
+    "    return table\n",
+    "\n",
+    "\n",
+    "analysis = comparative_analysis(net)\n",
+    "print('Analyse comparative des strategies de dispatch :')\n",
+    "print(f'{\"Strategie\":<25} {\"Cout (EUR)\":>12} {\"CO2 (kg)\":>12} {\"Risque max\":>12} {\"Score\":>8}')\n",
+    "print('-' * 75)\n",
+    "for name, m in analysis.items():\n",
+    "    print(f'{name:<25} {m[\"cout_EUR\"]:>12} {m[\"co2_kg\"]:>12} '\n",
+    "          f'{m[\"risque_max\"]:>12.2e} {m[\"score\"]:>8.3f}')\n",
+    "print()\n",
+    "best = min(analysis.items(), key=lambda kv: kv[1]['score'])\n",
+    "print(f'Strategie optimale (score multi-objectif minimal) : {best[0]}')\n"
    ]
   },
   {
@@ -469,7 +621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.14"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/solution/SmartGrid-Energy.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/solution/SmartGrid-Energy.ipynb
@@ -1,0 +1,477 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c0",
+   "metadata": {},
+   "source": [
+    "# CC3 : SmartGrid - Ordonnancement de la production energetique sous incertitude\n",
+    "\n",
+    "**Etude de cas interdisciplinaire** combinant programmation par contraintes (OR-Tools CP-SAT),\n",
+    "inference probabiliste (modele bayesien), optimisation multi-objectif et un jumeau numerique\n",
+    "de reseau electrique.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1",
+   "metadata": {},
+   "source": [
+    "## Contexte metier\n",
+    "\n",
+    "Un operateur de reseau electrique doit, pour chaque heure, decider quelles centrales activer\n",
+    "et a quel niveau de production (le *unit commitment* / dispatch) afin de satisfaire la demande\n",
+    "tout en minimisant le cout economique et les emissions de CO2. Ce probleme est rendu difficile\n",
+    "par :\n",
+    "\n",
+    "- **l'incertitude** sur la production renouvelable (eolien, solaire) et sur la demande ;\n",
+    "- **les contraintes dures** : capacites min/max des centrales, temps de montee/descente,\n",
+    "  reserve tournante (securite n-1) ;\n",
+    "- **les objectifs multiples conflictuels** : cout, emissions, fiabilite.\n",
+    "\n",
+    "Une seule technique ne suffit pas : un solveur deterministe ignore l'incertitude, un modele\n",
+    "probabiliste seul ne respecte pas les contraintes physiques. Cette etude de cas materialise\n",
+    "leur **composition ordonnee** : filtrer les dispatches impossibles (contraintes), modeliser\n",
+    "l'aleatoire (incertitude), puis optimiser (multi-objectif).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2",
+   "metadata": {},
+   "source": [
+    "## Architecture en 4 couches\n",
+    "\n",
+    "| Couche | Role | Technique | Partie |\n",
+    "|--------|------|-----------|--------|\n",
+    "| **Contraintes dures** | Filtrer les dispatches impossibles | OR-Tools CP-SAT | Partie 1 |\n",
+    "| **Incertitude** | Modeliser l'aleatoire renouvelable | Modele bayesien | Partie 2 |\n",
+    "| **Optimisation** | Choisir le meilleur compromis | Multi-objectif pondere | Partie 3 |\n",
+    "| **Decision** | Synthese + comparaison | Workflow + scoring | Partie 4 |\n",
+    "\n",
+    "Ce notebook est une **fondation** : le jumeau numerique (couche 0) est operationnel ; les\n",
+    "implementations des 4 couches seront completees et executees dans les cycles suivants.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3",
+   "metadata": {},
+   "source": [
+    "## 0. Installation et jumeau numerique\n",
+    "\n",
+    "Le jumeau numerique represente un reseau electrique : un ensemble de centrales (avec cout,\n",
+    "capacites, facteur d'emission) et une demande horaire a satisfaire, avec une production\n",
+    "renouvelable stochastique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:55:03.484579Z",
+     "iopub.status.busy": "2026-07-01T08:55:03.484328Z",
+     "iopub.status.idle": "2026-07-01T08:55:03.599467Z",
+     "shell.execute_reply": "2026-07-01T08:55:03.597999Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reseau : 3 centrales, capacite totale 800 MW\n",
+      "  H0: demande 500 MW, renouvelable 80 +/- 15, demande nette 420.0 MW\n",
+      "  H1: demande 520 MW, renouvelable 60 +/- 12, demande nette 460.0 MW\n",
+      "  H2: demande 480 MW, renouvelable 40 +/- 10, demande nette 440.0 MW\n",
+      "  H3: demande 540 MW, renouvelable 50 +/- 12, demande nette 490.0 MW\n",
+      "  H4: demande 600 MW, renouvelable 120 +/- 25, demande nette 480.0 MW\n",
+      "  H5: demande 580 MW, renouvelable 150 +/- 30, demande nette 430.0 MW\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Installation des dependances (executees dans les cycles suivants avec les solveurs)\n",
+    "# %pip install ortools numpy scipy  # decommenter pour execution complete\n",
+    "\n",
+    "from dataclasses import dataclass, field\n",
+    "from typing import List, Dict\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class PowerPlant:\n",
+    "    \"\"\"Centrale de production electrique.\"\"\"\n",
+    "    name: str\n",
+    "    pmin: float          # puissance minimale stable (MW)\n",
+    "    pmax: float          # puissance maximale (MW)\n",
+    "    cost_per_mw: float   # cout variable (EUR/MWh)\n",
+    "    co2_per_mw: float    # emission (kg/MWh)\n",
+    "    is_renewable: bool = False\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class PowerNetwork:\n",
+    "    \"\"\"Jumeau numerique d'un reseau electrique horaire.\"\"\"\n",
+    "    plants: List[PowerPlant]\n",
+    "    demand_mw: List[float]               # demande par heure (MW)\n",
+    "    renewable_forecast_mean: List[float]  # production renouvelable moyenne attendue (MW)\n",
+    "    renewable_forecast_std: List[float]   # incertitude (ecart-type, MW)\n",
+    "\n",
+    "    def total_capacity(self) -> float:\n",
+    "        return sum(p.pmax for p in self.plants)\n",
+    "\n",
+    "    def net_demand(self, hour: int) -> float:\n",
+    "        \"\"\"Demande a couvrir par les centrales pilotables apres renouvelable.\"\"\"\n",
+    "        return max(0.0, self.demand_mw[hour] - self.renewable_forecast_mean[hour])\n",
+    "\n",
+    "\n",
+    "def demo_network() -> PowerNetwork:\n",
+    "    \"\"\"Reseau de demonstration : 3 centrales pilotables + renouvelable sur 6 heures.\"\"\"\n",
+    "    plants = [\n",
+    "        PowerPlant('Charbon', 50, 400, cost_per_mw=30, co2_per_mw=900),\n",
+    "        PowerPlant('Gaz',    20, 250, cost_per_mw=60, co2_per_mw=400),\n",
+    "        PowerPlant('Hydro',   0, 150, cost_per_mw=10, co2_per_mw=0,  is_renewable=False),\n",
+    "    ]\n",
+    "    return PowerNetwork(\n",
+    "        plants=plants,\n",
+    "        demand_mw=[500, 520, 480, 540, 600, 580],\n",
+    "        renewable_forecast_mean=[80, 60, 40, 50, 120, 150],\n",
+    "        renewable_forecast_std=[15, 12, 10, 12, 25, 30],\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "net = demo_network()\n",
+    "print(f'Reseau : {len(net.plants)} centrales, capacite totale {net.total_capacity()} MW')\n",
+    "for h in range(len(net.demand_mw)):\n",
+    "    print(f'  H{h}: demande {net.demand_mw[h]} MW, renouvelable {net.renewable_forecast_mean[h]} '\n",
+    "          f'+/- {net.renewable_forecast_std[h]}, demande nette {net.net_demand(h):.1f} MW')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5",
+   "metadata": {},
+   "source": [
+    "## Partie 1 : Le Dispatcher sous Contraintes (OR-Tools CP-SAT)\n",
+    "\n",
+    "**Theorie** : le *unit commitment* est un probleme NP-difficile. On modelise, pour chaque\n",
+    "heure et chaque centrale pilotable, une variable binaire (activee) et une variable continue\n",
+    "(niveau de production), soumises aux contraintes :\n",
+    "\n",
+    "- somme des productions = demande nette (equilibre offre/demande) ;\n",
+    "- `pmin <= production <= pmax` quand la centrale est activee ;\n",
+    "- reserve tournante : capacite excédentaire disponible >= marge de securite.\n",
+    "\n",
+    "L'objectif primaire : minimiser le cout total.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:55:03.603391Z",
+     "iopub.status.busy": "2026-07-01T08:55:03.602746Z",
+     "iopub.status.idle": "2026-07-01T08:55:03.610763Z",
+     "shell.execute_reply": "2026-07-01T08:55:03.609400Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dispatch CP-SAT : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Partie 1 : modele CP-SAT du dispatch (implementation cycle suivant)\n",
+    "def solve_dispatch_cp(network: PowerNetwork):\n",
+    "    \"\"\"Resout le unit commitment par programmation par contraintes.\n",
+    "\n",
+    "    Renvoie un dict {hour: {plant_name: production_mw}} minimisant le cout total\n",
+    "    sous contraintes de capacite et d'equilibre offre/demande.\n",
+    "    \"\"\"\n",
+    "    result = None  # TODO etudiant : implementer avec ortools.sat.python.cp_model\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "dispatch = solve_dispatch_cp(net)\n",
+    "print('Dispatch CP-SAT :', dispatch)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Reserve tournante (securite n-1)\n",
+    "\n",
+    "Ajoutez au modele CP-SAT une contrainte de **reserve tournante** : a chaque heure, la somme\n",
+    "des capacites disponibles (non utilisees) des centrales activees doit couvrir la perte de la\n",
+    "plus grande centrale en service (critere n-1).\n",
+    "\n",
+    "**Indice** : pour chaque heure, la reserve = `sum(pmax_i - prod_i pour i active)` doit etre\n",
+    "`>= max(pmax_i pour i active)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:55:03.614348Z",
+     "iopub.status.busy": "2026-07-01T08:55:03.613886Z",
+     "iopub.status.idle": "2026-07-01T08:55:03.620773Z",
+     "shell.execute_reply": "2026-07-01T08:55:03.619146Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 : contrainte de reserve tournante n-1\n",
+    "def solve_dispatch_with_spinning_reserve(network: PowerNetwork):\n",
+    "    \"\"\"Dispatch CP-SAT avec reserve tournante n-1.\"\"\"\n",
+    "    result = None  # TODO etudiant : etendre solve_dispatch_cp avec la reserve n-1\n",
+    "    return result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9",
+   "metadata": {},
+   "source": [
+    "## Partie 2 : Le Previsionniste Probabiliste (modele bayesien)\n",
+    "\n",
+    "**Theorie** : la production renouvelable est aleatoire. On modelise l'ecart\n",
+    "`demande - renouvelable` comme une variable aleatoire et on infere sa distribution, pour\n",
+    "quantifier le **risque de defaillance** (probabilite que la demande nette depasse la capacite\n",
+    "pilotable disponible).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:55:03.624599Z",
+     "iopub.status.busy": "2026-07-01T08:55:03.624112Z",
+     "iopub.status.idle": "2026-07-01T08:55:03.631314Z",
+     "shell.execute_reply": "2026-07-01T08:55:03.629969Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "H0: risque de defaillance estime a None\n",
+      "H1: risque de defaillance estime a None\n",
+      "H2: risque de defaillance estime a None\n",
+      "H3: risque de defaillance estime a None\n",
+      "H4: risque de defaillance estime a None\n",
+      "H5: risque de defaillance estime a None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Partie 2 : modele bayesien de l'incertitude (implementation cycle suivant)\n",
+    "def failure_risk(network: PowerNetwork, hour: int) -> float:\n",
+    "    \"\"\"Probabilite que la demande nette (aleatoire) depasse la capacite pilotable.\n",
+    "\n",
+    "    Modele l'ecart offre/demande comme une gaussienne (demande - renouvelable)\n",
+    "    et calcule P(ecart > capacite pilotable disponible).\n",
+    "    \"\"\"\n",
+    "    risk = None  # TODO etudiant : implementer (gaussienne, scipy.stats.norm.sf)\n",
+    "    return risk\n",
+    "\n",
+    "\n",
+    "for h in range(len(net.demand_mw)):\n",
+    "    print(f'H{h}: risque de defaillance estime a {failure_risk(net, h)}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c11",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Sensibilite au prior sur la variabilite eolienne\n",
+    "\n",
+    "Analysez comment le risque de defaillance (Partie 2) evolue quand on modifie l'incertitude\n",
+    "du renouvelable (multipliez `renewable_forecast_std` par 0.5, 1.0, 2.0). Quelle heure\n",
+    "devient la plus risqueuse ? Concluez sur la robustesse du dispatch determine en Partie 1.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:55:03.635116Z",
+     "iopub.status.busy": "2026-07-01T08:55:03.634580Z",
+     "iopub.status.idle": "2026-07-01T08:55:03.641483Z",
+     "shell.execute_reply": "2026-07-01T08:55:03.640054Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 : analyse de sensibilite au prior d'incertitude\n",
+    "def sensitivity_to_renewable_std(network: PowerNetwork, factors=(0.5, 1.0, 2.0)):\n",
+    "    \"\"\"Retourne le risque max par heure pour chaque facteur d'incertitude.\"\"\"\n",
+    "    result = None  # TODO etudiant : boucler sur les facteurs, retourner {factor: max_risk}\n",
+    "    return result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c13",
+   "metadata": {},
+   "source": [
+    "## Partie 3 : L'Optimiseur Multi-Objectif\n",
+    "\n",
+    "**Theorie** : on veut minimiser simultanement le **cout** economique, les **emissions** CO2\n",
+    "et le **risque** de defaillance. Ces objectifs sont conflictuels (le charbon est bon marche\n",
+    "mais tres emissif). On construit un score pondere `S = a*cout + b*co2 + c*risque` et on\n",
+    "cherche le dispatch minimisant S, en explorant le front de Pareto.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:55:03.644566Z",
+     "iopub.status.busy": "2026-07-01T08:55:03.644136Z",
+     "iopub.status.idle": "2026-07-01T08:55:03.651372Z",
+     "shell.execute_reply": "2026-07-01T08:55:03.649619Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Partie 3 : optimisation multi-objectif (implementation cycle suivant)\n",
+    "def multi_objective_score(dispatch, network: PowerNetwork, weights=(1.0, 1.0, 1.0)):\n",
+    "    \"\"\"Score = a*cout_normalise + b*co2_normalise + c*risque_normalise.\"\"\"\n",
+    "    score = None  # TODO etudiant : normaliser chaque objectif puis combiner\n",
+    "    return score\n",
+    "\n",
+    "\n",
+    "def pareto_front(network: PowerNetwork, weights_grid=None):\n",
+    "    \"\"\"Explore le front de Pareto en variant les poids (a, b, c).\"\"\"\n",
+    "    front = None  # TODO etudiant : boucler sur weights_grid, collecter les dispatches optimaux\n",
+    "    return front\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c15",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Ajouter un troisieme objectif (equite territoriale)\n",
+    "\n",
+    "Ajoutez un troisieme objectif : **equite territoriale** (eviter qu'une meme region subisse\n",
+    "toutes les centrales les plus polluantes). Supposons que chaque centrale a un attribut\n",
+    "`region`. Mesurez la concentration regionale de la pollution et ajoutez-la au score.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:55:03.654731Z",
+     "iopub.status.busy": "2026-07-01T08:55:03.654156Z",
+     "iopub.status.idle": "2026-07-01T08:55:03.659915Z",
+     "shell.execute_reply": "2026-07-01T08:55:03.658674Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3 : objectif d'equite territoriale\n",
+    "def territorial_equity_score(dispatch, network: PowerNetwork) -> float:\n",
+    "    \"\"\"Mesure de concentration de la pollution par region (0 = equitable).\"\"\"\n",
+    "    score = None  # TODO etudiant : mesurer la concentration (ex: variance/entropy regionale des co2)\n",
+    "    return score\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17",
+   "metadata": {},
+   "source": [
+    "## Partie 4 : Decision finale et analyse comparative\n",
+    "\n",
+    "**Synthese** : on compare les strategies (CP-SAT pur, multi-objectif weighted-sum, front de\n",
+    "Pareto) sur les 3 axes cout/CO2/fiabilite + l'equite territoriale. Le tableau comparatif et\n",
+    "le graphique radar seront produits une fois les Parties 1-3 executees.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T08:55:03.663166Z",
+     "iopub.status.busy": "2026-07-01T08:55:03.662672Z",
+     "iopub.status.idle": "2026-07-01T08:55:03.667882Z",
+     "shell.execute_reply": "2026-07-01T08:55:03.666747Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Partie 4 : analyse comparative (implementation cycle suivant)\n",
+    "def comparative_analysis(network: PowerNetwork):\n",
+    "    \"\"\"Compare CP-SAT pur vs multi-objectif vs Pareto sur cout/CO2/fiabilite/equite.\"\"\"\n",
+    "    analysis = None  # TODO etudiant : produire le tableau + graphique radar\n",
+    "    return analysis\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c19",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Cette etude de cas illustre la **composition ordonnee** des paradigmes IA sur un probleme\n",
+    "metier reel (transition energetique) : on filtre les dispatches impossibles (CP-SAT) avant\n",
+    "de modeliser l'incertitude (bayesien) avant d'optimiser (multi-objectif). Inverser l'ordre\n",
+    "produit un systeme soit trop rigide (contraintes ignorent l'aleatoire), soit trop flou\n",
+    "(decision sans contraintes physiques).\n",
+    "\n",
+    "**Etat de la fondation** : jumeau numerique operationnel (couche 0), 4 couches de solveurs\n",
+    "modelisees en stub. Implementations + execution + analyse comparative : cycles suivants.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

**Complete CC3 SmartGrid-Energy CaseStudy** (foundation + solver + student template + subject + README), following the Diagnostic-Medical / Oncology-Planning convention: `student/` + `solution/` + `subject.md` + series README entry. One coherent mergeable checkpoint (one domain, one subject — not a composite).

| Commit | Deliverable |
|--------|-------------|
| `0676fd58e` | Foundation: digital twin (`PowerNetwork`/`PowerPlant`) + 4-layer architecture headers + 3 exercise stubs |
| `4b04af3b6` | Solver layers: 4 BASE solvers implemented (cells 6/10/14/18), exercise stubs 8/12/16 kept |
| `73fcf7f69` | Student template (stubs reverted) + subject.md + CaseStudies README entry |

| Partie | Cell | Layer | Technique | Status |
|--------|------|-------|-----------|--------|
| 1 | 6 | **Contraintes dures** | OR-Tools CP-SAT unit commitment | implemented (solution) / stub (student) |
| 2 | 10 | **Incertitude** | Bayesian survivor function | implemented (solution) / stub (student) |
| 3 | 14 | **Optimisation** | Multi-objectif (cost+CO2+risk) | implemented (solution) / stub (student) |
| 4 | 18 | **Decision** | Comparative analysis | implemented (solution) / stub (student) |
| — | 8/12/16 | exercises | spinning reserve / sensitivity / equity | **stubs kept** |

## Implementation detail (solution)

- **Cell 6 — `solve_dispatch_cp(network, cost_weights)`**: bool `on[(h,i)]` + intvar `p[(h,i)]`, balance constraint + pmin/pmax bounds, weighted cost+CO2 objective. Weights folded *per-term* into `cp_model.LinearExpr.Sum([...])` — robust vs the `0 * IntVar` → `IntConstant` `__radd__` pitfall (when a weight==0).
- **Cell 10 — `failure_risk`**: `0.5 * erfc(z/sqrt(2))` survivor function.
- **Cell 14 — `dispatch_metrics` + `multi_objective_score`**: per-objective normalization + weighted sum.
- **Cell 18 — `comparative_analysis`**: re-solves CP-SAT 3× (eco/green/compromise), normalizes, scores.

## Execution proof (regle C.2 / H.1)

Both notebooks executed via `jupyter nbconvert --to notebook --execute --inplace` with `miniconda3-base` kernel (has ortools 9.x + numpy + pandas; default `python3` Store kernel has ortools but no pandas → ortools imports pandas unconditionally → `ModuleNotFoundError`):

**Solution** (real solvers):
```
8/8 code cells: execution_count = 1..8, 0 errors
Cell 6: Dispatch CP-SAT (min cout) - statut: OPTIMAL (Charbon+Hydro, 63600 EUR)
Cell 14: Score multi-objectif = 1.137
Cell 18: Eco €63600/1638t vs Green €106800/918t → green cuts CO2 44% at +68% cost
C.1 violations (source): 0 | machine-path/secret hits: 0 | kernel: python3 (portable)
```

**Student** (stubs):
```
8/8 code cells: execution_count = 1..8, 0 errors (stubs print None, students fill in)
C.1 violations (source): 0 | machine-path/secret hits: 0
```

## Files (3 commits, 4 files)

- `solution/SmartGrid-Energy.ipynb` — foundation + 4 solver layers (real outputs)
- `student/SmartGrid-Energy.ipynb` — template, 4 solver cells stubbed (C.1-safe)
- `subject.md` — full assignment spec (objectives, 4-layer arch, 3 exercises, grading grid 20pts)
- `CaseStudies/README.md` — +13 prose (structure tree + Projets entry). CATALOG-STATUS block byte-identical (generated).

No dependency added (ortools already in `CaseStudies/requirements.txt` line 13). No submodule drift staged. No catalog regeneration.

Part of #3801 (axe-2 SOTA + problem-richness — real CP-SAT solver on a genuine NP-hard unit-commitment problem).
See #2137, #3801.

Co-Authored-By: Claude <noreply@anthropic.com>