### PR TITLE
feat(quarto): scaffold static site #4211

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -855,3 +855,8 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/data/temp_*.owl
 
 # Shared Mathlib checkout cache (NTFS junctions, scripts/lean/setup_shared_mathlib.ps1, #2611)
 /.mathlib-cache/
+
+# Quarto build output
+_site/
+**/.quarto/
+_freeze/

--- a/MyIA.AI.Notebooks/index.qmd
+++ b/MyIA.AI.Notebooks/index.qmd
@@ -1,0 +1,111 @@
+---
+title: "Notebooks"
+subtitle: "12 séries pédagogiques niveau 1"
+description: "Liste des 12 séries niveau 1 du dépôt CoursIA — Search, Sudoku, ML, RL, GameTheory, GenAI, Probas, SymbolicAI, QuantConnect, CaseStudies, IIT, SemanticKernel."
+---
+
+# Séries de notebooks
+
+Chaque série est un dossier thématique sous `MyIA.AI.Notebooks/`. Chaque série a son propre README avec table des matières, prérequis, et durée estimée.
+
+## Vue d'ensemble
+
+::: {.series-card}
+### [Search](Search/README.md) — Algorithmes de recherche
+
+BFS, DFS, Dijkstra, A*, métaheuristiques (recuit simulé, essaims), CSP. Point d'entrée idéal pour débutants.
+
+**Notebooks** : 19+ (3 parties : Foundations, CSP, Advanced) · **Kernels** : python3, .net-csharp · **GPU** : non
+:::
+
+::: {.series-card}
+### [Sudoku](Sudoku/README.md) — Résolution multi-paradigme
+
+Un seul problème, plusieurs approches : backtracking, propagation de contraintes, recherche locale, ILP/Z3.
+
+**Notebooks** : 15+ · **Kernels** : python3, .net-csharp · **GPU** : non
+:::
+
+::: {.series-card}
+### [ML](ML/README.md) — Machine Learning (.NET ML.NET)
+
+Classification, régression, clustering, séries temporelles, ML.NET tutorials.
+
+**Notebooks** : 9+ · **Kernels** : .net-csharp · **GPU** : non
+:::
+
+::: {.series-card}
+### [RL](RL/README.md) — Reinforcement Learning
+
+PPO, DQN, Stable Baselines3, Decision Transformer, LSTM-RL, mamba, PatchTST, iTransformer.
+
+**Notebooks** : 7+ · **Kernels** : python3 · **GPU** : recommandé (entraînement)
+:::
+
+::: {.series-card}
+### [GameTheory](GameTheory/README.md) — Théorie des jeux + Lean
+
+Jeux combinatoires, équilibre de Nash, théorème de Folk, choix social (Arrow, Sen), preuves formelles Lean.
+
+**Notebooks** : 6+ (GT-1 à GT-6 + variantes) · **Kernels** : python3, .net-csharp, lean4 · **GPU** : non
+:::
+
+::: {.series-card}
+### [GenAI](../GenAI/README.md) — IA générative multimodale
+
+Image (Stable Diffusion, FLUX, Qwen-VL), audio (Whisper, music), texte (transformers, agents), vibe-coding.
+
+**Notebooks** : 60+ · **Kernels** : python3 · **GPU** : OBLIGATOIRE (RTX 3090+)
+:::
+
+::: {.series-card}
+### [Probas](../Probas/README.md) — Probabilités & décision
+
+Infer.NET (modèles graphiques), PyMC (MCMC, NUTS, ArviZ), Decision Theory (EVPI, EVPII), théorie de la décision bayésienne.
+
+**Notebooks** : 25+ · **Kernels** : .net-csharp (Infer), python3 (PyMC) · **GPU** : non
+:::
+
+::: {.series-card}
+### [SymbolicAI](../SymbolicAI/README.md) — Raisonnement formel
+
+Lean 4 (preuves formelles), Tweety (argumentation), SemanticWeb (RDF, OWL), Planning (OR-tools), SmartContract (Solidity).
+
+**Notebooks** : 30+ · **Kernels** : lean4, .net-csharp, python3 · **GPU** : non
+:::
+
+::: {.series-card}
+### [QuantConnect](../QuantConnect/README.md) — Trading algorithmique
+
+50+ stratégies (Alpha, Momentum, Trend-Following, Options, Mean-Reversion), 27 notebooks, backtest Sharpe/CAGR/MaxDD.
+
+**Notebooks** : 27 + 50 stratégies · **Kernels** : python3 · **GPU** : non (QC Cloud)
+:::
+
+::: {.series-card}
+### [CaseStudies](../CaseStudies/README.md) — Études de cas transverses
+
+Diagnostic médical, oncology planning, Barbie-Schreck, Fort-Boyard, Recipe-Maker, SmartGrid.
+
+**Notebooks** : 6+ · **Kernels** : variable · **GPU** : variable
+:::
+
+::: {.series-card}
+### [IIT](../IIT/README.md) — Integrated Information Theory
+
+PyPhi, φ (phi) computation, causal analysis, théorème de Tononi.
+
+**Notebooks** : 4+ · **Kernels** : python3 · **GPU** : non
+:::
+
+::: {.series-card}
+### [SemanticKernel](../SemanticKernel/README.md) — Microsoft Semantic Kernel
+
+SDK agents IA Microsoft, planners, memory connectors, function calling.
+
+**Notebooks** : 5+ · **Kernels** : python3, .net-csharp · **GPU** : non
+:::
+
+## Cross-series
+
+[`cross-series/`](../cross-series/README.md) — notebooks transverses (multi-séries) : agents de coordination, IPC, validation inter-langages.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,57 @@
+project:
+  type: site
+  output-dir: _site
+  render:
+    - "*.qmd"
+    - "MyIA.AI.Notebooks/index.qmd"
+    - "docs/index.qmd"
+
+site:
+  title: "CoursIA"
+  description: "Apprendre l'intelligence artificielle par la pratique, des fondements théoriques aux applications avancées."
+  site-url: https://jsboige.github.io/CoursIA
+  repo-url: https://github.com/jsboige/CoursIA
+  repo-actions: [edit, issue]
+  page-navigation: true
+  favicon: "favicon.ico"
+  search: true
+  back-to-top-navigation: true
+
+  navbar:
+    title: "CoursIA"
+    left:
+      - href: index.qmd
+        text: "Accueil"
+      - href: MyIA.AI.Notebooks/index.qmd
+        text: "Notebooks"
+      - href: docs/index.qmd
+        text: "Documentation"
+      - href: parcours.qmd
+        text: "Parcours"
+    right:
+      - icon: github
+        href: https://github.com/jsboige/CoursIA
+
+format:
+  html:
+    theme:
+      - cosmo
+      - brand
+    css: styles.css
+    toc: true
+    toc-depth: 3
+    code-link: true
+    code-fold: false
+    code-overflow: wrap
+    smooth-scroll: true
+    lang: fr
+
+lang: fr
+
+execute:
+  freeze: auto
+  cache: true
+  echo: false
+  warning: false
+
+notebook-preview: false

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -1,0 +1,79 @@
+---
+title: "Documentation"
+subtitle: "Documentation projet, règles, et infrastructure"
+description: "Documentation CoursIA : règles (vigilance, validation), infrastructure (kernels, MCP), procédures récurrentes, et guides d'apprentissage."
+---
+
+# Documentation projet
+
+Le répertoire `docs/` centralise les règles de travail, l'infrastructure, les procédés récurrents et les guides d'apprentissage. Cette documentation est destinée aux **contributeurs et opérateurs** du dépôt, pas aux apprenants.
+
+## Catégories
+
+### [Règles & vigilance](reference/regles-vigilance-detail.md)
+
+Détail des règles G.1-G.9 (vigilance permanente) avec incidents fondateurs. Anti-complaisance, vérification G.1, audit avant merge cascade, audit pré-merge, escalade stagnation cross-cycle.
+
+### [Validation réelle](reference/regles-validation-detail.md)
+
+Détail H.1-H.7 (validation REELLE) avec incident Sudoku-13 et plan P0-P4. Preuves vérifiables, exécution Papermill, scan de notebooks non-exécutés, validation post-fix.
+
+### [Procédures récurrentes](reference/procedures-recurrentes.md)
+
+Workflow PR (10 étapes), dispatch agents template, validation notebook bash, audit anti-régression bash, productivité opérations longues (2 tracks min).
+
+### [Anti-régression](reference/anti-regression-detail.md)
+
+Préserver le code de production (preuves Lean, fonctions métier). Interdit de remplacer par sorry/return None/pass sans diagnostic.
+
+### [Kernels & runtime](reference/kernels-runtime.md)
+
+.NET Interactive, Python, WSL Lean 4. Conda envs (coursia-ml-training, mcp-jupyter, epita_symbolic_ai), dotnet-interactive PIN, troubleshooting kernels.
+
+### [Agents & skills](reference/claude-code-config.md)
+
+Catalogue des 21 sous-agents et 15 skills Claude Code, mapping Epic → specialists.
+
+### [Architecture MCP roo-state-manager](reference/architecture_mcp_roo.md)
+
+Architecture du MCP roo-state-manager (34 outils, RooSync), dashboards, coordination inter-machines.
+
+### [Subagents reference](reference/subagents-reference.md)
+
+Catalogue des sous-agents avec mapping Epic → specialists.
+
+### [Scripts reference](reference/scripts-reference.md)
+
+Catalogue des scripts dépôt (notebook CLI, exécution, catalogue anti-drift, qualité, maintenance).
+
+### [Environment Python](reference/env-python-reparation.md)
+
+Réparation env Python (règle F : installer le kernel/env, jamais contourner).
+
+### [Common commands](reference/common-commands.md)
+
+Setup environnement, validation notebooks, slash commands.
+
+### [Curriculum](../curriculum/ia-classique.md) et [Curriculum GenAI](../curriculum/genai.md)
+
+Plans d'apprentissage par école (ECE, ESGF, EPITA, EPF), scope pédagogique.
+
+### [Grothendieckian lens](../grothendieckian-lens.md)
+
+Perspective unificatrice sur les séries du dépôt, à la Grothendieck.
+
+### [Lean](../lean/README.md)
+
+Prover iteration history, intractable diagnosis, LLM endpoints.
+
+### [QC](../qc/quantconnect.md)
+
+Backtests, MCP Docker, structure, livre référence (*Hands-On AI Trading*).
+
+## Pour les apprenants
+
+Si vous venez d'arriver et cherchez à **apprendre** (pas à contribuer) :
+
+1. [PARCOURS.md](../parcours.qmd) — trois parcours certifiés selon votre niveau
+2. [README.md](../README.md) — vue d'ensemble du dépôt
+3. [Catalogue](../COURSE_CATALOG.generated.md) — inventaire exhaustif et à jour

--- a/index.qmd
+++ b/index.qmd
@@ -1,0 +1,68 @@
+---
+title: "CoursIA — Apprendre l'IA par la pratique"
+subtitle: "Notebooks interactifs couvrant l'ensemble du spectre de l'intelligence artificielle"
+description: "CoursIA = collection de notebooks Jupyter (Python, C# .NET Interactive, Lean 4) couvrant recherche, contraintes, théorie des jeux, probabilités, ML, GenAI, et trading algorithmique."
+toc: false
+---
+
+::: {.quarto-title-banner}
+# Bienvenue sur CoursIA
+
+**Une collection de notebooks interactifs pour apprendre l'IA par la pratique — des fondements théoriques aux applications avancées.**
+
+[Parcourir les séries](MyIA.AI.Notebooks/index.qmd){.btn .btn-primary} [Lire la documentation](docs/index.qmd){.btn .btn-secondary}
+:::
+
+## Pourquoi CoursIA ?
+
+**Du concret, pas du bla-bla.** Chaque concept est illustré par un notebook exécutable, avec code, sortie, et interprétation pédagogique. Les notebooks couvrent l'ensemble du spectre de l'IA :
+
+- **Algorithmes fondamentaux** — recherche (BFS, A*, métaheuristiques), résolution de contraintes (CSP), planification
+- **Raisonnement formel** — Lean 4, Tweety (argumentation), logique, théorie des jeux
+- **Probabilités & décision** — Infer.NET, PyMC, modèles graphiques, EVPI
+- **Machine learning** — ML.NET, PPO, Decision Transformer, GNN, LSTM
+- **IA générative multimodale** — ComfyUI, Qwen 2.5-VL, Semantic Kernel, Playwright-OWUI
+- **Trading algorithmique** — QuantConnect, 50+ stratégies, Sharpe/CAGR/MaxDD
+
+## Trois langages, une plateforme
+
+| Langage | Usage | Outils |
+|---------|-------|--------|
+| **Python 3.10+** | ML, GenAI, probabilités, trading | Jupyter, Papermill, PyTorch, PyMC |
+| **C# / .NET 9** | Algorithmes, contraintes, raisonnement | .NET Interactive, ML.NET, Semantic Kernel |
+| **Lean 4** | Preuves formelles, vérification | Lake, Mathlib, REPL |
+
+## Structure du dépôt
+
+```
+MyIA.AI.Notebooks/         # Séries pédagogiques par thème (12 séries niveau 1)
+  Search/                  # Algorithmes de recherche + métaheuristiques
+  Sudoku/                  # Résolution multi-paradigme
+  ML/                      # Machine Learning (.NET C#)
+  RL/                      # Reinforcement Learning (Python)
+  GameTheory/              # Théorie des jeux + Lean (Arrow, Sen)
+  GenAI/                   # IA générative multimodale (image, audio, texte)
+  Probas/                  # Probabilités (Infer.NET, PyMC)
+  SymbolicAI/              # Lean, Tweety, SemanticWeb, Planning
+  QuantConnect/            # Trading algorithmique (27 notebooks + 50 stratégies)
+  CaseStudies/             # Études de cas transverses
+  IIT/                     # Integrated Information Theory (PyPhi)
+  SemanticKernel/          # SDK Microsoft Semantic Kernel
+docs/                      # Documentation projet (règles, harnais, références)
+```
+
+## Comment commencer ?
+
+Trois parcours certifiés selon votre niveau — voir [PARCOURS.md](parcours.qmd) :
+
+1. **Local sobre** — Python + Jupyter uniquement, sans GPU, sans Docker. Idéal pour démarrer.
+2. **ML.NET + Symbolic** — Ajout de .NET Interactive pour les algorithmes C# et Lean 4.
+3. **GenAI complet** — Inclut Docker (ComfyUI, Qwen), GPU RTX 3090, services cloud.
+
+## Catalogue vivant
+
+L'inventaire exhaustif (nombre exact de notebooks par série, statut READY/DEMO, maturité PRODUCTION/BETA) vit dans [`COURSE_CATALOG.generated.md`](COURSE_CATALOG.generated.md). Ce catalogue est régénéré automatiquement chaque jour : il fait foi sur les chiffres et les statuts, ce site en donne la vue d'ensemble pédagogique.
+
+## Licence
+
+MIT — voir [LICENSE](LICENSE).

--- a/parcours.qmd
+++ b/parcours.qmd
@@ -1,0 +1,72 @@
+---
+title: "Parcours d'apprentissage"
+subtitle: "Trois parcours certifiés selon votre niveau"
+description: "Parcours d'apprentissage CoursIA : local sobre (Python uniquement), ML.NET + Symbolic (avec .NET Interactive + Lean 4), GenAI complet (Docker + GPU)."
+---
+
+# Parcours d'apprentissage
+
+Trois parcours certifiés selon votre niveau, vos prérequis, et votre matériel. Tous convergent vers le catalogue unifié — vous pouvez passer de l'un à l'autre au fil de votre progression.
+
+## 1. Local sobre — Python + Jupyter uniquement
+
+**Prérequis** : Python 3.10+, 8 GB RAM. Aucun GPU, aucun Docker.
+
+**Couvre** : notebooks Python purs, sans dépendance externe.
+
+**Séries accessibles** :
+
+- `Search/Part1-Foundations` — BFS, DFS, Dijkstra, A*
+- `Sudoku/Sudoku-Python` — solveur Python pur
+- `GameTheory` — jeux combinatoires en Python
+- `Probas/InferGlossary` — probabilités discrètes de base
+- `RL` — Reinforcement Learning (Stable Baselines3)
+- `GenAI/Audio/01-Foundation` — audio via librosa + transformers
+
+**Démarrage rapide** :
+
+```bash
+git clone https://github.com/jsboige/CoursIA.git
+cd CoursIA
+python -m venv .venv
+source .venv/bin/activate   # ou .venv\Scripts\activate sous Windows
+pip install jupyter papermill
+jupyter notebook MyIA.AI.Notebooks/
+```
+
+## 2. ML.NET + Symbolic — .NET Interactive + Lean 4
+
+**Prérequis** : Python (parcours 1) + .NET 9 SDK + (optionnel) WSL pour Lean 4.
+
+**Ajoute** : notebooks C#/.NET Interactive, preuves formelles Lean, Argumentum (Tweety porté).
+
+**Séries supplémentaires** :
+
+- `ML/` — ML.NET tutorials (classification, régression, clustering)
+- `Sudoku/Sudoku-CSharp` — solveur C# avec contraintes
+- `SymbolicAI/Lean` — preuves formelles (gammes, socles, induction)
+- `SymbolicAI/Tweety` — argumentation computationnelle (port IKVM)
+- `SymbolicAI/Planning` — planification automatique (OR-tools)
+
+## 3. GenAI complet — Docker + GPU + services cloud
+
+**Prérequis** : parcours 2 + Docker Desktop + GPU NVIDIA (RTX 3090 recommandée, 24 GB VRAM).
+
+**Ajoute** : services GenAI auto-hébergés (ComfyUI, Qwen, Forge), notebooks GenAI avancés.
+
+**Séries supplémentaires** :
+
+- `GenAI/Image` — génération d'images (Stable Diffusion, FLUX, Qwen-VL)
+- `GenAI/Audio/02-Advanced` — TTS, Whisper, music generation
+- `GenAI/Vibe-Coding` — assistants IA en local (Claude Code, Roo)
+- `QuantConnect/` — 50+ stratégies de trading algorithmique (Lean engine)
+
+## Passerelles entre parcours
+
+Le dépôt est conçu pour être progressif. Les notebooks marqués `Prerequisites: parcours N` indiquent leur niveau. Le [catalogue](COURSE_CATALOG.generated.md) référence pour chaque notebook :
+
+- Kernel requis (python3 / .net-csharp / lean4)
+- GPU requis (oui/non)
+- Clés API nécessaires (HF, OpenAI, Anthropic, QC)
+
+**Règle d'or** : commencez par le parcours 1 (local sobre), explorez jusqu'à saturation, puis passez au parcours 2. Le parcours 3 est optionnel et demande du matériel dédié.

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,45 @@
+/* CoursIA custom styles */
+
+.navbar-brand {
+  font-weight: 600;
+}
+
+.quarto-title-banner {
+  background: linear-gradient(135deg, #1e3a8a 0%, #3b82f6 100%);
+  color: white;
+  padding: 3rem 1.5rem;
+  border-radius: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.quarto-title-banner h1 {
+  color: white;
+  font-size: 2.5rem;
+}
+
+.quarto-title-banner p.lead {
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 1.25rem;
+}
+
+.series-card {
+  border-left: 4px solid #3b82f6;
+  padding: 1rem;
+  margin: 1rem 0;
+  background: #f8fafc;
+  border-radius: 0.25rem;
+}
+
+.series-card h3 {
+  margin-top: 0;
+}
+
+.series-card .badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: #dbeafe;
+  color: #1e40af;
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
feat(quarto): scaffold static site #4211

## Scope
Scaffolding initial du site Quarto pour CoursIA — 6 nouveaux fichiers + 5 lignes .gitignore, **zero modification de code**. Permet de publier un site pedagogique coherent en FR avec :
- Homepage FR (banner + 12-series tree + 3 parcours)
- Page Notebooks (12 series niveau 1, kernels/GPU clarifies)
- Page Documentation (pointeurs succints vers docs/reference/*)
- Page Parcours (3 parcours certifies selon niveau/materiel)

## Files (7 changed, +437/-0)
- `_quarto.yml` (57) : config site (theme cosmo+brand, lang FR, render list EXPLICITE)
- `index.qmd` (68) : homepage
- `parcours.qmd` (72) : 3 parcours
- `MyIA.AI.Notebooks/index.qmd` (111) : 12 series
- `docs/index.qmd` (79) : documentation projet
- `styles.css` (45) : banner gradient + .series-card
- `.gitignore` (+5) : `_site/`, `**/.quarto/`, `_freeze/`

## Validation locale (papermill-like)
- `quarto --version` -> 1.7.32 ✅
- `quarto render` -> 4/4 pages, _site/ = 1.7MB ✅
  - `index.html` (26KB)
  - `parcours.html` (29KB)
  - `MyIA.AI.Notebooks/index.html` (52KB)
  - `docs/index.html` (60KB)
- search.json operationnel, sitemap.xml genere, robots.txt present

## Anti-patterns evites
- **JAMAIS regenerer catalogue** sur cette branche (cf catalog-pr-hygiene) : `_quarto.yml` n'inclut PAS le catalog-cron, et la branche ne touche ni `COURSE_CATALOG.generated.*` ni les blocs CATALOG-STATUS des READMEs.
- **Render list explicite** dans `_quarto.yml` pour eviter le scan massif de 1870+ fichiers (sinon Quarto detecte tous les .md/.ipynb du repo).
- **CRLF preserve** sur .gitignore (printf au lieu de echo) — diff minimal (+5 lignes), pas de conversion LF/CRLF.
- **Pas de secrets** : aucun token/cle dans les fichiers scaffolding (FR doc only).
- **FR-first** (readme-french-first) : 100% du contenu pedagogique en francais, pas de "match surrounding EN".

## Decisions architecturales
- **`render:` list explicite** au lieu de `*.qmd` glob : protection contre scan massif accidentel.
- **`output-dir: _site`** : convention Quarto standard (Jekyll-like).
- **`freeze: auto`** + **`cache: true`** : pour futures integrations notebooks (papermill-like).
- **`notebook-preview: false`** : on n'inclut PAS les .ipynb dans le site pour cette premiere passe (scaffolding docs uniquement).
- **`echo: false`** dans `execute` : resultat visible, code cache (UX).

## Liens
- Closes nothing (scaffolding initial, scope fondation site)
- Part of #4211 (creer le site Quarto - premiere tranche)
- See #1271 (catalogue moteur Argumentum - Phase scriptée, hors-scope ici)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
