### PR TITLE
docs(lean): fix toolchain drift v4.30.0-rc2 → v4.31.0-rc1 in 5 leaf READMEs (See #3978, #4364)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
@@ -4,7 +4,7 @@ Formalisation en Lean 4 de la théorie des jeux coopératifs (valeur de Shapley,
 
 ## Statut
 
-- **Toolchain** : v4.30.0-rc2
+- **Toolchain** : v4.31.0-rc1
 - **Compte de sorry** : **0** — le théorème de Bondareva-Shapley est prouvé dans les deux directions
 - **Build** : `lake build CooperativeGames` — SUCCESS
 - **Dépendances** : Mathlib4
@@ -157,7 +157,7 @@ Ce projet formalise la théorie des jeux coopératifs en Lean 4 — la **valeur 
 (close, 0 `sorry`), le **Cœur** avec le **théorème de Bondareva-Shapley** (0 `sorry`,
 prouvé dans les deux directions), et la **théorie des jeux de vote simples** avec sa
 taxonomie des joueurs et les théorèmes d'indice de pouvoir associés (0 `sorry`). Il compile
-avec `lake build CooperativeGames` sur Mathlib4 (toolchain `v4.30.0-rc2`).
+avec `lake build CooperativeGames` sur Mathlib4 (toolchain `v4.31.0-rc1`).
 
 ### Ce qui est prouvé
 

--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
@@ -32,7 +32,7 @@ flowchart TD
 | `StableMarriage/GaleShapley.lean` | Terminaison, stabilité, `man_optimal`, `woman_pessimal` | 0 |
 | `StableMarriage/Lattice.lean` | Treillis de Knuth, réfutations, `exists_isManOptimal` | 0 |
 
-**Total** : 0 sorry en production. `lake build StableMarriage` SUCCESS. Toolchain `v4.30.0-rc2`.
+**Total** : 0 sorry en production. `lake build StableMarriage` SUCCESS. Toolchain `v4.31.0-rc1`.
 
 ## Théorèmes (statut)
 
@@ -89,7 +89,7 @@ grep -c sorry StableMarriage/*.lean
 Ce projet est une formalisation Lean 4 **complète, à 0 `sorry`** du **théorème de
 mariage stable de Gale-Shapley** (1962) et de la **structure de treillis de Knuth** de
 ses couplages stables. Les douze résultats phares sont tous CLOSED (`lake build
-StableMarriage` SUCCESS, toolchain `v4.30.0-rc2`).
+StableMarriage` SUCCESS, toolchain `v4.31.0-rc1`).
 
 ### Ce qui est prouvé
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
@@ -14,7 +14,7 @@ régression du prouveur.
 
 ## Statut
 
-- **Toolchain** : v4.30.0-rc2
+- **Toolchain** : v4.31.0-rc1
 - **Compte de sorry** : 0 en production (les 4 cibles de calibration sont prouvées ; un ancien compte de « 4 sorry » correspondait à du texte de docstring à l'intérieur de blocs `/-- ... -/`, pas à des termes `sorry` réels)
 - **Build** : `lake build Calibration` -- SUCCESS
 - **Dépendances** : Mathlib4
@@ -70,7 +70,7 @@ flowchart LR
 Ce projet est une **suite de calibration** pour le prouveur Lean multi-agents :
 quatre cibles de preuve de type manuel (C / D / E / F) dans
 `Calibration/Nash.lean`, toutes **prouvées avec 0 `sorry`**
-(`lake build Calibration` SUCCESS, toolchain `v4.30.0-rc2`).
+(`lake build Calibration` SUCCESS, toolchain `v4.31.0-rc1`).
 
 ### Pourquoi ce module existe
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -81,7 +81,7 @@ lake build Grothendieck
 
 ## Toolchain
 
-Alignée avec les autres projets SymbolicAI/Lean : `leanprover/lean4:v4.30.0-rc2`
+Alignée avec les autres projets SymbolicAI/Lean : `leanprover/lean4:v4.31.0-rc1`
 
 ## References
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/README.md
@@ -13,7 +13,7 @@ projets plus ambitieux (`calibration_lean`, `conway_lean`, `sensitivity_lean`).
 
 ## Statut
 
-- **Toolchain** : v4.30.0-rc2
+- **Toolchain** : v4.31.0-rc1
 - **Compte de sorry** : 0
 - **Build** : `lake build MathLibExamples` -- SUCCESS
 - **Dépendances** : Mathlib4


### PR DESCRIPTION
## Contexte

Issue #3978 (part de #3973 — READMEs feuilles ascendantes). Driver : les READMEs feuilles Lean doivent refléter **l'état formel réel**. L'audit firsthand de ce cycle révèle que la convergence Mathlib #4364 (rc2→rc1) avait bumpé les fichiers `lean-toolchain` des lakes rc1, mais que **5 READMEs feuilles portaient encore la mention `v4.30.0-rc2`** — une drift toolchain vérifiable.

## Méthode (G.1 — firsthand, pas sur foi)

Pour chaque lake candidat, comparaison de la mention README vs le **vrai fichier `lean-toolchain`** sur disque :

```
GameTheory/stable_marriage_lean        lean-toolchain = v4.31.0-rc1  (README disait rc2)  DRIFT
GameTheory/cooperative_games_lean      lean-toolchain = v4.31.0-rc1  (README disait rc2)  DRIFT
SymbolicAI/Lean/calibration_lean       lean-toolchain = v4.31.0-rc1  (README disait rc2)  DRIFT
SymbolicAI/Lean/grothendieck_lean      lean-toolchain = v4.31.0-rc1  (README disait rc2)  DRIFT
SymbolicAI/Lean/mathlib_examples       lean-toolchain = v4.31.0-rc1  (README disait rc2)  DRIFT
```

Les 5 sont **réellement sur rc1** → les mentions rc2 sont de la drift (le README n'a pas suivi le bump de toolchain #4364).

## Correctifs (5 fichiers, +8/-8, README text-only)

| Fichier | Lignes | Correction |
|---------|--------|------------|
| `GameTheory/stable_marriage_lean/README.md` | L35, L92 | `v4.30.0-rc2` → `v4.31.0-rc1` (2 mentions) |
| `GameTheory/cooperative_games_lean/README.md` | L7, L160 | idem (2 mentions) |
| `SymbolicAI/Lean/calibration_lean/README.md` | L17, L73 | idem (2 mentions) |
| `SymbolicAI/Lean/grothendieck_lean/README.md` | L84 | idem (1 mention) |
| `SymbolicAI/Lean/mathlib_examples/README.md` | L16 | idem (1 mention) |

## Vérification

- Diff **toolchain-text-only** : 8 insertions / 8 deletions, **chaque ligne modifiée** est une mention rc2→rc1. 0 mention rc2 restante dans les 5 fichiers.
- **Note historique `mathlib_examples` L41** (« Lean core depuis v4.30 ») — **intacte** : le pattern `v4.30.0-rc2` ne la matche pas, et c'est une note historique (quand `omega` est devenu core), pas une claim toolchain.
- `CATALOG-STATUS` markers **inchangés** (catalog-pr-hygiene R1 respectée).
- Encodage UTF-8 no-BOM préservé.

## Intentionnellement NON touchés (nuance, soin séparé)

Deux READMEs portent des mentions rc2 mais nécessitent une **reformulation prudente** (pas un simple find-replace), différés pour ne pas casser le markdown :
- **`conway_cgt_lean/README.md` L15** : phrase comparative « plus récente que les autres séries Lean en v4.30.0-rc2 » — maintenant obsolète (tout le groupe est rc1), à reformuler.
- **`social_choice_lean/README.md`** (L11, L62, L141, L253) : L62 est une **cellule de tableau 2-colonnes** comparant notre projet (rc2) vs `social_choice_lean_peters` **pinné v4.27.0-rc1** (vérifié : son `lean-toolchain` = v4.27.0-rc1, pin légitime). La colonne peters reste v4.27 — seul le nôtre passe rc2→rc1, dans une cellule de tableau. À faire dans un cycle dédié.

Ces 2 cas flaggés pour ai-01 / prochain cycle.

## Notes

- See #3978, #4364. Part of #3973 (READMEs feuilles → ascendantes).
- Aucun `Closes` : #3978 est un rollout multi-README, cette PR est une tranche.
- FR-first respecté (correction dans la langue existante des READMEs, déjà FR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
