### PR TITLE
docs(causal): cross-pointers to do-calculus bridge from 4 causal notebooks

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb
@@ -906,6 +906,7 @@
     "- [ICT-0 — Cadrage](ICT-0-Framing.md) : place de ce notebook dans la feuille de route.\n",
     "\n",
     "### Pour aller plus loin\n",
+    "- **[Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb)** : l'armature formelle unifiée de Pearl (échelle + 3 règles du do-calculus, paradigme interventionniste) exécutée sur `dowhy`, à mettre en regard de l'émergence causale de Hoel (information effective) de ce notebook.\n",
     "\n",
     "- Hoel, E. (2017). *When the map is better than the territory*. **Entropy**.\n",
     "- Jansma, A. & Hoel, E. (2025). *Engineering Emergence*. arXiv.\n",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Causal-Inference.ipynb
@@ -1775,6 +1775,7 @@
     "- **Backdoor et front-door rendent l'effet causal identifiable** a partir de donnees observationnelles, sous conditions graphiques — formalisees par le do-calculus (Pearl 1995), complet (Shpitser & Pearl 2006).\n",
     "\n",
     "### Pour aller plus loin\n",
+    "- **[Notebook-pont — du graphe causal au do-calculus](../DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb)** : l'armature formelle unifiée de Pearl (échelle + 3 règles) exécutée sur l'outil de référence `dowhy` (identification backdoor/front-door + estimation + réfutation), qui relie cette série à Tweety-11, PyMC-14 et ICT-5.\n",
     "\n",
     "- **Pont symbolique** : [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) traite le `do()` et les contrefactuels en **Java/Tweety** (raisonnement propositionnel) — meme echelle de Pearl, paradigme different.\n",
     "- **Pont Python** : [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb) demontre la meme distinction `P(Cloudy|Rain)` vs `P(Cloudy|do(Rain))` en MCMC.\n",

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Causal-Inference.ipynb
@@ -895,6 +895,7 @@
     "- **Backdoor et front-door rendent l'effet causal identifiable** a partir de donnees observationnelles, sous conditions graphiques — formalisees par le do-calculus (Pearl 1995), complet (Shpitser & Pearl 2006).\n",
     "\n",
     "### Pour aller plus loin — le meme do-calculus, d'autres paradigmes\n",
+    "- **[Notebook-pont — du graphe causal au do-calculus](../DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb)** : l'armature formelle unifiee de Pearl (echelle + 3 regles) executee sur l'outil de reference `dowhy` (identification backdoor/front-door + estimation + refutation), qui relie cette serie a Tweety-11, Infer-14 et ICT-5.\n",
     "\n",
     "Ce notebook traite le `do()` en **probabiliste MCMC + enumeration exacte** (`pm.do`). Le **meme operateur** structure trois autres series du depot, chacune dans un paradigme different :\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal.ipynb
@@ -815,6 +815,7 @@
     "Le moteur causal de Tweety est **qualitatif** (booléen) : il ne calcule pas de probabilités numériques $P(y \\mid do(x))$, mais décide si une conclusion *peut* / *doit* suivre causalement. Pour des estimations quantitatives (effets moyens, intervalles de confiance), il faudrait coupler le SCM à un estimateur bayésien ou à des données observationnelles (front-door / back-door adjustment). C'est une frontière de paradigme, pas un bug — le verdict SOTA est **SOTA-OK** pour le raisonnement qualitatif, avec cette borne explicite.\n",
     "\n",
     "### Pour aller plus loin\n",
+    "- **[Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb)** : l'armature formelle unifiée de Pearl (échelle + 3 règles du do-calculus) exécutée sur l'outil de référence `dowhy`, qui relie cette série à Infer-14, PyMC-14 et ICT-5.\n",
     "\n",
     "- **Judea Pearl**, *Causality: Models, Reasoning, and Inference* (Cambridge, 2009) — la référence formelle du do-calculus.\n",
     "- **Pearl & Mackenzie**, *The Book of Why* (2018) — version accessible, l'échelle causale.\n",


### PR DESCRIPTION
## Ce que fait cette PR

**Step 2 du deep-queue ai-01** (`msg-20260701T220249`) : câble les 4 notebooks causaux vers le notebook-pont do-calculus (#4806, désormais sur `main`), en aller-retour.

Dans la section « Pour aller plus loin » / constellation de chaque notebook, un bullet pointe vers le bridge :

| Notebook | Lien ajouté |
|----------|-------------|
| Tweety-11-Causal | `→ Do-Calculus-Bridge.ipynb` (armature unifiée + dowhy) |
| Infer-14-Causal-Inference | idem (identification backdoor/front-door + réfutation) |
| PyMC-14-Causal-Inference | idem (relié à Tweety-11/Infer-14/ICT-5) |
| ICT-5-CausalEmergence | idem (paradigme interventionniste Pearl vs émergence Hoel) |

## Preuve

- **0 lien dangling** post-rebase : bridge désormais sur `origin/main` (`f286495f8`), liens vérifiés vs `git ls-tree origin/main`.
- Rebase frais sur `main` (HARD 2 catalog-pr-hygiene).
- Édits **chirurgicaux** (raw splice, 1 ligne/notebook, 0 churn nbformat). Markdown-only → **C.2 exempt**.
- Diff : 4 fichiers, 4 insertions.

## Périmètre

- 1 sujet atomique (step 2 cross-pointers), issue parent #4788 (constellation causale close via #4806 + cette PR).
- Pas de `Closes` : contribution à la constellation, pas résolution d'issue dédiée.

Suite logique (step 3 du deep-queue) : ICT-6 (CE 2.0, post-bridge, autorisé maintenant).
