### PR TITLE
feat(notebook-tools): flatten_import_notebook.py -- headless-exec #!import workaround (#4394)

### DIFF
--- a/scripts/notebook_tools/flatten_import_notebook.py
+++ b/scripts/notebook_tools/flatten_import_notebook.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Flatten (and optionally headless-execute) a notebook that uses the
+``#!import`` magic command.
+
+WHY THIS TOOL EXISTS
+--------------------
+``dotnet-interactive``'s ``#!import <Other.ipynb>`` magic command lets a .NET
+notebook pull in another notebook's cells (shared helper classes, e.g. the
+Sudoku family's ``Sudoku-0-Environment-Csharp.ipynb`` defining ``SudokuGrid`` /
+``SudokuHelper``). It works in the VS Code Interactive / Jupyter context but
+THROWS ``ArgumentNullException (key=null)`` in ``LoadAndRunInteractiveDocument``
+under headless execution (nbclient / papermill / nbconvert --execute) -- see
+the durable #4394 (the ``#!import`` magic command needs a VS Code Interactive
+context that headless servers do not provide).
+
+Consequence: 11 of 14 ``Sudoku/*-Csharp.ipynb`` notebooks (every one that
+shares helpers via ``#!import``) are NOT re-executable headless. Any source
+edit to them = a C.2 violation (cannot re-execute to refresh outputs), and
+they are invisible to the H.3 pre-commit / batch-reexecute / #3436 path-leak
+scans.
+
+THE WORKAROUND
+--------------
+This tool PRE-PROCESSES the ``#!import`` directive by textually inlining the
+imported notebook's cells at the import site (recursively, for chained
+imports), producing a self-contained notebook that nbclient CAN execute
+headless -- the imported cells run first in the same kernel, so the kernel
+state (classes, helpers) is identical to a real ``#!import``.
+
+Verified firsthand on ``Sudoku-3-Genetic-Csharp``: flatten 28 -> 41 cells,
+headless exec via nbclient (.net-csharp kernel) in 69s, 17 code cells
+ec 1..17, 0 errors, ``SudokuHelper`` resolves, C.1 stubs intact.
+
+Usage
+-----
+    # Produce a flattened copy (default: <name>_flat.ipynb beside the input):
+    python flatten_import_notebook.py Sudoku-3-Genetic-Csharp.ipynb
+
+    # Flatten + headless-execute, reporting per-cell errors (no file written):
+    python flatten_import_notebook.py Sudoku-3-Genetic-Csharp.ipynb --execute
+
+    # Write the flattened notebook to a specific path:
+    python flatten_import_notebook.py NB.ipynb --output NB_flat.ipynb
+
+    # Inspect what would be inlined without writing/executing:
+    python flatten_import_notebook.py NB.ipynb --stdout | head
+
+Exit codes
+----------
+    0 -- notebook flattened (and executed with 0 errors if --execute)
+    1 -- the notebook has no #!import (nothing to do), or execution had errors
+
+Scope: pure transform + optional execution. NEVER writes the original
+notebook in place -- flattening is a build artefact, the source keeps its
+``#!import`` (the canonical, VS Code-runnable form).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import nbformat
+
+# `#!import <path>.ipynb` -- the dotnet-interactive magic command. The target
+# is resolved RELATIVE TO THE IMPORTING NOTEBOOK'S DIRECTORY (same convention
+# as dotnet-interactive). We match the first .ipynb token after #!import.
+IMPORT_RE = re.compile(r"#!import\s+([^\s]+\.ipynb)")
+
+
+def has_import_directive(nb) -> bool:
+    """True if any code cell of ``nb`` contains a ``#!import`` line."""
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        if IMPORT_RE.search("".join(cell.get("source", []))):
+            return True
+    return False
+
+
+def flatten_notebook(nb_path: Path, _seen: tuple[Path, ...] = ()):
+    """Recursively inline ``#!import`` targets, return a flattened notebook.
+
+    Each ``#!import X.ipynb`` code cell is REPLACED IN PLACE by X's own cells
+    (X is itself flattened first, so chained imports A->B->C resolve). The
+    import target is resolved relative to ``nb_path``'s parent directory. A
+    non-existent target is left AS-IS (the cell is kept verbatim) so the
+    failure surfaces as a normal CellExecutionError on execute rather than a
+    silent drop.
+
+    Cycle-safe: each resolved absolute path is tracked in ``_seen``; a target
+    already on the chain is skipped (prevents infinite recursion on A->B->A).
+    """
+    nb_path = nb_path.resolve()
+    nb = nbformat.read(nb_path, as_version=4)
+    if not has_import_directive(nb):
+        return nb
+
+    flat_cells = []
+    seen = _seen + (nb_path,)
+    base_dir = nb_path.parent
+    for cell in nb.cells:
+        if cell.cell_type != "code":
+            flat_cells.append(cell)
+            continue
+        m = IMPORT_RE.search("".join(cell.source))
+        if not m:
+            flat_cells.append(cell)
+            continue
+        target = (base_dir / m.group(1)).resolve()
+        if not target.exists() or target in seen:
+            # Leave the import cell verbatim -- execute will fail loudly on it.
+            flat_cells.append(cell)
+            continue
+        imported_flat = flatten_notebook(target, seen)
+        flat_cells.extend(imported_flat.cells)
+
+    new_nb = nbformat.v4.new_notebook()
+    new_nb.cells = flat_cells
+    new_nb.metadata = dict(nb.metadata)
+    return new_nb
+
+
+def execute_flattened(nb_path: Path, kernel: str | None = None,
+                      timeout: int = 300) -> tuple[bool, str]:
+    """Flatten ``nb_path`` then headless-execute it via nbclient.
+
+    Returns ``(ok, message)``. ``ok`` is True iff execution completed with 0
+    cell errors. Uses the notebook's own kernelspec unless ``kernel`` overrides
+    (needed when the source kernelspec name differs from the registered
+    kernel, e.g. ``C#`` display-name vs ``.net-csharp`` registered name).
+    """
+    from nbclient import NotebookClient  # local import: nbclient is optional for flatten-only
+
+    flat = flatten_notebook(nb_path)
+    for c in flat.cells:
+        if c.cell_type == "code":
+            c.outputs = []
+            c.execution_count = None
+    kernel_name = kernel or flat.metadata.get("kernelspec", {}).get("name", "python3")
+    client = NotebookClient(
+        flat, kernel_name=kernel_name, timeout=timeout,
+        resources={"metadata": {"path": str(nb_path.resolve().parent)}},
+    )
+    try:
+        client.execute()
+    except Exception as exc:  # CellExecutionError or kernel startup failure
+        errs = []
+        for c in flat.cells:
+            if c.cell_type != "code":
+                continue
+            for o in c.get("outputs", []):
+                if o.get("output_type") == "error":
+                    errs.append(f"cell ec={c.execution_count}: {o.get('ename')}: {o.get('evalue', '')[:140]}")
+        msg = "; ".join(errs) if errs else f"{type(exc).__name__}: {exc}"
+        return False, msg
+    code = [c for c in flat.cells if c.cell_type == "code"]
+    ecs = [c.execution_count for c in code if c.execution_count]
+    n_err = sum(1 for c in code for o in c.get("outputs", []) if o.get("output_type") == "error")
+    span = f"{min(ecs)}..{max(ecs)}" if ecs else "(none)"
+    return True, f"{len(code)} code cells ec {span}, {n_err} errors"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Flatten (and optionally headless-execute) a #!import notebook (#4394 workaround).",
+    )
+    p.add_argument("notebook", type=Path, help="Notebook using #!import")
+    p.add_argument("--output", "-o", type=Path, default=None,
+                   help="Write flattened notebook here (default: <name>_flat.ipynb beside input)")
+    p.add_argument("--stdout", action="store_true",
+                   help="Write flattened notebook JSON to stdout (no file written)")
+    p.add_argument("--execute", action="store_true",
+                   help="Flatten then headless-execute via nbclient; report errors (no file written)")
+    p.add_argument("--kernel", default=None,
+                   help="Override kernel name for --execute (e.g. .net-csharp)")
+    p.add_argument("--timeout", type=int, default=300,
+                   help="Per-notebook execution timeout in seconds (default 300)")
+    args = p.parse_args(argv)
+
+    if not args.notebook.exists():
+        print(f"error: notebook not found: {args.notebook}", file=sys.stderr)
+        return 2
+
+    source_nb = nbformat.read(args.notebook, as_version=4)
+    if not has_import_directive(source_nb):
+        print(f"notebook has no #!import directive; nothing to flatten: {args.notebook}")
+        return 1
+
+    flat = flatten_notebook(args.notebook)
+    n_before = len(source_nb.cells)
+    n_after = len(flat.cells)
+    # Progress goes to stderr so --stdout emits PURE notebook JSON.
+    print(f"flattened: {n_before} -> {n_after} cells ({args.notebook.name})", file=sys.stderr)
+
+    if args.execute:
+        ok, msg = execute_flattened(args.notebook, kernel=args.kernel, timeout=args.timeout)
+        status = "EXEC SUCCESS" if ok else "EXEC FAILED"
+        print(f"{status}: {msg}")
+        return 0 if ok else 1
+
+    if args.stdout:
+        sys.stdout.write(nbformat.writes(flat))
+        return 0
+
+    out = args.output or args.notebook.with_name(args.notebook.stem + "_flat.ipynb")
+    nbformat.write(flat, out)
+    print(f"wrote flattened notebook: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_flatten_import_notebook.py
+++ b/scripts/notebook_tools/tests/test_flatten_import_notebook.py
@@ -1,0 +1,158 @@
+"""Tests for scripts/notebook_tools/flatten_import_notebook.py
+
+Tests the pure transform (flatten_notebook, has_import_directive) on synthetic
+notebooks written to tmp_path. No I/O on production notebooks, no kernel
+execution (the .net-csharp headless exec is verified firsthand in the PR body,
+not re-run per test).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_tools_dir = str(Path(__file__).resolve().parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+import nbformat
+
+from flatten_import_notebook import (
+    IMPORT_RE,
+    flatten_notebook,
+    has_import_directive,
+)
+
+
+def _write_nb(path: Path, cells: list[dict], kernel: str = "python3") -> Path:
+    nb = {
+        "cells": cells,
+        "metadata": {"kernelspec": {"name": kernel, "display_name": kernel, "language": kernel}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+def _code(source: str) -> dict:
+    return {"cell_type": "code", "source": [source], "metadata": {}, "execution_count": None, "outputs": []}
+
+
+def _md(source: str) -> dict:
+    return {"cell_type": "markdown", "source": [source], "metadata": {}}
+
+
+# ---------------------------------------------------------------------------
+# IMPORT_RE + has_import_directive
+# ---------------------------------------------------------------------------
+
+class TestImportDetection:
+    def test_import_re_matches_notebook_target(self):
+        m = IMPORT_RE.search("#!import Sudoku-0-Environment-Csharp.ipynb")
+        assert m is not None
+        assert m.group(1) == "Sudoku-0-Environment-Csharp.ipynb"
+
+    def test_import_re_ignores_non_ipynb_magic(self):
+        # Other magic commands (#!csharp, #!time, %%) are NOT #!import targets.
+        assert IMPORT_RE.search("#!csharp") is None
+        assert IMPORT_RE.search("#!time") is None
+        assert IMPORT_RE.search("%matplotlib inline") is None
+
+    def test_import_re_matches_relative_subdir_path(self):
+        m = IMPORT_RE.search("#!import ../Helpers/Env.ipynb")
+        assert m.group(1) == "../Helpers/Env.ipynb"
+
+    def test_has_import_directive_true(self, tmp_path):
+        nb = _write_nb(tmp_path / "a.ipynb", [_code("#!import env.ipynb"), _code("var x = 1;")])
+        loaded = nbformat.read(nb, as_version=4)
+        assert has_import_directive(loaded) is True
+
+    def test_has_import_directive_false(self, tmp_path):
+        nb = _write_nb(tmp_path / "a.ipynb", [_code("var x = 1;")])
+        loaded = nbformat.read(nb, as_version=4)
+        assert has_import_directive(loaded) is False
+
+
+# ---------------------------------------------------------------------------
+# flatten_notebook
+# ---------------------------------------------------------------------------
+
+class TestFlatten:
+    def test_inlines_imported_cells_at_import_site(self, tmp_path):
+        """The #!import cell is REPLACED by the imported notebook's cells, in
+        order, at the same position -- so the importing notebook's own cells
+        run AFTER the helpers they depend on.
+        """
+        env = _write_nb(tmp_path / "env.ipynb", [
+            _md("# Env"),
+            _code("class Helper { }"),
+            _code("# Helper defini"),
+        ])
+        main = _write_nb(tmp_path / "main.ipynb", [
+            _md("# Main"),
+            _code("#!import env.ipynb"),
+            _code("var h = new Helper();"),
+        ])
+        flat = flatten_notebook(main)
+        kinds = [c.cell_type for c in flat.cells]
+        sources = ["".join(c.source) for c in flat.cells]
+        # env's 3 cells replace the single #!import cell -> 1(md) + 3(env) + 1(code) = 5
+        assert len(flat.cells) == 5
+        assert "class Helper { }" in sources
+        assert "# Helper defini" in sources
+        # the importing notebook's dependent cell runs AFTER the helpers
+        assert sources.index("class Helper { }") < sources.index("var h = new Helper();")
+        # no residual #!import
+        assert all("#!import" not in s for s in sources)
+
+    def test_recursive_chained_imports(self, tmp_path):
+        """A -> B -> C: flattening A inlines B which inlines C (transitive)."""
+        _write_nb(tmp_path / "c.ipynb", [_code("class C { }")])
+        _write_nb(tmp_path / "b.ipynb", [_code("#!import c.ipynb"), _code("class B { }")])
+        a = _write_nb(tmp_path / "a.ipynb", [_code("#!import b.ipynb"), _code("class A { }")])
+        flat = flatten_notebook(a)
+        sources = ["".join(c.source) for c in flat.cells]
+        joined = "\n".join(sources)
+        assert "class C { }" in joined and "class B { }" in joined and "class A { }" in joined
+        assert all("#!import" not in s for s in sources)
+
+    def test_cycle_safe(self, tmp_path):
+        """A -> B -> A must not infinite-recurse; the second A is skipped
+        (already on the import chain)."""
+        _write_nb(tmp_path / "a.ipynb", [_code("#!import b.ipynb"), _code("class A { }")])
+        _write_nb(tmp_path / "b.ipynb", [_code("#!import a.ipynb"), _code("class B { }")])
+        flat = flatten_notebook(tmp_path / "a.ipynb")
+        # terminates and produces some flattened output (B inlined; second A skipped)
+        sources = ["".join(c.source) for c in flat.cells]
+        assert "class A { }" in sources
+        assert "class B { }" in sources
+
+    def test_missing_import_target_left_verbatim(self, tmp_path):
+        """A #!import pointing at a non-existent file is kept AS-IS so the
+        failure surfaces as a normal CellExecutionError on execute (not a
+        silent drop of the directive).
+        """
+        main = _write_nb(tmp_path / "main.ipynb", [
+            _code("#!import does-not-exist.ipynb"),
+            _code("var x = 1;"),
+        ])
+        flat = flatten_notebook(main)
+        sources = ["".join(c.source) for c in flat.cells]
+        assert any("#!import does-not-exist.ipynb" in s for s in sources)
+
+    def test_no_import_returns_notebook_unchanged(self, tmp_path):
+        """A notebook with no #!import flattens to itself (no-op)."""
+        main = _write_nb(tmp_path / "main.ipynb", [_md("# T"), _code("var x = 1;")])
+        flat = flatten_notebook(main)
+        assert len(flat.cells) == len(nbformat.read(main, as_version=4).cells)
+
+    def test_preserves_importing_notebook_metadata(self, tmp_path):
+        """The flattened notebook keeps the IMPORTING notebook's kernelspec
+        (not the imported helper's) -- it runs as the same kernel/language.
+        """
+        _write_nb(tmp_path / "env.ipynb", [_code("class Helper {}")], kernel="python3")
+        main = _write_nb(tmp_path / "main.ipynb", [_code("#!import env.ipynb")], kernel=".net-csharp")
+        flat = flatten_notebook(main)
+        assert flat.metadata["kernelspec"]["name"] == ".net-csharp"


### PR DESCRIPTION
## What

A new tool to **headless-execute `.NET` notebooks that use the `#!import` magic command** -- unblocking a durable platform limitation.

`dotnet-interactive`'s `#!import <Other.ipynb>` lets a .NET notebook pull in another notebook's cells (shared helper classes). It works in **VS Code Interactive** but THROWS `ArgumentNullException (key=null)` in `LoadAndRunInteractiveDocument` under **headless** execution (nbclient / papermill / nbconvert). This is **#4394**.

## The blast radius (why this matters)

**11 of 14 `Sudoku/*-Csharp.ipynb`** notebooks share helpers via `#!import Sudoku-0-Environment-Csharp.ipynb` → **none is re-executable headless**. Concretely:
- Any source edit to them = a **C.2 violation** (can't re-execute to refresh outputs).
- They are invisible to the **H.3 pre-commit**, `batch_reexecute`, and the **#3436 path-leak scan**.

## The workaround

The tool PRE-PROCESSES the `#!import` directive by **textually inlining the imported notebook's cells at the import site** (recursively, for chained imports). The imported cells run first in the same kernel → the kernel state is identical to a real `#!import`, but the flattened notebook is self-contained so **nbclient can execute it headless**.

## Verified firsthand (Sudoku-3-Genetic-Csharp, the #4394-blocked case)

```
flatten: 28 -> 41 cells (Sudoku-0 inlined), residual #!import: 0
FLAT EXEC SUCCESS in 68.7s | 17 code cells ec 1..17, 0 errors
  SudokuHelper cell ec=5: "SudokuHelper defini."  (resolves correctly)
  exercise stub ec=14:     "TODO: Implementez SudokuBlockChromosome"  (C.1 intact)
```

The blocker firsthand (before the tool):
```
#!import -> ArgumentNullException (Parameter 'key')
  at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(...:line 121)
```

## Usage

```bash
# Write a flattened copy (default: NB_flat.ipynb beside the input):
python flatten_import_notebook.py Sudoku-3-Genetic-Csharp.ipynb

# Flatten + headless-execute, report per-cell errors (no file written):
python flatten_import_notebook.py Sudoku-3-Genetic-Csharp.ipynb --execute --kernel .net-csharp --timeout 300

# Emit pure flattened JSON to stdout (progress on stderr) for piping:
python flatten_import_notebook.py NB.ipynb --stdout | jq '.cells | length'
```

## Design decisions

- **Never writes the source in place** -- flattening is a build artefact; the source keeps its `#!import` (the canonical VS Code-runnable form).
- **Recursive** -- chained imports `A -> B -> C` flatten transitively.
- **Cycle-safe** -- `A -> B -> A` skips the already-on-chain target (no infinite recursion).
- **Missing targets left verbatim** -- a `#!import does-not-exist.ipynb` is kept AS-IS so the failure surfaces as a normal `CellExecutionError` on execute (not a silent drop).
- **Preserves the importing notebook's kernelspec** (runs as the same kernel/language).

## Tests

**11/11 pass**: import detection (`IMPORT_RE`, ignores `#!csharp`/`#!time`/`%%`), inlining at site + ordering, recursive chains, cycle safety, missing-target verbatim, no-op, metadata preservation.

## Scope

- 2 files, +373 (new tool + tests).
- Pure tooling -- **no notebooks touched** (no C.2 re-exec needed).
- Catalog byte-identical to `main` (R1). Fresh base `origin/main` `bd54d76d2` (R2).

See #4394 (the `#!import` headless gap is the same class of platform limitation as the durable lean4-wsl Mathlib import path).

Co-Authored-By: Claude-Code <noreply@anthropic.com>