### PR TITLE
feat(hashlife): P4.4 LHS-assembly through whnf wall — node16_level_ne_two + node out_* decomp (sorry 4->4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1707,6 +1707,29 @@ private theorem node16_level (nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
   show 1 + (1 + nw_nw.level) = n
   omega
 
+/-- **P4.4 assembly grain (c.156).** In a CLEAN context (the 16 grandchildren as
+    opaque binders + one level hypothesis), the `hashlifeResultAux_succ_node`
+    if-condition `(node16).level == 2` is false for `k ≥ 1` (the node level is
+    `k + 2 ≥ 3`). Proven standalone because stating/rewriting `(node16).level`
+    INLINE inside `p4_succ_membership`'s rich context (post `_h1`/`_h2`/`_h3`/`_h4`
+    obtain of 16 gc's) whnf-diverges (the c.142 pathology). Applying this helper
+    there keeps the level term inferred, never re-elaborated — the opaque-binder
+    pattern of c.139/c.143. -/
+private theorem node16_level_ne_two (k : Nat) (hk1 : 1 ≤ k)
+    (nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+     sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se : MacroCell)
+    (hnw : nw_nw.level = k) :
+    ¬ ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+             (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).level == 2) := by
+  -- Mirror the working pos-arm discharge at L1810-1815: `beq_iff_eq` converts the
+  -- `==` (Nat.beq) to `=`, then omega finds k+2 = 2 contradicts k >= 1.
+  intro heq
+  have hnode := node16_level nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+               sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se (k + 2) (by omega) (by omega)
+  rw [hnode] at heq
+  have hn2 : k + 2 = 2 := by simpa [beq_iff_eq] using heq
+  omega
+
 /-- Apply the level/`cellWf` IH to a `node` of four level-`(n-2)` `cellWf` cells
     (c.142 workhorse), for BOTH wave layers of the preservation lemma: wave-1
     (the nine `n_i`, each a `node` of four grandchildren) and wave-2 (the four
@@ -2354,6 +2377,33 @@ noncomputable def p4_succ_membership
   have _h3 := p4_wave2_ih c k hwf hk hk1 ih
   have _h4 := p4_half_steps_compose c k hwf hk
   intro p
+  -- LHS assembly (c.156). The 3 G3 gates (hcnode, hashlifeResultAux_succ_node,
+  -- if_neg) now compose through the whnf wall, exposing the `node out_*`
+  -- constructor and decomposing it via `mem_toGrid_node`.
+  -- Destruct c via _h1 (p4_double_nine_shape: c = node(node×4)×4 ∧ 16 facts).
+  obtain ⟨nw_nw, nw_ne, nw_sw, nw_se, ne_nw, ne_ne, ne_sw, ne_se,
+          sw_nw, sw_ne, sw_sw, sw_se, se_nw, se_ne, se_sw, se_se, _hcshape⟩ := _h1
+  obtain ⟨hcnode, hfacts⟩ := _hcshape
+  -- Rewrite the input cell to its 16-grandchild node, then iota-reduce hRA.
+  rw [hcnode]
+  rw [show (k + 2) = (k + 1) + 1 from by omega]
+  rw [hashlifeResultAux_succ_node]
+  -- The if-condition (node16).level == 2 is FALSE for k >= 1 (level = k+2 >= 3).
+  -- Discharge via the clean-context helper (opaque binders, c.139/c.143 pattern):
+  -- applying it here keeps the level term inferred, never whnf-re-elaborated.
+  have hne2 := node16_level_ne_two k hk1
+    nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+    sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se hfacts.1
+  rw [if_neg hne2]
+  -- LHS is now `p ∈ (node out_nw out_ne out_sw out_se).toGrid (2^k, 2^k)`;
+  -- `mem_toGrid_node` (G3) decomposes it into the four quadrant memberships.
+  rw [mem_toGrid_node]
+  -- RESIDUAL (the offset-matching assembly): each `out_*.toGrid (off_*, off_*)`
+  -- must be characterized via `centralCorrect_mem` (G2 congruence, crossing the
+  -- whnf wall on the composed result) + the induction hypothesis `centralCorrect
+  -- q_* (k-1)` from `_h3`, then bridged to the RHS window via `evolve_half_step`
+  -- (the `2^k` half-step) + `evolve_add` (G1). The offsets `2^out_*.level` vs
+  -- `2^k` and the ih at level (k-1) vs goal at level k are the matching core.
   sorry
 
 /-- For a level-`k` MacroCell `c` with `k ≥ 2`, the centered region of


### PR DESCRIPTION
## Summary

Sorry-stable infrastructure for lane **#3846** (Conway Hashlife GOL). The `p4_succ_membership` **LHS assembly now composes the 3 G3 gates through the whnf wall**, exposing the `node out_*` constructor and decomposing it via `mem_toGrid_node`. A new proven helper `node16_level_ne_two` discharges the `if ... == 2` condition in a clean context (opaque-binder pattern c.139/c.143). Branched fresh off `b88ddf43d` (post #4767), rebased onto origin/main.

## The breakthrough (c.156)

The c.156 probe confirmed that stating `(node16).level = k+2` **INLINE** inside `p4_succ_membership`'s rich context (post `obtain` of 16 gc's + `_h1`/`_h2`/`_h3`/`_h4`) **whnf-diverges** (the c.142 pathology — 8M-heartbeat timeout). The fix: a clean-context helper (`node16_level_ne_two`) that takes the 16 gc's as opaque binders. Applying it in the rich context keeps the level term **inferred**, never re-elaborated.

With this helper, the full chain compiles **EXIT 0 with NO whnf divergence**:

```
hcnode → show (k+2)=(k+1)+1 → hashlifeResultAux_succ_node → if_neg → mem_toGrid_node
```

The LHS is now `p ∈ out_nw.toGrid … ∨ out_ne.toGrid … ∨ out_sw.toGrid … ∨ out_se.toGrid …` — exactly the state the G3 gates were designed to reach.

## New helper `node16_level_ne_two` (~L1712)

```
¬ ((node (node nw_nw..)(node ne_nw..)(node sw_nw..)(node se_nw..)).level == 2)
```
for `k ≥ 1`, given `nw_nw.level = k`. Proof:
```
intro heq
have hnode := node16_level … (k + 2) (by omega) (by omega)
rw [hnode] at heq
have hn2 : k + 2 = 2 := by simpa [beq_iff_eq] using heq
omega
```

## Key lesson — `beq_iff_eq` for `==` (Nat.beq) discharge

`omega` **cannot** directly close `¬ (x == 2)` — `==` is `Nat.beq` (Bool, with an Int coercion `↑` that omega atomizes as a free variable, disconnecting the `hnw` hypothesis). The canonical discharge pattern (mirrors the working pos-arm at L1810-1815):

```
intro heq; rw [hnode] at heq; have : k+2 = 2 := by simpa [beq_iff_eq] using heq; omega
```

This unblocks every `if c.level == 2 then` split in the lane.

## The residual (offset-matching assembly — the research-level core)

Each `out_*.toGrid (off, off)` must be characterized via `centralCorrect_mem` (G2 congruence, crossing the whnf wall on the composed result) + the induction hypothesis `centralCorrect q_* (k-1)` from `_h3`, then bridged to the RHS window via `evolve_half_step` (the `2^k` half-step) + `evolve_add` (G1). The offsets `2^out_*.level` vs `2^k`, and the ih at level `(k-1)` vs goal at level `k`, are the matching core. Closing this would take `p4_succ_membership` **sorry 4→3** (the real front).

## Why sorry-stable (4→4, honest)

`+50 insertions, 0 deletions`. The new helper is proven (no `sorryAx`). `p4_succ_membership` already had its 1 sorry — it is **relocated, not added**: the restructuring proves the LHS-assembly compiles + characterizes the residual precisely. Same shape as the P4.3 cadence (c.142 gate sorry-stable → c.143 consumer sorry 5→4). The `node16_level_ne_two` helper + LHS-assembly is the "gate" the next cycle consumes for the offset-matching.

## Lean PR checklist (pr-review-discipline §B)

1. **sorry before/after**: **4 → 4** (authoritative token grep, exclude `.lake`, same regex `^\s*sorry\s*$|:= by sorry|:= sorry\b|exact sorry|^\s*· sorry`, verified on both `origin/main` and `HEAD`). The 4 sorries: `p4_half_steps_compose`, `p4_succ_membership` (relocated residual), 2× P5.
2. **Lake build SUCCESS**: `lake build Conway.Life.HashlifeCorrectness` → **EXIT 0** (Mathlib junction `54f98fd6` rc2, `lake.exe` Windows-side, 3320 jobs, ~80s).
3. **Proof integrity**: `node16_level_ne_two` proven by `omega`/`simpa` — **no `sorryAx`, no "declaration uses sorry" warning** on it (the 4 warnings are the 4 pre-existing sorries).
4. **No prover Python refactor** — N/A.

## Anti-regression

+50 insertions, 0 deletions. New helper only + restructuring of `p4_succ_membership` body (which was already `sorry`). No existing proof touched. Sorry count unchanged (4→4, verified firsthand).

See #3846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
