### PR TITLE
fix(ci): detect Lean/alectryon text-rendered errors in notebook merge gate (See #4209)

### DIFF
--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -377,3 +377,93 @@ class TestValidateNotebookPaths:
         ], kernelspec={"name": "python3", "language": "python"})
         result = validate_notebook(nb)
         assert result["kernel"] == "python3"
+
+
+# ---------------------------------------------------------------------------
+# validate_notebook — Lean/alectryon text-rendered errors (H.1, #5151)
+# ---------------------------------------------------------------------------
+
+class TestValidateNotebookLeanTextErrors:
+    """Lean via lean4_jupyter/alectryon renders compile errors as TEXT
+    (display_data / execute_result), never as output_type=="error". A whole
+    Lean notebook can be red (every cell ❌) while CI stays green. The
+    detector anchors on the toolchain-emitted `severity: error` message.
+    Regression guard for #5151 (Sudoku-7b-Lean-Propagation: failed import ->
+    48 unknown-identifier + 12 unknown-constant cascade, CI all green)."""
+
+    def _lean_err_output(self) -> dict:
+        # Shape mirrors the real lean4_jupyter/alectryon output on #5151:
+        # the compiler's own JSON message is embedded in text/plain.
+        return {
+            "output_type": "display_data",
+            "data": {
+                "text/plain": [
+                    "import Sudoku.Basic\n     ──────▶ ❌ unknown namespace `Sudoku`\n",
+                    'Raw output:\n{"messages": [{"severity": "error", '
+                    '"pos": {"line": 4, "column": 5}, "data": "unknown namespace `Sudoku`"}]}',
+                ],
+            },
+        }
+
+    def test_lean_text_error_blocks_even_though_skip_exec(self, tmp_path):
+        """The #5151 case: lean4 kernel is skip_exec, but a text-rendered
+        toolchain error is BLOCKING (never advisory — Lean compile errors are
+        never 'expected', and QC notebooks are Python)."""
+        nb = _write_nb(tmp_path / "Sudoku-7b.ipynb", [
+            _code("import Sudoku.Basic\nopen Sudoku", exec_count=1,
+                  outputs=[self._lean_err_output()]),
+        ], kernelspec={"name": "lean4", "language": "lean4"})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("Lean toolchain error" in e for e in result["errors"])
+
+    def test_lean_text_error_in_html_output(self, tmp_path):
+        """severity:error embedded in text/html is caught too."""
+        html_out = {
+            "output_type": "display_data",
+            "data": {"text/html": [
+                '<pre class="alectryon-io">... {"severity": "error", '
+                '"data": "unknown identifier"} ...</pre>'
+            ]},
+        }
+        nb = _write_nb(tmp_path / "lean.ipynb", [
+            _code("#check Foo", exec_count=1, outputs=[html_out]),
+        ], kernelspec={"name": "lean4", "language": "lean4"})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+
+    def test_clean_lean_output_passes(self, tmp_path):
+        """A successful #check with a normal alectryon output (no severity
+        error) must PASS — no false positive."""
+        ok_out = {
+            "output_type": "display_data",
+            "data": {"text/plain": ["#check Nat\nNat : Type"]},
+        }
+        nb = _write_nb(tmp_path / "lean.ipynb", [
+            _code("#check Nat", exec_count=1, outputs=[ok_out]),
+        ], kernelspec={"name": "lean4", "language": "lean4"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+
+    def test_raises_exception_tag_opts_out(self, tmp_path):
+        """A cell tagged 'raises-exception' (intentional error demo) is exempt
+        from the Lean text-error gate."""
+        cell = _code("import Sudoku.Basic", exec_count=1,
+                     outputs=[self._lean_err_output()])
+        cell["metadata"] = {"tags": ["raises-exception"]}
+        nb = _write_nb(tmp_path / "lean.ipynb", [cell],
+                       kernelspec={"name": "lean4", "language": "lean4"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+
+    def test_python_checkmark_emoji_no_false_positive(self, tmp_path):
+        """A Python cell that prints a ❌ glyph in a legit result table (e.g.
+        a pass/fail summary) must NOT be flagged — the detector keys on the
+        Lean 'severity: error' string, not on the emoji."""
+        out = {"output_type": "stream", "name": "stdout",
+               "text": ["Test 1: ✅ passed\nTest 2: ❌ failed\n"]}
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code("run_checks()", exec_count=1, outputs=[out]),
+        ])
+        result = validate_notebook(nb)
+        assert result["passed"] is True

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -41,6 +41,19 @@ SKIP_EXEC_KERNELS = {
 # H.3 is advisory-only for these — they can only be executed via QC Cloud.
 QC_CLOUD_PATHS = ("QuantConnect/Python", "QuantConnect/projects")
 
+# Kernels that render errors as TEXT, not as output_type=="error" (#5151).
+# Lean via lean4_jupyter/alectryon embeds the compiler's own message severity
+# in the cell output (text/plain + text/html). A `severity: error` message is
+# an unambiguous toolchain error (failed import, unknown identifier, unsolved
+# goals, ...) that the output_type=="error" check misses entirely — a whole
+# Lean notebook can be red (every cell ❌) while CI stays green, because the
+# alectryon renderer never emits a Jupyter error output. We anchor on the
+# toolchain-emitted severity string, so notebook *prose* that merely discusses
+# errors does not trip it (verified: 0 false positives on clean Lean
+# notebooks). A cell tagged "raises-exception" (the standard Jupyter/nbval
+# marker for an intentionally-erroring teaching cell) is exempt.
+TEXT_RENDERED_ERROR_SIGNATURES = ('"severity": "error"', '"severity":"error"')
+
 
 def get_changed_notebooks(base: str, paths: list[str] | None = None) -> list[Path]:
     """Get list of .ipynb files changed relative to base branch."""
@@ -75,6 +88,23 @@ def get_kernel_name(nb_path: Path) -> str:
         )
     except (json.JSONDecodeError, UnicodeDecodeError):
         return "unknown"
+
+
+def _output_text(output: dict) -> str:
+    """Concatenate the textual payload of an output so text-rendered errors
+    (Lean/alectryon) can be scanned. Covers display_data / execute_result
+    (text/plain + text/html) and stream outputs."""
+    parts = []
+    otype = output.get("output_type")
+    if otype in ("display_data", "execute_result"):
+        data = output.get("data", {})
+        for mime in ("text/plain", "text/html"):
+            v = data.get(mime, "")
+            parts.append("".join(v) if isinstance(v, list) else str(v))
+    elif otype == "stream":
+        t = output.get("text", "")
+        parts.append("".join(t) if isinstance(t, list) else str(t))
+    return " ".join(parts)
 
 
 def validate_notebook(nb_path: Path) -> dict:
@@ -123,9 +153,15 @@ def validate_notebook(nb_path: Path) -> dict:
         if not source.strip():
             continue
 
-        # Skip comment-only cells
+        # Skip comment-only cells. Comment syntax is kernel-dependent: in Lean,
+        # '#check' / '#eval' / '#print' / '#reduce' are COMMANDS (comments are
+        # '--'), so the Python-centric '#' heuristic would wrongly skip real
+        # Lean command cells — and with them any error output they carry
+        # (#5151: the failing '#print axioms' / '#check' cells were skipped;
+        # the notebook was only caught by its failing 'import' cell).
+        comment_prefix = "--" if "lean" in kernel else "#"
         lines = [l.strip() for l in source.split("\n") if l.strip()]
-        if all(l.startswith("#") for l in lines):
+        if all(l.startswith(comment_prefix) for l in lines):
             continue
 
         result["total_code"] += 1
@@ -147,8 +183,19 @@ def validate_notebook(nb_path: Path) -> dict:
                     f"cell {i}: execution_count is null (H.3 violation)"
                 )
 
-        # H.1 check: no error outputs (advisory for QC Cloud — errors expected
-        # from [REFERENCE QC] cells executed locally without QuantBook runtime)
+        # H.1 check: no error outputs. Two rendering paths:
+        #  (a) output_type == "error" — Python/IPython, .NET Interactive.
+        #      Advisory for QC Cloud reference cells (errors expected without
+        #      the QuantBook runtime).
+        #  (b) text-rendered errors — Lean (lean4_jupyter/alectryon) embeds the
+        #      compiler's `severity: error` in text output and NEVER emits
+        #      output_type=error, so (a) misses it (incident #5151: notebook
+        #      red top-to-bottom, CI green). These are ALWAYS blocking: a Lean
+        #      compile error is never "expected", and QC notebooks are Python,
+        #      so there is no overlap with the QC-advisory carve-out. Opt out
+        #      per-cell with the "raises-exception" tag for intentional demos.
+        cell_tags = cell.get("metadata", {}).get("tags", []) or []
+        raises_ok = "raises-exception" in cell_tags
         for output in cell.get("outputs", []):
             if output.get("output_type") == "error":
                 ename = output.get("ename", "Unknown")
@@ -161,6 +208,16 @@ def validate_notebook(nb_path: Path) -> dict:
                     result["errors"].append(
                         f"cell {i}: has error output — {ename}"
                     )
+            elif not raises_ok and any(
+                sig in _output_text(output)
+                for sig in TEXT_RENDERED_ERROR_SIGNATURES
+            ):
+                result["passed"] = False
+                result["errors"].append(
+                    f"cell {i}: Lean toolchain error in output "
+                    f"(severity:error — failed compile/import/proof)"
+                )
+                break  # one report per cell is enough
 
     return result
 


### PR DESCRIPTION
## Problem (incident #5151)

The notebook merge gate (`validate_pr_notebooks.py`, job **Static validation (H.1/H.3/C.1)**) only detects `output_type == "error"`. **Lean via `lean4_jupyter`/alectryon never emits a Jupyter error output** — the compiler's messages (failed import, unknown identifier, unsolved goals) render as **text** in `display_data` (`text/plain` + `text/html`), carrying the toolchain's own `{"severity": "error"}`.

Result: **a whole Lean notebook can be red (every cell ❌) while every CI check is green.** PR #5151 (`Sudoku-7b-Lean-Propagation`) did exactly this: `import Sudoku.Basic` failed → 48 `unknown identifier` + 12 `unknown constant` cascade, all 5 Lean cells ❌, yet *Static validation* AND *Golden-set execution* passed. (Golden-set is a pinned **Python** subset — it never runs Lean notebooks.) It was held unmerged and surfaced by the user.

## Fix — three coupled defects

1. **Detection.** Add a text-rendered error detector anchored on the Lean toolchain `severity: error` string. Verified **0 false positives** on clean Lean notebooks (#5163, #5166) and clean .NET notebooks. A cell tagged `raises-exception` (standard Jupyter/nbval marker) opts out for intentional error demos.
2. **Blocking, not advisory.** `skip_exec` (lean4/.NET kernels) made even real errors advisory-only — a carve-out meant for QC-Cloud reference cells. Lean text errors are **always blocking**: a Lean compile error is never "expected", and QC notebooks are Python, so there's no overlap.
3. **Comment-skip was kernel-blind.** The "comment-only cell" skip treated any `#`-prefixed line as a Python comment, so Lean `#check`/`#print`/`#eval` **command** cells (Lean comments are `--`) were skipped and their error outputs never checked. In #5151 that meant cells 4/6/9/13 slipped through; only the failing `import` cell caught it. Made the comment prefix kernel-aware.

## Validation

- `pytest scripts/notebook_tools/tests/test_validate_pr_notebooks.py` → **41 passed** (+5 new regression cases in `TestValidateNotebookLeanTextErrors`).
- Direct run on the real #5151 head → `passed=False`, **5/5** Lean error cells flagged. Clean #5163/#5166 → `passed=True`.
- **Blast radius = 0**: `grep -rlE '"severity": ?"error"'` over all notebooks on `main` returns 0 — no existing content newly fails; the gate only fires on the next edit of a broken notebook.

## Follow-up (not in this PR)

#5151 itself is **not** merged: its notebook needs real re-execution with the `Sudoku` lake actually built (RECOVERABLE — machine with the Lean env), then re-committed with genuine outputs. Requesting changes on that PR separately.

See #4209 (axe A — CI reliability, H.7 P3).