### PR TITLE
docs(qc): index L1/L2/L3 ladder notebooks in ML-Training-Pipeline README

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -11,7 +11,10 @@ Les notebooks de ce répertoire sont des **recherches indépendantes (c)** — a
 | `ML-Research-Template.ipynb` | Template pour recherche ML | (c) |
 | `m3_har_asymmetric_semivariance.ipynb` | HAR semi-variance asymétrique | (c) |
 | `research_what_dl_can_predict.ipynb` | Ce que le DL peut prédire en finance | (c) |
-| `research_l4_decision_transformer.ipynb` | Évaluation Decision Transformer | (c) |
+| `research_l1_tsmom.ipynb` | L1 TSMOM — baseline momentum temporelle (NO BEATS) | (c) |
+| `research_l2_dual_momentum.ipynb` | L2 Cross-Sectional + Dual Momentum (NO BEATS) | (c) |
+| `research_l3_trend.ipynb` | L3 Trend Long-Horizon — LSTM directionnel (NO BEATS) | (c) |
+| `research_l4_decision_transformer.ipynb` | L4 Decision Transformer (seul BEATS du ladder) | (c) |
 | `hmm_alpha_research.ipynb` | HMM gaussien pour alpha trading (Broad Ch6 Ex4) | (c) |
 | `m4_dlinear_vol_research.ipynb` | DLinear-vol : DL linéaire vs HAR (prévisions pures) | (c) |
 | `m5_hmm_regime_research.ipynb` | HMM regime-switching HAR : quand la sophistication structurelle nuit | (c) |


### PR DESCRIPTION
## Summary

The research-notebooks table in `ML-Training-Pipeline/README.md` (lines 9-21) listed **only** `research_l4_decision_transformer.ipynb`. Now that the L1/L2/L3 ladder notebooks are merged, they were missing from the index → not discoverable from the README.

This groups the **4 ladder entries together** (L1-L4), each annotated with its verdict so the ladder arc is legible at a glance:

```
| `research_l1_tsmom.ipynb`              | L1 TSMOM — baseline momentum temporelle (NO BEATS)      | (c) |
| `research_l2_dual_momentum.ipynb`      | L2 Cross-Sectional + Dual Momentum (NO BEATS)           | (c) |
| `research_l3_trend.ipynb`              | L3 Trend Long-Horizon — LSTM directionnel (NO BEATS)    | (c) |
| `research_l4_decision_transformer.ipynb` | L4 Decision Transformer (seul BEATS du ladder)        | (c) |
```

## Why now

The ladder notebooks just landed: L1 (#4918), L2 (#4923), L3 (#4926) — all merged. This PR makes them discoverable from the README index that already listed L4. The verdicts (NO BEATS / sole BEATS) match the canonical `docs/L1_tsmom.md`, `docs/L2_dual_momentum.md`, and `scripts/results/l3_trend_long_horizon/` (#1574/#1575/#1576).

## Convention checks

- **Markdown-only** (4 insertions, 1 deletion — replaced the single L4 line with a 4-line ladder block).
- **FR-first** (rule readme-french-first).
- Table still renders correctly (verified the rows).
- No catalog markers touched.

Follows the just-merged ladder work (#4918/#4923/#4926) — discoverability polish. See #1409, See #4876.

Co-Authored-By: Claude <noreply@anthropic.com>
