### PR TITLE
fix(gametheory): VCG canonical bundle order — eliminate flake on Python set iteration (Fixes #4934)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/examples/vcg_auction.py
+++ b/MyIA.AI.Notebooks/GameTheory/examples/vcg_auction.py
@@ -68,8 +68,15 @@ def vcg_combinatorial_auction(
         )
 
     def get_value(bidder: str, bundle: Tuple[str, ...]) -> float:
-        """Get valuation for a bundle."""
-        return valuations.get((bidder, bundle), 0)
+        """Get valuation for a bundle.
+
+        Normalises ``bundle`` to its sorted-tuple canonical form before
+        the dict lookup, so the result is robust to bundle order
+        (e.g. ``('Y','X')`` == ``('X','Y')``). This matches the
+        convention used when the caller constructs the ``valuations``
+        dict with sorted-tuple keys.
+        """
+        return valuations.get((bidder, tuple(sorted(bundle))), 0)
 
     def find_efficient_allocation(
         bidders_subset: List[str],
@@ -100,8 +107,12 @@ def vcg_combinatorial_auction(
             bidder = remaining_bidders[0]
             rest_bidders = remaining_bidders[1:]
 
-            # Try all subsets of remaining items for this bidder
-            for bundle in powerset(list(remaining_items)):
+            # Try all subsets of remaining items for this bidder.
+            # `sorted(...)` makes bundle enumeration order canonical
+            # (independent of `set` iteration order across Python runs),
+            # so the recursion no longer misses the optimal bundle when
+            # `remaining_items` is a set. See #4934 for diagnosis.
+            for bundle in powerset(sorted(remaining_items)):
                 bundle_value = get_value(bidder, bundle)
                 new_remaining = remaining_items - set(bundle)
                 current_allocation[bidder] = bundle

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_vcg_auction.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_vcg_auction.py
@@ -66,6 +66,15 @@ def brute_force_efficient_welfare(bidders, items, valuations):
     Reimplementation de l'enumeration SANS reutiliser le code sous test,
     pour que les tests d'efficacite et de paiement de Clarke soient de
     vrais controles croises.
+
+    Bundle lookup goes through ``tuple(sorted(bundle))`` so this helper
+    is robust to bundle order: ``('Y','X')`` matches ``('X','Y')`` in
+    the valuations dict (cf. the canonical ``(_, ('X', 'Y'))`` key
+    convention). Without this, on Python builds where
+    ``list(set(items))`` happens to enumerate items in non-sorted order
+    this brute-force returns a suboptimal welfare and the
+    ``test_efficiency_vs_bruteforce`` cross-checks spuriously fail.
+    See #4934.
     """
     best = 0.0
 
@@ -76,8 +85,8 @@ def brute_force_efficient_welfare(bidders, items, valuations):
             return
         bidder = remaining_bidders[0]
         rest = remaining_bidders[1:]
-        for bundle in _powerset(list(remaining_items)):
-            value = valuations.get((bidder, bundle), 0)
+        for bundle in _powerset(sorted(remaining_items)):
+            value = valuations.get((bidder, tuple(sorted(bundle))), 0)
             allocate(rest, set(remaining_items) - set(bundle), welfare + value)
 
     allocate(list(bidders), set(items), 0.0)


### PR DESCRIPTION
## Bug

`MyIA.AI.Notebooks/GameTheory/examples/vcg_auction.py::find_efficient_allocation` (line 74+) returns the wrong allocation for the canonical Alice/Bob case on certain Python builds:

- Expected: `Allocation: {'Alice': ['X','Y'], 'Bob': []}` (welfare 15), `Payments: {'Alice': 14, 'Bob': 0}`
- Actual: `Allocation: {'Alice': ['Y'], 'Bob': ['X']}` (welfare 12), `Payments: {'Alice': 0, 'Bob': 0}`

5 tests in `MyIA.AI.Notebooks/GameTheory/tests/test_vcg_auction.py::TestVCGCanonicalCase` and 3 in `TestVCGGeneralInvariants` fail in CI when the `Scripts Tests (CPU)` workflow runs (e.g. PR #4932).

## Root cause

The recursive `allocate()` calls `powerset(list(remaining_items))` where `remaining_items` is a `set`. `list(set)` produces non-canonical order across Python runs (hash-based), and the valuations dict uses **sorted** tuple keys. So `('Y','X')` lookup returns 0 instead of 15. The optimal bundle is therefore missed whenever `list(set)` happens to yield non-sorted order.

Same flaw in the test helper `brute_force_efficient_welfare` (line 79), which means the "cross-check" welfare baseline is also wrong on those builds → spurious cross-check failures.

## Fix

1. `powerset(list(remaining_items))` → `powerset(sorted(remaining_items))` in both production and test helper.
2. `get_value` normalises bundle to `tuple(sorted(bundle))` before the dict lookup (defensive belt-and-braces for callers that pass unsorted tuples).

## Verification

```
$ python -m pytest scripts/notebook_tools/tests/ MyIA.AI.Notebooks/GameTheory/tests/
2258 passed, 4 xfailed in 21.07s
```

The canonical Alice/Bob case now returns `welfare=15, Alice pays 14, Bob pays 0` deterministically across runs.

## Files

- `MyIA.AI.Notebooks/GameTheory/examples/vcg_auction.py`: 2 fixes (+13/-3)
- `MyIA.AI.Notebooks/GameTheory/tests/test_vcg_auction.py`: 1 helper fix + docstring (+13/-2)

26 net additions, 2 files, single domain (GameTheory). Atomic PR.

Fixes #4934
🤖 Generated with [Claude Code](https://claude.com/claude-code)