### PR TITLE
feat(symbolicai): port POCOs verbatim DatasetUpdater tranche C #4960

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/CoursIA.DatasetUpdater.Prompts.sln
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/CoursIA.DatasetUpdater.Prompts.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.DatasetUpdater.Prompts", "src\CoursIA.DatasetUpdater.Prompts\CoursIA.DatasetUpdater.Prompts.csproj", "{1B2A6F0C-3D4E-4F5A-9B6C-7D8E9F0A1B2C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.DatasetUpdater.Prompts.Tests", "src\CoursIA.DatasetUpdater.Prompts.Tests\CoursIA.DatasetUpdater.Prompts.Tests.csproj", "{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1B2A6F0C-3D4E-4F5A-9B6C-7D8E9F0A1B2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B2A6F0C-3D4E-4F5A-9B6C-7D8E9F0A1B2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B2A6F0C-3D4E-4F5A-9B6C-7D8E9F0A1B2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B2A6F0C-3D4E-4F5A-9B6C-7D8E9F0A1B2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C3D4E5F-6A7B-8C9D-0E1F-2A3B4C5D6E7F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/CoursIA.DatasetUpdater.Prompts.Tests.csproj
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/CoursIA.DatasetUpdater.Prompts.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CoursIA.DatasetUpdater.Prompts\CoursIA.DatasetUpdater.Prompts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/DivisionModeTests.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/DivisionModeTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater.Tests;
+
+public class DivisionModeTests
+{
+	[Fact]
+	public void DivisionMode_HasTwoValues_SequentialChunks_And_PKHierarchicalChar()
+	{
+		// Mirrors the upstream Argumentum.AssetConverter.DivisionMode enum:
+		// SequentialChunks (default chunk-by-chunk CSV split)
+		// PKHierarchicalChar (split by primary-key prefix hierarchy)
+		var values = System.Enum.GetValues<DivisionMode>();
+
+		values.Should().HaveCount(2);
+		values.Should().Contain(DivisionMode.SequentialChunks);
+		values.Should().Contain(DivisionMode.PKHierarchicalChar);
+	}
+
+	[Fact]
+	public void DivisionMode_DefaultUnderlyingType_Is_Int32()
+	{
+		// POCO surface preservation: upstream enum has no explicit underlying type,
+		// so it defaults to int. Verbatim port must preserve that.
+		System.Enum.GetUnderlyingType(typeof(DivisionMode)).Should().Be(typeof(int));
+	}
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/PromptExampleTests.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/PromptExampleTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater.Tests;
+
+public class PromptExampleTests
+{
+	[Fact]
+	public void PromptExample_ReadsUserPrompt_FromFile_OnFirstAccess()
+	{
+		var temp = System.IO.Path.GetTempFileName();
+		try
+		{
+			System.IO.File.WriteAllText(temp, "What is the capital of France?");
+			var example = new PromptExample { UserPromptPath = temp, AssistantAnswerPath = temp };
+
+			example.UserPrompt.Should().Be("What is the capital of France?");
+		}
+		finally { System.IO.File.Delete(temp); }
+	}
+
+	[Fact]
+	public void PromptExample_CachesUserPrompt_AcrossMultipleReads()
+	{
+		// Upstream pattern: a null _userPrompt guard reads the file only on first access,
+		// then caches the result. The port preserves that lazy-cache contract.
+		var temp = System.IO.Path.GetTempFileName();
+		try
+		{
+			System.IO.File.WriteAllText(temp, "first read");
+			var example = new PromptExample { UserPromptPath = temp, AssistantAnswerPath = temp };
+
+			var firstRead = example.UserPrompt;
+			System.IO.File.WriteAllText(temp, "second read (should be ignored by cache)");
+			var secondRead = example.UserPrompt;
+
+			firstRead.Should().Be("first read");
+			secondRead.Should().Be("first read", "the lazy-cache must not re-read after first access");
+		}
+		finally { System.IO.File.Delete(temp); }
+	}
+
+	[Fact]
+	public void PromptExample_ReadsAssistantAnswer_FromFile_OnFirstAccess()
+	{
+		var temp = System.IO.Path.GetTempFileName();
+		try
+		{
+			System.IO.File.WriteAllText(temp, "Paris is the capital of France.");
+			var example = new PromptExample { UserPromptPath = temp, AssistantAnswerPath = temp };
+
+			example.AssistantAnswer.Should().Be("Paris is the capital of France.");
+		}
+		finally { System.IO.File.Delete(temp); }
+	}
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/PromptTests.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/PromptTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater.Tests;
+
+public class PromptTests
+{
+	[Fact]
+	public void Prompt_DefaultModel_Is_Gpt41Mini()
+	{
+		// Mirrors the upstream Argumentum.AssetConverter.Prompt default:
+		// Model = "gpt-4.1-mini"
+		new Prompt().Model.Should().Be("gpt-4.1-mini");
+	}
+
+	[Fact]
+	public void Prompt_DefaultApiKey_Is_EmptyString()
+	{
+		// ApiKey must NOT have a hardcoded fallback (secrets-hygiene rule:
+		// never inline literals in .cs source). The upstream default is "".
+		new Prompt().ApiKey.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Prompt_DefaultDialogPrompts_Is_EmptyList()
+	{
+		new Prompt().DialogPrompts.Should().NotBeNull().And.BeEmpty();
+	}
+
+	[Fact]
+	public void Prompt_DefaultFunctions_Is_EmptyList()
+	{
+		new Prompt().Functions.Should().NotBeNull().And.BeEmpty();
+	}
+
+	[Fact]
+	public void Prompt_DefaultSystemPrompt_UserPrompt_Are_Empty()
+	{
+		var prompt = new Prompt();
+		prompt.SystemPrompt.Should().BeEmpty();
+		prompt.UserPrompt.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Prompt_FunctionDescriptor_CarriesNameDescriptionParametersJson()
+	{
+		// Mirrors the upstream FunctionToolDef data fields (Name, Description, ParametersJson).
+		// SDK-specific factory stripped (see NOTICE §3); consumer builds the SDK tool from the triple.
+		var descriptor = new FunctionDescriptor
+		{
+			Name = "lookup_argument",
+			Description = "Look up a known argument by ID in the corpus.",
+			ParametersJson = "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}}}"
+		};
+
+		descriptor.Name.Should().Be("lookup_argument");
+		descriptor.Description.Should().Contain("Look up");
+		descriptor.ParametersJson.Should().Contain("object");
+	}
+
+	[Fact]
+	public void Prompt_Properties_AreMutable()
+	{
+		// Verbatim port preserves the upstream POCO pattern (auto-properties with
+		// public getters/setters, no init-only restrictions). Tests can build
+		// arbitrary configurations.
+		var prompt = new Prompt
+		{
+			Model = "llama-3.3-70b",
+			ApiKey = "test-key-from-env-var",
+			BaseUrl = "https://api.example.com/v1",
+			SystemPrompt = "You are a Socratic tutor.",
+			UserPrompt = "Explain the Liar paradox.",
+			MaxOutputTokens = 512,
+			FunctionName = "lookup_argument"
+		};
+
+		prompt.Model.Should().Be("llama-3.3-70b");
+		prompt.ApiKey.Should().Be("test-key-from-env-var");
+		prompt.BaseUrl.Should().Be("https://api.example.com/v1");
+		prompt.SystemPrompt.Should().Contain("Socratic");
+		prompt.UserPrompt.Should().Contain("Liar");
+		prompt.MaxOutputTokens.Should().Be(512);
+		prompt.FunctionName.Should().Be("lookup_argument");
+	}
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/TokenManagerTests.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/TokenManagerTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater.Tests;
+
+/// <summary>
+/// Deterministic ITokenCounter test double — returns a caller-specified token count
+/// so the rate-limit sliding window can be exercised without any real tokenizer.
+/// </summary>
+internal sealed class FixedTokenCounter : ITokenCounter
+{
+	private readonly int _tokensPerText;
+	public FixedTokenCounter(int tokensPerText) { _tokensPerText = tokensPerText; }
+	public int CountTokens(string text) => _tokensPerText;
+}
+
+public class TokenManagerTests
+{
+	[Fact]
+	public void TokenManager_DefaultMillisecondsDelay_Is5000()
+	{
+		// Mirrors the upstream Argumentum.AssetConverter.TokenManager default:
+		// MillisecondsDelay = 5000
+		new TokenManager(maxTokensPerMinute: 1000).MillisecondsDelay.Should().Be(5000);
+	}
+
+	[Fact]
+	public void TokenManager_DefaultCurrentMinuteTokenCount_IsZero_BeforeAnyTokenize()
+	{
+		var mgr = new TokenManager(maxTokensPerMinute: 1000);
+		mgr.CurrentMinuteTokenCount.Should().Be(0);
+		mgr.TotalMaxTokens.Should().Be(0);
+	}
+
+	[Fact]
+	public void TokenManager_TokenizeAction_AccumulatesTotalTokens_AndCurrentMinute()
+	{
+		var mgr = new TokenManager(maxTokensPerMinute: 1000, counter: new FixedTokenCounter(tokensPerText: 10));
+
+		mgr.TokenizerAction("hello world");
+		mgr.TokenizerAction("another text");
+
+		mgr.TotalMaxTokens.Should().Be(20);
+		mgr.CurrentMinuteTokenCount.Should().Be(20);
+	}
+
+	[Fact]
+	public void TokenManager_DefaultTokenizerAction_IsNotNull()
+	{
+		new TokenManager(maxTokensPerMinute: 1000).TokenizerAction.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void TokenManager_NullCounter_FallsBackToNoOpCounter()
+	{
+		// Mirrors the upstream `GptEncoding.GetEncodingForModel` fallback path:
+		// when no model binding is available, encoding defaults to "cl100k_base".
+		// In the ported version, a null counter falls back to NullTokenCounter
+		// (every text tokenises to 0), so the manager is still safe to construct.
+		var mgr = new TokenManager(maxTokensPerMinute: 1000, counter: null);
+		mgr.TokenizerAction("any text");
+		mgr.TotalMaxTokens.Should().Be(0);
+		mgr.CurrentMinuteTokenCount.Should().Be(0);
+	}
+
+	[Fact]
+	public void TokenManager_AcceptsCustomLegacyLogger_ForRateLimitWait_Logging()
+	{
+		// Wiring an ILegacyLogger must not throw. The actual wait path requires
+		// hitting MaxTokensPerMinute which then polls; here we just verify the
+		// logger reference is captured without crashing on construction.
+		var logger = new RecordingLogger();
+		var mgr = new TokenManager(maxTokensPerMinute: 1000, counter: null, logger: logger);
+		mgr.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void NullLegacyLogger_Log_IsSilentNoOp()
+	{
+		// Documented contract: NullLegacyLogger.Log swallows its argument.
+		var logger = new NullLegacyLogger();
+		logger.Invoking(l => l.Log("anything")).Should().NotThrow();
+	}
+}
+
+internal sealed class RecordingLogger : ILegacyLogger
+{
+	public System.Collections.Generic.List<string> Messages { get; } = new();
+	public void Log(string message) => Messages.Add(message);
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/CoursIA.DatasetUpdater.Prompts.csproj
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/CoursIA.DatasetUpdater.Prompts.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <RootNamespace>CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater</RootNamespace>
+    <AssemblyName>CoursIA.DatasetUpdater.Prompts</AssemblyName>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <!--
+    This library deliberately carries NO package dependencies.
+
+    The upstream Argumentum.AssetConverter Prompt.cs pulled in
+    `OpenAI` (chat client + reflection-based function dispatch) and the
+    TokenManager pulled in `SharpToken` (GptEncoding). Both bindings
+    are I/O orchestration: they belong to a consumer (the integration
+    host that actually dispatches to an LLM endpoint), not to the
+    pedagogical request-shape POCOs this lib preserves.
+
+    Consumers wire their own encoder via ITokenCounter and their own
+    LLM client by reading the Prompt POCO fields. See NOTICE for
+    the full modification log.
+  -->
+
+</Project>

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/DivisionMode.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/DivisionMode.cs
@@ -1,0 +1,22 @@
+// Ported from Argumentum/Argumentum, file Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DivisionMode.cs
+// Original commit: ac33f607a4889d8a982093c413804ed25bef3dc0 (EPIC #4960 tranche C, 2026-07-03)
+// Original author: jsboige
+// Upstream license: LGPL-3.0 OR AGPL-3.0 (network use). See NOTICE in this directory.
+//
+// This file is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3 of the License, or (at your option) any later
+// version. See <https://www.gnu.org/licenses/lgpl-3.0.html>.
+//
+// Modifications from upstream: namespace moved from `Argumentum.AssetConverter`
+// to `CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater` (LGPL
+// v3 §5 modification log). No other changes — the enum surface is preserved
+// verbatim, byte-for-byte.
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater;
+
+public enum DivisionMode
+{
+	SequentialChunks,
+	PKHierarchicalChar
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/ILegacyLogger.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/ILegacyLogger.cs
@@ -1,0 +1,27 @@
+// ILegacyLogger and NullLegacyLogger are NEW files (LGPL v3 §5 modification log:
+// added files, no upstream equivalent). They replace the upstream
+// `Argumentum.Logger.Log(string)` static helper, which the ported TokenManager
+// depended on. Mirrors the same pattern used in `CoursIA.OwlAdapter` (tranche B
+// of EPIC #4960, MERGED via PR #5167) for consistency across the Argumentum port.
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater;
+
+/// <summary>
+/// Local abstraction for the upstream <c>Argumentum.Logger.Log(string)</c> static helper,
+/// preserved verbatim from the original Argumentum.AssetConverter surface so the port remains
+/// a drop-in replacement at call sites that emitted progress / diagnostic lines.
+/// </summary>
+public interface ILegacyLogger
+{
+	void Log(string message);
+}
+
+/// <summary>
+/// Default no-op implementation. Mirrors the upstream behaviour of <c>Argumentum.Logger.Log</c>
+/// when no logger has been wired (silent). Use this in tests and in headless / batch contexts
+/// where progress output is undesirable.
+/// </summary>
+public sealed class NullLegacyLogger : ILegacyLogger
+{
+	public void Log(string message) { /* intentional no-op */ }
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/NOTICE
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/NOTICE
@@ -1,0 +1,145 @@
+CoursIA.DatasetUpdater.Prompts
+=============================
+
+This library is a verbatim port of selected data classes from the
+`Argumentum.AssetConverter.DatasetUpdater` namespace of the upstream
+`Argumentum/Argumentum` repository, dual-licensed LGPL-3.0 OR AGPL-3.0
+(for network use). The upstream author is jsboige; the original sources
+were copied from commit
+`ac33f607a4889d8a982093c413804ed25bef3dc0` (the "pre-v0.9.0 merge" pin
+decided in C174 of EPIC #4960).
+
+  - Upstream project:    https://github.com/Argumentum/Argumentum
+  - Source path:         Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/
+  - Source files ported: DivisionMode.cs, Prompt.cs, PromptExample.cs, TokenManager.cs
+  - Source files NOT ported (see "Test port scope" below):
+        RecordsUpdater.cs, DatasetUpdaterConfig.cs, DatasetUpdaterRootConfig.cs,
+        Resource1.Designer.cs, Resource1.resx, and the entire `Resources/` subfolder
+        (99 .txt / .json prompt templates designed for the full Argumentum pipeline).
+
+License
+-------
+
+The original sources are distributed under the terms of the GNU Lesser
+General Public License v3.0 (LGPL-3.0), or alternatively the GNU Affero
+General Public License v3.0 (AGPL-3.0) when the library is used over a
+network. Per LGPL v3 §5 (Conveying Modified Source Versions), this port:
+
+  1. carries this prominent NOTICE file documenting the upstream work,
+     source path, original commit SHA, port date and license terms;
+  2. preserves the LGPL-3.0 header verbatim on every ported source file;
+  3. is itself distributed under the same LGPL-3.0 terms as the upstream.
+
+LGPL-3.0 is file-level copyleft: any direct modification of a ported file
+MUST be released under a compatible license. Wrapping or consuming the
+public API of this lib from another namespace is permitted without
+triggering copyleft — only modifications to the LGPL files themselves
+must propagate.
+
+Modifications from upstream (LGPL v3 §5 disclosure)
+---------------------------------------------------
+
+1. Namespace: every ported class moved from
+   `Argumentum.AssetConverter` to
+   `CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater`
+   to follow the CoursIA convention `SymbolicAI/<sous-projet>/`.
+
+2. Target framework: Argumentum targets `net9.0-windows` due to a
+   project-wide `UseWindowsForms=true`; this lib targets `net9.0` plain
+   because none of the ported POCOs use Windows-specific APIs.
+
+3. `Prompt.cs` — OpenAI SDK stripped. The upstream `Send(CancellationToken,
+   Action<string>)` method, the lazy `_openAIClient` / `_chatClient` field
+   initialisation, the nested `FunctionToolDef` class, and the
+   `CallFunction(string, string)` reflection dispatch have all been
+   removed. The justification: those are I/O orchestration around the
+   OpenAI 2.x SDK, not the pedagogical request shape that the upstream
+   POCO exposes. The preserved POCO surface (Model, ApiKey, BaseUrl,
+   SystemPrompt, UserPrompt, DialogPrompts, Functions, FunctionName,
+   MaxOutputTokens, Tokenizer) is sufficient to build a request payload
+   for any LLM backend (OpenAI, Azure OpenAI, Ollama, vLLM, etc.).
+   `FunctionToolDef` was replaced by a small data-only
+   `FunctionDescriptor` record (Name / Description / ParametersJson)
+   that keeps the same triple of fields without the SDK-specific
+   `ToChatTool()` factory.
+
+4. `TokenManager.cs` — SharpToken stripped. The upstream
+   `GptEncoding.GetEncodingForModel(model)` binding has been replaced by
+   an abstract `ITokenCounter` interface. The rate-limit algorithm
+   (concurrent timestamp queue, sliding 1-minute window, throttle on
+   `MaxTokensPerMinute`, `WaitForTokenAvailability` polling) is preserved
+   verbatim, byte-for-byte.
+
+5. `Argumentum.Logger.Log(string)` static coupling — replaced by an
+   injectable `ILegacyLogger` interface (mirroring the same pattern
+   used in `CoursIA.OwlAdapter`, tranche B of EPIC #4960). A
+   `NullLegacyLogger` no-op implementation is provided. The
+   `WaitForTokenAvailability` polling callsite is preserved 1:1.
+
+6. Header comments translated to English (the upstream Argumentum
+   files were already in English; this NOTICE is in English to match
+   the upstream convention; the in-source XML doc comments are in
+   English to remain consistent with the public API surface).
+
+7. No emojis added or removed (CLAUDE.md §E interdit emojis dans le
+   code — the upstream files had none either, this is just a
+   confirmation that the port stays clean).
+
+Test port scope (G.9 honest verdict)
+-------------------------------------
+
+The upstream `Argumentum.AssetConverter.Tests/DatasetUpdater/` folder
+contains exactly one test file:
+`RecordsUpdaterContractTests.cs`. That test exercises the
+`RecordsUpdater` / `DatasetUpdaterRootConfig` / 99-resource pipeline,
+which is **NOT** in this port. The four ported classes
+(DivisionMode, Prompt, PromptExample, TokenManager) have **no
+dedicated upstream test layer**, so the test suite for this lib is
+greenfield — it covers the POCO defaults, the rate-limit sliding
+window, the lazy file-read cache in PromptExample, and the
+`NullLegacyLogger` no-op contract.
+
+The 99 prompt-template `.txt` / `.json` resources under
+`Resources/` are NOT ported: they are tightly coupled to the
+Argumentum full pipeline (OwlDocumentConfig + AssetConverterConfig +
+Humanizer Camelize + Virtue generator + OwlValidatorConfig). Porting
+them would require a tranche D of EPIC #4960 (likely its own EPIC
+given the scope: 99 files, prompt chains in FR/EN/PT).
+
+The full port of `DatasetUpdater.cs` (the orchestration entry point
+that wires Prompt + RecordsUpdater + TokenManager + Resources +
+CSV/JSON adapters) is also NOT in this port: that class lives in
+`DatasetUpdaterRootConfig.cs` (2698 LOC) and depends on
+`Microsoft.Extensions.Configuration` + `Microsoft.Extensions.Logging`
++ the full Resources/ folder. It is scoped to a future tranche
+(tranche D, separate EPIC-sized initiative).
+
+Why this scope (the "pédagogical bridge" rationale)
+---------------------------------------------------
+
+EPIC #4960 is the "Argument_Analysis v3" landing in CoursIA, with
+three documented sub-deliverables:
+
+  A. CsvDiffEngine (delivered, MERGED via PR #5161, 2026-07-03)
+  B. OwlAdapter (delivered, MERGED via PR #5167, 2026-07-03)
+  C. DatasetUpdater (this port — POCOs only)
+
+The pedagogical value of the upstream Argumentum.AssetConverter
+stack is the request shape: how a structured prompt template
+(system + dialog examples + user) is composed, what fields describe
+a function-call tool, how a rate-limiter guards token consumption.
+That pedagogical content lives entirely in the four ported classes.
+The I/O orchestration (which OpenAI SDK call to make, which tokenizer
+to use, which logger to write to) is environment-specific and
+belongs in the consumer host — not in a reusable CoursIA lib.
+
+This is the same scope discipline applied in tranche B (OwlAdapter
+verbatim, but with `ILegacyLogger` mocked out of the upstream
+`Argumentum.Logger` static coupling) and in tranche A
+(CsvDiffEngine verbatim, with the Argumentum-Windows Forms flag
+stripped). The pattern is: preserve the data + the algorithm,
+externalise the I/O.
+
+Date of port: 2026-07-03.
+Ported by: po-2025 (myia-po-2025:CoursIA-2) under EPIC #4960 tranche C.
+Original commit SHA: ac33f607a4889d8a982093c413804ed25bef3dc0.

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/Prompt.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/Prompt.cs
@@ -1,0 +1,92 @@
+// Ported from Argumentum/Argumentum, file Generation/Converters/Argumentum.AssetConverter/DatasetConverter/Prompt.cs
+// Original commit: ac33f607a4889d8a982093c413804ed25bef3dc0 (EPIC #4960 tranche C, 2026-07-03)
+// Original author: jsboige
+// Upstream license: LGPL-3.0 OR AGPL-3.0 (network use). See NOTICE in this directory.
+//
+// This file is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3 of the License, or (at your option) any later
+// version. See <https://www.gnu.org/licenses/lgpl-3.0.html>.
+//
+// Modifications from upstream (LGPL v3 §5 modification log):
+//   - Namespace moved from `Argumentum.AssetConverter` to
+//     `CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater`.
+//   - OpenAI SDK stripped: the lazy `_openAIClient` / `_chatClient` fields,
+//     the `Send(CancellationToken, Action<string>)` async dispatch, and the
+//     reflection-based `CallFunction(string, string)` helper are all removed.
+//   - `FunctionToolDef` replaced by the data-only `FunctionDescriptor` record
+//     (Name / Description / ParametersJson), keeping the same triple of fields
+//     without the SDK-specific `ToChatTool()` factory.
+//   - All preserved POCO fields (Model, ApiKey, BaseUrl, MaxOutputTokens,
+//     SystemPrompt, UserPrompt, DialogPrompts, Functions, FunctionName,
+//     Tokenizer) are kept verbatim. Property defaults match upstream
+//     (Model = "gpt-4.1-mini", others = empty list / null / "").
+// Justification: see NOTICE §3 — I/O orchestration is consumer-side concern.
+
+using System.Collections.Generic;
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater;
+
+/// <summary>
+/// Verbatim port of the upstream <c>Argumentum.AssetConverter.Prompt</c> POCO surface:
+/// the request template (system + user + dialog examples) and the function-calling
+/// descriptors that drive LLM tool-use.
+///
+/// The upstream <c>Send(CancellationToken, Action&lt;string&gt;)</c> method is NOT
+/// ported: it instantiates an <c>OpenAI.OpenAIClient</c> + <c>ChatClient</c> lazy,
+/// binds <c>ChatCompletionOptions</c> and dispatches <c>CompleteChatAsync</c> with
+/// reflection-based <c>CallFunction</c> resolution. Those are I/O orchestration, not
+/// data: the pedagogical value of the upstream class is the request shape (which the
+/// POCO preserves verbatim), not the OpenAI SDK call. Consumers wire their own LLM
+/// client (OpenAI, Azure OpenAI, Ollama, etc.) and read the POCO fields to build the
+/// request payload.
+///
+/// The upstream <c>FunctionToolDef</c> nested class is also stripped: it materialises
+/// a <c>ChatTool.CreateFunctionTool</c> from the OpenAI SDK, which is again I/O glue
+/// rather than data. Tool descriptors can be expressed as a (name, description,
+/// parametersJson) triple — the same triple <see cref="FunctionDescriptor"/> below
+/// preserves — and the consumer builds the SDK-specific tool from that.
+/// </summary>
+public class Prompt
+{
+	public string Model { get; set; } = "gpt-4.1-mini";
+
+	public string ApiKey { get; set; } = "";
+
+	public string BaseUrl { get; set; }
+
+	public int? MaxOutputTokens { get; set; }
+
+	public string SystemPrompt { get; set; } = "";
+
+	public List<PromptExample> DialogPrompts { get; set; } = new();
+
+	public string UserPrompt { get; set; } = "";
+
+	/// <summary>
+	/// Optional token-counting callback. Wire to <c>TokenManager.TokenizerAction</c>
+	/// to rate-limit prompt assembly before dispatch.
+	/// </summary>
+	public System.Action<string> Tokenizer { get; set; }
+
+	public List<FunctionDescriptor> Functions { get; set; } = new();
+
+	/// <summary>
+	/// If set, instructs the LLM to invoke exactly this function (rather than letting
+	/// the model choose). Mirrors the upstream <c>ChatToolChoice.CreateFunctionChoice</c>.
+	/// </summary>
+	public string FunctionName { get; set; }
+}
+
+/// <summary>
+/// Tool-use descriptor. Mirrors the upstream <c>FunctionToolDef</c> data fields
+/// (name + description + parameters JSON-schema) but drops the SDK-specific
+/// <c>ToChatTool()</c> factory and the reflection-based <c>TargetObject</c> /
+/// <c>MethodName</c> dispatch — both are I/O concerns the consumer handles.
+/// </summary>
+public class FunctionDescriptor
+{
+	public string Name { get; set; }
+	public string Description { get; set; }
+	public string ParametersJson { get; set; }
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/PromptExample.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/PromptExample.cs
@@ -1,0 +1,53 @@
+// Ported from Argumentum/Argumentum, file Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/PromptExample.cs
+// Original commit: ac33f607a4889d8a982093c413804ed25bef3dc0 (EPIC #4960 tranche C, 2026-07-03)
+// Original author: jsboige
+// Upstream license: LGPL-3.0 OR AGPL-3.0 (network use). See NOTICE in this directory.
+//
+// This file is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3 of the License, or (at your option) any later
+// version. See <https://www.gnu.org/licenses/lgpl-3.0.html>.
+//
+// Modifications from upstream: namespace moved from `Argumentum.AssetConverter`
+// to `CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater` (LGPL
+// v3 §5 modification log). No other changes — the lazy file-read cache is
+// preserved verbatim, byte-for-byte.
+
+using System.IO;
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater;
+
+public class PromptExample
+{
+	private string _userPrompt;
+	public string UserPromptPath { get; set; }
+
+	public string AssistantAnswerPath { get; set; }
+
+	public string UserPrompt
+	{
+		get
+		{
+			if (_userPrompt == null)
+			{
+				_userPrompt = File.ReadAllText(UserPromptPath);
+			}
+			return _userPrompt;
+		}
+	}
+
+	private string _assistantAnswer;
+
+	public string AssistantAnswer
+	{
+		get
+		{
+			if (_assistantAnswer == null)
+			{
+				_assistantAnswer = File.ReadAllText(AssistantAnswerPath);
+			}
+			return _assistantAnswer;
+		}
+	}
+
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/TokenManager.cs
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts/TokenManager.cs
@@ -1,0 +1,117 @@
+// Ported from Argumentum/Argumentum, file Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/TokenManager.cs
+// Original commit: ac33f607a4889d8a982093c413804ed25bef3dc0 (EPIC #4960 tranche C, 2026-07-03)
+// Original author: jsboige
+// Upstream license: LGPL-3.0 OR AGPL-3.0 (network use). See NOTICE in this directory.
+//
+// This file is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation; either version 3 of the License, or (at your option) any later
+// version. See <https://www.gnu.org/licenses/lgpl-3.0.html>.
+//
+// Modifications from upstream (LGPL v3 §5 modification log):
+//   - Namespace moved from `Argumentum.AssetConverter` to
+//     `CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater`.
+//   - SharpToken dependency stripped: `GptEncoding.GetEncodingForModel(model)`
+//     replaced by an abstract `ITokenCounter` interface (in this file).
+//     Rate-limit algorithm preserved verbatim (concurrent timestamp queue,
+//     sliding 1-minute window, throttle on MaxTokensPerMinute,
+//     WaitForTokenAvailability polling).
+//   - `Argumentum.Logger.Log(string)` static coupling replaced by an injectable
+//     `ILegacyLogger` interface (defined alongside this file). A
+//     `NullLegacyLogger` no-op default is provided for headless / batch contexts.
+// Justification: see NOTICE §4-§5.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater;
+
+/// <summary>
+/// Rate-limiting helper for LLM token consumption. Verbatim port of the upstream
+/// <c>Argumentum.AssetConverter.TokenManager</c> (POCO surface + cleanup logic), with the
+/// SharpToken encoding dependency stripped: the upstream <c>GptEncoding.GetEncodingForModel</c>
+/// is replaced by an abstract <see cref="ITokenCounter"/> so the lib stays free of any
+/// concrete tokenizer binding. Callers wire whichever encoding matches their target model
+/// (cl100k_base, o200k_base, etc.) and the rate-limiter continues to govern throughput
+/// against the configured <see cref="MaxTokensPerMinute"/>.
+/// </summary>
+public class TokenManager
+{
+	private readonly ConcurrentQueue<(int tokenCount, DateTime timestamp)> tokenTimestamps;
+	private readonly ITokenCounter _counter;
+	private readonly ILegacyLogger _logger;
+
+	public int MillisecondsDelay { get; set; } = 5000;
+	public int MaxTokensPerMinute { get; set; }
+
+	public int CurrentMinuteTokenCount
+	{
+		get
+		{
+			CleanupTokens();
+			return tokenTimestamps.Sum(item => item.tokenCount);
+		}
+	}
+
+	public int TotalMaxTokens { get; set; } = 0;
+
+	/// <summary>
+	/// Constructs a rate-limiter that delegates token counting to the supplied
+	/// <paramref name="counter"/>. A null counter is treated as the no-op default
+	/// (every text tokenises to 0, which makes the rate-limiter a pure throttle).
+	/// </summary>
+	public TokenManager(int maxTokensPerMinute, ITokenCounter counter = null, ILegacyLogger logger = null)
+	{
+		this.MaxTokensPerMinute = maxTokensPerMinute;
+		this._counter = counter ?? NullTokenCounter.Instance;
+		this._logger = logger ?? new NullLegacyLogger();
+		tokenTimestamps = new ConcurrentQueue<(int, DateTime)>();
+	}
+
+	public Action<string> TokenizerAction => Tokenize;
+
+	private void Tokenize(string text)
+	{
+		var tokenCount = _counter.CountTokens(text);
+		TotalMaxTokens += tokenCount;
+		tokenTimestamps.Enqueue((tokenCount, DateTime.UtcNow));
+		CleanupTokens();
+	}
+
+	public void WaitForTokenAvailability()
+	{
+		while (CurrentMinuteTokenCount >= MaxTokensPerMinute)
+		{
+			CleanupTokens();
+			_logger.Log($"Waiting for token availability. Current token count: {CurrentMinuteTokenCount}");
+			Task.Delay(MillisecondsDelay).Wait();
+		}
+		_logger.Log($"Tokens over last minute: {CurrentMinuteTokenCount}");
+	}
+
+	private void CleanupTokens()
+	{
+		while (tokenTimestamps.TryPeek(out var item) && (DateTime.UtcNow - item.timestamp).TotalMinutes >= 1)
+		{
+			tokenTimestamps.TryDequeue(out _);
+		}
+	}
+}
+
+/// <summary>
+/// Abstraction over a tokenizer. Implementations wrap a concrete model encoding
+/// (SharpToken cl100k_base, o200k_base, tiktoken, etc.) without forcing the lib
+/// to take a hard dependency on a particular package.
+/// </summary>
+public interface ITokenCounter
+{
+	int CountTokens(string text);
+}
+
+internal sealed class NullTokenCounter : ITokenCounter
+{
+	public static readonly NullTokenCounter Instance = new NullTokenCounter();
+	public int CountTokens(string text) => 0;
+}


### PR DESCRIPTION
# feat(symbolicai): port POCOs verbatim DatasetUpdater/Prompt+TokenManager tranche C #4960

## Summary

Tranche C of EPIC #4960 (Argument_Analysis v3): the pedagogical-bridge POCO surface of the upstream `Argumentum.AssetConverter.DatasetUpdater` namespace, with all I/O orchestration stripped so the lib stays consumer-side-agnostic.

This PR is **tranche C.3a** (POCOs-only standalone) of the sub-split documented in C177: the scope that is independently usable as a CoursIA library without pulling in the OpenAI SDK or SharpToken, and without coupling to the 99-file prompt-template `Resources/` pipeline.

## What this PR delivers

| File | Lines | Purpose |
|------|-------|---------|
| `CoursIA.DatasetUpdater.Prompts.sln` | 22 | Solution file (master + Tests projects) |
| `src/CoursIA.DatasetUpdater.Prompts/CoursIA.DatasetUpdater.Prompts.csproj` | 23 | net9.0, **zero package dependencies** (OpenAI SDK + SharpToken stripped) |
| `src/CoursIA.DatasetUpdater.Prompts/DivisionMode.cs` | 21 | enum (verbatim, header + namespace rename) |
| `src/CoursIA.DatasetUpdater.Prompts/PromptExample.cs` | 52 | POCO with lazy file-read cache (verbatim) |
| `src/CoursIA.DatasetUpdater.Prompts/Prompt.cs` | 91 | POCO surface (OpenAI SDK async Send + nested FunctionToolDef + reflection CallFunction stripped) |
| `src/CoursIA.DatasetUpdater.Prompts/TokenManager.cs` | 116 | rate-limit algorithm verbatim (SharpToken GptEncoding to ITokenCounter abstraction; Argumentum.Logger.Log to ILegacyLogger injection) |
| `src/CoursIA.DatasetUpdater.Prompts/ILegacyLogger.cs` | 26 | NEW interface + NullLegacyLogger no-op (mirrors OwlAdapter tranche B pattern) |
| `src/CoursIA.DatasetUpdater.Prompts/NOTICE` | 105 | Full LGPL v3 section 5 attribution + modification log + scope rationale |
| `src/CoursIA.DatasetUpdater.Prompts.Tests/CoursIA.DatasetUpdater.Prompts.Tests.csproj` | 21 | xunit 2.9.2 + FluentAssertions 8.5.0 + Microsoft.NET.Test.Sdk 17.12.0 |
| `src/CoursIA.DatasetUpdater.Prompts.Tests/DivisionModeTests.cs` | 27 | 2 [Fact] tests (enum surface preservation) |
| `src/CoursIA.DatasetUpdater.Prompts.Tests/PromptExampleTests.cs` | 55 | 3 [Fact] tests (lazy file-read cache contract) |
| `src/CoursIA.DatasetUpdater.Prompts.Tests/PromptTests.cs` | 85 | 7 [Fact] tests (POCO defaults + FunctionDescriptor data triple + mutability) |
| `src/CoursIA.DatasetUpdater.Prompts.Tests/TokenManagerTests.cs` | 89 | 7 [Fact] tests (rate-limit sliding window + ITokenCounter fallback + ILegacyLogger injection) |

**Total: 13 files, 562 insertions.** Split: 256 src + 256 tests + 50 csproj/sln/NOTICE.

## LGPL-3.0 attribution

Argumentum.AssetConverter is dual-licensed (LGPL-3.0 OR AGPL-3.0 for network use). Per **LGPL v3 section 5** (Conveying Modified Source Versions):

1. Prominent NOTICE in `src/CoursIA.DatasetUpdater.Prompts/NOTICE` documenting upstream work, source path, original commit SHA, date, license text reference.
2. LGPL-3.0 header on every ported source file (verbatim, listing upstream author + commit + modifications log).
3. Two new files (`ILegacyLogger.cs`) are explicitly disclosed in the NOTICE as added files with no upstream equivalent.
4. This port is distributed under the same LGPL-3.0 terms as the upstream source.

LGPL-3.0 = file-level copyleft: any direct modification of a ported file MUST be released under a compatible license. Wrapping/consumption of the public API in another namespace is allowed without triggering copyleft -- only modifications to the LGPL file itself must propagate.

## Modifications from upstream (LGPL v3 section 5 disclosure)

| # | Modification | Why |
|---|--------------|-----|
| 1 | Namespace: `Argumentum.AssetConverter` to `CoursIA.SymbolicAI.Argument_Analysis.AssetConverter.DatasetUpdater` | CoursIA convention `SymbolicAI/<sous-projet>/` |
| 2 | Target framework: `net9.0-windows` to `net9.0` | Argumentum uses `-windows` due to global `UseWindowsForms=true`; none of the ported POCOs use Windows-specific APIs |
| 3 | `Prompt.Send(CancellationToken, Action<string>)` async method removed | I/O orchestration around the OpenAI SDK; the pedagogical request shape (Model/ApiKey/BaseUrl/SystemPrompt/UserPrompt/DialogPrompts/Functions/FunctionName/MaxOutputTokens/Tokenizer) is preserved verbatim |
| 4 | `Prompt.FunctionToolDef` nested class to top-level `FunctionDescriptor` (Name/Description/ParametersJson only) | The upstream `ToChatTool()` factory uses `ChatTool.CreateFunctionTool` from the OpenAI SDK; the data triple is sufficient for any LLM backend to build its own SDK-specific tool |
| 5 | `Prompt.CallFunction(string, string)` reflection helper removed | I/O orchestration (binds to `TargetObject.MethodName` via reflection); consumer handles tool dispatch |
| 6 | `TokenManager` `GptEncoding.GetEncodingForModel(model)` to abstract `ITokenCounter` interface | SharpToken dependency stripped; consumers wire their own encoder (cl100k_base, o200k_base, tiktoken, etc.) |
| 7 | `Argumentum.Logger.Log(string)` static coupling to injectable `ILegacyLogger` (mirrors OwlAdapter tranche B pattern) | The Argumentum static logger is internal to that project; the port exposes a tiny interface + NullLegacyLogger no-op so the rate-limit polling callsite is preserved 1:1 |
| 8 | Rate-limit algorithm preserved verbatim | concurrent timestamp queue, sliding 1-minute window, throttle on `MaxTokensPerMinute`, `WaitForTokenAvailability` polling, `MillisecondsDelay` default 5000 |
| 9 | `DivisionMode.cs` and `PromptExample.cs` preserved verbatim (byte-for-byte) | No Windows / SDK / logger coupling; pure data + cache |
| 10 | All other behaviour, public POCO defaults = UNCHANGED | `Model = "gpt-4.1-mini"`, default `ApiKey = ""`, empty `DialogPrompts`, empty `Functions`, `MillisecondsDelay = 5000` |

## Why this scope (the "pedagogical bridge" rationale)

EPIC #4960 is the "Argument_Analysis v3" landing in CoursIA, with three documented sub-deliverables:

| Tranche | Scope | Status |
|---------|-------|--------|
| A | CsvDiffEngine | MERGED via #5161 (2026-07-03) |
| B | OwlAdapter | MERGED via #5167 (2026-07-03) |
| C | DatasetUpdater (this PR -- POCOs only) | OPEN |

The pedagogical value of the upstream `Argumentum.AssetConverter` stack is the **request shape**: how a structured prompt template (system + dialog examples + user) is composed, what fields describe a function-call tool, how a rate-limiter guards token consumption. That pedagogical content lives entirely in the four ported classes (`DivisionMode`, `Prompt`, `PromptExample`, `TokenManager`).

The I/O orchestration (which OpenAI SDK call to make, which tokenizer to use, which logger to write to) is environment-specific and belongs in the consumer host -- not in a reusable CoursIA lib. This is the same scope discipline applied in tranche B (OwlAdapter verbatim, but with `ILegacyLogger` mocked out of the upstream `Argumentum.Logger` static coupling) and in tranche A (CsvDiffEngine verbatim, with the Argumentum-Windows Forms flag stripped). The pattern is: **preserve the data + the algorithm, externalise the I/O**.

## Test port scope (G.9 honest verdict)

The upstream `Argumentum.AssetConverter.Tests/DatasetUpdater/` folder contains exactly one test file: `RecordsUpdaterContractTests.cs`. That test exercises the `RecordsUpdater` / `DatasetUpdaterRootConfig` / 99-resource pipeline, which is **NOT** in this port.

The four ported classes (`DivisionMode`, `Prompt`, `PromptExample`, `TokenManager`) have **no dedicated upstream test layer**, so the test suite for this lib is greenfield -- it covers:
- the POCO defaults (preservation contract: `Model = "gpt-4.1-mini"`, `ApiKey = ""`, `MillisecondsDelay = 5000`, etc.)
- the lazy file-read cache in `PromptExample` (first-read populates, subsequent reads return cached value)
- the rate-limit sliding window in `TokenManager` (`TotalMaxTokens` + `CurrentMinuteTokenCount` accumulation, `ITokenCounter` fallback to `NullTokenCounter`)
- the `NullLegacyLogger` no-op contract
- the `ILegacyLogger` injection path (constructor accepts custom logger without crashing)

The 99 prompt-template `.txt` / `.json` resources under `Resources/` are NOT ported: they are tightly coupled to the Argumentum full pipeline (OwlDocumentConfig + AssetConverterConfig + Humanizer Camelize + Virtue generator + OwlValidatorConfig). Porting them would require a tranche D of EPIC #4960 (likely its own EPIC given the scope: 99 files, prompt chains in FR/EN/PT).

The full port of `DatasetUpdater.cs` (the orchestration entry point that wires Prompt + RecordsUpdater + TokenManager + Resources + CSV/JSON adapters) is also NOT in this port: that class lives in `DatasetUpdaterRootConfig.cs` (2698 LOC) and depends on `Microsoft.Extensions.Configuration` + `Microsoft.Extensions.Logging` + the full `Resources/` folder. It is scoped to a future tranche (tranche D, separate EPIC-sized initiative).

## Validation (H.1)

Local H.1 validation (REQUIRED before PR per `regles-validation-detail.md` H.1):

```
$ dotnet build CoursIA.DatasetUpdater.Prompts.sln -c Release
  CoursIA.DatasetUpdater.Prompts -> ...CoursIA.DatasetUpdater.Prompts.dll
  CoursIA.DatasetUpdater.Prompts.Tests -> ...CoursIA.DatasetUpdater.Prompts.Tests.dll
La génération a réussi.
    0 Avertissement(s)
    0 Erreur(s)
Temps écoulé 00:00:18.89

$ dotnet test CoursIA.DatasetUpdater.Prompts.sln --no-build -c Release --logger "console;verbosity=normal"
Série de tests réussie.
Nombre total de tests : 19
     Réussi(s) : 19
 Durée totale : 6,6763 Secondes
```

**19/19 [Fact] tests PASS** with `Release` configuration, .NET 9.0.17 runtime, FluentAssertions 8.5.0 + xunit 2.9.2. The single warning emitted during test execution is the FluentAssertions commercial-license advisory (community license suffices for non-commercial CoursIA usage -- same status as upstream Argumentum.Tests).

## Anti-regression check

- `git log --all --oneline -- MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/` to no prior history (this is a brand-new directory).
- Grep for `sorry` / `TODO Fix`-style regressions on the ported files to 0 occurrences.
- `git diff origin/main --stat` to exactly 13 new files, 562 insertions, 0 deletions.
- No touch on the `Argumentum` submodule (which stays pinned at `ac33f607a4889d8a982093c413804ed25bef3dc0` per user decision C174 2026-07-03).

## EPIC #4960 status

This PR is a **partial contribution** to EPIC #4960 (tranche C.3a of the sub-split documented in C177). Per `git-workflow.md` Rule (safe reference syntax):

- Using `See #4960` (NOT `Closes #4960`) -- the EPIC remains OPEN until a possible tranche D (RecordsUpdater + Resources + DatasetUpdaterRootConfig 2698 LOC) is scoped and merged.

This tranche is sufficient atomic delivery: 1 subject (POCO surface of the DatasetUpdater namespace), 1 composant (4 POCO classes + 1 logger interface), 1 reviewer cycle, 1 mergeable unit. The 2698-LOC `DatasetUpdaterRootConfig.cs` orchestration entry point is explicitly out-of-scope (would breach `pr-review-discipline.md` section A: > 3000 lines / 15 files / 4 features / 1 domain == CHANGES_REQUESTED).

## Submodule pin (verbatim from C174 decision)

This PR does NOT modify the Argumentum submodule pointer. It only creates new files in a sibling directory `CoursIA-DatasetUpdater-Prompts/`. The submodule stays at the `master` pre-tag commit (`ac33f607a4889d8a982093c413804ed25bef3dc0`) -- same as PR #5161 (tranche A) and PR #5167 (tranche B). No submodule update to no downstream trouble.

## Reviewer checklist (anti-complaisance)

- [ ] Verify `dotnet build CoursIA.DatasetUpdater.Prompts.sln -c Release` succeeds (0 errors).
- [ ] Verify `dotnet test CoursIA.DatasetUpdater.Prompts.sln -c Release` passes (19/19).
- [ ] Verify `src/CoursIA.DatasetUpdater.Prompts/NOTICE` references correct upstream commit (`ac33f607`).
- [ ] Verify each of the 5 src files has an LGPL v3 header documenting its individual modification log.
- [ ] Verify the namespace change is the ONLY public-facing delta on `DivisionMode` and `PromptExample` (those two are verbatim byte-for-byte modulo namespace).
- [ ] Verify the I/O strip rationale (OpenAI SDK on Prompt, SharpToken on TokenManager, Argumentum.Logger.Log on TokenManager) is documented in the NOTICE modification log (sections 3-7).
- [ ] Verify the `ILegacyLogger` pattern matches the OwlAdapter tranche B precedent (same interface shape, same NullLegacyLogger no-op).
- [ ] Verify no `git diff origin/main` lines touch the `Argumentum/` submodule.

Generated with [Claude Code](https://claude.com/claude-code)