### PR TITLE
feat(hashlife): hashlifeResultAux_succ_node (non-private) — LHS-unlock for p4_succ_membership (sorry 4->4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1053,6 +1053,54 @@ theorem mem_toGrid_node {nw ne sw se : MacroCell} {r0 c0 : Int} {p : Int × Int}
   simp only [toCellsAux, List.mem_append]
   tauto
 
+/-- **G3 LHS-unlock infrastructure.** The single-step iota reduction of
+    `hashlifeResultAux` at the well-formed (`fuel + 1`, 16-grandchild node) arm.
+
+    `hashlifeResultAux`'s definition uses a pattern alias `c@(node ...)`, whose
+    alias fvar blocks `simp`/`unfold` syntactic rewriting (cf. the
+    `HashlifeMemo` comment). This lemma restates the well-formed arm with
+    explicit patterns and zeta-expanded `let`s, so it IS available for
+    rewriting from this module. It is true by `rfl` (iota + zeta reduction).
+
+    **Why this is the LHS-unlock for `p4_succ_membership`**: the goal's LHS is
+    `p ∈ (hashlifeResultAux (k+2) c).toGrid (2^k, 2^k)`. With `k+2 = (k+1)+1`
+    and `c` destructured via `p4_double_nine_shape`, this lemma rewrites the
+    `hRA` application to the explicit `node out_nw out_ne out_sw out_se` (else
+    branch, level ≥ 3), exposing the `node _ _ _ _` constructor that
+    `mem_toGrid_node` needs. It is the missing link between the LHS and the
+    G3 toGrid decomposition. -/
+theorem hashlifeResultAux_succ_node (fuel : Nat)
+    (a1 a2 a3 a4 b1 b2 b3 b4 c1 c2 c3 c4 d1 d2 d3 d4 : MacroCell) :
+    hashlifeResultAux (fuel + 1)
+      (node (node a1 a2 a3 a4) (node b1 b2 b3 b4)
+            (node c1 c2 c3 c4) (node d1 d2 d3 d4)) =
+    if (node (node a1 a2 a3 a4) (node b1 b2 b3 b4)
+             (node c1 c2 c3 c4) (node d1 d2 d3 d4)).level == 2 then
+      step4x4 (node (node a1 a2 a3 a4) (node b1 b2 b3 b4)
+                    (node c1 c2 c3 c4) (node d1 d2 d3 d4))
+    else
+      node
+        (hashlifeResultAux fuel (node
+          (hashlifeResultAux fuel (node a1 a2 a3 a4))
+          (hashlifeResultAux fuel (node a2 b1 a4 b3))
+          (hashlifeResultAux fuel (node a3 a4 c1 c2))
+          (hashlifeResultAux fuel (node a4 b3 c2 d1))))
+        (hashlifeResultAux fuel (node
+          (hashlifeResultAux fuel (node a2 b1 a4 b3))
+          (hashlifeResultAux fuel (node b1 b2 b3 b4))
+          (hashlifeResultAux fuel (node a4 b3 c2 d1))
+          (hashlifeResultAux fuel (node b3 b4 d1 d2))))
+        (hashlifeResultAux fuel (node
+          (hashlifeResultAux fuel (node a3 a4 c1 c2))
+          (hashlifeResultAux fuel (node a4 b3 c2 d1))
+          (hashlifeResultAux fuel (node c1 c2 c3 c4))
+          (hashlifeResultAux fuel (node c2 d1 c4 d3))))
+        (hashlifeResultAux fuel (node
+          (hashlifeResultAux fuel (node a4 b3 c2 d1))
+          (hashlifeResultAux fuel (node b3 b4 d1 d2))
+          (hashlifeResultAux fuel (node c2 d1 c4 d3))
+          (hashlifeResultAux fuel (node d1 d2 d3 d4)))) := rfl
+
 /-- Membership in a restricted grid: in the grid and inside the window. -/
 theorem mem_restrictGridTo {g : Grid} {lo : Int} {size : Nat} {p : Int × Int} :
     p ∈ restrictGridTo g lo size ↔


### PR DESCRIPTION
## Summary

Sorry-stable infrastructure for lane **#3846** (Conway Hashlife GOL). Re-establishes the single-step iota-reduction lemma for `hashlifeResultAux` as a **non-private** theorem in `HashlifeCorrectness` — it already exists as `private` in `HashlifeMemo` (not imported here), where it works around the pattern-alias `c@(node ...)` that blocks `simp`/`unfold`. This makes it available to the P4.4 assembly. Branched fresh off main (b8c9d3cc8, post #4736 merge).

## The 3 G3 gates now form the full sorry-free path

| Gate | Lemma | PR | Role |
|---|---|---|---|
| G2 | `centralCorrect_mem` | #4583 (merged) | membership via congruence — **crosses** the whnf wall |
| G3 | `mem_toGrid_node` | #4736 (merged) | node `toGrid` decomposition |
| **LHS** | `hashlifeResultAux_succ_node` | **this PR** | expose `node _ _ _ _` constructor (defeating the pattern-alias block) |

## New theorem `hashlifeResultAux_succ_node` (~L1057)

```
hashlifeResultAux (fuel+1) (node(node a1 a2 a3 a4)(node b1 b2 b3 b4)(node c1 c2 c3 c4)(node d1 d2 d3 d4))
  = if (...) .level == 2 then step4x4 ... else node out_nw out_ne out_sw out_se
:= rfl   -- iota + zeta reduction
```

Statement identical to the `HashlifeMemo` private version (re-proven, not duplicated — the private original stays for the memo machinery).

## Why this unlocks the `p4_succ_membership` LHS

The goal LHS is `p ∈ (hRA (k+2) c).toGrid (2^k, 2^k)`. The def's pattern alias blocks direct `simp`/`unfold`. With `k+2 = (k+1)+1` and `c` destructured via `p4_double_nine_shape`, this lemma rewrites the `hRA` application to the explicit `node out_* ` (else branch, level ≥ 3 for `k ≥ 1`), exposing the `node _ _ _ _` constructor that `mem_toGrid_node` needs.

## Why sorry-stable (4→4, not 4→3)

`rfl`-true infrastructure (no `sorryAx`). Does not itself close any sorry — the assembly consumes it. Same shape as the P4.3 gate (c.142 sorry-stable) → consumer (c.143 sorry 5→4). With all three gates now on main, the next cycle can attempt the **offset-matching assembly** (the `out_*` offsets vs `centralCorrect` offsets + ih via opaque binders, c.139 technique) → if it closes, `p4_succ_membership` sorry **4→3** (the real front).

## Lean PR checklist (pr-review-discipline §B)

1. **sorry before/after**: **4 → 4** (token grep, exclude `.lake`). `hashlifeResultAux_succ_node` proven by `rfl` (no "declaration uses sorry" warning).
2. **Lake build SUCCESS**: `lake build Conway.Life.HashlifeCorrectness` → **EXIT 0**.
3. **Proof integrity**: `:= rfl` → **no `sorryAx`**.
4. **No prover Python refactor** — N/A.

## Anti-regression

+48 insertions, 0 deletions. New theorem only; no existing proof touched. Sorry count unchanged.

See #3846

Co-Authored-By: Claude-Code <noreply@anthropic.com>
