### PR TITLE
docs(lean): #3978 de-stalle conway_lean README (toolchain rc1 + P4/P5 balisage ingredients)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -18,9 +18,9 @@ flowchart LR
 
 ## Statut
 
-- **Toolchain** : v4.30.0-rc2
-- **Compte de sorry** : 4 (tous dans `HashlifeCorrectness.lean` — pas inductif P4 double-nine [2] + grand-n P5 jump [2], Epic #2162). Trois sous-lemmes P4 sont désormais prouvés sorry-free (voir § « Jeu de la Vie » ci-dessous)
-- **Build** : `lake build Conway` — SUCCESS (3352 jobs)
+- **Toolchain** : v4.31.0-rc1
+- **Compte de sorry** : 4 (tous dans `HashlifeCorrectness.lean` — assemblage offset-matching P4 `p4_half_steps_compose` [2] + grand-n P5 [2], Epic #2162). Plusieurs sous-lemmes P4 et ingrédients additifs sont prouvés sorry-free (voir § « Jeu de la Vie » ci-dessous)
+- **Build** : `lake build Conway` — SUCCESS
 - **Dépendances** : Mathlib4
 
 ## Modules
@@ -94,19 +94,24 @@ flowchart LR
 - **Hashlife mémoïsé** : témoins des piliers communautaires (OTCA 35K gen, UnitCell 4096 gen, Gemini 33M gen)
 - **HashlifeCorrectness** : correction bornée `hashlife_correct`, décomposée en P1-P5
   - **P1-P3 prouvés** (cas de base `k=0` via `2^16 native_decide`, PR #2810)
-  - **Pas inductif P4** (2 sorry) : décomposé par le scaffolding #2975 en cinq sous-lemmes.
-    Trois sont désormais **prouvés sorry-free** avec énoncés réels — `p4_double_nine_shape`
-    (existence structurelle des neuf quadrants d'une cellule double-nine), `p4_wave1_ih` et
-    `p4_wave2_ih` (propagation du `centralCorrect` par l'hypothèse d'induction sur les deux
-    vagues). Restent : `p4_half_steps_compose` (placeholder `: True`, composition des
-    demi-pas light-cone double-nine) + la colle `p4_succ_membership` (la biconditionnelle
-    ponctuelle réelle après `intro p`). Composition light-cone double-nine de niveau recherche,
-    whnf-dure — réservée à un effort multi-cycle dédié. Les énoncés réels des sous-lemmes
-    vivent dans leurs docstrings — les restituer et les prouver, ne pas les éliminer comme `True`.
-  - **Grand-n P5** (2 sorry) : `p5_small_n_fallback` **PROUVÉ** (PR #2984) ; `p5_large_n_jump`
-    (P5.2, placeholder `: True`, bloqué sur P4) + branche grand-n de `p5_inductive_step`
-    (colle P5.3) restent. Cas de base `n=0` prouvé (`hashlife_correct_base_zero` #2898,
-    `evolveHashlifeFastAux_zero_n` #2901).
+  - **Pas inductif P4** (2 sorry) : le scaffolding #2975 décompose le pas inductif en
+    sous-lemmes. Sont **prouvés sorry-free** — `p4_double_nine_shape` (existence
+    structurelle des neuf quadrants d'une cellule double-nine), `p4_wave1_ih` et
+    `p4_wave2_ih` (propagation du `centralCorrect` par l'hypothèse d'induction sur les
+    deux vagues), `p4_ext_bridge`, ainsi que les ingrédients additifs clos cycles 145-160 :
+    `evolve_add` (S1), `window_cone_in_domain` (S2), `evolve_half_step` (demi-pas `2^k`,
+    #4555), `centralCorrect_mem_shift` (gate G2 offset-généralisé, #4812) et
+    `evolve_cone_agree` (gate de composition de localité radius-doubling, #4892). Restent
+    les **2 sorry** de `p4_half_steps_compose` — le cœur d'assemblage offset-matching G3
+    (« p4_succ_membership ») : caractériser l'appartenance des super-cellules `q_*` aux
+    quatre offsets de quadrant via `centralCorrect_mem` (G2) + le pontage
+    `evolve_half_step`/`step_light_cone` (G3). Composition light-cone double-nine whnf-dure
+    de niveau recherche — cible du BG-prover multi-cycle.
+  - **Grand-n P5** (2 sorry) : `p5_small_n_fallback` **PROUVÉ** (PR #2984) ;
+    `evolve_dead_of_cone_dead` (contrapositive P5.2, #4574) **prouvé sorry-free** ;
+    `p5_large_n_jump` (P5.2, placeholder `: True`, bloqué sur P4) + branche grand-n de
+    `p5_inductive_step` (colle P5.3) restent. Cas de base `n=0` prouvé
+    (`hashlife_correct_base_zero` #2898, `evolveHashlifeFastAux_zero_n` #2901).
 
 ### Kochen-Specker + Free Will Theorem (Phase 3, PROUVÉ)
 
@@ -136,7 +141,7 @@ Ce workspace formalise en Lean 4 trois facettes de l'oeuvre de John Conway, des 
 
 ### État honnête du verrou HashlifeCorrectness
 
-Le théorème central `hashlife_correct` (borné par l'hypothèse de padding `BoxAssezGrand`) n'est **pas encore prouvé en pleine généralité** : il reste **4 `sorry`** dans `HashlifeCorrectness.lean`. Le socle est solide — cas de base `k=0` prouvé (`2^16 native_decide`), cas de base `n=0` prouvé, P1/P2/P3 (padding, light-cone, locality) prouvés, `p5_small_n_fallback` prouvé, et trois des cinq sous-lemmes P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`) désormais prouvés sorry-free — mais le pas inductif P4 (double-nine decomposition, 2 sorry résiduels : `p4_half_steps_compose` + colle `p4_succ_membership`) et le grand-n P5 (2 sorry, bloqué sur P4) sont **research-level**. Ce sont les cibles du BG-prover (`agent_tests/prover/`), pas des grains bornés : la composition light-cone multi-vagues résiste à l'automatisation tactique courante. Les scaffolds P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_half_steps_compose`, `p4_succ_membership`) énoncent précisément chaque sous-but dans leurs docstrings.
+Le théorème central `hashlife_correct` (borné par l'hypothèse de padding `BoxAssezGrand`) n'est **pas encore prouvé en pleine généralité** : il reste **4 `sorry`** dans `HashlifeCorrectness.lean`. Le socle est solide — cas de base `k=0` prouvé (`2^16 native_decide`), cas de base `n=0` prouvé, P1/P2/P3 (padding, light-cone, locality) prouvés, `p5_small_n_fallback` prouvé, les sous-lemmes P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_ext_bridge`) prouvés sorry-free, ainsi que les ingrédients additifs clos cycles 145-160 (`evolve_add`, `window_cone_in_domain`, `evolve_half_step`, `centralCorrect_mem_shift`, `evolve_cone_agree`) et la contrapositive P5.2 (`evolve_dead_of_cone_dead`) — mais le pas inductif P4 (assemblage offset-matching G3, 2 sorry résiduels dans `p4_half_steps_compose`) et le grand-n P5 (2 sorry, bloqué sur P4) sont **research-level**. Ce sont les cibles du BG-prover (`agent_tests/prover/`), pas des grains bornés : la composition light-cone multi-vagues résiste à l'automatisation tactique courante. Les scaffolds P4 énoncent précisément chaque sous-but dans leurs docstrings.
 
 *La pyramide de correction `hashlife_correct` : le socle prouvé (cas de base, P1-P3,
 `p5_small_n_fallback`) porte le théorème ; au sommet, le verrou research-level P4
@@ -150,8 +155,8 @@ flowchart TD
     P2["P2 — Light-cone<br/>step_light_cone  <b>✓</b>"]
     P3["P3 — Localité<br/>aliveNext_local · step_local  <b>✓</b>"]
     P5S["P5 petit-n<br/>p5_small_n_fallback  <b>✓</b> (#2984)"]
-    P4["P4 — Pas inductif double-nine  <b>⚠ research-level</b><br/>2 sorry · p4_half_steps_compose · p4_succ_membership<br/><i>3 sous-lemmes prouvés (shape, wave1, wave2) ; reste la colle light-cone</i>"]
-    P5["P5 — Grand-n jump  <b>⚠ bloqué sur P4</b><br/>2 sorry · p5_large_n_jump"]
+    P4["P4 — Pas inductif double-nine  <b>⚠ research-level</b><br/>2 sorry · p4_half_steps_compose (assemblage offset-matching G3)<br/><i>sous-lemmes + ingrédients additifs prouvés (shape, wave1, wave2, ext_bridge, evolve_cone_agree, centralCorrect_mem_shift, evolve_half_step) ; reste le cœur G3 whnf-dur</i>"]
+    P5["P5 — Grand-n jump  <b>⚠ bloqué sur P4</b><br/>2 sorry · p5_large_n_jump · p5_inductive_step<br/><i>p5_small_n_fallback + evolve_dead_of_cone_dead prouvés</i>"]
     GOAL["hashlife_correct  <b>non prouvé en pleine généralité</b>"]
 
     BASE --> P1 --> P2 --> P3 --> GOAL


### PR DESCRIPTION
## Summary

`#3978` feuille tranche — de-stalle `conway_lean/README.md` to reflect the **verified formal state** of HashlifeCorrectness (Part of #3973 feuilles-READMEs-ascendantes, owner po-2026:CoursIA). Driven by the #3978 mandate: « refléter les preuves avancées, retirer les WIP/admis résolus, décrire l'état formel réel ».

Conway is explicitly named in the #3978 driver (« Conway #2162 (P4/P5 #3846) »), and I just shipped `evolve_cone_agree` (#4892) on this lane, so the proof state is firsthand-known.

## Changes (4 factual corrections, all verified firsthand this session)

1. **Toolchain** `v4.30.0-rc2` → `v4.31.0-rc1` (conway_lean converged via #4819 `3441179c3`; manifest `d568c8c0` verified, lake-manifest.json matches).
2. **P4 narrative error fixed**: the README claimed « `p4_half_steps_compose` (placeholder `: True`) » — this is **factually wrong**. The `: True` placeholder is `p5_large_n_jump` (L2852); `p4_half_steps_compose` (L2469) holds real offset-matching proof work (`mem_toGrid_node` / `centralCorrect_mem` / `evolve_half_step`) with 2 sorries (L2471, L2536). Added the 5 sorry-free ingredients closed cycles 145-160: `evolve_add` (S1), `window_cone_in_domain` (S2), `evolve_half_step` (#4555), `centralCorrect_mem_shift` (#4812), `evolve_cone_agree` (#4892).
3. **P5 narrative**: added `evolve_dead_of_cone_dead` contrapositive (#4574) proven sorry-free.
4. **État honnête + mermaid P4/P5 boxes**: updated for internal coherence with the corrected narrative.

## Verification (G.1 firsthand, this session)

```
$ grep -nE '^\s*sorry\s*$|^\s*· sorry' HashlifeCorrectness.lean
2471:  sorry   # p4_half_steps_compose (1/2)
2536:  sorry   # p4_half_steps_compose (2/2) — the G3 offset-matching assembly
2853:  sorry   # p5_large_n_jump (: True placeholder)
2862:  · sorry # p5_inductive_step (large-n bullet)
TOTAL: 4
```

Theorem↔sorry map grounded via `grep -nE '^theorem (p4|p5)'`: `p4_half_steps_compose` L2469 (sorries L2471+L2536), `p5_large_n_jump` L2852 (L2853), `p5_inductive_step` L2858 (L2862). `p4_succ_membership` is NOT a separate theorem — it's the conceptual name for the G3 assembly implemented inside `p4_half_steps_compose` (only in docstrings/comments). Proven sub-lemmes confirmed: `p4_double_nine_shape` L1744, `p4_wave1_ih` L2168, `p4_wave2_ih` L2200, `p4_ext_bridge` L1202. New ingredients confirmed present: `evolve_cone_agree` L712, `centralCorrect_mem_shift` L2076, `evolve_half_step` L2370, `evolve_dead_of_cone_dead` L770.

## Notes

- Markdown-only, no re-exec needed (C.3 — not a notebook). No `CATALOG-STATUS` markers in this README.
- **Toolchain scope**: only conway_lean is rc1 (converged #4819). The other Lean feuilles (calibration, finiteness, grothendieck, mathlib_examples, sensitivity, cooperative_games, social_choice, stable_marriage) are **genuinely still rc2** — intentionally NOT touched. Only conway_lean/knot_lean/conway_cgt_lean/minimax_lean are rc1.
- `See #3978`, `Part of #3973` (feuille tranche, not a full close).

See #3978
