### PR TITLE
fix(pymc): silence PyMC-6 ipywidgets path-leak via re-exec (#3436 cause B)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-TrueSkill.ipynb
@@ -29,8 +29,7 @@
     "- Maitriser l'apprentissage en ligne (posterieurs deviennent priors)\n",
     "- Etendre aux equipes et multi-joueurs\n",
     "\n",
-    "**Prerequis** : PyMC-5 (modeles de competences IRT), statistiques\n",
-    ""
+    "**Prerequis** : PyMC-5 (modeles de competences IRT), statistiques\n"
    ]
   },
   {
@@ -39,10 +38,10 @@
    "id": "5ad1ba8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:42:11.696661Z",
-     "iopub.status.busy": "2026-06-15T03:42:11.696661Z",
-     "iopub.status.idle": "2026-06-15T03:42:14.886676Z",
-     "shell.execute_reply": "2026-06-15T03:42:14.886676Z"
+     "iopub.execute_input": "2026-07-03T15:02:29.352622Z",
+     "iopub.status.busy": "2026-07-03T15:02:29.352622Z",
+     "iopub.status.idle": "2026-07-03T15:02:32.047926Z",
+     "shell.execute_reply": "2026-07-03T15:02:32.047926Z"
     },
     "papermill": {
      "duration": 3.194065,
@@ -184,10 +183,10 @@
    "id": "40e53b79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:42:14.912118Z",
-     "iopub.status.busy": "2026-06-15T03:42:14.910376Z",
-     "iopub.status.idle": "2026-06-15T03:42:37.660644Z",
-     "shell.execute_reply": "2026-06-15T03:42:37.660644Z"
+     "iopub.execute_input": "2026-07-03T15:02:32.049672Z",
+     "iopub.status.busy": "2026-07-03T15:02:32.049672Z",
+     "iopub.status.idle": "2026-07-03T15:02:54.435771Z",
+     "shell.execute_reply": "2026-07-03T15:02:54.435771Z"
     },
     "papermill": {
      "duration": 22.755034,
@@ -222,16 +221,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "40d074fe614c4aa3a2b8c26ca27f6c1a",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -251,7 +247,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 21 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 20 seconds.\n"
      ]
     },
     {
@@ -324,10 +320,10 @@
    "id": "5760e439",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:42:37.681447Z",
-     "iopub.status.busy": "2026-06-15T03:42:37.681447Z",
-     "iopub.status.idle": "2026-06-15T03:42:37.802005Z",
-     "shell.execute_reply": "2026-06-15T03:42:37.800991Z"
+     "iopub.execute_input": "2026-07-03T15:02:54.508951Z",
+     "iopub.status.busy": "2026-07-03T15:02:54.508951Z",
+     "iopub.status.idle": "2026-07-03T15:02:54.648303Z",
+     "shell.execute_reply": "2026-07-03T15:02:54.648303Z"
     },
     "papermill": {
      "duration": 0.126604,
@@ -411,10 +407,10 @@
    "id": "ab84b100",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:42:37.827048Z",
-     "iopub.status.busy": "2026-06-15T03:42:37.827048Z",
-     "iopub.status.idle": "2026-06-15T03:45:02.687585Z",
-     "shell.execute_reply": "2026-06-15T03:45:02.687585Z"
+     "iopub.execute_input": "2026-07-03T15:02:54.650309Z",
+     "iopub.status.busy": "2026-07-03T15:02:54.650309Z",
+     "iopub.status.idle": "2026-07-03T15:05:28.274937Z",
+     "shell.execute_reply": "2026-07-03T15:05:28.274937Z"
     },
     "papermill": {
      "duration": 144.868049,
@@ -449,16 +445,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9b23fc3f5f5744b5ad95367f180c7d82",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -478,7 +471,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 144 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 153 seconds.\n"
      ]
     },
     {
@@ -599,10 +592,10 @@
    "id": "a3853c70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:45:02.714390Z",
-     "iopub.status.busy": "2026-06-15T03:45:02.713403Z",
-     "iopub.status.idle": "2026-06-15T03:45:02.716831Z",
-     "shell.execute_reply": "2026-06-15T03:45:02.716831Z"
+     "iopub.execute_input": "2026-07-03T15:05:29.958548Z",
+     "iopub.status.busy": "2026-07-03T15:05:29.958548Z",
+     "iopub.status.idle": "2026-07-03T15:05:29.974150Z",
+     "shell.execute_reply": "2026-07-03T15:05:29.974150Z"
     },
     "papermill": {
      "duration": 0.011706,
@@ -664,10 +657,10 @@
    "id": "22afe534",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:45:02.742653Z",
-     "iopub.status.busy": "2026-06-15T03:45:02.742653Z",
-     "iopub.status.idle": "2026-06-15T03:45:02.750488Z",
-     "shell.execute_reply": "2026-06-15T03:45:02.750488Z"
+     "iopub.execute_input": "2026-07-03T15:05:29.974150Z",
+     "iopub.status.busy": "2026-07-03T15:05:29.974150Z",
+     "iopub.status.idle": "2026-07-03T15:05:29.984207Z",
+     "shell.execute_reply": "2026-07-03T15:05:29.984207Z"
     },
     "papermill": {
      "duration": 0.014442,
@@ -760,10 +753,10 @@
    "id": "c0f1b776",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:45:02.776920Z",
-     "iopub.status.busy": "2026-06-15T03:45:02.776920Z",
-     "iopub.status.idle": "2026-06-15T03:47:27.225635Z",
-     "shell.execute_reply": "2026-06-15T03:47:27.225635Z"
+     "iopub.execute_input": "2026-07-03T15:05:29.985217Z",
+     "iopub.status.busy": "2026-07-03T15:05:29.985217Z",
+     "iopub.status.idle": "2026-07-03T15:07:27.728047Z",
+     "shell.execute_reply": "2026-07-03T15:07:27.728047Z"
     },
     "papermill": {
      "duration": 144.457147,
@@ -808,7 +801,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 22 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 19 seconds.\n"
      ]
     },
     {
@@ -843,14 +836,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 21 seconds.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Match : Alice bat Charlie\n"
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 19 seconds.\n"
      ]
     },
     {
@@ -858,6 +844,13 @@
      "output_type": "stream",
      "text": [
       "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Match : Alice bat Charlie\n"
      ]
     },
     {
@@ -878,7 +871,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 22 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 19 seconds.\n"
      ]
     },
     {
@@ -913,7 +906,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 20 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 19 seconds.\n"
      ]
     },
     {
@@ -948,7 +941,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 20 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 19 seconds.\n"
      ]
     },
     {
@@ -983,7 +976,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 23 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 19 seconds.\n"
      ]
     },
     {
@@ -1043,10 +1036,10 @@
    "id": "b73bd9ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:47:27.255282Z",
-     "iopub.status.busy": "2026-06-15T03:47:27.255282Z",
-     "iopub.status.idle": "2026-06-15T03:47:27.376248Z",
-     "shell.execute_reply": "2026-06-15T03:47:27.376248Z"
+     "iopub.execute_input": "2026-07-03T15:07:27.729746Z",
+     "iopub.status.busy": "2026-07-03T15:07:27.729746Z",
+     "iopub.status.idle": "2026-07-03T15:07:27.855726Z",
+     "shell.execute_reply": "2026-07-03T15:07:27.855726Z"
     },
     "papermill": {
      "duration": 0.130726,
@@ -1123,10 +1116,10 @@
    "id": "3b2c7481",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:47:27.411099Z",
-     "iopub.status.busy": "2026-06-15T03:47:27.411099Z",
-     "iopub.status.idle": "2026-06-15T03:48:02.104973Z",
-     "shell.execute_reply": "2026-06-15T03:48:02.104973Z"
+     "iopub.execute_input": "2026-07-03T15:07:27.856907Z",
+     "iopub.status.busy": "2026-07-03T15:07:27.856907Z",
+     "iopub.status.idle": "2026-07-03T15:07:50.905842Z",
+     "shell.execute_reply": "2026-07-03T15:07:50.905842Z"
     },
     "papermill": {
      "duration": 34.705097,
@@ -1161,16 +1154,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4f2f2bd246ba498a93610dc05d93c6f3",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -1190,7 +1180,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 28 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 22 seconds.\n"
      ]
     },
     {
@@ -1278,10 +1268,10 @@
    "id": "050f6d0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:48:02.140589Z",
-     "iopub.status.busy": "2026-06-15T03:48:02.140589Z",
-     "iopub.status.idle": "2026-06-15T03:48:26.928834Z",
-     "shell.execute_reply": "2026-06-15T03:48:26.928834Z"
+     "iopub.execute_input": "2026-07-03T15:07:51.003076Z",
+     "iopub.status.busy": "2026-07-03T15:07:51.003076Z",
+     "iopub.status.idle": "2026-07-03T15:08:18.665341Z",
+     "shell.execute_reply": "2026-07-03T15:08:18.665341Z"
     },
     "papermill": {
      "duration": 24.797078,
@@ -1316,16 +1306,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0c71618971934e069871efe7e7338040",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -1345,7 +1332,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 21 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 27 seconds.\n"
      ]
     },
     {
@@ -1411,10 +1398,10 @@
    "id": "3e9588ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:48:26.963723Z",
-     "iopub.status.busy": "2026-06-15T03:48:26.963723Z",
-     "iopub.status.idle": "2026-06-15T03:48:27.080892Z",
-     "shell.execute_reply": "2026-06-15T03:48:27.080892Z"
+     "iopub.execute_input": "2026-07-03T15:08:18.805991Z",
+     "iopub.status.busy": "2026-07-03T15:08:18.805991Z",
+     "iopub.status.idle": "2026-07-03T15:08:18.937169Z",
+     "shell.execute_reply": "2026-07-03T15:08:18.937169Z"
     },
     "papermill": {
      "duration": 0.125188,
@@ -1504,6 +1491,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ca1eafe9",
    "metadata": {},
    "source": [
     "## 7 bis. Le coeur de TrueSkill : EP, formules V(t)/W(t) et dynamique\n",
@@ -1581,10 +1569,10 @@
    "id": "5a6152f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:48:27.136443Z",
-     "iopub.status.busy": "2026-06-15T03:48:27.136443Z",
-     "iopub.status.idle": "2026-06-15T03:48:27.139469Z",
-     "shell.execute_reply": "2026-06-15T03:48:27.139469Z"
+     "iopub.execute_input": "2026-07-03T15:08:18.939182Z",
+     "iopub.status.busy": "2026-07-03T15:08:18.939182Z",
+     "iopub.status.idle": "2026-07-03T15:08:18.942283Z",
+     "shell.execute_reply": "2026-07-03T15:08:18.942283Z"
     },
     "papermill": {
      "duration": 0.013338,
@@ -1648,10 +1636,10 @@
    "id": "dcd98748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:48:27.174729Z",
-     "iopub.status.busy": "2026-06-15T03:48:27.174729Z",
-     "iopub.status.idle": "2026-06-15T03:48:27.178382Z",
-     "shell.execute_reply": "2026-06-15T03:48:27.178382Z"
+     "iopub.execute_input": "2026-07-03T15:08:18.942283Z",
+     "iopub.status.busy": "2026-07-03T15:08:18.942283Z",
+     "iopub.status.idle": "2026-07-03T15:08:18.949269Z",
+     "shell.execute_reply": "2026-07-03T15:08:18.949269Z"
     },
     "papermill": {
      "duration": 0.013672,
@@ -1745,7 +1733,65 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "1636a112f43a4939a2f1ed8373eca2de": {
+     "0c71618971934e069871efe7e7338040": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_a544bf1390784d9cbbfe2eb49470bbea",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.286       7            1340.15 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.311       7            479.27 draws/s    0:00:08   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.314       7            445.12 draws/s    0:00:08   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.338       15           338.10 draws/s    0:00:11   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.286       7            1340.15 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.311       7            479.27 draws/s    0:00:08   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.314       7            445.12 draws/s    0:00:08   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.338       15           338.10 draws/s    0:00:11   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "40d074fe614c4aa3a2b8c26ca27f6c1a": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_f6b237b17dd34cd99582107b3bd13ffe",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.352       15           2098.11 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.304       7            1580.01 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.312       15           1201.62 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.251       7            777.86 draws/s    0:00:05   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.352       15           2098.11 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.304       7            1580.01 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.312       15           1201.62 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.251       7            777.86 draws/s    0:00:05   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "460d704700e0462b89d7323f23566b35": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1798,7 +1844,65 @@
        "width": null
       }
      },
-     "2b0b7c90849744aabe602bc8e8689fde": {
+     "4f2f2bd246ba498a93610dc05d93c6f3": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_460d704700e0462b89d7323f23566b35",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.169       15           927.41 draws/s    0:00:04   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.177       23           1070.97 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.231       31           797.41 draws/s    0:00:05   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.214       15           571.29 draws/s    0:00:07   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.169       15           927.41 draws/s    0:00:04   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.177       23           1070.97 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.231       31           797.41 draws/s    0:00:05   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.214       15           571.29 draws/s    0:00:07   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "9b23fc3f5f5744b5ad95367f180c7d82": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_c0071f41a12b4d91a4e52e1b93137e93",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                    </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed         </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.000       1023         29.74 draws/s   0:02:14   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.002       1023         29.59 draws/s   0:02:15   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.001       1023         29.40 draws/s   0:02:16   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.000       1023         29.06 draws/s   0:02:17   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                   \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed        \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.000       1023         29.74 draws/s   0:02:14   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.002       1023         29.59 draws/s   0:02:15   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.001       1023         29.40 draws/s   0:02:16   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.000       1023         29.06 draws/s   0:02:17   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "a544bf1390784d9cbbfe2eb49470bbea": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1851,94 +1955,7 @@
        "width": null
       }
      },
-     "71f7da64b13449b081cbec46c25265aa": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_1636a112f43a4939a2f1ed8373eca2de",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.410       15          1771.00 draws/s      0:00:02    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.267       15          2033.98 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.266       15          1565.29 draws/s      0:00:02    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.383       23          1442.63 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.410       15          1771.00 draws/s      0:00:02    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.267       15          2033.98 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.266       15          1565.29 draws/s      0:00:02    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.383       23          1442.63 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "73e04fa564c34db69bc6d2283e619c71": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_c7c21a7687fa4dc3aa7804dc3c0c8d37",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.236       15          1580.33 draws/s      0:00:02    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.152       7           1439.76 draws/s      0:00:02    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.254       15          1301.49 draws/s      0:00:03    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.287       31          1220.76 draws/s      0:00:03    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.236       15          1580.33 draws/s      0:00:02    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.152       7           1439.76 draws/s      0:00:02    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.254       15          1301.49 draws/s      0:00:03    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.287       31          1220.76 draws/s      0:00:03    0:00:00   \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "b16f3f9dfeb14a39b34fee4ac059fff5": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_2b0b7c90849744aabe602bc8e8689fde",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.000       1023        42.15 draws/s        0:01:34    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.002       1023        41.69 draws/s        0:01:35    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.001       1023        41.87 draws/s        0:01:35    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.000       1023        41.55 draws/s        0:01:36    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.000       1023        42.15 draws/s        0:01:34    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.002       1023        41.69 draws/s        0:01:35    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.001       1023        41.87 draws/s        0:01:35    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.000       1023        41.55 draws/s        0:01:36    0:00:00   \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "be2c48d404da463d836b4971217f7ac6": {
+     "c0071f41a12b4d91a4e52e1b93137e93": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1991,7 +2008,7 @@
        "width": null
       }
      },
-     "c7c21a7687fa4dc3aa7804dc3c0c8d37": {
+     "f6b237b17dd34cd99582107b3bd13ffe": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -2042,35 +2059,6 @@
        "top": null,
        "visibility": null,
        "width": null
-      }
-     },
-     "e48d45f376424b01bd5d36de81184ce5": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_be2c48d404da463d836b4971217f7ac6",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.341       7           3109.44 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.309       11          2591.11 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.346       15          2183.07 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.228       15          1833.51 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.341       7           3109.44 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.309       11          2591.11 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.346       15          2183.07 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.228       15          1833.51 draws/s      0:00:02    0:00:00   \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
       }
      }
     },


### PR DESCRIPTION
## What

`PyMC-6-TrueSkill.ipynb` had **4 machine-path leaks** (cells 4, 8, 18, 20), all `rich\live.py:260: UserWarning: install ipywidgets` during `pm.sample()` (TrueSkill ranking, match nul, 2v2 équipes, multi-joueurs). **Cause B**.

## Fix (Stop & Repair — re-exec real, NOT a scrub)

ipywidgets 8.1.8 installed (rule F) + re-exec with forced kernel via **nbconvert CLI** (ai-01 decision msg-g5awy3, canonical path — MCP jupyter excluded: async #5211 ignores kernel_name, sync #835 hangs).

## Validation (H.1)

| Check | Before | After |
|-------|--------|-------|
| machine-path leaks | **4** | **0** |
| ec range | [1..13] | [1..13] (coherent) |
| error outputs | — | 0 |
| C.1 banned patterns | 0 | 0 |
| source changed | — | **none** (pure cause-B) |
| kernelspec | python3 | python3 (preserved) |
| outputs changed | — | cells 4, 8, 14, 18, 20 only |

Papermill paths normalized to basename. Diff +206/-218 = legitimate stochastic re-exec cost (honest re-exec, not scrubbing).

## Scope

One notebook, one cause. Follows #5218 (PyMC-3) + #5219 (PyMC-7), same recipe. Probas/PyMC = po-2025 #3974 turf.

See #3436 (cause-B pass).

Co-Authored-By: Claude-Code <noreply@anthropic.com>