### PR TITLE
fix(qc): repair 3 dangling docs links — path depth + missing /qc/ (#4788)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/docs/OVERVIEW.md
+++ b/MyIA.AI.Notebooks/QuantConnect/docs/OVERVIEW.md
@@ -144,7 +144,7 @@ Les notebooks pedagogiques `Python/QC-Py-*` couvrent les concepts ; les projets 
 ## Pour aller plus loin
 
 - [Quick Tour](../QUICK_TOUR.md) — Vue d'ensemble en 2 minutes
-- [Patterns confirmes](../../../docs/quantconnect.md) — 20 patterns + 10 anti-patterns
-- [Catalogue detaille](STRATEGIES_DETAIL.md) — Toutes les strategies par categorie
+- [Patterns confirmes](../../../docs/qc/quantconnect.md) — 20 patterns + 10 anti-patterns
+- [Catalogue detaille](../projects/STRATEGIES_DETAIL.md) — Toutes les strategies par categorie
 - [Livre Jared Broad](../BOOK_MAPPING.md) — 63 exemples du livre *Hands-On AI Trading*
 - [Catalogue QC Cloud](qc_strategies_catalog.md) — Metriques par strategy avec Cloud IDs

--- a/MyIA.AI.Notebooks/QuantConnect/projects/STRATEGIES_DETAIL.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/STRATEGIES_DETAIL.md
@@ -167,4 +167,4 @@ Références avancées clonées depuis la QC Cloud Library (avril 2026). Métriq
 
 ---
 
-Voir aussi : [README.md](README.md) (résumé) · [Leçons](../../docs/quantconnect.md) · [Catalogue QC Cloud](../docs/qc_strategies_catalog.md)
+Voir aussi : [README.md](README.md) (résumé) · [Leçons](../../../docs/qc/quantconnect.md) · [Catalogue QC Cloud](../docs/qc_strategies_catalog.md)


### PR DESCRIPTION
## Summary

Second QC tranche of **#4788** (cross-famille dangling-link sweep). Repairs 3 broken markdown links in QC docs that pointed to the canonical `docs/qc/quantconnect.md` (repo root) with wrong relative paths.

| File | Link | Fix |
|------|------|-----|
| `projects/STRATEGIES_DETAIL.md` | `[Leçons](../../docs/quantconnect.md)` | → `../../../docs/qc/quantconnect.md` (2 ups short + missing `/qc/`) |
| `docs/OVERVIEW.md` | `[Patterns confirmes](../../../docs/quantconnect.md)` | → `../../../docs/qc/quantconnect.md` (missing `/qc/`) |
| `docs/OVERVIEW.md` | `[Catalogue detaille](STRATEGIES_DETAIL.md)` | → `../projects/STRATEGIES_DETAIL.md` (target lives in `projects/`, not `docs/`) |

## Verification (G.1 firsthand)

- Canonical target confirmed: `docs/qc/quantconnect.md` exists at repo root.
- All 3 corrected paths verified to resolve from each file's directory (`ls` returns the path); the prior paths confirmed NOT resolving.
- Pure markdown link edits — no notebook, no execution affected.

## Scope (atomic, separate from PR #4901)

PR #4901 covered the ML-Training-Pipeline notebook off-by-one `../` links (different defect class). This PR covers the QC docs path-depth + missing-segment links. Kept separate per atomicity (one defect class per PR).

NOT in scope (need context-driven decision, separate tranche):
- `GETTING-STARTED.md` → `TROUBLESHOOTING.md` (target genuinely missing — create stub vs remove link).
- `docs/HANDSON_AI_TRADING_MAPPING.md` → `examples/Markov-Regime-Detection/` + `Gaussian-Direction-Classifier/` (folders genuinely missing).
- `OVERVIEW.md` table cell `docs/quantconnect.md` (L83) + tree-diagram `STRATEGIES_DETAIL.md` (L112) — plain text, not `[..](..)` links.

Issue #4788 remains OPEN.

See #4788

🤖 Generated with [Claude Code](https://claude.com/claude-code)
