### PR TITLE
docs(iit): ICT-1 — Repères IIT canoniques (recadrage vocabulaire Φ/TPM/partition)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb
@@ -50,6 +50,22 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": null,
+     "exception": false,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Repères IIT canoniques\n\n> Vocabulaire de référence pour rattacher ce notebook à la colonne vertébrale de la série (mandat user *2026-07-03, directive 1 — recadrage IIT/$\\Phi$*). Sources : [IIT-1-IntroToPyphi](../IIT-1-IntroToPyphi.ipynb) (fondations), [ICT-0-Framing](ICT-0-Framing.md) § *« Double lecture du sigle »*, [ICT-0-Annexe](ICT-0-Annexe-IntegratedComplexityTheory.md) (texte fondateur, $\\Phi_{\\text{dyn}}$).\n\nTrois notions de **Integrated Information Theory** (Tononi, 2004/2008) suffisent pour ce qui suit :\n\n- **$\\Phi$ (information intégrée, *integrated information*)** — la quantité d'information qu'un système génère *par le fait d'être un*, au-dessus et au-delà de ses parties prises indépendantes. Calcul canonique : $\\Phi = \\min_{\\text{partition } p} \\mathrm{EMD}(p)$ — l'information qui ne *peut pas* être factorisée sur la partition qui sépare le système en parties indépendantes (Minimum Information Partition, MIP). Implémentation de référence : [PyPhi](https://pyphi.readthedocs.io), utilisé tel quel ici (aucun substitut).\n- **TPM (*Transition Probability Matrix*)** — la matrice de transition conditionnelle du système sous-jacent. Au format *state-by-node* de PyPhi, `network.tpm` est un tableau `(N, N)` indicé par un tuple d'état : pour chaque état présent (ligne), la probabilité de chaque état futur (colonne). Pour les réseaux déterministes de ce notebook, chaque ligne a un seul `1` (et des `0` ailleurs).\n- **Partition** — une bipartition du système en deux sous-systèmes $\\mathcal{S}^L \\cup \\mathcal{S}^R = \\mathcal{S}$ avec $\\mathcal{S}^L \\cap \\mathcal{S}^R = \\varnothing$. Pour la *cause-effect information* ($\\Phi_{\\mathrm{CE}}$), PyPhi balaie toutes les bipartitions *dirigées* et retient celle qui **minimise** la divergence entre le système entier et la somme de ses parties (MIP).\n\nCe que ce notebook ajoute : $\\Phi$ est habituellement calculé **état par état**, comme une photographie. ICT-1 le filme — on suit la *trajectoire* de $\\Phi$ le long de $s_0 \\rightarrow s_1 \\rightarrow s_2 \\rightarrow \\dots$ pendant que le système déterministe évolue dans son espace d'états. Les trois questions (paysage, trajectoire, robustesse) sont les projections naturelles de $\\Phi$ sur la dimension temporelle.\n\n**Pourquoi 3 nœuds.** Le calcul exact de $\\Phi$ est exponentiel en $N$ (chaque bipartition d'un système à $N$ nœuds $= 2^{N-1} - 1$ coupes dirigées, plus le calcul EMD par coupe). Pour $N = 3$ on a $3$ bipartitions, et PyPhi termine en quelques millisecondes ; pour $N = 10$ le calcul devient intraitable — c'est la *contrainte intrinsèque* discutée en conclusion, et la motivation des approximations introduites par les strates suivantes ($\\Phi_{\\text{dyn}}$ dans [l'annexe fondatrice](ICT-0-Annexe-IntegratedComplexityTheory.md), $\\Phi$-trajectoires échantillonnées, mesures variationnelles)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "32e6860b",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Recadrage IIT/Φ du notebook ICT-1-PhiTrajectories, première tranche d'une passe éditoriale demandée par le user 2026-07-03 sur l'Epic #4588 (directive 1) : **« passe éditoriale sur ICT-1..13 pour que chaque notebook re-raccroche explicitement ses mesures au vocabulaire IIT (Φ, partitions, TPM) »**.

ICT-1 reçoit **1 cellule markdown insérée** entre l'intro (cell 0) et « Mise en place » (anciennement cell 1, désormais cell 2) :

**« Repères IIT canoniques »** — trois notions définies explicitement, avec leurs références canoniques (Tononi 2004, PyPhi implémentation de référence, ICT-0-Annexe texte fondateur) :

- **Φ** (information intégrée, *integrated information*) : calcul canonique $\Phi = \min_{\text{partition } p} \mathrm{EMD}(p)$ (MIP, Minimum Information Partition), implémentation = [PyPhi](https://pyphi.readthedocs.io) utilisé tel quel (aucun substitut).
- **TPM** (Transition Probability Matrix) : format *state-by-node* PyPhi = tableau `(N, N)` indexé par tuple d'état.
- **Partition** : bipartition $\mathcal{S}^L \cup \mathcal{S}^R = \mathcal{S}$ avec intersection vide ; pour Φ_CE, PyPhi balaie les bipartitions dirigées et retient celle qui minimise la divergence (MIP).

Closing **« Pourquoi 3 nœuds »** : explique la complexité exponentielle en $N$ ($2^{N-1} - 1$ coupes dirigées + EMD par coupe) — pour $N=3$ on a 3 bipartitions et PyPhi termine en millisecondes ; pour $N=10$ le calcul exact devient intraitable. Justifie le choix pédagogique de N=3 et motive les approximations des strates suivantes (Φ_dyn dans l'annexe fondatrice, Φ-trajectoires échantillonnées, mesures variationnelles).

## Pourquoi cette tranche maintenant

Constat : `ICT-1-PhiTrajectories.ipynb` (24 markdown cells) ne contenait **aucune définition explicite** de Φ, TPM ou partition avant le notebook. Le lecteur arrivait directement sur « Mise en place » et « Paysage » sans avoir le vocabulaire IIT canonique en main. La passe éditoriale demandée par le user vise à fermer ce gap sur **chaque notebook ICT-1..13**.

Cette PR traite ICT-1 ; les notebooks ICT-2..13 recevront des PRs analogues (cellules d'ancrage vocabulaire IIT au début de chaque notebook) dans des PRs ultérieures, scope atomique 1-notebook / 1-cellule / 0-régression, conformément à la règle R3 catalog-pr-hygiene.

## Scope (1 sujet = 1 PR)

| Métrique | Valeur | Seuil §A | Verdict |
|----------|--------|----------|---------|
| `additions + deletions` | 18 | > 3000 | ✅ Très en dessous |
| `changedFiles` | 1 | > 15 | ✅ Très en dessous |
| Features distinctes | 1 (recadrage IIT) | > 4 | ✅ Mono-feature |
| Domaines | 1 (docs/IIT) | > 1 | ✅ Mono-domaine |

## Anti-régression strict

- **0 cellule existante touchée** (insertion pure : 24 → 25 cells). Cell 0 (intro) intact. Cell 1 (Mise en place) décalée en cell 2 sans modification.
- **Code cells ec=1..10 préservés** avec outputs C.2 OK (vérification programmatique sur les 10 cellules code).
- **0 violation C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = 0 match.
- **0 cellule `# Solution` / `# Exemple résolu` supprimée** (cf CLAUDE.md section D).

## Catalog-pr-hygiene R1+R2+R3+R4

- **R1** : `git diff origin/main -- COURSE_CATALOG.generated.json COURSE_CATALOG.generated.md | wc -l` = **0** (CATALOG byte-identique).
- **R2** : branche fraîche `docs/ict1-iit-vocabulary-recentrage` depuis `origin/main` `68402b4e0` (post-#5138 ICT-0 C192, post-#5122 Lean i18n, post-#5116 ICT-14).
- **R3** : PR atomique, 1 sujet (recadrage IIT/Φ d'ICT-1), 1 fichier `.ipynb`, +17/-1.
- **R4** : `Part of #4588` (et **PAS** `Closes #4588`, car la PR ne résout qu'une partie de l'Epic — ICT-2..13 restent à traiter dans des PRs ultérieures).

## Acceptance criteria

- [x] 1 cellule markdown « Repères IIT canoniques » insérée après cell 0 (intro), avant cell 1 (Mise en place) — vérifié programmatiquement (verify_cell.py output: cell 0 = `# ICT-1 — Trajectoires de $\Phi$`, cell 1 = `## Repères IIT canoniques`, cell 2 = `## 0. Mise en place`).
- [x] Φ défini explicitement avec sa formule canonique (MIP, EMD) + ref PyPhi.
- [x] TPM défini avec son format concret (state-by-node, `(N, N)` indexé par tuple).
- [x] Partition définie avec sa notation math ($\mathcal{S}^L \cup \mathcal{S}^R = \mathcal{S}$) + Φ_CE + MIP.
- [x] Justification « Pourquoi 3 nœuds » : $N=3$ = 3 bipartitions, $N=10$ intraitable.
- [x] Refs croisées IIT-1-IntroToPyphi + ICT-0-Framing § Double lecture du sigle + ICT-0-Annexe Φ_dyn.
- [x] `python scripts/check_docs_links.py --check` : **0 broken link ICT-spécifique** sur `ICT-Series/ICT-1*`, `ICT-0-Annexe`, `ICT-0-Framing` (le 221 « REGRESSION » pré-existant sur origin/main est hors scope — vérifié sur main sans la branche : résultats identiques).
- [x] Anti-tunneling R5.4b MUST respecté : C189 (Sudoku-3 enrich) + C190 (Sudoku-4-SA enrich) + C191 (Search-5 enrich) = 3 cycles Search/Sudoku → C192 = pivot diversification ICT (PR #5138 ICT-0 cadrage) → C193 = continuation légitime diversification famille ICT/IIT ≠ Search ≠ Sudoku.

## Note méthodologique — leçon C193

Une première tentative d'insertion inline (via bash avec Python `-c`) avait **mangé les backslashes** des formules LaTeX (`\Phi`, `\text`, `\mathcal{S}`, `\rightarrow`, etc.) — bash interprétait les `\` avant que Python ne voie la string. Récupération : réécriture via un script Python externe dans `scratchpad/c193/repair_ict1.py` avec **raw triple-quoted strings** (`r'''...'''`) qui préservent les backslashes intacts. Vérification programmatique finale : 10/10 checks LaTeX OK (`\Phi`, `\text{partition`, `\rightarrow`, `\mathcal{S}`, `\mathrm{EMD}`, `2^{N-1}`, `N = 3`, `N = 10`, `\Phi_{\mathrm{CE}}`, `\Phi_{\text{dyn}}`).

## Liens

- **Epic #4588** — IIT → ICT (Part of #4588)
- **#5091** — ICT-0 cadrage canonique (C192, PR #5138) — référence cadrage de la série
- **#5089** — ICT-14 FreeEnergySurprise (strate 4 ✅, livré C181-C182)
- **#5090** — ICT-15 IntegratedComplexity (strate 4 → 5)
- **#5099..#5105** — ICT-16..22 (strate 5 : MDL, ε-machine, SAE/LLM, …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>