### PR TITLE
fix(probas): repair PyMC-7 -> Infer-8 cross-pointer (double DecisionTheory segment)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-7-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-7-Sequential.ipynb
@@ -1916,7 +1916,7 @@
     "| **Adversariale** | Choisis par un adversaire | **Hedge / Exp3** | Distribution de probabilites sur les bras |\n",
     "| **Markovienne** | Transitions d'etat connues | **Indice de Gittins** | Index independant par bras, optimal sous discount |\n",
     "\n",
-    "> **Cette section** se concentre sur la formulation Markovienne et l'indice de Gittins. Pour une discussion approfondie du cadre SFABP (Famille Simple de Processus Bandits Alternatifs) et de la preuve constructive d'optimalite (argument des \"prevailing charges\"), voir le notebook compagnon [Infer-8](../DecisionTheory/Infer/Infer-8-Sequential.ipynb) qui detaille ces aspects theoriques."
+    "> **Cette section** se concentre sur la formulation Markovienne et l'indice de Gittins. Pour une discussion approfondie du cadre SFABP (Famille Simple de Processus Bandits Alternatifs) et de la preuve constructive d'optimalite (argument des \"prevailing charges\"), voir le notebook compagnon [Infer-8](../Infer/Infer-8-Sequential.ipynb) qui detaille ces aspects theoriques."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fix one dangling cross-pointer in the #4788 sweep (po-2025 / Probas family tranche). `PyMC-7-Sequential` cell 37 links the companion Infer-8 notebook with a path that resolves to a **double `DecisionTheory/` segment → 404**.

- File: `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/PyMC-7-Sequential.ipynb` (cell 37)
- Before: `[Infer-8](../DecisionTheory/Infer/Infer-8-Sequential.ipynb)` → resolves to `Probas/DecisionTheory/DecisionTheory/Infer/Infer-8-Sequential.ipynb` (ABSENT)
- After: `[Infer-8](../Infer/Infer-8-Sequential.ipynb)` → resolves to `Probas/DecisionTheory/Infer/Infer-8-Sequential.ipynb` (EXISTS, verified `git ls-tree origin/main`)

## Why this was still broken

This exact fix was authored in PR #4772, but #4772 was **closed as a duplicate** of the canonical naming PR #4770 (collision: same 11 files created 16s apart in a double po-2025 session). #4770 (merged) did not include this Infer-8 cell, so the broken link survived on `main`. This re-delivers the lost fix.

## Validation (#4788 acceptance)

- `git grep '../DecisionTheory/Infer/Infer-8'` = 0 residual in the tranche.
- Markdown-only path correction, no prose change (#4788: "correction de chemin uniquement").
- JSON round-trip byte-faithful (`indent=1`); 0 code cell touched, all 23 code-cell outputs preserved (C.2 markdown-only exception).
- Target existence grounded firsthand: `Infer-8-Sequential.ipynb` confirmed at `Probas/DecisionTheory/Infer/`.

## po-2025 family tranche status (#4788)

Fresh sweep on `origin/main` (path-normalization-fixed script): **13 candidates**, of which:
- **1 fixed here** (PyMC-7 → Infer-8)
- **2** = `Probas/LEAN_INVENTORY.md` → machine-local `.claude/projects/c--dev-CoursIA-2/memory/*` paths — **content-decision class** (these memory files are gitignored/machine-local and will never exist in the repo; the honest fix is remove-or-redirect, not a path correction) — flagged for separate handling, NOT forced here.
- **1** false positive (GameTheory/README `https://www.md` = scanner artifact matching `www.mdpi`, not a real link).
- **9** = `QuantConnect/Python/` (QC-Py-Cloud Sommaire + QC-Py-30/31 numbered nav) — **po-2024 QC turf**, left to that lane to avoid collision.

`See #4788` (partial — Probas/PyMC family tranche). `See #4725`.