### PR TITLE
fix(ml-day3): convert 3 'Étape N' H3 headings to bullet bold-inline, Lab7-Data-Analysis-Agent (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
@@ -66,7 +66,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 1 : Préparation de l'Environnement et des Données"
+    "- **Étape 1 :** Préparation de l'Environnement et des Données\n"
    ]
   },
   {
@@ -276,7 +276,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 2 : Le Cerveau et le nouvel \"Outil\""
+    "- **Étape 2 :** Le Cerveau et le nouvel \"Outil\"\n"
    ]
   },
   {
@@ -343,7 +343,7 @@
     "tags": []
    },
    "source": [
-    "### Étape 3 : Dialoguer avec l'Agent Analyste"
+    "- **Étape 3 :** Dialoguer avec l'Agent Analyste\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. **6e et dernier notebook ML** (6/6). → **ML DRAINED** après merge.

## Changement (1 fichier, +3/-3)

**`ML/.../Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb`** cells 2/6/9 — 3 flags HINT-AS-HEADING : `### Étape N : X` H3 → `- **Étape N :** X`. Step labels procéduraux du pipeline analysis-agent (env+data→brain+tool→dialog).

## Conformité
- Markdown-only, `list` source préservé, LF + trailing newline, rescan 0/1 ✓

## Scope
\`See #3966\`. Atomique. **ML = 6/6 notebooks couverts** (#4753 Lab2, #4754 Lab3, #4755 Lab4, #4756 Lab5, #4757 Lab6, this Lab7).

Co-Authored-By: Claude-Code <noreply@anthropic.com>