### PR TITLE
docs(ml): README thème ML aligné sur la série ML.NET complète (9 notebooks + TP)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -34,9 +34,9 @@ Avoir les deux approches permet de comprendre que le ML n'est pas lié à un lan
 
 ## Parcours d'apprentissage
 
-### Track A : ML.NET (.NET/C#, 8 notebooks, ~6h)
+### Track A : ML.NET (.NET/C#, 9 notebooks + TP, ~7h)
 
-Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML). Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
+Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML). Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Les notebooks 8-9 ouvrent sur l'apprentissage non-supervisé : clustering K-Means (segmentation RFM, méthode du coude) puis détection d'anomalies par Randomized PCA (maintenance prédictive, choix du seuil de décision). Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
 
 ### Track B : Data Science with Agents (Python, 27 notebooks, ~21h)
 
@@ -60,6 +60,8 @@ ML/
 │   ├── ML-5-TimeSeries.ipynb
 │   ├── ML-6-ONNX.ipynb
 │   ├── ML-7-Recommendation.ipynb
+│   ├── ML-8-Clustering.ipynb
+│   ├── ML-9-Anomaly-Detection.ipynb
 │   ├── TP-prevision-ventes.ipynb
 │   └── taxi-fare.csv
 │
@@ -85,7 +87,9 @@ Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du 
 | 5 | [ML-5-TimeSeries](ML.Net/ML-5-TimeSeries.ipynb) | Forecasts temporelles, windowing | Séries temporelles |
 | 6 | [ML-6-ONNX](ML.Net/ML-6-ONNX.ipynb) | Export ONNX, inférence en production | Déploiement |
 | 7 | [ML-7-Recommendation](ML.Net/ML-7-Recommendation.ipynb) | Système de recommandation | Recommandations |
-| 8 | [TP-prevision-ventes](ML.Net/TP-prevision-ventes.ipynb) | Régression bayésienne (Infer.NET) | Application pratique |
+| 8 | [ML-8-Clustering](ML.Net/ML-8-Clustering.ipynb) | K-Means, segmentation RFM, méthode du coude | Non-supervisé |
+| 9 | [ML-9-Anomaly-Detection](ML.Net/ML-9-Anomaly-Detection.ipynb) | Randomized PCA, AUC, seuil de décision | Détection d'anomalies |
+| TP | [TP-prevision-ventes](ML.Net/TP-prevision-ventes.ipynb) | Régression bayésienne (Infer.NET) | Application pratique |
 
 ### Installation ML.NET
 


### PR DESCRIPTION
## Contexte (session éditoriale ai-01, rotation ML)

Passe narrative sur la famille **ML** : cohérence promesse README ↔ contenu réel.

Le README de **thème** (`MyIA.AI.Notebooks/ML/README.md`) annonçait « 8 notebooks » pour le Track ML.NET, alors que la série en livre **10** (`CATALOG-STATUS: ML.Net=10`). Les deux notebooks **ML-8-Clustering** et **ML-9-Anomaly-Detection** étaient déjà :
- documentés dans le README **feuille** (`ML.Net/README.md`, lignes 46-47),
- réellement présents et exécutés sur `main`.

…mais absents du README intermédiaire (arc du Track A, arbre Structure, table ML.NET). Écart promesse↔contenu, corrigé ici.

## Changements (additifs, No-Pendulum — freshness, pas réécriture)

1. **Track A** : « 8 notebooks, ~6h » → « 9 notebooks + TP, ~7h » + arc étendu (K-Means / segmentation RFM / méthode du coude ; Randomized PCA / maintenance prédictive / seuil de décision).
2. **Arbre Structure** : ajout de `ML-8-Clustering.ipynb` et `ML-9-Anomaly-Detection.ipynb` avant le TP.
3. **Table ML.NET** : ajout des lignes ML-8 et ML-9, TP relabellé « TP » (au lieu de « 8 »).

Descriptions **mirror** du README feuille (grounding firsthand : notebooks présents sur origin/main, titres/contenus vérifiés).

## Hygiène

- Marqueurs `CATALOG-STATUS` **inchangés** ; `COURSE_CATALOG.generated.*` **byte-identique** à main (catalog cron-owned).
- Un seul fichier touché (atomique), prose **FR-first** (readme-french-first).
- `See #4212` (finition éditoriale) / `See #3973` (feuilles-READMEs) — pas de `Closes` (contribution partielle à des Epics ouvertes).

See #4212
See #3973