### PR TITLE
feat(notebook-tools): audit_solution_leaks C# // candidate detection (#2161, complement to #5179)

### DIFF
--- a/scripts/notebook_tools/audit_solution_leaks.py
+++ b/scripts/notebook_tools/audit_solution_leaks.py
@@ -31,6 +31,31 @@ EXAMPLE_RESOLU_MARKERS = re.compile(
     r'#\s*(Exemple\s+résolu|Exemple\s+resolu|Solution\s*[:-]?\s*$)', re.IGNORECASE
 )
 
+# --- C# / .NET Interactive markers (#2161 blind-spot, complement to count_exercises #5179) ---
+# The Python leak detectors above only match `#` comments. C# notebooks use `//`.
+# C# exercise cells are flagged for MANUAL review -- the example-vs-leak verdict is a
+# content judgment (exercise-example-labeling rule) that must NOT be automated. The
+# detector emits CANDIDATES only, never an auto-verdict.
+CSHARP_EXERCICE_MARKER = re.compile(r'^\s*//\s*[Ee]xercice', re.IGNORECASE)
+CSHARP_SOLUTION_MARKER = re.compile(
+    r'^\s*//\s*(Solution|Exemple\s+résolu|Exemple\s+resolu|Réponse\s*:|Reponse\s*:)',
+    re.IGNORECASE,
+)
+# C# stub markers -- their presence means the cell is a legit student stub, not a leak.
+CSHARP_STUB_MARKERS = re.compile(
+    r'(//\s*TODO|//\s*Indice|//\s*Étape|//\s*Etape|\bpass\b|\breturn\s*;|\breturn\s+null\b)',
+    re.IGNORECASE,
+)
+# C# language detection: kernelspec language_info.name OR a .net-csharp kernel.
+def _is_csharp_notebook(nb):
+    """True if the notebook is C# / .NET Interactive (so `//` comments apply)."""
+    meta = nb.get('metadata', {})
+    lang = (meta.get('language_info') or {}).get('name', '')
+    if lang and lang.lower() in ('c#', 'csharp', 'f#', 'fsharp'):
+        return True
+    ks = (meta.get('kernelspec') or {}).get('name', '')
+    return '.net-csharp' in ks or '.net-fsharp' in ks or '.net-polyglot' in ks
+
 
 def get_cells_after_exercice_md(cells, start_idx):
     """Get code cells that follow a markdown exercice header."""
@@ -180,6 +205,68 @@ def detect_preresolved_cells(cells):
     return leaks
 
 
+def detect_csharp_leak_candidates(cells):
+    """Pattern 4 (C#): FLAG ``// Exercice`` / ``// Solution`` code cells for manual review.
+
+    The Python leak detectors only match ``#`` comments, so every C# notebook
+    was invisible. This detector emits **candidates** for human review -- it
+    does NOT auto-classify, because the example-vs-leak verdict is a content
+    judgment (exercise-example-labeling rule: a cell with complete working code
+    under ``// Exercice`` is a leak; under ``// Exemple`` it is a legit demo).
+
+    Heuristic for "candidate worth flagging" (mirrors the Python >3-logic-line
+    rule + #5179's stub detection, adapted to C#):
+
+      - a ``// Exercice`` cell WITHOUT a stub marker (TODO/pass/return;/return
+        null) AND with >3 non-comment, non-brace code lines -> FLAG
+        (``csharp_exercice_body``); this is the analogue of a Python
+        function_body_leak under ``# Exercice``.
+      - a ``// Solution`` / ``// Exemple resolu`` cell with >3 such code lines
+        -> FLAG (``csharp_preresolved``); legit demos exist, so the verdict is
+        left to the reviewer.
+
+    Returns leak dicts with ``severity`` = ``FLAG`` (a distinct severity so the
+    report makes clear these are candidates, not auto-verdicted leaks).
+    """
+    candidates = []
+    for i, cell in enumerate(cells):
+        if cell.get('cell_type') != 'code':
+            continue
+        source = ''.join(cell.get('source', []))
+        if not source:
+            continue
+        # Does this cell carry a C# exercice/solution marker on any line?
+        is_exercice = any(
+            CSHARP_EXERCICE_MARKER.match(ln) for ln in source.split('\n')
+        )
+        is_solution = any(
+            CSHARP_SOLUTION_MARKER.match(ln) for ln in source.split('\n')
+        )
+        if not (is_exercice or is_solution):
+            continue
+        # Count non-comment, non-brace, non-trivial code lines.
+        code_lines = [
+            ln for ln in source.split('\n')
+            if ln.strip()
+            and not ln.strip().startswith('//')
+            and ln.strip() not in ('{', '}', '(', ')', ';')
+        ]
+        if len(code_lines) <= 3:
+            continue
+        # An exercice cell with a stub marker is a legit student stub, not a leak.
+        if is_exercice and not is_solution and CSHARP_STUB_MARKERS.search(source):
+            continue
+        kind = 'csharp_preresolved' if is_solution else 'csharp_exercice_body'
+        candidates.append({
+            'type': kind,
+            'cell_index': i,
+            'code_lines': len(code_lines),
+            'first_line': source.split('\n')[0][:80],
+            'severity': 'FLAG',
+        })
+    return candidates
+
+
 def audit_notebook(path):
     """Audit a single notebook for solution leaks."""
     try:
@@ -250,6 +337,11 @@ def audit_notebook(path):
     preresolved = detect_preresolved_cells(cells)
     all_leaks.extend(preresolved)
 
+    # Pattern 4 (C#): FLAG // Exercice / // Solution cells for manual review.
+    # Only run on C# notebooks -- the Python detectors above cover `#` cells.
+    if _is_csharp_notebook(nb):
+        all_leaks.extend(detect_csharp_leak_candidates(cells))
+
     return all_leaks
 
 
@@ -262,7 +354,10 @@ def main():
     print()
 
     results = {}
-    total_leaks = {'function_body_leak': 0, 'commented_solution_leak': 0, 'preresolved_cell': 0}
+    total_leaks = {
+        'function_body_leak': 0, 'commented_solution_leak': 0, 'preresolved_cell': 0,
+        'csharp_exercice_body': 0, 'csharp_preresolved': 0,
+    }
 
     for nb_path in sorted(notebooks):
         leaks = audit_notebook(nb_path)
@@ -273,21 +368,27 @@ def main():
                 total_leaks[leak['type']] = total_leaks.get(leak['type'], 0) + 1
 
     # Report
-    print(f"## Audit Results: {len(results)} notebooks with leaks")
+    print(f"## Audit Results: {len(results)} notebooks with findings")
     print(f"Total: function_body_leak={total_leaks.get('function_body_leak', 0)}, "
           f"commented_solution_leak={total_leaks.get('commented_solution_leak', 0)}, "
           f"preresolved_cell={total_leaks.get('preresolved_cell', 0)}")
+    cs_body = total_leaks.get('csharp_exercice_body', 0)
+    cs_pre = total_leaks.get('csharp_preresolved', 0)
+    if cs_body or cs_pre:
+        print(f"C# candidates (FLAGGED FOR REVIEW, not auto-verdicted): "
+              f"csharp_exercice_body={cs_body}, csharp_preresolved={cs_pre}")
     print()
 
-    # Sort by severity (HIGH first)
+    # Sort by severity (HIGH first). FLAG = C# candidates for manual review.
     for path, leaks in sorted(results.items()):
         high = [l for l in leaks if l.get('severity') == 'HIGH']
         medium = [l for l in leaks if l.get('severity') == 'MEDIUM']
         low = [l for l in leaks if l.get('severity') == 'LOW']
+        flags = [l for l in leaks if l.get('severity') == 'FLAG']
 
-        if high or medium:
+        if high or medium or flags:
             print(f"### {path}")
-            for leak in high + medium:
+            for leak in high + medium + flags:
                 leak_desc = f"  [{leak['severity']}] {leak['type']}"
                 if 'func_name' in leak:
                     leak_desc += f" `{leak['func_name']}` ({leak['logic_lines']} logic lines)"

--- a/scripts/notebook_tools/tests/test_audit_solution_leaks.py
+++ b/scripts/notebook_tools/tests/test_audit_solution_leaks.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from audit_solution_leaks import (
     audit_notebook,
     detect_commented_solution_leak,
+    detect_csharp_leak_candidates,
     detect_function_body_leak,
     detect_preresolved_cells,
     get_cells_after_exercice_md,
@@ -565,3 +566,123 @@ class TestAuditNotebook:
         types = {l["type"] for l in leaks}
         assert "function_body_leak" in types
         assert "preresolved_cell" in types
+
+
+# ---------------------------------------------------------------------------
+# C# / .NET Interactive leak candidates (#2161 blind-spot, complement to #5179)
+# ---------------------------------------------------------------------------
+# A C# notebook metadata marker so detect_csharp_leak_candidates runs.
+CSHARP_META = {
+    "kernelspec": {"name": ".net-csharp", "display_name": ".NET (C#)"},
+    "language_info": {"name": "C#"},
+}
+
+
+class TestCSharpLeakCandidates:
+    """The Python detectors only match `#`; C# uses `//`. These tests verify the
+    C# candidate layer flags cells for MANUAL review (never auto-verdicts -- the
+    example-vs-leak judgment is content-based, exercise-example-labeling rule).
+    """
+
+    def test_csharp_exercice_with_full_body_is_flagged(self, tmp_path):
+        """A `// Exercice` cell holding >3 code lines and NO stub marker is a
+        leak candidate (C# analogue of a Python function_body_leak)."""
+        src = (
+            "// Exercice : implementez le melange a 3 composantes\n"
+            "public class CyclisteBase3Composantes {\n"
+            "    var a = data[0];\n"
+            "    var b = data[1];\n"
+            "    var c = data[2];\n"
+            "    var model = Mix(a, b, c);\n"
+            "    return model;\n"
+            "}\n"
+        )
+        candidates = detect_csharp_leak_candidates([_code_cell(src)])
+        assert len(candidates) == 1
+        assert candidates[0]["type"] == "csharp_exercice_body"
+        # FLAG severity = candidate, NOT an auto-verdicted leak.
+        assert candidates[0]["severity"] == "FLAG"
+        assert candidates[0]["code_lines"] > 3
+
+    def test_csharp_exercice_with_todo_stub_is_not_flagged(self, tmp_path):
+        """A `// Exercice` cell with a TODO stub marker is a legit student stub
+        -- NOT a leak candidate. (Guards against over-flagging 302/350 real
+        C# stubs that the #5179 lesson showed are the common case.)"""
+        src = (
+            "// Exercice 1 : Lancer de trois pieces\n"
+            "// TODO etudiant : Creer trois variables booleennes\n"
+            "// TODO etudiant : Calculer la probabilite\n"
+            "bool p1 = true;\n"
+            "bool p2 = false;\n"
+        )
+        candidates = detect_csharp_leak_candidates([_code_cell(src)])
+        assert len(candidates) == 0, (
+            "C# exercice cell WITH TODO stub must NOT be flagged"
+        )
+
+    def test_csharp_exercice_with_few_lines_is_not_flagged(self, tmp_path):
+        """A `// Exercice` cell with <=3 code lines (even without TODO) is too
+        small to be a solution leak -- a real solution needs >3 logic lines."""
+        src = (
+            "// Exercice : court stub sans TODO\n"
+            "var x = 1;\n"
+            "var y = 2;\n"
+        )
+        candidates = detect_csharp_leak_candidates([_code_cell(src)])
+        assert len(candidates) == 0
+
+    def test_csharp_solution_cell_is_flagged_as_preresolved(self, tmp_path):
+        """A `// Solution` / `// Exemple resolu` cell with >3 code lines is a
+        pre-resolved candidate. It MAY be a legit worked example -- hence FLAG
+        for review, not an auto-leak verdict."""
+        src = (
+            "// Exemple resolu : factorielle recursive\n"
+            "int Factorielle(int n) {\n"
+            "    if (n <= 1) return 1;\n"
+            "    return n * Factorielle(n - 1);\n"
+            "}\n"
+            "Console.WriteLine(Factorielle(5));\n"
+        )
+        candidates = detect_csharp_leak_candidates([_code_cell(src)])
+        assert len(candidates) == 1
+        assert candidates[0]["type"] == "csharp_preresolved"
+        assert candidates[0]["severity"] == "FLAG"
+
+    def test_python_cell_is_not_double_flagged_by_csharp_layer(self, tmp_path):
+        """A Python `# Exercice` cell (not C#) must NOT be picked up by the C#
+        candidate layer -- `#` comments are not `//`. (Guards scope boundary.)"""
+        src = (
+            "# Exercice 1 : solution complete en Python\n"
+            "def solve(x):\n"
+            "    a = compute(x)\n"
+            "    b = transform(a)\n"
+            "    c = validate(b)\n"
+            "    return aggregate(a, b, c)\n"
+        )
+        candidates = detect_csharp_leak_candidates([_code_cell(src)])
+        assert len(candidates) == 0, "Python # cell must not hit the // detector"
+
+    def test_audit_notebook_only_runs_csharp_layer_on_csharp_notebooks(
+        self, tmp_path
+    ):
+        """A Python-kernel notebook with a `// Exercice`-looking cell must NOT
+        trigger the C# layer (false-positive guard: // in a Python notebook is
+        not a C# comment)."""
+        # Python kernel metadata
+        py_meta = {"kernelspec": {"name": "python3"}, "language_info": {"name": "python"}}
+        nb = {
+            "cells": [_code_cell(
+                "// Exercice : ceci n'est pas un commentaire C#\n"
+                "x = compute(data)  # mais ceci l'est, en Python\n"
+                "y = transform(x)\n"
+                "z = validate(y)\n"
+                "return aggregate(x, y, z)\n"
+            )],
+            "metadata": py_meta,
+        }
+        path = _write_nb(tmp_path, nb)
+        leaks = audit_notebook(path)
+        csharp_types = {l["type"] for l in leaks if l["type"].startswith("csharp_")}
+        assert csharp_types == set(), (
+            "C# layer must NOT run on a Python-kernel notebook"
+        )


### PR DESCRIPTION
## What

Complement to **#5179** (count_exercises C# `//` blind-spot). The solution-leak detector `audit_solution_leaks.py` was Python-centric — `EXERCICE_MARKERS`, `detect_function_body_leak` (`def\s+`), `detect_commented_solution_leak` (`#`), and `SOLUTION`/`EXAMPLE_RESOLU` markers all match `#` comments only. Every C# notebook was invisible: the same blind-spot class #5179 closed for the exercise counter.

This PR adds a **C# candidate-detection layer**.

## Why candidates, not auto-verdicts (design — ai-01 dispatch)

Per ai-01's scope (msg on c.20 thread) and the **exercise-example-labeling rule**: the example-vs-leak verdict is a **content judgment that must NOT be automated**. A `// Exercice` cell with complete working code is a leak; under `// Exemple` it is a legit worked demo. The detector **surfaces candidates**; a human decides. All C# findings carry `severity: 'FLAG'` (distinct from HIGH/MEDIUM/LOW auto-leaks) so the report makes the boundary explicit.

## Implementation

- `CSHARP_EXERCICE_MARKER` / `CSHARP_SOLUTION_MARKER` / `CSHARP_STUB_MARKERS` regexes for `//` comments
- `_is_csharp_notebook()`: kernelspec `.net-csharp`/`.net-fsharp`/`.net-polyglot` OR `language_info.name` C#/F#
- `detect_csharp_leak_candidates(cells)`:
  - `// Exercice` cell, **>3 non-comment code lines**, **NO stub marker** (TODO/pass/`return;`/`return null`) → `csharp_exercice_body` (C# analogue of Python function_body_leak)
  - `// Solution` / `// Exemple resolu` cell, >3 code lines → `csharp_preresolved`
- Wired into `audit_notebook` (C# notebooks only) + totals + report

## G.1 proof — verified firsthand

| Metric | Baseline | After | Change |
|--------|----------|-------|--------|
| Python function_body_leak | 499 | 499 | **0 (unchanged)** |
| Python commented_solution_leak | 101 | 101 | **0 (unchanged)** |
| Python preresolved_cell | 56 | 56 | **0 (unchanged)** |
| **C# csharp_exercice_body** | — | **1** | new (additive) |
| **C# csharp_preresolved** | — | **15** | new (additive) |

The C# layer is purely additive — Python detection is byte-identical. Conservative by design: 302/350 C# `// Exercice` cells carry TODO/pass stubs and are correctly skipped (per #5179's lesson that stubs are the common case).

## Tests — 52/52 pass (46 existing + 6 new)

```
tests\test_audit_solution_leaks.py::TestCSharpLeakCandidates::test_csharp_exercice_with_full_body_is_flagged PASSED
tests\test_audit_solution_leaks.py::TestCSharpLeakCandidates::test_csharp_exercice_with_todo_stub_is_not_flagged PASSED
tests\test_audit_solution_leaks.py::TestCSharpLeakCandidates::test_csharp_exercice_with_few_lines_is_not_flagged PASSED
tests\test_audit_solution_leaks.py::TestCSharpLeakCandidates::test_csharp_solution_cell_is_flagged_as_preresolved PASSED
tests\test_audit_solution_leaks.py::TestCSharpLeakCandidates::test_python_cell_is_not_double_flagged_by_csharp_layer PASSED
tests\test_audit_solution_leaks.py::TestCSharpLeakCandidates::test_audit_notebook_only_runs_csharp_layer_on_csharp_notebooks PASSED
============================== 52 passed in 0.33s ==============================
```

count_exercises tests also re-run green (25/25) — no cross-tool regression.

## Scope

- 2 files, +227/-5 (logic + tests). Pure tooling — no notebooks touched (no C.2 re-exec).
- Catalog byte-identical to `main` (R1). Fresh base `origin/main` (R2), atomic (R3).
- The stray `audit_solution_leaks_results.json` (local run artifact) was correctly NOT committed (untracked).

See #2161 (blind-spot detection, complement to #5179).

Co-Authored-By: Claude-Code <noreply@anthropic.com>