### PR TITLE
fix(genai-posttraining): demote 'Rappel' aside H3->bold-inline, PT-03 DPO (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "## 1. Le loss DPO — de RLHF a l'optimisation directe\n",
     "\n",
-    "### Rappel RLHF classique (3 etapes)\n",
+    "**Rappel — RLHF classique (3 etapes)**\n",
     "\n",
     "| Etape | Objectif | Cout |\n",
     "|-------|----------|------|\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. Notebook PostTraining (1/1 PostTraining flaggé).

## Changement (1 fichier, +1/-1)

**`PostTraining/PT_03_dpo_direct_preference.ipynb`** cell 1 — 1 flag HINT-AS-HEADING :

\`\`\`diff
- ### Rappel RLHF classique (3 etapes)
+ **Rappel — RLHF classique (3 etapes)**
```

`### Rappel RLHF classique (3 etapes)` est un aside de rappel (le scanner `HINT_RE` matche `rappel` à tout niveau H1-H6), suivi d'un tableau structuré 3 lignes (SFT / Reward Model / PPO). Conversion en **bold inline** comme block-header du tableau — pattern canonique pour aside + contenu structuré (cf #4712 Audio 02-6 « Note technique »). Le tableau et tout le contenu sont préservés mot pour mot.

## Conformité

- **Markdown-only** : 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception)
- **Type source préservé** : `list` (inchangé) — `src[2]` modifié in-place
- **EOF/line-endings préservés** : LF + trailing newline (byte-identique à l'original)
- **Rescan post-fix** : `scan_md_hierarchy.py PT_03` → 0/1 flagged ✓

## Scope

\`See #3966\`. Atomique : 1 fichier. → **PostTraining DRAINED**.

Co-Authored-By: Claude-Code <noreply@anthropic.com>