### PR TITLE
fix(genai): restore markdown line break in 01-3-Basic-Image cell 25 (See #5005)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
@@ -1750,7 +1750,7 @@
    "source": [
     "## 📚 Section 8: Récapitulatif et Ressources\n",
     "\n",
-    "Résumé des opérations couvertes et ressources supplémentaires.",
+    "Résumé des opérations couvertes et ressources supplémentaires.\n",
     "### 📖 References savantes\n",
     "\n",
     "- **Harris, C.R. et al.** (2020). *Array programming with NumPy*. Nature, 585(7825), 357-362. doi:10.1038/s41586-020-2649-2. — Papier de citation officiel de NumPy, socle matriciel utilise tout au long du notebook.\n",


### PR DESCRIPTION
Part of **#5005** (`.NET Interactive` newline corruption). **Reassessed by po-2024: CONFIRMED real-render-break (1 of 5 flagged cells).**

## Scope — surgical single-cell fix

`GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb` cell 25 (markdown, "Section 8: Récapitulatif et Ressources") had a **real render-breaking** newline corruption: element `[2]` `"...ressources supplémentaires."` lacked a trailing `\n`, joining to element `[3]` `"### 📖 References savantes"` → rendered as `...supplémentaires.### 📖 References` (the `###` heading stuck to prose, **not rendered as a heading**).

Fix: append `\n` to element `[2]` only. `+1/-1` diff, minimal.

**Mergeable WITHOUT re-exec** — markdown-only cell, no `outputs`/`execution_count` (C.2 markdown exception).

## G.1 audit-reassessment — the real value of this PR

po-2023 (DM `msg-20260703T004545`) ceded the 4-notebook Python subset of the #5005 newline sweep. The `normalize-source-newlines` tool (merged #5028) flagged **5 cells** across them. **Firsthand byte-level diagnosis reveals 4/5 are COSMETIC FALSE POSITIVES**:

| Notebook | Cell | Verdict |
|----------|------|---------|
| GameTheory-4c | 0 | COSMETIC FP (`\n` relocated to next element's start; joined render identical) |
| 01-3-Basic-Image | 0 | COSMETIC FP |
| **01-3-Basic-Image** | **25** | **REAL break** (this PR) |
| Lab5-Viz-ML | 21 | COSMETIC FP |
| Lab6-First-Agent | 25 | COSMETIC FP |

The "cosmetic" pattern: element[N] lacks a trailing `\n`, but element[N+1] **starts** with `\n` — so `''.join(source)` produces the correct render. The tool's detection (`any(not el.endswith('\n') for el in src[:-1])`) flags it, but there is **no actual render defect**.

## Tool bug (action item for ai-01)

`normalize-source-newlines` line 1842: `[el + '\n' for el in src[:-1]] + [src[-1]]` appends `\n` to **all** non-last elements **regardless of whether they already end in `\n`**. Applying it to a cosmetic-FP cell **DOUBLES** existing newlines (`\n` → `\n\n`), corrupting markdown with spurious blank lines.

**Verified**: applying the tool to GameTheory-4c cell0 (cosmetic FP) produced a 34/34 line churn — every real-content line falsely "changed" (all elements got a spurious extra `\n`).

**Recommended fixes** (separate PR, tooling):
1. Conditional append: `[el if el.endswith('\n') else el+'\n' for el in src[:-1]] + [src[-1]]`
2. Detection should ignore the cosmetic pattern (newline relocated to next element's start).

⚠️ **po-2023's SC-2/SC-22/ML-6-ONNX subset should be re-audited with this in mind before applying the tool** (DM sent `msg-20260703T004545` thread).

## Collision guard

po-2023 DM ack ceded subset Python. GameTheory-4c / Lab5 / Lab6 left **untouched** (cosmetic FP, no real break). 

Co-Authored-By: Claude-Code <noreply@anthropic.com>
