### PR TITLE
docs(lean): ML LEAN_INVENTORY — resync Perceptron Tightness (#4301, modules 4→5)

### DIFF
--- a/MyIA.AI.Notebooks/ML/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/ML/LEAN_INVENTORY.md
@@ -13,8 +13,8 @@ n'entrent pas dans ce compte ; cf.
 
 | Lake | Toolchain | sorry (production) | Modules | Notebook câblé | Classe | Suivi |
 |------|-----------|--------------------:|--------:|---------------:|--------|-------|
-| `learning_theory_lean` | v4.31.0-rc1 | 0 | 4 | 0¹ | PEDA/REF | #4051, #4038 |
-| **Total** | — | **0** | **4** | — | — | — |
+| `learning_theory_lean` | v4.31.0-rc1 | 0 | 5 | 0¹ | PEDA/REF | #4051, #4301, #4038 |
+| **Total** | — | **0** | **5** | — | — | — |
 
 ¹ Aucun notebook Lean dédié. Companion conceptuel = la série **ML.NET** (classification
 linéaire, le perceptron comme ancêtre) — convention sibling-lake (le lake est le livrable
@@ -33,25 +33,38 @@ Lean de la série ML (roadmap #4038 Tier 2).
 - **Toolchain** : v4.31.0-rc1 · **Dépendance** : Mathlib4
 - **lib** : `Perceptron` (`globs := #[.submodules \`Perceptron]`)
 - **Modules** : `Perceptron/Data.lean`, `Perceptron/Perceptron.lean`,
-  `Perceptron/Convergence.lean` + umbrella `Perceptron.lean`
-- **sorry (production)** : **0**. `lake build Perceptron` SUCCESS (8496 jobs, 0 warning).
+  `Perceptron/Convergence.lean`, `Perceptron/Tightness.lean` + umbrella `Perceptron.lean`
+- **sorry (production)** : **0**. `lake build Perceptron` SUCCESS (8497 jobs, 0 warning).
 
 #### Théorèmes prouvés (0 sorry)
 
-- **`PerceptronRun.novikoff_mistake_bound`** (flagship) : `n·γ² ≤ R²` — la borne de
-  Novikoff sur le nombre de mises à jour.
+- **`PerceptronRun.novikoff_mistake_bound`** (flagship Convergence, #4140) : `n·γ² ≤ R²` —
+  la borne de Novikoff sur le nombre de mises à jour.
+- **`novikoff_bound_is_sharp`** (flagship Tightness, #4301) :
+  `∃ run : PerceptronRun ℂ, (run.n : ℝ) * run.γ^2 = run.R^2` — un témoin concret sur `ℂ`
+  (deux points `1±I`, séparateur `u=1`, marge `γ=1`, rayon `R=√2`, `n=2`) sature la borne
+  avec **égalité** `n·γ² = R²`. L'inégalité universelle `≤ R²` (`novikoff_mistake_bound`) et
+  l'égalité du témoin coexistent ⟹ aucune borne `n·γ² ≤ c·R²` avec `c < 1` n'est universelle :
+  la constante `1` (devant `(R/γ)²`) est **optimale**.
 - `PerceptronRun.align_growth` (Lemme A) : `⟪wₖ, u⟫ ≥ k·γ` — croissance de l'alignement
   avec le vecteur séparateur `u`.
 - `PerceptronRun.norm_bound` (Lemme B) : `‖wₖ‖² ≤ k·R²` — borne quadratique sur la norme
   des poids.
 - Support IPS (espace préhilbertien réel) : `norm_sq_eq_inner_self`, `norm_add_sq_eq`,
   `perceptronWeights_zero`/`_succ` (suite de récurrence `w₀=0`, `w_{k+1}=wₖ+yₖ•xₖ`).
+- Support Tightness (witness `ℂ`) : `complex_inner_re` (produit scalaire réel sur `ℂ` en
+  coordonnées `w.re·z.re + w.im·z.im`), `witnessPts_norm_sq` (`‖xₖ‖² = 2`),
+  `witness_margin_inner`, `witness_cross_inner` (orthogonalité `⟨1+I, 1−I⟩ = 0`),
+  `witness_w1`, `witness_lbl`, `witness_rad`, `witness_margin`, `witness_mistake`,
+  `tightnessRun_saturates` (égalité `2·1² = (√2)²`).
 
 #### Honnêteté du périmètre (G.3/G.9)
 
 La borne de Novikoff **complète** (alignement + norme + Cauchy–Schwarz `real_inner_le_norm`)
-est prouvée 0 sorry. Aucun jalon laissé en `sorry`. Axiomes `[propext, Classical.choice,
-Quot.sound]` (Mathlib standard, **pas de `sorryAx`**).
+est prouvée 0 sorry, **et sa sharpness est établie** (`novikoff_bound_is_sharp`, #4301) —
+le lac ne se contente pas de la borne universelle, il prouve son optimalité. Aucun jalon
+laissé en `sorry`. Axiomes `[propext, Classical.choice, Quot.sound]` (Mathlib standard,
+**pas de `sorryAx`**).
 
 ## Notes transverses
 


### PR DESCRIPTION
## Contexte

Driver **#4041** (LEAN_INVENTORY colonnes correctes par lake). `ML/LEAN_INVENTORY.md` était **stale** : écrit après `#4140` (Convergence) mais **avant `#4301`** (Tightness). Vérification firsthand ce cycle (grep + `lake build Perceptron` SUCCESS 8497 jobs).

## Corrections (verify-before-claiming G.1)

| # | Avant (stale) | Après (réel) |
|---|---------------|--------------|
| 1 | Modules `4` (table + total) | `5` — `Perceptron/Tightness.lean` manquait |
| 2 | Liste modules sans Tightness | `+ Perceptron/Tightness.lean` |
| 3 | `8496 jobs` | `8497 jobs` (Tightness ajoute 1 job) |
| 4 | Suivi `#4051, #4038` | `#4051, #4301, #4038` |
| 5 | Théorèmes : `novikoff_mistake_bound` seul flagship | `+ novikoff_bound_is_sharp` (flagship Tightness #4301) : témoin `ℂ` (`x₀=1+I, x₁=1−I, u=1, γ=1, R=√2, n=2`) sature la borne avec **égalité** `n·γ² = R²` ⟹ la constante `1` devant `(R/γ)²` est **optimale** |
| 6 | Théorèmes witness absents | `+ complex_inner_re`, `witnessPts_norm_sq`, `witness_cross_inner` (orthogonalité `⟨1+I,1−I⟩=0`), `tightnessRun_saturates`… |
| 7 | §G.3 « borne complète » | « borne complète **ET sa sharpness établie** (optimalité prouvée, pas juste majoration) » |

## Discipline respectée

- **catalog-pr-hygiene** : `COURSE_CATALOG.*` **byte-identique à main** (vérifié)
- **anti-regression** : aucun fichier `.lean` modifié → sorry-baseline n/a (linventaire reflète létat réel : 0 sorry, 5 modules, #4140+#4301 merged)
- §E : 1 fichier doc, +21/−8 (édition ciblée dinventaire existant, pas création)

## Contexte cycle

Steer ai-01 `g9w4kg` = #4038 création Lean, mais verify firsthand = #4038 **exhaustivement livré** (tous lacs Tier 1-3 créés + prouvés, #4051+#4301 merged). Cet inventaire stale en était un symptôme — corrigé. Détails dans reply DM à ai-01 (`h32hjl`).

`See #4041` · `See #4038` · `See #4301`

🤖 Generated with [Claude Code](https://claude.com/claude-code)