### PR TITLE
feat(hashlife): centralCorrect_mem_shift — offset-generalized membership gate (P4.4 G2, sorry 4->4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2027,6 +2027,47 @@ theorem centralCorrect_mem (c : MacroCell) (j : Nat) (p : Int × Int)
           fun ⟨H, h1, h2, h3, h4⟩ => ⟨?_, h1, h2, h3, h4⟩⟩ <;>
     simp_all [isAlive]
 
+/-- **Offset-generalized centralCorrect membership** (P4.4 offset-matching G2 gate).
+
+    `centralCorrect_mem` characterizes membership of a cell's result at its
+    *canonical* centered offset `(2^j, 2^j)`. The P4.4 offset-matching assembly
+    needs the same characterization at the **quadrant offsets** where the
+    super-cells `q_*` actually sit in the parent result node (e.g. NW quadrant at
+    `(2^k, 2^k)`, per `mem_toGrid_node`). This lemma re-anchors
+    `centralCorrect_mem` from `(2^j, 2^j)` to an arbitrary offset `(a, b)` via
+    `toGrid_shift_between`: the alive-status is evaluated at the back-shifted
+    point `(p.1 - a + 2^j, p.2 - b + 2^j)`, and the centered window bounds
+    `[2^j, 2^j + 2^(j+1))` translate to `[a, a + 2^(j+1))` (and `[b, b + 2^(j+1))`).
+
+    Pure composition of `centralCorrect_mem` (G2 congruence, c.153) and
+    `toGrid_shift_between` (#4797, the double-shift ingredient) — sorry-free gate
+    ingredient. The residual research heart (sorry 4→3) is `evolve_half_step`,
+    which consumes this gate to connect the induction hypothesis
+    `centralCorrect q_* (k-1)` to the four quadrant offsets at once. -/
+theorem centralCorrect_mem_shift (c : MacroCell) (j : Nat) (a b : Int) (p : Int × Int)
+    (h : centralCorrect c j) :
+    p ∈ (hashlifeResultAux (j + 2) c).toGrid (a, b) ↔
+      isAlive (evolve (2^j) (c.toGrid (0, 0)))
+        (p.1 - a + (2^j : Int), p.2 - b + (2^j : Int)) = true ∧
+      a ≤ p.1 ∧ p.1 < a + 2^(j+1) ∧
+      b ≤ p.2 ∧ p.2 < b + 2^(j+1) := by
+  -- Re-anchor `(a,b)` → the canonical `(2^j,2^j)` offset. `centralCorrect_mem`'s
+  -- canonical offset is the Nat-cast `↑(2^j)` (the display of `(2^j : Nat)`
+  -- coerced to Int), so we instantiate `toGrid_shift_between` with
+  -- `a' = b' = (2^j : Nat)` to match its rewrite pattern (native `(2^j : Int)`
+  -- would not unify — the c.146/c.147 native-Int-vs-Nat-cast distinction).
+  have hshift : p ∈ (hashlifeResultAux (j + 2) c).toGrid (a, b) ↔
+      (p.1 - a + (2^j : Nat), p.2 - b + (2^j : Nat)) ∈
+        (hashlifeResultAux (j + 2) c).toGrid ((2^j : Nat), (2^j : Nat)) :=
+    toGrid_shift_between
+  rw [hshift, centralCorrect_mem c j _ h]
+  -- `centralCorrect_mem`'s bounds carry native `(2^j : Int)` literals, while the
+  -- substituted point carries `↑(2^j)` (Nat-cast). Normalize to a single atom
+  -- (c.146: linarith otherwise sees `↑(2^j)` and `(2^j : Int)` as unrelated).
+  rw [show ((2 : Nat)^j).cast = (2^j : Int) from Nat.cast_pow 2 j]
+  refine ⟨fun ⟨H, h1, h2, h3, h4⟩ => ⟨H, ?_, ?_, ?_, ?_⟩,
+          fun ⟨H, h1, h2, h3, h4⟩ => ⟨H, ?_, ?_, ?_, ?_⟩⟩ <;> linarith
+
 /-- **P4.2 helper (c.139 workaround).** The `ih` *application*
     `ih (node nw_se ne_sw sw_ne se_nk) (k-1) ...` diverges on `whnf` when it
     appears inline inside `p4_wave1_ih`'s body, because there the four


### PR DESCRIPTION
## Summary

Add `centralCorrect_mem_shift`, the **offset-generalized membership gate** (G2 ingredient) for the P4.4 offset-matching assembly — the next step of the Hashlife sorry-4→3 campaign per ai-01's deep-queue dispatch (`msg-…-d31lg1`, step 1).

`centralCorrect_mem` (c.153 whnf-wall bypass) characterizes a cell's result membership only at the **canonical** centered offset `(2^j, 2^j)`. The offset-matching assembly (`p4_succ_membership` sorry) needs the same characterization at the four **quadrant offsets** where the super-cells `q_*` sit in the parent result node (NW `(2^k,2^k)`, NE `(2^k,2^(k+1))`, SW, SE — per `mem_toGrid_node`). `centralCorrect_mem_shift` re-anchors from `(2^j,2^j)` to an arbitrary `(a,b)`:

- alive-status evaluated at the back-shifted point `(p.1 − a + 2^j, p.2 − b + 2^j)`;
- centered window `[2^j, 2^j + 2^(j+1))²` translates to `[a, a + 2^(j+1)) × [b, b + 2^(j+1))`.

Pure composition of `centralCorrect_mem` (G2 congruence) + `toGrid_shift_between` (#4797 double-shift) — sorry-free gate. The residual research heart (sorry 4→3) is the G3 bridge inside `p4_succ_membership`: connect `evolve 2^(k-1)(q_*)` to `evolve 2^k(c)` via `evolve_half_step` + `step_light_cone`. This gate is consumed there.

## Lean §B checklist

**1. sorry count (token grep, c.139 authoritative — `declaration uses sorry` warnings are NOT reliable):**

```
$ grep -nE '^\s*sorry\s*$|:= by sorry|:= sorry\b|exact sorry|^\s*· sorry' HashlifeCorrectness.lean | wc -l
4   # UNCHANGED (4 → 4)
```

The four residual sorries are the pre-existing stubs: `p4_half_steps_compose` (True placeholder), `p4_succ_membership` (the assembly — next campaign target), `p5_large_n_jump`, `p5_inductive_step`. The new lemma `centralCorrect_mem_shift` (L2047) is **sorry-free** (verified: `sed -n '2047,2070p' | grep sorry` → empty).

**2. Lake build SUCCESS (local, ai-01 machine myia-po-2026):**

```
$ lake.exe build Conway.Life.HashlifeCorrectness
Build completed successfully (3320 jobs).
=== EXIT: 0 ===
```

Toolchain `leanprover/lean4:v4.30.0-rc2`, Mathlib junction `54f98fd6` rc2 (conway_lean is a Mathlib-dependent lake, not in the #4803 no-dep cohort).

**3. Proof integrity (axioms):** the lemma composes sorry-free lemmas (`centralCorrect_mem`, `toGrid_shift_between`, `Nat.cast_pow`) closed by `linarith`; it introduces **no new axiom** and uses no `sorryAx`. (A full `#print axioms` pass will be run at the campaign close with the other sorry-free gates.)

**4. No prover-Python refactor** — pure Lean addition, single theorem, single file. `+41/−0`.

## Proof notes (c.146/c.147 lessons)

- `toGrid_shift_between` instantiated with `a' = b' = (2^j : Nat)` to match `centralCorrect_mem`'s Nat-cast `↑(2^j)` rewrite pattern — native `(2^j : Int)` does not unify (the native-Int-vs-Nat-cast distinction documented in c.146/c.147).
- `Nat.cast_pow 2 j` normalizes the mixed `↑(2^j)` (from the substituted point) and `(2^j : Int)` (from `centralCorrect_mem`'s bound literals) to a single atom before `linarith` — otherwise linarith sees them as unrelated atoms (c.146).
- All 8 bound-transformation goals close with `linarith` (the `2^j` atom cancels; `2^(j+1)` is a consistent atom on both sides).

See #3846
