### PR TITLE
fix(gametheory): GT-6c typographic hierarchy — Étape N inline bold not H1 (#3968)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
@@ -443,8 +443,8 @@
     "\n",
     "**Indice :** calculez le nouveau seuil $\\delta^*=(T-R)/(T-P)$ et comparez-le au DP canonique (0,5). La tentation plus forte rend-elle la coopération plus ou moins facile à soutenir ?\n",
     "\n",
-    "# Étape 1 : vérifier les inégalités du DP et 2R > T+S.\n",
-    "# Étape 2 : calculer le seuil analytiquement.\n"
+    "**Étape 1 :** vérifier les inégalités du DP et 2R > T+S.\n",
+    "**Étape 2 :** calculer le seuil analytiquement.\n"
    ]
   },
   {
@@ -486,8 +486,8 @@
     "\n",
     "**Indice :** plus $N$ est petit, plus la punition est légère, donc plus $\\delta$ requis est élevé. Écrivez $V_D$ pour cette stratégie.\n",
     "\n",
-    "# Étape 1 : exprimer le paiement de déviation (T, puis N tours à P, puis retour à R/(1-d)).\n",
-    "# Étape 2 : pour N=2, trouver numériquement le seuil et le comparer au grim trigger.\n"
+    "**Étape 1 :** exprimer le paiement de déviation (T, puis N tours à P, puis retour à R/(1-d)).\n",
+    "**Étape 2 :** pour N=2, trouver numériquement le seuil et le comparer au grim trigger.\n"
    ]
   },
   {
@@ -530,8 +530,8 @@
     "\n",
     "**Indice :** identifiez les deux équilibres de Nash purs de ce jeu étape. Que dit le Folk Theorem sur les paiements soutenables dans sa version infinie ?\n",
     "\n",
-    "# Étape 1 : trouver les équilibres de Nash purs (matrice 2x2).\n",
-    "# Étape 2 : calculer le paiement de minimax et l'ensemble faisable & IR.\n"
+    "**Étape 1 :** trouver les équilibres de Nash purs (matrice 2x2).\n",
+    "**Étape 2 :** calculer le paiement de minimax et l'ensemble faisable & IR.\n"
    ]
   },
   {


### PR DESCRIPTION
## Resume

`GameTheory-6c-RepeatedGames-FolkTheorem.ipynb` avait **7 H1** dans le notebook : le titre (cell 0) + six lignes `# Étape 1/2 :` d'instructions d'étapes dans les cellules Exercice 1/2/3 (15, 17, 19). Ces lignes rendaient en **grande police** comme titres concurrents du titre du notebook, alors que ce sont des instructions d'étapes qui doivent lire comme labels inline (règle typographique : `# Étape N -> gras inline **Étape N :**`).

**Dernier résiduel GameTheory** sous #3968 — le compte 261 dans le body de l'issue est stale ; au scan actuel seule cette cellule restait.

## Changement (typo SEULEMENT, .claude/rules/... #3968)

Édition chirurgicale text-level (pas de churn JSON), 6 lignes :
```
- # Étape 1 : vérifier les inégalités du DP et 2R > T+S.
+ **Étape 1 :** vérifier les inégalités du DP et 2R > T+S.
```
(idem pour les 6 occurrences Étape 1/2 dans les 3 cellules exercices)

**Rien d'autre touché** : wording des instructions byte-identique, aucun texte d'exercice/indice modifié, aucune cellule ajoutée/supprimée, aucun relabeling Exercice/Exemple.

## Acceptance vérifiée firsthand

```
python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks/GameTheory
=== 0/31 notebooks flagged ===
```
Was 1/31 (ce notebook) → maintenant 0/31. Critère d'acceptance #3968 rempli pour GameTheory.

## Pas de re-exécution (C.2 exception markdown)

Modification **markdown uniquement** (les cellules 15/17/19 sont des cellules markdown) → outputs précédents valides (C.2 : « modifs uniquement markdown -> outputs précédents valides »). Aucun code cell touché, aucun output affecté.

## Pas de collision

#4920 (repeated_games_lean lake, « GT-6c companion ») ajoute un lake Lean sibling (`repeated_games_lean/*.lean`) — vérifié firsthand : il ne modifie PAS le `.ipynb`. Le titre mentionne « GT-6c » car le lake formalise le même contenu, mais 0 fichier `.ipynb` dans #4920.

See #3968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)