### PR TITLE
fix(rl): demote 'Attention au shaping naif' aside H3->bold inline, RL-10 (#3968)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb
@@ -398,9 +398,7 @@
     "La valeur modifiee $Q'(s, a) = Q^*(s, a) + \\Phi(s)$ : le potentiel s'ajoute comme un biais constant\n",
     "par etat, qui ne change pas l'ordre relatif des actions. L'argmax est preserve.\n",
     "\n",
-    "### Attention au shaping naif\n",
-    "\n",
-    "Le shaping heuristique $F(s, s') = 2 \\cdot (d(s) - d(s'))$ n'est PAS potential-based\n",
+    "**Attention au shaping naif :** Le shaping heuristique $F(s, s') = 2 \\cdot (d(s) - d(s'))$ n'est PAS potential-based\n",
     "(il n'existe pas de $\\Phi$ tel que $F = \\gamma \\Phi(s') - \\Phi(s)$). Dans certains environnements,\n",
     "ce type de shaping peut induire une politique sous-optimale en recompensant un chemin\n",
     "qui semble bon selon l'heuristique mais qui ne l'est pas.\n"


### PR DESCRIPTION
## Contexte

Part of #3968 (mise en forme typographique des notebooks). `RL/rl_10_reward_shaping.ipynb` cell 9 avait un hint-as-heading : `### Attention au shaping naif` (H3) servant d'aside warning, ce qui le rendait plus gros typographiquement que les titres réels.

## Changement

Demote en **bold inline lead-in** fusionné avec le paragraphe explicatif :

```
- ### Attention au shaping naif
-
- Le shaping heuristique $F(s, s') = ...$ n'est PAS potential-based
+ **Attention au shaping naif :** Le shaping heuristique $F(s, s') = ...$ n'est PAS potential-based
```

Pattern canonique #3968 (cf PRs mergées #4745 Sudoku, #4747 GenAI-CaseStudies, #4748 Search, #4749 GenAI-PostTraining).

## Validation

| Check | Résultat |
|-------|----------|
| `scan_md_hierarchy.py` : 0 finding résiduel | ✅ (était 1/1) |
| Diff +1/-3, hunk unique (aucun drift de formatage) | ✅ |
| JSON valide | ✅ |
| C.1 (0 `raise NotImplementedError`/`assert False`/`1/0`) | ✅ |
| Typos-only : texte de l'aside/paragraphe préservé | ✅ |

Markdown-only → outputs précédents valides (C.2), pas de re-exec. La cellule est markdown sans outputs.

See #3968

🤖 Generated with [Claude Code](https://claude.com/claude-code)