### PR TITLE
fix(tour-plateforme): capture les surfaces à contenu réel sur opt-in seulement

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/.env.example
@@ -19,3 +19,9 @@ DEMO_OWUI_PASSWORD=
 # Optionnel : nom d'un modèle « thinking » (raisonnement affiché en direct, v0.10)
 # pour la capture 02-raisonnement-direct.png. Laisser vide pour sauter cette capture.
 DEMO_OWUI_REASONING_MODEL=
+
+# Optionnel (défaut : off). Mettre à 1 UNIQUEMENT sur une instance à données
+# fictives pour autoriser les captures de surfaces à contenu réel (sélecteur de
+# modèles, workspace, bases de connaissances, canaux). Par défaut ces surfaces
+# sont sautées (anti-fuite par construction) et restent schématisées.
+DEMO_OWUI_CAPTURE_REAL_CONTENT=

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/README.md
@@ -29,6 +29,10 @@ Les images produites atterrissent dans [`../assets/`](../assets/).
    chat neuf sur invite fictive, et des panneaux de réglages vides. Les surfaces
    qui exposeraient du contenu (listes de modèles/bases internes, canaux) restent
    **schématisées** dans [`../architecture.md`](../architecture.md), pas capturées.
+   Le script **applique cette règle par défaut** : les captures à contenu réel
+   (sélecteur de modèles, workspace, bases, canaux) sont **sautées** sauf opt-in
+   explicite `DEMO_OWUI_CAPTURE_REAL_CONTENT=1` (réservé à une instance à données
+   fictives) — la sûreté ne dépend donc pas de la seule relecture a posteriori.
 3. **Masquage** (`mask`) des zones sensibles (identité, e-mail) sur chaque image.
 4. **Revue anti-fuite de chaque PNG en PR** avant fusion — relecture humaine des
    images générées.
@@ -53,6 +57,7 @@ Variables attendues (voir [`.env.example`](.env.example)) :
 | `DEMO_OWUI_EMAIL` | E-mail du compte **non-admin** de capture |
 | `DEMO_OWUI_PASSWORD` | Mot de passe de ce compte |
 | `DEMO_OWUI_REASONING_MODEL` | *(optionnel)* nom d'un modèle « thinking » pour la capture du raisonnement en direct (v0.10) ; vide → capture sautée |
+| `DEMO_OWUI_CAPTURE_REAL_CONTENT` | *(optionnel, défaut off)* `1` pour autoriser les captures de surfaces à **contenu réel** (sélecteur de modèles, workspace, bases, canaux). À réserver à une instance à **données fictives** : par défaut ces surfaces sont **sautées** (`test.skip`) et restent schématisées dans [`../architecture.md`](../architecture.md) |
 
 ## Exécution
 

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/tour-captures.spec.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/00-Tour-Plateforme/capture/tour-captures.spec.ts
@@ -28,6 +28,15 @@ const PASSWORD = process.env.DEMO_OWUI_PASSWORD;
 // Optionnel : nom d'un modèle « thinking » pour la capture du raisonnement (v0.10).
 const REASONING_MODEL = process.env.DEMO_OWUI_REASONING_MODEL;
 
+// Surfaces exposant du CONTENU RÉEL d'établissement (listes de modèles/bases,
+// canaux) : NON capturées par défaut. Le principe « anti-fuite par construction »
+// (capture/README.md §2) veut qu'on ne capture QUE des surfaces sans contenu réel.
+// Opt-in EXPLICITE (=== '1') réservé à une instance à DONNÉES FICTIVES, où ces
+// surfaces deviennent sûres. Par défaut désactivé : la génération standard ne
+// produit que le sous-ensemble sûr, sans dépendre de la relecture pour écarter
+// des PNG à contenu établissement.
+const CAPTURE_REAL_CONTENT = process.env.DEMO_OWUI_CAPTURE_REAL_CONTENT === '1';
+
 // Dossier de sortie : ../assets relativement à ce fichier.
 const ASSETS = path.resolve(__dirname, '..', 'assets');
 
@@ -123,13 +132,17 @@ test.describe('Tour de la plateforme — captures (compte de capture)', () => {
 
     // 2 — chat : sélecteur de modèle + réponse en streaming.
     test('02 — chat & modèles', async ({ page }) => {
-      await page
-        .getByRole('button', { name: /select a model|choisir un modèle|model/i })
-        .first()
-        .click()
-        .catch(() => {}); // tolérant : la capture vaut même si l'ouverture échoue
-      await capture(page, '02-selecteur-modele.png');
-      await page.keyboard.press('Escape').catch(() => {});
+      // Le sélecteur ouvert liste des modèles réels (contenu établissement) :
+      // capture réservée à l'opt-in données fictives (CAPTURE_REAL_CONTENT).
+      if (CAPTURE_REAL_CONTENT) {
+        await page
+          .getByRole('button', { name: /select a model|choisir un modèle|model/i })
+          .first()
+          .click()
+          .catch(() => {}); // tolérant : la capture vaut même si l'ouverture échoue
+        await capture(page, '02-selecteur-modele.png');
+        await page.keyboard.press('Escape').catch(() => {});
+      }
 
       // Réponse en cours de streaming sur une invite FICTIVE (aucun contenu réel).
       // Sans envoi d'invite, l'écran resterait vide : le fichier serait mal nommé.
@@ -148,7 +161,12 @@ test.describe('Tour de la plateforme — captures (compte de capture)', () => {
     });
 
     // 3 — Workspace : modèles personnalisés + bases de connaissances.
+    // Contenu établissement (modèles/bases internes) : opt-in données fictives.
     test('03 — workspace', async ({ page }) => {
+      test.skip(
+        !CAPTURE_REAL_CONTENT,
+        'Surface à contenu réel (modèles/bases) — opt-in DEMO_OWUI_CAPTURE_REAL_CONTENT=1 requis (données fictives) ; sinon schématisée dans architecture.md',
+      );
       await page
         .getByRole('link', { name: /workspace|espace de travail/i })
         .first()
@@ -166,7 +184,12 @@ test.describe('Tour de la plateforme — captures (compte de capture)', () => {
     });
 
     // 4 — Canaux.
+    // Contenu établissement (noms de canaux) : opt-in données fictives.
     test('04 — canaux', async ({ page }) => {
+      test.skip(
+        !CAPTURE_REAL_CONTENT,
+        'Surface à contenu réel (canaux) — opt-in DEMO_OWUI_CAPTURE_REAL_CONTENT=1 requis (données fictives) ; sinon schématisée dans architecture.md',
+      );
       await page
         .getByRole('link', { name: /channel|canal|canaux/i })
         .first()


### PR DESCRIPTION
## Quoi

Le script de capture du Tour (`capture/tour-captures.spec.ts`) capturait **sans condition** 4 surfaces à **contenu réel d'établissement** :

| Capture | Contenu exposé |
|---|---|
| `02-selecteur-modele.png` | liste des modèles / personas du tenant |
| `03-workspace-modele.png` | modèles personnalisés internes |
| `03-base-connaissances.png` | bases de connaissances internes |
| `04-canal.png` | noms de canaux |

Or la politique anti-fuite est explicite — [`capture/README.md` §2](README.md) *« Surfaces sans contenu réel uniquement… les surfaces qui exposeraient du contenu (listes de modèles/bases internes, canaux) restent schématisées, pas capturées »* — et [`assets/README.md`](../assets/README.md) marque ces 4 entrées **⚠️ « contenu établissement »**. Le script contredisait donc sa propre règle : la sûreté ne reposait que sur la **relecture manuelle a posteriori**, l'inverse du principe affiché « anti-fuite **par construction** ».

## Correctif (`+41 / -7`, 3 fichiers)

Aligne l'utilitaire sur sa politique : les 4 captures à contenu réel sont **sautées par défaut**, réactivables par un **opt-in explicite** `DEMO_OWUI_CAPTURE_REAL_CONTENT=1`, à réserver à une instance à **données fictives**.

- `test.skip(!CAPTURE_REAL_CONTENT, …)` en tête de `03 — workspace` et `04 — canaux` ;
- garde `if (CAPTURE_REAL_CONTENT)` autour du seul `02-selecteur-modele.png` (le `02-chat-streaming.png` sûr, invite fictive, **reste capturé** inconditionnellement) ;
- `capture/README.md` (principe §2 + table des variables) et `capture/.env.example` documentent l'opt-in (défaut off).

**Non-pendulum** : on ne supprime pas ces captures (elles redeviendront utiles avec un jeu de données fictives) — on les met derrière un interrupteur explicite. **Idiome miroir** du `REASONING_MODEL` opt-in déjà présent dans le fichier. Le **sous-ensemble sûr** (connexion, première vue, chat streamé, réglages, nouveautés v0.10 : raisonnement / dossier d'équipe / mémoire) reste capturé par défaut.

## Vérification

- **`tsc --noEmit` vert** avec les options exactes du projet Playwright-OWUI (fichier hors `testDir` → type-check via copie temporaire dans le projet, supprimée ensuite ; suite Playwright-OWUI inchangée).
- **0 secret** : aucune valeur réelle, `.env` gitignoré, scan diff vide.
- Génération PNG **toujours gated** (compte-capture + revue anti-fuite par image) — ce correctif rend l'utilitaire **correct-by-construction** : une exécution standard ne produit plus aucun PNG à contenu établissement.

## Hors périmètre

La production effective des PNG reste en attente de la décision compte-capture (throwaway non-admin vs pauwels) + revue anti-fuite par image.

Part of #4433 (sous #4427). **Pas de self-merge** → review ai-01:CoursIA.
