### PR TITLE
fix(docs): restore FR diacritics in MyIA.AI.Notebooks hub README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -39,23 +39,23 @@ Dernière mise à jour : 2026-06-11
 
 **[IIT](IIT/README.md)** — La plus spéculative : la théorie de l'information intégrée et la mesure Phi (PyPhi) appliquées à des réseaux logiques — où l'on calcule, littéralement, des candidats quantitatifs à une mesure de la conscience. La série prolonge le Phi *statique* vers les **trajectoires** causales avec l'extension **ICT** (*Integrated Causal Trajectories*) : tri auto-organisé comme morphogenèse, émergence causale multi-échelles (Hoel, *Causal Emergence 2.0*). Elle rejoint ainsi le fil rouge **causalité** du dépôt, où le même opérateur `do(·)` de Pearl s'instancie à travers quatre paradigmes — symbolique (Tweety), message passing (Infer.NET), MCMC (PyMC) et théorie de l'information (ICT).
 
-### Progression pedagogique
+### Progression pédagogique
 
 ```text
 GenAI
 ├── 00-GenAI-Environment/ - Setup Docker, GPU, services
-├── Image/ - Generation d'images (SDXL, Qwen, Flux)
+├── Image/ - Génération d'images (SDXL, Qwen, Flux)
 ├── Audio/ - STT, TTS, music, pipeline audiobook FishAudio S2-Pro
-├── Video/ - Generation video, animation
+├── Video/ - Génération vidéo, animation
 ├── Texte/ - LLMs, RAG, reasoning
 ├── SemanticKernel/ - SDK Microsoft
 ├── FineTuning/ - Fine-tuning LoRA, adapters
-├── CaseStudies/ - Etudes de cas etudiants
+├── CaseStudies/ - Études de cas étudiants
 └── Vibe-Coding/ - Claude-Code + Roo-Code
 
 QuantConnect
-├── Python/ - Cours progressifs QC-Py (fondamentaux → strategies)
-├── projects/ - Strategies backtestees et ML (GARCH, Kelly, ensemble)
+├── Python/ - Cours progressifs QC-Py (fondamentaux → stratégies)
+├── projects/ - Stratégies backtestées et ML (GARCH, Kelly, ensemble)
 └── ML-Training-Pipeline/ - Pipeline training thermal-safe
 
 SymbolicAI
@@ -79,22 +79,22 @@ SymbolicAI
 
 ### QuantConnect / Finance
 - **LEAN Engine**: Backtesting, live trading, optimisation
-- **sklearn / XGBoost / PyTorch**: Modeles ML financiers
+- **sklearn / XGBoost / PyTorch**: Modèles ML financiers
 - **QuantConnect Cloud**: 95 projets, backtests cloud
-- **Hands-On AI Trading**: 18/19 exemples du livre implementes
+- **Hands-On AI Trading**: 18/19 exemples du livre implémentés
 
 ### Infrastructure
 - **Docker**: ComfyUI (29GB VRAM), services GenAI
 - **MCP**: Jupyter automation, QuantConnect MCP server
-- **Papermill**: Execution batch
+- **Papermill**: Exécution batch
 
-### Domaines d'etude
+### Domaines d'étude
 - **Computer Vision**: Image, Video, Animation
 - **NLP**: LLMs, RAG, Reasoning, Sentiment
 - **Audio**: STT, TTS, Voice Cloning, Music
 - **Finance**: Trading algorithmique, ML financier, options
 - **Symbolic**: RDF, Z3 SMT, Lean 4, SmartContracts
-- **Optimization**: CSP, metaheuristiques, recherche operationnelle
+- **Optimization**: CSP, metaheuristiques, recherche opérationnelle
 
 ## Configuration requise
 


### PR DESCRIPTION
## Summary

Single-file atomic PR restoring French diacritics in the **hub README** of MyIA.AI.Notebooks/ (root README for the entire pedagogical notebook tree).

11 single-word accent restorations across 3 sections:
- **Progression pédagogique** (was: pedagogique) — section heading
- **GenAI/QuantConnect tree descriptions** (Generation→Génération, video→vidéo, Etudes→Études, etudiants→étudiants, strategies→stratégies, Strategies→Stratégies, backtestees→backtestées)
- **Technologies / Domaines d'étude lists** (Modeles→Modèles, implementes→implémentés, Execution→Exécution, etude→étude, operationnelle→opérationnelle)

## Diff stats

```
 MyIA.AI.Notebooks/README.md | 22 +++++++++++-----------
 1 file changed, 11 insertions(+), 11 deletions(-)
```

11 insertions / 11 deletions — pure diacritic pass, **zero content change**.

## Out of scope (deliberate)

- COURSE_CATALOG.generated.json / .md — belong to automation (catalog-pr-hygiene rule 1, #2632). Not touched.
- CATALOG-STATUS blocks — generated. Not touched.
- ASCII directory names (_pending_execution/, projects/_archive/, archive-2025/) — must stay ASCII (filesystem paths).
- Code blocks (CLI commands, Jupyter cell examples) — convention code = FR/EN sans accent, kept ASCII per CLAUDE.md §E.
- Python / C# / Lean source files — anti-règle explicite §E.

## Verification

```bash
grep -nE '(pedagogique|strategies|Strateg|Generation|video|Etudes|etudiants|Modeles|implementes|Execution|etude|operationnelle)' MyIA.AI.Notebooks/README.md
# → 0 results
```

## Anti-regression

- 0 source files touched (no Python, no C#, no Lean)
- 0 catalog artefacts regenerated
- 0 cell outputs scrubbed
- Atomic 1-file scope (G.4 composite rule respected, well under 3000-line threshold)

## Partial close of #2876

Issue #2876 lists this file in the **échantillon affecté** section: MyIA.AI.Notebooks/README.md — 5 occurrences. Actual count was 11 (heading + tree + bullet lists); all resolved here.

Tracking other orphan files from #2876 top-10 not yet covered: Search/README.md, QuantConnect/README.md, SymbolicAI/Tweety/README.md, GenAI/PostTraining/README.md. Separate PRs queued for those if/when picked up.

## See also

- #2876 — accents manquants dans les READMEs francophones
- .claude/rules/catalog-pr-hygiene.md — catalogue = propriété de l'automatisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)