### PR TITLE
fix(sudoku4-csharp): relabel mislabeled "Exemple guide 2" stub -> Exercice 2 (See #4940)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -2988,7 +2988,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : Rechauffement adaptatif\n",
+    "### Exercice 2 : Rechauffement adaptatif\n",
     "\n",
     "Modifiez la classe `SimulatedAnnealingWithReheatSolver` pour implementer un rechauffement **adaptatif** :\n",
     "\n",


### PR DESCRIPTION
## Scope — #4940 Phase 1 criterion 4 (relabeling stubs -> Exercice)

`Sudoku-4-SimulatedAnnealing-Csharp.ipynb` cell[41] markdown title said **"### Exemple guide 2 : Rechauffement adaptatif"**, but the following code cell[42] is a **pure stub** — only comments + `display("Exercice 2 : implementez le rechauffement adaptatif ci-dessus.")`, no implementation body. The stub's own display text contradicted the title by calling itself "Exercice 2".

Per `.claude/rules/exercise-example-labeling.md` case 2 (*"Titre 'Exemple' + cellule code = stub vide => relabeler le titre en Exercice"*): relabeled the title to **"### Exercice 2 : Rechauffement adaptatif"** so title + stub are consistent.

## Classification by CONTENT (anti-#1214 blind find-replace)

Verified each candidate by hand (read the actual code cell):
- **cell[39]/[40] "Exemple guide 1"**: cell[40] has a COMPLETE functional solution (foreach over alphas, `Solve(puzzle)` + timing + display) = legitimate guided example, correctly labeled → **NOT touched**.
- **cell[41]/[42] "Exemple guide 2"**: cell[42] is a pure stub → genuine mislabel → **fixed**.

A repo-wide heuristic scan for "Exemple guide" + pure-stub was run but produced many false positives (e.g. Infer-4 already titled "Exercice", Infer-11 is an interpretation cell, Search/CSP "# Exemple resolu" stubs). Only this cell is a true mislabel in the .NET Sudoku family — each candidate verified by content, no blind find-replace.

## Validation

Markdown-only edit (1 heading line). **C.2-exempt** (markdown-only, no re-execution needed):
- Cell count unchanged (45 → 45)
- Exactly 1 cell source changed (md[41])
- outputs / execution_count byte-identical to origin/main (script-verified)

`See #4940` (Phase 1 criterion 4 — partial; Cas 1-4 Phase 2 already merged via #4961/#4970/#4972/#4969). Diagnostic details on residual Sudoku state posted as issue comment.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
