### PR TITLE
docs(genai-casestudies): restore FR diacritics in README (accents manquants)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/README.md
@@ -1,4 +1,4 @@
-# CaseStudies - Projets etudiants en IA Generative
+# CaseStudies - Projets étudiants en IA Générative
 
 <!-- CATALOG-STATUS
 series: GenAI-CaseStudies
@@ -9,9 +9,9 @@ maturity: PRODUCTION=3, BETA=1
 
 [← GenAI](../README.md)
 
-Quatre projets complets, bout en bout, illustrent la diversite des applications de l'IA generative : un duel verbal multi-agent avec generation d'images, un generateur de recettes orchestre par agents, un chatbot medical multi-agent avec plugins, et un jeu interactif inspire de Fort Boyard. Chaque projet combine appel a un LLM (OpenAI) avec une architecture agentique (Semantic Kernel ou API directe), et inclut des exercices pour etendre le systeme.
+Quatre projets complets, bout en bout, illustrent la diversité des applications de l'IA générative : un duel verbal multi-agent avec génération d'images, un générateur de recettes orchestré par agents, un chatbot médical multi-agent avec plugins, et un jeu interactif inspiré de Fort Boyard. Chaque projet combine appel à un LLM (OpenAI) avec une architecture agentique (Semantic Kernel ou API directe), et inclut des exercices pour étendre le système.
 
-Ces notebooks sont le point d'entree ideal pour decouvrir les capacites de l'IA generative avant d'approfondir dans les series thematiques ([Texte](../Texte/README.md), [SemanticKernel](../SemanticKernel/README.md), [Image](../Image/README.md)).
+Ces notebooks sont le point d'entrée idéal pour découvrir les capacités de l'IA générative avant d'approfondir dans les séries thématiques ([Texte](../Texte/README.md), [SemanticKernel](../SemanticKernel/README.md), [Image](../Image/README.md)).
 
 ## Pourquoi ces projets
 
@@ -29,44 +29,44 @@ Les séries thématiques de GenAI démontent chaque composant ; ces quatre proje
 
 ## Objectifs d'apprentissage
 
-A l'issue de ces projets, vous serez capable de :
+À l'issue de ces projets, vous serez capable de :
 
-1. **Orchestrer** des agents conversationnels multi-role avec Semantic Kernel ou l'API OpenAI
-2. **Integrer** la generation d'images (DALL-E) dans un dialogue automatise
-3. **Concevoir** des strategies de terminaison et des plugins specialises pour des agents
-4. **Etendre** un projet existant en ajoutant des contraintes, des agents ou des fonctionnalites (exercices inclus)
+1. **Orchestrer** des agents conversationnels multi-rôle avec Semantic Kernel ou l'API OpenAI
+2. **Intégrer** la génération d'images (DALL-E) dans un dialogue automatisé
+3. **Concevoir** des stratégies de terminaison et des plugins spécialisés pour des agents
+4. **Étendre** un projet existant en ajoutant des contraintes, des agents ou des fonctionnalités (exercices inclus)
 
 ## Projets
 
 | # | Projet | Notebook | Technologies | Contenu |
 |---|--------|----------|-------------|---------|
-| 1 | [Barbie-Schreck](Barbie-Schreck/README.md) | [barbie-schreck.ipynb](Barbie-Schreck/barbie-schreck.ipynb) | Semantic Kernel, OpenAI DALL-E | Duel verbal contraint entre Barbie et l'Ane de Shrek avec generation d'images |
-| 2 | [Recipe-Maker](Recipe-Maker/README.md) | [receipe_maker.ipynb](Recipe-Maker/receipe_maker.ipynb) | Semantic Kernel, OpenAI, PDF | Collaboration multi-agents pour generer une recette personnalisee avec export PDF |
-| 3 | [Medical-Chatbot](Medical-Chatbot/README.md) | [medical_chatbot.ipynb](Medical-Chatbot/medical_chatbot.ipynb) | Semantic Kernel, OpenAI, plugins | Chatbot medical avec plugins de verification, logging et terminaison intelligente |
-| 4 | [Fort-Boyard](Fort-Boyard/README.md) | [fort-boyard-python.ipynb](Fort-Boyard/fort-boyard-python.ipynb) | OpenAI GPT | Jeu de devinettes entre le Pere Fouras et un candidat, avec strategies de terminaison |
+| 1 | [Barbie-Schreck](Barbie-Schreck/README.md) | [barbie-schreck.ipynb](Barbie-Schreck/barbie-schreck.ipynb) | Semantic Kernel, OpenAI DALL-E | Duel verbal contraint entre Barbie et l'Âne de Shrek avec génération d'images |
+| 2 | [Recipe-Maker](Recipe-Maker/README.md) | [receipe_maker.ipynb](Recipe-Maker/receipe_maker.ipynb) | Semantic Kernel, OpenAI, PDF | Collaboration multi-agents pour générer une recette personnalisée avec export PDF |
+| 3 | [Medical-Chatbot](Medical-Chatbot/README.md) | [medical_chatbot.ipynb](Medical-Chatbot/medical_chatbot.ipynb) | Semantic Kernel, OpenAI, plugins | Chatbot médical avec plugins de vérification, logging et terminaison intelligente |
+| 4 | [Fort-Boyard](Fort-Boyard/README.md) | [fort-boyard-python.ipynb](Fort-Boyard/fort-boyard-python.ipynb) | OpenAI GPT | Jeu de devinettes entre le Père Fouras et un candidat, avec stratégies de terminaison |
 
-Chaque projet contient 3 exercices permettant d'etendre le systeme (ajout de contraintes, nouveaux agents, strategies de terminaison personnalisees).
+Chaque projet contient 3 exercices permettant d'étendre le système (ajout de contraintes, nouveaux agents, stratégies de terminaison personnalisées).
 
-## Prerequis & environnement
+## Prérequis & environnement
 
-| Besoin | Detail |
+| Besoin | Détail |
 |--------|--------|
 | Python | 3.10+ |
 | `openai` | Requis pour les 4 projets |
 | `semantic-kernel` | Requis pour Barbie-Schreck, Recipe-Maker et Medical-Chatbot |
-| Cle API | `OPENAI_API_KEY` dans `GenAI/.env` (voir [00-GenAI-Environment](../00-GenAI-Environment/README.md)) |
-| `fpdf` | Recipe-Maker uniquement (generation PDF) |
+| Clé API | `OPENAI_API_KEY` dans `GenAI/.env` (voir [00-GenAI-Environment](../00-GenAI-Environment/README.md)) |
+| `fpdf` | Recipe-Maker uniquement (génération PDF) |
 
 ## FAQ
 
-### Quelle cle API est requise ?
+### Quelle clé API est requise ?
 
-Les 4 projets necessitent `OPENAI_API_KEY`. Recipe-Maker et Medical-Chatbot utilisent en plus Semantic Kernel pour l'orchestration agentique. Configurer les cles dans `GenAI/.env` (voir [00-GenAI-Environment](../00-GenAI-Environment/README.md)).
+Les 4 projets nécessitent `OPENAI_API_KEY`. Recipe-Maker et Medical-Chatbot utilisent en plus Semantic Kernel pour l'orchestration agentique. Configurer les clés dans `GenAI/.env` (voir [00-GenAI-Environment](../00-GenAI-Environment/README.md)).
 
-### Peut-on executer Medical-Chatbot sans Semantic Kernel ?
+### Peut-on exécuter Medical-Chatbot sans Semantic Kernel ?
 
-Medical-Chatbot utilise Semantic Kernel pour l'orchestration des plugins (requete vers API, parsing, formatage de reponse). Pour le faire sans SK, remplacer les appels `kernel.invoke()` par des appels directs `openai.chat.completions.create()` -- la logique metier reste la meme, seule la couche d'orchestration change.
+Medical-Chatbot utilise Semantic Kernel pour l'orchestration des plugins (requête vers API, parsing, formatage de réponse). Pour le faire sans SK, remplacer les appels `kernel.invoke()` par des appels directs `openai.chat.completions.create()` -- la logique métier reste la même, seule la couche d'orchestration change.
 
-### Quelle difference avec les autres series GenAI ?
+### Quelle différence avec les autres séries GenAI ?
 
-CaseStudies rassemble des projets complets et autonomes, adaptes de realisations etudiantes. Les series thematiques approfondissent chaque composant : [Texte](../Texte/README.md) pour les techniques NLP avancees, [SemanticKernel](../SemanticKernel/README.md) pour le SDK d'orchestration, [Image](../Image/README.md) pour la generation et l'edition d'images.
+CaseStudies rassemble des projets complets et autonomes, adaptés de réalisations étudiantes. Les séries thématiques approfondissent chaque composant : [Texte](../Texte/README.md) pour les techniques NLP avancées, [SemanticKernel](../SemanticKernel/README.md) pour le SDK d'orchestration, [Image](../Image/README.md) pour la génération et l'édition d'images.


### PR DESCRIPTION
## Contexte

Suite de #2876 (accents manquants dans les READMEs francophones). `GenAI/CaseStudies/README.md` avait échappé au sweep : la section descriptions détaillées (§projets) était correctement accentuée, mais l'en-tête, les objectifs, le tableau des projets, les prérequis et la FAQ (23 lignes) avaient des accents manquants.

## Changement

Restaure les diacritiques sur les 23 lignes défectueuses (intro, objectifs, tableau projets, prérequis, FAQ). Diff **+23/-23** (symétrie parfaite, delta char = 0 = accent-only pur).

## Validation méthode 4-gates (#2876)

| Gate | Contrôle | Résultat |
|------|----------|----------|
| 1 | deaccent NFD égal (aucun changement de base letter / forme verbale / casse) | ✅ True |
| 2 | CATALOG-STATUS byte-identique | ✅ True |
| 3 | URLs de liens identiques | ✅ True |
| 4 | code inline / fences identiques | ✅ True |

- LF préservé, CRLF = 0
- Aucun changement de forme verbale (`Configurer` conservé, non `Configurez`)
- Casse préservée (`Générative` garde le capital d'origine `Generative`)

## Non-concerne

PR #2912 (merged 2026-06-13) portait sur `MyIA.AI.Notebooks/CaseStudies/README.md` (sans parent `GenAI/`) — un fichier différent. Ce PR cible bien `GenAI/CaseStudies/README.md` qui sur `origin/main` est toujours non accentué.

See #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)