### PR TITLE
feat(hashlife): mem_toGrid_node — G3 toGrid node-decomposition (sorry 4->4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1031,6 +1031,28 @@ theorem mem_toGrid {c : MacroCell} {offset : Int × Int} {p : Int × Int} :
   unfold MacroCell.toGrid
   exact mem_sortDedup
 
+/-- **G3 infrastructure (toGrid node-decomposition).** Membership in a `node`
+    cell's grid decomposes into membership in the four children's grids, with
+    the standard quadtree offset shifts (row increases downward, column
+    rightward): `nw` at `(r0,c0)`, `ne` at `(r0, c0+half)`, `sw` at
+    `(r0+half, c0)`, `se` at `(r0+half, c0+half)`, where `half = 2^nw.level`.
+
+    Pure structural fact — no `hashlifeResultAux`. This is the sorry-free G3
+    piece of `p4_succ_membership`: once established, the LHS
+    `p ∈ (hashlifeResultAux (k+2) c).toGrid (2^k, 2^k)` (which is a
+    `node out_nw out_ne out_sw out_se`) decomposes into the four
+    `out_*.toGrid ...` memberships, each characterizable via
+    `centralCorrect_mem` + the induction hypothesis `centralCorrect q_* (k-1)`. -/
+theorem mem_toGrid_node {nw ne sw se : MacroCell} {r0 c0 : Int} {p : Int × Int} :
+    p ∈ (node nw ne sw se).toGrid (r0, c0) ↔
+      p ∈ nw.toGrid (r0, c0) ∨
+      p ∈ ne.toGrid (r0, c0 + (2 ^ nw.level : Int)) ∨
+      p ∈ sw.toGrid (r0 + (2 ^ nw.level : Int), c0) ∨
+      p ∈ se.toGrid (r0 + (2 ^ nw.level : Int), c0 + (2 ^ nw.level : Int)) := by
+  repeat rw [mem_toGrid]
+  simp only [toCellsAux, List.mem_append]
+  tauto
+
 /-- Membership in a restricted grid: in the grid and inside the window. -/
 theorem mem_restrictGridTo {g : Grid} {lo : Int} {size : Nat} {p : Int × Int} :
     p ∈ restrictGridTo g lo size ↔


### PR DESCRIPTION
## Summary

Sorry-stable G3 infrastructure lemma for lane **#3846** (Conway Hashlife GOL sorry elimination). The toGrid node-decomposition piece — complements `centralCorrect_mem` (G2, #4583 merged): together they lift the G2/G3 reasoning off the whnf wall. Branched fresh off main (02aab067f, post #4574/#4583 merge); insertion at ~L1034, distant from any prior PR.

## New theorem `mem_toGrid_node`

```
p ∈ (node nw ne sw se).toGrid (r0, c0) ↔
  p ∈ nw.toGrid (r0, c0)
  ∨ p ∈ ne.toGrid (r0, c0 + 2^nw.level)
  ∨ p ∈ sw.toGrid (r0 + 2^nw.level, c0)
  ∨ p ∈ se.toGrid (r0 + 2^nw.level, c0 + 2^nw.level)
```

Pure structural — no `hashlifeResultAux`. Proof: `repeat rw [mem_toGrid]` + `simp only [toCellsAux, List.mem_append]` + `tauto` (the residual is `Or`-associativity + Nat-cast display defeq; atoms are identical).

## Why this unlocks G3

`hashlifeResultAux (k+2) c` (well-formed level-(k+2) `c`) returns `node out_nw out_ne out_sw out_se` where `out_* = hRA fuel q_*`. The LHS of the `p4_succ_membership` goal — `p ∈ (hRA (k+2) c).toGrid (2^k, 2^k)` — is a node's toGrid. `mem_toGrid_node` decomposes it into the four `out_*.toGrid ...` memberships, each characterizable via `centralCorrect_mem` (c.153, #4583) + the induction hypothesis `centralCorrect q_* (k-1)` — crossing the whnf wall by **congruence** rather than unfolding `hRA`.

## Why sorry-stable (4→4, not 4→3)

The full G3 assembly still needs the **offset-matching** argument: the `out_*` grids sit at shifted offsets within the centered window, and reconciling those shifts with the `centralCorrect` offsets is the remaining sub-step. This lemma is the **gate infrastructure** — same shape as the P4.3 gate (c.142, sorry-stable) → consumer (c.143, sorry 5→4). With `centralCorrect_mem` (G2) + `mem_toGrid_node` (G3) now both on main, the next cycle can attempt the offset-matching assembly → if it closes, `p4_succ_membership` sorry **4→3** (the real front).

## Lean PR checklist (pr-review-discipline §B)

1. **sorry before/after**: **4 → 4** (token grep, exclude `.lake`). No new sorry; `mem_toGrid_node` has no "declaration uses sorry" warning.
2. **Lake build SUCCESS**: `lake build Conway.Life.HashlifeCorrectness` → **EXIT 0**.
3. **Proof integrity**: depends only on `mem_toGrid`/`mem_sortDedup`/`List.mem_append`/`tauto` → **no `sorryAx`**.
4. **No prover Python refactor** — N/A.

## Anti-regression

+22 insertions, 0 deletions. New theorem only; no existing proof touched.

See #3846

Co-Authored-By: Claude-Code <noreply@anthropic.com>
