### PR TITLE
docs(qc): accent backfill QUICK_TOUR.md + AUDIT_RAPPORT (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
+++ b/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
@@ -1,27 +1,27 @@
 # QuantConnect AI Trading - Quick Tour
 
-**95+ strategies backtested | 51 notebooks Python | 20 patterns confirmes | Composite robuste (TrendWeather Sharpe aligné 0.95)**
+**95+ strategies backtested | 51 notebooks Python | 20 patterns confirmés | Composite robuste (TrendWeather Sharpe aligné 0.95)**
 
-Cette section contient un parcours complet de trading algorithmique sur **QuantConnect LEAN**, du debutant au deploiement live. Tout est executable gratuitement sur le cloud QC.
+Cette section contient un parcours complet de trading algorithmique sur **QuantConnect LEAN**, du débutant au déploiement live. Tout est exécutable gratuitement sur le cloud QC.
 
 > **Lecture vérifiée sous frais réels (#1630, 2018-2025).** Les Sharpes « catalogue » ci-dessous sont **pré-frais, fenêtres variables** ; elles ne résistent pas toutes à un backtest honnête sous frais IBKR réels sur une fenêtre alignée 2018-2025. Cas emblématique : **EMA-Cross-Alpha** passe de Sharpe catalogue **0.996 à -0.010 aligné** (PSR 0.5%) = overfitting sévère d'un backtest court, **pas** un top performer. Les vrais leaders vérifiés alignés : **LongShortHarvest 1.64** (PSR 98.7%, le plus robuste), **TrendWeather 0.948** (composite qui tient, PSR 56.6%), **EMATrend 0.611** / **composite-c2 0.574** (backbone no-ML). Catalogue complet + diagnostics par stratégie : [docs/qc/qc-comparative-backtests.md](../../docs/qc/qc-comparative-backtests.md) (See #1630).
 
-## 5 arrets pour comprendre notre travail
+## 5 arrêts pour comprendre notre travail
 
-1. **[Meilleure strategie](projects/Framework_Composite_TrendWeather/)** — Composite TrendStocks + AllWeather (Sharpe 1.156, CAGR 27.4%). Architecture Algorithm Framework modulaire : AlphaModel + PortfolioConstruction + Execution.
+1. **[Meilleure stratégie](projects/Framework_Composite_TrendWeather/)** — Composite TrendStocks + AllWeather (Sharpe 1.156, CAGR 27.4%). Architecture Algorithm Framework modulaire : AlphaModel + PortfolioConstruction + Execution.
 
-2. **[Catalogue strategies](docs/qc_strategies_catalog.md)** — 95+ projets organises par categorie (Alpha, Trend Following, ML/RL, Composites). Top performers vérifiés alignés (#1630) : Long-Short Harvest (Sharpe **1.64**, PSR 98.7%), TrendWeather Composite (**0.948**, PSR 56.6%), EMATrend (**0.611**).
+2. **[Catalogue strategies](docs/qc_strategies_catalog.md)** — 95+ projets organisés par catégorie (Alpha, Trend Following, ML/RL, Composites). Top performers vérifiés alignés (#1630) : Long-Short Harvest (Sharpe **1.64**, PSR 98.7%), TrendWeather Composite (**0.948**, PSR 56.6%), EMATrend (**0.611**).
 
-3. **[Patterns confirmes](../../docs/qc/quantconnect.md)** — 20 patterns valides sur 30+ iterations (risk-adjusted momentum, skip-month, stop-loss -8/-12%, monthly rebalancing, anti-overfitting) et 10 anti-patterns critiques (SPY Parking, backtests courts, yfinance != QC cloud).
+3. **[Patterns confirmés](../../docs/qc/quantconnect.md)** — 20 patterns valides sur 30+ iterations (risk-adjusted momentum, skip-month, stop-loss -8/-12%, monthly rebalancing, anti-overfitting) et 10 anti-patterns critiques (SPY Parking, backtests courts, yfinance != QC cloud).
 
-4. **[Notebooks pedagogiques](Python/)** — 51 notebooks en 8 phases progressives : fondations LEAN, universe/asset classes, risk management, Algorithm Framework, donnees alternatives, ML (RF/XGBoost), deep learning (LSTM/Transformers), RL et LLMs pour trading.
+4. **[Notebooks pédagogiques](Python/)** — 51 notebooks en 8 phases progressives : fondations LEAN, universe/asset classes, risk management, Algorithm Framework, données alternatives, ML (RF/XGBoost), deep learning (LSTM/Transformers), RL et LLMs pour trading.
 
-5. **[Mapping livre Jared Broad](BOOK_MAPPING.md)** — 63 exemples du livre *Hands-On AI Trading* (2025) mappes a nos notebooks et projets. 22 strategies ML du Chapitre 6 importees.
+5. **[Mapping livre Jared Broad](BOOK_MAPPING.md)** — 63 exemples du livre *Hands-On AI Trading* (2025) mappés a nos notebooks et projets. 22 strategies ML du Chapitre 6 importées.
 
-## Demarrer en 5 minutes
+## Démarrer en 5 minutes
 
-1. Creer un compte gratuit sur [quantconnect.com](https://www.quantconnect.com/signup)
+1. Créer un compte gratuit sur [quantconnect.com](https://www.quantconnect.com/signup)
 2. Copier un `main.py` depuis [projects/](projects/) dans un nouveau projet QC Lab
 3. Cliquer **Backtest** — c'est tout
 
-> Documentation complete : [README.md](README.md) | [Guide demarrage](GETTING-STARTED.md) | [Patterns QC](../../docs/qc/quantconnect.md)
+> Documentation complete : [README.md](README.md) | [Guide démarrage](GETTING-STARTED.md) | [Patterns QC](../../docs/qc/quantconnect.md)

--- a/MyIA.AI.Notebooks/QuantConnect/docs/audits/AUDIT_RAPPORT_2026-03-22.md
+++ b/MyIA.AI.Notebooks/QuantConnect/docs/audits/AUDIT_RAPPORT_2026-03-22.md
@@ -1,30 +1,30 @@
-# Audit Pedagogique README - QuantConnect
+# Audit Pédagogique README - QuantConnect
 
 **Date** : 2026-03-22
 **Issue** : #48
 **Auditeur** : po-2026 (Claude Code)
-**Portee** : 26 READMEs (excluant les fichiers LEAN par defaut dans `data/`)
+**Portée** : 26 READMEs (excluant les fichiers LEAN par défaut dans `data/`)
 
 ---
 
-## Resume Executif
+## Résumé Exécutif
 
-| Metrique | Resultat | Target | Status |
+| Métrique | Résultat | Target | Status |
 |----------|----------|--------|--------|
-| **Liens brises** | 0 | 0 | [OK] |
+| **Liens brisés** | 0 | 0 | [OK] |
 | **READMEs avec titre** | 26/26 (100%) | >80% | [OK] |
 | **READMEs avec description (>50 mots)** | 26/26 (100%) | >90% | [OK] |
 | **Sections manquantes** | 94 (projets uniquement) | - | [!] |
 
-**Note** : Les 94 sections manquantes sont dans les dossiers `projects/` et `ESGF-2026/examples/`, qui ont leur propre structure adaptee aux algorithmes de trading. Ce n'est pas un probleme pedagogique.
+**Note** : Les 94 sections manquantes sont dans les dossiers `projects/` et `ESGF-2026/examples/`, qui ont leur propre structure adaptée aux algorithmes de trading. Ce n'est pas un problème pédagogique.
 
 ---
 
-## Corrections Appliquees
+## Corrections Appliquées
 
-### 1. Liens C# brises (29 liens corriges)
+### 1. Liens C# brisés (29 liens corrigés)
 
-**Probleme** : Le README principal contenait des liens vers des notebooks C# qui n'existent pas encore.
+**Problème** : Le README principal contenait des liens vers des notebooks C# qui n'existent pas encore.
 
 **Solution** : Remplace les liens par du texte avec indication "*(a venir)*"
 
@@ -32,44 +32,44 @@
 # Avant
 | QC-Py-01-Setup.ipynb | [QC-CS-01-Setup.ipynb](CSharp/QC-CS-01-Setup.ipynb) |
 
-# Apres (entries 01-04)
+# Après (entries 01-04)
 | QC-Py-01-Setup.ipynb | QC-CS-01-Setup *(a venir)* |
 
-# Apres (entries 05-27, dernier fix)
+# Après (entries 05-27, dernier fix)
 | QC-Py-05-Universe-Selection.ipynb | QC-CS-05-Universe-Selection *(a venir)* |
 ```
 
-**Fichiers modifies** :
-- `README.md` (27 liens C# corriges)
+**Fichiers modifiés** :
+- `README.md` (27 liens C# corrigés)
 
-### 2. Script d'audit cree
+### 2. Script d'audit créé
 
 **Fichier** : `scripts/audit_readme.py`
 
-**Fonctionnalites** :
+**Fonctionnalités** :
 - Analyse structurelle des READMEs (lignes, mots, sections)
-- Detection des liens brises (liens relatifs uniquement)
+- Détection des liens brisés (liens relatifs uniquement)
 - Classification par type (MAIN, PROJECT, ESGF_EXAMPLE, etc.)
-- Verification des sections attendues (flexible par mots-cles)
+- Vérification des sections attendues (flexible par mots-cles)
 - Exclusion automatique du dossier `data/` (fichiers LEAN)
 
-### 3. Amelioration du script d'audit
+### 3. Amélioration du script d'audit
 
 **Corrections** (commit 0cc9efb) :
 
 - Bug H5 : `"ESGF-2026/examples" in parts` → `"ESGF-2026" in parts and "examples" in parts`
 - Bug H6 : ZeroDivisionError protege par `if total == 0: return`
-- Style : Emojis supprimes (code-style.md compliance)
-- Exclusion du dossier `data/` (fichiers LEAN par defaut, non pedagogiques)
+- Style : Emojis supprimés (code-style.md compliance)
+- Exclusion du dossier `data/` (fichiers LEAN par défaut, non pédagogiques)
 - Recherche flexible des sections (mots-cles au lieu de correspondance exacte)
 - Ignorage des ancres internes (`#troubleshooting`, etc.)
 
 ---
 
-## Resultats par Categorie
+## Résultats par Catégorie
 
 ### MAIN (1 fichier) [OK]
-- `README.md` : 726 lignes, 19 sections, 0 liens brises
+- `README.md` : 726 lignes, 19 sections, 0 liens brisés
 
 ### ESGF_MAIN (2 fichiers) [OK]
 - `ESGF-2026/README.md` : 331 lignes, 10 sections
@@ -80,7 +80,7 @@
 Les exemples ESGF ont leur propre structure :
 
 - BTC-MachineLearning, Crypto-MultiCanal, ETF-Pairs-Trading, Multi-Layer-EMA, Option-Wheel-Strategy, Options-VGT, Sector-Momentum, Trend-Following
-- Sections manquantes : Objectif, Strategie, Resultats, Installation, Utilisation (optionnelles pour exemples)
+- Sections manquantes : Objectif, Stratégie, Résultats, Installation, Utilisation (optionnelles pour exemples)
 
 ### ESGF_TEMPLATE (3 fichiers) [OK]
 
@@ -92,10 +92,10 @@ Tous les templates ESGF sont OK :
 
 ### PROJECT (12 fichiers) [!]
 
-Les projets ont leur propre structure adaptee :
+Les projets ont leur propre structure adaptée :
 
-- Les sections manquantes (Description, Strategie, Performance, etc.) sont optionnelles selon le type de projet
-- Certains projets sont documentes de maniere minimale (2 sections seulement)
+- Les sections manquantes (Description, Stratégie, Performance, etc.) sont optionnelles selon le type de projet
+- Certains projets sont documentés de manière minimale (2 sections seulement)
 - Recommandation : Standardiser la documentation des projets (futur)
 
 ---
@@ -103,34 +103,34 @@ Les projets ont leur propre structure adaptee :
 ## Recommandations
 
 ### Court terme ([OK] complete)
-1. [OK] Corriger les liens C# brises dans README principal
-2. [OK] Creer un script d'audit automatise
-3. [OK] Exclure les fichiers non pedagogiques (data/)
+1. [OK] Corriger les liens C# brisés dans README principal
+2. [OK] Créer un script d'audit automatise
+3. [OK] Exclure les fichiers non pédagogiques (data/)
 4. [OK] Corriger les bugs du script (H5, H6, emojis)
 
 ### Moyen terme (suggere)
 
 1. **Standardiser la documentation des projets** dans `projects/`
-   - Ajouter des sections "Strategie" et "Performance" manquantes
-   - Creer un template de README pour les projets
+   - Ajouter des sections "Stratégie" et "Performance" manquantes
+   - Créer un template de README pour les projets
 
 2. **Standardiser la documentation des exemples** dans `ESGF-2026/examples/`
-   - Ajouter des sections "Objectif", "Strategie", "Resultats" manquantes
-   - Creer un template de README pour les exemples
+   - Ajouter des sections "Objectif", "Stratégie", "Résultats" manquantes
+   - Créer un template de README pour les exemples
 
-3. **Creer les notebooks C#** marques comme "a venir"
-   - 27 notebooks C# a creer pour parite Python/C#
+3. **Créer les notebooks C#** marques comme "a venir"
+   - 27 notebooks C# a créer pour parite Python/C#
 
 ### Long terme
 
 1. **Automatiser l'audit** dans le CI/CD
-2. **Creer un guide de style** pour les READMEs QuantConnect
+2. **Créer un guide de style** pour les READMEs QuantConnect
 
 ---
 
 ## Conclusion
 
-L'audit pedagogique #48 est **TERMINE avec succes**.
+L'audit pédagogique #48 est **TERMINE avec succes**.
 
 - **0 lien brise** dans les 26 READMEs analyses
 - **100% des READMEs** ont un titre conforme


### PR DESCRIPTION
Part of **#2876** (accents manquants — repo-wide FR READMEs/docs). **Partial contribution** (epic stays open).

## Scope — 2-file FR-primary accent tranche (single class)

| File | Lines fixed |
|------|-------------|
| `QUICK_TOUR.md` (27L) | 11 |
| `docs/audits/AUDIT_RAPPORT_2026-03-22.md` (146L) | 37 |

Both files verified **FR-primary** via firsthand full-file read (G.1) — language trap caught: my initial regex flagged `REGIME_ANALYSIS.md` (14 hits) but that file is **EN-primary** and the "hits" were valid EN words (`strategies`/`iterations`/`complete`) — correctly excluded from this tranche.

## Verification (mechanical, gold-standard)

- **De-accent invariant PASS** per-file: `deaccent(old) == deaccent(new)` => only accents added, **NO letter dropped/added/changed**.
- **LF-only blobs**; `+48/-48` = pure accentuation, zero net content change. CATALOG/markers untouched.

## EN-ambiguous words EXCLUDED (consistent with #5070/#5080 EN-mask)

Valid EN words / FR present-tense verbs left unaccented: **strategies** (plural), **complete**, **Remplace** (FR present verb), **Analyse**, **Classification**, **analyses**.

Singular **Strategie → Stratégie** IS accented (not a valid EN word).

## Known residuals (conservative EN-mask; documented honestly, not filler)

- **`a`** (standalone, as in "a venir"): too ambiguous to accent globally (EN article/letter `a`). → `à venir` left as-is.
- **`succes` / `cles` / `TERMINE`**: FR-only misspellings not included in this dict round (follow-up candidate).
- **`marques` / `automatise`**: EN-ambiguous loanwords (EN "marques" = brands).

## Scope discipline (G.4/G.5)

Single-class (accent backfill), 2-file coherent tranche. RESEARCH_SUMMARY.md + OPTIMIZATION_BACKLOG.md accent pass still **DEFERRED** until #5075 merges (those files are touched by #5075 — avoid self-conflict).

## Collision guard

`gh pr list --search` on both files = 0 OPEN PR. #5070 (merged) + #5075 (open) + #5080 (open) = disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
