### PR TITLE
docs(qc): align research README with M12-HF + RL verdicts (#3976)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/research/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/research/README.md
@@ -10,7 +10,10 @@ Independent research using local data (yfinance, pandas, sklearn). No QuantConne
 | `research_composite_ff_aw.ipynb` | FamaFrench + AllWeather composite | (c) Standalone | yfinance |
 | `research_composite_mom_regime.ipynb` | Momentum + Regime composite | (c) Standalone | yfinance |
 | `research_m11ef_ensemble.ipynb` | Ensemble methods | (c) Standalone | yfinance |
-| `research_m12_har_rv_j.ipynb` | HAR-RV-J volatility model | (c) Standalone | yfinance |
+| `research_m12_har_rv_j.ipynb` | HAR-RV-J volatility model (hourly) | (c) Standalone | yfinance |
+| `research_m12_har_rv_j_minute.ipynb` | M12-HF : variante minute (QuantBook QC Cloud) | (c) Standalone | QC Cloud crypto |
+| `research_m12_hf_btc_local.ipynb` | M12-HF : verdict BTC minute vs hourly (local) | (c) Standalone | BTC tick Bitstamp |
+| `research_m12_hf_dm_test.ipynb` | M12-HF : test de significativité Diebold-Mariano | (c) Standalone | BTC tick Bitstamp |
 | `research_quality_lowvol.ipynb` | Quality + Low Vol factor | (c) Standalone | yfinance |
 | `research_risk_parity.ipynb` | Risk parity allocation | (c) Standalone | yfinance |
 | `research_rl_grpo.ipynb` | RL GRPO trading agent | (c) Standalone | yfinance |
@@ -21,7 +24,7 @@ Independent research using local data (yfinance, pandas, sklearn). No QuantConne
 | `research_rl_tactical_overlay.ipynb` | RL tactical overlay | (c) Standalone | yfinance |
 | `research_vrp_putwrite.ipynb` | VRP put-write strategy | (c) Standalone | yfinance |
 
-All 14 notebooks are type **(c) standalone research**. Executable locally with `pip install yfinance pandas matplotlib scikit-learn`.
+All 17 notebooks are type **(c) standalone research**. La plupart s'exécutent localement avec `pip install yfinance pandas matplotlib scikit-learn` ; la famille M12-HF (3 notebooks) utilise des données tick BTC Bitstamp possédées (agrégées en minute localement), et la variante `_minute` est un QuantBook à exécuter sur QC Cloud.
 
 ---
 
@@ -29,10 +32,10 @@ All 14 notebooks are type **(c) standalone research**. Executable locally with `
 
 ### Ce que vous avez appris
 
-Ces **14 notebooks standalone** sont le **laboratoire local** de la série QuantConnect : ils ne nécessitent **pas** de compte QC Cloud ni de données payantes — `yfinance` (données gratuites) + `pandas` / `scikit-learn` suffisent. Ils illustrent deux familles de recherche :
+Ces **17 notebooks standalone** sont le **laboratoire local** de la série QuantConnect : ils ne nécessitent **pas** de compte QC Cloud ni de données payantes — `yfinance` (données gratuites) + `pandas` / `scikit-learn` suffisent (la famille M12-HF utilise des données tick BTC possédées). Ils illustrent deux familles de recherche :
 
-- **Recherche factorielle & allocation** (HAR-RV-J vol, FamaFrench + AllWeather composite, Momentum + Regime, Quality/LowVol, Risk Parity, VRP put-write) — on apprend que les modèles de volatilité et d'allocation robuste sont reproductibles en local sur données publiques, et que les composites (M12, M11ef) sont les briques des stratégies *Robuste* du catalogue.
-- **Recherche Reinforcement Learning** (intro, PPO, GRPO, reward shaping, multi-asset, tactical overlay) — on apprend que le RL trading se prototypé localement avant tout déploiement QC Cloud, et que le *reward shaping* est le levier le plus sensible (un reward mal spécifié fige la policy).
+- **Recherche factorielle & allocation** (HAR-RV-J vol, FamaFrench + AllWeather composite, Momentum + Regime, Quality/LowVol, Risk Parity, VRP put-write) — on apprend que les modèles de volatilité et d'allocation robuste sont reproductibles en local sur données publiques, et que les composites (M12, M11ef) sont les briques des stratégies *Robuste* du catalogue. **Verdict honnête M12-HF** (`research_m12_hf_btc_local.ipynb` + `research_m12_hf_dm_test.ipynb`) : l'estimation de la realized variance en minute **bat** celle en hourly (delta médian +0.548, MSE minute ~moitié hourly), statistiquement validée par un test de Diebold-Mariano (HAC, p≈0.000) et un block-bootstrap dont l'IC95 est entièrement négatif. La cause du gain est cependant la **fréquence d'échantillonnage** (qualité de l'estimateur RV, Andersen-Bollerslev-Diebold 2003), **pas** la composante de jump — HAR-Classic sans jump montre le même gain. Leçon méthodologique : la résolution hourly (24 bars/jour) est trop bruitée pour le vol-targeting Kelly ; la minute (1440 bars/jour) l'est beaucoup moins.
+- **Recherche Reinforcement Learning** (intro, PPO, GRPO, reward shaping, multi-asset, tactical overlay) — on apprend que le RL trading se prototypé localement avant tout déploiement QC Cloud, et que le *reward shaping* est le levier le plus sensible (un reward mal spécifié fige la policy). **Leçon d'intégrité #3360** : diviser la reward portfolio-level par le nombre d'actifs (`reward / N_ASSETS`) détruit le signal du critic per-asset → la policy gèle près de l'uniforme → l'argmax collapse vers Buy (fingerprint buy-and-hold, Sharpe 0.657 identique au collapse PPO). Corrigé : la reward portfolio complète alimente chaque transition per-asset (cohérence #3359/#3360). Verdict ré-évalué honnête après fix : NO BEATS (A2C Sharpe 0.000, SAC −0.063 sur univers non-FAANG) — pour la bonne raison.
 
 Le fil rouge : **l'indépendance de la plateforme**. Ces notebooks prouvent que l'idéation et la validation ML peuvent se faire hors QC Cloud ; le cloud n'est requis que pour le backtest haute-fidélité sur données natives.
 


### PR DESCRIPTION
## Summary

Markdown-only refresh of `MyIA.AI.Notebooks/QuantConnect/research/README.md` — a bounded slice of the **#3976** README-feuilles sweep (child of **#3973** README ascendant). `See #3976`.

The notebook table listed **14** entries while the folder holds **17**; the 3 M12-HF notebooks delivered by PRs #4243/#4255/#4452 were missing, and the conclusion did not reflect the honest verdicts.

## Changes (+8/-5, markdown-only, 0 catalog marker in this file)

1. **Table** — add 3 M12-HF rows with accurate data sources:
   - `research_m12_har_rv_j_minute.ipynb` — M12-HF minute variant (QuantBook QC Cloud)
   - `research_m12_hf_btc_local.ipynb` — M12-HF BTC verdict minute vs hourly (BTC tick Bitstamp)
   - `research_m12_hf_dm_test.ipynb` — M12-HF Diebold-Mariano significance test (BTC tick Bitstamp)
2. **Counts** — 14 → 17 (table caption + conclusion).
3. **Conclusion — Factorielle** — honest M12-HF verdict: minute RV beats hourly (delta médian +0.548, MSE minute ~moitié hourly), Diebold-Mariano HAC p≈0.000 + block-bootstrap IC95<0. Cause = sampling frequency (ABDL 2003), **not** jumps (HAR-Classic shows the same gain).
4. **Conclusion — RL** — #3360 reward-coherence lesson: `reward / N_ASSETS` freezes the per-asset critic → buy-and-hold fingerprint (Sharpe 0.657 == PPO collapse). Post-fix honest verdict: NO BEATS (A2C 0.000, SAC −0.063 on non-FAANG universe) for the right reason.

## Grounding (G.1 firsthand)

- Folder inventory verified via `git ls-tree origin/main` (17 notebooks).
- M12-HF verdict verified against merged PRs #4255 (BTC local) + #4452 (DM test), both with real C.2 outputs (5/5 and 7/7 cells executed).
- RL verdict verified against origin/main post-#4785 (FAANG dropped → BAC/KO/PFE/CVX/LLY/COST; `reward / N_ASSETS` removed).
- FR prose per readme-french-first rule. Branch rebased fresh from `origin/main` (catalog-pr-hygiene rule 2).

`See #3976` `See #3973`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)