### PR TITLE
feat(prover): FX-6b in-statement sorry guard - refuse specification holes before any run

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -74,6 +74,68 @@ def count_real_sorries(content: str) -> int:
     return len(_SORRY_TOKEN_RE.findall(strip_lean_comments(content)))
 
 
+_DECL_START_RE = re.compile(
+    r"^\s*(?:@\[[^\]]*\]\s*)?"
+    r"(?:private\s+|protected\s+|noncomputable\s+|partial\s+|unsafe\s+)*"
+    r"(?:theorem|lemma|def|instance|example|abbrev|structure|inductive|"
+    r"class|opaque)\b"
+)
+
+
+def sorry_is_in_statement(content: str, sorry_line: int) -> bool:
+    """True when the sorry at ``sorry_line`` sits INSIDE its declaration's
+    statement — i.e. BEFORE the first ``:=`` of the enclosing declaration
+    (FX-6b, #1453).
+
+    Such a hole is a SPECIFICATION gap, not a proof obligation: "filling" it
+    rewrites the theorem itself (founding incident: Reidemeister.lean L545,
+    ``sorry -- ambient_isotopic k₁ k₂`` inside an Iff statement, rewritten
+    to the RHS producing a vacuous X ↔ X). No prover run can honestly close
+    it — the decision of WHAT the statement says belongs to a human.
+
+    Deliberately conservative (never blocks a legitimate run):
+    - sorry only inside a comment on the target line → False
+    - no enclosing declaration found → False
+    - no ``:=`` in the declaration (match-syntax ``| pat =>`` bodies)
+      → False (a sorry in the TYPE of a match-syntax def is the accepted
+      residual false-negative; none exists in the repo)
+    - a ``:=`` inside a ``/- -/`` block comment or a default-value binder
+      ``(h : T := v)`` before the real one → False (residual, documented)
+
+    ``--`` line comments ARE stripped per-line before the structural scan.
+    """
+    lines = content.split("\n")
+    if not (1 <= sorry_line <= len(lines)):
+        return False
+
+    def _code(line: str) -> str:
+        return line.split("--", 1)[0]
+
+    m_sorry = _SORRY_TOKEN_RE.search(_code(lines[sorry_line - 1]))
+    if m_sorry is None:
+        return False
+
+    decl_idx = None
+    for i in range(sorry_line - 1, -1, -1):
+        if _DECL_START_RE.match(_code(lines[i])):
+            decl_idx = i
+            break
+    if decl_idx is None:
+        return False
+
+    for j in range(decl_idx, len(lines)):
+        if j > decl_idx and _DECL_START_RE.match(_code(lines[j])):
+            return False  # next declaration reached without any ':='
+        col = _code(lines[j]).find(":=")
+        if col >= 0:
+            if j < sorry_line - 1:
+                return False  # ':=' above the sorry line → sorry in the body
+            if j == sorry_line - 1:
+                return m_sorry.start() < col  # same line: position decides
+            return True  # ':=' below the sorry line → sorry in the statement
+    return False
+
+
 def is_honest_sorry(filepath: str, sorry_line: int,
                     lookback: int = 12) -> Tuple[bool, str]:
     """Check whether the sorry at `sorry_line` is documented as intentionally

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -18,7 +18,7 @@ from .state import ProofState, SorryContext, ProofPhase, PHASE_TRANSITIONS, Tact
 from .lean_utils import (
     extract_sorry_block, get_goal_state, verify_sorry_replacement,
     extract_hypotheses, extract_local_lemmas, build_def_type_warnings,
-    is_honest_sorry,
+    is_honest_sorry, sorry_is_in_statement,
 )
 from .tools import SearchTools, TacticTools, CriticTools, CoordinatorTools, DiagnosisTools
 from .agents import (
@@ -174,6 +174,43 @@ def _refuse_honest_sorry(filepath: str, sorry_line: int,
             "filepath": filepath,
         }
     return None
+
+
+def _refuse_in_statement_sorry(filepath: str, sorry_line: int,
+                               demo_name: str) -> Optional[dict]:
+    """Return an early-fail result dict if the target sorry is IN-STATEMENT.
+
+    FX-6b (#1453): a sorry BEFORE the ``:=`` of its enclosing declaration is
+    a hole in the STATEMENT itself (e.g. Reidemeister.lean L545,
+    ``sorry -- ambient_isotopic k₁ k₂`` inside an Iff). No run can honestly
+    close it: any "fix" mutates the theorem — exactly the false-success
+    family the FX-6 gate catches downstream. Refusing here saves the whole
+    run (~190-2600s observed) instead of looping to the iteration cap.
+    Mirrors the shape of ``_refuse_honest_sorry``. Returns None when the
+    file is unreadable (the run proceeds; downstream guards still apply).
+    """
+    try:
+        content = Path(filepath).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not sorry_is_in_statement(content, sorry_line):
+        return None
+    msg = (
+        f"REFUSED: sorry at {filepath}:{sorry_line} is INSIDE the declaration "
+        f"statement (before its ':='). Filling it is a specification "
+        f"decision, not a proof — a human must decide what the statement "
+        f"says. (FX-6b, founding incident Reidemeister.lean L545)"
+    )
+    print(f"\n{'!'*70}\n{msg}\n{'!'*70}\n")
+    return {
+        "success": False,
+        "skipped": True,
+        "reason": "in_statement_sorry",
+        "detail": msg,
+        "demo": demo_name,
+        "sorry_line": sorry_line,
+        "filepath": filepath,
+    }
 
 
 def _autonomous_success_gate(final_sorry: int, original_sorry_count: int,
@@ -349,6 +386,12 @@ class MultiAgentSorryProver:
         intractable = _refuse_intractable(filepath, sorry_line, demo["name"])
         if intractable is not None:
             return intractable
+
+        # FX-6b (#1453): refuse in-statement sorrys BEFORE spinning up agents
+        # — a specification hole cannot be proved, only mutated.
+        in_stmt = _refuse_in_statement_sorry(filepath, sorry_line, demo["name"])
+        if in_stmt is not None:
+            return in_stmt
 
         print(f"\n{'='*70}")
         print(f"MULTI-AGENT PROVER: {demo['name']}")
@@ -939,6 +982,12 @@ class AutonomousProver:
         intractable = _refuse_intractable(filepath, sorry_line, demo["name"])
         if intractable is not None:
             return intractable
+
+        # FX-6b (#1453): refuse in-statement sorrys BEFORE spinning up the
+        # agent — a specification hole cannot be proved, only mutated.
+        in_stmt = _refuse_in_statement_sorry(filepath, sorry_line, demo["name"])
+        if in_stmt is not None:
+            return in_stmt
 
         print(f"\n{'='*70}")
         print(f"AUTONOMOUS PROVER: {demo['name']}")

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -749,6 +749,43 @@ class VerifyExecutor(Executor):
             await ctx.send_message(msg)
             return
 
+        # FX-6b (#1453): defense-in-depth against the latch+proof_found hole
+        # (po-2026 post-merge review of #4909). The in-place latch below and
+        # verify_sorry_replacement both set msg.proof_found=True WITHOUT
+        # touching state.tactic_history, and proof_found is a standalone OR
+        # disjunct in the success gates — so a statement-mutation that fires
+        # either path would bypass both the verified_tactic_count check and
+        # _stmt_mutation_guard (which requires NOT proof_found). A sorry that
+        # sits INSIDE its declaration's statement can never be honestly
+        # proved: refuse the verify outright. The provers.py entry refusal
+        # normally catches this before any agent runs; this covers direct
+        # workflow entries.
+        try:
+            from .lean_utils import sorry_is_in_statement as _fx6b_in_stmt
+            _fx6b_src = getattr(self._sorry_ctx, "full_file", "") or ""
+            if _fx6b_src and _fx6b_in_stmt(
+                    _fx6b_src, self._sorry_ctx.sorry_line):
+                msg.error = (
+                    "IN_STATEMENT_SORRY: the target sorry is inside the "
+                    "declaration statement (before its ':='); filling it is "
+                    "a specification decision, not a proof (FX-6b)."
+                )
+                msg.error_type = "in_statement_sorry"
+                if self._trace:
+                    self._trace.log(
+                        agent="VerifyExecutor", role="fx6b_guard",
+                        content=msg.error,
+                    )
+                await ctx.yield_output(msg)
+                return
+        except Exception as _fx6b_err:
+            if self._trace:
+                self._trace.log(
+                    agent="VerifyExecutor", role="fx6b_guard_error",
+                    content=(f"in-statement check failed, falling through: "
+                             f"{_fx6b_err}"),
+                )
+
         # P1 latch-success (Epic #1453, 2026-05-23 forensic): detect the case
         # where TacticAgent has ALREADY proved the target in-place before this
         # verify runs. tools.file_replace_lines edits the REAL target file on

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1620,3 +1620,156 @@ def test_strip_lean_comments_preserves_code():
     assert "tail comment" not in stripped
     assert "spanning lines" not in stripped
     assert "theorem t : 1 + 1 = 2 := by norm_num" in stripped
+
+
+# --- FX-6b (#1453): sorry_is_in_statement + in-statement entry refusal ------
+# The latch (workflow.py) and verify_sorry_replacement both set
+# proof_found=True without touching tactic_history, and proof_found is a
+# standalone OR disjunct in the success gates (po-2026 post-merge review of
+# #4909). An in-statement sorry "closed" through either path is a statement
+# mutation the FX-6 gate cannot see. The fix is upstream: such a hole is a
+# SPECIFICATION gap, refused before any agent runs.
+
+REIDEMEISTER_L545_SHAPE = (
+    "import Mathlib.Tactic\n"                                        # 1
+    "\n"                                                             # 2
+    "def KnotEquiv (a b : Nat) : Prop := a = b\n"                    # 3
+    "\n"                                                             # 4
+    "theorem reidemeister_theorem :\n"                               # 5
+    "    ∀ (k₁ k₂ : Nat),\n"                          # 6
+    "      -- Ambient isotopy of the embeddings\n"                   # 7
+    "      sorry -- ambient_isotopic k₁ k₂\n"              # 8  <- in-statement
+    "      ↔\n"                                                 # 9
+    "      KnotEquiv k₁ k₂ := by\n"                        # 10 <- first ':='
+    "  exact sorry\n"                                                # 11 <- in-body
+)
+
+
+def test_in_statement_detected_on_reidemeister_shape():
+    from prover.lean_utils import sorry_is_in_statement
+
+    assert sorry_is_in_statement(REIDEMEISTER_L545_SHAPE, 8) is True
+
+
+def test_in_body_sorry_of_same_declaration_not_flagged():
+    from prover.lean_utils import sorry_is_in_statement
+
+    assert sorry_is_in_statement(REIDEMEISTER_L545_SHAPE, 11) is False
+
+
+def test_same_line_sorry_after_assign_is_body():
+    from prover.lean_utils import sorry_is_in_statement
+
+    content = "theorem foo : 1 + 1 = 2 := by sorry\n"
+    assert sorry_is_in_statement(content, 1) is False
+
+
+def test_same_line_sorry_before_assign_is_statement():
+    from prover.lean_utils import sorry_is_in_statement
+
+    content = "def x : sorry := trivial\n"
+    assert sorry_is_in_statement(content, 1) is True
+
+
+def test_match_syntax_body_without_assign_not_flagged():
+    from prover.lean_utils import sorry_is_in_statement
+
+    content = (
+        "def f : Nat → Nat\n"
+        "  | 0 => sorry\n"
+        "  | _ => 1\n"
+    )
+    assert sorry_is_in_statement(content, 2) is False
+
+
+def test_sorry_only_in_comment_on_target_line_not_flagged():
+    from prover.lean_utils import sorry_is_in_statement
+
+    content = (
+        "theorem t :\n"
+        "    -- sorry, this comment mentions it\n"
+        "    1 + 1 = 2 := by norm_num\n"
+    )
+    assert sorry_is_in_statement(content, 2) is False
+
+
+def test_attribute_and_modifiers_above_declaration_handled():
+    from prover.lean_utils import sorry_is_in_statement
+
+    content = (
+        "@[simp]\n"
+        "private noncomputable def g :\n"
+        "    sorry := by\n"
+        "  trivial\n"
+    )
+    # ':=' is on line 3 at a column AFTER the sorry token -> statement
+    assert sorry_is_in_statement(content, 3) is True
+
+
+def test_line_comment_assign_is_ignored_in_scan():
+    from prover.lean_utils import sorry_is_in_statement
+
+    content = (
+        "theorem t :\n"
+        "    -- fake := in a comment\n"
+        "    sorry\n"
+        "    ↔ True := by\n"
+        "  exact sorry\n"
+    )
+    assert sorry_is_in_statement(content, 3) is True
+
+
+def test_out_of_range_line_not_flagged():
+    from prover.lean_utils import sorry_is_in_statement
+
+    assert sorry_is_in_statement("theorem t : True := by sorry\n", 99) is False
+    assert sorry_is_in_statement("", 1) is False
+
+
+def test_no_enclosing_declaration_not_flagged():
+    from prover.lean_utils import sorry_is_in_statement
+
+    content = "-- orphan\nsorry\n"
+    assert sorry_is_in_statement(content, 2) is False
+
+
+def test_next_declaration_bounds_the_scan():
+    from prover.lean_utils import sorry_is_in_statement
+
+    # decl A uses match syntax (no ':='); decl B below has one. The scan
+    # must stop at decl B and NOT attribute B's ':=' to A's sorry.
+    content = (
+        "def f : Nat → Nat\n"
+        "  | 0 => sorry\n"
+        "theorem t : True := by trivial\n"
+    )
+    assert sorry_is_in_statement(content, 2) is False
+
+
+def test_refuse_in_statement_sorry_returns_skip_dict(tmp_path):
+    from prover.provers import _refuse_in_statement_sorry
+
+    f = tmp_path / "Reid.lean"
+    f.write_text(REIDEMEISTER_L545_SHAPE, encoding="utf-8")
+    result = _refuse_in_statement_sorry(str(f), 8, "demo-reid")
+    assert result is not None
+    assert result["success"] is False
+    assert result["skipped"] is True
+    assert result["reason"] == "in_statement_sorry"
+    assert result["sorry_line"] == 8
+    assert result["demo"] == "demo-reid"
+
+
+def test_refuse_in_statement_sorry_none_for_body_sorry(tmp_path):
+    from prover.provers import _refuse_in_statement_sorry
+
+    f = tmp_path / "Reid.lean"
+    f.write_text(REIDEMEISTER_L545_SHAPE, encoding="utf-8")
+    assert _refuse_in_statement_sorry(str(f), 11, "demo-reid") is None
+
+
+def test_refuse_in_statement_sorry_none_when_file_missing(tmp_path):
+    from prover.provers import _refuse_in_statement_sorry
+
+    missing = tmp_path / "nope.lean"
+    assert _refuse_in_statement_sorry(str(missing), 8, "demo") is None


### PR DESCRIPTION
## Summary

Closes the **residual hole** po-2026 flagged in its post-merge review of #4909 (msg-...kwmlxt): the in-place latch (workflow.py:808) and `verify_sorry_replacement` success (workflow.py:852) both set `proof_found=True` **without touching `tactic_history`**, and `proof_found` is a **standalone OR disjunct** in the success gates — so a statement mutation that fires either path bypasses both the FX-6 `verified_tactic_count` check and `_stmt_mutation_guard` (which requires `NOT proof_found`). Verified against source before acting (G.1): gate at provers.py ~744, latch at workflow.py ~808/852.

## Fix (upstream of the gates)

A sorry sitting **inside its declaration's statement** (before the first `:=`) is a **specification hole** — no run can honestly close it; any "fix" mutates the theorem (founding incident: Reidemeister.lean L545, `sorry -- ambient_isotopic k₁ k₂` inside an Iff).

| Layer | Change |
|-------|--------|
| `lean_utils.py` | `sorry_is_in_statement()` — delimits the enclosing declaration (attributes/modifiers, next-declaration bound, per-line `--` strip), compares sorry position vs first `:=`. **Conservative**: match-syntax bodies / unreadable → False (never blocks a legitimate run). |
| `provers.py` | `_refuse_in_statement_sorry()` early refusal at **both** entries (multi + autonomous), mirroring `_refuse_honest_sorry`. Saves the whole run (~190-2600s observed on the two mutation traces) instead of looping to the iteration cap. |
| `workflow.py` | Defense-in-depth guard **before the latch**, covering both `proof_found` paths for direct workflow entries. |

## Proof

- **105/105 tests** (14 new: shape tests incl. exact Reidemeister L545 multi-line Iff shape, same-line before/after `:=`, match-syntax, comment-only sorry, attributes, next-decl bound, refusal dict shape).
- **Real-file validation**: Reidemeister L545 → `True` ; L549 (`exact sorry`) → `False` ; all 8 Conway sorries → `False` (**zero false positives on the real sorry map**, 27 real sorries).
- Live-fire context: today's replay (trace `multi_custom_Reidemeister_L545_zai.json`) burned 190s to reach the FX-6 downstream guard; with FX-6b the same run refuses in <1s at entry.

## Notes

- `proof_knowledge.json` churn NOT committed (FX-4 rule).
- FX-5 (True-placeholder short-circuit) + FX-7 (counter migration) remain with po-2026 (ping-pong #1453).

See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)