### PR TITLE
fix(search): dedup duplicate Conclusion in Exploration notebook

### DIFF
--- a/MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb
+++ b/MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb
@@ -1893,6 +1893,8 @@
     "\n",
     "Selon le probleme, la taille de l'espace d'etats et les ressources disponibles, on choisira l'algorithme le plus adapte : la **connaissance du domaine** (heuristique, structure de l'espace d'etats) joue un role majeur dans l'efficacite de la recherche.  \n",
     "\n",
+    "Les **exercices** de ce notebook prolongent chaque famille : approfondissement iteratif (Ex. 1), heuristique euclidienne pour A* (Ex. 2), algorithme genetique pour le TSP (Ex. 3), comparaison BFS/DFS/A* (Ex. 4), et etude de l'impact des parametres du recuit simule (Ex. 5) et de l'algorithme genetique (Ex. 6).\n",
+    "\n",
     "---\n",
     "\n",
     "**References** :  \n",
@@ -1901,12 +1903,6 @@
     "\n",
     "**Retour au sommaire** : [Index](../../README.md)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f9a49504",
-   "source": "## Conclusion\n\nCe notebook a parcouru les principales familles d'algorithmes de recherche en intelligence artificielle, en s'appuyant sur le cadre AIMA (Russell & Norvig). Les recherches **non informées** (BFS, DFS) garantissent l'exploration complète de l'espace d'états mais restent coûteuses en l'absence de guide heuristique. Les recherches **informées** (A*, Greedy Best-First) exploitent une fonction heuristique pour concentrer l'exploration vers les solutions optimales, A* offrant à la fois optimalité et complétude sous réserve d'une heuristique admissible. Les méthodes de **recherche locale** (Hill Climbing, Recuit Simulé, Algorithmes Génétiques) abordent les problèmes d'optimisation dans des espaces de grande taille, au prix de l'abandon de la garantie de trouver l'optimum global. Le choix de l'algorithme dépend de la nature du problème (espace d'états, disponibilité d'une heuristique, exigence d'optimalité) et des ressources disponibles. Les exercices proposés (Iterative Deepening, heuristiques euclidiennes, TSP génétique) permettent d'approfondir chacune de ces approches.",
-   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
Part of #4212 (finition editoriale) — revue de fond editoriale (cron :41 regard-neuf).

## Defaut corrige (firsthand)
Le notebook `Search/Exploration_non_informée_et_informée_intro.ipynb` contenait **deux cellules `## Conclusion` consecutives** (cells 42 et 43 avant fix) — redondantes, formulations differentes. Consolidation en **une seule** :
- Conservee : la version structuree (recap par famille non-informee / informee / locale + **Bilan** + **References** + retour au sommaire).
- Repliee : la mention distinctive des exercices de la version prose supprimee (approfondissement iteratif, heuristique euclidienne pour A*, TSP genetique, comparaison BFS/DFS/A*, parametres SA/AG) — aucune perte de contenu.

## Preuve C.2 — markdown uniquement
- `git diff` : **3 insertions / 7 deletions**, **aucun** `outputs` / `execution_count` / cellule `code` touche.
- Code cells `execution_count` 1-18 intacts → pas de re-execution requise (modification markdown-only, outputs precedents valides).
- 1 seule `## Conclusion` apres fix ; 1 seul `### Exercice 1` (inchange).

## Constat editorial complementaire (documente, pas modifie ici)
- **Prong B #3801 = POSITIF** : l exemple A*/SLD sur la carte de Roumanie (cells 14-16) est un showcase **non-degenere** — il stage explicitement A*-sans-heuristique (=UCS, developpe beaucoup de noeuds) / Greedy-Best-First (piege) / A* (optimal + cible). Aucune violation SOTA a signaler sur ce notebook.
- Nit mineur **non traite** (eviterait un reorder de cellules code + re-exec) : ordering Ex5(Recuit Simule)/Ex6(AG) — les deux titres (cells 37-38) precedent leurs deux cellules code (39=test AG, 41=test SA) en ordre inverse. Contenu tout present ; flux pedagogique perfectible. A traiter dans une passe dediee si un reorder+re-exec est fait.

Livrable atomique, un seul sujet (dedup conclusion), un seul notebook.