### PR TITLE
docs(gametheory): repair 4 broken docs/lean/ paths in LEAN_INVENTORY

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
@@ -172,7 +172,7 @@ Conway calibration targets (Doomsday / FRACTRAN / Look-and-Say / Nim / Angel) li
 
 ## Related documentation
 
-- [docs/lean/sota-2026-analysis.md](../../../docs/lean/sota-2026-analysis.md) — SOTA in automated Lean 4 proving
-- [docs/lean/prover_iteration_history.md](../../../docs/lean/prover_iteration_history.md) — Prover iterations F6-F11, B3
-- [docs/lean/llm-endpoints.md](../../../docs/lean/llm-endpoints.md) — LLM providers for the prover
-- [docs/lean/coordinator-workflow.md](../../../docs/lean/coordinator-workflow.md) — Coordinator build + BG iter workflow
+- [docs/lean/sota-2026-analysis.md](../../docs/lean/sota-2026-analysis.md) — SOTA in automated Lean 4 proving
+- [docs/lean/prover_iteration_history.md](../../docs/lean/prover_iteration_history.md) — Prover iterations F6-F11, B3
+- [docs/lean/llm-endpoints.md](../../docs/lean/llm-endpoints.md) — LLM providers for the prover
+- [docs/lean/coordinator-workflow.md](../../docs/lean/coordinator-workflow.md) — Coordinator build + BG iter workflow


### PR DESCRIPTION
## Summary

`GameTheory/LEAN_INVENTORY.md` lignes 175-178 contenaient 4 liens cassés vers `docs/lean/` : ils utilisaient `../../../docs/lean/` (3 niveaux `../`) qui, depuis `MyIA.AI.Notebooks/GameTheory/`, résout vers **le parent du repo** (`../docs/lean/` = absent). Les 4 cibles existent à la racine du repo sous `docs/lean/` — il fallait 2 niveaux `../`.

## Fix

Mécanique, 4 lignes : `../../../docs/lean/` → `../../docs/lean/`. Aucune ambiguïté — les 4 fichiers cibles sont vérifiés existants :
- `docs/lean/sota-2026-analysis.md` ✅
- `docs/lean/prover_iteration_history.md` ✅
- `docs/lean/llm-endpoints.md` ✅
- `docs/lean/coordinator-workflow.md` ✅

## Vérification

- `check_docs_links.py --check` : **0 new broken, 0 pre-existing (3044 total)** ✅
- 4 cibles `git cat-file -e` vérifiées EXISTANTES ✅
- Markdown-only (4 lignes), atomique (§A OK)

## Contexte

Découvert via un sweep repo-wide des dangling notebook/md links. La leçon #4767 : `check_docs_links.py` ne scanne pas les cellules markdown des `.ipynb` et rate certains chemins relatifs — un sweep direct complète le garde-fou. Sur ma lane (Probas/GameTheory/IIT), 7 dangling trouvés ; ce PR en fixe 4 (les `docs/lean/` de GameTheory). Les autres (LEAN_INVENTORY refs `.claude/projects/` machine-locales, 1 lien sibling PyMC-7) sont traités à part (PyMC-7 dans #4772).

Self-serve pool pickup (méthode Rule-5, ai-01 2026-07-01).

Co-Authored-By: Claude-Code <noreply@anthropic.com>