### PR TITLE
fix(prover): FX-6 statement-mutation false-success guard + c.139 token count (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -23,6 +23,33 @@ _HONEST_SORRY_RE = re.compile(
     "|".join(_HONEST_SORRY_PATTERNS), re.IGNORECASE,
 )
 
+# Token-level sorry counter (FX-6 / c.139, Epic #1453). The naive
+# ``content.count("sorry")`` over-counts: it matches the word inside comments,
+# docstrings and identifiers, so removing a `sorry` mention from a doc-comment
+# would read as "progress". This pattern counts only sorry TOKENS in proof
+# positions, and — unlike the strict ``^[ \t]*sorry$`` — also catches in-statement
+# forms that carry a trailing comment (``sorry -- ambient_isotopic k1 k2``) or a
+# bullet (``- sorry`` / ``· sorry``). It is strictly <= the naive count, so a
+# drop under the token count implies a drop under the naive count: using it in
+# the persist decision is SAFE (never persists a non-proof) and HONEST.
+_SORRY_TOKEN_RE = re.compile(
+    r"^[ \t]*sorry(?=$|[ \t]|--)"   # bare sorry line (+ optional trailing comment)
+    r"|:=\s*by\s+sorry\b"            # := by sorry
+    r"|:=\s*sorry\b"                 # := sorry
+    r"|\bexact\s+sorry\b"            # exact sorry
+    r"|^[ \t]*[·\-]\s*sorry\b",      # bullet sorry (middle dot U+00B7 or hyphen)
+    re.MULTILINE,
+)
+
+
+def count_sorry_tokens(content: str) -> int:
+    """Count sorry TOKENS in proof positions (c.139 corrected pattern).
+
+    Excludes ``sorry`` mentions in comments/strings and catches the in-statement
+    forms that the strict line-anchored pattern missed. See FX-6.
+    """
+    return len(_SORRY_TOKEN_RE.findall(content))
+
 
 def is_honest_sorry(filepath: str, sorry_line: int,
                     lookback: int = 12) -> Tuple[bool, str]:
@@ -830,8 +857,11 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
             # re-introducing one, e.g. a returned `simp; sorry`).
             real_has_error = bool(re.search(r"\berror:", real_output))
             implicit_sorry = "declaration uses 'sorry'" in real_output
-            sorry_dropped = (new_content.count("sorry")
-                             < original_content.count("sorry"))
+            # FX-6 (c.139): count sorry TOKENS, not naive substrings, so a
+            # `sorry` removed only from a comment cannot read as a drop. Token
+            # count is <= naive, so this is strictly safer for the persist gate.
+            sorry_dropped = (count_sorry_tokens(new_content)
+                             < count_sorry_tokens(original_content))
             if real_has_error or implicit_sorry or not sorry_dropped:
                 Path(filepath).write_text(original_content, encoding="utf-8", newline="")
                 is_success = False

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -203,6 +203,49 @@ def _autonomous_success_gate(final_sorry: int, original_sorry_count: int,
     return success, structural_progress
 
 
+def _multi_success_verdict(
+    proof_found: bool,
+    final_sorry: int,
+    original_sorry_count: int,
+    structural_progress: bool,
+    final_build_ok: bool,
+    attempts: int,
+    final_proof: Optional[str],
+) -> bool:
+    """Decide MultiAgentSorryProver session success with the statement-mutation
+    guard (FX-6, Epic #1453).
+
+    Pure decision extracted from ``run()`` so the guard is unit-testable. The
+    sorry-count disjuncts (``final_sorry == 0`` / ``< original`` /
+    ``structural_progress``) stay as in #1453, BUT a sorry-count change alone is
+    never a proof: it must come with >=1 verified tactic. The Reidemeister L545
+    run (trace ``multi_custom_Reidemeister_L545_openrouter_result.json``) filled
+    an in-statement ``sorry`` placeholder with the goal RHS, making the theorem
+    reflexive; the build passed and sorry 2->0, yet ``attempts == 0`` and
+    ``final_proof is None`` because the in-place latch (workflow.py) sets
+    ``proof_found`` without any tactic ever being verified. The guard therefore
+    keys on ``attempts`` / ``final_proof`` — NOT on ``proof_found``, which the
+    latch taints — so a pure statement mutation cannot report success,
+    independently of the sorry delta. (#4075 persists on "build OK + sorry count
+    dropped"; this completes it by requiring the drop to be backed by a real
+    tactic.)
+
+    Returns ``success``.
+    """
+    # No verified tactic => any sorry-count change is a statement mutation, not
+    # a proof. Block regardless of the delta (Reidemeister had sorry 2->0).
+    no_verified_tactic = attempts == 0 or final_proof is None
+    if no_verified_tactic:
+        return False
+    return (
+        (proof_found
+         or final_sorry == 0
+         or final_sorry < original_sorry_count
+         or structural_progress)
+        and final_build_ok
+    )
+
+
 class MultiAgentSorryProver:
     """Multi-agent sorry replacement using WorkflowBuilder graph.
 
@@ -678,13 +721,39 @@ class MultiAgentSorryProver:
         # IMPORTANT: success ALSO requires final_build_ok — a sorry-count drop
         # without a real build is the iter 2 false positive we are guarding
         # against. final_build_ok is set above in the mandatory verify.
-        success = (
-            (proof_found
-             or final_sorry == 0
-             or final_sorry < original_sorry_count
-             or structural_progress)
-            and final_build_ok
+        # FX-6 (Epic #1453, statement-mutation guard): a sorry-count drop with
+        # NO verified tactic is a statement mutation, not a proof (Reidemeister
+        # L545 trace). Delegate to the pure verifier so the guard is testable.
+        attempts_count = len(state.tactic_history)
+        success = _multi_success_verdict(
+            proof_found=proof_found,
+            final_sorry=final_sorry,
+            original_sorry_count=original_sorry_count,
+            structural_progress=structural_progress,
+            final_build_ok=final_build_ok,
+            attempts=attempts_count,
+            final_proof=state.final_proof,
         )
+        # FX-6 restore: when the build passed and sorry dropped but NO tactic
+        # was attempted (attempts == 0, the unambiguous statement-mutation
+        # signal), the on-disk file holds the mutation (e.g. an in-statement
+        # sorry filled with the goal RHS). Restore the original so the mutation
+        # cannot persist as a silent "success". Conservative: only fires on
+        # attempts == 0 so a legitimate decomposition snapshot (attempts > 0)
+        # is never undone here.
+        if (not success and final_build_ok and attempts_count == 0
+                and final_sorry < original_sorry_count):
+            print(
+                f"  STATEMENT-MUTATION GUARD (FX-6): build OK + sorry "
+                f"{original_sorry_count}->{final_sorry} with no verified tactic "
+                f"(attempts=0, proof={'set' if state.final_proof else 'null'}). "
+                f"Restoring original — not a proof."
+            )
+            try:
+                Path(filepath).write_text(original_content, encoding="utf-8")
+                final_sorry = original_sorry_count
+            except OSError:
+                pass
         self.trace.end_session_span(success, f"{original_sorry_count}->{final_sorry}")
 
         # Persist outcome to cross-session history (best-effort)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1451,3 +1451,153 @@ def test_build_check_or_revert_real_solve_records_zero(tmp_path, monkeypatch):
     original = proved.replace("  trivial\n", "  sorry\n")
     assert tt._build_check_or_revert(original, "test") is None
     assert tt._min_compile_sorry_count == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# FX-6 (Epic #1453) — statement-mutation false-success guard + c.139 token count
+#
+# Incident: the Reidemeister L545 run (trace
+# multi_custom_Reidemeister_L545_openrouter_result.json) filled an in-statement
+# `sorry` placeholder with the goal RHS, making the theorem reflexive -> build
+# OK, sorry 2->0, reported success=true, YET attempts=0 and proof=null. The
+# in-place latch (workflow.py) set proof_found without any verified tactic, so
+# the success verdict must key on attempts/proof, NOT proof_found.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_fx6_guard_blocks_when_no_tactic_attempted():
+    """Reidemeister L545 case: build OK + sorry 2->0, but attempts=0 and
+    proof=None -> success MUST be False (statement mutation, not a proof)."""
+    from prover.provers import _multi_success_verdict
+    assert _multi_success_verdict(
+        proof_found=True,           # tainted by the latch — must NOT rescue it
+        final_sorry=0,
+        original_sorry_count=2,
+        structural_progress=False,
+        final_build_ok=True,
+        attempts=0,                 # no verified tactic
+        final_proof=None,
+    ) is False
+
+
+def test_fx6_guard_blocks_when_proof_null():
+    """attempts>0 but final_proof=None (tactics submitted, none verified) ->
+    still blocked, even with a sorry drop."""
+    from prover.provers import _multi_success_verdict
+    assert _multi_success_verdict(
+        proof_found=False,
+        final_sorry=0,
+        original_sorry_count=2,
+        structural_progress=False,
+        final_build_ok=True,
+        attempts=3,                 # tactics submitted...
+        final_proof=None,           # ...but none verified
+    ) is False
+
+
+def test_fx6_guard_passes_verified_tactic():
+    """Genuine proof: >=1 verified tactic + sorry drop + build OK -> success."""
+    from prover.provers import _multi_success_verdict
+    assert _multi_success_verdict(
+        proof_found=True,
+        final_sorry=0,
+        original_sorry_count=2,
+        structural_progress=False,
+        final_build_ok=True,
+        attempts=1,
+        final_proof="exact Nat.zero_add n",
+    ) is True
+
+
+def test_fx6_guard_build_failure_never_success():
+    """Build failed -> never success, even with a verified tactic."""
+    from prover.provers import _multi_success_verdict
+    assert _multi_success_verdict(
+        proof_found=True,
+        final_sorry=0,
+        original_sorry_count=2,
+        structural_progress=False,
+        final_build_ok=False,
+        attempts=1,
+        final_proof="exact h",
+    ) is False
+
+
+def test_fx6_guard_no_drop_with_tactic_is_failure():
+    """Verified tactic present but sorry did NOT drop (no proof_found, no
+    structural progress) -> failure (the tactic did not close the goal)."""
+    from prover.provers import _multi_success_verdict
+    assert _multi_success_verdict(
+        proof_found=False,
+        final_sorry=2,              # unchanged
+        original_sorry_count=2,
+        structural_progress=False,
+        final_build_ok=True,
+        attempts=2,
+        final_proof="some tactic",  # present -> guard passes, but no drop
+    ) is False
+
+
+def test_fx6_guard_structural_progress_needs_verified_tactic():
+    """structural_progress (decomposition) still requires a verified tactic —
+    decomposition without a proved step is not real progress."""
+    from prover.provers import _multi_success_verdict
+    assert _multi_success_verdict(
+        proof_found=False,
+        final_sorry=3,              # increased (decomposition)
+        original_sorry_count=1,
+        structural_progress=True,
+        final_build_ok=True,
+        attempts=0,
+        final_proof=None,
+    ) is False
+
+
+# ── c.139 token-level sorry count ─────────────────────────────────────────
+
+
+def test_count_sorry_tokens_catches_trailing_comment():
+    """c.139: the strict ``^[ \\t]*sorry$`` missed a bare-sorry line carrying a
+    trailing comment (``sorry -- comment``). The corrected pattern catches it."""
+    from prover.lean_utils import count_sorry_tokens
+    content = "theorem t : True := by\n  sorry -- TODO etudiant\n  sorry\n"
+    # One bare-sorry line with a trailing comment + one clean bare sorry = 2.
+    assert count_sorry_tokens(content) == 2
+
+
+def test_count_sorry_tokens_excludes_comment_mentions():
+    """A ``sorry`` inside a doc/line comment must NOT count (naive .count
+    over-counts these)."""
+    from prover.lean_utils import count_sorry_tokens
+    content = (
+        "/-- Doc mentioning sorry as a word. -/\n"
+        "-- sorry is not a tactic here\n"
+        "theorem t : True := by trivial\n"
+    )
+    assert count_sorry_tokens(content) == 0
+
+
+def test_count_sorry_tokens_le_naive_count():
+    """Token count <= naive substring count (safety invariant for the persist
+    gate: a token-count drop implies a naive-count drop)."""
+    from prover.lean_utils import count_sorry_tokens
+    content = (
+        "-- sorry in a comment\n"
+        "theorem t : True := by sorry\n"
+        "theorem u : True := by\n  sorry\n"
+    )
+    assert count_sorry_tokens(content) <= content.count("sorry")
+    # 2 real proof sorries, 3 naive substring hits (incl. the comment).
+    assert count_sorry_tokens(content) == 2
+
+
+def test_count_sorry_tokens_covers_all_proof_forms():
+    """Covers `:= by sorry`, `:= sorry`, `exact sorry`, and bullet sorry."""
+    from prover.lean_utils import count_sorry_tokens
+    content = (
+        "theorem a : True := by sorry\n"        # := by sorry
+        "def b : True := sorry\n"               # := sorry
+        "theorem c : True := by\n  exact sorry\n"  # exact sorry
+        "theorem d : True := by\n  · sorry\n"   # bullet sorry (· U+00B7)
+    )
+    assert count_sorry_tokens(content) == 4


### PR DESCRIPTION
## Summary

**FX-6 (Epic #1453, mandated by ai-01 msg-20260702T050841-k7w0j9).** Closes the false-success hole that #4075 left open: **a sorry-count drop with NO verified tactic is a statement mutation, not a proof.**

## Incident (founding trace)

`multi_custom_Reidemeister_L545_openrouter_result.json` (knot_lean `Reidemeister.lean` L545): the multi-agent prover filled an in-statement `sorry` placeholder with the goal RHS, making `reidemeister_theorem` reflexive (`KnotEquiv ↔ KnotEquiv`). The build passed and sorry 2→0, so the JSON reported `success=true` / `sorry_delta=-2` — **yet `proof=null` and `attempts=0`** (zero verified tactics). The in-place latch (`workflow.py`) set `proof_found` without any tactic being verified, so the verdict must key on `attempts`/`proof`, NOT on the latch-tainted `proof_found`.

## Changes (3 files, +257/−8)

1. **`provers.py` — `_multi_success_verdict` guard (completes #4075):** extract the success decision into a pure function and gate the sorry-count disjuncts on `attempts > 0 and final_proof is not None`. When the guard blocks on a passing build + sorry drop + `attempts == 0`, **restore the original file** so the mutation cannot persist on disk. Conservative restore (only `attempts == 0`) so legitimate decomposition snapshots (`attempts > 0`) are never undone.
2. **`lean_utils.py` — c.139 `count_sorry_tokens`:** precise token-level sorry counter (catches `sorry -- comment`, `:= by sorry`, `:= sorry`, `exact sorry`, bullet `· sorry`; excludes comment mentions). Used in the persist block's `sorry_dropped` — token count ≤ naive count, so the gate is never loosened, only made honest.
3. **`tests/test_prover_guards.py` — 10 new unit tests:** 6 verdict guards (Reidemeister case, proof-null, verified-tactic pass, build-fail, no-drop, structural-progress) + 4 token-count. **85/85 pass.**

## Verification

```
$ python -m pytest tests/test_prover_guards.py -q
85 passed in 1.64s
```

Reidemeister case modeled directly — the guard returns `False` where the old inline verdict returned `True`:

```python
_multi_success_verdict(proof_found=True, final_sorry=0, original_sorry_count=2,
                       structural_progress=False, final_build_ok=True,
                       attempts=0, final_proof=None)  # -> False (was True)
```

## Notes

- **§B Lean PR criteria:** N/A `grep -c sorry` / Lake build / axiom check — this PR touches **Python harness only** (no `.lean` files). Evidence = the pytest run above.
- In-statement sorry **detection** is intentionally out of scope (FX-4/5 queue); the `attempts=0` signal catches Reidemeister at the verdict layer.
- `proof_knowledge.json` (runtime KB cache) deliberately NOT staged — unrelated timestamp churn.

See #1453
