### PR TITLE
fix(docs): repair 3 broken relative links (GameTheory/Lean/QC)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.en.md
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.en.md
@@ -1,6 +1,6 @@
 # Repeated Games — Lean (formal companion of GT-6c)
 
-> **Formal companion** of the pedagogical notebook [GameTheory-6c](../GameTheory-6c.ipynb) (`Repeated Games` — Iterated prisoner's dilemma).
+> **Formal companion** of the pedagogical notebook [GameTheory-6c](../GameTheory-6c-RepeatedGames-FolkTheorem.ipynb) (`Repeated Games` — Iterated prisoner's dilemma).
 > This companion fills the gap in the GameTheory series (which already has 4 Lean lakes: `cooperative_games`, `minimax`, `social_choice`, `stable_marriage`).
 
 ## Headline theorem
@@ -42,5 +42,5 @@ The numeric threshold `δ ≥ (T − R) / (T − P)` is the **falsifiable gate**
 
 - [Issue #4880 (lake creation)](https://github.com/jsboige/CoursIA/issues/4880)
 - [Issue #4363 (junction shared Mathlib cache)](https://github.com/jsboige/CoursIA/issues/4363)
-- Notebook: [`GameTheory-6c.ipynb`](../GameTheory-6c.ipynb)
+- Notebook: [`GameTheory-6c.ipynb`](../GameTheory-6c-RepeatedGames-FolkTheorem.ipynb)
 - Sibling lake `cooperative_games_lean` (sorries closed 2026-06-09, see BONDAREVA_SHAPLEY_HARDNESS.md)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M11g_FEE_AWARE_KELLY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M11g_FEE_AWARE_KELLY.md
@@ -95,7 +95,7 @@ non clippée, par exemple), pas sur Kelly capé.
 
 - [M11f_TX_COST_SWEEP.md](M11f_TX_COST_SWEEP.md) — fee-sweep baseline (break-even 50-100bps)
 - [M11e_ENSEMBLE.md](M11e_ENSEMBLE.md) — ensemble equal-weight DILUTION
-- [project_m11ef_ensemble_txcost.md](../../../C:/Users/MYIA/.claude/projects/d--CoursIA/memory/project_m11ef_ensemble_txcost.md) — mémoire M11e+f
+- `project_m11ef_ensemble_txcost.md` — mémoire interne M11e+f (note d'agent, hors dépôt)
 
 ## Pattern récurrent M11
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/Finiteness.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/Finiteness.en.md
@@ -75,7 +75,7 @@ of Symbolic Derivatives in Lean*, ITP 2025), repo
 Since its upstream license is not confirmed, **this file does not vendor their
 code**: it illustrates the intuition through **original** definitions and
 examples, with no dependency (no Mathlib). The notebook
-[`Lean-14-Finiteness-Derivatives.ipynb`](../../Lean-14-Finiteness-Derivatives.ipynb)
+[`Lean-14-Finiteness-Derivatives.ipynb`](../Lean-14-Finiteness-Derivatives.ipynb)
 develops the pedagogical presentation and the bridge to the Conway Epic #2162.
 
 ### `Regex`


### PR DESCRIPTION
## Résumé

Répare 3 liens relatifs cassés (détectés par un sweep sur `origin/main`, résolus contre `git ls-tree`) — tous vérifiés comme de vrais défauts, cibles confirmées présentes.

| Fichier | Lien cassé | Correction |
|---------|-----------|-----------|
| `GameTheory/repeated_games_lean/README.en.md` (×2) | `../GameTheory-6c.ipynb` | `../GameTheory-6c-RepeatedGames-FolkTheorem.ipynb` (notebook renommé ; le README FR pointait déjà correctement, seule la variante `.en.md` gardait le lien pré-renommage) |
| `SymbolicAI/Lean/finiteness_lean/Finiteness.en.md` (L78) | `../../Lean-14-…` | `../Lean-14-…` (off-by-one ; L37 du même fichier était déjà correcte) |
| `QuantConnect/ML-Training-Pipeline/docs/M11g_FEE_AWARE_KELLY.md` | `../../../C:/Users/MYIA/.claude/projects/…/memory/…` | délié → mention texte (chemin machine absolu, mémoire d'agent hors dépôt) |

## Scope & conformité
- **Markdown-only**, C.3-exempt (aucune source de notebook modifiée, pas de ré-exécution requise).
- **Catalogue non touché** (byte-identique à main).
- Diff : 3 fichiers, 4 insertions / 4 suppressions — uniquement les liens.
- Cibles vérifiées présentes dans l'arbre (`GameTheory-6c-RepeatedGames-FolkTheorem.ipynb`, `Lean-14-Finiteness-Derivatives.ipynb`).

Note : le cluster `LEAN_INVENTORY.md` référençant `.claude/projects/c--dev-CoursIA-2/memory/*` (12 liens systématiques vers la mémoire privée d'une autre machine) est un défaut distinct, laissé à une issue dédiée plutôt qu'à un patch au coup par coup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)