### PR TITLE
fix(qc): repair L4 broken nav links to L1/L2/L3 ladder notebooks

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# L4 Decision Transformer — Research Notebook\n",
     "\n",
-    "> **Ladder ML #1409** | [L1 TSMOM](../research/research_l1_tsmom.ipynb) · [L2 CS+DM](../research/research_l2_dual_momentum.ipynb) · [L3 Trend Long-Horizon](../research/research_l3_trend.ipynb) · **L4 Decision Transformer**\n",
+    "> **Ladder ML #1409** | [L1 TSMOM](research_l1_tsmom.ipynb) · [L2 CS+DM](research_l2_dual_momentum.ipynb) · [L3 Trend Long-Horizon](research_l3_trend.ipynb) · **L4 Decision Transformer**\n",
     "\n",
     "## Objectifs\n",
     "- Evaluer le **Decision Transformer** (Chen et al. 2021) comme modele offline RL pour le trading multi-actif\n",


### PR DESCRIPTION
## Summary

The `research_l4_decision_transformer.ipynb` header nav (cell 0) had **3 broken/dead links** pointing to `../research/research_l1/l2/l3_*.ipynb`. But those ladder notebooks live in the **same directory** (`ML-Training-Pipeline/`), not `QuantConnect/research/` (which contains no `research_l*` notebooks — verified `git ls-files`).

```
broken:  [L1 TSMOM](../research/research_l1_tsmom.ipynb)       → dead (file absent)
fixed:   [L1 TSMOM](research_l1_tsmom.ipynb)                   → resolves
```
Same for L2 (`research_l2_dual_momentum.ipynb`) and L3 (`research_l3_trend.ipynb`).

## Why now

This bug was latent until the L1/L2/L3 notebooks existed. Now that they're delivered:
- **L1** TSMOM → #4918 **MERGED**
- **L2** CS+DM → #4923 (OPEN)
- **L3** Trend → #4926 (OPEN)

…L4's header nav must resolve so students can navigate the full ladder. My L1/L2/L3 notebooks already reference each other and L4 with correct same-directory paths — **L4 was the dangling inconsistent edge**. This PR completes ladder nav consistency.

## Convention checks

- **Markdown-only edit** (rule C.2 exception — existing outputs preserved, no re-execution needed; the 6 code cells retain `execution_count` + outputs from the original #1615/#4418 run).
- **Surgical**: 1 line changed, 3 links. Verified no other `../research/` refs exist in the notebook.
- `nbformat.validate` PASSES, 0 errors.
- The 3 links will fully resolve once #4923 (L2) + #4926 (L3) merge (L1 already on main).

## G.1 grounding

Verified firsthand: `QuantConnect/research/` dir has no `research_l*` files; all ladder notebooks are in `ML-Training-Pipeline/`; L4's `../research/` path overshoots by one level. My own L1 notebook (on main via #4918) already uses the correct `research_l4_decision_transformer.ipynb` same-dir path — so L4 was inconsistent with the rest of the ladder.

See #1409 (ladder Epic). No `Closes` — this is a nav-consistency fix, the ladder Epic stays open.

Co-Authored-By: Claude <noreply@anthropic.com>
