### PR TITLE
docs(lean): delink 12 dead private-memory refs in 6 LEAN_INVENTORY.md (Closes #5087)

### DIFF
--- a/MyIA.AI.Notebooks/ML/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/ML/LEAN_INVENTORY.md
@@ -7,7 +7,7 @@ vérité : corps de l'Epic
 [#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification `firsthand`. Colonne
 *Sorry (production)* = métrique CI `standalone-tactic` (les mentions prose « 0 sorry »
 n'entrent pas dans ce compte ; cf.
-[`lean-ci-sorry-filter`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+`lean-ci-sorry-filter`).
 
 ## Résumé
 
@@ -71,7 +71,7 @@ laissé en `sorry`. Axiomes `[propext, Classical.choice, Quot.sound]` (Mathlib s
 - **WDAC workaround** (RECOVERABLE-LOCAL) : `lake exe cache get` bloqué (err 4551) → réutilise
   les oleans `.lake/packages/` d'un lake frère binairement compatible (`astar_lean`, même
   toolchain `v4.31.0-rc1` + même révision Mathlib). Cf.
-  [`lean-wdac-olean-wholesale-copy`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+  `lean-wdac-olean-wholesale-copy`.
 - **Mathlib v4.31.0-rc1 IPS-API renames** (documentés durably) : `InnerProductSpace ℝ V`
   exige `[SeminormedAddCommGroup V]` param-class ; `norm_sq_eq_inner`→`real_inner_self_eq_norm_sq` ;
   `abs_inner_le_norm`→`real_inner_le_norm` ; `inner_comm`→`real_inner_comm` ;

--- a/MyIA.AI.Notebooks/Probas/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/Probas/LEAN_INVENTORY.md
@@ -8,7 +8,7 @@ vérité : corps de l'Epic
 [#4041](https://github.com/jsboige/CoursIA/issues/4041)). Colonne *sorry (production)* =
 métrique CI `standalone-tactic` (les mentions prose « 0 sorry »/« sans sorry » n'entrent pas
 dans ce compte ; cf.
-[`lean-ci-sorry-filter`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+`lean-ci-sorry-filter`).
 
 ## Résumé
 
@@ -128,7 +128,7 @@ Index de Gittins pour les bandits manchots à escompte géométrique.
 - **WDAC workaround** : `decision_theory_lean` (cohorte v4.30.0-rc2) se construit en
   réutilisant le `.lake` d'un lake frère binairement compatible (wholesale
   `cp -r sibling/.lake` + `lake-manifest.json`, révision Mathlib identique). Cf.
-  [`lean-wdac-olean-wholesale-copy`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+  `lean-wdac-olean-wholesale-copy`.
 - **Coordination finitude-derivatives (#2978)** : `decision_theory_lean` Gittins est
   coordonné avec `finiteness_lean` (#3111) — pas de chevauchement (Gittins = décision
   séquentielle, finiteness = résultat de finitude standalone).

--- a/MyIA.AI.Notebooks/Search/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/Search/LEAN_INVENTORY.md
@@ -7,7 +7,7 @@ vérité : corps de l'Epic
 [#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification `firsthand`. Colonne
 *Sorry (production)* = métrique CI `standalone-tactic` (les mentions prose « 0 sorry »
 n'entrent pas dans ce compte ; cf.
-[`lean-ci-sorry-filter`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+`lean-ci-sorry-filter`).
 
 ## Résumé
 
@@ -66,7 +66,7 @@ Axiomes `[propext, Classical.choice, Quot.sound]` (Mathlib standard, **pas de `s
 
 - **WDAC workaround** (RECOVERABLE-LOCAL) : `lake exe cache get` bloqué → réutilise les
   oleans `.lake/packages/` d'un lake frère binairement compatible. Cf.
-  [`lean-wdac-olean-wholesale-copy`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+  `lean-wdac-olean-wholesale-copy`.
 - **Mathlib v4.31.0-rc1 tactic learnings** (documentés durably) : `subst` sur l'égalité de
   tête d'induction élimine l'AUTRE variable → utiliser `hd` dans le corps ; lemmes de
   `head?`/`getLast?` non nommés → `simp`/`simp_all` plutôt que lemme nommé ; warnings

--- a/MyIA.AI.Notebooks/Sudoku/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/Sudoku/LEAN_INVENTORY.md
@@ -7,7 +7,7 @@ vérité : corps de l'Epic
 [#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification `firsthand`. Colonne
 *Sorry (production)* = métrique CI `standalone-tactic` (les mentions prose « 0 sorry »
 n'entrent pas dans ce compte ; cf.
-[`lean-ci-sorry-filter`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+`lean-ci-sorry-filter`).
 
 ## Résumé
 
@@ -62,6 +62,6 @@ Prop/Fintype ; **pas de `sorryAx`**).
   (pas de conflit de symbols/namespaces).
 - **WDAC workaround** (RECOVERABLE-LOCAL) : `lake exe cache get` bloqué → copie wholesale
   `cp -r sibling/.lake` + `lake-manifest.json` d'un lake frère compatible. Cf.
-  [`lean-wdac-olean-wholesale-copy`](../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+  `lean-wdac-olean-wholesale-copy`.
 - CI : `.github/workflows/lean-sudoku.yml` (`sorry-filter-mode: standalone-tactic`,
   baseline `"0"`).

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/LEAN_INVENTORY.md
@@ -7,7 +7,7 @@ Source de vérité : corps de l'Epic
 [#4041](https://github.com/jsboige/CoursIA/issues/4041)). Colonne *sorry (production)* =
 métrique CI `standalone-tactic` (les mentions prose « 0 sorry »/« sans sorry » et les
 définitions `:= sorry` non-tactique n'entrent pas dans ce compte ; cf.
-[`lean-ci-sorry-filter`](../../../../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+`lean-ci-sorry-filter`).
 
 ## Résumé
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/LEAN_INVENTORY.md
@@ -6,7 +6,7 @@ sur le modèle de [`GameTheory/LEAN_INVENTORY.md`](../../GameTheory/LEAN_INVENTO
 de l'Epic [#4038](https://github.com/jsboige/CoursIA/issues/4038) + vérification
 `firsthand`. Colonne *Sorry (production)* = métrique CI `standalone-tactic` (les mentions
 prose « 0 sorry » n'entrent pas dans ce compte ; cf.
-[`lean-ci-sorry-filter`](../../../.claude/projects/c--dev-CoursIA-2/memory/lean-ci-sorry-filter.md)).
+`lean-ci-sorry-filter`).
 
 ## Résumé
 
@@ -61,9 +61,9 @@ Axiomes `[propext, Classical.choice, Quot.sound]` (Mathlib standard, **pas de `s
 - **Mathlib v4.31.0-rc1 Finset sum binder** (documenté durably) : le binder de somme est
   unicode **`∑ x ∈ s`**, PAS le mot `in` (`∑ x in s` ne parse pas) ; extraction additive via
   `conv_lhs` + `Finset.insert_erase` ; mots-clés `to`/`from` → `src`/`dst`. Cf.
-  [`lean-finset-sum-binder-elem`](../../../.claude/projects/c--dev-CoursIA-2/memory/lean-finset-sum-binder-elem.md).
+  `lean-finset-sum-binder-elem`.
 - **WDAC workaround** (RECOVERABLE-LOCAL) : `lake exe cache get` bloqué → copie wholesale
   des oleans d'un lake frère compatible. Cf.
-  [`lean-wdac-olean-wholesale-copy`](../../../.claude/projects/c--dev-CoursIA-2/memory/lean-wdac-olean-wholesale-copy.md).
+  `lean-wdac-olean-wholesale-copy`.
 - CI : `.github/workflows/lean-erc20.yml` (`sorry-filter-mode: standalone-tactic`,
   baseline `"0"`).


### PR DESCRIPTION
## Contexte

Un sweep de liens sur `origin/main` a détecté **12 liens relatifs morts** dans **6 fichiers `LEAN_INVENTORY.md`** curés, tous pointant vers `.claude/projects/c--dev-CoursIA-2/memory/*.md` — la mémoire d'agent locale d'une machine, **jamais versionnée** dans le dépôt public. Ces liens ne résolvent donc jamais pour un lecteur du repo.

## Correction (option 1 « délier » de #5087)

Ces cibles sont des notes d'agent internes, pas du contenu destiné aux lecteurs. Le concept reste **nommé en inline code** ; seul le lien mort disparaît. Même pattern que la réparation de `M11g_FEE_AWARE_KELLY.md` dans #5086.

| Fichier | # liens | Cibles délinkées |
|---------|--------:|------------------|
| `ML/LEAN_INVENTORY.md` | 2 | `lean-ci-sorry-filter`, `lean-wdac-olean-wholesale-copy` |
| `Probas/LEAN_INVENTORY.md` | 2 | idem |
| `Search/LEAN_INVENTORY.md` | 2 | idem |
| `Sudoku/LEAN_INVENTORY.md` | 2 | idem |
| `SymbolicAI/Lean/LEAN_INVENTORY.md` | 1 | `lean-ci-sorry-filter` |
| `SymbolicAI/SmartContracts/LEAN_INVENTORY.md` | 3 | `lean-ci-sorry-filter`, `lean-finset-sum-binder-elem`, `lean-wdac-olean-wholesale-copy` |

## Vérification

- `grep -rn "c--dev-CoursIA-2/memory" .../LEAN_INVENTORY.md` → **0 résultat** après fix (avant : 12).
- `grep -rn "\.claude/projects" .../LEAN_INVENTORY.md` → **0 résultat** (aucun autre lien vers mémoire privée résiduel).
- Diff LF-normalisé : **6 fichiers, 12 insertions / 12 deletions**, aucune autre ligne touchée (flip CRLF évité via `sed 's/\r$//'`).
- Docs-only, aucune cellule/notebook/preuve Lean touchée.

Closes #5087
