### PR TITLE
fix(vibe-coding): restore accents in INSTALLATION + OPENROUTER_SETUP residual (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
@@ -209,7 +209,7 @@ Claude Code charge les configurations dans cet ordre (la dernière ecrase les pr
 
 ### Étape 3 : Configuration via Variables d'Environnement (Alternative)
 
-Si vous preferez utiliser les variables d'environnement, cette méthode fonctionne egalement. **Choisissez l'une ou l'autre méthode, pas les deux a la fois.**
+Si vous préférez utiliser les variables d'environnement, cette méthode fonctionne également. **Choisissez l'une ou l'autre méthode, pas les deux a la fois.**
 
 #### Windows (PowerShell)
 
@@ -262,7 +262,7 @@ Sauvegardez et rechargez :
 - **`~/.bashrc`** : Shells bash interactifs. Uniquement si vous utilisez bash (`chsh -s /bin/bash`).
 - **`~/.bash_profile`** : Shells bash de connexion. Même remarque que `.zprofile` pour bash.
 
-> **Conseil :** Si vous avez déjà un `~/.zprofile` mais pas de `~/.zshrc`, le plus simple est de créer `~/.zshrc` ou d'ajouter les exports dans votre `~/.zprofile` existant. Les deux fonctionnent depuis Terminal.app. Si vous utilisez aussi le terminal integre de VSCode, preferez `~/.zshrc`.
+> **Conseil :** Si vous avez déjà un `~/.zprofile` mais pas de `~/.zshrc`, le plus simple est de créer `~/.zshrc` ou d'ajouter les exports dans votre `~/.zprofile` existant. Les deux fonctionnent depuis Terminal.app. Si vous utilisez aussi le terminal integre de VSCode, préférez `~/.zshrc`.
 
 Pour verifier quel shell vous utilisez :
 
@@ -393,7 +393,7 @@ Qwen 3.6 Plus est le modèle flagship de la famille Qwen 3.6 (Alibaba, avril 202
 
 - **Context window** : 262K tokens
 - **Forces** : Raisonnement avance, programmation complexe, taches agentiques multi-étapes
-- **Cas d'usage ideaux** : Refactoring complexe, architecture de projets, documentation technique
+- **Cas d'usage idéaux** : Refactoring complexe, architecture de projets, documentation technique
 - **Prix** : voir [openrouter.ai/qwen/qwen3.6-plus](https://openrouter.ai/qwen/qwen3.6-plus)
 
 #### MiniMax M2.7 (Alias Sonnet)
@@ -404,7 +404,7 @@ Modèle de dernière génération optimise pour la productivite et le coding :
 
 - **Context window** : 205K tokens
 - **Forces** : Coding agentique, workflows autonomes, amelioration continue, excellent sur benchmarks coding
-- **Cas d'usage ideaux** : Developpement quotidien, debug, génération de tests, refactoring
+- **Cas d'usage idéaux** : Developpement quotidien, debug, génération de tests, refactoring
 - **Prix** : $0.30 / $1.20 per million tokens (input/output)
 
 #### Qwen 3.6 35B-A3B (Alias Haiku)
@@ -413,10 +413,10 @@ Modèle de dernière génération optimise pour la productivite et le coding :
 
 Modèle dense compact et rapide :
 
-- **Taille** : 27B parametres (dense)
+- **Taille** : 27B paramètres (dense)
 - **Context window** : 262K tokens
 - **Forces** : Rapidite, bon rapport qualite/coût, coding solide pour sa taille
-- **Cas d'usage ideaux** : Exploration rapide, questions simples, taches repetitives, prototypage
+- **Cas d'usage idéaux** : Exploration rapide, questions simples, taches repetitives, prototypage
 - **Prix** : $0.20 / $1.56 per million tokens (input/output)
 
 ### Comparaison avec les Modèles Claude Natifs
@@ -454,13 +454,13 @@ Vous pouvez assigner des modèles différents aux subagents :
 
 ## Configuration de l'Extension VS Code
 
-### Parametres Recommandes
+### Paramètres Recommandes
 
-1. Ouvrez les parametres : `Cmd+,` / `Ctrl+,`
+1. Ouvrez les paramètres : `Cmd+,` / `Ctrl+,`
 1. Allez dans **Extensions > Claude Code**
 1. Configurez :
 
-| Parametre | Valeur Recommandée | Description |
+| Paramètre | Valeur Recommandée | Description |
 | ------------------------- | ------------------ | ------------------------------------ |
 | **Disable Login Prompt** | Active | Évite la connexion Anthropic |
 | **Initial Permission Mode** | `default` | Demande avant chaque action |
@@ -616,9 +616,9 @@ Vous devriez voir le serveur `qc-mcp` avec le statut "Connected" et environ 60 o
 > Analyse les resultats du dernier backtest : Sharpe, CAGR, Max Drawdown
 ```
 
-**Resolution de problemes :**
+**Resolution de problèmes :**
 
-| Probleme | Solution |
+| Problème | Solution |
 | ---------- | ---------- |
 | "Docker not found" | Installez Docker Desktop et redémarrez votre terminal |
 | "Authentication failed" | Verifiez vos identifiants dans `.mcp.json` |
@@ -719,9 +719,9 @@ Puis dans Claude :
 
 Claude générera automatiquement un fichier `CLAUDE.md` adapte a votre projet.
 
-## Resolution de Problemes
+## Resolution de Problèmes
 
-### Probleme : "Command not found: claude"
+### Problème : "Command not found: claude"
 
 **Solution :**
 
@@ -729,7 +729,7 @@ Claude générera automatiquement un fichier `CLAUDE.md` adapte a votre projet.
 - Ajoutez au PATH si nécessaire
 - Redémarrez votre terminal
 
-### Probleme : "Authentication failed" avec OpenRouter
+### Problème : "Authentication failed" avec OpenRouter
 
 **Solution :**
 
@@ -745,25 +745,25 @@ Verifiez votre clé API sur [openrouter.ai/settings/keys](https://openrouter.ai/
 
 Sur macOS, verifiez que les exports sont dans le bon fichier de profil (voir Étape 3).
 
-### Probleme : Extension VS Code ne se connecte pas
+### Problème : Extension VS Code ne se connecte pas
 
 **Solution :**
 
-1. Activez **"Disable Login Prompt"** dans les parametres
+1. Activez **"Disable Login Prompt"** dans les paramètres
 1. Redémarrez VS Code **complètement** (pas juste recharger la fenetre)
 1. Verifiez les logs : `Cmd+Shift+P` > "Developer: Show Logs"
 
-### Probleme : "Model not found"
+### Problème : "Model not found"
 
 Verifiez que l'identifiant du modèle est correct sur [OpenRouter Models](https://openrouter.ai/models).
 
-### Probleme : "Rate limit exceeded"
+### Problème : "Rate limit exceeded"
 
 1. Attendez quelques secondes et reessayez
 1. Verifiez vos credits sur [OpenRouter Activity](https://openrouter.ai/activity)
 1. Considerez un plan payant pour des limites plus élevées
 
-### Probleme : Le modèle ne repond pas comme attendu
+### Problème : Le modèle ne repond pas comme attendu
 
 Certains modèles alternatifs ont des comportements différents. Ajustez vos prompts :
 
@@ -775,7 +775,7 @@ claude -p "Reponds UNIQUEMENT avec du code Python, sans explication"
 claude -p "En tant qu'expert Python, analyse ce code : ..."
 ```
 
-### Probleme : MCP server ne repond pas (Windows)
+### Problème : MCP server ne repond pas (Windows)
 
 Pour les serveurs locaux `npx` sur Windows, utilisez le wrapper `cmd /c` :
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
@@ -144,7 +144,7 @@ Contenu (remplacez `sk-or-v1-VOTRE_CLE` par votre vraie clé) :
 
 ### Alternative : variables d'environnement PowerShell (Windows)
 
-Si vous preferez les variables d'environnement, ouvrez votre profil :
+Si vous préférez les variables d'environnement, ouvrez votre profil :
 
 ```powershell
 notepad $PROFILE


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg `lygoyu`) : accents #2876 résiduels Vibe-Coding/Claude-Code/docs/. Tranche = **INSTALLATION-CLAUDE-CODE.md** (644L, 21 corrections) + **OPENROUTER_SETUP.md** (restant post-#4820, 1 correction). Fichiers déjà partiellement touchés (#4810 INSTALLATION, #4820 OPENROUTER) mais résiduels subsistaient.

## Méthode

**Masked-dictionary** (leçon #4502, durcie avec restore order outer-first : urls → inlines → fences → escaped).
1. Mask escaped fences / fenced code / inline code / bare URLs / full markdown links.
2. Dictionnaire 31 entrées (case-aware, longest-first). **Conservateur strict** : uniquement noms/adjectifs/infinitifs — **PAS de 3sg présent, PAS de pp ambigu** (incident cycle précédent : `Configure`/`genere`/`modifie` actifs corrompus en pp).
3. Restore dans l'ordre inverse du masking depth (urls → inlines → fences → escaped).
4. 4-gate validation + eyeball diff complet.

## Eyeball = 22 corrections toutes grammaticalement valides

| Mot | Ligne(s) | Avant | Après | Type |
|-----|----------|-------|-------|------|
| `preferez` | INSTALLATION L209, L262 | preferez | préférez | 2pl impératif |
| `preferez` | OPENROUTER L147 | preferez | préférez | 2pl impératif |
| `egalement` | INSTALLATION L209 | egalement | également | adverbe |
| `ideaux` | INSTALLATION L395, L407, L416 | ideaux | idéaux | adj pl |
| `parametres/Parametre/parametre` | INSTALLATION L416, L457, L459, L463 | parametres | paramètres | nom |
| `probleme/Probleme/problemes` | INSTALLATION L619, L621, L630, L640, L729, L742, L745, L748, L758, L772, L775 | probleme | problème | nom |
| `Parametres` | INSTALLATION L457 (heading) | Parametres | Paramètres | heading capital |

Toutes les corrections = **noms/adjectifs/adverbes canoniques**. Aucun verbe fléchi touché (3sg présent et pp EXCLUS par principe).

## Choix conservateurs

- **`Methode` / `recommandee` / `Etape` / `parametres` (lignes dans fences)** : tous situés **dans des blocs de code** (lignes 320-329 OPENROUTER pour `parametres`/`Etape`, ligne 337-341 pour `Preferez/Methode/recommandee/Etape`, ligne 287-301 INSTALLATION pour `modeles`/`parametres`) → **préservés par masquage fence** selon convention (code = intact).
- **`Active` (3sg ou pp?)** : multiples occurrences dans tables de configuration (`Disable Login Prompt` | Active). **3sg présent = ambigu**, EXCLU du dict. Source conservée telle quelle.
- **Termes anglais/produits gardés EN** : `VS Code`, `Cmd+Shift+P`, `OpenRouter`, `claude-cli`, `MiniMax M2.7` (claude alias), `Qwen 3.6`, `qwen/qwen3.6-plus`.

## Validation (4 gates + protected strings, tous PASS)

| Fichier | G1 NFD | G2 fences intactes | G2 urls byte-identical | G4 byte-delta | G4 pas de placeholder | G3 seul |
|---------|--------|---------------------|------------------------|---------------|----------------------|---------|
| INSTALLATION-CLAUDE-CODE | ✓ | ✓ (65 fences preserved) | ✓ | +21/-21 (= +N added UTF-8 bytes for é) | ✓ | ✓ |
| OPENROUTER_SETUP | ✓ | ✓ | ✓ | +1/-1 | ✓ | ✓ |

G1 = `deaccent(old)==deaccent(new)` NFD+Mn → **PASS**.
G2 fences preserved byte-identical (regex `\x60{3}.*?\x60{3}` DOTALL). G2 urls préserver.
Real-inline-count (short, single-line) = **73 unchanged** sur INSTALLATION (gate `\`[^\`\n]{1,80}\`` identique sets).
G4 = aucune fuite placeholder dans le fichier final.

## Non-scope

- **Verbes 3sg/pp** : `Active`, `repond`, `configure`, `Utilise`, `connecte`, `applique` (multiples) — **EXCLUS** par leçon #4502 strict (ambigu 3sg/pp sans contexte vérifié). Batch de suivi séparé si contexte grammatical univoque est trouvé.
- **`Methode`/`recommandee`/`redemarrage`** (dans fences) : code = EN/canonical par convention.

See #2876