### PR TITLE
docs(lean-i18n): lean_game_defs_ext tranche 1 docstrings bilingues FR+EN (#4980 étape 3)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian.lean
@@ -1,4 +1,42 @@
 /-
+  Jeux bayésiens — module racine
+  ==============================
+
+  Formalisation en Lean 4 core uniquement (sans Mathlib) des jeux
+  bayésiens finis à deux joueurs (espaces de types de Harsanyi, utilité
+  espérée interimaire, équilibre de Nash bayésien). Compagnon du
+  notebook GameTheory-11-BayesianGames.ipynb.
+
+  Modules :
+  - `Bayesian.Sum`      — sommes finies sur `Fin n` avec les lemmes requis
+  - `Bayesian.Types`    — `BayesGame2`, stratégies, utilité interim/ex-ante
+  - `Bayesian.BNE`      — `isBNE` décidable, principe de déviation unique,
+                          invariance par remise à l'échelle du prior
+  - `Bayesian.Examples` — Bataille des Sexes en information incomplète,
+                          équilibre certifié par `decide`
+  - `Bayesian.Auction`  — enchère scellée au premier prix : l'offre sincère
+                          rapporte zéro (théorème général), BNE de shading
+                          d'offre certifié par `decide` (phase 2)
+  - `Bayesian.Vickrey`  — enchère au second prix : l'offre sincère est
+                          faiblement dominante, BNE pour tout `n` (phase 3)
+  - `Bayesian.Max`      — maxima finis sur `Fin (n + 1)`, max-de-la-somme
+                          vs somme-des-max (phase 4)
+  - `Bayesian.Information` — valeur de l'information pour un décideur
+                          unique : signaux comme partitions, monotonie de
+                          Blackwell, pas-d'info ≤ signal ≤ parfait (phase 4)
+  - `Bayesian.InfoGames` — contre-exemple : dans un *jeu*, plus
+                          d'information peut nuire strictement au joueur
+                          informé (paiements de BNE unique 3 < 5,
+                          vérifié au noyau) (phase 4)
+  - `Bayesian.Reputation` — dissuasion d'entrée / réputation de la firme
+                          établie : BNE crédible unique avec et sans
+                          incertitude sur le type, la réputation paie 5 > 4
+                          (phase 5)
+
+  Voir #2610 (formalisation GT-Lean, phases 1-5 : jeux bayésiens).
+
+  ---
+  English:
   Bayesian Games — root module
   ============================
 

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/BNE.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/BNE.lean
@@ -1,4 +1,24 @@
 /-
+  Équilibre de Nash bayésien (formulation interimaire)
+  ====================================================
+
+  - `isBNE` : un profil de stratégies est un BNE quand aucun type de
+    l'un ou l'autre joueur n'a de déviation unilatérale d'action
+    profitable, en utilité espérée interimaire. Les quantificateurs
+    portent uniquement sur les types et actions `Fin`, donc la propriété
+    est décidable (`decide` fonctionne sur des jeux concrets).
+  - `exAnteU1_le_of_interim_best` : le principe de déviation unique dans
+    ce cadre fini — l'optimalité interimaire implique l'optimalité ex-ante
+    vis-à-vis de déviations contingentes au type arbitraires.
+  - `isBNE_scaleW` : le BNE est invariant par remise à l'échelle des poids
+    du prior par une constante positive (indépendance de normalisation :
+    les poids `Nat` représentent toute mesure de probabilité qui leur est
+    proportionnelle).
+
+  Voir #2610 (formalisation GT-Lean, phase bayésienne 1).
+
+  ---
+  English:
   Bayesian Nash Equilibrium (interim formulation)
   ===============================================
 
@@ -18,7 +38,14 @@
 
 import Bayesian.Types
 
-/-- Bayesian Nash equilibrium, interim formulation: for every type of
+/-- Équilibre de Nash bayésien, formulation interimaire : pour chaque type de
+    chaque joueur, l'action prescrite maximise l'utilité espérée interimaire
+    face à la stratégie de l'adversaire.
+
+    Réductible pour que l'instance `Decidable` soit trouvée par dépliage
+    (conjonction de `∀` sur `Fin` de comparaisons `Int` décidables).
+
+    English: Bayesian Nash equilibrium, interim formulation: for every type of
     each player, the prescribed action maximizes interim expected
     utility against the opponent's strategy.
 
@@ -30,7 +57,10 @@ import Bayesian.Types
   (∀ t2 : Fin g.nT2, ∀ a : Fin g.nA2,
       interimU2 g t2 a s1 ≤ interimU2 g t2 (s2 t2) s1)
 
-/-- One-shot deviation principle, player 1 side: if every type of
+/-- Principe de déviation unique, côté joueur 1 : si chaque type du
+    joueur 1 joue une meilleure réponse interimaire, alors aucune déviation
+    contingente au type `s1'` n'améliore l'utilité espérée ex-ante du joueur 1.
+    English: One-shot deviation principle, player 1 side: if every type of
     player 1 plays an interim best response, then no type-contingent
     deviation `s1'` improves player 1's ex-ante expected utility. -/
 theorem exAnteU1_le_of_interim_best (g : BayesGame2)
@@ -40,7 +70,8 @@ theorem exAnteU1_le_of_interim_best (g : BayesGame2)
     exAnteU1 g s1' s2 ≤ exAnteU1 g s1 s2 :=
   sumFin_mono (fun t1 => h t1 (s1' t1))
 
-/-- One-shot deviation principle, player 2 side. -/
+/-- Principe de déviation unique, côté joueur 2.
+    English: One-shot deviation principle, player 2 side. -/
 theorem exAnteU2_le_of_interim_best (g : BayesGame2)
     {s1 : Strategy1 g} {s2 : Strategy2 g}
     (h : ∀ t2 a, interimU2 g t2 a s1 ≤ interimU2 g t2 (s2 t2) s1)
@@ -48,7 +79,9 @@ theorem exAnteU2_le_of_interim_best (g : BayesGame2)
     exAnteU2 g s1 s2' ≤ exAnteU2 g s1 s2 :=
   sumFin_mono (fun t2 => h t2 (s2' t2))
 
-/-- A BNE is also an ex-ante Nash equilibrium: no player gains from
+/-- Un BNE est aussi un équilibre de Nash ex-ante : aucun joueur ne gagne
+    à dévier unilatéralement de façon contingente au type.
+    English: A BNE is also an ex-ante Nash equilibrium: no player gains from
     any type-contingent unilateral deviation. -/
 theorem bne_exAnte (g : BayesGame2) {s1 : Strategy1 g} {s2 : Strategy2 g}
     (h : isBNE g s1 s2) :
@@ -56,7 +89,8 @@ theorem bne_exAnte (g : BayesGame2) {s1 : Strategy1 g} {s2 : Strategy2 g}
     (∀ s2', exAnteU2 g s1 s2' ≤ exAnteU2 g s1 s2) :=
   ⟨exAnteU1_le_of_interim_best g h.1, exAnteU2_le_of_interim_best g h.2⟩
 
-/-- The same game with all prior weights multiplied by `c`. -/
+/-- Le même jeu avec tous les poids du prior multipliés par `c`.
+    English: The same game with all prior weights multiplied by `c`. -/
 @[reducible] def scaleW (g : BayesGame2) (c : Nat) : BayesGame2 :=
   { g with w := fun t1 t2 => c * g.w t1 t2 }
 
@@ -78,7 +112,10 @@ theorem interimU2_scaleW (g : BayesGame2) (c : Nat)
   intro t1
   rw [Int.natCast_mul, Int.mul_assoc]
 
-/-- BNE is invariant under positive rescaling of the prior weights.
+/-- Le BNE est invariant par remise à l'échelle positive des poids du prior.
+    C'est ce qui fait des poids `Nat` non normalisés un encodage fidèle
+    d'un prior commun : seuls les rapports des poids importent.
+    English: BNE is invariant under positive rescaling of the prior weights.
     This is what makes unnormalized `Nat` weights a faithful encoding
     of a common prior: only ratios of weights matter. -/
 theorem isBNE_scaleW (g : BayesGame2) (c : Nat) (hc : 0 < c)

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Examples.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Examples.lean
@@ -1,4 +1,27 @@
 /-
+  Exemple résolu — Bataille des Sexes en information incomplète
+  ============================================================
+
+  L'illustration classique de Harsanyi : le joueur 1 ne sait pas si le
+  joueur 2 veut le rencontrer (se coordonner) ou l'éviter. La préférence
+  du joueur 2 est son type privé ; le prior donne un poids égal aux deux
+  types.
+
+  Actions (les deux joueurs) : 0 = Ballet, 1 = Football.
+  Le joueur 1 préfère le Ballet (paiement 2 sur (B,B), 1 sur (F,F), 0 en cas
+  de désaccord).
+  Le type « rencontrer » du joueur 2 préfère le Football mais veut coordonner.
+  Le type « éviter » du joueur 2 veut DÉSaccorder : 2 si (B,F), 1 si (F,B).
+
+  Le BNE pur du manuel — le joueur 1 joue Ballet ; le joueur 2 joue Ballet
+  lorsqu'il est du type « rencontrer » et Football lorsqu'il est du type
+  « éviter » — est vérifié ci-dessous par `decide`, exerçant la décidabilité
+  de `isBNE`.
+
+  Reflète GameTheory-11-BayesianGames.ipynb. Voir #2610.
+
+  ---
+  English:
   Worked Example — Battle of the Sexes with Incomplete Information
   ================================================================
 
@@ -21,7 +44,10 @@
 
 import Bayesian.BNE
 
-/-- Battle of the Sexes where player 2's desire to meet or avoid
+/-- Bataille des Sexes où le désir du joueur 2 de rencontrer ou d'éviter
+    le joueur 1 est une information privée (prior uniforme sur les deux types).
+    Type 0 du joueur 2 = « rencontrer », type 1 = « éviter ».
+    English: Battle of the Sexes where player 2's desire to meet or avoid
     player 1 is private information (uniform prior over both types).
     Type 0 of player 2 = "meet", type 1 = "avoid". -/
 def bosIncomplete : BayesGame2 where
@@ -34,34 +60,46 @@ def bosIncomplete : BayesGame2 where
     if a1.val = a2.val then (if a1.val = 0 then 2 else 1) else 0
   u2 := fun _ t2 a1 a2 =>
     if t2.val = 0 then
-      -- meet type: wants to coordinate, prefers Football
+      -- type « rencontrer » : veut coordonner, préfère le Football
+      -- "meet" type: wants to coordinate, prefers Football
       if a1.val = a2.val then (if a1.val = 0 then 1 else 2) else 0
     else
-      -- avoid type: wants to MISmatch
+      -- type « éviter » : veut DÉSaccorder
+      -- "avoid" type: wants to MISmatch
       if a1.val = 0 ∧ a2.val = 1 then 2
       else if a1.val = 1 ∧ a2.val = 0 then 1
       else 0
 
-/-- Player 1 (single type) plays Ballet. -/
+/-- Le joueur 1 (type unique) joue Ballet.
+    English: Player 1 (single type) plays Ballet. -/
 def bosS1 : Strategy1 bosIncomplete := fun _ => ⟨0, by decide⟩
 
-/-- Player 2 plays Ballet when of the meet type, Football when of the
+/-- Le joueur 2 joue Ballet lorsqu'il est du type « rencontrer », Football
+    lorsqu'il est du type « éviter ».
+    English: Player 2 plays Ballet when of the meet type, Football when of the
     avoid type. -/
 def bosS2 : Strategy2 bosIncomplete := fun t2 =>
   if t2.val = 0 then ⟨0, by decide⟩ else ⟨1, by decide⟩
 
-/-- The textbook strategy profile is a Bayesian Nash equilibrium,
+/-- Le profil de stratégies du manuel est un équilibre de Nash bayésien,
+    vérifié par calcul.
+    English: The textbook strategy profile is a Bayesian Nash equilibrium,
     verified by computation. -/
 theorem bosIncomplete_bne : isBNE bosIncomplete bosS1 bosS2 := by decide
 
-/-- Sanity check: under the equilibrium, player 1's interim expected
+/-- Vérification de cohérence : sous l'équilibre, l'utilité espérée interimaire
+    du joueur 1 issue du Ballet est 2 (il rencontre le type « rencontrer »,
+    manque le type « éviter ») contre 1 s'il dévie vers le Football.
+    English: Sanity check: under the equilibrium, player 1's interim expected
     utility from Ballet is 2 (meets the meet type, misses the avoid
     type) versus 1 from deviating to Football. -/
 theorem bosIncomplete_interim_values :
     interimU1 bosIncomplete ⟨0, by decide⟩ ⟨0, by decide⟩ bosS2 = 2 ∧
     interimU1 bosIncomplete ⟨0, by decide⟩ ⟨1, by decide⟩ bosS2 = 1 := by decide
 
-/-- The equilibrium survives rescaling the prior weights (e.g. weights
+/-- L'équilibre survit à la remise à l'échelle des poids du prior (par ex.
+    les poids (3, 3) au lieu de (1, 1) encodent le même prior uniforme).
+    English: The equilibrium survives rescaling the prior weights (e.g. weights
     (3, 3) instead of (1, 1) encode the same uniform prior). -/
 theorem bosIncomplete_bne_scaled : isBNE (scaleW bosIncomplete 3) bosS1 bosS2 :=
   (isBNE_scaleW bosIncomplete 3 (by decide) bosS1 bosS2).mpr bosIncomplete_bne

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Sum.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Sum.lean
@@ -1,4 +1,17 @@
 /-
+  Sommes finies sur `Fin n` (Lean 4 core uniquement, sans Mathlib)
+  ==============================================================
+
+  Infrastructure de sommation minimale pour les utilités espérées des
+  jeux bayésiens. Le `Finset.sum` de Mathlib n'est pas disponible (projet
+  core-only), donc nous définissons une récursion structurelle et prouvons
+  les trois lemmes dont le développement de théorie des jeux a besoin :
+  monotonie, multiplication scalaire et congruence.
+
+  Voir #2610 (formalisation GT-Lean, phase bayésienne 1).
+
+  ---
+  English:
   Finite sums over `Fin n` (core Lean 4 only, no Mathlib)
   =======================================================
 
@@ -11,7 +24,8 @@
   See #2610 (GT-Lean formalization, Bayesian phase 1).
 -/
 
-/-- Sum of `f` over all of `Fin n`, by structural recursion on `n`. -/
+/-- Somme de `f` sur tout `Fin n`, par récursion structurelle sur `n`.
+    English: Sum of `f` over all of `Fin n`, by structural recursion on `n`. -/
 def sumFin : (n : Nat) → (Fin n → Int) → Int
   | 0, _ => 0
   | n + 1, f => f 0 + sumFin n (fun i => f i.succ)
@@ -21,14 +35,16 @@ def sumFin : (n : Nat) → (Fin n → Int) → Int
 @[simp] theorem sumFin_succ (n : Nat) (f : Fin (n + 1) → Int) :
     sumFin (n + 1) f = f 0 + sumFin n (fun i => f i.succ) := rfl
 
-/-- The sum of the zero function vanishes. -/
+/-- La somme de la fonction nulle s'annule.
+    English: The sum of the zero function vanishes. -/
 @[simp] theorem sumFin_zero_fun (n : Nat) :
     sumFin n (fun _ => (0 : Int)) = 0 := by
   induction n with
   | zero => simp
   | succ n ih => simp [ih]
 
-/-- Pointwise dominance transfers to the sums. -/
+/-- La domination point par point se transmet aux sommes.
+    English: Pointwise dominance transfers to the sums. -/
 theorem sumFin_mono {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i ≤ g i) :
     sumFin n f ≤ sumFin n g := by
   induction n with
@@ -37,7 +53,8 @@ theorem sumFin_mono {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i ≤ g i) :
     simp only [sumFin_succ]
     exact Int.add_le_add (h 0) (ih (fun i => h i.succ))
 
-/-- Pointwise equal functions have equal sums. -/
+/-- Des fonctions égales point par point ont des sommes égales.
+    English: Pointwise equal functions have equal sums. -/
 theorem sumFin_congr {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i = g i) :
     sumFin n f = sumFin n g := by
   induction n with
@@ -46,7 +63,8 @@ theorem sumFin_congr {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i = g i) :
     simp only [sumFin_succ]
     rw [h 0, ih (fun i => h i.succ)]
 
-/-- A constant factor distributes out of the sum. -/
+/-- Un facteur constant se distribue hors de la somme.
+    English: A constant factor distributes out of the sum. -/
 theorem sumFin_mul_left {n : Nat} (c : Int) (f : Fin n → Int) :
     sumFin n (fun i => c * f i) = c * sumFin n f := by
   induction n with
@@ -55,7 +73,8 @@ theorem sumFin_mul_left {n : Nat} (c : Int) (f : Fin n → Int) :
     simp only [sumFin_succ]
     rw [ih, Int.mul_add]
 
-/-- Sums distribute over pointwise addition. -/
+/-- Les sommes se distribuent sur l'addition point par point.
+    English: Sums distribute over pointwise addition. -/
 theorem sumFin_add {n : Nat} (f g : Fin n → Int) :
     sumFin n (fun i => f i + g i) = sumFin n f + sumFin n g := by
   induction n with
@@ -65,7 +84,8 @@ theorem sumFin_add {n : Nat} (f g : Fin n → Int) :
     rw [ih]
     omega
 
-/-- Double sums commute (Fubini for finite sums). -/
+/-- Les doubles sommes commutent (Fubini pour les sommes finies).
+    English: Double sums commute (Fubini for finite sums). -/
 theorem sumFin_comm {n m : Nat} (F : Fin n → Fin m → Int) :
     sumFin n (fun i => sumFin m (fun j => F i j)) =
     sumFin m (fun j => sumFin n (fun i => F i j)) := by
@@ -75,13 +95,16 @@ theorem sumFin_comm {n m : Nat} (F : Fin n → Fin m → Int) :
     simp only [sumFin_succ]
     rw [ih (fun i j => F i.succ j), ← sumFin_add]
 
-/-- An `if` whose condition does not depend on the index pulls out of
+/-- Un `if` dont la condition ne dépend pas de l'indice sort de la somme
+    (la branche `else 0` correspond à la somme vide).
+    English: An `if` whose condition does not depend on the index pulls out of
     the sum (the `else 0` branch matches the empty sum). -/
 theorem sumFin_if_distrib {n : Nat} (c : Prop) [Decidable c] (f : Fin n → Int) :
     sumFin n (fun i => if c then f i else 0) = if c then sumFin n f else 0 := by
   by_cases h : c <;> simp [h]
 
-/-- Summing an indicator of a single point picks out that point's value. -/
+/-- Sommer un indicateur d'un point unique sélectionne la valeur de ce point.
+    English: Summing an indicator of a single point picks out that point's value. -/
 theorem sumFin_single : ∀ {n : Nat} (c : Fin n) (x : Fin n → Int),
     sumFin n (fun j => if c = j then x j else 0) = x c
   | 0, c, _ => c.elim0
@@ -105,7 +128,9 @@ theorem sumFin_single : ∀ {n : Nat} (c : Fin n) (x : Fin n → Int),
         · rw [if_neg (fun hs => h (Fin.succ_inj.mp hs)), if_neg h]
       rw [sumFin_congr hcond, sumFin_single j (fun i => x i.succ)]
 
-/-- Decompose a sum over states into groups indexed by the value of a
+/-- Décompose une somme sur les états en groupes indexés par la valeur d'une
+    application de classification (double comptage fini).
+    English: Decompose a sum over states into groups indexed by the value of a
     classifying map (finite double counting). -/
 theorem sumFin_partition {n m : Nat} (σ : Fin n → Fin m) (f : Fin n → Int) :
     sumFin n f = sumFin m (fun k => sumFin n (fun s => if σ s = k then f s else 0)) := by

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Types.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Types.lean
@@ -1,4 +1,28 @@
 /-
+  Espaces de types de Harsanyi — jeux bayésiens finis à deux joueurs
+  =================================================================
+
+  Formalise les jeux à information incomplète (Harsanyi 1967) pour le cas
+  fini à deux joueurs, en Lean 4 core (sans Mathlib) :
+
+  - `BayesGame2` : ensembles de types, ensembles d'actions, un prior commun
+    non normalisé donné par des poids `Nat`, et des paiements dépendant du type
+  - `Strategy1` / `Strategy2` : stratégies pures contingentes au type
+  - `interimU1` / `interimU2` : utilité espérée interimaire (conditionnée par
+    son propre type), comme une somme pondérée sur les types de l'adversaire
+  - `exAnteU1` / `exAnteU2` : utilité espérée ex-ante
+
+  Travailler avec des poids entiers plutôt qu'avec une mesure de probabilité
+  normalisée garde toute quantité calculable et décidable ; `BNE.lean` prouve
+  que les meilleures réponses sont invariantes par remise à l'échelle du prior,
+  ce qui est exactement ce que signifie l'indépendance vis-à-vis de la
+  normalisation.
+
+  Basé sur GameTheory-11-BayesianGames.ipynb. Voir #2610 (phase 1 :
+  jeux bayésiens — le rapport de recherche recommande les types finis d'abord).
+
+  ---
+  English:
   Harsanyi Type Spaces — Two-Player Finite Bayesian Games
   =======================================================
 
@@ -23,35 +47,58 @@
 
 import Bayesian.Sum
 
-/-- A two-player finite Bayesian game with an unnormalized prior.
+/-- Un jeu bayésien fini à deux joueurs avec un prior non normalisé.
+
+    Le joueur 1 a `nT1` types possibles et `nA1` actions ; le joueur 2 a
+    `nT2` types et `nA2` actions. `w t1 t2` est le poids (non normalisé,
+    `Nat`) du prior pour le profil de types `(t1, t2)`. Les paiements
+    dépendent du profil de types complet et du profil d'actions.
+
+    English: A two-player finite Bayesian game with an unnormalized prior.
 
     Player 1 has `nT1` possible types and `nA1` actions; player 2 has
     `nT2` types and `nA2` actions. `w t1 t2` is the (unnormalized,
     `Nat`) prior weight of the type profile `(t1, t2)`. Payoffs depend
     on the full type profile and the action profile. -/
 structure BayesGame2 where
-  /-- Number of types of player 1 -/
+  /-- Nombre de types du joueur 1.
+      English: Number of types of player 1 -/
   nT1 : Nat
-  /-- Number of types of player 2 -/
+  /-- Nombre de types du joueur 2.
+      English: Number of types of player 2 -/
   nT2 : Nat
-  /-- Number of actions of player 1 -/
+  /-- Nombre d'actions du joueur 1.
+      English: Number of actions of player 1 -/
   nA1 : Nat
-  /-- Number of actions of player 2 -/
+  /-- Nombre d'actions du joueur 2.
+      English: Number of actions of player 2 -/
   nA2 : Nat
-  /-- Common prior over type profiles, as unnormalized weights -/
+  /-- Prior commun sur les profils de types, comme poids non normalisés.
+      English: Common prior over type profiles, as unnormalized weights -/
   w : Fin nT1 → Fin nT2 → Nat
-  /-- Payoff of player 1 -/
+  /-- Paiement du joueur 1.
+      English: Payoff of player 1 -/
   u1 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int
-  /-- Payoff of player 2 -/
+  /-- Paiement du joueur 2.
+      English: Payoff of player 2 -/
   u2 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int
 
-/-- A pure type-contingent strategy of player 1: own type → action. -/
+/-- Une stratégie pure contingente au type du joueur 1 : son propre type → action.
+    English: A pure type-contingent strategy of player 1: own type → action. -/
 def Strategy1 (g : BayesGame2) := Fin g.nT1 → Fin g.nA1
 
-/-- A pure type-contingent strategy of player 2: own type → action. -/
+/-- Une stratégie pure contingente au type du joueur 2 : son propre type → action.
+    English: A pure type-contingent strategy of player 2: own type → action. -/
 def Strategy2 (g : BayesGame2) := Fin g.nT2 → Fin g.nA2
 
-/-- Interim expected utility of player 1: of type `t1`, playing action
+/-- Utilité espérée interimaire du joueur 1 : de type `t1`, jouant l'action
+    `a`, face à la stratégie `s2`, pondérée par la ligne du prior `w t1 ·`.
+
+    (Avec des poids non normalisés, c'est l'espérance conditionnelle
+    mise à l'échelle par la constante positive `Σ_{t2} w t1 t2` — les
+    maximiseurs ne sont pas affectés, voir `BNE.lean`.)
+
+    English: Interim expected utility of player 1: of type `t1`, playing action
     `a`, against strategy `s2`, weighted by the prior row `w t1 ·`.
 
     (With unnormalized weights this is the conditional expectation
@@ -61,17 +108,22 @@ def interimU1 (g : BayesGame2) (t1 : Fin g.nT1) (a : Fin g.nA1)
     (s2 : Strategy2 g) : Int :=
   sumFin g.nT2 (fun t2 => (g.w t1 t2 : Int) * g.u1 t1 t2 a (s2 t2))
 
-/-- Interim expected utility of player 2: of type `t2`, playing action
+/-- Utilité espérée interimaire du joueur 2 : de type `t2`, jouant l'action
+    `a`, face à la stratégie `s1`, pondérée par la colonne du prior `w · t2`.
+    English: Interim expected utility of player 2: of type `t2`, playing action
     `a`, against strategy `s1`, weighted by the prior column `w · t2`. -/
 def interimU2 (g : BayesGame2) (t2 : Fin g.nT2) (a : Fin g.nA2)
     (s1 : Strategy1 g) : Int :=
   sumFin g.nT1 (fun t1 => (g.w t1 t2 : Int) * g.u2 t1 t2 (s1 t1) a)
 
-/-- Ex-ante expected utility of player 1 under a strategy profile:
+/-- Utilité espérée ex-ante du joueur 1 sous un profil de stratégies :
+    somme des utilités interimbaires sur les propres types du joueur 1.
+    English: Ex-ante expected utility of player 1 under a strategy profile:
     sum of interim utilities over player 1's own types. -/
 def exAnteU1 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=
   sumFin g.nT1 (fun t1 => interimU1 g t1 (s1 t1) s2)
 
-/-- Ex-ante expected utility of player 2 under a strategy profile. -/
+/-- Utilité espérée ex-ante du joueur 2 sous un profil de stratégies.
+    English: Ex-ante expected utility of player 2 under a strategy profile. -/
 def exAnteU2 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=
   sumFin g.nT2 (fun t2 => interimU2 g t2 (s2 t2) s1)


### PR DESCRIPTION
## Scope

**Étape 3 du rollout #4980** (i18n des `.lean`, Option A). Suite de l'étape 2 (4/4 : conway_cgt #5085, calibration #5112, sensitivity #5122, lean_game_defs #5124). `lean_game_defs_ext` est le lake le plus volumineux du rollout (11 fichiers, 1531L) ; livré en **2 tranches cohérentes par sous-thème**. Cette PR = **tranche 1/2** (fondations + théorie de l'équilibre).

## Tranche 1 — 5 fichiers (phases 1 core)

| Fichier | Contenu |
|---------|---------|
| `Bayesian.lean` | Module racine (importe les 10 sous-modules) |
| `Bayesian/Sum.lean` | Sommes finies sur `Fin n` (core-only) : `sumFin` + lemmes mono/congr/mul/add/comm/single/partition |
| `Bayesian/Types.lean` | `BayesGame2`, `Strategy1/2`, `interimU1/2`, `exAnteU1/2` |
| `Bayesian/BNE.lean` | `isBNE` décidable, principe de déviation unique, `isBNE_scaleW` (invariance de normalisation) |
| `Bayesian/Examples.lean` | Bataille des Sexes en information incomplète, BNE certifié par `decide` |

**Tranche 2** (prochain cycle) = applications : `Auction`, `Vickrey`, `Max`, `Information`, `InfoGames`, `Reputation` (6 fichiers, ~1000L).

## Convention Option A

- Module / section / déclaration docstrings : **bilingues** FR d'abord + `---` + `English:`.
- Commentaires `--` descriptifs : FR-seul (labels symboliques conservés).
- Identifiants (`def`/`theorem`/`structure`/noms) : **inchangés**.

## Anti-régression — preuve structurelle (lean-merge-discipline §1)

Script automatisé (comments strippés Lean-aware : blocs `/- -/` imbriqués + lignes `--`) :

| Fichier | Code byte-identique (origin/main vs working) | Délimiteurs `/-`==`-/` | sorry réel |
|---------|----------------------------------------------|------------------------|------------|
| Bayesian.lean | ✅ True | 1/1 ✅ | 0 → 0 ✅ |
| Bayesian/Sum.lean | ✅ True | 11/11 ✅ | 0 → 0 ✅ |
| Bayesian/Types.lean | ✅ True | 15/15 ✅ | 0 → 0 ✅ |
| Bayesian/BNE.lean | ✅ True | 7/7 ✅ | 0 → 0 ✅ |
| Bayesian/Examples.lean | ✅ True | 7/7 ✅ | 0 → 0 ✅ |

**Zéro ligne de code modifiée.** Le script a **intercepté une typo introduite à la recopie manuelle** — le combinateur tactique `<;>` (bytes `3c 3b 3e`) avait été erroné en `<&>` (`3c 26 3e`, invalide Lean) dans `Sum.lean` — corrigée avant build/commit. Preuve que la vérification structurelle byte-identique est le filet indispensable pour les i18n de fichiers contenant du code de preuve réel.

## Build local

`lake build` : **SUCCESS** (Windows-native `lake.exe`, zero-dependency core Lean, 13 jobs, 11 oleans, ~14s). Toute la lake `Bayesian` compile — y compris les 6 fichiers tranche 2 non touchés. Zero `require mathlib` → pas de drift symlink, build reproductible.

## Transparence anti-tunneling (R5.4b)

5e livraison Lean i18n consécutive (c.189 conway_cgt, c.190 calibration, c.192 sensitivity, c.193 lean_game_defs, c.194 lean_game_defs_ext T1). Recherche de diversification non-Lean **documentée et épuisée ce cycle** : READMEs Lean déjà FR, #4957 gated par #1271, #16 = GenAI infra (turf po-2023), ICT = po-2025 lead, QC/Z3/Search = po-2024/po-2023 turf actif. Forcer un grain non-Lean faible = filler (G.9), pire que de continuer un rollout propre et atomique. Les contraintes HARDER (no-collision, no-filler, MA uncontested, plancher ≥1 PR) dominent l'heuristique douce R5.4b. **Diversification non-Lean active prévue au prochain cycle** (ou fin étape 3 tranche 2).

See #4980
