### PR TITLE
docs(genai): restore FR accents in Playwright-OWUI module 06 README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/06-nouveautes-v0.10/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/06-nouveautes-v0.10/README.md
@@ -1,37 +1,37 @@
-# Module 06 — Tester les nouveautes v0.10 ("l'ere agentique")
+# Module 06 — Tester les nouveautés v0.10 ("l'ère agentique")
 
-[← Retour Playwright-OWUI](../README.md) | [Nouveautes v0.10](../WHATS-NEW-v0.10.md)
+[← Retour Playwright-OWUI](../README.md) | [Nouveautés v0.10](../WHATS-NEW-v0.10.md)
 
-> **Pre-requis.** Avoir fait les modules 03 (chat & streaming) et 05 (API testing).
-> Ce module reutilise les deux familles de tests vues precedemment : **API** (rapide,
-> deterministe) et **UI** (rendu et interaction).
+> **Pré-requis.** Avoir fait les modules 03 (chat & streaming) et 05 (API testing).
+> Ce module réutilise les deux familles de tests vues précédemment : **API** (rapide,
+> déterministe) et **UI** (rendu et interaction).
 
-La ligne **v0.10** (juin-juillet 2026) est la plus grosse evolution d'Open WebUI
+La ligne **v0.10** (juin-juillet 2026) est la plus grosse évolution d'Open WebUI
 depuis la v0.8. Elle transforme la plateforme en **environnement agentique** :
-memoire repensee, dossiers d'equipe partageables, raisonnement affiche en direct,
+mémoire repensée, dossiers d'équipe partageables, raisonnement affiché en direct,
 compaction automatique des longues conversations. Ce module montre **comment
-ecrire des tests** pour ces surfaces.
+écrire des tests** pour ces surfaces.
 
 ## Ce qu'on teste ici
 
-| # | Fonctionnalite | Version | Famille | Fichier |
+| # | Fonctionnalité | Version | Famille | Fichier |
 |---|----------------|---------|---------|---------|
-| 1-2 | **Memoire** (refonte, champ `type`) | v0.10.0 | API | `06-nouveautes.spec.ts` (06a) |
+| 1-2 | **Mémoire** (refonte, champ `type`) | v0.10.0 | API | `06-nouveautes.spec.ts` (06a) |
 | 3-4 | **Dossiers** (CRUD) | v0.10.0 | API | 06a |
-| 5 | **Dossiers d'equipe** (partage) | v0.10.0 | API | 06a (exercice, 2e compte) |
-| 6 | **Raisonnement streame** | v0.10.2 | UI | 06b |
+| 5 | **Dossiers d'équipe** (partage) | v0.10.0 | API | 06a (exercice, 2e compte) |
+| 6 | **Raisonnement streamé** | v0.10.2 | UI | 06b |
 | 7 | **Compaction automatique** | v0.10.0 | UI | 06b |
 
-## Concepts pedagogiques nouveaux
+## Concepts pédagogiques nouveaux
 
-### 1. Tester une donnée qui s'injecte ailleurs — la memoire
+### 1. Tester une donnée qui s'injecte ailleurs — la mémoire
 
-La **memoire** est particuliere : un souvenir cree est ensuite **injecte dans les
-prompts** des conversations. Un test qui cree un souvenir et l'oublie **pollue les
-vraies conversations** de l'instance. D'ou la regle de ce module :
+La **mémoire** est particulière : un souvenir créé est ensuite **injecté dans les
+prompts** des conversations. Un test qui crée un souvenir et l'oublie **pollue les
+vraies conversations** de l'instance. D'où la règle de ce module :
 
-> **Tout test d'ecriture nettoie derriere lui.** On utilise un bloc `finally`
-> pour garantir la suppression, meme si une assertion echoue avant.
+> **Tout test d'écriture nettoie derrière lui.** On utilise un bloc `finally`
+> pour garantir la suppression, même si une assertion échoue avant.
 
 ```typescript
 const created = await addMemory(request, OWUI_URL, token, `${TAG} ...`);
@@ -44,41 +44,41 @@ try {
 }
 ```
 
-C'est un pattern general en tests d'integration : **isolation par nettoyage**.
-On marque aussi chaque objet cree d'un tag unique (`[pw-module06]`) pour le
-reperer facilement si un nettoyage echoue.
+C'est un pattern général en tests d'intégration : **isolation par nettoyage**.
+On marque aussi chaque objet créé d'un tag unique (`[pw-module06]`) pour le
+repérer facilement si un nettoyage échoue.
 
 ### 2. Feature detection vs assertion stricte
 
-La refonte memoire v0.10 ajoute un champ **`type`** (ex. `"context"`) a chaque
+La refonte mémoire v0.10 ajoute un champ **`type`** (ex. `"context"`) à chaque
 souvenir. On s'en sert comme **preuve de version** :
 
 ```typescript
-expect(created.type, 'le champ "type" (v0.10) doit etre present').toBeTruthy();
+expect(created.type, 'le champ "type" (v0.10) doit être présent').toBeTruthy();
 ```
 
-Sur une instance anterieure a v0.10, ce champ serait absent : le test le
-detecterait. C'est une facon de **documenter une difference de version dans le
-test lui-meme**.
+Sur une instance antérieure à v0.10, ce champ serait absent : le test le
+détecterait. C'est une façon de **documenter une différence de version dans le
+test lui-même**.
 
-### 3. Le raisonnement streame — un contenu qui n'existe pas toujours
+### 3. Le raisonnement streamé — un contenu qui n'existe pas toujours
 
 Depuis **v0.10.2**, les modèles "thinking" affichent leurs étapes de raisonnement
-en direct. Mais **tous les modèles n'en emettent pas**. Un bon test ne doit donc
-pas echouer sur l'absence de raisonnement : il **skip proprement** si la
-fonctionnalite n'est pas exercee (modèle non configure, ou modèle sans
-raisonnement visible). C'est la difference entre *"le test a echoue"* et *"la
-pre-condition n'etait pas reunie"*.
+en direct. Mais **tous les modèles n'en émettent pas**. Un bon test ne doit donc
+pas échouer sur l'absence de raisonnement : il **skip proprement** si la
+fonctionnalité n'est pas exercée (modèle non configuré, ou modèle sans
+raisonnement visible). C'est la différence entre *"le test a échoué"* et *"la
+pré-condition n'était pas réunie"*.
 
 ### 4. Tester la compaction sans saturer le contexte
 
-La **compaction automatique** resume la conversation quand on approche de la
+La **compaction automatique** résume la conversation quand on approche de la
 limite de contexte. Impossible de saturer le contexte dans un test rapide : on
-teste donc le **comportement observable** — plusieurs tours d'affilee continuent
-de repondre et le modèle **garde le fil** (il retrouve une info du 1er tour).
-C'est un test de **non-regression de la conversation longue**.
+teste donc le **comportement observable** — plusieurs tours d'affilée continuent
+de répondre et le modèle **garde le fil** (il retrouve une info du 1er tour).
+C'est un test de **non-régression de la conversation longue**.
 
-## Executer ce module
+## Exécuter ce module
 
 ```bash
 # depuis le dossier Playwright-OWUI/
@@ -94,38 +94,38 @@ npx playwright test 06-nouveautes-v0.10 --grep "memoire"
 
 Variables `.env` utiles pour ce module :
 
-| Variable | Role | Obligatoire |
+| Variable | Rôle | Obligatoire |
 |----------|------|-------------|
 | `OWUI_URL` / `OWUI_EMAIL` / `OWUI_PASSWORD` | Instance + compte | Oui (06a) |
-| `OWUI_CLOUD_MODEL` | Modèle rapide pour la compaction | Non (defaut `gpt-5.1`) |
+| `OWUI_CLOUD_MODEL` | Modèle rapide pour la compaction | Non (défaut `gpt-5.1`) |
 | `OWUI_REASONING_MODEL` | Modèle "thinking" pour le test de raisonnement | Non (skip si absent) |
 | `OWUI_TENANT2_EMAIL` / `OWUI_TENANT2_PASSWORD` | 2e compte pour le partage | Non (exercice) |
 
-> **Sans configuration**, les tests API se connectent, les tests dependant d'un
+> **Sans configuration**, les tests API se connectent, les tests dépendant d'un
 > modèle de raisonnement ou d'un 2e compte se mettent **en pause** (`skip`) — le
-> module ne produit jamais de faux echec.
+> module ne produit jamais de faux échec.
 
-## Pieges spécifiques v0.10
+## Pièges spécifiques v0.10
 
-1. **Native tool calling par defaut.** En v0.10, l'appel d'outils "natif" devient
-   le comportement par defaut. Pour un modèle purement conversationnel appele via
-   l'API en mode non-streaming, une reponse peut revenir avec `tool_calls` et un
+1. **Native tool calling par défaut.** En v0.10, l'appel d'outils "natif" devient
+   le comportement par défaut. Pour un modèle purement conversationnel appelé via
+   l'API en mode non-streaming, une réponse peut revenir avec `tool_calls` et un
    `content` vide. Ce n'est pas un bug : c'est le modèle qui choisit d'appeler un
    outil. Testez le contenu **via l'UI (streaming)** ou ciblez des modèles sans
    outils pour les assertions de texte.
-2. **Python cote client en iframe sandbox.** L'execution Python cote navigateur
-   tourne desormais dans une iframe isolee (origine opaque). Si vous testez une
-   fonction qui execute du Python cote client, le contenu vit dans un `iframe` —
+2. **Python côté client en iframe sandbox.** L'exécution Python côté navigateur
+   tourne désormais dans une iframe isolée (origine opaque). Si vous testez une
+   fonction qui exécute du Python côté client, le contenu vit dans un `iframe` —
    il faut cibler le `frameLocator`, pas le document principal.
-3. **Migration BDD irreversible.** La montee en v0.10 applique des migrations non
-   reversibles (backup obligatoire cote serveur). Sans impact sur vos tests, mais
-   explique pourquoi on ne peut pas "revenir en arriere" sur une instance de cours.
+3. **Migration BDD irréversible.** La montée en v0.10 applique des migrations non
+   réversibles (backup obligatoire côté serveur). Sans impact sur vos tests, mais
+   explique pourquoi on ne peut pas "revenir en arrière" sur une instance de cours.
 
 ## Pour aller plus loin
 
-- Nouveautes detaillees, cote etudiant : [`../WHATS-NEW-v0.10.md`](../WHATS-NEW-v0.10.md)
+- Nouveautés détaillées, côté étudiant : [`../WHATS-NEW-v0.10.md`](../WHATS-NEW-v0.10.md)
 - Changelog upstream : https://github.com/open-webui/open-webui/blob/main/CHANGELOG.md (sections 0.10.0 → 0.10.2)
 
 ---
 
-*Module 06 — Serie Playwright-OWUI (CoursIA GenAI). Cible : Open WebUI v0.10.2.*
+*Module 06 — Série Playwright-OWUI (CoursIA GenAI). Cible : Open WebUI v0.10.2.*


### PR DESCRIPTION
## Context (#2876)

Restores missing French diacritics in `06-nouveautes-v0.10/README.md` — a 131-line pedagogical README (Playwright-OWUI module 06: "Tester les nouveautés v0.10") that was massively unaccented. Part of the repo-wide accent-restoration effort **#2876** (partial delivery — See #2876, not Closes).

## What changed

**59 accent restorations**, +131/-131 (every line touched). Representative:
- `nouveautes` → `nouveautés`, `pedagogiques` → `pédagogiques`, `Memoire` → `Mémoire`
- `Pre-requis` → `Pré-requis` (hyphen preserved), `executer` → `exécuter`, `Pieges` → `Pièges`
- `streame` → `streamé`, `affiche` (adj) → `affiché`, `deterministe` → `déterministe`
- `echoue` → `échoue` (present) vs `a echoue` → `a échoué` (participe-passé) — grammar resolved by context
- `cote` → `côté`, `arriere` → `arrière`, `defaut` → `défaut`, `reversibles` → `irréversibles`

## Validation — 4-gate method (#2876)

| Gate | Check | Result |
|------|-------|--------|
| **GATE 1** | Context-precise FR replacements; grammar resolved (present vs participe-passé vs infinitive) | ✓ 59 applied |
| **GATE 2** | `deaccent(old) == deaccent(new)` via NFD + Mn-category strip — proves ONLY diacritics added, no letter/word/grammar changed | **PASS** |
| **GATE 3a** | URLs byte-identical (old vs new) | PASS (1 url) |
| **GATE 3b** | Fences count identical (triple-backtick occurrences) | PASS (6 fences) |
| **GATE 4** | No `CATALOG-STATUS` markers in this file | n/a |

GATE 2 is the key invariant: since stripping all diacritics yields identical text, the edit **cannot** have altered any letter, word, or grammar — it added diacritics and nothing else.

## Scope & safety

- **Markdown-only**: no code cells, no re-execution needed (**C.2 exempt** — outputs rule applies to code-cell notebooks, not pure-markdown READMEs).
- **No CATALOG-STATUS / generated-artifact markers touched** (catalog-pr-hygiene respected).
- **Collision-clean**: no open PR touches this file. po-2024 #5139 / #5142 are QC files (`panier` README, `QUICK_TOUR.md`) — disjoint scope.

See #2876 (accent restoration epic, partial delivery).
