### PR TITLE
docs(qc): French accent backfill in GETTING-STARTED.md (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/GETTING-STARTED.md
+++ b/MyIA.AI.Notebooks/QuantConnect/GETTING-STARTED.md
@@ -66,15 +66,15 @@ class MyFirstAlgorithm(QCAlgorithm):
 
 **Félicitations !** Vous venez d'exécuter votre premier algorithme de trading.
 
-### Etape 4 : Utiliser les ressources CoursIA
+### Étape 4 : Utiliser les ressources CoursIA
 
-Les notebooks `QC-Py-XX` sont des **supports de cours** a lire sur GitHub ou en Jupyter local. Ils ne sont pas conçus pour être uploadés dans QC Lab.
+Les notebooks `QC-Py-XX` sont des **supports de cours** à lire sur GitHub ou en Jupyter local. Ils ne sont pas conçus pour être uploadés dans QC Lab.
 
-**Pour votre projet QC, utilisez plutot** :
+**Pour votre projet QC, utilisez plutôt** :
 
-1. **Projets prets a backtester** : Copiez un `main.py` depuis `projects/` dans votre projet QC Lab
-2. **Templates de projet** : Partez d'un template (`partner-course-quant-trading/templates/starter/`) adapte a votre niveau
-3. **Notebooks de reference** : Lisez les `QC-Py-XX` pour comprendre la théorie et les patterns
+1. **Projets prêts à backtester** : Copiez un `main.py` depuis `projects/` dans votre projet QC Lab
+2. **Templates de projet** : Partez d'un template (`partner-course-quant-trading/templates/starter/`) adapté à votre niveau
+3. **Notebooks de référence** : Lisez les `QC-Py-XX` pour comprendre la théorie et les patterns
 
 **Exemple concret** :
 1. Ouvrez `projects/EMA-Cross-Alpha/main.py` sur GitHub


### PR DESCRIPTION
## What

French accent backfill in `QuantConnect/GETTING-STARTED.md` — 7 missing accents across 6 lines of FR-dominant prose:
- `Etape 4` → `Étape 4` (L69 heading)
- `a lire` → `à lire` (L71 preposition)
- `plutot` → `plutôt` (L73)
- `prets a backtester` → `prêts à backtester` (L75 adjective + preposition)
- `adapte a votre niveau` → `adapté à votre niveau` (L76 past-participle + preposition)
- `reference` → `référence` (L77)

See #2876 (accent backfill residual — sub-agents missed 5-10%; residual QC onboarding doc in the po-2024 lane).

## Verification — whole-file de-accent invariant

```python
deaccent(old) == deaccent(new)  # True
```

Whole-file proof (NFKD-normalize then strip combining marks on both old `HEAD` and new working-tree): the two are **equal after de-accenting**. Proves mechanically that **only accents were added** — zero letter/word/grammar changed.

## FP correctly excluded (G.1)

L265 `Docker a accès au disque C:\` — here `a` is the **verb** *avoir* (Docker **has** access), NOT the preposition `à`. **Left unchanged.** A blind `a → à` replace would have introduced a grammar error; reading each `a` in context (G.1) caught it.

## Scope

- Markdown-only (single `GETTING-STARTED.md`). No notebook, no code, no `COURSE_CATALOG` markers → C.2-exempt, catalog byte-identical.
- No `.en.md` to preserve (file was FR-primary already).
- `See #2876` (partial — residual accent backfill).
- Companion to #5139 (panier README) + #5142 (QUICK_TOUR) — same #2876 residual batch.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
