### PR TITLE
docs(genai): Mermaid Process Framework architecture + human-in-the-loop (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb
@@ -239,6 +239,43 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sk06-mermaid-arch",
+   "metadata": {},
+   "source": [
+    "La même architecture, rendue sous forme de **graphe** : un `Process` encapsule un `State`\n",
+    "partagé, une chaîne de `Step` (Generate → Review → Publish) et un bus d'`Events` qui déclenche\n",
+    "le passage d'une étape à la suivante.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    subgraph PROCESS[\"PROCESS · conteneur du workflow\"]\n",
+    "        direction TB\n",
+    "        STATE[\"STATE<br/>données partagées entre étapes\"]\n",
+    "        S1[\"STEP · Generate\"] --> S2[\"STEP · Review\"] --> S3[\"STEP · Publish\"]\n",
+    "        EV[\"EVENTS<br/>déclencheurs entre étapes\"]\n",
+    "        STATE -.->|lit / écrit| S1\n",
+    "        STATE -.->|lit / écrit| S2\n",
+    "        STATE -.->|lit / écrit| S3\n",
+    "        S1 -.->|émet| EV\n",
+    "        S2 -.->|émet| EV\n",
+    "        S3 -.->|émet| EV\n",
+    "    end\n",
+    "    classDef state fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef step fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "    classDef event fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    class STATE state\n",
+    "    class S1,S2,S3 step\n",
+    "    class EV event\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Le `Process` est le conteneur ; le `State` est la mémoire partagée que chaque\n",
+    "> `Step` lit et met à jour ; les `Events` sont les déclencheurs qui font avancer le pipeline\n",
+    "> `Generate → Review → Publish`. C'est cette séparation *état / étapes / événements* qui permet\n",
+    "> à un workflow d'être repris après un point de contrôle (checkpoint).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2f9b53c7",
    "metadata": {
     "papermill": {
@@ -889,6 +926,34 @@
     "**Note technique** : SK Process Framework (preview) n'a pas encore de primitive dédiée pour human-in-the-loop. Utiliser Dapr Workflows pour cette fonctionnalité en production.\n"
    ],
    "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sk06-mermaid-hil",
+   "metadata": {},
+   "source": [
+    "Le même flux, rendu sous forme de **graphe** avec le branchement conditionnel explicite :\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    G[\"Generate\"] --> R[\"Review · LLM auto\"]\n",
+    "    R --> D{\"Review OK ?\"}\n",
+    "    D -->|oui| P[\"Publish\"]\n",
+    "    D -->|non| W[\"Send webhook<br/>Wait for event\"]\n",
+    "    W -->|humain approuve| P\n",
+    "    classDef step fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "    classDef decision fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef human fill:#f8d7da,stroke:#842029,color:#2c0b0e\n",
+    "    class G,R,P step\n",
+    "    class D decision\n",
+    "    class W human\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Tant que la revue automatique échoue, le process bascule sur un **breakpoint\n",
+    "> asynchrone** : il émet un webhook et **attend un événement externe** (l'approbation humaine)\n",
+    "> avant de publier. En production, cet état d'attente doit être **persisté** (Dapr, Temporal,\n",
+    "> file + base) pour survivre à une pause de plusieurs heures.\n"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Contexte

Filon #4212 (rendre les diagrammes ASCII en Mermaid), famille GenAI/SemanticKernel. SK-06 ProcessFramework portait **deux blocs ASCII d'architecture jamais dessinés** comme diagrammes propres.

## Changement

Ajout d'**une cellule Mermaid markdown juste après chaque bloc ASCII** — additif (l'ASCII est conservé), **markdown-only** (aucune ré-exécution kernel, exempt C.2/C.3) :

1. **`## 2. Architecture du Process Framework`** → graphe `flowchart TB` : conteneur `PROCESS` (subgraph) avec `STATE` partagé, chaîne `Generate → Review → Publish`, bus `EVENTS`, arêtes pointillées lit/écrit + émet, `classDef state/step/event`.
2. **`Interprétation : Human-in-the-Loop`** → graphe `flowchart TD` : flux conditionnel `Generate → Review → {Review OK ?}` → `oui` Publish / `non` webhook+wait → `humain approuve` Publish, `classDef step/decision/human`.

Chaque cellule ouvre par une phrase d'intro référençant l'ASCII directement au-dessus et se ferme par un `> **Lecture.**`, conforme au pattern de la série (SK-08-MCP).

## Vérifications

- `git diff --stat` = **1 fichier, +65 / −0** (2 cellules markdown insérées, aucune suppression).
- **8 cellules code + toutes leurs sorties préservées byte-identical** (markdown-only).
- **Catalogue byte-identical** (`COURSE_CATALOG.generated.*` + marqueurs `CATALOG-STATUS` non touchés).
- Adjacence confirmée : chaque Mermaid suit immédiatement le bloc ASCII qu'il rend.
- JSON valide (`json.load` OK), `indent=1` + newline final (nbformat).

See #4212
Part of #4208