### PR TITLE
fix(sudoku,gt): repair 4 dangling cross-pointers in Lean companion notebooks (See #4788)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-5b-Lean-Minimax.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-5b-Lean-Minimax.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# GameTheory-5b — Théorème minimax de von Neumann (companion formel natif)\n",
     "\n",
-    "Ce notebook est le **companion formel** du lake [`minimax_lean`](../minimax_lean/),\n",
+    "Ce notebook est le **companion formel** du lake [`minimax_lean`](minimax_lean/),\n",
     "dont la lib `Minimax` prouve le **théorème minimax de von Neumann** (1928) pour les\n",
     "jeux finis à somme nulle — via le **minimax de Sion** (Mathlib `Topology.Sion`) — avec\n",
     "**zéro `sorry`**.\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "# Comparaison des Solveurs de Sudoku\n",
     "\n",
-    "Voir aussi : [Search Foundations](../Search/Foundations/) pour les algorithmes sous-jacents\n",
+    "Voir aussi : [Search Foundations](../Search/Part1-Foundations/) pour les algorithmes sous-jacents\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -2836,12 +2836,13 @@
     "---\n",
     "\n",
     "**Voir aussi** :\n",
-    "- [Search Foundations](../Search/Foundations/) - Fondamentaux des algorithmes utilisés\n",
+    "- [Search Foundations](../Search/Part1-Foundations/) - Fondamentaux des algorithmes utilisés\n",
     "- [Search Applications](../Search/Applications/) - Applications des mêmes algorithmes\n",
     "\n",
     "---\n",
     "\n",
-    "**Retour au sommaire** : [Index Sudoku](README.md)\n"
+    "**Retour au sommaire** : [Index Sudoku](README.md)\n",
+    ""
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7b-Lean-Propagation.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7b-Lean-Propagation.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Sudoku-7b — Soundness de la propagation de contraintes (companion formel natif)\n",
     "\n",
-    "Ce notebook est le **companion formel** du lake [`sudoku_lean`](../sudoku_lean/),\n",
+    "Ce notebook est le **companion formel** du lake [`sudoku_lean`](sudoku_lean/),\n",
     "dont la lib `Sudoku` prouve la **soundness des règles de propagation** d'un Sudoku\n",
     "(*naked single*, *hidden single*) : ces règles, utilisées par tous les solveurs\n",
     "(backtracking, OR-Tools, .NET), **ne retirent aucune solution valide** — elles\n",


### PR DESCRIPTION
## Sudoku + GameTheory tranche of #4788

Cross-famille dangling-link sweep (see memory `dangling-notebook-link-sweep-method`). This tranche covers **Sudoku + GameTheory** Lean companion notebooks.

Claimed per-famille per ai-01 decision `a3evi0` (claim PAR FAMILLE on multi-famille sweeps, else two workers double-fix).

### 3 path-fixes (4 link occurrences)

| Notebook | Cell | Fix | Class |
|----------|------|-----|-------|
| Sudoku-7b-Lean-Propagation | c0 | `../sudoku_lean/` -> `sudoku_lean/` | B (one `../` too many) |
| GameTheory-5b-Lean-Minimax | c0 | `../minimax_lean/` -> `minimax_lean/` | B |
| Sudoku-18-Comparison-Python | c0 + c65 | `../Search/Foundations/` -> `../Search/Part1-Foundations/` | A (rename residual) |

All targets verified to **EXIST** firsthand on fresh `origin/main` (`bda9f054c`):
- `Sudoku/sudoku_lean/` (Lean lake)
- `GameTheory/minimax_lean/` (Lean lake)
- `Search/Part1-Foundations/` (renamed from `Foundations/`)

### Deferred (ambiguous targets, out of this tranche)

- **GameTheory-16 c39** `social_choice_lean/MechanismDesign.lean` -> only `SocialChoice.lean` exists in `social_choice_lean/`; `MechanismDesign.lean` module not created. This is a forward-reference to a not-yet-written Lean module = content decision, not a path-fix.

### Why not the ML tranche (transparency G.9)

YIELDED the ML family: 25 dangling found, but ~13 are class D (student-lab double-seg `../../DayX/`, scope-large per `dangling-notebook-link-sweep-method`) and the remaining 12 have %26 URL-encoding FP risk + uncertain localization. Forcing = risk of regressing a functional link. ML is not a clean worker grain.

### Validation (guards)

- 4/4 replacements count-verified (1 + 1 + 2)
- 0 residual repo-wide (`git grep ../sudoku_lean|../minimax_lean|../Search/Foundations/` in Sudoku/GT)
- 3/3 JSON valid (`json.load`)
- `check_docs_links.py --check`: 0 broken (3056 total), no new broken
- Catalog byte-identical to `origin/main`
- Markdown-only (C.2-exempt, no re-exec required)

See #4788 (partial tranche — epic stays open).