### PR TITLE
fix(genai-vibe): demote 'Note environnement execution' aside H3->bold inline, Claude-Code 04+05 (#3968)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/04-Claude-CLI-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/04-Claude-CLI-Agents.ipynb
@@ -118,9 +118,7 @@
     "tags": []
    },
    "source": [
-    "### Note sur l'environnement d'execution\n",
-    "\n",
-    "L'erreur `ModuleNotFoundError: No module named 'claude_cli'` est attendue dans ce notebook pedagogique. Le module `claude_cli` est un helper qui encapsule les appels a `subprocess` pour interagir avec la CLI Claude. En environnement de production, ce module serait installe dans le path Python. Les cellules suivantes simulent le comportement de la CLI avec les memes patterns d'appels, permettant de comprendre les concepts meme sans acces direct a la CLI."
+    "**Note sur l'environnement d'execution :** L'erreur `ModuleNotFoundError: No module named 'claude_cli'` est attendue dans ce notebook pedagogique. Le module `claude_cli` est un helper qui encapsule les appels a `subprocess` pour interagir avec la CLI Claude. En environnement de production, ce module serait installe dans le path Python. Les cellules suivantes simulent le comportement de la CLI avec les memes patterns d'appels, permettant de comprendre les concepts meme sans acces direct a la CLI."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/05-Claude-CLI-Automatisation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/05-Claude-CLI-Automatisation.ipynb
@@ -132,9 +132,7 @@
     "tags": []
    },
    "source": [
-    "### Note sur l'environnement d'execution\n",
-    "\n",
-    "L'erreur `ModuleNotFoundError: No module named 'claude_cli'` est attendue dans ce notebook pedagogique. Le module `claude_cli` est un helper qui encapsule les appels a `subprocess` pour interagir avec la CLI Claude. Les cellules suivantes definissent les memes fonctions et patterns, permettant de comprendre les concepts meme sans acces direct a la CLI."
+    "**Note sur l'environnement d'execution :** L'erreur `ModuleNotFoundError: No module named 'claude_cli'` est attendue dans ce notebook pedagogique. Le module `claude_cli` est un helper qui encapsule les appels a `subprocess` pour interagir avec la CLI Claude. Les cellules suivantes definissent les memes fonctions et patterns, permettant de comprendre les concepts meme sans acces direct a la CLI."
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Part of #3968. Deux notebooks de la sous-série Claude-Code (Vibe-Coding) avaient un hint-as-heading identique : `### Note sur l'environnement d'execution` (H3) servant d'aside d'avertissement (`ModuleNotFoundError` attendu).

## Changement

Demote en **bold inline lead-in** fusionné avec le paragraphe explicatif, dans les 2 notebooks (fix identique) :

- `04-Claude-CLI-Agents.ipynb` cell 3
- `05-Claude-CLI-Automatisation.ipynb` cell 3

```
- ### Note sur l'environnement d'execution
-
- L'erreur `ModuleNotFoundError...` est attendue dans ce notebook pedagogique...
+ **Note sur l'environnement d'execution :** L'erreur `ModuleNotFoundError...` est attendue...
```

Sous-lot cohérent Claude-Code (1 PR/famille, cf #3968). Pattern canonique validé par #4745/#4747/#4748/#4749.

## Validation

| Check | Résultat |
|-------|----------|
| `scan_md_hierarchy.py` : 0 finding résiduel | ✅ (était 2/2) |
| Diff +1/-3 par notebook, hunk unique | ✅ (newline final préservé) |
| JSON valide | ✅ |
| C.1 (0 `raise NotImplementedError`/`assert False`/`1/0`) | ✅ |
| Typos-only : texte préservé | ✅ |

Markdown-only → outputs précédents valides (C.2). Notebooks IDLE pour #3968 (dernier commit 06-25 #4495 Mermaid, aucune activité #3968).

See #3968

🤖 Generated with [Claude Code](https://claude.com/claude-code)