### PR TITLE
docs(rules): MiniMax M3 = tier haiku on po-2023

### DIFF
--- a/.claude/rules/model-delegation.md
+++ b/.claude/rules/model-delegation.md
@@ -36,9 +36,17 @@ S'applique a **tout agent qui delegue du travail a un sous-agent** (`Agent()` to
 
 **Comportement attendu du sous-agent (bon signe)** : deferer explicitement les jugements hors de sa portee (« the coordinator should assess ») plutot qu'halluciner un verdict. Un sous-agent qui defere sur un blind-spot connu est plus fiable, pas moins.
 
-## Note de mapping (environnement ai-01)
+## Note de mapping (par machine)
 
-Sur ai-01, les alias resolvent : `sonnet` => GLM-5.1, `haiku` => Qwen 3.6 local. Sur une autre machine le mapping peut differer : raisonner en **tiers** (intermediaire / leger), pas en nom de modele. Le principe — deleguer le read-heavy borne, garder la decision, modele explicite obligatoire — est invariant.
+Le mapping `model` explicite vers le moteur sous-jacent depend de la machine d'execution. Raisonner en **tiers** (intermediaire / leger), pas en nom de modele. Le principe — deleguer le read-heavy borne, garder la decision, modele explicite obligatoire — est invariant.
+
+| Machine   | `sonnet` (tier intermediaire) | `haiku` (tier leger)     |
+|-----------|-------------------------------|--------------------------|
+| ai-01     | GLM-5.1                       | Qwen 3.6 local           |
+| po-2023   | ZAI GLM-5.1                   | MiniMax M3               |
+| autres workers po-* | voir `roosync_inventory`     | voir `roosync_inventory` |
+
+MiniMax M3 (deploie sur `po-2023` depuis 2026-07-02, mandat coordinateur) remplace Qwen 3.6 sur le tier `haiku` pour cette lane. Conséquence operationnelle : les sous-agents `model: "haiku"` invoques depuis `po-2023` (ou routés vers lui) sont executes par MiniMax M3, pas par Qwen. La regle de qualite (deleguer le read-heavy borne, garder la decision) reste identique — seul le moteur change.
 
 ## Voir aussi
 

--- a/.claude/rules/model-delegation.md
+++ b/.claude/rules/model-delegation.md
@@ -46,7 +46,7 @@ Le mapping `model` explicite vers le moteur sous-jacent depend de la machine d'e
 | po-2023   | ZAI GLM-5.1                   | MiniMax M3               |
 | autres workers po-* | voir `roosync_inventory`     | voir `roosync_inventory` |
 
-MiniMax M3 (deploie sur `po-2023` depuis 2026-07-02, mandat coordinateur) remplace Qwen 3.6 sur le tier `haiku` pour cette lane. Conséquence operationnelle : les sous-agents `model: "haiku"` invoques depuis `po-2023` (ou routés vers lui) sont executes par MiniMax M3, pas par Qwen. La regle de qualite (deleguer le read-heavy borne, garder la decision) reste identique — seul le moteur change.
+MiniMax M3 (deploie sur `po-2023` depuis 2026-07-02, mandat user) remplace Qwen 3.6 sur le tier `haiku` pour cette lane. Conséquence operationnelle : les sous-agents `model: "haiku"` invoques depuis `po-2023` (ou routés vers lui) sont executes par MiniMax M3, pas par Qwen. La regle de qualite (deleguer le read-heavy borne, garder la decision) reste identique — seul le moteur change.
 
 ## Voir aussi
 


### PR DESCRIPTION
## Decision coordinateur (2026-07-02)

MiniMax M3 (nouveau modele deploye sur worker `po-2023`) remplace Qwen 3.6 sur le tier `haiku` pour cette lane. Les sous-agents `model: "haiku"` invoques depuis / routes vers po-2023 sont executes par MiniMax M3.

## Diff (10 lignes, 1 fichier)

Mise a jour de la section "Note de mapping" dans `.claude/rules/model-delegation.md` :
- Titre de la section : "par machine" (au lieu de "environnement ai-01")
- Tableau de mapping par machine (ai-01, po-2023, autres po-*)
- Note explicative sur la substitution MiniMax M3 = haiku

## Regle invariante

- Le principe (deleguer read-heavy borne, garder la decision, modele explicite obligatoire) est inchange.
- Seul le moteur sous-jacent change pour le tier leger sur po-2023.
- Regle de qualite (deleguer le read-heavy borne, garder la decision) reste identique.

## Scope

1 fichier, 10 insertions, 2 suppressions. Pas de modification d'autre regle. Conforme a `catalog-pr-hygiene.md` regle 3 (un seul livrable par PR).

## Mandat user (verbatim)

> "MiniMax M3, vous intégrez une flotte avec Anthropic Opus/Fable et ZAI GLM qui seront respectivement les modeles opus et sonnet tandis que vous serez notre haiku. Je vais passer tous les agents de votre workspace CoursIA-2 sous votre modele pour simplifier la gestion."

## Action attendue de ai-01

- Review + merge (PR scope mini, conforme a `pr-review-discipline.md`).
- Annoncer sur les dashboards `workspace-CoursIA` et `workspace-CoursIA-2` la bascule : workers `po-2023` tournent maintenant sous MiniMax M3 sur le tier `haiku`.

## Liens

- PR ouverte par : `myia-po-2023` worker, modele MiniMax M3 (mandat coordinateur 2026-07-02).
- Voir : `.claude/rules/coordinator-discipline.md`, `proactive-coordination.md`, `harness-hygiene.md`.