### PR TITLE
fix(pymc): silence PyMC-1/2/5/11 residual path-leaks (#3436 cause B+C)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
@@ -41,10 +41,10 @@
    "id": "b5e04482",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:15:15.079601Z",
-     "iopub.status.busy": "2026-06-28T12:15:15.079601Z",
-     "iopub.status.idle": "2026-06-28T12:15:16.807101Z",
-     "shell.execute_reply": "2026-06-28T12:15:16.806590Z"
+     "iopub.execute_input": "2026-07-03T15:29:11.040055Z",
+     "iopub.status.busy": "2026-07-03T15:29:11.040055Z",
+     "iopub.status.idle": "2026-07-03T15:29:11.047409Z",
+     "shell.execute_reply": "2026-07-03T15:29:11.047409Z"
     },
     "tags": []
    },
@@ -88,10 +88,10 @@
    "id": "0ac2091a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:15:16.837130Z",
-     "iopub.status.busy": "2026-06-28T12:15:16.837130Z",
-     "iopub.status.idle": "2026-06-28T12:15:29.262331Z",
-     "shell.execute_reply": "2026-06-28T12:15:29.260318Z"
+     "iopub.execute_input": "2026-07-03T15:29:11.048422Z",
+     "iopub.status.busy": "2026-07-03T15:29:11.048422Z",
+     "iopub.status.idle": "2026-07-03T15:29:14.139451Z",
+     "shell.execute_reply": "2026-07-03T15:29:14.139451Z"
     },
     "tags": []
    },
@@ -184,10 +184,10 @@
    "id": "62138dcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:15:29.319858Z",
-     "iopub.status.busy": "2026-06-28T12:15:29.318858Z",
-     "iopub.status.idle": "2026-06-28T12:16:24.958913Z",
-     "shell.execute_reply": "2026-06-28T12:16:24.956882Z"
+     "iopub.execute_input": "2026-07-03T15:29:14.141413Z",
+     "iopub.status.busy": "2026-07-03T15:29:14.141413Z",
+     "iopub.status.idle": "2026-07-03T15:29:36.783015Z",
+     "shell.execute_reply": "2026-07-03T15:29:36.783015Z"
     },
     "tags": []
    },
@@ -215,16 +215,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "786a20b9960b46a58bb9560f1ede903c",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -244,7 +241,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 48 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 20 seconds.\n"
      ]
     },
     {
@@ -305,10 +302,10 @@
    "id": "b5495e80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:16:25.024219Z",
-     "iopub.status.busy": "2026-06-28T12:16:25.022205Z",
-     "iopub.status.idle": "2026-06-28T12:16:25.555339Z",
-     "shell.execute_reply": "2026-06-28T12:16:25.553682Z"
+     "iopub.execute_input": "2026-07-03T15:29:36.872718Z",
+     "iopub.status.busy": "2026-07-03T15:29:36.872718Z",
+     "iopub.status.idle": "2026-07-03T15:29:37.060426Z",
+     "shell.execute_reply": "2026-07-03T15:29:37.060426Z"
     },
     "tags": []
    },
@@ -355,10 +352,10 @@
    "id": "a23ff6f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:16:25.603238Z",
-     "iopub.status.busy": "2026-06-28T12:16:25.603238Z",
-     "iopub.status.idle": "2026-06-28T12:16:25.929918Z",
-     "shell.execute_reply": "2026-06-28T12:16:25.927903Z"
+     "iopub.execute_input": "2026-07-03T15:29:37.062432Z",
+     "iopub.status.busy": "2026-07-03T15:29:37.062432Z",
+     "iopub.status.idle": "2026-07-03T15:29:37.171463Z",
+     "shell.execute_reply": "2026-07-03T15:29:37.170457Z"
     },
     "tags": []
    },
@@ -423,10 +420,10 @@
    "id": "exo1-prior-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:16:25.980925Z",
-     "iopub.status.busy": "2026-06-28T12:16:25.978914Z",
-     "iopub.status.idle": "2026-06-28T12:16:25.986513Z",
-     "shell.execute_reply": "2026-06-28T12:16:25.986513Z"
+     "iopub.execute_input": "2026-07-03T15:29:37.173465Z",
+     "iopub.status.busy": "2026-07-03T15:29:37.173465Z",
+     "iopub.status.idle": "2026-07-03T15:29:37.176731Z",
+     "shell.execute_reply": "2026-07-03T15:29:37.176731Z"
     },
     "tags": []
    },
@@ -470,10 +467,10 @@
    "id": "50e11458",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:16:26.037050Z",
-     "iopub.status.busy": "2026-06-28T12:16:26.037050Z",
-     "iopub.status.idle": "2026-06-28T12:16:26.666552Z",
-     "shell.execute_reply": "2026-06-28T12:16:26.665522Z"
+     "iopub.execute_input": "2026-07-03T15:29:37.179738Z",
+     "iopub.status.busy": "2026-07-03T15:29:37.179738Z",
+     "iopub.status.idle": "2026-07-03T15:29:37.396528Z",
+     "shell.execute_reply": "2026-07-03T15:29:37.396528Z"
     },
     "tags": []
    },
@@ -562,10 +559,10 @@
    "id": "e5f60718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:16:26.731644Z",
-     "iopub.status.busy": "2026-06-28T12:16:26.730646Z",
-     "iopub.status.idle": "2026-06-28T12:16:54.764553Z",
-     "shell.execute_reply": "2026-06-28T12:16:54.763447Z"
+     "iopub.execute_input": "2026-07-03T15:29:37.398542Z",
+     "iopub.status.busy": "2026-07-03T15:29:37.398542Z",
+     "iopub.status.idle": "2026-07-03T15:29:43.042879Z",
+     "shell.execute_reply": "2026-07-03T15:29:43.042879Z"
     },
     "tags": []
    },
@@ -601,16 +598,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9607b2ca982a4328a68a3701de2a83a3",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -630,7 +624,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 25 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 5 seconds.\n"
      ]
     },
     {
@@ -849,10 +843,10 @@
    "id": "3e4f5a6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:16:54.835761Z",
-     "iopub.status.busy": "2026-06-28T12:16:54.834761Z",
-     "iopub.status.idle": "2026-06-28T12:16:55.322636Z",
-     "shell.execute_reply": "2026-06-28T12:16:55.319782Z"
+     "iopub.execute_input": "2026-07-03T15:29:43.118461Z",
+     "iopub.status.busy": "2026-07-03T15:29:43.117948Z",
+     "iopub.status.idle": "2026-07-03T15:29:43.283837Z",
+     "shell.execute_reply": "2026-07-03T15:29:43.283193Z"
     },
     "tags": []
    },
@@ -933,10 +927,10 @@
    "id": "exo2-shrink-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:16:55.411332Z",
-     "iopub.status.busy": "2026-06-28T12:16:55.410618Z",
-     "iopub.status.idle": "2026-06-28T12:16:55.419104Z",
-     "shell.execute_reply": "2026-06-28T12:16:55.417228Z"
+     "iopub.execute_input": "2026-07-03T15:29:43.286109Z",
+     "iopub.status.busy": "2026-07-03T15:29:43.286109Z",
+     "iopub.status.idle": "2026-07-03T15:29:43.290149Z",
+     "shell.execute_reply": "2026-07-03T15:29:43.289411Z"
     },
     "tags": []
    },
@@ -1017,10 +1011,10 @@
    "id": "645fbcf8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T12:16:55.544957Z",
-     "iopub.status.busy": "2026-06-28T12:16:55.544284Z",
-     "iopub.status.idle": "2026-06-28T12:16:55.554081Z",
-     "shell.execute_reply": "2026-06-28T12:16:55.551925Z"
+     "iopub.execute_input": "2026-07-03T15:29:43.291957Z",
+     "iopub.status.busy": "2026-07-03T15:29:43.291957Z",
+     "iopub.status.idle": "2026-07-03T15:29:43.297499Z",
+     "shell.execute_reply": "2026-07-03T15:29:43.296897Z"
     },
     "tags": []
    },
@@ -1096,6 +1090,178 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "5896bf7ec55a4df2a9dc383614209edc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "786a20b9960b46a58bb9560f1ede903c": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_f80fc6532de94eefaf2fe310ab101e05",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             1.540       1            3553.32 draws/s   0:00:00   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             1.195       3            1548.27 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.861       1            1048.97 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             1.184       3            786.73 draws/s    0:00:03   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             1.540       1            3553.32 draws/s   0:00:00   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             1.195       3            1548.27 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.861       1            1048.97 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             1.184       3            786.73 draws/s    0:00:03   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "9607b2ca982a4328a68a3701de2a83a3": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_5896bf7ec55a4df2a9dc383614209edc",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.213       15           1361.78 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.258       15           648.65 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.213       15           1361.78 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.258       15           648.65 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "f80fc6532de94eefaf2fe310ab101e05": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Sequences.ipynb
@@ -38,10 +38,10 @@
    "id": "575970fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:29.997263Z",
-     "iopub.status.busy": "2026-06-23T21:14:29.997263Z",
-     "iopub.status.idle": "2026-06-23T21:14:31.670116Z",
-     "shell.execute_reply": "2026-06-23T21:14:31.669601Z"
+     "iopub.execute_input": "2026-07-03T15:41:58.685849Z",
+     "iopub.status.busy": "2026-07-03T15:41:58.685849Z",
+     "iopub.status.idle": "2026-07-03T15:41:58.709524Z",
+     "shell.execute_reply": "2026-07-03T15:41:58.707516Z"
     },
     "papermill": {
      "duration": 1.681796,
@@ -99,10 +99,10 @@
    "id": "44ea9740",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:31.698985Z",
-     "iopub.status.busy": "2026-06-23T21:14:31.698985Z",
-     "iopub.status.idle": "2026-06-23T21:14:38.499281Z",
-     "shell.execute_reply": "2026-06-23T21:14:38.499281Z"
+     "iopub.execute_input": "2026-07-03T15:41:58.711523Z",
+     "iopub.status.busy": "2026-07-03T15:41:58.710523Z",
+     "iopub.status.idle": "2026-07-03T15:42:01.758459Z",
+     "shell.execute_reply": "2026-07-03T15:42:01.758459Z"
     },
     "papermill": {
      "duration": 6.808575,
@@ -124,6 +124,12 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "# arviz (FutureWarning de refactor) et pytensor (\"could not link BLAS\", advisory de perf, pas de correctness)\n",
+    "# leakent le chemin absolu du fichier source site-packages ; on les filtre. Les alertes utiles (R-hat, ESS) restent visibles.\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning, module=\"arviz\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*could not link.*\", category=UserWarning)\n",
+    "\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import pymc as pm\n",
@@ -182,10 +188,10 @@
    "id": "20552d64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:38.537899Z",
-     "iopub.status.busy": "2026-06-23T21:14:38.536714Z",
-     "iopub.status.idle": "2026-06-23T21:14:39.198659Z",
-     "shell.execute_reply": "2026-06-23T21:14:39.198659Z"
+     "iopub.execute_input": "2026-07-03T15:42:01.761475Z",
+     "iopub.status.busy": "2026-07-03T15:42:01.760476Z",
+     "iopub.status.idle": "2026-07-03T15:42:02.099480Z",
+     "shell.execute_reply": "2026-07-03T15:42:02.098037Z"
     },
     "papermill": {
      "duration": 0.674677,
@@ -277,10 +283,10 @@
    "id": "33e78e24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:39.239855Z",
-     "iopub.status.busy": "2026-06-23T21:14:39.239855Z",
-     "iopub.status.idle": "2026-06-23T21:14:39.252575Z",
-     "shell.execute_reply": "2026-06-23T21:14:39.252575Z"
+     "iopub.execute_input": "2026-07-03T15:42:02.106578Z",
+     "iopub.status.busy": "2026-07-03T15:42:02.102580Z",
+     "iopub.status.idle": "2026-07-03T15:42:02.113968Z",
+     "shell.execute_reply": "2026-07-03T15:42:02.113968Z"
     },
     "papermill": {
      "duration": 0.026576,
@@ -366,10 +372,10 @@
    "id": "8611f98b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:39.293783Z",
-     "iopub.status.busy": "2026-06-23T21:14:39.292727Z",
-     "iopub.status.idle": "2026-06-23T21:14:39.772367Z",
-     "shell.execute_reply": "2026-06-23T21:14:39.772367Z"
+     "iopub.execute_input": "2026-07-03T15:42:02.117208Z",
+     "iopub.status.busy": "2026-07-03T15:42:02.117208Z",
+     "iopub.status.idle": "2026-07-03T15:42:02.353202Z",
+     "shell.execute_reply": "2026-07-03T15:42:02.353202Z"
     },
     "papermill": {
      "duration": 0.492549,
@@ -468,10 +474,10 @@
    "id": "a75fe048",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:39.832154Z",
-     "iopub.status.busy": "2026-06-23T21:14:39.832154Z",
-     "iopub.status.idle": "2026-06-23T21:14:39.853814Z",
-     "shell.execute_reply": "2026-06-23T21:14:39.852765Z"
+     "iopub.execute_input": "2026-07-03T15:42:02.356208Z",
+     "iopub.status.busy": "2026-07-03T15:42:02.355208Z",
+     "iopub.status.idle": "2026-07-03T15:42:02.367374Z",
+     "shell.execute_reply": "2026-07-03T15:42:02.366200Z"
     },
     "papermill": {
      "duration": 0.031173,
@@ -608,10 +614,10 @@
    "id": "5e2e2470",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:39.895406Z",
-     "iopub.status.busy": "2026-06-23T21:14:39.895406Z",
-     "iopub.status.idle": "2026-06-23T21:14:40.360087Z",
-     "shell.execute_reply": "2026-06-23T21:14:40.359033Z"
+     "iopub.execute_input": "2026-07-03T15:42:02.369375Z",
+     "iopub.status.busy": "2026-07-03T15:42:02.369375Z",
+     "iopub.status.idle": "2026-07-03T15:42:02.592621Z",
+     "shell.execute_reply": "2026-07-03T15:42:02.592115Z"
     },
     "papermill": {
      "duration": 0.475195,
@@ -715,10 +721,10 @@
    "id": "07dbd193",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:40.437580Z",
-     "iopub.status.busy": "2026-06-23T21:14:40.437187Z",
-     "iopub.status.idle": "2026-06-23T21:14:40.451354Z",
-     "shell.execute_reply": "2026-06-23T21:14:40.450897Z"
+     "iopub.execute_input": "2026-07-03T15:42:02.594628Z",
+     "iopub.status.busy": "2026-07-03T15:42:02.594628Z",
+     "iopub.status.idle": "2026-07-03T15:42:02.601677Z",
+     "shell.execute_reply": "2026-07-03T15:42:02.601677Z"
     },
     "papermill": {
      "duration": 0.031259,
@@ -803,10 +809,10 @@
    "id": "b0a55e8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:40.501738Z",
-     "iopub.status.busy": "2026-06-23T21:14:40.501738Z",
-     "iopub.status.idle": "2026-06-23T21:14:40.960695Z",
-     "shell.execute_reply": "2026-06-23T21:14:40.960001Z"
+     "iopub.execute_input": "2026-07-03T15:42:02.603685Z",
+     "iopub.status.busy": "2026-07-03T15:42:02.603685Z",
+     "iopub.status.idle": "2026-07-03T15:42:02.769087Z",
+     "shell.execute_reply": "2026-07-03T15:42:02.769087Z"
     },
     "papermill": {
      "duration": 0.471332,
@@ -902,10 +908,10 @@
    "id": "9cf446da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:14:41.007949Z",
-     "iopub.status.busy": "2026-06-23T21:14:41.007949Z",
-     "iopub.status.idle": "2026-06-23T21:18:32.183907Z",
-     "shell.execute_reply": "2026-06-23T21:18:32.183907Z"
+     "iopub.execute_input": "2026-07-03T15:42:02.771093Z",
+     "iopub.status.busy": "2026-07-03T15:42:02.771093Z",
+     "iopub.status.idle": "2026-07-03T15:43:45.983142Z",
+     "shell.execute_reply": "2026-07-03T15:43:45.983142Z"
     },
     "papermill": {
      "duration": 231.191027,
@@ -928,17 +934,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\pytensor\\link\\c\\cmodule.py:2986: UserWarning: PyTensor could not link to a BLAS installation. Operations that might benefit from BLAS will be severely degraded.\n",
-      "This usually happens when PyTensor is installed via pip. We recommend it be installed via conda/mamba/pixi instead.\n",
-      "Alternatively, you can use an experimental backend such as Numba or JAX that perform their own BLAS optimizations, by setting `pytensor.config.mode == 'NUMBA'` or passing `mode='NUMBA'` when compiling a PyTensor function.\n",
-      "For more options and details see https://pytensor.readthedocs.io/en/latest/troubleshooting.html#how-do-i-configure-test-my-blas-library\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "Multiprocess sampling (4 chains in 4 jobs)\n"
      ]
     },
@@ -953,7 +948,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 218 seconds.\n"
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 99 seconds.\n"
      ]
     },
     {
@@ -1100,10 +1095,10 @@
    "id": "a8de8840",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:18:32.248511Z",
-     "iopub.status.busy": "2026-06-23T21:18:32.248511Z",
-     "iopub.status.idle": "2026-06-23T21:18:32.263512Z",
-     "shell.execute_reply": "2026-06-23T21:18:32.263512Z"
+     "iopub.execute_input": "2026-07-03T15:43:45.985755Z",
+     "iopub.status.busy": "2026-07-03T15:43:45.985216Z",
+     "iopub.status.idle": "2026-07-03T15:43:45.992198Z",
+     "shell.execute_reply": "2026-07-03T15:43:45.992198Z"
     },
     "papermill": {
      "duration": 0.028137,
@@ -1205,10 +1200,10 @@
    "id": "c9ac2844",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:18:32.346356Z",
-     "iopub.status.busy": "2026-06-23T21:18:32.346356Z",
-     "iopub.status.idle": "2026-06-23T21:18:32.351893Z",
-     "shell.execute_reply": "2026-06-23T21:18:32.351370Z"
+     "iopub.execute_input": "2026-07-03T15:43:45.994256Z",
+     "iopub.status.busy": "2026-07-03T15:43:45.994256Z",
+     "iopub.status.idle": "2026-07-03T15:43:45.998386Z",
+     "shell.execute_reply": "2026-07-03T15:43:45.998386Z"
     },
     "papermill": {
      "duration": 0.038503,
@@ -1264,10 +1259,10 @@
    "id": "a0c85767",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:18:32.419783Z",
-     "iopub.status.busy": "2026-06-23T21:18:32.419260Z",
-     "iopub.status.idle": "2026-06-23T21:18:32.788087Z",
-     "shell.execute_reply": "2026-06-23T21:18:32.788087Z"
+     "iopub.execute_input": "2026-07-03T15:43:46.000450Z",
+     "iopub.status.busy": "2026-07-03T15:43:46.000450Z",
+     "iopub.status.idle": "2026-07-03T15:43:46.173226Z",
+     "shell.execute_reply": "2026-07-03T15:43:46.173226Z"
     },
     "papermill": {
      "duration": 0.39058,
@@ -1344,10 +1339,10 @@
    "id": "0ad6e0fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:18:32.851807Z",
-     "iopub.status.busy": "2026-06-23T21:18:32.851807Z",
-     "iopub.status.idle": "2026-06-23T21:18:32.862533Z",
-     "shell.execute_reply": "2026-06-23T21:18:32.861457Z"
+     "iopub.execute_input": "2026-07-03T15:43:46.173226Z",
+     "iopub.status.busy": "2026-07-03T15:43:46.173226Z",
+     "iopub.status.idle": "2026-07-03T15:43:46.181054Z",
+     "shell.execute_reply": "2026-07-03T15:43:46.181054Z"
     },
     "papermill": {
      "duration": 0.035979,
@@ -1441,10 +1436,10 @@
    "id": "ffbf9980",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:18:32.915111Z",
-     "iopub.status.busy": "2026-06-23T21:18:32.915111Z",
-     "iopub.status.idle": "2026-06-23T21:18:32.922109Z",
-     "shell.execute_reply": "2026-06-23T21:18:32.921051Z"
+     "iopub.execute_input": "2026-07-03T15:43:46.181054Z",
+     "iopub.status.busy": "2026-07-03T15:43:46.181054Z",
+     "iopub.status.idle": "2026-07-03T15:43:46.188109Z",
+     "shell.execute_reply": "2026-07-03T15:43:46.188109Z"
     },
     "papermill": {
      "duration": 0.019524,
@@ -1538,10 +1533,10 @@
    "id": "b35f7ec0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:18:32.976133Z",
-     "iopub.status.busy": "2026-06-23T21:18:32.976133Z",
-     "iopub.status.idle": "2026-06-23T21:18:32.982545Z",
-     "shell.execute_reply": "2026-06-23T21:18:32.982545Z"
+     "iopub.execute_input": "2026-07-03T15:43:46.188109Z",
+     "iopub.status.busy": "2026-07-03T15:43:46.188109Z",
+     "iopub.status.idle": "2026-07-03T15:43:46.195332Z",
+     "shell.execute_reply": "2026-07-03T15:43:46.195332Z"
     },
     "papermill": {
      "duration": 0.021971,
@@ -1642,10 +1637,10 @@
    "id": "6b65728f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T21:18:33.062345Z",
-     "iopub.status.busy": "2026-06-23T21:18:33.062345Z",
-     "iopub.status.idle": "2026-06-23T21:18:33.071004Z",
-     "shell.execute_reply": "2026-06-23T21:18:33.070486Z"
+     "iopub.execute_input": "2026-07-03T15:43:46.195332Z",
+     "iopub.status.busy": "2026-07-03T15:43:46.195332Z",
+     "iopub.status.idle": "2026-07-03T15:43:46.201300Z",
+     "shell.execute_reply": "2026-07-03T15:43:46.201300Z"
     },
     "papermill": {
      "duration": 0.026943,
@@ -1760,8 +1755,8 @@
    "end_time": "2026-06-23T21:18:34.479269+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Sequences.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Sequences.ipynb",
+   "input_path": "PyMC-11-Sequences.ipynb",
+   "output_path": "PyMC-11-Sequences.ipynb",
    "parameters": {},
    "start_time": "2026-06-23T21:14:27.863146+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
@@ -29,8 +29,7 @@
     "- Predire et calculer des probabilites\n",
     "- Implementer un melange de gaussiennes (GMM) pour gerer les evenements extraordinaires\n",
     "\n",
-    "**Prerequis** : PyMC-1, bases de statistique (loi normale, prior conjugue)\n",
-    ""
+    "**Prerequis** : PyMC-1, bases de statistique (loi normale, prior conjugue)\n"
    ]
   },
   {
@@ -62,10 +61,10 @@
    "id": "808287e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:11:28.227709Z",
-     "iopub.status.busy": "2026-06-03T06:11:28.227709Z",
-     "iopub.status.idle": "2026-06-03T06:11:38.235289Z",
-     "shell.execute_reply": "2026-06-03T06:11:38.232845Z"
+     "iopub.execute_input": "2026-07-03T15:29:51.263353Z",
+     "iopub.status.busy": "2026-07-03T15:29:51.263353Z",
+     "iopub.status.idle": "2026-07-03T15:29:54.377683Z",
+     "shell.execute_reply": "2026-07-03T15:29:54.377683Z"
     },
     "papermill": {
      "duration": 10.025188,
@@ -86,6 +85,12 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "# arviz (FutureWarning de refactor) et pytensor (\"could not link BLAS\", advisory de perf, pas de correctness)\n",
+    "# leakent le chemin absolu du fichier source site-packages ; on les filtre. Les alertes utiles (R-hat, ESS) restent visibles.\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning, module=\"arviz\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*could not link.*\", category=UserWarning)\n",
+    "\n",
     "try:\n",
     "    import numpy as np\n",
     "    NUMPY_AVAILABLE = True\n",
@@ -159,10 +164,10 @@
    "id": "238dab2d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:11:38.273524Z",
-     "iopub.status.busy": "2026-06-03T06:11:38.273524Z",
-     "iopub.status.idle": "2026-06-03T06:12:41.632867Z",
-     "shell.execute_reply": "2026-06-03T06:12:41.630836Z"
+     "iopub.execute_input": "2026-07-03T15:29:54.379689Z",
+     "iopub.status.busy": "2026-07-03T15:29:54.379689Z",
+     "iopub.status.idle": "2026-07-03T15:30:22.725348Z",
+     "shell.execute_reply": "2026-07-03T15:30:22.725348Z"
     },
     "papermill": {
      "duration": 63.372112,
@@ -197,16 +202,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c7b649534d7d43e2abaea453896211cc",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -226,7 +228,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 53 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 20 seconds.\n"
      ]
     },
     {
@@ -304,10 +306,10 @@
    "id": "3593c7fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:12:41.687206Z",
-     "iopub.status.busy": "2026-06-03T06:12:41.687206Z",
-     "iopub.status.idle": "2026-06-03T06:12:44.338576Z",
-     "shell.execute_reply": "2026-06-03T06:12:44.336055Z"
+     "iopub.execute_input": "2026-07-03T15:30:22.793652Z",
+     "iopub.status.busy": "2026-07-03T15:30:22.793136Z",
+     "iopub.status.idle": "2026-07-03T15:30:24.234766Z",
+     "shell.execute_reply": "2026-07-03T15:30:24.234766Z"
     },
     "papermill": {
      "duration": 2.669051,
@@ -328,16 +330,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1e907a0e10f44544b245303b47fe5d3b",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -431,10 +430,10 @@
    "id": "a9781026",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:12:44.396723Z",
-     "iopub.status.busy": "2026-06-03T06:12:44.394200Z",
-     "iopub.status.idle": "2026-06-03T06:12:44.404818Z",
-     "shell.execute_reply": "2026-06-03T06:12:44.403274Z"
+     "iopub.execute_input": "2026-07-03T15:30:24.243788Z",
+     "iopub.status.busy": "2026-07-03T15:30:24.243788Z",
+     "iopub.status.idle": "2026-07-03T15:30:24.246824Z",
+     "shell.execute_reply": "2026-07-03T15:30:24.246824Z"
     },
     "papermill": {
      "duration": 0.026782,
@@ -489,10 +488,10 @@
    "id": "7814aa2d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:12:44.464798Z",
-     "iopub.status.busy": "2026-06-03T06:12:44.463785Z",
-     "iopub.status.idle": "2026-06-03T06:13:39.273319Z",
-     "shell.execute_reply": "2026-06-03T06:13:39.270807Z"
+     "iopub.execute_input": "2026-07-03T15:30:24.249096Z",
+     "iopub.status.busy": "2026-07-03T15:30:24.248095Z",
+     "iopub.status.idle": "2026-07-03T15:30:52.422755Z",
+     "shell.execute_reply": "2026-07-03T15:30:52.422755Z"
     },
     "papermill": {
      "duration": 54.82748,
@@ -515,17 +514,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\pytensor\\link\\c\\cmodule.py:2986: UserWarning: PyTensor could not link to a BLAS installation. Operations that might benefit from BLAS will be severely degraded.\n",
-      "This usually happens when PyTensor is installed via pip. We recommend it be installed via conda/mamba/pixi instead.\n",
-      "Alternatively, you can use an experimental backend such as Numba or JAX that perform their own BLAS optimizations, by setting `pytensor.config.mode == 'NUMBA'` or passing `mode='NUMBA'` when compiling a PyTensor function.\n",
-      "For more options and details see https://pytensor.readthedocs.io/en/latest/troubleshooting.html#how-do-i-configure-test-my-blas-library\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "Multiprocess sampling (4 chains in 4 jobs)\n"
      ]
     },
@@ -538,16 +526,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "22fd542bba4545ac81fae940163152a4",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -567,7 +552,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 51 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 20 seconds.\n"
      ]
     },
     {
@@ -637,10 +622,10 @@
    "id": "851b9f2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:13:39.321407Z",
-     "iopub.status.busy": "2026-06-03T06:13:39.319402Z",
-     "iopub.status.idle": "2026-06-03T06:13:39.326896Z",
-     "shell.execute_reply": "2026-06-03T06:13:39.326896Z"
+     "iopub.execute_input": "2026-07-03T15:30:52.493583Z",
+     "iopub.status.busy": "2026-07-03T15:30:52.493583Z",
+     "iopub.status.idle": "2026-07-03T15:30:52.496802Z",
+     "shell.execute_reply": "2026-07-03T15:30:52.496802Z"
     },
     "papermill": {
      "duration": 0.02214,
@@ -709,10 +694,10 @@
    "id": "791be0b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:13:39.384760Z",
-     "iopub.status.busy": "2026-06-03T06:13:39.383713Z",
-     "iopub.status.idle": "2026-06-03T06:14:59.759076Z",
-     "shell.execute_reply": "2026-06-03T06:14:59.757558Z"
+     "iopub.execute_input": "2026-07-03T15:30:52.498820Z",
+     "iopub.status.busy": "2026-07-03T15:30:52.498820Z",
+     "iopub.status.idle": "2026-07-03T15:31:35.336268Z",
+     "shell.execute_reply": "2026-07-03T15:31:35.336268Z"
     },
     "papermill": {
      "duration": 80.395876,
@@ -754,16 +739,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "32d4e865d93c402bb8a0cd3fc29d42f2",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -783,7 +765,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 74 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 26 seconds.\n"
      ]
     },
     {
@@ -871,10 +853,10 @@
    "id": "164a548e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:14:59.824445Z",
-     "iopub.status.busy": "2026-06-03T06:14:59.823927Z",
-     "iopub.status.idle": "2026-06-03T06:15:00.281729Z",
-     "shell.execute_reply": "2026-06-03T06:15:00.279721Z"
+     "iopub.execute_input": "2026-07-03T15:31:35.462346Z",
+     "iopub.status.busy": "2026-07-03T15:31:35.462346Z",
+     "iopub.status.idle": "2026-07-03T15:31:35.591135Z",
+     "shell.execute_reply": "2026-07-03T15:31:35.591135Z"
     },
     "papermill": {
      "duration": 0.476482,
@@ -968,10 +950,10 @@
    "id": "bcea493b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:15:00.348540Z",
-     "iopub.status.busy": "2026-06-03T06:15:00.347016Z",
-     "iopub.status.idle": "2026-06-03T06:16:09.710211Z",
-     "shell.execute_reply": "2026-06-03T06:16:09.708203Z"
+     "iopub.execute_input": "2026-07-03T15:31:35.593141Z",
+     "iopub.status.busy": "2026-07-03T15:31:35.593141Z",
+     "iopub.status.idle": "2026-07-03T15:32:03.333060Z",
+     "shell.execute_reply": "2026-07-03T15:32:03.333060Z"
     },
     "papermill": {
      "duration": 69.383181,
@@ -1006,16 +988,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "204b691819bb43bda07403623974bf41",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -1035,7 +1014,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 64 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 24 seconds.\n"
      ]
     },
     {
@@ -1137,10 +1116,10 @@
    "id": "479b72bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:16:09.821517Z",
-     "iopub.status.busy": "2026-06-03T06:16:09.820009Z",
-     "iopub.status.idle": "2026-06-03T06:16:09.830084Z",
-     "shell.execute_reply": "2026-06-03T06:16:09.827588Z"
+     "iopub.execute_input": "2026-07-03T15:32:03.474549Z",
+     "iopub.status.busy": "2026-07-03T15:32:03.473548Z",
+     "iopub.status.idle": "2026-07-03T15:32:03.477068Z",
+     "shell.execute_reply": "2026-07-03T15:32:03.477068Z"
     },
     "papermill": {
      "duration": 0.033114,
@@ -1233,6 +1212,424 @@
    "parameters": {},
    "start_time": "2026-06-03T06:11:24.868792+00:00",
    "version": "2.7.0"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "189f462f3205406899aed9c5a4346bf5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "1e907a0e10f44544b245303b47fe5d3b": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_2e2f9f72bdeb4c3d9ffdbadcadf71d2f",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Sampling ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00 / 0:00:00\n</pre>\n",
+          "text/plain": "Sampling ... \u001b[38;2;23;100;244m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m 0:00:00 / 0:00:00\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "204b691819bb43bda07403623974bf41": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_189f462f3205406899aed9c5a4346bf5",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   8             0.233       15           944.50 draws/s   0:00:04   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   3             0.301       7            812.47 draws/s   0:00:04   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   2             0.266       7            663.07 draws/s   0:00:06   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.464       1            499.88 draws/s   0:00:08   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   8             0.233       15           944.50 draws/s   0:00:04   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   3             0.301       7            812.47 draws/s   0:00:04   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   2             0.266       7            663.07 draws/s   0:00:06   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.464       1            499.88 draws/s   0:00:08   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "22fd542bba4545ac81fae940163152a4": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_2ae58d1073534e059dff89be3c9d873e",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.214       3            3199.20 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.197       3            1953.59 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.690       3            1333.00 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.047       1            944.50 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.214       3            3199.20 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.197       3            1953.59 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.690       3            1333.00 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.047       1            944.50 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "2ae58d1073534e059dff89be3c9d873e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "2e2f9f72bdeb4c3d9ffdbadcadf71d2f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "32d4e865d93c402bb8a0cd3fc29d42f2": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_54782e9f86d7422abbea4781444e5d3f",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   96            0.191       7            536.49 draws/s   0:00:07   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   79            0.211       7            494.07 draws/s   0:00:08   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   33            0.497       3            607.94 draws/s   0:00:06   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   63            0.288       7            393.76 draws/s   0:00:10   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   96            0.191       7            536.49 draws/s   0:00:07   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   79            0.211       7            494.07 draws/s   0:00:08   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   33            0.497       3            607.94 draws/s   0:00:06   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   63            0.288       7            393.76 draws/s   0:00:10   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "54782e9f86d7422abbea4781444e5d3f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c7b649534d7d43e2abaea453896211cc": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_e879c485a8d242d3ba44136dd19de460",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.882       3            3602.70 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.358       3            1983.63 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.115       3            1325.93 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.992       3            937.41 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.882       3            3602.70 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.358       3            1983.63 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.115       3            1325.93 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.992       3            937.41 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "e879c485a8d242d3ba44136dd19de460": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Skills-IRT.ipynb
@@ -29,8 +29,7 @@
     "- Evaluer les modeles avec les courbes ROC\n",
     "- Comparer l'approche continue (IRT) vs discrete (DINA)\n",
     "\n",
-    "**Prerequis** : PyMC-1 a PyMC-4, theoreme de Bayes, variables latentes\n",
-    ""
+    "**Prerequis** : PyMC-1 a PyMC-4, theoreme de Bayes, variables latentes\n"
    ]
   },
   {
@@ -39,10 +38,10 @@
    "id": "35fc902f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:25:10.844877Z",
-     "iopub.status.busy": "2026-06-03T06:25:10.844877Z",
-     "iopub.status.idle": "2026-06-03T06:25:19.825589Z",
-     "shell.execute_reply": "2026-06-03T06:25:19.823574Z"
+     "iopub.execute_input": "2026-07-03T15:32:10.918793Z",
+     "iopub.status.busy": "2026-07-03T15:32:10.918793Z",
+     "iopub.status.idle": "2026-07-03T15:32:14.163083Z",
+     "shell.execute_reply": "2026-07-03T15:32:14.163083Z"
     },
     "papermill": {
      "duration": 8.997154,
@@ -63,6 +62,12 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "# arviz (FutureWarning de refactor) et pytensor (\"could not link BLAS\", advisory de perf, pas de correctness)\n",
+    "# leakent le chemin absolu du fichier source site-packages ; on les filtre. Les alertes utiles (R-hat, ESS) restent visibles.\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning, module=\"arviz\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*could not link.*\", category=UserWarning)\n",
+    "\n",
     "try:\n",
     "    import numpy as np\n",
     "    NUMPY_AVAILABLE = True\n",
@@ -171,10 +176,10 @@
    "id": "ba6d4075",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:25:19.893384Z",
-     "iopub.status.busy": "2026-06-03T06:25:19.893384Z",
-     "iopub.status.idle": "2026-06-03T06:25:19.905101Z",
-     "shell.execute_reply": "2026-06-03T06:25:19.903441Z"
+     "iopub.execute_input": "2026-07-03T15:32:14.165097Z",
+     "iopub.status.busy": "2026-07-03T15:32:14.165097Z",
+     "iopub.status.idle": "2026-07-03T15:32:14.169107Z",
+     "shell.execute_reply": "2026-07-03T15:32:14.169107Z"
     },
     "papermill": {
      "duration": 0.025623,
@@ -248,10 +253,10 @@
    "id": "d2e50400",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:25:19.953750Z",
-     "iopub.status.busy": "2026-06-03T06:25:19.953750Z",
-     "iopub.status.idle": "2026-06-03T06:26:21.568647Z",
-     "shell.execute_reply": "2026-06-03T06:26:21.567530Z"
+     "iopub.execute_input": "2026-07-03T15:32:14.171116Z",
+     "iopub.status.busy": "2026-07-03T15:32:14.171116Z",
+     "iopub.status.idle": "2026-07-03T15:32:45.611597Z",
+     "shell.execute_reply": "2026-07-03T15:32:45.611597Z"
     },
     "papermill": {
      "duration": 61.629713,
@@ -274,17 +279,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\pytensor\\link\\c\\cmodule.py:2986: UserWarning: PyTensor could not link to a BLAS installation. Operations that might benefit from BLAS will be severely degraded.\n",
-      "This usually happens when PyTensor is installed via pip. We recommend it be installed via conda/mamba/pixi instead.\n",
-      "Alternatively, you can use an experimental backend such as Numba or JAX that perform their own BLAS optimizations, by setting `pytensor.config.mode == 'NUMBA'` or passing `mode='NUMBA'` when compiling a PyTensor function.\n",
-      "For more options and details see https://pytensor.readthedocs.io/en/latest/troubleshooting.html#how-do-i-configure-test-my-blas-library\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "Multiprocess sampling (4 chains in 4 jobs)\n"
      ]
     },
@@ -297,16 +291,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8b76f5a87ef8413aa4b3c76aaf9164ec",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -326,7 +317,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 54 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 22 seconds.\n"
      ]
     }
    ],
@@ -390,10 +381,10 @@
    "id": "0e20eb03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:26:21.616682Z",
-     "iopub.status.busy": "2026-06-03T06:26:21.616682Z",
-     "iopub.status.idle": "2026-06-03T06:26:21.629830Z",
-     "shell.execute_reply": "2026-06-03T06:26:21.628345Z"
+     "iopub.execute_input": "2026-07-03T15:32:45.708120Z",
+     "iopub.status.busy": "2026-07-03T15:32:45.708120Z",
+     "iopub.status.idle": "2026-07-03T15:32:45.712950Z",
+     "shell.execute_reply": "2026-07-03T15:32:45.712950Z"
     },
     "papermill": {
      "duration": 0.028549,
@@ -478,10 +469,10 @@
    "id": "76b12769",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:26:21.681519Z",
-     "iopub.status.busy": "2026-06-03T06:26:21.680504Z",
-     "iopub.status.idle": "2026-06-03T06:26:22.299398Z",
-     "shell.execute_reply": "2026-06-03T06:26:22.297405Z"
+     "iopub.execute_input": "2026-07-03T15:32:45.714957Z",
+     "iopub.status.busy": "2026-07-03T15:32:45.714957Z",
+     "iopub.status.idle": "2026-07-03T15:32:45.913276Z",
+     "shell.execute_reply": "2026-07-03T15:32:45.913276Z"
     },
     "papermill": {
      "duration": 0.63421,
@@ -556,14 +547,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "id": "8326e94b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:27:38.138991Z",
-     "iopub.status.busy": "2026-06-03T06:27:38.138991Z",
-     "iopub.status.idle": "2026-06-03T06:27:38.146197Z",
-     "shell.execute_reply": "2026-06-03T06:27:38.144416Z"
+     "iopub.execute_input": "2026-07-03T15:32:45.915284Z",
+     "iopub.status.busy": "2026-07-03T15:32:45.915284Z",
+     "iopub.status.idle": "2026-07-03T15:32:45.918283Z",
+     "shell.execute_reply": "2026-07-03T15:32:45.918283Z"
     },
     "papermill": {
      "duration": 0.021917,
@@ -642,10 +633,10 @@
    "id": "37c8107b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:26:22.463389Z",
-     "iopub.status.busy": "2026-06-03T06:26:22.462264Z",
-     "iopub.status.idle": "2026-06-03T06:26:27.436120Z",
-     "shell.execute_reply": "2026-06-03T06:26:27.434086Z"
+     "iopub.execute_input": "2026-07-03T15:32:45.920399Z",
+     "iopub.status.busy": "2026-07-03T15:32:45.920399Z",
+     "iopub.status.idle": "2026-07-03T15:32:48.356517Z",
+     "shell.execute_reply": "2026-07-03T15:32:48.356517Z"
     },
     "papermill": {
      "duration": 4.991453,
@@ -666,16 +657,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a7922e8d50ea4a1e88819f11b2e1a2a2",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -775,10 +763,10 @@
    "id": "00cf05ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:26:27.497706Z",
-     "iopub.status.busy": "2026-06-03T06:26:27.497706Z",
-     "iopub.status.idle": "2026-06-03T06:26:27.510596Z",
-     "shell.execute_reply": "2026-06-03T06:26:27.508858Z"
+     "iopub.execute_input": "2026-07-03T15:32:48.374006Z",
+     "iopub.status.busy": "2026-07-03T15:32:48.373006Z",
+     "iopub.status.idle": "2026-07-03T15:32:48.378187Z",
+     "shell.execute_reply": "2026-07-03T15:32:48.378187Z"
     },
     "papermill": {
      "duration": 0.029601,
@@ -864,10 +852,10 @@
    "id": "e2376568",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:26:27.573055Z",
-     "iopub.status.busy": "2026-06-03T06:26:27.572531Z",
-     "iopub.status.idle": "2026-06-03T06:27:37.346746Z",
-     "shell.execute_reply": "2026-06-03T06:27:37.345026Z"
+     "iopub.execute_input": "2026-07-03T15:32:48.380394Z",
+     "iopub.status.busy": "2026-07-03T15:32:48.380394Z",
+     "iopub.status.idle": "2026-07-03T15:33:35.815393Z",
+     "shell.execute_reply": "2026-07-03T15:33:35.815393Z"
     },
     "papermill": {
      "duration": 69.79079,
@@ -909,16 +897,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "333c72847c3441ac82248e356db2b2d6",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -938,7 +923,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 63 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 25 seconds.\n"
      ]
     }
    ],
@@ -1005,10 +990,10 @@
    "id": "a6fefe5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:27:37.385030Z",
-     "iopub.status.busy": "2026-06-03T06:27:37.385030Z",
-     "iopub.status.idle": "2026-06-03T06:27:37.398520Z",
-     "shell.execute_reply": "2026-06-03T06:27:37.397437Z"
+     "iopub.execute_input": "2026-07-03T15:33:35.944581Z",
+     "iopub.status.busy": "2026-07-03T15:33:35.944581Z",
+     "iopub.status.idle": "2026-07-03T15:33:35.950450Z",
+     "shell.execute_reply": "2026-07-03T15:33:35.950450Z"
     },
     "papermill": {
      "duration": 0.024056,
@@ -1105,10 +1090,10 @@
    "id": "82004c14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:27:37.435252Z",
-     "iopub.status.busy": "2026-06-03T06:27:37.435252Z",
-     "iopub.status.idle": "2026-06-03T06:27:37.675555Z",
-     "shell.execute_reply": "2026-06-03T06:27:37.674250Z"
+     "iopub.execute_input": "2026-07-03T15:33:35.950450Z",
+     "iopub.status.busy": "2026-07-03T15:33:35.950450Z",
+     "iopub.status.idle": "2026-07-03T15:33:36.099946Z",
+     "shell.execute_reply": "2026-07-03T15:33:36.099946Z"
     },
     "papermill": {
      "duration": 0.251271,
@@ -1203,10 +1188,10 @@
    "id": "bce94a4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:27:37.738192Z",
-     "iopub.status.busy": "2026-06-03T06:27:37.737560Z",
-     "iopub.status.idle": "2026-06-03T06:27:38.068844Z",
-     "shell.execute_reply": "2026-06-03T06:27:38.067655Z"
+     "iopub.execute_input": "2026-07-03T15:33:36.099946Z",
+     "iopub.status.busy": "2026-07-03T15:33:36.099946Z",
+     "iopub.status.idle": "2026-07-03T15:33:36.279361Z",
+     "shell.execute_reply": "2026-07-03T15:33:36.279361Z"
     },
     "papermill": {
      "duration": 0.343872,
@@ -1332,14 +1317,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "b14240ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:27:38.197717Z",
-     "iopub.status.busy": "2026-06-03T06:27:38.197717Z",
-     "iopub.status.idle": "2026-06-03T06:27:38.204365Z",
-     "shell.execute_reply": "2026-06-03T06:27:38.202741Z"
+     "iopub.execute_input": "2026-07-03T15:33:36.281368Z",
+     "iopub.status.busy": "2026-07-03T15:33:36.281368Z",
+     "iopub.status.idle": "2026-07-03T15:33:36.284789Z",
+     "shell.execute_reply": "2026-07-03T15:33:36.284273Z"
     },
     "papermill": {
      "duration": 0.022056,
@@ -1403,14 +1388,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "id": "17cd6f26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T06:26:22.369685Z",
-     "iopub.status.busy": "2026-06-03T06:26:22.367172Z",
-     "iopub.status.idle": "2026-06-03T06:26:22.378490Z",
-     "shell.execute_reply": "2026-06-03T06:26:22.376320Z"
+     "iopub.execute_input": "2026-07-03T15:33:36.285795Z",
+     "iopub.status.busy": "2026-07-03T15:33:36.285795Z",
+     "iopub.status.idle": "2026-07-03T15:33:36.296185Z",
+     "shell.execute_reply": "2026-07-03T15:33:36.296185Z"
     },
     "papermill": {
      "duration": 0.030679,
@@ -1499,6 +1484,260 @@
    "parameters": {},
    "start_time": "2026-06-03T06:25:07.325466+00:00",
    "version": "2.7.0"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0bcf8ccc79874fa89bd471674c46cfb5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "333c72847c3441ac82248e356db2b2d6": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_f877d0f521a44a61be1f11db19a0b8a3",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.779       7            600.81 draws/s   0:00:06   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.632       7            548.03 draws/s   0:00:07   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.663       7            666.50 draws/s   0:00:06   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.499       7            428.71 draws/s   0:00:09   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.779       7            600.81 draws/s   0:00:06   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.632       7            548.03 draws/s   0:00:07   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.663       7            666.50 draws/s   0:00:06   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.499       7            428.71 draws/s   0:00:09   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "8b76f5a87ef8413aa4b3c76aaf9164ec": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_bd937103fd94434aa1ab6e821f267c04",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.497       7            1212.92 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.326       7            1599.60 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.693       7            984.49 draws/s    0:00:04   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.539       7            663.07 draws/s    0:00:06   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.497       7            1212.92 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.326       7            1599.60 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.693       7            984.49 draws/s    0:00:04   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.539       7            663.07 draws/s    0:00:06   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "a7922e8d50ea4a1e88819f11b2e1a2a2": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_0bcf8ccc79874fa89bd471674c46cfb5",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Sampling ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00 / 0:00:01\n</pre>\n",
+          "text/plain": "Sampling ... \u001b[38;2;23;100;244m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m 0:00:00 / 0:00:01\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "bd937103fd94434aa1ab6e821f267c04": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "f877d0f521a44a61be1f11db19a0b8a3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Eradicates **13 path-leaks** (→0) across 4 PyMC notebooks, continuing #3436 on the Probas/Python turf. Applies the **unified root-cause fix** + ai-01 canonical re-exec path (`jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=coursia-ml-training`, decision msg-g5awy3).

| Notebook | Before | After | Source edit |
|----------|--------|-------|-------------|
| PyMC-1-Setup | 2 leaks | 0 | none (pure cause-B) |
| PyMC-2-Gaussian-Mixtures | 6 leaks | 0 | +filterwarnings (import cell) |
| PyMC-5-Skills-IRT | 4 leaks | 0 | +filterwarnings (import cell) |
| PyMC-11-Sequences | 1 leak | 0 | +filterwarnings (import cell) |

## Root cause (unified)

Python warnings print the **absolute source-file path** of the emitter (`C:\ProgramData\miniconda3\envs\coursia-ml-training\Lib\site-packages\<lib>\<file>.py:NN`). All 13 leaks share the same `site-packages` prefix. Three sub-causes:

1. **`rich/live.py:260` "install ipywidgets"** (cause-B) — rich emits this during `pm.sample()` when ipywidgets is missing. **Fix**: ipywidgets 8.1.8 is now installed in the env → rich renders a proper progress widget, no warning. **No source edit.**
2. **`pytensor/link/c/cmodule.py:2986` "could not link BLAS"** (cause-C) — pytensor perf advisory (not correctness). **Fix**: `warnings.filterwarnings("ignore", message=".*could not link.*", category=UserWarning)`.
3. **`arviz/__init__.py:50` FutureWarning** (cause-C, preventive) — arviz refactor advisory. **Fix**: `warnings.filterwarnings("ignore", category=FutureWarning, module="arviz")`.

The filterwarnings block (6 lines) is added at the **top of the import cell**, before `import pymc`/`import arviz`. Same pattern as the merged PyMC-4 fix (#5191).

## Validation (H.1)

Re-exec real via nbconvert (all EXIT=0): PyMC-1 40s / PyMC-2 2min20 / PyMC-5 1min33 / PyMC-11 ~1min:
- **0 path-leaks** (all 4, scanned worktree post-exec).
- `execution_count` coherent: PyMC-1 [1..11], PyMC-2 [1..10], PyMC-5 [1..14], PyMC-11 [1..17].
- **0 errors**, **C.1 banned patterns = 0**.
- `kernelspec` python3 preserved; `metadata.papermill` basenames normalized; LF line-endings.
- C.3 anti-churn: PyMC-1 = **0 source change** (pure re-exec); PyMC-2/5/11 = only the 6-line filterwarnings block, **0 structural cell change**.

## Stop & Repair compliance

No cell-output hand-editing. Source-side fix (filterwarnings) + real re-exec — clean outputs genuinely produced by nbconvert. ipywidgets installed (regle F: repair, not workaround).

## Remaining (not in this PR)

PyMC-8 (13 leaks, ~10min) + PyMC-9 (4 leaks) still have residual leaks — longer sampling + mixed arviz-stats warnings, deferred to a follow-up cycle. `See #3436`.

See #3436