### PR TITLE
docs(gametheory): fix stale link to renamed GameTheory-6c notebook (repeated_games_lean README)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md
@@ -1,6 +1,6 @@
 # Repeated Games — Lean (compagnon formel GT-6c)
 
-> **Compagnon formel** du notebook pédagogique [GameTheory-6c](../GameTheory-6c.ipynb) (`Jeux répétés` — Dilemme du prisonnier itéré).
+> **Compagnon formel** du notebook pédagogique [GameTheory-6c](../GameTheory-6c-RepeatedGames-FolkTheorem.ipynb) (`Jeux répétés` — Dilemme du prisonnier itéré).
 > Série GameTheory a déjà 4 lakes (`cooperative_games`, `minimax`, `social_choice`, `stable_marriage`).
 > Aucun ne couvrait les jeux répétés — ce companion comble le manque avec le théorème-phare de la **stratégie grim-trigger**.
 
@@ -78,5 +78,5 @@ Cibles : `Discounting.discount_threshold_rewrite`, `GrimTrigger.grim_trigger_sus
 
 - [Issue #4880 (création du lake)](https://github.com/jsboige/CoursIA/issues/4880)
 - [Issue #4363 (junction shared Mathlib cache)](https://github.com/jsboige/CoursIA/issues/4363)
-- Notebook : [`GameTheory-6c.ipynb`](../GameTheory-6c.ipynb)
+- Notebook : [`GameTheory-6c.ipynb`](../GameTheory-6c-RepeatedGames-FolkTheorem.ipynb)
 - Lake jumeau `cooperative_games_lean` (sorries closed 2026-06-09, voir BONDAREVA_SHAPLEY_HARDNESS.md)


### PR DESCRIPTION
## Problem
`repeated_games_lean/README.md` (L3, L81) linked to `../GameTheory-6c.ipynb`, but that notebook was renamed to **`GameTheory-6c-RepeatedGames-FolkTheorem.ipynb`** (the parent `GameTheory/README.md` already uses the correct name). This is a **pre-existing broken link** — verified present on a clean `origin/main` worktree, unrelated to any content PR.

## Impact
The `check-links` CI job (stale baseline recorded "0 known broken") flags this as a *regression* on **every** README-touching PR (e.g. it was falsely blaming #5051). Fixing it here unblocks the fleet-wide `check-links` gate.

## Fix
Both links now point to the real file. `check_docs_links.py --check` on this branch → 0 new broken (the only residual `MetaGeneticSharp/GeneticSharp/README.md` entries are a local dirty-submodule artifact, absent on a clean checkout).

Atomic, docs-only, branched from fresh `origin/main`.