### PR TITLE
docs(qc): complete ML-Training-Pipeline README classification table (#3976)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -13,6 +13,12 @@ Les notebooks de ce répertoire sont des **recherches indépendantes (c)** — a
 | `research_what_dl_can_predict.ipynb` | Ce que le DL peut prédire en finance | (c) |
 | `research_l4_decision_transformer.ipynb` | Évaluation Decision Transformer | (c) |
 | `hmm_alpha_research.ipynb` | HMM gaussien pour alpha trading (Broad Ch6 Ex4) | (c) |
+| `m4_dlinear_vol_research.ipynb` | DLinear-vol : DL linéaire vs HAR (prévisions pures) | (c) |
+| `m5_hmm_regime_research.ipynb` | HMM regime-switching HAR : quand la sophistication structurelle nuit | (c) |
+| `m9_tft_vol_research.ipynb` | TFT (Temporal Fusion Transformer) : l'échec du surparamétrage | (c) |
+| `m11e_ensemble_research.ipynb` | Ensemble HAR-Kelly : la dilution confirmée (3e axe d'échec) | (c) |
+| `m12_har_rv_j_research.ipynb` | HAR-RV-J : décomposition de sauts (Andersen-Bollerslev-Diebold 2007) | (c) |
+| `m15_lstm_rv_research.ipynb` | Log-LSTM RV : mémoire séquentielle pour la variance réalisée | (c) |
 
 Classification complète : [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md)
 


### PR DESCRIPTION
## Summary

First slice of **#3976** (QuantConnect feuilles, Epic #3973 ascending README resync). The `ML-Training-Pipeline/README.md` "Classification type (c)" table listed **5** standalone-research notebooks, but **11 canonical `.ipynb`** exist on disk (verified `find`). Add the **6 missing** so readers discover them from the top-level table.

## Scope — 6 additions, single file

| Notebook (added) | Sujet (verbatim from notebook title) |
|---|---|
| `m4_dlinear_vol_research.ipynb` | DLinear-vol : DL linéaire vs HAR (prévisions pures) |
| `m5_hmm_regime_research.ipynb` | HMM regime-switching HAR : quand la sophistication structurelle nuit |
| `m9_tft_vol_research.ipynb` | TFT (Temporal Fusion Transformer) : l'échec du surparamétrage |
| `m11e_ensemble_research.ipynb` | Ensemble HAR-Kelly : la dilution confirmée (3e axe d'échec) |
| `m12_har_rv_j_research.ipynb` | HAR-RV-J : décomposition de sauts (Andersen-Bollerslev-Diebold 2007) |
| `m15_lstm_rv_research.ipynb` | Log-LSTM RV : mémoire séquentielle pour la variance réalisée |

## Verification (G.1)

- `find ML-Training-Pipeline -maxdepth 1 -name "*.ipynb"` = **11** canonical (excl. `_output` variants) — table now lists all 11.
- **Sujet descriptions taken verbatim from each notebook's first markdown title cell** (not invented) — concise + FR-accented to match the 5 existing rows.
- These notebooks were already referenced indirectly in the Curriculum V2 keeper tables (M12, M15 = S1 keepers) — this makes them discoverable at the classification table too.
- **No `CATALOG-STATUS` markers** in this file (`grep -c` = 0) → zero catalog-drift risk.
- FR-first (rule #3871): new prose in FR with accents.

## Method

Audit-driven: delegated the read-heavy recensement to the `readme-hierarchy-auditor` subagent (sonnet), which ranked ML-Training-Pipeline as the #1 first-slice candidate (concrete undeniably-stale table, atomic, no catalog risk). Cross-checked the pivot counts firsthand (`find` = 11, table = 5) before editing — angles morts of delegated counting.

Issue #3976 **remains OPEN**: other sub-areas pending (Python/ L17-vs-L88 count contradiction, partner-course gaps, projects/ 116→113, root README 21-vs-36 baselines + missing sub-sections).

See #3976
Part of #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
