### PR TITLE
fix(ci): add "real" sorry-filter mode for calibration_lean (#5120)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -21,11 +21,19 @@ name: Lean Build (reusable)
 #   standalone-tactic : sorry as the sole tactic token on a line, INCLUDING the
 #                       Lean case-bullet form `· sorry` (U+00B7), which a bare
 #                       `^\s*sorry\s*$` silently dropped (blind spot, See #2747)
+#   real              : strip Lean comments (-- line + nested /- -/ block) then count
+#                       word-bounded `\bsorry\b`. Mirrors the prover harness
+#                       `count_real_sorries` (FX-6 #1453) — the repo's canonical
+#                       counter. Use when a project's prose/docstrings LEGITIMATELY
+#                       mention "sorry" (e.g. calibration_lean P4 "sorry-increase"
+#                       docstring examples, See #5120) so comment edits do not flip
+#                       the raw count.
 # Use raw only when sorry ALWAYS means tactic (no prose mentions). Use prose-header
 # when the only non-tactic mentions are "sorries"/"sorry's" in header comments.
 # Use standalone-tactic when there are MANY prose mentions of "sorry" mixed with
-# real tactic sorries (e.g. Conway block comments). Choose the mode whose baseline
-# is robust to editing comments in that project.
+# real tactic sorries (e.g. Conway block comments). Use `real` when docstring prose
+# legitimately says "sorry" (the most robust: counts exactly compiled-tactic sorries).
+# Choose the mode whose baseline is robust to editing comments in that project.
 
 on:
   workflow_call:
@@ -43,7 +51,7 @@ on:
         type: string
         required: true
       sorry-filter-mode:
-        description: "How to count sorry: raw | prose-header | standalone-tactic"
+        description: "How to count sorry: raw | prose-header | standalone-tactic | real"
         type: string
         required: true
 
@@ -81,6 +89,30 @@ jobs:
                 # spot, See #2747). Strip bullet bytes (c2 b7) first so BOTH
                 # forms match in any locale (byte-exact, not UTF-8 dependent).
                 COUNT=$(tr -d '\302\267' < "$f" | grep -cE "^\s*sorry\s*$" || true) ;;
+              real)
+                # Strip Lean line comments (-- ...) and nested block comments
+                # (/- ... -/) then count word-bounded `sorry`. Mirrors the
+                # prover harness `count_real_sorries` (FX-6 #1453), the repo's
+                # canonical counter. Catches every compiled-tactic form
+                # (`exact sorry`, `:= by sorry`, bare `sorry`, `sorry -- c`)
+                # while ignoring prose mentions in docstrings/comments. Use
+                # when docstring prose legitimately says "sorry" so comment
+                # edits do not flip the raw count (See #5120).
+                COUNT=$(awk '
+                  BEGIN { depth=0 }
+                  {
+                    line=$0; out=""; i=1; n=length(line)
+                    while (i<=n) {
+                      two = (i<n) ? substr(line,i,2) : substr(line,i,1)
+                      if (depth==0 && two=="--") { break }
+                      if (two=="/-") { depth++; i+=2; continue }
+                      if (depth>0 && two=="-/") { depth--; i+=2; continue }
+                      if (depth==0) { out = out substr(line,i,1) }
+                      i++
+                    }
+                    if (depth==0) print out
+                  }
+                ' "$f" | grep -oE '\bsorry\b' | wc -l || true) ;;
               *)
                 echo "ERROR: unknown sorry-filter-mode '$MODE'"; exit 2 ;;
             esac

--- a/.github/workflows/lean-calibration.yml
+++ b/.github/workflows/lean-calibration.yml
@@ -7,12 +7,17 @@ name: Lean Calibration CI
 # Migrated to the reusable lean-build.yml per ai-01 DRY decision (option 2: matrix).
 # Behavior is identical to the former inline check-sorry + build jobs.
 #
-# Sorry profile (verified 2026-06-10, raw mode, baseline=4): the 4 raw "sorry"
-# mentions in Nash.lean are 2 INTENTIONAL P4 tactic targets (L95/L96 — the
-# sorry-increase case the harness must NOT revert) + 2 prose mentions (L89/L97
-# describing them). raw mode + baseline 4 preserves the exact prior enforcement:
-# any new sorry-as-tactic raises the raw count >4 and fails. (standalone-tactic
-# would read 0 here because the P4 sorries carry a leading `·` and inline comment.)
+# Sorry profile (verified 2026-07-03, mode=real, baseline=0): calibration_lean has
+# ZERO compiled-tactic sorries. The 10 raw "sorry" mentions in Nash.lean are ALL
+# prose inside the P4 "sorry-increase calibration target" docstring (L125-L150):
+# it describes, as illustrative examples, what the prover SHOULD eventually produce
+# (`· sorry  -- player 1 has no incentive to deviate`), not compiled tactics. The
+# former raw+baseline=4 config double-counted this docstring prose and flipped to a
+# false positive on any i18n/enrichment edit that touched the P4 docstring (incident
+# #5112: docstring-only i18n PR raised raw 4→10 on 0 code change). mode=real strips
+# Lean comments/docstrings first (mirrors prover `count_real_sorries`, FX-6 #1453),
+# so the gate counts exactly compiled-tactic sorries and a real regression (a new
+# `:= by sorry`) still trips it. See #5120.
 
 on:
   push:
@@ -37,5 +42,5 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean
       display-name: calibration_lean
-      sorry-baseline: "4"
-      sorry-filter-mode: raw
+      sorry-baseline: "0"
+      sorry-filter-mode: real


### PR DESCRIPTION
## Scope — Closes #5120

The `calibration_lean` CI gate used `sorry-filter-mode: raw` (substring `grep -c "sorry"`, baseline=4), but the lake's 10 raw "sorry" mentions are **ALL prose** inside the P4 "sorry-increase calibration target" docstring (`Nash.lean` L125-L150): illustrative examples of what the prover SHOULD eventually produce (`· sorry -- player 1 has no incentive to deviate`), **not compiled tactics**. The lake has **ZERO compiled-tactic sorries** — verified firsthand with the repo's canonical counter `count_real_sorries` (FX-6 #1453).

Consequence (incident #5112): a docstring-only i18n PR (0 code change, code byte-identical 4/4, lake build SUCCESS) raised raw 4→10 and tripped a false positive — merged only via admin+justification. Any future docstring/enrichment edit refrups this.

## Fix

1. **`lean-build.yml`**: add a 4th mode `real` that strips Lean line comments (`--`) and nested block comments (`/- -/`) then counts word-bounded `\bsorry\b`. This **mirrors the prover harness `count_real_sorries`** (`lean_utils.py`, FX-6 #1453) — the repo's canonical counter — so CI and the prover agree on what a "sorry" is. The strip+count is a portable `awk` program (no python dependency in the CI shell step).
2. **`lean-calibration.yml`**: switch mode `raw`→`real`, baseline `4`→`"0"`, and replace the stale raw-profile comment (which documented the wrong baseline).

## Why not the existing `standalone-tactic` mode?

`standalone-tactic` (`^\s*sorry\s*$` after stripping the `·` bullet) reads 0 here too, but for the **wrong reason**: it is blind to the 4 real P4 tactic forms BECAUSE they carry an inline `-- comment` (the line is `· sorry -- ...`, not bare `sorry`). It would also miss `:= by sorry` and `exact sorry` forms. `real` is strictly more correct: it counts every compiled-tactic form while ignoring prose.

## Validation (G.1 — both acceptance criteria of #5120)

| Criterion | Test | Result |
|-----------|------|--------|
| **No false positive** (CI passes on main + docstring-only PR) | awk strip+count on `Nash.lean` | **0** (the 10 prose mentions all sit inside `/- ... -/` docstring, stripped). Matches `count_real_sorries(Nash.lean)=0` |
| **Regression detected** (gate fails on a new real `sorry` tactic) | inject `theorem x : True := by sorry` outside docstring | **1** > baseline 0 → gate **FAILS** ✓ |

Tested forms (all counted = 1): bare `sorry`, `sorry -- inline`, `:= by sorry`. Prose-only "sorry" inside `/- ... -/` → 0. Both workflows YAML-valid (`yaml.safe_load`).

**Additive only**: `lean-build.yml` gains a new mode branch; the 3 existing modes (raw / prose-header / standalone-tactic) and all other lake callers are byte-unchanged.

Closes #5120

Co-Authored-By: Claude-Code <noreply@anthropic.com>
