### PR TITLE
fix(ml-day2): convert 3 'Étape N' H2 headings to bullet bold-inline, Lab3-CV-Screening (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb
@@ -67,7 +67,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 1 : Charger l'Offre et les CVs"
+    "- **Étape 1 :** Charger l'Offre et les CVs\n"
    ]
   },
   {
@@ -159,7 +159,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 2 : Définir l'Agent de Recrutement IA\n",
+    "- **Étape 2 :** Définir l'Agent de Recrutement IA\n",
     "\n",
     "#### Prompt engineering pour l'extraction structurée\n",
     "\n",
@@ -254,7 +254,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 3 : Évaluer les candidats"
+    "- **Étape 3 :** Évaluer les candidats\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **2e notebook ML** (2/6). Même pattern aside-step que #4753 (Lab2-RFP).

## Changement (1 fichier, +3/-3)

**`ML/.../Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb`** cells 2/4/6 — 3 flags HINT-AS-HEADING : `## Étape N : X` H2 → `- **Étape N :** X`. Step labels procéduraux (intro des cells code), pas des sections. L'H4 « #### Prompt engineering » non flaggé est laissé intact.

## Conformité
- Markdown-only, `list` source préservé, LF + trailing newline, rescan 0/1 ✓

## Scope
\`See #3966\`. Atomique. Reste ML : Lab4/Lab5/Lab6/Lab7.

Co-Authored-By: Claude-Code <noreply@anthropic.com>