### PR TITLE
docs(qc): fix internal contradiction in baseline count (#3976)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -492,7 +492,7 @@ Le **fil rouge** de la série : un Sharpe spectaculaire en backtest court est pr
 - **Les stars du catalogue ne survivent pas toutes à l'alignement** : PuppiesOfTheDow (1.99 → 0.302) et HighBookToMarketFScore (2.09 → 0.411) s'effondrent sur 2018-2025 — leurs Sharpe catalogue venaient d'une fenêtre glissante non standardisée.
 - **Crypto = diversification stable** : MaxDD maitrisé (~17%), rendement modéré.
 
-> Voir [docs/qc/qc-comparative-backtests.md](../../docs/qc/qc-comparative-backtests.md) pour les 21 baselines vérifiées, les comparaisons best-vs-aligned, et les diagnostics détaillés (See #1630).
+> Voir [docs/qc/qc-comparative-backtests.md](../../docs/qc/qc-comparative-backtests.md) pour les 36 baselines vérifiées, les comparaisons best-vs-aligned, et les diagnostics détaillés (See #1630).
 
 ---
 


### PR DESCRIPTION
## Summary

Rank-4 slice of **#3976** (QuantConnect feuilles, Epic #3973). Resolves an internal contradiction in `QuantConnect/README.md` on the number of verified baselines:

| Line | Before | After |
|------|--------|-------|
| L495 | "les **21** baselines vérifiées" | "les **36** baselines vérifiées" |
| L523 | "Le catalogue de **36** baselines vérifiées" | (unchanged) |
| L532 | "les **36** baselines vérifiées" | (unchanged) |

All three reference the same catalog (`docs/qc/qc-comparative-backtests.md`). Two of three already said 36; the third (L495) was stale (pre-#1630-campaign count).

## Verification (G.1)

- **Majority + external corroboration**: L523/L532 say 36; `projects/README.md` L65 confirms "#1630 campaign re-vérifié 36+ de ces stratégies sous frais IBKR réels". So 36 is the post-campaign count; 21 is the pre-campaign stale value.
- This is a **minority-alignment** fix (1 occurrence aligned to the 2-occurrence majority + corroboration), not a count derived from re-tallying the catalog file.
- Post-fix consistency: `**36** baselines vérifiées` now at L495/L523/L532; no stale `21 baseline` remains.

## Out of scope (NOT touched — deliberate)

- **`115 stratégies` (L211)**: QC root says 115, partner-course README says 116, local subdirs = 114, main.py = 101. Ground truth (deployed QC Cloud count) is ambiguous — fixing without QC Cloud API verification risks introducing drift in the wrong direction. Needs separate verification.
- **dead `archive-2025/` reference (L258/L271)**: references `partner-course-quant-trading/archive-2025/` which does not exist on disk. Needs git investigation (moved/renamed vs genuinely deleted) — separate issue.

## Catalog hygiene

CATALOG-STATUS markers (L3-8) left **byte-identical** to `origin/main` (verified: `git diff` shows 0 catalog-marker lines changed). Per [catalog-pr-hygiene](../../blob/main/.claude/rules/catalog-pr-hygiene.md) Regle 1, the catalog is automation property — never regenerated on a branch. Branch created fresh from `origin/main` (Regle 2).

See #3976
Part of #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
