### PR TITLE
docs(quantconnect): fix stale QC-Py refs in cross-series bridges table

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -525,12 +525,12 @@ Pour aller plus loin : [EPIC #4038](https://github.com/jsboige/CoursIA/issues/40
 
 | Serie | Lien | Connection |
 |-------|------|------------|
-| [ML](../ML/README.md) | Machine Learning | Les modèles de prédiction ML (régression, classification, XGBoost) s'appliquent directement aux stratégies de trading (QC-13 à QC-16) |
-| [GenAI](../GenAI/README.md) | IA générative | L'analyse de sentiment par LLM (QC-17) et les agents sémantiques (QC-18) utilisent les LLMs couverts dans GenAI/Texte |
-| [RL](../RL/README.md) | Apprentissage par renforcement | Les stratégies RL (QC-22 PPO, QC-23 DRL, QC-24 Crypto RL) prolongent les fondamentaux RL de cette série |
+| [ML](../ML/README.md) | Machine Learning | Les modèles de prédiction ML (régression, classification, XGBoost) s'appliquent directement aux stratégies de trading (QC-Py-19 à QC-Py-21) |
+| [GenAI](../GenAI/README.md) | IA générative | L'analyse de sentiment (QC-Py-17) et les signaux de trading par LLM (QC-Py-26) utilisent les LLMs couverts dans GenAI/Texte |
+| [RL](../RL/README.md) | Apprentissage par renforcement | Les stratégies RL (QC-Py-25 DQN/PPO, QC-Py-33 PPO, QC-Py-34 SAC/A2C, QC-Py-35 portfolio) prolongent les fondamentaux RL de cette série |
 | [Probas](../Probas/README.md) | Programmation probabiliste | La modélisation bayésienne des rendements et la gestion du risque s'appuient sur les modèles probabilistes de la série Probas |
 | [Search](../Search/README.md) | Recherche et optimisation | L'optimisation des hyperparamètres de stratégies (grid search, bayésienne) rejoint les techniques de recherche |
-| [ML](../ML/ML.Net/README.md) | Séries temporelles ML.NET | L'analyse technique (QC-4 à QC-7) partage les mêmes fondements que le forecasting par SSA (ML-5) |
+| [ML](../ML/ML.Net/README.md) | Séries temporelles ML.NET | L'analyse technique (QC-Py-11 Technical-Indicators) partage les mêmes fondements que le forecasting par SSA (ML-5) |
 | **Lean 4 (kelly_lean)** | **Preuves formelles** | **Le théorème de Kelly est prouvé formellement dans `kelly_lean/` (Mathlib, toolchain v4.31.0-rc1) — fondement du position sizing enseigné dans QC-Py-10** |
 
 ---


### PR DESCRIPTION
## Contexte — passe éditoriale ai-01 (cron :41, rotation famille #7 QuantConnect)

Regard narratif « promesses README vs contenu réel » sur le README intermédiaire QuantConnect. Le tableau **Cross-series Bridges** citait dans sa colonne *Connection* des numéros de notebooks **périmés** : un lecteur suivant la référence tomberait sur un notebook au sujet différent.

## Dérives corrigées (G.1-groundées firsthand vs section Structure)

| Row | Avant (périmé) | Réel | Après |
|-----|----------------|------|-------|
| ML | `QC-13 à QC-16` = Framework/AltData | RF/XGBoost/régression = QC-19/20/21 | `QC-Py-19 à QC-Py-21` |
| GenAI | `agents sémantiques (QC-18)` = ML-Features-Eng | signaux LLM = QC-26 | `QC-Py-26` |
| RL | `QC-22 PPO, QC-23 DRL, QC-24 Crypto RL` = LSTM/Transformers/Autoencoders | RL réels = QC-25/33/34/35 | `QC-Py-25/33/34/35` |
| ML.NET | `analyse technique (QC-4 à QC-7)` = Research/Universe/Options/Futures | indicateurs = QC-11 | `QC-Py-11 Technical-Indicators` |

Chaque cible vérifiée `ls` firsthand : QC-Py-22/23/24 = LSTM/Transformers/Autoencoders, QC-Py-25 = Reinforcement-Learning, QC-Py-33/34/35 = RL PPO/SAC/portfolio, QC-Py-19/20/21 = ML supervisé/régression/portfolio-opt, QC-Py-26 = LLM-Trading-Signals, QC-Py-11 = Technical-Indicators.

## Garde-fous

- **+4/-4**, README.md seul, **atomique** (1 sujet : références de pont périmées).
- **No-Pendulum** : freshness — numéros corrigés, **zéro réécriture** du tableau ni des descriptions.
- **CATALOG-STATUS byte-identique** (non touché).
- FR-first (readme-french-first). Les 6 READMEs cibles de pont existent (liens intacts).
- Comptes (« 115 stratégies » ≈ 112 dirs/101 main.py) laissés inchangés — pas une contradiction réelle.

See #4208 (référence publique, axe D finition #4212), See #3973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)