### PR TITLE
fix(genai-casestudies): demote section heading H1->H2, medical_chatbot (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
@@ -566,7 +566,7 @@
     "tags": []
    },
    "source": [
-    "# Ajout des plugins pour chaque agent"
+    "## Ajout des plugins pour chaque agent"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **3e et dernier notebook CaseStudies** (3/3). → **CaseStudies DRAINED**.

## Changement (1 fichier, +1/-1)

**`CaseStudies/Medical-Chatbot/medical_chatbot.ipynb`** — 2 flags (MULTI-H1 + H1-DEEP), même racine.

Le notebook avait **2 H1** :
- cell 1 : `# Docteur vs ChatGPT : Chatbot medical multi-agent` — **titre légitime**, bien placé en première cellule markdown (OK, conservé)
- cell 18 : `# Ajout des plugins pour chaque agent` — **section parasite** (entre H2 « Création du Kernel » cell 16 et H2 « Prompts système » cell 20), mal nivelée en H1

**Fix** : démote cell 18 `# ` → `## ` (H1 → H2). Il reste un seul H1 (le titre cell 1) → **MULTI-H1 cleared** + **H1-DEEP cell 18 cleared** d'un seul edit. Contenu préservé mot pour mot, seul le niveau du heading change.

## Conformité

- **Markdown-only** : 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception)
- **Type source préservé** : `list` (inchangé)
- **EOF/line-endings préservés** : LF + trailing newline (byte-identique à l'original hors la ligne)
- **Rescan post-fix** : `scan_md_hierarchy.py medical_chatbot` → 0/1 flagged ✓

## Scope

\`See #3966\`. Atomique : 1 fichier case study.

Co-Authored-By: Claude-Code <noreply@anthropic.com>