### PR TITLE
feat(tweety): Tweety-3-Dung-Csharp — argumentation abstraite de Dung .NET natif (IKVM)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -25,7 +25,14 @@ TweetyProject est une collection de bibliothèques Java couvrant plusieurs domai
 - **Agents et dialogues** : Multi-agents, Protocoles argumentatifs
 - **Préférences et vote** : Ordres de préférence, Agrégation
 
-Les notebooks utilisent **JPype** pour intégrer Java dans Python, permettant un apprentissage interactif.
+Les notebooks utilisent **deux implémentations** pour exécuter TweetyProject, selon le langage d'apprentissage visé :
+
+| Implémentation           | Stack                          | Kernel        | JVM requise ?                     | Notebooks                                                                                                    |
+| ------------------------ | ------------------------------ | ------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Python** (originelle)  | JPype (pont Java↔Python)       | Python 3      | Oui (JDK téléchargé par le setup) | `Tweety-1` à `Tweety-11` (13 notebooks)                                                                      |
+| **C#/.NET** (port natif) | IKVM 8.15 (bytecode Java→.NET) | `.net-csharp` | **Non** (runtime IKVM pur .NET)   | `Tweety-2-Basic-Logics-Csharp`, `Tweety-2b-Semantics-Csharp`, `Tweety-2c-FOL-Csharp`, `Tweety-3-Dung-Csharp` |
+
+Les deux implémentations couvrent les mêmes concepts fondamentaux (logique propositionnelle, sémantique des mondes possibles, logique du premier ordre, argumentation de Dung) ; le port C# les expose **sans JVM**, directement dans le runtime .NET, ce qui les rend exécutables côté .NET Interactive comme n'importe quel notebook C#. Les notebooks `-Csharp` vivent **à côté** de leurs homologues Python (pas dans un sous-dossier), pour faciliter la comparaison des deux stacks sur un même concept. Voir EPIC [#4667](https://github.com/jsboige/CoursIA/issues/4667).
 
 À l'heure des modèles statistiques et des LLMs, pourquoi étudier ces logiques symboliques ? Parce qu'elles apportent ce que l'apprentissage seul ne garantit pas : un raisonnement **explicite, vérifiable et explicable**. L'argumentation computationnelle (cadres de Dung, ASPIC+, ABA) modélise la façon dont des agents confrontent des arguments, gèrent les contradictions et aboutissent à des conclusions justifiées — avec des applications en raisonnement juridique, en aide à la décision, en négociation multi-agents, et de plus en plus comme couche de contrôle au-dessus des LLMs (détecter les incohérences, structurer un débat). La révision de croyances (AGM) formalise comment un agent rationnel met à jour ses connaissances face à une information nouvelle ou contradictoire. L'intérêt de TweetyProject est de réunir tous ces formalismes sous un même toit : on expérimente d'une logique à l'autre sans avoir à réimplémenter chaque solveur.
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
@@ -1,0 +1,929 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "m601032",
+   "metadata": {},
+   "source": [
+    "# Tweety-3 — Argumentation abstraite de Dung en C#/.NET (port natif IKVM)\n",
+    "\n",
+    "> **Série Tweety — port C#/.NET natif (EPIC [#4667](https://github.com/jsboige/CoursIA/issues/4667)).**\n",
+    "> Ce notebook exploite le module **`arg-dung`** de [TweetyProject](https://tweetyproject.org/) **sans JVM** :\n",
+    "> la librairie Java est compilée vers un fat-jar Maven shade puis exécutée sur le runtime .NET via\n",
+    "> [IKVM](https://github.com/ikvm-refined/ikvm).\n",
+    "\n",
+    "Navigation : [Tweety-2-Basic-Logics-Csharp](Tweety-2-Basic-Logics-Csharp.ipynb) (propositionnel) ·\n",
+    "[Tweety-2b-Semantics-Csharp](Tweety-2b-Semantics-Csharp.ipynb) (mondes possibles) ·\n",
+    "[Tweety-2c-FOL-Csharp](Tweety-2c-FOL-Csharp.ipynb) (premier ordre) ·\n",
+    "**Tweety-3-Dung (ce notebook)**.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Objectifs pédagogiques\n",
+    "\n",
+    "L'**argumentation abstraite de Dung** (1995) est le formalisme historique fondateur de TweetyProject.\n",
+    "On s'affranchit de la nature des arguments pour ne retenir que leur **structure d'attaque** :\n",
+    "\n",
+    "- un **argument** est un nœud abstrait (on ne regarde pas son contenu) ;\n",
+    "- une **attaque** `a → b` (« `a` réfute `b` ») est une arête orientée ;\n",
+    "- un **cadre d'argumentation** (AF, *argumentation framework*) = un graphe orienté d'attaques.\n",
+    "\n",
+    "La question centrale : étant donné un AF, **quels arguments accepter** ? Dung définit plusieurs\n",
+    "**sémantiques** (ensembles d'arguments « rationnellement acceptables » = les *extensions*) :\n",
+    "\n",
+    "| Sémantique | Idée | Extensions |\n",
+    "|------------|------|------------|\n",
+    "| **Sans conflit** (CF) | pas d'attaque mutuelle interne | plusieurs |\n",
+    "| **Admissible** | sans conflit + se défend contre toute attaque | plusieurs |\n",
+    "| **Complète** (CO) | admissible + contient tout argument qu'elle défend | plusieurs |\n",
+    "| **Fondée** (GR, *grounded*) | la plus petite extension complète | **une seule** |\n",
+    "| **Préférée** (PR) | une extension complète **maximale** (pour l'inclusion) | ≥ 1 |\n",
+    "| **Stable** (ST) | bat (attaque) tout argument hors de l'extension | 0 ou plusieurs |\n",
+    "\n",
+    "Ce notebook construit des AF en C#, calcule leurs extensions sous chaque sémantique, et teste\n",
+    "l'**acceptation** (sceptique) d'un argument.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m121394",
+   "metadata": {},
+   "source": [
+    "## 1 — Runtime IKVM : charger le module `arg-dung`\n",
+    "\n",
+    "On installe le runtime IKVM, on fusionne l'image (base + arch), puis on charge la DLL\n",
+    "`org.tweetyproject.tweety-dung.dll` (compilée côté build à partir d'un fat-jar shade embarquant\n",
+    "`arg-dung` + ses dépendances transitives : `graphs`, `commons`, `math`, `logics-fol`, `logics-pl`).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c56790",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:13.284393Z",
+     "iopub.status.busy": "2026-07-02T00:28:13.277916Z",
+     "iopub.status.idle": "2026-07-02T00:28:14.273458Z",
+     "shell.execute_reply": "2026-07-02T00:28:14.270821Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-24552.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.30.224.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '24552.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>IKVM, 8.15.0</span></li><li><span>IKVM.Image, 8.15.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: IKVM, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image.runtime.win-x64, 8.15.0\"\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c492816",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:14.275975Z",
+     "iopub.status.busy": "2026-07-02T00:28:14.275689Z",
+     "iopub.status.idle": "2026-07-02T00:28:15.114101Z",
+     "shell.execute_reply": "2026-07-02T00:28:15.113454Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IKVM home=OK\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.IO;\n",
+    "string ikvmVer = \"8.15.0\", ikvmRid = \"win-x64\";\n",
+    "string nugetRoot = Environment.GetEnvironmentVariable(\"NUGET_PACKAGES\")\n",
+    "    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \".nuget\", \"packages\");\n",
+    "string ikvmBaseAny = Path.Combine(nugetRoot, \"ikvm.image\", ikvmVer, \"ikvm\", \"any\", \"any\");\n",
+    "string ikvmArchDir = Path.Combine(nugetRoot, \"ikvm.image.runtime.\" + ikvmRid, ikvmVer, \"ikvm\", \"any\", ikvmRid);\n",
+    "string ikvmHome = Path.Combine(Path.GetTempPath(), \"ikvm-home-\" + ikvmVer + \"-\" + ikvmRid);\n",
+    "void IkvmCopyMerge(string src, string dst)\n",
+    "{\n",
+    "    foreach (var d in Directory.GetDirectories(src, \"*\", SearchOption.AllDirectories))\n",
+    "        Directory.CreateDirectory(d.Replace(src, dst));\n",
+    "    foreach (var f in Directory.GetFiles(src, \"*\", SearchOption.AllDirectories))\n",
+    "    {\n",
+    "        var t = f.Replace(src, dst);\n",
+    "        Directory.CreateDirectory(Path.GetDirectoryName(t));\n",
+    "        File.Copy(f, t, overwrite: true);\n",
+    "    }\n",
+    "}\n",
+    "if (Directory.Exists(ikvmBaseAny) && Directory.Exists(ikvmArchDir))\n",
+    "{\n",
+    "    Directory.CreateDirectory(ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmBaseAny, ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmArchDir, ikvmHome);\n",
+    "}\n",
+    "AppContext.SetData(\"IKVM.Home\", ikvmHome);\n",
+    "Console.WriteLine(\"IKVM home=\" + (File.Exists(Path.Combine(ikvmHome, \"lib\", \"tzdb.dat\")) ? \"OK\" : \"MISSING\"));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c835153",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:15.116336Z",
+     "iopub.status.busy": "2026-07-02T00:28:15.116027Z",
+     "iopub.status.idle": "2026-07-02T00:28:15.138457Z",
+     "shell.execute_reply": "2026-07-02T00:28:15.138165Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#r \"org.tweetyproject.tweety-dung.dll\"\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m882736",
+   "metadata": {},
+   "source": [
+    "## 2 — Construire un cadre d'argumentation (AF)\n",
+    "\n",
+    "Un AF se construit avec `DungTheory` (qui implémente `Graph<Argument>`). On y ajoute des\n",
+    "**arguments** (`Argument`, nommés) et des **attaques** (`Attack(attacker, attacked)`).\n",
+    "\n",
+    "### 2.1 Un premier AF : attaque simple `a → b`\n",
+    "\n",
+    "L'argument `a` attaque `b`. Intuitivement, si on accepte `a`, on ne peut pas accepter `b`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c646116",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:15.140675Z",
+     "iopub.status.busy": "2026-07-02T00:28:15.140197Z",
+     "iopub.status.idle": "2026-07-02T00:28:15.649823Z",
+     "shell.execute_reply": "2026-07-02T00:28:15.649597Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF = <{ a, b },[(a,b)]>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nb noeuds = 2\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.arg.dung.syntax;\n",
+    "using org.tweetyproject.arg.dung.semantics;\n",
+    "using org.tweetyproject.arg.dung.reasoner;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "var a = new Argument(\"a\");\n",
+    "var b = new Argument(\"b\");\n",
+    "\n",
+    "var af = new DungTheory();\n",
+    "af.add(a);\n",
+    "af.add(b);\n",
+    "af.add(new Attack(a, b));   // a attaque b\n",
+    "\n",
+    "Console.WriteLine(\"AF = \" + af);\n",
+    "Console.WriteLine(\"nb noeuds = \" + af.getNodes().size());\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m786216",
+   "metadata": {},
+   "source": [
+    "### 2.2 Attaque mutuelle et cycle\n",
+    "\n",
+    "Quand `a` et `b` s'attaquent mutuellement, aucune des deux sémantiques « strictes » ne peut trancher\n",
+    "seule : c'est le cas typique où **plusieurs extensions** coexistent (l'une accepte `a`, l'autre `b`).\n",
+    "On construit aussi un cycle `c → d → e → c`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c298429",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:15.651443Z",
+     "iopub.status.busy": "2026-07-02T00:28:15.651111Z",
+     "iopub.status.idle": "2026-07-02T00:28:15.718610Z",
+     "shell.execute_reply": "2026-07-02T00:28:15.718387Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF2 (attaque mutuelle) = <{ x, y },[(x,y), (y,x)]>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bien-fondé ? False\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var af2 = new DungTheory();\n",
+    "var x = new Argument(\"x\");\n",
+    "var y = new Argument(\"y\");\n",
+    "af2.add(x); af2.add(y);\n",
+    "af2.add(new Attack(x, y));\n",
+    "af2.add(new Attack(y, x));   // attaque mutuelle\n",
+    "Console.WriteLine(\"AF2 (attaque mutuelle) = \" + af2);\n",
+    "Console.WriteLine(\"Bien-fondé ? \" + af2.isWellFounded());   // faux : cycle d'attaque\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m315100",
+   "metadata": {},
+   "source": [
+    "## 3 — Calculer les extensions\n",
+    "\n",
+    "Chaque sémantique est incarnée par un **raisonneur** (`Simple*Reasoner`). Tous héritent de\n",
+    "`AbstractExtensionReasoner` qui expose :\n",
+    "\n",
+    "- **`getModels(DungTheory)`** → la collection des **extensions** (`Extension<DungTheory>`) ;\n",
+    "- **`query(DungTheory, Argument)`** → `Boolean`, acceptation **sceptique** de l'argument.\n",
+    "\n",
+    "### 3.1 L'extension fondée (grounded) — unique, sceptique\n",
+    "\n",
+    "L'extension **fondée** est la plus prudente : on part de l'ensemble vide, on ajoute tout argument\n",
+    "non attaqué, puis tout argument défendu, et on itère jusqu'à point fixe. Elle est **toujours unique**.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c87284",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:15.720220Z",
+     "iopub.status.busy": "2026-07-02T00:28:15.719999Z",
+     "iopub.status.idle": "2026-07-02T00:28:15.789073Z",
+     "shell.execute_reply": "2026-07-02T00:28:15.788792Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extensions fondées de AF :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {a}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "AF, fondée ⊨ a ? true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF, fondée ⊨ b ? false\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Sur l'AF a -> b : l'extension fondée est {a} (a est inattaqué, b est battu par a)\n",
+    "AbstractExtensionReasoner grounded = new SimpleGroundedReasoner();\n",
+    "// getModels renvoie une java.util.Collection : on itère via toArray() (foreach C# cast chaque élément).\n",
+    "Console.WriteLine(\"Extensions fondées de AF :\");\n",
+    "foreach (Extension ext in grounded.getModels(af).toArray(new Extension[0]))\n",
+    "    Console.WriteLine(\"  \" + ext);\n",
+    "\n",
+    "// Acceptation sceptique : a accepté, b refusé\n",
+    "Console.WriteLine(\"\\nAF, fondée ⊨ a ? \" + grounded.query(af, a));\n",
+    "Console.WriteLine(\"AF, fondée ⊨ b ? \" + grounded.query(af, b));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m819417",
+   "metadata": {},
+   "source": [
+    "### 3.2 Attaque mutuelle : fondée vs stable vs préférée\n",
+    "\n",
+    "Sur l'AF à attaque mutuelle `{x↔y}` :\n",
+    "\n",
+    "- **fondée** : `{}` (vide — ni x ni y n'est défendu, le point fixe ne décolle pas) ;\n",
+    "- **stable** : `{x}` et `{y}` (deux extensions — chaque argument bat l'autre) ;\n",
+    "- **préférée** : `{x}` et `{y}` (deux extensions maximales admissibles).\n",
+    "\n",
+    "C'est l'exemple canonique où sémantiques **divergent** : prudente (fondée) vs tranchantes (stable/préférée).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c563412",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:15.790967Z",
+     "iopub.status.busy": "2026-07-02T00:28:15.790743Z",
+     "iopub.status.idle": "2026-07-02T00:28:15.892172Z",
+     "shell.execute_reply": "2026-07-02T00:28:15.891866Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF2 fondée :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF2 stable :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {x}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {y}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF2 préférée :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {x}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {y}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF2 complète :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {x}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {y}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  {}\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "void Dump(string label, AbstractExtensionReasoner r, DungTheory theory)\n",
+    "{\n",
+    "    Console.WriteLine(label + \" :\");\n",
+    "    foreach (Extension ext in r.getModels(theory).toArray(new Extension[0]))\n",
+    "        Console.WriteLine(\"  \" + ext);\n",
+    "}\n",
+    "\n",
+    "Dump(\"AF2 fondée\",   new SimpleGroundedReasoner(),  af2);\n",
+    "Dump(\"AF2 stable\",   new SimpleStableReasoner(),    af2);\n",
+    "Dump(\"AF2 préférée\", new SimplePreferredReasoner(), af2);\n",
+    "Dump(\"AF2 complète\", new SimpleCompleteReasoner(),  af2);\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m622273",
+   "metadata": {},
+   "source": [
+    "## 4 — Un AF plus riche : défense en chaîne\n",
+    "\n",
+    "Construisons un AF où un argument est attaqué mais **défendu** par un autre :\n",
+    "\n",
+    "```\n",
+    "        d\n",
+    "        |\n",
+    "        v\n",
+    "   c <- a -> b\n",
+    "```\n",
+    "\n",
+    "- `a` attaque `b` et `c` ;\n",
+    "- `d` attaque `a` (donc `d` défend indirectement `b` et `c`).\n",
+    "\n",
+    "L'extension fondée devrait contenir `d` (inattaqué), qui défend `b` et `c` contre `a`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c233858",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:15.894262Z",
+     "iopub.status.busy": "2026-07-02T00:28:15.893979Z",
+     "iopub.status.idle": "2026-07-02T00:28:15.969233Z",
+     "shell.execute_reply": "2026-07-02T00:28:15.968380Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF3 = <{ A, B, C, D },[(A,B), (A,C), (D,A)]>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF3 fondée = {B,C,D}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "AF3 fondée ⊨ D ? true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF3 fondée ⊨ B ? true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF3 fondée ⊨ A ? false\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var A = new Argument(\"A\");\n",
+    "var B = new Argument(\"B\");\n",
+    "var C = new Argument(\"C\");\n",
+    "var D = new Argument(\"D\");\n",
+    "\n",
+    "var af3 = new DungTheory();\n",
+    "af3.add(A); af3.add(B); af3.add(C); af3.add(D);\n",
+    "af3.add(new Attack(A, B));   // A attaque B\n",
+    "af3.add(new Attack(A, C));   // A attaque C\n",
+    "af3.add(new Attack(D, A));   // D attaque A (défend B et C)\n",
+    "Console.WriteLine(\"AF3 = \" + af3);\n",
+    "\n",
+    "// Extension fondée : D (inattaqué) défend B et C contre A -> {D, B, C}\n",
+    "AbstractExtensionReasoner gr = new SimpleGroundedReasoner();\n",
+    "foreach (Extension ext in gr.getModels(af3).toArray(new Extension[0]))\n",
+    "    Console.WriteLine(\"AF3 fondée = \" + ext);\n",
+    "\n",
+    "// Acceptation sceptique\n",
+    "Console.WriteLine(\"\\nAF3 fondée ⊨ D ? \" + gr.query(af3, D));\n",
+    "Console.WriteLine(\"AF3 fondée ⊨ B ? \" + gr.query(af3, B));\n",
+    "Console.WriteLine(\"AF3 fondée ⊨ A ? \" + gr.query(af3, A));   // battu par D\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m90160",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "> Stubs **sans `throw`/`raise`** (convention C.1) : le notebook s'exécute de bout en bout même non complété.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m219209",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Cycle à trois : stable vs fondée\n",
+    "\n",
+    "Construisez un AF en cycle `p → q → r → p` (chaque argument en attaque un autre, formant un 3-cycle).\n",
+    "Affichez l'extension **fondée** et les extensions **stables**.\n",
+    "\n",
+    "**Question** : combien d'extensions stables obtient-on ? L'extension fondée est-elle vide ? (Indice :\n",
+    "dans un cycle impair sans argument inattaqué, le point fixe fondé ne décolle pas, mais chaque argument\n",
+    "isolé bat la chaîne restante → plusieurs stables.)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c192121",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:15.971278Z",
+     "iopub.status.busy": "2026-07-02T00:28:15.970974Z",
+     "iopub.status.idle": "2026-07-02T00:28:16.032871Z",
+     "shell.execute_reply": "2026-07-02T00:28:16.032182Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "extensions stables du cycle = Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// TODO etudiant : cycle p -> q -> r -> p\n",
+    "// Indice : declarez p,q,r, ajoutez 3 Attack, puis getModels(SimpleGroundedReasoner) et (SimpleStableReasoner).\n",
+    "object nbStables = null;  // TODO etudiant : nombre d'extensions stables (int)\n",
+    "Console.WriteLine(\"extensions stables du cycle = \" + (nbStables ?? \"Exercice a completer\"));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m501805",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Auto-attaque\n",
+    "\n",
+    "Un argument qui **s'attaque lui-même** (`s → s`) est dit *auto-réfuté*. Construisez un AF avec un seul\n",
+    "argument `s` qui s'attaque, et vérifiez que **aucune** sémantique admissible ne l'accepte :\n",
+    "l'extension fondée doit être vide, et `query(af, s)` doit valoir `false`.\n",
+    "\n",
+    "**Indice** : `af.add(new Attack(s, s))`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c398942",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:16.035331Z",
+     "iopub.status.busy": "2026-07-02T00:28:16.034785Z",
+     "iopub.status.idle": "2026-07-02T00:28:16.086811Z",
+     "shell.execute_reply": "2026-07-02T00:28:16.086556Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AF auto-attaque, fondée ⊨ s ? Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// TODO etudiant : auto-attaque s -> s\n",
+    "// Indice : un seul Argument s + Attack(s,s). Puis grounded.query(af, s).\n",
+    "bool? accepteS = null;  // TODO etudiant\n",
+    "Console.WriteLine(\"AF auto-attaque, fondée ⊨ s ? \" + (accepteS?.ToString() ?? \"Exercice a completer\"));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m144582",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Comparer complète et préférée\n",
+    "\n",
+    "Sur l'AF `{a → b, a → c}` (où `a` attaque `b` et `c`, mais rien n'attaque `a`), la sémantique\n",
+    "**complète** admet une extension non-maximale en plus de la préférée. Affichez les extensions\n",
+    "**complètes** ET **préférées** et identifiez laquelle est commune.\n",
+    "\n",
+    "**Indice** : `{a}` est complète ; est-elle aussi préférée ? Et `{a, b}` est-elle admissible\n",
+    "(si `b` et `c` ne s'attaquent pas mutuellement) ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c559554",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-02T00:28:16.088287Z",
+     "iopub.status.busy": "2026-07-02T00:28:16.087984Z",
+     "iopub.status.idle": "2026-07-02T00:28:16.118664Z",
+     "shell.execute_reply": "2026-07-02T00:28:16.118429Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "extension commune complète/préférée = Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// TODO etudiant : AF {a -> b, a -> c}, extensions completes vs preferees\n",
+    "// Indice : utilisez Dump(\"complete\", new SimpleCompleteReasoner(), af) et (\"preferee\", new SimplePreferredReasoner(), af).\n",
+    "string verdict = null;  // TODO etudiant : quelle extension est commune aux deux sémantiques ?\n",
+    "Console.WriteLine(\"extension commune complète/préférée = \" + (verdict ?? \"Exercice a completer\"));\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m372034",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "On a porté en C#/.NET natif (sans JVM) l'**argumentation abstraite de Dung** — le cœur historique de\n",
+    "TweetyProject — via le module `arg-dung` et IKVM :\n",
+    "\n",
+    "1. **Construction** d'un cadre d'argumentation (`DungTheory` + `Argument` + `Attack`), y compris\n",
+    "   attaques mutuelles, cycles et défense indirecte.\n",
+    "2. **Calcul des extensions** sous les quatre sémantiques fondatrices : fondée (unique, sceptique),\n",
+    "   complète, préférée (maximale), stable (agressive) — via `getModels`.\n",
+    "3. **Acceptation sceptique** d'un argument via `query`.\n",
+    "\n",
+    "### Pourquoi plusieurs sémantiques ?\n",
+    "\n",
+    "| Sémantique | Stratégie | Quand l'utiliser |\n",
+    "|------------|-----------|------------------|\n",
+    "| **Fondée** | la plus prudente (point fixe) | décision unique, conservatrice |\n",
+    "| **Complète** | tout argument défendu est inclus | fermeture « naturelle » |\n",
+    "| **Préférée** | maximale pour l'inclusion | « le mieux possible » sans arbitrer |\n",
+    "| **Stable** | bat tout l'extérieur | verdicts nets, mais peut ne pas exister |\n",
+    "\n",
+    "### Références\n",
+    "\n",
+    "- Dung, P. M. *On the Acceptability of Arguments and its Fundamental Role in Nonmonotonic Reasoning,\n",
+    "  Logic Programming and n-Person Games*. Artificial Intelligence, 1995.\n",
+    "- TweetyProject — [arg-dung module](https://tweetyproject.org/api/dung/).\n",
+    "- Port C#/.NET via IKVM — EPIC [#4667](https://github.com/jsboige/CoursIA/issues/4667).\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-TweetyDungShade.csproj
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-TweetyDungShade.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <RestoreAdditionalProjectSources></RestoreAdditionalProjectSources>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="IKVM" Version="8.15.0" />
+    <PackageReference Include="IKVM.MSBuild" Version="8.15.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <IkvmReference Include="tweety-dung-full-1.30.jar">
+      <AssemblyName>org.tweetyproject.tweety-dung</AssemblyName>
+      <AssemblyVersion>1.30.0.0</AssemblyVersion>
+      <AssemblyFileVersion>1.30.0.0</AssemblyFileVersion>
+    </IkvmReference>
+  </ItemGroup>
+</Project>

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-tweety-dung-shade.pom.xml
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-tweety-dung-shade.pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Standalone shade aggregator for Dung argumentation: bundles arg-dung +
+     transitive deps (graphs, commons, math, logics-commons, fol, pl) from local
+     m2 into one coherent fat-jar. Clones the proven pl recipe (#4792).
+     IKVM 8.15 needs a single shade artifact (not zip-merge) to resolve
+     cross-module types. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>local</groupId>
+  <artifactId>tweety-dung-shade</artifactId>
+  <version>1.30</version>
+  <packaging>jar</packaging>
+  <name>Tweety arg-dung shaded fat-jar (IKVM target)</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.tweetyproject.arg</groupId>
+      <artifactId>dung</artifactId>
+      <version>1.30-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit</groupId>
+          <artifactId>junit-bom</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>tweety-dung-full-1.30</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Summary

Port de l'**argumentation abstraite de Dung** (AAF) vers C#/.NET via Tweety/IKVM — **sans JVM à l'exécution**. **Cœur historique de TweetyProject** (Dung 1995). Suite de #4792 (pilote PL) + #4802 (sémantiques) + #4808 (FOL). EPIC #4667, étape 2 de la deep-queue.

## Contenu

Cadres d'argumentation (AF) + calcul des extensions sous 4 sémantiques fondatrices :

- **AF** : `DungTheory` (implémente `Graph<Argument>`), `Argument(String)`, `Attack(attacker, attacked)`
- **Extension** : `Extension<DungTheory>` (collection d'arguments acceptés)
- **Raisonneurs** : `SimpleGroundedReasoner` / `SimplePreferredReasoner` / `SimpleStableReasoner` / `SimpleCompleteReasoner`, héritent de `AbstractExtensionReasoner`
  - `getModels(DungTheory)` → collection des extensions
  - `query(DungTheory, Argument)` → `Boolean` (acceptation sceptique)

### Démonstrations (exec réelle, 0 erreur)

- AF simple `a → b`
- **Attaque mutuelle `x ↔ y`** : les 4 sémantiques **divergent** comme attendu — fondée `{}` (point fixe ne décolle pas), stable/préférée `{x}`/`{y}` (chaque argument bat l'autre), complète `{x}`/`{y}`/`{}` (inclut la vide)
- **Défense indirecte** : `A→B, A→C, D→A` → extension fondée `{B,C,D}` (D défend B et C contre A), `⊨D=true`, `⊨B=true`, `⊨A=false` (battu par D)

## Découverte API (G.1, firsthand sur source Java v1.30)

API extraite du source TweetyProject v1.30 cloné (`org.tweetyproject.arg.dung.syntax/semantics/reasoner`), pas d'invention. Le module `arg-dung` est **séparé de `pl`** (pas transitif) → re-shade requis.

## Build recipe — blocage Java-14 résolu (leçon durable)

`arg-dung` v1.30 utilise switch-expressions (Java 14) + `var` (Java 10) de façon envahissante. **Le core est Java-8-clean** (~104 fichiers : syntax/semantics/Simple*Reasoners/ldo/parser) après suppression des sous-paquets non-pédagogiques (equivalence/serialisability/writer/analysis/learning/principles/util) + 1 réécriture de switch dans `AbstractExtensionReasoner.getSimpleReasonerForSemantics()`. Le module `graphs` (dépendance) recompilé en Java 8 (major 52) — le parent-pom source impose `<source>15</source>` et `<relativePath>` le résout avant le m2 patché.

Recette complète (shade POM + `<IkvmReference>` csproj) committée dans `dotnet-build/` pour reproductibilité. DLL `org.tweetyproject.tweety-dung.dll` (9.1 MB) à côté du notebook (pattern #4711).

## Exercices (3, C.1-compliant)

1. **Cycle à 3** (`p→q→r→p`) : extensions stables vs fondée (fondée vide, plusieurs stables)
2. **Auto-attaque** (`s→s`) : aucune sémantique admissible n'accepte `s`
3. **Complète vs préférée** : identifier l'extension commune sur `{a→b, a→c}`

Stubs sans `throw`/`raise` (C.1) — notebook exécutable de bout en bout non complété.

## Validation (H.1-H.3)

- `jupyter nbconvert --execute` end-to-end kernel `.net-csharp` : **EXIT=0, 0 erreur**
- 11 cellules code, toutes `execution_count` peuplés + outputs cohérents (C.2)
- H.3 pre-commit : PASS ; C.1 scan source-only : **0 violation**
- Catalogue byte-identique à `origin/main`

See #4667

🤖 Generated with [Claude Code](https://claude.com/claude-code)