### PR TITLE
docs(qc): French accent backfill in QUICK_TOUR.md (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
+++ b/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
@@ -1,6 +1,6 @@
 # QuantConnect AI Trading - Quick Tour
 
-**95+ strategies backtested | 51 notebooks Python | 20 patterns confirmés | Composite robuste (TrendWeather Sharpe aligné 0.95)**
+**95+ stratégies backtested | 51 notebooks Python | 20 patterns confirmés | Composite robuste (TrendWeather Sharpe aligné 0.95)**
 
 Cette section contient un parcours complet de trading algorithmique sur **QuantConnect LEAN**, du débutant au déploiement live. Tout est exécutable gratuitement sur le cloud QC.
 
@@ -10,13 +10,13 @@ Cette section contient un parcours complet de trading algorithmique sur **QuantC
 
 1. **[Meilleure stratégie](projects/Framework_Composite_TrendWeather/)** — Composite TrendStocks + AllWeather (Sharpe 1.156, CAGR 27.4%). Architecture Algorithm Framework modulaire : AlphaModel + PortfolioConstruction + Execution.
 
-2. **[Catalogue strategies](docs/qc_strategies_catalog.md)** — 95+ projets organisés par catégorie (Alpha, Trend Following, ML/RL, Composites). Top performers vérifiés alignés (#1630) : Long-Short Harvest (Sharpe **1.64**, PSR 98.7%), TrendWeather Composite (**0.948**, PSR 56.6%), EMATrend (**0.611**).
+2. **[Catalogue stratégies](docs/qc_strategies_catalog.md)** — 95+ projets organisés par catégorie (Alpha, Trend Following, ML/RL, Composites). Top performers vérifiés alignés (#1630) : Long-Short Harvest (Sharpe **1.64**, PSR 98.7%), TrendWeather Composite (**0.948**, PSR 56.6%), EMATrend (**0.611**).
 
 3. **[Patterns confirmés](../../docs/qc/quantconnect.md)** — 20 patterns valides sur 30+ iterations (risk-adjusted momentum, skip-month, stop-loss -8/-12%, monthly rebalancing, anti-overfitting) et 10 anti-patterns critiques (SPY Parking, backtests courts, yfinance != QC cloud).
 
 4. **[Notebooks pédagogiques](Python/)** — 51 notebooks en 8 phases progressives : fondations LEAN, universe/asset classes, risk management, Algorithm Framework, données alternatives, ML (RF/XGBoost), deep learning (LSTM/Transformers), RL et LLMs pour trading.
 
-5. **[Mapping livre Jared Broad](BOOK_MAPPING.md)** — 63 exemples du livre *Hands-On AI Trading* (2025) mappés a nos notebooks et projets. 22 strategies ML du Chapitre 6 importées.
+5. **[Mapping livre Jared Broad](BOOK_MAPPING.md)** — 63 exemples du livre *Hands-On AI Trading* (2025) mappés à nos notebooks et projets. 22 stratégies ML du Chapitre 6 importées.
 
 ## Démarrer en 5 minutes
 
@@ -24,4 +24,4 @@ Cette section contient un parcours complet de trading algorithmique sur **QuantC
 2. Copier un `main.py` depuis [projects/](projects/) dans un nouveau projet QC Lab
 3. Cliquer **Backtest** — c'est tout
 
-> Documentation complete : [README.md](README.md) | [Guide démarrage](GETTING-STARTED.md) | [Patterns QC](../../docs/qc/quantconnect.md)
+> Documentation complète : [README.md](README.md) | [Guide démarrage](GETTING-STARTED.md) | [Patterns QC](../../docs/qc/quantconnect.md)


### PR DESCRIPTION
## What

French accent backfill in `QuantConnect/QUICK_TOUR.md` — 5 missing accents in 4 lines of FR-dominant prose:
- `strategies` → `stratégies` (3×: L3 headline, L13 + L19 link **text**)
- `mappés a nos` → `mappés à nos` (preposition `à`, not the verb `a`)
- `Documentation complete` → `Documentation complète` (FR feminine adjective)

See #2876 (accent backfill residual — sub-agents missed 5-10%; this is a residual QC doc in the po-2024 lane).

## Verification — whole-file de-accent invariant

```python
deaccent(old) == deaccent(new)  # True
```

Whole-file proof (NFKD-normalize then strip combining marks on both old `HEAD` and new working-tree): the two are **equal after de-accenting**. This proves mechanically that **only accents were added** — zero letter changed, zero word changed, zero grammar changed.

## Link-path safety

The 3 `strategies → stratégies` changes hit the link **text only**. The real filename path `docs/qc_strategies_catalog.md` is a tracked file and is **preserved byte-identical** (verified `grep -c qc_strategies_catalog.md == 1` before/after). Link stays valid.

## Scope

- Markdown-only (single 27-line `QUICK_TOUR.md`). No notebook, no code, no `COURSE_CATALOG` markers → C.2-exempt, catalog byte-identical.
- No `.en.md` to preserve (file was FR-primary already, just sparsely unaccented).
- `See #2876` (partial — residual accent backfill, not closing the epic).
- Companion to #5139 (panier README, same #2876 residual batch, c.8).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
