### PR TITLE
docs(qc): accent cross-check on 3 FR-primary QC docs (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/GETTING-STARTED.md
+++ b/MyIA.AI.Notebooks/QuantConnect/GETTING-STARTED.md
@@ -68,13 +68,13 @@ class MyFirstAlgorithm(QCAlgorithm):
 
 ### Etape 4 : Utiliser les ressources CoursIA
 
-Les notebooks `QC-Py-XX` sont des **supports de cours** a lire sur GitHub ou en Jupyter local. Ils ne sont pas conçus pour etre uploades dans QC Lab.
+Les notebooks `QC-Py-XX` sont des **supports de cours** a lire sur GitHub ou en Jupyter local. Ils ne sont pas conçus pour être uploadés dans QC Lab.
 
 **Pour votre projet QC, utilisez plutot** :
 
 1. **Projets prets a backtester** : Copiez un `main.py` depuis `projects/` dans votre projet QC Lab
 2. **Templates de projet** : Partez d'un template (`partner-course-quant-trading/templates/starter/`) adapte a votre niveau
-3. **Notebooks de reference** : Lisez les `QC-Py-XX` pour comprendre la theorie et les patterns
+3. **Notebooks de reference** : Lisez les `QC-Py-XX` pour comprendre la théorie et les patterns
 
 **Exemple concret** :
 1. Ouvrez `projects/EMA-Cross-Alpha/main.py` sur GitHub

--- a/MyIA.AI.Notebooks/QuantConnect/docs/PAPER_TO_LIVE_TRANSITION.md
+++ b/MyIA.AI.Notebooks/QuantConnect/docs/PAPER_TO_LIVE_TRANSITION.md
@@ -6,7 +6,7 @@ Ce document decrit les prerequis et étapes pour passer du paper trading au live
 
 ## 1. Checklist pre-live
 
-Avant de passer en live, **toutes** les conditions suivantes doivent etre remplies :
+Avant de passer en live, **toutes** les conditions suivantes doivent être remplies :
 
 ### Performance
 - [ ] Sharpe Ratio > 0.5 sur le backtest (minimum 3 ans)
@@ -34,8 +34,8 @@ Avant de passer en live, **toutes** les conditions suivantes doivent etre rempli
 
 ```
 Backtest (historique)
-  -> Paper Trading (donnees reelles, fills simules)
-    -> Live Trading (donnees reelles, fills reels)
+  -> Paper Trading (données réelles, fills simulés)
+    -> Live Trading (données réelles, fills réels)
 ```
 
 | Source | Backtest | Paper | Live |
@@ -108,7 +108,7 @@ brokerage = {
 brokerage = {
     "id": "InteractiveBrokersBrokerage",
     "ib-user-name": "<username>",
-    "ib-account": "U12345",  # <- compte reel (pas DU...)
+    "ib-account": "U12345",  # <- compte réel (pas DU...)
     "ib-password": "<password>",
     "ib-weekly-restart-utc-time": "04:00:00"
 }
@@ -117,8 +117,8 @@ brokerage = {
 ### Risques spécifiques equities
 
 - **Gap risk** : le marche ouvre avec un gap par rapport a la cloture precedente
-- **Short selling** : les actions peuvent etre "hard to borrow"
-- **Regulation T** : regles de marge spécifiques (pattern day trader aux US)
+- **Short selling** : les actions peuvent être "hard to borrow"
+- **Regulation T** : règles de marge spécifiques (pattern day trader aux US)
 - **Corporate actions** : splits, dividendes, mergers affectent les positions
 
 ---
@@ -144,12 +144,12 @@ position_size = (capital * risk_per_trade) / stop_loss_distance
 
 Chaque position live doit avoir un stop-loss. Options :
 
-| Methode | Description | Avantage |
+| Méthode | Description | Avantage |
 |---------|-------------|----------|
 | Fixe (%) | -5% du prix d'entrée | Simple |
 | ATR-based | k * ATR(14) sous l'entrée | S'adapte a la volatilite |
 | Trailing | Monte avec le prix | Protege les gains |
-| Time-based | Sortie apres N jours | Evite les positions stagnantes |
+| Time-based | Sortie après N jours | Évite les positions stagnantes |
 
 ### Diversification minimum
 
@@ -176,9 +176,9 @@ Chaque position live doit avoir un stop-loss. Options :
 Si une anomalie est detectee :
 
 1. **Stop live algorithm** via MCP QC : `stop_live_algorithm(projectId=...)`
-2. **Liquidier les positions** si necessaire : `liquidate_live_algorithm(projectId=...)`
+2. **Liquidier les positions** si nécessaire : `liquidate_live_algorithm(projectId=...)`
 3. **Analyser les logs** : `read_live_logs(projectId=..., algorithmId=..., startLine=0, endLine=250)`
-4. **Corriger l'algorithme** et re-backtester avant de re-deployer
+4. **Corriger l'algorithme** et re-backtester avant de re-déployer
 
 ---
 
@@ -188,7 +188,7 @@ Ce document est un **guide pedagogique**, pas un conseil financier. Le trading a
 
 > "Past performance is not indicative of future results."
 
-Les strategies presentees dans les notebooks QC-Py-40 et QC-Py-41 sont des exemples educatifs. Leur performance en backtest ou paper trading ne garantit pas de performance en live.
+Les strategies présentées dans les notebooks QC-Py-40 et QC-Py-41 sont des exemples éducatifs. Leur performance en backtest ou paper trading ne garantit pas de performance en live.
 
 ### Ressources
 - [QC Live Trading Docs](https://www.quantconnect.com/docs/v2/our-platform/live-trading)

--- a/MyIA.AI.Notebooks/QuantConnect/docs/QC_CLOUD_ASSISTANTS_WORKFLOW.md
+++ b/MyIA.AI.Notebooks/QuantConnect/docs/QC_CLOUD_ASSISTANTS_WORKFLOW.md
@@ -10,35 +10,35 @@ QC Cloud offre 8 assistants IA qui executent des recherches, backtests, et valid
 | Assistant | Role | Cas d'usage cluster |
 |-----------|------|---------------------|
 | **Research Assistant** | Notebooks Jupyter (QuantBook) | Re-exec/reconstruction de notebooks QC-Py-* |
-| **Backtest Assistant** | Backtests | Sweep multi-parametres quand MCP indisponible |
+| **Backtest Assistant** | Backtests | Sweep multi-paramètres quand MCP indisponible |
 | **Ideas Assistant** | Ideation strategies | Brainstorming nouvelles strategies curriculum |
-| **Research Validation Assistant** | Validation croisee | Verification resultats de recherche |
+| **Research Validation Assistant** | Validation croisée | Verification résultats de recherche |
 | **Conductor** | Orchestration | Workflows multi-etapes |
 | **Paper Testing Assistant** | Paper trading | Deploy paper tests |
 | **Live Monitoring Assistant** | Monitoring algos live | Surveillance 24/7 (Phase 3 future) |
-| **Mia** | Generaliste | Taches QC generales |
+| **Mia** | Généraliste | Tâches QC générales |
 
 ## Acces
 
 **URL** : `https://www.quantconnect.com/organization/{org-id}/assistants`
 **Org ESGF** : `d600793ee4caecb03441a09fc2d00f7f`
 **Credits restants** : ~3457 QCC (a verifier avant chaque deployment)
-**Cout estime par session Research** : 800-1200 QCC (14 cells)
+**Coût estime par session Research** : 800-1200 QCC (14 cells)
 
-## Methode preferee vs Fallbacks
+## Méthode préférée vs Fallbacks
 
-| Tache | Methode primaire | Fallback | Rationale |
+| Tâche | Méthode primaire | Fallback | Rationale |
 |-------|------------------|----------|-----------|
-| Notebooks QuantBook | **QC Research Assistant** | MCP `read_file` + local papermill | Assistant auto-debogue (NaN, colonnes, parametres) |
+| Notebooks QuantBook | **QC Research Assistant** | MCP `read_file` + local papermill | Assistant auto-débogue (NaN, colonnes, paramètres) |
 | Backtests | **MCP Docker** (`create_compile` -> `create_backtest`) | Backtest Assistant | MCP = gratuit, scriptable, repeatable |
 | Paper trading | MCP `create_live_algorithm` | Paper Testing Assistant | MCP pour automatisation |
-| Ideation strategies | LLM local (Qwen3.6) | Ideas Assistant | Gratuit, pas de cout QCC |
+| Ideation strategies | LLM local (Qwen3.6) | Ideas Assistant | Gratuit, pas de coût QCC |
 
 ## Protocole de mesure des couts (calibrage)
 
 ### Principe
 
-Avant de basculer le cluster vers les assistants de maniere systematique, **mesurer le cout reel** de 3 categories de complexite.
+Avant de basculer le cluster vers les assistants de manière systématique, **mesurer le coût réel** de 3 catégories de complexité.
 
 ### Mesure
 
@@ -47,14 +47,14 @@ Avant de basculer le cluster vers les assistants de maniere systematique, **mesu
    - **Leger** : Research Assistant — re-executer 5-10 cells existantes (cible : QC-Py-* simple)
    - **Moyen** : Research Assistant — reconstruction 15-25 cells avec feature engineering (cote : ML-* moyen)
    - **Lourd** : Research Assistant — strategy from scratch (cf Portfolio Phase 1 = 105 features)
-3. **Snapshot balance apres** : delta = cout
-4. **Reporter** : `categorie | nb_cells | nb_features | balance_avant | balance_apres | delta_QCC | duree | quality`
+3. **Snapshot balance après** : delta = coût
+4. **Reporter** : `catégorie | nb_cells | nb_features | balance_avant | balance_apres | delta_QCC | durée | quality`
 
-**Budget calibrage** : 200 QCC max (garde 90%+ pour use cases reels).
+**Budget calibrage** : 200 QCC max (garde 90%+ pour use cases réels).
 
-### Resultats existants
+### Résultats existants
 
-| Deployment | Cells | Balance avant | Balance apres | Delta | Duree | Qualite |
+| Deployment | Cells | Balance avant | Balance après | Delta | Durée | Qualité |
 |------------|-------|---------------|---------------|-------|-------|---------|
 | Portfolio Phase 1 (A-8ad2fb) | 14 | ~3457 | ~2657 (estime) | ~800 | 45min | Sharpe 3.50 assistant vs 0.971 cluster |
 
@@ -62,18 +62,18 @@ _Note : le Sharpe assistant est inflated (pas tx costs, pas slippage, 365j annua
 
 ## Matrice de delegation
 
-### Taches delegables aux assistants
+### Tâches delegables aux assistants
 
-| Tache cluster | Owner actuel | Delegation proposee | Conditions |
+| Tâche cluster | Owner actuel | Delegation proposée | Conditions |
 |---------------|-------------|--------------------:|------------|
-| Re-exec 21 QC-Py-* (audit H.7) | po-2024 manuel | Research Assistant batch | Cout < 30 QCC/nb |
+| Re-exec 21 QC-Py-* (audit H.7) | po-2024 manuel | Research Assistant batch | Coût < 30 QCC/nb |
 | Quantbooks `projects/*/quantbook.ipynb` | po-2024 via Playwright | Research Assistant | Fallback Playwright si echec |
 | Strategy ideation (Curriculum V2) | ai-01 + po-2024 | Ideas + Research Assistant | Garder validation cluster-side |
 | Notebook creation from scratch | po-2024 manuel | Research Assistant | Pour scaffold initial |
 
-### Taches NON delegables (gardees cluster-side)
+### Tâches NON delegables (gardées cluster-side)
 
-- **Validation multi-seed** (walk-forward 5-fold + >=4 seeds + edge >= 2sigma + 10bps tx) — regle G.2
+- **Validation multi-seed** (walk-forward 5-fold + >=4 seeds + edge >= 2sigma + 10bps tx) — règle G.2
 - **Decisions strategiques** (curriculum, declassement vs maintien, achats QCC)
 - **PR review + merge** (audit forensique H.4)
 - **Recherche methodologique** (Hands-On AI Trading, papers)
@@ -91,11 +91,11 @@ L'assistant rapporte des Sharpes **inflationnes** car :
 
 **Exemple** : Portfolio Phase 1 — Sharpe assistant 3.50 vs Sharpe cluster (blended) 0.971.
 
-**Toujours re-valides cluster-side** les resultats assistants.
+**Toujours re-valides cluster-side** les résultats assistants.
 
 ### Coordination obligatoire
 
-- **Annoncer sur dashboard** avant chaque deployment (eviter chevauchement agents)
+- **Annoncer sur dashboard** avant chaque deployment (éviter chevauchement agents)
 - **Rate limiter** : max 10 appels API/min (fleet-wide)
 - **Budget restant** : verifier credits avant chaque session
 
@@ -105,14 +105,14 @@ L'assistant rapporte des Sharpes **inflationnes** car :
 2. Selectionner **Research Assistant**
 3. Pointer vers le projet cible (ex: QC-Py-15)
 4. Donner des instructions claires (re-executer notebook, corriger erreurs, ajouter features)
-5. L'assistant debogue automatiquement (NaN, colonnes manquantes, parametres)
+5. L'assistant débogue automatiquement (NaN, colonnes manquantes, paramètres)
 6. **Download le notebook result** depuis le deployment
 7. **Re-valider cluster-side** : Papermill local + verification multi-seed si ML
 
 ## References
 
 - Issue #1195 : contexte + protocole + matrice delegation
-- `feedback_qc_assistants_preferred.md` : methode preferee QC Cloud Assistants
-- `docs/qc/quantconnect.md` : configuration MCP Docker + regles QC
+- `feedback_qc_assistants_preferred.md` : méthode préférée QC Cloud Assistants
+- `docs/qc/quantconnect.md` : configuration MCP Docker + règles QC
 - `docs/ml-trading-state.md` : 7 disciplines ML trading
 - Portfolio IBKR-Binance-Hybrid : validation Phase 1 (deployment A-8ad2fb)


### PR DESCRIPTION
Part of #2876 (accents manquants — repo-wide FR READMEs/docs). **Partial contribution** to the epic (epic stays open).

## Scope

37 lines accent-fixed across 3 FR-primary QC docs:

| File | Lines |
|------|-------|
| `docs/QC_CLOUD_ASSISTANTS_WORKFLOW.md` | 24 |
| `docs/PAPER_TO_LIVE_TRANSITION.md` | 11 |
| `GETTING-STARTED.md` | 2 |

## Verification (mechanical, evidence-cited)

- **De-accent invariant PASS per-file**: `deaccent(old) == deaccent(new)` => only accents added, **NO letter dropped/added/changed**. Gold-standard proof (cf. `accent-pr-deaccent-verification` lesson).
- **LF-only**: CRLF count = 0 on all 3 files (`write_bytes`, no Windows churn — #5046/#5060 lesson).
- **Diff stat**: `+37/-37` = pure accentuation, zero net content change.

## EN-safety — EN-ambiguous words EXCLUDED from the dict

`method/estime/utilise/valide/generation/definition/depend/precise/complete/genere/termine/strategies/reference/Verification/Delegation` are all **also valid EN words** → replacing their unaccented form could break EN prose. Correctly left untouched.

**Known residual** (EN-ambiguous tradeoff, deferred): `strategies` (PAPER_TO_LIVE line 191) and `Delegation` (QC_CLOUD line 67) are visibly unaccented on FR lines. These stay untouched because the accent tool cannot distinguish FR-context from EN-context occurrences — per the accent-PR EN-mask rule, EN-ambiguous words are excluded entirely rather than risk EN-prose false-positives.

EN/code prose preserved intact: Short selling, Regulation T, hard to borrow, Sweep, MCP, dashboard, deployment, snake_case fields, QCC, papermill, multi-seed, walk-forward.

## Collision guard

`gh pr list --search 2876` = 0 OPEN PR on these files; po-2023 accent tranches (#5025/#5031/#5032) = disjoint file subsets.

## Method

Curated FR-only-spelling dict (unaccented forms that are NOT valid EN words), case-aware regex, word-boundary matched. Applied via `fix_2876_qc_accents.py` with the de-accent invariant as a hard abort gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
