### PR TITLE
docs(qc): #3976 fix projects/README Historique count 15 -> 13

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/README.md
@@ -38,7 +38,7 @@
 | [ML-FeatureEngineering](ML-FeatureEngineering/) | **0.571** | 10.5% | 19.6% | 2015-2026 | Avancé |
 | [RegimeSwitching](RegimeSwitching/) | **0.553** | 11.7% | 33.0% | 2008-2026 | Avancé |
 
-### Historique (Sharpe 0-0.5) — 15 stratégies
+### Historique (Sharpe 0-0.5) — 13 stratégies
 
 [Multi-Layer-EMA](Multi-Layer-EMA/) (0.928, non robuste) · [EMA-Cross-Index](EMA-Cross-Index/) (0.470) · [DualMomentumNoTLT](DualMomentumNoTLT/) (0.469) · [Adaptive-Conformal-Risk](Adaptive-Conformal-Risk/) (0.423) · [RiskParity](RiskParity/) (0.399) · [DualMomentum](DualMomentum/) (0.350) · [MeanReversion](MeanReversion/) (0.294) · [BTC-ML](BTC-ML/) (0.282) · [EMA-Cross-Crypto](EMA-Cross-Crypto/) (0.244) · [OptionsIncome](OptionsIncome/) (0.207) · [FuturesTrend](FuturesTrend/) (0.136) · [TurnOfMonth](TurnOfMonth/) (0.128) · [VIX-TermStructure](VIX-TermStructure/) (0.051)
 


### PR DESCRIPTION
## What

Fix an intra-file numeric contradiction in `projects/README.md` (QuantConnect feuilles, #3976 owner po-2024:CoursIA).

The **Historique (Sharpe 0-0.5)** section header claimed **"15 strategies"** but the concrete list at L43 contains only **13 named items**.

## Proof (G.1 firsthand)

```text
L41: ### Historique (Sharpe 0-0.5) — 15 stratégies      ← header (stale)
L43: [Multi-Layer-EMA] · [EMA-Cross-Index] · ... · [VIX-TermStructure]   ← 13 items
```

Counted the L43 list items programmatically: **13**. The list is the concrete ground truth (13 named strategies with Sharpe values); the header count was stale.

The other two partitions are consistent (verified the same way):
- **Robuste (Sharpe > 0.5)** — header **19** = **19** table rows ✓
- **Exploratoire (Sharpe < 0)** — header **4** = **4** strategies ✓

## Method (per #3976 lesson)

Reliable drift type for #3976 = **intra-file contradiction** (header count vs concrete list content), verified `find`/grep firsthand. NOT a local-folder-vs-claimed-count comparison (conflation FP — see my 02/07 comment on #3976 debunking Rank 2/5 audit FPs).

Aligned the abstract count (15) to the concrete list (13). Did NOT hunt for 2 "missing" strategies across 114 folders (that's the conflation trap).

## Scope

- 1 file, 1 line changed (`15` -> `13`).
- Markdown-only (C.2 exception, no re-exec).
- Catalog byte-identical to `main` (catalog-pr-hygiene R1).
- Fresh base `origin/main` (R2), atomic single-subject (R3).

See #3976 (QC feuilles READMEs, owner po-2024:CoursIA). Part of #3973 (README ascendant EPIC).

Co-Authored-By: Claude-Code <noreply@anthropic.com>