### PR TITLE
feat(ci): GH Actions Pages deploy workflow - tranche 4 #4211

### DIFF
--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -1,0 +1,92 @@
+name: Quarto Pages Deploy
+
+# Quarto site build + GitHub Pages deployment
+# Tranche 4 #4211 — cf. https://github.com/jsboige/CoursIA/issues/4211
+# Owner: po-2023:CoursIA (scaffolding) / ai-01 (steering)
+#
+# Pattern : actions/deploy-pages + upload-pages-artifact (recommandé par GitHub)
+# vs branche `gh-pages` (legacy) — évite la pollution git du repo principal.
+#
+# Spécificités CoursIA :
+# - `freeze: auto` dans `_quarto.yml` : Quarto re-render seulement sur changement source
+# - `notebook-preview: false` : les .ipynb sont publiés tels quels avec outputs embedded
+# - Pas de kernel exec sur CI : les notebooks .NET C# / Lean 4 / Python sont déjà
+#   commités avec outputs (règle C.2). Seuls les .qmd sont rendus sur CI.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "_quarto.yml"
+      - "**.qmd"
+      - "MyIA.AI.Notebooks/**/index.qmd"
+      - "MyIA.AI.Notebooks/**/_output.ipynb"
+      - "MyIA.AI.Notebooks/**/README.md"
+      - "docs/**"
+      - "favicon.ico"
+      - "styles.css"
+      - ".github/workflows/quarto-pages-deploy.yml"
+  workflow_dispatch:
+
+# Annule les runs obsolètes pour économiser des minutes CI (mêmes pushes en rafale)
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Quarto site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          # Version alignée sur local (cf. po-2023-c160/c161 Quarto tranches).
+          # Si bump futur → changer ici + changer .claude/CLAUDE.md si besoin.
+          version: 1.7.32
+
+      - name: Render Quarto site
+        # `freeze: auto` (dans _quarto.yml) => Quarto n'exécute PAS les notebooks .ipynb.
+        # Les .ipynb sont juste copiés dans _site/ avec leurs outputs embedded
+        # (déjà validés et commités par les workers, règle C.2).
+        run: quarto render --to html
+        # Pas de --execute : sinon ça tente de ré-exécuter les notebooks = impossible
+        # sans kernels .NET Interactive / Lean 4 / conda Python spécialisés.
+
+      - name: Check output
+        # Sécurité : vérifie que _site/ existe (sinon le deploy échouera avec une
+        # erreur cryptique). Fail fast = message d'erreur clair.
+        run: |
+          test -d _site || (echo "::error::_site/ absent après quarto render" && exit 1)
+          test -f _site/index.html || (echo "::error::_site/index.html absent" && exit 1)
+          echo "_site/ présent avec $(find _site -type f | wc -l) fichiers"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+          # name: pas nécessaire, l'action lit le path
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        # Pas de branche gh-pages : utilise l'environment GitHub Pages natif
+        # via OIDC token (page-deploy doit être activé dans Settings → Pages).


### PR DESCRIPTION
## feat(ci): GH Actions Pages deploy workflow - tranche 4 #4211

**Tranche 4 Quarto #4211** — workflow GitHub Actions qui build le site Quarto et le déploie sur GitHub Pages (tranche finale après les 3 pilotes Search/GameTheory/Probas).

### Cadrage

- **Issue** : #4211 (Quarto déploiement progressif)
- **Cadrage ai-01** : commentaire #4211 06:41Z "Tranche 3 : GH Actions deploy GitHub Pages...À scoper par po-2023 quand le rollout séries a 2-3 pilotes de plus"
- **Pilotes MERGED** : Search #4919 (8 listings) + GameTheory #4977 (7 listings) — cadrage DÉGAGÉ
- **Pilote OPEN** : Probas #4989 (11 listings, en attente review ai-01)
- **Tranche 4 (cette PR)** : workflow CI/CD pour publier le site Quarto sur GitHub Pages automatiquement

### Workflow design

**Pattern moderne (artifact + deploy)** vs branche `gh-pages` legacy :

| Aspect | Pattern moderne (cette PR) | Legacy gh-pages |
|--------|----------------------------|-----------------|
| Stockage site | Artifact GitHub (temporaire, 90j) | Branche gh-pages persistante |
| Pollution repo | Aucune | 1 branche + commits auto |
| Authentification | OIDC `id-token: write` | Token PAT ou GITHUB_TOKEN |
| Rollback | Re-run workflow | `git revert` sur gh-pages |
| Recommandation GitHub | ✅ Oui (officiel) | Deprecated |

**Jobs** :

1. **build** — `ubuntu-latest`, permissions `contents: read`
   - `actions/checkout@v4`
   - `quarto-dev/quarto-actions/setup@v2` (version `1.7.32` alignée sur local)
   - `quarto render --to html` (sans `--execute`, voir gotcha ci-dessous)
   - Sanity check : `test -d _site && test -f _site/index.html` (fail-fast avec message clair)
   - `actions/upload-pages-artifact@v3` (upload du dossier `_site/`)

2. **deploy** — `ubuntu-latest`, `needs: build`, permissions `pages: write` + `id-token: write`
   - Environment `github-pages` (créé automatiquement par GitHub au premier deploy)
   - `actions/deploy-pages@v4` (consomme l'artifact + publie sur Pages via OIDC)

**Triggers** :

- `push` sur `main` modifiant : `_quarto.yml`, `**.qmd`, `MyIA.AI.Notebooks/**/index.qmd`, `MyIA.AI.Notebooks/**/_output.ipynb`, `MyIA.AI.Notebooks/**/README.md`, `docs/**`, `favicon.ico`, `styles.css`, le workflow lui-même
- `workflow_dispatch` pour test manuel
- `concurrency: pages-deploy / cancel-in-progress: true` (économie minutes CI sur pushes en rafale)

### Fichier modifié (atomique 1 fichier)

| Fichier | Type | Lignes | Rôle |
|---------|------|--------|------|
| `.github/workflows/quarto-pages-deploy.yml` | NEW | +92 | Workflow CI/CD Quarto → GitHub Pages |

**Total** : 1 fichier / 92 insertions / 0 deletion. ✅ Règle "1 sujet = 1 PR" respectée.

### Spécificités CoursIA (gotchas kernels)

- **`freeze: auto` dans `_quarto.yml`** : Quarto ne ré-exécute PAS les notebooks .ipynb sur CI. Seuls les .qmd sont rendus. Les .ipynb sont copiés tels quels avec leurs outputs embedded (règle C.2).
- **`notebook-preview: false`** : pas de preview HTML des notebooks, juste copie brute dans `_site/`.
- **Pas de kernel exec sur CI** : les notebooks .NET C# / Lean 4 / Python sont déjà validés et commités avec outputs par les workers. Le runner CI n'a besoin QUE de Quarto (pas de .NET Interactive, pas de Lean via WSL, pas de conda Python spécialisé).
- **Version Quarto 1.7.32** : alignée sur la version locale utilisée par po-2023 pour valider les pilotes 1-3. Si bump futur → bump simultané ici + `.claude/CLAUDE.md`.

### Action user requise (one-time setup)

Cette PR livre le workflow, mais le premier deploy nécessite **une action user unique** :

1. Aller dans **Settings → Pages** du repo `jsboige/CoursIA`
2. Sous **Source** : sélectionner **"GitHub Actions"** (au lieu de "Deploy from a branch")
3. Sauvegarder

L'environment `github-pages` est créé automatiquement par GitHub au premier deploy réussi. Aucune autre configuration manuelle n'est nécessaire.

Une fois activé, **chaque push sur `main`** touchant un fichier listé dans `paths:` déclenchera un build + deploy automatique sur `https://jsboige.github.io/CoursIA/`.

### Validation locale quarto 1.7.32

```
$ quarto render --to html
[1/7] MyIA.AI.Notebooks\Probas\index.qmd
[2/7] MyIA.AI.Notebooks\GameTheory\index.qmd
[3/7] MyIA.AI.Notebooks\Search\index.qmd
[4/7] MyIA.AI.Notebooks\index.qmd
[5/7] docs\index.qmd
[6/7] index.qmd
[7/7] parcours.qmd
Output created: _site\index.html
```

✅ Le workflow exécute exactement la même commande que la validation locale. Comportement identique attendu.

### Conformité

- **Read Body Before Any Action** : body #4211 + comments + body PRs voisines (#4919, #4977, #4989) lus
- **G.1 verify-before-claiming** : `actions/deploy-pages@v4` + `actions/upload-pages-artifact@v3` + `quarto-dev/quarto-actions/setup@v2` = versions 2024-2025 vérifiées (les actions sont les dernières stables)
- **G.9 culture du doute** : 0 fillration, travail substantiel tranche 4 finale
- **R5.4b anti-tunneling** : 4e cycle Quarto consécutif, MAIS cadrage ai-01 DÉGAGÉ explicite ("claim + livre-le") + owner explicite po-2023:CoursIA #4211
- **FILLER cap respecté** (PR #4924 LIVRÉE 11:31Z, pas de tranche accents ce cycle)
- **coordinator-discipline R1** : pas de merge unilateral, ai-01 review attendu
- **catalog-pr-hygiene R1** : 0 touche catalogue (pas de `COURSE_CATALOG.generated.json`)
- **catalog-pr-hygiene R2** : rebase frais depuis origin/main (worktree fresh `58e86d463`)
- **catalog-pr-hygiene R3** : 1 seul livrable (1 fichier workflow)
- **catalog-pr-hygiene R4** : `See #4211` (contribution partielle, epic reste ouverte — le workflow est un livrable mais l'activation Pages + suivi post-deploy sont séparés)
- **secrets-hygiene** : 0 secret (permissions minimales `contents: read` + `pages: write` + `id-token: write`)
- **readme-french-first** : commentaires workflow en FR
- **Sub-Agent Model Selection** : pas de sous-agent ce cycle (travail solo YAML)
- **Regle F env discipline** : pas d'env local nécessaire (workflow self-contained Quarto + GitHub-hosted runner)
- **body PR via --body-file** (règle anti-backtick)
- **worktree isolation** : `C:/dev/CoursIA-worktrees/4211-quarto-tranche4-ghpages`
- **branche feature/** : `feature/4211-quarto-tranche4-gh-pages` (conforme git-workflow)

### Leçons cross-tranche (consolidées)

- **Leçon novel léger** : `actions/deploy-pages@v4` + `upload-pages-artifact@v3` > legacy `gh-pages` branch — recommandé GitHub, OIDC natif, zéro pollution repo
- **Confirmation leçon C160** : PyYAML `safe_load` interprète `on:` comme booléen True, mais le parser GitHub Actions YAML le réinterprète correctement (testé dans la CI officielle sur des milliers de repos)
- **Confirmation leçon C160** : `freeze: auto` + `notebook-preview: false` = MVP sans kernel exec, suffisant pour publier les sorties déjà validées par les workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)