### PR TITLE
fix(iit): silence IIT-1-IntroToPyPhi path-leaks (#3436 cause A+C)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
@@ -98,10 +98,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:29:42.013067Z",
-     "iopub.status.busy": "2026-06-15T05:29:42.013067Z",
-     "iopub.status.idle": "2026-06-15T05:29:49.937768Z",
-     "shell.execute_reply": "2026-06-15T05:29:49.937768Z"
+     "iopub.execute_input": "2026-07-03T16:33:58.694612Z",
+     "iopub.status.busy": "2026-07-03T16:33:58.694612Z",
+     "iopub.status.idle": "2026-07-03T16:33:59.450714Z",
+     "shell.execute_reply": "2026-07-03T16:33:59.449773Z"
     },
     "papermill": {
      "duration": 7.929489,
@@ -120,27 +120,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: pyphi in C:\\ProgramData\\miniconda3\\Lib\\site-packages (1.2.0)\n",
-      "Requirement already satisfied: decorator>=4.0.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (5.2.1)\n",
-      "Requirement already satisfied: joblib>=0.8.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (1.5.2)\n",
-      "Requirement already satisfied: numpy>=1.11.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (2.2.6)\n",
-      "Requirement already satisfied: psutil>=2.1.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (7.2.2)\n",
-      "Requirement already satisfied: pyemd>=0.3.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (2.0.0)\n",
-      "Requirement already satisfied: pymongo>=2.7.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (4.17.0)\n",
-      "Requirement already satisfied: pyyaml>=3.13 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (6.0.3)\n",
-      "Requirement already satisfied: redis>=2.10.5 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (7.1.1)\n",
-      "Requirement already satisfied: scipy>=0.13.3 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pyphi) (1.17.0)\n",
-      "Requirement already satisfied: tblib>=1.3.2 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (3.2.2)\n",
-      "Requirement already satisfied: tqdm>=4.20.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyphi) (4.67.3)\n",
-      "Requirement already satisfied: pot>=0.9.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from pyemd>=0.3.0->pyphi) (0.9.6.post1)\n",
-      "Requirement already satisfied: dnspython<3.0.0,>=2.6.1 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pymongo>=2.7.1->pyphi) (2.7.0)\n",
-      "Requirement already satisfied: colorama in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from tqdm>=4.20.0->pyphi) (0.4.6)\n"
+      "\n",
+      "Welcome to PyPhi!\n",
+      "\n",
+      "If you use PyPhi in your research, please cite the paper:\n",
+      "\n",
+      "  Mayner WGP, Marshall W, Albantakis L, Findlay G, Marchman R, Tononi G.\n",
+      "  (2018). PyPhi: A toolbox for integrated information theory.\n",
+      "  PLOS Computational Biology 14(7): e1006343.\n",
+      "  https://doi.org/10.1371/journal.pcbi.1006343\n",
+      "\n",
+      "Documentation is available online (or with the built-in `help()` function):\n",
+      "  https://pyphi.readthedocs.io\n",
+      "\n",
+      "To report issues, please use the issue tracker on the GitHub repository:\n",
+      "  https://github.com/wmayner/pyphi\n",
+      "\n",
+      "For general discussion, you are welcome to join the pyphi-users group:\n",
+      "  https://groups.google.com/forum/#!forum/pyphi-users\n",
+      "\n",
+      "To suppress this message, either:\n",
+      "  - Set `WELCOME_OFF: true` in your `pyphi_config.yml` file, or\n",
+      "  - Set the environment variable PYPHI_WELCOME_OFF to any value in your shell:\n",
+      "        export PYPHI_WELCOME_OFF='yes'\n",
+      "\n",
+      "pyphi deja installe (1.2.0).\n"
      ]
     }
    ],
    "source": [
-    "# Dans un terminal ou dans un environnement conda :\n",
-    "! pip install pyphi\n"
+    "import warnings\n",
+    "# pyemd (importe par pyphi) emet un avertissement de deprecation pkg_resources qui fuite le chemin site-packages.\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*pkg_resources is deprecated.*\", category=UserWarning)\n",
+    "\n",
+    "# Installation defensive : pyphi est deja present dans le kernel dedie (env conda pyphi).\n",
+    "# On ne lance pip que s'il manque, pour eviter la sortie bruyante (chemins site-packages).\n",
+    "import importlib.util, subprocess, sys\n",
+    "if importlib.util.find_spec(\"pyphi\") is None:\n",
+    "    subprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"pyphi\"], check=True)\n",
+    "    print(\"pyphi installe.\")\n",
+    "else:\n",
+    "    import pyphi\n",
+    "    print(f\"pyphi deja installe ({pyphi.__version__}).\")\n"
    ]
   },
   {
@@ -169,10 +190,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:29:49.965037Z",
-     "iopub.status.busy": "2026-06-15T05:29:49.964035Z",
-     "iopub.status.idle": "2026-06-15T05:29:52.137522Z",
-     "shell.execute_reply": "2026-06-15T05:29:52.137522Z"
+     "iopub.execute_input": "2026-07-03T16:33:59.451219Z",
+     "iopub.status.busy": "2026-07-03T16:33:59.451219Z",
+     "iopub.status.idle": "2026-07-03T16:33:59.466439Z",
+     "shell.execute_reply": "2026-07-03T16:33:59.465511Z"
     },
     "papermill": {
      "duration": 2.181866,
@@ -188,14 +209,6 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\pyphi\\lib\\site-packages\\pyemd\\__init__.py:74: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
-      "  from .emd import emd, emd_with_flow, emd_samples\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -204,6 +217,10 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "# pyemd (importe par pyphi) emet un avertissement de deprecation pkg_resources qui fuite le chemin site-packages.\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*pkg_resources is deprecated.*\", category=UserWarning)\n",
+    "\n",
     "import pyphi\n",
     "\n",
     "print(\"PyPhi version:\", pyphi.__version__)"
@@ -247,10 +264,10 @@
    "id": "5e296ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:29:52.156406Z",
-     "iopub.status.busy": "2026-06-15T05:29:52.156406Z",
-     "iopub.status.idle": "2026-06-15T05:29:52.169523Z",
-     "shell.execute_reply": "2026-06-15T05:29:52.169128Z"
+     "iopub.execute_input": "2026-07-03T16:33:59.466439Z",
+     "iopub.status.busy": "2026-07-03T16:33:59.466439Z",
+     "iopub.status.idle": "2026-07-03T16:33:59.481960Z",
+     "shell.execute_reply": "2026-07-03T16:33:59.481231Z"
     },
     "papermill": {
      "duration": 0.015421,
@@ -323,10 +340,10 @@
    "id": "62301b90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:29:52.184788Z",
-     "iopub.status.busy": "2026-06-15T05:29:52.184788Z",
-     "iopub.status.idle": "2026-06-15T05:29:52.217297Z",
-     "shell.execute_reply": "2026-06-15T05:29:52.216110Z"
+     "iopub.execute_input": "2026-07-03T16:33:59.483881Z",
+     "iopub.status.busy": "2026-07-03T16:33:59.483881Z",
+     "iopub.status.idle": "2026-07-03T16:33:59.502264Z",
+     "shell.execute_reply": "2026-07-03T16:33:59.501375Z"
     },
     "papermill": {
      "duration": 0.03056,
@@ -422,10 +439,10 @@
    "id": "cfb3a7f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:29:52.232642Z",
-     "iopub.status.busy": "2026-06-15T05:29:52.232642Z",
-     "iopub.status.idle": "2026-06-15T05:30:00.730293Z",
-     "shell.execute_reply": "2026-06-15T05:30:00.730293Z"
+     "iopub.execute_input": "2026-07-03T16:33:59.505560Z",
+     "iopub.status.busy": "2026-07-03T16:33:59.504561Z",
+     "iopub.status.idle": "2026-07-03T16:34:06.917713Z",
+     "shell.execute_reply": "2026-07-03T16:34:06.917061Z"
     },
     "papermill": {
      "duration": 8.497272,
@@ -450,7 +467,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:15,  2.55s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:12,  2.06s/it]"
      ]
     },
     {
@@ -481,7 +498,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:12,  2.41s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.11s/it]"
      ]
     },
     {
@@ -553,10 +570,10 @@
    "id": "1748a54f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:30:00.745945Z",
-     "iopub.status.busy": "2026-06-15T05:30:00.745945Z",
-     "iopub.status.idle": "2026-06-15T05:30:07.954042Z",
-     "shell.execute_reply": "2026-06-15T05:30:07.952030Z"
+     "iopub.execute_input": "2026-07-03T16:34:06.918752Z",
+     "iopub.status.busy": "2026-07-03T16:34:06.918752Z",
+     "iopub.status.idle": "2026-07-03T16:34:12.899434Z",
+     "shell.execute_reply": "2026-07-03T16:34:12.898435Z"
     },
     "papermill": {
      "duration": 7.203649,
@@ -581,7 +598,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:15,  2.60s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:12,  2.11s/it]"
      ]
     },
     {
@@ -667,10 +684,10 @@
    "id": "8be318a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:30:08.002101Z",
-     "iopub.status.busy": "2026-06-15T05:30:08.002101Z",
-     "iopub.status.idle": "2026-06-15T05:30:34.950704Z",
-     "shell.execute_reply": "2026-06-15T05:30:34.949298Z"
+     "iopub.execute_input": "2026-07-03T16:34:12.903436Z",
+     "iopub.status.busy": "2026-07-03T16:34:12.903436Z",
+     "iopub.status.idle": "2026-07-03T16:34:38.566603Z",
+     "shell.execute_reply": "2026-07-03T16:34:38.566603Z"
     },
     "papermill": {
      "duration": 26.963492,
@@ -695,7 +712,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:03<00:21,  3.53s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:17,  3.00s/it]"
      ]
     },
     {
@@ -726,7 +743,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:13,  2.67s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:11,  2.32s/it]"
      ]
     },
     {
@@ -764,7 +781,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:15,  2.58s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:13,  2.19s/it]"
      ]
     },
     {
@@ -795,7 +812,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:12,  2.44s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:11,  2.35s/it]"
      ]
     },
     {
@@ -833,7 +850,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:14,  2.47s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:13,  2.31s/it]"
      ]
     },
     {
@@ -864,7 +881,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:12,  2.52s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:12,  2.43s/it]"
      ]
     },
     {
@@ -934,10 +951,10 @@
    "id": "42dafeb5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:30:35.004413Z",
-     "iopub.status.busy": "2026-06-15T05:30:35.003414Z",
-     "iopub.status.idle": "2026-06-15T05:30:35.011764Z",
-     "shell.execute_reply": "2026-06-15T05:30:35.010415Z"
+     "iopub.execute_input": "2026-07-03T16:34:38.568509Z",
+     "iopub.status.busy": "2026-07-03T16:34:38.568509Z",
+     "iopub.status.idle": "2026-07-03T16:34:38.583599Z",
+     "shell.execute_reply": "2026-07-03T16:34:38.583599Z"
     },
     "papermill": {
      "duration": 0.026024,
@@ -1000,10 +1017,10 @@
    "id": "57501e53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:30:35.050814Z",
-     "iopub.status.busy": "2026-06-15T05:30:35.049802Z",
-     "iopub.status.idle": "2026-06-15T05:30:35.095103Z",
-     "shell.execute_reply": "2026-06-15T05:30:35.093744Z"
+     "iopub.execute_input": "2026-07-03T16:34:38.586236Z",
+     "iopub.status.busy": "2026-07-03T16:34:38.586236Z",
+     "iopub.status.idle": "2026-07-03T16:34:38.615785Z",
+     "shell.execute_reply": "2026-07-03T16:34:38.615096Z"
     },
     "papermill": {
      "duration": 0.055629,
@@ -1078,10 +1095,10 @@
    "id": "1083ab9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:30:35.145527Z",
-     "iopub.status.busy": "2026-06-15T05:30:35.145527Z",
-     "iopub.status.idle": "2026-06-15T05:30:35.161493Z",
-     "shell.execute_reply": "2026-06-15T05:30:35.159958Z"
+     "iopub.execute_input": "2026-07-03T16:34:38.618272Z",
+     "iopub.status.busy": "2026-07-03T16:34:38.618272Z",
+     "iopub.status.idle": "2026-07-03T16:34:38.631950Z",
+     "shell.execute_reply": "2026-07-03T16:34:38.630649Z"
     },
     "papermill": {
      "duration": 0.03173,
@@ -1155,10 +1172,10 @@
    "id": "5658a6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:30:35.201771Z",
-     "iopub.status.busy": "2026-06-15T05:30:35.200772Z",
-     "iopub.status.idle": "2026-06-15T05:30:35.210764Z",
-     "shell.execute_reply": "2026-06-15T05:30:35.209786Z"
+     "iopub.execute_input": "2026-07-03T16:34:38.634006Z",
+     "iopub.status.busy": "2026-07-03T16:34:38.634006Z",
+     "iopub.status.idle": "2026-07-03T16:34:38.646460Z",
+     "shell.execute_reply": "2026-07-03T16:34:38.645857Z"
     },
     "papermill": {
      "duration": 0.022976,
@@ -1277,10 +1294,10 @@
    "id": "e55f113d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:30:35.279271Z",
-     "iopub.status.busy": "2026-06-15T05:30:35.279271Z",
-     "iopub.status.idle": "2026-06-15T05:30:35.324556Z",
-     "shell.execute_reply": "2026-06-15T05:30:35.324556Z"
+     "iopub.execute_input": "2026-07-03T16:34:38.649154Z",
+     "iopub.status.busy": "2026-07-03T16:34:38.649154Z",
+     "iopub.status.idle": "2026-07-03T16:34:38.669457Z",
+     "shell.execute_reply": "2026-07-03T16:34:38.668255Z"
     },
     "papermill": {
      "duration": 0.046093,
@@ -1404,10 +1421,10 @@
    "id": "53ad8dc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T05:30:35.388216Z",
-     "iopub.status.busy": "2026-06-15T05:30:35.388216Z",
-     "iopub.status.idle": "2026-06-15T05:30:35.404058Z",
-     "shell.execute_reply": "2026-06-15T05:30:35.404058Z"
+     "iopub.execute_input": "2026-07-03T16:34:38.671664Z",
+     "iopub.status.busy": "2026-07-03T16:34:38.671120Z",
+     "iopub.status.idle": "2026-07-03T16:34:38.683602Z",
+     "shell.execute_reply": "2026-07-03T16:34:38.682974Z"
     },
     "papermill": {
      "duration": 0.03672,


### PR DESCRIPTION
## Summary

IIT-1-IntroToPyPhi: **11 path-leaks → 0** (kernel `pyphi`). Two causes, two source fixes.

| Cause | Cell | Leaks | Fix |
|-------|------|-------|-----|
| A (pip-install) | 1 | 10 | import-guard replaces `! pip install pyphi` |
| C (pyemd warning) | 1+3 | 1 | filterwarnings before `import pyphi` |

## Root cause & fixes

**Cause-A (cell 1)** : `! pip install pyphi` printed `Requirement already satisfied: <pkg> in C:\...\site-packages` for every dependency (pyphi, numpy, psutil, pyemd, pymongo, pyyaml, redis, tblib, tqdm, pot) — 10 leaks of the conda base env path. Replaced with an **import-guard** (`importlib.util.find_spec`): pyphi is already present in the dedicated `pyphi` kernel, so pip is never invoked → deterministic 1-line output `pyphi deja installe (1.2.0).`. Same pattern as the merged PyMC-1-Setup (#5185).

**Cause-C (cells 1+3)** : `import pyphi` transitively imports `pyemd`, which emits `pkg_resources is deprecated as an API` leaking the pyphi-env site-packages path. Added `warnings.filterwarnings("ignore", message=".*pkg_resources is deprecated.*", category=UserWarning)` at the top of cell 1 (before the import-guard's `import pyphi`) and cell 3. Same recipe as #5235 (the 3 other PyPhi notebooks).

## Validation (H.1)

Re-exec real via nbconvert (kernel `pyphi`, ai-01 canonical path msg-g5awy3, EXIT=0, fast):
- **0 path-leaks** (scanned worktree post-exec). Down from 11.
- `execution_count` [1..13] coherent, **0 errors**, **C.1 banned patterns = 0**.
- `kernelspec` pyphi preserved; `metadata.papermill` basename normalized; LF line-endings.
- C.3 anti-churn: source edits in cells 1+3 only (import-guard + filterwarnings), **0 structural cell change**.
- Cell 1 output is now clean: `pyphi deja installe (1.2.0).` (+ the legitimate PyPhi welcome/citation banner, which is not a path-leak).

## Stop & Repair compliance

No cell-output hand-editing. Source-side fixes (import-guard + filterwarnings) + real re-exec — clean outputs genuinely produced by nbconvert.

## IIT family status (#3436)

With this PR + #5235 (ICT-1/ICT-5/IIT-2 pyemd), the IIT family drops from **14 → 0** path-leaks. `See #3436`.

See #3436