### PR TITLE
fix(qc): repair 9 broken inter-notebook links in QC subtree (#4788 tranche)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-29-ML-Ensemble <<](./QC-Py-29-ML-Ensemble.ipynb) | [Suivant : QC-Py-32-RL-DQN-Trading >>](./QC-Py-32-RL-DQN-Trading.ipynb)\n",
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-29-ML-Ensemble <<](./QC-Py-28-Market-Regime-Detection.ipynb) | [Suivant : QC-Py-32-RL-DQN-Trading >>](./QC-Py-32-RL-DQN-Trading.ipynb)\n",
     "\n",
     "# QC-Py-30 - LSTM Training Multi-Asset (GPU)\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# QC-Py-31 - Transformer Encoder Multi-Asset (GPU)\n",
     "\n",
-    "[< Retour au sommaire](../README.md) | [Suivant : DQN Training >](QC-Py-32-DQN-Training.ipynb)\n",
+    "[< Retour au sommaire](../README.md) | [Suivant : DQN Trading >](QC-Py-32-RL-DQN-Trading.ipynb)\n",
     "\n",
     "**Module** : Machine Learning pour le Trading - Modeles Transformer  \n",
     "**Pre-requis** : QC-Py-30 LSTM Training  \n",
@@ -3270,7 +3270,7 @@
     "\n",
     "---\n",
     "\n",
-    "[< Retour au sommaire](../README.md) | [Suivant : DQN Training >](QC-Py-32-DQN-Training.ipynb)"
+    "[< Retour au sommaire](../README.md) | [Suivant : DQN Trading >](QC-Py-32-RL-DQN-Trading.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
@@ -1054,8 +1054,8 @@
     "|----------|-------|------|\n",
     "| Cloud-02 | Classification ML (Random Forest) | [QC-Py-Cloud-02-ML-Classification.ipynb](QC-Py-Cloud-02-ML-Classification.ipynb) |\n",
     "| Cloud-03 | Risk Parity | [QC-Py-Cloud-03-Risk-Parity.ipynb](QC-Py-Cloud-03-Risk-Parity.ipynb) |\n",
-    "| Cloud-04 | RL Options Hedging | [QC-Py-Cloud-04-RL-Options.ipynb](QC-Py-Cloud-04-RL-Options.ipynb) |\n",
-    "| Cloud-05 | Multi-Asset Transformer | [QC-Py-Cloud-05-Transformer.ipynb](QC-Py-Cloud-05-Transformer.ipynb) |\n"
+    "| Cloud-04 | RL DQN Trading | [QC-Py-Cloud-04-RL-Options.ipynb](QC-Py-Cloud-04-RL-DQN-Trading.ipynb) |\n",
+    "| Cloud-05 | Regime Switching | [QC-Py-Cloud-05-Transformer.ipynb](QC-Py-Cloud-05-RegimeSwitching.ipynb) |\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-ML-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-ML-Classification.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# QC-Py-Cloud-02 : Classification de Texte et Sentiment NLP\n",
     "\n",
-    "[< Retour au sommaire](./QC-Py-00-Sommaire.ipynb) | [Suivant : Risk Parity >](./QC-Py-Cloud-03-Risk-Parity.ipynb)\n",
+    "[< Retour au sommaire](../README.md) | [Suivant : Risk Parity >](./QC-Py-Cloud-03-Risk-Parity.ipynb)\n",
     "\n",
     "**Niveau** : Intermediaire | **Duree estimee** : 30 min | **Kernel** : Python 3\n",
     "\n",
@@ -679,7 +679,7 @@
     "| RSI / EMA | Indicators API | Signal technique |\n",
     "| Rebalancement | `Schedule.On()` | Execution hebdomadaire |\n",
     "\n",
-    "[< Retour au sommaire](./QC-Py-00-Sommaire.ipynb) | [Suivant : Risk Parity >](./QC-Py-Cloud-03-Risk-Parity.ipynb)"
+    "[< Retour au sommaire](../README.md) | [Suivant : Risk Parity >](./QC-Py-Cloud-03-Risk-Parity.ipynb)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# QC-Py-Cloud-05 : Prevision par Reseau de Neurones (MLP)\n",
     "\n",
-    "[< RL DQN](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | [Retour au sommaire](./QC-Py-00-Sommaire.ipynb)\n",
+    "[< RL DQN](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | [Retour au sommaire](../README.md)\n",
     "\n",
     "**Niveau** : Avance | **Duree estimee** : 30 min | **Kernel** : Python 3\n",
     "\n",
@@ -659,7 +659,7 @@
     "| Re-entrainement | `Schedule.month_start` | Mensuel sur fenetre 252j |\n",
     "| Selection | Seuil P>0.52 | Top-N avec min positions |\n",
     "\n",
-    "[RL DQN <](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | [Retour au sommaire](./QC-Py-00-Sommaire.ipynb)"
+    "[RL DQN <](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | [Retour au sommaire](../README.md)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_composite_ff_aw.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_composite_ff_aw.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Composite FamaFrench + AllWeather — Factor-Hedged Strategy Research\n",
     "\n",
-    "> **Strategy #44** | [RL-1 Q-Learning](research_rl_tabular.ipynb) · [RL-2 PPO](research_rl_ppo.ipynb) · [RL-3 Reward Shaping](research_rl_reward_shaping.ipynb) · [RL-4 Multi-Asset](research_rl_multi_asset.ipynb) · [RL-5 Overlay](research_rl_tactical_overlay.ipynb) · [RL-6 GRPO](research_rl_grpo.ipynb) · **Composite FF+AW**\n",
+    "> **Strategy #44** | [RL-1 Q-Learning](research_rl_intro.ipynb) · [RL-2 PPO](research_rl_ppo.ipynb) · [RL-3 Reward Shaping](research_rl_reward_shaping.ipynb) · [RL-4 Multi-Asset](research_rl_multi_asset.ipynb) · [RL-5 Overlay](research_rl_tactical_overlay.ipynb) · [RL-6 GRPO](research_rl_grpo.ipynb) · **Composite FF+AW**\n",
     "\n",
     "## Objectifs\n",
     "- Combiner **FamaFrench factor rotation** (VLUE/MTUM/SIZE/QUAL/USMV) avec le socle defensif **AllWeather** (SPY/IEF/GLD/XLP)\n",

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_rl_grpo.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_rl_grpo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# RL-6 : GRPO — Group Relative Policy Optimization pour le Trading\n",
     "\n",
-    "> **Série RL for Trading (#1461)** | [RL-1 Q-Learning](research_rl_tabular.ipynb) · [RL-2 PPO](research_rl_ppo.ipynb) · [RL-3 Reward Shaping](research_rl_reward_shaping.ipynb) · [RL-4 Multi-Asset](research_rl_multi_asset.ipynb) · [RL-5 Overlay](research_rl_tactical_overlay.ipynb) · **RL-6 GRPO**\n",
+    "> **Série RL for Trading (#1461)** | [RL-1 Q-Learning](research_rl_intro.ipynb) · [RL-2 PPO](research_rl_ppo.ipynb) · [RL-3 Reward Shaping](research_rl_reward_shaping.ipynb) · [RL-4 Multi-Asset](research_rl_multi_asset.ipynb) · [RL-5 Overlay](research_rl_tactical_overlay.ipynb) · **RL-6 GRPO**\n",
     "\n",
     "## Objectifs\n",
     "- Implémenter **GRPO** (Group Relative Policy Optimization), l'algorithme clé de DeepSeek-R1\n",

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_rl_tactical_overlay.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_rl_tactical_overlay.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# RL-5 : Tactical Overlay — RL sur B&H\n",
     "\n",
-    "> **Série RL for Trading (#1461)** | [RL-1 Q-Learning](research_rl_tabular.ipynb) · [RL-2 PPO](research_rl_ppo.ipynb) · [RL-3 Reward Shaping](research_rl_reward_shaping.ipynb) · [RL-4 Multi-Asset](research_rl_multi_asset.ipynb) · **RL-5 Tactical Overlay**\n",
+    "> **Série RL for Trading (#1461)** | [RL-1 Q-Learning](research_rl_intro.ipynb) · [RL-2 PPO](research_rl_ppo.ipynb) · [RL-3 Reward Shaping](research_rl_reward_shaping.ipynb) · [RL-4 Multi-Asset](research_rl_multi_asset.ipynb) · **RL-5 Tactical Overlay**\n",
     "\n",
     "## Objectifs\n",
     "- Utiliser un agent RL comme **couche tactique** au-dessus d'un portefeuille B&H equal-weight\n",


### PR DESCRIPTION
## Scope
Tranche : QC subtree only (excludes GenAI already #4860, ML/IIT/Search/RL/Probas with 0 broken). 8 notebooks, +12/-12.

## Mapping (verified by `ls` vs actual filenames)

| Notebook | Old (broken) | New (verified) |
|----------|--------------|----------------|
| QC-Py-30-LSTM-Training | `QC-Py-29-ML-Ensemble` | `QC-Py-28-Market-Regime-Detection` (skip deleted L29) |
| QC-Py-31-Transformer-Training | `QC-Py-32-DQN-Training` | `QC-Py-32-RL-DQN-Trading` (actual filename) |
| QC-Py-Cloud-01-FinBERT-Sentiment | `QC-Py-Cloud-04-RL-Options` + label "RL Options Hedging" | `QC-Py-Cloud-04-RL-DQN-Trading` + label "RL DQN Trading" |
| QC-Py-Cloud-01-FinBERT-Sentiment | `QC-Py-Cloud-05-Transformer` + label "Multi-Asset Transformer" | `QC-Py-Cloud-05-RegimeSwitching` + label "Regime Switching" |
| QC-Py-Cloud-02-ML-Classification | `./QC-Py-00-Sommaire` (×2 cells) | `../README.md` (real sommaire) |
| QC-Py-Cloud-05-MLP-Forecasting | `./QC-Py-00-Sommaire` (×2 cells) | `../README.md` (real sommaire) |
| research/research_composite_ff_aw | `research_rl_tabular` | `research_rl_intro` |
| research/research_rl_grpo | `research_rl_tabular` | `research_rl_intro` |
| research/research_rl_tactical_overlay | `research_rl_tabular` | `research_rl_intro` |

## Cell-preservation (anti-régression C.2)
8/8 files : `cells == cells` AND `execution_count == execution_count` AND `outputs == outputs`.

## Out-of-scope (separate issue)
3 stale ladder links in `ML-Training-Pipeline/research_l4_decision_transformer.ipynb` pointing to a `research/` subdir that was flattened (`research_l1_tsmom`, `research_l2_dual_momentum`, `research_l3_trend` notebooks don't exist). **Needs new notebooks created, not just link fix** — separate PR.

## Comparison with #4860 (GenAI tranche)
- Same author + same family tranche pattern (#4788 cross-famille self-serve pool)
- Same script-based fix approach (substring replace + 4-gate validation)
- This tranche has more nuanced label-text co-fixes (Cloud-01 RL-Options/Transformer labels were misleading; updated to match actual notebook titles)

Refs #4788 (cross-famille self-serve pool, atomic tranche per family).
Co-Authored-By: Claude-Code <noreply@anthropic.com>