### PR TITLE
docs(qcpy): realign 17 audit exec-counts to actual .ipynb state

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -20,9 +20,9 @@ Full classification: [docs/archive/qc-strategies-status.md](../../../docs/archiv
 
 ---
 
-## État réel d'exécution (audit 2026-05-05, mise à jour 2026-05-28)
+## État réel d'exécution (audit 2026-05-05, mise à jour 2026-07-02)
 
-Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Aucun output theatrical** (cellules qui printent des métadonnées en se faisant passer pour une exécution) ne subsiste après nettoyage de la PR `chore/qc-strip-fake-outputs`. Mise à jour 2026-05-28 : ajout des 5 notebooks créés depuis l'audit initial (RL avancé + 2 Cloud).
+Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Aucun output theatrical** (cellules qui printent des métadonnées en se faisant passer pour une exécution) ne subsiste après nettoyage de la PR `chore/qc-strip-fake-outputs`. Mise à jour 2026-05-28 : ajout des 5 notebooks créés depuis l'audit initial (RL avancé + 2 Cloud). Mise à jour 2026-07-02 : réalignement des comptes « A/B cellules avec outputs » sur l'état réel des `.ipynb` (convention A = cellules avec outputs non vides, B = cellules code totales) — 17 lignes mises à jour après les ré-exécutions post-audit (RL PPO/SAC-A2C/DQN, training LSTM/Transformer, paper-trading, Cloud-Risk-Parity, etc.).
 
 **Légende** :
 - **EXÉCUTÉ** : cellules avec outputs réels issus d'une vraie exécution kernel
@@ -48,44 +48,44 @@ Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Auc
 | QC-Py-15-Parameter-Optimization | NON EXÉCUTÉ | 29 cellules code, 0 output |
 | QC-Py-16-Alternative-Data | NON EXÉCUTÉ | 15 cellules code, 0 output |
 | QC-Py-17-Sentiment-Analysis | NON EXÉCUTÉ | 19 cellules code, 0 output |
-| QC-Py-18-ML-Features-Engineering | EXÉCUTÉ | 21/22 cellules avec outputs |
+| QC-Py-18-ML-Features-Engineering | EXÉCUTÉ | 22/25 cellules avec outputs |
 | QC-Py-19-ML-Supervised-Classification | NON EXÉCUTÉ | 24 cellules code, 0 output |
 | QC-Py-20-ML-Regression-Prediction | NON EXÉCUTÉ | 22 cellules code, 0 output |
 | QC-Py-21-Portfolio-Optimization-ML | NON EXÉCUTÉ | 20 cellules code, 0 output |
 | QC-Py-22-Deep-Learning-LSTM | NON EXÉCUTÉ | 26 cellules code, 0 output |
-| QC-Py-23-Attention-Transformers | EXÉCUTÉ | 14/14 cellules avec outputs |
+| QC-Py-23-Attention-Transformers | EXÉCUTÉ | 14/17 cellules avec outputs |
 | QC-Py-23b-PatchTST-iTransformer | EXÉCUTÉ | 13/13 cellules avec outputs |
-| QC-Py-24-Autoencoders-Anomaly | EXÉCUTÉ | 18/18 cellules avec outputs |
-| QC-Py-25-Reinforcement-Learning | EXÉCUTÉ | 12/12 cellules avec outputs |
+| QC-Py-24-Autoencoders-Anomaly | EXÉCUTÉ | 18/21 cellules avec outputs |
+| QC-Py-25-Reinforcement-Learning | EXÉCUTÉ | 12/15 cellules avec outputs |
 | QC-Py-26-LLM-Trading-Signals | NON EXÉCUTÉ | 11 cellules code, 0 output |
 | QC-Py-27-Production-Deployment | NON EXÉCUTÉ | 9 cellules code, 0 output |
 | QC-Py-28-Market-Regime-Detection | NON EXÉCUTÉ | 14 cellules code, 0 output |
-| QC-Py-30-LSTM-Training | EXÉCUTÉ | 16/16 cellules avec outputs |
-| QC-Py-31-Transformer-Training | EXÉCUTÉ | 14/14 cellules avec outputs |
-| QC-Py-32-RL-DQN-Trading | EXÉCUTÉ | 12/12 cellules avec outputs |
-| QC-Py-40-PaperTrading-Binance | EXÉCUTÉ | 10/10 cellules avec outputs |
-| QC-Py-41-PaperTrading-IBKR | EXÉCUTÉ | 9/9 cellules avec outputs |
-| QC-Py-Cloud-01-FinBERT-Sentiment | EXÉCUTÉ | 5/6 cellules avec outputs |
+| QC-Py-30-LSTM-Training | EXÉCUTÉ | 19/19 cellules avec outputs |
+| QC-Py-31-Transformer-Training | EXÉCUTÉ | 17/17 cellules avec outputs |
+| QC-Py-32-RL-DQN-Trading | EXÉCUTÉ | 15/15 cellules avec outputs |
+| QC-Py-40-PaperTrading-Binance | EXÉCUTÉ | 11/12 cellules avec outputs |
+| QC-Py-41-PaperTrading-IBKR | EXÉCUTÉ | 12/12 cellules avec outputs |
+| QC-Py-Cloud-01-FinBERT-Sentiment | EXÉCUTÉ | 6/9 cellules avec outputs |
 | QC-Py-Cloud-01-RiskParity-Composite | doc cloud | markdown-only — backtest sur QC Cloud |
-| QC-Py-Cloud-02-ML-Classification | EXÉCUTÉ | 2/3 cellules avec outputs |
+| QC-Py-Cloud-02-ML-Classification | EXÉCUTÉ | 2/6 cellules avec outputs |
 | QC-Py-Cloud-02-SectorRotation-Momentum | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-03-DualMomentum | doc cloud | markdown-only — backtest sur QC Cloud |
-| QC-Py-Cloud-03-Risk-Parity | EXÉCUTÉ | 1/2 cellules avec outputs |
+| QC-Py-Cloud-03-Risk-Parity | EXÉCUTÉ | 6/6 cellules avec outputs |
 | QC-Py-Cloud-04-MeanReversion | doc cloud | markdown-only — backtest sur QC Cloud |
-| QC-Py-Cloud-04-RL-DQN-Trading | EXÉCUTÉ | 1/2 cellules avec outputs |
-| QC-Py-Cloud-05-MLP-Forecasting | EXÉCUTÉ | 1/2 cellules avec outputs |
+| QC-Py-Cloud-04-RL-DQN-Trading | EXÉCUTÉ | 2/5 cellules avec outputs |
+| QC-Py-Cloud-05-MLP-Forecasting | EXÉCUTÉ | 2/5 cellules avec outputs |
 | QC-Py-Cloud-05-RegimeSwitching | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-06-VolTargeting | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-06-PCA-StatArb | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-07-TemporalCNN | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-08-ValueFactor-ZScore | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-09-OptionWheel | doc cloud | markdown-only — backtest sur QC Cloud |
-| QC-Py-33-RL-PPO-Trading | EXÉCUTÉ | 12/12 cellules avec outputs |
-| QC-Py-34-RL-SAC-A2C-Trading | EXÉCUTÉ | 11/11 cellules avec outputs |
-| QC-Py-35-RL-Portfolio-Construction | EXÉCUTÉ | 5/5 cellules avec outputs |
+| QC-Py-33-RL-PPO-Trading | EXÉCUTÉ | 15/16 cellules avec outputs |
+| QC-Py-34-RL-SAC-A2C-Trading | EXÉCUTÉ | 14/17 cellules avec outputs |
+| QC-Py-35-RL-Portfolio-Construction | EXÉCUTÉ | 7/9 cellules avec outputs |
 | QC-Py-Dataset-Workflow | NON EXÉCUTÉ | 11 cellules code, 0 output |
 
-**Récapitulatif** : 53 notebooks total — 17 exécutés, 26 non exécutés, 10 doc cloud.
+**Récapitulatif** : 53 notebooks total — 18 exécutés, 25 non exécutés, 10 doc cloud.
 
 **Politique** : un notebook NON EXÉCUTÉ avec du code réel est préférable à un notebook avec des outputs théâtraux (print de métadonnées prétendant être une exécution). Les patterns théâtraux suivants sont désormais détectés comme erreur par [`scripts/validate_qc_notebooks.py`](../scripts/validate_qc_notebooks.py) :
 - `print("Algorithme charge : {len(qc_code)} caracteres")` — métadonnée d'une string, pas une exécution


### PR DESCRIPTION
## Summary

Genuine slice of **#3976** (aligner les comptes de stratégies/notebooks sur l'état réel). The "État réel d'exécution" audit table in `QuantConnect/Python/README.md` held stale `A/B` cell counts (dated 2026-05-28) for **17 notebooks** re-executed after the initial audit. Realigned to actual `.ipynb` state.

**Convention**: `A/B cellules avec outputs` where **A = code cells with non-empty outputs**, **B = total code cells**.

## Changes (single file, markdown-only)

17 exec-count rows realigned (old → new):

| Notebook | Old | New |
|----------|-----|-----|
| QC-Py-18-ML-Features-Engineering | 21/22 | 22/25 |
| QC-Py-23-Attention-Transformers | 14/14 | 14/17 |
| QC-Py-24-Autoencoders-Anomaly | 18/18 | 18/21 |
| QC-Py-25-Reinforcement-Learning | 12/12 | 12/15 |
| QC-Py-30-LSTM-Training | 16/16 | 19/19 |
| QC-Py-31-Transformer-Training | 14/14 | 17/17 |
| QC-Py-32-RL-DQN-Trading | 12/12 | 15/15 |
| QC-Py-33-RL-PPO-Trading | 12/12 | 15/16 |
| QC-Py-34-RL-SAC-A2C-Trading | 11/11 | 14/17 |
| QC-Py-35-RL-Portfolio-Construction | 5/5 | 7/9 |
| QC-Py-40-PaperTrading-Binance | 10/10 | 11/12 |
| QC-Py-41-PaperTrading-IBKR | 9/9 | 12/12 |
| QC-Py-Cloud-01-FinBERT-Sentiment | 5/6 | 6/9 |
| QC-Py-Cloud-02-ML-Classification | 2/3 | 2/6 |
| QC-Py-Cloud-03-Risk-Parity | 1/2 | 6/6 |
| QC-Py-Cloud-04-RL-DQN-Trading | 1/2 | 2/5 |
| QC-Py-Cloud-05-MLP-Forecasting | 1/2 | 2/5 |

- **Récapitulatif** corrected: `17/26/10` → `18/25/10` (the table body has 18 EXÉCUTÉ / 25 NON EXÉCUTÉ / 10 doc-cloud = 53 total, unchanged).
- **Date** bumped to 2026-07-02 with a note documenting the realignment + the A/B convention.

## Verification (G.1 firsthand)

Each row cross-checked against the real `.ipynb` on `origin/main`:
```
checked 18 EXÉCUTÉ rows, still-mismatched 0
```
All 18 EXÉCUTÉ rows now match `len(non-empty outputs)/len(code cells)`.

## Notes

- Markdown-only, single file. No code cells touched, no pedagogical content removed, no catalog markers (`CATALOG-STATUS`) present in this file.
- Notable jump: QC-Py-Cloud-03-Risk-Parity 1/2 → 6/6 (fully re-executed). QC-Py-34 (the #3359/#3360/#4785 RL integrity-fix subject) 11/11 → 14/17 reflects the post-fix re-exec with the non-FAANG universe.
- The `research_classification.ipynb` / `research_lstm.ipynb` live in `Python/research/` (separate sub-folder) and are intentionally out of the curriculum audit table scope.

See #3976 (partial slice — QC-Py audit table).

Co-Authored-By: Claude-Code <noreply@anthropic.com>