### PR TITLE
feat(infer): Infer-18 Change-Point detection (bayesian structural break)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
@@ -1,0 +1,897 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8cd92d9d",
+   "metadata": {},
+   "source": [
+    "# Infer-18 — Détection de Rupture (Change-Point) : inférer le moment d'un changement de régime\n",
+    "\n",
+    "> **Corpus bayésien Infer.NET.** Ce notebook (18ᵉ du corpus) complète la famille des\n",
+    "> « séquences dans le temps » : il étend [Infer-11 (Séquences / HMM)](Infer-11-Sequences.ipynb)\n",
+    "> et [Infer-17 (Filtre de Kalman)](Infer-17-Kalman-Filter.ipynb) au cas où ce n'est pas l'état\n",
+    "> qui change à chaque instant, mais la **structure** du processus qui bascule **une seule fois**\n",
+    "> à un instant inconnu.\n",
+    "\n",
+    "**Durée estimée** : 50 minutes\n",
+    "**Prérequis** : [Infer-11-Sequences](Infer-11-Sequences.ipynb) (HMM, `Variable.ForEach`), [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb) (conjugaison gaussienne), [Infer-8-Model-Selection](Infer-8-Model-Selection.ipynb) (évidence, Bayes factors)\n",
+    "\n",
+    "Imaginez une chaîne de production dont la qualité dérive soudainement, un marché financier\n",
+    "qui change de régime, ou le taux d'accidents miniers qui chute après une nouvelle réglementation.\n",
+    "Dans tous ces cas, le signal observé suit un régime stable, puis **bascule** vers un autre régime\n",
+    "à un instant `cp` que l'on ne connaît pas à l'avance. La question n'est pas « quel est l'état à\n",
+    "chaque pas ? » (répondue par le HMM ou le filtre de Kalman), mais « **à quel instant unique** le\n",
+    "processus a-t-il changé de nature ? ». C'est l'inférence d'un **point de rupture** (*change-point*).\n",
+    "\n",
+    "Ce notebook montre comment Infer.NET traite ce problème de façon native : un *a priori* uniforme\n",
+    "sur l'indice de rupture (`Variable.DiscreteUniform`), une sélection de vraisemblance conditionnée\n",
+    "par cet indice (`Variable.If` / `Variable.IfNot` sur une plage), et le moteur **EP** qui retourne\n",
+    "un postérieur **discret** sur la localisation de la rupture — l’idiome message-passing-sur-graphe\n",
+    "de-facteurs que Infer.NET est conçu pour résoudre."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "975d8fa1",
+   "metadata": {},
+   "source": [
+    "## 1. Motivation : là où le HMM et le filtre de Kalman s'arrêtent\n",
+    "\n",
+    "[Infer-11](Infer-11-Sequences.ipynb) modélise une séquence où l'état caché est **discret** et\n",
+    "change à **chaque instant** (météo d'aujourd'hui, mot de la phrase). [Infer-17](Infer-17-Kalman-Filter.ipynb)\n",
+    "est son pendant **continu** : l'état (position, prix) évolue pas-à-pas. Les deux infèrent un état\n",
+    "**récurrent** — un par pas de temps.\n",
+    "\n",
+    "Le **point de rupture** est différent : l'inconnue n'est pas une trajectoire d'états, mais **un\n",
+    "unique entier** `cp ∈ {0, …, N−1}` — l'indice où le processus bascule. On veut le postérieur\n",
+    "$p(\\text{cp} \\mid y_{0:N-1})$, une distribution discrète sur $N$ positions.\n",
+    "\n",
+    "L'idiome Infer.NET repose sur trois briques que les notebooks précédents n'exploitent **pas**\n",
+    "ensemble :\n",
+    "\n",
+    "| Brique | Rôle | Où déjà vu ? |\n",
+    "|--------|------|--------------|\n",
+    "| `Variable.DiscreteUniform(N)` | *a priori* uniforme sur l'indice de rupture | Infer-3 (Monty Hall) |\n",
+    "| `Variable.ForEach` sur la plage temporelle | une vraisemblance par instant | Infer-11, Infer-17 |\n",
+    "| `Variable.If(block.Index <= cp)` / `IfNot` | sélectionner la vraisemblance *avant*/*après* la rupture | Infer-3 (If/IfNot statique) |\n",
+    "\n",
+    "La nouveauté est le couplage : la condition `block.Index <= cp` (l'indice de boucle, obtenu via\n",
+    "`ForEachBlock.Index`) **branche la vraisemblance sur un indice latent couplé à toute la plage** —\n",
+    "un usage plus riche du `If` que le cas statique de Infer-3. EP propage les messages et retourne\n",
+    "une `Discrete` (un vecteur de probabilités sur les $N$ positions) pour `cp`, plus les postérieurs\n",
+    "des paramètres de chaque segment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ac22d2ac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:46.820326Z",
+     "iopub.status.busy": "2026-07-01T15:35:46.814549Z",
+     "iopub.status.idle": "2026-07-01T15:35:51.052735Z",
+     "shell.execute_reply": "2026-07-01T15:35:51.046808Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2048/\",\"http://172.27.64.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:58e6:e4cc:f299:db58:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '291496.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.ML.Probabilistic\"\n",
+    "#r \"nuget: Microsoft.ML.Probabilistic.Compiler\"\n",
+    "// restore Infer.NET -- isole dans sa propre cellule (convention de la serie)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54bb8901",
+   "metadata": {},
+   "source": [
+    "Configuration des espaces de noms Infer.NET. Le moteur **EP** (Expectation Propagation) est\n",
+    "celui qui traite les facteurs `If` discrets couplés à une plage. On définit aussi le helper\n",
+    "de tirage gaussien (Box-Muller) pour générer une série synthétique dont on connaît le vrai\n",
+    "point de rupture."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "26d51878",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:51.055496Z",
+     "iopub.status.busy": "2026-07-01T15:35:51.055220Z",
+     "iopub.status.idle": "2026-07-01T15:35:52.172396Z",
+     "shell.execute_reply": "2026-07-01T15:35:52.171908Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Serie generee : N=100 points, vrai cp cache a t=50 (mu 2 -> 7, sigma=1,5)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.ML.Probabilistic;\n",
+    "using Microsoft.ML.Probabilistic.Distributions;\n",
+    "using Microsoft.ML.Probabilistic.Models;\n",
+    "using Microsoft.ML.Probabilistic.Algorithms;\n",
+    "using Range = Microsoft.ML.Probabilistic.Models.Range;   // desambiguise vs System.Range\n",
+    "using System;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// Helper : tirage N(0, 1) par Box-Muller (defini AVANT usage).\n",
+    "double Randn(Random r) {\n",
+    "    double u1 = 1.0 - r.NextDouble();\n",
+    "    double u2 = 1.0 - r.NextDouble();\n",
+    "    return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);\n",
+    "}\n",
+    "\n",
+    "// --- Terrain de jeu : serie avec un SEUL changement de regime ---\n",
+    "// Le vrai point de rupture est CACHE ; on verifiera que le modele le recupere.\n",
+    "Random rng = new Random(42);\n",
+    "int N = 100;\n",
+    "int vraiCp = 50;                  // vrai indice de rupture (inconnu du modele)\n",
+    "double muAvant = 2.0, muApres = 7.0;   // moyennes des deux regimes\n",
+    "double sigma = 1.5;               // bruit d'observation\n",
+    "double[] data = new double[N];\n",
+    "for (int i = 0; i < N; i++) {\n",
+    "    double mu = (i <= vraiCp) ? muAvant : muApres;\n",
+    "    data[i] = mu + Randn(rng) * sigma;\n",
+    "}\n",
+    "Console.WriteLine($\"Serie generee : N={N} points, vrai cp cache a t={vraiCp} (mu {muAvant} -> {muApres}, sigma={sigma})\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7765fc61",
+   "metadata": {},
+   "source": [
+    "## 2. Le modèle de point de rupture gaussien\n",
+    "\n",
+    "On déclare `cp` comme un entier d'*a priori* uniforme sur `{0, …, N−1}`, deux moyennes de segment\n",
+    "(*a priori* gaussiens vagues) et une précision commune. Pour chaque instant `t`, on **branche** la\n",
+    "vraisemblance selon la position de `cp` : gaussienne de moyenne `mean1` avant la rupture, `mean2`\n",
+    "après. C'est le couplage `Variable.ForEach` + `If(block.Index <= cp)` qui fait tout le travail\n",
+    "(l'indice de boucle est obtenu via `block.Index`, l'API moderne d'Infer.NET).\n",
+    "\n",
+    "EP retourne : un postérieur **`Discrete`** sur `cp` (vecteur de $N$ probabilités), et les postérieurs\n",
+    "gaussiens/gamma des paramètres. Notons que **rien n'est échantillonné** : c'est de l'inférence\n",
+    "déterministe par passage de messages, en quelques itérations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d80b88b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:52.174400Z",
+     "iopub.status.busy": "2026-07-01T15:35:52.174137Z",
+     "iopub.status.idle": "2026-07-01T15:35:56.162746Z",
+     "shell.execute_reply": "2026-07-01T15:35:56.162485Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Posterieur sur le point de rupture cp ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  mode (argmax)        = 50    (vrai cp cache = 50)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  moyenne              =  50,00\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Moyenne avant  (mu1) :  1,892  (vrai 2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Moyenne apres  (mu2) :  7,197  (vrai 7)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Precision commune    :  0,550  (vrai 0,444)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Modele de change-point gaussien ---\n",
+    "Range t = new Range(N);\n",
+    "VariableArray<double> y = Variable.Array<double>(t);\n",
+    "y.ObservedValue = data;\n",
+    "\n",
+    "Variable<int> cp = Variable.DiscreteUniform(N);                      // localisation de la rupture\n",
+    "Variable<double> mean1 = Variable.GaussianFromMeanAndVariance(0.0, 100.0);\n",
+    "Variable<double> mean2 = Variable.GaussianFromMeanAndVariance(0.0, 100.0);\n",
+    "Variable<double> precision = Variable.GammaFromMeanAndVariance(1.0, 1.0);\n",
+    "\n",
+    "using (var block = Variable.ForEach(t)) {\n",
+    "    using (Variable.If(block.Index <= cp)) {                         // segment AVANT\n",
+    "        y[t] = Variable.GaussianFromMeanAndPrecision(mean1, precision);\n",
+    "    }\n",
+    "    using (Variable.IfNot(block.Index <= cp)) {                      // segment APRES\n",
+    "        y[t] = Variable.GaussianFromMeanAndPrecision(mean2, precision);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var ie = new InferenceEngine(new ExpectationPropagation()) { ShowProgress = false, NumberOfIterations = 50 };\n",
+    "Discrete cpPost = ie.Infer<Discrete>(cp);\n",
+    "Gaussian m1Post = ie.Infer<Gaussian>(mean1);\n",
+    "Gaussian m2Post = ie.Infer<Gaussian>(mean2);\n",
+    "Gamma precPost  = ie.Infer<Gamma>(precision);\n",
+    "\n",
+    "Console.WriteLine(\"=== Posterieur sur le point de rupture cp ===\");\n",
+    "Console.WriteLine($\"  mode (argmax)        = {cpPost.GetMode()}    (vrai cp cache = {vraiCp})\");\n",
+    "Console.WriteLine($\"  moyenne              = {cpPost.GetMean(),6:F2}\");\n",
+    "Console.WriteLine($\"Moyenne avant  (mu1) : {m1Post.GetMean(),6:F3}  (vrai {muAvant})\");\n",
+    "Console.WriteLine($\"Moyenne apres  (mu2) : {m2Post.GetMean(),6:F3}  (vrai {muApres})\");\n",
+    "Console.WriteLine($\"Precision commune    : {precPost.GetMean(),6:F3}  (vrai {1.0/(sigma*sigma):F3})\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cb6e2d0",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Le mode du postérieur sur `cp` doit tomber **très près** de 50 (le vrai point caché),\n",
+    "et les moyennes de segment doivent approcher 2 et 7. Si le signal est fort (`|mu2 − mu1| ≫ sigma`),\n",
+    "le postérieur se concentre sur **quelques indices** ; s'il est faible, il s'étale. Examinons la\n",
+    "forme exacte de ce postérieur discret."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e72abe1e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:56.164669Z",
+     "iopub.status.busy": "2026-07-01T15:35:56.164299Z",
+     "iopub.status.idle": "2026-07-01T15:35:56.288886Z",
+     "shell.execute_reply": "2026-07-01T15:35:56.288587Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Postérieur sur cp (masses > 0.1%, normalisees au pic) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  t= 50  ##################################################   0,9978\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  t= 51                                                       0,0022\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Visualisation : postérieur discret sur la localisation de la rupture ---\n",
+    "double pmax = 0.0;\n",
+    "for (int i = 0; i < N; i++) pmax = Math.Max(pmax, cpPost[i]);\n",
+    "Console.WriteLine(\"Postérieur sur cp (masses > 0.1%, normalisees au pic) :\");\n",
+    "for (int i = 0; i < N; i++) {\n",
+    "    if (cpPost[i] < 0.001) continue;                                // on n'affiche que la masse utile\n",
+    "    int barLen = (int)Math.Round(cpPost[i] / pmax * 50.0);\n",
+    "    Console.WriteLine($\"  t={i,3}  {new string('#', barLen),-50}  {cpPost[i],7:F4}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbba2a95",
+   "metadata": {},
+   "source": [
+    "## 3. Le cas canonique : les catastrophes minières (loi de Poisson)\n",
+    "\n",
+    "Le jeu de données historique du change-point bayésien est la série annuelle des **catastrophes\n",
+    "de mines de charbon** en Grande-Bretagne (1851–1962, Jarrett 1979). Il s'agit de **comptes** :\n",
+    "le modèle naturel est une loi de **Poisson** dont le *taux* bascule une fois — de ~3 accidents/an\n",
+    "avant la réforme de sécurité des années 1880 à ~1/an après.\n",
+    "\n",
+    "Même idiome que le cas gaussien : `DiscreteUniform` sur l'année de rupture, `If/IfNot` sur la\n",
+    "plage des années, mais `Variable.Poisson(taux)` en lieu et place de la gaussienne. EP retourne le\n",
+    "postérieur `Discrete` sur l'année de rupture et les taux `Gamma` des deux régimes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7ba74aef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:56.290717Z",
+     "iopub.status.busy": "2026-07-01T15:35:56.290439Z",
+     "iopub.status.idle": "2026-07-01T15:35:57.670121Z",
+     "shell.execute_reply": "2026-07-01T15:35:57.669809Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Serie cataclysmes miniers : 112 annees (1851..1962)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Annee de rupture detectee : 1891  (indice 40)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Taux AVANT  :  3,12 catastrophes/an\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Taux APRES  :  0,94 catastrophes/an\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rapport de taux : 3,3x\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Catastrophes minieres britanniques, 1851-1962 (Jarrett 1979) ---\n",
+    "int[] disasters = new int[] {\n",
+    "    4,5,4,0,1,4,3,4,0,6, 3,3,4,0,2,6,3,3,5,4,\n",
+    "    5,3,1,4,4,1,5,5,3,4, 2,5,2,2,3,4,2,1,3,2,\n",
+    "    2,1,1,1,1,3,0,0,1,0, 1,1,0,0,3,1,0,3,2,2,\n",
+    "    0,1,1,1,0,1,0,1,0,0, 0,2,1,0,0,0,1,1,0,2,\n",
+    "    3,3,1,1,2,1,1,1,1,2, 4,2,0,0,1,4,0,0,0,1,\n",
+    "    0,0,0,0,1,0,0,1,0,1, 0,1\n",
+    "};\n",
+    "int N2 = disasters.Length;\n",
+    "Console.WriteLine($\"Serie cataclysmes miniers : {N2} annees ({1851}..{1851 + N2 - 1})\");\n",
+    "\n",
+    "Range an = new Range(N2);\n",
+    "VariableArray<int> d = Variable.Array<int>(an);\n",
+    "d.ObservedValue = disasters;\n",
+    "\n",
+    "Variable<int> cp2 = Variable.DiscreteUniform(N2);\n",
+    "Variable<double> tauxAvant  = Variable.GammaFromMeanAndVariance(3.0, 100.0);\n",
+    "Variable<double> tauxApres  = Variable.GammaFromMeanAndVariance(1.0, 100.0);\n",
+    "\n",
+    "// Initialisation data-driven : EP est deterministe (pas d'echantillonnage), donc un point de\n",
+    "// rupture peut pieger EP dans un optimum local. On amorce les deux taux vers les extremes\n",
+    "// empiriques de la serie (moyennes des premieres et des dernieres annees) -- une heuristique\n",
+    "// standard pour les modeles de change-point sous EP.\n",
+    "double estAvant = disasters.Take(10).Average();\n",
+    "double estApres = disasters.Skip(N2 - 10).Take(10).Average();\n",
+    "tauxAvant.InitialiseTo(Gamma.FromMeanAndVariance(estAvant, 1.0));\n",
+    "tauxApres.InitialiseTo(Gamma.FromMeanAndVariance(estApres, 1.0));\n",
+    "\n",
+    "using (var block2 = Variable.ForEach(an)) {\n",
+    "    using (Variable.If(block2.Index <= cp2)) {\n",
+    "        d[an] = Variable.Poisson(tauxAvant);\n",
+    "    }\n",
+    "    using (Variable.IfNot(block2.Index <= cp2)) {\n",
+    "        d[an] = Variable.Poisson(tauxApres);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var ie2 = new InferenceEngine(new ExpectationPropagation()) { ShowProgress = false, NumberOfIterations = 50 };\n",
+    "Discrete cp2Post = ie2.Infer<Discrete>(cp2);\n",
+    "Gamma tauxAvantPost = ie2.Infer<Gamma>(tauxAvant);\n",
+    "Gamma tauxApresPost = ie2.Infer<Gamma>(tauxApres);\n",
+    "\n",
+    "int modeCp2 = cp2Post.GetMode();\n",
+    "Console.WriteLine($\"Annee de rupture detectee : {1851 + modeCp2}  (indice {modeCp2})\");\n",
+    "Console.WriteLine($\"Taux AVANT  : {tauxAvantPost.GetMean(),5:F2} catastrophes/an\");\n",
+    "Console.WriteLine($\"Taux APRES  : {tauxApresPost.GetMean(),5:F2} catastrophes/an\");\n",
+    "Console.WriteLine($\"Rapport de taux : {tauxAvantPost.GetMean() / Math.Max(1e-6, tauxApresPost.GetMean()):F1}x\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5a20101",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Le postérieur concentre la rupture autour de **1890–1891** — soit exactement\n",
+    "la période des grandes réformes de sécurité dans les mines britanniques. Le taux passe de ~3,1 à\n",
+    "~0,9 catastrophe par an, un rapport de ~3,3×. C'est le résultat historique de la littérature\n",
+    "sur les modèles de point de rupture (Carlin, Gelfand & Smith 1992 ; PyMC en fait son exemple\n",
+    "introductif). **Aucun échantillonnage MCMC** n'est utilisé ici : EP propage les messages sur le\n",
+    "graphe de facteurs et renvoie le postérieur en quelques itérations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62c94bdc",
+   "metadata": {},
+   "source": [
+    "## 4. Vraie rupture ou caprice du bruit ? Le piège de la flexibilité\n",
+    "\n",
+    "Un modèle de point de rupture est **flexible** : il peut, si on le laisse faire, trouver une\n",
+    "« meilleure » coupure dans n'importe quelle série — y compris du pur bruit. C'est le piège du\n",
+    "surajustement. Pour le mesurer, on génère une série **sans rupture** (même moyenne du début à la\n",
+    "fin) et on lui applique le **même** modèle. On quantifie la concentration du postérieur sur `cp`\n",
+    "par son **entropie** $H$ (en bits) : $H_{\\max} = \\log_2 N$ pour un postérieur plat (aucune idée sur\n",
+    "la localisation), $H \\to 0$ pour un postérieur piqué (localisation quasi certaine).\n",
+    "\n",
+    "Le résultat est instructif : une **vraie** rupture fait chuter l'entropie vers 0, mais même du\n",
+    "pur bruit laisse l'entropie **nettement sous** le maximum — le modèle surajuste et « trouve » une\n",
+    "coupure spurieuse. Distinguer les deux exige donc plus que la seule concentration : un **Bayes\n",
+    "factor** (rapport de vraisemblance marginale) qui pénalise la flexibilité supplémentaire du modèle\n",
+    "à rupture (rasoir d'Occam) — c'est l'objet d'[Infer-8](Infer-8-Model-Selection.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "388b1f4b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:57.672008Z",
+     "iopub.status.busy": "2026-07-01T15:35:57.671736Z",
+     "iopub.status.idle": "2026-07-01T15:35:59.729918Z",
+     "shell.execute_reply": "2026-07-01T15:35:59.729655Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Serie AVEC rupture   : H(cp) =  0,023 bits / 6,644  =>  information = 6,621 bits\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Controle SANS rupture : H(cp) =  0,686 bits / 6,644  =>  information = 5,957 bits\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Vraie rupture : H -> 0 (localisation quasi certaine).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Pur bruit    : H reste BAS mais non nul -- le modele SURAJUSTE une coupure spurieuse.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. Infer-8), pas la seule entropie.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Entropie (bits) du postérieur de cp sur la serie AVEC rupture\n",
+    "double Hcp = 0.0, HmaxReel = Math.Log(N, 2);\n",
+    "for (int i = 0; i < N; i++) { double p = cpPost[i]; if (p > 1e-12) Hcp -= p * Math.Log(p, 2); }\n",
+    "\n",
+    "// --- Controle : serie SANS rupture (moyenne constante) ---\n",
+    "Random rng2 = new Random(7);\n",
+    "int Nc = 100;\n",
+    "double[] dataCtrl = new double[Nc];\n",
+    "double muConst = 5.0;\n",
+    "for (int i = 0; i < Nc; i++) dataCtrl[i] = muConst + Randn(rng2) * 1.5;\n",
+    "\n",
+    "Range tc = new Range(Nc);\n",
+    "VariableArray<double> yc = Variable.Array<double>(tc);\n",
+    "yc.ObservedValue = dataCtrl;\n",
+    "Variable<int> cpC = Variable.DiscreteUniform(Nc);\n",
+    "Variable<double> mc1 = Variable.GaussianFromMeanAndVariance(0.0, 100.0);\n",
+    "Variable<double> mc2 = Variable.GaussianFromMeanAndVariance(0.0, 100.0);\n",
+    "Variable<double> pc  = Variable.GammaFromMeanAndVariance(1.0, 1.0);\n",
+    "using (var blockC = Variable.ForEach(tc)) {\n",
+    "    using (Variable.If(blockC.Index <= cpC)) yc[tc] = Variable.GaussianFromMeanAndPrecision(mc1, pc);\n",
+    "    using (Variable.IfNot(blockC.Index <= cpC)) yc[tc] = Variable.GaussianFromMeanAndPrecision(mc2, pc);\n",
+    "}\n",
+    "var ieC = new InferenceEngine(new ExpectationPropagation()) { ShowProgress = false, NumberOfIterations = 50 };\n",
+    "Discrete cpCPost = ieC.Infer<Discrete>(cpC);\n",
+    "\n",
+    "double Hctrl = 0.0;\n",
+    "for (int i = 0; i < Nc; i++) { double p = cpCPost[i]; if (p > 1e-12) Hctrl -= p * Math.Log(p, 2); }\n",
+    "double HmaxCtrl = Math.Log(Nc, 2);\n",
+    "\n",
+    "Console.WriteLine($\"Serie AVEC rupture   : H(cp) = {Hcp,6:F3} bits / {HmaxReel:F3}  =>  information = {HmaxReel - Hcp,5:F3} bits\");\n",
+    "Console.WriteLine($\"Controle SANS rupture : H(cp) = {Hctrl,6:F3} bits / {HmaxCtrl:F3}  =>  information = {HmaxCtrl - Hctrl,5:F3} bits\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"=> Vraie rupture : H -> 0 (localisation quasi certaine).\");\n",
+    "Console.WriteLine(\"=> Pur bruit    : H reste BAS mais non nul -- le modele SURAJUSTE une coupure spurieuse.\");\n",
+    "Console.WriteLine(\"=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. Infer-8), pas la seule entropie.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1a4682a",
+   "metadata": {},
+   "source": [
+    "**Lecture.** La série **avec** rupture pousse l'entropie vers 0 (localisation quasi certaine),\n",
+    "tandis que le **contrôle** (pur bruit) laisse une entropie faible mais non nulle (~0,7 bits) :\n",
+    "le modèle, trop flexible, a « trouvé » une coupure spurieuse. C'est le piège classique des\n",
+    "modèles de point de rupture.\n",
+    "\n",
+    "La leçon : la concentration du postérieur signale qu'une coupure est **possible**, mais seule la\n",
+    "comparaison de modèles par **Bayes factor** (vraisemblance marginale) tranche entre « vraie\n",
+    "rupture » et « surajustement ». Le Bayes factor pénalise la flexibilité supplémentaire du modèle\n",
+    "à rupture (rasoir d'Occam) : sur la vraie série, le gain de vraisemblance compense largement la\n",
+    "pénalité ; sur le bruit, non. C'est exactement le mécanisme étudié dans\n",
+    "[Infer-8 (Sélection de modèles)](Infer-8-Model-Selection.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d45bf2f",
+   "metadata": {},
+   "source": [
+    "## 5. Exercices\n",
+    "\n",
+    "Les trois exercices ci-dessous exploitent le même idiome `DiscreteUniform` + `If/IfNot` sur une\n",
+    "plage. Ils sont laissés **à compléter** (stubbs sans erreur) — le notebook s'exécute de bout en\n",
+    "bout même non rempli."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac15704c",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Deux points de rupture (trois régimes)\n",
+    "\n",
+    "Étendez le modèle à **deux** ruptures `cp1 < cp2` délimitant trois segments de moyennes\n",
+    "`mu1, mu2, mu3`. Le postérieur devient joint sur `(cp1, cp2)`.\n",
+    "\n",
+    "**Indice :** générez une série à trois régimes, puis emboîtez les `If` — `If(t <= cp1)` pour le\n",
+    "premier segment, sinon `If(t <= cp2)` pour le second, sinon le troisième.\n",
+    "\n",
+    "**Étape 1.** Générez `data3` avec `mu = 2` sur `[0, cp1]`, `mu = 5` sur `[cp1, cp2]`, `mu = 8`\n",
+    "au-delà.\n",
+    "**Étape 2.** Déclarez `cp1, cp2` (`DiscreteUniform`, avec `cp1 < cp2`), trois moyennes, et\n",
+    "emboîtez les `If/IfNot`.\n",
+    "**Étape 3.** Inférez `cp1Post` et `cp2Post` et vérifiez la récupération des deux positions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8bdae4b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:59.731651Z",
+     "iopub.status.busy": "2026-07-01T15:35:59.731414Z",
+     "iopub.status.idle": "2026-07-01T15:35:59.772092Z",
+     "shell.execute_reply": "2026-07-01T15:35:59.771846Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : deux points de rupture (trois regimes).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : deux points de rupture (a completer)\n",
+    "// TODO etudiant : declarer cp1, cp2, mu1, mu2, mu3 et emboiter les If/IfNot sur les trois segments.\n",
+    "Console.WriteLine(\"Exercice 1 a completer : deux points de rupture (trois regimes).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d655f518",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Un changement de variance (moyenne constante)\n",
+    "\n",
+    "Jusqu'ici la rupture portait sur la **moyenne**. Détectez une rupture de **variance** seule : la\n",
+    "moyenne reste constante, mais la précision bascule de `prec1` (régime calme) à `prec2` (régime\n",
+    "turbulent) à l'instant `cp`.\n",
+    "\n",
+    "**Indice :** la moyenne `mu` est commune aux deux segments ; seules les précisions diffèrent.\n",
+    "Placez `mu` *en dehors* des `If`, et branchez la précision à l'intérieur.\n",
+    "\n",
+    "**Étape 1.** Générez une série de moyenne 5 constante, de variance 0.25 avant `cp` et 4.0 après.\n",
+    "**Étape 2.** Adaptez le modèle (une moyenne commune, deux précisions branchées par `If/IfNot`).\n",
+    "**Étape 3.** Le postérieur sur `cp` se concentre-t-il malgré l'absence de saut de moyenne ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "99527d63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:59.773806Z",
+     "iopub.status.busy": "2026-07-01T15:35:59.773590Z",
+     "iopub.status.idle": "2026-07-01T15:35:59.804033Z",
+     "shell.execute_reply": "2026-07-01T15:35:59.803754Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : detection d'un changement de variance.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : changement de variance (a completer)\n",
+    "// TODO etudiant : moyenne commune, deux precisions (prec1, prec2) branchees par If/IfNot.\n",
+    "Console.WriteLine(\"Exercice 2 a completer : detection d'un changement de variance.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b80db48",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Robustesse au signal et à la taille\n",
+    "\n",
+    "Étudiez comment la **concentration** du postérieur sur `cp` dépend (a) de l'amplitude du saut\n",
+    "`delta = mu2 − mu1` et (b) de la longueur `N` de la série.\n",
+    "\n",
+    "**Indice :** reprenez le modèle de la section 2 dans une boucle sur `delta ∈ {1, 2, 4}` et notez\n",
+    "`H(cp)` à chaque fois.\n",
+    "\n",
+    "**Étape 1.** Pour chaque `delta`, générez une série et inférez `cpPost`.\n",
+    "**Étape 2.** Calculez l'entropie `H(cp)` et l'information `Hmax − H`.\n",
+    "**Étape 3.** Observez : un signal faible ou une courte série élargit le postérieur ; un signal\n",
+    "fort ou une longue série le resserre. Quantifiez la transition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8fdbb0ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T15:35:59.805950Z",
+     "iopub.status.busy": "2026-07-01T15:35:59.805686Z",
+     "iopub.status.idle": "2026-07-01T15:35:59.835541Z",
+     "shell.execute_reply": "2026-07-01T15:35:59.835302Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : robustesse du posterieur au signal et a la taille.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : robustesse au signal et a N (a completer)\n",
+    "// TODO etudiant : boucler sur delta dans {1, 2, 4}, mesurer H(cp) a chaque fois.\n",
+    "Console.WriteLine(\"Exercice 3 a completer : robustesse du posterieur au signal et a la taille.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40705fce",
+   "metadata": {},
+   "source": [
+    "## 6. Conclusion\n",
+    "\n",
+    "Le **point de rupture** complète la famille des séquences temporelles du corpus :\n",
+    "\n",
+    "| Notebook | État caché | Inférence |\n",
+    "|----------|-----------|-----------|\n",
+    "| [Infer-11](Infer-11-Sequences.ipynb) (HMM) | discret, **récurrent** (un par pas) | postérieur sur la trajectoire d'états |\n",
+    "| [Infer-17](Infer-17-Kalman-Filter.ipynb) (Kalman) | continu, **récurrent** | postérieur gaussien pas-à-pas |\n",
+    "| **Infer-18 (change-point)** | **entier structurel unique** | postérieur `Discrete` sur la localisation |\n",
+    "\n",
+    "Le trait distinctif : l'inconnue est un **indice structurel** couplé à toute la plage temporelle,\n",
+    "et EP retourne sa distribution discrète — un usage du `Variable.If(t.Item <= cp)` sur une plage\n",
+    "que n'exploite aucun autre notebook de l'arc. C'est aussi le chaînon naturel vers\n",
+    "[Infer-14 (Causal)](Infer-14-Causal-Inference.ipynb) : un point de rupture est un changement de\n",
+    "**mécanisme générateur**, exactement ce que l'inférence causale cherche à détecter (rupture dans\n",
+    "$p(Y \\mid do(X))$), et vers la sélection de modèles ([Infer-8](Infer-8-Model-Selection.ipynb)),\n",
+    "où la concentration du postérieur joue le rôle d'un Bayes factor.\n",
+    "\n",
+    "**Pour aller plus loin.** Plusieurs ruptures (exercice 1) ; ruptures de variance (exercice 2) ;\n",
+    "nombre de ruptures inconnu (processus de Dirichlet — non natif en Infer.NET, voir le versant PyMC) ;\n",
+    "ou la détection en ligne (filtering) plutôt qu'off-line."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -2,7 +2,7 @@
 
 [← Série Probas](../README.md) | [Série PyMC (Python) →](../PyMC/README.md) | [ML.NET (C#) →](../../ML/ML.Net/README.md)
 
-Programmation probabiliste avec Microsoft Infer.NET : une série de 27 notebooks, scindée en deux arcs. Le **corpus bayésien** (17 notebooks, ce README) va des fondamentaux (distributions, factor graphs) aux frontières (modèles relationnels, TrueSkill, LDA, HMM, **inférence causale** (do-calculus de Pearl), **processus gaussiens** (GP sparse, frontières non-linéaires), **modèles hiérarchiques** (pooling partiel, shrinkage), **filtre de Kalman**). Un **arc autonome de 10 notebooks de théorie de la décision** ([`../DecisionTheory/Infer/`](../DecisionTheory/Infer/README.md)) couvre utilité espérée, EVPI, MDPs, indice de Gittins et **bandits bayésiens** (Thompson Sampling), avec des preuves formelles Lean 4.
+Programmation probabiliste avec Microsoft Infer.NET : une série de 28 notebooks, scindée en deux arcs. Le **corpus bayésien** (18 notebooks, ce README) va des fondamentaux (distributions, factor graphs) aux frontières (modèles relationnels, TrueSkill, LDA, HMM, **inférence causale** (do-calculus de Pearl), **processus gaussiens** (GP sparse, frontières non-linéaires), **modèles hiérarchiques** (pooling partiel, shrinkage), **filtre de Kalman**, **détection de rupture** (change-point bayésien)). Un **arc autonome de 10 notebooks de théorie de la décision** ([`../DecisionTheory/Infer/`](../DecisionTheory/Infer/README.md)) couvre utilité espérée, EVPI, MDPs, indice de Gittins et **bandits bayésiens** (Thompson Sampling), avec des preuves formelles Lean 4.
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs .NET souhaitant maîtriser l'inférence probabiliste par message passing, et data scientists intéressés par les graphes de facteurs. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en probabilités avancées : les concepts sont introduits progressivement.
 
@@ -65,10 +65,11 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 | 15 | [Infer-15-Sparse-Gaussian-Process](Infer-15-Sparse-Gaussian-Process.ipynb) | 55 min | Processus gaussiens, noyau RBF, classification non-linéaire, sparse GP |
 | 16 | [Infer-16-Modeles-Hierarchiques](Infer-16-Modeles-Hierarchiques.ipynb) | 50 min | Modèles hiérarchiques, pooling partiel, shrinkage, VariableArray indexé |
 | 17 | [Infer-17-Kalman-Filter](Infer-17-Kalman-Filter.ipynb) | 55 min | Filtre de Kalman, système dynamique linéaire gaussien, conjugaison, EP exacte |
+| 18 | [Infer-18-Change-Point](Infer-18-Change-Point.ipynb) | 50 min | Détection de rupture, DiscreteUniform, ForEach + If/IfNot sur plage, EP, Poisson |
 
 > **Théorie de la décision** : les 10 notebooks de décision (utilité, EVPI, MDPs, Thompson Sampling, plus 2 companions Lean) forment désormais un arc autonome dans [`../DecisionTheory/Infer/`](../DecisionTheory/Infer/README.md), adossé au lake [`decision_theory_lean`](../decision_theory_lean/).
 
-**Durée totale** : ~13h (corpus bayésien 1-17)
+**Durée totale** : ~14h (corpus bayésien 1-18)
 
 **Ressource complémentaire** : [Glossaire](Infer-Glossary.md) - Définitions des termes techniques
 
@@ -81,7 +82,7 @@ flowchart TD
     P3["<b>Classification & sélection</b> (7-8)<br/>A/B tests · evidence · ARD"]
     P4["<b>Modèles avancés</b> (9-12)<br/>LDA · crowdsourcing · HMM · reco"]
     P5["<b>Référence</b> (13)<br/>Debugging · comparaison algorithmes"]
-    P8["<b>Frontières</b> (14-17)<br/>causalité · GP sparse · hiérarchique · Kalman"]
+    P8["<b>Frontières</b> (14-18)<br/>causalité · GP sparse · hiérarchique · Kalman · change-point"]
     DT["<b>Théorie de la décision</b><br/>arc autonome : ../DecisionTheory/Infer/"]
     P1 --> P2 --> P3 --> P4
     P4 --> P8
@@ -92,7 +93,7 @@ flowchart TD
     class DT decision;
 ```
 
-Le socle d'inference (1-12) se suit en séquence ; le notebook **13 (Debugging)** est transversal — il compare aussi les trois algorithmes (EP/VMP/Gibbs) et sert de référence dès qu'une inférence dysfonctionne. Les notebooks **14-17 (Frontières)** prolongent le corpus bayésien (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman). La **théorie de la décision** — utilité espérée, EVPI, MDPs, Thompson Sampling, plus les companions Lean (indice de Gittins) — forme désormais un **arc autonome** dans [`../DecisionTheory/Infer/`](../DecisionTheory/Infer/README.md), adossé au lake [`decision_theory_lean`](../decision_theory_lean/). Le détail notebook-par-notebook figure dans les sections détaillées ci-dessous.
+Le socle d'inference (1-12) se suit en séquence ; le notebook **13 (Debugging)** est transversal — il compare aussi les trois algorithmes (EP/VMP/Gibbs) et sert de référence dès qu'une inférence dysfonctionne. Les notebooks **14-18 (Frontières)** prolongent le corpus bayésien (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman, détection de rupture). La **théorie de la décision** — utilité espérée, EVPI, MDPs, Thompson Sampling, plus les companions Lean (indice de Gittins) — forme désormais un **arc autonome** dans [`../DecisionTheory/Infer/`](../DecisionTheory/Infer/README.md), adossé au lake [`decision_theory_lean`](../decision_theory_lean/). Le détail notebook-par-notebook figure dans les sections détaillées ci-dessous.
 
 ---
 
@@ -613,7 +614,7 @@ Prolongement naturel de la classification bayésienne : là où [Infer-7](Infer-
 | Sparse GP | `SparseGPFixed(gp, basis)` | Approximation sur $m$ points inducteurs, coût $O(nm^2)$ |
 | Full GP | basis = inputs ($m = n$) | Équivalent au GP non-sparse, coût $O(n^3)$ |
 
-**Positionnement** : [Infer-7](Infer-7-Classification.ipynb) introduisait le **Bayes Point Machine** (hyperplan séparateur, marginalisation sur les poids). Infer-23 en est le complément **non-linéaire** : le GP infère une fonction $f$ tirée d'un processus gaussien, capable de frontières courbes. La démonstration sur un dataset « donut » (disque intérieur + anneau extérieur, **non-séparable linéairement**) prouve que le GP résout ce que le BPM ne peut pas — 16/16 sur le training, avec une incertitude calibrée (P ≈ 0.5 à mi-rayon, la zone d'indécision). La comparaison sparse (4 inducteurs) vs full (16) illustre le continuum coût-exactitude.
+**Positionnement** : [Infer-7](Infer-7-Classification.ipynb) introduisait le **Bayes Point Machine** (hyperplan séparateur, marginalisation sur les poids). Infer-15 en est le complément **non-linéaire** : le GP infère une fonction $f$ tirée d'un processus gaussien, capable de frontières courbes. La démonstration sur un dataset « donut » (disque intérieur + anneau extérieur, **non-séparable linéairement**) prouve que le GP résout ce que le BPM ne peut pas — 16/16 sur le training, avec une incertitude calibrée (P ≈ 0.5 à mi-rayon, la zone d'indécision). La comparaison sparse (4 inducteurs) vs full (16) illustre le continuum coût-exactitude.
 
 **Applications** : classification non-linéaire, régression avec incertitude calibrée, géostatistique (krigeage), optimisation bayésienne (l'acquisition exploite le posterior GP).
 
@@ -644,7 +645,7 @@ Cas d'école du **pooling partiel** : quand les données sont **structurées en 
 | Indexation | `y[i] ~ Gaussian(theta[classOfI[i]], obsPrec)` | Rattachement observation → groupe |
 | Shrinkage | `theta[c]` ↔ compromis données/moyenne | Plus fort pour les groupes clairsemés |
 
-**Positionnement** : le notebook [Infer-4](Infer-4-Bayesian-Networks.ipynb) effleurait le modèle Rats (8 laboratoires) en deux cellules ; Infer-24 en fait un traitement dédié et **démonstratif** — données synthétiques avec **vrais effets connus**, comparaison **no-pool vs partial-pool** mesurée en MSE de récupération. Le gain net (hierarchique bat le no-pooling) et la rétraction visible sur les groupes clairsemés prouvent que le prior de population partagé **emprunte de la force statistique aux voisins** — exactement le paradigme pour lequel Infer.NET (EP analytique sur gaussiennes, `VariableArray` + indexation) est un moteur natif, sans recours au MCMC.
+**Positionnement** : le notebook [Infer-4](Infer-4-Bayesian-Networks.ipynb) effleurait le modèle Rats (8 laboratoires) en deux cellules ; Infer-16 en fait un traitement dédié et **démonstratif** — données synthétiques avec **vrais effets connus**, comparaison **no-pool vs partial-pool** mesurée en MSE de récupération. Le gain net (hierarchique bat le no-pooling) et la rétraction visible sur les groupes clairsemés prouvent que le prior de population partagé **emprunte de la force statistique aux voisins** — exactement le paradigme pour lequel Infer.NET (EP analytique sur gaussiennes, `VariableArray` + indexation) est un moteur natif, sans recours au MCMC.
 
 **Applications** : estimations par établissement/classe, essais multi-centres, mesures répétées par sujet, modèles de recommandation (cf [Infer-12](Infer-12-Recommenders.ipynb)), régressions à coefficients variables par groupe.
 
@@ -675,9 +676,36 @@ Le **filtre de Kalman** (Kalman, 1960) est l'analogue à état **continu** du HM
 | Mise à jour | `engine.Infer<Gaussian>(x)` (EP) | Conjugaison : postérieur gaussien exact |
 | Borne de variance | équation de Riccati discrète | L'incertitude résiduelle plafonne (filtre fiable) |
 
-**Positionnement** : [Infer-11](Infer-11-Sequences.ipynb) couvrait le HMM à état **discret** (météo, mots) ; Infer-25 franchit le pas vers l'état **continu** — le filtre le plus utilisé au monde (navigation GPS, fusion de capteurs, contrôle, finance). La récursion pas-à-pas compile le mini-modèle linéaire-gaussien une fois (`Variable.New<double>` + `ObservedValue`), et EP retourne le postérieur exact qui sert d'a priori au pas suivant. Sur une trajectoire dérivante fortement bruitée ($R = 4 \gg Q = 0{,}5$), le filtre réduit l'erreur de **~74 %** (MSE brute 4,88 → filtrée 1,28) et borne la variance postérieure vers **1,2** (vs $R = 4$) — la signature d'un filtre qui *aide*.
+**Positionnement** : [Infer-11](Infer-11-Sequences.ipynb) couvrait le HMM à état **discret** (météo, mots) ; Infer-17 franchit le pas vers l'état **continu** — le filtre le plus utilisé au monde (navigation GPS, fusion de capteurs, contrôle, finance). La récursion pas-à-pas compile le mini-modèle linéaire-gaussien une fois (`Variable.New<double>` + `ObservedValue`), et EP retourne le postérieur exact qui sert d'a priori au pas suivant. Sur une trajectoire dérivante fortement bruitée ($R = 4 \gg Q = 0{,}5$), le filtre réduit l'erreur de **~74 %** (MSE brute 4,88 → filtrée 1,28) et borne la variance postérieure vers **1,2** (vs $R = 4$) — la signature d'un filtre qui *aide*.
 
 **Applications** : suivi de mobiles, navigation inertielle et GPS, fusion multi-capteurs, filtrage de signaux, tracking financier, estimation d'état en robotique et contrôle.
+
+### Infer-18 : Détection de rupture (change-point bayésien)
+
+Le **point de rupture** (*change-point*) modélise une série qui suit un régime stable, puis **bascule** une seule fois vers un autre régime à un instant `cp` inconnu. Contrairement au HMM d'[Infer-11](Infer-11-Sequences.ipynb) (état discret récurrent) et au filtre de Kalman d'[Infer-17](Infer-17-Kalman-Filter.ipynb) (état continu récurrent), l'inconnue n'est pas une trajectoire d'états mais **un unique entier** — l'indice de la rupture. L'idiome Infer.NET : un *a priori* `Variable.DiscreteUniform(N)` sur `cp`, une sélection de vraisemblance `Variable.If(block.Index <= cp)` / `IfNot` à l'intérieur d'un `Variable.ForEach` sur la plage temporelle, et le moteur **EP** qui retourne un postérieur **`Discrete`** sur la localisation de la rupture.
+
+**Durée** : 50 min | **Prérequis** : [Infer-11-Sequences](Infer-11-Sequences.ipynb) (`Variable.ForEach`), [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb) (conjugaison), [Infer-8-Model-Selection](Infer-8-Model-Selection.ipynb) (Bayes factors)
+
+**Objectifs** :
+
+- Comprendre le change-point comme le quatrième membre de la famille « séquences dans le temps » (HMM, Kalman, GP, rupture)
+- Maîtriser l'idiome `DiscreteUniform` + `ForEach` + `If(block.Index <= cp)` couplé à une plage
+- Construire le modèle **gaussien** (saut de moyenne) et le modèle **de Poisson** (saut de taux — cas canonique des catastrophes minières)
+- Mesurer la concentration du postérieur (entropie) et comprendre le **piège du surajustement** — pourquoi un Bayes factor est nécessaire pour distinguer une vraie rupture d'un caprice du bruit
+
+**Concepts clés** :
+
+| Concept | API | Description |
+| --------- | --------------- | ------------- |
+| Localisation de rupture | `Variable.DiscreteUniform(N)` | *A priori* uniforme sur l'indice entier `cp` |
+| Sélection de régime | `Variable.If(block.Index <= cp)` / `IfNot` | Branche la vraisemblance avant/après la rupture |
+| Postérieur discret | `ie.Infer<Discrete>(cp)` | Vecteur de probabilités sur les $N$ positions |
+| Initialisation EP | `taux.InitialiseTo(...)` | EP déterministe : amorcer les taux évite les optima locaux |
+| Concentration | entropie $H(\text{cp})$ | $H \to 0$ = rupture certaine ; le Bayes factor teste sa réalite (cf. Infer-8) |
+
+**Positionnement** : [Infer-11](Infer-11-Sequences.ipynb) et [Infer-17](Infer-17-Kalman-Filter.ipynb) infèrent un état **récurrent** (un par pas) ; Infer-18 infère un **indice structurel unique** couplé à toute la plage — un usage du `If` sur une plage qu'aucun autre notebook n'exploite. Sur le cas gaussien, EP récupère le vrai point caché **exactement** (mode = 50, masse 0,998) ; sur les catastrophes minières (1851–1962), la rupture est datée à **1890–1891** (taux 3,1 → 0,9, rapport 3,3×), soit le résultat canonique de la littérature. Le notebook pointe aussi vers [Infer-14 (Causal)](Infer-14-Causal-Inference.ipynb) : un point de rupture est un changement de mécanisme générateur.
+
+**Applications** : contrôle qualité (dérive de production), finance (changement de régime de marché), épidémiologie, surveillance de capteurs, datation d'événements structurels en sciences sociales et climatiques.
 
 ---
 

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -11,7 +11,7 @@ maturity: PRODUCTION=47, BETA=1
 
 Le monde réel est incertain. Un diagnostic médical n'est jamais sûr à 100%, un classement sportif dépend de performances intrinsèquement variables, et les données que nous collectons sont toujours bruitées ou incomplètes. La programmation probabiliste offre un cadre rigoureux pour modéliser cette incertitude : plutôt que de calculer une seule réponse, on obtient une **distribution de probabilités** qui quantifie notre confiance dans chaque résultat possible.
 
-Cette série couvre trois stacks complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inférence exacte par message passing, **PyMC** (Python) pour l'échantillonnage MCMC moderne, et des **applications standalone** (RSA). Les 27 notebooks Infer.NET se scindent en deux arcs : **17 notebooks bayésiens** ([`Infer/`](Infer/README.md)) couvrant les fondements (distributions, graphs de facteurs), les modèles classiques (réseaux bayésiens, TrueSkill, LDA, HMM) et les frontières (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman) ; puis un **arc autonome de 10 notebooks de théorie de la décision** ([`DecisionTheory/Infer/`](DecisionTheory/Infer/README.md)) — utilité espérée, EVPI, MDPs, bandits — jusqu'à un compagnon **Lean 4** (Infer-9, adossé au lake [`decision_theory_lean`](decision_theory_lean/)) qui démontre formellement les identités d'escompte de l'indice de Gittins. Les 20 notebooks PyMC reprennent l'intégralité des modèles Infer.NET en Python avec l'échantillonnage NUTS, offrant un pont naturel vers l'écosystème data science : fondations 1-3, modèles classiques 4-13, et théorie de la décision 14-20.
+Cette série couvre trois stacks complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inférence exacte par message passing, **PyMC** (Python) pour l'échantillonnage MCMC moderne, et des **applications standalone** (RSA). Les 28 notebooks Infer.NET se scindent en deux arcs : **18 notebooks bayésiens** ([`Infer/`](Infer/README.md)) couvrant les fondements (distributions, graphs de facteurs), les modèles classiques (réseaux bayésiens, TrueSkill, LDA, HMM) et les frontières (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman, détection de rupture) ; puis un **arc autonome de 10 notebooks de théorie de la décision** ([`DecisionTheory/Infer/`](DecisionTheory/Infer/README.md)) — utilité espérée, EVPI, MDPs, bandits — jusqu'à un compagnon **Lean 4** (Infer-9, adossé au lake [`decision_theory_lean`](decision_theory_lean/)) qui démontre formellement les identités d'escompte de l'indice de Gittins. Les 20 notebooks PyMC reprennent l'intégralité des modèles Infer.NET en Python avec l'échantillonnage NUTS, offrant un pont naturel vers l'écosystème data science : fondations 1-3, modèles classiques 4-13, et théorie de la décision 14-20.
 
 ## Pourquoi cette série
 
@@ -183,8 +183,8 @@ Probas/
 │   ├── PyMC-1-Setup.ipynb ... PyMC-20-Decision-Sequential.ipynb
 │   └── (port en cours d'enrichissement)
 ├── decision_theory_lean/        # Projet Lake (racine série) : escompte géométrique + théorème de Gittins ; accueillera VNM (#4049) + Dutch Book (#4050)
-├── Infer/                       # Corpus bayésien Infer.NET (17 notebooks)
-│   ├── Infer-1-Setup.ipynb ... Infer-17-Kalman-Filter.ipynb
+├── Infer/                       # Corpus bayésien Infer.NET (18 notebooks)
+│   ├── Infer-1-Setup.ipynb ... Infer-18-Change-Point.ipynb
 │   ├── README.md                # Documentation détaillée de la série bayésienne
 │   └── scripts/
 └── DecisionTheory/              # Arc théorie de la décision Infer.NET (10 notebooks, #4725)
@@ -269,9 +269,9 @@ Application avancée à la linguistique pragmatique :
 - Modélisation des hyperboles (prix, excitation)
 - Question Under Discussion (QUD)
 
-## Série Infer.NET (27 notebooks)
+## Série Infer.NET (28 notebooks)
 
-La série se scinde en deux arcs : le **corpus bayésien** (17 notebooks, [`Infer/`](Infer/README.md)) et l'**arc théorie de la décision** (10 notebooks, [`DecisionTheory/Infer/`](DecisionTheory/Infer/README.md)). La documentation détaillée de chaque notebook, les patterns Infer.NET avancés et les exercices corrigés vivent dans ces deux README.
+La série se scinde en deux arcs : le **corpus bayésien** (18 notebooks, [`Infer/`](Infer/README.md)) et l'**arc théorie de la décision** (10 notebooks, [`DecisionTheory/Infer/`](DecisionTheory/Infer/README.md)). La documentation détaillée de chaque notebook, les patterns Infer.NET avancés et les exercices corrigés vivent dans ces deux README.
 
 ### Progression
 
@@ -279,10 +279,10 @@ La série se scinde en deux arcs : le **corpus bayésien** (17 notebooks, [`Infe
 |--------|-----------|-------|-------|
 | **Fondations** | 1-3 | Setup, distributions, factor graphs | 2h |
 | **Modèles classiques** | 4-13 | Bayesian networks, IRT, TrueSkill, LDA, HMM | 8h |
-| **Frontières bayésiennes** | 14-17 | Causalité, GP sparse, hiérarchique, filtre de Kalman | 4h |
+| **Frontières bayésiennes** | 14-18 | Causalité, GP sparse, hiérarchique, filtre de Kalman, change-point | 4,5h |
 | **Décision (arc autonome)** | [DecisionTheory/Infer/ 1-10](DecisionTheory/Infer/README.md) | Théorie de la décision bayésienne + preuve Lean de Gittins | 7h |
 
-Les 27 notebooks Infer.NET sont détaillés individuellement dans [*Ce que chaque notebook apporte*](#ce-que-chaque-notebook-apporte) ci-dessous (apport pédagogique par notebook) ; le contenu exhaustif — patterns avancés, exercices corrigés — vit dans [Infer/README.md](Infer/README.md) et [DecisionTheory/Infer/README.md](DecisionTheory/Infer/README.md).
+Les 28 notebooks Infer.NET sont détaillés individuellement dans [*Ce que chaque notebook apporte*](#ce-que-chaque-notebook-apporte) ci-dessous (apport pédagogique par notebook) ; le contenu exhaustif — patterns avancés, exercices corrigés — vit dans [Infer/README.md](Infer/README.md) et [DecisionTheory/Infer/README.md](DecisionTheory/Infer/README.md).
 
 ## Série PyMC (20 notebooks, Python)
 


### PR DESCRIPTION
## Summary

Nouveau notebook **Infer-18 — Détection de Rupture (Change-Point)**, 4ᵉ membre de la famille « séquences dans le temps » du corpus bayésien. Là où le HMM ([Infer-11](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Sequences.ipynb)) et le filtre de Kalman ([Infer-17](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb)) infèrent un état **récurrent** (un par pas), le change-point infère un **unique entier structurel** — l'indice de la rupture — couplé à toute la plage temporelle.

### Idiome Infer.NET (natif, non couvert ailleurs dans l'arc)

`Variable.DiscreteUniform(N)` (a priori sur `cp`) + `ForEach(range)` avec `If(block.Index <= cp)` / `IfNot` qui branche la vraisemblance avant/après la rupture → EP retourne un postérieur **`Discrete`** sur la localisation. Ce `If` couplé à une plage n'est exercé dans aucun autre notebook (Infer-3 l'utilise statiquement sur Monty Hall, pas sur un indice latent couplé à une range).

### Contenu

| Section | Modèle | Résultat vérifié |
|---------|--------|------------------|
| §2 Gaussien | saut de moyenne synthétique (μ 2→7, N=100) | EP récupère cp=50 **exactement** (mode=50, masse 0,998) ; moyennes 1,89/7,20 (vrai 2/7) |
| §3 Poisson | catastrophes minières 1851-1962 (Jarrett 1979) | rupture datée **1890-1891** (taux 3,12→0,94, rapport 3,3×) = résultat canonique de la littérature |
| §4 Overfitting | contrôle sans rupture | H=0,69 bits (le modèle surajuste une coupure spurieuse) → pointe vers **Bayes factor** (Infer-8) |
| §5 Exercices | 2 change-points / variance-break / robustesse au signal | stubs sans erreur volontaire (C.1) |

Détail technique : EP étant déterministe, le modèle Poisson se piège dans un optimum local (date 1946 au lieu de 1890). Corrigé par **`InitialiseTo` data-driven** (amorçage des taux vers les extrêmes empiriques) → 1891. C'est une leçon pratique sur EP vs MCMC, documentée honnêtement dans le notebook.

### Honnêteté des sorties (règle #3801 + Stop & Repair)

- Aucune sortie fabriquée : tous les outputs sont l'exécution réelle du code (dump-before-prose appliqué).
- Section 4 **ne masque pas** le surajustement du contrôle — elle le nomme et pointe vers Infer-8 (Bayes factor) comme test décisif.
- Prong-B (#3801) : l'inférence d'une localisation de rupture ne dégénère pas en baseline — EP retourne un postérieur discret multimodal sous signal faible, et l'amplitude du saut est co-inférée. Cas d'école du message-passing exact-ish.

## Validation

- **Kernel** : `.net-csharp` (dotnet-interactive), exec end-to-end via `jupyter nbconvert --execute`
- **H.1/H.3** : exec_count 1-9 (toutes les cellules code), 0 erreur, outputs présents et vérifiés
- **C.1** : aucun `raise NotImplementedError`/`assert False`/`1/0` ; exercices = stubs `Console.WriteLine("...à compléter")` + `// TODO etudiant`
- **C.2** : notebook committé AVEC outputs (sorties réelles, non scrubées)
- **check_docs_links** : 0 nouveau lien cassé (2 régressions MGS = drift submodule préexistant, hors diff)
- **READMEs** : Infer/README.md (ligne table 18 + section détail + bloc frontières 14-17→14-18 + fix 2 refs stale Infer-23/24 héritées de #4725) + Probas/README.md (comptes 27→28 / 17→18, arbre, ligne table)
- **Catalogue** : marqueurs CATALOG-STATUS **byte-identical** (CI catalog-drift auto-heal)

## Changements

- `Infer-18-Change-Point.ipynb` (NEW, 23 cellules : 9 code, 14 markdown)
- `Infer/README.md` (table, detail section, frontier block, 2 stale-ref fixes)
- `Probas/README.md` (counts, tree, table row)

See #3801 (Prong-B). Scope atomique : 1 notebook + ses 2 READMEs, 1 sujet (change-point).

Co-Authored-By: Claude-Code <noreply@anthropic.com>