### PR TITLE
docs(lean): add grim-trigger one-shot-deviation Mermaid diagram to repeated_games_lean README (See #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md
@@ -16,6 +16,23 @@ Pour un jeu répété à horizon infini, facteur d'actualisation δ ∈ [0,1), p
 
 > Au-dessus du seuil, **aucune déviation unilatérale n'est profitable**. La grim est une stratégie d'équilibre sous-jeu-parfait (subgame-perfect Nash equilibrium).
 
+### One-shot deviation principle — schéma de décision
+
+Le théorème repose sur le **principe de déviation unilatérale** : sous grim-trigger, une seule déviation déclenche la punition éternelle. La coopération est soutenable ssi la valeur actualisée de coopérer perpétuellement dépasse celle de dévier une fois puis d'être puni.
+
+```mermaid
+flowchart TD
+    A["Agent au stage t (historique : coopération mutuelle)"] --> B{"Action choisie au stage t ?"}
+    B -->|"Coopérer (C)"| C["Payoff R, puis coopération perpétuelle"]
+    B -->|"Dévier (D)"| D["Payoff T maintenant, puis punition éternelle P"]
+    C --> CV["Valeur actualisée = R / (1 - δ)"]
+    D --> DV["Valeur actualisée = T + δ * P / (1 - δ)"]
+    CV --> E{"CV ≥ DV ?"}
+    DV --> E
+    E -->|"δ ≥ (T-R)/(T-P)"| F["Coopération soutenable : équilibre sous-jeu-parfait"]
+    E -->|"δ < (T-R)/(T-P)"| G["Déviation profitable : la grim ne tient pas"]
+```
+
 ## Cohorte (leçon #4362, Issue #4880)
 
 | Paramètre | Valeur | Référence |


### PR DESCRIPTION
## Contexte

Tranche **#4212** (finition éditoriale : aération prose + visuels Mermaid). Cible : `MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md` — l'un des **3 lakes encore sans diagramme Mermaid** après le rollout « ≥1 Mermaid/lake » (les autres : `learning_theory_lean`, `decision_theory_lean`). `SymbolicAI/Lean/knot_lean` (4ᵉ sans Mermaid) est off-limits (lane ai-01 HOLD contrat).

Le README était **déjà dense en contenu** (théorème-phare grim-trigger, table Cohorte #4362, table Modules, pont ICT-13 #4879, Reproving BG, références externes) mais **sans aucun visuel**. La valeur pédagogique maximale = rendre concret le concept central.

## Livrable (1 fichier modifié — additif pur)

| Fichier | Action | Détail |
|---------|--------|--------|
| `repeated_games_lean/README.md` | ajout Mermaid | +17 lignes, **0 suppression**. Nouvelle sous-section + 1 bloc `mermaid` flowchart TD. |

**Diagramme ajouté** : visualisation du **one-shot deviation principle** — le principe au cœur du théorème grim-trigger. L'agent au stage `t` (historique : coopération mutuelle) choisit entre :
- **Coopérer (C)** → payoff `R`, puis coopération perpétuelle → valeur actualisée `R / (1−δ)`
- **Dévier (D)** → payoff `T` maintenant, puis punition éternelle `P` → valeur actualisée `T + δ·P / (1−δ)`

La coopération est soutenable ssi `CV ≥ DV` ⟺ `δ ≥ (T−R)/(T−P)` — le seuil visualisé comme gate de décision dans le flowchart.

## Intentionnellement préservé (verbatim)

- Théorème-phare et ses formules originales (seuil d'indifférence, équations).
- Table **Cohorte** (Toolchain v4.31.0-rc1, Mathlib rev d568c8c0, sorry counts).
- Table **Modules** (Stage / Discounting / GrimTrigger / Folk).
- Pont **ICT-13** (#4879).
- Bloc **Reproving BG** (fence bash intacte, commande `run_prover_bg.py`).
- Références externes (Geanakoplos, Fudenberg–Maskin, Mailath–Samuelson) + liens.

## Vérification (G.1 firsthand)

1. **No UTF-8 BOM** : head bytes = `0x23 0x20 0x52` (`# R`).
2. **Diff additif pur** : 17 insertions / **0 suppression** (`git diff --stat`) — zéro contenu supprimé, anti-régression respectée.
3. **Mermaid fence balance** : 4 triple-backticks au total = 2 paires (bloc bash Reproving BG préexistant + nouveau bloc mermaid). 1 bloc `mermaid` confirmé (avant : 0).
4. **Mermaid syntax robuste** : tous les labels quotés `"..."`, formules en ASCII (`-`, `*`), Unicode safe (`δ`, `≥`) uniquement dans labels quotés — rendu GitHub Mermaid validé par construction.
5. **Collision-check** : 0 PR open sur `repeated_games mermaid/readme`.
6. **FR-first** : sous-section et labels en français (README environnant FR-dominant).

## Notes

- See **#4212**. Part of **#4208**.
- **Aucun `Closes`** : #4212 = rolling famille-partitionné ; cette PR est une tranche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
