### PR TITLE
fix(genai): repair 3 broken inter-notebook links (#4788)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](01-1-GPT-5-Vision-Analysis.ipynb) | [Suivant >>](01-3-Basic-Image-Operations.ipynb)\n",
+    "**Navigation** : [Index](../../README.md) | [<< Precedent](01-1-OpenAI-DALL-E-3.ipynb) | [Suivant >>](01-3-Basic-Image-Operations.ipynb)\n",
     "\n",
     "# 🤖 GPT-5 Multimodal - Analyse et Génération d'Images\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
@@ -1608,7 +1608,7 @@
     "|----------|---------|\n",
     "| [04-Filters](04-SemanticKernel-Filters-Observability.ipynb) | Intercepter et modifier les appels |\n",
     "| [05-VectorStores](05-SemanticKernel-VectorStores.ipynb) | RAG avec Qdrant |\n",
-    "| [05-NotebookMaker](05-NotebookMaker.ipynb) | Systeme 3-agents en production |\n",
+    "| [05-NotebookMaker](10-SemanticKernel-NotebookMaker.ipynb) | Systeme 3-agents en production |\n",
     "\n",
     "---\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
@@ -1421,7 +1421,7 @@
     "| 08 | MCP | Interoperabilite, Serveurs |\n",
     "\n",
     "**Prochaines etapes** :\n",
-    "- Explorer [05-NotebookMaker](05-NotebookMaker.ipynb) pour un exemple d'agents en production\n",
+    "- Explorer [05-NotebookMaker](10-SemanticKernel-NotebookMaker.ipynb) pour un exemple d'agents en production\n",
     "- Consulter la [documentation SK](https://learn.microsoft.com/semantic-kernel)\n",
     "- Suivre le [blog SK](https://devblogs.microsoft.com/semantic-kernel/) pour les nouveautes"
    ]


### PR DESCRIPTION
## Scope
3 source notebooks in `GenAI/` subtree :
- `Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb` (1 fix)
- `SemanticKernel/03-SemanticKernel-Agents.ipynb` (1 fix)
- `SemanticKernel/08-SemanticKernel-MCP.ipynb` (1 fix)

Total : +3/-3 (link target only).

## Method (per #4788 acceptance criteria)
- `git grep` of broken targets + manual mapping to current filename
- Anti-régression : cell count + execution_count + outputs preserved (validated)
- Atomique PR per HARD 3 (1 family = 1 tranche = 1 PR)
- Markdown-only changes inside notebook cells (no code execution re-run needed)

## Excluded (deliberate)
- 1 stale link in `4_Function_Calling_output.ipynb` (`5_RAG_Introduction` → `5_RAG_Modern`) — file is `.gitignored` (output companion), primary `4_Function_Calling.ipynb` already has correct link
- Other families' broken links (ML, DataScience, SymbolicAI, …) — covered by other workers' tranches per #4788 self-serve model

## See
See #4788 (partial — GenAI tranche only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)