### PR TITLE
fix(qc): replace dead TROUBLESHOOTING.md link with existing 'Problèmes Courants' section (#4788)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/GETTING-STARTED.md
+++ b/MyIA.AI.Notebooks/QuantConnect/GETTING-STARTED.md
@@ -301,6 +301,6 @@ Une fois votre environnement configuré :
 
 ---
 
-**Besoin d'aide ?** Consultez le [TROUBLESHOOTING.md](TROUBLESHOOTING.md) (à venir) ou posez vos questions sur le forum QuantConnect.
+**Besoin d'aide ?** Consultez la section « Problèmes Courants » ci-dessus, ou posez vos questions sur le forum QuantConnect.
 
 **Bon trading algorithmique !** 🚀


### PR DESCRIPTION
## Summary

Tranche of **#4788** (QC subtree dangling-link sweep), genuinely-missing-target class. `GETTING-STARTED.md` L304 linked to a `TROUBLESHOOTING.md` (marked "(à venir)") that never existed.

| Before | After |
|--------|-------|
| `Consultez le [TROUBLESHOOTING.md](TROUBLESHOOTING.md) (à venir)` | `Consultez la section « Problèmes Courants » ci-dessus` |

## Verification (G.1 firsthand)

- **`TROUBLESHOOTING.md` does not exist** anywhere under `QuantConnect/` (`find` = empty), never committed (git history empty).
- The "(à venir)" tag = a **dead promise** ("pas de promesses mortes" mandate, 2026-07-02).
- The troubleshooting content **already exists inline**: `## Problèmes Courants` section (L243) covers 4 issues (backtest timeout, data availability, compute hours, Docker).
- Fix redirects help-seekers to the real existing section rather than a phantom file. Redirect target confirmed present (L243).

## Scope (atomic)

Single file, single line, single defect (dead link + dead promise). NOT bundled with:
- HANDSON mapping → 2 missing example folders (`docs/HANDSON_AI_TRADING_MAPPING.md`) — separate file, separate tranche.
- Pure markdown edit, no notebook execution (C.2 n/a).

Issue #4788 remains OPEN.

See #4788

🤖 Generated with [Claude Code](https://claude.com/claude-code)
