### PR TITLE
fix(vibe-coding): restore accent preferences in INSTALLATION-ROO.md (#2876 residual3)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Roo-Code/docs/INSTALLATION-ROO.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Roo-Code/docs/INSTALLATION-ROO.md
@@ -141,7 +141,7 @@ Faire instruire une tâche pour valider le fonctionnement des différents outils
 
 ## Étape 11 : Configurer les Custom Instructions
 
-Les Custom Instructions permettent de personnaliser le comportement de Roo selon vos projets et preferences.
+Les Custom Instructions permettent de personnaliser le comportement de Roo selon vos projets et préférences.
 
 ### Configuration rapide projet
 


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg lygoyu, **tranche 3**) : accents #2876 résiduels Vibe-Coding. Tranche = **1 fichier / 1 hit**.

## Méthode

Re-probe **body text seul** (172 .md scannés, 23 fichiers déjà touchés exclus), masked-fences+inlines+urls (lesson accumulée). Résultat : **3 hits totaux**, dont :
- 2 Instagram-brand `Reels` (capital) → **SKIP** per AVOID_CAPS
- 1 noun `preferences` body texte, INSTALLATION-ROO.md L144 → **SAFE**.

**HEADINGS tranche DROPPED** (cf note plus bas) — la tranche 3 ORIGINALE visait l'observation ai-01 « headings partiellement accentués (#4810 Étape 4/Modèles Recommandés) » mais le re-probe masked-exclude-fences sur 171 fichiers montre **zéro heading-debt réel**. Les `#specifique` détectées en raw étaient des **commentaires bash dans blocs fences** (correctement exclus par masking).

## Eyeball = 1 correction

| Fichier | Ligne | Avant | Après | Type |
|---------|-------|-------|-------|------|
| Roo-Code/docs/INSTALLATION-ROO.md | 144 | preferences | préférences | noun |

## Choix conservateurs

- **`Reels` (Instagram brand, capital)** : 2 occurrences dans 04-creation-contenu (strategie-contenu.md, modeles-publications.md) → EXCLUES per AVOID_CAPS lessons (terme-propre EN).

- **3sg/pp/infinitive verbs** : pas de hits trouvés dans le subtree Vibe-Coding whole-tree après masked-probe (les verbes `utilise`/`applique`/`configure`/`identifie` qui restaient ont déjà été couverts par les PRs #4805-#4840). Si de nouveaux hits verbaux émergent : batch dédié 3sg/pp-allowlist, leçon #4502 strict.

- **Preposition autonome `a`→`à`** : hors scope (gate peut passer le verbe avoir, false-positive HIGH) — leçon #4502 hardened.

- **Ligature `œ`** : hors scope (NFD-decomposable fail sur `noeud`→`nœud`) — leçon #4502.

## Validation (4 gates + protected strings, tous PASS)

| Fichier | G1 NFD | G2 fences | G2 inlines | G2 urls | G4 no-placeholder |
|---------|--------|-----------|------------|---------|--------------------|
| Roo-Code/docs/INSTALLATION-ROO.md | ✓ | ✓ | ✓ | ✓ | ✓ |

Signature = **+1/-1** (single noun).

## Non-scope (deep-queue restant)

1. **HEADINGS tranche = DROPPED** (cf méthode plus haut). Faux positif structural sur raw-grep.
2. **3sg/pp verbs** (`utilise`, `applique`, `configure`, `identifie`, `preferees`, `recherche` confusionnel, etc.) : leçon #4502 strict → EXCLUS. Batch dédié 3sg-allowlist si scope surgit.
3. **Preposition `à`** : ambigu avec verbe avoir, hors scope hardened.
4. **Ligature `œ`** : hors scope (NFD-decomposable fail).
5. **Fichiers `Roo-Code/Corrections/corrigés ateliers-roo/*`** : travaux étudiants, hors-scope #2876.

## Notes sur l'observation ai-01 source

ai-01 verbatim avait flaggé : « headings partiellement accentués (#4810 Etape 4/Modeles Recommandes) ». Hypothèse 1 : PRs post-#4810 (#4830 INSTALLATION+OPENROUTER_SETUP #4840) ont effectivement nettoyé ces headings-specific (Eyeball diff L352 `## Modèles Alternatifs via OpenRouter` + L722 `## Résolution de Problèmes` = accented ✓). Hypothèse 2 : le verbe générique était déjà satisfait (l'observation datait d'avant #4840). HEADINGS = **saturated as of #4840**, confirmé par probe masked.

See #2876