### PR TITLE
docs(search): table de parité .NET ⇄ Python + pistes de portage

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -301,6 +301,37 @@ CSP-8  Temporal            ───> Temporal Planning, STP
 
 ---
 
+## Parité .NET ⇄ Python
+
+Cette série est **Python d'abord** pour son cœur pédagogique (recherche, CSP, applications), avec des **side tracks C# / .NET** là où l'écosystème .NET apporte une valeur propre : la [Partie 4 — métaheuristiques composables](Part4-Metaheuristics/README.md) (native .NET au-dessus de MetaGeneticSharp) et deux applications hybrides portées en C# (détection de bords, portefeuille). Le tableau ci-dessous fait le point sur la couverture par langage et sert de carte de départ pour un portage .NET progressif.
+
+### Couverture actuelle
+
+| Sous-série | Notebooks | Langage | Correspondance dans l'autre langage |
+|-----------|-----------|---------|-------------------------------------|
+| [Part1-Foundations](Part1-Foundations/) | 11 (Search-1 à Search-11) | Python | Aucune |
+| [Part2-CSP](Part2-CSP/) | 9 (CSP-1 à CSP-9) | Python | Aucune |
+| [Part3-Advanced](Part3-Advanced/) | 3 (Search-12 à Search-14) | Python | Aucune |
+| [Part4-Metaheuristics](Part4-Metaheuristics/) | 19 (MGS-1 à MGS-19) | C# / .NET (natif) | Prolonge Search-5 / Search-11 (Python) sous l'angle ingénierie |
+| [Applications](Applications/) | 21 | 19 Python + 2 C# | App-9 ⇄ App-9b, App-10 ⇄ App-10b (2 paires) |
+| Racine | 5 | 3 Python + 2 C# | GeneticSharp-EdgeDetection, Portfolio_Optimization_GeneticSharp |
+
+Le **cœur curriculaire** (Parties 1 à 3, soit 23 notebooks) est aujourd'hui exclusivement en Python ; seules deux applications disposent d'un binôme Python/C#.
+
+### Pistes de portage .NET
+
+Le levier .NET dépend de la dépendance sous-jacente de chaque notebook :
+
+| Cible | Dépendance Python | Levier .NET | Précédent / remarque |
+|-------|-------------------|-------------|----------------------|
+| CSP-1 à CSP-9 (modélisation par contraintes) | `ortools` (CSP-3 à CSP-8) | **Google.OrTools** (NuGet natif) pour CP-SAT ; **Choco-solver** via **IKVM** pour l'API de modélisation | Précédent en place : `Sudoku-11-Choco-Csharp` (Choco via IKVM) et son binôme `Sudoku-11-Choco-Python` |
+| Search-9 Linear Programming | `pulp` | **Google.OrTools** (NuGet natif, GLOP / PDLP) | Port direct, sans IKVM |
+| Recherche d'états (Search-1 à Search-4) | aucune dépendance lourde | **.NET Interactive** pur | Structures d'états directement portables |
+
+Le portage se fait **au fil de l'eau, une tranche par contribution** — un notebook .NET exécuté de bout en bout avec ses exercices — et non en une seule passe. Le suivi d'ensemble est assuré par l'issue [#4956](https://github.com/jsboige/CoursIA/issues/4956).
+
+---
+
 ## Prérequis
 
 ### Python


### PR DESCRIPTION
## Scope

Ajoute une section **Parité .NET ⇄ Python** au README de la série Search (`MyIA.AI.Notebooks/Search/README.md`), **docs uniquement**, +31 lignes / -0.

Deux tableaux :
1. **Couverture actuelle** par sous-série — état factuel du split Python / .NET.
2. **Pistes de portage .NET** — levier recommandé par dépendance sous-jacente.

## Contribution à l'epic #4956

Carte de départ (« point de départ du marathon ») pour le portage progressif .NET ⇄ Python : montre où les correspondances existent déjà et quels notebooks sont candidats à un port, avec le bon levier. Aide au découpage des filles par le coordinateur. **`See #4956`** (contribution partielle — l'epic reste ouverte).

## Données vérifiées firsthand

Toutes les affirmations du tableau sont grounded contre le dépôt (pas d'estimation) :
- **Kernelspec réel** par notebook : Part1-Foundations (11), Part2-CSP (9), Part3-Advanced (3) = 100% Python ; Part4-Metaheuristics (MGS-1..19) = `.net-csharp` natif ; Applications = 19 Python + 2 C# (App-9b, App-10b).
- **Dépendances réelles** (imports) : CSP-3 à CSP-8 → `ortools` ; Search-9 → `pulp` (pas ortools).
- **Précédent IKVM Choco vérifié** : `Sudoku-11-Choco-Csharp.ipynb` (kernel `.net-csharp`, références choco + ikvm) + son binôme `Sudoku-11-Choco-Python.ipynb` + `org.chocosolver.solver.dll` compilé — parité Choco déjà en place.

## Hygiène

- Branche fraîche depuis `origin/main` (rebase à jour).
- Bloc `CATALOG-STATUS` **inchangé** (byte-identique à main — vérifié : hors diff).
- Section **en français** (readme-french-first ; README déjà FR, pas de bascule EN→FR).
- Style de tableau identique aux 15+ tables existantes du README (pipes espacés).
- Aucun notebook touché, aucune régénération de catalogue.

Co-Authored-By: Claude-Code <noreply@anthropic.com>