### PR TITLE
docs(vibe-coding): restore FR diacritics in Claude-Code README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/README.md
@@ -135,17 +135,17 @@ Semaine 3: Atelier 05 (Automatisation avancée)
 
 ## Notebooks Interactifs CLI
 
-Une serie de **5 notebooks Jupyter** pour apprendre et experimenter avec `claude -p` en ligne de commande.
+Une série de **5 notebooks Jupyter** pour apprendre et expérimenter avec `claude -p` en ligne de commande.
 
-| Notebook | Duree | Description |
+| Notebook | Durée | Description |
 |----------|-------|-------------|
-| [01-Claude-CLI-Bases](notebooks/01-Claude-CLI-Bases.ipynb) | 20 min | Installation, premiere commande, modeles |
+| [01-Claude-CLI-Bases](notebooks/01-Claude-CLI-Bases.ipynb) | 20 min | Installation, première commande, modèles |
 | [02-Claude-CLI-Sessions](notebooks/02-Claude-CLI-Sessions.ipynb) | 25 min | Gestion des conversations et sessions |
 | [03-Claude-CLI-References](notebooks/03-Claude-CLI-References.ipynb) | 25 min | @-mentions, contexte fichiers, CLAUDE.md |
 | [04-Claude-CLI-Agents](notebooks/04-Claude-CLI-Agents.ipynb) | 30 min | Agents Explore, Plan, subagents |
 | [05-Claude-CLI-Automatisation](notebooks/05-Claude-CLI-Automatisation.ipynb) | 30 min | Pipelines, scripts, hooks |
 
-**Duree totale : 2h10** | [README des notebooks](notebooks/README.md)
+**Durée totale : 2h10** | [README des notebooks](notebooks/README.md)
 
 ## Documentation complémentaire
 
@@ -153,12 +153,12 @@ Une serie de **5 notebooks Jupyter** pour apprendre et experimenter avec `claude
 
 | Document | Emplacement | Description |
 |----------|-------------|-------------|
-| **Quickstart OpenRouter** | [docs/OPENROUTER_SETUP.md](docs/OPENROUTER_SETUP.md) | 15 min, prise en main etape par etape |
-| **Introduction** | [INTRO-CLAUDE-CODE.md](docs/INTRO-CLAUDE-CODE.md) | Concepts et fonctionnalites |
+| **Quickstart OpenRouter** | [docs/OPENROUTER_SETUP.md](docs/OPENROUTER_SETUP.md) | 15 min, prise en main étape par étape |
+| **Introduction** | [INTRO-CLAUDE-CODE.md](docs/INTRO-CLAUDE-CODE.md) | Concepts et fonctionnalités |
 | **Installation** | [INSTALLATION-CLAUDE-CODE.md](docs/INSTALLATION-CLAUDE-CODE.md) | Guide complet avec OpenRouter |
-| **Modeles alternatifs** | [INSTALLATION-CLAUDE-CODE.md#modeles-alternatifs-via-openrouter](docs/INSTALLATION-CLAUDE-CODE.md#modeles-alternatifs-via-openrouter) | GLM-4.7, Qwen3 Coder via OpenRouter |
-| **Aide-memoire** | [CHEAT-SHEET.md](docs/CHEAT-SHEET.md) | Commandes essentielles |
-| **Concepts avances** | [CONCEPTS-AVANCES.md](docs/CONCEPTS-AVANCES.md) | Skills, Subagents, Hooks, MCP |
+| **Modèles alternatifs** | [INSTALLATION-CLAUDE-CODE.md#modeles-alternatifs-via-openrouter](docs/INSTALLATION-CLAUDE-CODE.md#modeles-alternatifs-via-openrouter) | GLM-4.7, Qwen3 Coder via OpenRouter |
+| **Aide-mémoire** | [CHEAT-SHEET.md](docs/CHEAT-SHEET.md) | Commandes essentielles |
+| **Concepts avancés** | [CONCEPTS-AVANCES.md](docs/CONCEPTS-AVANCES.md) | Skills, Subagents, Hooks, MCP |
 | **Comparaison** | [COMPARAISON-CLAUDE-ROO.md](../docs/COMPARAISON-CLAUDE-ROO.md) | Claude Code vs Roo Code |
 
 ### Documentation officielle


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg `lygoyu`) : accents #2876 résiduels GenAI/Vibe-Coding. Tranche ciblée = `Claude-Code/README.md` (spine pédagogique de la sous-série).

Le README était majoritairement bien accenté (sections Objectifs/Structure correctes), mais **2 sections ajoutées tardivement** (table notebooks CLI + table documentation) avaient échappé au sweep #2876 GenAI.

## Changes

9 corrections accent-only dans 2 sections :

| Section | Corrections |
|---------|-------------|
| Notebooks Interactifs CLI | `serie`→`série`, `experimenter`→`expérimenter`, `Duree`→`Durée` (×2), `premiere commande`→`première commande`, `modeles`→`modèles` |
| Documentation complémentaire (table) | `etape par etape`→`étape par étape`, `fonctionnalites`→`fonctionnalités`, `**Modeles alternatifs**`→`**Modèles alternatifs**`, `**Aide-memoire**`→`**Aide-mémoire**`, `**Concepts avances**`→`**Concepts avancés**` |

## Validation (méthode 4-gates)

- **GATE 1 (accent-only)** : `deaccent(old) == deaccent(new)` en NFD pour chaque remplacement. Delta taille = **0 octet** (preuve accent-pur). **A rejeté** `Ecosystem → Écosystème` car c'est une traduction (ajoute un "e" final), pas un accent-only — `Ecosystem` est un anglicisme légitime en prose tech FR, laissé intact (leçon #4502 : ne pas sur-corriger).
- **GATE 3 (URLs identiques)** : tous les liens `](...)` byte-identiques. L'ancre `#modeles-alternatifs-via-openrouter` et les cibles `.md`/`.ipynb` **intacts** — seul le label gras `**Modèles alternatifs**` est accenté (distinction label vs URL préservée).
- **GATE 4 (fences/inline-code)** : nombre de ```` ``` ```` identique, code blocks PowerShell/bash non touchés.
- **CATALOG** : aucun marqueur `CATALOG-STATUS` dans ce fichier (byte-identical).

## Non-scope

Le reste de la sous-série Vibe-Coding (Roo-Code, Claw-Systems, Claudish, notebooks) a aussi des lacunes d'accents (scan ~56KB) — grain multi-batch dédié pour cycles suivants. Cette PR = tranche atomique du spine Claude-Code.

See #2876
