### PR TITLE
docs(qc): restore accents in qc-comparative-backtests Key findings FR prose (#2876)

### DIFF
--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -451,24 +451,24 @@ ou `Sigma` est la **matrice de covariance** complete (correlations incluses). Re
 
 ## Key findings
 
-1. **TrendFollowing = leader indiscutable**: Sharpe 1.072 sur 2018-2025 avec MaxDD 9.3%. PSR 81.8% (statistiquement significatif). Seule strategie "Robuste" confirmee sur la periode aligned.
-2. **EMA-Cross-Stocks: surprise positive**: Sharpe 0.891 sur 2018-2025, CAGR 26.2%. PSR 40.5%. 2e meilleur Sharpe aligne, derriere TrendFollowing.
-3. **EMA-Cross-Alpha: chute dramatique**: Sharpe passe de 0.996 (meilleur backtest) a -0.010 sur la periode aligned. PSR 0.5% = bruit. Confirme le pattern "backtests courts = overfitting".
-4. **Composites ne battent pas les single-strategies**: MomentumRegime (SectorMomentum + RegimeSwitching) obtient 0.185, confirmant le probleme de "double-defense".
+1. **TrendFollowing = leader indiscutable**: Sharpe 1.072 sur 2018-2025 avec MaxDD 9.3%. PSR 81.8% (statistiquement significatif). Seule stratégie "Robuste" confirmee sur la période aligned.
+2. **EMA-Cross-Stocks: surprise positive**: Sharpe 0.891 sur 2018-2025, CAGR 26.2%. PSR 40.5%. 2e meilleur Sharpe aligne, derrière TrendFollowing.
+3. **EMA-Cross-Alpha: chute dramatique**: Sharpe passe de 0.996 (meilleur backtest) a -0.010 sur la période aligned. PSR 0.5% = bruit. Confirme le pattern "backtests courts = overfitting".
+4. **Composites ne battent pas les single-strategies**: MomentumRegime (SectorMomentum + RegimeSwitching) obtient 0.185, confirmant le problème de "double-defense".
 5. **Crypto = rendement modere mais stable**: Crypto-MultiCanal (0.581) et Portfolio-IBKR-Binance (0.519) offrent diversification avec MaxDD maitrises.
 6. **FX Carry = perdant**: Sharpe -1.108, les taux bas post-COVID ont elimine l'avantage du carry trade.
 7. **AllWeather: performance confirme**: Sharpe 0.631 (2010-2025), MaxDD 16.4%, PSR 31.2%. Risk-parity solide.
 8. **MomentumStrategy (SectorMom v4.0)**: Sharpe 0.555, CAGR 11.7%, mais PSR 7.2% = non significatif.
 9. **SectorDualMomentum v3.2**: Sharpe 0.581, CAGR 13.5%, MaxDD 22.8%. PSR 15.3%.
 10. **TrendStocks-Alpha: high return, high risk**: CAGR 15.9% mais MaxDD 39.6% (Calmar 0.40). PSR 5.8% = non significatif.
-11. **Student DualMomentum: PSR > 50%**: Sharpe 0.493 sur 2023-2025 avec MaxDD 9.0%. Seule strategie etudiante avec PSR significatif (54.9%).
-12. **Student RiskParity: performance honnete**: Sharpe 0.514, CAGR 9.3%, MaxDD 20.7%. Inverse-vol simple mais efficace. PSR 16.3% (non significatif mais respectable).
-13. **Student OptionWheel: catastrophe pedagogique**: Sharpe -0.51, MaxDD 103.5%. Parfait comme etude de cas du "win-rate paradoxe".
-14. **Student ValueFactor: alpha negatif confirmee**: Sharpe 0.227, PSR 0.8%. Decennie growth-dominée = facteur value sous-performant.
-15. **LeveragedETFMomentum: confirme et significatif**: Sharpe 1.779 sur 2018-2025, PSR 79.8% (2e PSR significatif apres TrendFollowing). Mais MaxDD 53.3% et CAGR 126% typiques d'un levier 3x — profil risque extreme, pas comparable aux strategies non-leveragees.
-16. **PuppiesOfTheDow et HighBookToMarketFScore: effondrement sur periode alignee**: Sharpe catalog 1.99 et 2.09 (obtenus sur leur fenetre glissante par defaut `end_date - 12 ans`) tombent a 0.302 (PSR 3.5%) et 0.411 (PSR 4.5%, MaxDD 60.4%) sur 2018-2025. Les deux meilleures lignes ML/IND du Tier 1 ne sont pas reproductibles sur la fenetre standardisee.
+11. **Student DualMomentum: PSR > 50%**: Sharpe 0.493 sur 2023-2025 avec MaxDD 9.0%. Seule stratégie etudiante avec PSR significatif (54.9%).
+12. **Student RiskParity: performance honnête**: Sharpe 0.514, CAGR 9.3%, MaxDD 20.7%. Inverse-vol simple mais efficace. PSR 16.3% (non significatif mais respectable).
+13. **Student OptionWheel: catastrophe pédagogique**: Sharpe -0.51, MaxDD 103.5%. Parfait comme étude de cas du "win-rate paradoxe".
+14. **Student ValueFactor: alpha négatif confirmee**: Sharpe 0.227, PSR 0.8%. Décennie growth-dominée = facteur value sous-performant.
+15. **LeveragedETFMomentum: confirme et significatif**: Sharpe 1.779 sur 2018-2025, PSR 79.8% (2e PSR significatif après TrendFollowing). Mais MaxDD 53.3% et CAGR 126% typiques d'un levier 3x — profil risque extreme, pas comparable aux strategies non-leveragees.
+16. **PuppiesOfTheDow et HighBookToMarketFScore: effondrement sur période alignee**: Sharpe catalog 1.99 et 2.09 (obtenus sur leur fenêtre glissante par défaut `end_date - 12 ans`) tombent a 0.302 (PSR 3.5%) et 0.411 (PSR 4.5%, MaxDD 60.4%) sur 2018-2025. Les deux meilleures lignes ML/IND du Tier 1 ne sont pas reproductibles sur la fenêtre standardisee.
 17. **TrendWeather: le composite qui tient**: Sharpe 0.948 (PSR 56.6%), proche du catalog 1.16. Contraste fort avec MomentumRegime (0.185) — toutes les architectures composites ne se valent pas.
-18. **Caveat reproductibilite Trend-Following**: le code du repo backteste sur 2018-2024 donne Sharpe 0.365 / MaxDD 13.8% (backtest `3748cb62`), loin du 1.072 publie ci-dessus (`7792ae0a`, 2018-2025, etat du code cloud anterieur). Periodes differentes (2025 inclus ou non) ET drift possible repo vs cloud — a investiguer avant de citer 1.072 comme reference du code versionne.
+18. **Caveat reproductibilité Trend-Following**: le code du repo backteste sur 2018-2024 donne Sharpe 0.365 / MaxDD 13.8% (backtest `3748cb62`), loin du 1.072 publie ci-dessus (`7792ae0a`, 2018-2025, état du code cloud antérieur). Périodes differentes (2025 inclus ou non) ET drift possible repo vs cloud — a investiguer avant de citer 1.072 comme référence du code versionne.
 19. **MeanReversion v5.2: Best Calmar ratio**: Sharpe 0.81, MaxDD 7.5%, Calmar 1.34 — best risk-adjusted return among non-leveraged strategies. PSR 46.8% (near significance). Promoted from Tier 2 (0.29) to Tier 1. The v5.2 code (IBKR brokerage, RSI65 exit, 10% stop-loss) dramatically outperforms the older version.
 20. **AdaptiveAssetAllocation: confirmed robuste**: Sharpe 0.509, CAGR 8.0%, MaxDD 18.9% (2008-2024, 16 years). Min-var + momentum approach produces steady returns. PSR 10.6% (not significant but positive).
 21. **PairsTrading: structural failure confirmed**: Sharpe -0.28 on aligned period, PSR 0.001%. OLS hedge + cointegration still produces negative alpha. Remains exploratoire/pedagogical.


### PR DESCRIPTION
## Summary

Restore French accents in the **hand-written FR-prose items (1-18)** of the "Key findings" section of `docs/qc/qc-comparative-backtests.md` — the QC reference catalog (40 verified baselines). This is a coherent `#2876` accent slice on **QC-family documentation** (my turf, no collision with po-2023 = SymbolicAI/Vibe-Coding).

### Why
The "Key findings" section mixes **FR-prose items 1-18** (hand-written during the original `#1630` campaign, with real accent debt) and **EN-prose items 19+** (written later 2026-06-22/23, deliberately English, zero debt). This PR addresses only the FR-prose items.

## Scope — 21 corrections across 11 lines

Nouns / adjectives / prepositions **only**:
- `stratégie` (×2), `période` (×3), `derrière`, `problème`, `honnête`, `pédagogique`, `étude`, `négatif`, `Décennie`, `après`, `fenêtre` (×2), `défaut`, `reproductibilité`, `état`, `antérieur`, `Périodes`, `référence`

### Strictly skipped (per guardrail #4502 — avoid pp/3sg flip-flop)
Past participles & 3rd-person-singular verbs left as-is: `confirmee`, `alignee`, `standardisee`, `maitrises`, `modere`, `non-leveragees`, `differentes`, `etudiante`, `publie`, `versionne`, `backteste`, `donne`, `Confirme`, `confirme`, `elimine`. The verb `a` (avoir) is hard-excluded (collides with EN article).

## Verification (G.1)

- `git diff` confirms **only** FR-prose items 1-4, 11-16, 18 changed; items 5-10, 17 and EN-tier items 19+ byte-identical.
- Backtest IDs (`3748cb62`, `7792ae0a`), Sharpe/CAGR/PSR/MaxDD numeric values, and all data-table rows **untouched**.
- No `CATALOG-STATUS` markers (this is `docs/`, not a catalog README).
- Surgical edits via `Edit` tool (no `sed` automation) — safe on FR prose interleaved with EN data.

## Methodology

Edit-tool surgical replacement, one unique-context `old_string` per item line. Initial batch had 2 mismatches where markdown bold-close `**:` was confused with a quote `":` — corrected after re-read; final diff verified clean.

See #2876
See #3976

🤖 Generated with [Claude Code](https://claude.com/claude-code)
