### PR TITLE
fix(probas-infer): add exercise headers to Infer-14-Causal-Inference (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Causal-Inference.ipynb
@@ -1624,6 +1624,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "infer14-ex1-hdr",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — SCM confondu : education -> revenu\n",
+    "\n",
+    "**Concept** : distinguer l'observation `P(Y|X)` de l'intervention `P(Y|do(X))` (niveau 1 de l'échelle de Pearl).\n",
+    "\n",
+    "**Objectif** : construisez un SCM où `U` (niveau d'études des parents) cause à la fois `Education (X)` et `Revenu (Y)`, avec l'arc `X -> Y`. Comparez `P(Revenu | Education=haute)` (observationnel) à `P(Revenu | do(Education=haute))` (interventionnel).\n",
+    "\n",
+    "**Indices** : codez les CPT avec `Variable.If` (cf. section 3), puis mutilez l'arc `U -> X` pour obtenir le `do()`."
+   ]
+  },
+  {
    "cell_type": "code",
    "id": "eb5112fe221d",
    "metadata": {},
@@ -1646,6 +1660,20 @@
     "// Etape 2 : P(Revenu | Education=haute) observationnel\n",
     "// Etape 3 : P(Revenu | do(Education=haute)) interventionnel\n",
     "Console.WriteLine(\"Exercice 1 a completer : SCM education -> revenu (observation vs intervention).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "infer14-ex2-hdr",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Backdoor adjustment\n",
+    "\n",
+    "**Concept** : identifier l'ensemble d'ajustement `Z` qui bloque tous les chemins backdoor vers `X`.\n",
+    "\n",
+    "**Objectif** : sur un réseau à 3-4 nœuds avec un confondeur observé `Z`, calculez `P(Y|do(X))` par ajustement backdoor, puis comparez au `do()` direct.\n",
+    "\n",
+    "**Indices** : vérifiez que `Z` bloque tous les chemins backdoor vers `X`, puis appliquez la formule `Σ_z P(Y|X,z)P(z)`."
    ]
   },
   {
@@ -1673,6 +1701,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "infer14-ex3-hdr",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Front-door : smoke -> tar -> cancer\n",
+    "\n",
+    "**Concept** : ajustement par médiateur `M` quand le confondeur `U` est inobservable (classique Pearl).\n",
+    "\n",
+    "**Objectif** : adaptez la section 6 en changeant les CPT (par ex. tabagisme passif, exposition professionnelle) tout en préservant la structure `X -> M -> Y` + `U -> X`, `U -> Y`.\n",
+    "\n",
+    "**Indices** : recalculez `P(M|X)`, `P(x')`, `P(Y|M,x')`, puis appliquez la formule front-door et interprétez."
+   ]
+  },
+  {
    "cell_type": "code",
    "id": "deeb4d1f5bc6",
    "metadata": {},
@@ -1694,6 +1736,20 @@
     "// Etape 2 : recalculer P(M|X), P(x'), P(Y|M,x')\n",
     "// Etape 3 : appliquer la formule front-door et interpreter\n",
     "Console.WriteLine(\"Exercice 3 a completer : front-door smoke -> tar -> cancer (Pearl).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "infer14-ex4-hdr",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 — Paradoxe de Simpson personnalisé\n",
+    "\n",
+    "**Concept** : renversement — la conclusion agrégée s'inverse par rapport à la conditionnelle.\n",
+    "\n",
+    "**Objectif** : concevez des CPT où `P(Y|X)` agrégé diffère de `P(Y|do(X))`. Choisissez un scénario (ex. traitement + âge, ou genre + admission Berkeley 1973).\n",
+    "\n",
+    "**Indices** : il faut un confondeur `Z` qui favorise `X` et défavorise `Y` (ou inverse)."
    ]
   },
   {


### PR DESCRIPTION
## Scope

Add `### Exercice N` markdown headers to `Infer-14-Causal-Inference.ipynb` so the 3-exercises-per-notebook convention (#2161) is satisfied. Markdown-only, no re-execution.

## Problem

`Infer-14-Causal-Inference.ipynb` had **4 exercise stubs** (code cells with `// Exercice 1..4` C# comments), but only a single `## 11. Exercices` intro section. The `count_exercises` tool — which scans markdown headers — reported **count=1**, below the `>=3` threshold.

This is the same C# `//` blind-spot documented by po-2023 in c.91:
- the exercise counter looks for markdown `# Exercice` headers
- C# notebooks mark exercise stubs in `//` code comments
- so `// Exercice N` stubs are invisible to the counter

Already fixed the same way in Infer-10 (#5158) and MGS-9 (#5160). po-2023 (c.92) identified Infer-14 as the next instance but deferred it to my lane (Probas/Infer is po-2025's #3974 partition):

> "`Infer-14-Causal-Inference` (count=1, 4 stubs C# `//` cachés = même blind-spot c.91, collision CLEAN, mon turf)"

## Fix

Insert a `### Exercice N` markdown header before each of the 4 existing stubs. Each header has the #2161 structure (concept + objective + indices), **derived solely from the stub's own `//` comment and the intro table (cell 27)** — no domain invention, no solution filled in (stubs stay stubs per the exercise-example-labeling rule).

| # | Exercice | Concept (from cell 27 table) |
|---|----------|------------------------------|
| 1 | SCM confondu education → revenu | observation vs intervention (do) |
| 2 | Backdoor adjustment | identification de l'ensemble Z |
| 3 | Front-door smoke → tar → cancer | ajustement par médiateur |
| 4 | Paradoxe de Simpson personnalisé | renversement agrégé vs conditionnel |

## Validation (markdown-only — C.2 exception, no re-exec)

Infer.NET is stochastic: re-executing would churn the 11 demo cells' outputs (cells ec=1..11) without any code change. Per the Infer-10/MGS-9 precedent, markdown-only edits are C.2-exempt.

```
$ python scripts/notebook_tools/count_exercises.py Infer-14-Causal-Inference.ipynb
Total exercises: 5 | Conforming: 1 | Sub-threshold: 0   # 1 -> 5 (>=3 OK)

# 15 code cells byte-identical (ec=1..15 preserved, stubs ec=12..15 + 1 output each)
old code cells: 15 | new code cells: 15 | ALL code cells byte-identical: True

# C.1 = 0 banned patterns (raise NotImplementedError / assert False / 1/0)
# scan_md_hierarchy: 0/1 flagged
# catalog byte-identical to main, LF preserved
# 1 file changed, +57/-1 (the -1 is the JSON closing brace reformatting from json.dump indent=1)
```

## Notes

- Anti-collision verified: the only other open PR touching Probas/Infer is #5153 (README.md, not this .ipynb).
- po-2023 explicitly deferred this grain to the Probas/Infer lane (owner: po-2025, #3974).
- No `Closes` — #2161 is a CLOSED tracker but the rollout is per-family/per-notebook (ongoing). `See #2161`.

See #2161
