### PR TITLE
docs(lean-i18n): calibration_lean docstrings bilingues FR+EN (#4980 etape 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration.lean
@@ -1,4 +1,15 @@
 /-
+  Cibles de calibration pour le prouveur Lean multi-agent (Epic #1452).
+
+  Chaque théorème exerce un chemin spécifique du harnais :
+  - P1 : détection d'absence de progrès (agents bloqués)
+  - P2 : diagnostic d'erreur distante
+  - P3 : liste de blocage d'identifiants fantômes (recherche de lemmes Mathlib inexistants)
+
+  Difficulté cible : 3-10 itérations du prouveur (zone de Goldilocks).
+
+  ---
+  English:
   Calibration targets for the multi-agent Lean prover (Epic #1452).
 
   Each theorem exercises a specific harness path:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration/Doomsday.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration/Doomsday.lean
@@ -1,4 +1,19 @@
 /-
+  Cible de calibration : algorithme du Doomsday de Conway
+  ========================================================
+
+  Théorèmes de calibration pour l'algorithme du Doomsday de Conway, basés sur les
+  définitions de conway_lean/Conway/Doomsday.lean.
+
+  Chemins du harnais exercés :
+  - Cible B (leap_year_2000, leap_year_1900) : validation P1 — decide simple.
+  - Cible F (conway_death_day) : P2 — calcul multi-étapes avec arithmétique modulaire.
+    Difficulté moyenne, exerce le diagnostic d'erreur distante.
+  - Cible I (dayOfWeek_period_7) : P1 — requiert un raisonnement d'arithmétique modulaire.
+    Preuve non triviale de type inductif mais bornée.
+
+  ---
+  English:
   Calibration Target: Conway's Doomsday Algorithm
   ================================================
 
@@ -14,46 +29,56 @@
 -/
 import Mathlib.Tactic
 
-/-! ## Doomsday Definitions (self-contained, mirrors Conway/Doomsday.lean) -/
+/-! ## Définitions du Doomsday (autonomes, reflètent Conway/Doomsday.lean)
 
-/-- Days of the week, starting from Sunday = 0 -/
+English: Doomsday Definitions (self-contained, mirrors Conway/Doomsday.lean) -/
+
+/-- Jours de la semaine, à partir de dimanche = 0.
+    English: Days of the week, starting from Sunday = 0. -/
 inductive DayOfWeek where
   | sunday | monday | tuesday | wednesday | thursday | friday | saturday
   deriving Repr, BEq, DecidableEq, Inhabited
 
 namespace DayOfWeek
 
-/-- Convert DayOfWeek to a Fin 7 -/
+/-- Convertit un DayOfWeek en Fin 7.
+    English: Convert DayOfWeek to a Fin 7. -/
 def toFin : DayOfWeek → Fin 7
   | sunday => 0 | monday => 1 | tuesday => 2 | wednesday => 3
   | thursday => 4 | friday => 5 | saturday => 6
 
-/-- Convert a Fin 7 to DayOfWeek -/
+/-- Convertit un Fin 7 en DayOfWeek.
+    English: Convert a Fin 7 to DayOfWeek. -/
 def ofFin : Fin 7 → DayOfWeek
   | 0 => sunday | 1 => monday | 2 => tuesday | 3 => wednesday
   | 4 => thursday | 5 => friday | 6 => saturday
   | _ => sunday
 
-/-- Add n days (modulo 7) -/
+/-- Ajoute n jours (modulo 7).
+    English: Add n days (modulo 7). -/
 def add (d : DayOfWeek) (n : Nat) : DayOfWeek :=
   ofFin ⟨(d.toFin + n) % 7, by omega⟩
 
-/-- Subtract n days (modulo 7) -/
+/-- Soustrait n jours (modulo 7).
+    English: Subtract n days (modulo 7). -/
 def sub (d : DayOfWeek) (n : Nat) : DayOfWeek :=
   ofFin ⟨(d.toFin + 7 - n % 7) % 7, by omega⟩
 
 end DayOfWeek
 
-/-- Check if a year is a leap year in the Gregorian calendar -/
+/-- Teste si une année est bissextile dans le calendrier grégorien.
+    English: Check if a year is a leap year in the Gregorian calendar. -/
 def isLeapYear (year : Nat) : Bool :=
   year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 
-/-- Century anchor day computation -/
+/-- Calcul du jour d'ancrage du siècle.
+    English: Century anchor day computation. -/
 def centuryAnchor (year : Nat) : DayOfWeek :=
   let c := year / 100
   DayOfWeek.ofFin ⟨(5 * (c % 4) + 2) % 7, by omega⟩
 
-/-- Conway's doomsday for a given year -/
+/-- Le Doomsday de Conway pour une année donnée.
+    English: Conway's doomsday for a given year. -/
 def doomsday (year : Nat) : DayOfWeek :=
   let yy := year % 100
   let a := yy / 12
@@ -61,7 +86,8 @@ def doomsday (year : Nat) : DayOfWeek :=
   let c := b / 4
   DayOfWeek.add (centuryAnchor year) (a + b + c)
 
-/-- The doomsday date for each month -/
+/-- La date Doomsday pour chaque mois.
+    English: The doomsday date for each month. -/
 def doomsdayDate (month year : Nat) : Nat :=
   match month with
   | 1 => if isLeapYear year then 4 else 3
@@ -70,7 +96,8 @@ def doomsdayDate (month year : Nat) : Nat :=
   | 7 => 11 | 8 => 8 | 9 => 5 | 10 => 10
   | 11 => 7 | _ => 12
 
-/-- Compute the day of the week for any Gregorian date -/
+/-- Calcule le jour de la semaine pour toute date grégorienne.
+    English: Compute the day of the week for any Gregorian date. -/
 def dayOfWeek (year month day : Nat) : DayOfWeek :=
   let dd := doomsdayDate month year
   let d := doomsday year
@@ -79,30 +106,51 @@ def dayOfWeek (year month day : Nat) : DayOfWeek :=
   else
     DayOfWeek.sub d (dd - day)
 
-/-! ## Calibration Targets -/
+/-! ## Cibles de calibration
 
-/-- Target B.1 (P1 validation): Year 2000 is a leap year.
+English: Calibration Targets -/
+
+/-- Cible B.1 (validation P1) : l'année 2000 est bissextile.
+    decide simple — valide que la définition isLeapYear fonctionne.
+    Itérations attendues : 1-2.
+
+    English: Target B.1 (P1 validation): Year 2000 is a leap year.
     Simple decide — validates the isLeapYear definition works.
     Expected iterations: 1-2. -/
 theorem leap_year_2000 : isLeapYear 2000 = true := by
   unfold isLeapYear
   decide
 
-/-- Target B.2 (P1 validation): Year 1900 is NOT a leap year (divisible by 100 but not 400).
+/-- Cible B.2 (validation P1) : l'année 1900 n'est PAS bissextile (divisible par 100 mais pas 400).
+    decide simple — valide le cas limite dans isLeapYear.
+    Itérations attendues : 1-2.
+
+    English: Target B.2 (P1 validation): Year 1900 is NOT a leap year (divisible by 100 but not 400).
     Simple decide — validates the edge case in isLeapYear.
     Expected iterations: 1-2. -/
 theorem leap_year_1900 : isLeapYear 1900 = false := by
   unfold isLeapYear
   decide
 
-/-- Target B.3 (P1 validation): Year 2024 is a leap year.
+/-- Cible B.3 (validation P1) : l'année 2024 est bissextile.
+    Autre contrôle de cohérence pour les dates récentes.
+    Itérations attendues : 1-2.
+
+    English: Target B.3 (P1 validation): Year 2024 is a leap year.
     Another sanity check for recent dates.
     Expected iterations: 1-2. -/
 theorem leap_year_2024 : isLeapYear 2024 = true := by
   unfold isLeapYear
   decide
 
-/-- Target F (P2): Conway passed away on Saturday, April 11, 2020.
+/-- Cible F (P2) : Conway est décédé le samedi 11 avril 2020.
+    Cela exerce le calcul complet de l'algorithme du Doomsday :
+    centuryAnchor → doomsday → dayOfWeek.
+    Difficulté moyenne : calcul multi-étapes avec arithmétique modulaire.
+    Le prouveur doit dérouler 4-5 définitions et gérer l'arithmétique Fin 7.
+    Itérations attendues : 5-8 (chaîne d'unfold → arithmétique → decide).
+
+    English: Target F (P2): Conway passed away on Saturday, April 11, 2020.
     This exercises the full Doomsday algorithm computation:
     centuryAnchor → doomsday → dayOfWeek.
     Medium difficulty: multi-step computation with modular arithmetic.
@@ -112,14 +160,24 @@ theorem conway_death_day : dayOfWeek 2020 4 11 = DayOfWeek.saturday := by
   unfold dayOfWeek doomsdayDate doomsday centuryAnchor DayOfWeek.add DayOfWeek.sub
   simp [DayOfWeek.toFin, DayOfWeek.ofFin]
 
-/-- Target F.2 (P2): September 11, 2001 was a Tuesday.
+/-- Cible F.2 (P2) : le 11 septembre 2001 était un mardi.
+    Deuxième validation de date historique, exerce le même chemin que F.
+    Itérations attendues : 5-8.
+
+    English: Target F.2 (P2): September 11, 2001 was a Tuesday.
     Second historical date validation, exercises same path as F.
     Expected iterations: 5-8. -/
 theorem sep11_day : dayOfWeek 2001 9 11 = DayOfWeek.tuesday := by
   unfold dayOfWeek doomsdayDate doomsday centuryAnchor DayOfWeek.add DayOfWeek.sub
   simp [DayOfWeek.toFin, DayOfWeek.ofFin]
 
-/-- Target I (P1 core): Adding 7 days returns to the same day of week.
+/-- Cible I (cœur P1) : ajouter 7 jours ramène au même jour de la semaine.
+    Cela exerce le raisonnement d'arithmétique modulaire.
+    Le prouveur doit comprendre que Fin 7 + 7 % 7 = l'original.
+    Itérations attendues : 4-7 (unfold add → arithmétique modulaire → omega/decide).
+    Note : DayOfWeek autonome ici, sans import depuis Conway/Doomsday.
+
+    English: Target I (P1 core): Adding 7 days returns to the same day of week.
     This exercises modular arithmetic reasoning.
     The prover must understand that Fin 7 + 7 % 7 = original.
     Expected iterations: 4-7 (unfold add → modular arithmetic → omega/decide).

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration/Nash.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration/Nash.lean
@@ -1,4 +1,18 @@
 /-
+  Cible de calibration : équilibre de Nash dans les jeux 2×2
+  ===========================================================
+
+  Définitions autonomes + théorèmes de calibration pour le dilemme du prisonnier.
+  Aucune dépendance externe au-delà de Mathlib.
+
+  Chemins du harnais exercés :
+  - Cible C (strictly_domin_defect_pd) : P3 — l'agent peut rechercher des lemmes
+    de théorie des jeux inexistants dans Mathlib ; doit se rabattre sur l'analyse par cas.
+  - Cible D (pd_defect_is_pure_ne) : P2 — preuve multi-étapes requérant des
+    disjonctions de cas Fin 2 et des comparaisons Int.
+
+  ---
+  English:
   Calibration Target: Nash Equilibrium in 2x2 Games
   ==================================================
 
@@ -15,25 +29,33 @@
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic
 
-/-! ## Game Theory Definitions (self-contained) -/
+/-! ## Définitions de théorie des jeux (autonomes)
 
-/-- A 2x2 game: 2 players, 2 actions each -/
+English: Game Theory Definitions (self-contained) -/
+
+/-- Un jeu 2×2 : 2 joueurs, 2 actions chacun.
+    English: A 2x2 game: 2 players, 2 actions each. -/
 structure Game2x2 where
   payoff1 : Fin 2 → Fin 2 → Int
   payoff2 : Fin 2 → Fin 2 → Int
 
-/-- Action a strictly dominates action a' for player 1 -/
+/-- L'action a domine strictement l'action a' pour le joueur 1.
+    English: Action a strictly dominates action a' for player 1. -/
 def strictlyDominates1 (g : Game2x2) (a a' : Fin 2) : Prop :=
   ∀ a2 : Fin 2, g.payoff1 a a2 > g.payoff1 a' a2
 
-/-- Nash equilibrium in pure strategies for 2x2 games -/
+/-- Équilibre de Nash en stratégies pures pour les jeux 2×2.
+    English: Nash equilibrium in pure strategies for 2x2 games. -/
 def isPureNashEquilibrium (g : Game2x2) (a1 : Fin 2) (a2 : Fin 2) : Prop :=
   (∀ a1' : Fin 2, g.payoff1 a1 a2 ≥ g.payoff1 a1' a2) ∧
   (∀ a2' : Fin 2, g.payoff2 a1 a2 ≥ g.payoff2 a1 a2')
 
-/-! ## Prisoner's Dilemma -/
+/-! ## Dilemme du prisonnier
 
-/-- Prisoner's Dilemma: C=0 (Cooperate), D=1 (Defect) -/
+English: Prisoner's Dilemma -/
+
+/-- Dilemme du prisonnier : C=0 (Coopérer), D=1 (Trahir).
+    English: Prisoner's Dilemma: C=0 (Cooperate), D=1 (Defect). -/
 def prisonersDilemma : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
@@ -54,9 +76,16 @@ def prisonersDilemma : Game2x2 := {
 def Cooperer : Fin 2 := ⟨0, by omega⟩
 def Trahir : Fin 2 := ⟨1, by omega⟩
 
-/-! ## Calibration Targets -/
+/-! ## Cibles de calibration
 
-/-- Target C (P3): Strict dominance of defection in Prisoner's Dilemma.
+English: Calibration Targets -/
+
+/-- Cible C (P3) : dominance stricte de la trahison dans le dilemme du prisonnier.
+    Exerce P3 : l'agent peut chercher dans Mathlib des lemmes de théorie des jeux inexistants.
+    Approche correcte : unfold + disjonction de cas Fin 2 + arithmétique.
+    Itérations attendues : 3-5 (recherche → échec → repli → disjonction de cas → fermer).
+
+    English: Target C (P3): Strict dominance of defection in Prisoner's Dilemma.
     Exercises P3: agent may search Mathlib for game-theory lemmas that don't exist.
     Correct approach: unfold + Fin 2 case split + arithmetic.
     Expected iterations: 3-5 (search → fail → fallback → case split → close). -/
@@ -64,7 +93,11 @@ theorem strictly_domin_defect_pd :
     strictlyDominates1 prisonersDilemma Trahir Cooperer := by
   unfold strictlyDominates1; intro a2; fin_cases a2 <;> decide
 
-/-- Target D (P2): (D, D) is a pure Nash equilibrium of Prisoner's Dilemma.
+/-- Cible D (P2) : (D, D) est un équilibre de Nash pur du dilemme du prisonnier.
+    Exerce P2 : requiert une analyse de cas Fin 2 + comparaison Int pour les deux joueurs.
+    Itérations attendues : 4-7 (unfold → disjonction de cas → arithmétique → fermer).
+
+    English: Target D (P2): (D, D) is a pure Nash equilibrium of Prisoner's Dilemma.
     Exercises P2: requires Fin 2 case analysis + Int comparison across both players.
     Expected iterations: 4-7 (unfold → case split → arithmetic → close). -/
 theorem pd_defect_is_pure_ne :
@@ -72,7 +105,12 @@ theorem pd_defect_is_pure_ne :
   unfold isPureNashEquilibrium
   constructor <;> intro a <;> fin_cases a <;> norm_num [prisonersDilemma, Trahir]
 
-/-- Target E (P1+P2): (C, C) is NOT a pure Nash equilibrium.
+/-- Cible E (P1+P2) : (C, C) n'est PAS un équilibre de Nash pur.
+    Plus difficile : requiert de construire un contre-exemple (trahir bat coopérer).
+    Cela exerce la capacité du prouveur à démontrer des énoncés NÉGATIFS.
+    Itérations attendues : 5-10 (unfold → négation → construire le témoin → decide).
+
+    English: Target E (P1+P2): (C, C) is NOT a pure Nash equilibrium.
     Harder: requires constructing a counterexample (defect beats cooperate).
     This exercises the prover's ability to prove NEGATIVE statements.
     Expected iterations: 5-10 (unfold → negation → construct witness → decide). -/
@@ -84,9 +122,24 @@ theorem pd_cooperate_not_ne :
   have hdev := h1 Trahir
   norm_num [isPureNashEquilibrium, prisonersDilemma, Cooperer, Trahir] at hdev
 
-/-! ## Sorry-Increase Calibration Target (P4) -/
+/-! ## Cible de calibration à augmentation de sorry (P4)
 
-/-- Target F (P4): sorry-increase case — harness must NOT revert when sorry count
+English: Sorry-Increase Calibration Target (P4) -/
+
+/-- Cible F (P4) : cas d'augmentation de sorry — le harnais ne DOIT PAS revert quand le
+    compte de sorry augmente mais que le build passe. Cette cible est CONÇUE pour que le
+    prouveur décompose naturellement la preuve en deux sous-buts (la contrainte d'incitation
+    de chaque joueur).
+
+    Le prouveur devrait produire quelque chose comme :
+      constructor
+      · sorry  -- le joueur 1 n'a aucune incitation à dévier
+      · sorry  -- le joueur 2 n'a aucune incitation à dévier
+    Ce qui augmente sorry 1→2 mais compile. Le harnais doit préserver cela.
+
+    Itérations attendues : 3-5 (unfold → constructor → 2 sorries → prouver l'un peut-être).
+
+    English: Target F (P4): sorry-increase case — harness must NOT revert when sorry count
     increases but build passes. This target is DESIGNED so the prover naturally
     decomposes the proof into two sub-goals (each player's incentive constraint).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration/Nim.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration/Nim.lean
@@ -1,4 +1,18 @@
 /-
+  Cible de calibration : théorie des jeux de Nim
+  ===============================================
+
+  Définitions de Nim autonomes + théorèmes de calibration basés sur les
+  définitions de lean_game_defs/Combinatorial.lean.
+
+  Chemins du harnais exercés :
+  - Cible A (nim_winning_345) : validation P1 — decide simple, devrait se fermer en 1-2 itérations.
+  - Cible H (nimSum_self_cancel) : P1 — simp naïf stagne, requiert Nat.xor_self ciblé.
+    Exerce la capacité du Director à pivoter du simp générique vers un lemme spécifique.
+  - Cible D (nimSum_single) : P1 — requiert Nat.xor_zero, non trivial mais borné.
+
+  ---
+  English:
   Calibration Target: Nim Game Theory
   ====================================
 
@@ -14,29 +28,45 @@
 import Mathlib.Data.Nat.Bitwise
 import Mathlib.Tactic
 
-/-! ## Nim Definitions (self-contained, mirrors Combinatorial.lean) -/
+/-! ## Définitions de Nim (autonomes, reflètent Combinatorial.lean)
 
-/-- A Nim position is a list of heaps -/
+English: Nim Definitions (self-contained, mirrors Combinatorial.lean) -/
+
+/-- Une position de Nim est une liste de tas.
+    English: A Nim position is a list of heaps. -/
 abbrev NimPosition := List Nat
 
-/-- XOR of all heap sizes (Sprague-Grundy value for Nim) -/
+/-- XOR de toutes les tailles de tas (valeur de Sprague-Grundy pour Nim).
+    English: XOR of all heap sizes (Sprague-Grundy value for Nim). -/
 def nimSum (pos : NimPosition) : Nat :=
   pos.foldl (· ^^^ ·) 0
 
-/-- A Nim position is winning for the player to move iff nimSum ≠ 0 -/
+/-- Une position de Nim est gagnante pour le joueur qui doit jouer ssi nimSum ≠ 0.
+    English: A Nim position is winning for the player to move iff nimSum ≠ 0. -/
 def isWinningNim (pos : NimPosition) : Bool :=
   nimSum pos != 0
 
-/-! ## Calibration Targets -/
+/-! ## Cibles de calibration
 
-/-- Target A (P1 validation): Classic [3,4,5] Nim is winning for first player.
+English: Calibration Targets -/
+
+/-- Cible A (validation P1) : le Nim classique [3,4,5] est gagnant pour le premier joueur.
+    decide simple — valide le pipeline de bout en bout (devrait se fermer en 1-2 itérations).
+    C'est le contrôle de cohérence de base : si le prouveur ne peut pas fermer ça, le pipeline est cassé.
+
+    English: Target A (P1 validation): Classic [3,4,5] Nim is winning for first player.
     Simple decide — validates end-to-end pipeline (should close in 1-2 iterations).
     This is the baseline sanity check: if the prover can't close this, the pipeline is broken. -/
 theorem nim_winning_345 : isWinningNim [3, 4, 5] = true := by
   unfold isWinningNim nimSum
   simp [List.foldl]
 
-/-- Target D (P1): nimSum of a single heap equals the heap size.
+/-- Cible D (P1) : le nimSum d'un tas unique égale la taille du tas.
+    Requiert Nat.xor_zero — le prouveur doit découvrir ce lemme spécifique.
+    Un simp naïf sans le bon lemme va stagner.
+    Itérations attendues : 3-5 (unfold → simp naïf → échec → découvrir Nat.xor_zero → fermer).
+
+    English: Target D (P1): nimSum of a single heap equals the heap size.
     Requires Nat.xor_zero — the prover must discover this specific lemma.
     A naive simp without the right lemma will stall.
     Expected iterations: 3-5 (unfold → simp naive → fail → discover Nat.xor_zero → close). -/
@@ -44,7 +74,13 @@ theorem nimSum_single (n : Nat) : nimSum [n] = n := by
   unfold nimSum
   simp [List.foldl_cons, List.foldl_nil]
 
-/-- Target H (P1 core): Two identical heaps cancel out (nimSum = 0).
+/-- Cible H (cœur P1) : deux tas identiques s'annulent (nimSum = 0).
+    C'est le cœur de la théorie de Nim : le xor est auto-annulant.
+    Un `simp` naïf va stagner — requiert `Nat.xor_self` ciblé.
+    Cela exerce la capacité du Director à pivoter du générique vers le spécifique.
+    Itérations attendues : 5-8 (unfold → simp naïf → stagnation → pivot vers Nat.xor_self → fermer).
+
+    English: Target H (P1 core): Two identical heaps cancel out (nimSum = 0).
     This is the heart of Nim theory: xor is self-canceling.
     A naive `simp` will stall — requires targeted `Nat.xor_self`.
     This exercises the Director's ability to pivot from generic to specific.
@@ -53,14 +89,21 @@ theorem nimSum_self_cancel (n : Nat) : nimSum [n, n] = 0 := by
   unfold nimSum
   simp [List.foldl_cons, List.foldl_nil, List.foldl_cons]
 
-/-- Target H+ (P1 extended): Three heaps where two cancel.
+/-- Cible H+ (P1 étendue) : trois tas dont deux s'annulent.
+    Combine nimSum_single et nimSum_self_cancel.
+    Itérations attendues : 4-7.
+
+    English: Target H+ (P1 extended): Three heaps where two cancel.
     Combines nimSum_single and nimSum_self_cancel.
     Expected iterations: 4-7. -/
 theorem nimSum_cancel_pair (n m : Nat) : nimSum [n, m, m] = n := by
   unfold nimSum
   simp [List.foldl_cons, List.foldl_nil, List.foldl_cons, List.foldl_cons]
 
-/-- Target A+ (P1 validation): Empty position is losing (nimSum = 0).
+/-- Cible A+ (validation P1) : la position vide est perdante (nimSum = 0).
+    Triviale mais assure la couverture du cas limite.
+
+    English: Target A+ (P1 validation): Empty position is losing (nimSum = 0).
     Trivial but ensures edge case coverage. -/
 theorem nimSum_empty : nimSum [] = 0 := by
   unfold nimSum


### PR DESCRIPTION
## Scope

Etape 2 du rollout **#4980** (i18n des fichiers `.lean`, décision user 02/07/2026, **Option A** = docstrings bilingues FR+EN inline). Suite du pilote conway_cgt (#5085).

`calibration_lean` = cibles de calibration pour le prouveur Lean multi-agent (Epic #1452). 4 fichiers `.lean`, 100% EN :
- `Calibration.lean` (module root)
- `Calibration/Doomsday.lean` (algorithme Doomsday de Conway)
- `Calibration/Nash.lean` (équilibre de Nash, dilemme du prisonnier)
- `Calibration/Nim.lean` (théorie des jeux de Nim)

**Single-`require mathlib`** → build clean sur cache rc1 junctioné (contrairement au pilote conway_cgt #5085 qui a un 2e `require CombinatorialGames` causant le pin drift préexistant).

## Convention Option A appliquée

| Type de commentaire | Traitement |
|---------------------|------------|
| Module docstrings `/- ... -/` | Bilingue : FR d'abord + `---` + `English:` |
| Section docstrings `/-! ## ... -/` | Bilingue : FR d'abord + `English:` |
| Déclaration docstrings `/-- ... -/` | Bilingue : FR d'abord + `English:` |
| Commentaires inline `-- ...` | Intacts (aucun dans calibration) |
| Identifiants (`def`/`theorem`/noms) | **Inchangés** (convention nommage Lean/Mathlib = anglais) |

## Anti-régression — preuve structurelle (lean-merge-discipline §1, anti-regression.md)

Vérification automatisée (script, comments strippés Lean-aware : blocs `/- -/` imbriqués + lignes `--`) :

| Fichier | Code byte-identique (origin/main vs working) | Délimiteurs `/-`==`-/` | sorry réel (token `\bsorry\b`) |
|---------|----------------------------------------------|------------------------|-------------------------------|
| Calibration.lean | ✅ True | 1/1 ✅ | 0 → 0 ✅ |
| Doomsday.lean | ✅ True | 19/19 ✅ | 0 → 0 ✅ |
| Nash.lean | ✅ True | 13/13 ✅ | 0 → 0 ✅ |
| Nim.lean | ✅ True | 11/11 ✅ | 0 → 0 ✅ |

**L'i18n ne touche QUE les commentaires/docstrings.** Zéro ligne de code (`def`/`theorem`/tactique/import) modifiée. Les mentions « sorry » dans Nash.lean sont de la **prose de docstring** décrivant le comportement attendu du harness P4 (Target F = cas d'augmentation de sorry que le harnais doit préserver), **pas des preuves** — c'est confirmé par le token-grep `\bsorry\b` sur le code strippé = 0.

## Build local

`lake build Calibration` : **SUCCESS — Build completed successfully (2954 jobs), EXIT 0, 1m42s** (Windows-native `lake.exe`). Calibration.Nim / Doomsday / Nash / root tous compilés avec les docstrings bilingues.

Single-`require mathlib` → pas de pin drift upstream (contrairement au pilote conway_cgt #5085 qui a un 2e `require CombinatorialGames`).

**Note transparence (env local, hors PR)** : le symlink `.lake/packages/mathlib` pointait stale vers le cache rc2 (`54f98fd6`) alors que la toolchain calibration_lean = rc1 (`v4.31.0-rc1`). Corrigé localement pour pointer vers le cache rc1 canonique du cluster mutualisé (`d568c8c0`, même cible que conway_lean, #4363) — `.lake/` est gitignored donc hors diff. Ce mismatch d'env était **préexistant** (symlink daté Jun 11) et **indépendant de l'i18n** (les échecs du build initial étaient tous sur des modules Mathlib, jamais sur Calibration).

## Diff

Additif pur (ajout de traductions FR + séparateurs `---`/`English:` avant les closers `-/` existants). Aucune ligne de code supprimée ni modifiée.

See #4980
