### PR TITLE
fix(sudoku10-csharp): fix CS0161 stubs + relabel md/code coherence (cells #28/#32, See #4940)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -1389,7 +1389,7 @@
     }
    ],
    "source": [
-    "// Exemple guide 2 : Sudoku X avec contraintes de diagonale (CP-SAT)\n",
+    "// EXERCICE 2 : Sudoku X avec contraintes de diagonale (CP-SAT)\n",
     "using Google.OrTools.Sat;\n",
     "\n",
     "public class SudokuXCPSATSolver : ISudokuSolver\n",
@@ -1420,10 +1420,11 @@
     "        // model.AddAllDifferent(antiDiag);\n",
     "\n",
     "        Console.WriteLine(\"Exercice a completer\");\n",
+    "        return inputGrid; // TODO etudiant : retourner la grille resolue par CP-SAT\n",
     "    }\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"TODO : Implementez SudokuXCPSATSolver avec les contraintes de diagonale\");"
+    "Console.WriteLine(\"TODO : Implementez SudokuXCPSATSolver avec les contraintes de diagonale\");\n"
    ]
   },
   {
@@ -1589,7 +1590,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Probleme des N-Reines avec OR-Tools CP-SAT\n",
+    "// EXERCICE : Probleme des N-Reines avec OR-Tools CP-SAT\n",
     "// TODO: Implementez un solveur pour compter les solutions du probleme des N-Reines\n",
     "\n",
     "using Google.OrTools.Sat;\n",
@@ -1597,33 +1598,34 @@
     "public class NQueensCPSATSolver\n",
     "{\n",
     "    public int N { get; set; }\n",
-    "    \n",
+    "\n",
     "    public NQueensCPSATSolver(int n)\n",
     "    {\n",
     "        N = n;\n",
     "    }\n",
-    "    \n",
+    "\n",
     "    public int CountSolutions()\n",
     "    {\n",
     "        var model = new CpModel();\n",
-    "        \n",
+    "\n",
     "        // TODO: Creer les variables queen[i] pour chaque ligne i (domaine 0..N-1)\n",
     "        // var queens = new IntVar[N];\n",
     "        // for (int i = 0; i < N; i++)\n",
     "        //     queens[i] = model.NewIntVar(0, N - 1, $\"queen_{i}\");\n",
-    "        \n",
+    "\n",
     "        // TODO: Contrainte de colonnes : toutes les reines dans des colonnes differentes\n",
     "        // model.AddAllDifferent(queens);\n",
-    "        \n",
+    "\n",
     "        // TODO: Contraintes de diagonales\n",
     "        // Pour chaque paire (i, j) avec i < j :\n",
     "        //   Diagonale principale : queens[i] - queens[j] != i - j\n",
     "        //   Diagonale secondaire : queens[i] - queens[j] != j - i\n",
-    "        \n",
+    "\n",
     "        // TODO: Utiliser un SolutionCollector pour compter les solutions\n",
     "        // Classe CpSolverSolutionCallback pour enumerer toutes les solutions\n",
-    "        \n",
+    "\n",
     "        Console.WriteLine(\"Exercice a completer\");\n",
+    "        return 0; // TODO etudiant : retourner le nombre de solutions trouvees\n",
     "    }\n",
     "}\n",
     "\n",
@@ -1633,7 +1635,7 @@
     "// int solutions = nQueens.CountSolutions();\n",
     "// Console.WriteLine($\"Nombre de solutions pour {N}-Reines : {solutions}\");\n",
     "// Console.WriteLine($\"Attendu : 92\");\n",
-    "Console.WriteLine($\"TODO: Implementez NQueensCPSATSolver.CountSolutions() pour le probleme des {N}-Reines\");"
+    "Console.WriteLine($\"TODO: Implementez NQueensCPSATSolver.CountSolutions() pour le probleme des {N}-Reines\");\n"
    ]
   },
   {


### PR DESCRIPTION
# fix(sudoku10-csharp): fix CS0161 stubs + relabel md/code coherence (cells #28/#32, See #4940)

## Contexte

Issue #4940 audit transversal Sudoku, Phase 2 reliquat identifié dans le
diagnostic po-2024 du 2026-07-03 :

> *« Sudoku-10-ORTools-Csharp code[28] : "Exemple guide 2 : Sudoku X" + TODO stub
> ne compilant pas (manque `return`) — critère 4 mislabel + C.1 (stub
> non-compilable). idem code[32] : "Exemple guide : N-Reines" + TODO stub
> non compilant — critère 4 + C.1. GATED sur cell[3] `#!import`. »*

Le dashboard ai-01 R2 (2026-07-03T05:53Z) cite explicitement ce reliquat :

> *« Reliquat worklist identifié : Sudoku-10-ORTools-Csharp (prose
> consacrante + benchmark sans output). À traiter en C167 si partition
> drainée ou délégation po-2024. »*

Pivot légitime post-C165/C166/C167/C168 saturation (partition drainée).

## Diagnostic G.1 firsthand (pre-fix)

Sortie actuelle cell [28] (id `f4f6b873`, ec=12, outputs=2) :

```
(8,23): error CS0161: 'SudokuXCPSATSolver.Solve(SudokuGrid)' :
        les chemins du code ne retournent pas tous une valeur

Error: compilation error
```

Sortie actuelle cell [32] (id `78048935`, ec=14, outputs=2) :

```
(15,16): error CS0161: 'NQueensCPSATSolver.CountSolutions()' :
         les chemins du code ne retournent pas tous une valeur

Error: compilation error
```

**Deux violations** :

1. **C.1 (notebook-conventions.md)** : les stubs d'exercice doivent être
   exécutables end-to-end. Une méthode sans `return` ne compile pas → le
   notebook ne s'exécute pas du tout (erreur compilation CS0161 sur cellule
   top-level).

2. **`exercise-example-labeling.md`** : règle HARD « Classification PAR
   CONTENU, pas par titre ». Les markdown parents disent **Exercice** :
   - cell [21] `## Exercice : Resoudre le Sudoku X avec contraintes de diagonale`
   - cell [31] `## Exercice : Solveur OR-Tools pour le probleme des N-Reines`
   Mais les commentaires en tête des cellules code disent **Exemple guide**
   (incohérence md/code) :
   - cell [28] `// Exemple guide 2 : Sudoku X ...`
   - cell [32] `// Exemple guide : Probleme des N-Reines ...`
   Le contenu est un stub TODO + `Console.WriteLine("Exercice a completer")`
   → c'est un EXERCICE, le label doit dire EXERCICE.

## Correctifs

| Cell idx | Cell id | Modification |
|----------|---------|--------------|
| [28] | `f4f6b873` | (1) `// Exemple guide 2 :` → `// EXERCICE 2 :` ; (2) ajout `return inputGrid; // TODO etudiant` après `Console.WriteLine("Exercice a completer")` (fix CS0161) |
| [32] | `78048935` | (1) `// Exemple guide :` → `// EXERCICE :` ; (2) ajout `return 0; // TODO etudiant` après `Console.WriteLine("Exercice a completer")` (fix CS0161) |

Tous les `# TODO`, `# Indice`, `# Etape N` préservés (cf C.1 règle).
Stub C.1-compliant : `Console.WriteLine("Exercice a completer")` +
`return` (pas de `raise NotImplementedError` / `assert False` / `1/0`).

## Diff

```
$ git diff --shortstat
 1 file changed, 13 insertions(+), 11 deletions(-)
```

Scope : 1 fichier, 2 cellules, +13/-11 (incluant normalisation
trailing-whitespace sur les lignes vides de cell [32] `    \n` → `\n`,
sans impact sémantique).

## Outputs — préservation consciente (Stop & Repair)

Les `outputs` des deux cellules (ec=12 / ec=14) sont **préservés tels
quels** : ils documentent l'état pre-fix avec erreur compilation
CS0161. C'est une décision **consciente** qui s'inscrit dans la règle
**Stop & Repair** (cf `.claude/rules/sota-not-workaround.md` + leçon
**feedback-no-cell-output-scrubbing**) :

- **JAMAIS** hand-editer une sortie de cellule pour maquiller un
  diagnostic. Ici on garde la trace de l'erreur.
- La **ré-exécution post-fix** est gated VS Code Interactive
  (RECOVERABLE-MACHINE, cf issue #4940 commentaires po-2023/po-2024
  + MEMORY `dotnet-interactive-import-cli-exec-limit`) : la cellule
  `[3] #!import Sudoku-0-Environment-Csharp` ne fonctionne que dans
  ce contexte (pas en CLI/papermill/nbconvert).
- Cette PR est une **correction source**. La re-exécution refresh des
  outputs sera faite en suivi par l'agent qui ouvre le notebook en
  VS Code Interactive (hors scope CLI).

## Conformité règles

- ✓ **C.1 notebook-conventions.md** : stubs C.1-compliant (pas
  `raise NotImplementedError`, `return` explicite même sur stub vide).
- ✓ **C.2 notebook-conventions.md** : `execution_count` non-null (12
  et 14 préservés) ; `outputs` documentent l'état réel (erreur
  compilation pre-fix, trace historique honnête).
- ✓ **C.3 notebook-conventions.md** : 1 notebook modifié, scope strict.
- ✓ **`exercise-example-labeling.md`** : cohérence md/code restaurée
  (label « Exercice » dans le code, alignement avec markdown parent).
- ✓ **#2632 catalog-pr-hygiene** : 0 regénération catalogue sur
  branche feature, byte-identique à `origin/main` pour `COURSE_CATALOG*`.
- ✓ **#1650 Phase 0.5 / readme-french-first** : pas de modification
  README dans cette PR.
- ✓ **Anti-régression (CLAUDE.md D)** : pas de touch à du code de
  production ; les stubs sont des cellules d'exercice (doivent rester
  stubbés).
- ✓ **Stop & Repair (sota-not-workaround.md)** : 0 hand-edit d'output,
  0 scrub de chemin machine, 0 redaction de secret.
- ✓ **atomicité (rule A)** : 1 sujet (CS0161 + cohérence labeling),
  1 fichier, +13/-11.

## Vérifications

- ✓ JSON notebook valide (nbformat 4.5, 35 cellules préservées)
- ✓ ec distincts 1-14 préservés (cell[28]=12, cell[32]=14)
- ✓ Sortie pre-fix confirmée par `python` lecture JSON + grep error output
- ✓ Diff stat : 1 fichier, 13 insertions, 11 deletions
- ✓ Branche `fix/4940-sudoku10-csharp-cs0161-mislabel` depuis
  `origin/main` (`68402b4e0`, frais, R2 catalog-pr-hygiene respecté)

## Note CI

Le CI validera la cohérence statique (validate-notebooks,
static-validation H.1/H.3/C.1). Le notebook ne sera **pas ré-exécuté**
en CI (kernel .NET Interactive `#!import` limitation connue, RECOVERABLE-MACHINE).
La re-exécution VS Code Interactive suivra cette PR en dehors du flux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>