### PR TITLE
fix(qc): normalize typographic hierarchy in 15 QuantConnect notebooks (See #3968)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/research_robustness.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/research_robustness.ipynb
@@ -996,7 +996,7 @@
     "tags": []
    },
    "source": [
-    "# Le Cout du Leverage en Bear Markets\n",
+    "## Le Cout du Leverage en Bear Markets\n",
     "\n",
     "## Synthese pedagogique\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/quantbook.ipynb
@@ -30,7 +30,7 @@
     "- Données crypto BTC\n",
     "- Durée estimée: ~8 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Cette version simplifiée se concentre sur l'analyse ZigZag et 2 canaux (macro/micro). L'implémentation complète utilise channel_helpers.py pour 3 canaux imbriqués."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/quantbook.ipynb
@@ -28,7 +28,7 @@
     "- Données equity journalières (SPY, QQQ, IWM)\n",
     "- Durée estimée: ~5 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Version adaptee pour le Docker research environment (donnees equity au lieu de crypto)."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/quantbook.ipynb
@@ -28,7 +28,7 @@
     "- Données SPY\n",
     "- Durée estimée: ~6 minutes\n",
     "\n",
-    "## Note de recherche (v2.0)\n",
+    "**Note de recherche (v2.0) :**\n",
     "- EMA 20/60 sélectionné via robustesse IS/OOS = 1.55\n",
     "- Cooldown 3d élimine 1 whipsaw sur 11 ans (+4.6% Sharpe)\n",
     "- Trailing stop rejeté: dégrade Sharpe OU change la nature de la stratégie"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/research.ipynb
@@ -2075,7 +2075,7 @@
     "L'alpha provient de la protection en régime Bear: la stratégie évite la plupart des drawdowns\n",
     "profonds (Mars 2020, correction 2022) en sortant sur EMA cross-down.\n",
     "\n",
-    "### Note pédagogique\n",
+    "**Note pédagogique :**\n",
     "\n",
     "Le Sharpe yfinance (0.765-0.853) est supérieur au Sharpe QC (0.384) pour plusieurs raisons:\n",
     "- yfinance utilise les prix Adj Close (dividendes inclus, ~1.5% CAGR de plus)\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Stocks/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Stocks/quantbook.ipynb
@@ -29,7 +29,7 @@
     "- Données actions US\n",
     "- Durée estimée: ~8 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Cette stratégie diffère de EMA-Cross-Index par la diversification intra-sectorielle (5 actions au lieu de 1 ETF SPY)."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ETF-Pairs/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ETF-Pairs/quantbook.ipynb
@@ -31,7 +31,7 @@
     "- statsmodels pour tests de cointégration\n",
     "- Durée estimée: ~10 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Cette version simplifiée se concentre sur quelques paires pré-sélectionnées. L'implémentation complète utilise des modules custom pour la sélection dynamique des paires."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/quantbook.ipynb
@@ -125,7 +125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Note sur les paires USD/XXX\n",
+    "**Note sur les paires USD/XXX :**\n",
     "\n",
     "Pour USDJPY et USDCAD, un prix qui monte = USD fort = devise locale faible.\n",
     "Pour mesurer le momentum de la devise (pas du USD), on inverse le return."

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/research.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Step 1: Load USDCAD Price Data**\n",
+    "## Step 1: Load USDCAD Price Data\n",
     "\n",
     "Load historical daily USDCAD prices for pattern analysis."
    ]
@@ -100,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Step 2: Generate Synthetic Training Data**\n",
+    "## Step 2: Generate Synthetic Training Data\n",
     "\n",
     "Create synthetic head-and-shoulders patterns and random price\n",
     "movements for training the CNN classifier."
@@ -177,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Step 3: Build and Train CNN Model**\n",
+    "## Step 3: Build and Train CNN Model\n",
     "\n",
     "Create a simple 1D Convolutional Neural Network for binary\n",
     "classification of head-and-shoulders patterns."
@@ -1457,7 +1457,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Step 4: Save Model to Object Store**\n",
+    "## Step 4: Save Model to Object Store\n",
     "\n",
     "Save the trained model so that `main.py` can load it during\n",
     "backtesting or live trading."
@@ -1503,7 +1503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Step 5: Visualize Training History**\n"
+    "## Step 5: Visualize Training History"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/research.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 1: Load USDCAD Price Data\n",
+    "**Step 1: Load USDCAD Price Data**\n",
     "\n",
     "Load historical daily USDCAD prices for pattern analysis."
    ]
@@ -100,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 2: Generate Synthetic Training Data\n",
+    "**Step 2: Generate Synthetic Training Data**\n",
     "\n",
     "Create synthetic head-and-shoulders patterns and random price\n",
     "movements for training the CNN classifier."
@@ -177,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 3: Build and Train CNN Model\n",
+    "**Step 3: Build and Train CNN Model**\n",
     "\n",
     "Create a simple 1D Convolutional Neural Network for binary\n",
     "classification of head-and-shoulders patterns."
@@ -1457,7 +1457,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 4: Save Model to Object Store\n",
+    "**Step 4: Save Model to Object Store**\n",
     "\n",
     "Save the trained model so that `main.py` can load it during\n",
     "backtesting or live trading."
@@ -1503,7 +1503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 5: Visualize Training History"
+    "**Step 5: Visualize Training History**\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/quantbook.ipynb
@@ -31,7 +31,7 @@
     "- Données equity journalières\n",
     "- Durée estimée: ~5 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Version adaptee pour le Docker research environment (donnees equity au lieu de crypto)."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/quantbook.ipynb
@@ -32,7 +32,7 @@
     "- Données SPY + VIX\n",
     "- Durée estimée: ~10 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Les options complètes ne sont pas disponibles dans QuantBook. Ce notebook utilise une approximation du premium basée sur Black-Scholes."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Options-VGT/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Options-VGT/quantbook.ipynb
@@ -30,7 +30,7 @@
     "- Données actions + approximation option premium\n",
     "- Durée estimée: ~8 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Les options complètes ne sont pas disponibles dans QuantBook. Ce notebook utilise une approximation du premium basée sur la volatilité historique et le delta."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/quantbook.ipynb
@@ -30,7 +30,7 @@
     "- Données SPY + VIX\n",
     "- Durée estimée: ~10 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Les options complètes ne sont pas disponibles dans QuantBook. Ce notebook utilise une approximation du premium basée sur le VIX et le delta."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/quantbook.ipynb
@@ -30,7 +30,7 @@
     "- numpy pour Q-table\n",
     "- Durée estimée: ~20 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Le Q-Learning apprend une politique d'allocation optimale par essai-erreur."
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/quantbook.ipynb
@@ -30,7 +30,7 @@
     "- Données actions US (200 stocks)\n",
     "- Durée estimée: ~10 minutes\n",
     "\n",
-    "## Note\n",
+    "**Note :**\n",
     "Cette stratégie utilise un Alpha Model custom avec filtre EMA 50/200 par stock."
    ]
   },


### PR DESCRIPTION
Part of #3968 (typographic hierarchy rollout). Lane: **QuantConnect (po-2024)**, per ai-01 dispatch (2026-06-23 comment).

## What
Normalizes the typographic hierarchy of the 15 QuantConnect notebooks still flagged by `scan_md_hierarchy.py` on `origin/main`: demotes HINT-as-heading asides (`## Note`, `### Note …`, `## Step N:`) to **inline bold** labels, and demotes one deep second H1 to H2. Asides no longer render at the same large font as real section headers / the notebook title.

Follows the merged GT-6c precedent (`## Étape N` → `**Étape N :**`, commit `5253bfc`).

## Changes — markdown cells ONLY, heading-level only
No source text, no code cell, no `outputs`/`execution_count` touched (C.2 preserved → no re-exec). Diff = 23 heading-marker changes, 0 content/exercise/label delta.

| Pattern | Notebooks | Transform |
|---|---|---|
| `## Note` cell-0 aside | 11 quantbook.ipynb (EMA-Cross-Stocks, Trend-Following, RL-Portfolio, EMA-Cross-Index "Note de recherche (v2.0)", Crypto-MultiCanal, EMA-Cross-Crypto, ETF-Pairs, Multi-Layer-EMA, Option-Wheel, Options-VGT, OptionsIncome) | → `**Note :**` |
| `### Note …` aside | ForexCarry, EMA-Cross-Index/research.ipynb (`### Note pédagogique`) | → inline bold |
| `## Step N: <title>` | ML-HeadShoulders-CNN/research.ipynb (5 cells) | → `**Step N: <title>**` |
| H1-DEEP / MULTI-H1 | Sector-Momentum/research_robustness.ipynb (`# Le Cout du Leverage…`) | → `## ` (real section, not title) |

## Acceptance (#3968) — all 4 verified
- [x] `scan_md_hierarchy.py MyIA.AI.Notebooks/QuantConnect/` → **0/232 flagged** (was 15).
- [x] Visual verification (nbconvert + Playwright) on EMA-Cross-Stocks/quantbook.ipynb — computed font-size table:

| Element | BEFORE (origin/main) | AFTER (this PR) |
|---|---|---|
| Title (H1) | 29.03 px | 29.03 px |
| Real section (H2 `Objectif`) | 24.19 px | 24.19 px |
| **`Note`** | **24.19 px (H2 — same size as real sections)** | **14 px (`<strong>`, body size)** |

  The aside is now body-size, clearly subordinate to the title (29 px) and real sections (24 px).
- [x] Markdown-only → C.2 preserved (outputs précédents valides), no re-exec.
- [x] Diff = heading-level only (no content/exercise/label delta; anti-regression + exercise-example-labeling respected).

## Judgment call (flag for review)
The 5 `## Step N: <title>` headers in ML-HeadShoulders-CNN are the tutorial's structural backbone (the only H2s). They are flagged by the scanner (`Step` ∈ HINT_RE) and the issue lists Step/Étape → inline bold with "0 finding résiduel" acceptance, so I demoted them to `**Step N: …**` for consistency with GT-6c. The issue's escape hatch ("ou H4/H5 si une vraie sous-section") would not clear the scanner (HINT_RE is level-agnostic). If you prefer to keep them as real section headers, the alternative is a scanner refinement (gate HINT-as-heading by level, or exclude `Step N: <descriptive title>` with a colon) — happy to split that into a separate tooling PR. Reverting these 5 is trivial.

## Scope note
4 partner-course notebooks flagged in an earlier base (ML-Regression-Researcher, BTC-MACD-ADX-Researcher, 2× Sector-Momentum-Researcher/output.ipynb) were already fixed on `origin/main` before this PR — not duplicated here.

\`See #3968\` (partial — QC lane tranche; the epic spans 10 families).