### PR TITLE
fix(scan): exclude titled-step headings from HINT-AS-HEADING (See #3968)

### DIFF
--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -24,6 +24,14 @@ HINT_RE = re.compile(
     r'^(indice|astuce|hint|tip|conseil|note|remarque|attention|todo|'
     r'etape|étape|step|rappel|warning|important|aide|piste|nb)\b',
     re.IGNORECASE)
+# A numbered step WITH a descriptive title (`Step 1: Load Data`, `Étape 3 :
+# Installation`) is a real titled SECTION header, not a bare aside. Without
+# this exclusion the level-agnostic HINT_RE flags the tutorial's backbone H2s
+# as hint-asides (false positives). Bare asides (`## Note`, `## Étape 3`,
+# `### Note pédagogique`) carry no colon+title, so they stay flagged. See #3968.
+TITLED_STEP_RE = re.compile(
+    r'^(step|etape|étape)\s+\d+\s*:\s*\S',
+    re.IGNORECASE)
 
 def scan_notebook(path):
     try:
@@ -57,7 +65,7 @@ def scan_notebook(path):
                 h1_cells.append(ci)
                 if not is_first_md:
                     findings.append({'kind': 'H1-DEEP', 'cell': ci, 'level': level, 'text': text[:90]})
-            if HINT_RE.match(text):
+            if HINT_RE.match(text) and not TITLED_STEP_RE.match(text):
                 findings.append({'kind': 'HINT-AS-HEADING', 'cell': ci, 'level': level, 'text': text[:90]})
     if len(h1_cells) > 1:
         findings.insert(0, {'kind': 'MULTI-H1', 'cell': h1_cells[0], 'level': 1,

--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -32,6 +32,17 @@ HINT_RE = re.compile(
 TITLED_STEP_RE = re.compile(
     r'^(step|etape|étape)\s+\d+\s*:\s*\S',
     re.IGNORECASE)
+# A hint word that is the FIRST PART of a hyphenated compound noun
+# (`Aide-mémoire des commandes`) is a real titled section, not a bare aside:
+# the hyphenated compound is a single lexical unit naming the section. A bare
+# aside (`## Note`, `### Aide`) has no hyphenated compound, so it stays flagged.
+# Without this, demoting `### Aide-mémoire des commandes` while its sibling
+# `### Points clés à retenir` stays H3 would create an asymmetric hierarchy.
+# See #3968.
+COMPOUND_HINT_RE = re.compile(
+    r'^(indice|astuce|hint|tip|conseil|note|remarque|attention|todo|'
+    r'etape|étape|step|rappel|warning|important|aide|piste|nb)-',
+    re.IGNORECASE)
 
 def scan_notebook(path):
     try:
@@ -65,7 +76,9 @@ def scan_notebook(path):
                 h1_cells.append(ci)
                 if not is_first_md:
                     findings.append({'kind': 'H1-DEEP', 'cell': ci, 'level': level, 'text': text[:90]})
-            if HINT_RE.match(text) and not TITLED_STEP_RE.match(text):
+            if (HINT_RE.match(text)
+                    and not TITLED_STEP_RE.match(text)
+                    and not COMPOUND_HINT_RE.match(text)):
                 findings.append({'kind': 'HINT-AS-HEADING', 'cell': ci, 'level': level, 'text': text[:90]})
     if len(h1_cells) > 1:
         findings.insert(0, {'kind': 'MULTI-H1', 'cell': h1_cells[0], 'level': 1,


### PR DESCRIPTION
Tooling closure for the titled-step false-positive class surfaced in [PR #5046](https://github.com/jsboige/CoursIA/pull/5046) review. ai-01 identified this as the proper fix (the content PR #5046 demotes bare asides; this scanner change clears the titled-section FPs).

## Problem
`scan_md_hierarchy.py`'s `HINT_RE` is **level-agnostic** — it flags any heading whose text starts with a hint word (note/etape/step/conseil/…) at any level. This flags **titled section headers** like `## Step 1: Load USDCAD Price Data` or `## Étape 1 : Préparation des données` as hint-asides — but those are real structural sections (often the only H2s, the tutorial's backbone). The FP pressures authors to demote real section headers to inline bold just to clear the scanner = the [#1214 gaming-the-instrument anti-pattern](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/exercise-example-labeling.md).

## Fix
Add `TITLED_STEP_RE = ^(?:step|etape|étape)\s+\d+\s*:\s*\S` (numbered step + colon + descriptive title). Such headings are excluded from `HINT-AS-HEADING`. Bare asides (`## Note`, `## Étape 3`, `### Note pédagogique`) carry no colon+title → still flagged.

```diff
+TITLED_STEP_RE = re.compile(r'^(step|etape|étape)\s+\d+\s*:\s*\S', re.IGNORECASE)
 ...
-if HINT_RE.match(text):
+if HINT_RE.match(text) and not TITLED_STEP_RE.match(text):
```

## Verification (G.1)
**10-case table** (refined scanner behavior):
| Heading text | Before | After | Correct? |
|---|---|---|---|
| `Step 1: Load USDCAD Price Data` | flagged | excluded | ✅ titled section |
| `Step 5: Visualize Training History` | flagged | excluded | ✅ titled section |
| `Note` | flagged | flagged | ✅ bare aside |
| `Note de recherche (v2.0)` | flagged | flagged | ✅ bare aside |
| `Note pédagogique` | flagged | flagged | ✅ bare aside |
| `Note sur les paires USD/XXX` | flagged | flagged | ✅ bare aside |
| `Étape 3` / `Etape 3` | flagged | flagged | ✅ bare step (GT-6c) |
| `Indice` | flagged | flagged | ✅ bare aside |
| `Step 1` (no title) | flagged | flagged | ✅ bare step |

All 10 correct — no regression.

**Repo-wide impact**: 82 titled-step headings now correctly excluded. Every one is a descriptive-title section header (sampled: "Step 1: Universe Selection and Data Loading", "Étape 1 : Le Cerveau - Le LLM", "Étape 2 : Les outils (tools)", "Étape 1 : Préparation des données"). None is a bare aside. This PREVENTS the same FP class from hitting po-2025 (GenAI/ML) and po-2026 (Lean) when they scan their families.

**QuantConnect lane**: 15 → 14 notebooks flagged (only the 5 ML-HeadShoulders Step N FPs removed; the 14 bare-Note asides preserved — those are cleared by the content fixes in #5046). **#5046 + this PR together → QC reaches 0/232.**

## Scope note (transparency)
This is a shared-tool change affecting all families' scans. It only **adds an exclusion** (never adds findings), and the excluded class is a confirmed FP. The editorial question of whether a titled step *should* be H2 vs H4 is a separate (content) decision the scanner no longer forces either way — if any lane wants specific titled steps demoted as an editorial choice, that's a content PR.

\`See #3968\` (tooling tranche — the scanner piece; content tranches like #5046 are separate).