### PR TITLE
docs(lean-i18n): sensitivity_lean docstrings bilingues FR+EN (#4980 etape 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity.lean
@@ -5,6 +5,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
   Patrick Massot
 
+Portage de mathlib4/Archive/Sensitivity.lean vers un workspace Lake autonome.
+Théorème de sensibilité de Huang : dans l'hypercube de dimension n ≥ 1, si l'on
+colorie plus de la moitié des sommets, alors au moins un sommet possède au moins
+√n voisins coloriés.
+
+---
+English:
 Port of mathlib4/Archive/Sensitivity.lean to standalone Lake workspace.
 Huang's sensitivity theorem: in the hypercube of dimension n >= 1, if one
 colors more than half the vertices then at least one vertex has at least

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Hypercube.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Hypercube.lean
@@ -12,6 +12,12 @@ import Mathlib.Analysis.Real.Sqrt
 import Mathlib.Tactic.FinCases
 
 /-!
+# L'hypercube pour le théorème de sensibilité de Huang
+
+Ce fichier définit l'hypercube `Q n = Fin n → Bool` et sa relation d'adjacence.
+
+---
+English:
 # The hypercube for Huang's sensitivity theorem
 
 This file defines the hypercube `Q n = Fin n → Bool` and its adjacency relation.
@@ -24,6 +30,15 @@ noncomputable section
 open Bool Finset Fintype
 
 /-!
+### L'hypercube
+
+Notations :
+- `ℕ` désigne les entiers naturels (zéro inclus).
+- `Fin n` = {0, ⋯ , n - 1}.
+- `Bool` = {`true`, `false`}.
+
+---
+English:
 ### The hypercube
 
 Notations:
@@ -33,11 +48,14 @@ Notations:
 -/
 
 
-/-- The hypercube in dimension `n`. -/
+/-- L'hypercube en dimension `n`.
+    English: The hypercube in dimension `n`. -/
 abbrev Q (n : ℕ) :=
   Fin n → Bool
 
-/-- The projection from `Q n.succ` to `Q n` forgetting the first value
+/-- La projection de `Q n.succ` vers `Q n` oubliant la première valeur
+(c'est-à-dire l'image de zéro).
+    English: The projection from `Q n.succ` to `Q n` forgetting the first value
 (i.e. the image of zero). -/
 def π {n : ℕ} : Q n.succ → Q n := fun p => p ∘ Fin.succ
 
@@ -48,11 +66,13 @@ theorem ext {n} {f g : Q n} (h : ∀ x, f x = g x) : f = g := funext h
 
 variable (n : ℕ)
 
-/-- `Q 0` has a unique element. -/
+/-- `Q 0` possède un unique élément.
+    English: `Q 0` has a unique element. -/
 instance : Unique (Q 0) :=
   ⟨⟨fun _ => true⟩, by intro; ext x; fin_cases x⟩
 
-/-- `Q n` has 2^n elements. -/
+/-- `Q n` possède 2^n éléments.
+    English: `Q n` has 2^n elements. -/
 theorem card : Fintype.card (Q n) = 2 ^ n := by simp
 
 variable {n}
@@ -67,14 +87,19 @@ theorem succ_n_eq (p q : Q n.succ) : p = q ↔ p 0 = q 0 ∧ π p = π q := by
     · rw [← Fin.succ_pred x hx]
       convert congr_fun h (Fin.pred x hx)
 
-/-- The adjacency relation defining the graph structure on `Q n`:
+/-- La relation d'adjacence définissant la structure de graphe sur `Q n` :
+`p.adjacent q` s'il existe une arête de `p` vers `q` dans `Q n`.
+    English: The adjacency relation defining the graph structure on `Q n`:
 `p.adjacent q` if there is an edge from `p` to `q` in `Q n`. -/
 def adjacent {n : ℕ} (p : Q n) : Set (Q n) := { q | ∃! i, p i ≠ q i }
 
-/-- In `Q 0`, no two vertices are adjacent. -/
+/-- Dans `Q 0`, aucun couple de sommets n'est adjacent.
+    English: In `Q 0`, no two vertices are adjacent. -/
 theorem not_adjacent_zero (p q : Q 0) : q ∉ p.adjacent := by rintro ⟨v, _⟩; apply finZeroElim v
 
-/-- If `p` and `q` in `Q n.succ` have different values at zero then they are adjacent
+/-- Si `p` et `q` dans `Q n.succ` ont des valeurs différentes en zéro, alors ils sont
+adjacents ssi leurs projections sur `Q n` sont égales.
+    English: If `p` and `q` in `Q n.succ` have different values at zero then they are adjacent
 iff their projections to `Q n` are equal. -/
 theorem adj_iff_proj_eq {p q : Q n.succ} (h₀ : p 0 ≠ q 0) : q ∈ p.adjacent ↔ π p = π q := by
   constructor
@@ -89,7 +114,9 @@ theorem adj_iff_proj_eq {p q : Q n.succ} (h₀ : p 0 ≠ q 0) : q ∈ p.adjacent
     rw [← Fin.succ_pred _ hy]
     apply congr_fun heq
 
-/-- If `p` and `q` in `Q n.succ` have the same value at zero then they are adjacent
+/-- Si `p` et `q` dans `Q n.succ` ont la même valeur en zéro, alors ils sont adjacents
+ssi leurs projections sur `Q n` sont adjacentes.
+    English: If `p` and `q` in `Q n.succ` have the same value at zero then they are adjacent
 iff their projections to `Q n` are adjacent. -/
 theorem adj_iff_proj_adj {p q : Q n.succ} (h₀ : p 0 = q 0) :
     q ∈ p.adjacent ↔ π q ∈ (π p).adjacent := by

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/MainTheorem.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/MainTheorem.lean
@@ -12,6 +12,14 @@ import Mathlib.Tactic.ApplyFun
 import Mathlib.Tactic.FinCases
 
 /-!
+# Théorème de sensibilité de Huang (résultat principal)
+
+Ce fichier prouve le théorème principal : dans l'hypercube de dimension n ≥ 1,
+si l'on colorie plus de la moitié des sommets, alors au moins un sommet possède
+au moins √n voisins coloriés.
+
+---
+English:
 # Huang's sensitivity theorem (main result)
 
 This file proves the main theorem: in the hypercube of dimension n ≥ 1,
@@ -38,6 +46,13 @@ local notation "Card " X:70 => Finset.card (Set.toFinset X)
 variable {m : ℕ}
 
 /-!
+### La preuve principale
+
+Dans cette section, afin d'imposer que `n` soit strictement positif, nous l'écrivons
+sous la forme `m + 1` pour un certain entier naturel `m`.
+
+---
+English:
 ### The main proof
 
 In this section, in order to enforce that `n` is positive, we write it as
@@ -45,7 +60,10 @@ In this section, in order to enforce that `n` is positive, we write it as
 
 
 open Classical in
-/-- If a subset `H` of `Q (m+1)` has cardinal at least `2^m + 1` then the
+/-- Si une partie `H` de `Q (m+1)` a un cardinal au moins `2^m + 1`, alors le
+sous-espace de `V (m+1)` engendré par les vecteurs de base correspondants intersecte
+non trivialement l'image de `g m`.
+    English: If a subset `H` of `Q (m+1)` has cardinal at least `2^m + 1` then the
 subspace of `V (m+1)` spanned by the corresponding basis vectors non-trivially
 intersects the range of `g m`. -/
 theorem exists_eigenvalue (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
@@ -80,7 +98,8 @@ theorem exists_eigenvalue (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
   linarith
 
 open Classical in
-/-- **Huang sensitivity theorem** also known as the **Huang degree theorem** -/
+/-- **Théorème de sensibilité de Huang** également connu sous le nom de **théorème du degré de Huang**.
+    English: **Huang sensitivity theorem** also known as the **Huang degree theorem** -/
 theorem huang_degree_theorem (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
     ∃ q, q ∈ H ∧ √(m + 1) ≤ Card H ∩ q.adjacent := by
   rcases exists_eigenvalue H hH with ⟨y, ⟨⟨y_mem_H, y_mem_g⟩, y_ne⟩⟩

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Operator.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Operator.lean
@@ -10,6 +10,13 @@ Port of mathlib4/Archive/Sensitivity.lean to standalone Lake workspace.
 import Sensitivity.VectorSpace
 
 /-!
+# Opérateurs linéaires pour le théorème de sensibilité de Huang
+
+Ce fichier définit les opérateurs linéaires `f` (matrice de Huang) et `g` (matrice de Knuth),
+et prouve les propriétés clés : f² = n·id, injectivité de g, et la relation d'image.
+
+---
+English:
 # Linear operators for Huang's sensitivity theorem
 
 This file defines the linear operators `f` (Huang's matrix) and `g` (Knuth's matrix),
@@ -26,10 +33,14 @@ local notation "√" => Real.sqrt
 
 variable {n : ℕ}
 
-/-! ### The linear map -/
+/-! ### L'application linéaire
+
+English: The linear map -/
 
 
-/-- The linear operator $f_n$ corresponding to Huang's matrix $A_n$,
+/-- L'opérateur linéaire $f_n$ correspondant à la matrice $A_n$ de Huang,
+défini inductivement comme une application ℝ-linéaire de `V n` vers `V n`.
+    English: The linear operator $f_n$ corresponding to Huang's matrix $A_n$,
 defined inductively as a ℝ-linear map from `V n` to `V n`. -/
 noncomputable def f : ∀ n, V n →ₗ[ℝ] V n
   | 0 => 0
@@ -70,7 +81,8 @@ theorem f_matrix (p q : Q n) : |ε q (f n (e p))| = if p ∈ q.adjacent then 1 e
       simp [hp, hq, IH, duality, abs_of_nonneg ite_nonneg, Q.adj_iff_proj_eq,
         Q.adj_iff_proj_adj]
 
-/-- The linear operator $g_m$ corresponding to Knuth's matrix $B_m$. -/
+/-- L'opérateur linéaire $g_m$ correspondant à la matrice $B_m$ de Knuth.
+    English: The linear operator $g_m$ corresponding to Knuth's matrix $B_m$. -/
 noncomputable def g (m : ℕ) : V m →ₗ[ℝ] V m.succ :=
   LinearMap.prod (f m + √(m + 1) • LinearMap.id) LinearMap.id
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/VectorSpace.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/VectorSpace.lean
@@ -13,6 +13,13 @@ import Mathlib.LinearAlgebra.Dual.Lemmas
 import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 
 /-!
+# Espace vectoriel pour le théorème de sensibilité de Huang
+
+Ce fichier définit l'espace vectoriel libre `V n` sur les sommets de l'hypercube,
+la base `e`, la base duale `ε`, et prouve les résultats de dualité et de dimension.
+
+---
+English:
 # Vector space for Huang's sensitivity theorem
 
 This file defines the free vector space `V n` on vertices of the hypercube,
@@ -27,10 +34,13 @@ open Function LinearMap Module Module.DualBases
 
 local notation "√" => Real.sqrt
 
-/-! ### The vector space -/
+/-! ### L'espace vectoriel
+
+English: The vector space -/
 
 
-/-- The free vector space on vertices of a hypercube, defined inductively. -/
+/-- L'espace vectoriel libre sur les sommets d'un hypercube, défini inductivement.
+    English: The free vector space on vertices of a hypercube, defined inductively. -/
 def V : ℕ → Type
   | 0 => ℝ
   | n + 1 => V n × V n
@@ -57,7 +67,8 @@ instance : Module ℝ (V n) := by induction n <;> · dsimp only [V]; infer_insta
 
 end V
 
-/-- The basis of `V` indexed by the hypercube, defined inductively. -/
+/-- La base de `V` indexée par l'hypercube, définie inductivement.
+    English: The basis of `V` indexed by the hypercube, defined inductively. -/
 noncomputable def e : ∀ {n}, Q n → V n
   | 0 => fun _ => (1 : ℝ)
   | Nat.succ _ => fun x => cond (x 0) (e (π x), 0) (0, e (π x))
@@ -66,7 +77,8 @@ noncomputable def e : ∀ {n}, Q n → V n
 theorem e_zero_apply (x : Q 0) : e x = (1 : ℝ) :=
   rfl
 
-/-- The dual basis to `e`, defined inductively. -/
+/-- La base duale de `e`, définie inductivement.
+    English: The dual basis to `e`, defined inductively. -/
 noncomputable def ε : ∀ {n : ℕ}, Q n → V n →ₗ[ℝ] ℝ
   | 0, _ => LinearMap.id
   | Nat.succ _, p =>
@@ -87,7 +99,8 @@ theorem duality (p q : Q n) : ε p (e q) = if p = q then 1 else 0 := by
         LinearMap.comp_apply, IH]
       congr 1; simp [Q.succ_n_eq, hp, hq]
 
-/-- Any vector in `V n` annihilated by all `ε p`'s is zero. -/
+/-- Tout vecteur de `V n` annulé par tous les `ε p` est nul.
+    English: Any vector in `V n` annihilated by all `ε p`'s is zero. -/
 theorem epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 := by
   induction n with
   | zero => dsimp [ε] at h; exact h fun _ => true
@@ -106,7 +119,8 @@ theorem epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 := by
 open Module
 
 open Classical in
-/-- `e` and `ε` are dual families of vectors. -/
+/-- `e` et `ε` sont des familles duales de vecteurs.
+    English: `e` and `ε` are dual families of vectors. -/
 theorem dualBases_e_ε (n : ℕ) : DualBases (@e n) (@ε n) where
   eval_same := by simp [duality]
   eval_of_ne _ _ h := by simp [duality, h]


### PR DESCRIPTION
## Scope

Étape 2 du rollout **#4980** (i18n des fichiers `.lean`, décision user 02/07/2026, **Option A** = docstrings bilingues FR+EN inline). Suite de conway_cgt (#5085) et calibration_lean (#5112).

`sensitivity_lean` = port de `mathlib4/Archive/Sensitivity.lean` (théorème de sensibilité de Huang) vers un workspace Lake autonome. 5 fichiers `.lean`, 100% EN. **Single-`require mathlib`**, toolchain rc1, mathlib junctioné au cache canonique cluster `d568c8c0` → build clean.

## Convention Option A appliquée

| Type de commentaire | Traitement |
|---------------------|------------|
| Section docstrings `/-! # / ###` | Bilingue : FR d'abord + `---` + `English:` |
| Déclaration docstrings `/-- ... -/` | Bilingue : FR d'abord + `English:` |
| **Copyright header Apache 2.0** (Reid Barton et al.) | **GARDÉ VERBATIM** (attribution légale, non traduit) |
| Identifiants (`def`/`theorem`/noms) | **Inchangés** |

## Anti-régression — preuve structurelle (lean-merge-discipline §1)

Vérification automatisée (script, comments strippés Lean-aware : blocs `/- -/` imbriqués + lignes `--`) :

| Fichier | Code byte-identique (origin/main vs working) | Délimiteurs `/-`==`-/` | sorry réel |
|---------|----------------------------------------------|------------------------|------------|
| Sensitivity.lean | ✅ True | 1/1 ✅ | 0 → 0 ✅ |
| Hypercube.lean | ✅ True | 11/11 ✅ | 0 → 0 ✅ |
| VectorSpace.lean | ✅ True | 8/8 ✅ | 0 → 0 ✅ |
| Operator.lean | ✅ True | 5/5 ✅ | 0 → 0 ✅ |
| MainTheorem.lean | ✅ True | 5/5 ✅ | 0 → 0 ✅ |

**L'i18n ne touche QUE les docstrings/commentaires.** Zéro ligne de code modifiée. Ce sont des preuves formelles complètes de Huang (0 sorry) — aucune n'est touchée.

## Build local

`lake build Sensitivity` : **SUCCESS** (Windows-native `lake.exe`, cache rc1 junctioné `d568c8c0`).

## Note transparence

`#4365` marquait sensitivity_lean « RESTE AUTONOME » (cache propre) au 02/07, mais depuis la mutualisation #4363 (19/19 junctioned) l'a rattrapé : son symlink `.lake/packages/mathlib` pointe maintenant vers le cache rc1 canonique `d568c8c0` (vérifié firsthand, 8119 oleans chaud). Build rapide comme calibration. `.lake/` gitignored donc hors diff.

See #4980
