### PR TITLE
docs(iit): IIT-1 — repositionner la definition intuitive de Φ avant compute.phi (Closes #5022)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
@@ -402,6 +402,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "phi-def-intuitive",
+   "metadata": {},
+   "source": [
+    "### Le Calcul de \\(\\Phi\\) : Définition Intuitive\n",
+    "\n",
+    "\\(\\Phi\\) mesure à quel point le système est \"plus que la somme de ses parties\".\n",
+    "\n",
+    "**Le calcul** : PyPhi essaie de couper le système en deux (une \"bipartition\") de toutes les manières possibles (A vs BC, B vs AC, etc.).\n",
+    "- La coupe qui fait perdre le *moins* d'information est appelée la **Minimum Information Partition (MIP)**.\n",
+    "- \\(\\Phi\\) est la quantité d'information perdue au niveau de cette coupe la plus faible.\n",
+    "- Si \\(\\Phi > 0\\), le système est irréductible (conscient selon l'IIT).\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "cfb3a7f7",
@@ -1220,16 +1235,6 @@
     "tags": []
    },
    "source": [
-    "### Le Calcul de \\(\\Phi\\) : Définition Intuitive\n",
-    "\n",
-    "\\(\\Phi\\) mesure à quel point le système est \"plus que la somme de ses parties\".\n",
-    "\n",
-    "**Le calcul** : PyPhi essaie de couper le système en deux (une \"bipartition\") de toutes les manières possibles (A vs BC, B vs AC, etc.).\n",
-    "- La coupe qui fait perdre le *moins* d'information est appelée la **Minimum Information Partition (MIP)**.\n",
-    "- \\(\\Phi\\) est la quantité d'information perdue au niveau de cette coupe la plus faible.\n",
-    "- Si \\(\\Phi > 0\\), le système est irréductible (conscient selon l'IIT).\n",
-    "\n",
-    "---\n",
     "\n",
     "<a id=\"sec6\"></a>\n",
     "## 6. Exemple avancé : analyse de causalité et macro-subsystems\n",
@@ -1439,6 +1444,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "67e8f08a",
    "metadata": {},
    "source": [
     "## Conclusion\n",
@@ -1467,8 +1473,7 @@
     "\n",
     "Le calcul de $\\Phi$ est **combinatoirement explosif** (toutes les partitions, tous les mecanismes), ce qui confine PyPhi a de petits systemes (quelques noeuds) -- une contrainte pratique a garder en tete avant toute ambition d'echelle. Les raffinements de la theorie (IIT 4.0, calcul du $\\varphi$ au niveau des distinctions et relations) et les strategies de passage a l'echelle sont approfondis dans le notebook [IIT-2 : Sujets avances](./IIT-2-AdvancedTopics.ipynb).\n",
     "\n",
-    "> **A retenir** : l'IIT propose de mesurer la conscience comme l'**integration causale irreductible** d'un systeme sur lui-meme. PyPhi rend cette definition operationnelle : on declare une dynamique (TPM), on choisit un decoupage (Subsystem), et le moteur calcule a la fois *combien* ($\\Phi$) et *quoi* (CES) le systeme integre.\n",
-    ""
+    "> **A retenir** : l'IIT propose de mesurer la conscience comme l'**integration causale irreductible** d'un systeme sur lui-meme. PyPhi rend cette definition operationnelle : on declare une dynamique (TPM), on choisit un decoupage (Subsystem), et le moteur calcule a la fois *combien* ($\\Phi$) et *quoi* (CES) le systeme integre.\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Issue #5022 (Part of #2651 prose pédagogique) : la cellule markdown **« Le Calcul de Φ : Définition Intuitive »** (cell id `5d067a10`, index 23 d'origine) du notebook `MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb` arrivait **trop tard** dans le fil du notebook — environ 10 cellules **après** le premier calcul `pyphi.compute.phi` et l'Exercice 1 sur la magnitude de Φ. Était en plus agglomérée à l'en-tête §6 (Actual Causation), incohérence thématique (la définition de Φ comme préambule à la section causalité événementielle).

## Correction

Repositionnement surgical de la cellule markdown, **markdown-only** :

- **Extraction** du bloc « ### Le Calcul de Φ : Définition Intuitive » (avec son contenu : bipartition, MIP, irréductibilité, Φ>0 ⇒ conscient selon IIT) depuis la cellule `5d067a10`.
- **Insertion** comme nouvelle cellule markdown (id `phi-def-intuitive`, metadata `{}`) juste après `7a35fb70` (§4.1 Subsystem), **avant** la première cellule code `cfb3a7f7` (`pyphi.compute.phi(subsystem)`) et l'Exercice 1 (`c91e98c8`).
- **Trim** de la cellule `5d067a10` pour ne conserver que l'en-tête §6 + §6.1 Actual Causation (le séparateur `---` est supprimé).

## Vérification (C.2 exception)

- **0 cellule code touchée**, **0 output modifié**, **0 execution_count perdu**.
- 13 cellules code préservées avec leurs outputs intacts : `ec=1..13` séquentiels, output counts `(1,2,1,1,9,8,27,1,4,1,1,1,1)` byte-identiques à `origin/main`.
- Validation nbformat re-read post-write : OK 32 cellules (était 31).
- LF normalization post-`nbformat.write()` (origin/main est en LF ; `nbformat.write` sur Windows écrit CRLF par défaut).

## Base de la PR

Issue détectée et corrigée : la première tentative #5024 a été créée avec une base parasite (`feature/4980-argumentation-i18n-companion-b`, encore unmerged et embarquant `Argumentation.en.md` hors scope). Fermée sans merge + branche recréée depuis `origin/main` (`67784734f`, à jour avec #5013 planning merge). Force push évité (incident 2026-03-13) → branche distante supprimée puis recréée (`git push origin --delete` + push nouveau). PR finale basée clean sur origin/main.

## Diff

```
 MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb | 29 ++++++++++++++-----------
 1 file changed, 17 insertions(+), 12 deletions(-)
```

Well under §A 3000/15/4/1. PR atomic single-notebook.

## Index des cellules après reposition

| Index | Type | id | Description |
|-------|------|----|-------------|
| 08 | MD | `7a35fb70` | §4.1 Subsystem (existant) |
| **09** | **MD** | **`phi-def-intuitive`** | **NOUVELLE — Le Calcul de Φ : Définition Intuitive** |
| 10 | CD | `cfb3a7f7` | `pyphi.compute.phi` (premier calcul) |
| 15 | MD | `c91e98c8` | Exercice 1 — Phi d'un sous-système partiel |
| 24 | MD | `5d067a10` | §6 Exemple avancé (trimmed, anchor préservé) |

L'étudiant reçoit désormais la **définition intuitive de Φ** (MIP, irréductibilité) **avant** de voir Φ calculé et d'être invité à raisonner sur sa magnitude (Exercice 1).

Closes #5022.