### PR TITLE
fix(probas): silence DecPyMC-7-Sequential path-leaks (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
@@ -14,8 +14,7 @@
     "tags": []
    },
    "source": [
-    "# DecPyMC-7-MDPs, Bandits et POMDPs",
-    "\n",
+    "# DecPyMC-7-MDPs, Bandits et POMDPs\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Sequential.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
@@ -33,8 +32,9 @@
     "\n",
     "**Prerequis** : DecPyMC-6 (systemes experts), bases de probabilites\n",
     "\n",
-    "**Duree estimee** : 90 minutes\n\n**Formalisation Lean complementaire** : [`Infer-9-Lean-Gittins`](../DecInfer/DecInfer-9-Lean-Gittins.ipynb) preuve formelle de l'indice de Gittins et du theoreme d'optimalite (Lean 4 + Mathlib), et le projet Lake [`decision_theory_lean`](../../decision_theory_lean/) (types bandit, escompte geometrique prouve, theoreme d'optimalite enonce).",
+    "**Duree estimee** : 90 minutes\n",
     "\n",
+    "**Formalisation Lean complementaire** : [`Infer-9-Lean-Gittins`](../DecInfer/DecInfer-9-Lean-Gittins.ipynb) preuve formelle de l'indice de Gittins et du theoreme d'optimalite (Lean 4 + Mathlib), et le projet Lake [`decision_theory_lean`](../../decision_theory_lean/) (types bandit, escompte geometrique prouve, theoreme d'optimalite enonce).\n",
     "---\n",
     "\n",
     "| Notebook precedent | Notebook suivant |\n",
@@ -76,10 +76,10 @@
    "id": "2d944f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:40.370353Z",
-     "iopub.status.busy": "2026-06-15T03:33:40.369354Z",
-     "iopub.status.idle": "2026-06-15T03:33:40.968169Z",
-     "shell.execute_reply": "2026-06-15T03:33:40.967665Z"
+     "iopub.execute_input": "2026-07-03T18:05:36.558366Z",
+     "iopub.status.busy": "2026-07-03T18:05:36.558366Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.056076Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.056076Z"
     },
     "papermill": {
      "duration": 0.608083,
@@ -100,13 +100,20 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning, module=\"arviz\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*could not link.*\", category=UserWarning)\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*install ipywidgets.*\", category=UserWarning)\n",
+    "def _warn_no_path(message, category, filename, lineno, file=None, line=None):\n",
+    "    return f\"{category.__name__}: {message}\\n\"\n",
+    "warnings.formatwarning = _warn_no_path\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from collections import defaultdict\n",
     "from typing import Dict, List, Tuple, Optional\n",
     "\n",
     "np.random.seed(42)\n",
-    "print(\"Environnement pret : numpy + matplotlib\")"
+    "print(\"Environnement pret : numpy + matplotlib\")\n"
    ]
   },
   {
@@ -163,10 +170,10 @@
    "id": "98217ea7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:41.014162Z",
-     "iopub.status.busy": "2026-06-15T03:33:41.013164Z",
-     "iopub.status.idle": "2026-06-15T03:33:41.022132Z",
-     "shell.execute_reply": "2026-06-15T03:33:41.022132Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.057625Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.057625Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.066657Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.066657Z"
     },
     "papermill": {
      "duration": 0.017983,
@@ -374,10 +381,10 @@
    "id": "7cb0699a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:41.099181Z",
-     "iopub.status.busy": "2026-06-15T03:33:41.098661Z",
-     "iopub.status.idle": "2026-06-15T03:33:41.108491Z",
-     "shell.execute_reply": "2026-06-15T03:33:41.107934Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.066657Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.066657Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.078544Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.078026Z"
     },
     "papermill": {
      "duration": 0.019191,
@@ -522,10 +529,10 @@
    "id": "8ccf7fe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:41.140647Z",
-     "iopub.status.busy": "2026-06-15T03:33:41.140647Z",
-     "iopub.status.idle": "2026-06-15T03:33:41.144520Z",
-     "shell.execute_reply": "2026-06-15T03:33:41.144520Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.080670Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.080154Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.085582Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.084494Z"
     },
     "papermill": {
      "duration": 0.01363,
@@ -617,10 +624,10 @@
    "id": "ea569e8c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:41.176423Z",
-     "iopub.status.busy": "2026-06-15T03:33:41.175416Z",
-     "iopub.status.idle": "2026-06-15T03:33:41.930963Z",
-     "shell.execute_reply": "2026-06-15T03:33:41.930427Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.087723Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.087723Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.745690Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.745690Z"
     },
     "papermill": {
      "duration": 0.763368,
@@ -636,8 +643,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "~\\AppData\\Local\\Temp\\ipykernel_<pid>\\3959998143.py:74: UserWarning: This figure includes Axes that are not compatible with tight_layout, so results might be incorrect.\n",
-      "  plt.tight_layout()\n"
+      "UserWarning: This figure includes Axes that are not compatible with tight_layout, so results might be incorrect.\n"
      ]
     },
     {
@@ -800,10 +806,10 @@
    "id": "64578801",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:41.984892Z",
-     "iopub.status.busy": "2026-06-15T03:33:41.983892Z",
-     "iopub.status.idle": "2026-06-15T03:33:41.994102Z",
-     "shell.execute_reply": "2026-06-15T03:33:41.994102Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.748155Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.747429Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.756443Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.755850Z"
     },
     "papermill": {
      "duration": 0.01921,
@@ -973,10 +979,10 @@
    "id": "80a83543",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:42.062008Z",
-     "iopub.status.busy": "2026-06-15T03:33:42.062008Z",
-     "iopub.status.idle": "2026-06-15T03:33:42.081959Z",
-     "shell.execute_reply": "2026-06-15T03:33:42.081959Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.757775Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.757775Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.776779Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.776369Z"
     },
     "papermill": {
      "duration": 0.03002,
@@ -1086,10 +1092,10 @@
    "id": "cbd0fc4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:42.118007Z",
-     "iopub.status.busy": "2026-06-15T03:33:42.118007Z",
-     "iopub.status.idle": "2026-06-15T03:33:42.139626Z",
-     "shell.execute_reply": "2026-06-15T03:33:42.139626Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.778796Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.778796Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.801311Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.801311Z"
     },
     "papermill": {
      "duration": 0.032623,
@@ -1113,14 +1119,14 @@
       "Iteration 3 : stable = True\n",
       "Methode             | Temps (ms) | Iterations | Erreur max | Couverture\n",
       "--------------------|------------|------------|------------|------------\n",
-      "Value Iteration     |       0.87 |         14 |     0.0000 |     100.0%\n",
-      "Policy Iteration    |       2.20 |          3 |     0.0004 |     100.0%\n",
-      "RTDP                |      10.30 |        100 |     0.6342 |      63.6%\n",
+      "Value Iteration     |       0.83 |         14 |     0.0000 |     100.0%\n",
+      "Policy Iteration    |       2.11 |          3 |     0.0004 |     100.0%\n",
+      "RTDP                |      11.11 |        100 |     0.6342 |      63.6%\n",
       "\n",
       "Details :\n",
-      "  VI  : 0.87 ms, 14 iterations, erreur = 0 (reference)\n",
-      "  PI  : 2.20 ms, 3 iterations, erreur = 0.0004\n",
-      "  RTDP: 10.30 ms, 100 trials, erreur max = 0.6342\n",
+      "  VI  : 0.83 ms, 14 iterations, erreur = 0 (reference)\n",
+      "  PI  : 2.11 ms, 3 iterations, erreur = 0.0004\n",
+      "  RTDP: 11.11 ms, 100 trials, erreur max = 0.6342\n",
       "        Couverture RTDP : 63.6% des etats avec erreur < 0.1\n"
      ]
     }
@@ -1272,10 +1278,10 @@
    "id": "a7a15f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:42.196758Z",
-     "iopub.status.busy": "2026-06-15T03:33:42.195758Z",
-     "iopub.status.idle": "2026-06-15T03:33:42.201607Z",
-     "shell.execute_reply": "2026-06-15T03:33:42.201607Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.803605Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.802605Z",
+     "iopub.status.idle": "2026-07-03T18:05:37.807700Z",
+     "shell.execute_reply": "2026-07-03T18:05:37.807700Z"
     },
     "papermill": {
      "duration": 0.015943,
@@ -1352,10 +1358,10 @@
    "id": "6df1e5af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:42.238554Z",
-     "iopub.status.busy": "2026-06-15T03:33:42.238554Z",
-     "iopub.status.idle": "2026-06-15T03:33:42.730333Z",
-     "shell.execute_reply": "2026-06-15T03:33:42.730333Z"
+     "iopub.execute_input": "2026-07-03T18:05:37.809708Z",
+     "iopub.status.busy": "2026-07-03T18:05:37.809708Z",
+     "iopub.status.idle": "2026-07-03T18:05:38.270658Z",
+     "shell.execute_reply": "2026-07-03T18:05:38.270658Z"
     },
     "papermill": {
      "duration": 0.507136,
@@ -1584,10 +1590,10 @@
    "id": "3e3693e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:42.794691Z",
-     "iopub.status.busy": "2026-06-15T03:33:42.794691Z",
-     "iopub.status.idle": "2026-06-15T03:33:42.824946Z",
-     "shell.execute_reply": "2026-06-15T03:33:42.824946Z"
+     "iopub.execute_input": "2026-07-03T18:05:38.270658Z",
+     "iopub.status.busy": "2026-07-03T18:05:38.270658Z",
+     "iopub.status.idle": "2026-07-03T18:05:38.301864Z",
+     "shell.execute_reply": "2026-07-03T18:05:38.301864Z"
     },
     "papermill": {
      "duration": 0.037867,
@@ -1737,10 +1743,10 @@
    "id": "a28fde4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:42.862648Z",
-     "iopub.status.busy": "2026-06-15T03:33:42.862648Z",
-     "iopub.status.idle": "2026-06-15T03:33:42.866797Z",
-     "shell.execute_reply": "2026-06-15T03:33:42.866797Z"
+     "iopub.execute_input": "2026-07-03T18:05:38.303481Z",
+     "iopub.status.busy": "2026-07-03T18:05:38.303481Z",
+     "iopub.status.idle": "2026-07-03T18:05:38.307353Z",
+     "shell.execute_reply": "2026-07-03T18:05:38.307353Z"
     },
     "papermill": {
      "duration": 0.015155,
@@ -1925,10 +1931,10 @@
    "id": "c212dea9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:42.958144Z",
-     "iopub.status.busy": "2026-06-15T03:33:42.958144Z",
-     "iopub.status.idle": "2026-06-15T03:33:42.967475Z",
-     "shell.execute_reply": "2026-06-15T03:33:42.967475Z"
+     "iopub.execute_input": "2026-07-03T18:05:38.309358Z",
+     "iopub.status.busy": "2026-07-03T18:05:38.309358Z",
+     "iopub.status.idle": "2026-07-03T18:05:38.318203Z",
+     "shell.execute_reply": "2026-07-03T18:05:38.318203Z"
     },
     "papermill": {
      "duration": 0.020767,
@@ -2108,10 +2114,10 @@
    "id": "1fd9449f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:43.025106Z",
-     "iopub.status.busy": "2026-06-15T03:33:43.025106Z",
-     "iopub.status.idle": "2026-06-15T03:33:43.030154Z",
-     "shell.execute_reply": "2026-06-15T03:33:43.030154Z"
+     "iopub.execute_input": "2026-07-03T18:05:38.318203Z",
+     "iopub.status.busy": "2026-07-03T18:05:38.318203Z",
+     "iopub.status.idle": "2026-07-03T18:05:38.324923Z",
+     "shell.execute_reply": "2026-07-03T18:05:38.324923Z"
     },
     "papermill": {
      "duration": 0.016541,
@@ -2251,10 +2257,10 @@
    "id": "286083d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:43.088824Z",
-     "iopub.status.busy": "2026-06-15T03:33:43.087520Z",
-     "iopub.status.idle": "2026-06-15T03:33:43.096328Z",
-     "shell.execute_reply": "2026-06-15T03:33:43.095824Z"
+     "iopub.execute_input": "2026-07-03T18:05:38.326828Z",
+     "iopub.status.busy": "2026-07-03T18:05:38.326828Z",
+     "iopub.status.idle": "2026-07-03T18:05:38.333538Z",
+     "shell.execute_reply": "2026-07-03T18:05:38.333538Z"
     },
     "papermill": {
      "duration": 0.019293,
@@ -2475,10 +2481,10 @@
    "id": "c9fc0f60",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:43.153108Z",
-     "iopub.status.busy": "2026-06-15T03:33:43.153108Z",
-     "iopub.status.idle": "2026-06-15T03:33:45.852245Z",
-     "shell.execute_reply": "2026-06-15T03:33:45.852245Z"
+     "iopub.execute_input": "2026-07-03T18:05:38.335552Z",
+     "iopub.status.busy": "2026-07-03T18:05:38.335552Z",
+     "iopub.status.idle": "2026-07-03T18:05:40.594566Z",
+     "shell.execute_reply": "2026-07-03T18:05:40.594191Z"
     },
     "papermill": {
      "duration": 2.710154,
@@ -2515,10 +2521,10 @@
    "id": "50f02e39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:45.871458Z",
-     "iopub.status.busy": "2026-06-15T03:33:45.871458Z",
-     "iopub.status.idle": "2026-06-15T03:33:45.946315Z",
-     "shell.execute_reply": "2026-06-15T03:33:45.946315Z"
+     "iopub.execute_input": "2026-07-03T18:05:40.596087Z",
+     "iopub.status.busy": "2026-07-03T18:05:40.596087Z",
+     "iopub.status.idle": "2026-07-03T18:05:40.692899Z",
+     "shell.execute_reply": "2026-07-03T18:05:40.692899Z"
     },
     "papermill": {
      "duration": 0.08585,
@@ -2655,10 +2661,10 @@
    "id": "9a7b6a29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:45.965700Z",
-     "iopub.status.busy": "2026-06-15T03:33:45.965700Z",
-     "iopub.status.idle": "2026-06-15T03:33:46.354799Z",
-     "shell.execute_reply": "2026-06-15T03:33:46.354799Z"
+     "iopub.execute_input": "2026-07-03T18:05:40.692899Z",
+     "iopub.status.busy": "2026-07-03T18:05:40.692899Z",
+     "iopub.status.idle": "2026-07-03T18:05:41.095723Z",
+     "shell.execute_reply": "2026-07-03T18:05:41.095723Z"
     },
     "papermill": {
      "duration": 0.400484,
@@ -2787,10 +2793,10 @@
    "id": "df1a0888",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:33:46.410395Z",
-     "iopub.status.busy": "2026-06-15T03:33:46.410395Z",
-     "iopub.status.idle": "2026-06-15T03:37:19.821313Z",
-     "shell.execute_reply": "2026-06-15T03:37:19.821313Z"
+     "iopub.execute_input": "2026-07-03T18:05:41.096734Z",
+     "iopub.status.busy": "2026-07-03T18:05:41.096734Z",
+     "iopub.status.idle": "2026-07-03T18:08:56.373045Z",
+     "shell.execute_reply": "2026-07-03T18:08:56.373045Z"
     },
     "papermill": {
      "duration": 213.415695,
@@ -2838,7 +2844,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -2887,7 +2893,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 11 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -2936,7 +2942,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -2985,7 +2991,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3041,7 +3047,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3090,7 +3096,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3132,56 +3138,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Multiprocess sampling (2 chains in 2 jobs)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "NUTS: [mu, sigma]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3230,7 +3187,56 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 11 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (2 chains in 2 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [mu, sigma]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3286,7 +3292,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3335,7 +3341,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 11 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3384,7 +3390,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3433,7 +3439,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3587,7 +3593,105 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (2 chains in 2 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [mu, sigma]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (2 chains in 2 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [mu, sigma]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 9 seconds.\n"
      ]
     },
     {
@@ -3637,104 +3741,6 @@
      "output_type": "stream",
      "text": [
       "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 10 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Multiprocess sampling (2 chains in 2 jobs)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "NUTS: [mu, sigma]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 11 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Multiprocess sampling (2 chains in 2 jobs)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "NUTS: [mu, sigma]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Sampling 2 chains for 50 tune and 100 draw iterations (100 + 200 draws total) took 11 seconds.\n"
      ]
     },
     {
@@ -3911,10 +3917,10 @@
    "id": "f036c793",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:37:19.922536Z",
-     "iopub.status.busy": "2026-06-15T03:37:19.922536Z",
-     "iopub.status.idle": "2026-06-15T03:37:37.757706Z",
-     "shell.execute_reply": "2026-06-15T03:37:37.757706Z"
+     "iopub.execute_input": "2026-07-03T18:08:56.373045Z",
+     "iopub.status.busy": "2026-07-03T18:08:56.373045Z",
+     "iopub.status.idle": "2026-07-03T18:09:11.401729Z",
+     "shell.execute_reply": "2026-07-03T18:09:11.401729Z"
     },
     "papermill": {
      "duration": 17.856273,
@@ -3927,15 +3933,6 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Modele PyMC : Maintenance Predictive ===\n",
-      "\n",
-      "Observations capteur : ['Normal', 'Normal', 'Anormal', 'Anormal', 'Anormal']\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
@@ -3943,14 +3940,12 @@
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\pytensor\\link\\c\\cmodule.py:2986: UserWarning: PyTensor could not link to a BLAS installation. Operations that might benefit from BLAS will be severely degraded.\n",
-      "This usually happens when PyTensor is installed via pip. We recommend it be installed via conda/mamba/pixi instead.\n",
-      "Alternatively, you can use an experimental backend such as Numba or JAX that perform their own BLAS optimizations, by setting `pytensor.config.mode == 'NUMBA'` or passing `mode='NUMBA'` when compiling a PyTensor function.\n",
-      "For more options and details see https://pytensor.readthedocs.io/en/latest/troubleshooting.html#how-do-i-configure-test-my-blas-library\n",
-      "  warnings.warn(\n"
+      "=== Modele PyMC : Maintenance Predictive ===\n",
+      "\n",
+      "Observations capteur : ['Normal', 'Normal', 'Anormal', 'Anormal', 'Anormal']\n"
      ]
     },
     {
@@ -3969,16 +3964,13 @@
     },
     {
      "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n",
-       "</pre>\n"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f706f0b01f104c3fae64bad9d91778e3",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\rich\\live.py:260: UserWarning: install \n",
-       "\"ipywidgets\" for Jupyter support\n",
-       "  warnings.warn('install \"ipywidgets\" for Jupyter support')\n"
+       "Output()"
       ]
      },
      "metadata": {},
@@ -3998,7 +3990,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 3 chains for 500 tune and 1_000 draw iterations (1_500 + 3_000 draws total) took 16 seconds.\n"
+      "Sampling 3 chains for 500 tune and 1_000 draw iterations (1_500 + 3_000 draws total) took 14 seconds.\n"
      ]
     },
     {
@@ -4092,10 +4084,10 @@
    "id": "b066d437",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:37:37.792440Z",
-     "iopub.status.busy": "2026-06-15T03:37:37.792440Z",
-     "iopub.status.idle": "2026-06-15T03:37:38.190765Z",
-     "shell.execute_reply": "2026-06-15T03:37:38.190765Z"
+     "iopub.execute_input": "2026-07-03T18:09:11.448581Z",
+     "iopub.status.busy": "2026-07-03T18:09:11.448581Z",
+     "iopub.status.idle": "2026-07-03T18:09:11.824331Z",
+     "shell.execute_reply": "2026-07-03T18:09:11.824331Z"
     },
     "papermill": {
      "duration": 0.416267,
@@ -4258,10 +4250,10 @@
    "id": "2cee5686",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:37:38.296150Z",
-     "iopub.status.busy": "2026-06-15T03:37:38.295151Z",
-     "iopub.status.idle": "2026-06-15T03:37:38.571233Z",
-     "shell.execute_reply": "2026-06-15T03:37:38.571233Z"
+     "iopub.execute_input": "2026-07-03T18:09:11.826258Z",
+     "iopub.status.busy": "2026-07-03T18:09:11.826258Z",
+     "iopub.status.idle": "2026-07-03T18:09:12.105122Z",
+     "shell.execute_reply": "2026-07-03T18:09:12.104243Z"
     },
     "papermill": {
      "duration": 0.297654,
@@ -4506,10 +4498,10 @@
    "id": "a5d93196",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T03:37:38.733213Z",
-     "iopub.status.busy": "2026-06-15T03:37:38.733213Z",
-     "iopub.status.idle": "2026-06-15T03:37:38.738716Z",
-     "shell.execute_reply": "2026-06-15T03:37:38.738716Z"
+     "iopub.execute_input": "2026-07-03T18:09:12.107154Z",
+     "iopub.status.busy": "2026-07-03T18:09:12.107154Z",
+     "iopub.status.idle": "2026-07-03T18:09:12.110992Z",
+     "shell.execute_reply": "2026-07-03T18:09:12.110992Z"
     },
     "papermill": {
      "duration": 0.025409,
@@ -4619,6 +4611,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "conclusion-pymc20-2651",
    "metadata": {},
    "source": [
     "## Conclusion : de l'incertitude modélisée à la décision séquentielle\n",
@@ -4634,8 +4627,7 @@
     "**Vers l'apprentissage par renforcement.** Ce notebook suppose $P(s'|s,a)$ et $R(s,a)$ *connus*. Dès qu'ils ne le sont plus, il faut les apprendre par interaction : c'est l'objet de la série RL (Q-Learning, Deep RL, policy gradient — Sutton & Barto, 2018). DecPyMC-7 en fournit les fondations théoriques.\n",
     "\n",
     "**Arc de la série.** En vingt notebooks, le parcours est allé de l'installation de PyMC (DecPyMC-1) à la décision séquentielle sous observabilité partielle (DecPyMC-7), en passant par l'estimation, les modèles hiérarchiques, la compétence (TrueSkill, IRT), la classification, la sélection de modèle et toute la théorie de la décision (utilité, valeur de l'information, systèmes experts). Le fil rouge demeure : l'incertitude n'est pas un bruit à éliminer, mais une quantité à *représenter*, *inférer*, puis sur laquelle *agir*."
-   ],
-   "id": "conclusion-pymc20-2651"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -4704,7 +4696,7 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "8815766ad17d49a9abd8e53fe6031051": {
+     "71722a6ad81b4ddea1fe4e4169d76d98": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -4757,7 +4749,7 @@
        "width": null
       }
      },
-     "f344aa955bf5429b8a4c065b5d956cdc": {
+     "f706f0b01f104c3fae64bad9d91778e3": {
       "model_module": "@jupyter-widgets/output",
       "model_module_version": "1.0.0",
       "model_name": "OutputModel",
@@ -4770,13 +4762,13 @@
        "_view_module": "@jupyter-widgets/output",
        "_view_module_version": "1.0.0",
        "_view_name": "OutputView",
-       "layout": "IPY_MODEL_8815766ad17d49a9abd8e53fe6031051",
+       "layout": "IPY_MODEL_71722a6ad81b4ddea1fe4e4169d76d98",
        "msg_id": "",
        "outputs": [
         {
          "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   1500        0           1.119       3           1081.20 draws/s      0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   1500        0           1.128       3           764.84 draws/s       0:00:01    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   1500        0           0.742       7           936.78 draws/s       0:00:01    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   1500        0           1.119       3           1081.20 draws/s      0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   1500        0           1.128       3           764.84 draws/s       0:00:01    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   1500        0           0.742       7           936.78 draws/s       0:00:01    0:00:00   \n                                                                                                                   \n"
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   1500   0             1.119       3            2822.98 draws/s   0:00:00   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   1500   0             0.913       1            1199.20 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   1500   0             0.742       7            607.13 draws/s    0:00:02   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   1500   0             1.119       3            2822.98 draws/s   0:00:00   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   1500   0             0.913       1            1199.20 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   1500   0             0.742       7            607.13 draws/s    0:00:02   0:00:00    \n                                                                                                                   \n"
          },
          "metadata": {},
          "output_type": "display_data"


### PR DESCRIPTION
## What

`DecPyMC-7-Sequential.ipynb` (DecisionTheory/PyMC series, Probas family) leaked 2 absolute paths from the PyMC stack during `pm.sample`:
- pytensor `could not link BLAS` (`cmodule.py:2986`)
- rich `live.py:260` `install ipywidgets`

## Cause (#3436 cause-B+C)

Same root cause as the PyMC family: library warnings print the absolute source-file path of the emitter.

## Fix (recipe identical to PyMC-8 #5238)

`filterwarnings` block prepended to first code cell (cell 2), before `import pymc`:
```python
import warnings
warnings.filterwarnings("ignore", category=FutureWarning, module="arviz")
warnings.filterwarnings("ignore", message=".*could not link.*", category=UserWarning)
warnings.filterwarnings("ignore", message=".*install ipywidgets.*", category=UserWarning)
def _warn_no_path(message, category, filename, lineno, file=None, line=None):
    return f"{category.__name__}: {message}\n"
warnings.formatwarning = _warn_no_path
```
`ipywidgets 8.1.8` already installed in `coursia-ml-training` (from the PyMC cycle) — rich renders the real widget. The custom `formatwarning` strips the absolute path prefix while keeping useful diagnostics (R-hat/ESS convergence) visible.

Re-exec: `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=coursia-ml-training` — EXIT=0, 722431 bytes.

## Validation (firsthand)

- **Leaks**: 0 (was 2)
- **execution_count**: 23 code cells, all executed (None=0)
- **errors**: 0
- **C.1** banned: 0
- **kernelspec**: python3
- **Line endings**: LF (0 CRLF)
- **C.3 source diff**: 1 cell changed (7-line filterwarnings block prepended), no structural churn

See #3436.

Co-Authored-By: Claude-Code <noreply@anthropic.com>