### PR TITLE
docs(reference): restore FR accents in kernels-runtime prose (See #2876)

### DIFF
--- a/docs/reference/kernels-runtime.md
+++ b/docs/reference/kernels-runtime.md
@@ -1,6 +1,6 @@
 # Kernels & Runtime — Cluster CoursIA
 
-Document de reference detaillant l'inventaire kernels obligatoire sur toute machine du cluster (cf CLAUDE.md regle H.2).
+Document de référence détaillant l'inventaire kernels obligatoire sur toute machine du cluster (cf CLAUDE.md règle H.2).
 
 **Regle user 2026-05-07** : toute machine du cluster (ai-01, po-2023, po-2024, po-2025, po-2026) doit pouvoir executer n'importe quel notebook du depot. Reparation env > contournement (regle F, cf [env-python-reparation.md](env-python-reparation.md)).
 
@@ -24,7 +24,7 @@ Installation : `dotnet tool install --global Microsoft.dotnet-interactive` puis 
 
 Notebooks dans `GenAI/`, `QuantConnect/`, `GameTheory/`, `IIT/`, `SymbolicAI/SemanticWeb/` (Python).
 
-### Envs Conda dedies (ai-01, reference)
+### Envs Conda dédiés (ai-01, référence)
 
 | Env | Python | Path | Usage principal |
 |-----|--------|------|-----------------|
@@ -36,7 +36,7 @@ Notebooks dans `GenAI/`, `QuantConnect/`, `GameTheory/`, `IIT/`, `SymbolicAI/Sem
 | `e2e_test_env` | 3.10+ | `C:\Users\MYIA\miniconda3\envs\e2e_test_env` | E2E tests |
 | `base` | 3.10+ | `C:\Users\MYIA\miniconda3` | Conda base — NE PAS modifier |
 
-### Stack ML training (coursia-ml-training, verifie 2026-05-06)
+### Stack ML training (coursia-ml-training, vérifié 2026-05-06)
 
 - Python 3.11.15
 - PyTorch 2.11.0+cu126 (CUDA 12.6 active sur RTX 4090)
@@ -65,19 +65,19 @@ python train_moe.py ...
 nohup "C:/Users/MYIA/miniconda3/envs/coursia-ml-training/python.exe" train_moe.py ... > run.log 2>&1 &
 ```
 
-### Pourquoi un env Conda dedie ?
+### Pourquoi un env Conda dédié ?
 
-Sur ai-01, le Python 3.14 systeme est instable : scipy DLL corruption recurrente, conflits pip Python 3.12 vs 3.14, `~cipy/` residus apres force-reinstall rates. L'env Conda `coursia-ml-training` est l'env de reference stable pour le training ML, configure expressement avec PyTorch CUDA pour la RTX 4090.
+Sur ai-01, le Python 3.14 système est instable : scipy DLL corruption récurrente, conflits pip Python 3.12 vs 3.14, `~cipy/` résidus après force-reinstall ratés. L'env Conda `coursia-ml-training` est l'env de référence stable pour le training ML, configuré expressément avec PyTorch CUDA pour la RTX 4090.
 
-Incident 2026-05-06 : training MoE tente directement sur Python 3.14 systeme : `scipy DLL load failed` → `sklearn force-reinstall denied`. Résolution : utiliser l'env Conda dedie. D'ou la regle F (cf [env-python-reparation.md](env-python-reparation.md)).
+Incident 2026-05-06 : training MoE tenté directement sur Python 3.14 système : `scipy DLL load failed` → `sklearn force-reinstall denied`. Résolution : utiliser l'env Conda dédié. D'où la règle F (cf [env-python-reparation.md](env-python-reparation.md)).
 
-**Reflexe coordinateur** : avant tout dispatch ML training local, verifier que le script utilise `coursia-ml-training`. Si un agent rapporte un `ImportError` ML (sklearn, scipy, torch), premier debug = "tu as utilise l'env Conda `coursia-ml-training` ?".
+**Réflexe coordinateur** : avant tout dispatch ML training local, vérifier que le script utilise `coursia-ml-training`. Si un agent rapporte un `ImportError` ML (sklearn, scipy, torch), premier debug = "tu as utilisé l'env Conda `coursia-ml-training` ?".
 
 ### po-2025 (inventaire complet, 2026-05-23)
 
 **Machine**: MSI GE76 Raider, RTX 3080 Ti Laptop 16GB, **CPU-only strict** (11 crashes GPU). Windows 11 Pro Build 26200.
 
-#### Python PATH piege
+#### Python PATH piège
 
 `python` sur PATH = MS Store Python 3.13 (`C:\Users\jsboi\AppData\Local\Microsoft\WindowsApps\...\python.exe`). Le kernel Jupyter `python3` = conda base (`C:\ProgramData\miniconda3\python.exe`). Pour papermill : utiliser **toujours** le chemin complet du binaire cible.
 
@@ -85,7 +85,7 @@ Incident 2026-05-06 : training MoE tente directement sur Python 3.14 systeme : `
 
 | Env | Python | Path | Usage |
 |-----|--------|------|-------|
-| base (ProgramData) | - | `C:\ProgramData\miniconda3` | Conda systeme |
+| base (ProgramData) | - | `C:\ProgramData\miniconda3` | Conda système |
 | base (user) | - | `C:\Users\jsboi\miniconda3` | Conda user |
 | coursia-ml-training | 3.12 | `C:\Users\jsboi\.conda\envs\...` | ML training (torch CPU-only) |
 | epita_symbolic_ai | 3.12 | `C:\Users\jsboi\.conda\envs\...` | SemanticWeb Python (rdflib, owlready2, pyshacl) |
@@ -167,7 +167,7 @@ Installation : `python SymbolicAI/SmartContracts/setup_env.py`.
 
 ### Autres machines (po-2023/24/26)
 
-Verifier qu'elles ont aussi un env Conda dedie ou un venv local equivalent. La memoire est spécifique ai-01 mais le pattern (env dedie ML) est cluster-wide. Inventorier via `conda env list` sur chaque machine.
+Vérifier qu'elles ont aussi un env Conda dédié ou un venv local équivalent. La mémoire est spécifique ai-01 mais le pattern (env dédié ML) est cluster-wide. Inventorier via `conda env list` sur chaque machine.
 
 ### GenAI GPU stack : triton-windows + bitsandbytes
 
@@ -178,7 +178,7 @@ Les notebooks GenAI GPU (ex. [Video/02-5-LTX2-Audiovisual](../../MyIA.AI.Noteboo
 | Detection CUDA par triton (`ptxas` + `cuda.h` + `cuda.lib`) | pip wheels `nvidia-cuda-nvcc-cu12` + `nvidia-cuda-runtime-cu12` |
 | Compilateur C hote pour le JIT triton (`driver.c`) + bnb | `CC` env ; triton-windows embarque un TinyCC (`triton/runtime/tcc/tcc.exe`) |
 
-**Piege Windows** : si Python et ses paquets sont en **user site-packages** (`%APPDATA%\Python\PythonXX\site-packages` — cas quand `C:\PythonXX\Lib\site-packages` exige admin), `sysconfig['platlib']` pointe sur la base. L'auto-detection de triton (`find_cuda_pip`) et de son TinyCC (`get_cc`) ratent alors. Symptomes : `RuntimeError: Failed to find CUDA` (triton) et `Failed to find C compiler. Please specify via CC` (triton + bnb).
+**Piège Windows** : si Python et ses paquets sont en **user site-packages** (`%APPDATA%\Python\PythonXX\site-packages` — cas quand `C:\PythonXX\Lib\site-packages` exige admin), `sysconfig['platlib']` pointe sur la base. L'auto-detection de triton (`find_cuda_pip`) et de son TinyCC (`get_cc`) ratent alors. Symptomes : `RuntimeError: Failed to find CUDA` (triton) et `Failed to find C compiler. Please specify via CC` (triton + bnb).
 
 **Fix sans UAC** (canonical triton-windows, prefere a un system Toolkit install) : un `usercustomize.py` en user site-packages injecte `CUDA_HOME` + `CC` au demarrage de chaque interpreteur Python. Exemple (po-2023, 2026-06-16, pour #2891) :
 
@@ -201,7 +201,7 @@ Notebooks dans `GameTheory/` et `SymbolicAI/Lean/` requierent un kernel WSL spé
 - `Python (GameTheory WSL + OpenSpiel)` pour GameTheory
 - `Python 3 (WSL)` ou `Lean 4 (WSL)` pour SymbolicAI/Lean
 
-Pieges : backslashes consommes par WSL shell, paths sans separateurs, kernel timeout 60s cold start, heredoc variables interpolees. Wrapper bash obligatoire (Python wrapper ne marche PAS).
+Pièges : backslashes consommés par WSL shell, paths sans séparateurs, kernel timeout 60s cold start, heredoc variables interpolées. Wrapper bash obligatoire (Python wrapper ne marche PAS).
 
 Detail diagnostic + workarounds : [.claude/rules/wsl-kernels.md](../../.claude/rules/wsl-kernels.md) + [docs/wsl-kernels-detail.md](wsl-kernels-detail.md).
 
@@ -223,11 +223,11 @@ Mapping avec `prover/config.py PROVIDERS` :
 - `provider="openrouter"` : backup
 - `director_provider` peut differer du `provider` worker
 
-**Pieges connus** :
+**Pièges connus** :
 
 1. Modèles powerful reasoning separent `content` et `reasoning_content` dans la reponse JSON. Le framework `agent_framework_openai` gere via `Content.from_text_reasoning()`.
 2. `finish_reason: "length"` arrive vite si `max_tokens <= 2048` sur les modèles reasoning (toute la fenetre passe en reasoning).
-3. Verifier le nom exact du modèle cote endpoint (changements silencieux possibles).
+3. Vérifier le nom exact du modèle côté endpoint (changements silencieux possibles).
 4. Ports vLLM locaux 5001/5002 sur ai-01 = surveiller dispo (escalations Cycle 20). Preferer endpoint stable si flaky.
 
 ## Training wrapper checkpoints (ai-01)
@@ -295,4 +295,4 @@ wsl -l -v
 
 ## Si un kernel manque
 
-Cf regle F (CLAUDE.md) : reparer plutot que contourner. Installer le kernel manquant, ne pas deleguer. Pour kernels privilegies (UAC), demander au user.
+Cf règle F (CLAUDE.md) : réparer plutôt que contourner. Installer le kernel manquant, ne pas déléguer. Pour kernels privilégiés (UAC), demander au user.


### PR DESCRIPTION
## Summary

15 targeted FR accent restorations in `docs/reference/kernels-runtime.md` narrative prose. Single-file docs PR, 0 notebook/Lean/code touched, 0 semantic change.

## Scope

- **File**: `docs/reference/kernels-runtime.md` (1 file, +15/-15 lines)
- **Domain**: docs/reference (no overlap with Lean / notebook / proof / config)
- **PR-review §A** : +15 < 3000 ✓ ; 1 file < 15 ✓ ; 1 feature ; 1 domain ✓

## Edits (15)

| Line | Change |
|------|--------|
| L3  | `reference detaillant ... regle H.2` → `référence détaillant ... règle H.2` |
| L27 | `Envs Conda dedies (ai-01, reference)` → `Envs Conda dédiés (ai-01, référence)` |
| L39 | `Stack ML training (..., verifie 2026-05-06)` → `Stack ML training (..., vérifié 2026-05-06)` |
| L68 | `Pourquoi un env Conda dedie ?` → `Pourquoi un env Conda dédié ?` |
| L70 | `systeme ... corruption recurrente ... residus apres ... rates ... reference ... configure expressement` → `système ... corruption récurrente ... résidus après ... ratés ... référence ... configuré expressément` |
| L72 | `MoE tente directement sur Python 3.14 systeme ... l'env Conda dedie. D'ou la regle F` → `MoE tenté directement sur Python 3.14 système ... l'env Conda dédié. D'où la règle F` |
| L74 | `**Reflexe coordinateur** ... verifier ... tu as utilise` → `**Réflexe coordinateur** ... vérifier ... tu as utilisé` |
| L80 | `#### Python PATH piege` → `#### Python PATH piège` |
| L88 | `\| ... \| Conda systeme \|` → `\| ... \| Conda système \|` |
| L170 | `Verifier ... env Conda dedie ... venv local equivalent. La memoire ... env dedie ML` → `Vérifier ... env Conda dédié ... venv local équivalent. La mémoire ... env dédié ML` |
| L181 | `**Piege Windows**` → `**Piège Windows**` |
| L204 | `Pieges ... backslashes consommes ... sans separateurs ... heredoc variables interpolees` → `Pièges ... backslashes consommés ... sans séparateurs ... heredoc variables interpolées` |
| L226 | `**Pieges connus** :` → `**Pièges connus** :` |
| L230 | `Verifier le nom exact du modèle cote endpoint` → `Vérifier le nom exact du modèle côté endpoint` |
| L298 | `Cf regle F ... reparer plutot que contourner ... ne pas deleguer. Pour kernels privilegies (UAC)` → `Cf règle F ... réparer plutôt que contourner ... ne pas déléguer. Pour kernels privilégiés (UAC)` |

## Methodology (G.1 verify-before-claiming)

Strict accent scan with TARGETS list of bare French words that REQUIRE accent (référ-/détail-/règle/vérifi-/système/etc.), negative lookbehind/lookahead for already-accented forms, code-block + link + table-header skip. 13 candidate files scanned across `docs/`; `kernels-runtime.md` was the largest coherent prose target.

**Skipped (with reason)**:
- L5 `**Regle user 2026-05-07**` bold heading-marker line (5 accents, formatting-rule conflict; would expand PR scope to title styling)
- L82 `binaire cible` (noun phrase `target binary` in tech jargon, valid French without accent)
- L146 `il configure` (present 3rd singular verb form, no accent in French)

## Acceptance

- **Semantic diff**: `git diff --ignore-cr-at-eol --stat` = `1 file changed, 15 insertions(+), 15 deletions(-)` — no whole-file rewrite.
- **CRLF guard**: re-normalized via `sed -i 's/\r$//'` post-edit (per c.211 lesson `edit-tool-crlf-flip-windows.md`).
- **No code/links/table-headers touched**: edits are pure prose restoration.
- **No tracking issue required** (`See #2876` only, not `Closes`): #2876 is a repo-wide family-partitioned rollout per `coordinator-discipline.md` Règle 3 (fallback perenne).

## Tests

Not applicable: docs-only, 0 notebook/Lean/proof touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)