### PR TITLE
feat(infer-10): 3 exercise markdown headers for Thompson Sampling (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Infer/Infer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Infer/Infer-10-Thompson-Sampling.ipynb
@@ -802,6 +802,11 @@
    "source": "## 9. Exercices\n\nTrois exercices pour aller plus loin. Chaque stub s'execute sans erreur ; completez le code entre les `// TODO`.\n\n| # | Exercice | Concept |\n|---|----------|---------|\n| 1 | Ajouter un 4e bras et observer la convergence | Thompson sur K=4 |\n| 2 | Bandit non-stationnaire (facteur d'oubli) | Adaptation au changement |\n| 3 | Prior informatif Beta(50, 50) | Impact du prior sur l'exploration |"
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 1 — Ajouter un 4e bras et observer la convergence\n\nThompson Sampling se generalise de 3 a **K** bras. Ajoutez un 4e bras de vraie\nmoyenne 0,65 et relancez la boucle de selection. Observez comment le choix bascule\nde bras en bras puis se stabilise sur le meilleur des 4.\n\n**Objectif.** Etendre le modele a 4 bras et verifier que Thompson identifie le meilleur.\n\n**Indices.**\n- Etendez `vraiTheta` a 4 valeurs (par ex. `[0.3, 0.5, 0.7, 0.65]`).\n- Mettez `K = 4` et construisez 4 `BayesArm`, comme en section 5.\n- Reportez les tirages par bras et la recompense totale cumulee."
+  },
+  {
    "cell_type": "code",
    "metadata": {},
    "outputs": [
@@ -825,6 +830,11 @@
    "execution_count": 10
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 2 — Bandit non-stationnaire (facteur d'oubli)\n\nJusqu'ici les vraies moyennes sont fixes. En pratique elles peuvent **changer** : ici\nla meilleure bascule a `t = 100`. Implantez un **facteur d'oubli** : a chaque pas, ne\ngardez qu'une fraction des observations passees afin que le posterior s'adapte au\nchangement de regime.\n\n**Objectif.** Ajouter l'oubli au posterior et comparer le regret avec et sans oubli.\n\n**Indices.**\n- Modifiez `BayesArm.Observe` pour decaler/oublier les observations, ou ajoutez une\n  methode `Forget(double gamma)`.\n- Definissez `theta*(t)` qui change a mi-parcours (ex. le bras 1 devient meilleur apres `t=100`).\n- Comparez le regret avec et sans oubli sur la sequence non-stationnaire."
+  },
+  {
    "cell_type": "code",
    "metadata": {},
    "outputs": [
@@ -846,6 +856,11 @@
     "Console.WriteLine(\"Exercice 2 a completer : bandit non-stationnaire avec facteur d oubli.\");"
    ],
    "execution_count": 11
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 3 — Prior informatif Beta(50, 50) vs uniforme\n\nUn prior `Beta(50, 50)` exprime une forte conviction que theta vaut environ 0,5 ; un\nprior `Beta(1, 1)` est uniforme (sans information a priori). Comparez le regret des\ndeux : un prior informatif reduit-il l'exploration prematuree ?\n\n**Objectif.** Mesurer l'impact du prior sur la vitesse de convergence de Thompson.\n\n**Indices.**\n- `BayesArm` accepte des parametres `priorA` / `priorB`.\n- Creez deux jeux de bras — l'un avec `Beta(1,1)`, l'autre avec `Beta(50,50)` — et\n  mesurez le regret de chacun.\n- Interpretez : dans quels cas un prior informatif aide-t-il, et quand nuit-il ?"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Context (#2161)

Rollout perenne **#2161 — >= 3 exercices par notebook pedagogique**. [`Infer-10-Thompson-Sampling.ipynb`](../blob/feature/infer10-thompson-exos-2161/MyIA.AI.Notebooks/Probas/DecisionTheory/Infer/Infer-10-Thompson-Sampling.ipynb) etait **sub-threshold** : la section « ## 9. Exercices » contenait bien 3 stubs de code C# (cellules 22-24), mais `count_exercises.py` ne comptait que **1** exercice.

## Root-cause du sous-compte (finding G.1)

Le compteur sous-comptait pour 2 raisons combinees :
1. **Cellule 22 absorbee** : la logique de dedup de `count_exercises.py` apparie le *premier* code cell qui suit un header markdown au header de section (« ## 9. Exercices ») -> la cellule 22 comptait comme le stub apparie du header de section, pas comme un exercice autonome.
2. **Cellules 23-24 invisibles** : `_code_cell_mentions_exercise()` ne detecte que les commentaires Python (`# Exercice`), pas les commentaires C# (`// Exercice`). Les 2 stubs restants etaient donc invisibles au second pass.

Net : 3 vrais stubs C.1-conformes (executes, avec outputs) mais `count == 1`.

## What changed

**+3 cellules markdown** (header par exercice : contexte + objectif + indices), inserees **avant** chacun des 3 stubs de code existants. Exercise count **1 -> 4** (conforme au seuil >= 3).

| Exercice | Concept vise | Section de reference |
|----------|--------------|----------------------|
| **Exercice 1** — Ajouter un 4e bras et observer la convergence | Thompson sur K=4 | section 5 (multi-bras) |
| **Exercice 2** — Bandit non-stationnaire (facteur d'oubli) | Adaptation au changement de regime | helper `BayesArm` (cellule 13) |
| **Exercice 3** — Prior informatif Beta(50, 50) vs uniforme | Impact du prior sur l'exploration | cellule 15 (Thompson) |

La structure canonique #2161 (header markdown + stub code qui suit) est maintenant respectee pour les 3 exercices.

## Validation

- **`count_exercises.py`** : `Total exercises: 4`, `Conforming: 1`, `Sub-threshold: 0` (was: 1 sub-threshold). `--check` exit 0.
- **C.1** : 0 violation (`raise NotImplemented` / `assert False` / `1/0` / `throw NotImplementedException` = 0). Les 3 stubs C# existants etaient deja C.1-conformes (`Console.WriteLine("Exercice N a completer ...")` + `// Etape N` + `// TODO`).
- **C.2 + C.3 (scope chirurgical)** : **uniquement des cellules markdown inserees** (+15/-0). Les **12 cellules code sont preservees BYTE-IDENTIQUE** (source + outputs + `execution_count` 1..12 inchanges vs `origin/main`) — manipulation JSON pure (pas de `nbformat`, qui aurait ajoute un champ `id` aux 26 cellules et churne tout le fichier). **Aucune re-execution** : les cellules code ne sont pas modifiees, et Infer.NET etant stochastique (Thompson echantillonne depuis le posterior), une re-exec churnerait les outputs des cellules 7-19 non-modifiees (violation C.3). Les outputs committes (ec=1..12) restent la preuve d'execution.
- **H.3 pre-commit** : 0 cellule code avec `execution_count: null` sans outputs (les nouvelles cellules sont markdown, exemptees).
- **JSON valide** : 29 cells (was 26), `json.load` OK.
- **Trailing newline byte-identity** : le notebook `origin/main` n'avait PAS de `\n` final ; ecrit sans `\n` final pour preserver la byte-identity (pas de diff parasite sur la derniere ligne).

## Scope & safety

- Single file, single subject : `MyIA.AI.Notebooks/Probas/DecisionTheory/Infer/Infer-10-Thompson-Sampling.ipynb`. +15 lignes markdown.
- **Collision-clean** : aucune PR ouverte ne touche ce notebook (#5153 touche seulement `Probas/Infer/README.md` + 2 autres README, pas le notebook ; #4737/#4546 MERGED).
- **Accents** : le notebook existant est en francais partiellement non-accentue (etat #2876 mid-restauration). Le nouveau contenu markdown suit le style local predominant (non-accentue) pour garder la PR atomique sur #2161 (structure). L'harmonisation des accents (ancien + nouveau contenu) est du ressort d'une PR #2876 separee.
- **Famille Probas/Infer (.NET / Infer.NET)** : pivot anti-tunneling apres 3 cycles sur la famille GenAI.

See #2161 (convention 3-exercices, livraison partielle — See, pas Closes).
