### PR TITLE
fix(ci): add tactic sorry-filter mode for calibration_lean (Closes #5120)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -13,7 +13,7 @@ name: Lean Build (reusable)
 #         project-path:      MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
 #         display-name:      grothendieck_lean
 #         sorry-baseline:    "0"
-#         sorry-filter-mode: prose-header   # raw | prose-header | standalone-tactic
+#         sorry-filter-mode: prose-header   # raw | prose-header | standalone-tactic | tactic
 #
 # Sorry-filter modes (chosen per project's sorry "profile"):
 #   raw               : grep -c "sorry"                          (every mention)
@@ -21,11 +21,18 @@ name: Lean Build (reusable)
 #   standalone-tactic : sorry as the sole tactic token on a line, INCLUDING the
 #                       Lean case-bullet form `· sorry` (U+00B7), which a bare
 #                       `^\s*sorry\s*$` silently dropped (blind spot, See #2747)
+#   tactic            : strip the case-bullet (·) AND any trailing inline comment
+#                       (`-- ...`), then count lines that are exactly `sorry`. This
+#                       catches the bullet+comment fixture form `· sorry -- comment`
+#                       that standalone-tactic misses, while excluding prose mentions
+#                       of "sorry" in docstrings/comments. (See #5120.)
 # Use raw only when sorry ALWAYS means tactic (no prose mentions). Use prose-header
 # when the only non-tactic mentions are "sorries"/"sorry's" in header comments.
 # Use standalone-tactic when there are MANY prose mentions of "sorry" mixed with
-# real tactic sorries (e.g. Conway block comments). Choose the mode whose baseline
-# is robust to editing comments in that project.
+# real tactic sorries (e.g. Conway block comments). Use tactic when the project's
+# real sorries carry a trailing inline comment (`· sorry -- ...`) AND prose also
+# mentions "sorry" (e.g. calibration_lean's bilingual P4 docstrings, See #5120).
+# Choose the mode whose baseline is robust to editing comments in that project.
 
 on:
   workflow_call:
@@ -43,7 +50,7 @@ on:
         type: string
         required: true
       sorry-filter-mode:
-        description: "How to count sorry: raw | prose-header | standalone-tactic"
+        description: "How to count sorry: raw | prose-header | standalone-tactic | tactic"
         type: string
         required: true
 
@@ -81,6 +88,16 @@ jobs:
                 # spot, See #2747). Strip bullet bytes (c2 b7) first so BOTH
                 # forms match in any locale (byte-exact, not UTF-8 dependent).
                 COUNT=$(tr -d '\302\267' < "$f" | grep -cE "^\s*sorry\s*$" || true) ;;
+              tactic)
+                # Like standalone-tactic but ALSO strips any trailing inline
+                # comment (`-- ...`) before matching, so the fixture form
+                # `· sorry -- comment` is counted as the tactic it is. Closes
+                # the standalone-tactic blind spot for projects whose real
+                # sorries carry an inline comment (e.g. calibration_lean P4
+                # targets). Prose mentions of "sorry" in docstrings/comments
+                # remain excluded because they are never the sole token after
+                # comment-stripping. (See #5120.)
+                COUNT=$(tr -d '\302\267' < "$f" | sed 's/--.*$//' | grep -cE "^\s*sorry\s*$" || true) ;;
               *)
                 echo "ERROR: unknown sorry-filter-mode '$MODE'"; exit 2 ;;
             esac

--- a/.github/workflows/lean-calibration.yml
+++ b/.github/workflows/lean-calibration.yml
@@ -7,12 +7,17 @@ name: Lean Calibration CI
 # Migrated to the reusable lean-build.yml per ai-01 DRY decision (option 2: matrix).
 # Behavior is identical to the former inline check-sorry + build jobs.
 #
-# Sorry profile (verified 2026-06-10, raw mode, baseline=4): the 4 raw "sorry"
-# mentions in Nash.lean are 2 INTENTIONAL P4 tactic targets (L95/L96 — the
-# sorry-increase case the harness must NOT revert) + 2 prose mentions (L89/L97
-# describing them). raw mode + baseline 4 preserves the exact prior enforcement:
-# any new sorry-as-tactic raises the raw count >4 and fails. (standalone-tactic
-# would read 0 here because the P4 sorries carry a leading `·` and inline comment.)
+# Sorry profile (verified 2026-07-03, tactic mode, baseline=4): Nash.lean carries
+# 4 INTENTIONAL P4 tactic sorries (the `· sorry -- comment` fixture form, now
+# bilingual FR+EN after #5112 — 2 per language block) that the harness must NOT
+# revert, plus 6 prose mentions of "sorry" in the P4 docstrings describing the
+# sorry-increase calibration target. `raw` mode (used until #5120) counted every
+# mention, so the i18n PR #5112 doubled the prose and raised raw 4->10 = false
+# positive on a docstring-only PR. `tactic` mode strips the bullet AND the
+# trailing inline comment before matching `^\s*sorry\s*$`, so it counts exactly
+# the 4 real tactic sorries and is robust to any prose growth/shrinkage (FR/EN).
+# standalone-tactic would read 0 here (blind spot: the fixtures carry a trailing
+# comment), so it fails the negative test for a `· sorry -- comment` regression.
 
 on:
   push:
@@ -38,4 +43,4 @@ jobs:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean
       display-name: calibration_lean
       sorry-baseline: "4"
-      sorry-filter-mode: raw
+      sorry-filter-mode: tactic


### PR DESCRIPTION
## Problem (#5120)

The `Lean CI (calibration_lean)` gate uses `sorry-filter-mode: raw` (substring `grep -c "sorry"`), which counts "sorry" in **docstring prose**, not just compiled sorry tactics. `calibration_lean` is the prover-harness calibration bench: `Nash.lean` carries **4 intentional P4 tactic sorries** (the `· sorry -- comment` fixture form, bilingual FR+EN after #5112) plus **6 prose mentions** of "sorry" in the P4 "sorry-increase calibration target" docstrings.

`raw` counted every mention, so the i18n PR **#5112** (docstring-only, code byte-identical, `lake build SUCCESS`) raised the raw count **4 → 10** = **false positive**. It was merged with admin override after firsthand verification. The workflow baseline on `main` is still `4`, so **the gate is currently broken** — any future `calibration_lean` PR (i18n, docstring enrich, new target) will fail.

## Fix

1. **New additive mode `tactic`** in the shared `lean-build.yml` reusable workflow: strip the Lean case-bullet (`·`, U+00B7) **and** any trailing inline comment (`-- ...`), then count lines matching `^\s*sorry\s*$`. This catches the bullet+comment fixture form that `standalone-tactic` misses, while excluding prose.

2. **Switch `lean-calibration.yml`** from `raw` to `tactic` mode. Baseline stays `4` — it now tracks exactly the 4 real tactic sorries (was 2 tactics + 2 prose under `raw`).

## Why not `standalone-tactic` baseline 0 (the issue's literal suggestion)

`standalone-tactic` reads **0** on the calibration_lean fixtures, because the P4 sorries carry a trailing inline comment (`· sorry -- comment`) that `^\s*sorry\s*$` doesn't match after bullet-strip. Setting baseline 0 would **fail acceptance #2** — it would miss a `· sorry -- comment` regression, which is precisely this project's fixture form. The new `tactic` mode closes that blind spot.

## Acceptance (#5120) — all verified locally

| Test | Command logic | Result |
|------|---------------|--------|
| **Positive** (CI green on main) | `tactic` mode on origin/main `Nash.lean` | count **4** = baseline 4 ✓ (was: raw reads 10 > 4, failing) |
| **Prose-only** (no FP on i18n) | + sorry-mention prose comment lines | count stays **4** ✓ |
| **Negative** (catches real regression) | append a new sorry tactic — pure `sorry`, `· sorry`, `· sorry -- comment`, `sorry -- comment` | count **5 > 4** → FAIL, **all 4 forms caught** ✓ |

## Scope

2 files, +33/-11. **Additive**: `lean-build.yml` gains a new enum value + `case` branch; the 20 other `lean-*` callers using `raw`/`prose-header`/`standalone-tactic` are **unaffected**. Both files pass YAML validation.

Closes #5120
