### PR TITLE
docs(sudoku): renumber Sudoku-7b → Sudoku-19 (companion Lean natif)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -9,7 +9,7 @@ maturity: PRODUCTION=30, BETA=2, ALPHA=1
 
 [← Notebooks](../README.md) | [→ Search](../Search/README.md)
 
-Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. Les 33 notebooks couvrent **13 paires miroir C#/Python** (algorithmes comparables dans les deux langages), **3 notebooks C# uniquement** (13-SymbolicAutomata, 14-BDD, 0-Environment), **3 notebooks Python uniquement** (16-NeuralNetwork, 17-LLM, 18-Comparison-benchmark) et **1 companion Lean natif** ([Sudoku-7b](Sudoku-7b-Lean-Propagation.ipynb), preuve formelle de la propagation de contraintes). Cette structure laisse à chaque étudiant le choix de son langage sur la majorité des algorithmes.
+Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. Les 33 notebooks couvrent **13 paires miroir C#/Python** (algorithmes comparables dans les deux langages), **3 notebooks C# uniquement** (13-SymbolicAutomata, 14-BDD, 0-Environment), **3 notebooks Python uniquement** (16-NeuralNetwork, 17-LLM, 18-Comparison-benchmark) et **1 companion Lean natif** ([Sudoku-19](Sudoku-19-Lean-Propagation.ipynb), preuve formelle de la propagation de contraintes). Cette structure laisse à chaque étudiant le choix de son langage sur la majorité des algorithmes.
 
 **À qui s'adresse cette série** : étudiants en informatique (L2-M2) découvrant les paradigmes algorithmiques, candidats à des entretiens techniques, et enseignants cherchant un fil rouge pédagogique. Les notebooks Python ne nécessitent que Python 3.10+. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en IA : les concepts sont introduits depuis le backtracking.
 
@@ -330,7 +330,7 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 5 | PSO | Essaim de particules : convergence collective, vitesse, position |
 | 6 | AIMA CSP | CSP académique : variables, domaines, contraintes, MRV, AC-3 |
 | 7 | Norvig | Propagation de Norvig : élimination des candidats + recherche efficace |
-| 7b | [Sudoku-7b-Lean-Propagation](Sudoku-7b-Lean-Propagation.ipynb) | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la soundness de la propagation (naked/hidden single, clé de voûte `peer_excludes_value`) dans le lake `sudoku_lean`, `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) |
+| 19 | [Sudoku-19-Lean-Propagation](Sudoku-19-Lean-Propagation.ipynb) | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la soundness de la propagation (naked/hidden single, clé de voûte `peer_excludes_value`) dans le lake `sudoku_lean`, `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) |
 | 8 | Human Stratégies | 13 techniques humaines : naked/hidden singles, pairs, pointing, box/line |
 | 9 | Graph Coloring | Formulation graphe : nx.sudoku_graph(), coloration DSATUR |
 | 10 | OR-Tools | CP-SAT industriel : modèle déclaratif, contraintes globales, parallélisme |

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-19-Lean-Propagation.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-19-Lean-Propagation.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Sudoku-7b — Soundness de la propagation de contraintes (companion formel natif)\n",
+    "# Sudoku-19 — Soundness de la propagation de contraintes (companion formel natif)\n",
     "\n",
     "Ce notebook est le **companion formel** du lake [`sudoku_lean`](sudoku_lean/),\n",
     "dont la lib `Sudoku` prouve la **soundness des règles de propagation** d'un Sudoku\n",
@@ -831,8 +831,8 @@
    "duration": 395.672045,
    "end_time": "2026-06-27T00:28:11.830294+00:00",
    "exception": null,
-   "input_path": "Sudoku-7b-Lean-Propagation.ipynb",
-   "output_path": "Sudoku-7b-Lean-Propagation.ipynb",
+   "input_path": "Sudoku-19-Lean-Propagation.ipynb",
+   "output_path": "Sudoku-19-Lean-Propagation.ipynb",
    "start_time": "2026-06-27T00:21:36.158249+00:00"
   }
  },

--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -388,7 +388,7 @@ class TestValidateNotebookLeanTextErrors:
     (display_data / execute_result), never as output_type=="error". A whole
     Lean notebook can be red (every cell ❌) while CI stays green. The
     detector anchors on the toolchain-emitted `severity: error` message.
-    Regression guard for #5151 (Sudoku-7b-Lean-Propagation: failed import ->
+    Regression guard for #5151 (Sudoku-19-Lean-Propagation: failed import ->
     48 unknown-identifier + 12 unknown-constant cascade, CI all green)."""
 
     def _lean_err_output(self) -> dict:


### PR DESCRIPTION
## Summary

Renommage de `Sudoku-7b-Lean-Propagation` → `Sudoku-19-Lean-Propagation`, **PR #1 du plan C201 audit #5081** (EPIC renumérotation narrative des séries). Résout **P1 (préfixage opportuniste `7b` à renuméroter)** identifié dans l'audit narratif PR #5171.

| Fichier | Type | Détail |
|---------|------|--------|
| `MyIA.AI.Notebooks/Sudoku/Sudoku-7b-Lean-Propagation.ipynb` → `Sudoku-19-Lean-Propagation.ipynb` | RENAME (99%) | 3 cellules internes modifiées : (1) titre H1 `# Sudoku-7b — ...` → `# Sudoku-19 — ...` ; (2-3) papermill `metadata.input_path` et `output_path`. Format `source list[str]` préservé (convention Jupyter UI). |
| `MyIA.AI.Notebooks/Sudoku/README.md` | MODIFY (2 lignes) | Paragraphe introductif ligne 12 (3 occurrences `Sudoku-7b` → `Sudoku-19`) + table inventaire ligne 333 (`7b` → `19`) |
| `scripts/notebook_tools/tests/test_validate_pr_notebooks.py` | MODIFY (1 ligne) | Docstring regression guard #5151 référence symbolique |

**Diff total : 3 fichiers / 6 insertions / 6 deletions** (scope chirurgical, R3 atomique 1 sujet respecté).

## Pourquoi ce renommage

**Le préfixage `7b` était un P1 de l'audit narratif C201** : numérotation opportuniste insérée entre les notebooks `7` (Norvig) et `8` (Human Stratégies) sans slot narratif légitime. C'est une **pollution de la table d'inventaire** qui brise l'arc narratif `0→18` de la série Sudoku.

**Slot narratif légitime proposé** : numéroter après `18` (Comparison-benchmark), soit `19`. Cela ouvre une **5ᵉ catégorie thématique** après les 4 familles actuelles :
1. `0-12` : Résolution algorithmique (Backtracking / DLX / GA / SA / PSO / AIMA CSP / Norvig / Human Stratégies / Graph Coloring / OR-Tools / Choco / Z3)
2. `13-14` : Automates symboliques / BDD
3. `15-17` : Probabiliste / Neural / LLM
4. `18` : Comparison-benchmark
5. **`19`** : **Formal proof (Lean natif)**

Le notebook reste un **companion formel** de la série — pas un notebook de résolution algorithmique supplémentaire, mais un **pont entre la résolution (1-12) et la preuve formelle** : la soundness de la propagation qui fonde tous les solveurs (backtracking, OR-Tools, Z3).

## Vérifications catalog-pr-hygiene R1-R4

| Règle | Check | Résultat |
|-------|-------|----------|
| R1 JAMAIS regen catalogue sur branche | `git diff origin/main -- COURSE_CATALOG.generated.{md,json}` | = 0 lignes (byte-identique) ✓ |
| R2 Branche fraîche depuis origin/main | `git log --oneline -1 origin/main` | `4ee811580` (avance vs C202 `f4a776aff`) ✓ |
| R3 PR atomique 1 sujet 1+ fichiers cohérents | `git diff --stat` | 3 fichiers / 1 sujet (renommage cohérent) ✓ |
| R4 `See #X` (epic partielle) | Body PR | `See #5081` (EPIC ouverte, plan marathon) ✓ |
| LF preservation | `count(b'\r\n')` | 0 sur 3 fichiers (warning Git CRLF→LF au prochain touch, conforme pratique repo) |
| scope vs seuil G.4 | 3 fichiers / 6 insertions | OK (< 3000 lignes / < 15 fichiers / < 4 features) |

## Vérifications H.3 (notebook validation)

| Check | Résultat |
|-------|----------|
| Format nbformat | 4.5 (standard) ✓ |
| Kernel | `lean4-wsl` (cohérent avec série Sudoku Lean) ✓ |
| Total cellules | 16 (12 markdown + 4 code Lean) ✓ |
| Cellules sans `id` | 0 ✓ |
| Cellules code `execution_count=None` | 0 ✓ |
| Red flags C.1 (`raise NotImplementedError`, `assert False`, `1/0`) | 0 ✓ |
| Grep `7b` dans le diff `+` | 0 (aucune fuite) ✓ |
| Titre contient `Sudoku-19` | ✓ |
| Papermill `input_path` = `Sudoku-19-Lean-Propagation.ipynb` | ✓ |
| Papermill `output_path` = `Sudoku-19-Lean-Propagation.ipynb` | ✓ |

## Non-touché (R1 catalog-pr-hygiene)

- `COURSE_CATALOG.generated.{md,json}` = **byte-identique origin/main** (catalog-cron quotidien régénèrera post-merge avec nouveau nom `Sudoku-19-Lean-Propagation`).
- `scratchpad/c202/pr_body.md` ligne 65 (référence historique à `Sudoku-7b → Sudoku-19` dans le **plan** C202 cartographie — préservé à dessein).

## Suite (par cycle worker)

Cette PR est **PR #1 d'un plan C201 de 8 PRs atomiques** (audit narratif #5081). Les 7 PRs restantes (deep-queue C204+) :

| # | PR | Substance | État |
|---|----|-----------|------|
| 1 | Sudoku-7b → Sudoku-19 renumber (cette PR) | rename | **OUVERTE** |
| 2 | Search racine → Part1 rename | rename | à brûler C205+ |
| 3 | DecisionTheory → DecInfer rename | rename | à brûler C206+ |
| 4 | DecisionTheory → DecPyMC rename | rename | à brûler C207+ |
| 5 | Table parité cross-série #4956 | cartographie | **LIVRÉE C202 (#5177 MERGED via #5178 chain)** |
| 6 | QC-Py trous 29-1 / 36-1 / 39-1 | renumérotation | à brûler C208+ |
| 7 | GenAI/Texte 01-1 / 1-1 / 2-1 / 3-1 | renumérotation | à brûler C209+ |
| 8 | Transition IIT → ICT (substance P2 fixup) | doc + navigation | à brûler C210+ |

Cette PR est **See #5081** (contribution partielle à l'EPIC). `Closes` interdit sur sous-tâche d'EPIC (cf catalog-pr-hygiene Règle 4). L'EPIC #5081 reste ouverte jusqu'à livraison des 8 PRs.

## Liens croisés

- **#5081** — EPIC Renumérotation narrative des séries (audit parent)
- **#5171** — PR audit #5081 (livrée C201, en attente merge ai-01)
- **#5177** — PR cartographie parité #4956 (livrée C202 MERGED)
- **#4055** — EPIC Sudoku-Lean (résultat central, 0 sorry, voir ce notebook)
- **#4667** — EPIC Tweety (jurisprudence du levier IKVM, coquille qui a cédé)
- **#4956** — EPIC Parité .NET ⇄ Python
- **#2161** — Convention 3 exercices/notebook (applicable à ce notebook)
- [`.claude/rules/catalog-pr-hygiene.md`](../../.claude/rules/catalog-pr-hygiene.md) — R1-R4 HARD respectées
- [`.claude/rules/git-workflow.md`](../../.claude/rules/git-workflow.md) — branche `docs/`, no force push
- [`.claude/rules/notebook-conventions.md`](../../.claude/rules/notebook-conventions.md) — C.1, C.2, C.3
- [`docs/suivis/numerotation-narrative-2026-07-03.md`](../../docs/suivis/numerotation-numerotation-2026-07-03.md) — plan 8 PRs atomiques C201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
