### PR TITLE
fix(genai): repair broken navigation links in INDEX.md + DEPLOYMENT.md (See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/DEPLOYMENT.md
+++ b/MyIA.AI.Notebooks/GenAI/DEPLOYMENT.md
@@ -46,7 +46,7 @@ Development  →  Staging  →  Production
 
 - ✅ Environnement configuré ([`00-1-Environment-Setup.ipynb`](00-GenAI-Environment/00-1-Environment-Setup.ipynb))
 - ✅ APIs validées ([`00-4-Environment-Validation.ipynb`](00-GenAI-Environment/00-4-Environment-Validation.ipynb))
-- ✅ Tests passés (voir [TROUBLESHOOTING.md](TROUBLESHOOTING.md))
+- ✅ Tests passés (voir [TROUBLESHOOTING.md (archive)](../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md))
 - ✅ Budget configuré (alertes activées)
 - ✅ Monitoring en place
 

--- a/MyIA.AI.Notebooks/GenAI/INDEX.md
+++ b/MyIA.AI.Notebooks/GenAI/INDEX.md
@@ -323,7 +323,7 @@ MyIA.AI.Notebooks/GenAI/
 ### Exemples Prêts-à-l'Emploi
 
 #### 1. **Science Diagrams** 🔬
-**Fichier** : [`examples/science-diagrams.ipynb`](examples/science-diagrams.ipynb)
+**Fichier** : [`Image/examples/science-diagrams.ipynb`](Image/examples/science-diagrams.ipynb)
 
 **Applications** :
 - Diagrammes cellule végétale/animale
@@ -337,7 +337,7 @@ MyIA.AI.Notebooks/GenAI/
 ---
 
 #### 2. **History & Geography** 🗺️
-**Fichier** : [`examples/history-geography.ipynb`](examples/history-geography.ipynb)
+**Fichier** : [`Image/examples/history-geography.ipynb`](Image/examples/history-geography.ipynb)
 
 **Applications** :
 - Reconstitutions événements historiques
@@ -351,7 +351,7 @@ MyIA.AI.Notebooks/GenAI/
 ---
 
 #### 3. **Literature & Visual Arts** 📖
-**Fichier** : [`examples/literature-visual.ipynb`](examples/literature-visual.ipynb)
+**Fichier** : [`Image/examples/literature-visual.ipynb`](Image/examples/literature-visual.ipynb)
 
 **Applications** :
 - Illustrations scènes littéraires
@@ -365,7 +365,7 @@ MyIA.AI.Notebooks/GenAI/
 ---
 
 #### 4. **Mathematics & Physics** 📐
-**Fichier** : [`examples/mathematics-physics.ipynb`](examples/mathematics-physics.ipynb)
+**Fichier** : *(exemple a venir - notebook non encore publie)*
 
 **Applications** :
 - Diagrammes géométriques annotés
@@ -789,10 +789,10 @@ execute_notebook(
 
 ## Documentation Technique
 
-- [docs/genai-services.md](../../../docs/genai-services.md) — Architecture services GenAI, GPU, modèles, configurations Docker
-- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — Resolution problemes courants, erreurs APIs, scripts diagnostiques
+- [docs/genai/genai-services.md](../../docs/genai/genai-services.md) — Architecture services GenAI, GPU, modèles, configurations Docker
+- [TROUBLESHOOTING.md (archive)](../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md) — Resolution problemes courants, erreurs APIs, scripts diagnostiques
 
-> Historique des investigations (phases 12a/29/30/31 ComfyUI-Qwen) : archive dans [docs/_archives/suivis/genai-image/](../../../docs/_archives/suivis/genai-image/)
+> Historique des investigations (phases 12a/29/30/31 ComfyUI-Qwen) : archive dans [docs/archive/suivis/genai-image/](../../docs/archive/suivis/genai-image/)
 
 ---
 
@@ -800,7 +800,7 @@ execute_notebook(
 
 ### Accès Rapide
 
-**Guide Complet** : [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md)
+**Guide Complet** : [`TROUBLESHOOTING.md` (archive)](../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md)
 
 ### Problèmes Fréquents
 
@@ -938,7 +938,7 @@ img.save('optimized.png')
 1. **Configuration** : Suivre [Quick Start](#quick-start)
 2. **Premier Notebook** : `01-1-OpenAI-DALL-E-3.ipynb`
 3. **Tutorial** : Lire [`dalle3-complete-guide.md`](tutorials/dalle3-complete-guide.md)
-4. **Exemple** : Exécuter [`examples/science-diagrams.ipynb`](examples/science-diagrams.ipynb)
+4. **Exemple** : Exécuter [`Image/examples/science-diagrams.ipynb`](Image/examples/science-diagrams.ipynb)
 
 ### Parcours Recommandé
 


### PR DESCRIPTION
## Résumé

Les deux docs de navigation de tête de la série GenAI (`INDEX.md`, `DEPLOYMENT.md`) pointaient vers des fichiers **déplacés** lors de réorganisations du dépôt. Réparation de tous les liens cassés — **chaque cible est vérifiée présente** au nouveau chemin.

| Lien cassé | Corrigé vers | Cause |
|---|---|---|
| `examples/{science-diagrams,history-geography,literature-visual}.ipynb` | `Image/examples/…` | notebooks déplacés sous `Image/` |
| `../../../docs/genai-services.md` | `../../docs/genai/genai-services.md` | `docs/` scindé en sous-dossiers + un `../` de trop |
| `TROUBLESHOOTING.md` (×3) | `../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md` | déplacé dans l'archive |
| `docs/_archives/suivis/genai-image/` | `docs/archive/suivis/genai-image/` | dossier renommé `_archives`→`archive` + un `../` de trop |
| `examples/mathematics-physics.ipynb` | *(exemple à venir)* | **jamais publié** — aucun fichier dans l'arbre → marqueur honnête au lieu d'un lien mort |

## Portée / conformité

- **Link-hygiene uniquement** : `+10 / -10`, deux fichiers `.md`, **aucun** changement de prose/contenu au-delà des liens (+ le marqueur « à venir »).
- **Vérification** : re-sweep post-fix → **0 lien `.md`/`.ipynb` cassé résiduel** dans les deux fichiers. Toutes les cibles MOVED confirmées présentes (`ls`).
- **Catalogue byte-identique** à `main` (aucun artefact généré touché).

## Contexte

Détecté par un sweep repo-wide des liens relatifs cassés (532 au total, dont la majorité dans `docs/archive/` — snapshots gelés, hors scope — et le corpus importé `Vibe-Coding/…/corrigés ateliers-roo/`). Cette PR traite le cluster **propre et vérifiable** des docs de navigation GenAI de premier niveau.

See #3966