### PR TITLE
docs(sudoku): #3968 normalize HINT-AS-HEADING "Indice" in Sudoku-15-Infer-Python

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
@@ -1708,7 +1708,7 @@
     "2. Combien de cellules la phase probabiliste parvient-elle a fixer correctement ?\n",
     "3. Comparer le temps total avec le solveur iteratif (`IterativeProbabilisticSolverPy`)\n",
     "\n",
-    "## Indice\n",
+    "**Indice**\n",
     "\n",
     "Pour la phase probabiliste, utilisez `np.max(probs[idx])` comme mesure de confiance. Pour le backtracking, vous pouvez reutiliser la logique de `_backtrack` du notebook Sudoku-1-Backtracking-Python."
    ]


### PR DESCRIPTION
## Contexte

Campagne de normalisation de la hiérarchie typographique (#3968, EPIC #3966). `Sudoku-15-Infer-Python.ipynb` présentait un aside `## Indice` (cell 31) flaggé `HINT-AS-HEADING`.

## Changement

| Cellule | Avant | Après |
|---------|-------|-------|
| cell 31 (exercice) | `## Indice` | `**Indice**` |

**Pattern canonique** (même fix que po-2023 #4712 / #4726 / #4732 / #4735) : les titres d'aside (Note/Indice/Rappel/Étape) polluent la hiérarchie du document et doivent être des labels inline bold, pas des ancres de section.

**Note sur le pluriel** : cell 31 `## Indice` (singulier) = l'aside flaggé. Les `### Indices` (pluriel) des cells 16/23 ne sont **PAS** touchés — `HINT_RE` cible `indice\b` qui exclut le pluriel ; ce sont des en-têtes de section « Indices » légitimes.

## Vérifications

- `scan_md_hierarchy.py` : **0/1 flaggé** (était `HINT-AS-HEADING "Indice"`)
- Diff : **1 ins / 1 del**, ligne source markdown uniquement → **exception C.2**, pas de re-execution
- Cellules de code et outputs **non touchées** (diff vérifié)
- `nbformat 4.5` valide, 0 erreur d'output, ids/metadata préservés
- `COURSE_CATALOG.generated.{json,md}` byte-identiques à `origin/main`

## Scope

Grain **hors-QC diversifié** (steer ai-01 : cap QC saturé). Famille Sudoku non-drainée pour #3968 (0 collision : 0 PR ouverte, dernier commit #3415 mergé). Contribution à #3968, ne clôt pas l'Epic.

See #3968
Part of #3966