### PR TITLE
fix(accents): revert franglais QC README (follow-up #4866)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -43,7 +43,7 @@ Maîtriser les bases de QuantConnect : architecture, lifecycle d'algorithme, ges
 | 01 | [QC-Py-01-Setup](Python/QC-Py-01-Setup.ipynb) | 45 min | Compte QC, premier backtest cloud, architecture LEAN |
 | 02 | [QC-Py-02-Platform-Fundamentals](Python/QC-Py-02-Platform-Fundamentals.ipynb) | 60 min | QCAlgorithm lifecycle, Initialize/OnData, Moving Average Crossover |
 | 03 | [QC-Py-03-Data-Management](Python/QC-Py-03-Data-Management.ipynb) | 75 min | History API, data normalization, consolidators, multi-timeframe |
-| 04 | [QC-Py-04-Research-Workflow](Python/QC-Py-04-Research-Workflow.ipynb) | 75 min | QuantBook, pandas intégration, notebook→algorithm transition |
+| 04 | [QC-Py-04-Research-Workflow](Python/QC-Py-04-Research-Workflow.ipynb) | 75 min | QuantBook, pandas integration, notebook→algorithm transition |
 
 **Objectifs** : Créer compte gratuit, maîtriser cycle de vie algorithme, gestion des données.
 
@@ -72,7 +72,7 @@ Gestion du risque professionnelle, types d'ordres avancés, analyse approfondie 
 |---|----------|-------|---------|
 | 09 | [QC-Py-09-Order-Types](Python/QC-Py-09-Order-Types.ipynb) | 75 min | Market, Limit, Stop, Stop-Limit, combo orders |
 | 10 | [QC-Py-10-Risk-Portfolio-Management](Python/QC-Py-10-Risk-Portfolio-Management.ipynb) | 90 min | Position sizing (Kelly, fixed fractional), stop-loss, take-profit |
-| 11 | [QC-Py-11-Technical-Indicators](Python/QC-Py-11-Technical-Indicators.ipynb) | 75 min | Indicateurs intégrés, custom indicators, signal génération |
+| 11 | [QC-Py-11-Technical-Indicators](Python/QC-Py-11-Technical-Indicators.ipynb) | 75 min | Indicateurs intégrés, custom indicators, signal generation |
 | 12 | [QC-Py-12-Backtesting-Analysis](Python/QC-Py-12-Backtesting-Analysis.ipynb) | 75 min | Performance metrics (Sharpe, Sortino, max drawdown), equity curve |
 
 **Objectifs** : Maîtriser gestion du risque, ordres avancés, analyse de backtests.


### PR DESCRIPTION
## Scope
2 mots, 1 fichier : `MyIA.AI.Notebooks/QuantConnect/README.md`.

#4866 a été mergée avec 2 sur-corrections franglais introduites par la passe accents : `pandas intégration` et `signal génération` — ce sont des mots anglais dans des descriptions techniques EN, ils ne prennent pas d'accent.

Pattern documenté : le check deac-net-0 ne détecte pas l'accentuation de mots EN (semantic FP, cf. review #4884/#4881). See #2876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)