### PR TITLE
fix(vibe-coding): restore accent supporte in COMPARAISON-CLAUDE-ROO L329 (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/COMPARAISON-CLAUDE-ROO.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/COMPARAISON-CLAUDE-ROO.md
@@ -326,7 +326,7 @@ Les coûts sont identiques si le même modèle est utilise via OpenRouter.
 
 ### Préférer Claude Code pour
 
-- Développement **professionnel** et **supporte**
+- Développement **professionnel** et **supporté**
 - **Parallélisation** de tâches (sous-agents)
 - Intégration **CLI** pour automatisation et CI/CD
 - Support **MCP** complet


### PR DESCRIPTION
## Scope

Step 4 du deep-queue ai-01 (msg lygoyu, **tranche 4**) : rattrapage verbatim ai-01 « supporte→supporté (COMPARAISON L~329) ». Tranche = **1 fichier / 1 hit**.

## Méthode

Re-probe masked-fences sur `docs/COMPARAISON-CLAUDE-ROO.md` (384L, post-#4829 baseline). Résultat = 0 hit nouns/adjectifs restants, 1 hit verbatim flagged par ai-01 : `supporte` L329 (raw) / L326 (masked-text offset).

**Sémantique unambiguous** : `- Développement **professionnel** et **supporte**` = `professionnel et supporté` (participe passé adjectif OU 3sg présent du verbe supporter ; formes confondues sur `supporté`). Pas de risque false-positive sur ce mot spécifique (contrairement aux -er verbs génériques où 3sg `presente` et pp `présenté` diffèrent).

## Eyeball = 1 correction

| Fichier | Ligne | Avant | Après | Type |
|---------|-------|-------|-------|------|
| docs/COMPARAISON-CLAUDE-ROO.md | 329 | supporte | supporté | pp/3sg (unambiguous) |

## Choix conservateurs

- **`Reels` (Instagram brand, capital)** : 0 occurrence body texte hors-fences dans ce fichier après le masked-probe.
- **Autres 3sg/pp verbs** : pas de hits trouvés (le fichier avait déjà été nettoyé par #4829 sur 22 nouns/adjectifs ; ce tranche attrape le dernier verb-pp verbatim flagged).
- **Preposition autonome `a`→`à`** : hors scope hardened (cf leçon #4502).
- **Ligature `œ`** : hors scope (NFD-decomposable fail).

## État antérieur vs cette PR

PR **#4829** (8f61b8b0, merged 2026-07-01 ~21h, ai-01 audit) : 22 corrections body sur le même fichier. **L329 `supporte` a manqué ce sweep** car `supporter` n'était pas dans le dict initial (verb-pp exclu leçon #4502 stricte). Cette PR le rattrape **uniquement parce que la sémantique contextuelle est unambiguous** (et pp, vs 3sg present).

## Validation (4 gates + protected strings, tous PASS)

| Fichier | G1 NFD | G2 fences | G2 inlines | G2 urls | G4 no-placeholder |
|---------|--------|-----------|------------|---------|--------------------|
| docs/COMPARAISON-CLAUDE-ROO.md | ✓ | ✓ | ✓ | ✓ | ✓ |

Signature = **+1/-1** (single verb/pp, semantically unambiguous).

## Non-scope (deep-queue restant)

1. **HEADINGS tranche = SATURATED** (cf PR #4850 : 171 fichiers Vibe-Coding re-probés, 0 hit heading-debt hors-fences).
2. **3sg/pp génériques** : hardened par leçon #4502 (cf PR #4850 body pour liste explicite des exclus).
3. **Preposition `à`** : hors scope (ambigu avec verbe avoir).
4. **Ligature `œ`** : hors scope (NFD-decomposable fail).
5. **Fichiers `Roo-Code/Corrections/corrigés ateliers-roo/*`** : travaux étudiants, hors-scope #2876.

## Notes sur l'observation ai-01 source

ai-01 verbatim avait flaggé : « `supporte`→`supporté` (COMPARAISON L~329) ». Cette PR honore verbatim la flag en livrant la correction avec justification sémantique. **HEADINGS tranche** flagged au même moment est **saturated** (PR #4850).

See #2876