### PR TITLE
fix(symbolicai): #3968 MealPlanner normalize heading hierarchy (4 H1 -> single H1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Meal_Planner_Modelisation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Meal_Planner_Modelisation.ipynb
@@ -210,7 +210,7 @@
     "tags": []
    },
    "source": [
-    "# Partie A — Modelisation declarative\n",
+    "## Partie A — Modelisation declarative\n",
     "\n",
     "De la base de donnees nutritionnelle au **theoreme hierarchique** `int[][]` : on modelise le meme probleme de menu equilibre selon plusieurs paradigmes Z3 (selection par index, enumeration, variables booleennes, optimisation par dichotomie), puis on montre comment `CollectionHandling` structure un plan multi-jours en pur LINQ."
    ]
@@ -231,7 +231,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 1. Contexte : Le théorème hiérarchique\n",
+    "### 1. Contexte : Le théorème hiérarchique\n",
     "\n",
     "Dans les notebooks précédents, nous avons utilisé `Symbols<T1, T2, ...>` pour créer des variables Z3 plates. Le **théorème hiérarchique** generalise cette approche :\n",
     "\n",
@@ -239,7 +239,7 @@
     "- Chaque niveau de la hiérarchie possède ses propres contraintes\n",
     "- Le solveur Z3 résout le système complet de manière cohérente\n",
     "\n",
-    "### Analogie\n",
+    "#### Analogie\n",
     "\n",
     "```\n",
     "Meal (contraintes globales : calories totales, budget)\n",
@@ -265,7 +265,7 @@
     "tags": []
    },
    "source": [
-    "## 2. Base de données nutritionnelle (data fusion)\n",
+    "### 2. Base de données nutritionnelle (data fusion)\n",
     "\n",
     "Nous definissons une base de données d'aliments avec leurs propriétés nutritionnelles. Ces données seront utilisees par le solveur pour sélectionner des combinaisons valides."
    ]
@@ -363,7 +363,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "La base contient 10 aliments répartis en 3 catégories (entree, plat, dessert). Chaque aliment a des propriétés nutritionnelles et un cout. Le solveur devra sélectionner exactement **1 entree + 1 plat + 1 dessert** qui satisfont les contraintes globales."
    ]
@@ -382,7 +382,7 @@
     "tags": []
    },
    "source": [
-    "## 3. Approche 1 : Sélection par index avec contraintes lineaires\n",
+    "### 3. Approche 1 : Sélection par index avec contraintes lineaires\n",
     "\n",
     "La première approche utilisé des variables entieres pour sélectionner un aliment dans chaque catégorie. Les contraintes sont exprimees lineairement en fonction de l'index."
    ]
@@ -505,7 +505,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "Sans contraintes nutritionnelles, le solveur trouve la première combinaison valide (index 0, 0, 0). Le résultat est trivialement la première entree, le premier plat et le premier dessert de la base. Nous devons ajouter des contraintes pour obtenir un menu équilibré."
    ]
@@ -524,7 +524,7 @@
     "tags": []
    },
    "source": [
-    "## 4. Approche 2 : Contraintes nutritionnelles avec énumération\n",
+    "### 4. Approche 2 : Contraintes nutritionnelles avec énumération\n",
     "\n",
     "La contrainte Z3.Linq fonctionne avec des expressions lineaires. Pour injecter les données nutritionnelles, nous énumérons les combinaisons possibles et posons des contraintes sur les totaux.\n",
     "\n",
@@ -677,7 +677,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "L'énumération exhaustive fonctionne car l'espace est petit (3 x 4 x 3 = 36 combinaisons). Pour de grands catalogues, le solveur Z3 est préférable car il explore intelligemment l'espace de recherche plutôt que de tout énumérer."
    ]
@@ -696,11 +696,11 @@
     "tags": []
    },
    "source": [
-    "## 5. Approche 3 : Modèle Z3 avec variables booléennes (sélection)\n",
+    "### 5. Approche 3 : Modèle Z3 avec variables booléennes (sélection)\n",
     "\n",
     "Pour modéliser la sélection d'aliments directement dans Z3, nous utilisons des **variables booléennes** : chaque aliment est soit sélectionné (`true`) soit non sélectionné (`false`).\n",
     "\n",
-    "### Principe\n",
+    "#### Principe\n",
     "\n",
     "- Une variable booléenne par aliment\n",
     "- Exactement 1 entree + 1 plat + 1 dessert sélectionnés\n",
@@ -881,7 +881,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "L'approche booléenne utilisé **`MkITE` (If-Then-Else)** pour conditionnellement ajouter la contribution nutritionnelle de chaque aliment. C'est la clé technique de la **data fusion** : les données statiques (calories, proteines, cout) sont injectees dans les expressions Z3 via `MkITE`.\n",
     "\n",
@@ -907,7 +907,7 @@
     "tags": []
    },
    "source": [
-    "## 6. Optimisation : menu le moins cher (dichotomie)\n",
+    "### 6. Optimisation : menu le moins cher (dichotomie)\n",
     "\n",
     "Le solveur Z3 (`MkSolver`) trouve une solution satisfaisante, mais pas forcement optimale. Pour trouver le menu **le moins cher**, nous utilisons une **recherche par dichotomie** :\n",
     "\n",
@@ -1107,7 +1107,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation\n",
+    "#### Interpretation\n",
     "\n",
     "La **dichotomie sur le cout** est un pattern classique en optimisation SAT/SMT. Plutôt que d'utiliser `MkOptimizer` (qui peut etre instable dans certains bindings), on utilisé `solver.Push()`/`solver.Pop()` pour tester différentes bornes de cout sans reconstruire le solver a chaque fois.\n",
     "\n",
@@ -1135,13 +1135,13 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Théorème hiérarchique : plan hebdomadaire en `int[][]`\n",
+    "### 7. Théorème hiérarchique : plan hebdomadaire en `int[][]`\n",
     "\n",
     "Jusqu'ici, nous avons manipulé des variables **plates** : des index isolés (section 3) ou un booléen par aliment (section 5). Pour planifier **plusieurs repas simultanément** — un plan sur N jours —, l'abstraction naturelle est un **tableau imbriqué** : une ligne par jour, une colonne par créneau (entrée, plat, dessert). C'est précisément ce que le fork `Z3.Linq` résout via le **théorème hiérarchique** sur `int[][]`.\n",
     "\n",
     "Le même mécanisme qui résout une grille de Sudoku (`Cells[i][j]`, notebook 05) structure ici un plan de repas `Plan[jour][créneau]`. Les contraintes **structurelles** — catégorie imposée par créneau, non-répétition entre jours, montée en gamme — s'expriment en **pur LINQ**, sans descendre dans le Microsoft.Z3 brut.\n",
     "\n",
-    "### Modèle\n",
+    "#### Modèle\n",
     "\n",
     "```\n",
     "Plan[0] = [entrée_j1, plat_j1, dessert_j1]   (indices dans foodDatabase)\n",
@@ -1390,7 +1390,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation — le domaine d'élégance du théorème hiérarchique\n",
+    "#### Interpretation — le domaine d'élégance du théorème hiérarchique\n",
     "\n",
     "Le plan hebdomadaire est résolu en **pur LINQ** sur `int[][]` : **zéro** appel à `MkSolver`/`MkITE`/`MkOr`. C'est l'aboutissement du notebook — la même API qui résout une grille de Sudoku (notebook 05) structure un plan de repas multi-jours. Les trois familles de contraintes ci-dessous sont toutes **linéaires sur les valeurs d'index**, donc natives en LINQ :\n",
     "\n",
@@ -1424,7 +1424,7 @@
     "tags": []
    },
    "source": [
-    "### 7.1 Permutation totale & mode `CollectionHandling.Array` explicite\n",
+    "#### 7.1 Permutation totale & mode `CollectionHandling.Array` explicite\n",
     "\n",
     "La cellule ci-dessus résout **deux variantes** du même théorème hiérarchique `int[][]` :\n",
     "\n",
@@ -1457,7 +1457,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Tableau récapitulatif des approches\n",
+    "### 8. Tableau récapitulatif des approches\n",
     "\n",
     "| Approche | Technique | Avantage | Limite |\n",
     "|----------|-----------|----------|--------|\n",
@@ -1483,7 +1483,7 @@
     "tags": []
    },
    "source": [
-    "## 9. La feature ressuscitée : `CollectionHandling` (mode Array vs Constants)\n",
+    "### 9. La feature ressuscitée : `CollectionHandling` (mode Array vs Constants)\n",
     "\n",
     "Jusqu'ici, ce notebook utilisait le fork `Z3.Linq` charge depuis NuGet. Depuis le **14/06/2026**, le fork embarque une enum `CollectionHandling` qui était **définie mais jamais câblée** (dead code). Elle est désormais **vivante** : le même code LINQ peut résoudre un CSP en modélisant les collections de deux façons différentes.\n",
     "\n",
@@ -1596,7 +1596,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation — dead code ressuscite\n",
+    "#### Interpretation — dead code ressuscite\n",
     "\n",
     "Le **même** code `BuildPlate` résout le CSP dans les deux modes. La seule différence est la configuration du `Z3Context` :\n",
     "\n",
@@ -1628,16 +1628,16 @@
    "source": [
     "---\n",
     "\n",
-    "# Partie B — Couplage hebdomadaire : fenetre nutritionnelle par jour et variete globale\n",
+    "## Partie B — Couplage hebdomadaire : fenetre nutritionnelle par jour et variete globale\n",
     "\n",
-    "## Objectifs d'apprentissage\n",
+    "### Objectifs d'apprentissage\n",
     "\n",
     "- Modéliser un **plan de repas sur toute une semaine** comme une **matrice booléenne `int[][]`** (jours × plats), et comprendre pourquoi ce modèle diffère de la grille d'index du [notebook 06 §7](06_Meal_Planner_Modelisation.ipynb).\n",
     "- Exprimer une **fenêtre nutritionnelle par jour** (somme des kcal des plats choisis ce jour ∈ `[min, max]`) — le chaînon manquant entre la nutrition (`MkITE`, Partie A §5) et le plan multi-jours (`int[][]`, Partie A §7).\n",
     "- Imposer une **variété globale** : aucun plat servi plus d'une fois dans la semaine.\n",
     "- Démontrer pourquoi un **remplissage glouton** (« *greedy* ») jour par jour **se bloque** sur ce couplage, alors que le solveur SMT trouve une affectation globalement cohérente en quelques millisecondes.\n",
     "\n",
-    "## Prérequis\n",
+    "### Prérequis\n",
     "\n",
     "- [Notebook 05](05_Nested_Arrays_2D.ipynb) : tableaux imbriqués `int[][]`, `Theorem<Grid>`.\n",
     "- **Partie A §5** : variables booléennes de sélection + agrégation conditionnelle.\n",
@@ -1661,7 +1661,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 1. Le corpus de plats\n",
+    "### 1. Le corpus de plats\n",
     "\n",
     "Contrairement au notebook de données 07 (corpus RecipeML x Ciqual chargé et matché), nous définissons ici un corpus **inline** plus large (18 plats) pour rendre la combinatoire **non triviale** (Prong-B). Chaque plat a une catégorie (`breakfast` / `lunch` / `dinner`), un apport calorique, une teneur en protéines et un coût.\n",
     "\n",
@@ -1758,7 +1758,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 2. Le modèle : matrice booléenne jour × plat\n",
+    "### 2. Le modèle : matrice booléenne jour × plat\n",
     "\n",
     "On planifie **`D = 5` jours** (lundi→vendredi). Pour chaque couple `(jour, plat)`, une variable `Sel[j][i] ∈ {0, 1}` vaut 1 si le plat `i` est servi le jour `j`. C'est une **matrice `D × N`** de booléens entiers.\n",
     "\n",
@@ -1844,7 +1844,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 3. Variété globale : aucun plat servi plus d'une fois\n",
+    "### 3. Variété globale : aucun plat servi plus d'une fois\n",
     "\n",
     "On veut que **chaque plat apparaisse au plus une fois** dans la semaine entière. Pour le plat `i`, la somme de ses sélections sur les `D` jours est `≤ 1`. C'est l'équivalent « matriciel » du `Z3Methods.Distinct` de la Partie A §7, mais projeté sur chaque plat à travers tous les jours."
    ]
@@ -1904,7 +1904,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 4. La fenêtre nutritionnelle par jour (le chaînon manquant)\n",
+    "### 4. La fenêtre nutritionnelle par jour (le chaînon manquant)\n",
     "\n",
     "C'est la contrainte qui transforme le problème : pour chaque jour `j`, la somme des calories des plats choisis doit tomber dans `[DAY_LO, DAY_HI]`. On l'écrit comme une **somme linéaire** de termes `Sel[j][i] × kcal[i]` — la même structure que l'agrégation `MkITE` du notebook 06 §5, mais projetée par jour sur la matrice multi-jours.\n",
     "\n",
@@ -2055,7 +2055,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Pourquoi le glouton (*greedy*) se bloque\n",
+    "### 5. Pourquoi le glouton (*greedy*) se bloque\n",
     "\n",
     "Essayons l'approche la plus naïve : **remplir les jours l'un après l'autre**, en choisissant pour chaque jour le premier trio (breakfast+lunch+dinner) qui tombe dans la fenêtre, **sans jamais reconsidérer un choix passé**. C'est un algorithme glouton sans retour arrière.\n",
     "\n",
@@ -2191,7 +2191,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 6. Interprétation : déclaratif vs glouton sur un CSP couplé\n",
+    "### 6. Interprétation : déclaratif vs glouton sur un CSP couplé\n",
     "\n",
     "| Aspect | Glouton sans retour | Solveur SMT |\n",
     "|--------|---------------------|-------------|\n",
@@ -2219,16 +2219,16 @@
    "source": [
     "---\n",
     "\n",
-    "# Partie C — Visualisation HTML des solutions Z3\n",
+    "## Partie C — Visualisation HTML des solutions Z3\n",
     "\n",
-    "## Objectifs d'apprentissage\n",
+    "### Objectifs d'apprentissage\n",
     "\n",
     "- Comprendre **pourquoi** le rendu d'une solution Z3 importe autant que sa résolution : un solveur n'a de valeur opérationnelle que si ses sorties sont **lisibles par un humain**\n",
     "- Utiliser l'API `display(HTML(...))` de `Microsoft.DotNet.Interactive` pour produire des **cartes HTML** (tableaux colorés, badges, barres de progression) depuis un modèle C#\n",
     "- Réutiliser les modèles des **Parties A-B** (sélection booléenne, plan `int[][]`) et **n'en changer que la couche de présentation** — le solveur reste identique\n",
     "- Produire un **front de Pareto** rendu visuellement : le solveur explore l'espace des solutions sous plusieurs bornes de budget, et le résultat est rendu comme un tableau de compromis\n",
     "\n",
-    "## Prérequis\n",
+    "### Prérequis\n",
     "\n",
     "- **Partie A** : pattern `int[][]`, `MkITE`, `CollectionHandling.Array`\n",
     "- **Partie A** : modèle booléen `MkITE`, théorème hiérarchique `int[][]` ; corpus RecipeML détaillé dans le notebook de données 07\n",
@@ -2251,7 +2251,7 @@
     "tags": []
    },
    "source": [
-    "### Vue d'ensemble : du modele Z3 a la carte lisible par un humain\n",
+    "#### Vue d'ensemble : du modele Z3 a la carte lisible par un humain\n",
     "\n",
     "```mermaid\n",
     "flowchart LR\n",
@@ -2286,7 +2286,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Introduction : la frontière solveur / communication\n",
+    "### Introduction : la frontière solveur / communication\n",
     "\n",
     "Les Parties A et B affichaient leurs solutions via `Console.WriteLine` sous forme de **tableaux plats alignés par espaces**. Cette représentation suffit pour debugger ou vérifier un résultat à l'écran d'un développeur. Mais en production — un menu affiché à un utilisateur, un planning imprimé, un rapport envoyé à un diététicien — **la sortie texte brute est inutilisable** :\n",
     "\n",
@@ -2297,7 +2297,7 @@
     "\n",
     "Ce notebook introduit la brique qui manque : un **rendu HTML structuré et coloré** de la solution Z3. Le principe est simple — l'API `display(HTML(htmlString))` de `Microsoft.DotNet.Interactive` accepte n'importe quelle chaîne HTML et la rend comme une cellule `text/html` riche. On construit cette chaîne en C# pur (interpolation `$\"...\"` ou `StringBuilder`), en injectant les valeurs issues du modèle Z3.\n",
     "\n",
-    "### Ce que ce notebook démontre\n",
+    "#### Ce que ce notebook démontre\n",
     "\n",
     "1. **Couplage faible solveur / rendu** (section 3) — on reprend *exactement* le modèle booléen de la Partie A §5 et on ne change **que la dernière ligne** : `display(HTML(RenderMenuCard(...)))` à la place de `Console.WriteLine`. Le solveur ne sait même pas qu'il est rendu en HTML.\n",
     "2. **Plan multi-jours rendu en grille** (section 4) — le `int[][]` de la Partie A §7 est projeté en une grille HTML 7 colonnes (jours en lignes), avec **détection visuelle des répétitions**.\n",
@@ -2322,7 +2322,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 1. Corpus RecipeML et classe de domaine\n",
+    "### 1. Corpus RecipeML et classe de domaine\n",
     "\n",
     "On réutilise un **corpus 7-recettes inline** (même esprit que le notebook de données 07) (entrées / plats / desserts avec un mix pédagogique de coûts, protéines, allergènes). Pour éviter le piège du **verbatim string C#** (les guillemets XML doivent être doublés dans `@\"...\"`, sous peine de CS1003/CS1010), on construit la chaîne XML via un `StringBuilder`. Plus sûr, même résultat.\n",
     "\n",
@@ -2489,11 +2489,11 @@
    "source": [
     "---\n",
     "\n",
-    "## 2. Helper de rendu HTML : cartes et grilles\n",
+    "### 2. Helper de rendu HTML : cartes et grilles\n",
     "\n",
     "On définit deux helpers statiques qui prennent en entrée des **objets du domaine** (pas des expressions Z3) et retournent une **chaîne HTML**. C'est cette séparation qui rend le rendu réutilisable : le helper ne sait pas que les données viennent d'un solveur.\n",
     "\n",
-    "### `RenderMenuCard(IEnumerable<Recipe> menu, ...)`\n",
+    "#### `RenderMenuCard(IEnumerable<Recipe> menu, ...)`\n",
     "\n",
     "Renvoie une carte HTML stylée représentant un menu complet. Encodage visuel :\n",
     "\n",
@@ -2502,7 +2502,7 @@
     "- **Coût** : badge vert si ≤ budget, rouge sinon\n",
     "- **Allergènes** : badge rouge avec libellé si présent, badge vert \"sans allergène\" sinon\n",
     "\n",
-    "### `RenderWeeklyGrid(int[][] plan, List<Recipe> corpus)`\n",
+    "#### `RenderWeeklyGrid(int[][] plan, List<Recipe> corpus)`\n",
     "\n",
     "Renvoie une grille HTML (jours en lignes, créneaux en colonnes). Les répétitions d'une même recette à travers les jours sont **détectées** et marquées d'une couleur commune, afin de révéler visuellement une violation potentielle de variété.\n",
     "\n",
@@ -2656,7 +2656,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 3. Modèle booléen + rendu en carte HTML\n",
+    "### 3. Modèle booléen + rendu en carte HTML\n",
     "\n",
     "On reprend **à l'identique** le modèle booléen de la Partie A §5 : une `BoolExpr` par recette, cardinalité 1 par catégorie, agrégation nutritionnelle via `MkITE`, exclusion de l'allergène `nuts`, bornes kcal/protéines/budget. La seule différence est la **dernière ligne** : au lieu de `Console.WriteLine`, on appelle `display(HTML(RenderMenuCard(...)))`.\n",
     "\n",
@@ -2782,7 +2782,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : ce que l'encodage couleur revele d'un coup d'oeil\n",
+    "#### Interpretation : ce que l'encodage couleur revele d'un coup d'oeil\n",
     "\n",
     "La carte HTML ci-dessus condense en une seule image ce que le tableau `Console.WriteLine` des Parties A-B laissait au lecteur le soin de recomposer :\n",
     "\n",
@@ -2817,7 +2817,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 4. Plan hebdomadaire `int[][]` + grille HTML\n",
+    "### 4. Plan hebdomadaire `int[][]` + grille HTML\n",
     "\n",
     "On étend au plan multi-jours de la Partie A §7 : un `int[][]` (3 jours x 2 créneaux) peuplé d'indices de recettes dans le corpus, avec contrainte de non-répétition des déjeuners via `Z3Methods.Distinct` en mode `CollectionHandling.Array`.\n",
     "\n",
@@ -2939,7 +2939,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : la grille rend la variété visible\n",
+    "#### Interpretation : la grille rend la variété visible\n",
     "\n",
     "La grille HTML ci-dessus attribue à **chaque indice de recette** une couleur de fond stable. Sans même lire les noms, l'œil repère :\n",
     "\n",
@@ -2974,7 +2974,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Front de Pareto HTML : exploration de l'espace des solutions\n",
+    "### 5. Front de Pareto HTML : exploration de l'espace des solutions\n",
     "\n",
     "Un seul solve montre qu'il **existe** une solution. Une **série de solves sous budgets décroissants** révèle la structure du compromis kcal/coût — c'est le front de Pareto. Cette section est la montée en gamme du notebook (EPIC #3801 Prong-B) : on fait valoir la capacité du moteur à **explorer** un espace paramétrique, pas seulement à trouver un point.\n",
     "\n",
@@ -3129,7 +3129,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : le solveur comme explorateur de l'espace des solutions\n",
+    "#### Interpretation : le solveur comme explorateur de l'espace des solutions\n",
     "\n",
     "Le tableau ci-dessus **ne montre pas une solution** mais un **spectre** : ce que le solveur peut atteindre à chaque niveau de budget. C'est l'argument opérationnel pour utiliser un moteur SMT plutôt qu'un algorithme glouton :\n",
     "\n",
@@ -3162,7 +3162,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Tableau récapitulatif : Console (Parties A-B) vs HTML (Partie C)\n",
+    "### Tableau récapitulatif : Console (Parties A-B) vs HTML (Partie C)\n",
     "\n",
     "| Critère | `Console.WriteLine` (Parties A-B) | `display(HTML(...))` (Partie C) |\n",
     "|---------|--------------------------------|----------------------------|\n",
@@ -3174,7 +3174,7 @@
     "| Effort code | un `Console.WriteLine` | un helper HTML + appel `display` |\n",
     "| Couplage au solveur | aucun | aucun (fonction pure des objets du domaine) |\n",
     "\n",
-    "### Le point fondamental\n",
+    "#### Le point fondamental\n",
     "\n",
     "Le solveur n'a **pas été modifié** entre les Parties A-B et C. Les modèles (booléen avec `MkITE`, hiérarchique `int[][]`) sont identiques. Seule la **dernière ligne** de chaque section a changé : `Console.WriteLine` est devenu `display(HTML(...))`. C'est la preuve que l'architecture est **découplée** : le solveur produit des objets du domaine, le rendu est une fonction pure de ces objets."
    ]
@@ -3193,7 +3193,7 @@
     "tags": []
    },
    "source": [
-    "## Exercices — Partie A : Modelisation declarative"
+    "### Exercices — Partie A : Modelisation declarative"
    ]
   },
   {
@@ -3210,7 +3210,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Menu équilibré avec contrainte de glucides\n",
+    "#### Exercice 1 : Menu équilibré avec contrainte de glucides\n",
     "\n",
     "Ajoutez une contrainte sur les **glucides totaux** (entre 40g et 80g) au modèle d'optimisation (section 6). Le menu optimal doit toujours minimiser le cout, mais satisfaire cette contrainte supplementaire.\n",
     "\n",
@@ -3279,7 +3279,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Planificateur de repas multi-jours\n",
+    "#### Exercice 2 : Planificateur de repas multi-jours\n",
     "\n",
     "Etendez le modèle pour planifier un menu sur **2 jours** (6 repas : 2 entrees, 2 plats, 2 desserts) sans répétition. Contrainte : chaque aliment ne peut etre sélectionné qu'**au maximum 1 fois**.\n",
     "\n",
@@ -3349,7 +3349,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Ajout d'un plat supplementaire (boisson)\n",
+    "#### Exercice 3 : Ajout d'un plat supplementaire (boisson)\n",
     "\n",
     "Ajoutez une catégorie **\"boisson\"** a la base de données (3 boissons) et modifiez le modèle d'optimisation pour inclure exactement 1 boisson par repas. Verifiez que les contraintes nutritionnelles sont toujours satisfaites.\n",
     "\n",
@@ -3419,7 +3419,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 4 : Modèle hiérarchique combiné (montée en gamme + permutation)\n",
+    "#### Exercice 4 : Modèle hiérarchique combiné (montée en gamme + permutation)\n",
     "\n",
     "La section 7 a montré deux variantes *séparées* du théorème `WeeklyPlan` : montée en gamme (variante A) et permutation totale (variante B). Construisez maintenant un **modèle unique** qui combine les deux familles de contraintes :\n",
     "\n",
@@ -3492,7 +3492,7 @@
     "tags": []
    },
    "source": [
-    "## Exercices — Partie B : Couplage hebdomadaire"
+    "### Exercices — Partie B : Couplage hebdomadaire"
    ]
   },
   {
@@ -3509,7 +3509,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Fenetre de proteines par jour"
+    "#### Exercice 1 : Fenetre de proteines par jour"
    ]
   },
   {
@@ -3565,7 +3565,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Budget hebdomadaire"
+    "#### Exercice 2 : Budget hebdomadaire"
    ]
   },
   {
@@ -3619,7 +3619,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Variete renforcee sur 2 jours consecutifs"
+    "#### Exercice 3 : Variete renforcee sur 2 jours consecutifs"
    ]
   },
   {
@@ -3673,7 +3673,7 @@
     "tags": []
    },
    "source": [
-    "## Exercices — Partie C : Visualisation HTML"
+    "### Exercices — Partie C : Visualisation HTML"
    ]
   },
   {
@@ -3690,7 +3690,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Badge végétarien dans la carte de menu\n",
+    "#### Exercice 1 : Badge végétarien dans la carte de menu\n",
     "\n",
     "Ajoutez à la fonction `RenderMenuCard` un **badge végétarien** global (en haut de la carte) : vert si **toutes** les recettes du menu sont végétariennes, rouge sinon. On considère comme non-végétariennes les recettes dont le nom contient `\"Poulet\"`, `\"boeuf\"` ou `\"Lasagnes\"`.\n",
     "\n",
@@ -3762,7 +3762,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Total kcal par jour dans la grille hebdomadaire\n",
+    "#### Exercice 2 : Total kcal par jour dans la grille hebdomadaire\n",
     "\n",
     "Modifiez `RenderWeeklyGrid` pour ajouter une **ligne finale \"Total/jour\"** qui affiche la somme des kcal de toutes les recettes de chaque journée, avec un code couleur (`KcalColor`).\n",
     "\n",
@@ -3831,7 +3831,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Front de Pareto 2D (budget × plancher protéines) rendu en heatmap\n",
+    "#### Exercice 3 : Front de Pareto 2D (budget × plancher protéines) rendu en heatmap\n",
     "\n",
     "Étendez la section 5 en faisant varier **simultanément** le budget (800..2000) **et** le plancher de protéines (10..50 g). Pour chaque couple `(budget, protFloor)`, résolvez et stockez le kcal atteint. Rendez le tout comme une **heatmap HTML 2D** : lignes = budgets, colonnes = planchers protéiques, couleur de la cellule = kcal atteint (vert = haut, rouge = bas/irréalisable).\n",
     "\n",
@@ -3900,11 +3900,11 @@
    "source": [
     "---\n",
     "\n",
-    "## Conclusion\n",
+    "### Conclusion\n",
     "\n",
     "Ce notebook a parcouru la **modelisation declarative** d'un planificateur de repas de bout en bout : du menu d'un seul jour (Partie A) au plan hebdomadaire couple (Partie B), jusqu'a la restitution visuelle des solutions (Partie C). Le fil conducteur est que **le solveur est la source de verite** et que tout le reste — enumeration, couplage temporel, rendu — se decline autour de ce noyau declaratif.\n",
     "\n",
-    "### Points cles a retenir\n",
+    "#### Points cles a retenir\n",
     "\n",
     "| Concept | Ou | Implementation |\n",
     "|---------|-----|----------------|\n",
@@ -3917,7 +3917,7 @@
     "| Decouplage solveur / rendu | Partie C | `display(HTML(...))` = fonction pure des objets du domaine |\n",
     "| Exploration parametrique | Partie C | boucle de solves sous budgets varies -> front de Pareto rendu |\n",
     "\n",
-    "### Perspective\n",
+    "#### Perspective\n",
     "\n",
     "Les techniques vues ici se generalisent a tout solveur produisant des objets structures : planification de personnel (grille par equipe), allocation de ressources (heatmap de charge), ordonnancement (frise temporelle). Le principe reste le meme : **le solveur produit des objets du domaine, le reste est une fonction pure de ces sorties.** Le corpus de donnees a l'echelle (matching RecipeML x Ciqual) est traite dans le notebook de donnees 07 ; la variante « deux stacks » (DSL `Z3.Linq` vs API brute `Microsoft.Z3`) est developpee plus loin dans la serie.\n",
     "\n",


### PR DESCRIPTION
## Context (See #3968, Part of #3966)

Le notebook `06_Meal_Planner_Modelisation.ipynb` était flaggué par `scan_md_hierarchy.py` :
- **MULTI-H1** (4 H1 en compétition : cell 0 titre + cell 2/27/39 "Partie A/B/C")
- **H1-DEEP** (cell 2/27/39 : H1 utilisé en milieu de notebook)

Rendu pathologique : les 3 "Parties" s'affichaient à la **même taille géante que le titre**, masquant la hiérarchie.

## Changement — démotion globale +1 sous le titre

Démoction de **tous les headings sous le titre c0** d'un niveau (H1→H2, H2→H3, H3→H4) :
- `# Partie A/B/C` → `## Partie A/B/C`
- leurs enfants `## 1. Contexte`, `## 2. ...` → `###`
- les asides `### Analogie`, `### Interpretation` → `####`

**Pourquoi global et non minimal** : les enfants de Partie sont en `##`/`###`. Démotter *seulement* `# Partie A`→`##` en ferait un **sibling de ses propres enfants** (hiérarchie muddée). La règle #3968 (« selon la profondeur réelle ») impose de préserver la relation parent-enfant → démotion de tout le sous-arbre. Le titre c0 reste l'unique H1.

**64 headings démotés across 51 cells** (markdown-only, aucun contenu/titre de section modifié — uniquement le niveau `#`).

## Validation (acceptance #3968)

| Critère | Avant | Après |
|---|---|---|
| `scan_md_hierarchy.py` | MULTI-H1 + H1-DEEP (flaggué) | **0/1 flaggué** ✓ |
| Hiérarchie rendue (nbconvert HTML) | 4× `<h1>` | **1× `<h1>`** (titre) + 3× `<h2>` (Parties) + 30× `<h3>` ✓ |
| Nature du diff | — | **64/64 heading-level only** (aucun delta de contenu/code) ✓ |
| Line endings | — | LF pur (0 CRLF), pas de trailing newline (byte-identique à origin) ✓ |
| Re-execution | — | markdown-only → outputs précédents valides (C.2 exception) ✓ |

Les Parties rendent maintenant en `<h2>` (plus petites que le titre `<h1>`) — hiérarchie visuelle restaurée, vérifiée structurellement via les tags HTML.

## Scope & safety

- **1 notebook atomique**, `SymbolicAI/SMT/Z3/` (non-Lean, non-ICT). Branche fraîche `fix/3968-mealplanner-hierarchy` from `origin/main` (1e939a883).
- **Collision CLEAN** : 0 PR ouverte touche Meal_Planner / Z3 (vérifié `gh pr list` + scan fichiers des PRs ouvertes).
- CATALOG byte-identique (markdown-only, pas de toucher CATALOG-STATUS).

## Résiduel #3968 (repo-wide)

Le scanner ne flaggue plus que **3 notebooks** au total (typo-ladder quasi-drained) :
- `Lean-16b-Conway` — turf **po-2026** (touché c.201 #5163), non touché ici.
- `ICT-14-FreeEnergySurprise` — série ICT strate-5 **active**, non touché ici.
- `06_Meal_Planner_Modelisation` — **cette PR** (corrigé).

See #3968 — Part of #3966. Contribution partielle (1 des 3 résiduels), ne Closes pas.
