### PR TITLE
fix(pymc): silence PyMC-8-Model-Selection path-leaks, keep WAIC diagnostic (#3436 cause B+C)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection.ipynb
@@ -29,8 +29,7 @@
     "- Utiliser les Bayes Factors pour la selection de composantes dans les melanges\n",
     "- Comparer Infer.NET (calcul exact de l'evidence) vs PyMC/ArviZ (WAIC/LOO)\n",
     "\n",
-    "**Prerequis** : PyMC-1 a PyMC-7, comparaison de modeles (WAIC/LOO)\n",
-    ""
+    "**Prerequis** : PyMC-1 a PyMC-7, comparaison de modeles (WAIC/LOO)\n"
    ]
   },
   {
@@ -39,10 +38,10 @@
    "id": "b2c3d4e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:23.590492Z",
-     "iopub.status.busy": "2026-06-03T00:03:23.590492Z",
-     "iopub.status.idle": "2026-06-03T00:03:31.436226Z",
-     "shell.execute_reply": "2026-06-03T00:03:31.435658Z"
+     "iopub.execute_input": "2026-07-03T16:53:49.649052Z",
+     "iopub.status.busy": "2026-07-03T16:53:49.648054Z",
+     "iopub.status.idle": "2026-07-03T16:53:52.760106Z",
+     "shell.execute_reply": "2026-07-03T16:53:52.760106Z"
     },
     "papermill": {
      "duration": 7.864892,
@@ -55,17 +54,6 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\arviz\\__init__.py:50: FutureWarning: \n",
-      "ArviZ is undergoing a major refactor to improve flexibility and extensibility while maintaining a user-friendly interface.\n",
-      "Some upcoming changes may be backward incompatible.\n",
-      "For details and migration guidance, visit: https://python.arviz.org/en/latest/user_guide/migration_guide.html\n",
-      "  warn(\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -75,6 +63,25 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "\n",
+    "# Trois familles d'avertissements Python apparaissent dans ce notebook :\n",
+    "#  1. arviz FutureWarning (refactor advisory) et pytensor \"could not link BLAS\" (advisory de perf,\n",
+    "#     pas de correctness) : bruit sans valeur pedagogique -> on les filtre.\n",
+    "#  2. Les diagnostics de convergence (WAIC, R-hat, ESS) sont AU CONTRAIRE des alertes utiles\n",
+    "#     (le notebook porte precisement sur la selection de modele) -> on les GARDE visibles,\n",
+    "#     mais on retire le prefixe de chemin absolu (qui fuiterais le chemin local site-packages).\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning, module=\"arviz\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*could not link.*\", category=UserWarning)\n",
+    "\n",
+    "\n",
+    "def _warn_no_path(message, category, filename, lineno, file=None, line=None):\n",
+    "    \"\"\"Affiche le warning SANS le chemin absolu du fichier source (anti path-leak #3436).\"\"\"\n",
+    "    return f\"{category.__name__}: {message}\\n\"\n",
+    "\n",
+    "\n",
+    "warnings.formatwarning = _warn_no_path\n",
+    "\n",
     "try:\n",
     "    import numpy as np\n",
     "    NUMPY_AVAILABLE = True\n",
@@ -155,10 +162,10 @@
    "id": "d4e5f6a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:31.462712Z",
-     "iopub.status.busy": "2026-06-03T00:03:31.461621Z",
-     "iopub.status.idle": "2026-06-03T00:03:31.936382Z",
-     "shell.execute_reply": "2026-06-03T00:03:31.936382Z"
+     "iopub.execute_input": "2026-07-03T16:53:52.763227Z",
+     "iopub.status.busy": "2026-07-03T16:53:52.762208Z",
+     "iopub.status.idle": "2026-07-03T16:53:53.045252Z",
+     "shell.execute_reply": "2026-07-03T16:53:53.045252Z"
     },
     "papermill": {
      "duration": 0.48315,
@@ -174,8 +181,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\2152268274.py:23: UserWarning: The figure layout has changed to tight\n",
-      "  plt.tight_layout()\n"
+      "UserWarning: The figure layout has changed to tight\n"
      ]
     },
     {
@@ -273,10 +279,10 @@
    "id": "f6a7b8c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:03:31.965173Z",
-     "iopub.status.busy": "2026-06-03T00:03:31.964142Z",
-     "iopub.status.idle": "2026-06-03T00:07:04.816917Z",
-     "shell.execute_reply": "2026-06-03T00:07:04.815253Z"
+     "iopub.execute_input": "2026-07-03T16:53:53.047015Z",
+     "iopub.status.busy": "2026-07-03T16:53:53.047015Z",
+     "iopub.status.idle": "2026-07-03T16:55:08.250456Z",
+     "shell.execute_reply": "2026-07-03T16:55:08.250456Z"
     },
     "papermill": {
      "duration": 212.86135,
@@ -311,16 +317,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5dbad8a0e1c9461c86d08e63cec91c9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -340,21 +343,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 31 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 21 seconds.\n"
      ]
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4b727cc39dc848be840edb7cea3adb67",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -381,17 +381,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\pytensor\\link\\c\\cmodule.py:2986: UserWarning: PyTensor could not link to a BLAS installation. Operations that might benefit from BLAS will be severely degraded.\n",
-      "This usually happens when PyTensor is installed via pip. We recommend it be installed via conda/mamba/pixi instead.\n",
-      "Alternatively, you can use an experimental backend such as Numba or JAX that perform their own BLAS optimizations, by setting `pytensor.config.mode == 'NUMBA'` or passing `mode='NUMBA'` when compiling a PyTensor function.\n",
-      "For more options and details see https://pytensor.readthedocs.io/en/latest/troubleshooting.html#how-do-i-configure-test-my-blas-library\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "Multiprocess sampling (4 chains in 4 jobs)\n"
      ]
     },
@@ -404,16 +393,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e31960849dc42c09430f99e9e651380",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -433,7 +419,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 92 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 40 seconds.\n"
      ]
     },
     {
@@ -452,16 +438,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3d5a7428d84e49a7b81601d955bdac97",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -537,10 +520,10 @@
    "id": "a7b8c9d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:04.853555Z",
-     "iopub.status.busy": "2026-06-03T00:07:04.853555Z",
-     "iopub.status.idle": "2026-06-03T00:07:05.430620Z",
-     "shell.execute_reply": "2026-06-03T00:07:05.429473Z"
+     "iopub.execute_input": "2026-07-03T16:55:08.652097Z",
+     "iopub.status.busy": "2026-07-03T16:55:08.652097Z",
+     "iopub.status.idle": "2026-07-03T16:55:08.905632Z",
+     "shell.execute_reply": "2026-07-03T16:55:08.904579Z"
     },
     "papermill": {
      "duration": 0.588038,
@@ -564,13 +547,7 @@
       "                 dse  warning scale  \n",
       "1-gaussien  0.000000    False   log  \n",
       "2-gaussien  0.111777    False   log  \n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "Comparaison LOO (donnees unimodales) :\n",
       "            rank   elpd_loo     p_loo  elpd_diff    weight        se  \\\n",
       "1-gaussien     0 -89.207598  1.713334   0.000000  0.697049  4.412981   \n",
@@ -627,10 +604,10 @@
    "id": "c9d0e1f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:05.465412Z",
-     "iopub.status.busy": "2026-06-03T00:07:05.465412Z",
-     "iopub.status.idle": "2026-06-03T00:07:05.727400Z",
-     "shell.execute_reply": "2026-06-03T00:07:05.726370Z"
+     "iopub.execute_input": "2026-07-03T16:55:08.906633Z",
+     "iopub.status.busy": "2026-07-03T16:55:08.906633Z",
+     "iopub.status.idle": "2026-07-03T16:55:09.009449Z",
+     "shell.execute_reply": "2026-07-03T16:55:09.009449Z"
     },
     "papermill": {
      "duration": 0.272989,
@@ -646,8 +623,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\760950352.py:5: UserWarning: The figure layout has changed to tight\n",
-      "  plt.tight_layout()\n"
+      "UserWarning: The figure layout has changed to tight\n"
      ]
     },
     {
@@ -702,10 +678,10 @@
    "id": "b6b3b8f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:05.766189Z",
-     "iopub.status.busy": "2026-06-03T00:07:05.765190Z",
-     "iopub.status.idle": "2026-06-03T00:07:05.773133Z",
-     "shell.execute_reply": "2026-06-03T00:07:05.771982Z"
+     "iopub.execute_input": "2026-07-03T16:55:09.012030Z",
+     "iopub.status.busy": "2026-07-03T16:55:09.012030Z",
+     "iopub.status.idle": "2026-07-03T16:55:09.016248Z",
+     "shell.execute_reply": "2026-07-03T16:55:09.016248Z"
     },
     "papermill": {
      "duration": 0.019036,
@@ -774,10 +750,10 @@
    "id": "e1f2a3b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:07:05.813728Z",
-     "iopub.status.busy": "2026-06-03T00:07:05.813728Z",
-     "iopub.status.idle": "2026-06-03T00:08:30.710127Z",
-     "shell.execute_reply": "2026-06-03T00:08:30.710127Z"
+     "iopub.execute_input": "2026-07-03T16:55:09.018347Z",
+     "iopub.status.busy": "2026-07-03T16:55:09.018347Z",
+     "iopub.status.idle": "2026-07-03T16:56:00.534919Z",
+     "shell.execute_reply": "2026-07-03T16:56:00.534919Z"
     },
     "papermill": {
      "duration": 84.911892,
@@ -812,16 +788,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e784fc6b6a4a40c0949cb4a48bae525d",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -841,21 +814,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 40 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 22 seconds.\n"
      ]
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ecdfe0083f704753af43efa55b9d6342",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -894,16 +864,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e82d849c39014866870f30403ebecf7e",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -923,21 +890,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 38 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 24 seconds.\n"
      ]
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3e84183d3b744704bbaf0cd1fe961fba",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -1012,10 +976,10 @@
    "id": "f2a3b4c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:08:30.767762Z",
-     "iopub.status.busy": "2026-06-03T00:08:30.767224Z",
-     "iopub.status.idle": "2026-06-03T00:08:31.304191Z",
-     "shell.execute_reply": "2026-06-03T00:08:31.303179Z"
+     "iopub.execute_input": "2026-07-03T16:56:00.723529Z",
+     "iopub.status.busy": "2026-07-03T16:56:00.723529Z",
+     "iopub.status.idle": "2026-07-03T16:56:00.962699Z",
+     "shell.execute_reply": "2026-07-03T16:56:00.962177Z"
     },
     "papermill": {
      "duration": 0.555171,
@@ -1032,13 +996,13 @@
      "output_type": "stream",
      "text": [
       "Comparaison WAIC (donnees bimodales) :\n",
-      "            rank   elpd_waic    p_waic  elpd_diff  weight        se      dse  \\\n",
-      "2-gaussien     0 -159.798962  5.399717   0.000000     1.0  7.329950  0.00000   \n",
-      "1-gaussien     1 -192.156555  1.224310  32.357593     0.0  3.081215  6.14657   \n",
+      "            rank   elpd_waic    p_waic  elpd_diff        weight        se  \\\n",
+      "2-gaussien     0 -159.798962  5.399717   0.000000  1.000000e+00  7.329950   \n",
+      "1-gaussien     1 -192.156555  1.224310  32.357593  1.151523e-12  3.081215   \n",
       "\n",
-      "            warning scale  \n",
-      "2-gaussien     True   log  \n",
-      "1-gaussien    False   log  \n",
+      "                dse  warning scale  \n",
+      "2-gaussien  0.00000     True   log  \n",
+      "1-gaussien  6.14657    False   log  \n",
       "\n"
      ]
     },
@@ -1046,11 +1010,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\arviz\\stats\\stats.py:1652: UserWarning: For one or more samples the posterior variance of the log predictive densities exceeds 0.4. This could be indication of WAIC starting to fail. \n",
+      "UserWarning: For one or more samples the posterior variance of the log predictive densities exceeds 0.4. This could be indication of WAIC starting to fail. \n",
       "See http://arxiv.org/abs/1507.04544 for details\n",
-      "  warnings.warn(\n",
-      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\2997805489.py:33: UserWarning: The figure layout has changed to tight\n",
-      "  plt.tight_layout()\n"
+      "UserWarning: The figure layout has changed to tight\n"
      ]
     },
     {
@@ -1144,10 +1106,10 @@
    "id": "b4c5d6e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:08:31.336103Z",
-     "iopub.status.busy": "2026-06-03T00:08:31.336103Z",
-     "iopub.status.idle": "2026-06-03T00:08:31.352290Z",
-     "shell.execute_reply": "2026-06-03T00:08:31.352290Z"
+     "iopub.execute_input": "2026-07-03T16:56:00.964774Z",
+     "iopub.status.busy": "2026-07-03T16:56:00.964255Z",
+     "iopub.status.idle": "2026-07-03T16:56:00.969046Z",
+     "shell.execute_reply": "2026-07-03T16:56:00.968499Z"
     },
     "papermill": {
      "duration": 0.024163,
@@ -1217,10 +1179,10 @@
    "id": "c5d6e7f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:08:31.391827Z",
-     "iopub.status.busy": "2026-06-03T00:08:31.390827Z",
-     "iopub.status.idle": "2026-06-03T00:09:09.409860Z",
-     "shell.execute_reply": "2026-06-03T00:09:09.408338Z"
+     "iopub.execute_input": "2026-07-03T16:56:00.970706Z",
+     "iopub.status.busy": "2026-07-03T16:56:00.970706Z",
+     "iopub.status.idle": "2026-07-03T16:56:30.932367Z",
+     "shell.execute_reply": "2026-07-03T16:56:30.932367Z"
     },
     "papermill": {
      "duration": 38.028112,
@@ -1255,16 +1217,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c4d7c7da05ee473a8b073515ea623c5e",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -1284,21 +1243,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 34 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 23 seconds.\n"
      ]
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b573566bf4b84e0f839e68d1e7fd9c3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -1373,10 +1329,10 @@
    "id": "d6e7f8a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:09:09.455614Z",
-     "iopub.status.busy": "2026-06-03T00:09:09.455614Z",
-     "iopub.status.idle": "2026-06-03T00:09:09.467306Z",
-     "shell.execute_reply": "2026-06-03T00:09:09.465256Z"
+     "iopub.execute_input": "2026-07-03T16:56:31.055356Z",
+     "iopub.status.busy": "2026-07-03T16:56:31.055356Z",
+     "iopub.status.idle": "2026-07-03T16:56:31.061372Z",
+     "shell.execute_reply": "2026-07-03T16:56:31.060867Z"
     },
     "papermill": {
      "duration": 0.025434,
@@ -1454,10 +1410,10 @@
    "id": "e7f8a9b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:09:09.510934Z",
-     "iopub.status.busy": "2026-06-03T00:09:09.510934Z",
-     "iopub.status.idle": "2026-06-03T00:09:10.917568Z",
-     "shell.execute_reply": "2026-06-03T00:09:10.917006Z"
+     "iopub.execute_input": "2026-07-03T16:56:31.064378Z",
+     "iopub.status.busy": "2026-07-03T16:56:31.063378Z",
+     "iopub.status.idle": "2026-07-03T16:56:31.849934Z",
+     "shell.execute_reply": "2026-07-03T16:56:31.848927Z"
     },
     "papermill": {
      "duration": 1.420872,
@@ -1473,8 +1429,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\447534189.py:29: UserWarning: The figure layout has changed to tight\n",
-      "  plt.tight_layout()\n"
+      "UserWarning: The figure layout has changed to tight\n"
      ]
     },
     {
@@ -1597,10 +1552,10 @@
    "id": "fc71ff76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:09:10.992241Z",
-     "iopub.status.busy": "2026-06-03T00:09:10.991194Z",
-     "iopub.status.idle": "2026-06-03T00:09:10.998897Z",
-     "shell.execute_reply": "2026-06-03T00:09:10.997757Z"
+     "iopub.execute_input": "2026-07-03T16:56:31.851935Z",
+     "iopub.status.busy": "2026-07-03T16:56:31.851935Z",
+     "iopub.status.idle": "2026-07-03T16:56:31.856339Z",
+     "shell.execute_reply": "2026-07-03T16:56:31.856339Z"
     },
     "papermill": {
      "duration": 0.026111,
@@ -1669,10 +1624,10 @@
    "id": "b0c1d2e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:09:11.107313Z",
-     "iopub.status.busy": "2026-06-03T00:09:11.107313Z",
-     "iopub.status.idle": "2026-06-03T00:09:11.886784Z",
-     "shell.execute_reply": "2026-06-03T00:09:11.885772Z"
+     "iopub.execute_input": "2026-07-03T16:56:31.858354Z",
+     "iopub.status.busy": "2026-07-03T16:56:31.858354Z",
+     "iopub.status.idle": "2026-07-03T16:56:32.144113Z",
+     "shell.execute_reply": "2026-07-03T16:56:32.144113Z"
     },
     "papermill": {
      "duration": 0.841255,
@@ -1759,10 +1714,10 @@
    "id": "c1d2e3f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:09:11.929820Z",
-     "iopub.status.busy": "2026-06-03T00:09:11.929820Z",
-     "iopub.status.idle": "2026-06-03T00:09:11.939461Z",
-     "shell.execute_reply": "2026-06-03T00:09:11.938420Z"
+     "iopub.execute_input": "2026-07-03T16:56:32.146121Z",
+     "iopub.status.busy": "2026-07-03T16:56:32.146121Z",
+     "iopub.status.idle": "2026-07-03T16:56:32.150207Z",
+     "shell.execute_reply": "2026-07-03T16:56:32.150207Z"
     },
     "papermill": {
      "duration": 0.022108,
@@ -1835,10 +1790,10 @@
    "id": "e3f4a5b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T00:09:11.992622Z",
-     "iopub.status.busy": "2026-06-03T00:09:11.992622Z",
-     "iopub.status.idle": "2026-06-03T00:09:12.000524Z",
-     "shell.execute_reply": "2026-06-03T00:09:11.998495Z"
+     "iopub.execute_input": "2026-07-03T16:56:32.152215Z",
+     "iopub.status.busy": "2026-07-03T16:56:32.152215Z",
+     "iopub.status.idle": "2026-07-03T16:56:32.158231Z",
+     "shell.execute_reply": "2026-07-03T16:56:32.158231Z"
     },
     "papermill": {
      "duration": 0.023104,
@@ -1971,11 +1926,839 @@
    "end_time": "2026-06-03T00:09:13.443623+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection_output.ipynb",
+   "input_path": "PyMC-8-Model-Selection.ipynb",
+   "output_path": "PyMC-8-Model-Selection.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:03:21.111595+00:00",
    "version": "2.7.0"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "03d41866c00b46559cd794867ca1e135": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "0c34b5b95f8a4166b79c4dcb6c41af37": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "3d5a7428d84e49a7b81601d955bdac97": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_419795f3e9e446deade219a88daabd06",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Computing ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00\n</pre>\n",
+          "text/plain": "Computing ... \u001b[38;2;23;100;244m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m 0:00:00\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "3e84183d3b744704bbaf0cd1fe961fba": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_65c68cc3e8c34c4b92bf583a929a7b24",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Computing ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00\n</pre>\n",
+          "text/plain": "Computing ... \u001b[38;2;23;100;244m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m 0:00:00\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "419795f3e9e446deade219a88daabd06": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "4b727cc39dc848be840edb7cea3adb67": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_703b873954514f37b89f9e34bd3b5187",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Computing ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00\n</pre>\n",
+          "text/plain": "Computing ... \u001b[38;2;23;100;244m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m 0:00:00\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "5dbad8a0e1c9461c86d08e63cec91c9a": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_babe947193bf4b9aa6d96fca7975a6e7",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.811       3            3412.12 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.263       3            1828.53 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.074       3            1201.62 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.112       3            901.28 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.811       3            3412.12 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.263       3            1828.53 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.074       3            1201.62 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.112       3            901.28 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "65c68cc3e8c34c4b92bf583a929a7b24": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "703b873954514f37b89f9e34bd3b5187": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "9e31960849dc42c09430f99e9e651380": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_b3a3df2888a44ab2be420802752797b5",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.063       7            314.78 draws/s   0:00:12   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.052       31           205.57 draws/s   0:00:19   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.035       15           298.99 draws/s   0:00:13   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.107       7            161.68 draws/s   0:00:24   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.063       7            314.78 draws/s   0:00:12   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.052       31           205.57 draws/s   0:00:19   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.035       15           298.99 draws/s   0:00:13   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.107       7            161.68 draws/s   0:00:24   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "a1adea5f95ec45488c31d91e94b33039": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "a817ef1ffbcb4287a46c1be1950d153e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "b3a3df2888a44ab2be420802752797b5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "b573566bf4b84e0f839e68d1e7fd9c3e": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_a1adea5f95ec45488c31d91e94b33039",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Computing ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00\n</pre>\n",
+          "text/plain": "Computing ... \u001b[38;2;23;100;244m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m 0:00:00\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "b961836c25214e61851b55a1c263e14a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "babe947193bf4b9aa6d96fca7975a6e7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c4d7c7da05ee473a8b073515ea623c5e": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_0c34b5b95f8a4166b79c4dcb6c41af37",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.367       3            1174.10 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.383       7            969.45 draws/s    0:00:04   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.440       7            790.00 draws/s    0:00:05   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.438       7            548.11 draws/s    0:00:07   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.367       3            1174.10 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.383       7            969.45 draws/s    0:00:04   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.440       7            790.00 draws/s    0:00:05   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.438       7            548.11 draws/s    0:00:07   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "e784fc6b6a4a40c0949cb4a48bae525d": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_a817ef1ffbcb4287a46c1be1950d153e",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.138       3            3048.02 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.383       3            1695.21 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.278       3            1158.12 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             1.355       3            844.74 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.138       3            3048.02 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.383       3            1695.21 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.278       3            1158.12 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             1.355       3            844.74 draws/s    0:00:04   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "e82d849c39014866870f30403ebecf7e": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_b961836c25214e61851b55a1c263e14a",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.500       7            1007.56 draws/s   0:00:03   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.545       7            855.95 draws/s    0:00:04   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.539       7            752.82 draws/s    0:00:05   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.604       7            514.94 draws/s    0:00:07   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.500       7            1007.56 draws/s   0:00:03   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.545       7            855.95 draws/s    0:00:04   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.539       7            752.82 draws/s    0:00:05   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.604       7            514.94 draws/s    0:00:07   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "ecdfe0083f704753af43efa55b9d6342": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_03d41866c00b46559cd794867ca1e135",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Computing ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00\n</pre>\n",
+          "text/plain": "Computing ... \u001b[38;2;23;100;244m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m 0:00:00\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

PyMC-8-Model-Selection: **13 path-leaks → 0** (kernel `coursia-ml-training`). This was the **last and most nuanced** PyMC notebook on #3436 — it needed a layered fix because one of its leaks is a genuinely useful diagnostic (not noise to suppress).

| Source of leak | Sub-cause | Count | Fix |
|----------------|-----------|-------|-----|
| `rich/live.py` "install ipywidgets" (cells 5/13/19, during `pm.sample`) | cause-B | ~11 | ipywidgets 8.1.8 installed → re-exec |
| `arviz/__init__.py:50` FutureWarning (refactor) | cause-C (advisory) | 1 | filterwarnings |
| `pytensor/.../cmodule.py:2986` "could not link BLAS" (perf) | cause-C (advisory) | 1 | filterwarnings |
| `arviz/stats/stats.py:1652` WAIC warning | cause-C (**useful diagnostic**) | 1 | **formatwarning strips path, keeps message** |

## The nuance: the WAIC warning is NOT noise

The `stats.py:1652` warning reads:
> *posterior variance of the log predictive densities exceeds 0.4. This could be indication of WAIC starting to fail.*

Since this notebook is literally about **model selection**, the WAIC-failing diagnostic is pedagogically valuable — suppressing it would hide the lesson (SOTA principle: don't hide the real output). So it is **not** filtered. Instead, a custom `warnings.formatwarning` strips the absolute source-file path prefix (the leak) while keeping the message fully visible:

```python
def _warn_no_path(message, category, filename, lineno, file=None, line=None):
    return f"{category.__name__}: {message}\n"
warnings.formatwarning = _warn_no_path
```

This is a reusable pattern for #3436: **advisory warnings → filter; diagnostic warnings → strip path, keep message**. Verified post-exec: the WAIC diagnostic IS still present in cell 15's output (no-path), 0 leaks.

## Validation (H.1)

Re-exec real via nbconvert (kernel `coursia-ml-training`, ai-01 canonical path msg-g5awy3, EXIT=0):
- **0 path-leaks** (scanned worktree post-exec, down from 13).
- **WAIC diagnostic still visible** (no-path) — confirms formatwarning works and the useful alert is preserved.
- `execution_count` [1..16] coherent, **0 errors**, **C.1 banned patterns = 0**.
- `kernelspec` python3 preserved; `metadata.papermill` basename normalized; LF line-endings.
- C.3 anti-churn: 19-line warnings block in the import cell only (filter advisories + formatwarning), **0 structural cell change**. The 991 insertions in the diff are genuine `pm.sample` output churn (3 sampling cells produce InferenceData + arviz summaries + plots).

## Stop & Repair compliance

No cell-output hand-editing. Source-side fix (filterwarnings + formatwarning) + real re-exec — clean outputs genuinely produced by nbconvert, ipywidgets installed (regle F: repair, not workaround).

## PyMC family status (#3436)

With this PR, the entire PyMC family is **leak-free**: PyMC-1/2/3/4/5/6/7/8/9/11 all done (this session: #5185/#5186/#5191 cause-A, #5218/#5219/#5220/#5225/#5228 cause-B/C, this PR PyMC-8). `See #3436`.

See #3436