### PR TITLE
feat(ml): L2 CS+DM research notebook (ladder #1409, See #4876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l2_dual_momentum.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l2_dual_momentum.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e22b7b4d",
+   "id": "87e89355",
    "metadata": {},
    "source": [
     "# L2 — Cross-Sectional + Dual Momentum sur le panier anti-biais\n",
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6f15fb7",
+   "id": "fa42c32f",
    "metadata": {},
    "source": [
     "## 1. Chargement du panier anti-biais (données locales mises en cache)\n",
@@ -48,13 +48,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "d3457eb3",
+   "id": "27eda9db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T06:44:14.979528Z",
-     "iopub.status.busy": "2026-07-02T06:44:14.979358Z",
-     "iopub.status.idle": "2026-07-02T06:44:17.467370Z",
-     "shell.execute_reply": "2026-07-02T06:44:17.466768Z"
+     "iopub.execute_input": "2026-07-02T08:25:58.659610Z",
+     "iopub.status.busy": "2026-07-02T08:25:58.659296Z",
+     "iopub.status.idle": "2026-07-02T08:26:01.486476Z",
+     "shell.execute_reply": "2026-07-02T08:26:01.485356Z"
     }
    },
    "outputs": [
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25a9ec38",
+   "id": "672ada2d",
    "metadata": {},
    "source": [
     "## 2. Benchmark : buy-and-hold equipondéré (Sharpe 1.15)\n",
@@ -195,13 +195,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "dfbc8ffb",
+   "id": "67638c04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T06:44:17.469679Z",
-     "iopub.status.busy": "2026-07-02T06:44:17.469509Z",
-     "iopub.status.idle": "2026-07-02T06:44:17.481857Z",
-     "shell.execute_reply": "2026-07-02T06:44:17.481315Z"
+     "iopub.execute_input": "2026-07-02T08:26:01.489129Z",
+     "iopub.status.busy": "2026-07-02T08:26:01.488831Z",
+     "iopub.status.idle": "2026-07-02T08:26:01.505236Z",
+     "shell.execute_reply": "2026-07-02T08:26:01.504249Z"
     }
    },
    "outputs": [
@@ -219,7 +219,8 @@
     "N_SPLITS, GAP = 5, 21\n",
     "TOP_N = 5\n",
     "LOOKBACKS = [63, 126, 252]\n",
-    "REBAL_FREQ = 21  # mensuel (21 jours de bourse ~ 1 mois)\n",
+    "# NB : la frequence de reequilibrage (mensuelle, 21j) est portee par le module\n",
+    "# canonique via la constante L2.REBALANCE_FREQ. Voir l'Exercice 3.\n",
     "\n",
     "bh_result = L2.run_buyhold_baseline(closes, SEEDS, N_SPLITS, GAP)\n",
     "bh_mean = float(np.mean([s[\"sharpe\"] for s in bh_result[\"seeds\"]]))\n",
@@ -229,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b3acacf",
+   "id": "c58fb666",
    "metadata": {},
    "source": [
     "## 3. Cross-sectional momentum (top-5 mensuel)\n",
@@ -242,13 +243,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "31a0f134",
+   "id": "a871ca51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T06:44:17.483610Z",
-     "iopub.status.busy": "2026-07-02T06:44:17.483470Z",
-     "iopub.status.idle": "2026-07-02T06:44:17.684825Z",
-     "shell.execute_reply": "2026-07-02T06:44:17.684097Z"
+     "iopub.execute_input": "2026-07-02T08:26:01.507475Z",
+     "iopub.status.busy": "2026-07-02T08:26:01.507127Z",
+     "iopub.status.idle": "2026-07-02T08:26:01.803000Z",
+     "shell.execute_reply": "2026-07-02T08:26:01.801938Z"
     }
    },
    "outputs": [
@@ -256,14 +257,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CS lb  63j | gross +0.681 | net +0.662 | delta -0.488 | ~205 trades/seed\n",
-      "CS lb 126j | gross +0.952 | net +0.935 | delta -0.216 | ~161 trades/seed\n"
+      "CS lb  63j | gross +0.681 | net +0.662 | delta -0.488 | ~205 trades/seed\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "CS lb 126j | gross +0.952 | net +0.935 | delta -0.216 | ~161 trades/seed\n",
       "CS lb 252j | gross +1.019 | net +0.997 | delta -0.153 | ~143 trades/seed\n"
      ]
     }
@@ -282,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dde0c7ea",
+   "id": "fbc44a9a",
    "metadata": {},
    "source": [
     "## 4. Dual momentum (cross-sectional + filtre absolu, cash = SHY)\n",
@@ -296,13 +297,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "290b4806",
+   "id": "8ff7f3dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T06:44:17.687360Z",
-     "iopub.status.busy": "2026-07-02T06:44:17.687172Z",
-     "iopub.status.idle": "2026-07-02T06:44:17.915331Z",
-     "shell.execute_reply": "2026-07-02T06:44:17.914596Z"
+     "iopub.execute_input": "2026-07-02T08:26:01.805852Z",
+     "iopub.status.busy": "2026-07-02T08:26:01.805321Z",
+     "iopub.status.idle": "2026-07-02T08:26:02.049578Z",
+     "shell.execute_reply": "2026-07-02T08:26:02.048780Z"
     }
    },
    "outputs": [
@@ -317,13 +318,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DM lb 126j | gross +0.648 | net +0.618 | delta -0.533 | ~138 trades/seed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "DM lb 126j | gross +0.648 | net +0.618 | delta -0.533 | ~138 trades/seed\n",
       "DM lb 252j | gross +0.667 | net +0.628 | delta -0.522 | ~120 trades/seed\n"
      ]
     }
@@ -342,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afdc9d65",
+   "id": "1d5131c2",
    "metadata": {},
    "source": [
     "### Table de verdict canonique (cross-sectional vs dual momentum)\n",
@@ -354,13 +349,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d3365ad9",
+   "id": "dc5a2616",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T06:44:17.918025Z",
-     "iopub.status.busy": "2026-07-02T06:44:17.917841Z",
-     "iopub.status.idle": "2026-07-02T06:44:17.931599Z",
-     "shell.execute_reply": "2026-07-02T06:44:17.930945Z"
+     "iopub.execute_input": "2026-07-02T08:26:02.051916Z",
+     "iopub.status.busy": "2026-07-02T08:26:02.051644Z",
+     "iopub.status.idle": "2026-07-02T08:26:02.065985Z",
+     "shell.execute_reply": "2026-07-02T08:26:02.065200Z"
     }
    },
    "outputs": [
@@ -402,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0cb5428b",
+   "id": "cf1aac46",
    "metadata": {},
    "source": [
     "### Lecture du verdict\n",
@@ -428,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5c8c987",
+   "id": "fd9a59fc",
    "metadata": {},
    "source": [
     "## 5. Exercices\n",
@@ -438,7 +433,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60057248",
+   "id": "42b58c45",
    "metadata": {},
    "source": [
     "### Exercice 1 — Sensibilité au top-N\n",
@@ -455,13 +450,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e4ed87bb",
+   "id": "ffd40b84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T06:44:17.933738Z",
-     "iopub.status.busy": "2026-07-02T06:44:17.933583Z",
-     "iopub.status.idle": "2026-07-02T06:44:17.936841Z",
-     "shell.execute_reply": "2026-07-02T06:44:17.936306Z"
+     "iopub.execute_input": "2026-07-02T08:26:02.068401Z",
+     "iopub.status.busy": "2026-07-02T08:26:02.068096Z",
+     "iopub.status.idle": "2026-07-02T08:26:02.072393Z",
+     "shell.execute_reply": "2026-07-02T08:26:02.071720Z"
     }
    },
    "outputs": [],
@@ -480,7 +475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a72896a",
+   "id": "9fb5f8c2",
    "metadata": {},
    "source": [
     "### Exercice 2 — L'effet du filtre absolu (dual vs cross-sectional)\n",
@@ -497,13 +492,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "cc36d2fd",
+   "id": "12b4fcad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T06:44:17.938906Z",
-     "iopub.status.busy": "2026-07-02T06:44:17.938615Z",
-     "iopub.status.idle": "2026-07-02T06:44:17.941820Z",
-     "shell.execute_reply": "2026-07-02T06:44:17.941311Z"
+     "iopub.execute_input": "2026-07-02T08:26:02.074229Z",
+     "iopub.status.busy": "2026-07-02T08:26:02.074050Z",
+     "iopub.status.idle": "2026-07-02T08:26:02.078068Z",
+     "shell.execute_reply": "2026-07-02T08:26:02.077253Z"
     }
    },
    "outputs": [],
@@ -522,7 +517,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbf8e25c",
+   "id": "e54c6a5a",
    "metadata": {},
    "source": [
     "### Exercice 3 — Fréquence de rebalancement vs coût de rotation\n",
@@ -530,30 +525,32 @@
     "**Contexte** : L1 (quotidien) = 5519 trades → net −2.26. L2 (mensuel) = 143 trades → net\n",
     "0.997. La fréquence est le levier dominant.\n",
     "\n",
-    "**Objectif** : testez une fréquence **bimensuelle** (42j) en modifiant `REBAL_FREQ`.\n",
+    "**Objectif** : testez une fréquence **bimensuelle** (42j) en modifiant `REBALANCE_FREQ`.\n",
     "Relancez le CS à 126j et comparez trades + net Sharpe vs mensuel (21j).\n",
     "\n",
-    "*Indice* : `REBAL_FREQ` est une constante du module. On peut monkey-patcher\n",
-    "`L2.REBAL_FREQ = 42` avant d'appeler `run_cross_sectional` ( restaurer à 21 après)."
+    "*Indice* : `REBALANCE_FREQ` est la constante du module canonique (vaut 21 = mensuel).\n",
+    "On peut la monkey-patcher via `L2.REBALANCE_FREQ = 42` avant d'appeler\n",
+    "`run_cross_sectional` (restaurer à 21 après), car la fonction lit cette constante\n",
+    "globale à l'exécution."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2ecf7cd0",
+   "id": "e7d8e4fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T06:44:17.943431Z",
-     "iopub.status.busy": "2026-07-02T06:44:17.943267Z",
-     "iopub.status.idle": "2026-07-02T06:44:17.946576Z",
-     "shell.execute_reply": "2026-07-02T06:44:17.946102Z"
+     "iopub.execute_input": "2026-07-02T08:26:02.080076Z",
+     "iopub.status.busy": "2026-07-02T08:26:02.079825Z",
+     "iopub.status.idle": "2026-07-02T08:26:02.083545Z",
+     "shell.execute_reply": "2026-07-02T08:26:02.082942Z"
     }
    },
    "outputs": [],
    "source": [
     "def cs_with_rebal_freq(freq, closes, lookback=126, top_n=5, seeds=None, n_splits=5, gap=21):\n",
     "    # Retourne (net_sharpe, total_trades) pour le CS avec une frequence de rebal donnee.\n",
-    "    # TODO etudiant : monkey-patcher L2.REBAL_FREQ=freq, run_cross_sectional, restaurer\n",
+    "    # TODO etudiant : monkey-patcher L2.REBALANCE_FREQ=freq, run_cross_sectional, restaurer a 21\n",
     "    result = None  # TODO etudiant\n",
     "    return result\n",
     "\n",
@@ -566,7 +563,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95a24de8",
+   "id": "b2e82636",
    "metadata": {},
    "source": [
     "## 6. Conclusion\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l2_dual_momentum.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l2_dual_momentum.ipynb
@@ -1,0 +1,614 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e22b7b4d",
+   "metadata": {},
+   "source": [
+    "# L2 — Cross-Sectional + Dual Momentum sur le panier anti-biais\n",
+    "\n",
+    "> **Ladder ML #1409** | [L1 TSMOM](research_l1_tsmom.ipynb) · **L2 CS+DM** · [L3 Trend Long-Horizon](research_l3_trend.ipynb) · [L4 Decision Transformer](research_l4_decision_transformer.ipynb)\n",
+    "\n",
+    "Deuxième échelon du curriculum ML trading V3 (Epic #1409) : après avoir établi que la\n",
+    "momentum **temporelle** (L1 TSMOM) est détruite par les coûts de rotation quotidienne, on\n",
+    "passe à deux variantes **cross-sectionales** qui **rééquilibrent mensuellement** :\n",
+    "cross-sectional momentum (Antonacci-style) et dual momentum (cross-sectional + filtre\n",
+    "absolu). L'objectif : réduire le coût de rotation pour sauver le signal momentum.\n",
+    "\n",
+    "Ce notebook **reproduit fidèlement** le verdict canonique #1575 en pilotant le pipeline\n",
+    "`scripts/L2_dual_momentum.py` (walk-forward expansif 5 folds × 4 seeds, coûts par trade).\n",
+    "\n",
+    "### Verdict de référence (#1575)\n",
+    "\n",
+    "**NO BEATS** : ni cross-sectional ni dual momentum ne battent le buy-and-hold equipondéré\n",
+    "(Sharpe 1.15). **Mais ils surclassent massivement L1 TSMOM** (net Sharpe ~1.0 vs ~−2.3) :\n",
+    "le rééquilibrage **mensuel** (≈ 143 trades) au lieu de **quotidien** (≈ 5519 trades) élimine\n",
+    "l'essentiel du coût de rotation. La leçon : la fréquence de trading importe plus que la\n",
+    "qualité du signal.\n",
+    "\n",
+    "### Méthode (Antonacci 2014)\n",
+    "\n",
+    "- **Cross-sectional momentum** : à chaque rebalancement mensuel, on classe les 25 actifs par rendement passé (lookback 63/126/252j ≈ 3/6/12 mois), on **long uniquement le top-5**, equal-weight. Pas de vol-scaling (vol non-scalée).\n",
+    "- **Dual momentum** : cross-sectional + **filtre absolu** — un actif n'est longé que si sa momentum relative ET sa momentum absolue (rendement passé > 0) sont positives ; sinonCash proxy = SHY (Treasury court terme).\n",
+    "- **Validation** : walk-forward expansif 5 folds, gap 21j, 4 seeds (0/1/7/42).\n",
+    "- **Coûts** : ~5 bps equity / ~10 bps crypto par trade (TransactionCostModel)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6f15fb7",
+   "metadata": {},
+   "source": [
+    "## 1. Chargement du panier anti-biais (données locales mises en cache)\n",
+    "\n",
+    "Même panier que L1 (25 symboles, 7 classes, sans FAANG/Mag7), lu depuis `datasets/panier/`.\n",
+    "`auto_fetch=False` → aucun appel réseau."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d3457eb3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T06:44:14.979528Z",
+     "iopub.status.busy": "2026-07-02T06:44:14.979358Z",
+     "iopub.status.idle": "2026-07-02T06:44:17.467370Z",
+     "shell.execute_reply": "2026-07-02T06:44:17.466768Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Panier: 25 symbols, 4141 bars\n",
+      "Plage: 2015-01-01 -> 2026-05-03\n",
+      "SHY (cash proxy) present: True\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SPY</th>\n",
+       "      <th>RSP</th>\n",
+       "      <th>IWM</th>\n",
+       "      <th>XLF</th>\n",
+       "      <th>XLK</th>\n",
+       "      <th>XLV</th>\n",
+       "      <th>XLY</th>\n",
+       "      <th>XLP</th>\n",
+       "      <th>XLI</th>\n",
+       "      <th>XLU</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SHY</th>\n",
+       "      <th>GLD</th>\n",
+       "      <th>USO</th>\n",
+       "      <th>DBA</th>\n",
+       "      <th>EFA</th>\n",
+       "      <th>EEM</th>\n",
+       "      <th>BTC-USD</th>\n",
+       "      <th>ETH-USD</th>\n",
+       "      <th>LTC-USD</th>\n",
+       "      <th>XRP-USD</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>last_close</th>\n",
+       "      <td>720.65</td>\n",
+       "      <td>202.82</td>\n",
+       "      <td>279.28</td>\n",
+       "      <td>51.92</td>\n",
+       "      <td>161.87</td>\n",
+       "      <td>145.16</td>\n",
+       "      <td>118.63</td>\n",
+       "      <td>84.17</td>\n",
+       "      <td>172.96</td>\n",
+       "      <td>46.55</td>\n",
+       "      <td>...</td>\n",
+       "      <td>82.25</td>\n",
+       "      <td>423.18</td>\n",
+       "      <td>142.8</td>\n",
+       "      <td>28.11</td>\n",
+       "      <td>102.1</td>\n",
+       "      <td>64.13</td>\n",
+       "      <td>78538.23</td>\n",
+       "      <td>2321.64</td>\n",
+       "      <td>55.29</td>\n",
+       "      <td>1.39</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1 rows × 25 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               SPY     RSP     IWM    XLF     XLK     XLV     XLY    XLP  \\\n",
+       "last_close  720.65  202.82  279.28  51.92  161.87  145.16  118.63  84.17   \n",
+       "\n",
+       "               XLI    XLU  ...    SHY     GLD    USO    DBA    EFA    EEM  \\\n",
+       "last_close  172.96  46.55  ...  82.25  423.18  142.8  28.11  102.1  64.13   \n",
+       "\n",
+       "             BTC-USD  ETH-USD  LTC-USD  XRP-USD  \n",
+       "last_close  78538.23  2321.64    55.29     1.39  \n",
+       "\n",
+       "[1 rows x 25 columns]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import importlib.util\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Charger le pipeline canonique scripts/L2_dual_momentum.py comme un module.\n",
+    "SCRIPTS = Path(\"scripts\").resolve()\n",
+    "spec = importlib.util.spec_from_file_location(\"L2_dual_momentum\", SCRIPTS / \"L2_dual_momentum.py\")\n",
+    "L2 = importlib.util.module_from_spec(spec)\n",
+    "spec.loader.exec_module(L2)\n",
+    "\n",
+    "from panier_loader import load_panier_closes, PANIER_GROUPS\n",
+    "\n",
+    "closes = load_panier_closes(auto_fetch=False).dropna(how=\"all\")\n",
+    "print(f\"Panier: {closes.shape[1]} symbols, {closes.shape[0]} bars\")\n",
+    "print(f\"Plage: {closes.index[0].date()} -> {closes.index[-1].date()}\")\n",
+    "print(f\"SHY (cash proxy) present: {'SHY' in closes.columns}\")\n",
+    "closes.apply(lambda s: s.dropna().iloc[-1]).round(2).to_frame(\"last_close\").T"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25a9ec38",
+   "metadata": {},
+   "source": [
+    "## 2. Benchmark : buy-and-hold equipondéré (Sharpe 1.15)\n",
+    "\n",
+    "Barre à battre identique à L1 : B&H equipondéré des 25 actifs, calculé sur les mêmes folds\n",
+    "walk-forward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dfbc8ffb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T06:44:17.469679Z",
+     "iopub.status.busy": "2026-07-02T06:44:17.469509Z",
+     "iopub.status.idle": "2026-07-02T06:44:17.481857Z",
+     "shell.execute_reply": "2026-07-02T06:44:17.481315Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Buy-and-Hold equipondere : Sharpe = 1.1504\n",
+      "OOS bars/seed = 1656\n"
+     ]
+    }
+   ],
+   "source": [
+    "SEEDS = [0, 1, 7, 42]\n",
+    "N_SPLITS, GAP = 5, 21\n",
+    "TOP_N = 5\n",
+    "LOOKBACKS = [63, 126, 252]\n",
+    "REBAL_FREQ = 21  # mensuel (21 jours de bourse ~ 1 mois)\n",
+    "\n",
+    "bh_result = L2.run_buyhold_baseline(closes, SEEDS, N_SPLITS, GAP)\n",
+    "bh_mean = float(np.mean([s[\"sharpe\"] for s in bh_result[\"seeds\"]]))\n",
+    "print(f\"Buy-and-Hold equipondere : Sharpe = {bh_mean:.4f}\")\n",
+    "print(f\"OOS bars/seed = {bh_result['seeds'][0]['n_oos']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b3acacf",
+   "metadata": {},
+   "source": [
+    "## 3. Cross-sectional momentum (top-5 mensuel)\n",
+    "\n",
+    "On lance le cross-sectional pour les 3 lookbacks canoniques. Chaque rebalancement\n",
+    "mensuel sélectionne le top-5 par momentum. Le coût de rotation chute (~143-205 trades vs\n",
+    "5519 en L1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "31a0f134",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T06:44:17.483610Z",
+     "iopub.status.busy": "2026-07-02T06:44:17.483470Z",
+     "iopub.status.idle": "2026-07-02T06:44:17.684825Z",
+     "shell.execute_reply": "2026-07-02T06:44:17.684097Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CS lb  63j | gross +0.681 | net +0.662 | delta -0.488 | ~205 trades/seed\n",
+      "CS lb 126j | gross +0.952 | net +0.935 | delta -0.216 | ~161 trades/seed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CS lb 252j | gross +1.019 | net +0.997 | delta -0.153 | ~143 trades/seed\n"
+     ]
+    }
+   ],
+   "source": [
+    "cs_results = []\n",
+    "for lb in LOOKBACKS:\n",
+    "    res = L2.run_cross_sectional(closes, lb, TOP_N, SEEDS, N_SPLITS, GAP)\n",
+    "    cs_results.append(res)\n",
+    "    mean_gross = float(np.mean([s[\"gross_sharpe\"] for s in res[\"seeds\"]]))\n",
+    "    mean_net = float(np.mean([s[\"net_sharpe\"] for s in res[\"seeds\"]]))\n",
+    "    trades = int(np.mean([s[\"total_trades\"] for s in res[\"seeds\"]]))\n",
+    "    print(f\"CS lb {lb:>3}j | gross {mean_gross:>+6.3f} | net {mean_net:>+6.3f} | \"\n",
+    "          f\"delta {mean_net - bh_mean:>+6.3f} | ~{trades} trades/seed\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dde0c7ea",
+   "metadata": {},
+   "source": [
+    "## 4. Dual momentum (cross-sectional + filtre absolu, cash = SHY)\n",
+    "\n",
+    "Le dual momentum ajoute le filtre d'Antonacci : un actif n'est longé que si sa momentum\n",
+    "**absolue** est aussi positive ; sinon on va en cash (SHY). En théorie, ce filtre protège\n",
+    "en bear market. En pratique sur 2015-2025 (décennie haussière), il **retire des gagnants**\n",
+    "et réduit le Sharpe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "290b4806",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T06:44:17.687360Z",
+     "iopub.status.busy": "2026-07-02T06:44:17.687172Z",
+     "iopub.status.idle": "2026-07-02T06:44:17.915331Z",
+     "shell.execute_reply": "2026-07-02T06:44:17.914596Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DM lb  63j | gross +0.713 | net +0.679 | delta -0.471 | ~174 trades/seed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DM lb 126j | gross +0.648 | net +0.618 | delta -0.533 | ~138 trades/seed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DM lb 252j | gross +0.667 | net +0.628 | delta -0.522 | ~120 trades/seed\n"
+     ]
+    }
+   ],
+   "source": [
+    "dm_results = []\n",
+    "for lb in LOOKBACKS:\n",
+    "    res = L2.run_dual_momentum(closes, lb, TOP_N, \"SHY\", SEEDS, N_SPLITS, GAP)\n",
+    "    dm_results.append(res)\n",
+    "    mean_gross = float(np.mean([s[\"gross_sharpe\"] for s in res[\"seeds\"]]))\n",
+    "    mean_net = float(np.mean([s[\"net_sharpe\"] for s in res[\"seeds\"]]))\n",
+    "    trades = int(np.mean([s[\"total_trades\"] for s in res[\"seeds\"]]))\n",
+    "    print(f\"DM lb {lb:>3}j | gross {mean_gross:>+6.3f} | net {mean_net:>+6.3f} | \"\n",
+    "          f\"delta {mean_net - bh_mean:>+6.3f} | ~{trades} trades/seed\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afdc9d65",
+   "metadata": {},
+   "source": [
+    "### Table de verdict canonique (cross-sectional vs dual momentum)\n",
+    "\n",
+    "Le verdict confirme **NO BEATS** : toutes les configurations restent sous le B&H 1.15.\n",
+    "Mais le cross-sectional à long lookback (252j, net 0.997) **frôle** la barre (delta −0.15)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d3365ad9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T06:44:17.918025Z",
+     "iopub.status.busy": "2026-07-02T06:44:17.917841Z",
+     "iopub.status.idle": "2026-07-02T06:44:17.931599Z",
+     "shell.execute_reply": "2026-07-02T06:44:17.930945Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      strategie  lookback_j  gross    net    B&H   delta  trades  verdict\n",
+      "cross_sectional          63  0.681 0.6624 1.1504 -0.4880     205 NO BEATS\n",
+      "cross_sectional         126  0.952 0.9348 1.1504 -0.2156     161 NO BEATS\n",
+      "cross_sectional         252  1.019 0.9970 1.1504 -0.1534     143 NO BEATS\n",
+      "  dual_momentum          63  0.713 0.6790 1.1504 -0.4714     174 NO BEATS\n",
+      "  dual_momentum         126  0.648 0.6178 1.1504 -0.5326     138 NO BEATS\n",
+      "  dual_momentum         252  0.667 0.6280 1.1504 -0.5224     120 NO BEATS\n",
+      "\n",
+      "BEATS: 0/6 configurations\n"
+     ]
+    }
+   ],
+   "source": [
+    "rows = []\n",
+    "for res in cs_results + dm_results:\n",
+    "    v = L2.compute_verdict(res, bh_mean)\n",
+    "    rows.append({\n",
+    "        \"strategie\": res[\"strategy\"],\n",
+    "        \"lookback_j\": res[\"lookback\"],\n",
+    "        \"gross\": round(float(np.mean([s[\"gross_sharpe\"] for s in res[\"seeds\"]])), 3),\n",
+    "        \"net\": v[\"mean_net_sharpe\"],\n",
+    "        \"B&H\": v[\"bh_sharpe\"],\n",
+    "        \"delta\": v[\"delta\"],\n",
+    "        \"trades\": int(np.mean([s[\"total_trades\"] for s in res[\"seeds\"]])),\n",
+    "        \"verdict\": v[\"verdict\"],\n",
+    "    })\n",
+    "verdict_df = pd.DataFrame(rows)\n",
+    "print(verdict_df.to_string(index=False))\n",
+    "n_beats = (verdict_df[\"verdict\"] == \"BEATS\").sum()\n",
+    "print(f\"\\nBEATS: {n_beats}/{len(verdict_df)} configurations\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cb5428b",
+   "metadata": {},
+   "source": [
+    "### Lecture du verdict\n",
+    "\n",
+    "- **NO BEATS sur toute la grille** : le meilleur (CS 252j, net 0.997) reste sous B&H 1.15 (delta −0.15).\n",
+    "- **Cross-sectional > dual momentum** : le filtre absolu du dual momentum retire des positions gagnantes en marché haussier, réduisant le Sharpe (0.997 vs 0.628 à 252j).\n",
+    "- **Lookbacks longs aident le cross-sectional** (252j: 0.997 vs 63j: 0.662) : la momentum est plus forte aux horizons longs.\n",
+    "- **B&H reste imbattable** sur 2015-2025 (décennie haussière).\n",
+    "\n",
+    "### Leçon clé : L2 surclasse L1 grâce au rééquilibrage mensuel\n",
+    "\n",
+    "| Métrique | L1 TSMOM (best) | L2 CS (best) | L2 DM (best) |\n",
+    "|----------|-----------------|--------------|--------------|\n",
+    "| Net Sharpe | −2.26 (126j) | **0.997** (252j) | 0.679 (63j) |\n",
+    "| Delta vs B&H | −3.41 | −0.153 | −0.471 |\n",
+    "| Trades | 5519 | **143** | 174 |\n",
+    "\n",
+    "L2 CS améliore de **+3.26 Sharpe** vs L1 TSMOM. Le rééquilibrage mensuel (143 trades vs\n",
+    "5519) élimine le coût de rotation — mais le signal momentum seul ne suffit pas à battre le\n",
+    "B&H d'une décennie haussière. D'où **L3 Trend Long-Horizon** (signaux encore moins\n",
+    "fréquents + vol-targeting) et **L4 Decision Transformer** (offline RL)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5c8c987",
+   "metadata": {},
+   "source": [
+    "## 5. Exercices\n",
+    "\n",
+    "Les exercices sont à compléter. Les stubs s'exécutent sans erreur (ils retournent `None`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60057248",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Sensibilité au top-N\n",
+    "\n",
+    "**Contexte** : on long le top-5. Mais on pourrait sélectionner top-3 (plus concentré) ou\n",
+    "top-10 (plus diversifié).\n",
+    "\n",
+    "**Objectif** : pour `top_n in [3, 5, 10]`, lancez le cross-sectional à 126j et comparez le\n",
+    "net Sharpe. Un top-N plus concentré améliore-t-il la performance ?\n",
+    "\n",
+    "*Indice* : `L2.run_cross_sectional(closes, 126, top_n, SEEDS, N_SPLITS, GAP)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e4ed87bb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T06:44:17.933738Z",
+     "iopub.status.busy": "2026-07-02T06:44:17.933583Z",
+     "iopub.status.idle": "2026-07-02T06:44:17.936841Z",
+     "shell.execute_reply": "2026-07-02T06:44:17.936306Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def cs_net_sharpe_by_topn(top_ns, closes, lookback=126, seeds=None, n_splits=5, gap=21):\n",
+    "    # Retourne {top_n: net_sharpe} pour le cross-sectional.\n",
+    "    # TODO etudiant : boucler sur top_ns, run_cross_sectional, collecter net_sharpe moyen\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n",
+    "\n",
+    "tn_res = cs_net_sharpe_by_topn([3, 5, 10], closes, 126, SEEDS, N_SPLITS, GAP)\n",
+    "if tn_res is not None:\n",
+    "    for tn, s in tn_res.items():\n",
+    "        print(f\"top-{tn:<2} : CS net Sharpe = {s:+.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a72896a",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — L'effet du filtre absolu (dual vs cross-sectional)\n",
+    "\n",
+    "**Contexte** : le dual momentum ajoute un filtre absolu (cash si momentum < 0). En théorie\n",
+    "protecteur, en pratique nuisible en bull market.\n",
+    "\n",
+    "**Objectif** : quantifiez le coût du filtre absolu = delta de Sharpe entre CS et DM pour\n",
+    "chaque lookback. Vérifiez qu'il est négatif (le filtre nuit sur 2015-2025).\n",
+    "\n",
+    "*Indice* : pour chaque lookback, `cs_net(lb) - dm_net(lb)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cc36d2fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T06:44:17.938906Z",
+     "iopub.status.busy": "2026-07-02T06:44:17.938615Z",
+     "iopub.status.idle": "2026-07-02T06:44:17.941820Z",
+     "shell.execute_reply": "2026-07-02T06:44:17.941311Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def absolute_filter_cost(lookbacks, closes, top_n=5, seeds=None, n_splits=5, gap=21):\n",
+    "    # Retourne {lookback: (cs_net, dm_net, delta_cs_minus_dm)}.\n",
+    "    # TODO etudiant : run_cross_sectional ET run_dual_momentum par lookback\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n",
+    "\n",
+    "afc = absolute_filter_cost([63, 126, 252], closes, 5, SEEDS, N_SPLITS, GAP)\n",
+    "if afc is not None:\n",
+    "    for lb, (cs, dm, d) in afc.items():\n",
+    "        print(f\"lb {lb:>3}j : CS {cs:+.3f} | DM {dm:+.3f} | cout filtre = {d:+.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbf8e25c",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Fréquence de rebalancement vs coût de rotation\n",
+    "\n",
+    "**Contexte** : L1 (quotidien) = 5519 trades → net −2.26. L2 (mensuel) = 143 trades → net\n",
+    "0.997. La fréquence est le levier dominant.\n",
+    "\n",
+    "**Objectif** : testez une fréquence **bimensuelle** (42j) en modifiant `REBAL_FREQ`.\n",
+    "Relancez le CS à 126j et comparez trades + net Sharpe vs mensuel (21j).\n",
+    "\n",
+    "*Indice* : `REBAL_FREQ` est une constante du module. On peut monkey-patcher\n",
+    "`L2.REBAL_FREQ = 42` avant d'appeler `run_cross_sectional` ( restaurer à 21 après)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2ecf7cd0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T06:44:17.943431Z",
+     "iopub.status.busy": "2026-07-02T06:44:17.943267Z",
+     "iopub.status.idle": "2026-07-02T06:44:17.946576Z",
+     "shell.execute_reply": "2026-07-02T06:44:17.946102Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def cs_with_rebal_freq(freq, closes, lookback=126, top_n=5, seeds=None, n_splits=5, gap=21):\n",
+    "    # Retourne (net_sharpe, total_trades) pour le CS avec une frequence de rebal donnee.\n",
+    "    # TODO etudiant : monkey-patcher L2.REBAL_FREQ=freq, run_cross_sectional, restaurer\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n",
+    "\n",
+    "freq_res = cs_with_rebal_freq(42, closes, 126, 5, SEEDS, N_SPLITS, GAP)\n",
+    "if freq_res is not None:\n",
+    "    s, t = freq_res\n",
+    "    print(f\"CS 126j bimensuel (42j) : net {s:+.3f}, ~{t} trades/seed\")\n",
+    "    print(f\"(comparer : mensuel 21j -> net 0.935, 161 trades)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95a24de8",
+   "metadata": {},
+   "source": [
+    "## 6. Conclusion\n",
+    "\n",
+    "| Idée clé | Traduction |\n",
+    "|---|---|\n",
+    "| Cross-sectional + dual momentum = 2e échelon | stratégies cross-sectionales (top-N mensuel) au lieu de temporelles (L1) |\n",
+    "| NO BEATS mais surclasse L1 | net ~1.0 (CS 252j) vs L1 −2.26 : +3.26 Sharpe d'amélioration |\n",
+    "| Coupable L1 = rotation quotidienne | L2 mensuel (143 trades) élimine le coût de rotation → sauve le signal |\n",
+    "| CS > dual momentum | le filtre absolu retire des gagnants en bull market (0.997 vs 0.628) |\n",
+    "| B&H 1.15 reste imbattable | décennie haussière 2015-2025 = barre trop haute pour la momentum seule |\n",
+    "| Implication ladder | L3 Trend Long-Horizon (signaux longs + vol-targeting) ; L4 Decision Transformer (offline RL, seul BEATS) |\n",
+    "\n",
+    "**Lien avec le ladder** : L2 confirme que **la fréquence de trading importe plus que la\n",
+    "qualité du signal**. Passer de quotidien (L1) à mensuel (L2) sauve +3.26 Sharpe — mais ça\n",
+    "ne suffit pas. L3 pousse plus loin (signaux à long horizon), L4 change de paradigme\n",
+    "(action-based offline RL).\n",
+    "\n",
+    "Référence : Antonacci, *Dual Momentum Investing*, McGraw-Hill (2014). Pipeline canonique :\n",
+    "`scripts/L2_dual_momentum.py`, `docs/L2_dual_momentum.md` (#1575). Epic #1409."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Second of 3 missing ladder notebooks (`research_l1/l2/l3`), Epic #1409, #4876. (L1 delivered in #4918.) This tranche delivers **L2 Cross-Sectional + Dual Momentum**.

The notebook **drives the canonical `scripts/L2_dual_momentum.py` pipeline** (`run_cross_sectional` + `run_dual_momentum` + `compute_verdict`) so it reproduces the **EXACT #1575 verdict**:

| strategy        | lookback | gross | NET   | B&H    | delta   | trades | verdict   |
|-----------------|----------|-------|-------|--------|---------|--------|-----------|
| cross-sectional | 63d      | 0.681 | 0.662 | 1.1504 | -0.488  | 205    | NO BEATS |
| cross-sectional | 126d     | 0.952 | 0.935 | 1.1504 | -0.216  | 161    | NO BEATS |
| cross-sectional | 252d     | 1.019 | 0.997 | 1.1504 | -0.153  | 143    | NO BEATS |
| dual momentum   | 63d      | 0.713 | 0.679 | 1.1504 | -0.471  | 174    | NO BEATS |
| dual momentum   | 126d     | 0.648 | 0.618 | 1.1504 | -0.533  | 138    | NO BEATS |
| dual momentum   | 252d     | 0.667 | 0.628 | 1.1504 | -0.522  | 120    | NO BEATS |

**BEATS: 0/6.** Numbers match `docs/L2_dual_momentum.md` + `checkpoints/l2_dual_momentum/` exactly.

**Pedagogical point**: L2 massively outperforms L1 TSMOM (best net **0.997** vs L1 **-2.26** = **+3.26 Sharpe**) thanks to **monthly** rebalancing (143 trades vs L1's 5519 daily). The rebalance frequency matters more than signal quality. But still NO BEATS vs B&H 1.15 (bull-market decade). Cross-sectional > dual momentum (Antonacci's absolute filter removes winners in bull markets).

## Execution proof (rule H.1 / C.2)

- Executed end-to-end via `nbconvert --execute --inplace`, Python313 kernel, cached panier (`auto_fetch=False`, **no network**).
- **8/8 code cells executed, 0 errors.** Real outputs.
- Reproduce `checkpoints/l2_dual_momentum/L2_dual_momentum_results.json` exactly.
- Pipeline runs in <1s.

## Convention checks

- **C.1**: 3 exercise stubs use `result = None  # TODO etudiant` — no `NotImplementedError`/`assert False`. Runs end-to-end with exercises uncompleted.
- **#2161**: 3 exercises (top-N sensitivity, absolute-filter cost, rebalance frequency).
- **FR-first**: prose in French.
- **Faithful**: drove the canonical pipeline directly (initial attempt used L1's `compute_verdict` key names — caught via real exec `KeyError: 'cagr'`, fixed to L2's actual schema).

## Scope

Partial delivery of #4876 (L3 Trend Long-Horizon remains — separate tranche). Issue stays OPEN. See #4876, See #1409, See #1575.

Co-Authored-By: Claude <noreply@anthropic.com>
