### PR TITLE
fix(genai-image): demote 'Note sur l'approche GGUF' aside H3->bold-inline, 02-4 (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-4-Z-Image-Lumina2.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-4-Z-Image-Lumina2.ipynb
@@ -43,7 +43,7 @@
     "- **Diffusers** (von Platen et al. 2022) — bibliothèque HuggingFace qui fournit le pipeline `LuminaPipeline` wrappé par le node ComfyUI.\n",
     "- Le **VAE SDXL** (Kingma & Welling 2013, arXiv:1312.6114) décode l'espace latent 4-channel vers l'espace pixel.\n",
     "\n",
-    "### Note sur l'approche GGUF\n",
+    "**Note sur l'approche GGUF**\n",
     "\n",
     "L'approche GGUF (z_image_turbo + gemma CLIP) a ete abandonnee en raison d'incompatibilites dimensionnelles (2560 vs 2304 entre RecurrentGemma et Gemma-2).\n",
     "\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **Transition vers la famille GenAI/Image** (2 notebooks : 02-4, 02-5). Suite de la famille GenAI/Texte drained (#4722/#4726/#4732).

## Changement (1 fichier, +1/-1)

**`Image/02-Advanced/02-4-Z-Image-Lumina2.ipynb`** cell 0 — 1 flag HINT-AS-HEADING :

\`\`\`diff
- ### Note sur l'approche GGUF
+ **Note sur l'approche GGUF**
```

Même pattern que #4712 (Note technique), #4726 (Note de mise à jour) : le scanner `HINT_RE` ([scan_md_hierarchy.py:23](scripts/notebook_tools/scan_md_hierarchy.py#L23)) matche `note` à **tout niveau H1-H6**. Demoter en H4 laisserait le flag → seul un non-heading (bold inline) clear. La directive [notebook-formatting §1.2](docs/reference/notebook-formatting.md) liste « note » comme aside interdit en heading. Mots préservés exactement.

Le paragraphe explicatif sous le titre (abandon de l'approche GGUF pour incompatibilités dimensionnelles) est inchangé.

## Conformité

- **Markdown-only** : cellule markdown, 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé) — `src[29]` modifié in-place
- **Rescan post-fix** : `scan_md_hierarchy.py 02-4` → 0/1 flagged ✓

## Scope

\`See #3966\` (partial — GenAI/Image : reste 02-5). 1 fichier = atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>