### PR TITLE
fix(search): demote 'Rappel' aside H2->bold-inline block-header, MGS-19 (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Rappel — le critère de Metropolis et son double habitat\n",
+    "**Rappel — le critère de Metropolis et son double habitat**\n",
     "\n",
     "Le critère de Metropolis (Metropolis et al., 1953 ; Kirkpatrick, Gelatt & Vecchi, 1983) accepte un voisin de fitness $\\Delta = f_{\\text{enfant}} - f_{\\text{parent}} < 0$ (plus mauvais) avec probabilité $\\exp(\\Delta / T_k)$ ; un voisin meilleur ($\\Delta \\geq 0$) est toujours accepté. La température suit un schedule géométrique $T_k = T_0 \\, \\alpha^k$ : chaud au départ (les montées passent), gelé à la fin (seules les améliorations passent — limite gloutonne).\n",
     "\n",


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. Seul notebook Search flaggé (1/1). → **Search DRAINED** après merge.

## Changement (1 fichier, +1/-1)

**`Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb`** cell 1 — 1 flag HINT-AS-HEADING :

\`\`\`diff
- ## Rappel — le critère de Metropolis et son double habitat
+ **Rappel — le critère de Metropolis et son double habitat**
```

Aside « Rappel » (scanner `HINT_RE` matche `rappel`) suivi de 2 paragraphes de prose substantielle sur le critère de Metropolis. Conversion en **bold inline** comme block-header de la prose — pattern canonique pour aside + contenu structuré (cf #4712 Audio 02-6 « Note technique »+table, #4749 PT_03 « Rappel »+table). Les 2 paragraphes sont préservés mot pour mot.

## Conformité

- **Markdown-only** : 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception)
- **Type source préservé** : `list` (inchangé) — `src[0]` modifié in-place
- **EOF préservé** : ce notebook n'avait **pas** de trailing newline final — byte-identique à l'original (`}` sans `\n`)
- **Rescan post-fix** : 0/1 flagged ✓

## Scope

\`See #3966\`. Atomique : 1 fichier.

Co-Authored-By: Claude-Code <noreply@anthropic.com>