### PR TITLE
feat(genai): #2161 — 3 structured exercises in 01-Hands-On-Grounding.ipynb

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb
@@ -490,10 +490,195 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b05f591",
+   "id": "ce33bdab",
    "metadata": {},
    "source": [
     "## 10. Exercices\n",
+    "\n",
+    "Les trois exercices ci-dessous sont à compléter dans les cellules de code qui suivent.\n",
+    "Chaque cellule est un **squelette exécutable** (elle s'exécute telle quelle, mais ne fait\n",
+    "rien d'utile tant que vous n'avez pas rempli les `# TODO`). Inspirez-vous des sections 4\n",
+    "(recherche sémantique), 6 (filtres de payload) et de la cellule 4 (modèle d'embeddings)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f175fa92",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Retrouver un document par le sens, pas par les mots\n",
+    "\n",
+    "Le grounding retrouve un texte grâce à sa **signification**, même si la requête ne partage\n",
+    "aucun mot avec lui. C'est tout l'intérêt d'une recherche vectorielle par rapport à un `grep`.\n",
+    "\n",
+    "**Objectif.** Ajoutez au corpus un document sur la sécurité des secrets (par exemple la\n",
+    "rotation des clés d'API), puis écrivez une requête qui le retrouve **sans employer aucun de\n",
+    "ses mots-clés** (« secret », « clé », « API »…).\n",
+    "\n",
+    "**Indices.**\n",
+    "- Inspirez-vous de la cellule 6 pour `client.add(...)` et de la fonction `chercher`\n",
+    "  (section 4) pour la requête.\n",
+    "- Un modèle multilingue rapproche par exemple « gestion des identifiants » et « sécurité des\n",
+    "  secrets » bien qu'aucun mot ne soit commun."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "031b3451",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 à compléter — résultat : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — Ajoutez un document sur la sécurité des secrets, puis retrouvez-le\n",
+    "# par le SENS, sans citer ses mots exacts (cf. section 4 : fonction `chercher`).\n",
+    "#\n",
+    "# TODO étudiants :\n",
+    "#   1. Complétez `nouveau_document` (une phrase sur la rotation/fuite de clés).\n",
+    "#   2. Ajoutez-le à la collection \"grounding_demo\" via `client.add(...)`\n",
+    "#      (même forme que la cellule 6 : documents=[...], metadata=[...]).\n",
+    "#   3. Complétez `requete_semantique` avec une formulation qui évite les mots du document.\n",
+    "#   4. Décommentez l'appel à `chercher` et vérifiez que votre document figure dans le top 3.\n",
+    "\n",
+    "nouveau_document = \"...\"  # TODO : votre phrase sur la sécurité des secrets\n",
+    "requete_semantique = \"...\"  # TODO : formulation sans les mots-clés du document\n",
+    "\n",
+    "# TODO : ajoutez le document à la collection\n",
+    "# client.add(collection_name=\"grounding_demo\", documents=[nouveau_document],\n",
+    "#             metadata=[{\"source\": \"exercice\", \"sujet\": \"secrets\"}])\n",
+    "\n",
+    "# resultat = chercher(requete_semantique, limit=3)\n",
+    "resultat = None  # TODO : remplacez par l'appel à chercher(...) ci-dessus\n",
+    "print(\"Exercice 1 à compléter — résultat :\", resultat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f06911e7",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Combiner deux conditions de filtre (ET logique)\n",
+    "\n",
+    "Un `Filter(must=[...])` ne retient que les points qui satisfont **toutes** les\n",
+    "`FieldCondition` listées : c'est l'équivalent d'un ET logique. La section 6 filtre sur une\n",
+    "seule condition ; ici on en combine deux.\n",
+    "\n",
+    "**Objectif.** Construisez un filtre qui sélectionne les documents dont `source = \"incident\"`\n",
+    "**et** `sujet = \"mount-drift\"`, puis interrogez la collection avec ce filtre.\n",
+    "\n",
+    "**Indices.**\n",
+    "- Inspectez d'abord les métadonnées de la cellule 6 pour connaître les valeurs exactes.\n",
+    "- Deux `FieldCondition` dans la même liste `must` = intersection (ET). Pour un OU,\n",
+    "  il faudrait `should=[...]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ee6141a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 à compléter — réponse : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — Combinez DEUX conditions de filtre (ET logique via `must`).\n",
+    "# Cf. section 6 : un `Filter(must=[...])` ne retient que les points satisfaisant\n",
+    "# TOUTES les FieldCondition listées.\n",
+    "#\n",
+    "# TODO étudiants :\n",
+    "#   1. Construisez `filtre_combine` avec models.Filter(must=[...]).\n",
+    "#   2. Ajoutez dans `must` la 1re FieldCondition (key=\"source\", value=\"incident\").\n",
+    "#   3. Ajoutez la 2e FieldCondition (key=\"sujet\", value=\"mount-drift\").\n",
+    "#   4. Décommentez l'appel à `client.query(...)` et observez le nombre de hits.\n",
+    "\n",
+    "filtre_combine = None  # TODO : models.Filter(must=[...]) avec deux FieldCondition\n",
+    "\n",
+    "# reponse = client.query(\n",
+    "#     collection_name=\"grounding_demo\",\n",
+    "#     query_text=\"dérive de montage du disque\",\n",
+    "#     query_filter=filtre_combine,\n",
+    "#     limit=5,\n",
+    "# )\n",
+    "reponse = None  # TODO : remplacez par l'appel à client.query(...) ci-dessus\n",
+    "print(\"Exercice 2 à compléter — réponse :\", reponse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70fefc02",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Comparer deux modèles d'embeddings\n",
+    "\n",
+    "Le choix du modèle d'embeddings (langue couverte, dimension du vecteur) change la qualité du\n",
+    "retrieval. `fastembed` supporte plusieurs modèles locaux ; la cellule 4 en a fixé un\n",
+    "(multilingue, 384 dimensions).\n",
+    "\n",
+    "**Objectif.** Créez un **second client** avec un modèle d'embeddings **différent**\n",
+    "(par exemple `BAAI/bge-small-en-v1.5`), ré-indexez le même petit corpus, puis comparez les\n",
+    "scores obtenus pour une même requête entre les deux modèles.\n",
+    "\n",
+    "**Indices.**\n",
+    "- Créez un nouveau `QdrantClient(\":memory:\")` puis appelez `client_b.set_model(...)`.\n",
+    "- Un modèle entraîné surtout sur l'anglais donnera des scores plus faibles sur un corpus\n",
+    "  francophone : c'est précisément ce que l'on veut mettre en évidence.\n",
+    "- Pour lister les modèles disponibles : `QdrantClient.get_models()` ou la doc `fastembed`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2b69427a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 à compléter — comparaison : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — Changez de modèle d'embeddings et comparez les scores.\n",
+    "# Cf. cellule 4 : `client.set_model(EMBED_MODEL)` définit le modèle utilisé.\n",
+    "#\n",
+    "# TODO étudiants :\n",
+    "#   1. Créez un second client `client_b = QdrantClient(\":memory:\")`.\n",
+    "#   2. Fixez-lui un modèle DIFFÉRENT (ex. \"BAAI/bge-small-en-v1.5\").\n",
+    "#   3. Recréez la collection \"comparaison\" et ré-indexez le corpus de la cellule 6.\n",
+    "#   4. Lancez la même requête sur les deux clients et comparez les scores du top hit.\n",
+    "\n",
+    "# client_b = QdrantClient(\":memory:\")\n",
+    "# client_b.set_model(\"BAAI/bge-small-en-v1.5\")  # TODO : un autre modèle fastembed\n",
+    "# ... TODO : créer la collection, indexer le corpus, requêter ...\n",
+    "\n",
+    "comparaison = None  # TODO : dict du type {\"multilingue\": 0.83, \"bge-small-en\": 0.71}\n",
+    "print(\"Exercice 3 à compléter — comparaison :\", comparaison)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77df170b",
+   "metadata": {},
+   "source": [
+    "## 11. Pour aller plus loin — explorations libres\n",
+    "\n",
+    "Les quatre pistes ci-dessous sont des **explorations ouvertes** (sans squelette de code)\n",
+    "pour approfondir, une fois les trois exercices ci-dessus terminés :\n",
     "\n",
     "1. **Ajoutez un document** sur un nouveau sujet (par exemple la sécurité des secrets), puis\n",
     "   vérifiez qu'une requête sémantique le retrouve sans en citer les mots exacts.\n",
@@ -502,8 +687,14 @@
     "3. **Faites varier `N`** dans la section 7 (par ex. 5 000 → 100 000) et observez comment l'écart\n",
     "   de temps `scroll` avec/sans index évolue. Que se passerait-il sur disque plutôt qu'en mémoire ?\n",
     "4. **Changez le modèle d'embeddings** (`client.set_model(...)` avec un autre modèle `fastembed`)\n",
-    "   et comparez les scores. La dimension du vecteur change-t-elle vos résultats ?\n",
-    "\n",
+    "   et comparez les scores. La dimension du vecteur change-t-elle vos résultats ?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58a9c42c",
+   "metadata": {},
+   "source": [
     "---\n",
     "\n",
     "*Notebook pratique — Section RAG et Mémoire Sémantique — Juin 2026. Exécutable hors ligne\n",


### PR DESCRIPTION
## Context (#2161)

Rollout perenne **#2161 — 3 exercices par notebook pédagogique**. [`01-Hands-On-Grounding.ipynb`](../blob/feat/2161-grounding-exercises/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb) était **sub-threshold** : la section « ## 10. Exercices » contenait **4 exercices en prose** mais **0 cellule de code stub** (le convention #2161 + [exercise-example-labeling](../../blob/main/.claude/rules/exercise-example-labeling.md) veut un header markdown + une cellule stub exécutable avec `# TODO`/`# Indice`). `count_exercises.py` ne comptait donc que 1 (le header de section).

## What changed

**+8 cellules** (3 exercices structurés = 3 headers markdown + 3 stubs code, + section « Pour aller plus loin » + footer). Exercise count **1 → 4** (conforme au seuil ≥ 3).

| Exercice | Concept visé | Section de référence |
|----------|--------------|----------------------|
| **Exercice 1** — Retrouver un document par le sens, pas par les mots | Recherche sémantique vs `grep` | § 4 (`chercher`) |
| **Exercice 2** — Combiner deux conditions de filtre (ET logique) | `Filter(must=[...])` intersection | § 6 |
| **Exercice 3** — Comparer deux modèles d'embeddings | Choix du modèle (langue, dimension) | cellule 4 (`set_model`) |

Chaque stub est un **squelette exécutable** : il s'exécute tel quel (affiche `Exercice N à compléter — résultat : None`) et obtient donc un `execution_count` + output (C.2), tout en laissant l'étudiant remplir les `# TODO`. La prose open-ended existante (4 pistes d'exploration) est **préservée** dans une nouvelle section « ## 11. Pour aller plus loin » (rien n'est perdu — `Consolider != Archiver`).

## Validation

- **`count_exercises.py`** : `Total exercises: 4`, `Conforming: 1`, `Sub-threshold: 0` ✓ (was: 1, sub-threshold).
- **C.1** : `grep -E "raise NotImplementedError|assert False|1/0"` = **0** (stubs utilisent `print("Exercice à compléter …")` + `= None` + `# TODO`).
- **C.2 + C.3 (scope chirurgical)** : les **7 cellules code originales sont préservées byte-identiques** (source + outputs + exec_count inchangés vs `origin/main`). Les **3 nouveaux stubs sont exécutés seuls** (standalone, self-contained — aucune dépendance à l'état antérieur `client`/`models`/`chercher`), puis leurs outputs injectés avec exec_count séquentiels (8, 9, 10). **Aucune re-exécution des cellules existantes** = zéro drift d'output, zéro fuite de chemin machine (les UserWarnings `fastembed` qui fuient `C:\Users\…\AppData` dans une re-exécution pleine sont évités — Stop & Repair, secrets-hygiene rule 6).
- **H.3** : aucune cellule code avec `execution_count: null` sans outputs.
- **nbformat** : VALID (27 cells, tous les cellules ont un `id`).
- **Path-leak scan** : `False` (aucun output ne contient de chemin machine).
- **CATALOG-STATUS** : notebook (pas README) → n/a.

## Scope & safety

- Single file, single subject : `MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb`. `+8 cellules` pédagogiques.
- **Collision-clean** : aucune PR ouverte ne touche ce notebook (#4608 l'a créé, MERGED).
- **Self-contained** : aucune dépendance Docker/GPU/vLLM (vLLM actuellement DOWN au moment de la livraison — ce grain est volontairement hors-infra).

See #2161 (convention 3-exercices, partial delivery — See, not Closes).
