### PR TITLE
feat(infer): add Infer-19 Survival Analysis (conjugate Exp/Weibull)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
@@ -162,7 +162,7 @@ Note: `_GoalExtract.lean` (former prover test file) has been removed from the re
 | Project                | Decision | Reasoning                                                      |
 |------------------------|----------|----------------------------------------------------------------|
 | stable_marriage_lean   | COMPLETE | 0 sorry. Former false statements refuted, honest `exists_isManOptimal` proved. |
-| cooperative_games_lean | NO-GO    | hCore requires Hahn-Banach / hyperplane separation.           |
+| cooperative_games_lean | COMPLETE | 0 sorry. Bondareva-Shapley proven (#3954) via compact-slice Weierstrass; hCore bypassed without added axiom. |
 | social_choice_lean     | N/A      | COMPLETE (0 sorry). MechanismDesign added (#1469).             |
 | social_choice_lean_peters | N/A   | Reference only (pinned v4.27.0-rc1).                           |
 

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
@@ -1,0 +1,1632 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "62712df6",
+   "metadata": {},
+   "source": [
+    "# Infer-19 — Analyse de survie / fiabilite bayesienne : inferer le temps jusqu'a un evenement\n",
+    "\n",
+    "> **Corpus bayesien Infer.NET.** Ce notebook (19e du corpus) ouvre la famille des\n",
+    "> **modeles de duree** (time-to-event) : la quantite centrale n'est plus une moyenne ou un compte,\n",
+    "> mais une **fonction de survie** `S(t) = P(T > t)` — probabilite qu'un composant, un patient ou\n",
+    "> un client survive au-dela de l'instant `t`. Il complete la famille « sequences dans le temps »\n",
+    "> ([Infer-11 HMM](Infer-11-Sequences.ipynb), [Infer-17 Kalman](Infer-17-Kalman-Filter.ipynb),\n",
+    "> [Infer-18 Change-Point](Infer-18-Change-Point.ipynb)) par le cas ou l'observation n'est pas un\n",
+    "> etat recurrent mais un **delai unique** avant evenement.\n",
+    "\n",
+    "**Plan.** (1) Pourquoi un modele dedie aux durees. (2) Le modele exponentiel (cas conjugue).\n",
+    "(3) Fonction de survie predictive en forme fermee. (4) Le modele de Weibull via une astuce de\n",
+    "transformee. (5) Selection de la forme `k`. (6) Trois exercices (censure, regression AFT,\n",
+    "comparaison de modeles)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25f729d4",
+   "metadata": {},
+   "source": [
+    "## 1. Motivation : pourquoi pas une gaussienne ?\n",
+    "\n",
+    "Un ingenieur fiabilite observe les **durees de vie** (en heures) de `N` composants identiques\n",
+    "soumis a un test. La grandeur qui l'interesse est : *« quelle probabilite qu'un composant\n",
+    "fonctionne encore apres 1500 h ? »* — c'est-a-dire `S(1500) = P(T > 1500)`.\n",
+    "\n",
+    "Modeliser `T` par une gaussienne est inadequat pour trois raisons :\n",
+    "\n",
+    "1. **Le temps est positif.** Une gaussienne attribue une masse non nulle aux durees negatives.\n",
+    "2. **La distribution est asymetrique a droite.** Quelques composants vivent tres longtemps\n",
+    "   (longue queue), la moyenne depasse la mediane.\n",
+    "3. **Ce qui importe est la queue**, pas le centre : `S(t)` dans la region ou peu de composants\n",
+    "   sont encore en vie.\n",
+    "\n",
+    "Deux lois canoniques repondent a ces contraintes :\n",
+    "\n",
+    "- **Exponentielle** `T ~ Exp(lambda)` : taux de defaillance **constant** dans le temps\n",
+    "  (memoire, usure nulle). Un seul parametre `lambda > 0` (le taux).\n",
+    "- **Weibull** `T ~ Weibull(k, eta)` : taux de defaillance qui **varie** — `k < 1` (mortalite\n",
+    "  infantile, le composant se rodit), `k = 1` (retombe sur l'exponentielle), `k > 1` (usure,\n",
+    "  le risque croit avec l'age).\n",
+    "\n",
+    "Le defi d'inference : estimer `lambda`, ou le couple `(k, eta)`, a partir de durees observees,\n",
+    "puis **propager l'incertitude** jusqu'a `S(t)` — avec un intervalle de credibilite, pas un\n",
+    "chiffre unique. C'est exactement ce que le calcul bayesien via Infer.NET fournit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6cafeb7a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:44.296803Z",
+     "iopub.status.busy": "2026-07-01T23:33:44.291398Z",
+     "iopub.status.idle": "2026-07-01T23:33:47.786831Z",
+     "shell.execute_reply": "2026-07-01T23:33:47.781717Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:10f2:2be1:913c:9eae:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%16:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3256:b4d8:946e:168d%23:2048/\",\"http://172.19.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '23188.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.ML.Probabilistic\"\n",
+    "#r \"nuget: Microsoft.ML.Probabilistic.Compiler\"\n",
+    "// restore Infer.NET -- isole dans sa propre cellule (convention de la serie)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf8be122",
+   "metadata": {},
+   "source": [
+    "Configuration des espaces de noms Infer.NET. On retrouve le moteur **EP** (Expectation\n",
+    "Propagation) et les helpers. On ajoute une graine fixee pour que les durees synthetiques soient\n",
+    "reproductibles (le test porte sur l'inference, pas sur le tirage)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "444c7d04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:47.789309Z",
+     "iopub.status.busy": "2026-07-01T23:33:47.789085Z",
+     "iopub.status.idle": "2026-07-01T23:33:48.713426Z",
+     "shell.execute_reply": "2026-07-01T23:33:48.713069Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Infer.NET charge. Helpers Uniform / SampleExponential / SampleWeibull definis.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.ML.Probabilistic;\n",
+    "using Microsoft.ML.Probabilistic.Distributions;\n",
+    "using Microsoft.ML.Probabilistic.Models;\n",
+    "using Microsoft.ML.Probabilistic.Algorithms;\n",
+    "using Range = Microsoft.ML.Probabilistic.Models.Range;   // desambiguise vs System.Range\n",
+    "using System;\n",
+    "using System.Linq;\n",
+    "\n",
+    "var rand = new Random(42);\n",
+    "\n",
+    "// Helper : tirage uniforme et exponentiel reproductibles.\n",
+    "double Uniform() => rand.NextDouble();                                   // U ~ Uniform(0,1)\n",
+    "double SampleExponential(double rate) => -Math.Log(Uniform()) / rate;     // T ~ Exp(rate)\n",
+    "double SampleWeibull(double shape, double scale)                         // T ~ Weibull(k, eta)\n",
+    "    => scale * Math.Pow(-Math.Log(Uniform()), 1.0 / shape);\n",
+    "\n",
+    "Console.WriteLine(\"Infer.NET charge. Helpers Uniform / SampleExponential / SampleWeibull definis.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e1ae6ae",
+   "metadata": {},
+   "source": [
+    "## 2. Un jeu de donnees synthetique (verite connue)\n",
+    "\n",
+    "On simule les durees de vie de `N = 60` composants dont le **vrai** taux de defaillance est\n",
+    "`lambda_true = 1/1000` (duree moyenne caracteristique 1000 h). Connaissant la verite, on pourra\n",
+    "verifier que le postieur la recouvre. On garde egalement un jeu **Weibull** avec usure\n",
+    "(`k = 1.8`) pour la section 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1dc34615",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:48.715367Z",
+     "iopub.status.busy": "2026-07-01T23:33:48.715055Z",
+     "iopub.status.idle": "2026-07-01T23:33:49.010736Z",
+     "shell.execute_reply": "2026-07-01T23:33:49.010178Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Durees Exponentiel : N=60, moyenne observee=1262,9 h (attendu ~1000)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Durees Weibull      : N=60, moyenne observee=1041,0 h (k=1.8 -> queue plus courte)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "const int N = 60;\n",
+    "const double lambdaTrue = 1.0 / 1000.0;   // duree moyenne 1000 h\n",
+    "\n",
+    "double[] lifetimesExp = Enumerable.Range(0, N)\n",
+    "    .Select(_ => SampleExponential(lambdaTrue)).ToArray();\n",
+    "\n",
+    "// Second jeu : Weibull avec usure (k=1.8), meme duree caracteristique (eta=1000).\n",
+    "const double kTrue = 1.8, etaTrue = 1000.0;\n",
+    "double[] lifetimesWei = Enumerable.Range(0, N)\n",
+    "    .Select(_ => SampleWeibull(kTrue, etaTrue)).ToArray();\n",
+    "\n",
+    "Console.WriteLine($\"Durees Exponentiel : N={N}, moyenne observee={lifetimesExp.Average():F1} h (attendu ~1000)\");\n",
+    "Console.WriteLine($\"Durees Weibull      : N={N}, moyenne observee={lifetimesWei.Average():F1} h (k=1.8 -> queue plus courte)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1949cf8",
+   "metadata": {},
+   "source": [
+    "## 3. Le modele exponentiel : le cas conjugue\n",
+    "\n",
+    "Le modele le plus simple : `T_i ~ Exp(lambda)` pour chaque composant, avec un *a priori*\n",
+    "**Gamma** sur le taux `lambda`. Le prior Gamma est **conjugue** a la vraisemblance exponentielle :\n",
+    "EP renvoie donc un postieur exact, lui-meme Gamma.\n",
+    "\n",
+    "**Lien de conjugaison.** Si `lambda ~ Gamma(a0, b0)` (parametre forme `a0`, parametre **taux**\n",
+    "`b0`, donc moyenne `a0/b0`) et `T_i ~ Exp(lambda)` pour `i = 1..N`, alors le postieur est\n",
+    "`Gamma(a0 + N, b0 + somme(T_i))`. On retrouve ainsi, a la main, ce que le moteur calcule :\n",
+    "chaque observation ajoute `1` a la forme et sa duree `T_i` au taux. Le prior faible\n",
+    "`Gamma(0.001, 0.001)` laisse les donnees parler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1722c159",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:49.012487Z",
+     "iopub.status.busy": "2026-07-01T23:33:49.012249Z",
+     "iopub.status.idle": "2026-07-01T23:33:51.082896Z",
+     "shell.execute_reply": "2026-07-01T23:33:51.082516Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Posterieur du taux lambda (modele exponentiel) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Forme A   = 60,001\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Taux  B   = 75774,766\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Moyenne   = 0,000792  (vrai lambda = 0,001000)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Ecart-type= 0,000102\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Modele exponentiel conjugue sur le jeu de durees exponentielles.\n",
+    "Range item = new Range(N);\n",
+    "var lambda = Variable.GammaFromShapeAndRate(0.001, 0.001).Named(\"lambda\");   // prior vague sur le taux\n",
+    "var T = Variable.Array<double>(item).Named(\"T\");\n",
+    "T[item] = Variable.GammaFromShapeAndRate(1.0, lambda).ForEach(item);   // shape=1 => Exponentielle(lambda)\n",
+    "T.ObservedValue = lifetimesExp;\n",
+    "\n",
+    "var engine = new InferenceEngine { Algorithm = new ExpectationPropagation() };\n",
+    "Gamma lambdaPost = engine.Infer<Gamma>(lambda);\n",
+    "\n",
+    "Console.WriteLine(\"=== Posterieur du taux lambda (modele exponentiel) ===\");\n",
+    "Console.WriteLine($\"  Forme A   = {lambdaPost.Shape:F3}\");\n",
+    "Console.WriteLine($\"  Taux  B   = {lambdaPost.Rate:F3}\");\n",
+    "Console.WriteLine($\"  Moyenne   = {lambdaPost.GetMean():F6}  (vrai lambda = {lambdaTrue:F6})\");\n",
+    "Console.WriteLine($\"  Ecart-type= {Math.Sqrt(lambdaPost.GetVariance()):F6}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ca37573",
+   "metadata": {},
+   "source": [
+    "### Lecture du postérieur : la conjugaison se vérifie chiffres en main\n",
+    "\n",
+    "Le postérieur `Gamma(A, B)` renvoyé par EP coincide avec la formule de conjugaison :\n",
+    "\n",
+    "- `A = 60,001 = 0,001 + N` — la forme est l'a priori plus le nombre d'observations, **au centieme pres**.\n",
+    "- `B = 75 774,77 = 0,001 + Σ T_i` — le taux est l'a priori plus la somme des durees\n",
+    "  (or `Σ T_i / 60 = 1262,9 h`, exactement la moyenne observee).\n",
+    "\n",
+    "La moyenne postérieure `A/B = 7,92e-4` est **identique a l'estimateur du maximum de vraisemblance**\n",
+    "`1 / moyenne(T_i)`, parce que le prior `Gamma(0,001 ; 0,001)` est negligible devant 60 donnees. Elle\n",
+    "est legerement inferieure au vrai `lambda = 1e-3` non par biais du modele, mais parce que **cet\n",
+    "echantillon** a tire une moyenne de 1262,9 h (queue haute) au lieu de 1000 : avec `N = 60`,\n",
+    "l'intervalle de confiance sur la moyenne est large, et le postérieur le reflete fidelement\n",
+    "(ecart-type `~1,0e-4`, soit un coefficient de variation de 13 %). C'est precisement l'interet du\n",
+    "bayesien : on recupere non un chiffre, mais une **distribution** dont on propagera l'incertitude\n",
+    "jusqu'a la fonction de survie."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b9b9f43",
+   "metadata": {},
+   "source": [
+    "## 4. Fonction de survie predictive : une forme fermee\n",
+    "\n",
+    "La question de l'ingenieur — *« probabilite de survivre au-dela de 1500 h »* — se traduit par\n",
+    "la **survie predictive** : on moyenne la survie `exp(-lambda * t)` sur le postieur de `lambda`.\n",
+    "\n",
+    "**Forme fermee.** Si `lambda ~ Gamma(A, B)`, alors par transformee de Laplace :\n",
+    "\n",
+    "```\n",
+    "S(t) = E_lambda[ exp(-lambda * t) ] = ( B / (B + t) )^A\n",
+    "```\n",
+    "\n",
+    "Pas besoin d'echantillonner : pour chaque `t`, on branche les moments du postieur Gamma et on\n",
+    "obtient `S(t)` **exactement**, avec son incertitude qui decroit quand le postieur se concentre.\n",
+    "On trace `S(t)` sur `t ∈ [0, 3000]` et on le compare a la courbe empirique (Kaplan-Meier simplifiee,\n",
+    "ici sans censure : fraction d'observations superieures a `t`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3358bca7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:51.084307Z",
+     "iopub.status.busy": "2026-07-01T23:33:51.084124Z",
+     "iopub.status.idle": "2026-07-01T23:33:51.274851Z",
+     "shell.execute_reply": "2026-07-01T23:33:51.271821Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Fonction de survie S(t) : bayesienne vs empirique ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   t (h)   S_bayes   S_empir\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       0     1,000     1,000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     250     0,821     0,900\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     500     0,674     0,700\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    1000     0,455     0,450\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    1500     0,308     0,317\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    2000     0,209     0,183\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    3000     0,097     0,100\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "S(t) bayesienne (modele exponentiel) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     0h |########################################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    60h |######################################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   120h |####################################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   180h |###################################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   240h |#################################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   300h |################################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   360h |##############################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   420h |#############################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   480h |###########################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   540h |##########################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   600h |#########################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   660h |########################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   720h |#######################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   780h |######################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   840h |#####################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   900h |####################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   960h |###################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1020h |##################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1080h |#################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1140h |################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1200h |################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1260h |###############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1320h |##############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1380h |##############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1440h |#############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1500h |############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1560h |############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1620h |###########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1680h |###########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1740h |##########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1800h |##########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1860h |#########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1920h |#########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1980h |#########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2040h |########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2100h |########\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2160h |#######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2220h |#######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2280h |#######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2340h |######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2400h |######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2460h |######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2520h |######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2580h |#####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2640h |#####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2700h |#####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2760h |#####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2820h |####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2880h |####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2940h |####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3000h |####\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Survie predictive (forme fermee) + comparaison empirique.\n",
+    "double A = lambdaPost.Shape, B = lambdaPost.Rate;\n",
+    "double Sbayes(double t) => Math.Pow(B / (B + t), A);\n",
+    "\n",
+    "// Courbe empirique : fraction de durees > t.\n",
+    "double Semp(double t, double[] data) => data.Count(d => d > t) / (double)data.Length;\n",
+    "\n",
+    "Console.WriteLine(\"=== Fonction de survie S(t) : bayesienne vs empirique ===\");\n",
+    "Console.WriteLine($\"{\"t (h)\",8}  {\"S_bayes\",8}  {\"S_empir\",8}\");\n",
+    "foreach (var t in new[] { 0.0, 250, 500, 1000, 1500, 2000, 3000 })\n",
+    "    Console.WriteLine($\"{t,8:F0}  {Sbayes(t),8:F3}  {Semp(t, lifetimesExp),8:F3}\");\n",
+    "\n",
+    "// Trace ASCII leger de S(t) bayesienne.\n",
+    "Console.WriteLine(\"\\nS(t) bayesienne (modele exponentiel) :\");\n",
+    "const int W = 50;\n",
+    "foreach (var t in Enumerable.Range(0, W + 1).Select(j => j * 3000.0 / W))\n",
+    "{\n",
+    "    int bar = (int)Math.Round(Sbayes(t) * 40);\n",
+    "    Console.WriteLine($\"{t,6:F0}h |{new string('#', bar)}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5f897c1",
+   "metadata": {},
+   "source": [
+    "### Lecture : la question de l'ingenieur a maintenant une reponse quantifiee\n",
+    "\n",
+    "La question *« probabilite qu'un composant survive au-dela de 1500 h »* admet la reponse\n",
+    "`S(1500) ≈ 0,31` : environ un composant sur trois est encore en vie a 1500 h. Deux points :\n",
+    "\n",
+    "- **Accord bayesien / empirique.** Les deux courbes se suivent (ecart maximal ~0,08 a `t = 250`)\n",
+    "  mais de nature differente : la bayesienne est **parametrique et lisse** (elle croit au modele\n",
+    "  exponentiel et projette sa forme), l'empirique est **en escalier** (fraction brute des durees\n",
+    "  superieures a `t`). Leur proximite valide que l'exponentielle decrit bien ce jeu.\n",
+    "- **Forme fermee exacte.** `S(t) = (B/(B+t))^A` n'est pas une approximation Monte-Carlo : c'est\n",
+    "  la transformee de Laplace du postieur Gamma, calculee en un seul coup. On peut donc donner un\n",
+    "  intervalle de credibilite sur `S(t)` en tirant des `lambda` du postieur — l'incertitude sur le\n",
+    "  taux se propage gratuitement jusqu'a la queue, la ou l'enjeu fiabilite se trouve."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1789688",
+   "metadata": {},
+   "source": [
+    "## 5. Le modele de Weibull : une astuce de transformee\n",
+    "\n",
+    "L'exponentielle suppose un taux **constant** (ni rodage, ni usure). La loi de **Weibull**\n",
+    "generalise : `T ~ Weibull(k, eta)` avec fonction de survie `S(t) = exp(-(t/eta)^k)`.\n",
+    "\n",
+    "Inferer directement la **forme** `k` par EP est delicat (la vraisemblance de Weibull n'est\n",
+    "conjuguee a aucun prior usuel). Mais si l'on fixe `k`, une **transformee** ramene le probleme au\n",
+    "cas conjugue :\n",
+    "\n",
+    "```\n",
+    "U_i = T_i^k  ==>  U_i ~ Exp(rate = eta^{-k})\n",
+    "```\n",
+    "\n",
+    "On infere donc le taux transforme `r = eta^{-k}` avec un prior Gamma (conjugue), puis on remonte\n",
+    "a `eta = r^{-1/k}`. La survie predictive devient `S(t) = (B / (B + t^k))^A` (meme forme fermee,\n",
+    "avec `t` remplace par `t^k`). La section suivante choisira le meilleur `k` par balayage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d77b4a83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:51.276786Z",
+     "iopub.status.busy": "2026-07-01T23:33:51.276418Z",
+     "iopub.status.idle": "2026-07-01T23:33:51.706128Z",
+     "shell.execute_reply": "2026-07-01T23:33:51.705973Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Modele Weibull (k=1.8 fixe) sur le jeu Weibull ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  r = eta^-k      = 2,926E-006\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  eta (back-out)  = 1186,7 h  (vrai eta = 1000,0)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Survie a 1000 h = 0,482\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Weibull a forme k fixee : transformee U = T^k ~ Exp(r), r = eta^{-k}.\n",
+    "double InferWeibullRate(double k, double[] data, out Gamma rPost)\n",
+    "{\n",
+    "    Range it = new Range(data.Length);\n",
+    "    var r = Variable.GammaFromShapeAndRate(0.001, 0.001).Named(\"r_\" + k.ToString(\"F1\"));\n",
+    "    var U = Variable.Array<double>(it).Named(\"U_\" + k.ToString(\"F1\"));\n",
+    "    U[it] = Variable.GammaFromShapeAndRate(1.0, r).ForEach(it);   // shape=1 => Exponentielle(r)\n",
+    "    U.ObservedValue = data.Select(t => Math.Pow(t, k)).ToArray();\n",
+    "    var eng = new InferenceEngine { Algorithm = new ExpectationPropagation() };\n",
+    "    rPost = eng.Infer<Gamma>(r);\n",
+    "    return rPost.GetMean();\n",
+    "}\n",
+    "\n",
+    "double kFixed = 1.8;   // (on retrouvera ce k par balayage a la section 6)\n",
+    "double rMean = InferWeibullRate(kFixed, lifetimesWei, out Gamma rPost);\n",
+    "double etaMean = Math.Pow(rMean, -1.0 / kFixed);\n",
+    "\n",
+    "Console.WriteLine(\"=== Modele Weibull (k=1.8 fixe) sur le jeu Weibull ===\");\n",
+    "Console.WriteLine($\"  r = eta^-k      = {rMean:E3}\");\n",
+    "Console.WriteLine($\"  eta (back-out)  = {etaMean:F1} h  (vrai eta = {etaTrue:F1})\");\n",
+    "Console.WriteLine($\"  Survie a 1000 h = {Math.Pow(rPost.Rate/(rPost.Rate + Math.Pow(1000,kFixed)), rPost.Shape):F3}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2589f066",
+   "metadata": {},
+   "source": [
+    "### Lecture : la transformee ramene Weibull au cas conjugue\n",
+    "\n",
+    "L'astuce `U = T^k ~ Exp(rate = eta^{-k})` fonctionne : EP infere un postérieur Gamma sur `r` sans\n",
+    "aucune fragilite (pas d'inference directe sur la forme). On remonte `eta = r^{-1/k} ≈ 1187 h`,\n",
+    "a comparer au vrai `eta = 1000 h`. La surestimation vient, comme pour l'exponentiel, de\n",
+    "l'echantillon : sa moyenne (1041 h) est un peu haute, et avec `k = 1,8` on a\n",
+    "`moyenne = eta · Γ(1 + 1/k) ≈ eta · 0,89`, d'ou un `eta` implique par les donnees autour de 1170 h.\n",
+    "\n",
+    "La survie estimee `S(1000) ≈ 0,48` (contre `e^{-1} ≈ 0,37` pour le vrai `Weibull(1,8 ; 1000)`)\n",
+    "reflete cette meme surestimation de `eta`. Ce n'est pas un defaut de la methode mais du bruit\n",
+    "d'echantillonnage a `N = 60` ; l'apport pedagogique est ailleurs : **toute la richesse de Weibull\n",
+    "(usure, rodage) est accessible sans payer le cout d'une inference EP sur la forme**, des lors que\n",
+    "l'on fixe `k` (ou qu'on le choisit par balayage, section suivante)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "876c6bfc",
+   "metadata": {},
+   "source": [
+    "## 6. Selection de la forme k : balayage par log-vraisemblance predictive\n",
+    "\n",
+    "Comment choisir `k` sans payer le cout d'une inference EP sur la forme ? On **balaye** `k` sur\n",
+    "une grille et, pour chaque `k`, on calcule la **log-vraisemblance predictive** (leave-one-out\n",
+    "approchee) du jeu observe : pour chaque duree `T_i`, la densite Weibull evaluee avec le postieur\n",
+    "entraene sur les autres. Le `k` qui maximise cette score est le meilleur compromis biais/variance.\n",
+    "\n",
+    "Sur le jeu exponentiel (taux constant), `k ≈ 1` doit gagner ; sur le jeu Weibull `k = 1.8`,\n",
+    "c'est `k ≈ 1.8` qui doit gagner. C'est un test de coherence interne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "71468adb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:51.707511Z",
+     "iopub.status.busy": "2026-07-01T23:33:51.707309Z",
+     "iopub.status.idle": "2026-07-01T23:33:55.095503Z",
+     "shell.execute_reply": "2026-07-01T23:33:55.095332Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Selection de la forme k (log-vraisemblance predictive) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    k     score Exp   score Weibull\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,8        -494,0          -485,7\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1,0        -488,5          -476,9\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1,2        -486,8          -471,3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1,5        -489,4          -467,1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1,8        -496,7          -466,7\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2,0        -503,5          -468,1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2,5        -526,1          -475,7\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  k* (jeu exponentiel) = 1,2  (attendu ~1.0)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  k* (jeu Weibull)     = 1,8  (attendu ~1.8)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Balayage de k : pour chaque k, log-vraisemblance predictive (LOO approchee).\n",
+    "double ShapeScore(double k, double[] data)\n",
+    "{\n",
+    "    // Posterieur du taux transforme r sur TOUT le jeu, densite Weibull evaluee en chaque point.\n",
+    "    // (approximation LOO : le postieur est peu sensible a un seul point quand N est grand.)\n",
+    "    double rMean = InferWeibullRate(k, data, out Gamma rPost);\n",
+    "    double A_ = rPost.Shape, B_ = rPost.Rate;\n",
+    "    // Densite de T_i sous Weibull(k, eta) avec eta = r^{-1/k}, r ~ Gamma(A,B).\n",
+    "    // On evalue la log-densite marginale approchee a la moyenne post.: r_hat = A/B.\n",
+    "    double rHat = A_ / B_;\n",
+    "    double eta = Math.Pow(rHat, -1.0 / k);\n",
+    "    double lp = 0.0;\n",
+    "    foreach (var t in data)\n",
+    "    {\n",
+    "        double z = t / eta;\n",
+    "        lp += Math.Log(k) - k * Math.Log(eta) + (k - 1) * Math.Log(t) - Math.Pow(z, k);\n",
+    "    }\n",
+    "    return lp;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"=== Selection de la forme k (log-vraisemblance predictive) ===\");\n",
+    "Console.WriteLine($\"{\"k\",5}  {\"score Exp\",12}  {\"score Weibull\",14}\");\n",
+    "var ks = new[] { 0.8, 1.0, 1.2, 1.5, 1.8, 2.0, 2.5 };\n",
+    "double bestExp = double.NegativeInfinity, bestWei = double.NegativeInfinity;\n",
+    "double kExp = 1, kWei = 1;\n",
+    "foreach (var k in ks)\n",
+    "{\n",
+    "    double se = ShapeScore(k, lifetimesExp);\n",
+    "    double sw = ShapeScore(k, lifetimesWei);\n",
+    "    Console.WriteLine($\"{k,5:F1}  {se,12:F1}  {sw,14:F1}\");\n",
+    "    if (se > bestExp) { bestExp = se; kExp = k; }\n",
+    "    if (sw > bestWei) { bestWei = sw; kWei = k; }\n",
+    "}\n",
+    "Console.WriteLine($\"\\n  k* (jeu exponentiel) = {kExp:F1}  (attendu ~1.0)\");\n",
+    "Console.WriteLine($\"  k* (jeu Weibull)     = {kWei:F1}  (attendu ~1.8)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb31ff41",
+   "metadata": {},
+   "source": [
+    "### Lecture : le balayage recupere la vraie forme et distingue les deux regimes\n",
+    "\n",
+    "Le test de coherence reussit sur les deux jeux :\n",
+    "\n",
+    "- **Jeu Weibull** (`k = 1,8`) : le score est **minimal en `k = 1,8`** (`-466,7`), c'est-a-dire\n",
+    "  exactement la valeur vraie. Le pic est net (`k = 1,5` et `k = 2,0` sont deja moins bons).\n",
+    "  La methode retrouve la signature d'usure.\n",
+    "- **Jeu exponentiel** (`k = 1`) : le meilleur est `k = 1,2` (`-486,8`), mais `k = 1,0` (`-488,5`)\n",
+    "  est a moins de 2 unites : **ex aequo dans le bruit d'echantillonnage**. Leger tilt vers `1,2`\n",
+    "  parce que cet echantillon exponentiel n'etait pas un exponentiel parfait. On conclut donc\n",
+    "  raisonnablement `k ≈ 1` (taux constant), ce qui est la bonne reponse.\n",
+    "\n",
+    "Cette approche par **grille** evite l'inference EP directe sur la forme (notoirement instable) au\n",
+    "prix de quelques compilations de modele (7 ici, chacune instantanee). C'est le compromis\n",
+    "operationnel : robustesse contre temps de calcul, dans l'esprit de la regle « realiser le moteur,\n",
+    "pas le contourner »."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf264f67",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Les trois exercices ci-dessous etendent le modele de duree. Ils sont laisses **a completer**\n",
+    "(stubs sans erreur) — le notebook s'execute de bout en bout meme non rempli."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a19660d6",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Censure a droite (donnees tronquees)\n",
+    "\n",
+    "En fiabilite reelle, beaucoup de composants **survivent** a la fin du test : on n'observe pas\n",
+    "leur duree exacte `T_i`, seulement qu'elle depasse la duree du test `c_i`. C'est la **censure a\n",
+    "droite**. La contribution de vraisemblance d'un point censure n'est pas la densite `f(c_i)` mais\n",
+    "la survie `S(c_i) = exp(-lambda * c_i)`.\n",
+    "\n",
+    "**Indice :** separez indices observes / censures. Pour les observes, branchez `T_i ~ Exp(lambda)`\n",
+    "comme en section 3. Pour les censures, ajoutez un facteur de survie : en Infer.NET on peut\n",
+    "exprimer `exp(-lambda * c_i)` comme la probabilite qu'une variable latente exponentielle de taux\n",
+    "`lambda` soit superieure a `c_i` (via `Variable.ConstrainPositive` sur `c_i - T_i`, ou en\n",
+    "modelisant un indicateur d'evenement). Comparez le postieur obtenu avec/sans censure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "668036ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:55.097025Z",
+     "iopub.status.busy": "2026-07-01T23:33:55.096829Z",
+     "iopub.status.idle": "2026-07-01T23:33:55.131640Z",
+     "shell.execute_reply": "2026-07-01T23:33:55.131464Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : modele exponentiel avec censure a droite.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : censure a droite (a completer)\n",
+    "// TODO etudiant : repartir indices observes/censures, ajouter le facteur S(c_i) pour les censures.\n",
+    "Console.WriteLine(\"Exercice 1 a completer : modele exponentiel avec censure a droite.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a84e4a09",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Regression de temps accelere (AFT)\n",
+    "\n",
+    "La duree depend d'une covariable (temperature, contrainte). Modele **AFT** (Accelerated Failure\n",
+    "Time) : le taux devient specifique au composant, `lambda_i = lambda0 * exp(beta * x_i)` ou `x_i`\n",
+    "est la covariable centree et `beta` le coefficient a inferer.\n",
+    "\n",
+    "**Indice :** declarez `lambda0 ~ Gamma` et `beta ~ Gaussian(0, grande)`, puis bouclez sur les\n",
+    "composants avec `Variable.Exponential(lambda0 * Variable.Exp(beta * x[i]))`. Inferer `beta`\n",
+    "donne l'effet de la contrainte sur la duree de vie (signe et amplitude). Attention : le produit\n",
+    "dans le taux rend le postieur non conjugue — EP le traite quand meme (approximation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e2014207",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:55.133271Z",
+     "iopub.status.busy": "2026-07-01T23:33:55.133052Z",
+     "iopub.status.idle": "2026-07-01T23:33:55.162533Z",
+     "shell.execute_reply": "2026-07-01T23:33:55.161998Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : regression de temps accelere (AFT).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : regression AFT (a completer)\n",
+    "// TODO etudiant : lambda_i = lambda0 * exp(beta * x_i), inferer beta.\n",
+    "Console.WriteLine(\"Exercice 2 a completer : regression de temps accelere (AFT).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c11b94eb",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Exponentiel vs Weibull : facteur de Bayes\n",
+    "\n",
+    "Sur un meme jeu de durees, comparer le modele exponentiel (`k = 1`) au modele Weibull (`k` libre)\n",
+    "via un **facteur de Bayes** (rapport des vraisemblances marginales). Le verdict depend de la\n",
+    "taille `N` et du vrai `k`.\n",
+    "\n",
+    "**Indice :** la section 6 calcule deja un score par `k`. Generalisez-le en vraisemblance\n",
+    "marginale (intégrez sur le postieur de `r`, pas juste evaluez a la moyenne), puis formez le\n",
+    "rapport `BF = p(D | Weibull) / p(D | exponentiel)`. A partir de quel `N` le Weibull `k = 1.8`\n",
+    "est-il prefere de facon decisive (`log BF > 5`) ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8f861db9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T23:33:55.164332Z",
+     "iopub.status.busy": "2026-07-01T23:33:55.164079Z",
+     "iopub.status.idle": "2026-07-01T23:33:55.218035Z",
+     "shell.execute_reply": "2026-07-01T23:33:55.217849Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : facteur de Bayes exponentiel vs Weibull.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : facteur de Bayes exponentiel vs Weibull (a completer)\n",
+    "// TODO etudiant : vraisemblance marginale par k, rapport BF, seuil en N.\n",
+    "Console.WriteLine(\"Exercice 3 a completer : facteur de Bayes exponentiel vs Weibull.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c52015b",
+   "metadata": {},
+   "source": [
+    "## 8. Conclusion\n",
+    "\n",
+    "L'analyse de survie complete la famille des modeles temporels du corpus Infer :\n",
+    "\n",
+    "| Notebook | Nature du temps | Quantite inferee |\n",
+    "|----------|-----------------|------------------|\n",
+    "| [Infer-11](Infer-11-Sequences.ipynb) (HMM) | discret, recurrent | trajectoire d'etats caches |\n",
+    "| [Infer-17](Infer-17-Kalman-Filter.ipynb) (Kalman) | continu, recurrent | etat filtre pas-a-pas |\n",
+    "| [Infer-18](Infer-18-Change-Point.ipynb) (Change-Point) | continu, a rupture | instant d'un changement de regime |\n",
+    "| **Infer-19 (Survie)** | **continu, duree unique** | **fonction de survie S(t)** |\n",
+    "\n",
+    "**A retenir.**\n",
+    "\n",
+    "- Le temps jusqu'a un evenement se modelise par une loi **positive asymetrique** (exponentielle,\n",
+    "  Weibull), pas une gaussienne — ce qui compte est la queue, i.e. `S(t)`.\n",
+    "- Le cas **exponentiel** est conjugue : prior Gamma sur le taux, postieur Gamma exact. La survie\n",
+    "  predictive se ramene a une **forme fermée** `(B/(B+t))^A` (transformee de Laplace du Gamma).\n",
+    "- Le cas **Weibull** se ramene a l'exponentiel par **transformee** `U = T^k` des que `k` est fixe,\n",
+    "  evitant la fragilite de EP sur la forme. On choisit `k` par balayage (log-vraisemblance\n",
+    "  predictive), non par inference directe.\n",
+    "- La censure, la regression AFT et la selection par facteur de Bayes sont les prolongements\n",
+    "  naturels (exercices).\n",
+    "\n",
+    "**Pour aller plus loin.** La censure a gauche/par intervalle, les modeles a risques concurrents\n",
+    "(competing risks) et les modeles de fragilite partagee (frailty, analogue hierarchique de\n",
+    "[Infer-16](Infer-16-Modeles-Hierarchiques.ipynb) applique a la survie) sont les extensions\n",
+    "classiques au-dela de ce notebook.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Gelman A. et al., *Bayesian Data Analysis* (3e ed.), chap. « Survival models ».\n",
+    "- Lawless J. F., *Statistical Models and Methods for Lifetime Data* — reference pour Weibull/AFT.\n",
+    "- Infer.NET documentation : `Variable.GammaFromShapeAndRate` (prior sur le taux ; shape=1 donne\n",
+    "  l'exponentielle), `Variable.Weibull`.\n",
+    "- Relation a la serie : [Infer-16](Infer-16-Modeles-Hierarchiques.ipynb) (modeles hierarchiques),\n",
+    "  [Infer-18](Infer-18-Change-Point.ipynb) (rupture — ou le taux change brusquement)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -66,10 +66,11 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 | 16 | [Infer-16-Modeles-Hierarchiques](Infer-16-Modeles-Hierarchiques.ipynb) | 50 min | Modèles hiérarchiques, pooling partiel, shrinkage, VariableArray indexé |
 | 17 | [Infer-17-Kalman-Filter](Infer-17-Kalman-Filter.ipynb) | 55 min | Filtre de Kalman, système dynamique linéaire gaussien, conjugaison, EP exacte |
 | 18 | [Infer-18-Change-Point](Infer-18-Change-Point.ipynb) | 50 min | Détection de rupture, DiscreteUniform, ForEach + If/IfNot sur plage, EP, Poisson |
+| 19 | [Infer-19-Survival-Analysis](Infer-19-Survival-Analysis.ipynb) | 50 min | Analyse de survie, Exponentielle conjugée (Gamma), Weibull par transformée, S(t) forme fermée |
 
 > **Théorie de la décision** : les 10 notebooks de décision (utilité, EVPI, MDPs, Thompson Sampling, plus 2 companions Lean) forment désormais un arc autonome dans [`../DecisionTheory/Infer/`](../DecisionTheory/Infer/README.md), adossé au lake [`decision_theory_lean`](../decision_theory_lean/).
 
-**Durée totale** : ~14h (corpus bayésien 1-18)
+**Durée totale** : ~14h50 (corpus bayésien 1-19)
 
 **Ressource complémentaire** : [Glossaire](Infer-Glossary.md) - Définitions des termes techniques
 
@@ -82,7 +83,7 @@ flowchart TD
     P3["<b>Classification & sélection</b> (7-8)<br/>A/B tests · evidence · ARD"]
     P4["<b>Modèles avancés</b> (9-12)<br/>LDA · crowdsourcing · HMM · reco"]
     P5["<b>Référence</b> (13)<br/>Debugging · comparaison algorithmes"]
-    P8["<b>Frontières</b> (14-18)<br/>causalité · GP sparse · hiérarchique · Kalman · change-point"]
+    P8["<b>Frontières</b> (14-19)<br/>causalité · GP sparse · hiérarchique · Kalman · change-point · survie"]
     DT["<b>Théorie de la décision</b><br/>arc autonome : ../DecisionTheory/Infer/"]
     P1 --> P2 --> P3 --> P4
     P4 --> P8


### PR DESCRIPTION
## Summary

New notebook **Infer-19 — Analyse de survie / fiabilité bayésienne** (19th of the bayesian Infer corpus), opening the **time-to-event** family. Plus a bundled doc-consistency fix in `GameTheory/LEAN_INVENTORY.md`.

### Theme choice (3-line argument, per dispatch `r47hah`)

The Infer corpus 1-18 covers **Poisson counts** (Infer-18 coal-mining), **GP + classification** (Infer-15), and **HMM / Kalman / change-point** (11/17/18). Of the 3 coordinator-suggested themes (Poisson / survival / GP-classification), only **survival analysis is genuinely missing** — a Poisson notebook would overlap Infer-18's coal-mining model, and GP-classification is already Infer-15's subject. Survival (time-to-event, `S(t) = P(T > t)`) is the distinct, uncovered member.

### Robust EP design (avoids shape-inference fragility)

- **Exponential model**: conjugate Gamma prior on rate `lambda` → exact Gamma posterior. Predictive survival `S(t) = (B/(B+t))^A` in **closed form** (Laplace transform of Gamma).
- **Weibull model**: power transform `U = T^k ~ Exp(rate = eta^{-k})` with `k` **fixed** → still conjugate. Back out `eta = r^{-1/k}`. Avoids EP fragility on the shape parameter.
- **Shape selection**: grid sweep over `k` (log-predictive), not direct EP inference on `k`.

## Validation (real execution)

- `.net-csharp` kernel, executed end-to-end via `jupyter nbconvert --execute` (NOT papermill — `.lake/packages` blow up the working set).
- **10/10 code cells executed, 0 errors, exec_counts 1-10** (rule H.1, C.2).
- 0 `raise NotImplementedError` / `assert False` / `1/0` (rule C.1); 3 exercise stubs use `Console.WriteLine("...a completer")`.
- Conjugation **verified numerically**: posterior shape `A = 60.001 = 0.001 + N` exactly (prior 0.001 + 60 obs), rate `B = 75774.77 = 0.001 + ΣT_i`.
- Grid sweep recovers the **true** `k = 1.8` on Weibull data (minimum score `-466.7`), and `k ≈ 1` (ex-aequo 1.0/1.2 within noise) on exponential data — internal coherence test passes.
- Survival `S(1500) ≈ 0.31` answers the engineer's question with propagated uncertainty.

## Files (3)

- `Infer-19-Survival-Analysis.ipynb` — new, 27 cells (10 code executed + 4 interpretation cells grounded on real outputs).
- `Probas/Infer/README.md` — added row 19, duration `~14h50` (1-19), Mermaid P8 node `(14-19 ... survie)`. No `CATALOG-STATUS` markers in this hub (byte-identical n/a).
- `GameTheory/LEAN_INVENTORY.md` — **bundled doc fix** (per dispatch `r47hah`, to clear the §E `<20-line doc-PR` threshold): the GO/NO-GO table row said `cooperative_games_lean NO-GO (hCore/Hahn-Banach)` while the same file's status section (lines 10, 69) documents Bondareva-Shapley **COMPLETE, 0 sorry** (PR #3954, hCore bypassed via compact-slice Weierstrass without added axiom). Markdown-only, no Lean code touched (Lean = po-2026 turf).

See #3801 (SOTA problem-richness, Prong B). See #4764 for the corpus lineage.

Co-Authored-By: Claude-Code <noreply@anthropic.com>