### PR TITLE
fix(vibe-coding): restore accents in CHEAT-SHEET aide-mémoire (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CHEAT-SHEET.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CHEAT-SHEET.md
@@ -1,12 +1,12 @@
-# Claude Code - Aide-Memoire Rapide
+# Claude Code - Aide-Mémoire Rapide
 
-Guide de reference rapide pour Claude Code CLI et Extension VS Code.
+Guide de référence rapide pour Claude Code CLI et Extension VS Code.
 
 > **Documentation officielle** : [code.claude.com/docs](https://code.claude.com/docs)
 
 ## Commandes CLI Essentielles
 
-### Demarrage et Sessions
+### Démarrage et Sessions
 
 ```bash
 # Demarrer une session interactive
@@ -28,7 +28,7 @@ claude -r "nom-session"
 claude --fork-session
 ```
 
-### Selection de Modele
+### Sélection de Modèle
 
 ```bash
 # Modele par defaut (Sonnet)
@@ -89,7 +89,7 @@ claude -p "query" --max-turns 5
 claude -p "query" --max-budget-usd 0.50
 ```
 
-### Agents Personnalises
+### Agents Personnalisés
 
 ```bash
 # Utiliser un agent defini dans .claude/agents/
@@ -155,9 +155,9 @@ claude --remote "Fix le bug de login"
 
 ### Workflow Typique
 
-1. **Ouvrir Claude** : Cliquer sur l'icone spark dans la barre laterale
-1. **Selectionner code** : Surligner dans l'editeur
-1. **Referencer** : `Alt+K` pour creer @-mention
+1. **Ouvrir Claude** : Cliquer sur l'icône spark dans la barre latérale
+1. **Sélectionner code** : Surligner dans l'éditeur
+1. **Référencer** : `Alt+K` pour créer @-mention
 1. **Poser question** : Taper dans Claude
 1. **Revoir changements** : Examiner les diffs
 1. **Accepter/Rejeter** : Valider ou refuser
@@ -237,7 +237,7 @@ claude mcp add --transport stdio db -- \
   npx -y @bytebase/dbhub --dsn "postgresql://..."
 ```
 
-## Slash Commands Integres
+## Slash Commands Intégrés
 
 ```text
 /init              # Generer CLAUDE.md pour le projet
@@ -252,7 +252,7 @@ claude mcp add --transport stdio db -- \
 
 ## Configuration Fichiers
 
-### Hierarchie de priorite (du plus fort au plus faible)
+### Hiérarchie de priorité (du plus fort au plus faible)
 
 1. **Managed** : `C:\Program Files\ClaudeCode\` (Windows) ou `/etc/claude-code/` (Linux)
 1. **Arguments CLI** : `--model`, `--permission-mode`, etc.
@@ -319,7 +319,7 @@ claude mcp add --transport stdio db -- \
 }
 ```
 
-### CLAUDE.md (Memoire Projet)
+### CLAUDE.md (Mémoire Projet)
 
 ```markdown
 # Mon Projet
@@ -348,9 +348,9 @@ claude mcp add --transport stdio db -- \
 - Commits conventionnels : `feat:`, `fix:`, `docs:`
 ```
 
-### .claude/rules/ (Regles modulaires)
+### .claude/rules/ (Règles modulaires)
 
-Les regles dans `.claude/rules/*.md` sont chargees automatiquement selon le contexte.
+Les règles dans `.claude/rules/*.md` sont chargées automatiquement selon le contexte.
 Ajoutez un frontmatter YAML pour limiter a certains fichiers :
 
 ```yaml
@@ -361,9 +361,9 @@ Utilise pytest pour les tests.
 Docstrings en Google style.
 ```
 
-### .claude/skills/ (Competences)
+### .claude/skills/ (Compétences)
 
-Les skills dans `.claude/skills/*/SKILL.md` fournissent des connaissances specifiques.
+Les skills dans `.claude/skills/*/SKILL.md` fournissent des connaissances spécifiques.
 Claude les applique automatiquement quand le contexte correspond.
 
 ```yaml
@@ -391,7 +391,7 @@ Tu es un expert en revue de code...
 
 ## Hooks (Automatisation)
 
-Les hooks executent des scripts a des points cles du workflow.
+Les hooks exécutent des scripts a des points clés du workflow.
 A configurer dans `settings.json` :
 
 ```json
@@ -492,17 +492,17 @@ export ENABLE_TOOL_SEARCH=auto:5
 export IS_DEMO=1
 ```
 
-## Resolution Problemes Rapide
+## Résolution Problèmes Rapide
 
-| Probleme | Solution |
+| Problème | Solution |
 | --- | --- |
-| `command not found: claude` | Verifier PATH, reinstaller, redemarrer terminal |
-| `Authentication failed` | Verifier `ANTHROPIC_AUTH_TOKEN` et `ANTHROPIC_BASE_URL` |
-| Extension ne se connecte pas | Verifier que le CLI est installe et dans le PATH |
-| MCP server timeout | Augmenter `MCP_TIMEOUT` ou verifier le serveur |
-| Modele non disponible | Verifier credits OpenRouter et nom du modele |
-| `npx` echoue (Windows) | Utiliser `cmd /c npx ...` dans les commandes MCP |
-| Hooks non executes | Verifier format dans `settings.json`, tester le script manuellement |
+| `command not found: claude` | Vérifier PATH, réinstaller, redémarrer terminal |
+| `Authentication failed` | Vérifier `ANTHROPIC_AUTH_TOKEN` et `ANTHROPIC_BASE_URL` |
+| Extension ne se connecte pas | Vérifier que le CLI est installe et dans le PATH |
+| MCP server timeout | Augmenter `MCP_TIMEOUT` ou vérifier le serveur |
+| Modèle non disponible | Vérifier credits OpenRouter et nom du modèle |
+| `npx` échoue (Windows) | Utiliser `cmd /c npx ...` dans les commandes MCP |
+| Hooks non exécutés | Vérifier format dans `settings.json`, tester le script manuellement |
 | macOS : variables perdues | Ajouter exports dans `~/.zshrc` (pas `.zprofile`) |
 
 ## Ressources
@@ -519,7 +519,7 @@ export IS_DEMO=1
 
 - [Introduction Claude Code](./INTRO-CLAUDE-CODE.md) - Vue d'ensemble et concepts de base
 - [Installation](./INSTALLATION-CLAUDE-CODE.md) - Guide d'installation avec OpenRouter
-- [Concepts Avances](./CONCEPTS-AVANCES.md) - Skills, Subagents, Hooks, MCP en detail
+- [Concepts Avancés](./CONCEPTS-AVANCES.md) - Skills, Subagents, Hooks, MCP en détail
 - [Comparaison Claude/Roo](../../docs/COMPARAISON-CLAUDE-ROO.md) - Choisir son outil
 
 ---


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg `lygoyu`) : accents #2876 résiduels GenAI/Vibe-Coding. Tranche = `Claude-Code/docs/CHEAT-SHEET.md` (527 L, aide-mémoire rapide Claude Code — dette dans la prose + headings, code blocks intacts).

## État initial

Le code (bash/json/yaml) était correct (env vars, model names, flags) mais la **prose autour** (headings de section, body, table de résolution de problèmes) était largement non-accentée. 26 mots à accentuer.

## Méthode

**Masked-dictionary** (leçon #4502) :
1. Mask fenced code / inline code / bare URLs / **full markdown links `[label](target)`** (préserve les noms de fichiers dans les libellés, leçon durcie OPENROUTER).
2. Dictionnaire accent word-internal (216 entrées, case-aware). Headings accentués (**aucune référence d'ancre** cross-file vers `CHEAT-SHEET.md#`, vérifié).
3. Restore. 4-gate validation + eyeball.

## Eyeball = a guidé 2 correctifs ciblés

- **`Resolution` oublié dans le dict** : heading `## Resolution Problèmes Rapide` → `## Résolution Problèmes Rapide` (correctif manuel ciblé, le dict ne couvrait pas ce mot).
- **Label de lien ligne 522** `[Concepts Avances](./CONCEPTS-AVANCES.md)` : masqué en tant que lien complet → le label restait non-accenté. **Correctif manuel chirurgical** : libellé d'affichage `Concepts Avances`→`Concepts Avancés` **tout en préservant la cible du nom de fichier** `CONCEPTS-AVANCES.md` byte-identical (le nom de fichier réel ne change pas).

## Choix conservateurs

- **`installe`** (ligne 501 « CLI est installe ») = participe passé → DEFER (cohérent avec le report des participes passés -é).
- **Standalone `a`** (ligne 394 « scripts a des points », 354 « limiter a certains ») = EXCLU (ambigu prep `à` vs avoir). Batch de suivi.
- **`System Prompts`, `Output`, `Debugging`, `Ecosystem`** = termes anglais légitimes, gardés EN (pas de half-accent).

## Validation (4 gates + protected strings, tous PASS)

- **GATE 1** : `deaccent(old)==deaccent(new)` NFD → **PASS**, delta **0 octet**.
- **GATE 3** : 12 markdown-link targets + 20 bare URLs → **byte-identical** (refs `CONCEPTS-AVANCES.md`/`INSTALLATION-CLAUDE-CODE.md`/`INTRO-CLAUDE-CODE.md`/`COMPARAISON-CLAUDE-ROO.md` préservées).
- **GATE 4** : 48 fences, 238 backticks → counts **identiques**.
- **Protected strings** unchanged : toutes les env vars (`ANTHROPIC_*`, `CLAUDE_CODE_*`, `MCP_TIMEOUT`, `DB_URL`, `API_KEY`), model names (`qwen/qwen3.6-plus`, `minimax/minimax-m2.7`, `claude-sonnet-4-5-20250929`), tokens (`sk-or-v1`/`VOTRE_CLE`), paths (`settings.json`, `.mcp.json`, `CLAUDE.md`, `SKILL.md`), flags (`acceptEdits`, `allowedTools`, `PreToolUse`), noms produit (`Claude Code`, `VS Code`, `OpenRouter`, `Anthropic`, MCP servers).

## Non-scope

`a` prépositionnel standalone et `installe` (participe) = batchs de suivi. Reste de la sous-série (Roo-Code, Claudish, Claw-Systems, notebooks) = tranches ultérieures.

See #2876
