### PR TITLE
feat(knot): 11n102 PD-code vérifié KnotInfo — élimine le sorry diagramme de Lidman.lean L39

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Lidman.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Lidman.lean
@@ -35,10 +35,31 @@ namespace Knots
 It is a Montesinos knot M(-2/3, 1/3, 2/7) with determinant 3.
 -/
 
+/-- The knot 11n102, defined by its PD-code from KnotInfo.
+    Reference: KnotInfo, https://knotinfo.org (entry 11n_102, PD notation),
+    fetched and hand-checked 2026-07-02: 11 crossings, 22 edge labels,
+    each label 1..22 appears exactly twice.
+    Classification (KnotInfo): Montesinos K(2/3;-1/3;-2/7), determinant 3. -/
+def knot_11n102_diagram : KnotDiagram where
+  crossings := [
+    ⟨4,  2,  5,  1⟩,   -- crossing 1
+    ⟨7,  12, 8,  13⟩,  -- crossing 2
+    ⟨10, 3,  11, 4⟩,   -- crossing 3
+    ⟨2,  11, 3,  12⟩,  -- crossing 4
+    ⟨5,  14, 6,  15⟩,  -- crossing 5
+    ⟨13, 6,  14, 7⟩,   -- crossing 6
+    ⟨17, 20, 18, 21⟩,  -- crossing 7
+    ⟨9,  19, 10, 18⟩,  -- crossing 8
+    ⟨19, 9,  20, 8⟩,   -- crossing 9
+    ⟨15, 22, 16, 1⟩,   -- crossing 10
+    ⟨21, 16, 22, 17⟩   -- crossing 11
+  ]
+  numEdges := 22
+  hwell := by trivial  -- TODO Phase 2: proper well-formedness check
+
 def knot_11n102 : Knot where
-  diagram := sorry  -- TODO: PD-code from KnotInfo
-  -- Reference: KnotInfo, https://knotinfo.org
-  -- Classification: Montesinos knot M(-2/3, 1/3, 2/7)
+  diagram := knot_11n102_diagram
+
 
 /-! ## 2. Unknotting number bounds
 


### PR DESCRIPTION
## Summary

Première récolte du harnais prover remis en service (mandat user 2026-07-02). Le run BG multi-agent (zai + Director openrouter, 1312s) a produit la **bonne forme de solution** — un `knot_11n102_diagram : KnotDiagram` concret branché dans `knot_11n102` à la place de `diagram := sorry` — mais avec un **PD-code fabriqué** faussement étiqueté « Reference: KnotInfo » (1 seul tuple sur 11 était une rotation de l'entrée réelle ; `hwell : True` laisse passer n'importe quelle donnée).

**Réparation G.1 à la récolte** (pas de consécration) : crossings remplacés par la **vraie** notation PD KnotInfo de 11n_102, vérifiée à la main (22 labels d'arêtes, chacun exactement 2×) :
`[4,2,5,1], [7,12,8,13], [10,3,11,4], [2,11,3,12], [5,14,6,15], [13,6,14,7], [17,20,18,21], [9,19,10,18], [19,9,20,8], [15,22,16,1], [21,16,22,17]`
Docstring : source vérifiée (knotinfo.org, 2026-07-02) + classification Montesinos KnotInfo K(2/3;-1/3;-2/7), déterminant 3.

## Preuves (§B pr-review-discipline)

1. **`grep -c sorry` réel** : Lidman.lean 3 → 2 (restants : `unknotting_11n102_upper` L71, `unknotting_11n102` L88 — cibles Phase 3, hors scope).
2. **Lake build local ai-01 (WSL)** : `Built Knots.Lidman (407s)` — `Build completed successfully (318 jobs)`. Seuls warnings : les 2 sorries déclarés restants + lints préexistants d'Invariant.lean.
3. Pas de refactor prover dans cette PR (les patchs harnais sont dans #4895) — 1 fichier, 1 sujet.
4. Aucune preuve existante supprimée (diff = +24/−3, remplacement d'un `sorry` par une définition).

La pathologie « données fabriquées derrière invariant trivial » est documentée côté harnais dans #4895 (`docs/lean/prover_iteration_history.md`).

See #1027. See #1453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)