### PR TITLE
fix(ml-day3): convert 5 'Étape N' H3 headings to bullet bold-inline, Lab4-DataWrangling (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
@@ -71,7 +71,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 1 : Inspection des Données"
+    "- **Étape 1 :** Inspection des Données\n"
    ]
   },
   {
@@ -362,7 +362,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 2 : Nettoyage - Gestion des Valeurs Manquantes"
+    "- **Étape 2 :** Nettoyage - Gestion des Valeurs Manquantes\n"
    ]
   },
   {
@@ -475,7 +475,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 3 : Correction des Types"
+    "- **Étape 3 :** Correction des Types\n"
    ]
   },
   {
@@ -587,7 +587,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 4 : Transformation - Création de Colonnes"
+    "- **Étape 4 :** Transformation - Création de Colonnes\n"
    ]
   },
   {
@@ -731,7 +731,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 5 : Agrégation pour l'Analyse"
+    "- **Étape 5 :** Agrégation pour l'Analyse\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **3e notebook ML** (3/6). Même pattern aside-step que #4753/#4754.

## Changement (1 fichier, +5/-5)

**`ML/.../Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb`** cells 2/9/13/17/19 — 5 flags HINT-AS-HEADING : `### Étape N : X` H3 → `- **Étape N :** X`. Step labels procéduraux du pipeline data wrangling (inspect→clean→types→transform→aggregate).

## Conformité
- Markdown-only, `list` source préservé, LF + trailing newline, rescan 0/1 ✓

## Scope
\`See #3966\`. Atomique. Reste ML : Lab5/Lab6/Lab7.

Co-Authored-By: Claude-Code <noreply@anthropic.com>