### PR TITLE
docs(search): place Part4-Metaheuristics in learning arc + restore Partie 3 coverage table

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -68,10 +68,16 @@ flowchart LR
     P2["<b>Phase 2 — Programmation<br/>par contraintes</b> (~6h)<br/>CSP-1 … CSP-6<br/><i>Réduire l'espace<br/>plutôt que l'explorer</i><br/>backtracking → AC-3<br/>→ contraintes globales<br/>→ ordonnancement<br/>→ CP + SAT / ML / LLM"]
     P3["<b>Phase 3 — Applications<br/>&amp; frontières</b> (~18h)<br/>20 cas réels : TSP, VRP,<br/>RCPSP, Bin Packing,<br/>Wordle, Picross…<br/>+ notebooks avancés<br/>(LP, automates,<br/>souples, temporelles)"]
     BR["<b>Séries connexes</b><br/>Sudoku (DLX)<br/>SymbolicAI (Z3)<br/>GameTheory (Minimax/MCTS)<br/>RL (MCTS + DQN)"]
+    P4["<b>Side-track .NET 9</b><br/>Part 4 — Métaheuristiques<br/>composables<br/>MGS-1 … MGS-19<br/><i>reconstruire &amp; composer<br/>au-dessus de GeneticSharp</i>"]
     P1 -->|"backtracking = DFS"| P2
     P2 -->|"modélisation industrielle"| P3
     P3 -.->|"ponts"| BR
+    P1 -.->|"side-track .NET"| P4
 ```
+
+### Side-track avancé : métaheuristiques composables (Part 4, C# .NET 9)
+
+En parallèle du parcours Python, la [Partie 4 — MetaGeneticSharp](Part4-Metaheuristics/README.md) propose un **side-track .NET 9** de 19 notebooks (MGS-1 à MGS-19) qui **reconstruit et compose** les métaheuristiques au-dessus de GeneticSharp plutôt que d'importer une boîte noire. Il prolonge Search-5 (GeneticAlgorithms) et Search-11 (Métaheuristiques) et se lit en quatre temps : **MGS-1 à 7** bâtissent le moteur et la grammaire de composition (jusqu'au TSP) ; **MGS-8 à 14** visualisent les paysages de fitness et mesurent la robustesse aux biais des bancs CEC (décalage, rotation, synergie d'îles) ; **MGS-15 à 18** referment la série sur l'analyse quantitative de paysage et la méta-stratégie (No-Free-Lunch, contrôle de paramètres) ; **MGS-19** démonte le recuit simulé pour éprouver l'opérateur de Metropolis seul. Optionnel pour qui vise le cœur Python, central pour qui veut *construire* ses métaheuristiques en .NET.
 
 ## Ce que chaque notebook apporte
 
@@ -106,6 +112,14 @@ Chaque notebook introduit un concept ou algorithme spécifique. Le tableau ci-de
 | 7 | CSP Soft | Contraintes souples, Fuzzy CSP : quand toutes les contraintes ne sont pas égales |
 | 8 | CSP Temporal | Allen's Interval Algebra, STP : raisonner sur le temps |
 | 9 | CSP Distributed | ABT, AWC : résoudre des CSP répartis entre agents |
+
+### Partie 3 : Recherche heuristique avancée
+
+| # | Notebook | Apport pédagogique |
+|---|----------|-------------------|
+| 12 | PatternDatabases | Heuristiques précalculées (Culberson & Schaeffer 1996, PDB additives Korf & Felner 2002) : 15-puzzle optimal via IDA* |
+| 13 | LimitedDiscrepancySearch | LDS (Harvey & Ginsberg 1995) : explorer d'abord les écarts au choix glouton, greedy vs LDS(k) vs exhaustif |
+| 14 | WeightedA* | A* pondéré (Pohl 1970) : sous-optimalité bornée par W pour accélérer sur terrain pondéré |
 
 ### Partie 4 : Métaheuristiques composables
 


### PR DESCRIPTION
## Regard editorial — arc pedagogique Search (rotation ai-01)

Session editoriale ai-01 : passe narrative sur la serie **Search/CSP**, dont la reorganisation structurelle C201 (#5081) vient de se clore (tranche 8/8 #5217). Deux ecarts « promesse README vs contenu reel » verifies G.1 sur `origin/main` :

### (A) Part4-Metaheuristics absente de l'arc d'apprentissage
La serie **MetaGeneticSharp** (19 notebooks MGS-1..19, side-track C# .NET 9) est integralement tabulee dans « Ce que chaque notebook apporte » (+ Navigation + Parite .NET), mais **invisible dans le « Parcours d'apprentissage »** (Phases 1-3) et le diagramme Mermaid. Ajout d'un noeud side-track `P4` (branche depuis `P1`, arete pointillee = optionnel) + une sous-section narrative reprenant le decoupage en 4 temps de l'auteur (moteur -> paysages -> meta-strategie -> demontage). Cadrage « side-track .NET » fidele a la section « Parite .NET <-> Python ».

### (B) Table de couverture Partie 3 manquante
« Ce que chaque notebook apporte » saute **Partie 2 -> Partie 4**, omettant la Partie 3 (recherche heuristique avancee). Ajout de la table 3 lignes (Search-12 PatternDatabases, Search-13 LimitedDiscrepancySearch, Search-14 WeightedA*), resumes derives de la section detaillee existante.

## Verifications
- Diff atomique : **1 fichier, +14/-0** (`Search/README.md`), aucun notebook/code touche.
- Marqueurs `CATALOG-STATUS` **inchanges** ; aucun fichier catalogue regenere (catalog-pr-hygiene).
- FR-first (readme-french-first) ; branche cut de `origin/main` frais (worktree isole).
- No-Pendulum : freshness (aligner l'arc au reel), pas de reecriture des sections detaillees correctes.

## Observation hors-scope (signalee, non corrigee)
Collision de numerotation : `Part1-Foundations/Search-12-NetworkX` + `Search-13-QuikGraph` vs `Part3-Advanced/Search-12-PatternDatabases` + `Search-13-LimitedDiscrepancySearch`. Renumerotation = touche des noms de notebooks (hors perimetre editorial) — a traiter en tranche dediee.

See #4212 · See #3973 · See #4208

🤖 Generated with [Claude Code](https://claude.com/claude-code)