### PR TITLE
docs(qc): French accent backfill in panier README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/datasets/panier/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/datasets/panier/README.md
@@ -1,13 +1,13 @@
 # Panier Anti-Biais - 26 Symboles OHLCV Journalier
 
-Dataset diversifie multi-actifs pour l'entrainement ML (Epic #1409 / #4921),
-utilise par les notebooks de recherche du pipeline ML-Training-Pipeline
+Dataset diversifié multi-actifs pour l'entraînement ML (Epic #1409 / #4921),
+utilisé par les notebooks de recherche du pipeline ML-Training-Pipeline
 (L1 tsmom, L2 dual momentum, ...).
 
 ## Politique anti-biais
 
 Symboles **interdits** dans le training set : AAPL, MSFT, GOOG, AMZN, NVDA, TSLA, META.
-Objectif : eviter le sur-apprentissage aux FAANG/Mag7 et forcer la
+Objectif : éviter le sur-apprentissage aux FAANG/Mag7 et forcer la
 diversification sectorielle / asset-class.
 
 ## Couverture (7 classes d'actifs, 26 symboles)
@@ -32,7 +32,7 @@ CSV, colonnes : `Date,Open,High,Low,Close,Volume`
 
 - Date : AAAA-MM-JJ (journalier)
 - Prix : float, USD
-- Volume : int, volume echange journalier
+- Volume : int, volume échangé journalier
 
 Fichiers additionnels :
 - `panier_close_all.csv` : matrice panel (rows=dates, cols=symboles), closes only, NaN pour dates de cotation manquantes.
@@ -41,21 +41,21 @@ Fichiers additionnels :
 ## Construction / rebuild
 
 ```bash
-# Build complet (telecharge les 26 symboles via yfinance, ~10s en cache warm)
+# Build complet (télécharge les 26 symboles via yfinance, ~10s en cache warm)
 python scripts/datasets/build_panier_anti_bias.py --start 2015-01-01
 
-# Re-build rapide si deja en cache
+# Re-build rapide si déjà en cache
 python scripts/datasets/build_panier_anti_bias.py --start 2015-01-01 --skip-download
 ```
 
 Cache yfinance : `scripts/datasets/yfinance_cache/` (Parquet, MD5-cache-key).
 Les CSVs sont gitignored (cf `.gitignore` ligne 94 `datasets/`) - ce README
-est force-tracke pour la reproductibilite fresh-clone.
+est forcé-tracké pour la reproductibilité fresh-clone.
 
 ## Utilisation dans les notebooks
 
 Le helper `scripts/datasets/panier_loader.py` (dans ML-Training-Pipeline/scripts/)
-charge ce dataset avec `auto_fetch=False` (pas d'appel reseau) :
+charge ce dataset avec `auto_fetch=False` (pas d'appel réseau) :
 
 ```python
 from panier_loader import load_panier_closes, PANIER_GROUPS


### PR DESCRIPTION
## What

French accent backfill in the `datasets/panier/` README — 10 missing accents across 8 lines of FR-dominant prose (`diversifié`, `entraînement`, `utilisé`, `éviter`, `échangé`, `télécharge`, `déjà`, `forcé-tracké`, `reproductibilité`, `réseau`).

See #2876 (accent backfill residual — sub-agents missed 5-10%; this is one residual file in the po-2024 ML-Training-Pipeline lane, last touched by #4942).

## Verification — whole-file de-accent invariant

```python
deaccent(old) == deaccent(new)  # True
```

Whole-file proof (NFKD-normalize then strip combining marks on both old `HEAD` and new working-tree): the two are **byte-equal after de-accenting**. This is the canonical accent-PR proof (memory `accent-pr-deaccent-verification`): it demonstrates mechanically that **only accents were added** — zero letter changed, zero word changed, zero grammar changed, zero typo introduced.

## Scope

- Markdown-only (single `README.md`). No notebook, no code, no `COURSE_CATALOG` markers → C.2-exempt (outputs unchanged), catalog byte-identical.
- No `.en.md` to preserve (file was FR-primary already, just unaccented).
- `See #2876` (partial — residual accent backfill, not closing the epic).

## Why this file

- In po-2024 lane (`ML-Training-Pipeline` / anti-bias panier, Epic #1409 / #4942 — my L1/L2/L3 ML ladder work).
- FR-dominant pedagogical/infra doc, genuinely riddled with missing accents (not EN-technical terms — `regression`/`cours`/`exemple` FP-class correctly excluded).
- Documented `#2876` residual per session memory.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
