### PR TITLE
fix(symbolic-ai): strip path from EML-NAND-Compose log RuntimeWarning (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Neurosymbolic-EML/EML-NAND-Compose.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Neurosymbolic-EML/EML-NAND-Compose.ipynb
@@ -29,7 +29,14 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "285e1983",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T18:14:07.546610Z",
+     "iopub.status.busy": "2026-07-03T18:14:07.546610Z",
+     "iopub.status.idle": "2026-07-03T18:14:10.408925Z",
+     "shell.execute_reply": "2026-07-03T18:14:10.408925Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -41,6 +48,10 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "def _warn_no_path(message, category, filename, lineno, file=None, line=None):\n",
+    "    return f\"{category.__name__}: {message}\\n\"\n",
+    "warnings.formatwarning = _warn_no_path\n",
     "import numpy as np\n",
     "import torch\n",
     "import torch.nn as nn\n",
@@ -78,7 +89,14 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "d0bddc74",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T18:14:10.408925Z",
+     "iopub.status.busy": "2026-07-03T18:14:10.408925Z",
+     "iopub.status.idle": "2026-07-03T18:14:10.414776Z",
+     "shell.execute_reply": "2026-07-03T18:14:10.414776Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -102,7 +120,14 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "981825ec",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T18:14:10.414776Z",
+     "iopub.status.busy": "2026-07-03T18:14:10.414776Z",
+     "iopub.status.idle": "2026-07-03T18:14:10.422820Z",
+     "shell.execute_reply": "2026-07-03T18:14:10.422820Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -177,7 +202,14 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "b44cafdf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T18:14:10.422820Z",
+     "iopub.status.busy": "2026-07-03T18:14:10.422820Z",
+     "iopub.status.idle": "2026-07-03T18:14:10.506253Z",
+     "shell.execute_reply": "2026-07-03T18:14:10.504930Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -242,7 +274,14 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "b7e25783",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T18:14:10.506253Z",
+     "iopub.status.busy": "2026-07-03T18:14:10.506253Z",
+     "iopub.status.idle": "2026-07-03T18:14:10.935610Z",
+     "shell.execute_reply": "2026-07-03T18:14:10.935610Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -253,29 +292,34 @@
      ]
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  B trial 2: seq=[np.str_('log'), np.str_('mul'), np.str_('add'), np.str_('add'), np.str_('log'), np.str_('log'), np.str_('div')], loss=0.2142, acc=0.625\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_43740\\725938985.py:30: RuntimeWarning: invalid value encountered in log\n",
-      "  return a * np.log(np.abs(b*y) + c + EPS)\n"
+      "RuntimeWarning: invalid value encountered in log\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  B trial 2: seq=[np.str_('log'), np.str_('mul'), np.str_('add'), np.str_('add'), np.str_('log'), np.str_('log'), np.str_('div')], loss=0.2142, acc=0.625\n",
       "  B trial 3: seq=[np.str_('tanh'), np.str_('div'), np.str_('sub'), np.str_('log'), np.str_('add'), np.str_('add'), np.str_('tanh')], loss=nan, acc=0.500\n",
       "  B trial 4: seq=[np.str_('mul'), np.str_('exp'), np.str_('log'), np.str_('exp'), np.str_('exp'), np.str_('exp'), np.str_('sub')], loss=0.2500, acc=0.500\n",
-      "  B trial 5: seq=[np.str_('add'), np.str_('tanh'), np.str_('div'), np.str_('sub'), np.str_('exp'), np.str_('add'), np.str_('sub')], loss=0.2500, acc=0.500\n"
+      "  B trial 5: seq=[np.str_('add'), np.str_('tanh'), np.str_('div'), np.str_('sub'), np.str_('exp'), np.str_('add'), np.str_('sub')], loss=0.2500, acc=0.500\n",
+      "  B trial 6: seq=[np.str_('tanh'), np.str_('exp'), np.str_('div'), np.str_('sub'), np.str_('div'), np.str_('mul'), np.str_('log')], loss=0.2500, acc=0.500\n",
+      "  B trial 7: seq=[np.str_('add'), np.str_('add'), np.str_('mul'), np.str_('mul'), np.str_('add'), np.str_('add'), np.str_('log')], loss=nan, acc=0.500\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  B trial 6: seq=[np.str_('tanh'), np.str_('exp'), np.str_('div'), np.str_('sub'), np.str_('div'), np.str_('mul'), np.str_('log')], loss=0.2500, acc=0.500\n",
-      "  B trial 7: seq=[np.str_('add'), np.str_('add'), np.str_('mul'), np.str_('mul'), np.str_('add'), np.str_('add'), np.str_('log')], loss=nan, acc=0.500\n",
       "  B trial 8: seq=[np.str_('exp'), np.str_('tanh'), np.str_('log'), np.str_('log'), np.str_('tanh'), np.str_('exp'), np.str_('exp')], loss=0.2500, acc=0.500\n",
       "  B trial 9: seq=[np.str_('add'), np.str_('sub'), np.str_('mul'), np.str_('log'), np.str_('tanh'), np.str_('exp'), np.str_('sub')], loss=0.2500, acc=0.500\n",
       "\n",
@@ -343,41 +387,29 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "c53d28bc",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T18:14:10.935610Z",
+     "iopub.status.busy": "2026-07-03T18:14:10.935610Z",
+     "iopub.status.idle": "2026-07-03T18:14:12.920610Z",
+     "shell.execute_reply": "2026-07-03T18:14:12.920610Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_43740\\725938985.py:30: RuntimeWarning: invalid value encountered in log\n",
-      "  return a * np.log(np.abs(b*y) + c + EPS)\n"
+      "RuntimeWarning: invalid value encountered in log\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  C trial 0: acc=0.500\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  C trial 1: acc=0.500\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  C trial 2: acc=0.500\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  C trial 0: acc=0.500\n",
+      "  C trial 1: acc=0.500\n",
+      "  C trial 2: acc=0.500\n",
       "  C trial 3: acc=0.500\n"
      ]
     },
@@ -385,20 +417,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  C trial 4: acc=0.500\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  C trial 5: acc=0.500\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  C trial 4: acc=0.500\n",
+      "  C trial 5: acc=0.500\n",
       "  C trial 6: acc=0.500\n"
      ]
     },
@@ -407,13 +427,7 @@
      "output_type": "stream",
      "text": [
       "  C trial 7: acc=0.500\n",
-      "  C trial 8: acc=0.500\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  C trial 8: acc=0.500\n",
       "  C trial 9: acc=0.500\n",
       "\n",
       "Meilleur Architecture C : acc=0.500\n"
@@ -501,7 +515,14 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "5e5e08e5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T18:14:12.920610Z",
+     "iopub.status.busy": "2026-07-03T18:14:12.920610Z",
+     "iopub.status.idle": "2026-07-03T18:14:12.927425Z",
+     "shell.execute_reply": "2026-07-03T18:14:12.927425Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -588,10 +609,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.13"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What

`EML-NAND-Compose.ipynb` (Neurosymbolic-EML series, SymbolicAI family) leaked 2 absolute ipykernel temp paths via a numpy `RuntimeWarning: invalid value encountered in log` emitted during the B_loss primitive-search optimization (cells 8 and 10).

## Cause (#3436 cause-C: diagnostic warning)

numpy emits the warning with the absolute source-file path of the emitter (`C:\Users\...\ipykernel_<pid>\<n>.py:30`).

## Fix — formatwarning strip-path (NOT filterwarnings)

The warning is a **useful numerical diagnostic** (log of invalid values during optimization over random primitive sequences) — suppressing it would hide a real signal (SOTA: hiding = regression). Per the cause-C diagnostic recipe (cf PyMC-8 #5238), a custom `formatwarning` strips the absolute path prefix while keeping the message visible:

```python
import warnings
def _warn_no_path(message, category, filename, lineno, file=None, line=None):
    return f"{category.__name__}: {message}\n"
warnings.formatwarning = _warn_no_path
```

Injected at first code cell (cell 1), before numpy/torch imports.

**Verified firsthand**: `RuntimeWarning: invalid value encountered in log` is STILL present in cell 8 + cell 10 outputs post-re-exec (diagnostic preserved), 0 path leak.

Re-exec: `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=coursia-ml-training` — EXIT=0, 28984 bytes (CPU torch optimization, bounded).

## Validation (firsthand)

- **Leaks**: 0 (was 2)
- **execution_count**: [1, 2, 3, 4, 5, 6, 7] coherent
- **errors**: 0
- **C.1** banned: 0
- **kernelspec**: python3
- **Line endings**: LF (0 CRLF)
- **C.3 source diff**: 1 cell changed (4-line formatwarning block prepended), no structural churn
- Diagnostic `RuntimeWarning: invalid value encountered in log` preserved (no path)

See #3436.

Co-Authored-By: Claude-Code <noreply@anthropic.com>