### PR TITLE
docs(search): resync MGS arc 18->19 + Kudela typo in root README (See #3973, See #1203)

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -111,7 +111,7 @@ Chaque notebook introduit un concept ou algorithme spécifique. Le tableau ci-de
 
 Side track C# .NET 9 (cf. [Search-5](Part1-Foundations/Search-5-GeneticAlgorithms.ipynb), [Search-11](Part1-Foundations/Search-11-Metaheuristics.ipynb)) : reconstruire et **composer** les métaheuristiques au-dessus de GeneticSharp plutôt que d'en importer une boîte noire.
 
-La série se lit en trois temps : **MGS-1 à 7** bâtissent le moteur et la grammaire de composition (jusqu'aux composés publiés et au TSP) ; **MGS-8 à 14** visualisent les paysages de fitness et mesurent la robustesse aux biais des bancs CEC (décalage, rotation, synergie d'îles) ; **MGS-15 à 18** referment la série sur l'**analyse quantitative de paysage** et la **méta-stratégie** — choisir l'optimiseur selon le paysage (No-Free-Lunch), adapter ses paramètres en cours de route, et confronter le portefeuille au protocole CEC complet.
+La série se lit en quatre temps : **MGS-1 à 7** bâtissent le moteur et la grammaire de composition (jusqu'aux composés publiés et au TSP) ; **MGS-8 à 14** visualisent les paysages de fitness et mesurent la robustesse aux biais des bancs CEC (décalage, rotation, synergie d'îles) ; **MGS-15 à 18** referment la série sur l'**analyse quantitative de paysage** et la **méta-stratégie** — choisir l'optimiseur selon le paysage (No-Free-Lunch), adapter ses paramètres en cours de route, et confronter le portefeuille au protocole CEC complet ; **MGS-19** prolonge la thèse « composants > métaphores » jusqu'au **démontage** — extraire l'opérateur de Metropolis du recuit simulé et l'éprouver seul sur un GA, pour vérifier que le bénéfice du recuit tient au couplage perturbation+acceptation, pas à l'acceptation seule.
 
 | # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
@@ -124,7 +124,7 @@ La série se lit en trois temps : **MGS-1 à 7** bâtissent le moteur et la gram
 | 7 | MGS-7 TSP | Grammaire agnostique à la représentation (permutation, `OrderedCrossover`) |
 | 8 | MGS-8 LandscapeExplorer | Visualiser la surface de fitness (heatmaps, trajectoire de convergence) |
 | 9 | MGS-9 EverestRelief | Relief terrestre réel comme paysage de fitness (DEM, flipbook) |
-| 10 | MGS-10 CenterBias | Biais central vs robustesse au déplacement (banc Kudella 2022) |
+| 10 | MGS-10 CenterBias | Biais central vs robustesse au déplacement (banc Kudela 2022) |
 | 11 | MGS-11 IslandSynergy | Synergie d'îles complémentaires (verdict mesuré) |
 | 12 | MGS-12 AxisAlignment | Biais d'alignement d'axes (rotation) |
 | 13 | MGS-13 LandscapeDebias | Pourquoi la rotation casse la séparabilité (visuel) |
@@ -133,6 +133,7 @@ La série se lit en trois temps : **MGS-1 à 7** bâtissent le moteur et la gram
 | 16 | MGS-16 AlgorithmSelection | No-Free-Lunch (Wolpert & Macready 1997) + cadre de Rice : features de paysage → recommandation d'optimiseur, validée sur un paysage inconnu (Rosenbrock) |
 | 17 | MGS-17 ParameterControl | Adapter les paramètres *pendant* la course (taxonomie d'Eiben : réglage vs contrôle) — la seconde réponse au No-Free-Lunch |
 | 18 | MGS-18 CecBanc | Banc CEC consolidé : combiner décalage (MGS-10) et rotation (MGS-12) — robuste à chaque biais séparément l'est-il au biais combiné ? |
+| 19 | [MGS-19 MetropolisReinsertion](Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb) | Démontage du recuit simulé : isoler `MetropolisReinsertion` du compound `SimulatedAnnealing` et le greffer seul sur un GA — verdict honnête négatif, le bénéfice du recuit tient au couplage perturbation+acceptation |
 
 ### Applications
 


### PR DESCRIPTION
## Résumé

Tranche **feuilles MGS #3973 partition po-2024:CoursIA-2** : resynchronisation de la prose d'arc de la **Partie 4 (métaheuristiques composables)** du `Search/README.md` racine, qui était restée à **18 notebooks** après l'ajout de MGS-19 (PR #4683 MERGED). Suite logique de mon C136 (accents FR tranche GameTheory+SymbolicAI), avec pivot de cible dicté par ai-01 TASK 03:36Z (« alternance = feuilles MGS, partition #3973 »).

## Pourquoi ce fix

PR #4686 (jsboige, MERGED 2026-07-01) a corrigé deux counts en dur laissés à 18 par mon PR #4683 (MGS-19 création) :
- `Search/Part4-Metaheuristics/README.md` L40 « dix-huit » → « dix-neuf »
- `Search/README.md` L447 arbre (MGS-1..18 → MGS-1..19)

Mais **trois artéfacts de prose** étaient restés à 18 dans `Search/README.md` :

| Ligne | Avant | Impact |
|-------|-------|--------|
| L114 | « se lit en **trois temps** : MGS-1..7 / MGS-8..14 / MGS-15..**18** referment » | Arc narratif stoppé à 18 ; MGS-19 invisible côté racine alors qu'il est explicitement listé côté Part4 (Mermaid 10 vagues, L66-80 Part4 README) |
| L127 | « banc **Kudella** 2022 » | Typo référence — Kudela 2022 correct (Part4 README L123 + L235) |
| L135 | Table avec dernière ligne `18 | MGS-18 CecBanc | …` | MGS-19 absent du sommaire racine alors que toutes les autres vagues y sont |

## Méthode

Scan ciblé `grep -nE "MGS-[0-9]+|19 (notebooks|nb)|Kudella|Kudela"` sur `Search/README.md`. Croisement avec `Part4-Metaheuristics/README.md` qui contient le Mermaid arc complet (10 vagues) — la source de vérité.

### Triage des faux positifs exclus

| Mention | Raison exclusion |
|---------|------------------|
| L6 marqueur `CATALOG-STATUS` (`breakdown: Part4-Metaheuristics=19`) | **Artefact généré** appartenant à l'automatisation — cron `catalog-cron.yml` + CI `catalog-drift.yml`. NE PAS régénérer sur une branche (cf `catalog-pr-hygiene.md` HARD 1). |
| L456 arbre « 19 notebooks MGS-1..19 » | **Déjà à jour** (cf PR #4686 MERGED). Pas de drift. |
| L16 « Partie 4 — métaheuristiques composables au-dessus de GeneticSharp » | Phrase générique, aucun compte en dur. |
| L214 « Partie 4 / Side track C# .NET 9 » | Phrase générique. |
| L550 « Partie 4 — métaheuristiques composables (C# .NET 9, MetaGeneticSharp) » | Phrase générique. |

## Scope (3 ins / 2 outs)

| Fichier | Ligne | Changement |
|---------|-------|-----------|
| `MyIA.AI.Notebooks/Search/README.md` | L114 | « trois temps » → « quatre temps » + phrase MGS-19 décrivant le démontage du recuit simulé (composants > métaphores dans sa forme la plus exigeante) |
| `MyIA.AI.Notebooks/Search/README.md` | L127 | typo « Kudella » → « Kudela » |
| `MyIA.AI.Notebooks/Search/README.md` | L135 | nouvelle ligne `\| 19 \| [MGS-19 MetropolisReinsertion](Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb) \| …` |

## Vérifications

- `git diff --stat` : 1 fichier, +3/-2, scope strict #3973 feuilles MGS.
- **Aucun regen catalogue** (cf `catalog-pr-hygiene` HARD rule) — `Part4-Metaheuristics=19` byte-identique à `main`.
- **Aucun submodule bump** (HARD submodule-drift #3103) — `MetaGeneticSharp` reste à `1ea0399` (HEAD origin).
- Branche fresh off `origin/main` post-#4883 merge (`25dd81070`).
- **Round-trip / cohérence** : nouvelle ligne MGS-19 alignée sur le format des 18 lignes précédentes (description condensée, ref au fork quand pertinent, lien hypertexte vers le notebook). Le seul écart mineur = ajout du lien hypertexte (`[MGS-19 MetropolisReinsertion](…)`) là où les 18 lignes précédentes ne linkaient pas — choix explicite pour rendre le sommaire racine navigable, dans l'esprit de #3973 (« chaque README feuille reflète l'état réel »).
- **Anti-regression** : aucune cellule `# Solution` / `# Exemple résolu` touchée, aucune fonction de code touchée, aucune preuve formelle touchée (cf `anti-regression.md`).

## Lien

- Voir **#3973** (Epic parente : feuilles README ascendant → resynchroniser la hiérarchie sur l'évolution du dépôt).
- Voir **#1203** (Epic MGS parente).
- Voir PR **#4686** (jsboige, MERGED 2026-07-01) qui a corrigé les counts L40 + L447 ; ce PR-ci **complète** le resync pour la prose d'arc racine + table sommaire + typo.

## Anti-tunneling R5.4b

C133 = Probas/Infer, C134 = QC+Search, C135 = SmartContracts tranche 1, C136 = GameTheory+SymbolicAI tranche 2, **C137 = Search racine MGS-19 resync** = retour sur partition .NET/Search après 4 tranches #2876 cross-famille. Rotation effective (5 cycles, 5 partitions distinctes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)