### PR TITLE
fix(links): repair inbound refs broken by Infer restructure (#4737)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -347,7 +347,7 @@ les arcs entrants de `X`, brisant les chemins de confusion — de sorte que
 | Paradigme | Notebook | Instanciation de `do(·)` | Résultat-signature |
 |-----------|----------|---------------------------|--------------------|
 | **Symbolique** (logique propositionnelle, Java/Tweety) | [Tweety-11-Causal](../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | `scm.intervene(p, b)` → nouveau SCM dont l'équation de `p` devient une constante | `P(rain\|drops)=True ≠ P(rain\|do(drops))=False` (baromètre) |
-| **Bayésien par message passing** (Infer.NET, EP/VMP — Gibbs disponible) | [Infer-22](../Probas/Infer/Infer-22-Causal-Inference.ipynb) | mutilation de graphe `Variable.Bernoulli(1.0)` ; backdoor / front-door | paradoxe de Simpson résolu, identifiabilité par ajustement |
+| **Bayésien par message passing** (Infer.NET, EP/VMP — Gibbs disponible) | [Infer-14](../Probas/Infer/Infer-14-Causal-Inference.ipynb) | mutilation de graphe `Variable.Bernoulli(1.0)` ; backdoor / front-door | paradoxe de Simpson résolu, identifiabilité par ajustement |
 | **Bayésien MCMC** (PyMC) | [PyMC-22](../Probas/PyMC/PyMC-22-Causal-Inference.ipynb) | opérateur natif `pm.do(model, {X:x})` ; backdoor / front-door | contrefactuel par abduction (postérieur sur les exogènes) |
 | **Théorie de l'information / émergence** (ICT) | [ICT-5-CausalEmergence](ICT-Series/ICT-5-CausalEmergence.ipynb) | distribution d'intervention `p(C)` **uniforme** sur les états = `do(X_t = x)` appliqué à tout le micro-état | quelle **échelle** « fait » le plus de travail causal (EI / CP) |
 
@@ -364,7 +364,7 @@ causal que le micro — l'`effectiveness` monte sous coarse-graining.
 
 **Parcours de lecture conseillé** : commencer par le **symbolique qualitatif**
 ([Tweety-11](../SymbolicAI/Tweety/Tweety-11-Causal.ipynb)) pour *voir* `observe` vs `do` sans
-nombres ; passer au **quantitatif distributionnel** ([Infer-22](../Probas/Infer/Infer-22-Causal-Inference.ipynb)
+nombres ; passer au **quantitatif distributionnel** ([Infer-14](../Probas/Infer/Infer-14-Causal-Inference.ipynb)
 message passing, [PyMC-22](../Probas/PyMC/PyMC-22-Causal-Inference.ipynb) MCMC) pour *calculer* les effets
 et lever le paradoxe de Simpson ; finir par l'**information-théorique**
 ([ICT-5](ICT-Series/ICT-5-CausalEmergence.ipynb)) où le même `do` mesure le travail causal **à travers les

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Infer/README.md
@@ -10,7 +10,7 @@ Arc autonome de **théorie de la décision bayésienne** en Infer.NET : 10 noteb
 
 ## Pourquoi un arc autonome
 
-Jusqu'à la restructure (#4725), la théorie de la décision était imbriquée dans le corpus bayésien Infer (notebooks 14-21), ce qui masquait la **dualité des deux fils** : *modéliser l'incertitude* (inférence bayésienne) vs *décider face à l'incertitude* (théorie de la décision). L'extraction dans [`DecisionTheory/Infer/`](Infer/) rend ces deux arcs **physiquement indépendants** tout en préservant le continuum pédagogique (le fil décision s'appuie sur les posteriors du corpus bayésien). Le lake [`decision_theory_lean`](../../decision_theory_lean/), à la **racine de la série Probas**, reste visible des deux pistes (Infer.NET et PyMC).
+Jusqu'à la restructure (#4725), la théorie de la décision était imbriquée dans le corpus bayésien Infer (notebooks 14-21), ce qui masquait la **dualité des deux fils** : *modéliser l'incertitude* (inférence bayésienne) vs *décider face à l'incertitude* (théorie de la décision). L'extraction dans [`DecisionTheory/Infer/`](./) rend ces deux arcs **physiquement indépendants** tout en préservant le continuum pédagogique (le fil décision s'appuie sur les posteriors du corpus bayésien). Le lake [`decision_theory_lean`](../../decision_theory_lean/), à la **racine de la série Probas**, reste visible des deux pistes (Infer.NET et PyMC).
 
 ## Vue d'ensemble
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -200,7 +200,7 @@ La signature du do-calculus — **P(rain | drops) ≠ P(rain | do(drops))** — 
 
 Tweety raisonne sur le do-calculus en **logique propositionnelle** : `do(X)` y est *qualitatif* — un atome forcé, un SCM réécrit, une réponse vrai/faux. C'est idéal pour *voir* la différence entre `observe` et `do` sans nombres, mais Tweety **ne chiffre pas** un effet causal ni ne lève quantitativement un paradoxe de Simpson. Les séries probabilistes du dépôt reprennent **exactement ce notebook** avec des distributions :
 
-- [Infer-22-Causal-Inference](../../Probas/Infer/Infer-22-Causal-Inference.ipynb) — le **jumeau distributionnel par message passing** : `P(Y|do(X))` calculé par mutilation de graphe en Infer.NET (EP/VMP), ajustements backdoor / front-door, paradoxe de Simpson résolu numériquement.
+- [Infer-14-Causal-Inference](../../Probas/Infer/Infer-14-Causal-Inference.ipynb) — le **jumeau distributionnel par message passing** : `P(Y|do(X))` calculé par mutilation de graphe en Infer.NET (EP/VMP), ajustements backdoor / front-door, paradoxe de Simpson résolu numériquement.
 - [PyMC-22-Causal-Inference](../../Probas/PyMC/PyMC-22-Causal-Inference.ipynb) — la version **MCMC** avec l'opérateur natif `pm.do` et le contrefactuel par abduction.
 - [ICT-5-CausalEmergence](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb) — le même `do` monte d'un cran : à **quelle échelle** un système fait-il le plus de travail causal ?
 


### PR DESCRIPTION
## Contexte

#4737 (mergé) a renuméroté `Infer-22-Causal-Inference` → `Infer-14-Causal-Inference` (gap-closure bayésien) mais **4 liens n'ont pas été mis à jour** — hors du périmètre intra-Probas vérifié par le worker :

| Fichier | Ligne | Avant | Après |
|---------|-------|-------|-------|
| `IIT/README.md` | 350, 367 | `[Infer-22](.../Infer-22-Causal-Inference.ipynb)` | `[Infer-14](.../Infer-14-Causal-Inference.ipynb)` |
| `SymbolicAI/Tweety/README.md` | 203 | `Infer-22-Causal-Inference` | `Infer-14-Causal-Inference` |
| `Probas/DecisionTheory/Infer/README.md` | 13 | self-link `(Infer/)` | `(./)` |

## Vérification

`python scripts/check_docs_links.py --check` : **6 liens cassés → 2**. Les 2 restants (`MetaGeneticSharp/GeneticSharp/README.md` L96 doubled-path + L170 `BlacorApp`) sont du **base-drift pré-existant** dans le sous-module MetaGeneticSharp (sans rapport, dispatché à la lane MGS).

Les refs `PyMC-22` sont **laissées intactes** (la restructure PyMC est le cycle #4725 séparé, non encore livré). Préserve le pont causal cross-séries ([[ict-causal-bridge-directive]]).

## Nature

Markdown-only (3 READMEs), aucune cellule / sortie touchée.

See #4725