### PR TITLE
fix(genai-casestudies): reposition H1 title to first markdown cell, recipe_maker (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
@@ -42,6 +42,7 @@
     "tags": []
    },
    "source": [
+    "# Générateur de Recettes PDF\n",
     "## Introduction - receipe maker\n",
     "\n",
     "**Navigation** : [Index](../README.md)\n",
@@ -65,7 +66,6 @@
     "tags": []
    },
    "source": [
-    "# Générateur de Recettes PDF\n",
     "\n",
     "Ce notebook orchestre une collaboration multi-agents pour :\n",
     "1. Collecter des contraintes utilisateur\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **1er notebook CaseStudies** (1/3). Famille CaseStudies = derniers notebooks GenAI restants pour #3966.

## Changement (1 fichier, +1/-1)

**`CaseStudies/Recipe-Maker/receipe_maker.ipynb`** — 1 flag H1-DEEP.

Le H1 titre `# Générateur de Recettes PDF` était en **cell 2** (3e cellule), après une cellule code `# Parameters` (cell 0) et une cellule template `## Introduction - receipe maker` (cell 1). Le scanner flag H1-DEEP car le H1 n'est pas dans la première cellule markdown.

**Fix** : déplacer la ligne H1 vers la tête de **cell 1** (première cellule markdown). L'Introduction H2 et tout le contenu étudiant sont préservés mot pour mot. Cell 2 garde sa prose descriptive sans le H1 dupliqué.

## Conformité

- **Markdown-only** : cellules markdown, 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé) — H1 déplacé entre éléments de 2 cellules
- **EOF/line-endings préservés** : LF + trailing newline (byte-identique à l'original hors la ligne déplacée)
- **Pattern canonique** : cf #4722 (3_Structured_Outputs), #4732 (2_PromptEngineering) — repositionnement H1
- **Rescan post-fix** : `scan_md_hierarchy.py receipe_maker` → 0/1 flagged ✓

## Scope

\`See #3966\`. Atomique : 1 fichier case study. Reste CaseStudies : barbie-schreck (1 H1-DEEP même pattern), medical_chatbot (MULTI-H1, pattern différent).

Co-Authored-By: Claude-Code <noreply@anthropic.com>