### PR TITLE
fix(vibe-coding): restore accents in Vibe-Coding README (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -118,7 +118,7 @@ Le répertoire `docs/` contient :
 | Document | Description |
 |----------|-------------|
 | [INTRO-GENAI.md](docs/INTRO-GENAI.md) | Introduction pratique a l'IA générative |
-| [Claude-Code/docs/](Claude-Code/docs/) | Documentation Claude Code (installation, concepts, aide-memoire) |
+| [Claude-Code/docs/](Claude-Code/docs/) | Documentation Claude Code (installation, concepts, aide-mémoire) |
 | [Roo-Code/docs/](Roo-Code/docs/) | Documentation Roo Code (installation, guide) |
 | [activites/](docs/activites/) | Activités pédagogiques |
 | [sessions/](docs/sessions/) | Sessions de formation |
@@ -148,7 +148,7 @@ Le répertoire `docs/` contient :
 A l'issue de cette série, vous serez capable de :
 
 1. **Décrire** un projet en langage naturel et obtenir du code fonctionnel via l'IA
-2. **Orchestrer** des workflows multi-agents (recherche, planification, execution)
+2. **Orchestrer** des workflows multi-agents (recherche, planification, exécution)
 3. **Automatiser** les tâches courantes du développeur (tests, documentation, déploiement)
 4. **Configurer** des agents autonomes conteneurisés (Claw Systems)
 


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg `lygoyu`) : accents #2876 résiduels GenAI/Vibe-Coding. Tranche = `Vibe-Coding/README.md` (247 L, index de la série Vibe-Coding — dette ciblée dans la table d'index et la liste de capabilities).

## Méthode

**Masked-dictionary** (leçon #4502, durcie OPENROUTER) :
1. Mask fenced code (6 blocs `\`\`\`bash`/`powershell`) / inline code / bare URLs / **full markdown links `[label](target)`**.
2. Dictionnaire accent word-internal (46 entrées, case-aware, longest-first). **Headings accentués** (aucune ref d'ancre cross-file ni TOC interne, vérifié `git grep`).
3. Restore. 4-gate validation + protected strings + eyeball diff.

## Eyeball = aucune corruption

Eyeball diff complet — 2 corrections sémantiquement correctes :
- `aide-memoire` → `aide-mémoire` (nom composé canonique, ligne 121 dans la table d'index).
- `execution` → `exécution` (nom dans liste de capabilities « recherche, planification, exécution »).

**8 hits du pré-sondage = commentaires shell dans des blocs de code** (`# Verifier Node.js`, `# doit etre`, `# si necessaire`, etc., lignes 83/162/168/171/173/197/198/213). **Préservés intentionnellement** par le masquage fence — code blocks = conventionnellement non-accentués, intact selon G4.

## Choix conservateurs

- **Standalone `a` EXCLU** : « Introduction pratique **a** l'IA générative » (ligne 119) — ambigu prep/avoir, laissé tel quel. Cohérent avec les batchs précédents.
- **Termes anglais légitimes gardés EN** : `OpenRouter`, `VS Code`, `RAG`, `Qdrant`, `Claude Code`, `Roo Code`, `Node.js`, `PowerShell`, `PATH`, `npm`.

## Validation (4 gates + protected strings, tous PASS)

- **GATE 1** : `deaccent(old)==deaccent(new)` NFD → **PASS**, delta **0 octet**.
- **GATE 3** : markdown-link targets + bare URLs → **byte-identical** (refs `Claude-Code/docs/`, `Roo-Code/docs/`, `docs/activites/`, `docs/sessions/`, `INTRO-GENAI.md` préservées).
- **GATE 4** : 12 triple-backtick occurrences (6 fences), 94 total backticks → counts **identiques**.
- **Protected strings** unchanged : env vars (`ANTHROPIC_BASE_URL`), noms de produits (`OpenRouter`/`VS Code`/`Claude-Code`/`Roo-Code`/`Claudish`/`Claw-Systems`/`Qdrant`).

## Non-scope

`a` prépositionnel standalone (5 occurrences dans commentaires shell), participes passés (`utilise`/`installe`/etc.), commentaires shell français (par convention code = intact). Reste Vibe-Coding (Claudish/Claw-Systems docs, notebooks Vibe-Coding) = tranches ultérieures.

See #2876