### PR TITLE
fix(qc): restore French accents in CSharp-CTG-Momentum README (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/README.md
@@ -1,12 +1,12 @@
 # CTG Momentum (C#) (ID: 19225388)
 
-Strategie momentum avec indicateurs custom avances en C#.
+Stratégie momentum avec indicateurs custom avancés en C#.
 
 ## Performance (post-bugfix SMA200)
 
-- **Periode**: 2021-01-01 → Now
+- **Période**: 2021-01-01 → Now
 - **Sharpe**: 0.507
-- **Recommandation recherche**: Etendre a 2015-01-01 (Sharpe attendu: 1.05)
+- **Recommandation recherche**: Étendre a 2015-01-01 (Sharpe attendu: 1.05)
 
 ## Fichiers
 
@@ -14,23 +14,23 @@ Strategie momentum avec indicateurs custom avances en C#.
 
 - `Main.cs` - StocksOnTheMoveAlgorithm, OEF ETF universe
 - `CustomMomentumIndicator.cs` - Indicateur composite (slope + MA + gap + ATR)
-- `AnnualizedExponentialSlopeIndicator.cs` - Regression exponentielle annualisee
-- `GapIndicator.cs` - Detection de gaps
-- `MarketRegimeFilter.cs` - Filtre regime SPY > SMA200
+- `AnnualizedExponentialSlopeIndicator.cs` - Régression exponentielle annualisée
+- `GapIndicator.cs` - Détection de gaps
+- `MarketRegimeFilter.cs` - Filtre régime SPY > SMA200
 
 ### Recherche
 
 - `RESEARCH_SUMMARY.md` - Analyse robustesse 2015-2025 (Feb 2026)
-- `research_robustness_simple.py` - Script Python backtest etendu
-- `research_robustness_charts.png` - Visualisations regime filter + walk-forward
+- `research_robustness_simple.py` - Script Python backtest étendu
+- `research_robustness_charts.png` - Visualisations régime filter + walk-forward
 - `research_results.txt` - Output complet backtest
 - `research_robustness.ipynb` - Notebook Jupyter (QuantBook, non execute)
 
 ## Concepts enseignes
 
 - Custom indicators en C# (WindowIndicator, TradeBarIndicator)
-- MathNet.Numerics (regression lineaire, R-squared)
-- Market regime filtering (SMA 200)
+- MathNet.Numerics (régression linéaire, R-squared)
+- Market régime filtering (SMA 200)
 - ATR-based position sizing
 - Walk-forward validation
 - Robustness testing sur 10+ ans
@@ -41,9 +41,9 @@ Strategie momentum avec indicateurs custom avances en C#.
 **Impact**: ~95% Risk-ON (trop agressif) → 76.8% Risk-ON (optimal)
 **Status**: Corrige, a valider par backtest cloud
 
-## Prochaines Etapes
+## Prochaines Étapes
 
 1. Modifier `Main.cs`: `SetStartDate(2015, 1, 1)`
 2. Compiler via QC cloud
 3. Lancer backtest via web UI
-4. Valider Sharpe >= 0.4 sur periode etendue
+4. Valider Sharpe >= 0.4 sur période étendue


### PR DESCRIPTION
## Summary

Restore French diacritics in `MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/README.md` (16 corrections across 12 lines). Part of issue #2876.

## Methodology

Round-trip guard (po-2025 PR #4500): each replacement verifies `strip_accents(accented) == bare`. We only **add** diacritics; we never change a letter.

Skipped (preserved verbatim):
- Code blocks (none in this file)
- Inline code (none)
- Markdown link targets (none)
- URLs (none)
- CATALOG-STATUS markers (none in this file)
- Identifiers class names (`AnnualizedExponentialSlopeIndicator.cs`, `MarketRegimeFilter.cs`, `R-squared` -- kept as-is, English technical terms)
- Numeric/measurement expressions (`10+ ans`, `~95%`, `(Feb 2026)`)

## Corrections applied

| Bare | Accented | Count |
|------|----------|-------|
| Strategie | Stratégie | 1 |
| avances (indicators) | avancés | 1 |
| Periode | Période | 1 |
| Etendre | Étendre | 1 |
| Regression | Régression | 1 |
| regression | régression | 1 |
| annualisee | annualisée | 1 |
| Detection | Détection | 1 |
| regime | régime | 3 |
| etendu | étendu | 1 |
| lineaire | linéaire | 1 |
| Etapes | Étapes | 1 |
| periode (lower) | période | 1 |
| etendue | étendue | 1 |

Total: 16 replacements.

## Bug caught during development

Initial run had a typo: `regime` → `règime` (è grave instead of é aigu) — `régime` takes the acute accent. Caught by manual line-by-line verification, restored via `git checkout`, fixed the script (and a separate case-preservation bug for `periode` → `Période` mid-sentence), re-ran clean. Round-trip guard only catches letter-equivalence, not which accent type — manual review is mandatory.

## Scope

- **1 file modified** (atomic)
- **12 lines changed** (+/-)
- **0 code, 0 catalog markers, 0 GenAI** touched
- LF line endings preserved
- No content/structure changes - only accent insertion

## Verification

- Round-trip guard: 17 forms verified (`strip_accents(accented).lower() == bare.lower()`)
- Manual review: each line context checked for false-positive jargon (no `R-squared`, no class-name fragments like `MarketRegimeFilter.cs` — those are NOT accented)
- Line endings: LF (git diff displays clean)
- No URL / link target touched (file has none)

## Context

This is a 2nd slice of #2876 in the same worker session as #4844 (Alpha-Correlation-Analysis), keeping the cadence going after the merge. Choosing CSharp-CTG-Momentum because:
1. Small scope (50 lines), pedagogically clear
2. Mixes 16 corrections on distinct words - demonstrates the round-trip guard works on heterogeneous forms
3. QC family - consistent with my prior slice, focused lane
4. No CATALOG-STATUS markers to preserve
5. No English technical terms to skip (just `R-squared` once and class names in backticks that aren't accented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
