### PR TITLE
feat(hashlife): mem_toGrid_shift — offset-translation for toGrid membership (P4.4 offset-matching ingredient, sorry 4->4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1031,6 +1031,20 @@ theorem mem_toGrid {c : MacroCell} {offset : Int × Int} {p : Int × Int} :
   unfold MacroCell.toGrid
   exact mem_sortDedup
 
+/-- **Offset-shift for `toGrid` membership** (P4.4 offset-matching ingredient).
+    Membership of `p` in `c.toGrid (r0, c0)` is equivalent to membership of the
+    translated point `(p.1 - r0, p.2 - c0)` in `c.toGrid (0, 0)` — i.e. the cell
+    content is the same grid, just viewed at a different origin. This is the
+    shift ingredient the P4.4 offset-matching assembly needs to relate each
+    quadrant membership `p ∈ out_*.toGrid (off, off)` (after `mem_toGrid_node`
+    decomposes the result node into its four children at offsets `(2^k, 2^k)`,
+    `(2^k, 2^k + 2^out_nw.level)`, …) to the centered form that
+    `centralCorrect_mem` + the ih characterize. -/
+theorem mem_toGrid_shift {c : MacroCell} {r0 c0 : Int} {p : Int × Int} :
+    p ∈ c.toGrid (r0, c0) ↔ (p.1 - r0, p.2 - c0) ∈ c.toGrid (0, 0) := by
+  rw [mem_toGrid, mem_toGrid]
+  exact mem_toCellsAux_shift
+
 /-- **G3 infrastructure (toGrid node-decomposition).** Membership in a `node`
     cell's grid decomposes into membership in the four children's grids, with
     the standard quadtree offset shifts (row increases downward, column


### PR DESCRIPTION
## Summary

Sorry-stable lemma for lane **#3846** (Conway Hashlife GOL). New proven helper `mem_toGrid_shift` — the offset-translation ingredient the P4.4 offset-matching assembly (consuming PR #4771) needs. Branched fresh off `origin/main`.

## The lemma (~L1033, after `mem_toGrid`)

```
theorem mem_toGrid_shift {c : MacroCell} {r0 c0 : Int} {p : Int × Int} :
    p ∈ c.toGrid (r0, c0) ↔ (p.1 - r0, p.2 - c0) ∈ c.toGrid (0, 0) := by
  rw [mem_toGrid, mem_toGrid]
  exact mem_toCellsAux_shift
```

Membership of `p` in `c.toGrid (r0, c0)` ≡ membership of the translated point `(p.1 - r0, p.2 - c0)` in `c.toGrid (0, 0)` — the same grid, viewed at a different origin.

## Why it matters (P4.4 offset-matching pipeline)

With PR **#4771** (LHS-assembly, under review), `p4_succ_membership`'s LHS is now:
```
p ∈ out_nw.toGrid … ∨ out_ne.toGrid … ∨ out_sw.toGrid … ∨ out_se.toGrid …
```
each quadrant at a distinct offset `(2^k, 2^k)`, `(2^k, 2^k + 2^out_nw.level)`, `(2^k + 2^out_nw.level, 2^k)`, `(2^k + 2^out_nw.level, 2^k + 2^out_nw.level)` (from `mem_toGrid_node`).

To match these against the RHS window `[2^k, 3·2^k)²` (via `mem_restrictGridTo`) and characterize each via `centralCorrect_mem` + the ih `centralCorrect q_* (k-1)`, each quadrant membership must be **re-centered to `(0, 0)`** first. `mem_toGrid_shift` is exactly that translation — it composes `mem_toGrid` (`toGrid ↔ toCellsAux`) with the pre-existing `mem_toCellsAux_shift` (MacroCell.lean) into the direct `toGrid` form the assembly consumes.

The planned pipeline toward `p4_succ_membership` sorry **4→3**:
```
mem_toGrid_node (decompose result node) → mem_toGrid_shift (re-center each quadrant)
  → centralCorrect_mem (characterize via congruence + ih) → bridge evolve_half_step + evolve_add
```

## Why sorry-stable (4→4)

Pure addition (**+14 lines**), no existing proof touched. The lemma is proven by `rw` + `exact` (composition of two pre-existing lemmas) — **no `sorryAx`**, no "declaration uses sorry" warning. Same cadence as the c.142/c.153/c.154/c.155/c.156 gate grains: sorry-free infrastructure the assembly will consume.

## Lean PR checklist (pr-review-discipline §B)

1. **sorry before/after**: **4 → 4** (pure addition of a proven lemma; token grep exclude `.lake`).
2. **Lake build SUCCESS**: `lake build Conway.Life.HashlifeCorrectness` → **EXIT 0** (Mathlib junction `54f98fd6` rc2, `lake.exe` Windows-side, 3320 jobs).
3. **Proof integrity**: `rw [mem_toGrid, mem_toGrid]; exact mem_toCellsAux_shift` → **no `sorryAx`**.
4. **No prover Python refactor** — N/A.

## Anti-regression

+14 insertions, 0 deletions. New lemma only; no existing proof touched. Sorry count unchanged (4→4).

See #3846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
