### PR TITLE
feat(notebook-tools): enforce .NET execution_count — CI skip != outputs may be empty (#5214)

### DIFF
--- a/.claude/rules/pr-review-discipline.md
+++ b/.claude/rules/pr-review-discipline.md
@@ -51,6 +51,8 @@ Toute PR touchant `*.ipynb` **DOIT** inclure :
 3. Cellules code = `execution_count: <int>` ET `outputs: [...]` cohérents (règle C.2 CLAUDE.md)
 4. Diff ne supprime pas de cellules `# Solution` ou `# Exemple résolu` sans issue référencée (anti-régression)
 
+**Advisory `.NET execution_count` ≠ outputs vides autorisés (#5214).** La CI ne peut pas Papermill-exécuter les notebooks .NET Interactive (pas de kernel en CI) — l'advisory autorise à **sauter la ré-exécution CI**, **pas** à committer des sorties vides. `.NET Interactive` s'exécute **localement** sur chaque machine worker (`dotnet-interactive`), donc une cellule .NET committée **DOIT** porter `execution_count != null` = preuve d'exécution locale. Le validateur `scripts/notebook_tools/validate_pr_notebooks.py` FAIL désormais sur un notebook .NET avec `execution_count: null` (verdict forensique H.5 `STRUCTURAL_ONLY`), et ne tolère `null` que là où l'exécution locale est aussi impossible (QC Cloud = besoin QuantBook ; Lean = advisory propre, hors scope). Incident fondateur : PRs Tweety-3 C# (#5194/#5199/#5202) mergées avec notebooks à `execution_count: null` + `outputs: []`. Verdict attendu dans le body : `EXEC_PROVED` (outputs réels) vs `STRUCTURAL_ONLY` (refus).
+
 ### E. Documentation/Admin PRs : groupement obligatoire
 
 PRs dont le contenu = uniquement docs/README/CLAUDE.md/rules :

--- a/scripts/notebook_tools/tests/test_validate_pr_mutation.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_mutation.py
@@ -71,13 +71,18 @@ def _code(source, execution_count=1, outputs=None):
 
 
 class TestSkipExecOrCombination:
-    """If either condition is true, skip_exec must be True.
+    """allow_null_exec_count is an OR of (Lean kernel) | (QC Cloud). #5214 split
+    this out of ci_reexec_skipped: .NET is in SKIP_EXEC_KERNELS (CI can't re-run)
+    but NOT in allow_null_exec_count (runs locally → must prove execution).
 
-    A mutation swapping `or` to `and` would make these fail.
+    A mutation swapping `or` to `and`, or wrongly re-adding .NET to
+    ALLOW_NULL_EXEC_COUNT_KERNELS, would make these fail.
     """
 
-    def test_dotnet_kernel_skips_exec(self, tmp_path):
-        """Kernel in SKIP_EXEC_KERNELS → H.3 skipped."""
+    def test_dotnet_kernel_does_not_skip_h3(self, tmp_path):
+        """Kernel in SKIP_EXEC_KERNELS but NOT in ALLOW_NULL_EXEC_COUNT_KERNELS
+        → H.3 is enforced (#5214: .NET runs locally). A mutation that re-adds
+        .NET to the allow-null set would make this fail."""
         cell = {
             "cell_type": "code",
             "source": ["print('hi')\n"],
@@ -86,10 +91,10 @@ class TestSkipExecOrCombination:
         }
         nb = _write_nb([cell], tmp_path, kernel=".net-csharp")
         result = validate_notebook(nb)
-        # H.3 not flagged (kernel skip)
-        assert result["passed"]
+        assert not result["passed"]
         h3_errors = [e for e in result["errors"] if "H.3" in e]
-        assert h3_errors == []
+        assert len(h3_errors) == 1
+        assert result["forensic_verdict"] == "STRUCTURAL_ONLY"
 
     def test_qc_cloud_path_skips_exec(self, tmp_path):
         """Path in QC_CLOUD_PATHS → H.3 skipped, even with python3 kernel."""
@@ -724,8 +729,9 @@ class TestSkipExecKernelSubstring:
         h3 = [e for e in result["errors"] if "H.3" in e]
         assert h3 == []
 
-    def test_dotnet_fsharp_kernel_skipped(self, tmp_path):
-        """'.net-fsharp' in SKIP_EXEC_KERNELS → H.3 skipped."""
+    def test_dotnet_fsharp_kernel_enforces_h3(self, tmp_path):
+        """'.net-fsharp' is in SKIP_EXEC_KERNELS (CI can't re-run) but, like all
+        .NET Interactive kernels, runs locally → H.3 enforced (#5214)."""
         cell = {
             "cell_type": "code",
             "source": ["let x = 1\n"],
@@ -735,10 +741,11 @@ class TestSkipExecKernelSubstring:
         nb = _write_nb([cell], tmp_path, kernel=".net-fsharp")
         result = validate_notebook(nb)
         h3 = [e for e in result["errors"] if "H.3" in e]
-        assert h3 == []
+        assert len(h3) == 1
 
-    def test_dotnet_powershell_kernel_skipped(self, tmp_path):
-        """'.net-powershell' in SKIP_EXEC_KERNELS → H.3 skipped."""
+    def test_dotnet_powershell_kernel_enforces_h3(self, tmp_path):
+        """'.net-powershell' is in SKIP_EXEC_KERNELS but runs locally → H.3
+        enforced (#5214)."""
         cell = {
             "cell_type": "code",
             "source": ["Get-Date\n"],
@@ -748,7 +755,7 @@ class TestSkipExecKernelSubstring:
         nb = _write_nb([cell], tmp_path, kernel=".net-powershell")
         result = validate_notebook(nb)
         h3 = [e for e in result["errors"] if "H.3" in e]
-        assert h3 == []
+        assert len(h3) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -890,20 +897,20 @@ class TestC1ScannerIntegration:
 
 
 # ---------------------------------------------------------------------------
-# Mutation test: main() --strict flag
+# Mutation test: main() exit code — .NET null exec_count fails BY DEFAULT (#5214)
 # ---------------------------------------------------------------------------
 
 
-class TestMainStrictFlag:
-    """Verify --strict flag affects behavior for non-Python kernels."""
+class TestMainDotnetStrictByDefault:
+    """A .NET notebook with execution_count=None fails by default — no opt-in
+    flag needed. #5214 made the .NET execution_count check mandatory because
+    dotnet-interactive runs locally on every worker (the old --strict opt-in
+    flag was never wired and is now removed; its intent is the default for .NET).
+    Regression guard for the Tweety-3 cluster (#5194/#5199/#5202) merged with
+    execution_count:null + outputs:[]."""
 
-    def test_strict_flag_causes_exit_1_for_dotnet_exec_none(self, tmp_path):
-        """--strict with dotnet kernel + execution_count=None → fail.
-
-        Note: current implementation does not implement --strict for H.3
-        (it only adds execution_count check for non-Python kernels).
-        This test documents expected behavior if --strict is implemented.
-        """
+    def test_dotnet_exec_none_fails_by_default(self, tmp_path):
+        """dotnet kernel + execution_count=None → exit 1, no flag required."""
         cell = {
             "cell_type": "code",
             "source": ["Console.WriteLine('hi');\n"],
@@ -911,7 +918,6 @@ class TestMainStrictFlag:
             "outputs": [],
         }
         p = _write_nb([cell], tmp_path, kernel=".net-csharp")
-        with patch("sys.argv", ["validate_pr_notebooks.py", "--strict", "origin/main", str(p)]):
+        with patch("sys.argv", ["validate_pr_notebooks.py", "origin/main", str(p)]):
             exit_code = main()
-        # Currently --strict doesn't affect H.3 skip_exec, so this passes
-        assert exit_code == 0
+        assert exit_code == 1

--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -102,6 +102,7 @@ class TestValidateNotebookH3:
         assert result["passed"] is True
         assert result["total_code"] == 2
         assert result["errors"] == []
+        assert result["forensic_verdict"] == "EXEC_PROVED"
 
     def test_null_exec_count_fails(self, tmp_path):
         nb = _write_nb(tmp_path / "test.ipynb", [
@@ -110,30 +111,67 @@ class TestValidateNotebookH3:
         result = validate_notebook(nb)
         assert result["passed"] is False
         assert any("execution_count is null" in e for e in result["errors"])
+        assert result["forensic_verdict"] == "STRUCTURAL_ONLY"
 
-    def test_skip_exec_for_dotnet_kernel(self, tmp_path):
-        """dotnet kernel notebooks skip execution_count check."""
+    def test_dotnet_null_exec_count_fails_5214(self, tmp_path):
+        """A .NET Interactive notebook with a null execution_count FAILS —
+        dotnet-interactive runs locally on every worker, so a committed .NET
+        cell must prove execution (#5214: "CI skip .NET" != "outputs may be
+        empty"). Regression guard for the Tweety-3 cluster (#5194/#5199/#5202)
+        merged at execution_count:null + outputs:[]."""
         nb = _write_nb(tmp_path / "test.ipynb", [
             _code("Console.WriteLine(\"hi\")", exec_count=None),
         ], kernelspec={"name": ".net-csharp", "language": "C#"})
         result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("execution_count is null" in e and "#5214" in e
+                   for e in result["errors"])
+        assert result["forensic_verdict"] == "STRUCTURAL_ONLY"
+
+    def test_dotnet_exec_proved_passes(self, tmp_path):
+        """A .NET notebook executed locally (execution_count set) PASSes and is
+        stamped EXEC_PROVED — the verdict a reviewer/bot trusts (#5214, H.5)."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code("Console.WriteLine(\"hi\")", exec_count=1,
+                  outputs=[{"output_type": "stream", "name": "stdout",
+                            "text": ["hi"]}]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
         assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"
+
+    def test_dotnet_empty_outputs_with_exec_count_passes(self, tmp_path):
+        """A .NET cell that ran but produced no display output (e.g. a pure
+        assignment `var x = 5;`) still PASSes — execution_count is the proof
+        of execution, NOT a non-empty outputs list. This is the crucial
+        distinction: null exec_count (never ran) FAILs, but exec_count set +
+        empty outputs (ran, no output) is legitimate (#5214)."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code("var x = 5;", exec_count=1),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"
 
     def test_skip_exec_for_lean_kernel(self, tmp_path):
+        """Lean notebooks tolerate a null execution_count (kept advisory — own
+        rendering subtleties via lean4_jupyter/alectryon, out of #5214 scope)."""
         nb = _write_nb(tmp_path / "test.ipynb", [
             _code("#check Nat", exec_count=None),
         ], kernelspec={"name": "lean4", "language": "lean4"})
         result = validate_notebook(nb)
         assert result["passed"] is True
+        assert result["forensic_verdict"] == "ADVISORY_NON_EXEC"
 
     def test_skip_exec_for_qc_cloud_path(self, tmp_path):
-        """Notebooks in QuantConnect/ paths skip execution check."""
+        """Notebooks in QuantConnect/ paths skip execution check (need QC Cloud)."""
         qc_path = tmp_path / "QuantConnect" / "Python" / "test.ipynb"
         nb = _write_nb(qc_path, [
             _code("qb = QuantBook()", exec_count=None),
         ])
         result = validate_notebook(nb)
         assert result["passed"] is True
+        assert result["forensic_verdict"] == "ADVISORY_NON_EXEC"
 
     def test_skip_exec_for_qc_projects_path(self, tmp_path):
         qc_path = tmp_path / "QuantConnect" / "projects" / "test.ipynb"

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -30,12 +30,28 @@ from notebook_lint import scan_c1_source
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
-# Kernels that cannot be executed via Papermill in CI (skip execution check,
-# but still check C.1 and structural validity)
+# Kernels that cannot be Papermill-executed in CI. The CI re-exec gate is
+# advisory for these (no kernel to re-run), but C.1 + structural validity are
+# still enforced. NOTE: "CI can't re-run" is NOT the same as "outputs may be
+# empty" — see ALLOW_NULL_EXEC_COUNT_KERNELS for that finer distinction (#5214).
 SKIP_EXEC_KERNELS = {
     ".net-csharp", ".net-fsharp", ".net-powershell",
     "lean4", "lean4-wsl", "lean",
 }
+
+# Where a NULL execution_count is genuinely tolerated (#5214): the reviewer
+# CANNOT execute the notebook locally either. Two cases:
+#  - QC Cloud needs the QuantBook runtime (nowhere on a worker machine).
+#  - Lean is kept advisory for now (its own rendering subtleties via
+#    lean4_jupyter/alectryon, and #5214 scopes the change to .NET).
+# .NET Interactive is EXCLUDED on purpose: dotnet-interactive runs on every
+# worker machine (the 6 older Tweety ports — Dung, Aspic, 2b, 2c — are
+# committed with real execution_count + outputs as proof), so a committed
+# .NET cell MUST prove local execution (execution_count != null). The
+# incident: PRs #5194/#5199/#5202 (Tweety-3 C#) were merged with notebooks at
+# execution_count:null + outputs:[] — a C.2 violation the old advisory let
+# through because it fused "CI skip" with "outputs may be empty".
+ALLOW_NULL_EXEC_COUNT_KERNELS = {"lean4", "lean4-wsl", "lean"}
 
 # Paths that require QC Cloud (python3 kernel but need QuantBook runtime).
 # H.3 is advisory-only for these — they can only be executed via QC Cloud.
@@ -107,6 +123,18 @@ def _output_text(output: dict) -> str:
     return " ".join(parts)
 
 
+def _is_qc_cloud(rel_path: str, data: dict) -> bool:
+    """Whether a notebook can ONLY be executed via QC Cloud (so a null
+    execution_count is tolerated everywhere — CI AND local). True if the path
+    is under a QC Cloud directory OR the notebook is explicitly flagged as a
+    QC reference template (metadata.qc_reference=True, content-aware unification
+    with regression_scan.py:261 / #3776)."""
+    normalized = rel_path.replace("\\", "/")
+    if any(p in normalized for p in QC_CLOUD_PATHS):
+        return True
+    return data.get("metadata", {}).get("qc_reference") is True
+
+
 def validate_notebook(nb_path: Path) -> dict:
     """Validate a single notebook for H.1/H.3 compliance.
 
@@ -132,18 +160,22 @@ def validate_notebook(nb_path: Path) -> dict:
         return result
 
     kernel = result["kernel"]
-    skip_exec = any(k in kernel for k in SKIP_EXEC_KERNELS)
-    normalized = rel_path.replace("\\", "/")
-    skip_exec = skip_exec or any(p in normalized for p in QC_CLOUD_PATHS)
-    # Content-aware unification (#3776): a notebook explicitly flagged as a
-    # QC Cloud reference/template (metadata.qc_reference=True) is exempt from
-    # the H.3 execution_count gate for the same reason QC_CLOUD_PATHS is — it
-    # can only be executed via QC Cloud. This unifies the gate with
-    # regression_scan.py:261, which is already content-aware. Without this,
-    # the H.3 gate exempts by PATH but not by content, so a flagged reference
-    # notebook outside QuantConnect/Python|projects (e.g. partner-course
-    # examples) fails H.3 even though it is honestly non-executable-by-design.
-    skip_exec = skip_exec or data.get("metadata", {}).get("qc_reference") is True
+    # "CI cannot Papermill-execute this kernel" — the CI re-exec gate is
+    # advisory, and H.1 error outputs are advisory (expected without the
+    # kernel/runtime). Covers .NET, Lean, QC Cloud, qc_reference templates.
+    qc_cloud = _is_qc_cloud(rel_path, data)
+    ci_reexec_skipped = any(k in kernel for k in SKIP_EXEC_KERNELS) or qc_cloud
+    # "A null execution_count is tolerated" — STRICTER than ci_reexec_skipped.
+    # Only where local execution is ALSO impossible (QC Cloud needs QuantBook;
+    # Lean kept advisory for now — own rendering subtleties, out of #5214).
+    # .NET Interactive runs locally (dotnet-interactive on every worker) → a
+    # committed .NET cell MUST carry execution_count != null = EXEC_PROVED
+    # (#5214: "CI skip .NET" != "outputs may be empty"). The Tweety-3 cluster
+    # (#5194/#5199/#5202) was merged at execution_count:null + outputs:[].
+    allow_null_exec_count = (
+        any(k in kernel for k in ALLOW_NULL_EXEC_COUNT_KERNELS) or qc_cloud
+    )
+    saw_null_exec = False  # for the forensic verdict (H.5)
 
     for i, cell in enumerate(data.get("cells", [])):
         if cell.get("cell_type") != "code":
@@ -174,13 +206,20 @@ def validate_notebook(nb_path: Path) -> dict:
                 f"cell {i}: C.1 violation — '{desc}' found"
             )
 
-        # H.3 check: execution_count must not be null (skip for non-Papermill kernels)
-        if not skip_exec:
+        # H.3 check: execution_count must not be null. Advisory ONLY where local
+        # execution is impossible too (QC Cloud / Lean — allow_null_exec_count).
+        # .NET Interactive executes locally, so a null execution_count is a C.2
+        # violation (commit proof of local execution); "CI skip" is not a
+        # license to ship empty outputs (#5214).
+        if not allow_null_exec_count:
             exec_count = cell.get("execution_count")
             if exec_count is None:
+                saw_null_exec = True
                 result["passed"] = False
                 result["errors"].append(
-                    f"cell {i}: execution_count is null (H.3 violation)"
+                    f"cell {i}: execution_count is null "
+                    f"(H.3/C.2 violation — {kernel} executes locally; "
+                    f"commit execution proof, See #5214)"
                 )
 
         # H.1 check: no error outputs. Two rendering paths:
@@ -199,7 +238,7 @@ def validate_notebook(nb_path: Path) -> dict:
         for output in cell.get("outputs", []):
             if output.get("output_type") == "error":
                 ename = output.get("ename", "Unknown")
-                if skip_exec:
+                if ci_reexec_skipped:
                     result["errors"].append(
                         f"cell {i}: has error output — {ename} (advisory, QC Cloud)"
                     )
@@ -219,6 +258,16 @@ def validate_notebook(nb_path: Path) -> dict:
                 )
                 break  # one report per cell is enough
 
+    # Forensic verdict (H.5): EXEC_PROVED / STRUCTURAL_ONLY / ADVISORY_NON_EXEC.
+    # Distinguishes "real outputs present" from "structural-only / advisory" so
+    # reviewers and bots apply CHANGES_REQUESTED on the second (#5214).
+    if allow_null_exec_count:
+        result["forensic_verdict"] = "ADVISORY_NON_EXEC"
+    elif saw_null_exec:
+        result["forensic_verdict"] = "STRUCTURAL_ONLY"
+    else:
+        result["forensic_verdict"] = "EXEC_PROVED"
+
     return result
 
 
@@ -237,10 +286,6 @@ def main():
     parser.add_argument(
         "--json", action="store_true",
         help="Output results as JSON",
-    )
-    parser.add_argument(
-        "--strict", action="store_true",
-        help="Also check execution_count for non-Python kernels",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## What

Harden the `.NET execution_count` advisory in `scripts/notebook_tools/validate_pr_notebooks.py` so that **"CI skip .NET" ≠ "outputs may be empty"** (issue #5214).

The PR-gate validator previously fused two distinct concepts into one boolean (`skip_exec`):
- "the CI cannot Papermill-execute this kernel" (legitimate advisory — no kernel in CI)
- "a null execution_count is tolerated" (NOT legitimate for .NET)

That fusion let the Tweety-3 C# cluster (#5194 / #5199 / #5202) merge with notebooks at `execution_count: null` + `outputs: []` — a C.2 violation the advisory was never meant to allow.

## The fix

Split `allow_null_exec_count` out of `ci_reexec_skipped`:

```python
# CI cannot re-run these kernels (advisory on the impossible CI re-exec)
ci_reexec_skipped = kernel in SKIP_EXEC_KERNELS or qc_cloud

# null execution_count tolerated ONLY where LOCAL execution is impossible too.
# .NET Interactive runs locally (dotnet-interactive on every worker) -> a
# committed .NET cell MUST prove execution (EXEC_PROVED). #5214.
allow_null_exec_count = kernel in ALLOW_NULL_EXEC_COUNT_KERNELS or qc_cloud
#   ALLOW_NULL_EXEC_COUNT_KERNELS = {lean4, lean4-wsl, lean}   # Lean kept advisory (own rendering, out of scope)
```

So for `.net-csharp` / `.net-fsharp` / `.net-powershell`: `execution_count == null` on an executable code cell is now a **FAIL** (`STRUCTURAL_ONLY`), exactly like Python. QC Cloud (needs QuantBook, nowhere on a worker) and Lean (kept advisory — own alectryon rendering subtleties, out of #5214 scope) still tolerate `null`.

## Bonus — forensic verdict (H.5)

Each notebook result now carries a `forensic_verdict` so reviewers and bots can apply `CHANGES_REQUESTED` deterministically:

| verdict | meaning |
|---------|---------|
| `EXEC_PROVED` | all executable cells have `execution_count != null` (real outputs present) |
| `STRUCTURAL_ONLY` | a cell has `execution_count: null` where local exec is possible → **FAIL** |
| `ADVISORY_NON_EXEC` | kernel/path where `null` is tolerated (QC Cloud, Lean) |

## Housekeeping

- Removed the dead `--strict` flag (defined on the parser but never read — `test_validate_pr_mutation.py:900` documented it as unwired). Its intent ("also check execution_count for non-Python kernels") is now the **default** for .NET.
- `.claude/rules/pr-review-discipline.md` §D: clarified that the advisory `.NET execution_count` authorizes the CI skip, **not** empty outputs.

## Acceptance (#5214)

- [x] The PR-notebook validator distinguishes "CI skip .NET" from "outputs-empty allowed" and FAILs on the latter for .NET.
- [x] Unit test: a .NET notebook with `execution_count: null` + `outputs: []` → verdict `STRUCTURAL_ONLY` / FAIL.
- [x] Reviewer doc (`pr-review-discipline.md` §D) notes the advisory .NET does not waive C.2.

## Proof

```
$ python -m pytest scripts/notebook_tools/tests/ -q
2007 passed in 21.49s

$ python validate_pr_notebooks.py origin/main Sudoku-3-Genetic-Csharp.ipynb --json
  Sudoku-3-Genetic-Csharp.ipynb: kernel=.net-csharp passed=True verdict=EXEC_PROVED cells=11

$ python validate_pr_notebooks.py origin/main QuantConnect/projects/ForexCarry/quantbook.ipynb --json
  quantbook.ipynb: kernel=python3 passed=True verdict=ADVISORY_NON_EXEC cells=10
```

Smoke (synthetic): `.NET null` → `passed=False verdict=STRUCTURAL_ONLY` (+ message `See #5214`); `.NET exec` (with or without display output) → `EXEC_PROVED`; `Lean null` / `QC null` → `ADVISORY_NON_EXEC`; `Python null` → `STRUCTURAL_ONLY` (unchanged).

## Honest caveat — pre-existing debt surfaced

A repo-wide sanity scan (`origin/main`) finds **7** `.NET` notebooks that already carry `execution_count: null` code cells and will FAIL the gate the next time a PR touches them (this is the intent — it forces local execution):

| notebook | null cells | note |
|----------|-----------|------|
| Tweety-3-Advanced / Conditional / QBF / Tweety-2-Basic | up to 8 | the very defect this guard targets — po-2024 rebuilds the DLLs (cause #2, #4667), outputs will fill |
| `GradeBook.ipynb` | 11/11 | grading template (likely a carve-out candidate, separate concern) |
| `ML/ML.Net/ML-5-TimeSeries.ipynb` | 14/14 | pre-existing pedagogical debt |
| `QuantConnect/projects/CSharp-BTC-MACD-ADX/Research.ipynb` | 1/18 | QC-adjacent C# |

This PR does **not** touch those notebooks (the gate runs only on changed notebooks), so CI stays green here. They are flagged for whoever next edits them.

## Scope

Single subject, 4 files, +143 / −52. No notebook outputs touched, no catalog change, no Lean/Python behavior change.

Closes #5214
See #4667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
