### PR TITLE
fix(smartcontracts): restore accents in 4 SmartContracts README subfiles (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/README.md
@@ -35,7 +35,7 @@ Solidity supporte l'héritage multiple avec le mot-clé `is`, les interfaces pou
 
 ### Étape 4 : Erreurs et observabilite (SC-6, 30 min)
 
-`require` (conditions d'entree, gas rembourse), `revert` (erreurs complexes), `assert` (invariants internes), les custom errors economes en gas depuis 0.8.4, et les events pour le logging hors-chain.
+`require` (conditions d'entrée, gas rembourse), `revert` (erreurs complexes), `assert` (invariants internes), les custom errors economes en gas depuis 0.8.4, et les events pour le logging hors-chain.
 
 ---
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/README.md
@@ -11,8 +11,8 @@ Cette troisième sous-série (SC-12 a SC-14) introduit le **testing rigoureux** 
 | # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 12 | [SC-12-Foundry-Testing](SC-12-Foundry-Testing.ipynb) | 45 min | Installation Foundry, structure de projet, tests Solidity (DSTest), cheatcodes, assertions |
-| 13 | [SC-13-Fuzz-Invariants](SC-13-Fuzz-Invariants.ipynb) | 40 min | Fuzz testing, parametres aleatoires, invariants de contrats, `vm.assume` |
-| 14 | [SC-14-Formal-Verification](SC-14-Formal-Verification.ipynb) | 50 min | Verification formelle, Certora Prover, CVL, specifications, regles |
+| 13 | [SC-13-Fuzz-Invariants](SC-13-Fuzz-Invariants.ipynb) | 40 min | Fuzz testing, paramètres aléatoires, invariants de contrats, `vm.assume` |
+| 14 | [SC-14-Formal-Verification](SC-14-Formal-Verification.ipynb) | 50 min | Verification formelle, Certora Prover, CVL, spécifications, regles |
 
 **Total** : 3 notebooks, ~2h15.
 
@@ -38,11 +38,11 @@ Installation et configuration de **Foundry** (forge, cast, anvil), création d'u
 
 ### Étape 2 : Fuzz et invariants (SC-13, 40 min)
 
-Le **fuzz testing** : passer des parametres aleatoires aux fonctions de test, tester des **invariants** (propriétés qui doivent toujours tenir, quelles que soient les entrees), et filtrer les entrees invalides avec `vm.assume`. Cette étape change la maniere de penser les tests : on ne vérifie plus des cas isolés mais des familles entieres de comportements.
+Le **fuzz testing** : passer des paramètres aléatoires aux fonctions de test, tester des **invariants** (propriétés qui doivent toujours tenir, quelles que soient les entrées), et filtrer les entrées invalides avec `vm.assume`. Cette étape change la manière de penser les tests : on ne vérifie plus des cas isolés mais des familles entières de comportements.
 
 ### Étape 3 : Verification formelle (SC-14, 50 min)
 
-La **vérification formelle** comme niveau au-dessus du testing : **Certora Prover** et le langage de specification **CVL** (Certora Verification Language), ecriture de **specifications** et de **regles**, vérification d'invariants mathematiques. Pont naturel avec la série Lean (preuve formelle de propriétés).
+La **vérification formelle** comme niveau au-dessus du testing : **Certora Prover** et le langage de spécification **CVL** (Certora Verification Language), ecriture de **spécifications** et de **regles**, vérification d'invariants mathematiques. Pont naturel avec la série Lean (preuve formelle de propriétés).
 
 ---
 
@@ -88,7 +88,7 @@ La **vérification formelle** comme niveau au-dessus du testing : **Certora Prov
 ## Ressources
 
 - **Foundry Book** (Foundry contributors) -- `forge test`, `forge build`, fuzzing, cheatcodes. book.getfoundry.sh.
-- **Certora Documentation** (Certora Inc.) -- Certora Prover, langage CVL, ecriture de specifications. docs.certora.com.
+- **Certora Documentation** (Certora Inc.) -- Certora Prover, langage CVL, ecriture de spécifications. docs.certora.com.
 - **Halmos** (a16z, 2023) -- symbolic exécution open-source pour tests Foundry.
 - Wilkinson, M. (2022) -- "Foundry: A Blazing Fast, Portable, and Modular Toolkit for Ethereum Application Development".
 - Voir aussi les références transversales dans le [README parent de la série](../README.md).

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/README.md
@@ -2,7 +2,7 @@
 
 **Navigation** : [Sommaire de la série](../README.md) | [<< SC-14 Formal Verification](../03-Foundry-Testing/SC-14-Formal-Verification.ipynb) | [SC-18 Vyper >>](../05-Alternative-Chains/SC-18-Vyper.ipynb)
 
-Cette quatrieme sous-série (SC-15 a SC-17) explore la cryptographie avancée au service de la confidentialite sur blockchain : les **preuves a divulgation nulle** (Zero-Knowledge Proofs), le **chiffrement homomorphe** (calcul sur données chiffrees), et le **vote électronique de bout en bout vérifiable** (E2E). Ces notebooks implementent les protocoles cryptographiques pour de vrai en Python (`pycryptodome`, `phe`, `tenseal`), avec la crypto Paillier et Schnorr reelement executee dans les outputs committes.
+Cette quatrième sous-série (SC-15 a SC-17) explore la cryptographie avancée au service de la confidentialite sur blockchain : les **preuves a divulgation nulle** (Zero-Knowledge Proofs), le **chiffrement homomorphe** (calcul sur données chiffrees), et le **vote électronique de bout en bout vérifiable** (E2E). Ces notebooks implementent les protocoles cryptographiques pour de vrai en Python (`pycryptodome`, `phe`, `tenseal`), avec la crypto Paillier et Schnorr reelement executee dans les outputs committes.
 
 ---
 
@@ -35,7 +35,7 @@ flowchart LR
 
 ### Étape 1 : Preuves Zero-Knowledge (SC-15, 60 min)
 
-Les **preuves a divulgation nulle** : prouver la connaissance d'un secret sans le reveler. Implémentation from scratch du **protocole de Schnorr** (preuve de connaissance d'un logarithme discret), transformation de **Fiat-Shamir** (rendre un protocole interactif non-interactif via oracle aleatoire), et exploration des **Sigma protocols** avec le protocole de **Chaum-Pedersen**. Crypto `pycryptodome` réelle dans les outputs.
+Les **preuves a divulgation nulle** : prouver la connaissance d'un secret sans le reveler. Implémentation from scratch du **protocole de Schnorr** (preuve de connaissance d'un logarithme discret), transformation de **Fiat-Shamir** (rendre un protocole interactif non-interactif via oracle aléatoire), et exploration des **Sigma protocols** avec le protocole de **Chaum-Pedersen**. Crypto `pycryptodome` réelle dans les outputs.
 
 ### Étape 2 : Chiffrement homomorphe (SC-16, 50 min)
 
@@ -82,7 +82,7 @@ Le **paradoxe du vote électronique** : concilier **anonymat** et **vérifiabili
 
 ## Points de vigilance (dépendances cryptographiques)
 
-- **Paillier + Schnorr exécutés réellement** (SC-15, SC-16, SC-17) : les outputs committes refletent une vraie exécution crypto `phe`/`pycryptodome`. Les parametres (clés, challenges, reponses) sont authentiques.
+- **Paillier + Schnorr exécutés réellement** (SC-15, SC-16, SC-17) : les outputs committes refletent une vraie exécution crypto `phe`/`pycryptodome`. Les paramètres (clés, challenges, réponses) sont authentiques.
 - **CKKS / TenSEAL (SC-16) optionnel** : si `tenseal` n'est pas installe, la section CKKS tourne en repli honnêtement disclose (message `TenSEAL non installe`), avec des plages d'erreur illustrees. Audit #3164 a vérifie que les nombres measures au-dessus de ce repli sont honnêtement documentés (PR #3382).
 - **ElectionGuard (SC-17)** : la partie SOTA est disclose comme **simulation conceptuelle** (ElectionGuard requiert un setup lourd) ; le vote a la main Paillier+ZKP est lui réellement exécute.
 - **ZKP interactif vs non-interactif** : SC-15 implémente les deux formes ; vérifier que la transformation Fiat-Shamir produit bien un proof non-transferable.
@@ -96,7 +96,7 @@ Le **paradoxe du vote électronique** : concilier **anonymat** et **vérifiabili
 - **Chaum, D., & Pedersen, T. (1993)** -- "Wallet Databases with Observers", *CRYPTO 1992*. Protocole Chaum-Pedersen.
 - **Paillier, P. (1999)** -- "Public-Key Cryptosystems Based on Composite Degree Residuosity Classes", *EUROCRYPT 1999*. Schéma de Paillier (additivement homomorphe).
 - **Shamir, A. (1979)** -- "How to Share a Secret", *Communications of the ACM* 22(11). Partage de secrets.
-- **ElectionGuard** (Microsoft, 2019) -- specification du vote E2E vérifiable. github.com/microsoft/electionguard.
+- **ElectionGuard** (Microsoft, 2019) -- spécification du vote E2E vérifiable. github.com/microsoft/electionguard.
 - Voir aussi les références transversales dans le [README parent de la série](../README.md).
 
 ---

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/README.md
@@ -42,7 +42,7 @@ flowchart LR
 
 ### Phase 1 : Interoperabilite (SC-23, ~45 min)
 
-Pourquoi deplacer un actif ou un message d'une chaîne a l'autre, comment Chainlink CCIP fait transituer des données on-chain de maniere vérifiable, et ou se cachent les attaques cross-chain (reentrancy de bridge, message spoofing). Le notebook reste en mode source-as-strings (les contrats CCIP sont lus comme texte pédagogique, non déployés).
+Pourquoi deplacer un actif ou un message d'une chaîne a l'autre, comment Chainlink CCIP fait transituer des données on-chain de manière vérifiable, et ou se cachent les attaques cross-chain (reentrancy de bridge, message spoofing). Le notebook reste en mode source-as-strings (les contrats CCIP sont lus comme texte pédagogique, non déployés).
 
 ### Phase 2 : Deploiement public (SC-24 + SC-25, ~1h30)
 


### PR DESCRIPTION
## Scope
4 README files in `SymbolicAI/SmartContracts` subtree :
- `01-Solidity-Foundation/README.md` (1 hit)
- `03-Foundry-Testing/README.md` (5 hits)
- `04-Privacy-Cryptography/README.md` (4 hits)
- `06-Real-World/README.md` (1 hit)

Total : +11/-11 (char delta = 0).

## Method (per `accent-restoration-2876-verification-method.md`)
- Conservative noun/adj dict (15 entries) — NO 3sg/pp verbs, NO `a` autonome
- Masked-dictionary approach : code fences, inlines, URLs, link targets preserved
- 4-gate validation : `deaccent(old)==deaccent(new)` + fences byte-identical + inlines byte-identical + URLs byte-identical + no placeholder leaks

## Excluded (deliberate)
- `verification` (capital V in `Formal Verification` English term + notebook filename `SC-14-Formal-Verification` inside markdown links)
- `implementation`/`reference` (mostly in foundry-lib vendored, EXCLUDED)
- All 3sg/pp ambiguous verbs (per lesson #4502)

## See
Closes #2876 (partial — SmartContracts tranche). Note : Vibe-Coding trunk saturated by #4840+#4850+#4852, this PR continues the cleanup into the SmartContracts sub-series.

## Test
```bash
python scripts/notebook_tools/scrub_papermill_paths.py --scan
```
(should be unaffected — README files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)