### PR TITLE
docs(qc): fix stale notebook count in Python README footnote (#3976)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -14,7 +14,7 @@ Supports de cours pour l'apprentissage du trading algorithmique avec QuantConnec
 | **(c)** standalone research | 6 | Local yfinance/sklearn training |
 | **(d)** pedagogical placeholder | 33 | Course material with embedded QCAlgorithm strings |
 
-> Récapitulatif : 16+2+6+33 = 57 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **51** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md) pour la classification détaillée.
+> Récapitulatif : 16+2+6+33 = 57 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **53** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md) pour la classification détaillée.
 
 Full classification: [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md)
 


### PR DESCRIPTION
## Summary

Rank-3 slice of **#3976** (QuantConnect feuilles, Epic #3973). Fixes an internal contradiction in `QuantConnect/Python/README.md`:
- **L17** (4-Type Classification footnote): "Le nombre total de fichiers `.ipynb` dans le dossier est **51**"
- **L88** (execution-status récapitulatif): "53 notebooks total"

L88 was already correct (realigned in PR #4826, 2026-07-02 audit); L17's count was left stale. This PR makes them consistent at **53**.

## Verification (G.1)

- `find Python -maxdepth 1 -name "*.ipynb" -not -name "*_output*"` = **53** canonical (61 incl. `_output` variants).
- Overlap arithmetic still holds: 57 classification entries (16+2+6+33) − 53 files = 4 notebooks in two categories.
- Post-fix consistency check: `**53**` now appears on both L17 and L88; no stale `**51**` remains.

## Method

Audit-driven (subagent `readme-hierarchy-auditor` ranked this Rank 3: "small, focused, internal contradiction"). Cross-checked the pivot count firsthand (`find` = 53) before editing.

Per ai-01 directive "1 PR atomique par sous-zone", Python/ is its own PR (not bundled with projects/ 116→113). Issue #3976 remains OPEN (partner-course, projects/, root README pending).

See #3976
Part of #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
