### PR TITLE
docs(knot): refresh knot_lean README sorry-state post #4899 (See #3979)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
@@ -5,7 +5,7 @@ avec sorry stratégiques commentés (références papier + prérequis Mathlib).
 
 Epic #2874 (Phase 5 en cours). Toolchain `v4.31.0-rc1`.
 
-## État des sorries (vérifié 2026-06-23, 18 réels — 16 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
+## État des sorries (vérifié 2026-07-03, 17 réels — 15 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
 
 Deux comptes, selon le filtre :
 
@@ -15,23 +15,27 @@ Deux comptes, selon le filtre :
 | `Knots/Reidemeister.lean` | 2 | 2 |
 | `Knots/Invariant.lean` | 5 | 6 |
 | `Knots/Conway.lean` | 8 | 11 |
-| `Knots/Lidman.lean` | 3 | 5 |
+| `Knots/Lidman.lean` | 2 | 4 |
 | `Knots/MathlibPrerequisites.lean` | 0 | 2 |
-| **Total** | **18** | **27** |
+| **Total** | **17** | **26** |
 
 - **sorry réels** (`exact sorry`, `:= sorry`, `:= by sorry`) = ce qui manque
-  vraiment comme preuve. **18** au total — 16 stables + **2 du transfer backward
+  vraiment comme preuve. **17** au total — 15 stables + **2 du transfer backward
   PARTIEL `tricolorable_backward` (#3124)** : sous-buts `fox`/`col` laissés en
   sorry après décomposition (`num` PROUVÉ par parité `wf`, cf. § Phase 5 ;
-  cœur `hcolPres` prouvé).
+  cœur `hcolPres` prouvé). Un sorry de scaffolding Lidman (diagramme L39) a été
+  éliminé par **#4899** (PD-code 11n102 depuis KnotInfo, MERGED 2026-07-02) :
+  Lidman passe de 3 à 2 réels.
 - **sorry prose** (toute ligne contenant `sorry`, filtre CI `prose-header`) =
-  **baseline CI 27** (workflow `lean-knot.yml`, baissé de 28 après preuve `num`). Ce compte inclut les
-  occurrences dans les commentaires de diagnostic (ex. le commentaire sur
-  `KnotDiagram.wf` dans `Basic.lean`).
+  **26** actuellement. La CI `lean-knot.yml` gate à `sorry-baseline: "28"`
+  (mode prose-header) : marge de 2 après #3163 (`num`) et #4899 (Lidman), la
+  baseline n'ayant pas encore été resserrée. Ce compte inclut les occurrences
+  dans les commentaires de diagnostic (ex. le commentaire sur `KnotDiagram.wf`
+  dans `Basic.lean`).
 
-La CI `.github/workflows/lean-knot.yml` gate sur le **prose-header baseline 27**
-(bump 25→28 dans #3124 pour la décomposition du transfer backward, puis **baissé à 27**
-après la preuve `num` #3163) : toute PR qui ajoute un sorry réel fait monter les
+La CI `.github/workflows/lean-knot.yml` gate sur le **prose-header baseline 28**
+(historique : bump 25→28 dans #3124 pour la décomposition du transfer backward,
+baissé à 27 après la preuve `num` #3163, puis re-bumpé à 28 par le suivi GF(3) #3003) : toute PR qui ajoute un sorry réel fait monter les
 deux comptes et échoue la CI, sauf justification documentée dans le body PR.
 
 ## Résultats par statut réel (vérifié contre le code)
@@ -64,7 +68,8 @@ deux comptes et échoue la CI, sauf justification documentée dans le body PR.
 - [ ] Conway (11n34) : `conway_not_smoothly_slice` (Piccirillo 2018/Annals 2020),
   `conway_topologically_slice` (Freedman 1982), mutation Kinoshita-Terasaka —
   8 sorry, scaffolding permanent
-- [ ] Lidman 11n102 : unknotting number = 2 (Heegaard-Floer) — 3 sorry, scaffolding
+- [ ] Lidman 11n102 : unknotting number = 2 (Heegaard-Floer) — 2 sorry, scaffolding
+  (le sorry du diagramme L39 a été éliminé par #4899, PD-code 11n102 depuis KnotInfo)
 - [ ] `reidemeister_theorem` — équivalence Reidemeister ↔ isotopie ambiante
   (topologie PL des 3-variétés, hors portée Mathlib actuel) — 2 sorry, permanent
 
@@ -230,8 +235,9 @@ prouvés** (un sous-cas chacun clos) :
    couleurs nécessite la construction colour-symmetry / proper-arc (#3003,
    `Invariant.lean` L1354).
 
-Ces **2 résiduels §9.1** maintiennent la **baseline CI 27** (baissée de 28 après la
-preuve `num` #3163 ; bump initial 25→28 justifié dans #3124).
+Ces **2 résiduels §9.1** s'inscrivent sous la **baseline CI 28** (historique : bump
+25→28 dans #3124, baissée à 27 après la preuve `num` #3163, re-bumpée à 28 par le suivi
+GF(3) #3003) ; le compte réel courant est **26** après #4899 (marge de 2).
 
 Le marquee `tricolorable_invariant` reste gated sur la **complétion des 2 résiduels
 §9.1 backward** (puis composition forward + backward = bi-implication R1
@@ -249,7 +255,7 @@ Référence : Fox (1962), A quick trip through knot theory ; Adams, *The Knot Bo
 | `Knots/Reidemeister.lean` | Mouvements R1/R2/R3 (modèle Phase 5), `ReidemeisterEquiv`, symétries | 2 |
 | `Knots/Invariant.lean` | 3-colorabilité (Fox), crossing number, unknotting number, contre-exemple PR1, transfer R1 forward (#3000) + backward PARTIEL (#3124) | 6 |
 | `Knots/Conway.lean` | Nœud de Conway (11n34), Piccirillo, dichotomie lisse/topologique | 8 |
-| `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 3 |
+| `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 2 |
 | `Knots/MathlibPrerequisites.lean` | Index des prérequis Mathlib manquants par tier | 0 |
 
 ## Dépendances externes
@@ -317,7 +323,7 @@ Le marquee `tricolorable_invariant` reste **gated** sur deux sous-buts résiduel
 §9.1 du backward : la symétrie des couleurs sur le crossing modifié `Y` (`fox`) et
 le lift « all-distinct » hors range du diagramme source (`col`). Leur clôture
 permettrait de composer forward + backward en une bi-implication R1 connectée
-(**18 sorry réels** au total). Les résultats « lointains » — Conway non-slice
+(**17 sorry réels** au total). Les résultats « lointains » — Conway non-slice
 (Piccirillo), unknotting number de Lidman, théorème Reidemeister ↔ isotopie
 ambiante — restent du **scaffolding permanent** : ils excèdent la portée actuelle
 de Mathlib (topologie PL des 3-variétés, Heegaard-Floer).


### PR DESCRIPTION
## Résumé

Le README de `knot_lean` documentait un **état des sorries daté du 2026-06-23**, rendu périmé par **#4899** (`a4ea5d615`, MERGED 2026-07-02) qui a éliminé le sorry de scaffolding du diagramme L39 dans `Lidman.lean` (PD-code 11n102 depuis KnotInfo). Docs-only, un seul fichier.

Grain du rollout **feuilles-READMEs ascendantes** — Part of #3973, See #3979 (lane po-2026:CoursIA-2).

## Changements (état formel rafraîchi)

| Métrique | Avant | Après |
|---|---|---|
| `Lidman.lean` sorry réels | 3 | **2** |
| `Lidman.lean` sorry prose (CI) | 5 | **4** |
| **Total réels** | 18 | **17** |
| **Total prose (CI prose-header)** | 27 | **26** |
| Date de vérification | 2026-06-23 | **2026-07-03** |

**Correction d'un fait erroné** : le README affirmait « baseline CI 27 ». Le gate réel est `sorry-baseline: "28"` ([`lean-knot.yml` L64](../blob/main/.github/workflows/lean-knot.yml#L64)). Historique rétabli : 25→28 (#3124 transfer backward) → 27 (#3163 preuve `num`) → 28 (#3003 suivi GF(3)).

## Vérification firsthand (G.1 / G.2, cf `lean-ci-sorry-filter`)

Classification manuelle de chaque occurrence `\bsorry\b` contre le code source **actuel** (pas un seul grep n'est autoritatif) :

| Fichier | réels | prose | détail réels |
|---|--:|--:|---|
| Basic | 0 | 1 | L9 commentaire |
| Reidemeister | 2 | 2 | L545 standalone, L549 `exact sorry` |
| Invariant | 5 | 6 | L242/951/1007 `exact`, L1581/1731 standalone (+L8 comment) |
| Conway | 8 | 11 | L50/129/158/166 `:=`, L139/145/191/221 `exact` (+3 comments) |
| **Lidman** | **2** | **4** | L72/89 `exact sorry` (L39 diagramme éliminé par #4899) |
| MathlibPrereq | 0 | 2 | L5/80 commentaires |
| **Total** | **17** | **26** | |

`#4899` confirmé sur `origin/main` (`git branch -r --contains a4ea5d615`), daté 2026-07-02 (postérieur à la date de vérif précédente du README).

## Scope / discipline

- **Docs-only** : aucun `.lean`, aucune preuve, aucun notebook touché. Pas de gate `lake build` (le README ne fait que refléter l'état déjà mergé par #4899).
- CATALOG-STATUS : ce README n'en contient pas (inchangé).
- EOL : LF préservé (diff atomique 23/17, pas de flip CRLF).
- `See #3979` / Part of #3973 — contribution partielle au rollout, l'Epic reste ouverte.

## Suivi possible (hors scope, non-bundlé)

Resserrer le gate CI `28 → 26` maintenant que #3163 (`num`) et #4899 (Lidman) ont réduit le compte prose réel — édition de config CI, domaine distinct d'une PR docs, à traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)