### PR TITLE
fix(scan): exclude compound-noun headings from HINT-AS-HEADING — #3968 to 0/818

### DIFF
--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -43,6 +43,23 @@ COMPOUND_HINT_RE = re.compile(
     r'^(indice|astuce|hint|tip|conseil|note|remarque|attention|todo|'
     r'etape|étape|step|rappel|warning|important|aide|piste|nb)-',
     re.IGNORECASE)
+# `Step`/`Étape` followed by a NON-numeric word forms a technical compound
+# noun (`Step recursif` = the recursive step of an algorithm, `Step function`,
+# `Step response`, `Étape méthodologique`) — a real subsection title, not the
+# bare numbered aside `## Étape 3` (which stays flagged). Distinct from
+# TITLED_STEP_RE (`Step N: Title`). Deliberately scoped to step/etape ONLY,
+# NOT the whole hint list, so `## Note pédagogique` (a legit bare aside per
+# the design above) stays flagged. See #3968.
+STEP_COMPOUND_RE = re.compile(
+    r'^(step|etape|étape)\s+[^\d\s:-]',
+    re.IGNORECASE)
+# `Rappel` followed by a reference token that contains a digit (`Rappel ICT-10`,
+# `Rappel du chapitre 3`, `Rappel ... la strate 4`) = a recap SECTION pointing
+# back at prior named content, not a bare aside (`## Rappel`). A bare
+# `## Rappel` has no digit reference, so it stays flagged. See #3968.
+RAPPEL_REFERENCE_RE = re.compile(
+    r'^rappel\s+.*\d',
+    re.IGNORECASE)
 
 def scan_notebook(path):
     try:
@@ -78,7 +95,9 @@ def scan_notebook(path):
                     findings.append({'kind': 'H1-DEEP', 'cell': ci, 'level': level, 'text': text[:90]})
             if (HINT_RE.match(text)
                     and not TITLED_STEP_RE.match(text)
-                    and not COMPOUND_HINT_RE.match(text)):
+                    and not COMPOUND_HINT_RE.match(text)
+                    and not STEP_COMPOUND_RE.match(text)
+                    and not RAPPEL_REFERENCE_RE.match(text)):
                 findings.append({'kind': 'HINT-AS-HEADING', 'cell': ci, 'level': level, 'text': text[:90]})
     if len(h1_cells) > 1:
         findings.insert(0, {'kind': 'MULTI-H1', 'cell': h1_cells[0], 'level': 1,


### PR DESCRIPTION
## Context

Closes #3968 (typography hierarchy rollout, 261 notebooks) to **true zero**.

Repo-wide `scan_md_hierarchy.py` had 2 residual findings — both are **false positives** (legitimate section/subsection titles that read as compound nouns, not bare asides):

| Notebook | Flagged heading | Reality |
|----------|-----------------|---------|
| `Lean-16b-Conway-Game-of-Life-Lean.ipynb` cell 16 | `### Step recursif et compression exponentielle` | Subsection under `## 5. Intuition Hashlife` — "Step recursif" = the recursive step of the Hashlife algorithm (technical compound noun), with substantial prose (periodicity, macrocells, exponential compression) |
| `ICT-14-FreeEnergySurprise.ipynb` cell 1 | `## Rappel ICT-10 et position de la strate 4` | Recap SECTION pointing back at prior notebook ICT-10, with substantial prose (internal representative $\hat p$, prediction bridge, MSE as surprise) |

G.1 firsthand: both verified as compound-noun titles with real body prose, **not** bare asides/hints.

## Fix — root cause in the scanner (not gaming)

Per the precedent of #1214 (never demote a real title to clear a scanner), the fix is **in the scanner**: two surgical exclusion regexes, added alongside the existing `TITLED_STEP_RE` / `COMPOUND_HINT_RE`:

```
STEP_COMPOUND_RE     ^(step|etape|étape)\s+[^\d\s:-]
                     'Step'/'Étape' + NON-numeric word = compound noun
                     (Step recursif, Step function, Step response).
                     Bare '## Étape 3' (number) stays flagged;
                     'Step 1: Title' handled by TITLED_STEP_RE.

RAPPEL_REFERENCE_RE  ^rappel\s+.*\d
                     'Rappel' + digit reference (Rappel ICT-10,
                     Rappel du chapitre 3) = recap section.
                     Bare '## Rappel' stays flagged.
```

**Deliberately scoped** to `step`/`etape` + `rappel` ONLY (not the full hint list), so the documented legitimate bare aside `## Note pédagogique` **stays flagged** — no new false negatives.

## Validation

- **Repo-wide**: `2/817 → 0/818` notebooks flagged.
- **Regression probe** (12 cases, all PASS):

| Heading | Should flag | After fix |
|---------|-------------|-----------|
| `Note pédagogique` | YES (legit aside) | ✅ flagged |
| `Étape 3` | YES (bare numbered) | ✅ flagged |
| `Rappel` | YES (bare) | ✅ flagged |
| `Note` / `Aide` | YES (bare) | ✅ flagged |
| `Note: voir X` | YES (inline-labeled) | ✅ flagged |
| `Step recursif` | NO (compound) | ✅ un-flagged |
| `Step function` | NO (math term) | ✅ un-flagged |
| `Rappel ICT-10 et suite` | NO (recap+ref) | ✅ un-flagged |
| `Rappel du chapitre 3` | NO (recap+ref) | ✅ un-flagged |
| `Step 1: Load` | NO (titled step) | ✅ un-flagged |
| `Aide-mémoire des cmd` | NO (compound-hyphen) | ✅ un-flagged |

## Scope

1 file, +20/-1. Markdown-only tooling fix, no notebook content change (no re-exec needed). No catalogue churn (scanner script, not under `CATALOG-STATUS`).

See #3968 · See #1214 (anti-gaming precedent) · Part of #3966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)