### PR TITLE
fix(ml-day3): convert 4 'Étape N' H2 headings to bullet bold-inline, Lab6-First-Agent (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
@@ -85,7 +85,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 1 : Le \"Cerveau\" - Le LLM"
+    "- **Étape 1 :** Le \"Cerveau\" - Le LLM\n"
    ]
   },
   {
@@ -147,7 +147,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 2 : Les \"Mains\" - Les Outils (Tools)"
+    "- **Étape 2 :** Les \"Mains\" - Les Outils (Tools)\n"
    ]
   },
   {
@@ -214,7 +214,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 3 : Les \"Instructions\" - Le Prompt"
+    "- **Étape 3 :** Les \"Instructions\" - Le Prompt\n"
    ]
   },
   {
@@ -290,7 +290,7 @@
     "tags": []
    },
    "source": [
-    "## Étape 4 : L' \"Orchestrateur\" - L'Agent et son Exécuteur"
+    "- **Étape 4 :** L' \"Orchestrateur\" - L'Agent et son Exécuteur\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **5e notebook ML** (5/6). Même pattern aside-step que #4753/#4754/#4755/#4756.

## Changement (1 fichier, +4/-4)

**`ML/.../Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb`** cells 3/6/9/12 — 4 flags HINT-AS-HEADING : `## Étape N : X` H2 → `- **Étape N :** X`. Step labels procéduraux du build agent (LLM→tools→prompt→orchestrator).

## Conformité
- Markdown-only, `list` source préservé, LF + trailing newline, rescan 0/1 ✓

## Scope
\`See #3966\`. Atomique. Reste ML : Lab7 (dernier).

Co-Authored-By: Claude-Code <noreply@anthropic.com>