### PR TITLE
fix(z3-python): repair 4 dangling cross-pointers in SMT/Z3-Python notebooks

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-02-Sudoku.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-02-Sudoku.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "---\n",
     "\n",
-    "Le [notebook precedent](Z3-Python-01-Introduction.ipynb) a introduit le solveur Z3. Ici, nous l'appliquons a un probleme NP-complet emblematique : le **Sudoku**. L'approche contraste avec la serie [Sudoku par backtracking](../Sudoku/Sudoku-1-Backtracking-Python.ipynb) : au lieu de programmer l'algorithme de recherche, nous **enonc ons les regles** et laissons le solveur deduire la solution."
+    "Le [notebook precedent](Z3-Python-01-Introduction.ipynb) a introduit le solveur Z3. Ici, nous l'appliquons a un probleme NP-complet emblematique : le **Sudoku**. L'approche contraste avec la serie [Sudoku par backtracking](../../../Sudoku/Sudoku-1-Backtracking-Python.ipynb) : au lieu de programmer l'algorithme de recherche, nous **enonc ons les regles** et laissons le solveur deduire la solution."
    ]
   },
   {
@@ -320,7 +320,7 @@
    "source": [
     "## 3. Visualisation : donne en noir, resolu en bleu\n",
     "\n",
-    "Pour distinguer les indices fournis par l'enonce des valeurs deduites par le solveur, nous reprenons le style de visualisation de la [serie Sudoku par backtracking](../Sudoku/Sudoku-1-Backtracking-Python.ipynb). Les valeurs **initiales** s'affichent en noir, les valeurs **ajoutees** par Z3 en bleu."
+    "Pour distinguer les indices fournis par l'enonce des valeurs deduites par le solveur, nous reprenons le style de visualisation de la [serie Sudoku par backtracking](../../../Sudoku/Sudoku-1-Backtracking-Python.ipynb). Les valeurs **initiales** s'affichent en noir, les valeurs **ajoutees** par Z3 en bleu."
    ]
   },
   {
@@ -696,7 +696,7 @@
     "| Variante (anti-diagonale) | Une contrainte de plus | Evolutivite immediate |\n",
     "| Visualisation | matplotlib (noir = donne, bleu = resolu) | Verification visuelle |\n",
     "\n",
-    "La force du paradigme declaratif est l'**evolutivite** : chaque nouvelle regle se traduit par une contrainte, sans reecrire la logique de recherche. Pour aller plus loin, consultez la [documentation z3-py](https://microsoft.github.io/z3guide/) et la serie [Sudoku par approches multiples](../Sudoku/README.md) qui compare Z3 a dix autres techniques algorithmiques."
+    "La force du paradigme declaratif est l'**evolutivite** : chaque nouvelle regle se traduit par une contrainte, sans reecrire la logique de recherche. Pour aller plus loin, consultez la [documentation z3-py](https://microsoft.github.io/z3guide/) et la serie [Sudoku par approches multiples](../../../Sudoku/README.md) qui compare Z3 a dix autres techniques algorithmiques."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Z3-Python 05 — Quantificateurs et preuves formelles\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3/README.md) | [<< Z3-Python-04 Chaines](Z3-Python-04-Strings.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3/README.md) | [<< Z3-Python-04 Chaines](Z3-Python-04-Strings-Regex.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",


### PR DESCRIPTION
## Summary

Fix 4 broken links from the repo-wide dangling-link sweep (#4788), **Z3-Python tranche** (`SymbolicAI/SMT/Z3-Python/` = Python raw-Z3 lane). These live in notebook markdown cells that `check_docs_links.py` does not scan.

| # | Notebook (cell) | Before (404) | After (exists) |
|---|---|---|---|
| 1 | Z3-Python-05-Quantifiers-Proofs (nav) | `Z3-Python-04-Strings.ipynb` | `Z3-Python-04-Strings-Regex.ipynb` (file renamed with `-Regex` suffix, nav link not updated) |
| 2 | Z3-Python-02-Sudoku (cell 0) | `../Sudoku/Sudoku-1-Backtracking-Python.ipynb` | `../../../Sudoku/Sudoku-1-Backtracking-Python.ipynb` |
| 3 | Z3-Python-02-Sudoku (cell 7) | `../Sudoku/Sudoku-1-Backtracking-Python.ipynb` | `../../../Sudoku/Sudoku-1-Backtracking-Python.ipynb` |
| 4 | Z3-Python-02-Sudoku (cell 16) | `../Sudoku/README.md` | `../../../Sudoku/README.md` |

## Root cause of the Sudoku links

From `SymbolicAI/SMT/Z3-Python/`, the original `../Sudoku/` resolves to `SymbolicAI/SMT/Sudoku/` (ABSENT). The Sudoku series lives at top-level `MyIA.AI.Notebooks/Sudoku/`, which is **3 ups** (`../../../`) — the author undercounted the directory depth. Verified by `normpath` resolution against `git ls-tree origin/main`: both `Sudoku/Sudoku-1-Backtracking-Python.ipynb` and `Sudoku/README.md` **EXIST**.

## Validation (#4788 acceptance)

- Path-only corrections, markdown cells only ("correction de chemin uniquement").
- 0 code cell touched; all outputs preserved (C.2 markdown-only exception). Z3-Python-02: 7/7 code cells with outputs; Z3-Python-05: 12/12.
- JSON round-trip byte-faithful (`indent=1`). 4 insertions / 4 deletions.
- Other navigation links in the same cells (README.md, ../README.md, ../Z3/README.md) **untouched**.
- Anti-collision: no other open PR touches `SMT/Z3-Python` (`gh pr list --search "Z3-Python"` empty).

`See #4788` (partial — Z3-Python tranche).

## Note on collision discipline

This tranche was chosen in my clearly-non-contested Python-SMT lane during an active **double-session po-2025** (a parallel session authored #4789 on Probas). I claimed explicitly on the dashboard before coding and re-checked `gh pr list` before push to avoid a duplicate (I already closed my own #4790 as a dup of #4789 this cycle — flagged the double-session to ai-01 for deconfliction).