### PR TITLE
feat(lean): PacLearning uniform_concentration — finite class 2|H|·exp(−2nε²) (iter-2 brique 6/6-agnostic étape a)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/UniformConcentration.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/UniformConcentration.lean
@@ -1,0 +1,89 @@
+import Mathlib
+import PacLearning.Data
+import PacLearning.Sample
+import PacLearning.SampleExpect
+import PacLearning.UnionBound
+import PacLearning.MGF
+import PacLearning.BernoulliMGF
+import PacLearning.Hoeffding
+
+/-!
+# PacLearning.UniformConcentration — concentration uniforme sur une classe finie
+## (iter-2 brique 6/6-agnostic, étape a)
+
+Sous-module de `PacLearning` : la **concentration uniforme** de l'erreur empirique sur une
+**classe d'hypothèses finie** `Hs`. C'est l'ingrédient-clé du cas **agnostic** du théorème PAC
+(le cas réalisable, `m ≥ (1/ε)(ln|H|+ln(1/δ))`, est livré dans `UnionBound.lean` /
+`pac_finite_class_bound`, PR #4580).
+
+On prouve :
+
+    ℙ_{S∼D^n} [ ∃ h ∈ Hs, |empError f h S − trueError D f h| ≥ ε ] ≤ 2 · |Hs| · exp(−2·n·ε²).
+
+C'est le **doublement fini** du flagship ponctuel `hoeffding_concentration` (brique 5/5,
+`Hoeffding.lean`) : chaque `h ∈ Hs` contribue individuellement `2·exp(−2nε²)` (Hoeffding), et
+l'union bound `sampleProb_union_bound` (`UnionBound.lean`) somme ces contributions sur la classe
+finie. L'argument ERM (brique 6b, cycle suivant : `ĥ = argmin empError` ⟹ `trueError ĥ ≤
+trueError h* + 2ε`) comblera l'écart avec la borne de complexité d'échantillon agnostic finale
+`m ≥ (1/ε²)(ln|H|+ln(1/δ))`.
+
+On reste dans le style **ℝ-weight pédagogique** : aucune machine `ℝ≥0∞`/`Measure`/`iIndepFun`.
+-/
+
+namespace PacLearning
+
+open Finset
+open scoped Classical
+
+variable {X : Type*} [Fintype X]
+variable (D : Distribution X)
+variable {D}
+
+/-- **Concentration uniforme sur une classe finie d'hypothèses** (brique 6/6-agnostic, étape a) :
+pour un concept cible `f`, une classe finie `Hs` d'hypothèses, `n ≥ 1` tirages i.i.d. et `ε > 0`,
+la probabilité qu'**il existe** une hypothèse `h ∈ Hs` dont l'erreur empirique dévie de son erreur
+vraie d'au moins `ε` est majorée par `2 · |Hs| · exp(−2·n·ε²)`.
+
+    ℙ_{S∼D^n} [ ∃ h ∈ Hs, |empError f h S − trueError D f h| ≥ ε ] ≤ 2 · |Hs| · exp(−2·n·ε²).
+
+C'est le **doublement fini** du flagship ponctuel (brique 5/5, `hoeffding_concentration`) :
+chaque `h ∈ Hs` contribue `2·exp(−2nε²)` (Hoeffding ponctuel), et l'union bound
+`sampleProb_union_bound` (UnionBound.lean) somme ces contributions sur la classe finie.
+
+Preuve : `sampleProb_union_bound Hs _` (Bornes de Boole) borne `ℙ[∃]` par
+`∑_{h∈Hs} ℙ[|empError−trueError| ≥ ε]`, chaque terme est borné par `hoeffding_concentration f h`
+(`2·exp(−2nε²)`), puis la somme constante se factorise en `|Hs| · 2·exp(−2nε²)`
+(`Finset.sum_const`).
+
+C'est l'ingrédient exact qui, combiné à l'argument ERM (brique 6b), donne la borne de complexité
+d'échantillon PAC **agnostique** `m ≥ (1/ε²)(ln|H|+ln(1/δ))` (à comparer au réalisable
+`m ≥ (1/ε)(ln|H|+ln(1/δ))`, où le `1/ε` traduit la concentration géométrique `(1−μ)^n ≤ e^{−εn}`
+plutôt que la concentration quadratique de Hoeffding). -/
+theorem uniform_concentration (f : Hypothesis X) (Hs : Finset (Hypothesis X)) {n : ℕ} (hn : 0 < n)
+    {ε : ℝ} (hε : 0 < ε) :
+    sampleProb D (fun S : Fin n → X ↦ ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|) ≤
+      ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2))) := by
+  -- (1) Union bound (Bornes de Boole) sur la classe finie :
+  --     ℙ[∃ h ∈ Hs, |empError−trueError| ≥ ε] ≤ ∑_{h∈Hs} ℙ[|empError−trueError| ≥ ε].
+  have hunion :
+      sampleProb D (fun S : Fin n → X ↦ ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|) ≤
+        ∑ h ∈ Hs, sampleProb D (fun S : Fin n → X ↦ ε ≤ |empError f h S - trueError D f h|) :=
+    sampleProb_union_bound Hs (fun h (S : Fin n → X) ↦ ε ≤ |empError f h S - trueError D f h|)
+  -- (2) Chaque terme ≤ 2·exp(−2nε²) (concentration ponctuelle de Hoeffding, brique 5/5).
+  have hhoef : ∀ h ∈ Hs,
+      sampleProb D (fun S : Fin n → X ↦ ε ≤ |empError f h S - trueError D f h|) ≤
+        (2 * Real.exp (-(2 * ↑n * ε ^ 2)) : ℝ) :=
+    fun h _ ↦ hoeffding_concentration f h hn hε
+  -- (3) Assemblage : borne la somme terme à terme, puis factorise la constante.
+  calc sampleProb D (fun S : Fin n → X ↦ ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|)
+      ≤ ∑ h ∈ Hs, sampleProb D (fun S : Fin n → X ↦ ε ≤ |empError f h S - trueError D f h|) :=
+        hunion
+    _ ≤ ∑ h ∈ Hs, (2 * Real.exp (-(2 * ↑n * ε ^ 2)) : ℝ) := by
+          exact Finset.sum_le_sum hhoef
+    _ = ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2))) := by
+          -- `Finset.sum_const` donne `card • c` ; `ring` (via `ring_nf`) normalise le `nsmul`
+          -- en multiplication et ferme le but (`push_cast` est inutile, `ring` suffit).
+          rw [Finset.sum_const]
+          ring
+
+end PacLearning


### PR DESCRIPTION
feat(lean): PacLearning uniform_concentration — finite class 2|H|·exp(−2nε²) (iter-2 brique 6/6-agnostic étape a)

Concentration uniforme de l'erreur empirique sur une **classe d'hypothèses finie** Hs —
l'ingrédient-clé du cas **agnostic** du théorème PAC :

    ℙ_{S∼D^n} [ ∃ h ∈ Hs, |empError f h S − trueError D f h| ≥ ε ] ≤ 2 · |Hs| · exp(−2·n·ε²).

C'est le **doublement fini** du flagship ponctuel `hoeffding_concentration` (brique 5/5,
PR #4752) : chaque h ∈ Hs contribue individuellement `2·exp(−2nε²)` (Hoeffding), et l'union
bound `sampleProb_union_bound` (UnionBound.lean) somme ces contributions sur la classe finie.

Preuve (style ℝ-weight pédagogique, pas de ℝ≥0∞/Measure/iIndepFun) :
1. `sampleProb_union_bound Hs _` (Bornes de Boole) borne `ℙ[∃]` par
   `∑_{h∈Hs} ℙ[|empError−trueError| ≥ ε]`.
2. Chaque terme est borné par `hoeffding_concentration f h hn hε` (`2·exp(−2nε²)`), via
   `Finset.sum_le_sum`.
3. La somme constante se factorise en `|Hs|·2·exp(−2nε²)` (`Finset.sum_const` + `ring`).

C'est l'ingrédient exact qui, combiné à l'argument ERM (brique 6b, cycle suivant :
ĥ = argmin empError ⟹ trueError ĥ ≤ trueError h* + 2ε), donnera la borne de complexité
d'échantillon PAC **agnostique** `m ≥ (1/ε²)(ln|H|+ln(1/δ))` — à comparer au réalisable
`m ≥ (1/ε)(ln|H|+ln(1/δ))` (PR #4580), où le `1/ε` traduit la concentration géométrique
`(1−μ)^n ≤ e^{−εn}` plutôt que la concentration quadratique de Hoeffding.

STACKING : cette brique dépend fonctionnellement de `hoeffding_concentration` (PR #4752, OPEN
CLEAN, pas encore mergée). La branche est donc stackée sur `feature/pac-iter2-hoeffding-
concentration-4293` ; au merge de #4752, GitHub auto-rebasera cette PR sur main (diff résiduel =
ce fichier uniquement). C'est le pattern documenté pour les briques séquentielles qui réutilisent
les defs d'une brique amont OPEN.

Validation:
- `lake build PacLearning.UniformConcentration` SUCCESS (exit 0), puis `lake build PacLearning`
  SUCCESS (exit 0, 0 erreur, 0 warning) — Mathlib v4.31.0-rc1.
- sorry-baseline **net-zéro vs origin/main** : filtre CI `grep "sorry"|grep -viE "sorries|sorry.s"`
  retourne 0 ligne sur `UniformConcentration.lean` (89 lignes, 1 nouveau fichier, pur additif).
  `hoeffding_concentration` et tous ses ingrédients sont sorry-free (build guarantee → pas de
  sorryAx). Aucune occurrence du mot "sorry" même en commentaire.

See #4293

Co-Authored-By: Claude <noreply@anthropic.com>
