### PR TITLE
fix(qc): actionable error when panier dataset missing (See #4921)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/panier_loader.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/panier_loader.py
@@ -246,6 +246,18 @@ def load_panier_closes(
 
     panel = pd.DataFrame(closes)
     panel.index.name = "Date"
+    # Fail fast with an actionable message when the dataset is missing and the
+    # caller opted out of network access (auto_fetch=False). Without this guard
+    # a fresh clone silently gets an empty DataFrame (see #4921).
+    if not closes and not auto_fetch:
+        raise FileNotFoundError(
+            f"No panier CSV data found in {panier_dir}. "
+            f"Build it first with:\n"
+            f"    python scripts/datasets/build_panier_anti_bias.py\n"
+            f"(datasets/ is gitignored by design -- the build script is the "
+            f"reproducibility path). Alternatively call "
+            f"load_panier_closes(auto_fetch=True) to fetch via yfinance."
+        )
     return panel
 
 


### PR DESCRIPTION
## Summary

Root-cause fix for **#4921** ("Build anti-bias panier dataset (L2/L3 prerequisite)"). The issue reports a fresh clone can't run the research notebooks because `datasets/panier/` is absent.

**Why it failed silently**: when `auto_fetch=False` (the default) and the panier CSVs are missing, `load_panier_closes()` silently returned an **empty DataFrame** — line 194 `if path is None: continue` skipped every symbol, with no error. The user got zero-symbol results and no hint that `build_panier_anti_bias.py` must be run first.

**The fix** (12 lines, `scripts/panier_loader.py`): fail fast with a clear `FileNotFoundError` pointing to the build script when no symbol loaded AND `auto_fetch=False`:

```
FileNotFoundError: No panier CSV data found in <dir>. Build it first with:
    python scripts/datasets/build_panier_anti_bias.py
(datasets/ is gitignored by design -- the build script is the reproducibility path).
Alternatively call load_panier_closes(auto_fetch=True) to fetch via yfinance.
```

`datasets/panier/` is **gitignored by design** (`.gitignore:94`) — `build_panier_anti_bias.py` IS the reproducibility path (not committing CSVs). The `auto_fetch=True` fallback (yfinance) is unaffected.

## Why not commit the CSVs?

Data is gitignored intentionally (large CSVs, regenerated on demand). The build script + this clear error message give full reproducibility without bloating the repo. This matches the existing `panier_loader.py` design (lines 7, 101 already document the build step; `auto_fetch=True` fetches via yfinance).

## Test proof

3 cases verified locally (Python313):
- **empty dir + auto_fetch=False** → clear `FileNotFoundError` with build instruction ✓
- **empty dir + auto_fetch=True** → guard does NOT fire (yfinance fetch proceeds, 26 symbols) ✓
- **real panier** → loads fine (4141, 25) ✓

The guard uses `not closes` (no symbol loaded at all), which is precise — it does NOT false-positive on date-range filtering that yields 0 rows (that case still has columns loaded).

## Scope

Directly serves the just-delivered ladder notebooks `research_l1/l2/l3` (#4918 merged, #4923/#4926 open) — they all call `load_panier_closes(auto_fetch=False)` and now fail fast on a fresh clone instead of silently producing empty results. Resolves #4921's discoverability root cause. See #4921.

Co-Authored-By: Claude <noreply@anthropic.com>
