### PR TITLE
docs(tweety): IKVM/Tweety load-confirmation cells (See #5039 Constat 3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
@@ -63,10 +63,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T19:43:32.325633Z",
-     "iopub.status.busy": "2026-07-01T19:43:32.318321Z",
-     "iopub.status.idle": "2026-07-01T19:43:33.201639Z",
-     "shell.execute_reply": "2026-07-01T19:43:33.198991Z"
+     "iopub.execute_input": "2026-07-03T02:53:03.524272Z",
+     "iopub.status.busy": "2026-07-03T02:53:03.517632Z",
+     "iopub.status.idle": "2026-07-03T02:53:04.991620Z",
+     "shell.execute_reply": "2026-07-03T02:53:04.985776Z"
     }
    },
    "outputs": [
@@ -75,7 +75,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-118308.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -120,12 +120,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::7d45:cacc:b8c8:f231%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '118308.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '256556.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -210,10 +210,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T19:43:33.209900Z",
-     "iopub.status.busy": "2026-07-01T19:43:33.206916Z",
-     "iopub.status.idle": "2026-07-01T19:43:34.374833Z",
-     "shell.execute_reply": "2026-07-01T19:43:34.374438Z"
+     "iopub.execute_input": "2026-07-03T02:53:04.994225Z",
+     "iopub.status.busy": "2026-07-03T02:53:04.993943Z",
+     "iopub.status.idle": "2026-07-03T02:53:06.332371Z",
+     "shell.execute_reply": "2026-07-03T02:53:06.332060Z"
     }
    },
    "outputs": [
@@ -279,15 +279,45 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T19:43:34.376859Z",
-     "iopub.status.busy": "2026-07-01T19:43:34.376502Z",
-     "iopub.status.idle": "2026-07-01T19:43:34.403833Z",
-     "shell.execute_reply": "2026-07-01T19:43:34.402233Z"
+     "iopub.execute_input": "2026-07-03T02:53:06.334570Z",
+     "iopub.status.busy": "2026-07-03T02:53:06.334152Z",
+     "iopub.status.idle": "2026-07-03T02:53:06.368524Z",
+     "shell.execute_reply": "2026-07-03T02:53:06.368205Z"
     }
    },
    "outputs": [],
    "source": [
     "#r \"org.tweetyproject.tweety-pl.dll\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fc526651",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T02:53:06.370673Z",
+     "iopub.status.busy": "2026-07-03T02:53:06.370329Z",
+     "iopub.status.idle": "2026-07-03T02:53:06.474066Z",
+     "shell.execute_reply": "2026-07-03T02:53:06.473609Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tweety (IKVM) reference chargee : org.tweetyproject.tweety-pl v1.30.0.0 (7,0 Mo).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Constat 3 (#5039) : la directive #r est silencieuse par defaut en .NET Interactive.\n",
+    "// On verifie que la DLL IKVM/Tweety referencee est bien presente et lisible (metadata).\n",
+    "using System.Reflection;\n",
+    "var tweetyDll = \"org.tweetyproject.tweety-pl.dll\";\n",
+    "var an = AssemblyName.GetAssemblyName(tweetyDll);\n",
+    "Console.WriteLine($\"Tweety (IKVM) reference chargee : {an.Name} v{an.Version} ({new FileInfo(tweetyDll).Length / 1024 / 1024:F1} Mo).\");"
    ]
   },
   {
@@ -303,17 +333,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c16522",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T19:43:34.405900Z",
-     "iopub.status.busy": "2026-07-01T19:43:34.405481Z",
-     "iopub.status.idle": "2026-07-01T19:43:34.934521Z",
-     "shell.execute_reply": "2026-07-01T19:43:34.933666Z"
+     "iopub.execute_input": "2026-07-03T02:53:06.476194Z",
+     "iopub.status.busy": "2026-07-03T02:53:06.475833Z",
+     "iopub.status.idle": "2026-07-03T02:53:07.058487Z",
+     "shell.execute_reply": "2026-07-03T02:53:07.058162Z"
     }
    },
    "outputs": [
@@ -386,17 +416,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c54393",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T19:43:34.937592Z",
-     "iopub.status.busy": "2026-07-01T19:43:34.937087Z",
-     "iopub.status.idle": "2026-07-01T19:43:35.039712Z",
-     "shell.execute_reply": "2026-07-01T19:43:35.039112Z"
+     "iopub.execute_input": "2026-07-03T02:53:07.060464Z",
+     "iopub.status.busy": "2026-07-03T02:53:07.060183Z",
+     "iopub.status.idle": "2026-07-03T02:53:07.145314Z",
+     "shell.execute_reply": "2026-07-03T02:53:07.144713Z"
     }
    },
    "outputs": [
@@ -439,17 +469,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c59450",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T19:43:35.041515Z",
-     "iopub.status.busy": "2026-07-01T19:43:35.041162Z",
-     "iopub.status.idle": "2026-07-01T19:43:35.116646Z",
-     "shell.execute_reply": "2026-07-01T19:43:35.116349Z"
+     "iopub.execute_input": "2026-07-03T02:53:07.147518Z",
+     "iopub.status.busy": "2026-07-03T02:53:07.147076Z",
+     "iopub.status.idle": "2026-07-03T02:53:07.243265Z",
+     "shell.execute_reply": "2026-07-03T02:53:07.243024Z"
     }
    },
    "outputs": [
@@ -511,17 +541,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c30432",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T19:43:35.118386Z",
-     "iopub.status.busy": "2026-07-01T19:43:35.118041Z",
-     "iopub.status.idle": "2026-07-01T19:43:35.172923Z",
-     "shell.execute_reply": "2026-07-01T19:43:35.172450Z"
+     "iopub.execute_input": "2026-07-03T02:53:07.244935Z",
+     "iopub.status.busy": "2026-07-03T02:53:07.244677Z",
+     "iopub.status.idle": "2026-07-03T02:53:07.290015Z",
+     "shell.execute_reply": "2026-07-03T02:53:07.289773Z"
     }
    },
    "outputs": [
@@ -542,17 +572,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c52534",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T19:43:35.174678Z",
-     "iopub.status.busy": "2026-07-01T19:43:35.174381Z",
-     "iopub.status.idle": "2026-07-01T19:43:35.224035Z",
-     "shell.execute_reply": "2026-07-01T19:43:35.223502Z"
+     "iopub.execute_input": "2026-07-03T02:53:07.291545Z",
+     "iopub.status.busy": "2026-07-03T02:53:07.291305Z",
+     "iopub.status.idle": "2026-07-03T02:53:07.352948Z",
+     "shell.execute_reply": "2026-07-03T02:53:07.352695Z"
     }
    },
    "outputs": [
@@ -582,7 +612,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2b-Semantics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2b-Semantics-Csharp.ipynb
@@ -53,10 +53,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:22.742087Z",
-     "iopub.status.busy": "2026-07-01T21:49:22.724404Z",
-     "iopub.status.idle": "2026-07-01T21:49:25.131647Z",
-     "shell.execute_reply": "2026-07-01T21:49:25.117554Z"
+     "iopub.execute_input": "2026-07-03T02:55:19.054523Z",
+     "iopub.status.busy": "2026-07-03T02:55:19.045671Z",
+     "iopub.status.idle": "2026-07-03T02:55:20.947466Z",
+     "shell.execute_reply": "2026-07-03T02:55:20.941543Z"
     }
    },
    "outputs": [
@@ -65,7 +65,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-104088.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -110,12 +110,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2052/\",\"http://172.28.160.1:2052/\",\"http://fe80::7d45:cacc:b8c8:f231%44:2052/\",\"http://172.21.192.1:2052/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2052/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2052/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2052/\",\"http://192.168.0.49:2052/\",\"http://::1:2052/\",\"http://127.0.0.1:2052/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '104088.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '249732.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -200,10 +200,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:25.137839Z",
-     "iopub.status.busy": "2026-07-01T21:49:25.137222Z",
-     "iopub.status.idle": "2026-07-01T21:49:28.535193Z",
-     "shell.execute_reply": "2026-07-01T21:49:28.534086Z"
+     "iopub.execute_input": "2026-07-03T02:55:20.950498Z",
+     "iopub.status.busy": "2026-07-03T02:55:20.950136Z",
+     "iopub.status.idle": "2026-07-03T02:55:22.523166Z",
+     "shell.execute_reply": "2026-07-03T02:55:22.522863Z"
     }
    },
    "outputs": [
@@ -257,15 +257,45 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:28.538538Z",
-     "iopub.status.busy": "2026-07-01T21:49:28.537889Z",
-     "iopub.status.idle": "2026-07-01T21:49:28.650028Z",
-     "shell.execute_reply": "2026-07-01T21:49:28.649463Z"
+     "iopub.execute_input": "2026-07-03T02:55:22.525527Z",
+     "iopub.status.busy": "2026-07-03T02:55:22.525053Z",
+     "iopub.status.idle": "2026-07-03T02:55:22.561678Z",
+     "shell.execute_reply": "2026-07-03T02:55:22.561310Z"
     }
    },
    "outputs": [],
    "source": [
     "#r \"org.tweetyproject.tweety-pl.dll\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "88646a94",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T02:55:22.563842Z",
+     "iopub.status.busy": "2026-07-03T02:55:22.563511Z",
+     "iopub.status.idle": "2026-07-03T02:55:22.679916Z",
+     "shell.execute_reply": "2026-07-03T02:55:22.679616Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tweety (IKVM) reference chargee : org.tweetyproject.tweety-pl v1.30.0.0 (7,0 Mo).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Constat 3 (#5039) : la directive #r est silencieuse par defaut en .NET Interactive.\n",
+    "// On verifie que la DLL IKVM/Tweety referencee est bien presente et lisible (metadata).\n",
+    "using System.Reflection;\n",
+    "var tweetyDll = \"org.tweetyproject.tweety-pl.dll\";\n",
+    "var an = AssemblyName.GetAssemblyName(tweetyDll);\n",
+    "Console.WriteLine($\"Tweety (IKVM) reference chargee : {an.Name} v{an.Version} ({new FileInfo(tweetyDll).Length / 1024 / 1024:F1} Mo).\");"
    ]
   },
   {
@@ -287,17 +317,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c418284",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:28.653592Z",
-     "iopub.status.busy": "2026-07-01T21:49:28.652924Z",
-     "iopub.status.idle": "2026-07-01T21:49:30.141391Z",
-     "shell.execute_reply": "2026-07-01T21:49:30.140517Z"
+     "iopub.execute_input": "2026-07-03T02:55:22.681785Z",
+     "iopub.status.busy": "2026-07-03T02:55:22.681521Z",
+     "iopub.status.idle": "2026-07-03T02:55:23.843323Z",
+     "shell.execute_reply": "2026-07-03T02:55:23.842609Z"
     }
    },
    "outputs": [
@@ -407,17 +437,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c338411",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:30.145626Z",
-     "iopub.status.busy": "2026-07-01T21:49:30.144760Z",
-     "iopub.status.idle": "2026-07-01T21:49:30.542639Z",
-     "shell.execute_reply": "2026-07-01T21:49:30.542098Z"
+     "iopub.execute_input": "2026-07-03T02:55:23.845268Z",
+     "iopub.status.busy": "2026-07-03T02:55:23.844976Z",
+     "iopub.status.idle": "2026-07-03T02:55:23.992679Z",
+     "shell.execute_reply": "2026-07-03T02:55:23.992374Z"
     }
    },
    "outputs": [
@@ -503,17 +533,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c77422",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:30.545835Z",
-     "iopub.status.busy": "2026-07-01T21:49:30.545232Z",
-     "iopub.status.idle": "2026-07-01T21:49:30.771288Z",
-     "shell.execute_reply": "2026-07-01T21:49:30.770433Z"
+     "iopub.execute_input": "2026-07-03T02:55:23.994461Z",
+     "iopub.status.busy": "2026-07-03T02:55:23.994195Z",
+     "iopub.status.idle": "2026-07-03T02:55:24.114584Z",
+     "shell.execute_reply": "2026-07-03T02:55:24.113751Z"
     }
    },
    "outputs": [
@@ -570,17 +600,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c374005",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:30.774688Z",
-     "iopub.status.busy": "2026-07-01T21:49:30.774084Z",
-     "iopub.status.idle": "2026-07-01T21:49:31.619683Z",
-     "shell.execute_reply": "2026-07-01T21:49:31.618696Z"
+     "iopub.execute_input": "2026-07-03T02:55:24.117040Z",
+     "iopub.status.busy": "2026-07-03T02:55:24.116687Z",
+     "iopub.status.idle": "2026-07-03T02:55:24.950309Z",
+     "shell.execute_reply": "2026-07-03T02:55:24.949686Z"
     }
    },
    "outputs": [
@@ -668,17 +698,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c629890",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:31.623707Z",
-     "iopub.status.busy": "2026-07-01T21:49:31.623039Z",
-     "iopub.status.idle": "2026-07-01T21:49:31.903910Z",
-     "shell.execute_reply": "2026-07-01T21:49:31.902921Z"
+     "iopub.execute_input": "2026-07-03T02:55:24.952650Z",
+     "iopub.status.busy": "2026-07-03T02:55:24.952307Z",
+     "iopub.status.idle": "2026-07-03T02:55:25.132177Z",
+     "shell.execute_reply": "2026-07-03T02:55:25.131496Z"
     }
    },
    "outputs": [
@@ -833,17 +863,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c236170",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:31.908517Z",
-     "iopub.status.busy": "2026-07-01T21:49:31.907265Z",
-     "iopub.status.idle": "2026-07-01T21:49:32.246586Z",
-     "shell.execute_reply": "2026-07-01T21:49:32.246948Z"
+     "iopub.execute_input": "2026-07-03T02:55:25.134472Z",
+     "iopub.status.busy": "2026-07-03T02:55:25.134118Z",
+     "iopub.status.idle": "2026-07-03T02:55:25.279187Z",
+     "shell.execute_reply": "2026-07-03T02:55:25.278914Z"
     }
    },
    "outputs": [
@@ -920,17 +950,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c417912",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:32.251976Z",
-     "iopub.status.busy": "2026-07-01T21:49:32.251290Z",
-     "iopub.status.idle": "2026-07-01T21:49:32.425843Z",
-     "shell.execute_reply": "2026-07-01T21:49:32.424037Z"
+     "iopub.execute_input": "2026-07-03T02:55:25.281694Z",
+     "iopub.status.busy": "2026-07-03T02:55:25.281164Z",
+     "iopub.status.idle": "2026-07-03T02:55:25.371696Z",
+     "shell.execute_reply": "2026-07-03T02:55:25.371181Z"
     }
    },
    "outputs": [
@@ -995,17 +1025,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "c539956",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T21:49:32.431030Z",
-     "iopub.status.busy": "2026-07-01T21:49:32.430399Z",
-     "iopub.status.idle": "2026-07-01T21:49:32.616809Z",
-     "shell.execute_reply": "2026-07-01T21:49:32.616204Z"
+     "iopub.execute_input": "2026-07-03T02:55:25.374359Z",
+     "iopub.status.busy": "2026-07-03T02:55:25.373846Z",
+     "iopub.status.idle": "2026-07-03T02:55:25.501919Z",
+     "shell.execute_reply": "2026-07-03T02:55:25.501542Z"
     }
    },
    "outputs": [
@@ -1076,7 +1106,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
@@ -63,10 +63,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:30.570070Z",
-     "iopub.status.busy": "2026-07-01T22:41:30.524255Z",
-     "iopub.status.idle": "2026-07-01T22:41:37.428333Z",
-     "shell.execute_reply": "2026-07-01T22:41:37.404715Z"
+     "iopub.execute_input": "2026-07-03T02:55:35.363810Z",
+     "iopub.status.busy": "2026-07-03T02:55:35.356932Z",
+     "iopub.status.idle": "2026-07-03T02:55:36.986648Z",
+     "shell.execute_reply": "2026-07-03T02:55:36.980762Z"
     }
    },
    "outputs": [
@@ -75,7 +75,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-118412.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -120,12 +120,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.18.16.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2052/\",\"http://172.28.160.1:2052/\",\"http://fe80::7d45:cacc:b8c8:f231%44:2052/\",\"http://172.21.192.1:2052/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2052/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2052/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2052/\",\"http://192.168.0.49:2052/\",\"http://::1:2052/\",\"http://127.0.0.1:2052/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '118412.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '257044.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -211,10 +211,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:37.438470Z",
-     "iopub.status.busy": "2026-07-01T22:41:37.437869Z",
-     "iopub.status.idle": "2026-07-01T22:41:42.131619Z",
-     "shell.execute_reply": "2026-07-01T22:41:42.130704Z"
+     "iopub.execute_input": "2026-07-03T02:55:36.989242Z",
+     "iopub.status.busy": "2026-07-03T02:55:36.988940Z",
+     "iopub.status.idle": "2026-07-03T02:55:38.210361Z",
+     "shell.execute_reply": "2026-07-03T02:55:38.209939Z"
     }
    },
    "outputs": [
@@ -265,16 +265,46 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:42.134392Z",
-     "iopub.status.busy": "2026-07-01T22:41:42.133838Z",
-     "iopub.status.idle": "2026-07-01T22:41:42.275373Z",
-     "shell.execute_reply": "2026-07-01T22:41:42.274453Z"
+     "iopub.execute_input": "2026-07-03T02:55:38.212628Z",
+     "iopub.status.busy": "2026-07-03T02:55:38.212258Z",
+     "iopub.status.idle": "2026-07-03T02:55:38.247133Z",
+     "shell.execute_reply": "2026-07-03T02:55:38.246762Z"
     }
    },
    "outputs": [],
    "source": [
     "#r \"org.tweetyproject.tweety-pl.dll\"\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "95309f07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T02:55:38.248843Z",
+     "iopub.status.busy": "2026-07-03T02:55:38.248562Z",
+     "iopub.status.idle": "2026-07-03T02:55:38.367972Z",
+     "shell.execute_reply": "2026-07-03T02:55:38.367756Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tweety (IKVM) reference chargee : org.tweetyproject.tweety-pl v1.30.0.0 (7,0 Mo).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Constat 3 (#5039) : la directive #r est silencieuse par defaut en .NET Interactive.\n",
+    "// On verifie que la DLL IKVM/Tweety referencee est bien presente et lisible (metadata).\n",
+    "using System.Reflection;\n",
+    "var tweetyDll = \"org.tweetyproject.tweety-pl.dll\";\n",
+    "var an = AssemblyName.GetAssemblyName(tweetyDll);\n",
+    "Console.WriteLine($\"Tweety (IKVM) reference chargee : {an.Name} v{an.Version} ({new FileInfo(tweetyDll).Length / 1024 / 1024:F1} Mo).\");"
    ]
   },
   {
@@ -298,17 +328,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c297868",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:42.278500Z",
-     "iopub.status.busy": "2026-07-01T22:41:42.277888Z",
-     "iopub.status.idle": "2026-07-01T22:41:44.219572Z",
-     "shell.execute_reply": "2026-07-01T22:41:44.218731Z"
+     "iopub.execute_input": "2026-07-03T02:55:38.369319Z",
+     "iopub.status.busy": "2026-07-03T02:55:38.369089Z",
+     "iopub.status.idle": "2026-07-03T02:55:38.864840Z",
+     "shell.execute_reply": "2026-07-03T02:55:38.864441Z"
     }
    },
    "outputs": [
@@ -364,17 +394,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c697660",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:44.222641Z",
-     "iopub.status.busy": "2026-07-01T22:41:44.222110Z",
-     "iopub.status.idle": "2026-07-01T22:41:44.574978Z",
-     "shell.execute_reply": "2026-07-01T22:41:44.573507Z"
+     "iopub.execute_input": "2026-07-03T02:55:38.866507Z",
+     "iopub.status.busy": "2026-07-03T02:55:38.866240Z",
+     "iopub.status.idle": "2026-07-03T02:55:38.929817Z",
+     "shell.execute_reply": "2026-07-03T02:55:38.929535Z"
     }
    },
    "outputs": [
@@ -430,17 +460,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c159435",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:44.577962Z",
-     "iopub.status.busy": "2026-07-01T22:41:44.577402Z",
-     "iopub.status.idle": "2026-07-01T22:41:44.916598Z",
-     "shell.execute_reply": "2026-07-01T22:41:44.915722Z"
+     "iopub.execute_input": "2026-07-03T02:55:38.932300Z",
+     "iopub.status.busy": "2026-07-03T02:55:38.931847Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.009434Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.009196Z"
     }
    },
    "outputs": [
@@ -487,17 +517,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c375540",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:44.919705Z",
-     "iopub.status.busy": "2026-07-01T22:41:44.919148Z",
-     "iopub.status.idle": "2026-07-01T22:41:45.222181Z",
-     "shell.execute_reply": "2026-07-01T22:41:45.221696Z"
+     "iopub.execute_input": "2026-07-03T02:55:39.011211Z",
+     "iopub.status.busy": "2026-07-03T02:55:39.010914Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.062820Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.062568Z"
     }
    },
    "outputs": [
@@ -547,17 +577,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c880179",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:45.225357Z",
-     "iopub.status.busy": "2026-07-01T22:41:45.224772Z",
-     "iopub.status.idle": "2026-07-01T22:41:45.778801Z",
-     "shell.execute_reply": "2026-07-01T22:41:45.777885Z"
+     "iopub.execute_input": "2026-07-03T02:55:39.064339Z",
+     "iopub.status.busy": "2026-07-03T02:55:39.064095Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.196194Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.196004Z"
     }
    },
    "outputs": [
@@ -565,7 +595,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "KB = { Homme(Socrate), forall X: ((Homme(X)=>Mortel(X))) }\r\n"
+      "KB = { forall X: ((Homme(X)=>Mortel(X))), Homme(Socrate) }\r\n"
      ]
     },
     {
@@ -614,17 +644,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c743358",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:45.782177Z",
-     "iopub.status.busy": "2026-07-01T22:41:45.781589Z",
-     "iopub.status.idle": "2026-07-01T22:41:46.105797Z",
-     "shell.execute_reply": "2026-07-01T22:41:46.105263Z"
+     "iopub.execute_input": "2026-07-03T02:55:39.197772Z",
+     "iopub.status.busy": "2026-07-03T02:55:39.197548Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.246524Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.246288Z"
     }
    },
    "outputs": [
@@ -668,17 +698,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c46812",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:46.109564Z",
-     "iopub.status.busy": "2026-07-01T22:41:46.108767Z",
-     "iopub.status.idle": "2026-07-01T22:41:46.352784Z",
-     "shell.execute_reply": "2026-07-01T22:41:46.351819Z"
+     "iopub.execute_input": "2026-07-03T02:55:39.247913Z",
+     "iopub.status.busy": "2026-07-03T02:55:39.247708Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.301199Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.300992Z"
     }
    },
    "outputs": [
@@ -721,17 +751,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "c615894",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:46.355759Z",
-     "iopub.status.busy": "2026-07-01T22:41:46.355230Z",
-     "iopub.status.idle": "2026-07-01T22:41:46.829983Z",
-     "shell.execute_reply": "2026-07-01T22:41:46.829008Z"
+     "iopub.execute_input": "2026-07-03T02:55:39.303011Z",
+     "iopub.status.busy": "2026-07-03T02:55:39.302741Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.464563Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.464224Z"
     }
    },
    "outputs": [
@@ -806,17 +836,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "c525316",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:46.833008Z",
-     "iopub.status.busy": "2026-07-01T22:41:46.832471Z",
-     "iopub.status.idle": "2026-07-01T22:41:47.181860Z",
-     "shell.execute_reply": "2026-07-01T22:41:47.181198Z"
+     "iopub.execute_input": "2026-07-03T02:55:39.466548Z",
+     "iopub.status.busy": "2026-07-03T02:55:39.466212Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.526412Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.526204Z"
     }
    },
    "outputs": [
@@ -858,17 +888,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "c712763",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:47.184867Z",
-     "iopub.status.busy": "2026-07-01T22:41:47.184318Z",
-     "iopub.status.idle": "2026-07-01T22:41:47.431539Z",
-     "shell.execute_reply": "2026-07-01T22:41:47.431054Z"
+     "iopub.execute_input": "2026-07-03T02:55:39.527667Z",
+     "iopub.status.busy": "2026-07-03T02:55:39.527464Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.557200Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.556845Z"
     }
    },
    "outputs": [
@@ -906,17 +936,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "c545430",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-01T22:41:47.434462Z",
-     "iopub.status.busy": "2026-07-01T22:41:47.433942Z",
-     "iopub.status.idle": "2026-07-01T22:41:47.633142Z",
-     "shell.execute_reply": "2026-07-01T22:41:47.631478Z"
+     "iopub.execute_input": "2026-07-03T02:55:39.558525Z",
+     "iopub.status.busy": "2026-07-03T02:55:39.558340Z",
+     "iopub.status.idle": "2026-07-03T02:55:39.590704Z",
+     "shell.execute_reply": "2026-07-03T02:55:39.590462Z"
     }
    },
    "outputs": [
@@ -985,7 +1015,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
@@ -67,10 +67,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:13.284393Z",
-     "iopub.status.busy": "2026-07-02T00:28:13.277916Z",
-     "iopub.status.idle": "2026-07-02T00:28:14.273458Z",
-     "shell.execute_reply": "2026-07-02T00:28:14.270821Z"
+     "iopub.execute_input": "2026-07-03T02:55:47.358601Z",
+     "iopub.status.busy": "2026-07-03T02:55:47.348660Z",
+     "iopub.status.idle": "2026-07-03T02:55:49.144790Z",
+     "shell.execute_reply": "2026-07-03T02:55:49.137989Z"
     }
    },
    "outputs": [
@@ -79,7 +79,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-24552.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -124,12 +124,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.30.224.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::7d45:cacc:b8c8:f231%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '24552.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '253048.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -215,10 +215,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:14.275975Z",
-     "iopub.status.busy": "2026-07-02T00:28:14.275689Z",
-     "iopub.status.idle": "2026-07-02T00:28:15.114101Z",
-     "shell.execute_reply": "2026-07-02T00:28:15.113454Z"
+     "iopub.execute_input": "2026-07-03T02:55:49.147248Z",
+     "iopub.status.busy": "2026-07-03T02:55:49.146927Z",
+     "iopub.status.idle": "2026-07-03T02:55:50.634006Z",
+     "shell.execute_reply": "2026-07-03T02:55:50.633464Z"
     }
    },
    "outputs": [
@@ -269,16 +269,46 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:15.116336Z",
-     "iopub.status.busy": "2026-07-02T00:28:15.116027Z",
-     "iopub.status.idle": "2026-07-02T00:28:15.138457Z",
-     "shell.execute_reply": "2026-07-02T00:28:15.138165Z"
+     "iopub.execute_input": "2026-07-03T02:55:50.636372Z",
+     "iopub.status.busy": "2026-07-03T02:55:50.635946Z",
+     "iopub.status.idle": "2026-07-03T02:55:50.682053Z",
+     "shell.execute_reply": "2026-07-03T02:55:50.681677Z"
     }
    },
    "outputs": [],
    "source": [
     "#r \"org.tweetyproject.tweety-dung.dll\"\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "28675c1a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T02:55:50.684160Z",
+     "iopub.status.busy": "2026-07-03T02:55:50.683822Z",
+     "iopub.status.idle": "2026-07-03T02:55:50.844771Z",
+     "shell.execute_reply": "2026-07-03T02:55:50.844445Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tweety (IKVM) reference chargee : org.tweetyproject.tweety-dung v1.30.0.0 (8,0 Mo).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Constat 3 (#5039) : la directive #r est silencieuse par defaut en .NET Interactive.\n",
+    "// On verifie que la DLL IKVM/Tweety referencee est bien presente et lisible (metadata).\n",
+    "using System.Reflection;\n",
+    "var tweetyDll = \"org.tweetyproject.tweety-dung.dll\";\n",
+    "var an = AssemblyName.GetAssemblyName(tweetyDll);\n",
+    "Console.WriteLine($\"Tweety (IKVM) reference chargee : {an.Name} v{an.Version} ({new FileInfo(tweetyDll).Length / 1024 / 1024:F1} Mo).\");"
    ]
   },
   {
@@ -299,17 +329,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c646116",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:15.140675Z",
-     "iopub.status.busy": "2026-07-02T00:28:15.140197Z",
-     "iopub.status.idle": "2026-07-02T00:28:15.649823Z",
-     "shell.execute_reply": "2026-07-02T00:28:15.649597Z"
+     "iopub.execute_input": "2026-07-03T02:55:50.846952Z",
+     "iopub.status.busy": "2026-07-03T02:55:50.846630Z",
+     "iopub.status.idle": "2026-07-03T02:55:51.447018Z",
+     "shell.execute_reply": "2026-07-03T02:55:51.446719Z"
     }
    },
    "outputs": [
@@ -362,17 +392,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c298429",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:15.651443Z",
-     "iopub.status.busy": "2026-07-02T00:28:15.651111Z",
-     "iopub.status.idle": "2026-07-02T00:28:15.718610Z",
-     "shell.execute_reply": "2026-07-02T00:28:15.718387Z"
+     "iopub.execute_input": "2026-07-03T02:55:51.448776Z",
+     "iopub.status.busy": "2026-07-03T02:55:51.448512Z",
+     "iopub.status.idle": "2026-07-03T02:55:51.553073Z",
+     "shell.execute_reply": "2026-07-03T02:55:51.552803Z"
     }
    },
    "outputs": [
@@ -425,17 +455,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c87284",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:15.720220Z",
-     "iopub.status.busy": "2026-07-02T00:28:15.719999Z",
-     "iopub.status.idle": "2026-07-02T00:28:15.789073Z",
-     "shell.execute_reply": "2026-07-02T00:28:15.788792Z"
+     "iopub.execute_input": "2026-07-03T02:55:51.555002Z",
+     "iopub.status.busy": "2026-07-03T02:55:51.554716Z",
+     "iopub.status.idle": "2026-07-03T02:55:51.664102Z",
+     "shell.execute_reply": "2026-07-03T02:55:51.663827Z"
     }
    },
    "outputs": [
@@ -502,17 +532,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c563412",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:15.790967Z",
-     "iopub.status.busy": "2026-07-02T00:28:15.790743Z",
-     "iopub.status.idle": "2026-07-02T00:28:15.892172Z",
-     "shell.execute_reply": "2026-07-02T00:28:15.891866Z"
+     "iopub.execute_input": "2026-07-03T02:55:51.666086Z",
+     "iopub.status.busy": "2026-07-03T02:55:51.665753Z",
+     "iopub.status.idle": "2026-07-03T02:55:51.748750Z",
+     "shell.execute_reply": "2026-07-03T02:55:51.748442Z"
     }
    },
    "outputs": [
@@ -641,17 +671,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c233858",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:15.894262Z",
-     "iopub.status.busy": "2026-07-02T00:28:15.893979Z",
-     "iopub.status.idle": "2026-07-02T00:28:15.969233Z",
-     "shell.execute_reply": "2026-07-02T00:28:15.968380Z"
+     "iopub.execute_input": "2026-07-03T02:55:51.750894Z",
+     "iopub.status.busy": "2026-07-03T02:55:51.750575Z",
+     "iopub.status.idle": "2026-07-03T02:55:51.955406Z",
+     "shell.execute_reply": "2026-07-03T02:55:51.955127Z"
     }
    },
    "outputs": [
@@ -748,17 +778,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c192121",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:15.971278Z",
-     "iopub.status.busy": "2026-07-02T00:28:15.970974Z",
-     "iopub.status.idle": "2026-07-02T00:28:16.032871Z",
-     "shell.execute_reply": "2026-07-02T00:28:16.032182Z"
+     "iopub.execute_input": "2026-07-03T02:55:51.957350Z",
+     "iopub.status.busy": "2026-07-03T02:55:51.957056Z",
+     "iopub.status.idle": "2026-07-03T02:55:52.024691Z",
+     "shell.execute_reply": "2026-07-03T02:55:52.024409Z"
     }
    },
    "outputs": [
@@ -795,17 +825,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c398942",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:16.035331Z",
-     "iopub.status.busy": "2026-07-02T00:28:16.034785Z",
-     "iopub.status.idle": "2026-07-02T00:28:16.086811Z",
-     "shell.execute_reply": "2026-07-02T00:28:16.086556Z"
+     "iopub.execute_input": "2026-07-03T02:55:52.026926Z",
+     "iopub.status.busy": "2026-07-03T02:55:52.026617Z",
+     "iopub.status.idle": "2026-07-03T02:55:52.109884Z",
+     "shell.execute_reply": "2026-07-03T02:55:52.109588Z"
     }
    },
    "outputs": [
@@ -843,17 +873,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "c559554",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:28:16.088287Z",
-     "iopub.status.busy": "2026-07-02T00:28:16.087984Z",
-     "iopub.status.idle": "2026-07-02T00:28:16.118664Z",
-     "shell.execute_reply": "2026-07-02T00:28:16.118429Z"
+     "iopub.execute_input": "2026-07-03T02:55:52.111906Z",
+     "iopub.status.busy": "2026-07-03T02:55:52.111595Z",
+     "iopub.status.idle": "2026-07-03T02:55:52.163238Z",
+     "shell.execute_reply": "2026-07-03T02:55:52.162925Z"
     }
    },
    "outputs": [
@@ -921,7 +951,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Aspic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Aspic-Csharp.ipynb
@@ -75,10 +75,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:03.652528Z",
-     "iopub.status.busy": "2026-07-02T00:49:03.647670Z",
-     "iopub.status.idle": "2026-07-02T00:49:04.446472Z",
-     "shell.execute_reply": "2026-07-02T00:49:04.444658Z"
+     "iopub.execute_input": "2026-07-03T02:56:01.049671Z",
+     "iopub.status.busy": "2026-07-03T02:56:01.039675Z",
+     "iopub.status.idle": "2026-07-03T02:56:03.329709Z",
+     "shell.execute_reply": "2026-07-03T02:56:03.322122Z"
     }
    },
    "outputs": [
@@ -87,7 +87,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-20872.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -132,12 +132,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.46:2048/\", \"http://172.30.224.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::7d45:cacc:b8c8:f231%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '20872.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '249600.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -223,10 +223,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:04.448723Z",
-     "iopub.status.busy": "2026-07-02T00:49:04.448274Z",
-     "iopub.status.idle": "2026-07-02T00:49:05.020738Z",
-     "shell.execute_reply": "2026-07-02T00:49:05.019998Z"
+     "iopub.execute_input": "2026-07-03T02:56:03.332986Z",
+     "iopub.status.busy": "2026-07-03T02:56:03.332610Z",
+     "iopub.status.idle": "2026-07-03T02:56:05.014088Z",
+     "shell.execute_reply": "2026-07-03T02:56:05.013738Z"
     }
    },
    "outputs": [
@@ -277,16 +277,46 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:05.022126Z",
-     "iopub.status.busy": "2026-07-02T00:49:05.021937Z",
-     "iopub.status.idle": "2026-07-02T00:49:05.042311Z",
-     "shell.execute_reply": "2026-07-02T00:49:05.041699Z"
+     "iopub.execute_input": "2026-07-03T02:56:05.016317Z",
+     "iopub.status.busy": "2026-07-03T02:56:05.015927Z",
+     "iopub.status.idle": "2026-07-03T02:56:05.051444Z",
+     "shell.execute_reply": "2026-07-03T02:56:05.051111Z"
     }
    },
    "outputs": [],
    "source": [
     "#r \"org.tweetyproject.tweety-aspic.dll\"\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7dc5dde1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T02:56:05.053491Z",
+     "iopub.status.busy": "2026-07-03T02:56:05.053156Z",
+     "iopub.status.idle": "2026-07-03T02:56:05.224539Z",
+     "shell.execute_reply": "2026-07-03T02:56:05.224281Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tweety (IKVM) reference chargee : org.tweetyproject.tweety-aspic v1.30.0.0 (8,0 Mo).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Constat 3 (#5039) : la directive #r est silencieuse par defaut en .NET Interactive.\n",
+    "// On verifie que la DLL IKVM/Tweety referencee est bien presente et lisible (metadata).\n",
+    "using System.Reflection;\n",
+    "var tweetyDll = \"org.tweetyproject.tweety-aspic.dll\";\n",
+    "var an = AssemblyName.GetAssemblyName(tweetyDll);\n",
+    "Console.WriteLine($\"Tweety (IKVM) reference chargee : {an.Name} v{an.Version} ({new FileInfo(tweetyDll).Length / 1024 / 1024:F1} Mo).\");"
    ]
   },
   {
@@ -316,17 +346,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c510136",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:05.043996Z",
-     "iopub.status.busy": "2026-07-02T00:49:05.043562Z",
-     "iopub.status.idle": "2026-07-02T00:49:05.713730Z",
-     "shell.execute_reply": "2026-07-02T00:49:05.713427Z"
+     "iopub.execute_input": "2026-07-03T02:56:05.226305Z",
+     "iopub.status.busy": "2026-07-03T02:56:05.226034Z",
+     "iopub.status.idle": "2026-07-03T02:56:06.183332Z",
+     "shell.execute_reply": "2026-07-03T02:56:06.182374Z"
     }
    },
    "outputs": [
@@ -381,17 +411,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c776727",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:05.715188Z",
-     "iopub.status.busy": "2026-07-02T00:49:05.715002Z",
-     "iopub.status.idle": "2026-07-02T00:49:05.787181Z",
-     "shell.execute_reply": "2026-07-02T00:49:05.786659Z"
+     "iopub.execute_input": "2026-07-03T02:56:06.186089Z",
+     "iopub.status.busy": "2026-07-03T02:56:06.185598Z",
+     "iopub.status.idle": "2026-07-03T02:56:06.284926Z",
+     "shell.execute_reply": "2026-07-03T02:56:06.284549Z"
     }
    },
    "outputs": [
@@ -443,17 +473,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c371148",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:05.789018Z",
-     "iopub.status.busy": "2026-07-02T00:49:05.788586Z",
-     "iopub.status.idle": "2026-07-02T00:49:05.879273Z",
-     "shell.execute_reply": "2026-07-02T00:49:05.879097Z"
+     "iopub.execute_input": "2026-07-03T02:56:06.287128Z",
+     "iopub.status.busy": "2026-07-03T02:56:06.286802Z",
+     "iopub.status.idle": "2026-07-03T02:56:06.503430Z",
+     "shell.execute_reply": "2026-07-03T02:56:06.502861Z"
     }
    },
    "outputs": [
@@ -542,17 +572,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c71105",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:05.880952Z",
-     "iopub.status.busy": "2026-07-02T00:49:05.880781Z",
-     "iopub.status.idle": "2026-07-02T00:49:05.945431Z",
-     "shell.execute_reply": "2026-07-02T00:49:05.944952Z"
+     "iopub.execute_input": "2026-07-03T02:56:06.507310Z",
+     "iopub.status.busy": "2026-07-03T02:56:06.506688Z",
+     "iopub.status.idle": "2026-07-03T02:56:06.653151Z",
+     "shell.execute_reply": "2026-07-03T02:56:06.652614Z"
     }
    },
    "outputs": [
@@ -629,17 +659,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c143177",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:05.947527Z",
-     "iopub.status.busy": "2026-07-02T00:49:05.947303Z",
-     "iopub.status.idle": "2026-07-02T00:49:06.015466Z",
-     "shell.execute_reply": "2026-07-02T00:49:06.015269Z"
+     "iopub.execute_input": "2026-07-03T02:56:06.656185Z",
+     "iopub.status.busy": "2026-07-03T02:56:06.655654Z",
+     "iopub.status.idle": "2026-07-03T02:56:06.877511Z",
+     "shell.execute_reply": "2026-07-03T02:56:06.877226Z"
     }
    },
    "outputs": [
@@ -775,17 +805,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c559284",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:06.017247Z",
-     "iopub.status.busy": "2026-07-02T00:49:06.016795Z",
-     "iopub.status.idle": "2026-07-02T00:49:06.076479Z",
-     "shell.execute_reply": "2026-07-02T00:49:06.076125Z"
+     "iopub.execute_input": "2026-07-03T02:56:06.880103Z",
+     "iopub.status.busy": "2026-07-03T02:56:06.879600Z",
+     "iopub.status.idle": "2026-07-03T02:56:06.946164Z",
+     "shell.execute_reply": "2026-07-03T02:56:06.945648Z"
     }
    },
    "outputs": [
@@ -826,17 +856,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c652505",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:06.078278Z",
-     "iopub.status.busy": "2026-07-02T00:49:06.078064Z",
-     "iopub.status.idle": "2026-07-02T00:49:06.133409Z",
-     "shell.execute_reply": "2026-07-02T00:49:06.133089Z"
+     "iopub.execute_input": "2026-07-03T02:56:06.948870Z",
+     "iopub.status.busy": "2026-07-03T02:56:06.948365Z",
+     "iopub.status.idle": "2026-07-03T02:56:07.022344Z",
+     "shell.execute_reply": "2026-07-03T02:56:07.022033Z"
     }
    },
    "outputs": [
@@ -878,17 +908,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "c816344",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-02T00:49:06.135263Z",
-     "iopub.status.busy": "2026-07-02T00:49:06.135030Z",
-     "iopub.status.idle": "2026-07-02T00:49:06.171147Z",
-     "shell.execute_reply": "2026-07-02T00:49:06.170967Z"
+     "iopub.execute_input": "2026-07-03T02:56:07.024703Z",
+     "iopub.status.busy": "2026-07-03T02:56:07.024231Z",
+     "iopub.status.idle": "2026-07-03T02:56:07.083734Z",
+     "shell.execute_reply": "2026-07-03T02:56:07.083257Z"
     }
    },
    "outputs": [
@@ -962,7 +992,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
@@ -58,10 +58,10 @@
    "id": "ikvm-ref",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:06.068100Z",
-     "iopub.status.busy": "2026-07-02T12:23:06.057287Z",
-     "iopub.status.idle": "2026-07-02T12:23:06.825581Z",
-     "shell.execute_reply": "2026-07-02T12:23:06.823368Z"
+     "iopub.execute_input": "2026-07-03T02:56:17.803330Z",
+     "iopub.status.busy": "2026-07-03T02:56:17.793474Z",
+     "iopub.status.idle": "2026-07-03T02:56:19.762331Z",
+     "shell.execute_reply": "2026-07-03T02:56:19.755968Z"
     }
    },
    "outputs": [
@@ -70,7 +70,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-13036.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -115,12 +115,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.47:2048/\", \"http://172.30.224.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::7d45:cacc:b8c8:f231%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '13036.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '249948.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -202,10 +202,10 @@
    "id": "ikvm-home",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:06.828576Z",
-     "iopub.status.busy": "2026-07-02T12:23:06.827586Z",
-     "iopub.status.idle": "2026-07-02T12:23:07.674189Z",
-     "shell.execute_reply": "2026-07-02T12:23:07.672787Z"
+     "iopub.execute_input": "2026-07-03T02:56:19.764755Z",
+     "iopub.status.busy": "2026-07-03T02:56:19.764472Z",
+     "iopub.status.idle": "2026-07-03T02:56:21.445646Z",
+     "shell.execute_reply": "2026-07-03T02:56:21.445197Z"
     }
    },
    "outputs": [
@@ -269,15 +269,44 @@
    "id": "load-dll",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:07.676329Z",
-     "iopub.status.busy": "2026-07-02T12:23:07.676329Z",
-     "iopub.status.idle": "2026-07-02T12:23:07.702934Z",
-     "shell.execute_reply": "2026-07-02T12:23:07.701943Z"
+     "iopub.execute_input": "2026-07-03T02:56:21.448359Z",
+     "iopub.status.busy": "2026-07-03T02:56:21.447877Z",
+     "iopub.status.idle": "2026-07-03T02:56:21.490857Z",
+     "shell.execute_reply": "2026-07-03T02:56:21.490099Z"
     }
    },
    "outputs": [],
    "source": [
     "#r \"org.tweetyproject.tweety-beliefdynamics.dll\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T02:56:21.493632Z",
+     "iopub.status.busy": "2026-07-03T02:56:21.493064Z",
+     "iopub.status.idle": "2026-07-03T02:56:21.597928Z",
+     "shell.execute_reply": "2026-07-03T02:56:21.597579Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tweety (IKVM) reference chargee : org.tweetyproject.tweety-beliefdynamics v1.30.0.0 (9,0 Mo).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Constat 3 (#5039) : la directive #r est silencieuse par defaut en .NET Interactive.\n",
+    "// On verifie que la DLL IKVM/Tweety referencee est bien presente et lisible (metadata).\n",
+    "using System.Reflection;\n",
+    "var tweetyDll = \"org.tweetyproject.tweety-beliefdynamics.dll\";\n",
+    "var an = AssemblyName.GetAssemblyName(tweetyDll);\n",
+    "Console.WriteLine($\"Tweety (IKVM) reference chargee : {an.Name} v{an.Version} ({new FileInfo(tweetyDll).Length / 1024 / 1024:F1} Mo).\");"
    ]
   },
   {
@@ -295,14 +324,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "incoherent",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:07.704942Z",
-     "iopub.status.busy": "2026-07-02T12:23:07.704942Z",
-     "iopub.status.idle": "2026-07-02T12:23:08.338610Z",
-     "shell.execute_reply": "2026-07-02T12:23:08.338610Z"
+     "iopub.execute_input": "2026-07-03T02:56:21.600119Z",
+     "iopub.status.busy": "2026-07-03T02:56:21.599756Z",
+     "iopub.status.idle": "2026-07-03T02:56:22.427306Z",
+     "shell.execute_reply": "2026-07-03T02:56:22.426943Z"
     }
    },
    "outputs": [
@@ -398,14 +427,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "contraction",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:08.338610Z",
-     "iopub.status.busy": "2026-07-02T12:23:08.338610Z",
-     "iopub.status.idle": "2026-07-02T12:23:08.491109Z",
-     "shell.execute_reply": "2026-07-02T12:23:08.491109Z"
+     "iopub.execute_input": "2026-07-03T02:56:22.430132Z",
+     "iopub.status.busy": "2026-07-03T02:56:22.429624Z",
+     "iopub.status.idle": "2026-07-03T02:56:22.580769Z",
+     "shell.execute_reply": "2026-07-03T02:56:22.580001Z"
     }
    },
    "outputs": [
@@ -481,14 +510,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "levi",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:08.494108Z",
-     "iopub.status.busy": "2026-07-02T12:23:08.493107Z",
-     "iopub.status.idle": "2026-07-02T12:23:08.598337Z",
-     "shell.execute_reply": "2026-07-02T12:23:08.598337Z"
+     "iopub.execute_input": "2026-07-03T02:56:22.583647Z",
+     "iopub.status.busy": "2026-07-03T02:56:22.583227Z",
+     "iopub.status.idle": "2026-07-03T02:56:22.718078Z",
+     "shell.execute_reply": "2026-07-03T02:56:22.717753Z"
     }
    },
    "outputs": [
@@ -570,14 +599,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "guided",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:08.600345Z",
-     "iopub.status.busy": "2026-07-02T12:23:08.600345Z",
-     "iopub.status.idle": "2026-07-02T12:23:08.760045Z",
-     "shell.execute_reply": "2026-07-02T12:23:08.760045Z"
+     "iopub.execute_input": "2026-07-03T02:56:22.720189Z",
+     "iopub.status.busy": "2026-07-03T02:56:22.719872Z",
+     "iopub.status.idle": "2026-07-03T02:56:22.908278Z",
+     "shell.execute_reply": "2026-07-03T02:56:22.907798Z"
     }
    },
    "outputs": [
@@ -715,14 +744,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "ex1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:08.762032Z",
-     "iopub.status.busy": "2026-07-02T12:23:08.762032Z",
-     "iopub.status.idle": "2026-07-02T12:23:08.825629Z",
-     "shell.execute_reply": "2026-07-02T12:23:08.825629Z"
+     "iopub.execute_input": "2026-07-03T02:56:22.910569Z",
+     "iopub.status.busy": "2026-07-03T02:56:22.910261Z",
+     "iopub.status.idle": "2026-07-03T02:56:23.019108Z",
+     "shell.execute_reply": "2026-07-03T02:56:23.018753Z"
     }
    },
    "outputs": [
@@ -749,14 +778,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "ex2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:08.836601Z",
-     "iopub.status.busy": "2026-07-02T12:23:08.825629Z",
-     "iopub.status.idle": "2026-07-02T12:23:08.901974Z",
-     "shell.execute_reply": "2026-07-02T12:23:08.901974Z"
+     "iopub.execute_input": "2026-07-03T02:56:23.020977Z",
+     "iopub.status.busy": "2026-07-03T02:56:23.020674Z",
+     "iopub.status.idle": "2026-07-03T02:56:23.074817Z",
+     "shell.execute_reply": "2026-07-03T02:56:23.074488Z"
     }
    },
    "outputs": [
@@ -782,14 +811,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "ex3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T12:23:08.903990Z",
-     "iopub.status.busy": "2026-07-02T12:23:08.903990Z",
-     "iopub.status.idle": "2026-07-02T12:23:08.938840Z",
-     "shell.execute_reply": "2026-07-02T12:23:08.938840Z"
+     "iopub.execute_input": "2026-07-03T02:56:23.076858Z",
+     "iopub.status.busy": "2026-07-03T02:56:23.076522Z",
+     "iopub.status.idle": "2026-07-03T02:56:23.140389Z",
+     "shell.execute_reply": "2026-07-03T02:56:23.140064Z"
     }
    },
    "outputs": [
@@ -826,7 +855,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Scope — #5039 Constat 3

The 6 `.net-csharp` Tweety notebooks each had exactly **1 code cell without output** — the `#r "org.tweetyproject.tweety-*.dll"` directive cell (`ec=3, outputs=[]`). This is **normal** (directives are silent in .NET Interactive) but Constat 3 of #5039 asked for an explicit confirmation print so the reader sees the IKVM/Tweety runtime load.

## Fix

Inserted a uniform confirmation cell immediately after each `#r` cell. The cell reads the referenced DLL metadata via `AssemblyName.GetAssemblyName` (metadata-only read — no execution-context load, no `GetTypes` fragility) and prints name + version + size:

```
Tweety (IKVM) reference chargee : org.tweetyproject.tweety-pl v1.30.0.0 (7,0 Mo).
```

## Design note (G.1 — why not introspect the AppDomain?)

`AppDomain.CurrentDomain.GetAssemblies()` **and** `AssemblyLoadContext.All` both return **0** for `#r "dll"` references. The assembly loads as a compiler `MetadataReference`, lazily materialized only on first type touch — so runtime introspection is misleading (would print "0 assembly" while downstream cells use Tweety types fine, e.g. `new Proposition("a")`). `AssemblyName.GetAssemblyName(path)` reads the DLL metadata directly = **honest + robust + uniform** (dll name extracted from the `#r` cell itself, no per-DLL type knowledge needed).

## Validation (H.1 reelle, not C.2-exempt — code cell added)

All 6 notebooks **re-executed end-to-end** via `jupyter nbconvert --execute --inplace` (kernel `.net-csharp`, IKVM/Tweety DLLs present locally; nbconvert **not** MCP Jupyter to avoid #835 hang). Per-notebook verification (script-backed):

| Notebook | DLL | Output | ec monotone | errors | cells |
|----------|-----|--------|-------------|--------|-------|
| Tweety-2-Basic-Logics-Csharp | tweety-pl v1.30.0.0 (7,0 Mo) | ✓ | ✓ | 0 | +1 -0 |
| Tweety-2b-Semantics-Csharp | tweety-pl v1.30.0.0 (7,0 Mo) | ✓ | ✓ | 0 | +1 -0 |
| Tweety-2c-FOL-Csharp | tweety-pl v1.30.0.0 (7,0 Mo) | ✓ | ✓ | 0 | +1 -0 |
| Tweety-3-Dung-Csharp | tweety-dung v1.30.0.0 (8,0 Mo) | ✓ | ✓ | 0 | +1 -0 |
| Tweety-4-Aspic-Csharp | tweety-aspic v1.30.0.0 (8,0 Mo) | ✓ | ✓ | 0 | +1 -0 |
| Tweety-4-Belief-Revision-Csharp | tweety-beliefdynamics v1.30.0.0 (9,0 Mo) | ✓ | ✓ | 0 | +1 -0 |

`grep -nE "raise NotImplementedError|assert False|1/0"` = 0 (C.1 respected; stubs untouched). No exercise/example re-labeling (exercise-example-labeling.md). Insertion via surgical `nbformat` script (**not** NotebookEdit — which flattens source + strips outputs on code cells per dashboard memory).

## Context

`See #5039` — Constat 3 = last acceptance criterion. Constats 1+2 (Tweety-5 answer-leak reorder + Tweety-7b kernelspec) done by **#5042** (MERGED). Tweety-5 orphan-intro by **#5109** (OPEN CLEAN, complementary, no collision — different notebook region). #5039 closeable once #5109 also merges.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
