### PR TITLE
editorial(tweety): fix answer-leaks (Tweety-5) + kernelspec (Tweety-7b) (#5039)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
@@ -2041,6 +2041,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sol-ex1-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017169,
+     "end_time": "2026-05-31T22:55:00.300150+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T22:55:00.282981+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Analyse des résultats\n",
+    "\n",
+    "`a` n'étant attaqué par personne, il est accepté dans toutes les sémantiques. Il neutralise `b`, ce qui libère `c` (son seul attaquant disparaît), et `c` neutralise à son tour `d`.\n",
+    "\n",
+    "Les trois sémantiques convergent vers `{a, c}` : le framework est entièrement déterminé, sans ambiguïté. Le cycle `b -> c -> d -> b` est bien impair (longueur 3), mais il n'est pas **isolé** — `a` le casse en éliminant `b`. Un cycle impair ne pose problème à la sémantique Stable que lorsqu'aucun argument extérieur ne l'attaque."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ex1-stub-md",
    "metadata": {
     "papermill": {
@@ -2092,27 +2113,6 @@
     "# Etape 2 : calculer les extensions\n",
     "# Etape 3 : interpreter les resultats\n",
     "print(\"Exercice a completer\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "sol-ex1-interp",
-   "metadata": {
-    "papermill": {
-     "duration": 0.017169,
-     "end_time": "2026-05-31T22:55:00.300150+00:00",
-     "exception": false,
-     "start_time": "2026-05-31T22:55:00.282981+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### Analyse des résultats\n",
-    "\n",
-    "`a` n'étant attaqué par personne, il est accepté dans toutes les sémantiques. Il neutralise `b`, ce qui libère `c` (son seul attaquant disparaît), et `c` neutralise à son tour `d`.\n",
-    "\n",
-    "Les trois sémantiques convergent vers `{a, c}` : le framework est entièrement déterminé, sans ambiguïté. Le cycle `b -> c -> d -> b` est bien impair (longueur 3), mais il n'est pas **isolé** — `a` le casse en éliminant `b`. Un cycle impair ne pose problème à la sémantique Stable que lorsqu'aucun argument extérieur ne l'attaque."
    ]
   },
   {
@@ -2291,6 +2291,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sol-ex2-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.027331,
+     "end_time": "2026-05-31T22:55:00.818177+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T22:55:00.790846+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Lecture des résultats\n",
+    "\n",
+    "**Stable retourne 0 extension.** Pour qu'une extension stable existe, elle devrait attaquer tous les arguments extérieurs. Sur un cycle impair, aucun sous-ensemble ne peut satisfaire cette contrainte globale sans tomber sur une contradiction de parité (elle finit pas s'attaquer elle meme indirectement).\n",
+    "\n",
+    "**CF2 retourne 5 extensions.** La sémantique CF2 décompose le graphe en composantes fortement connexes (SCC) — ici une seule SCC contenant les 5 arguments. À l'intérieur, elle retient les ensembles \"conflict-free\" maximaux : les paires d'arguments non adjacents dans le cycle, `{a,c}`, `{a,d}`, `{b,d}`, `{b,e}`, `{c,e}`.\n",
+    "\n",
+    "La différence fondamentale : Stable impose une contrainte **globale** (attaquer tout l'extérieur), CF2 impose une contrainte **locale** (pas de conflit interne à la SCC). CF2 garantit toujours au moins une extension, même là où Stable échoue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ex4-stub-md",
    "metadata": {
     "papermill": {
@@ -2342,29 +2365,6 @@
     "# Etape 2 : identifier les relations d'attaque\n",
     "# Etape 3 : construire le cadre et analyser\n",
     "print(\"Exercice a completer\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "sol-ex2-interp",
-   "metadata": {
-    "papermill": {
-     "duration": 0.027331,
-     "end_time": "2026-05-31T22:55:00.818177+00:00",
-     "exception": false,
-     "start_time": "2026-05-31T22:55:00.790846+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### Lecture des résultats\n",
-    "\n",
-    "**Stable retourne 0 extension.** Pour qu'une extension stable existe, elle devrait attaquer tous les arguments extérieurs. Sur un cycle impair, aucun sous-ensemble ne peut satisfaire cette contrainte globale sans tomber sur une contradiction de parité (elle finit pas s'attaquer elle meme indirectement).\n",
-    "\n",
-    "**CF2 retourne 5 extensions.** La sémantique CF2 décompose le graphe en composantes fortement connexes (SCC) — ici une seule SCC contenant les 5 arguments. À l'intérieur, elle retient les ensembles \"conflict-free\" maximaux : les paires d'arguments non adjacents dans le cycle, `{a,c}`, `{a,d}`, `{b,d}`, `{b,e}`, `{c,e}`.\n",
-    "\n",
-    "La différence fondamentale : Stable impose une contrainte **globale** (attaquer tout l'extérieur), CF2 impose une contrainte **locale** (pas de conflit interne à la SCC). CF2 garantit toujours au moins une extension, même là où Stable échoue."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
@@ -1390,7 +1390,7 @@
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
-   "name": "nlp-course"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
See #5039 (ai-01's regard-neuf editorial review of SymbolicAI/Tweety). All findings grounded firsthand.

## Tweety-5-Abstract-Argumentation — finding 1: answer leaks (FIXED)

Two interpretation cells leaked exercise answers. Each sat right after a **stub** instead of after its own worked-example solution:

| Interpretation cell | Was after | Revealed | Now after |
|---|---|---|---|
| \`sol-ex1-interp\` (\"Analyse des résultats\") | Exercice-1 stub | diamond-frame analysis \`{a,c}\` (the Ex1 answer) | \`sol-ex1-code\` (ec=10, the \`abcd\` cycle it interprets) |
| \`sol-ex2-interp\` (\"Lecture des résultats\") | Exercice-4 stub | CF2-vs-Stable length-5 cycle (0 stable / 5 CF2) | \`sol-ex2-code\` (ec=14, the \`abcde\` cycle it interprets) |

Both moved into canonical **intro → code → interpretation** triads.

### Why no re-exec needed (the key constraint)

ai-01's issue noted \"le fix impose reorder → re-exec JVM/Tweety\". That holds for a *full* reorder, but the two leaked cells are **markdown** — moving them doesn't touch code cells. Verified:
- **Source content byte-identical** as a multiset (no text edited; only order). 61 → 61 cells.
- **Code \`execution_count\` multiset unchanged \`[1..19]\`** and strictly monotonic in document order. No code cell moved → committed outputs stay valid → **C.2 preserved without re-exec** (the Tweety/JVM stack — 35 JARs + Zulu JDK17 + 5 external tools — isn't available locally = RECOVERABLE-MACHINE).

### Deferred (needs re-exec) — orphaned intro #3240

\`sol-ex2-md\` (Exemple-guide-2 intro) is separated from its \`sol-ex2-code\` solution (ec=14) by the Exercice-3 stub (ec=13). Fixing it requires moving a **code** cell, which would put ec=14 before ec=13 → non-monotonic → would need a real re-exec. Deferred, documented (not forced) to keep this PR honest & mergeable now.

## Tweety-7b-Ranking-Probabilistic — finding 2: kernelspec (FIXED)

\`kernelspec.name\` was \`nlp-course\` (an unregistered local alias from another project's env) while \`display_name\` already said \"Python 3\" and \`language=python\`. Fixed to the registered standard kernel \`python3\`. Plain-python notebook (first cell \`%pip install JPype1\`), no special-kernel needs.

## Finding 3 (.net cells with no output) = FALSE POSITIVE (documented, no fix)

All 6 Tweety \`.net-csharp\` notebooks have one ec-set code cell with no output — but each is a \`#r \"....dll\"\` reference directive (\`org.tweetyproject.tweety-*.dll\`). A successful \`#r\` produces no stdout by design; **ec-set + empty output is the CORRECT state** for a reference cell, not missing output. No fix warranted.

## Scope

2 files, +45/−45 (Tweety-5 reorder = 44/44 cell moves; Tweety-7b kernelspec = 1 line). No catalog markers touched. FR-first.

See #5039, #3240, #4212. Co-Authored-By: Claude-Code <noreply@anthropic.com>