### PR TITLE
feat(tweety): C#/.NET semantics notebook — possible worlds + entailment (#4667)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2b-Semantics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2b-Semantics-Csharp.ipynb
@@ -1,0 +1,1084 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "m63273",
+   "metadata": {},
+   "source": [
+    "# Tweety C# / IKVM - Semantique propositionnelle : mondes possibles et raisonnement\n",
+    "\n",
+    "**Navigation** : [<- Tweety-2-Basic-Logics](Tweety-2-Basic-Logics-Csharp.ipynb) | [Index serie](Tweety-1-Setup.ipynb) | [Tweety-3-Advanced-Logics ->](Tweety-3-Advanced-Logics.ipynb)\n",
+    "\n",
+    "> Ce notebook est le **second volet C# / .NET** de la serie Tweety. Il poursuit\n",
+    "> [Tweety-2-Basic-Logics-Csharp](Tweety-2-Basic-Logics-Csharp.ipynb) (construction de formules, parsing, base\n",
+    "> de croyances) en abordant la **semantique** : mondes possibles, satisfaction, et raisonnement\n",
+    "> (entaînement). Comme le pilote, il execute les classes Tweety **recompilees en bytecode .NET via\n",
+    "> IKVM** - aucune JVM au runtime. Voir [le notebook Python](Tweety-2-Basic-Logics.ipynb) pour le contexte theorique complet.\n",
+    "\n",
+    "## Objectifs pedagogiques\n",
+    "\n",
+    "1. Construire une **signature** propositionnelle (`PlSignature`) et enumerer ses **mondes possibles** (`PossibleWorldIterator`)\n",
+    "2. Tester la **satisfaction** d'une formule par un monde (`PossibleWorld.satisfies`)\n",
+    "3. Effectuer du **raisonnement** : une base de croyances entaîne-t-elle une formule ? (`SatReasoner.query`)\n",
+    "4. Relier l'approche semantique (enumeration des modeles) et l'approche syntaxique (solveur SAT)\n",
+    "\n",
+    "## Prerequis\n",
+    "\n",
+    "- [Tweety-2-Basic-Logics-Csharp](Tweety-2-Basic-Logics-Csharp.ipynb) (construction de formules, `PlBeliefSet`, `PlParser`)\n",
+    "- Notions de logique propositionnelle : valuation, modele, consequence logique\n",
+    "\n",
+    "> **Rappel d'API (C# / IKVM)** : les classes Java Tweety sont exposees via IKVM avec la convention\n",
+    "> Java minuscule (`.add()`, `.size()`, `.hasNext()`...). Le `PlParser.parseFormula()` retourne le type\n",
+    "> de base `commons.Formula` ; on le **cast en `PlFormula`** pour les methodes semantiques.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m51083",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration du runtime IKVM\n",
+    "\n",
+    "> Identique au [pilote](Tweety-2-Basic-Logics-Csharp.ipynb) : on restaure les paquets NuGet IKVM, on\n",
+    "> assemble le home IKVM (motrice d'execution de la JVM en .NET), puis on charge la DLL Tweety. A executer\n",
+    "> en premier. ~30-60 s la premiere fois.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c390571",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:22.742087Z",
+     "iopub.status.busy": "2026-07-01T21:49:22.724404Z",
+     "iopub.status.idle": "2026-07-01T21:49:25.131647Z",
+     "shell.execute_reply": "2026-07-01T21:49:25.117554Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-104088.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '104088.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>IKVM, 8.15.0</span></li><li><span>IKVM.Image, 8.15.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: IKVM, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image.runtime.win-x64, 8.15.0\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c317339",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:25.137839Z",
+     "iopub.status.busy": "2026-07-01T21:49:25.137222Z",
+     "iopub.status.idle": "2026-07-01T21:49:28.535193Z",
+     "shell.execute_reply": "2026-07-01T21:49:28.534086Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.IO;\n",
+    "string ikvmVer = \"8.15.0\", ikvmRid = \"win-x64\";\n",
+    "string nugetRoot = Environment.GetEnvironmentVariable(\"NUGET_PACKAGES\")\n",
+    "    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \".nuget\", \"packages\");\n",
+    "string ikvmBaseAny = Path.Combine(nugetRoot, \"ikvm.image\", ikvmVer, \"ikvm\", \"any\", \"any\");\n",
+    "string ikvmArchDir = Path.Combine(nugetRoot, \"ikvm.image.runtime.\" + ikvmRid, ikvmVer, \"ikvm\", \"any\", ikvmRid);\n",
+    "string ikvmHome    = Path.Combine(Path.GetTempPath(), \"ikvm-home-\" + ikvmVer + \"-\" + ikvmRid);\n",
+    "\n",
+    "void IkvmCopyMerge(string src, string dst)\n",
+    "{\n",
+    "    foreach (var d in Directory.GetDirectories(src, \"*\", SearchOption.AllDirectories))\n",
+    "        Directory.CreateDirectory(d.Replace(src, dst));\n",
+    "    foreach (var f in Directory.GetFiles(src, \"*\", SearchOption.AllDirectories))\n",
+    "    {\n",
+    "        var t = f.Replace(src, dst);\n",
+    "        Directory.CreateDirectory(Path.GetDirectoryName(t));\n",
+    "        File.Copy(f, t, overwrite: true);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "if (Directory.Exists(ikvmBaseAny) && Directory.Exists(ikvmArchDir))\n",
+    "{\n",
+    "    Directory.CreateDirectory(ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmBaseAny, ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmArchDir, ikvmHome);\n",
+    "}\n",
+    "AppContext.SetData(\"IKVM.Home\", ikvmHome);\n",
+    "\n",
+    "bool tzdbOk = File.Exists(Path.Combine(ikvmHome, \"lib\", \"tzdb.dat\"));\n",
+    "Console.WriteLine($\"IKVM 8.15.0 pret (home=ikvm-home-{ikvmVer}-{ikvmRid}, tzdb={tzdbOk})\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c603247",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:28.538538Z",
+     "iopub.status.busy": "2026-07-01T21:49:28.537889Z",
+     "iopub.status.idle": "2026-07-01T21:49:28.650028Z",
+     "shell.execute_reply": "2026-07-01T21:49:28.649463Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#r \"org.tweetyproject.tweety-pl.dll\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22726",
+   "metadata": {},
+   "source": [
+    "## 2. Signature et mondes possibles\n",
+    "\n",
+    "Une **signature** propositionnelle (`PlSignature`) est l'ensemble des atomes (propositions)\n",
+    "du langage. Pour *n* atomes, il existe **2^n mondes possibles** (valuations) : chaque atome\n",
+    "peut etre vrai ou faux. Un **monde possible** (`PossibleWorld`) est l'ensemble des atomes\n",
+    "consideres comme **vrais** (les autres etant faux par complement).\n",
+    "\n",
+    "Le `PossibleWorldIterator` enumerera automatiquement tous les mondes d'une signature.\n",
+    "\n",
+    "> Exemple : signature `{a, b}` -> 4 mondes : `[]` (aucun), `[a]`, `[b]`, `[a, b]`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c418284",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:28.653592Z",
+     "iopub.status.busy": "2026-07-01T21:49:28.652924Z",
+     "iopub.status.idle": "2026-07-01T21:49:30.141391Z",
+     "shell.execute_reply": "2026-07-01T21:49:30.140517Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Signature : [a, b]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mondes possibles :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  monde 0 = []\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  monde 1 = [a]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  monde 2 = [b]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  monde 3 = [a, b]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> 4 mondes pour 2 atomes (2^2 = 4).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.semantics;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "\n",
+    "var p = new PlParser();\n",
+    "var sig = new PlSignature();\n",
+    "sig.add(p.parseFormula(\"a\"));\n",
+    "sig.add(p.parseFormula(\"b\"));\n",
+    "\n",
+    "Console.WriteLine($\"Signature : {sig}\");\n",
+    "\n",
+    "Console.WriteLine(\"Mondes possibles :\");\n",
+    "int n = 0;\n",
+    "var it = new PossibleWorldIterator(sig);\n",
+    "while (it.hasNext())\n",
+    "{\n",
+    "    var world = (PossibleWorld) it.next();\n",
+    "    Console.WriteLine($\"  monde {n} = {world}\");\n",
+    "    n++;\n",
+    "}\n",
+    "Console.WriteLine($\"=> {n} mondes pour 2 atomes (2^2 = 4).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m33502",
+   "metadata": {},
+   "source": [
+    "### Interpretation : mondes possibles et semantique\n",
+    "\n",
+    "Chaque monde correspond a une **interpretation** (valuation de verite) : `{a}` signifie\n",
+    "*a est vrai, b est faux*. Le monde vide `[]` = tous les atomes faux. L'iteration couvre\n",
+    "exhaustivement les **2^n cas** de la table de verite. Cette enumeration est la base de la\n",
+    "**semantique de Tarski** : une formule est vraie dans un monde si sa valuation la satisfait.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m66831",
+   "metadata": {},
+   "source": [
+    "## 3. Satisfaction : un monde est-il modele d'une formule ?\n",
+    "\n",
+    "La methode **`PossibleWorld.satisfies(PlFormula)`** repond : ce monde rend-il la formule\n",
+    "vraie ? Une formule est **satisfiable** s'il existe au moins un monde qui la satisfait ; elle\n",
+    "est une **tautologie** si *tous* les mondes la satisfont ; elle est une **contradiction** si\n",
+    "aucun monde ne la satisfait.\n",
+    "\n",
+    "> On construit un monde en lui ajoutant des `Proposition` (les atomes vrais), puis on teste\n",
+    "> la satisfaction. Notez le **cast `(PlFormula)`** : `parseFormula` retourne le type generique\n",
+    "> `Formula`, que les methodes semantiques precisent en `PlFormula`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c338411",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:30.145626Z",
+     "iopub.status.busy": "2026-07-01T21:49:30.144760Z",
+     "iopub.status.idle": "2026-07-01T21:49:30.542639Z",
+     "shell.execute_reply": "2026-07-01T21:49:30.542098Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Monde w = [a]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  w satisfait a      = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  w satisfait b      = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  w satisfait a && b = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  w satisfait a || b = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  w satisfait a => b = False\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.semantics;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "\n",
+    "var p = new PlParser();\n",
+    "\n",
+    "// Un monde ou a=vrai, b=faux\n",
+    "var w = new PossibleWorld();\n",
+    "w.add(new Proposition(\"a\"));\n",
+    "Console.WriteLine($\"Monde w = {w}\");\n",
+    "\n",
+    "var fa   = (PlFormula) p.parseFormula(\"a\");\n",
+    "var fb   = (PlFormula) p.parseFormula(\"b\");\n",
+    "var fAND = (PlFormula) p.parseFormula(\"a && b\");\n",
+    "var fOR  = (PlFormula) p.parseFormula(\"a || b\");\n",
+    "var fIMP = (PlFormula) p.parseFormula(\"a => b\");\n",
+    "\n",
+    "Console.WriteLine($\"  w satisfait a      = {w.satisfies(fa)}\");   // vrai  (a dans w)\n",
+    "Console.WriteLine($\"  w satisfait b      = {w.satisfies(fb)}\");   // faux  (b absent)\n",
+    "Console.WriteLine($\"  w satisfait a && b = {w.satisfies(fAND)}\"); // faux  (b absent)\n",
+    "Console.WriteLine($\"  w satisfait a || b = {w.satisfies(fOR)}\");  // vrai  (a vrai)\n",
+    "Console.WriteLine($\"  w satisfait a => b = {w.satisfies(fIMP)}\"); // faux  (a vrai, b faux)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m5545",
+   "metadata": {},
+   "source": [
+    "### Representation canonique d'un monde\n",
+    "\n",
+    "La methode **`getCompleteConjunction(PlSignature)`** produit la conjonction complete\n",
+    "representant un monde dans une signature donnee (un litteral positif par atome vrai, negatif\n",
+    "par atome faux). C'est la **forme normale disjonctive** canonique d'une valuation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c77422",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:30.545835Z",
+     "iopub.status.busy": "2026-07-01T21:49:30.545232Z",
+     "iopub.status.idle": "2026-07-01T21:49:30.771288Z",
+     "shell.execute_reply": "2026-07-01T21:49:30.770433Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Monde = [a, c]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conjonction complete dans {a,b,c} = a&&c&&!b\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.semantics;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "\n",
+    "var p = new PlParser();\n",
+    "var sig = new PlSignature();\n",
+    "sig.add(p.parseFormula(\"a\"));\n",
+    "sig.add(p.parseFormula(\"b\"));\n",
+    "sig.add(p.parseFormula(\"c\"));\n",
+    "\n",
+    "// Monde {a, c} dans la signature {a, b, c}\n",
+    "var w = new PossibleWorld();\n",
+    "w.add(new Proposition(\"a\"));\n",
+    "w.add(new Proposition(\"c\"));\n",
+    "Console.WriteLine($\"Monde = {w}\");\n",
+    "Console.WriteLine($\"Conjonction complete dans {{a,b,c}} = {w.getCompleteConjunction(sig)}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m88739",
+   "metadata": {},
+   "source": [
+    "## 4. Raisonnement : consequence logique (entaînement)\n",
+    "\n",
+    "Enumerer les mondes est exact mais couteux (2^n). Pour le **raisonnement** - une base de\n",
+    "croyances `KB` entaîne-t-elle une formule `phi` (note `KB |= phi`) ? - on delegue a un\n",
+    "**solveur SAT** interne (Sat4j) via **`SatReasoner.query(PlBeliefSet, PlFormula)`**.\n",
+    "\n",
+    "**Principe** : `KB |= phi` ssi il n'existe aucun modele de KB qui falsifie `phi`. Le solveur\n",
+    "verifie cela sans enumerer exhaustivement. La methode retourne un booleen.\n",
+    "\n",
+    "> Exemple : avec `KB = { a, a => b }`, on a `KB |= b` (modus ponens) mais `KB |= c` est faux.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c374005",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:30.774688Z",
+     "iopub.status.busy": "2026-07-01T21:49:30.774084Z",
+     "iopub.status.idle": "2026-07-01T21:49:31.619683Z",
+     "shell.execute_reply": "2026-07-01T21:49:31.618696Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB = { (a=>b), a }\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= b    ? true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= c    ? false\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= a||c ? true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= !a   ? false\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.reasoner;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "\n",
+    "var p = new PlParser();\n",
+    "var kb = new PlBeliefSet();\n",
+    "kb.add(p.parseFormula(\"a\"));\n",
+    "kb.add(p.parseFormula(\"a => b\"));\n",
+    "Console.WriteLine($\"KB = {kb}\");\n",
+    "\n",
+    "var r = new SatReasoner();\n",
+    "Console.WriteLine($\"KB |= b    ? {r.query(kb, (PlFormula)p.parseFormula(\"b\"))}\");      // vrai  : modus ponens\n",
+    "Console.WriteLine($\"KB |= c    ? {r.query(kb, (PlFormula)p.parseFormula(\"c\"))}\");      // faux  : c non derive\n",
+    "Console.WriteLine($\"KB |= a||c ? {r.query(kb, (PlFormula)p.parseFormula(\"a || c\"))}\"); // vrai  : a vrai => disjonction\n",
+    "Console.WriteLine($\"KB |= !a   ? {r.query(kb, (PlFormula)p.parseFormula(\"!a\"))}\");     // faux  : KB contient a\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m72867",
+   "metadata": {},
+   "source": [
+    "### Interpretation : les deux faces de la verite\n",
+    "\n",
+    "Deux approches equivalentes pour `KB |= phi` :\n",
+    "- **Semantique** (enumerateur) : parcourir tous les modeles de KB et verifier que chacun satisfait `phi`.\n",
+    "- **Syntaxique** (solveur SAT) : tester la (in)satisfiabilite de `KB et non phi` - s'il n'y a pas de modele,\n",
+    "  alors `phi` est consequence.\n",
+    "\n",
+    "Le `SatReasoner` emploie la seconde (DPLL/CDCL via Sat4j), bien plus efficace que l'enumeration\n",
+    "des 2^n mondes des que *n* grandit. C'est le coeur des moteurs modernes de raisonnement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m64411",
+   "metadata": {},
+   "source": [
+    "## Exemple guide : modeles d'une base de croyances\n",
+    "\n",
+    "Croisons les deux approches : trouvons **les mondes qui satisfont toute la KB** (ses modeles).\n",
+    "Un monde est modele de KB s'il satisfait chaque formule. `PossibleWorld.satisfies` accepte\n",
+    "directement un `PlBeliefSet`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c629890",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:31.623707Z",
+     "iopub.status.busy": "2026-07-01T21:49:31.623039Z",
+     "iopub.status.idle": "2026-07-01T21:49:31.903910Z",
+     "shell.execute_reply": "2026-07-01T21:49:31.902921Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB = { (a=>b), (b=>c) }\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modeles de KB :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  []  -> conjonction complete : !a&&!b&&!c\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [c]  -> conjonction complete : c&&!a&&!b\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [b, c]  -> conjonction complete : b&&c&&!a\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [a, b, c]  -> conjonction complete : a&&b&&c\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> 4 modele(s) sur 8.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.semantics;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "\n",
+    "var p = new PlParser();\n",
+    "var kb = new PlBeliefSet();\n",
+    "kb.add(p.parseFormula(\"a => b\"));   // si a alors b\n",
+    "kb.add(p.parseFormula(\"b => c\"));   // si b alors c\n",
+    "Console.WriteLine($\"KB = {kb}\");\n",
+    "\n",
+    "// Signature {a, b, c} -> 8 mondes ; on filtre ceux qui sont modeles de KB\n",
+    "var sig = new PlSignature();\n",
+    "sig.add(p.parseFormula(\"a\"));\n",
+    "sig.add(p.parseFormula(\"b\"));\n",
+    "sig.add(p.parseFormula(\"c\"));\n",
+    "\n",
+    "Console.WriteLine(\"Modeles de KB :\");\n",
+    "int models = 0;\n",
+    "var it = new PossibleWorldIterator(sig);\n",
+    "while (it.hasNext())\n",
+    "{\n",
+    "    var world = (PossibleWorld) it.next();\n",
+    "    if (world.satisfies(kb))\n",
+    "    {\n",
+    "        Console.WriteLine($\"  {world}  -> conjonction complete : {world.getCompleteConjunction(sig)}\");\n",
+    "        models++;\n",
+    "    }\n",
+    "}\n",
+    "Console.WriteLine($\"=> {models} modele(s) sur 8.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m96153",
+   "metadata": {},
+   "source": [
+    "### Interpretation\n",
+    "\n",
+    "KB impose `c` des que `a` est vrai (chainage `a => b => c`). Les modeles respectent donc\n",
+    "l'ordre : si `a` est present, `b` et `c` doivent l'etre aussi. Verifiez sur la liste : aucun\n",
+    "monde ne contient `a` sans `b`, ni `b` sans `c`. C'est exactement la **fermeture transitive**\n",
+    "des implications, vue semantiquement.\n",
+    "\n",
+    "> On retrouve ici le lien profond : la consequence logique `KB |= phi` equivaut a dire que\n",
+    "> `phi` est vraie dans **tous** les modeles de KB - c'est le **theorem de Tarski**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m34593",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook complete le pilote [Tweety-2-Basic-Logics-Csharp](Tweety-2-Basic-Logics-Csharp.ipynb)\n",
+    "avec la **semantique** de la logique propositionnelle en .NET natif :\n",
+    "\n",
+    "| Concept | Classe Tweety (C#) | Methode | Statut |\n",
+    "|---------|-------------------|---------|--------|\n",
+    "| Signature | `PlSignature` | `.add()` | OK |\n",
+    "| Monde possible | `PossibleWorld` | `.add(Proposition)`, `.satisfies()` | OK |\n",
+    "| Enumeration des mondes | `PossibleWorldIterator` | `.hasNext()`, `.next()` | OK |\n",
+    "| Conjonction complete | `PossibleWorld` | `.getCompleteConjunction(sig)` | OK |\n",
+    "| Raisonnement (entaînement) | `SatReasoner` | `.query(PlBeliefSet, PlFormula)` | OK |\n",
+    "\n",
+    "**Deux approches equivalentes** : enumeration semantique (2^n) pour la pedagogie, solveur SAT\n",
+    "(Sat4j) pour l'efficacite. Le port .NET couvre desormais la construction **et** le raisonnement\n",
+    "de la logique propositionnelle, sans JVM.\n",
+    "\n",
+    "### Limitation\n",
+    "\n",
+    "Comme le pilote, ce notebook porte uniquement le **cluster `pl`** (logique propositionnelle).\n",
+    "Les logiques avancees (Description Logic, Modale, QBF - [Tweety-3-Advanced-Logics](Tweety-3-Advanced-Logics.ipynb))\n",
+    "requierent d'autres clusters Tweety (dl, ml) non inclus dans cette DLL ; les notebooks Python restent\n",
+    "canoniques pour ces logiques, ainsi que pour l'argumentation (Dung, notebooks 5-7) et les reseaux\n",
+    "logiques markoviens (notebook 10).\n",
+    "\n",
+    "### Exercices\n",
+    "\n",
+    "Adaptez ceux du [notebook Python](Tweety-2-Basic-Logics.ipynb) a l'API C# (cast `PlFormula`, methodes\n",
+    "Java minuscules). Rappel : les stubs doivent s'executer sans erreur (jamais `raise`/`assert`/`1/0`).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m45853",
+   "metadata": {},
+   "source": [
+    "#### Exercice 1 : Tautologie, contradiction ou contingence ?\n",
+    "\n",
+    "Ecrivez une fonction qui, etant donne une formule et une signature, determine si elle est\n",
+    "**tautologie** (tous les mondes la satisfont), **contradiction** (aucun), ou **contingente**.\n",
+    "Testez sur `a || !a`, `a && !a`, et `a => b`.\n",
+    "\n",
+    "**Indice** : enumerer les mondes via `PossibleWorldIterator`, compter ceux qui satisfont la formule,\n",
+    "comparer au total `2^n`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c236170",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:31.908517Z",
+     "iopub.status.busy": "2026-07-01T21:49:31.907265Z",
+     "iopub.status.idle": "2026-07-01T21:49:32.246586Z",
+     "shell.execute_reply": "2026-07-01T21:49:32.246948Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(9,9): warning CS0219: La variable 'total' est assignée, mais sa valeur n'est jamais utilisée\r\n",
+      "\r\n",
+      "(9,20): warning CS0219: La variable 'satisfied' est assignée, mais sa valeur n'est jamais utilisée\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.semantics;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "\n",
+    "// TODO etudiant : implementer Classify(p, sig, formulaStr) -> \"tautologie\"/\"contradiction\"/\"contingente\"\n",
+    "string Classify(PlParser p, PlSignature sig, string formulaStr)\n",
+    "{\n",
+    "    var f = (PlFormula) p.parseFormula(formulaStr);\n",
+    "    int total = 0, satisfied = 0;\n",
+    "    // TODO : parcourir PossibleWorldIterator(sig), compter total et les mondes qui satisfont f\n",
+    "    return \"Exercice 1 a completer\";\n",
+    "}\n",
+    "\n",
+    "var p = new PlParser();\n",
+    "var sig = new PlSignature();\n",
+    "sig.add(p.parseFormula(\"a\"));\n",
+    "sig.add(p.parseFormula(\"b\"));\n",
+    "Console.WriteLine(Classify(p, sig, \"a || !a\"));   // attendu : tautologie\n",
+    "Console.WriteLine(Classify(p, sig, \"a && !a\"));   // attendu : contradiction\n",
+    "Console.WriteLine(Classify(p, sig, \"a => b\"));    // attendu : contingente\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m84967",
+   "metadata": {},
+   "source": [
+    "#### Exercice 2 : Equivalence logique via l'entaînement\n",
+    "\n",
+    "Deux formules `f1` et `f2` sont **logiquement equivalentes** ssi `f1 |= f2` ET `f2 |= f1`.\n",
+    "Verifiez que `a => b` est equivalent a `!a || b`, et que `!(a && b)` est equivalent a `!a || !b`\n",
+    "(loi de De Morgan).\n",
+    "\n",
+    "**Indice** : construire un `PlBeliefSet` contenant `f1`, puis `SatReasoner.query(kb, f2)` ;\n",
+    "recommencer en inversant. Equivalent ssi les deux sens sont vrais.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c417912",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:32.251976Z",
+     "iopub.status.busy": "2026-07-01T21:49:32.251290Z",
+     "iopub.status.idle": "2026-07-01T21:49:32.425843Z",
+     "shell.execute_reply": "2026-07-01T21:49:32.424037Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.reasoner;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "\n",
+    "// TODO etudiant : implementer AreEquivalent(p, f1Str, f2Str) -> bool\n",
+    "bool AreEquivalent(PlParser p, string f1Str, string f2Str)\n",
+    "{\n",
+    "    var f1 = (PlFormula) p.parseFormula(f1Str);\n",
+    "    var f2 = (PlFormula) p.parseFormula(f2Str);\n",
+    "    var r = new SatReasoner();\n",
+    "    // TODO : KB{f1} |= f2  ET  KB{f2} |= f1\n",
+    "    return false;  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "var p = new PlParser();\n",
+    "Console.WriteLine(AreEquivalent(p, \"a => b\", \"!a || b\"));        // attendu : True\n",
+    "Console.WriteLine(AreEquivalent(p, \"!(a && b)\", \"!a || !b\"));    // attendu : True (De Morgan)\n",
+    "Console.WriteLine(AreEquivalent(p, \"a => b\", \"b => a\"));         // attendu : False\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m18873",
+   "metadata": {},
+   "source": [
+    "#### Exercice 3 : Deduire une consequence cachee\n",
+    "\n",
+    "Soit la base `KB = { (a || b) => c, c => d, a }`. Quelles propositions parmi `{a, b, c, d, e}`\n",
+    "sont entaînees par KB ? Utilisez `SatReasoner.query` pour tester chaque proposition et afficher celles\n",
+    "qui sont consequences. Reflechissez ensuite : pourquoi `d` est-il entaîne alors qu'il n'apparait\n",
+    "dans aucune premisse contenant directement `a` ?\n",
+    "\n",
+    "**Indice** : `a` vrai + `(a||b)=>c` donne `c` vrai, puis `c=>d` donne `d` vrai. C'est le **chainage avant**\n",
+    "des implications - verifiez-le machinelement.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c539956",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T21:49:32.431030Z",
+     "iopub.status.busy": "2026-07-01T21:49:32.430399Z",
+     "iopub.status.idle": "2026-07-01T21:49:32.616809Z",
+     "shell.execute_reply": "2026-07-01T21:49:32.616204Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= a ? (Exercice 3 a completer)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= b ? (Exercice 3 a completer)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= c ? (Exercice 3 a completer)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= d ? (Exercice 3 a completer)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB |= e ? (Exercice 3 a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.reasoner;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "\n",
+    "var p = new PlParser();\n",
+    "var kb = new PlBeliefSet();\n",
+    "kb.add(p.parseFormula(\"(a || b) => c\"));\n",
+    "kb.add(p.parseFormula(\"c => d\"));\n",
+    "kb.add(p.parseFormula(\"a\"));\n",
+    "\n",
+    "var r = new SatReasoner();\n",
+    "foreach (var atom in new[]{ \"a\", \"b\", \"c\", \"d\", \"e\" })\n",
+    "{\n",
+    "    // TODO etudiant : tester r.query(kb, atom) et afficher \"KB |= atom : oui/non\"\n",
+    "    Console.WriteLine($\"KB |= {atom} ? (Exercice 3 a completer)\");\n",
+    "}\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Tweety C#/.NET — second volet : sémantique propositionnelle

Suite du pilote merged **#4792** (`Tweety-2-Basic-Logics-Csharp.ipynb`, construction de formules + parsing + KB). Ce notebook couvre la **sémantique** : mondes possibles, satisfaction, raisonnement (entaîlement) — port C# des sections "Mondes possibles" + "SAT4J" du notebook Python `Tweety-2-Basic-Logics.ipynb` (cell 12-20). **Tourne nativement en .NET via IKVM, aucune JVM au runtime.**

### Livrable — `Tweety-2b-Semantics-Csharp.ipynb` (25 cells, exec end-to-end 1-9, **0 erreur, outputs réels**)

API découverte **firsthand via kernel reflection probes** (G.1, pas d'invention — la sémantique était honnêtement DEFERRED dans le pilote #4792 car non testée) :

| Concept | Classe C# (IKVM) | Méthode | Testé |
|---------|------------------|---------|-------|
| Signature | `PlSignature` | `.add()` | ✓ |
| Monde possible | `PossibleWorld` | `.add(Proposition)`, `.satisfies(PlFormula)` | ✓ |
| Énumération mondes | `PossibleWorldIterator` | `.ctor(PlSignature)`, `.hasNext()`, `.next()` | ✓ (2^n) |
| Conjonction complète | `PossibleWorld` | `.getCompleteConjunction(sig)` | ✓ |
| Raisonnement | `SatReasoner` | `.query(PlBeliefSet, PlFormula)` | ✓ (Sat4j) |

**Note d'API** (découverte ce cycle, corrige mon souvenir C132) :
- `PlParser.parseFormula()` retourne le type de base `commons.Formula` → **cast `(PlFormula)`** requis pour `satisfies`/`query`.
- `SatReasoner.query(PlBeliefSet, PlFormula) → Boolean` (signature exacte). `isEquivalent` **n'existe pas** sur SatReasoner — non documenté (l'exercice 2 reconstruit l'équivalence via double `query`).

### Outputs réels vérifiés
- Mondes de `{a,b}` : `[]`, `[a]`, `[b]`, `[a,b]` (4 = 2²)
- Monde `{a}` satisfait : `a=True, b=False, a&&b=False, a||b=True, a=>b=False`
- `getCompleteConjunction` monde `{a,c}` dans `{a,b,c}` = `a&&c&&!b` (littéral négatif pour b)
- `SatReasoner.query` KB `{a, a=>b}` : `⊨b=true`, `⊨c=false`, `⊨a||c=true`, `⊨!a=false`
- Modèles de KB `{a=>b, b=>c}` : `[]`, `[c]`, `[b,c]`, `[a,b,c]` = 4/8 (fermeture transitive)

### Pédagogie
- Relie approche **sémantique** (énumération 2^n) et **syntaxique** (solveur SAT Sat4j) du `KB |= phi` (théorème de Tarski)
- **3 exercices** (convention #2161) : Classify tautologie/contradiction/contingente, équivalence logique (De Morgan), chainage avant d'implications
- Stubs C.1-conformes (s'exécutent sans erreur, TODO étudiant)

### Validation §D (notebook PR)
- **Exécution** : `nbconvert --execute --inplace`, kernel `.net-csharp`, 11/11 code cells execed (count 1-9), **0 error**
- **C.1** : `grep` source-only → **0** `raise NotImplementedError`/`assert False`/`1/0`
- **C.2** : `execution_count` + `outputs` cohérents pour chaque cellule (H.3 : 0 stale)
- **Anti-régression §D.4** : nouveau fichier (aucune cellule supprimée)
- **SOTA-OK** (Prong A) : vrai outil Tweety via IKVM, vraies sorties du solveur Sat4j — pas de workaround
- **Reproductibilité** : réutilise la DLL `org.tweetyproject.tweety-pl.dll` déjà mergée (à côté du notebook, pattern #4711) ; runtime setup identique au pilote

`See #4667` (Epic — rollout cluster pl se poursuit : fol, argumentation Dung dans des notebooks suivants).

Co-Authored-By: Claude-Code <noreply@anthropic.com>