### PR TITLE
fix(sudoku-10): silence setup-cell machine-path leak (#3436, cause A)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -79,27 +79,14 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: ortools in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (9.15.6755)\n",
-      "Requirement already satisfied: absl-py>=2.0.0 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (2.4.0)\n",
-      "Requirement already satisfied: numpy>=2.0.2 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (2.4.4)\n",
-      "Requirement already satisfied: pandas>=2.0.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from ortools) (3.0.3)\n",
-      "Requirement already satisfied: protobuf<6.34,>=6.33.1 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (6.33.6)\n",
-      "Requirement already satisfied: typing-extensions>=4.12 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (4.15.0)\n",
-      "Requirement already satisfied: immutabledict>=3.0.0 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from ortools) (4.3.1)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas>=2.0.0->ortools) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas>=2.0.0->ortools) (2025.3)\n",
-      "Requirement already satisfied: six>=1.5 in ~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from python-dateutil>=2.8.2->pandas>=2.0.0->ortools) (1.17.0)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import sys\n",
-    "!{sys.executable} -m pip install ortools"
+    "# Installation silencieuse d'OR-Tools (uniquement si absent de l'environnement)\n",
+    "import subprocess, sys\n",
+    "try:\n",
+    "    import ortools  # noqa: F401\n",
+    "except ImportError:\n",
+    "    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'ortools'])\n"
    ]
   },
   {


### PR DESCRIPTION
## Context (See #3436)

`Sudoku-10-ORTools-Python.ipynb` c1 (`!{sys.executable} -m pip install ortools`) **leaked machine paths** in its committed output via pip's "Requirement already satisfied" noise:

```
Requirement already satisfied: ortools in ~\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.13_...\site-packages
Requirement already satisfied: pandas>=2.0.0 in C:\ProgramData\miniconda3\Lib\site-packages
... (10 lines)
```

This is **cause A (env/cwd)** per the #3436 Stop & Repair taxonomy: a setup cell printing dynamically-resolved install locations. `Sudoku` family had **52 path-leak findings** in outputs (mostly this pattern across setup cells) — never scanned before (po-2026 did Lean, po-2024 did QC).

## Changement — import-guard (pip ne tourne que si le paquet est absent)

`c1` devient :

```python
# Installation silencieuse d'OR-Tools (uniquement si absent de l'environnement)
import subprocess, sys
try:
    import ortools  # noqa: F401
except ImportError:
    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'ortools'])
```

- **Si OR-Tools est installé** (cas normal étudiant/machine) : `import ortools` réussit, pip **n'est jamais invoqué** → sortie vide, **aucun chemin machine**. C'est le déterminisme clé : on évite même les avertissements parasites de pip (le kernel `python3` local a des dist-info orphelines `~penai`/`~ydantic_core` qui émettent `WARNING: Ignoring invalid distribution ...` au moindre appel pip — verrouillées en écriture, nécessiteraient UAC — l'import-guard les court-circuite entièrement).
- **Si OR-Tools est absent** : `subprocess.check_call` affiche la progression d'installation (héritée du stdout) — sortie pédagogiquement légitime pour l'étudiant qui découvre.

C'est une **vraie ré-exécution** (nbclient, kernel `python3`, capture réelle `[]`), **pas un hand-scrub** (Stop & Repair règle 6 : on corrige la cause, on ré-exécute, on ne maquille jamais la sortie).

## Validation

| Critère | Avant | Après |
|---|---|---|
| `scan_machine_path_leaks.py` (outputs) | 1 cell leaky (10 lignes) | **0 leak** ✓ |
| C.1 (`raise NotImplementedError`/`assert False`/`1/0`) | 0 | **0** ✓ |
| C.2 (ec + outputs cohérents) | ec=1, 1 stream output | **ec=1, `outputs: []`** (cohérent — cell silencieuse) ✓ |
| C.3 (scope) | — | **1 notebook, c1 seul modifié** (source + outputs) ✓ |
| Nature du diff | — | **7 insertions / 20 suppressions** = c1 source + vidage sortie bruitée ✓ |
| Line endings | — | **LF pur (0 CRLF)** ✓ |
| Trailing byte | — | **`}\n` byte-identique à origin** ✓ |
| Re-exec | bruit pip | **nbclient kernel python3, capture réelle `[]`** ✓ |

## Scope & safety

- **1 notebook atomique**, `Sudoku/` (mon turf CoursIA : Probas/Sudoku/Search/ML/SymbolicAI-SMT). Branche fraîche `fix/3436-sudoku-setup-path-leak` from `origin/main`.
- **Collision CLEAN** : 0 PR ouverte touche Sudoku-10 setup (vérifié `gh pr list --search "Sudoku-10"` + `--search "3436"` ; #5151 = Sudoku-7b, #5171 = audit numérotation, sans rapport).
- **CATALOG byte-identique** (1 notebook source modifié, pas de toucher CATALOG-STATUS).
- Manipulation JSON + ré-exec ciblée 1 cellule (pas de papermill full-notebook → pas de churn sur les 24 autres cellules, dont les cellules solveur CP déterministes).

See #3436 — contribution partielle (1 cellule setup, cause A). Ne Closes pas (tracker rollout repo-wide ; 616 findings restants across Probas/Search/ML/Sudoku).
