### PR TITLE
docs(lean-i18n): conway_cgt_lean/CGTTour.lean docstrings bilingues FR+EN (#4980 pilote)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/CGTTour.lean
+++ b/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/CGTTour.lean
@@ -1,35 +1,53 @@
 /-
-  Tour of vihdzp/combinatorial-games Results
-  ===========================================
+  Tour des résultats de vihdzp/combinatorial-games
+  =================================================
 
-  This file provides a curated tour of the main results formalized in
+  Ce fichier propose une visite guidée des principaux résultats formalisés dans
+  vihdzp/combinatorial-games, importé comme dépendance Lake.
+
+  ---
+  English: This file provides a curated tour of the main results formalized in
   vihdzp/combinatorial-games, imported as a Lake dependency.
 
-  Repository: https://github.com/vihdzp/combinatorial-games
-  Authors: Violeta Hernandez Palacios (vihdzp)
-  License: Apache-2.0
+  Dépôt / Repository: https://github.com/vihdzp/combinatorial-games
+  Auteurs / Authors: Violeta Hernandez Palacios (vihdzp)
+  Licence / License: Apache-2.0
 
-  Historical note:
+  Note historique :
+  Ce dépôt a remplacé les modules CGT de Mathlib (SetTheory.Surreal,
+  SetTheory.PGame, SetTheory.Game, SetTheory.Nimber), dépréciés dans la PR
+  #28063 (août 2025) puis retirés dans la PR #35550 (février 2026). L'autrice
+  (vihdzp) est la même personne qui maintenait le code CGT de Mathlib.
+
+  ---
+  English — Historical note:
   This repository superseded Mathlib's CGT modules (SetTheory.Surreal,
   SetTheory.PGame, SetTheory.Game, SetTheory.Nimber), which were deprecated
   in PR #28063 (Aug 2025) and removed in PR #35550 (Feb 2026). The author
   (vihdzp) is the same person who maintained the Mathlib CGT code.
 
-  Key contributions formalized here:
+  Principales contributions formalisées ici :
+  1. Jeux combinatoires (IGame, Game, anniversaire, équivalence, ordre)
+  2. Nombres surréels (LinearOrder, théorème de simplicité, multiplication, division)
+  3. Nimbers (corps de caractéristique 2, connexion Sprague-Grundy)
+  4. Jeux dyadiques et plongements ordinaux
+
+  ---
+  English — Key contributions formalized here:
   1. Combinatorial games (IGame, Game, birthday, equivalence, ordering)
   2. Surreal numbers (LinearOrder, simplicity theorem, multiplication, division)
   3. Nimbers (characteristic 2 field, Sprague-Grundy connection)
   4. Dyadic games and ordinal embeddings
 -/
 
--- Core game theory
+-- Théorie des jeux de base / Core game theory
 import CombinatorialGames.Game.Basic
 import CombinatorialGames.Game.Birthday
 import CombinatorialGames.Game.Order
 import CombinatorialGames.Game.Canonical
 import CombinatorialGames.Game.Player
 
--- Surreal numbers
+-- Nombres surréels / Surreal numbers
 import CombinatorialGames.Surreal.Basic
 import CombinatorialGames.Surreal.Multiplication
 import CombinatorialGames.Surreal.Division
@@ -44,7 +62,33 @@ namespace CGTTour
 
 open IGame Game Surreal Nimber
 
-/-! ## 1. Combinatorial Games
+/-! ## 1. Jeux combinatoires
+
+La formalisation repose sur deux couches :
+
+### IGame (pré-jeux)
+Un `IGame` est un jeu combinatoire défini par ses ensembles d'options gauches et
+droites :
+```
+structure IGame : Type (u+1) where
+  left : Set IGame
+  right : Set IGame
+  [small_left : Small left]
+  [small_right : Small right]
+```
+C'est la représentation concrète, où l'on peut inspecter les coups individuels.
+
+### Game (jeux à équivalence près)
+Deux jeux `x` et `y` sont équivalents (`x ≈ y`) quand aucun joueur n'a de
+préférence — formellement `x ≤ y ∧ y ≤ x`. Le type quotient :
+```
+def Game := Antisymmetrization IGame (· ≤ ·)
+```
+
+`Game` forme un `OrderedAddCommGroup` :
+
+---
+**English**
 
 The formalization is built on two layers:
 
@@ -68,11 +112,31 @@ def Game := Antisymmetrization IGame (· ≤ ·)
 
 `Game` forms an `OrderedAddCommGroup`:
 -/
-#check @Game.mk                               -- IGame → Game (quotient map)
+#check @Game.mk                               -- IGame → Game (application du quotient)
 #check (inferInstance : AddCommGroupWithOne Game)
 #check (inferInstance : PartialOrder Game)
 
-/-! ## 2. Surreal Numbers
+/-! ## 2. Nombres surréels
+
+Un nombre surréel est un jeu numérique quotienté par équivalence :
+```
+def Surreal := Antisymmetrization (Subtype Numeric) (· ≤ ·)
+```
+
+Les surréels héritent de `≤` et `<` des jeux, formant un **ordre linéaire**.
+Ils forment un corps ordonné complet contenant tout corps ordonné comme sous-corps.
+
+### Théorème de simplicité
+Si un jeu numérique `x` tient dans `y` (se situe entre les options gauches et
+droites de y) mais qu'aucune de ses options n'y tient, alors `x ≈ y`. C'est
+l'outil clé pour calculer les valeurs surréelles :
+```
+theorem IGame.Fits.equiv_of_forall_not_fits :
+    Numeric x → x.Fits y → (∀ p z ∈ x.moves p, ¬ z.Fits y) → x ≈ y
+```
+
+---
+**English**
 
 A surreal number is a numeric game quotiented by equivalence:
 ```
@@ -92,10 +156,18 @@ theorem IGame.Fits.equiv_of_forall_not_fits :
 ```
 -/
 #check @Surreal.mk                            -- IGame → [Numeric] → Surreal
-#check (inferInstance : LinearOrder Surreal)   -- Total order on surreals
-#check @IGame.Fits.equiv_of_forall_not_fits   -- Simplicity theorem
+#check (inferInstance : LinearOrder Surreal)   -- Ordre total sur les surréels
+#check @IGame.Fits.equiv_of_forall_not_fits   -- Théorème de simplicité
 
-/-! ### Surreal Arithmetic
+/-! ### Arithmétique des surréels
+
+Les surréels portent les opérations complètes d'un corps :
+- Addition (héritée du AddCommGroup de Game)
+- Multiplication (définie dans Surreal.Multiplication)
+- Division (définie dans Surreal.Division)
+
+---
+**English — Surreal Arithmetic**
 
 The surreals carry full field operations:
 - Addition (inherited from Game's AddCommGroup)
@@ -105,20 +177,51 @@ The surreals carry full field operations:
 #check (inferInstance : CommRing Surreal)
 #check (inferInstance : LinearOrder Surreal)
 
-/-! ### Dyadic Surreals
+/-! ### Surréels dyadiques
+
+Tout rationnel dyadique se plonge dans les surréels via `Dyadic.toIGame`.
+Les surréels dyadiques sont exactement ceux d'anniversaire fini.
+
+---
+**English — Dyadic Surreals**
 
 Every dyadic rational embeds into the surreals via `Dyadic.toIGame`.
 The dyadic surreals are precisely those with finite birthday.
 -/
-#check @Dyadic.toIGame    -- Dyadic rational → IGame embedding
+#check @Dyadic.toIGame    -- Plongement Rationnel dyadique → IGame
 
-/-! ### Ordinal Embedding
+/-! ### Plongement ordinal
+
+Tout ordinal se plonge dans les surréels via `NatOrdinal.toSurreal` :
+
+---
+**English — Ordinal Embedding**
 
 Every ordinal embeds into the surreals via `NatOrdinal.toSurreal`:
 -/
 #check @NatOrdinal.toSurreal  -- NatOrdinal ↪o Surreal
 
 /-! ## 3. Nimbers
+
+Les nimbers sont des ordinaux munis de l'arithmétique de nim. Ils proviennent des
+jeux impartiaux via le théorème de Sprague-Grundy : tout jeu impartial est
+équivalent à une partie de nim.
+
+### Définition
+```
+Nimber = Ordinal (synonyme de type avec addition et multiplication nimber)
+```
+Notation : `∗o` pour `Nimber.of o` (conversion depuis Ordinal).
+
+### Addition de nim
+`a + b` est la valeur minimale exclue (mex) de `{a' + b, a + b'}` :
+```
+theorem add_def (a b : Nimber) :
+    a + b = sInf {x | (∃ a' < a, a' + b = x) ∨ ∃ b' < b, a + b' = x}ᶜ
+```
+
+---
+**English**
 
 Nimbers are ordinals equipped with nim arithmetic. They arise from impartial
 games via the Sprague-Grundy theorem: every impartial game is equivalent to
@@ -137,10 +240,19 @@ theorem add_def (a b : Nimber) :
     a + b = sInf {x | (∃ a' < a, a' + b = x) ∨ ∃ b' < b, a + b' = x}ᶜ
 ```
 -/
-#check @Nimber.add_def          -- mex definition of nim addition
-#check @Nimber.exists_of_lt_add -- converse: every smaller value is reached
+#check @Nimber.add_def          -- Définition de l'addition de nim par mex
+#check @Nimber.exists_of_lt_add -- Réciproque : toute valeur plus petite est atteinte
 
-/-! ### Nimber Field
+/-! ### Corps des nimbers
+
+Les nimbers avec addition et multiplication de nim forment un **corps de
+caractéristique 2** (chaque élément est son propre opposé pour l'addition).
+
+L'objectif à long terme du projet est de prouver que les nimbers sont
+algébriquement clos.
+
+---
+**English — Nimber Field**
 
 Nimbers with nim addition and nim multiplication form a **field of
 characteristic 2** (every element is its own additive inverse).
@@ -149,7 +261,23 @@ The long-term goal of the project is to prove nimbers are algebraically closed.
 -/
 #check (inferInstance : Field Nimber)
 
-/-! ## 4. Key Differences with the Former Mathlib CGT
+/-! ## 4. Différences clés avec l'ancien CGT de Mathlib
+
+Le dépôt `combinatorial-games` représente une expansion substantielle :
+
+| Aspect | Mathlib (retiré) | combinatorial-games (actuel) |
+|--------|------------------|------------------------------|
+| Jeux | `PGame` (basique) | `IGame` (concret) + `Game` (quotient) |
+| Surréels | `Surreal.Basic/Dyadic/Mul` | + Division, séries de Hahn, Anniversaire, Pow |
+| Nimbers | `Nimber.Basic/Field` | + Nat, SimplestExtension |
+| Ordre | `PGame.Order` | `LinearOrder` complet sur les surréels |
+| Bibliothèque de jeux | 8 modules | 15+ modules (Impartial, Loopy, Specific...) |
+| Toolchain | v4.x (ancien) | v4.31.0-rc1 (actuel) |
+
+Référence : Conway, J.H. - *On Numbers and Games* (2001)
+
+---
+**English — Key Differences with the Former Mathlib CGT**
 
 The `combinatorial-games` repo represents a substantial expansion:
 


### PR DESCRIPTION
See #4980. Pilote i18n `.lean` (décision user 2026-07-02) sur le plus petit lake EN-dominant.

## What & why

#4980 (user decision 2026-07-02): harmoniser les **fichiers `.lean` eux-mêmes** (docstrings + commentaires) en français + traduire en anglais, « comme les readme ». Clarifie #4957/#1650 (qui couvraient les READMEs seulement). Pilote PR #4988 (sudoku_lean) a établi la convention **Option A** (docstrings bilingues inline FR+EN, source unique = zéro dérive).

**Candidat pilote** : `conway_cgt_lean` — le plus petit lake EN-dominant (1 fichier `.lean`, 0 FR-marks AVANT, 100% anglais). Étape 2 du rollout mémorisé (« EN-dominants petits »). Lake **distinct** de `conway_lean` (lane Hashlife ai-01, coordonné — non touché).

## Convention appliquée (Option A, lean-i18n-convention)

| Élément | Règle |
|---------|-------|
| Docstrings module `/-! ... -/` + sections | Bilingues : **FR d'abord**, puis EN après séparateur `---` + lead-in `**English**` |
| Commentaires tactiques inline `-- ...` | **FR seul** (orientés dev, traduire chaque commentaire de `#check` = FR-seul) |
| Noms d'identifiants / signatures Lean | **Inchangés** (convention nommage Mathlib = anglais) |
| Blocs de code markdown dans docstrings | Recopiés à l'identique en FR et EN |

## Anti-régression (prouvée)

Memoire `lean-i18n-convention` : « Commentaires ne changent pas la compilation ». Preuve structurelle :
- **Délimiteurs `/-` == `-/` équilibrés (9/9)** — pas d'erreur de parsing de bloc.
- **Code Lean réel byte-identique** : les 28 lignes de code (`#check` + `import` + `namespace` + `open` + `end`) sont **identiques AVANT == APRÈS** (signatures sans les commentaires `--`).
- **0 sorry AVANT et APRÈS** (CGTTour.lean = tour `#check`, aucune preuve).
- Les 4 `def` / 4 `theorem` / 2 `structure` détectés sont **tous dans des blocs de code markdown** des docstrings (versions FR + EN du même bloc, contenu identique recopié de l'original) — aucune signature réelle dupliquée ou modifiée.

## Build / Verification

- **`grep -c sorry`** : 0 AVANT, 0 APRÈS.
- **Délimiteurs équilibrés** : 9 `/-` == 9 `-/` (Python count).
- **Code réel identique** : 28 code-lines AVANT == 28 APRÈS, signatures identiques.
- **Local `lake build`** : bloqué par un **mathlib pin drift préexistant** (le `lakefile` `require mathlib` + `require CombinatorialGames` crée un conflit transitif de versions — warning `lake` explicite « project pins different versions than Mathlib »). **Non introduit par cette PR** : aucune PR récente n'a touché le `.lean` (les 5 dernières = #4999 toolchain rc1, #4347 Mermaid, #3894/#3859/#3120 README/docs). Le pin drift est latent et mérite une PR config séparée (classe `peters #4364`), pas mélangé à une PR i18n.
- **Gate de référence** : CI `lean-conway-cgt.yml` (existe, déclenchée par cette PR). Les docstrings ne changent pas la compilation (pilot #4988 a vérifié `lake build EXIT 0` sur docstring-only sur sudoku_lean).

## Cohérence i18n du lake

`README.md` déjà FR-dominant (75 FR-marks) + companion `README.en.md` (Phase 0.5 #1650). Le `.lean` bilingue FR-d'abord est maintenant **cohérent** avec le README du même lake.

## Scope

Atomique : 1 fichier, +151/−23 (additif prose bilingue, code Lean inchangé). Pilote #4980. Le mathlib pin drift (si la CI échoue dessus) = PR config séparée, pas dans le scope i18n.
