### PR TITLE
fix(genai-image): demote 'Note sur les dependances' aside H3->bold-inline, 02-5 (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
@@ -475,7 +475,7 @@
     "\n",
     "Le client `ComfyUIClient` (module shared) gere l'authentification Bearer et le polling asynchrone du resultat. La configuration est lue depuis `GenAI/.env` (`COMFYUI_API_URL` + `COMFYUI_API_TOKEN`).\n",
     "\n",
-    "### Note sur les dependances\n",
+    "**Note sur les dependances**\n",
     "\n",
     "Contrairement a la recette `DiffusionPipeline` (qui necessite `torch+CUDA`, `diffusers`, `gemlite`, `hqq` installes localement), l'approche API ComfyUI ne requiert **aucune dependance GPU locale** : tout tourne dans le container Docker ComfyUI. Seuls `requests` (ou `urllib`, dans la stdlib) et le module `comfyui_client.py` sont necessaires."
    ]


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **Dernier notebook de la famille GenAI/Image** (2/2 : après #4735 02-4).

## Changement (1 fichier, +2/-2)

**`Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb`** cell 7 — 1 flag HINT-AS-HEADING :

\`\`\`diff
- ### Note sur les dependances
+ **Note sur les dependances**
```

Même pattern que #4735 (02-4), #4712, #4726 : le scanner `HINT_RE` ([scan_md_hierarchy.py:23](scripts/notebook_tools/scan_md_hierarchy.py#L23)) matche `note` à **tout niveau H1-H6**. Demoter en H4 laisserait le flag → seul un non-heading (bold inline) clear. La directive [notebook-formatting §1.2](docs/reference/notebook-formatting.md) liste « note » comme aside interdit en heading. Mots préservés exactement.

## Conformité

- **Markdown-only** : cellule markdown, 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé) — `src[6]` modifié in-place
- **Rescan post-fix** : `scan_md_hierarchy.py 02-5` → 0/1 flagged ✓

## Scope

\`See #3966\`. **GenAI/Image = DRAINED** (2/2). Reste GenAI : Video (1), PostTraining (1), CaseStudies (3). 1 fichier = atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>