### PR TITLE
fix(infra): normalize-source-newlines surgical fix (no doubling)

### DIFF
--- a/scripts/notebook_tools/notebook_tools.py
+++ b/scripts/notebook_tools/notebook_tools.py
@@ -1789,19 +1789,57 @@ def cmd_golden_set(args):
     return 1 if fail_count > 0 else 0
 
 
-def cmd_normalize_source_newlines(args):
-    """Normalize nbformat `source` arrays so every element except the last ends with '\\n'.
+def _fix_source_newlines(src):
+    """Surgically fix a nbformat ``source`` list at GENUINELY-glued boundaries only.
 
-    Fixes a silent corruption (#5005): some notebooks store code-cell `source` as a
-    JSON list whose elements lack the trailing newline mandated by the nbformat spec.
-    The standard `''.join(source)` then produces a single line with no newlines, so a
-    leading line-comment (`#` in Python, `//` in C#) swallows the entire cell -- the
-    code never executes and no output/error is emitted (cell appears as ec=None/outs=0
-    or, after a forced run, silently passes). Adding '\\n' to all-but-last element
+    A boundary between ``src[k]`` and ``src[k+1]`` is genuinely corrupt when
+    ``''.join`` glues two tokens with no separator at all: ``src[k]`` does not end in
+    ``'\\n'`` or whitespace AND ``src[k+1]`` does not start in ``'\\n'`` or whitespace.
+    Trailing/leading spaces (mid-paragraph chunks) or an existing ``'\\n'`` on either
+    side already render correctly and are cosmetic false positives -- left untouched.
+
+    Returns ``(new_src, changed)``: ``new_src`` is the (possibly fixed) source list,
+    ``changed`` is True iff at least one boundary was fixed. When unchanged, ``new_src``
+    is the input list object itself (callers may rely on identity to skip re-serialization).
+    """
+    if not isinstance(src, list) or len(src) <= 1:
+        return src, False
+    _WS = (' ', '\t')
+    genuine = [
+        k for k in range(len(src) - 1)
+        if not src[k].endswith('\n') and not src[k].endswith(_WS)
+        and not src[k + 1].startswith('\n') and not src[k + 1].startswith(_WS)
+    ]
+    if not genuine:
+        return src, False
+    new_src = list(src)
+    for k in genuine:
+        if not new_src[k].endswith('\n'):
+            new_src[k] = new_src[k] + '\n'
+    return new_src, True
+
+
+def cmd_normalize_source_newlines(args):
+    """Normalize nbformat `source` arrays where a GENUINE line-merge corrupts the cell.
+
+    Fixes a silent corruption (#5005): some notebooks store `source` as a JSON list
+    whose elements lack the trailing newline mandated by the nbformat spec. When
+    `''.join(source)` glues two non-whitespace tokens with no separator at all, a
+    leading line-comment (`#` in Python, `//` in C#) can swallow the entire cell, or
+    two markdown lines merge into one. Adding '\\n' at the genuinely-glued boundary
     restores the intended line structure without touching source content, execution
     counts, or outputs.
 
-    See #5005 (root-cause firsthand), #4956 (marathon .NET/Python parity).
+    A boundary src[k]/src[k+1] is treated as genuine ONLY when neither side carries a
+    separator -- src[k] does not end in '\\n' or whitespace AND src[k+1] does not
+    start in '\\n' or whitespace. Boundaries with a trailing/leading space (mid-
+    paragraph chunks) or an existing '\\n' on either side render correctly already and
+    are left untouched (cosmetic false positives). The earlier blanket form added
+    '\\n' to every non-last element unconditionally, which doubled existing newlines
+    ('\\n\\n' -> '\\n\\n\\n\\n') and broke flowing markdown prose; this surgical form
+    touches only the genuinely-glued boundaries and preserves everything else
+    byte-identical. See #5005 (root cause), #5094 (tool fix), #5093 (closed, the
+    corruption the blanket form caused), #4956 (.NET/Python parity marathon).
     """
     repo_root = get_repo_root()
     notebooks = discover_notebooks(
@@ -1837,9 +1875,12 @@ def cmd_normalize_source_newlines(args):
             # Only the list form can carry this corruption; a string is nbformat-valid as-is.
             if not isinstance(src, list) or len(src) <= 1:
                 continue
-            # Corrupt = any non-last element lacks a trailing newline.
-            if any(not el.endswith('\n') for el in src[:-1]):
-                cell['source'] = [el + '\n' for el in src[:-1]] + [src[-1]]
+            # Surgical fix at GENUINELY-glued boundaries only (see _fix_source_newlines).
+            # The earlier blanket form doubled existing newlines and broke flowing prose;
+            # this touches only boundaries where ''.join glues two non-whitespace tokens.
+            new_src, changed = _fix_source_newlines(src)
+            if changed:
+                cell['source'] = new_src
                 fixed_cells += 1
 
         if fixed_cells > 0:

--- a/scripts/notebook_tools/tests/test_normalize_source_newlines.py
+++ b/scripts/notebook_tools/tests/test_normalize_source_newlines.py
@@ -1,0 +1,127 @@
+"""Tests for the `_fix_source_newlines` helper (normalize-source-newlines, #5005).
+
+Locks in the boundary-aware surgical fix that replaced the earlier blanket transform.
+The blanket form added '\\n' to every non-last source element unconditionally, which
+(a) doubled existing newlines ('\\n\\n' -> '\\n\\n\\n\\n') and (b) inserted hard breaks
+into flowing markdown prose split across list elements -- both cosmetic false positives
+that the blanket transform corrupted. The surgical fix touches ONLY boundaries where
+''.join glues two non-whitespace tokens.
+
+Covers:
+  - genuine code-cell merge (the original #5005 root cause: a leading comment swallows
+    the cell when ''.join collapses to one line)
+  - genuine markdown heading-glue (po-2024's 01-3-Basic-Image cell25 pattern)
+  - cosmetic: mid-paragraph chunk split at a trailing space (must stay flowing)
+  - cosmetic: next element carries the '\\n' (must not double)
+  - cosmetic: elements already ending in '\\n' (must not double)
+  - regression: a cell the OLD blanket tool corrupted is left byte-identical
+  - string-form source and single-element lists (no-op)
+"""
+
+import sys
+from pathlib import Path
+
+_tools_dir = str(Path(__file__).resolve().parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from notebook_tools import _fix_source_newlines
+
+
+# --- genuine cases (must fix) ---
+
+
+def test_genuine_code_cell_merge_is_fixed():
+    # The #5005 root cause: two statements glued, ''.join = one line.
+    src = ["print('a')", "print('b')"]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is True
+    assert "".join(new_src) == "print('a')\nprint('b')"
+
+
+def test_genuine_markdown_heading_glue_is_fixed():
+    # po-2024's 01-3-Basic-Image cell25 pattern: heading glued to preceding prose.
+    src = ["Some prose ending here.", "### Heading glued"]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is True
+    assert "".join(new_src) == "Some prose ending here.\n### Heading glued"
+
+
+# --- cosmetic cases (must NOT change) ---
+
+
+def test_cosmetic_mid_paragraph_space_is_untouched():
+    # Trailing space = mid-paragraph chunk; join flows correctly. Must not break.
+    src = ["A paragraph that ", "continues flowing."]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is False
+    assert "".join(new_src) == "A paragraph that continues flowing."
+
+
+def test_cosmetic_next_element_carries_newline_is_untouched():
+    # elem[k] lacks '\n' but elem[k+1] STARTS with '\n' -> separator already present.
+    src = ["Line one", "\nLine two"]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is False
+    assert "".join(new_src) == "Line one\nLine two"
+
+
+def test_cosmetic_leading_space_next_is_untouched():
+    # elem[k+1] starts with a space -> joins cleanly. Must not add '\n'.
+    src = ["mots", " collés par espace en tête"]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is False
+    assert "".join(new_src) == "mots collés par espace en tête"
+
+
+def test_already_newline_terminated_not_doubled():
+    # Every non-last element already ends in '\n' -> no genuine break, no change.
+    # The OLD blanket form would have produced '\n\n' here (the doubling bug).
+    src = ["line1\n", "line2\n", "line3"]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is False
+    assert new_src == src  # byte-identical (no doubling)
+
+
+# --- regression: mixed genuine + cosmetic in one cell ---
+
+
+def test_mixed_cell_fixes_only_genuine_boundaries():
+    # One genuine break + one cosmetic (space) boundary: only the genuine one fixed.
+    src = ["print('a')", "print('b')", " # trailing comment chunk"]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is True
+    # boundary 0 (print/print) genuine -> '\n' added; boundary 1 (space) cosmetic -> kept.
+    assert "".join(new_src) == "print('a')\nprint('b') # trailing comment chunk"
+
+
+def test_paragraph_break_not_doubled():
+    # A markdown cell with a deliberate '\n\n' paragraph break plus a cosmetic chunk.
+    # The OLD blanket tool turned '\n\n' into '\n\n\n\n'. Surgical fix must preserve.
+    src = ["First paragraph.\n\n", "Second ", "paragraph flows."]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is False
+    assert "".join(new_src) == "First paragraph.\n\nSecond paragraph flows."
+
+
+# --- no-op cases ---
+
+
+def test_string_form_source_is_noop():
+    new_src, changed = _fix_source_newlines("a single string source")
+    assert changed is False
+    assert new_src == "a single string source"
+
+
+def test_single_element_list_is_noop():
+    src = ["only one element"]
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is False
+    assert new_src is src
+
+
+def test_empty_list_is_noop():
+    src = []
+    new_src, changed = _fix_source_newlines(src)
+    assert changed is False
+    assert new_src is src


### PR DESCRIPTION
## Résumé

L'outil `normalize-source-newlines` (#5005) avait **2 bugs qui corrompaient les cellules** au lieu de les corriger. Fix root-cause + tests de régression.

## Les 2 bugs

1. **Détection trop large** : `any(not el.endswith('\n') for el in src[:-1])` flaggait des **cosmetic false positives** — chunks mid-paragraph séparés par espace, ou boundaries où `src[k+1]` commence par `\n` (le séparateur est déjà porté par l'élément suivant). Ces cellules rendent correctement.

2. **Transform trop large** : `[el + '\n' for el in src[:-1]] + [src[-1]]` ajoutait `\n` à **TOUS** les éléments non-finaux **sans vérifier s'ils finissaient déjà par `\n`** → **doublait les `\n` existants** (`\n\n` paragraphe → `\n\n\n\n`) + insérait des hard breaks mid-prose dans du markdown flowing.

## Fix

Boundary-aware surgical : une boundary `src[k]`/`src[k+1]` est GENUINELY corrupt ssi `''.join` colle deux tokens sans séparateur — `src[k]` finit ni par `\n` ni par whitespace ET `src[k+1]` commence ni par `\n` ni par whitespace. Seules ces boundaries reçoivent `\n` ; tout le reste est préservé byte-identical. Logique extraite dans helper pur `_fix_source_newlines(src)` (testable).

## Validation

- **Repo-wide TRUE genuine count = 1** (01-3-Basic-Image cell25) — **matche exactement le diagnostic surgical de po-2024** (PR #5096). Les 7+ autres notebooks précédemment flaggés (SC-2, SC-22, ML-6-ONNX, GameTheory-4c, Lab5, Lab6, rl_3, Diagnostic-Medical) sont des cosmetic FPs, maintenant correctement laissés intacts.
- **11 tests de régression** (genuine corrigé, cosmetic intact, garde anti-doublage) : `test_normalize_source_newlines.py`. **Suite complète 1977 passed** (1966 + 11).
- **Blast radius du sweep buggy antérieur** (PR #5028, 39 fichiers QC-Py) : **CONTAINED** — 0/39 montrent la signature doublage dans main (le sweep a touché des genuine breaks seulement).
- Tests des 3 cas : SC-22 cosmetic → 0 fix (était 5 buggy) ; SC-2 cosmetic → 0 (était 1 buggy) ; synthétique genuine → exactement 2 fixés (md heading-glue + code print-glue), les 2 cosmetic laissés intacts.

## Contexte

C'est le fix root-cause qui aurait **empêché PR #5093** (fermée — 6 cellules markdown SmartContracts corrompues par le blanket transform ; ma validation `content-identical-minus-newlines` insuffisante car elle strippait tous les `\n`, masquant le doublage). Bug attrapé par po-2024 ([URGENT] DM, merci à eux) avant propagation.

## Conformité

- 2 fichiers : `notebook_tools.py` (+53/-12) + nouveau `test_normalize_source_newlines.py` (11 tests).
- Anti-régression : le helper préserve l'identité de l'objet source quand inchangé (skip re-sérialisation).
- Worktree isolé, base frais origin/main, WIP user non-grabbé.

See #5005

Co-Authored-By: Claude-Code <noreply@anthropic.com>