### PR TITLE
feat(lean): Hashlife L2536 → 4-quadrant + reverse decomposition (build-verified, P4.4 gate identified) (See #3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2070,9 +2070,10 @@ theorem centralCorrect_mem (c : MacroCell) (j : Nat) (p : Int × Int)
 
     Pure composition of `centralCorrect_mem` (G2 congruence, c.153) and
     `toGrid_shift_between` (#4797, the double-shift ingredient) — sorry-free gate
-    ingredient. The residual research heart (sorry 4→3) is `evolve_half_step`,
-    which consumes this gate to connect the induction hypothesis
-    `centralCorrect q_* (k-1)` to the four quadrant offsets at once. -/
+    ingredient. `evolve_half_step` (L2370) and `evolve_add` (L2353) are now
+    sorry-free (c.167 audit); the residual research heart is the L2536
+    offset-matching assembly, which consumes this gate to relate each
+    `out_*` quadrant grid to the wave-2 super-cell `centralCorrect`. -/
 theorem centralCorrect_mem_shift (c : MacroCell) (j : Nat) (a b : Int) (p : Int × Int)
     (h : centralCorrect c j) :
     p ∈ (hashlifeResultAux (j + 2) c).toGrid (a, b) ↔
@@ -2533,7 +2534,61 @@ noncomputable def p4_succ_membership
   -- q_* (k-1)` from `_h3`, then bridged to the RHS window via `evolve_half_step`
   -- (the `2^k` half-step) + `evolve_add` (G1). The offsets `2^out_*.level` vs
   -- `2^k` and the ih at level (k-1) vs goal at level k are the matching core.
-  sorry
+  --
+  -- ATTACK PLAN (c.167 structural audit, po-2026): all G2/G3 infrastructure is
+  -- sorry-free (`evolve_add` L2353, `evolve_half_step` L2370,
+  -- `centralCorrect_mem_shift` L2076, `mem_toGrid_node` L1113,
+  -- `centralCorrect_mem` L2045) — do NOT re-litigate them. The crux is that
+  -- `p4_wave2_ih` (L2200) provides `centralCorrect` of the wave-2 SUPER-CELL
+  -- (a node of 4 `hashlifeResultAux (k+1)` cells), NOT of the individual
+  -- `out_*` quadrants; the goal needs each quadrant separately. Strategy:
+  -- prove ONE intermediate lemma per quadrant relating
+  -- `out_*.toGrid (off_*, off_*)` to the super-cell's `centralCorrect`, via
+  -- `centralCorrect_mem_shift` (#4812, arbitrary-offset re-anchoring) +
+  -- `toGrid_shift_between` (#4797); reduce the RHS with
+  -- `simp [mem_restrictGridTo, isAlive]`. Then assemble the four quadrant
+  -- lemmas under `mem_toGrid_node`. Quadrant-by-quadrant, not all at once.
+  -- Decomposition (c.167 structural balisage): split the iff into (mp) 4 quadrants
+  -- + (mpr) reverse direction. Each mp-branch is a standalone offset-matching
+  -- assembly: relate `out_*.toGrid (off_*, off_*)` to the wave-2 super-cell's
+  -- `centralCorrect` (via `centralCorrect_mem_shift` + `p4_wave2_ih`), then bridge
+  -- to the RHS `restrictGridTo` window via `evolve_half_step` + `evolve_add`.
+  refine Iff.intro (fun hmem => ?_) (fun hmem => ?_)
+  rcases hmem with hnw | hne | hsw | hse
+  · -- NW quadrant: p ∈ (hashlifeResultAux (k+1) out_nw).toGrid (2^k, 2^k)
+    -- where out_nw = hashlifeResultAux (k+1) (node r1 r2 r4 r5).
+    -- Apply centralCorrect_mem_shift with `a = b = 2^k`, `j = k`, `c = out_nw`,
+    -- using centralCorrect via p4_wave2_ih on the super-cell q_nw = node r1 r2 r4 r5.
+    -- Then reduce isAlive/restrictGridTo on RHS via mem_restrictGridTo + evolve_half_step.
+    sorry
+  · -- NE quadrant: shifted window offset (2^k, 2^k + 2^level_out) via out_ne.
+    sorry
+  · -- SW quadrant: shifted window offset (2^k + 2^level_out, 2^k) via out_sw.
+    sorry
+  · -- SE quadrant: shifted window offset (2^k + 2^level_out, 2^k + 2^level_out) via out_se.
+    sorry
+  · -- Reverse direction (mpr): from `p ∈ restrictGridTo (evolve 2^k g) 2^k 2^(k+1)`,
+    -- extract `p.1, p.2 ∈ [2^k, 3·2^k)` and split into 4 sub-windows to pick the
+    -- correct quadrant, then invert the mp argument via centralCorrect_mem_shift.
+    rw [mem_restrictGridTo] at hmem
+    obtain ⟨halive, h1, h2, h3, h4⟩ := hmem
+    -- Window bounds: h1..h4 : (2^k : Int) ≤ p.i < (2^k : Int) + 2^(k+1).
+    -- Convert to `+ 2 * 2^k` form for quad_partition_bounds.
+    have hpow : (2^(k+1) : Int) = 2 * (2^k : Int) := by
+      rw [pow_succ]; ring
+    have h2' : p.1 < (2^k : Int) + 2 * (2^k : Int) := by rw [← hpow]; exact h2
+    have h4' : p.2 < (2^k : Int) + 2 * (2^k : Int) := by rw [← hpow]; exact h4
+    have hs : (0 : Int) ≤ (2^k : Int) := by positivity
+    have hpart := (quad_partition_bounds (2^k : Int) (2^k : Int) hs p).mp
+      ⟨h1, h2', h3, h4'⟩
+    -- hpart : one of 4 sub-window disjuncts. Each disjunct pins p to one quadrant
+    -- sub-window, from which the appropriate out_* is selected via left/right and
+    -- membership reconstructed via inverse centralCorrect_mem_shift + p4_wave2_ih.
+    -- Full case-split (rcases hpart with ⟨..⟩ | ⟨..⟩ | ⟨..⟩ | ⟨..⟩) will consume
+    -- 4 sub-sorries — deferred to next cycle to respect the sorry ceiling budget.
+    -- Ingredients ready in scope: halive, h1..h4, hpart, hpow, p4_wave2_ih.
+    sorry
+
 
 /-- For a level-`k` MacroCell `c` with `k ≥ 2`, the centered region of
     `hashlifeResultAux (k+2) c` (viewed at offset `(2^k, 2^k)`) equals


### PR DESCRIPTION
## Contexte

Lane #3846 Hashlife GOL — **P4.4 G2 offset-matching assembly**. Le sorry opaque `p4_succ_membership` (L2536 sur `main`, jamais prouvé) bloquait la chaîne inductive P4. ai-01 a lancé un run BG ciblé (multi/12, L2551) qui a produit une **décomposition quadrant build-vérifiée**, poussée sur `wip/l2536-quadrant-decomposition`. ai-01 délègue la PR (DM `msg-...9vdwin` : « PR la décomposition pure avec le log lake build SUCCESS en preuve + framing honnête »). Cette PR livre cette décomposition + une **analyse de gate** (la contribution analytique de po-2026).

## Ce que fait la décomposition

Le sorry opaque L2536 est remplacé par un squelette `refine Iff.intro ... ; rcases hmem with hnw|hne|hsw|hse` qui **typecheck** :
- **4 sous-buts quadrant** (NW/NE/SW/SE), chacun annoté avec sa recette d'attaque (`centralCorrect_mem_shift` #4812 + `toGrid_shift_between` #4797, reduce via `mem_restrictGridTo`/`isAlive`).
- **1 direction reverse (mpr)** avec échafaudage tactique **réel** (pas un sorry brut) : `mem_restrictGridTo`, `quad_partition_bounds` appliqué, bornes `h1..h4` + `hpow` (`2^(k+1) = 2·2^k`), `positivity`, avant le sorry final de case-split.

## ★ Analyse de gate (contribution po-2026 — point-clé stratégique)

L'examen firsthand de chaque sous-but révèle que **les 5 sous-buts sont tous bloqués en amont par P4.4 `p4_half_steps_compose`** (L2472, actuellement placeholder `True`), et NON par l'offset-matching assembly lui-même :

- Chaque quadrant `out_*` est `hashlifeResultAux (k+1) (...)`, donc `centralCorrect_mem_shift` s'instantie avec **j = k−1** (j+2 = k+1), caractérisant l'appartenance via **`evolve 2^(k−1)`** sur le quadrant.
- Le **RHS** du but est **`evolve 2^k`**.
- Combler l'écart `evolve 2^k` vs `evolve 2^(k−1)` = la composition half-step **sur la fenêtre centrée avec localité light-cone** = exactement `p4_half_steps_compose` (P4.4, light-cone lemma P2 + `step_light_cone`).
- Note : `evolve_half_step` (L2370, **closed**) donne la composition en générations (`evolve 2^k = evolve 2^(k−1) ∘ evolve 2^(k−1)`) mais **pas** la version localisée-fenêtre — d'où le placeholder `True` restant sur P4.4.

**Implication** : attaquer les quadrants directement est prématuré — tant que P4.4 est un placeholder `True`, aucun quadrant ne peut closer. La décomposition reste le bon roadmap (chaque sous-but est désormais documenté et isolé), mais **la prochaine attaque doit cibler `p4_half_steps_compose` (P4.4)**, pas les quadrants. Reco po-2026 → ai-01 : prochain BG ciblé sur le statement réel de P4.4 (light-cone half-step composition sur la fenêtre).

## Comptage sorry honnête (FX-7 — token-grep, pas substring)

| | token-grep (authoritaire) | substring (FX-7 INFLATED) |
|---|---:|---:|
| `main` | **4** (L2471/2536/2853/2862) | 32 |
| Cette PR | **8** (L2472/2563/2565/2567/2569/2590/2908/2917) | 38 |

**Net : +4 sorries réels** (4 → 8). C'est **balisage/roadmap**, PAS proof-progress : le sorry opaque L2536 (jamais prouvé) est décomposé en 5 sous-buts documentés + échafaudage reverse à tactiques réelles. **Aucun code prouvé n'est remplacé par sorry** (L2536 n'a jamais été prouvé) → pas une régression anti-règle D. La valeur = roadmap actionnable + identification de la gate P4.4.

## Vérification build (indépendante, G.1)

- `lake build Conway.Life.HashlifeCorrectness` **SUCCESS 2950 jobs, EXIT 0** — confirmé **firsthand sur le cache po-2026** (8112 oleans, rc1 partagé réparé via `lake exe cache get` c.168). Confirmatit le claim build de ai-01 (cache ai-01 8123 oleans), pas pris sur foi.
- 4 déclarations "uses sorry" (L2470 p4_half_steps_compose placeholder, L2499 p4_succ_membership décomposé, L2907/L2913 — inchangés vs main, renumérotés).

## Attribution

Décomposition (commit `a16480e0d`) = **ai-01** (run BG + build firsthand). Build-verification indépendante + analyse de gate P4.4 + framing PR = **po-2026** (ce cycle c.170).

## Notes

- See #3846 (Hashlife GOL epic, milestone P4.4). Pas `Closes` : P4.4 reste ouvert, c'est la gate identifiée.
- Commit a16480e0d poussé par ai-01 sur `wip/l2536-quadrant-decomposition` ; PR ouverte par po-2026 vers `main` (délégation DM `msg-...9vdwin`).
- Pas de collision fichier : ai-01 ne souhaite plus éditer `HashlifeCorrectness.lean` (« la balle est chez toi »).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
