### PR TITLE
docs(lean): i18n bilingual docstrings — sudoku_lean pilot + convention proposal (See #4980)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku.lean
@@ -30,4 +30,35 @@ hidden single), fondement formel des solveurs enseignés dans la série `Sudoku`
 - #2978 (Sudoku comme regex symbolique) : angle Lean = `finiteness-derivatives`
   (terminaison de reconnaisseur), **sans chevauchement** avec la propagation/exact-cover
   formalisés ici (coordination vérifiée).
+
+---
+
+**English — Soundness of Sudoku constraint propagation (Lean 4).**
+
+Formalisation of the **soundness of the propagation rules** of a Sudoku (naked single,
+hidden single), the formal foundation of the solvers taught in the `Sudoku` series
+(backtracking, OR-Tools, .NET). See issue #4055 (Lean roadmap #4038).
+
+## Contents
+- `Sudoku.Basic`: abstract constraint structure — `Scopes` (all-distinct scopes),
+  `Solution`, `IsSolution`, `AllDistinctOn`, `IsPeer`, `PresentIn`. The abstraction
+  captures any "all-distinct-scopes" CSP (the 9×9 grid is one instance, not a special
+  case).
+- `Sudoku.Propagation`: the **keystone** `peer_excludes_value` (an assigned cell excludes
+  its value from all its peers) and the two soundness theorems `naked_single_sound` +
+  `hidden_single_sound`, 0 `sorry`.
+
+## Status
+- Proved without `sorry`: soundness of the naked/hidden single rules (via the keystone
+  `peer_excludes_value`). Propagation removes **no valid solution**.
+- Open (next milestone): the **Sudoku ⇔ exact-cover reduction** (Knuth, 4 constraint
+  families) and completeness of the rules. Not `sorry`-backed.
+- Out of scope: the "17-clue minimum" result (massive computation, not formalisable).
+
+## Cross-reference
+- `Sudoku` series (C#/.NET + Python): the backtracking/OR-Tools/Infer.NET solvers whose
+  propagation step this lake formally grounds.
+- #2978 (Sudoku as a symbolic regex): the Lean angle is `finiteness-derivatives`
+  (recogniser termination), **without overlap** with the propagation/exact-cover
+  formalised here (coordination verified).
 -/

--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Basic.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Basic.lean
@@ -16,6 +16,23 @@ pas du fait qu'il y ait 9 valeurs ou des blocs 3×3, mais seulement de l'invaria
 
 Référence croisée : la série `Sudoku` (backtracking, OR-Tools, .NET, Infer.NET) dont ce
 lake fonde formellement les solveurs par propagation. Voir issue #4055.
+
+---
+
+**English — Constraint structure, solutions, peers.**
+
+Abstract formalisation of a Sudoku (more generally: any constraint-satisfaction problem
+with "all-distinct scopes"). A concrete 9×9 Sudoku is one instance of this framework: the
+**scopes** are its 27 families (9 rows, 9 columns, 9 blocks), each of which must carry
+**all-distinct** values.
+
+The abstraction is deliberate: the soundness theorems of propagation (`Propagation.lean`)
+hold for **every** structure of this kind, not only the 9×9 grid. This is the right level
+of formalisation — the logic of propagation does not depend on there being 9 values or
+3×3 blocks, only on the "all-distinct per scope" invariant.
+
+Cross-reference: the `Sudoku` series (backtracking, OR-Tools, .NET, Infer.NET), whose
+propagation-based solvers this lake formally grounds. See issue #4055.
 -/
 
 namespace Sudoku
@@ -23,36 +40,57 @@ namespace Sudoku
 variable {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V] [DecidableEq V]
 
 /-- La structure de contraintes d'un Sudoku : un ensemble fini de **portées** (chacune
-    un `Finset` de cellules) devant porter des valeurs toutes distinctes. -/
+    un `Finset` de cellules) devant porter des valeurs toutes distinctes.
+
+    The constraint structure of a Sudoku: a finite set of **scopes** (each a `Finset` of
+    cells) that must carry all-distinct values. -/
 abbrev Scopes (ι : Type*) := Finset (Finset ι)
 
-/-- Une affectation complète : une valeur par cellule. -/
+/-- Une affectation complète : une valeur par cellule.
+
+    A complete assignment: one value per cell. -/
 abbrev Solution (ι V : Type*) := ι → V
 
 /-- `σ` est **toutes-distinctes sur `s`** si deux cellules distinctes de `s` ne portent
-    jamais la même valeur (injectivité de `σ` sur `s`). -/
+    jamais la même valeur (injectivité de `σ` sur `s`).
+
+    `σ` is **all-distinct on `s`** if two distinct cells of `s` never carry the same
+    value (injectivity of `σ` on `s`). -/
 def AllDistinctOn (σ : Solution ι V) (s : Finset ι) : Prop :=
   ∀ ⦃c c'⦄, c ∈ s → c' ∈ s → σ c = σ c' → c = c'
 
 /-- `σ` est une **solution** de la structure `scopes` si elle est toutes-distinctes sur
     chacune des portées. C'est l'invariant fondamental du Sudoku (chaque ligne, colonne
-    et bloc contient chaque valeur au plus une fois). -/
+    et bloc contient chaque valeur au plus une fois).
+
+    `σ` is a **solution** of the structure `scopes` if it is all-distinct on every scope.
+    This is the fundamental Sudoku invariant (each row, column and block contains each
+    value at most once). -/
 def IsSolution (scopes : Scopes ι) (σ : Solution ι V) : Prop :=
   ∀ s ∈ scopes, AllDistinctOn σ s
 
-/-- `σ` **concorde** avec une affectation partielle `a` partout où `a` est définie. -/
+/-- `σ` **concorde** avec une affectation partielle `a` partout où `a` est définie.
+
+    `σ` **agrees** with a partial assignment `a` wherever `a` is defined. -/
 def AgreesWith (σ : Solution ι V) (a : ι → Option V) : Prop :=
   ∀ i, ∀ v, a i = some v → σ i = v
 
 /-- `c'` est une **paire** de `c` (anglais : *peer*) si elles sont distinctes et
     partagent au moins une portée. Deux cellules paires ne peuvent porter la même
-    valeur dans une solution. -/
+    valeur dans une solution.
+
+    `c'` is a **peer** of `c` if they are distinct and share at least one scope. Two peer
+    cells cannot carry the same value in a solution. -/
 def IsPeer (scopes : Scopes ι) (c c' : ι) : Prop :=
   c ≠ c' ∧ ∃ s ∈ scopes, c ∈ s ∧ c' ∈ s
 
 /-- Une valeur `v` est **présente dans la portée `s`** si quelque cellule de `s` la
     porte. Pour une portée « pleine maison » (|s| = |V|) d'une solution, toute valeur y
-    est présente (lemme de la maison pleine). -/
+    est présente (lemme de la maison pleine).
+
+    A value `v` is **present in the scope `s`** if some cell of `s` carries it. For a
+    "full house" scope (|s| = |V|) of a solution, every value is present there (full-house
+    lemma). -/
 def PresentIn (σ : Solution ι V) (s : Finset ι) (v : V) : Prop :=
   ∃ c ∈ s, σ c = v
 
@@ -63,7 +101,16 @@ def PresentIn (σ : Solution ι V) (s : Finset ι) (v : V) : Prop :=
     C'est l'argument de pigeonhole : `σ` restreinte à `s` est injective, donc son image
     a `card s = card V` éléments distincts — soit la totalité de `V` — donc toute valeur
     y apparaît. Ce lemme rend automatique l'hypothèse `PresentIn σ s v` du « hidden single »
-    (`Propagation.hidden_single_sound`) dans le cas plein-maison (cf #4055). -/
+    (`Propagation.hidden_single_sound`) dans le cas plein-maison (cf #4055).
+
+    **Full-house lemma.** If a scope `s` contains as many cells as there are possible
+    values (`s.card = card V`) and an assignment `σ` is all-distinct on `s`, then
+    **every** value `v` is present in `s`.
+
+    This is the pigeonhole argument: `σ` restricted to `s` is injective, so its image has
+    `card s = card V` distinct elements — i.e. all of `V` — hence every value appears
+    there. This lemma makes the hypothesis `PresentIn σ s v` of the "hidden single"
+    (`Propagation.hidden_single_sound`) automatic in the full-house case (cf. #4055). -/
 theorem full_house_present {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
     [DecidableEq V] (σ : Solution ι V) (s : Finset ι) (v : V)
     (hcard : s.card = Fintype.card V) (hAD : AllDistinctOn σ s) : PresentIn σ s v := by

--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Propagation.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Propagation.lean
@@ -24,6 +24,29 @@ tout Sudoku ? non en général — d'où le backtracking), sont des jalons natur
 **ouverts**, délibérément **non `sorry`-backed** : la bibliothèque reste entièrement
 `sorry`-free. Le résultat de calcul massif « 17 indices minimum » est hors scope
 (non formalisable).
+
+---
+
+**English — Soundness of the propagation rules.**
+
+Issue #4055. Sudoku solvers (backtracking, OR-Tools, the .NET solvers of the `Sudoku`
+series) speed up resolution by **propagating** constraints: as soon as a value is placed,
+the candidates that have become impossible are eliminated. Two canonical rules:
+
+- **Naked single**: a cell whose only remaining candidate is `v` must contain `v`.
+- **Hidden single**: a value that can go in only one cell of a scope must go there.
+
+This module proves the **soundness** of these rules: they **remove no valid solution** —
+eliminating a candidate via propagation means eliminating an assignment that **no
+solution uses**. The keystone is `peer_excludes_value`: an assigned cell excludes its
+value from all its peers.
+
+**Honest scoping (G.3/G.9).** The soundness of both propagation rules is proved in full
+(0 `sorry`). The **Sudoku ⇔ exact-cover reduction** (Knuth, 4 constraint families), as
+well as completeness (do the rules suffice to solve every Sudoku? no in general — hence
+backtracking), are natural milestones left **open**, deliberately **not `sorry`-backed**:
+the library remains entirely `sorry`-free. The massive-computation "17-clue minimum"
+result is out of scope (not formalisable).
 -/
 
 namespace Sudoku
@@ -36,7 +59,14 @@ namespace Sudoku
 
     **Preuve** (0 `sorry`) : `c` et `c'` partagent une portée `s` ; `σ` est
     toutes-distinctes sur `s`, donc `σ c = σ c'` impliquerait `c = c'`, contredisant
-    `c ≠ c'` (définition de paire). -/
+    `c ≠ c'` (définition de paire).
+
+    **Keystone.** In a solution, a cell `c` carrying the value `v` excludes `v` from
+    every **peer** cell `c'` (same scope): `σ c' ≠ v`. This is the fundamental fact from
+    which all propagation rules derive.
+
+    **Proof** (0 `sorry`): `c` and `c'` share a scope `s`; `σ` is all-distinct on `s`, so
+    `σ c = σ c'` would imply `c = c'`, contradicting `c ≠ c'` (the definition of peer). -/
 theorem peer_excludes_value {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
     [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V)
     (hσ : IsSolution scopes σ) (c c' : ι) (v : V)
@@ -60,7 +90,20 @@ theorem peer_excludes_value {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintyp
 
     **Preuve** (0 `sorry`) : par l'absurde, `σ c = w ≠ v`. Par l'hypothèse de couverture,
     `w` apparaît sur une paire `c'` de `c` ; mais `peer_excludes_value` interdit à `c'`
-    de porter `σ c`. Contradiction. -/
+    de porter `σ c`. Contradiction.
+
+    **Naked single (soundness).** If, in a solution `σ`, every value but `v` is already
+    carried by a **peer** of `c` (i.e. each `w ≠ v` occurs on a peer cell of `c`), then
+    `σ c = v`.
+
+    This is the formalisation of the "naked single": cell `c` has only `v` left as a
+    possible candidate (every other value is excluded by its peers), so every solution
+    places `v` there. The rule removes no solution because it identifies a **forced**
+    value.
+
+    **Proof** (0 `sorry`): by contradiction, `σ c = w ≠ v`. By the coverage hypothesis,
+    `w` occurs on a peer `c'` of `c`; but `peer_excludes_value` forbids `c'` from
+    carrying `σ c`. Contradiction. -/
 theorem naked_single_sound {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
     [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V)
     (hσ : IsSolution scopes σ) (c : ι) (v : V)
@@ -83,7 +126,20 @@ theorem naked_single_sound {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype
 
     **Preuve** (0 `sorry`) : `v` apparaît en `c0 ∈ s`. Si `c0 ≠ c`, l'hypothèse
     d'exclusion donne une paire `c''` de `c0` portant `v` ; mais `peer_excludes_value`
-    interdit à `c''` de porter `σ c0 = v`. Contradiction. Donc `c0 = c`, `σ c = v`. -/
+    interdit à `c''` de porter `σ c0 = v`. Contradiction. Donc `c0 = c`, `σ c = v`.
+
+    **Hidden single (soundness).** If, in a solution `σ` of the structure `scopes`, the
+    value `v` is present in the scope `s` (`PresentIn σ s v`), `c ∈ s`, and `v` is
+    **excluded** from every other cell `c' ∈ s` (each `c' ≠ c` has a peer carrying `v`),
+    then `σ c = v`.
+
+    This is the formalisation of the "hidden single": within a scope, `v` can only go in
+    `c`, so every solution places it there. For a "full house" scope (`|s| = |V|`), the
+    hypothesis `PresentIn σ s v` is automatic (every value occurs).
+
+    **Proof** (0 `sorry`): `v` occurs at `c0 ∈ s`. If `c0 ≠ c`, the exclusion hypothesis
+    gives a peer `c''` of `c0` carrying `v`; but `peer_excludes_value` forbids `c''` from
+    carrying `σ c0 = v`. Contradiction. Hence `c0 = c`, so `σ c = v`. -/
 theorem hidden_single_sound {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
     [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V)
     (hσ : IsSolution scopes σ) (s : Finset ι) (_hs : s ∈ scopes)

--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/lakefile.lean
@@ -38,6 +38,43 @@ Notebook compagnon (série `Sudoku`) : présentation pédagogique des solveurs p
 propagation. Le câblage du notebook revient au propriétaire de la série Sudoku
 (convention des lakes frères : le lake est le livrable formel, le `lake build` est la
 preuve d'exécution).
+
+---
+
+**English — Pedagogical Lean mini-project: soundness of Sudoku constraint propagation.**
+
+A Lean 4 (with Mathlib) project proving the **soundness of the propagation rules** of a
+Sudoku (naked single, hidden single): these rules, used by every solver taught in the
+`Sudoku` series (backtracking, OR-Tools, .NET), **remove no valid solution** — they only
+eliminate impossible assignments. See issue #4055 (Lean roadmap #4038). Coordination
+#2978 verified: the Lean angle of #2978 is regex-recogniser termination
+(`finiteness-derivatives`), without overlap with the propagation/exact-cover formalised
+here.
+
+First Lean theorem of the **Sudoku** series. The formalisation is **abstract over the
+constraint structure** (a Sudoku = a set of "scopes" `scopes`, each of which must carry
+all-distinct values): the soundness theorems hold for any structure of this kind (rows,
+columns, 3×3 blocks of the 9×9 grid, but also any all-distinct-scopes CSP). The concrete
+9×9 grid is one instance, not a special case.
+
+**Keystone**: `peer_excludes_value` — an assigned cell excludes its value from all its
+"peer" cells (same scope) in any solution. This is the fundamental fact from which the
+propagation rules derive:
+
+- `naked_single_sound`: if every value but `v` is already present among a cell's peers,
+  every solution places `v` there.
+- `hidden_single_sound`: if a value can go in only one cell of a scope, every solution
+  places it there.
+
+The Sudoku ⇔ exact-cover equivalence (Knuth, 4 constraint families) is a natural milestone
+left open (not `sorry`-backed) — propagation soundness is delivered in full.
+
+Mathlib provides `Finset`, injectivity on a set (`Set.InjOn`), and the finite-image
+arithmetic needed.
+
+Companion notebook (`Sudoku` series): pedagogical presentation of propagation-based
+solvers. Wiring the notebook is the responsibility of the Sudoku series owner (sibling-lake
+convention: the lake is the formal deliverable, `lake build` is the execution proof).
 -/
 
 package «sudoku_lean» where


### PR DESCRIPTION
## Contexte

Décision user 2026-07-02 (issue #4980) : les **fichiers `.lean` eux-mêmes** (docstrings `/-- -/`, commentaires `--`, sections doc) — aujourd'hui patchwork FR/EN selon le lake et l'auteur — doivent être **harmonisés en français** et **traduits au moins en anglais**, « comme les readme ». Cette PR livre les 3 livrables du grain po-2026 : (1) inventaire, (2) proposition de convention, (3) PR pilote sur `sudoku_lean`.

---

## 1. Inventaire FR/EN par lake (194 fichiers, evidence-cited)

Méthode : pour chaque `.lean` traqué (hors vendored `.lake/`, `_peters/`, `Z3.Linq/`, `agent_tests/.../reference_docs/`), extraction du texte des commentaires (`--` + `/-! ... -/` + `/-- ... -/`), classification par **présence de caractères accentués français** (àâäéèêëîïôöûüùçœ) dans les commentaires.

- **FR** = au moins un accent dans un commentaire (le fichier est au moins partiellement FR).
- **EN** = commentaires non-vides mais purement ASCII (anglais).
- **--** = aucun commentaire.

| Lake (racine) | fichiers | FR | EN | -- | lignes comm. |
|---|---:|---:|---:|---:|---:|
| GameTheory/conway_cgt_lean | 2 | 0 | 2 | 0 | 14 |
| GameTheory/cooperative_games_lean | 5 | 1 | 3 | 1 | 428 |
| GameTheory/examples | 1 | 0 | 1 | 0 | 30 |
| GameTheory/lean_game_defs | 6 | 0 | 6 | 0 | 177 |
| GameTheory/lean_game_defs_ext | 11 | 0 | 10 | 1 | 137 |
| GameTheory/minimax_lean | 5 | 4 | 0 | 1 | 21 |
| GameTheory/repeated_games_lean | 5 | 3 | 1 | 1 | 25 |
| GameTheory/social_choice_lean | 10 | 0 | 8 | 2 | 289 |
| GameTheory/stable_marriage_lean | 7 | 0 | 6 | 1 | 245 |
| ML/learning_theory_lean | 19 | 19 | 0 | 0 | 304 |
| Probas/decision_theory_lean | 13 | 3 | 6 | 4 | 108 |
| QuantConnect/kelly_lean | 4 | 3 | 0 | 1 | 39 |
| Search/astar_lean | 6 | 4 | 0 | 2 | 31 |
| **Sudoku/sudoku_lean** ⬅ pilote | 4 | 2 | 0 | 2 | 15 |
| SymbolicAI/Lean (racine) | 8 | 1 | 6 | 1 | 198 |
| SymbolicAI/Lean/calibration_lean | 5 | 0 | 4 | 1 | 45 |
| SymbolicAI/Lean/conway_lean | 25 | 0 | 24 | 1 | 884 |
| SymbolicAI/Lean/finiteness_lean | 3 | 2 | 0 | 1 | 14 |
| SymbolicAI/Lean/grothendieck_lean | 25 | 0 | 24 | 1 | 266 |
| SymbolicAI/Lean/knot_lean | 8 | 2 | 5 | 1 | 525 |
| SymbolicAI/Lean/sensitivity_lean | 6 | 0 | 5 | 1 | 21 |
| SymbolicAI/Planners/planning_lean | 4 | 3 | 0 | 1 | 22 |
| SymbolicAI/SmartContracts/erc20_lean | 5 | 3 | 0 | 2 | 23 |
| SymbolicAI/Tweety/argumentation_lean | 7 | 6 | 0 | 1 | 48 |
| **TOTAL** | **194** | **56** | **111** | **27** | **3909** |

**Lecture :** ~29 % des fichiers sont déjà FR (au moins partiellement), ~57 % EN pur, ~14 % sans commentaire. Le travail se répartit en deux natures :
- **Lakes EN-dominants** (conway, grothendieck, social_choice, stable_marriage, calibration, sensitivity, cooperative, lean_game_defs) → harmonisation FR + ajout EN.
- **Lakes FR-dominants** (learning_theory, minimax, kelly, astar, planning, erc20, argumentation, finiteness, sudoku) → déjà FR, ajout EN seulement.

---

## 2. Convention de traduction proposée (recommandation + trade-offs)

Le mécanisme `.en.md` des READMEs **ne transpose pas** à du code : un `.en.lean` parallèle dupliquerait tout le code = **dérive garantie** (deux sources de vérité). Trois options :

| Option | Description | Avantages | Inconvénients |
|---|---|---|---|
| **(A) Docstrings bilingues inline** ⬅ recommandée | FR puis EN dans le même docstring (`/-! ... -/` module, `/-- ... -/` déclaration), séparés par une ligne `---` + lead-in `English:` | Source unique ⇒ **zéro dérive** ; rendu doc-gen4 natif ; fonctionne **sans aucune infrastructure** ; couvre docstrings ET commentaires `--` ; reviewable in-repo dans la PR | Double le volume des docstrings ; nécessite une convention de délimiteur claire |
| (B) doc-gen4 + docs traduites extraites | FR canonique dans la source, EN générée séparément à partir du portail doc-gen4 | FR = seule source ; rendu HTML bilingue propre | Traduction = artefact de build (**pas in-repo, pas reviewable**) ; nécessite doc-gen4 par lake ; **ne couvre pas** les commentaires `--` tactiques |
| (C) Fichier doc compagnon `.md` par module | `.lean` FR canonique + `<Module>.md` EN à côté | Sépare prose et code | **Risque de dérive** (le compagnon pourrit quand le code bouge) ; un fichier de plus par module ; s'approche du problème `.en.lean` |

### Recommandation : **(A) Docstrings bilingues inline**, avec la sous-convention suivante :

1. **Docstrings de module** (`/-! ... -/`) et **de déclaration** (`/-- ... -/`) : **bilingues**, FR d'abord, puis EN après un séparateur `---` + lead-in `English:` / `**English — ...**`.
2. **Commentaires tactiques inline** (`-- ...`) : **FR seulement**. Justification : orientés développeur, liés aux tactiques Lean (langage-neutre) — traduire chaque `-- apply lemme X` double le bruit pour une valeur marginale. Tunable si le user préfère tout traduire.
3. **Noms d'identifiants** : **inchangés**. La convention de nommage Lean suit l'anglais/Mathlib (`peer_excludes_value`, `AllDistinctOn`) ; franciser casserait l'écosystème et chaque import.
4. **Exclusions** : mêmes que readme-french-first (libs vendored `.lake/packages/**`, lakes externes `_peters`, forks untracked `Z3.Linq`, snapshots `agent_tests/.../reference_docs/`).

---

## 3. PR pilote — `sudoku_lean` (ce qui est appliqué)

`sudoku_lean` est le pilote idéal : petit (4 fichiers), **0 sorry** (vérifié token-grep, pas substring), déjà **entièrement FR** — il démontre la convention sur du contenu FR (l'état cible vers lequel les lakes EN convergeront aussi).

**Fichiers modifiés (4, docstrings/commentaires uniquement — zéro ligne de code/tactique touchée) :**
- `Sudoku.lean` : docstring module +EN
- `Sudoku/Basic.lean` : docstring module + 7 docstrings de déclaration (`Scopes`, `Solution`, `AllDistinctOn`, `IsSolution`, `AgreesWith`, `IsPeer`, `PresentIn`, `full_house_present`) +EN
- `Sudoku/Propagation.lean` : docstring module + 3 docstrings de théorème (`peer_excludes_value`, `naked_single_sound`, `hidden_single_sound`) +EN
- `lakefile.lean` : docstring module +EN

### Vérification

- **Real sorry count (token-grep)** : 0 avant, 0 après (leçon FX-7 appliquée — le substring grep renvoie 6/3/1 à cause des mentions prose + deps vendored).
- **Diff docstring-only** : 182 insertions / 11 deletions ; les 11 suppressions = fermetures `-/` de docstrings **repositionnées** (EN inséré avant chaque `-/`), aucune ligne `def`/`theorem`/tactique modifiée.
- **Équilibre des délimiteurs de commentaires** préservé (opens==closes par fichier).
- **`lake build Sudoku` LOCAL SUCCESS** : 8495 jobs, EXIT 0 (Mathlib via cache rc1 partagé réparé par `lake exe cache get` ; `Sudoku.Basic` + `Sudoku.Propagation` buildés proprement). Les commentaires ne changent pas la compilation — confirmé **zero semantic impact**.
- **FR préservé verbatim** (anti-régression honored — aucun français retiré).

---

## 4. Rollout proposé

Après validation de la convention par le user / ai-01, rollout **lake par lake** à la même cadence que #3870 / #1650 Phase 0.5 (pas de big-bang). Ordre suggéré par difficulté croissante :
1. Lakes FR-dominants déjà propres (kelly, astar, planning, erc20, argumentation, finiteness, learning_theory, minimax) — ajout EN seul, faible risque.
2. Lakes EN-dominants petits (calibration, sensitivity, conway_cgt, lean_game_defs).
3. Lakes EN-dominants lourds (stable_marriage, social_choice, cooperative_games).
4. conway_lean (24 fichiers EN, 884 lignes) — **coordination ai-01 requise** (lane Hashlife L2536 active, collision fichier).
5. grothendieck_lean (24 fichiers EN) — dernier.
6. knot_lean — **lane ai-01 `[CLAIMED]`**, ne pas toucher sans coordination.

---

## Notes

- See #4980, #4957, #1650. Part of #4208 (axe E).
- Aucun `Closes` : la convention est un rollout multi-lake ; cette PR ne clôt pas l'issue (pilot + proposition seulement).
- Collision vérifiée : aucune PR ouverte sur #4980 / i18n Lean au moment du push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
