### PR TITLE
fix(qc): restore French diacritics in Options-VGT README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Options-VGT/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Options-VGT/README.md
@@ -1,12 +1,12 @@
 # Trading Options sur VGT Equities (ID: 21113806)
 
-Strategie d'options (PUTs/CALLs) sur 5 valeurs tech (NVDA, ORCL, CSCO, AMD, QCOM).
+Stratégie d'options (PUTs/CALLs) sur 5 valeurs tech (NVDA, ORCL, CSCO, AMD, QCOM).
 
 ## Architecture
-- `main.py` - Wheel strategy multi-equity avec seuils OTM personnalises
+- `main.py` - Wheel strategy multi-equity avec seuils OTM personnalisés
 - `essai_pour_voir.ipynb` - Exploration options chains et distributions
 
-## Concepts enseignes
+## Concepts enseignés
 - Options trading (PUT selling, covered CALL)
-- OTM threshold personnalise par actif
+- OTM threshold personnalisé par actif
 - Exposure validation et cash-secured positions


### PR DESCRIPTION
## Summary

Restore French diacritics in `MyIA.AI.Notebooks/QuantConnect/projects/Options-VGT/README.md` (4 corrections across 4 lines). Part of issue #2876.

## Methodology

Round-trip guard (po-2025 PR #4500): each replacement verifies `strip_accents(accented).lower() == bare.lower()`. We only **add** diacritics; we never change a letter.

## Corrections applied

| Bare | Accented | Count |
|------|----------|-------|
| Strategie | Stratégie | 1 |
| personnalises | personnalisés | 1 |
| enseignes | enseignés | 1 |
| personnalise | personnalisé | 1 |

Total: 4 replacements.

## Skipped (preserved verbatim)

- Inline code backticks (`` `main.py` ``, `` `essai_pour_voir.ipynb` ``)
- English terminology (`Wheel strategy`, `OTM`, `threshold`, `PUTs/CALLs`, `tech`, `NVDA ORCL CSCO AMD QCOM`)
- No code blocks, no link targets, no URLs, no CATALOG-STATUS markers in this file
- LF line endings preserved

## Scope

- **1 file modified** (atomic)
- **4 lines changed** (+/-)
- **0 code, 0 catalog markers, 0 GenAI** touched
- No content/structure changes - only accent insertion

## Verification

- Round-trip guard: 4 distinct forms verified, 4 total replacements
- Manual review: each line context checked (preserved backticks and EN terminology intact)
- Line endings: LF (git diff displays clean)
- Same methodology as #4844 (Alpha), #4846 (CTG-Momentum), #4851 (Trend-Following) all MERGED clean

## Context

5th tranche #2876 this session, **5th distinct QC project** (Options-VGT — options trading on VGT equities, ID: 21113806) for lane diversity within the QC family. Different from #4844 (Alpha), #4846 (CTG-Momentum), #4851 (Trend-Following). All 5 PRs are atomic, single-file, 3-16 corrections each, demonstrating the round-trip guard works on heterogeneous forms and project types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>