### PR TITLE
feat(lean): align finiteness_lean toolchain rc2 -> rc1 (no-dep, build SUCCESS)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
@@ -9,7 +9,7 @@ Mini-projet Lean 4 issu de l'Epic #2978 (livrable C), livré par la PR #3018.
 
 ## État
 
-- **Toolchain** : `leanprover/lean4:v4.30.0-rc2`
+- **Toolchain** : `leanprover/lean4:v4.31.0-rc1`
 - **Sorry** : **0 sorry, 0 axiom** — tout est prouvé ou illustré par `#eval`
 - **Build** : `lake build Finiteness` — **autonome, sans Mathlib** (Lean core seul)
 - **Dépendances** : aucune

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.30.0-rc2
+leanprover/lean4:v4.31.0-rc1


### PR DESCRIPTION
## Summary

**Whole-fleet rc1 alignment — `finiteness_lean` toolchain rc2 → rc1.** This is a **no-dependency** lake (Lean core only, **no Mathlib**), so it sits **outside** the #4364 9-lake Mathlib-mutualized convergence group (which is complete after sensitivity_lean #4931). This bump contributes to the broader fleet-wide rc1 uniformity tracked by #4362.

## Changes (2 files)

| File | Change |
|------|--------|
| `lean-toolchain` | `leanprover/lean4:v4.30.0-rc2` → `v4.31.0-rc1` |
| `README.md` | toolchain line rc2 → rc1 (consistency) |

No proof touched. A no-dep lake has no Mathlib dependency, so there is **no possible rc1 API drift** — the bump is purely a toolchain-version alignment. No source file changed.

## Verification (G.1 firsthand)

```
$ lake build Finiteness
✔ [2/4] Built Finiteness.Basic (949ms)
✔ [3/4] Built Finiteness (658ms)
Build completed successfully (4 jobs). EXIT=0
```

- **Sorry count (token-grep): 0** — unchanged.
- "declaration uses sorry" warnings: 0.
- The `info: ... true/false` lines in the log are the pedagogical `#eval` outputs (the README states the lake is "illustré par `#eval`"), not warnings.

## Notes

- **Scope note**: `lake build` auto-generated a minimal `lake-manifest.json` (`{"packages": [], "name": "finiteness", ...}`) — this was **not** committed, to keep the PR atomic (toolchain alignment only). The prior state had no committed manifest; this is preserved. A fleet-wide manifest-pinning policy, if wanted, is a separate concern.
- §B Lean PR: `grep -c sorry` = 0 (before and after); Lake build SUCCESS (log above); no Mathlib → no axiom drift.

See #4362
