### PR TITLE
docs(qc): typo tranche on 5 QC FR docs — non-word misspellings (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M11h_KELLY_CAP_RELAXED.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M11h_KELLY_CAP_RELAXED.md
@@ -59,7 +59,7 @@ Cellules en gras : ESCALATE (sign-test p < 0.10 a 100bps avec cap=3.0).
 - **POSITIVE sur Kelly cap** : 12/27 cellules de la grille (cap, thr, fee>=50bps)
   passent ESCALATE (>=60% delta>0 et p<0.10). Toutes les cellules cap=3.0/fee>=50bps
   sont positives.
-- **Trade-off** : cap=3.0 = jusqu'a 3x leverage sur la Kelly fraction. Drawdowns
+- **Trade-off** : cap=3.0 = jusqu'à 3x leverage sur la Kelly fraction. Drawdowns
   potentiels significativement plus eleves. M11h NE QUANTIFIE PAS ces drawdowns
   (script ne calcule que Sharpe paired diff).
 
@@ -92,7 +92,7 @@ Sortie : `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/results/m11h_kelly
 
 ## Discipline (G.2 / regle multi-seed)
 
-- Walk-forward 5-fold preserve (n_splits=5 par default, refit_every=22)
+- Walk-forward 5-fold preserve (n_splits=5 par défaut, refit_every=22)
 - Pas de FAANG/Mag7 (crypto only, conforme dataset_paths.md)
 - Transaction costs documentes (10/50/100 bps)
 - Pas de single-seed verdict — agregation 35-combo cross-coin/cross-horizon

--- a/MyIA.AI.Notebooks/QuantConnect/docs/PAPER_TO_LIVE_TRANSITION.md
+++ b/MyIA.AI.Notebooks/QuantConnect/docs/PAPER_TO_LIVE_TRANSITION.md
@@ -176,7 +176,7 @@ Chaque position live doit avoir un stop-loss. Options :
 Si une anomalie est detectee :
 
 1. **Stop live algorithm** via MCP QC : `stop_live_algorithm(projectId=...)`
-2. **Liquidier les positions** si nécessaire : `liquidate_live_algorithm(projectId=...)`
+2. **Liquider les positions** si nécessaire : `liquidate_live_algorithm(projectId=...)`
 3. **Analyser les logs** : `read_live_logs(projectId=..., algorithmId=..., startLine=0, endLine=250)`
 4. **Corriger l'algorithme** et re-backtester avant de re-déployer
 

--- a/MyIA.AI.Notebooks/QuantConnect/docs/PAPER_TRADING_ARCHITECTURE.md
+++ b/MyIA.AI.Notebooks/QuantConnect/docs/PAPER_TRADING_ARCHITECTURE.md
@@ -106,7 +106,7 @@ def initialize(self):
 ### Leverage
 
 - Compte Cash : 1x
-- Compte Margin : jusqu'a 3x
+- Compte Margin : jusqu'à 3x
 - Binance US : Cash uniquement
 
 ### Assets disponibles

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_SUMMARY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_SUMMARY.md
@@ -307,7 +307,7 @@ Le notebook genere:
 
 ### Si recherche concluante
 
-1. **Compiler** la strategie mise a jour sur QuantConnect
+1. **Compiler** la strategie mise à jour sur QuantConnect
 2. **Lancer backtest** complet 2019-2025 via web UI
 3. **Valider metriques** vs predictions du notebook
 4. **Deployer** en paper trading si Sharpe > 0.8
@@ -319,7 +319,7 @@ Le notebook genere:
    - Machine Learning (RandomForest sur features MACD+ADX)
    - Regime switching (HMM pour detecter bull/bear)
 2. **Creer nouveau research notebook** pour approche alternative
-3. **Iterer** jusqu'a trouver strategie robuste
+3. **Itérer** jusqu'à trouver strategie robuste
 
 ## Notes Techniques
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/_docs/OPTIMIZATION_BACKLOG.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/_docs/OPTIMIZATION_BACKLOG.md
@@ -226,7 +226,7 @@ SPY seul. 5 features. Sharpe 0.136, Beta 0.276, Alpha -0.009. Signaux aleatoires
 
 **Bug critique corrige (v2.0 -> v2.0.1)**: _target_network.predict() avant premier fit() -> NotFittedError.
 FIX: _target_initialized = False separement de _network_initialized.
-Utiliser Q-network comme fallback jusqu'a la premiere mise a jour mensuelle du target network.
+Utiliser Q-network comme fallback jusqu'à la première mise à jour mensuelle du target network.
 Insidieux: build reussit, echec uniquement a l'execution apres quelques semaines.
 
 **Pistes restantes (non testees):**


### PR DESCRIPTION
Part of **#2876** (accents manquants — repo-wide FR READMEs/docs). **Partial contribution** (epic stays open). Pickup of ai-01 cycle-23:52Z note (`Liquidier` typo left out-of-scope by #5070).

## Scope — single class: unambiguous non-word misspellings + apostrophe-accent errors

Every fixed form is either **a non-word** (`Liquidier`, `Iterer`) or **a FR-only apostrophe construction** (`jusqu'a`→`jusqu'à`, `mise a jour`→`mise à jour`) or **EN-intrusion in FR** (`par default`→`par défaut`). All zero-risk: none of the source forms are valid EN words.

| File | Fix |
|------|-----|
| `docs/PAPER_TO_LIVE_TRANSITION.md` | `Liquidier` → `Liquider` |
| `docs/PAPER_TRADING_ARCHITECTURE.md` | `jusqu'a` → `jusqu'à` |
| `ML-Training-Pipeline/docs/M11h_KELLY_CAP_RELAXED.md` | `jusqu'a` → `jusqu'à`, `par default` → `par défaut` |
| `projects/CSharp-BTC-MACD-ADX/RESEARCH_SUMMARY.md` | `mise a jour` → `mise à jour`, `Iterer` → `Itérer`, `jusqu'a` → `jusqu'à` |
| `projects/_docs/OPTIMIZATION_BACKLOG.md` | `jusqu'a` → `jusqu'à`, `premiere` → `première`, `mise a jour` → `mise à jour` |

## Verification (mechanical, evidence-cited)

- **Residual scan**: 0 remaining instances of `jusqu'a` / `par default` / `Iterer` / `Liquidier` / `mise a jour` in QC tree (excl vendored/.en.md).
- **LF-only blobs**: `autocrlf=input`; HEAD blobs confirmed CRLF=0. Clean diff — no whole-file CRLF churn (+7/-7 = only the 7 typo lines).
- **Diff stat**: `+7/-7` = pure typo correction, zero net content change.
- **G.1 context-read firsthand** every site (all FR-context confirmed). `premiere` at OPTIMIZATION_BACKLOG:229 is FR ("premiere mise a jour mensuelle"), not EN movie-premiere.

## Scope discipline (G.4/G.5) — what is deliberately NOT included

`RESEARCH_SUMMARY.md` and `OPTIMIZATION_BACKLOG.md` carry **systematic accent debt** (`strategie` ×8, `periode`, `calcules`, `fenetre`, `etendue`, `ajoutee`, `metriques`, `predictions`, `Deployer`, `Creer`, `detecter`, `eleves`) — a **different class** (full-doc accent backfill), kept as a **separate future grain** to avoid G.4 composite scope.

`strategie` is intentionally left (consistent exclusion: systematic accent debt, not a non-word typo). Zero risk either way — EN = "strategy" ≠ "strategie".

## Collision guard

`gh pr list` on each of the 5 files = 0 OPEN PR. #5070 (merged) touched 3 disjoint QC docs (`QC_CLOUD_ASSISTANTS_WORKFLOW`, `GETTING-STARTED`, and the now-fixed `PAPER_TO_LIVE_TRANSITION` accent layer — this PR fixes the non-accent typo on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
