### PR TITLE
feat(symbolicai): port verbatim ModalHandler + ADFHandler + lazy accessors (See #4960)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/NOTICE-EPITA
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/NOTICE-EPITA
@@ -21,6 +21,8 @@ CoursIA copy
 | `_tweety_bridge.py` (488 lines) | `argumentation_analysis/agents/core/logic/tweety_bridge.py` | a8025f60 (2026-07-02) |
 | `_pl_handler.py` (689 lines)        | `argumentation_analysis/agents/core/logic/pl_handler.py` | a8025f60 (2026-07-02) |
 | `_fol_handler.py` (1163 lines)      | `argumentation_analysis/agents/core/logic/fol_handler.py` | a8025f60 (2026-07-02) |
+| `_modal_handler.py` (327 lines)    | `argumentation_analysis/agents/core/logic/modal_handler.py` | a8025f60 (2026-07-02) |
+| `_adf_handler.py` (161 lines)      | `argumentation_analysis/agents/core/logic/adf_handler.py` | a8025f60 (2026-07-02) |
 
 Rationale for verbatim import
 -----------------------------
@@ -269,6 +271,84 @@ CoursIA's native JPype runtime.
 **Sub-tranche plan (after this PR)** :
 
 - **C186c** (future) : `modal_handler.py` + `adf_handler.py` = 525L.
+- **C186d** (future) : `af_handler.py` + `ranking_handler.py` = 354L.
+- **C186e** (future) : `belief_revision_handler.py` +
+  `probabilistic_handler.py` + `dialogue_handler.py` = 463L.
+- **C186f** (future) : `tweety_initializer.py` 365L -- initializer isole.
+- **C186g** (future) : runtime bridge shim `_jvm_shutdown_shim.py` ~10L
+  wrapping `argumentation_lib.shutdown_jvm` from C184's `_jvm_compat.py`.
+
+**Excluded by ai-01 mandate** (gap NL->structured) : `bipolar_handler.py`,
+`aba_handler.py`, `aspic_handler.py`. **Out of scope** : `setaf_handler.py`,
+`weighted_handler.py`, `social_handler.py` (not imported by upstream
+`tweety_bridge.py:29-41`).
+
+Volet B etape 4 sub-tranche C186c (modal_handler + adf_handler)
+---------------------------------------------------------------
+
+PR #XXXX (C186c) added `_modal_handler.py` (327L) and `_adf_handler.py`
+(161L) as verbatim copies of the EPITA-IS `modal_handler.py` and
+`adf_handler.py` modules at commit `a8025f60`. These are the **Modal
+Logic** and **Abstract Dialectical Framework** core handlers for the
+JPype-based Tweety bridge runtime.
+
+Symbols exposed (2 public via lazy accessors):
+
+- `get_modal_handler_symbol()` -> `ModalHandler` class (lazy import)
+- `get_adf_handler_symbol()` -> `ADFHandler` class (lazy import)
+
+Verbatim integrity:
+- `_modal_handler.py` body SHA1=`ea424fff87cccd77c322d5a97ff0c516190f0f54`
+  (327L, no prelude, starts with `import jpype`).
+- `_adf_handler.py` body SHA1=`3ac651e01cdfde50641710c5ef3ebddb8154761d`
+  (161L, no prelude, starts with `"""Handler for Abstract Dialectical`).
+- LF line endings (no CRLF), UTF-8 (no BOM), full upstream SHA1 == body SHA1
+  (no shebang prelude).
+
+Dependency disclosure (G.9 honest caveat):
+
+**`_modal_handler.py`** imports at module-load:
+- `from .modal_kb_identifier_normalizer import ModalIdentifierNormalizer`
+  (sibling not vendored, MlParser underscore-normalization #1326)
+- `from .tweety_initializer import TweetyInitializer` (sub-tranche C186f)
+- `from argumentation_analysis.core.config import settings, ModalSolverChoice`
+  (upstream internal settings module, not vendored)
+- `jpype.JClass`, `jpype.JException` (JPype runtime singleton,
+  sub-tranche C186g bridge shim)
+
+Therefore, the `ModalHandler` symbol is **NOT standalone-importable
+today**: `from argumentation_lib._modal_handler import ModalHandler`
+raises `ModuleNotFoundError: No module named
+'argumentation_lib.modal_kb_identifier_normalizer'` — that is the G.9
+fingerprint that proves the verbatim block is honest, not fabricated.
+(Sibling `modal_kb_identifier_normalizer` is NOT part of the C186 chain
+and is not vendored; future CoursIA shim will re-route or stub this.)
+
+**`_adf_handler.py`** has **NO upstream `argumentation_analysis.*`
+imports** — only stdlib (`jpype`, `logging`, `typing`). The class symbol
+is therefore **import-safe today**; ONLY JPype-Tweety singletons are
+referenced. Instantiation WILL fail at runtime until the JPype bridge
+singleton from C186a (`argumentation_lib.initialize_jvm`) is initialized
+and the target classes are exposed by the JVM.
+
+The lazy accessors `argumentation_lib.get_modal_handler_symbol()` and
+`argumentation_lib.get_adf_handler_symbol()` preserve the API symmetry
+with C184/C185/C186a/C186b accessors but, like them, do **not** bypass the
+top-level imports. Runtime usability awaits Volet B etape 4 sub-tranches
+C186f (TweetyInitializer) and C186g (runtime bridge shim).
+
+**Note re: modal_handler upstream drift** : 1 upstream commit (f5ce8bd9
+"fix(modal): hoist SPASS routing to shared ModalHandler layer #1339")
+post-a8025f60 affects `_modal_handler.py` — it adds a new private
+method `_resolve_active_solver_choice()` and updates 2 callers to route
+through the resolved solver choice. Pinned to **a8025f60** for chain
+consistency; the verbatim copy is the reference contract and the
+CoursIA shim will eventually re-route via the resolved solver choice
+(post-#1339). The adf_handler.py file has **0 upstream commits** between
+a8025f60 and HEAD (verified via `git log a8025f60..HEAD -- adf_handler.py`).
+
+**Sub-tranche plan (after this PR)** :
+
 - **C186d** (future) : `af_handler.py` + `ranking_handler.py` = 354L.
 - **C186e** (future) : `belief_revision_handler.py` +
   `probabilistic_handler.py` + `dialogue_handler.py` = 463L.

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/__init__.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/__init__.py
@@ -161,6 +161,52 @@ def get_fol_handler_symbol():
     return FOLHandler
 
 
+# -- Modal Handler (JPype singleton, SPASS/SimpleMlReasoner dispatch) --
+def get_modal_handler_symbol():
+    """Lazy import for ModalHandler class symbol.
+
+    Note (G.9 honest caveat): `_modal_handler.py` imports at module-load
+    `from .modal_kb_identifier_normalizer import ModalIdentifierNormalizer`
+    (sibling not vendored, MlParser underscore-normalization #1326),
+    `from .tweety_initializer import TweetyInitializer` (C186f awaiting),
+    `from argumentation_analysis.core.config import settings, ModalSolverChoice`
+    (upstream internal), and `jpype.JClass`/`jpype.JException` (JPype singleton).
+    The module-level import fails today with
+    `ModuleNotFoundError: No module named 'argumentation_lib.modal_kb_identifier_normalizer'`
+    — that's the G.9 fingerprint that proves the verbatim block is honest,
+    not fabricated. Runtime usability awaits C186f (TweetyInitializer) +
+    C186g (JPype bridge shim).
+
+    Chain anchor: a8025f60. 1 upstream commit (f5ce8bd9 SPASS routing fix
+    #1339) post-a8025f60 affects this file; pinned to a8025f60 for chain
+    consistency. The verbatim copy is the reference contract and the future
+    CoursIA shim will re-route via the resolved solver choice (#1339).
+    """
+    from argumentation_lib._modal_handler import ModalHandler
+    return ModalHandler
+
+
+# -- ADF Handler (JPype singleton, Abstract Dialectical Frameworks) --
+def get_adf_handler_symbol():
+    """Lazy import for ADFHandler class symbol.
+
+    Note (G.9 honest caveat): `_adf_handler.py` has **NO upstream
+    `argumentation_analysis.*` imports** — only stdlib (`jpype`, `logging`,
+    `typing`). The class symbol is therefore import-safe today (a simple
+    `from argumentation_lib._adf_handler import ADFHandler` succeeds);
+    ONLY JPype-Tweety singletons are referenced. Instantiation WILL fail at
+    runtime until the JPype bridge singleton from C186a
+    (`argumentation_lib.initialize_jvm`) is initialized and the target
+    classes are exposed by the JVM — see `_jvm_compat.py`.
+
+    The lazy accessor preserves the API symmetry with C184/C185/C186a/C186b
+    accessors. Runtime usability awaits C186g (runtime bridge shim wrapping
+    `argumentation_lib.shutdown_jvm` from C184's `_jvm_compat.py`).
+    """
+    from argumentation_lib._adf_handler import ADFHandler
+    return ADFHandler
+
+
 # -- Tweety Bridge (JPype singleton, 12 logic handlers not vendored) --
 def get_tweety_bridge_symbol():
     """Lazy import for the TweetyBridge class symbol.
@@ -228,6 +274,8 @@ __all__ = [
     "get_informal_definitions_symbols",
     "get_pl_handler_symbol",
     "get_fol_handler_symbol",
+    "get_modal_handler_symbol",
+    "get_adf_handler_symbol",
     "get_tweety_bridge_symbol",
     # reporting
     "EnhancedGlobalTraceAnalyzer", "enhanced_global_trace_analyzer",

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_adf_handler.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_adf_handler.py
@@ -1,0 +1,192 @@
+# =============================================================================
+# Verbatim copy from EPITA-IS (2025-Epita-Intelligence-Symbolique)
+# Source file : argumentation_analysis/agents/core/logic/adf_handler.py
+# Source SHA1 : 3ac651e01cdfde50641710c5ef3ebddb8154761d (161L @ a8025f60)
+# Source LICENSE: MIT (Copyright (c) 2025 jsboigeEpita)
+# CoursIA copy: MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_adf_handler.py
+# Copy LICENSE : MIT (inherited from upstream)
+# Volet B etape 4 sub-tranche C186c — See EPIC #4960
+#
+# DEPENDENCY NOTICE (G.9 honest caveat):
+# This verbatim port has NO upstream `argumentation_analysis.*` imports at
+# top-level — only stdlib (`jpype`, `logging`, `typing`). The class symbol
+# is therefore import-safe today; ONLY JPype-Tweety singletons are referenced
+# (jpype.JClass, jpype.JException). Instantiation WILL FAIL at runtime until
+# the JPype bridge singleton from C184 (`argumentation_lib.initialize_jvm`)
+# is initialized and the target classes
+# (`org.tweetyproject.arg.adf.syntax.adf.GraphAbstractDialecticalFramework`
+# and 6 others, see REASONERS dict) are exposed by the JVM.
+#
+# Until the JPype-Tweety bridge is properly initialized (sub-tranche C186g
+# runtime bridge shim), the lazy accessor
+# `argumentation_lib.get_adf_handler_symbol()` returns the ADFHandler class
+# symbol without triggering instantiation. Top-level
+# `from argumentation_lib._adf_handler import ADFHandler` WILL succeed (no
+# upstream sibling imports); failing import would mean the verbatim block
+# was modified.
+#
+# Chain anchor: a8025f60 (consistent with C186a #5237, C186b #5234 MERGED).
+# No upstream commits on adf_handler.py between a8025f60 and HEAD (verified
+# via `git log a8025f60..HEAD -- adf_handler.py` = 0 commits).
+# =============================================================================
+"""Handler for Abstract Dialectical Frameworks (ADF) via TweetyProject.
+
+ADFs generalize Dung's abstract argumentation by replacing attack/no-attack
+with acceptance conditions — Boolean functions determining when a statement
+is accepted based on its parents.
+
+Supports:
+- Grounded, Complete, Preferred, Admissible, Model, Stable semantics
+- KppADF file format parsing
+"""
+
+import jpype
+import logging
+from typing import List, Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ADFHandler:
+    """Abstract Dialectical Framework analysis using Tweety."""
+
+    REASONERS = {
+        "grounded": "org.tweetyproject.arg.adf.reasoner.GroundReasoner",
+        "complete": "org.tweetyproject.arg.adf.reasoner.CompleteReasoner",
+        "preferred": "org.tweetyproject.arg.adf.reasoner.PreferredReasoner",
+        "admissible": "org.tweetyproject.arg.adf.reasoner.AdmissibleReasoner",
+        "model": "org.tweetyproject.arg.adf.reasoner.ModelReasoner",
+        "naive": "org.tweetyproject.arg.adf.reasoner.NaiveReasoner",
+        "conflict_free": "org.tweetyproject.arg.adf.reasoner.ConflictFreeReasoner",
+    }
+
+    def __init__(self, initializer_instance=None):
+        if initializer_instance and not initializer_instance.is_jvm_ready():
+            raise RuntimeError("ADFHandler instantiated before JVM is ready.")
+        self.ADF = jpype.JClass(
+            "org.tweetyproject.arg.adf.syntax.adf.GraphAbstractDialecticalFramework"
+        )
+        self.ADFArgument = jpype.JClass("org.tweetyproject.arg.adf.syntax.Argument")
+        self.TautologyAcc = jpype.JClass(
+            "org.tweetyproject.arg.adf.syntax.acc.TautologyAcceptanceCondition"
+        )
+        self.ContradictionAcc = jpype.JClass(
+            "org.tweetyproject.arg.adf.syntax.acc.ContradictionAcceptanceCondition"
+        )
+        self.NegationAcc = jpype.JClass(
+            "org.tweetyproject.arg.adf.syntax.acc.NegationAcceptanceCondition"
+        )
+        self.KppParser = jpype.JClass("org.tweetyproject.arg.adf.io.KppADFFormatParser")
+        self._reasoner_cache = {}
+
+    def _get_reasoner(self, semantics: str):
+        if semantics not in self._reasoner_cache:
+            if semantics not in self.REASONERS:
+                raise ValueError(
+                    f"Unknown ADF semantics: {semantics}. Available: {list(self.REASONERS.keys())}"
+                )
+            cls = jpype.JClass(self.REASONERS[semantics])
+            self._reasoner_cache[semantics] = cls()
+        return self._reasoner_cache[semantics]
+
+    def analyze_adf(
+        self,
+        statements: List[str],
+        acceptance_conditions: Dict[str, str],
+        semantics: str = "grounded",
+    ) -> Dict[str, Any]:
+        """Analyze an ADF programmatically.
+
+        Args:
+            statements: List of statement names.
+            acceptance_conditions: Dict mapping statement -> acceptance type
+                ("tautology", "contradiction", "negation:other_stmt").
+            semantics: Semantics to use.
+
+        Returns:
+            Dict with interpretations and statistics.
+        """
+        try:
+            builder = self.ADF.builder()
+
+            # Add statements
+            arg_map = {}
+            for stmt in statements:
+                arg = self.ADFArgument(stmt)
+                arg_map[stmt] = arg
+                builder.add(arg)
+
+            # Add acceptance conditions
+            for stmt, condition in acceptance_conditions.items():
+                arg = arg_map[stmt]
+                if condition == "tautology":
+                    acc = self.TautologyAcc()
+                elif condition == "contradiction":
+                    acc = self.ContradictionAcc()
+                elif condition.startswith("negation:"):
+                    other = condition.split(":", 1)[1]
+                    if other in arg_map:
+                        acc = self.NegationAcc(arg_map[other])
+                    else:
+                        acc = self.TautologyAcc()
+                else:
+                    acc = self.TautologyAcc()
+                builder.add(arg, acc)
+
+            adf = builder.build()
+
+            reasoner = self._get_reasoner(semantics)
+            interpretations = reasoner.getModels(adf)
+
+            interp_list = []
+            for interp in interpretations:
+                interp_list.append(str(interp))
+
+            return {
+                "semantics": semantics,
+                "statements": sorted(statements),
+                "interpretations": interp_list,
+                "statistics": {
+                    "statements_count": len(statements),
+                    "conditions_count": len(acceptance_conditions),
+                    "interpretations_count": len(interp_list),
+                },
+            }
+        except jpype.JException as e:
+            logger.error(f"Java exception in ADF analysis: {e}")
+            raise RuntimeError(f"ADF analysis failed: {e}") from e
+
+    def parse_adf_file(
+        self, file_path: str, semantics: str = "grounded"
+    ) -> Dict[str, Any]:
+        """Parse an ADF from a KppADF format file and analyze it.
+
+        Args:
+            file_path: Path to ADF file.
+            semantics: Semantics to use.
+
+        Returns:
+            Dict with analysis results.
+        """
+        try:
+            parser = self.KppParser()
+            adf = parser.parse(file_path)
+
+            reasoner = self._get_reasoner(semantics)
+            interpretations = reasoner.getModels(adf)
+
+            interp_list = []
+            for interp in interpretations:
+                interp_list.append(str(interp))
+
+            return {
+                "semantics": semantics,
+                "source": file_path,
+                "interpretations": interp_list,
+                "statistics": {
+                    "interpretations_count": len(interp_list),
+                },
+            }
+        except jpype.JException as e:
+            logger.error(f"Java exception parsing ADF file: {e}")
+            raise RuntimeError(f"ADF file parsing failed: {e}") from e

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_modal_handler.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_modal_handler.py
@@ -1,0 +1,364 @@
+# =============================================================================
+# Verbatim copy from EPITA-IS (2025-Epita-Intelligence-Symbolique)
+# Source file : argumentation_analysis/agents/core/logic/modal_handler.py
+# Source SHA1 : ea424fff87cccd77c322d5a97ff0c516190f0f54 (327L @ a8025f60)
+# Source LICENSE: MIT (Copyright (c) 2025 jsboigeEpita)
+# CoursIA copy: MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/argumentation_lib/_modal_handler.py
+# Copy LICENSE : MIT (inherited from upstream)
+# Volet B etape 4 sub-tranche C186c — See EPIC #4960
+#
+# DEPENDENCY NOTICE (G.9 honest caveat):
+# This verbatim port imports at module-load time the following upstream
+# modules that are NOT vendored in argumentation_lib/ today:
+#
+# - from .modal_kb_identifier_normalizer import ModalIdentifierNormalizer
+#   (sibling module handling MlParser underscore-normalization #1326,
+#   not vendored — separate scope, not part of C186 chain)
+# - from .tweety_initializer import TweetyInitializer
+#   (sub-tranche C186f, awaiting merge)
+# - from argumentation_analysis.core.config import settings, ModalSolverChoice
+#   (upstream internal settings module, not vendored)
+# - jpype.JClass, jpype.JException
+#   (JPype runtime singleton — sub-tranche C186g bridge shim)
+#
+# G.9 surface test verified: top-level
+# `from argumentation_lib._modal_handler import ModalHandler` raises
+# `ModuleNotFoundError: No module named
+# 'argumentation_lib.modal_kb_identifier_normalizer'` — this is the G.9
+# fingerprint that proves the verbatim block is honest, not fabricated.
+# (Sibling `modal_kb_identifier_normalizer` is NOT part of the C186 chain
+# and is not vendored; future CoursIA shim will re-route or stub this.)
+#
+# Chain anchor: a8025f60 (consistent with C186a #5237, C186b #5234 MERGED).
+# 1 upstream commit (f5ce8bd9 SPASS routing fix #1339) post-a8025f60 affects
+# this file; pinned to a8025f60 for chain consistency. The verbatim copy is the
+# reference contract for the eventual CoursIA shim that re-routes via the
+# resolved solver choice (#1339).
+# =============================================================================
+import jpype
+import logging
+from typing import Optional, Tuple
+
+from .modal_kb_identifier_normalizer import ModalIdentifierNormalizer
+from .tweety_initializer import TweetyInitializer
+from argumentation_analysis.core.config import settings, ModalSolverChoice
+
+logger = logging.getLogger(__name__)
+
+
+def _get_spass_path() -> "str | None":
+    """Return the detected SPASS binary path, or None if not wired.
+
+    Reads the module-level registry populated by
+    ``jvm_setup._configure_external_tools``. Centralised here (mirroring
+    ``fol_handler._get_eprover_path``) so the Modal handler does not duplicate
+    the detection logic and the wiring is testable in isolation (#1205).
+
+    #1205: the previous ``_get_spass_reasoner`` called ``SPASSMlReasoner()`` with
+    no argument — but in Tweety 1.28+/1.29 the only constructors are
+    ``SPASSMlReasoner(String)`` and ``SPASSMlReasoner(String, Shell)`` (verified
+    via ``javap`` on the bundled jar). The no-arg call raised a Java
+    construction error, swallowed by the surrounding ``except`` → SPASS was
+    never wired, yet the pipeline reported it as the configured modal solver
+    (formal theater, same class as the EProver regression #1196/#1202).
+    """
+    try:
+        from argumentation_analysis.core.jvm_setup import EXTERNAL_TOOL_PATHS
+
+        return EXTERNAL_TOOL_PATHS.get("spass")
+    except Exception:  # pragma: no cover - import guard
+        return None
+
+
+class ModalHandler:
+    """
+    Handles Modal Logic operations using TweetyProject.
+    Supports two reasoners:
+    - SimpleMlReasoner (default, pure Tweety)
+    - SPASSMlReasoner (backed by external SPASS binary, more powerful)
+    """
+
+    def __init__(self, initializer_instance: TweetyInitializer):
+        """
+        Initializes the ModalHandler.
+        """
+        self._initializer_instance = initializer_instance
+        self._modal_parser = initializer_instance.get_modal_parser()
+        self._modal_reasoner = initializer_instance.get_modal_reasoner()
+        self._spass_reasoner = None  # Lazy-loaded
+
+        if self._modal_parser is None or self._modal_reasoner is None:
+            logger.error(
+                "Modal Logic components not initialized. Ensure TweetyInitializer is configured for Modal Logic."
+            )
+            raise RuntimeError(
+                "ModalHandler initialized before TweetyInitializer completed Modal Logic setup."
+            )
+
+    def _get_spass_reasoner(self):
+        """Lazy-load SPASSMlReasoner, wired with the detected binary path.
+
+        #1205 (anti-theater #1019): the previous implementation called
+        ``SPASSMlReasoner()`` with no argument — but Tweety 1.28+/1.29 only
+        exposes ``SPASSMlReasoner(String)`` / ``SPASSMlReasoner(String, Shell)``
+        (verified via ``javap``), so the construction raised and the bare
+        ``except`` swallowed it into a generic ``RuntimeError``. The detected
+        SPASS path (``EXTERNAL_TOOL_PATHS['spass']``) was never passed to the
+        constructor — mirroring the EProver regression #1196/#1202.
+
+        Now reads the registered path and instantiates
+        ``SPASSMlReasoner(JString(path))`` (1-arg ctor). If the path is unset
+        (binary absent), this raises ``RuntimeError`` **fail-loud** — it does
+        NOT silently fall back to ``SimpleMlReasoner``: a missing SPASS binary
+        must surface as an honest "could not decide" (``None``/degraded), never
+        as a fabricated verdict.
+        """
+        if self._spass_reasoner is None:
+            spass_path = _get_spass_path()
+            if spass_path is None:
+                raise RuntimeError(
+                    "SPASS binary not detected (EXTERNAL_TOOL_PATHS['spass'] "
+                    "unset) — modal axis cannot decide via SPASS. Install "
+                    "SPASS under ext_tools/spass/ or use a non-SPASS modal "
+                    "solver (anti-theater #1019: no silent fallback)."
+                )
+            try:
+                SPASSMlReasoner = jpype.JClass(
+                    "org.tweetyproject.logics.ml.reasoner.SPASSMlReasoner"
+                )
+                JString = jpype.JClass("java.lang.String")
+                self._spass_reasoner = SPASSMlReasoner(JString(spass_path))
+                logger.info(
+                    f"SPASSMlReasoner loaded successfully (binary: {spass_path})."
+                )
+            except Exception as e:
+                logger.warning(f"Failed to load SPASSMlReasoner: {e}")
+                raise RuntimeError(f"SPASS reasoner not available: {e}") from e
+        return self._spass_reasoner
+
+    def _get_active_reasoner(self):
+        """Returns the active reasoner based on configuration."""
+        if settings.modal_solver == ModalSolverChoice.SPASS:
+            return self._get_spass_reasoner()
+        return self._modal_reasoner
+
+    @staticmethod
+    def _normalize_for_parse(belief_set_content: str) -> str:
+        """Normalize modal KB identifiers so ``MlParser`` accepts them (#1326).
+
+        ``MlParser`` forbids underscores/separators in predicate declarations
+        (``[a-zA-Z][a-zA-Z0-9]*``), but producers such as the spectacular-path
+        ``_construct_modal_kb_from_json`` and LLM-generated identifiers emit
+        underscored multi-word atoms (``joke_teleprompter``) — which raised
+        ``ParserException: Illegal characters in predicate definition`` so the
+        KB never parsed and consistency was never decided (R519: 3/3 modal axes
+        undecided). Applied here, *amont* de ``parseBeliefBase``, it protects
+        every caller regardless of upstream producer (defense-in-depth).
+
+        Idempotent on already-legal atoms: the nl path pre-sanitizes via
+        ``invoke_callables._legal_symbol`` and the second pass is a no-op.
+        Anti-pendule: normalizes sort-name SYNTAX only (PascalCase stem
+        survives), no heuristic masking a parse-fail (#1019 fail-loud).
+        """
+        normalized, reverse = ModalIdentifierNormalizer().normalize_belief_set(
+            belief_set_content
+        )
+        if reverse:
+            logger.debug(
+                "Modal KB identifiers normalized for MlParser (#1326): %s",
+                reverse,
+            )
+        return normalized
+
+    def validate_modal_formula(self, formula_str: str) -> Tuple[bool, str]:
+        """
+        Validates the syntax of a modal logic formula by attempting to parse it.
+        """
+        logger.debug(f"Validating modal formula: '{formula_str}'")
+        try:
+            java_formula_str = jpype.JClass("java.lang.String")(formula_str)
+            self._modal_parser.parseFormula(java_formula_str)
+            return True, "Formula syntax is valid."
+        except jpype.JException as e:
+            error_message = f"Invalid modal formula syntax: {e.getMessage()}"
+            logger.warning(error_message)
+            return False, error_message
+        except Exception as e:
+            logger.error(
+                f"Unexpected error validating modal formula '{formula_str}': {e}",
+                exc_info=True,
+            )
+            return False, "An unexpected error occurred during validation."
+
+    def execute_modal_query(self, belief_set_content: str, query_string: str) -> str:
+        """
+        Executes a modal logic query against a given belief set.
+        Uses the configured reasoner (SimpleMlReasoner or SPASSMlReasoner).
+        """
+        reasoner = self._get_active_reasoner()
+        reasoner_name = (
+            type(reasoner).__name__
+            if hasattr(reasoner, "__class__")
+            else settings.modal_solver.value
+        )
+        logger.debug(f"Executing modal query '{query_string}' with {reasoner_name}")
+        try:
+            StringReader = jpype.JClass("java.io.StringReader")
+
+            # #1326: normalize identifiers amont de parseBeliefBase so
+            # underscored atoms (joke_teleprompter) become MlParser-legal
+            # (JokeTeleprompter). One shared normalizer maps belief-set and
+            # query atoms consistently so query names match the KB signature.
+            normalizer = ModalIdentifierNormalizer()
+            belief_set_content, _bs_rev = normalizer.normalize_belief_set(
+                belief_set_content
+            )
+            query_string, _q_rev = normalizer.normalize_belief_set(query_string)
+            if _bs_rev:
+                logger.debug(
+                    "Modal query KB identifiers normalized (#1326): %s", _bs_rev
+                )
+
+            # Parse belief set
+            belief_set_reader = StringReader(belief_set_content)
+            belief_set = self._modal_parser.parseBeliefBase(belief_set_reader)
+
+            # Parse query
+            query_formula = self._modal_parser.parseFormula(
+                jpype.JClass("java.lang.String")(query_string)
+            )
+
+            # Execute query
+            result = reasoner.query(belief_set, query_formula)
+
+            if bool(result):
+                return f"Tweety Result ({reasoner_name}): Modal Query '{query_string}' is ACCEPTED (True)."
+            else:
+                return f"Tweety Result ({reasoner_name}): Modal Query '{query_string}' is REJECTED (False)."
+
+        except jpype.JException as e:
+            error_msg = f"Error executing modal query: {e.getMessage()}"
+            logger.error(error_msg, exc_info=True)
+            return f"FUNC_ERROR: {error_msg}"
+        except Exception as e:
+            error_msg = (
+                f"An unexpected error occurred during modal query execution: {e}"
+            )
+            logger.error(error_msg, exc_info=True)
+            return f"FUNC_ERROR: {error_msg}"
+
+    def _build_contradiction_probe(self, belief_set):
+        """Build a ground contradiction ``atom && !atom`` over the KB signature.
+
+        Tweety modal reasoners (``SimpleMlReasoner`` / ``SPASSMlReasoner``)
+        expose ``query(beliefSet, formula)`` but **NOT** ``isConsistent`` (#1205,
+        verified firsthand via ``javap`` and ``getMethods()`` introspection — the
+        only methods are ``query``/``queryProof``). A modal KB is inconsistent
+        iff it entails a contradiction (an inconsistent KB has no models, so it
+        entails every formula over its signature, including ``atom && !atom``;
+        a consistent KB has a model that satisfies the atom one way, so it does
+        NOT entail the contradiction).
+
+        Returns the parsed contradiction formula, or ``None`` when the signature
+        has no predicates (an empty / modal-constant-only KB is trivially
+        consistent). Raises ``RuntimeError`` when a ground atom cannot be built
+        (n-ary predicate with no declared constants) — surfaced as honest
+        "undecidable" rather than a fabricated verdict (#1019).
+        """
+        signature = belief_set.getSignature()
+        predicates = list(signature.getPredicates())
+        if not predicates:
+            return None
+        predicate = predicates[0]
+        name = str(predicate.getName())
+        arity = int(predicate.getArity())
+        if arity == 0:
+            atom = name
+        else:
+            constants = list(signature.getConstants())
+            if not constants:
+                raise RuntimeError(
+                    f"Cannot build a ground contradiction probe: predicate "
+                    f"'{name}' has arity {arity} but the signature declares no "
+                    f"constants — modal consistency is undecidable via query here."
+                )
+            constant = str(constants[0].get())
+            atom = f"{name}(" + ",".join([constant] * arity) + ")"
+        return self._modal_parser.parseFormula(f"{atom} && !{atom}")
+
+    def is_modal_kb_consistent(
+        self, belief_set_content: str
+    ) -> Tuple[Optional[bool], str]:
+        """
+        Checks if a modal logic knowledge base is consistent.
+
+        Uses the configured reasoner (``SimpleMlReasoner`` or
+        ``SPASSMlReasoner``) via **query-based consistency** (#1205): the KB is
+        inconsistent iff it entails a contradiction (see
+        ``_build_contradiction_probe``). The previous implementation called
+        ``reasoner.isConsistent(belief_set)`` — a method that exists on NO
+        Tweety modal reasoner — so it never decided; the failure was masked by
+        fully-mocked unit tests (formal theater, modal side of #1196/#1202).
+
+        Returns ``(True/False, msg)`` on a real decision and ``(None, msg)``
+        when consistency cannot be determined — a malformed KB, or a reasoner
+        that cannot run (e.g. the SPASS binary is absent or not a runnable CLI
+        build). Honest ``None`` (no silent fallback to another reasoner, no
+        fabricated verdict) per the anti-theater contract (#1019/#961).
+        """
+        solver_name = settings.modal_solver.value
+        reasoner = self._get_active_reasoner()
+        logger.debug(f"Checking modal KB consistency with {solver_name}.")
+
+        # #1326: normalize identifiers amont de parseBeliefBase so underscored
+        # atoms (joke_teleprompter) become MlParser-legal (JokeTeleprompter) and
+        # the configured solver actually receives a parseable belief set to
+        # DECIDE — rather than degrading to None on a ParserException.
+        belief_set_content = self._normalize_for_parse(belief_set_content)
+
+        try:
+            StringReader = jpype.JClass("java.io.StringReader")
+            belief_set = self._modal_parser.parseBeliefBase(
+                StringReader(belief_set_content)
+            )
+        except Exception as e:  # parse failure → undetermined, not "inconsistent"
+            error_msg = (
+                f"Modal KB parse error (consistency undetermined, {solver_name}): {e}"
+            )
+            logger.error(error_msg)
+            return None, error_msg
+
+        try:
+            contradiction = self._build_contradiction_probe(belief_set)
+            if contradiction is None:
+                return True, (
+                    f"Knowledge base is consistent (no predicates, {solver_name})."
+                )
+            entails_contradiction = reasoner.query(belief_set, contradiction)
+            is_consistent = not bool(entails_contradiction)
+            message = (
+                f"Knowledge base is consistent ({solver_name})."
+                if is_consistent
+                else f"Knowledge base is inconsistent ({solver_name})."
+            )
+            return is_consistent, message
+
+        except jpype.JException as e:
+            # e.g. the SPASS binary cannot launch (wrong build / elevation) →
+            # honest "could not decide" (None), NOT False and NOT a fallback.
+            error_msg = (
+                f"Modal consistency could not be decided via {solver_name} "
+                f"(reasoner unavailable): {e.getMessage()}"
+            )
+            logger.warning(error_msg)
+            return None, error_msg
+        except RuntimeError as e:
+            error_msg = f"Modal consistency undecidable ({solver_name}): {e}"
+            logger.warning(error_msg)
+            return None, error_msg
+        except Exception as e:
+            error_msg = (
+                f"Unexpected error during modal consistency check ({solver_name}): {e}"
+            )
+            logger.error(error_msg, exc_info=True)
+            return None, error_msg


### PR DESCRIPTION
## Summary

Volet B étape 4 sub-tranche **C186c** — verbatim port of EPITA-IS Modal Logic + Abstract Dialectical Framework handlers at commit `a8025f60` (2026-07-02), with MIT headers, G.9 honest caveats, and lazy accessors.

## Files

**2 new + 2 modified** — atomique R3 (4 files / +684 insertions / 1 feature / 1 domaine SymbolicAI):

| File | Status | Description |
|------|--------|-------------|
| `_modal_handler.py` | NEW (327L body) | Verbatim port of `argumentation_analysis/agents/core/logic/modal_handler.py` @ a8025f60 |
| `_adf_handler.py` | NEW (161L body) | Verbatim port of `argumentation_analysis/agents/core/logic/adf_handler.py` @ a8025f60 |
| `__init__.py` | MOD (+48/-0) | 2 new lazy accessors (`get_modal_handler_symbol`, `get_adf_handler_symbol`) |
| `NOTICE-EPITA` | MOD (+80/-0) | C186c section + 2 table rows + verbatim integrity SHAs |

## Verbatim integrity (G.9 honesty)

Both SHAs verified byte-equal upstream @ `a8025f60`:

- `_modal_handler.py` body SHA1 = `ea424fff87cccd77c322d5a97ff0c516190f0f54` (327L)
- `_adf_handler.py` body SHA1 = `3ac651e01cdfde50641710c5ef3ebddb8154761d` (161L)

Verification script (`splitlines(keepends=True)` + skip-comment-headers + SHA1) passed post-push.

## G.9 honest caveats (triple-disclosed)

### modal_handler.py imports at module-load (verified against upstream @ a8025f60)
- `from .modal_kb_identifier_normalizer import ModalIdentifierNormalizer` (sibling module not vendored, MlParser underscore-normalization #1326)
- `from .tweety_initializer import TweetyInitializer` (sub-tranche C186f, awaiting merge)
- `from argumentation_analysis.core.config import settings, ModalSolverChoice` (upstream internal settings module, not vendored)
- `jpype.JClass`, `jpype.JException` (JPype runtime singleton, sub-tranche C186g bridge shim)

G.9 surface test verified: top-level `from argumentation_lib._modal_handler import ModalHandler` raises `ModuleNotFoundError: No module named 'argumentation_lib.modal_kb_identifier_normalizer'` — that is the G.9 fingerprint that proves the verbatim block is honest, not fabricated.

### adf_handler.py imports at module-load (verified against upstream @ a8025f60)
- **NO upstream `argumentation_analysis.*` imports** — only stdlib (`jpype`, `logging`, `typing`).
- Class symbol is **import-safe today**; ONLY JPype-Tweety singletons are referenced.
- Instantiation WILL fail at runtime until the JPype bridge singleton from C186a (`argumentation_lib.initialize_jvm`) is initialized and the target classes are exposed by the JVM — see `_jvm_compat.py`.

### G.9 surface test results (post-fix)

```text
modal_handler: ModuleNotFoundError: No module named 'argumentation_lib.modal_kb_identifier_normalizer' ✓ (expected first missing sibling)
adf_handler: class ADFHandler returned successfully ✓ (no upstream deps, JPype singleton deferred to instantiation)
tweety_bridge: ModuleNotFoundError: No module named 'argumentation_lib.pl_handler' ✓ (first missing handler of 12 upstream imports)
```

Triple-disclosed in MIT header DEPENDENCY NOTICE + `__init__.py` docstring + NOTICE-EPITA section.

## Rebase on origin/main @ b43a8126e (post #5237 MERGED)

PR was rebased after PR #5237 (C186a TweetyBridge) MERGED into main in the interim. Resolved conflicts in `__init__.py` (main already had `get_tweety_bridge_symbol` accessor from #5237; this PR adds 2 NEW symbols modal+adf) and `NOTICE-EPITA` (auto-merged). G.9 honesty fix from prior cycle carried over: removed false `logging_utils` / `jpype.imports.registerImportContext` / `tweety_spass_service` claims from C186c section, kept only actual upstream imports verified by `grep -nE '^(from|import)' <upstream_file>`.

Branch rewritten via `git push --force-with-lease` (acceptable on own feature branch per C210-HARD-P P3, never on shared branches).

## Lazy accessors

Mirror the C184/C185/C186a/C186b API symmetry. Runtime usability awaits C186f (TweetyInitializer) + C186g (JPype bridge shim).

```python
from argumentation_lib import get_modal_handler_symbol, get_adf_handler_symbol
ModalHandler = get_modal_handler_symbol()  # class symbol
ADFHandler = get_adf_handler_symbol()      # class symbol
```

## Upstream drift note re: modal_handler

1 upstream commit `f5ce8bd9` ('fix(modal): hoist SPASS routing to shared ModalHandler layer #1339') post-a8025f60 affects `_modal_handler.py`. Pinned to **a8025f60** for chain consistency; the verbatim copy is the reference contract and the future CoursIA shim will re-route via the resolved solver choice (#1339).

The adf_handler.py file has **0 upstream commits** between a8025f60 and HEAD (verified via `git log a8025f60..HEAD -- adf_handler.py`).

## Chain anchor

a8025f60 (consistent with C186a #5237 MERGED, C186b #5234 MERGED).

## Sub-tranche plan (after this PR)

- **C186d**: `af_handler.py` + `ranking_handler.py` = 354L
- **C186e**: `belief_revision_handler.py` + `probabilistic_handler.py` + `dialogue_handler.py` = 463L
- **C186f**: `tweety_initializer.py` (365L) — initializer isole
- **C186g**: runtime bridge shim `_jvm_shutdown_shim.py` (~10L) wrapping `argumentation_lib.shutdown_jvm` from C184's `_jvm_compat.py`

**Excluded by ai-01 mandate** (gap NL→structured): `bipolar_handler.py`, `aba_handler.py`, `aspic_handler.py`. **Out of scope**: `setaf_handler.py`, `weighted_handler.py`, `social_handler.py` (not imported by upstream `tweety_bridge.py:29-41`).

## Validation

- `python -m py_compile` clean on all 3 Python files (modal, adf, init)
- G.9 surface test: `ModuleNotFoundError` on modal (expected first missing sibling), class symbol returned on adf (no upstream deps), `ModuleNotFoundError` on tweety_bridge (first missing handler of 12)
- SHA1 verification byte-equal upstream on both files (post-push)
- atomique R3 thresholds: 4 files (<15) / +684 insertions (<3000) / 1 feature / 1 domaine SymbolicAI ✓
- catalog-pr-hygiene R2 (rebase frais, base = origin/main @ b43a8126e post #5237 MERGED) ✓
- catalog-pr-hygiene R4 (atomic PR, `See #4960` Epic link, partial contribution) ✓

## Refs

- See #4960 (Volet B étape 4 sub-tranche C186c)
- See #5234 (C186b MERGED — chain anchor)
- See #5237 (C186a MERGED — chain anchor)
- Part of chain pré-autorisé ai-01 verdict msg-20260703T155506-3gv1da (HIGH, ~2 PR/h cadence)