### PR TITLE
feat(tweety): C#/.NET port pilot — Tweety-2-Basic-Logics via IKVM (cluster pl) (#4667)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
@@ -1,0 +1,590 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "m13718",
+   "metadata": {},
+   "source": [
+    "# Tweety C# / IKVM - Logiques de Base (Port .NET du notebook Python)\n",
+    "\n",
+    "**Navigation** : [<- Tweety-1-Setup](Tweety-1-Setup.ipynb) | [Index serie](Tweety-1-Setup.ipynb) | [Tweety-3-Advanced-Logics ->](Tweety-3-Advanced-Logics.ipynb)\n",
+    "\n",
+    "> Ce notebook est le **port C# / .NET** de [Tweety-2-Basic-Logics.ipynb](Tweety-2-Basic-Logics.ipynb).\n",
+    "> Au lieu d'appeler Tweety depuis Python via JPype + JVM, on execute directement les\n",
+    "> classes Tweety **recompilees en bytecode .NET via IKVM** - aucune JVM, aucun JDK requis\n",
+    "> au runtime. Voir le notebook Python pour le contexte theorique complet.\n",
+    "\n",
+    "## Objectifs pedagogiques\n",
+    "\n",
+    "1. Charger la DLL Tweety (cluster `pl`) recompilee via IKVM 8.15\n",
+    "2. Construire des formules propositionnelles (`Proposition`, `Negation`, `Conjunction`, `Disjunction`, `Implication`)\n",
+    "3. Parser des formules depuis une chaine avec `PlParser`\n",
+    "4. Manipuler une base de croyances (`PlBeliefSet`) et explorer les mondes possibles (`PossibleWorld`)\n",
+    "\n",
+    "## Prerequis\n",
+    "\n",
+    "- Le notebook Python `Tweety-2-Basic-Logics.ipynb` pour les notions (logique propositionnelle, mondes possibles)\n",
+    "- Le runtime est **tout .NET** : aucune installation Java/JDK n'est necessaire\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m51407",
+   "metadata": {},
+   "source": [
+    "## Comment Tweety tourne en .NET (sans JVM)\n",
+    "\n",
+    "Tweety est une bibliotheque **Java**. Pour l'utiliser depuis C#, on recompile son bytecode\n",
+    "Java en **bytecode .NET** grace a [IKVM](https://github.com/ikvm-revived/ikvm) :\n",
+    "\n",
+    "1. **Recompilation** : le bytecode Tweety 1.30 (Java 15) est recompile vers Java 8 (compatible IKVM 8.15, qui cible Java 8 SE), puis converti en une DLL .NET via `<IkvmReference>`.\n",
+    "2. **Fat-jar Maven shade** : on assemble `pl` + ses dependances transitives (`fol`, `logics-commons`, `math`, `commons`, `commons-math3`, `ojalgo`, `sat4j`) en un unique fat-jar Maven coheren, qui preserve les metadonnees cross-module (un zip-merge artisanal les casserait).\n",
+    "3. **Runtime** : la DLL `org.tweetyproject.tweety-pl.dll` (placee a cote de ce notebook) est referencee via `#r` ; IKVM fournit l'execution de la JVM en .NET. La recette de build complete (POM shade + csproj) est dans [`dotnet-build/`](dotnet-build/).\n",
+    "\n",
+    "La cellule suivante configure ce runtime - **a executer avant toute utilisation de Tweety**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m74154",
+   "metadata": {},
+   "source": [
+    "### 1. Configuration du runtime IKVM\n",
+    "\n",
+    "> Cette cellule restaure les paquets NuGet IKVM et assemble le home IKVM. ~30-60 s la premiere fois.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c23932",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T19:43:32.325633Z",
+     "iopub.status.busy": "2026-07-01T19:43:32.318321Z",
+     "iopub.status.idle": "2026-07-01T19:43:33.201639Z",
+     "shell.execute_reply": "2026-07-01T19:43:33.198991Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-118308.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '118308.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>IKVM, 8.15.0</span></li><li><span>IKVM.Image, 8.15.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: IKVM, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image.runtime.win-x64, 8.15.0\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c41366",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T19:43:33.209900Z",
+     "iopub.status.busy": "2026-07-01T19:43:33.206916Z",
+     "iopub.status.idle": "2026-07-01T19:43:34.374833Z",
+     "shell.execute_reply": "2026-07-01T19:43:34.374438Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.IO;\n",
+    "\n",
+    "string ikvmVer = \"8.15.0\", ikvmRid = \"win-x64\";\n",
+    "string nugetRoot = Environment.GetEnvironmentVariable(\"NUGET_PACKAGES\")\n",
+    "    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \".nuget\", \"packages\");\n",
+    "string ikvmBaseAny = Path.Combine(nugetRoot, \"ikvm.image\", ikvmVer, \"ikvm\", \"any\", \"any\");\n",
+    "string ikvmArchDir = Path.Combine(nugetRoot, \"ikvm.image.runtime.\" + ikvmRid, ikvmVer, \"ikvm\", \"any\", ikvmRid);\n",
+    "string ikvmHome    = Path.Combine(Path.GetTempPath(), \"ikvm-home-\" + ikvmVer + \"-\" + ikvmRid);\n",
+    "\n",
+    "void IkvmCopyMerge(string src, string dst)\n",
+    "{\n",
+    "    foreach (var d in Directory.GetDirectories(src, \"*\", SearchOption.AllDirectories))\n",
+    "        Directory.CreateDirectory(d.Replace(src, dst));\n",
+    "    foreach (var f in Directory.GetFiles(src, \"*\", SearchOption.AllDirectories))\n",
+    "    {\n",
+    "        var t = f.Replace(src, dst);\n",
+    "        Directory.CreateDirectory(Path.GetDirectoryName(t));\n",
+    "        File.Copy(f, t, overwrite: true);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "if (Directory.Exists(ikvmBaseAny) && Directory.Exists(ikvmArchDir))\n",
+    "{\n",
+    "    Directory.CreateDirectory(ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmBaseAny, ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmArchDir, ikvmHome);\n",
+    "}\n",
+    "AppContext.SetData(\"IKVM.Home\", ikvmHome);\n",
+    "\n",
+    "bool tzdbOk = File.Exists(Path.Combine(ikvmHome, \"lib\", \"tzdb.dat\"));\n",
+    "Console.WriteLine($\"IKVM 8.15.0 pret (home=ikvm-home-{ikvmVer}-{ikvmRid}, tzdb={tzdbOk})\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m74269",
+   "metadata": {},
+   "source": [
+    "### 2. Chargement de la DLL Tweety\n",
+    "\n",
+    "On reference la DLL recompilee. Le cluster `pl` expose les espaces de noms\n",
+    "`org.tweetyproject.logics.pl.syntax`, `org.tweetyproject.logics.pl.parser`, etc.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c1036",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T19:43:34.376859Z",
+     "iopub.status.busy": "2026-07-01T19:43:34.376502Z",
+     "iopub.status.idle": "2026-07-01T19:43:34.403833Z",
+     "shell.execute_reply": "2026-07-01T19:43:34.402233Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#r \"org.tweetyproject.tweety-pl.dll\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m58656",
+   "metadata": {},
+   "source": [
+    "### 3. Logique propositionnelle - construction manuelle de formules\n",
+    "\n",
+    "On construit des formules comme dans le notebook Python, via l'API des classes\n",
+    "`Proposition`, `Negation`, `Conjunction`, `Disjunction`, `Implication`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c16522",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T19:43:34.405900Z",
+     "iopub.status.busy": "2026-07-01T19:43:34.405481Z",
+     "iopub.status.idle": "2026-07-01T19:43:34.934521Z",
+     "shell.execute_reply": "2026-07-01T19:43:34.933666Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a       = a\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "!b      = !b\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a && !c = a&&!c\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a || b  = a||b\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a => b  = (a=>b)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "\n",
+    "var a = new Proposition(\"a\");\n",
+    "var b = new Proposition(\"b\");\n",
+    "var c = new Proposition(\"c\");\n",
+    "\n",
+    "var f1 = a;\n",
+    "var f2 = new Negation(b);\n",
+    "var f3 = new Conjunction(a, new Negation(c));\n",
+    "var f4 = new Disjunction(a, b);\n",
+    "var f5 = new Implication(a, b);\n",
+    "\n",
+    "Console.WriteLine($\"a       = {a}\");\n",
+    "Console.WriteLine($\"!b      = {f2}\");\n",
+    "Console.WriteLine($\"a && !c = {f3}\");\n",
+    "Console.WriteLine($\"a || b  = {f4}\");\n",
+    "Console.WriteLine($\"a => b  = {f5}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m24048",
+   "metadata": {},
+   "source": [
+    "### 4. Parsing de formules avec `PlParser`\n",
+    "\n",
+    "Le `PlParser` lit des formules depuis une chaine : `!` (negation), `&&` (conjonction),\n",
+    "`||` (disjonction), `=>` (implication), `<=>` (equivalence), `^^` (XOR).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c54393",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T19:43:34.937592Z",
+     "iopub.status.busy": "2026-07-01T19:43:34.937087Z",
+     "iopub.status.idle": "2026-07-01T19:43:35.039712Z",
+     "shell.execute_reply": "2026-07-01T19:43:35.039112Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parse de '(a || b) && !c' = (a||b)&&!c\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XOR 'a ^^ b' = a^^b\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var parser = new org.tweetyproject.logics.pl.parser.PlParser();\n",
+    "\n",
+    "var fParsed = parser.parseFormula(\"(a || b) && !c\");\n",
+    "Console.WriteLine($\"Parse de '(a || b) && !c' = {fParsed}\");\n",
+    "\n",
+    "var fXor = parser.parseFormula(\"a ^^ b\");\n",
+    "Console.WriteLine($\"XOR 'a ^^ b' = {fXor}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m95461",
+   "metadata": {},
+   "source": [
+    "### 5. Base de croyances (`PlBeliefSet`)\n",
+    "\n",
+    "Une `PlBeliefSet` est un ensemble de formules (base de connaissances). On reproduit la KB\n",
+    "du notebook Python. **Note d'API** : IKVM expose les methodes Java en minuscules\n",
+    "(`kb.add(...)`, `kb.size()`) - c'est la convention Java, pas les wrappers .NET.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c59450",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T19:43:35.041515Z",
+     "iopub.status.busy": "2026-07-01T19:43:35.041162Z",
+     "iopub.status.idle": "2026-07-01T19:43:35.116646Z",
+     "shell.execute_reply": "2026-07-01T19:43:35.116349Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Base de croyances KB = { a&&!c, (a=>b), a, !b }\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de formules : 4\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "\n",
+    "var kb = new PlBeliefSet();\n",
+    "var p = new org.tweetyproject.logics.pl.parser.PlParser();\n",
+    "kb.add(p.parseFormula(\"a\"));\n",
+    "kb.add(p.parseFormula(\"!b\"));\n",
+    "kb.add(p.parseFormula(\"a && !c\"));\n",
+    "kb.add(p.parseFormula(\"a => b\"));\n",
+    "\n",
+    "Console.WriteLine($\"Base de croyances KB = {kb}\");\n",
+    "Console.WriteLine($\"Nombre de formules : {kb.size()}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m62216",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook demontre le **port .NET fonctionnel** de Tweety pour la logique propositionnelle :\n",
+    "\n",
+    "| Concept | Classe Tweety (C#) | Statut |\n",
+    "|---------|-------------------|--------|\n",
+    "| Atome propositionnel | `Proposition` | OK |\n",
+    "| Connecteurs | `Negation`, `Conjunction`, `Disjunction`, `Implication` | OK |\n",
+    "| Parsing | `PlParser.parseFormula` | OK |\n",
+    "| Base de croyances | `PlBeliefSet` (`.add()`, `.size()`) | OK |\n",
+    "\n",
+    "**Avantage du port .NET** : aucune JVM ni JDK a installer, execution native dans le kernel\n",
+    "`.net-csharp`. **Limitation** : seule la logique propositionnelle (cluster `pl`) est portee\n",
+    "dans ce pilote ; les notebooks Python restent canoniques pour la FOL complete,\n",
+    "l'argumentation (notebooks 5-7), les MLN (notebook 10), etc. La semantique via\n",
+    "`PossibleWorld` + `SatReasoner.query` fera l'objet d'un notebook suivant.\n",
+    "\n",
+    "### Exercices\n",
+    "\n",
+    "Reprenez ceux du notebook Python, adaptes a l'API C# (methodes Java minuscules).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c30432",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T19:43:35.118386Z",
+     "iopub.status.busy": "2026-07-01T19:43:35.118041Z",
+     "iopub.status.idle": "2026-07-01T19:43:35.172923Z",
+     "shell.execute_reply": "2026-07-01T19:43:35.172450Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Construisez la formule (a => b) && (b => a) et affichez sa forme DNF.\n",
+    "// Indice : PlParser + .toNnf() ou construction manuelle.\n",
+    "// TODO etudiant : completez ici\n",
+    "Console.WriteLine(\"Exercice 1 a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c52534",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T19:43:35.174678Z",
+     "iopub.status.busy": "2026-07-01T19:43:35.174381Z",
+     "iopub.status.idle": "2026-07-01T19:43:35.224035Z",
+     "shell.execute_reply": "2026-07-01T19:43:35.223502Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Parsez une KB de 4 formules et affichez sa taille + contenu.\n",
+    "// TODO etudiant : completez ici\n",
+    "Console.WriteLine(\"Exercice 2 a completer\");\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/README.md
@@ -1,0 +1,42 @@
+# `dotnet-build/` — Recette de build du runtime Tweety C# / IKVM
+
+Ce dossier contient la **recette de build** (POM shade + csproj) du runtime .NET de Tweety
+(cluster `pl`) recompilé via IKVM 8.15.0. Le runtime compilé (`org.tweetyproject.tweety-pl.dll`)
+est placé **à côté du notebook** [`../Tweety-2-Basic-Logics-Csharp.ipynb`](../Tweety-2-Basic-Logics-Csharp.ipynb).
+
+## Fichiers
+
+| Fichier | Rôle | Committé ? |
+|---------|------|-----------|
+| `org.tweetyproject.tweety-pl.dll` (7.6 MB) | **Runtime** .NET de Tweety cluster `pl` (chargé par le notebook via `#r`) | Oui (pattern #4711) |
+| `tweety-pl-full-1.30.jar` (6.9 MB) | Fat-jar Maven shade (artefact de build intermédiaire) | Non (gitignoré, reconstruit ci-dessous) |
+| `build-tweety-pl-shade.pom.xml` | POM aggregator Maven shade (produit le fat-jar) | Oui (reproductibilité) |
+| `build-TweetyShade.csproj` | Projet MSBuild `<IkvmReference>` (convertit le fat-jar en DLL) | Oui (reproductibilité) |
+
+## Recette de rebuild (si la DLL doit être régénérée)
+
+Prérequis : JDK 17 (`JAVA_HOME`), Maven 3.9+, .NET SDK 8.0+, les 5 modules Tweety recompilés
+en Java 8 installés dans le `~/.m2` local (clone `TweetyProject` tag `v1.30`, patch parent-pom
+`maven-compiler-plugin` 2.3.2 → 3.13.0 + `<release>8</release>`, downgrade source Java 9-11 → 8,
+puis `mvn install -DskipTests -Dgpg.skip=true` sur commons/logics-commons/math/logics-fol/logics-pl).
+
+```bash
+# 1. Fat-jar Maven shade (déclare pl comme dep, tire transitivement fol/commons/math/...)
+mvn -f build-tweety-pl-shade.pom.xml clean package -Dgpg.skip=true
+cp target/tweety-pl-full-1.30.jar .
+
+# 2. DLL .NET via <IkvmReference> (TargetFramework = net8.0, PAS net10.0 — runtime kernel LTS)
+dotnet build build-TweetyShade.csproj -c Release
+cp bin/Release/net8.0/org.tweetyproject.tweety-pl.dll .
+```
+
+## Pourquoi cette approche
+
+- **maven-shade-plugin** (pas un zip-merge artisanal) : produit un fat-jar Maven cohérent qui
+  préserve les métadonnées cross-module IKVM. Un zip-merge casse l'exposition des types
+  (`new Proposition()` → CS0246).
+- **`net8.0` pas `net10.0`** : le kernel `.net-csharp` fournit le runtime `System.Runtime`
+  en version 8.0 ; un DLL `net10.0` compile `Proposition` mais lève `FileNotFoundException:
+  System.Runtime 10.0.0.0` au premier appel méthode.
+
+Voir `Tweety-2-Basic-Logics-Csharp.ipynb` pour l'utilisation. Epic #4667.

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-TweetyShade.csproj
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-TweetyShade.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <RestoreAdditionalProjectSources></RestoreAdditionalProjectSources>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="IKVM" Version="8.15.0" />
+    <PackageReference Include="IKVM.MSBuild" Version="8.15.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <IkvmReference Include="tweety-pl-full-1.30.jar">
+      <AssemblyName>org.tweetyproject.tweety-pl</AssemblyName>
+      <AssemblyVersion>1.30.0.0</AssemblyVersion>
+      <AssemblyFileVersion>1.30.0.0</AssemblyFileVersion>
+    </IkvmReference>
+  </ItemGroup>
+</Project>

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-tweety-pl-shade.pom.xml
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-tweety-pl-shade.pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Standalone shade aggregator: bundles logics-pl + transitive deps (commons,
+     logics-commons, math, fol, commons-math3, ojalgo, sat4j, commons-math, jama)
+     from local m2 into one coherent fat-jar. Reproduces the Choco #4711 pattern:
+     a single Maven shade artifact (not a zip-merge) with merged metadata, which
+     IKVM 8.15 can resolve cross-module types from. Missing isula/gurobi jars are
+     skipped (not used by pl/fol/commons). -->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>local</groupId>
+  <artifactId>tweety-pl-shade</artifactId>
+  <version>1.30</version>
+  <packaging>jar</packaging>
+  <name>Tweety logics-pl shaded fat-jar (IKVM target)</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.tweetyproject.logics</groupId>
+      <artifactId>pl</artifactId>
+      <version>1.30-SNAPSHOT</version>
+      <exclusions>
+        <!-- junit (incl. junit-jupiter 5.x = Java 9+ bytecode) is test-only and
+             would pollute the fat-jar with IKVM0101-rejecting classes. -->
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit</groupId>
+          <artifactId>junit-bom</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>tweety-pl-full-1.30</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Summary

First Tweety notebook running Tweety **natively in .NET** (no JVM/JPype/JDK at runtime) — a C#/.NET port of the Python [`Tweety-2-Basic-Logics.ipynb`](MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb). This closes the **runtime wall** of Epic #4667.

Two keys unlocked it (after the bytecode wall fell last cycle):
1. **maven-shade-plugin** (not a zip-merge) → coherent fat-jar preserving IKVM cross-module metadata (`CS0246` on `Proposition` gone).
2. **`net8.0` not `net10.0`** in `<IkvmReference>` → the kernel's `System.Runtime` LTS; `net10.0` compiled but threw `FileNotFoundException: System.Runtime 10.0.0.0` at the first method call.

## Pilot notebook — `Tweety-2-Basic-Logics-Csharp.ipynb` (16 cells)

Executes end-to-end via `jupyter nbconvert --execute`, **exec_count 1-8, 0 error, real outputs** (#835-safe):
- IKVM 8.15.0 runtime setup (`IKVM.Home` assembly — pattern #4711, same as Choco)
- PL construction: `Proposition`/`Negation`/`Conjunction`/`Disjunction`/`Implication` → `a`, `!b`, `a&&!c`, `a||b`, `(a=>b)`
- `PlParser.parseFormula`: `(a || b) && !c` → `(a||b)&&!c`, `a ^^ b` → `a^^b`
- `PlBeliefSet` KB: `{ a&&!c, (a=>b), a, !b }`, size 4
- 2 exercises (C.1 compliant stubs — no `raise`)

## Files

| File | Role |
|------|------|
| `Tweety-2-Basic-Logics-Csharp.ipynb` | Pedagogical port (executed, with outputs) |
| `org.tweetyproject.tweety-pl.dll` (7.6 MB) | Runtime, beside notebook (#4711: DLL committed, not NuGet-restored at nbconvert time) |
| `dotnet-build/README.md` + `build-tweety-pl-shade.pom.xml` + `build-TweetyShade.csproj` | Reproducible build recipe (the fat-jar is gitignored; these let anyone rebuild the DLL from source) |

## Validation (§D notebook PR discipline)

- `jupyter nbconvert --execute` end-to-end **exit 0**, exec_count 1-8, 0 error
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1)
- All code cells have `execution_count` + `outputs` coherent (C.2)
- Cell-by-cell API verification: `PlBeliefSet` uses Java-lowercase `.add()`/`.size()` (verified in-kernel before authoring); `SatReasoner` API diverged (`.query` not `.satisfies`) → semantics deferred honestly, not stubbed with a fake call

## Honest limitation

PL cluster (`pl`) only. FOL/argumentation (notebooks 3-11) stay Python-canonical. Semantics (`PossibleWorld` + `SatReasoner.query`) is a follow-up notebook (API needs mapping from Python's `.satisfies`).

See #4667. See #4711 (canonical IKVM pattern). See #3801 (SOTA axis-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)