### PR TITLE
fix(probas): repair 2 dangling cross-pointers in DecisionTheory notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Infer/Infer-3-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Infer/Infer-3-Utility-Money.ipynb
@@ -3906,7 +3906,7 @@
     "\n",
     "L'etudiant a realise une traduction complete en Python du modele de portfolio\n",
     "avec optimisation sous contrainte CVaR. Le code est dans\n",
-    "[exercice_portfolio.py](exercice_portfolio.py) et couvre :\n",
+    "[exercice_portfolio.py](../../Infer/exercice_portfolio.py) et couvre :\n",
     "- Modelisation gaussienne des 3 actifs (Obligataire, Actions, Immobilier)\n",
     "- Calcul analytique VaR/CVaR a 95%\n",
     "- Optimisation scipy SLSQP sous contrainte CVaR < 5%\n",

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-7-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-7-Sequential.ipynb
@@ -1916,7 +1916,7 @@
     "| **Adversariale** | Choisis par un adversaire | **Hedge / Exp3** | Distribution de probabilites sur les bras |\n",
     "| **Markovienne** | Transitions d'etat connues | **Indice de Gittins** | Index independant par bras, optimal sous discount |\n",
     "\n",
-    "> **Cette section** se concentre sur la formulation Markovienne et l'indice de Gittins. Pour une discussion approfondie du cadre SFABP (Famille Simple de Processus Bandits Alternatifs) et de la preuve constructive d'optimalite (argument des \"prevailing charges\"), voir le notebook compagnon [Infer-8](../DecisionTheory/Infer/Infer-8-Sequential.ipynb) qui detaille ces aspects theoriques."
+    "> **Cette section** se concentre sur la formulation Markovienne et l'indice de Gittins. Pour une discussion approfondie du cadre SFABP (Famille Simple de Processus Bandits Alternatifs) et de la preuve constructive d'optimalite (argument des \"prevailing charges\"), voir le notebook compagnon [Infer-8](../Infer/Infer-8-Sequential.ipynb) qui detaille ces aspects theoriques."
    ]
   },
   {


### PR DESCRIPTION
## Summary

See **#4788** (cross-famille dangling-link sweep, **tranche Probas**). Two markdown hrefs in  notebooks resolved to non-existent paths — the link class that `scripts/check_docs_links.py` does **NOT** scan (it only walks `.md`; `.ipynb` markdown cells are its blind spot, cf [[dangling-notebook-link-sweep-method]] piège #2).

### Fix 1 — PyMC-7-Sequential.ipynb (cell 37) [**regression of #4759**]
`../DecisionTheory/Infer/Infer-8-Sequential.ipynb` → resolved to `DecisionTheory/DecisionTheory/Infer/...` (**double segment**). When PyMC-7 moved into `DecisionTheory/PyMC/` (#4759), its cross-link to Infer inherited one `../` too many. `DecisionTheory/Infer/` is a **sibling** of `DecisionTheory/PyMC/`, so the correct href is `../Infer/Infer-8-Sequential.ipynb`.

### Fix 2 — Infer-3-Utility-Money.ipynb (cell 45)
`exercice_portfolio.py` (bare, 0 ups) → resolved to `DecisionTheory/Infer/exercice_portfolio.py` (missing). The script lives in `Probas/Infer/exercice_portfolio.py` (left there by the #4737 Infer restructure). From `DecisionTheory/Infer/` the correct relative path is `../../Infer/exercice_portfolio.py` (2 ups back to `Probas/`).

**Path-fix only** (anti-régression: no prose refactor). Markdown-only → **C.2-exempt**, no re-exec.

## Vérification (preuves vérifiables)
- **Probas tranche re-scan: 0 dangling residual** (was 2) ✅
- **JSON integrity**: 2 notebooks OK ✅
- `check_docs_links.py --check` : **0 delta (3055 total)** — no `.md` touched ✅
- `COURSE_CATALOG` **byte-identique** à `origin/main` ✅
- 2 files, 2+/2- (pure markdown href corrections, 0 code cell touched) ✅

## Note (design smell signalé, hors-scope)
`exercice_portfolio.py` could warrant colocation into `DecisionTheory/Infer/` (where Infer-3 now lives) rather than the current path-fix pointing 2-ups back to `Probas/Infer/`. Flagged as a **separate subject** (move = may touch tests/other refs), out of this path-fix PR's scope (cf CLAUDE.md principle #3 — signal, don't bundle).

See #4788 (tranche Probas, partielle — 82 dangling repo-wide, cette PR en résout 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)