### PR TITLE
docs(qc): remove phantom archive-2025/ references from QC root README (#3976)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -255,7 +255,6 @@ partner-course-quant-trading/
 │   ├── starter/        # Niveau débutant
 │   ├── intermediate/   # Niveau intermédiaire
 │   └── advanced/       # Niveau avancé
-└── archive-2025/       # Archives historiques
 ```
 
 Voir [partner-course-quant-trading/README.md](partner-course-quant-trading/README.md) pour le détail des exemples et templates.
@@ -268,7 +267,6 @@ Voir [partner-course-quant-trading/README.md](partner-course-quant-trading/READM
 |-----------|--------|-------------|
 | `_pending_execution/` | Local-only | Transient QuantBook workspace (untracked local files); committed placeholder purged |
 | `projects/_archive/` | Purged | Dedup-archive removed; canonical strategies retained in `projects/` (commit `#1815`, `#1627`) |
-| `partner-course-quant-trading/archive-2025/` | Reference | 2024-2025 student project IDs and cloud references |
 | `_archive/` | Purged | Superseded reports moved to `docs/audits/` (commit `#1626`) |
 | `_esgf_cours_5mai/` | Purged | Course 5 May 2026 backtest results archived to G drive (commit `#1626`) |
 


### PR DESCRIPTION
## Summary

#3976 follow-up slice **handed by ai-01** (msg-...eaojrt, after #4894): *"l'archive-2025 une investigation git"*. Firsthand git investigation confirms `partner-course-quant-trading/archive-2025/` is a **phantom directory** — referenced in 2 places but never existed. This PR removes both phantom references.

| Location | Reference | Fix |
|----------|-----------|-----|
| Structure tree diagram (L258) | `└── archive-2025/ # Archives historiques` | line removed |
| Transient Directories table (L271) | `\| archive-2025/ \| Reference \| 2024-2025 student project IDs \|` | row removed |

## Verification (G.1 firsthand — git investigation)

- **`git log --all --diff-filter=AD` for any `partner-course*archive*` path = EMPTY** → the directory was never added nor deleted in git history. It never existed.
- No `archive/2025/2024` dir on disk under partner-course-quant-trading/ (only `.data_cache/` parquet files with 2025 in their date *range* = unrelated).
- The row's claimed content ("2024-2025 student project IDs and cloud references") **is already correctly documented** in `partner-course-quant-trading/README.md` Researcher table (5 QC Cloud IDs verified present) — where it belongs, not in a phantom subdir.
- The "Transient Directories" table is an honest record of purged/local dirs; a never-existed phantom pollutes it → removal is the honest fix (not a relabel).

## Catalog hygiene

CATALOG-STATUS markers (L3-8) left **byte-identical** to `origin/main` (verified: 0 catalog-marker lines in diff). Per [catalog-pr-hygiene](../../blob/main/.claude/rules/catalog-pr-hygiene.md). Branch fresh from `origin/main`.

## Scope

Single file, 2-line removal, single verified defect (phantom dir). The **other** #4894 follow-up — "115-vs-116 stratégies" — needs QC Cloud API deployed-count truth (ambiguous local-vs-deployed), separate slice, not bundled here.

Issue #3976 remains OPEN.

See #3976
Part of #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
