### PR TITLE
feat(lean): port Gittins Float→ℝ — close monotone_discount (#4039 Barrier B)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Basic.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Basic.lean
@@ -1,8 +1,12 @@
+import Mathlib.Data.Real.Basic
+
 /-!
 # Basic Definitions — Multi-Armed Bandits
 
 Core types for the bandit problem: arms, instances, policies, and value functions.
-No Mathlib dependency — pure Lean 4 definitions.
+Means and discount factors are carried on `ℝ` (not `Float`) so that order laws are
+reflexive — a bandit mean is a real number, never a `NaN`. Sampled reward histories
+stay `Float` (empirical quantities); the two notions are deliberately distinct.
 -/
 
 namespace Gittins
@@ -10,14 +14,12 @@ namespace Gittins
 /-- A bandit arm characterized by its true mean reward. -/
 structure BanditArm where
   name : String
-  trueMean : Float
-  deriving Repr
+  trueMean : ℝ
 
 /-- A bandit instance: a collection of arms with a discount factor. -/
 structure BanditInstance where
   arms : Array BanditArm
-  discount : Float  -- gamma in (0, 1)
-  deriving Repr
+  discount : ℝ  -- gamma in (0, 1)
 
 /-- A policy maps each time step to the index of the arm to pull. -/
 def Policy := Nat → Nat

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/GittinsTheorem.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/GittinsTheorem.lean
@@ -47,7 +47,7 @@ such that continuing to play the arm is better than retiring with that value.
     (e.g. Beta–Bernoulli) and the optimal-stopping / Bellman machinery that is
     absent from Mathlib. That barrier is recorded at `gittins_optimality` below
     (INTRINSIC, court-terme, #4039). -/
-def gittinsIndex (arm : BanditArm) (γ : Float) (history : RewardHistory) : Float :=
+def gittinsIndex (arm : BanditArm) (γ : ℝ) (history : RewardHistory) : ℝ :=
   arm.trueMean
 
 /-!
@@ -58,17 +58,17 @@ is optimal for the discounted infinite-horizon multi-armed bandit.
 -/
 
 /-- A Gittins index policy: at each step, play the arm with highest Gittins index. -/
-def gittinsPolicy (inst : BanditInstance) (histories : Array RewardHistory) : Nat :=
+noncomputable def gittinsPolicy (inst : BanditInstance) (histories : Array RewardHistory) : Nat :=
   -- Argmax of the Gittins index over the arms (in the known-mean model this is
   -- the highest-`trueMean` arm, i.e. the greedy arm — correct for known arms).
   ((Array.range inst.arms.size).foldl
-    (fun (best : Nat × Float) i =>
+    (fun (best : Nat × ℝ) i =>
       match inst.arms[i]? with
       | none => best
       | some arm =>
         let g := gittinsIndex arm inst.discount (histories[i]?.getD [])
         if g > best.2 then (i, g) else best)
-    (0, 0.0)).1
+    (0, 0)).1
 
 /-- **Gittins Index Theorem** (Gittins 1979, Weber 1992): the Gittins index
     policy maximizes the total expected discounted reward for the multi-armed
@@ -92,10 +92,10 @@ def gittinsPolicy (inst : BanditInstance) (histories : Array RewardHistory) : Na
     ~2000–5000 lines of supporting definitions; this is left as the INTRINSIC
     court-terme target rather than a degraded workaround.
 -/
-theorem gittins_optimality {γ : Float} (hγ : 0 < γ ∧ γ < 1)
+theorem gittins_optimality {γ : ℝ} (hγ : 0 < γ ∧ γ < 1)
     (inst : BanditInstance) :
     ∀ π : Policy,
-      let V (policy : Policy) : Float :=
+      let V (policy : Policy) : ℝ :=
         sorry
       V (fun _ => gittinsPolicy inst (Array.replicate inst.arms.size []))
         ≥
@@ -114,7 +114,7 @@ the index equals `trueMean`; the remaining open question is the MDP-gated
 /-- The Gittins index of a known arm (empty history — no posterior uncertainty)
     equals its true mean. Definitional in the known-mean model: the index is
     calibrated to the retirement value `μ`, independent of `history` and `γ`. -/
-theorem gittins_index_known_arm (arm : BanditArm) (γ : Float) :
+theorem gittins_index_known_arm (arm : BanditArm) (γ : ℝ) :
     gittinsIndex arm γ [] = arm.trueMean := by
   rfl
 
@@ -126,20 +126,16 @@ theorem gittins_index_known_arm (arm : BanditArm) (γ : Float) :
     value, absent for a known arm (`discount_monotone` in `Discount.lean` captures
     the `γ`-dependence of the *discounted value* on the `ℝ` side).
 
-    **Formalization subtlety (Float-order wart, NOT MDP-intrinsic, #4039).** After
-    `simp only [gittinsIndex]` the goal reduces to `arm.trueMean ≤ arm.trueMean`.
-    This is *not* provable as stated: `Float` follows IEEE 754, so `≤` is not
-    reflexive (`NaN ≤ NaN` is false — Lean core documents this at
-    `Init/Data/Float.lean`), there is no `Preorder Float` instance, and no
-    self-`≤` lemma exists in Lean core or Mathlib. Semantically a bandit mean is a
-    real number (never `NaN`); a clean proof would require either coercing
-    `BanditArm.trueMean` to `ℝ` (ripples across `Basic.lean`) or a non-`NaN` guard
-    plus a core lemma Lean lacks. This is a distinct, smaller barrier than the
-    MDP-gated `gittins_optimality` and is left `sorry`-backed honestly. -/
-theorem gittins_index_monotone_discount (arm : BanditArm) (γ₁ γ₂ : Float)
+    **Proven (#4039 Barrier B closed).** After the `Float → ℝ` port of
+    `BanditArm.trueMean` / `BanditInstance.discount`, the goal reduces to
+    `arm.trueMean ≤ arm.trueMean` on `ℝ`, which holds by reflexivity (`le_refl`).
+    The earlier `Float`-order wart (IEEE 754 `≤` not reflexive, no `Preorder Float`
+    instance) is gone: a bandit mean is a real number, never `NaN`. -/
+theorem gittins_index_monotone_discount (arm : BanditArm) (γ₁ γ₂ : ℝ)
     (h : γ₁ ≤ γ₂) :
     gittinsIndex arm γ₁ [] ≤ gittinsIndex arm γ₂ [] := by
-  sorry
+  simp only [gittinsIndex]
+  apply le_refl
 
 /-- For the 2-armed bandit, the Gittins policy outperforms the greedy policy. -/
 theorem gittins_beats_greedy (inst : BanditInstance)


### PR DESCRIPTION
## Summary

Close **Barrier B** of #4039 (the Float-order wart) by porting `BanditArm.trueMean` and
`BanditInstance.discount` from `Float` to `ℝ`. This makes `gittins_index_monotone_discount`
provable and reduces the sorry count 3 → 2. The README of #5074 names this as the clean fix;
this PR delivers it.

## Why the port is safe and atomic (c.208 had estimated it multi-day — that was based on a wrong
assumption that the companion notebook consumed the lake)

Firsthand re-check (G.1): `Infer-9-Lean-Gittins.ipynb` has **0 imports of the Gittins lake** — it is
fully self-contained (`abbrev Real := Float` + local struct/def re-definitions). The lake port has
**zero notebook ripple, zero re-exec**. Blast radius = 2 `.lean` files (22 ins / 24 del).

## The fix

`gittins_index_monotone_discount` previously reduced (after `simp [gittinsIndex]`) to
`arm.trueMean ≤ arm.trueMean` on `Float` — **not provable**: `Float` follows IEEE 754, `≤` is not
reflexive (`NaN ≤ NaN` is false), there is no `Preorder Float` instance (Lean core
`Init/Data/Float.lean`). On `ℝ`, the same goal holds by `le_refl`.

### `Gittins/Basic.lean`
- `import Mathlib.Data.Real.Basic` (was "No Mathlib dependency").
- `trueMean`, `discount`: `Float` → `ℝ`.
- Drop `deriving Repr` (`Real.instRepr` is unsafe; lake is proof-focused).
- `RewardHistory := List Float` and `empiricalMean` KEPT Float (sampled rewards ≠ model mean; the
  index def ignores history).

### `Gittins/GittinsTheorem.lean`
- Signatures `Float` → `ℝ` (gittinsIndex, gittins_optimality, known_arm, monotone_discount).
- `gittinsPolicy`: `Nat × Float` → `Nat × ℝ`; `noncomputable` (Real.decidableLT).
- **`gittins_index_monotone_discount`**: `sorry` → `by simp only [gittinsIndex]; apply le_refl`.

## Anti-régression (FX-7)

| File | sorry main | sorry branch |
|------|-----------|-------------|
| `GittinsTheorem.lean` | 3 | **2** (−1) |
| `Basic.lean` | 0 | 0 |

- The 2 proven sites stay proven (`gittinsIndex` definitional, `gittins_index_known_arm` = `rfl`).
- The 2 residual sorries (`V` + `gittins_optimality`, lines 99/103) = **Barrier A, MDP-INTRINSIC**:
  Mathlib lacks Bellman/optimal-stopping machinery (~2000–5000 lines). Documented honestly, NOT newly
  introduced.
- No previously-proven lemma replaced by `sorry`. Additive progress.
- `le_refl` introduces no new axioms (`Classical`-free, no `sorryAx`).

## Verification (lean-merge-discipline: lake build SUCCESS local)

- `lake build Gittins` (Windows-native `lake.exe`, rc1, Mathlib junctioned `d568c8c0`):
  **SUCCESS** (1648 jobs). Sole remaining warning = expected `declaration uses sorry` at
  `gittins_optimality` (Barrier A, MDP-INTRINSIC).
- Companion notebook untouched (self-contained, 0 imports of the lake).

See #4039 (partial: Barrier B closed; Barrier A MDP remains INTRINSIC research).

Co-Authored-By: Claude <noreply@anthropic.com>
