### PR TITLE
fix(infra): scrub papermill absolute paths — GameTheory + Search residual (See #3436)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
@@ -2326,8 +2326,8 @@
    "end_time": "2026-07-02T20:07:24.343158+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb",
-   "output_path": "/tmp/03-Voting-Methods_wsl_output.ipynb",
+   "input_path": "03-Voting-Methods.ipynb",
+   "output_path": "03-Voting-Methods.ipynb",
    "parameters": {},
    "start_time": "2026-07-02T20:07:13.946340+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -2885,8 +2885,8 @@
    "end_time": "2026-07-02T20:09:39.961165+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb",
-   "output_path": "/tmp/04-Computational-Aggregation-SAT-Z3_wsl_output.ipynb",
+   "input_path": "04-Computational-Aggregation-SAT-Z3.ipynb",
+   "output_path": "04-Computational-Aggregation-SAT-Z3.ipynb",
    "parameters": {},
    "start_time": "2026-07-02T20:09:28.147060+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb
+++ b/MyIA.AI.Notebooks/Search/Exploration_non_informée_et_informée_intro.ipynb
@@ -1929,8 +1929,8 @@
    "end_time": "2026-07-02T10:31:18.588621+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--dev-CoursIA/88210e0c-f98c-40cf-bfe1-5b36978be52f/scratchpad/exploration_in.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--dev-CoursIA/88210e0c-f98c-40cf-bfe1-5b36978be52f/scratchpad/exploration_exec.ipynb",
+   "input_path": "Exploration_non_informée_et_informée_intro.ipynb",
+   "output_path": "Exploration_non_informée_et_informée_intro.ipynb",
    "parameters": {},
    "start_time": "2026-07-02T10:31:12.450889+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Metadata-only fix for 3 notebooks with absolute machine paths in `metadata.papermill.{input,output}_path`. No re-execution needed — this is the **authorized exception** to Stop & Repair rule 6 (`metadata.papermill.input/output_path` basename normalization is metadata, NOT a cell output).

## Notebooks fixed (3)

| Notebook | Old leak |
|----------|----------|
| `GameTheory/SocialChoice/03-Voting-Methods.ipynb` | WSL `/mnt/c/dev/CoursIA/...` + `/tmp/..._wsl_output.ipynb` |
| `GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb` | WSL `/mnt/c/dev/CoursIA/...` + `/tmp/..._wsl_output.ipynb` |
| `Search/Exploration_non_informée_et_informée_intro.ipynb` | claude scratchpad `C:/Users/jsboi/AppData/Local/Temp/claude/.../scratchpad/...` |

Each path → basename (`<notebook>.ipynb`).

## G.1 byte-identity validation (per notebook)

- cell count unchanged (44 / 68 / 43)
- `source` byte-identical all cells
- `outputs` byte-identical all cells
- `execution_count` identical
- metadata sans papermill identical
- **ONLY `input_path`/`output_path` VALUES changed** in papermill block (verified: `changed keys == ['input_path','output_path']`)
- CATALOG-STATUS byte-identical (catalog-pr-hygiene HARD)

`git diff --stat`: 3 files, +6/-6.

## Tool + pattern

- Canonical tool: `scripts/notebook_tools/scrub_papermill_paths.py` (PR #4401, modes `--scan/--apply/--check`).
- Established grouping pattern: PR #4442 (6-nb metadata-only sweep).

## Out of scope (deferred)

- `SymbolicAI/Lean/Lean-18-Search-AStar-Optimality.ipynb` (also flagged by `--scan-all`) — SymbolicAI/Lean = **po-2026 turf**; deferred for lane discipline. po-2026 can pick it up.

See #3436 (papermill-path repo-wide, quasi-complete after this).