### PR TITLE
fix(datasciencewithagents): Day2/Day3 nav READMEs + 7 path-geometry cross-link fixes (See #4788)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# 1.3 - Analyse de Données avec Pandas\n",
     "\n",
-    "**Navigation** : [<< 1.2 NumPy](1.2-Manipulation_de_Donnees_avec_NumPy.ipynb) | [Index](../../README.md) | [>> Lab 1](../PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb)\n",
+    "**Navigation** : [<< 1.2 NumPy](1.2-Manipulation_de_Donnees_avec_NumPy.ipynb) | [Index](../../README.md) | [>> Lab 1](../../PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Lab 2 - Analyser un Appel d'Offre avec l'IA\n",
     "\n",
-    "**Navigation** : [Lab 1 <<](../../Day1/Labs/Lab1-PythonForDataScience/Lab1-PythonForDataScience.ipynb) | [Index](../../README.md) | [>> Lab 3](../Lab3-CV-Screening/Lab3-CV-Screening.ipynb)\n",
+    "**Navigation** : [Lab 1 <<](../../../Day1/Labs/Lab1-PythonForDataScience.ipynb) | [Index](../../README.md) | [>> Lab 3](../Lab3-CV-Screening/Lab3-CV-Screening.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Lab 3 - Pré-qualifier des Candidats avec l'IA\n",
     "\n",
-    "**Navigation** : [Lab 2 <<](../../Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb) | [Index](../../README.md) | [>> Lab 4](../Lab4-DataWrangling/Lab4-DataWrangling.ipynb)\n",
+    "**Navigation** : [Lab 2 <<](../Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb) | [Index](../../README.md) | [>> Lab 4](../../../Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/README.md
@@ -1,0 +1,21 @@
+# Journée 2 — Agents pour l'analyse documentaire
+
+[← PythonAgentsForDataScience (track)](../README.md) | [Journée 1 →](../Day1/Labs/README.md) | [Journée 3 →](../Day3/README.md)
+
+La **Journée 2** opère le basculement central du workshop : de l'écriture du code data science à l'**orchestration d'agents LLM**. On y traite deux tâches documentaires — l'analyse d'un appel d'offres et le pré-screening de CVs — où l'agent extrait une information structurée à partir d'un texte libre, tout en gardant l'humain dans la boucle pour la validation.
+
+## Labs
+
+| Lab | Sujet | Concept-phare |
+|-----|-------|---------------|
+| [Lab 2 — RFP Analysis](Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb) | d'un appel d'offres à un PoC en 1 heure | extraction structurée d'un texte libre par LLM |
+| [Lab 3 — CV Screening](Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb) | pré-qualifier des candidats avec l'IA | analyse, notation et résumé de CVs vs offre |
+
+## Prérequis
+
+- Avoir suivi la [Journée 1](../Day1/Labs/README.md) (Pandas, Matplotlib, régression linéaire).
+- **LangChain** + clé API OpenAI (les labs 2 et 3 appellent un LLM).
+
+## Suite
+
+La [Journée 3](../Day3/README.md) monte en abstraction : data wrangling agentique, visualisation/ML, puis le premier agent d'analyse de données autonome (Lab 7).

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Lab 4 - Le Nettoyage de Données avec Pandas\n",
     "\n",
-    "**Navigation** : [Lab 3 <<](../../Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb) | [Index](../../README.md) | [>> Lab 5](../Lab5-Viz-ML/Lab5-Viz-ML.ipynb)\n",
+    "**Navigation** : [Lab 3 <<](../../../Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb) | [Index](../../README.md) | [>> Lab 5](../Lab5-Viz-ML/Lab5-Viz-ML.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](../../../../README.md) | [<< Lab5](../Lab5-Viz-ML/Lab5-Viz-ML.ipynb) | [Lab7 >>](../../../Day4/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb)\n",
+    "**Navigation** : [Index](../../../../README.md) | [<< Lab5](../Lab5-Viz-ML/Lab5-Viz-ML.ipynb) | [Lab7 >>](../Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb)\n",
     "# Lab 6 - Anatomie de votre premier Agent d'IA"
    ]
   },

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Lab 7 - Votre premier Agent Analyste de Données\n",
     "\n",
-    "**Navigation** : [Lab 6 <<](../Lab6-First-Agent/Lab6-First-Agent.ipynb) | [Index](../../README.md) | [>> Lab 8](../../../AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb)\n",
+    "**Navigation** : [Lab 6 <<](../Lab6-First-Agent/Lab6-First-Agent.ipynb) | [Index](../../README.md) | [>> Lab 8](../../../../AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/README.md
@@ -1,0 +1,23 @@
+# Journée 3 — Data wrangling & premiers agents autonomes
+
+[← PythonAgentsForDataScience (track)](../README.md) | [Journée 2 →](../Day2/README.md) | [Track Google ADK (Jours 4-7) →](../../AgenticDataScience/README.md)
+
+La **Journée 3** clôt le track LangChain : les agents deviennent capables de **manipuler des données** par eux-mêmes — nettoyage de données sales, interrogation en langage naturel, puis assemblage des composants d'un agent en un analyseur de données autonome. C'est la transition vers le track Google ADK (Jours 4-7).
+
+## Labs
+
+| Lab | Sujet | Concept-phare |
+|-----|-------|---------------|
+| [Lab 4 — Data Wrangling](Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb) | nettoyer un jeu de données « sale » réaliste | Pandas au service de la robustesse |
+| [Lab 5 — Viz & ML](Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb) | exploration visuelle puis classification scikit-learn | la visualisation guidant le modèle |
+| [Lab 6 — First Agent](Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb) | construire son premier agent LangChain | les 4 composants : LLM, Outils, Prompt, Exécuteur |
+| [Lab 7 — Data Analysis Agent](Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb) | agent répondant en langage naturel sur un DataFrame | l'agent comme interface d'analyse |
+
+## Prérequis
+
+- Avoir suivi la [Journée 2](../Day2/README.md) (analyse documentaire agentique).
+- **LangChain** + clé API OpenAI (les labs 6 et 7 appellent un LLM).
+
+## Suite
+
+Le workshop se poursuit avec le track **Google ADK** dans [`AgenticDataScience`](../../AgenticDataScience/README.md) : fondations ADK (Lab 8), agents DS-STAR / MLE-STAR, puis mise en production.


### PR DESCRIPTION
## Ce que fait cette PR

Résout les **13 liens morts** de `ML/DataScienceWithAgents` (classe D de #4788, dispatch ai-01 deep-queue step 4 « bâtir la nav manquante »). Grounding G.1 : le steer ai-01 (« créer les README de navigation ») ne couvrait que 6/13 — les 7 autres étaient des **bugs de géométrie de chemin** (même cause racine : nav étudiante cassée).

### 2 READMEs créés (6 refs `../../README.md` satisfaites)

- `PythonAgentsForDataScience/Day2/README.md` — hub de navigation Journée 2 (Lab2, Lab3)
- `PythonAgentsForDataScience/Day3/README.md` — hub de navigation Journée 3 (Lab4, Lab5, Lab6, Lab7)

FR, légers, factuels. Les descriptions par lab sont **reprises verbatim** du README parent (`PythonAgentsForDataScience/README.md`) pour éviter toute fabrication.

### 7 bugs de géométrie de chemin corrigés (6 notebooks)

Les liens comptaient mal les `../` → paths fantômes `Day2/Day1/`, `Day3/Day2/` vers des fichiers qui **existent** ailleurs :

| Notebook | Fix |
|----------|-----|
| `1.3-Analyse_de_Donnees_avec_Pandas` | `../PythonAgents…` → `../../PythonAgents…` (Lab1) |
| `Lab2-RFP-Analysis` | `../../Day1/Labs/Lab1-…/Lab1-…` → `../../../Day1/Labs/Lab1-…` (+ drop sous-dossier fantôme) |
| `Lab3-CV-Screening` ×2 | `../../Day2/Labs/Lab2…` → `../Lab2…` (sibling) ; `../Lab4…` → `../../../Day3/Labs/Lab4…` (cross-day) |
| `Lab4-DataWrangling` | `../../Day2/Labs/Lab3…` → `../../../Day2/Labs/Lab3…` (cross-day) |
| `Lab6-First-Agent` | `../../../Day4/Labs/Lab7…` → `../Lab7…` (Lab7 est sibling Day3, pas Day4) |
| `Lab7-Data-Analysis-Agent` | `../../../AgenticDataScience/…` → `../../../../AgenticDataScience/…` (Lab8, cross-top-level) |

## Preuve

- **Re-sweep dangling post-fix : 0** (vérifié vs `git ls-tree origin/main` + READMEs sur disque, filtre famille DataScienceWithAgents, normalisation Windows `.replace('\','/')`).
- Édits **chirurgicaux octet-par-octet** : 1 ligne/notebook changée (raw `.replace()`, pas de `json.dumps` qui churn le nbformat). Markdown-only → **C.2 exempt** (outputs préservés).
- Diff total : 50 ins / 6 del.

## Périmètre

- Un seul sujet (classe D #4788), famille ML/DataScienceWithAgents (turf po-2025).
- Pas de `Closes #4788` : c'est une tranche (classe D spécifique) ; #4788 reste ouvert pour les autres familles résiduelles.

Dispatch : ai-01 deep-queue `msg-20260701T220249` step 4.
