### PR TITLE
fix(genai-texte): move title H1 + demote 'Rappel' aside, 2_PromptEngineering (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "# 2. Prompt Engineering : Techniques Avancées\n",
     "**Navigation** : [Index](../../README.md) | [<< Precedent](1_OpenAI_Intro.ipynb) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
     "\n",
     "## Prompt Engineering : Advanced Prompting avec OpenAI\n",
@@ -41,7 +42,6 @@
     "tags": []
    },
    "source": [
-    "# 2. Prompt Engineering : Techniques Avancées\n",
     "\n",
     "**Navigation** : [<< Precedent](1_OpenAI_Intro.ipynb) | [Index](../../README.md) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
     "\n",
@@ -539,7 +539,7 @@
     "tags": []
    },
    "source": [
-    "### Rappel des différences entre Zero-shot, Few-shot, Chain-of-thought et Self-refine\n",
+    "**Rappel des différences entre Zero-shot, Few-shot, Chain-of-thought et Self-refine**\n",
     "\n",
     "1. **Zero-shot Prompting**  \n",
     "   - Aucune instruction ou exemple préalable (à part la demande de l'utilisateur).  \n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **Dernier notebook de la famille GenAI/Texte** (3/3 : après #4722 3_Structured_Outputs, #4726 8_Reasoning_Models). 2 flags dans 1 fichier → 1 PR atomique.

## Changements (1 fichier, +3/-3)

### 1. H1-DEEP (cell 1) — déplacement du titre

Même pattern que #4722 : le titre `# 2. Prompt Engineering : Techniques Avancées` était en cell 1 (2e md), alors que cell 0 (1er md) ne portait que nav+intro. Le scanner exige le H1 unique dans le **premier** cell markdown (pattern canonique 1_OpenAI_Intro / 5_RAG).

Fix minimal : **déplacement de la ligne H1 en tête de cell 0**. 1 ligne repositionnée, 0 wording changé.

### 2. HINT-AS-HEADING (cell 12) — démote « Rappel »

`### Rappel des différences entre Zero-shot, Few-shot, Chain-of-thought et Self-refine` → `**Rappel des différences...**` (bold inline).

- Le scanner `HINT_RE` matche `rappel` à **tout niveau** H1-H6 → H4 laisserait le flag, seul un non-heading clear.
- Ce Rappel porte une liste numérotée de 4 techniques + citations arXiv — le bold inline sert d'en-tête de bloc, la liste structurée reste intacte. **Même pattern que #4712** (Note technique portant une table).
- Mots préservés exactement.

## Désordre éditorial préexistant — SIGNALÉ, hors scope

Comme #4722, ce notebook a une « cell intro » redondante (cell 0 = nav + H2 thématique, dupliqués avec cell 1). Restructurer = décision éditoriale hors scope typo-hierarchy §4. **Non nettoyé** ici.

## Conformité

- **Markdown-only** : 3 cellules markdown, 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé)
- **Contenu préservé** : 0 caractère de wording modifié (1 heading déplacé, 1 démote de markup)
- **Rescan post-fix** : `scan_md_hierarchy.py 2_PromptEngineering` → 0/1 flagged ✓

## Scope

\`See #3966\`. **GenAI/Texte = DRAINED** (3/3 notebooks). Au prochain cycle : Image (2) / Video (1) / PostTraining (1) / CaseStudies (3). 1 fichier = atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>