### PR TITLE
docs(genai): Mermaid VectorStore abstraction + Qdrant cluster + RAG prompt (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
@@ -243,6 +243,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sk05-mermaid-vs",
+   "metadata": {},
+   "source": [
+    "La même **abstraction à trois niveaux**, rendue sous forme de graphe : chaque niveau\n",
+    "en encapsule un autre.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    subgraph VS[\"VectorStore — InMemory · Qdrant · Azure · Pinecone …\"]\n",
+    "        subgraph COL[\"VectorStoreRecordCollection — équivalent d'une « table »\"]\n",
+    "            RD[\"VectorStoreRecordDefinition<br/>schéma des records\"]\n",
+    "        end\n",
+    "    end\n",
+    "    style VS fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    style COL fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "    style RD fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** L'encapsulation suit l'analogie SQL : le `VectorStore` est la *connexion à la\n",
+    "> base*, la `Collection` une *table*, la `RecordDefinition` le *schéma* de ses lignes. Changer\n",
+    "> de backend (InMemory → Qdrant) ne change que le niveau externe : le code SK reste identique.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4c5a3336",
    "metadata": {
     "papermill": {
@@ -1012,6 +1037,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sk05-mermaid-qdrant",
+   "metadata": {},
+   "source": [
+    "Le déploiement Qdrant en production décrit plus haut, rendu sous forme de graphe : un\n",
+    "client SK adresse un cluster *sharded* via REST/gRPC.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    APP[\"Application — SK Client\"]\n",
+    "    APP -->|REST / gRPC| CLUSTER\n",
+    "    subgraph CLUSTER[\"Qdrant Cluster\"]\n",
+    "        direction LR\n",
+    "        S1[\"Shard 1<br/>10M docs\"]\n",
+    "        S2[\"Shard 2<br/>10M docs\"]\n",
+    "        S3[\"Shard 3<br/>10M docs\"]\n",
+    "    end\n",
+    "    style APP fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    style CLUSTER fill:#f8f9fa,stroke:#495057,color:#212529\n",
+    "    style S1 fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "    style S2 fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "    style S3 fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Le *sharding* horizontal répartit les documents sur plusieurs nœuds : la\n",
+    "> capacité croît linéairement (millions de docs) et la recherche reste sous-linéaire grâce à\n",
+    "> l'index HNSW. En production, on ajoute des *replicas* par shard pour la haute disponibilité.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "902f7b85",
    "metadata": {
     "papermill": {
@@ -1231,6 +1286,37 @@
     "2. **Hybrid search** : Combiner recherche vectorielle + BM25 (keywords)\n",
     "3. **Metadata filtering** : Filtrer par date, auteur, type avant recherche\n",
     "4. **Chain-of-thought** : Demander au LLM d'expliquer son raisonnement\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sk05-mermaid-rag",
+   "metadata": {},
+   "source": [
+    "Le même **prompt augmenté**, rendu sous forme de graphe — les blocs empilés qui composent\n",
+    "l'entrée envoyée au LLM.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TB\n",
+    "    SYS[\"System — « Tu es un assistant… »<br/>instructions de comportement\"]\n",
+    "    CTX[\"CONTEXTE — Top-K documents<br/>base de connaissances dynamique\"]\n",
+    "    Q[\"QUESTION — saisie utilisateur\"]\n",
+    "    REP[\"RÉPONSE — générée par le LLM\"]\n",
+    "    SYS --> CTX --> Q --> REP\n",
+    "    classDef instr fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef ctx fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    classDef q fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "    classDef rep fill:#f8d7da,stroke:#842029,color:#2c0b0e\n",
+    "    class SYS instr\n",
+    "    class CTX ctx\n",
+    "    class Q q\n",
+    "    class REP rep\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Le *grounding* consiste à injecter le CONTEXTE (documents récupérés par\n",
+    "> recherche vectorielle) entre les instructions système et la question : le LLM répond à\n",
+    "> partir de faits vérifiables plutôt que de sa mémoire, ce qui limite les hallucinations et\n",
+    "> rend les sources traçables. C'est ce prompt que le pipeline RAG assemble à chaque requête.\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Filon #4212 (rendre les diagrammes ASCII en Mermaid), famille GenAI/SemanticKernel. SK-05 VectorStores avait déjà un Mermaid pour le pipeline RAG d'intro, mais **trois blocs ASCII d'architecture restaient non rendus**.

## Changement

Ajout d'**une cellule Mermaid markdown juste après chaque bloc ASCII** — additif (l'ASCII est conservé), **markdown-only** (aucune ré-exécution kernel, exempt C.2/C.3) :

1. **`## 2. Architecture Vector Store SK`** → `flowchart TB` avec subgraphs imbriqués : `VectorStore ⊃ Collection ⊃ RecordDefinition`. Blockquote = analogie SQL.
2. **`Architecture Qdrant en production`** (cellule InMemory-vs-Qdrant) → `flowchart TB` : client SK → cluster Qdrant *sharded* (3 shards) via REST/gRPC. Blockquote = sharding horizontal + HNSW + replicas HA.
3. **`Architecture du prompt augmenté`** (cellule interprétation RAG) → `flowchart TB` : pile `System → Contexte → Question → Réponse`. Blockquote = grounding anti-hallucination.

Chaque cellule ouvre par une phrase d'intro référençant l'ASCII directement au-dessus et se ferme par un `> **Lecture.**`, conforme au pattern de la série (SK-08-MCP). Les trois diagrammes sont **distincts** du Mermaid d'intro pré-existant (pipeline de récupération).

## Vérifications

- `git diff --stat` = **1 fichier, +86 / −0** (3 cellules markdown insérées, aucune suppression).
- **11 cellules code + toutes leurs sorties préservées** (markdown-only).
- **Catalogue byte-identical** (`COURSE_CATALOG.generated.*` + marqueurs `CATALOG-STATUS` non touchés).
- Adjacence confirmée : chaque Mermaid suit immédiatement le bloc ASCII qu'il rend.
- Pas de PR ouverte concurrente sur ce fichier (vérifié `gh pr list`).
- JSON valide, `indent=1` + newline final (nbformat).

See #4212
Part of #4208