### PR TITLE
docs(sudoku): fix 3 narration inconsistencies in series README

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -18,7 +18,7 @@ Comment résoudre un Sudoku ? Cette série explore les techniques de résolution
 À l'issue de cette série, vous serez capable de :
 
 1. **Implémenter** un solveur de backtracking avec heuristiques (MRV, Forward Checking) et comprendre sa complexité
-2. **Comparer** 7 paradigmes algorithmiques (exhaustif, métaheuristique, CP, SMT, neuronal, LLM) sur un même problème NP-complet
+2. **Comparer** 7 paradigmes algorithmiques (exhaustif, métaheuristique, CP, SMT, probabiliste, neuronal, LLM) sur un même problème NP-complet
 3. **Modéliser** le Sudoku comme un CSP (variables, domaines, contraintes) et utiliser des solveurs industriels (OR-Tools, Choco)
 4. **Evaluer** les compromis garantie vs performance vs généralisation pour choisir une stratégie de résolution
 5. **Mesurer** empiriquement les performances de chaque approche (temps, taux de succès, échelle de difficulté)
@@ -341,7 +341,7 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 15 | Infer/NumPyro | Inférence probabiliste : distribution a posteriori sur les cases |
 | 16 | Neural Network | CNN PyTorch : apprentissage de patterns visuels sur grilles |
 | 17 | LLM | LLM Solver : prompt engineering pour résolution logique, limites |
-| 18 | Comparison | Benchmark comparatif : toutes les approches sur Easy/Medium/Hard/Expert |
+| 18 | Comparison | Benchmark comparatif : toutes les approches sur Easy/Medium/Hard |
 
 ---
 
@@ -709,7 +709,7 @@ Les notebooks Python (suffixe `-Python`) couvrent 16 solveurs avec PyGAD, OR-Too
 Cette série a utilisé le Sudoku comme **banc d'essai unique** pour comparer, sur un même problème NP-complet, sept paradigmes algorithmiques radicalement différents. L'arc pédagogique suit une progression naturelle :
 
 - **Le geste fondateur** — poser qu'un problème computationnel peut s'attaquer par des voies très différentes : énumération exhaustive (backtracking), métaheuristiques (recuit simulé, algorithmes génétiques), programmation par contraintes (CP-SAT, OR-Tools), satisfiabilité modulaire (Z3/SMT), inférence probabiliste (NumPyro, Infer.NET), et approches data-driven (réseaux de neurones, LLM). Le Sudoku n'est pas l'objectif : c'est le **terrain commun** qui rend les paradigmes comparables.
-- **Le double langage** — l'approche miroir C#/Python (16 + 16 notebooks) ancre une leçon concrète : les mêmes algorithmes se transposent d'un écosystème à l'autre. GeneticSharp ↔ PyGAD, OR-Tools .NET ↔ OR-Tools Python, Z3 .NET ↔ Z3 Python. Le concept précède l'outil.
+- **Le double langage** — l'approche miroir C#/Python (13 paires miroir, soit 26 notebooks) ancre une leçon concrète : les mêmes algorithmes se transposent d'un écosystème à l'autre. GeneticSharp ↔ PyGAD, OR-Tools .NET ↔ OR-Tools Python, Z3 .NET ↔ Z3 Python. Le concept précède l'outil.
 - **Le compromis fondamental** — chaque paradigme paie un prix différent. Les solveurs exacts (DLX, Norvig, CP-SAT, Z3) **garantissent** la solution mais au coût d'une recherche combinatoire. Les métaheuristiques sont plus rapides en moyenne sans garantie. Les approches neuronales **généralisent** mais échouent sur les instances difficiles. Le notebook 18 (Comparison) synthétise ces compromis : garantie vs performance vs généralisation.
 
 La thèse pratique est honnête : il n'existe pas de « meilleur solveur » dans l'absolu — il existe un solveur adapté à chaque contexte (garantie requise, temps imparti, données disponibles), et savoir le choisir est précisément ce que cette série enseigne.


### PR DESCRIPTION
## Contexte

Passe éditoriale « regard-neuf » (cron `:41`) sur la série **Sudoku**. La série est solide (arc 7 niveaux cohérent, thèse « pas de meilleur solveur dans l'absolu » honnête), mais une relecture fraîche fait ressortir **3 incohérences internes** dans le README, toutes vérifiées firsthand contre l'inventaire de fichiers et le notebook-capstone.

## Corrections (narration fidelity)

| Ligne | Avant | Après | Preuve firsthand |
|-------|-------|-------|------------------|
| Objectif 2 | `7 paradigmes (…, SMT, neuronal, LLM)` — **6 items** listés | ajoute `probabiliste` → **7 items** | La parenthèse comptait 6 termes pour « 7 paradigmes » ; le paradigme probabiliste (Infer.NET/NumPyro, notebook 15) était omis |
| Apport notebook 18 | `benchmark … Easy/Medium/Hard/Expert` | `… Easy/Medium/Hard` | `Sudoku-18-Comparison-Python.ipynb` définit `EASY/MEDIUM/HARD_PUZZLES` uniquement — **0 occurrence** de « Expert » dans le notebook (grep vérifié) |
| Conclusion « double langage » | `l'approche miroir C#/Python (16 + 16 notebooks)` | `(13 paires miroir, soit 26 notebooks)` | 13 paires miroir vérifiées (notebooks 1-12 + 15 ont bien `-Csharp` **et** `-Python`) ; cohérent avec l'intro ligne 12 et le CATALOG (33 = 26 miroir + 3 C#-only + 3 Py-only + 1 Lean) |

## Garanties

- **CATALOG-STATUS block non touché** (cron-owned, cf `catalog-pr-hygiene`).
- **Zéro changement de lien** → check-links non affecté (les 3 lignes modifiées ne contiennent aucun lien markdown).
- Diff = **3 lignes de prose**, un seul fichier, un seul sujet (fidélité narrative du README Sudoku).

## Suivi (hors scope de cette PR)

Le notebook-18 s'arrête à **Hard** (25-29 indices) et n'atteint jamais **Expert** (17-24 indices) — précisément le régime où la thèse garantie-vs-heuristique de la série devient indéniable (les métaheuristiques timeout, les solveurs exacts tiennent). Enrichissement **Prong B #3801** tracké dans une issue dédiée (les données `Puzzles/Sudoku_hardest.txt` et `Sudoku_top95.txt` sont déjà dans le repo). Cette PR ne fait que rendre le README honnête sur l'état **actuel** du benchmark.

Part of #4212 (finition éditoriale) · Part of #2651 (prose pédagogique)