### PR TITLE
docs(sudoku): fix notebook-19 table ordering + drop internal cycle-jargon (See #4208)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -330,7 +330,6 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 5 | PSO | Essaim de particules : convergence collective, vitesse, position |
 | 6 | AIMA CSP | CSP académique : variables, domaines, contraintes, MRV, AC-3 |
 | 7 | Norvig | Propagation de Norvig : élimination des candidats + recherche efficace |
-| 19 | [Sudoku-19-Lean-Propagation](Sudoku-19-Lean-Propagation.ipynb) | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la soundness de la propagation (naked/hidden single, clé de voûte `peer_excludes_value`) dans le lake `sudoku_lean`, `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) |
 | 8 | Human Stratégies | 13 techniques humaines : naked/hidden singles, pairs, pointing, box/line |
 | 9 | Graph Coloring | Formulation graphe : nx.sudoku_graph(), coloration DSATUR |
 | 10 | OR-Tools | CP-SAT industriel : modèle déclaratif, contraintes globales, parallélisme |
@@ -342,6 +341,7 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 16 | Neural Network | CNN PyTorch : apprentissage de patterns visuels sur grilles |
 | 17 | LLM | LLM Solver : prompt engineering pour résolution logique, limites |
 | 18 | Comparison | Benchmark comparatif : toutes les approches sur Easy/Medium/Hard/Expert |
+| 19 | [Sudoku-19-Lean-Propagation](Sudoku-19-Lean-Propagation.ipynb) | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la soundness de la propagation (naked/hidden single, clé de voûte `peer_excludes_value`) dans le lake `sudoku_lean`, `#check` + `#print axioms` in-kernel (jonction Mathlib #2611) |
 
 ---
 


### PR DESCRIPTION
## Passe editoriale ai-01 — famille Sudoku (rotation :41)

Le `MyIA.AI.Notebooks/Sudoku/README.md` (v1.1.0, juin 2026) est deja complet, coherent et FR-first (arc pedagogique 7 niveaux, diagramme mermaid, tableaux comparatifs, parcours C#/Python, resultats d'entrainement RRN, conclusion cross-linkee). Conformement au principe No-Pendulum (**freshness, pas rewrite**), cette PR se limite a **deux corrections chirurgicales** dans le tableau *"Ce que chaque notebook apporte"*.

### 1. Ordre numerique du tableau
La ligne du **notebook 19** (Lean-Propagation) etait intercalee entre les lignes **7** (Norvig) et **8** (Human Strategies) — probablement inseree la par thematique (propagation) mais jamais renumerotee. Elle rompait la sequence numerique du tableau. Deplacee a sa position correcte, **apres 18**. Le tableau est desormais strictement `0..19`.

### 2. Hygiene reference publique (See #4208)
Retrait du jargon interne **`UNLOCK c.127`** (vocabulaire de cycle de coordination du cluster, sans signification pour un lecteur public) de la cellule du notebook 19. La reference substantielle **`jonction Mathlib #2611`** est conservee.

### Verification firsthand (G.1)
La claim **"preuve formelle 0-sorry"** a ete verifiee contre la source : chaque occurrence de `sorry` dans le lake `sudoku_lean` (`Sudoku.lean`, `Propagation.lean`, `ExactCover.lean`, `lakefile.lean`) est **dans une docstring qui affirme l'absence de sorry** (`Preuve (0 sorry)`, `reste entierement sorry-free`, `non sorry-backed` pour les jalons deliberement ouverts). **Zero tactique `sorry` reelle.** La claim du README est exacte et donc preservee.

### Garde-fous
- Marqueurs `CATALOG-STATUS` **inchanges** (byte-identical, catalog cron-owned).
- Diff : **1 insertion / 1 deletion**, aucun autre churn.
- Cross-links conclusion (../Search, ../SymbolicAI, ../Probas) verifies valides.

See #4208 (reference publique) · See #4212 (finition editoriale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)