### PR TITLE
docs(search): #3968 normalize HINT-AS-HEADING "Rappel" in MGS-19 (rename, preserve H2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Rappel — le critère de Metropolis et son double habitat\n",
+    "## Le critère de Metropolis et son double habitat\n",
     "\n",
     "Le critère de Metropolis (Metropolis et al., 1953 ; Kirkpatrick, Gelatt & Vecchi, 1983) accepte un voisin de fitness $\\Delta = f_{\\text{enfant}} - f_{\\text{parent}} < 0$ (plus mauvais) avec probabilité $\\exp(\\Delta / T_k)$ ; un voisin meilleur ($\\Delta \\geq 0$) est toujours accepté. La température suit un schedule géométrique $T_k = T_0 \\, \\alpha^k$ : chaud au départ (les montées passent), gelé à la fin (seules les améliorations passent — limite gloutonne).\n",
     "\n",


### PR DESCRIPTION
## Contexte

Campagne de normalisation #3968 (EPIC #3966). `MGS-19-MetropolisReinsertion.ipynb` présentait un `## Rappel — le critère de Metropolis et son double habitat` (cell 1) flaggé `HINT-AS-HEADING` (le scanner cible `rappel` comme mot-clé d'aside).

## Changement

| Cellule | Avant | Après |
|---------|-------|-------|
| cell 1 | `## Rappel — le critère de Metropolis et son double habitat` | `## Le critère de Metropolis et son double habitat` |

## Décision G.9 (jugement, non mécanique)

Contrairement à un petit aside (`Note:`, `Indice:`), ce `## Rappel` est une **vraie section H2 peer** — au même niveau que `## Méthode`, `## Partie A/B/C/D`, `## Synthèse` — portant le setup théorique (critère de Metropolis, citant Metropolis et al. 1953). Le **demote mécanique** vers `**Rappel**` (pattern po-2023) **sortait une section substantielle du TOC** = nuisible.

**Fix adopté = renommage** : on drop le mot-clé HINT (`Rappel`) tout en préservant le H2 de section. Le titre devient plus direct (`## Le critère de Metropolis et son double habitat`), la section reste dans l'outline, et le scanner clear. C'est la normalisation #3968 dans son esprit (les hints ne doivent pas être des titres), appliquée avec discernement plutôt qu'à l'aveugle.

## Vérifications

- `scan_md_hierarchy.py` : **0/1 flaggé** (était `HINT-AS-HEADING "Rappel"`)
- Hiérarchie de titres **préservée** : H2 peer aux côtés de Méthode / Partie A-D / Synthèse (voir body)
- Diff : **1 ins / 1 del**, ligne source markdown uniquement → **exception C.2**, pas de re-execution
- Cellules de code et outputs **non touchées** (vérifié)
- `nbformat 4.5` valide, 0 erreur d'output, ids/metadata préservés
- `COURSE_CATALOG.generated.{json,md}` byte-identiques à `origin/main`

## Scope

Grain **hors-QC diversifié** (steer ai-01 : cap QC saturé). Famille Search/Metaheuristics (sphère .NET), non-drainée pour #3968 (0 collision : dernier commit #4683). Contribution à #3968, ne clôt pas l'Epic.

See #3968
Part of #3966