### PR TITLE
fix(tour-plateforme): 02-chat-streaming capture une vraie réponse en streaming

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/tour-captures.spec.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/tour-captures.spec.ts
@@ -130,6 +130,20 @@ test.describe('Tour de la plateforme — captures (compte de capture)', () => {
         .catch(() => {}); // tolérant : la capture vaut même si l'ouverture échoue
       await capture(page, '02-selecteur-modele.png');
       await page.keyboard.press('Escape').catch(() => {});
+
+      // Réponse en cours de streaming sur une invite FICTIVE (aucun contenu réel).
+      // Sans envoi d'invite, l'écran resterait vide : le fichier serait mal nommé.
+      // On saisit une invite neutre dans l'éditeur TipTap (#chat-input requiert
+      // keyboard.type, pas fill) puis on capture dès que la réponse de l'assistant
+      // commence à s'afficher. Sélecteurs à confirmer contre l'UI live.
+      await page.locator('#chat-input').click().catch(() => {});
+      await page.keyboard.type('Rédige un court poème sur la mer.', { delay: 8 });
+      await page.keyboard.press('Enter');
+      await page
+        .locator('[id^="message-"], .chat-assistant, [class*="assistant" i]')
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 })
+        .catch(() => {});
       await capture(page, '02-chat-streaming.png');
     });
 


### PR DESCRIPTION
## Quoi

Le script de capture du Tour de la plateforme prenait `02-chat-streaming.png` **juste après avoir fermé le sélecteur de modèle, sans envoyer d'invite** → l'image montrait un **chat vide**, alors que le [README §2](../README.md) (ligne « 📷 Capture à venir — `02-chat-streaming.png` (réponse en cours de streaming) ») la documente comme une réponse en cours de streaming.

## Correctif (`+14` lignes, 1 fichier)

Envoi d'une **invite fictive neutre** (« Rédige un court poème sur la mer. ») via `#chat-input` (éditeur TipTap → `keyboard.type`, pas `fill`), puis capture dès que la réponse de l'assistant apparaît. Réutilise **le même patron déjà vérifié en direct vs v0.10.2** que la capture du raisonnement v0.10 du même fichier (sélecteurs confirmés firsthand dans #5044).

Même en cas d'échec du sélecteur d'attente (`.catch` + cap 30 s), le résultat — un chat avec une réponse — reste **strictement meilleur que l'ancien chat vide**.

## Vérification

- **`tsc --noEmit` vert** avec les options exactes du projet Playwright-OWUI (`@playwright/test` + `node`). Ce fichier vit **hors du `testDir`** de la série (donc non couvert par le workflow `owui-playwright-check`) → type-check effectué en local via une copie temporaire dans le projet, supprimée ensuite. La suite Playwright-OWUI reste verte (exit 0).
- **0 secret** : invite fictive, aucune donnée réelle, aucun PNG généré.

## Hors périmètre

La **génération des PNG reste gated** (décision compte-capture non-admin + revue anti-fuite par image). Ce correctif rend l'utilitaire **correct-by-construction** : le jour où les captures seront produites, `02-chat-streaming.png` montrera réellement une réponse en streaming, sans re-toucher le script.

Part of #4433 (sous #4427). **Pas de self-merge** → review ai-01:CoursIA.
