### PR TITLE
feat(argumentum): cable submodule Argumentum (master premerge @ ac33f607)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "MyIA.AI.Notebooks/SymbolicAI/SMT/Automata"]
 	path = MyIA.AI.Notebooks/SymbolicAI/SMT/Automata
 	url = https://github.com/MyIntelligenceAgency/Automata.git
+[submodule "MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argumentum"]
+	path = MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argumentum
+	url = https://github.com/ArgumentumGames/Argumentum


### PR DESCRIPTION
## Summary
Câble le submodule **Argumentum** (décision user A.1 du 2026-07-02 : « On fera la MAJ au fur et à mesure, tu peux sync le sous-module » — pin master prémerge maintenant, resync au fil de l'eau, pas d'attente du tag v0.9.0).

- URL : https://github.com/ArgumentumGames/Argumentum
- Pin : `ac33f607` (origin/master vérifié à jour ce jour)
- Montage : `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argumentum` (convention lib-à-côté-de-la-série : MetaGeneticSharp sous Search/, Z3.Linq sous SMT/)

Diff = 2 fichiers, 4 lignes (.gitmodules + gitlink). Aucun impact catalogue, aucun notebook touché. Coche l'item acceptance « Submodule Argumentum câblé (`git submodule update --init` OK sur clone frais) » de l'epic.

See #4960

🤖 Generated with [Claude Code](https://claude.com/claude-code)