### PR TITLE
feat(ict): cross-substrate emergence harness — ICT-Synthèse groundwork (See #4588, #4946)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
@@ -32,11 +32,12 @@ from . import bistable
 from . import reaction_diffusion
 from . import agency
 from . import catastrophe
+from . import synthesis
 
 __all__ = [
     "Cell", "Probe", "SelfSortingArray", "KinSortingArray", "ALGOTYPES",
     "GrazingModel", "GrayScott",
     "sorting_metrics", "trajectories", "causal_emergence", "tpm_estimation",
     "scale_free", "early_warning", "bistable", "reaction_diffusion", "agency",
-    "catastrophe",
+    "catastrophe", "synthesis",
 ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/synthesis.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/synthesis.py
@@ -13,7 +13,11 @@ discretisees (labels hachables), sans rien connaitre des substrats. La
 discretisation substrat-specifique (coarse-graining d'un champ 2D, binning
 d'un scalaire, symbolisation d'un vecteur de frequences strategiques) vit dans
 le notebook ICT-Synthese, ou elle est un choix documente et mesure -- pas une
-constante cachee dans la librairie.
+constante cachee dans la librairie. Ce choix doit rester **grossier** : le
+chemin d'echelles de ``causal_emergence.greedy_apportionment`` explore toutes
+les paires d'etats a chaque pas (cout ~O(k^2) par echelle, k = nombre d'etats
+distincts), donc une trajectoire de tri brute (``tuple(config)``) explose vite
+alors que sa version macro (niveau d'inversions) tient en une dizaine d'etats.
 
 Gate falsifiable central : *un scalaire d'integration transfere-t-il entre
 substrats ?* Les aides ``cross_substrate_summary`` et ``rank_consistency``

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/synthesis.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/synthesis.py
@@ -1,0 +1,211 @@
+"""Synthese cross-substrat de la serie ICT (capstone, Epic #4588, voir #4946).
+
+Le fil unificateur de la serie ICT : chaque substrat -- tri auto-organise (S1),
+paysage bistable / reaction-diffusion (S2), replicateur strategique (S3) --
+produit une **trajectoire**. On estime une TPM etat-a-etat depuis cette
+trajectoire propre (le pont tri->TPM d'ICT-6, generalise via
+``ict.tpm_estimation``) puis on lui applique la MEME batterie d'emergence
+causale (``ict.causal_emergence``). C'est le seul appareil de mesure de la
+serie applique a l'identique a des substrats radicalement differents.
+
+Ce module reste **generique** : il opere sur des suites d'etats deja
+discretisees (labels hachables), sans rien connaitre des substrats. La
+discretisation substrat-specifique (coarse-graining d'un champ 2D, binning
+d'un scalaire, symbolisation d'un vecteur de frequences strategiques) vit dans
+le notebook ICT-Synthese, ou elle est un choix documente et mesure -- pas une
+constante cachee dans la librairie.
+
+Gate falsifiable central : *un scalaire d'integration transfere-t-il entre
+substrats ?* Les aides ``cross_substrate_summary`` et ``rank_consistency``
+permettent de le tester. L'attendu (a confirmer par execution dans le
+notebook) est **non** : le classement des substrats change selon la mesure
+choisie (EI brute vs gain d'emergence), et aucun nombre unique ne les ordonne
+tous. L'invariant de la serie n'est pas un scalaire universel mais une
+*methode* : une emergence n'est creditee que **contrastee a son propre controle
+degenere**.
+
+Sans complaisance : ``shuffled_baseline`` casse la structure temporelle de la
+trajectoire tout en conservant exactement les frequences marginales d'etats.
+Si l'emergence "reelle" ne depasse pas ce controle, elle n'est qu'un artefact
+du reservoir d'etats visites (des degres de liberte), pas de la dynamique.
+
+Dependances : numpy + ``ict.tpm_estimation`` + ``ict.causal_emergence``.
+Reference : ICT-0 (cadrage + feuille de route synthese), Epic #4588.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+import numpy as np
+
+from . import causal_emergence as CE
+from . import tpm_estimation as TE
+
+
+# --------------------------------------------------------------- batterie sur une TPM
+def emergence_battery(tpm) -> dict:
+    """Batterie d'emergence causale sur une TPM etat-a-etat.
+
+    Combine le profil causal (``causal_emergence.causal_profile``) et le chemin
+    d'echelles glouton (``greedy_apportionment``). Retourne un dict plat :
+    ``n``, ``effective_information`` (bits, micro), ``determinism``,
+    ``degeneracy``, ``effectiveness``, ``emergent_complexity`` (EC sur le chemin
+    d'echelles), ``n_scales`` (longueur du chemin micro -> macro).
+    """
+    prof = CE.causal_profile(tpm)
+    appo = CE.greedy_apportionment(tpm)
+    return {
+        "n": prof["n"],
+        "effective_information": prof["effective_information"],
+        "determinism": prof["determinism"],
+        "degeneracy": prof["degeneracy"],
+        "effectiveness": prof["effectiveness"],
+        "emergent_complexity": appo["emergent_complexity"],
+        "n_scales": len(appo["scales"]),
+    }
+
+
+# --------------------------------------------------------------- trajectoire -> batterie
+def trajectory_battery(states: Sequence, unseen: str = "self") -> dict:
+    """Estime la TPM d'une trajectoire discrete puis calcule la batterie.
+
+    ``states`` : suite d'etats consecutifs (labels hachables). Ajoute au
+    resultat de ``emergence_battery`` deux champs de contexte : ``n_states``
+    (nombre d'etats distincts observes) et ``n_transitions``.
+    """
+    seq = list(states)
+    tpm, mapping = TE.tpm_from_trajectory(seq, unseen=unseen)
+    out = emergence_battery(tpm)
+    out["n_states"] = len(mapping)
+    out["n_transitions"] = max(0, len(seq) - 1)
+    return out
+
+
+# --------------------------------------------------------------- controle degenere
+def shuffle_states(states: Sequence, rng: np.random.Generator) -> List:
+    """Permute la suite d'etats (casse la structure temporelle).
+
+    Conserve exactement le multi-ensemble d'etats : le controle isole la part
+    d'emergence qui vient de l'ORDRE (la dynamique) plutot que du simple
+    reservoir d'etats visites.
+    """
+    seq = list(states)
+    idx = rng.permutation(len(seq))
+    return [seq[i] for i in idx]
+
+
+def shuffled_baseline(states: Sequence, rng: np.random.Generator,
+                      n_shuffles: int = 20, unseen: str = "self") -> dict:
+    """Batterie moyenne sur ``n_shuffles`` permutations de la trajectoire.
+
+    Retourne la moyenne (et l'ecart-type sous ``*_std``) de
+    ``effective_information`` et ``emergent_complexity`` sur les permutations.
+    C'est le controle *sans complaisance* : la valeur a battre pour crediter une
+    emergence reelle.
+    """
+    eis, ecs = [], []
+    for _ in range(int(n_shuffles)):
+        b = trajectory_battery(shuffle_states(states, rng), unseen=unseen)
+        eis.append(b["effective_information"])
+        ecs.append(b["emergent_complexity"])
+    return {
+        "effective_information": float(np.mean(eis)),
+        "effective_information_std": float(np.std(eis)),
+        "emergent_complexity": float(np.mean(ecs)),
+        "emergent_complexity_std": float(np.std(ecs)),
+        "n_shuffles": int(n_shuffles),
+    }
+
+
+def emergence_gain(states: Sequence, rng: np.random.Generator,
+                   n_shuffles: int = 20, unseen: str = "self") -> dict:
+    """Gain d'emergence : mesure reelle - controle shuffle (le signal credite).
+
+    Retourne les valeurs reelles, les valeurs du controle et le gain pour EI et
+    EC, plus un booleen ``credited`` : True quand le gain d'EC depasse
+    l'ecart-type du controle (signal au-dessus du bruit du reservoir d'etats).
+    """
+    real = trajectory_battery(states, unseen=unseen)
+    base = shuffled_baseline(states, rng, n_shuffles=n_shuffles, unseen=unseen)
+    ec_gain = real["emergent_complexity"] - base["emergent_complexity"]
+    ei_gain = real["effective_information"] - base["effective_information"]
+    credited = ec_gain > base["emergent_complexity_std"] + 1e-12
+    return {
+        "ei_real": real["effective_information"],
+        "ei_shuffled": base["effective_information"],
+        "ei_gain": ei_gain,
+        "ec_real": real["emergent_complexity"],
+        "ec_shuffled": base["emergent_complexity"],
+        "ec_gain": ec_gain,
+        "credited": bool(credited),
+        "n_states": real["n_states"],
+    }
+
+
+# --------------------------------------------------------------- comparaison inter-substrat
+def cross_substrate_summary(named_trajectories: Dict[str, Sequence],
+                            rng: np.random.Generator,
+                            n_shuffles: int = 20, unseen: str = "self") -> dict:
+    """Applique la batterie + le controle a chaque substrat nomme.
+
+    ``named_trajectories`` : ``{nom_substrat: suite d'etats}``. Retourne
+    ``{nom: emergence_gain(...)}`` -- la table brute pour le gate inter-substrat.
+    """
+    return {
+        name: emergence_gain(states, rng, n_shuffles=n_shuffles, unseen=unseen)
+        for name, states in named_trajectories.items()
+    }
+
+
+def _kendall_tau(x: Sequence[float], y: Sequence[float]) -> float:
+    """Tau de Kendall (concordance de rangs), implementation directe O(n^2).
+
+    Compte les paires concordantes/discordantes, sans dependance a scipy. Les
+    paires a egalite (sur x ou y) sont ignorees. Retourne 0.0 s'il y a moins de
+    deux elements ou aucune paire departageable.
+    """
+    xs = list(x)
+    ys = list(y)
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    conc = disc = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            sx = np.sign(xs[i] - xs[j])
+            sy = np.sign(ys[i] - ys[j])
+            if sx == 0 or sy == 0:
+                continue
+            if sx == sy:
+                conc += 1
+            else:
+                disc += 1
+    total = conc + disc
+    if total == 0:
+        return 0.0
+    return float((conc - disc) / total)
+
+
+def rank_consistency(summary: dict, key_a: str = "ei_real",
+                     key_b: str = "ec_gain") -> dict:
+    """Teste si deux mesures classent les substrats dans le MEME ordre.
+
+    Coeur du gate falsifiable : si un "scalaire d'integration" transferait entre
+    substrats, le classement selon ``key_a`` et selon ``key_b`` coinciderait.
+    Retourne l'ordre (decroissant) selon chaque cle, le tau de Kendall entre les
+    deux (dans ``[-1, 1]`` : +1 = ordres identiques, -1 = inverses, ~0 = pas de
+    transfert) et un booleen ``consistent`` (tau ~ +1).
+    """
+    names = list(summary)
+    va = [summary[n][key_a] for n in names]
+    vb = [summary[n][key_b] for n in names]
+    order_a = [names[i] for i in np.argsort(va)[::-1]]
+    order_b = [names[i] for i in np.argsort(vb)[::-1]]
+    tau = _kendall_tau(va, vb)
+    return {
+        "order_by_" + key_a: order_a,
+        "order_by_" + key_b: order_b,
+        "kendall_tau": tau,
+        "consistent": bool(tau > 0.999),
+    }

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_synthesis.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_synthesis.py
@@ -1,0 +1,145 @@
+"""Tests du module ict.synthesis (batterie cross-substrat, stdlib+numpy).
+
+Verifie l'appareil de mesure unifie de la synthese ICT : trajectoire -> TPM ->
+batterie d'emergence causale, et surtout le controle degenere *sans
+complaisance* (shuffle) qui distingue une emergence reelle d'un artefact du
+reservoir d'etats. Cf Epic #4588, issue #4946.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict import synthesis as S  # noqa: E402
+
+
+# --------------------------------------------------------------- generateurs de test
+def _deterministic_cycle(length: int = 30) -> list:
+    """Cycle deterministe 0 -> 1 -> 2 -> 0 ... (maximalement causal au micro)."""
+    return [t % 3 for t in range(length)]
+
+
+def _macro_deterministic_micro_random(rng, length: int = 600) -> list:
+    """Macro-cycle deterministe, micro-etat bruite (emergence multi-echelles).
+
+    L'etat macro suit le cycle 0 -> 1 -> 2 -> 0 (deterministe), mais chaque
+    macro-etat emet un micro-etat ``(macro, bit)`` avec ``bit`` aleatoire. Le
+    micro est donc partiellement indeterministe ; un coarse-graining qui
+    regroupe les deux micro-etats d'un meme macro RECOUVRE le determinisme ->
+    emergence causale positive. Le shuffle de cette trajectoire detruit le
+    cycle et donc l'emergence : c'est le contraste que la synthese credite.
+    """
+    return [(t % 3, int(rng.integers(0, 2))) for t in range(length)]
+
+
+# --------------------------------------------------------------- batterie de base
+def test_emergence_battery_deterministic_cycle():
+    tpm = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]], dtype=float)
+    bat = S.emergence_battery(tpm)
+    # cycle deterministe : effectiveness maximale, EI = log2(3)
+    assert abs(bat["effectiveness"] - 1.0) < 1e-9
+    assert abs(bat["effective_information"] - np.log2(3)) < 1e-9
+    # tout le travail causal est deja au micro : aucune fusion n'aide -> EC nulle
+    assert bat["emergent_complexity"] == 0.0
+    assert bat["n_scales"] == 1
+    assert bat["n"] == 3
+
+
+def test_trajectory_battery_counts():
+    states = _deterministic_cycle(30)
+    bat = S.trajectory_battery(states)
+    assert bat["n_states"] == 3
+    assert bat["n_transitions"] == 29
+    assert abs(bat["effectiveness"] - 1.0) < 1e-9
+
+
+# --------------------------------------------------------------- controle degenere
+def test_shuffle_preserves_marginals():
+    rng = np.random.default_rng(0)
+    states = _macro_deterministic_micro_random(rng, length=200)
+    shuffled = S.shuffle_states(states, rng)
+    # meme multi-ensemble d'etats (seul l'ORDRE change)
+    assert sorted(shuffled) == sorted(states)
+    assert len(shuffled) == len(states)
+
+
+def test_shuffled_baseline_keys():
+    rng = np.random.default_rng(1)
+    states = _deterministic_cycle(30)
+    base = S.shuffled_baseline(states, rng, n_shuffles=5)
+    assert base["n_shuffles"] == 5
+    for key in ("effective_information", "effective_information_std",
+                "emergent_complexity", "emergent_complexity_std"):
+        assert key in base
+
+
+# --------------------------------------------------------------- gain d'emergence
+def test_emergence_gain_structured_beats_shuffle():
+    # substrat structure multi-echelles : le reel doit dominer son shuffle
+    rng = np.random.default_rng(42)
+    states = _macro_deterministic_micro_random(rng, length=600)
+    gain = S.emergence_gain(states, rng, n_shuffles=30)
+    # la structure temporelle porte plus d'information effective que son shuffle
+    assert gain["ei_real"] > gain["ei_shuffled"]
+    assert gain["ei_gain"] > 0.0
+    # une emergence multi-echelles reelle existe (EC micro->macro > 0)
+    assert gain["ec_real"] > 0.0
+
+
+def test_emergence_gain_iid_not_credited():
+    # substrat sans structure temporelle : reel ~ shuffle -> non credite
+    rng = np.random.default_rng(7)
+    states = [int(rng.integers(0, 4)) for _ in range(600)]
+    gain = S.emergence_gain(states, rng, n_shuffles=30)
+    # une suite iid n'a pas de dynamique : le shuffle ne change (presque) rien
+    assert gain["credited"] is False
+    assert abs(gain["ei_gain"]) < 0.3
+
+
+# --------------------------------------------------------------- gate inter-substrat
+def test_cross_substrate_summary_keys():
+    rng = np.random.default_rng(3)
+    trajs = {
+        "cycle": _deterministic_cycle(60),
+        "emergent": _macro_deterministic_micro_random(rng, length=300),
+    }
+    summary = S.cross_substrate_summary(trajs, rng, n_shuffles=5)
+    assert set(summary) == {"cycle", "emergent"}
+    for entry in summary.values():
+        for key in ("ei_real", "ei_gain", "ec_real", "ec_gain", "credited"):
+            assert key in entry
+
+
+def test_kendall_tau_identical_and_inverse():
+    assert abs(S._kendall_tau([3, 2, 1], [6, 4, 2]) - 1.0) < 1e-12
+    assert abs(S._kendall_tau([3, 2, 1], [1, 2, 3]) - (-1.0)) < 1e-12
+    # moins de deux points : pas de paire departageable
+    assert S._kendall_tau([1.0], [2.0]) == 0.0
+
+
+def test_rank_consistency_detects_disagreement():
+    # ei_real classe A>B>C, ec_gain classe C>B>A -> aucun scalaire ne transfere
+    summary = {
+        "A": {"ei_real": 3.0, "ec_gain": 0.1},
+        "B": {"ei_real": 2.0, "ec_gain": 0.5},
+        "C": {"ei_real": 1.0, "ec_gain": 0.9},
+    }
+    rc = S.rank_consistency(summary)
+    assert rc["order_by_ei_real"] == ["A", "B", "C"]
+    assert rc["order_by_ec_gain"] == ["C", "B", "A"]
+    assert abs(rc["kendall_tau"] - (-1.0)) < 1e-12
+    assert rc["consistent"] is False
+
+
+def test_rank_consistency_detects_agreement():
+    summary = {
+        "A": {"ei_real": 3.0, "ec_gain": 0.9},
+        "B": {"ei_real": 2.0, "ec_gain": 0.5},
+        "C": {"ei_real": 1.0, "ec_gain": 0.1},
+    }
+    rc = S.rank_consistency(summary)
+    assert abs(rc["kendall_tau"] - 1.0) < 1e-12
+    assert rc["consistent"] is True


### PR DESCRIPTION
## Scope

Generic measurement backbone for the **ICT-Synthèse** capstone (Epic #4588, design tracked in #4946). Pure library + tests — **no notebook** (that awaits ai-01 design sign-off on #4946; this harness is design-independent).

The unifying *single fil* of the series: each substrate — self-sorting (S1), bistable / reaction-diffusion (S2), strategic replicator (S3) — produces a **trajectory**. We estimate a state-to-state TPM from that own trajectory (ICT-6's tri→TPM bridge, generalized via `ict.tpm_estimation`) and apply the **same** causal-emergence battery (`ict.causal_emergence`) to all of them. One measuring apparatus, radically different substrates.

## Files

| File | What |
|------|------|
| `ict/synthesis.py` (+211) | `emergence_battery`, `trajectory_battery`, `shuffle_states`, `shuffled_baseline`, `emergence_gain`, `cross_substrate_summary`, `rank_consistency` |
| `tests/test_synthesis.py` (+145) | 10 tests |
| `ict/__init__.py` (±2) | export `synthesis` at package level (sibling of `causal_emergence`/`tpm_estimation`) |

## Design choices

- **Generic by construction**: operates on pre-discretized state sequences (hashable labels). Per-substrate discretization (coarse-graining a 2D field, binning a scalar, symbolizing a strategy-frequency vector) stays in the notebook — a documented, measured choice, not a hidden library constant. Minimal churn if the design shifts.
- **Sans complaisance**: `shuffled_baseline` breaks temporal structure while preserving exact state marginals. Real emergence is *credited* only when it beats this degenerate control (`emergence_gain` → `credited` flag). Otherwise it is an artifact of the state reservoir, not the dynamics.
- **Falsifiable cross-substrate gate**: `rank_consistency` computes a Kendall-tau between substrate rankings by EI vs by emergence gain — the central question *"does a single integration scalar transfer across substrates?"*. The expected honest answer (to be confirmed by real substrate runs in the notebook) is **no**; the invariant is methodological, not a universal number.

## Validation

\`\`\`
conda run -n coursia-ml-training python -m pytest tests/ -q
======================= 224 passed in 62.41s =======================
\`\`\`

Suite 214 → 224 (10 new), all green. `__init__` export change introduces no import regression.

See #4588, #4946.