### PR TITLE
feat(lean): PacLearning bernoulli_mgf_le — Hoeffding MGF bound (iter-2 brique 2c/3-finale)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/BernoulliMGF.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/BernoulliMGF.lean
@@ -201,4 +201,246 @@ theorem bernoulli_logmgf_second_deriv_le (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : �
   rw [bernoulli_tilted_mean_deriv μ t hμ hμ2]
   exact bernoulli_var_le _
 
+
+/-! ## Brique 2b/5-finale — borne MGF générale `bernoulli_mgf_le`
+
+La borne finale de Hoeffding (forme Bernoulli) : pour `μ ∈ [0, 1]` et `t ∈ ℝ`,
+
+    μ · exp(t · (1 − μ)) + (1 − μ) · exp(−(t · μ))  ≤  exp(t² / 8).
+
+C'est le **lemme de Hoeffding** complet. La preuve contourne le machinery lourd
+`convexOn_univ_of_deriv2_nonneg` + `deriv^[2]` (qui timeout sur `simp`) en passant par la
+**monotonie de la dérivée** : on pose le log-MGF centré `K(t) = log((1−μ) + μ·exp t) − t·μ`
+(de sorte que `MGF = exp(K)`), et le gap `g(t) = t²/8 − K(t)`. On montre `g ≥ 0` via :
+
+1. la dérivée `g'(t) = t/4 − (q(t) − μ)` (notée `g₁`) est **monotone croissante globale**
+   (`g₁'(t) = 1/4 − q(t)·(1−q(t)) ≥ 0` par `bernoulli_var_le`) ;
+2. `g₁(0) = 0`, donc `g₁(t) ≥ 0` pour `t ≥ 0` (et `≤ 0` pour `t ≤ 0`) ;
+3. sur `Set.Ici 0`, `g' = g₁ ≥ 0` ⟹ `g` monotone croissante ⟹ `g(t) ≥ g(0) = 0` ;
+4. sur `Set.Iic 0`, `g' ≤ 0` ⟹ `g` monotone décroissante ⟹ `g(t) ≥ g(0) = 0` ;
+5. `g(t) ≥ 0` ⟹ `t²/8 ≥ K(t)` ⟹ (exponentielle croissante) `exp(t²/8) ≥ exp(K(t)) = MGF`.
+
+La monotonie s'établit via `monotone_of_hasDerivAt_nonneg` / `monotoneOn_of_deriv_nonneg`
+(HasDerivAt pointwise, **aucun `deriv^[2]`**, aucun `Differentiable ℝ` global à synthétiser).
+-/
+
+/-- La « moyenne tiltée » `q(t) = μ·exp t / ((1−μ) + μ·exp t)`, exposée pour réutilisation.
+C'est `φ'(t)` (dérivée du log-MGF non-centré) et l'argument de `bernoulli_var_le` donnant
+`φ''(t) ≤ 1/4`. -/
+noncomputable def bernoulliTiltedMean (μ t : ℝ) : ℝ := μ * Real.exp t / ((1 - μ) + μ * Real.exp t)
+
+/-- `g₁ μ t = t/4 − (q(t) − μ)` : la dérivée du gap `g μ`. -/
+noncomputable def bernoulliMGFDeriv (μ t : ℝ) : ℝ := t / 4 - (bernoulliTiltedMean μ t - μ)
+
+/-- Le gap `g μ t = t²/8 − K(t)` où `K(t) = log((1−μ)+μ·exp t) − t·μ` est le log-MGF centré.
+Prouver `g μ t ≥ 0` ⟹ `MGF ≤ exp(t²/8)`. -/
+noncomputable def bernoulliMGFGap (μ t : ℝ) : ℝ := t^2 / 8 - (Real.log ((1 - μ) + μ * Real.exp t) - t * μ)
+
+/-- `HasDerivAt` de la moyenne tiltée : `q'(t) = q(t)·(1 − q(t))` (variance tiltée). -/
+theorem bernoulliTiltedMean_hasDerivAt (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    HasDerivAt (bernoulliTiltedMean μ)
+      (bernoulliTiltedMean μ t * (1 - bernoulliTiltedMean μ t)) t := by
+  have hDpos : 0 < (1 - μ) + μ * Real.exp t := bernoulli_logmgf_denom_pos μ t hμ hμ2
+  have hDne : (1 - μ) + μ * Real.exp t ≠ 0 := ne_of_gt hDpos
+  have hnum : HasDerivAt (fun s => μ * Real.exp s) (μ * Real.exp t) t :=
+    HasDerivAt.const_mul μ (hasDerivAt_exp t)
+  have hdenom : HasDerivAt (fun s => (1 - μ) + μ * Real.exp s) (μ * Real.exp t) t :=
+    HasDerivAt.const_add _ (HasDerivAt.const_mul _ (hasDerivAt_exp t))
+  have hdiv : HasDerivAt (fun s => μ * Real.exp s / ((1 - μ) + μ * Real.exp s))
+      ((μ * Real.exp t * ((1 - μ) + μ * Real.exp t) - μ * Real.exp t * (μ * Real.exp t)) /
+        ((1 - μ) + μ * Real.exp t) ^ 2) t :=
+    HasDerivAt.div hnum hdenom hDne
+  have hfun : (fun s => μ * Real.exp s / ((1 - μ) + μ * Real.exp s)) = bernoulliTiltedMean μ := by
+    funext s; rfl
+  rw [hfun] at hdiv
+  have heq : bernoulliTiltedMean μ t * (1 - bernoulliTiltedMean μ t) =
+      (μ * Real.exp t * ((1 - μ) + μ * Real.exp t) - μ * Real.exp t * (μ * Real.exp t)) /
+        ((1 - μ) + μ * Real.exp t) ^ 2 := by
+    simp only [bernoulliTiltedMean]
+    field_simp
+  rw [heq]
+  exact hdiv
+
+/-- `HasDerivAt` du log-MGF non-centré `φ(t) = log((1−μ)+μ·exp t)` : `φ'(t) = q(t)`. -/
+theorem bernoulli_logmgf_hasDerivAt (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    HasDerivAt (fun s => Real.log ((1 - μ) + μ * Real.exp s)) (bernoulliTiltedMean μ t) t := by
+  have hDpos : 0 < (1 - μ) + μ * Real.exp t := bernoulli_logmgf_denom_pos μ t hμ hμ2
+  have hDne : (1 - μ) + μ * Real.exp t ≠ 0 := ne_of_gt hDpos
+  have hinner : HasDerivAt (fun s => (1 - μ) + μ * Real.exp s) (μ * Real.exp t) t :=
+    HasDerivAt.const_add _ (HasDerivAt.const_mul _ (hasDerivAt_exp t))
+  have hlog : HasDerivAt (fun s => Real.log ((1 - μ) + μ * Real.exp s))
+      ((μ * Real.exp t) / ((1 - μ) + μ * Real.exp t)) t :=
+    HasDerivAt.log hinner hDne
+  simpa [bernoulliTiltedMean] using hlog
+
+/-- `HasDerivAt` du gap `g` : `g'(t) = g₁(t) = t/4 − (q(t) − μ)`. -/
+theorem bernoulliMGFGap_hasDerivAt (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    HasDerivAt (bernoulliMGFGap μ) (bernoulliMGFDeriv μ t) t := by
+  have hlog : HasDerivAt (fun s : ℝ => Real.log ((1 - μ) + μ * Real.exp s))
+      (bernoulliTiltedMean μ t) t := bernoulli_logmgf_hasDerivAt μ t hμ hμ2
+  have hsq8 : HasDerivAt (fun s : ℝ => s ^ 2 / 8) (2 * t / 8) t := by
+    have h := HasDerivAt.div (hasDerivAt_pow 2 t) (hasDerivAt_const t 8) (by norm_num : (8 : ℝ) ≠ 0)
+    convert h using 1 <;> first
+      | rfl
+      | (rw [show (2 - 1 : ℕ) = 1 from rfl, pow_one]; ring)
+  have htmu : HasDerivAt (fun s : ℝ => s * μ) (1 * μ) t :=
+    (hasDerivAt_id' t).mul_const μ
+  have hK : HasDerivAt (fun s : ℝ => Real.log ((1 - μ) + μ * Real.exp s) - s * μ)
+      (bernoulliTiltedMean μ t - 1 * μ) t := HasDerivAt.sub hlog htmu
+  have hgap : HasDerivAt
+      (fun s : ℝ => s ^ 2 / 8 - (Real.log ((1 - μ) + μ * Real.exp s) - s * μ))
+      (2 * t / 8 - (bernoulliTiltedMean μ t - 1 * μ)) t :=
+    HasDerivAt.sub hsq8 hK
+  have hfun : (fun s : ℝ => s ^ 2 / 8 - (Real.log ((1 - μ) + μ * Real.exp s) - s * μ)) =
+      bernoulliMGFGap μ := by funext s; rfl
+  rw [hfun] at hgap
+  have heq : bernoulliMGFDeriv μ t =
+      2 * t / 8 - (bernoulliTiltedMean μ t - 1 * μ) := by
+    simp only [bernoulliMGFDeriv, one_mul]
+    ring
+  rw [heq]
+  exact hgap
+
+/-- `g₁` est monotone croissante globale : `g₁'(t) = 1/4 − q(t)·(1−q(t)) ≥ 0` (bernoulli_var_le). -/
+theorem bernoulliMGFDeriv_monotone (μ : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    Monotone (bernoulliMGFDeriv μ) := by
+  apply monotone_of_hasDerivAt_nonneg
+    (f' := fun x => 1 / 4 - bernoulliTiltedMean μ x * (1 - bernoulliTiltedMean μ x))
+  · intro x
+    have hs4 : HasDerivAt (fun s : ℝ => s / 4) (1 / 4) x := by
+      have h := HasDerivAt.div (hasDerivAt_id' x) (hasDerivAt_const x 4) (by norm_num : (4 : ℝ) ≠ 0)
+      convert h using 1 <;> first | rfl | ring
+    have hq : HasDerivAt (bernoulliTiltedMean μ)
+        (bernoulliTiltedMean μ x * (1 - bernoulliTiltedMean μ x)) x :=
+      bernoulliTiltedMean_hasDerivAt μ x hμ hμ2
+    have hqmu : HasDerivAt (fun s : ℝ => bernoulliTiltedMean μ s - μ)
+        (bernoulliTiltedMean μ x * (1 - bernoulliTiltedMean μ x) - 0) x :=
+      HasDerivAt.sub hq (hasDerivAt_const x μ)
+    have hg1 : HasDerivAt (fun s : ℝ => s / 4 - (bernoulliTiltedMean μ s - μ))
+        (1 / 4 - (bernoulliTiltedMean μ x * (1 - bernoulliTiltedMean μ x) - 0)) x :=
+      HasDerivAt.sub hs4 hqmu
+    have hfun : (fun s : ℝ => s / 4 - (bernoulliTiltedMean μ s - μ)) = bernoulliMGFDeriv μ := by
+      funext s; rfl
+    rw [hfun] at hg1
+    convert hg1 using 1 <;> first | rfl | ring
+  · intro x
+    have h := bernoulli_var_le (bernoulliTiltedMean μ x)
+    show 0 ≤ 1 / 4 - bernoulliTiltedMean μ x * (1 - bernoulliTiltedMean μ x)
+    linarith
+
+/-- `g₁(0) = 0` (car `q(0) = μ`). -/
+theorem bernoulliMGFDeriv_zero (μ : ℝ) : bernoulliMGFDeriv μ 0 = 0 := by
+  have hq : bernoulliTiltedMean μ 0 = μ := by
+    simp only [bernoulliTiltedMean, Real.exp_zero, mul_one]
+    field_simp
+    ring
+  simp only [bernoulliMGFDeriv, zero_div, hq, sub_self]
+
+/-- `deriv g = g₁` (funext + HasDerivAt.deriv). -/
+theorem deriv_bernoulliMGFGap (μ : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    deriv (bernoulliMGFGap μ) = bernoulliMGFDeriv μ := by
+  funext x
+  exact HasDerivAt.deriv (bernoulliMGFGap_hasDerivAt μ x hμ hμ2)
+
+/-- `g` est continue (composée de polynôme, log, exp ; le log est défini car denom > 0). -/
+theorem continuous_bernoulliMGFGap (μ : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    Continuous (bernoulliMGFGap μ) := by
+  have hlog : Continuous (fun t : ℝ => Real.log ((1 - μ) + μ * Real.exp t)) := by
+    apply Continuous.log
+    · fun_prop
+    · intro x; exact ne_of_gt (bernoulli_logmgf_denom_pos μ x hμ hμ2)
+  show Continuous (fun t : ℝ => t ^ 2 / 8 - (Real.log ((1 - μ) + μ * Real.exp t) - t * μ))
+  fun_prop
+
+/-- `g(t) ≥ 0` pour `0 ≤ t` : g monotone croissante sur `Set.Ici 0`, `g(0) = 0`. -/
+theorem bernoulliMGFGap_nonneg_of_nonneg (μ : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) {t : ℝ}
+    (ht : 0 ≤ t) : 0 ≤ bernoulliMGFGap μ t := by
+  have hmono : MonotoneOn (bernoulliMGFGap μ) (Set.Ici 0) := by
+    apply monotoneOn_of_deriv_nonneg (convex_Ici 0)
+    · exact (continuous_bernoulliMGFGap μ hμ hμ2).continuousOn
+    · intro x _; exact (bernoulliMGFGap_hasDerivAt μ x hμ hμ2).differentiableAt.differentiableWithinAt
+    · intro x hx
+      rw [deriv_bernoulliMGFGap μ hμ hμ2]
+      have h0x : (0 : ℝ) ≤ x := Set.mem_Ici.mp (interior_subset hx)
+      have h1 : bernoulliMGFDeriv μ 0 ≤ bernoulliMGFDeriv μ x :=
+        (bernoulliMGFDeriv_monotone μ hμ hμ2) h0x
+      rw [bernoulliMGFDeriv_zero] at h1
+      exact h1
+  have h0 : bernoulliMGFGap μ 0 = 0 := by
+    have h1 : (1 - μ : ℝ) + μ = 1 := by ring
+    show (0 : ℝ) ^ 2 / 8 - (Real.log ((1 - μ) + μ * Real.exp 0) - 0 * μ) = 0
+    simp only [Real.exp_zero, mul_one, zero_mul, sub_zero]
+    rw [h1, Real.log_one]
+    ring
+  have hIn : (0 : ℝ) ∈ Set.Ici 0 := Set.mem_Ici.mpr (le_refl _)
+  have htIn : t ∈ Set.Ici 0 := Set.mem_Ici.mpr ht
+  have := hmono hIn htIn ht
+  rwa [h0] at this
+
+/-- `g(t) ≥ 0` pour `t ≤ 0` : `−g` monotone croissante sur `Set.Iic 0` (car `g' = g₁ ≤ 0` sur
+`Iio 0`), `g(0) = 0`. -/
+theorem bernoulliMGFGap_nonneg_of_nonpos (μ : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) {t : ℝ}
+    (ht : t ≤ 0) : 0 ≤ bernoulliMGFGap μ t := by
+  have hcont : ContinuousOn (fun s => -bernoulliMGFGap μ s) (Set.Iic 0) :=
+    (continuous_bernoulliMGFGap μ hμ hμ2).neg.continuousOn
+  have hmono : MonotoneOn (fun s => -bernoulliMGFGap μ s) (Set.Iic 0) := by
+    apply monotoneOn_of_deriv_nonneg (convex_Iic 0)
+    · exact hcont
+    · intro x _
+      exact (bernoulliMGFGap_hasDerivAt μ x hμ hμ2).differentiableAt.neg.differentiableWithinAt
+    · intro x hx
+      have hderiv : deriv (fun s => -bernoulliMGFGap μ s) x = -bernoulliMGFDeriv μ x :=
+        (bernoulliMGFGap_hasDerivAt μ x hμ hμ2).neg.deriv
+      rw [hderiv]
+      have hx0 : x ≤ (0 : ℝ) := Set.mem_Iic.mp (interior_subset hx)
+      have h1 : bernoulliMGFDeriv μ x ≤ bernoulliMGFDeriv μ 0 :=
+        (bernoulliMGFDeriv_monotone μ hμ hμ2) hx0
+      rw [bernoulliMGFDeriv_zero] at h1
+      linarith
+  have h0 : bernoulliMGFGap μ 0 = 0 := by
+    have h1 : (1 - μ : ℝ) + μ = 1 := by ring
+    show (0 : ℝ) ^ 2 / 8 - (Real.log ((1 - μ) + μ * Real.exp 0) - 0 * μ) = 0
+    simp only [Real.exp_zero, mul_one, zero_mul, sub_zero]
+    rw [h1, Real.log_one]
+    ring
+  have hIn : (0 : ℝ) ∈ Set.Iic 0 := Set.mem_Iic.mpr (le_refl _)
+  have htIn : t ∈ Set.Iic 0 := Set.mem_Iic.mpr ht
+  have hle := hmono htIn hIn ht
+  simp only at hle
+  rw [h0, neg_zero] at hle
+  linarith
+
+/-- Le **lemme de Hoeffding** (forme Bernoulli) — borne analytique finale. Pour `μ ∈ [0, 1]`
+et tout `t ∈ ℝ`, la MGF centrée est majorée par `exp(t²/8)`. C'est l'ingrédient exact qui,
+combiné à l'indépendance produit (brique 3/5) et à l'optimisation `t = 4ε` (brique 4/5), donne
+la concentration bilatérale de Hoeffding (brique 5/5). Preuve via le gap `g = t²/8 − log MGF ≥ 0`
+(monotonie de la dérivée, sans `deriv^[2]`), puis exponentiation. -/
+theorem bernoulli_mgf_le (μ t : ℝ) (hμ : 0 ≤ μ) (hμ2 : μ ≤ 1) :
+    μ * Real.exp (t * (1 - μ)) + (1 - μ) * Real.exp (-(t * μ)) ≤ Real.exp (t ^ 2 / 8) := by
+  have hgeq : 0 ≤ bernoulliMGFGap μ t := by
+    by_cases ht : 0 ≤ t
+    · exact bernoulliMGFGap_nonneg_of_nonneg μ hμ hμ2 ht
+    · simp only [not_le] at ht
+      exact bernoulliMGFGap_nonneg_of_nonpos μ hμ hμ2 ht.le
+  have hDpos : 0 < (1 - μ) + μ * Real.exp t := bernoulli_logmgf_denom_pos μ t hμ hμ2
+  have hlogle : Real.log ((1 - μ) + μ * Real.exp t) - t * μ ≤ t ^ 2 / 8 := by
+    have heq : bernoulliMGFGap μ t = t ^ 2 / 8 - (Real.log ((1 - μ) + μ * Real.exp t) - t * μ) := rfl
+    rw [heq, le_sub_iff_add_le] at hgeq
+    linarith
+  -- Forme produit (via `exp_add`, pas `exp_sub`) : la MGF = exp(log D) · exp(−tμ) = D · exp(−tμ).
+  have hexp : (1 - μ + μ * Real.exp t) * Real.exp (-(t * μ)) ≤ Real.exp (t ^ 2 / 8) := by
+    have hkey : Real.exp (Real.log ((1 - μ) + μ * Real.exp t) + -(t * μ)) ≤ Real.exp (t ^ 2 / 8) := by
+      apply Real.exp_le_exp.mpr
+      linarith [hlogle]
+    rw [Real.exp_add, Real.exp_log hDpos] at hkey
+    exact hkey
+  -- Factorisation : μ·exp(t(1−μ)) + (1−μ)·exp(−tμ) = (1−μ+μ·exp t)·exp(−tμ) (algèbre, atomes
+  -- `exp t` et `exp(−tμ)`), via `exp_add` sur `exp(t(1−μ)) = exp(t − tμ)`.
+  rw [show t * (1 - μ) = t + -(t * μ) by ring, Real.exp_add]
+  have heq : μ * (Real.exp t * Real.exp (-(t * μ))) + (1 - μ) * Real.exp (-(t * μ)) =
+      (1 - μ + μ * Real.exp t) * Real.exp (-(t * μ)) := by ring
+  rw [heq]
+  exact hexp
+
+
 end PacLearning


### PR DESCRIPTION
## Summary

PAC iter-2, **brique 2c/3-finale** : the general **Hoeffding MGF bound** (Bernoulli form) — the analytic crux of the whole concentration chain.

For `μ ∈ [0, 1]` and all `t ∈ ℝ`:

```
μ · exp(t · (1 − μ)) + (1 − μ) · exp(−(t · μ))  ≤  exp(t² / 8)
```

This is the full **Hoeffding lemma**. Combined with:
- the **product-independence** / MGF-of-sum factorization (brique 3/5, shipped `2a627b936`), and
- the **`t = 4ε` optimization** (brique 4/5),

it yields the **bilateral concentration** of Hoeffding (brique 5/5) and unlocks the **agnostic PAC bound** (`1/ε²` sample complexity).

## Proof strategy — monotonicity of the first derivative (NO `deriv^[2]`)

Define the centered log-MGF `K(t) = log((1−μ) + μ·exp t) − t·μ` (so `MGF = exp K`) and the gap `g(t) = t²/8 − K(t)`. Prove `g ≥ 0`:

1. `g₁(t) = g'(t) = t/4 − (q(t) − μ)`, where `q(t) = μ·exp t / ((1−μ) + μ·exp t)` (the tilted mean), is **globally monotone increasing**: `g₁'(t) = 1/4 − q(t)·(1 − q(t)) ≥ 0` by the **unconditional** `bernoulli_var_le` (`q(1−q) ≤ 1/4`, witnessed by `(q − 1/2)²`).
2. `g₁(0) = 0` (since `q(0) = μ`).
3. Hence `g₁ ≥ 0` on `[0, ∞)` and `g₁ ≤ 0` on `(−∞, 0]`:
   - on `Set.Ici 0`, `g' = g₁ ≥ 0` ⟹ `g` monotone ⟹ `g(t) ≥ g(0) = 0` (via `monotoneOn_of_deriv_nonneg`);
   - on `Set.Iic 0`, `−g` monotone ⟹ `g(t) ≥ g(0) = 0`.
4. `g(t) ≥ 0` ⟹ `t²/8 ≥ K(t)` ⟹ (`exp` increasing) `exp(t²/8) ≥ exp K(t) = MGF`.

Global monotonicity uses `monotone_of_hasDerivAt_nonneg` (**pointwise `HasDerivAt`**, no global `Differentiable ℝ` synthesis). This **deliberately avoids** `convexOn_univ_of_deriv2_nonneg` + `deriv^[2]`/`iteratedDeriv`, which **timeouts on `simp`** for this log-MGF expression. Only first-derivative `HasDerivAt` tracking is used throughout.

## Scope

13 new declarations appended to `BernoulliMGF.lean` (before `end PacLearning`):

| Declaration | Role |
|---|---|
| `bernoulliTiltedMean` | `q(t) = μ·exp t / ((1−μ)+μ·exp t)` |
| `bernoulliMGFDeriv` | `g₁(t) = t/4 − (q(t) − μ)` |
| `bernoulliMGFGap` | `g(t) = t²/8 − K(t)` |
| `bernoulliTiltedMean_hasDerivAt` | `q'(t) = q(t)·(1−q(t))` |
| `bernoulli_logmgf_hasDerivAt` | `φ'(t) = q(t)` |
| `bernoulliMGFGap_hasDerivAt` | `g'(t) = g₁(t)` |
| `bernoulliMGFDeriv_monotone` | `g₁` globally monotone increasing |
| `bernoulliMGFDeriv_zero`, `deriv_bernoulliMGFGap`, `continuous_bernoulliMGFGap` | auxiliary glue |
| `bernoulliMGFGap_nonneg_of_nonneg` / `_of_nonpos` | `g(t) ≥ 0` on each half-line |
| **`bernoulli_mgf_le`** | **flagship Hoeffding MGF bound** |

The 3 `def`s are marked `noncomputable` (they depend on `instDivInvMonoid`).

## Verification (Lean PR body §B)

- **`lake build PacLearning`**: ✅ **SUCCESS (8502 jobs), exit 0** (Mathlib v4.31.0-rc1, rev `d568c8c`; `lake exe cache get` restored 8477 olean).
- **sorry baseline** (standalone-tactic, `grep '\bsorry\b' | grep -viE "sorries|sorry.s"`):
  - `BernoulliMGF.lean`: **0** (branch) = **0** (origin/main) — net-zero.
  - full `PacLearning/` module: **0** tactic-`sorry` (the 2 grep hits are the words *"sorry-backed"* / *"(0 sorry)"* in comments of `Data.lean`/`Hoeffding.lean`).
- **Diff**: `+242 / −0`, single file (`BernoulliMGF.lean`). Atomic.

See #4293 (PAC iter-2 epic). The agnostic case + briques 4/5 (`t = 4ε`) and 5/5 (bilateral concentration) remain open, now unblocked by this MGF crux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)