### PR TITLE
test(playwright-owui): confirm 06b reasoning selectors live vs v0.10.2 + document prefixed model ids

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/.env.example
@@ -47,7 +47,10 @@ OWUI_PASSWORD=your_password_here
 # SECTION 3 : Modeles LLM disponibles
 # ============================================================================
 # Nom du modele cloud (OpenAI, Anthropic, etc.) pour les tests de chat
-# Doit etre un modele rapide et disponible sur votre instance
+# Doit etre un modele rapide et disponible sur votre instance.
+# NB : sur une instance multi-connecteurs, l'id est souvent PREFIXE par le
+# connecteur (ex. "OpenAI.gpt-5.1", "MistralAI.magistral-medium-latest").
+# Verifiez le nom EXACT dans le selecteur de modeles de votre instance.
 OWUI_CLOUD_MODEL=gpt-5.1
 
 # Nom du modele local (optionnel - pour les tests avec modele local/vLLM)
@@ -60,6 +63,10 @@ OWUI_CLOUD_MODEL=gpt-5.1
 # Nom d'un modele "thinking" qui affiche son raisonnement (Module 06, v0.10.2)
 # Doit correspondre exactement au nom dans le selecteur de modeles.
 # Laisser vide (ou non defini) pour SAUTER le test de raisonnement.
+# Exemple VERIFIE firsthand contre v0.10.2 (rend le bloc de raisonnement en direct) :
+#   OWUI_REASONING_MODEL=OpenRouter.deepseek/deepseek-r1-0528
+# Autres candidats "thinking" (non testes ici) : MistralAI.magistral-medium-latest,
+# Qwen_think-reason (modele local vLLM).
 # OWUI_REASONING_MODEL=
 
 # ============================================================================

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/helpers/selectors.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/helpers/selectors.ts
@@ -113,8 +113,10 @@ export const ACCOUNT = {
 // La v0.10.2 affiche EN DIRECT les etapes de raisonnement des modeles
 // "thinking". Le bloc est generalement un <details> repliable, ou un
 // conteneur dont le libelle contient "raisonnement"/"reflexion"/"thinking".
-// Selecteurs volontairement larges — A CONFIRMER contre l'UI live (comme
-// tous les selecteurs, l'interface peut deriver d'une version a l'autre).
+// VERIFIE firsthand contre v0.10.2 (2026-07-02) : avec un modele "thinking"
+// (ex. OpenRouter.deepseek/deepseek-r1-0528), ces selecteurs detectent bien le
+// bloc de raisonnement rendu en direct (test 06b "raisonnement", 7 passed).
+// Restent volontairement larges (l'UI peut deriver d'une version a l'autre).
 export const REASONING = {
   // Conteneur repliable du raisonnement
   block:


### PR DESCRIPTION
## Contexte

Showcase Open WebUI v0.10 (Epic #4427). Ce module `Playwright-OWUI/06-nouveautes-v0.10/` teste les nouveautés de la ligne v0.10. Les tests **06a (API)** étaient déjà validés ; les deux tests **06b (UI)** — raisonnement streamé + compaction multi-tours — ne l'étaient pas, et les sélecteurs `REASONING` portaient le commentaire *« A CONFIRMER contre l'UI live »*.

## Ce que fait cette PR

Validation **live** du module complet contre une instance Open WebUI **v0.10.2** réelle :

```
7 passed, 1 skipped (58.8s)
  → bloc de raisonnement affiché par l'UI        (06b test 6, DeepSeek-R1)
  → conversation stable sur 4 tours              (06b test 7, compaction)
  → souvenir type=context, dossiers CRUD          (06a, 5 tests)
```

Deux améliorations **grounded** par ce run (docs/commentaires uniquement, aucun changement fonctionnel de test) :

1. **`helpers/selectors.ts`** — le commentaire `REASONING` passe de *« A CONFIRMER »* à **« VERIFIE firsthand contre v0.10.2 »** : avec un modèle *thinking* (`OpenRouter.deepseek/deepseek-r1-0528`), ces sélecteurs détectent bien le bloc de raisonnement rendu en direct.
2. **`.env.example`** — corrige un écueil de reproductibilité découvert pendant le run : sur une instance multi-connecteurs l'id modèle est **préfixé** par le connecteur (`OpenAI.gpt-5.1`, pas le `gpt-5.1` nu supposé par les défauts). Ajoute la note + un exemple `OWUI_REASONING_MODEL` vérifié firsthand.

## Vérifications

- `tsc --noEmit` : clean
- `npx playwright test 06-nouveautes` (live myia v0.10.2) : **7 passed, 1 skipped**
- Diff = 2 fichiers, +12/-3, commentaires + `.env.example` seulement — 0 secret (le `.env` local reste gitignoré)

## Review

Auteur : worker **myia-ai-01:myia-open-webui**. Merci à **ai-01:CoursIA** pour review+merge (pas de self-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)