### PR TITLE
feat(mgs-9): 3 exercise markdown headers for EverestRelief (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb
@@ -984,6 +984,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 1 — Sensibilite a la tolerance tau\n\nLe taux de reussite depend du **rayon d'acceptation** `tau`. Re-tabulez les 4 methodes\nx 4 zooms pour `tau` dans `{ 0.03, 0.06, 0.12 }` et observez comment la **hierarchie des\nmethodes** bouge selon qu'on est strict ou tolerant.\n\n**Objectif.** Mesurer la sensibilite d'une metaheuristique au rayon de reussite.\n\n**Indices.**\n- Parametrez `Hit`/`Rate` pour accepter `tau` en argument, puis re-affichez la table de la section 4.\n- Un `tau` petit = critere strict (peu de methodes reussissent) ; un `tau` grand = tolerant.\n- Une methode robuste garde une hierarchie stable quand `tau` varie."
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "908c4bcd",
@@ -1029,6 +1034,11 @@
     "\n",
     "Console.WriteLine(\"Exercice a completer : taux de reussite en fonction de tau (0.03 / 0.06 / 0.12).\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 2 — Ajouter une baseline « hill-climber »\n\nAjoutez une **5e ligne** au tableau : un *hill-climber* (montee de gradient stochastique).\nDepart aleatoire, petits pas `(u, v) ± epsilon`, on garde le pas s'il monte. Meme budget\n`NFE = Pop * Gens` que les metaheuristiques. Ou se classe-t-il face a GA/PSO/WOA/EO ?\n\n**Objectif.** Comparer une recherche locale gloutonne aux metaheuristiques populationnelles.\n\n**Indices.**\n- 1 seul point courant, `NFE = Pop * Gens` evaluations, pas `epsilon ~ 0.05`, clamp `[0,1]`.\n- Un hill-climber est vite piege dans un optimum local sur un relief multimodal comme l'Everest.\n- C'est precisement ce qui justifie les metaheuristiques populationnelles (diversite)."
   },
   {
    "cell_type": "code",
@@ -1077,6 +1087,11 @@
     "\n",
     "Console.WriteLine(\"Exercice a completer : baseline hill-climber, meme budget NFE.\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 3 — Taux de reussite vs budget NFE\n\nFaites varier le **budget** `NFE` (par ex. `Pop * Gens` dans `{ 200, 450, 900, 1800 }`)\npour la WOA sur `everestRegion` et tracez (en ASCII ou en colonne) le taux de reussite\ncorrespondant. Le scaling est-il lineaire, sous-lineaire, ou a seuil ?\n\n**Objectif.** Etudier la convergence d'une metaheuristique en fonction du budget.\n\n**Indices.**\n- Ajustez `Gens = nfe / Pop` (gardez `Pop` fixe), relancez `Rate(everestRegion, ...)`.\n- Un seuil (`NFE` minimal pour atteindre le sommet) est plus informatif qu'une pente lineaire.\n- Comparez la forme de la courbe WOA a celle d'un hill-climber (exercice 2)."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Context (#2161)

Rollout perenne **#2161 — >= 3 exercices par notebook pedagogique**. [`MGS-9-EverestRelief.ipynb`](../blob/feature/mgs9-everest-exos-2161/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb) etait **sub-threshold** : `count_exercises.py` comptait **1** alors que le notebook contient 3 vrais stubs C# (`// Exercice 1/2/3`).

## Root-cause du sous-compte (finding G.1, meme pattern que PR #5158 Infer-10)

Le compteur `count_exercises.py` sous-compte dans les notebooks .NET / C# :
1. Le header de section « ## 6. Exercices » (cellule 17) est compte comme 1 exercice.
2. La logique de dedup apparie le **premier** code cell qui suit ce header comme son « stub apparie » -> cellule 18 absorbee (non recomptee).
3. Les cellules 19, 20 (`// Exercice 2/3`) ne sont pas detectees : `_code_cell_mentions_exercise()` cherche `\bexercice\b` uniquement dans les commentaires Python `#`, pas les commentaires C# `//`.

Net : 3 vrais stubs C.1-conformes (executes ec=9/10/11 avec outputs) mais `count == 1`.

## What changed

**+3 cellules markdown** (header par exercice : contexte + objectif + indices), inserees **avant** chacun des 3 stubs de code existants. Exercise count **1 -> 4** (conforme au seuil >= 3).

| Exercice | Concept vise | Section de reference |
|----------|--------------|----------------------|
| **Exercice 1** — Sensibilite a la tolerance tau | Robustesse d'une metaheuristique au rayon d'acceptation | section 4 (table taux de reussite) |
| **Exercice 2** — Ajouter une baseline « hill-climber » | Recherche locale gloutonne vs metaheuristiques populationnelles | sections 3-4 (GA/PSO/WOA/EO) |
| **Exercice 3** — Taux de reussite vs budget NFE | Convergence / scaling d'une metaheuristique | section 4 (budget NFE) |

## Validation

- **`count_exercises.py`** : `Total exercises: 4`, `Conforming: 1`, `Sub-threshold: 0` (was: 1 sub-threshold).
- **C.1** : 0 violation (`raise NotImplemented` / `assert False` / `1/0` / `throw NotImplementedException` = 0). Les 3 stubs C# existants etaient deja C.1-conformes (`Console.WriteLine("Exercice a completer ...")` + `// TODO etudiant` + `// Indice`).
- **C.2 + C.3 (scope chirurgical)** : **uniquement des cellules markdown inserees** (+15/-0). Les cellules code sont preservees BYTE-IDENTIQUE (source + outputs + `execution_count`) via manipulation JSON pure (pas de `nbformat`, qui reformaterait tout le fichier). **Aucune re-execution** : les cellules code ne sont pas modifiees, et les metaheuristiques MGS sont stochastiques (GA/PSO/WOA/EO), donc une re-exec churnerait les outputs des cellules 9-15 non-modifiees (violation C.3). Les outputs committes (ec=1..11) restent la preuve d'execution.
- **H.3 pre-commit** : 0 cellule code avec `execution_count: null` sans outputs.
- **JSON valide** : 25 cells (was 22).

## Scope & safety

- Single file, single subject : `MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb`. +15 lignes markdown.
- **Collision-clean** : aucune PR ouverte ne touche ce notebook (#5154 touche `MGS-19-MetropolisReinsertion`, un autre notebook de la meme serie ; #3166 CLOSED, #3100/#3513/#3169 MERGED).
- **Accents** : le notebook existant est en francais partiellement non-accentue (etat #2876 mid-restauration). Le nouveau contenu markdown suit le style local predominant (non-accentue) pour garder la PR atomique sur #2161 (structure). L'harmonisation des accents est du ressort d'une PR #2876 separee.
- **Famille Search/Part4-Metaheuristics (.NET / C#)** : 3e famille differente pour #2161 ce cycle (apres GenAI grounding #5152, Probas Infer-10 #5158) — cross-family perpetual rollout (coordinator-discipline Regle 4). Prochain cycle : pivot vers un genre different (R5.4b anti-tunneling).

See #2161 (convention 3-exercices, livraison partielle — See, pas Closes).
