### PR TITLE
docs(genai): restore ### Aide-memoire heading in 02-Claude-CLI-Sessions (See #3968)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/02-Claude-CLI-Sessions.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/02-Claude-CLI-Sessions.ipynb
@@ -1154,7 +1154,7 @@
     "- **`--fork-session`** : Cree une branche alternative\n",
     "- **Scripts multi-tours** : Automatiser des conversations\n",
     "\n",
-    "**Aide-memoire des commandes :**\n",
+    "### Aide-memoire des commandes\n",
     "\n",
     "```bash\n",
     "# Commandes essentielles\n",


### PR DESCRIPTION
## Contexte

PR #5058 (typo-hierarchy ladder #3968) a demote `### Aide-memoire des commandes` -> `**Aide-memoire des commandes :**` (gras) dans `02-Claude-CLI-Sessions.ipynb` cell 32, pour satisfaire le scanner de hierarchie.

C'etait une **sur-correction** (pattern #1214) : `Aide-memoire` est un **nom compose**, pas un vrai indice/etape. Le scanner affine de #5048 (`COMPOUND_HINT_RE` exclut le prefixe `aide-`) l'ignore desormais correctement. Le demote laissait une **hierarchie asymetrique** : le sibling `### Points cles a retenir` est reste un heading H3.

## Fix

- 1 ligne, cellule **markdown** : `**Aide-memoire des commandes :**` -> `### Aide-memoire des commandes`.
- **Aucune** cellule code, **aucun** output, **aucun** `execution_count` touche (Stop & Repair : markdown -> pas de re-exec).
- JSON valide (`json.loads` round-trip OK).
- Le demote #5058 de `### Note sur la section Virtuoso` (RDF.Net, bare aside) est **laisse en place** — acceptable.

## Verdict coherence
po-2024 avait flagge cette incoherence #5058 vs son scanner #5048 (DM). Ruling ai-01 : restaurer le heading. Instrument (#5048) prime sur le contournement (#5058 demote).

See #3968