### PR TITLE
fix(gametheory): replace stale 16d refs in GameTheory-1-Setup (See #5052, Part of #4212)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -288,7 +288,7 @@
     "    ('seaborn', 'seaborn'),\n",
     "    ('pandas', 'pandas'),\n",
     "    ('tqdm', 'tqdm'),\n",
-    "    ('pysat', 'pysat'),       # SAT solving (notebook 16d)\n",
+    "    ('pysat', 'pysat'),       # SAT solving (notebook SC-04)\n",
     "]\n",
     "\n",
     "print(\"Verification et installation des dependances de base...\")\n",
@@ -320,7 +320,7 @@
     "**Packages installes** :\n",
     "- nashpy, numpy, scipy, matplotlib, networkx, seaborn, pandas, tqdm, pysat\n",
     "\n",
-    "**Observation** : PySAT affiche un avertissement sur la configuration des donnees, mais cela n'affecte pas son fonctionnement pour la theorie des jeux (SAT solving pour les notebooks 16d sur la logique propositionnelle).\n",
+    "**Observation** : PySAT affiche un avertissement sur la configuration des donnees, mais cela n'affecte pas son fonctionnement pour la theorie des jeux (SAT solving pour le notebook SC-04 sur la logique propositionnelle).\n",
     "\n",
     "**Impact** : L'environnement Python a toutes les dependances necessaires pour la serie GameTheory. PySAT sera utilise dans les notebooks sur la logique et les preuves formelles (notebooks 16-19)."
    ]


### PR DESCRIPTION
See #5052. Part of #4212.

## What & why

Orphaned residual of the SocialChoice post-consolidation cleanup. PR #5059 (merged as 018405cb4) closed #5052 after fixing SC-03/SC-04, but ai-01's editorial pass (#5051, 20:38Z) had flagged that the same `16x -> SC-0x` drift also hits **GameTheory-1-Setup.ipynb** and scoped those cells to #5052 (worker bucket). The issue closed before they were addressed — the 2 stale `16d` refs remained on `main`. This PR closes that gap.

## Changes (16d -> SC-04, the confirmed mapping)

| Cell | Type | Before -> After |
|------|------|-----------------|
| `b957d13d` | code | `# SAT solving (notebook 16d)` -> `# SAT solving (notebook SC-04)` |
| `3dc400bc` | markdown | `SAT solving pour les notebooks 16d sur la logique propositionnelle` -> `... pour le notebook SC-04 sur ...` |

`16d` = the old `16d-SocialChoice-SAT`, which consolidated into `04-Computational-Aggregation-SAT-Z3.ipynb` (SC-04). PySAT is installed here precisely for that SAT notebook.

## How edited (anti-NotebookEdit-corruption)

`NotebookEdit` was **avoided** — it flattens `source` and strips `outputs`/`execution_count` on code cells (po-2023 c.199 incident, recurring). Instead: surgical raw-text replacement of the 2 source strings only, then JSON re-validated. `outputs`, `execution_count`, `metadata`, kernelspec all preserved byte-identical.

## Re-execution (C.2)

Not required. Both edits are **comment/markdown-only** on an install cell whose output is **provably invariant** — a comment change cannot alter pip-install output, and re-running the install would only inject version-drift noise. This matches the c.199 comment-only surgical-restore precedent. (Outputs are preserved unchanged, not scrubbed — Stop & Repair compliant.)

## Verification

- `grep 16[a-g]` over **source + text outputs** of this notebook = **0 hits** (remaining raw `16d` byte matches are base64 PNG noise, not prose)
- diff = exactly 2 insertions / 2 deletions (the 2 intended lines, nothing else)
- JSON re-validated after edit
- CATALOG byte-identical to `origin/main` (no regeneration on branch)

## Scope

Tight: 1 file, 2 lines, 1 feature (post-consolidation ref cleanup), 1 domain (GameTheory infra). Atomic.

**Not in scope** (left to ai-01's #5051, which owns the consolidation mapping + the active editorial PR): `GameTheory/INVENTORY.md` structural table rebuild (16b-16f schema -> SC-01..04, mapping-sensitive for 16e/16g). DM sent to ai-01 (msg-...m27wje) before editing this file.

Collision-check: this file is NOT in #5051's changed files.
