### PR TITLE
docs(lean-i18n): lean_game_defs docstrings bilingues FR+EN (#4980 étape 2)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Basic.lean
@@ -1,4 +1,16 @@
 /-
+  Définitions fondamentales de la théorie des jeux en Lean 4
+  ==========================================================
+
+  Définit les structures fondamentales des jeux sous forme normale :
+  - NormalFormGame : structure générale de jeu
+  - FiniteGame : jeux à joueurs et actions en nombre fini
+  - Game2x2 : jeux spécialisés à 2 joueurs et 2 actions
+
+  Basé sur GameTheory-16-Lean-Definitions.ipynb
+
+  ---
+  English:
   Basic Game Theory Definitions in Lean 4
   ========================================
 
@@ -10,38 +22,68 @@
   Based on GameTheory-16-Lean-Definitions.ipynb
 -/
 
-/-! ## Normal Form Game -/
+/-!
+## Jeu sous forme normale
 
-/-- A normal-form game with arbitrary player and action sets -/
+---
+English:
+## Normal Form Game
+-/
+
+/-- Un jeu sous forme normale avec des ensembles arbitraires de joueurs et d'actions.
+    English: A normal-form game with arbitrary player and action sets -/
 structure NormalFormGame where
-  /-- Set of players -/
+  /-- Ensemble des joueurs.
+      English: Set of players -/
   Players : Type
-  /-- Set of actions for each player -/
+  /-- Ensemble des actions pour chaque joueur.
+      English: Set of actions for each player -/
   Actions : Players → Type
-  /-- Payoff function for each player -/
+  /-- Fonction de paiement pour chaque joueur.
+      English: Payoff function for each player -/
   payoff : (i : Players) → ((j : Players) → Actions j) → Int
 
-/-! ## Finite Game -/
+/-!
+## Jeu fini
 
-/-- A finite game where players and actions are indexed by Fin types -/
+---
+English:
+## Finite Game
+-/
+
+/-- Un jeu fini où les joueurs et les actions sont indexés par des types `Fin`.
+    English: A finite game where players and actions are indexed by Fin types -/
 structure FiniteGame where
-  /-- Number of players (uses Fin n to have exactly n players) -/
+  /-- Nombre de joueurs (utilise `Fin n` pour avoir exactement n joueurs).
+      English: Number of players (uses Fin n to have exactly n players) -/
   numPlayers : Nat
-  /-- Number of actions for each player -/
+  /-- Nombre d'actions pour chaque joueur.
+      English: Number of actions for each player -/
   numActions : Fin numPlayers → Nat
-  /-- Payoff function: for each player, returns the payoff given action profile -/
+  /-- Fonction de paiement : pour chaque joueur, renvoie le paiement étant donné le profil d'actions.
+      English: Payoff function: for each player, returns the payoff given action profile -/
   payoff : (i : Fin numPlayers) → ((j : Fin numPlayers) → Fin (numActions j)) → Int
 
-/-! ## 2x2 Games -/
+/-!
+## Jeux 2x2
 
-/-- A 2x2 game: 2 players, 2 actions each -/
+---
+English:
+## 2x2 Games
+-/
+
+/-- Un jeu 2x2 : 2 joueurs, 2 actions chacun.
+    English: A 2x2 game: 2 players, 2 actions each -/
 structure Game2x2 where
-  /-- Player 1's payoff matrix (rows) -/
+  /-- Matrice de paiement du joueur 1 (lignes).
+      English: Player 1's payoff matrix (rows) -/
   payoff1 : Fin 2 → Fin 2 → Int
-  /-- Player 2's payoff matrix (columns) -/
+  /-- Matrice de paiement du joueur 2 (colonnes).
+      English: Player 2's payoff matrix (columns) -/
   payoff2 : Fin 2 → Fin 2 → Int
 
-/-- Create a 2x2 game from 8 payoff values -/
+/-- Construit un jeu 2x2 à partir de 8 valeurs de paiement.
+    English: Create a 2x2 game from 8 payoff values -/
 def mkGame2x2 (a11 b11 a12 b12 a21 b21 a22 b22 : Int) : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
@@ -55,36 +97,61 @@ def mkGame2x2 (a11 b11 a12 b12 a21 b21 a22 b22 : Int) : Game2x2 := {
     | _, _ => 0
 }
 
-/-! ## Strategies -/
+/-!
+## Stratégies
 
-/-- A pure strategy is just an action -/
+---
+English:
+## Strategies
+-/
+
+/-- Une stratégie pure est simplement une action.
+    English: A pure strategy is just an action -/
 def PureStrategy (g : FiniteGame) (i : Fin g.numPlayers) := Fin (g.numActions i)
 
-/-- A profile of pure strategies: one strategy per player -/
+/-- Un profil de stratégies pures : une stratégie par joueur.
+    English: A profile of pure strategies: one strategy per player -/
 def PureStrategyProfile (g : FiniteGame) := (i : Fin g.numPlayers) → Fin (g.numActions i)
 
-/-! ## Mixed Strategies (simplified) -/
+/-!
+## Stratégies mixtes (version simplifiée)
 
-/-- Check if a function assigns non-negative values -/
+---
+English:
+## Mixed Strategies (simplified)
+-/
+
+/-- Vérifie si une fonction associe des valeurs non négatives.
+    English: Check if a function assigns non-negative values -/
 def isNonNeg (f : Fin n → Float) : Prop := ∀ i, f i >= 0
 
-/-- Check if probabilities sum to one -/
+/-- Vérifie si les probabilités somment à un.
+    English: Check if probabilities sum to one -/
 def sumToOne (f : Fin n → Float) : Prop :=
   (List.finRange n).foldl (fun acc i => acc + f i) 0 = 1
 
-/-- Mixed strategy profile for 2-player games -/
+/-- Profil de stratégies mixtes pour les jeux à 2 joueurs.
+    English: Mixed strategy profile for 2-player games -/
 structure MixedProfile2 (n1 n2 : Nat) where
   sigma1 : Fin n1 → Float
   sigma2 : Fin n2 → Float
   h1_pos : ∀ i, sigma1 i >= 0 := by decide
   h2_pos : ∀ i, sigma2 i >= 0 := by decide
 
-/-! ## Expected Payoffs -/
+/-!
+## Paiements espérés
 
-/-- Convert Int to Float -/
+---
+English:
+## Expected Payoffs
+-/
+
+/-- Convertit un `Int` en `Float`.
+    English: Convert Int to Float -/
 def intToFloat (n : Int) : Float := Float.ofInt n
 
-/-- Expected payoff for player 1 in a 2x2 game -/
+/-- Paiement espéré du joueur 1 dans un jeu 2x2.
+    English: Expected payoff for player 1 in a 2x2 game -/
 def expectedPayoff1 (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) : Float :=
   let i0 : Fin 2 := ⟨0, by omega⟩
   let i1 : Fin 2 := ⟨1, by omega⟩
@@ -93,7 +160,8 @@ def expectedPayoff1 (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) 
   s1 i1 * s2 i0 * intToFloat (g.payoff1 i1 i0) +
   s1 i1 * s2 i1 * intToFloat (g.payoff1 i1 i1)
 
-/-- Expected payoff for player 2 in a 2x2 game -/
+/-- Paiement espéré du joueur 2 dans un jeu 2x2.
+    English: Expected payoff for player 2 in a 2x2 game -/
 def expectedPayoff2 (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) : Float :=
   let i0 : Fin 2 := ⟨0, by omega⟩
   let i1 : Fin 2 := ⟨1, by omega⟩
@@ -102,6 +170,7 @@ def expectedPayoff2 (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) 
   s1 i1 * s2 i0 * intToFloat (g.payoff2 i1 i0) +
   s1 i1 * s2 i1 * intToFloat (g.payoff2 i1 i1)
 
-/-- Convert a pure strategy to a degenerate mixed strategy -/
+/-- Convertit une stratégie pure en une stratégie mixte dégénérée.
+    English: Convert a pure strategy to a degenerate mixed strategy -/
 def pureToMixed (a : Fin 2) : Fin 2 → Float :=
   fun i => if i == a then 1.0 else 0.0

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Bayesian.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Bayesian.lean
@@ -1,4 +1,23 @@
 /-
+  Définitions de la théorie des jeux bayésienne en Lean 4
+  =======================================================
+
+  Définit les structures pour les jeux à information incomplète (Harsanyi) :
+  - BayesianGame : jeux avec types privés et croyance commune (prior)
+  - TypeStrategy : stratégie conditionnée par le type privé
+  - BayesianNashEquilibrium : concept d'équilibre pour l'info incomplète
+  - SignalingGame : jeux en deux phases (émetteur/récepteur)
+  - InformationSet : partition des nœuds de décision (info imparfaite)
+
+  Basé sur GameTheory-11-BayesianGames.ipynb et
+           GameTheory-13-ImperfectInfo-CFR.ipynb
+
+  Note : ce sont des définitions pédagogiques à but d'enseignement.
+  Pour une formalisation complète, il faudrait la probabilité mesurée
+  et les espaces mesurables de Mathlib.
+
+  ---
+  English:
   Bayesian Game Theory Definitions in Lean 4
   ============================================
 
@@ -19,64 +38,121 @@
 
 import Basic
 
-/-! ## Utility (avoids Mathlib dependency) -/
+/-!
+## Utilitaires (évite la dépendance Mathlib)
 
-/-- Update a dependent function at a given index.
+---
+English:
+## Utility (avoids Mathlib dependency)
+-/
+
+/-- Met à jour une fonction dépendante à un indice donné.
+    Équivalent au `Function.update` de Mathlib mais autonome.
+    Utilise l'égalité décidable sur `Fin` pour la comparaison.
+    English: Update a dependent function at a given index.
     Equivalent to Mathlib's `Function.update` but self-contained.
     Uses `Fin` decidable equality for comparison. -/
 def funUpdate {n : Nat} {β : Fin n → Type} (f : (i : Fin n) → β i)
     (i : Fin n) (x : β i) : (j : Fin n) → β j :=
   fun j => if h : j = i then h ▸ x else f j
 
-/-! ## Type Spaces and Beliefs -/
+/-!
+## Espaces de types et croyances
 
-/-- A type space for a player: the set of possible private types -/
+---
+English:
+## Type Spaces and Beliefs
+-/
+
+/-- Un espace de types pour un joueur : l'ensemble des types privés possibles.
+    English: A type space for a player: the set of possible private types -/
 def TypeSpace (α : Type) := List α
 
-/-- A common prior over type profiles (simplified: uniform weights) -/
+/-- Une croyance commune (prior) sur les profils de types (simplifié : poids uniformes).
+    English: A common prior over type profiles (simplified: uniform weights) -/
 structure CommonPrior (T : Type) (n : Nat) where
-  /-- Possible type profiles: list of n-tuples -/
+  /-- Profils de types possibles : liste de n-uplets.
+      English: Possible type profiles: list of n-tuples -/
   typeProfiles : List (Fin n → T)
-  /-- Probability of each profile (simplified as rational weight) -/
+  /-- Probabilité de chaque profil (simplifiée en poids rationnel).
+      English: Probability of each profile (simplified as rational weight) -/
   weights : List Nat
-  /-- Weights sum to 100 (scaled probabilities) -/
+  /-- Les poids somment à 100 (probabilités mises à l'échelle).
+      English: Weights sum to 100 (scaled probabilities) -/
   weightsSum100 : weights.sum = 100 := by decide
 
-/-! ## Bayesian Game Structure -/
+/-!
+## Structure du jeu bayésien
 
-/-- A Bayesian (incomplete information) game with finite types.
+---
+English:
+## Bayesian Game Structure
+-/
+
+/-- Un jeu bayésien (information incomplète) à types finis.
+
+    Chaque joueur a un type privé tiré d'une croyance commune.
+    Les stratégies associent des types à des actions. Les paiements
+    dépendent du profil de types complet et du profil d'actions.
+
+    English: A Bayesian (incomplete information) game with finite types.
 
     Each player has a private type drawn from a common prior.
     Strategies map types to actions. Payoffs depend on the full
     type profile and action profile.
 -/
 structure BayesianGame (PlayerType : Type) where
-  /-- Number of players -/
+  /-- Nombre de joueurs.
+      English: Number of players -/
   numPlayers : Nat
-  /-- Possible types for each player -/
+  /-- Types possibles pour chaque joueur.
+      English: Possible types for each player -/
   typeSet : Fin numPlayers → List PlayerType
-  /-- Number of actions available to each player -/
+  /-- Nombre d'actions disponibles pour chaque joueur.
+      English: Number of actions available to each player -/
   numActions : Fin numPlayers → Nat
-  /-- Payoff depends on type profile AND action profile -/
+  /-- Le paiement dépend du profil de types ET du profil d'actions.
+      English: Payoff depends on type profile AND action profile -/
   payoff : (i : Fin numPlayers) →
            (types : Fin numPlayers → PlayerType) →
            (actions : (j : Fin numPlayers) → Fin (numActions j)) → Int
-  /-- Common prior probability over type profiles (simplified) -/
+  /-- Probabilité a priori (prior) sur les profils de types (simplifié).
+      English: Common prior probability over type profiles (simplified) -/
   priorProb : (types : Fin numPlayers → PlayerType) → Float
 
-/-! ## Type-Conditioned Strategies -/
+/-!
+## Stratégies conditionnées par le type
 
-/-- A type-conditioned (pure) strategy: maps own type to an action -/
+---
+English:
+## Type-Conditioned Strategies
+-/
+
+/-- Une stratégie (pure) conditionnée par le type : associe son propre type à une action.
+    English: A type-conditioned (pure) strategy: maps own type to an action -/
 def TypeStrategy (g : BayesianGame α) (i : Fin g.numPlayers) :=
   α → Fin (g.numActions i)
 
-/-- A profile of type strategies: one per player -/
+/-- Un profil de stratégies par type : une par joueur.
+    English: A profile of type strategies: one per player -/
 def TypeStrategyProfile (g : BayesianGame α) :=
   (i : Fin g.numPlayers) → TypeStrategy g i
 
-/-! ## Expected Payoff (Simplified) -/
+/-!
+## Paiement espéré (simplifié)
 
-/-- Expected payoff for player i given a type strategy profile
+---
+English:
+## Expected Payoff (Simplified)
+-/
+
+/-- Paiement espéré du joueur i étant donné un profil de stratégies par type
+    et un profil de types particulier (simplifié : pas d'intégration).
+
+    Dans une formalisation complète, cela impliquerait de sommer sur tous
+    les profils de types pondérés par la croyance commune.
+
+    English: Expected payoff for player i given a type strategy profile
     and a particular type profile (simplified: no integration).
 
     In a full formalization this would involve summing over all
@@ -88,9 +164,22 @@ def expectedPayoffBayesian (g : BayesianGame α)
     (i : Fin g.numPlayers) : Int :=
   g.payoff i types (fun j => profile j (types j))
 
-/-! ## Bayesian Nash Equilibrium -/
+/-!
+## Équilibre de Nash bayésien
 
-/-- Bayesian Nash Equilibrium: no player can improve by deviating,
+---
+English:
+## Bayesian Nash Equilibrium
+-/
+
+/-- Équilibre de Nash bayésien : aucun joueur ne peut améliorer en déviant,
+    étant donné son type.
+
+    Pour chaque joueur i et chaque type t_i du joueur i, le profil de
+    stratégies doit être une meilleure réponse conditionnellement à t_i.
+    (Simplifié : vérifié sur un seul profil de types.)
+
+    English: Bayesian Nash Equilibrium: no player can improve by deviating,
     given their type.
 
     For each player i and each type t_i of player i, the strategy
@@ -104,92 +193,156 @@ def isBayesianNashEquilibrium (g : BayesianGame α)
     expectedPayoffBayesian g profile types i >=
     expectedPayoffBayesian g (funUpdate profile i altStrategy) types i
 
-/-! ## Information Sets (Imperfect Information) -/
+/-!
+## Ensembles d'information (information imparfaite)
 
-/-- An information set groups decision nodes that a player cannot
+---
+English:
+## Information Sets (Imperfect Information)
+-/
+
+/-- Un ensemble d'information regroupe des nœuds de décision qu'un joueur ne
+    peut pas distinguer. Modélisé comme un ensemble d'historiques de jeu.
+
+    Tiré de GT-13 : « l'ensemble d'information d'un joueur à un moment du jeu
+    est l'ensemble des nœuds où il pourrait être, compte tenu de ce qu'il observe. »
+
+    English: An information set groups decision nodes that a player cannot
     distinguish between. Modeled as a set of game histories.
 
     From GT-13: "A player's information set at any point in the game
     is the set of nodes they might be at, given what they observe."
 -/
 structure InformationSet where
-  /-- Player who faces this information set -/
+  /-- Joueur confronté à cet ensemble d'information.
+      English: Player who faces this information set -/
   player : Nat
-  /-- Possible histories (game states) in this set -/
+  /-- Historiques possibles (états du jeu) dans cet ensemble.
+      English: Possible histories (game states) in this set -/
   nodes : List String
-  /-- Available actions at this information set -/
+  /-- Actions disponibles dans cet ensemble d'information.
+      English: Available actions at this information set -/
   actions : List String
 
-/-- Check if two histories belong to the same information set -/
+/-- Vérifie si deux historiques appartiennent au même ensemble d'information.
+    English: Check if two histories belong to the same information set -/
 def sameInfoSet (h1 h2 : String) (iset : InformationSet) : Bool :=
   iset.nodes.contains h1 && iset.nodes.contains h2
 
-/-! ## Signaling Games (Spence 1973) -/
+/-!
+## Jeux de signal (Spence 1973)
 
-/-- A signaling game: sender observes type, sends message,
+---
+English:
+## Signaling Games (Spence 1973)
+-/
+
+/-- Un jeu de signal : l'émetteur observe son type, envoie un message,
+    le récepteur observe le message, choisit une action.
+
+    Tiré de GT-11 Section 6 (modèle de signal de Spence).
+    Deux joueurs : Émetteur (joueur 0) et Récepteur (joueur 1).
+
+    English: A signaling game: sender observes type, sends message,
     receiver observes message, chooses action.
 
     From GT-11 Section 6 (Spence signaling model).
     Two players: Sender (player 0) and Receiver (player 1).
 -/
 structure SignalingGame (MessageType : Type) (ActionResult : Type) where
-  /-- Possible types of the sender -/
+  /-- Types possibles de l'émetteur.
+      English: Possible types of the sender -/
   senderTypes : List MessageType
-  /-- Messages the sender can send -/
+  /-- Messages que l'émetteur peut envoyer.
+      English: Messages the sender can send -/
   messages : List MessageType
-  /-- Actions the receiver can take -/
+  /-- Actions que le récepteur peut entreprendre.
+      English: Actions the receiver can take -/
   receiverActions : List ActionResult
-  /-- Sender payoff: depends on type, message sent, receiver action -/
+  /-- Paiement de l'émetteur : dépend du type, du message envoyé, de l'action du récepteur.
+      English: Sender payoff: depends on type, message sent, receiver action -/
   senderPayoff : MessageType → MessageType → ActionResult → Int
-  /-- Receiver payoff: depends on type, message sent, receiver action -/
+  /-- Paiement du récepteur : dépend du type, du message envoyé, de l'action du récepteur.
+      English: Receiver payoff: depends on type, message sent, receiver action -/
   receiverPayoff : MessageType → MessageType → ActionResult → Int
-  /-- Prior probability of each sender type -/
+  /-- Probabilité a priori de chaque type de l'émetteur.
+      English: Prior probability of each sender type -/
   typePrior : MessageType → Float
 
-/-- A sender strategy: type → message -/
+/-- Stratégie de l'émetteur : type → message.
+    English: A sender strategy: type → message -/
 def SenderStrategy (_g : SignalingGame α β) := α → α
 
-/-- A receiver strategy: message → action -/
+/-- Stratégie du récepteur : message → action.
+    English: A receiver strategy: message → action -/
 def ReceiverStrategy (_g : SignalingGame α β) := α → β
 
-/-! ## First-Price Auction (from GT-11 Section 5) -/
+/-!
+## Enchère au premier prix (tiré de GT-11 Section 5)
 
-/-- A first-price sealed-bid auction with private values.
+---
+English:
+## First-Price Auction (from GT-11 Section 5)
+-/
+
+/-- Une enchère scellée au premier prix avec valeurs privées.
+
+    Chaque enchérisseur a une valorisation privée. Il soumet une offre.
+    L'offre la plus élevée gagne et paie son offre.
+
+    English: A first-price sealed-bid auction with private values.
 
     Each bidder has a private valuation. They submit a bid.
     Highest bid wins and pays their bid.
 -/
 structure FirstPriceAuction where
-  /-- Number of bidders -/
+  /-- Nombre d'enchérisseurs.
+      English: Number of bidders -/
   numBidders : Nat
-  /-- Maximum possible value -/
+  /-- Valeur maximale possible.
+      English: Maximum possible value -/
   maxValue : Nat
-  /-- Bidding strategy: valuation → bid (simplified, same for all) -/
+  /-- Stratégie d'enchère : valorisation → offre (simplifié, identique pour tous).
+      English: Bidding strategy: valuation → bid (simplified, same for all) -/
   bidStrategy : Nat → Nat
-  /-- Check if bid is valid (0 ≤ bid ≤ maxValue) -/
+  /-- Vérifie si l'enchère est valide (0 ≤ offre ≤ maxValue).
+      English: Check if bid is valid (0 ≤ bid ≤ maxValue) -/
   validBid : (bid : Nat) → Bool := fun bid => bid <= maxValue
 
-/-- Determine winner of auction given bids.
+/-- Détermine le gagnant de l'enchère étant donné les offres.
+    Renvoie l'indice du premier enchérisseur avec l'offre maximale.
+    Nécessite n ≥ 1 (au moins un enchérisseur).
+    English: Determine winner of auction given bids.
     Returns the index of the first bidder with the maximum bid.
     Requires n ≥ 1 (at least one bidder). -/
 def auctionWinner {n : Nat} (h_n : n ≥ 1) (bids : Fin n → Nat) : Fin n :=
   let maxBid := (List.finRange n).foldl (fun acc i => max acc (bids i)) 0
-  -- First player who bid the maximum wins (tie-breaking)
+  -- Le premier joueur ayant offert le maximum gagne (départage les égalités)
   match (List.finRange n).find? (fun i => bids i = maxBid) with
   | some i => i
   | none => ⟨0, by omega⟩
 
-/-- Revenue for the auctioneer -/
+/-- Revenu pour l'enchérisseur (l'organisateur de l'enchère).
+    English: Revenue for the auctioneer -/
 def auctionRevenue {n : Nat} (h_n : n ≥ 1) (bids : Fin n → Nat) : Nat :=
   bids (auctionWinner h_n bids)
 
-/-! ## Kuhn Poker (from GT-13 Section 2) -/
+/-!
+## Poker de Kuhn (tiré de GT-13 Section 2)
 
-/-- A card in Kuhn poker (simplified: Jack=0, Queen=1, King=2).
+---
+English:
+## Kuhn Poker (from GT-13 Section 2)
+-/
+
+/-- Une carte au poker de Kuhn (simplifié : Valet=0, Dame=1, Roi=2).
+    `abbrev` (et non `def`) pour que les instances de `Fin 3` (`LT`, `DecidableEq`, ...) se propagent.
+    English: A card in Kuhn poker (simplified: Jack=0, Queen=1, King=2).
     `abbrev` (not `def`) so `Fin 3` instances (`LT`, `DecidableEq`, ...) propagate. -/
 abbrev KuhnCard := Fin 3
 
-/-- History of actions in a Kuhn poker round -/
+/-- Historique des actions dans une donne de poker de Kuhn.
+    English: History of actions in a Kuhn poker round -/
 inductive KuhnAction where
   | check : KuhnAction
   | bet : KuhnAction
@@ -204,45 +357,52 @@ instance : ToString KuhnAction where
     | .fold => "fold"
     | .call => "call"
 
-/-- A Kuhn poker game state -/
+/-- Un état de partie de poker de Kuhn.
+    English: A Kuhn poker game state -/
 structure KuhnState where
-  /-- Cards dealt to each player -/
+  /-- Cartes distribuées à chaque joueur.
+      English: Cards dealt to each player -/
   cards : Fin 2 → KuhnCard
-  /-- Action history -/
+  /-- Historique des actions.
+      English: Action history -/
   history : List KuhnAction
 
--- no deriving Repr: `cards` is a function type, not derivable. Manual instance:
+-- pas de `deriving Repr` : `cards` est un type fonctionnel, non dérivable. Instance manuelle :
 instance : Repr KuhnState where
   reprPrec s _ :=
     let c0 := toString (s.cards ⟨0, by omega⟩)
     let c1 := toString (s.cards ⟨1, by omega⟩)
     s!"KuhnState({c0}, {c1}, {toString s.history})"
 
-/-- Check if a Kuhn poker game has reached a terminal state -/
+/-- Vérifie si une partie de poker de Kuhn a atteint un état terminal.
+    English: Check if a Kuhn poker game has reached a terminal state -/
 def KuhnIsTerminal (history : List KuhnAction) : Bool :=
   match history with
-  | [KuhnAction.check, KuhnAction.check] => true    -- both check
+  | [KuhnAction.check, KuhnAction.check] => true    -- les deux checkent
   | [KuhnAction.check, KuhnAction.bet, KuhnAction.fold] => true
   | [KuhnAction.check, KuhnAction.bet, KuhnAction.call] => true
   | [KuhnAction.bet, KuhnAction.fold] => true
   | [KuhnAction.bet, KuhnAction.call] => true
   | _ => false
 
-/-- Get the information set for a player in Kuhn poker -/
+/-- Renvoie l'ensemble d'information d'un joueur au poker de Kuhn.
+    English: Get the information set for a player in Kuhn poker -/
 def kuhnInfoSet (card : KuhnCard) (history : List KuhnAction) : String :=
   s!"card={card.val}-hist={toString history}"
 
-/-- Payoff for player 1 in terminal Kuhn poker states.
+/-- Paiement du joueur 1 dans les états terminaux du poker de Kuhn.
+    Renvoie 0 pour les états non terminaux.
+    English: Payoff for player 1 in terminal Kuhn poker states.
     Returns 0 for non-terminal states.
 -/
 def kuhnPayoff (cards : Fin 2 → KuhnCard) (history : List KuhnAction) : Int :=
   match history with
   | [KuhnAction.check, KuhnAction.check] =>
     if cards 0 > cards 1 then 1 else -1
-  | [KuhnAction.check, KuhnAction.bet, KuhnAction.fold] => 1  -- P1 wins pot
+  | [KuhnAction.check, KuhnAction.bet, KuhnAction.fold] => 1  -- J1 gagne le pot
   | [KuhnAction.check, KuhnAction.bet, KuhnAction.call] =>
     if cards 0 > cards 1 then 2 else -2  -- pot = 2
-  | [KuhnAction.bet, KuhnAction.fold] => 1   -- P2 folds, P1 wins pot
+  | [KuhnAction.bet, KuhnAction.fold] => 1   -- J2 se couche, J1 gagne le pot
   | [KuhnAction.bet, KuhnAction.call] =>
     if cards 0 > cards 1 then 2 else -2  -- pot = 2
-  | _ => 0  -- non-terminal
+  | _ => 0  -- non terminal

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Combinatorial.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Combinatorial.lean
@@ -1,4 +1,21 @@
 /-
+  Théorie des jeux combinatoires en Lean 4
+  ========================================
+
+  Introduit les notions pour les jeux combinatoires :
+  - Jeux séquentiels à deux joueurs
+  - Information parfaite
+  - Jeux à somme nulle
+  - Détermination Gagnant/Perdant
+
+  Note : pour le support complet de PGame, utiliser Mathlib :
+  import Mathlib.SetTheory.PGame.Basic
+  import Mathlib.SetTheory.Game.Nim
+
+  Basé sur GameTheory-18-Lean-CombinatorialGames.ipynb
+
+  ---
+  English:
   Combinatorial Game Theory in Lean 4
   ====================================
 
@@ -15,70 +32,105 @@
   Based on GameTheory-18-Lean-CombinatorialGames.ipynb
 -/
 
-/-! ## Simple Combinatorial Game Structures -/
+/-!
+## Structures simples de jeux combinatoires
 
-/-- A simple game tree node -/
+---
+English:
+## Simple Combinatorial Game Structures
+-/
+
+/-- Un nœud d'arbre de jeu simple.
+    English: A simple game tree node -/
 inductive GameTree where
-  | leaf : (winner : Int) → GameTree  -- 1 = player 1 wins, -1 = player 2 wins, 0 = draw
+  | leaf : (winner : Int) → GameTree  -- 1 = le joueur 1 gagne, -1 = le joueur 2 gagne, 0 = nul
   | node : (moves : List GameTree) → GameTree
 
-/-- Evaluate a game tree using minimax (player 1 = maximizer) -/
+/-- Évalue un arbre de jeu par minimax (joueur 1 = maximiseur).
+    English: Evaluate a game tree using minimax (player 1 = maximizer) -/
 def minimax : GameTree → Bool → Int
   | GameTree.leaf w, _ => w
-  | GameTree.node [], _ => 0  -- No moves = draw
+  | GameTree.node [], _ => 0  -- Aucun coup = nul
   | GameTree.node (m :: ms), isMax =>
     let first := minimax m (not isMax)
     let rest := minimax (GameTree.node ms) isMax
     if isMax then max first rest else min first rest
 
-/-! ## Nim-like Games -/
+/-!
+## Jeux de type Nim
 
-/-- A Nim heap is just a natural number -/
+---
+English:
+## Nim-like Games
+-/
+
+/-- Un tas de Nim est simplement un entier naturel.
+    English: A Nim heap is just a natural number -/
 def NimHeap := Nat
 
-/-- A Nim position is a list of heaps -/
+/-- Une position de Nim est une liste de tas.
+    English: A Nim position is a list of heaps -/
 def NimPosition := List Nat
 
-/-- XOR of all heap sizes (Sprague-Grundy value for Nim) -/
+/-- XOR de toutes les tailles de tas (valeur de Sprague-Grundy pour Nim).
+    English: XOR of all heap sizes (Sprague-Grundy value for Nim) -/
 def nimSum (pos : NimPosition) : Nat :=
   pos.foldl (· ^^^ ·) 0
 
-/-- A Nim position is winning for the player to move iff nimSum ≠ 0 -/
+/-- Une position de Nim est gagnante pour le joueur qui doit jouer ssi `nimSum ≠ 0`.
+    English: A Nim position is winning for the player to move iff nimSum ≠ 0 -/
 def isWinningNim (pos : NimPosition) : Bool :=
   nimSum pos != 0
 
-/-- Helper: enumerate a list with indices (avoids Mathlib dependency) -/
+/-- Utilitaire : énumère une liste avec ses indices (évite la dépendance Mathlib).
+    English: Helper: enumerate a list with indices (avoids Mathlib dependency) -/
 def listEnum {α : Type} (l : List α) : List (Nat × α) :=
   (List.range l.length).zip l
 
-/-- Helper: update element at index (avoids Mathlib dependency).
+/-- Utilitaire : met à jour l'élément à un indice donné (évite la dépendance Mathlib).
+    Utilise `listEnum` pour le parcours indexé.
+    English: Helper: update element at index (avoids Mathlib dependency).
     Uses listEnum for indexed traversal. -/
 def listSet {α : Type} (l : List α) (i : Nat) (x : α) : List α :=
   (listEnum l).map fun (j, a) =>
     if j == i then x else a
 
-/-- Get all valid moves from a Nim position -/
+/-- Renvoie tous les coups valides depuis une position de Nim.
+    English: Get all valid moves from a Nim position -/
 def nimMoves (pos : NimPosition) : List NimPosition :=
   (listEnum pos).flatMap fun (i, heap) =>
     (List.range heap).map fun newSize =>
       listSet pos i newSize
 
-/-! ## Two-Player Perfect Information Game -/
+/-!
+## Jeu à deux joueurs à information parfaite
 
-/-- A two-player perfect information game -/
+---
+English:
+## Two-Player Perfect Information Game
+-/
+
+/-- Un jeu à deux joueurs à information parfaite.
+    English: A two-player perfect information game -/
 structure TwoPlayerGame (State : Type) where
-  /-- Initial state -/
+  /-- État initial.
+      English: Initial state -/
   initial : State
-  /-- Check if it's player 1's turn -/
+  /-- Vérifie si c'est au tour du joueur 1.
+      English: Check if it's player 1's turn -/
   isPlayer1Turn : State → Bool
-  /-- Get available moves -/
+  /-- Renvoie les coups disponibles.
+      English: Get available moves -/
   moves : State → List State
-  /-- Check if game is over -/
+  /-- Vérifie si la partie est terminée.
+      English: Check if game is over -/
   isTerminal : State → Bool
-  /-- Get winner (1 = P1, -1 = P2, 0 = draw) -/
+  /-- Renvoie le gagnant (1 = J1, -1 = J2, 0 = nul).
+      English: Get winner (1 = P1, -1 = P2, 0 = draw) -/
   winner : State → Int
 
-/-- Check if a state is winning for the current player using backward induction -/
+/-- Vérifie si un état est gagnant pour le joueur courant par induction à rebours.
+    English: Check if a state is winning for the current player using backward induction -/
 partial def isWinning {State : Type} (game : TwoPlayerGame State) (state : State) : Bool :=
   if game.isTerminal state then
     let w := game.winner state
@@ -88,29 +140,46 @@ partial def isWinning {State : Type} (game : TwoPlayerGame State) (state : State
     if nextStates.isEmpty then false
     else nextStates.any fun s => not (isWinning game s)
 
-/-! ## Nim as a TwoPlayerGame -/
+/-!
+## Nim vu comme un TwoPlayerGame
 
-/-- Nim game instance -/
+---
+English:
+## Nim as a TwoPlayerGame
+-/
+
+/-- Instance du jeu de Nim.
+    English: Nim game instance -/
 def nimGame : TwoPlayerGame NimPosition := {
-  initial := [3, 4, 5]  -- Classic starting position
-  isPlayer1Turn := fun pos => (pos.foldl (· + ·) 0) % 2 == 1  -- Simplified
+  initial := [3, 4, 5]  -- Position de départ classique
+  isPlayer1Turn := fun pos => (pos.foldl (· + ·) 0) % 2 == 1  -- Simplifié
   moves := nimMoves
   isTerminal := fun pos => pos.all (· == 0)
-  winner := fun pos => if pos.all (· == 0) then -1 else 0  -- Last to move loses
+  winner := fun pos => if pos.all (· == 0) then -1 else 0  -- Le dernier à jouer perd
 }
 
-/-! ## Sprague-Grundy Theorem (Statement) -/
+/-!
+## Théorème de Sprague-Grundy (énoncé)
 
--- For impartial games, every position is equivalent to a Nim heap of some size.
--- This is a simplified version; full implementation requires more machinery.
+---
+English:
+## Sprague-Grundy Theorem (Statement)
+-/
 
-/-- Minimum excludant (mex) of a set of naturals.
+-- Pour les jeux impartiaux, toute position est équivalente à un tas de Nim d'une certaine taille.
+-- Ceci est une version simplifiée ; l'implémentation complète nécessite davantage de machinerie.
+
+/-- Minimum excludant (mex) d'un ensemble d'entiers naturels.
+    La valeur de Sprague-Grundy d'une position de jeu se définit via mex :
+    grundy(terminal) = 0, grundy(pos) = mex { grundy(pos') : pos' dans moves(pos) }.
+    English: Minimum excludant (mex) of a set of naturals.
     The Sprague-Grundy value of a game position is defined via mex:
     grundy(terminal) = 0, grundy(pos) = mex { grundy(pos') : pos' in moves(pos) }. -/
 def mex (s : List Nat) : Nat :=
   (List.range (s.length + 1)).find? (fun n => !s.contains n) |>.getD (s.length + 1)
 
-/-- Compute Grundy value for a simple game (partial: no memoization). -/
+/-- Calcule la valeur de Grundy pour un jeu simple (partiel : pas de mémoïsation).
+    English: Compute Grundy value for a simple game (partial: no memoization). -/
 partial def grundyValue {State : Type} [BEq State] [Hashable State]
     (moves : State → List State) (isTerminal : State → Bool) (state : State) : Nat :=
   if isTerminal state then 0

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Nash.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Nash.lean
@@ -1,4 +1,17 @@
 /-
+  Définitions de l'équilibre de Nash en Lean 4
+  ============================================
+
+  Définit l'équilibre de Nash et les notions associées :
+  - Meilleure réponse
+  - Équilibre de Nash en stratégies pures
+  - Équilibre de Nash en stratégies mixtes
+  - Dominance stricte
+
+  Basé sur GameTheory-16-Lean-Definitions.ipynb
+
+  ---
+  English:
   Nash Equilibrium Definitions in Lean 4
   ======================================
 
@@ -13,49 +26,81 @@
 
 import Basic
 
-/-! ## Best Response -/
+/-!
+## Meilleure réponse
 
-/-- Player 1 plays a best response to s2 -/
+---
+English:
+## Best Response
+-/
+
+/-- Le joueur 1 joue une meilleure réponse face à `s2`.
+    English: Player 1 plays a best response to s2 -/
 def isBestResponse1 (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) : Prop :=
   ∀ s1' : Fin 2 → Float,
     expectedPayoff1 g s1 s2 >= expectedPayoff1 g s1' s2
 
-/-- Player 2 plays a best response to s1 -/
+/-- Le joueur 2 joue une meilleure réponse face à `s1`.
+    English: Player 2 plays a best response to s1 -/
 def isBestResponse2 (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) : Prop :=
   ∀ s2' : Fin 2 → Float,
     expectedPayoff2 g s1 s2 >= expectedPayoff2 g s1 s2'
 
-/-! ## Nash Equilibrium -/
+/-!
+## Équilibre de Nash
 
-/-- Nash equilibrium in mixed strategies: each player plays a best response -/
+---
+English:
+## Nash Equilibrium
+-/
+
+/-- Équilibre de Nash en stratégies mixtes : chaque joueur joue une meilleure réponse.
+    English: Nash equilibrium in mixed strategies: each player plays a best response -/
 def isNashEquilibrium (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) : Prop :=
   isBestResponse1 g s1 s2 ∧ isBestResponse2 g s1 s2
 
-/-- Nash equilibrium in pure strategies for 2x2 games -/
+/-- Équilibre de Nash en stratégies pures pour les jeux 2x2.
+    English: Nash equilibrium in pure strategies for 2x2 games -/
 def isPureNashEquilibrium (g : Game2x2) (a1 : Fin 2) (a2 : Fin 2) : Prop :=
-  -- Player 1 cannot improve by changing action
+  -- Le joueur 1 ne peut pas améliorer en changeant d'action
   (∀ a1' : Fin 2, g.payoff1 a1 a2 >= g.payoff1 a1' a2) ∧
-  -- Player 2 cannot improve by changing action
+  -- Le joueur 2 ne peut pas améliorer en changeant d'action
   (∀ a2' : Fin 2, g.payoff2 a1 a2 >= g.payoff2 a1 a2')
 
-/-! ## Dominance -/
+/-!
+## Dominance
 
-/-- Action a strictly dominates action a' for player 1 -/
+---
+English:
+## Dominance
+-/
+
+/-- L'action `a` domine strictement l'action `a'` pour le joueur 1.
+    English: Action a strictly dominates action a' for player 1 -/
 def strictlyDominates1 (g : Game2x2) (a a' : Fin 2) : Prop :=
   ∀ a2 : Fin 2, g.payoff1 a a2 > g.payoff1 a' a2
 
-/-- Action a weakly dominates action a' for player 1 -/
+/-- L'action `a` domine faiblement l'action `a'` pour le joueur 1.
+    English: Action a weakly dominates action a' for player 1 -/
 def weaklyDominates1 (g : Game2x2) (a a' : Fin 2) : Prop :=
   (∀ a2 : Fin 2, g.payoff1 a a2 >= g.payoff1 a' a2) ∧
   (∃ a2 : Fin 2, g.payoff1 a a2 > g.payoff1 a' a2)
 
-/-- Action a strictly dominates action a' for player 2 -/
+/-- L'action `a` domine strictement l'action `a'` pour le joueur 2.
+    English: Action a strictly dominates action a' for player 2 -/
 def strictlyDominates2 (g : Game2x2) (a a' : Fin 2) : Prop :=
   ∀ a1 : Fin 2, g.payoff2 a1 a > g.payoff2 a1 a'
 
-/-! ## Classic Games -/
+/-!
+## Jeux classiques
 
-/-- Prisoner's Dilemma: C=0 (Cooperate), D=1 (Defect) -/
+---
+English:
+## Classic Games
+-/
+
+/-- Dilemme du prisonnier : C=0 (Coopérer), D=1 (Trahir).
+    English: Prisoner's Dilemma: C=0 (Cooperate), D=1 (Defect) -/
 def prisonersDilemma : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
@@ -73,14 +118,15 @@ def prisonersDilemma : Game2x2 := {
     | _, _ => 0
 }
 
-/-- Chicken Game: Yield=0, Charge=1 -/
+/-- Jeu de la poule (Chicken) : Céder=0, Foncer=1.
+    English: Chicken Game: Yield=0, Charge=1 -/
 def chickenGame : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
     | 0, 0 => 3  -- (Yield, Yield)
     | 0, 1 => 2  -- (Yield, Charge)
     | 1, 0 => 4  -- (Charge, Yield)
-    | 1, 1 => 0  -- (Charge, Charge) - crash!
+    | 1, 1 => 0  -- (Charge, Charge) - collision !
     | _, _ => 0
   payoff2 := fun i j =>
     match i.val, j.val with
@@ -91,7 +137,8 @@ def chickenGame : Game2x2 := {
     | _, _ => 0
 }
 
-/-- Stag Hunt: Stag=0, Hare=1 -/
+/-- Chasse au cerf (Stag Hunt) : Cerf=0, Lièvre=1.
+    English: Stag Hunt: Stag=0, Hare=1 -/
 def stagHunt : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
@@ -109,7 +156,8 @@ def stagHunt : Game2x2 := {
     | _, _ => 0
 }
 
-/-- Matching Pennies (zero-sum): Heads=0, Tails=1 -/
+/-- Matching Pennies (jeu à somme nulle) : Pile=0, Face=1.
+    English: Matching Pennies (zero-sum): Heads=0, Tails=1 -/
 def matchingPennies : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
@@ -127,7 +175,13 @@ def matchingPennies : Game2x2 := {
     | _, _ => 0
 }
 
-/-! ## Action Names -/
+/-!
+## Noms d'actions
+
+---
+English:
+## Action Names
+-/
 
 def Cooperer : Fin 2 := ⟨0, by omega⟩
 def Trahir : Fin 2 := ⟨1, by omega⟩

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Regret.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Regret.lean
@@ -1,4 +1,21 @@
 /-
+  Minimisation du regret et définitions du CFR en Lean 4
+  =====================================================
+
+  Définit les structures pour l'apprentissage basé sur le regret dans les jeux :
+  - Regret : écart entre le paiement obtenu et le meilleur paiement possible
+  - RegretMatching : règle de mise à jour de stratégie à partir des regrets cumulés
+  - CFR (Counterfactual Regret Minimization) : algorithme clé pour
+    résoudre les jeux à information imparfaite
+
+  Basé sur GameTheory-13-ImperfectInfo-CFR.ipynb
+
+  Note : ce sont des définitions pédagogiques. Une formalisation complète
+  nécessiterait la théorie de la mesure et des preuves de convergence
+  (non abordées ici).
+
+  ---
+  English:
   Regret Minimization and CFR Definitions in Lean 4
   ==================================================
 
@@ -17,9 +34,20 @@
 import Basic
 import Bayesian
 
-/-! ## Regret Concepts -/
+/-!
+## Notions de regret
 
-/-- Instantaneous regret for an action: how much better that action
+---
+English:
+## Regret Concepts
+-/
+
+/-- Regret instantané pour une action : de combien cette action
+    aurait été meilleure que ce qui a réellement été joué.
+
+    regret(a) = u(a) - u(a_played)
+
+    English: Instantaneous regret for an action: how much better that action
     would have been compared to what was actually played.
 
     regret(a) = u(a) - u(a_played)
@@ -27,22 +55,38 @@ import Bayesian
 def instantRegret (payoff : Fin n → Float) (played : Fin n) (action : Fin n) : Float :=
   payoff action - payoff played
 
-/-- Cumulative regret for each action over T iterations.
-    Stored as a map from action index to accumulated regret.
--/
+/-- Regret cumulé pour chaque action sur T itérations.
+    Stocké sous forme d'application de l'indice d'action vers le regret accumulé.
+    English: Cumulative regret for each action over T iterations.
+    Stored as a map from action index to accumulated regret. -/
 def CumulativeRegret (n : Nat) := Fin n → Float
 
-/-- Initialize zero regret -/
+/-- Initialise un regret nul.
+    English: Initialize zero regret -/
 def zeroRegret (n : Nat) : CumulativeRegret n := fun _ => 0
 
-/-- Update cumulative regret with a new observation -/
+/-- Met à jour le regret cumulé avec une nouvelle observation.
+    English: Update cumulative regret with a new observation -/
 def updateRegret {n : Nat} (regret : CumulativeRegret n)
     (payoff : Fin n → Float) (played : Fin n) : CumulativeRegret n :=
   fun a => regret a + instantRegret payoff played a
 
-/-! ## Regret Matching -/
+/-!
+## Regret matching
 
-/-- Regret matching: convert positive cumulative regrets to a strategy.
+---
+English:
+## Regret Matching
+-/
+
+/-- Regret matching : convertit les regrets cumulés positifs en une stratégie.
+
+    Pour chaque action a : σ(a) = R+(a) / Σ_a' R+(a')
+    où R+ est la partie positive du regret cumulé.
+
+    Si tous les regrets sont non positifs, jouer uniformément.
+
+    English: Regret matching: convert positive cumulative regrets to a strategy.
 
     For each action a: σ(a) = R+(a) / Σ_a' R+(a')
     where R+ is the positive part of cumulative regret.
@@ -55,11 +99,22 @@ def regretMatchingStrategy {n : Nat} (regret : CumulativeRegret n) : Fin n → F
   if total > 0 then
     fun a => posRegret a / total
   else
-    fun _ => (1.0 : Float) / n.toFloat  -- uniform
+    fun _ => (1.0 : Float) / n.toFloat  -- uniforme
 
-/-! ## External Regret (Hannan Consistency) -/
+/-!
+## Regret externe (cohérence de Hannan)
 
-/-- External regret: difference between realized payoff and best
+---
+English:
+## External Regret (Hannan Consistency)
+-/
+
+/-- Regret externe : écart entre le paiement réalisé et la meilleure
+    action fixe avec le recul.
+
+    R_T = max_a Σ_t u_t(a) - Σ_t u_t(a_t)
+
+    English: External regret: difference between realized payoff and best
     fixed action in hindsight.
 
     R_T = max_a Σ_t u_t(a) - Σ_t u_t(a_t)
@@ -74,9 +129,25 @@ def externalRegret (T : Nat) (payoffs : Fin T → (Fin n → Float))
     (fun s t => s + payoffs t (played t)) 0
   bestFixed - realized
 
-/-! ## Counterfactual Regret -/
+/-!
+## Regret contrefactuel
 
-/-- Counterfactual regret for a player at an information set.
+---
+English:
+## Counterfactual Regret
+-/
+
+/-- Regret contrefactuel pour un joueur à un ensemble d'information.
+
+    L'idée clé du CFR : minimiser le regret contrefactuel à chaque
+    ensemble d'information indépendamment, et la stratégie moyenne converge
+    vers un équilibre de Nash dans les jeux à somme nulle à deux joueurs.
+
+    CFR(I, a) = Σ_z∈Z_I  π_{-i}(z) · (u_i(z, a) - u_i(z, σ(I)))
+
+    où π_{-i} est la probabilité d'atteindre z en excluant le joueur i.
+
+    English: Counterfactual regret for a player at an information set.
 
     The key insight of CFR: minimize counterfactual regret at each
     information set independently, and the average strategy converges
@@ -87,39 +158,63 @@ def externalRegret (T : Nat) (payoffs : Fin T → (Fin n → Float))
     where π_{-i} is the reach probability excluding player i.
 -/
 structure CounterfactualRegret where
-  /-- The information set identifier -/
+  /-- L'identifiant de l'ensemble d'information.
+      English: The information set identifier -/
   infoSet : String
-  /-- The player -/
+  /-- Le joueur.
+      English: The player -/
   player : Nat
-  /-- Regret for each available action -/
-  actionRegrets : List (String × Float)  -- (action_name, regret_value)
+  /-- Regret pour chaque action disponible.
+      English: Regret for each available action -/
+  actionRegrets : List (String × Float)  -- (nom_action, valeur_regret)
   deriving Repr
 
-/-! ## CFR Solver State -/
+/-!
+## État du solveur CFR
 
-/-- The state maintained by a CFR solver across iterations -/
+---
+English:
+## CFR Solver State
+-/
+
+/-- L'état maintenu par un solveur CFR au fil des itérations.
+    English: The state maintained by a CFR solver across iterations -/
 structure CFRState where
-  /-- Cumulative counterfactual regret per information set and action -/
+  /-- Regret contrefactuel cumulé par ensemble d'information et action.
+      English: Cumulative counterfactual regret per information set and action -/
   cumulativeRegret : List (String × List (String × Float))
-  /-- Cumulative strategy (sum of strategies weighted by reach) -/
+  /-- Stratégie cumulée (somme des stratégies pondérées par la probabilité d'atteinte).
+      English: Cumulative strategy (sum of strategies weighted by reach) -/
   strategySum : List (String × List (String × Float))
-  /-- Number of iterations completed -/
+  /-- Nombre d'itérations effectuées.
+      English: Number of iterations completed -/
   iterations : Nat
   deriving Repr
 
-/-- Initialize empty CFR state -/
+/-- Initialise un état CFR vide.
+    English: Initialize empty CFR state -/
 def initCFRState : CFRState where
   cumulativeRegret := []
   strategySum := []
   iterations := 0
 
-/-! ## Convergence Concepts -/
+/-!
+## Notions de convergence
 
-/-- Average regret approaches zero (ε-Nash equilibrium) -/
+---
+English:
+## Convergence Concepts
+-/
+
+/-- Le regret moyen tend vers zéro (ε-équilibre de Nash).
+    English: Average regret approaches zero (ε-Nash equilibrium) -/
 def epsilonNash (ε : Float) (externalReg : Float) : Prop :=
   externalReg <= ε
 
-/-- No-regret learning: average external regret goes to zero.
+/-- Apprentissage sans regret : le regret externe moyen tend vers zéro.
+    Les paiements et les coups sont indexés par `Nat` (horizon infini) ; le regret
+    à l'horizon `t` est calculé sur le préfixe des `t` premières rondes.
+    English: No-regret learning: average external regret goes to zero.
     Payoffs and plays are indexed by `Nat` (infinite horizon); the regret
     at horizon `t` is computed on the prefix of the first `t` rounds. -/
 def noRegret (payoffs : Nat → (Fin n → Float))
@@ -127,9 +222,23 @@ def noRegret (payoffs : Nat → (Fin n → Float))
   ∀ ε > 0, ∃ T0, ∀ t ≥ T0,
     externalRegret t (fun s => payoffs s.val) (fun s => played s.val) / t.toFloat < ε
 
-/-! ## Fictitious Play (from GT-17 Section 3) -/
+/-!
+## Fictitious play (tiré de GT-17 Section 3)
 
-/-- Fictitious play: each player plays best response to the
+---
+English:
+## Fictitious Play (from GT-17 Section 3)
+-/
+
+/-- Fictitious play : chaque joueur joue la meilleure réponse face à la
+    distribution empirique des coups passés de l'adversaire.
+
+    Brown (1951) : converge vers l'équilibre de Nash pour :
+    - les jeux à somme nulle à 2 joueurs
+    - les jeux 2x2
+    - les jeux à intérêts identiques
+
+    English: Fictitious play: each player plays best response to the
     empirical distribution of opponent's past plays.
 
     Brown (1951): converges to Nash equilibrium in:
@@ -138,13 +247,20 @@ def noRegret (payoffs : Nat → (Fin n → Float))
     - Games with identical interests
 -/
 structure FictitiousPlayState (n : Nat) where
-  /-- Empirical frequency of each player's actions -/
+  /-- Fréquence empirique des actions de chaque joueur.
+      English: Empirical frequency of each player's actions -/
   actionCounts : Fin n → (Fin m → Nat)
-  /-- Number of rounds played -/
+  /-- Nombre de rondes jouées.
+      English: Number of rounds played -/
   rounds : Nat
-  -- no deriving Repr: `actionCounts` is a function type, not derivable
+  -- pas de `deriving Repr` : `actionCounts` est un type fonctionnel, non dérivable
 
-/-- Best response to empirical distribution of opponent.
+/-- Meilleure réponse face à la distribution empirique de l'adversaire.
+
+    Conceptuellement : argmax_a Σ_{a_{-i}} empiricalDist(a_{-i}) · u_i(a, a_{-i}).
+    Dans une formalisation complète, cela utiliserait l'argmax de Mathlib.
+
+    English: Best response to empirical distribution of opponent.
 
     Conceptually: argmax_a Σ_{a_{-i}} empiricalDist(a_{-i}) · u_i(a, a_{-i}).
     In a full formalization this would use Mathlib's argmax.

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/SocialChoice.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/SocialChoice.lean
@@ -1,4 +1,18 @@
 /-
+  Théorie du choix social en Lean 4
+  =================================
+
+  Formalise les notions clés de la théorie du choix social :
+  - Préférences et ordres
+  - Fonctions de bien-être social
+  - Axiomes d'Arrow (Pareto, IIA, Non-dictature)
+  - Théorème d'impossibilité d'Arrow (énoncé)
+
+  Basé sur GameTheory-19-Lean-SocialChoice.ipynb
+  Inspiré de asouther4/lean-social-choice (Lean 3)
+
+  ---
+  English:
   Social Choice Theory in Lean 4
   ==============================
 
@@ -12,56 +26,102 @@
   Inspired by asouther4/lean-social-choice (Lean 3)
 -/
 
-/-! ## Preferences -/
+/-!
+## Préférences
 
-/-- A preference relation is a binary relation on alternatives -/
+---
+English:
+## Preferences
+-/
+
+/-- Une relation de préférence est une relation binaire sur les alternatives.
+    English: A preference relation is a binary relation on alternatives -/
 structure Preference (A : Type) where
-  /-- R x y means "x is at least as good as y" -/
+  /-- `R x y` signifie « x est au moins aussi bon que y ».
+      English: R x y means "x is at least as good as y" -/
   R : A → A → Prop
-  /-- Completeness: for any x, y, either R x y or R y x -/
+  /-- Complétude : pour tout x, y, soit R x y soit R y x.
+      English: Completeness: for any x, y, either R x y or R y x -/
   complete : ∀ x y, R x y ∨ R y x
-  /-- Transitivity -/
+  /-- Transitivité.
+      English: Transitivity -/
   trans : ∀ x y z, R x y → R y z → R x z
 
-/-- Strict preference: x is strictly preferred to y -/
+/-- Préférence stricte : x est strictement préféré à y.
+    English: Strict preference: x is strictly preferred to y -/
 def StrictPref {A : Type} (p : Preference A) (x y : A) : Prop :=
   p.R x y ∧ ¬p.R y x
 
-/-- Indifference: x and y are equally good -/
+/-- Indifférence : x et y sont également bons.
+    English: Indifference: x and y are equally good -/
 def Indifferent {A : Type} (p : Preference A) (x y : A) : Prop :=
   p.R x y ∧ p.R y x
 
-/-! ## Social Welfare Functions -/
+/-!
+## Fonctions de bien-être social
 
-/-- A social welfare function aggregates individual preferences into a social preference -/
+---
+English:
+## Social Welfare Functions
+-/
+
+/-- Une fonction de bien-être social agrège les préférences individuelles en une préférence sociale.
+    English: A social welfare function aggregates individual preferences into a social preference -/
 structure SocialWelfareFunction (I A : Type) where
-  /-- The aggregation function -/
+  /-- La fonction d'agrégation.
+      English: The aggregation function -/
   aggregate : (I → Preference A) → Preference A
 
-/-! ## Arrow's Axioms -/
+/-!
+## Axiomes d'Arrow
 
-/-- Weak Pareto: If everyone strictly prefers x to y, society prefers x to y -/
+---
+English:
+## Arrow's Axioms
+-/
+
+/-- Pareto faible : si tout le monde préfère strictement x à y, la société préfère x à y.
+    English: Weak Pareto: If everyone strictly prefers x to y, society prefers x to y -/
 def WeakPareto {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
   ∀ prefs : I → Preference A, ∀ x y,
     (∀ i, StrictPref (prefs i) x y) → StrictPref (swf.aggregate prefs) x y
 
-/-- Independence of Irrelevant Alternatives (IIA) -/
+/-- Indépendance des alternatives non pertinentes (IIA).
+    English: Independence of Irrelevant Alternatives (IIA) -/
 def IIA {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
   ∀ prefs prefs' : I → Preference A, ∀ x y,
-    -- If x vs y preferences are the same in both profiles
+    -- Si les préférences x vs y sont identiques dans les deux profils
     (∀ i, (prefs i).R x y ↔ (prefs' i).R x y) →
     (∀ i, (prefs i).R y x ↔ (prefs' i).R y x) →
-    -- Then social preference over x,y is the same
+    -- Alors la préférence sociale sur x, y est identique
     ((swf.aggregate prefs).R x y ↔ (swf.aggregate prefs').R x y)
 
-/-- Non-dictatorship: No single individual determines the social preference -/
+/-- Non-dictature : aucun individu unique ne détermine la préférence sociale.
+    English: Non-dictatorship: No single individual determines the social preference -/
 def NonDictatorial {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
   ¬∃ d : I, ∀ prefs : I → Preference A, ∀ x y,
     StrictPref (prefs d) x y → StrictPref (swf.aggregate prefs) x y
 
-/-! ## Arrow's Impossibility Theorem -/
+/-!
+## Théorème d'impossibilité d'Arrow
+
+---
+English:
+## Arrow's Impossibility Theorem
+-/
 
 /--
+Théorème d'impossibilité d'Arrow (énoncé) :
+il n'existe pas de fonction de bien-être social avec ≥ 3 alternatives qui satisfasse :
+1. Pareto faible
+2. Indépendance des alternatives non pertinentes
+3. Non-dictature
+
+Note : énoncé avec des types `Fin n` explicites plutôt qu'un `Fintype` générique
+pour éviter la dépendance Mathlib. Le contenu mathématique du théorème est identique.
+
+---
+English:
 Arrow's Impossibility Theorem (Statement):
 There is no social welfare function with ≥3 alternatives that satisfies:
 1. Weak Pareto
@@ -71,7 +131,7 @@ There is no social welfare function with ≥3 alternatives that satisfies:
 Note: Stated with explicit `Fin n` types instead of generic `Fintype`
 to avoid Mathlib dependency. The theorem's mathematical content is identical.
 -/
--- Full proof requires extensive machinery; we state it as an axiom
+-- La preuve complète nécessite une machinerie importante ; nous l'énonçons comme axiome
 axiom arrow_impossibility {nI nA : Nat}
     (hI : nI ≥ 2)
     (hA : nA ≥ 3)
@@ -80,14 +140,22 @@ axiom arrow_impossibility {nI nA : Nat}
     (h_iia : IIA swf) :
     ¬NonDictatorial swf
 
-/-! ## Examples -/
+/-!
+## Exemples
 
-/-- Dictatorship SWF: Individual d's preference becomes social preference -/
+---
+English:
+## Examples
+-/
+
+/-- SWF dictatorial : la préférence de l'individu d devient la préférence sociale.
+    English: Dictatorship SWF: Individual d's preference becomes social preference -/
 def dictatorship {I A : Type} (d : I) : SocialWelfareFunction I A := {
   aggregate := fun prefs => prefs d
 }
 
-/-- Theorem: A dictatorship satisfies Pareto and IIA -/
+/-- Théorème : une dictature satisfait Pareto et IIA.
+    English: Theorem: A dictatorship satisfies Pareto and IIA -/
 theorem dictatorship_satisfies_pareto {I A : Type} (d : I) :
     WeakPareto (dictatorship (I := I) (A := A) d) := by
   intro prefs x y h_all
@@ -98,27 +166,47 @@ theorem dictatorship_satisfies_iia {I A : Type} (d : I) :
   intro prefs prefs' x y h1 h2
   exact h1 d
 
-/-! ## Sen's Impossibility -/
+/-!
+## Impossibilité de Sen
 
-/-- Minimal Liberalism: Some individual is decisive over some pair -/
+---
+English:
+## Sen's Impossibility
+-/
+
+/-- Libéralisme minimal : un individu est décisif sur au moins une paire.
+    English: Minimal Liberalism: Some individual is decisive over some pair -/
 def MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
   ∃ i : I, ∃ x y : A,
     ∀ prefs : I → Preference A,
       StrictPref (prefs i) x y → StrictPref (swf.aggregate prefs) x y
 
-/- Sen's Impossibility Theorem (Statement):
+/- Théorème d'impossibilité de Sen (énoncé) :
+   aucune SWF ne peut satisfaire à la fois Pareto faible et Libéralisme minimal
+   sous certaines configurations de préférences.
+   (Énoncé plus faible — le théorème complet nécessite de construire
+   des profils de préférences spécifiques.)
+   English: Sen's Impossibility Theorem (Statement):
    No SWF can satisfy both Weak Pareto and Minimal Liberalism
    under certain preference configurations.
    (Weaker statement — the full theorem requires constructing
    specific preference profiles.) -/
 
-/-! ## Utility Representations -/
+/-!
+## Représentations par utilité
 
-/-- A utility function represents a preference if u(x) ≥ u(y) iff R x y -/
+---
+English:
+## Utility Representations
+-/
+
+/-- Une fonction d'utilité représente une préférence si `u(x) ≥ u(y)` ssi `R x y`.
+    English: A utility function represents a preference if u(x) ≥ u(y) iff R x y -/
 def represents {A : Type} (u : A → Int) (p : Preference A) : Prop :=
   ∀ x y, p.R x y ↔ u x >= u y
 
-/-- Create a preference from a utility function -/
+/-- Construit une préférence à partir d'une fonction d'utilité.
+    English: Create a preference from a utility function -/
 def prefFromUtility {A : Type} (u : A → Int)
     (h_finite : ∀ x y, u x >= u y ∨ u y >= u x := by decide) : Preference A := {
   R := fun x y => u x >= u y


### PR DESCRIPTION
## Scope

Étape 2 du rollout **#4980** (i18n des fichiers `.lean`, décision user 02/07/2026, **Option A** = docstrings bilingues FR+EN inline). Suite de conway_cgt (#5085), calibration_lean (#5112) et sensitivity_lean (#5122). **Clôt l'étape 2** « EN-dominants petits » (4/4).

`lean_game_defs` = 6 fichiers `.lean` (Basic, Nash, Bayesian, Combinatorial, SocialChoice, Regret ; 902L), 100% EN. Définitions pédagogiques de théorie des jeux (jeux sous forme normale, équilibre de Nash, jeux combinatoires + Sprague-Grundy, choix social + Arrow, jeux bayésiens + Kuhn poker, minimisation du regret + CFR). Lake autonome **zero-dependency** (core Lean only), toolchain rc1.

## Convention Option A appliquée

| Type de commentaire | Traitement |
|---------------------|------------|
| Module header `/- ... -/` | Bilingue : FR d'abord + `---` + `English:` |
| Section docstrings `/-! ## /` | Bilingue : FR d'abord + `---` + `English:` |
| Déclaration docstrings `/-- ... -/` (y compris champs de structure) | Bilingue : FR d'abord + `English:` |
| Commentaires `--` descriptifs | FR-seul |
| Labels symboliques `-- (C, C)`, `-- pot = 2` | **Conservés verbatim** (notation universelle) |
| Identifiants (`def`/`theorem`/`structure`/`inductive`/`axiom`/noms) | **Inchangés** |
| `axiom arrow_impossibility` (SocialChoice.lean) | **Conservé verbatim** (axiome explicite, NON un sorry) |

## Anti-régression — preuve structurelle (lean-merge-discipline §1)

Vérification automatisée (script, comments strippés Lean-aware : blocs `/- -/` imbriqués + lignes `--`) :

| Fichier | Code byte-identique (origin/main vs working) | Délimiteurs `/-`==`-/` | sorry réel | axiom |
|---------|----------------------------------------------|------------------------|------------|-------|
| Basic.lean | ✅ True | 28/28 ✅ | 0 → 0 ✅ | 0 → 0 ✅ |
| Nash.lean | ✅ True | 17/17 ✅ | 0 → 0 ✅ | 0 → 0 ✅ |
| Combinatorial.lean | ✅ True | 25/25 ✅ | 0 → 0 ✅ | 0 → 0 ✅ |
| SocialChoice.lean | ✅ True | 26/26 ✅ | 0 → 0 ✅ | 1 → 1 ✅ |
| Bayesian.lean | ✅ True | 56/56 ✅ | 0 → 0 ✅ | 0 → 0 ✅ |
| Regret.lean | ✅ True | 29/29 ✅ | 0 → 0 ✅ | 0 → 0 ✅ |

**L'i18n ne touche QUE les docstrings/commentaires.** Zéro ligne de code modifiée. Ce sont des définitions pures (0 sorry, 0 preuve formelle) — l'unique `axiom arrow_impossibility` (théorème d'impossibilité d'Arrow énoncé non prouvé) est conservé verbatim.

## Build local

`lake build` : **SUCCESS** (Windows-native `lake.exe`, zero-dependency core Lean, 8 jobs, 6 modules compilés Basic/Combinatorial/SocialChoice/Nash/Bayesian/Regret en ~6s, 6 oleans). Pas de `require mathlib` → pas de drift symlink, build reproductible et rapide.

## Note transparence

4e grain Lean i18n consécutif (c.189 conway_cgt, c.190 calibration, c.192 sensitivity, c.193 lean_game_defs). R5.4b anti-tunneling a été pesé : scan honnête du pool cross-lane — les quick-wins non-Lean propres sont rares ce cycle (#5082 Search actif côté po-2024, #4940 Sudoku COMPLETE, ICT #5091+ = notebooks recherche lourds, #3870 README = turf collision c.175 avec po-2023, #3968 typo partitionné po-2025 avec po-2026 hors-partition explicite). lean_game_defs satisfait les contraintes HARDER : MA lane #4980 uncontested, 0 sorry (zéro risque anti-régression), zero-dep build clean, clôt un rollout cohérent (étape 2 4/4). Diversification non-Lean prévue au prochain cycle.

See #4980
