### PR TITLE
feat(infer-14): 4 pedagogical exercise headers for Causal-Inference (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Causal-Inference.ipynb
@@ -1624,6 +1624,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 - SCM confondu : education -> revenu\n",
+    "\n",
+    "**Concept** (cf. section 3, barometre) : un meme parent latent `U` (niveau d'etudes des parents) cause a la fois `X` (education de l'enfant) et `Y` (revenu). L'**observation** `P(Revenu | Education=haute)` et l'**intervention** `P(Revenu | do(Education=haute))` different : seule la seconde isole l'effet causal de l'education, en coupant l'influence de `U` sur `X`.\n",
+    "\n",
+    "**Objectif** : coder le SCM (CPT via `Variable.If` comme en section 3), calculer les deux quantites, puis **mutiler l'arc `U -> X`** (`Bernoulli(1.0)` force) pour le `do()`.\n",
+    "\n",
+    "Les etapes (`// Etape N`) et l'indice sont dans le code ci-dessous."
+   ]
+  },
+  {
    "cell_type": "code",
    "id": "eb5112fe221d",
    "metadata": {},
@@ -1646,6 +1659,19 @@
     "// Etape 2 : P(Revenu | Education=haute) observationnel\n",
     "// Etape 3 : P(Revenu | do(Education=haute)) interventionnel\n",
     "Console.WriteLine(\"Exercice 1 a completer : SCM education -> revenu (observation vs intervention).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 - Backdoor adjustment : identifier l'ensemble Z\n",
+    "\n",
+    "**Concept** (cf. section 5) : quand un confondeur `Z` est **observe** et bloque tous les chemins backdoor vers `X`, l'effet causal s'obtient **sans mutiler le graphe**, par la **formule d'ajustement backdoor** (Pearl, 1995) :\n",
+    "\n",
+    "$$P(Y \\mid do(X)) = \\sum_z P(Y \\mid X, z)\\, P(z)$$\n",
+    "\n",
+    "**Objectif** : choisir un reseau a 3-4 noeuds avec un confondeur observe, **identifier l'ensemble d'ajustement `Z`**, appliquer la formule, et comparer au `do()` direct (les deux doivent coïncider si `Z` est valide)."
    ]
   },
   {
@@ -1673,6 +1699,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 - Front-door : smoke -> tar -> cancer (Pearl)\n",
+    "\n",
+    "**Concept** (cf. section 6) : quand le confondeur `U` (predisposition genetique) est **non observe** mais qu'un **mediateur** `M` (goudron dans les poumons) est observe et capture tout l'effet de `X` (fumer) sur `Y` (cancer), Pearl (1995) montre l'identifiabilite par la **formule front-door** :\n",
+    "\n",
+    "$$P(Y \\mid do(X)) = \\sum_m P(M=m \\mid X) \\sum_{x'} P(Y \\mid M=m, x')\\, P(x')$$\n",
+    "\n",
+    "**Objectif** : adapter la section 6 avec de nouvelles CPT (fumer passif, exposition professionnelle) en **preservant la structure** `X -> M -> Y` + `U -> X`, `U -> Y` (U reste non observe)."
+   ]
+  },
+  {
    "cell_type": "code",
    "id": "deeb4d1f5bc6",
    "metadata": {},
@@ -1694,6 +1733,17 @@
     "// Etape 2 : recalculer P(M|X), P(x'), P(Y|M,x')\n",
     "// Etape 3 : appliquer la formule front-door et interpreter\n",
     "Console.WriteLine(\"Exercice 3 a completer : front-door smoke -> tar -> cancer (Pearl).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 - Paradoxe de Simpson personnalise\n",
+    "\n",
+    "**Concept** (cf. section 7) : un **renversement de Simpson** survient quand une conclusion s'inverse entre l'analyse agregee et l'analyse conditionnelle - typiquement parce qu'un confondeur `Z` favorise `X` tout en defavorisant `Y` (les patients graves, moins soignes, faussent la moyenne).\n",
+    "\n",
+    "**Objectif** : concevoir des CPT produisant un renversement (ex. traitement + age, ou genre + admission Berkeley 1973), puis montrer que `P(Y|X)` agrege **differere** de `P(Y|do(X))` et expliquer le mecanisme. C'est le cas ou la **conclusion naive** (agregee) est causalement **fausse** - le coeur de pourquoi l'ajustement causal importe."
    ]
   },
   {


### PR DESCRIPTION
## Context (See #2161)

`Infer-14-Causal-Inference.ipynb` (Probas/Infer, série Infer.NET 22/23) était **sub-threshold** : `count_exercises` = 1 malgré **4 stubs d'exercice réels**.

**Diagnostic G.1** (cf leçon [count-exercises-csharp-comment-blindspot]) : les 4 stubs sont des cellules code C# consécutives (`// Exercice 1..4`, c28-c31) après un seul header markdown de section (`## 11. Exercices`, c27). Le compteur est aveugle aux commentaires C# `//` (ligne 171 : `not ln.strip().startswith("//")`), et la logique de dédup absorbe le 1er stub dans le header de section → **count=1** au lieu de 4.

## Changement — 4 headers markdown pédagogiques

Insertion d'un header markdown dédié **devant chacun des 4 stubs** (pas de modification des stubs eux-mêmes) :

| Exo | Header | Concept (réf. section du notebook) |
|-----|--------|-------------------------------------|
| 1 | SCM confondu education→revenu | §3 baromètre : observation vs intervention, mutilation `U→X` |
| 2 | Backdoor adjustment — identifier Z | §5 : formule Σ_z P(Y\|X,z)P(z) |
| 3 | Front-door smoke→tar→cancer | §6 : formule Pearl Σ_m P(M\|X)Σ_{x'} P(Y\|M,x')P(x') |
| 4 | Paradoxe de Simpson personnalisé | §7 : renversement agrégé vs conditionnel |

Chaque header rappelle le **concept**, donne l'**objectif** précis (ce que l'étudiant doit produire), et pointe vers les **étapes/indices déjà présents** dans le code stub (`// Etape N`, `// Indice`) — aucune redondance. Les formules LaTeX (backdoor/front-door) reprennent **exactement** celles des sections §5/§6 du notebook lui-même.

## Validation

| Critère | Résultat |
|---|---|
| `count_exercises` | **1 → 5** (conforming ≥3) ✓ |
| C.1 (0 `raise NotImplementedError`/`assert False`/`1/0`) | **0 violation** ✓ |
| H.3 (pas de code cell ec=None sans outputs) | **0** ✓ |
| Code stubs byte-identiques | **15/15 code cells préservées** (set equality), stubs gardent ec=12/13/14/15 + outputs ✓ |
| Nature du diff | **50 insertions / 0 suppression** (pure insertion markdown) ✓ |
| Line endings | LF pur (0 CRLF), pas de trailing newline (byte-identique à origin) ✓ |
| Re-execution | markdown-only → outputs précédents valides (C.2 exception) ✓ |

## Scope & safety

- **1 notebook atomique**, Probas/Infer (mon turf). Branche fraîche `fix/infer14-exercise-headers` from `origin/main` (1e939a883).
- **Collision CLEAN** : 0 PR ouverte touche Infer-14 (vérifié `gh pr list` + scan fichiers des PRs ouvertes).
- CATALOG byte-identique (markdown-only, pas de toucher CATALOG-STATUS).
- Manipulation JSON pure (pas nbformat qui ajouterait `id` à toutes les cellules → churn, cf leçon).

See #2161 — contribution pédagogique (4 exercices structurés). Ne Closes pas (tracker de rollout).
