### PR TITLE
fix(genai-vibe): reorder misplaced title to cell 0, group exercises, Claude-Code 03 (#3968)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/03-Claude-CLI-References.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/03-Claude-CLI-References.ipynb
@@ -2,102 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0aad80c3ba60",
-   "metadata": {},
-   "source": [
-    "### Exercice : Test generation\n",
-    "\n",
-    "Generez des tests unitaires pour une fonction donnee en respectant le pattern AAA\n",
-    "\n",
-    "- **Indice** : Arrange-Act-Assert est le pattern attendu\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "b074a6732289",
-   "metadata": {},
-   "source": [
-    "# Exercice : Test generation\n",
-    "# TODO etudiant : Implementer la solution\n",
-    "print(\"Exercice a completer : test generation\")\n"
-   ],
-   "execution_count": 14,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer : test generation\n"
-     ]
-    }
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e88e273031c8",
-   "metadata": {},
-   "source": [
-    "### Exercice : Analyse de dependances\n",
-    "\n",
-    "Analysez les imports d'un projet et identifiez les dependances inutilisees\n",
-    "\n",
-    "- **Indice** : Utilisez grep pour extraire les imports\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "554d79296925",
-   "metadata": {},
-   "source": [
-    "# Exercice : Analyse de dependances\n",
-    "# TODO etudiant : Implementer la solution\n",
-    "print(\"Exercice a completer : analyse de dependances\")\n"
-   ],
-   "execution_count": 15,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer : analyse de dependances\n"
-     ]
-    }
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4d911b88e57e",
-   "metadata": {},
-   "source": [
-    "### Exercice : Generation de documentation\n",
-    "\n",
-    "Utilisez Claude CLI pour generer automatiquement la docstring d'une fonction\n",
-    "\n",
-    "- **Indice** : Fournissez le code en entree et demandez le format Google/Numpy\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "71d030de10d0",
-   "metadata": {},
-   "source": [
-    "# Exercice : Generation de documentation\n",
-    "# TODO etudiant : Implementer la solution\n",
-    "print(\"Exercice a completer : generation de documentation\")\n"
-   ],
-   "execution_count": 16,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer : generation de documentation\n"
-     ]
-    }
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "670da470",
    "metadata": {
     "papermill": {
@@ -1415,6 +1319,102 @@
     "# print_response(stdout, stderr, code)\n",
     "\n",
     "print(\"Decommentez le code ci-dessus pour executer l'exercice\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0aad80c3ba60",
+   "metadata": {},
+   "source": [
+    "### Exercice : Test generation\n",
+    "\n",
+    "Generez des tests unitaires pour une fonction donnee en respectant le pattern AAA\n",
+    "\n",
+    "- **Indice** : Arrange-Act-Assert est le pattern attendu\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "b074a6732289",
+   "metadata": {},
+   "source": [
+    "# Exercice : Test generation\n",
+    "# TODO etudiant : Implementer la solution\n",
+    "print(\"Exercice a completer : test generation\")\n"
+   ],
+   "execution_count": 14,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : test generation\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e88e273031c8",
+   "metadata": {},
+   "source": [
+    "### Exercice : Analyse de dependances\n",
+    "\n",
+    "Analysez les imports d'un projet et identifiez les dependances inutilisees\n",
+    "\n",
+    "- **Indice** : Utilisez grep pour extraire les imports\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "554d79296925",
+   "metadata": {},
+   "source": [
+    "# Exercice : Analyse de dependances\n",
+    "# TODO etudiant : Implementer la solution\n",
+    "print(\"Exercice a completer : analyse de dependances\")\n"
+   ],
+   "execution_count": 15,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : analyse de dependances\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d911b88e57e",
+   "metadata": {},
+   "source": [
+    "### Exercice : Generation de documentation\n",
+    "\n",
+    "Utilisez Claude CLI pour generer automatiquement la docstring d'une fonction\n",
+    "\n",
+    "- **Indice** : Fournissez le code en entree et demandez le format Google/Numpy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "71d030de10d0",
+   "metadata": {},
+   "source": [
+    "# Exercice : Generation de documentation\n",
+    "# TODO etudiant : Implementer la solution\n",
+    "print(\"Exercice a completer : generation de documentation\")\n"
+   ],
+   "execution_count": 16,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : generation de documentation\n"
+     ]
+    }
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Part of #3968 (mise en forme / hiérarchie). `03-Claude-CLI-References.ipynb` (Vibe-Coding/Claude-Code) avait un défaut structurel : le titre H1 « Claude CLI - References et Contexte » était en **cell 6**, APRÈS 3 exercices génériques (cells 0-5).

Ces 3 exercices (exec_count 14-16) étaient des artefacts d'enrichissement (#2161) exécutés en fin de session kernel et physiquement placés **avant** le titre → séquence exec non-monotonic (14,15,16 puis 1-13) + titre H1 profond (scanner `H1-DEEP`).

## Changement — pure cell reorder (#3248-style)

1. **Titre H1** (cell 6) → **cell 0** (résout `H1-DEEP` scanner)
2. **3 exercices génériques** (cells 0-5) → après EXERCICE 3 (section exercices, à côté des exercices projet)
3. Séquence exec devient **monotonic 1→16** (était 14,15,16,1-13)
4. **0 contenu perdu, 0 output touché, exec_count préservé**

## Validation

| Check | Résultat |
|-------|----------|
| `scan_md_hierarchy.py` : 0 finding résiduel | ✅ (`H1-DEEP` résolu, était 1) |
| exec sequence monotone | ✅ [1,2,...,16] |
| **content IDENTICAL** (same multiset of 33 cells) | ✅ pure reorder, aucun contenu modifié |
| diff +96/-96 (symétrie parfaite) | ✅ |
| C.2 : outputs/exec_count préservés (reorder seul) | ✅ pas de re-exec |

## Note

Le diff +96/-96 est entièrement des cellules déplacées (exercices : ancienne position  → nouvelle position ). Aucune ligne de contenu modifiée — vérifié par comparaison du multiset des cellules (old==new).

Sous-série Claude-Code IDLE pour #3968 (dernier commit 06-25 #4495 Mermaid, aucune activité #3968) → pas de collision.

See #3968

🤖 Generated with [Claude Code](https://claude.com/claude-code)