### PR TITLE
feat(causal): do-calculus bridge notebook (dowhy SOTA) — pivot des 4 séries causales

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb
@@ -1,0 +1,613 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0948c441733a",
+   "metadata": {},
+   "source": [
+    "# Du graphe causal au do-calculus — le pont entre les quatre séries causales\n",
+    "\n",
+    "> **Notebook-pont** de la constellation causale du dépôt (règle F : `dowhy` installé et exécuté réellement, SOTA-OK). Il ne remplace pas les notebooks dédiés de chaque moteur : il donne l'**armature formelle unifiée** (échelle de Pearl + trois règles du do-calculus) et la fait tourner sur l'**outil de référence** [`dowhy`](https://www.pywhy.org/dowhy/), avant de renvoyer à chaque série pour l'instanciation par moteur.\n",
+    "\n",
+    "La causalité est traitée à **quatre endroits** du dépôt, chacun avec son moteur et son angle :\n",
+    "\n",
+    "| Série | Moteur | Angle |\n",
+    "|-------|--------|-------|\n",
+    "| [Tweety-11](../../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | Tweety (.NET, logique) | SCM, opérateur `do`, contrefactuels |\n",
+    "| [Infer-14](../../Infer/Infer-14-Causal-Inference.ipynb) | Infer.NET (message passing) | backdoor, front-door, Simpson, médiation |\n",
+    "| [PyMC-14](../../PyMC/PyMC-14-Causal-Inference.ipynb) | PyMC (MCMC) | backdoor, front-door, contrefactuel bayésien |\n",
+    "| [ICT-5](../../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb) / [ICT-6](../../../IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb) | PyPhi (CE 2.0) | **émergence causale** (information effective de Hoel) |\n",
+    "\n",
+    "Ce que ce pont ajoute, que les quatre notebooks ne font pas chacun séparément : (1) la **théorie unifiée** du do-calculus présentée une bonne fois ; (2) une exécution sur l'**outil SOTA** `dowhy` qui **identifie** l'estimande (backdoor/front-door/IV), **estime** puis **réfute** ; (3) la **mise en regard** des deux grands paradigmes — l'interventionnisme de Pearl et l'émergence causale de Hoel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "578dbe74ca68",
+   "metadata": {},
+   "source": [
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "À l'issue de ce notebook vous saurez :\n",
+    "\n",
+    "1. **Situer** chaque série causale du dépôt sur l'échelle de Pearl (observation / intervention / contrefactuel).\n",
+    "2. **Énoncer** les trois règles du do-calculus et les lire comme des chirurgies du graphe causal.\n",
+    "3. **Reconnaître** les critères *backdoor* et *front-door*, et les **exécuter** avec `dowhy` sur des données simulées à effet connu.\n",
+    "4. **Distinguer** la causalité interventionniste (Pearl) de l'émergence causale (Hoel / information effective) — deux réponses différentes à la question « quelle échelle cause ? ».\n",
+    "\n",
+    "**Prérequis** : probabilités conditionnelles, graphes orientés acycliques (DAG), notions d'inférence bayésienne. Une lecture préalable de l'un des quatre notebooks ci-dessus rend le pont plus concret."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38042c63c784",
+   "metadata": {},
+   "source": [
+    "## 1. L'échelle de Pearl — trois niveaux de causalité\n",
+    "\n",
+    "Judea Pearl structure la causalité en **trois échelons** croissants, chacun subsumant le précédent :\n",
+    "\n",
+    "| Niveau | Question type | Symbole | Opération |\n",
+    "|:------:|---------------|---------|-----------|\n",
+    "| **1. Association** | *Que vois-je ?* | $P(y \\mid x)$ | observer |\n",
+    "| **2. Intervention** | *Que se passe-t-il si je fais $x$ ?* | $P(y \\mid do(x))$ | agir |\n",
+    "| **3. Contrefactuel** | *Que se serait-il passé si j'avais fait $x'$ ?* | $P(y_x \\mid x', y')$ | imaginer |\n",
+    "\n",
+    "Le saut du niveau 1 au niveau 2 est **le** cœur du do-calculus : $P(y \\mid x)$ (ce qu'on observe dans les données) diffère en général de $P(y \\mid do(x))$ (l'effet d'une intervention), précisément à cause des **chemins confondants** que le do-calculus permet de neutraliser. Les quatre notebooks de la constellation couvrent les trois niveaux depuis l'angle de leur moteur ; nous récapitulons ici le **formalisme** partagé."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df21efed039a",
+   "metadata": {},
+   "source": [
+    "## 2. Les trois règles du do-calculus\n",
+    "\n",
+    "Soit $G$ un graphe causal, $G_{\\overline{Z}}$ (resp. $G_{\\underline{Z}}$) le graphe où l'on **coupe** les arêtes entrant dans (resp. sortant de) $Z$. Les trois règles de Pearl permettent de transformer toute expression avec $do(\\cdot)$ en expression sans $do(\\cdot)$ lorsque c'est possible :\n",
+    "\n",
+    "> **Règle 1 (insertion/suppression d'observations).**\n",
+    "> $P(y \\mid do(x), z, w) = P(y \\mid do(x), w)$ si $(Y \\perp\\!\\!\\!\\perp Z \\mid X, W)_{G_{\\overline{X}}}$.\n",
+    "\n",
+    "> **Règle 2 (échange action/observation).**\n",
+    "> $P(y \\mid do(x), do(z), w) = P(y \\mid do(x), z, w)$ si $(Y \\perp\\!\\!\\!\\perp Z \\mid X, W)_{G_{\\overline{X}\\underline{Z}}}$.\n",
+    "\n",
+    "> **Règle 3 (insertion/suppression d'actions).**\n",
+    "> $P(y \\mid do(x), do(z), w) = P(y \\mid do(x), w)$ si $(Y \\perp\\!\\!\\!\\perp Z \\mid X, W)_{G_{\\overline{X}\\overline{Z(W)}}}$.\n",
+    "\n",
+    "**Intuition unifiée** : chaque règle est une **chirurgie du graphe** suivie d'un test de $d$-séparation. Si deux variables sont indépendantes conditionnellement dans le graphe mutilé approprié, on peut réécrire la probabilité. Le critère *backdoor* (§4) et le critère *front-door* (§5) sont les **cas spéciaux les plus utiles** qui en découlent directement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff3b87c1a4ce",
+   "metadata": {},
+   "source": [
+    "## 3. Configuration — l'outil de référence `dowhy`\n",
+    "\n",
+    "Nous utilisons [`dowhy`](https://www.pywhy.org/dowhy/) (écosystème PyWhy), la librairie de référence pour l'inférence causale. Elle poursuit le pipeline en **quatre étapes** qui structurent toute analyse causale sérieuse :\n",
+    "\n",
+    "1. **Modèle** — on fournit les données **et** le graphe causal (hypothèses expertes) ;\n",
+    "2. **Identification** — `dowhy` lit le graphe et détermine *quel* estimande est calculable (backdoor, front-door, variable instrumentale) ;\n",
+    "3. **Estimation** — on choisit un estimateur (régression, appariement, pondération inverse) ;\n",
+    "4. **Réfutation** — on stress-teste l'estimation (placebo, sous-échantillon, proxy) pour vérifier sa robustesse.\n",
+    "\n",
+    "C'est précisément la rigueur (identification **avant** estimation) qui distingue une analyse causale d'une simple régression corrélationnelle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "f46048fb51e7",
+   "metadata": {},
+   "execution_count": 1,
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dowhy 0.14 | networkx 3.6.1 | pandas 3.0.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import networkx as nx\n",
+    "from dowhy import CausalModel\n",
+    "import dowhy\n",
+    "\n",
+    "print(\"dowhy\", dowhy.__version__, \"| networkx\", nx.__version__, \"| pandas\", pd.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95a24801c3c6",
+   "metadata": {},
+   "source": [
+    "## 4. Le critère *backdoor* — neutraliser le confondeur observable\n",
+    "\n",
+    "**Énoncé** (Pearl). Un ensemble $Z$ satisfait le critère *backdoor* relativement à $(X, Y)$ si :\n",
+    "\n",
+    "1. aucun nœud de $Z$ n'est un descendant de $X$ ;\n",
+    "2. $Z$ **bloque tous les chemins backdoor** (chemins entrant dans $X$ par une arête pointée vers $X$) entre $X$ et $Y$.\n",
+    "\n",
+    "Quand un tel $Z$ existe et est **observable**, alors\n",
+    "\n",
+    "$$P(y \\mid do(x)) = \\sum_z P(y \\mid x, z)\\, P(z),$$\n",
+    "\n",
+    "ce qui ramène l'intervention à un ajustement — **règle 2 du do-calculus**.\n",
+    "\n",
+    "### Exemple : aptitude → {études, salaire}\n",
+    "\n",
+    "Le facteur d'**aptitude** $U$ cause à la fois la décision de **faire des études** ($T$) et le **salaire** $Y$. L'effet vrai de $T$ sur $Y$ est $2{,}0$. La simple comparaison des salaires moyens est **biaisée** car $U$ ouvre un chemin backdoor $T \\leftarrow U \\rightarrow Y$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "900bd9619759",
+   "metadata": {},
+   "execution_count": 2,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Effet NAIF observé : 3.494   (biaisé — l'aptitude confond)\n",
+      "Effet VRAI (connu) : 2.000\n"
+     ]
+    }
+   ],
+   "source": [
+    "np.random.seed(42)\n",
+    "N = 20_000\n",
+    "aptitude = np.random.normal(0, 1, N)\n",
+    "college  = (0.8 * aptitude + np.random.normal(0, 1, N) > 0).astype(int)\n",
+    "earnings = 2.0 * college + 1.5 * aptitude + np.random.normal(0, 1, N)\n",
+    "df_backdoor = pd.DataFrame({\"aptitude\": aptitude, \"college\": college, \"earnings\": earnings})\n",
+    "\n",
+    "naive = df_backdoor.query(\"college == 1\").earnings.mean() - df_backdoor.query(\"college == 0\").earnings.mean()\n",
+    "print(f\"Effet NAIF observé : {naive:.3f}   (biaisé — l'aptitude confond)\")\n",
+    "print(f\"Effet VRAI (connu) : 2.000\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "4d16459390f2",
+   "metadata": {},
+   "execution_count": 3,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimand type: EstimandType.NONPARAMETRIC_ATE\n",
+      "\n",
+      "### Estimand : 1\n",
+      "Estimand name: backdoor\n",
+      "Estimand expression:\n",
+      "    d                           \n",
+      "──────────(E[earnings|aptitude])\n",
+      "d[college]                      \n",
+      "Estimand assumption 1, Unconfoundedness: If U→{college} and U→earnings then P(earnings|college,aptitude,U) = P(earnings|college,aptitude)\n",
+      "\n",
+      "### Estimand : 2\n",
+      "Estimand name: iv\n",
+      "No such variable(s) found!\n",
+      "\n",
+      "### Estimand : 3\n",
+      "Estimand name: frontdoor\n",
+      "No such variable(s) found!\n",
+      "\n",
+      "### Estimand : 4\n",
+      "Estimand name: general_adjustment\n",
+      "Estimand expression:\n",
+      "    d                           \n",
+      "──────────(E[earnings|aptitude])\n",
+      "d[college]                      \n",
+      "Estimand assumption 1, Unconfoundedness: If U→{college} and U→earnings then P(earnings|college,aptitude,U) = P(earnings|college,aptitude)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Graphe causal : aptitude -> college, college -> earnings, aptitude -> earnings\n",
+    "gml_backdoor = '''\n",
+    "graph [\n",
+    "  directed 1\n",
+    "  node [ id 0 label \"aptitude\" ]\n",
+    "  node [ id 1 label \"college\" ]\n",
+    "  node [ id 2 label \"earnings\" ]\n",
+    "  edge [ source 0 target 1 ]\n",
+    "  edge [ source 1 target 2 ]\n",
+    "  edge [ source 0 target 2 ]\n",
+    "]\n",
+    "'''\n",
+    "model_bd = CausalModel(data=df_backdoor, treatment=\"college\", outcome=\"earnings\", graph=gml_backdoor)\n",
+    "estimand_bd = model_bd.identify_effect(proceed_when_unidentifiable=False)\n",
+    "print(estimand_bd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "7266933db347",
+   "metadata": {},
+   "execution_count": 4,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Effet estime (dowhy, ajustement backdoor) : 1.981"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Effet vrai                                : 2.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Placebo (effet attendu ~0) : -0.001\n",
+      "Sous-echantillon           : 1.981\n"
+     ]
+    }
+   ],
+   "source": [
+    "estimate_bd = model_bd.estimate_effect(estimand_bd, method_name=\"backdoor.linear_regression\")\n",
+    "print(f\"Effet estime (dowhy, ajustement backdoor) : {estimate_bd.value:.3f}\")\n",
+    "print(f\"Effet vrai                                : 2.000\")\n",
+    "\n",
+    "# Réfutation : l'effet résiste-t-il à un placebo et à un sous-échantillon ?\n",
+    "refute_placebo = model_bd.refute_estimate(estimand_bd, estimate_bd, method_name=\"placebo_treatment_refuter\")\n",
+    "refute_subset  = model_bd.refute_estimate(estimand_bd, estimate_bd, method_name=\"data_subset_refuter\")\n",
+    "print(\"\\nPlacebo (effet attendu ~0) :\", round(refute_placebo.new_effect, 3))\n",
+    "print(\"Sous-echantillon           :\", round(refute_subset.new_effect, 3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd1725a0c427",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- L'effet **naïf** (~3,49) **surévalue** l'effet des études : les diplômés gagnent plus en partie parce qu'ils étaient **plus aptes** au départ (chemin backdoor).\n",
+    "- Une fois **ajusté sur l'aptitude** (l'ensemble backdoor $\\{U\\}$), `dowhy` recouvre ~1,98 ≈ effet vrai 2,0 : la chirurgie graphique a neutralisé le confondeur.\n",
+    "- Les **réfutations** confirment la robustesse : l'effet tombe vers 0 sous placebo (un faux traitement ne donne rien) et reste stable sur un sous-échantillon."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e4ce72c7cd5",
+   "metadata": {},
+   "source": [
+    "## 5. Le critère *front-door* — quand le confondeur est inobservable\n",
+    "\n",
+    "Que faire si le confondeur est **inobservable** (génétique, préférences latentes) ? Si l'on dispose d'un **médiateur** $M$ captant tout l'effet de $X$ sur $Y$, le critère *front-door* sauve la situation :\n",
+    "\n",
+    "1. $M$ **intercepte** tous les chemins dirigés de $X$ vers $Y$ ;\n",
+    "2. il n'existe pas de chemin backdoor de $X$ vers $M$ ;\n",
+    "3. tous les chemins backdoor de $M$ vers $Y$ sont bloqués par $X$.\n",
+    "\n",
+    "Alors $P(y \\mid do(x)) = \\sum_m P(m \\mid x) \\sum_{x'} P(y \\mid x', m)\\, P(x')$.\n",
+    "\n",
+    "### Exemple : génotype (latent) → tabagisme → goudron → cancer\n",
+    "\n",
+    "Un **génotype** $U$ (non observé) pousse à la fois au **tabagisme** $X$ et au **cancer** $Y$. Impossible d'ajuster sur $U$ : on n'a pas la donnée. Mais le tabagisme n'affecte le cancer **qu'à travers le goudron** $M$, qu'on mesure. `dowhy` doit alors **échouer** à trouver une backdoor et **basculer** sur la front-door via le médiateur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "d1a4fb0cf4d6",
+   "metadata": {},
+   "execution_count": 5,
+   "outputs": [],
+   "source": [
+    "np.random.seed(7)\n",
+    "N = 20_000\n",
+    "genotype = np.random.normal(0, 1, N)                      # CONFOUNDEUR LATENT (non observé)\n",
+    "smoking  = (1.0 * genotype + np.random.normal(0, 1, N) > 0).astype(int)\n",
+    "tar      = 0.9 * smoking + np.random.normal(0, 0.5, N)\n",
+    "cancer   = 1.0 * tar + 0.8 * genotype + np.random.normal(0, 1, N)\n",
+    "# On n'observe QUE smoking, tar, cancer (le génotype reste caché)\n",
+    "df_frontdoor = pd.DataFrame({\"smoking\": smoking, \"tar\": tar, \"cancer\": cancer})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "78ddf6d65004",
+   "metadata": {},
+   "execution_count": 6,
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\dowhy\\causal_model.py:581: UserWarning: 1 variables are assumed unobserved because they are not in the dataset. Configure the logging level to `logging.WARNING` or higher for additional details.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimand type: EstimandType.NONPARAMETRIC_ATE\n",
+      "\n",
+      "### Estimand : 1\n",
+      "Estimand name: backdoor\n",
+      "No such variable(s) found!\n",
+      "\n",
+      "### Estimand : 2\n",
+      "Estimand name: iv\n",
+      "No such variable(s) found!\n",
+      "\n",
+      "### Estimand : 3\n",
+      "Estimand name: frontdoor\n",
+      "Estimand expression:\n",
+      " ⎡  d                d            ⎤\n",
+      "E⎢──────(cancer)⋅──────────([tar])⎥\n",
+      " ⎣d[tar]         d[smoking]       ⎦\n",
+      "Estimand assumption 1, Full-mediation: tar intercepts (blocks) all directed paths from smoking to c,a,n,c,e,r.\n",
+      "Estimand assumption 2, First-stage-unconfoundedness: If U→{smoking} and U→{tar} then P(tar|smoking,U) = P(tar|smoking)\n",
+      "Estimand assumption 3, Second-stage-unconfoundedness: If U→{tar} and U→cancer then P(cancer|tar, smoking, U) = P(cancer|tar, smoking)\n",
+      "\n",
+      "### Estimand : 4\n",
+      "Estimand name: general_adjustment\n",
+      "No such variable(s) found!\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Graphe : U(latent) -> smoking, smoking -> tar, tar -> cancer, U(latent) -> cancer\n",
+    "gml_frontdoor = '''\n",
+    "graph [\n",
+    "  directed 1\n",
+    "  node [ id 0 label \"U\" ]\n",
+    "  node [ id 1 label \"smoking\" ]\n",
+    "  node [ id 2 label \"tar\" ]\n",
+    "  node [ id 3 label \"cancer\" ]\n",
+    "  edge [ source 0 target 1 ]\n",
+    "  edge [ source 1 target 2 ]\n",
+    "  edge [ source 2 target 3 ]\n",
+    "  edge [ source 0 target 3 ]\n",
+    "]\n",
+    "'''\n",
+    "model_fd = CausalModel(data=df_frontdoor, treatment=\"smoking\", outcome=\"cancer\", graph=gml_frontdoor)\n",
+    "estimand_fd = model_fd.identify_effect(proceed_when_unidentifiable=True)\n",
+    "print(estimand_fd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "3b06c59976a0",
+   "metadata": {},
+   "execution_count": 7,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Effet estime (front-door, deux etapes) : 0.934"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Effet vrai via le mediateur             : ~0.900  (0.9 * 1.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "estimate_fd = model_fd.estimate_effect(estimand_fd, method_name=\"frontdoor.two_stage_regression\")\n",
+    "print(f\"Effet estime (front-door, deux etapes) : {estimate_fd.value:.3f}\")\n",
+    "print(f\"Effet vrai via le mediateur             : ~0.900  (0.9 * 1.0)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f4987f87ffd",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "`dowhy` confirme le raisonnement :\n",
+    "\n",
+    "- **backdoor** : *« No such variable(s) found! »* — $U$ est latent, aucun ajustement direct possible ;\n",
+    "- **front-door** : l'estimande identifiée passe par le médiateur `tar` ($E[\\frac{\\partial\\, cancer}{\\partial\\, tar} \\cdot \\frac{\\partial\\, tar}{\\partial\\, smoking}]$) ;\n",
+    "- l'estimation (~0,93) recouvre l'effet vrai (~0,9) **sans jamais observer le génotype**. C'est toute la puissance du front-door : neutraliser un confondeur latent via un médiateur mesurable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "407314d30aed",
+   "metadata": {},
+   "source": [
+    "## 6. Comment chaque moteur instancie le do-calculus\n",
+    "\n",
+    "Les quatre séries **implantent le même formalisme** (§1-2) avec des outils différents. Partout, $do(X=x)$ se traduit par une **mutilation du graphe** : on supprime les arêtes entrant dans $X$ (déconnexion du mécanisme générant $X$) puis on fige $X=x$.\n",
+    "\n",
+    "| Série | Moteur | `do(X)` opérationnellement | Angle couvert |\n",
+    "|-------|--------|----------------------------|---------------|\n",
+    "| [Infer-14](../../Infer/Infer-14-Causal-Inference.ipynb) | Infer.NET | mutilation + **message passing exact** | backdoor, front-door, Simpson, médiation |\n",
+    "| [PyMC-14](../../PyMC/PyMC-14-Causal-Inference.ipynb) | PyMC | mutilation + **échantillonnage MCMC** | backdoor, front-door, contrefactuel bayésien |\n",
+    "| [Tweety-11](../../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | Tweety (.NET) | **backend causal logique**, opérateur `do` natif | SCM, contrefactuels |\n",
+    "| **Ce pont** | `dowhy` | **identification + estimation + réfutation** | formalisme unifié + outil SOTA |\n",
+    "\n",
+    "Le présent notebook est **complémentaire** : là où Infer-14 et PyMC-14 instrumentent le `do` à la main sur leur moteur, `dowhy` **automatise l'identification** (lit le graphe, choisit backdoor/front-door/IV) puis **estime et réfute** — le pipeline qu'on utiliserait en pratique pour une vraie étude causale."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7134b9e2fdb9",
+   "metadata": {},
+   "source": [
+    "## 7. Deux paradigmes : Pearl (intervention) vs Hoel (émergence causale)\n",
+    "\n",
+    "Les notebooks [ICT-5](../../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb) et [ICT-6](../../../IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb) défendent une thèse **différente** et complémentaire : la **causalité émergente** d'Erik Hoel. Là où Pearl demande « *quel est l'effet d'une intervention sur $X$ ?* » au sein d'un graphe **fixé**, Hoel demande « **quelle échelle** de description du système porte le plus de causalité ? ».\n",
+    "\n",
+    "Le formalisme de Hoel repose sur l'**information effective** (EI), mesurée sur la matrice de transition d'un système :\n",
+    "\n",
+    "$$\\text{EI} = \\underbrace{\\text{déterminisme}}_{\\text{le futur est-il prévisible ?}}\n",
+    "            \\;-\\; \\underbrace{\\text{dégénérescence}}_{\\text{plusieurs passés} \\to \\text{même futur}}.$$\n",
+    "\n",
+    "Un **coarse-graining** (regroupement de micro-états en macro-état) peut **augmenter** l'EI : la macro-échelle est alors *plus* causale que la micro. ICT-5 le démontre sur le réseau canonique de PyPhi (EI passe de ~0,11 à ~0,60).\n",
+    "\n",
+    "|  | **Pearl** (do-calculus) | **Hoel** (émergence causale) |\n",
+    "|---|---|---|\n",
+    "| Question | Effet d'une intervention ? | Quelle échelle cause le plus ? |\n",
+    "| Objet | un graphe causal **fixé** | l'**échelle de description** optimale |\n",
+    "| Outil | `dowhy`, Infer.NET, PyMC | PyPhi (CE 2.0) |\n",
+    "| Causalité vue comme | chirurgie du graphe ($do$) | information effective (EI) |\n",
+    "\n",
+    "**Pont conceptuel** : les deux cadres répondent à « où est la causalité ? » — Pearl la localise dans les **flèches** qu'on coupe, Hoel dans l'**échelle** qui maximise l'information sur le futur. Un système peut admettre une description causale riche au sens de Hoel (forte EI macro) tout en se prêtant au do-calculus de Pearl au niveau micro : ce sont deux **loupes** différentes, non concurrentes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed63379fe712",
+   "metadata": {},
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "Les exercices suivent la convention du dépôt (stub à compléter). Aucun ne lève d'erreur : remplacez `None` par votre code.\n",
+    "\n",
+    "### Exercice 1 — Ajouter un second confondeur à la backdoor\n",
+    "\n",
+    "Ajoutez un confondeur **observable** `motivation` (qui cause `college` **et** `earnings`) au modèle backdoor, puis demandez à `dowhy` d'identifier l'estimande. L'ensemble backdoor doit maintenant contenir `{aptitude, motivation}`.\n",
+    "\n",
+    "### Exercice 2 — Rompre le critère front-door\n",
+    "\n",
+    "Modifiez le graphe front-door en ajoutant un chemin **direct** `smoking -> cancer` (contournant le médiateur `tar`). Vérifiez que le critère front-door **échoue** à identifier l'effet — l'hypothèse de médiation complète est rompue.\n",
+    "\n",
+    "### Exercice 3 — Comparer effet naïf et effet ajusté sur un nouveau jeu\n",
+    "\n",
+    "Générez un nouveau jeu backdoor avec un effet vrai de **5,0** et un confondeur plus fort (coefficient 2,5 sur l'aptitude). Calculez l'effet naïf puis l'effet ajusté, et **commentez** l'écart relatif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "6094715b6d97",
+   "metadata": {},
+   "execution_count": 8,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — ajoutez un 2e confondeur observable au modèle backdoor.\n",
+    "# Objectif : dowhy doit identifier l'ensemble backdoor {aptitude, motivation}.\n",
+    "# Indice : motivation -> college ET motivation -> earnings (mêmes flèches que aptitude).\n",
+    "# TODO etudiant : construisez df_ex1, le graphe gml_ex1, puis identifiez l'estimande.\n",
+    "df_ex1 = None        # TODO etudiant\n",
+    "gml_ex1 = None       # TODO etudiant\n",
+    "estimand_ex1 = None  # TODO etudiant\n",
+    "print(\"Exercice 1 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "a8b84b32684c",
+   "metadata": {},
+   "execution_count": 9,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — ajoutez un chemin direct smoking -> cancer (médiation rompue).\n",
+    "# Objectif : montrer que l'identification front-door échoue.\n",
+    "# Indice : ajoutez 'edge [ source 1 target 3 ]' au graphe gml_frontdoor.\n",
+    "# TODO etudiant : définissez gml_ex2 avec ce chemin direct, identifiez l'effet.\n",
+    "gml_ex2 = None  # TODO etudiant\n",
+    "print(\"Exercice 2 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "8d916b67aa64",
+   "metadata": {},
+   "execution_count": 10,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — nouvel effet vrai = 5.0, confondeur plus fort (2.5*aptitude).\n",
+    "# Objectif : comparer effet naïf vs ajusté, commenter l'écart relatif.\n",
+    "# TODO etudiant : générez les données, calculez naive puis estimate_bd, affichez l'écart.\n",
+    "print(\"Exercice 3 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21288d103255",
+   "metadata": {},
+   "source": [
+    "## 9. Synthèse\n",
+    "\n",
+    "Vous avez parcouru l'**armature formelle** partagée par les quatre séries causales du dépôt :\n",
+    "\n",
+    "- **Échelle de Pearl** (§1) : observation < intervention < contrefactuel — le do-calculus opère le saut $P(y\\mid x) \\to P(y\\mid do(x))$.\n",
+    "- **Trois règles** (§2) : chacune est une chirurgie du graphe + un test de $d$-séparation.\n",
+    "- **Backdoor** (§4) : ajustement sur les confondeurs observables — exécuté par `dowhy`, recouvre l'effet vrai.\n",
+    "- **Front-door** (§5) : sauvetage par médiateur quand le confondeur est latent.\n",
+    "- **Pearl vs Hoel** (§7) : intervention sur un graphe fixé *vs* échelle de description optimale (information effective).\n",
+    "\n",
+    "### Constellation causale — où approfondir\n",
+    "\n",
+    "| Direction | Notebook | Ce qu'il apporte de plus |\n",
+    "|-----------|----------|--------------------------|\n",
+    "| Logique + SCM + contrefactuels | [Tweety-11](../../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | backend causal .NET, opérateur `do` natif |\n",
+    "| Message passing exact | [Infer-14](../../Infer/Infer-14-Causal-Inference.ipynb) | Simpson, médiation, capstone contrefactuel |\n",
+    "| MCMC bayésien | [PyMC-14](../../PyMC/PyMC-14-Causal-Inference.ipynb) | incertitude postérieure sur l'effet |\n",
+    "| Émergence causale (Hoel) | [ICT-5](../../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb), [ICT-6](../../../IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb) | information effective, coarse-graining |\n",
+    "\n",
+    "> **Pont suivant** (après *merge* de ce notebook) : câbler les quatre notebooks en aller-retour vers ce pont, pour que chaque série renvoie ici pour le formalisme unifié."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (coursia-ml-training)",
+   "language": "python",
+   "name": "coursia-ml-training"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Ce que fait cette PR

Notebook-pont de la **constellation causale** : armature formelle unifiée (échelle de Pearl + 3 règles du do-calculus) exécutée sur l'**outil SOTA de référence `dowhy`**, puis mise en regard des 4 séries causales du dépôt (Tweety-11, Infer-14, PyMC-14, ICT-5/6).

**Nouveau fichier :** `MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb` (23 cellules : 13 markdown + 10 code).

## Placement

`Probas/DecisionTheory/Causal-Bridges/` — *hub des ponts décision/causalité* post-#4737 (défaut du dispatch ai-01). Sous-dossier `Causal-Bridges/` créé pour exprimer le scope cross-famille (Probas + SymbolicAI + IIT) tout en restant dans le hub. Override argumenté accepté dans le dispatch.

## Verdict SOTA-OK (règle F + EPIC #3801)

`dowhy` (PyWhy, v0.14) est l'**outil de référence** pour l'inférence causale — installé et **exécuté réellement** dans l'env `coursia-ml-training` (pas de réimplémentation jouet). Le notebook démontre le pipeline complet : **modèle (graphe causal expert) → identification (dowhy lit le graphe, choisit backdoor/front-door/IV) → estimation → réfutation** (placebo + sous-échantillon).

## Preuve d'exécution (C.2)

Papermill, kernel `coursia-ml-training`, **23/23 cellules, 0 erreur, 10/10 code cells avec `execution_count`** :

| Cellule | Output vérifié |
|---------|----------------|
| Backdoor identify | dowhy identifie l'ensemble backdoor `{aptitude}` (IV/front-door : « No such variable(s) found! ») |
| Backdoor estimate | **1.981** (effet vrai 2.0) — naive biaisée à 3.49 |
| Réfutation | placebo **-0.001** (effet attendu ~0 ✓), sous-échantillon **1.981** (stable ✓) |
| Front-door identify | backdoor échoue (U latent) → dowhy bascule sur front-door via médiateur `tar` |
| Front-door estimate | **0.934** (effet vrai via-médiateur 0.9) — sans jamais observer le confondeur latent |

## Périmètre (anti-régression + non-duplication)

- **Complète** Infer-14/PyMC-14 (qui instrumentent `do()` à la main sur leur moteur) — ne duplique pas leurs exemples baromètre/sprinkler. Apport unique : formalisme unifié + outil SOTA qui automatise l'identification.
- 15 cross-links vers les 4 séries, **0 dangling** (vérifié vs `git ls-tree origin/main`).
- FR (règle readme-french-first). ≥3 exercices stubbés (C.1 : `None`/`# TODO`, aucun `raise`).

## Notes

- Catalogue **non régénéré** à la main (règle catalog-pr-hygiene HARD 1) — le cron/ci catalog-drift créera l'entrée.
- Pas de `Closes #N` (pas d'issue dédiée « causal bridge » ; provenance = dispatch ai-01 deep-queue `msg-20260701T220249`, mandat user 2026-06-29). La step 2 du dispatch (cross-pointers aller-retour depuis les 4 notebooks) suivra après merge.
