### PR TITLE
fix(ml-cours): repair predecessor link in 2.1-Workflow-ML (See #4788)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# 2.1 — Le workflow d'apprentissage automatique\n",
     "\n",
-    "**Navigation** : [<< 01-PythonForDataScience](../../01-PythonForDataScience/) | [2.2-Descente-de-gradient >>](2.2-Descente-de-gradient.ipynb) | [Index](../README.md)\n",
+    "**Navigation** : [<< 01-PythonForDataScience](../01-PythonForDataScience/) | [2.2-Descente-de-gradient >>](2.2-Descente-de-gradient.ipynb) | [Index](../README.md)\n",
     "\n",
     "**Kernel** : Python 3\n",
     "\n",


### PR DESCRIPTION
## Summary

Repair the broken predecessor navigation link in `2.1-Workflow-ML.ipynb` cell0:
`../../01-PythonForDataScience/` → `../01-PythonForDataScience/`.

The predecessor (`DataScienceWithAgents/01-PythonForDataScience/`) is a **sibling** of `02-ML-Cours/`, so the link needs to go **one** level up, not two. The two-up path resolves to the non-existent `MyIA.AI.Notebooks/ML/01-PythonForDataScience` (verified via `git ls-tree`).

This is the **deferred item** from merged #4890 (cb7953e19), whose body noted:
> NOT in this PR (deferred to next cycles): `ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb L19`

Part of the cross-family dangling-link sweep EPIC #4788.

## Scope

- **1 file**, **1 insertion / 1 deletion** (surgical).
- Markdown cell (cell0) only — **C.2-exempt**, no re-execution needed.
- Catalogue (`COURSE_CATALOG.generated.*`, CATALOG-STATUS markers) **byte-identical to main** (catalog-pr-hygiene rule 1).
- `0` occurrences of `raise NotImplementedError` / `assert False` / `1/0` (C.1).

## Verification

```
$ git diff --stat
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Resolved link against repo tree (`git ls-tree -r --name-only origin/main`):
- before: `MyIA.AI.Notebooks/ML/01-PythonForDataScience` → BROKEN
- after:  `MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/` → EXISTS

See #4788