### PR TITLE
fix(pymc): silence PyMC-9-Topic-Models path-leaks (#3436 cause B+C)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models.ipynb
@@ -29,8 +29,7 @@
     "- Visualiser les distributions de mots par sujet\n",
     "- Comparer Infer.NET VMP vs PyMC NUTS pour les modeles discrets\n",
     "\n",
-    "**Prerequis** : PyMC-1 a PyMC-8, algebre lineaire (matrices, vecteurs)\n",
-    ""
+    "**Prerequis** : PyMC-1 a PyMC-8, algebre lineaire (matrices, vecteurs)\n"
    ]
   },
   {
@@ -39,10 +38,10 @@
    "id": "b2c3d4e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:23.590492Z",
-     "iopub.status.busy": "2026-06-03T00:03:23.590492Z",
-     "iopub.status.idle": "2026-06-03T00:03:31.436226Z",
-     "shell.execute_reply": "2026-06-03T00:03:31.435110Z"
+     "iopub.execute_input": "2026-07-03T15:51:06.133793Z",
+     "iopub.status.busy": "2026-07-03T15:51:06.132787Z",
+     "iopub.status.idle": "2026-07-03T15:51:08.938282Z",
+     "shell.execute_reply": "2026-07-03T15:51:08.938282Z"
     },
     "papermill": {
      "duration": 7.85928,
@@ -55,17 +54,6 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\arviz\\__init__.py:50: FutureWarning: \n",
-      "ArviZ is undergoing a major refactor to improve flexibility and extensibility while maintaining a user-friendly interface.\n",
-      "Some upcoming changes may be backward incompatible.\n",
-      "For details and migration guidance, visit: https://python.arviz.org/en/latest/user_guide/migration_guide.html\n",
-      "  warn(\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -74,6 +62,12 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "# arviz (FutureWarning de refactor) et pytensor (\"could not link BLAS\", advisory de perf, pas de correctness)\n",
+    "# leakent le chemin absolu du fichier source site-packages ; on les filtre. Les alertes utiles (R-hat, ESS) restent visibles.\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning, module=\"arviz\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*could not link.*\", category=UserWarning)\n",
+    "\n",
     "try:\n",
     "    import numpy as np\n",
     "    NUMPY_AVAILABLE = True\n",
@@ -202,10 +196,10 @@
    "id": "e5f6a7b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:31.471480Z",
-     "iopub.status.busy": "2026-06-03T00:03:31.470462Z",
-     "iopub.status.idle": "2026-06-03T00:03:31.489085Z",
-     "shell.execute_reply": "2026-06-03T00:03:31.489085Z"
+     "iopub.execute_input": "2026-07-03T15:51:08.940737Z",
+     "iopub.status.busy": "2026-07-03T15:51:08.940737Z",
+     "iopub.status.idle": "2026-07-03T15:51:08.948234Z",
+     "shell.execute_reply": "2026-07-03T15:51:08.948234Z"
     },
     "papermill": {
      "duration": 0.027415,
@@ -306,10 +300,10 @@
    "id": "f6a7b8c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:31.513837Z",
-     "iopub.status.busy": "2026-06-03T00:03:31.513837Z",
-     "iopub.status.idle": "2026-06-03T00:03:31.523036Z",
-     "shell.execute_reply": "2026-06-03T00:03:31.521809Z"
+     "iopub.execute_input": "2026-07-03T15:51:08.949241Z",
+     "iopub.status.busy": "2026-07-03T15:51:08.949241Z",
+     "iopub.status.idle": "2026-07-03T15:51:08.958246Z",
+     "shell.execute_reply": "2026-07-03T15:51:08.958246Z"
     },
     "papermill": {
      "duration": 0.0164,
@@ -382,10 +376,10 @@
    "id": "b8c9d0e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:31.543566Z",
-     "iopub.status.busy": "2026-06-03T00:03:31.543566Z",
-     "iopub.status.idle": "2026-06-03T00:05:53.629649Z",
-     "shell.execute_reply": "2026-06-03T00:05:53.628563Z"
+     "iopub.execute_input": "2026-07-03T15:51:08.958246Z",
+     "iopub.status.busy": "2026-07-03T15:51:08.958246Z",
+     "iopub.status.idle": "2026-07-03T15:52:16.419727Z",
+     "shell.execute_reply": "2026-07-03T15:52:16.419727Z"
     },
     "papermill": {
      "duration": 142.090709,
@@ -408,17 +402,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\pytensor\\link\\c\\cmodule.py:2986: UserWarning: PyTensor could not link to a BLAS installation. Operations that might benefit from BLAS will be severely degraded.\n",
-      "This usually happens when PyTensor is installed via pip. We recommend it be installed via conda/mamba/pixi instead.\n",
-      "Alternatively, you can use an experimental backend such as Numba or JAX that perform their own BLAS optimizations, by setting `pytensor.config.mode == 'NUMBA'` or passing `mode='NUMBA'` when compiling a PyTensor function.\n",
-      "For more options and details see https://pytensor.readthedocs.io/en/latest/troubleshooting.html#how-do-i-configure-test-my-blas-library\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "Multiprocess sampling (4 chains in 4 jobs)\n"
      ]
     },
@@ -431,16 +414,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "78db0471937f42be8f0570875e6900e3",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -460,7 +440,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 57 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 30 seconds.\n"
      ]
     },
     {
@@ -524,10 +504,10 @@
    "id": "c9d0e1f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:05:53.656561Z",
-     "iopub.status.busy": "2026-06-03T00:05:53.656561Z",
-     "iopub.status.idle": "2026-06-03T00:05:53.668784Z",
-     "shell.execute_reply": "2026-06-03T00:05:53.668140Z"
+     "iopub.execute_input": "2026-07-03T15:52:16.612808Z",
+     "iopub.status.busy": "2026-07-03T15:52:16.612808Z",
+     "iopub.status.idle": "2026-07-03T15:52:16.618793Z",
+     "shell.execute_reply": "2026-07-03T15:52:16.618793Z"
     },
     "papermill": {
      "duration": 0.021439,
@@ -616,10 +596,10 @@
    "id": "adf10941",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:05:53.693760Z",
-     "iopub.status.busy": "2026-06-03T00:05:53.693760Z",
-     "iopub.status.idle": "2026-06-03T00:05:53.699719Z",
-     "shell.execute_reply": "2026-06-03T00:05:53.699054Z"
+     "iopub.execute_input": "2026-07-03T15:52:16.620796Z",
+     "iopub.status.busy": "2026-07-03T15:52:16.620796Z",
+     "iopub.status.idle": "2026-07-03T15:52:16.626987Z",
+     "shell.execute_reply": "2026-07-03T15:52:16.626987Z"
     },
     "papermill": {
      "duration": 0.013703,
@@ -680,10 +660,10 @@
    "id": "e1f2a3b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:05:53.724698Z",
-     "iopub.status.busy": "2026-06-03T00:05:53.724698Z",
-     "iopub.status.idle": "2026-06-03T00:05:53.735083Z",
-     "shell.execute_reply": "2026-06-03T00:05:53.735083Z"
+     "iopub.execute_input": "2026-07-03T15:52:16.628991Z",
+     "iopub.status.busy": "2026-07-03T15:52:16.628991Z",
+     "iopub.status.idle": "2026-07-03T15:52:16.633993Z",
+     "shell.execute_reply": "2026-07-03T15:52:16.633993Z"
     },
     "papermill": {
      "duration": 0.015826,
@@ -748,10 +728,10 @@
    "id": "f2a3b4c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:05:53.762821Z",
-     "iopub.status.busy": "2026-06-03T00:05:53.762821Z",
-     "iopub.status.idle": "2026-06-03T00:07:41.427933Z",
-     "shell.execute_reply": "2026-06-03T00:07:41.426800Z"
+     "iopub.execute_input": "2026-07-03T15:52:16.636178Z",
+     "iopub.status.busy": "2026-07-03T15:52:16.636178Z",
+     "iopub.status.idle": "2026-07-03T15:53:12.119603Z",
+     "shell.execute_reply": "2026-07-03T15:53:12.119072Z"
     },
     "papermill": {
      "duration": 107.673973,
@@ -786,16 +766,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be473910c1ff421aabd93041c9f601b0",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -815,7 +792,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 103 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 44 seconds.\n"
      ]
     },
     {
@@ -872,10 +849,10 @@
    "id": "a3b4c5d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:41.476144Z",
-     "iopub.status.busy": "2026-06-03T00:07:41.475634Z",
-     "iopub.status.idle": "2026-06-03T00:07:41.488293Z",
-     "shell.execute_reply": "2026-06-03T00:07:41.486584Z"
+     "iopub.execute_input": "2026-07-03T15:53:12.494204Z",
+     "iopub.status.busy": "2026-07-03T15:53:12.494204Z",
+     "iopub.status.idle": "2026-07-03T15:53:12.501497Z",
+     "shell.execute_reply": "2026-07-03T15:53:12.500961Z"
     },
     "papermill": {
      "duration": 0.023681,
@@ -987,10 +964,10 @@
    "id": "4e2a0393",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:41.538143Z",
-     "iopub.status.busy": "2026-06-03T00:07:41.537143Z",
-     "iopub.status.idle": "2026-06-03T00:07:41.544202Z",
-     "shell.execute_reply": "2026-06-03T00:07:41.543190Z"
+     "iopub.execute_input": "2026-07-03T15:53:12.503344Z",
+     "iopub.status.busy": "2026-07-03T15:53:12.503344Z",
+     "iopub.status.idle": "2026-07-03T15:53:12.506804Z",
+     "shell.execute_reply": "2026-07-03T15:53:12.506804Z"
     },
     "papermill": {
      "duration": 0.016334,
@@ -1027,10 +1004,10 @@
    "id": "b4c5d6e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:41.561246Z",
-     "iopub.status.busy": "2026-06-03T00:07:41.561246Z",
-     "iopub.status.idle": "2026-06-03T00:07:42.285433Z",
-     "shell.execute_reply": "2026-06-03T00:07:42.285433Z"
+     "iopub.execute_input": "2026-07-03T15:53:12.508860Z",
+     "iopub.status.busy": "2026-07-03T15:53:12.508860Z",
+     "iopub.status.idle": "2026-07-03T15:53:12.938999Z",
+     "shell.execute_reply": "2026-07-03T15:53:12.938999Z"
     },
     "papermill": {
      "duration": 0.734997,
@@ -1096,10 +1073,10 @@
    "id": "c5d6e7f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:42.324248Z",
-     "iopub.status.busy": "2026-06-03T00:07:42.324248Z",
-     "iopub.status.idle": "2026-06-03T00:07:42.555952Z",
-     "shell.execute_reply": "2026-06-03T00:07:42.555952Z"
+     "iopub.execute_input": "2026-07-03T15:53:12.938999Z",
+     "iopub.status.busy": "2026-07-03T15:53:12.938999Z",
+     "iopub.status.idle": "2026-07-03T15:53:13.034019Z",
+     "shell.execute_reply": "2026-07-03T15:53:13.034019Z"
     },
     "papermill": {
      "duration": 0.244613,
@@ -1173,10 +1150,10 @@
    "id": "e7f8a9b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:42.594155Z",
-     "iopub.status.busy": "2026-06-03T00:07:42.594155Z",
-     "iopub.status.idle": "2026-06-03T00:07:42.606735Z",
-     "shell.execute_reply": "2026-06-03T00:07:42.606735Z"
+     "iopub.execute_input": "2026-07-03T15:53:13.036024Z",
+     "iopub.status.busy": "2026-07-03T15:53:13.036024Z",
+     "iopub.status.idle": "2026-07-03T15:53:13.040286Z",
+     "shell.execute_reply": "2026-07-03T15:53:13.040286Z"
     },
     "papermill": {
      "duration": 0.024089,
@@ -1254,10 +1231,10 @@
    "id": "a9b0c1d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:42.649340Z",
-     "iopub.status.busy": "2026-06-03T00:07:42.649340Z",
-     "iopub.status.idle": "2026-06-03T00:07:43.627581Z",
-     "shell.execute_reply": "2026-06-03T00:07:43.626020Z"
+     "iopub.execute_input": "2026-07-03T15:53:13.042389Z",
+     "iopub.status.busy": "2026-07-03T15:53:13.041293Z",
+     "iopub.status.idle": "2026-07-03T15:53:13.301424Z",
+     "shell.execute_reply": "2026-07-03T15:53:13.301424Z"
     },
     "papermill": {
      "duration": 0.990755,
@@ -1330,10 +1307,10 @@
    "id": "c1d2e3f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:43.665926Z",
-     "iopub.status.busy": "2026-06-03T00:07:43.665371Z",
-     "iopub.status.idle": "2026-06-03T00:07:43.671871Z",
-     "shell.execute_reply": "2026-06-03T00:07:43.671144Z"
+     "iopub.execute_input": "2026-07-03T15:53:13.301424Z",
+     "iopub.status.busy": "2026-07-03T15:53:13.301424Z",
+     "iopub.status.idle": "2026-07-03T15:53:13.306683Z",
+     "shell.execute_reply": "2026-07-03T15:53:13.306683Z"
     },
     "papermill": {
      "duration": 0.018615,
@@ -1448,11 +1425,183 @@
    "end_time": "2026-06-03T00:07:45.096022+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models_output.ipynb",
+   "input_path": "PyMC-9-Topic-Models.ipynb",
+   "output_path": "PyMC-9-Topic-Models.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:03:21.120320+00:00",
    "version": "2.7.0"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "08f1565377af42ee9b1e30475c222401": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "78db0471937f42be8f0570875e6900e3": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_08f1565377af42ee9b1e30475c222401",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.165       31           251.24 draws/s   0:00:11   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.157       31           290.38 draws/s   0:00:10   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.126       31           274.18 draws/s   0:00:10   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.130       31           210.46 draws/s   0:00:14   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.165       31           251.24 draws/s   0:00:11   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.157       31           290.38 draws/s   0:00:10   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.126       31           274.18 draws/s   0:00:10   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.130       31           210.46 draws/s   0:00:14   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "946e105200704532abc98fe8150f0450": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "be473910c1ff421aabd93041c9f601b0": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_946e105200704532abc98fe8150f0450",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.090       31           149.23 draws/s   0:00:26   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.127       31           164.49 draws/s   0:00:24   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.083       63           155.02 draws/s   0:00:25   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.100       63           137.23 draws/s   0:00:29   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.090       31           149.23 draws/s   0:00:26   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.127       31           164.49 draws/s   0:00:24   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.083       63           155.02 draws/s   0:00:25   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.100       63           137.23 draws/s   0:00:29   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

PyMC-9-Topic-Models: **4 path-leaks → 0**, continuing #3436 on the Probas/Python turf. Last short PyMC notebook (only PyMC-8 long remains). Same unified root-cause fix + ai-01 canonical re-exec path (`jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=coursia-ml-training`, decision msg-g5awy3).

| Source of leak | Sub-cause | Fix |
|----------------|-----------|-----|
| `arviz/__init__.py:50` FutureWarning | cause-C (refactor advisory) | filterwarnings |
| `pytensor/link/c/cmodule.py:2986` "could not link BLAS" | cause-C (perf advisory, not correctness) | filterwarnings |
| `rich/live.py:260` "install ipywidgets" (2 cells, during `pm.sample`) | cause-B | ipywidgets 8.1.8 installed |

## Root cause (unified)

Python warnings print the **absolute source-file path** of the emitter (`C:\ProgramData\miniconda3\envs\coursia-ml-training\Lib\site-packages\<lib>\<file>.py:NN`). The filterwarnings block (6 lines) is added at the **top of the import cell**, before `import pymc`/`import arviz`. Same pattern as the merged PyMC-4 (#5191) and the in-flight #5225 (PyMC-1/2/5/11).

## Validation (H.1)

Re-exec real via nbconvert (EXIT=0, ~5min topic-models sampling):
- **0 path-leaks** (scanned worktree post-exec).
- `execution_count` [1..15] coherent, **0 errors**, **C.1 banned patterns = 0**.
- `kernelspec` python3 preserved; `metadata.papermill` basenames normalized; LF line-endings.
- C.3 anti-churn: only the 6-line filterwarnings block in the import cell, **0 structural cell change** (no cell added/removed/reordered).

## Stop & Repair compliance

No cell-output hand-editing. Source-side fix (filterwarnings) + real re-exec — clean outputs genuinely produced by nbconvert. ipywidgets installed (regle F: repair, not workaround).

## Remaining

Only PyMC-8 (13 leaks, ~10min sampling) remains for #3436 on the PyMC family. `See #3436`.

See #3436