### PR TITLE
fix(genai-semantickernel): reposition H1 title to first markdown cell, Createur de mail (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/Créateur de mail personnalisé.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/Créateur de mail personnalisé.ipynb
@@ -42,6 +42,7 @@
     "tags": []
    },
    "source": [
+    "# Projet Createur de Mail personnalise\n",
     "**Navigation** : [Index](README.md)\n",
     "\n",
     "## Introduction - Créateur de mail personnalisé\n",
@@ -66,7 +67,6 @@
     "tags": []
    },
    "source": [
-    "# Projet Createur de Mail personnalise\n",
     "\n",
     "Ce notebook illustre un workflow multi-agents pour creer des emails personnalises. Deux agents collaborent :\n",
     "- **InputCollector** : Collecte les informations necessaires via des questions interactives\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. Notebook SemanticKernel (1/1 SemanticKernel flaggé). **Dernier notebook GenAI** restant → **#3966 GenAI = QUASI-DRAINED** après cette PR.

## Changement (1 fichier, +1/-1)

**`SemanticKernel/Créateur de mail personnalisé.ipynb`** — 1 flag H1-DEEP.

Le H1 titre `# Projet Createur de Mail personnalise` était en **cell 2**, après une cellule code `# Parameters` (cell 0) et une cellule navigation + `## Introduction` (cell 1).

**Fix** : déplacer la ligne H1 vers la tête de **cell 1** (première cellule markdown). Navigation, Introduction H2 et contenu étudiant préservés mot pour mot.

## Conformité

- **Markdown-only** : 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception)
- **Type source préservé** : `list` (inchangé)
- **EOF/line-endings préservés** : LF + trailing newline (byte-identique à l'original hors la ligne déplacée)
- **Pattern canonique** : cf #4744 (recipe_maker), #4746 (barbie-schreck), #4722, #4732
- **Rescan post-fix** : 0/1 flagged ✓

## Scope

\`See #3966\`. Atomique : 1 fichier.

Co-Authored-By: Claude-Code <noreply@anthropic.com>