### PR TITLE
docs(lean): fix toolchain drift rc2->rc1 in 2 deferred READMEs (conway_cgt, social_choice) (See #3978)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/README.md
@@ -12,7 +12,7 @@ Référence : Conway, J.H. — *On Numbers and Games* (2001).
 
 ## Statut
 
-- **Toolchain** : `leanprover/lean4:v4.31.0-rc1` (suit le dépôt amont — plus récente que les autres séries Lean en v4.30.0-rc2)
+- **Toolchain** : `leanprover/lean4:v4.31.0-rc1` (suit le dépôt amont)
 - **Sorry** : **0** — le fichier est une visite de `#check` et de docstrings, aucune preuve
 - **Build** : `lake build CGTTour` (dépend de Mathlib4 + CombinatorialGames)
 - **Dépendances** :

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
@@ -8,7 +8,7 @@ Ce répertoire contient les formalisations mathématiques de la théorie du choi
 |-------------|--------|
 | Théorèmes/Lemmas | 76 (0 sorry, 7 modules) |
 | sorry restants | 0 |
-| Toolchain | `leanprover/lean4:v4.30.0-rc2` |
+| Toolchain | `leanprover/lean4:v4.31.0-rc1` |
 | Dépendances | Mathlib4, Lake |
 
 **Statut formel** : les **sept** modules (Basic, Framework, Arrow, Sen, Voting,
@@ -59,7 +59,7 @@ Résultats formalisés par Peters :
 |--------|---------------------------|---------------|
 | Type de préférence | `PrefOrder α` (réflexif, total, transitif) | `LinearOrder A` (strict, Mathlib) |
 | Règle de vote | `SCC ι σ` (types fixés) | `VotingRule` (polymorphe sur V, A) |
-| Toolchain | `v4.30.0-rc2` | `v4.27.0-rc1` (pin commit `d679d950`) |
+| Toolchain | `v4.31.0-rc1` | `v4.27.0-rc1` (pin commit `d679d950`) |
 
 ### 1. Théorème d'Impossibilité d'Arrow (Arrow's Impossibility Theorem)
 
@@ -138,7 +138,7 @@ au-delà du choix social pur vers la **théorie des mécanismes** (incitations e
 social_choice_lean/
 ├── README.md                          # Documentation générale
 ├── lakefile.lean                      # Configuration du projet Lake
-├── lean-toolchain                     # Version de Lean (v4.30.0-rc2)
+├── lean-toolchain                     # Version de Lean (v4.31.0-rc1)
 ├── SocialChoice.lean                  # Fichier d'imports principaux
 ├── SocialChoice/                      # Module principal (7 fichiers, 0 sorry)
 │   ├── Basic.lean                    # Définitions de base (P, I, PrefOrder, QuasiOrder,
@@ -250,7 +250,7 @@ résultats fondateurs de la théorie du choix social : le **théorème d'impossi
 d'Arrow**, le **paradoxe libéral de Sen**, la **théorie du vote** (Condorcet, électeur
 médian, Split Cycle) et la **véridicité de l'enchère de Vickrey** (théorie des mécanismes).
 Tous les modules sont FORMAL-CERTIFIED et recompilables via `lake build` sur la toolchain
-`v4.30.0-rc2`.
+`v4.31.0-rc1`.
 
 ### Ce qui est prouvé
 


### PR DESCRIPTION
## Contexte

Clôt le sweep toolchain des READMEs feuilles Lean (#3978/#3973) : les **2 cas nuancés différés en #4995** (le diff simple rc2→rc1 ne suffisait pas, reformulation prudente requise pour ne pas casser le markdown ni mal représenter la pin peters).

## Correctifs (2 fichiers, +5/-5, README text-only)

### `conway_cgt_lean/README.md` L15
La valeur toolchain (`v4.31.0-rc1`) était **déjà correcte**. Seule la **clause comparative stale** a été retirée :
- AVANT : `(suit le dépôt amont — plus récente que les autres séries Lean en v4.30.0-rc2)`
- APRÈS : `(suit le dépôt amont)`
La clause « plus récente que les autres séries en rc2 » est **obsolète post-#4364** : tout le groupe de lakes est désormais rc1, l'affirmation comparative est devenue fausse.

### `social_choice_lean/README.md` — 4 mentions rc2→rc1 de **notre projet**
| Ligne | Contexte | Correction |
|-------|----------|------------|
| L11 | Table de stats (col unique) | `leanprover/lean4:v4.30.0-rc2` → `v4.31.0-rc1` |
| **L62** | **Table comparative 2-col** (Notre projet \| DominikPeters) | col « Notre projet » rc2→rc1 ; **col DominikPeters `v4.27.0-rc1` (pin legit) INCHANGÉE** |
| L141 | Annotation arbre de fichiers | `v4.30.0-rc2` → `v4.31.0-rc1` |
| L253 | Prose de conclusion | `v4.30.0-rc2` → `v4.31.0-rc1` |

**L62 = la cellule délicate** : table 2-colonnes comparant notre projet (rc2→rc1) vs `social_choice_lean_peters` pinné `v4.27.0-rc1`. La colonne peters reste v4.27 — seul le nôtre passe rc2→rc1. 3 colonnes préservées, alignement intact (même longueur de token).

## Vérification (firsthand G.1)

```
conway_cgt_lean/lean-toolchain          = v4.31.0-rc1  ✓ (README L15 déjà correct, clause stale retirée)
social_choice_lean/lean-toolchain       = v4.31.0-rc1  ✓ (4 mentions rc2 = drift)
social_choice_lean_peters/lean-toolchain= v4.27.0-rc1  ✓ (pin legit, colonne L62 inchangée)
```

- Diff **README-text-only** : 5 insertions / 5 deletions, chaque ligne modifiée = claim toolchain. **0 mention `v4.30.0-rc2` résiduelle** dans les 2 fichiers.
- Marqueurs `CATALOG-STATUS` inchangés (catalog-pr-hygiene R1). Encodage UTF-8 no-BOM préservé.
- Aucun `.lean`, aucun code, aucun catalogue touché.

## Notes

- See #3978, #4364. Part of #3973 (leaf READMEs → ascendantes).
- **Follow-up de #4995** (les 5 cas simples rc2→rc1, MERGED). Cette PR = la passe différée des 2 cas nuancés.
- Aucun `Closes` : #3978 est un rollout multi-README, cette PR est une tranche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
