### PR TITLE
fix(qc): restore French diacritics in Trend-Following README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/README.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Strategie trend following avec oracles multiples (MACD, RSI, Bollinger).
+Stratégie trend following avec oracles multiples (MACD, RSI, Bollinger).
 
 ## How to Run
 
@@ -16,7 +16,7 @@ Strategie trend following avec oracles multiples (MACD, RSI, Bollinger).
 ## Architecture (multi-fichiers)
 - `main.py` - Algorithme principal, universe equity top 600
 - `alpha.py` - Custom alpha avec 7+ indicateurs et scoring composite
-- `trendCalculator.py` - Detection HH/HL/LL/LH (extrema locaux)
+- `trendCalculator.py` - Détection HH/HL/LL/LH (extrema locaux)
 - `macd_oracle.py` - Oracle MACD (cross + seuils)
 - `rsi_oracle.py` - Oracle RSI (convergence/divergence trend)
 - `bollinger_oracle.py` - Oracle Bollinger (position relative)
@@ -24,7 +24,7 @@ Strategie trend following avec oracles multiples (MACD, RSI, Bollinger).
 
 ## Concepts enseignes
 - Multi-oracle scoring
-- Detection de tendance (Higher Highs, Lower Lows)
+- Détection de tendance (Higher Highs, Lower Lows)
 - ATR trailing stop-loss
 - EMA 50/200 cross confirmation
 - ADX strength filter


### PR DESCRIPTION
## Summary

Restore French diacritics in `MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/README.md` (3 corrections across 3 lines). Part of issue #2876.

## Methodology

Round-trip guard (po-2025 PR #4500): each replacement verifies `strip_accents(accented).lower() == bare.lower()`. We only **add** diacritics; we never change a letter.

## Corrections applied

| Bare | Accented | Count |
|------|----------|-------|
| Strategie | Stratégie | 1 |
| Detection | Détection | 2 |

Total: 3 replacements.

## Skipped (preserved verbatim)

- Inline code backticks (`` `trendCalculator.py` ``)
- Acronyms (`HH/HL/LL/LH`) and English descriptors (`Higher Highs, Lower Lows`)
- No code blocks, no link targets, no URLs, no CATALOG-STATUS markers in this file
- LF line endings preserved

## Scope

- **1 file modified** (atomic)
- **3 lines changed** (+/-)
- **0 code, 0 catalog markers, 0 GenAI** touched
- No content/structure changes - only accent insertion

## Verification

- Round-trip guard: 2 distinct forms verified, 3 total replacements
- Manual review: each line context checked (preserved backticks and EN acronyms intact)
- Line endings: LF (git diff displays clean)
- Same methodology as #4846 (CTG-Momentum) which MERGED clean

## Context

3rd tranche of #2876 in this session, in a **different QC project** (Trend-Following multi-oracle) for lane diversity within the QC family - not the same project as #4844 (Alpha-Correlation-Analysis) or #4846 (CTG-Momentum). All three PRs are atomic, single-file, 3-16 corrections each, demonstrating the round-trip guard works across heterogeneous forms and project types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>