### PR TITLE
feat(hashlife): toGrid_shift_between — offset-to-offset toGrid translation (P4.4 offset-matching, sorry 4->4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1045,6 +1045,30 @@ theorem mem_toGrid_shift {c : MacroCell} {r0 c0 : Int} {p : Int × Int} :
   rw [mem_toGrid, mem_toGrid]
   exact mem_toCellsAux_shift
 
+/-- **Offset-to-offset translation for `toGrid` membership** (P4.4 offset-matching
+    ingredient). Membership of `p` in `c.toGrid (a, b)` is equivalent to
+    membership of the point translated by `(a'-a, b'-b)` in `c.toGrid (a', b')` —
+    i.e. re-anchoring the same cell's grid at a different origin.
+
+    This is the double-shift ingredient the P4.4 offset-matching assembly needs:
+    after `mem_toGrid_node` decomposes the result node, each quadrant sits at its
+    own offset (e.g. NW at `(2^k, 2^k)`), but `centralCorrect_mem` (G2)
+    characterizes the quadrant at offset `(2^(k-1), 2^(k-1))` (its `2^j` centering
+    with `j = k-1`). `toGrid_shift_between` bridges those two offsets directly,
+    without re-centering through `(0,0)` twice. -/
+theorem toGrid_shift_between {c : MacroCell} {a b a' b' : Int} {p : Int × Int} :
+    p ∈ c.toGrid (a, b) ↔ (p.1 - a + a', p.2 - b + b') ∈ c.toGrid (a', b') := by
+  rw [mem_toGrid_shift]
+  constructor
+  · intro h
+    rw [mem_toGrid_shift]
+    have he : (p.1 - a + a' - a', p.2 - b + b' - b') = (p.1 - a, p.2 - b) := by ext <;> ring
+    rw [he]; exact h
+  · intro h
+    rw [mem_toGrid_shift] at h
+    have he : (p.1 - a, p.2 - b) = (p.1 - a + a' - a', p.2 - b + b' - b') := by ext <;> ring
+    rw [he]; exact h
+
 /-- **G3 infrastructure (toGrid node-decomposition).** Membership in a `node`
     cell's grid decomposes into membership in the four children's grids, with
     the standard quadtree offset shifts (row increases downward, column


### PR DESCRIPTION
feat(hashlife): toGrid_shift_between — offset-to-offset toGrid translation (P4.4 offset-matching, sorry 4->4)

New sorry-free lemma `toGrid_shift_between` (after `mem_toGrid_shift`):
  p ∈ c.toGrid (a, b) ↔ (p.1 - a + a', p.2 - b + b') ∈ c.toGrid (a', b')
Proof: re-anchor via mem_toGrid_shift in both directions (point equalities by ring).

WHY THIS MATTERS (P4.4 offset-matching, lane #3846):
After mem_toGrid_node (PR #4736) decomposes the result node, each quadrant sits
at its own offset (NW at (2^k, 2^k), NE at (2^k, 2^(k+1)), …). But centralCorrect_mem
(G2, PR #4583) characterizes each quadrant at its 2^j centering — offset
(2^(k-1), 2^(k-1)) with j = k-1. toGrid_shift_between bridges those two offsets
DIRECTLY, re-anchoring the same cell's grid from (a,b) to (a',b') without
re-centering through (0,0) twice. It is the double-shift ingredient the
offset-matching assembly consumes to connect the LHS quadrant memberships to the
centralCorrect_mem characterizations.

This cycle (c.158) also diagnosed that `out_*.level = k` CANNOT be stated as a
theorem (the nested-hRA `(hRA (k+1) (node (hRA (k+1) n1) …)).level` whnf-diverges
at SIGNATURE elaboration — the c.142 pathology at the type level, not the body).
The viable offset-matching path is therefore centralCorrect_mem + shift algebra
(this lemma), NOT rewriting offsets via `out_*.level`. Diagnostic recorded in the
lane memory to spare future cycles the same dead-end.

WHY SORRY-STABLE (4->4):
Pure addition (+24 lines), no existing proof touched. Proven by `rw` + `ring`
(point equalities) — no `sorryAx`. Gate grain for the offset-matching assembly.

Verification (lean-merge-discipline section 1):
- lake build Conway.Life.HashlifeCorrectness: EXIT 0 (Mathlib junction
  54f98fd6 rc2, lake.exe Windows-side, 3320 jobs).
- sorry token grep (exclude .lake): 4 pre -> 4 post (pure addition).
- No prover Python refactor.

Branched fresh off main. Insertion at ~L1048 (after `mem_toGrid_shift`).

See #3846

Co-Authored-By: Claude-Code <noreply@anthropic.com>
