### PR TITLE
feat(ict): ICT-Synthèse capstone — un seul appareil, trois substrats, une question falsifiable (See #4588, #4946)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb
@@ -1,0 +1,1189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "55c513d8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010468,
+     "end_time": "2026-07-02T10:04:11.992273+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:11.981805+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# ICT-Synthèse — un seul appareil de mesure, trois substrats, une question falsifiable\n",
+    "\n",
+    "[← ICT-Series](README.md) | [↑ IIT](../README.md) | *Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588), capstone — voir [#4946](https://github.com/jsboige/CoursIA/issues/4946)*\n",
+    "\n",
+    "La série **ICT** (*Integrated Causal Trajectories*) a promené un même regard — la structure\n",
+    "causale d'un système *le long de sa trajectoire* — sur des substrats de plus en plus riches :\n",
+    "le tri auto-organisé (strate 1), les paysages d'attracteurs et la morphogenèse réaction-diffusion\n",
+    "(strate 2), les agents et les stratégies (strate 3). À chaque étape, une capacité (robustesse,\n",
+    "agence, émergence, anticipation, stabilité stratégique) n'a été **créditée** qu'après avoir\n",
+    "**battu un contrôle dégénéré** — jamais déclarée. Et le même mot est revenu, notebook après\n",
+    "notebook : **régime-dépendance**.\n",
+    "\n",
+    "Ce notebook de synthèse ne rejoue pas la série. Il **replie son fil** en une seule question\n",
+    "falsifiable :\n",
+    "\n",
+    "> **Existe-t-il *un* scalaire d'intégration qui transfère d'un substrat à l'autre** — qui\n",
+    "> classe le tri, le paysage bistable et le réplicateur stratégique dans le *même* ordre —\n",
+    "> ou bien le seul invariant de la série est-il la **méthode** elle-même (créditer une\n",
+    "> émergence uniquement contre son propre contrôle dégénéré) ?\n",
+    "\n",
+    "Le fil unificateur est un **appareil de mesure unique**, appliqué à l'identique aux trois\n",
+    "substrats : depuis la trajectoire propre de chaque substrat, on estime une **matrice de\n",
+    "transition état-à-état** (le pont tri → TPM d'[ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb),\n",
+    "généralisé) ; puis on lui applique la **même batterie d'émergence causale**\n",
+    "([ICT-5](ICT-5-CausalEmergence.ipynb)/[ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb),\n",
+    "cadre *Causal Emergence 2.0* de Jansma & Hoel). C'est le seul instrument de toute la série\n",
+    "branché **sans modification** sur des substrats radicalement différents.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08eebbfc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004589,
+     "end_time": "2026-07-02T10:04:12.006195+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.001606+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le fil de la série — tableau récapitulatif\n",
+    "\n",
+    "Le cœur de ce capstone : une ligne par notebook, la **question centrale**, le **verdict\n",
+    "réellement committé** (pas l'intuition de départ), et les **chiffres des gates** qui le\n",
+    "soutiennent. On y lit deux constantes de la série — (a) une capacité n'est créditée qu'au\n",
+    "**contraste** d'un contrôle dégénéré, et (b) le verdict est, de plus en plus, **régime-dépendant**\n",
+    "(ICT-10 → ICT-13).\n",
+    "\n",
+    "| ICT-N | Question centrale | Verdict réel committé | Chiffres-clés des gates |\n",
+    "|-------|-------------------|-----------------------|--------------------------|\n",
+    "| **[ICT-0](ICT-0-Framing.md)** | De l'état (IIT) à la trajectoire : quel cadre ? | Cadre méthodologique : *mesurer ce que le modèle fait vraiment, pas ce qu'on espérait* ; deux strates ; contrôle dégénéré obligatoire | doc de cadrage (2 articles fondateurs : Levin ; Jansma & Hoel) |\n",
+    "| **[ICT-1](ICT-1-PhiTrajectories.ipynb)** | $\\Phi$ a-t-il un paysage, une trajectoire, une robustesse ? | OUI aux trois : $\\Phi$ **pulse** le long de l'attracteur et se **répare** (vrai PyPhi) | AND/OR pic $\\Phi$=2.31 vs 0.19 (amplitude 2.12) ; XOR plat 1.875 ; attracteur cycle longueur 3 |\n",
+    "| **[ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb)** | Le tri est-il une morphogenèse à compétences ? | Robustesse + délai de gratification + auto-réparation OUI ; agrégation « kin » **NON** (impasses) → renvoi ICT-4 | tri homogène 315 pas / 68 swaps ; chimère sortedness 0.784, 4 impasses résiduelles |\n",
+    "| **[ICT-3](ICT-3-RobustnessDelayedGratification.ipynb)** | Ces compétences se quantifient-elles ? | OUI : dégradation gracieuse, réparation **24/24**, délai ~90 épisodes | @50 % lésion passif 0.59–0.62 vs obstacle 0.53 ; délai bubble 91.4 / insertion 89.8 |\n",
+    "| **[ICT-4](ICT-4-ChimericArraysKinAggregation.ipynb)** | Quel enrichissement minimal fait émerger l'agrégation « kin » ? | Réparation bidirectionnelle guérit l'impasse mais **n'agrège pas** ; l'agrégation émerge **seulement** dans les degrés de liberté laissés par le tri | copies=1 (liberté nulle) → agrégation kin ≈ 0 ; décolle dès copies ≥ 2 ; 40/40 → 0/40 non triés |\n",
+    "| **[ICT-5](ICT-5-CausalEmergence.ipynb)** | L'émergence causale ($\\Phi_\\text{macro} > \\Phi_\\text{micro}$) est-elle réelle et systématique ? | **Discriminante**, pas systématique : absente sur des systèmes déjà micro-intégrés | Hoel 0.114 → 0.597 (**+0.483**) ; XOR **−1.375** ; basic\\_network **−1.792** |\n",
+    "| **[ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb)** | Peut-on porter l'émergence au tri au-delà de PyPhi (CE 2.0) ? | OUI ; le macro *intuitif* (niveau de tri) **échoue**, seul l'apportionnement glouton trouve l'échelle | micro EI 3.29 bits ; macro-tri gain **−0.034** (NON) ; glouton effectiveness 0.717 → 0.826 (**+0.109**) |\n",
+    "| **[ICT-7](ICT-7-ScaleFreeSignatures.ipynb)** | Le tri auto-organisé est-il scale-free ? | **NON** : échelle caractéristique (la taille $n$, révélée par effondrement d'échelle) ; le scale-free est rare et réglé | branchement critique $\\mu$=1 : $\\alpha$=1.58, KS=0.017, $p$=0.625 ($\\tau$=3/2) ; tri **rejeté** $p$-GoF=0.0 |\n",
+    "| **[ICT-8](ICT-8-AttractorLandscapesEWS.ipynb)** | Les *early-warning signals* montent-ils **avant** la bascule ? | OUI (variance ↑, AR1 ↑) ; une mesure naïve **fabrique ou masque** le signal | $c_\\text{fold}$≈2.604 ; stationnaire $\\tau$=+1.00 ; AR1 brute 0.9987 (saturée) vs amincie 0.939 |\n",
+    "| **[ICT-9](ICT-9-AgencyRegeneration.ipynb)** | Quand un système répare-t-il *sa propre* forme (agence) ? | Agence = **gain de réparation > 0** (réaction-diffusion vs diffusion pure) ; mesure naïve = signal fantôme | gain=1.22 ; cosinus spectral RD 0.631 **<** diffusion 0.735 (fantôme) ; sweep 9/9 positif (moy 1.26) |\n",
+    "| **[ICT-10](ICT-10-CatastropheGrammar.ipynb)** | La grammaire des catastrophes est-elle mesurable ? $\\hat p$ anticipe-t-il ? | OUI en régime non dégénéré ($a<0$) ; hors régime = **fantôme**. $\\hat p$ : avantage **régime-dépendant** | comptage [1,3], 2 transitions ; lacet aire signée +1.633 ; $\\hat p$ horizon-4 0.055 vs persistance 0.101 ; $a$=+0.5 → 0 saut |\n",
+    "| **[ICT-11](ICT-11-CausalAgencyProfiles.ipynb)** | À quelle échelle l'agence est-elle la plus lisible ? | **Résultat négatif robuste** : pas de granularité privilégiée | 2 mesures se contredisent ; effectiveness↔repair\\_gain $r$=+0.50 mais ↔basin\\_return $r$=−0.14 ; effectiveness sans sommet (0.71/0.50/0.79/0.63) |\n",
+    "| **[ICT-12](ICT-12-ValenceFieldsAndAnimats.ipynb)** | Dans quels environnements le modèle interne $\\hat p$ paie-t-il son coût ? | **Régime-dépendant** : $\\hat p$ paie **où la source échappe au réactif ET reste prévisible** | balistique rapide capture $\\hat p$ 0.072 vs réactif 0.018 ; anticipation $\\hat p$ 2.44 vs persistance 14.95 (balist.) mais **perd** en bruité (0.62 vs 0.23) |\n",
+    "| **[ICT-13](ICT-13-AxelrodStrategicMorphodynamics.ipynb)** | Une stratégie est-elle une forme stable ? | Stable **seulement dans un paysage donné** ; TFT gagne sans bruit mais s'effondre ; correction honnête : **grim** chute le moins | sans bruit TFT/grim 2.635, AllD 2.313 ; $\\delta^*$=0.5 (num. 0.55) ; chute sous bruit TFT +0.399 vs grim +0.287 ; invasion TFT/grim 0.02, pavlov/allc jamais (1.0) |\n",
+    "\n",
+    "**Ce que le tableau donne à voir.** La série ne consacre presque **rien** sans réserve : à chaque\n",
+    "ligne, un « OUI » s'accompagne d'un « mais » chiffré, et le dernier tiers (ICT-10 → 13) répète\n",
+    "le même mot — *régime-dépendant*. La question du capstone est de savoir si cette répétition\n",
+    "cache un **scalaire commun** transférable, ou si elle **est** le résultat.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79b7556a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005003,
+     "end_time": "2026-07-02T10:04:12.016195+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.011192+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Le fil unificateur : un seul appareil, trois substrats\n",
+    "\n",
+    "Chaque substrat produit une **trajectoire** d'états. On la discrétise **grossièrement** (un choix\n",
+    "documenté, propre à chaque substrat — pas une constante cachée), on estime une **TPM état-à-état**\n",
+    "(`ict.tpm_estimation`, le pont d'ICT-6), puis on applique la **même** batterie d'émergence causale\n",
+    "(`ict.causal_emergence`) via le module de synthèse `ict.synthesis` livré en amont (#4948) :\n",
+    "\n",
+    "- **information effective** (EI, bits) et **effectiveness** (déterminisme − dégénérescence, sans échelle) ;\n",
+    "- **complexité émergente** (EC) le long du chemin d'échelles glouton (`greedy_apportionment`).\n",
+    "\n",
+    "**Le contrôle *sans complaisance*.** Pour chaque substrat, on compare la mesure réelle à un\n",
+    "**contrôle dégénéré** : la trajectoire dont on a **permuté l'ordre temporel** (`shuffle_states`),\n",
+    "ce qui conserve *exactement* le multi-ensemble d'états visités mais **détruit la dynamique**. Une\n",
+    "émergence n'est **créditée** que si elle dépasse ce contrôle — sinon, elle n'est qu'un artefact du\n",
+    "réservoir d'états (des degrés de liberté), pas de l'ordre. C'est la discipline d'ICT-8/9/11\n",
+    "généralisée à trois substrats à la fois.\n",
+    "\n",
+    "> **Runtime borné (choix assumé).** Le chemin d'échelles de `greedy_apportionment` explore toutes\n",
+    "> les paires d'états à chaque pas (coût ~$O(k^2)$ par échelle, $k$ = nombre d'états distincts).\n",
+    "> On garde donc une **discrétisation grossière** (≈ 6–12 états par substrat) et des trajectoires\n",
+    "> **sous-échantillonnées** : l'exécution complète tient en **moins de deux minutes** tout en\n",
+    "> laissant chaque gate discriminant. Une discrétisation fine (ex. `tuple(config)` brut du tri)\n",
+    "> ferait exploser $k$ sans rien ajouter au verdict.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "839b291b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:04:12.031066Z",
+     "iopub.status.busy": "2026-07-02T10:04:12.031066Z",
+     "iopub.status.idle": "2026-07-02T10:04:12.645023Z",
+     "shell.execute_reply": "2026-07-02T10:04:12.644201Z"
+    },
+    "papermill": {
+     "duration": 0.626565,
+     "end_time": "2026-07-02T10:04:12.648233+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.021668+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Appareil de mesure unique : trajectoire -> TPM etat-a-etat -> batterie d'emergence causale.\n",
+      "Controle degenere : permutation temporelle (marginales d'etats conservees, dynamique detruite).\n",
+      "Graines gate 3 : (0, 1, 7, 42, 99) | n_shuffles gates 1-2 = 100, gate 3 = 30\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys, os\n",
+    "sys.path.insert(0, os.getcwd())\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "from ict import synthesis as S\n",
+    "from ict import sorting_metrics as sm\n",
+    "from ict.self_sorting import SelfSortingArray\n",
+    "from ict.bistable import GrazingModel\n",
+    "from ict import strategic_morphodynamics as SM\n",
+    "\n",
+    "# --- parametres bornes (voir la note \"Runtime borne\" ci-dessus) ---\n",
+    "N_SHUF = 100            # controle degenere pour les gates 1-2 (une graine)\n",
+    "N_SHUF_SEED = 30        # controle par graine pour le gate 3 (multi-graines)\n",
+    "SEEDS = (0, 1, 7, 42, 99)   # graines du gate 3 (regime = alea de generation)\n",
+    "SEED0 = SEEDS[0]        # graine representative des gates 1-2\n",
+    "\n",
+    "\n",
+    "def traj_S1(seed, n_runs=6, max_steps=1500):\n",
+    "    \"\"\"S1 - tri auto-organise : etat = nombre d'inversions (coarse, ICT-2/6).\"\"\"\n",
+    "    states = []\n",
+    "    for r in range(n_runs):\n",
+    "        rng = np.random.default_rng(seed + r)\n",
+    "        arr = SelfSortingArray(list(rng.permutation(6)), seed=seed + r)\n",
+    "        arr.run(max_steps=max_steps, record=True)\n",
+    "        states.extend(sm.inversion_count(c) for c in arr.probe.values)\n",
+    "    return states\n",
+    "\n",
+    "\n",
+    "def traj_S2(seed, T=1500):\n",
+    "    \"\"\"S2 - paysage bistable (modele de paturage de May, ICT-8) : SDE pres du pli,\n",
+    "    etat = decile du scalaire de biomasse.\"\"\"\n",
+    "    gm = GrazingModel()\n",
+    "    c = 0.92 * gm.find_fold()          # sous le pli : deux etats stables coexistent\n",
+    "    xs = gm.simulate_sde(c=c, x0=8.0, sigma=0.55, dt=0.02, T=T, seed=seed)\n",
+    "    lo, hi = np.percentile(xs, 1), np.percentile(xs, 99)\n",
+    "    bins = np.linspace(lo, hi, 11)     # 10 deciles -> ~11 etats\n",
+    "    return [int(v) for v in np.clip(np.digitize(xs, bins), 0, 10)]\n",
+    "\n",
+    "\n",
+    "def traj_S3(seed, n_runs=10, n_steps=300):\n",
+    "    \"\"\"S3 - replicateur strategique (IPD/Axelrod, ICT-13) : etat = strategie dominante.\"\"\"\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    strat = SM.make_strategies(rng)\n",
+    "    A = SM.payoff_matrix(strat, rng=rng)\n",
+    "    states = []\n",
+    "    for _ in range(n_runs):\n",
+    "        x0 = rng.dirichlet(np.ones(len(strat)))\n",
+    "        traj = SM.replicator_trajectory(A, x0, n_steps=n_steps)\n",
+    "        states.extend(int(np.argmax(row)) for row in traj)\n",
+    "    return states\n",
+    "\n",
+    "\n",
+    "print(\"Appareil de mesure unique : trajectoire -> TPM etat-a-etat -> batterie d'emergence causale.\")\n",
+    "print(f\"Controle degenere : permutation temporelle (marginales d'etats conservees, dynamique detruite).\")\n",
+    "print(f\"Graines gate 3 : {SEEDS} | n_shuffles gates 1-2 = {N_SHUF}, gate 3 = {N_SHUF_SEED}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "199e26fd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014154,
+     "end_time": "2026-07-02T10:04:12.673660+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.659506+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Trois substrats, trois strates\n",
+    "\n",
+    "On instancie les trois trajectoires avec la graine représentative `SEED0`. Chacune vient d'une\n",
+    "**strate différente** de la série et n'a, *a priori*, rien à voir avec les autres.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac4cdea3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006169,
+     "end_time": "2026-07-02T10:04:12.687373+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.681204+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### S1 — le tri auto-organisé (strate 1)\n",
+    "\n",
+    "Le banc d'entrée de la série ([ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb)/[ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb)) :\n",
+    "plusieurs tris distribués, résumés par leur **nombre d'inversions** à chaque pas (macro-état\n",
+    "grossier, borné par $n(n-1)/2$).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0456af6e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:04:12.697584Z",
+     "iopub.status.busy": "2026-07-02T10:04:12.697584Z",
+     "iopub.status.idle": "2026-07-02T10:04:12.711543Z",
+     "shell.execute_reply": "2026-07-02T10:04:12.711543Z"
+    },
+    "papermill": {
+     "duration": 0.020268,
+     "end_time": "2026-07-02T10:04:12.711543+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.691275+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "S1 (tri)          longueur=  216  etats distincts= 12  (min=0, max=11)\n"
+     ]
+    }
+   ],
+   "source": [
+    "s1 = traj_S1(SEED0)\n",
+    "print(f\"S1 (tri)          longueur={len(s1):5d}  etats distincts={len(set(s1)):3d}  \"\n",
+    "      f\"(min={min(s1)}, max={max(s1)})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7070c73b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010108,
+     "end_time": "2026-07-02T10:04:12.721651+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.711543+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### S2 — le paysage bistable (strate 2)\n",
+    "\n",
+    "Le modèle de pâturage de May ([ICT-8](ICT-8-AttractorLandscapesEWS.ipynb)), simulé en **SDE juste\n",
+    "sous le pli** ($c = 0.92\\,c_\\text{fold}$) : deux bassins coexistent et le bruit provoque des\n",
+    "bascules occasionnelles. L'état est le **décile** de la biomasse.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cde2cec9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:04:12.736328Z",
+     "iopub.status.busy": "2026-07-02T10:04:12.736328Z",
+     "iopub.status.idle": "2026-07-02T10:04:12.845894Z",
+     "shell.execute_reply": "2026-07-02T10:04:12.845894Z"
+    },
+    "papermill": {
+     "duration": 0.134183,
+     "end_time": "2026-07-02T10:04:12.861986+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.727803+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "S2 (bistable)     longueur= 1500  etats distincts= 11  (deciles occupes)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "s2 = traj_S2(SEED0)\n",
+    "print(f\"S2 (bistable)     longueur={len(s2):5d}  etats distincts={len(set(s2)):3d}  \"\n",
+    "      f\"(deciles occupes)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a32caab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032525,
+     "end_time": "2026-07-02T10:04:12.909664+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.877139+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### S3 — le réplicateur stratégique (strate 3)\n",
+    "\n",
+    "Le dilemme du prisonnier itéré sous dynamique de réplicateur ([ICT-13](ICT-13-AxelrodStrategicMorphodynamics.ipynb)) :\n",
+    "plusieurs trajectoires depuis des populations initiales aléatoires, résumées par la **stratégie\n",
+    "dominante** (argmax des fréquences) à chaque pas.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "22d84be9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:04:12.971329Z",
+     "iopub.status.busy": "2026-07-02T10:04:12.971329Z",
+     "iopub.status.idle": "2026-07-02T10:04:13.362587Z",
+     "shell.execute_reply": "2026-07-02T10:04:13.362587Z"
+    },
+    "papermill": {
+     "duration": 0.437736,
+     "end_time": "2026-07-02T10:04:13.389901+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:12.952165+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "S3 (replicateur)  longueur= 3010  etats distincts=  6  (strategies dominantes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3 = traj_S3(SEED0)\n",
+    "print(f\"S3 (replicateur)  longueur={len(s3):5d}  etats distincts={len(set(s3)):3d}  \"\n",
+    "      f\"(strategies dominantes)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c279b797",
+   "metadata": {
+    "papermill": {
+     "duration": 0.020546,
+     "end_time": "2026-07-02T10:04:13.492527+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:13.471981+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Le même appareil appliqué aux trois — batterie + contrôle dégénéré\n",
+    "\n",
+    "On calcule, pour chaque substrat, la batterie **réelle** (`trajectory_battery`) et le\n",
+    "**contrôle dégénéré** moyenné sur `N_SHUF` permutations temporelles (`shuffled_baseline`).\n",
+    "Le gain d'émergence est la différence réel − contrôle ; il est **crédité** si le gain d'EC\n",
+    "dépasse l'écart-type du contrôle.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "42974492",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:04:13.504050Z",
+     "iopub.status.busy": "2026-07-02T10:04:13.504050Z",
+     "iopub.status.idle": "2026-07-02T10:04:38.975159Z",
+     "shell.execute_reply": "2026-07-02T10:04:38.975159Z"
+    },
+    "papermill": {
+     "duration": 25.47675,
+     "end_time": "2026-07-02T10:04:38.976380+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:13.499630+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "substrat         n_etats  EI_reel  EI_shuf  EC_reel  EC_shuf  EC_std\n",
+      "------------------------------------------------------------------------\n",
+      "S1_tri                12    2.538    0.672    6.127    2.077   2.174\n",
+      "S2_bistable           11    2.822    0.106    6.255    5.240   0.818\n",
+      "S3_replicateur         6    2.413    0.029    4.415    2.341   0.781\n"
+     ]
+    }
+   ],
+   "source": [
+    "subs = {\"S1_tri\": s1, \"S2_bistable\": s2, \"S3_replicateur\": s3}\n",
+    "rng = np.random.default_rng(2025)\n",
+    "\n",
+    "detail = {}\n",
+    "for name, st in subs.items():\n",
+    "    real = S.trajectory_battery(st)\n",
+    "    base = S.shuffled_baseline(st, rng, n_shuffles=N_SHUF)\n",
+    "    detail[name] = {\"real\": real, \"base\": base}\n",
+    "\n",
+    "print(f\"{'substrat':16s} {'n_etats':>7s} {'EI_reel':>8s} {'EI_shuf':>8s} \"\n",
+    "      f\"{'EC_reel':>8s} {'EC_shuf':>8s} {'EC_std':>7s}\")\n",
+    "print(\"-\" * 72)\n",
+    "for name, d in detail.items():\n",
+    "    r, b = d[\"real\"], d[\"base\"]\n",
+    "    print(f\"{name:16s} {r['n_states']:7d} {r['effective_information']:8.3f} \"\n",
+    "          f\"{b['effective_information']:8.3f} {r['emergent_complexity']:8.3f} \"\n",
+    "          f\"{b['emergent_complexity']:8.3f} {b['emergent_complexity_std']:7.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf291279",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004039,
+     "end_time": "2026-07-02T10:04:38.986425+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:38.982386+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Gate 1 — l'émergence survit-elle au contrôle dégénéré ?\n",
+    "\n",
+    "**Critère falsifiable.** Pour chaque substrat, on crédite une émergence dynamique si le gain de\n",
+    "complexité émergente dépasse le bruit du contrôle : $z = (\\text{EC}_\\text{réel} -\n",
+    "\\text{EC}_\\text{shuffle}) / \\sigma_\\text{shuffle} > 1$. Si aucun substrat ne passe, l'appareil ne\n",
+    "mesure que du réservoir d'états — pas de la dynamique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "354278c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:04:38.997398Z",
+     "iopub.status.busy": "2026-07-02T10:04:38.997398Z",
+     "iopub.status.idle": "2026-07-02T10:04:39.195131Z",
+     "shell.execute_reply": "2026-07-02T10:04:39.195131Z"
+    },
+    "papermill": {
+     "duration": 0.210267,
+     "end_time": "2026-07-02T10:04:39.196692+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:38.986425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "substrat          EI_gain  EC_gain   z(EC)  credite\n",
+      "--------------------------------------------------------\n",
+      "S1_tri             +1.865   +4.049    1.86  True\n",
+      "S2_bistable        +2.716   +1.015    1.24  True\n",
+      "S3_replicateur     +2.384   +2.074    2.66  True\n",
+      "\n",
+      "Gate 1 : 3/3 substrats creditent une emergence dynamique (z > 1).\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAFKCAYAAADhULxpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAASd9JREFUeJzt3QeYE9X6x/GX3kF6b4oiSAdRsICKApYLdhEFBVG8NAELWChSRVBEvSIWsF5RUFRUEFFQKQpSFAWkCRaq9I5L/s/v3Gfyz2azu8lusrthv5/nGdhMJjMnUzLvnHnPmRw+n89nAAAAQJzJmdkFAAAAANKCQBYAAABxiUAWAAAAcYlAFgAAAHGJQBYAAABxiUAWAAAAcYlAFgAAAHGJQBYAAABxiUAWAAAAcYlAFoiBKVOmWI4cOey3336L6fodMmSIW86pQOtK30XrLquXcezYsRYPWrZs6YZ4WsfI+OP7VPodQfZDIIt02bRpk/Xs2dPOOussK1iwoBtq165tPXr0sB9//DFN81y4cKH7Yd27d29Ut87Bgwdt8ODB1qZNGytRogQndGQJsdrfkTHefvttGz9+PKs7G9qxY4c9+uijVqdOHStUqJCdccYZNnz4cPvnn38yu2jZCoEs0mzmzJnuAH7jjTesVatW9vTTT9szzzxjbdu2tU8//dQaNGhgmzdvTtOJfejQoVE/se/atcsef/xxW716tdWvXz+q80b6Va1a1Y4cOWK33357tlqdsdrfkTEIZLOv//znP/baa69Z+/bt3cVMkyZN7LHHHnPBLDJO7gxcFk4hGzZssFtuucUFH3PnzrXy5csnev+JJ55wB3nOnFnnWkll3Lp1q5UrV86WLl1q5557bmYXCQF0azN//vysE5yyjh49annz5s1Sv4vZVTS2xbXXXmsDBgzw/25169bNfv/9d3vrrbfcXRZkDI4mpMmYMWPs0KFDNnny5CRBrOTOndt69+5tlStX9o9TqsEdd9xhp59+ujvwFVB26dLF/v77b/80OvgfeOAB93f16tVdcBOca/rmm29a48aNrUCBAi5FQAG1fjxSky9fPrfMzPLhhx/aVVddZRUqVHBl0W2oYcOGWUJCQlif//bbb13wrXWnz7744otJpmnRokWytc01a9a01q1bJ8n1nDRpkpufyqT5L1myJNHnwtlugXl2v/76q912221WrFgxK126tKuh8Pl8bhu1a9fOihYt6uYxbty4RJ9PLn9zxowZruZfy9b/H3zwgStPtWrV/NPMmzfPfVb/hzPPNWvW2A033OD2H81XNSkfffSRRUJ3IHQhp/1Q633VqlURr7dw9vdQTp486WqAzjnnHDfvsmXL2j333GN79uyxtEjP+njnnXfc8VikSBG3bevWrevuzATauHGj3XjjjW7+Sj86//zz7ZNPPkk0jbcN3333XRsxYoRVqlTJleWyyy6z9evXh1WWP//807p27eo/xrRO7733Xjt+/HhMyqL8Y31Wd568beftl948tH50+7lixYpuefv373fvv/fee/7fsVKlSrljRuUPR1p/A8P9HYl0Oc8//7zbzzVd06ZN7ZtvvkmSny3Hjh1z6V01atRw20fnhwcffNCND6T1ppQ179jXtNrXZ82alWTZWmc6rnQMeNO9+uqriaZJbVt89913LuVMv1kar+N5wYIFqa5L/dYGX3zrdeD+htijRhZpTivQj9F5550X9mfmzJnjTiJ33nmnO6n//PPPLojS/4sXL3Y/NNddd50LhP773/+6QEE/8KKASHRSUWB000032V133WU7d+60Z5991i6++GJbvny5nXbaaVl2iyqYKly4sPXr18/9/+WXX9qgQYPcj+mTTz6Z4md/+uknu+KKK9x6UPCjHCydEPTjHUi35VUroKBKJwCPglOtV/2IB98WPXDggAuCtP51gaJtoO2UJ0+esLdboJtvvtlq1aplo0ePdid53WbTSVAnzEsvvdTV1qvG4v7773cnVG275Hz++ed2/fXXu7zrUaNGuSBQ5VBgkVYq9wUXXOBOZqpNUW6bAhbdHpw+fbqrZUnN66+/7tabcsFVs6PATd9N28nbJtHY35Oj7aX9SfPWBaNy1Z977jl3DOgE7G27WK8PfccOHTq4AE/bVZS6ozL06dPHvd6+fbs1b97cDh8+7MpasmRJdzv2X//6l02bNi3J/LXfqJZM+8e+ffvcPtmxY0cXbKTkr7/+ckGUUjTuvvtuO/vss12Qo2Vo2ap9i3ZZHnnkETf+jz/+cNtPdGwH0sWqlq15KGDT39620/6v/Vrl0j6k9Zba71h6fgPD/R2JZDkvvPCCCzovuugi69u3r7sI075TvHjxRMepLr60nhVIa/voN0Ll0XrTMaCgNZCme//99+3f//63u0iaMGGC+y3YsmWL226i9aYLES/w1ff67LPP3MWMflfvu+++VLeFfoeVDqeAXetC21sVNDqeFZBrnwqXLv4UNGs+yEA+IEL79u3zaddp3759kvf27Nnj27lzp384fPiw/73Avz3//e9/3by+/vpr/7gnn3zSjdu0aVOiaX/77Tdfrly5fCNGjEg0/qeffvLlzp07yfiULFmyxC1j8uTJvljQfIO/Q6jvf8899/gKFizoO3r0aIrz07rOnz+/b/Pmzf5xv/zyi1sfgYfx3r173XQPPfRQos/37t3bV6hQId/Bgwfda5VLnytZsqRv9+7d/uk+/PBDN/7jjz+OeLsNHjzYjbv77rv94/755x9fpUqVfDly5PCNHj060X5SoEABX+fOnf3jvDIFbpMGDRr4ypcv776X5/PPP3fTVa1a1T/uq6++cuP0f6BQ87zssst8devWTbTOT5486WvevLnvzDPPTPJdQ81PZf/jjz/847/77js3vm/fvlHb35PzzTffuOnfeuutRONnzZqVZHyLFi3cEKv10adPH1/RokXddk7Offfd55apcnsOHDjgq169uq9atWq+hISERNuwVq1avmPHjvmnfeaZZ9x4Hecp6dSpky9nzpzu2A6m7xOrslx11VWJ9kWPN4/TTz890b5w/PhxX5kyZXx16tTxHTlyxD9+5syZbvpBgwYlOaai9RsY7u9IuMvRutFvyLnnnus7ceKEf7opU6a4+QXue2+88YbbPoHrXiZOnOimXbBggX+cXufNm9e3fv16/7iVK1e68c8++6x/XNeuXd3vw65duxLN85ZbbvEVK1bMv96T2xbaL7SPt27d2r+PiKbRPnH55Zf7wvXll1/68uXL5/aHlI4HRB+pBYiYdzsmuOZBdCtJV8XeoFtOHt128qgWS42vdDUty5YtS3W5ujrXVb1qCPRZb1Bt15lnnmlfffVVlt6agd9ftXkqu2oxVDukW7vJUerB7NmzXS1HlSpV/ONVo+GlCnh0a0y371XD97/zwf8+P3XqVPd51bYF156q5sSj8ohqEtO63VR748mVK5e7Ta2yqJbEo9ocpToELieY8plXrFhhnTt3dt/Lc/nll7sa2rTYvXu3q4HRPuRtAw2q6dW6XLduXVi3d7UuVYPpUa2N7k6okWO09vfk6Ja01ofWQ+BxoBolHZORHAfpXR/ajkoxUs1scrROtH4uvPBC/ziVU7Vyqr375ZdfEk2vmkrVlKW0TwbT74Jq9K655hq3vwXz7hpkRFmCaf8N3BeUn6/W7qppDLwtrbQj1SIHpzlE6zcwkt+RcJej76J9RXeBlE7mUa114O+Kt99qWfqOgfNUzacEl10NiJX64KlXr55LXfHWvX5TdMdA21x/B85T30c15cHHWfC20O+L9vFbb73VfQ/v89qndZfh66+/dushNaqtVm2xGjjre+p3DxmH1AJETLd5vO6sgun2sU6IuuWjnK/gk6ZaZytPST/kgfSjkxr94OgHSz+koURyOzVSak0fXMZI8211C1e39hU4eBcD4Xx//Uhq+aG+t4LBwOBJOnXq5AJX3RbTbcAvvvjCbY9QvQEEntDEO/kE5lpGut2C56mgSyds77Z54PjgPNtAXo8XyX3vtASDym/UPqRbphpC0XcMDFJDCVUmdUGnW/LR2t/1+cBcO52Atc50HOjzZcqUSbb8GbU+FIzpO+vWrKbRbWsFP8o3DNyOoVKQFNR47wemwYSzT4Y6RnRMBc4nlIwoSzDl6QaXwduHgynI0y31WPwGRvI7Eu5yvO+iNLNACmoDc9i9eSrtJLm0meD9Nnjde+vfW/f6PkojUbqOhnDmGbwtVCYvwE2OjrXgoDyYLj5ULqVJBAbKyBgEsoiYTqZq4BXcuEW8k0Soxio6wamrITVu0ZWrakJ0tauTXjhXvZpGNSvKgQp1xRuqhjhaFBiqdiaQV+MZDv3gqgGBahTUBZhqGhTcKRh76KGHwvr+4VJthHLe1FBDgaz+V9CtGo5gydUcBH63SLdbqHmGs5z0SK4z9+CGdF55lSMXXAvlCT4pp1V693flz86fP9//Widb5VbqswpilWccSmr5tdFcHyqHarVU06fjUoPyC3UxpdzTtIj1vpLRZYlmYJNRv4GxWI7mqYaATz31VMj3AxsGh7PuvX1XFSbJBaKqxU1pW3jzUBsFHaOhhPNdvQvyUA2fEXsEskgT3QZ7+eWX7fvvvw8rGV5Xq+qmSzVUauAUfEUcTlCi4E8/YrqqVu1XRtJJPqXbp6lRAwD92OmWXWDjJjXSSY0CE/0Ah1pXa9euTTJOJwDdKlPQowY4uuWqW39pud0VyXaLNvUIkNyygr+3V2MS3BdrcD/Galnt1SiFCuzDFapMarDi1UJFY39Xrw6BNX9qie8dB6plVwOt9AZJ0VgfuvWu27saFBiollZ3ZlTDqyBY2zHUfuql03jbOT10jOgiMdTFdaBYlCXSJ2J5y1A5vNvqHo1LqQzp+Q2M5Hck3OV4ZVXN/iWXXOIfr0ZkqswIDCQ1z5UrV7pb9tF4ipi+j+4O6mI1rfuul7qgfSc9vwcKgtXwU/NBxiNHFmmiLlPUTYm6PdFt69RqLLwgKnh8qCfieHmcwUGJaqg0HwUHwfPR65RuU6eXrrT1Qxc4RCLU99dtY/W1G85nFUgrIFWLXY9u06kmLBSlESgIUut2pYAEp3mkp9ySEU8y0jrXCUI1e4G34nVBEZzLqBOqyqqctkDB61c1iMrjVqClHNxgul0ZDm2LwNxRXdCpJbtusUdrf1fOa+D+5uUFq6ZXJ2+1wA6mACKSByukd30EH3Nq8e0FL16XSldeeaVbP4sWLfJPpxxE3Q5W4J/WfOfg5Sr38+OPP3Z5m8G87RCLsmj7hZMq4lEOr9b7xIkTE3U7pdpPHdOqJEhOen4DI/kdCXc5+i7qQeCll15K9DQr3S0ITr/QfqtjRtMGU8qDtkMkVD7lpSpPNtQFTDjHso4xBbPqhjBUqly4vwfqhku9Jnhpd8hY1MgiTZQ7pa6b1PWO8quU3K+DWT9yqmXUezq5eN2v6EpVNZHqvubEiRMun05dK4WqkdSPi9e1jfotVG2Ranu8x/8NHDjQ38WLfjg0D/UtqgYbukWaEnVRpBO9uuoRnfjUdY706tUrUaOiaFKXP6o11C0wdfujGgk9ES3cW5Q6oagPRTU2UY2XThrqCkd9JoZ6FHDDhg1drp/XwKJRo0ZpKnck2y0W1DWRTuxqnKOLJuWNet878MSj7aa+QfWe1q32FXURFypfVA0QNT/d5lRNtWoldTGm4Eb7gmqNUqOaRs1DfZQqGFGAqhO6LvCitb8HN8zzKEVFFyhaN7qtr7xUfUY1bdre6sZJfcKGKz3rQw37tE1Us6hjXTXg2ga6APHyTtWllxofKsjXvq+u2HRxonWhICRaDwcYOXKkW8daP173TgrOtU6Ud6qGabEoi7afUo/UrZ6609KtaG2/5Ghb6U6JUpVUVv2Get1vKZhWF1bJSe9vYLi/I+EuR7Xx6sZLv53aBxSsanrdDdI8AmtedXGtfOru3bu7hl26o6ALMtWGa7yC6VAN9VKi7tE0L6W0ad/VhYj2R6Vs6a6F/k6JtrfuLGp/0DrQNtGxqoBb89VxrHNEanRe0brV+gnODUYGiEFPCMhG1D3Kvffe66tRo4br1kXdEp199tm+7t27+1asWJFoWnVXdO211/pOO+001zXKjTfe6Pvrr79ctyjqZibQsGHDfBUrVnTdtQR3TTR9+nTfhRde6LqT0qDl9ejRw7d27dpUy6tucjS/UEO43R+ltfstdS9z/vnnu3VUoUIF34MPPuibPXt2yG6jQpk/f76vcePGrlsadSOjbmuCu+cJNGbMGPfeyJEjk7zndcOkrp+CBW+PcLebVxZ1uxZIXWxpOwVT1zznnHNOkjIFd4mm7a1ukNS1Te3atX3vv/++m2dwl0da7vXXX++6MytevLjr2mzVqlUh57lhwwbXXVO5cuV8efLkcfva1Vdf7Zs2bVrIdRlqvY0bN85XuXJlV66LLrrIdQ8Ui/09OZMmTXL7g/anIkWKuC60tE9pGZF0v5We9aH3r7jiCtedlPbLKlWquPW+devWJPO/4YYb3LrQ70TTpk1dd1OBvC6S3nvvvZDrPJyu8tStlL5H6dKl3XbRcaLfhsAutKJdFnVpd+utt7r5BXYLl9w8PFOnTvU1bNjQlbNEiRK+jh07JurSTZI7vtPzGxjJ70i4y5kwYYL73vouWp/6rdMy2rRpk2g6dT32xBNPuONe0+o41XRDhw513Tp6VBYtJ5iWEdhln2zfvt1Nq2NR+672YXUpp+PDk9q2WL58ue+6665zXYmpXFrOTTfd5Js7d64vHN76i+Y5BOHLoX8yImAGkLFUw+N1UB6qBXA80xOzlHec2hOwAGQ85Uorh1UpCqFSCYBoIkcWOAXp+vSVV15xty5PtSAWQNahPpKD68P05Dvd1g9+RC0QC+TIAqcQNZjQYxKV36XHP3744YeZXSQApzA9bll3fpSjrjxx5afqIlo5+hoHxBqBLHAKUStbdb2lhi0PP/ywe7Y5AMSKGjepD9gJEya4Wlg1oFM/wmqIFfhUNCBWyJEFAABAXCJHFgAAAHGJQBYAAABxKXd27BZEneGrc+doPCYPAAAA0aOeMA4cOOAezZ3ag0qyXSCrIFaJ6QAAAMi6fv/9d/8TQpOT7QJZ71nIWjl6/BwAAACyjv3797tKRy9mS0m2C2S9dAIFsQSyAAAAWVM4KaA09gIAAEBcIpAFAABAXCKQBQAAQFzKdjmyAIBTs2vF48ePZ3YxAIQhT548litXLosGAlkAQFxTALtp0yYXzAKID6eddpqVK1cu3X36E8gCAOK64/StW7e62h1115Na5+kAMv+YPXz4sO3YscO9Ll++fLrmRyALAIhb//zzjzsp6glABQsWzOziAAhDgQIF3P8KZsuUKZOuNAMuXQEAcSshIcH9nzdv3swuCoAIeBeeJ06csPQgkAUAxL305tkBiM9jlkAWAAAAcYkcWQCZru6Q2ZldhLj305DWmV0EZLJ58+bZJZdcYnv27HEtwoHsgEAWAHDKyeiLIy4kgMxBagEAAJmMhzkAaUMgCwBABmvZsqX17NnT7rvvPitVqpS1bt3aVq1aZW3btrXChQtb2bJl7fbbb7ddu3b5P6MHPowaNcqqV6/uui+qX7++TZs2jW2HbI1AFgCATPDaa6+5bsMWLFhgo0ePtksvvdQaNmxoS5cutVmzZtn27dvtpptu8k+vIPb111+3iRMn2s8//2x9+/a12267zebPn8/2Q7ZFjiwAAJngzDPPtDFjxri/hw8f7oLYkSNH+t9/9dVX3dPKfv31V6tatap774svvrBmzZq5908//XT79ttv7cUXX7QWLVqwDZEtEcgCAJAJGjdu7P975cqV9tVXX7m0gmAbNmxwncbrCWaXX355ktxaBcBAdkUgCwBAJihUqJD/74MHD9o111xjTzzxRJLp9Cx65c/KJ598YhUrVkz0fr58+TKgtEDWRCALAEAma9SokU2fPt2qVatmuXMnPTXXrl3bBaxbtmwhjQAIQGMvAAAyWY8ePWz37t3WoUMHW7JkiUsnmD17tt15552WkJBgRYoUsfvvv9818FIjMb2/bNkye/bZZ91rILuiRhYAgExWoUIF13vBQw89ZFdccYUdO3bMNfBq06aN5cz5vzqnYcOGWenSpV3vBRs3bnRP71JN7sMPP5zZxQcyTQ6fz+ezbGT//v1WrFgx27dvnxUtWjSziwOAR9RGRXZ9stTRo0dt06ZNrm/V/PnzZ3ZxAETh2I0kViO1AAAAAHGJQBYAAABxiUAWAAAAcYlAFgAAAHGJQBYAAABxiUAWAAAAcYlAFgAAAHGJQBYAAABxiUAWAAAAcYlAFgAApGjKlCnukbjRdscdd1j79u1Z+2b22GOP2d13352h623NmjV2/vnnuydrNWjQIOS43377zXLkyGErVqwIe7633HKLjRs3zjJC7gxZCgAAGWj+/PkZur5btGhhWU21atXsvvvucwOytm3bttkzzzxjP/30U4Yud/DgwVaoUCFbu3atFS5cOOS4AwcORDzfRx991C6++GK766673KNmY4kaWQAAsqmEhAQ7efJkZhfjlHD8+PE0f/bll1+25s2bW9WqVS0jbdiwwS688EK33JIlSyY7LlJ16tSxM844w958802LtUwNZEeNGmXnnnuuFSlSxMqUKeOqyXUFkNrtDVVxBw6q/gYAIF4oeBwzZozVqFHD8uXLZ1WqVLERI0b431fN3KWXXmoFChRwwYRuOR88eDDJreWxY8da+fLl3TQ9evSwEydOuPdbtmxpmzdvtr59+/rPlYEpAh999JHVrl3bLXvLli22Z88e69SpkxUvXtwKFixobdu2tXXr1qX4HT788ENr1KiROweffvrpNnToUPvnn39SDJr79evnlq/yPvjgg+bz+ZKsF8UG1atXd9+9fv36Nm3atETTqOxnnnmmW+4ll1xir732mvt+e/fu9U/z7bff2kUXXeTmUblyZevdu7cdOnQoUW31yJEjrUuXLi4G0fqfNGlSouX8/vvvdtNNN7nylihRwtq1a+duswdvA223ChUqWM2aNcP6XCjvvPOOXXPNNYnG6XvXrVvXvw+0atUq0XeQsclsf9E6mTFjRqLpVSbtA977P/zwgz3++OPu7yFDhoQcF8qqVavcPqIa27Jly9rtt99uu3btSjSNvo++1ymdWqBbP1rxCma18z/88MN2xRVX2C+//OKqtZNTtGjRRAGvd4BmVXWHzM7sIsS9n4a0zuwiAEDUDBw40F566SV7+umnXe3X1q1bXW6iKFhp3bq1NWvWzJYsWWI7duxwt2h79uzpD0Lkq6++ckGM/l+/fr3dfPPNLqexW7du9v7777sgUAGwXgc6fPiwPfHEE64WUAGQKpI6dOjgAlcFiTrHPvTQQ3bllVe683GePHmSlP+bb75xge+ECRNcwKhaPC+/U7emQ1HOpMr/6quvWq1atdzrDz74wAXsHgWxqsWbOHGiC1a//vpru+2226x06dIufWPTpk12ww03WJ8+fdw6Wb58ud1///2JlqOytGnTxoYPH+6WtXPnTrfuNEyePDlReYYNG+ZiDwWN9957r1uGAlIFhN420HfNnTu3m5/m++OPP1revHndPObOnevW15w5c9zrcD8XaPfu3W49N2nSxD9O+4O2iS52rr32Wnd7X/MLDPxT2v7h0DIUHKtsWocKSrt3755kXHCAqgsGbTOtf+2/R44ccfuLgvcvv/zSP13Tpk1dkH/s2DF3wXRKBrKzZs1K9Fo7uA4oXQ0otyI5ClzLlSuXASUEACC6FJQoH/K5556zzp07u3G6DauAVt5++207evSovf766/5KHU2rGi4FoKoBE9WeanyuXLns7LPPtquuusoFVgpkVBOo8aptDD5fKtj6z3/+4wJd8QLYBQsWuNvb8tZbb7maTNXo3XjjjUm+g2pfBwwY4C+/amQVFKqWNblAdvz48S6Av+6669xrBauzZ/9/RY8CHtWSfvHFFy4Q9Oar2tUXX3zRBZn6X4Hmk08+6d7X36odDKzNVjDcsWNHf26wAmIF3Pr8Cy+84L+Lq0D93//+t/tbgZiCMgWFmufUqVNd7bCCfa+yTEGwajTnzZvnKt1E20fTeAGqgvBwPhdINeIKUFWrGxhkqoJP68pLN1DtbKCUtn84tF8o0Faw6u0j+jt4XHAgq2U2bNjQbSuPLhi0v/z666921llnuXH6Pkq3UP5vLFMmslRjr3379rn/dQCmRLdXtFK0s+i2hlbmOeeck0GlBAAg7VavXu2CtssuuyzZ9xVkBt6ZvOCCC9w5T3cjvUBW5z0FMR7VzoXTWEhBV7169RItT8HLeeed5x+nmloFdHovlJUrV7rANzCAVOqAAnDV+Co9Ifj8ruAscBlapmohvVpG1Srqs5dffnmizyoYUuAk+v66ixtINX/BZVPtp4Jxj5ah9acaXdUGS+A68CrIVPvtzUPl0YVAIH0/1fh6FFwG1rKG+7lAqtGUwDRJbX/tH5q/angVAKsmWsGrJ63bP730HRXwe43DAuk7eoGsUiJE2zSWIgpktUMr30HV28q9UeFU3a8dTCv6+uuvT3P1sXYwXT3pYFWScHJ0YCny1w6oA0P5IbqC/Pnnn61SpUpJptePhQbP/v3701Q+AACiwTvBp1fwLX8FY+E03NLy05uSpwol1cp6tauB0tpuxcsB/uSTT6xixYqJ3oskttB87rnnHpcXG0y5sOGsP82jcePGiYJhj+IeT3AaZLifC1SqVCn3v/KUvWkUoCpdYeHChfb555/bs88+a4888oh99913Ln84tfJ7r4NzkANzaNNK39G7OxBMwXRgykRK3ztDA9lly5a52wWq3legqSsq5WzoYFBBVa2vFdyrVy83nQLSSANa5cpqPlpGSnS7wbvlIApidXWl2w26rRFMtxh0sAEAkBXoVrfOn7oNrDzDYDqnKdVOubJeoKTaz5w5c/obFIVDNYWqJU2Nlqfb2AqSvNSCv//+29V+qkFYKLobqvfVWC0c6oJJQY6W4aUOaplKJdS8JLDxWXLdmen7f/rpp4nGKY84uGzKOQ23bKFoHkovULqjcmBj+TmllWhaldmrzfQCUcVcGgYNGuTuRCunWA3mwlG6dGlXC+5RCkk0akf1HadPn+4azKlWPTmK6VTB6AXqmdprgWpaddWlPAcdeAoOFbTqAFTgqjweVdfPnDnTJV5H2gmuErD1WVVVh6pVTYmuSFQjrKr8UJSPo5pbb1BrQgAAMotqLJWT6Z0/dTt28eLF9sorr7j3ld+paZR/qmBA50adc9Uy3EsrCIcCDTWW+vPPP5PkOQYH1mpZr9xKVSbp1rEaWKlWVONDUWClsquiSHdEvTu26j80OWqgNXr0aJd3q4Ztyk8N7GlAt+PVwEg9LagnAq0XVaSpNlKvRTWt+qzWn/Ix33333USt8EXvqSZTsYU68VcApx4W9Dpc2gYKwPT9dRdaMY5yXFXL+8cff0T1c7pAUQOrwIo8BfxKm1y6dKkL7NV4T43WvLSIcFx66aUun1VxmeajhlyhGu5FShWPqsRUYzRdRGg7Kdf5zjvvTHThpO8fKic4UwJZ7Sza4VJ7qodqSrUjP/DAA2EtXFXe2rF0haGWbl51eSS00pQTElidHUhXd7rSCRwAAMjspzj179/fBYQKTtTi3MvPVH6pAgMFC8oHVW6k8iUVlERCXSip2yfV+KV2e1cNknRL/Oqrr3bncp2fVfOZXOCjdEJVQOm2t8qoJ0GpsVRKjXr0fRWMK0DXMhS46u5uIN1Z1bpRhZnWi1rPK9XAiw/0v3oYUGCnFEM13tIdYfHuBGu8ekVS7KIeFVTZpfUc2JgqNdoGughQKoIq8lSWrl27ulzXlOKItH5OFYOKn7zUAE2r+ahBmmppdYGgSkJ1eRWucePGuQZYWge33nqru0gIzl1OC61H3SFQ/KVAVXm8uhOvGFFBuej76oIl3IZn6ZHDF5xAkQa6okrLo+sUHKt1pq6UAm+X6BaEl0Ok7j10Vaid2jswdcDoloGWq5aLWlm6PZHcLZBAypHV/FU7m1FBLd1vpR/db53aOEbSL7seIzphqtZLAQ59imdPanCmHhDi+Y6rQjGlbao2WjWd8e6FF15wlZS60EnLsRtJrBbxAxGU3Kv8D4/6DVPrRgWbuh0R6RdVIdVxs2pUvSFw/qpSD8zxUDK0Inxd5ehKRV9WtxDCCWIBAEB8U9dhuqW9ceNGe+ONN1yFltcNWLxSWoQeyJDSAyXiSZ48eVxKSEaIuPstXfV4rfHUok7DZ5995vJUlFKQUvQdLJzKYOWWBNKtCw0AACD7Uc6rHjKg1AvdwlfKgtrDxDs9zEDDqeCuEI0Ys0wgqwZfyrkQ5ceoRlY5EkoqD+wfDgAAINqo0EK6All1xqs8FAWzejKXroq82tVwuvkAAACR+fmv/z0wCGl3ToVirL5TUMSBrFrhqfWbuutQP3NeCzp175CePtsAAACAmAayqtJXGoFqZceMGeN/RJkaZHnPLAYAICNFoQMeABkonKfQxSSQXbRokesvLPhpDuqsWb0HAACQka2j1eJbncWrr9T0Pno1qzr5z/HMLkLcU3dPyBoXncePH3fHrPqd1RPoMjSQveSSS1ztqx6/FkjdaOk98mQBABlFz6TXEyH11CR1/n+q2rH3SGYXIe7lPvS//umRNejhDOp1wnuIQoYFsoqkQ13xKl/WeyY0AAAZRSluardx4sSJU3al93nu/x9firT5qOeFrLosdAGqO/vRuIOSO5JGXqKF3nHHHf5HwYlqYX/88Udr3rx5ugsEAEBaTowaTlVbD9IrUHrx5LdTU9iBrB4V5tXI6vnI3iNkRfkNemxsRjxTFwAAAIgokJ08ebL7Xz0W3H///aQRAAAAIFNFnCM7ePDg2JQEAAAAiHYg26hRI5s7d657qlfDhg1TTM5dtmxZJMsHAAAAYhfItmvXzt+4q3379mlbEgAAAJDRgWxgOgGpBQAAAIjLHFnP0qVLbfXq1e7v2rVrW+PGjaNZLgAAACC6gayentKhQwdbsGCBnXbaaW7c3r17XR+y77zzjnvCCgAAABBrET8X7K677nJPT1Ft7O7du92gv0+ePOneAwAAALJkjez8+fNt4cKFVrNmTf84/f3ss8/aRRddFO3yAQAAANGpka1cuXLI51nrMbUVKlSIdHYAAABAxgSyTz75pPXq1cs19vLo7z59+tjYsWPTVgoAAAAgFqkFehBC4EMQDh06ZOedd57lzv2/j//zzz/u7y5dutDPLAAAALJOIDt+/PjYlwQAAACIdiDbuXPnSOYJAAAAZI0cWaUSRCLS6QEAAICYBLI1atSw0aNH29atW5Odxufz2Zw5c6xt27Y2YcKEiAsCAAAARD21YN68efbwww/bkCFDrH79+takSRPX1Vb+/Pltz5499ssvv9iiRYtcg6+BAwfaPffcE1EhAAAAgJgEsnrgwfTp023Lli323nvv2TfffOMeinDkyBErVaqUNWzY0F566SVXG5srV66ICwEAAADE9MleVapUsf79+7sBAAAAiKsHIgAAAABZAYEsAAAA4hKBLAAAAOISgSwAAADiEoEsAAAAsk8gq+63brvtNmvWrJn9+eefbtwbb7xh3377bbTLBwAAAEQnkFV/sq1bt7YCBQrY8uXL7dixY278vn37bOTIkRHNa9SoUXbuuedakSJFrEyZMta+fXtbu3Ztqp9TX7Znn322eyBD3bp17dNPP430awAAACC7BbLDhw+3iRMnugcg5MmTxz/+ggsusGXLlkU0r/nz51uPHj1s8eLF7vG2J06csCuuuMIOHTqU7Gf0IIYOHTpY165dXSCt4FfDqlWrIv0qAAAAyC4PRBDVmF588cVJxhcrVsz27t0b0bxmzZqV6PWUKVNczewPP/wQchnyzDPPWJs2beyBBx5wr4cNG+aC4Oeee84F2AAAAMgeIq6RLVeunK1fvz7JeOXHnn766ekqjNITpESJEslOs2jRImvVqlWicUp10PhQlPqwf//+RAMAAACyYSDbrVs369Onj3333XeWI0cO++uvv+ytt96y+++/3+699940F+TkyZN23333uRSFOnXqJDvdtm3brGzZsonG6bXGJ5eHq9pib6hcuXKaywgAAIA4Ti0YMGCACzovu+wyO3z4sEsByJcvnwtke/XqleaCKFdWea7R7vlg4MCB1q9fP/9r1cgSzAIAAGTDQFa1sI888ojLUVWKwcGDB6127dpWuHDhNBeiZ8+eNnPmTPv666+tUqVKqaY2bN++PdE4vdb4UBRkawAAAEA2Ty148803XU1s3rx5XQDbtGnTNAexPp/PBbEffPCBffnll1a9evVUP6O+a+fOnZtonBp7aTwAAACyj4gD2b59+7qeBW699VbXf2tCQkK60gkUGL/99tuuL1nluWo4cuSIf5pOnTq59ACP8nPV28G4ceNszZo1NmTIEFu6dKkLiAEAAJB9RBzIbt261d555x2XYnDTTTdZ+fLlXUCq/l0j9cILL7ieClq2bOnm4w1Tp071T7Nlyxa3TE/z5s1d4Dtp0iSrX7++TZs2zWbMmJFiAzEAAACceiLOkc2dO7ddffXVblCKgdICFFhecsklLr91w4YNEaUWpGbevHlJxt14441uAAAAQPYVcSAbqGDBgq4P1z179tjmzZtt9erV0SsZAAAAEM3UAlFNrPqOvfLKK61ixYo2fvx4u/baa+3nn39Oy+wAAACA2NfI3nLLLa6rLNXGKkf2scceo8cAAAAAZP1ANleuXPbuu++6lAL9DQAAAMRFIKuUAgAAACAuAtkJEybY3Xffbfnz53d/p6R3797RKhsAAACQvkD26aefto4dO7pAVn8nR33LEsgCAAAgywSymzZtCvk3AAAAEDfdbz3++OOu+61geqys3gMAAACyZCA7dOhQO3jwYJLxCm71HgAAAJAlA1k9Vla5sMFWrlxpJUqUiFa5AAAAgOh0v1W8eHEXwGo466yzEgWzCQkJrpa2e/fu4c4OAAAAyJhAVo+hVW1sly5dXApBsWLF/O/lzZvXqlWrxhO+AAAAkPUC2c6dO7v/q1evbhdccIHlzh3xsxQAAACAzMuRPXTokM2dOzfJ+NmzZ9tnn30WrXIBAAAA0Q1kBwwY4HJigyntQO8BAAAAWTKQXbdundWuXTvJ+LPPPtvWr18frXIBAAAA0Q1k1chr48aNScYriC1UqFCkswMAAAAyJpBt166d3XfffbZhw4ZEQWz//v3tX//6V9pKAQAAAMQ6kB0zZoyreVUqgXow0FCrVi0rWbKkjR07NtLZAQAAAGmSOy2pBQsXLrQ5c+a4p3kVKFDA6tWrZxdffHHaSgAAAACkQZo6g9VTva644goXvObLly/kI2sBAACALJVacPLkSRs2bJhVrFjRChcubJs2bXLjH3vsMXvllVdiUUYAAAAg/YHs8OHDbcqUKS5XVo+m9dSpU8defvnlSGcHAAAAZEwg+/rrr9ukSZOsY8eOlitXLv/4+vXr25o1a9JWCgAAACDWgeyff/5pNWrUCJlycOLEiUhnBwAAAGRMIKunen3zzTdJxk+bNs0aNmyYtlIAAAAAse61YNCgQda5c2dXM6ta2Pfff9/Wrl3rUg5mzpwZ6ewAAACAjHuy18cff2xffPGFezCCAtvVq1e7cZdffnnaSgEAAADEokZ2woQJdvfdd1v+/Plty5YtduGFF7oHIgAAAABZuka2X79+tn//fve3Hkm7c+fOWJcLAAAASH+NbIUKFWz69Ol25ZVXms/nsz/++MOOHj0actoqVaqEM0sAAAAg9oHso48+ar169bKePXu6x9Gee+65SaZRgKv3EhIS0lciAAAAIFqpBcqP3bVrl61cudIFrMqPXbZsWaJh+fLl7v9IfP3113bNNde4Gl8FwTNmzEhx+nnz5rnpgodt27ZFtFwAAABks8Zeegzt5MmTrVmzZlagQIF0L/zQoUPuiWBdunSx6667LuzPqbuvokWL+l+XKVMm3WUBAADAKRjIqrHXLbfc4notUNDZtm3bqASymo+GSClwPe2009K9fAAAAMSvuGzs1aBBAzt27JirIR4yZIhdcMEFMV8mAAAAspa4auxVvnx5mzhxojVp0sQFsi+//LK1bNnSvvvuO2vUqFHIz2g6DR6vGzEAAABkg0BW+bEdOnSwzZs3W7169dxTvUqWLGkZrWbNmm7wNG/e3DZs2GBPP/20vfHGGyE/M2rUKBs6dGgGlhIAAABZJpCVIkWK+Bt76VZ+vnz5LCto2rSpffvtt8m+P3DgQJfjG1gjW7ly5QwqHQAAADK1+61AnTt3tiNHjrjb+goSd+/e7car660///zTMtqKFStcykFyFHCrh4PAAQAAANmoRtbz448/WqtWraxYsWL222+/Wbdu3axEiRL2/vvv25YtW+z1118Pe14HDx609evX+19v2rTJBaaanxqNKVBWcOzNc/z48e4Rueecc45rbKZg+ssvv7TPP/880q8BAACA7FYj27dvX7vjjjts3bp1rjsuj3o00AMOIrF06VJr2LChG0QpAPp70KBB7vXWrVtdcOw5fvy49e/f3+rWrWstWrRwD2hQvu5ll10W6dcAAABAdquRVfA5adKkJOMrVqwY8RO21OOAejtIzpQpUxK9fvDBB90AAAAARFwjq5zTUF1Y/frrr1a6dGnWKAAAALJmIPuvf/3LHn/8cTtx4oR7rb5jdfv/oYcesuuvvz4WZQQAAADSH8iOGzfONdLSY2LVe4FyVWvUqOG65xoxYkSkswMAAAAyJkdWvRXMmTPHFixY4BpbKajVU7XUkwEAAACQZQNZjx6KoAEAAACIi9QCAAAAICsgkAUAAEBcIpAFAABAXCKQBQAAQPZp7HXy5Elbv3697dixw/0d6OKLL45W2QAAAIDoBbKLFy+2W2+91TZv3pzk8bJ6OEJCQkKkswQAAABiH8h2797dmjRpYp988omVL1/eBa8AAABAlg9k161bZ9OmTXNP8wIAAADiprHXeeed5/JjAQAAgLiqke3Vq5f179/ftm3bZnXr1rU8efIker9evXrRLB8AAAAQnUD2+uuvd/936dLFP055smr4RWMvAAAAZNlAdtOmTbEpCQAAABDLQLZq1aqRfgQAAADIGg9E2LBhg40fP95Wr17tXteuXdv69OljZ5xxRrTLBwAAAESn14LZs2e7wPX77793Dbs0fPfdd3bOOefYnDlzIp0dAAAAkDE1sgMGDLC+ffva6NGjk4x/6KGH7PLLL09bSQAAAIBY1sgqnaBr165JxqsXg19++SXS2QEAAAAZE8iWLl3aVqxYkWS8xpUpUyZtpQAAAABinVrQrVs3u/vuu23jxo3WvHlzN27BggX2xBNPWL9+/SKdHQAAAJAxgexjjz1mRYoUsXHjxtnAgQPduAoVKtiQIUOsd+/eaSsFAAAAEOtAVk/vUmMvDQcOHHDjFNgCAAAAWb4fWQ8BLAAAALJ0INuoUSObO3euFS9e3Bo2bOhqZZOzbNmyaJYPAAAASHsg265dO8uXL5//75QCWQAAACDLBLKDBw/2/61GXQAAAEDc9SN7+umn299//51k/N69e917AAAAQJYMZH/77TdLSEhIMv7YsWP2xx9/RKtcAAAAQHR6Lfjoo4/8f8+ePduKFSvmf63AVo3BqlevHu7sAAAAgIwJZNu3b+/+V0Ovzp07J3ovT548Vq1aNfeQBAAAACBLpRacPHnSDVWqVLEdO3b4X2tQWsHatWvt6quvjmjhX3/9tV1zzTXuyWAKkGfMmJHqZ+bNm+e6A1MvCjVq1LApU6ZEtEwAAABk0xzZTZs2WalSpaKy8EOHDln9+vXt+eefD3vZV111lV1yySW2YsUKu+++++yuu+5yqQ4AAADIXnKnNQCdP3++bdmyxY4fP57ovd69e4c9n7Zt27ohXBMnTnR5uF4KQ61atezbb7+1p59+2lq3bh3BNwAAAEC2C2SXL19uV155pR0+fNgFtCVKlLBdu3ZZwYIFrUyZMhEFspFatGiRtWrVKtE4BbCqmU2O0h40ePbv3x+z8gEAACALpxb07dvX5bXu2bPHChQoYIsXL7bNmzdb48aNbezYsRZL27Zts7JlyyYap9cKTo8cORLyM6NGjXI9LHhD5cqVY1pGAAAAZNFAVrmp/fv3t5w5c1quXLlcbaeCwzFjxtjDDz9sWc3AgQNt3759/uH333/P7CIBAAAgM1IL1NWWglhRKoHyZJWrqtrOWAeJ5cqVs+3btycap9dFixZ1tcOhqHcDDQAAAMjmgWzDhg1tyZIlduaZZ1qLFi1s0KBBLkf2jTfesDp16lgsNWvWzD799NNE4+bMmePGAwAAIHuJOLVg5MiRVr58eff3iBEjrHjx4nbvvffazp07bdKkSRHN6+DBgy5VQYPXvZb+Vi2vlxbQqVMn//Tdu3e3jRs32oMPPmhr1qyx//znP/buu++6vF0AAABkLxHXyDZp0sT/t1ILZs2aleaFL1261PUJ6+nXr5/7X08O04MOtm7d6g9qRV1vffLJJy5wfeaZZ6xSpUr28ssv0/UWAABANpSmfmSjpWXLlubz+ZJ9P9RTu/QZdQEGAACA7C3iQPbvv/92ebFfffWV/1G1gXbv3h3N8gEAAADRCWRvv/12W79+vXXt2tX14ZojR45IZwEAAABkfCD7zTffuMfC1q9fP/1LBwAAADKq14Kzzz472adoAQAAAFk2kFWXV4888ojNnz/f5cvq8bCBAwAAAJAlUwtOO+00F7Beeumlicar9wHlyyYkJESzfAAAAEB0AtmOHTu6x9S+/fbbNPYCAABA/ASyq1atcv241qxZMzYlAgAAAGKRI6sne/3++++RfgwAAADI3BrZXr16WZ8+feyBBx6wunXrujSDQPXq1Ytm+QAAAIDoBLI333yz+79Lly7+cWrkRWMvAAAAZOlAdtOmTbEpCQAAABCrQPbEiROu262ZM2darVq1IvkoAAAAkHmNvZQPe/To0eiWAAAAAMiIXgt69OhhTzzxhP3zzz9pWR4AAACQOTmyS5Yssblz59rnn3/uei0oVKhQovfff//96JQMAAAAiPYjaq+//vpIPwYAAABkbiA7efLk6JYAAAAAyIhA1rNz505bu3at+1uPqy1dunRaZwUAAADEvrHXoUOH3MMQypcvbxdffLEbKlSoYF27drXDhw9HXgIAAAAgIwLZfv362fz58+3jjz+2vXv3uuHDDz904/r375+WMgAAAACxTy2YPn26TZs2zVq2bOkfd+WVV1qBAgXspptushdeeCHyUgAAAACxDmSVPlC2bNkk48uUKUNqAWJGNf5IuxYtWrD6AACnnIhTC5o1a2aDBw9O9ISvI0eO2NChQ917AAAAQJaskR0/fry1adPGKlWqZPXr13fjVq5cafnz57fZs2fHoowAAABA+gNZPc1r3bp19tZbb9maNWvcuA4dOljHjh1dniwAAACQZQLZRo0aucfSFi9e3B5//HG7//77rVu3brEvHQAAAJCeHNnVq1e7/mNFubAHDx4M52MAAABA5tbINmjQwO6880678MILzefz2dixY61w4cIhpx00aFC0ywgAAACkLZCdMmWK66lg5syZliNHDvvss88sd+6kH9V7BLIAAADIMoFszZo17Z133nF/58yZ0+XLqt9YAAAAIG56LTh58mRsSgIAAADEMpAVdb/11Vdf2Y4dO5IEtqQWAAAAIEs+2eull16yWrVquYB12rRp9sEHH/iHGTNmpKkQzz//vFWrVs09VOG8886z77//PsV8XeXiBg76HAAAALKXiGtkhw8fbiNGjLCHHnooKgWYOnWq9evXzyZOnOiCWD05rHXr1rZ27dpk83CLFi3q3vcomAUAAED2EnGN7J49e+zGG2+MWgGeeuop93AFde9Vu3ZtF9AWLFjQXn311WQ/o8C1XLly/qFs2bJRKw8AAABO0UBWQeznn38elYUfP37cfvjhB2vVqtX/FyhnTvd60aJFyX5OD2SoWrWqVa5c2dq1a2c///xzVMoDAACAUzi1oEaNGvbYY4/Z4sWLrW7dupYnT55E7/fu3Tvsee3atcsSEhKS1Kjq9Zo1a5LtCky1tfXq1bN9+/a5hzM0b97cBbOVKlVKMv2xY8fc4Nm/f3/Y5QMAAMApFMhOmjTJPdVr/vz5bgi+5R9JIJsWzZo1c4NHQawan7344os2bNiwJNOPGjXKPVYXAAAA2TyQ3bRpU9QWXqpUKcuVK5dt37490Xi9Vu5rOFQj3LBhQ1u/fn3I9wcOHOgakwXWyColAQAAANksRzaa8ubNa40bN3ZPCvOoX1q9Dqx1TYlSE3766ScrX758yPfz5cvnejkIHAAAAJBNamRVo6nb9oUKFUpUu5lcLwSR0Pw6d+5sTZo0saZNm7rutw4dOuR6MZBOnTpZxYoVXYqAPP7443b++ee7XN29e/fak08+aZs3b7a77rorouUCAAAgGwSyy5cvtxMnTvj/Tk5a+nO9+eabbefOne4BC9u2bbMGDRrYrFmz/A3AtmzZ4noyCOz+S911adrixYu7Gt2FCxe6rrsAAACQfYQVyOpxtKH+jpaePXu6IZR58+Ylev3000+7AQAAANlbpubIAgAAAGlFIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4lDuzCwAASL/58+ezGtOhRYsWrD8gDlEjCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLiUJQLZ559/3qpVq2b58+e38847z77//vsUp3/vvffs7LPPdtPXrVvXPv300wwrKwAAALKGTA9kp06dav369bPBgwfbsmXLrH79+ta6dWvbsWNHyOkXLlxoHTp0sK5du9ry5cutffv2bli1alWGlx0AAADZuPutp556yrp162Z33nmnez1x4kT75JNP7NVXX7UBAwYkmf6ZZ56xNm3a2AMPPOBeDxs2zObMmWPPPfec+ywAAEAwuqg7Nbuoy9RA9vjx4/bDDz/YwIED/eNy5sxprVq1skWLFoX8jMarBjeQanBnzJgRcvpjx465wbNv3z73//79+y2jJBw7lGHLOlUdOpSQ2UWIaxm5v6cFx0j6cYykD8fIqY9jJH6OEW9ZPp8vaweyu3btsoSEBCtbtmyi8Xq9Zs2akJ/Ztm1byOk1PpRRo0bZ0KFDk4yvXLlyusqOjHXVaNY4wDECcB7JTg4cOGDFihXL2qkFsaba3sAa3JMnT9ru3butZMmSliNHjkwtG8K/MtOFx++//25FixZltQEcI0BEOI/EF9XEKoitUKFCqtNmaiBbqlQpy5Url23fvj3ReL0uV65cyM9ofCTT58uXzw2BTjvttHSXHRlPQSyBLMAxAnAeOfUVS6UmNkv0WpA3b15r3LixzZ07N1GNqV43a9Ys5Gc0PnB6UWOv5KYHAADAqSnTUwt0279z587WpEkTa9q0qY0fP94OHTrk78WgU6dOVrFiRZfrKn369HEt58aNG2dXXXWVvfPOO7Z06VKbNGlSJn8TAAAAZKtA9uabb7adO3faoEGDXIOtBg0a2KxZs/wNurZs2eJ6MvA0b97c3n77bXv00Uft4YcftjPPPNP1WFCnTp1M/BaIJaWGqJ/h4BQRABwjAOeR7C2HL5y+DQAAAIAsJtOf7AUAAACkBYEsAAAA4hKBLAAAAOISgSyyjWrVqrleMYCsat68ee5BLXv37k12milTpsS8L+ysUg4gvYL30yFDhrhG5Th1EMgiptQjxb333mtVqlRxvQ7owRWtW7e2BQsWuPfVbVrLli3dgw5SO3EG++2339xnVqxYEdb0S5YssbvvvjvN3wVIbZ/WUwN79eplNWvWtAIFCrhpevfubfv27YtqTy+//vprWNMSbCKjfsvvueceO+OMM9x+X7p0aWvXrl2yj5rPTPfff3+SvujTg2Ms82V691s4tV1//fV2/Phxe+211+z00093T2HTj8jff//t3j98+LC1adPGDXqccCxo+Xr4hn5cgfRKaZ/+66+/3DB27FirXbu2bd682bp37+7GTZs2LSorX4GCBiAr/Zbr4UYdO3Z0ga4u6FTzecUVV9imTZvcEzwjoc6UEhISLHfu6IcohQsXdkM88s5lCKLut4BY2LNnj7p2882bNy/Vab/66is3rT4TLk0fOLRo0cKN79y5s69du3a+4cOH+8qXL++rVq2aG1+1alXf008/nY5vhOwukn3a8+677/ry5s3rO3HiRNjHwcyZM31169b15cuXz3feeef5fvrpJ/80kydP9hUrVsz/esWKFb6WLVv6Chcu7CtSpIivUaNGviVLlvjnFTgMHjzYfeb111/3NW7c2H2mbNmyvg4dOvi2b9+ernLIjBkzfA0bNnTTV69e3TdkyJCwvjdOvf1+5cqV7jPr169PdVpvf/v000/d/psnTx43LiEhwTdy5Ej3G54/f35fvXr1fO+991669lMdA/Xr10+0/FdeecVXu3Ztd5yWK1fO16NHD/9748aN89WpU8dXsGBBX6VKlXz33nuv78CBA4mWH+oYO3r0qK9///6+ChUquM82bdrUTZ9SOXR+0nnKk9y5DImRWoCY8a589cCKY8eORX3+33//vfv/iy++sK1bt9r777/vf081BWvXrnWPL545c2bUl43sKS37tNIKlDoTSe3SAw884J5eqHQY3Um45ppr7MSJEyGnVS1YpUqV3LQ//PCDDRgwwPLkyeMeHqOccC1bx4cG3VYVzWvYsGG2cuVK912UpnPHHXekqxzffPONexKjnr74yy+/2Isvvuhuu44YMSLs741TY7/X0zknT55s1atXt8qVK4e9HO27o0ePttWrV1u9evXcEz1ff/11mzhxov3888/Wt29fu+2222z+/Plp3k+DvfDCC9ajRw+XdvbTTz/ZRx99ZDVq1PC/rwcyTZgwwS1ftdFffvmlPfjgg+69lI6xnj172qJFi9zTR3/88Ue78cYb3Z3HdevWWSQ4l4UhKLAFomratGm+4sWLu6vp5s2b+wYOHOiu1KNRI7tp0yb3meXLlycar6tY1TIdO3Ys0XhqZJGR+7Ts3LnTV6VKFd/DDz8c1ry94+Cdd97xj/v77799BQoU8E2dOjVkDZNqYadMmRJyfqFqTUNRDa6WG1zTFEk5LrvsMld7FuiNN95wNUnIHvv9888/7ytUqJDbd2rWrBlWbWzg/qYafY9qNFWTuXDhwkTTdu3a1d1BSOt+GlwTqhrTRx55JOz1oBrhkiVLpniMbd682ZcrVy7fn3/+mWi8jhGtt1DlSK5GNtS5DIlRI4uY51UpP1BXuboaVWvoRo0auZqaWKpbty65RMjUfXr//v121VVXuVxZ5QtGolmzZv6/S5Qo4RqPqZYqlH79+tldd91lrVq1crVZGzZsSHX+qrlVrZXyGYsUKWItWrTwPxI8reVQ7e7jjz/ur73T0K1bN1dLpVx4nPr7ve4OLF++3NWYnnXWWXbTTTfZ0aNHw15GkyZN/H+vX7/e7TeXX355on1KNbTB+3gk+2mgHTt2uO902WWXJTuN7vjp/YoVK7pj5fbbb3d5wSnt06rZVY6v1kFg2bVewjk+A3EuSx2BLGIuf/787sfoscces4ULF7pbmIMHD47pMgsVKhTT+SN7S22fPnDggDvZ68T3wQcfuFv9saIgWbc9FTTrtqcCZy0zpdu+am2u26FvvfWWux3rTa/GJGl18OBBGzp0qOtFxBt0QtetVK0vnPr7fbFixezMM8+0iy++2DVuVK8FKe2LKf1ua3+STz75JNE+pbSVaDacTIlSbq6++mqX5jB9+nR3Afj888+neqyo7GrgpukDy67g+plnnvGnLPyvqcf/C5UOwbksdfRagAynE61yrdLLa72pK18gq+zTqolVoKguilR7lZYgbvHixa62VPbs2eO626pVq1ay06vmR4NyCDt06ODyE6+99lp3jAQfHwouVKOk2lsvf3Hp0qXpLodq55SXHphfiOz7W64gTUNa20do3jqGdJfAu2MQrePFowtN9S+uPNRLLrkkyfsKRE+ePOnybxV4yrvvvptomlDHWMOGDd041fhedNFFIZetXN5t27a5daRuJCXcriSRGIEsYkYnSyW4d+nSxV3R6kdDJ8wxY8a4PgZFB7IG3UYS1eBoOv0o6RZRSsqUKeOuqGfNmuUauyhgUI0AkFn7tIJYdTmk245vvvmme63BO3GF2w2RbtGXLFnSypYta4888oiVKlXK2rdvn2S6I0eOuIYuN9xwg2tY88cff7gaVt0GFp2kVTukE3X9+vWtYMGC7tjSyffZZ591XYOtWrXKNfxKTzlk0KBBrvZK81d5dOJXuoHmP3z48AjWMuJtv9+4caNNnTrV7fvaz7Uf6kJJv89XXnllmpapZajhlC7OFExeeOGFruGk+q3V3YTOnTunaT8NdUdDx4HOJ23btnV3U7QM9QetizLVkupYUSqOxqvhWaBQx5guKpVmocaPCoIV2KofXk2j9ae7J+o/XeO0DnW86Dz22Wefue+GCAXlzAJRo2T9AQMGuO5UlAyvxH01AHj00Ud9hw8f9ie8B3dfokEJ9OF46aWXfJUrV/blzJkzSfdbwWjshVjv06G64/EGNU5Mjff5jz/+2HfOOee47oDUbU9go5rAxiVqBHLLLbe4Y0DTquFKz549fUeOHPFP3717d9c4JbBroLffftt15aPuipo1a+b76KOPEjWcjLQcnlmzZrmGQGpsU7RoUfeZSZMmseOd4vu9GjW1bdvWV6ZMGdd1lrqpuvXWW31r1qwJa/7JNfY9efKkb/z48W5Zmm/p0qV9rVu39s2fPz/N+2moRlYTJ070L0ONE3v16uV/76mnnnLjtE9r2eq6LrisoY6x48eP+wYNGuSOM2++1157re/HH3/0f+6FF15wx64ayHXq1Mk3YsSIkN1vIWU59E+kwS8AAEBmUoMzpQQonYDHJWdfNPYCAABAXCKQRZY1cuTIRF2XBA7KZQLijXLxktun9R5wKmK/RyyRWoAsS8/r1hCKGhGoXz8gnqgVs9f4K5gaeajBCXCqYb9HLBHIAgAAIC6RWgAAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAACAuEQgCwAAgLhEIAsAAIC4RCALAAAAi0f/ByJawFBbFWh5AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 700x340 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "summary = {}\n",
+    "print(f\"{'substrat':16s} {'EI_gain':>8s} {'EC_gain':>8s} {'z(EC)':>7s}  credite\")\n",
+    "print(\"-\" * 56)\n",
+    "for name, d in detail.items():\n",
+    "    r, b = d[\"real\"], d[\"base\"]\n",
+    "    ei_gain = r[\"effective_information\"] - b[\"effective_information\"]\n",
+    "    ec_gain = r[\"emergent_complexity\"] - b[\"emergent_complexity\"]\n",
+    "    ec_std = b[\"emergent_complexity_std\"]\n",
+    "    z = ec_gain / ec_std if ec_std > 1e-12 else float(\"inf\")\n",
+    "    credited = z > 1.0\n",
+    "    summary[name] = {\"ei_real\": r[\"effective_information\"],\n",
+    "                     \"ec_real\": r[\"emergent_complexity\"],\n",
+    "                     \"ei_gain\": ei_gain, \"ec_gain\": ec_gain,\n",
+    "                     \"z\": z, \"credited\": credited}\n",
+    "    print(f\"{name:16s} {ei_gain:+8.3f} {ec_gain:+8.3f} {z:7.2f}  {credited}\")\n",
+    "\n",
+    "n_credited = sum(v[\"credited\"] for v in summary.values())\n",
+    "print(f\"\\nGate 1 : {n_credited}/3 substrats creditent une emergence dynamique (z > 1).\")\n",
+    "\n",
+    "# --- figure : reel vs controle degenere (information effective) ---\n",
+    "names = list(subs)\n",
+    "x = np.arange(len(names))\n",
+    "fig, ax = plt.subplots(figsize=(7, 3.4))\n",
+    "ax.bar(x - 0.2, [detail[n][\"real\"][\"effective_information\"] for n in names], 0.4,\n",
+    "       label=\"reel\", color=\"#2c7fb8\")\n",
+    "ax.bar(x + 0.2, [detail[n][\"base\"][\"effective_information\"] for n in names], 0.4,\n",
+    "       label=\"controle degenere (shuffle)\", color=\"#c0c0c0\")\n",
+    "ax.set_xticks(x); ax.set_xticklabels(names); ax.set_ylabel(\"information effective (bits)\")\n",
+    "ax.set_title(\"Gate 1 - la dynamique bat-elle son controle degenere ?\"); ax.legend()\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eca15c13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006998,
+     "end_time": "2026-07-02T10:04:39.209800+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:39.202802+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du gate 1\n",
+    "\n",
+    "**L'appareil mesure de la dynamique, pas du réservoir.** À la graine représentative, les **trois**\n",
+    "substrats créditent une émergence dynamique ($z > 1$) : S1 $z$=1.86 (gain d'EC +4.05), S2 $z$=1.24\n",
+    "(+1.02), S3 $z$=2.66 (+2.07). Autrement dit, l'ordre temporel réel bat son contrôle dégénéré dans\n",
+    "chaque cas — l'instrument capte bien la **dynamique**, pas seulement la taille du multi-ensemble\n",
+    "d'états. Premier indice cependant : les gains d'EC sont **très inégaux** (S1 ≫ S3 > S2) alors que\n",
+    "l'information effective, elle, place S2 en tête. « Combien d'émergence » et « combien d'intégration »\n",
+    "ne classent déjà pas les substrats pareil — ce que le gate 2 va trancher.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7641c4b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008998,
+     "end_time": "2026-07-02T10:04:39.228716+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:39.219718+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Gate 2 — un scalaire d'intégration transfère-t-il ? (une graine)\n",
+    "\n",
+    "**Critère falsifiable.** Si un « scalaire d'intégration » gouvernait les trois substrats, ils\n",
+    "seraient **classés dans le même ordre** par l'information effective réelle (`ei_real`) et par le\n",
+    "gain d'émergence crédité (`ec_gain`). On mesure la concordance de rangs (**$\\tau$ de Kendall**) :\n",
+    "`consistent` = vrai seulement si $\\tau \\approx +1$. Un $\\tau < 1$ falsifie l'existence d'un scalaire\n",
+    "transférable — dès une seule graine.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0c4fba13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:04:39.290552Z",
+     "iopub.status.busy": "2026-07-02T10:04:39.289552Z",
+     "iopub.status.idle": "2026-07-02T10:04:39.461683Z",
+     "shell.execute_reply": "2026-07-02T10:04:39.461683Z"
+    },
+    "papermill": {
+     "duration": 0.218409,
+     "end_time": "2026-07-02T10:04:39.462822+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:39.244413+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classement par EI reelle  : ['S2_bistable', 'S1_tri', 'S3_replicateur']\n",
+      "Classement par gain d'EC   : ['S1_tri', 'S3_replicateur', 'S2_bistable']\n",
+      "tau de Kendall (EI vs EC_gain) = -0.333  ->  consistent = False\n",
+      "tau de Kendall (EI vs EC_reel) = +1.000  ->  consistent = True\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAEiCAYAAAAF9zFeAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAQVtJREFUeJzt3QeYE+Xa//EbkLZU6V0QUEA6HDggiBwQsFIsiCgIyFEU8ACiIkhTiihFAcGGiuWI5agcQUARUIovUqQqqFSV3qWX+V+/5/0nb3Y3uyS72RL2+7muwGYymXkymUnuPHM/92TyPM8zAAAAIMpkTusGAAAAAElBIAsAAICoRCALAACAqEQgCwAAgKhEIAsAAICoRCALAACAqEQgCwAAgKhEIAsAAICoRCALAACAqEQgCyAkQ4cOtUyZMrG1MqiFCxe691//R7P777/fypYtm9bNABAhBLLIsLZu3Wo9e/a0q666ymJiYtytSpUq9sgjj9jatWuTtMylS5e6gO/w4cMRbesPP/zg2nrNNddYrly5rEyZMnbXXXfZ5s2bI7oeAEjIn3/+6T7ffvzxx4htpNmzZ9tNN91kxYsXt/z589sNN9xga9as4U1AyAhkkSF98cUXVrVqVXvnnXesefPmNn78eHvxxRftxhtvdB+sNWvWtO3btycpkB02bFjEA9nnnnvOPvnkE2vWrJlr5z//+U/79ttvrXbt2rZ+/fqIrgsAEgpk9fkWyUD2lltusaxZs9rgwYNtwIAB7vNMwey+fft4ExCSy0KbDbh0/Pbbb3b33XfbFVdcYfPnz3c9AXGDxpdfftkyZ04/v/P69u1r77//vmXLls0/rX379latWjUbPXq0vfvuu2naPkTW8ePHXc87cKlbtmyZ1a9f33+/Vq1a1rJlS5s3b5517NgxTduG6JB+vqmBVDJmzBgXKLz55pvxgli57LLLrHfv3la6dGn/NKUaKLfuyiuvtBw5clixYsWsa9euduDAAf88OuXWv39/93e5cuVcPqFu27Zt88+jgLNOnTqWM2dOK1CggAuod+7cedE2N2zYMFYQKxUrVnSpBj/99JNF2uLFi+1vf/ube63ly5e3V155JcF5Q3lNyknU9ovr+uuvdzefzp07u3XGfU36Yrv88stdj1BCtJ21vV944QWbPHmye6+ULtKiRQvXHs/z7JlnnrFSpUq5trZu3doOHjwYbzlffvmlNW7c2AWSefLksZtvvtk2bNgQa57du3dbly5d3LKyZ8/u9iMtL/C9Vlu0T8QVd1u89dZbbt5FixbZww8/bEWKFHHLjXR7wvH7779bmzZt3DrVnj59+tjp06eDzvs///M/1qpVK8uXL5/b3k2aNLElS5aElJcaN+9ax6TuT5s2LdZ8I0eOdNN1tuRitL3UBm2rvHnzuv1YPwITo31Gx1jBggXdvqH9+eOPP44331dffWWNGjVyp8Bz585tV199tT311FOx5pk4caI7LrUttM/WrVs33vr/+OMP9/lRtGhR935p/riv2ZeT/OGHH7pe0JIlS7rXdMcdd9iRI0fc+/Gvf/3LvT9qi97/YO9RKMenjkGdodq4caM1bdrUtV3r02dlYHu0LUXr8n2+af+VX375xW6//Xb32ahjWPui1qW2JiYwiBU9V86cOZPo8wAfemSRIdMKKlSoEO8DNDH6AtuyZYv7ANcHtQKJV1991f3//fffuw/0du3auZzVf//73y5VoVChQu65hQsXdv+PGDHCnn76aZfb+sADD7hTZ/rSu+6662z16tXuyzEcCsz27NnjvgQjad26dS74U7sVaJw7d86GDBnivnTjivRrUtrEN9984wJa9dRkyZLFBdHqnVEaSIkSJS66jPfee899Cfbq1csFqvoyVvv+8Y9/uC/jJ554wn799VfXzsceeyxWAKF1aN0KnNUzf+LECZsyZYoLXvR6fMGYvrD13msdmrZ37163j+zYsSPJA4kUxGqb6xSrfmilVXtOnjzpUlj0XP2g0zZXO/S+xKVpSsdRoKR9RGcxFIxqW3/33XdWr169sNat4+s///mPOwOh08v6Man9UYFct27dXC5lYhRUKUDUMaHT1Nr/tJ3mzJlj99xzT6L73W233eZ6ALXvfPDBB3bnnXe6zwr9cBBtX50Gr169ug0fPtwFoNqPAoP21157zW0zBZuPPvqonTp1yv0IVrDvW7+O2b///e/uM0N573rPFXzr9R09etQFp4FGjRrlgtAnn3zSv9/qVLy29aFDh9wxqs8gvXb9gNb+k5TjU8vSDxJ9jml+BfI6VnTWR+9x5cqV3evW8pXapB9Xoh8A2mbaRxVIax/UZ6SCdW0/pVnpR04otL30w0A/KPRDDAiJB2QgR44c8bTbt2nTJt5jhw4d8vbt2+e/nThxwv9Y4N8+//73v92yvv32W/+0559/3k3bunVrrHm3bdvmZcmSxRsxYkSs6evWrfMuu+yyeNND8c4777h1vfHGG14kadvkyJHD2759u3/axo0bXfsDPzLCeU1XXHGF17lz53jratKkibsFmjt3rlvPs88+623ZssXLnTt30PcrLm1zPa9w4cLe4cOH/dMHDBjgpteoUcM7e/asf3qHDh28bNmyeadOnXL3jx075uXPn9/r3r17rOXu3r3by5cvn3+69hMtT+91YjTPkCFD4k2Puy3efPNNN2+jRo28c+fO+adHuj2hmjBhglvehx9+6J92/Phxr0KFCm76ggUL3LQLFy54FStW9Fq2bOn+DjxWypUr591www3+aXq9et1xafvE/RratWuXV6BAAff806dPe7Vq1fLKlCnjjt3E6D3PkyePV79+fe/kyZOxHgtsX7C2xD2+z5w541WtWtX7xz/+4Z82fvx411Z9NiSkdevW3jXXXJNoO7t16+YVL17c279/f6zpd999t3tffW3Rdtb61A61J3C/zZQpk3fjjTfGen6DBg1iva5wjk8dg1rX9OnT/dO07YsVK+bdfvvt/mk//PCDm0/7bKDVq1e76R999JGXVDo2b7rpJi979uzewoULk7wcZDykFiBDUY+H6FRcXDq9pt4R302np33UIxLYa7B//37XqyKrVq266HrVy3ThwgXX06Hn+m7quVCKwIIFC8J6HT///LOrrtCgQQPXYxcp58+ft7lz57rTyqqM4KPeGPW4pORr8lFv8IMPPuh6f9Q7pFONiaU2xKWetMAeIF/P+7333uvSRgKnqydJPUeiHkz1HnXo0CHW61GvsOb1vR7tC0rzUO+uerEipXv37m5dPmnVHp2+V2qCehV9dKpZvXCBNOBHp5PV06gUG1/71JusHl0NRtT+ES7tPzr29PrV66f1qNdcaQKJ0fzHjh1zPZe+09M+FysbF3h8axvqdLjWHXhs+3ovP//88wRfl+ZRWoaqjASj3zcatHnrrbe6vwPfVx1fWm/cz5NOnTq5Hlgfvfd6rnqeA2m6UgZ0BiUpx6c+E3WM+GifUo+6zkRdjO9402eHzhokhXrd1TOtMypKDQFCRWoBMhTlmMlff/0V7zEFS/oi1Km/wA900SlqfdDqlKNO2wa6WA6Y6AtfXz76Agkm8IvqYpQPqdOd+vLQ6b/A4CehU8Vx26gvs2B06lHzB2un8gEDcxQj+ZqC5SwqYFAQo/xC5QGGKjAAD/ySDcx5DpzuC/70ekSnxYPxBVI6pazT/P369XPpFvpBo1POCjgS2q6h0GnhQGnVHlXrUOpN3OBP73+w9iX2Q0r7nfJEw6XcSuV2zpo1ywXQCoxDGcQpyvUMl06BP/vss25/C8wzDdwGGlz5+uuvu1P0CpbVJv3QUsDvGxiqU/Fff/21CwC1DfWjTIH+tdde6z++9ONEaUm6BRP38yWc/VmBq7a5Ts2He3wqpzXue673LpRShNp3lQ4ybtw4F4jqR4BSNfQ5GmpagdJXlE6iNBkgHASyyFD0oarepmAlq3w9d8EGyKhXQ6W1NJhLpbnUe6EvDeWUhdLrpHn0JaEeh2CBZ7Ae4mD0JaV8NX0ZKgcxlJzRGTNmuNzDQP975jt5wnlNCfWIqQc42HOVv+f7QleOpHolQ5VQYJ/QdN+28L2P+kINFgAG9uYqj1G9ap999pnrhVIeonIZlTOqUdeJ0Wu+WK9garYnqXzte/75590xEYxvH0js/Q9GPbwrVqxwf2sAktaVUlVEdBwp6FLeqKqV6PNBQZ5yfQMHaen9US+zejIVYCvvVseWfmgoh1v7l85cbNq0yQXGely9r1qm8kr1Q9i3zRTgJfQDQDm4kdqfw/nMudjyLmbs2LFuUJ9+gGp7KFdY+6DydwMHLyZE73mwwbfAxRDIIsNRb6Z6VpYvXx7SYBT12KlMl76IAgdS+HqkAiX0ha2R//pCUM+FLsCQFEppULCiAWXq9dHFG0KhU5Y67RoKpVToCzvYa9MXdFJfk3p2gtXWVe+fqgsE0qlpBd56fRpIosFabdu29Y+YTil6PaLeX9UWDmV+9YLqpu2lYE5f5r5SaMFes1IZdu3alSbtCZXK0umHnt7bwP052Pvv6xm+WPsSe/+DUdqMzo4oENKgrQkTJrgev8T42qO2qzc0VAo2lYqgHwDq3fZRIBuXgmn1xOqm3kdVUxg4cKALbn3bQJUe1Hurm95v9dpq0JVeh44vnRVSAB/Ke5ockfjMietiKRoaGKbboEGD3A9/9URPnTrV9XZfjHreU+pHFy5t5Mgiw3n88cddzp9yzJRGcLEeCF9PRdzp+nKNy1f7M+6Xtr7MtBwFw3GXo/uBZbyC0Refvhg1kv+jjz5yubGhUi+HvjQDbwlRGxX4qmdPo9Z9VA5LX/RJfU36UlXPTGBJHfVaBSs9ptOzWvfbb7/tggWNulfvVULlnyJFr1tBmYKTs2fPxnvcV6BdOYD6URFIr08BSmAbNU09eIF0OjmhXsiUbk+oVBlAZc4Cy09pHXFPhatSgdajNJBgqTqBBe01n84mBJ6mVkD/6aefxnue1queTtVH1il8pRkoMLrYVex0Gl+vWcFv3O2RWK+i9mEFaIHvi87K6BgIFKxUm68n2red4x7HyjPVDzKtX++h1qVT5wqeg50ViuRFAJL7mRNMQp9vGnvgy831UUCrwD/UfVA54qGkkABx0SOLDEc5YzplqNPVyvtTyZ0aNWq4D3ddtlaP6QPYdzpMwYROO6pnUF9Gqq+oU2eaNy59uYt6afQFrFOU6kXVF7l6JdQroy9JDabSl66WoS9z9UaoFFRC1Ms2c+ZMtyx9ocbtZYub05sc+uLTaVHluakklL6gfLUxAwORcF6T8goVoCgVQ2kaymfUa/D1ovnoVLhOxaqUk65a5usZ00A8nS4PrGsZaXqfVdrqvvvuc+vW+6ceNAXVOpWs3qVJkya5gEpfuHodClJ0il+vVz+K9BwfveaHHnrIBS6+y27qx4CvLFtqt0flmdTTre0ZrKZvYECh5SrHduXKle6HkNIb9OMvkI4RndlQqov2DS1bx4YGz6mHUu3/73//6+ZVO/QDRT3rOuXsKyOmnsLAwU1KJ+nRo4erZarSVKK2aHlqs+obJ5RioPWp7J22u3rvlZuqnmBtd61PP4wSOkOjH0zaN/UctUGDzdSrG7i/a/ChfphofvVaaz7tq/qcUDk0XzCtNBC9N8pX1g9AtV/P8eXnK0DX61Eqk7a13jMd09oOOtMSLGBOiuR+5iS0TA1oUy+rlqXAVq9D21jvlwZa6j3VZ4b2GV/gHgqlZegHq68uLRCytC6bAKSVX3/91evRo4crK6RyUzlz5vQqVarkPfTQQ96PP/4Ya97ff//da9u2rSuHpBI5d955p/fnn38GLbH0zDPPeCVLlvQyZ84crxTXJ5984sos5cqVy920vkceecTbtGlTom31lcdJ6BZpixYt8urUqePKU1155ZXe1KlTg5ZKCuc1jR071m0Xlde59tprvRUrVsQqv3X06FFXPqh27dqxymRJnz593PZctmzZRctvxS1D5StjFLc0kK/slUoKxZ1fJaX0Pmu/KF++vHf//fe79orKJun16XXq9Wo+lXwKLFcl58+f95544gmvUKFCXkxMjFum9rmEym/FbUek2zNx4kS3njlz5ngXo9Jrt912m2u32v/oo4+65wWW3wosvdSuXTuvYMGC7r3V67vrrru8+fPnx5pv3rx5rpSU9qmrr77ae/fdd+PtU1qOSmipdFSgzz//3M333HPPXbTtM2fO9Bo2bOiO57x583r16tVzpfISK7+lEnYqJab2azvqPYnbNr0eldcqUaKEew36X6WwNm/e7J/nlVde8a677jr/ttB71b9//3ilw/bs2ePes9KlS3tZs2Z1Za6aNWvmvfrqq0neb33tjVseLJTjU8dgsLJhwbaV3osqVaq4El6+Ulwqk9e1a1f3erWPqnxa06ZNva+//toLlZYVrEQfcDGZ9E/oYS8AIBqpx1Y9c8oNB4BLBakFAHCJU3+F6syGO/ALANI7emQBAAAQlahaAAAAgKhEIAsAAICoRCALAACAqEQgCwAAgKiU4aoW6PrTumqNijlf7HJ7AAAASP1KK7pMdYkSJRK8CEqGDWQVxJYuXTqtmwEAAIBE6DLmvqtsJiTDBbK+ywRq4+iShgAAAEg/jh496jodfTFbYjJcIOtLJ1AQSyALAACQPoWSAspgLwAAAEQlAlkAAABEJQJZAAAARKU0zZH99ttv7fnnn7eVK1farl277NNPP7U2bdok+pyFCxda3759bcOGDS4ReNCgQXb//fenWpsBAEDaOn/+vJ09e5a3IUplzZrVsmTJEv2B7PHjx61GjRrWtWtXa9eu3UXn37p1q91888320EMP2XvvvWfz58+3Bx54wIoXL24tW7ZMlTYDAIC0qy+6e/duO3z4MG9BlMufP78VK1Ys2TX90zSQvfHGG90tVFOnTrVy5crZ2LFj3f3KlSvb4sWLbfz48QSyAABc4nxBbJEiRSwmJoYLG0Xpj5ETJ07Y3r173X11RiZHVJXfWrZsmTVv3jzWNPXE/utf/0qzNgEAgNRJJ/AFsQULFmSTR7GcOXO6/xXM6v1MTprBZdH2S6xo0aKxpum+CueePHnSv2ECnT592t18NC8AAIguvpxY9cQi+sX8//dR72uGCWSTYtSoUTZs2LC0bgaSYmg+tlvY2+xI1G+zsk/OSusmRKVto29O6yYAqSK5OZW4tN7HqCq/paTgPXv2xJqm+7pCV7DeWBkwYIAdOXLEf9OlaQEAABD9oiqQbdCggatUEOirr75y0xOSPXt2/+VouSwtAADA/9m2bZvrHf3xxx/9ZU51P1oqQ6RpasFff/1lv/76a6zyWtqQBQoUsDJlyrje1D/++MOmT5/uHlfZrUmTJtnjjz/uSnZ988039uGHH9qsWZyKBAAgo0rtlKRwU3lU7/7tt9+ON10D1ufMmeP+Llu2rBu8zgD2KApkV6xYYU2bNvXf14UOpHPnzvbWW2+5iyTs2LHD/7hKbylo7dOnj7344otWqlQpe/311ym9BQAA0rVWrVrZm2++Ge+scVKdOXPGsmXLZhldmqYWXH/99a6eWNybgljR/+rijvuc1atXu0oEv/32G1f1AgAA6Z6CVo31CbxdfvnlYfXq6uqnI0aMsBIlStjVV1/tpmvsz1133eUuMKAz2q1bt3bpAoHU6afa+zly5LBKlSrZyy+/HFbbVbO/cePGbjySrqrau3dvd1Gr9CCqcmQBAAAyKo0T2rRpkxsf9MUXX7jSVUpPyJMnj3333Xe2ZMkSy507t+v9VY+t6EqogwcPdgHwTz/9ZCNHjrSnn346aKpDMOo01PJuv/12W7t2rc2YMcMFtj179rT04JIvvwUAAJDWFHgqyAz01FNPuVuocuXK5XpXfSkF7777rl24cMFN85WzUvqCemd1RrtFixY2ZMgQd0XUdu3a+dM0N27caK+88opL5QyljGnHjh39ubsVK1a0l156yZo0aWJTpkxxvbxpiUAWAAAghWlMkAK/QEoFCEe1atVi5cWuWbPGDZpXj2ygU6dOuZ5Unf7X/926dbPu3bv7Hz937pzlyxdarXatQz2x6tn1URqoAmgN0lfKQloikAUAAEhh6k2tUKFCspcRt/pTnTp1YgWZPoULF3aPy2uvvWb169eP9XioV9PSMh588EGXFxuXKkylNQJZAACAKFS7dm2Xs1qkSBFXKz8u9bpqYNiWLVtcekBS16FUhOQG4SmFwV4AAAApTNWWdu/eHeu2f//+ZC2zY8eOVqhQIVepQIO9dKpfubHqPf3999/dPMOGDXN5rspr3bx5s61bt87l0Y4bNy6kdTzxxBO2dOlSN7hLtf5/+eUX+/zzzxnsBQAAkFHowgfFixePNU0ltH7++eckLzMmJsa+/fZbF2xqMNexY8esZMmS1qxZM38P7QMPPODme/75561///4uPUG5tqFeeKF69eq2aNEiGzhwoCvBpfzY8uXLW/v27S09yOSpRRnI0aNHXVf7kSNHgnbDIx0ZGloiOgK32ZGo3xypfYWeS0W4VxoCoo0GMKnHUaPu03qkPFL2/QwnViO1AAAAAFGJQBYAAABRiUAWAAAAUYlAFgAAAFGJQBYAAABRiUAWAAAAUYlAFgAAAFGJS9SmAupiJs02ygQCAIBE0CMLAACAqEQgCwAAkM4tXLjQMmXKZIcPH46K5aYWUgsAAEB0S+1LmqfB5cAbNmxou3btcpduTUkLFy60+++/37Zt2+buv/XWW9alS5d482XPnt1dZtZn9+7dNmLECJs1a5b98ccfVqRIEatZs6b961//smbNmqVYewlkAQAA0rls2bJZsWLF0mTdefPmtU2bNsWapl5cHwW91157reXPn9+ef/55q1atmp09e9bmzp1rjzzyiP38888p1jZSCwAAAFLQsWPHrGPHjpYrVy4rXry4jR8/3q6//nrXW+nzzjvvWN26dS1PnjwuYL3nnnts7969CaYAqKc0f/78LlisXLmy5c6d21q1auV6bRMze/Zsu+qqqyxnzpzWtGlTf89rYrRetSnwVrRoUf/jDz/8sJtn+fLldvvtt7vlX3PNNda3b1/7/vvvLSURyAIAAKQgBXRLliyxmTNn2ldffWXfffedrVq1KtY86sF85plnbM2aNfbZZ5+5AFOn+BNz4sQJe+GFF1wQ/O2339qOHTvsscceS3D+nTt3Wrt27ezWW2+1H3/80R544AF78sknk/XaDh48aHPmzHE9rwrU41KwnZJILQAAAEjB3ti3337b3n//fX+u6JtvvmklSpSINV/Xrl39f1955ZX20ksv2d/+9jf766+/XG9rMGfPnrWpU6da+fLl3f2ePXva8OHDE2zLlClT3Lxjx45196+++mpbt26dPffcc/551FMct5f2yJEj8drQuHFj+/LLL+3XX381z/OsUqVKlhYIZAEAAFLIli1bXMBZr149/zQN2FIQGWjlypU2dOhQ1yN76NAhu3DhgpuuXtYqVaoEXXZMTIw/iBWlLQSmI8T1008/Wf369WNNa9CgwUVfg9Id4vYgKzVBFMSmJQJZAACANHT8+HFr2bKlu7333ntWuHBhF8Dq/pkzZxJ8XtasWWPdV55qSgSWmTNntgoVKgR9rGLFim69KTmgK2KBrH4dLFq0yOV2bN++3eVmaGPXqlXLmjdvbqVLl065lgIAgAx75ciSebLY0KZF7EzOo5bpsv8r+yTVLf1SmoACzh9++MHKlCnjP1W/efNmu+6669x9BYEHDhyw0aNH+2OpFStWRLwtlStXdnm6gZI7GKtAgQIu4J48ebL17t07Xp6sBqelZJ5sSIO9Tp48ac8++6zbuDfddJPLiVDDsmTJ4nIjhgwZYuXKlXOPpfToNAAAgGih0/KdO3e2/v3724IFC2zDhg3WrVs318vpK2GlAFfltSZOnOhSERRsauBXpD300EP2yy+/uLaonJbydlX94GLUy6s6sXFvvvQHBbHnz5936ROffPKJW4fSGJTnG0rqQooHsiqjsHbtWnvttdfs6NGjtmzZMtfQd99915VxUPf3b7/95hJ/7777bjcfAAAAzMaNG+cCultuucWdwVbNVfWO5siRw20end1WQPnRRx+5fFj1zKoaQaSVKVPGxW+qilCjRg03UGzkyJEXfZ5iP+Xfxr358nHV66wcWpXz6tevn1WtWtVuuOEGmz9/vhtglpIyeSEkUyiq1gYPhRKaFdgGJh+nJ3ozlGStbn0V+E0NGenUTyRty3FPWjch+qTB1WYijeMlabaNvjnC7wSiQUZMLShSopRluixbkpdTvVTKloMKNSe2ZMmSrnqAemczolOnTtnWrVvdGX1fQJ+UWC2kHNlQg1hRHkh6DWIBAABS2+rVq10erE69Kzjzlchq3bo1b0ZaXBBBg73uvfde102u6+mKivEuXrw4ue0BAAC45ChVQKfzlVqgHlnFUoUKFUrrZmW8QFa5FRqdpvph+oVx+vRpN12/MELJswAAAMhIVN1JdWJ1cQNdCUtX96pWrVpaNytjBrKqXqDkYA3oCqxfpsTluMVyQ6GRbmXLlnX5ESrSq+v0JmbChAmuiLACaVVR6NOnj8uzAAAAQMYSdiCrcg2+umeBlJSrklzhmDFjhrv+sMp3KQhWl7t6exO6KoXKROiawJpfA9DeeOMNt4ynnnoq3JcBAACAKBd2IFusWDFXOzYu5ceq/EK45Si6d+9uXbp0ceUm1NOry61NmzYt6PxLly51Pb/33HOP68Vt0aKFdejQ4aK9uAAAILpdcDWWPBU1TeumIAJ8NWhT/RK1CjwfffRRF2yqkO+ff/7p6so+9thj9vTTT4e8HF1yTfkiAwYM8E9TcWAlQWt5wTRs2NDVrlXgqpF/KhqsOrb33XdfuC8DAABEkX3Hz9uhE+cs9+H9ljPv5ZYpS9ghjEM6YtpS1VfFgPv27XNxny4EkRxh7wU6ta8oulmzZu4StUozyJ49uwtke/XqFfJy9u/f764CUbRo0VjTdT+h6/WqJ1bPa9SokdsQ586dc1epSCy1QIPRfAPSfLXJAABAdDnnmY1efNA6VDtr1YqetCyZk1R4ybKdzBnxtiF8OgOvCzQomE3VQFa9sAMHDnSXN1OKgUbgKS0gd+7cltIWLlzoKiO8/PLLbmCY1q/eYV3GLaHe4FGjRtmwYcNSvG0AACBlHTx1wV7+4YjlyXbUcmXLbJn/9wqvYZnf7/qUaBrCkCVLFrvsssv8l+hNjqT1y5u5q3ft3LnT9ciqgoB6SMNpkGqn6YXs2bMn1nTdVx5uMApWlUbwwAMPuPsqXaFabP/85z9dcB0sqlfqggaUBfbIqtoBAACIPsqQPXrGs6Nnzifp+XGvIoXoFnZ/7oEDB1xawVVXXWU33XST7dq1y03XJdZ0fd1QKSeiTp067jq8PkpZ0H1daCEYpTLEDVYVDEtCV9pV2oMubxZ4AwAAQAYMZFW3VfVj1SOr/Aaf9u3b25w5c8JalnpKVY/27bffduW0evTo4XpYVcVAOnXqFGsw2K233mpTpkyxDz74wF2fVwWF1Uur6b6AFgAAABlD2KkF8+bNs7lz51qpUqViTa9YsaJt3749rGUp+NWotcGDB9vu3butZs2aLhj2DQBTsBzYAzto0CCXvqD/dWncwoULuyB2xIgR4b4MAAAAZLRAVj2mgT2xPrrkmk7jh6tnz57ultDgrkBKDNbFEHQDAABAxhZ2akHjxo1t+vTp/vvqIVVu65gxY6xp06aRbh8AAAAQmR5ZBawa7LVixQpX0Pbxxx+3DRs2uB7ZJUuWhLs4AAAAIHV6ZKtWrWqbN292FyVo3bq1SzVo166drV692sqXL5+0VgAAAACpUUc2X758rm4rAAAAEDU9sqoqsHjxYv/9yZMnu2oDunzsoUOHIt0+AAAAIDKBrC5Nq6tjybp161wtWF0YQXVdA6+gBQAAAKSr1AIFrFWqVHF/f/LJJ66O68iRI23VqlUuoAUAAADSZY+sLi2rS8XK119/bS1atHB/FyhQwN9TCwAAAKS7HllVK1AKwbXXXmvLly+3GTNmuOmqZBD3al8AAABAuumRnTRpkrvC1scff2xTpkyxkiVLuulffvmltWrVKiXaCAAAACS/R7ZMmTL2xRdfxJs+fvz4cBcFAAAApGwgq9zXvHnz+v9OjG8+AAAAIM0D2csvv9x27dplRYoUsfz581umTJnizeN5npt+/vz5lGgnAAAAEH4g+80337iqBLJgwYJQngIAAACkfSDbpEmToH8DAAAA6TqQXbt2bcgLrF69enLaAwAAAEQukK1Zs6bLf1UebGLIkQUAAEC6CmR1WVoAAAAg6gLZK664IuVbAgAAAKTkBRF8Nm7caDt27LAzZ87Emn7bbbcldZEAAABAygWyW7ZssbZt29q6deti5c36astSRxYAAACpIXO4T3j00UetXLlytnfvXouJibENGzbYt99+a3Xr1rWFCxemTCsBAACA5PbILlu2zF0goVChQpY5c2Z3a9SokY0aNcp69+5tq1evDneRAAAAQMr3yCp1IE+ePO5vBbN//vmnf0DYpk2bwm8BAAAAkBo9slWrVrU1a9a49IL69evbmDFjLFu2bPbqq6/alVdemZQ2AAAAACkfyA4aNMiOHz/u/h4+fLjdcsst1rhxYytYsKDNmDEj/BYAAAAAqRHItmzZ0v93hQoV7Oeff7aDBw/a5Zdf7q9cAAAAAKTbOrKBChQoEInFAAAAACkXyJ46dcomTpxoCxYscCW4Lly4EOvxVatWhbtIAAAAIOUD2W7dutm8efPsjjvusHr16pFOAAAAgOgIZL/44gubPXu2XXvttSnTIgAAACAl6siWLFnSX0cWAAAAiJpAduzYsfbEE0/Y9u3bI9KAyZMnW9myZS1HjhyuLu3y5csTnf/w4cP2yCOPWPHixS179ux21VVXuR5iAAAAZCxhpxbUrVvXDfjSxQ9iYmIsa9assR5XKa5Qqe5s3759berUqS6InTBhgivvpSuEFSlSJN78Z86csRtuuME99vHHH7veYQXU+fPnD/dlAAAAIKMFsh06dLA//vjDRo4caUWLFk3WYK9x48ZZ9+7drUuXLu6+AtpZs2bZtGnT7Mknn4w3v6YrUF66dKk/gFZvLgAAADKesANZBZHLli2zGjVqJGvF6l1duXKlDRgwwD8tc+bM1rx5c7f8YGbOnGkNGjRwqQWff/65FS5c2O655x6X6pAlS5agzzl9+rS7+Rw9ejRZ7QYAAECU5shWqlTJTp48mewV79+/386fP+96dQPp/u7du4M+Z8uWLS6lQM9TXuzTTz/tcnafffbZBNczatQoy5cvn/9WunTpZLcdAAAAURjIjh492vr162cLFy60AwcOuB7OwFtK0sUXlB/76quvWp06dax9+/Y2cOBAl5KQEPX4HjlyxH/buXNnirYRAAAA6TS1oFWrVu7/Zs2axZrueZ7Ll1VvaSgKFSrk0gH27NkTa7ruFytWLOhzVKlAubGBaQSVK1d2PbhKVciWLVu856iygW4AAADI4IGsLk0bCQo61as6f/58a9Omjb/HVfd79uwZ9Dm6CMP777/v5lM+rWzevNkFuMGCWAAAAFy6wgpkz549a8OHD3en8itWrJjslav0VufOnV1JL13uVuW3jh8/7q9i0KlTJ1diS3mu0qNHD5s0aZI9+uij1qtXL/vll19c9YTevXsnuy0AAAC4hANZndZfu3ZtxFauHNd9+/bZ4MGDXXpAzZo1bc6cOf4BYDt27PD3vIoGas2dO9f69Olj1atXd0GuglpVLQAAAEDGEnZqwb333mtvvPGGG/QVCUojSCiVQAPK4lL5re+//z4i6wYAAEAGCmTPnTvnLkzw9ddfuxzXXLlyxbvIAQAAAJDuAtn169db7dq1/QOtAiXnKl8AAABAVFQtAAAAAFL1ggiBfv/9d3cDAAAA0n0gqxquKsGly71eccUV7pY/f3575pln3GMAAABAukwt0CVhfVULdIECWbx4sQ0dOtROnTplI0aMSIl2AgAAAMkLZN9++217/fXX7bbbbvNP89V0ffjhhwlkAQAAkD5TCw4ePGiVKlWKN13T9BgAAACQLgPZGjVquMvExqVpegwAAABIl6kFY8aMsZtvvtldEEFX2ZJly5bZzp07bfbs2SnRRgAAACD5PbJNmjRxF0Jo27atHT582N3atWtnmzZtssaNG4e7OAAAACB1emSlRIkSDOoCAABA9AWy6oVdvny57d27N17t2E6dOkWqbQAAAJE1NB9bNCmGHrFLIpD973//ax07drS//vrL8ubNa5kyZfI/pr8JZAEAAJAuc2T79etnXbt2dYGsemYPHTrkv1F+CwAAAOk2kP3jjz+sd+/eFhMTkzItAgAAAFIikG3ZsqWtWLEi3KcBAAAAaZsjqxqy/fv3t40bN1q1atUsa9assR4PvHQtAAAAkG4C2e7du7v/hw8fHu8xDfY6f/58ZFoGAAAARDKQjVtuCwAAAIiKHFkAAAAgagLZDz74IOQF7ty505YsWZKcNgEAAACRCWSnTJlilStXtjFjxthPP/0U7/EjR47Y7Nmz7Z577rHatWvbgQMHQlksAAAAkLI5sosWLbKZM2faxIkTbcCAAZYrVy4rWrSo5ciRw10IYffu3VaoUCG7//77bf369e4xAAAAIF0M9lJZLd32799vixcvtu3bt9vJkyddAFurVi13y5yZlFsAAACk06oFClzbtGmTMq0BAAAAQkQXKgAAAKISgSwAAACiEoEsAAAAohKBLAAAADJWIHvmzBnbtGmTnTt3LrItAgAAAFIikD1x4oR169bNYmJi7JprrrEdO3a46b169bLRo0dbUkyePNnKli3r6tLWr1/fli9fHtLzdMWxTJkyUUUBAAAgAwo7kNUFEdasWWMLFy50gadP8+bNbcaMGWE3QM/p27evDRkyxFatWmU1atSwli1b2t69exN93rZt2+yxxx6zxo0bh71OAAAAZMBA9rPPPrNJkyZZo0aNXG+oj3pnf/vtt7AbMG7cOOvevbt16dLFqlSpYlOnTnW9vdOmTUvwOefPn7eOHTvasGHD7Morrwx7nQAAAMiAgey+ffusSJEi8aYfP348VmAbap7typUrXW+uv0GZM7v7y5YtS/B5w4cPd21QigMAAAAyprAD2bp169qsWbP8933B6+uvv24NGjQIa1m63K16V4sWLRpruu7v3r076HN0edw33njDXnvttZDWcfr0aTt69GisGwAAADLgJWpHjhxpN954o23cuNFVLHjxxRfd30uXLrVFixZZSjp27Jjdd999LojVpXJDMWrUKJeCAAAAgAzeI6vcWA32UhBbrVo1mzdvnjvNr1SAOnXqhLUsBaNZsmSxPXv2xJqu+8WKFYs3v3JwNcjr1ltvtcsuu8zdpk+fbjNnznR/B8vR1eC0I0eO+G87d+4M9yUDAAAg2ntkz549aw8++KA9/fTTIZ/aT0y2bNlc8Dt//nx/Ca0LFy64+z179ow3f6VKlWzdunWxpg0aNMj11KpnuHTp0vGekz17dncDAABABg5ks2bNap988okLZCNFpbc6d+7scm/r1atnEyZMcAPHVMVAOnXqZCVLlnQpAir3VbVq1VjPz58/v/s/7nQAAABc2sLOkVXPqUpw9enTJyINaN++vauEMHjwYDfAq2bNmjZnzhz/ADBdcEGVDAAAAIBkBbIVK1Z05a+WLFni0gJy5coV6/HevXuHu0iXRhAslUB04YXEvPXWW2GvDwAAABkwkFXpK53OV/1X3QKpFFdSAlkAAAAgxQPZrVu3spUBAACQ5kg+BQAAQMboke3atWuij0+bNi057QEAAABSJpA9dOhQvNqy69evt8OHD9s//vGPcBcHAAAApE4g++mnn8abposY9OjRw8qXL5+0VgAAAABpkSOrOq+6sMH48eMjsTgAAAAg9QZ7/fbbb3bu3LlILQ4AAACIbGqBel4DeZ5nu3btslmzZrlLzQIAAADpMpBdvXp1vLSCwoUL29ixYy9a0QAAAABIs0B2wYIFEVs5AAAAkGo5sidPnrQTJ07472/fvt0mTJhg8+bNS3IjAAAAgBQPZFu3bm3Tp093f6t2bL169VxagaZPmTIl7AYAAAAAqRLIrlq1yho3buz+/vjjj61YsWKuV1bB7UsvvZSkRgAAAAApHsgqrSBPnjzub6UTtGvXzg34+vvf/+4CWgAAACBdBrIVKlSwzz77zHbu3Glz5861Fi1auOl79+61vHnzpkQbAQAAgOQHsoMHD7bHHnvMypYt6/JjGzRo4O+drVWrVriLAwAAAFKn/NYdd9xhjRo1chdBqFGjhn96s2bNrG3btklrBQAAAJAal6jVAC/lyX711VeuHJf87W9/s0qVKiVlcQAAAEDKB7IHDhxwva9XXXWV3XTTTa5nVrp162b9+vULvwUAAABAagSyffr0saxZs9qOHTssJibGP719+/Y2Z86cpLQBAAAASPkcWQ3qUrWCUqVKxZpesWJFym8BAAAg/fbIHj9+PFZPrM/Bgwcte/bskWoXAAAAENlAVlf18l2iVjJlymQXLlywMWPGWNOmTcNdHAAAAJA6qQUKWDXYa8WKFXbmzBl7/PHHbcOGDa5HdsmSJUlrBQAAAJDSPbJVq1a1zZs3u1qyrVu3dqkGukzt6tWrrXz58uEuDgAAAEidHlnJly+fDRw4MGlrBABE3tB8bNWwt9kRthmQEQPZU6dO2dq1a23v3r0uPzbQbbfdFqm2AQAAAJELZFUrtlOnTrZ///54j2ng1/nz58NdJAAAAJDyObK9evWyO++8013RS72xgTeCWAAAAKTbQHbPnj3Wt29fK1q0aMq0CAAAAEiJQPaOO+6whQsXhvs0AAAAIG1zZCdNmuRSC7777jurVq2aZc2aNdbjvXv3DrsRkydPtueff952795tNWrUsIkTJ1q9evWCzvvaa6+5CzKsX7/e3a9Tp46NHDkywfkBAABwaQo7kP33v/9t8+bNsxw5crieWQ3w8tHf4QayM2bMcKkKU6dOtfr169uECROsZcuWtmnTJitSpEi8+bXODh06WMOGDV0bnnvuOWvRooW7KEPJkiXDfTkAAADIKKkFqh87bNgwO3LkiG3bts22bt3qv23ZsiXsBowbN866d+9uXbp0sSpVqriANiYmxqZNmxZ0/vfee88efvhhq1mzplWqVMlef/11N9Bs/vz5Ya8bAAAAGSiQ1WVp27dvb5kzh/3UoMtauXKlNW/e/P8alDmzu79s2bKQlnHixAk7e/asFShQINntAQAAQPQIOxrt3LmzSweIBNWiVcmuuBUQdF/5sqF44oknrESJErGC4UCnT5+2o0ePxroBAAAgA+bIKvAcM2aMzZ0716pXrx5vsJdSBVLL6NGj7YMPPnB5s8qXDWbUqFEuFQIAAAAZPJBdt26d1apVy/3tqxzgEzjwKxSFChWyLFmyuNq0gXS/WLFiiT73hRdecIHs119/7QLqhAwYMMANJvNRj2zp0qXDaicAAAAugUB2wYIFEVt5tmzZXPksDdRq06aNm+YbuNWzZ88En6ce4REjRrhe4bp16ya6juzZs7sbAAAAMnggG2nqLVXerQJS1YJV+a3jx4+7KgbSqVMnV1ZLKQKicluDBw+2999/38qWLevPpc2dO7e7AQAAIGNI80BWFRD27dvnglMFpSqrNWfOHP8AsB07dsSqkDBlyhRX7UBXGAs0ZMgQGzp0aKq3HwAAABk0kBWlESSUShD3criqXQsAAAAkvxgsAAAAkAYIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCVCGQBAAAQlQhkAQAAEJUIZAEAABCV0kUgO3nyZCtbtqzlyJHD6tevb8uXL090/o8++sgqVark5q9WrZrNnj071doKAACA9CHNA9kZM2ZY3759bciQIbZq1SqrUaOGtWzZ0vbu3Rt0/qVLl1qHDh2sW7dutnr1amvTpo27rV+/PtXbDgAAgAwcyI4bN866d+9uXbp0sSpVqtjUqVMtJibGpk2bFnT+F1980Vq1amX9+/e3ypUr2zPPPGO1a9e2SZMmpXrbAQAAkHYuS8N125kzZ2zlypU2YMAA/7TMmTNb8+bNbdmyZUGfo+nqwQ2kHtzPPvss6PynT592N58jR464/48ePWqp5cLpE6m2rkvJ0UxeWjch+qTifp1SOF6ShuMlKRuN4yUj4lhJ/8eLL0bzPC99B7L79++38+fPW9GiRWNN1/2ff/456HN2794ddH5ND2bUqFE2bNiweNNLly6drLYj5eVjI4dvNFsto+KdTwKOlwyJYyV6jpdjx45Zvnz50m8gmxrU2xvYg3vhwgU7ePCgFSxY0DJlypSmbUPiv8b0Y2Pnzp2WN29eNhXA8QIkG98t0UE9sQpiS5QocdF50zSQLVSokGXJksX27NkTa7ruFytWLOhzND2c+bNnz+5ugfLnz5/stiN1KIglkAU4XgC+WzKWfBfpiU0Xg72yZctmderUsfnz58fqMdX9Bg0aBH2OpgfOL1999VWC8wMAAODSlOapBTrt37lzZ6tbt67Vq1fPJkyYYMePH3dVDKRTp05WsmRJl+sqjz76qDVp0sTGjh1rN998s33wwQe2YsUKe/XVV9P4lQAAACBDBbLt27e3ffv22eDBg92ArZo1a9qcOXP8A7p27NjhKhn4NGzY0N5//30bNGiQPfXUU1axYkVXsaBq1app+CoQaUoHUW3huGkhADheAL5b4JPJC6W2AQAAAJDOpPkFEQAAAICkIJAFAABAVCKQBQAAQFQikMUlrWzZsq4SBhANFi5c6C7Ucvjw4QTneeutt1K8FnZ6aQcQSXH32aFDh7oB5ohuBLKIOFWh6NGjh5UpU8ZVHdDFKlq2bGlLlixxj6tU2vXXX+8udHCxL8u4tm3b5p7z448/hjT/Dz/8YP/85z+T/FqAcPZvXTWwV69edvXVV1vOnDndPL1797YjR45EtNLL5s2bQ5qXYBNp8Rn/4IMPWvny5d0xULhwYWvdunWCl51PS4899li8uvTJwfGWQctv4dJz++2325kzZ+ztt9+2K6+80l15TR8WBw4ccI+fOHHCWrVq5W66hHBK0Pp1wQ19iAKptX//+eef7vbCCy9YlSpVbPv27fbQQw+5aR9//HFE1q/gQDcgvX7G60JHHTt2dIGuftyp57NFixa2detWdzXPcKiw0vnz5+2yyyIfruTOndvdopHvOw7/u5MAEXPo0CGVc/MWLlx40XkXLFjg5tVzQqX5A29NmjRx0zt37uy1bt3ae/bZZ73ixYt7ZcuWddOvuOIKb/z48cl4RUDS9m+fDz/80MuWLZt39uzZkI+JL774wqtWrZqXPXt2r379+t66dev887z55ptevnz5/Pd//PFH7/rrr/dy587t5cmTx6tdu7b3ww8/+JcVeBsyZIh7zvTp0706deq45xQtWtTr0KGDt2fPnmS1Qz777DOvVq1abv5y5cp5Q4cODel149I+BtasWeOe8+uvv150Xt++N3v2bLcvZ82a1U07f/68N3LkSPfZniNHDq969ereRx99lKx9VsdDjRo1Yq3/jTfe8KpUqeKO2WLFinmPPPKI/7GxY8d6VatW9WJiYrxSpUp5PXr08I4dOxZr/cGOt1OnTnn9+vXzSpQo4Z5br149N39i7dD3lr6/fBL6joPnkVqAFPmFq4tUnD59OuJbd/ny5e7/r7/+2nbt2mX/+c9//I+pR2DTpk3uksVffPFFxNcNJGX/VlqB0mjC6VHq37+/u3qhUmN0VuHWW2+1s2fPBp1XPV+lSpVy865cudKefPJJy5o1q7t4jPLDtW4dK7rpVKpoWc8884ytWbPGvRal7Nx///3Jasd3333nrsSoqy9u3LjRXnnlFXeqdcSIEew4GfgY0JU633zzTStXrpyVLl065PVoPx49erT99NNPVr16dXd1z+nTp9vUqVNtw4YN1qdPH7v33ntt0aJFSd5n45oyZYo98sgjLh1t3bp1NnPmTKtQoYL/cV2c6aWXXnLrV2/0N998Y48//rh7LLHjrWfPnrZs2TJ3JdK1a9fanXfe6c5I/vLLLxYOvuMSQDSPSPv444+9yy+/3P1qbtiwoTdgwAD3izwSPbJbt251z1m9enWs6fq1qp6l06dPx5pOjyzSav+Wffv2eWXKlPGeeuqpkJbtOyY++OAD/7QDBw54OXPm9GbMmBG0V0m9sG+99VbQ5QXrNQ1GPbhab9zepXDa0axZM9djFuidd95xvUfIeMfA5MmTvVy5crn96Oqrrw6pNzZw31Pvvo96NNWTuXTp0ljzduvWzZ1NSOo+G7cnVD2mAwcODHk7qEe4YMGCiR5v27dv97JkyeL98ccfsabreNF2C9aOhHpkg33HgR5ZpFD+lHIC9WtWvzo1Arp27dqudyYlVatWjZwhpJv9++jRo3bzzTe7XFnlCIajQYMG/r8LFCjgBo+pZyqYvn372gMPPGDNmzd3PVi//fbbRZevnlv1VCmHMU+ePNakSRP/JcGT2g717g4fPtzfY6db9+7dXc+U8uKRsY4BnSlYvXq16zG96qqr7K677rJTp06FvI66dev6//7111/dPnTDDTfE2r/UQxt3fw9nnw20d+9e95qaNWuW4Dw6E6jHS5Ys6Y6b++67z+UFJ7Z/q2dXOb7aBoFt13YJ5VgNxHdccKQWIEXkyJHDfeg8/fTTtnTpUnfacsiQISm6tXPlypWiywdC3b+PHTvmvuD1Zffpp5+6U/0pRUGyTnUqaNapTgXOWmdip3o1wlynQN977z13CtY3vwaQJNVff/1lw4YNcxVFfDd9iev0qbYXMtYxkC9fPqtYsaJdd911bqCjqhYktl8m9nmufUtmzZoVa/9SCkskB1EmRuk3t9xyi0tz+OSTT9yPwcmTJ1/0uFHbNcBN8we2XcH1iy++6E9Z+N8hIP8nWDoE33HBUbUAqUJfrsqpSi7fKE39wgXS4/6tnlgFiipLpB6rpARx33//vestlUOHDrlyW5UrV05wfvX26Ka8wQ4dOricxLZt27rjJe6xooBCvUjqvfXlLK5YsSLZ7VCPnHLUA3MKkXEk9hmvIE23pI6b0LJ1POmMge/sQaSOHR/96FTdceWhNm3aNN7jCkQvXLjg8m8VeMqHH34Ya55gx1utWrXcNPX4Nm7cOOi6lcu7e/dut41UXlJCLTEJAllEmL4glcjetWtX98tVHw76khwzZoyrJSg6YHXT6SJRr43m04ePTgUlpkiRIu6X85w5c9wAFwUJ+uUPpIf9W0GsygzpVOO7777r7uvm+7IKtfSQTtEXLFjQihYtagMHDrRChQpZmzZt4s138uRJN7jljjvucINpfv/9d9fDqlO/oi9m9Qjpy7lGjRoWExPjjjN94U6cONGVBlu/fr0b+JWcdsjgwYNdj5WWr/boy17pBlr+s88+G8ZWRjQfA1u2bLEZM2a440D7vPZJ/WjS5/ZNN92UpHVqHRo4pR9qCiYbNWrkBlGqbq3OLHTu3DlJ+2ywsxs6JvQ9c+ONN7ozK1qHakPrB5p6SXXcKC1H0zXwLFCw400/MJVmoYGQCoIV2KoOr+bR9tOZFNVV1zRtQx07+n778ssv3WtDCEgURiQpKf/JJ590ZVOU9K4EfSX6Dxo0yDtx4oQ/sT1umRLdlCgfitdee80rXbq0lzlz5njlt+JisBdSc/8OVoLHd9NAxYvxPf+///2vd80117gSQCrVEziQJnBAiQZ+3H333e540LwarNKzZ0/v5MmT/vkfeughNyAlsBzQ+++/78r3qERRgwYNvJkzZ8YaRBluO3zmzJnjBv9ogE3evHndc1599dUIbHlEyzGgQU033nijV6RIEVc6S2Wq7rnnHu/nn38OafkJDQK+cOGCN2HCBLcuLbdw4cJey5YtvUWLFiV5nw02yGrq1Kn+dWigYq9evfyPjRs3zk3T/q11q4xd3LYGO97OnDnjDR482B1zvuW2bdvWW7t2rf95U6ZMccexBsh16tTJGzFiRNDyW4gvk/4JJeAFAABIjzTgTCkBSifg0skZC4O9AAAAEJUIZJGujBw5MlaJksCbcpaAaKb8u4T2bz0GXOo4BhBppBYgXdF1uXULRoMFVL8PiFYauewb/BWXBnZokAlwKeMYQKQRyAIAACAqkVoAAACAqEQgCwAAgKhEIAsAAICoRCALAACAqEQgCwAAgKhEIAsAAICoRCALAACAqEQgCwAAAItG/w9rmI3TGV8HhQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 700x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rc = S.rank_consistency(summary, \"ei_real\", \"ec_gain\")\n",
+    "print(\"Classement par EI reelle  :\", rc[\"order_by_ei_real\"])\n",
+    "print(\"Classement par gain d'EC   :\", rc[\"order_by_ec_gain\"])\n",
+    "print(f\"tau de Kendall (EI vs EC_gain) = {rc['kendall_tau']:+.3f}  ->  consistent = {rc['consistent']}\")\n",
+    "\n",
+    "# second couple de mesures, pour montrer que le desaccord n'est pas un artefact du choix\n",
+    "rc2 = S.rank_consistency(summary, \"ei_real\", \"ec_real\")\n",
+    "print(f\"tau de Kendall (EI vs EC_reel) = {rc2['kendall_tau']:+.3f}  ->  consistent = {rc2['consistent']}\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 3.0))\n",
+    "metrics = {\"EI reelle\": [summary[n][\"ei_real\"] for n in names],\n",
+    "           \"gain d'EC\": [summary[n][\"ec_gain\"] for n in names]}\n",
+    "w = 0.38\n",
+    "for i, (lab, vals) in enumerate(metrics.items()):\n",
+    "    v = np.array(vals); v = v / (np.abs(v).max() + 1e-12)   # normalise pour comparer les rangs\n",
+    "    ax.bar(x + (i - 0.5) * w, v, w, label=lab)\n",
+    "ax.set_xticks(x); ax.set_xticklabels(names)\n",
+    "ax.set_ylabel(\"mesure (normalisee)\"); ax.set_title(\"Gate 2 - deux mesures, deux classements ?\")\n",
+    "ax.legend(); plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79fb8093",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002986,
+     "end_time": "2026-07-02T10:04:39.469820+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:39.466834+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du gate 2\n",
+    "\n",
+    "**Le scalaire transférable est un mirage de magnitude.** Deux mesures *brutes* — information\n",
+    "effective réelle et complexité émergente réelle — classent les trois substrats à l'**identique**\n",
+    "($\\tau$ = +1.00) : de quoi croire à un « scalaire d'intégration » commun. Mais dès qu'on classe par\n",
+    "le **gain crédité** contre le contrôle dégénéré (`ec_gain`), l'ordre **s'inverse** ($\\tau$ = −0.33,\n",
+    "`consistent = False`) : S2 domine en EI réelle mais **tombe dernier** en gain crédité, tandis que S1\n",
+    "mène par le gain mais reste au milieu en EI. La concordance parfaite était donc un artefact de\n",
+    "**magnitude** (des systèmes plus grands ont mécaniquement plus d'EI et d'EC bruts) ; ce qui **survit**\n",
+    "au contrôle *sans complaisance* — la seule quantité que toute la série accepte de créditer — **ne\n",
+    "transfère pas**. L'hypothèse du scalaire unique est falsifiée dès une seule graine.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac8b8d10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010444,
+     "end_time": "2026-07-02T10:04:39.480264+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:39.469820+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Gate 3 — la créditation est-elle robuste au régime ? (multi-graines)\n",
+    "\n",
+    "**Critère falsifiable.** On répète toute la chaîne sur `SEEDS` graines (chaque graine = un\n",
+    "*régime* d'aléa de génération). Pour chacune : l'ensemble **crédité** et la concordance de rangs\n",
+    "$\\tau$. Si un scalaire transférait vraiment, `consistent` serait **stablement vrai** et l'ensemble\n",
+    "crédité **stable**. S'ils **varient** d'une graine à l'autre, alors non seulement aucun scalaire ne\n",
+    "transfère, mais la **créditation elle-même est régime-dépendante** — l'écho, un cran plus haut, du\n",
+    "fil ICT-10 → ICT-13.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "17a52472",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:04:39.515166Z",
+     "iopub.status.busy": "2026-07-02T10:04:39.515166Z",
+     "iopub.status.idle": "2026-07-02T10:05:44.920507Z",
+     "shell.execute_reply": "2026-07-02T10:05:44.919476Z"
+    },
+    "papermill": {
+     "duration": 65.434688,
+     "end_time": "2026-07-02T10:05:44.929173+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:04:39.494485+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "graine    tau  consistent  ensemble credite\n",
+      "------------------------------------------------------------\n",
+      "     0  -0.33       False  {S1_tri, S2_bistable, S3_replicateur}\n",
+      "     1  +0.33       False  {S2_bistable, S3_replicateur}\n",
+      "     7  +0.33       False  {S2_bistable, S3_replicateur}\n",
+      "    42  +1.00        True  {S2_bistable}\n",
+      "    99  -0.33       False  {S2_bistable, S3_replicateur}\n",
+      "\n",
+      "tau observes : [-0.33, 0.33, 1.0]\n",
+      "consistent = vrai sur 1/5 graines\n",
+      "nombre d'ensembles credites distincts : 3\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAEiCAYAAAAF9zFeAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAbFtJREFUeJzt3Qd8E+UbB/Cnu6W0rJaWvVW2AoKgf0FAQFBAFFkyFBSVLbKUPUVUkCUoioJsGaIoQ4YTRKbsPcroAkr3zv/ze8uFJE3btDRN0/y+n0+guVwud28ulyfvPe9zTjqdTidERERERHbG2dYrQERERESUEwxkiYiIiMguMZAlIiIiIrvEQJaIiIiI7BIDWSIiIiKySwxkiYiIiMguMZAlIiIiIrvEQJaIiIiI7BIDWSIiIiKySwxkifLQN998I05OTnL58mWHbPetW7fKo48+Kp6enqodIiIixNGY2weaNWumbvlBnz59pHDhwhbNi+2YOHGi1dcpr14nv9mzZ4/advxfEOA9xPYQ5SYGsmQVly5dkoEDB8pDDz0khQoVUrcaNWrIgAED5L///svRMv/++291IMzt4OfEiRPSuXNnqVy5slpPPz8/efrpp+XHH3+U/O7kyZOqTewhML5165a88sor4uXlJQsWLJDly5eLt7d3riz7559/tlmgs3DhQhWc5gc3btxQ7XDkyBFxhB8DZP8qVqxo9c/uypUrZc6cOZJXQkNDZezYsVKrVi11jKtSpYpMnTpVkpOT82wdHAkDWcp1P/30k/oAI1Bp2bKlzJ49Wz777DN57rnnVMCBHrkrV67kKJCdNGlSrgeyWJeoqCjp3bu3Ws9x48ap6e3bt5cvvvhC8nsgizaxh0D233//Ve08ZcoU6du3r7z66qvi5uaWK8vGfoV2sIdAtmfPnhIXFycVKlSwSiCLdijogayjwA9q7Cv4n+wnkMUx4dtvv5WOHTuq123QoIH6XkEwS7nP1QrLJAd24cIF6dq1q/qS3rlzp5QqVcro8ZkzZ6oPubNz/vkN1bZtW3UzhN7k+vXry6effipvvvmmFAQ6nU7i4+NVj6gtoJcCihYtmmvLjImJybVe3bzi4uKiblRwWGs/xHESaTiUd3CMdHd3f6DvqBdffFFGjx6tf+/eeOMNCQoKkhUrVjhkioy15Z9oggqEjz76SB3Uly5dmi6IBVdXVxk8eLCUK1dOPw2pBsjLw6l9fPADAwPl9ddfV6eiNfjwjxgxQv1dqVIldVrRNM/wu+++U8EnArXixYurgBoHj5xAoIF1zKsczl9++UX+97//qS9DHx8fadeunUp5yAx6AZESAc8884y+TbR8Opyye/7552Xbtm2qRwDtsnjxYvUY3p/mzZtLyZIlxcPDQ6V9fP755+leQ1vGn3/+KQ0bNlTvD96nZcuWGc2XlJSkegKrVaum5ilRooQ89dRTsmPHDvU48j/R4w2PP/64Wk+855p//vlH2rRpI0WKFFHpHU2bNpW//vrLbH4deqG7d+8uxYoVU6+B5SBVAbQ2sOS0syVtHhwcLK+99pqULVtWtRP26Q4dOuj3O7QPnvPbb7/pXzerXNcHyZNGe2Kb8WMAeawPP/ywvP/+++oxvO9oW8A6a+uj9Rb/8ccfan8pX7682hbs38OGDVM9fuZcvHhRWrdurdqndOnSMnnyZPVjKCvXr19Xn9+AgAD1OjVr1pSvv/7aou1LSEhQ6+Tv76/eE5wVuXbt2gPl0eI9MtzXtPbH/vXuu++q18I2IvgICwuzOIcYP9rxAxjr2aNHD/VYamqq6oHDNuNzgDbo37+/3Llzx2gZmA/rinbF/o7PL/Zr03U1lyOL/QtnvHDcxOcEz69atap8//336nHsi40aNVKfd+wfv/76a66+R5YeO3Lq9u3b8t5770nt2rVVO/v6+qqzeUePHrXoc2TaZmivLVu2qDNv2mcC7Ww47+rVq1UqQJkyZVR7RkZGWnxcMqdu3brpfoDgfmJi4gO3D6XHHlnK9bQCHFRxIM3OlzO+NPHliyAWgQFO6eP/ffv2qQNNp06d5OzZs7Jq1SqVqoA8VsCXEEybNk2dukEOZr9+/dQX0rx589QpucOHD1vUC4gAHF/qd+/elc2bN6tAp0uXLmJtSMFAkIegAT3WsbGx6osBAQvWXTvomsK24UfB3LlzVTBTvXp1NV37H86cOSPdunVTX6boFcAXG2D5+PJCoIAfF8gHfuedd9QXLPKYDZ0/f15efvlllQ6A9cQXHr5s8aMBywB8Kc+YMUO1PQJefBEcOHBADh06JM8++6x88MEH6rXxviIgwo8R5I3Brl271BcVljdhwgTVE6J9WSL4wvIMIRhDwDx9+nQVWD322GPqlDr2I7Rlbrb5Sy+9pPbDQYMGqWnoVcbrXL16Vd1H0ILH8IWLbQQEB9aA9cCPijp16qg2RBCB90b7YsX7junjx49XZxEQpEOTJk3U/+vWrVPb+fbbb6sfGvv371efEQSKeMxQSkqK+gJ/4okn1I9TDNLDe4McP7xGRkJCQtRz8JnFWQ18PvE5wr6DfWLo0KGZbiP2H/wgxQ8VrDf2DfzAsAa8b/gxhO1CMIT3Euu8Zs2aLJ+LdsC+g/3l448/VkEO4HOGAAvHMnw2MVZg/vz5ap/C+6Sl0owZM0a16wsvvKCWgyAN/6M30BIIjLEv4Mc6Pg/Yd/E3evzQxm+99ZZqw1mzZqnPLn7QI+DOjfcoO8eOnMB3waZNm9R24TiB9cUPcASRCPYR/GcHPpc4pmM/x3cHmA5mRLoTemERQOPHFP7O7nEpM/g+QdCM5ZAV6Ihyyd27d9Fdo+vYsWO6x+7cuaMLCwvT32JjY/WPGf6tWbVqlVrW77//rp82a9YsNe3SpUtG816+fFnn4uKimzZtmtH0Y8eO6VxdXdNNz0j//v3V8nFzdnbWvfzyy7rbt2/rctPSpUuNtiEqKkpXtGhR3RtvvGE0X3BwsK5IkSLppptat26dWt7u3bvTPVahQgX12NatW9M9Zq7NW7duratcubLZZRi+D6GhoToPDw/d8OHD9dPq1q2ra9eunUXb/u+//+qnpaam6qpVq6ZeG38brl+lSpV0zz77rH7ahAkT1PO7deuWbtkDBgxQj1nC0jbHPotlYr/LTM2aNXVNmzbV5XQfADw/q2XMnj1bPQ+fn4ygbTEPXsOS93zGjBk6Jycn3ZUrV/TTevfurZYxaNAg/TS8N3h/3d3djV4f8+F90fTt21dXqlQpXXh4uNHrdO3aVbWtuXXQHDlyRC3vnXfeMZrevXv3dK9jTkbzYB/GNpm2f8uWLY32uWHDhqnjSERERKavo7XP6NGjjab/8ccfavqKFSuMpuPzZzgd+xmOS6bHyYkTJ6r5DNcVn2vTzzf2E0xbuXKlftrp06f1x619+/bpp2/bti3d/vAg71F2jh3maJ/hzMTHx+tSUlKMpuGzgmPO5MmTM/0cZdRm2HexH5jS5sW6G25Xdo5LWdm1a5dad6xDcnKyxc8jyzG1gHKNdjrGXOkenN7BL3/tpp0KBsOcTfRIhIeHqx4DQI9eVjZs2KB6A9Abi+dqN/Tuoudu9+7dFq0/eiLQ24YkffwSR6+UtU8F4fWQvoBeU8N1R2oDerUtXfeMoEcDPT2mDNscvRV4TfR4oDcE9w3h1KHWuwd4/9C7ink16PFGj+G5c+eytX4YlITnoPcIqSTa9qN3vEWLFvL777+r99YQepvyos3RRuiZQU+K6alhW9DOKvzwww/p2sQShu852hfbjF5PxIDoMTSF3jqN1nuHz4O5U9WA5axfv171MuJvw7bFPoj9KrPPMwbsAXoyDWXVQ5hT6LU2TEHBPo7PvKUDUdGzbQi92jgFjTMQhtuOHj0cE7X9CmMH0KOLXkzTHmJLYXnogdXg84j9A73yhmfDtL+1z+qDvkfZPXbkBM40aPmpeD9wXNDSaCz5PsgJnJ0x3K6cHJfMwZlBnNXBAGfsH8yNtw6mFlCu0U5dRUdHp3sMp4YwYh2niTBa3TQnCvmVyFPSBgRpLDkw4oCDgzKCVnMsHRn/yCOPqBv06tVLWrVqpQ74yJPKKOdSS0UwhADaUlrgh9NV5iA/7EEDWXNwmhOnufbu3atONxvC9uALWYOcSlM4JWsY3OF0M3JHUW4N+Xs4LY3R+TgNbsn2a/mz5mB98HpZbVNutzm+UJF2MHz4cJUugB9XOJ2LfSOr9xhfwKb5lsjbRmCcU0hzWbJkiTr9joEk+EJFyg1OHVsyMAXpEEg7wGlO08DcdB/G8pALbQjvLWSU24vtxQ8EpI9kVO3D9PNtCAEkXldLOdFo6TC5zXS/1vYxS3604JQ68qZN9yu0I3JHM9t2LVBGCpbp/mG4n2cGr216TMJn1nDsgTbNcJse9D3K7rEjJxAgonoMBgUjNQOfJQ1SYqzB9JiSk+OSOcjNRdsjpcFWg2wdAQNZyjU4gGEwzPHjx9M9pvUMmPsSRE8qSmthMBd+ueLXNw5mCIYs+dWLeXBQR56XuV+8lhZ3N4UAATlvyM3N6MsU+XTIhzNkyYAYjbZ9yNk0FxzhC/NBmDt4YpAKgiAE7ajKgC8/BFjoEcMB17TNM+pFMNxO5Otiuegt3L59uwq4sKxFixapwCsj2mshlw/vvTmm79+DfiFkp83RG4gfM8jZw6A55GEjFxj5c8jNzQhyEk2/HNEj9yAXPcB2oycIy8EXJPJWsf8hIEebZ9bbg2AAPYX40Thq1Cj13mOAEwb9IN85Jz28prRl4IdqRgFAVj9srMEwEMrufm1Jr6Hh9iOIRZ6qOVo+f27IaN2z2qYHfY+ye+zICeS+43OGwWjIXUWAj7bGZ9Fw+Rl1LmT0fmfG9JiSk+OSOdqAZXMDnyn3MJClXIWBGQhiMJDEkmR4/FrFqTb0yKK3SGPuFHVGBy704OBAjcBB6zXKDdpo7sx6hXE6ThuZnxNa7xO+AFFzN7tyUhQegzMwoAE9c4a9Ug+axoAvHAT1uKFXHsEtBoFlFshq249e0Jxsf07aIbttjvnRK4sb9kt8sX3yySdqUFJGr40A2XS/wEjmB4UvdAQSuCGQwJc+BrPgvcO2ZNQOx44dUz/IkDaDHmVNRvsuvshxqtjw84TnQ0aDD7VKAwgkcvJeomQfXhfBkuEPRwxYtAR6x0yrjCAV4ubNm5IXsJ8g7eLJJ5/M9MeWVj8YA/UMf+wg6LF2CsuDvkfWOnYYQvUFVHH46quvjKbjvdUG+YLWG2r6nptLDcnucTK3jks4VmAA3IOeWaPMMUeWctXIkSPVCF78mkYaQVa9HVoPgul0c8WrtTqNpgcunF7FchAMmy4H9w3LeFl6Kg3lpFBiCl9IyBHNCH5p40BneMsOBMI4yCEgwWuayqocUEZtkhlzbY5gHSNyc8q0jdFbgVOn+NLLDPIH8aWBkd/mUlIsKYeU3XawtM1x2tR0FDnWFYGA4XbhtU1fF6V2TPcLS08bZwS9qaa03iJtfTJqB3PvOf7GKdyMYLS94by4jzQdBNHm4DWQD4gcTHNnZbJ6L5GXDqjCYcjSQvZ4b9BjbQinz3PSQ5cTOLOE10IvoinkxGrvCdoPvf6mJasM29taHvQ9ssaxw9xrmB7HkV+Kswfmgk3D9xztby5lAp+L7OTv5tZxCT9ekVuupd2RdbBHlnIV8lRxFRUMpEGvCuor4sOMAxPynfAYepW0/DIEFOi5QykaBBWo44fTpJjX3MEF0AOFgQ74UsVpX+3yfyhpg9QFXE0FBw4sY+PGjWpQB8qqZATpAxiohvXA66N2KE4Pnj59WvW85TQ1wRLYfnyhIZ+0Xr16arvQa4J8Rpw+Ru9OZl9wCGRw4EcuJw7UOOWp1XjMCHJ/cToQbYdtx4H6yy+/VM/Jae8Vgn2cNsd7hJ5ZlN5Cz4rhgCFzsC+gBx9BDEr6oDcX7wG+tNDLg/ax5FLB2r6BgUIIVNEmhoNhctLm6IFE0IEABduH4AP7E36gGS4br43lYR9E8I52zCj/9kEgDxlf2jjrgV49/ABDHiE+SygDBfgsYNAPUjrwGcAXONJ6cCoYj+FzgLZFGyCYyagHEIE4Uhdw+hnPR9oO2gZl3jI7Rf7hhx+q9w3PQbk3tBsCcAzSQW+luWDccF/GcQPbhH0ZA9FwtgY9l5ZAzz8GAiJQQxoFSlohHcSwF8+aMOAJnyeknmCwED5nOEahFx+BGH40IF0J+dZDhgxRxxaUsEIKFdYVbYx1tfaldx/kPbLGscMU8tCxr+NYgH0AZxNwPDbN2cbxAnnrOO5jnXHcwTgLc5eBxWcUaTioG4xayzimYxusfVzCcQQdLPguyuhMBuWCbFQ4ILLY+fPndW+//bauatWqOk9PT52Xl5fukUce0b311luqzI6ha9eu6V588UVVEgnlXzp37qy7ceOG2XI6U6ZM0ZUpU0aVmTEtvbJ+/XrdU089pfP29lY3vB7KMp05cybTdUWpL5TiCQgIUGVxihUrpu7/8MMPuf6OZ1YyBqVesP1orypVquj69OmjO3DgQJbL/PLLL1X5GJQOMiw7g3IzGZXE2rx5s65OnTrqtSpWrKibOXOm7uuvv063bhktw7Rc1NSpU3UNGzZU76H2XqPsWWJiYqbltzSHDx/WderUSVeiRAlVqgav+8orr+h27tyZrnSPufJTKGuDclH+/v6qnJQlh7as2hzlibD/YFuwP2G+Ro0a6dauXWu0HJRTQhv5+Pio182qjFZOy2+hLTp06KArXbq0KoOF/1GK7OzZs0bzYb+tUaOG2pcNSy+dPHlS7deFCxfW+fn5qTJjR48eTVeeCeWfsL0XLlzQtWrVSleoUCH12UD7m5ZFMvcZDQkJUe1Wrlw5nZubmy4wMFDXokUL3RdffKHLSlxcnG7w4MFqP8A6vPDCC7qgoCCLym9h3UaNGqW2DeuM9xbHoYzKb5nuh+bKNpmjtU9GsJ3169dXnwPsE7Vr19aNHDlSHdMM99dx48aptsF8zZs31506dUptN46Rma0T9hOUfDOV0WcVz8f7kVvvkaXHjgcpv4XSfigRhrZ58skndXv37jX7GcE+in0axwzso++//75ux44d6dosOjpalXHD8QmPaaW4tPZFGUNzLDkuWbK9WbULPRgn/JMbATERERHlDFIPkH6Cnn3t4hpElDXmyBIREeUhc5cF1nKBH6SyBZEjYo4sERFRHkK+Ji5l27ZtW5Wv+eeff6rLbyMHFTnaRGQ5BrJERER5CLVaMXgQg1wx0FQbAIa0AiLKHubIEhEREZFdYo4sEREREdklBrJEREREZJeYI5sFXDLxxo0bqri4tQtVExERETk6nU4nUVFRUrp0aXWBiswwkM0Cgthy5crl5vtDRERERFkICgrSXwk0Iwxks6BdIxmNicvSEREREZH1oJoHOhG1GCwzDGSzoKUTIIhlIEtERESUNyxJ6eRgLyIiIiKySwxkiYiIiMguMZAlIiIiIrvEQJaIiIiI7BIDWSIiIiKySwxkiYiIiMgu2VUg+/vvv8sLL7ygrvSAkgybNm3K8jl79uyRevXqiYeHh1StWlW++eabPFlXIiKi/EyXkiJx//4j0T//pP7HfSJ7Y1eBbExMjNStW1cWLFhg0fyXLl2Sdu3ayTPPPCNHjhyRoUOHSr9+/WTbtm1WX1ciIqL8KubX7RLUprkE9+0lYaOHq/9xH9OJ7ImTDhe0tUPokd24caN07Ngxw3lGjRolW7ZskePHj+unde3aVSIiImTr1q0WX12iSJEicvfuXV4QgYiI7B6C1dDhg3FBe+MH7hWfL/nJXPFu2co2K0ck2Yu97KpHNrv27t0rLVu2NJrWunVrNZ2IiMjRIH3g1sxp6YNY9WDatFsfTWOaAdmNAn2J2uDgYAkICDCahvuI9OPi4sTLyyvdcxISEtRNg3nh9O0rUjjp/jV/fd29payPvySkJMqFiBvpllOjREX1/6W7NyUu+f7yoExhPyniUVhux0dKcMxto8e83Tylgm+gpKSmypk7V9Mtt1qxsuLm7CpBUaESlRhr9FjJQsXEz6uI3E2IkevRYUaPebq6S+UipdXfp25fEdOOeDyGeW5Eh0tEQrTRYyW8ikhAoWISkxQnVyJDjB5zdXaRh4qVU3+fvRMkyanGOVYVfAPE281LQmLvyK24u0aPFfUoLKUL+0l8cqJcvHsjXY979eIV1N94DPMYt6G/FPHwlvC4uxIae8foMR/3QlLOp6QkpSbLuTvX0rXhw8XKi4uzs1yJDJaYpHijxwK9i0txT1+5mxAt16PDjR7zcvWQSkVKqb9P3rqcbrlVipYWDxd3uRYVJpGJMUaP+XsVFf9CRSU6MU6uRhm3obuLm1QtWkb9feZOkKSYtGFF30Ap5Oap9hXsM4aKefpIKe8Sah/DvmbI2clJHrnXhhcirktCSpLR49h/sR+Hx0VIaGyE+TZMSZZzEenb8JHi5cXZyVkuRwZLrEkbYn2wXnfio+RmzC2jx7Ad2J5UXaqcvm1m/y5aVtxcMtq/i4qfV1HVtmhjQx4ublLlXhvis5pqsn/jfcP7h/XBehnC+433HduB7THk4uwiD9/bv89HXJdEkzYs7xMghd29JCw2QsLijNuQx4g0PEbkr2OE85Gj4hFivJ8b0ekkJThYzuz5SUr/ryWPETxG2CSOiI4yPk47bCCbEzNmzJBJkyalm95n+wxx8XLX329XqbF8+FR/CYm5I11+nphu/mM90waVjf17ifwXfsHoselPvikvVG4i267sl+n7vzN6rEmpWrK45XvqoGNuub91nqu+eD86sFL2XDti9Nh79btK7xptZF/wCXnv94VGjyEoXNsubbt6/DJFBXmGNr4wTR0oFx/bLBvO/270WN+a7WRovc4qeHt9x8x0wfPOl2arv9/e9Wm6oPLrZ0fJ44HVZdXpX+WrE1uMHutU9WmZ1Ph1uRYdlm5bEawf6rFE/T36z8XqQ2Po46ffkdYVGsqWS3vl44OrjR5rVvZRmffMUBUImWvDvV0+V8EH2v7vm/fTTuD9hq9Kt4dbyu/X/5P3//rC6LE6flVkxXPj1N/mlrulw0wp7xsg849uUOtl6O06HeSdui/K0fDz8tbOT4weQ8D4c8eP1N9v7PhI7iQYf4CXtxkrj/pXlWWntsnyU8b53V0eai5jG/VSX1Cm64QfRfu6LlJ/D/99gVww+bEwt9kQeabcY7Lp/J/y2ZHvjR57tnwD+bTpQLkVH2l2Ww92/1LcXZxl0r6lciDkjNFjE594TV6q1lR2BR2SifuWGj3WIOBhWdpqjDpQmVvujk6fqqBy9qG1suPqAaPHhjz6svSr/bwcDDkrg/d8ZvRYlSKlZVP76frPqukPlDVtJ6ofl18d3yJrzu4yeqxn9dYyskE3ORtxTXpunWr0WDEPH/n9lXnqb7wmAmxDi1oMlydL15Z153bL5//9YPQYjxFpeIzIP8eIHpvHS9/dl6WdZG3ezi/l5YfK8xjBY4RN4oiUOOPOK4fNkX366adVxYI5c+bopy1dulQN+kLehTnmemTLlSsn/1z6Twr7sEeWPbLskQX2yKZhj2wanrXJ32dt/ONS5fbq7yR63RpxumPc2ZCRhNkfsUf2Hp61sU2PbKNKdSzKkS3wg71+/vlnOXbsmH5a9+7d5fbt2xzsRUREBVrCsf/k7splErNtq0hyWlqMs7+/6OLiRBdtHGiY8pv6ofi0fzGP1pQo54O97Cq1IDo6Ws6fP29UXgtltYoXLy7ly5eXMWPGyPXr12XZsmXq8bfeekvmz58vI0eOlNdff1127dola9euVZUMiIiIChpdUqLEbN8mkSuXS8Kxo/rpHo/VE99uPcW7xbMS+9vutKoF6gmGfVmoWpB2P3zsaEm+fl2KvjVAdRwR5Vd21SOLixugJqyp3r17qwsd9OnTRy5fvqzmM3zOsGHD5OTJk1K2bFkZN26cms9SLL9FRET5XcqtcIlct1qi1q6WlPB7gyHd3KTwc8+Lb/dXxaNGrXQluFC9IMVg4JdLYKAUHzFGEk8cl7tff6mmeT/fXvwnThMn9/tjRIisLTuxl10FsrbAQJaIiPKrhOP/SeTK7yR668/69AEXf3/x6dJdfF/qIi4lSmRaiiv+0AFJCQtTz/Gs10CcXFzUY5Hfr5Vb0yaKpKSIR70GEjBnvrgULZZn20WOLZKBrG0ak4iIKE/SB3ZsT0sf+O9+9RqPuo+Jb/ee4t3yWXFye/Ae1Li9f0nI8MEqn9a1QkUJXPCFuJVPK+lHZE0MZG3UmERERFZNH/h+jUStXaV6URVXNyncpm1a+kCtOrn+monnzkrIoLck+cZ1cS5aVALmLFA9t0TWxEDWRo1JRESU2xJOHpfIFcsleusWkaR76QN+/uLzSlfxebmLuPr5W7XRk8PDJGTw25J4/JjKu/Wf8qEUbvu8VV+THFtkQa1aQERE5Ah0SUkSs3OHRK5cJglHDuune9R5NC194NlWuZI+YAkEyqW+Wi5h74+Q2J07JGz0cEm6dlWKvvE2KxqQzXGwVxbYI0tERHkl5fZtifp+jUSuXSkpofeuJOfqJt5tnpMi3XqKR+3cTx+wlC41Ve7MniV3v/1a3S/c/kXxmzA5zwJqchyR7JElIiKyHwknT0jkqu8k5pefRJeYdnlOlxJ+4vNKN/HpbP30AUs4OTtL8eGjxLVcebk1Y4pEb94oyTevS8nZ88XFt4itV48cFFMLiIiIbJU+sAvpA8sl4fAh/XT3WrWlSI9e4t2qTb7s7fR9pZu4likroe8Nkfh/98vNV7tIwMIvxa1s2mVGifISUwuywNQCIiLK9fSB9Wslcg3SB0Lupw+0ai2+3XuJZ526dtHgiWfPSPDA/pISfFOcixWTgM8Wiuej9Wy9WlQAsGqBjRqTiIgoIwmnTkrkquUS8/P99AHn4iVUD6dKH/AvaXeNlxwWqspzJZ48oa7+5Td1pioHRvQgmCNLRESUD+iSkyV2169yF+kDhw7op7vXrHUvfeA5u778K4LvUl9/J2Fj3pPY3TslbOQwSQ66KkX69WdFA8oTTC3IAntkiYgou1Lu3JaoDd9L5OoVkhISnDbR1VW8n22jymd51KlboAI9XO729qcfSeTyb9T9wh07id+4Sfkyx5fyP/bIEhER2UDC6VP30wcSEtQ052LFxRcXL+jcVVxLBhTI98XJxUVKjBgjbqho8OFUid60QZJv3JCSn84TF6blkRWxagEREdGDpg/s3qmqD8Qf/Fc/3b1GTTV4y7v1c+Ls4eEQbezbtUdaRYMRQyV+/z652aurBMxfzIoGZDVMLcgCUwuIiMiclIg7ErVhnUSuXqlG7uvTB1qi+sCr4lH3sQKVPpAdCWdOS8iAN1VVBvRIB8z9XDzrPmrr1SI7waoFNmpMIiIq+BLPnpa7K7+TmC2bjdMHOncRn87dxDWgYKYPZFdySEhaRYPTJ8XJw0P8p32kauMSZYWBbC5iIEtERCp9YM8ulf+KiwBo3B+pIb6oPtCmrcOkD2RHamyMhI4cLnG/71b3iw19T4q81s9he6rJMgxkcxEDWSIix5VyN0Ki1q9Lu3jBzRtpE11cxLtlq7TqA4/WY1BmSUWDWTNUDjEU7tRZ/D6YIE5ublZ//8g+sWoBERHRA161KnLVdxKN9IH4eDXNuWhR8Xm5a9olWgMD2b7ZqWgweqy4liuvAtroDesk+cZ1Cfhkrjj7+LAd6YFwsFcW2CNLROQ4PYexv+2WyBXLJP7ff/TT3R+prnpfvdu0E2dPT5uuo71D+4aOfFd0cbHiVqVqWkWDMmVtvVqUzzC1wEaNSURE9icl8q5E37t4AXoK9ekDLZ4V3249xaNefaYP5PKlekMG9ZeU0FBxKeGnKhp41K6Tmy9Bdo6BrI0ak4iI7EfiubNp6QM//WCcPvBSF/HtgvSBUrZexQIrOThYBbOJZ06Lk6en+E+fpfKOiYCBbC5iIEtEVMDSB35H+sByVbBf4/7wI2npA889z/SBPJIaE63SDOL++E3EyUmKDxshvr1fZ+83CQPZXMRAloiogKQPbFyvemD16QPOzlKo+bMqgPWs34ABlI3Kmt36aLpErV6h7vt07iIlxowXJ1deeNSRRWbjbDj3FCIiKrASL5xXZZ+if0T6QJya5lwE6QOdxbdLd3EtVdrWq+jQELCWGDNO3MpXUBUNotatkeTr16Xkx5+Jc+HCtl49sgOsWpAF9sgSEdlf+gBOV99duVzi9/2tn+5W7SEp0r2XeLd9Xpy9vGy6jpRezO5fJWzUe+oHB96rwPmL+UPDQUVmo0eWgWwuNiYREdlOSmSkRP+wIS194FrQ/fSBZ1qKb/dXxbNBQ6YP5HMJJ49LyMC3JCU8TFz8/CVg3ufiUbO2rVeL8hgDWRs1JhER5b3Eixfupw/Exappzr5FVPqAT5fu4la6DN8WO5J884YED+wvSefOplU0+PAT8W7e0tarRXmIgayNGpOIiPKGLjX1fvrA3r/0092qPqQGbxVu9wLTB+xYanS0hL43ROL+/jOtosF7o8X31d7sUXcQkUwtsE1jEhGRdaVGRUnUpvVpFy8Iuno/faBZ87TqA483YrBTkCoazJisBoABetdLjPqAFQ0cQCSrFhARUUGSeOmCRK5aIdE/bLyfPuDjKz6dXk5LHyhbztarSNaoaDB2kriVryi3P/1IotaslOTr16TkrNni7M2KBpSGg72ywB5ZIiIbpg/89YdErliWdor5HrcqVe+lD7QX50KF+PY4gJidOyRsDCoaxIv7Qw9LwPwvxDUw0NarRVbC1AIbNSYREeVOfmSUVn3g6pW0iU5OaekD3XqKZ6MnmD7ggBKO/ychg96WlFvh4lKypATMXSQeNWraerXIChjI2qgxiYgo5xIvXVRXeEIQq4vV0gd8pPCLncW3K9MHSCTpxnUJGdBfki6cEyevQlJy5ifqBw4VLAxkbdSYRESUw/SBlcvV/xq3ylXS0geeR/qAN5uVjAb8hbw3JK1ahbOzFB8xRor06MUWKkByPZCdO3euxS8+ePBgsaYFCxbIrFmzJDg4WOrWrSvz5s2Thg0bmp33m2++kddee81omoeHh8THx1v8egxkiYislD6weWNa+sCVy/fTB55uJr49eolno8ZMH6AM6ZKS5Nb0yRK1fq26jx89CGidXFzYagVArlctmD17tkUv7OTkZNVAds2aNfLuu+/KokWLpFGjRjJnzhxp3bq1nDlzRkqWLGn2OWgAPG64jkREZBtJVy6r4FWlD8TEpB2XCxcWnxdfFt+uPcStXHm+NZQlJzc3KTF+sriWryB3Zs9SPfpJ165JyY8+YQ++g7GrqgUIXh9//HGZP3++up+amirlypWTQYMGyejRo832yA4dOlQiIiJy/JrskSUiyoX0gb1/paUP/PGbfrpbpcri2+1VKdy+I4MPyrGY7Vsl7IORoktIEPdHqkvAvMXiGhDAFrVjBbKObGJiohw8eFDGjBmjn+bs7CwtW7aUvXv3Zvi86OhoqVChggp669WrJ9OnT5eaNTMe5ZiQkKBuho1JRETZlxoTLdGbN6X1lhmkD3j9r5kU6dFTPJ9owrNk9MC8W7URl8BSEjL4bUk8fUpu9OgsAfMXi8cj1dm6DsCiQBan8y316aefijWEh4dLSkqKBJj8ysL906dPm33Oww8/LF9//bXUqVNHRfUff/yxNGnSRE6cOCFly5Y1+5wZM2bIpEmTrLINRESOIOnqlbT0gU3rjdMHOr6Ulj5QvoKtV5EKGM86daX0d2skZGB/Sbp4QW727q4unICcayrYLApkDx8+bNHC8lv+aePGjdVNgyC2evXqsnjxYpkyZYrZ56DH1zBwR48s0heIiChjyFIzSh+4l7XmVrFSWvWBFzrwakxkVbi6W6llqyV0+GCJ/2ev6qEtMXqs+vFEDh7I7t69W2zNz89PXFxcJCQkxGg67gdaeHUPNzc3eeyxx+T8+fMZzoOqBrgREVHWUmNj0tIHVn0nSZcu6qd7/a+pCmC9Gj8pTs7ObErKEy6+vhK48EsJnzpRojd+ryob4AxB8eGjWNGggLKbo4u7u7vUr19fdu7cqZ+GvFfcN+x1zQxSE44dOyalSpWy4poSERV8SUFX5dZH0+Vqy6fTgoVLF8XJ21sFr2V/3CaBC76QQk/+j0Es2aSigd/EqVJsyHB1P/K7byV02EBJvXeRDSpYcjTY68CBA7J27Vq5evWqGoRlaMOGDWItOOXfu3dvadCggaodi/JbMTEx+lqxvXr1kjJlyqg8V5g8ebI88cQTUrVqVVW5APVnr1y5Iv369bPaOhIRFeT0gfh9f8vdFUgf2HM/faBCxbT0AVQf8C5s69UkUqmORfu+Ka5ly0r4B6Mkds8uufnaqxIw73NxLcmKBg4dyK5evVoFjKjfun37dmnVqpWcPXtWneJ/8cUXxZq6dOkiYWFhMn78eHVBhEcffVS2bt2qHwCGwBqVDDR37tyRN954Q81brFgx1aP7999/S40aNay6nkREBS594Mcf0tIHLl7QT/d66um09IEmT7HnlfKlwq3biqtW0eDUCbnxahcJnL9I3B96xNarRraqI4sKAP3795cBAwaIj4+PHD16VCpVqqSm4ZR9QRvxzzqyROSokq4FSeTqFSrXEJcFBadChe5XH6hYydarSGTxvhwy4E19CkzJWXOk0FNPs/Uc5RK1hry9vVX5qooVK0qJEiVkz549Urt2bTl16pQ0b95cbt68KQUJA1kicrj0gX/2quoDsb/t1qcP4ApKuHiBT4dO4lyY6QNkf1Ii70rosEES/+8/Ii4uaRUNunS39WpRXl8QAafoo+79Mkc+6vHjx1UgixzUWCZSExHZJQyEif7pXvrAhfuVXZA24Nujl3hx4BbZORffIhK4aImET54g0T9skFvTJqlBi8WHjWBFAzuW7UD26aeflh07dqjgtXPnzjJkyBDZtWuXmtaiRQvrrCUREVkxfWDlvfSByPvpAx06iU/XHuJeqTJbngoMJzd38Zs8XdzKlZc78+dI5LKlknwtSPynzxLnQoVsvXqUA9lOLbh9+7bEx8dL6dKlVfmrjz76SA2gqlatmowdO1b12BYkTC2g/ESXkiLxhw5ISliYuPj7i2e9BuxJoGzvJyp9YP++tPSBPbvupw+UK38/fcDHhy1LBVr0zz9J+PgxoktMFPeatSRg3iJx9fO39WqRWDlH1tEwkKX8IubX7XJr5jRJCQnWT3MJCJQSoz4Q75atbLpuZB/7CdIEon/+USJXLJekC+eM0wdQfeCpp1l9gBxK/OGDEjLkHUmNiBCXUqUlcP5ica/2kK1Xy+FF5nYgiwVaKqsXtDcMZCm/BCe47KLWc6Z377LQJT+Zy2CWMt5PtN3Fq5Do4mL1f6PuK3pg3StXYeuRw8KVv1RFgyuXxalwYSn58WdSqMlTtl4thxaZ24EsarOiuLClV88qSBjIUn44TRzUprlRD5spFz9/Cfx6OdMMHHw/CX79VUkJD890PpcyZaUILl7QoZO6nCcRiaTcjZDQoQMl/uC/aRUNPpgovi+/wqYpKFULdu/erf/78uXLMnr0aOnTp4/+0rB79+6Vb7/9Vn9FLSLKPSrXMZMgFlLCw+R6+zZsdsoSLt1ZqJFll/UmchQuRYpK4OKvJXziWFW949bkcZIcdEVd5tbJ4EJLlP9YFMg2bdpU/zcu+/rpp59Kt27d9NPat2+vqhh88cUX6hKyRJR7Es/fz2XMlLu7OLnm6KrTVADokpNFTC4Zbk7qrVt5sj5E9sbJ3V38ps0U1/LlJWLhPLm7dIkkBQWJ/7SZ4uzlZevVowxk+1sPva+LFi1KN71BgwbSr1+/7C6OiMxAxk/C4YNqVDnyHi0R+PkS8Xq8EdvTQcX9+48E9+2V5XyoYkBE5iGNsthbA8WtbDkJm/CBxP66TYKDb0rAvM/FpYQfmy0fynZ/ebly5eTLL79MN33JkiXqMSLKudSEBInatF5udOkkN/v0kJjtW0VSU0Xc3DN+kpOTuAQGqhJL5Ljw/qM6gTYAMB3uJ0QWK/x8BwlcvFScixSVhOP/yY0er0iiwYVCyI57ZGfPni0vvfSS/PLLL9KoUVrvz/79++XcuXOyfv16a6wjUYGXHBwskWtXSdT6NZJ6546a5uThoQ6mvt16SNLVq2mj0cFwfOa9oKXEyA840MvBoU4sSmyp/QT7BfcTogfi1eBxKb18tQQP7C/JV6/IzV5dVYUYryeasGXzkRzVkb127ZosXLhQTp8+re5Xr15d3nrrrQLZI8uqBWTV9IEjh+6nD9yr+IFahrj+t0+nl8WlaLHM64MGBqoglnVkifsJkXWk3LktIUMHqnQvcXUVv7ETxadTZza3FfGCCDZqTCJL0wditv6sAtjEUyf00z0bNFRF6Qs1a57hoC1e2Ysswf2EKHfh6l9hE96XmC0/qvtF+r4pxQYNY0UDew1kIyIiVDpBaGioukytoV69sh5sYE8YyFJuSQ4Jkah1qyRyHdIHbuvTB7zbvqACWI+HH2FjExHlUwiXIj6fLxGL5qv73q3aiN/UmeLs6WnrVStwrBrI/vjjj9KjRw+Jjo5WCze8UAL+vn077Qu6oGAgSw+cPnD08P30AZRIunfJUN+uPdLSB4oVZyMTEdmJqM2bVL1ZSU4SjzqPSsBnC8WlRAlbr1aBYtVA9qGHHpK2bdvK9OnTpVChQlLQMZClnJ6GilbpA8sk8aRB+kD9x9UlQQs1b8mar0REdiruwH51JbDUyLviWqasBCz4gpd6tpdA1tvbW44dOyaVK1cWR8BAlrIjORTpA6vT0gdu39IX2fZu94L4duspHo9UZ4MSERUAiZcuSsiANyX5WpA4+/hKyU/nihevmpc/L1FrqHXr1nLgwAGHCWSJLEof+O9oWvrAjq330wdKBqSlD7zUmekDREQFjHulylL6u7USMvQdSThyWILf7id+4yeLT8eXbL1qDiXbgWy7du1kxIgRcvLkSXVZWjc3N6PHcblaIkdJH4jZ/ovcRfWB48f00z0eqy9FevSUQs+0FCeTzwcRERUcLsWLS+CX30r4uNGqGk34+PclKeiqFBswhBUN8ki2UwucnTO+GBgGe6Xcq4VZUDC1gEwlh4VK1NrVEvX9Gkm5FX4/feC551X+q0eNmmw0IiIHoktNlTsLPpO7Xy5S973btBO/KTPE2cPD1qtml6yaWmBabovIUcSr9IFlErN9mxqtqk8fwMULXnpF/TInIiLH4+TsLMUHDRO3cuUlfPJ4idm6RZKDb0jAnIX8brCybAeyhuLj48WT9dOoANMlIX1gq0SuWK6ut63xeKyeqv3q3fxZpg8QEZGC/FjXUqUl9N3BKm/2Rs8uEjB/scqnJevIOE8gA0gdmDJlipQpU0YKFy4sFy9eVNPHjRsnX331lTXWkSjPJYeHyZ3P50tQ6+YSNmZEWhDr5iaF278opVevl9LfrpLCrdsyiCUiIiOoXFBq+WpVlis56Krc7NlVleuifBLITps2Tb755hv56KOPxN3dXT+9Vq1asmTJktxeP6I8hYA19P0REtTqGYn4fJ6khIeJi7+/FB04RMpv/038p34oHjVq8V0hIqIMuVeuoioa4IIJqDUb/ObrEvXjJrZYfhjsVbVqVVm8eLG0aNFCfHx85OjRo6oU1+nTp6Vx48Zy584dKUg42MtB0gd2bFflsxL+O6Kf7lH3sbT0gZat2PNKRETZlhofL+FjR6kUNSjaf4AUfWeQ0VVRKY8He12/fl0Fs+YGgSUlpQ2AIbIHqDgQuW61qkCAnlcF6QNt2olv91fFo2ZtW68iERHZMWdPT/H/aLa4lqsgd79aLBGLF0jStaviP2m6qnZDDy7bgWyNGjXkjz/+kAoVKhhN//777+XRRx/NhVUisq6EE8fU4K3obT+L3Pvx5eLnLz5duonvy13EpYQf3wIiIsq9igZD3hW3cuUkfOpEidnyoyTfQEWD+bxYji0C2fHjx0vv3r1Vzyx6YTds2CBnzpyRZcuWyU8//ZQb60SU63RJSRLz6730gaOH9dORv6TSB55F+gB/HRMRkXX4dOosrqXLSMi7gyTh8EG50bOrBC74QtwqVGST52WOLKBHdvLkySo/Njo6WurVq6cC3CZNmqhKBgUJc2TtW8qtWxK5fo1ErV0lKaGhaRNd3cS7zXNSpFtP8ahdx9arSEREDiTx/DkJGdhfkm9cF+ciRSVgzgLxrN/A1qtlt7GXxYHs7NmzZdiwYRk+HhUVJW3atJG//vpLChIGsvYp4eRxiVz5nUT/8tP99IESfuLzSjfx6dxFXP38bb2KRETkwGM0Qga9rS/t6D95uhRu197Wq1WwB3u9//77UqJECenVq1e6x2JiYlQQe+vWrZytMVFupQ/s3KGuvoVC1BqPWnXEt0dP8W7VhukDRERkc+hYCfxqmYR9MEpif92m6pUnBV1VVQ1Y0SB7LA5kly9fLj179pSiRYtK+/b3fzUgtQBBbFhYmPz222/ZfHmiB5dy+7ZEfb9GIteuNE4faN1GfLv1FM86ddnMRESUrzh7eUnJj+fInc8+kbtLl0jEwnmSfPWq+E2cyooG1rggwssvvyzz5s2Tbt26yZ49e/Q9sc8995yEhISoaaVKlRJrW7BggVSsWFFdGrdRo0ayf3/mV8tYt26dPPLII2r+2rVry88//2z1daS8kXDqpISNGyNBrZrKnflzVBCLX7lF3xoo5bbtkpIzPmYQS0RE+buiwbARUmL8ZBEXF4n+6QcJfquvpNyNsPWqFcwre/Xr108mTJggHTp0UIErgtgbN27I7t27pXTp0mJta9askXfffVetw6FDh6Ru3brSunVrCdV64Uz8/fffKvDu27evHD58WDp27Khux48ft/q6khXTB7b/Ijd6d5cbXV6U6B82iC4xUdxr1hL/6R9JuW27pdg7g8TVvyTfAiIisgso/Riw4Atx8vaW+AP75earXVSqAVmpasHo0aNl1qxZqmcUAW25cuUkL6AH9vHHH5f58+er+yj/hdceNGiQWidTXbp0Ub3GhmXBnnjiCVXvdtGiRRa9Jgd75aP0gfVrJRLVB0KC0ya6uor3s21U+SyPOnWZV0RERHYt8dxZCR7YX1Ju3hDnYsXSKho8Vl8cTaQ1Bnt16tTJ6L6bm5v4+fnJkCFDjKajrqw1JCYmysGDB2XMmDH6ac7OztKyZUvZu3ev2edgOnpwDaEHd9MmXu/YXiScPqUGb8X8/JPqeQXn4iXEt3MX8encVVxLBth6FYmIiHKFe7WHpPR3ayRk8NuSeOK4BL/RR/wmz5DCbZ9nCz9oagEiY8MbTtnjKl+m060lPDxcUlJSJCDAOHDB/eDgez10JjA9O/NDQkKC+iVgeIPbt2/r57lz544a5AbJyclq3RBoQ2xsrFH1hoiICFWaTOtBNpw3Li5O3dfgl4f2etq8WB+Ix/Waw8NF60A3XDdMw2OYR9sG3McytHmxbMO2xGsD1sVwXqwr1lmDbcE2Gc6LbQa0AdpCgzbS5sXlig3nRc+4YRvib9M21C5xHBMZKcEb1smNPj3kxisdJXrTvfSBGjWlxJQPpdDK78X7jbdVEIvXM2xDc+2ttaEl7a21obn2Nm3DzNrbsA3NtTf2Za0NM2pv0zY0195oV8M2zKi9ze2zWnub22e1ebGeme2zmDerfdZce5vus9q8luyzpu1tus/iMdN91rC9Ddswq/Y23WdN29uwDXmMyLtjhOk+a7h/m+6zPEbwGGFvx4hE78LiMeszKdS8pfruCxs9XELmz1HHTUeKI3I9kF26dKlFN3s3Y8YMo8BcS5vYsWOHfp6dO3eqi0EAdlr0Qms70rlz54xSGZB6gXxewA6CebVA+uLFi0a9w3/++af8+++/6m+8yZgXV1CDK1euqPvaDoj8X9wA0/AY5gE8B/e1HQXLxLI1eE28NmBdMK+282JdtcF8gG3BNgG2EfNqH1S0AdpC88svv8jJkyfV39gxMa+24584cUK2b9+unxftqeUq4wOCeW9duigRX30hwe3bSNzEsZJw6IBKH7hdq46EvTdGSq9aL07NW8rGn37S50WfP39efvzxR/1yUTkDPffaBxHLvXnzprp/6dIl2bhxo35e1Dz+559/1N84iGHea9euqftBQUHqvvbB3Ldvn769AY9dvnxZ/Y08cdzXDiwHDhxQFw3RbN68WS5cuKD+xsBIzKsdANDeyDHXbNmyRV0pT/vwY17tYHfs2DH59ddf9fNu3bpV3944aGBe7eCB6Xhcg+fh+YDlqfa+Fwjg9fC6GqyPts9iPTEv1huwHdgeDbYT2wvYfsyL9gC0j+EZGrQf2hG0qwKinQHtjvvalwneF8Oa1Hjf8P4B3k/Mqx2c8X4bVkzB/oD9ArCfYF7twHjkyBHZtWuXfl4M/jx9+rT+AIp5tQM79k/Dzz32X+zHgP0a82oHYLQ39n8NjxHWOUZogQDeM8OBu3hP8d4C3mvMy2MEjxH2fIzYsnOnlPxkrvj2ej1tv/7icwkf/77ERUU5TBxhMZ2dSEhI0Lm4uOg2btxoNL1Xr1669u3bm31OuXLldLNnzzaaNn78eF2dOnUyfJ34+Hjd3bt39begoCC847pLly7p57l9+7YuKipK/Z2UlKQLCwtT6wcxMTG68PBw/bx37tzRRUZGqr9TUlKM5o2NjVX3NREREeo1DefF+kBcXJy6n5qaqu5r6weYhscwj7YNuI9laPNi2Ro8htfW2tVwXqwr1lmDbcE2Gc6LbQa0AdpCc+vWLf28iYmJRvNGR0erxw3n1dow5sQxXdCod3UXG9TWXaz9kLpd+l9D3e15s3VJwcFG7Z2cnJyuvQ3b0Fx7a21oSXtrbWiuvU3bMLP2NmxDc+2N7dDaMKP2Nm1Dc+2NdjXcDzNqb3P7LJaf0T6bUXubtiHmzWqfNdfepvusNq8l+6xpe5vus3jMdJ81bG/DNsyqvU33WdP2NmzDrNqbx4icHyOy2md5jOAxoiAfI4KXLtFdrPuI+m68/npPXejFCwU+jrh7966KvbT1y0yOBnvZCgZ7NWzYUJUB03p1ypcvLwMHDsxwsBd+ZRn22OEyunXq1OFgLxvTJSdL7O6dErlyucQfTPv1CO7Va6rBW95t2oqzh4dN15GIiCg/iP3jNwkdMVR0sbHiVqmyqnDgVjZvBtoXmMFe+QEGbvXu3VsaNGigAto5c+ao7unXXntNPY6rjpUpU0alBwAGojVt2lQ++eQTadeunaxevVqdBv3iiy9svCWOKyXijkRtWCeRq1dKSnDaKX/UzvN+tnVa9YG6j7H6ABERkYFC/2sqpZetkuAB/SXp0kW50eMVCZi7UDzrPubw7WRXgSx6WHEFsfHjx6ucDJTRQh6gNqDr6tWrqpKBYe/rypUrZezYseoSu9WqVVN5HbVq1bLhVjimxLOn5e7K7yRmy2bR3ctbQmkRn5e7iG/nbuIaGGjrVSQiIsq33B96REqvWCshg96WxFMnJLhvL/GbNlMKt24rjsyuUgtsgXVkHzB94LfdqnxW/L/3r8Dm/kh18e3RS7zbtGP6ABERUTakxsaqSgaxe9IGpRUbMlyKvP5GgTqbmZ3YK1tX9tIsX75cnnzySXU1L22EG07z//DDDzlbYypQcGm9iKVL5NrzrSR02MC0IBbpA63aSKlvVkjpNRvFp0MnBrFERETZ5FyokJScPV98X+2t7t/57BMJnzhWXfnSEWU7kP38889Vrmrbtm1VqR+tXE7RokVVMEuOfUWS8MnjJejZpnJn9ixJvnFdnIsWlSJ9+0u5X3ZKyY8/E896DQrUr0YiIqK85uTiIiVGvi8lxozD1aEkeuP3EvzOG5JyrzSYI8l2agEugjB9+nTp2LGj+Pj4qBpglStXVvXUmjVrZlSYtyBgakHmdCkpaekDK5A+kFaTFdwffuR++oCnp9XfJyIiIkcU+/seCR0xTHRxseJWuYoEzF9s9xUNrFq1AEXJH3ss/Sg5Dw8PfYFbKvhSIu9K9IbvJXL1CtXzqjg7S6EWz0qR7r3Eo1599rwSERFZWaGnm0mpb1dKyMA3JeniBbnxahcJmPu5eNap6xBtn+1AtlKlSurKFxUqVDCajuoB1atXz811o3wo8fw5iVy1XKJ/3Cy6+LSrUzkXKSo+L78ivq90E9dSpW29ikRERA7F45HqUvq7dRIy+C1JPH1Kgvv2FP/ps1Rpy4Iu24Es8mMHDBigLkWGrIT9+/fLqlWrVO3WJUuWWGctyfbpA7/vSbt4wT979dPdH3o47eIFbV9g+gAREZENuQYGqgHVoSPflTikGwwfLMWGjZAiffoW6DOkOSq/tWLFCpk4caL++vGoXjBp0iTp27evFDSOnCOLpPHoTeslctV3knz92v30gWdaim+PnuJZ//EC/eEgIiKyx86n27NmqM4nQL12DApzcnOTghh7PVAdWVz+NTo6WkqWLCkFlSMGsokXzqvgNXrzpvvpA75FxOelzuLTpbu4lS5j61UkIiKiTNxdsUwFtJKaKp6Nn5SAjz8TZx8fsQd5Fsg6AkcJZPELLu6P3+Qu0gf2/a2f7lb1ISmC6gNtnxdnLy+briMRERFZLnbPLpVqgE4ptyrVJGDBYrvojMr1QBZVCiw9hXzo0CEpSAp6IKvSB37YkJY+cC3IIH2ghcp/9WzQkOkDREREdirh5AkJGdRfUsLCxKWEnwTM+1w8atURhyq/hZqxGgzyWrhwoaon27hxYzVt3759cuLECXnnnXcedN0pjyRevHA/fSAuVk1z9vG9nz5QpizfCyIiIjvnUaOmlF6xTkIG9pfEs2fk5us9xX/Gx+Ld4lkpCLKdWtCvXz8pVaqUTJkyxWj6hAkTJCgoSL7++mspSApSj6wuNVXi/vxdJYDH/f2nfjpON2DwVmFUHyhUyKbrSERERLkvNSZaXTgBcYA4OUnxd0eKb6/X8uVZV6vmyGLBBw4ckGrVqhlNP3funDRo0EC9aEFSEALZ1KgoiUL1AVy8IOhq2kQnJynUrHla+kDDJ/LljkxERES5R5ecLLc+nCpRa1ep+z6du6ZVNHDNdjVW+72yl5eXl/z111/pAllM8+SlSPOVxEtIH1gh0T9sNE4f6PRyWvqAnV/CjoiIiCyHgLXEBxPErUJFuf3xhxK1brW6OmfJWXPEuXBhsUfZDmSHDh0qb7/9thrU1bBhQzXtn3/+USkF48aNs8Y6UnbTB/76QyJXLDNJH6iqel8Lt2vP9AEiIiIH5eTkJEV69hHXMmUlbPR7Kma40bubBC74QlwDS4m9yVH5rbVr18pnn30mp06dUvdxadohQ4bIK6+8IgWNvaQWpEZHS5RWfeDqlfvpA02fEd/uvcSzEdMHiIiI6L6EE8ckZNDbkhIeJi7+/hIwb5F41KgltsY6sjZqTFtIunxJ5b4iB1YXq6UP+EjhF18W3649mD5AREREGUq+eUOCB/SXpPNnxcnTS/xnfiLez7QQW2Iga6PGzPP0AVQf+OsP/XS3ylXEt9urUviFDuJcyNum60hERET2ITU6WkLfG5KWkoiKBiPGiG+PXjYbCM5A1kaN+aBX1oo/dCCtYLG/v3jWayBOLi7p0wc2b0xLH7hy+X76wNPN1A7n2agxqw8QERFRtumSkuTWh1Mkat0adR8dYwhoEWdkFZ/YVdUCyn0xv26XWzOnSUpIsH6aS0CglBj1gXi3bCVJVy6r4BU5sLqYGPW4U+HC4qOlD5Qrz7eFiIiIcszJzU1KjJ0kbuUqyO3Zs1TcEX/kkKTcCpeU0FCz8YndDvZyJNbukUUQGzp8sIjp24DufJ1O3KvXkMRTJ/WT3SpWSqs+0L4j0weIiIjIOrHJqHdFkpLSP3gv3aDkJ3OtFsyyR9ZOIJ0APbHpglj1YNo0LYj1QvpA957i9UQTcXJ2zutVJSIiIgdR6JkWqu586u1b5uMTJye59dE0NZ+10wyyku3Ugtdffz3TxwvaJWqtSeWcGKQTZMRv+izxeb59nqwTERERObb4QwfMB7EanU5SgoPVfF6PNxK7CmTv3LljdD8pKUmOHz8uERER0rx589xctwIPidOWYA8sERER5bf4JMXC+fJVILtx48Z001JTU9XVvqpUqZJb6+UQMPovN+cjIiIicqT4JFeSLZ2dneXdd9+V2bNn58biHAZKWGD0n5Y4nY6Tk7gEBqr5iIiIiPKCpx3FJ7k2aujChQuSnJycW4tzCEiQRgmLtDsmO8u9+yVGfmDzRGoiIiJyHE52FJ9kO7UAPa+GUL3r5s2bsmXLFundu3durptDQOkKlLBIX0c2QO0k+aVOGxERETkObzuJT7JdR/aZZ55Jl1bg7++vBnqhooGra8G6xkJ+urIXERERUV7S2SA+4SVqbdSYRERERJR3sRcr6xMRERGRXcpRHsD3338va9eulatXr0piYqLRY4cOHcqtdSMiIiIiyr0e2blz58prr70mAQEBcvjwYWnYsKGUKFFCLl68KM8991x2F0dERERElDeB7MKFC+WLL76QefPmibu7u4wcOVJ27NghgwcPVrkM1nL79m3p0aOHypUoWrSo9O3bV6KjozN9TrNmzcTJycno9tZbb1ltHYmIiIgoHweySCdo0qSJ+tvLy0uioqLU3z179pRVq1aJtSCIPXHihAqaf/rpJ/n999/lzTffzPJ5b7zxhioPpt0++ugjq60jEREREeXjQDYwMFD1jkL58uVl37596u9Lly6pmrLWcOrUKdm6dassWbJEGjVqJE899ZTqEV69erXcuHEj0+cWKlRIrbN2Y+UBIiIiIgcNZFEvdvPmzepv5MoOGzZMnn32WenSpYu8+OKL1lhH2bt3r0onaNDg/qXQWrZsqWrY/vPPP5k+d8WKFeLn5ye1atWSMWPGSGxsrFXWkYiIiIjyedUC5MempqaqvwcMGKAGev3999/Svn176d+/vzXWUYKDg6VkyZJG03DhheLFi6vHMtK9e3epUKGClC5dWv777z8ZNWqUnDlzRjZs2JDhcxISEtTNsJYZERERERWAQPbatWtSrlw5/f2uXbuqG9IKgoKCVLqBpUaPHi0zZ87MMq0gpwxzaGvXri2lSpWSFi1ayIULF6RKlSpmnzNjxgyZNGlSjl+TiIiIiPJpIFupUiU1aMq0hxR5s3gsJSXF4mUNHz5c+vTpk+k8lStXVrmtoaGhRtOTk5PVa+IxSyG/Fs6fP59hIIv0g3fffdeoR9YwcCciIiIiOw1k0fOKMlamUArL09MzW8vy9/dXt6w0btxYIiIi5ODBg1K/fn01bdeuXSrFQQtOLXHkyBH1P3pmM+Lh4aFuRERERFRAAlmtlxJB7Lhx41Q1AA16YTHo6tFHH7XKSlavXl3atGmjSmktWrRIkpKSZODAgSqlAfmvcP36dZU2sGzZMnWRBqQPrFy5Utq2bavyeJEji4FpTz/9tNSpU8cq60lERERE+TCQxVW8tB7ZY8eOqYshaPB33bp15b333rPOWt6rPoDgFcEqqhW89NJL6ipjGgS3GMilVSXAOv36668yZ84ciYmJUekBeM7YsWOtsn4I5rEORGRbbm5u4uLiwreBiMgBOOmyWfwVJbc+++wzh6nHihzZIkWKqKuWmdtmNB8qJyD1gYjyB5TrQ/68uTQoIiKy79jrgXJkly5d+iDrVuBoQSwGvyHdgl+cRLaDH5Y4K6MNDs0sH56IiOxftgNZMk4n0IJY5OESke3h0tmAYBafTaYZEBEVXNm+shfdp+XEGg58IyLb0z6TzFsnIirYGMjmAqYTEOUv/EwSETkGBrLkEHr27CnTp0+X/Or06dPyxBNPqFrM1ipjl9e5qriyHi4jjaBSq+GcmcuXL1s0L8ruffLJJ7m4tkREZK8YyDqgZs2aydChQ8XenDhxQpVQq1ixogp4UFrNEkePHpWff/5ZBg8erJ+GZVj6/LwwYcIE8fb2ViXkdu7c+UDLyg/btnXrVvnmm2/kp59+UlcCrFWrVpbPQYk8w3n37Nmj3mfTiiAooTdt2jQ1mpWIiBwbA1nKNxC4IAjLCEaj45LFH374YbYuTTxv3jzp3LmzFC5cONuD+XD1uLyAC3g89dRTUqFChRwPHExMTMz19crpOmB7UDGgSZMm6r1ydc16XCkGZVkyLwJdXGL6u+++y7X1JiIiO4U6spSxu3fvos6u+t9UXFyc7uTJk+p/e9G7d2+1PYa3S5cu6ZKTk3Wvv/66rmLFijpPT0/dQw89pJszZ47Rc5s2baobMmSI0bQOHTqoZeaG3bt36ypUqGDRvJhv9uzZWc6H7SpSpIjup59+MtoO0zaApUuXqnl/+OEHXfXq1XUuLi6qbfbv369r2bKlrkSJEjpfX1/d008/rTt48KDR62AZX375pa5jx446Ly8vXdWqVdVyNLdv39Z1795d5+fnp9oXj3/99df65xreJkyYoKZfvXpV17lzZ7VOxYoV07Vv316tjwbtjvafOnWqrlSpUuq9y2jbzMFjCxcu1LVp00atU6VKlXTr1q0zmmfkyJG6atWqqW3C42PHjtUlJibqH8e61q1bV207Xt/JySndPqa9p7/88ovuySefVNtTvHhxXbt27XTnz5/XLwvbhvkPHz6s/9vwZrifTZo0SffUU09luG32+NkkIqKsYy9T7JF1MLiYRePGjdXlfnEaFzec0kXPY9myZWXdunVy8uRJGT9+vLz//vuydu3abC3/rbfeUj2fmd3yEi5NjFPQDRo00E/bsGGD2tbJkyfr28Cw13fmzJmyZMkSlcqA8k1RUVHSu3dv+fPPP2Xfvn1SrVo1deljTDc0adIkeeWVV9Rr4vEePXrI7du31WO4rDPa9ZdffpFTp07J559/Ln5+fuoxvH7NmjVl+PDh6m9cIQ+j7Vu3bi0+Pj7yxx9/yF9//aXaDpdqNux5RRoC0hF27NihTuNntm3mYL2QroH0C6wv8k+xfhq8PlIEsO7Yd7788kuZPXu20TLOnz8v69evV6+N/FbMh9fHeuD1//33XzUfrrCHS10fOHBArTeu0Pfiiy+a7fXGPollArYPy8FyNbgM9f79+yUhISHLfYCIiAou1pG1grDYCAmLM87r83X3lrI+/pKQkigXIm6ke06NEmmn1C/dvSlxycZfzmUK+0kRj8JyOz5SgmPSAiONt5unVPC1/DQ7rpSBy/eiPJHh6Xmc1kUgpqlUqZLs3btXBbIIziyFAMaalyrOritXrqhtQ0CqwQAkTEOQZpqigABy4cKF6pLLmubNmxvN88UXX6grR/3222/y/PPP66f36dNHunXrpv7GwDJcQhnBFoLPq1evymOPPaYPqA1TKLTT6QhUtfXBaXMEeAiotRH4uBgJXhcpGK1atVLTkFeLeQwvGZ3RtpmDlIt+/fqpv6dMmaICYqRioA3A8JLOWGe8t6tXr5aRI0fqpyOwXrZsmfj7++un4fW1VAENAmZDX3/9tXoOgmTTHFo8F+8T4L3DdhsqXbq0el1ckATpGERE5JgYyFrBunO75fP/fjCa1q5SY/nwqf4SEnNHuvw8Md1zjvX8Rv0/9u8l8l/4BaPHpj/5prxQuYlsu7Jfpu83zgtsUqqWLG6ZO4HjggULVHCBoCsuLk4FCtkdQY+gwzBozIphDy1yUtHDZjjt1VdflUWLFklOYTs8PDwsLseEgLBOnTpG00JCQlRAhwASRfaxnui5RTsZMnweAkxcVk+7wtTbb7+tArlDhw6pILRjx44qfzQj6CFFTycCQkPx8fEq/1RTu3ZtoyA2u9A7b3rfsGrAmjVrVECO14yOjpbk5OR0lwtEIGkYxGbk3Llzqqf/n3/+kfDwcH1PLNrRksFg5i56gPeBiIgcFwNZK+hc7RlpVvaxdD2yEOBdTNa0TR/IaqY26We2RxZaV2godf2qpuuRzQ3oZUNvG8oaIZhBADVr1iwVdGhwKjgttfI+04LzSC3IahAOAiKNYdCE1xo1apQKGDVZXWM5Kzh9j2AHQbklAR8CJNOgF2kFt27dUqe2EbQhMEYbmQ6ucnNzM7qP5WjB2nPPPad6h1E9Ab2eLVq0kAEDBsjHH3+cYRvVr19fVqxYke4xw6ARAbO1oEce6QboqUeaA3rzsZ+Ylr6ydB1eeOEF1X5IT0CPKtoGAWxOBqlpKRuWBNBERFRwMZC1Av9CRdXNHA8Xd30agTmVimR8bfjinr7q9qAQ0KFX0RByMNFD+M477+inGfb8aUGDYc4llnH8+HF55plncpxaULXq/cD82rVr6hS74bQHpfUo4/S1Ye+yuTbICNoGp9qR9wpBQUGqRzG70H4IinH73//+JyNGjMgwkK1Xr57qDUXvdnaD+exsG3J+e/XqZXQfKRDw999/q8Dzgw8+0D+OYDwn8EMAua4IYrHtgJzjrLYDzG0L9jvk4Gp5xkRE5Jg42MsBIdcRvZ8oQK+d4sUAJgzC2bZtm5w9e1YNAtIG6Rjmim7ZskXdUMAfp8tNa3wi8EIgmtktp9Bzhx5c3PD39evX1d84BZ9Z8Iig0DRoQhv8/vvvahlZBaVom+XLl6tBUGg39FJqp7YthVPqP/zwg1pXDCLDwKzq1atnOD9eA0Fahw4d1GCvS5cuqZ5q1MJFwJ+Z7GwbBvchnQTvOWrZIqd34MCB+u3GaX/0wuJHDVIMNm7cKDlRrFgxVVYM+cVog127dqmBX5lBEI1ebbRVWFiYUU8+2kTLEyYiIsfFQNYBoccUg2lq1KihAj0EK/3795dOnTpJly5dpFGjRqoHzbB3Fl5//XXVm4gevKZNm6qaroa9sdZ248YN1VuIG3qG0ZuJv7XBShnB46an6NFzjEAe9UizOj391VdfyZ07d1RAjCuEIZjMTh6w1rs4ZswYlUf79NNPq/ZHgJgRDMZDMFq+fHn1viDo7du3r8qRzaqHNjvbhrQBrAfWCwO2Vq1apfYLaN++vQwbNkwFtujNRg8tfuDkBNJS8DoHDx5U6QRYLlJXMlOmTBm1fqNHj5aAgAB9gI022LRpk6q8QUREjs0JNbhsvRL5WWRkpMoNRAkn0wACX6joKcMIf1xalPInDPh6+OGH1al608FNjgy9nehhxcAze4LSZVjv7du3ZzgPP5tERAUz9jLFHlkq8JAGgN7GnOS1Uv6DQXUoEUZERMTBXuQQmjVrZutVoFySVSoJERE5DgayRA6KWUVERGTvmFpARERERHaJgSwRERER2SUGskRERERklxjIEhEREZFdYiBLRERERHaJgSwRERER2SUGspQncFnWlStXFvjW7tOnj1WulGWt5ZraunWruhxtamqq1V+LiIjoQTGQzQd0KSkS9+8/Ev3zT+p/3Lf2xQGGDh0qeWXz5s0SEhIiXbt21U+rWLGiukSq6e3DDz9Uj1++fFndP3LkiNiTzz77TL755hurvw4C24kTJxq9p+ba86233jJ63u7du6Vt27ZSokQJKVSokNSoUUOGDx8u169fV4+3adNGXTlrxYoVVt8GIiKiB8ULIthYzK/b5dbMaZISEqyf5hIQKCVGfSDeLVtJQTB37lx57bXXxNnZ+HfT5MmT5Y033jCa5uPjI/YM14a2FbQl2tQQglXN4sWL5Z133pHevXvL+vXr1Y+Jq1evqsv3fvLJJ/Lpp5/qg2S8Zz179szzbSAiIsoO9sjaOIgNHT7YKIiFlNAQNR2P5zYEKb/99pvqOdR67dD7mZKSIn379pVKlSqJl5eXPPzww2qerHpycboby8xIWFiY7Nq1S1544YV0jyFoDQwMNLp5e3tbtB3vv/++NGrUKN30unXr6oO5PXv2SMOGDdUyixYtKk8++aRcuXIlw2X+/fff6rS6p6enNGjQQDZt2mTUK2xJG5mmAKDNBg8eLCNHjpTixYurbTTsSTUHr/Puu++qdUbPKZ5ryVW4ELSatqevr6967Nq1a2o9cPv666/VeiGQRcrHkiVLZPz48frl4L06cOCAXLhwIcvXJCIisiUGsrkIwUZqbKxFt5SoKLn14VQ8ydyCRHQit2ZOVfNZsjxLLzeKwKtx48aq9+7mzZvqVq5cOZUTWbZsWVm3bp2cPHlSBTYIFteuXftAbfLnn3+qAKt69eqSm3r06CH79+83CrZOnDgh//33n3Tv3l2Sk5NVQNm0aVM1be/evfLmm2+qwNScyMhIFcDVrl1bDh06JFOmTJFRo0YZzZPTNvr2229VMP3PP//IRx99pALtHTt2ZDg/ekeRnoCAE+13+/Zt2bhxozwIrHNiYqIKis1B0KwpX768BAQEyB9//PFAr0lERGRtTC3IRbq4OLnyxGO5tTRJCQmRq082sGjuCvsOi5PBaeTMTn27u7vre+80Li4uMmnSJP199Doi+EOQ9sorr+RwG0T1gCIoMk0rAASKY8eONZr2yy+/yP/+978sl1uzZk3V+4oBZOPGjVPTkNeJXtqqVauq4O/u3bvy/PPPS5UqVdTjmQXTWA6C3C+//FL1yCJ3FHmjhqkPyB3NSRvVqVNHJkyYoP6uVq2azJ8/X3bu3CnPPvus2fnnzJkjY8aMkU6dOqn7ixYtkm3bthnNYy4Pd+HChap31RDSCRD0nzt3TvXOlipVSixRunTpTHuviYiI8gMGsqS3YMEC1QuIvMm4uDjVg4dT7Q8Cy0FgaM6IESPSpSWUKVPG4mUjQMP6IpBFj/SqVavUKXnAaXwsu3Xr1ipgbNmypQo2Mwrkzpw5owJOw3VFWkJutBGWawjrEBoaanZeBN/oJTdMm3B1dVWpDln1uqM9PvjgA6Np+BEBeG5GvdHmIHUiNjbW4vmJiIhsgYFsLnLy8lI9o5aIP3hAQgYYD3QyJ2DBl+JZv4FFr/0gVq9eLe+99546rY3UA+Svzpo1S50O16BX1TSYSkpKynS5fn5+cufOnQwfQ+9pTnXr1k316iIVAEFlUFCQdOnSRf/40qVLVU4oSkqtWbNG9f7ilP4TTzxhtTYyBz25hhBQWqO8FXrbM2rPhx56SB8kW9Irix5tf3//XF9HIiKi3MQc2VyEAMW5UCGLbl5NnlTVCSSjXjInJ3EJDFTzWbK87PS2IbUAA4oM/fXXX9KkSRM1qv2xxx5TAZHpYB8ENgiENFjG8ePHM30tLCs4ODjDYPZBIF8VObBIKcANPa8lS5ZM9/o4TY+BXLVq1cqwli0Gbh07dkwSEhL00/79999st1FuBKMINA2DY+T7Hjx48IGW+/LLL6v3HTm65kREROj/jo+PV9uFbSQiIsrP7CaQnTZtmgoikNtpODAlM+g9xIAcBAY4VYrTy8gVzA+cXFxUia20OyZB6L37JUZ+oObLbRitjkAJ1QrCw8NV7yByNzFSHbmYZ8+eVafrTQO55s2by5YtW9Tt9OnT8vbbbxsFQOYgGELPK4JAU1FRUSrINbxh0FV24HQ6ekoxmAl/ay5duqQCWOSwItdz+/bt6r3PKE8WA8TQDhgQdurUKdUOH3/8sXpM+5FgSRvlhiFDhqh6uqiagHZG4JxVOwNSAUzbU/sBgQF9s2fPVoP9UHkBlSvQLnhf+vfvrwa3afbt2yceHh6q15mIiCg/s5tAFrmInTt3VsGTpdD7hHqYGCyDwA0jx5EziR6n/AB1Ykt+MldcSqblMWpcAgLUdGvVkcXpcQzuwoAm9LIi3xPBDAYX4dQ88jNv3bqlAihDr7/+uqpB2qtXL9UTWrlyZXnmmWcyfS28DmrImiuwr/3IMLxlNKo+s55GrCuCOMOyV/jBgyDwpZdeUqfVEaAOGDBAbac5GAj1448/qlJbyHlFrqlWkkrLm7WkjXIDLlCAGq5oay2F4cUXX8zyeRioZtqeSL/QYF0R0GMQG5b3yCOPSL9+/dS2Y5/QINcYPwoMa9ASERHlR046S+s25RMYrY1apln1UGGzMPIaQYH2JY0cQQx+wTIMrzKVGfQQ4nQvnqvV5NQgIEbPH0avZzSgyRK4klf8oQOSEhYmLv7+4lmvgVV6Ym0FPYOoMoBc1goVKoi9QPCNIBzvPXr0HQF66JFmgZ5n7Nf2Krc+m0RElPcyi70cZrAXvsQQQCGdQINGQU8aTjdnFMgiR9IwTzK7p7pzAkGr1+Ppi/sXFCjz9dVXX6me3/wcyOIKV+hlRuWEo0ePqoFkqHTgKEEsIN0EZbzsOYglIiLHUWADWQSxhuWHNLivPWbOjBkzjGqFUu4wPO2fX2G/QDoB/sdpeaSyIDfbkaDMF25ERET2wKY5sqNHj9ZfJjWjG/Ic8xIGCKErW7uhpBM5BuTnokdSOy2NwVHMEyUiIsq/bNoji/xV04L4pnCqNye0q1aFhIQY1c3E/cwK2GO0Nm5ERERElL/ZNJDFiHlrFV1Hjh+CWVwKVAtcke+K6gXZqXxARERERPmT3ZTfwkAhlEbC/yjEj79xi46O1s+DckIbN25UfyMtAdUNpk6dKps3b1bF7lE2CpUMcjtf084KPxAVePxMEhE5BrsZ7IVBON9++63+vnbVod27d0uzZs3U32fOnFF5rYY5jzExMaqGKMp1PfXUU+pypblVjke79ChqmDrSyHai/A6fSXOXByYiooLF7urI5rdaZrhkK4JkXBq1UDYvFUtEuQuHMwSxoaGh6gqAhvnxRERkH1hHNg9pg8rwxUlE+QOCWO2zSUREBZfdpBbkV+iBRa8PemSTkpJsvTpEDg/pBLg0MhERFXwMZHMJvjj55UlERESUd+ymagERERERkSEGskRERERklxjIEhEREZFdYo5sFrTqZCgFQURERETWpcVcllSIZSCbhaioKPV/uXLlcuO9ISIiIiILYzDU8s8ML4iQhdTUVLlx44b4+PhY/WIH+AWCgDkoKMjsxReIuJ8QjyfE7x3Ka5F5HJ+gJxZBbOnSpcXZOfMsWPbIZgENWLZsWclL2EkYyBL3E+LxhPi9Q/mJbx7GJ1n1xGo42IuIiIiI7BIDWSIiIiKySwxk8xEPDw+ZMGGC+p+I+wnxeEL83qH8wCMfxycc7EVEREREdok9skRERERklxjIEhEREZFdYiBLRERERHaJgWw+smDBAqlYsaJ4enpKo0aNZP/+/bZeJcpnfv/9d3nhhRdUkWhcoGPTpk22XiXKZ3AMwb5hehswYICtV43yiQ8//FDtE0OHDlX3b9++LYMGDZKHH35YvLy8pHz58jJ48GC5e/eurVeV8lhUVJTaLypUqKD2hSZNmsi///6rfzwkJET69OmjvoMKFSokbdq0kXPnztn0fWIgm0+sWbNG3n33XTUq8NChQ1K3bl1p3bq1hIaG2nrVKB+JiYlR+wZ+9BCZgy+dmzdv6m87duxQ0zt37swGI7V/LF68WOrUqaNvDVy9ErePP/5Yjh8/Lt98841s3bpV+vbtyxZzMP369VPHjOXLl8uxY8ekVatW0rJlS7l+/bq62lbHjh3l4sWL8sMPP8jhw4dVwIvH8d1kK6xakE+gB/bxxx+X+fPn6y+Ni8vB4Vfy6NGjbb16lA+hR2Xjxo3qwEKUEfSu/PTTT6rXxNqX2ab8LTo6WurVqycLFy6UqVOnyqOPPipz5swxO++6devk1VdfVQGKqysvAuoI4uLixMfHRwWp7dq100+vX7++PPfcc9KrVy/Va48fOzVr1tTHKoGBgTJ9+nQVBNsCe2TzgcTERDl48KD6VWN4aVzc37t3r03XjYjs+9jy3Xffyeuvv84gllR6CQIUw++ajCCtAJciZRDrOJKTkyUlJUWlNxpCisGff/4pCQkJ6r7h44hVUFsWj9sKA9l8IDw8XO08AQEBRtNxPzg42GbrRUT2DTnUERERKqeNHNvq1atV2tqMGTMs+k6aMmWKvPnmm3mybpQ/+Pj4SOPGjdV7j1QTxCX4IYwONaQpPfLIIyp/esyYMXLnzh31Q3nmzJly7do19bitMJAlIiqgvvrqK3VKEAMzyHEFBQXJkCFDZMWKFel620xFRkaqXtsaNWrIxIkT82wdKX9Yvny5yoUtU6aM6mmdO3eudOvWTfW8urm5yYYNG+Ts2bNSvHhxNdhr9+7d6hiDx22FiS/5gJ+fn7i4uKjRgIZwH7knRETZdeXKFfn111/VFw85NqSuYeAw8mM16G1DFRSMy8ApY3wHYcQ6RqGjZw759whcyLFUqVJFfvvtN5UbjR81pUqVki5dukjlypX1+bJHjhxRqSfokfX391djfBo0aGCzdWaPbD7g7u6udo6dO3fqpyGBGvfRzU9ElF1Lly6VkiVLGg3aIMfUokULNQIdAYh2Q+DRo0cP9TeCWAQtGKGO76PNmzdn2XNLBZu3t7cKYpFCsG3bNunQoYPR40WKFFFBLAaRHjhwIN3jeYk9svkESm/17t1bHVwaNmyoRpLiF9Frr71m61WjfDbq+Pz58/r7ly5dUl9EOM2D3CUi7YcwAlkcUzhYh9DDWqtWrXSBSokSJdR0LYiNjY1VOZG4jxsgWEGgS45h27ZtKrUA1QnwXTNixAiVG6vFIqhmgX0C3zf4cYSUFVTOwf5jKwxk8wl03YeFhcn48ePVAC+URUEdP9MBYOTY8Mv3mWeeMfoBBAhYUPuRCJBScPXqVVWtgCgrGAT2zz//qL+rVq1q9Bh+LOMiG+QY7t69qwZzYQAXOkheeuklmTZtmj7NBIO68L2D1Ef02KIk17hx42y6zqwjS0RERER2iTmyRERERGSXGMgSERERkV1iIEtEREREdomBLBERERHZJQayRERERGSXGMgSERERkV1iIEtEREREdomBLBERERHZJQayRERWNnHiRHW1vrywc+dOqV69uqSkpFj9tfr06aMuT2ltXbt2lU8++cTqr0NE9odX9iIisrLo6GhJSEhQ17a3tvr166tLSPbo0SNPLmeJ67IXLVrUqq9z/Phxefrpp9XlUosUKWLV1yIi+8IeWSKiHEpMTLRovsKFC+dJEPvnn3/KhQsX1PXRH3SdLYGg0tpBLNSqVUuqVKki3333ndVfi4jsCwNZIiIRiYqKUr2Y3t7eUqpUKZk9e7Y0a9ZMhg4dqm+fihUrypQpU6RXr17i6+srb775ppo+atQoeeihh6RQoUJSuXJlGTdunCQlJWWYWqCdkv/444/VayHIHTBggNFz0IP73nvvSZkyZdQ6NWrUSPbs2ZPpe7V69Wp59tlnxdPTM91rL1myRCpVqqR/LCIiQvr16yf+/v5qW5o3by5Hjx41Wt7UqVOlZMmS4uPjo+YdPXq02e3QoL0GDRqk2qxYsWISEBAgX375pcTExMhrr72mllO1alX55Zdf0vW4Pvfccyrgx3N69uwp4eHhRvO88MILavuIiAwxkCUiElGn4//66y/ZvHmz7NixQ/744w85dOhQurZB8Fm3bl05fPiwClgBAdo333wjJ0+elM8++0wFbwiEM7N7927Ve4r/v/32W/V83DQDBw6UvXv3quDtv//+k86dO0ubNm3k3LlzGS4T69ygQYN008+fPy/r16+XDRs2yJEjR9Q0LC80NFQFlQcPHpR69epJixYt5Pbt2+rxFStWyLRp02TmzJnq8fLly8vnn3+e5b6CbfHz85P9+/eroPbtt99Wr9WkSRPVnq1atVKBamxsrD6gRhD92GOPyYEDB2Tr1q0SEhIir7zyitFyGzZsqJaJAJ+ISE9HROTgIiMjdW5ubrp169bpp0VEROgKFSqkGzJkiH5ahQoVdB07dsxyebNmzdLVr19ff3/ChAm6unXr6u/37t1bLSs5OVk/rXPnzrouXbqov69cuaJzcXHRXb9+3Wi5LVq00I0ZMybD1y1SpIhu2bJlRtPw2ti20NBQ/bQ//vhD5+vrq4uPjzeat0qVKrrFixervxs1aqQbMGCA0eNPPvlkuu3o0KGD/n7Tpk11Tz31lP4+ts/b21vXs2dP/bSbN2/q8NWzd+9edX/KlCm6Vq1aGb1OUFCQmufMmTP6aUePHlXTLl++nOH2E5Hjcb0f0hIROaaLFy+q0/ro9TPM/3z44YfTzWuux3PNmjUyd+5c1cOKgV3JycnqdH1matasKS4uLvr7SDE4duyY+hv/o+oA0hUMZTVgLC4uziitQFOhQgWVQqBBCgHW03RZeD62Ac6cOSPvvPOO0eNon127dmW6XXXq1NH/je3Da9SuXVs/DakDgN5gbV3QK420AlNYF60NvLy81P9aTy4RETCQJSLKBuSrGsLpf+TWTpo0SVq3bq0CYKQDZFUuys3Nzei+k5OTpKamqr8RZCIIxCl9w2AXzAV8GpzSv3PnTpbrjOUjcDaXc/ugg7fMbZfhNNwHw21F/itSGExhHTVayoNhQE5ExECWiBweBmgh2Pr3339VLqhWWurs2bOq7FNm/v77b9Xj+cEHH+inXbly5YHaFPmi6JFFr+X//ve/bD0PebpZQT5scHCwuLq6qgFs5qA3Gu2BgW0a3M9tWBfk72I9sD4ZwYCwsmXLqmCdiEjDwV5E5PAwWKt3794yYsQIdZr7xIkT0rdvX3F2dtb3IGakWrVqcvXqVdULi1PhSDHYuHHjA7UpTqejlxdBJAZooX4qBjrNmDFDtmzZkuHz0COMElxZadmypTRu3FhVHNi+fbtcvnxZBeQIxjHgCjBQ66uvvlKDtzDADBUMMOgsq/bILlRrQG9rt27dVKCMNty2bZuqcmB4UQcMZMNAMSIiQwxkiYhE5NNPP1XB3fPPP68CvSeffFJdIctczqmh9u3by7Bhw1SVAZSmQkCoVTN4EEuXLlWB7PDhw1XvKIJOwx5jcxD8IghHfmtmEIz+/PPPqrcZASMCZ1w9Cz3JWg4rljVmzBhVAgy9pgimUW4rq/bIrtKlS6tqEQhaEaginxblu5DigB8SEB8fL5s2bZI33ngjV1+biOwfr+xFRGQGap+ihityXdE7ay/QqxwZGSmLFy/O9WWjRm1gYKAsX75c8hLKfqGXG73HRESGmCNLRCSi6sKePn1ajcxHfuzkyZNVu3To0MGu2gfpAQsXLlSDqbQezZxAdYBFixapdAUMOFu1apX8+uuvqsZuXkP+8rx58/L8dYko/2OPLBHRvUAWV6/CaXl3d3epX7++SjcwLB3lSFCKC9UE0C44tY/0hrFjx0qnTp1svWpERHoMZImIiIjILnGwFxERERHZJQayRERERGSXGMgSERERkV1iIEtEREREdomBLBERERHZJQayRERERGSXGMgSERERkV1iIEtEREREdomBLBERERGJPfo/kmBHMKJxJbQAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 700x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rows = []\n",
+    "for seed in SEEDS:\n",
+    "    ss = {\"S1_tri\": traj_S1(seed), \"S2_bistable\": traj_S2(seed), \"S3_replicateur\": traj_S3(seed)}\n",
+    "    r = np.random.default_rng(1000 + seed)\n",
+    "    summ = S.cross_substrate_summary(ss, r, n_shuffles=N_SHUF_SEED)\n",
+    "    rcx = S.rank_consistency(summ, \"ei_real\", \"ec_gain\")\n",
+    "    credited = tuple(sorted(k for k, v in summ.items() if v[\"credited\"]))\n",
+    "    rows.append({\"seed\": seed, \"tau\": rcx[\"kendall_tau\"],\n",
+    "                 \"consistent\": rcx[\"consistent\"], \"credited\": credited})\n",
+    "\n",
+    "print(f\"{'graine':>6s} {'tau':>6s} {'consistent':>11s}  ensemble credite\")\n",
+    "print(\"-\" * 60)\n",
+    "for row in rows:\n",
+    "    print(f\"{row['seed']:6d} {row['tau']:+6.2f} {str(row['consistent']):>11s}  \"\n",
+    "          f\"{{{', '.join(row['credited']) if row['credited'] else '(aucun)'}}}\")\n",
+    "\n",
+    "taus = [row[\"tau\"] for row in rows]\n",
+    "n_consistent = sum(row[\"consistent\"] for row in rows)\n",
+    "credited_sets = {row[\"credited\"] for row in rows}\n",
+    "print(f\"\\ntau observes : {sorted(set(round(t, 2) for t in taus))}\")\n",
+    "print(f\"consistent = vrai sur {n_consistent}/{len(rows)} graines\")\n",
+    "print(f\"nombre d'ensembles credites distincts : {len(credited_sets)}\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 3.0))\n",
+    "ax.axhline(1.0, color=\"#2ca25f\", ls=\"--\", lw=1, label=\"tau=+1 (transfert parfait)\")\n",
+    "ax.axhline(0.0, color=\"#999999\", ls=\":\", lw=1)\n",
+    "ax.plot(range(len(SEEDS)), taus, \"o-\", color=\"#de2d26\", label=\"tau (EI vs gain d'EC)\")\n",
+    "ax.set_xticks(range(len(SEEDS))); ax.set_xticklabels([str(s) for s in SEEDS])\n",
+    "ax.set_xlabel(\"graine (regime)\"); ax.set_ylabel(\"tau de Kendall\"); ax.set_ylim(-1.15, 1.15)\n",
+    "ax.set_title(\"Gate 3 - le transfert est-il stable d'un regime a l'autre ?\"); ax.legend()\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d88bb2e9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006015,
+     "end_time": "2026-07-02T10:05:44.939916+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:44.933901+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du gate 3\n",
+    "\n",
+    "**Non seulement rien ne transfère, mais la créditation elle-même est régime-dépendante.** Sur cinq\n",
+    "graines (cinq régimes d'aléa), `consistent` n'est vrai que **1 fois sur 5** — et cette unique\n",
+    "« cohérence » (graine 42) est **dégénérée** : elle ne crédite que S2, si bien qu'un classement à un\n",
+    "seul élément est trivialement « cohérent ». L'**ensemble crédité varie** d'une graine à l'autre —\n",
+    "trois ensembles distincts : les trois substrats (graine 0), {S2, S3} (graines 1, 7, 99), {S2} seul\n",
+    "(graine 42) — et $\\tau$ oscille dans {−0.33, +0.33, +1.0}. Concrètement : **S2 (bistable) est crédité\n",
+    "partout (5/5)**, S3 (réplicateur) presque partout (4/5), **S1 (tri) une seule fois (1/5)**. La question\n",
+    "« quels substrats émergent ? » n'a donc pas de réponse absolue — elle dépend du régime. C'est\n",
+    "*exactement* le motif que la série a rencontré **à l'intérieur** de chaque substrat — ICT-10 ($\\hat p$\n",
+    "utile en régime $a<0$ seulement), ICT-11 (aucune granularité privilégiée), ICT-12 ($\\hat p$ ne paie\n",
+    "que dans certains environnements), ICT-13 (stratégie stable dans un paysage donné seulement) —\n",
+    "reproduit ici **un cran plus haut**, entre substrats.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa646beb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012819,
+     "end_time": "2026-07-02T10:05:44.962352+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:44.949533+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Verdict sans complaisance\n",
+    "\n",
+    "**Réponse à la question centrale : *non*, aucun scalaire d'intégration ne transfère entre substrats.**\n",
+    "\n",
+    "- Les scalaires *bruts* co-varient (EI réelle vs EC réelle, $\\tau$ = +1.00) — un mirage de magnitude\n",
+    "  qui donne l'illusion d'une grandeur commune.\n",
+    "- Mais l'**émergence créditée** — la seule que la série consent à reconnaître, celle qui bat son\n",
+    "  contrôle dégénéré — **réordonne** les substrats (gate 2, $\\tau$ = −0.33) et **change de membres**\n",
+    "  selon le régime (gate 3, cohérent 1/5, trois ensembles crédités distincts).\n",
+    "\n",
+    "**Ce qui transfère, c'est la méthode, pas le nombre.** Le *même* appareil — estimer la structure\n",
+    "causale le long de la trajectoire propre d'un système, puis ne créditer une émergence qu'au contraste\n",
+    "d'un contrôle dégénéré — s'applique **sans modification** aux trois substrats et rend à chaque fois un\n",
+    "verdict falsifiable (gate 1 : 3/3 crédités à la graine représentative). Mais les **verdicts** qu'il\n",
+    "produit sont **régime-bornés** : ils dépendent du substrat *et* du régime, jamais d'un invariant\n",
+    "numérique unique.\n",
+    "\n",
+    "C'est la thèse d'ICT jouée un niveau au-dessus. À l'intérieur d'un substrat, chaque notebook a montré\n",
+    "qu'une capacité est réelle mais **régime-dépendante** ; entre substrats, on retrouve la même chose sur\n",
+    "la capacité la plus abstraite de toutes — « émerger ». L'invariant de la série n'est donc pas $\\Phi$,\n",
+    "ni l'information effective, ni un « niveau d'intégration » : c'est la **discipline de mesure** —\n",
+    "mesurer ce que le système fait vraiment, et ne rien créditer qui ne batte son propre contrôle\n",
+    "dégénéré. Le livrable du capstone est cette honnêteté-là, pas un scalaire de plus.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47130e32",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011898,
+     "end_time": "2026-07-02T10:05:44.984412+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:44.972514+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Exercices\n",
+    "\n",
+    "Trois exercices à compléter. Convention C.1 : stub **sans erreur volontaire**\n",
+    "(`pass` / `return None` / `# TODO etudiant`) — le notebook s'exécute de bout en bout même non\n",
+    "complété. Chaque exercice est une **extension falsifiable** de la synthèse.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fee11470",
+   "metadata": {
+    "papermill": {
+     "duration": 0.020831,
+     "end_time": "2026-07-02T10:05:45.017147+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:44.996316+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — un quatrième substrat\n",
+    "\n",
+    "Ajoutez un substrat issu d'une **autre strate** — par exemple le champ de réaction-diffusion\n",
+    "d'[ICT-9](ICT-9-AgencyRegeneration.ipynb) résumé par une statistique scalaire discrétisée, ou une\n",
+    "trajectoire de $\\Phi$ d'[ICT-1](ICT-1-PhiTrajectories.ipynb). Rejoint-il l'ensemble crédité ?\n",
+    "Déplace-t-il le classement (gate 2) ?\n",
+    "\n",
+    "- *Étape 1* : construire une trajectoire `traj_s4` (liste d'états discrets grossiers).\n",
+    "- *Étape 2* : appeler `S.emergence_gain(traj_s4, rng, n_shuffles=N_SHUF)` et comparer `credited`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6bec4eaf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:05:45.052039Z",
+     "iopub.status.busy": "2026-07-02T10:05:45.051040Z",
+     "iopub.status.idle": "2026-07-02T10:05:45.065893Z",
+     "shell.execute_reply": "2026-07-02T10:05:45.065893Z"
+    },
+    "papermill": {
+     "duration": 0.029795,
+     "end_time": "2026-07-02T10:05:45.065893+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:45.036098+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : definir traj_s4 (liste d'etats discrets).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 - a completer\n",
+    "traj_s4 = None  # TODO etudiant : liste d'etats discrets d'un 4e substrat (ICT-9 ou ICT-1)\n",
+    "if traj_s4 is not None:\n",
+    "    g4 = S.emergence_gain(traj_s4, np.random.default_rng(4), n_shuffles=N_SHUF)\n",
+    "    print(f\"S4 : credite={g4['credited']}  ec_gain={g4['ec_gain']:+.3f}  n_etats={g4['n_states']}\")\n",
+    "else:\n",
+    "    print(\"Exercice 1 a completer : definir traj_s4 (liste d'etats discrets).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63eea193",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012377,
+     "end_time": "2026-07-02T10:05:45.098763+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:45.086386+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — robustesse à la discrétisation\n",
+    "\n",
+    "Le verdict dépend-il du **grain** de discrétisation ? Reprenez S2 (le bistable) avec un binning\n",
+    "plus fin (par ex. 20 bins au lieu de 10) et un plus grossier (5 bins), et vérifiez si son statut\n",
+    "`credited` et le $\\tau$ du gate 2 survivent. Une discrétisation qui **fabrique** l'émergence est un\n",
+    "piège que la série dénonce (ICT-7/9).\n",
+    "\n",
+    "- *Étape 1* : écrire `traj_S2_grain(seed, n_bins)` (copie de `traj_S2` paramétrée).\n",
+    "- *Étape 2* : recalculer `emergence_gain` pour `n_bins ∈ {5, 10, 20}` et comparer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8c4e2ab9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:05:45.115692Z",
+     "iopub.status.busy": "2026-07-02T10:05:45.115692Z",
+     "iopub.status.idle": "2026-07-02T10:05:45.125167Z",
+     "shell.execute_reply": "2026-07-02T10:05:45.125167Z"
+    },
+    "papermill": {
+     "duration": 0.016447,
+     "end_time": "2026-07-02T10:05:45.127229+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:45.110782+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : balayer n_bins in {5, 10, 20}.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 - a completer\n",
+    "def traj_S2_grain(seed, n_bins):\n",
+    "    \"\"\"TODO etudiant : copier traj_S2 en parametrant le nombre de bins.\"\"\"\n",
+    "    return None  # remplacer par la trajectoire discretisee a n_bins deciles\n",
+    "\n",
+    "resultats = None  # TODO etudiant : dict {n_bins: emergence_gain(...)}\n",
+    "if resultats is not None:\n",
+    "    for nb, g in resultats.items():\n",
+    "        print(f\"n_bins={nb:2d} : credite={g['credited']}  ec_gain={g['ec_gain']:+.3f}\")\n",
+    "else:\n",
+    "    print(\"Exercice 2 a completer : balayer n_bins in {5, 10, 20}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68b27b12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004481,
+     "end_time": "2026-07-02T10:05:45.138610+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:45.134129+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — un contrôle dégénéré plus dur\n",
+    "\n",
+    "Le contrôle par permutation totale détruit **tout** l'ordre temporel. Un contrôle plus exigeant\n",
+    "préserve l'ordre **à courte portée** : le *block-shuffle* permute des **blocs** contigus de longueur\n",
+    "$b$ (il garde la dynamique locale, casse la globale). Sous ce contrôle plus dur, le gain crédité\n",
+    "**rétrécit-il** ? De combien ?\n",
+    "\n",
+    "- *Étape 1* : écrire `block_shuffle(states, rng, b)` (permutation de blocs de longueur `b`).\n",
+    "- *Étape 2* : recalculer le gain d'EC de S1/S2/S3 contre ce contrôle et comparer au shuffle total.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "edfda9d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:05:45.163079Z",
+     "iopub.status.busy": "2026-07-02T10:05:45.163079Z",
+     "iopub.status.idle": "2026-07-02T10:05:45.171408Z",
+     "shell.execute_reply": "2026-07-02T10:05:45.170274Z"
+    },
+    "papermill": {
+     "duration": 0.021511,
+     "end_time": "2026-07-02T10:05:45.172390+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:45.150879+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : implementer block_shuffle et comparer au controle total.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 - a completer\n",
+    "def block_shuffle(states, rng, b=10):\n",
+    "    \"\"\"TODO etudiant : decouper en blocs de longueur b, permuter l'ordre des blocs.\"\"\"\n",
+    "    return None  # remplacer par la trajectoire block-shufflee\n",
+    "\n",
+    "# Indice : comparer S.trajectory_battery(block_shuffle(...)) a S.trajectory_battery(states)\n",
+    "print(\"Exercice 3 a completer : implementer block_shuffle et comparer au controle total.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a309752b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019694,
+     "end_time": "2026-07-02T10:05:45.219658+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:05:45.199964+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Pour aller plus loin\n",
+    "\n",
+    "- [ICT-0 — Cadrage de la série](ICT-0-Framing.md) : les deux articles fondateurs (Levin ;\n",
+    "  Jansma & Hoel), le principe méthodologique *sans complaisance*, la feuille de route.\n",
+    "- [ICT-6 — Pont tri → TPM](ICT-6-SortingToTPM-CausalEmergence.ipynb) : le pont trajectoire → TPM\n",
+    "  que ce capstone généralise à trois substrats.\n",
+    "- [ICT-5 — Émergence causale](ICT-5-CausalEmergence.ipynb) : la batterie causale (déterminisme,\n",
+    "  dégénérescence, information effective) branchée ici sans modification.\n",
+    "- Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588) — registre des livrables ICT ;\n",
+    "  design du capstone : [#4946](https://github.com/jsboige/CoursIA/issues/4946).\n",
+    "\n",
+    "---\n",
+    "*ICT-Synthèse — un seul appareil de mesure, trois substrats. Epic #4588. Voir\n",
+    "[ICT-0-Framing](ICT-0-Framing.md) pour le cadrage de la série.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 95.701367,
+   "end_time": "2026-07-02T10:05:45.582681+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "ICT-Synthese-CrossSubstrat.ipynb",
+   "output_path": "ICT-Synthese-CrossSubstrat.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-02T10:04:09.881314+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

Capstone du fil **ICT** (*Integrated Causal Trajectories*, Epic #4588). Un **seul appareil de mesure** — trajectoire → TPM état-à-état (pont [ICT-6](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb)) → batterie d'émergence causale ([ICT-5](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb)/6, module `ict.synthesis` livré en #4948) — appliqué **à l'identique** à trois substrats de strates différentes :

- **S1** — tri auto-organisé (strate 1, ICT-2/6), état = nombre d'inversions
- **S2** — paysage bistable SDE juste sous le pli (strate 2, ICT-8), état = décile de biomasse
- **S3** — réplicateur stratégique IPD/Axelrod (strate 3, ICT-13), état = stratégie dominante

**Question falsifiable centrale** : existe-t-il *un* scalaire d'intégration qui transfère d'un substrat à l'autre, ou le seul invariant de la série est-il la **méthode** (créditer une émergence uniquement contre son propre contrôle dégénéré) ?

## Contenu (les 2 cadrages ai-01)

1. **Tableau récapitulatif de la série (ICT-0..13)** — une ligne par notebook : question centrale → verdict réel committé + chiffres des gates. C'est la valeur capstone : on y lit le fil *régime-dépendance* qui traverse ICT-10 → ICT-13.
2. **Runtime borné** : exécution complète **~98 s** (papermill, kernel `coursia-ml-training`), bien sous la cible <8 min. Discrétisation grossière (6–12 états/substrat) + trajectoires sous-échantillonnées, trade-off documenté dans le notebook.

## Trois gates falsifiables (résultats réels exécutés)

| Gate | Question | Résultat |
|------|----------|----------|
| **1** | L'émergence bat-elle le contrôle dégénéré (shuffle temporel) ? | **3/3 crédités** ($z$ > 1) — l'appareil mesure de la dynamique, pas du réservoir d'états |
| **2** | Un scalaire d'intégration transfère-t-il entre substrats ? | EI vs EC brutes $\tau$=+1.00 (mirage de magnitude) **mais** EI vs gain crédité $\tau$=**−0.33** → **NON** |
| **3** | La créditation est-elle robuste au régime (5 graines) ? | cohérent **1/5** (et dégénéré), **3 ensembles crédités distincts** → **NON**, régime-dépendant |

**Verdict sans complaisance** : aucun scalaire ne transfère ; ce qui transfère est la **méthode** (estimer la structure causale le long de la trajectoire propre, ne créditer qu'au contraste d'un contrôle dégénéré), pas un nombre. La thèse ICT jouée un cran au-dessus.

## Conformité

- ✅ **C.2** : committé avec outputs (11/11 cellules code, exec_count set, 0 erreur, 3 figures rendues)
- ✅ **C.1** : 0 pattern interdit (`raise NotImplementedError`/`assert False`/`1/0`)
- ✅ **3 exercices** (stubs `= None # TODO etudiant`) : 4e substrat, robustesse à la discrétisation, contrôle block-shuffle plus dur — notebook s'exécute end-to-end
- ✅ Catalogue byte-identique à main (aucun `COURSE_CATALOG.*` / marqueur `CATALOG-STATUS` touché)
- ✅ Kernelspec générique `python3`

## Suites (follow-ups séparés, après merge)

- Ligne README ICT-Synthèse + passage roadmap ICT-0-Framing 🚧→✅ (édition atomique docs-only)

See #4588. Closes #4946 (design-track entierement adresse par ce capstone — table recap 14 lignes, runtime 98s <8min, 3 exercices C.1, creditedness regime-dependante lue au gate 3 + verdict final).
