### PR TITLE
fix(symbolicai): OR-tools-Stiegler H2 heading-hierarchy — drop Étape N hint-prefix (#3968)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
@@ -54,7 +54,7 @@
    "id": "e0e061ba",
    "cell_type": "markdown",
    "source": [
-    "## Étape 1 : Configuration de l'environnement C#\n",
+    "## Configuration de l'environnement C#\n",
     "\n",
     "Nous commençons par importer les bibliothèques .NET nécessaires pour manipuler les données et créer des visualisations. Ces bibliothèques nous permettront de :\n",
     "\n",
@@ -86,7 +86,7 @@
    "id": "0471905e",
    "cell_type": "markdown",
    "source": [
-    "## Étape 2 : Installation de la bibliothèque OR-Tools\n",
+    "## Installation de la bibliothèque OR-Tools\n",
     "\n",
     "Google OR-Tools est disponible via NuGet, le gestionnaire de packages .NET. L'installation charge automatiquement :\n",
     "\n",
@@ -102,7 +102,7 @@
    "id": "4165f7f7",
    "cell_type": "markdown",
    "source": [
-    "## Étape 3 : Comprendre les données du problème\n",
+    "## Comprendre les données du problème\n",
     "\n",
     "Avant de modéliser le problème, il est essentiel de comprendre la structure des données.\n",
     "\n",
@@ -176,7 +176,7 @@
    "id": "ecc17726",
    "cell_type": "markdown",
    "source": [
-    "## Étape 4 : Importer le solveur de programmation linéaire\n",
+    "## Importer le solveur de programmation linéaire\n",
     "\n",
     "Nous importons maintenant le namespace `Google.OrTools.LinearSolver` qui contient les classes nécessaires pour :\n",
     "\n",
@@ -210,7 +210,7 @@
     "| Niacine                          | 18 milligrammes                     |\n",
     "| Acide ascorbique (vitamine C)    | 75 milligrammes                     |\n",
     "\n",
-    "### Liste\n",
+    "### Liste des marchandises (corpus de Stigler 1939)\n",
     "\n",
     "| Marchandises                 | Unité           | Prix 1939 (cents) | Calories (kcal) | Protéines (g) | Calcium (g) | Fer (mg) | Vitamine A (KIU) | Thiamine (mg) | Riboflavine (mg) | Niacine (mg) | Acide ascorbique (mg) |\n",
     "|------------------------------|-----------------|-------------------|------------------|---------------|-------------|----------|------------------|---------------|------------------|--------------|----------------------|\n",
@@ -298,7 +298,7 @@
    "id": "cb4cdab0",
    "cell_type": "markdown",
    "source": [
-    "## Étape 5 : Chargement des données en mémoire\n",
+    "## Chargement des données en mémoire\n",
     "\n",
     "Nous définissons maintenant deux structures de données :\n",
     "\n",
@@ -329,7 +329,7 @@
    "id": "dc6a25f5",
    "cell_type": "markdown",
    "source": [
-    "## Étape 6 : Création du solveur de programmation linéaire\n",
+    "## Création du solveur de programmation linéaire\n",
     "\n",
     "Nous créons maintenant une instance du solveur GLOP (Google Linear Optimization Package).\n",
     "\n",
@@ -415,7 +415,7 @@
    "id": "9f878ebe",
    "cell_type": "markdown",
    "source": [
-    "## Étape 7 : Définition des variables de décision\n",
+    "## Définition des variables de décision\n",
     "\n",
     "Nous créons maintenant une **variable de décision** pour chaque aliment. Chaque variable $x_i$ représente la quantité à acheter de l'aliment $i$ par jour.\n",
     "\n",
@@ -459,7 +459,7 @@
    "id": "1ef4f606",
    "cell_type": "markdown",
    "source": [
-    "## Étape 8 : Définition des contraintes et de la fonction objectif\n",
+    "## Définition des contraintes et de la fonction objectif\n",
     "\n",
     "Cette étape cruciale consiste à traduire le problème en équations mathématiques.\n",
     "\n",
@@ -640,7 +640,7 @@
    "id": "be9bbcf3",
    "cell_type": "markdown",
    "source": [
-    "## Étape 9 : Résolution du problème et analyse des résultats\n",
+    "## Résolution du problème et analyse des résultats\n",
     "\n",
     "Nous lançons maintenant le solveur pour trouver la solution optimale. Le code effectue trois opérations :\n",
     "\n",


### PR DESCRIPTION
## Scope

Tranche #3968 (hiérarchie typographique) sur SymbolicAI/OR-tools-Stiegler.ipynb (.NET C#, SymbolicAI non-Lean).

Le scanner scan_md_hierarchy.py flaguait ce notebook avec 9 headings HINT-AS-HEADING ("Étape N" comme titre H2) + 1 heading tronqué.

## Changements (10 lignes, markdown-only)

- 9x : "## Étape N : titre" -> "## titre" (drop du préfixe procédural)
- 1x : "### Liste" (tronqué) -> "### Liste des marchandises (corpus de Stigler 1939)"

**Pourquoi drop du préfixe plutôt que démotion de niveau** : les "## Étape N" ont des sous-sections "###" (ex. "Structure du problème", "Analyse des contraintes"). Rétrograder "Étape" en H3/H4 aurait orpheliné ces enfants (hiérarchie inversée). Drop du préfixe "Étape N :" conserve le niveau H2 -> les enfants "###" restent correctement nichés, et le keyword hint disparaît du scan. L ordre des étapes reste lisible par séquence des cellules (top-to-bottom), comme les autres tutoriels Search/SymbolicAI.

## Preuves

- scan_md_hierarchy.py : 1 flagged -> 0 flagged
- git diff --stat : 10 insertions / 10 deletions (texte de heading uniquement)
- Markdown-only : aucun execution_count / outputs / code cell touché -> exception C.2 (pas de re-exécution)
- JSON valide (json.load OK)

## Anti-régression

- Aucune cellule code / preuve / stub touchée.
- Aucun "# Solution" / "# Exemple résolu" supprimé.
- Pas de relabel Exercice<->Exemple, pas de texte d exercice modifié.

See #3968 (part of EPIC #3966).

PRs en attente de merge par ai-01 : #4811 (ML-9), #4824 (Infer-19), #4825 (MGS bump).
