### PR TITLE
See #5039 — Tweety-5 orphan intro sol-ex2-md reposition before its solution

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
@@ -2172,25 +2172,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sol-ex2-md",
-   "metadata": {
-    "papermill": {
-     "duration": 0.020634,
-     "end_time": "2026-05-31T22:55:00.421275+00:00",
-     "exception": false,
-     "start_time": "2026-05-31T22:55:00.400641+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exemple guide 2 : CF2 vs Stable\n",
-    "\n",
-    "Un cycle impair isole de longueur 5. La semantique CF2 capture des extensions que stable ne peut pas atteindre."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "ex3-stub-md",
    "metadata": {
     "papermill": {
@@ -2242,6 +2223,25 @@
     "# Etape 2 : calculer les extensions\n",
     "# Etape 3 : comparer avec l'exemple guide\n",
     "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sol-ex2-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.020634,
+     "end_time": "2026-05-31T22:55:00.421275+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T22:55:00.400641+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple guide 2 : CF2 vs Stable\n",
+    "\n",
+    "Un cycle impair isole de longueur 5. La semantique CF2 capture des extensions que stable ne peut pas atteindre."
    ]
   },
   {


### PR DESCRIPTION
## See #5039 — Tweety-5 Abstract Argumentation orphan intro (sub-grain deferred by #5042)

### Diagnostic

Issue #5039 signale plusieurs violations pedagogiques dans `Tweety-5-Abstract-Argumentation.ipynb`. La majeure partie a ete adressee par la PR #5042 (merge 2026-06-30). Celle-ci a explicitement **differe** un reliquat : la cellule `sol-ex2-md` (l'introduction markdown du second exemple guide, "### Exemple guide 2 : CF2 vs Stable") est restee **orpheline** a l'index [41] du notebook, separee de sa solution code `sol-ex2-code` (ec=14, index [44]) par les cellules de l'Exercice 3.

Raison du deferral dans #5042 : deplacer une cellule code aurait casse la **monotonicite de `execution_count`** (l'ordre ec=1..19 aurait ete invalide), obligeant une re-execution JVM de Tweety (RECOVERABLE-MACHINE, ~5-10 min).

### Reframe

La cellule a deplacer est **markdown** (`execution_count: null`), pas code. Les cellules markdown n'apparaissent pas dans la sequence des `execution_count` ; deplacer une cellule markdown laisse la monotonie du code **intacte** (sequence 1..19 preservee). Donc : **pas de re-execution JVM**, C.2 preservee, fix atomique.

### Fix

| Avant (index [41]) | → Apres (index [43]) |
|--------------------|---------------------|
| `sol-ex2-md` (orphan, ec=null) | `sol-ex2-md` (intro precede sa solution) |
| `ex3-stub-md` (Ex3) | `ex3-stub-md` (Ex3) |
| `ex3-stub-code` (ec=13) | `ex3-stub-code` (ec=13) |
| `sol-ex2-code` (ec=14, AVEC orphan loin) | `sol-ex2-md` (juste avant — fixe) |
|  | `sol-ex2-code` (ec=14, precede de son intro) |

**1 cellule deplacee** (id = `sol-ex2-md`). Contenu byte-identique. `git diff --stat` : `1 file changed, 19 insertions(+), 19 deletions(-)`.

### Verification C.2 / H.1

- **Monotonie `execution_count`** : sequence code AVANT/AFTER identique = `[1, 2, ..., 19]` (19 cellules code).
- **Outputs** : non modifies (champ `outputs` intouchable pour la cellule markdown deplacee).
- **Content-multiset** : `sha1(source)` pour les 61 cellules = identique AVANT/AFTER (verifie par script). Aucune cellule ajoutee, aucune perdue.
- **Pas de re-execution** : 0 JVM Tweety requise. Notebook executable tel quel post-fix.

### Script de validation (preview)

```python
import json, hashlib
nb = json.load(open(NB_PATH, encoding='utf-8'))
cells = nb['cells']
assert len(cells) == 61
assert [c.get('execution_count') for c in cells if c['cell_type'] == 'code'] == list(range(1, 20))
# orphan now at index 43 (just before sol-ex2 code at 44)
assert 'CF2 vs Stable' in ''.join(cells[43]['source']) if isinstance(cells[43]['source'], list) else cells[43]['source']
assert 'Solution complete' in (''.join(cells[44]['source']) if isinstance(cells[44]['source'], list) else cells[44]['source'])
assert cells[43]['cell_type'] == 'markdown'
assert cells[44]['cell_type'] == 'code' and cells[44]['execution_count'] == 14
```

### Conformite

- **Atomique** : 1 fichier, 1 cellule, 19 lignes diff (re-indentation JSON uniquement, contenu byte-identical).
- **Scope strict** : 0 touche au catalogue, 0 side-effect notebook, 0 changement outputs.
- **G.1 verify-before-claiming** : upstream #5042 verifie `gh pr view --json state,mergedAt` AVANT de claim ce reliquat. Raisons du deferral lues dans le body PR.
- **Anti-regression D** : aucune preuve/temoignage supprime. Cellule preservee byte-identique.
- **C.2 preservee** : monotonicite 1..19 confirmee, outputs intacts.
- **C.1 preservee** : pas d'ajout de stub/raise dans le notebook.
- **See #5039** : contribution partielle a l'EPIC, reliquat specifique. Issue reste ouverte pour les autres sous-grains eventuels.
- **Refs #3240** : la convention anti-orphelin-initiale source.
- **R5.4b anti-tunneling** : pivot hors CSP/.NET-tooling vers editorial Tweety.
- **FR doc primaire** : PR + body en francais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
