### PR TITLE
fix(qc): #3968 typographic normalization ## Note → **Note :** in 5 ML quantbooks (See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb
@@ -34,7 +34,7 @@
     "- Données BTCUSDT horaires/journalières\n",
     "- Durée estimée: ~15 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Ce notebook utilise une approche simplifiée pour la recherche. Le modèle complet utilise ObjectStore pour la persistance."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-EnhancedPairs/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-EnhancedPairs/quantbook.ipynb
@@ -32,7 +32,7 @@
     "- scikit-learn pour ML\n",
     "- Durée estimée: ~15 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Cette stratégie combine l'analyse statistique (cointégration) avec le ML pour optimiser le timing d'entrée."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/quantbook.ipynb
@@ -31,7 +31,7 @@
     "- scikit-learn pour tous les modèles\n",
     "- Durée estimée: ~15 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Cette stratégie utilise le principe de \"crowd wisdom\" - plusieurs modèles faibles = un fort."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FeatureEngineering/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FeatureEngineering/quantbook.ipynb
@@ -23,7 +23,7 @@
     "- pandas, numpy, scikit-learn\n",
     "- Durée estimée: ~20 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Ce notebook est une référence - utilisez ces features dans vos stratégies ML."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/quantbook.ipynb
@@ -31,7 +31,7 @@
     "- scikit-learn pour Ridge Regression\n",
     "- Durée estimée: ~12 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Cette stratégie utilise la régression Ridge pour éviter l'overfitting tout en capturant les relations linéaires entre features et rendements."
    ]
   },


### PR DESCRIPTION
## Contexte

**[#3966](https://github.com/jsboige/CoursIA/issues/3966) EPIC** : `scan-md-hierarchy` findings repo-wide — 36+ notebooks pédagogiques ont des headings H1-H6 qui matchent `HINT_RE` du scanner. Chaque finding est transformé en PR atomique par famille/quantbook.

**[#3968](https://github.com/jsboige/CoursIA/issues/3968)** (sous-tâche de #3966) : famille **neurosymbolic-eml typo ladder**. Premier PR atomique de la famille = **QC ML ladder lot 1** (5 quantbooks).

## Fichiers modifiés (5)

| Fichier | Ligne | Avant | Après |
|---------|-------|-------|-------|
| `MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb` | cell 0, ligne JSON 37 | `## Note` | `**Note :**` |
| `MyIA.AI.Notebooks/QuantConnect/projects/ML-EnhancedPairs/quantbook.ipynb` | cell 0, ligne JSON 35 | `## Note` | `**Note :**` |
| `MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/quantbook.ipynb` | cell 0, ligne JSON 34 | `## Note` | `**Note :**` |
| `MyIA.AI.Notebooks/QuantConnect/projects/ML-FeatureEngineering/quantbook.ipynb` | cell 0, ligne JSON 26 | `## Note` | `**Note :**` |
| `MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/quantbook.ipynb` | cell 0, ligne JSON 34 | `## Note` | `**Note :**` |

**Diff stat** : `5 files changed, 5 insertions(+), 5 deletions(-)` — 1 ligne par fichier, +3 ou +4 bytes (le `:` + espaces).

## Pourquoi `**Note :**` (bold inline) ?

Le scanner `scripts/notebook_tools/scan_md_hierarchy.py` détecte **HINT_AS_HEADING** : tout heading H1-H6 dont le texte matche `HINT_RE = ^(indice|astuce|hint|tip|conseil|note|remarque|attention|todo|etape|étape|step|rappel|warning|important|aide|piste|nb)\b` case-insensitive.

`HINT_RE` matche `note` à **tous les niveaux H1-H6** (cf memory `scan-md-hierarchy-edge-cases.md` : « Demote H→H4 ne clear PAS ; seul non-heading (bold/blockquote) clear »). Donc `## Note` → `### Note` aurait été un no-op (le scanner aurait re-flagué `### Note` au même titre).

La seule transformation qui clear le scanner pour `note` = **`**Note :**`** (bold inline, non-heading). Vérifié firsthand : `python scripts/notebook_tools/scan_md_hierarchy.py <5 quantbooks>` retourne `=== 0/5 notebooks flagged ===`.

## Politique respectée

- **Markdown only** : 0 modification de cellule code
- **0 modif de contenu textuel** : seule la hiérarchie `## Note` → `**Note :**` change
- **0 modif de cellule code** : aucune cellule Python / .NET touchée
- **0 modif d'outputs** : C.2 notebook-conventions respectée (modifs uniquement markdown → outputs précédents valides)
- **0 modif de trailing newline** : BTC-ML origin/main sans `\n` final préservé (vérifié `tail -c 30` avant/après)
- **Acceptance #1** : scanner 0/5 flagged ✅
- **Acceptance #2** : structure JSON validée via `nbformat.read(as_version=4)` — toutes les cellules `id`, `execution_count`, `outputs` byte-identiques ✅
- **Acceptance #3** : re-exec Papermill N/A (aucune cellule code modifiée). Quantbooks QC = exécution via QC Cloud obligatoire (CLAUDE.md QUANTCONNECT), hors scope d'une PR typo

## FP doc — `## Step N: ...` ≠ aside

`MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/research.ipynb` contient **5× `## Step N: ...`** (cellules 3, 5, 7, 9, 11). Vérifié firsthand : ce sont les **vraies sections d'un pipeline CNN training** (data prep → augmentation → model definition → training loop → evaluation). Le scanner les flague `HINT_AS_HEADING` parce que `step` matche `HINT_RE`, mais le contenu est une vraie section pédagogique structurée avec sous-cellules H3/fences. **GARDÉ tel quel** — un aside court se transforme en bold inline, une section de pipeline avec enfants H3 reste un H2.

## Reste du ladder #3966 (25 findings)

- **Lot 2** : 19 autres quantbooks QC (ML-HeadShoulders-CNN, options, stat-arb, alpha-vectors, etc.) — à scanner + transformer en PR atomique par lot de 5-10 fichiers
- **Lot 3** : 4 SymbolicAI (planners, social_choice_lean, smart_contracts, semantic_web)
- **Lot 4** : 1 GenAI (GenAI/SymbolicAI-19 par exemple)
- **Lot 5** : 1 Sudoku (notebooks Lean .NET)

Chaque lot = 1 PR distincte (scope strict, [catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md) R3 — 1 seul livrable par PR).

## Liens

- Issue : [#3968](https://github.com/jsboige/CoursIA/issues/3968) (See — contribution partielle à EPIC #3966)
- EPIC parente : [#3966](https://github.com/jsboige/CoursIA/issues/3966)
- Tool : `scripts/notebook_tools/scan_md_hierarchy.py`
- Memory : `scan-md-hierarchy-edge-cases.md` (FP scanner), `scan-hierarchy-hint-re-false-positive.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>