### PR TITLE
docs(qc): FR backfill regime/mean-reversion READMEs (#3870 Phase 0.5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection/README.en.md
@@ -1,0 +1,27 @@
+# Markov-Regime-Detection
+
+**Asset class:** US Equities/ETF (SPY, TLT, GLD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Markov regime detection using statsmodels MarkovRegression. Identifies 2-regime (bull/bear) states on SPY returns.
+
+**Consolidated from ML-HMM-Regime** (near-identical copy with same class name, same k_regimes=2, same allocation logic).
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.408 |
+| Model | MarkovRegression |
+| Regimes | 2 (bull/bear) |
+
+## Files
+
+- main.py - Strategy (v1.1, Markov regime, consolidated from ML-HMM-Regime)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection/README.md
@@ -1,27 +1,27 @@
 # Markov-Regime-Detection
 
-**Asset class:** US Equities/ETF (SPY, TLT, GLD)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions/ETF américains (SPY, TLT, GLD)
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-Markov regime detection using statsmodels MarkovRegression. Identifies 2-regime (bull/bear) states on SPY returns.
+Détection de régime markovien avec `MarkovRegression` de statsmodels. Identifie 2 régimes (haussier/baissier) sur les rendements de SPY.
 
-**Consolidated from ML-HMM-Regime** (near-identical copy with same class name, same k_regimes=2, same allocation logic).
+**Consolidé depuis ML-HMM-Regime** (copie quasi-identique avec même nom de classe, même `k_regimes=2`, même logique d'allocation).
 
-## How to Run
+## Comment lancer
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour lancer.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 0.408 |
-| Model | MarkovRegression |
-| Regimes | 2 (bull/bear) |
+| Modèle | MarkovRegression |
+| Régimes | 2 (haussier/baissier) |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (v1.1, Markov regime, consolidated from ML-HMM-Regime)
+- `main.py` - Stratégie (v1.1, régime markovien, consolidé depuis ML-HMM-Regime)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/README.en.md
@@ -1,0 +1,41 @@
+# MeanReversion
+
+**Asset class:** US Sector ETFs
+**Cloud project ID:** None (local only)
+
+## Description
+
+Short-term mean reversion strategy on 11 GICS sector ETFs (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC).
+Buys the most oversold ETFs (RSI(14) < 40) and holds for 15 days or until RSI > 60.
+
+SMA200 regime filter on SPY: exits all positions in bear markets.
+Stop-loss at -8% to cut real breakdowns. Max 4 concurrent positions at 25% each.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion"`
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.294 |
+| CAGR | 7.53% |
+| Max Drawdown | 16.5% |
+| Net Return | +80.9% |
+| Rebalance | Daily scan |
+
+## Files
+
+- `main.py` - Strategy (v4.0, sector ETF mean reversion)
+- `research.ipynb` - RSI optimization, stop-loss, and holding period tests
+
+## References
+
+- Jegadeesh (1990), "Evidence of Predictable Behavior of Security Returns"
+- De Bondt & Thaler (1985), "Does the Stock Market Overreact?"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/README.md
@@ -1,41 +1,41 @@
 # MeanReversion
 
-**Asset class:** US Sector ETFs
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** ETF sectoriels américains
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-Short-term mean reversion strategy on 11 GICS sector ETFs (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC).
-Buys the most oversold ETFs (RSI(14) < 40) and holds for 15 days or until RSI > 60.
+Stratégie de mean-reversion court terme sur 11 ETF sectoriels GICS (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC).
+Achète les ETF les plus survendus (RSI(14) < 40) et conserve 15 jours ou jusqu'à RSI > 60.
 
-SMA200 regime filter on SPY: exits all positions in bear markets.
-Stop-loss at -8% to cut real breakdowns. Max 4 concurrent positions at 25% each.
+Filtre de régime SMA200 sur SPY : sort de toutes les positions en marché baissier.
+Stop-loss à -8 % pour couper les vraies ruptures. Maximum 4 positions simultanées à 25 % chacune.
 
-## How to Run
+## Comment lancer
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion"`
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion"`
 ```bash
 lean backtest --project .
 ```
 
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour lancer.
 
-## Backtest Metrics (2015-2026)
+## Métriques de backtest (2015-2026)
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | 0.294 |
-| CAGR | 7.53% |
-| Max Drawdown | 16.5% |
-| Net Return | +80.9% |
-| Rebalance | Daily scan |
+| CAGR | 7.53 % |
+| Max Drawdown | 16.5 % |
+| Rendement net | +80.9 % |
+| Rebalance | Scan quotidien |
 
-## Files
+## Fichiers
 
-- `main.py` - Strategy (v4.0, sector ETF mean reversion)
-- `research.ipynb` - RSI optimization, stop-loss, and holding period tests
+- `main.py` - Stratégie (v4.0, mean-reversion sur ETF sectoriels)
+- `research.ipynb` - Optimisation RSI, stop-loss et tests de période de détention
 
-## References
+## Références
 
-- Jegadeesh (1990), "Evidence of Predictable Behavior of Security Returns"
-- De Bondt & Thaler (1985), "Does the Stock Market Overreact?"
+- Jegadeesh (1990), « Evidence of Predictable Behavior of Security Returns »
+- De Bondt & Thaler (1985), « Does the Stock Market Overreact? »

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching/README.en.md
@@ -1,0 +1,24 @@
+# RegimeSwitching
+
+**Asset class:** US Equities/ETF
+**Cloud project ID:** None (local only)
+
+## Description
+
+Momentum/mean-reversion regime switching using SMA50/SMA200 crossover. Applies momentum in trending, mean-reversion in sideways.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching"`
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | SMA50/200 regime switch |
+| Strategies | Momentum + Mean-reversion |
+
+## Files
+
+- main.py - Strategy (iter3, regime switching)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching/README.md
@@ -1,24 +1,24 @@
 # RegimeSwitching
 
-**Asset class:** US Equities/ETF
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions/ETF américains
+**ID projet Cloud :** Aucun (local uniquement)
 
 ## Description
 
-Momentum/mean-reversion regime switching using SMA50/SMA200 crossover. Applies momentum in trending, mean-reversion in sideways.
+Basculage de régime momentum/mean-reversion par croisement SMA50/SMA200. Applique le momentum en tendance, la mean-reversion en range.
 
-## How to Run
+## Comment lancer
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching"`
+**QC Cloud :** Pas encore déployé. Copier les fichiers dans un nouveau projet QC Cloud pour lancer.
 
-## Backtest Metrics
+## Métriques de backtest
 
-| Metric | Value |
-|--------|-------|
-| Method | SMA50/200 regime switch |
-| Strategies | Momentum + Mean-reversion |
+| Métrique | Valeur |
+|----------|--------|
+| Méthode | Bascule de régime SMA50/200 |
+| Stratégies | Momentum + Mean-reversion |
 
-## Files
+## Fichiers
 
-- main.py - Strategy (iter3, regime switching)
+- `main.py` - Stratégie (iter3, bascule de régime)


### PR DESCRIPTION
## Contexte

Phase 0.5 du backfill français (#1650) — règle `readme-french-first`. Trois READMEs de la sous-famille **regime / mean-reversion** de QuantConnect, jusqu'ici en anglais uniquement.

## Changements

| Fichier | Action |
|---------|--------|
| `RegimeSwitching/README.en.md` | EN original préservé byte-identique (golden set) |
| `RegimeSwitching/README.md` | Nouveau README français (même structure) |
| `Markov-Regime-Detection/README.en.md` | EN original préservé byte-identique |
| `Markov-Regime-Detection/README.md` | Nouveau README français |
| `MeanReversion/README.en.md` | EN original préservé byte-identique |
| `MeanReversion/README.md` | Nouveau README français |

## Stratégies couvertes

- **RegimeSwitching** — bascule momentum/mean-reversion par croisement SMA50/SMA200
- **Markov-Regime-Detection** — `MarkovRegression` statsmodels, 2 régimes (haussier/baissier), consolidé depuis ML-HMM-Regime
- **MeanReversion** — RSI(14) sur 11 ETF sectoriels GICS + filtre baissier SMA200 + stop-loss -8 %

## Vérifications

- `scan_md_hierarchy.py` sur les 3 nouveaux FR : **0 finding** (pas de H1-DEEP / MULTI-H1 / HINT-AS-HEADING)
- `README.en.md` sha256 identiques aux originaux (préservation byte-identique du golden set EN)
- `COURSE_CATALOG.generated.{json,md}` byte-identiques à `origin/main` (pas de régénération sur la branche — cron + CI-drift gèrent le catalogue)
- Markdown-only (exception C.2 : aucune cellule de code notebook touchée, pas de re-execution requise)
- Sous-famille **distincte** des batches précédents : volatility (#4723), ranking, HandsOn

## Scope

Backfill partiel de l'Epic #1650 Phase 0.5 — contribution à #3870, ne clôt pas l'Epic.

See #3870
Part of #1650