### PR TITLE
fix(tooling): C.1 scanners recognise C-family // comments

### DIFF
--- a/scripts/notebook_tools/audit_c1_c3.py
+++ b/scripts/notebook_tools/audit_c1_c3.py
@@ -76,9 +76,12 @@ def check_c1(nb_path: Path) -> list[dict]:
         source = "".join(cell.get("source", []))
         in_doc = False
         for line in source.split("\n"):
-            if line.lstrip().startswith("#"):
+            # Skip full-line comments (Python '#' or C-family '//', e.g. C#).
+            stripped = line.lstrip()
+            if stripped.startswith("#") or stripped.startswith("//"):
                 continue
-            code_part = line.split("#")[0].rstrip()
+            # Strip inline comments before checking patterns (both '#' and '//').
+            code_part = re.split(r"#|//", line, maxsplit=1)[0].rstrip()
             in_doc, inside = _is_in_docstring(line, in_doc)
             if inside:
                 continue

--- a/scripts/notebook_tools/notebook_lint.py
+++ b/scripts/notebook_tools/notebook_lint.py
@@ -64,16 +64,24 @@ def scan_c1_source(source: str) -> list[tuple[str, str]]:
     substring) is not flagged. This is the single shared C.1 detector; both
     notebook_lint and validate_pr_notebooks consume it to avoid divergence
     (#1505).
+
+    Comment syntax is language-agnostic here: both Python '#' and C-family '//'
+    (C#/.NET Interactive, JS, Java) markers are recognised. Without the '//'
+    case a '.net-csharp' cell whose comment merely *mentions* a banned pattern
+    — e.g. "// stub : pas de raise NotImplementedError" — was flagged as a
+    C.1 violation (false positive on Tweety C# stubs, #5261). Executable C#
+    'int x = 1/0;' is still caught because the pattern sits before any '//'.
     """
     hits: list[tuple[str, str]] = []
     in_docstring = False
     for line in source.split("\n"):
         stripped = line.lstrip()
-        # Skip any comment line (commented-out code is not executable)
-        if stripped.startswith("#"):
+        # Skip any full-line comment (Python '#' or C-family '//');
+        # commented-out code is not executable.
+        if stripped.startswith("#") or stripped.startswith("//"):
             continue
-        # Strip inline comments before checking patterns
-        code_part = line.split("#")[0].rstrip()
+        # Strip inline comments before checking patterns (both '#' and '//').
+        code_part = re.split(r"#|//", line, maxsplit=1)[0].rstrip()
         # Track and skip docstring content
         in_docstring, is_inside = _is_in_docstring(line, in_docstring)
         if is_inside:

--- a/scripts/notebook_tools/tests/test_notebook_lint.py
+++ b/scripts/notebook_tools/tests/test_notebook_lint.py
@@ -132,6 +132,25 @@ class TestScanC1Source:
         hits = scan_c1_source("pass  # raise NotImplementedError")
         assert hits == []
 
+    def test_csharp_line_comment_not_flagged(self):
+        """C-family '//' comment mentioning a banned pattern is not code (#5261).
+
+        A .net-csharp stub whose comment reads
+        '// stub : pas de raise NotImplementedError' must not false-flag C.1.
+        """
+        hits = scan_c1_source("// Cellule stub : pas de raise NotImplementedError")
+        assert hits == []
+
+    def test_csharp_inline_comment_stripped(self):
+        hits = scan_c1_source('Console.WriteLine("ok");  // raise NotImplementedError')
+        assert hits == []
+
+    def test_csharp_executable_division_still_flagged(self):
+        """Executable C# 'int x = 1/0;' sits before any '//' and is still caught."""
+        hits = scan_c1_source("int x = 1/0;  // divide by zero")
+        assert len(hits) == 1
+        assert hits[0][1] == "1/0"
+
     def test_date_not_flagged(self):
         """Date 21/02/2022 should not be flagged as 1/0."""
         hits = scan_c1_source("date = '21/02/2022'")


### PR DESCRIPTION
## Problème

Le détecteur C.1 partagé `scan_c1_source` ([notebook_lint.py](scripts/notebook_tools/notebook_lint.py)) et son jumeau dans [audit_c1_c3.py](scripts/notebook_tools/audit_c1_c3.py) ne reconnaissaient que les commentaires Python `#`. Dans une cellule `.net-csharp`, un commentaire `//` qui *mentionne* seulement un motif banni — p.ex. `// Cellule stub : pas de raise NotImplementedError` — était scanné comme du code exécutable et signalé comme violation C.1.

Résultat : la CI **Static validation (H.1/H.3/C.1)** échouait en **faux positif** sur tout notebook C# dont un commentaire cite la règle C.1. Surface d'origine : les stubs de `Tweety-10-MLN-Csharp.ipynb` dans #5261, dont les cellules s'exécutent proprement (exec_count séquentiel 1..9, 0 erreur, sortie `"Exercice a completer"`).

## Correctif

Dans les **deux** détecteurs : sauter les commentaires pleine-ligne `//` et retirer les `//` en fin de ligne, à l'identique du traitement `#` existant.
- Le C# exécutable `int x = 1/0;` reste détecté (le motif précède tout `//`).
- Le garde-fou #1505 (date `21/02/2022`, regex digit-bounded) est **inchangé**.

## Tests

3 tests de régression ajoutés ([test_notebook_lint.py](scripts/notebook_tools/tests/test_notebook_lint.py)) : commentaire-ligne C#, commentaire inline C#, division exécutable C#. **146 tests de la suite C.1 passent** (`test_notebook_lint` + `test_audit_c1_c3` + `test_validate_pr_notebooks`).

## Portée

Refs #1505 (détecteur C.1 partagé unique — ceci garde les deux en phase). Débloque le faux positif Static-validation observé sur #5261 (fleet-wide pour tous les notebooks C#).

🤖 Generated with [Claude Code](https://claude.com/claude-code)