### PR TITLE
fix(vibe-coding): restore accents in CONCEPTS-AVANCES doc (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CONCEPTS-AVANCES.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CONCEPTS-AVANCES.md
@@ -1,6 +1,6 @@
 # Concepts Avances de Claude Code
 
-Ce document approfondit les concepts cles de Claude Code : **Slash Commands**, **Skills**, **Subagents**, **Hooks**, **Permissions**, **Sandbox** et **MCP**. Ces fonctionnalites permettent de personnaliser et d'etendre considerablement les capacites de l'assistant.
+Ce document approfondit les concepts clés de Claude Code : **Slash Commands**, **Skills**, **Subagents**, **Hooks**, **Permissions**, **Sandbox** et **MCP**. Ces fonctionnalités permettent de personnaliser et d'étendre considérablement les capacités de l'assistant.
 
 > **Documentation officielle** : [code.claude.com/docs](https://code.claude.com/docs)
 
@@ -10,7 +10,7 @@ Ce document approfondit les concepts cles de Claude Code : **Slash Commands**, *
 1. [Skills (Compétences)](#skills-compétences)
 1. [Subagents (Sous-agents)](#subagents-sous-agents)
 1. [Hooks (Déclencheurs)](#hooks-déclencheurs)
-1. [Permissions et Securite](#permissions-et-securite)
+1. [Permissions et Sécurité](#permissions-et-securite)
 1. [Sandbox](#sandbox)
 1. [MCP (Model Context Protocol)](#mcp-model-context-protocol)
 1. [Comparaison et Cas d'Usage](#comparaison-et-cas-dusage)
@@ -672,27 +672,27 @@ hooks:
 
 ### Securite des Hooks
 
-Claude Code inclut une protection : les modifications directes des fichiers de configuration de hooks necessitent une revue dans le menu `/hooks` avant prise d'effet.
+Claude Code inclut une protection : les modifications directes des fichiers de configuration de hooks nécessitent une revue dans le menu `/hooks` avant prise d'effet.
 
 ---
 
 ## Permissions et Securite
 
-Le systeme de permissions de Claude Code permet un controle granulaire sur les actions autorisees. Il repose sur des regles `allow`, `deny` et `ask` configurees dans `settings.json`.
+Le système de permissions de Claude Code permet un contrôle granulaire sur les actions autorisées. Il repose sur des règles `allow`, `deny` et `ask` configurées dans `settings.json`.
 
 ### Niveaux de Permission
 
 | Mode | Comportement |
 | --- | --- |
 | `default` | Demande permission pour chaque action |
-| `acceptEdits` | Accepte lectures et ecritures de fichiers, demande pour Bash |
-| `plan` | Mode lecture seule, pas d'execution |
+| `acceptEdits` | Accepte lectures et écritures de fichiers, demande pour Bash |
+| `plan` | Mode lecture seule, pas d'exécution |
 | `auto-accept` | Accepte tout automatiquement (a utiliser avec prudence) |
-| `bypassPermissions` | Ignore les permissions (deconseille en production) |
+| `bypassPermissions` | Ignore les permissions (déconseillé en production) |
 
 ### Regles de Permission
 
-Les regles se configurent dans `settings.json` avec trois niveaux :
+Les règles se configurent dans `settings.json` avec trois niveaux :
 
 ```json
 {
@@ -719,23 +719,23 @@ Les regles se configurent dans `settings.json` avec trois niveaux :
 
 ### Syntaxe des Regles
 
-| Regle | Effet |
+| Règle | Effet |
 | --- | --- |
 | `Bash` | Correspond a toutes les commandes Bash |
-| `Bash(npm run *)` | Commandes commencant par `npm run` |
+| `Bash(npm run *)` | Commandes commençant par `npm run` |
 | `Read(.env)` | Lecture du fichier `.env` |
 | `Read(./secrets/**)` | Lecture recursive dans `secrets/` |
-| `Edit(src/**)` | Editions dans `src/` |
-| `WebFetch(domain:example.com)` | Requetes vers example.com |
+| `Edit(src/**)` | Éditions dans `src/` |
+| `WebFetch(domain:example.com)` | Requêtes vers example.com |
 | `MCP(github)` | Utilisation du serveur MCP github |
 
 ### Ordre d'Evaluation
 
-1. **Deny** : premiere regle correspondante gagne
-1. **Ask** : premiere regle correspondante gagne
-1. **Allow** : premiere regle correspondante gagne
+1. **Deny** : première règle correspondante gagne
+1. **Ask** : première règle correspondante gagne
+1. **Allow** : première règle correspondante gagne
 
-Les regles `deny` sont toujours evaluees en premier, garantissant que les interdictions ne peuvent pas etre contournees.
+Les règles `deny` sont toujours évaluées en premier, garantissant que les interdictions ne peuvent pas être contournées.
 
 ### Options Avancees
 
@@ -749,15 +749,15 @@ Les regles `deny` sont toujours evaluees en premier, garantissant que les interd
 }
 ```
 
-- **additionalDirectories** : Repertoires supplementaires accessibles a Claude
-- **defaultMode** : Mode de permission par defaut
-- **disableBypassPermissionsMode** : Empeche l'utilisation du mode bypass
+- **additionalDirectories** : Répertoires supplémentaires accessibles a Claude
+- **defaultMode** : Mode de permission par défaut
+- **disableBypassPermissionsMode** : Empêche l'utilisation du mode bypass
 
 ---
 
 ## Sandbox
 
-Le sandbox isole l'execution de Claude Code dans un environnement controle, limitant l'acces au systeme de fichiers et au reseau.
+Le sandbox isole l'exécution de Claude Code dans un environnement contrôlé, limitant l'accès au système de fichiers et au réseau.
 
 ### Activation
 
@@ -770,7 +770,7 @@ Le sandbox isole l'execution de Claude Code dans un environnement controle, limi
 }
 ```
 
-Quand `autoAllowBashIfSandboxed` est `true`, les commandes Bash sont auto-acceptees car le sandbox empeche les actions destructives.
+Quand `autoAllowBashIfSandboxed` est `true`, les commandes Bash sont auto-acceptées car le sandbox empêche les actions destructives.
 
 ### Configuration Reseau
 
@@ -793,7 +793,7 @@ Quand `autoAllowBashIfSandboxed` est `true`, les commandes Bash sont auto-accept
 
 ### Commandes Exclues
 
-Certaines commandes peuvent etre exclues du sandbox (executees hors isolation) :
+Certaines commandes peuvent être exclues du sandbox (exécutées hors isolation) :
 
 ```json
 {
@@ -807,7 +807,7 @@ Certaines commandes peuvent etre exclues du sandbox (executees hors isolation) :
 
 ### Disponibilite
 
-Le sandbox est disponible sur macOS et Linux. Sur Windows, il n'est pas encore supporte nativement (utiliser WSL comme alternative).
+Le sandbox est disponible sur macOS et Linux. Sur Windows, il n'est pas encore supporté nativement (utiliser WSL comme alternative).
 
 ---
 


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg `lygoyu`) : accents #2876 résiduels GenAI/Vibe-Coding. Tranche = `Claude-Code/docs/CONCEPTS-AVANCES.md` (1040 L, doc de référence sur Slash Commands / Skills / Subagents / Hooks / Permissions / Sandbox / MCP).

## État initial

Le doc était **partiellement accentué** : les ~2/3 (intro Slash/Skills/Subagents/Hooks/MCP, lignes 20-680) étaient déjà bien accentés par un sweep antérieur. La dette résiduelle était concentrée dans :
- l'intro (lignes 1-3) ;
- les sections **Permissions et Sécurité** (679-755) ;
- **Sandbox** (758-812) ;
- **Securite des Hooks** (673-675).

## Méthode

**Masked-dictionary** (leçon #4502 : fichiers riches = batch soigneux, jamais regex blind) :
1. Mask des fenced code blocks, inline code, URLs, **markdown-link targets** (ancres préservées) et **heading lines** (sécurité d'ancrage : les headings génèrent les ancres GitHub, on ne les accentue pas pour éviter toute dérive d'ancre cross-file/TOC).
2. Application d'un dictionnaire accent word-internal (260 entrées, case-aware, longest-first) sur le texte restant.
3. Restore.
4. **Eyeball du diff complet** (obligatoire) + 4-gate validation.

## Eyeball = obligatoire — 4 défauts du dictionnaire corrigés à la main

L'eyeball a attrapé **4 corruptions verbales/participiales** que le dictionnaire a introduites (exactement la leçon #4502 : les gates prouvent l'accent-only sur ce qu'on CHANGE, pas la justesse grammaticale) :

| # | Défaut | Diagnostic | Fix |
|---|--------|-----------|-----|
| 1 | `Configure les hooks` → `Configuré` | **Verbe** (3e pers. « configures »), pas de participe passé. « Configuré les hooks » = faute | laissé `Configure` (correct) |
| 2 | `General-purpose` → `Général-purpose` | Terme anglais / nom du type de subagent Claude Code. Half-accent = corruption | gardé `General-purpose` (anglicisme légitime) |
| 3 | `Le sandbox isole l'exécution` → `isolé` ; `environnement controle` → `contrôle` (nom) | `isole` = **verbe actif** (« the sandbox isolates »), pas participe. `controle` modifie `environnement` → **adjectif** `contrôlé` (controlled), pas le nom `contrôle` | `isole` (verbe) + `contrôlé` (adjectif) |
| 4 | `[Hooks Référence]` | Label de **doc-page anglaise** (lien vers code.claude.com/docs/en/hooks) | gardé `Hooks Reference` (cohérent avec `CLI Reference` / `MCP Guide`) |

+ **3 gap-fills sûrs** (formes nominales/participiales non ambiguës ratées par le dict) : `capacites`→`capacités`, `auto-acceptees`→`auto-acceptées`, `evaluees`→`évaluées`.

## Validation (4 gates, tous PASS)

- **GATE 1** : `deaccent(old) == deaccent(new)` (NFD+Mn) → **PASS**, delta **0 octet** (preuve accent-pur).
- **GATE 3** : 23 markdown-link targets + 19 bare URLs → tous **byte-identical** (ancres TOC `#permissions-et-securite` etc. préservées).
- **GATE 4** : 78 fences ```` ``` ````, 496 backticks → counts **identiques**.
- **Headings byte-identical** (114) : sécurité d'ancrage (aucune dérive d'ancre GitHub).
- **Protected strings** : `settings.json`, `.mcp.json`, `.claude/{commands,skills,agents}/`, `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`, `ENABLE_TOOL_SEARCH`, `MAX_MCP_OUTPUT_TOKENS`, `DB_URL`/`DATABASE_URL`/`API_KEY`, `claude-sonnet-4`, `code.claude.com/docs`, refs `INSTALLATION-CLAUDE-CODE.md`/`CHEAT-SHEET.md`, `acceptEdits`/`bypassPermissions`/`permissionDecisionReason`/`additionalDirectories`/`autoAllowBashIfSandboxed` etc. → tous **inchangés**.

## Choix conservateurs

- **Headings non-accentués** (Permissions/Sandbox/Securite-des-Hooks) laissés tels quels par sécurité d'ancrage : le TOC pointe ces ancres ; masquer les headings garantit zéro dérive. Le body-texte est accentué normalement. Le label TOC `Permissions et Sécurité` est accentué (cosmétique, l'ancre `#permissions-et-securite` masquée reste byte-identique → lien résolu).
- **Standalone `a`/`ou` EXCLUS** (ambigu prep-vs-avoir / ou-vs-où, cf leçon HARD EXCLUDE) : « Correspond a toutes », « accessibles a Claude », « a utiliser avec prudence » laissés tels quels.
- **Labels de doc-pages anglais** gardés en anglais (`Hooks Reference`, comme `CLI Reference`/`MCP Guide` dans le doc d'installation).

## Non-scope

Les participes passés en -é résiduels et le `à` prépositionnel standalone = batchs de suivi. Le reste de la sous-série Vibe-Coding (OPENROUTER_SETUP.md, Roo-Code, Claudish, notebooks) = tranches ultérieures.

See #2876
