### PR TITLE
fix(ci): add matplotlib dep to Scripts Tests workflow (Fixes #4937)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -61,6 +61,11 @@ jobs:
           # python-dotenv: scripts/whisper_int8_comparison.py (and several
           # genai-stack modules) import `dotenv` at top level.
           pip install python-dotenv
+          # matplotlib: MyIA.AI.Notebooks/GameTheory/trust_simulation/visualization.py
+          # imports it at module top level. Without it, pytest bails on
+          # collection errors for test_trust_simulation.py and skips the
+          # entire suite, masking every other test result. See #4937.
+          pip install matplotlib
           # papermill + nbformat: genai-stack/commands/notebooks.py imports
           # papermill at top level, so test_genai_notebooks.py needs it at
           # collection time. Both are declared deps of genai-stack


### PR DESCRIPTION
## Bug

\`Scripts & Notebook-Tools Tests\` workflow (scripts-tests.yml) is red on every PR for ~9+ days because \`MyIA.AI.Notebooks/GameTheory/trust_simulation/visualization.py\` imports \`matplotlib\` at module top level, and matplotlib isn't installed in the workflow's \`Install dependencies\` step.

When pytest hits the collection error, it bails with \`exit code 2\` and skips the entire suite, masking every other test result.

## Fix

Add \`pip install matplotlib\` to the install step, with a comment explaining the dep.

5 lines, 1 file, single-purpose PR.

## Verification

Before this fix, PRs like #4932 and #4935 show:

\`\`\`
ERROR collecting MyIA.AI.Notebooks/GameTheory/tests/test_trust_simulation.py
E   ModuleNotFoundError: No module named 'matplotlib'
========================== 1 skipped, 1 error in 8.71s ==========================
\`\`\`

After the fix, the same runs should reach the actual test bodies (and pass cleanly for #4935, given the VCG flake is now patched in #4935).

Fixes #4937
🤖 Generated with [Claude Code](https://claude.com/claude-code)