### PR TITLE
fix(tweety-7b): align kernelspec.name on python3 (See #5039)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
@@ -1390,7 +1390,7 @@
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
-   "name": "nlp-course"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Scope

Constat 2 of #5039 (`Tweety-7b-Ranking-Probabilistic.ipynb` kernelspec non-reproductible).

`metadata.kernelspec.name` = `nlp-course` (alias local de l'auteur, kernel non enregistre sur machines standard) → **`python3`** (aligner sur la serie).

## G.1 firsthand verification

- 22 cells (8 code, 14 markdown), 0 null `execution_count`, 0 errors, 0 char-split corruption
- `language_info.name` = python (coherent with kernelspec fix)
- Rest of the Tweety Python series (13 sibling notebooks) uniformly uses `python3` (verified firsthand)
- Sibling `Tweety-7b-Ranking-Probabilistic_output.ipynb` already runs under `python3`

## H.1 safety (no re-execution needed)

- 1-line metadata-only change
- Outputs preserved byte-identically (no source cell touched, `execution_count` and `outputs` fields untouched)
- JPype1 + JVM cell contents unchanged (kernel `python3` supports `%pip install` magics used by cell 1)

## Diffstat

```
1 file changed, 1 insertion(+), 1 deletion(-)
```

See #5039