### PR TITLE
feat(tweety): Tweety-2c-FOL-Csharp — logique du premier ordre .NET natif (IKVM)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
@@ -1,0 +1,993 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "m328317",
+   "metadata": {},
+   "source": [
+    "# Tweety-2c — Logique du premier ordre en C#/.NET (port natif IKVM)\n",
+    "\n",
+    "> **Série Tweety — port C#/.NET natif (EPIC [#4667](https://github.com/jsboige/CoursIA/issues/4667)).**\n",
+    "> Ce notebook exploite la librairie Java [TweetyProject](https://tweetyproject.org/) **sans JVM** : les modules\n",
+    "> sont compilés vers du bytecode Java puis exécutés sur le runtime .NET via [IKVM](https://github.com/ikvm-refined/ikvm).\n",
+    "> Aucun `java` n'est requis à l'exécution — tout se passe dans le kernel `.net-csharp`.\n",
+    "\n",
+    "Navigation : [Tweety-2-Basic-Logics-Csharp](Tweety-2-Basic-Logics-Csharp.ipynb) (logique propositionnelle) ·\n",
+    "[Tweety-2b-Semantics-Csharp](Tweety-2b-Semantics-Csharp.ipynb) (mondes possibles, conséquence sémantique) ·\n",
+    "**Tweety-2c-FOL (ce notebook)**.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Objectifs pédagogiques\n",
+    "\n",
+    "La [logique propositionnelle](Tweety-2-Basic-Logics-Csharp.ipynb) raisonne sur des **propositions entières**\n",
+    "(`Man_Socrates`, `Mortal_Socrates`) reliées par connecteurs. Elle ne peut ni exprimer la **généralité**\n",
+    "(« tous les hommes sont mortels ») ni le **lien interne** d'un énoncé (« Socrate est un homme »).\n",
+    "\n",
+    "La **logique du premier ordre** (FOL, *first-order logic*) introduit :\n",
+    "\n",
+    "| Concept | Rôle | Exemple |\n",
+    "|---------|------|---------|\n",
+    "| **Terme** (`Term`) | Objet du discours | la variable `X`, la constante `Socrate` |\n",
+    "| **Prédicat** (`Predicate`) | Propriété / relation sur les termes | `Homme(·)`, `Parent(·,·)` |\n",
+    "| **Atome** (`FolAtom`) | Énoncé atomique | `Homme(Socrate)` |\n",
+    "| **Quantificateur universel** `∀` | « pour tout » | `∀X (Homme(X) ⇒ Mortel(X))` |\n",
+    "| **Quantificateur existentiel** `∃` | « il existe » | `∃X Mortel(X)` |\n",
+    "\n",
+    "Ce notebook montre comment **construire** des formules FOL de façon programmatique en C#,\n",
+    "puis **raisonner** dessus avec le raisonneur d'énumération de Tweety (`SimpleFolReasoner`) —\n",
+    "le célèbre **syllogisme** de la mortalité de Socrate, jusqu'à la **généralisation existentielle**.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m412865",
+   "metadata": {},
+   "source": [
+    "## 1 — Runtime IKVM : exécuter Tweety sur .NET\n",
+    "\n",
+    "On installe le runtime IKVM (machine virtuelle Java réimplémentée en .NET) à partir des paquets NuGet,\n",
+    "puis on pointe `IKVM.Home` vers une image fusionnée (base `any` + runtime spécifique `win-x64`).\n",
+    "La librairie `org.tweetyproject.tweety-pl.dll` (compilée côté build) se charge par `#r` ; elle embarque\n",
+    "**transitivement** le module `fol` (logique du premier ordre), aucun module supplémentaire à compiler ici.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c344536",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:30.570070Z",
+     "iopub.status.busy": "2026-07-01T22:41:30.524255Z",
+     "iopub.status.idle": "2026-07-01T22:41:37.428333Z",
+     "shell.execute_reply": "2026-07-01T22:41:37.404715Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-118412.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '118412.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>IKVM, 8.15.0</span></li><li><span>IKVM.Image, 8.15.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: IKVM, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image.runtime.win-x64, 8.15.0\"\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c154534",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:37.438470Z",
+     "iopub.status.busy": "2026-07-01T22:41:37.437869Z",
+     "iopub.status.idle": "2026-07-01T22:41:42.131619Z",
+     "shell.execute_reply": "2026-07-01T22:41:42.130704Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IKVM home=OK\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.IO;\n",
+    "string ikvmVer = \"8.15.0\", ikvmRid = \"win-x64\";\n",
+    "string nugetRoot = Environment.GetEnvironmentVariable(\"NUGET_PACKAGES\")\n",
+    "    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \".nuget\", \"packages\");\n",
+    "string ikvmBaseAny = Path.Combine(nugetRoot, \"ikvm.image\", ikvmVer, \"ikvm\", \"any\", \"any\");\n",
+    "string ikvmArchDir = Path.Combine(nugetRoot, \"ikvm.image.runtime.\" + ikvmRid, ikvmVer, \"ikvm\", \"any\", ikvmRid);\n",
+    "string ikvmHome = Path.Combine(Path.GetTempPath(), \"ikvm-home-\" + ikvmVer + \"-\" + ikvmRid);\n",
+    "void IkvmCopyMerge(string src, string dst)\n",
+    "{\n",
+    "    foreach (var d in Directory.GetDirectories(src, \"*\", SearchOption.AllDirectories))\n",
+    "        Directory.CreateDirectory(d.Replace(src, dst));\n",
+    "    foreach (var f in Directory.GetFiles(src, \"*\", SearchOption.AllDirectories))\n",
+    "    {\n",
+    "        var t = f.Replace(src, dst);\n",
+    "        Directory.CreateDirectory(Path.GetDirectoryName(t));\n",
+    "        File.Copy(f, t, overwrite: true);\n",
+    "    }\n",
+    "}\n",
+    "if (Directory.Exists(ikvmBaseAny) && Directory.Exists(ikvmArchDir))\n",
+    "{\n",
+    "    Directory.CreateDirectory(ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmBaseAny, ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmArchDir, ikvmHome);\n",
+    "}\n",
+    "AppContext.SetData(\"IKVM.Home\", ikvmHome);\n",
+    "Console.WriteLine(\"IKVM home=\" + (File.Exists(Path.Combine(ikvmHome, \"lib\", \"tzdb.dat\")) ? \"OK\" : \"MISSING\"));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c505006",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:42.134392Z",
+     "iopub.status.busy": "2026-07-01T22:41:42.133838Z",
+     "iopub.status.idle": "2026-07-01T22:41:42.275373Z",
+     "shell.execute_reply": "2026-07-01T22:41:42.274453Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#r \"org.tweetyproject.tweety-pl.dll\"\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m971748",
+   "metadata": {},
+   "source": [
+    "## 2 — Signature, termes et atomes\n",
+    "\n",
+    "Une **signature** FOL fixe le vocabulaire : quels **prédicats** (avec leur arité) et quelles **constantes**\n",
+    "représentent les objets nommés. Les **variables** (`X`, `Y`) dénotent des objets arbitraires ; les **constantes**\n",
+    "(`Socrate`) dénotent un objet précis. Un **atome** applique un prédicat à des termes.\n",
+    "\n",
+    "### 2.1 Construire un atome\n",
+    "\n",
+    "On importe les espaces de noms Tweety puis on instancie un prédicat unaire et on l'applique à un terme.\n",
+    "L'API C# expose les classes Java en PascalCase mais conserve **les méthodes Java en minuscules**\n",
+    "(`.add`, `.size`) — c'est la convention de port IKVM.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c297868",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:42.278500Z",
+     "iopub.status.busy": "2026-07-01T22:41:42.277888Z",
+     "iopub.status.idle": "2026-07-01T22:41:44.219572Z",
+     "shell.execute_reply": "2026-07-01T22:41:44.218731Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Homme(X)        = Homme(X)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Homme(Socrate)  = Homme(Socrate)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.commons.syntax;\n",
+    "using org.tweetyproject.logics.commons.syntax.interfaces;\n",
+    "using org.tweetyproject.logics.fol.syntax;\n",
+    "using org.tweetyproject.logics.fol.reasoner;\n",
+    "using org.tweetyproject.logics.fol.parser;\n",
+    "\n",
+    "// Un prédicat unaire \"Homme\" et une variable X\n",
+    "var Homme = new Predicate(\"Homme\", 1);\n",
+    "var X = new Variable(\"X\");\n",
+    "\n",
+    "// Atome Homme(X) : le prédicat appliqué à la variable\n",
+    "var hommeX = new FolAtom(Homme, X);\n",
+    "Console.WriteLine(\"Homme(X)        = \" + hommeX);\n",
+    "\n",
+    "// Une constante nommée Socrate\n",
+    "var socrate = new Constant(\"Socrate\");\n",
+    "var hommeSocrate = new FolAtom(Homme, socrate);\n",
+    "Console.WriteLine(\"Homme(Socrate)  = \" + hommeSocrate);\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m618654",
+   "metadata": {},
+   "source": [
+    "### 2.2 Atomes, prédicats et types de termes\n",
+    "\n",
+    "`FolAtom` accepte une liste variable de termes (`Predicate`, `params Term[]`) — l'arité du prédicat\n",
+    "doit correspondre au nombre de termes fournis. `Term` est une **interface** (`...syntax.interfaces.Term`)\n",
+    "implémentée à la fois par `Variable` et `Constant` : un atome est donc polymorphe sur ses arguments.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c697660",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:44.222641Z",
+     "iopub.status.busy": "2026-07-01T22:41:44.222110Z",
+     "iopub.status.idle": "2026-07-01T22:41:44.574978Z",
+     "shell.execute_reply": "2026-07-01T22:41:44.573507Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parent(Anne,Bob) = Parent(Anne,Bob)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parent(Anne,Y)   = Parent(Anne,Y)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Prédicat binaire : Parent(·,·) — arité 2\n",
+    "var Parent = new Predicate(\"Parent\", 2);\n",
+    "var anne = new Constant(\"Anne\");\n",
+    "var bob = new Constant(\"Bob\");\n",
+    "var parentAnneBob = new FolAtom(Parent, anne, bob);\n",
+    "Console.WriteLine(\"Parent(Anne,Bob) = \" + parentAnneBob);\n",
+    "\n",
+    "// Une variable peut figurer parmi les arguments (relation \"Anne est parent de quelqu'un\")\n",
+    "var Y = new Variable(\"Y\");\n",
+    "var parentAnneY = new FolAtom(Parent, anne, Y);\n",
+    "Console.WriteLine(\"Parent(Anne,Y)   = \" + parentAnneY);\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m585777",
+   "metadata": {},
+   "source": [
+    "## 3 — Connecteurs et quantificateurs\n",
+    "\n",
+    "Les connecteurs propositionnels (`Implication`, `Conjunction`, `Disjunction`, `Negation`) s'appliquent\n",
+    "aux formules FOL exactement comme en logique propositionnelle. La nouveauté est le **quantificateur**,\n",
+    "qui lie une variable à l'intérieur d'une formule :\n",
+    "\n",
+    "- **`ForallQuantifiedFormula(formule, variable)`** → `∀X formule`\n",
+    "- **`ExistsQuantifiedFormula(formule, variable)`** → `∃X formule`\n",
+    "\n",
+    "### 3.1 L'axiome classique : « tous les hommes sont mortels »\n",
+    "\n",
+    "`∀X (Homme(X) ⇒ Mortel(X))` se construit en emboîtant un `Implication` dans un `ForallQuantifiedFormula`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c159435",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:44.577962Z",
+     "iopub.status.busy": "2026-07-01T22:41:44.577402Z",
+     "iopub.status.idle": "2026-07-01T22:41:44.916598Z",
+     "shell.execute_reply": "2026-07-01T22:41:44.915722Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Homme(X) => Mortel(X) = (Homme(X)=>Mortel(X))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "∀X (Homme(X)=>Mortel(X)) = forall X: ((Homme(X)=>Mortel(X)))\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var Mortel = new Predicate(\"Mortel\", 1);\n",
+    "\n",
+    "// Homme(X) ⇒ Mortel(X)\n",
+    "var hommeX = new FolAtom(Homme, X);\n",
+    "var mortelX = new FolAtom(Mortel, X);\n",
+    "var impl = new Implication(hommeX, mortelX);\n",
+    "Console.WriteLine(\"Homme(X) => Mortel(X) = \" + impl);\n",
+    "\n",
+    "// ∀X (Homme(X) => Mortel(X))\n",
+    "var tousMortels = new ForallQuantifiedFormula(impl, X);\n",
+    "Console.WriteLine(\"∀X (Homme(X)=>Mortel(X)) = \" + tousMortels);\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m908739",
+   "metadata": {},
+   "source": [
+    "### 3.2 Existential : « il existe un mortel »\n",
+    "\n",
+    "`∃X Mortel(X)` ne quantifie qu'un atome. On réutilise le même atome `mortelX` (qui porte la variable `X`).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c375540",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:44.919705Z",
+     "iopub.status.busy": "2026-07-01T22:41:44.919148Z",
+     "iopub.status.idle": "2026-07-01T22:41:45.222181Z",
+     "shell.execute_reply": "2026-07-01T22:41:45.221696Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "∃X Mortel(X) = exists X: (Mortel(X))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "¬∃X Mortel(X) = !exists X: (Mortel(X))\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var existeMortel = new ExistsQuantifiedFormula(mortelX, X);\n",
+    "Console.WriteLine(\"∃X Mortel(X) = \" + existeMortel);\n",
+    "\n",
+    "// Négation d'une formule quantifiée : ¬∃X Mortel(X)  (\"personne n'est mortel\")\n",
+    "var personneMortel = new Negation(existeMortel);\n",
+    "Console.WriteLine(\"¬∃X Mortel(X) = \" + personneMortel);\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m633793",
+   "metadata": {},
+   "source": [
+    "## 4 — Raisonnement : le syllogisme\n",
+    "\n",
+    "On rassemble les axiomes dans un **ensemble de croyances** (`FolBeliefSet`, équivalent FOL du\n",
+    "`PlBeliefSet` propositionnel) puis on interroge le raisonneur.\n",
+    "\n",
+    "`SimpleFolReasoner` procède par **énumération des interprétations de Herbrand** : il construit\n",
+    "l'univers de Herbrand (les constantes apparaissant dans la base) et teste les formules sur les\n",
+    "interprétations possibles. C'est complet mais exponentiel — adapté à de petites bases pédagogiques.\n",
+    "\n",
+    "> **Syllogisme classique.** Des prémisses `∀X (Homme(X) ⇒ Mortel(X))` et `Homme(Socrate)`,\n",
+    "> on infère `Mortel(Socrate)`. En termes de conséquence logique : **KB ⊨ Mortal(Socrates)**.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c880179",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:45.225357Z",
+     "iopub.status.busy": "2026-07-01T22:41:45.224772Z",
+     "iopub.status.idle": "2026-07-01T22:41:45.778801Z",
+     "shell.execute_reply": "2026-07-01T22:41:45.777885Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB = { Homme(Socrate), forall X: ((Homme(X)=>Mortel(X))) }\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "taille KB = 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "KB ⊨ Mortel(Socrate) ?  true\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Base de croyances : l'axiome universel + le fait Homme(Socrate)\n",
+    "var kb = new FolBeliefSet();\n",
+    "kb.add(tousMortels);\n",
+    "kb.add(new FolAtom(Homme, socrate));\n",
+    "\n",
+    "Console.WriteLine(\"KB = \" + kb);\n",
+    "Console.WriteLine(\"taille KB = \" + kb.size());\n",
+    "\n",
+    "var r = new SimpleFolReasoner();\n",
+    "var mortelSocrate = new FolAtom(Mortel, socrate);\n",
+    "Console.WriteLine(\"\\nKB ⊨ Mortel(Socrate) ?  \" + r.query(kb, mortelSocrate));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m846460",
+   "metadata": {},
+   "source": [
+    "### 4.1 Contrôle négatif : ce qui n'est **pas** impliqué\n",
+    "\n",
+    "`Platon` n'apparaît dans aucune prémisse : `Homme(Platon)` n'est ni affirmé ni inférable.\n",
+    "Le raisonneur répond donc `false` à `KB ⊨ Mortel(Platon)` — la base est **sous-déterminée** pour Platon.\n",
+    "Ce `false` signifie « pas conséquence logique », **pas** « conséquence logique du contraire ».\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c743358",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:45.782177Z",
+     "iopub.status.busy": "2026-07-01T22:41:45.781589Z",
+     "iopub.status.idle": "2026-07-01T22:41:46.105797Z",
+     "shell.execute_reply": "2026-07-01T22:41:46.105263Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB ⊨ Mortel(Platon) ?  false\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB ⊨ Homme(Platon) ?  false\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var platon = new Constant(\"Platon\");\n",
+    "var mortelPlaton = new FolAtom(Mortel, platon);\n",
+    "Console.WriteLine(\"KB ⊨ Mortel(Platon) ?  \" + r.query(kb, mortelPlaton));\n",
+    "\n",
+    "// Idem : Homme(Platon) n'est pas impliqué non plus\n",
+    "Console.WriteLine(\"KB ⊨ Homme(Platon) ?  \" + r.query(kb, new FolAtom(Homme, platon)));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m991269",
+   "metadata": {},
+   "source": [
+    "### 4.2 Généralisation existentielle\n",
+    "\n",
+    "Si `Mortel(Socrate)` est conséquence, alors `∃X Mortel(X)` l'est aussi : il **existe** au moins un mortel\n",
+    "(Socrate). C'est la règle d'**introduction du quantificateur existentiel**. Le raisonneur le confirme\n",
+    "directement sur la formule quantifiée.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c46812",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:46.109564Z",
+     "iopub.status.busy": "2026-07-01T22:41:46.108767Z",
+     "iopub.status.idle": "2026-07-01T22:41:46.352784Z",
+     "shell.execute_reply": "2026-07-01T22:41:46.351819Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB ⊨ ∃X Mortel(X) ?  true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB ⊨ ∀X Mortel(X) ?    false\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "Console.WriteLine(\"KB ⊨ ∃X Mortel(X) ?  \" + r.query(kb, existeMortel));\n",
+    "\n",
+    "// Symétriquement, ∀X Mortel(X) n'est PAS impliqué : seuls les hommes connus le sont\n",
+    "var tousMortels2 = new ForallQuantifiedFormula(mortelX, X);\n",
+    "Console.WriteLine(\"KB ⊨ ∀X Mortel(X) ?    \" + r.query(kb, tousMortels2));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m359571",
+   "metadata": {},
+   "source": [
+    "### 4.3 Une KB plus riche : raisonnement sur plusieurs faits\n",
+    "\n",
+    "Ajoutons un second fait `Homme(Platon)` et un prédicat `Grec`. On vérifie que le syllogisme se propage\n",
+    "à tous les hommes connus, et qu'un énoncé mixte `∃X (Grec(X) ∧ Mortel(X))` devient conséquence dès\n",
+    "qu'au moins un Grec mortel est dans la base.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c615894",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:46.355759Z",
+     "iopub.status.busy": "2026-07-01T22:41:46.355230Z",
+     "iopub.status.idle": "2026-07-01T22:41:46.829983Z",
+     "shell.execute_reply": "2026-07-01T22:41:46.829008Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB2 ⊨ Mortel(Socrate) ? true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB2 ⊨ Mortel(Platon) ?  true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB2 ⊨ ∃X (Grec(X) ∧ Mortel(X)) ? true\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var Grec = new Predicate(\"Grec\", 1);\n",
+    "var kb2 = new FolBeliefSet();\n",
+    "kb2.add(tousMortels);                       // ∀X (Homme(X) => Mortel(X))\n",
+    "kb2.add(new FolAtom(Homme, socrate));       // Homme(Socrate)\n",
+    "kb2.add(new FolAtom(Homme, platon));        // Homme(Platon)\n",
+    "kb2.add(new FolAtom(Grec, socrate));        // Grec(Socrate)\n",
+    "\n",
+    "Console.WriteLine(\"KB2 ⊨ Mortel(Socrate) ? \" + r.query(kb2, new FolAtom(Mortel, socrate)));\n",
+    "Console.WriteLine(\"KB2 ⊨ Mortel(Platon) ?  \" + r.query(kb2, new FolAtom(Mortel, platon)));\n",
+    "\n",
+    "// ∃X (Grec(X) ∧ Mortel(X)) : \"il existe un Grec mortel\"\n",
+    "var grecX = new FolAtom(Grec, X);\n",
+    "var existeGrecMortel = new ExistsQuantifiedFormula(\n",
+    "    new Conjunction(grecX, mortelX), X);\n",
+    "Console.WriteLine(\"KB2 ⊨ ∃X (Grec(X) ∧ Mortel(X)) ? \" + r.query(kb2, existeGrecMortel));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m967528",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "> Les exercices sont à compléter. Conformément à la convention du dépôt, les stubs **ne lèvent jamais\n",
+    "> d'erreur** (`raise`/`throw` interdits) : ils retournent `null` / affichent un message. Le notebook\n",
+    "> s'exécute donc de bout en bout même non complété.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m283487",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Le chat mammifère\n",
+    "\n",
+    "Construisez programmatiquement l'axiome `∀X (Chat(X) ⇒ Mammifère(X))`, ajoutez le fait `Chat(Felix)`,\n",
+    "puis vérifiez que `KB ⊨ Mammifère(Felix)` vaut `true`. Créez les prédicats `Chat` et `Mammifère` (arité 1)\n",
+    "et la constante `Felix`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c525316",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:46.833008Z",
+     "iopub.status.busy": "2026-07-01T22:41:46.832471Z",
+     "iopub.status.idle": "2026-07-01T22:41:47.181860Z",
+     "shell.execute_reply": "2026-07-01T22:41:47.181198Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB ⊨ Mammifere(Felix) ? Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// TODO etudiant : construire la base et le raisonneur\n",
+    "// Indice : suivez la structure de la section 4 (Predicate, Constant, FolAtom, Implication,\n",
+    "//          ForallQuantifiedFormula, FolBeliefSet.add, SimpleFolReasoner.query).\n",
+    "// Etape 1 : déclarer les prédicats Chat / Mammifere et la constante Felix.\n",
+    "// Etape 2 : construire ∀X (Chat(X) => Mammifere(X)) et Chat(Felix).\n",
+    "// Etape 3 : interroger KB |= Mammifere(Felix).\n",
+    "bool? reponse = null;  // TODO etudiant : affecter le resultat de la requete\n",
+    "Console.WriteLine(\"KB ⊨ Mammifere(Felix) ? \" + (reponse?.ToString() ?? \"Exercice a completer\"));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m561725",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Transitivité : grand-parent\n",
+    "\n",
+    "Avec un prédicat binaire `Parent(·,·)`, on veut définir « grand-parent » sans nouveau prédicat :\n",
+    "`∀X ∀Y ∀Z (Parent(X,Y) ∧ Parent(Y,Z) ⇒ GrandParent(X,Z))`. Construisez cette formule à partir de\n",
+    "deux quantificateurs universels emboîtés et affichez-la.\n",
+    "\n",
+    "**Indice :** `ForallQuantifiedFormula` ne lie qu'**une** variable à la fois ; pour `∀X ∀Y ∀Z` il faut\n",
+    "emboîter **trois** constructeurs (le plus externe lie `Z`, l'intermédiaire lie `Y`, l'interne lie `X`).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c712763",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:47.184867Z",
+     "iopub.status.busy": "2026-07-01T22:41:47.184318Z",
+     "iopub.status.idle": "2026-07-01T22:41:47.431539Z",
+     "shell.execute_reply": "2026-07-01T22:41:47.431054Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GrandParent = Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// TODO etudiant : construire la formule GrandParent\n",
+    "// Indice : declarez Z = new Variable(\"Z\"); construisez l'implication,\n",
+    "//          puis ForallQuantifiedFormula(... X) dans ForallQuantifiedFormula(... Y) dans ForallQuantifiedFormula(... Z).\n",
+    "object formuleGrandParent = null;  // TODO etudiant\n",
+    "Console.WriteLine(\"GrandParent = \" + (formuleGrandParent?.ToString() ?? \"Exercice a completer\"));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m104860",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Détection d'inconsistance\n",
+    "\n",
+    "Une base est **inconsistante** si elle implique une contradiction (ex. à la fois `P(a)` et `¬P(a)`).\n",
+    "Avec `SimpleFolReasoner`, une KB inconsistante implique **toute** formule (*ex falso quodlibet*).\n",
+    "\n",
+    "Ajoutez à une KB les faits `Mortel(Socrate)` et `¬Mortel(Socrate)`, puis vérifiez que\n",
+    "`KB ⊨ Homme(Socrate)` vaut `true` (principe d'explosion) — bien qu'aucun axiome ne parle d'`Homme`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c545430",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-01T22:41:47.434462Z",
+     "iopub.status.busy": "2026-07-01T22:41:47.433942Z",
+     "iopub.status.idle": "2026-07-01T22:41:47.633142Z",
+     "shell.execute_reply": "2026-07-01T22:41:47.631478Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KB inconsistante ⊨ Homme(Socrate) ? Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// TODO etudiant : mettre en evidence le principe d'explosion\n",
+    "// Indice : kb.add(FolAtom Mortel(Socrate)) ; kb.add(new Negation(FolAtom Mortel(Socrate))).\n",
+    "//          Puis interrogez KB |= Homme(Socrate) sur un prédicat Homme non lie par vos axiomes.\n",
+    "bool? explosion = null;  // TODO etudiant\n",
+    "Console.WriteLine(\"KB inconsistante ⊨ Homme(Socrate) ? \" + (explosion?.ToString() ?? \"Exercice a completer\"));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m641676",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "On a porté en C#/.NET natif (sans JVM) le raisonnement **du premier ordre** via Tweety/IKVM :\n",
+    "\n",
+    "1. **Construction programmatique** des formules FOL — termes (`Variable`/`Constant`), prédicats (`Predicate`),\n",
+    "   atomes (`FolAtom`), connecteurs (`Implication`/`Conjunction`/`Negation`), quantificateurs\n",
+    "   (`ForallQuantifiedFormula`/`ExistsQuantifiedFormula`).\n",
+    "2. **Raisonnement sémantique** par énumération de Herbrand (`SimpleFolReasoner.query`) — le syllogisme\n",
+    "   `∀X (Homme(X) ⇒ Mortel(X)), Homme(Socrate) ⊨ Mortel(Socrate)`, le contrôle négatif, la généralisation\n",
+    "   existentielle, et une KB multi-faits.\n",
+    "\n",
+    "### FOL vs propositionnel — ce que FOL apporte\n",
+    "\n",
+    "| Aspect | Propositionnel (Tweety-2) | Premier ordre (ce notebook) |\n",
+    "|--------|---------------------------|------------------------------|\n",
+    "| Objets du discours | propositions atomiques entières | **termes** (variables + constantes) |\n",
+    "| Généralité | impossible | **`∀`** (pour tout) |\n",
+    "| Existence | impossible | **`∃`** (il existe) |\n",
+    "| Structure interne d'un énoncé | plate | prédicat appliqué à des termes |\n",
+    "| Raisonneur | tables de vérité / mondes | énumération de Herbrand |\n",
+    "\n",
+    "### Références\n",
+    "\n",
+    "- TweetyProject — [FOL module](https://tweetyproject.org/api/fol/) et [tutoriels](https://tweetyproject.org/).\n",
+    "- Port C#/.NET via IKVM — EPIC [#4667](https://github.com/jsboige/CoursIA/issues/4667).\n",
+    "- Notebook compagnon propositionnel : [Tweety-2-Basic-Logics-Csharp](Tweety-2-Basic-Logics-Csharp.ipynb).\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Port de la **logique du premier ordre** (FOL) vers C#/.NET via Tweety/IKVM — **sans JVM à l'exécution**. Suite de #4802 (Tweety-2b-Semantics, cluster `pl` C# complet). EPIC #4667.

## Contenu

Construction programmatique des formules FOL + raisonnement sémantique par énumération de Herbrand :

- **Termes** : `Variable`, `Constant` (`org.tweetyproject.logics.commons.syntax`)
- **Prédicats & atomes** : `Predicate(name, arity)`, `FolAtom(pred, params Term[])`
- **Connecteurs** : `Implication`, `Conjunction`, `Negation`
- **Quantificateurs** : `ForallQuantifiedFormula`, `ExistsQuantifiedFormula`
- **Raisonneur** : `SimpleFolReasoner().query(FolBeliefSet, FolFormula) → Boolean`

### Démonstrations (exec réelle)

- Syllogisme classique : `∀X (Homme(X) ⇒ Mortel(X)), Homme(Socrate) ⊨ Mortel(Socrate)` → **true**
- Contrôle négatif : `⊨ Mortel(Platon)` → **false** (Platon absent des prémisses)
- Généralisation existentielle : `⊨ ∃X Mortel(X)` → **true** ; `⊨ ∀X Mortel(X)` → **false**
- KB enrichie multi-faits : les deux hommes mortels + `∃X (Grec(X) ∧ Mortel(X))` → **true**

## Découverte API (G.1, pas d'invention)

API découverte **firsthand par réflexion** sur l'assembly chargé (`typeof(SatReasoner).Assembly`). Le module `fol` est **déjà présent transitivement** dans le fat-jar `tweety-pl` existant (compilé en #4792) — **aucun re-shade nécessaire** pour ce notebook (gain de temps notable vs dung/asp qui nécessiteront re-shade).

## Exercices (3, C.1-compliant)

1. **Le chat mammifère** — construire `∀X (Chat(X) ⇒ Mammifère(X))` + `Chat(Felix)`, vérifier `⊨ Mammifère(Felix)`
2. **Grand-parent transitif** — emboîter 3 `ForallQuantifiedFormula` pour `∀X∀Y∀Z (Parent(X,Y) ∧ Parent(Y,Z) ⇒ GrandParent(X,Z))`
3. **Principe d'explosion** — KB inconsistante (`P(a)` ∧ `¬P(a)`) implique toute formule

Stubs sans `raise`/`throw` (convention C.1) : `bool? reponse = null` + message « Exercice a completer ». Le notebook s'exécute de bout en bout même non complété.

## Validation (H.1-H.3)

- `jupyter nbconvert --execute` end-to-end via kernel `.net-csharp` : **EXIT=0, 0 erreurs**
- 14 cellules code, toutes `execution_count` peuplés + outputs cohérents (C.2)
- H.3 pre-commit : aucune cellule code non-exécutée
- C.1 scan source-only : **0 violation** (`raise`/`throw`/`NotImplemented`/`1/0`)
- Catalogue byte-identique à `origin/main` (règle catalog)

See #4667

🤖 Generated with [Claude Code](https://claude.com/claude-code)