### PR TITLE
fix(prover): forensic FX-1..FX-3 — honest verify wrapper, conditional leanexplore, canonical result_kind

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
@@ -43,18 +43,26 @@ def create_search_agent(tools: SearchTools, provider: str = "local",
                         goal: str = "", name: str = "SearchAgent") -> Agent:
     """SearchAgent: finds Mathlib lemmas. Uses fast local model."""
     client = create_client(provider, model_key="fast")
+    # Forensic #1453 (2026-07-02, traces L849/L180): when the lean-explore
+    # client is not installed, search_leanexplore is a 0.0s no-op — yet the
+    # agent invoked it 11x/5x per run (span noise + one LLM decision each).
+    # Probe availability once (cached module-global) and only register the
+    # tool when it can actually answer.
+    from .tools import _get_leanexplore_client
+    _, _le_available = _get_leanexplore_client()
+    agent_tools = [
+        tools.search_mathlib_lemmas,
+        *([tools.search_leanexplore] if _le_available else []),
+        tools.lookup_proven_pattern,
+        tools.get_proof_state,
+        tools.add_discovered_lemma,
+        tools.file_read_lines,
+        tools.file_load,
+    ]
     return Agent(
         client=client,
         instructions=augment_instructions(SEARCH_AGENT_INSTRUCTIONS, goal=goal),
-        tools=[
-            tools.search_mathlib_lemmas,
-            tools.search_leanexplore,
-            tools.lookup_proven_pattern,
-            tools.get_proof_state,
-            tools.add_discovered_lemma,
-            tools.file_read_lines,
-            tools.file_load,
-        ],
+        tools=agent_tools,
         name=name,
         default_options=_fast_options(),
     )

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -86,6 +86,7 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
             "original_sorry": 0,
             "final_sorry": 0,
             "sorry_delta": 0,
+            "result_kind": "already_solved",
             "elapsed_s": 0.0,
             "result": {"status": "already_solved",
                        "reason": "0 sorry in target file (pre-check, no prover spawn)"},
@@ -131,11 +132,29 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     final = Path(filepath).read_text(encoding="utf-8")
     final_sorry = final.count("sorry")
 
+    # Forensic #1453 (2026-07-02): a run's outcome was scattered across 4 fields
+    # (result.status, sorry_delta, structural_progress, error) and every consumer
+    # re-derived its own verdict — the ai-01 harvest step included. One canonical
+    # verdict, ranked by what a coordinator does next:
+    #   sorry_decreased  -> harvest: branch + PR (textual sorry count dropped)
+    #   structural_only  -> keep iterating: decomposition landed, count did not drop
+    #   crashed          -> postmortem the harness, not the proof
+    #   no_progress      -> diagnostic data only
+    if isinstance(result, dict) and result.get("error"):
+        result_kind = "crashed"
+    elif final_sorry < original_sorry:
+        result_kind = "sorry_decreased"
+    elif isinstance(result, dict) and result.get("structural_progress"):
+        result_kind = "structural_only"
+    else:
+        result_kind = "no_progress"
+
     trace_name = f"{mode}_{name.replace(' ', '_')}_{provider}"
     trace_path = trace.save(trace_name)
 
     print(f"\n{'='*60}")
     print(f"RESULT: {result.get('status', 'unknown')}")
+    print(f"  Verdict: {result_kind}")
     print(f"  Sorry: {original_sorry} → {final_sorry}")
     _actual_iters = result.get("iterations") if isinstance(result, dict) else None
     print(f"  Iterations: {_actual_iters if _actual_iters is not None else '?'}/{iterations} (actual/budget)")
@@ -164,6 +183,9 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         # Convention: sorry_delta = final - original. POSITIF = REGRESSION (plus de sorry), NEGATIF = progres. Oppose a tools.py (original - current). Forensic #1453 2026-06-23.
         "sorry_delta": final_sorry - original_sorry,
         "sorry_reduction": original_sorry - final_sorry,  # positif = progres (lecture non ambigue)
+        # Canonical verdict (see derivation above): sorry_decreased |
+        # structural_only | no_progress | crashed | already_solved.
+        "result_kind": result_kind,
         "elapsed_s": round(elapsed, 1),
         "result": result,
         "trace_file": trace_path,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1910,16 +1910,41 @@ class TacticTools:
         duration = time.time() - start
         sorry_count = self._count_sorry_after_replacement(tactic)
 
+        # Forensic #1453 (2026-07-02, traces L180/L185/Basic_L224): the probe
+        # `success` alone means "the replacement COMPILES in isolation" — a
+        # tactic that IS `sorry` or leaves sorry placeholders compiles fine, so
+        # the agent read success=True as PROOF FOUND while the sorry count
+        # stayed flat. Gate `success` on actual sorry elimination (same
+        # semantics the VerifyExecutor adopted via persist_on_success on
+        # 2026-06-23) and expose the raw probe verdict as `probe_compiles` so
+        # decomposition-style tactics still see that their edit builds.
+        probe_compiles = bool(result["success"])
+        original_count = (self._sorry_ctx.full_file.count("sorry")
+                          if self._sorry_ctx.full_file else -1)
+        sorry_eliminated = (probe_compiles and sorry_count >= 0
+                            and original_count >= 0
+                            and sorry_count < original_count)
+        note = None
+        if probe_compiles and not sorry_eliminated:
+            note = (f"Compiles but sorry count did not decrease "
+                    f"({original_count} -> {sorry_count}): NOT a completed "
+                    f"proof — the tactic is or leaves a sorry placeholder.")
+
         if self._trace:
             self._trace.log(
                 agent="TacticAgent", role="sorry_verify",
-                content=f"tactic={tactic[:80]} -> success={result['success']}",
+                content=(f"tactic={tactic[:80]} -> compiles={probe_compiles} "
+                         f"eliminated={sorry_eliminated}"),
                 duration_s=duration, tool_name="verify_sorry_replacement",
-                tool_result=f"success={result['success']}, sorry_count={sorry_count}",
+                tool_result=(f"success={sorry_eliminated}, "
+                             f"probe_compiles={probe_compiles}, "
+                             f"sorry_count={sorry_count}"),
             )
 
         return json.dumps({
-            "success": result["success"],
+            "success": sorry_eliminated,
+            "probe_compiles": probe_compiles,
+            "note": note,
             "errors": result.get("errors", "")[:500],
             "error_type": result.get("error_type"),
             "residual_goals": result.get("residual_goals", []),

--- a/docs/lean/prover_iteration_history.md
+++ b/docs/lean/prover_iteration_history.md
@@ -163,6 +163,22 @@ From 20 prover history files containing 89 tactic attempts:
 | **F10** | 2026-05-17 | — | Critical verifier bug fix (lake config error ≠ build failure) |
 | **F11** | 2026-05-17 | #1231 | SearchAgent loop detection for sterile queries |
 | **B3** | 2026-05-18 | #1225 | Constructive existential heuristic (regex parse ∃ goals → scan constructors) |
+| **Verify write-back** | 2026-06-23 | — | `lean_utils.verify_sorry_replacement` : `is_success` conditionné au rebuild réel sans erreur + sans sorry implicite + baisse stricte du compte ; `persist_on_success` restaure l'original sinon |
+| **FX-1** | 2026-07-02 | — | tools.py wrapper `verify_sorry_replacement` : succès = compile **ET** baisse du compte sorry (avant : probe-only, `tactic=sorry` → success=True) |
+| **FX-2** | 2026-07-02 | — | agents.py : `search_leanexplore` enregistré seulement si le client lean-explore est disponible (16 appels no-op observés par run sinon) |
+| **FX-3** | 2026-07-02 | — | run_prover_bg.py : verdict canonique `result_kind` dans le summary (sorry_decreased / structural_only / no_progress / crashed / already_solved) |
+
+### Itération forensic 2026-07-02 (ping-pong #1453)
+
+Analyse forensic de 8 traces (02/06–23/06 : coneSteer, Lattice, Hashlife L849/L231, Basic L224, BONDAREVA, SHAPLEY) confrontée au code courant **avant** patch (G.1) :
+
+- **Déjà corrigé, ne pas re-patcher** : le TOP-1 forensic (gate de vérification laxiste) visait des traces **antérieures** au fix write-back du 2026-06-23 — `lean_utils.verify_sorry_replacement` + le VerifyExecutor de workflow.py sont déjà sains. Idem F1/F8/B2c (escalade Director sur échecs de build consécutifs / wall-clock / compteur cumulatif) : déjà dans workflow.py. Le succès-sur-augmentation-de-sorry est un choix P4 délibéré (#1483, décomposition).
+- **Réellement ouvert, patché (FX-1..FX-3)** : le wrapper tools.py côté TacticAgent retournait un succès probe-only (une tactique qui *est* un sorry compilait donc « réussissait ») ; `search_leanexplore` était enregistré même sans client installé ; le verdict d'un run était éparpillé sur 4 champs (`result.status`, `sorry_delta`, `structural_progress`, `error`), chaque consommateur re-dérivait le sien.
+- **Validation** : 75/75 `tests/test_prover_guards.py` (env `coursia-ml-training`) + import smoke des 3 modules.
+
+Leçon de méthode : un rapport forensic sur traces datées se relit **contre le code courant** avant d'agir — ici 2 des 3 recommandations TOP étaient déjà résolues, le patch set réel s'est réduit aux 3 écarts ci-dessus.
+
+**Pathologie nouvelle observée le même jour (run Lidman L39)** : élimination de sorry par **données fabriquées derrière un invariant trivial**. Le prover a remplacé `diagram := sorry` par un PD-code plausible étiqueté « Reference: KnotInfo » — mais le code ne correspondait PAS à l'entrée KnotInfo réelle de 11n_102 (seul 1 tuple sur 11 en était une rotation). Comme `KnotDiagram.hwell : True` (placeholder Phase 2), le build passe quelle que soit la donnée : le gate build+compte-sorry est structurellement aveugle à l'hallucination de données. Contre-mesures : (a) G.1 côté récolte — toute donnée « citée d'une source » se re-vérifie contre la source avant PR (fait ici : PD-code corrigé depuis knotinfo.org) ; (b) le vrai fix est le prédicat de bonne-formation Phase 2 (chaque label d'arête apparaît exactement 2×), qui aurait rejeté... non, qui ne suffirait PAS (un code cohérent peut rester le mauvais nœud) — seule la vérification contre la source fait foi pour la *donnée*, le prédicat n'attrape que la malformation.
 
 ### Dual-Track Workflow (established May 11)
 


### PR DESCRIPTION
## Summary

Ping-pong Forensic #1453 relancé (mandat user 2026-07-02, reprise du harnais prover dédié). 8 traces (02/06–23/06) confrontées au code courant **avant** patch (G.1) : les recommandations TOP-1/TOP-2 du forensic visaient des traces antérieures au fix write-back du 2026-06-23 (`lean_utils.verify_sorry_replacement` + VerifyExecutor) — déjà saines, **non re-patchées**. Le patch set réel se réduit à 3 écarts :

- **FX-1 `prover/tools.py`** : le wrapper `verify_sorry_replacement` côté TacticAgent retournait un succès probe-only (une tactique qui *est* un sorry compilait donc « réussissait » — traces L180/L185/Basic_L224). Désormais `success = probe_compiles ET compte sorry strictement < original` ; champs `probe_compiles` + `note` ajoutés, ligne de trace enrichie.
- **FX-2 `prover/agents.py`** : `search_leanexplore` n'est enregistré au SearchAgent que si le client lean-explore est réellement disponible (16 appels no-op/run observés sinon — bruit de spans + une décision LLM gâchée à chaque appel).
- **FX-3 `prover/run_prover_bg.py`** : verdict canonique `result_kind` dans le summary JSON (`sorry_decreased | structural_only | no_progress | crashed | already_solved`) + ligne imprimée — le verdict était éparpillé sur 4 champs et chaque consommateur re-dérivait le sien.
- **Doc** : section « Itération forensic 2026-07-02 » dans `docs/lean/prover_iteration_history.md`, incluant la pathologie **données-fabriquées-derrière-invariant-trivial** observée le même jour sur le run Lidman L39 (PR séparée pour la réparation des données).

## Validation

- `tests/test_prover_guards.py` : **75/75 passed** (env `coursia-ml-training`, python 3.11.15) — relancé APRÈS le dernier patch.
- Import smoke : `prover.tools`, `prover.agents`, `prover.run_prover_bg` OK.
- Aucun fichier `.lean` touché (pas de critère §B) ; aucun notebook ; catalogue byte-identique à main.

## Scope

4 fichiers : 3 modules prover + 1 doc. Un seul sujet (ping-pong forensic). `See #1453` (l'epic reste ouverte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)