### PR TITLE
refactor(probas): harmonize PyMC decision-arc naming with Infer (drop Decision- prefix)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-1-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-1-Utility-Foundations.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# PyMC-1-Decision-Utility-Foundations : Axiomes et Fondements\n",
+    "# PyMC-1-Utility-Foundations : Axiomes et Fondements\n",
     "\n",
     "**Serie** : Programmation Probabiliste avec PyMC (1/7)  \n",
     "**Duree estimee** : 50 minutes  \n",
@@ -35,7 +35,7 @@
     "\n",
     "| Precedent | Suivant |\n",
     "|-----------|--------|\n",
-    "| [PyMC-13-Debugging](../../PyMC/PyMC-13-Debugging.ipynb) | [PyMC-2-Decision-Utility-Money](PyMC-2-Decision-Utility-Money.ipynb) |\n",
+    "| [PyMC-13-Debugging](../../PyMC/PyMC-13-Debugging.ipynb) | [PyMC-2-Utility-Money](PyMC-2-Utility-Money.ipynb) |\n",
     "\n",
     "---"
    ]
@@ -1754,8 +1754,8 @@
     "\n",
     "| Si vous voulez... | Consultez... |\n",
     "|-------------------|-------------|\n",
-    "| Approfondir l'aversion au risque | [PyMC-2-Decision-Utility-Money](PyMC-2-Decision-Utility-Money.ipynb) |\n",
-    "| Decisions multi-criteres | [PyMC-3-Decision-Multi-Attribute](PyMC-3-Decision-Multi-Attribute.ipynb) |\n",
+    "| Approfondir l'aversion au risque | [PyMC-2-Utility-Money](PyMC-2-Utility-Money.ipynb) |\n",
+    "| Decisions multi-criteres | [PyMC-3-Multi-Attribute](PyMC-3-Multi-Attribute.ipynb) |\n",
     "| Visualiser les reseaux de decision | [PyMC-4-Decision-Networks](PyMC-4-Decision-Networks.ipynb) |\n",
     "\n",
     "## References\n",
@@ -1797,7 +1797,7 @@
     "\n",
     "**Retour au sommaire** : [Index Probas](../../README.md)\n",
     "\n",
-    "**Navigation** : [<< PyMC-13](../../PyMC/PyMC-13-Debugging.ipynb) | [PyMC-2 >>](PyMC-2-Decision-Utility-Money.ipynb)"
+    "**Navigation** : [<< PyMC-13](../../PyMC/PyMC-13-Debugging.ipynb) | [PyMC-2 >>](PyMC-2-Utility-Money.ipynb)"
    ]
   }
  ],
@@ -1825,8 +1825,8 @@
    "end_time": "2026-06-23T21:48:48.423677+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-1-Decision-Utility-Foundations.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-1-Decision-Utility-Foundations.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-1-Utility-Foundations.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-1-Utility-Foundations.ipynb",
    "parameters": {},
    "start_time": "2026-06-23T21:46:31.741535+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-2-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-2-Utility-Money.ipynb
@@ -14,11 +14,11 @@
     "tags": []
    },
    "source": [
-    "# PyMC-2-Decision-Utility-Money : Utilite de l'Argent et Aversion au Risque\n",
+    "# PyMC-2-Utility-Money : Utilite de l'Argent et Aversion au Risque\n",
     "\n",
     "**Serie** : Programmation Probabiliste avec PyMC (2/7)  \n",
     "**Duree estimee** : 60 minutes  \n",
-    "**Prerequis** : [PyMC-1-Decision-Utility-Foundations](PyMC-1-Decision-Utility-Foundations.ipynb) (loteries, axiomes VNM, utilite)\n",
+    "**Prerequis** : [PyMC-1-Utility-Foundations](PyMC-1-Utility-Foundations.ipynb) (loteries, axiomes VNM, utilite)\n",
     "\n",
     "---\n",
     "\n",
@@ -37,7 +37,7 @@
     "\n",
     "| Precedent | Suivant |\n",
     "|-----------|--------|\n",
-    "| [PyMC-1-Decision-Utility-Foundations](PyMC-1-Decision-Utility-Foundations.ipynb) | [PyMC-3-Decision-Multi-Attribute](PyMC-3-Decision-Multi-Attribute.ipynb) |"
+    "| [PyMC-1-Utility-Foundations](PyMC-1-Utility-Foundations.ipynb) | [PyMC-3-Multi-Attribute](PyMC-3-Multi-Attribute.ipynb) |"
    ]
   },
   {
@@ -3429,7 +3429,7 @@
     "\n",
     "| Si vous voulez... | Consultez... |\n",
     "|-------------------|-------------|\n",
-    "| Multi-attributs et compromis | [PyMC-3-Decision-Multi-Attribute](PyMC-3-Decision-Multi-Attribute.ipynb) |\n",
+    "| Multi-attributs et compromis | [PyMC-3-Multi-Attribute](PyMC-3-Multi-Attribute.ipynb) |\n",
     "| Reseaux de decision | [PyMC-4-Decision-Networks](PyMC-4-Decision-Networks.ipynb) |\n",
     "\n",
     "## References\n",
@@ -3476,8 +3476,8 @@
    "end_time": "2026-06-15T04:29:57.624530+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "PyMC-2-Decision-Utility-Money.ipynb",
-   "output_path": "PyMC-2-Decision-Utility-Money.ipynb",
+   "input_path": "PyMC-2-Utility-Money.ipynb",
+   "output_path": "PyMC-2-Utility-Money.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T04:28:43.260206+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-3-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-3-Multi-Attribute.ipynb
@@ -14,11 +14,11 @@
     "tags": []
    },
    "source": [
-    "# PyMC-3-Decision-Multi-Attribute : Utilite Multi-Attributs\n",
+    "# PyMC-3-Multi-Attribute : Utilite Multi-Attributs\n",
     "\n",
     "**Serie** : Programmation Probabiliste avec PyMC (3/7)  \n",
     "**Duree estimee** : 50 minutes  \n",
-    "**Prerequis** : [PyMC-2-Decision-Utility-Money](PyMC-2-Decision-Utility-Money.ipynb) (utilite de l'argent, aversion au risque)\n",
+    "**Prerequis** : [PyMC-2-Utility-Money](PyMC-2-Utility-Money.ipynb) (utilite de l'argent, aversion au risque)\n",
     "\n",
     "---\n",
     "\n",
@@ -36,7 +36,7 @@
     "\n",
     "| Precedent | Suivant |\n",
     "|-----------|--------|\n",
-    "| [PyMC-2-Decision-Utility-Money](PyMC-2-Decision-Utility-Money.ipynb) | [PyMC-4-Decision-Networks](PyMC-4-Decision-Networks.ipynb) |"
+    "| [PyMC-2-Utility-Money](PyMC-2-Utility-Money.ipynb) | [PyMC-4-Decision-Networks](PyMC-4-Decision-Networks.ipynb) |"
    ]
   },
   {
@@ -2790,8 +2790,8 @@
     "| Si vous voulez... | Consultez... |\n",
     "|-------------------|-------------|\n",
     "| Visualiser les reseaux de decision | [PyMC-4-Decision-Networks](PyMC-4-Decision-Networks.ipynb) |\n",
-    "| Calculer la valeur de l'information | [PyMC-5-Decision-Value-Information](PyMC-5-Decision-Value-Information.ipynb) |\n",
-    "| Decisions sequentielles | [PyMC-7-Decision-Sequential](PyMC-7-Decision-Sequential.ipynb) |\n",
+    "| Calculer la valeur de l'information | [PyMC-5-Value-Information](PyMC-5-Value-Information.ipynb) |\n",
+    "| Decisions sequentielles | [PyMC-7-Sequential](PyMC-7-Sequential.ipynb) |\n",
     "\n",
     "---\n",
     "\n",
@@ -2829,7 +2829,7 @@
     "\n",
     "**Retour au sommaire** : [Index Probas](../../README.md)\n",
     "\n",
-    "**Navigation** : [<< PyMC-2](PyMC-2-Decision-Utility-Money.ipynb) | [PyMC-4 >>](PyMC-4-Decision-Networks.ipynb)"
+    "**Navigation** : [<< PyMC-2](PyMC-2-Utility-Money.ipynb) | [PyMC-4 >>](PyMC-4-Decision-Networks.ipynb)"
    ]
   }
  ],
@@ -2857,8 +2857,8 @@
    "end_time": "2026-06-23T22:47:50.086189+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-3-Decision-Multi-Attribute.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-3-Decision-Multi-Attribute.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-3-Multi-Attribute.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-3-Multi-Attribute.ipynb",
    "parameters": {},
    "start_time": "2026-06-23T22:46:21.011081+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-4-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-4-Decision-Networks.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "| Precedent | Suivant |\n",
     "|-----------|--------|\n",
-    "| [PyMC-3-Decision-Multi-Attribute](PyMC-3-Decision-Multi-Attribute.ipynb) | [PyMC-5-Decision-Value-Information](PyMC-5-Decision-Value-Information.ipynb) |\n",
+    "| [PyMC-3-Multi-Attribute](PyMC-3-Multi-Attribute.ipynb) | [PyMC-5-Value-Information](PyMC-5-Value-Information.ipynb) |\n",
     "\n",
     "---"
    ]
@@ -2156,15 +2156,15 @@
     "\n",
     "| Si vous voulez... | Consultez... |\n",
     "|-------------------|-------------|\n",
-    "| Calculer la valeur de l'information | [PyMC-5-Decision-Value-Information](PyMC-5-Decision-Value-Information.ipynb) |\n",
-    "| Decisions robustes | [PyMC-6-Decision-Expert-Systems](PyMC-6-Decision-Expert-Systems.ipynb) |\n",
-    "| Decisions sequentielles (MDPs) | [PyMC-7-Decision-Sequential](PyMC-7-Decision-Sequential.ipynb) |\n",
+    "| Calculer la valeur de l'information | [PyMC-5-Value-Information](PyMC-5-Value-Information.ipynb) |\n",
+    "| Decisions robustes | [PyMC-6-Expert-Systems](PyMC-6-Expert-Systems.ipynb) |\n",
+    "| Decisions sequentielles (MDPs) | [PyMC-7-Sequential](PyMC-7-Sequential.ipynb) |\n",
     "\n",
     "---\n",
     "\n",
     "## Prochaine etape\n",
     "\n",
-    "Dans [PyMC-5-Decision-Value-Information](PyMC-5-Decision-Value-Information.ipynb), nous verrons :\n",
+    "Dans [PyMC-5-Value-Information](PyMC-5-Value-Information.ipynb), nous verrons :\n",
     "\n",
     "- La valeur de l'information parfaite (EVPI)\n",
     "- La valeur de l'information d'echantillon (EVSI)\n",
@@ -2203,7 +2203,7 @@
     "\n",
     "**Retour au sommaire** : [Index Probas](../../README.md)\n",
     "\n",
-    "**Navigation** : [<< PyMC-3](PyMC-3-Decision-Multi-Attribute.ipynb) | [PyMC-5 >>](PyMC-5-Decision-Value-Information.ipynb)"
+    "**Navigation** : [<< PyMC-3](PyMC-3-Multi-Attribute.ipynb) | [PyMC-5 >>](PyMC-5-Value-Information.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-5-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-5-Value-Information.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# PyMC-5 : Valeur de l'Information\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Decision-Value-Information.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Value-Information.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -28,7 +28,7 @@
     "\n",
     "| Notebook precedent | Notebook suivant |\n",
     "|--------------------|------------------|\n",
-    "| [PyMC-4 - Reseaux de decision](PyMC-4-Decision-Networks.ipynb) | [PyMC-6 - Systemes experts](PyMC-6-Decision-Expert-Systems.ipynb) |"
+    "| [PyMC-4 - Reseaux de decision](PyMC-4-Decision-Networks.ipynb) | [PyMC-6 - Systemes experts](PyMC-6-Expert-Systems.ipynb) |"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-6-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-6-Expert-Systems.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# PyMC-6 : Systemes Experts et Decisions Robustes\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Decision-Expert-Systems.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Expert-Systems.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -35,7 +35,7 @@
     "\n",
     "| Notebook precedent | Notebook suivant |\n",
     "|--------------------|------------------|\n",
-    "| [PyMC-5 - Valeur de l'information](PyMC-5-Decision-Value-Information.ipynb) | [PyMC-7 - Decisions sequentielles](PyMC-7-Decision-Sequential.ipynb) |"
+    "| [PyMC-5 - Valeur de l'information](PyMC-5-Value-Information.ipynb) | [PyMC-7 - Decisions sequentielles](PyMC-7-Sequential.ipynb) |"
    ]
   },
   {
@@ -3217,7 +3217,7 @@
     "\n",
     "**Retour au sommaire** : [Index Probas](../../README.md)\n",
     "\n",
-    "**Navigation** : [<< PyMC-5](PyMC-5-Decision-Value-Information.ipynb) | [PyMC-7 >>](PyMC-7-Decision-Sequential.ipynb)"
+    "**Navigation** : [<< PyMC-5](PyMC-5-Value-Information.ipynb) | [PyMC-7 >>](PyMC-7-Sequential.ipynb)"
    ]
   }
  ],
@@ -3245,8 +3245,8 @@
    "end_time": "2026-06-23T00:41:54.751445+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "PyMC-6-Decision-Expert-Systems.ipynb",
-   "output_path": "PyMC-6-Decision-Expert-Systems.ipynb",
+   "input_path": "PyMC-6-Expert-Systems.ipynb",
+   "output_path": "PyMC-6-Expert-Systems.ipynb",
    "parameters": {},
    "start_time": "2026-06-23T00:38:40.337459+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-7-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-7-Sequential.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# PyMC-7 : MDPs, Bandits et POMDPs\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Decision-Sequential.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Sequential.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -39,7 +39,7 @@
     "\n",
     "| Notebook precedent | Notebook suivant |\n",
     "|--------------------|------------------|\n",
-    "| [PyMC-6 - Systemes experts](PyMC-6-Decision-Expert-Systems.ipynb) | *Dernier de la serie* |"
+    "| [PyMC-6 - Systemes experts](PyMC-6-Expert-Systems.ipynb) | *Dernier de la serie* |"
    ]
   },
   {
@@ -4608,12 +4608,12 @@
     "\n",
     "| Notebook | Theme |\n",
     "|----------|-------|\n",
-    "| [PyMC-1](PyMC-1-Decision-Utility-Foundations.ipynb) | Fondements utilite |\n",
-    "| [PyMC-2](PyMC-2-Decision-Utility-Money.ipynb) | Utilite et argent |\n",
-    "| [PyMC-3](PyMC-3-Decision-Multi-Attribute.ipynb) | Multi-attributs |\n",
+    "| [PyMC-1](PyMC-1-Utility-Foundations.ipynb) | Fondements utilite |\n",
+    "| [PyMC-2](PyMC-2-Utility-Money.ipynb) | Utilite et argent |\n",
+    "| [PyMC-3](PyMC-3-Multi-Attribute.ipynb) | Multi-attributs |\n",
     "| [PyMC-4](PyMC-4-Decision-Networks.ipynb) | Reseaux de decision |\n",
-    "| [PyMC-5](PyMC-5-Decision-Value-Information.ipynb) | Valeur de l'information |\n",
-    "| [PyMC-6](PyMC-6-Decision-Expert-Systems.ipynb) | Systemes experts |\n",
+    "| [PyMC-5](PyMC-5-Value-Information.ipynb) | Valeur de l'information |\n",
+    "| [PyMC-6](PyMC-6-Expert-Systems.ipynb) | Systemes experts |\n",
     "| **PyMC-7** | **MDPs, Bandits, POMDPs, Thompson Sampling, PyMC** |"
    ]
   },
@@ -4695,8 +4695,8 @@
    "end_time": "2026-06-15T03:37:39.901230+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "PyMC-7-Decision-Sequential.ipynb",
-   "output_path": "PyMC-7-Decision-Sequential.ipynb",
+   "input_path": "PyMC-7-Sequential.ipynb",
+   "output_path": "PyMC-7-Sequential.ipynb",
    "parameters": {},
    "start_time": "2026-06-15T03:33:38.417359+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
@@ -16,13 +16,13 @@ Jusqu'à la restructure (#4725), la théorie de la décision était imbriquée d
 
 | # | Notebook | Durée | Concepts |
 |---|----------|-------|----------|
-| 1 | [PyMC-1-Decision-Utility-Foundations](PyMC-1-Decision-Utility-Foundations.ipynb) | 50 min | Loteries, axiomes VNM, utilité espérée, diagnostic hiérarchique multi-sites |
-| 2 | [PyMC-2-Decision-Utility-Money](PyMC-2-Decision-Utility-Money.ipynb) | 60 min | Paradoxe St-Petersbourg, CARA, CRRA, profil de risque par inference bayésienne |
-| 3 | [PyMC-3-Decision-Multi-Attribute](PyMC-3-Decision-Multi-Attribute.ipynb) | 50 min | MAUT, SMART, swing weights |
+| 1 | [PyMC-1-Utility-Foundations](PyMC-1-Utility-Foundations.ipynb) | 50 min | Loteries, axiomes VNM, utilité espérée, diagnostic hiérarchique multi-sites |
+| 2 | [PyMC-2-Utility-Money](PyMC-2-Utility-Money.ipynb) | 60 min | Paradoxe St-Petersbourg, CARA, CRRA, profil de risque par inference bayésienne |
+| 3 | [PyMC-3-Multi-Attribute](PyMC-3-Multi-Attribute.ipynb) | 50 min | MAUT, SMART, swing weights |
 | 4 | [PyMC-4-Decision-Networks](PyMC-4-Decision-Networks.ipynb) | 55 min | Diagrammes d'influence, prévalence à test imparfait (état latent) |
-| 5 | [PyMC-5-Decision-Value-Information](PyMC-5-Decision-Value-Information.ipynb) | 45 min | EVPI, EVSI, valeur de l'information |
-| 6 | [PyMC-6-Decision-Expert-Systems](PyMC-6-Decision-Expert-Systems.ipynb) | 50 min | Systèmes experts, Minimax, regret |
-| 7 | [PyMC-7-Decision-Sequential](PyMC-7-Decision-Sequential.ipynb) | 60 min | MDPs, itération valeur/politique, bandits, Thompson Sampling MCMC, POMDPs |
+| 5 | [PyMC-5-Value-Information](PyMC-5-Value-Information.ipynb) | 45 min | EVPI, EVSI, valeur de l'information |
+| 6 | [PyMC-6-Expert-Systems](PyMC-6-Expert-Systems.ipynb) | 50 min | Systèmes experts, Minimax, regret |
+| 7 | [PyMC-7-Sequential](PyMC-7-Sequential.ipynb) | 60 min | MDPs, itération valeur/politique, bandits, Thompson Sampling MCMC, POMDPs |
 
 **Durée totale** : ~6h
 
@@ -47,7 +47,7 @@ Le socle des **fondations** (1-3) pose les axiomes de rationalité et la notion 
 
 ## Spécificité PyMC : Thompson Sampling par MCMC
 
-Là où l'arc [Infer.NET](../Infer/README.md) calcule les posteriors de bandits par message passing (EP/VMP, analytique), cet arc PyMC les obtient par **échantillonnage NUTS**. La valeur distinctive apparaît sur des modèles de bandits **non conjugués** (priors Beta-Bernoulli conjugués mis à part) : seul l'échantillonnage MCMC sait alors explorer le posterior, et Thompson Sampling se nourrit directement des échantillons. Le sujet d'Infer-21 (Thompson Sampling) est, côté Python, **intégré dans** [PyMC-7-Decision-Sequential](PyMC-7-Decision-Sequential.ipynb) (section bandits bayésiens MCMC).
+Là où l'arc [Infer.NET](../Infer/README.md) calcule les posteriors de bandits par message passing (EP/VMP, analytique), cet arc PyMC les obtient par **échantillonnage NUTS**. La valeur distinctive apparaît sur des modèles de bandits **non conjugués** (priors Beta-Bernoulli conjugués mis à part) : seul l'échantillonnage MCMC sait alors explorer le posterior, et Thompson Sampling se nourrit directement des échantillons. Le sujet d'Infer-21 (Thompson Sampling) est, côté Python, **intégré dans** [PyMC-7-Sequential](PyMC-7-Sequential.ipynb) (section bandits bayésiens MCMC).
 
 ## Ponts inter-series
 

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Causal-Inference.ipynb
@@ -25,9 +25,9 @@
     "\n",
     "| Precedent | Suivant |\n",
     "|-----------|---------|\n",
-    "| [PyMC-7-Decision-Sequential](../DecisionTheory/PyMC/PyMC-7-Decision-Sequential.ipynb) | (fin de la serie) |\n",
+    "| [PyMC-7-Sequential](../DecisionTheory/PyMC/PyMC-7-Sequential.ipynb) | (fin de la serie) |\n",
     "\n",
-    "> **Note de numerotation** : ce notebook porte le numero **14** par **parite** avec son jumeau C# [Infer-14-Causal-Inference](../Infer/Infer-14-Causal-Inference.ipynb). Le sujet d'Infer-21 (Thompson Sampling) est, cote Python, **integre dans** [PyMC-7-Decision-Sequential](../DecisionTheory/PyMC/PyMC-7-Decision-Sequential.ipynb) (section 10ter, bandits bayesiens) — d'ou l'absence d'un PyMC-21 distinct.\n",
+    "> **Note de numerotation** : ce notebook porte le numero **14** par **parite** avec son jumeau C# [Infer-14-Causal-Inference](../Infer/Infer-14-Causal-Inference.ipynb). Le sujet d'Infer-21 (Thompson Sampling) est, cote Python, **integre dans** [PyMC-7-Sequential](../DecisionTheory/PyMC/PyMC-7-Sequential.ipynb) (section 10ter, bandits bayesiens) — d'ou l'absence d'un PyMC-21 distinct.\n",
     "\n",
     "> **Ponts inter-series** : le versant **message passing** (Infer.NET, effet causal *calcule* par EP/VMP) est dans [Infer-14-Causal-Inference](../Infer/Infer-14-Causal-Inference.ipynb) ; le versant **symbolique** (Java/Tweety, raisonneur contrefactuel propositionnel) est dans [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb). Ce notebook en est le versant **probabiliste MCMC + enumeration exacte**, ou l'operateur `do` est une **transformation de graphe native** de PyMC."
    ]
@@ -909,7 +909,7 @@
     "\n",
     "---\n",
     "\n",
-    "[← PyMC-7-Decision-Sequential](../DecisionTheory/PyMC/PyMC-7-Decision-Sequential.ipynb) | [Retour a la serie](README.md)"
+    "[← PyMC-7-Sequential](../DecisionTheory/PyMC/PyMC-7-Sequential.ipynb) | [Retour a la serie](README.md)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -45,9 +45,9 @@ La série illustre ce fil rouge sur plusieurs notebooks, chacun sur un cas non-c
 
 - [PyMC-1-Setup](PyMC-1-Setup.ipynb) — introduction : du Beta-Bernoulli conjugué (où MCMC = prior) à un modèle hiérarchique non-centré sur plusieurs pièces, où le shrinkage devient visible.
 - [PyMC-11-Sequences](PyMC-11-Sequences.ipynb) — HMM à états cachés : la vraisemblance de mélange (`NormalMixture`) marginalise l'assignation discrète pour garder un NUTS pur sur les paramètres continus.
-- [PyMC-1-Decision-Utility-Foundations](../DecisionTheory/PyMC/PyMC-1-Decision-Utility-Foundations.ipynb) — diagnostic multi-sites : un portefeuille de groupes hétérogènes où le partial pooling régularise les estimations à faible effectif.
+- [PyMC-1-Utility-Foundations](../DecisionTheory/PyMC/PyMC-1-Utility-Foundations.ipynb) — diagnostic multi-sites : un portefeuille de groupes hétérogènes où le partial pooling régularise les estimations à faible effectif.
 - [PyMC-4-Decision-Networks](../DecisionTheory/PyMC/PyMC-4-Decision-Networks.ipynb) — états latents : prévalence réelle d'un phénomène observé via un test imparfait (inversion d'état caché, non-conjuguée).
-- [PyMC-6-Decision-Expert-Systems](../DecisionTheory/PyMC/PyMC-6-Decision-Expert-Systems.ipynb) — recette de référence : paramétrisation **non-centrée** (offsets de Neal) qui évite le funnel et stabilise la convergence.
+- [PyMC-6-Expert-Systems](../DecisionTheory/PyMC/PyMC-6-Expert-Systems.ipynb) — recette de référence : paramétrisation **non-centrée** (offsets de Neal) qui évite le funnel et stabilise la convergence.
 
 > **Leçon technique récurrente** : sur ces modèles, la **paramétrisation non-centrée** `θ = μ + σ · z` (avec `z ~ Normal(0,1)`) est souvent indispensable. Elle découple l'estimation de la moyenne de celle de la dispersion et évite le *funnel de Neal* — une pathologie géométrique qui piège l'échantillonneur quand la dispersion inter-groupes est faible. Le réflexe naïf « augmenter `target_accept` » **aggrave** alors les divergences ; c'est la reparamétrisation, pas la tolérance, qui débloque la convergence. Voir [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) pour les diagnostics associés.
 
@@ -82,7 +82,7 @@ La série illustre ce fil rouge sur plusieurs notebooks, chacun sur un cas non-c
 
 > **Théorie de la décision** : les notebooks décisionnels (utilité espérée, EVPI, MDPs, bandits) forment désormais une sous-série autonome dans [DecisionTheory/PyMC/](../DecisionTheory/PyMC/README.md) (1 à 7), miroir Python de [DecisionTheory/Infer/](../DecisionTheory/Infer/README.md).
 
-> **Numérotation** : le notebook **14** (inférence causale) porte ce numéro par **parité** avec son jumeau C# [Infer-14-Causal-Inference](../Infer/Infer-14-Causal-Inference.ipynb). Le sujet d'Infer-21 (Thompson Sampling) est, côté Python, **intégré dans** [PyMC-7-Decision-Sequential](../DecisionTheory/PyMC/PyMC-7-Decision-Sequential.ipynb) (section bandits bayésiens MCMC) — d'où l'absence d'un PyMC-21 distinct.
+> **Numérotation** : le notebook **14** (inférence causale) porte ce numéro par **parité** avec son jumeau C# [Infer-14-Causal-Inference](../Infer/Infer-14-Causal-Inference.ipynb). Le sujet d'Infer-21 (Thompson Sampling) est, côté Python, **intégré dans** [PyMC-7-Sequential](../DecisionTheory/PyMC/PyMC-7-Sequential.ipynb) (section bandits bayésiens MCMC) — d'où l'absence d'un PyMC-21 distinct.
 
 > **Ponts causaux** : [PyMC-14](PyMC-14-Causal-Inference.ipynb) est le maillon **MCMC** d'un pont à quatre paradigmes autour du `do(·)` de Pearl — le jumeau **message passing** en C# [Infer-14](../Infer/Infer-14-Causal-Inference.ipynb) (Infer.NET, EP/VMP), le jumeau symbolique [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb), et la lecture par l'émergence causale [ICT-5](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb). Vue d'ensemble : le [README IIT](../../IIT/README.md), section « Ponts causaux : le do-calculus de Pearl à travers les paradigmes ».
 
@@ -149,10 +149,10 @@ Notebooks 1-3 (fondations) puis 7-8 (classification/sélection) puis 9-12 (modè
 
 Ce parcours couvre l'utilité espérée, la valeur de l'information et les MDPs avec un moteur MCMC. Il se suit dans la sous-série [DecisionTheory/PyMC/](../DecisionTheory/PyMC/README.md) (notebooks 1 à 7).
 
-1. [PyMC-1](../DecisionTheory/PyMC/PyMC-1-Decision-Utility-Foundations.ipynb) -> axiomes VNM
-2. [PyMC-2](../DecisionTheory/PyMC/PyMC-2-Decision-Utility-Money.ipynb) -> aversion au risque
+1. [PyMC-1](../DecisionTheory/PyMC/PyMC-1-Utility-Foundations.ipynb) -> axiomes VNM
+2. [PyMC-2](../DecisionTheory/PyMC/PyMC-2-Utility-Money.ipynb) -> aversion au risque
 3. [PyMC-4](../DecisionTheory/PyMC/PyMC-4-Decision-Networks.ipynb) -> réseaux de décision
-4. [PyMC-5](../DecisionTheory/PyMC/PyMC-5-Decision-Value-Information.ipynb) -> [PyMC-7](../DecisionTheory/PyMC/PyMC-7-Decision-Sequential.ipynb) -> EVPI, MDPs
+4. [PyMC-5](../DecisionTheory/PyMC/PyMC-5-Value-Information.ipynb) -> [PyMC-7](../DecisionTheory/PyMC/PyMC-7-Sequential.ipynb) -> EVPI, MDPs
 
 ### Parcours comparatif Infer.NET vs PyMC (~15h)
 

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -189,7 +189,7 @@ Probas/
 │   └── scripts/
 └── DecisionTheory/              # Arc théorie de la décision (#4725) : Infer.NET + PyMC (miroirs)
     ├── Infer/                   # Infer-1-Utility ... Infer-10-Thompson (+ companions Lean 2/9)
-    └── PyMC/                    # PyMC-1-Decision ... PyMC-7-Decision-Sequential
+    └── PyMC/                    # PyMC-1-Decision ... PyMC-7-Sequential
 ```
 
 ## Ce que chaque notebook apporte
@@ -318,13 +318,13 @@ Port Python complet des modèles Infer.NET, utilisant l'échantillonnage MCMC (N
 
 | # | Notebook | Sujet |
 |---|----------|-------|
-| 1 | [PyMC-1-Decision-Utility-Foundations](DecisionTheory/PyMC/PyMC-1-Decision-Utility-Foundations.ipynb) | Loteries, axiomes Von Neumann-Morgenstern, utilité espérée |
-| 2 | [PyMC-2-Decision-Utility-Money](DecisionTheory/PyMC/PyMC-2-Decision-Utility-Money.ipynb) | Aversion au risque, CARA, CRRA, paradoxe Saint-Petersbourg |
-| 3 | [PyMC-3-Decision-Multi-Attribute](DecisionTheory/PyMC/PyMC-3-Decision-Multi-Attribute.ipynb) | MAUT, SMART, swing weights, décisions multi-critères |
+| 1 | [PyMC-1-Utility-Foundations](DecisionTheory/PyMC/PyMC-1-Utility-Foundations.ipynb) | Loteries, axiomes Von Neumann-Morgenstern, utilité espérée |
+| 2 | [PyMC-2-Utility-Money](DecisionTheory/PyMC/PyMC-2-Utility-Money.ipynb) | Aversion au risque, CARA, CRRA, paradoxe Saint-Petersbourg |
+| 3 | [PyMC-3-Multi-Attribute](DecisionTheory/PyMC/PyMC-3-Multi-Attribute.ipynb) | MAUT, SMART, swing weights, décisions multi-critères |
 | 4 | [PyMC-4-Decision-Networks](DecisionTheory/PyMC/PyMC-4-Decision-Networks.ipynb) | Réseaux de décision, diagrammes d'influence, politique optimale |
-| 5 | [PyMC-5-Decision-Value-Information](DecisionTheory/PyMC/PyMC-5-Decision-Value-Information.ipynb) | EVPI, EVSI, valeur de l'information parfaite et d'échantillon |
-| 6 | [PyMC-6-Decision-Expert-Systems](DecisionTheory/PyMC/PyMC-6-Decision-Expert-Systems.ipynb) | Systèmes experts, Minimax, Minimax Regret, décisions robustes |
-| 7 | [PyMC-7-Decision-Sequential](DecisionTheory/PyMC/PyMC-7-Decision-Sequential.ipynb) | MDPs, itération de valeur/politique, bandits, POMDPs |
+| 5 | [PyMC-5-Value-Information](DecisionTheory/PyMC/PyMC-5-Value-Information.ipynb) | EVPI, EVSI, valeur de l'information parfaite et d'échantillon |
+| 6 | [PyMC-6-Expert-Systems](DecisionTheory/PyMC/PyMC-6-Expert-Systems.ipynb) | Systèmes experts, Minimax, Minimax Regret, décisions robustes |
+| 7 | [PyMC-7-Sequential](DecisionTheory/PyMC/PyMC-7-Sequential.ipynb) | MDPs, itération de valeur/politique, bandits, POMDPs |
 
 ### Phase 4 — Inférence causale (notebook 14, ~1h)
 


### PR DESCRIPTION
## Summary

Epic **#4725** follow-up to #4759 (merged). ai-01 decision (msg-`...snnqy7`): drop the `Decision-` filename prefix on 6/7 PyMC decision notebooks to restore the conceptual **Infer↔PyMC parallelism** the refactor aimed for — the Infer sibling (#4737) dropped it (`Infer-1-Utility-Foundations`), but #4759 had kept it (`PyMC-1-Decision-Utility-Foundations`), a visible divergence.

**PyMC-4-Decision-Networks kept** ("Decision" IS the concept there, mirrors `Infer-5-Decision-Networks`).

### Renames (6) + content edits
| old | new |
|-----|-----|
| PyMC-1-Decision-Utility-Foundations | PyMC-1-Utility-Foundations |
| PyMC-2-Decision-Utility-Money | PyMC-2-Utility-Money |
| PyMC-3-Decision-Multi-Attribute | PyMC-3-Multi-Attribute |
| PyMC-5-Decision-Value-Information | PyMC-5-Value-Information |
| PyMC-6-Decision-Expert-Systems | PyMC-6-Expert-Systems |
| PyMC-7-Decision-Sequential | PyMC-7-Sequential |

PyMC-4-Decision-Networks: content edited for sibling refs, **not** renamed.

### Inbound ref re-point
Basenames + prose + `metadata.papermill.input_path`, across: `Probas/README.md`, `DecisionTheory/PyMC/README.md` + the 7 notebooks, `PyMC/README.md`, `PyMC-14-Causal-Inference` (refs PyMC-7). **Blast radius entirely within Probas/** — the causal PyMC-14 and the IIT/Tweety/SmartContracts inbound refs are bare-number/causal, unaffected by the decision-prefix drop.

## Vérification (preuves vérifiables) — garde-fous obligatoires ai-01
- **`check_docs_links.py --check` : 0 broken (3044 total)** — leçon #4737 respectée ✅
- **`git grep 'PyMC-[0-9]+-Decision-(Utility|Multi-Attribute|Value|Expert|Sequential)'` : 0 résiduel repo-wide** (Networks regex-excluded) — c'est le **second garde-fou obligatoire** car `check_docs_links` ne scanne PAS les cellules markdown `.ipynb` ✅
- **`COURSE_CATALOG` byte-identique** à `origin/main` ; marqueurs `CATALOG-STATUS` inchangés ✅
- **JSON integrity** : 8 notebooks OK ; `metadata.papermill.input_path` → nouveaux basenames ✅
- 11 fichiers, 70+/70- (sous seuils G.4) ; worktree isolé `d:/dev/wt-pymc-4725` fresh off `origin/main` `b88ddf43d`

## C.2 — exempt
Markdown-only (titres/nav/refs) + `metadata.papermill` (exception autorisée). Aucune cellule code modifiée → pas de re-exec. Outputs préservés byte-identiques.

Closes #4725 (les 2 moitiés sur main : Infer #4737 + PyMC #4759 ; naming maintenant harmonisé Infer↔PyMC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)