### PR TITLE
docs(genai): document FineTuning + PostTraining subsections in theme README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -27,7 +27,7 @@ GenAI/
 ├── PostTraining/            # Post-training SOTA : SFT/RLHF/DPO/GRPO/RLVR
 ├── CaseStudies/             # Études de cas étudiants
 ├── Open-WebUI/              # Plateforme Open WebUI : tour guidé + série QA Playwright
-│   └── Playwright-OWUI/     # Tests E2E Playwright (5 modules, 30+ tests)
+│   └── Playwright-OWUI/     # Tests E2E Playwright (6 modules, 30+ tests)
 ├── Vibe-Coding/             # Tutoriels Claude Code et Roo Code
 └── RAG-et-Memoire-Semantique/  # Mémoire sémantique : Qdrant, embeddings, grounding (SDDD)
 ```
@@ -87,6 +87,22 @@ Le texte est le socle de toute interaction avec l'IA générative. Cette série 
 Semantic Kernel est le SDK Microsoft pour construire des applications agentiques. Il fournit les briques pour orchestrer les LLMs avec des plugins, des agents, des filtres, des vector stores, et des processus multi-étapes. Cette série couvre le SDK en Python et en C# (.NET Interactive), avec une progression qui va des fondamentaux aux patterns avancés (MCP, multi-modalité, interop CLR).
 
 [README complet](SemanticKernel/README.md) | ~20h
+
+---
+
+### FineTuning - Adapter un modèle à votre tâche
+
+Un modèle généraliste ne connaît pas votre domaine, et le ré-entraîner de zéro coûterait des millions. Le fine-tuning l'adapte à moindre frais. Cette série progressive de 5 notebooks part des adaptateurs légers — LoRA, puis QLoRA qui quantifie le modèle en 4 bits pour tenir sur un GPU grand public (T4/V100) —, passe par le supervised fine-tuning (SFT) au format ChatML qui transforme un *base model* en modèle conversationnel, l'alignement sur les préférences humaines (RLHF/DPO), et culmine avec la fusion de plusieurs modèles spécialisés en un seul (TIES, DARE, routage MoE). C'est la boîte à outils **pratique** pour spécialiser un LLM.
+
+[README complet](FineTuning/README.md)
+
+---
+
+### PostTraining - La chaîne SOTA du post-entraînement
+
+Là où FineTuning donne la boîte à outils, PostTraining en est le **pendant théorique et SOTA (2024-2025)** : il remonte toute la chaîne conceptuelle du post-entraînement — SFT vers RLHF, DPO, GRPO, puis RLVR. Ces 7 notebooks prennent le parti d'expliquer d'abord la *mathématique du loss*, puis l'intuition, puis l'implémentation (TRL/HuggingFace) — l'ordre inverse des tutoriels habituels. Le fil rouge reproduit les techniques récentes, jusqu'au raisonnement à la Deepseek-R1 (janvier 2025), sur de **petits** modèles (Qwen2.5-0.5B/1.5B) qui tiennent sur un GPU 8 Go, avec évaluation comparative et détection du *reward hacking*. À suivre après FineTuning pour la profondeur méthodologique.
+
+[README complet](PostTraining/README.md)
 
 ---
 


### PR DESCRIPTION
## Contexte

Session éditoriale ai-01 (rotation famille **GenAI**) : regard narratif sur le README de thème `MyIA.AI.Notebooks/GenAI/README.md` — arc pédagogique, **promesses README vs contenu réel**, cohérence prose↔structure. Les feuilles-READMEs de la famille sont vertes → mise à jour ciblée du README intermédiaire (partition ai-01), pas de réécriture (No-Pendulum).

## Ce que corrige la PR (2 écarts *grounded* firsthand)

1. **Deux sous-domaines documentés dans la Structure + CATALOG-STATUS + Concepts clés mais absents de « ## Les sous-domaines »** :
   - `### FineTuning` — 5 notebooks (LoRA → QLoRA 4-bit → SFT ChatML → RLHF/DPO → fusion TIES/DARE/MoE), la boîte à outils **pratique**.
   - `### PostTraining` — 7 notebooks, le pendant **théorique/SOTA** (SFT→RLHF→DPO→GRPO→RLVR, reproductions Deepseek-R1 sur Qwen2.5-0.5B/1.5B, GPU 8 Go).
   - Prose FR-first fondée sur les README de feuille (`FineTuning/README.md`, `PostTraining/README.md`), placée après SemanticKernel comme dans le bloc Structure.
2. **Compteur périmé** : bloc Structure `Playwright-OWUI (5 modules...)` → **6 modules** — le `Playwright-OWUI/README.md` documente les modules 01→06 (module 06 = nouveautés v0.10, refonte #4433).

## Garanties d'hygiène

- Marqueur `CATALOG-STATUS` **byte-identique** (vérifié : diff ne touche pas les lignes 3-8).
- Aucun artefact de catalogue (`COURSE_CATALOG.generated.*`) touché.
- Atomique : 1 fichier, 17 insertions / 1 suppression, branche fraîche depuis origin/main.
- Liens `FineTuning/README.md` et `PostTraining/README.md` vérifiés (fichiers présents).

## Références

See #3974 (feuilles-READMEs GenAI/Python)
See #4208 (CoursIA → référence publique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)