### PR TITLE
fix(sudoku-17): silence setup-cell machine-path leak (#3436, cause A)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "id": "171c8f00-f501-4be4-9130-b4422d35c895",
    "metadata": {
     "execution": {
@@ -407,42 +407,14 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: openai in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (2.24.0)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (4.13.0)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (1.9.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (0.28.1)\n",
-      "Requirement already satisfied: jiter<1,>=0.10.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (0.14.0)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (2.12.5)\n",
-      "Requirement already satisfied: sniffio in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (1.3.1)\n",
-      "Requirement already satisfied: tqdm>4 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (4.67.3)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.11 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (4.15.0)\n",
-      "Requirement already satisfied: idna>=2.8 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from anyio<5,>=3.5.0->openai) (3.11)\n",
-      "Requirement already satisfied: certifi in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (2025.11.12)\n",
-      "Requirement already satisfied: httpcore==1.* in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\n",
-      "Requirement already satisfied: h11>=0.16 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\n",
-      "Requirement already satisfied: annotated-types>=0.6.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.41.5 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pydantic<3,>=1.9.0->openai) (2.41.5)\n",
-      "Requirement already satisfied: typing-inspection>=0.4.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.4.2)\n",
-      "Requirement already satisfied: colorama in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from tqdm>4->openai) (0.4.6)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!pip install openai"
+    "# Installation silencieuse d'OpenAI (uniquement si absent de l'environnement)\n",
+    "import subprocess, sys\n",
+    "try:\n",
+    "    import openai  # noqa: F401\n",
+    "except ImportError:\n",
+    "    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'openai'])\n"
    ]
   },
   {


### PR DESCRIPTION
## Context (See #3436)

`Sudoku-17-LLM-Python.ipynb` c8 (`!pip install openai`) **leaked machine paths** in committed output + a pip upgrade notice:

```
Requirement already satisfied: openai in c:\users\jsboi\appdata\local\programs\python\python313\lib\site-packages (2.24.0)
... + [notice] A new release of pip is available: 25.2 -> 26.1.1
```

Cause A (env/cwd) — même pattern que #5180 (Sudoku-10). Suite atomique sur la même famille.

## Changement — import-guard (pip ne tourne que si openai absent)

`c8` devient un import-guard : `import openai` d'abord, pip uniquement sur `ImportError`. Le kernel `python3` (C:\Python313) a openai 2.43.0 → import réussit → pip sauté → sortie vide, **aucun chemin machine**.

## Validation

| Critère | Après |
|---|---|
| `scan_machine_path_leaks.py` | **0 leak** ✓ |
| C.1 | **0** ✓ |
| C.2 | **ec=1, `outputs: []`** ✓ |
| C.3 | **1 notebook, c8 seul** (jamais les 40 cellules LLM/API) ✓ |
| Diff | **8 insertions / 36 suppressions** (c8 source + 2 sorties bruitées) ✓ |
| Line endings | **LF pur (0 CRLF)** ✓ |
| Trailing byte | **`}\n` byte-identique à origin** ✓ |
| Re-exec | **nbclient kernel python3, capture réelle `[]`** ✓ |

## Scope & safety

- **1 notebook atomique**, `Sudoku/`. Branche fraîche `fix/3436-sudoku17-setup-path-leak` from `origin/main`.
- **Collision CLEAN** : 0 PR ouverte touche Sudoku-17.
- **CATALOG byte-identique**. Single-cell re-exec (les cellules API OpenAI ne sont JAMAIS ré-exécutées).

See #3436 — contribution partielle (1 cellule setup, cause A). Ne Closes pas.
