### PR TITLE
feat(casestudies): CC3 SmartGrid student template + subject + CaseStudies README entry

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -70,6 +70,10 @@ CaseStudies/
 │   ├── student/           # Template étudiant
 │   ├── solution/          # Solution de référence
 │   └── data/              # Données patients
+├── SmartGrid-Energy/      # Dispatch énergétique sous incertitude (CP-SAT, bayésien, multi-objectif)
+│   ├── student/           # Template étudiant
+│   ├── solution/          # Solution de référence
+│   └── subject.md         # Sujet du devoir
 └── requirements.txt       # Dépendances communes
 ```
 
@@ -92,6 +96,15 @@ Protocole oncologique adaptatif combinant IA symbolique (ontologie, CSP/OR-Tools
 - **Concepts** : Ontologies, planification CSP, inférence bayésienne, programmation probabiliste
 
 [README complet](Oncology-Planning/README.md) | 2 notebooks (student + solution) | ~3-4h
+
+### SmartGrid Energy
+
+Ordonnancement de la production électrique (unit commitment) sous incertitude renouvelable, combinant programmation par contraintes (OR-Tools CP-SAT), inférence bayésienne du risque de défaillance et optimisation multi-objectif (coût + CO2 + risque). Jumeau numérique d'un réseau à 3 centrales sur 6 heures.
+
+- **Technologies** : Python, ortools (CP-SAT), numpy
+- **Concepts** : Unit commitment NP-difficile, modèle bayésien de l'incertitude, optimisation multi-objectif, architecture en couches (filtrer > modéliser > optimiser)
+
+[Sujet](SmartGrid-Energy/subject.md) | 2 notebooks (student + solution) | ~3-4h
 
 ## Acquis d'apprentissage
 

--- a/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/student/SmartGrid-Energy.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/student/SmartGrid-Energy.ipynb
@@ -1,0 +1,506 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c0",
+   "metadata": {},
+   "source": [
+    "# CC3 : SmartGrid - Ordonnancement de la production energetique sous incertitude\n",
+    "\n",
+    "**Etude de cas interdisciplinaire** combinant programmation par contraintes (OR-Tools CP-SAT),\n",
+    "inference probabiliste (modele bayesien), optimisation multi-objectif et un jumeau numerique\n",
+    "de reseau electrique.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1",
+   "metadata": {},
+   "source": [
+    "## Contexte metier\n",
+    "\n",
+    "Un operateur de reseau electrique doit, pour chaque heure, decider quelles centrales activer\n",
+    "et a quel niveau de production (le *unit commitment* / dispatch) afin de satisfaire la demande\n",
+    "tout en minimisant le cout economique et les emissions de CO2. Ce probleme est rendu difficile\n",
+    "par :\n",
+    "\n",
+    "- **l'incertitude** sur la production renouvelable (eolien, solaire) et sur la demande ;\n",
+    "- **les contraintes dures** : capacites min/max des centrales, temps de montee/descente,\n",
+    "  reserve tournante (securite n-1) ;\n",
+    "- **les objectifs multiples conflictuels** : cout, emissions, fiabilite.\n",
+    "\n",
+    "Une seule technique ne suffit pas : un solveur deterministe ignore l'incertitude, un modele\n",
+    "probabiliste seul ne respecte pas les contraintes physiques. Cette etude de cas materialise\n",
+    "leur **composition ordonnee** : filtrer les dispatches impossibles (contraintes), modeliser\n",
+    "l'aleatoire (incertitude), puis optimiser (multi-objectif).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2",
+   "metadata": {},
+   "source": [
+    "## Architecture en 4 couches\n",
+    "\n",
+    "| Couche | Role | Technique | Partie |\n",
+    "|--------|------|-----------|--------|\n",
+    "| **Contraintes dures** | Filtrer les dispatches impossibles | OR-Tools CP-SAT | Partie 1 |\n",
+    "| **Incertitude** | Modeliser l'aleatoire renouvelable | Modele bayesien | Partie 2 |\n",
+    "| **Optimisation** | Choisir le meilleur compromis | Multi-objectif pondere | Partie 3 |\n",
+    "| **Decision** | Synthese + comparaison | Workflow + scoring | Partie 4 |\n",
+    "\n",
+    "Ce notebook est une **fondation** : le jumeau numerique (couche 0) est operationnel ; les\n",
+    "implementations des 4 couches seront completees et executees dans les cycles suivants.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3",
+   "metadata": {},
+   "source": [
+    "## 0. Installation et jumeau numerique\n",
+    "\n",
+    "Le jumeau numerique represente un reseau electrique : un ensemble de centrales (avec cout,\n",
+    "capacites, facteur d'emission) et une demande horaire a satisfaire, avec une production\n",
+    "renouvelable stochastique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T10:49:45.527304Z",
+     "iopub.status.busy": "2026-07-01T10:49:45.525861Z",
+     "iopub.status.idle": "2026-07-01T10:49:45.710948Z",
+     "shell.execute_reply": "2026-07-01T10:49:45.709976Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reseau : 3 centrales, capacite totale 800 MW\n",
+      "  H0: demande 500 MW, renouvelable 80 +/- 15, demande nette 420.0 MW\n",
+      "  H1: demande 520 MW, renouvelable 60 +/- 12, demande nette 460.0 MW\n",
+      "  H2: demande 480 MW, renouvelable 40 +/- 10, demande nette 440.0 MW\n",
+      "  H3: demande 540 MW, renouvelable 50 +/- 12, demande nette 490.0 MW\n",
+      "  H4: demande 600 MW, renouvelable 120 +/- 25, demande nette 480.0 MW\n",
+      "  H5: demande 580 MW, renouvelable 150 +/- 30, demande nette 430.0 MW\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Installation des dependances (executees dans les cycles suivants avec les solveurs)\n",
+    "# %pip install ortools numpy scipy  # decommenter pour execution complete\n",
+    "\n",
+    "from dataclasses import dataclass, field\n",
+    "from typing import List, Dict\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class PowerPlant:\n",
+    "    \"\"\"Centrale de production electrique.\"\"\"\n",
+    "    name: str\n",
+    "    pmin: float          # puissance minimale stable (MW)\n",
+    "    pmax: float          # puissance maximale (MW)\n",
+    "    cost_per_mw: float   # cout variable (EUR/MWh)\n",
+    "    co2_per_mw: float    # emission (kg/MWh)\n",
+    "    is_renewable: bool = False\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class PowerNetwork:\n",
+    "    \"\"\"Jumeau numerique d'un reseau electrique horaire.\"\"\"\n",
+    "    plants: List[PowerPlant]\n",
+    "    demand_mw: List[float]               # demande par heure (MW)\n",
+    "    renewable_forecast_mean: List[float]  # production renouvelable moyenne attendue (MW)\n",
+    "    renewable_forecast_std: List[float]   # incertitude (ecart-type, MW)\n",
+    "\n",
+    "    def total_capacity(self) -> float:\n",
+    "        return sum(p.pmax for p in self.plants)\n",
+    "\n",
+    "    def net_demand(self, hour: int) -> float:\n",
+    "        \"\"\"Demande a couvrir par les centrales pilotables apres renouvelable.\"\"\"\n",
+    "        return max(0.0, self.demand_mw[hour] - self.renewable_forecast_mean[hour])\n",
+    "\n",
+    "\n",
+    "def demo_network() -> PowerNetwork:\n",
+    "    \"\"\"Reseau de demonstration : 3 centrales pilotables + renouvelable sur 6 heures.\"\"\"\n",
+    "    plants = [\n",
+    "        PowerPlant('Charbon', 50, 400, cost_per_mw=30, co2_per_mw=900),\n",
+    "        PowerPlant('Gaz',    20, 250, cost_per_mw=60, co2_per_mw=400),\n",
+    "        PowerPlant('Hydro',   0, 150, cost_per_mw=10, co2_per_mw=0,  is_renewable=False),\n",
+    "    ]\n",
+    "    return PowerNetwork(\n",
+    "        plants=plants,\n",
+    "        demand_mw=[500, 520, 480, 540, 600, 580],\n",
+    "        renewable_forecast_mean=[80, 60, 40, 50, 120, 150],\n",
+    "        renewable_forecast_std=[15, 12, 10, 12, 25, 30],\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "net = demo_network()\n",
+    "print(f'Reseau : {len(net.plants)} centrales, capacite totale {net.total_capacity()} MW')\n",
+    "for h in range(len(net.demand_mw)):\n",
+    "    print(f'  H{h}: demande {net.demand_mw[h]} MW, renouvelable {net.renewable_forecast_mean[h]} '\n",
+    "          f'+/- {net.renewable_forecast_std[h]}, demande nette {net.net_demand(h):.1f} MW')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5",
+   "metadata": {},
+   "source": [
+    "## Partie 1 : Le Dispatcher sous Contraintes (OR-Tools CP-SAT)\n",
+    "\n",
+    "**Theorie** : le *unit commitment* est un probleme NP-difficile. On modelise, pour chaque\n",
+    "heure et chaque centrale pilotable, une variable binaire (activee) et une variable continue\n",
+    "(niveau de production), soumises aux contraintes :\n",
+    "\n",
+    "- somme des productions = demande nette (equilibre offre/demande) ;\n",
+    "- `pmin <= production <= pmax` quand la centrale est activee ;\n",
+    "- reserve tournante : capacite excédentaire disponible >= marge de securite.\n",
+    "\n",
+    "L'objectif primaire : minimiser le cout total.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T10:49:45.717749Z",
+     "iopub.status.busy": "2026-07-01T10:49:45.717372Z",
+     "iopub.status.idle": "2026-07-01T10:49:45.722526Z",
+     "shell.execute_reply": "2026-07-01T10:49:45.721583Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dispatch CP-SAT : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Partie 1 : modele CP-SAT du dispatch (unit commitment)\n",
+    "# TODO etudiant : implementer solve_dispatch_cp avec ortools.sat.python.cp_model.\n",
+    "# Pour chaque heure et centrale pilotable : binaire `on` + entier `p`.\n",
+    "# Contraintes : equilibre offre/demande nette + bornes pmin <= p <= pmax.\n",
+    "# Objectif : minimiser le cout total.\n",
+    "def solve_dispatch_cp(network, cost_weights=None):\n",
+    "    \"\"\"Resout le unit commitment par programmation par contraintes (CP-SAT).\"\"\"\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "dispatch = solve_dispatch_cp(net)\n",
+    "print('Dispatch CP-SAT :', dispatch)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Reserve tournante (securite n-1)\n",
+    "\n",
+    "Ajoutez au modele CP-SAT une contrainte de **reserve tournante** : a chaque heure, la somme\n",
+    "des capacites disponibles (non utilisees) des centrales activees doit couvrir la perte de la\n",
+    "plus grande centrale en service (critere n-1).\n",
+    "\n",
+    "**Indice** : pour chaque heure, la reserve = `sum(pmax_i - prod_i pour i active)` doit etre\n",
+    "`>= max(pmax_i pour i active)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T10:49:45.725997Z",
+     "iopub.status.busy": "2026-07-01T10:49:45.725675Z",
+     "iopub.status.idle": "2026-07-01T10:49:45.729609Z",
+     "shell.execute_reply": "2026-07-01T10:49:45.728756Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 : contrainte de reserve tournante n-1\n",
+    "def solve_dispatch_with_spinning_reserve(network: PowerNetwork):\n",
+    "    \"\"\"Dispatch CP-SAT avec reserve tournante n-1.\"\"\"\n",
+    "    result = None  # TODO etudiant : etendre solve_dispatch_cp avec la reserve n-1\n",
+    "    return result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9",
+   "metadata": {},
+   "source": [
+    "## Partie 2 : Le Previsionniste Probabiliste (modele bayesien)\n",
+    "\n",
+    "**Theorie** : la production renouvelable est aleatoire. On modelise l'ecart\n",
+    "`demande - renouvelable` comme une variable aleatoire et on infere sa distribution, pour\n",
+    "quantifier le **risque de defaillance** (probabilite que la demande nette depasse la capacite\n",
+    "pilotable disponible).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T10:49:45.733928Z",
+     "iopub.status.busy": "2026-07-01T10:49:45.733698Z",
+     "iopub.status.idle": "2026-07-01T10:49:45.738619Z",
+     "shell.execute_reply": "2026-07-01T10:49:45.737843Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Risque de defaillance (a completer par letudiant) :\n",
+      "  H0: risque = None\n",
+      "  H1: risque = None\n",
+      "  H2: risque = None\n",
+      "  H3: risque = None\n",
+      "  H4: risque = None\n",
+      "  H5: risque = None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Partie 2 : modele bayesien de l'incertitude renouvelable\n",
+    "# TODO etudiant : P(demande nette reelle > capacite pilotable).\n",
+    "# Modele l'ecart offre/demande comme une gaussienne et utilise sa survivor function.\n",
+    "from math import erfc, sqrt\n",
+    "\n",
+    "\n",
+    "def failure_risk(network, hour):\n",
+    "    \"\"\"Probabilite que la demande nette (aleatoire) depasse la capacite pilotable.\"\"\"\n",
+    "    risk = None  # TODO etudiant : calculer via la survivor function d'une gaussienne\n",
+    "    return risk\n",
+    "\n",
+    "\n",
+    "print('Risque de defaillance (a completer par l' + 'etudiant) :')\n",
+    "for h in range(len(net.demand_mw)):\n",
+    "    print(f'  H{h}: risque = {failure_risk(net, h)}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c11",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Sensibilite au prior sur la variabilite eolienne\n",
+    "\n",
+    "Analysez comment le risque de defaillance (Partie 2) evolue quand on modifie l'incertitude\n",
+    "du renouvelable (multipliez `renewable_forecast_std` par 0.5, 1.0, 2.0). Quelle heure\n",
+    "devient la plus risqueuse ? Concluez sur la robustesse du dispatch determine en Partie 1.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T10:49:45.743250Z",
+     "iopub.status.busy": "2026-07-01T10:49:45.743036Z",
+     "iopub.status.idle": "2026-07-01T10:49:45.746649Z",
+     "shell.execute_reply": "2026-07-01T10:49:45.745849Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 : analyse de sensibilite au prior d'incertitude\n",
+    "def sensitivity_to_renewable_std(network: PowerNetwork, factors=(0.5, 1.0, 2.0)):\n",
+    "    \"\"\"Retourne le risque max par heure pour chaque facteur d'incertitude.\"\"\"\n",
+    "    result = None  # TODO etudiant : boucler sur les facteurs, retourner {factor: max_risk}\n",
+    "    return result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c13",
+   "metadata": {},
+   "source": [
+    "## Partie 3 : L'Optimiseur Multi-Objectif\n",
+    "\n",
+    "**Theorie** : on veut minimiser simultanement le **cout** economique, les **emissions** CO2\n",
+    "et le **risque** de defaillance. Ces objectifs sont conflictuels (le charbon est bon marche\n",
+    "mais tres emissif). On construit un score pondere `S = a*cout + b*co2 + c*risque` et on\n",
+    "cherche le dispatch minimisant S, en explorant le front de Pareto.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T10:49:45.751579Z",
+     "iopub.status.busy": "2026-07-01T10:49:45.751383Z",
+     "iopub.status.idle": "2026-07-01T10:49:45.756043Z",
+     "shell.execute_reply": "2026-07-01T10:49:45.755230Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Score multi-objectif : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Partie 3 : score multi-objectif (cout + CO2 + risque)\n",
+    "# TODO etudiant : normaliser chaque objectif puis combiner par somme ponderee.\n",
+    "def dispatch_metrics(dispatch, network):\n",
+    "    \"\"\"Calcule cout total, CO2 total et risque max d'un dispatch.\"\"\"\n",
+    "    if dispatch is None:\n",
+    "        return {'cost': float('inf'), 'co2': float('inf'), 'max_risk': 1.0}\n",
+    "    metrics = None  # TODO etudiant : boucler sur heures + plants\n",
+    "    return metrics\n",
+    "\n",
+    "\n",
+    "def multi_objective_score(dispatch, network, weights=(1.0, 1.0, 1.0), norms=None):\n",
+    "    \"\"\"Score = w_c*cout_norm + w_co2*co2_norm + w_r*risque_norm.\"\"\"\n",
+    "    score = None  # TODO etudiant\n",
+    "    return score\n",
+    "\n",
+    "\n",
+    "print('Score multi-objectif :', multi_objective_score(dispatch, net))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c15",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Ajouter un troisieme objectif (equite territoriale)\n",
+    "\n",
+    "Ajoutez un troisieme objectif : **equite territoriale** (eviter qu'une meme region subisse\n",
+    "toutes les centrales les plus polluantes). Supposons que chaque centrale a un attribut\n",
+    "`region`. Mesurez la concentration regionale de la pollution et ajoutez-la au score.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T10:49:45.760550Z",
+     "iopub.status.busy": "2026-07-01T10:49:45.760254Z",
+     "iopub.status.idle": "2026-07-01T10:49:45.764518Z",
+     "shell.execute_reply": "2026-07-01T10:49:45.763674Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3 : objectif d'equite territoriale\n",
+    "def territorial_equity_score(dispatch, network: PowerNetwork) -> float:\n",
+    "    \"\"\"Mesure de concentration de la pollution par region (0 = equitable).\"\"\"\n",
+    "    score = None  # TODO etudiant : mesurer la concentration (ex: variance/entropy regionale des co2)\n",
+    "    return score\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17",
+   "metadata": {},
+   "source": [
+    "## Partie 4 : Decision finale et analyse comparative\n",
+    "\n",
+    "**Synthese** : on compare les strategies (CP-SAT pur, multi-objectif weighted-sum, front de\n",
+    "Pareto) sur les 3 axes cout/CO2/fiabilite + l'equite territoriale. Le tableau comparatif et\n",
+    "le graphique radar seront produits une fois les Parties 1-3 executees.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T10:49:45.767517Z",
+     "iopub.status.busy": "2026-07-01T10:49:45.767319Z",
+     "iopub.status.idle": "2026-07-01T10:49:45.771588Z",
+     "shell.execute_reply": "2026-07-01T10:49:45.770976Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Analyse comparative : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Partie 4 : analyse comparative des strategies de dispatch\n",
+    "# TODO etudiant : comparer 3 strategies (min cout / min CO2 / compromis).\n",
+    "def comparative_analysis(network):\n",
+    "    \"\"\"Compare 3 strategies CP-SAT sur cout / CO2 / risque.\"\"\"\n",
+    "    analysis = None  # TODO etudiant : re-solve 3x, normaliser, scorer\n",
+    "    return analysis\n",
+    "\n",
+    "\n",
+    "print('Analyse comparative :', comparative_analysis(net))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c19",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Cette etude de cas illustre la **composition ordonnee** des paradigmes IA sur un probleme\n",
+    "metier reel (transition energetique) : on filtre les dispatches impossibles (CP-SAT) avant\n",
+    "de modeliser l'incertitude (bayesien) avant d'optimiser (multi-objectif). Inverser l'ordre\n",
+    "produit un systeme soit trop rigide (contraintes ignorent l'aleatoire), soit trop flou\n",
+    "(decision sans contraintes physiques).\n",
+    "\n",
+    "**Etat de la fondation** : jumeau numerique operationnel (couche 0), 4 couches de solveurs\n",
+    "modelisees en stub. Implementations + execution + analyse comparative : cycles suivants.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/subject.md
+++ b/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/subject.md
@@ -1,0 +1,97 @@
+---
+title: "CC3 - Ordonnancement Energetique sous Incertitude"
+description: "Etude de cas - Ordonnancement de la production energetique d'un reseau electrique sous incertitude renouvelable"
+author: "EPF IA / CoursIA"
+date: "2026-07-01"
+version: "1.0.0"
+tags: ["CC3", "SmartGrid", "unit-commitment", "cp-sat", "bayesien", "multi-objectif", "energie", "transition-energetique"]
+duration: "3-4 heures"
+points: "20"
+---
+
+# CC3 - Ordonnancement Energetique sous Incertitude
+## SmartGrid : dispatch de la production electrique sous incertitude renouvelable
+
+### Objectifs pedagogiques
+
+Cette etude de cas evalue votre capacite a **composer plusieurs paradigmes d'IA** pour resoudre un
+probleme metier reel de la transition energetique : decider, heure par heure, quelles centrales activer
+et a quel niveau de production (*unit commitment* / dispatch) pour satisfaire la demande electrique tout
+en minimisant le cout et les emissions de CO2.
+
+**Competences evaluees :**
+- Programmation par contraintes (OR-Tools CP-SAT, unit commitment NP-difficile)
+- Inference probabiliste (modele bayesien de l'incertitude renouvelable)
+- Optimisation multi-objectif (cout + CO2 + risque, front de Pareto)
+- Architecture en couches : filtrer (contraintes) avant de modeliser (incertitude) avant d'optimiser
+- Application sectorielle (reseau electrique, transition energetique)
+
+### Contexte du probleme
+
+Un operateur de reseau electrique doit, pour chaque heure de la journee, decider quelles centrales
+pilotables activer (charbon, gaz, hydro) et a quel niveau de production, afin de satisfaire la demande
+des consommateurs. La difficulte vient de trois facteurs combines :
+
+1. **l'incertitude** : la production renouvelable (eolien, solaire) est stochastique ; la demande varie ;
+2. **les contraintes dures** : chaque centrale a une capacite minimale stable (`pmin`) et maximale
+   (`pmax`), et ne peut pas etre exploitee en dessous de `pmin` ;
+3. **les objectifs multiples conflictuels** : le charbon est bon marche mais tres emissif ; le gaz est
+   intermediaire ; l'hydro est propre mais capacite limitee.
+
+Une seule technique ne suffit pas : un solveur deterministe ignore l'incertitude, un modele probabiliste
+seul ne respecte pas les contraintes physiques. Le systeme doit les **composer dans le bon ordre**.
+
+### Le jumeau numerique
+
+On dispose d'un modele de reseau (`PowerNetwork`) representant :
+- 3 centrales pilotables : Charbon (50-400 MW, 30 EUR/MWh, 900 kg/MWh), Gaz (20-250 MW, 60 EUR/MWh,
+  400 kg/MWh), Hydro (0-150 MW, 10 EUR/MWh, 0 kg/MWh)
+- une demande horaire sur 6 heures : [500, 520, 480, 540, 600, 580] MW
+- une production renouvelable moyenne + incertitude (ecart-type) par heure
+
+### Les 4 couches a implementer
+
+| Partie | Couche | Technique | Livrable attendu |
+|--------|--------|-----------|------------------|
+| **1** | Contraintes dures | OR-Tools CP-SAT | `solve_dispatch_cp` : unit commitment min-cout |
+| **2** | Incertitude | Modele bayesien | `failure_risk` : probabilite de defaillance |
+| **3** | Optimisation | Multi-objectif pondere | `multi_objective_score` : score normalise |
+| **4** | Decision | Analyse comparative | `comparative_analysis` : 3 strategies comparees |
+
+### Exercices d'extension
+
+Apres les 4 couches de base, 3 exercices approfondissent le systeme :
+
+- **Exercice 1 (reserve tournante n-1)** : ajouter une contrainte de securite — la reserve disponible
+  doit couvrir la perte de la plus grosse centrale en service.
+- **Exercice 2 (sensibilite au prior)** : analyser comment le risque de defaillance evolue quand on
+  modifie l'incertitude renouvelable (x0.5, x1, x2). Quelle heure devient la plus risqueuse ?
+- **Exercice 3 (equite territoriale)** : ajouter un troisieme objectif evitant qu'une region subisse
+  toutes les centrales les plus polluantes.
+
+### Donnees et lancement
+
+- **Notebook etudiant** : `student/SmartGrid-Energy.ipynb` (a completer)
+- **Notebook solution** : `solution/SmartGrid-Energy.ipynb` (reference)
+- **Dependances** : `ortools>=9.8`, `numpy` (cf `CaseStudies/requirements.txt`)
+- **Kernel** : Python 3
+
+### Criteres d'evaluation
+
+| Critere | Points | Detail |
+|---------|--------|--------|
+| Partie 1 - CP-SAT dispatch | 5 | Solveur fonctionnel, contraintes correctes, statut OPTIMAL |
+| Partie 2 - Risque bayesien | 4 | Survivor function correcte, interpretation des valeurs |
+| Partie 3 - Multi-objectif | 4 | Normalisation coherente, score calcule |
+| Partie 4 - Analyse comparative | 4 | 3 strategies, table comparatif, conclusion argumentee |
+| Exercices (au choix, 1 minimum) | 3 | Implementation + analyse |
+| **Total** | **20** | |
+
+### Concepts cles transversaux
+
+- **Composition ordonnee** des paradigmes : l'ordre importe (filtrer > modeliser > optimiser)
+- **Jumeau numerique** : modele de reseau reactif aux decisions de dispatch
+- **Incertitude vs contraintes** : un systeme trop rigide ignore l'aleatoire ; trop flou, il ignore la physique
+- **Multi-objectif** : pas de solution unique optimale, mais un compromis (front de Pareto)
+
+Cf [README CaseStudies](../README.md) pour le principe d'integration et les etudes de cas associees.


### PR DESCRIPTION
## Summary

Completes the **SmartGrid-Energy CaseStudy structure** on top of the merged solver (#4728), matching the Diagnostic-Medical / Oncology-Planning convention: `student/` template + `subject.md` + series README entry.

| File | Content |
|------|---------|
| `student/SmartGrid-Energy.ipynb` | Student template: the 4 base solver cells (6/10/14/18) reverted to C.1-safe stubs (`return None` / `TODO etudiant`), digital twin (cell 4) and 3 exercise stubs (8/12/16) unchanged |
| `subject.md` | Full assignment spec: objectives, 4-layer architecture, 3 extension exercises, grading grid (20 pts), concepts transversaux |
| `CaseStudies/README.md` | +13 prose: structure tree + Projets section entry for SmartGrid-Energy |

## Execution proof (regle C.2)

Student template executed via `jupyter nbconvert --to notebook --execute --inplace` (`miniconda3-base` kernel):
```
8/8 code cells: execution_count = 1..8, 0 errors
stubs print None (students fill them in); digital twin (cell 4) prints the network
C.1 violations (source): 0 | machine-path/secret hits: 0 | kernel metadata: python3 (portable)
```

## Context

The solver layers (solution notebook) were merged in #4728 (foundation + CP-SAT dispatch + Bayesian risk + multi-objectif + comparative analysis). This PR adds the **student-facing** deliverables so the CaseStudy is complete and usable as an assignment — the same structure every CaseStudy has.

## Scope

One coherent unit (CaseStudy completion, one domain). CATALOG-STATUS block left byte-identical (generated, updated by cron/CI per catalog-pr-hygiene). No submodule drift. No catalog regeneration. No new dependency.

See #3801 (axe-2 SOTA + problem-richness).

Co-Authored-By: Claude <noreply@anthropic.com>