### PR TITLE
fix(qc): de-leak research_what_dl_can_predict CWD print (#3436)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_what_dl_can_predict.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_what_dl_can_predict.ipynb
@@ -29,10 +29,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:12.538985Z",
-     "iopub.status.busy": "2026-05-06T10:39:12.537744Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.086084Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.085727Z"
+     "iopub.execute_input": "2026-07-03T20:54:11.386968Z",
+     "iopub.status.busy": "2026-07-03T20:54:11.386968Z",
+     "iopub.status.idle": "2026-07-03T20:54:11.940249Z",
+     "shell.execute_reply": "2026-07-03T20:54:11.940249Z"
     }
    },
    "outputs": [
@@ -41,11 +41,12 @@
      "output_type": "stream",
      "text": [
       "Research notebook initialized\n",
-      "Working directory: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\n"
+      "Working directory: ML-Training-Pipeline\n"
      ]
     }
    ],
    "source": [
+    "from pathlib import Path\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from IPython.display import HTML, display\n",
@@ -53,7 +54,7 @@
     "import os\n",
     "\n",
     "print(\"Research notebook initialized\")\n",
-    "print(f\"Working directory: {os.getcwd()}\")"
+    "print(f\"Working directory: {Path.cwd().name}\")\n"
    ]
   },
   {
@@ -73,10 +74,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.139169Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.138824Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.159154Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.158565Z"
+     "iopub.execute_input": "2026-07-03T20:54:11.973443Z",
+     "iopub.status.busy": "2026-07-03T20:54:11.973443Z",
+     "iopub.status.idle": "2026-07-03T20:54:11.992353Z",
+     "shell.execute_reply": "2026-07-03T20:54:11.992353Z"
     }
    },
    "outputs": [
@@ -254,10 +255,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.161761Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.161611Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.170042Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.169677Z"
+     "iopub.execute_input": "2026-07-03T20:54:11.992353Z",
+     "iopub.status.busy": "2026-07-03T20:54:11.992353Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.005155Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.005155Z"
     }
    },
    "outputs": [
@@ -394,10 +395,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.172095Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.171910Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.180528Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.180035Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.005155Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.005155Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.017989Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.017989Z"
     }
    },
    "outputs": [
@@ -531,10 +532,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.183174Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.182955Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.188628Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.188263Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.017989Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.017989Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.027812Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.027812Z"
     }
    },
    "outputs": [
@@ -660,10 +661,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.191169Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.191013Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.195041Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.194659Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.027812Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.027812Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.035274Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.035274Z"
     }
    },
    "outputs": [
@@ -764,10 +765,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.197383Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.197198Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.200669Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.200306Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.035274Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.035274Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.041339Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.041339Z"
     }
    },
    "outputs": [
@@ -830,10 +831,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.203039Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.202863Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.208355Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.207962Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.041339Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.041339Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.049905Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.049392Z"
     }
    },
    "outputs": [
@@ -975,10 +976,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.211535Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.211371Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.217720Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.217147Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.051916Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.051916Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.058187Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.058187Z"
     }
    },
    "outputs": [
@@ -1043,10 +1044,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.220303Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.220024Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.225592Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.224743Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.060201Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.060201Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.065217Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.065217Z"
     }
    },
    "outputs": [
@@ -1188,10 +1189,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.228742Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.228434Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.235933Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.235468Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.069977Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.069434Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.077022Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.077022Z"
     }
    },
    "outputs": [
@@ -1333,10 +1334,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.238940Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.238504Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.242870Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.242398Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.077022Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.077022Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.083937Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.083396Z"
     }
    },
    "outputs": [
@@ -1438,10 +1439,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.245271Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.245030Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.252457Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.252077Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.086949Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.085950Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.094190Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.094190Z"
     }
    },
    "outputs": [
@@ -1578,10 +1579,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.254831Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.254667Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.260744Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.260383Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.096194Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.096194Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.104360Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.104360Z"
     }
    },
    "outputs": [
@@ -1705,10 +1706,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T10:39:13.262964Z",
-     "iopub.status.busy": "2026-05-06T10:39:13.262747Z",
-     "iopub.status.idle": "2026-05-06T10:39:13.266406Z",
-     "shell.execute_reply": "2026-05-06T10:39:13.266041Z"
+     "iopub.execute_input": "2026-07-03T20:54:12.107365Z",
+     "iopub.status.busy": "2026-07-03T20:54:12.106381Z",
+     "iopub.status.idle": "2026-07-03T20:54:12.110795Z",
+     "shell.execute_reply": "2026-07-03T20:54:12.110795Z"
     }
    },
    "outputs": [
@@ -1770,7 +1771,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

`research_what_dl_can_predict.ipynb` (QuantConnect/ML-Training-Pipeline) leaked **1** absolute machine path via the CWD print in cell 1:

```python
print(f"Working directory: {os.getcwd()}")   # -> D:\dev\CoursIA\...ML-Training-Pipeline
```

### Fix (cause-C source-fix)
```python
from pathlib import Path
print(f"Working directory: {Path.cwd().name}")  # -> ML-Training-Pipeline
```
The folder **name** preserves the useful info (which directory the research runs from) without leaking the machine checkout path.

## Notes

- Despite the **"dl" name**, this is a **pure research/exploration notebook**: pandas/numpy/visualization, **0 training** (no `model.fit`, no `DataLoader`, no `.cuda()`). Verified firsthand by scanning all 15 code cells (`train_risk=False` everywhere).
- No CWD-dependent file ops (no `read_csv` against cwd, no `datasets/`, no `scripts/`, no `sys.path` manipulation) — safe to change the printed cwd to a basename.

## Validation (cause-C #3436)
- **Leaks: 1 → 0** (regex scan of all cell outputs: stream/execute_result/display_data/error)
- **15 code cells all executed** (`execution_count` None=0), **0 errors**
- **C.1 = 0** banned patterns (`raise NotImplementedError`/`assert False`/`1/0`)
- kernelspec `python3`, **LF** (0 CRLF), last byte `0xa`
- Re-exec via `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=coursia-ml-training --ExecutePreprocessor.timeout=600` — EXIT=0
- **C.3 source-diff = 1 cell changed** (2 lines: `from pathlib import Path` added + `{os.getcwd()}`→`{Path.cwd().name}`), no structural churn. The 64/63 ins/del in `--stat` is JSON output-regeneration serialization, not source change.
- Output now: `Working directory: ML-Training-Pipeline`

See #3436