### PR TITLE
Add: Sudoku-3-Genetic-Python Section 7 comparaison quantitative + exercice ratio (Prong B #3801)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -1783,6 +1783,55 @@
     "---\n",
     "**Navigation** : [<< Python DancingLinks](Sudoku-2-DancingLinks-Python.ipynb) | [Index](README.md) | [Python SimulatedAnnealing >>](Sudoku-4-SimulatedAnnealing-Python.ipynb)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Comparaison quantitative avec solveurs exacts (Prong B #3801)\n\nLe benchmark precedent (Section 5) a mesure les algorithmes genetiques sur 3 puzzles faciles (1/3 resolu, ~1-30s par puzzle). Pour situer les GA par rapport aux solveurs exacts, voici une **comparaison quantitative** sur les memes classes de puzzles (Easy / Hard), avec les chiffres reels publies dans les notebooks voisins.\n\n### Tableau comparatif (chiffres verifies, sources citees)\n\n| Solveur | Easy (10 puzzles) | Hard/Top11 (11 puzzles) | Garantie exactitude |\n|---------|--------------------|-------------------------|---------------------|\n| **GA Permutations** (mesure, cell 22) | 1/3 resolus, ~1-30s | non teste (gap pedagogique) | Non |\n| **Backtracking simple** (`Sudoku-1-Backtracking-Python`, cell 15) | 10/10, 1436.72 ms total, **143.67 ms moyen** | non teste dans la source | Oui (exhaustif) |\n| **OR-Tools CP-SAT** (`Sudoku-10-ORTools-Python`, cell 19) | 10/10, 145.87 ms total, **14.59 ms moyen** | 11/11, 263.65 ms total, **23.97 ms moyen** | Oui (CP) |\n| **Z3 BitVector** (`Sudoku-12-Z3-Python`, cell 14, Hard1) | non mesure sur Easy | Hard1: **68.65 ms** | Oui (SMT) |\n\n### Observations (Prong B illustre)\n\n1. **Ecart de 1 a 3 ordres de grandeur** entre GA et solveurs exacts sur les memes instances :\n   - GA Permutations Easy : ~10 000 ms (estimation d'apres cell 22)\n   - OR-Tools CP-SAT Easy : 14.59 ms moyen\n   - **Ratio GA / OR-Tools ~ 700x** sur Easy.\n2. **Taux de succes** : 1/3 (GA) vs 10/10 (Backtracking, OR-Tools) -- les GA sont **non-garantis**, les solveurs exacts sont **complets**.\n3. **Passage a l'echelle** : OR-Tools reste ~24 ms meme sur Top11 (puzzles les plus durs), GA non teste au-dela de Easy mais extrapolation pessimiste.\n4. **Valeur pedagogique des GA** : les algorithmes genetiques ne sont **pas adaptes au Sudoku** mais illustrent une famille de methodes (recherche stochastique, sans garantie) complementaire des solveurs exacts (garantis).\n\n> **Note methodologique** : tous les chiffres cites proviennent des cellules de benchmark des notebooks sources (outputs reels, ec != null, 0 erreur). Aucune valeur fabriquee.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)\n\n### Contexte\n\nLe tableau ci-dessus compare les GA (mesure : ~1-30s par puzzle) aux solveurs exacts (~15-25 ms). Pour faire toucher du doigt le **ratio de cout**, on veut le chiffrer.\n\n### Enonce\n\nA partir des **chiffres reels** du tableau comparatif (cellule precedente) :\n\n1. Calculer le ratio `temps_GA / temps_OR-Tools` sur Easy, en utilisant :\n   - GA : le **pire cas** observe (Puzzle 3 = 29.53 s = 29530 ms, d'apres `Sudoku-3-Genetic-Python` cell 22 du notebook original).\n   - OR-Tools : le **temps moyen** sur Easy (14.59 ms).\n2. Comparer avec le ratio Backtracking / OR-Tools (143.67 / 14.59).\n3. Conclure sur la **position des GA dans la hierarchie** : efficaces / equivalentes / nettement inferieures / sans commune mesure.\n\n### Indication\n\n- `ratio_ga_ortools = temps_ga_ms / temps_ortools_ms`\n- `ratio_bt_ortools = temps_bt_moyen_ms / temps_ortools_moyen_ms`\n- Si `ratio_ga_ortools > ratio_bt_ortools * 100`, on a un ecart d'au moins 2 ordres de grandeur (Prong B demontre).\n\n### Solution (a completer par l'etudiant)\n\n```\nratio_ga_ortools = None  # TODO etudiant\nratio_bt_ortools = None  # TODO etudiant\nconclusion       = None  # TODO etudiant\n```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)\n# Cf. cellule markdown precedente pour l'enonce et les indications.\n\n# Chiffres reels tires du tableau comparatif (cellule du dessus)\nTEMPS_GA_PIRRE_MS   = 29530.0   # Pire cas Easy : Puzzle 3 (Sudoku-3 cell 22)\nTEMPS_GA_MEILLEUR_MS = 1670.0   # Meilleur cas Easy : Puzzle 1 (Sudoku-3 cell 22)\nTEMPS_BT_MOYEN_MS   = 143.67    # Backtracking moyen Easy (Sudoku-1 cell 15)\nTEMPS_ORTOOLS_MOYEN_MS = 14.59  # OR-Tools CP-SAT moyen Easy (Sudoku-10 cell 19)\n\n\ndef compute_ratio_ga_ortools() -> float:\n    \"\"\"Calcule le ratio temps_GA_pire / temps_OR-Tools_moyen (Prong B).\"\"\"\n    return None  # TODO etudiant\n\n\ndef compute_ratio_bt_ortools() -> float:\n    \"\"\"Calcule le ratio temps_BT_moyen / temps_OR-Tools_moyen.\"\"\"\n    return None  # TODO etudiant\n\n\ndef conclude_prong_b(ratio_ga: float, ratio_bt: float) -> str:\n    \"\"\"Conclut sur la position des GA dans la hierarchie des solveurs.\n\n    Returns:\n        \"memes-ordre-grandeur\", \"1-ordre\", \"2-ordres\", \"3-ordres+\", \"autre\"\n    \"\"\"\n    return None  # TODO etudiant\n\n\n# Affichage pedagogique (fonctionne meme si l'etudiant n'a pas complete)\nratio_ga = compute_ratio_ga_ortools()\nratio_bt = compute_ratio_bt_ortools()\nconclusion = conclude_prong_b(ratio_ga, ratio_bt) if ratio_ga and ratio_bt else None\n\nprint(\"=== Estimation du ratio GA / solveurs exacts (Prong B #3801) ===\")\nprint()\nprint(f\"Temps GA pire cas (Easy, Puzzle 3) : {TEMPS_GA_PIRRE_MS:.0f} ms\")\nprint(f\"Temps GA meilleur cas (Easy, P1)   : {TEMPS_GA_MEILLEUR_MS:.0f} ms\")\nprint(f\"Temps Backtracking moyen (Easy)     : {TEMPS_BT_MOYEN_MS:.1f} ms\")\nprint(f\"Temps OR-Tools CP-SAT moyen (Easy)  : {TEMPS_ORTOOLS_MOYEN_MS:.1f} ms\")\nprint()\nprint(f\"Ratio GA / OR-Tools  : {ratio_ga}\")\nprint(f\"Ratio BT / OR-Tools  : {ratio_bt}\")\nprint(f\"Conclusion Prong B   : {conclusion}\")\nprint()\nif ratio_ga is None:\n    print(\">>> Exercice a completer : implementer compute_ratio_ga_ortools() et compute_ratio_bt_ortools()\")\n"
+   ],
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Estimation du ratio GA / solveurs exacts (Prong B #3801) ===\n",
+      "\n",
+      "Temps GA pire cas (Easy, Puzzle 3) : 29530 ms\n",
+      "Temps GA meilleur cas (Easy, P1)   : 1670 ms\n",
+      "Temps Backtracking moyen (Easy)     : 143.7 ms\n",
+      "Temps OR-Tools CP-SAT moyen (Easy)  : 14.6 ms\n",
+      "\n",
+      "Ratio GA / OR-Tools  : None\n",
+      "Ratio BT / OR-Tools  : None\n",
+      "Conclusion Prong B   : None\n",
+      "\n",
+      ">>> Exercice a completer : implementer compute_ratio_ga_ortools() et compute_ratio_bt_ortools()\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### References Section 7 (chiffres verifies)\n\nLes chiffres du tableau comparatif (cellule Section 7) proviennent des cellules source suivantes :\n\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb` (cell 15 : benchmark Easy 10 puzzles, 1436.72 ms total)\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb` (cell 19 : benchmark Easy + Hard/Top11)\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb` (cell 14 : comparaison Z3 Int vs BitVector sur Hard)\n\n**Verification** : tous outputs `execution_count != null`, 0 erreur, dans les notebooks sources au moment de la rédaction (2026-07-03).\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Ajout d'une **Section 7 (Comparaison quantitative avec solveurs exacts)** + **1 exercice C.1** au notebook `Sudoku-3-Genetic-Python.ipynb`. La section presente un tableau comparatif des 4 solveurs Python de la serie (GA Permutations, Backtracking simple, OR-Tools CP-SAT, Z3 BitVector) avec les **chiffres reels** publies dans les notebooks sources, illustrant Prong B #3801 (SOTA vs workaround degrade) : ecart de 1-3 ordres de grandeur entre solveurs stochastiques et solveurs exacts.

## Pourquoi cette section (Prong B #3801)

Le benchmark original (Section 5) du notebook mesurait les algorithmes genetiques sur **3 puzzles faciles** (1/3 resolu, ~1-30s par puzzle) sans situer les GA par rapport aux solveurs exacts voisins. Cette Section 7 comble le gap pedagogique en montrant :

- **GA Permutations** : 1/3 resolus Easy, ~10s (mesure Section 5)
- **Backtracking simple** : 10/10 Easy, 143.67 ms moyen (Sudoku-1 cell 15)
- **OR-Tools CP-SAT** : 10/10 Easy / 11/11 Hard, 14.59/23.97 ms moyen (Sudoku-10 cell 19)
- **Z3 BitVector** : 68.65 ms sur Hard1 (Sudoku-12 cell 14)

**Ratio GA / OR-Tools ~ 700x** sur Easy = **demonstration quantitative** que les GA sont inadaptes au Sudoku en production (meme si pedagogiquement riches).

## Contenu ajoute (4 cellules, 50 insertions, 0 modification)

| Cell | Type | Contenu |
|------|------|---------|
| 30 | markdown | Section 7 + tableau comparatif 4 solveurs avec sources citees |
| 31 | markdown | Exercice C.1 "Estimer le ratio GA / solveur-exact (Prong B reflexif)" |
| 32 | code | Stub C.1-compliant (`return None  # TODO etudiant`) avec chiffres reels + print pedagogique |
| 33 | markdown | References verifiees (cell 15/19/14 des notebooks sources) |

## Regles respectees

- **C.1 (no NotImplementedError)** : exercice utilise `return None  # TODO etudiant`, s'execute de bout en bout meme non complete.
- **C.2 (outputs reels)** : Papermill SUCCESS ec=12 0 erreur, sortie `Ratio GA / OR-Tools: None` + message "Exercice a completer" (coherent avec stub).
- **C.3 (scope strict)** : seul ce notebook modifie et stage. Aucun autre fichier.
- **Anti-regression** : 30 cellules existantes preservees + leurs `execution_count` (1 a 11) et outputs (verifie post-exec).
- **#2161 (3 exercices/notebook)** : passe de 3 a 4 exercices (cell 11 + 19 + 27 + 32). 4/4 OK.
- **Prong B #3801** : probleme non-trivial (comparaison quantitative cross-notebook), moteur mis en valeur (ecart mesure).
- **Stop & Repair** : aucun hand-edit d'output. Tous les chiffres sont des outputs reels des notebooks sources (ec != null, 0 erreur).
- **catalog-pr-hygiene R1** : CATALOG-STATUS byte-identique (verifie).
- **#4940 (Phase 2 Python)** : 1ere PR Python livree. 4 notebooks Python supplementaires identifies comme gap pedagogique (mono-instance) pour C190+.

## Verification Papermill

```
=== Estimation du ratio GA / solveurs exacts (Prong B #3801) ===

Temps GA pire cas (Easy, Puzzle 3) : 29530 ms
Temps GA meilleur cas (Easy, P1)   : 1670 ms
Temps Backtracking moyen (Easy)     : 143.7 ms
Temps OR-Tools CP-SAT moyen (Easy)  : 14.6 ms

Ratio GA / OR-Tools  : None
Ratio BT / OR-Tools  : None
Conclusion Prong B   : None

>>> Exercice a completer : implementer compute_ratio_ga_ortools() et compute_ratio_bt_ortools()

PAPERMILL: SUCCESS, 1/1 cell, 0 erreur, ec=12.
```

Execution_count des cellules existantes preserve :
- cell 1: ec=1
- cell 5: ec=3
- cell 8: ec=4
- cell 13: ec=6
- cell 16: ec=7
- cell 21: ec=9
- cell 25: ec=10
- cell 27: ec=11
- cell 32: ec=12 (NEW)

## Statistiques

- 4 cellules ajoutees, 30 preservees
- 50 insertions / 1 deletion / 1 fichier (scope atomique)
- Section pedagogique = markdown pur (pas de re-execution PyGAD longue)

## Liens

- #4940 — Phase 2 Python (1ere PR sur 5 notebooks Python identifies)
- #3801 — Prong B SOTA + probleme non-trivial illustre
- #2161 — Convention 3 exercices/notebook (passe de 3 a 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>