### PR TITLE
fix(search): A* informed-search demo optimal + non-degenerate (See #3801)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb
+++ b/MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb
@@ -650,16 +650,16 @@
    "id": "12c6f050",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T20:06:49.793000Z",
-     "iopub.status.busy": "2026-05-14T20:06:49.792522Z",
-     "iopub.status.idle": "2026-05-14T20:06:49.804048Z",
-     "shell.execute_reply": "2026-05-14T20:06:49.802972Z"
+     "iopub.execute_input": "2026-07-02T10:31:17.337915Z",
+     "iopub.status.busy": "2026-07-02T10:31:17.337915Z",
+     "iopub.status.idle": "2026-07-02T10:31:17.349850Z",
+     "shell.execute_reply": "2026-07-02T10:31:17.349850Z"
     },
     "papermill": {
-     "duration": 0.021073,
-     "end_time": "2026-05-14T20:06:49.804977+00:00",
+     "duration": 0.02277,
+     "end_time": "2026-07-02T10:31:17.349850+00:00",
      "exception": false,
-     "start_time": "2026-05-14T20:06:49.783904+00:00",
+     "start_time": "2026-07-02T10:31:17.327080+00:00",
      "status": "completed"
     },
     "tags": []
@@ -670,13 +670,13 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Greedy Best First Search :\n",
+      "Greedy Best First Search (h == 0, sans guidage) :\n",
       "Chemin = ['Sibiu', 'Fagaras', 'Bucharest']\n",
       "Coût = 450\n",
       "\n",
-      "A* Search :\n",
-      "Chemin = ['Sibiu', 'Fagaras', 'Bucharest']\n",
-      "Coût = 450\n"
+      "A* Search (h == 0, = Uniform Cost Search) :\n",
+      "Chemin = ['Sibiu', 'Rimnicu', 'Pitesti', 'Bucharest']\n",
+      "Coût = 418\n"
      ]
     }
    ],
@@ -685,7 +685,7 @@
     "\n",
     "class PriorityQueue:\n",
     "    \"\"\"\n",
-    "    File de priorité (min-heap). \n",
+    "    File de priorité (min-heap).\n",
     "    f est une fonction qui renvoie la priorité de l'élément.\n",
     "    \"\"\"\n",
     "    def __init__(self, order='min', f=lambda x: x):\n",
@@ -716,25 +716,33 @@
     "    \"\"\"\n",
     "    Recherche qui sélectionne en priorité le noeud avec la plus petite valeur f(n).\n",
     "    Couvre Greedy Best First Search (f(n) = h(n)) et A* (f(n) = g(n) + h(n)).\n",
+    "\n",
+    "    On maintient une table 'reached' (état -> meilleur noeud connu) : lorsqu'un chemin\n",
+    "    MOINS CHER vers un état déjà atteint est découvert, on met la table à jour et on\n",
+    "    ré-insère le noeud (decrease-key). Sans cette mise à jour, A* peut renvoyer un\n",
+    "    chemin SOUS-OPTIMAL (cf. AIMA 4e éd., fonction best_first_search) : c'est elle qui\n",
+    "    garantit l'optimalité avec une heuristique admissible. On compte au passage le\n",
+    "    nombre de noeuds développés (attribut best_first_graph_search.n_expanded), pour\n",
+    "    mesurer combien une bonne heuristique cible la recherche.\n",
     "    \"\"\"\n",
     "    node = Node(problem.initial)\n",
-    "    if problem.goal_test(node.state):\n",
-    "        return node\n",
     "    frontier = PriorityQueue('min', f)\n",
     "    frontier.append(node)\n",
-    "    explored = set()\n",
+    "    reached = {problem.initial: node}\n",
+    "    best_first_graph_search.n_expanded = 0\n",
     "    while frontier:\n",
     "        node = frontier.pop()\n",
     "        if problem.goal_test(node.state):\n",
     "            return node\n",
-    "        explored.add(node.state)\n",
+    "        # Entrée périmée : un chemin moins cher vers cet état a été trouvé depuis.\n",
+    "        if node is not reached.get(node.state):\n",
+    "            continue\n",
+    "        best_first_graph_search.n_expanded += 1\n",
     "        for child in node.expand(problem):\n",
-    "            if child.state not in explored and child not in frontier:\n",
+    "            s = child.state\n",
+    "            if s not in reached or child.path_cost < reached[s].path_cost:\n",
+    "                reached[s] = child\n",
     "                frontier.append(child)\n",
-    "            else:\n",
-    "                # Si déjà dans frontier avec un coût plus élevé, on pourrait le mettre à jour\n",
-    "                # (AIMA gère un update plus détaillé).\n",
-    "                pass\n",
     "    return None\n",
     "\n",
     "def greedy_best_first_search(problem, h=None):\n",
@@ -747,24 +755,174 @@
     "    h = h or problem.h\n",
     "    return best_first_graph_search(problem, f=lambda n: n.path_cost + h(n))\n",
     "\n",
-    "# Exemple d'heuristique simpliste pour la carte : h = 0 pour tout le monde\n",
-    "# (donc A* se réduit à un Uniform Cost Search).\n",
+    "# Baseline SANS heuristique : h == 0 pour tous les états (heuristique par défaut de GraphProblem).\n",
+    "# => A* se réduit à Uniform Cost Search (il trouve l'optimum, mais explore à l'aveugle),\n",
+    "#    et Greedy n'a aucun guidage (ordre d'insertion arbitraire).\n",
+    "# La section suivante ajoute une VRAIE heuristique admissible pour voir la différence.\n",
     "solution_greedy = greedy_best_first_search(romania_problem)\n",
     "solution_astar  = astar_search(romania_problem)\n",
     "\n",
-    "print(\"\\nGreedy Best First Search :\")\n",
+    "print(\"\\nGreedy Best First Search (h == 0, sans guidage) :\")\n",
     "if solution_greedy:\n",
     "    print(\"Chemin =\", solution_greedy.solution())\n",
     "    print(\"Coût =\", solution_greedy.path_cost)\n",
     "else:\n",
     "    print(\"Aucune solution (Greedy).\")\n",
     "\n",
-    "print(\"\\nA* Search :\")\n",
+    "print(\"\\nA* Search (h == 0, = Uniform Cost Search) :\")\n",
     "if solution_astar:\n",
     "    print(\"Chemin =\", solution_astar.solution())\n",
     "    print(\"Coût =\", solution_astar.path_cost)\n",
     "else:\n",
-    "    print(\"Aucune solution (A*).\")"
+    "    print(\"Aucune solution (A*).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sld-intro-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008622,
+     "end_time": "2026-07-02T10:31:17.367927+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:31:17.359305+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Avec une vraie heuristique : la distance à vol d'oiseau\n",
+    "\n",
+    "Sans heuristique, A\\* est aveugle : il se réduit à Uniform Cost Search. Donnons-lui une\n",
+    "**heuristique admissible** — la distance à vol d'oiseau (*straight-line distance*, SLD)\n",
+    "jusqu'à Bucharest, la table classique d'AIMA (Fig. 3.22). Elle ne surestime jamais le coût\n",
+    "routier réel, donc A\\* reste **optimal**.\n",
+    "\n",
+    "On compare alors trois recherches sur le même problème (Arad → Bucharest) :\n",
+    "\n",
+    "- **A\\* sans heuristique** (= UCS) : optimal, mais développe beaucoup de noeuds.\n",
+    "- **Greedy Best First** (f = h) : fonce vers ce qui *paraît* le plus proche… et se fait piéger.\n",
+    "- **A\\*** (f = g + h) : combine coût déjà payé et estimation restante → optimal ET ciblé.\n",
+    "\n",
+    "> L'**exercice 2** vous fera *dériver* une heuristique équivalente à partir de coordonnées\n",
+    "> géographiques ; ici on utilise directement la table SLD tabulée d'AIMA.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "sld-demo-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T10:31:17.387635Z",
+     "iopub.status.busy": "2026-07-02T10:31:17.387635Z",
+     "iopub.status.idle": "2026-07-02T10:31:17.404477Z",
+     "shell.execute_reply": "2026-07-02T10:31:17.403442Z"
+    },
+    "papermill": {
+     "duration": 0.024504,
+     "end_time": "2026-07-02T10:31:17.405455+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:31:17.380951+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problème : Arad -> Bucharest\n",
+      "\n",
+      "(1) A* SANS heuristique (h == 0) = Uniform Cost Search\n",
+      "    A* / UCS                       : coût= 418  noeuds développés=12\n",
+      "                                     chemin = Arad -> Sibiu -> Rimnicu -> Pitesti -> Bucharest\n",
+      "\n",
+      "(2) Avec l'heuristique distance à vol d'oiseau :\n",
+      "    Greedy Best First (f = h)      : coût= 450  noeuds développés= 3\n",
+      "                                     chemin = Arad -> Sibiu -> Fagaras -> Bucharest\n",
+      "    A* (f = g + h)                 : coût= 418  noeuds développés= 5\n",
+      "                                     chemin = Arad -> Sibiu -> Rimnicu -> Pitesti -> Bucharest\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<__main__.Node at 0x267b6b689e0>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Heuristique admissible : distance à vol d'oiseau vers Bucharest (table AIMA, Fig. 3.22).\n",
+    "straight_line_to_bucharest = {\n",
+    "    'Arad': 366, 'Bucharest': 0, 'Craiova': 160, 'Drobeta': 242, 'Eforie': 161,\n",
+    "    'Fagaras': 176, 'Giurgiu': 77, 'Hirsova': 151, 'Iasi': 226, 'Lugoj': 244,\n",
+    "    'Mehadia': 241, 'Neamt': 234, 'Oradea': 380, 'Pitesti': 100, 'Rimnicu': 193,\n",
+    "    'Sibiu': 253, 'Timisoara': 329, 'Urziceni': 80, 'Vaslui': 199, 'Zerind': 374,\n",
+    "}\n",
+    "\n",
+    "def h_sld(node):\n",
+    "    \"\"\"Distance à vol d'oiseau (admissible : toujours <= au coût routier réel).\"\"\"\n",
+    "    return straight_line_to_bucharest[node.state]\n",
+    "\n",
+    "def run_search(label, search_fn, problem, **kwargs):\n",
+    "    \"\"\"Lance une recherche et affiche coût, noeuds développés et chemin complet.\"\"\"\n",
+    "    sol = search_fn(problem, **kwargs)\n",
+    "    n = best_first_graph_search.n_expanded\n",
+    "    if sol is None:\n",
+    "        print(f\"{label:34s} : aucune solution\")\n",
+    "        return None\n",
+    "    chemin = [problem.initial] + sol.solution()\n",
+    "    print(f\"{label:34s} : coût={sol.path_cost:4d}  noeuds développés={n:2d}\")\n",
+    "    print(f\"{'':34s}   chemin = {' -> '.join(chemin)}\")\n",
+    "    return sol\n",
+    "\n",
+    "print(\"Problème : Arad -> Bucharest\\n\")\n",
+    "print(\"(1) A* SANS heuristique (h == 0) = Uniform Cost Search\")\n",
+    "run_search(\"    A* / UCS\", astar_search, romania_problem)\n",
+    "\n",
+    "print(\"\\n(2) Avec l'heuristique distance à vol d'oiseau :\")\n",
+    "run_search(\"    Greedy Best First (f = h)\", greedy_best_first_search, romania_problem, h=h_sld)\n",
+    "run_search(\"    A* (f = g + h)\", astar_search, romania_problem, h=h_sld)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sld-reading-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008653,
+     "end_time": "2026-07-02T10:31:17.423317+00:00",
+     "exception": false,
+     "start_time": "2026-07-02T10:31:17.414664+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : ce que l'heuristique apporte\n",
+    "\n",
+    "Trois enseignements, **lisibles directement dans les coûts et les compteurs ci-dessus** :\n",
+    "\n",
+    "1. **A\\* est optimal** — avec ou sans heuristique, il renvoie le coût minimal **418**\n",
+    "   (Arad → Sibiu → Rimnicu → Pitesti → Bucharest). C'est la garantie apportée par la table\n",
+    "   `reached` (mise à jour *decrease-key*) : sans elle, l'ancienne version restait bloquée à\n",
+    "   **450**, un chemin **sous-optimal**, parce qu'elle ne corrigeait jamais le coût d'un état\n",
+    "   déjà placé dans la file.\n",
+    "2. **Greedy se fait piéger** — en ne regardant que l'estimation `h`, il file vers Fagaras\n",
+    "   (qui *paraît* proche de Bucharest) et paie **450** au lieu de 418. Très rapide (**3 noeuds\n",
+    "   développés**) mais **non optimal** : c'est le classique piège glouton d'AIMA.\n",
+    "3. **Une bonne heuristique cible la recherche** — A\\* avec `h_sld` ne développe que **5 noeuds**\n",
+    "   contre **12** pour l'UCS aveugle (`h == 0`), pour le *même* résultat optimal. C'est tout\n",
+    "   l'intérêt de la recherche **informée** : atteindre l'optimum en explorant moins.\n",
+    "\n",
+    "Avec `h == 0`, ces distinctions s'effondrent (A\\* = UCS, Greedy sans guidage) : une heuristique\n",
+    "non triviale est donc indispensable pour *illustrer* ce que fait réellement A\\*.\n"
    ]
   },
   {
@@ -795,7 +953,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c592806d",
    "metadata": {
     "execution": {
@@ -906,7 +1064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "b140a601",
    "metadata": {
     "execution": {
@@ -1010,7 +1168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "7039ed69",
    "metadata": {
     "execution": {
@@ -1201,7 +1359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "e60c287a",
    "metadata": {
     "execution": {
@@ -1269,7 +1427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "8f14667f",
    "metadata": {
     "execution": {
@@ -1355,7 +1513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "25699177",
    "metadata": {
     "execution": {
@@ -1442,7 +1600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "865b06fd",
    "metadata": {
     "execution": {
@@ -1515,7 +1673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "f46baf1b",
    "metadata": {
     "execution": {
@@ -1598,7 +1756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "cfda83c9",
    "metadata": {
     "execution": {
@@ -1658,7 +1816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "aba037e5",
    "metadata": {
     "execution": {
@@ -1767,18 +1925,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.090596,
-   "end_time": "2026-05-14T20:06:50.946001+00:00",
+   "duration": 6.137732,
+   "end_time": "2026-07-02T10:31:18.588621+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Exploration_non_informée_et_informée_intro.ipynb",
-   "output_path": "Exploration_non_informée_et_informée_intro.ipynb",
+   "input_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--dev-CoursIA/88210e0c-f98c-40cf-bfe1-5b36978be52f/scratchpad/exploration_in.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--dev-CoursIA/88210e0c-f98c-40cf-bfe1-5b36978be52f/scratchpad/exploration_exec.ipynb",
    "parameters": {},
-   "start_time": "2026-05-14T20:06:44.855405+00:00",
+   "start_time": "2026-07-02T10:31:12.450889+00:00",
    "version": "2.6.0"
   },
   "polyglot_notebook": {


### PR DESCRIPTION
## Contexte — #3801 axe-2 SOTA (famille Search / Python-mixed)

`MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb` présente la recherche **informée** (Greedy Best First, A\*), mais la section était **doublement dégénérée** — les deux prongs de #3801 :

### Prong A — correctness (workaround dégradé consacré)
`best_first_graph_search` sautait la mise à jour *decrease-key* (`else: pass`) : A\* renvoyait le chemin **sous-optimal 450** *même en tant qu'UCS*, sans jamais atteindre l'optimal **418**. Un solveur d'optimalité qui ne trouve pas l'optimum ne démontre rien.

**Fix (AIMA 4e éd., `best_first_search`)** : table `reached` (état → meilleur noeud, ré-insertion sur chemin moins cher) + saut des entrées périmées + compteur de noeuds développés. Verdict : **RECOVERABLE-LOCAL** (le vrai algorithme SOTA, écrit correctement).

### Prong B — problème trivial
`GraphProblem.h` renvoyait `0` pour tout état → A\* = UCS, l'heuristique n'illustrait rien (analogue au piège **BFS vs A\*** cité dans la règle). 

**Fix** : ajout de la table canonique **distance à vol d'oiseau vers Bucharest** (AIMA Fig. 3.22) comme exemple guidé, + un helper `run_search` affichant coût / noeuds développés / chemin complet.

## Résultat (sorties ré-exécutées, visibles dans le notebook)

| Recherche | Coût | Noeuds développés | Chemin |
|-----------|------|-------------------|--------|
| A\* / UCS (`h == 0`) | **418** | 12 | Arad→Sibiu→Rimnicu→Pitesti→Bucharest (optimal, aveugle) |
| Greedy (`f = h`) | 450 | 3 | Arad→Sibiu→**Fagaras**→Bucharest (piège glouton) |
| A\* (`f = g + h`) | **418** | **5** | Arad→Sibiu→Rimnicu→Pitesti→Bucharest (optimal ET ciblé) |

A\* est **optimal avec ou sans heuristique** (garantie de la table `reached`) ; une bonne heuristique **cible** la recherche (5 noeuds vs 12).

## Conformité
- **Add-only** : exercice 2 (`GraphProblemWithCoords`) intact, aucune cellule d'exemple supprimée (anti-régression OK — insertions >> deletions).
- **Ré-exécuté end-to-end** via papermill (`coursia-ml-training`), **0 erreur** ; sorties injectées chirurgicalement (cellules inchangées restaurées byte-identiques, pas de churn timestamp).
- C.1 clean (aucun `raise NotImplementedError`/`assert False`/`1/0`), C.2 outputs présents, exec_count monotone 1..18.

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)