### PR TITLE
fix(vibe-coding): restore accents in OPENROUTER_SETUP quickstart (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
@@ -1,18 +1,18 @@
 # Quickstart : Claude Code + OpenRouter
 
-**15 minutes pour etre operationnel.**
+**15 minutes pour être opérationnel.**
 
-Ce guide vous prend par la main pour configurer Claude Code avec OpenRouter comme fournisseur de modeles. Suivez les etapes dans l'ordre, et validez chaque checkpoint avant de passer a la suivante.
+Ce guide vous prend par la main pour configurer Claude Code avec OpenRouter comme fournisseur de modèles. Suivez les étapes dans l'ordre, et validez chaque checkpoint avant de passer a la suivante.
 
-> **Pourquoi OpenRouter ?** Au lieu d'utiliser l'API Anthropic (payante, compte obligatoire), OpenRouter vous donne acces a des modeles performants a moindre cout, avec une cle unique pour plusieurs modeles.
+> **Pourquoi OpenRouter ?** Au lieu d'utiliser l'API Anthropic (payante, compte obligatoire), OpenRouter vous donne accès a des modèles performants a moindre coût, avec une clé unique pour plusieurs modèles.
 >
-> **Compatibilite OpenRouter** : Les requetes OpenRouter ne sont pas strictement compatibles avec le protocole Anthropic utilise par Claude Code (bug connu). L'installation du proxy [openrouter-proxy](https://github.com/ahaostudy/openrouter-proxy) resout le probleme. La configuration ci-dessous inclut cette etape.
+> **Compatibilité OpenRouter** : Les requêtes OpenRouter ne sont pas strictement compatibles avec le protocole Anthropic utilise par Claude Code (bug connu). L'installation du proxy [openrouter-proxy](https://github.com/ahaostudy/openrouter-proxy) résout le problème. La configuration ci-dessous inclut cette étape.
 
 ---
 
-## Etape 0 : Installer le proxy OpenRouter (2 min)
+## Étape 0 : Installer le proxy OpenRouter (2 min)
 
-Claude Code utilise le protocole Anthropic pour communiquer avec les modeles. OpenRouter ne respecte pas strictement ce protocole, ce qui provoque des erreurs (reponses mal formatees, echecs d'authentification intermittents). Le proxy [openrouter-proxy](https://github.com/ahaostudy/openrouter-proxy) traduit les requetes correctement.
+Claude Code utilise le protocole Anthropic pour communiquer avec les modèles. OpenRouter ne respecte pas strictement ce protocole, ce qui provoque des erreurs (réponses mal formatées, échecs d'authentification intermittents). Le proxy [openrouter-proxy](https://github.com/ahaostudy/openrouter-proxy) traduit les requêtes correctement.
 
 ### Installation
 
@@ -21,18 +21,18 @@ Claude Code utilise le protocole Anthropic pour communiquer avec les modeles. Op
 npm install -g openrouter-proxy
 ```
 
-### Demarrage
+### Démarrage
 
 ```bash
 # Lance le proxy sur le port 8899 par defaut
 openrouter-proxy
 ```
 
-Le proxy tourne en arriere-plan et traduit les requetes Claude Code vers OpenRouter. Gardez-le actif tant que vous utilisez Claude Code.
+Le proxy tourne en arrière-plan et traduit les requêtes Claude Code vers OpenRouter. Gardez-le actif tant que vous utilisez Claude Code.
 
 ### Lancement automatique (optionnel)
 
-Pour eviter de le lancer manuellement a chaque session :
+Pour éviter de le lancer manuellement a chaque session :
 
 **Windows** - Ajoutez a votre profil PowerShell (`notepad $PROFILE`) :
 
@@ -46,21 +46,21 @@ Start-Process -WindowStyle Hidden -FilePath "openrouter-proxy"
 (openrouter-proxy &>/dev/null &)
 ```
 
-**Checkpoint :** Verifiez que le proxy tourne :
+**Checkpoint :** Vérifiez que le proxy tourne :
 
 ```bash
 curl http://127.0.0.1:8899/api/v1/models
 ```
 
-Si vous voyez une reponse JSON avec des modeles, le proxy fonctionne.
+Si vous voyez une réponse JSON avec des modèles, le proxy fonctionne.
 
 ---
 
-## Etape 1 : Installer Claude Code (3 min)
+## Étape 1 : Installer Claude Code (3 min)
 
 ### Windows
 
-Telechargez l'installateur depuis [claude.com/code](https://claude.com/code), executez le `.exe`, suivez les instructions.
+Téléchargez l'installateur depuis [claude.com/code](https://claude.com/code), exécutez le `.exe`, suivez les instructions.
 
 ### macOS
 
@@ -74,60 +74,60 @@ brew install --cask claude-code
 curl -fsSL https://install.claude.com | sh
 ```
 
-### Verifier
+### Vérifier
 
 ```bash
 claude --version
 ```
 
-**Checkpoint :** Vous devez voir un numero de version. Sinon, redemarrez votre terminal et reessayez.
+**Checkpoint :** Vous devez voir un numero de version. Sinon, redémarrez votre terminal et réessayez.
 
 ---
 
-## Etape 2 : Obtenir votre cle API OpenRouter (2 min)
+## Étape 2 : Obtenir votre clé API OpenRouter (2 min)
 
-**La cle vous est fournie par le formateur.** Elle ressemble a `sk-or-v1-xxxxxxxxxx`.
+**La clé vous est fournie par le formateur.** Elle ressemble a `sk-or-v1-xxxxxxxxxx`.
 
-Si vous voulez votre propre cle :
+Si vous voulez votre propre clé :
 1. Allez sur [openrouter.ai](https://openrouter.ai/)
-2. Creez un compte
+2. Créez un compte
 3. [Settings > API Keys](https://openrouter.ai/settings/keys) > "Create Key"
-4. Copiez la cle (elle ne sera plus affichee apres)
+4. Copiez la clé (elle ne sera plus affichée après)
 
-**Checkpoint :** Vous avez une cle qui commence par `sk-or-v1-`.
+**Checkpoint :** Vous avez une clé qui commence par `sk-or-v1-`.
 
 ---
 
-## Etape 3 : Configurer les variables d'environnement (5 min)
+## Étape 3 : Configurer les variables d'environnement (5 min)
 
-C'est l'etape la plus importante. Vous devez definir **3 variables obligatoires** + **3 variables de mapping de modeles** (fortement recommandees).
+C'est l'étape la plus importante. Vous devez définir **3 variables obligatoires** + **3 variables de mapping de modèles** (fortement recommandées).
 
 ### Ce que vous configurez
 
 | Variable | Valeur | Role |
 |----------|--------|------|
-| `ANTHROPIC_BASE_URL` | `http://127.0.0.1:8899/api` | Passe par le proxy OpenRouter (Etape 0) au lieu d'Anthropic |
-| `ANTHROPIC_AUTH_TOKEN` | `sk-or-v1-VOTRE_CLE` | Votre cle d'authentification OpenRouter |
-| `ANTHROPIC_API_KEY` | *(vide)* | Doit etre vide pour ne pas conflit avec OpenRouter |
-| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `qwen/qwen3.6-plus` | Modele "opus" = Qwen 3.6 Plus (raisonnement complexe) |
-| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `minimax/minimax-m2.7` | Modele "sonnet" = MiniMax M2.7 (usage quotidien) |
-| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `qwen/qwen3.6-35b-a3b` | Modele "haiku" = Qwen 3.6 35B-A3B (taches rapides) |
+| `ANTHROPIC_BASE_URL` | `http://127.0.0.1:8899/api` | Passe par le proxy OpenRouter (Étape 0) au lieu d'Anthropic |
+| `ANTHROPIC_AUTH_TOKEN` | `sk-or-v1-VOTRE_CLE` | Votre clé d'authentification OpenRouter |
+| `ANTHROPIC_API_KEY` | *(vide)* | Doit être vide pour ne pas conflit avec OpenRouter |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `qwen/qwen3.6-plus` | Modèle "opus" = Qwen 3.6 Plus (raisonnement complexe) |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `minimax/minimax-m2.7` | Modèle "sonnet" = MiniMax M2.7 (usage quotidien) |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `qwen/qwen3.6-35b-a3b` | Modèle "haiku" = Qwen 3.6 35B-A3B (taches rapides) |
 
-### Pourquoi le mapping des modeles ?
+### Pourquoi le mapping des modèles ?
 
-Sans les variables `ANTHROPIC_DEFAULT_*_MODEL`, Claude Code essaie d'utiliser les modeles Claude natifs (`claude-sonnet-4-20250514`, etc.), qui **ne sont pas disponibles via OpenRouter**. Vous obtiendrez une erreur "Model not found".
+Sans les variables `ANTHROPIC_DEFAULT_*_MODEL`, Claude Code essaie d'utiliser les modèles Claude natifs (`claude-sonnet-4-20250514`, etc.), qui **ne sont pas disponibles via OpenRouter**. Vous obtiendrez une erreur "Model not found".
 
-Le mapping dit a Claude Code : "quand on te demande 'sonnet', utilise MiniMax M2.7 sur OpenRouter au lieu de chercher un modele Anthropic".
+Le mapping dit a Claude Code : "quand on te demande 'sonnet', utilise MiniMax M2.7 sur OpenRouter au lieu de chercher un modèle Anthropic".
 
-### Methode recommandee : fichier settings.json
+### Méthode recommandée : fichier settings.json
 
-Creez le fichier de configuration machine. C'est la methode la plus fiable car elle fonctionne dans tous les contextes (terminal, VS Code, scripts).
+Créez le fichier de configuration machine. C'est la méthode la plus fiable car elle fonctionne dans tous les contextes (terminal, VS Code, scripts).
 
-**Windows** : Creez le fichier `C:\Users\<VOTRE_USER>\.claude\settings.json`
+**Windows** : Créez le fichier `C:\Users\<VOTRE_USER>\.claude\settings.json`
 
-**macOS / Linux** : Creez le fichier `~/.claude/settings.json`
+**macOS / Linux** : Créez le fichier `~/.claude/settings.json`
 
-Contenu (remplacez `sk-or-v1-VOTRE_CLE` par votre vraie cle) :
+Contenu (remplacez `sk-or-v1-VOTRE_CLE` par votre vraie clé) :
 
 ```json
 {
@@ -170,7 +170,7 @@ Sauvegardez et rechargez :
 
 ### Alternative : variables d'environnement macOS/Linux
 
-Editez `~/.zshrc` (ou `~/.bashrc` si vous utilisez bash) :
+Éditez `~/.zshrc` (ou `~/.bashrc` si vous utilisez bash) :
 
 ```bash
 nano ~/.zshrc
@@ -194,7 +194,7 @@ Rechargez :
 source ~/.zshrc
 ```
 
-**Checkpoint :** Fermez et rouvrez votre terminal, puis verifiez :
+**Checkpoint :** Fermez et rouvrez votre terminal, puis vérifiez :
 
 ```bash
 # Windows
@@ -210,16 +210,16 @@ Si les variables sont vides, le fichier settings.json n'est pas au bon endroit o
 
 ---
 
-## Etape 4 : Installer l'extension VS Code (3 min)
+## Étape 4 : Installer l'extension VS Code (3 min)
 
 1. Ouvrez VS Code
 2. `Ctrl+Shift+X` (Windows/Linux) ou `Cmd+Shift+X` (macOS)
 3. Recherchez **"Claude Code"**
 4. Installez l'extension par **Anthropic**
 
-### Reglage CRITIQUE : "Disable Login Prompt"
+### Réglage CRITIQUE : "Disable Login Prompt"
 
-Sans ce reglage, VS Code vous demandera de vous connecter avec un compte Anthropic (inutile avec OpenRouter).
+Sans ce réglage, VS Code vous demandera de vous connecter avec un compte Anthropic (inutile avec OpenRouter).
 
 1. `Ctrl+,` / `Cmd+,` (Settings)
 2. Recherchez **"Claude Code"**
@@ -229,7 +229,7 @@ Sans ce reglage, VS Code vous demandera de vous connecter avec un compte Anthrop
 
 ---
 
-## Etape 5 : Verifier que tout fonctionne (2 min)
+## Étape 5 : Vérifier que tout fonctionne (2 min)
 
 ### Test CLI
 
@@ -237,9 +237,9 @@ Sans ce reglage, VS Code vous demandera de vous connecter avec un compte Anthrop
 claude -p "Reponds juste 'OK' pour confirmer que tu fonctionnes"
 ```
 
-Vous devez recevoir une reponse du modele (MiniMax M2.7 par defaut).
+Vous devez recevoir une réponse du modèle (MiniMax M2.7 par défaut).
 
-### Test des modeles
+### Test des modèles
 
 ```bash
 # Modele par defaut (sonnet = MiniMax M2.7)
@@ -256,13 +256,13 @@ claude --model haiku -p "Reponds 'Haiku OK'"
 
 1. Cliquez sur l'icone Claude Code dans la barre laterale
 2. Tapez : `Bonjour, confirme que tu fonctionnes`
-3. Vous devez voir une reponse du modele
+3. Vous devez voir une réponse du modèle
 
-**Checkpoint :** Les 3 modeles repondent en CLI et l'extension VS Code fonctionne.
+**Checkpoint :** Les 3 modèles répondent en CLI et l'extension VS Code fonctionne.
 
 ---
 
-## Etape 6 : Premiers pas dans un projet (optionnel)
+## Étape 6 : Premiers pas dans un projet (optionnel)
 
 Ouvrez un dossier de projet dans votre terminal :
 
@@ -277,19 +277,19 @@ Puis tapez :
 /init
 ```
 
-Claude Code va analyser votre projet et creer un fichier `CLAUDE.md` avec le contexte du projet. Ce fichier aide Claude a comprendre votre codebase.
+Claude Code va analyser votre projet et créer un fichier `CLAUDE.md` avec le contexte du projet. Ce fichier aide Claude a comprendre votre codebase.
 
 ---
 
-## Les 3 modeles et quand les utiliser
+## Les 3 modèles et quand les utiliser
 
-| Alias | Modele | Quand l'utiliser |
+| Alias | Modèle | Quand l'utiliser |
 |-------|--------|-----------------|
-| **sonnet** (defaut) | MiniMax M2.7 | Developpement quotidien, debug, questions |
+| **sonnet** (défaut) | MiniMax M2.7 | Développement quotidien, debug, questions |
 | **opus** | Qwen 3.6 Plus | Refactoring complexe, architecture, documentation |
 | **haiku** | Qwen 3.6 35B-A3B | Questions rapides, exploration, prototypage |
 
-Pour changer de modele dans une session :
+Pour changer de modèle dans une session :
 
 ```bash
 claude --model opus    # utilise Qwen 3.6 Plus
@@ -299,7 +299,7 @@ claude --model haiku   # utilise Qwen 3.6 35B-A3B
 
 ---
 
-## Problemes frequents
+## Problèmes fréquents
 
 ### "Authentication failed"
 
@@ -344,7 +344,7 @@ Sinon, redemarrez VS Code COMPLETEMENT (pas juste recharger la fenetre).
 
 ## Pour aller plus loin
 
-- **Guide complet** : [INSTALLATION-CLAUDE-CODE.md](./INSTALLATION-CLAUDE-CODE.md) (installation avancee, MCP, configuration detaillee)
+- **Guide complet** : [INSTALLATION-CLAUDE-CODE.md](./INSTALLATION-CLAUDE-CODE.md) (installation avancée, MCP, configuration détaillée)
 - **Aide-memoire** : [CHEAT-SHEET.md](./CHEAT-SHEET.md)
-- **Concepts avances** : [CONCEPTS-AVANCES.md](./CONCEPTS-AVANCES.md) (Skills, Subagents, Hooks)
+- **Concepts avancés** : [CONCEPTS-AVANCES.md](./CONCEPTS-AVANCES.md) (Skills, Subagents, Hooks)
 - **Introduction** : [INTRO-CLAUDE-CODE.md](./INTRO-CLAUDE-CODE.md)


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg `lygoyu`) : accents #2876 résiduels GenAI/Vibe-Coding. Tranche = `Claude-Code/docs/OPENROUTER_SETUP.md` (350 L, quickstart 15 min « Claude Code + OpenRouter » — quasi entièrement non-accenté).

## État initial

Le doc était **presque entièrement sans accents** (intro + Étapes 0-6 + table modèles + problèmes fréquents). 56 mots à accentuer.

## Méthode

**Masked-dictionary** (leçon #4502 : jamais regex blind sur fichiers riches) :
1. Mask des fenced code blocks, inline code, bare URLs.
2. **Mask des LIENS MARKDOWN COMPLETS `[label](target)`** (et non seulement la cible `](...)`) — **crucial** : le label `[CONCEPTS-AVANCES.md]` contient le nom de fichier ; un mask cible-seul laissait le dict corrompre `AVANCES`→`AVANCÉS` dans le label → référence de fichier cassée. La GATE protected-string a attrapé ce défaut à la première passe (`CONCEPTS-AVANCES.md` 2→1), j'ai élargi le mask au lien complet et re-passé. **Eyeball + protected-string gate = obligatoires** (leçon durcie).
3. Application d'un dictionnaire accent word-internal (210 entrées, case-aware, longest-first) sur le texte restant (headings inclus — **aucune référence d'ancre** vers ce fichier, vérifié `git grep OPENROUTER_SETUP.md#` = 0, donc les headings sont accentués sans risque d'ancre).
4. Restore. 4-gate validation + eyeball diff complet.

## Eyeball = a attrapé 1 défaut + guidé 4 gap-fills

- **Défaut attrapé par GATE** : première passe corrompait `[CONCEPTS-AVANCES.md]` (label de lien) → `[CONCEPTS-AVANCÉS.md]`. Fix : mask du lien markdown complet, pas seulement la cible.
- **Défaut de COntexte évité** : `utilise` est **ambigu** dans ce doc :
  - lignes 9/15 « protocole Anthropic **utilise par** Claude Code » = participe passé passif → DEVRAIT être `utilisé`
  - ligne 120 « **utilise** MiniMax M2.7 sur OpenRouter » = **impératif** (« utilise ! ») → NE DOIT PAS être accentué
  - Ajouter `utilise` au dict aurait corrompu l'impératif ligne 120 → **DEFER** (cohérent avec le report des participes passés -é des batches INSTALLATION/CONCEPTS). Batch de suivi avec revue manuelle de contexte.
- **4 gap-fills sûrs** (noms/verbes inambigus, pas de conflit impératif) : `resout`→`résout` (verbe résoudre), `echecs`→`échecs` (nom), `formatees`→`formatées` (participe passé fém. pluriel, présent = « formate »), `repondent`→`répondent` (verbe répondre, présent 3e pers. pl.).

## Validation (4 gates + protected strings, tous PASS)

- **GATE 1** : `deaccent(old) == deaccent(new)` (NFD+Mn) → **PASS**, delta **0 octet** (preuve accent-pur).
- **GATE 3** : 9 markdown-link targets + 13 bare URLs → tous **byte-identical** (labels de fichiers `[CONCEPTS-AVANCES.md]`, `[INSTALLATION-CLAUDE-CODE.md]` etc. préservés).
- **GATE 4** : 52 fences ```` ``` ````, 216 backticks → counts **identiques** (env vars / model names / tokens dans code blocks intacts).
- **Protected strings** unchanged : `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_API_KEY`/`ANTHROPIC_DEFAULT_*_MODEL`, `sk-or-v1`/`VOTRE_CLE`, `openrouter-proxy`, `qwen/qwen3.6-plus`/`minimax/minimax-m2.7`/`qwen/qwen3.6-35b-a3b`, `claude-sonnet-4-20250514`, `http://127.0.0.1:8899/api`, `claude.com/code`/`install.claude.com`/`openrouter.ai`/`ahaostudy/openrouter-proxy`, `settings.json`/`$PROFILE`/`~/.zshrc`/`~/.bashrc`, `CLAUDE.md`, refs `INSTALLATION-CLAUDE-CODE.md`/`CHEAT-SHEET.md`/`CONCEPTS-AVANCES.md`/`INTRO-CLAUDE-CODE.md`, `Anthropic`/`OpenRouter`/`MiniMax`/`Qwen`/`VS Code`/`Disable Login Prompt`.

## Choix conservateurs

- **Headings accentués** (aucun risque d'ancre : 0 référence cross-file/interne vers `#etape-*` etc.). Cela donne un doc plus poli que les batches où je masquais les headings.
- **Standalone `a`/`ou` EXCLUS** (ambigu prep-vs-avoir / ou-vs-où) : « passer a la suivante », « acces a des modeles », « dit a Claude Code », « aide Claude a comprendre » laissés tels quels. Batch de suivi pour le `à` prépositionnel.
- **Participe passé `utilise par`** DEFERRED (conflit impératif ligne 120).

## Non-scope

Le `à` prépositionnel standalone et `utilise par` = batchs de suivi. Le reste de la sous-série Vibe-Coding (INTRO-CLAUDE-CODE, CHEAT-SHEET, Roo-Code, Claudish, Claw-Systems, notebooks) = tranches ultérieures.

See #2876
