### PR TITLE
docs(genai): restore FR accents in Vibe-Coding README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -207,7 +207,7 @@ Points fréquents :
 
 ### Les scripts PowerShell de preparation échouent
 
-Les scripts `Scripts/prepare-workspaces.ps1` et `Scripts/clean-workspaces.ps1` (references dans les modules Claude Code et Roo Code) préparent les espaces de travail individuels. Si erreur :
+Les scripts `Scripts/prepare-workspaces.ps1` et `Scripts/clean-workspaces.ps1` (référencés dans les modules Claude Code et Roo Code) préparent les espaces de travail individuels. Si erreur :
 
 ```powershell
 # Verifier la politique d'execution PowerShell
@@ -234,10 +234,10 @@ Les Claw Systems ([README](Claw-Systems/README.md)) sont des agents IA conteneur
 
 ### Peut-on faire les ateliers sans OpenRouter ?
 
-Oui, partiellement. OpenRouter est le fournisseur par défaut car il aggrege plusieurs modeaux (Claude, GPT, Gemini) sous une seule clé. Alternatives :
+Oui, partiellement. OpenRouter est le fournisseur par défaut car il aggrege plusieurs modèles (Claude, GPT, Gemini) sous une seule clé. Alternatives :
 
-- **API Anthropic directe** : `$env:ANTHROPIC_API_KEY = "sk-ant-..."` (sans `ANTHROPIC_BASE_URL`). Fonctionne avec les modeaux Claude uniquement.
-- **API OpenAI directe** : configurée via les settings Claude Code (sans OpenRouter). Modeaux GPT uniquement.
+- **API Anthropic directe** : `$env:ANTHROPIC_API_KEY = "sk-ant-..."` (sans `ANTHROPIC_BASE_URL`). Fonctionne avec les modèles Claude uniquement.
+- **API OpenAI directe** : configurée via les settings Claude Code (sans OpenRouter). Modèles GPT uniquement.
 - **Mode hors-ligne** : les modules [01](Claude-Code/01-decouverte/) et [02](Claude-Code/02-orchestration-taches/) contiennent des exercices de découverte qui ne nécessitent pas d'API (exploration de l'interface, configuration CLAUDE.md, gestion de sessions).
 
 Le module [05](Claude-Code/05-automatisation-avancee/) (Skills, Subagents, MCP) nécessite un LLM actif pour les démonstrations avancées.


### PR DESCRIPTION
## Summary

Restore FR accents dans `MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md` — tranche 2 de la sweep GenAI #2876 (post PR #5149 PostTraining).

**4 corrections surgicales** sur 247 lignes :

- l.210 : `references` → `référencés` (contexte scripts PowerShell modules Claude Code et Roo Code)
- l.237, l.239, l.240 : `modeaux` → `modèles` (typo "eau" au lieu de "èle", 3 occurrences section "Peut-on faire les ateliers sans OpenRouter ?")

## Leçons C196 = leçon C195-HARD #1 réutilisée

Suite à C195 où j'avais identifié que le `replace_all` global FR accents produisait **5 faux positifs sur termes anglais RLHF/DPO établis**, C196 applique directement la bonne pratique : **EDIT SURGICAL par Edit tool, un par un, scoped strictement aux contextes français certains.**

**3 termes anglais préservés** volontairement (NE PAS accentuer) :
- `OpenRouter` (nom de service)
- `Claude Code`, `Roo Code` (noms de produits Anthropic/Roo)
- `OpenAI` (nom de société)

**Mots "invariants" en -oin ou noms de dossiers préservés** (leçon C195-HARD #3) :
- `orchestration-taches`, `automatisation-avancee`, `decouverte`, `execution` (chemins de fichiers dans URLs)
- `preparation`, `Verifier` dans titres H3 (titres de section courts, accentuer ou pas = choix éditorial, laissé tel quel pour rester surgical)

Cette livraison volontairement **chirurgicale** : 4 corrections certaines > 10 risquées. Le scope peut être étendu dans des PRs suivantes si audit plus approfondi.

## Suite rollout #2876 GenAI (post C196)

| Famille | Statut C195+C196 |
|---------|------------------|
| Open-WebUI | déjà fait (#5029 + #5143 + #5146) |
| CaseStudies | déjà fait (#4406 + #4782) |
| **PostTraining** | **C195 ✅ (PR #5149, 2 corrections)** |
| **Vibe-Coding** | **C196 ✅ (cette PR, 4 corrections dont 1 typo 3x)** |
| Image | à scanner |
| Video | à scanner |
| SemanticKernel | à scanner |
| Audio | à scanner (scan initial = 0 gap) |
| Texte | à scanner |
| **RAG-et-Memoire-Semantique** | à scanner (scan initial = 0 gap) |
| **FineTuning** | à scanner (scan initial = 0 gap) |

C196 confirme la leçon C195-HARD : la grande majorité des READMEs GenAI sont déjà bien accentués. Les gaps restants sont des typos isolés comme `modeaux` ou des cas chirurgicaux comme `references` → `référencés`. Appropriation EDIT SURGICAL > replace_all.

## Vérifications

| Check | Résultat |
|-------|----------|
| catalog-pr-hygiene R1 | ✅ `git diff origin/main -- COURSE_CATALOG.* | wc -l` = 0 |
| catalog-pr-hygiene R2 | ✅ branche fraîche `fix/2876-vibe-coding-accents` depuis `origin/main c485a1af1` (rebase frais post-fetches PRs upstream mergées) |
| catalog-pr-hygiene R3 | ✅ PR atomique, 1 sujet (accents FR + typos), 1 fichier, +4/-4 |
| catalog-pr-hygiene R4 | ✅ `See #2876` (Epic tracker, pas Closes car famille GenAI non terminée) |
| LF preservation | ✅ `git diff --stat` = +4/-4, vérifié `b'\r\n' not in read_bytes()` |
| Anti-faux-positifs leçon C195 | ✅ 3 termes anglais préservés (OpenRouter, Claude Code, Roo Code) |
| G.1 cross-check upstream | ✅ `git show origin/main:Vibe-Coding/README.md` confirme que les 3 `modeaux` ne sont PAS mergés (PRs antérieures #4845/#4836/#4407/#4403 ont raté ces typos) |
| Pre-commit H.3 | N/A (markdown only) |
| C.1/C.2/C.3 | N/A (notebook not modified) |
| Anti-tunneling R5.4b | ✅ C195 PostTraining accents (sous-thème pivot) + C196 Vibe-Coding accents = diversification sous-thème au sein de la même famille GenAI/lane respectée |

## Liens

- **#2876** — accents manquants READMEs francophones (rollout LIVE)
- **PR #4403** — Vibe-Coding/README accents (antérieure, raté ces typos)
- **PR #4407** — Vibe-Coding sub-READMEs accents (antérieure)
- **PR #4836** — Vibe-Coding/README accents (antérieure)
- **PR #4845** — Vibe-Coding 2 files accents (antérieure)
- **PR #5149** — PostTraining README accents (sister C195)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>