### PR TITLE
fix(lean-16b): print figure basename to avoid #3436 machine-path leak

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16b-Conway-Game-of-Life-Lean.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16b-Conway-Game-of-Life-Lean.ipynb
@@ -5,10 +5,10 @@
    "id": "intro-title",
    "metadata": {
     "papermill": {
-     "duration": 0.057703,
-     "end_time": "2026-06-07T00:50:12.145408",
+     "duration": 0.006001,
+     "end_time": "2026-07-03T08:25:35.846821",
      "exception": false,
-     "start_time": "2026-06-07T00:50:12.087705",
+     "start_time": "2026-07-03T08:25:35.840820",
      "status": "completed"
     },
     "tags": []
@@ -66,10 +66,10 @@
    "id": "section-1-phase1-recap",
    "metadata": {
     "papermill": {
-     "duration": 0.005005,
-     "end_time": "2026-06-07T00:50:12.155508",
+     "duration": 0.005,
+     "end_time": "2026-07-03T08:25:35.856994",
      "exception": false,
-     "start_time": "2026-06-07T00:50:12.150503",
+     "start_time": "2026-07-03T08:25:35.851994",
      "status": "completed"
     },
     "tags": []
@@ -96,16 +96,16 @@
    "id": "subprocess-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:12.165583Z",
-     "iopub.status.busy": "2026-06-07T00:50:12.165583Z",
-     "iopub.status.idle": "2026-06-07T00:50:12.176557Z",
-     "shell.execute_reply": "2026-06-07T00:50:12.176557Z"
+     "iopub.execute_input": "2026-07-03T08:25:35.875815Z",
+     "iopub.status.busy": "2026-07-03T08:25:35.874815Z",
+     "iopub.status.idle": "2026-07-03T08:25:35.889093Z",
+     "shell.execute_reply": "2026-07-03T08:25:35.889093Z"
     },
     "papermill": {
-     "duration": 0.017301,
-     "end_time": "2026-06-07T00:50:12.177565",
+     "duration": 0.026106,
+     "end_time": "2026-07-03T08:25:35.890100",
      "exception": false,
-     "start_time": "2026-06-07T00:50:12.160264",
+     "start_time": "2026-07-03T08:25:35.863994",
      "status": "completed"
     },
     "tags": []
@@ -163,16 +163,16 @@
    "id": "phase1-files-list",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:12.188178Z",
-     "iopub.status.busy": "2026-06-07T00:50:12.188178Z",
-     "iopub.status.idle": "2026-06-07T00:50:12.199984Z",
-     "shell.execute_reply": "2026-06-07T00:50:12.199984Z"
+     "iopub.execute_input": "2026-07-03T08:25:35.903106Z",
+     "iopub.status.busy": "2026-07-03T08:25:35.903106Z",
+     "iopub.status.idle": "2026-07-03T08:25:35.916588Z",
+     "shell.execute_reply": "2026-07-03T08:25:35.916588Z"
     },
     "papermill": {
-     "duration": 0.017811,
-     "end_time": "2026-06-07T00:50:12.200988",
+     "duration": 0.022104,
+     "end_time": "2026-07-03T08:25:35.918209",
      "exception": false,
-     "start_time": "2026-06-07T00:50:12.183177",
+     "start_time": "2026-07-03T08:25:35.896105",
      "status": "completed"
     },
     "tags": []
@@ -188,9 +188,10 @@
       "  Doomsday.lean                    113 lignes\n",
       "  DoomsdayLemmas.lean               46 lignes\n",
       "  Fractran.lean                     65 lignes\n",
+      "  FractranLemmas.lean               67 lignes\n",
       "  FreeWillTheorem.lean             208 lignes\n",
       "  KochenSpecker.lean               258 lignes\n",
-      "  Life.lean                        202 lignes\n",
+      "  Life.lean                        224 lignes\n",
       "  LookAndSay.lean                   74 lignes\n",
       "  LookAndSayLemmas.lean             55 lignes\n",
       "  MathlibMap.lean                  119 lignes\n",
@@ -198,12 +199,13 @@
       "\n",
       "Modules dans conway_lean/Conway/Life/ :\n",
       "  Computation.lean                 194 lignes\n",
-      "  Hashlife.lean                    470 lignes\n",
-      "  HashlifeCorrectness.lean         867 lignes\n",
-      "  HashlifeMemo.lean                212 lignes\n",
-      "  MacroCell.lean                   265 lignes\n",
+      "  GridCanonical.lean               133 lignes\n",
+      "  Hashlife.lean                    471 lignes\n",
+      "  HashlifeCorrectness.lean        2970 lignes\n",
+      "  HashlifeMemo.lean                348 lignes\n",
+      "  MacroCell.lean                   640 lignes\n",
       "  Oscillators.lean                 201 lignes\n",
-      "  Pillars.lean                     199 lignes\n",
+      "  Pillars.lean                     234 lignes\n",
       "  RLE.lean                         342 lignes\n",
       "  Spaceships.lean                  128 lignes\n"
      ]
@@ -232,10 +234,10 @@
    "id": "section-1b-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.005005,
-     "end_time": "2026-06-07T00:50:12.211301",
+     "duration": 0.005,
+     "end_time": "2026-07-03T08:25:35.929214",
      "exception": false,
-     "start_time": "2026-06-07T00:50:12.206296",
+     "start_time": "2026-07-03T08:25:35.924214",
      "status": "completed"
     },
     "tags": []
@@ -253,10 +255,10 @@
    "id": "section-2-rule",
    "metadata": {
     "papermill": {
-     "duration": 0.003996,
-     "end_time": "2026-06-07T00:50:12.219919",
+     "duration": 0.004001,
+     "end_time": "2026-07-03T08:25:35.939216",
      "exception": false,
-     "start_time": "2026-06-07T00:50:12.215923",
+     "start_time": "2026-07-03T08:25:35.935215",
      "status": "completed"
     },
     "tags": []
@@ -282,16 +284,16 @@
    "id": "gol-python-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:12.230923Z",
-     "iopub.status.busy": "2026-06-07T00:50:12.230923Z",
-     "iopub.status.idle": "2026-06-07T00:50:13.389790Z",
-     "shell.execute_reply": "2026-06-07T00:50:13.389790Z"
+     "iopub.execute_input": "2026-07-03T08:25:35.956903Z",
+     "iopub.status.busy": "2026-07-03T08:25:35.956903Z",
+     "iopub.status.idle": "2026-07-03T08:25:37.409293Z",
+     "shell.execute_reply": "2026-07-03T08:25:37.409293Z"
     },
     "papermill": {
-     "duration": 1.164872,
-     "end_time": "2026-06-07T00:50:13.389790",
+     "duration": 1.463928,
+     "end_time": "2026-07-03T08:25:37.410298",
      "exception": false,
-     "start_time": "2026-06-07T00:50:12.224918",
+     "start_time": "2026-07-03T08:25:35.946370",
      "status": "completed"
     },
     "tags": []
@@ -357,10 +359,10 @@
    "id": "section-2b-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.00451,
-     "end_time": "2026-06-07T00:50:13.401264",
+     "duration": 0.005347,
+     "end_time": "2026-07-03T08:25:37.420865",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.396754",
+     "start_time": "2026-07-03T08:25:37.415518",
      "status": "completed"
     },
     "tags": []
@@ -386,10 +388,10 @@
    "id": "8998c242",
    "metadata": {
     "papermill": {
-     "duration": 0.004504,
-     "end_time": "2026-06-07T00:50:13.410768",
+     "duration": 0.007998,
+     "end_time": "2026-07-03T08:25:37.433865",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.406264",
+     "start_time": "2026-07-03T08:25:37.425867",
      "status": "completed"
     },
     "tags": []
@@ -408,16 +410,16 @@
    "id": "70f39299",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:13.421388Z",
-     "iopub.status.busy": "2026-06-07T00:50:13.421388Z",
-     "iopub.status.idle": "2026-06-07T00:50:13.425293Z",
-     "shell.execute_reply": "2026-06-07T00:50:13.425293Z"
+     "iopub.execute_input": "2026-07-03T08:25:37.448054Z",
+     "iopub.status.busy": "2026-07-03T08:25:37.448054Z",
+     "iopub.status.idle": "2026-07-03T08:25:37.452052Z",
+     "shell.execute_reply": "2026-07-03T08:25:37.452052Z"
     },
     "papermill": {
-     "duration": 0.010912,
-     "end_time": "2026-06-07T00:50:13.426299",
+     "duration": 0.014517,
+     "end_time": "2026-07-03T08:25:37.453382",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.415387",
+     "start_time": "2026-07-03T08:25:37.438865",
      "status": "completed"
     },
     "tags": []
@@ -463,10 +465,10 @@
    "id": "section-3-patterns",
    "metadata": {
     "papermill": {
-     "duration": 0.003796,
-     "end_time": "2026-06-07T00:50:13.435287",
+     "duration": 0.008001,
+     "end_time": "2026-07-03T08:25:37.466382",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.431491",
+     "start_time": "2026-07-03T08:25:37.458381",
      "status": "completed"
     },
     "tags": []
@@ -493,16 +495,16 @@
    "id": "patterns-viz",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:13.446099Z",
-     "iopub.status.busy": "2026-06-07T00:50:13.446099Z",
-     "iopub.status.idle": "2026-06-07T00:50:13.709907Z",
-     "shell.execute_reply": "2026-06-07T00:50:13.709907Z"
+     "iopub.execute_input": "2026-07-03T08:25:37.486495Z",
+     "iopub.status.busy": "2026-07-03T08:25:37.485498Z",
+     "iopub.status.idle": "2026-07-03T08:25:37.867117Z",
+     "shell.execute_reply": "2026-07-03T08:25:37.866080Z"
     },
     "papermill": {
-     "duration": 0.269439,
-     "end_time": "2026-06-07T00:50:13.709907",
+     "duration": 0.392744,
+     "end_time": "2026-07-03T08:25:37.868125",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.440468",
+     "start_time": "2026-07-03T08:25:37.475381",
      "status": "completed"
     },
     "tags": []
@@ -512,7 +514,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Figure sauvee : /tmp/lean14_patterns.png\n",
+      "Figure sauvee : lean14_patterns.png\n",
       "\n",
       "Illustrations numeriques (grille bornee) :\n",
       "  Block      : step(block)   == block         ? True\n",
@@ -573,7 +575,7 @@
     "out = '/tmp/lean14_patterns.png'\n",
     "plt.savefig(out, dpi=80, bbox_inches='tight')\n",
     "plt.close()\n",
-    "print(f'Figure sauvee : {out}')\n",
+    "print(f'Figure sauvee : {out.rsplit(\"/\", 1)[-1]}')\n",
     "print()\n",
     "print('Illustrations numeriques (grille bornee) :')\n",
     "print(f'  Block      : step(block)   == block         ? {np.array_equal(block_frames[0], block_frames[1])}')\n",
@@ -593,10 +595,10 @@
    "id": "section-3b-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.005896,
-     "end_time": "2026-06-07T00:50:13.721243",
+     "duration": 0.009658,
+     "end_time": "2026-07-03T08:25:37.888395",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.715347",
+     "start_time": "2026-07-03T08:25:37.878737",
      "status": "completed"
     },
     "tags": []
@@ -622,10 +624,10 @@
    "id": "ea418142",
    "metadata": {
     "papermill": {
-     "duration": 0.004651,
-     "end_time": "2026-06-07T00:50:13.730593",
+     "duration": 0.011249,
+     "end_time": "2026-07-03T08:25:37.910978",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.725942",
+     "start_time": "2026-07-03T08:25:37.899729",
      "status": "completed"
     },
     "tags": []
@@ -644,16 +646,16 @@
    "id": "4deed899",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:13.742558Z",
-     "iopub.status.busy": "2026-06-07T00:50:13.742558Z",
-     "iopub.status.idle": "2026-06-07T00:50:13.746794Z",
-     "shell.execute_reply": "2026-06-07T00:50:13.746794Z"
+     "iopub.execute_input": "2026-07-03T08:25:37.931047Z",
+     "iopub.status.busy": "2026-07-03T08:25:37.930045Z",
+     "iopub.status.idle": "2026-07-03T08:25:37.937886Z",
+     "shell.execute_reply": "2026-07-03T08:25:37.936878Z"
     },
     "papermill": {
-     "duration": 0.012796,
-     "end_time": "2026-06-07T00:50:13.748296",
+     "duration": 0.018842,
+     "end_time": "2026-07-03T08:25:37.938888",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.735500",
+     "start_time": "2026-07-03T08:25:37.920046",
      "status": "completed"
     },
     "tags": []
@@ -699,10 +701,10 @@
    "id": "section-4-spartan",
    "metadata": {
     "papermill": {
-     "duration": 0.005828,
-     "end_time": "2026-06-07T00:50:13.758801",
+     "duration": 0.009007,
+     "end_time": "2026-07-03T08:25:37.957892",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.752973",
+     "start_time": "2026-07-03T08:25:37.948885",
      "status": "completed"
     },
     "tags": []
@@ -732,10 +734,10 @@
    "id": "section-5-hashlife",
    "metadata": {
     "papermill": {
-     "duration": 0.006002,
-     "end_time": "2026-06-07T00:50:13.769206",
+     "duration": 0.009794,
+     "end_time": "2026-07-03T08:25:37.978202",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.763204",
+     "start_time": "2026-07-03T08:25:37.968408",
      "status": "completed"
     },
     "tags": []
@@ -779,10 +781,10 @@
    "id": "section-6-pillars",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-07T00:50:13.779714",
+     "duration": 0.007001,
+     "end_time": "2026-07-03T08:25:37.995204",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.774714",
+     "start_time": "2026-07-03T08:25:37.988203",
      "status": "completed"
     },
     "tags": []
@@ -815,16 +817,16 @@
    "id": "pillars-toolbox",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:13.790988Z",
-     "iopub.status.busy": "2026-06-07T00:50:13.790988Z",
-     "iopub.status.idle": "2026-06-07T00:50:13.805009Z",
-     "shell.execute_reply": "2026-06-07T00:50:13.804503Z"
+     "iopub.execute_input": "2026-07-03T08:25:38.017948Z",
+     "iopub.status.busy": "2026-07-03T08:25:38.017948Z",
+     "iopub.status.idle": "2026-07-03T08:25:38.037257Z",
+     "shell.execute_reply": "2026-07-03T08:25:38.035743Z"
     },
     "papermill": {
-     "duration": 0.020295,
-     "end_time": "2026-06-07T00:50:13.805009",
+     "duration": 0.032823,
+     "end_time": "2026-07-03T08:25:38.038259",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.784714",
+     "start_time": "2026-07-03T08:25:38.005436",
      "status": "completed"
     },
     "tags": []
@@ -961,10 +963,10 @@
    "id": "acte1-otca",
    "metadata": {
     "papermill": {
-     "duration": 0.005667,
-     "end_time": "2026-06-07T00:50:13.815679",
+     "duration": 0.006998,
+     "end_time": "2026-07-03T08:25:38.051257",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.810012",
+     "start_time": "2026-07-03T08:25:38.044259",
      "status": "completed"
     },
     "tags": []
@@ -1006,16 +1008,16 @@
    "id": "render-otca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:13.827687Z",
-     "iopub.status.busy": "2026-06-07T00:50:13.826708Z",
-     "iopub.status.idle": "2026-06-07T00:50:14.171752Z",
-     "shell.execute_reply": "2026-06-07T00:50:14.171752Z"
+     "iopub.execute_input": "2026-07-03T08:25:38.069396Z",
+     "iopub.status.busy": "2026-07-03T08:25:38.068396Z",
+     "iopub.status.idle": "2026-07-03T08:25:38.720412Z",
+     "shell.execute_reply": "2026-07-03T08:25:38.719123Z"
     },
     "papermill": {
-     "duration": 0.352073,
-     "end_time": "2026-06-07T00:50:14.172757",
+     "duration": 0.664258,
+     "end_time": "2026-07-03T08:25:38.721516",
      "exception": false,
-     "start_time": "2026-06-07T00:50:13.820684",
+     "start_time": "2026-07-03T08:25:38.057258",
      "status": "completed"
     },
     "tags": []
@@ -1025,14 +1027,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "witness : otcametapixel.rle"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "witness : otcametapixel.rle\n",
       "    #N OTCA metapixel\n",
       "    #O Brice Due\n",
       "    #C A unit cell that is capable of emulating any Life-like cellular aut\n",
@@ -1067,10 +1062,10 @@
    "id": "acte2-cpu",
    "metadata": {
     "papermill": {
-     "duration": 0.005426,
-     "end_time": "2026-06-07T00:50:14.183318",
+     "duration": 0.011001,
+     "end_time": "2026-07-03T08:25:38.741577",
      "exception": false,
-     "start_time": "2026-06-07T00:50:14.177892",
+     "start_time": "2026-07-03T08:25:38.730576",
      "status": "completed"
     },
     "tags": []
@@ -1110,16 +1105,16 @@
    "id": "render-cpu",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:14.195508Z",
-     "iopub.status.busy": "2026-06-07T00:50:14.194508Z",
-     "iopub.status.idle": "2026-06-07T00:50:14.417304Z",
-     "shell.execute_reply": "2026-06-07T00:50:14.417304Z"
+     "iopub.execute_input": "2026-07-03T08:25:38.763885Z",
+     "iopub.status.busy": "2026-07-03T08:25:38.763885Z",
+     "iopub.status.idle": "2026-07-03T08:25:39.146970Z",
+     "shell.execute_reply": "2026-07-03T08:25:39.145960Z"
     },
     "papermill": {
-     "duration": 0.22993,
-     "end_time": "2026-06-07T00:50:14.418309",
+     "duration": 0.396384,
+     "end_time": "2026-07-03T08:25:39.147969",
      "exception": false,
-     "start_time": "2026-06-07T00:50:14.188379",
+     "start_time": "2026-07-03T08:25:38.751585",
      "status": "completed"
     },
     "tags": []
@@ -1164,10 +1159,10 @@
    "id": "acte3-gemini",
    "metadata": {
     "papermill": {
-     "duration": 0.005246,
-     "end_time": "2026-06-07T00:50:14.429399",
+     "duration": 0.010728,
+     "end_time": "2026-07-03T08:25:39.167704",
      "exception": false,
-     "start_time": "2026-06-07T00:50:14.424153",
+     "start_time": "2026-07-03T08:25:39.156976",
      "status": "completed"
     },
     "tags": []
@@ -1209,16 +1204,16 @@
    "id": "render-gemini",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:14.440777Z",
-     "iopub.status.busy": "2026-06-07T00:50:14.440777Z",
-     "iopub.status.idle": "2026-06-07T00:50:15.267414Z",
-     "shell.execute_reply": "2026-06-07T00:50:15.266376Z"
+     "iopub.execute_input": "2026-07-03T08:25:39.190257Z",
+     "iopub.status.busy": "2026-07-03T08:25:39.189258Z",
+     "iopub.status.idle": "2026-07-03T08:25:40.463956Z",
+     "shell.execute_reply": "2026-07-03T08:25:40.463956Z"
     },
     "papermill": {
-     "duration": 0.83419,
-     "end_time": "2026-06-07T00:50:15.268962",
+     "duration": 1.28939,
+     "end_time": "2026-07-03T08:25:40.466646",
      "exception": false,
-     "start_time": "2026-06-07T00:50:14.434772",
+     "start_time": "2026-07-03T08:25:39.177256",
      "status": "completed"
     },
     "tags": []
@@ -1275,10 +1270,10 @@
    "id": "synthese-piliers",
    "metadata": {
     "papermill": {
-     "duration": 0.005921,
-     "end_time": "2026-06-07T00:50:15.281198",
+     "duration": 0.00817,
+     "end_time": "2026-07-03T08:25:40.487816",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.275277",
+     "start_time": "2026-07-03T08:25:40.479646",
      "status": "completed"
     },
     "tags": []
@@ -1313,8 +1308,7 @@
     "\n",
     "Le quatrieme temoin (`unitcell_witness`, UnitCell de Beluchenko, 4096 generations) n'apparait pas dans le recit des trois actes : c'est un metapixel plus petit que l'OTCA, plus accessible comme premiere cible `native_decide`. Il est integrallement defini dans `Pillars.lean` et constitue un jalon intermediaire naturel avant l'OTCA complete.\n",
     "\n",
-    "Chaque preuve reelle est prevue comme un seul `by native_decide` une fois la memoization Hashlife en place.\n",
-    ""
+    "Chaque preuve reelle est prevue comme un seul `by native_decide` une fois la memoization Hashlife en place.\n"
    ]
   },
   {
@@ -1323,24 +1317,24 @@
    "id": "50dcfe8c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:15.294358Z",
-     "iopub.status.busy": "2026-06-07T00:50:15.293357Z",
-     "iopub.status.idle": "2026-06-07T00:50:15.305730Z",
-     "shell.execute_reply": "2026-06-07T00:50:15.304661Z"
+     "iopub.execute_input": "2026-07-03T08:25:40.504823Z",
+     "iopub.status.busy": "2026-07-03T08:25:40.503822Z",
+     "iopub.status.idle": "2026-07-03T08:25:40.519275Z",
+     "shell.execute_reply": "2026-07-03T08:25:40.518267Z"
     },
     "papermill": {
-     "duration": 0.019074,
-     "end_time": "2026-06-07T00:50:15.305730",
+     "duration": 0.024459,
+     "end_time": "2026-07-03T08:25:40.520275",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.286656",
+     "start_time": "2026-07-03T08:25:40.495816",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Fichier : Conway/Life/Pillars.lean (234 lignes)\n",
       "\n",
@@ -1382,15 +1376,14 @@
       "  L163:   native_decide\n",
       "\n",
       "Sorry reels dans HashlifeMemo.lean : 0 (bridge theoremes prouves)\n",
-      "Sorry reels dans HashlifeCorrectness.lean : 1 (P5 = hashlife_correct)\n",
+      "Sorry reels dans HashlifeCorrectness.lean : 3 (P5 = hashlife_correct)\n",
       "\n",
-      "Total sorry Phase 3 (Pillars + Memo + Correctness) : 1\n",
+      "Total sorry Phase 3 (Pillars + Memo + Correctness) : 3\n",
       "Les 4 piliers (OTCA/CPU/Gemini/UnitCell) sont PROUVES contre grilles vides ;\n",
       "leur preuve reelle (pattern RLE charge) attend la memoization Hashlife.\n",
       "Le seul sorry restant est P5 dans HashlifeCorrectness.lean (theoreme principal).\n",
       "Le temoin pulsar_period3, prouve par native_decide sur RLE.pulsar_parsed\n",
-      "(48 cellules), demontre que le pipeline RLE -> Grid -> evolve fonctionne deja.\n",
-      ""
+      "(48 cellules), demontre que le pipeline RLE -> Grid -> evolve fonctionne deja.\n"
      ]
     }
    ],
@@ -1474,8 +1467,7 @@
     "print('leur preuve reelle (pattern RLE charge) attend la memoization Hashlife.')\n",
     "print('Le seul sorry restant est P5 dans HashlifeCorrectness.lean (theoreme principal).')\n",
     "print('Le temoin pulsar_period3, prouve par native_decide sur RLE.pulsar_parsed')\n",
-    "print('(48 cellules), demontre que le pipeline RLE -> Grid -> evolve fonctionne deja.')\n",
-    ""
+    "print('(48 cellules), demontre que le pipeline RLE -> Grid -> evolve fonctionne deja.')\n"
    ]
   },
   {
@@ -1483,10 +1475,10 @@
    "id": "de4e4b3a",
    "metadata": {
     "papermill": {
-     "duration": 0.005601,
-     "end_time": "2026-06-07T00:50:15.317334",
+     "duration": 0.007,
+     "end_time": "2026-07-03T08:25:40.533886",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.311733",
+     "start_time": "2026-07-03T08:25:40.526886",
      "status": "completed"
     },
     "tags": []
@@ -1542,8 +1534,7 @@
     "| 3 | `HashlifeCorrectness.lean` | Theoreme central P4 (`hashlifeResultAux_correct`) | P4 PROUVE ; seul P5 (`hashlife_correct`) reste en sorry |\n",
     "| 4 | Chaque temoin | `by native_decide` sur le pattern reel | En attente des etapes 1-3 |\n",
     "\n",
-    "Le chemin vers les preuves reelles est donc : **HashlifeMemo operationnel -> chargement RLE -> native_decide -> temoin prouve sur pattern reel**. Le temoin pulsar confirme que l'infrastructure RLE -> Grid est prete ; il reste a rendre la memoization tractable pour les patterns geants.\n",
-    ""
+    "Le chemin vers les preuves reelles est donc : **HashlifeMemo operationnel -> chargement RLE -> native_decide -> temoin prouve sur pattern reel**. Le temoin pulsar confirme que l'infrastructure RLE -> Grid est prete ; il reste a rendre la memoization tractable pour les patterns geants.\n"
    ]
   },
   {
@@ -1551,10 +1542,10 @@
    "id": "exercice-3-md",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-06-07T00:50:15.328335",
+     "duration": 0.01013,
+     "end_time": "2026-07-03T08:25:40.555029",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.323335",
+     "start_time": "2026-07-03T08:25:40.544899",
      "status": "completed"
     },
     "tags": []
@@ -1581,16 +1572,16 @@
    "id": "exercice-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:15.340524Z",
-     "iopub.status.busy": "2026-06-07T00:50:15.340524Z",
-     "iopub.status.idle": "2026-06-07T00:50:15.344369Z",
-     "shell.execute_reply": "2026-06-07T00:50:15.343364Z"
+     "iopub.execute_input": "2026-07-03T08:25:40.575093Z",
+     "iopub.status.busy": "2026-07-03T08:25:40.574092Z",
+     "iopub.status.idle": "2026-07-03T08:25:40.579023Z",
+     "shell.execute_reply": "2026-07-03T08:25:40.578017Z"
     },
     "papermill": {
-     "duration": 0.010845,
-     "end_time": "2026-06-07T00:50:15.344369",
+     "duration": 0.013995,
+     "end_time": "2026-07-03T08:25:40.580023",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.333524",
+     "start_time": "2026-07-03T08:25:40.566028",
      "status": "completed"
     },
     "tags": []
@@ -1623,10 +1614,10 @@
    "id": "section-7-turing",
    "metadata": {
     "papermill": {
-     "duration": 0.004999,
-     "end_time": "2026-06-07T00:50:15.355368",
+     "duration": 0.012478,
+     "end_time": "2026-07-03T08:25:40.601157",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.350369",
+     "start_time": "2026-07-03T08:25:40.588679",
      "status": "completed"
     },
     "tags": []
@@ -1676,10 +1667,10 @@
    "id": "section-8-demo",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-07T00:50:15.360691",
+     "duration": 0.011941,
+     "end_time": "2026-07-03T08:25:40.622696",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.360691",
+     "start_time": "2026-07-03T08:25:40.610755",
      "status": "completed"
     },
     "tags": []
@@ -1696,16 +1687,16 @@
    "id": "demo-blinker-glider",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:15.381281Z",
-     "iopub.status.busy": "2026-06-07T00:50:15.380280Z",
-     "iopub.status.idle": "2026-06-07T00:50:15.703041Z",
-     "shell.execute_reply": "2026-06-07T00:50:15.702001Z"
+     "iopub.execute_input": "2026-07-03T08:25:40.646252Z",
+     "iopub.status.busy": "2026-07-03T08:25:40.646252Z",
+     "iopub.status.idle": "2026-07-03T08:25:41.155849Z",
+     "shell.execute_reply": "2026-07-03T08:25:41.154841Z"
     },
     "papermill": {
-     "duration": 0.342864,
-     "end_time": "2026-06-07T00:50:15.703555",
+     "duration": 0.521337,
+     "end_time": "2026-07-03T08:25:41.156850",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.360691",
+     "start_time": "2026-07-03T08:25:40.635513",
      "status": "completed"
     },
     "tags": []
@@ -1715,7 +1706,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Figure sauvee : /tmp/lean14_blinker_glider.png\n",
+      "Figure sauvee : lean14_blinker_glider.png\n",
       "\n",
       "Illustrations de periodicite :\n",
       "  step^2(blinker) == blinker ? True\n",
@@ -1744,7 +1735,7 @@
     "out2 = '/tmp/lean14_blinker_glider.png'\n",
     "plt.savefig(out2, dpi=80, bbox_inches='tight')\n",
     "plt.close()\n",
-    "print(f'Figure sauvee : {out2}')\n",
+    "print(f'Figure sauvee : {out2.rsplit(\"/\", 1)[-1]}')\n",
     "print()\n",
     "# Illustrations numeriques (les preuves formelles sont dans Life.lean)\n",
     "print('Illustrations de periodicite :')\n",
@@ -1763,10 +1754,10 @@
    "id": "section-8b-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.005904,
-     "end_time": "2026-06-07T00:50:15.717843",
+     "duration": 0.010239,
+     "end_time": "2026-07-03T08:25:41.177087",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.711939",
+     "start_time": "2026-07-03T08:25:41.166848",
      "status": "completed"
     },
     "tags": []
@@ -1786,10 +1777,10 @@
    "id": "section-9-lean",
    "metadata": {
     "papermill": {
-     "duration": 0.005623,
-     "end_time": "2026-06-07T00:50:15.729284",
+     "duration": 0.009001,
+     "end_time": "2026-07-03T08:25:41.196094",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.723661",
+     "start_time": "2026-07-03T08:25:41.187093",
      "status": "completed"
     },
     "tags": []
@@ -1896,16 +1887,16 @@
    "id": "life-lean-stats",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:15.747148Z",
-     "iopub.status.busy": "2026-06-07T00:50:15.746601Z",
-     "iopub.status.idle": "2026-06-07T00:50:15.757430Z",
-     "shell.execute_reply": "2026-06-07T00:50:15.756421Z"
+     "iopub.execute_input": "2026-07-03T08:25:41.215315Z",
+     "iopub.status.busy": "2026-07-03T08:25:41.214798Z",
+     "iopub.status.idle": "2026-07-03T08:25:41.224739Z",
+     "shell.execute_reply": "2026-07-03T08:25:41.223159Z"
     },
     "papermill": {
-     "duration": 0.020903,
-     "end_time": "2026-06-07T00:50:15.757430",
+     "duration": 0.01997,
+     "end_time": "2026-07-03T08:25:41.225258",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.736527",
+     "start_time": "2026-07-03T08:25:41.205288",
      "status": "completed"
     },
     "tags": []
@@ -1917,11 +1908,11 @@
      "text": [
       "Statistiques des modules Life\n",
       "=======================================================\n",
-      "  Life.lean                       202 lignes | 20 defs |  7 thms | sorry=0\n",
+      "  Life.lean                       224 lignes | 21 defs |  8 thms | sorry=0\n",
       "  Life/Spaceships.lean            128 lignes |  3 defs |  3 thms | sorry=0\n",
       "  Life/Oscillators.lean           201 lignes |  7 defs |  7 thms | sorry=0\n",
       "-------------------------------------------------------\n",
-      "  TOTAL                           531 lignes | 30 defs | 17 thms | sorry=0\n",
+      "  TOTAL                           553 lignes | 31 defs | 18 thms | sorry=0\n",
       "\n",
       "Cible Phase 1+2 : sorry = 0 ... ATTEINT\n"
      ]
@@ -1970,10 +1961,10 @@
    "id": "section-9b-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.01196,
-     "end_time": "2026-06-07T00:50:15.779019",
+     "duration": 0.006644,
+     "end_time": "2026-07-03T08:25:41.238807",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.767059",
+     "start_time": "2026-07-03T08:25:41.232163",
      "status": "completed"
     },
     "tags": []
@@ -1999,10 +1990,10 @@
    "id": "section-9-7-eval-md",
    "metadata": {
     "papermill": {
-     "duration": 0.012603,
-     "end_time": "2026-06-07T00:50:15.799244",
+     "duration": 0.011151,
+     "end_time": "2026-07-03T08:25:41.257899",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.786641",
+     "start_time": "2026-07-03T08:25:41.246748",
      "status": "completed"
     },
     "tags": []
@@ -2029,16 +2020,16 @@
    "id": "13a8ea0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:50:15.824004Z",
-     "iopub.status.busy": "2026-06-07T00:50:15.824004Z",
-     "iopub.status.idle": "2026-06-07T00:51:28.046449Z",
-     "shell.execute_reply": "2026-06-07T00:51:28.046449Z"
+     "iopub.execute_input": "2026-07-03T08:25:41.277330Z",
+     "iopub.status.busy": "2026-07-03T08:25:41.276330Z",
+     "iopub.status.idle": "2026-07-03T08:34:03.289755Z",
+     "shell.execute_reply": "2026-07-03T08:34:03.288748Z"
     },
     "papermill": {
-     "duration": 72.238592,
-     "end_time": "2026-06-07T00:51:28.053089",
+     "duration": 502.031057,
+     "end_time": "2026-07-03T08:34:03.300326",
      "exception": false,
-     "start_time": "2026-06-07T00:50:15.814497",
+     "start_time": "2026-07-03T08:25:41.269269",
      "status": "completed"
     },
     "tags": []
@@ -2141,10 +2132,10 @@
    "id": "exercice-4-md",
    "metadata": {
     "papermill": {
-     "duration": 0.006213,
-     "end_time": "2026-06-07T00:51:28.065791",
+     "duration": 0.011009,
+     "end_time": "2026-07-03T08:34:03.322556",
      "exception": false,
-     "start_time": "2026-06-07T00:51:28.059578",
+     "start_time": "2026-07-03T08:34:03.311547",
      "status": "completed"
     },
     "tags": []
@@ -2163,16 +2154,16 @@
    "id": "exercice-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:51:28.079558Z",
-     "iopub.status.busy": "2026-06-07T00:51:28.079558Z",
-     "iopub.status.idle": "2026-06-07T00:51:28.085181Z",
-     "shell.execute_reply": "2026-06-07T00:51:28.084644Z"
+     "iopub.execute_input": "2026-07-03T08:34:03.345791Z",
+     "iopub.status.busy": "2026-07-03T08:34:03.344790Z",
+     "iopub.status.idle": "2026-07-03T08:34:03.353768Z",
+     "shell.execute_reply": "2026-07-03T08:34:03.352372Z"
     },
     "papermill": {
-     "duration": 0.014088,
-     "end_time": "2026-06-07T00:51:28.085863",
+     "duration": 0.020499,
+     "end_time": "2026-07-03T08:34:03.354768",
      "exception": false,
-     "start_time": "2026-06-07T00:51:28.071775",
+     "start_time": "2026-07-03T08:34:03.334269",
      "status": "completed"
     },
     "tags": []
@@ -2218,10 +2209,10 @@
    "id": "section-9-8-rle-eval-md",
    "metadata": {
     "papermill": {
-     "duration": 0.013992,
-     "end_time": "2026-06-07T00:51:28.106858",
+     "duration": 0.010758,
+     "end_time": "2026-07-03T08:34:03.374593",
      "exception": false,
-     "start_time": "2026-06-07T00:51:28.092866",
+     "start_time": "2026-07-03T08:34:03.363835",
      "status": "completed"
     },
     "tags": []
@@ -2246,16 +2237,16 @@
    "id": "rle-parse-eval",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:51:28.123909Z",
-     "iopub.status.busy": "2026-06-07T00:51:28.123909Z",
-     "iopub.status.idle": "2026-06-07T00:54:12.336256Z",
-     "shell.execute_reply": "2026-06-07T00:54:12.336256Z"
+     "iopub.execute_input": "2026-07-03T08:34:03.396160Z",
+     "iopub.status.busy": "2026-07-03T08:34:03.395152Z",
+     "iopub.status.idle": "2026-07-03T08:38:11.383840Z",
+     "shell.execute_reply": "2026-07-03T08:38:11.383840Z"
     },
     "papermill": {
-     "duration": 164.229381,
-     "end_time": "2026-06-07T00:54:12.343264",
+     "duration": 247.99969,
+     "end_time": "2026-07-03T08:38:11.383840",
      "exception": false,
-     "start_time": "2026-06-07T00:51:28.113883",
+     "start_time": "2026-07-03T08:34:03.384150",
      "status": "completed"
     },
     "tags": []
@@ -2353,10 +2344,10 @@
    "id": "de0111f4",
    "metadata": {
     "papermill": {
-     "duration": 0.005999,
-     "end_time": "2026-06-07T00:54:12.355263",
+     "duration": 0.016094,
+     "end_time": "2026-07-03T08:38:11.409838",
      "exception": false,
-     "start_time": "2026-06-07T00:54:12.349264",
+     "start_time": "2026-07-03T08:38:11.393744",
      "status": "completed"
     },
     "tags": []
@@ -2377,16 +2368,16 @@
    "id": "d8678121",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:54:12.367503Z",
-     "iopub.status.busy": "2026-06-07T00:54:12.367503Z",
-     "iopub.status.idle": "2026-06-07T00:54:13.130865Z",
-     "shell.execute_reply": "2026-06-07T00:54:13.129860Z"
+     "iopub.execute_input": "2026-07-03T08:38:11.425896Z",
+     "iopub.status.busy": "2026-07-03T08:38:11.425896Z",
+     "iopub.status.idle": "2026-07-03T08:38:12.664841Z",
+     "shell.execute_reply": "2026-07-03T08:38:12.663835Z"
     },
     "papermill": {
-     "duration": 0.770364,
-     "end_time": "2026-06-07T00:54:13.130865",
+     "duration": 1.239535,
+     "end_time": "2026-07-03T08:38:12.665431",
      "exception": false,
-     "start_time": "2026-06-07T00:54:12.360501",
+     "start_time": "2026-07-03T08:38:11.425896",
      "status": "completed"
     },
     "tags": []
@@ -2507,10 +2498,10 @@
    "id": "section-10-build",
    "metadata": {
     "papermill": {
-     "duration": 0.006014,
-     "end_time": "2026-06-07T00:54:13.143883",
+     "duration": 0.006999,
+     "end_time": "2026-07-03T08:38:12.678978",
      "exception": false,
-     "start_time": "2026-06-07T00:54:13.137869",
+     "start_time": "2026-07-03T08:38:12.671979",
      "status": "completed"
     },
     "tags": []
@@ -2531,16 +2522,16 @@
    "id": "lake-build-life",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:54:13.157865Z",
-     "iopub.status.busy": "2026-06-07T00:54:13.156864Z",
-     "iopub.status.idle": "2026-06-07T00:55:22.065220Z",
-     "shell.execute_reply": "2026-06-07T00:55:22.065220Z"
+     "iopub.execute_input": "2026-07-03T08:38:12.700097Z",
+     "iopub.status.busy": "2026-07-03T08:38:12.700097Z",
+     "iopub.status.idle": "2026-07-03T08:39:16.862394Z",
+     "shell.execute_reply": "2026-07-03T08:39:16.860801Z"
     },
     "papermill": {
-     "duration": 68.922443,
-     "end_time": "2026-06-07T00:55:22.072308",
+     "duration": 64.185337,
+     "end_time": "2026-07-03T08:39:16.872426",
      "exception": false,
-     "start_time": "2026-06-07T00:54:13.149865",
+     "start_time": "2026-07-03T08:38:12.687089",
      "status": "completed"
     },
     "tags": []
@@ -2559,14 +2550,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "info: Conway/Life/Oscillators.lean:98:0: true\n",
-      "info: Conway/Life/Oscillators.lean:99:0: true\n",
-      "info: Conway/Life/Oscillators.lean:100:0: true\n",
-      "info: Conway/Life/Oscillators.lean:101:0: true\n",
-      "info: Conway/Life/Oscillators.lean:163:0: true\n",
-      "info: Conway/Life/Oscillators.lean:195:0: true\n",
-      "ℹ [3318/3318] Replayed Conway.Life.Spaceships\n",
-      "info: Conway/Life/Spaceships.lean:55:0: [(0, 1), (0, 2), (0, 3), (0, 4), (1, 0), (1, 4), (2, 4), (3, 0), (3, 3)]\n",
       "info: Conway/Life/Spaceships.lean:56:0: [(0, 3), (0, 4), (0, 5), (0, 6), (1, 2), (1, 6), (2, 6), (3, 2), (3, 5)]\n",
       "info: Conway/Life/Spaceships.lean:57:0: [(0, 3), (0, 4), (0, 5), (0, 6), (1, 2), (1, 6), (2, 6), (3, 2), (3, 5)]\n",
       "info: Conway/Life/Spaceships.lean:58:0: true\n",
@@ -2578,7 +2561,15 @@
       "info: Conway/Life/Spaceships.lean:120:0: [(0, 3), (0, 4), (0, 5), (0, 6), (0, 7), (0, 8), (1, 2), (1, 8), (2, 8), (3, 2), (3, 7), (4, 4), (4, 5)]\n",
       "info: Conway/Life/Spaceships.lean:121:0: [(0, 3), (0, 4), (0, 5), (0, 6), (0, 7), (0, 8), (1, 2), (1, 8), (2, 8), (3, 2), (3, 7), (4, 4), (4, 5)]\n",
       "info: Conway/Life/Spaceships.lean:122:0: true\n",
-      "Build completed successfully (3318 jobs).\n",
+      "ℹ [2948/2948] Replayed Conway.Life.Oscillators\n",
+      "info: Conway/Life/Oscillators.lean:97:0: true\n",
+      "info: Conway/Life/Oscillators.lean:98:0: true\n",
+      "info: Conway/Life/Oscillators.lean:99:0: true\n",
+      "info: Conway/Life/Oscillators.lean:100:0: true\n",
+      "info: Conway/Life/Oscillators.lean:101:0: true\n",
+      "info: Conway/Life/Oscillators.lean:163:0: true\n",
+      "info: Conway/Life/Oscillators.lean:195:0: true\n",
+      "Build completed successfully (2948 jobs).\n",
       "\n",
       "\n",
       "Exit code : 0\n",
@@ -2623,16 +2614,16 @@
    "id": "grep-sorry-life",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-07T00:55:22.085598Z",
-     "iopub.status.busy": "2026-06-07T00:55:22.085598Z",
-     "iopub.status.idle": "2026-06-07T00:55:22.441782Z",
-     "shell.execute_reply": "2026-06-07T00:55:22.440774Z"
+     "iopub.execute_input": "2026-07-03T08:39:16.897360Z",
+     "iopub.status.busy": "2026-07-03T08:39:16.896832Z",
+     "iopub.status.idle": "2026-07-03T08:39:17.717939Z",
+     "shell.execute_reply": "2026-07-03T08:39:17.716887Z"
     },
     "papermill": {
-     "duration": 0.363557,
-     "end_time": "2026-06-07T00:55:22.441782",
+     "duration": 0.835387,
+     "end_time": "2026-07-03T08:39:17.719525",
      "exception": false,
-     "start_time": "2026-06-07T00:55:22.078225",
+     "start_time": "2026-07-03T08:39:16.884138",
      "status": "completed"
     },
     "tags": []
@@ -2644,19 +2635,25 @@
      "text": [
       "Verification sorry — modules Life (fondation single-source) :\n",
       "------------------------------------------------------------\n",
-      "  Conway/Life.lean                       sorry = 0\n",
-      "  Conway/Life/Spaceships.lean            sorry = 0\n"
+      "  Conway/Life.lean                       sorry = 0\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  Conway/Life/Spaceships.lean            sorry = 0\n",
       "  Conway/Life/Oscillators.lean           sorry = 0\n",
       "------------------------------------------------------------\n",
       "  Total sorry (3 modules Life) : 0\n",
       "  Cible 0 sorry sur la fondation Life ... ATTEINT\n",
-      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Faux positif documente — root Conway.lean :\n",
       "   13:lemmas as a prover-harness difficulty gradient (sorry scaffolding, intentional).\n",
       "   => occurrence dans un COMMENTAIRE (pas un `:= by sorry`). La fondation Life est a 0 sorry.\n",
@@ -2703,10 +2700,10 @@
    "id": "section-11-roadmap",
    "metadata": {
     "papermill": {
-     "duration": 0.00604,
-     "end_time": "2026-06-07T00:55:22.454654",
+     "duration": 0.012007,
+     "end_time": "2026-07-03T08:39:17.743713",
      "exception": false,
-     "start_time": "2026-06-07T00:55:22.448614",
+     "start_time": "2026-07-03T08:39:17.731706",
      "status": "completed"
     },
     "tags": []
@@ -2773,8 +2770,7 @@
     "- **#1151 (CLOSED)** : 5 modules Lean sur des resultats moins connus de Conway (Doomsday, FRACTRAN, LookAndSay, Nim, Angel) - dans `conway_lean/Conway/`\n",
     "- **#1647 (CETTE EPIC)** : Life-as-Computation (ce notebook Lean-16b + Life.lean + Spaceships + Oscillators + MacroCell + Hashlife + HashlifeCorrectness + HashlifeMemo + Pillars)\n",
     "- **#1651** : Theoreme de Libre Arbitre Conway-Kochen (notebook Lean-13 + KochenSpecker.lean) - **FAIT (PR #2026)**\n",
-    "- **#1646** : Tribute Grothendieck (notebook Lean-15, parallele structurel)\n",
-    ""
+    "- **#1646** : Tribute Grothendieck (notebook Lean-15, parallele structurel)\n"
    ]
   },
   {
@@ -2782,10 +2778,10 @@
    "id": "section-12-conclusion",
    "metadata": {
     "papermill": {
-     "duration": 0.007002,
-     "end_time": "2026-06-07T00:55:22.467614",
+     "duration": 0.012291,
+     "end_time": "2026-07-03T08:39:17.768013",
      "exception": false,
-     "start_time": "2026-06-07T00:55:22.460612",
+     "start_time": "2026-07-03T08:39:17.755722",
      "status": "completed"
     },
     "tags": []
@@ -2856,14 +2852,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 311.951394,
-   "end_time": "2026-06-07T00:55:22.821066",
+   "duration": 823.85572,
+   "end_time": "2026-07-03T08:39:18.229561",
    "environment_variables": {},
    "exception": null,
    "input_path": "Lean-16b-Conway-Game-of-Life-Lean.ipynb",
    "output_path": "Lean-16b-Conway-Game-of-Life-Lean.ipynb",
    "parameters": {},
-   "start_time": "2026-06-07T00:50:10.869672",
+   "start_time": "2026-07-03T08:25:34.373841",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Lean-16b — nettoyage du leak #3436 (chemin machine dans les prints matplotlib)

**Issue #3436** (critère « notebook sans leak de chemin machine »). `Lean-16b-Conway-Game-of-Life-Lean.ipynb` cells 11 & 32 imprimaient le chemin absolu `/tmp` de sauvegarde des figures matplotlib (`/tmp/lean14_patterns.png`, `/tmp/lean14_blinker_glider.png`), leakant un chemin machine dans la sortie committee.

### Diagnostic (cause C, secrets-hygiene §6)
Le `print(f'Figure sauvee : {out}')` écrivait le chemin absolu `out = '/tmp/lean14_patterns.png'`. **Cause C = source-leak** (le code source imprime le chemin), pas un drift d'env.

### Fix (Stop & Repair, PAS de scrub)
- **Source** : `print(f'Figure sauvee : {out.rsplit('/', 1)[-1]}')` — imprime le basename (`lean14_patterns.png`), garde la logique de sauvegarde intacte.
- **Re-exec** : papermill kernel python3 (cwd=SymbolicAI/Lean pour `lean_notebook_utils` + résolution `conway_lean` junctionné cache rc1), toutes cells re-executées, **0 erreur**.
- Éditer la sortie à la main = banni (règle ancestrale Stop & Repair) ; on corrige la cause + on re-exec.

### Preuve d'exécution réelle (H.1/H.3)
- Re-exec papermill complete, `execution_count` renseignés, outputs refreshed.
- Anti-régression : **aucun code de preuve Lean touché** (cells 11/32 = visualisation matplotlib pure, pas du port Life.lean) ; edit structure-préservant (seulement les 2 éléments de liste `print`, structure source intacte → diff propre 2 lignes).
- #3436 papermill-path : `metadata.papermill.input/output_path` normalisés au basename (seule normalisation manuelle tolérée = metadata, pas cell-output).

### Cadrage honnête (G.3/G.9)
- Leak cosmétique (chemin `/tmp`, pas un secret), mais #3436 vise l'hygiène repo-wide « notebook sans chemin machine ».
- Grain de convergence (lane Lean #3436 = mon turf déféré c.198). Les autres leaks Lean résiduels (Lean-1/10/15b/16a/18) restent — Lean-18 nécessite un re-exec build lake, Lean-10 = logs internes tqdm/lean_dojo (cause lib externe).

See #3436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
