### PR TITLE
docs(search-csp): add Python ⇄ .NET parity table to Part2-CSP README (#4956 acceptance)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -38,6 +38,19 @@ Si la Partie 1 enseigne à chercher, celle-ci enseigne à modéliser — et c'es
 | 8 | [CSP-8-Temporal](CSP-8-Temporal.ipynb) | Python 3 | Algèbre d'intervalles d'Allen, Simple Temporal Problems (STP), TCSP | ~1h |
 | 9 | [CSP-9-Distributed](CSP-9-Distributed.ipynb) | Python 3 | Asynchronous Backtracking (ABT), AWC, Privacy-preserving CSP | ~1h30 |
 
+### Parité Python ⇄ .NET
+
+Quatre notebooks de cette partie existent en **binôme bilingue** : une version Python (OR-Tools CP-SAT) et une version C# / .NET, dans l'esprit de l'Epic de parité #4956. Le port .NET invoque la **vraie lib** — jamais une réimplémentation jouet : Choco-solver bridgé via IKVM (jurisprudence #4667) ou OR-Tools natif selon le terrain.
+
+| # | Python (OR-Tools CP-SAT) | .NET (C#) | Solveur .NET |
+|---|--------------------------|-----------|--------------|
+| 3 | [CSP-3-Advanced](CSP-3-Advanced.ipynb) | [CSP-3-Advanced-Csharp](CSP-3-Advanced-Csharp.ipynb) | Choco-solver via IKVM |
+| 4 | [CSP-4-Scheduling](CSP-4-Scheduling.ipynb) | [CSP-4-Scheduling-Csharp](CSP-4-Scheduling-Csharp.ipynb) | OR-Tools CP-SAT natif (+ section Choco comparative) |
+| 5 | [CSP-5-Optimization](CSP-5-Optimization.ipynb) | [CSP-5-Optimization-Csharp](CSP-5-Optimization-Csharp.ipynb) | Choco-solver via IKVM (contrainte globale `binPacking`) |
+| 7 | [CSP-7-Soft](CSP-7-Soft.ipynb) | [CSP-7-Soft-Csharp](CSP-7-Soft-Csharp.ipynb) | Choco-solver via IKVM (réification `reifyWith` / `ifThen`) |
+
+> **Pourquoi CSP-4 en OR-Tools natif plutôt que Choco ?** L'ordonnancement (`IntervalVar`, `NoOverlap`, `Cumulative`) est le terrain où CP-SAT excelle ; router cette partie vers OR-Tools C# honore le principe du *vrai outil SOTA pour le problème* (cf. #3801), là où Choco-solver serait plus lourd. Les trois autres binômes (3, 5, 7) illustrent Choco via IKVM comme levier de parité .NET pour une lib Java — y compris `binPacking`, contrainte globale dont la propagation surpasse la linéarisation BoolVar manuelle.
+
 ## Progression
 
 CSP-1 et CSP-2 sont incontournables : tout le paradigme — un modèle déclaratif, une propagation qui élague — tient dans ces deux notebooks. Au-delà, trois chemins s'offrent selon votre objectif :


### PR DESCRIPTION
## Scope

Add a dedicated "Parité Python ⇄ .NET" subsection to the Part2-CSP README, surfacing the four biling notebooks of the series. This serves the acceptance criterion of Epic #4956: *« Chaque README de famille portée affiche sa table de parité Python ⇄ .NET »*.

## Problem

Ground truth (verified firsthand on `origin/main` via `git ls-tree` + first-cell read): CSP-3/4/5/7 each exist as a **Python OR-Tools CP-SAT notebook** AND a **C#/.NET twin**, but the README's "Notebooks" table only listed the Python versions — the four `.NET` twins were invisible. The four C# notebooks (#5072, #5073, #5067, #5133 — all merged by ai-01 R3 this cycle) landed without their parent README documenting them.

```
$ git ls-tree origin/main MyIA.AI.Notebooks/Search/Part2-CSP/ | grep Csharp
CSP-3-Advanced-Csharp.ipynb
CSP-4-Scheduling-Csharp.ipynb
CSP-5-Optimization-Csharp.ipynb
CSP-7-Soft-Csharp.ipynb
```

## What was added

A 13-line subsection inserted between the "Notebooks" table and "Progression", with:
- A one-paragraph framing tying it to Epic #4956 and the #4667 IKVM jurisprudence.
- A 4-row parity table: notebook #, Python twin, .NET twin, .NET solver used.
- A blockquote explaining the one non-obvious choice: **CSP-4 uses OR-Tools CP-SAT native (not Choco)** because scheduling is CP-SAT's strong terrain (cf #3801 sota-not-workaround), with Choco kept as a comparative section.

The parity is **honest about the tool choice** — it is not 1:1:

| # | Python | .NET solver |
|---|--------|-------------|
| 3 | OR-Tools CP-SAT | Choco-solver via IKVM |
| 4 | OR-Tools CP-SAT | OR-Tools CP-SAT **native** (+ Choco comparative) |
| 5 | OR-Tools CP-SAT | Choco via IKVM (`binPacking` global) |
| 7 | OR-Tools CP-SAT | Choco via IKVM (reification `reifyWith`/`ifThen`) |

The `.NET` port invokes the **real libs** (Choco-IKVM or OR-Tools NuGet) — never a toy reimplementation (sota-not-workaround Prong A).

## Validation

```
$ git diff --stat
 Search/Part2-CSP/README.md | 13 +++++++++++++
 1 file changed, 13 insertions(+)
$ # all 4 Csharp link targets exist in Part2-CSP/:
$ for f in CSP-3-Advanced-Csharp CSP-4-Scheduling-Csharp CSP-5-Optimization-Csharp CSP-7-Soft-Csharp; do test -f $f.ipynb && echo OK; done
OK OK OK OK
$ git diff --stat -- COURSE_CATALOG.generated.*   # empty = byte-identical
```

## Out of scope

- No `Closes #N` — this is a partial contribution to Epic #4956 (the marathon stays OPEN). `See #4956`.
- No change to the "Notebooks" table itself (Python rows untouched) — additive subsection only.
- No anti-regression concern — documentation prose only.

See #4956
