### PR TITLE
fix(probas): silence Do-Calculus-Bridge path-leaks, keep dowhy advisory (#3436 cause B+C)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb
@@ -96,18 +96,17 @@
   },
   {
    "cell_type": "code",
-   "id": "f46048fb51e7",
-   "metadata": {},
    "execution_count": 1,
+   "id": "f46048fb51e7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:30.371142Z",
+     "iopub.status.busy": "2026-07-03T17:01:30.370140Z",
+     "iopub.status.idle": "2026-07-03T17:01:33.940854Z",
+     "shell.execute_reply": "2026-07-03T17:01:33.940854Z"
+    }
+   },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -117,6 +116,20 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "\n",
+    "# dowhy emet un advisory de modelisation causale (\"N variables are assumed\") qui fuit le chemin\n",
+    "# absolu du fichier source. C'est une information utile (identification causale) -> on la GARDE\n",
+    "# visible, mais on retire le prefixe de chemin (anti path-leak #3436).\n",
+    "\n",
+    "\n",
+    "def _warn_no_path(message, category, filename, lineno, file=None, line=None):\n",
+    "    \"\"\"Affiche le warning SANS le chemin absolu du fichier source (anti path-leak #3436).\"\"\"\n",
+    "    return f\"{category.__name__}: {message}\\n\"\n",
+    "\n",
+    "\n",
+    "warnings.formatwarning = _warn_no_path\n",
+    "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import networkx as nx\n",
@@ -151,9 +164,16 @@
   },
   {
    "cell_type": "code",
-   "id": "900bd9619759",
-   "metadata": {},
    "execution_count": 2,
+   "id": "900bd9619759",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:33.940854Z",
+     "iopub.status.busy": "2026-07-03T17:01:33.940854Z",
+     "iopub.status.idle": "2026-07-03T17:01:33.954179Z",
+     "shell.execute_reply": "2026-07-03T17:01:33.954179Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -179,9 +199,16 @@
   },
   {
    "cell_type": "code",
-   "id": "4d16459390f2",
-   "metadata": {},
    "execution_count": 3,
+   "id": "4d16459390f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:33.954179Z",
+     "iopub.status.busy": "2026-07-03T17:01:33.954179Z",
+     "iopub.status.idle": "2026-07-03T17:01:33.968031Z",
+     "shell.execute_reply": "2026-07-03T17:01:33.966950Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -236,22 +263,22 @@
   },
   {
    "cell_type": "code",
-   "id": "7266933db347",
-   "metadata": {},
    "execution_count": 4,
+   "id": "7266933db347",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:33.970396Z",
+     "iopub.status.busy": "2026-07-03T17:01:33.969875Z",
+     "iopub.status.idle": "2026-07-03T17:01:37.261779Z",
+     "shell.execute_reply": "2026-07-03T17:01:37.261779Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Effet estime (dowhy, ajustement backdoor) : 1.981"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Effet estime (dowhy, ajustement backdoor) : 1.981\n",
       "Effet vrai                                : 2.000\n"
      ]
     },
@@ -311,9 +338,16 @@
   },
   {
    "cell_type": "code",
-   "id": "d1a4fb0cf4d6",
-   "metadata": {},
    "execution_count": 5,
+   "id": "d1a4fb0cf4d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:37.261779Z",
+     "iopub.status.busy": "2026-07-03T17:01:37.261779Z",
+     "iopub.status.idle": "2026-07-03T17:01:37.269383Z",
+     "shell.execute_reply": "2026-07-03T17:01:37.269383Z"
+    }
+   },
    "outputs": [],
    "source": [
     "np.random.seed(7)\n",
@@ -328,18 +362,17 @@
   },
   {
    "cell_type": "code",
-   "id": "78ddf6d65004",
-   "metadata": {},
    "execution_count": 6,
+   "id": "78ddf6d65004",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:37.269383Z",
+     "iopub.status.busy": "2026-07-03T17:01:37.269383Z",
+     "iopub.status.idle": "2026-07-03T17:01:37.412609Z",
+     "shell.execute_reply": "2026-07-03T17:01:37.412609Z"
+    }
+   },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\dowhy\\causal_model.py:581: UserWarning: 1 variables are assumed unobserved because they are not in the dataset. Configure the logging level to `logging.WARNING` or higher for additional details.\n",
-      "  warnings.warn(\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -369,6 +402,13 @@
       "No such variable(s) found!\n",
       "\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "UserWarning: 1 variables are assumed unobserved because they are not in the dataset. Configure the logging level to `logging.WARNING` or higher for additional details.\n"
+     ]
     }
    ],
    "source": [
@@ -393,22 +433,22 @@
   },
   {
    "cell_type": "code",
-   "id": "3b06c59976a0",
-   "metadata": {},
    "execution_count": 7,
+   "id": "3b06c59976a0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:37.412609Z",
+     "iopub.status.busy": "2026-07-03T17:01:37.412609Z",
+     "iopub.status.idle": "2026-07-03T17:01:37.446823Z",
+     "shell.execute_reply": "2026-07-03T17:01:37.446823Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Effet estime (front-door, deux etapes) : 0.934"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Effet estime (front-door, deux etapes) : 0.934\n",
       "Effet vrai via le mediateur             : ~0.900  (0.9 * 1.0)\n"
      ]
     }
@@ -502,9 +542,16 @@
   },
   {
    "cell_type": "code",
-   "id": "6094715b6d97",
-   "metadata": {},
    "execution_count": 8,
+   "id": "6094715b6d97",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:37.446823Z",
+     "iopub.status.busy": "2026-07-03T17:01:37.446823Z",
+     "iopub.status.idle": "2026-07-03T17:01:37.452826Z",
+     "shell.execute_reply": "2026-07-03T17:01:37.451942Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -527,9 +574,16 @@
   },
   {
    "cell_type": "code",
-   "id": "a8b84b32684c",
-   "metadata": {},
    "execution_count": 9,
+   "id": "a8b84b32684c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:37.453661Z",
+     "iopub.status.busy": "2026-07-03T17:01:37.453661Z",
+     "iopub.status.idle": "2026-07-03T17:01:37.458272Z",
+     "shell.execute_reply": "2026-07-03T17:01:37.458272Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -550,9 +604,16 @@
   },
   {
    "cell_type": "code",
-   "id": "8d916b67aa64",
-   "metadata": {},
    "execution_count": 10,
+   "id": "8d916b67aa64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T17:01:37.460279Z",
+     "iopub.status.busy": "2026-07-03T17:01:37.459279Z",
+     "iopub.status.idle": "2026-07-03T17:01:37.463010Z",
+     "shell.execute_reply": "2026-07-03T17:01:37.463010Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -604,8 +665,16 @@
    "name": "coursia-ml-training"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Do-Calculus-Bridge: **2 path-leaks → 0** (kernel `coursia-ml-training`, Probas/DecisionTheory/Causal-Bridges). Same layered SOTA pattern as PyMC-8 (#5238): advisory noise filtered, useful diagnostic kept via `formatwarning` path-strip.

| Source of leak | Sub-cause | Fix |
|----------------|-----------|-----|
| `tqdm/auto.py:21` TqdmWarning "IProgress not found" | cause-B | ipywidgets 8.1.8 installed → re-exec |
| `dowhy/causal_model.py:581` "1 variables are assumed" | cause-C (**useful diagnostic**) | formatwarning strips path, keeps message |

## The nuance: the dowhy advisory is kept

`causal_model.py:581` warns about causal-identification assumptions ("N variables are assumed"). For a **causal-bridges notebook**, this is pedagogically valuable (it surfaces the identification step). So it is **not** filtered. A custom `warnings.formatwarning` strips the absolute source-file path (the leak) while keeping the message visible. Verified post-exec: the dowhy advisory IS still present in cell 13's output (no-path), 0 leaks.

This is the reusable #3436 pattern (also in #5238 PyMC-8): **advisory warnings → filter; diagnostic warnings → strip path, keep message**.

## Validation (H.1)

Re-exec real via nbconvert (kernel `coursia-ml-training`, ai-01 canonical path msg-g5awy3, EXIT=0, fast — no MCMC):
- **0 path-leaks** (down from 2).
- **dowhy advisory still visible** (no-path).
- `execution_count` [1..10] coherent, **0 errors**, **C.1 banned patterns = 0**.
- `kernelspec` preserved; `metadata.papermill` basename normalized; LF line-endings.
- C.3 anti-churn: 14-line formatwarning block in the import cell only, **0 structural cell change**.

## Stop & Repair compliance

No cell-output hand-editing. Source-side fix + real re-exec — ipywidgets installed (regle F: repair, not workaround).

See #3436