### PR TITLE
feat(docs): #4210 health dashboard derived from catalogue (acceptance #4)

### DIFF
--- a/docs/reference/HEALTH_DASHBOARD.md
+++ b/docs/reference/HEALTH_DASHBOARD.md
@@ -1,0 +1,77 @@
+# Tableau de santé du dépôt — snapshot dérivé du catalogue
+
+> Snapshot statique généré depuis `COURSE_CATALOG.generated.json` (date catalogue : **2026-07-03**).
+> Ce fichier **n'est pas maintenu à la main** : il est dérivé du catalogue (acceptance #4 de #4210).
+> Pour le régénérer : `python scripts/notebook_tools/generate_health_dashboard.py`.
+
+**670** notebooks référencés au catalogue.
+
+## État global
+
+| Statut | Count | % |
+|--------|-------|---|
+| READY | 518 | 77.3% |
+| DEMO | 147 | 21.9% |
+| BROKEN | 5 | 0.7% |
+
+## Exigences d'environnement (badges)
+
+| Exigence | Notebooks concernés |
+|----------|---------------------|
+| **local** (exécutable sans GPU/cloud/WSL) | 369 |
+| WSL requis | 42 |
+| GPU requis | 83 |
+| Cloud requis (QC / GenAI Docker) | 105 |
+| API key requise | 133 |
+
+## Distribution par série
+
+| Série | READY | DEMO | BROKEN | Total | % READY |
+|-------|-------|------|--------|-------|---------|
+| CaseStudies | 6 | 0 | 0 | 6 | 100% |
+| GameTheory | 28 | 0 | 0 | 28 | 100% |
+| GenAI | 59 | 80 | 2 | 141 | 42% |
+| IIT | 18 | 0 | 0 | 18 | 100% |
+| ML | 33 | 3 | 1 | 37 | 89% |
+| Probas | 53 | 0 | 0 | 53 | 100% |
+| QuantConnect | 48 | 57 | 0 | 105 | 46% |
+| RL | 16 | 0 | 0 | 16 | 100% |
+| Search | 71 | 0 | 0 | 71 | 100% |
+| Sudoku | 30 | 1 | 2 | 33 | 91% |
+| SymbolicAI | 156 | 6 | 0 | 162 | 96% |
+
+## Kernels
+
+| Kernel | Count |
+|--------|-------|
+| Python 3 | 486 |
+| .NET (C#) | 117 |
+| Python 3 (ipykernel) | 18 |
+| Lean 4 (WSL) | 17 |
+| Python (GameTheory WSL + OpenSpiel) | 9 |
+| Python 3 (WSL) | 7 |
+| Python 3 (PyPhi/IIT) | 4 |
+| Lean 4 | 3 |
+| Python 3 (coursia-ml-training) | 2 |
+| .venv | 2 |
+| pyphi | 1 |
+| .venv (3.14.3) | 1 |
+| .venv (3.12.3) | 1 |
+| Python (CoursIA SemanticWeb) | 1 |
+| cours-ia | 1 |
+
+## BROKEN (5 — à traiter en priorité)
+
+| Série | Notebook | Maturité | Dernière validation |
+|-------|----------|----------|---------------------|
+| GenAI | Notebook de travail | TEMPLATE | 2026-06-26 |
+| GenAI | Notebook de travail | TEMPLATE | 2026-06-26 |
+| ML | ML-5 : Time Series Forecasting avec ML.NET | DRAFT | 2026-06-24 |
+| Sudoku | Sudoku-10 : Resolution avec OR-Tools (C#) | PRODUCTION | 2026-07-02 |
+| Sudoku | Sudoku-6 : Resolution par CSP Academique (AIMA) | PRODUCTION | 2026-07-02 |
+
+## Voir aussi
+
+- [Catalogue source](../../COURSE_CATALOG.generated.md) — données brutes régénérées par `catalog-cron.yml`.
+- See #4210 (onboarding/packaging, acceptance #4).
+- See #4208 (CoursIA → référence publique).

--- a/scripts/notebook_tools/generate_health_dashboard.py
+++ b/scripts/notebook_tools/generate_health_dashboard.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""#4210 acceptance #4 — derive a public health dashboard from COURSE_CATALOG.generated.json.
+Snapshot doc (generated, not hand-maintained). Mirrors docs/archive/qc-strategies-status.md precedent.
+Read-only generator -> writes docs/reference/HEALTH_DASHBOARD.md."""
+import json, pathlib, collections, datetime
+
+CAT = pathlib.Path("COURSE_CATALOG.generated.json")
+OUT = pathlib.Path("docs/reference/HEALTH_DASHBOARD.md")
+
+d = json.loads(CAT.read_text(encoding="utf-8"))
+assert isinstance(d, list) and d, "catalog must be a non-empty list"
+
+# Today date from last_validation max (catalogue-derived, not Date.now which is forbidden in some contexts)
+dates = [x.get("last_validation","") for x in d if x.get("last_validation")]
+snapshot_date = max(dates) if dates else "n/a"
+
+# Global aggregates
+status_global = collections.Counter(x.get("status","?") for x in d)
+maturity_global = collections.Counter(x.get("maturity","?") for x in d)
+kernel_global = collections.Counter(x.get("kernel","?") for x in d)
+
+# Requirement badges (acceptance #2 feed): local-executable vs needs-GPU/cloud/wsl
+req_gpu = sum(1 for x in d if x.get("requires_gpu"))
+req_cloud = sum(1 for x in d if x.get("requires_cloud"))
+req_wsl = sum(1 for x in d if x.get("requires_wsl"))
+req_api = sum(1 for x in d if x.get("requires_api"))
+local_exec = sum(1 for x in d if x.get("executable_locally"))
+
+# Per-serie breakdown
+series = collections.defaultdict(lambda: collections.Counter())
+for x in d:
+    s = x.get("serie","?")
+    series[s][x.get("status","?")] += 1
+
+# BROKEN detail (actionable)
+broken = [x for x in d if x.get("status")=="BROKEN"]
+
+lines = []
+a = lines.append
+a("# Tableau de santé du dépôt — snapshot dérivé du catalogue")
+a("")
+a(f"> Snapshot statique généré depuis `COURSE_CATALOG.generated.json` (date catalogue : **{snapshot_date}**).")
+a("> Ce fichier **n'est pas maintenu à la main** : il est dérivé du catalogue (acceptance #4 de #4210).")
+a("> Pour le régénérer : `python scripts/notebook_tools/generate_health_dashboard.py`.")
+a("")
+a(f"**{len(d)}** notebooks référencés au catalogue.")
+a("")
+a("## État global")
+a("")
+a("| Statut | Count | % |")
+a("|--------|-------|---|")
+for st in ["READY","DEMO","BROKEN"]:
+    n = status_global.get(st,0)
+    a(f"| {st} | {n} | {100*n/len(d):.1f}% |")
+a("")
+a("## Exigences d'environnement (badges)")
+a("")
+a("| Exigence | Notebooks concernés |")
+a("|----------|---------------------|")
+a(f"| **local** (exécutable sans GPU/cloud/WSL) | {local_exec} |")
+a(f"| WSL requis | {req_wsl} |")
+a(f"| GPU requis | {req_gpu} |")
+a(f"| Cloud requis (QC / GenAI Docker) | {req_cloud} |")
+a(f"| API key requise | {req_api} |")
+a("")
+a("## Distribution par série")
+a("")
+a("| Série | READY | DEMO | BROKEN | Total | % READY |")
+a("|-------|-------|------|--------|-------|---------|")
+for s in sorted(series):
+    c = series[s]
+    total = sum(c.values())
+    rdy = c.get("READY",0)
+    pct = 100*rdy/total if total else 0
+    a(f"| {s} | {rdy} | {c.get('DEMO',0)} | {c.get('BROKEN',0)} | {total} | {pct:.0f}% |")
+a("")
+a("## Kernels")
+a("")
+a("| Kernel | Count |")
+a("|--------|-------|")
+for k,n in kernel_global.most_common():
+    a(f"| {k} | {n} |")
+a("")
+if broken:
+    a(f"## BROKEN ({len(broken)} — à traiter en priorité)")
+    a("")
+    a("| Série | Notebook | Maturité | Dernière validation |")
+    a("|-------|----------|----------|---------------------|")
+    for x in broken:
+        a(f"| {x.get('serie','?')} | {x.get('title','?')} | {x.get('maturity','?')} | {x.get('last_validation','?')} |")
+    a("")
+a("## Voir aussi")
+a("")
+a("- [Catalogue source](../../COURSE_CATALOG.generated.md) — données brutes régénérées par `catalog-cron.yml`.")
+a("- See #4210 (onboarding/packaging, acceptance #4).")
+a("- See #4208 (CoursIA → référence publique).")
+a("")
+
+OUT.parent.mkdir(parents=True, exist_ok=True)
+OUT.write_text("\n".join(lines), encoding="utf-8")
+print(f"=== wrote {OUT} ({OUT.stat().st_size} bytes, {len(lines)} lines) ===")
+print(f"total notebooks: {len(d)} | READY {status_global.get('READY',0)} DEMO {status_global.get('DEMO',0)} BROKEN {status_global.get('BROKEN',0)}")


### PR DESCRIPTION
## What

First tranche of #4210 — **acceptance #4: public health dashboard derived from the catalogue** (not hand-maintained).

Two atomic files:
- `docs/reference/HEALTH_DASHBOARD.md` — static snapshot derived from `COURSE_CATALOG.generated.json`.
- `scripts/notebook_tools/generate_health_dashboard.py` — the derivation script (referenced by the doc header), so the snapshot is reproducible / re-runnable.

## What it shows (catalogue date 2026-07-03)

- **670** notebooks catalogued.
- Status global: **518 READY (77.3%) / 147 DEMO (21.9%) / 5 BROKEN (0.7%)**.
- Environment badges (feeds #4210 acceptance #2): **369 local-executable**, 42 WSL, 83 GPU, 105 cloud, 133 API-key.
- Per-serie breakdown (GenAI 42% READY and QuantConnect 46% READY are the two maturity-long-tail series; Probas/Search/GameTheory/IIT/RL/CaseStudies 100%).
- **5 BROKEN surfaced as an actionable table** (2 GenAI TEMPLATE, 1 ML DRAFT, 2 Sudoku PRODUCTION).

## Design choices

- **Static snapshot, not a live marker.** Mirrors the `docs/archive/qc-strategies-status.md` precedent (static derived doc). Does **not** touch `catalog-cron.yml` or any `CATALOG-STATUS` marker → zero catalog-churn risk (catalog-pr-hygiene R1 respected). The catalogue remains the single source of truth; this doc is a faithful projection.
- **Not hand-maintained** (acceptance #4 verbatim: "derive catalogue, pas maintenu a la main"). Regeneration = `python scripts/notebook_tools/generate_health_dashboard.py`.
- **G.1 caveat surfaced**: the BROKEN list includes `Sudoku-10` (maturity PRODUCTION, last_validation 2026-07-02), but #5147 (merged today) fixed its CS0161 stubs. The catalogue is stale by 1 day and will self-correct on the next `catalog-cron` run. The dashboard correctly reflects its source — the fix is a catalogue-regen, not a dashboard edit.

## Scope

- 2 files, 179 insertions, additive only (no deletions, no code logic touched).
- `See #4210` (partial — acceptance #4 only; #1 Quickstart / #2 badges / #3 release remain ai-01's vision scope).

## Self-serve note (Rule 5.4b)

ai-01's HIGH dispatch (09:06Z) explicitly offered #4210. ai-01's refined .NET steer (09:26Z: #5082/#4956/#4667) was grounded firsthand as stale/collision (#5082 already MERGED #5118+#5094; #4667/#4956 = po-2025 active `parité .NET⇄Python` marathon turf). #4210 was the only clean, unowned, ai-01-offered grain — proceeding follows the "self-serve du pool global" directive.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
