### PR TITLE
docs(kernels): document #5211 async-ignores-kernel_name + canonical nbconvert CLI path

### DIFF
--- a/docs/reference/kernels-runtime.md
+++ b/docs/reference/kernels-runtime.md
@@ -147,6 +147,21 @@ timeout 600 /c/Users/jsboi/.conda/envs/mcp-jupyter-py310/python.exe -m papermill
 
 Un worker **oisif une demi-journée** parce que « le MCP hang » = **échec coordinateur** (coordinator-discipline Règle 4/5 : une lane ne s'arrête jamais), jamais un état worker acceptable.
 
+#### MCP execute_notebook async ignore kernel_name (bug #5211) : nbconvert CLI explicite = chemin canonique
+
+**Le MCP `execute_notebook` mode async IGNORE le paramètre `kernel_name`** et utilise le kernelspec stocké dans le notebook (typiquement `python3` = `WindowsApps\Python313`, qui n'a **pas pymc/pyphi/dowhy**) → `NameError` silencieux car la cellule d'import avale l'`ImportError`. Le mode sync honore `kernel_name` mais bloque ~10 min (risque crash session). Les deux modes MCP sont donc **inutilisables** pour forcer un kernel env-spécifique.
+
+**Décision ai-01 (msg-g5awy3, 2026-07-03) — chemin canonique de re-exec kernel-spécifique** : `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=<k>` en background (`run_in_background:true`), **JAMAIS le MCP** pour les notebooks nécessitant un env précis (coursia-ml-training, pyphi, lean4-wsl, .net-csharp). Validé firsthand sur 10 notebooks #3436 ce cycle (PyMC/IIT/Probas/GenAI/ML, 0 NameError).
+
+```bash
+# Kernel env-spécifique (force le kernel, indépendant du kernelspec stocké) :
+jupyter nbconvert --execute --to notebook --inplace \
+  --ExecutePreprocessor.kernel_name=coursia-ml-training \
+  --ExecutePreprocessor.timeout=900 <nb>.ipynb
+```
+
+**Gotcha subprocess CLI (découvert PT_07 #5245, 2026-07-03)** : si le notebook appelle un **CLI empaqueté dans l'env** via `subprocess.run(["<cli>", ...])` (ex `rewardspy`, `dot`, `lean`), le bare `jupyter nbconvert` hérite d'un PATH **sans** le `Scripts\` de l'env → `FileNotFoundError [WinError 2]`. Fix = wrapper avec **`conda run -n <env> jupyter nbconvert ...`** (active l'env = PATH complet avec `Scripts\`). Sans ça, la cellule subprocess fail même si le notebook tournait en interactif Jupyter.
+
 #### SmartContracts (8/14 groups, maj 2026-05-23)
 
 Packages installes dans mcp-jupyter-py310 : web3, py-solc-x, pycryptodome, py_ecc, phe, tenseal, mpyc, xrpl-py, python-bitcoinlib, vyper, tabulate.


### PR DESCRIPTION
## What

Documents two firsthand lessons from the #3436 de-leak cycle in `docs/reference/kernels-runtime.md`, as a new subsection right after the existing #835 MCP-hang section.

## 1. Bug #5211 — async ignores kernel_name

The MCP `execute_notebook` mode **async** ignores the `kernel_name` parameter and uses the notebook's stored kernelspec (`python3` = `WindowsApps\Python313`, which lacks pymc/pyphi/dowhy) → silent `NameError` (the import cell swallows `ImportError`). Sync mode honors `kernel_name` but blocks ~10 min (session-crash risk). Both MCP modes are unusable for forcing an env-specific kernel.

Records the **ai-01 canonical decision (msg-g5awy3)**: `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=<k>` in background — validated firsthand on 10 notebooks this cycle (PyMC/IIT/Probas/GenAI/ML, 0 NameError).

## 2. Gotcha — subprocess CLI under nbconvert (PT_07 #5245)

Notebooks that subprocess an env-packaged CLI (`rewardspy`/`dot`/`lean` via `subprocess.run`) fail under bare `jupyter nbconvert` with `FileNotFoundError [WinError 2]` — the inherited PATH lacks the env `Scripts\` dir. Fix = `conda run -n <env> jupyter nbconvert ...` (activates the env = full PATH).

## Scope

Docs-only. The **root MCP-server fix** belongs upstream in `roo-extensions` (cross-team); this captures the durable CoursIA-side workaround so future agents don't rediscover it. See #5211.

Co-Authored-By: Claude-Code <noreply@anthropic.com>