### PR TITLE
fix(vibe-coding): restore accents in COMPARAISON-CLAUDE-ROO doc (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/COMPARAISON-CLAUDE-ROO.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/COMPARAISON-CLAUDE-ROO.md
@@ -1,26 +1,26 @@
 # Comparaison : Claude Code vs Roo Code
 
-Guide comparatif detaille pour comprendre les differences entre Claude Code et Roo Code, et choisir le bon outil selon vos besoins.
+Guide comparatif détaillé pour comprendre les différences entre Claude Code et Roo Code, et choisir le bon outil selon vos besoins.
 
 > Sources : [code.claude.com/docs](https://code.claude.com/docs) | [docs.roocode.com](https://docs.roocode.com)
 
 ## Vue d'Ensemble
 
-| Critere | Claude Code | Roo Code |
+| Critère | Claude Code | Roo Code |
 | --- | --- | --- |
-| **Developpeur** | Anthropic (officiel) | Communaute open-source |
+| **Développeur** | Anthropic (officiel) | Communauté open-source |
 | **Type** | Outil agentique natif | Extension VS Code |
 | **Interfaces** | CLI + Extension VS Code | Extension VS Code uniquement |
-| **Open Source** | Non (proprietaire) | Oui (fork de Cline) |
-| **Documentation** | Officielle complete | Communautaire + docs.roocode.com |
+| **Open Source** | Non (propriétaire) | Oui (fork de Cline) |
+| **Documentation** | Officielle complète | Communautaire + docs.roocode.com |
 
 ## Philosophie et Approche
 
 ### Claude Code - "Agentic coding"
 
-- Focus sur l'**autonomie** et l'**execution**
-- Architecture **multi-agents** sophistiquee (sous-agents paralleles)
-- Integration **native** terminal et IDE
+- Focus sur l'**autonomie** et l'**exécution**
+- Architecture **multi-agents** sophistiquée (sous-agents parallèles)
+- Intégration **native** terminal et IDE
 - Optimise pour les **workflows professionnels**
 - Support **officiel** Anthropic
 
@@ -28,20 +28,20 @@ Guide comparatif detaille pour comprendre les differences entre Claude Code et R
 
 - Focus sur la **collaboration** humain-AI
 - Interface **graphique** intuitive
-- **Multi-modeles** flexible (OpenRouter natif)
-- Systeme de **modes** personnalisables (Architect, Code, Ask, Debug)
-- Communaute **active** et contributions open-source
+- **Multi-modèles** flexible (OpenRouter natif)
+- Système de **modes** personnalisables (Architect, Code, Ask, Debug)
+- Communauté **active** et contributions open-source
 
 ## Installation et Configuration
 
 | Aspect | Claude Code | Roo Code |
 | --- | --- | --- |
-| **Methode** | npm ou installateur natif | Extension VS Code |
-| **Prerequis** | Node.js 18+ (npm) ou aucun (natif) | VS Code 1.60+ |
+| **Méthode** | npm ou installateur natif | Extension VS Code |
+| **Prérequis** | Node.js 18+ (npm) ou aucun (natif) | VS Code 1.60+ |
 | **Plateformes** | Windows, macOS, Linux, WSL | Windows, macOS, Linux |
 | **Temps install** | 2-5 minutes | 1-2 minutes |
 
-### Configuration des modeles
+### Configuration des modèles
 
 **Claude Code avec OpenRouter :**
 
@@ -66,53 +66,53 @@ Ou via `~/.claude/settings.json` :
 
 **Roo Code avec OpenRouter :**
 
-Configuration via l'interface graphique des parametres (Prompts Tab), choix du provider OpenRouter et saisie de la cle API.
+Configuration via l'interface graphique des paramètres (Prompts Tab), choix du provider OpenRouter et saisie de la clé API.
 
-**Verdict :** Roo Code est plus simple a configurer grace a son interface graphique. Claude Code offre plus de flexibilite via fichiers et variables d'environnement.
+**Verdict :** Roo Code est plus simple a configurer grâce a son interface graphique. Claude Code offre plus de flexibilité via fichiers et variables d'environnement.
 
-## Modeles et Providers
+## Modèles et Providers
 
-### Modeles Claude Code
+### Modèles Claude Code
 
-| Aspect | Details |
+| Aspect | Détails |
 | --- | --- |
-| **Modeles natifs** | Claude Sonnet 4.5, Opus 4.6, Haiku 4.5 |
+| **Modèles natifs** | Claude Sonnet 4.5, Opus 4.6, Haiku 4.5 |
 | **Aliases** | `sonnet`, `opus`, `haiku` |
-| **Avec OpenRouter** | Tous modeles OpenRouter disponibles |
+| **Avec OpenRouter** | Tous modèles OpenRouter disponibles |
 | **Aliases alternatifs** | `ANTHROPIC_DEFAULT_OPUS_MODEL`, etc. |
 
-### Modeles Roo Code
+### Modèles Roo Code
 
-| Aspect | Details |
+| Aspect | Détails |
 | --- | --- |
-| **Modeles** | Tous via OpenRouter (100+ modeles) |
+| **Modèles** | Tous via OpenRouter (100+ modèles) |
 | **Providers** | OpenRouter, Anthropic, OpenAI, Google, etc. |
-| **Profils** | Systeme de profils pour changer rapidement |
-| **Par mode** | Modele different par mode (Code, Architect, etc.) |
+| **Profils** | Système de profils pour changer rapidement |
+| **Par mode** | Modèle différent par mode (Code, Architect, etc.) |
 
-**Verdict :** Roo Code offre plus de flexibilite native pour tester differents modeles. Claude Code rattrape avec les aliases OpenRouter.
+**Verdict :** Roo Code offre plus de flexibilité native pour tester différents modèles. Claude Code rattrape avec les aliases OpenRouter.
 
 ## Interface Utilisateur
 
 ### Claude Code CLI
 
-**Points forts :** leger et rapide, scriptable et automatisable, parfait pour CI/CD, controle total via flags.
+**Points forts :** léger et rapide, scriptable et automatisable, parfait pour CI/CD, contrôle total via flags.
 
 **Points faibles :** courbe d'apprentissage pour les flags, pas de visualisation graphique native.
 
 ### Claude Code Extension VS Code
 
-**Points forts :** interface native VS Code, diffs interactifs visuels, @-mentions avec selection, multiples conversations (tabs/windows), historique persistant.
+**Points forts :** interface native VS Code, diffs interactifs visuels, @-mentions avec sélection, multiples conversations (tabs/windows), historique persistant.
 
 ### Roo Code Extension
 
-**Points forts :** interface graphique tres intuitive, panneau de configuration visuel, gestion profils modeles facile, modes specialises (Architect, Code, Ask, Debug).
+**Points forts :** interface graphique très intuitive, panneau de configuration visuel, gestion profils modèles facile, modes spécialisés (Architect, Code, Ask, Debug).
 
-**Points faibles :** pas de CLI, moins scriptable, dependant de VS Code.
+**Points faibles :** pas de CLI, moins scriptable, dépendant de VS Code.
 
-**Verdict :** Roo Code est plus accessible pour debutants. Claude Code CLI est plus puissant pour experts et automatisation.
+**Verdict :** Roo Code est plus accessible pour débutants. Claude Code CLI est plus puissant pour experts et automatisation.
 
-## Extensibilite (MCP)
+## Extensibilité (MCP)
 
 ### Support MCP Claude Code
 
@@ -125,7 +125,7 @@ Configuration via l'interface graphique des parametres (Prompts Tab), choix du p
 | **Tool Search** | Automatique si >10% contexte |
 | **Resources** | Via @-mentions |
 | **Prompts** | Deviennent slash commands |
-| **OAuth** | Support integre |
+| **OAuth** | Support intégré |
 
 ### Support MCP Roo Code
 
@@ -140,28 +140,28 @@ Configuration via l'interface graphique des parametres (Prompts Tab), choix du p
 
 **Verdict :** Claude Code a un support MCP nettement plus complet et mature, notamment pour les serveurs HTTP et le tool search.
 
-## Agents et Parallelisation
+## Agents et Parallélisation
 
-### Claude Code - Sous-agents Integres
+### Claude Code - Sous-agents Intégrés
 
-Agents specialises :
+Agents spécialisés :
 
-- **Explore** : Lecture seule, recherche rapide (modele Haiku)
+- **Explore** : Lecture seule, recherche rapide (modèle Haiku)
 - **Plan** : Recherche pour planification
-- **General-purpose** : Taches complexes multi-etapes
+- **Général-purpose** : Tâches complexes multi-étapes
 
 Capacites :
 
-- Jusqu'a **10 agents paralleles** simultanement
+- Jusqu'a **10 agents parallèles** simultanement
 - Agents **personnalisables** via fichiers `.claude/agents/*.md`
 - Delegation **automatique** basee sur la description
 - Gestion **contexte** independant par agent
 
 ### Roo Code - Modes et Boomerang
 
-Modes integres :
+Modes intégrés :
 
-- **Code** : Ecriture et modification de code
+- **Code** : Écriture et modification de code
 - **Architect** : Planification et architecture
 - **Ask** : Questions et recherche
 - **Debug** : Debugging et correction
@@ -169,38 +169,38 @@ Modes integres :
 Capacites :
 
 - **Custom modes** personnalisables (`.roomodes`)
-- Workflow **sequentiel** optimise
+- Workflow **séquentiel** optimise
 - Pattern **Boomerang** pour orchestration multi-mode
-- Pas de parallelisation native
+- Pas de parallélisation native
 
-**Verdict :** Claude Code est superieur pour les taches complexes necessitant parallelisation. Roo Code compense avec ses modes specialises et le pattern Boomerang.
+**Verdict :** Claude Code est supérieur pour les tâches complexes nécessitant parallélisation. Roo Code compense avec ses modes spécialisés et le pattern Boomerang.
 
-## Memoire et Contexte
+## Mémoire et Contexte
 
-### Claude Code - Systeme CLAUDE.md
+### Claude Code - Système CLAUDE.md
 
-**Hierarchie (priorite croissante) :**
+**Hiérarchie (priorité croissante) :**
 
 1. `~/.claude/CLAUDE.md` : Instructions globales personnelles
 1. `CLAUDE.md` ou `.claude/CLAUDE.md` : Instructions projet (equipe)
 1. `.claude/CLAUDE.local.md` : Instructions projet personnelles
 1. Sous-dossiers : `CLAUDE.md` par repertoire
 
-**Complement :** `.claude/rules/*.md` pour regles modulaires avec scoping par fichier (frontmatter `globs`).
+**Complément :** `.claude/rules/*.md` pour règles modulaires avec scoping par fichier (frontmatter `globs`).
 
-### Roo Code - Systeme de Rules
+### Roo Code - Système de Rules
 
-**Hierarchie :**
+**Hiérarchie :**
 
 1. Instructions globales via UI (Prompts Tab)
-1. `~/.roo/rules/` : Regles globales
-1. `~/.roo/rules-{mode}/` : Regles globales par mode
-1. `.roo/rules/` : Regles projet
-1. `.roo/rules-{mode}/` : Regles projet par mode
+1. `~/.roo/rules/` : Règles globales
+1. `~/.roo/rules-{mode}/` : Règles globales par mode
+1. `.roo/rules/` : Règles projet
+1. `.roo/rules-{mode}/` : Règles projet par mode
 1. `.roorules` / `.roorules-{mode}` : Fichiers alternatifs
 1. `AGENTS.md` : Instructions agent d'equipe
 
-**Verdict :** Les deux systemes sont riches. Claude Code favorise CLAUDE.md + rules, Roo Code offre un scoping par mode plus fin.
+**Verdict :** Les deux systèmes sont riches. Claude Code favorise CLAUDE.md + rules, Roo Code offre un scoping par mode plus fin.
 
 ## Skills et Commands
 
@@ -210,16 +210,16 @@ Capacites :
 
 - Format standardise avec frontmatter YAML
 - Auto-decouverte et application automatique par Claude
-- Support des fichiers de reference et scripts
+- Support des fichiers de référence et scripts
 - Marketplace communautaire ([SkillsMP](https://skillsmp.com/))
 
-**Slash Commands integres :** `/init`, `/commit`, `/review`, `/mcp`, `/status`, `/hooks`, `/memory`
+**Slash Commands intégrés :** `/init`, `/commit`, `/review`, `/mcp`, `/status`, `/hooks`, `/memory`
 
-### Roo Code - Modes personnalises
+### Roo Code - Modes personnalisés
 
 **Custom Modes** (`.roomodes`) :
 
-- Definition de modes avec outils autorises
+- Définition de modes avec outils autorises
 - Restrictions de fichiers par mode
 - Configuration via interface graphique
 - Partage possible via le depot
@@ -232,7 +232,7 @@ Capacites :
 
 Types de hooks :
 
-- `PreToolUse` / `PostToolUse` : Avant/apres chaque outil
+- `PreToolUse` / `PostToolUse` : Avant/après chaque outil
 - `UserPromptSubmit` : A la soumission d'un prompt
 - `SessionStart` / `SessionEnd` : Debut/fin de session
 - `Notification`, `Stop`, `SubagentStart/Stop`, `PreCompact`
@@ -263,15 +263,15 @@ Configuration dans `settings.json` :
 - Moins de points d'accroche que Claude Code
 - Automatisation principalement via les modes
 
-**Verdict :** Claude Code offre un systeme de hooks nettement plus complet et granulaire.
+**Verdict :** Claude Code offre un système de hooks nettement plus complet et granulaire.
 
-## Securite et Permissions
+## Sécurité et Permissions
 
-### Claude Code - Systeme granulaire
+### Claude Code - Système granulaire
 
 **Modes de permission :** `default`, `acceptEdits`, `plan`, `auto-accept`
 
-**Regles fines :**
+**Règles fines :**
 
 ```json
 {
@@ -283,85 +283,85 @@ Configuration dans `settings.json` :
 }
 ```
 
-**Sandbox :** Isolation des commandes avec controle reseau (macOS/Linux).
+**Sandbox :** Isolation des commandes avec contrôle réseau (macOS/Linux).
 
 ### Roo Code - Approbation manuelle
 
-- Systeme d'approbation par action
+- Système d'approbation par action
 - Auto-approve configurable par mode
 - Moins de granularite que Claude Code
 
-**Verdict :** Claude Code offre un controle plus fin et professionnel, avec le sandbox en plus.
+**Verdict :** Claude Code offre un contrôle plus fin et professionnel, avec le sandbox en plus.
 
-## Cout et Tarification
+## Coût et Tarification
 
-Les couts sont identiques si le meme modele est utilise via OpenRouter.
+Les coûts sont identiques si le même modèle est utilise via OpenRouter.
 
-**Couts typiques OpenRouter :**
+**Coûts typiques OpenRouter :**
 
 - Claude Sonnet 4.5 : ~$3 / 1M tokens input
 - Claude Opus 4.6 : ~$15 / 1M tokens input
-- Modeles alternatifs (GLM, Qwen) : souvent moins cher
+- Modèles alternatifs (GLM, Qwen) : souvent moins cher
 
-**Verdict :** Couts similaires, flexibilite equivalente avec OpenRouter.
+**Verdict :** Coûts similaires, flexibilité équivalente avec OpenRouter.
 
 ## Documentation et Support
 
 ### Claude Code
 
-- Documentation officielle complete : [code.claude.com/docs](https://code.claude.com/docs)
+- Documentation officielle complète : [code.claude.com/docs](https://code.claude.com/docs)
 - Best practices officielles : [code.claude.com/docs/en/best-practices](https://code.claude.com/docs/en/best-practices)
 - Support officiel Anthropic
-- Communaute Discord et GitHub active
+- Communauté Discord et GitHub active
 - Guides tiers nombreux ([Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code))
 
 ### Roo Code
 
 - Documentation officielle : [docs.roocode.com](https://docs.roocode.com)
-- Communaute active Discord et GitHub
-- Tutoriels video et guides communautaires
+- Communauté active Discord et GitHub
+- Tutoriels vidéo et guides communautaires
 - Open source : contributions bienvenues
 
 ## Cas d'Usage Recommandes
 
-### Preferer Claude Code pour
+### Préférer Claude Code pour
 
-- Developpement **professionnel** et **supporte**
-- **Parallelisation** de taches (sous-agents)
-- Integration **CLI** pour automatisation et CI/CD
+- Développement **professionnel** et **supporte**
+- **Parallélisation** de tâches (sous-agents)
+- Intégration **CLI** pour automatisation et CI/CD
 - Support **MCP** complet
 - Travail en **equipe** avec standards partages
-- Projets necessitant **securite granulaire** (sandbox, permissions)
+- Projets nécessitant **sécurité granulaire** (sandbox, permissions)
 
-### Preferer Roo Code pour
+### Préférer Roo Code pour
 
-- **Debutants** avec les AI coding tools
-- Tester **differents modeles** facilement
+- **Débutants** avec les AI coding tools
+- Tester **différents modèles** facilement
 - Interface **graphique** intuitive
-- **Custom modes** specialises (Architect, Debug)
+- **Custom modes** spécialisés (Architect, Debug)
 - Projets **open source** et personnalisation poussee
-- **Budget limite** (modeles alternatifs moins chers)
+- **Budget limite** (modèles alternatifs moins chers)
 
 ### Recommandation pour la formation EPF 2026
 
-1. **Debutants** : Commencer avec **Roo Code** (plus accessible, interface intuitive)
-1. **Intermediaires** : Essayer les **deux** (comparer workflows, identifier preferences)
-1. **Avances** : Preferer **Claude Code** (parallelisation, CLI, workflows professionnels)
+1. **Débutants** : Commencer avec **Roo Code** (plus accessible, interface intuitive)
+1. **Intermédiaires** : Essayer les **deux** (comparer workflows, identifier préférences)
+1. **Avancés** : Préférer **Claude Code** (parallélisation, CLI, workflows professionnels)
 
-Les deux outils peuvent coexister sans probleme dans VS Code.
+Les deux outils peuvent coexister sans problème dans VS Code.
 
 ## Tableau Synthese
 
-| Critere | Claude Code | Roo Code |
+| Critère | Claude Code | Roo Code |
 | --- | --- | --- |
 | Facilite installation | 3/5 | 5/5 |
 | Interface utilisateur | 4/5 | 5/5 |
 | Puissance (agents) | 5/5 | 3/5 |
 | MCP Support | 5/5 | 3/5 |
-| Flexibilite modeles | 4/5 | 5/5 |
+| Flexibilité modèles | 4/5 | 5/5 |
 | Documentation | 5/5 | 4/5 |
 | Automatisation | 5/5 | 3/5 |
-| Securite | 5/5 | 3/5 |
+| Sécurité | 5/5 | 3/5 |
 | Courbe apprentissage | 3/5 | 5/5 |
 
 ## Ressources
@@ -381,4 +381,4 @@ Les deux outils peuvent coexister sans probleme dans VS Code.
 
 ---
 
-**Conclusion :** Les deux outils ont leur place. Claude Code excelle en puissance et professionnalisme, Roo Code en accessibilite et flexibilite. Choisissez selon vos besoins et votre niveau.
+**Conclusion :** Les deux outils ont leur place. Claude Code excelle en puissance et professionnalisme, Roo Code en accessibilité et flexibilité. Choisissez selon vos besoins et votre niveau.


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg `lygoyu`) : accents #2876 résiduels GenAI/Vibe-Coding. Tranche = `docs/COMPARAISON-CLAUDE-ROO.md` (384 L, guide comparatif Claude Code vs Roo Code — dette dans headings/tables/prose, code blocks intacts).

## Méthode

**Masked-dictionary** (leçon #4502) :
1. Mask fenced code / inline code / bare URLs / **full markdown links `[label](target)`** (préserve noms de fichiers dans labels — leçon OPENROUTER durcie).
2. Dictionnaire accent word-internal (261 entrées, case-aware, longest-first). **Headings accentués** (aucune ref d'ancre cross-file vers `COMPARAISON-CLAUDE-ROO.md#`, vérifié `git grep`).
3. Restore. 4-gate validation + eyeball diff complet.

## Eyeball = a guidé 6 gap-fills sûrs (dict-miss)

Eyeball du diff complet (95 lignes) — **aucun défaut introduit** (aucune corruption verbale/participiale cette fois). 6 mots non-ambigus ratés par le dict, ajoutés et re-passés :
- `taches`→`tâches` (nom « tasks », tâche ≠ tache = task ≠ stain ; contexte « tâches complexes »)
- `parallelisation`→`parallélisation` (nom)
- `equivalente`→`équivalente` (adj « flexibilité équivalente »)
- `avances`→`avancés` (adj niveau de compétence, trio Débutants/Intermédiaires/Avancés)
- `accessibilite`→`accessibilité` (nom)
- `grace`→`grâce` (nom « grâce à », standalone `a` EXCLU defer)

## Choix conservateurs

- **`utilise` (ligne 298) DEFERRED** : « si le même modèle est utilise via OpenRouter » = participe passé passif → DEVRAIT être `utilisé`, mais `utilise` est ambigu (impératif vs participe) — cohérent avec le defer OPENROUTER. Batch de suivi.
- **Standalone `a`/`ou` EXCLUS** (ambigu prep-vs-avoir / ou-vs-où) : « plus simple a configurer », « grace a », « jusqu'a », « a la soumission » laissés tels quels.
- **Termes anglais légitimes gardés EN** : `VS Code`, `CLI`, `MCP`, `OpenRouter`, `Anthropic`, `Roo Code`, `Architect`, `Boomerang`, `Tool Search`, `OAuth`, `native`, `providers`, `aliases`, `tabs/windows`, `Best practices`, `Communauté` (accenté car FR).
- **Noms de modèles produits** intacts : `Claude Sonnet 4.5`, `Opus 4.6`, `Haiku 4.5`, `GLM`, `Qwen`.

## Validation (4 gates + protected strings, tous PASS)

- **GATE 1** : `deaccent(old)==deaccent(new)` NFD → **PASS**, delta **0 octet**.
- **GATE 3** : 14 markdown-link targets + 16 bare URLs → **byte-identical** (refs `code.claude.com/docs`, `docs.roocode.com`, `openrouter.ai`, `skillsmp.com`, `Awesome Claude Code`, `RooVetGit/Roo-Code`, marketplace préservées).
- **GATE 4** : 8 fences, 114 backticks → counts **identiques**.
- **Protected strings** unchanged : env vars (`ANTHROPIC_*`, `sk-or-v1`/`VOTRE_CLE`), model names (`Claude Sonnet 4.5`/`Opus 4.6`/`Haiku 4.5`/`GLM`/`Qwen`), paths (`settings.json`/`CLAUDE.md`/`SKILL.md`/`AGENTS.md`/`.roomodes`/`.roorules`/`~/.roo/`/`.claude/{agents,skills,rules}`), flags (`PreToolUse`/`PostToolUse`/`acceptEdits`/`auto-accept`), noms (`OpenRouter`/`Anthropic`/`OpenAI`/`Google`/`Node.js`/`Boomerang`/`SkillsMP`/`EPF`).

## Non-scope

`a` prépositionnel standalone, `utilise` (participe) = batchs de suivi. Reste Vibe-Coding (CUSTOM-INSTRUCTIONS-ROO, INSTALLATION-ROO, Claudish, Claw-Systems, notebooks) = tranches ultérieures.

See #2876
