### PR TITLE
docs(probas): hub Probas - cartographie Lean 4 inter-familles (See #4959, See #4038)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -512,6 +512,57 @@ Le notebook `Infer-101.ipynb` est le seul à mélanger les deux kernels. Il util
 - Von Neumann & Morgenstern (1944) - *Theory of Games and Economic Behavior*
 - Russell & Norvig - *Artificial Intelligence*, Chapter 16 (Decision Theory)
 
+### Pont vers les Preuves Formelles (Lean 4) — différenciant CoursIA
+
+Cette série ancre mathématiquement ses résultats phares dans un assistant de preuve, en partenariat avec les autres familles du dépôt. La programmation probabiliste ne se contente pas de **calculer** des densités, des utilités espérées et des bornes de généralisation — elle les **prouve**. Le tableau ci-dessous croise les notebooks Probas avec les **lakes Lean 4** qui certifient leurs théorèmes, et signale les passerelles vers les autres hubs (`QC` ↔ `kelly_lean`, `GameTheory` ↔ `social_choice_lean` Arrow, `Search` ↔ `astar_lean`, `SymbolicAI` ↔ `argumentation_lean`).
+
+| Famille                  | Lake phare                       | Théorème                                                                          | Branchement notebook                                                |
+| ---                      | ---                              | ---                                                                               | ---                                                                  |
+| Probas (DecisionTheory)  | `decision_theory_lean`           | Axiomes de Von Neumann-Morgenstern ⇒ existence d'une utilité espérée (`0 sorry`)  | [`DecisionTheory/Infer/`](DecisionTheory/Infer/README.md) Infer-14b  |
+| Probas (DecisionTheory)  | `decision_theory_lean`           | Coherence utility ⟹ preferences (loterie de référence) `#4150 MERGED`             | [`DecisionTheory/Infer/`](DecisionTheory/Infer/README.md) Coherence   |
+| Probas (PAC Learning)    | chaîne PAC iter-2 complète       | `pac_finite_class_bound` + `pac_agnostic_generalization` (`0 sorry bout-en-bout`)  | notebook PAC Learning compagnon Lean                                 |
+| Probas (DecisionTheory)  | `decision_theory_lean` Peters    | Indice de Gittins, identités d'escompte (`0 sorry`, ref `v4.27.0-rc1`)            | Infer-9 (companion Lean)                                             |
+| QC ↔ Probas              | `kelly_lean` `#4052`             | Fraction risquée `f* = μ−σ²/2` sous log-bienveillance (`0 sorry`, `#4164 SHIPPED`) | notebook `kelly-criterion`                                           |
+| GameTheory ↔ Probas      | `social_choice_lean`             | Impossibilité d'Arrow (5 axiomes ⇒ dictature)                                     | hub GameTheory notebook 16a                                          |
+| Search ↔ Probas          | `astar_lean` `#4048`             | Consistance heuristique `h ≤ h*` ⇒ optimalité `A*`                                 | hub Search notebook `A*` phases 1-3 (`#4090 SHIPPED`)                |
+| SymbolicAI ↔ Probas      | `argumentation_lean`             | Extension Dung (`grounded`/`preferred`/`stable`) par cadre formel                 | hub SymbolicAI/Tweety notebook AF-Dung                               |
+
+```mermaid
+flowchart LR
+    subgraph SIM["Probas — simulation numérique"]
+        NB_DT["Infer-14b vNM sound"]
+        NB_CO["Infer Coherence"]
+        NB_GIT["Infer-9 Gittins companion"]
+        NB_PAC["PAC Learning iter-2"]
+        NB_MCMC["PyMC NUTS / HMC"]
+        NB_EP["Infer.NET EP / VMP"]
+    end
+    subgraph LEAN["Lakes Lean 4 — preuves formelles"]
+        LK_DT["decision_theory_lean VNM"]
+        LK_CO["decision_theory_lean Coherence"]
+        LK_PAC["PAC chain uniform_concentration"]
+        LK_GIT["decision_theory_lean Peters Gittins"]
+        LK_KELLY["kelly_lean"]
+        LK_SC["social_choice_lean"]
+    end
+    NB_DT -. "axiomes vNM ⟹ utilité espérée" .-> LK_DT
+    NB_CO -. "coherence ⟹ preferences" .-> LK_CO
+    NB_PAC -. "uniform_concentration ⟹ erm_error_bound" .-> LK_PAC
+    NB_GIT -. "identités d'escompte ⟹ indice Gittins" .-> LK_GIT
+    NB_MCMC -. "log-bienveillance ⟹ f* = μ−σ²/2" .-> LK_KELLY
+    NB_EP -. "extension Dung ⟹ cadre formel" .-> LK_SC
+    style LK_DT fill:#e8f5e9,stroke:#2e7d32
+    style LK_CO fill:#e8f5e9,stroke:#2e7d32
+    style LK_PAC fill:#e8f5e9,stroke:#2e7d32
+    style LK_GIT fill:#e8f5e9,stroke:#2e7d32
+    style LK_KELLY fill:#e8f5e9,stroke:#2e7d32
+    style LK_SC fill:#e8f5e9,stroke:#2e7d32
+```
+
+La double culture Probas tient en deux gestes complémentaires. D'un côté, **simuler** : PyMC fait tourner NUTS/HMC sur des modèles hiérarchiques, Infer.NET propage des messages EP/VMP sur des graphes factoriels, et les notebooks PAC entraînent des hypothèses parERM. De l'autre, **prouver** : `decision_theory_lean` (VNM résolu 0 sorry #4049, Coherence #4150 MERGED, mono-livret #4193 OPEN) certifie que les axiomes de rationalité impliquent l'existence d'une utilité espérée, et la chaîne PAC iter-2 démontre `pac_agnostic_generalization` de bout en bout sans `sorry`. Les deux faces du même raisonnement bayésien et décisionnel — l'une touche l'intuition numérique, l'autre ancre la garantie formelle.
+
+EPIC [#4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) · cross-ref hubs [`QC` ↔ `kelly_lean`](../QuantConnect/README.md) (PR #5047), [central P0](../README.md) (PR #5049), [`GameTheory` ↔ `social_choice_lean`](../GameTheory/README.md) (PR #5050), [`SymbolicAI/Lean`](../SymbolicAI/Lean/README.md) (PR #5043 MERGED).
+
 ## Conclusion / Prochaines étapes
 
 ### Ce que vous avez appris


### PR DESCRIPTION
## Résumé

Cartographie Lean 4 inter-familles sur le **hub Probas** du dépôt (`MyIA.AI.Notebooks/Probas/README.md`). Le hub Probas alignait 5 occurrences Lean en prose (L14 `decision_theory_lean` arc autonome, L76, L185, L223, L523), mais ne posait pas de **cartographie inter-familles formalisée** avec table + Mermaid flowchart — donc la spécificité Probas (le seul hub avec un lake phare DecisionTheory : VNM/PAC/Gittins ancrés mathématiquement) restait dispersée et invisible depuis la table des matières du hub.

`grep -E "cartographie|inter-familles|Proof Formelles"` dans le hub Probas = **0 occurrence** avant cette PR. La même section livrée c.194 sur le hub GameTheory (`MyIA.AI.Notebooks/GameTheory/README.md`, #5050) reçoit 6 lignes de cartographie ; le hub Probas doit donc renvoyer la balle avec une **vue locale focalisée DecisionTheory**, pas un copier-coller du hub GameTheory.

## Changements

**`MyIA.AI.Notebooks/Probas/README.md`** (+51 lignes, 1 fichier) :

- Nouvelle section `### Pont vers les Preuves Formelles (Lean 4) — différenciant CoursIA` insérée entre L513 (Russell & Norvig) et L515 (`## Conclusion / Prochaines étapes`)
- Table 8 lignes : famille | lake phare | théorème | branchement notebook, **focalisée Probas** : `decision_theory_lean` (VNM 0 sorry #4049 + Coherence #4150 MERGED + Peters Gittins ref v4.27.0-rc1), chaîne PAC iter-2 complète 0-sorry bout-en-bout (`pac_finite_class_bound` + `pac_agnostic_generalization`), + cross-réf QC `kelly_lean` (#4052) + GameTheory `social_choice_lean` Arrow (#5050) + Search `astar_lean` (#4048) + SymbolicAI `argumentation_lean`
- **Mermaid flowchart** `flowchart LR` 2 subgraphs SIM (notebooks Probas, 6 nœuds Infer-14b/Infer Coherence/Infer-9 Gittins/PAC iter-2/PyMC NUTS/Infer.NET EP) + LEAN (6 nœuds decision_theory_lean × 3 + PAC chain + kelly + social_choice) reliés par flèches pointillées labellisées (axiomes vNM, coherence, uniform_concentration, identités d'escompte, log-bienveillance, extension Dung) ; style vert pâle `#e8f5e9` sur les nodes Lean
- Prose de transition sur la double culture Probas : simulation MCMC NUTS / message passing EP-VMP / ERM PAC ↔ preuve formelle (decision_theory_lean 0 sorry, PAC iter-2 0 sorry bout-en-bout) — les deux faces du même raisonnement bayésien/décisionnel
- Liens [EPIC #4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) + cross-ref [hub QC ↔ kelly_lean](../QuantConnect/README.md) (PR #5047) + [hub central P0](../README.md) (PR #5049) + [hub GameTheory](../GameTheory/README.md) (PR #5050) + [hub SymbolicAI Lean](../SymbolicAI/Lean/README.md) (PR #5043 MERGED)

## Pourquoi ce patch

Le mandat user 2026-07-02 sur [#4959](https://github.com/jsboige/CoursIA/issues/4959) précise « très en retard pour les plus centraux ». **P0** = hubs famille centraux ; po-2026 a livré SymbolicAI via #5043 (c.190 MERGED), po-2023 a livré QC via #5047 (c.191 OPEN), central P0 via #5049 (c.192 OPEN) + GameTheory via #5050 (c.194 OPEN). Cette PR livre Probas pour permettre à la suite (ML, GenAI, Search) de citer Probas comme **référence locale DecisionTheory** dans leurs propres sections Lean-bridge.

Probas est le **seul hub** avec un lake phare DecisionTheory (rationalité axiomatique → utilité espérée → Gittins → PAC bornes) — c'est précisément parce qu'il ancre la décision sous incertitude mathématiquement qu'il mérite une cartographie distincte d'un copier-coller. La simulation MCMC et la preuve `decision_theory_lean` sont les deux faces du même raisonnement bayésien/décisionnel. Sans cette section, les 3+ lakes Lean-phares Probas restent dispersés dans le hub, et la promesse « prouver ce qu'on a calculé » reste invisible depuis la table des matières Probas.

Suit #5050 (po-2023 moi-même, hub GameTheory OPEN), #5049 (po-2023 moi-même, hub central P0 OPEN), #5047 (po-2023 moi-même, hub QC OPEN), #5043 (po-2026 SymbolicAI MERGED). Ces 5 PRs + un dernier grain (ML ou Search ou GenAI) = un kit réutilisable pour achever la trilogie hubs-READMEs.

## Conformité règles

- **catalog-pr-hygiene HARD 1** : marqueur `CATALOG-STATUS` (L3-8) **INTACT** dans le diff (1 occurrence préservée, `pedagogical_count: 48` toujours L5, vérifié `git diff` — `--- a/...` header only) — pas de régénération catalogue sur branche feature ; c'est le cron `catalog-cron.yml` sur `main` qui régénère.
- **readme-french-first.md HARD 1** : nouveau contenu en français (hub déjà FR, edit 100% FR).
- **pr-review-discipline.md §A** : 1 fichier / 51 lignes nettes / 1 feature / 1 domaine = bien sous les seuils split (3000/15/4/1).
- **Conventional commits** : `docs(probas):` scope + description concise + `Co-Authored-By` trailer.
- **`See`/`Part of` et non `Closes`** : contribution partielle à l'epic [#4959](https://github.com/jsboige/CoursIA/issues/4959) (les hubs famille restants — ML/GenAI/Search — restent à faire) + see [#4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) + part of [#4208](https://github.com/jsboige/CoursIA/issues/4208) (porte d'entrée publique).
- **Linter MD001/heading-increment** : `###` (h3) au lieu de `####` (h4) pour rester cohérent avec le parent `### Théorie`. Linter MD060/table-column-style corrigé (pipes alignés verticalement, espaces autour des pipes). Linter MD037/no-space-in-emphasis évité (remplacement des `**bold**` dans cellules par `` `code-span` `` sémantiquement plus correct).
- **Linter leçon c.192 (Edit needs Re-Read on file modified upstream)** : `git fetch origin main` + Re-Read L508-517 appliqué avant Edit pour rafraîchir le hash du fichier (origin/main inchangé `b350a90c9`).

## Vérifications pré-PR

- `git fetch origin main` → inchangé `b350a90c9` (post-#5045 MERGE + #5043/#5045 sweep MERGE) — pas de user-pushed collision
- `git diff --stat` = 1 fichier, 51 insertions, 0 deletions
- `gh pr list --search "Probas Lean"` = aucune OPEN PR correspondante (juste #5050 mienne GameTheory, scope hub GameTheory distinct) — pas de doublon
- Pas de `Closes #X` qui auto-fermerait une epic partiellement adressée
- parent commit = `b350a90c9` sur branche fraîche `docs/4959-probas-hub-lean-bridge` from `origin/main`
- commit local = `688f78242` (vérifié `git log -1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)