### PR TITLE
fix(ml): repair %26-encoded dangling links in ML.Net navigation

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# ML-1 : Introduction au Machine Learning avec ML.NET\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [Suivant >>](ML-2-Data%26Features.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [Suivant >>](ML-2-Data&Features.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -798,7 +798,7 @@
     "\n",
     "## Module suivant\n",
     "\n",
-    "[Module Suivant - Préparation des Données et Ingénierie des Caractéristiques](ML-2-Data%26Features.ipynb)"
+    "[Module Suivant - Préparation des Données et Ingénierie des Caractéristiques](ML-2-Data&Features.ipynb)"
    ]
   },
   {
@@ -1221,7 +1221,7 @@
     "- L'algorithme SDCA (Stochastic Dual Coordinate Ascent, Shalev-Shwartz & Zhang, 2013) est adapté aux problèmes de régression linéaire\n",
     "- Le coefficient R² mesure la qualité de l'ajustement (1.0 = parfait)\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [Suivant >> ML-2 Data & Features](ML-2-Data%26Features.ipynb)"
+    "**Navigation** : [Index](README.md) | [Suivant >> ML-2 Data & Features](ML-2-Data&Features.ipynb)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# ML-2 : Préparation des données et ingénierie des features\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< ML-1](ML-1-Introduction.ipynb) | [Suivant >>](ML-3-Entrainement%26AutoML.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< ML-1](ML-1-Introduction.ipynb) | [Suivant >>](ML-3-Entrainement&AutoML.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -1295,7 +1295,7 @@
     "- L'encodage one-hot est indispensable pour les colonnes catégorielles\n",
     "- La concaténation des features prépare les données pour l'entraînement\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< ML-1 Introduction](ML-1-Introduction.ipynb) | [Suivant >> ML-3 Entrainement&AutoML](ML-3-Entrainement%26AutoML.ipynb)"
+    "**Navigation** : [Index](README.md) | [<< ML-1 Introduction](ML-1-Introduction.ipynb) | [Suivant >> ML-3 Entrainement&AutoML](ML-3-Entrainement&AutoML.ipynb)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# ML-3 : Entraînement et AutoML\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< ML-2](ML-2-Data%26Features.ipynb) | [Suivant >>](ML-4-Evaluation.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< ML-2](ML-2-Data&Features.ipynb) | [Suivant >>](ML-4-Evaluation.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -1435,7 +1435,7 @@
     "- AutoML simplifie la HPO en explorant automatiquement les configurations possibles\n",
     "- Un bon modèle minimise la perte à la fois sur le train set et le test set\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< ML-2 Data&Features](ML-2-Data%26Features.ipynb) | [Suivant >> ML-4 Evaluation](ML-4-Evaluation.ipynb)"
+    "**Navigation** : [Index](README.md) | [<< ML-2 Data&Features](ML-2-Data&Features.ipynb) | [Suivant >> ML-4 Evaluation](ML-4-Evaluation.ipynb)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# ML-4 : Evaluation des modèles\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< ML-3 Entrainement&AutoML](ML-3-Entrainement%26AutoML.ipynb) | [Suivant >> ML-5 TimeSeries](ML-5-TimeSeries.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< ML-3 Entrainement&AutoML](ML-3-Entrainement&AutoML.ipynb) | [Suivant >> ML-5 TimeSeries](ML-5-TimeSeries.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -2186,7 +2186,7 @@
     "- PFI et FCC permettent de comprendre quelles features influencent les prédictions\n",
     "- R² proche de 1.0 indique un bon ajustement, mais surveiller aussi le surapprentissage\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< ML-3 Entrainement&AutoML](ML-3-Entrainement%26AutoML.ipynb) | [Suivant >> ML-5 TimeSeries](ML-5-TimeSeries.ipynb)"
+    "**Navigation** : [Index](README.md) | [<< ML-3 Entrainement&AutoML](ML-3-Entrainement&AutoML.ipynb) | [Suivant >> ML-5 TimeSeries](ML-5-TimeSeries.ipynb)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
@@ -396,7 +396,7 @@
    "id": "ml8-md-12",
    "metadata": {},
    "source": [
-    "On charge la liste dans un [IDataView](https://learn.microsoft.com/dotnet/api/microsoft.ml.idataview) — la structure colonnaire fondamentale de ML.NET, deja utilisee dans [ML-1](ML-1-Introduction.ipynb) et [ML-2](ML-2-Data%26Features.ipynb)."
+    "On charge la liste dans un [IDataView](https://learn.microsoft.com/dotnet/api/microsoft.ml.idataview) — la structure colonnaire fondamentale de ML.NET, deja utilisee dans [ML-1](ML-1-Introduction.ipynb) et [ML-2](ML-2-Data&Features.ipynb)."
    ]
   },
   {
@@ -434,7 +434,7 @@
     "\n",
     "Le pipeline comporte **trois** etapes. La concatenation regroupe les trois features en un vecteur `\"Features\"`. La **normalisation MinMax** ramene chaque feature dans `[0, 1]`. Le trainer **K-Means** partitionne ensuite l'espace normalise en `numberOfClusters: 3` groupes.\n",
     "\n",
-    "**Pourquoi normaliser absolument ?** K-Means mesure la proximite par **distance euclidienne**. Sans normalisation, `Monetary` (50 a 500 EUR) ecrase totalement `Frequency` (2 a 20) et `Recency` (8 a 85 jours) : la distance serait dominee par la depense, et le clustering reflete surtout l'argent. Normaliser met les trois dimensions a la meme echelle — c'est l'objet de l'[Exercice 3](#Exercice-3-:-Effet-de-la-normalisation). C'est l'equivalent, en non-supervise, de l'ingenierie de features vue en [ML-2](ML-2-Data%26Features.ipynb)."
+    "**Pourquoi normaliser absolument ?** K-Means mesure la proximite par **distance euclidienne**. Sans normalisation, `Monetary` (50 a 500 EUR) ecrase totalement `Frequency` (2 a 20) et `Recency` (8 a 85 jours) : la distance serait dominee par la depense, et le clustering reflete surtout l'argent. Normaliser met les trois dimensions a la meme echelle — c'est l'objet de l'[Exercice 3](#Exercice-3-:-Effet-de-la-normalisation). C'est l'equivalent, en non-supervise, de l'ingenierie de features vue en [ML-2](ML-2-Data&Features.ipynb)."
    ]
   },
   {


### PR DESCRIPTION
## Scope

Tranche **ML.Net** du sweep #4788 (dangling cross-notebook links invisibles à `check_docs_links.py`, qui ne scanne que les `.md`).

11 liens de navigation dans 5 notebooks ML.Net URL-encodaient le `&` des noms de fichiers en `%26`, alors que les fichiers réels utilisent un `&` littéral → liens 404 sous rendu markdown standard.

## Root cause

Les noms de fichiers contiennent un `&` : `ML-2-Data&Features.ipynb`, `ML-3-Entrainement&AutoML.ipynb`. Les liens markdown les encodaient à tort `%26` (encodage URL de query-string, inadapté aux chemins de fichiers locaux).

## Changes

| Notebook | Cell | Lien corrigé |
|----------|------|--------------|
| ML-1-Introduction | 0, 25, 38 | `ML-2-Data%26Features` → `ML-2-Data&Features` |
| ML-2-Data&Features | 0, 26 | `ML-3-Entrainement%26AutoML` → `ML-3-Entrainement&AutoML` |
| ML-3-Entrainement&AutoML | 0, 18 | `ML-2-Data%26Features` → `ML-2-Data&Features` |
| ML-4-Evaluation | 0, 76 | `ML-3-Entrainement%26AutoML` → `ML-3-Entrainement&AutoML` |
| ML-8-Clustering | 11, 13 | `ML-2-Data%26Features` → `ML-2-Data&Features` |

Fix = `%26` → `&` dans la **target parenthèse uniquement** (labels de liens et prose intacts).

## Validation

- **Cibles EXISTENT** sur disque : `ls MyIA.AI.Notebooks/ML/ML.Net/` confirme `ML-2-Data&Features.ipynb` et `ML-3-Entrainement&AutoML.ipynb`.
- **Diff** : 5 fichiers, `+11/-11`, **path-fix only** (labels/prose intacts, eyeball confirmé).
- **Re-scan résiduel** : 0 lien `%26` restant dans ML.Net.
- **Markdown-only** (C.2 exempt) : aucune cellule code, aucun output, aucun `execution_count` touché.
- **JSON valide** : `json.loads` OK sur les 5 fichiers après édition (raw-text replace, tous caractères JSON-safe → byte-faithful, indent préservée).
- **Anti-regression** : 0 contenu supprimé, 0 cellule Solution/Exemple touchée.
- **CATALOG** : non touché (byte-identical).

## Non-scope

Cluster DataScienceWithAgents (labs `../../DayX/` double-segment, 15+ nav) laissé intact — po-2025 l'a signalé risqué (labs étudiants en réorg, structure cible incertaine). Tranche ML.Net = suite .NET distincte, pattern `%26` mécanique et sûr.

See #4788
