### PR TITLE
feat(claudish): notebook pedagogique wire Anthropic + helpers client

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb
@@ -1,0 +1,650 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-1",
+   "metadata": {},
+   "source": [
+    "# Claude Code via Claudish\n",
+    "\n",
+    "**Navigation** : [Index](../../README.md)\n",
+    "\n",
+    "**Module :** Vibe-Coding / Claudish / Notebooks\n",
+    "**Niveau :** Debutant\n",
+    "**Duree :** 25 min\n",
+    "**Prerequis :** Python 3.10+, `httpx>=0.25`, acces au proxy Claudish (`ANTHROPIC_AUTH_TOKEN`)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "- [ ] Comprendre le **wire Anthropic** que Claudish expose cote client\n",
+    "- [ ] Brancher **Claude Code** sur Claudish via 3 variables d'environnement\n",
+    "- [ ] Composer un appel `POST /v1/messages` direct (sans CLI)\n",
+    "- [ ] Distinguer les **3 tiers** budgetes (Opus / Sonnet / Haiku) et leur provider reel\n",
+    "- [ ] Reconnaitre les codes HTTP **429** (quota) vs **529** (surcharge transitoire)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Pourquoi ce notebook ?\n",
+    "\n",
+    "Claudish est le proxy multi-provider du cluster MyIA : il rend **Claude Code**, **Roo Code**, les bots (Hermes, NanoClaw) **agnostiques du fournisseur**. Un agent qui croit parler a Anthropic peut en realite interroger GLM (z.ai), Qwen (vLLM local), ou Anthropic natif, sans changer une ligne de son code.\n",
+    "\n",
+    "Le detail du deploiement (wire, topologie, router 3 tiers, fork MyIA) est documente dans [`../docs/Claudish-Proxy.md`](../docs/Claudish-Proxy.md). Ce notebook est le pendant **pratique** : il montre comment appeler Claudish depuis Python, sans passer par le CLI Claude Code.\n",
+    "\n",
+    "> **Limite assumee** : pour executer les cellules d'appel direct, il faut une cle Claudish (`ANTHROPIC_AUTH_TOKEN`). Si la cle manque, le notebook continue a tourner : les cellules de demonstration visuelle (wire, headers, JSON) s'executent quand meme, seules les cellules d'appel reel leveront une `RuntimeError` claire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-1",
+   "metadata": {},
+   "source": [
+    "## 1. Le wire Anthropic que Claudish expose\n",
+    "\n",
+    "Claudish se place **en frontal** d'un client qui parle le wire Anthropic (Claude Code, le SDK, les bots Hermes/NanoClaw). Cote client, rien ne change : on envoie une requete HTTP standard sur `/v1/messages` avec les memes headers que ceux d'`api.anthropic.com`.\n",
+    "\n",
+    "### Anatomie d'une requete\n",
+    "\n",
+    "```\n",
+    "POST /v1/messages HTTP/1.1\n",
+    "Host: models.myia.io            (ou http://localhost:3000 en dev)\n",
+    "x-api-key: <cle claudish>\n",
+    "anthropic-version: 2023-06-01\n",
+    "content-type: application/json\n",
+    "\n",
+    "{\n",
+    "  \"model\": \"glm-5.2\",                 # tier Sonnet -> route vers z.ai GLM\n",
+    "  \"max_tokens\": 256,\n",
+    "  \"messages\": [\n",
+    "    {\"role\": \"user\", \"content\": \"Explique le no-fallback en 2 phrases.\"}\n",
+    "  ]\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "### Reponse (meme format qu'Anthropic natif)\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"id\": \"msg_01abc...\",\n",
+    "  \"type\": \"message\",\n",
+    "  \"role\": \"assistant\",\n",
+    "  \"content\": [\n",
+    "    {\"type\": \"text\", \"text\": \"Le no-fallback signifie ...\"}\n",
+    "  ],\n",
+    "  \"model\": \"glm-5.2\",\n",
+    "  \"stop_reason\": \"end_turn\",\n",
+    "  \"usage\": {\"input_tokens\": 23, \"output_tokens\": 87}\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "**Le client ne sait pas** que la reponse vient de GLM plutot que d'Anthropic : le wire est identique. C'est ca, le principe du proxy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-2",
+   "metadata": {},
+   "source": [
+    "## 2. Les 3 tiers budgetes (router no-fallback)\n",
+    "\n",
+    "Au lieu de laisser le proxy basculer silencieusement entre providers (ce qui degrade qualite et cout en plein milieu d'une conversation), **chaque tier a un provider unique budgete** :\n",
+    "\n",
+    "| Tier | Modele visible     | Provider reel               | Usage typique                    |\n",
+    "|------|--------------------|----------------------------|----------------------------------|\n",
+    "| **Opus** | `claude-opus-4-8` | Anthropic natif            | Raisonnement lourd, architecture |\n",
+    "| **Sonnet**| `glm-5.2`        | z.ai GLM Coding Plan       | Code au quotidien, defaut        |\n",
+    "| **Haiku** | `qwen3.6-35b-a3b`| vLLM self-heberge (po-2023)| Taches rapides, illimite         |\n",
+    "\n",
+    "**Principe no-fallback** : sur un rate-limit, Claudish **backoff** puis reessaie le meme provider. Sur une panne franche, il **fail-hard** (erreur explicite). Mieux vaut une erreur visible qu'une derive cachee de qualite. Voir `docs/Claudish-Proxy.md` §3 pour le detail."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-3-setup",
+   "metadata": {},
+   "source": [
+    "## 3. Setup : importer le client et verifier la connexion\n",
+    "\n",
+    "Le module `helpers/claudish_client.py` encapsule le wire Anthropic dans une API Python simple : `chat()`, `stream_chat()`, `list_models()`. Pas besoin de manipuler `httpx` directement.\n",
+    "\n",
+    "### Configuration requise\n",
+    "\n",
+    "Deux variables d'environnement :\n",
+    "\n",
+    "- `ANTHROPIC_AUTH_TOKEN` : la cle Claudish (recuperee depuis `.secrets/master.env`, **jamais de fallback inline**).\n",
+    "- `CLAUDISH_BASE_URL` (optionnel) : URL du proxy. Par defaut `http://localhost:3000`, ou `https://models.myia.io` en prod.\n",
+    "\n",
+    "Voir [`../configs/claudish.env.secrets.example`](../configs/claudish.env.secrets.example) pour le template complet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "sec-3-setup-1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T07:39:29.624609Z",
+     "iopub.status.busy": "2026-07-02T07:39:29.624231Z",
+     "iopub.status.idle": "2026-07-02T07:39:29.734684Z",
+     "shell.execute_reply": "2026-07-02T07:39:29.734073Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Module claudish_client charge OK\n",
+      "   helpers_path : D:\\Dev\\CoursIA\\.claude\\worktrees\\claudish-expansion\\MyIA.AI.Notebooks\\GenAI\\Vibe-Coding\\Claudish\\notebooks\\helpers\n",
+      "   Endpoint par defaut : http://localhost:3000\n",
+      "   Cle ANTHROPIC_AUTH_TOKEN : MANQUANTE\n",
+      "   Modeles connus : 6 declares\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration : localiser le dossier helpers/ parmi plusieurs candidats.\n",
+    "# Le cwd peut etre n'importe lequel selon le lanceur (nbclient, jupyter-lab, papermill, ...).\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "# On essaie plusieurs emplacements relatifs au cwd courant.\n",
+    "# Le notebook est dans Claudish/notebooks/, et helpers/ est son voisin direct.\n",
+    "candidates = [\n",
+    "    # Cas 1 : cwd = notebooks/\n",
+    "    'helpers',\n",
+    "    # Cas 2 : cwd = Claudish/\n",
+    "    os.path.join('notebooks', 'helpers'),\n",
+    "    # Cas 3 : cwd = Vibe-Coding/\n",
+    "    os.path.join('Claudish', 'notebooks', 'helpers'),\n",
+    "    # Cas 4 : cwd = GenAI/\n",
+    "    os.path.join('Vibe-Coding', 'Claudish', 'notebooks', 'helpers'),\n",
+    "    # Cas 5 : cwd = racine du repo (worktree root)\n",
+    "    os.path.join('MyIA.AI.Notebooks', 'GenAI', 'Vibe-Coding', 'Claudish', 'notebooks', 'helpers'),\n",
+    "]\n",
+    "\n",
+    "helpers_path = None\n",
+    "for c in candidates:\n",
+    "    abs_c = os.path.abspath(c)\n",
+    "    if os.path.isdir(abs_c) and os.path.isfile(os.path.join(abs_c, 'claudish_client.py')):\n",
+    "        helpers_path = abs_c\n",
+    "        break\n",
+    "\n",
+    "if helpers_path is None:\n",
+    "    raise FileNotFoundError(\n",
+    "        f\"Dossier helpers/ introuvable. cwd={os.getcwd()}. \"\n",
+    "        f\"Candidats testes : {candidates}. \"\n",
+    "        f\"Lancer le notebook depuis son propre dossier ou depuis la racine du repo.\"\n",
+    "    )\n",
+    "\n",
+    "if helpers_path not in sys.path:\n",
+    "    sys.path.insert(0, helpers_path)\n",
+    "\n",
+    "from claudish_client import (\n",
+    "    chat,\n",
+    "    stream_chat,\n",
+    "    list_models,\n",
+    "    get_endpoint,\n",
+    "    get_api_key,\n",
+    "    KNOWN_MODELS,\n",
+    "    DEFAULT_BASE_URL,\n",
+    ")\n",
+    "\n",
+    "print(\"Module claudish_client charge OK\")\n",
+    "print(f\"   helpers_path : {helpers_path}\")\n",
+    "print(f\"   Endpoint par defaut : {DEFAULT_BASE_URL}\")\n",
+    "print(f\"   Cle ANTHROPIC_AUTH_TOKEN : {'definie' if get_api_key() else 'MANQUANTE'}\")\n",
+    "print(f\"   Modeles connus : {len(KNOWN_MODELS)} declares\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "sec-3-list",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T07:39:29.736778Z",
+     "iopub.status.busy": "2026-07-02T07:39:29.736386Z",
+     "iopub.status.idle": "2026-07-02T07:39:30.236785Z",
+     "shell.execute_reply": "2026-07-02T07:39:30.235981Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Claudish expose 5 modele(s) :\n",
+      "\n",
+      "   - glm-5.2                   display=glm-5.2\n",
+      "   - glm-5.1                   display=glm-5.1\n",
+      "   - glm-4.7                   display=glm-4.7\n",
+      "   - qwen3.6-35b-a3b           display=qwen3.6-35b-a3b\n",
+      "   - MiniMax-M3                display=MiniMax-M3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Lister les modeles exposes par Claudish (endpoint public /v1/models, pas de cle requise)\n",
+    "try:\n",
+    "    models = list_models()\n",
+    "    print(f\"Claudish expose {len(models)} modele(s) :\\n\")\n",
+    "    for m in models:\n",
+    "        print(f\"   - {m.get('id'):24s}  display={m.get('display_name', '?')}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Impossible de lister les modeles : {e}\")\n",
+    "    print(\"   Verifier que Claudish est lance (docker ps | grep claudish)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-3-interpret",
+   "metadata": {},
+   "source": [
+    "**Interpretation** : la liste ci-dessus reflete **exactement** le `modelMap` actif du profil Claudish. Si tu vois `glm-5.2` mais pas `claude-opus-4-8`, c'est que le profil en cours est configure pour le tier Sonnet uniquement (voir `docs/Claudish-Proxy.md` §6 pour les profils)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-4",
+   "metadata": {},
+   "source": [
+    "## 4. Premier appel : wire Anthropic en Python\n",
+    "\n",
+    "Voici un **exemple resolu** qui appelle Claudish via `chat()`. Le modele par defaut est `glm-5.2` (tier Sonnet -> z.ai GLM). Si la cle manque, une `RuntimeError` explicite est levee.\n",
+    "\n",
+    "### Exemple guide : question simple sur Sonnet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "sec-4-call",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T07:39:30.239176Z",
+     "iopub.status.busy": "2026-07-02T07:39:30.238740Z",
+     "iopub.status.idle": "2026-07-02T07:39:30.243493Z",
+     "shell.execute_reply": "2026-07-02T07:39:30.242540Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Appel impossible : Cle Claudish manquante : definir ANTHROPIC_AUTH_TOKEN (voir configs/claudish.env.secrets.example).\n",
+      "   -> definir ANTHROPIC_AUTH_TOKEN puis relancer la cellule\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple resolu : appel Sonnet (glm-5.2 -> z.ai GLM)\n",
+    "prompt = \"En une phrase, qu'est-ce que le wire Anthropic ?\"\n",
+    "\n",
+    "try:\n",
+    "    reponse = chat(prompt, model=\"glm-5.2\", max_tokens=128)\n",
+    "    print(f\"Reponse (tier Sonnet, provider reel : z.ai GLM) :\\n  {reponse}\")\n",
+    "except RuntimeError as e:\n",
+    "    print(f\"Appel impossible : {e}\")\n",
+    "    print(\"   -> definir ANTHROPIC_AUTH_TOKEN puis relancer la cellule\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-4-interpret",
+   "metadata": {},
+   "source": [
+    "**Interpretation** : cet appel a traverse **3 couches** : (1) `chat()` construit la requete wire Anthropic, (2) `httpx` la POST sur `/v1/messages`, (3) Claudish la traduit vers le wire z.ai GLM, recupere la reponse, la reformatte en wire Anthropic, et la renvoie. Pour le client, c'est transparent : il a poste et lu au format Anthropic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-5",
+   "metadata": {},
+   "source": [
+    "## 5. Brancher Claude Code sur Claudish\n",
+    "\n",
+    "Pour brancher le CLI Claude Code sur Claudish (au lieu d'`api.anthropic.com`), il suffit de **3 variables d'environnement** :\n",
+    "\n",
+    "```powershell\n",
+    "$env:ANTHROPIC_BASE_URL   = \"https://models.myia.io\"   # URL Claudish\n",
+    "$env:ANTHROPIC_AUTH_TOKEN = \"<cle claudish>\"          # cle d'auth\n",
+    "$env:ANTHROPIC_MODEL      = \"glm-5.2\"                  # tier par defaut\n",
+    "```\n",
+    "\n",
+    "Puis, dans le meme shell :\n",
+    "\n",
+    "```bash\n",
+    "claude -p \"Bonjour, qui es-tu ?\"\n",
+    "# -> croit parler a Anthropic, mais passe en realite par GLM (tier Sonnet)\n",
+    "```\n",
+    "\n",
+    "Aucun patch de code cote Claude Code : il suit son `ANTHROPIC_BASE_URL` et envoie son wire standard. **C'est le point cle de Claudish** : rendre les clients Anthropic-compatibles sans toucher a leur code.\n",
+    "\n",
+    "### Exemple guide : voir les env vars dans le shell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "sec-5-env",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T07:39:30.246227Z",
+     "iopub.status.busy": "2026-07-02T07:39:30.245897Z",
+     "iopub.status.idle": "2026-07-02T07:39:30.251608Z",
+     "shell.execute_reply": "2026-07-02T07:39:30.250257Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ANTHROPIC_BASE_URL       = http://192.168.0.46:3000\n",
+      "  CLAUDISH_BASE_URL        = (non definie)\n",
+      "  ANTHROPIC_MODEL          = (non definie)\n",
+      "  ANTHROPIC_AUTH_TOKEN     = <masque, 0 caracteres>\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verifier quelles env vars sont deja positionnees (NE PAS afficher les valeurs completes)\n",
+    "for var in (\"ANTHROPIC_BASE_URL\", \"CLAUDISH_BASE_URL\", \"ANTHROPIC_MODEL\", \"ANTHROPIC_AUTH_TOKEN\"):\n",
+    "    val = os.environ.get(var)\n",
+    "    if val is None:\n",
+    "        print(f\"  {var:24s} = (non definie)\")\n",
+    "    elif \"TOKEN\" in var or \"KEY\" in var:\n",
+    "        print(f\"  {var:24s} = <masque, {len(val)} caracteres>\")\n",
+    "    else:\n",
+    "        print(f\"  {var:24s} = {val}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-5-interpret",
+   "metadata": {},
+   "source": [
+    "**Interpretation** : `ANTHROPIC_AUTH_TOKEN` doit etre **presente** (meme masquee) pour que `chat()` reussisse. Si elle manque, va voir `.secrets/master.env` ou demande a l'admin cluster la valeur (placeholders uniquement cote doc).\n",
+    "\n",
+    "Le notebook peut continuer sans cle : seules les cellules d'appel reel echoueront avec un message clair."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-6",
+   "metadata": {},
+   "source": [
+    "## 6. Exercice 1 : composer un appel direct sur /v1/messages\n",
+    "\n",
+    "Objectif : implementer `call_claudish_raw()` qui envoie un prompt et retourne la **reponse JSON complete** (pas seulement le texte). Cela permet d'inspecter `usage`, `model`, `stop_reason` pour debugger ou facturer.\n",
+    "\n",
+    "Indice : tu peux utiliser `httpx.Client()` directement, ou importer `get_endpoint` et `get_api_key` depuis `claudish_client` et construire le payload a la main."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "sec-6-exo",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T07:39:30.254294Z",
+     "iopub.status.busy": "2026-07-02T07:39:30.253918Z",
+     "iopub.status.idle": "2026-07-02T07:39:30.259828Z",
+     "shell.execute_reply": "2026-07-02T07:39:30.259094Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stub non complete : la fonction retourne None. Implementer puis relancer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : appel brut, retourne le dict JSON complet\n",
+    "def call_claudish_raw(prompt: str, model: str = \"glm-5.2\", max_tokens: int = 128):\n",
+    "    \"\"\"Envoie un prompt a Claudish et retourne la reponse JSON brute.\n",
+    "\n",
+    "    Args:\n",
+    "        prompt: Question utilisateur.\n",
+    "        model: Modele (defaut 'glm-5.2', tier Sonnet).\n",
+    "        max_tokens: Limite tokens sortie.\n",
+    "\n",
+    "    Returns:\n",
+    "        Le dict JSON de la reponse wire Anthropic (champs id, model,\n",
+    "        content, usage, stop_reason, ...).\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : construire headers + payload, POST sur /v1/messages, retourner r.json()\n",
+    "    # Indice 1 : utiliser get_endpoint() et get_api_key() du module claudish_client\n",
+    "    # Indice 2 : headers = {\"x-api-key\": ..., \"anthropic-version\": \"2023-06-01\", \"content-type\": \"application/json\"}\n",
+    "    # Indice 3 : payload = {\"model\": model, \"max_tokens\": max_tokens, \"messages\": [{\"role\": \"user\", \"content\": prompt}]}\n",
+    "    # Etape 1 : verifier que la cle est presente, sinon lever RuntimeError explicite\n",
+    "    # Etape 2 : POST httpx avec timeout=30s\n",
+    "    # Etape 3 : si status >= 400, lever RuntimeError avec le body\n",
+    "    # Etape 4 : retourner response.json()\n",
+    "    response_json = None  # TODO etudiant : remplacez par l'implementation\n",
+    "    return response_json\n",
+    "\n",
+    "\n",
+    "# Test (la fonction retourne None tant que le stub n'est pas complete)\n",
+    "result = call_claudish_raw(\"Cite un avantage de Claudish.\")\n",
+    "if result is None:\n",
+    "    print(\"Stub non complete : la fonction retourne None. Implementer puis relancer.\")\n",
+    "else:\n",
+    "    print(f\"Modele utilise : {result.get('model', '?')}\")\n",
+    "    print(f\"Tokens input : {result.get('usage', {}).get('input_tokens', '?')}\")\n",
+    "    print(f\"Tokens output : {result.get('usage', {}).get('output_tokens', '?')}\")\n",
+    "    print(f\"Stop reason : {result.get('stop_reason', '?')}\")\n",
+    "    content = result.get('content', [])\n",
+    "    if content and content[0].get('type') == 'text':\n",
+    "        print(f\"Texte : {content[0]['text'][:200]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-7",
+   "metadata": {},
+   "source": [
+    "## 7. Exercice 2 : comparer 3 tiers sur une meme question\n",
+    "\n",
+    "Objectif : poser la meme question aux **3 tiers** (Opus, Sonnet, Haiku) et comparer les reponses. Cela permet de sentir le compromis qualite/cout/vitesse en condition reelle.\n",
+    "\n",
+    "Note : `claude-opus-4-8` et `qwen3.6-35b-a3b` ne sont visibles que si ton profil Claudish les expose. Si un tier renvoie 404, note-le dans la sortie (pas un bug du client)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "sec-7-exo",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T07:39:30.261972Z",
+     "iopub.status.busy": "2026-07-02T07:39:30.261706Z",
+     "iopub.status.idle": "2026-07-02T07:39:30.267636Z",
+     "shell.execute_reply": "2026-07-02T07:39:30.266730Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stub non complete : la fonction retourne None. Implementer puis relancer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : comparaison 3 tiers\n",
+    "TIERS = {\n",
+    "    \"Opus\":   \"claude-opus-4-8\",\n",
+    "    \"Sonnet\": \"glm-5.2\",\n",
+    "    \"Haiku\":  \"qwen3.6-35b-a3b\",\n",
+    "}\n",
+    "\n",
+    "def compare_tiers(question: str, max_tokens: int = 128):\n",
+    "    \"\"\"Pose la meme question aux 3 tiers et collecte les resultats.\n",
+    "\n",
+    "    Args:\n",
+    "        question: La question commune.\n",
+    "        max_tokens: Limite par appel.\n",
+    "\n",
+    "    Returns:\n",
+    "        Dict {tier_name: {\"model\": ..., \"text\": ..., \"error\": ...}}\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : appeler chat() pour chaque tier de TIERS, collecter resultat ou erreur\n",
+    "    # Indice : utiliser un try/except par tier pour ne pas bloquer sur un tier indisponible\n",
+    "    # Etape 1 : initialiser un dict resultats = {}\n",
+    "    # Etape 2 : pour chaque (tier_name, model_id) dans TIERS.items() :\n",
+    "    #          - appeler chat(question, model=model_id, max_tokens=max_tokens)\n",
+    "    #          - stocker {\"model\": model_id, \"text\": reponse}\n",
+    "    #          - en cas d'exception RuntimeError, stocker {\"model\": model_id, \"error\": str(e)}\n",
+    "    # Etape 3 : retourner le dict\n",
+    "    resultats = None  # TODO etudiant : remplacez par l'implementation\n",
+    "    return resultats\n",
+    "\n",
+    "\n",
+    "# Test (la fonction retourne None tant que le stub n'est pas complete)\n",
+    "resultats = compare_tiers(\"Quelle est la capitale de la France ?\")\n",
+    "if resultats is None:\n",
+    "    print(\"Stub non complete : la fonction retourne None. Implementer puis relancer.\")\n",
+    "else:\n",
+    "    for tier, data in resultats.items():\n",
+    "        print(f\"\\n=== Tier {tier} (modele {data.get('model')}) ===\")\n",
+    "        if \"error\" in data:\n",
+    "            print(f\"  Erreur : {data['error'][:200]}\")\n",
+    "        else:\n",
+    "            print(f\"  Texte : {data.get('text', '')[:200]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-8",
+   "metadata": {},
+   "source": [
+    "## 8. Exercice 3 : distinguer 429 (quota) vs 529 (surcharge)\n",
+    "\n",
+    "Objectif : implementer `classify_http_error()` qui retourne une categorie semantique a partir du code HTTP recu de Claudish.\n",
+    "\n",
+    "**Pourquoi c'est important** : un client bien eleve retry sur **529** (surcharge transitoire, ~5 min), mais **arrete** sur **429** (quota epuise, pas la peine de retenter tout de suite). Confondre les deux = soit gaspiller du quota, soit abandonner une requete qui aurait reussi 30 secondes plus tard.\n",
+    "\n",
+    "Voir `docs/Claudish-Proxy.md` §6 et §7.3 pour le detail du overload->529."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "sec-8-exo",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T07:39:30.270104Z",
+     "iopub.status.busy": "2026-07-02T07:39:30.269648Z",
+     "iopub.status.idle": "2026-07-02T07:39:30.274952Z",
+     "shell.execute_reply": "2026-07-02T07:39:30.274097Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  HTTP 200 -> (stub: None)\n",
+      "  HTTP 401 -> (stub: None)\n",
+      "  HTTP 403 -> (stub: None)\n",
+      "  HTTP 429 -> (stub: None)\n",
+      "  HTTP 500 -> (stub: None)\n",
+      "  HTTP 502 -> (stub: None)\n",
+      "  HTTP 503 -> (stub: None)\n",
+      "  HTTP 504 -> (stub: None)\n",
+      "  HTTP 529 -> (stub: None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : classifier un code HTTP Claudish\n",
+    "def classify_http_error(status_code: int) -> str:\n",
+    "    \"\"\"Classifie un code HTTP retourne par Claudish.\n",
+    "\n",
+    "    Args:\n",
+    "        status_code: Code HTTP (401, 429, 500, 503, 529, ...).\n",
+    "\n",
+    "    Returns:\n",
+    "        Une chaine parmi :\n",
+    "        - \"auth\"          : 401, 403 -> reconfigurer la cle\n",
+    "        - \"quota\"         : 429 -> quota epuise, NE PAS retry\n",
+    "        - \"overload\"      : 529 -> surcharge transitoire, RETRY avec backoff\n",
+    "        - \"server\"        : 500, 502, 504 -> bug cote provider\n",
+    "        - \"unavailable\"   : 503 -> service down, RETRY long\n",
+    "        - \"client\"        : 4xx autres -> requete mal formee\n",
+    "        - \"ok\"            : 2xx\n",
+    "        - \"unknown\"       : tout le reste\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementer la classification avec une serie de if/elif\n",
+    "    # Indice : 401/403 -> auth ; 429 -> quota ; 529 -> overload ; 500/502/504 -> server ; 503 -> unavailable ; 4xx autres -> client ; 2xx -> ok\n",
+    "    category = None  # TODO etudiant : remplacez par l'implementation\n",
+    "    return category\n",
+    "\n",
+    "\n",
+    "# Test avec un echantillon de codes\n",
+    "samples = [200, 401, 403, 429, 500, 502, 503, 504, 529]\n",
+    "for code in samples:\n",
+    "    cat = classify_http_error(code)\n",
+    "    print(f\"  HTTP {code:3d} -> {cat if cat else '(stub: None)'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-9",
+   "metadata": {},
+   "source": [
+    "## 9. Resume\n",
+    "\n",
+    "### Ce que tu as vu\n",
+    "\n",
+    "| Concept | Detail |\n",
+    "|---------|--------|\n",
+    "| **Wire Anthropic** | `POST /v1/messages` + headers `x-api-key` / `anthropic-version` + payload JSON standard |\n",
+    "| **3 tiers budgetes** | Opus = Anthropic, Sonnet = z.ai GLM, Haiku = Qwen vLLM |\n",
+    "| **Brancher Claude Code** | 3 env vars : `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL` |\n",
+    "| **Codes HTTP** | 429 = quota (stop), 529 = surcharge (retry), 401/403 = auth (fix cle) |\n",
+    "\n",
+    "### Points cles a retenir\n",
+    "\n",
+    "1. **Claudish est un proxy, pas une lib** : on l'appelle via le wire Anthropic standard, il route vers le bon provider.\n",
+    "2. **Le client ne sait jamais** quel provider reel a repondu (Anthropic, GLM, Qwen).\n",
+    "3. **Le `modelMap` du profil actif** determine la visibilite des tiers (`/v1/models` reflete l'etat reel).\n",
+    "4. **Pas de bascule silencieuse** : sur rate-limit, backoff sur le meme provider ; sur panne, fail-hard.\n",
+    "5. **429 vs 529** = quetes semantiques distinctes, le client doit retry seulement sur 529.\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "\n",
+    "- [`../docs/Claudish-Proxy.md`](../docs/Claudish-Proxy.md) : detail du deploiement, fork MyIA, war-stories (no-fallback, never-hang, 529).\n",
+    "- [`../configs/claudish.env.secrets.example`](../configs/claudish.env.secrets.example) : template de configuration complet.\n",
+    "- [`../../Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb`](../../Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb) : utilisation cote CLI (le pendant de ce notebook cote client CLI)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/helpers/__init__.py
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/helpers/__init__.py
@@ -1,0 +1,17 @@
+"""Helpers pour les notebooks Claudish.
+
+Ce module fournit des fonctions utilitaires pour appeler Claudish
+(le proxy multi-provider compatible wire Anthropic) depuis des
+notebooks Jupyter, sans dépendre du CLI Claude Code.
+
+Exemple d'utilisation:
+
+    from helpers.claudish_client import chat, list_models, get_endpoint
+
+    # Lister les modeles exposes par Claudish
+    print(list_models())
+
+    # Appel direct sur le wire Anthropic
+    text = chat("Explique le no-fallback en 2 phrases", model="glm-5.2")
+    print(text)
+"""

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/helpers/claudish_client.py
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/helpers/claudish_client.py
@@ -1,0 +1,180 @@
+"""
+Client Python pour Claudish — proxy Anthropic-compatible multi-providers.
+
+Claudish expose le wire Anthropic standard (`POST /v1/messages`) derriere
+une URL unique (par defaut `http://localhost:3000` en local, ou
+`https://models.myia.io` en production). Le client de ce module suit
+exactement ce wire : headers `x-api-key`, `anthropic-version`, body
+`{model, max_tokens, messages, stream}`.
+
+Le tier budgete par defaut dans le cluster MyIA :
+
+| Tier | Modele visible     | Provider reel               |
+|------|--------------------|----------------------------|
+| Opus | claude-opus-4-8    | Anthropic natif            |
+| Sonnet| glm-5.2           | z.ai GLM Coding Plan       |
+| Haiku| qwen3.6-35b-a3b    | vLLM self-heberge (po-2023)|
+
+Voir `docs/Claudish-Proxy.md` section 3 pour le detail du router
+no-fallback (3 providers, pas de bascule silencieuse).
+"""
+
+import json
+import os
+from typing import Iterator, List, Optional
+
+import httpx
+
+
+# URL par defaut : localhost en dev, models.myia.io en prod
+DEFAULT_BASE_URL = os.environ.get("CLAUDISH_BASE_URL", "http://localhost:3000")
+ANTHROPIC_VERSION = "2023-06-01"
+
+# Modeles exposes par defaut par le deploiement MyIA (cf /v1/models)
+KNOWN_MODELS = [
+    "claude-opus-4-8",       # Opus -> Anthropic natif
+    "glm-5.2",               # Sonnet -> z.ai GLM Coding
+    "glm-5.1",               # Sonnet (alias)
+    "glm-4.7",               # Sonnet (alias historique)
+    "qwen3.6-35b-a3b",       # Haiku -> Qwen vLLM
+    "MiniMax-M3",            # Haiku (pool secondaire)
+]
+
+
+def get_endpoint(base_url: Optional[str] = None) -> str:
+    """Retourne l'URL complet du endpoint /v1/messages."""
+    base = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    return f"{base}/v1/messages"
+
+
+def get_api_key(env_var: str = "ANTHROPIC_AUTH_TOKEN") -> Optional[str]:
+    """Recupere la cle Claudish depuis l'environnement (jamais de fallback inline)."""
+    key = os.environ.get(env_var)
+    if not key:
+        return None
+    return key
+
+
+def list_models(base_url: Optional[str] = None, timeout: float = 5.0) -> List[dict]:
+    """Liste les modeles exposes par Claudish (endpoint /v1/models)."""
+    base = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    with httpx.Client(timeout=timeout) as client:
+        r = client.get(f"{base}/v1/models")
+        r.raise_for_status()
+        data = r.json()
+    return data.get("data", [])
+
+
+def chat(
+    prompt: str,
+    model: str = "glm-5.2",
+    max_tokens: int = 256,
+    system: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: float = 60.0,
+) -> str:
+    """Envoie un prompt a Claudish via le wire Anthropic et retourne le texte.
+
+    Args:
+        prompt: Question utilisateur.
+        model: Identifiant modele vu du client (ex: ``glm-5.2``).
+        max_tokens: Limite de tokens en sortie.
+        system: Prompt systeme optionnel.
+        base_url: URL de base Claudish (override env).
+        api_key: Cle d'authentification (override env ``ANTHROPIC_AUTH_TOKEN``).
+        timeout: Timeout HTTP en secondes.
+
+    Returns:
+        Le texte de la reponse (champ ``content[0].text`` du wire Anthropic).
+
+    Raises:
+        RuntimeError: si la cle API manque, ou si la reponse est en erreur.
+    """
+    key = api_key or get_api_key()
+    if not key:
+        raise RuntimeError(
+            "Cle Claudish manquante : definir ANTHROPIC_AUTH_TOKEN "
+            "(voir configs/claudish.env.secrets.example)."
+        )
+
+    messages = [{"role": "user", "content": prompt}]
+    payload = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": messages,
+    }
+    if system:
+        payload["system"] = system
+
+    headers = {
+        "x-api-key": key,
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+    }
+
+    with httpx.Client(timeout=timeout) as client:
+        r = client.post(get_endpoint(base_url), headers=headers, json=payload)
+        if r.status_code >= 400:
+            raise RuntimeError(
+                f"Claudish HTTP {r.status_code} : {r.text[:500]}"
+            )
+        data = r.json()
+
+    # Wire Anthropic : content est une liste de blocs {type: "text", text: "..."}
+    content = data.get("content", [])
+    texts = [block.get("text", "") for block in content if block.get("type") == "text"]
+    return "\n".join(texts).strip()
+
+
+def stream_chat(
+    prompt: str,
+    model: str = "glm-5.2",
+    max_tokens: int = 256,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: float = 60.0,
+) -> Iterator[str]:
+    """Version streaming du chat. Yield les deltas de texte au fur et a mesure.
+
+    Le wire Anthropic streaming renvoie des evenements SSE
+    (``event: content_block_delta``). Ce helper les parse et yield
+    uniquement le texte.
+    """
+    key = api_key or get_api_key()
+    if not key:
+        raise RuntimeError(
+            "Cle Claudish manquante : definir ANTHROPIC_AUTH_TOKEN."
+        )
+
+    payload = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": True,
+    }
+    headers = {
+        "x-api-key": key,
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+    }
+
+    with httpx.Client(timeout=timeout) as client:
+        with client.stream(
+            "POST", get_endpoint(base_url), headers=headers, json=payload
+        ) as response:
+            for line in response.iter_lines():
+                if not line or not line.startswith("data: "):
+                    continue
+                raw = line[len("data: "):].strip()
+                if raw == "[DONE]":
+                    break
+                try:
+                    evt = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if evt.get("type") == "content_block_delta":
+                    delta = evt.get("delta", {})
+                    text = delta.get("text", "")
+                    if text:
+                        yield text


### PR DESCRIPTION
## Summary

Derniere tranche du plan #4445 (Doc Claudish / Vibe-Coding).

Phase A (#4453) et Phase B (#4695) deja merges : structure du dossier, README chapeau (67L), et docs/Claudish-Proxy.md (197L). Il manquait le notebook pedagogique pour fermer la boucle planifiee.

## Livrable

| Fichier | Role |
|---------|------|
| `MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb` | 9 sections pedagogiques, 3 exercices stub |
| `notebooks/helpers/claudish_client.py` | Client httpx wire Anthropic (chat, stream_chat, list_models, get_endpoint, get_api_key) |
| `notebooks/helpers/__init__.py` | Package marker |

## Sections du notebook

1. Le wire Anthropic (intro visuelle, pas d'appel)
2. Les 3 tiers budgetes (Opus/Sonnet/Haiku + providers reels)
3. Setup : helper client + verification connexion via `list_models()`
4. Premier appel : exemple resolu `chat()` (RuntimeError explicite si pas de cle)
5. Brancher Claude Code sur Claudish (3 env vars)
6. Exercice 1 : composer un appel direct `/v1/messages` (stub)
7. Exercice 2 : comparer 3 tiers (stub)
8. Exercice 3 : classifier HTTP 429 vs 529 (stub)
9. Resume + liens doc

## Garde-fous respectes

- **secrets-hygiene** : aucune cle API inline, `getenv()` sans fallback literal, placeholders uniquement dans `configs/claudish.env.secrets.example` (deja merge #4453)
- **C.1** (notebooks) : zero `raise NotImplementedError` / `assert False` / `1/0`, stubs `None + # TODO etudiant + # Indice + # Etape N`
- **three-exercises-per-notebook** : 3 exercices distincts (sections 6, 7, 8)
- **FR-first** : introduction + interpretations en francais ; inline code FR
- **execution reelle** : valide via `nbclient`, les 7 cellules code tournent, le helper `list_models()` a interroge Claudish live (5 modeles recus)

## Verification execution

```text
cell4 (setup)        : Module claudish_client charge OK
                       helpers_path : .../Claudish/notebooks/helpers
cell5 (list_models)  : Claudish expose 5 modele(s) :
                         - glm-5.2  glm-5.1  glm-4.7  qwen3.6-35b-a3b  MiniMax-M3
cell8 (chat)         : Appel impossible : Cle Claudish manquante
                       (INTRINSIC, design prevu : RuntimeError explicite)
cell11 (env vars)    : ANTHROPIC_BASE_URL = http://192.168.0.46:3000
cell14/16/18 (exo)   : 3 stubs retournant None comme attendu
```

Voir : #4445