### PR TITLE
fix(lean-18): normalize lake path prints to avoid #3436 machine-path leak

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-18-Search-AStar-Optimality.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-18-Search-AStar-Optimality.ipynb
@@ -5,10 +5,10 @@
    "id": "153addc9",
    "metadata": {
     "papermill": {
-     "duration": 0.004618,
-     "end_time": "2026-06-26T08:11:12.619409",
+     "duration": 0.008001,
+     "end_time": "2026-07-03T08:50:40.387667",
      "exception": false,
-     "start_time": "2026-06-26T08:11:12.614791",
+     "start_time": "2026-07-03T08:50:40.379666",
      "status": "completed"
     },
     "tags": []
@@ -34,10 +34,10 @@
    "id": "54d2b874",
    "metadata": {
     "papermill": {
-     "duration": 0.004787,
-     "end_time": "2026-06-26T08:11:12.628445",
+     "duration": 0.006001,
+     "end_time": "2026-07-03T08:50:40.398914",
      "exception": false,
-     "start_time": "2026-06-26T08:11:12.623658",
+     "start_time": "2026-07-03T08:50:40.392913",
      "status": "completed"
     },
     "tags": []
@@ -72,16 +72,16 @@
    "id": "06366578",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:11:12.638901Z",
-     "iopub.status.busy": "2026-06-26T08:11:12.637900Z",
-     "iopub.status.idle": "2026-06-26T08:11:12.664090Z",
-     "shell.execute_reply": "2026-06-26T08:11:12.664090Z"
+     "iopub.execute_input": "2026-07-03T08:50:40.409914Z",
+     "iopub.status.busy": "2026-07-03T08:50:40.409914Z",
+     "iopub.status.idle": "2026-07-03T08:50:40.442102Z",
+     "shell.execute_reply": "2026-07-03T08:50:40.441594Z"
     },
     "papermill": {
-     "duration": 0.030851,
-     "end_time": "2026-06-26T08:11:12.664090",
+     "duration": 0.038195,
+     "end_time": "2026-07-03T08:50:40.443109",
      "exception": false,
-     "start_time": "2026-06-26T08:11:12.633239",
+     "start_time": "2026-07-03T08:50:40.404914",
      "status": "completed"
     },
     "tags": []
@@ -91,8 +91,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Lake astar_lean (Windows) : C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\astar_lean\n",
-      "Lake astar_lean (WSL)     : /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/Search/astar_lean\n",
+      "Lake astar_lean detecte   : astar_lean (sous Search/)\n",
+      "Chemin WSL                 : (normalise, non affiche pour #3436)\n",
       "Lean natif (hors WSL)     : False\n"
      ]
     }
@@ -162,8 +162,8 @@
     "WIN_LEAN_PROJECT = find_astar_lean_project()\n",
     "LEAN_PROJECT = win_to_wsl(WIN_LEAN_PROJECT)\n",
     "USE_NATIVE_LEAN = shutil.which('lake') is not None and os.name != 'nt'\n",
-    "print(f\"Lake astar_lean (Windows) : {WIN_LEAN_PROJECT}\")\n",
-    "print(f\"Lake astar_lean (WSL)     : {LEAN_PROJECT}\")\n",
+    "print(f\"Lake astar_lean detecte   : {WIN_LEAN_PROJECT.name} (sous {WIN_LEAN_PROJECT.parent.name}/)\")\n",
+    "print(f\"Chemin WSL                 : (normalise, non affiche pour #3436)\")\n",
     "print(f\"Lean natif (hors WSL)     : {USE_NATIVE_LEAN}\")\n",
     "\n",
     "def wsl(cmd, timeout=60):\n",
@@ -268,16 +268,16 @@
    "id": "c8f96298",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:11:12.667090Z",
-     "iopub.status.busy": "2026-06-26T08:11:12.667090Z",
-     "iopub.status.idle": "2026-06-26T08:11:12.679542Z",
-     "shell.execute_reply": "2026-06-26T08:11:12.679542Z"
+     "iopub.execute_input": "2026-07-03T08:50:40.455110Z",
+     "iopub.status.busy": "2026-07-03T08:50:40.455110Z",
+     "iopub.status.idle": "2026-07-03T08:50:40.463691Z",
+     "shell.execute_reply": "2026-07-03T08:50:40.462682Z"
     },
     "papermill": {
-     "duration": 0.012452,
-     "end_time": "2026-06-26T08:11:12.679542",
+     "duration": 0.014581,
+     "end_time": "2026-07-03T08:50:40.463691",
      "exception": false,
-     "start_time": "2026-06-26T08:11:12.667090",
+     "start_time": "2026-07-03T08:50:40.449110",
      "status": "completed"
     },
     "tags": []
@@ -318,16 +318,16 @@
    "id": "4d0b1a42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:11:12.690978Z",
-     "iopub.status.busy": "2026-06-26T08:11:12.690978Z",
-     "iopub.status.idle": "2026-06-26T08:21:12.812969Z",
-     "shell.execute_reply": "2026-06-26T08:21:12.805964Z"
+     "iopub.execute_input": "2026-07-03T08:50:40.476693Z",
+     "iopub.status.busy": "2026-07-03T08:50:40.475690Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.442817Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.441524Z"
     },
     "papermill": {
-     "duration": 600.230183,
-     "end_time": "2026-06-26T08:21:12.913113",
+     "duration": 411.977126,
+     "end_time": "2026-07-03T08:57:32.446817",
      "exception": false,
-     "start_time": "2026-06-26T08:11:12.682930",
+     "start_time": "2026-07-03T08:50:40.469691",
      "status": "completed"
     },
     "tags": []
@@ -337,12 +337,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "lake build Astar -> exit=-1 : build non complete sur cette machine\n",
-      "(oles Mathlib manquants : `lake exe cache get` ne repond pas ici).\n",
-      "\n",
-      "La verification statique ci-dessus (regex sur les sources) confirme deja 0 sorry.\n",
-      "Pour valider par compilation, lancer sur une machine avec l'env Lean/WSL complet :\n",
-      "  wsl -d Ubuntu -- bash -lc \"cd /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/Search/astar_lean && lake exe cache get && lake build Astar\"\n"
+      "lake build Astar -> exit=0 : SUCCESS, preuves compilees, 0 sorry verifie par build.\n",
+      "Build completed successfully (8497 jobs).\n"
      ]
     }
    ],
@@ -363,7 +359,7 @@
     "    print()\n",
     "    print(\"La verification statique ci-dessus (regex sur les sources) confirme deja 0 sorry.\")\n",
     "    print(\"Pour valider par compilation, lancer sur une machine avec l'env Lean/WSL complet :\")\n",
-    "    print(f'  wsl -d Ubuntu -- bash -lc \"cd {LEAN_PROJECT} && lake exe cache get && lake build Astar\"')\n"
+    "    print(f'  wsl -d Ubuntu -- bash -lc \"cd <astar_lean> && lake exe cache get && lake build Astar\"')\n"
    ]
   },
   {
@@ -371,10 +367,10 @@
    "id": "ad0e26ad",
    "metadata": {
     "papermill": {
-     "duration": 0.004231,
-     "end_time": "2026-06-26T08:21:12.928824",
+     "duration": 0.005,
+     "end_time": "2026-07-03T08:57:32.456816",
      "exception": false,
-     "start_time": "2026-06-26T08:21:12.924593",
+     "start_time": "2026-07-03T08:57:32.451816",
      "status": "completed"
     },
     "tags": []
@@ -394,16 +390,16 @@
    "id": "a1b07c38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:21:12.964051Z",
-     "iopub.status.busy": "2026-06-26T08:21:12.962604Z",
-     "iopub.status.idle": "2026-06-26T08:21:12.979939Z",
-     "shell.execute_reply": "2026-06-26T08:21:12.979939Z"
+     "iopub.execute_input": "2026-07-03T08:57:32.469823Z",
+     "iopub.status.busy": "2026-07-03T08:57:32.468842Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.476152Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.475138Z"
     },
     "papermill": {
-     "duration": 0.048911,
-     "end_time": "2026-06-26T08:21:12.981245",
+     "duration": 0.015872,
+     "end_time": "2026-07-03T08:57:32.477695",
      "exception": false,
-     "start_time": "2026-06-26T08:21:12.932334",
+     "start_time": "2026-07-03T08:57:32.461823",
      "status": "completed"
     },
     "tags": []
@@ -481,10 +477,10 @@
    "id": "d1a30e36",
    "metadata": {
     "papermill": {
-     "duration": 0.002585,
-     "end_time": "2026-06-26T08:21:12.986793",
+     "duration": 0.005999,
+     "end_time": "2026-07-03T08:57:32.489700",
      "exception": false,
-     "start_time": "2026-06-26T08:21:12.984208",
+     "start_time": "2026-07-03T08:57:32.483701",
      "status": "completed"
     },
     "tags": []
@@ -511,10 +507,10 @@
    "id": "726d522b",
    "metadata": {
     "papermill": {
-     "duration": 0.002875,
-     "end_time": "2026-06-26T08:21:12.992318",
+     "duration": 0.005001,
+     "end_time": "2026-07-03T08:57:32.499704",
      "exception": false,
-     "start_time": "2026-06-26T08:21:12.989443",
+     "start_time": "2026-07-03T08:57:32.494703",
      "status": "completed"
     },
     "tags": []
@@ -543,16 +539,16 @@
    "id": "0f97f3e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:21:12.999468Z",
-     "iopub.status.busy": "2026-06-26T08:21:12.999468Z",
-     "iopub.status.idle": "2026-06-26T08:21:13.004044Z",
-     "shell.execute_reply": "2026-06-26T08:21:13.004044Z"
+     "iopub.execute_input": "2026-07-03T08:57:32.508923Z",
+     "iopub.status.busy": "2026-07-03T08:57:32.508923Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.515375Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.514366Z"
     },
     "papermill": {
-     "duration": 0.008716,
-     "end_time": "2026-06-26T08:21:13.004044",
+     "duration": 0.013672,
+     "end_time": "2026-07-03T08:57:32.516374",
      "exception": false,
-     "start_time": "2026-06-26T08:21:12.995328",
+     "start_time": "2026-07-03T08:57:32.502702",
      "status": "completed"
     },
     "tags": []
@@ -656,10 +652,10 @@
    "id": "85e7c5cf",
    "metadata": {
     "papermill": {
-     "duration": 0.003196,
-     "end_time": "2026-06-26T08:21:13.011411",
+     "duration": 0.005487,
+     "end_time": "2026-07-03T08:57:32.526861",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.008215",
+     "start_time": "2026-07-03T08:57:32.521374",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +681,10 @@
    "id": "c942eb65",
    "metadata": {
     "papermill": {
-     "duration": 0.001976,
-     "end_time": "2026-06-26T08:21:13.014715",
+     "duration": 0.005007,
+     "end_time": "2026-07-03T08:57:32.536875",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.012739",
+     "start_time": "2026-07-03T08:57:32.531868",
      "status": "completed"
     },
     "tags": []
@@ -713,16 +709,16 @@
    "id": "291a2a3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:21:13.024389Z",
-     "iopub.status.busy": "2026-06-26T08:21:13.024389Z",
-     "iopub.status.idle": "2026-06-26T08:21:13.029069Z",
-     "shell.execute_reply": "2026-06-26T08:21:13.028549Z"
+     "iopub.execute_input": "2026-07-03T08:57:32.550218Z",
+     "iopub.status.busy": "2026-07-03T08:57:32.550218Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.556158Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.555554Z"
     },
     "papermill": {
-     "duration": 0.011436,
-     "end_time": "2026-06-26T08:21:13.030747",
+     "duration": 0.014001,
+     "end_time": "2026-07-03T08:57:32.557166",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.019311",
+     "start_time": "2026-07-03T08:57:32.543165",
      "status": "completed"
     },
     "tags": []
@@ -837,10 +833,10 @@
    "id": "a19783f4",
    "metadata": {
     "papermill": {
-     "duration": 0.003913,
-     "end_time": "2026-06-26T08:21:13.038427",
+     "duration": 0.006,
+     "end_time": "2026-07-03T08:57:32.568165",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.034514",
+     "start_time": "2026-07-03T08:57:32.562165",
      "status": "completed"
     },
     "tags": []
@@ -873,10 +869,10 @@
    "id": "928ccb5c",
    "metadata": {
     "papermill": {
-     "duration": 0.003165,
-     "end_time": "2026-06-26T08:21:13.044713",
+     "duration": 0.004999,
+     "end_time": "2026-07-03T08:57:32.578387",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.041548",
+     "start_time": "2026-07-03T08:57:32.573388",
      "status": "completed"
     },
     "tags": []
@@ -907,16 +903,16 @@
    "id": "223eaff2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:21:13.052059Z",
-     "iopub.status.busy": "2026-06-26T08:21:13.051532Z",
-     "iopub.status.idle": "2026-06-26T08:21:13.057745Z",
-     "shell.execute_reply": "2026-06-26T08:21:13.057226Z"
+     "iopub.execute_input": "2026-07-03T08:57:32.590387Z",
+     "iopub.status.busy": "2026-07-03T08:57:32.590387Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.597351Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.596345Z"
     },
     "papermill": {
-     "duration": 0.010445,
-     "end_time": "2026-06-26T08:21:13.058268",
+     "duration": 0.013964,
+     "end_time": "2026-07-03T08:57:32.598352",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.047823",
+     "start_time": "2026-07-03T08:57:32.584388",
      "status": "completed"
     },
     "tags": []
@@ -1072,10 +1068,10 @@
    "id": "05bb11e7",
    "metadata": {
     "papermill": {
-     "duration": 0.003882,
-     "end_time": "2026-06-26T08:21:13.065849",
+     "duration": 0.0,
+     "end_time": "2026-07-03T08:57:32.604353",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.061967",
+     "start_time": "2026-07-03T08:57:32.604353",
      "status": "completed"
     },
     "tags": []
@@ -1106,10 +1102,10 @@
    "id": "b454a17d",
    "metadata": {
     "papermill": {
-     "duration": 0.003155,
-     "end_time": "2026-06-26T08:21:13.072280",
+     "duration": 0.01667,
+     "end_time": "2026-07-03T08:57:32.621023",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.069125",
+     "start_time": "2026-07-03T08:57:32.604353",
      "status": "completed"
     },
     "tags": []
@@ -1144,10 +1140,10 @@
    "id": "10e00a65",
    "metadata": {
     "papermill": {
-     "duration": 0.003005,
-     "end_time": "2026-06-26T08:21:13.077917",
+     "duration": 0.0,
+     "end_time": "2026-07-03T08:57:32.621023",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.074912",
+     "start_time": "2026-07-03T08:57:32.621023",
      "status": "completed"
     },
     "tags": []
@@ -1171,16 +1167,16 @@
    "id": "45115592",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:21:13.085920Z",
-     "iopub.status.busy": "2026-06-26T08:21:13.085920Z",
-     "iopub.status.idle": "2026-06-26T08:21:13.097158Z",
-     "shell.execute_reply": "2026-06-26T08:21:13.097158Z"
+     "iopub.execute_input": "2026-07-03T08:57:32.636411Z",
+     "iopub.status.busy": "2026-07-03T08:57:32.636411Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.654950Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.654950Z"
     },
     "papermill": {
-     "duration": 0.018247,
-     "end_time": "2026-06-26T08:21:13.099163",
+     "duration": 0.033927,
+     "end_time": "2026-07-03T08:57:32.654950",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.080916",
+     "start_time": "2026-07-03T08:57:32.621023",
      "status": "completed"
     },
     "tags": []
@@ -1249,16 +1245,16 @@
    "id": "e98124bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:21:13.108444Z",
-     "iopub.status.busy": "2026-06-26T08:21:13.107446Z",
-     "iopub.status.idle": "2026-06-26T08:21:13.112949Z",
-     "shell.execute_reply": "2026-06-26T08:21:13.112444Z"
+     "iopub.execute_input": "2026-07-03T08:57:32.667076Z",
+     "iopub.status.busy": "2026-07-03T08:57:32.667076Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.675691Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.675691Z"
     },
     "papermill": {
-     "duration": 0.011507,
-     "end_time": "2026-06-26T08:21:13.113953",
+     "duration": 0.020741,
+     "end_time": "2026-07-03T08:57:32.675691",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.102446",
+     "start_time": "2026-07-03T08:57:32.654950",
      "status": "completed"
     },
     "tags": []
@@ -1324,16 +1320,16 @@
    "id": "3dbe2a83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:21:13.121955Z",
-     "iopub.status.busy": "2026-06-26T08:21:13.121955Z",
-     "iopub.status.idle": "2026-06-26T08:21:13.126135Z",
-     "shell.execute_reply": "2026-06-26T08:21:13.126135Z"
+     "iopub.execute_input": "2026-07-03T08:57:32.683301Z",
+     "iopub.status.busy": "2026-07-03T08:57:32.683301Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.693706Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.693706Z"
     },
     "papermill": {
-     "duration": 0.010188,
-     "end_time": "2026-06-26T08:21:13.127141",
+     "duration": 0.010405,
+     "end_time": "2026-07-03T08:57:32.693706",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.116953",
+     "start_time": "2026-07-03T08:57:32.683301",
      "status": "completed"
     },
     "tags": []
@@ -1392,16 +1388,16 @@
    "id": "efa74d77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T08:21:13.133192Z",
-     "iopub.status.busy": "2026-06-26T08:21:13.133192Z",
-     "iopub.status.idle": "2026-06-26T08:21:13.140876Z",
-     "shell.execute_reply": "2026-06-26T08:21:13.140876Z"
+     "iopub.execute_input": "2026-07-03T08:57:32.698404Z",
+     "iopub.status.busy": "2026-07-03T08:57:32.698404Z",
+     "iopub.status.idle": "2026-07-03T08:57:32.710766Z",
+     "shell.execute_reply": "2026-07-03T08:57:32.710766Z"
     },
     "papermill": {
-     "duration": 0.010163,
-     "end_time": "2026-06-26T08:21:13.140876",
+     "duration": 0.012362,
+     "end_time": "2026-07-03T08:57:32.710766",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.130713",
+     "start_time": "2026-07-03T08:57:32.698404",
      "status": "completed"
     },
     "tags": []
@@ -1468,10 +1464,10 @@
    "id": "1259861b",
    "metadata": {
     "papermill": {
-     "duration": 0.005463,
-     "end_time": "2026-06-26T08:21:13.149582",
+     "duration": 0.0,
+     "end_time": "2026-07-03T08:57:32.714065",
      "exception": false,
-     "start_time": "2026-06-26T08:21:13.144119",
+     "start_time": "2026-07-03T08:57:32.714065",
      "status": "completed"
     },
     "tags": []
@@ -1532,14 +1528,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 601.863034,
-   "end_time": "2026-06-26T08:21:13.393749",
+   "duration": 414.083194,
+   "end_time": "2026-07-03T08:57:32.976590",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\Lean-18-Search-AStar-Optimality.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\Lean-18-Search-AStar-Optimality_output.ipynb",
+   "input_path": "Lean-18-Search-AStar-Optimality.ipynb",
+   "output_path": "Lean-18-Search-AStar-Optimality.ipynb",
    "parameters": {},
-   "start_time": "2026-06-26T08:11:11.530715",
+   "start_time": "2026-07-03T08:50:38.893396",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Lean-18 — nettoyage du leak #3436 (chemin absolu du lake dans les prints)

**Issue #3436** (critère « notebook sans leak de chemin machine »). `Lean-18-Search-AStar-Optimality.ipynb` leakait un chemin machine absolu dans deux cellules :
- **cell 2** : imprimait le chemin résolu du lake `astar_lean` en Windows (`C:\dev\CoursIA\...`) ET WSL (`/mnt/c/dev/CoursIA/...`) — leak **constant** à chaque exécution.
- **cell 4** : l'`else`-branch (chemin d'échec du build) échoit la commande manuelle avec le chemin absolu `{LEAN_PROJECT}`.

### Diagnostic (cause C, secrets-hygiene §6)
Les `print` écrivaient le chemin absolu résolu (`find_astar_lean_project` + `win_to_wsl`). **Cause C = source-leak**, pas un drift d'env.

### Fix (Stop & Repair, PAS de scrub)
- **cell 2** : `print(f"Lake astar_lean detecte : {WIN_LEAN_PROJECT.name} (sous {WIN_LEAN_PROJECT.parent.name}/)")` — affiche le **basename** (`astar_lean`) + nom du dossier parent (`Search/`), informatif sans chemin machine. La ligne WSL redondante est remplacée par un placeholder normalisé.
- **cell 4** : le `else`-branch echo commande → `<astar_lean>` placeholder au lieu de `{LEAN_PROJECT}` (robustesse : même si le build échoue sur une autre machine, pas de leak).
- **Re-exec** : papermill kernel python3 (cwd=SymbolicAI/Lean, `find_astar_lean_project` résout `Search/astar_lean` cross-CWD). Le lake `astar_lean` est junctioné au cache rc1 et `lake build Astar` réussit (8497 jobs, 0 sorry) → cell 4 prend la branche SUCCESS (pas d'echo commande). Toutes cells re-exécutées, **0 erreur**.
- Éditer la sortie à la main = banni (Stop & Repair) ; on corrige la cause + on re-exec.

### Preuve d'exécution réelle (H.1/H.3)
- Re-exec papermill complète, `execution_count` renseignés, outputs refreshed.
- Anti-régression : **aucun code de preuve Lean touché** (cells 2/4 = plomberie résolution-projet + build) ; edit structure-préservant (3 éléments de liste `print` seulement, structure source intacte → diff propre).
- #3436 papermill-path : `metadata.papermill.input/output_path` normalisés au basename (seule normalisation manuelle tolérée = metadata, pas cell-output).

### Cadrage honnête (G.3/G.9)
- Leak cosmétique (chemin dans prints info/debug), mais #3436 vise l'hygiène repo-wide.
- Grain de clôture de la famille Lean #3436 (Lean-16b c.201 #5163 + Lean-18 c.202 = les 2 notebooks Lean-GOL/A* dont le leak était une cause C source-print). Les autres leaks Lean résiduels (Lean-1/10/15b/16a) sont soit des setup/error temp paths (cause B), soit des logs internes tqdm/lean_dojo (cause lib externe Lean-10).

See #3436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
