### PR TITLE
docs(owui-tour): finalize Tour writing for v0.10 + harden capture apparatus

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/README.md
@@ -29,13 +29,15 @@ Chaque section suit le même rythme :
 4. **Exercice** *(certaines sections)* — une manipulation à faire soi-même.
 
 > **Note sur les captures.** Les images de ce tour sont produites de façon
-> **reproductible** par un script Playwright ([`capture/`](capture/)) qui vise un
-> **tenant de démonstration** dédié, avec un compte non-administrateur, des
-> données fictives, et le masquage (`mask`) des zones sensibles. Tant que le
-> tenant de démonstration n'est pas en ligne, les emplacements de capture sont
-> indiqués par `📷 Capture à venir` et le dossier [`assets/`](assets/) reste un
-> gabarit. **Aucune capture ne montre d'URL réelle de tenant, d'e-mail nominatif,
-> de clé ni de jeton.**
+> **reproductible** par un script Playwright ([`capture/`](capture/)) exécuté
+> contre une **instance réelle** avec un **compte non-administrateur**, sur des
+> **données fictives ou fraîches**, et avec le **masquage** (`mask`) des zones
+> sensibles. Chaque image passe une **revue anti-fuite** avant d'être commitée.
+> Les captures de surfaces qui exposeraient du contenu réel d'un établissement
+> (listes de modèles ou de bases internes, canaux) restent volontairement
+> indiquées par `📷 Capture à venir` et **schématisées** dans
+> [`architecture.md`](architecture.md). **Aucune capture ne montre d'URL réelle de
+> tenant, d'e-mail nominatif, de clé ni de jeton.**
 
 ---
 
@@ -49,6 +51,18 @@ Chaque section suit le même rythme :
 | 4 | [Canaux & collaboration](#4--canaux--collaboration) | Échanges en équipe, bots |
 | 5 | [Notes & autres surfaces](#5--notes--autres-surfaces) | Prise de notes, historique, paramètres |
 | 6 | [Administration & multi-tenant](#6--administration--multi-tenant) | Panneau admin, RBAC, isolation des tenants |
+
+> **Nouveautés de la v0.10 (juillet 2026).** Cette édition du tour intègre les
+> apports marquants de la version 0.10 d'Open WebUI, signalés par la mention
+> ***(nouveau — v0.10)*** au fil des sections :
+> - **Raisonnement affiché en direct** et **compaction automatique du contexte** (section 2) ;
+> - **Dossiers d'équipe partageables** et **téléversement de dossier** vers une base de connaissances (section 3) ;
+> - **Mémoire** de l'assistant, sortie de bêta (section 5) ;
+> - **Configuration de l'authentification** déplacée dans le panneau d'administration (section 6).
+>
+> Ces mêmes fonctionnalités sont *testées* par le **module 06** de la
+> [série QA Playwright-OWUI](../Playwright-OWUI/README.md) : le tour montre *comment
+> s'en servir*, la série QA vérifie *qu'elles marchent*.
 
 ---
 
@@ -89,8 +103,24 @@ WebUI unifie derrière une seule interface des modèles très différents — lo
 4. Reprenez une réponse, régénérez-la, ou comparez deux modèles côte à côte selon
    les options offertes par votre instance.
 
+**Raisonnement affiché en direct *(nouveau — v0.10)*.** Avec les modèles dits
+« thinking » (Claude, Qwen, o-series…), la plateforme affiche désormais **en
+temps réel** les étapes de raisonnement du modèle, dans un bloc repliable placé
+au-dessus de la réponse finale. On voit le modèle « réfléchir » pendant qu'il
+génère, puis on peut replier ce bloc pour ne garder que la conclusion. C'est un
+appui pédagogique précieux : on rend visible le *cheminement*, pas seulement le
+résultat.
+
+**Compaction automatique du contexte *(nouveau — v0.10)*.** Sur les conversations
+longues, la plateforme **résume et compacte** automatiquement les échanges les
+plus anciens pour rester dans la fenêtre de contexte du modèle, sans qu'on ait à
+démarrer une nouvelle conversation. La discussion se prolonge donc sans perdre le
+fil ni provoquer d'erreur de dépassement de contexte.
+
 > 📷 Capture à venir — `02-chat-streaming.png` (réponse en cours de streaming) et
 > `02-selecteur-modele.png` (liste des modèles), masquage du nom d'utilisateur.
+> `02-raisonnement-direct.png` illustre le bloc de raisonnement en direct
+> *(nouveau — v0.10)*.
 
 ### Exercice 1 — Prendre le chat en main
 
@@ -119,10 +149,19 @@ outils, et constituer des bases de connaissances interrogeables (RAG).
   API, exécuter du code, consulter une source externe via le protocole MCP.
 - **Bases de connaissances (RAG).** Téléversez des documents ; la plateforme les
   découpe, les vectorise et les rend interrogeables. Le modèle cite alors vos
-  documents dans ses réponses.
+  documents dans ses réponses. *(nouveau — v0.10)* Le **téléversement d'un dossier
+  entier** préserve désormais son **arborescence** : la structure des sous-dossiers
+  est conservée dans la base, ce qui aide à organiser de gros corpus.
+- **Dossiers d'équipe partageables *(nouveau — v0.10)*.** On peut regrouper des
+  conversations (et le travail associé) dans des **dossiers**, puis **partager un
+  dossier avec un groupe**. Tous les membres du groupe y accèdent avec les droits
+  accordés — pratique pour un binôme de TP ou une promotion entière. Le partage
+  s'appuie sur le même modèle d'octroi d'accès que les modèles et les bases (voir
+  le [modèle RBAC](architecture.md)).
 
 > 📷 Capture à venir — `03-workspace-modele.png`, `03-base-connaissances.png`
-> (données fictives uniquement).
+> (données fictives uniquement) ; `03-dossier-equipe.png` pour le partage de
+> dossier *(nouveau — v0.10)*.
 
 ### Exercice 2 — Créer un assistant RAG
 
@@ -170,9 +209,15 @@ prise de **notes**, historique et recherche des conversations, dossiers, et
   conversations.
 - **Paramètres** — changez la langue de l'interface (multilingue), le thème
   clair/sombre, activez la synthèse ou la reconnaissance vocale.
+- **Mémoire *(nouveau — v0.10)*.** L'assistant peut **retenir des informations**
+  d'une conversation à l'autre (mémoire à long terme) ou au sein d'une conversation
+  donnée. On garde la **main** : la mémoire se gère depuis *Paramètres >
+  Personnalisation*, où l'on consulte, modifie ou supprime chaque souvenir. Sortie
+  de bêta en v0.10, elle permet par exemple à un tuteur de se rappeler le niveau ou
+  les préférences d'un·e étudiant·e sans qu'on ait à les répéter.
 
 > 📷 Capture à venir — `05-parametres.png` (panneau de paramètres, identité
-> masquée).
+> masquée) ; `05-memoire.png` pour la gestion de la mémoire *(nouveau — v0.10)*.
 
 ### Exercice 3 — Personnaliser son espace
 
@@ -210,6 +255,10 @@ même infrastructure, chacun isolé des autres.
 3. Les **connecteurs** déclarent les fournisseurs de modèles (URL, type) ; les
    secrets associés ne vivent **jamais** dans un support pédagogique — voir la
    section sécurité ci-dessous.
+4. *(nouveau — v0.10)* La **configuration de l'authentification** (OAuth, LDAP,
+   SAML, inscription ouverte ou sur invitation) se règle désormais **dans le
+   panneau d'administration** plutôt que par des variables d'environnement au
+   démarrage — un·e admin peut donc ajuster ces réglages sans redéployer l'instance.
 
 ### Exercice 4 — Cartographier les accès (sur schéma)
 
@@ -227,9 +276,10 @@ module 5 vérifie par des tests.)*
 
 Conformément à la [politique du dossier ombrelle](../README.md#sécurité--pas-de-secret-dans-les-supports) :
 pas d'URL de tenant réel, pas d'e-mail nominatif, pas de clé d'API ni de jeton,
-pas de mot de passe. Les captures s'appuient sur un **tenant de démonstration**
-(compte non-admin, données fictives, masquage Playwright). Les identifiants et
-URL de démonstration vivent dans un `.env` **non commité** ; seuls les
+pas de mot de passe. Les captures sont produites contre une **instance réelle**
+via un **compte non-administrateur neuf** (aucune donnée réelle visible), avec
+**masquage Playwright** et **revue anti-fuite de chaque image**. Les identifiants
+et l'URL de capture vivent dans un `.env` **non commité** ; seuls les
 `*.env.example` documentent les variables attendues. Voir
 [`capture/README.md`](capture/README.md).
 
@@ -246,5 +296,6 @@ URL de démonstration vivent dans un `.env` **non commité** ; seuls les
 ---
 
 *Tour de la plateforme — parcours découverte (Epic #4433, sous #4427). FR-first.
-Statut : narratif disponible ; captures live à générer une fois le tenant de
-démonstration en ligne.*
+Édition **v0.10** (contenu validé contre Open WebUI 0.10.2, juillet 2026).
+Statut : narratif complet ; script de capture reproductible prêt (voir la
+[note sur les captures](#comment-lire-ce-tour)).*

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/architecture.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/architecture.md
@@ -77,8 +77,9 @@ flowchart LR
     User -->|role| Role{Role<br/>admin / user / pending}
     Group -->|octroi d'acces| Grant[Access grant]
     Grant -->|autorise| Res[Ressource<br/>modele, base de connaissances, outil]
+    Grant -->|autorise| Folder[Dossier d'equipe<br/>conversations partagees<br/>v0.10]
 
-    Role -. admin .-> Admin[Panneau d'administration<br/>gestion users / groupes / connecteurs]
+    Role -. admin .-> Admin[Panneau d'administration<br/>gestion users / groupes / connecteurs<br/>+ config authentification v0.10]
 ```
 
 - Un **rôle** détermine ce qu'on peut faire globalement (un *admin* accède au
@@ -88,6 +89,16 @@ flowchart LR
 - Un **access grant** relie un groupe (ou « tout le monde ») à une ressource
   précise. C'est le maillon qui répond à la question « qui a le droit de voir ce
   modèle / cette base de connaissances ? ».
+- **Dossiers d'équipe *(nouveau — v0.10)*.** Le même mécanisme d'octroi d'accès
+  s'étend aux **dossiers** : partager un dossier avec un groupe, c'est créer un
+  *access grant* du groupe vers ce dossier. Les membres accèdent alors aux
+  conversations qu'il contient, toujours **dans les limites de leur tenant** —
+  l'isolation multi-tenant de la section 1 reste la frontière infranchissable.
+- **Configuration de l'authentification *(nouveau — v0.10)*.** Les réglages
+  d'identité (OAuth, LDAP, SAML, mode d'inscription) se pilotent désormais depuis
+  le **panneau d'administration** et non plus uniquement par variables
+  d'environnement au démarrage — d'où la branche `+ config authentification` sur
+  le nœud d'administration ci-dessus.
 
 ---
 
@@ -157,4 +168,5 @@ cours. Voir la [politique du dossier ombrelle](../README.md#sécurité--pas-de-s
 ---
 
 *Architecture — Tour de la plateforme (Epic #4433, sous #4427). FR-first.
+Édition **v0.10** (dossiers d'équipe + config d'authentification ajoutés au RBAC).
 Diagrammes Mermaid (rendus nativement par GitHub).*

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/assets/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/assets/README.md
@@ -6,23 +6,32 @@ Ce dossier accueille les **captures d'écran annotées** du
 [tour](../README.md), générées de façon reproductible par le script
 [`../capture/tour-captures.spec.ts`](../capture/).
 
-> **Statut : gabarit.** Les images ne sont pas encore présentes : elles seront
-> produites une fois le **tenant de démonstration** en ligne (compte non-admin,
-> données fictives, masquage des zones sensibles). En attendant, le tour indique
-> chaque emplacement par `📷 Capture à venir`.
+> **Statut.** Les captures sont produites contre une **instance réelle** via un
+> **compte non-administrateur neuf**, avec **masquage** des zones sensibles et
+> **revue anti-fuite de chaque image**. Les surfaces qui exposeraient du contenu
+> réel d'un établissement (listes de modèles/bases internes, canaux) restent
+> volontairement **schématisées** dans [`../architecture.md`](../architecture.md)
+> et signalées `📷 Capture à venir` dans le tour.
 
 ## Fichiers attendus
 
-| Fichier | Section du tour |
-|---------|-----------------|
-| `01-connexion.png` | 1 — page de connexion (champs masqués) |
-| `01-premiere-vue.png` | 1 — écran de chat |
-| `02-selecteur-modele.png` | 2 — liste des modèles |
-| `02-chat-streaming.png` | 2 — réponse en streaming |
-| `03-workspace-modele.png` | 3 — modèle personnalisé |
-| `03-base-connaissances.png` | 3 — base de connaissances (RAG) |
-| `04-canal.png` | 4 — fil de discussion d'un canal |
-| `05-parametres.png` | 5 — paramètres personnels |
+| Fichier | Section du tour | Peut être capturé sans contenu réel ? |
+|---------|-----------------|:---:|
+| `01-connexion.png` | 1 — page de connexion (champs masqués) | ✅ (pré-auth) |
+| `01-premiere-vue.png` | 1 — écran de chat vide | ✅ (compte neuf) |
+| `02-selecteur-modele.png` | 2 — liste des modèles | ⚠️ (noms de modèles) |
+| `02-chat-streaming.png` | 2 — réponse en streaming (invite fictive) | ✅ |
+| `02-raisonnement-direct.png` | 2 — raisonnement en direct *(v0.10)* | ✅ (invite fictive) |
+| `03-workspace-modele.png` | 3 — modèle personnalisé | ⚠️ (contenu établissement) |
+| `03-base-connaissances.png` | 3 — base de connaissances (RAG) | ⚠️ (contenu établissement) |
+| `03-dossier-equipe.png` | 3 — dossier d'équipe *(v0.10)* | ✅ (compte neuf) |
+| `04-canal.png` | 4 — fil de discussion d'un canal | ⚠️ (contenu établissement) |
+| `05-parametres.png` | 5 — paramètres personnels | ✅ (identité masquée) |
+| `05-memoire.png` | 5 — gestion de la mémoire *(v0.10)* | ✅ (compte neuf, vide) |
+
+Les entrées ⚠️ exposent du contenu réel d'un établissement : elles restent
+schématisées dans [`../architecture.md`](../architecture.md) tant qu'un jeu de
+**données fictives** dédié n'est pas disponible.
 
 ## Règles
 
@@ -34,5 +43,4 @@ Ce dossier accueille les **captures d'écran annotées** du
 
 ---
 
-*Assets — Tour de la plateforme (Epic #4433, sous #4427). FR-first. Gabarit en
-attente du tenant de démonstration.*
+*Assets — Tour de la plateforme (Epic #4433, sous #4427). FR-first.*

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/.env.example
@@ -1,15 +1,21 @@
-# Tenant de DÉMONSTRATION pour la génération des captures du tour.
+# Compte de CAPTURE pour la génération des captures du tour.
 # Copiez ce fichier en `.env` (non commité — `*.env` est ignoré par le dépôt)
 # et renseignez les valeurs localement. NE JAMAIS commiter de vraies valeurs.
 #
-# Contraintes :
-#   - tenant de démonstration dédié (jamais une instance de production) ;
-#   - compte NON-ADMINISTRATEUR ;
-#   - données fictives uniquement.
+# Contraintes anti-fuite :
+#   - compte NON-ADMINISTRATEUR, de préférence neuf (aucune donnée réelle
+#     d'établissement visible) ;
+#   - on ne capture que des surfaces sans contenu réel (connexion, chat neuf,
+#     réglages vides) ;
+#   - masquage Playwright + revue de chaque image avant commit.
 
-# URL du tenant de démonstration (ex. https://demo.exemple)
+# URL de l'instance ciblée (ex. https://votre-instance.exemple)
 DEMO_OWUI_URL=
 
-# Compte non-admin de démonstration
+# Compte non-admin utilisé pour la capture
 DEMO_OWUI_EMAIL=
 DEMO_OWUI_PASSWORD=
+
+# Optionnel : nom d'un modèle « thinking » (raisonnement affiché en direct, v0.10)
+# pour la capture 02-raisonnement-direct.png. Laisser vide pour sauter cette capture.
+DEMO_OWUI_REASONING_MODEL=

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/README.md
@@ -6,11 +6,11 @@ Ce dossier contient le script qui **génère** les captures d'écran du
 [tour](../README.md), de façon **reproductible** et **sans fuite de secret**.
 Les images produites atterrissent dans [`../assets/`](../assets/).
 
-> **Statut.** Le script vise un **tenant de démonstration** dédié, qui n'est pas
-> encore en ligne au moment où ce chapitre est écrit (en attente de
-> provisionnement). Tant que les variables d'environnement ne sont pas
-> renseignées, le script se **met en pause automatiquement** (`test.skip`) — il ne
-> s'exécute donc jamais, et n'échoue jamais, en intégration continue.
+> **Statut.** Le script cible une **instance réelle** via un **compte
+> non-administrateur** (de préférence neuf, sans donnée réelle visible). Tant que
+> les variables d'environnement ne sont pas renseignées, il se **met en pause
+> automatiquement** (`test.skip`) — il ne s'exécute donc jamais, et n'échoue
+> jamais, en intégration continue.
 
 ## Pourquoi un script plutôt que des captures à la main ?
 
@@ -18,38 +18,43 @@ Les images produites atterrissent dans [`../assets/`](../assets/).
   l'interface change (montée de version, refonte UI).
 - **Anti-fuite par construction** : le masquage (`mask` de Playwright) est appliqué
   à *chaque* capture, plutôt que de compter sur un floutage manuel a posteriori.
-- **Cohérence** : même fenêtre, même zoom, mêmes données fictives partout.
+- **Cohérence** : même fenêtre, même zoom, mêmes conditions partout.
 
 ## Principe anti-fuite
 
-1. **Tenant de démonstration** dédié — jamais une instance de production.
-2. **Compte non-administrateur** — la session de capture n'a pas les droits
-   d'admin (les vues admin sensibles restent schématisées dans
-   [`../architecture.md`](../architecture.md), pas capturées).
-3. **Données fictives** uniquement dans le tenant de démonstration.
-4. **Masquage** (`mask`) des zones sensibles (identité, e-mail) sur chaque image.
-5. **Revue des PNG en PR** avant fusion — relecture humaine des images générées.
+1. **Compte non-administrateur**, de préférence **neuf** — la session de capture
+   n'a pas les droits d'admin, et un compte neuf ne voit **aucune donnée réelle**
+   d'établissement.
+2. **Surfaces sans contenu réel uniquement** — on ne capture que la connexion, un
+   chat neuf sur invite fictive, et des panneaux de réglages vides. Les surfaces
+   qui exposeraient du contenu (listes de modèles/bases internes, canaux) restent
+   **schématisées** dans [`../architecture.md`](../architecture.md), pas capturées.
+3. **Masquage** (`mask`) des zones sensibles (identité, e-mail) sur chaque image.
+4. **Revue anti-fuite de chaque PNG en PR** avant fusion — relecture humaine des
+   images générées.
+5. **Aucune URL réelle dans l'image** : Playwright capture le *contenu de la page*,
+   pas la barre d'adresse du navigateur.
 
 ## Configuration
 
-Les identifiants et l'URL du tenant de démonstration vivent dans un fichier
-`.env` **non commité** (le dépôt ignore `*.env`). Copiez le gabarit et
-renseignez-le localement :
+Les identifiants et l'URL vivent dans un fichier `.env` **non commité** (le dépôt
+ignore `*.env`). Copiez le gabarit et renseignez-le localement :
 
 ```bash
 cp .env.example .env
-# puis éditez .env avec l'URL et le compte non-admin du tenant de démo
+# puis éditez .env avec l'URL de l'instance et le compte non-admin de capture
 ```
 
 Variables attendues (voir [`.env.example`](.env.example)) :
 
 | Variable | Rôle |
 |----------|------|
-| `DEMO_OWUI_URL` | URL du tenant de démonstration |
-| `DEMO_OWUI_EMAIL` | E-mail du compte **non-admin** de démonstration |
+| `DEMO_OWUI_URL` | URL de l'instance ciblée |
+| `DEMO_OWUI_EMAIL` | E-mail du compte **non-admin** de capture |
 | `DEMO_OWUI_PASSWORD` | Mot de passe de ce compte |
+| `DEMO_OWUI_REASONING_MODEL` | *(optionnel)* nom d'un modèle « thinking » pour la capture du raisonnement en direct (v0.10) ; vide → capture sautée |
 
-## Exécution (une fois le tenant de démo en ligne)
+## Exécution
 
 Depuis la racine du projet Playwright de la série QA (qui fournit déjà
 `@playwright/test`) :
@@ -59,14 +64,13 @@ Depuis la racine du projet Playwright de la série QA (qui fournit déjà
 npx playwright test 00-Tour-Plateforme/capture/tour-captures.spec.ts
 ```
 
-Les images sont écrites dans [`../assets/`](../assets/). Vérifiez-les visuellement
-avant de les commiter.
+Les images sont écrites dans [`../assets/`](../assets/). **Vérifiez chaque image
+visuellement** (revue anti-fuite) avant de la commiter.
 
 > **Note sélecteurs.** Les sélecteurs du script sont volontairement robustes
 > (rôles ARIA, libellés multilingues) mais devront être **confirmés contre la
-> version live** du tenant de démonstration — comme pour la série QA, l'interface
-> peut dériver d'une version à l'autre. Cette confirmation fait partie de l'étape
-> « captures live » (différée).
+> version live** de l'instance — comme pour la série QA, l'interface peut dériver
+> d'une version à l'autre.
 
 ---
 

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/tour-captures.spec.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/tour-captures.spec.ts
@@ -2,18 +2,22 @@
  * Captures du « Tour de la plateforme » — utilitaire de génération, PAS un test QA.
  * -----------------------------------------------------------------------------
  * Ce script produit, de façon reproductible, les images annotées du tour
- * (../assets/*.png) en visitant un TENANT DE DÉMONSTRATION dédié avec un compte
- * NON-ADMINISTRATEUR et des données fictives.
+ * (../assets/*.png) en visitant une INSTANCE RÉELLE avec un compte
+ * NON-ADMINISTRATEUR et des données fictives ou fraîches (compte neuf).
  *
  * Anti-fuite (voir capture/README.md) :
- *   - tenant de démonstration uniquement (jamais une instance de production) ;
- *   - compte non-admin → pas d'accès aux panneaux d'administration sensibles ;
+ *   - compte NON-ADMIN, de préférence neuf → aucune donnée réelle
+ *     d'établissement visible (ni listes de modèles/bases internes, ni canaux) ;
+ *   - on ne capture QUE des surfaces sans contenu réel (connexion, chat neuf sur
+ *     invite fictive, réglages vides) ; les surfaces à contenu restent
+ *     schématisées dans ../architecture.md ;
  *   - masquage (`mask`) des zones d'identité sur CHAQUE capture ;
+ *   - revue anti-fuite de CHAQUE image avant de la commiter ;
  *   - identifiants/URL lus depuis un .env NON commité (placeholders ci-dessous).
  *
- * Exécution différée : tant que les variables d'environnement du tenant de démo
- * ne sont pas fournies, tout le fichier est `skip` — il ne s'exécute donc jamais,
- * et n'échoue jamais, en intégration continue.
+ * Exécution différée : tant que les variables d'environnement de capture ne sont
+ * pas fournies, tout le fichier est `skip` — il ne s'exécute donc jamais, et
+ * n'échoue jamais, en intégration continue.
  */
 import { test, type Page, type Locator } from '@playwright/test';
 import path from 'node:path';
@@ -21,27 +25,33 @@ import path from 'node:path';
 const URL = process.env.DEMO_OWUI_URL;
 const EMAIL = process.env.DEMO_OWUI_EMAIL;
 const PASSWORD = process.env.DEMO_OWUI_PASSWORD;
+// Optionnel : nom d'un modèle « thinking » pour la capture du raisonnement (v0.10).
+const REASONING_MODEL = process.env.DEMO_OWUI_REASONING_MODEL;
 
 // Dossier de sortie : ../assets relativement à ce fichier.
 const ASSETS = path.resolve(__dirname, '..', 'assets');
 
-// Sans tenant de démo configuré, on ne fait rien (pas d'exécution en CI).
+// Sans compte de capture configuré, on ne fait rien (pas d'exécution en CI).
 const configured = Boolean(URL && EMAIL && PASSWORD);
 test.skip(
   !configured,
-  'Tenant de démonstration non configuré — voir 00-Tour-Plateforme/capture/README.md',
+  'Compte de capture non configuré — voir 00-Tour-Plateforme/capture/README.md',
 );
 
 /**
  * Zones sensibles masquées sur toutes les captures. Les sélecteurs sont
  * volontairement larges (rôles ARIA + libellés multilingues) et devront être
- * confirmés contre la version live du tenant de démonstration.
+ * confirmés contre la version live de l'instance ciblée.
  */
 function sensitiveZones(page: Page): Locator[] {
   return [
     page.locator('[data-tour-mask]'), // points de masquage explicites si présents
     page.getByRole('button', { name: /account|compte|profil|profile/i }),
     page.getByText(/@/), // adresses e-mail visibles
+    // Marque / logo de l'instance (identité du tenant) — visible en haut de la
+    // sidebar sur toutes les vues authentifiées. Sélecteurs volontairement larges,
+    // à CONFIRMER contre l'UI live lors de la génération (revue anti-fuite).
+    page.locator('nav a[href="/"], #sidebar a[href="/"], header a[href="/"]'),
   ];
 }
 
@@ -63,7 +73,7 @@ async function signIn(page: Page): Promise<void> {
   await page.waitForLoadState('networkidle');
 }
 
-test.describe('Tour de la plateforme — captures (tenant démo)', () => {
+test.describe('Tour de la plateforme — captures (compte de capture)', () => {
   // 1 — page de connexion (avant authentification, champs masqués).
   test('01 — page de connexion', async ({ page }) => {
     await page.goto(URL!);
@@ -134,6 +144,91 @@ test.describe('Tour de la plateforme — captures (tenant démo)', () => {
         .click()
         .catch(() => {});
       await capture(page, '05-parametres.png');
+    });
+
+    // ================================================================
+    // Nouveautés v0.10 — surfaces sans contenu réel (compte neuf)
+    // ================================================================
+
+    // 2 — raisonnement affiché en direct (v0.10) : bloc de réflexion d'un
+    // modèle « thinking » sur une invite FICTIVE. Nécessite un modèle de
+    // raisonnement ; sans DEMO_OWUI_REASONING_MODEL, on saute.
+    test('02 — raisonnement en direct (v0.10)', async ({ page }) => {
+      test.skip(!REASONING_MODEL, 'DEMO_OWUI_REASONING_MODEL non défini');
+      await page.goto(URL!);
+      await page.waitForLoadState('networkidle');
+      // Ouvrir le sélecteur de modèle et choisir le modèle de raisonnement.
+      await page
+        .locator('button[id^="model-selector-"]')
+        .first()
+        .click()
+        .catch(() => {});
+      await page
+        .locator('#model-search-input, [role="listbox"] input')
+        .first()
+        .fill(REASONING_MODEL!)
+        .catch(() => {});
+      await page.waitForTimeout(400);
+      await page.locator('[role="option"]').first().click().catch(() => {});
+      // Envoyer une invite neutre qui déclenche du raisonnement.
+      await page.locator('#chat-input').click().catch(() => {});
+      await page.keyboard.type(
+        'Explique étape par étape pourquoi le ciel est bleu.',
+        { delay: 8 },
+      );
+      await page.keyboard.press('Enter');
+      // Attendre l'apparition du bloc de raisonnement, puis capturer.
+      await page
+        .locator(
+          'details[class*="reason" i], details[class*="think" i], [class*="reasoning" i], [class*="thinking" i]',
+        )
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 })
+        .catch(() => {});
+      await capture(page, '02-raisonnement-direct.png');
+    });
+
+    // 3 — dossiers d'équipe partageables (v0.10) : création d'un dossier dans la
+    // sidebar (compte neuf → aucun dossier réel visible).
+    test("03 — dossier d'équipe (v0.10)", async ({ page }) => {
+      await page.goto(URL!);
+      await page.waitForLoadState('networkidle');
+      await page
+        .getByRole('button', {
+          name: /nouveau dossier|new folder|cr[ée]er un dossier/i,
+        })
+        .first()
+        .click()
+        .catch(() => {});
+      await capture(page, '03-dossier-equipe.png');
+    });
+
+    // 5 — mémoire (v0.10) : Paramètres > Personnalisation > Mémoire
+    // (compte neuf → aucun souvenir réel enregistré).
+    test('05 — mémoire (v0.10)', async ({ page }) => {
+      await page.goto(URL!);
+      await page.waitForLoadState('networkidle');
+      await page
+        .getByRole('button', { name: /account|compte|profil|profile/i })
+        .first()
+        .click()
+        .catch(() => {});
+      await page
+        .getByRole('menuitem', { name: /settings|param[èe]tres/i })
+        .first()
+        .click()
+        .catch(() => {});
+      await page
+        .getByText(/personnalisation|personalization/i)
+        .first()
+        .click()
+        .catch(() => {});
+      await page
+        .getByText(/m[ée]moire|memory/i)
+        .first()
+        .click()
+        .catch(() => {});
+      await capture(page, '05-memoire.png');
     });
   });
 });


### PR DESCRIPTION
## Contexte

Wave 2 sous **Epic #4433** (gouvernance #4427). Fait suite à la Wave 1 (Tour PR #4621, mergée le 2026-06-30) et au module 06 de la série QA (**PR #4769**, en attente de merge). Cette PR **finalise le travail d'écriture** du *Tour de la plateforme* en y intégrant les nouveautés d'Open WebUI **v0.10** (contenu validé contre la 0.10.2, montée myia effectuée cette session).

## Ce que fait cette PR

### Écriture (le cœur de la demande)
- **`README.md`** — nouveautés v0.10 tissées dans les sections existantes, marquées *(nouveau — v0.10)* :
  - §2 : **raisonnement affiché en direct** + **compaction automatique du contexte**
  - §3 : **dossiers d'équipe partageables** + **téléversement de dossier** (arborescence préservée)
  - §5 : **mémoire** (sortie de bêta)
  - §6 : **configuration de l'authentification** déplacée dans le panneau d'admin
  - Encadré « Nouveautés de la v0.10 » au sommaire + renvoi au **module 06** de la série QA
- **`architecture.md`** — diagramme **RBAC** étendu : nœud *dossier d'équipe* (partage via access grant) + branche *config authentification* sur le panneau d'admin.

### Apparatus de capture (aligné sur la méthode approuvée)
- **`capture/tour-captures.spec.ts`** — 3 captures v0.10 ajoutées (**raisonnement en direct**, **dossier d'équipe**, **mémoire**), toutes sur des **surfaces sans contenu réel** (compte non-admin neuf). Principe anti-fuite réécrit : instance réelle + compte non-admin neuf + `mask` + revue par image ; **marque/logo de l'instance ajoutée aux zones masquées** ; variable optionnelle pour le modèle de raisonnement.
- **`capture/README.md`**, **`assets/README.md`**, **`capture/.env.example`** — alignés ; le tableau des assets distingue les captures **sans contenu (sûres)** des surfaces **schématisées**.

## Génération des PNG — étape suivante, sous garde
Aucune capture d'écran d'un tenant de production n'est commitée dans cette PR. Le script est prêt ; conformément à la posture sécurité, les images seront générées contre un **compte non-admin neuf** avec **revue anti-fuite image par image** — action à confirmer (sur cette PR ou en suivi dédié). Les placeholders `📷 Capture à venir` et les schémas d'`architecture.md` couvrent les fonctionnalités entre-temps.

## Sécurité
0 secret. Pas d'URL de tenant réel, d'e-mail, de clé ni de jeton (scan diff propre). `.env` de capture jamais commité (`*.env` ignoré).

## Gouvernance (#4427)
Worktree isolé, PR atomique, **review + merge par ai-01 (pas d'auto-merge).**

Refs #4433 #4427

🤖 Generated with [Claude Code](https://claude.com/claude-code)