### PR TITLE
docs(qc): FR-backfill crypto_panier README + fix 5->6 full-coverage count

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/datasets/yfinance/crypto_panier/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/datasets/yfinance/crypto_panier/README.en.md
@@ -31,7 +31,7 @@ CSV, columns: `Date,Open,High,Low,Close,Volume`
 
 ## Anti-bias design
 
-5 coins with full 2018+ coverage (BTC, ETH, LTC, XRP, ADA, LINK) prevent the model from overfitting to a single asset's return distribution. 4 coins with shorter histories test generalization to newer assets. MATIC tests handling of delisted/rebranded assets.
+6 coins with full 2018+ coverage (BTC, ETH, LTC, XRP, ADA, LINK) prevent the model from overfitting to a single asset's return distribution. 4 coins with shorter histories test generalization to newer assets. MATIC tests handling of delisted/rebranded assets.
 
 ## Regeneration
 

--- a/MyIA.AI.Notebooks/QuantConnect/datasets/yfinance/crypto_panier/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/datasets/yfinance/crypto_panier/README.md
@@ -1,0 +1,51 @@
+# Panier Crypto - 10 Coins OHLCV Journalier
+
+Dataset anti-biais de l'étape 3a pour l'entraînement ML multi-actifs (étape 3).
+
+## Source
+
+yfinance (Yahoo Finance), téléchargé le 2026-05-06.
+
+## Couverture
+
+| Symbole | Début | Fin | Lignes | Note |
+|---------|-------|-----|--------|------|
+| BTC-USD | 2018-01-01 | 2026-04-30 | 3042 | Plage complète |
+| ETH-USD | 2018-01-01 | 2026-04-30 | 3042 | Plage complète |
+| LTC-USD | 2018-01-01 | 2026-04-30 | 3042 | Plage complète |
+| XRP-USD | 2018-01-01 | 2026-04-30 | 3042 | Plage complète |
+| ADA-USD | 2018-01-01 | 2026-04-30 | 3042 | Plage complète |
+| LINK-USD | 2018-01-01 | 2026-04-30 | 3042 | Plage complète |
+| SOL-USD | 2020-04-10 | 2026-04-30 | 2212 | Cotation 2020 |
+| MATIC-USD | 2019-04-28 | 2025-03-24 | 2158 | Delisted/rebrandé en POL |
+| AVAX-USD | 2020-07-13 | 2026-04-30 | 2049 | Cotation 2020 |
+| DOT-USD | 2020-08-20 | 2026-04-30 | 2080 | Cotation 2020 |
+
+## Format
+
+CSV, colonnes : `Date,Open,High,Low,Close,Volume`
+
+- Date : AAAA-MM-JJ (journalier)
+- Prix : float, USD
+- Volume : int, volume échangé journalier
+
+## Conception anti-biais
+
+6 coins avec une couverture complète 2018+ (BTC, ETH, LTC, XRP, ADA, LINK) empêchent le modèle de surajuster la distribution de rendement d'un seul actif. 4 coins avec un historique plus court testent la généralisation à des actifs plus récents. MATIC teste la gestion des actifs delisted/rebrandés.
+
+## Régénération
+
+```bash
+conda activate base
+python -c "
+import yfinance as yf, pandas as pd, os
+COINS = ['BTC-USD','ETH-USD','LTC-USD','XRP-USD','ADA-USD',
+         'DOT-USD','SOL-USD','AVAX-USD','MATIC-USD','LINK-USD']
+for t in COINS:
+    df = yf.download(t, start='2018-01-01', end='2026-05-01', auto_adjust=True, progress=False)
+    if isinstance(df.columns, pd.MultiIndex): df.columns = df.columns.get_level_values(0)
+    df = df[['Open','High','Low','Close','Volume']]
+    df.index.name = 'Date'
+    df.to_csv(f'{t}_2018-01-01_2026-05-01.csv')
+"
+```


### PR DESCRIPTION
## Summary

Two-part slice on QC turf (po-2024): **EPIC #1650 Phase 0.5 FR-backfill (#3870)** + **genuine count-alignment bug fix (#3976)** for the crypto panier dataset README.

## Changes

1. **`git mv README.md -> README.en.md`** — preserve the EN original verbatim per [readme-french-first.md](../.claude/rules/readme-french-first.md) HARD rule 2 (no destructive translation, golden-set preservation for Phase 3).
2. **New `README.md` in French** — faithful translation (source, 10-coin coverage table, CSV format, anti-bias design, regeneration snippet), same structure and links.
3. **Bug fix (both files)**: "5 coins with full 2018+ coverage" -> **6**. The coverage table lists **6** full-range coins (BTC, ETH, LTC, XRP, ADA, LINK — all 3042 rows, 2018-01-01 → 2026-04-30), not 5. Prose undercounted them.

## Gitignore note (HARD-earned)

The `datasets/` folder is gitignored (`QuantConnect/.gitignore:94`). The original README was force-tracked in #776 (commit `f13875885`). To preserve tracking, the new FR README.md is force-added (`-f`) on this branch — matching that precedent. Without `-f`, the branch would have shipped only the `.en.md` rename and left the folder without a `README.md`.

## Verification (G.1 firsthand)

- Coverage table cross-checked: exactly 6 coins with 2018-01-01 → 2026-04-30 / 3042 rows (BTC/ETH/LTC/XRP/ADA/LINK); 4 with shorter histories (SOL/MATIC/AVAX/DOT). Prose now matches the table.
- Both files present on branch: `README.md` (FR, 51 lines) + `README.en.md` (EN original + count fix).
- No CATALOG-STATUS markers. No links broken (relative paths unchanged). QC turf, no collision.

See #3870 (FR backfill, Part of #1650) and See #3976 (QC READMEs, Part of #3973).

Co-Authored-By: Claude-Code <noreply@anthropic.com>