### PR TITLE
fix(notebook_tools): add .NET Interactive warmup post-wait_for_ready (#5005)

### DIFF
--- a/docs/reference/scripts-reference.md
+++ b/docs/reference/scripts-reference.md
@@ -58,6 +58,25 @@ python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.Notebooks/GenAI/
 python scripts/notebook_tools/notebook_tools.py execute SmartContracts --scrub-keys --batch-mode
 ```
 
+#### Capture des outputs .NET post-`#r` (#5005)
+
+Les notebooks .NET Interactive contenant une directive `#r "nuget: ..."` ou `#r "<dll>"` perdent leurs outputs stdout (`Console.WriteLine`) si exécutes via le chemin Papermill par defaut (drain iopub / timing `nbclient` 2.7.0).
+
+**Recommandations** :
+
+- **`--cell-by-cell`** (chemin `jupyter_client` direct) : OK depuis le fix du warmup post-`wait_for_ready` (cf PR `feature/5005-cell-by-cell-warmup`, fichier `scripts/notebook_tools/notebook_helpers.py`). Pas de régression Python/Lean (warmup conditionnel `.net-*`).
+- **`dotnet_executor.py`** directement : chemin canonique pour les notebooks .NET, déjà fonctionnel avant le fix. À privilégier pour les re-exécutions de validation.
+
+```bash
+# Validation .NET canonique (chemin kc.execute() direct, sans Papermill)
+python scripts/notebook_tools/dotnet_executor.py <notebook> --kernel .net-csharp --timeout 240
+
+# Equivalent via le CLI multi-famille (depuis le fix warmup)
+python scripts/notebook_tools/notebook_tools.py execute <notebook> --cell-by-cell --kernel .net-csharp --timeout 240
+```
+
+**Diagnostic** : le bug n'est PAS dans le kernel .NET Interactive ni dans le mode HTTP — un test `jupyter_client` direct (`kc.execute()` + `get_iopub_msg`) capture 9/9 outputs post-`#r`. Le défaut venait des wrappers client (Papermill + cell-by-cell sans warmup).
+
 ### Catalogue (anti-drift)
 | Script | Usage |
 |--------|-------|

--- a/scripts/notebook_tools/notebook_helpers.py
+++ b/scripts/notebook_tools/notebook_helpers.py
@@ -1052,6 +1052,14 @@ class NotebookExecutor:
             result.duration = time.time() - start_time
             return result
 
+        # .NET Interactive: after protocol-ready, the kernel still loads default
+        # usings (System, etc.). Without this delay, the first kc.execute() hits
+        # a NameError ('Console'/'using' not defined) and outputs of all subsequent
+        # cells are lost. dotnet_executor.py uses the same warmup for the same
+        # reason. See jsboige/CoursIA#5005.
+        if '.net' in kernel_name or kernel_name in ('csharp', 'fsharp'):
+            time.sleep(5)
+
         try:
             # Set working directory
             nb_dir = str(Path(notebook_path).parent)

--- a/scripts/notebook_tools/notebook_tools.py
+++ b/scripts/notebook_tools/notebook_tools.py
@@ -1259,13 +1259,15 @@ class NotebookExecutor:
             )
 
     def execute_cell_by_cell(self, timeout: int = 60,
-                              verbose: bool = False) -> NotebookExecutionResult:
+                              verbose: bool = False,
+                              kernel_override: Optional[str] = None) -> NotebookExecutionResult:
         """Execute notebook cell by cell using jupyter_client."""
         # Use base executor if available
         if self._base_executor:
             self._base_executor.verbose = verbose
             result = self._base_executor.execute_notebook_cell_by_cell(
-                str(self.path), timeout_per_cell=timeout
+                str(self.path), timeout_per_cell=timeout,
+                kernel_name=kernel_override,
             )
             msg = (
                 f"Executed {result.executed_cells} cells: "
@@ -1613,7 +1615,8 @@ def cmd_execute(args):
         if args.cell_by_cell:
             result = executor.execute_cell_by_cell(
                 timeout=args.timeout,
-                verbose=args.verbose
+                verbose=args.verbose,
+                kernel_override=kernel_override,
             )
         else:
             result = executor.execute_with_papermill(


### PR DESCRIPTION
## Fix #5005 : .NET Interactive stdout capture post-`#r nuget`

### Diagnostic firsthand

Issue #5005 attribue le bug au kernel .NET Interactive ou à son mode HTTP. Investigation firsthand (C151, ce cycle) **invalide cette hypothèse** :

1. **Le kernel n'est PAS en cause.** Avec `jupyter_client` bas niveau (`kc.execute()` direct + `get_iopub_msg`), **9/9 cellules** post-`#r` capturent leur stdout — même avec un gros nuget (NumSharp 0.30.0). Vérifié sur kernel HTTP ET kernel "stdio" (le binaire force HTTP par défaut de toute façon — `--http-port-range` redondant).
2. **`dotnet_executor.py` (chemin canonique) marche déjà à 9/9** sur le même reproducer. Pattern : `km.start_kernel(cwd=notebook_dir)` + `time.sleep(3)` + `kc.execute()` direct.
3. **`notebook_tools.py execute --cell-by-cell` échouait** : sans warmup post-`wait_for_ready`, .NET Interactive n'a pas fini de charger ses default-usings (System, etc.) — le premier `kc.execute()` hit un `NameError`, et tous les outputs suivants sont perdus.
4. **`notebook_tools.py execute` (Papermill par défaut)** : drain iopub (timing `nbclient` 2.7.0), chemin différent.

### Fix (1 fichier + 1 fix bug, ~17 lignes)

**`scripts/notebook_tools/notebook_helpers.py`** — ajout d'un warmup post `wait_for_ready` :

```python
# .NET Interactive: after protocol-ready, the kernel still loads default
# usings (System, etc.). Without this delay, the first kc.execute() hits
# a NameError ('Console'/'using' not defined) and outputs of all subsequent
# cells are lost. dotnet_executor.py uses the same warmup for the same
# reason. See jsboige/CoursIA#5005.
if '.net' in kernel_name or kernel_name in ('csharp', 'fsharp'):
    time.sleep(5)
```

- **1 emplacement**, ~8 lignes, **conditionnel aux kernels `.net-*`** (n'affecte pas Python/Lean — le warmup leur est inutile).
- `time` est déjà importé en haut de la méthode.

**`scripts/notebook_tools/notebook_tools.py`** — fix bug **C151-bis** : `kernel_override` n'était pas propagé à `execute_cell_by_cell` (le flag `--kernel .net-csharp` du CLI était silencieusement ignoré). Ajout du paramètre + propagation.

**`docs/reference/scripts-reference.md`** — note FR dans la section "Exécution", subsection "Capture des outputs .NET post-`#r` (#5005)".

### Verification

```bash
# Reproducer 9-cell (1 pre-#r Console.WriteLine + 1 #r nuget:Microsoft.ML + 7 post-#r Console.WriteLine)
python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.Notebooks/Search/Part2-CSP/repro_5005_smoke.ipynb --cell-by-cell --kernel .net-csharp --timeout 120 --verbose

# Output observe (avec fix):
#   Cell 1: OK
#   Cell 2: OK
#   ...
#   Cell 9: OK
#   [+] Executed 9 cells: 9 OK, 0 errors
#   Total time: 10.3s
```

- **9/9 cellules capturées** (avant fix : 0/9 post-`#r` à cause du NameError "Console not defined").
- **0 régression Python/Lean** : le warmup est conditionnel (`if '.net' in kernel_name`).
- **Validation croisée** avec `dotnet_executor.py` (chemin canonique de référence) : 9/9 OK identique.

### Note sur la persistance (C151-ter, hors scope)

`execute_notebook_cell_by_cell` ne save pas le notebook JSON sur disque après exécution — `cell.outputs` et `cell.execution_count` du fichier restent vides, mais le `NotebookExecutionResult` retourne les outputs **en mémoire** (`result.cell_results`). C'est un autre bug du wrapper (à tracker en issue séparée) ; ce PR ne le fixe pas (atomique). Pour la validation réelle des outputs sur disque, utiliser `dotnet_executor.py` directement.

### Conformité

- **Atomique** : 1 fichier code (fix) + 1 fix bug latent + 1 section doc. 1 sujet.
- **G.1 verify-before-claiming** : root cause confirmée firsthand (3 tests : kc.execute direct, dotnet_executor, validate_fix) avant d'invalider l'hypothèse #5005.
- **R5.4b anti-tunneling** : pivot légitime hors CSP (4 cycles consécutifs) vers tooling .NET, partition po-2024.
- **Documentation primaire en français** (note FR dans `scripts-reference.md`).
- **No emojis** dans code/commits.
- **`See #5005`** (contribution partielle, l'issue reste ouverte pour le chemin Papermill + la persistance disque).
- **catalog-pr-hygiene** : 0 touche au catalogue. Rebase frais depuis `origin/main` (1af087f92 sur ed8123bee).
- **R.3 model-delegation** : N/A (fix direct, pas de sous-agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)