### PR TITLE
docs(gametheory): #3968 normalize H1-DEEP in GT-1-Setup + SocialChoice/01-Arrow

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -5,6 +5,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# GameTheory-1-Setup\n",
+    "\n",
     "> **Navigation** : [Notebooks](../) | \n",
     "> **Serie** : GameTheory-1-Setup\n"
    ]
@@ -23,8 +25,6 @@
     "tags": []
    },
    "source": [
-    "# GameTheory-1-Setup\n",
-    "\n",
     "**Navigation** : [Index](README.md) | [2-NormalForm >>](GameTheory-2-NormalForm.ipynb)\n",
     "\n",
     "## Installation et Configuration de l'Environnement\n",

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
@@ -5,6 +5,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# SocialChoice 01 - Theoreme d'Arrow : Preuve Formelle et Simulation\n",
+    "\n",
     "> **Navigation** : [Notebooks](../) | \n",
     "> **Serie** : SocialChoice 01 - Theoreme d'Arrow : Preuve Formelle et Simulation\n"
    ]
@@ -23,8 +25,6 @@
     "tags": []
    },
    "source": [
-    "# SocialChoice 01 - Theoreme d'Arrow : Preuve Formelle et Simulation\n",
-    "\n",
     "**Navigation** : SocialChoice | [02-Lean-SocialChoice-Formal.ipynb >>](02-Lean-SocialChoice-Formal.ipynb) | [Index](../README.md)\n",
     "\n",
     "**Autres notebooks** : [03-Voting-Methods.ipynb](03-Voting-Methods.ipynb) | [04-Computational-Aggregation-SAT-Z3.ipynb](04-Computational-Aggregation-SAT-Z3.ipynb)\n",


### PR DESCRIPTION
## Contexte

Campagne de normalisation de la hiérarchie typographique (#3968, EPIC #3966). Deux notebooks de la famille **GameTheory** présentaient un titre H1 « profond » (en cellule 1 au lieu de la cellule 0 canonique), flaggé `H1-DEEP` par `scan_md_hierarchy.py`.

## Changements

| Notebook | Fix |
|----------|-----|
| `GameTheory/GameTheory-1-Setup.ipynb` | `# GameTheory-1-Setup` déplacé cell 1 → tête de cell 0 |
| `GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb` | `# SocialChoice 01 - ...` déplacé cell 1 → tête de cell 0 |

**Pattern canonique** (même fix que po-2023 #4722 / #4732 sur GenAI/Texte) : cell 0 ne portait que le bloc `> **Navigation**` minimal ; cell 1 portait le titre H1 + nav + contenu. Après fix, cell 0 mène avec le H1, cell 1 démarre à la nav.

**0 wording changé** — pur repositionnement de la ligne de titre (+ sa ligne blanche de séparation).

## Vérifications

- `scan_md_hierarchy.py` : **0/2 flaggé** (était `H1-DEEP` ×2)
- Diff : **4 ins / 4 del** sur 2 fichiers (2 lignes déplacées par notebook)
- Cellules source markdown uniquement (cells 0 et 1, toutes deux markdown) → **exception C.2**, pas de re-execution
- Cellules de code et outputs **non touchées** (diff vérifié)
- `nbformat 4.5` valide, 0 erreur d'output, ids/metadata cellules préservés
- `COURSE_CATALOG.generated.{json,md}` byte-identiques à `origin/main`

## Scope

Grain **hors-QC diversifié** (steer ai-01 : cap QC saturé ce run — déjà 4 PRs QC + #4734). Famille GameTheory non-drainée pour #3968 (0 collision : 0 PR ouverte sur ces fichiers, derniers commits #4581 / #4239 déjà mergés). Contribution à #3968, ne clôt pas l'Epic.

See #3968
Part of #3966