### PR TITLE
fix(sudoku): demote 'Indice' aside H2->bold inline, Sudoku-15 (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
@@ -1708,7 +1708,7 @@
     "2. Combien de cellules la phase probabiliste parvient-elle a fixer correctement ?\n",
     "3. Comparer le temps total avec le solveur iteratif (`IterativeProbabilisticSolverPy`)\n",
     "\n",
-    "## Indice\n",
+    "**Indice**\n",
     "\n",
     "Pour la phase probabiliste, utilisez `np.max(probs[idx])` comme mesure de confiance. Pour le backtracking, vous pouvez reutiliser la logique de `_backtrack` du notebook Sudoku-1-Backtracking-Python."
    ]


### PR DESCRIPTION
## Contexte

Contribution à **#3966**. Seul notebook Sudoku flaggé (1/1). → **Sudoku DRAINED** après merge.

## Changement (1 fichier, +1/-1)

**`Sudoku/Sudoku-15-Infer-Python.ipynb`** cell 31 (line `## Indice`) — 1 flag HINT-AS-HEADING :

\`\`\`diff
- ## Indice
+ **Indice**
```

Aside « Indice » (scanner `HINT_RE` matche `indice`) dans une cellule d'exercice qui contient aussi `## Exercice`, `## Enonce`, `## Questions`. L'Indice est un hint court (1 paragraphe). Conversion en **bold inline** (pattern canonique aside court, cf #4715, #4749). Le paragraphe d'indice est préservé mot pour mot.

## Conformité

- **Markdown-only** : 0 `outputs`/`execution_count` touché → 0 re-exécution (C.2 exception)
- **Type source préservé** : `list` (inchangé) — `src[28]` modifié in-place
- **EOF/line-endings préservés** : LF + trailing newline (byte-identique à l'original)
- **Rescan post-fix** : 0/1 flagged ✓

## Scope

\`See #3966\`. Atomique : 1 fichier.

Co-Authored-By: Claude-Code <noreply@anthropic.com>