### PR TITLE
fix(qc): correct L4 Decision Transformer ladder nav links (See #4876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
@@ -13,30 +13,7 @@
     },
     "tags": []
    },
-   "source": [
-    "# L4 Decision Transformer — Research Notebook\n",
-    "\n",
-    "> **Ladder ML #1409** | [L1 TSMOM](../research/research_l1_tsmom.ipynb) · [L2 CS+DM](../research/research_l2_dual_momentum.ipynb) · [L3 Trend Long-Horizon](../research/research_l3_trend.ipynb) · **L4 Decision Transformer**\n",
-    "\n",
-    "## Objectifs\n",
-    "- Evaluer le **Decision Transformer** (Chen et al. 2021) comme modele offline RL pour le trading multi-actif\n",
-    "- Le DT formule la decision comme un probleme de sequence modeling : etat → action → return-to-go\n",
-    "- Architecture transformer (d_model=128, 4 heads, 3 layers, ~642K params) predit des actions discretes (hold/buy/sell)\n",
-    "- Walk-forward 5-fold sur 26 symbols du panier anti-biais, 4 seeds (0/1/7/42)\n",
-    "- Validation multi-seed : sigma_edge = mean_delta / std_delta >= 2σ pour signal\n",
-    "\n",
-    "## Pourquoi Decision Transformer ?\n",
-    "| Aspect | PPO (online RL) | Decision Transformer (offline RL) |\n",
-    "|--------|----------------|----------------------------------|\n",
-    "| Donnees | Interaction en temps reel | **Dataset historique fixe** |\n",
-    "| Value function | Oui (Critic) | **Non** (conditionne par RTG) |\n",
-    "| Entrainement | On-policy (instable) | **Off-line** (stable) |\n",
-    "| Conditionnement | Policy gradient | **Return-to-go** (conditionne par performance cible) |\n",
-    "\n",
-    "Le DT contourne les defis de l'apprentissage online (exploration, stabilite) en traitant le RL comme un probleme de sequence prediction.\n",
-    "\n",
-    "**Duree estimee** : ~2h (GPU sweep 104 combos) | **Prerequis** : PyTorch, panier anti-biais"
-   ]
+   "source": "# L4 Decision Transformer — Research Notebook\n\n> **Ladder ML #1409** | [L1 TSMOM](research_l1_tsmom.ipynb) · [L2 CS+DM](research_l2_dual_momentum.ipynb) · [L3 Trend Long-Horizon](research_l3_trend.ipynb) · **L4 Decision Transformer**\n\n## Objectifs\n- Evaluer le **Decision Transformer** (Chen et al. 2021) comme modele offline RL pour le trading multi-actif\n- Le DT formule la decision comme un probleme de sequence modeling : etat → action → return-to-go\n- Architecture transformer (d_model=128, 4 heads, 3 layers, ~642K params) predit des actions discretes (hold/buy/sell)\n- Walk-forward 5-fold sur 26 symbols du panier anti-biais, 4 seeds (0/1/7/42)\n- Validation multi-seed : sigma_edge = mean_delta / std_delta >= 2σ pour signal\n\n## Pourquoi Decision Transformer ?\n| Aspect | PPO (online RL) | Decision Transformer (offline RL) |\n|--------|----------------|----------------------------------|\n| Donnees | Interaction en temps reel | **Dataset historique fixe** |\n| Value function | Oui (Critic) | **Non** (conditionne par RTG) |\n| Entrainement | On-policy (instable) | **Off-line** (stable) |\n| Conditionnement | Policy gradient | **Return-to-go** (conditionne par performance cible) |\n\nLe DT contourne les defis de l'apprentissage online (exploration, stabilite) en traitant le RL comme un probleme de sequence prediction.\n\n**Duree estimee** : ~2h (GPU sweep 104 combos) | **Prerequis** : PyTorch, panier anti-biais"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Resume

Corrige les 3 liens casses du header du notebook `research_l4_decision_transformer.ipynb`
(pointaient vers un sous-repertoire `research/` inexistant) pour les aligner sur la
convention **bare-path sibling** deja utilisee par L1/L2/L3.

Issue scope : #4876 (tranche broken-links ML-Training-Pipeline), epic parente #1409.

## Root cause

Cellule markdown `76562ee3` (header du L4) reference les notebooks L1/L2/L3 avec
le prefixe `../research/` :

```
[L1 TSMOM](../research/research_l1_tsmom.ipynb)
[L2 CS+DM](../research/research_l2_dual_momentum.ipynb)
[L3 Trend Long-Horizon](../research/research_l3_trend.ipynb)
```

Or les 4 notebooks du ladder sont **freres** dans le meme repertoire
`MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/` — il n'existe pas de
sous-dossier `research/`. Les liens cassent (cible introuvable).

L1/L2/L3 utilisent deja les chemins bare-sibling corrects (`research_l1_tsmom.ipynb` etc.).
Seul L4 etait outlier.

## Fix (atomique 1 cellule)

3 caracteres retires par lien : `../research/` → vide.

| Avant | Apres |
|-------|-------|
| `[L1 TSMOM](../research/research_l1_tsmom.ipynb)` | `[L1 TSMOM](research_l1_tsmom.ipynb)` |
| `[L2 CS+DM](../research/research_l2_dual_momentum.ipynb)` | `[L2 CS+DM](research_l2_dual_momentum.ipynb)` |
| `[L3 Trend Long-Horizon](../research/research_l3_trend.ipynb)` | `[L3 Trend Long-Horizon](research_l3_trend.ipynb)` |

Le contenu pedagogique de la cellule (Objectifs, tableau Pourquoi DT, Duree
estimee, Prerequis) est preserve verbatim.

## Verification

- `git diff --stat` : 1 fichier, +1/-24 (le -24 = changement de serialisation
  nbformat du `source` array → string, equivalent fonctionnel, Jupyter rend
  identique)
- H.3 pre-commit : 6 code cells, 0 avec `execution_count=None`, 0 sans outputs,
  0 erreurs
- Ladder coherence L1↔L2↔L3↔L4 : bare paths partout maintenant
- Hors scope L3 (#4921) : le run GPU pre-calcule `results.json` n'est pas
  touche par ce PR (atomicite cellule markdown uniquement)

## Anti-regression

- Pas de suppression de cellule `# Solution` / `# Exemple resolu`
- Pas d'edition de sortie de cellule (meme format-serialization nbformat
  preserve le contenu byte-identique, juste regroupement en string unique)
- Pas de regen catalogue (catalog-pr-hygiene R1)

## Lien issues

- See #4876 (tranche broken-links cleanup)
- See #1409 (Ladder ML epic parente, L4 Decision Transformer rung)

## Note scope

PR strictement atomique : 1 cellule markdown, 1 fichier. Aucun impact sur
les resultats du sweep L4 (`scripts/results/l4_decision_transformer/results.json`
non touche). Cohabite avec PR #4942 (panier anti-biais, epic #1409/#4921)
sans conflit (fichiers distincts).