### PR TITLE
docs(qc): repair stale docs/quantconnect.md references -> docs/qc/quantconnect.md

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
+++ b/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
@@ -12,7 +12,7 @@ Cette section contient un parcours complet de trading algorithmique sur **QuantC
 
 2. **[Catalogue strategies](docs/qc_strategies_catalog.md)** — 95+ projets organises par categorie (Alpha, Trend Following, ML/RL, Composites). Top performers vérifiés alignés (#1630) : Long-Short Harvest (Sharpe **1.64**, PSR 98.7%), TrendWeather Composite (**0.948**, PSR 56.6%), EMATrend (**0.611**).
 
-3. **[Patterns confirmes](../../docs/quantconnect.md)** — 20 patterns valides sur 30+ iterations (risk-adjusted momentum, skip-month, stop-loss -8/-12%, monthly rebalancing, anti-overfitting) et 10 anti-patterns critiques (SPY Parking, backtests courts, yfinance != QC cloud).
+3. **[Patterns confirmes](../../docs/qc/quantconnect.md)** — 20 patterns valides sur 30+ iterations (risk-adjusted momentum, skip-month, stop-loss -8/-12%, monthly rebalancing, anti-overfitting) et 10 anti-patterns critiques (SPY Parking, backtests courts, yfinance != QC cloud).
 
 4. **[Notebooks pedagogiques](Python/)** — 51 notebooks en 8 phases progressives : fondations LEAN, universe/asset classes, risk management, Algorithm Framework, donnees alternatives, ML (RF/XGBoost), deep learning (LSTM/Transformers), RL et LLMs pour trading.
 
@@ -24,4 +24,4 @@ Cette section contient un parcours complet de trading algorithmique sur **QuantC
 2. Copier un `main.py` depuis [projects/](projects/) dans un nouveau projet QC Lab
 3. Cliquer **Backtest** — c'est tout
 
-> Documentation complete : [README.md](README.md) | [Guide demarrage](GETTING-STARTED.md) | [Patterns QC](../../docs/quantconnect.md)
+> Documentation complete : [README.md](README.md) | [Guide demarrage](GETTING-STARTED.md) | [Patterns QC](../../docs/qc/quantconnect.md)

--- a/MyIA.AI.Notebooks/QuantConnect/docs/OVERVIEW.md
+++ b/MyIA.AI.Notebooks/QuantConnect/docs/OVERVIEW.md
@@ -80,7 +80,7 @@ Forex                  -0.32   -0.32   1    ▏
 | 2 | **Monthly rebalancing** bat weekly et daily sur la plupart des strategies | Stabilite | Multiple strategies |
 | 3 | **Stop-loss asymetrique -8%/-12%** (trailing) optimal vs -5% ou -15% | Réduit MaxDD | Portfolio construction |
 | 4 | **Modeles action (DT)** surpassent modeles prediction rendement (PatchTST) | AUC 0.56 vs 0.50 | L4 vs L5 Ladder ML |
-| 5 | **yfinance != QC Cloud** : les resultats locaux ne reproduisent pas QC (dividends, splits, fills) | 20+ patterns | docs/quantconnect.md |
+| 5 | **yfinance != QC Cloud** : les resultats locaux ne reproduisent pas QC (dividends, splits, fills) | 20+ patterns | docs/qc/quantconnect.md |
 
 ## Timeline des iterations majeures
 

--- a/MyIA.AI.Notebooks/QuantConnect/docs/QC_CLOUD_ASSISTANTS_WORKFLOW.md
+++ b/MyIA.AI.Notebooks/QuantConnect/docs/QC_CLOUD_ASSISTANTS_WORKFLOW.md
@@ -113,6 +113,6 @@ L'assistant rapporte des Sharpes **inflationnes** car :
 
 - Issue #1195 : contexte + protocole + matrice delegation
 - `feedback_qc_assistants_preferred.md` : methode preferee QC Cloud Assistants
-- `docs/quantconnect.md` : configuration MCP Docker + regles QC
+- `docs/qc/quantconnect.md` : configuration MCP Docker + regles QC
 - `docs/ml-trading-state.md` : 7 disciplines ML trading
 - Portfolio IBKR-Binance-Hybrid : validation Phase 1 (deployment A-8ad2fb)

--- a/docker-configurations/notebook-runner/README.md
+++ b/docker-configurations/notebook-runner/README.md
@@ -69,7 +69,7 @@ The runner is designed for CI/CD:
 
 - **QuantConnect notebooks**: Only 5 tickers have data locally (SPY, QQQ, AAPL, GOOGL, IWM).
   Crypto and sector ETF notebooks will fail with empty data errors.
-  Full data requires QC Cloud backend (see `docs/quantconnect.md`).
+  Full data requires QC Cloud backend (see `docs/qc/quantconnect.md`).
 - **Lean 4 notebooks**: Require `lean4` kernel installed in the image. WSL-specific notebooks
   (kernel `lean4-wsl`) may need path adjustments.
 - **GPU notebooks**: No GPU support in this runner. GenAI notebooks requiring GPU


### PR DESCRIPTION
## Résumé

Le document de patterns QC a été déplacé vers `docs/qc/quantconnect.md`, mais **5 références réparties sur 4 fichiers** pointaient encore vers l'ancien chemin `docs/quantconnect.md` (lien cassé).

| Fichier | Occurrences | Forme |
|---------|-------------|-------|
| `MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md` | 2 | liens cliquables `[...](../../docs/quantconnect.md)` |
| `MyIA.AI.Notebooks/QuantConnect/docs/OVERVIEW.md` | 1 | référence texte (cellule de tableau) |
| `MyIA.AI.Notebooks/QuantConnect/docs/QC_CLOUD_ASSISTANTS_WORKFLOW.md` | 1 | référence texte (puce) |
| `docker-configurations/notebook-runner/README.md` | 1 | référence texte |

## Vérification

- `docs/qc/quantconnect.md` **existe** à `origin/main` ; `docs/quantconnect.md` **absent** (cible confirmée déplacée).
- Balayage complet : **0 référence obsolète restante** après le correctif (`git grep docs/quantconnect.md` = vide).
- `docs/quantconnect.md` n'est pas une sous-chaîne de `docs/qc/quantconnect.md` (le `qc/` la coupe) → les références déjà correctes ne sont pas touchées.
- Diff : `4 files changed, 5 insertions(+), 5 deletions(-)`. Docs uniquement — aucun notebook ni catalogue modifié.

Réparation de liens vérifiée (hygiène documentaire).