### PR TITLE
fix(catalog-cron): sync remote main before push to heal stale-marker drift (See #4910)

### DIFF
--- a/.github/workflows/catalog-cron.yml
+++ b/.github/workflows/catalog-cron.yml
@@ -92,6 +92,18 @@ jobs:
             -m "Refresh COURSE_CATALOG.generated.{json,md} + CATALOG-STATUS markers." \
             -m "Catalog is owned by automation; agents must not regenerate it on feature branches (see .claude/rules/catalog-pr-hygiene.md, #2433)."
 
+          # Sync with remote main before pushing. Without this, when other PRs
+          # land between checkout and push, `git push` is rejected with
+          # "[rejected] HEAD -> main (fetch first)" (incident: 2026-07-02 cron
+          # run 28566453812, catalog stayed stale for 24h+ -> CaseStudies
+          # marker held at pedagogical_count: 4 while disk had 6, See #4910).
+          # `--rebase` rewrites our local catalog commit on top of remote main
+          # (the catalog regen is idempotent and pull-and-retry safe since
+          # #2433); `--autostash` preserves any in-progress local changes if
+          # the rebase touches the same files.
+          git fetch origin main
+          git pull --rebase --autostash origin main
+
           # Direct push of a generated artifact to main. Requires branch
           # protection to allow github-actions[bot] (GITHUB_TOKEN) to push to
           # main, or main to have no PR-required protection for this actor.


### PR DESCRIPTION
## Summary

The `catalog-cron.yml` workflow (daily 03:37 UTC auto-regen of `COURSE_CATALOG.generated.{json,md}` + CATALOG-STATUS markers) **failed on 2026-07-02 04:56:23** (run 28566453812) with:

```
! [rejected]            HEAD -> main (fetch first)
error: failed to push some refs to 'https://github.com/jsboige/CoursIA'
##[error]Could not push the regenerated catalog to main.
```

### Root cause

Between step 1 (checkout `main` with `fetch-depth: 0`) and step 4 (`git push origin HEAD:main`), other PRs land on `main`. The runner does **not** re-fetch, so its local `main` ref falls behind → push rejected as non-fast-forward.

### Visible symptom (See #4910)

Catalog held the correct **6 entries** for `CaseStudies/` (incl. SmartGrid-Energy × 2), but the marker in `MyIA.AI.Notebooks/CaseStudies/README.md` stayed at `pedagogical_count: 4` because the cron commit never landed. Marker drift persists until the next successful cron run.

### Fix

Add `git fetch origin main` + `git pull --rebase --autostash origin main` between the catalog commit and the push:

```diff
+          # Sync with remote main before pushing. Without this, when other PRs
+          # land between checkout and push, `git push` is rejected with
+          # "[rejected] HEAD -> main (fetch first)" (incident: 2026-07-02 cron
+          # run 28566453812, catalog stayed stale for 24h+ -> CaseStudies
+          # marker held at pedagogical_count: 4 while disk had 6, See #4910).
+          # `--rebase` rewrites our local catalog commit on top of remote main
+          # (the catalog regen is idempotent and pull-and-retry safe since
+          # #2433); `--autostash` preserves any in-progress local changes if
+          # the rebase touches the same files.
+          git fetch origin main
+          git pull --rebase --autostash origin main
```

- `--rebase` rewrites the cron-local catalog commit on top of newer main (catalog regen is idempotent since #2433: `_load_main_catalog` + `_merge_curated_fields` preserve curated git fields).
- `--autostash` safeguards any in-progress local changes if the rebase touches the same files.

## Acceptance

- Next cron run (2026-07-03 03:37 UTC) succeeds instead of failing at push.
- Catalog JSON + MD + markers all land on main in one atomic commit.
- CaseStudies marker auto-heals `pedagogical_count: 4` → `6` + breakdown adds `SmartGrid-Energy=2` (verified locally via `python scripts/notebook_tools/expand_catalog_markers.py --dry-run`).
- Manual `workflow_dispatch` re-run of run #28566453812 will also work after merge (currently fails, demonstrating the bug).

## Constraints respected

- **catalog-pr-hygiene R1**: this PR does NOT regenerate the catalog itself — only the workflow file. Catalog remains byte-identical on the branch.
- **No force push**: `--rebase` rewrites local cron-side commits only; the remote never receives a force push from this workflow.
- **No new secrets**: pure shell + git.

See #4910.
