### PR TITLE
fix(pymc): silence PyMC-7 ipywidgets path-leak via re-exec (#3436 cause B)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Classification.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Classification.ipynb
@@ -29,8 +29,7 @@
     "- Comprendre l'impact de la taille d'echantillon\n",
     "- Appliquer au CTR (Click-Through Rate)\n",
     "\n",
-    "**Prerequis** : PyMC-1 a PyMC-4, statistiques (loi binomiale, test d'hypothese)\n",
-    ""
+    "**Prerequis** : PyMC-1 a PyMC-4, statistiques (loi binomiale, test d'hypothese)\n"
    ]
   },
   {
@@ -39,10 +38,10 @@
    "id": "3cc69a7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:37:44.868377Z",
-     "iopub.status.busy": "2026-06-15T03:37:44.868377Z",
-     "iopub.status.idle": "2026-06-15T03:37:48.059967Z",
-     "shell.execute_reply": "2026-06-15T03:37:48.059462Z"
+     "iopub.execute_input": "2026-07-03T14:55:55.537614Z",
+     "iopub.status.busy": "2026-07-03T14:55:55.536616Z",
+     "iopub.status.idle": "2026-07-03T14:55:58.498817Z",
+     "shell.execute_reply": "2026-07-03T14:55:58.498817Z"
     },
     "papermill": {
      "duration": 3.197938,
@@ -141,10 +140,10 @@
    "id": "2c3ba543",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:37:48.078050Z",
-     "iopub.status.busy": "2026-06-15T03:37:48.078050Z",
-     "iopub.status.idle": "2026-06-15T03:38:15.207593Z",
-     "shell.execute_reply": "2026-06-15T03:38:15.207593Z"
+     "iopub.execute_input": "2026-07-03T14:55:58.502330Z",
+     "iopub.status.busy": "2026-07-03T14:55:58.501825Z",
+     "iopub.status.idle": "2026-07-03T14:56:21.516254Z",
+     "shell.execute_reply": "2026-07-03T14:56:21.516254Z"
     },
     "papermill": {
      "duration": 27.134621,
@@ -179,16 +178,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9a7e0a604095463b875f65fa4773f4b2",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -208,7 +204,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 25 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 21 seconds.\n"
      ]
     },
     {
@@ -283,10 +279,10 @@
    "id": "75dfc0f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:38:15.225649Z",
-     "iopub.status.busy": "2026-06-15T03:38:15.223643Z",
-     "iopub.status.idle": "2026-06-15T03:38:15.546623Z",
-     "shell.execute_reply": "2026-06-15T03:38:15.546623Z"
+     "iopub.execute_input": "2026-07-03T14:56:21.612042Z",
+     "iopub.status.busy": "2026-07-03T14:56:21.612042Z",
+     "iopub.status.idle": "2026-07-03T14:56:21.998144Z",
+     "shell.execute_reply": "2026-07-03T14:56:21.998144Z"
     },
     "papermill": {
      "duration": 0.327994,
@@ -375,10 +371,10 @@
    "id": "dc87018d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:38:15.569261Z",
-     "iopub.status.busy": "2026-06-15T03:38:15.569261Z",
-     "iopub.status.idle": "2026-06-15T03:38:15.573766Z",
-     "shell.execute_reply": "2026-06-15T03:38:15.573261Z"
+     "iopub.execute_input": "2026-07-03T14:56:21.998144Z",
+     "iopub.status.busy": "2026-07-03T14:56:21.998144Z",
+     "iopub.status.idle": "2026-07-03T14:56:22.003608Z",
+     "shell.execute_reply": "2026-07-03T14:56:22.003608Z"
     },
     "papermill": {
      "duration": 0.011018,
@@ -445,10 +441,10 @@
    "id": "e38f59d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:38:15.594381Z",
-     "iopub.status.busy": "2026-06-15T03:38:15.594381Z",
-     "iopub.status.idle": "2026-06-15T03:38:39.385209Z",
-     "shell.execute_reply": "2026-06-15T03:38:39.384825Z"
+     "iopub.execute_input": "2026-07-03T14:56:22.003608Z",
+     "iopub.status.busy": "2026-07-03T14:56:22.003608Z",
+     "iopub.status.idle": "2026-07-03T14:56:42.921743Z",
+     "shell.execute_reply": "2026-07-03T14:56:42.921743Z"
     },
     "papermill": {
      "duration": 23.797978,
@@ -483,16 +479,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7eda8b2d211e43f78c8128ce99dc2a9b",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -512,7 +505,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 22 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 20 seconds.\n"
      ]
     },
     {
@@ -584,10 +577,10 @@
    "id": "db62adc3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:38:39.404411Z",
-     "iopub.status.busy": "2026-06-15T03:38:39.404411Z",
-     "iopub.status.idle": "2026-06-15T03:41:00.585130Z",
-     "shell.execute_reply": "2026-06-15T03:41:00.584315Z"
+     "iopub.execute_input": "2026-07-03T14:56:42.987785Z",
+     "iopub.status.busy": "2026-07-03T14:56:42.987785Z",
+     "iopub.status.idle": "2026-07-03T14:58:58.794033Z",
+     "shell.execute_reply": "2026-07-03T14:58:58.792977Z"
     },
     "papermill": {
      "duration": 141.184787,
@@ -624,14 +617,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 22 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 20 seconds.\n"
      ]
     },
     {
@@ -639,6 +625,13 @@
      "output_type": "stream",
      "text": [
       "n= 10 : P(B>A) = 0.961\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -698,17 +691,17 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "n= 50 : P(B>A) = 0.988\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -729,7 +722,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 27 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 22 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -743,13 +743,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "Multiprocess sampling (4 chains in 4 jobs)\n"
      ]
     },
@@ -764,14 +757,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 20 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 21 seconds.\n"
      ]
     },
     {
@@ -779,6 +765,13 @@
      "output_type": "stream",
      "text": [
       "n=200 : P(B>A) = 0.983\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -879,10 +872,10 @@
    "id": "ebe74f79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:41:00.616703Z",
-     "iopub.status.busy": "2026-06-15T03:41:00.616703Z",
-     "iopub.status.idle": "2026-06-15T03:41:00.886259Z",
-     "shell.execute_reply": "2026-06-15T03:41:00.886259Z"
+     "iopub.execute_input": "2026-07-03T14:58:58.796278Z",
+     "iopub.status.busy": "2026-07-03T14:58:58.796278Z",
+     "iopub.status.idle": "2026-07-03T14:58:59.135649Z",
+     "shell.execute_reply": "2026-07-03T14:58:59.135649Z"
     },
     "papermill": {
      "duration": 0.278589,
@@ -960,10 +953,10 @@
    "id": "f67b10e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:41:00.919020Z",
-     "iopub.status.busy": "2026-06-15T03:41:00.919020Z",
-     "iopub.status.idle": "2026-06-15T03:41:25.011436Z",
-     "shell.execute_reply": "2026-06-15T03:41:25.010889Z"
+     "iopub.execute_input": "2026-07-03T14:58:59.135649Z",
+     "iopub.status.busy": "2026-07-03T14:58:59.135649Z",
+     "iopub.status.idle": "2026-07-03T14:59:24.318040Z",
+     "shell.execute_reply": "2026-07-03T14:59:24.317525Z"
     },
     "papermill": {
      "duration": 24.101493,
@@ -998,16 +991,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "73e589eb968f4dd38741b2bd2f7c457b",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -1027,7 +1017,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 23 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 24 seconds.\n"
      ]
     },
     {
@@ -1103,10 +1093,10 @@
    "id": "f80f194e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:41:25.039404Z",
-     "iopub.status.busy": "2026-06-15T03:41:25.039404Z",
-     "iopub.status.idle": "2026-06-15T03:41:25.052925Z",
-     "shell.execute_reply": "2026-06-15T03:41:25.052925Z"
+     "iopub.execute_input": "2026-07-03T14:59:24.429206Z",
+     "iopub.status.busy": "2026-07-03T14:59:24.429206Z",
+     "iopub.status.idle": "2026-07-03T14:59:24.441248Z",
+     "shell.execute_reply": "2026-07-03T14:59:24.441248Z"
     },
     "papermill": {
      "duration": 0.014531,
@@ -1204,10 +1194,10 @@
    "id": "927f8ffa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:41:25.110469Z",
-     "iopub.status.busy": "2026-06-15T03:41:25.109470Z",
-     "iopub.status.idle": "2026-06-15T03:41:25.114642Z",
-     "shell.execute_reply": "2026-06-15T03:41:25.113631Z"
+     "iopub.execute_input": "2026-07-03T14:59:24.441248Z",
+     "iopub.status.busy": "2026-07-03T14:59:24.441248Z",
+     "iopub.status.idle": "2026-07-03T14:59:24.448056Z",
+     "shell.execute_reply": "2026-07-03T14:59:24.448056Z"
     },
     "papermill": {
      "duration": 0.016843,
@@ -1309,7 +1299,7 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "3b12a835eadf4798af70de82ac1a5f7a": {
+     "73e589eb968f4dd38741b2bd2f7c457b": {
       "model_module": "@jupyter-widgets/output",
       "model_module_version": "1.0.0",
       "model_name": "OutputModel",
@@ -1322,13 +1312,13 @@
        "_view_module": "@jupyter-widgets/output",
        "_view_module_version": "1.0.0",
        "_view_name": "OutputView",
-       "layout": "IPY_MODEL_5779adf2443642fca50ce13a43ccbeaa",
+       "layout": "IPY_MODEL_fa3fd0da4f294b0e8e24be42f97dbe11",
        "msg_id": "",
        "outputs": [
         {
          "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           1.393       3           4862.43 draws/s      0:00:00    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           1.479       3           3350.21 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           1.087       1           2110.33 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           1.252       3           1655.82 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           1.393       3           4862.43 draws/s      0:00:00    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           1.479       3           3350.21 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           1.087       1           2110.33 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           1.252       3           1655.82 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n"
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.393       3            2844.24 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.479       3            1683.79 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.087       1            1158.12 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.252       3            850.31 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.393       3            2844.24 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.479       3            1683.79 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.087       1            1158.12 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.252       3            850.31 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -1338,7 +1328,36 @@
        "tooltip": null
       }
      },
-     "5779adf2443642fca50ce13a43ccbeaa": {
+     "7eda8b2d211e43f78c8128ce99dc2a9b": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_9768016fa7cf43c9a35310d270bdfbff",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.989       3            3554.67 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.651       3            1881.88 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.117       1            1254.79 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.229       3            951.46 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.989       3            3554.67 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.651       3            1881.88 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.117       1            1254.79 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.229       3            951.46 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "9768016fa7cf43c9a35310d270bdfbff": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1391,7 +1410,7 @@
        "width": null
       }
      },
-     "685593301547400bbe5ff1f015421fa7": {
+     "9a7e0a604095463b875f65fa4773f4b2": {
       "model_module": "@jupyter-widgets/output",
       "model_module_version": "1.0.0",
       "model_name": "OutputModel",
@@ -1404,13 +1423,13 @@
        "_view_module": "@jupyter-widgets/output",
        "_view_module_version": "1.0.0",
        "_view_name": "OutputView",
-       "layout": "IPY_MODEL_961b5f80dd0848d8b6f61a9ef6cc1ced",
+       "layout": "IPY_MODEL_cfc901a325c54615ab810ff74b99cc92",
        "msg_id": "",
        "outputs": [
         {
          "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.989       3           3876.67 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           1.651       3           2914.41 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           1.117       1           1947.37 draws/s      0:00:02    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           1.229       3           1600.75 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.989       3           3876.67 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           1.651       3           2914.41 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           1.117       1           1947.37 draws/s      0:00:02    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           1.229       3           1600.75 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n"
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.185       15           1273.16 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   1             0.209       15           1570.08 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.244       15           996.01 draws/s    0:00:04   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.232       15           697.42 draws/s    0:00:05   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.185       15           1273.16 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   1             0.209       15           1570.08 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.244       15           996.01 draws/s    0:00:04   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.232       15           697.42 draws/s    0:00:05   0:00:00    \n                                                                                                                   \n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -1420,7 +1439,7 @@
        "tooltip": null
       }
      },
-     "961b5f80dd0848d8b6f61a9ef6cc1ced": {
+     "cfc901a325c54615ab810ff74b99cc92": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1473,36 +1492,7 @@
        "width": null
       }
      },
-     "a583d0bc9f3b452a834c6fe6cee53e77": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_c5d9a381ac0947b4be6272dcdd81f14a",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.322       7           2129.31 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.233       7           2467.21 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.206       13          1809.30 draws/s      0:00:02    0:00:00   \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━</span>   4000        18          0.142       7           1621.59 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.322       7           2129.31 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.233       7           2467.21 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.206       13          1809.30 draws/s      0:00:02    0:00:00   \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        18          0.142       7           1621.59 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "c5d9a381ac0947b4be6272dcdd81f14a": {
+     "fa3fd0da4f294b0e8e24be42f97dbe11": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",


### PR DESCRIPTION
## What

`PyMC-7-Classification.ipynb` had **3 machine-path leaks** (cells 3, 9, 15), all `rich\live.py:260: UserWarning: install ipywidgets` during `pm.sample()` (Bayesian logistic regression, A/B test, CTR test). **Cause B**.

## Fix (Stop & Repair — re-exec real, NOT a scrub)

ipywidgets 8.1.8 installed (rule F) + re-exec with forced kernel via **nbconvert CLI** (ai-01 decision msg-g5awy3, canonical path — MCP jupyter excluded: async #5211 ignores kernel_name, sync #835 hangs).

## Validation (H.1)

| Check | Before | After |
|-------|--------|-------|
| machine-path leaks | **3** | **0** |
| ec range | [1..10] | [1..10] (coherent) |
| error outputs | — | 0 |
| C.1 banned patterns | 0 | 0 |
| source changed | — | **none** (pure cause-B) |
| kernelspec | python3 | python3 (preserved) |
| outputs changed | — | cells 3, 9, 11, 15 only |

Papermill `input/output_path` normalized to basename (convention). Diff +121/-131 = legitimate stochastic re-exec cost (honest re-exec, not scrubbing).

## Scope

One notebook, one cause. Follows #5218 (PyMC-3, same recipe). Probas/PyMC = po-2025 #3974 turf.

See #3436 (cause-B pass).

Co-Authored-By: Claude-Code <noreply@anthropic.com>