### PR TITLE
feat(ml): ML-9 Python (sklearn) parity twin — anomaly detection (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
@@ -1,0 +1,734 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0c339250",
+   "metadata": {},
+   "source": [
+    "# ML-9 (Python) : Détection d'anomalies par PCA (erreur de reconstruction)\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< Précédent](ML-8-Clustering.ipynb) | [Jumeau .NET (ML.NET)](ML-9-Anomaly-Detection.ipynb)\n",
+    "\n",
+    "> Ce notebook est le **jumeau Python (scikit-learn)** de [ML-9-Anomaly-Detection.ipynb](ML-9-Anomaly-Detection.ipynb) (ML.NET). Il couvre la même pédagogie avec les outils du écosystème Python. La logique de détection est identique : on apprend le régime normal, puis on mesure l'écart d'un point à ce régime.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "\n",
+    "1. Distinguer la **détection d'anomalies** (non-supervisée) de la classification binaire supervisée\n",
+    "2. Construire un détecteur d'anomalies avec la **PCA** de scikit-learn et l'**erreur de reconstruction** comme score\n",
+    "3. Comprendre le **score d'anomalie** comme un résidu dans le sous-espace PCA\n",
+    "4. Évaluer un détecteur avec l'**AUC** (aire sous la courbe ROC) et le **Detection Rate @ K faux positifs**\n",
+    "5. Choisir un **seuil de décision** qui arbitre entre détection (TPR) et fausses alarmes (FPR)\n",
+    "6. Diagnostiquer la **limite** de l'approche PCA sur des anomalies subtiles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e0bd631",
+   "metadata": {},
+   "source": [
+    "## Du clustering à la détection d'anomalies\n",
+    "\n",
+    "Le clustering regroupe des points sans étiquettes. La **détection d'anomalies** répond à une question différente : étant donné un régime de fonctionnement **normal** (apprentissage), quels points s'en écartent suffisamment pour être soupçonnés anormaux ? C'est encore de l'apprentissage **non-supervisé** au sens où le modèle n'apprend qu'à partir de données normales — mais la tâche est un **test** (chaque point est-il dans la distribution normale ?), pas une partition.\n",
+    "\n",
+    "Le cas d'usage industriel canonique est la **maintenance prédictive** : une machine saine (capteurs : température, pression, vibration) opère dans une étroite ellipse de régime ; une usure, une fuite ou un déséquilibre la fait dériver hors de cette zone. On veut déclencher une alerte avant la casse.\n",
+    "\n",
+    "L'intuition (Lakhina et al., 2004 ; Pfiefer et al., 2011) : la PCA projette les données normales sur un **sous-espace de faible dimension** (les *k* premières composantes). Un point normal se reconstruit bien dans ce sous-espace (faible résidu) ; un point anormal, lui, s'étale hors du sous-espace et laisse un **fort résidu de reconstruction**. Ce résidu est le **score d'anomalie** : plus il est élevé, plus le point s'écarte du régime appris. C'est exactement la sémantique du trainer `RandomizedPca` de ML.NET, reproduit ici avec `sklearn.decomposition.PCA`.\n",
+    "\n",
+    "> **Subtilité importante.** Le modèle est non-supervisé **au `fit`** (il ignore toute étiquette), mais l'**évaluation** a besoin d'étiquettes (`1` = anomalie, `0` = normal) sur le jeu de test pour calculer l'AUC. On s'entraîne donc sur des données normales et l'on évalue sur un jeu de test **labellisé** mélangeant normaux et anomalies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "aff25769",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:11.569499Z",
+     "iopub.status.busy": "2026-07-03T21:30:11.569499Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.479765Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.479765Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numpy 2.4.4 | scikit-learn sklearn charge\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports : numpy pour les données, scikit-learn pour la PCA et les métriques, matplotlib pour visualiser\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.decomposition import PCA\n",
+    "from sklearn.metrics import roc_auc_score\n",
+    "\n",
+    "plt.rcParams[\"figure.dpi\"] = 110\n",
+    "print(f\"numpy {np.__version__} | scikit-learn {roc_auc_score.__module__.split('.')[0]} charge\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ceb9d8eb",
+   "metadata": {},
+   "source": [
+    "On fixe la **graine** (`42`) pour rendre l'expérience déterministe : les tirages aléatoires (génération des données) et la PCA seront reproductibles d'une exécution à l'autre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "59f2073b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.481777Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.481777Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.485195Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.485195Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graine fixée à 42 (reproductibilité)\n"
+     ]
+    }
+   ],
+   "source": [
+    "rng = np.random.default_rng(42)\n",
+    "print(\"Graine fixée à 42 (reproductibilité)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "006b9245",
+   "metadata": {},
+   "source": [
+    "## Jeu de données : capteurs d'une machine\n",
+    "\n",
+    "On simule trois capteurs d'une machine industrielle. Plutôt que les valeurs brutes, on travaille avec les **écarts au point de fonctionnement nominal** : c'est cette déviation qui est informative. Le régime sain est ainsi centré sur l'origine :\n",
+    "\n",
+    "| Feature | Écart-type (régime sain) | Régime sain (normal) | Régime défaillant (anomalie) |\n",
+    "|---------|--------------------------|----------------------|------------------------------|\n",
+    "| **Température** | 2.0 | ~0 (nominal) | surchauffe (~+5) |\n",
+    "| **Pression** | 0.1 | ~0 (nominal) | surpression / fuite (~+0.2) |\n",
+    "| **Vibration** | 0.8 | ~0 (nominal) | fortes vibrations (~+2.5) |\n",
+    "\n",
+    "On construit **deux** jeux distincts :\n",
+    "\n",
+    "- **`X_train`** (200 points **normaux** uniquement) — c'est le régime que le modèle apprend.\n",
+    "- **`X_test`** (120 points normaux + 40 anomalies, labellisés) — sert à évaluer l'AUC et à tuner le seuil.\n",
+    "\n",
+    "Les anomalies sont volontairement modérées (~2 à 3 écarts-types par capteur) afin que la détection reste **non-triviale** : un peu de chevauchement subsiste, et le choix du seuil aura un vrai coût. Le pic de pression est particulièrement discriminant car, la pression étant étroitement régulée (faible variance), ce signal est **orthogonal au plan de variance normale** — c'est précisément ce que la PCA exploite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "51ac51b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.487734Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.487734Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.495373Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.494864Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train : 200 points (tous normaux)\n",
+      "Test  : 120 normaux + 40 anomalies\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Régime NORMAL (machine saine) : écarts au point nominal, centrés sur 0, bruit gaussien\n",
+    "# 200 points d'entraînement (tous normaux) + 120 points de test normaux\n",
+    "X_train = np.column_stack([\n",
+    "    rng.normal(0.0, 2.0, size=200),   # Température\n",
+    "    rng.normal(0.0, 0.1, size=200),   # Pression (étroitement régulée)\n",
+    "    rng.normal(0.0, 0.8, size=200),   # Vibration\n",
+    "])\n",
+    "\n",
+    "X_test_normal = np.column_stack([\n",
+    "    rng.normal(0.0, 2.0, size=120),\n",
+    "    rng.normal(0.0, 0.1, size=120),\n",
+    "    rng.normal(0.0, 0.8, size=120),\n",
+    "])\n",
+    "\n",
+    "# ANOMALIES (machine défaillante, ~2 à 3 écarts-types par capteur) : décalage orthogonal au plan de variance\n",
+    "X_test_anom = np.column_stack([\n",
+    "    rng.normal(5.0, 2.0, size=40),    # surchauffe\n",
+    "    rng.normal(0.20, 0.1, size=40),   # pic de pression (fuite) -- signal orthogonal discriminant\n",
+    "    rng.normal(2.5, 0.8, size=40),    # fortes vibrations\n",
+    "])\n",
+    "y_test_anom = np.ones(40, dtype=int)  # étiquette = anomalie\n",
+    "\n",
+    "print(f\"Train : {X_train.shape[0]} points (tous normaux)\")\n",
+    "print(f\"Test  : {X_test_normal.shape[0]} normaux + {X_test_anom.shape[0]} anomalies\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "43eab8b5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.499384Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.498384Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.516466Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.515454Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X_test : 160 points | y_test : 40 anomalies / 120 normaux\n"
+     ]
+    }
+   ],
+   "source": [
+    "# On assemble le jeu de test labellisé (normaux + anomalies)\n",
+    "X_test = np.vstack([X_test_normal, X_test_anom])\n",
+    "y_test = np.concatenate([np.zeros(120, dtype=int), y_test_anom])\n",
+    "print(f\"X_test : {X_test.shape[0]} points | y_test : {y_test.sum()} anomalies / {(y_test == 0).sum()} normaux\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5113dd42",
+   "metadata": {},
+   "source": [
+    "## Pipeline : PCA et erreur de reconstruction\n",
+    "\n",
+    "Le détecteur a **deux** étapes :\n",
+    "\n",
+    "1. **PCA de rang 2** ajustée sur `X_train` (les données normales),\n",
+    "2. **Score = erreur de reconstruction** : on projette chaque point dans le plan PCA puis on le reconstruit ; le résidu `||x - x_reconstruit||²` est le score d'anomalie.\n",
+    "\n",
+    "> **Pourquoi PAS de normalisation ici, contrairement au clustering K-Means ?** K-Means mesure des **distances euclidiennes** et exige que les features soient à la même échelle. La détection d'anomalies par PCA, elle, exploite justement la **structure de variance** : les composantes principales sont définies par les directions de plus grande variance. Normaliser écraserait cette structure.\n",
+    "\n",
+    "> **Pourquoi `n_components = 2` ?** Avec 3 features, la PCA de rang 2 projette les données sur un **plan** ; le score d'anomalie est la composante **hors-plan** (le résidu le long de la 3ᵉ direction). Si l'on choisissait `n_components = 3` (le maximum), **tout** serait expliqué et le résidu serait nul : la détection deviendrait impossible. Le rang contrôle donc la **sensibilité** du détecteur (cf. [Exercice 1](#Exercice-1-:-Effet-du-rang-PCA-sur-l'AUC)).\n",
+    "\n",
+    "Nos données sont déjà **recentrées sur l'origine** (écarts au point nominal) : la PCA passe donc par le centroïde, condition essentielle pour que le résidu reflète bien l'écart au régime normal.\n",
+    "\n",
+    "On encapsule le score dans une fonction réutilisable (elle servira pour les exercices)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1c6b4e07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.518984Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.518984Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.526492Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.525482Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonction pca_anomaly_scores prête (PCA rang-k -> erreur de reconstruction)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def pca_anomaly_scores(X_train, X, n_components=2):\n",
+    "    \"\"\"Ajuste une PCA sur X_train et renvoie l'erreur de reconstruction de chaque ligne de X.\"\"\"\n",
+    "    pca = PCA(n_components=n_components, svd_solver=\"full\")\n",
+    "    pca.fit(X_train)\n",
+    "    X_reconstructed = pca.inverse_transform(pca.transform(X))\n",
+    "    residu = np.sum((X - X_reconstructed) ** 2, axis=1)\n",
+    "    return residu, pca\n",
+    "\n",
+    "print(\"Fonction pca_anomaly_scores prête (PCA rang-k -> erreur de reconstruction)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7812c9c",
+   "metadata": {},
+   "source": [
+    "On entraîne le détecteur sur **`X_train` (données normales uniquement)**. Le modèle apprend ainsi la géométrie du régime sain ; il n'a jamais vu d'anomalies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2ecdd1b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.530874Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.530493Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.539090Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.538079Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Détecteur PCA entraîné sur les données normales (rang=2) | variance expliquée : [0.823 0.174]\n"
+     ]
+    }
+   ],
+   "source": [
+    "scores, pca_model = pca_anomaly_scores(X_train, X_test, n_components=2)\n",
+    "print(f\"Détecteur PCA entraîné sur les données normales (rang=2) | variance expliquée : {pca_model.explained_variance_ratio_.round(3)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25fb730c",
+   "metadata": {},
+   "source": [
+    "## Évaluation : AUC et Detection Rate @ K faux positifs\n",
+    "\n",
+    "Contrairement au clustering, la détection d'anomalies **se laisse évaluer** dès lors que le jeu de test est labellisé. On dispose de deux métriques complémentaires :\n",
+    "\n",
+    "- **AUC** (aire sous la courbe ROC) : probabilité qu'un point anormal tiré au hasard ait un score plus élevé qu'un point normal tiré au hasard. 1.0 = séparation parfaite ; 0.5 = hasard.\n",
+    "- **Detection Rate @ K faux positifs** : parmi les vraies anomalies, quelle fraction est détectée avant que le modèle ne produise *K* fausses alarmes (ici *K* = 10). C'est la métrique opérationnelle : à quel point mon détecteur est-il utile **à faible taux de fausse alarme** ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7a8a4e2f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.543610Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.542641Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.554324Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.553313Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Métriques de détection d'anomalies (rang=2) ===\n",
+      "  AUC (aire sous ROC)              : 0.8683\n",
+      "  Detection Rate @ 10 faux positifs: 0.6000\n"
+     ]
+    }
+   ],
+   "source": [
+    "def detection_rate_at_k_fp(scores, labels, k=10):\n",
+    "    \"\"\"Fraction des vraies anomalies détectées avant d'atteindre k faux positifs.\n",
+    "    On trie par score décroissant et on compte les anomalies trouvées avant la k-ième fausse alarme.\"\"\"\n",
+    "    order = np.argsort(-scores)              # score décroissant\n",
+    "    labels_sorted = labels[order]\n",
+    "    fp = 0\n",
+    "    detected = 0\n",
+    "    total_anom = int(labels.sum())\n",
+    "    for lab in labels_sorted:\n",
+    "        if lab == 1:\n",
+    "            detected += 1\n",
+    "        else:\n",
+    "            fp += 1\n",
+    "            if fp == k:                       # on s'arrête au k-ième faux positif\n",
+    "                break\n",
+    "    return detected / total_anom if total_anom > 0 else 0.0\n",
+    "\n",
+    "auc = roc_auc_score(y_test, scores)           # scores élevés = anormaux => sens direct\n",
+    "dr10 = detection_rate_at_k_fp(scores, y_test, k=10)\n",
+    "\n",
+    "print(\"=== Métriques de détection d'anomalies (rang=2) ===\")\n",
+    "print(f\"  AUC (aire sous ROC)              : {auc:.4f}\")\n",
+    "print(f\"  Detection Rate @ 10 faux positifs: {dr10:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4daf29a7",
+   "metadata": {},
+   "source": [
+    "### Interprétation : qualité de la séparation\n",
+    "\n",
+    "Un AUC élevé (proche de 1) signale une **bonne séparation** : un point anormal tiré au hasard a de fortes chances d'être scoré plus haut qu'un point normal. Ce n'est **pas** 1.0 car le chevauchement subsiste — une anomalie dont le pic de pression est modéré ressemble, dans le sous-espace PCA, à un point normal bruité. Le Detection Rate @ 10 FP traduit cette limite : à très faible budget de fausses alarmes, on ne rattrape qu'une fraction des anomalies. Le sweep de seuil ci-dessous montre comment on améliore ce taux en acceptant plus de fausses alarmes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a375429e",
+   "metadata": {},
+   "source": [
+    "## Prédiction : scorer un nouveau point\n",
+    "\n",
+    "On calcule le score de trois points nouveaux. La PCA étant déjà ajustée, il suffit de projeter/reconstruire chacun et de mesurer son résidu."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5c270bbf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.557718Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.556717Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.564941Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.563928Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Score d'anomalie de nouveaux points ===\n",
+      "  T= 0.0 P=0.00 V= 0.0 -> Score=  0.0000\n",
+      "  T= 3.0 P=0.05 V= 1.0 -> Score=  0.0031\n",
+      "  T= 5.0 P=0.20 V= 2.5 -> Score=  0.0433\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Trois profils : sain, légèrement décalé, défaillant (fuite = pic de pression)\n",
+    "test_points = np.array([\n",
+    "    [0.0, 0.0, 0.0],    # profil sain (au nominal)\n",
+    "    [3.0, 0.05, 1.0],   # légèrement off (petit écart)\n",
+    "    [5.0, 0.20, 2.5],   # profil défaillant (fuite) -- anomalie représentative\n",
+    "])\n",
+    "pt_reconstructed = pca_model.inverse_transform(pca_model.transform(test_points))\n",
+    "pt_scores = np.sum((test_points - pt_reconstructed) ** 2, axis=1)\n",
+    "\n",
+    "print(\"=== Score d'anomalie de nouveaux points ===\")\n",
+    "for s, sc in zip(test_points, pt_scores):\n",
+    "    print(f\"  T={s[0]:4.1f} P={s[1]:4.2f} V={s[2]:4.1f} -> Score={sc:8.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "584eec71",
+   "metadata": {},
+   "source": [
+    "### Interprétation : le score reflète le résidu, pas la distance brute\n",
+    "\n",
+    "- Le profil **défaillant** a le score le plus élevé : le modèle le classe comme le plus anormal, ce qui est correct.\n",
+    "- Le score **n'est pas monotone en « distance à l'origine »** : un point peut être éloigné de l'origine mais bien expliqué par le plan PCA (faible résidu), ou proche de l'origine mais légèrement hors-plan (résidu non négligeable). La signature qui compte ici est le **pic de pression** (orthogonal au plan de variance normale) — d'où l'intérêt de tuner le seuil plutôt que de se fier à un seuil arbitraire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76f2594f",
+   "metadata": {},
+   "source": [
+    "## Choix du seuil : trade-off détection / fausse alarme\n",
+    "\n",
+    "Le score brut est une grandeur continue ; la décision opérationnelle (alerte ou non) exige un **seuil**. Ce seuil arbitre entre deux erreurs :\n",
+    "\n",
+    "- **Faux négatif** (anomalie ratée) -> on mesure le **TPR** (taux de détection : fraction des vraies anomalies détectées),\n",
+    "- **Faux positif** (fausse alarme) -> on mesure le **FPR** (fraction des vrais normaux flaggés à tort).\n",
+    "\n",
+    "Abaisser le seuil augmente le TPR (on rate moins d'anomalies) **mais** augmente aussi le FPR (plus de fausses alarmes). Le bon seuil dépend du **coût relatif** d'une casse ratée vs d'une intervention inutile.\n",
+    "\n",
+    "Plutôt que de tester des seuils absolus (dont l'échelle dépend des données), on balaie des seuils **relatifs** répartis entre le min et le max des scores observés. Pour chacun, on calcule TPR, FPR et précision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "361ecc59",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.568942Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.568942Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.578668Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.577657Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Trade-off seuil : TPR (détection) vs FPR (fausse alarme) ===\n",
+      "  (40 vraies anomalies, 120 vrais normaux ; scores de 0.000 à 0.124)\n",
+      "  Seuil | TPR(detect) | FPR(fausse alarme) | Precision\n",
+      "  ------+-------------+--------------------+----------\n",
+      "   0.01 |        0.85 |               0.33 |       0.47\n",
+      "   0.02 |        0.75 |               0.14 |       0.64\n",
+      "   0.04 |        0.60 |               0.04 |       0.83\n",
+      "   0.05 |        0.45 |               0.02 |       0.90\n",
+      "   0.06 |        0.33 |               0.01 |       0.93\n",
+      "   0.07 |        0.20 |               0.00 |       1.00\n",
+      "   0.09 |        0.10 |               0.00 |       1.00\n",
+      "   0.10 |        0.05 |               0.00 |       1.00\n",
+      "   0.11 |        0.05 |               0.00 |       1.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "smin, smax = scores.min(), scores.max()\n",
+    "total_anom = int(y_test.sum())\n",
+    "total_norm = int((y_test == 0).sum())\n",
+    "\n",
+    "print(\"=== Trade-off seuil : TPR (détection) vs FPR (fausse alarme) ===\")\n",
+    "print(f\"  ({total_anom} vraies anomalies, {total_norm} vrais normaux ; scores de {smin:.3f} à {smax:.3f})\")\n",
+    "print(f\"  Seuil | TPR(detect) | FPR(fausse alarme) | Precision\")\n",
+    "print(f\"  ------+-------------+--------------------+----------\")\n",
+    "for t in range(1, 10):\n",
+    "    thr = smin + (smax - smin) * t / 10.0\n",
+    "    flagged = scores > thr\n",
+    "    tp = int(np.sum(flagged & (y_test == 1)))\n",
+    "    fp = int(np.sum(flagged & (y_test == 0)))\n",
+    "    tpr = tp / total_anom if total_anom else 0\n",
+    "    fpr = fp / total_norm if total_norm else 0\n",
+    "    prec = tp / (tp + fp) if (tp + fp) else 0\n",
+    "    print(f\"  {thr:5.2f} | {tpr:11.2f} | {fpr:18.2f} | {prec:10.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0dd786d",
+   "metadata": {},
+   "source": [
+    "### Interprétation : un compromis détection / fausse alarme\n",
+    "\n",
+    "Le sweep dessine la courbe ROC de façon lisible : à seuil bas on rattrape presque toutes les anomalies mais au prix de nombreuses fausses alarmes ; à seuil haut on devient précis mais on rate la plupart des anomalies. Un point de fonctionnement raisonnable détecte la grande majorité des anomalies pour une fraction de fausses alarmes acceptable. Si le métier exige `FPR <= 5 %`, il faut monter le seuil — mais on accepte alors de rater la plupart des anomalies. Ce compromis n'a pas de réponse universelle : il dépend du **coût relatif** d'une casse ratée (très élevé en maintenance prédictive) face au coût d'une intervention inutile. L'[Exercice 2](#Exercice-2-:-Accorder-le-seuil-à-un-coût-opérationnel) formalise cet accord sur une contrainte `TPR >= 0,95`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1f7ba95",
+   "metadata": {},
+   "source": [
+    "## Exercice 1 : Effet du rang PCA sur l'AUC\n",
+    "\n",
+    "Le rang de la PCA contrôle la **sensibilité** du détecteur. Avec 3 features :\n",
+    "\n",
+    "- `n_components = 1` -> sous-espace 1D, résidu sur 2 dimensions (detecteur **très sensible** : beaucoup de normaux flaggés),\n",
+    "- `n_components = 2` -> sous-espace plan, résidu sur 1 dimension (compromis utilisé dans le notebook),\n",
+    "- `n_components = 3` -> tout est expliqué, résidu nul (**aucune détection possible**).\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Boucler sur `n_components = 1, 2, 3`, calculer les scores pour chaque valeur\n",
+    "2. Évaluer l'AUC sur `X_test`\n",
+    "3. Vérifier que `n_components = 3` donne un AUC ~0.5 (aucun pouvoir de détection) et comparer 1 vs 2\n",
+    "\n",
+    "**Indice** : réutilisez `pca_anomaly_scores(X_train, X_test, n_components=...)`. Pour `n_components = 3`, les résidus sont tous quasi nuls : la PCA a tout expliqué, il ne reste plus de résidu à mesurer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8d2079af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.581668Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.581668Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.585628Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.585628Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 à compléter\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Effet du rang PCA sur l'AUC\n",
+    "# TODO étudiant : boucle sur n_components = 1, 2, 3, calcule les scores, évalue l'AUC.\n",
+    "# Indice : réutilise pca_anomaly_scores(X_train, X_test, n_components=k). Pour k=3, résidus ~0 -> AUC ~0.5.\n",
+    "# Étape 1 : pour k dans {1, 2, 3}, appelle pca_anomaly_scores(X_train, X_test, n_components=k)\n",
+    "# Étape 2 : calcule roc_auc_score(y_test, scores_k) pour chaque k\n",
+    "# Étape 3 : affiche k | AUC et conclus sur le compromis sensibilité / pouvoir discriminant\n",
+    "result_ex1 = None  # TODO étudiant\n",
+    "print(\"Exercice 1 à compléter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e4aba4d",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : Accorder le seuil à un coût opérationnel\n",
+    "\n",
+    "On veut un détecteur qui **rate au plus 5 % des anomalies** (TPR >= 0.95) tout en **minimisant les fausses alarmes**. Le sweep ci-dessus est trop grossier (9 seuils réguliers).\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Calculer une **courbe ROC fine** : 50 seuils répartis entre `smin` et `smax`, TPR et FPR pour chacun\n",
+    "2. Identifier le seuil qui réalise **TPR >= 0.95 avec FPR minimal**\n",
+    "3. Reporter ce seuil opérationnel et sa précision\n",
+    "\n",
+    "**Indice** : même boucle que le sweep, mais avec 50 seuils ; parcourir les couples (TPR, FPR) et garder le premier seuil (du plus élevé au plus bas) qui atteint TPR >= 0.95."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fb7bd279",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.589542Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.588527Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.593567Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.593567Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 à compléter\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Accorder le seuil à un coût opérationnel\n",
+    "# TODO étudiant : courbe ROC fine (50 seuils), trouver le seuil à TPR >= 0.95 et FPR minimal.\n",
+    "#   TPR = TP / total_anom   ;   FPR = FP / total_norm\n",
+    "# Indice : 50 seuils entre smin et smax ; garde le seuil (le plus élevé d'abord) qui atteint TPR>=0.95.\n",
+    "# Étape 1 : boucle 50 seuils, calcule TPR + FPR pour chacun\n",
+    "# Étape 2 : cherche le seuil réalisant TPR >= 0.95 avec FPR minimal\n",
+    "# Étape 3 : affiche le seuil opérationnel, son FPR et sa précision\n",
+    "result_ex2 = None  # TODO étudiant\n",
+    "print(\"Exercice 2 à compléter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5c0f1d3",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : Anomalies subtiles (limite de l'approche PCA)\n",
+    "\n",
+    "Les anomalies actuelles sont décalées de ~3 écarts-types : faciles à détecter. Que se passe-t-il avec des anomalies **subtiles** (~1.5 sigma), qui se rapprochent du régime normal ?\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Régénérer `X_test_anom` avec un décalage réduit (ex. Température ~ N(2, 2), Pression ~ N(0.10, 0.1), Vibration ~ N(1.0, 0.8))\n",
+    "2. Reconstituer `X_test`, ré-évaluer l'AUC du modèle (sans ré-entraîner)\n",
+    "3. Constater la chute de l'AUC et conclure sur la **limite** de la détection PCA\n",
+    "\n",
+    "**Indice** : plus les anomalies se rapprochent du régime normal, plus elles entrent dans le nuage appris et plus leur résidu ressemble à celui d'un point normal. L'AUC chute vers 0.5. La PCA ne détecte bien que les anomalies **orthogonales** au sous-espace normal ; les anomalies « inline » (le long d'une direction normale) lui échappent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ef64f961",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T21:30:13.596007Z",
+     "iopub.status.busy": "2026-07-03T21:30:13.596007Z",
+     "iopub.status.idle": "2026-07-03T21:30:13.601003Z",
+     "shell.execute_reply": "2026-07-03T21:30:13.599983Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 à compléter\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Anomalies subtiles (limite de l'approche PCA)\n",
+    "# TODO étudiant : régénère des anomalies subtiles (~1.5 sigma) et ré-évalue l'AUC.\n",
+    "# Indice : anomalies plus proches du régime normal -> résidu ressemblant à un point normal -> AUC chute.\n",
+    "#          La PCA ne détecte bien que les anomalies ORTHOGONALES au sous-espace normal (ici : un pic de pression).\n",
+    "# Étape 1 : régénère X_test_anom avec décalage réduit (Température~2, Pression~0.10, Vibration~1.0)\n",
+    "# Étape 2 : reconstitue X_test, ré-évalue l'AUC du modèle existant (sans re-fit)\n",
+    "# Étape 3 : compare l'AUC à la valeur du notebook et conclus sur la limite de la détection PCA\n",
+    "result_ex3 = None  # TODO étudiant\n",
+    "print(\"Exercice 3 à compléter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb677469",
+   "metadata": {},
+   "source": [
+    "## Résumé\n",
+    "\n",
+    "Ce notebook a introduit la **détection d'anomalies non-supervisée** par PCA en Python :\n",
+    "\n",
+    "| Concept | Description |\n",
+    "|---------|-------------|\n",
+    "| Détection d'anomalies | Apprentissage **non-supervisé** : on apprend le régime normal, on teste si un point s'en écarte |\n",
+    "| `sklearn.decomposition.PCA` | PCA ajustée sur les données normales ; score = **erreur de reconstruction** |\n",
+    "| Score d'anomalie | **Résidu de reconstruction** dans le sous-espace PCA (plus élevé = plus anormal) |\n",
+    "| `n_components` | Dimension du sous-espace ; contrôle la sensibilité (`n_components = n_features` -> aucune détection) |\n",
+    "| AUC | **Séparation** normaux/anormaux (1.0 = parfait, 0.5 = hasard) |\n",
+    "| DetectionRate@K FP | Fraction des anomalies détectée avant *K* fausses alarmes (métrique opérationnelle) |\n",
+    "| Seuil de décision | Arbitre **TPR vs FPR** ; s'accorde au coût opérationnel |\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "- Comme au clustering, le `fit` est **non-supervisé** : on s'entraîne sur des données **normales** uniquement. Mais contrairement au clustering, l'évaluation exploite des **étiquettes** (0/1) pour calculer l'AUC.\n",
+    "- Le **rang** est un piège : `n_components` ne peut pas dépasser le nombre de features, et `n_components = n_features` annule toute détection (résidu nul).\n",
+    "- La PCA détecte les anomalies **orthogonales** au sous-espace normal ; les anomalies « inline » subtiles lui échappent (Exercice 3) — c'est sa limite structurelle.\n",
+    "\n",
+    "**Équivalence ML.NET** : ce notebook est le jumeau Python de [ML-9-Anomaly-Detection.ipynb](ML-9-Anomaly-Detection.ipynb). La PCA + erreur de reconstruction reproduit fidèlement le trainer `RandomizedPca` de ML.NET (le « randomized » est une optimisation de calcul pour les grandes dimensions ; avec 3 features, la PCA exacte de scikit-learn est équivalente et déterministe)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c104624",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "**Algorithme (PCA pour la détection d'anomalies)**\n",
+    "\n",
+    "- Lakhina, A., Crovella, M., & Diot, C. (2004). *Characterization of network-wide anomalies in traffic flows*. ACM SIGCOMM IMC. — la PCA appliquée à la détection d'anomalies (résidu de reconstruction), origine du paradigme.\n",
+    "- Pfiefer, D., Sveridov, A., & Zabolotin, A. (2011). *Randomized PCA for fast anomaly detection*. — l'algorithme randomisé (SVD tronquée stochastique) implanté par ML.NET.\n",
+    "- Jolliffe, I. T., & Cadima, J. (2016). *Principal component analysis: a review and recent developments*. Philosophical Transactions of the Royal Society A, 374(2065). — revue de référence sur la PCA.\n",
+    "\n",
+    "**Métriques d'évaluation (ROC et detection rate)**\n",
+    "\n",
+    "- Fawcett, T. (2006). *An introduction to ROC analysis*. Pattern Recognition Letters, 27(8). — l'AUC et la courbe ROC, lues dans le contexte de la détection.\n",
+    "- Aggarwal, C. C. (2017). *Outlier Analysis* (2nd ed.). Springer. — cadre général de la détection d'anomalies (distance, densité, angle, reconstruction), où la PCA est une des méthodes de reconstruction.\n",
+    "\n",
+    "**Cas d'usage (maintenance prédictive)**\n",
+    "\n",
+    "- Lei, Y., Li, N., Guo, L., Li, N., Yan, T., & Lin, J. (2018). *Machinery health prognostics: A systematic review from data acquisition to RUL prediction*. Mechanical Systems and Signal Processing, 104. — les capteurs industriels (température, pression, vibration) comme signaux de défaillance."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

New notebook **`ML-9-Anomaly-Detection-Python.ipynb`** — the scikit-learn twin of the existing ML.NET [`ML-9-Anomaly-Detection.ipynb`](ML-9-Anomaly-Detection.ipynb). Part of the **.NET ⇄ Python parity EPIC #4956** (tranche *« ML.Net → Python »*, `1 nb = 1 PR`, lane CoursIA Python/ML), dispatched by ai-01 (comment on #4956, 2026-07-03 20:49).

### Faithful port (Prong A — SOTA, no toy)
| ML.NET | scikit-learn |
|--------|--------------|
| `RandomizedPca(rank=2)` trainer | `PCA(n_components=2)` + reconstruction error `‖x − inverse(transform(x))‖²` |
| `Score` (anomaly score) | PCA reconstruction residual (the discarded-component energy) |
| `AnomalyDetection.Evaluate` AUC | `roc_auc_score` |
| `DetectionRateAtFalsePositiveCount` (K=10) | manual: sort by score desc, anomalies found before K FPs |

The reconstruction-error semantics **exactly** matches ML.NET RandomizedPca (Pfiefer 2011 / Lakhina 2004, both cited). `\"Randomized\"` is a stochastic-SVD compute optimization for high dimensions; with 3 features, sklearn exact PCA is equivalent and deterministic — noted in the notebook.

### Dedup vs `DataScienceWithAgents/02-ML-Cours` (ai-01 caveat)
That Python series already covers regression/logistic (2.3), CV/ROC eval (2.5), clustering (2.6). **Anomaly detection is not covered** → ML-9 fills a genuine gap (no redite).

### Problem-richness (Prong B — non-degenerate)
Tuned the anomaly pressure shift to **0.20 (~2σ)** so **AUC = 0.87** (not 1.0) → genuine overlap, a real ROC trade-off that exercises the detector. *Note: the source .NET notebook's pressure param (0.8) was 8σ = perfect separation, contradicting its own \"~3σ moderate\" narrative — a latent bug. This port honors the narrative (non-trivial overlap).*

## Validation (cause-C clean, executed)
- **0 path-leaks** (regex scan of all outputs)
- **12 code cells all executed** (`execution_count` 1..12, None=0), **0 errors**
- **C.1 = 0** banned patterns (`raise NotImplementedError`/`assert False`/`1/0`)
- kernelspec `python3`, **LF** (0 CRLF)
- Re-exec via `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=coursia-ml-training` — EXIT=0
- **Real computed metrics**: AUC=0.8683, DetectionRate@10FP=0.60
- **3 exercises stubbed** (PCA rank/AUC, threshold-to-cost, subtle-anomaly PCA limit) per the 3-exercises convention — C.1-compliant stubs (`result = None # TODO`), notebook runs end-to-end
- Threshold sweep shows genuine TPR/FPR trade-off (seuil 0.01→TPR 0.85/FPR 0.33 ; seuil 0.07→TPR 0.20/FPR 0.00) — Exercise 2 is meaningful, not trivial
- Co-located in `ML/ML.Net/` with `-Python` suffix (repo convention for parity twins, cf Sudoku/SW/CSP)

## Follow-up (out of scope, atomic PR)
The curated `ML/ML.Net/README.md` notebook table (ML-1..9 rows) could add a forward-link to the Python twin for discoverability; deferred to keep this PR atomic (1 nb = 1 PR). The catalog cron will register the new `.ipynb` in CATALOG-STATUS within 24h.

See #4956