### PR TITLE
fix(prover): FX-9 honest launcher reporting (status from success, multi iterations from remaining) (See #1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -888,7 +888,18 @@ class MultiAgentSorryProver:
         return {
             "success": success,
             "proof": state.final_proof,
-            "iterations": state.iteration,
+            # FX-9 (#1453, ai-01 L2536 harvest): the multi-agent workflow loops
+            # on the message-level iteration counter (workflow.py) but never
+            # copies it onto the shared state's iteration field, so the count
+            # reported here was stuck at 0 while the workflow looped (observed
+            # ``Iterations: 0/12`` with 13 attempts on the L2536 run). The
+            # workflow DOES keep ``remaining_iterations`` in sync per step
+            # (workflow.py:1167), so the actual loops run is
+            # ``max(0, max_iterations - remaining_iterations)``. ``attempts``
+            # below carries the tactic count (>= iterations via CriticAgent
+            # routing). The autonomous path keeps its own iteration field (it
+            # increments it in its own loop).
+            "iterations": max(0, max_iterations - state.remaining_iterations),
             "attempts": len(state.tactic_history),
             "total_s": round(total_s, 1),
             "config": f"multi-{self.provider}",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -154,7 +154,13 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     trace_path = trace.save(trace_name)
 
     print(f"\n{'='*60}")
-    print(f"RESULT: {result.get('status', 'unknown')}")
+    # FX-9 (#1453, ai-01 L2536 harvest): the prover result dict carries a
+    # boolean ``success`` field, not a string ``status`` field — reading the
+    # latter always fell through to the ``unknown`` default. Derive the
+    # SUCCESS/FAILED label from the boolean to match the prover's own internal
+    # RESULT line (provers.py:880/1580).
+    _success = bool(result.get("success")) if isinstance(result, dict) else False
+    print(f"RESULT: {'SUCCESS' if _success else 'FAILED'}")
     print(f"  Verdict: {result_kind}")
     print(f"  Sorry: {original_sorry} → {final_sorry}")
     _actual_iters = result.get("iterations") if isinstance(result, dict) else None

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1551,6 +1551,77 @@ def test_fx8_gate_same_count_stays_structural_with_verified():
     assert structural is True
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# FX-9 (#1453, ai-01 L2536 harvest): launcher/reporting accuracy. Two lies
+# observed on the L2536 multi-agent run (be9uzhmc1, multi/zai/12, 1757s):
+#   (a) ``RESULT: unknown`` — run_prover_bg read ``result['status']`` which the
+#       prover never sets (it returns ``success``), so the launcher always fell
+#       through to ``unknown``.
+#   (b) ``Iterations: 0/12`` while 13 attempts ran — the multi-agent workflow
+#       increments ``msg.iteration`` (workflow.py:185) but never mirrors it into
+#       ``state.iteration``, so the result's ``iterations`` field was stuck at 0.
+#       The workflow DOES keep ``state.remaining_iterations`` in sync
+#       (workflow.py:1167), so the real loop count is
+#       ``max(0, budget - remaining_iterations)``.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_fx9_multi_result_iterations_derived_from_remaining():
+    """The multi-agent result must report actual loops run, not the stale
+    state iteration field (which the workflow never increments).
+
+    Regression guard: the fix line is unique in provers.py — the early-return
+    paths use the literal ``"iterations": 0``, so the computed form is unique
+    to the main multi-agent return. Catches a reintroduction of the 0-count bug.
+    """
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parent.parent / "prover" / "provers.py"
+           ).read_text(encoding="utf-8")
+    assert (
+        '"iterations": max(0, max_iterations - state.remaining_iterations),' in src
+    ), (
+        "FX-9 violated — multi-agent result iterations must be derived from "
+        "remaining_iterations (max(0, max_iterations - state.remaining_iterations)), "
+        "not the stale per-state iteration field the workflow never updates"
+    )
+
+
+def test_fx9_multi_iterations_formula_matches_l2536_scenario():
+    """The FX-9 iteration formula gives the honest loop count for the L2536
+    harvest scenario: budget 12, workflow ran to the cap (remaining=0) =>
+    12 loops reported (not 0). A session that exited after 3 loops
+    (remaining=9) => 3."""
+    # budget=12, remaining=0 (cap hit, the L2536 case): 12 loops, not 0.
+    assert max(0, 12 - 0) == 12
+    # budget=12, remaining=9 (early exit after 3 loops): 3.
+    assert max(0, 12 - 9) == 3
+    # budget=8, remaining=8 (no loop ran): 0.
+    assert max(0, 8 - 8) == 0
+
+
+def test_fx9_launcher_status_derived_from_success():
+    """The launcher RESULT line must derive SUCCESS/FAILED from ``success``
+    (bool), not the nonexistent ``status`` key (which always yielded
+    ``unknown``).
+
+    Regression guard (FX-7-style source scan).
+    """
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parent.parent / "prover" / "run_prover_bg.py"
+           ).read_text(encoding="utf-8")
+    # The buggy form read the never-set 'status' key.
+    assert "result.get('status'" not in src and 'result.get("status"' not in src, (
+        "FX-9 violated — launcher must not read result['status'] (the prover "
+        "returns 'success', never 'status'); that yielded 'RESULT: unknown'"
+    )
+    # The fix derives the label from the bool 'success' field.
+    assert "result.get(\"success\")" in src, (
+        "FX-9 violated — launcher RESULT line must derive from result['success']"
+    )
+
+
 def test_gate_backward_compat_without_verified_param():
     """Legacy callers (no verified_tactic_count) keep pre-FX-6 behaviour."""
     from prover.provers import _autonomous_success_gate


### PR DESCRIPTION
## Summary

**FX-9 (#1453 launcher reporting)** — fix the two lies ai-01 caught firsthand on the L2536 multi-agent harvest (run `be9uzhmc1`, multi/zai/12, 1757s): `RESULT: unknown` and `Iterations: 0/12` while 13 attempts ran. Renumbered from ai-01's harvest "FX-8 candidate" (msg `1lv05q`) — my FX-8 (#4951, autonomous gate) took the FX-8 slot; this is **FX-9 (reporting-only)**.

Closes the loop on ai-01's `msg-20260702T100944-1lv05q` harvest: "le 2e bloc ment sur les itérations — à corriger quand tu passeras dans run_prover_bg.py / le résumé final."

## The two bugs (verified firsthand)

### 1. `RESULT: unknown` — launcher read a nonexistent field

`run_prover_bg.py:157` did `result.get('status', 'unknown')`. But the prover result dict carries a **boolean `success`** field (provers.py:889/1589), never a string `status`. So `result.get('status')` was always `None` → always printed `unknown`. The prover's own internal RESULT line (provers.py:880/1580) already derived `SUCCESS`/`FAILED` from the boolean correctly — only the launcher summary lied.

**Fix**: derive the label the same way — `_success = bool(result.get("success"))` → `RESULT: {'SUCCESS' if _success else 'FAILED'}`.

### 2. `Iterations: 0/12` while 13 attempts ran — multi-agent count stuck at 0

The multi-agent workflow loops on the **message-level** iteration counter (`msg.iteration`, workflow.py:185) but never mirrors it onto the shared state's iteration field. So the result's `"iterations": state.iteration` (provers.py:891) was stuck at `0` while the workflow looped.

The workflow **does** keep `state.remaining_iterations` in sync every step (workflow.py:1167: `max(0, max_iterations - msg.iteration)`), so the actual loops run is `max(0, max_iterations - remaining_iterations)`.

**Fix** (multi-agent result, provers.py:891): `"iterations": max(0, max_iterations - state.remaining_iterations)`. The autonomous path keeps its own iteration field (it increments it in its own loop). L2536 scenario: budget=12, ran to cap (remaining=0) → now reports `12`, not `0`. `attempts` (len tactic_history) still carries the tactic count (≥ iterations via CriticAgent routing).

## Scope (reporting-only, no gate/prove logic)

- No success-gate, no `_stmt_mutation_guard`, no proof logic touched.
- The double "Trace saved" (prover `trace.save` + launcher `trace.save` to the same path) is cosmetic and deliberately out of scope.
- Harness Python only, **0 `.lean` touched**.

## Verification (G.1 firsthand)

```
$ PYTHONPATH=. python -m pytest tests/test_prover_guards.py -q   # env coursia-ml-training
collected 121 items
.........................................................................................................  [100%]
============================== 121 passed in 2.00s ==============================
```

- **121/121 passing** (118 base + 3 FX-9), **0 regressions**. (`tests/` contains only this file → 121 is the full prover suite.)
- 3 new tests:
  - `test_fx9_multi_result_iterations_derived_from_remaining` — FX-7-style regression guard: the exact fix line is unique in provers.py (early-returns use the literal `"iterations": 0`), so its presence proves the multi return derives from `remaining_iterations`.
  - `test_fx9_multi_iterations_formula_matches_l2536_scenario` — pins the arithmetic: `(budget=12, remaining=0)→12`, `(12, 9)→3`, `(8, 8)→0`.
  - `test_fx9_launcher_status_derived_from_success` — regression guard: launcher must not read the never-set `status` field; must derive from the boolean `success`.
- Guards are **presence-based on the exact fix** (not absence-based on the buggy pattern), so they don't trip on comment documentation — the NanoClaw #4936 △ Mineur lesson applied.

## Notes

- §B applicability: touches the **prover harness** (`run_prover_bg.py`, `provers.py`, test), not `*.lean`. Refactor justification = honest launcher reporting (the harvest block must not lie about status/iterations), directly serving #1453.
- Independent base (origin/main fresh, FX-8 #4951 already merged). No merge-order constraint.
- 3 files, +90/-2, `proof_knowledge.json` (runtime artifact) deliberately excluded.

See #1453
