### PR TITLE
docs(ml): reconcile ML READMEs with .NET⇄Python parity arc (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -11,6 +11,8 @@ maturity: PRODUCTION=8, ALPHA=1, DRAFT=1
 
 ML.NET — la bibliothèque open-source de Microsoft — apporte le machine learning **nativement dans l'écosystème .NET** : on entraîne et on consomme des modèles directement en C#, sans quitter sa stack applicative ni dépendre d'un runtime Python. C'est un choix pensé pour les développeurs autant que pour les data scientists — l'AutoML abaisse la barrière d'entrée, et les modèles s'exécutent *in-process* dans des applications existantes (API web, services, desktop). L'interopérabilité **ONNX** permet d'importer des modèles entraînés ailleurs (scikit-learn, PyTorch, Hugging Face) et de les servir côté .NET : ML.NET devient ainsi un pont concret entre la recherche en Python et la production en entreprise.
 
+> **Jumeaux de parité (C# ⇄ Python/scikit-learn).** Plusieurs notebooks avancés de cette série disposent d'un **jumeau Python** co-localisé (`*-Python.ipynb`) qui couvre le **même concept pédagogique** avec les outils canoniques de l'écosystème Python (scikit-learn, statsmodels) — un contrepoint direct au pipeline ML.NET. Là où ML.NET `RandomizedPca` détecte les anomalies, le jumeau utilise `sklearn.PCA` + erreur de reconstruction ; là où `ForecastBySsa` prévoit les séries temporelles, le jumeau emploie `statsmodels` STL + SARIMA ; là où `MatrixFactorization` recommande, le jumeau applique `NMF`. Cette parité permet de voir qu'un **même problème** se modélise idiomatiquement dans deux écosystèmes, et que les concepts (résidu de reconstruction, facteurs latents, décomposition tendance/saisonnalité) sont universels — seuls les outils diffèrent. Les jumeaux sont signalés dans la table des notebooks avancés ci-dessous.
+
 Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : préparation des données et feature engineering (ML-2), entraînement et AutoML (ML-3), évaluation rigoureuse par cross-validation et importance des variables (ML-4), puis les fonctionnalités avancées — prévision de séries temporelles par SSA (ML-5), interopérabilité ONNX (ML-6), systèmes de recommandation (ML-7), clustering non-supervisé par K-Means (ML-8) et détection d'anomalies par Randomized PCA (ML-9) — avant un TP capstone qui marie ML.NET et la régression bayésienne d'Infer.NET.
 
 > **À qui s'adresse cette série** : développeurs C#/.NET découvrant le Machine Learning, équipes enterprise souhaitant intégrer du ML sans sortir de leur stack .NET, ou data scientists souhaitant servir des modèles en production dans des applications C#. Aucun prérequis en statistiques avancées — les concepts sont introduits progressivement dans chaque notebook.
@@ -38,13 +40,13 @@ Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : p
 
 ### Fonctionnalités avancées (ML-5 à ML-9)
 
-| # | Notebook | Contenu | Durée |
-|---|----------|---------|-------|
-| 5 | [ML-5-TimeSeries](ML-5-TimeSeries.ipynb) | **Time Series Forecasting** avec ForecastBySsa (SSA) | 45-60 min |
-| 6 | [ML-6-ONNX](ML-6-ONNX.ipynb) | **ONNX Integration** : modèles Python/PyTorch dans .NET | 45-60 min |
-| 7 | [ML-7-Recommendation](ML-7-Recommendation.ipynb) | **Recommandation** : Matrix Factorization, collaborative filtering | 45-60 min |
-| 8 | [ML-8-Clustering](ML-8-Clustering.ipynb) | **Clustering non-supervisé** : K-Means, segmentation RFM, méthode du coude | 45-60 min |
-| 9 | [ML-9-Anomaly-Detection](ML-9-Anomaly-Detection.ipynb) | **Détection d'anomalies** : Randomized PCA, AUC, seuil de décision | 45-60 min |
+| # | Notebook | Contenu | Jumeau Python (scikit-learn / statsmodels) | Durée |
+|---|----------|---------|------------------------------------------|-------|
+| 5 | [ML-5-TimeSeries](ML-5-TimeSeries.ipynb) | **Time Series Forecasting** avec ForecastBySsa (SSA) | [ML-5-Python](ML-5-TimeSeries-Python.ipynb) — STL + SARIMA | 45-60 min |
+| 6 | [ML-6-ONNX](ML-6-ONNX.ipynb) | **ONNX Integration** : modèles Python/PyTorch dans .NET | — (pont inter-langage, par nature .NET-centrique) | 45-60 min |
+| 7 | [ML-7-Recommendation](ML-7-Recommendation.ipynb) | **Recommandation** : Matrix Factorization, collaborative filtering | [ML-7-Python](ML-7-Recommendation-Python.ipynb) — NMF | 45-60 min |
+| 8 | [ML-8-Clustering](ML-8-Clustering.ipynb) | **Clustering non-supervisé** : K-Means, segmentation RFM, méthode du coude | — (déjà couvert en Python : [2.6-Clustering](../DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb)) | 45-60 min |
+| 9 | [ML-9-Anomaly-Detection](ML-9-Anomaly-Detection.ipynb) | **Détection d'anomalies** : Randomized PCA, AUC, seuil de décision | [ML-9-Python](ML-9-Anomaly-Detection-Python.ipynb) — PCA + erreur de reconstruction | 45-60 min |
 
 ### TP Pratique
 

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -9,16 +9,17 @@ maturity: PRODUCTION=29, BETA=6, ALPHA=1, DRAFT=1
 
 [← Notebooks](../README.md) | [ML.NET (C#) →](ML.Net/README.md) | [Data Science with Agents (Python) →](DataScienceWithAgents/README.md) | [RL →](../RL/)
 
-Le monde regorge de données, mais les transformer en décisions éclairées demande plus qu'un tableur. Le Machine Learning offre un cadre systématique pour construire des modèles prédictifs à partir de données, en allant de la régression linéaire aux réseaux de neurones en passant par les systèmes de recommandation. Cette série vous forme au ML pratique avec deux stack complémentaires : **ML.NET** pour l'écosystème .NET/C# et **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs.
+Le monde regorge de données, mais les transformer en décisions éclairées demande plus qu'un tableur. Le Machine Learning offre un cadre systématique pour construire des modèles prédictifs à partir de données, en allant de la régression linéaire aux réseaux de neurones en passant par les systèmes de recommandation. Cette série vous forme au ML pratique avec trois fils complémentaires : **ML.NET** pour l'écosystème .NET/C#, **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs, et les **jumeaux de parité** qui confrontent un même concept aux deux écosystèmes.
 
 ## Pourquoi cette série
 
-Le Machine Learning est partout : recommandations Netflix, détection de spam, prévisions de vente, diagnostic médical. Mais passer de la théorie à la pratique reste un saut difficile. Cette série comble ce gap en proposant une **double approche** :
+Le Machine Learning est partout : recommandations Netflix, détection de spam, prévisions de vente, diagnostic médical. Mais passer de la théorie à la pratique reste un saut difficile. Cette série comble ce gap en proposant **trois angles d'attaque** :
 
 - **ML.NET (C#/.NET)** : Pour les développeurs déjà familiers avec l'écosystème .NET, ML.NET offre un pipeline ML natif en C#. Pas besoin d'apprendre Python pour faire du ML en entreprise. Les notebooks couvrent le pipeline complet, de `IDataView` au déploiement ONNX, avec une évaluation rigoureuse par cross-validation.
 - **Python + AI Agents** : Pour les data scientists et praticiens IA, le track Python combine les fondamentaux (NumPy, Pandas, scikit-learn) avec les agents LLM (LangChain, Google ADK). C'est le futur du data science workflow : l'automatisation par des agents capables de nettoyer, analyser et modéliser des données.
+- **Jumeaux de parité (C# ⇄ Python/scikit-learn)** : Pour saisir que les concepts ML sont universels, plusieurs notebooks avancés de la série ML.NET disposent d'un **jumeau Python** co-localisé (`*-Python.ipynb`) qui traite le **même problème** avec les outils canoniques Python (détection d'anomalies `RandomizedPca`↔`PCA`+résidu, recommandation `MatrixFactorization`↔`NMF`, séries temporelles `ForecastBySsa`↔`STL`+`SARIMA`). Voir la [feuille ML.NET](ML.Net/README.md).
 
-Avoir les deux approches permet de comprendre que le ML n'est pas lié à un langage : les concepts (features, entraînement, évaluation, généralisation) sont universels, seuls les outils différent.
+Avoir ces trois angles permet de comprendre que le ML n'est pas lié à un langage : les concepts (features, entraînement, évaluation, généralisation) sont universels, seuls les outils diffèrent.
 
 **Applications réelles couvertes** : prévisions de ventes (régression bayésienne), systèmes de recommandation (collaborative filtering), séries temporelles (forecasting), analyse de CV (NLP + agents), compétitions Kaggle (MLE-STAR pipeline).
 


### PR DESCRIPTION
## Summary

Editorial reconciliation of the two ML READMEs to present the **sklearn parity twins** (ML-5/7/9-Python, merged #5263/#5265/#5266) — per **ai-01's acceptance criteria** (comment [#4954 4879603094](https://github.com/jsboige/CoursIA/issues/4956), deferred to tranche-verte). With 3 clean ports merged + ML-6/8 explicitly SKIP'd + ML-1-4 documented as redite, the tranche is stable enough to reconcile. **FR-first**, **CATALOG-STATUS markers byte-identical** (catalog-pr-hygiene).

### Feuille `ML.Net/README.md`
- **Parity-arc note** after the intro: frames the C# ⇄ sklearn twins as a direct counterpoint to ML.NET pipelines (`RandomizedPca`↔`PCA`+résidu, `ForecastBySsa`↔`STL`+`SARIMA`, `MatrixFactorization`↔`NMF`), *beyond* the ONNX-interop narrative already present.
- **Advanced notebooks table** (ML-5..9): new **« Jumeau Python »** column. ML-5/7/9 link to their co-located `-Python.ipynb`; ML-6 = N/A (co-bridge, .NET-centric by nature); ML-8 = N/A (already covered by 02-ML-Cours/2.6-Clustering).

### Intermédiaire `ML/README.md`
- Framing **« 2 stacks » → « 3 fils »** (ML.NET natif / DataScienceWithAgents agentique / jumeaux de parité sklearn) — third bullet for the parity twins with concept mappings + link to the ML.Net feuille.

## Decisions documented (G.9 firsthand)
| Notebook | Port? | Rationale |
|----------|-------|-----------|
| ML-9 / ML-7 / ML-5 | ✅ merged (#5263/#5265/#5266) | genuine gaps vs 02-ML-Cours |
| ML-6-ONNX | ❌ SKIP | multi-language bridge notebook; a Python twin strips the .NET half that is its whole point |
| ML-8-Clustering | ❌ SKIP | dedup vs 02-ML-Cours/2.6-Clustering-KMeans-PCA |
| ML-1..4 | ❌ not ported | fundamentals already covered in 02-ML-Cours (Intro/Data/AutoML/Eval) → Python twin = redite |
| TP-prevision-ventes | deferred | capstone depends on ML-5 |

→ **Clean-ports ML.Net→Python = 3/N done.** Recommendation to ai-01: declare clean-ports close (option (a)); pivot #4956 toward another Python family or cross-lane pool.

## Catalog hygiene
`CATALOG-STATUS` markers left **byte-identical** (catalog-pr-hygiene HARD rule — they are automation property). The count drift (`ML.Net=10 → 13`, `pedagogical_count: 37 → 40`) is **cron-owned**, self-heals via `catalog-cron.yml` < 24h. No manual edit.

## Validation
- 2 files, +13/-10 (well above Rule-E doc-PR floor; single coherent subject)
- All 4 link targets verified to exist on origin/main (3 `-Python.ipynb` + `2.6-Clustering`)
- CATALOG-STATUS / series / breakdown / maturity lines untouched (grep-verified)
- FR-first (no EN new content)

See #4956