### PR TITLE
fix(ml): strip path from 2.5-Biais-Variance ConvergenceWarning (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -47,10 +47,10 @@
    "id": "a50c0002",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:22.182879Z",
-     "iopub.status.busy": "2026-06-25T11:44:22.181874Z",
-     "iopub.status.idle": "2026-06-25T11:44:25.634277Z",
-     "shell.execute_reply": "2026-06-25T11:44:25.627499Z"
+     "iopub.execute_input": "2026-07-03T18:23:09.158940Z",
+     "iopub.status.busy": "2026-07-03T18:23:09.158940Z",
+     "iopub.status.idle": "2026-07-03T18:23:11.022933Z",
+     "shell.execute_reply": "2026-07-03T18:23:11.022306Z"
     },
     "papermill": {
      "duration": 3.479595,
@@ -71,6 +71,10 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "def _warn_no_path(message, category, filename, lineno, file=None, line=None):\n",
+    "    return f\"{category.__name__}: {message}\\n\"\n",
+    "warnings.formatwarning = _warn_no_path\n",
     "# Configuration et imports pour le notebook 2.5\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -84,7 +88,7 @@
     "from sklearn.metrics import accuracy_score, roc_curve, roc_auc_score, confusion_matrix\n",
     "\n",
     "np.random.seed(42)\n",
-    "print(\"Configuration OK : 2.5 - Biais, variance, validation croisee et ROC\")"
+    "print(\"Configuration OK : 2.5 - Biais, variance, validation croisee et ROC\")\n"
    ]
   },
   {
@@ -119,10 +123,10 @@
    "id": "a50c0004",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:25.695929Z",
-     "iopub.status.busy": "2026-06-25T11:44:25.694886Z",
-     "iopub.status.idle": "2026-06-25T11:44:25.722530Z",
-     "shell.execute_reply": "2026-06-25T11:44:25.721867Z"
+     "iopub.execute_input": "2026-07-03T18:23:11.024543Z",
+     "iopub.status.busy": "2026-07-03T18:23:11.024543Z",
+     "iopub.status.idle": "2026-07-03T18:23:11.040330Z",
+     "shell.execute_reply": "2026-07-03T18:23:11.040330Z"
     },
     "papermill": {
      "duration": 0.03924,
@@ -191,10 +195,10 @@
    "id": "a50c0006",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:25.744766Z",
-     "iopub.status.busy": "2026-06-25T11:44:25.744766Z",
-     "iopub.status.idle": "2026-06-25T11:44:26.847649Z",
-     "shell.execute_reply": "2026-06-25T11:44:26.846517Z"
+     "iopub.execute_input": "2026-07-03T18:23:11.042613Z",
+     "iopub.status.busy": "2026-07-03T18:23:11.041614Z",
+     "iopub.status.idle": "2026-07-03T18:23:11.304737Z",
+     "shell.execute_reply": "2026-07-03T18:23:11.304737Z"
     },
     "papermill": {
      "duration": 1.110889,
@@ -211,28 +215,7 @@
      "output_type": "stream",
      "text": [
       "Modele                 |   train |    test |   ecart\n",
-      "-------------------------------------------------------\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
-      "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
-      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-      "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "-------------------------------------------------------\n",
       "Regression logistique  |   0.967 |   0.942 |   0.026\n"
      ]
     },
@@ -242,6 +225,20 @@
      "text": [
       "Foret aleatoire        |   1.000 |   0.936 |   0.064\n",
       "Arbre profond          |   1.000 |   0.918 |   0.082\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     }
    ],
@@ -294,10 +291,10 @@
    "id": "a50c0008",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:26.869630Z",
-     "iopub.status.busy": "2026-06-25T11:44:26.868593Z",
-     "iopub.status.idle": "2026-06-25T11:44:26.875055Z",
-     "shell.execute_reply": "2026-06-25T11:44:26.873638Z"
+     "iopub.execute_input": "2026-07-03T18:23:11.306743Z",
+     "iopub.status.busy": "2026-07-03T18:23:11.306743Z",
+     "iopub.status.idle": "2026-07-03T18:23:11.309843Z",
+     "shell.execute_reply": "2026-07-03T18:23:11.309843Z"
     },
     "papermill": {
      "duration": 0.011421,
@@ -356,10 +353,10 @@
    "id": "a50c000a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:26.897806Z",
-     "iopub.status.busy": "2026-06-25T11:44:26.896797Z",
-     "iopub.status.idle": "2026-06-25T11:44:28.569887Z",
-     "shell.execute_reply": "2026-06-25T11:44:28.568741Z"
+     "iopub.execute_input": "2026-07-03T18:23:11.309843Z",
+     "iopub.status.busy": "2026-07-03T18:23:11.309843Z",
+     "iopub.status.idle": "2026-07-03T18:23:11.951683Z",
+     "shell.execute_reply": "2026-07-03T18:23:11.951683Z"
     },
     "papermill": {
      "duration": 1.680078,
@@ -375,7 +372,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
@@ -383,14 +380,21 @@
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
@@ -398,37 +402,14 @@
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
       "You might also want to scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
-      "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
-      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-      "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
@@ -444,15 +425,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
       "You might also want to scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     }
    ],
@@ -490,10 +470,10 @@
    "id": "a50c000c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:28.594225Z",
-     "iopub.status.busy": "2026-06-25T11:44:28.593116Z",
-     "iopub.status.idle": "2026-06-25T11:44:31.559657Z",
-     "shell.execute_reply": "2026-06-25T11:44:31.559041Z"
+     "iopub.execute_input": "2026-07-03T18:23:11.951683Z",
+     "iopub.status.busy": "2026-07-03T18:23:11.951683Z",
+     "iopub.status.idle": "2026-07-03T18:23:13.315397Z",
+     "shell.execute_reply": "2026-07-03T18:23:13.315397Z"
     },
     "papermill": {
      "duration": 2.973963,
@@ -506,6 +486,20 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -517,75 +511,56 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
       "You might also want to scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
       "You might also want to scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
       "You might also want to scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
       "You might also want to scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
-      "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
-      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-      "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
@@ -643,10 +618,10 @@
    "id": "a50c000e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:31.592419Z",
-     "iopub.status.busy": "2026-06-25T11:44:31.591325Z",
-     "iopub.status.idle": "2026-06-25T11:44:31.597782Z",
-     "shell.execute_reply": "2026-06-25T11:44:31.596769Z"
+     "iopub.execute_input": "2026-07-03T18:23:13.317403Z",
+     "iopub.status.busy": "2026-07-03T18:23:13.317403Z",
+     "iopub.status.idle": "2026-07-03T18:23:13.320441Z",
+     "shell.execute_reply": "2026-07-03T18:23:13.320441Z"
     },
     "papermill": {
      "duration": 0.017455,
@@ -700,10 +675,10 @@
    "id": "a50c0010",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:31.628190Z",
-     "iopub.status.busy": "2026-06-25T11:44:31.628190Z",
-     "iopub.status.idle": "2026-06-25T11:44:32.274603Z",
-     "shell.execute_reply": "2026-06-25T11:44:32.273968Z"
+     "iopub.execute_input": "2026-07-03T18:23:13.322597Z",
+     "iopub.status.busy": "2026-07-03T18:23:13.321597Z",
+     "iopub.status.idle": "2026-07-03T18:23:13.551867Z",
+     "shell.execute_reply": "2026-07-03T18:23:13.551867Z"
     },
     "papermill": {
      "duration": 0.65754,
@@ -719,15 +694,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
       "You might also want to scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
@@ -794,10 +768,10 @@
    "id": "a50c0012",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:32.310810Z",
-     "iopub.status.busy": "2026-06-25T11:44:32.310810Z",
-     "iopub.status.idle": "2026-06-25T11:44:32.316892Z",
-     "shell.execute_reply": "2026-06-25T11:44:32.315836Z"
+     "iopub.execute_input": "2026-07-03T18:23:13.553872Z",
+     "iopub.status.busy": "2026-07-03T18:23:13.553872Z",
+     "iopub.status.idle": "2026-07-03T18:23:13.556325Z",
+     "shell.execute_reply": "2026-07-03T18:23:13.556325Z"
     },
     "papermill": {
      "duration": 0.017292,
@@ -850,10 +824,10 @@
    "id": "a50c0014",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:32.353509Z",
-     "iopub.status.busy": "2026-06-25T11:44:32.352514Z",
-     "iopub.status.idle": "2026-06-25T11:44:32.365902Z",
-     "shell.execute_reply": "2026-06-25T11:44:32.364875Z"
+     "iopub.execute_input": "2026-07-03T18:23:13.558340Z",
+     "iopub.status.busy": "2026-07-03T18:23:13.558340Z",
+     "iopub.status.idle": "2026-07-03T18:23:13.568180Z",
+     "shell.execute_reply": "2026-07-03T18:23:13.568180Z"
     },
     "papermill": {
      "duration": 0.023502,
@@ -929,10 +903,10 @@
    "id": "a50c0016",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-25T11:44:32.404469Z",
-     "iopub.status.busy": "2026-06-25T11:44:32.403462Z",
-     "iopub.status.idle": "2026-06-25T11:44:35.749365Z",
-     "shell.execute_reply": "2026-06-25T11:44:35.748314Z"
+     "iopub.execute_input": "2026-07-03T18:23:13.570315Z",
+     "iopub.status.busy": "2026-07-03T18:23:13.570315Z",
+     "iopub.status.idle": "2026-07-03T18:23:14.937092Z",
+     "shell.execute_reply": "2026-07-03T18:23:14.937092Z"
     },
     "papermill": {
      "duration": 3.357242,
@@ -948,7 +922,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
@@ -956,14 +930,21 @@
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
@@ -971,52 +952,28 @@
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "\n",
+      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
+      "You might also want to scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
+      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
       "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
       "\n",
       "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
       "You might also want to scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
-      "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
-      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-      "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
-      "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
-      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-      "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n"
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
      ]
     },
     {


### PR DESCRIPTION
## What

`2.5-Biais-Variance-CV-ROC.ipynb` (ML / 02-ML-Cours series) leaked 17 absolute paths via sklearn `ConvergenceWarning` from logistic regression (`_logistic.py`) during cross-validation (cells 5 and 9).

## Cause (#3436 cause-C: diagnostic warning)

sklearn emits the warning with the absolute source-file path of the emitter (`C:\ProgramData\miniconda3\envs\coursia-ml-training\Lib\site-packages\sklearn\linear_model\_logistic.py:NN`).

## Fix — formatwarning strip-path (NOT filterwarnings)

In a **bias-variance notebook**, the non-convergence of logistic regression **IS pedagogically relevant** (it illustrates model capacity, regularization, and the bias-variance tradeoff). Suppressing it with `filterwarnings("ignore")` would hide a real signal — SOTA: hiding a useful diagnostic = regression.

Per the cause-C diagnostic recipe (cf PyMC-8 #5238, EML-NAND #5248), a custom `formatwarning` strips the absolute path prefix while keeping the message visible:

```python
import warnings
def _warn_no_path(message, category, filename, lineno, file=None, line=None):
    return f"{category.__name__}: {message}\n"
warnings.formatwarning = _warn_no_path
```

Injected at first code cell (cell 1), before sklearn imports.

**Verified firsthand**: all **17 ConvergenceWarning messages are STILL present** post-re-exec (diagnostic fully preserved), 0 path leak.

Re-exec: `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=coursia-ml-training` — EXIT=0, 125726 bytes (pure sklearn CPU, no torch/cuda).

## Validation (firsthand)

- **Leaks**: 0 (was 17)
- **execution_count**: [1..11] coherent
- **errors**: 0
- **C.1** banned: 0
- **ConvergenceWarning diagnostic kept**: 17 (all preserved, path stripped)
- **kernelspec**: python3
- **Line endings**: LF (0 CRLF)
- **C.3 source diff**: 1 cell changed (4-line formatwarning block prepended), no structural churn

See #3436.

Co-Authored-By: Claude-Code <noreply@anthropic.com>