### PR TITLE
fix(GenAI): de-leak PT_07 rewardspy CLI console_script path (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_07_rewardspy_reward_hacking.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_07_rewardspy_reward_hacking.ipynb
@@ -42,10 +42,10 @@
    "id": "7a7932e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T14:12:45.896990Z",
-     "iopub.status.busy": "2026-06-28T14:12:45.895962Z",
-     "iopub.status.idle": "2026-06-28T14:12:45.933126Z",
-     "shell.execute_reply": "2026-06-28T14:12:45.933126Z"
+     "iopub.execute_input": "2026-07-03T17:56:33.324578Z",
+     "iopub.status.busy": "2026-07-03T17:56:33.324578Z",
+     "iopub.status.idle": "2026-07-03T17:56:33.346606Z",
+     "shell.execute_reply": "2026-07-03T17:56:33.346098Z"
     }
    },
    "outputs": [
@@ -55,7 +55,7 @@
      "text": [
       "rewardspy 0.1.0\n",
       "Python API : ['watch', 'show', 'read_jsonl']\n",
-      "CLI console script : C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Scripts\\rewardspy.EXE\n"
+      "CLI console script : rewardspy.EXE\n"
      ]
     }
    ],
@@ -71,7 +71,8 @@
     "\n",
     "print(\"rewardspy\", getattr(rewardspy, \"__version__\", \"?\"))\n",
     "print(\"Python API :\", [s for s in [\"watch\", \"show\", \"read_jsonl\"] if hasattr(rewardspy, s)])\n",
-    "print(\"CLI console script :\", shutil_ := __import__(\"shutil\").which(\"rewardspy\"))"
+    "_cli = __import__(\"shutil\").which(\"rewardspy\")\n",
+    "print(\"CLI console script :\", os.path.basename(_cli) if _cli else \"(non trouve)\")\n"
    ]
   },
   {
@@ -117,10 +118,10 @@
    "id": "308ffb53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T14:12:45.936266Z",
-     "iopub.status.busy": "2026-06-28T14:12:45.936266Z",
-     "iopub.status.idle": "2026-06-28T14:12:45.948856Z",
-     "shell.execute_reply": "2026-06-28T14:12:45.948856Z"
+     "iopub.execute_input": "2026-07-03T17:56:33.347613Z",
+     "iopub.status.busy": "2026-07-03T17:56:33.347613Z",
+     "iopub.status.idle": "2026-07-03T17:56:33.358585Z",
+     "shell.execute_reply": "2026-07-03T17:56:33.358585Z"
     }
    },
    "outputs": [
@@ -136,7 +137,7 @@
       "  step 59: length=1.00 correctness=0 total=0.400\n",
       "\n",
       "Alertes levees pendant la run : 1\n",
-      "Log JSONL : pt07_g5sof5rq/hackable_run.jsonl  (15051 bytes)\n"
+      "Log JSONL : pt07_4ue2a6w3/hackable_run.jsonl  (15094 bytes)\n"
      ]
     }
    ],
@@ -219,10 +220,10 @@
    "id": "8c233366",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T14:12:45.951062Z",
-     "iopub.status.busy": "2026-06-28T14:12:45.951062Z",
-     "iopub.status.idle": "2026-06-28T14:12:46.184193Z",
-     "shell.execute_reply": "2026-06-28T14:12:46.184193Z"
+     "iopub.execute_input": "2026-07-03T17:56:33.360526Z",
+     "iopub.status.busy": "2026-07-03T17:56:33.360526Z",
+     "iopub.status.idle": "2026-07-03T17:56:33.596834Z",
+     "shell.execute_reply": "2026-07-03T17:56:33.596834Z"
     }
    },
    "outputs": [
@@ -272,10 +273,10 @@
    "id": "ac57f4d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T14:12:46.186001Z",
-     "iopub.status.busy": "2026-06-28T14:12:46.186001Z",
-     "iopub.status.idle": "2026-06-28T14:12:46.191348Z",
-     "shell.execute_reply": "2026-06-28T14:12:46.190977Z"
+     "iopub.execute_input": "2026-07-03T17:56:33.598839Z",
+     "iopub.status.busy": "2026-07-03T17:56:33.598839Z",
+     "iopub.status.idle": "2026-07-03T17:56:33.602777Z",
+     "shell.execute_reply": "2026-07-03T17:56:33.602777Z"
     }
    },
    "outputs": [
@@ -347,10 +348,10 @@
    "id": "4b2c6309",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T14:12:46.193617Z",
-     "iopub.status.busy": "2026-06-28T14:12:46.192618Z",
-     "iopub.status.idle": "2026-06-28T14:12:46.195818Z",
-     "shell.execute_reply": "2026-06-28T14:12:46.195818Z"
+     "iopub.execute_input": "2026-07-03T17:56:33.604807Z",
+     "iopub.status.busy": "2026-07-03T17:56:33.603782Z",
+     "iopub.status.idle": "2026-07-03T17:56:33.607164Z",
+     "shell.execute_reply": "2026-07-03T17:56:33.607164Z"
     }
    },
    "outputs": [
@@ -389,10 +390,10 @@
    "id": "2b5c81ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T14:12:46.197938Z",
-     "iopub.status.busy": "2026-06-28T14:12:46.196923Z",
-     "iopub.status.idle": "2026-06-28T14:12:46.200128Z",
-     "shell.execute_reply": "2026-06-28T14:12:46.200128Z"
+     "iopub.execute_input": "2026-07-03T17:56:33.608169Z",
+     "iopub.status.busy": "2026-07-03T17:56:33.608169Z",
+     "iopub.status.idle": "2026-07-03T17:56:33.613303Z",
+     "shell.execute_reply": "2026-07-03T17:56:33.613303Z"
     }
    },
    "outputs": [
@@ -431,10 +432,10 @@
    "id": "f2272b1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T14:12:46.201241Z",
-     "iopub.status.busy": "2026-06-28T14:12:46.201241Z",
-     "iopub.status.idle": "2026-06-28T14:12:46.204229Z",
-     "shell.execute_reply": "2026-06-28T14:12:46.204229Z"
+     "iopub.execute_input": "2026-07-03T17:56:33.614495Z",
+     "iopub.status.busy": "2026-07-03T17:56:33.614495Z",
+     "iopub.status.idle": "2026-07-03T17:56:33.618358Z",
+     "shell.execute_reply": "2026-07-03T17:56:33.618358Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## What

`PT_07_rewardspy_reward_hacking.ipynb` (PostTraining series, GenAI family) leaked 1 absolute path via `shutil.which("rewardspy")` printed in cell 1, exposing the full env `Scripts\rewardspy.EXE` path.

## Cause (#3436 cause-C: source-printed path)

Cell 1 printed the resolved CLI executable path directly:
```python
print("CLI console script :", shutil_ := __import__("shutil").which("rewardspy"))
# -> C:\ProgramData\miniconda3\envs\coursia-ml-training\Scripts\rewardspy.EXE
```

## Fix (Stop & Repair, source-fix)

Print `os.path.basename` instead of the absolute path:
```python
_cli = __import__("shutil").which("rewardspy")
print("CLI console script :", os.path.basename(_cli) if _cli else "(non trouve)")
# -> rewardspy.EXE
```

## Re-exec note (env-activated PATH required)

Re-executed via `conda run -n coursia-ml-training jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=coursia-ml-training`. The `conda run` wrapper is **required**: cell 7 calls `subprocess.run(["rewardspy", "audit", ...])` which needs the env `Scripts\` dir on PATH to resolve `rewardspy.EXE`. Bare `jupyter nbconvert` inherits a PATH without it -> `FileNotFoundError [WinError 2]`. EXIT=0, 27551 bytes.

## Validation (firsthand)

- **Leaks**: 0 (was 1)
- **execution_count**: [1, 2, 3, 4, 5, 6, 7] coherent
- **errors**: 0
- **C.1** banned: 0
- **kernelspec**: python3
- **Line endings**: LF (0 CRLF)
- **C.3 source diff**: 1 line removed, 2 added in cell 1 (print rewrite), no other churn
- Cell 1 output now shows `rewardspy.EXE` (basename) instead of the absolute path

See #3436.

Co-Authored-By: Claude-Code <noreply@anthropic.com>