### PR TITLE
fix(docs): restore 58 missing French accents in live reference docs (#2876)

### DIFF
--- a/docs/curriculum/genai.md
+++ b/docs/curriculum/genai.md
@@ -2,7 +2,7 @@
 
 **Generation d'images, audio, video et texte**
 
-Generation d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthese vocale, generation musicale, video, et orchestration de modeles. Inclut les workflows Vibe-Coding et les pipelines de production.
+Generation d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthese vocale, generation musicale, video, et orchestration de modèles. Inclut les workflows Vibe-Coding et les pipelines de production.
 
 ## Statistiques
 
@@ -25,13 +25,13 @@ Generation d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthese vocale, 
 | 6 | XTTS v2 - Clonage Vocal Zero-Shot | ALPHA | Non |
 | 7 | MusicGen - Generation Musicale par IA | ALPHA | Non |
 | 8 | Demucs v4 - Separation de Sources Audio | ALPHA | Non |
-| 9 | Multi-Model TTS Gateway - Synthese Vocale Multi-Modeles | ALPHA | Oui |
+| 9 | Multi-Model TTS Gateway - Synthese Vocale Multi-Modèles | ALPHA | Oui |
 | 10 | Generation MIDI avec midi-model (SkyTNT) | ALPHA | Non |
 | 11 | Generation de Chansons Completes : YuE vs SongGeneratio | ALPHA | Non |
-| 12 | TTS Expressif : Fish S2 Pro et Modeles SOTA | ALPHA | Non |
-| 13 | Comparaison Multi-Modeles Audio | ALPHA | Non |
+| 12 | TTS Expressif : Fish S2 Pro et Modèles SOTA | ALPHA | Non |
+| 13 | Comparaison Multi-Modèles Audio | ALPHA | Non |
 | 14 | Orchestration de Pipelines Audio | ALPHA | Non |
-| 15 | Creation de Contenu Audio Educatif | ALPHA | Non |
+| 15 | Création de Contenu Audio Educatif | ALPHA | Non |
 | 16 | Pipeline de Transcription et Sous-titrage | ALPHA | Non |
 | 17 | Workflow de Composition Musicale | ALPHA | Non |
 | 18 | Synchronisation Audio-Video (Passerelle) | ALPHA | Non |

--- a/docs/curriculum/ia-classique.md
+++ b/docs/curriculum/ia-classique.md
@@ -1,8 +1,8 @@
 # IA Classique
 
-**Recherche, CSP et resolution de problemes**
+**Recherche, CSP et résolution de problemes**
 
-Algorithmes de recherche classique, satisfaction de contraintes (CSP), resolution de Sudoku, planification classique. De A* aux heuristiques avancees, en passant par les solveurs SAT/SMT.
+Algorithmes de recherche classique, satisfaction de contraintes (CSP), résolution de Sudoku, planification classique. De A* aux heuristiques avancees, en passant par les solveurs SAT/SMT.
 
 ## Statistiques
 
@@ -37,11 +37,11 @@ Algorithmes de recherche classique, satisfaction de contraintes (CSP), resolutio
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Notebook 11: Resolution de Sudoku avec Choco Constraint | PRODUCTION | Oui |
+| 1 | Notebook 11: Résolution de Sudoku avec Choco Constraint | PRODUCTION | Oui |
 | 2 | Sudoku-12-Z3-Python : Z3 SMT Solver (Python) | BETA | Oui |
 | 3 | Sudoku-13 : Automates avec BDD/MDD - Approche Pure | BETA | Oui |
-| 4 | Sudoku-15-Infer-Python : Resolution Probabiliste avec N | BETA | Oui |
+| 4 | Sudoku-15-Infer-Python : Résolution Probabiliste avec N | BETA | Oui |
 | 5 | Sudoku-Python-Genetic : Algorithme Genetique (Python) | BETA | Oui |
 | 6 | Sudoku-5 : Particle Swarm Optimization (Python) | BETA | Oui |
-| 7 | Sudoku-6 : Resolution par CSP Academique (Python) | BETA | Oui |
+| 7 | Sudoku-6 : Résolution par CSP Academique (Python) | BETA | Oui |
 | 8 | Sudoku-9-GraphColoring-Python : Coloration de Graphe (P | BETA | Oui |

--- a/docs/genai/genai-services.md
+++ b/docs/genai/genai-services.md
@@ -2,7 +2,7 @@
 
 ## Services disponibles
 
-| Service | Modele | VRAM | Description |
+| Service | Modèle | VRAM | Description |
 |---------|--------|------|-------------|
 | **Qwen Image Edit** | qwen_image_edit_2509 | ~29GB | Edition d'images avec prompts multimodaux |
 | **Z-Image/Lumina** | Lumina-Next-SFT | ~10GB | Generation text-to-image haute qualite |
@@ -53,7 +53,7 @@ VAEDecode
 SaveImage
 ```
 
-**Parametres LuminaDiffusersNode** :
+**Paramètres LuminaDiffusersNode** :
 - `model_path`: "Alpha-VLLM/Lumina-Next-SFT-diffusers"
 - `num_inference_steps`: 20-40
 - `guidance_scale`: 3.0-5.0
@@ -109,7 +109,7 @@ python scripts/genai-stack/genai.py auth sync              # Synchroniser tokens
 | 01-4, 02-3 | SD Forge | Service local ou myia.io |
 | 01-5, 02-1 | ComfyUI Qwen | COMFYUI_AUTH_TOKEN, ~29GB VRAM |
 | 02-4 | Z-Image/vLLM | ~10GB VRAM |
-| 03-* | Multi-modeles | Tous les services |
+| 03-* | Multi-modèles | Tous les services |
 | 04-* | Applications | Variable |
 
 ## Mapping notebooks Audio -> services
@@ -124,7 +124,7 @@ python scripts/genai-stack/genai.py auth sync              # Synchroniser tokens
 | Audio/02-2 | XTTS v2 | GPU ~6 GB |
 | Audio/02-3 | MusicGen | GPU ~10 GB |
 | Audio/02-4 | Demucs v4 | GPU ~4 GB |
-| Audio/03-* | Multi-modeles | Mixed |
+| Audio/03-* | Multi-modèles | Mixed |
 | Audio/04-11 | Kokoro TTS + FishAudio S2-Pro | GPU ~5 GB (FishAudio BnB 4-bit NF4) + ~2 GB (Kokoro) |
 | Audio/04-* | Applications | Mixed |
 

--- a/docs/lean/llm-endpoints.md
+++ b/docs/lean/llm-endpoints.md
@@ -6,10 +6,10 @@ Configuration des providers LLM utilises par le multi-agent prover dans `MyIA.AI
 
 ## Providers
 
-| Provider key | Type | Modele | Usage | Comportement |
+| Provider key | Type | Modèle | Usage | Comportement |
 |--------------|------|--------|-------|--------------|
 | `zai` | Cloud dedie Lean | `glm-5.1` | **Powerful** — reasoning model | Heavy thinking : ~99% des completion_tokens vont en `reasoning_content`. 1 prompt simple peut consommer 2048 tokens en raisonnement seul. **Exiger `max_tokens >= 8192` et timeout per-call >= 300s**. |
-| `local` | Cluster interne reverse-proxy | `qwen3.6-35b-a3b` | **Fast** — modeste mais rapide | Modere : ~5s pour 293 tokens dont ~270 reasoning. Plus rapide que zai mais reste thinking-aware. Attention au nom de modele (`.6` pas `.5`, changement silencieux 2026-05-11). |
+| `local` | Cluster interne reverse-proxy | `qwen3.6-35b-a3b` | **Fast** — modeste mais rapide | Modere : ~5s pour 293 tokens dont ~270 reasoning. Plus rapide que zai mais reste thinking-aware. Attention au nom de modèle (`.6` pas `.5`, changement silencieux 2026-05-11). |
 | `openrouter` | OpenRouter API | `anthropic/claude-sonnet-4.5` (powerful) / `google/gemma-3-27b-it:free` (fast) | Backup powerful, free tier rate-limite | Bon fallback Director. Free tier limite ~50 req/jour. |
 | `anthropic` | Anthropic API directe | `claude-sonnet-4-5` | **Reserve** — pas encore wire | Le framework actuel utilise `OpenAIChatCompletionClient` only. Necessiterait un client Anthropic natif. |
 
@@ -23,7 +23,7 @@ Configuration des providers LLM utilises par le multi-agent prover dans `MyIA.AI
 
 3. **Local LLM ports DOWN** : ai-01 ports 5001/5002 (vLLM mini/medium) ont ete observes DOWN cycliquement (Cycle 20 Track 1 po-2023 escalation). Toujours preferer l'endpoint reverse-proxy public (`local` provider key) plutot que `localhost:500X`.
 
-4. **Nom de modele case-sensitive** : si une cle valide retourne 404, verifier le nom exact via `curl /v1/models` avant de presumer une cle expiree.
+4. **Nom de modèle case-sensitive** : si une cle valide retourne 404, verifier le nom exact via `curl /v1/models` avant de presumer une cle expiree.
 
 ## Cout indicatif (estimation 2026-05)
 

--- a/docs/qc/qc-comparative-backtests.md
+++ b/docs/qc/qc-comparative-backtests.md
@@ -380,9 +380,9 @@ Les 4 strategies etudiantes ci-dessus sont aussi un support de cours. Cette sect
 
 #### 1. Le PSR (Probabilistic Sharpe Ratio) — Bailey & Lopez de Prado (2012)
 
-Le ratio de Sharpe observe suppose des rendements **IID et gaussiens**. Les rendements reels violent ces deux hypotheses : ils ont en general une **asymetrie (skew) negative** (les krachs sont plus profonds que les booms ne sont hauts) et des **queues epaisses (kurtosis > 3)**. Sous ces conditions, le Sharpe empirique est **systematiquement surestime**, surtout sur de courtes fenetres.
+Le ratio de Sharpe observe suppose des rendements **IID et gaussiens**. Les rendements réels violent ces deux hypotheses : ils ont en general une **asymetrie (skew) negative** (les krachs sont plus profonds que les booms ne sont hauts) et des **queues epaisses (kurtosis > 3)**. Sous ces conditions, le Sharpe empirique est **systematiquement surestime**, surtout sur de courtes fenetres.
 
-Le PSR corrige en estimant la probabilite que le vrai Sharpe depasse un seuil de reference `SR0` (souvent 0, le hasard) :
+Le PSR corrige en estimant la probabilité que le vrai Sharpe depasse un seuil de reference `SR0` (souvent 0, le hasard) :
 
 ```text
                      (SR_hat - SR0) * sqrt(T - 1)
@@ -392,16 +392,16 @@ Le PSR corrige en estimant la probabilite que le vrai Sharpe depasse un seuil de
 
 ou `T` = nombre d'annees d'observation (quand `SR_hat` est annualise), `skew` et `kurt` sont les moments empiriques des rendements, et `Phi` = fonction de repartition de la loi normale centree.
 
-**Lecture** : asymetrie negative et exces de kurtosis (kurt > 3) **gonflent le denominateur**, donc abaissent le PSR. Un meme Sharpe nominal peut donner un PSR tres different selon la distribution des rendements. Regle pratique : **PSR > 50%** = l'edge observe a plus de chances d'etre reel que d'etre du bruit ; **PSR < 50%** = on ne peut pas ecarter le bruit.
+**Lecture** : asymetrie negative et exces de kurtosis (kurt > 3) **gonflent le denominateur**, donc abaissent le PSR. Un meme Sharpe nominal peut donner un PSR tres different selon la distribution des rendements. Regle pratique : **PSR > 50%** = l'edge observe a plus de chances d'etre réel que d'etre du bruit ; **PSR < 50%** = on ne peut pas ecarter le bruit.
 
 **Applique aux 4 strategies etudiantes** :
 
 | Strategie | Sharpe | PSR% | Lecture |
 |-----------|--------|------|---------|
 | DualMomentum | 0.493 | **54.9** | Edge a la limite de la significativite (juste au-dessus de 50%). Fenetre courte (2 ans) => estimation des moments bruitee, a confirmer sur une periode plus longue. |
-| RiskParity inverse-vol | 0.514 | 16.3 | Sharpe plus haut mais PSR faible : sur 10 ans, l'edge moyen est reel mais **statistiquement peu concluant** (estimation robuste d'un edge faible). |
+| RiskParity inverse-vol | 0.514 | 16.3 | Sharpe plus haut mais PSR faible : sur 10 ans, l'edge moyen est réel mais **statistiquement peu concluant** (estimation robuste d'un edge faible). |
 | ValueFactor | 0.227 | 0.8 | Quasi-zero : l'alpha observe est indistinguable du bruit. Confirme l'effondrement du facteur value sur une decennie dominee par la growth. |
-| OptionWheel | -0.51 | 0.0 | Aucun edge. La probabilite d'un vrai Sharpe positif est nulle. |
+| OptionWheel | -0.51 | 0.0 | Aucun edge. La probabilité d'un vrai Sharpe positif est nulle. |
 
 **Contraste cle** : Sharpe et PSR ne classent pas pareil. RiskParity bat DualMomentum en Sharpe (0.514 > 0.493) mais DualMomentum le bat largement en PSR (54.9 > 16.3). Le PSR est la statistique a citer, pas le Sharpe brut — premiere lecon de lecture critique.
 
@@ -414,7 +414,7 @@ Le `RiskParity inverse-vol` etudiant n'implemente pas du "vrai" risk parity. Deu
 ```text
    poids_i  proportionnel a  1 / sigma_i
 ```
-Chaque actif recoit un poids inverse a sa volatilite **individuelle**. Methode simple, une seule donnee par actif, mais elle **ignore les correlations**.
+Chaque actif recoit un poids inverse a sa volatilite **individuelle**. Methode simple, une seule donnée par actif, mais elle **ignore les correlations**.
 
 **Equal Risk Contribution (ERC)** — Maillard, Roncalli & Teiletche (2010), le "vrai" risk parity :
 
@@ -422,16 +422,16 @@ Chaque actif recoit un poids inverse a sa volatilite **individuelle**. Methode s
    chaque actif i contribue EGALEMENT au risque total :
    (Sigma * w)_i / (w' * Sigma * w)  =  constant   pour tout i
 ```
-ou `Sigma` est la **matrice de covariance** complete (correlations incluses). Resolution par programmation convexe (QP / Newton-Lagrange), sans solution analytique en general.
+ou `Sigma` est la **matrice de covariance** complete (correlations incluses). Résolution par programmation convexe (QP / Newton-Lagrange), sans solution analytique en general.
 
 **Pourquoi la difference compte** : avec l'inverse-vol naive, deux actifs **fortement correles** (ex. deux ETF actions US) reçoivent chacun un budget de risque eleve, donc le portefeuille reste **concentre sur un meme facteur** — faussement "diversifie". L'ERC, en integrant la covariance, **force une vraie diversification** : deux actifs correles se partagent un meme budget de risque cumule, pas deux budgets independants.
 
-**Pedagogique** : le `RiskParity inverse-vol` (Sharpe 0.514, PSR 16.3%) est un **bon point d'entree** — simple, robuste, peu de parametres. L'upgrade naturel est l'**ERC** (gestion des correlations via la matrice de covariance). Le saut conceptuel : passer de "donner moins de poids au plus volatile" (1D) a "egaliser la contribution marginale au risque" (matricielle, multidimensionnelle).
+**Pedagogique** : le `RiskParity inverse-vol` (Sharpe 0.514, PSR 16.3%) est un **bon point d'entrée** — simple, robuste, peu de paramètres. L'upgrade naturel est l'**ERC** (gestion des correlations via la matrice de covariance). Le saut conceptuel : passer de "donner moins de poids au plus volatile" (1D) a "egaliser la contribution marginale au risque" (matricielle, multidimensionnelle).
 
 #### 3. Lecture critique d'un backtest — les pieges visibles dans la table ci-dessus
 
 - **Dates de debut hardcoded** (`*` sur les 4) : les fenetres ne sont **pas aligned** avec le reste du catalogue (2018-2025). Les metriques ne sont pas directement comparables — comparer le Sharpe d'un DualMomentum 2023-2025 a un TrendFollowing 2018-2025 est abusif.
-- **MaxDD > 100% (OptionWheel, 103.5%)** : un drawdown superieur a 100% signale une vente d'options **naked non couverte** integrale — le simulateur ne capture pas parfaitement l'assignation / liquidation forcee. Le backtest est probablement **optimiste** sur la perte reelle.
+- **MaxDD > 100% (OptionWheel, 103.5%)** : un drawdown superieur a 100% signale une vente d'options **naked non couverte** integrale — le simulateur ne capture pas parfaitement l'assignation / liquidation forcee. Le backtest est probablement **optimiste** sur la perte réelle.
 - **Croiser PSR et duree** : un PSR de 54.9% sur 2 ans (DualMomentum) n'a pas le meme poids qu'un PSR de 81.8% sur 8 ans (TrendFollowing, ligne 381). La signification statistique croit avec `sqrt(T)` ; une courte fenetre a besoin d'un edge plus fort pour convaincre.
 
 #### References

--- a/docs/qc/quantconnect.md
+++ b/docs/qc/quantconnect.md
@@ -8,7 +8,7 @@ Le repo contient deja plusieurs documents canoniques. **Ne pas dupliquer ici** c
 
 | Document | Role | Source canonique de |
 |----------|------|---------------------|
-| [MyIA.AI.Notebooks/QuantConnect/README.md](../../MyIA.AI.Notebooks/QuantConnect/README.md) | Entree serie pedagogique | Catalog des 27+ notebooks Python, structure series |
+| [MyIA.AI.Notebooks/QuantConnect/README.md](../../MyIA.AI.Notebooks/QuantConnect/README.md) | Entrée serie pedagogique | Catalog des 27+ notebooks Python, structure series |
 | [MyIA.AI.Notebooks/QuantConnect/GETTING-STARTED.md](../../MyIA.AI.Notebooks/QuantConnect/GETTING-STARTED.md) | Setup utilisateur | Premiere prise en main QC + LEAN |
 | [MyIA.AI.Notebooks/QuantConnect/BOOK_MAPPING.md](../../MyIA.AI.Notebooks/QuantConnect/BOOK_MAPPING.md) | Mapping livre Jared | 63 exemples / 71 deliverables HandsOnAITradingBook -> nos notebooks/projects |
 | [MyIA.AI.Notebooks/QuantConnect/docs/HANDSON_AI_TRADING_MAPPING.md](../../MyIA.AI.Notebooks/QuantConnect/docs/HANDSON_AI_TRADING_MAPPING.md) | Mapping detaille Ch06 | 22 strategies ML du livre |
@@ -26,14 +26,14 @@ Le repo contient deja plusieurs documents canoniques. **Ne pas dupliquer ici** c
 
 ## Backtests obligatoires
 
-Toute modification d'une strategie QC (main.py, parametres, periodes) **DOIT** etre validee par un backtest :
+Toute modification d'une strategie QC (main.py, paramètres, periodes) **DOIT** etre validee par un backtest :
 
 1. `create_compile` pour verifier la compilation
 2. `create_backtest` pour lancer le backtest
 3. `read_backtest` pour recuperer les metriques (Sharpe, CAGR, MaxDD)
 4. Reporter les resultats dans le message de commit ET sur RooSync
 
-**Changer une date ou un parametre sans backtest = travail invalide.**
+**Changer une date ou un paramètre sans backtest = travail invalide.**
 
 ## QC Cloud API - Acces via MCP Docker (OBLIGATOIRE)
 
@@ -73,7 +73,7 @@ Le MCP Docker officiel charge un schema d'outils volumineux (~40k tokens). Pour 
 
 Outils exposes : `create_compile`, `read_compile`, `create_backtest`, `read_backtest` (Sharpe/CAGR/MaxDD), `list_backtests`, `list_projects`, `read_project`, `read_file`, `create_file`, `update_file_contents`. Auth = pattern QC v2 (`SHA256(token:timestamp)` + header `Basic userId:hash`). Rate limiting 10 appels/min applique in-process (meme limite fleet-wide).
 
-Config `.mcp.json` (remplace l'entree Docker `qc-mcp` ; secrets dans `.env` gitignore, **JAMAIS inline**) :
+Config `.mcp.json` (remplace l'entrée Docker `qc-mcp` ; secrets dans `.env` gitignore, **JAMAIS inline**) :
 
 ```json
 {
@@ -112,7 +112,7 @@ Verifier dans cet ordre :
 2. `.mcp.json` racine projet (config projet standard)
 3. Token valide sur QC (tester via API directe Python)
 
-**Fix recurrent** : supprimer l'entree `mcpServers.qc-mcp` de `~/.claude.json` pour que `.mcp.json` soit la seule source de verite.
+**Fix recurrent** : supprimer l'entrée `mcpServers.qc-mcp` de `~/.claude.json` pour que `.mcp.json` soit la seule source de verite.
 
 ## Organisations QC
 
@@ -231,7 +231,7 @@ Pattern standardise pour combiner plusieurs strategies dans un meme algo QC :
 8. **Vol window 60d > 20d** pour covariance min-var
 9. **Monthly + regime-change rebal > daily** : reduit trades 80%
 10. **Trail breakeven 3% > 4%** pour BTC daily
-11. **SMA50 >> SMA100 pour crypto** : SMA100 filtre les bonnes entrees bull
+11. **SMA50 >> SMA100 pour crypto** : SMA100 filtre les bonnes entrées bull
 12. **SL 6% minimum sur BTC daily** : 5% trop serre
 13. **OLS hedge ratio ne sauve pas pairs trading** : le probleme est les paires elles-memes
 14. **Fix structural bugs >> academic improvements** : leverage/risk mgmt > signal refinement

--- a/docs/reference/cluster-agents.md
+++ b/docs/reference/cluster-agents.md
@@ -8,7 +8,7 @@ Reference perenne sur la structure du cluster : machines, GPUs, workspaces RooSy
 |---------|----------------|------|-------------|
 | `myia-ai-01` | **Coordinateur** + tests universels + vLLM hosting + training BG GPU 2 + prover BG forensic | 3x RTX 4090 | 72 GB (3x 24) |
 | `myia-po-2023` | Hote services GenAI Image/Audio/Video (8 Docker services) | RTX 3080 + eGPU RTX 3090 | 40 GB (16 + 24) |
-| `myia-po-2024` | QC backtest + ML training (modeles <= 10M params) | RTX 3070 | 8 GB |
+| `myia-po-2024` | QC backtest + ML training (modèles <= 10M params) | RTX 3070 | 8 GB |
 | `myia-po-2025` | Tracks intensives ML/audits + workspace EPITA (3 agents) | RTX 3080 Ti laptop | 16 GB |
 | `myia-po-2026` | Lean prover + QC MCP + service embedding + reverse proxy `xx.myia.io` | RTX 3080 | 16 GB |
 
@@ -18,7 +18,7 @@ Reference perenne sur la structure du cluster : machines, GPUs, workspaces RooSy
 
 Cluster simplifie depuis 2026-05-15 : **un workspace `CoursIA` par machine**, sauf po-2025 qui a 3 agents distincts pour 3 workspaces dedies (CoursIA + 2 EPITA).
 
-| RooSync ID | Role | Capacite dispatch depuis ai-01 |
+| RooSync ID | Role | Capacité dispatch depuis ai-01 |
 |-----------|------|--------------------------------|
 | `myia-ai-01:CoursIA` | Coord + reviewer PR + merger + tests universels | (self) |
 | `myia-po-2023:CoursIA` | GenAI Image/Audio/Video + audit notebooks (Search/CSP/Sudoku) | OUI |
@@ -95,7 +95,7 @@ Si user dit "OK GPU heavy po-2025" : verifier qu'il connait l'incident avant d'a
 | `myia-po-2025:2026-Epita-Programmation-par-Contraintes` | Review/merge PRs etudiants PrCon | EN ATTENTE PRs etudiants |
 | `myia-po-2025:2026-Epita-Intelligence-Symbolique` | Veille sujets + enrichissement | ACTIF veille |
 
-**Skills cross-workspace tappables** : po-2025 developpe des skills specifiques par workspace, mais ai-01 peut tapper l'agent qui a deja la skill fraiche. Exemple : formulaire eval partenaire cree par `po-2025:2026-Epita-PrCon` plutot que `po-2025:CoursIA`, parce que PrCon avait fait des formulaires GWorkspace+Playwright le meme jour.
+**Skills cross-workspace tappables** : po-2025 developpe des skills spécifiques par workspace, mais ai-01 peut tapper l'agent qui a deja la skill fraiche. Exemple : formulaire eval partenaire cree par `po-2025:2026-Epita-PrCon` plutot que `po-2025:CoursIA`, parce que PrCon avait fait des formulaires GWorkspace+Playwright le meme jour.
 
 ## Specialisations infrastructure
 
@@ -118,15 +118,15 @@ Container embedding dedie sur po-2026. Tout agent peut consommer l'endpoint.
 
 ### Reverse proxy `xx.myia.io` -> po-2023
 
-Sous-domaines publics qui pointent vers les services GenAI de po-2023. Permet validation **bout-en-bout** des notebooks GenAI (auth bearer + timeouts + latences reelles client-side) en plus du test localhost de po-2023.
+Sous-domaines publics qui pointent vers les services GenAI de po-2023. Permet validation **bout-en-bout** des notebooks GenAI (auth bearer + timeouts + latences réelles client-side) en plus du test localhost de po-2023.
 
-**Sequence GenAI a 2 etapes** : po-2023 dev + test local, puis po-2026 (optionnel) re-validation via sous-domaine public. po-2026 intervient APRES po-2023, jamais a la place.
+**Sequence GenAI a 2 étapes** : po-2023 dev + test local, puis po-2026 (optionnel) re-validation via sous-domaine public. po-2026 intervient APRES po-2023, jamais a la place.
 
 ### QuantConnect MCP -> po-2024 + po-2026
 
 Tokens API QC configures dans `.mcp.json` sur les 2 machines (Docker MCP server `quantconnect/mcp-server`). Ils peuvent `create_compile` + `create_backtest` sur QC Cloud.
 
-**Polyvalence** : avoir le token QC ne signifie PAS perimetre exclusif. Ces agents peuvent etre dispatch sur n'importe quelle mission (audit, Lean, notebooks). Le token QC = capacite **supplementaire**.
+**Polyvalence** : avoir le token QC ne signifie PAS perimetre exclusif. Ces agents peuvent etre dispatch sur n'importe quelle mission (audit, Lean, notebooks). Le token QC = capacité **supplementaire**.
 
 **Contrainte rate limit** : MAX 10 appels API QC / minute entre **tous les agents**. Avant backtest, annonce obligatoire sur dashboard workspace CoursIA pour eviter contention.
 
@@ -161,7 +161,7 @@ Rotation cle API geree par po-2023 lui-meme. **NON consomme** dans workspace Cou
 
 ## Dispatch via Epic GitHub (sprints multi-stages)
 
-Pour tout sprint / curriculum >= 3 etapes, creer **Epic GitHub** + sub-issues numerotees AVANT de dispatcher. Les agents lisent l'issue, voient leur prochain step, livrent la PR liee, prennent le step suivant **sans re-demander la coord**.
+Pour tout sprint / curriculum >= 3 étapes, creer **Epic GitHub** + sub-issues numerotees AVANT de dispatcher. Les agents lisent l'issue, voient leur prochain step, livrent la PR liee, prennent le step suivant **sans re-demander la coord**.
 
 | Element | Format |
 |---------|--------|

--- a/docs/reference/kernels-runtime.md
+++ b/docs/reference/kernels-runtime.md
@@ -69,7 +69,7 @@ nohup "C:/Users/MYIA/miniconda3/envs/coursia-ml-training/python.exe" train_moe.p
 
 Sur ai-01, le Python 3.14 systeme est instable : scipy DLL corruption recurrente, conflits pip Python 3.12 vs 3.14, `~cipy/` residus apres force-reinstall rates. L'env Conda `coursia-ml-training` est l'env de reference stable pour le training ML, configure expressement avec PyTorch CUDA pour la RTX 4090.
 
-Incident 2026-05-06 : training MoE tente directement sur Python 3.14 systeme : `scipy DLL load failed` → `sklearn force-reinstall denied`. Resolution : utiliser l'env Conda dedie. D'ou la regle F (cf [env-python-reparation.md](env-python-reparation.md)).
+Incident 2026-05-06 : training MoE tente directement sur Python 3.14 systeme : `scipy DLL load failed` → `sklearn force-reinstall denied`. Résolution : utiliser l'env Conda dedie. D'ou la regle F (cf [env-python-reparation.md](env-python-reparation.md)).
 
 **Reflexe coordinateur** : avant tout dispatch ML training local, verifier que le script utilise `coursia-ml-training`. Si un agent rapporte un `ImportError` ML (sklearn, scipy, torch), premier debug = "tu as utilise l'env Conda `coursia-ml-training` ?".
 
@@ -167,7 +167,7 @@ Installation : `python SymbolicAI/SmartContracts/setup_env.py`.
 
 ### Autres machines (po-2023/24/26)
 
-Verifier qu'elles ont aussi un env Conda dedie ou un venv local equivalent. La memoire est specifique ai-01 mais le pattern (env dedie ML) est cluster-wide. Inventorier via `conda env list` sur chaque machine.
+Verifier qu'elles ont aussi un env Conda dedie ou un venv local equivalent. La memoire est spécifique ai-01 mais le pattern (env dedie ML) est cluster-wide. Inventorier via `conda env list` sur chaque machine.
 
 ### GenAI GPU stack : triton-windows + bitsandbytes
 
@@ -196,7 +196,7 @@ if os.path.isfile(os.path.join(base, "triton", "runtime", "tcc", "tcc.exe")):
 
 ## WSL kernels (Lean / GameTheory / OpenSpiel)
 
-Notebooks dans `GameTheory/` et `SymbolicAI/Lean/` requierent un kernel WSL specifique :
+Notebooks dans `GameTheory/` et `SymbolicAI/Lean/` requierent un kernel WSL spécifique :
 
 - `Python (GameTheory WSL + OpenSpiel)` pour GameTheory
 - `Python 3 (WSL)` ou `Lean 4 (WSL)` pour SymbolicAI/Lean
@@ -212,7 +212,7 @@ Le multi-agent Lean prover (`MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prove
 | Provider type | Comportement attendu | Quand utiliser |
 |---------------|----------------------|----------------|
 | **Powerful reasoning** (e.g. GLM-5.1) | Heavy thinking : ~99% des completion_tokens en `reasoning_content`. Necessite `max_tokens >= 8192` et `timeout >= 300s` par call. | Multi-step proof discovery, theoremes non-triviaux |
-| **Fast/modest** (e.g. Qwen3.6 local 35B-A3B) | Moins de thinking, plus rapide (~5s/293 tokens). | Validation lemma, sorry guard, etapes routine |
+| **Fast/modest** (e.g. Qwen3.6 local 35B-A3B) | Moins de thinking, plus rapide (~5s/293 tokens). | Validation lemma, sorry guard, étapes routine |
 | **Openrouter** (Sonnet/Gemma fallback) | Free tier rate-limited. | Backup powerful quand endpoint principal down |
 | **Anthropic direct** | Reserve si on ajoute un client natif (le framework actuel = `OpenAIChatCompletionClient` seul). | A activer ulterieurement |
 
@@ -225,9 +225,9 @@ Mapping avec `prover/config.py PROVIDERS` :
 
 **Pieges connus** :
 
-1. Modeles powerful reasoning separent `content` et `reasoning_content` dans la reponse JSON. Le framework `agent_framework_openai` gere via `Content.from_text_reasoning()`.
-2. `finish_reason: "length"` arrive vite si `max_tokens <= 2048` sur les modeles reasoning (toute la fenetre passe en reasoning).
-3. Verifier le nom exact du modele cote endpoint (changements silencieux possibles).
+1. Modèles powerful reasoning separent `content` et `reasoning_content` dans la reponse JSON. Le framework `agent_framework_openai` gere via `Content.from_text_reasoning()`.
+2. `finish_reason: "length"` arrive vite si `max_tokens <= 2048` sur les modèles reasoning (toute la fenetre passe en reasoning).
+3. Verifier le nom exact du modèle cote endpoint (changements silencieux possibles).
 4. Ports vLLM locaux 5001/5002 sur ai-01 = surveiller dispo (escalations Cycle 20). Preferer endpoint stable si flaky.
 
 ## Training wrapper checkpoints (ai-01)

--- a/docs/reference/notebook-formatting.md
+++ b/docs/reference/notebook-formatting.md
@@ -10,7 +10,7 @@ Source : mandat user 2026-06-23 (EPIC #3966). Les agents editent le markdown/cod
 - **Symptome a bannir** (`MULTI-H1`, `H1-DEEP`) : plusieurs H1 -> le vrai titre n'est plus visuellement distinct (« les titres sont difficilement visibles »).
 
 ### 1.2 Asides d'exercice : JAMAIS un heading
-Un **indice / objectif / etape / conseil / note / remarque / attention / TODO** ne doit **jamais** etre ecrit en `#` ou `##` : il apparaitrait dans la **plus grande police** alors qu'il doit etre discret (« les indices apparaissent comme les elements de police la plus grande alors que ca devrait etre l'inverse »).
+Un **indice / objectif / étape / conseil / note / remarque / attention / TODO** ne doit **jamais** etre ecrit en `#` ou `##` : il apparaitrait dans la **plus grande police** alors qu'il doit etre discret (« les indices apparaissent comme les elements de police la plus grande alors que ca devrait etre l'inverse »).
 
 | A bannir | A utiliser |
 |----------|-----------|
@@ -60,7 +60,7 @@ Le rendu notebook de `github.com/.../blob/...ipynb` est **React-virtualise** : s
 
 ## 4. Garde-fous (rollout)
 - **Scope typo strict** : changer le **niveau** d'un heading n'est pas changer le **contenu** pedagogique. Ne jamais en profiter pour resoudre/stubber/relabeler un exercice (cf [exercise-example-labeling.md](../../.claude/rules/exercise-example-labeling.md), [anti-regression.md](../../.claude/rules/anti-regression.md)).
-- **C.2** : modif markdown seule -> outputs precedents valides ; cellule code modifiee -> re-exec reelle, jamais scrub.
+- **C.2** : modif markdown seule -> outputs precedents valides ; cellule code modifiee -> re-exec réelle, jamais scrub.
 - **1 sujet par PR** (G.4/G.5) : rollout par famille / sous-lot, pas de composite.
 - **Verifier visuellement** apres fix, pas seulement relancer le scanner.
 

--- a/docs/reference/readme-series-gabarit.md
+++ b/docs/reference/readme-series-gabarit.md
@@ -2,7 +2,7 @@
 
 Canevas commun pour l'harmonisation des READMEs de series (niveau 1) et de sous-series (niveau 2), Partie 2 de l'issue #2651. Chaque element du gabarit est **derive d'un exemplaire existant** du depot (recensement des 37 READMEs, commentaire #2651) : rien n'est invente, on generalise ce qui marche deja.
 
-Le README principal du depot donne le ton de reference (registre sobre, ouverture par une question, pas de jugement de valeur editorial) ; les READMEs de series emmenent le lecteur **plus loin**, au plus pres du contenu reel des notebooks.
+Le README principal du depot donne le ton de reference (registre sobre, ouverture par une question, pas de jugement de valeur editorial) ; les READMEs de series emmenent le lecteur **plus loin**, au plus pres du contenu réel des notebooks.
 
 ---
 
@@ -19,7 +19,7 @@ Le README principal du depot donne le ton de reference (registre sobre, ouvertur
 | 6 | Parcours de progression / « Pourquoi cet ordre ? » | `GenAI/README.md:117-133` ; `Sudoku/README.md:170-231` | niveau 1 : oui |
 | 7 | Prerequis & environnement | `SymbolicAI/README.md:72-84` | oui |
 | 8 | Exercices (couverture) | `SymbolicAI/README.md:497-512` | si exercices |
-| 9 | Ponts cross-series (specifiques) | cf. anti-pattern 3 | optionnel |
+| 9 | Ponts cross-series (spécifiques) | cf. anti-pattern 3 | optionnel |
 | 10 | References | `GameTheory/README.md:421-459` | recommande |
 | 11 | FAQ (bornee) | cf. anti-pattern 4 | optionnel |
 
@@ -27,7 +27,7 @@ Le README principal du depot donne le ton de reference (registre sobre, ouvertur
 
 ### 1. Pitch
 
-Le fil rouge de la serie pose en une phrase, puis 1-2 phrases de cadrage. Modele : `Sudoku/README.md:1-10` (equilibre concision/information). Pas de bandeau de chiffres en ouverture : les decomptes exacts vivent dans le catalogue genere.
+Le fil rouge de la serie pose en une phrase, puis 1-2 phrases de cadrage. Modèle : `Sudoku/README.md:1-10` (equilibre concision/information). Pas de bandeau de chiffres en ouverture : les decomptes exacts vivent dans le catalogue genere.
 
 ### 2. Navigation
 
@@ -35,19 +35,19 @@ Une seule barre, en tete de fichier, sous le titre : lien parent + precedent + s
 
 ### 4. Objectifs d'apprentissage
 
-Numerotes, verbes d'action, en trois categories : techniques / methodologiques / applicatifs. Modele : `CaseStudies/README.md:81-105` (competences verifiables). Present dans 8 series sur 12 ; a creer pour RL, a normaliser pour GenAI et QuantConnect.
+Numerotes, verbes d'action, en trois categories : techniques / methodologiques / applicatifs. Modèle : `CaseStudies/README.md:81-105` (competences verifiables). Present dans 8 series sur 12 ; a creer pour RL, a normaliser pour GenAI et QuantConnect.
 
 ### 5. Table des notebooks
 
-Colonnes normalisees : `# | Notebook | Kernel | Contenu | Duree`. Modele : `GameTheory/README.md:64-105` (fil principal et side-tracks separes). Colonne optionnelle « Apport conceptuel » par notebook, differenciateur majeur de `Search/README.md:82-113` -- a generaliser quand la serie s'y prete. Les miroirs C#/Python (Sudoku) ou les phases (QuantConnect) restent des specificites legitimes : adapter les colonnes, pas les supprimer.
+Colonnes normalisees : `# | Notebook | Kernel | Contenu | Duree`. Modèle : `GameTheory/README.md:64-105` (fil principal et side-tracks separes). Colonne optionnelle « Apport conceptuel » par notebook, differenciateur majeur de `Search/README.md:82-113` -- a generaliser quand la serie s'y prete. Les miroirs C#/Python (Sudoku) ou les phases (QuantConnect) restent des specificites legitimes : adapter les colonnes, pas les supprimer.
 
 ### 6. Parcours de progression
 
-Profils de progression chiffres en heures (modele : `GenAI/README.md:117-133`, 4 profils 20h -> 120h+) ou encart « Pourquoi cet ordre ? » justifiant la sequence (modele : `Sudoku/README.md:170-231`).
+Profils de progression chiffres en heures (modèle : `GenAI/README.md:117-133`, 4 profils 20h -> 120h+) ou encart « Pourquoi cet ordre ? » justifiant la sequence (modèle : `Sudoku/README.md:170-231`).
 
 ### 7. Prerequis & environnement
 
-Tableau : Kernel / Env special / Packages / Cles API. Modele : `SymbolicAI/README.md:72-84`. Renvoyer au notebook de setup de la serie plutot que dupliquer les instructions d'installation du README principal.
+Tableau : Kernel / Env special / Packages / Cles API. Modèle : `SymbolicAI/README.md:72-84`. Renvoyer au notebook de setup de la serie plutot que dupliquer les instructions d'installation du README principal.
 
 ### 9. Ponts cross-series
 
@@ -55,7 +55,7 @@ Un pont doit nommer le notebook ou le concept precis **des deux cotes** (ex. : �
 
 ### 10. References
 
-References academiques avec couverture par notebook + bibliotheques + formalisations le cas echeant. Modele : `GameTheory/README.md:421-459`.
+References academiques avec couverture par notebook + bibliotheques + formalisations le cas echeant. Modèle : `GameTheory/README.md:421-459`.
 
 ---
 
@@ -83,5 +83,5 @@ Les blocs CATALOG-STATUS et `COURSE_CATALOG.generated.*` sont **bot-owned** : ja
 
 - **1 livrable par PR** : une serie, ou un petit lot coherent de 4-6 sous-series. Pas de composite.
 - **Conserver les specificites legitimes** de chaque serie (miroirs C#/Python, phases, sous-series) : le gabarit normalise la structure, pas le contenu.
-- **Cibles prioritaires (bimodalite niveau 2)** : remonter les stubs (`GenAI/CaseStudies` 61 lignes, `QuantConnect/projects` 86, `Search/Part1` 111) vers le gabarit ; reequilibrer les tres longs (`Probas/Infer` 1069 lignes) sans perte de contenu reel.
-- **Enrichissement** : rapprocher chaque entree de table du contenu reel du notebook (ce qu'il demontre, point cle), pour prolonger les intros du README principal.
+- **Cibles prioritaires (bimodalite niveau 2)** : remonter les stubs (`GenAI/CaseStudies` 61 lignes, `QuantConnect/projects` 86, `Search/Part1` 111) vers le gabarit ; reequilibrer les tres longs (`Probas/Infer` 1069 lignes) sans perte de contenu réel.
+- **Enrichissement** : rapprocher chaque entrée de table du contenu réel du notebook (ce qu'il demontre, point cle), pour prolonger les intros du README principal.


### PR DESCRIPTION
## Scope
Tranche : 10 live docs (75 hits scanned, 58 chars changed — diacritics only).

| File | Hits |
|------|------|
| docs/qc/qc-comparative-backtests.md | 12 |
| docs/reference/readme-series-gabarit.md | 12 |
| docs/qc/quantconnect.md | 6 |
| docs/reference/kernels-runtime.md | 7 |
| docs/reference/cluster-agents.md | 7 |
| docs/curriculum/ia-classique.md | 5 |
| docs/curriculum/genai.md | 5 |
| docs/genai/genai-services.md | 4 |
| docs/lean/llm-endpoints.md | 3 |
| docs/reference/notebook-formatting.md | 2 |

## Method
Masked-dictionary method (lesson #4502) :
- Mask escaped fences → fences → inlines → URLs
- Apply word-internal accent dict (case-aware, longest-first)
- Restore outer-first reverse mask depth

Dictionary : 37 entries (nouns + adjectives only, NO 3sg/pp verbs per lesson #4502).

## Exclusions (verified)
- `Resolution.DAILY` / `Resolution.Hour` QC API code → regex negative-lookbehind `.` → preserved
- `C# implementation`, `(C# implementation)` EN tech terms → excluded from dict
- `Real-ESRGAN` model name → `\b` boundary → preserved
- `## References` EN H2 headers → excluded from dict
- `Reference` EN column header → excluded from dict
- `reel` mid-equation `cout reel` (in MathJax context) → safe FR prose accent

## 4-gate validation
ALL PASS per file :
- G1 : deaccent(old) == deaccent(new)
- G2a : fences identical
- G2b : inline code identical
- G2c : link URLs + bare URLs identical
- G4 : no placeholder leaks

## Diff signature
`+58/-58` (perfectly balanced: only diacritics added, no char count change).

Refs #2876 (good first issue, accents manquants dans les docs francophones).
Co-Authored-By: Claude-Code <noreply@anthropic.com>