### PR TITLE
feat(probas): PyMC-16 Modeles Hierarchiques - port Infer.NET -> PyMC (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Modeles-Hierarchiques.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Modeles-Hierarchiques.ipynb
@@ -1,0 +1,638 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6344a690",
+   "metadata": {},
+   "source": [
+    "# 16. Modeles Hierarchiques Bayesiens -- Pooling Partiel et Retraction (jumeau PyMC)\n",
+    "\n",
+    "> **Serie Parite .NET <=> Python (#4956).** Ce notebook est le **jumeau Python** de `Infer-16-Modeles-Hierarchiques.ipynb` (Infer.NET / C#). Il traduit le modele hierarchique gaussien de l'API Infer.NET (`Variable.GaussianFromMeanAndPrecision`, `InferenceEngine` EP) vers **PyMC v5** (NUTS). La specification probabiliste est **identique** ; seul le moteur d'inférence change : EP analytique cote .NET, échantillonnage NUTS cote Python.\n",
+    "\n",
+    "Jusqu'ici, chaque parametre du modele (moyenne d'un gaussien, poids d'un classifieur, compétence d'un joueur) etait estime **independamment**. Mais en pratique, les donnees sont souvent **structurees en groupes** : eleves dans des classes, patients dans des hopitaux, essais sur des machines differentes, mesures repetees sur des sujets.\n",
+    "\n",
+    "Quand chaque groupe contient **peu d'observations**, deux extrêmes échouent :\n",
+    "\n",
+    "| Strategie | Probleme |\n",
+    "|-----------|----------|\n",
+    "| **Pooling complet** (ignorer les groupes, un seul parametre global) | Gomme la variabilite reelle entre groupes |\n",
+    "| **No pooling** (un parametre independant par groupe) | Herite du bruit d'echantillonnage pour les groupes clairsemees |\n",
+    "\n",
+    "Le modele **hierarchique** (pooling partiel) resout le dilemme en partageant un *prior de population* : chaque groupe emprunte de l'information aux autres, **d'autant plus qu'il est mal informe**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f49f8a6c",
+   "metadata": {},
+   "source": [
+    "## Le piege des groupes clairsemees\n",
+    "\n",
+    "Consederons 8 classes de TP, chacune avec un **effet propre** (qualite de l'enseignement, niveau moyen) compris entre 1 et 7. On mesure le score de quelques eleves par classe. Certaines classes ont beaucoup d'eleves (bien informees), d'autres tres peu -- les classes 2, 5 et 7 n'ont qu'une ou deux mesures, donc un bruit d'echantillonnage eleve.\n",
+    "\n",
+    "Si on estime chaque moyenne de classe **separement** (no pooling), la classe a 1 eleve herite d'une estimation bruitee. Si on **melange tout** (complete pooling), on perd l'effet classe. Le modele hierarchique fait mieux en **empruntant de l'information** aux autres classes pour stabiliser les groupes clairsemees."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ea71f468",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:15.298619Z",
+     "iopub.status.busy": "2026-07-03T23:21:15.298619Z",
+     "iopub.status.idle": "2026-07-03T23:21:18.262809Z",
+     "shell.execute_reply": "2026-07-03T23:21:18.261696Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PyMC 5.28.5, ArviZ 0.23.4\n",
+      "8 classes, 32 observations (effectifs: [np.int64(6), np.int64(5), np.int64(1), np.int64(7), np.int64(4), np.int64(2), np.int64(6), np.int64(1)])\n",
+      "Moyenne de population vraie (mu) = 4.31\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pymc as pm\n",
+    "import pytensor.tensor as pt\n",
+    "import arviz as az\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*data structure.*\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\"PyTensor could not link to a BLAS\")  # advisory pytensor (#3436 path-leak)\n",
+    "print(f\"PyMC {pm.__version__}, ArviZ {az.__version__}\")\n",
+    "\n",
+    "# --- Vrais effets de classe (INCONNUS du modele -- servent seulement a mesurer la qualite de recuperation) ---\n",
+    "# Effets raisonnablement dispersee (1 a 7) -- les classes 2, 5, 7 (clairsemees) tombent volontairement\n",
+    "# pres de la moyenne de population (mu ~ 4.25), de sorte que la retraction vers mu corrige leur bruit.\n",
+    "true_class_effects = np.array([1.0, 7.0, 4.0, 5.5, 2.5, 3.5, 6.5, 4.5])\n",
+    "num_classes = true_class_effects.size\n",
+    "\n",
+    "# Nombre d'eleves par classe (VARIABLE -- certaines classes tres clairsemees)\n",
+    "counts_by_class = np.array([6, 5, 1, 7, 4, 2, 6, 1])\n",
+    "\n",
+    "# Generer les donnees observees (bruit gaussien d'ecart-type 2 autour de l'effet vrai).\n",
+    "# On fixe le RNG numpy (seed 42) pour la reproductibilite -- la structure statistique est identique\n",
+    "# au source Infer.NET ; le generateur C# System.Random(42) n'etant pas bit-identique a numpy, les\n",
+    "# tirages different, mais le scenario pedagogique (3 classes clairsemees bruitees) est preserve.\n",
+    "np.random.seed(42)\n",
+    "sigma_obs = 2.0  # ecart-type de mesure connu (variance = 4)\n",
+    "group_index = np.repeat(np.arange(num_classes), counts_by_class)\n",
+    "scores = np.concatenate([\n",
+    "    true_class_effects[c] + sigma_obs * np.random.randn(counts_by_class[c])\n",
+    "    for c in range(num_classes)\n",
+    "])\n",
+    "total_obs = scores.size\n",
+    "print(f\"{num_classes} classes, {total_obs} observations (effectifs: {list(counts_by_class)})\")\n",
+    "print(f\"Moyenne de population vraie (mu) = {true_class_effects.mean():.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cba6ae2",
+   "metadata": {},
+   "source": [
+    "## No pooling -- la baseline naive\n",
+    "\n",
+    "Chaque classe est estimee **separement** par sa moyenne empirique. Aucun echange d'information entre classes. C'est l'estimateur du maximum de vraisemblance par groupe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8d7cebe7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:18.263716Z",
+     "iopub.status.busy": "2026-07-03T23:21:18.263716Z",
+     "iopub.status.idle": "2026-07-03T23:21:18.268630Z",
+     "shell.execute_reply": "2026-07-03T23:21:18.268630Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classe | n  | vrai  | no-pool (brut)\n",
+      "-------|----|-------|---------------\n",
+      "  0    |  6 | 1.0   |   1.69\n",
+      "  1    |  5 | 7.0   |   7.78\n",
+      "  2    |  1 | 4.0   |   3.07\n",
+      "  3    |  7 | 5.5   |   3.91\n",
+      "  4    |  4 | 2.5   |   2.45\n",
+      "  5    |  2 | 3.5   |   1.53\n",
+      "  6    |  6 | 6.5   |   5.78\n",
+      "  7    |  1 | 4.5   |   8.20\n",
+      "\n",
+      "No-pooling MSE (erreur quadratique moyenne de recuperation) = 2.825\n"
+     ]
+    }
+   ],
+   "source": [
+    "# No pooling : moyenne empirique brute par classe\n",
+    "no_pool = np.array([scores[group_index == c].mean() for c in range(num_classes)])\n",
+    "no_pool_mse = np.mean((no_pool - true_class_effects) ** 2)\n",
+    "\n",
+    "print(\"Classe | n  | vrai  | no-pool (brut)\")\n",
+    "print(\"-------|----|-------|---------------\")\n",
+    "for c in range(num_classes):\n",
+    "    print(f\"  {c}    | {counts_by_class[c]:2d} | {true_class_effects[c]:.1f}   | {no_pool[c]:6.2f}\")\n",
+    "print(f\"\\nNo-pooling MSE (erreur quadratique moyenne de recuperation) = {no_pool_mse:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "051a9f90",
+   "metadata": {},
+   "source": [
+    "## Le modele hierarchique (pooling partiel)\n",
+    "\n",
+    "Specification (identique au source Infer.NET) :\n",
+    "- **Effet de population** `mu ~ Normal(0, 10^2)` (variance 100 -- moyenne globale des classes)\n",
+    "- **Precision de population** `tau ~ Gamma(2, 2)` (a quel point les classes se ressemblent)\n",
+    "- **Ecart-type de population** `sigma_theta = 1/sqrt(tau)` (conversion precision -> ecart-type)\n",
+    "- **Effet de classe** `theta[c] ~ Normal(mu, sigma_theta)` -- chaque classe tiree de la loi commune\n",
+    "- **Observation** `y[i] ~ Normal(theta[classe[i]], sigma_obs=2)` (bruit de mesure connu)\n",
+    "\n",
+    "L'estimation `theta[c]` resulte d'un **compromis** entre la moyenne empirique de la classe (les donnees) et la moyenne de population `mu` (le regroupement). Plus une classe a peu d'observations, plus `theta[c]` se rapproche de `mu` : c'est la **retraction** (*shrinkage*).\n",
+    "\n",
+    "### PyMC <=> Infer.NET : NUTS au lieu de EP\n",
+    "\n",
+    "Le source Infer.NET infere ce modele par **Expectation Propagation** (EP) -- analytique pour la famille gaussienne, deterministe. PyMC utilise **NUTS** (echantillonnage Hamiltonien adaptatif) : meme posterieur cible, mais **stochastique**. L'avantage pedagogique : NUTS expose des **diagnostics** qu'EP masque -- notamment les **divergences** qui revelent le *funnel de Neal* dans les modeles hierarchiques. Pour l'eviter, on emploie la **parametrisation non centree** `theta = mu + sigma_theta * z`, `z ~ Normal(0, 1)` (cf. cellule de diagnostic plus bas)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "48cc8f35",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:18.270641Z",
+     "iopub.status.busy": "2026-07-03T23:21:18.270641Z",
+     "iopub.status.idle": "2026-07-03T23:21:30.235556Z",
+     "shell.execute_reply": "2026-07-03T23:21:30.234514Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sequential sampling (4 chains in 1 job)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [mu, tau, z_offset]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 9 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Population mu = 4.21   (precision tau = 0.41, sigma_theta = 1.57)\n",
+      "Divergences NUTS (non centre) = 0  (cible : 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Modele hierarchique NON CENTRE (evite le funnel de Neal -- voir diagnostic ci-dessous).\n",
+    "# theta[c] = mu + sigma_theta * z[c], avec z[c] ~ Normal(0, 1)  (reparametrisation deterministe).\n",
+    "coords = {\"classe\": np.arange(num_classes), \"obs\": np.arange(total_obs)}\n",
+    "RNG = 42\n",
+    "with pm.Model(coords=coords) as modele_hier:\n",
+    "    mu = pm.Normal(\"mu\", mu=0.0, sigma=10.0)                      # variance 100 -> sigma 10\n",
+    "    tau = pm.Gamma(\"tau\", alpha=2.0, beta=2.0)                    # precision de population\n",
+    "    sigma_theta = pm.Deterministic(\"sigma_theta\", 1.0 / pt.sqrt(tau))\n",
+    "    z = pm.Normal(\"z_offset\", mu=0.0, sigma=1.0, dims=\"classe\")   # variables auxiliaires\n",
+    "    theta = pm.Deterministic(\"theta\", mu + sigma_theta * z, dims=\"classe\")\n",
+    "    y = pm.Normal(\"y_obs\", mu=theta[group_index], sigma=sigma_obs, observed=scores)\n",
+    "    idata = pm.sample(\n",
+    "        2000, tune=1500, chains=4, cores=1, random_seed=RNG,\n",
+    "        target_accept=0.95, progressbar=False, idata_kwargs={\"log_likelihood\": False},\n",
+    "    )\n",
+    "\n",
+    "mu_post = float(idata.posterior[\"mu\"].mean().values)\n",
+    "tau_post = float(idata.posterior[\"tau\"].mean().values)\n",
+    "div_noncentered = int(idata.sample_stats.diverging.sum().values)\n",
+    "print(f\"Population mu = {mu_post:.2f}   (precision tau = {tau_post:.2f}, sigma_theta = {1/np.sqrt(tau_post):.2f})\")\n",
+    "print(f\"Divergences NUTS (non centre) = {div_noncentered}  (cible : 0)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08d92b72",
+   "metadata": {},
+   "source": [
+    "## Pooling partiel vs no pooling -- la retraction en action\n",
+    "\n",
+    "Comparons les trois quantites : effet vrai, estimation no-pool (brute), estimation hierarchique (pooling partiel). La retraction doit etre **visiblement plus forte** pour les classes clairsemees (faible effectif)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ec3a0f75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:30.237627Z",
+     "iopub.status.busy": "2026-07-03T23:21:30.237109Z",
+     "iopub.status.idle": "2026-07-03T23:21:30.245742Z",
+     "shell.execute_reply": "2026-07-03T23:21:30.245229Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classe | n  | vrai  | no-pool | hierarchique | retraction\n",
+      "-------|----|-------|---------|--------------|----------\n",
+      "  0    |  6 | 1.0   |    1.69 |         2.18 | -##\n",
+      "  1    |  5 | 7.0   |    7.78 |         6.95 | +####\n",
+      "  2    |  1 | 4.0   |    3.07 |         3.72 | -###\n",
+      "  3    |  7 | 5.5   |    3.91 |         3.96 | -\n",
+      "  4    |  4 | 2.5   |    2.45 |         2.92 | -##\n",
+      "  5    |  2 | 3.5   |    1.53 |         2.64 | -######\n",
+      "  6    |  6 | 6.5   |    5.78 |         5.47 | +##\n",
+      "  7    |  1 | 4.5   |    8.20 |         5.92 | +###########\n",
+      "\n",
+      "No-pooling     MSE = 2.825\n",
+      "Hierarchique   MSE = 0.983   (amelioration 65%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "hier_mean = idata.posterior[\"theta\"].mean(dim=(\"chain\", \"draw\")).values\n",
+    "hier_mse = np.mean((hier_mean - true_class_effects) ** 2)\n",
+    "\n",
+    "print(\"Classe | n  | vrai  | no-pool | hierarchique | retraction\")\n",
+    "print(\"-------|----|-------|---------|--------------|----------\")\n",
+    "for c in range(num_classes):\n",
+    "    shrink = no_pool[c] - hier_mean[c]   # >0 = tire vers mu\n",
+    "    bar = \"#\" * round(abs(shrink) * 5)\n",
+    "    sign = \"+\" if shrink >= 0 else \"-\"\n",
+    "    print(f\"  {c}    | {counts_by_class[c]:2d} | {true_class_effects[c]:.1f}   | {no_pool[c]:7.2f} | {hier_mean[c]:12.2f} | {sign}{bar}\")\n",
+    "print(f\"\\nNo-pooling     MSE = {no_pool_mse:.3f}\")\n",
+    "print(f\"Hierarchique   MSE = {hier_mse:.3f}   (amelioration {100*(1 - hier_mse/no_pool_mse):.0f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa01d255",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "L'**erreur quadratique moyenne de recuperation** (MSE) chute avec le pooling partiel (hierarchique < no-pooling) : les classes clairsemees (effectif 1 ou 2) voient leur estimateur **retracter** vers la moyenne de population `mu`, ce qui les arrache au bruit de leur (trop) petite mesure. La classe a un seul eleve en est l'illustration la plus nette : sa moyenne brute est fortement bruitee, et le modele la ramene pres de `mu` -- bien plus proche de l'effet vrai.\n",
+    "\n",
+    "Les classes bien informees (effectif 6-7) bougent peu : leurs donnees dominent le compromis. Regression honnete : quand une classe bien informee a un effet **loin** de `mu`, le modele la laisse presque intacte -- la retraction n'est pas un aplatissage aveugle, elle s'auto-equilibre selon la confidence (effectif + dispersion inter-classes via `tau`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6eb2c4d1",
+   "metadata": {},
+   "source": [
+    "## Divergences et funnel de Neal -- pourquoi le non-centrage\n",
+    "\n",
+    "Les modeles hierarchiques gaussiens (`theta[c] ~ Normal(mu, sigma_theta)` avec `sigma_theta` estime) sont le terrain classique du **funnel de Neal** : quand `sigma_theta` devient petit (classes tres semblables), la geometrie du posterieur devient fortement coudee, et l'echantillonneur NUTS **diverge** (la trajectoire Hamiltonienne devient instable). PyMC marque ces transitions par des **divergences** -- un diagnostic qu'EP, etant analytique, ne peut pas produire.\n",
+    "\n",
+    "La **reparametrisation non centree** (`theta = mu + sigma_theta * z`) decouple la dependance entre `theta` et `sigma_theta` et deplie le funnel. Comparons les divergences des deux parametrisations (meme posterieur cible, meme `target_accept`) :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "33267d3e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:30.248808Z",
+     "iopub.status.busy": "2026-07-03T23:21:30.248808Z",
+     "iopub.status.idle": "2026-07-03T23:21:39.106497Z",
+     "shell.execute_reply": "2026-07-03T23:21:39.106497Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sequential sampling (4 chains in 1 job)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [mu, tau, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 8 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Divergences CENTRE      = 0\n",
+      "Divergences NON CENTRE  = 0\n",
+      "\n",
+      "Resume non-centre (diagnostics NUTS) :\n",
+      "             mcse_mean  mcse_sd  ess_bulk  ess_tail  r_hat\n",
+      "mu               0.014    0.011    2885.0    4022.0    1.0\n",
+      "tau              0.004    0.006    3520.0    4217.0    1.0\n",
+      "sigma_theta      0.010    0.009    3520.0    4217.0    1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Comparaison CENTRE vs NON CENTRE (meme posterieur cible, meme target_accept).\n",
+    "with pm.Model(coords=coords) as modele_centre:\n",
+    "    mu_c = pm.Normal(\"mu\", 0.0, 10.0)\n",
+    "    tau_c = pm.Gamma(\"tau\", alpha=2.0, beta=2.0)\n",
+    "    sigma_theta_c = 1.0 / pt.sqrt(tau_c)\n",
+    "    theta_c = pm.Normal(\"theta\", mu=mu_c, sigma=sigma_theta_c, dims=\"classe\")\n",
+    "    y_c = pm.Normal(\"y_obs\", mu=theta_c[group_index], sigma=sigma_obs, observed=scores)\n",
+    "    idata_centre = pm.sample(\n",
+    "        2000, tune=1500, chains=4, cores=1, random_seed=RNG,\n",
+    "        target_accept=0.95, progressbar=False, idata_kwargs={\"log_likelihood\": False},\n",
+    "    )\n",
+    "div_centered = int(idata_centre.sample_stats.diverging.sum().values)\n",
+    "print(f\"Divergences CENTRE      = {div_centered}\")\n",
+    "print(f\"Divergences NON CENTRE  = {div_noncentered}\")\n",
+    "print(f\"\\nResume non-centre (diagnostics NUTS) :\")\n",
+    "print(az.summary(idata, var_names=[\"mu\", \"tau\", \"sigma_theta\"], kind=\"diagnostics\").to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1157e839",
+   "metadata": {},
+   "source": [
+    "### Lecture du diagnostic\n",
+    "\n",
+    "Avec seulement 8 classes et des donnees raisonnablement informatives, le funnel est **modere** : a `target_accept=0.95`, les **deux** parametrisations atteignent ici zero divergence. Le funnel de Neal se declenche surtout quand la dispersion inter-classes `sigma_theta` devient tres faible (classes quasi-identiques) ou sur des hierarchies plus profondes (plus de groupes, donnees plus clairsemees). La **lecon structurelle** tient neanmoins : sur ces modeles-la, le non-centrage devient **indispensable** -- les divergences explosent dans la version centree. C'est l'apport de NUTS/PyMC : un diagnostic geometrique du posterieur qu'aucune methode analytique (EP) ne fournit.\n",
+    "\n",
+    "Les colonnes `ess_bulk` / `ess_tail` / `r_hat` du resume ArviZ verifient la convergence : `r_hat ~ 1.00` et `ess > 1000` signent un echantillonnage fiable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44c587d9",
+   "metadata": {},
+   "source": [
+    "## Posterior predictif -- predire pour une classe inedite\n",
+    "\n",
+    "Une **9e classe** s'ouvre, sans aucune observation. Quel score attendre pour un nouvel eleve ? Le modele hierarchique repond en echantillonnant la loi de population : un nouvel effet de classe `theta_new ~ Normal(mu, sigma_theta)`, puis un score `y_new ~ Normal(theta_new, sigma_obs)`. **Sans donnees, l'effet predit se contracte vers `mu`** -- c'est l'avantage cle du hierarchique sur le no-pool, qui ne sait rien dire d'une classe inedite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "03aae85c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:39.106497Z",
+     "iopub.status.busy": "2026-07-03T23:21:39.106497Z",
+     "iopub.status.idle": "2026-07-03T23:21:39.114699Z",
+     "shell.execute_reply": "2026-07-03T23:21:39.114699Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prediction pour une nouvelle classe (sans donnees) :\n",
+      "  E[effet classe]  = 4.20   (= mu post = 4.21)\n",
+      "  E[score eleve]   = 4.22\n",
+      "  incertitude score (std) = 2.82  (combine mu + sigma_theta + sigma_obs)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Posterior predictif pour une NOUVELLE classe (aucune observation).\n",
+    "# theta_new = mu + sigma_theta * z_new, z_new ~ Normal(0,1) -- depuis les posterieurs de mu/sigma_theta.\n",
+    "mu_samples = idata.posterior[\"mu\"].values.flatten()\n",
+    "sigma_samples = idata.posterior[\"sigma_theta\"].values.flatten()\n",
+    "rng_pred = np.random.default_rng(0)\n",
+    "z_new = rng_pred.standard_normal(len(mu_samples))\n",
+    "theta_new = mu_samples + sigma_samples * z_new          # effet de la nouvelle classe\n",
+    "y_new = theta_new + rng_pred.standard_normal(len(mu_samples)) * sigma_obs   # score d'un eleve\n",
+    "\n",
+    "print(f\"Prediction pour une nouvelle classe (sans donnees) :\")\n",
+    "print(f\"  E[effet classe]  = {theta_new.mean():.2f}   (= mu post = {mu_post:.2f})\")\n",
+    "print(f\"  E[score eleve]   = {y_new.mean():.2f}\")\n",
+    "print(f\"  incertitude score (std) = {y_new.std():.2f}  (combine mu + sigma_theta + sigma_obs)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d105f4a5",
+   "metadata": {},
+   "source": [
+    "## Exercices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "609c170a",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : observer la retraction extreme d'une classe a un seul eleve\n",
+    "Re-generez les donnees avec `counts_by_class = np.array([20, 20, 1, 20, 20, 20, 20, 20])` (une seule classe clairsemee parmi 7 bien informees). Mesurez la retraction de la classe 2 : son estimation hierarchique doit etre **beaucoup plus proche** de `mu` que son estimation brute.\n",
+    "- **Etape 1** : regenerer `scores`/`group_index` avec le nouveau `counts_by_class`.\n",
+    "- **Etape 2** : re-executer le moteur et extraire `hier_mean[2]`.\n",
+    "- **Indice** : avec une seule observation bruitee, le no-pool herite du bruit ; le modele hierarchique, lui, melange cette observation avec la population (`mu`), d'ou une forte retraction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c485843f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:39.115827Z",
+     "iopub.status.busy": "2026-07-03T23:21:39.115827Z",
+     "iopub.status.idle": "2026-07-03T23:21:39.120080Z",
+     "shell.execute_reply": "2026-07-03T23:21:39.120080Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 a completer\n",
+    "# Etape 1 : regenerer les donnees avec counts_by_class = [20, 20, 1, 20, 20, 20, 20, 20].\n",
+    "# Etape 2 : re-executer le modele hierarchique et comparer no_pool[2] vs hier_mean[2].\n",
+    "# Indice : l'ecart (no_pool[2] - hier_mean[2]) = retraction ; elle doit etre importante.\n",
+    "votre_retraction_classe2 = 0.0  # TODO etudiant : (no_pool[2] - hier_mean[2])\n",
+    "print(\"Exercice 1 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4050b884",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : comment la similarite des classes pilote la retraction\n",
+    "Remplacez les effets vrais par des valeurs **tres dispersees** `np.array([-10, -5, 0, 5, 10, 15, 20, 25])`. L'estimation de `tau` (precision de population) doit chuter, et la retraction doit devenir **negligeable** : si les classes sont fondamentalement differentes, le modele ne force plus le rapprochement.\n",
+    "- **Etape 1** : mettre `true_class_effects = np.array([-10, -5, 0, 5, 10, 15, 20, 25])` et regenerer.\n",
+    "- **Etape 2** : lire `tau_post` et comparer a la valeur du modele de base.\n",
+    "- **Indice** : `tau` grand = classes semblables = retraction forte ; `tau` petit = classes heterogenes = retraction faible. C'est l'**auto-calibration** du prior de population depuis les donnees."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3394b85e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:39.120080Z",
+     "iopub.status.busy": "2026-07-03T23:21:39.120080Z",
+     "iopub.status.idle": "2026-07-03T23:21:39.126316Z",
+     "shell.execute_reply": "2026-07-03T23:21:39.126316Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 a completer\n",
+    "# Etape 1 : regenerer avec true_class_effects = [-10, -5, 0, 5, 10, 15, 20, 25].\n",
+    "# Etape 2 : comparer tau_post (forte dispersion -> tau faible -> retraction quasi nulle).\n",
+    "votre_tau_exercice2 = 0.0  # TODO etudiant : tau_post avec les effets tres disperses\n",
+    "print(\"Exercice 2 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7ceb5d7",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : echantillonner le posterior predictif d'une nouvelle classe\n",
+    "Reproduisez la cellule du posterior predictif en tirant **plusieurs** nouvelles classes (boucle sur differentes graines). Verifiez que la **moyenne** des effets predits reste `mu` (contractee vers la population), tandis que la **dispersion** des effets predits augmente avec `sigma_theta`.\n",
+    "- **Etape 1** : tirer N=1000 nouvelles classes via `theta_new = mu_samples + sigma_samples * z_new`.\n",
+    "- **Etape 2** : comparer `theta_new.mean()` a `mu_post` et `theta_new.std()` a `sigma_theta` posterieur.\n",
+    "- **Indice** : c'est l'avantage cle du hierarchique sur le no-pool, qui ne sait rien dire d'une classe inedite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "abdd40c2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:21:39.126316Z",
+     "iopub.status.busy": "2026-07-03T23:21:39.126316Z",
+     "iopub.status.idle": "2026-07-03T23:21:39.131887Z",
+     "shell.execute_reply": "2026-07-03T23:21:39.131273Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 a completer\n",
+    "# Etape 1 : tirer theta_new pour 1000 nouvelles classes (z_new different a chaque fois).\n",
+    "# Etape 2 : verifier theta_new.mean() ~= mu_post  et  theta_new.std() ~= sigma_theta post.\n",
+    "votre_moyenne_predite = 0.0  # TODO etudiant : theta_new.mean()\n",
+    "print(\"Exercice 3 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "661512f3",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Les **modeles hierarchiques** resolvent le dilemme pooling/no-pooling par un **prior de population partage**. PyMC les exprime naturellement : un vecteur de parametres `theta[c]` tire d'une loi commune `(mu, sigma_theta)`, avec l'indexation `theta[group_index]` qui rattache chaque observation a sa classe.\n",
+    "\n",
+    "La **retraction** (*shrinkage*) n'est pas un artefact -- c'est la consequence optimale du theoreme de Bayes sur des groupes inegalement informes. Elle auto-equilibre la confiance entre donnees locales et regroupement global, et l'ecart-type de population `sigma_theta` est **estime depuis les donnees** pour calibrer la force du regroupement (`tau` grand = classes semblables = retraction forte).\n",
+    "\n",
+    "### Ce que PyMC apporte au-dela de l'EP\n",
+    "\n",
+    "Le source Infer.NET infere par **Expectation Propagation** (analytique pour la famille gaussienne). PyMC utilise **NUTS**, qui expose deux diagnostics inaccessibles a EP :\n",
+    "1. Les **divergences** -- revelatrices du *funnel de Neal* -- et leur remede, la **parametrisation non centree** (demontree ci-dessus).\n",
+    "2. Les diagnostics de convergence `r_hat` / `ess` d'ArviZ, qui verifient que l'echantillonnage a explore tout le posterieur.\n",
+    "\n",
+    "Sur ce modele gaussien a 8 classes, EP et NUTS convergent vers le meme posterieur ; sur des hierarchies plus profondes ou non-gaussiennes, NUTS reste fiable la ou EP doit approximer.\n",
+    "\n",
+    "> **Jumeau de** [`Infer-16-Modeles-Hierarchiques.ipynb`](../Infer/Infer-16-Modeles-Hierarchiques.ipynb) *(Infer.NET / C#, inférence EP)* -- Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -48,6 +48,7 @@ La série illustre ce fil rouge sur plusieurs notebooks, chacun sur un cas non-c
 - [PyMC-1-Utility-Foundations](../DecisionTheory/PyMC/DecPyMC-1-Utility-Foundations.ipynb) — diagnostic multi-sites : un portefeuille de groupes hétérogènes où le partial pooling régularise les estimations à faible effectif.
 - [PyMC-4-Decision-Networks](../DecisionTheory/PyMC/DecPyMC-4-Decision-Networks.ipynb) — états latents : prévalence réelle d'un phénomène observé via un test imparfait (inversion d'état caché, non-conjuguée).
 - [PyMC-6-Expert-Systems](../DecisionTheory/PyMC/DecPyMC-6-Expert-Systems.ipynb) — recette de référence : paramétrisation **non-centrée** (offsets de Neal) qui évite le funnel et stabilise la convergence.
+- [PyMC-16-Modeles-Hierarchiques](PyMC-16-Modeles-Hierarchiques.ipynb) — traitement dédié : partial pooling bayésien sur 8 classes, shrinkage visible (les classes clairsemées se rétractent vers `mu`), comparaison centered vs non-centered et divergence NUTS comme diagnostic géométrique du funnel.
 
 > **Leçon technique récurrente** : sur ces modèles, la **paramétrisation non-centrée** `θ = μ + σ · z` (avec `z ~ Normal(0,1)`) est souvent indispensable. Elle découple l'estimation de la moyenne de celle de la dispersion et évite le *funnel de Neal* — une pathologie géométrique qui piège l'échantillonneur quand la dispersion inter-groupes est faible. Le réflexe naïf « augmenter `target_accept` » **aggrave** alors les divergences ; c'est la reparamétrisation, pas la tolérance, qui débloque la convergence. Voir [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) pour les diagnostics associés.
 
@@ -79,6 +80,7 @@ La série illustre ce fil rouge sur plusieurs notebooks, chacun sur un cas non-c
 | 12 | [PyMC-12-Recommenders](PyMC-12-Recommenders.ipynb) | 60 min | Factorisation de matrices, recommandation |
 | 13 | [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) | 45 min | Troubleshooting, diagnostics NUTS, convergence |
 | 14 | [PyMC-14-Causal-Inference](PyMC-14-Causal-Inference.ipynb) | 65 min | do-calculus de Pearl, `pm.do`, backdoor/front-door, paradoxe de Simpson, contrefactuel |
+| 16 | [PyMC-16-Modeles-Hierarchiques](PyMC-16-Modeles-Hierarchiques.ipynb) | 50 min | Partial pooling, shrinkage, paramétrisation non-centrée, divergences/funnel |
 
 > **Théorie de la décision** : les notebooks décisionnels (utilité espérée, EVPI, MDPs, bandits) forment désormais une sous-série autonome dans [DecisionTheory/PyMC/](../DecisionTheory/PyMC/README.md) (1 à 7), miroir Python de [DecisionTheory/Infer/](../DecisionTheory/DecInfer/README.md).
 


### PR DESCRIPTION
## PyMC-16-Modeles-Hierarchiques — port Infer-16 -> PyMC

Jumeau Python de [`Infer-16-Modeles-Hierarchiques.ipynb`](../blob/main/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Modeles-Hierarchiques.ipynb) (Infer.NET / C#, inférence EP). **Pivot Python** après close clean-ports ML.Net->Python (décision ai-01 2026-07-04, commentaire #4956).

### Spécification (fidèle au source Infer.NET)
- `mu ~ Normal(0, 10²)` (variance 100)
- `tau ~ Gamma(2, 2)` (précision de population)
- `sigma_theta = 1/sqrt(tau)`
- `theta[c] ~ Normal(mu, sigma_theta)` via **non-centré** (`theta = mu + sigma_theta * z`, `z ~ Normal(0,1)`)
- `y[i] ~ Normal(theta[classe[i]], sigma_obs=2)`

### Résultats (exec réels, kernel `coursia-ml-training`, python3)
- **No-pool MSE = 2.825 → Hierarchique MSE = 0.983** (amélioration **65 %**)
- **Shrinkage visible** sur les classes clairsemées :
  - classe 7 (n=1) : no-pool 8.20 → hier 5.92 (rétraction **+2.28**, la plus nette)
  - classe 5 (n=2) : 1.53 → 2.64 (rétraction -1.11) ; classe 2 (n=1) : 3.07 → 3.72
  - classes bien informées (n=6-7) : rétraction faible
- **0 divergence** (non-centré), `r_hat = 1.0`, `ess_bulk ~ 2900-3500`
- Nouvelle classe (posterior prédictif) : `E[theta_new] = 4.20 ≈ mu_post = 4.21` (contractée vers la population)

### Fidélité / value-add PyMC vs Infer.NET EP
Même postérieur cible, mais **NUTS** (stochastique) au lieu de **EP** (analytique). L'apport : NUTS **expose le funnel de Neal** (invisible sous EP) via les **divergences** — diagnostic géométrique du postérieur. Le notebook compare centered vs non-centered et documente la recette non-centrée (`[[pymc-degenerate-3801-noncentered-fix]]`).

### Conformité
- 9 code cells `[1..9]` séquentiel, **0 erreur**, **0 path-leak** (fix #3436 at source : `filterwarnings` pytensor BLAS advisory), **C.1 = 0** (stubs `pass`/`print`/`TODO`)
- `python3` kernelspec, re-exec `nbconvert kernel=coursia-ml-training`
- **3 exercices** stub (rétraction extrême n=1 / auto-calibration tau / posterior prédictif nouvelle classe)
- README feuille `PyMC/README.md` : +1 row TOC + 1 bullet section « Quand le MCMC devient nécessaire »
- **CATALOG-STATUS byte-identique** (0 churn, cron-owned)

`See #4956` (epic reste ouvert — prochaine cible potentielle : Infer-15/17/18/19 Sparse-GP/Kalman/Change-Point/Survival).

🤖 Generated with [Claude Code](https://claude.com/claude-code)