### PR TITLE
docs(qc): FR backfill TrendFilteredMeanReversion README (See #3870, Part of #1650)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendFilteredMeanReversion/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendFilteredMeanReversion/README.en.md
@@ -1,0 +1,93 @@
+# TrendFilteredMeanReversion Strategy
+
+**Status**: ❌ PLAFOND STRUCTUREL CONFIRMÉ - Counter-Example for Educational Purposes
+
+## Performance
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | **-0.016** |
+| CAGR | 3.4% |
+| Max Drawdown | 11.4% |
+| Period | 2015-2026 |
+
+## Why This Strategy Failed
+
+### Root Cause: Signal Frequency vs. Quality Trade-off
+
+This strategy combines:
+1. **RSI(2) < 10**: Extreme oversold signal (pullback)
+2. **SMA200 filter**: Only trade in bull markets
+3. **Time stop 5 days**: Exit if signal doesn't materialize
+
+**The problem**: It's a **valid signal** (73% win rate) but occurs **too rarely** (~9 trades/year).
+
+### Performance Breakdown
+
+| Version | Signal | Sharpe | Trades/Year | Win Rate | Max DD |
+|---------|--------|--------|-------------|----------|--------|
+| v1.0 | RSI(2) < 10 | -0.016 | ~9 | 73% | 11.4% |
+| v2.0 | RSI(2) < 20 | -0.002 | ~31 | 71% | 16.2% |
+| v3.0 | RSI(3) < 15 | -0.050 | ~12 | 72% | 10.3% |
+| v4.0 | Multi-instrument (3x) | -0.129 | ~27 | 65% | 18.5% |
+
+**Pattern observed**:
+- **Tighter signal** (RSI<10) = High quality but too rare
+- **Looser signal** (RSI<20) = More frequent but lower quality
+- **Multi-instrument** = More trades but dilutes edge + higher correlation risk
+
+### Cause of Failure: Cash Drag
+
+| Metric | Value |
+|--------|-------|
+| Time in cash | ~85% |
+| Cash return (2015-2026) | ~0% (no interest earned) |
+| Risk-free rate (T-bills) | 2-5% annualized |
+
+**The structural problem**:
+- Strategy is in cash 85% of the time
+- Cash earns 0% while risk-free (T-bills) earns 2-5%
+- This **opportunity cost** creates negative alpha
+- Even with 73% win rate, the cash drag destroys returns
+
+### Why Multi-Instrument Failed (v4.0)
+
+We tested SPY + QQQ + IWM to increase opportunities:
+- **Hypothesis**: 3x more instruments = 3x more signals
+- **Reality**: Signals are correlated (all 3 trigger together) + individual quality drops
+- **Result**: Sharpe -0.129 (worse than baseline)
+
+### Lessons Learned
+
+1. **Signal quality vs. frequency is a real trade-off**: Can't have both
+2. **Cash drag is real**: Being in cash 85% of the time = -2 to -5% annualized vs. T-bills
+3. **Multi-instrument ≠ independent signals**: Correlated markets don't increase true opportunities
+4. **Know when to stop**: We tested RSI(2), RSI(3), RSI(7), multi-instrument - all failed
+5. **Regime dependence**: This strategy only works in bull markets with sharp pullbacks (rare)
+
+## When This Approach CAN Work
+
+Similar strategies may work in:
+- **Bear markets**: RSI pullbacks are more frequent
+- **Higher volatility**: More extreme RSI readings
+- **Individual stock screening**: Cherry-pick the best setups (not systematic)
+- **Different asset classes**: Crypto, FX where mean reversion is stronger
+
+**For SPY (2015-2026)**: Plafond structurel confirmé.
+
+## Pedagogical Value
+
+This strategy demonstrates:
+- ❌ The importance of **signal frequency** in strategy design
+- ❌ **Cash drag** as a hidden cost (especially vs. risk-free rate)
+- ❌ When to declare a **plafond structurel** (after exhaustive testing)
+- ❌ The **73% win rate trap**: High win rate ≠ profitability if trades are too rare
+
+## References
+
+- **OPTIMIZATION_BACKLOG.md**: Full iteration history (v1.0-v4.0)
+- **MeanReversion**: Similar strategy but with different parameters
+
+---
+
+**Note**: This strategy has a valid signal but is structurally unprofitable due to cash drag. It serves as a lesson in opportunity cost and signal frequency.

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendFilteredMeanReversion/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendFilteredMeanReversion/README.md
@@ -1,93 +1,97 @@
-# TrendFilteredMeanReversion Strategy
+# Stratégie TrendFilteredMeanReversion
 
-**Status**: ❌ PLAFOND STRUCTUREL CONFIRMÉ - Counter-Example for Educational Purposes
+**Statut** : ❌ PLAFOND STRUCTUREL CONFIRMÉ — Contre-exemple à des fins pédagogiques
 
 ## Performance
 
-| Metric | Value |
-|--------|-------|
+| Métrique | Valeur |
+|----------|--------|
 | Sharpe Ratio | **-0.016** |
 | CAGR | 3.4% |
-| Max Drawdown | 11.4% |
-| Period | 2015-2026 |
+| Drawdown maximum | 11.4% |
+| Période | 2015-2026 |
 
-## Why This Strategy Failed
+## Pourquoi cette stratégie a échoué
 
-### Root Cause: Signal Frequency vs. Quality Trade-off
+### Cause racine : arbitrage fréquence vs. qualité du signal
 
-This strategy combines:
-1. **RSI(2) < 10**: Extreme oversold signal (pullback)
-2. **SMA200 filter**: Only trade in bull markets
-3. **Time stop 5 days**: Exit if signal doesn't materialize
+Cette stratégie combine :
+1. **RSI(2) < 10** : signal de survente extrême (repli)
+2. **Filtre SMA200** : ne trader qu'en marché haussier
+3. **Time stop 5 jours** : sortie si le signal ne se matérialise pas
 
-**The problem**: It's a **valid signal** (73% win rate) but occurs **too rarely** (~9 trades/year).
+**Le problème** : c'est un **signal valide** (73 % de taux de réussite) mais qui survient **trop rarement** (~9 transactions/an).
 
-### Performance Breakdown
+### Décomposition des performances
 
-| Version | Signal | Sharpe | Trades/Year | Win Rate | Max DD |
-|---------|--------|--------|-------------|----------|--------|
+| Version | Signal | Sharpe | Transactions/an | Taux de réussite | Max DD |
+|---------|--------|--------|-----------------|------------------|--------|
 | v1.0 | RSI(2) < 10 | -0.016 | ~9 | 73% | 11.4% |
 | v2.0 | RSI(2) < 20 | -0.002 | ~31 | 71% | 16.2% |
 | v3.0 | RSI(3) < 15 | -0.050 | ~12 | 72% | 10.3% |
 | v4.0 | Multi-instrument (3x) | -0.129 | ~27 | 65% | 18.5% |
 
-**Pattern observed**:
-- **Tighter signal** (RSI<10) = High quality but too rare
-- **Looser signal** (RSI<20) = More frequent but lower quality
-- **Multi-instrument** = More trades but dilutes edge + higher correlation risk
+**Schéma observé** :
+- **Signal strict** (RSI<10) = haute qualité mais trop rare
+- **Signal laxiste** (RSI<20) = plus fréquent mais de moindre qualité
+- **Multi-instrument** = plus de transactions mais dilue l'avantage + risque de corrélation accru
 
-### Cause of Failure: Cash Drag
+### Cause de l'échec : cash drag (coût de détention de liquidités)
 
-| Metric | Value |
-|--------|-------|
-| Time in cash | ~85% |
-| Cash return (2015-2026) | ~0% (no interest earned) |
-| Risk-free rate (T-bills) | 2-5% annualized |
+| Métrique | Valeur |
+|----------|--------|
+| Temps en liquidités | ~85% |
+| Rendement du cash (2015-2026) | ~0% (aucun intérêt perçu) |
+| Taux sans risque (T-bills) | 2-5% annualisé |
 
-**The structural problem**:
-- Strategy is in cash 85% of the time
-- Cash earns 0% while risk-free (T-bills) earns 2-5%
-- This **opportunity cost** creates negative alpha
-- Even with 73% win rate, the cash drag destroys returns
+**Le problème structurel** :
+- La stratégie est en liquidités 85 % du temps
+- Le cash rapporte 0 % tandis que le sans risque (T-bills) rapporte 2-5 %
+- Ce **coût d'opportunité** crée un alpha négatif
+- Même avec 73 % de taux de réussite, le cash drag détruit la performance
 
-### Why Multi-Instrument Failed (v4.0)
+### Pourquoi le multi-instrument a échoué (v4.0)
 
-We tested SPY + QQQ + IWM to increase opportunities:
-- **Hypothesis**: 3x more instruments = 3x more signals
-- **Reality**: Signals are correlated (all 3 trigger together) + individual quality drops
-- **Result**: Sharpe -0.129 (worse than baseline)
+Nous avons testé SPY + QQQ + IWM pour augmenter les opportunités :
+- **Hypothèse** : 3x plus d'instruments = 3x plus de signaux
+- **Réalité** : les signaux sont corrélés (les 3 se déclenchent ensemble) + la qualité individuelle baisse
+- **Résultat** : Sharpe -0.129 (pire que la baseline)
 
-### Lessons Learned
+### Leçons apprises
 
-1. **Signal quality vs. frequency is a real trade-off**: Can't have both
-2. **Cash drag is real**: Being in cash 85% of the time = -2 to -5% annualized vs. T-bills
-3. **Multi-instrument ≠ independent signals**: Correlated markets don't increase true opportunities
-4. **Know when to stop**: We tested RSI(2), RSI(3), RSI(7), multi-instrument - all failed
-5. **Regime dependence**: This strategy only works in bull markets with sharp pullbacks (rare)
+1. **Qualité vs. fréquence du signal est un véritable arbitrage** : on ne peut pas avoir les deux
+2. **Le cash drag est réel** : être en liquidités 85 % du temps = -2 à -5 % annualisé vs. T-bills
+3. **Multi-instrument ≠ signaux indépendants** : des marchés corrélés n'augmentent pas les vraies opportunités
+4. **Savoir quand s'arrêter** : nous avons testé RSI(2), RSI(3), RSI(7), multi-instrument — tous ont échoué
+5. **Dépendance au régime** : cette stratégie ne fonctionne qu'en marchés haussiers avec replis francs (rares)
 
-## When This Approach CAN Work
+## Quand cette approche PEUT fonctionner
 
-Similar strategies may work in:
-- **Bear markets**: RSI pullbacks are more frequent
-- **Higher volatility**: More extreme RSI readings
-- **Individual stock screening**: Cherry-pick the best setups (not systematic)
-- **Different asset classes**: Crypto, FX where mean reversion is stronger
+Des stratégies similaires peuvent fonctionner en :
+- **Marchés baissiers** : les replis de RSI sont plus fréquents
+- **Forte volatilité** : lectures RSI plus extrêmes
+- **Screening d'actions individuelles** : sélectionner les meilleurs setups (non systématique)
+- **Autres classes d'actifs** : crypto, FX où le retour à la moyenne est plus fort
 
-**For SPY (2015-2026)**: Plafond structurel confirmé.
+**Pour SPY (2015-2026)** : plafond structurel confirmé.
 
-## Pedagogical Value
+## Valeur pédagogique
 
-This strategy demonstrates:
-- ❌ The importance of **signal frequency** in strategy design
-- ❌ **Cash drag** as a hidden cost (especially vs. risk-free rate)
-- ❌ When to declare a **plafond structurel** (after exhaustive testing)
-- ❌ The **73% win rate trap**: High win rate ≠ profitability if trades are too rare
+Cette stratégie illustre :
+- ❌ L'importance de la **fréquence du signal** dans la conception de stratégie
+- ❌ Le **cash drag** comme coût caché (notamment vs. taux sans risque)
+- ❌ Quand déclarer un **plafond structurel** (après tests exhaustifs)
+- ❌ Le **piège du 73 % de réussite** : taux de réussite élevé ≠ rentabilité si les trades sont trop rares
 
-## References
+## Références
 
-- **OPTIMIZATION_BACKLOG.md**: Full iteration history (v1.0-v4.0)
-- **MeanReversion**: Similar strategy but with different parameters
+- **OPTIMIZATION_BACKLOG.md** : historique complet des itérations (v1.0-v4.0)
+- **MeanReversion** : stratégie similaire avec des paramètres différents
 
 ---
 
-**Note**: This strategy has a valid signal but is structurally unprofitable due to cash drag. It serves as a lesson in opportunity cost and signal frequency.
+**Note** : cette stratégie a un signal valide mais est structurellement non rentable à cause du cash drag. Elle sert de leçon sur le coût d'opportunité et la fréquence du signal.
+
+---
+
+*Version anglaise préservée dans [README.en.md](README.en.md).*


### PR DESCRIPTION
## Summary

Backfills the French README for `TrendFilteredMeanReversion` (QuantConnect/projects/) — one of only **2 residual hand-written EN-only pedagogic READMEs** repo-wide (#3870 Phase 0.5).

This is **not** an auto-gen project stub. It is a hand-written pedagogical counter-example (created by `5023b8887` *"docs(QC): add project READMEs with pedagogical counter-examples"*) that documents why a trend-filtered mean-reversion strategy hits a structural ceiling (cash drag + signal-frequency/quality trade-off). Genuine FR-backfill target per `readme-french-first.md` scope.

## Approach (non-destructive FR switch, rule 2)

- `README.md` → `README.en.md` — original English preserved **VERBATIM** (byte-identical, the golden set for Phase 3 of #1650)
- new `README.md` written in French — same structure, same sections, same references

## Faithfulness proof (numbers are backtest results — must not drift)

**75 numeric tokens, space-insensitive, EN vs FR IDENTICAL (PASS).** All backtest numbers preserved EXACTLY:
- Sharpe **-0.016**, CAGR **3.4%**, MaxDD **11.4%**, period **2015-2026**
- v1-v4 table: **-0.016 / -0.002 / -0.050 / -0.129**, trades/yr **~9/~31/~12/~27**, win **73/71/72/65%**
- cash-time **85%**, risk-free **2-5%**, RSI thresholds **10/20/15/200**
- bold-wrapped table values preserved (`**-0.016**` etc.)

The whitespace-sensitive token-diff shows shifts only because **French typography inserts a space before `%`** in prose (standard FR rule: « 73 % » vs "73%"). The space-insensitive comparison (75==75) confirms no value changed.

References preserved & valid: `OPTIMIZATION_BACKLOG.md` (exists), `MeanReversion` (sibling project exists). Added a footer pointer to `README.en.md`.

## Repo-wide census (G.1 firsthand)

Scanned all `MyIA.AI.Notebooks/**/README.md` (>80 lines real content, accent-ratio <0.3%, no `.en.md` sibling, excluding vendored/data/archive/stubs). **2 EN-only pedagogic READMEs** remain:
1. `QuantConnect/projects/TrendFilteredMeanReversion/README.md` ← **this PR**
2. `SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/upstream/README.md` ← Lean upstream reference doc (Lean lane, not QC)

So this PR closes the QC-lane portion of #3870 Phase 0.5.

## Conformity

- `readme-french-first.md` rule 2: `.en.md` separator = point ✓, original preserved ✓
- `catalog-pr-hygiene`: base fresh from `origin/main` (287b10a74), CATALOG-STATUS byte-identical, atomic (1 file translated + 1 preserved)
- `pr-review-discipline §A`: 2 files / 156 lines / 1 feature (i18n) / 1 domain (QC) — within thresholds
- `See #3870` + `Part of #1650` (partial delivery, not closing the epics)
- Conventional commit `docs(qc):` + Co-Authored-By trailer ✓
- UTF-8 no-BOM, LF-only (no CRLF churn) ✓

## Collision guard

`gh pr list` = 0 OPEN PR touches this file. No FR-backfill QC activity on the intercom (po-2023 on #5005 newline sweep, po-2026 Lean, ai-01 editorial hubs). Claimed `[CLAIMED] #3870 FR-backfill` on dashboard 22:5x before work.
