### PR TITLE
docs(search/Part1-Foundations): resync table notebooks (Search-12-NetworkX manquant, See #3973)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -39,6 +39,7 @@ Cette partie est l'alphabet de toute la série : la formalisation en espace d'é
 | 9 | [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) | Python 3 | Programmation linéaire avec PuLP, simplex, problème du transport, diet problem, PLNE | ~2h |
 | 10 | [Search-10-SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | Python 3 | Automates finis (DFA/NFA) avec automata-lib, prédicats Z3, automates symboliques | ~2h |
 | 11 | [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) | Python 3 | PSO, ABC, SA, BRO avec MEALPy, benchmark comparatif de métaheuristiques | ~1h30 |
+| 12 | [Search-12-NetworkX](Search-12-NetworkX.ipynb) | Python 3 | Bibliothèque de graphes `networkx` : `Graph`/`DiGraph`, DFS/BFS, Dijkstra, Bellman-Ford, centralités de degré, composantes connexes, MST, Floyd-Warshall, parité structurelle avec QuikGraph (Search-13) | ~1h |
 | 13 | [Search-13-QuikGraph](Search-13-QuikGraph.ipynb) | .NET (C#) | Bibliothèque de graphes QuikGraph 2.5.0 (NuGet) : AdjacencyGraph / BidirectionalGraph / UndirectedGraph, DFS/BFS, Dijkstra, Bellman-Ford, centralités de degré, composantes connexes, Edmonds-Karp (flot max), parité avec NetworkX | ~1h |
 
 ## Progression
@@ -82,6 +83,8 @@ Pour le setup complet, voir le [README de la série Search](../README.md).
 ## Bibliothèques : parité Python `networkx` ↔ .NET `QuikGraph`
 
 Le notebook [Search-13-QuikGraph](Search-13-QuikGraph.ipynb) ferme la boucle côté **.NET Interactive** : il offre l'équivalent C# du notebook Python [Search-12-NetworkX](Search-12-NetworkX.ipynb), avec une table de parité structurelle entre les deux écosystèmes. La règle pratique : **QuikGraph 2.5.0** (fork KeRNeLith, NuGet) couvre les algorithmes classiques (DFS, BFS, Dijkstra, Bellman-Ford, A\*, Edmonds-Karp, Tarjan, MST, Floyd-Warshall) et **suffit pour tous les notebooks Search 1-11** si l'on travaille en C# — son **verdict honnête** est qu'il ne fournit pas les centralités élaborées (betweenness, closeness, PageRank) ni la détection de communautés (Louvain), qu'il faut alors implémenter à la main ou brancher une autre bibliothèque.
+
+> **Note de numérotation.** Les numéros 12 et 13 réapparaissent dans la [Partie 3 (Recherche avancée)](../Part3-Advanced/README.md) pour `Search-12-PatternDatabases` et `Search-13-LimitedDiscrepancySearch`. Les deux numérotations sont **parallèles par design** : cette Partie 1 utilise 12-13 pour les **bibliothèques de graphes** (parité `networkx` ↔ `QuikGraph`), la Partie 3 réserve 12-14 aux **heuristiques avancées** (Pattern Databases, Limited Discrepancy Search, Weighted A\*). Quand un lien renvoie à `Search-12` ou `Search-13`, la partie d'appartenance lève l'ambiguïté.
 
 ## Ponts vers les autres séries
 


### PR DESCRIPTION
## Resync table notebooks Partie 1 Search — Search-12-NetworkX manquant

Part of #3973 (EPIC README ascendant, refactor bottom-up des feuilles Search).
Pivot po-2024:CoursIA-2 confirmé par ai-01 R2 dashboard 2026-07-02.
Suit #3975 (READMEs feuilles, scope Search/Python).

### Problème constaté

```
$ ls MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1*.ipynb
Search-1-StateSpace.ipynb ... Search-11-Metaheuristics.ipynb
Search-12-NetworkX.ipynb       <- EXISTE
Search-13-QuikGraph.ipynb      <- EXISTE
```

13 notebooks `.ipynb` sont physiquement présents dans `Part1-Foundations/`, mais la table de la section "Notebooks" du README (lignes 29-42) n'en affiche que **12** : elle saute directement de **Search-11-Metaheuristics** à **Search-13-QuikGraph**, omettant la ligne **Search-12-NetworkX**.

Pourtant, **Search-12-NetworkX** est déjà correctement référencé :
- Section "Bibliothèques : parité Python `networkx` ↔ .NET `QuikGraph`" (ligne 84, lien + parité Search-13)
- `Search/README.md` parent (ligne 136, description MGS-19)
- `Search/Applications/README.md` (note de parité implicite)

### Changement

**1. Ajout de la ligne Search-12-NetworkX dans la table** (entre #11 et #13) :

```markdown
| 12 | [Search-12-NetworkX](Search-12-NetworkX.ipynb) | Python 3 | Bibliothèque de graphes `networkx` : `Graph`/`DiGraph`, DFS/BFS, Dijkstra, Bellman-Ford, centralités de degré, composantes connexes, MST, Floyd-Warshall, parité structurelle avec QuikGraph (Search-13) | ~1h |
```

**2. Note de numérotation** ajoutée à la section "Bibliothèques : parité" — clarifie le doublon `Search-12`/`Search-13` entre Partie 1 (bibliothèques de graphes : `networkx` ↔ `QuikGraph`) et Partie 3 (heuristiques avancées : Pattern Databases, Limited Discrepancy Search).

### Conformité

- **#2632 catalog-pr-hygiene** : `CATALOG-STATUS` non touchés (la feuille Part1-Foundations n'en porte pas ; le parent Search non plus n'a pas été régénéré). Rebase frais depuis `origin/main` (commit `68402b4e0`).
- **#1650 Phase 0.5** : nouveau contenu en français.
- **rule A atomique** : 1 fichier, 1 feature, 1 sujet, +3 lignes.
- **readme-french-first** : contenu nouveau FR, structure existante préservée.
- **G.1 verify** : `grep` confirmé — Search-12-NetworkX.ipynb existe bien sur disque, table omet la ligne.
- **Hors scope** : le `CATALOG-STATUS` du parent Search (`Part1-Foundations=11` dans le breakdown) reste stale par construction — c'est le cron `catalog-cron.yml` qui le régénère ; ce PR ne le touche pas.

### Vérification

- `git diff` = +3 lignes sur 1 fichier (Search/Part1-Foundations/README.md)
- Aucun autre fichier modifié
- Aucune régénération catalogue (parent `COURSE_CATALOG.generated.json` byte-identique à `origin/main`)