### PR TITLE
fix(owui-playwright): verified v0.10.2 fr-FR account/memory selectors

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/helpers/selectors.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/helpers/selectors.ts
@@ -87,6 +87,24 @@ export const SIDEBAR = {
   searchContainer: '#search-container',
 } as const;
 
+// --- Compte / menu utilisateur ---
+// VERIFIE firsthand contre v0.10.2 fr-FR (2026-07, lors de la generation des
+// captures du Tour). Le bouton avatar (bas de la sidebar) porte l'aria-label
+// localise "Menu utilisateur" (fr) / "User menu" (en) et n'a pas d'ID stable.
+// Les entrees du menu (Reglages, Conversations archivees, Deconnexion...) sont
+// des <button> cibles par leur libelle via getByRole('button', { name }).
+export const ACCOUNT = {
+  // Bouton avatar ouvrant le menu utilisateur.
+  menuButton:
+    'button[aria-label="Menu utilisateur"], button[aria-label="User menu" i]',
+  // ATTENTION v0.10.2 fr : l'entree des reglages s'appelle "Reglages"
+  // (PAS "Parametres"). Regex tolerante pour les deux libelles fr + l'anglais.
+  settingsEntry: /r[ée]glages|param[èe]tres|settings/i,
+  // Autres entrees du menu (multilingue)
+  logout: /d[ée]connexion|log ?out|sign ?out/i,
+  archivedChats: /conversations archiv[ée]es|archived chats/i,
+} as const;
+
 // =====================================================================
 // Nouveautes v0.10 (voir module 06)
 // =====================================================================
@@ -116,7 +134,19 @@ export const FOLDER = {
 } as const;
 
 // --- Memoire (v0.10 : refonte, sort de beta) ---
+// Chemin VERIFIE firsthand contre v0.10.2 fr-FR (2026-07) :
+//   ACCOUNT.menuButton -> ACCOUNT.settingsEntry ("Reglages")
+//   -> personalizationTab ("Personnalisation") -> manageButton ("Gerer")
+//   -> fenetre "Memoire N" (emptyState visible sur un compte neuf).
 export const MEMORY = {
-  // Section "Memoire" dans Parametres > Personnalisation (libelle multilingue)
+  // Onglet "Personnalisation" dans la fenetre Reglages
+  personalizationTab: /personnalisation|personalization/i,
+  // Bouton "Gerer" de la section Memoire (ouvre la fenetre de gestion)
+  manageButton: /g[ée]rer|manage/i,
+  // Etat vide (compte neuf) dans la fenetre de gestion de la memoire
+  emptyState: /aucun|les souvenirs|no memories|seront affich/i,
+  // Bouton d'ajout d'un souvenir
+  addButton: /ajouter un souvenir|add memory/i,
+  // (conserve) libelle multilingue de la section (compat module 06)
   settingsLabel: /m[ée]moire|memory|personnalisation|personalization/i,
 } as const;


### PR DESCRIPTION
## Contexte

Aval direct de la **montée de flotte OWUI en v0.10.2** (7 tenants). La série QA `Playwright-OWUI/` s'exécute désormais contre cette version. En générant les captures du Tour (PR #4809), j'ai **vérifié firsthand** contre une instance **v0.10.2 fr-FR** que la chaîne compte/mémoire avait dérivé — les sections `MEMORY`/`REASONING`/`FOLDER` du `helpers/selectors.ts` étaient explicitement marquées « À CONFIRMER contre l'UI live ».

Epic #4433 (sous #4427). Worker `myia-ai-01:myia-open-webui`.

## Changement (`helpers/selectors.ts`, additif uniquement)

- **`ACCOUNT` (nouveau)** : bouton avatar du menu utilisateur (`aria-label="Menu utilisateur"` fr / `"User menu"` en, pas d'ID stable) + entrée réglages. **Piège v0.10.2 fr** : le libellé est **« Réglages », PAS « Paramètres »** — l'ancienne hypothèse cassait silencieusement la navigation vers les réglages.
- **`MEMORY` (étendu)** : chaîne vérifiée `personalizationTab` → `manageButton` (« Gérer ») → `emptyState` / `addButton`. `settingsLabel` **conservé** pour compat module 06.

## Sûreté / non-régression

- **Additif** : aucune clé existante modifiée. `grep` firsthand : **aucun spec n'importe `MEMORY`/`ACCOUNT`** aujourd'hui → rien ne casse.
- `REASONING`/`FOLDER` **laissés tels quels** (non confirmés firsthand — honnêteté sur le périmètre vérifié).
- Vérif firsthand : chaîne `Menu utilisateur → Réglages → Personnalisation → Gérer → « Mémoire 0 »` (a produit `05-memoire.png` de #4809).

## Coordination

Chemin `GenAI/Open-WebUI/**` : **aucune PR ouverte concurrente vérifiée** avant de brancher (collision-free). Petite PR chirurgicale de maintenance de sélecteurs, aval de l'upgrade. Si po-2023/ai-01 considèrent ce fichier comme turf actif, fermez sans souci — c'est additif et sans enjeu. **Review+merge ai-01** (pas de self-merge, #4427).

🤖 Generated with [Claude Code](https://claude.com/claude-code)