### PR TITLE
feat(lean): #4364 converge no-dep lakes rc2 -> v4.31.0-rc1

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lean-toolchain
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.30.0-rc2
+leanprover/lean4:v4.31.0-rc1

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lean-toolchain
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.30.0-rc2
+leanprover/lean4:v4.31.0-rc1


### PR DESCRIPTION
## Summary

First grain of **#4364** (Mathlib harmonization, Phase 3 of epic #4362): converge the **no-dep cohort** — the two self-contained GameTheory lakes with **zero Mathlib dependency** — from `v4.30.0-rc2` to the target `v4.31.0-rc1` (`d568c8c0`).

This is the easiest of #4364 four cohorts (no-dep → splinters → famille → peters): a pure toolchain bump, since no Mathlib means no API drift to repair.

### Lakes converged (no-dep cohort)

| Lake | Toolchain | Build (rc1) | sorry |
|------|-----------|-------------|-------|
| `lean_game_defs` | rc2 → **rc1** | SUCCESS (**8 jobs**) | 0 (unchanged) |
| `lean_game_defs_ext` | rc2 → **rc1** | SUCCESS (**13 jobs**) | 0 (unchanged) |

## Validation (firsthand, G.1)

```text
# lean_game_defs (core-only, rc1)
$ lake build
✔ [2/8] Built Basic (2.2s)  ✔ [3/8] Built Combinatorial  ✔ [4/8] Built SocialChoice
✔ [5/8] Built Nash  ✔ [6/8] Built Bayesian  ✔ [7/8] Built Regret
Build completed successfully (8 jobs).  EXIT: 0

# lean_game_defs_ext (core-only, rc1)
$ lake build
✔ [2/13] Built Bayesian.Sum  ...  ✔ [11/13] Built Bayesian.Reputation
Build completed successfully (13 jobs).  EXIT: 0
```

- **sorry baseline net-zero** vs `origin/main`: `0 → 0` (comment-stripped grep on both lakes)
- **No tactical adaptation needed** — no Mathlib = no API drift between rc2/rc1. Every `.lean` module recompiled cleanly on rc1.
- **Anti-regression**: 0 `.lean` source touched (toolchain bump only), no proof replaced by `sorry` (#4364 garde-fou respected).

## Integrity

- 0 `.lean` files touched (2 `lean-toolchain` files only)
- `COURSE_CATALOG.generated.{json,md}` byte-identical to `origin/main`
- Branch fresh from `origin/main`

## Context (#4364 cohort roadmap)

This delivers the **no-dep** cohort. Remaining:
- **Splinters rc2** (calibration / conway / grothendieck @ 54f98fd6 / decision_theory @ 5450b53e)
- **Famille rc2-`1c1dadbc`** (cooperative_games / social_choice / stable_marriage / mathlib_examples / sensitivity)
- **peters v4.27** (hardest — 4 revs gap, may stay INTRINSIC per #4364 acceptance)

See #4364 (no-dep cohort).
Part of #4362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)