### PR TITLE
fix(notebook-tools): count_exercises detect C# // exercise comments (#2161 blind-spot)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -11,8 +11,9 @@ that UNDERCOUNTED two real cases (the G.1 finding from the #2161 audit cycle):
      The strict `^#+\\s*Exercice` requires the word right after the hashes with
      no intervening number/dash, so `## 8. Exercice` was missed.
   2. Exercise CODE cells with NO markdown header at all -- a stub code cell
-     whose first comment is `# Exercice ...` but is not preceded by any markdown
-     "Exercice" header. A header-only counter never sees these.
+     whose first comment is `# Exercice ...` (Python/F#/Lean) or
+     `// Exercice ...` (C# / .NET Interactive) but is not preceded by any
+     markdown "Exercice" header. A header-only counter never sees these.
 
 This tool counts `\bexercice\b` ANYWHERE in a markdown header (numbered or not)
 PLUS stub code cells whose source comments reference an exercise, then
@@ -179,8 +180,23 @@ def _is_stub_code(source: str) -> bool:
 
 
 def _code_cell_mentions_exercise(source: str) -> bool:
-    """A code cell whose comments name an exercise (`# Exercice ...`)."""
-    comments = [ln for ln in source.split("\n") if ln.strip().startswith("#")]
+    """A code cell whose comments name an exercise.
+
+    Language-agnostic comment detection: a full-line comment is one whose
+    stripped form starts with ``#`` (Python / F# / Lean) OR ``//`` (C# /
+    .NET Interactive). Inline trailing comments (``code // Exercice``) are
+    intentionally NOT matched -- a stub marker is a full-line comment, not a
+    reference buried after executable code.
+
+    Historically this only matched ``#``, which made every C# notebook blind
+    to ``// Exercice N`` stubs (the .NET family uses ``//``). Agents then
+    re-discovered the undercount ad-hoc, notebook by notebook (Probas/Infer,
+    ML.Net). Matching ``//`` here closes that blind-spot at the source.
+    """
+    comments = [
+        ln for ln in source.split("\n")
+        if ln.strip().startswith("#") or ln.strip().startswith("//")
+    ]
     blob = "\n".join(comments)
     return bool(EXERCISE_WORD_RE.search(blob) or EXERCISE_WORD_EN_RE.search(blob))
 

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -192,6 +192,53 @@ class TestCodeCellOnlyExercise:
         result = count_exercises_in_notebook(nb)
         assert result.count == 1
 
+    def test_csharp_double_slash_comment_exercise_is_counted(self, tmp_path):
+        """The .NET / C# family uses ``//`` for line comments (not ``#``).
+        A stub code cell whose ``// Exercice ...`` comment names an exercise
+        with NO preceding markdown header must be counted -- historically this
+        was the canonical-tool blind-spot (agents re-discovered it ad-hoc on
+        Probas/Infer and ML.Net).
+        """
+        nb = _write_nb(
+            tmp_path / "cs.ipynb",
+            [
+                _md("# Titre C#"),
+                # C# code-cell-only exercise, no markdown header above:
+                _code(
+                    "// Exercice : backdoor adjustment\n"
+                    "// TODO etudiant : implement SCM\n"
+                    "pass"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            "C# // Exercice stub (no markdown header) must count"
+        )
+        assert result.exercises[0].detected_by == "code_cell_comment"
+
+    def test_inline_csharp_comment_after_code_is_not_a_stub_marker(
+        self, tmp_path
+    ):
+        """An inline trailing ``// Exercice`` after executable code is a
+        reference, not a stub marker -- the exercise-word must be on a
+        full-line comment to count. (Guards against over-counting.)
+        """
+        nb = _write_nb(
+            tmp_path / "inline.ipynb",
+            [
+                _md("# Titre"),
+                _code(
+                    "var x = Compute();  // Exercice reference inline\n"
+                    "Console.WriteLine(x);"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 0, (
+            "Inline // Exercice after code must NOT count as a stub"
+        )
+
     def test_solution_code_cell_is_not_an_exercise(self, tmp_path):
         """A code cell whose comments mention 'Exercice' but holds a COMPLETE
         solution (not a stub) is an example, not an exercise -- not counted.


### PR DESCRIPTION
## What

Fix the canonical #2161 exercise counter (`scripts/notebook_tools/count_exercises.py`) — it was **blind to C# / .NET Interactive `//` line comments**. `_code_cell_mentions_exercise` only matched `#` (Python/F#/Lean), so every C# notebook labeling its exercise stubs with `// Exercice N` comments (no preceding markdown header) was undercounted.

## The recurring blind-spot (why this is worth a tool fix)

Across recent cycles, multiple agents hit this blind-spot **ad-hoc**:
- po-2023 on Infer-14 (C# `// Exercice` stubs hidden under `## 11. Exercices`) — had to manually discover 4 hidden stubs
- po-2026 c.203 (regex missed C# `// TODO` stubs)
- po-2024 (me) c.16 on QC-Py (markdown-only scan flaw)

Each agent re-discovered the undercount notebook-by-notebook instead of fixing the canonical tool once. This PR closes the blind-spot at the source.

## G.1 proof — real exercises invisible before the fix

8 genuine C# exercises across Probas/Infer were invisible to the tool:

```text
Infer-1-Utility-Foundations.ipynb  cell[13] // Exercice : Verification axiome independance
Infer-1-Utility-Foundations.ipynb  cell[25] // Exercice : Decision medicale test sequentiel
Infer-4-Multi-Attribute.ipynb      cell[19] // Exercice : Swing weights
Infer-4-Multi-Attribute.ipynb      cell[35] // Exercice : Sensibilite multi-attributs
Infer-6-Value-Information.ipynb    cell[47] // Exercice : Decision test medical
Infer-13-Debugging.ipynb           cell[18] // Exercice : Modele melange gaussien
Infer-13-Debugging.ipynb           cell[31] // Exercice : Test depistage prior
Infer-14-Causal-Inference.ipynb    cell[31] // Exercice 4 : Paradoxe Simpson
```

## Fix

`_code_cell_mentions_exercise` now matches full-line comments starting with `#` **OR** `//`. Inline trailing comments (`code // Exercice`) are intentionally excluded — a stub marker is a full-line comment, not a reference buried after executable code.

## Impact (verified firsthand)

| Scope | Before | After |
|-------|--------|-------|
| Probas total exercises | 186 | 196 (+8 hidden + 2 paired edges) |
| Probas sub-threshold | 2 | 1 (one notebook legitimately crossed) |
| Repo-wide exercises | — | 2308 / 604 conforming of 786 scanned |
| QC-Py (Python) exercises | 176 | 176 (**unchanged — no regression**) |

## Tests

**25/25 pass** (23 existing + 2 new):
- `test_csharp_double_slash_comment_exercise_is_counted` — the fix (C# `//` stub counted)
- `test_inline_csharp_comment_after_code_is_not_a_stub_marker` — guards against over-counting inline `//`

```
tests\test_count_exercises.py::TestCodeCellOnlyExercise::test_csharp_double_slash_comment_exercise_is_counted PASSED
tests\test_count_exercises.py::TestCodeCellOnlyExercise::test_inline_csharp_comment_after_code_is_not_a_stub_marker PASSED
============================== 25 passed in 0.22s ==============================
```

## Pre-existing limitation surfaced (not introduced — out of scope here, G.4 atomic)

The forward-only dedup (markdown header → next code cell within 3) does NOT pair a code stub that **precedes** its descriptive markdown header (a notebook layout where a stub ends a section, header introduces the next). This affects `#` and `//` equally (verified with a synthetic `#` test). Not introduced by this PR; documented for a separate improvement.

## Scope

- 2 files, +67/-4 (count_exercises.py logic + docstring; 2 new tests).
- Pure tooling — no notebooks touched (no C.2 re-exec needed).
- Catalog byte-identical to `main` (R1). Fresh base `origin/main` (R2).

See #2161 (3-exercises convention tooling — the convention rollout is ongoing even though the tracker issue is closed).

Co-Authored-By: Claude-Code <noreply@anthropic.com>