### PR TITLE
fix(z3): rewire capstone 08 loader onto 07's mealplan_cache.json (See #4677)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/08_Meal_Planner_Patient_Capstone.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/08_Meal_Planner_Patient_Capstone.ipynb
@@ -9,15 +9,15 @@
    "source": [
     "# 08 — Capstone hiérarchique : du squelette `int[][]` réel aux restrictions patient (port fidèle)\n",
     "\n",
-    "[< Série Z3](README.md) | Capstone MealPlanner **Slice C** (*Part of* #4617, *See* #1206)\n",
+    "[< Série Z3](README.md) | Capstone MealPlanner capstone (*Part of* #4617, *See* #1206)\n",
     "\n",
     "Ce notebook est le **cœur solveur** du capstone MealPlanner. Il porte **fidèlement** la méthode\n",
     "`PlanificateurDeMenus.Create` du Demo2 d'origine\n",
     "([fork Z3.Linq, branche `EPFdevelopment`](https://github.com/MyIntelligenceAgency/Z3.LinqBinding)),\n",
     "et le construit en **deux mouvements** sur le **corpus réel** Ciqual ANSES 2025 × Recettes\n",
-    "(`dietetique.json`, produit par la **Slice A** — [07](07_Meal_Planner_Data_External.ipynb)) :\n",
+    "(`mealplan_cache.json`, produit par la [couche de donnees 07] — [07](07_Meal_Planner_Data_External.ipynb)) :\n",
     "\n",
-    "- **Mouvement 1 — le squelette structurel `int[][]` sur les 138 plats réels.** Bornes de créneau par\n",
+    "- **Mouvement 1 — le squelette structurel `int[][]` sur les recettes reelles du cache.** Bornes de créneau par\n",
     "  rôle (entrée, plat, accompagnement…), montée en gamme, permutation totale (`Distinct` cross-row en\n",
     "  mode `CollectionHandling.Array`). C'est la **structure** hiérarchique — *quel plat à quel créneau* —\n",
     "  qui passe sans modification du corpus jouet (06) à l'échelle réelle. **Aucune nutrition** ici.\n",
@@ -39,8 +39,8 @@
     "```\n",
     "\n",
     "La nutrition d'un menu est la **somme** des compositions de ses plats ; chaque plat apporte le vecteur\n",
-    "de teneurs (74 constituants) calculé en Slice A. Le **patient** impose des bornes `Min`/`Max` par\n",
-    "constituant (ex : énergie entre 800 et 2600 kcal, lipides plafonnées) — exactement la classe\n",
+    "de teneurs (5 constituants Ciqual) calculé par 07. Le **patient** impose des bornes `Min`/`Max` par\n",
+    "constituant (ex : énergie dans une fenêtre kJ, lipides plafonnées) — exactement la classe\n",
     "`Restriction { Min, Max }` du source.\n",
     "\n",
     "> **Note de consolidation.** Ce notebook réunit le squelette structurel à l'échelle réelle (Mouvement 1)\n",
@@ -58,7 +58,7 @@
    "source": [
     "## 0. Dependances et corpus\n",
     "\n",
-    "Le notebook charge le cache `dietetique.json` produit par la **Slice A** ([07](07_Meal_Planner_Data_External.ipynb)).\n",
+    "Le notebook charge le cache `mealplan_cache.json` produit par [07(07_Meal_Planner_Data_External.ipynb)).\n",
     "Si le cache est absent : executer 07 (ou `python download_meal_data.py` puis 07). **Echec bruyant**, pas\n",
     "de corpus de substitution (regle SOTA : on raisonne sur les vraies donnees nutritionnelles).\n",
     "\n",
@@ -85,7 +85,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-7096.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-38160.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -130,12 +130,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.12:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.30.224.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '7096.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '38160.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -199,7 +199,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Corpus charge : 74 constituants / 198 denrees / 138 plats\r\n"
+      "Cache present : data/meals\\mealplan_cache.json (121 Ko)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache charge en 0,0s : 736 recettes exploitables (sur 2454 brutes), 5 constituants.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constituants : [0] Energie | [1] Protéines | [2] Glucides (g/100 g) | [3] Lipides (g/100 g) | [4] Sel chlorure de sodium (g/100 g)\r\n"
      ]
     }
    ],
@@ -216,35 +230,55 @@
     "using System.Text.Json;\n",
     "using System.Diagnostics;\n",
     "\n",
-    "// POCOs miroir du schema dietetique.json (couche de fusion Ciqual x Recettes, Slice A).\n",
-    "public class Dietetique {\n",
-    "    public List<Constituant> Constituants { get; set; }\n",
-    "    public List<DenreeImport> Denrees { get; set; }\n",
-    "    public List<PlatImport> Plats { get; set; }\n",
+    "// Plat du corpus (miroir du contrat du cache 07 : recipes[].{title,cats,vec}).\n",
+    "public class PlatImport {\n",
+    "    public string Nom { get; set; }\n",
+    "    public int Ordre { get; set; }              // creneau 1..5, derive des cats RecipeML\n",
+    "    public decimal[] Compositions { get; set; } // vec[5] = [Energie kJ, Proteines, Glucides, Lipides, Sel]\n",
     "}\n",
-    "public class Constituant { public string Nom { get; set; } }\n",
-    "public class DenreeImport { public string Nom { get; set; } = \"\"; public decimal[] Compositions { get; set; } }\n",
-    "public class Ingredient { public int Denree { get; set; } public decimal Quantite { get; set; } }\n",
-    "public class PlatImport { public string Nom { get; set; } public int Ordre { get; set; } public decimal[] Compositions { get; set; } }\n",
     "\n",
-    "// Resolution robuste du cache (relatif au notebook, repli remontant) ; affichage relatif (pas de chemin machine).\n",
-    "string ResolveDiet() {\n",
-    "    foreach (var c in new[]{ \"data/meals/dietetique.json\",\n",
-    "                             \"MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/data/meals/dietetique.json\" })\n",
-    "        if (File.Exists(c)) return c;\n",
-    "    return \"data/meals/dietetique.json\";\n",
+    "// Cache solveur-usable produit par le notebook 07 (couche Ciqual x Recettes RecipeML).\n",
+    "var CACHE = Path.Combine(\"data/meals\", \"mealplan_cache.json\");\n",
+    "if (!File.Exists(CACHE)) {\n",
+    "    Console.WriteLine(\"[CACHE ABSENT] \" + CACHE);\n",
+    "    Console.WriteLine(\"Executez d'abord 07 (couche de donnees) de bout en bout,\");\n",
+    "    Console.WriteLine(\"ou : python download_meal_data.py puis 07. Echec bruyant (regle SOTA).\");\n",
+    "    throw new FileNotFoundException(CACHE);\n",
     "}\n",
-    "var dietPath = ResolveDiet();\n",
-    "Dietetique diet = null;\n",
-    "if (!File.Exists(dietPath)) {\n",
-    "    Console.WriteLine(\"[CACHE ABSENT] \" + dietPath);\n",
-    "    Console.WriteLine(\"Executez d'abord 05c (Slice A) qui produit dietetique.json,\");\n",
-    "    Console.WriteLine(\"ou : python download_meal_data.py  puis 05c.\");\n",
-    "} else {\n",
-    "    diet = JsonSerializer.Deserialize<Dietetique>(File.ReadAllText(dietPath));\n",
-    "    Console.WriteLine($\"Corpus charge : {diet.Constituants.Count} constituants / \"\n",
-    "                      + $\"{diet.Denrees.Count} denrees / {diet.Plats.Count} plats\");\n",
-    "}\n"
+    "Console.WriteLine($\"Cache present : {CACHE} ({new FileInfo(CACHE).Length / 1024} Ko)\");\n",
+    "\n",
+    "// Derivation du creneau (Ordre 1..5) depuis les cats RecipeML (corpus anglo-saxon).\n",
+    "// 1=entree/appetizer, 2=plat principal/main dish, 3=accompagnement/vegetal, 4=laitage/fromage, 5=dessert.\n",
+    "// Les recettes non-categorisees (cats=['None'] ou ambigu) sont ecartees (pas de fabrication de creneau).\n",
+    "int OrdreFromCats(List<string> cats) {\n",
+    "    var j = string.Join(\" \", cats).ToLowerInvariant();\n",
+    "    if (j.Contains(\"appetizer\") || j.Contains(\"starter\") || j.Contains(\"soup\")) return 1;\n",
+    "    if (j.Contains(\"main dish\") || j.Contains(\"beef\") || j.Contains(\"pork\") || j.Contains(\"chicken\") || j.Contains(\"meat\") || j.Contains(\"fish\")) return 2;\n",
+    "    if (j.Contains(\"vegetable\") || j.Contains(\"salad\") || j.Contains(\"rice\") || j.Contains(\"pasta\") || j.Contains(\"potato\") || j.Contains(\"bread\") || j.Contains(\"side\")) return 3;\n",
+    "    if (j.Contains(\"cheese\") || j.Contains(\"dairy\") || j.Contains(\"yogurt\") || j.Contains(\"cream\")) return 4;\n",
+    "    if (j.Contains(\"dessert\") || j.Contains(\"cake\") || j.Contains(\"cookie\") || j.Contains(\"pie\") || j.Contains(\"fruit\") || j.Contains(\"sweet\") || j.Contains(\"tart\")) return 5;\n",
+    "    return 0;\n",
+    "}\n",
+    "\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "var root = JsonDocument.Parse(File.ReadAllText(CACHE)).RootElement;\n",
+    "var constituants = root.GetProperty(\"constituants\").EnumerateArray().Select(x => x.GetString()).ToArray();\n",
+    "int C = constituants.Length;\n",
+    "var allPlats = new List<PlatImport>();\n",
+    "foreach (var r in root.GetProperty(\"recipes\").EnumerateArray()) {\n",
+    "    var t = r.GetProperty(\"title\").GetString().Trim();\n",
+    "    var cats = r.GetProperty(\"cats\").EnumerateArray().Select(x => x.GetString()).ToList();\n",
+    "    int o = OrdreFromCats(cats);\n",
+    "    if (o < 1) continue;   // orphan ecarte\n",
+    "    allPlats.Add(new PlatImport {\n",
+    "        Nom = t.Length > 44 ? t.Substring(0, 44) : t,\n",
+    "        Ordre = o,\n",
+    "        Compositions = r.GetProperty(\"vec\").EnumerateArray().Select(x => x.GetDecimal()).ToArray()\n",
+    "    });\n",
+    "}\n",
+    "sw.Stop();\n",
+    "Console.WriteLine($\"Cache charge en {sw.Elapsed.TotalSeconds:F1}s : {allPlats.Count} recettes exploitables (sur {root.GetProperty(\"n_total\").GetInt32()} brutes), {C} constituants.\");\n",
+    "Console.WriteLine(\"Constituants : \" + string.Join(\" | \", constituants.Select((n, i) => $\"[{i}] {n.Split(',')[0].Trim()}\")));"
    ]
   },
   {
@@ -254,9 +288,9 @@
     "tags": []
    },
    "source": [
-    "## Mouvement 1 — Le squelette structurel `int[][]` sur le corpus réel (138 plats)\n",
+    "## Mouvement 1 — Le squelette structurel `int[][]` sur le corpus réel (plusieurs centaines de recettes)\n",
     "\n",
-    "Avant la nutrition, on établit la **structure** : sélectionner, parmi le vrai catalogue de 138 plats,\n",
+    "Avant la nutrition, on établit la **structure** : sélectionner, parmi le vrai catalogue de plusieurs centaines de recettes (cache 07 plats,\n",
     "un plan de 7 jours qui respecte le **rôle de chaque créneau** et la **diversité** — le tout en LINQ pur\n",
     "sur un `int[][]`. C'est le théorème hiérarchique du notebook [06](06_Meal_Planner_Modelisation.ipynb)\n",
     "(corpus jouet) porté **sans modification** à l'échelle réelle, en deux variantes : *montée en gamme* et\n",
@@ -295,43 +329,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  creneau 1 (entree          ) : index [0..28]  (29 plats)\r\n"
+      "  creneau 1 (entree          ) : index [0..65]  (66 plats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  creneau 2 (plat principal  ) : index [29..65]  (37 plats)\r\n"
+      "  creneau 2 (plat principal  ) : index [66..142]  (77 plats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  creneau 3 (accompagnement  ) : index [66..86]  (21 plats)\r\n"
+      "  creneau 3 (accompagnement  ) : index [143..380]  (238 plats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  creneau 4 (laitage/fromage ) : index [87..107]  (21 plats)\r\n"
+      "  creneau 4 (laitage/fromage ) : index [381..389]  (9 plats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  creneau 5 (dessert         ) : index [108..121]  (14 plats)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Total exploitable : 122 plats sur 5 creneaux.\r\n"
+      "  creneau 5 (dessert         ) : index [390..735]  (346 plats)\r\n"
      ]
     },
     {
@@ -339,7 +365,15 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Exemples (creneau 1) : CAROTTES A L'ORANGE, CAROTTES RAPEES(S/V), CELERI REMOULADE, GOUGERE INDIVIDUELLE\r\n"
+      "Total exploitable : 736 plats sur 5 creneaux.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Exemples (creneau 1) : 'ncapriata Di Fave (Fava Bean Puree with Gre, 4 B's Restaurant Tomato Soup, 5-Minute Broccoli Soup, 7 Layer Dip\r\n"
      ]
     }
    ],
@@ -348,7 +382,7 @@
     "const int Creneaux = 5;   // ordres 1..5\n",
     "\n",
     "// Trie par creneau -> chaque ordre occupe une plage d'index contigue [lo[o]..hi[o]].\n",
-    "var plats = diet.Plats.Where(p => p.Ordre >= 1 && p.Ordre <= Creneaux)\n",
+    "var plats = allPlats.Where(p => p.Ordre >= 1 && p.Ordre <= Creneaux)\n",
     "                      .OrderBy(p => p.Ordre).ThenBy(p => p.Nom).ToList();\n",
     "\n",
     "var lo = new int[Creneaux + 1];\n",
@@ -466,7 +500,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[A] Montee en gamme resolue en 76 ms :\n",
+      "[A] Montee en gamme resolue en 64 ms :\n",
       "\r\n"
      ]
     },
@@ -474,49 +508,49 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 1 : RADIS BEURRE | BOULETTES SOJA | CAROTTE RONDELLES (BTE | BLEU FRANCAIS 25G | ANANAS SIROP MORCEAUX\r\n"
+      "  Jour 1 : Anasazi Bean Spread | (Sort-Of) Sweet and So | 'sense and Sensibility | 3-Step Cheesecake | 'gimme Both' Pumpkin-P\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 2 : RILLETTES DE LA MER IN | BOULETTES SOJA SCE TOM | CHOU FLEUR BECHAMEL | BREBICREME 20G | BISCUIT FOURRE CHOCOLA\r\n"
+      "  Jour 2 : Andouille and Potato S | 1-Pot Pastitsio Goes L | ( From Bread Mix ) Big | Acapulco Rice | (Sort of Light) Boston\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 3 : SAL COLESLAW CC | BRANDADE | CHOU FLEUR PERSILLE | CABECOU BIOLOGIQUE | BOUDOIR\r\n"
+      "  Jour 3 : Andouille in Comfortin | 1-Pot: Pastitsio Goes  | ( From Bread Mix ) Cin | Ananas a la Creme (Cre | #1 Lemon Bars\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 4 : SAL D  HIVER (crudités | BROCHETTE DE DINDONNEA | COQUILLETTES BEURRE | CAMEMBERT PORTION  30G | COMPOTE IND POMME SUD \r\n"
+      "  Jour 4 : Andouille in Puff Past | 10 Minute Szechuan Chi | 1-2-3 Meurbeteig Dough | Ann's White Chocolate  | #10 Cake\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 5 : SAL ENDIVES | CUBES DE COLIN CREME C | COURGETTES BECHAMEL | CANTAL PORTION 25G | COMPOTE IND POMME/ABRI\r\n"
+      "  Jour 5 : Angel Biscuits | 16th-Street Stew | 1-Pot Creamy Chicken N | Annemarie's German App | $100 Chocolate Cake\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 6 : SAL MELANGE TENDRE | CUBES POIS POIVRONS | EPINARDS BECHAMEL | CHANTENEIGE | COMPOTE IND POMME/ANAN\r\n"
+      "  Jour 6 : Angel of Mercy Cheese | 19-Alarm Chili | 1-Pot: Creamy Chicken  | Apple Omelette | 1 Egg Butter Spritz\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 7 : SAL P DE TERRE (PARMEN | CUBES SAUMON A L ANETH | FLAGEOLETS PERSILLES | CHEVRE PETIT CABRAY | COMPOTE IND POMME/MIRA\r\n"
+      "  Jour 7 : Angelini Grill Brusche | 2 Pungent Bbq Sauces | 10-Minute Lasagna | Apricot Nectar Cheesec | 1-2-3 Cookies\r\n"
      ]
     }
    ],
@@ -574,7 +608,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[B] Permutation totale (Distinct cross-row) resolue en 31 ms :\n",
+      "[B] Permutation totale (Distinct cross-row) resolue en 26 ms :\n",
       "\r\n"
      ]
     },
@@ -582,49 +616,49 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 1 : RADIS BEURRE | BOULETTES SOJA | CAROTTE RONDELLES (BTE | BLEU FRANCAIS 25G | ANANAS SIROP MORCEAUX\r\n"
+      "  Jour 1 : Anasazi Bean Spread | (Sort-Of) Sweet and So | 'sense and Sensibility | 3-Step Cheesecake | 'gimme Both' Pumpkin-P\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 2 : RILLETTES DE LA MER IN | BOULETTES SOJA SCE TOM | CHOU FLEUR BECHAMEL | BREBICREME 20G | BISCUIT FOURRE CHOCOLA\r\n"
+      "  Jour 2 : Andouille and Potato S | 1-Pot Pastitsio Goes L | ( From Bread Mix ) Big | Acapulco Rice | (Sort of Light) Boston\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 3 : SAL COLESLAW CC | BRANDADE | CHOU FLEUR PERSILLE | CABECOU BIOLOGIQUE | BOUDOIR\r\n"
+      "  Jour 3 : Andouille in Comfortin | 1-Pot: Pastitsio Goes  | ( From Bread Mix ) Cin | Ananas a la Creme (Cre | #1 Lemon Bars\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 4 : SAL D  HIVER (crudités | BROCHETTE DE DINDONNEA | COQUILLETTES BEURRE | CAMEMBERT PORTION  30G | COMPOTE IND POMME SUD \r\n"
+      "  Jour 4 : Andouille in Puff Past | 10 Minute Szechuan Chi | 1-2-3 Meurbeteig Dough | Ann's White Chocolate  | #10 Cake\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 5 : SAL ENDIVES | CUBES SAUMON A L ANETH | COURGETTES BECHAMEL | CANTAL PORTION 25G | COMPOTE IND POMME/ABRI\r\n"
+      "  Jour 5 : Angel Biscuits | 2 Pungent Bbq Sauces | 1-Pot Creamy Chicken N | Annemarie's German App | $100 Chocolate Cake\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 6 : SAL MELANGE TENDRE | CUBES DE COLIN CREME C | EPINARDS BECHAMEL | CHANTENEIGE | COMPOTE IND POMME/ANAN\r\n"
+      "  Jour 6 : Angel of Mercy Cheese | 16th-Street Stew | 1-Pot: Creamy Chicken  | Apple Omelette | 1 Egg Butter Spritz\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Jour 7 : SAL P DE TERRE (PARMEN | CUBES POIS POIVRONS | FLAGEOLETS PERSILLES | CHEVRE PETIT CABRAY | COMPOTE IND POMME/MIRA\r\n"
+      "  Jour 7 : Angelini Grill Brusche | 19-Alarm Chili | 10-Minute Lasagna | Apricot Nectar Cheesec | 1-2-3 Cookies\r\n"
      ]
     }
    ],
@@ -675,10 +709,10 @@
     "## Mouvement 2 — La nutrition *fidèle* force la curation\n",
     "\n",
     "Le squelette structurel passe à l'échelle réelle sans effort (Z3 résout les deux variantes en quelques\n",
-    "dizaines de millisecondes sur 138 plats). On ajoute maintenant la **couche nutritionnelle fidèle** au\n",
+    "dizaines de millisecondes sur le corpus réel). On ajoute maintenant la **couche nutritionnelle fidèle** au\n",
     "Demo2 : le **linking de composition** (la variable de teneur liée au plat réellement choisi) **et** les\n",
     "**restrictions patient Min/Max** sur la somme par menu. Mais le linking, à l'échelle complète, génère\n",
-    "`7 × 5 × 138 × 74 ≈ 357 000` assertions — l'instance **explose**. On **cure** donc d'abord un\n",
+    "`7 × 5 × R × C` assertions (R recettes, C constituants) — l'instance **explose**. On **cure** donc d'abord un\n",
     "sous-ensemble tractable, en préservant la **structure** du théorème (port fidèle de\n",
     "`PlanificateurDeMenus.Create`)."
    ]
@@ -692,13 +726,13 @@
    "source": [
     "### 2.1 Curation d'un sous-ensemble tractable\n",
     "\n",
-    "La source pose le theoreme sur **138 plats x 74 constituants x 7 menus x 5 creneaux**. Le linking de\n",
-    "composition genere alors `7 x 5 x 138 x 74 ~ 357 000` assertions — l'instance **explose** (c'est\n",
-    "precisement le probleme de *convergence a l'echelle*, objet de la **Slice D**). Le corps de l'issue\n",
+    "La source pose le theoreme sur plusieurs centaines de recettes x 5 constituants x 7 menus x 5 creneaux. Le linking de\n",
+    "composition genere alors `7 x 5 x R x C` (R recettes, C constituants) assertions — l'instance **explose** (c'est\n",
+    "precisement le probleme de *convergence a l'echelle*, objet de [09 (convergence a l'echelle)](09_Meal_Planner_Convergence_Scale.ipynb)). Le corps de l'issue\n",
     "#4617 le prevoit : **on cure d'abord un sous-ensemble**.\n",
     "\n",
     "On reduit donc a **2 menus x 3 creneaux**, **5 candidats par creneau**, et **3 constituants cles**\n",
-    "(energie kcal, proteines, lipides). Le theoreme reste **fidele dans sa structure** ; seules les\n",
+    "(energie kJ, proteines, lipides). Le theoreme reste **fidele dans sa structure** ; seules les\n",
     "*dimensions* sont reduites pour rester pedagogiquement lisible et resoluble en quelques secondes."
    ]
   },
@@ -727,21 +761,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  [1] Energie, Règlement UE N° 1169/2011 (kcal/100 g)\r\n"
+      "  [0] Energie, Règlement UE N° 1169/2011 (kJ/100 g)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  [19] Protéines, N x facteur de Jones (g/100 g)\r\n"
+      "  [1] Protéines, N x facteur de Jones (g/100 g)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  [32] Lipides (g/100 g)\r\n"
+      "  [3] Lipides (g/100 g)\r\n"
      ]
     },
     {
@@ -757,28 +791,28 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Apercu (creneau : candidats -> energie kcal) :\r\n"
+      "Apercu (creneau : candidats -> energie kJ) :\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  creneau 1 : RADIS BEURRE(11), SAL MELANGE TENDRE(79), PAIN BAGNAT ECOLE(253), GOUGERE INDIVIDUELLE(0), SALADE KOUKI AU CURRY(1366)\r\n"
+      "  creneau 1 : 'ncapriata Di Fave (Fava Bean Puree with Gre(5922), 4 B's Restaurant Tomato Soup(3409), 5-Minute Broccoli Soup(6415), 7 Layer Dip(11374), 90-Minute Soft Pretzels(7426)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  creneau 2 : DAUBE BBC(1889), SAUCISSE VEGETALE(398), ROTI DE VEAU (cuisson)(491), POISSON PANE CUIT / CITRON(275), NUGGETS VEGETAL(247)\r\n"
+      "  creneau 2 : (Sort-Of) Sweet and Sour Chicken (Also Good(1018), 1-Pot Pastitsio Goes Light(15054), 1-Pot: Pastitsio Goes Light(15054), 10 Minute Szechuan Chicken(1178), 16th-Street Stew(10678)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  creneau 3 : RIZ CAMARGUAIS(1455), TORSADES HALLOWEEN(2026), P DE TERRE VAPEUR(1033), CAROTTE RONDELLES (BTE)(1310), GRATIN DE COURGETTES A LA TOMATE(1354)\r\n"
+      "  creneau 3 : 'sense and Sensibility' Scones(5329), ( From Bread Mix ) Big Soft Pretzels(4421), ( From Bread Mix ) Cinnamon Rolls(13568), 1-2-3 Meurbeteig Dough (Mellow Dough)(14026), 1-Pot Creamy Chicken Noodle Casserole(3471)\r\n"
      ]
     }
    ],
@@ -788,31 +822,30 @@
     "const int NbPlats = 3;          // 3 creneaux (ordre 1, 2, 3)\n",
     "const int CandParOrdre = 5;     // 5 candidats par creneau\n",
     "\n",
-    "// 3 constituants cles, reperes par NOM (robuste a l'ordre du fichier)\n",
-    "int cEnergie = diet.Constituants.FindIndex(c => c.Nom.Contains(\"kcal/100 g\") && c.Nom.Contains(\"1169\"));\n",
-    "int cProt    = diet.Constituants.FindIndex(c => c.Nom.ToLowerInvariant().Contains(\"prot\"));\n",
-    "int cLip     = diet.Constituants.FindIndex(c => c.Nom.ToLowerInvariant().Contains(\"lipides\"));\n",
+    "// 3 constituants cles du cache 07 (ordre fixe : [0] Energie kJ, [1] Proteines, [3] Lipides).\n",
+    "int cEnergie = 0;\n",
+    "int cProt    = 1;\n",
+    "int cLip     = 3;\n",
     "int[] CONST  = new[]{ cEnergie, cProt, cLip };\n",
-    "string[] NOMK = new[]{ \"energie(kcal)\", \"proteines(g)\", \"lipides(g)\" };\n",
+    "string[] NOMK = new[]{ \"energie(kJ)\", \"proteines(g)\", \"lipides(g)\" };\n",
     "Console.WriteLine(\"Constituants suivis :\");\n",
-    "foreach (var ci in CONST) Console.WriteLine($\"  [{ci}] {diet.Constituants[ci].Nom.Trim()}\");\n",
+    "foreach (var ci in CONST) Console.WriteLine($\"  [{ci}] {constituants[ci].Trim()}\");\n",
     "\n",
     "// Pool curee : CandParOrdre plats par ordre 1..NbPlats, re-indexes 0..(NbPlats*CandParOrdre-1).\n",
-    "// Le creneau p (0-base) ne propose que les plats d'ordre (p+1) -> indices [p*CandParOrdre, (p+1)*CandParOrdre).\n",
     "var pool = new List<PlatImport>();\n",
     "for (int o = 1; o <= NbPlats; o++)\n",
-    "    pool.AddRange(diet.Plats.Where(p => p.Ordre == o).Take(CandParOrdre));\n",
+    "    pool.AddRange(allPlats.Where(p => p.Ordre == o).Take(CandParOrdre));\n",
     "Console.WriteLine($\"\\nPool curee : {pool.Count} plats ({NbPlats} creneaux x {CandParOrdre} candidats)\");\n",
     "\n",
     "// teneur arrondie a l'entier (arithmetique entiere Z3) ; helpers d'indexation aplatie\n",
     "int Teneur(int poolIdx, int constIdx) => (int)Math.Round(pool[poolIdx].Compositions[constIdx]);\n",
     "int Slot(int m, int p) => m * NbPlats + p;   // ligne aplatie pour le slot (menu m, creneau p)\n",
-    "Console.WriteLine(\"\\nApercu (creneau : candidats -> energie kcal) :\");\n",
+    "Console.WriteLine(\"\\nApercu (creneau : candidats -> energie kJ) :\");\n",
     "for (int p = 0; p < NbPlats; p++) {\n",
     "    var noms = Enumerable.Range(p*CandParOrdre, CandParOrdre)\n",
     "        .Select(i => $\"{pool[i].Nom.Trim()}({Teneur(i, cEnergie)})\");\n",
     "    Console.WriteLine($\"  creneau {p+1} : \" + string.Join(\", \", noms));\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -908,18 +941,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Patient : energie in [800, 2600] kcal, proteines >= 30 g, lipides <= 600 g (par menu)\r\n"
+      "Patient : energie in [3347, 10878] kJ, proteines >= 30 g, lipides <= 600 g (par menu)\r\n"
      ]
     }
    ],
    "source": [
     "// Restrictions patient (fidele a Restriction { Min, Max }, -1 = pas de borne), par MENU.\n",
-    "// Echelle : compositions Ciqual en /100 g sommees sur les 3 plats du menu.\n",
-    "int energieMin = 800;    // kcal cumules minimum par menu\n",
-    "int energieMax = 2600;   // kcal cumules maximum par menu\n",
-    "int protMin    = 30;     // proteines minimum par menu\n",
-    "int lipMax     = 600;    // lipides maximum par menu\n",
-    "Console.WriteLine($\"Patient : energie in [{energieMin}, {energieMax}] kcal, proteines >= {protMin} g, lipides <= {lipMax} g (par menu)\");\n"
+    "// Echelle : cache 07 en kJ/100 g (Energie Ciqual) sommees sur les 3 plats du menu.\n",
+    "// ( bornes rescalees de kcal -> kJ lors du rewire sur le cache 07 : x4,184 )\n",
+    "int energieMin = 3347;   // ~800 kcal cumules minimum par menu\n",
+    "int energieMax = 10878;  // ~2600 kcal cumules maximum par menu\n",
+    "int protMin    = 30;     // proteines minimum par menu (g)\n",
+    "int lipMax     = 600;    // lipides maximum par menu (g)\n",
+    "Console.WriteLine($\"Patient : energie in [{energieMin}, {energieMax}] kJ, proteines >= {protMin} g, lipides <= {lipMax} g (par menu)\");\n"
    ]
   },
   {
@@ -934,7 +968,7 @@
     "Les cinq familles de contraintes reproduisent `PlanificateurDeMenus.Create` (source lignes 38-101) :\n",
     "\n",
     "1. **Bornes = ordre** : `PlatId[m][p]` indexe un plat du creneau (p+1) — la source impose\n",
-    "   `Dietetique.Plats[rid].Ordre == p+1` ; ici la partition de la pool par ordre l'encode dans les bornes.\n",
+    "   `allPlats[rid].Ordre == p+1` ; ici la partition de la pool par ordre l'encode dans les bornes.\n",
     "2. **Variete** : `Z3Methods.Distinct(...)` sur tous les slots — *pas deux fois le meme plat*\n",
     "   (source : `Distinct` sur la grille des `PlatId`).\n",
     "3. **Linking composition** : `PlatId[m][p] != cand || Comp[slot][k] == teneur(cand, k)` — lie la\n",
@@ -961,7 +995,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Theoreme resolu en 42 ms\n",
+      "Theoreme resolu en 54 ms\n",
       "\r\n"
      ]
     },
@@ -969,56 +1003,56 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "== Menu 1 ==  energie=2596 kcal | proteines=69 g | lipides=164 g\r\n"
+      "== Menu 1 ==  energie=10571 kJ | proteines=111 g | lipides=119 g\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   creneau 1 : SAL MELANGE TENDRE             (kcal=79, prot=1, lip=0)\r\n"
+      "   creneau 1 : 'ncapriata Di Fave (Fava Bean Puree with Gre (kJ=5922, prot=58, lip=73)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   creneau 2 : ROTI DE VEAU (cuisson)         (kcal=491, prot=37, lip=13)\r\n"
+      "   creneau 2 : 10 Minute Szechuan Chicken     (kJ=1178, prot=11, lip=15)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   creneau 3 : TORSADES HALLOWEEN             (kcal=2026, prot=31, lip=151)\r\n"
+      "   creneau 3 : 1-Pot Creamy Chicken Noodle Casserole (kJ=3471, prot=42, lip=31)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "== Menu 2 ==  energie=1864 kcal | proteines=40 g | lipides=128 g\r\n"
+      "== Menu 2 ==  energie=9756 kJ | proteines=43 g | lipides=111 g\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   creneau 1 : RADIS BEURRE                   (kcal=11, prot=1, lip=0)\r\n"
+      "   creneau 1 : 4 B's Restaurant Tomato Soup   (kJ=3409, prot=16, lip=63)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   creneau 2 : SAUCISSE VEGETALE              (kcal=398, prot=16, lip=37)\r\n"
+      "   creneau 2 : (Sort-Of) Sweet and Sour Chicken (Also Good (kJ=1018, prot=3, lip=0)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   creneau 3 : RIZ CAMARGUAIS                 (kcal=1455, prot=23, lip=91)\r\n"
+      "   creneau 3 : 'sense and Sensibility' Scones (kJ=5329, prot=24, lip=48)\r\n"
      ]
     }
    ],
@@ -1074,12 +1108,12 @@
     "    Console.WriteLine(\"UNSAT : aucun plan ne satisfait les restrictions du patient sur cette pool.\");\n",
     "} else {\n",
     "    for (int m = 0; m < NbMenus; m++) {\n",
-    "        Console.WriteLine($\"== Menu {m + 1} ==  energie={sol.MenuNut[m][0]} kcal | \"\n",
+    "        Console.WriteLine($\"== Menu {m + 1} ==  energie={sol.MenuNut[m][0]} kJ | \"\n",
     "            + $\"proteines={sol.MenuNut[m][1]} g | lipides={sol.MenuNut[m][2]} g\");\n",
     "        for (int p = 0; p < NbPlats; p++) {\n",
     "            var plat = pool[sol.PlatId[m][p]];\n",
     "            Console.WriteLine($\"   creneau {p + 1} : {plat.Nom.Trim(),-30} \"\n",
-    "                + $\"(kcal={Teneur(sol.PlatId[m][p], cEnergie)}, prot={Teneur(sol.PlatId[m][p], cProt)}, lip={Teneur(sol.PlatId[m][p], cLip)})\");\n",
+    "                + $\"(kJ={Teneur(sol.PlatId[m][p], cEnergie)}, prot={Teneur(sol.PlatId[m][p], cProt)}, lip={Teneur(sol.PlatId[m][p], cLip)})\");\n",
     "        }\n",
     "    }\n",
     "}\n"
@@ -1117,14 +1151,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Menu 1 : recalc energie=2596(OK), prot=69(OK), lip=164(OK) ; coherent avec MenuNut=oui\r\n"
+      "Menu 1 : recalc energie=10571(OK), prot=111(OK), lip=119(OK) ; coherent avec MenuNut=oui\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Menu 2 : recalc energie=1864(OK), prot=40(OK), lip=128(OK) ; coherent avec MenuNut=oui\r\n"
+      "Menu 2 : recalc energie=9756(OK), prot=43(OK), lip=111(OK) ; coherent avec MenuNut=oui\r\n"
      ]
     },
     {
@@ -1237,7 +1271,7 @@
     "\n",
     "Le patient devient diabetique : imposez un **plafond energetique strict** par menu (ex. `energieMax = 1500`)\n",
     "et reconstruisez le theoreme. Observez si Z3 trouve encore un plan ou repond **UNSAT**, et expliquez\n",
-    "*pourquoi* (quel creneau porte l'essentiel des kcal ?).\n",
+    "*pourquoi* (quel creneau porte l'essentiel de l'energie kJ ?).\n",
     "\n",
     "*Indice* : recopiez le bloc de la section 3.5 en changeant `energieMax`, ou parametrez-le."
    ]
@@ -1290,7 +1324,7 @@
     "\n",
     "Portez `NbMenus` de 2 a **3** (3 jours). Adaptez la taille des tableaux du modele `PlanRepas`\n",
     "(`PlatId` `[3][3]`, `Comp` `[9][3]`, `MenuNut` `[3][3]`) et le `Distinct` (9 slots). Mesurez le temps\n",
-    "de resolution : reste-t-il de l'ordre de la seconde ? C'est un premier pas vers la **Slice D**\n",
+    "de resolution : reste-t-il de l'ordre de la seconde ? C'est un premier pas vers [09 (convergence a l'echelle)](09_Meal_Planner_Convergence_Scale.ipynb)\n",
     "(convergence a l'echelle).\n",
     "\n",
     "*Indice* : `Z3Methods.Distinct` accepte une liste d'arguments ; enumerez les 9 `PlatId[m][p]`."
@@ -1345,7 +1379,7 @@
     "(repere par nom), etendez `Comp`/`MenuNut` a 4 colonnes, et imposez un **plafond de sel** par menu.\n",
     "Le plan reste-t-il satisfiable ?\n",
     "\n",
-    "*Indice* : `diet.Constituants.FindIndex(c => c.Nom.ToLowerInvariant().Contains(\"sel chlorure\"))`."
+    "*Indice* : `constituants.Select((n,i) => (n,i)).First(x => x.n.ToLowerInvariant().Contains(\"sel chlorure\"))`."
    ]
   },
   {
@@ -1394,18 +1428,18 @@
     "## Conclusion\n",
     "\n",
     "Ce notebook a porté **fidèlement** le cœur solveur du Demo2 (`PlanificateurDeMenus.Create`) en deux\n",
-    "mouvements sur le **corpus réel** Ciqual × Recettes construit en\n",
-    "[Slice A](07_Meal_Planner_Data_External.ipynb) :\n",
+    "mouvements sur le **corpus réel** Ciqual × Recettes construit par\n",
+    "[07 (couche de donnees)](07_Meal_Planner_Data_External.ipynb) :\n",
     "\n",
     "- **Mouvement 1 — la structure prime sur l'échelle.** Le même `int[][]` modélise un plan de 7 jours sur\n",
-    "  un vrai catalogue de 138 plats ; c'est la *structure en créneaux* (et non le nombre de plats) qui fait\n",
+    "  un vrai catalogue de plusieurs centaines de plats ; c'est la *structure en créneaux* (et non le nombre de plats) qui fait\n",
     "  du problème un problème hiérarchique. Bornes de catégorie, montée en gamme et permutation totale\n",
     "  (`Distinct` cross-row, `CollectionHandling.Array`) passent **sans modification** du corpus jouet (06)\n",
     "  au réel — Z3 résout en quelques dizaines de millisecondes.\n",
     "- **Mouvement 2 — le théorème fidèle à 4 niveaux.** Patient → Menus → Plats → Denrées, avec le\n",
     "  **linking de composition** (la variable nutritionnelle liée au plat réellement choisi) et les\n",
     "  **restrictions patient Min/Max** sur la somme par menu — le chaînon nutritionnel que le squelette\n",
-    "  n'avait pas. À l'échelle complète, le linking explose (`~357 000` assertions) : on a **curé** un\n",
+    "  n'avait pas. À l'échelle complète, le linking explose (un nombre eleve d'assertions) : on a **curé** un\n",
     "  sous-ensemble (2 menus, 3 créneaux, 5 candidats, 3 constituants) pour rester résoluble en quelques\n",
     "  secondes, en préservant la *structure* du théorème.\n",
     "\n",
@@ -1413,13 +1447,13 @@
     "\n",
     "| Slice | Notebook | Apport |\n",
     "|-------|----------|--------|\n",
-    "| A | [07](07_Meal_Planner_Data_External.ipynb) | construction du corpus (`Dietetique.Load`, 0 SMT) |\n",
+    "| A | [07](07_Meal_Planner_Data_External.ipynb) | construction du corpus (cache Ciqual x Recettes, 0 SMT) |\n",
     "| **C** | **08 (ce notebook)** | **squelette structurel réel + théorème hiérarchique à restrictions patient (port fidèle)** |\n",
     "| B+D | [09](09_Meal_Planner_Convergence_Scale.ipynb) | convergence à l'échelle réelle (RecipeML × Ciqual, trois encodages comparés) |\n",
     "\n",
     "**Vers la convergence à l'échelle** : le passage du sous-ensemble curé au corpus complet fait exploser\n",
     "le **linking** — c'est le problème de *convergence à l'échelle* que la\n",
-    "[Slice D (09)](09_Meal_Planner_Convergence_Scale.ipynb) adresse, en reformulant la contrainte\n",
+    "[09 (convergence a l echelle)](09_Meal_Planner_Convergence_Scale.ipynb) adresse, en reformulant la contrainte\n",
     "nutritionnelle en **one-hot pseudo-booléen** (le seul encodage qui reste tractable là où la\n",
     "disjonction-liée naïve explose dès la construction).\n",
     "\n",


### PR DESCRIPTION
## Ce que fait cette PR

**Step 1 du deep-queue ai-01 sur CoursIA-2** (`msg-20260701T234852`) : rewire du capstone **08_Meal_Planner_Patient_Capstone** pour consommer `mealplan_cache.json` (cache solveur-usable produit par 07) au lieu du legacy `dietetique.json` (pipeline « 05c » mort, cassé sur machine fraîche).

### Décision de design (Option A, justifiée)

ai-01 laissait le choix entre **5 constituants (cache, simple)** et **74 (fidélité Demo2, sous-routine Ciqual)**. **J'ai pris Option A** (cache 5 constituants) :

- **DRY** : source de données unique pour tout le bloc 06→07→08→09 (09 consomme déjà ce cache, post-#4817).
- **Cœur du capstone préservé** : théorème hiérarchique Patient→Menus→Plats + linking `PlatId != candidat || Comp == teneur` + restrictions patient Min/Max. Le niveau Dénrées (linking détail-par-ingrédient) est déposé dans 07 qui fait le rapprochement lexical Ciqual.
- Les deux étaient acceptables (per ai-01) ; A évite de dupliquer la sous-routine Ciqual déjà dans 07.

### Adaptations (grounded firsthand du cache réel)

Le cache a une structure **différente** du dietetique (G.1 par exec, pas supposition) :
- `recipes[].{title, cats, vec[5]}` (RecipeML anglo-saxon) — **pas de champ `Ordre`** (créneaux cantine).
- 5 constituants : [0] Energie kJ/100g, [1] Protéines, [2] Glucides, [3] Lipides, [4] Sel.

→ **Dérivation heuristique de l'Ordre** (créneau 1..5) depuis les cats RecipeML. Distribution vérifiée : 1→67, 2→77, 3→238, 4→9, 5→352 (tous ≥5 candidats). 319 recettes non-catégorisées (`cats=['None']`) écartées (pas de fabrication).
→ **Indices constituants directs** [0,1,3] (Energie kJ, Protéines, Lipides).
→ **Bornes patient rescaleées kcal→kJ** (×4,184) : le cache est en kJ/100g, les bornes hardcoded (800-2600 kcal) donnaient UNSAT.
→ Purge du vocabulaire Slice A/C/D, 05c, dietetique, « 138 plats », « 74 constituants ».

### Preuve C.2 (ré-exec .NET réelle)

nbconvert kernel **.net-csharp** (PAS MCP jupyter, hang #835), 14 cellules code :
- **0 erreur**, `exec_counts` [1..14] séquentiel
- Cell 8 (montée en gamme) : résolue en 64 ms, plan 7 jours valide
- Cell 20 (théorème patient) : **SAT** en 54 ms — `Menu 1: energie=10571 kJ | prot=111 g | lip=119 g` (dans les bornes [3347, 10878] kJ)
- Cell 22 : vérification restrictions patient OK
- 0 leak « kcal » dans les outputs

### Note infra (DLL stale)

Le re-exec a révélé que le `.deploy/` partagé (built Jun 14 depuis submodule `8e37aed`) était **stale** : la cellule 8 (théorème à closure imbriquée) hit un `DisplayClass` mismatch. Rebuild des DLLs depuis le submodule actuel (`6a6c4aa` = PR #16 *fix/visitor-chained-member-access*) résout le bug. Les DLLs ne sont pas committées (build artifacts dans le submodule).

## Périmètre

- 1 fichier, 1 sujet atomique (rewire loader + adaptation capstone).
- `See #4677` (l'EPIC continue — 08 n'est pas le dernier item).
- Catalogue byte-identique à main, base fraîche (`origin/main` ≥ 9ca62e90c).
