### PR TITLE
fix(genai-video): renumber 5 'Etape N' section H2 -> '## N.', 04-4 (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-4-Production-Video-Pipeline.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-4-Production-Video-Pipeline.ipynb
@@ -397,7 +397,7 @@
     "tags": []
    },
    "source": [
-    "## Etape 1 : Generation du script video avec LLM\n",
+    "## 1. Generation du script video avec LLM\n",
     "\n",
     "Le pipeline commence par la generation d'un script structure.\n",
     "Un LLM (GPT-4 ou equivalent) produit une liste de scenes avec :\n",
@@ -509,7 +509,7 @@
     "2. La qualite du prompt LLM influence directement la coherence de la video finale\n",
     "3. Un bon script equilibre la duree des narrations avec le temps d'affichage des visuels\n",
     "\n",
-    "## Etape 2 : Generation des images de chaque scene\n",
+    "## 2. Generation des images de chaque scene\n",
     "\n",
     "A partir des descriptions visuelles du script, nous generons une image\n",
     "representant chaque scene. En production, on utiliserait DALL-E 3 ou\n",
@@ -620,7 +620,7 @@
     "tags": []
    },
    "source": [
-    "## Etape 3 : Animation des images\n",
+    "## 3. Animation des images\n",
     "\n",
     "Chaque image statique est transformee en sequence animee avec un mouvement\n",
     "de camera cinematographique : zoom avant/arriere, panoramique gauche/droite.\n",
@@ -739,7 +739,7 @@
     "tags": []
    },
    "source": [
-    "## Etape 4 : Generation de la narration TTS\n",
+    "## 4. Generation de la narration TTS\n",
     "\n",
     "La narration vocale est generee a partir du texte de chaque scene avec OpenAI TTS.\n",
     "En mode demonstration, nous generons un signal audio synthetique (ton sinusoidal)\n",
@@ -849,7 +849,7 @@
     "tags": []
    },
    "source": [
-    "## Etape 5 : Sous-titres et assemblage final\n",
+    "## 5. Sous-titres et assemblage final\n",
     "\n",
     "Les sous-titres sont generes a partir du texte de narration avec un timing\n",
     "synchronise sur chaque scene. L'assemblage final combine video + audio + sous-titres\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **1er notebook de la famille GenAI/Video** (1/1 — seul Video flagged).

## Changement (1 fichier, +5/-5)

**`Video/04-Applications/04-4-Production-Video-Pipeline.ipynb`** cells 6/8/10/12/14 — 5 flags HINT-AS-HEADING :

\`\`\`diff
- ## Etape 1 : Generation du script video avec LLM
+ ## 1. Generation du script video avec LLM
- ## Etape 2 : Generation des images de chaque scene
+ ## 2. Generation des images de chaque scene
- ## Etape 3 : Animation des images
+ ## 3. Animation des images
- ## Etape 4 : Generation de la narration TTS
+ ## 4. Generation de la narration TTS
- ## Etape 5 : Sous-titres et assemblage final
+ ## 5. Sous-titres et assemblage final
```

## Décision éditoriale (jugement, pas pattern mécanique)

Contrairement aux `#### Etape N` H4 de l'Audio (#4691 etc.) qui étaient des **sous-étapes procédurales** dans une cellule d'exercice, ces 5 `## Etape N : <title>` sont des **titres de section H2** — même niveau que `Objectifs` / `Recapitulatif` / `Exercice` — elles constituent le **flux principal** du notebook (les 5 stages du pipeline de production vidéo).

La conversion canonique §1.2 (`**Etape N —**` gras inline) cible les **asides courts**. L'appliquer ici **détruirait les 5 sections** du notebook (5 titres H2 → 5 lignes gras suivies de prose) = dégradation structurelle, pire que le flag (cf. validation tip directive : « aucun aside n'est plus gros qu'une section » — ici les « Etape » *sont* les sections).

**Fix choisi** : garder le statut H2 de section, remplacer le préfixe aside « Etape N : » par une numérotation non-déclencheuse `## N.`. Titres descriptifs **inchangés mot pour mot**. Le scanner `HINT_RE` ne matche plus (plus de `etape`), la structure H2 est préservée, la numérotation 1-5 du pipeline est conservée.

## Conformité

- **Markdown-only** : 5 cellules markdown, 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé) — élément modifié in-place
- **EOF/line-endings préservés** : LF, pas de trailing newline après `}` (byte-identique à l'original hors les 5 lignes)
- **Rescan post-fix** : `scan_md_hierarchy.py 04-4` → 0/1 flagged ✓

## Scope

\`See #3966\`. **GenAI/Video = DRAINED** (1/1). Reste GenAI : CaseStudies (3 notebooks). 1 fichier = atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>