### PR TITLE
fix(ml-day3): convert 3 'Étape N' H2 headings to bullet bold-inline, Lab5-Viz-ML (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
@@ -85,7 +85,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 1 : Préparation des Données"
+    "- **Étape 1 :** Préparation des Données\n"
    ]
   },
   {
@@ -255,7 +255,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 2 : Analyse Exploratoire par la Visualisation (EDA)"
+    "- **Étape 2 :** Analyse Exploratoire par la Visualisation (EDA)\n"
    ]
   },
   {
@@ -464,7 +464,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 3 : Introduction au Machine Learning - Classification\n",
+    "- **Étape 3 :** Introduction au Machine Learning - Classification\n",
     "\n",
     "#### Régression logistique\n",
     "\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **4e notebook ML** (4/6). Même pattern aside-step que #4753/#4754/#4755.

## Changement (1 fichier, +3/-3)

**`ML/.../Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb`** cells 3/5/13 — 3 flags HINT-AS-HEADING : `## Étape N : X` H2 → `- **Étape N :** X`. Step labels procéduraux du pipeline viz+ML (prepare→EDA→ML classification).

## Conformité
- Markdown-only, `list` source préservé, LF + trailing newline, rescan 0/1 ✓

## Scope
\`See #3966\`. Atomique. Reste ML : Lab6/Lab7.

Co-Authored-By: Claude-Code <noreply@anthropic.com>