### PR TITLE
feat(ml): ML-8-Clustering — K-Means non-supervisé, segmentation RFM, méthode du coude

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
@@ -1,0 +1,1039 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-1",
+   "metadata": {},
+   "source": [
+    "# ML-8 : Clustering non-supervise avec K-Means\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](ML-7-Recommendation.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "\n",
+    "1. Distinguer le **clustering non-supervise** de la classification supervisée (ML-1, ML-3)\n",
+    "2. Construire un pipeline ML.NET avec le trainer **K-Means** (`ClusteringCatalog`)\n",
+    "3. Evaluer une partition avec l'**inertie intra-cluster** (`AverageDistance`) et l'**indice de Davies-Bouldin**\n",
+    "4. Choisir le nombre de clusters **K** par la **methode du coude** (elbow method)\n",
+    "5. Expliquer **pourquoi normaliser** les features avant un clustering par distance euclidienne\n",
+    "6. Predire le segment (cluster) d'un nouveau client (segmentation RFM)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-2",
+   "metadata": {},
+   "source": [
+    "## Du supervise au non-supervise\n",
+    "\n",
+    "Les notebooks [ML-1](ML-1-Introduction.ipynb) a [ML-4](ML-4-Evaluation.ipynb) traitent l'apprentissage **supervise** : on dispose d'etiquettes (prix d'une maison, transaction suspecte) et l'on apprend a les predire. Le **clustering** est **non-supervise** : aucune etiquette n'est fournie, l'algorithme doit seul decouvrir une structure de groupes dans les donnees.\n",
+    "\n",
+    "Le cas d'usage canonique est la **segmentation client** : etant donne l'historique d'achat de milliers de clients, identifier des groupes naturels (dormants, reguliers, VIP) sans connaitre a l'avance ces categories. ML.NET fournit le trainer [K-Means](https://learn.microsoft.com/dotnet/api/microsoft.ml.trainers.kmeans.kmeansplusplustrainer) via `mlContext.Clustering.Trainers.KMeans`.\n",
+    "\n",
+    "K-Means (MacQueen, 1967 ; Lloyd, 1957) partitionne les points en **K groupes** en minimisant l'inertie intra-cluster (somme des distances carrees au centroide le plus proche). C'est un probleme NP-difficile en general, resolu en pratique par l'heuristique de Lloyd : initialisation **K-Means++** des centroides, puis iteration *assigner* (chaque point au centroide le plus proche) / *mettre a jour* (chaque centroide au barycentre de ses points) jusqu'a convergence.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ml8-code-3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:50.942421Z",
+     "iopub.status.busy": "2026-07-01T11:45:50.933902Z",
+     "iopub.status.idle": "2026-07-01T11:45:53.427298Z",
+     "shell.execute_reply": "2026-07-01T11:45:53.422094Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2048/\",\"http://172.27.64.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:58e6:e4cc:f299:db58:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '235092.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML, 5.0.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Microsoft.ML 5.0.0 charge\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.ML, 5.0.0\"\n",
+    "Console.WriteLine(\"Microsoft.ML 5.0.0 charge\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-4",
+   "metadata": {},
+   "source": [
+    "On reference ensuite les espaces de noms ML.NET et `System.Linq` (pour `Select` sur les tableaux de distances)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ml8-code-5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:53.429681Z",
+     "iopub.status.busy": "2026-07-01T11:45:53.429479Z",
+     "iopub.status.idle": "2026-07-01T11:45:53.501976Z",
+     "shell.execute_reply": "2026-07-01T11:45:53.501477Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Espaces de noms importes (Microsoft.ML + System.Linq)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using Microsoft.ML;\n",
+    "using Microsoft.ML.Data;\n",
+    "Console.WriteLine(\"Espaces de noms importes (Microsoft.ML + System.Linq)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-6",
+   "metadata": {},
+   "source": [
+    "Comme dans [ML-1](ML-1-Introduction.ipynb), on commence par creer le [MLContext](https://learn.microsoft.com/dotnet/api/microsoft.ml.mlcontext) — le point d'entree commun a toutes les operations ML.NET. On fixe la graine (`seed: 42`) pour rendre K-Means deterministe et reproductible (sinon l'initialisation K-Means++ varie d'une execution a l'autre)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ml8-code-7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:53.503707Z",
+     "iopub.status.busy": "2026-07-01T11:45:53.503468Z",
+     "iopub.status.idle": "2026-07-01T11:45:53.626868Z",
+     "shell.execute_reply": "2026-07-01T11:45:53.626645Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MLContext cree (seed fixe a 42 pour reproductibilite)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var mlContext = new MLContext(seed: 42);\n",
+    "Console.WriteLine(\"MLContext cree (seed fixe a 42 pour reproductibilite)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-8",
+   "metadata": {},
+   "source": [
+    "## Jeu de donnees : segmentation RFM\n",
+    "\n",
+    "La segmentation **RFM** (Recency, Frequency, Monetary — Hughes, 1996) classe les clients selon trois dimensions comportementales :\n",
+    "\n",
+    "| Feature | Sens | Valeur haute | Valeur basse |\n",
+    "|---------|------|--------------|--------------|\n",
+    "| **Recency** | jours depuis le dernier achat | client dormant | client actif |\n",
+    "| **Frequency** | achats par mois | client fidele | client occasionnel |\n",
+    "| **Monetary** | depense moyenne par achat (EUR) | gros panier | petit panier |\n",
+    "\n",
+    "Nous generons **90 clients synthetiques** issus de **3 segments caches** (30 chacun) que K-Means devra retrouver sans connaitre les etiquettes. Les segments se chevauchent legerement (bruit gaussien) pour rester non-triviaux.\n",
+    "\n",
+    "Definissons d'abord les classes de donnees ML.NET et un utilitaire gaussien (Box-Muller) pour la generation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ml8-code-9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:53.628392Z",
+     "iopub.status.busy": "2026-07-01T11:45:53.628162Z",
+     "iopub.status.idle": "2026-07-01T11:45:53.948338Z",
+     "shell.execute_reply": "2026-07-01T11:45:53.948047Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classes CustomerData / ClusterPrediction / RandUtil definies\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "public class CustomerData\n",
+    "{\n",
+    "    public float Recency { get; set; }    // jours depuis le dernier achat (haut = dormant)\n",
+    "    public float Frequency { get; set; }  // achats par mois\n",
+    "    public float Monetary { get; set; }   // depense moyenne par achat (EUR)\n",
+    "}\n",
+    "\n",
+    "public class ClusterPrediction\n",
+    "{\n",
+    "    [ColumnName(\"PredictedLabel\")]\n",
+    "    public uint PredictedClusterId { get; set; }\n",
+    "\n",
+    "    [ColumnName(\"Score\")]\n",
+    "    public float[] Distances { get; set; }\n",
+    "}\n",
+    "\n",
+    "public static class RandUtil\n",
+    "{\n",
+    "    static readonly Random _r = new Random(42);\n",
+    "\n",
+    "    // Box-Muller : echantillonne un flottant selon N(mean, std), clame a >= 0\n",
+    "    public static float NextGaussian(float mean, float std)\n",
+    "    {\n",
+    "        double u1 = 1.0 - _r.NextDouble();\n",
+    "        double u2 = 1.0 - _r.NextDouble();\n",
+    "        double z = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);\n",
+    "        return Math.Max(0f, mean + (float)(z * std));\n",
+    "    }\n",
+    "}\n",
+    "Console.WriteLine(\"Classes CustomerData / ClusterPrediction / RandUtil definies\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-10",
+   "metadata": {},
+   "source": [
+    "On genere maintenant les trois segments. Chaque client est tire d'une gaussienne centree sur le profil du segment (ex. le VIP achete recemment, souvent, avec un gros panier). K-Means ne verra **jamais** l'appartenance a un segment — il doit la reconstruire depuis la seule geometrie des points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ml8-code-11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:53.950798Z",
+     "iopub.status.busy": "2026-07-01T11:45:53.950525Z",
+     "iopub.status.idle": "2026-07-01T11:45:54.153812Z",
+     "shell.execute_reply": "2026-07-01T11:45:54.153539Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Genere 90 clients : 3 segments caches x 30\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// 3 segments de clients (segments CACHES, que K-Means doit retrouver)\n",
+    "var customers = new List<CustomerData>();\n",
+    "\n",
+    "// Segment \"Dormants\" : achat ancien, peu frequent, petit panier\n",
+    "for (int i = 0; i < 30; i++)\n",
+    "    customers.Add(new CustomerData {\n",
+    "        Recency   = RandUtil.NextGaussian(85, 15),\n",
+    "        Frequency = RandUtil.NextGaussian(2, 1),\n",
+    "        Monetary  = RandUtil.NextGaussian(50, 20)\n",
+    "    });\n",
+    "\n",
+    "// Segment \"Reguliers\" : achat recent, frequence moyenne, panier moyen\n",
+    "for (int i = 0; i < 30; i++)\n",
+    "    customers.Add(new CustomerData {\n",
+    "        Recency   = RandUtil.NextGaussian(30, 8),\n",
+    "        Frequency = RandUtil.NextGaussian(8, 2),\n",
+    "        Monetary  = RandUtil.NextGaussian(150, 40)\n",
+    "    });\n",
+    "\n",
+    "// Segment \"VIP\" : achat tres recent, tres frequent, gros panier\n",
+    "for (int i = 0; i < 30; i++)\n",
+    "    customers.Add(new CustomerData {\n",
+    "        Recency   = RandUtil.NextGaussian(8, 3),\n",
+    "        Frequency = RandUtil.NextGaussian(20, 4),\n",
+    "        Monetary  = RandUtil.NextGaussian(500, 100)\n",
+    "    });\n",
+    "\n",
+    "Console.WriteLine($\"Genere {customers.Count} clients : 3 segments caches x 30\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-12",
+   "metadata": {},
+   "source": [
+    "On charge la liste dans un [IDataView](https://learn.microsoft.com/dotnet/api/microsoft.ml.idataview) — la structure colonnaire fondamentale de ML.NET, deja utilisee dans [ML-1](ML-1-Introduction.ipynb) et [ML-2](ML-2-Data%26Features.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ml8-code-13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:54.155654Z",
+     "iopub.status.busy": "2026-07-01T11:45:54.155360Z",
+     "iopub.status.idle": "2026-07-01T11:45:54.239055Z",
+     "shell.execute_reply": "2026-07-01T11:45:54.238779Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IDataView charge : 90 lignes, 3 features (Recency, Frequency, Monetary)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "IDataView dataView = mlContext.Data.LoadFromEnumerable(customers);\n",
+    "Console.WriteLine($\"IDataView charge : {customers.Count} lignes, 3 features (Recency, Frequency, Monetary)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-14",
+   "metadata": {},
+   "source": [
+    "## Pipeline : concatenation, normalisation, K-Means\n",
+    "\n",
+    "Le pipeline comporte **trois** etapes. La concatenation regroupe les trois features en un vecteur `\"Features\"`. La **normalisation MinMax** ramene chaque feature dans `[0, 1]`. Le trainer **K-Means** partitionne ensuite l'espace normalise en `numberOfClusters: 3` groupes.\n",
+    "\n",
+    "**Pourquoi normaliser absolument ?** K-Means mesure la proximite par **distance euclidienne**. Sans normalisation, `Monetary` (50 a 500 EUR) ecrase totalement `Frequency` (2 a 20) et `Recency` (8 a 85 jours) : la distance serait dominee par la depense, et le clustering reflete surtout l'argent. Normaliser met les trois dimensions a la meme echelle — c'est l'objet de l'[Exercice 3](#Exercice-3-:-Effet-de-la-normalisation). C'est l'equivalent, en non-supervise, de l'ingenierie de features vue en [ML-2](ML-2-Data%26Features.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ml8-code-15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:54.240842Z",
+     "iopub.status.busy": "2026-07-01T11:45:54.240574Z",
+     "iopub.status.idle": "2026-07-01T11:45:54.379856Z",
+     "shell.execute_reply": "2026-07-01T11:45:54.379628Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pipeline cree : Concatenate -> NormalizeMinMax -> KMeans(K=3)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var pipeline = mlContext.Transforms\n",
+    "    .Concatenate(\"Features\", nameof(CustomerData.Recency), nameof(CustomerData.Frequency), nameof(CustomerData.Monetary))\n",
+    "    .Append(mlContext.Transforms.NormalizeMinMax(\"Features\"))\n",
+    "    .Append(mlContext.Clustering.Trainers.KMeans(\"Features\", numberOfClusters: 3));\n",
+    "\n",
+    "Console.WriteLine(\"Pipeline cree : Concatenate -> NormalizeMinMax -> KMeans(K=3)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-16",
+   "metadata": {},
+   "source": [
+    "On entraine le modele en appelant [Fit](https://learn.microsoft.com/dotnet/api/microsoft.ml.iestimator-1.fit) sur l'`IDataView`, exactement comme en [ML-1](ML-1-Introduction.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ml8-code-17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:54.381539Z",
+     "iopub.status.busy": "2026-07-01T11:45:54.381305Z",
+     "iopub.status.idle": "2026-07-01T11:45:54.598490Z",
+     "shell.execute_reply": "2026-07-01T11:45:54.598049Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele K-Means (K=3) entraine\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var model = pipeline.Fit(dataView);\n",
+    "Console.WriteLine(\"Modele K-Means (K=3) entraine\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-18",
+   "metadata": {},
+   "source": [
+    "## Evaluation : inertie et separation\n",
+    "\n",
+    "L'evaluation d'un clustering est delicate : contrairement a la classification (ML-4), il n'y a **pas d'etiquette de verite** a laquelle comparer. On mesure donc la **qualite intrinseque** de la partition :\n",
+    "\n",
+    "- **`AverageDistance`** (inertie intra-cluster) : distance moyenne de chaque point au centroide de son cluster. Plus bas = groupes compacts. C'est la grandeur que K-Means minimise.\n",
+    "- **`DaviesBouldinIndex`** (Davies & Bouldin, 1979) : rapport moyen entre la dispersion intra-cluster et la separation inter-cluster. Plus bas = clusters a la fois compacts et bien separes.\n",
+    "\n",
+    "On obtient ces metriques via `mlContext.Clustering.Evaluate`, qui calcule les distances a partir de la colonne `\"Features\"` (normalisee)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ml8-code-19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:54.599895Z",
+     "iopub.status.busy": "2026-07-01T11:45:54.599687Z",
+     "iopub.status.idle": "2026-07-01T11:45:54.691955Z",
+     "shell.execute_reply": "2026-07-01T11:45:54.691634Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Metriques de clustering (K=3) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  AverageDistance (inertie intra-cluster) : 0,0209\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  DaviesBouldinIndex (separation)         : 0,394\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var predictions = model.Transform(dataView);\n",
+    "var metrics = mlContext.Clustering.Evaluate(predictions, featureColumnName: \"Features\");\n",
+    "\n",
+    "Console.WriteLine(\"=== Metriques de clustering (K=3) ===\");\n",
+    "Console.WriteLine($\"  AverageDistance (inertie intra-cluster) : {metrics.AverageDistance:F4}\");\n",
+    "Console.WriteLine($\"  DaviesBouldinIndex (separation)         : {metrics.DaviesBouldinIndex:F3}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-20",
+   "metadata": {},
+   "source": [
+    "### Interpretation : qualite de la partition (K=3)\n",
+    "\n",
+    "| Metrique | Valeur | Lecture |\n",
+    "|----------|--------|---------|\n",
+    "| AverageDistance | 0,0209 | compacite elevee (features normalisees dans [0,1]) |\n",
+    "| DaviesBouldinIndex | 0,394 | separation nette (< 0,5 = clusters bien separes) |\n",
+    "\n",
+    "L'indice de Davies-Bouldin de **0,394** est nettement sous le seuil de 0,5 : les trois clusters sont a la fois compacts et bien separes. Au-dela de 1,0 on parlerait de clusters qui se chevauchent. Les trois segments RFM etant volontairement bien distingues (Dormants / Reguliers / VIP), K-Means a effectivement retrouve la structure cachee -- sans jamais avoir vu les etiquettes de segment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-21",
+   "metadata": {},
+   "source": [
+    "## Prediction : segmenter un nouveau client\n",
+    "\n",
+    "On cree un [PredictionEngine](https://learn.microsoft.com/dotnet/api/microsoft.ml.predictionengine-2) (comme en [ML-1](ML-1-Introduction.ipynb)) pour inferer le cluster de nouveaux clients. La prediction renvoie :\n",
+    "\n",
+    "- `PredictedClusterId` : le cluster assigne (1 a K),\n",
+    "- `Distances` : le vecteur des distances (normalisees) aux **K centroides** — utile pour mesurer la certitude (un point a mi-chemin de deux centroides est ambigus)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ml8-code-22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:54.693497Z",
+     "iopub.status.busy": "2026-07-01T11:45:54.693273Z",
+     "iopub.status.idle": "2026-07-01T11:45:54.895905Z",
+     "shell.execute_reply": "2026-07-01T11:45:54.895608Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Prediction du segment de nouveaux clients ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Recency=90 Freq=1 Monetary=40EUR -> Cluster 2  (distances normalisees: [0,45, 0,01, 1,50])\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Recency=25 Freq=9 Monetary=160EUR -> Cluster 1  (distances normalisees: [0,00, 0,43, 0,39])\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Recency=5 Freq=22 Monetary=520EUR -> Cluster 3  (distances normalisees: [0,56, 1,52, 0,01])\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var engine = mlContext.Model.CreatePredictionEngine<CustomerData, ClusterPrediction>(model);\n",
+    "\n",
+    "CustomerData[] testClients = new[] {\n",
+    "    new CustomerData { Recency = 90, Frequency = 1,  Monetary = 40   },  // profil dormant\n",
+    "    new CustomerData { Recency = 25, Frequency = 9,  Monetary = 160  },  // profil regulier\n",
+    "    new CustomerData { Recency = 5,  Frequency = 22, Monetary = 520  },  // profil VIP\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine(\"=== Prediction du segment de nouveaux clients ===\");\n",
+    "foreach (var c in testClients)\n",
+    "{\n",
+    "    var p = engine.Predict(c);\n",
+    "    string distStr = string.Join(\", \", p.Distances.Select(d => d.ToString(\"F2\")));\n",
+    "    Console.WriteLine($\"  Recency={c.Recency} Freq={c.Frequency} Monetary={c.Monetary}EUR -> Cluster {p.PredictedClusterId}  (distances normalisees: [{distStr}])\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-23",
+   "metadata": {},
+   "source": [
+    "### Interpretation : les segments retrouves\n",
+    "\n",
+    "Les trois profils tombent dans trois clusters distincts, et pour chacun la distance a son cluster est **negligeable** devant les deux autres :\n",
+    "\n",
+    "| Profil | Cluster assigne | Distances (normalisees) aux 3 centroides |\n",
+    "|--------|-----------------|-----------------------------------------|\n",
+    "| dormant (R90 F1 M40EUR) | 2 | [0,45 ; **0,01** ; 1,50] |\n",
+    "| regulier (R25 F9 M160EUR) | 1 | [**0,00** ; 0,43 ; 0,39] |\n",
+    "| VIP (R5 F22 M520EUR) | 3 | [0,56 ; 1,52 ; **0,01**] |\n",
+    "\n",
+    "La separation est nette : chaque client est quasi exactement sur un centroide (distance ~0,00-0,01) et loin des deux autres. K-Means a donc reconstruit, sans aucune etiquette, la segmentation Dormants / Reguliers / VIP. Les numeros de cluster (1, 2, 3) sont arbitraires -- ils dependent de l'initialisation K-Means++ -- mais la **partition** est correcte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-24",
+   "metadata": {},
+   "source": [
+    "## Choix de K : la methode du coude\n",
+    "\n",
+    "Mais **comment sait-on que K=3 est le bon nombre de clusters** ? C'est la question centrale du clustering non-supervise. La **methode du coude** (Thorndike, 1953) consiste a entrainer K-Means pour plusieurs valeurs de K et a observer l'evolution de l'inertie (`AverageDistance`) :\n",
+    "\n",
+    "- L'inertie **diminue mecaniquement** quand K augmente (plus de centroides = points plus proches d'un centroide),\n",
+    "- mais au-dela du \\\"vrai\\\" nombre de clusters, le gain devient **marginal** : la courbe forme un \\\"coude\\\".\n",
+    "\n",
+    "On complete avec l'indice de Davies-Bouldin : son **minimum** pointe vers le K optimal. Si les deux criteres convergent vers K=3, c'est un signal fort que les donnees ont structurellement 3 groupes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ml8-code-25",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:54.897663Z",
+     "iopub.status.busy": "2026-07-01T11:45:54.897419Z",
+     "iopub.status.idle": "2026-07-01T11:45:55.074129Z",
+     "shell.execute_reply": "2026-07-01T11:45:55.073854Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Choix de K : methode du coude (K=2..6) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  K | AverageDistance | DaviesBouldin\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  --+-----------------+---------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2 |          0,0961 |         0,513\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3 |          0,0209 |         0,394\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4 |          0,0190 |         0,759\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  5 |          0,0133 |         0,875\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  6 |          0,0115 |         0,901\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "Console.WriteLine(\"=== Choix de K : methode du coude (K=2..6) ===\");\n",
+    "Console.WriteLine(\"  K | AverageDistance | DaviesBouldin\");\n",
+    "Console.WriteLine(\"  --+-----------------+---------------\");\n",
+    "for (int k = 2; k <= 6; k++)\n",
+    "{\n",
+    "    var sweepPipe = mlContext.Transforms\n",
+    "        .Concatenate(\"Features\", nameof(CustomerData.Recency), nameof(CustomerData.Frequency), nameof(CustomerData.Monetary))\n",
+    "        .Append(mlContext.Transforms.NormalizeMinMax(\"Features\"))\n",
+    "        .Append(mlContext.Clustering.Trainers.KMeans(\"Features\", numberOfClusters: k));\n",
+    "    var sweepModel = sweepPipe.Fit(dataView);\n",
+    "    var sweepMetrics = mlContext.Clustering.Evaluate(sweepModel.Transform(dataView), featureColumnName: \"Features\");\n",
+    "    Console.WriteLine($\"  {k} | {sweepMetrics.AverageDistance,15:F4} | {sweepMetrics.DaviesBouldinIndex,13:F3}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-26",
+   "metadata": {},
+   "source": [
+    "### Interpretation : ou est le coude ?\n",
+    "\n",
+    "| K | AverageDistance (inertie) | DaviesBouldin |\n",
+    "|---|---------------------------|---------------|\n",
+    "| 2 | 0,0961 | 0,513 |\n",
+    "| 3 | **0,0209** | **0,394** |\n",
+    "| 4 | 0,0190 | 0,759 |\n",
+    "| 5 | 0,0133 | 0,875 |\n",
+    "| 6 | 0,0115 | 0,901 |\n",
+    "\n",
+    "**Lecture** : l'inertie chute brutalement entre K=2 (0,096) et K=3 (0,021) -- une baisse de 78 % -- puis la pente s'adoucit fortement (K=4 ne gagne plus que 9 %, et la decroissance devient lineaire pour K=5 et K=6). Le **coude est nettement a K=3**. Parallelement, l'indice de Davies-Bouldin atteint son **minimum a K=3** (0,394) puis remonte pour K superieur (les clusters supplementaires fragmentent les vrais groupes, degradant la separation). La convergence des deux criteres -- coude de l'inertie ET minimum du Davies-Bouldin -- confirme que **3 est le nombre structurel de segments** dans ces donnees RFM. C'est precisement le nombre de segments caches que nous avions genere."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-27",
+   "metadata": {},
+   "source": [
+    "## Exercice 1 : Determiner le K optimal sur un dataset a 4 segments\n",
+    "\n",
+    "Reutilisez la generation ci-dessus, mais avec **4 segments caches** distincts (ajoutez par exemple un segment \"Nouveaux\" : Recency tres bas, Frequency tres basse, Monetary moyen). Cherchez ensuite le K optimal.\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Generer un nouveau jeu `customers4` avec 4 segments x 25 points\n",
+    "2. Le charger dans un `IDataView`\n",
+    "3. Boucler K=2..7, entrainer K-Means, evaluer (AverageDistance + DaviesBouldin)\n",
+    "4. Identifier le K avec le DaviesBouldin minimum = votre K optimal\n",
+    "\n",
+    "**Indice** : recopiez la boucle de sweep ci-dessus sur `customers4`. Le coude de l'inertie et le minimum du DaviesBouldin doivent pointer vers K=4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ml8-code-28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:55.075873Z",
+     "iopub.status.busy": "2026-07-01T11:45:55.075649Z",
+     "iopub.status.idle": "2026-07-01T11:45:55.121362Z",
+     "shell.execute_reply": "2026-07-01T11:45:55.120897Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Determiner le K optimal sur un dataset a 4 segments\n",
+    "// TODO etudiant : genere 4 clusters caches (4 x 25 points), puis cherche le K optimal (2..7)\n",
+    "// Indice : recopie la boucle de sweep ci-dessus sur customers4 ; le DaviesBouldin minimum\n",
+    "//          et le coude de AverageDistance doivent pointer vers K=4.\n",
+    "// Etape 1 : genere un nouveau jeu customers4 avec 4 segments distincts\n",
+    "// Etape 2 : charge-le dans un IDataView\n",
+    "// Etape 3 : boucle K=2..7, entraine KMeans, evalue\n",
+    "// Etape 4 : affiche le K avec le DaviesBouldin minimum = ton K optimal\n",
+    "Console.WriteLine(\"Exercice 1 a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-29",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : Implementer la silhouette moyenne (Rousseeuw, 1987)\n",
+    "\n",
+    "La silhouette est une mesure plus fine que le Davies-Bouldin. Pour chaque point *i* :\n",
+    "\n",
+    "$$s(i) = \\frac{b(i) - a(i)}{\\max(a(i), b(i))}$$\n",
+    "\n",
+    "ou `a(i)` est la distance moyenne de *i* aux autres points de **son** cluster, et `b(i)` la distance moyenne de *i* au **cluster voisin le plus proche**. La silhouette globale est la moyenne des `s(i)` ; elle varie dans `[-1, 1]` (proche de 1 = clustering excellent).\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Recuperer les features normalisees et les labels via `model.Transform(dataView).GetColumn<float[]>(\"Features\")` et `GetColumn<uint>(\"PredictedLabel\")`\n",
+    "2. Calculer la matrice des distances euclidiennes (double boucle sur les 90 points)\n",
+    "3. Pour chaque point, calculer `a(i)` puis `b(i)`, puis `s(i)`\n",
+    "4. Moyenner et verifier que K=3 maximise la silhouette (vs K=2, K=4)\n",
+    "\n",
+    "**Indice** : `a(i)` moyenne sur le cluster de *i* (exclure *i* lui-meme) ; `b(i)` = minimum sur les autres clusters de la distance moyenne a ce cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ml8-code-30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:55.122961Z",
+     "iopub.status.busy": "2026-07-01T11:45:55.122718Z",
+     "iopub.status.idle": "2026-07-01T11:45:55.156994Z",
+     "shell.execute_reply": "2026-07-01T11:45:55.156749Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Implementer la silhouette moyenne (Rousseeuw, 1987)\n",
+    "// TODO etudiant : la silhouette s(i) = (b(i) - a(i)) / max(a(i), b(i))\n",
+    "//   a(i) = distance moyenne de i aux autres points de SON cluster\n",
+    "//   b(i) = distance moyenne de i au cluster voisin le plus proche\n",
+    "// Indice : recupere les features normalisees et les labels via\n",
+    "//   var feats = model.Transform(dataView).GetColumn<float[]>(\"Features\").ToArray();\n",
+    "//   var labels = model.Transform(dataView).GetColumn<uint>(\"PredictedLabel\").ToArray();\n",
+    "// Etape 1 : calcule la matrice des distances euclidiennes (double boucle)\n",
+    "// Etape 2 : pour chaque point, calcule a(i) puis b(i)\n",
+    "// Etape 3 : moyenne s(i) sur tous les points = silhouette globale\n",
+    "// Etape 4 : verifie que K=3 maximise la silhouette (vs K=2, K=4)\n",
+    "Console.WriteLine(\"Exercice 2 a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-31",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : Effet de la normalisation sur K-Means\n",
+    "\n",
+    "Le pipeline principal normalise (`NormalizeMinMax`). Que se passe-t-il **sans** normalisation ?\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Construire un pipeline **sans** `NormalizeMinMax` (Concatenate -> KMeans, K=3)\n",
+    "2. L'entrainer, l'evaluer (AverageDistance, DaviesBouldin)\n",
+    "3. Predire les 3 `testClients` et comparer les clusters a la version normalisee\n",
+    "4. Conclure : pourquoi la normalisation est-elle indispensable en clustering ?\n",
+    "\n",
+    "**Indice** : `Monetary` (50 a 500 EUR) domine totalement `Recency` et `Frequency` en echelle brute. Sans normalisation, le clustering reflete surtout la depense — les clusters se forment essentiellement le long de l'axe `Monetary`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ml8-code-32",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T11:45:55.158457Z",
+     "iopub.status.busy": "2026-07-01T11:45:55.158220Z",
+     "iopub.status.idle": "2026-07-01T11:45:55.192055Z",
+     "shell.execute_reply": "2026-07-01T11:45:55.191798Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Effet de la normalisation sur K-Means\n",
+    "// TODO etudiant : entraine KMeans SANS NormalizeMinMax et compare les clusters trouves.\n",
+    "// Indice : Monetary (50..500 EUR) domine totalement Recency et Frequency en echelle brute ;\n",
+    "//          sans normalisation, le clustering reflete surtout la depense.\n",
+    "// Etape 1 : construis un pipeline SANS NormalizeMinMax (Concatenate -> KMeans)\n",
+    "// Etape 2 : entraine, evalue (AverageDistance, DaviesBouldin)\n",
+    "// Etape 3 : predit les 3 testClients et compare les clusters a la version normalisee\n",
+    "// Etape 4 : conclus : pourquoi la normalisation est-elle indispensable en clustering ?\n",
+    "Console.WriteLine(\"Exercice 3 a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-33",
+   "metadata": {},
+   "source": [
+    "## Resume\n",
+    "\n",
+    "Ce notebook a introduit le **clustering non-supervise** avec K-Means :\n",
+    "\n",
+    "| Concept | Description |\n",
+    "|---------|-------------|\n",
+    "| Clustering | Apprentissage **non-supervise** : trouver des groupes sans etiquettes |\n",
+    "| `ClusteringCatalog` | Catalogue ML.NET pour K-Means (`mlContext.Clustering.Trainers.KMeans`) |\n",
+    "| AverageDistance | **Inertie** intra-cluster (plus bas = groupes compacts) |\n",
+    "| DaviesBouldinIndex | Mesure de **separation** (plus bas = clusters mieux separes) |\n",
+    "| NormalizeMinMax | **Indispensable** : met les features a la meme echelle avant la distance euclidienne |\n",
+    "| Methode du coude | Choix de K : la ou l'inertie cesse de baisser fortement |\n",
+    "\n",
+    "**Points cles** :\n",
+    "\n",
+    "- Contrairement a ML-1..ML-4 (supervise), **aucune etiquette** n'est fournie : K-Means decouvre seul la structure.\n",
+    "- **Normaliser avant de clusterer** : des features d'echelles differentes (Recency en jours, Monetary en EUR) deformeraient la distance euclidienne (Exercice 3).\n",
+    "- K-Means minimise l'inertie intra-cluster ; le **choix de K est un compromis** (coude + Davies-Bouldin), pas une verite absolue.\n",
+    "- La prediction renvoie un cluster **et** les distances aux centroides — la certitude se lit dans l'ecart entre la plus petite distance et les suivantes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ml8-md-34",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "**Algorithme (K-Means)**\n",
+    "\n",
+    "- MacQueen, J. (1967). *Some methods for classification and analysis of multivariate observations*. Proceedings of the Fifth Berkeley Symposium on Mathematical Statistics and Probability, 2(1), 281-297. --- formulation originale de K-Means.\n",
+    "- Lloyd, S. P. (1957/1982). *Least squares quantization in PCM*. IEEE Transactions on Information Theory, 28(2), 129-137. --- l'algorithme d'iteration *assigner / mettre-a-jour* utilise en pratique (Lloyd's algorithm).\n",
+    "- Arthur, D., & Vassilvitskii, S. (2007). *K-means++: The advantages of careful seeding*. Proceedings of SODA. --- l'initialisation intelligente des centroides utilisee par ML.NET.\n",
+    "\n",
+    "**Metriques d'evaluation**\n",
+    "\n",
+    "- Davies, D. L., & Bouldin, D. W. (1979). *A cluster separation measure*. IEEE Transactions on Pattern Analysis and Machine Intelligence, 1(2), 224-227. --- l'indice de Davies-Bouldin (rapport dispersion / separation).\n",
+    "- Rousseeuw, P. J. (1987). *Silhouettes: a graphical aid to the interpretation and validation of cluster analysis*. Journal of Computational and Applied Mathematics, 20, 53-65. --- la silhouette (Exercice 2).\n",
+    "- Thorndike, R. L. (1953). *Who belongs in the family?* Psychometrika, 18(4), 267-276. --- la methode du coude (elbow method).\n",
+    "\n",
+    "**Cas d'usage (segmentation RFM)**\n",
+    "\n",
+    "- Hughes, A. M. (1996). *The Complete Database Marketer: Second-Generation Strategies and Techniques for Tapping the Power of Your Customer Database*. McGraw-Hill. --- formalisation de la segmentation RFM (Recency, Frequency, Monetary).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 9.324064,
+   "end_time": "2026-05-02T18:20:38.267750+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "ML-1-Introduction.ipynb",
+   "output_path": "ML-1-Introduction.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-02T18:20:28.943686+00:00",
+   "version": "2.6.0"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "aliases": [],
+      "languageName": "csharp",
+      "name": "csharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -11,7 +11,7 @@ maturity: PRODUCTION=6, ALPHA=1, DRAFT=1
 
 ML.NET — la bibliothèque open-source de Microsoft — apporte le machine learning **nativement dans l'écosystème .NET** : on entraîne et on consomme des modèles directement en C#, sans quitter sa stack applicative ni dépendre d'un runtime Python. C'est un choix pensé pour les développeurs autant que pour les data scientists — l'AutoML abaisse la barrière d'entrée, et les modèles s'exécutent *in-process* dans des applications existantes (API web, services, desktop). L'interopérabilité **ONNX** permet d'importer des modèles entraînés ailleurs (scikit-learn, PyTorch, Hugging Face) et de les servir côté .NET : ML.NET devient ainsi un pont concret entre la recherche en Python et la production en entreprise.
 
-Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : préparation des données et feature engineering (ML-2), entraînement et AutoML (ML-3), évaluation rigoureuse par cross-validation et importance des variables (ML-4), puis les fonctionnalités avancées — prévision de séries temporelles par SSA (ML-5), interopérabilité ONNX (ML-6) et systèmes de recommandation (ML-7) — avant un TP capstone qui marie ML.NET et la régression bayésienne d'Infer.NET.
+Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : préparation des données et feature engineering (ML-2), entraînement et AutoML (ML-3), évaluation rigoureuse par cross-validation et importance des variables (ML-4), puis les fonctionnalités avancées — prévision de séries temporelles par SSA (ML-5), interopérabilité ONNX (ML-6), systèmes de recommandation (ML-7) et clustering non-supervisé par K-Means (ML-8) — avant un TP capstone qui marie ML.NET et la régression bayésienne d'Infer.NET.
 
 > **À qui s'adresse cette série** : développeurs C#/.NET découvrant le Machine Learning, équipes enterprise souhaitant intégrer du ML sans sortir de leur stack .NET, ou data scientists souhaitant servir des modèles en production dans des applications C#. Aucun prérequis en statistiques avancées — les concepts sont introduits progressivement dans chaque notebook.
 
@@ -36,13 +36,14 @@ Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : p
 | 3 | [ML-3-Entrainement&AutoML](ML-3-Entrainement&AutoML.ipynb) | SDCA, LightGBM, AutoML | 45-60 min |
 | 4 | [ML-4-Evaluation](ML-4-Evaluation.ipynb) | Cross-validation, métriques, PFI | 40-50 min |
 
-### Fonctionnalités avancées (ML-5 à ML-7)
+### Fonctionnalités avancées (ML-5 à ML-8)
 
 | # | Notebook | Contenu | Durée |
 |---|----------|---------|-------|
 | 5 | [ML-5-TimeSeries](ML-5-TimeSeries.ipynb) | **Time Series Forecasting** avec ForecastBySsa (SSA) | 45-60 min |
 | 6 | [ML-6-ONNX](ML-6-ONNX.ipynb) | **ONNX Integration** : modèles Python/PyTorch dans .NET | 45-60 min |
 | 7 | [ML-7-Recommendation](ML-7-Recommendation.ipynb) | **Recommandation** : Matrix Factorization, collaborative filtering | 45-60 min |
+| 8 | [ML-8-Clustering](ML-8-Clustering.ipynb) | **Clustering non-supervisé** : K-Means, segmentation RFM, méthode du coude | 45-60 min |
 
 ### TP Pratique
 
@@ -184,6 +185,15 @@ Avoir une intuition de ces concepts aidera, mais ils sont **expliqués dans les 
 | Cold Start | Gérer nouveaux utilisateurs/items |
 | Métriques | Precision@K, Recall@K, NDCG |
 
+### ML-8-Clustering
+
+| Section | Contenu |
+|---------|---------|
+| K-Means | Clustering non-supervisé via `ClusteringCatalog` |
+| Normalisation | `NormalizeMinMax` indispensable pour la distance euclidienne |
+| Évaluation | AverageDistance (inertie), DaviesBouldinIndex (séparation) |
+| Choix de K | Méthode du coude (elbow method), Thorndike 1953 |
+
 ## Dataset
 
 | Fichier          | Description                                                  |
@@ -260,6 +270,8 @@ ML-5-TimeSeries (forecasting)
 ML-6-ONNX (interopérabilité)
     |
 ML-7-Recommendation (systèmes de recommandation)
+    |
+ML-8-Clustering (clustering non-supervisé)
 ```
 
 **Note** : Les notebooks ML-5, ML-6, ML-7 présentent les fonctionnalités récentes de ML.NET (2024-2025) et sont conçus comme références pédagogiques. Certains exemples nécessitent des modèles ou services externes pour une exécution complète.


### PR DESCRIPTION
## ML-8 : Clustering non-supervisé avec K-Means

Nouveau notebook `ML-8-Clustering.ipynb` — le **clustering non-supervisé**, paradigme absent du curriculum ML.NET actuel (ML-1..7 = supervisé). Comble le gap « Clustering / K-Means » identifié dans le parcours ML.

### Contenu

- **K-Means** via `mlContext.Clustering.Trainers.KMeans` (`ClusteringCatalog`)
- **Segmentation RFM** (Recency / Frequency / Monetary, Hughes 1996) — 90 clients synthétiques, 3 segments cachés (Dormants / Réguliers / VIP) que K-Means doit retrouver sans étiquettes
- **`NormalizeMinMax`** — indispensable pour la distance euclidienne (Monetary 50-500 écraserait Frequency 2-20 sinon)
- **Évaluation** : `AverageDistance` (inertie intra-cluster) + `DaviesBouldinIndex` (séparation)
- **Méthode du coude** (Thorndike 1953) : sweep K=2..6, choix de K par double critère

### Exécution réelle (C.2)

Exécuté de bout en bout, kernel `.net-csharp`, exec_count 1-14, **0 erreur**. Sorties réelles :

| Sortie | Valeur |
|--------|--------|
| Métriques K=3 | `AverageDistance = 0,0209`, `DaviesBouldinIndex = 0,394` (< 0,5 = clusters bien séparés) |
| Prédiction | dormant→C2 [0,45 ; **0,01** ; 1,50] · régulier→C1 [**0,00** ; 0,43 ; 0,39] · VIP→C3 [0,56 ; 1,52 ; **0,01**] — séparation nette |
| Coude | K=2→0,096 · **K=3→0,021** (-78 %) · K=4→0,019 · K=5/6 s'aplatissent ; **DB minimum à K=3** (0,394) — les deux critères convergent sur K=3 = le nombre de segments cachés |

### Problème non-trivial (#3801 Prong-B)

3 segments RFM bien séparés avec bruit gaussien, normalisation obligatoire (échelles hétérogènes), sélection de K par double critère (coude + minimum DB) — le notebook exerce le moteur K-Means de façon significative, pas un cas dégénéré.

### Exercices (3)

1. Déterminer le K optimal sur un dataset à 4 segments cachés (sweep + DB minimum)
2. Implémenter la silhouette moyenne (Rousseeuw 1987) — `s(i) = (b(i)-a(i))/max(a(i),b(i))`
3. Effet de la normalisation (K-Means sans `NormalizeMinMax` → clustering dominé par Monetary)

Stubs `// TODO etudiant` + `// Indice` + `// Etape N` (C.1 conforme — pas de `raise NotImplementedError`).

### Références académiques

MacQueen 1967, Lloyd 1957, Arthur & Vassilvitskii 2007 (K-Means++), Davies & Bouldin 1979, Rousseeuw 1987 (silhouette), Thorndike 1953 (elbow), Hughes 1996 (RFM).

### Fichiers

- `MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb` (nouveau, 34 cellules, exécuté avec outputs)
- `MyIA.AI.Notebooks/ML/ML.Net/README.md` (ML-8 ajouté : table avancée + section détaillée + parcours ; marqueur `CATALOG-STATUS` inchangé)

See #3801
