### PR TITLE
fix(prover): FX-7 retire legacy substring sorry counter repo-wide (107/107 tests)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -67,9 +67,10 @@ def count_real_sorries(content: str) -> int:
     ``/- -/`` blocks, the word-bounded token catches every real form
     (``exact sorry``, ``:= sorry``, bare ``sorry``, ``sorry -- comment``).
 
-    Reporting/diagnostic use only for now: the success gates keep the legacy
-    substring counter so their deltas stay consistent with the snapshot
-    counters in tools.py (migrating ALL counters at once = FX-7 follow-up).
+    Used everywhere a sorry tally is needed (FX-7, #1453): success gates,
+    snapshot counters in tools.py, and run_prover_bg reporting all call this
+    so their deltas stay consistent — the legacy substring counter was retired
+    repo-wide in one pass to avoid mixed-counter drift.
     """
     return len(_SORRY_TOKEN_RE.findall(strip_lean_comments(content)))
 
@@ -942,8 +943,8 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
             # re-introducing one, e.g. a returned `simp; sorry`).
             real_has_error = bool(re.search(r"\berror:", real_output))
             implicit_sorry = "declaration uses 'sorry'" in real_output
-            sorry_dropped = (new_content.count("sorry")
-                             < original_content.count("sorry"))
+            sorry_dropped = (count_real_sorries(new_content)
+                             < count_real_sorries(original_content))
             if real_has_error or implicit_sorry or not sorry_dropped:
                 Path(filepath).write_text(original_content, encoding="utf-8", newline="")
                 is_success = False

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -18,7 +18,7 @@ from .state import ProofState, SorryContext, ProofPhase, PHASE_TRANSITIONS, Tact
 from .lean_utils import (
     extract_sorry_block, get_goal_state, verify_sorry_replacement,
     extract_hypotheses, extract_local_lemmas, build_def_type_warnings,
-    is_honest_sorry, sorry_is_in_statement,
+    is_honest_sorry, sorry_is_in_statement, count_real_sorries,
 )
 from .tools import SearchTools, TacticTools, CriticTools, CoordinatorTools, DiagnosisTools
 from .agents import (
@@ -325,7 +325,7 @@ class MultiAgentSorryProver:
 
         # Read original content
         original_content = Path(filepath).read_text(encoding="utf-8")
-        original_sorry_count = original_content.count("sorry")
+        original_sorry_count = count_real_sorries(original_content)
 
         # Auto-detect actual sorry line — exclude lines where "sorry" appears
         # only inside comments. A line is "sorry inside comment" when:
@@ -673,7 +673,7 @@ class MultiAgentSorryProver:
             # that work instead of throwing it away. The agent is then free
             # to resume from that partial state in a future run.
             total_s = time.time() - session_start
-            final_sorry = Path(filepath).read_text(encoding="utf-8").count("sorry")
+            final_sorry = count_real_sorries(Path(filepath).read_text(encoding="utf-8"))
             structural_progress = False
             # Default value so the success check after finally always has it,
             # even if an exception is raised mid-block before the verify runs.
@@ -936,7 +936,7 @@ class AutonomousProver:
         from agent_framework import Agent
 
         original_content = Path(filepath).read_text(encoding="utf-8")
-        original_sorry_count = original_content.count("sorry")
+        original_sorry_count = count_real_sorries(original_content)
 
         # Auto-detect actual sorry line — pick NEAREST to configured line
         actual_sorry_lines = [
@@ -1199,7 +1199,7 @@ class AutonomousProver:
                 self._update_state_from_response(state, response_text, proof_tactics_found)
 
                 # Auto-compile after each iteration
-                current_sorry = Path(filepath).read_text(encoding="utf-8").count("sorry")
+                current_sorry = count_real_sorries(Path(filepath).read_text(encoding="utf-8"))
                 compile_str = tactic_tools.compile()
                 try:
                     compile_data = json.loads(compile_str)
@@ -1403,7 +1403,7 @@ class AutonomousProver:
             print(f"  Autonomous session error: {e}")
 
         total_s = (datetime.now() - state.start_time).total_seconds()
-        final_sorry = Path(filepath).read_text(encoding="utf-8").count("sorry")
+        final_sorry = count_real_sorries(Path(filepath).read_text(encoding="utf-8"))
 
         # Restore best state if worse — but validate first (P2, V5).
         # best_content was captured when sorry decreased AND build passed,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from prover import DEMOS, PROVED_DEMOS, TraceLogger
 from prover.provers import MultiAgentSorryProver, AutonomousProver
 from prover.config import create_client
+from prover.lean_utils import count_real_sorries
 
 TRACES_DIR = Path(__file__).parent / "traces"
 TRACES_DIR.mkdir(exist_ok=True)
@@ -56,7 +57,7 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         sys.exit(1)
 
     original = Path(filepath).read_text(encoding="utf-8")
-    original_sorry = original.count("sorry")
+    original_sorry = count_real_sorries(original)
     print(f"Target: {name}")
     print(f"  File: {filepath} (line {line})")
     print(f"  Mode: {mode}, Iterations: {iterations}")
@@ -70,8 +71,8 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     # curation — or any direct --file/--line target that is already clean — would
     # otherwise still spawn a full multi-agent run for zero work (the forensic
     # "already-solved schedule" pathology). A count of 0 is a SAFE skip signal:
-    # str.count("sorry") only ever OVER-counts (it also matches comments/strings),
-    # so == 0 guarantees there is genuinely nothing to prove and can never skip a
+    # count_real_sorries strips comments/docstrings and word-bounds the token, so
+    # == 0 guarantees there is genuinely nothing to prove and can never skip a
     # live target. (count > 0 still spawns the prover, exactly as before.)
     if original_sorry == 0:
         print(f"Already solved: 0 sorry in {filepath} — skipping prover spawn.")
@@ -130,7 +131,7 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     elapsed = time.time() - start
 
     final = Path(filepath).read_text(encoding="utf-8")
-    final_sorry = final.count("sorry")
+    final_sorry = count_real_sorries(final)
 
     # Forensic #1453 (2026-07-02): a run's outcome was scattered across 4 fields
     # (result.status, sorry_delta, structural_progress, error) and every consumer

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -17,6 +17,7 @@ from typing import Optional, Dict, List
 from .state import ProofState, TacticAttempt, SorryContext
 from .trace import TraceLogger
 from .knowledge import ProofKnowledgeBase
+from .lean_utils import count_real_sorries
 
 # Regex to detect standalone `axiom` declarations in Lean 4 source.
 # Matches lines like `axiom foo`, `axiom bar : Prop`, `axiom baz (n : Nat) : ...`
@@ -1036,7 +1037,7 @@ class TacticTools:
             # provers.run_session / workflow P1 latch.
             _content = Path(self._filepath).read_text(encoding="utf-8")
             sorry_count = max(
-                _content.count("sorry"),
+                count_real_sorries(_content),
                 _count_sorries_from_build_output(result.get("raw_output", "")),
             )
             self._record_sorry_count(sorry_count)
@@ -1075,7 +1076,7 @@ class TacticTools:
             # file_replace, build-aware (see the success-path note above).
             _content = Path(self._filepath).read_text(encoding="utf-8")
             current_sorry = max(
-                _content.count("sorry"),
+                count_real_sorries(_content),
                 _count_sorries_from_build_output(raw_output),
             )
             self._record_sorry_count(current_sorry)
@@ -1086,8 +1087,8 @@ class TacticTools:
         # If the edit reduced sorry count but introduced non-sorry errors,
         # preserve the progress rather than throwing it away.
         current_content = Path(self._filepath).read_text(encoding="utf-8")
-        current_sorry_count = current_content.count("sorry")
-        original_sorry_count = original_content.count("sorry")
+        current_sorry_count = count_real_sorries(current_content)
+        original_sorry_count = count_real_sorries(original_content)
         if current_sorry_count < original_sorry_count and non_sorry_errors:
             # Progress made but with non-sorry errors — log but don't revert.
             # Update best snapshot if this is an improvement.
@@ -1254,7 +1255,7 @@ class TacticTools:
                                    "replaced_lines": f"{start}-{end}"},
                                   ensure_ascii=False)
 
-            sorry_count = new_file_content.count("sorry")
+            sorry_count = count_real_sorries(new_file_content)
 
             # Axiom guard: block edits that introduce new `axiom` declarations.
             # The prover can game sorry_guard by replacing `lemma foo := by sorry`
@@ -1452,7 +1453,7 @@ class TacticTools:
 
             Path(self._filepath).write_text(new_file_content, encoding="utf-8")
 
-            sorry_count = new_file_content.count("sorry")
+            sorry_count = count_real_sorries(new_file_content)
             if self._trace:
                 self._trace.log(
                     agent="TacticTools", role="tool",
@@ -1564,7 +1565,7 @@ class TacticTools:
                                    "replaced": old_line.strip()},
                                   ensure_ascii=False)
 
-            sorry_count = new_content.count("sorry")
+            sorry_count = count_real_sorries(new_content)
 
             # Axiom guard: block edits that introduce new `axiom` declarations.
             new_axiom_count = _count_axiom_declarations(new_content)
@@ -1784,7 +1785,7 @@ class TacticTools:
                 errors.append({"line": int(m.group(1)), "message": m.group(2)})
 
         content = Path(self._filepath).read_text(encoding="utf-8")
-        text_sorry_count = content.count("sorry")
+        text_sorry_count = count_real_sorries(content)
         build_sorry_count = _count_sorries_from_build_output(raw_output)
         sorry_count = max(text_sorry_count, build_sorry_count)
         implicit_sorry = build_sorry_count - text_sorry_count
@@ -1919,7 +1920,7 @@ class TacticTools:
         # 2026-06-23) and expose the raw probe verdict as `probe_compiles` so
         # decomposition-style tactics still see that their edit builds.
         probe_compiles = bool(result["success"])
-        original_count = (self._sorry_ctx.full_file.count("sorry")
+        original_count = (count_real_sorries(self._sorry_ctx.full_file)
                           if self._sorry_ctx.full_file else -1)
         sorry_eliminated = (probe_compiles and sorry_count >= 0
                             and original_count >= 0
@@ -1962,7 +1963,7 @@ class TacticTools:
         indent_str = " " * indent
         replacement_lines = [indent_str + l.strip() for l in tactic.strip().split("\n") if l.strip()]
         new_lines = lines[:sorry_idx] + replacement_lines + lines[sorry_idx + 1:]
-        return "\n".join(new_lines).count("sorry")
+        return count_real_sorries("\n".join(new_lines))
 
     @property
     def best_sorry_count(self) -> int:
@@ -2542,8 +2543,8 @@ class DiagnosisTools:
             current = Path(self._filepath).read_text(encoding="utf-8")
         except OSError as e:
             return json.dumps({"error": f"Cannot read file: {e}"})
-        current_count = current.count("sorry")
-        original_count = self._original_content.count("sorry") if self._original_content else current_count
+        current_count = count_real_sorries(current)
+        original_count = count_real_sorries(self._original_content) if self._original_content else current_count
         delta = current_count - original_count
         return json.dumps({
             "current_sorry_count": current_count,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -37,6 +37,7 @@ from agent_framework import (
 from .state import SorryContext
 from .trace import TraceLogger
 from .knowledge import ProofKnowledgeBase
+from .lean_utils import count_real_sorries
 
 
 # Default per-agent LLM timeout. Reasoning models (z.ai GLM-5.1, Qwen3.6) burn
@@ -817,11 +818,11 @@ class VerifyExecutor(Executor):
                 and "sorry" not in _latch_lines[_latch_target - 1]
             )
             _latch_orig = (
-                self._sorry_ctx.full_file.count("sorry")
+                count_real_sorries(self._sorry_ctx.full_file)
                 if getattr(self._sorry_ctx, "full_file", "")
                 else (self._original_sorry_count or 0)
             )
-            _latch_now = _latch_cur.count("sorry")
+            _latch_now = count_real_sorries(_latch_cur)
             if _latch_line_clear and _latch_now < _latch_orig:
                 _latch_verifier = _latch_get_verifier(
                     str(_LatchPath(_latch_fp).parent.parent))
@@ -1133,7 +1134,7 @@ class VerifyExecutor(Executor):
         indent_str = " " * indent
         replacement_lines = [indent_str + l.strip() for l in tactic.strip().split("\n") if l.strip()]
         new_lines = lines[:sorry_idx] + replacement_lines + lines[sorry_idx + 1:]
-        return "\n".join(new_lines).count("sorry")
+        return count_real_sorries("\n".join(new_lines))
 
 
 class DiagnosisExecutor(Executor):

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1622,6 +1622,62 @@ def test_strip_lean_comments_preserves_code():
     assert "theorem t : 1 + 1 = 2 := by norm_num" in stripped
 
 
+# --- FX-7 (#1453): migrate ALL sorry counters to count_real_sorries ----------
+# The success gates (verify_sorry_replacement, the workflow latch), snapshot
+# counters in tools.py, and run_prover_bg reporting all historically used the
+# `content.count("sorry")` substring counter, which over-counts prose mentions
+# in comments/docstrings (HashlifeCorrectness: substring 34, real 4 — 8.5x
+# inflation). FX-7 retires the substring counter repo-wide in one pass so every
+# before/after delta is consistent; a "0 sorry -> skip" gate now fires on the
+# REAL count instead of never firing while comment prose mentions survive.
+
+
+def test_fx7_count_real_sorries_massively_undercounts_comment_prose():
+    """Mirrors the founding HashlifeCorrectness inflation: a file with heavy
+    'sorry' prose in comments/docstrings must count only the REAL tokens, so
+    the migrated gates see the true obligation count (FX-7 value)."""
+    from prover.lean_utils import count_real_sorries
+
+    content = (
+        "/-!\n"
+        "This file proves the hashlife result. It used to be sorry everywhere;\n"
+        "we removed sorry after sorry until only sorry-free scaffolding sorry\n"
+        "mentions remained in this docstring (sorry, sorry, sorry).\n"
+        "-/\n"
+        "-- NB: the word sorry in this line comment is NOT an obligation.\n"
+        "theorem t1 : True := by\n"
+        "  sorry\n"                       # 1 real
+        "theorem t2 : True := by\n"
+        "  exact sorry\n"                 # 2 real
+    )
+    assert content.count("sorry") >= 8    # substring over-counts prose
+    assert count_real_sorries(content) == 2
+
+
+def test_fx7_no_legacy_substring_counter_in_prover_source():
+    """FX-7 regression guard: no prover source module may reintroduce the
+    legacy `.count("sorry")` substring counter on file content — every gate,
+    snapshot, and report must go through count_real_sorries so deltas stay
+    consistent. The only allowed mention is the historical docstring in
+    lean_utils.py describing the retired counter."""
+    from pathlib import Path
+
+    prover_dir = Path(__file__).resolve().parent.parent / "prover"
+    legacy = []
+    for py in sorted(prover_dir.glob("*.py")):
+        for ln, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1):
+            if '.count("sorry")' in line:
+                # lean_utils.py keeps ONE historical mention in the
+                # count_real_sorries docstring describing the retired counter.
+                if py.name == "lean_utils.py" and line.strip().startswith("``"):
+                    continue
+                legacy.append(f"{py.name}:{ln}: {line.strip()}")
+    assert not legacy, (
+        "FX-7 violated — legacy substring `.count(\"sorry\")` reintroduced:\n"
+        + "\n".join(legacy)
+    )
+
+
 # --- FX-6b (#1453): sorry_is_in_statement + in-statement entry refusal ------
 # The latch (workflow.py) and verify_sorry_replacement both set
 # proof_found=True without touching tactic_history, and proof_found is a


### PR DESCRIPTION
## Summary

**FX-7 (#1453 false-success hardening)** — retire the legacy `content.count("sorry")` substring counter **repo-wide** across the prover harness, migrating every site to `count_real_sorries` (comment-stripped, word-bounded) in **one pass** so all before/after deltas stay consistent.

This is the FX-7 grain assigned to po-2026 by ai-01 in the FX-5/FX-7 ping-pong (msg `msg-20260702T061522-bxanww`: « FX-7 (migration des ~20 sites substring `content.count("sorry")` vers `count_real_sorries`) — TOUT d'un coup, jamais site-par-site »). Done all-at-once as specified. **FX-5 (TRUE_PLACEHOLDER_GOAL) follows in a separate atomic PR** (anti-composite G.4).

## Why it matters (G.1 firsthand)

The legacy substring counter over-counts prose mentions of "sorry" in `--` line comments and `/- -/` docstrings. Verified on the real files:

| File | substring | real | inflation |
|------|----------:|-----:|----------:|
| `HashlifeCorrectness.lean` | 34 | 4 | **+30 (8.5×)** |
| `Reidemeister.lean` | 2 | 2 | +0 (clean) |

Concretely: the `run_prover_bg` "0 sorry → skip" gate could **never fire** for `HashlifeCorrectness` while 30 comment-prose mentions survived — the harness spawned full multi-agent runs for an already-clean file (the forensic "already-solved schedule" pathology). The success gates (`verify_sorry_replacement`, the workflow P1 latch) compared inflated counts. `count_real_sorries` strips comments and word-bounds the token, so gates now see the true obligation count.

## Changes (6 files, +90/-30)

| File | Sites | Note |
|------|------:|------|
| `lean_utils.py` | 1 | `verify_sorry_replacement` gate delta + docstring updated (FX-7 follow-up note retired) |
| `provers.py` | 5 | `original_sorry_count` at both entries + 3 inline read+count; import added to top-level block |
| `tools.py` | 12 | snapshot counters, workflow-latch mirror, sorry-eliminated probe gate; top-level import added |
| `workflow.py` | 3 | P1 latch `_latch_orig`/`_latch_now` delta + re-verify tally; top-level import added |
| `run_prover_bg.py` | 2 | skip-spawn gate + final report; comment refreshed; absolute import |
| `tests/test_prover_guards.py` | +2 tests | see below |

**20 substring sites migrated total.** No success-gate semantics change for clean fixtures (`count_real_sorries == substring` when no comment noise); the migration is strictly more accurate on real files with prose.

## Verification (G.1 firsthand)

```
$ PYTHONPATH=. python -m pytest tests/test_prover_guards.py -q
collected 107 items
....................................................   [100%]
============================= 107 passed in 1.93s =============================
```

- **107/107 passing** (was 105/105 after FX-6b — 2 new FX-7 tests, 0 regressions).
- All 5 edited modules import cleanly (`import prover.{lean_utils,provers,tools,workflow,run_prover_bg}`).
- `count_real_sorries` value proven on real files (table above).

## New tests (2)

- `test_fx7_count_real_sorries_massively_undercounts_comment_prose` — a Hashlife-shape fixture (≥8 substring mentions, 2 real) documents **why** FX-7 mattered.
- `test_fx7_no_legacy_substring_counter_in_prover_source` — **regression guard**: scans the prover package so no gate can silently revert to the inflated substring counter (the only allowed mention is the historical docstring in `lean_utils.py`).

## Notes

- §B Lean PR applicability: this PR touches the **prover harness** (`agent_tests/prover/`), not `*.lean`. The 4 §B elements (sorry diff / lake build / axiom check / refactor justification): N/A for sorry/build/axiom (no proofs touched); refactor justification = the FX-7 migration IS the false-success hardening claimed (substring inflation masked clean files), directly serving #1453.
- Scope: 20 sites in one atomic pass (FX-7 mandate: never site-by-site). FX-5 (TRUE_PLACEHOLDER_GOAL, design) is a separate concern → separate PR.
- Ping-pong with ai-01: FX-6b (#4917, merged) took the in-statement-sorry guard upstream; FX-7 (this PR) + FX-5 (next) are po-2026's half.

See #1453
