### PR TITLE
docs(gametheory): sync README Lean claims to verified 0-sorry ground truth

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -514,10 +514,10 @@ GameTheory/
 │   ├── strategies.py              # Tit-for-tat, hawks, doves, etc.
 │   ├── tournament.py              # Tournoi Axelrod
 │   └── visualization.py           # Animations populations
-├── cooperative_games_lean/        # Projet Lake jeux cooperatifs (Shapley 0 sorry, Bondareva-Shapley 1 sorry INTRACTABLE)
+├── cooperative_games_lean/        # Projet Lake jeux cooperatifs (Shapley + Bondareva-Shapley 0 sorry, cf #3954)
 ├── social_choice_lean/            # Projet Lake choix social (Arrow, Sen, Voting/Median Voter — 0 sorry)
 ├── social_choice_lean_peters/     # Projet Lake référence DominikPeters (0 sorry, toolchain v4.27.0-rc1)
-├── stable_marriage_lean/          # Projet Lake Gale-Shapley (GS COMPLETE, 3 sorry residual dans Lattice.lean)
+├── stable_marriage_lean/          # Projet Lake Gale-Shapley (GS COMPLETE, 0 sorry — énoncés faux réfutés, exists_isManOptimal prouvé)
 ├── lean_game_defs/                # Types Lean partages (pas de Lake project)
 ├── examples/
 │   ├── prisoners_dilemma.py
@@ -583,7 +583,7 @@ La théorie des jeux n'est pas qu'un objet académique : ses résultats structur
 
 ### Pont vers les Preuves Formelles (Lean 4) — différenciant CoursIA
 
-GameTheory occupe une place à part dans la couche Lean : c'est la famille qui aligne le plus directement simulation numérique et preuve formelle. Le Niveau 3 promet de « prouver ce qu'on a calculé » ; cette série tient la promesse par **cinq lakes game-théoriques phares** (toolchain `v4.31.0-rc1`, branchés sur les notebooks qui les enseignent ou les utilisent). Cartographie inter-familles :
+GameTheory occupe une place à part dans la couche Lean : c'est la famille qui aligne le plus directement simulation numérique et preuve formelle. Le Niveau 3 promet de « prouver ce qu'on a calculé » ; cette série tient la promesse par **cinq lakes game-théoriques phares** (toolchains détaillées dans [LEAN_INVENTORY.md](LEAN_INVENTORY.md) — harmonisation Mathlib en cours, cf #4362 —, branchés sur les notebooks qui les enseignent ou les utilisent). Cartographie inter-familles :
 
 | Famille | Lake phare | Théorème | Branchement notebook |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## Contexte

Passe éditoriale (rotation famille **GameTheory**) : `regard narratif` — cohérence prose↔preuves du README intermédiaire, cross-checkée contre `LEAN_INVENTORY.md` (que le README lui-même cite comme source-of-truth des `sorry`/toolchains, L153/L649) **et vérifiée firsthand**.

## Trois claims prose↔preuve périmés corrigés

Vérification firsthand (grep `^\s*sorry`/`admit` sur les `.lean` de production, hors `.lake/packages`) : **0 sorry / 0 admit** dans `cooperative_games_lean`, `stable_marriage_lean`, `social_choice_lean`, `minimax_lean`.

| Ligne | Avant (périmé) | Après (ground truth) |
|-------|----------------|----------------------|
| **517** | `cooperative_games_lean … Bondareva-Shapley 1 sorry INTRACTABLE` | `Shapley + Bondareva-Shapley 0 sorry, cf #3954` — le kernel `hb_witness` a été fermé par #3954 ; cohérent avec L593/612/630 + `LEAN_INVENTORY.md` L10/65/165 |
| **520** | `stable_marriage_lean … 3 sorry residual dans Lattice.lean` | `0 sorry — énoncés faux réfutés, exists_isManOptimal prouvé` — les 3 occurrences `sorry` restantes dans `Lattice.lean` sont du **texte narratif en commentaire** (L138/149/780), pas des tactiques ; cf `LEAN_INVENTORY.md` L9/164 |
| **586** | blanket `toolchain v4.31.0-rc1` sur les 5 lakes phares | renvoi à `LEAN_INVENTORY.md` + note `harmonisation Mathlib en cours, cf #4362` — **faux** : 3 des 5 lakes sont encore `v4.30.0-rc2` (seuls `minimax_lean` + `conway_cgt_lean` sont `v4.31.0-rc1`) |

## Nature

Édition **éditoriale de fraîcheur** (No-Pendulum : on synchronise la prose sur la ground truth déjà établie, pas de réécriture). Le README n'a **pas** été réécrit : famille Lean en cours de consolidation (#4362), donc la partie toolchain est renvoyée à la source-of-truth (`LEAN_INVENTORY.md`) plutôt que hardcodée — collision-proof avec #4362.

- Diff : **3 insertions / 3 deletions**, README.md uniquement.
- Marqueurs `CATALOG-STATUS` **inchangés** ; aucun fichier catalogue touché.
- FR-first (readme-french-first) — prose déjà FR.

See #4208 #4212 #4362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)