### PR TITLE
docs(casestudies): intégrer SmartGrid-Energy (3e projet) dans la prose du README

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -138,11 +138,11 @@ Cette série consolide cinq concepts qui reviennent dans tous les systèmes IA a
 
 | Concept | Définition | Manifestation dans CaseStudies | Cours connexes |
 |---------|------------|--------------------------------|----------------|
-| **Architecture hybride** | Pipeline combinant techniques symboliques et statistiques | Diagnostic : A* + GA + Z3 / OncoPlan : Ontologie + CSP + Pyro | [SymbolicAI](../SymbolicAI/README.md), [Probas](../Probas/README.md) |
-| **Jumeau numérique** | Modèle logiciel d'un objet/personne réagissant à des interventions | Modèle patient (état, paramètres bio, réponse au traitement) | [RL](../RL/README.md), [Probas](../Probas/README.md) |
+| **Architecture hybride** | Pipeline combinant techniques symboliques et statistiques | Diagnostic : A* + GA + Z3 / OncoPlan : Ontologie + CSP + Pyro / SmartGrid : CP-SAT + Bayésien + multi-objectif | [SymbolicAI](../SymbolicAI/README.md), [Probas](../Probas/README.md) |
+| **Jumeau numérique** | Modèle logiciel d'un objet/personne/système réagissant à des interventions | Modèle patient (état, paramètres bio, réponse au traitement) / réseau électrique (charge, pannes) | [RL](../RL/README.md), [Probas](../Probas/README.md) |
 | **Knowledge engineering** | Formalisation explicite des connaissances métier en classes/règles | Ontologie oncologique, règles de diagnostic | [SemanticWeb](../SymbolicAI/SemanticWeb/README.md) |
 | **Inférence sous contraintes** | Résolution conjointe d'un problème avec contraintes dures et incertitudes | OncoPlan : calendrier valide ET probable | [Search](../Search/README.md), [SymbolicAI/Tweety](../SymbolicAI/Tweety/README.md) |
-| **Décision sous incertitude** | Choisir entre options avec résultats probabilistes et regret asymétrique | OncoPlan : adapter ou non un protocole | [Probas](../Probas/README.md), [GameTheory](../GameTheory/README.md) |
+| **Décision sous incertitude** | Choisir entre options avec résultats probabilistes et regret asymétrique | OncoPlan : adapter ou non un protocole / SmartGrid : dispatch sous risque de panne | [Probas](../Probas/README.md), [GameTheory](../GameTheory/README.md) |
 
 Ces concepts ne sont pas exclusifs au domaine médical : on les retrouve à l'identique en **finance algorithmique** (jumeau de marché + contraintes réglementaires + signaux probabilistes), **logistique** (jumeau de flotte + planification + prévisions) et **maintenance prédictive** (jumeau équipement + règles métier + Bayésien). Le choix du médical est pédagogique : domaine riche en contraintes formelles et en incertitude irréductible.
 
@@ -210,7 +210,7 @@ Dépendances principales : numpy, pandas, matplotlib, seaborn, z3-solver, pyro-p
 
 ### Faut-il avoir suivi toutes les séries avant de commencer les études de cas ?
 
-Non, mais les prérequis varient par projet. Le **Diagnostic Médical** nécessite d'avoir vu Search Part 1 (recherche informée) et Search Part 2 (CSP/Z3). L'**Oncology Planning** nécessite Probas (inférence bayésienne) et idéalement Planners (CP-SAT). Chaque projet indique les prérequis spécifiques dans sa section. Commencez par le projet dont vous maîtrisez les prérequis.
+Non, mais les prérequis varient par projet. Le **Diagnostic Médical** nécessite d'avoir vu Search Part 1 (recherche informée) et Search Part 2 (CSP/Z3). L'**Oncology Planning** nécessite Probas (inférence bayésienne) et idéalement Planners (CP-SAT). Le **SmartGrid Energy** nécessite Planners (CP-SAT / OR-Tools) et Probas (inférence bayésienne du risque de panne). Chaque projet indique les prérequis spécifiques dans sa section. Commencez par le projet dont vous maîtrisez les prérequis.
 
 ### Qu'est-ce qu'un jumeau numérique patient ?
 

--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -11,7 +11,7 @@ maturity: BETA=2, PRODUCTION=2
 
 Études de cas interdisciplinaires combinant plusieurs domaines de l'IA dans des projets appliqués.
 
-La force des études de cas réside dans leur capacité à **fusionner les techniques apprises en silos** : un solveur SMT (Search), un algorithme génétique (Sudoku), une ontologie OWL (SemanticWeb) et un modèle bayésien (Probas) ne valent pas grand chose isolément face à une question réelle. C'est leur combinaison, orchestrée autour d'un problème métier (diagnostic médical, protocole oncologique), qui transforme un catalogue d'outils en **système décisionnel cohérent**. Les deux projets de cette série illustrent ce passage : chacun mobilise 3 à 4 paradigmes IA différents qui se renforcent mutuellement plutôt que de se concurrencer.
+La force des études de cas réside dans leur capacité à **fusionner les techniques apprises en silos** : un solveur SMT (Search), un algorithme génétique (Sudoku), une ontologie OWL (SemanticWeb) et un modèle bayésien (Probas) ne valent pas grand chose isolément face à une question réelle. C'est leur combinaison, orchestrée autour d'un problème métier (diagnostic médical, protocole oncologique, dispatch énergétique), qui transforme un catalogue d'outils en **système décisionnel cohérent**. Les trois projets de cette série illustrent ce passage : chacun mobilise 3 à 4 paradigmes IA différents qui se renforcent mutuellement plutôt que de se concurrencer.
 
 ## À qui s'adresse cette série
 
@@ -56,7 +56,7 @@ flowchart TD
 
 ### Le pattern "twin numérique"
 
-Les deux projets reposent sur un **modèle de patient simulé** : un objet logiciel qui représente l'état clinique (symptômes, antécédents, paramètres biologiques) et réagit à des interventions (diagnostic proposé, traitement appliqué). Ce pattern, appelé **jumeau numérique** (digital twin), est devenu central en santé numérique, en industrie 4.0 et en simulation environnementale. L'apprendre sur 10 patients diabétiques (Diagnostic-Medical) ou un cas oncologique (Oncology-Planning) prépare directement aux applications professionnelles.
+Les trois projets reposent sur un **modèle simulé** : un objet logiciel qui représente l'état d'un système — état clinique du patient ou réseau électrique — et réagit à des interventions (diagnostic proposé, traitement appliqué, dispatch injecté). Ce pattern, appelé **jumeau numérique** (digital twin), est devenu central en santé numérique, en industrie 4.0 et en simulation environnementale. L'apprendre sur 10 patients diabétiques (Diagnostic-Medical), un cas oncologique (Oncology-Planning) ou un réseau électrique sous incertitude (SmartGrid-Energy) prépare directement aux applications professionnelles.
 
 ## Structure
 
@@ -178,7 +178,7 @@ Ces dimensions sont abordées en survol dans les notebooks mais méritent un mod
 
 ## Conclusion
 
-Cette série se veut un **capstone intégré** : le moment où les techniques apprises en silo au fil du cursus — la recherche heuristique de la série Search, les contraintes formelles de SymbolicAI, l'inférence bayésienne de Probas — cessent d'être des objets d'étude isolés pour devenir les couches d'un même système décisionnel. Les deux projets l'illustrent sous deux angles complémentaires : le **Diagnostic Médical** comme problème de *classification* (recherche dans l'espace des diagnostics + validation par contraintes Z3), l'**Oncology Planning** comme problème d'*optimisation* (planification CP-SAT + modèle probabiliste de réponse patient).
+Cette série se veut un **capstone intégré** : le moment où les techniques apprises en silo au fil du cursus — la recherche heuristique de la série Search, les contraintes formelles de SymbolicAI, l'inférence bayésienne de Probas — cessent d'être des objets d'étude isolés pour devenir les couches d'un même système décisionnel. Les trois projets l'illustrent sous trois angles complémentaires : le **Diagnostic Médical** comme problème de *classification* (recherche dans l'espace des diagnostics + validation par contraintes Z3), l'**Oncology Planning** comme problème d'*optimisation* (planification CP-SAT + modèle probabiliste de réponse patient), et le **SmartGrid Energy** comme problème de *décision multi-objectif sous incertitude* (dispatch CP-SAT + modèle bayésien du risque de panne).
 
 ### Ce que vous avez appris
 


### PR DESCRIPTION
## Contexte

Quand SmartGrid-Energy a été ajouté à la série CaseStudies (#4728 solver + #4731 student template, mergés `02aab067f`), l'arbre et la section projet du `CaseStudies/README.md` ont été mis à jour, mais la **prose narrative** continuait de décrire la série comme « deux projets » en omettant SmartGrid de l'arc pédagogique.

See #3973 — fraîcheur README (feuilles ascendantes). PR transverse (partition .NET mature-saturée ce cycle ; CaseStudies est famille po-2025 mais po-2025 est sur Tweety #4667 et CaseStudies est « COMPLETE », zéro collision active).

## Drift corrigé (firsthand, 1 fichier 1 thème)

| Endroit | Avant | Après |
|---------|-------|-------|
| Intro (L14) | « deux projets », exemples métier (diagnostic, oncologie) | « trois projets » + dispatch énergétique |
| Twin numérique (L59) | « modèle de patient simulé » | « modèle simulé » (patient **ou** réseau électrique) + exemple SmartGrid |
| Conclusion (L181) | « deux projets, deux angles » | « trois projets, trois angles » + SmartGrid (décision multi-objectif sous incertitude) |
| Table Concepts (L141/142/145) | manifestations Diagnostic + OncoPlan seules | + manifestations SmartGrid (CP-SAT/Bayésien, jumeau réseau, dispatch sous risque) |
| FAQ prérequis (L213) | prérequis Diagnostic + OncoPlan seuls | + prérequis SmartGrid (Planners CP-SAT + Probas) |

**Nuance respectée** (L59) : SmartGrid utilise un jumeau numérique de **réseau électrique**, pas un patient — un remplace aveugle « deux → trois » y aurait été faux. La généralisation « modèle simulé » préserve les spécificités patient (Diagnostic/OncoPlan) tout en couvrant la grille.

## Validations

- **Prose-only** : aucune sortie de cellule touchée → exception C.2 markdown-only (pas de re-exec).
- **CATALOG-STATUS marker byte-identical** (`pedagogical_count: 4` inchangé) → catalog-drift CI guérit `4 → 6` + ajoute `SmartGrid-Energy=2` au breakdown (règle catalog-pr-hygiene HARD 1 — jamais régénérer le catalogue sur une branche).
- 0 « deux projets » résiduel (vérifié `grep`), 3 « trois projets ».
- Références « deux » résiduelles (L89/98/107 « 2 notebooks », L229 « deux paradigmes » classification vs optimisation) = correctes, pas du drift (compte par-projet / contraste de paradigme).
- Diff : 1 fichier, 7 lignes (`+7 -7`).

## Note review (§E)

PR docs-only petite mais **cohérente** (1 fichier, 1 thème : intégration SmartGrid dans la prose), pas un fix trivial type typo. Si ai-01 applique §E (< 20 lignes) et préfère grouper/différer, je défère sans objection — c'est un grain transverse depuis une partition .NET saturée, pas un blocker.

See #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)