### PR TITLE
feat(tweety): Tweety-4-Belief-Revision-Csharp — AGM belief revision .NET native (IKVM)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
@@ -1,0 +1,834 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# Tweety C# / IKVM - Revision de Croyances (Port .NET du notebook Python)\n",
+    "\n",
+    "Ce notebook porte en **C# / .NET** (via IKVM, sans JVM) le module **belief-revision** de\n",
+    "[TweetyProject](https://tweetyproject.org/). Il fait partie de l'Epic #4667 (portage .NET de la\n",
+    "serie Tweety) et prolonge les notebooks deja portes : logiques de base, semantique, FOL,\n",
+    "argumentation de Dung et ASPIC+.\n",
+    "\n",
+    "Le pendant Python est [`Tweety-4-Belief-Revision.ipynb`](Tweety-4-Belief-Revision.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "## De quoi parle la revision de croyances ?\n",
+    "\n",
+    "Un agent rationnel doit parfois **integrer une information qui contredit ce qu'il croit deja**.\n",
+    "Ajouter naivement la nouvelle formule a sa base la rendrait **incoherente** (elle impliquerait\n",
+    "tout et n'importe quoi). La **theorie AGM** (Alchourron, Gardenfors, Makinson, 1985) formalise\n",
+    "les trois operations du changement de croyance :\n",
+    "\n",
+    "- **Expansion** (`K + phi`) : on ajoute `phi` sans se soucier de la coherence.\n",
+    "- **Contraction** (`K - phi`) : on retire juste assez de croyances pour que `K` n'implique plus `phi`.\n",
+    "- **Revision** (`K * phi`) : on integre `phi` **en preservant la coherence**, quitte a abandonner\n",
+    "  d'anciennes croyances.\n",
+    "\n",
+    "L'**identite de Levi** relie les trois : `K * phi = (K - !phi) + phi`. On contracte d'abord par la\n",
+    "negation de l'information, puis on expanse. Tweety implemente ces operateurs ; ce notebook les\n",
+    "execute reellement sur des bases propositionnelles.\n",
+    "\n",
+    "## Comment Tweety tourne en .NET (sans JVM)\n",
+    "\n",
+    "Tweety est une bibliotheque **Java**. On la recompile en assembly **.NET** avec **IKVM 8.15.0** :\n",
+    "le bytecode Java devient du code .NET, appelable directement en C# depuis le kernel `.net-csharp`.\n",
+    "La recette de build (Maven shade + `<IkvmReference>`) est documentee dans\n",
+    "[`dotnet-build/`](dotnet-build/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec1",
+   "metadata": {},
+   "source": [
+    "### 1. Configuration du runtime IKVM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ikvm-ref",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:06.068100Z",
+     "iopub.status.busy": "2026-07-02T12:23:06.057287Z",
+     "iopub.status.idle": "2026-07-02T12:23:06.825581Z",
+     "shell.execute_reply": "2026-07-02T12:23:06.823368Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-13036.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://192.168.1.47:2048/\", \"http://172.30.224.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '13036.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>IKVM, 8.15.0</span></li><li><span>IKVM.Image, 8.15.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: IKVM, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image, 8.15.0\"\n",
+    "#r \"nuget: IKVM.Image.runtime.win-x64, 8.15.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ikvm-home",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:06.828576Z",
+     "iopub.status.busy": "2026-07-02T12:23:06.827586Z",
+     "iopub.status.idle": "2026-07-02T12:23:07.674189Z",
+     "shell.execute_reply": "2026-07-02T12:23:07.672787Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.IO;\n",
+    "\n",
+    "string ikvmVer = \"8.15.0\", ikvmRid = \"win-x64\";\n",
+    "string nugetRoot = Environment.GetEnvironmentVariable(\"NUGET_PACKAGES\")\n",
+    "    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \".nuget\", \"packages\");\n",
+    "string ikvmBaseAny = Path.Combine(nugetRoot, \"ikvm.image\", ikvmVer, \"ikvm\", \"any\", \"any\");\n",
+    "string ikvmArchDir = Path.Combine(nugetRoot, \"ikvm.image.runtime.\" + ikvmRid, ikvmVer, \"ikvm\", \"any\", ikvmRid);\n",
+    "string ikvmHome    = Path.Combine(Path.GetTempPath(), \"ikvm-home-\" + ikvmVer + \"-\" + ikvmRid);\n",
+    "\n",
+    "void IkvmCopyMerge(string src, string dst)\n",
+    "{\n",
+    "    foreach (var d in Directory.GetDirectories(src, \"*\", SearchOption.AllDirectories))\n",
+    "        Directory.CreateDirectory(d.Replace(src, dst));\n",
+    "    foreach (var f in Directory.GetFiles(src, \"*\", SearchOption.AllDirectories))\n",
+    "    {\n",
+    "        var t = f.Replace(src, dst);\n",
+    "        Directory.CreateDirectory(Path.GetDirectoryName(t));\n",
+    "        File.Copy(f, t, overwrite: true);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "if (Directory.Exists(ikvmBaseAny) && Directory.Exists(ikvmArchDir))\n",
+    "{\n",
+    "    Directory.CreateDirectory(ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmBaseAny, ikvmHome);\n",
+    "    IkvmCopyMerge(ikvmArchDir, ikvmHome);\n",
+    "}\n",
+    "AppContext.SetData(\"IKVM.Home\", ikvmHome);\n",
+    "\n",
+    "bool tzdbOk = File.Exists(Path.Combine(ikvmHome, \"lib\", \"tzdb.dat\"));\n",
+    "Console.WriteLine($\"IKVM 8.15.0 pret (home=ikvm-home-{ikvmVer}-{ikvmRid}, tzdb={tzdbOk})\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec2",
+   "metadata": {},
+   "source": [
+    "### 2. Chargement de la DLL Tweety beliefdynamics\n",
+    "\n",
+    "La DLL `org.tweetyproject.tweety-beliefdynamics.dll` est un fat-jar shade (beliefdynamics +\n",
+    "ses dependances : logique propositionnelle, SAT, math) recompile par IKVM. Elle expose les\n",
+    "operateurs de revision, de contraction par noyaux et de revision selective."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "load-dll",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:07.676329Z",
+     "iopub.status.busy": "2026-07-02T12:23:07.676329Z",
+     "iopub.status.idle": "2026-07-02T12:23:07.702934Z",
+     "shell.execute_reply": "2026-07-02T12:23:07.701943Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#r \"org.tweetyproject.tweety-beliefdynamics.dll\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec3",
+   "metadata": {},
+   "source": [
+    "### 3. Le probleme : une base de croyances incoherente\n",
+    "\n",
+    "Construisons une base `K = { a, a => b, !c }`, coherente. Puis observons que lui ajouter\n",
+    "naivement l'information `!b` la rend **incoherente** : comme `a` et `a => b` impliquent `b`,\n",
+    "la base contiendrait a la fois `b` (deduit) et `!b`. C'est exactement la situation que la\n",
+    "revision doit resoudre proprement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "incoherent",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:07.704942Z",
+     "iopub.status.busy": "2026-07-02T12:23:07.704942Z",
+     "iopub.status.idle": "2026-07-02T12:23:08.338610Z",
+     "shell.execute_reply": "2026-07-02T12:23:08.338610Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Base initiale         K = { (a=>b), a, !c }\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K incoherente ?           false\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Union naive K + [!b]  = { (a=>b), a, !b, !c }\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Union naive incoherente ? true\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.logics.pl.syntax;\n",
+    "using org.tweetyproject.logics.pl.parser;\n",
+    "using org.tweetyproject.logics.pl.reasoner;\n",
+    "\n",
+    "var parser = new PlParser();\n",
+    "var reasoner = new SimplePlReasoner();\n",
+    "\n",
+    "// Test de coherence sans solveur SAT externe : une base est INCOHERENTE si et seulement\n",
+    "// si elle entraine une contradiction (elle n'a alors aucun modele). On reutilise donc le\n",
+    "// raisonneur propositionnel : query(base, \"a && !a\") vaut true ssi la base est incoherente.\n",
+    "var faux = (PlFormula) parser.parseFormula(\"a && !a\");\n",
+    "\n",
+    "// Base de croyances initiale  K = { a, a=>b, !c }  (coherente).\n",
+    "var K = new PlBeliefSet();\n",
+    "K.add((PlFormula) parser.parseFormula(\"a\"));\n",
+    "K.add((PlFormula) parser.parseFormula(\"a=>b\"));\n",
+    "K.add((PlFormula) parser.parseFormula(\"!c\"));\n",
+    "Console.WriteLine($\"Base initiale         K = {K}\");\n",
+    "Console.WriteLine($\"K incoherente ?           {reasoner.query(K, faux)}\");\n",
+    "\n",
+    "// Nouvelle information  phi = !b. Or a et a=>b impliquent b : phi contredit K.\n",
+    "// L'union naive  K + [ !b ]  est donc incoherente.\n",
+    "var naive = new PlBeliefSet();\n",
+    "naive.add((PlFormula) parser.parseFormula(\"a\"));\n",
+    "naive.add((PlFormula) parser.parseFormula(\"a=>b\"));\n",
+    "naive.add((PlFormula) parser.parseFormula(\"!c\"));\n",
+    "naive.add((PlFormula) parser.parseFormula(\"!b\"));\n",
+    "Console.WriteLine($\"Union naive K + [!b]  = {naive}\");\n",
+    "Console.WriteLine($\"Union naive incoherente ? {reasoner.query(naive, faux)}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp3",
+   "metadata": {},
+   "source": [
+    "#### Interpretation\n",
+    "\n",
+    "L'union naive est incoherente : le raisonneur le confirme — elle entraine la contradiction\n",
+    "`a && !a`, donc la question « incoherente ? » passe de `false` (pour `K`) a `true` (pour l'union).\n",
+    "Une base incoherente implique **toute** formule (principe d'explosion), elle est donc inutilisable\n",
+    "pour raisonner. La revision AGM va integrer `!b` **sans** produire cette explosion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec4",
+   "metadata": {},
+   "source": [
+    "### 4. Contraction par noyaux (kernel contraction)\n",
+    "\n",
+    "Avant de reviser, il faut savoir **contracter**. La *contraction par noyaux* (Hansson) procede\n",
+    "ainsi : un **noyau** de `K` par rapport a `b` est un sous-ensemble **minimal** de `K` qui implique\n",
+    "`b`. Pour que `K` cesse d'impliquer `b`, il faut « couper » au moins une formule dans **chaque**\n",
+    "noyau : c'est le role de la **fonction d'incision**. Ici :\n",
+    "\n",
+    "- `SimplePlReasoner` fournit les noyaux (`KernelProvider`),\n",
+    "- `RandomIncisionFunction` choisit la formule a retirer dans chaque noyau."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "contraction",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:08.338610Z",
+     "iopub.status.busy": "2026-07-02T12:23:08.338610Z",
+     "iopub.status.idle": "2026-07-02T12:23:08.491109Z",
+     "shell.execute_reply": "2026-07-02T12:23:08.491109Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K contractee par b = [a, !c]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Entraine encore b ? false\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using java.util;\n",
+    "using org.tweetyproject.logics.pl.reasoner;\n",
+    "using org.tweetyproject.beliefdynamics.kernels;\n",
+    "\n",
+    "// La contraction retire juste ce qu'il faut pour que la base n'implique plus b.\n",
+    "// KernelContractionOperator(fonction d'incision, fournisseur de noyaux).\n",
+    "//   - SimplePlReasoner joue le role de KernelProvider (il enumere les noyaux).\n",
+    "//   - RandomIncisionFunction choisit dans chaque noyau la formule a couper.\n",
+    "var baseK = new HashSet();\n",
+    "baseK.add((PlFormula) parser.parseFormula(\"a\"));\n",
+    "baseK.add((PlFormula) parser.parseFormula(\"a=>b\"));\n",
+    "baseK.add((PlFormula) parser.parseFormula(\"!c\"));\n",
+    "\n",
+    "var aRetirer = new HashSet();\n",
+    "aRetirer.add((PlFormula) parser.parseFormula(\"b\"));\n",
+    "\n",
+    "var contraction = new KernelContractionOperator(new RandomIncisionFunction(), new SimplePlReasoner());\n",
+    "var contractee = contraction.contract(baseK, aRetirer);\n",
+    "Console.WriteLine($\"K contractee par b = {contractee}\");\n",
+    "\n",
+    "// La base contractee ne doit plus entrainer b. On reconstruit une PlBeliefSet a partir\n",
+    "// de la collection retournee, puis on interroge le raisonneur.\n",
+    "var contracteeKb = new PlBeliefSet();\n",
+    "var itc = contractee.iterator();\n",
+    "while (itc.hasNext()) contracteeKb.add((PlFormula) itc.next());\n",
+    "var b = (PlFormula) parser.parseFormula(\"b\");\n",
+    "Console.WriteLine($\"Entraine encore b ? {reasoner.query(contracteeKb, b)}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp4",
+   "metadata": {},
+   "source": [
+    "#### Interpretation\n",
+    "\n",
+    "La base contractee n'implique plus `b` : la contraction a retire l'une des formules\n",
+    "responsables (`a` ou `a => b`). La fonction d'incision etant **aleatoire**, la formule\n",
+    "exactement retiree peut varier d'une execution a l'autre — mais la propriete garantie\n",
+    "(« ne plus impliquer `b` ») est, elle, toujours respectee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec5",
+   "metadata": {},
+   "source": [
+    "### 5. Revision par l'identite de Levi\n",
+    "\n",
+    "On assemble maintenant la revision complete. `LeviMultipleBaseRevisionOperator` prend un\n",
+    "operateur de contraction et un operateur d'expansion, et applique l'identite de Levi\n",
+    "`K * phi = (K - !phi) + phi`. Revisons `K` par `!b`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "levi",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:08.494108Z",
+     "iopub.status.busy": "2026-07-02T12:23:08.493107Z",
+     "iopub.status.idle": "2026-07-02T12:23:08.598337Z",
+     "shell.execute_reply": "2026-07-02T12:23:08.598337Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K revisee par !b (Levi) = [a, !b, !c]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat incoherent ?     false\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contient bien !b ?        True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using org.tweetyproject.beliefdynamics;\n",
+    "\n",
+    "// Identite de Levi :  K * phi  =  (K - !phi) + phi\n",
+    "//   revision = contraction par la negation de l'information, puis expansion.\n",
+    "var expansion = new DefaultMultipleBaseExpansionOperator();\n",
+    "var levi = new LeviMultipleBaseRevisionOperator(contraction, expansion);\n",
+    "\n",
+    "var nouvelleInfo = new HashSet();\n",
+    "nouvelleInfo.add((PlFormula) parser.parseFormula(\"!b\"));\n",
+    "\n",
+    "var revisee = levi.revise(baseK, nouvelleInfo);\n",
+    "Console.WriteLine($\"K revisee par !b (Levi) = {revisee}\");\n",
+    "\n",
+    "var reviseeKb = new PlBeliefSet();\n",
+    "var itr = revisee.iterator();\n",
+    "while (itr.hasNext()) reviseeKb.add((PlFormula) itr.next());\n",
+    "var notB = (PlFormula) parser.parseFormula(\"!b\");\n",
+    "Console.WriteLine($\"Resultat incoherent ?     {reasoner.query(reviseeKb, faux)}\");\n",
+    "Console.WriteLine($\"Contient bien !b ?        {reviseeKb.contains(notB)}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp5",
+   "metadata": {},
+   "source": [
+    "#### Interpretation\n",
+    "\n",
+    "Le resultat est **coherent** et contient bien la nouvelle information `!b`. La revision a\n",
+    "sacrifie juste ce qu'il fallait des anciennes croyances pour accueillir `!b` sans contradiction :\n",
+    "c'est la difference fondamentale avec l'union naive de la section 3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec6",
+   "metadata": {},
+   "source": [
+    "### 6. Exemple guide : le pingouin Tweety (raisonnement non-monotone)\n",
+    "\n",
+    "La bibliotheque tire son nom de **Tweety**, l'oiseau emblematique du raisonnement non-monotone.\n",
+    "Partons de trois croyances : Tweety est un pingouin (`p`), un pingouin est un oiseau (`p => b`),\n",
+    "un oiseau vole (`b => f`). La base **conclut donc que Tweety vole**. Puis on **observe** que ce\n",
+    "pingouin ne vole pas (`!f`). Pour integrer l'observation, la revision doit **abandonner une regle\n",
+    "par defaut** de la chaine de raisonnement `p => b => f`. C'est un probleme non-trivial : l'incoherence\n",
+    "est **derivee** (via une chaine d'implications), pas directe.\n",
+    "\n",
+    "Le notebook affiche la ou les croyances effectivement sacrifiees. Notez qu'une contraction AGM\n",
+    "n'est **pas unique** : plusieurs retraits minimaux restaurent la coherence (ici retirer `p => b`\n",
+    "*ou* `b => f`). Le choix depend de la **fonction d'incision** (`RandomIncisionFunction`) ; un\n",
+    "operateur muni de priorites sur les croyances retirerait preferentiellement la regle la moins fiable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "guided",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:08.600345Z",
+     "iopub.status.busy": "2026-07-02T12:23:08.600345Z",
+     "iopub.status.idle": "2026-07-02T12:23:08.760045Z",
+     "shell.execute_reply": "2026-07-02T12:23:08.760045Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K conclut que Tweety vole (f) ? true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K revisee par !f = [(b=>f), p, !f]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat incoherent ?         false\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conclut desormais !f (ne vole pas) ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Croyance(s) abandonnee(s) par la revision : [(p=>b)]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "La revision a du abandonner une regle par defaut de la chaine p=>b=>f pour\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "integrer l'observation !f sans contradiction : c'est le coeur de l'AGM.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple guide : le pingouin Tweety (raisonnement non-monotone).\n",
+    "// p = \"est un pingouin\", b = \"est un oiseau\", f = \"vole\".\n",
+    "// K = { p, p=>b, b=>f }  =>  la base conclut que Tweety vole.\n",
+    "var Kt = new HashSet();\n",
+    "Kt.add((PlFormula) parser.parseFormula(\"p\"));\n",
+    "Kt.add((PlFormula) parser.parseFormula(\"p=>b\"));\n",
+    "Kt.add((PlFormula) parser.parseFormula(\"b=>f\"));\n",
+    "\n",
+    "var KtKb = new PlBeliefSet();\n",
+    "var itk = Kt.iterator();\n",
+    "while (itk.hasNext()) KtKb.add((PlFormula) itk.next());\n",
+    "var f = (PlFormula) parser.parseFormula(\"f\");\n",
+    "Console.WriteLine($\"K conclut que Tweety vole (f) ? {reasoner.query(KtKb, f)}\");\n",
+    "\n",
+    "// Observation : ce pingouin ne vole PAS. On revise K par !f.\n",
+    "var obs = new HashSet();\n",
+    "obs.add((PlFormula) parser.parseFormula(\"!f\"));\n",
+    "var reviseeTweety = levi.revise(Kt, obs);\n",
+    "Console.WriteLine($\"K revisee par !f = {reviseeTweety}\");\n",
+    "\n",
+    "var rtKb = new PlBeliefSet();\n",
+    "var itt = reviseeTweety.iterator();\n",
+    "while (itt.hasNext()) rtKb.add((PlFormula) itt.next());\n",
+    "var notF = (PlFormula) parser.parseFormula(\"!f\");\n",
+    "Console.WriteLine($\"Resultat incoherent ?         {reasoner.query(rtKb, faux)}\");\n",
+    "Console.WriteLine($\"Conclut desormais !f (ne vole pas) ? {rtKb.contains(notF)}\");\n",
+    "\n",
+    "// Quelle(s) croyance(s) la revision a-t-elle du sacrifier ?\n",
+    "var abandonnees = new java.util.ArrayList();\n",
+    "var itd = Kt.iterator();\n",
+    "while (itd.hasNext()) {\n",
+    "    var croyance = (PlFormula) itd.next();\n",
+    "    if (!reviseeTweety.contains(croyance)) abandonnees.add(croyance);\n",
+    "}\n",
+    "Console.WriteLine($\"Croyance(s) abandonnee(s) par la revision : {abandonnees}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"La revision a du abandonner une regle par defaut de la chaine p=>b=>f pour\");\n",
+    "Console.WriteLine(\"integrer l'observation !f sans contradiction : c'est le coeur de l'AGM.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "conclusion",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a execute, en C# natif via IKVM, les operateurs AGM de Tweety :\n",
+    "\n",
+    "- **test de coherence** par entailment d'une contradiction (`SimplePlReasoner`) : une base\n",
+    "  est incoherente ssi elle entraine `a && !a` ;\n",
+    "- **contraction par noyaux** (`KernelContractionOperator` + `RandomIncisionFunction`) ;\n",
+    "- **revision** par l'**identite de Levi** (`LeviMultipleBaseRevisionOperator`) ;\n",
+    "- une application non-monotone (le pingouin Tweety) ou la revision resout une incoherence\n",
+    "  **derivee** en abandonnant une regle par defaut.\n",
+    "\n",
+    "La revision de croyances est au coeur des systemes intelligents qui doivent **apprendre en\n",
+    "presence d'informations contradictoires** : mise a jour de bases de connaissances, fusion de\n",
+    "sources, diagnostic. Le notebook Python compagnon poursuit avec les **mesures d'incoherence**\n",
+    "et l'enumeration de **MUS** (sous-ensembles incoherents minimaux)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exos",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices ci-dessous reutilisent les operateurs construits plus haut (`levi`, la contraction\n",
+    "par noyaux, le raisonneur `reasoner`, le `parser`). Completez les stubs ; la base reste executable\n",
+    "de bout en bout meme si les exercices ne sont pas remplis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ex1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:08.762032Z",
+     "iopub.status.busy": "2026-07-02T12:23:08.762032Z",
+     "iopub.status.idle": "2026-07-02T12:23:08.825629Z",
+     "shell.execute_reply": "2026-07-02T12:23:08.825629Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : reviser votre propre base de croyances.\n",
+    "// Objectif : construire K = { pluie, pluie => sol_mouille } puis reviser par !sol_mouille.\n",
+    "// Indice : reutilisez le patron levi.revise(base, nouvelleInfo) et testez la coherence.\n",
+    "// Etape 1 : construire la HashSet baseEx1 avec les deux formules.\n",
+    "// Etape 2 : construire nouvelleInfoEx1 = { !sol_mouille }.\n",
+    "// Etape 3 : appeler levi.revise(...) et afficher le resultat + sa coherence.\n",
+    "\n",
+    "// var baseEx1 = new HashSet();\n",
+    "// TODO : completer\n",
+    "Console.WriteLine(\"Exercice 1 a completer\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ex2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:08.836601Z",
+     "iopub.status.busy": "2026-07-02T12:23:08.825629Z",
+     "iopub.status.idle": "2026-07-02T12:23:08.901974Z",
+     "shell.execute_reply": "2026-07-02T12:23:08.901974Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : contraction par noyaux.\n",
+    "// Objectif : partir de K = { x, x=>y, y=>z } et la contracter par z.\n",
+    "// Indice : new KernelContractionOperator(new RandomIncisionFunction(), new SimplePlReasoner()).\n",
+    "// Etape 1 : construire la base et l'ensemble { z } a retirer.\n",
+    "// Etape 2 : appeler .contract(base, aRetirer).\n",
+    "// Etape 3 : verifier avec un SimplePlReasoner que la base contractee n'implique plus z.\n",
+    "\n",
+    "// TODO : completer\n",
+    "Console.WriteLine(\"Exercice 2 a completer\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ex3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T12:23:08.903990Z",
+     "iopub.status.busy": "2026-07-02T12:23:08.903990Z",
+     "iopub.status.idle": "2026-07-02T12:23:08.938840Z",
+     "shell.execute_reply": "2026-07-02T12:23:08.938840Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : revision vs union naive (mesure de l'ecart).\n",
+    "// Objectif : sur K = { m, m=>n, !o }, comparer |K + {!n}| (union naive, incoherente)\n",
+    "//            au cardinal de la base revisee levi.revise(K, {!n}) (coherente).\n",
+    "// Indice : la revision retire au moins une formule ; comptez .size() de chaque cote.\n",
+    "// Etape 1 : construire K et la nouvelle information { !n }.\n",
+    "// Etape 2 : calculer l'union naive et la base revisee.\n",
+    "// Etape 3 : afficher les deux cardinaux et la difference (nombre de croyances sacrifiees).\n",
+    "\n",
+    "// TODO : completer\n",
+    "Console.WriteLine(\"Exercice 3 a completer\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/README.md
@@ -1,10 +1,10 @@
-# `dotnet-build/` — Recette de build du runtime Tweety C# / IKVM
+# `dotnet-build/` — Recette de build des runtimes Tweety C# / IKVM
 
-Ce dossier contient la **recette de build** (POM shade + csproj) du runtime .NET de Tweety
-(cluster `pl`) recompilé via IKVM 8.15.0. Le runtime compilé (`org.tweetyproject.tweety-pl.dll`)
-est placé **à côté du notebook** [`../Tweety-2-Basic-Logics-Csharp.ipynb`](../Tweety-2-Basic-Logics-Csharp.ipynb).
+Ce dossier contient les **recettes de build** (POM shade + csproj) des runtimes .NET de Tweety
+recompilés via IKVM 8.15.0. Chaque runtime compilé (`org.tweetyproject.tweety-<module>.dll`)
+est placé **à côté du notebook** qui le charge.
 
-## Fichiers
+## Fichiers — cluster `pl` (notebook [`../Tweety-2-Basic-Logics-Csharp.ipynb`](../Tweety-2-Basic-Logics-Csharp.ipynb))
 
 | Fichier | Rôle | Committé ? |
 |---------|------|-----------|
@@ -12,6 +12,25 @@ est placé **à côté du notebook** [`../Tweety-2-Basic-Logics-Csharp.ipynb`](.
 | `tweety-pl-full-1.30.jar` (6.9 MB) | Fat-jar Maven shade (artefact de build intermédiaire) | Non (gitignoré, reconstruit ci-dessous) |
 | `build-tweety-pl-shade.pom.xml` | POM aggregator Maven shade (produit le fat-jar) | Oui (reproductibilité) |
 | `build-TweetyShade.csproj` | Projet MSBuild `<IkvmReference>` (convertit le fat-jar en DLL) | Oui (reproductibilité) |
+
+## Fichiers — cluster `beliefdynamics` (notebook [`../Tweety-4-Belief-Revision-Csharp.ipynb`](../Tweety-4-Belief-Revision-Csharp.ipynb))
+
+| Fichier | Rôle | Committé ? |
+|---------|------|-----------|
+| `org.tweetyproject.tweety-beliefdynamics.dll` (10.3 MB) | **Runtime** .NET des opérateurs AGM (contraction, révision de Levi) | Oui (pattern #4711) |
+| `tweety-beliefdynamics-full-1.30.jar` (9.6 MB) | Fat-jar Maven shade (artefact intermédiaire) | Non (gitignoré, reconstruit ci-dessous) |
+| `build-tweety-beliefdynamics-shade.pom.xml` | POM aggregator Maven shade | Oui (reproductibilité) |
+| `build-TweetyBeliefDynamicsShade.csproj` | Projet MSBuild `<IkvmReference>` | Oui (reproductibilité) |
+
+### Contrainte bytecode Java 8 (piège majeur du cluster `beliefdynamics`)
+
+IKVM 8.15 est un runtime **Java 8** : il **saute silencieusement** toute classe compilée en
+bytecode major > 52 (Java 9+), avec un warning `IKVM0101 class format error "55.0"`. Le pom parent
+de Tweety compile par défaut en `<release>11</release>` (major 55) → **les opérateurs de révision
+seraient absents de la DLL**. La recette rebuild patche le pom parent en `<release>8</release>`
+(+ `source`/`target` 8) avant `mvn install` du module `beliefdynamics`, garantissant du major-52
+IKVM-compilable. Vérification : `od -An -tu1 -j6 -N2 LeviMultipleBaseRevisionOperator.class` doit
+afficher `52`.
 
 ## Recette de rebuild (si la DLL doit être régénérée)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-TweetyBeliefDynamicsShade.csproj
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-TweetyBeliefDynamicsShade.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <RestoreAdditionalProjectSources></RestoreAdditionalProjectSources>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="IKVM" Version="8.15.0" />
+    <PackageReference Include="IKVM.MSBuild" Version="8.15.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <IkvmReference Include="tweety-beliefdynamics-full-1.30.jar">
+      <AssemblyName>org.tweetyproject.tweety-beliefdynamics</AssemblyName>
+      <AssemblyVersion>1.30.0.0</AssemblyVersion>
+      <AssemblyFileVersion>1.30.0.0</AssemblyFileVersion>
+    </IkvmReference>
+  </ItemGroup>
+</Project>

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-tweety-beliefdynamics-shade.pom.xml
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/build-tweety-beliefdynamics-shade.pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>local</groupId>
+  <artifactId>tweety-beliefdynamics-shade</artifactId>
+  <version>1.30</version>
+  <packaging>jar</packaging>
+  <name>Tweety beliefdynamics shaded fat-jar (IKVM target)</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.tweetyproject</groupId>
+      <artifactId>beliefdynamics</artifactId>
+      <version>1.30-SNAPSHOT</version>
+      <exclusions>
+        <exclusion><groupId>junit</groupId><artifactId>junit</artifactId></exclusion>
+        <exclusion><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId></exclusion>
+        <exclusion><groupId>org.junit</groupId><artifactId>junit-bom</artifactId></exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <finalName>tweety-beliefdynamics-full-1.30</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+              </transformers>
+              <filters>
+                <filter><artifact>*:*</artifact><excludes>
+                  <exclude>META-INF/*.SF</exclude><exclude>META-INF/*.DSA</exclude>
+                  <exclude>META-INF/*.RSA</exclude><exclude>module-info.class</exclude>
+                </excludes></filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Résumé

Sixième notebook C# de l'**Epic Tweety .NET** (#4667, IKVM 8.15.0) — module **beliefdynamics** : les opérateurs de **révision de croyances AGM** exécutés en C# natif via .NET Interactive. Complète la série `pl` (#4792) / semantics (#4802) / fol (#4808) / dung (#4831) / aspic (#4837).

Assignation anti-collision : **Tw-4 belief-revision assigné `po-2025:CoursIA-2`** (checklist #4667).

## Contenu pédagogique (23 cellules, 10 code / 3 exercices, exécuté end-to-end)

| Section | Opérateur AGM démontré |
|---------|------------------------|
| 3. Cohérence | test par entailment d'une contradiction (`SimplePlReasoner` : une base est incohérente ssi elle entraîne `a && !a`) |
| 4. Contraction | `KernelContractionOperator` + `RandomIncisionFunction` (retire `b` de `{a, a=>b, !c}` → `{a, !c}`) |
| 5. Révision | identité de **Levi** `K * φ = (K - ¬φ) + φ` via `LeviMultipleBaseRevisionOperator` |
| 6. Exemple guidé | **le pingouin Tweety** (raisonnement non-monotone) |

**Problème non-trivial (Prong B, #3801)** : le pingouin `K = {p, p=>b, b=>f}` conclut « Tweety vole ». L'observation `!f` crée une incohérence **dérivée** (via la chaîne d'implications `p → b → f`, pas un `p ∧ ¬p` direct). La révision doit sacrifier une règle par défaut. Le notebook **calcule et affiche** la croyance effectivement abandonnée, et explicite que la contraction AGM n'est **pas unique** (l'incision dépend de `RandomIncisionFunction`).

## Preuve d'exécution (règle D / C.2)

Kernel `.net-csharp`, `jupyter nbconvert --execute` — **0 cellule en erreur**, tous les `execution_count` renseignés, outputs réels committés. Extraits :

```
Base initiale         K = { (a=>b), a, !c }
K incoherente ?           false
Union naive incoherente ? true
K contractee par b = [a, !c]        // Entraine encore b ? false
K revisee par !b (Levi) = [a, !b, !c]   // incoherent ? false | contient !b ? True
--- pingouin ---
K conclut que Tweety vole (f) ? true
K revisee par !f = [(b=>f), p, !f]      // incoherent ? false | conclut !f ? True
Croyance(s) abandonnee(s) par la revision : [(p=>b)]
```

`grep raise NotImplementedError|assert False|1/0` (source) = **0** (règle C.1). 3 exercices stub (`Console.WriteLine("Exercice N a completer")`).

## Verdict SOTA — **SOTA-OK**

La bibliothèque réelle `org.tweetyproject.beliefdynamics` est IKVM-compilée (`org.tweetyproject.tweety-beliefdynamics.dll`, 10.3 MB) et invoquée directement ; toutes les sorties sont sa vraie sortie d'exécution. Aucun workaround dégradé.

**Piège majeur documenté** (`dotnet-build/README.md`) : IKVM 8.15 est un runtime **Java 8** qui saute silencieusement les classes bytecode major > 52 (`IKVM0101 class format error "55.0"`). Le pom parent de Tweety compile en `release 11` (major 55) → les opérateurs de révision seraient **absents de la DLL**. La recette rebuild patche le pom parent en `release 8` (major 52 IKVM-compilable), vérifié par `od -An -tu1 -j6 -N2 LeviMultipleBaseRevisionOperator.class` → `52`.

## Fichiers

- `Tweety-4-Belief-Revision-Csharp.ipynb` — le notebook (sorties réelles)
- `org.tweetyproject.tweety-beliefdynamics.dll` — runtime IKVM (sibling, pattern #4711)
- `dotnet-build/{build-TweetyBeliefDynamicsShade.csproj, build-tweety-beliefdynamics-shade.pom.xml}` — recette reproductible
- `dotnet-build/README.md` — section beliefdynamics + contrainte bytecode Java 8

Catalogue **inchangé** (byte-identique à main) — régénéré par l'automatisation.

See #4667
See #3801