### PR TITLE
fix(ml-day2): convert 5 'Étape N' procedural headings to bullet bold-inline, Lab2-RFP (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
@@ -73,7 +73,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 1 : Charger le document d'appel d'offre"
+    "- **Étape 1 :** Charger le document d'appel d'offre\n"
    ]
   },
   {
@@ -128,7 +128,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 2 : Créer une chaîne d'extraction d'informations\n",
+    "- **Étape 2 :** Créer une chaîne d'extraction d'informations\n",
     "\n",
     "Nous allons définir un `PromptTemplate` qui guidera le LLM pour qu'il identifie précisément les points qui nous intéressons.\n",
     "\n",
@@ -216,7 +216,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 3 : Exécuter la chaîne et extraire les points clés"
+    "- **Étape 3 :** Exécuter la chaîne et extraire les points clés\n"
    ]
   },
   {
@@ -280,7 +280,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 4 : Créer une chaîne de génération de proposition"
+    "- **Étape 4 :** Créer une chaîne de génération de proposition\n"
    ]
   },
   {
@@ -352,7 +352,7 @@
     "tags": []
    },
    "source": [
-    "### Etape 5 : Execution de la generation\n",
+    "- **Étape 5 :** Execution de la generation\n",
     "\n",
     "Maintenant que notre chaine de generation est configuree, nous allons l'executer avec les donnees extraites precedemment. Le LLM va synthetiser une proposition structuree en trois volets (approche, technologies, livrables) adaptee aux besoins specifiques du client."
    ]


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **1er notebook ML** (1/6, famille DataScienceWithAgents). Famille ML = terrain Python natif po-2023.

## Changement (1 fichier, +5/-5)

**`ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb`** cells 2/4/6/8/10 — 5 flags HINT-AS-HEADING :

\`\`\`diff
- ### Étape 1 : Charger le document d'appel d'offre
- ### Étape 2 : Créer une chaîne d'extraction d'informations
- ### Étape 3 : Exécuter la chaîne et extraire les points clés
- ### Étape 4 : Créer une chaîne de génération de proposition
- ### Etape 5 : Execution de la generation
+ - **Étape 1 :** Charger le document d'appel d'offre
+ - **Étape 2 :** Créer une chaîne d'extraction d'informations
+ - **Étape 3 :** Exécuter la chaîne et extraire les points clés
+ - **Étape 4 :** Créer une chaîne de génération de proposition
+ - **Étape 5 :** Execution de la generation
```

Les 5 `### Étape N : X` H3 sont des **étiquettes d'étapes procédurales** — chacune précède le cell code qui exécute cette étape du pipeline d'analyse RFP. Ce ne sont pas des titres de section (cell markdown d'une ligne, sans corps). Conversion en liste à puces bold inline (pattern aside-step canonique, cf Audio #4691/#4696/#4698/#4704/#4707/#4709). Titres préservés mot pour mot. 2 cellules sans `\n` final normalisées.

## Conformité

- **Markdown-only** : 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception markdown)
- **Type source préservé** : `list` (inchangé)
- **EOF/line-endings** : LF + trailing newline préservés
- **Rescan post-fix** : `scan_md_hierarchy.py Lab2-RFP` → 0/1 flagged ✓

## Scope

\`See #3966\`. Atomique : 1 fichier lab. Reste ML : 5 labs (Lab3-Lab7), même pattern « Étape N ».

Co-Authored-By: Claude-Code <noreply@anthropic.com>