### PR TITLE
fix(notebook-tools): count_exercises dedup stub-preceding-its-header (#2161)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -79,6 +79,20 @@ EXERCISE_WORD_EN_RE = re.compile(r"\bexercises?\b", re.IGNORECASE)
 # initially mis-paired a `---` cell with the exercise code cell below it.
 MARKDOWN_HEADER_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.*)", re.MULTILINE)
 
+# The exercise NUMBER a cell references, e.g. ``Exercice 3`` -> ``'3'``,
+# ``Exercice 3b`` -> ``'3b'``, ``Exercise 2`` -> ``'2'``. Used ONLY to gate
+# backward stub/header pairing (see count_exercises_in_notebook): a stub that
+# PRECEDES a header is absorbed into it only when both reference the same
+# number, so a stub belonging to the *previous* exercise in a sequential
+# layout (header N -> stub N -> header N+1) is never wrongly absorbed. The
+# optional trailing letter distinguishes ``3`` from ``3b`` (two distinct
+# exercises). Numberless references (``# Exercice : ...``) return None and are
+# left unpaired -- conservative (may leave a residual double-count, but never
+# under-counts by absorbing a foreign stub).
+EXERCISE_NUMBER_RE = re.compile(
+    r"\b(?:exercic(?:e|es)|exercises?)\s*([-+]?\d+[a-z]?)", re.IGNORECASE
+)
+
 # Stub indicators inside a code cell source (mirrors detect_solution_leaks.py +
 # the notebook-conventions C.1 patterns). An exercise cell is a STUB; a complete
 # solution is an EXAMPLE and is not counted as an exercise.
@@ -210,12 +224,32 @@ def _markdown_mentions_exercise(source: str) -> bool:
     return False
 
 
+def _exercise_number(source: str) -> str | None:
+    """Exercise number token a cell references, e.g. ``'3'`` or ``'3b'``.
+
+    Returns the first ``Exercice <n>`` / ``Exercise <n>`` capture found
+    anywhere in ``source`` (markdown header text or code comment), sign-stripped
+    and lowercased. Returns None when the cell names an exercise with NO number
+    (``# Exercice : ...``): numberless references cannot be safely pair-matched,
+    so the caller treats them as unpaired.
+    """
+    m = EXERCISE_NUMBER_RE.search(source)
+    if not m:
+        return None
+    return m.group(1).lstrip("+-").lower()
+
+
 def count_exercises_in_notebook(path: Path) -> NotebookCount:
     """Count exercises in one notebook, with per-cell evidence.
 
-    Deduplication: a markdown header at cell i followed by the matching code
-    stub at cell i+1 is ONE exercise. We pair them. A code-cell exercise with
-    no preceding markdown header is its own exercise.
+    Deduplication: an exercise may appear as BOTH a markdown header AND an
+    adjacent code stub. We pair them so it counts once. Pairing covers two
+    layouts -- the common one (header at cell i, stub at cell i+1) and the
+    "fill-in box then description" layout (stub at cell i, header at cell
+    i+1). The backward layout is gated by a matching exercise NUMBER so a stub
+    belonging to the *previous* exercise in a sequential layout (header N ->
+    stub N -> header N+1) is never absorbed. A code-cell exercise with no
+    paired header is its own exercise.
     """
     result = NotebookCount(path=path)
     try:
@@ -244,15 +278,40 @@ def count_exercises_in_notebook(path: Path) -> NotebookCount:
             )
             header_cell_indices.add(i)
 
-    # Track which code cells are the paired stub of a header just above them
-    # so we do not double-count them in the second pass.
+    # Track which code cells are the paired stub of an exercise header so we
+    # do not double-count them in the second pass. A stub may sit EITHER just
+    # below its header (common) OR just above it (a "fill-in box then
+    # description" layout, where the stub at cell i precedes its own header at
+    # cell i+1). The backward direction is gated by a MATCHING EXERCISE NUMBER
+    # so we never absorb a stub that belongs to the *previous* exercise in the
+    # normal sequential layout (header N -> stub N -> header N+1): there the
+    # stub's number N differs from the following header's number N+1, so the
+    # match fails and both are counted as distinct exercises (no under-count).
     paired_code_indices: set[int] = set()
     for idx in sorted(header_cell_indices):
+        # Forward (common): the stub just below the header, within 3 cells.
         for j in range(idx + 1, min(idx + 4, len(cells))):
-            cell = cells[j]
-            if cell.get("cell_type") == "code":
+            if cells[j].get("cell_type") == "code":
                 paired_code_indices.add(j)
                 break
+        # Backward (stub-then-header layout): the nearest preceding code cell,
+        # absorbed only when it references the SAME exercise number as the
+        # header. Numberless headers/stubs are left unpaired (conservative).
+        header_source = "".join(cells[idx].get("source", []))
+        header_num = _exercise_number(header_source)
+        if header_num is None:
+            continue
+        for j in range(idx - 1, max(idx - 4, -1), -1):
+            cell = cells[j]
+            if cell.get("cell_type") != "code":
+                continue
+            stub_source = "".join(cell.get("source", []))
+            if (
+                _code_cell_mentions_exercise(stub_source)
+                and _exercise_number(stub_source) == header_num
+            ):
+                paired_code_indices.add(j)
+            break  # nearest preceding code cell is the only candidate
 
     # Second pass: code-cell exercises with NO preceding markdown header.
     for i, cell in enumerate(cells):

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -192,6 +192,96 @@ class TestCodeCellOnlyExercise:
         result = count_exercises_in_notebook(nb)
         assert result.count == 1
 
+    def test_stub_preceding_its_header_same_number_not_double_counted(
+        self, tmp_path
+    ):
+        """The "fill-in box then description" layout: a stub code cell at cell
+        i PRECEDES its own descriptive markdown header at cell i+1. Both
+        reference the same exercise number, so they are ONE exercise -- not
+        two. This is the forward-only-dedup blind-spot documented in #5179
+        (genuine case: Oncology-Planning reported 6 exercises for 3 real ones).
+        """
+        nb = _write_nb(
+            tmp_path / "backward.ipynb",
+            [
+                _code("# Exercice 1 : etendre l'ontologie\n# TODO etudiant\npass"),
+                _md("### Exercice 1 : Etendre l'ontologie avec de nouveaux medicaments"),
+                _code("# Exercice 2 : sensibilite au prior\n# TODO\nreturn None"),
+                _md("### Exercice 2 : Sensibilite du modele bayesien au prior"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 2, (
+            "stub-then-header same-number layout must not double-count"
+        )
+        # The header is the canonical representative; the stub is absorbed.
+        assert all(h.detected_by == "markdown_header" for h in result.exercises)
+
+    def test_stub_preceding_different_number_header_is_not_absorbed(
+        self, tmp_path
+    ):
+        """SAFETY GUARD (anti under-count): the normal sequential layout is
+        ``header N -> stub N -> header N+1``. The stub at cell i belongs to
+        exercise N, the header at cell i+1 introduces exercise N+1. The
+        backward pairing must NOT absorb the stub here (numbers differ), or
+        exercise N would be silently lost. Verified repo-wide: 27 sequential
+        notebooks (GameTheory, Sudoku-12, Lean, SW) stay byte-identical.
+        """
+        nb = _write_nb(
+            tmp_path / "sequential.ipynb",
+            [
+                _md("### Exercice 1 : premier"),
+                _code("# Exercice 1 : premiere impl\n# TODO\npass"),
+                _md("### Exercice 2 : second"),
+                _code("# Exercice 2 : seconde impl\n# TODO\npass"),
+                _md("### Exercice 3 : troisieme"),
+                _code("# Exercice 3 : troisieme impl\n# TODO\npass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            "sequential layout must count each exercise once (no under-count)"
+        )
+
+    def test_stub_preceding_header_with_hint_cell_between_pairs(
+        self, tmp_path
+    ):
+        """Backward pairing skips an intervening non-code (markdown hint) cell
+        to find the stub, as long as the number matches. A gap of one markdown
+        hint between the stub and its header is still paired.
+        """
+        nb = _write_nb(
+            tmp_path / "gap.ipynb",
+            [
+                _code("# Exercice 4 : mini-KG\n# Indice\nresult = None"),
+                _md("**Indice:** pensez aux cycles."),
+                _md("### Exercice 4 : Un mini-KG ou la PCA est trompeuse"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            "stub + hint + same-number header is one exercise"
+        )
+
+    def test_stub_preceding_numberless_header_left_unpaired(self, tmp_path):
+        """A stub with NO number before a header with NO number cannot be
+        safely pair-matched (conservative -- we cannot tell whether the stub
+        belongs to this header or the previous exercise). It is left
+        unpaired: both the stub and the header count, which may leave a
+        residual double-count but never under-counts.
+        """
+        nb = _write_nb(
+            tmp_path / "numberless.ipynb",
+            [
+                _code("# Exercice : free-form\n# TODO\npass"),
+                _md("### Exercice : description sans numero"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 2, (
+            "numberless stub/header are not absorbed (conservative)"
+        )
+
     def test_csharp_double_slash_comment_exercise_is_counted(self, tmp_path):
         """The .NET / C# family uses ``//`` for line comments (not ``#``).
         A stub code cell whose ``// Exercice ...`` comment names an exercise


### PR DESCRIPTION
## What

Fix the canonical #2161 exercise counter's **forward-only deduplication** blind-spot, documented by po-2024 in #5179 as a pre-existing limitation deferred for a separate atomic improvement (G.4).

The tool paired a markdown header with its stub only FORWARD (header at cell `i` -> stub at cell `i+1`). The **"fill-in box then description" layout** — a stub code cell at `i` PRECEDING its own descriptive header at `i+1` — was **double-counted** (both the stub and the header counted as separate exercises).

## G.1 grounding — real double-count (firsthand)

`CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb` reported **6 exercises for 3 real ones** — each `# Exercice N` stub immediately preceded its `### Exercice N` header.

## Why a naive backward-window fix would be WRONG

A repo-wide scan found 564 "stub precedes a header" instances — but **almost all are the normal sequential layout** `header N -> stub N -> header N+1`, where the stub belongs to exercise N and the header introduces exercise N+1. A structural backward window would absorb exercise N's stub into exercise N+1's header -> **under-count** (could flip a conforming notebook to a false sub-threshold flag = spurious work).

## The fix — backward pairing gated by matching exercise NUMBER

Extend pairing to the backward direction (header at `i` <- nearest preceding code cell within 3), but absorb the stub **only when it references the SAME exercise number** as the header. New helper `_exercise_number()` extracts the number token (`'3'`, `'3b'`, `'12'`); returns `None` for numberless cells which are left unpaired (conservative — may leave a residual double-count, never under-counts). The trailing-letter capture (`3` vs `3b`) prevents matching two distinct exercises that share a leading digit.

## Verified repo-wide (786 notebooks)

| Metric | Value |
|--------|-------|
| Double-counts removed | **3** (Oncology 6->3, Claude-CLI-Bases 6->4, SL-3 5->4) |
| **Increases (under-count regression)** | **0** |
| **False sub-threshold flips** | **0** |
| Sequential notebooks unchanged | 27 (GameTheory-2/11, Sudoku-12, Lean-15/17, SW-10, ...) all byte-identical |

The fix ONLY decreases counts (removes double-counts), never increases — the safe direction for a conformity checker.

## Tests

**29/29 pass** (25 existing + 4 new): backward same-number pairing, sequential different-number safety guard, hint-cell gap, numberless conservative residual.

## Scope

- 2 files, +156/-7 (tooling logic + helper + docstring; 4 new tests).
- Pure tooling — **no notebooks touched** (no C.2 re-exec needed).
- Catalog byte-identical to `main` (R1). Fresh base `origin/main` `bd54d76d2` (R2).

See #2161 (3-exercises convention tooling; the convention rollout is ongoing even though the tracker issue is closed).

Co-Authored-By: Claude-Code <noreply@anthropic.com>