### PR TITLE
feat(probas): PyMC-18 Change-Point - port Infer.NET -> PyMC (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
@@ -1,0 +1,671 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "53395130",
+   "metadata": {},
+   "source": [
+    "# 18. Detection de Rupture (Change-Point) : inferer le moment d'un changement de regime (jumeau PyMC)\n",
+    "\n",
+    "> **Serie Parite .NET <=> Python (#4956).** Ce notebook est le **jumeau Python** de `Infer-18-Change-Point.ipynb` (Infer.NET / C#, inférence EP). La specification probabiliste est **identique** ; seul le moteur d'inférence change : EP analytique cote .NET, échantillonnage **CompoundStep** (NUTS + Metropolis) cote Python, car la localisation `cp` est une variable **discrète**.\n",
+    "\n",
+    "Ce notebook complète la famille des « séquences dans le temps » : il étend [PyMC-11 (Séquences / HMM)](PyMC-11-Sequences.ipynb) au cas où ce n'est pas l'état qui change à chaque instant, mais la **structure** du processus qui bascule **une seule fois** à un instant inconnu.\n",
+    "\n",
+    "**Durée estimée** : 50 minutes | **Prérequis** : [PyMC-11-Sequences](PyMC-11-Sequences.ipynb) (HMM)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8271b35b",
+   "metadata": {},
+   "source": [
+    "## 1. Motivation : la où le HMM et le filtre de Kalman s'arrêtent\n",
+    "\n",
+    "[PyMC-11](PyMC-11-Sequences.ipynb) modélise une séquence où l'état caché est **discret** et change à **chaque instant**. Le filtre de Kalman ([Infer-17](../Infer/Infer-17-Kalman-Filter.ipynb)) en est le pendant **continu**. Les deux infèrent un état **récurrent** — un par pas de temps.\n",
+    "\n",
+    "Le **point de rupture** est différent : l'inconnue n'est pas une trajectoire d'états, mais **un unique entier** `cp in {0, ..., N-1}` — l'indice où le processus bascule. On veut le postérieur $p(cp \\mid y)$ sur cette **unique** variable structurelle, et les paramètres des deux régimes qu'elle sépare."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b8f8f126",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:36:15.119011Z",
+     "iopub.status.busy": "2026-07-03T23:36:15.119011Z",
+     "iopub.status.idle": "2026-07-03T23:36:20.407124Z",
+     "shell.execute_reply": "2026-07-03T23:36:20.405971Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PyMC 5.28.5, ArviZ 0.23.4\n",
+      "Serie generee : N=100 points, vrai cp cache a t=50 (mu 2.0 -> 7.0, sigma=1.5)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pymc as pm\n",
+    "import pytensor.tensor as pt\n",
+    "import arviz as az\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*data structure.*\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\"PyTensor could not link to a BLAS\")  # advisory pytensor (#3436)\n",
+    "print(f\"PyMC {pm.__version__}, ArviZ {az.__version__}\")\n",
+    "\n",
+    "# --- Terrain de jeu : serie avec un SEUL changement de regime ---\n",
+    "# Le vrai point de rupture est CACHE ; on verifiera que le modele le recupere.\n",
+    "np.random.seed(42)\n",
+    "N = 100\n",
+    "vrai_cp = 50                      # vrai indice de rupture (inconnu du modele)\n",
+    "mu_avant, mu_apres = 2.0, 7.0     # moyennes des deux regimes\n",
+    "sigma = 1.5                       # bruit d'observation\n",
+    "t_idx = np.arange(N)\n",
+    "data = np.where(t_idx <= vrai_cp, mu_avant, mu_apres) + sigma * np.random.randn(N)\n",
+    "print(f\"Serie generee : N={N} points, vrai cp cache a t={vrai_cp} (mu {mu_avant} -> {mu_apres}, sigma={sigma})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3e24918",
+   "metadata": {},
+   "source": [
+    "## 2. Le modele de point de rupture gaussien\n",
+    "\n",
+    "On déclare `cp` comme un entier d'*a priori* uniforme sur `{0, ..., N-1}`, deux moyennes de segment (*a priori* gaussiens vagues) et une précision commune. Pour chaque instant `t`, on **branche** la vraisemblance selon la position de `cp` : gaussienne de moyenne `mean1` avant la rupture, `mean2` après. L'idiome PyMC est `pm.math.switch(t <= cp, mean1, mean2)` — equivalent exact du `Variable.If/IfNot(block.Index <= cp)` d'Infer.NET.\n",
+    "\n",
+    "### PyMC <=> Infer.NET : CompoundStep au lieu de EP\n",
+    "\n",
+    "Comme `cp` est **discrète** et les moyennes/précision **continues**, PyMC ne peut pas utiliser NUTS seul (NUTS exige des variables différentiables). Il compose automatiquement un **CompoundStep** : NUTS pour `(mean1, mean2, precision)` + Metropolis pour `cp`. EP, lui, propage les messages analytiquement sur le graphe de facteurs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "52d1acc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:36:20.410123Z",
+     "iopub.status.busy": "2026-07-03T23:36:20.409119Z",
+     "iopub.status.idle": "2026-07-03T23:36:45.647349Z",
+     "shell.execute_reply": "2026-07-03T23:36:45.636471Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sequential sampling (4 chains in 1 job)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "CompoundStep\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ">Metropolis: [cp]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ">NUTS: [mean1, mean2, precision]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 18 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Posterieur sur le point de rupture cp ===\n",
+      "  mode (argmax) = 50    (vrai cp cache = 50)\n",
+      "  moyenne       =  50.00\n",
+      "Moyenne avant  (mu1) :  1.676  (vrai 2.0)\n",
+      "Moyenne apres  (mu2) :  7.009  (vrai 7.0)\n",
+      "sigma estime        :  1.361  (vrai 1.5)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Modele de change-point gaussien ---\n",
+    "coords = {\"t\": t_idx}\n",
+    "with pm.Model(coords=coords) as modele_cp:\n",
+    "    cp = pm.DiscreteUniform(\"cp\", lower=0, upper=N - 1)           # localisation de la rupture\n",
+    "    mean1 = pm.Normal(\"mean1\", mu=0.0, sigma=10.0)                # variance 100 -> sigma 10\n",
+    "    mean2 = pm.Normal(\"mean2\", mu=0.0, sigma=10.0)\n",
+    "    precision = pm.Gamma(\"precision\", alpha=1.0, beta=1.0)        # mean 1\n",
+    "    sigma_det = pm.Deterministic(\"sigma_det\", 1.0 / pt.sqrt(precision))\n",
+    "    mu = pm.math.switch(t_idx <= cp, mean1, mean2)                # branchement avant/apres\n",
+    "    pm.Normal(\"y\", mu=mu, sigma=sigma_det, observed=data)\n",
+    "    idata_g = pm.sample(\n",
+    "        2000, tune=1500, chains=4, cores=1, random_seed=42,\n",
+    "        target_accept=0.95, progressbar=False, idata_kwargs={\"log_likelihood\": False},\n",
+    "    )\n",
+    "\n",
+    "cp_samples = idata_g.posterior[\"cp\"].values.flatten().astype(int)\n",
+    "cp_counts = np.bincount(cp_samples, minlength=N)\n",
+    "cp_proba = cp_counts / cp_counts.sum()\n",
+    "cp_mode = int(cp_counts.argmax())\n",
+    "m1 = float(idata_g.posterior[\"mean1\"].mean())\n",
+    "m2 = float(idata_g.posterior[\"mean2\"].mean())\n",
+    "sig = float(idata_g.posterior[\"sigma_det\"].mean())\n",
+    "print(f\"=== Posterieur sur le point de rupture cp ===\")\n",
+    "print(f\"  mode (argmax) = {cp_mode}    (vrai cp cache = {vrai_cp})\")\n",
+    "print(f\"  moyenne       = {cp_samples.mean():6.2f}\")\n",
+    "print(f\"Moyenne avant  (mu1) : {m1:6.3f}  (vrai {mu_avant})\")\n",
+    "print(f\"Moyenne apres  (mu2) : {m2:6.3f}  (vrai {mu_apres})\")\n",
+    "print(f\"sigma estime        : {sig:6.3f}  (vrai {sigma})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b1ec2032",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:36:45.662330Z",
+     "iopub.status.busy": "2026-07-03T23:36:45.662330Z",
+     "iopub.status.idle": "2026-07-03T23:36:45.692376Z",
+     "shell.execute_reply": "2026-07-03T23:36:45.689460Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Postérieur sur cp (masses > 0.5%, normalisees au pic) :\n",
+      "  t= 49                                                       0.0053\n",
+      "  t= 50  ##################################################   0.9875\n",
+      "  t= 51                                                       0.0070\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Visualisation : posterieur discret sur la localisation de la rupture ---\n",
+    "pmax = cp_proba.max()\n",
+    "print(\"Postérieur sur cp (masses > 0.5%, normalisees au pic) :\")\n",
+    "for i in range(N):\n",
+    "    if cp_proba[i] < 0.005:\n",
+    "        continue\n",
+    "    bar_len = int(round(cp_proba[i] / pmax * 50))\n",
+    "    print(f\"  t={i:3d}  {'#' * bar_len:<50}  {cp_proba[i]:7.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8bc0c10",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Le **mode** du postérieur sur `cp` tombe **très près** du vrai point caché (50), et les moyennes de segment approchent les vraies valeurs (2 et 7). Le signal étant fort (`|mu_apres - mu_avant| = 5 >> sigma`), le postérieur se concentre sur **quelques indices** autour du vrai `cp`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "729a39ae",
+   "metadata": {},
+   "source": [
+    "## 3. Le cas canonique : les catastrophes minieres (loi de Poisson)\n",
+    "\n",
+    "Le jeu de données historique du change-point bayésien est la série annuelle des **catastrophes de mines de charbon** en Grande-Bretagne (1851–1962, Jarrett 1979). Il s'agit de **comptes** : le modèle naturel est une loi de **Poisson** dont le *taux* bascule une fois — de ~3 accidents/an avant la réforme de sécurité des années 1880 à ~1/an après.\n",
+    "\n",
+    "C'est **l'exemple introductif canonique** de la documentation PyMC. Même idiome que le cas gaussien : `DiscreteUniform` sur l'année de rupture, `switch` sur la plage des années, mais `pm.Poisson(taux)` en lieu et place de la gaussienne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b28d33d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:36:45.698270Z",
+     "iopub.status.busy": "2026-07-03T23:36:45.698270Z",
+     "iopub.status.idle": "2026-07-03T23:37:03.256938Z",
+     "shell.execute_reply": "2026-07-03T23:37:03.255921Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Serie catastrophes miniers : 112 annees (1851..1962)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sequential sampling (4 chains in 1 job)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "CompoundStep\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ">Metropolis: [cp2]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ">NUTS: [early_rate, late_rate]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 15 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Annee de rupture detectee : 1891  (indice 40)\n",
+      "Taux AVANT  :  3.07 catastrophes/an\n",
+      "Taux APRES  :  0.94 catastrophes/an\n",
+      "Rapport de taux : 3.3x\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Catastrophes minieres britanniques, 1851-1962 (Jarrett 1979) ---\n",
+    "disasters = np.array([\n",
+    "    4,5,4,0,1,4,3,4,0,6, 3,3,4,0,2,6,3,3,5,4,\n",
+    "    5,3,1,4,4,1,5,5,3,4, 2,5,2,2,3,4,2,1,3,2,\n",
+    "    2,1,1,1,1,3,0,0,1,0, 1,1,0,0,3,1,0,3,2,2,\n",
+    "    0,1,1,1,0,1,0,1,0,0, 0,2,1,0,0,0,1,1,0,2,\n",
+    "    3,3,1,1,2,1,1,1,1,2, 4,2,0,0,1,4,0,0,0,1,\n",
+    "    0,0,0,0,1,0,0,1,0,1, 0,1\n",
+    "])\n",
+    "N2 = disasters.size\n",
+    "annees = 1851 + np.arange(N2)\n",
+    "t2 = np.arange(N2)\n",
+    "print(f\"Serie catastrophes miniers : {N2} annees ({annees[0]}..{annees[-1]})\")\n",
+    "\n",
+    "with pm.Model() as modele_disasters:\n",
+    "    cp2 = pm.DiscreteUniform(\"cp2\", lower=0, upper=N2 - 1)\n",
+    "    early_rate = pm.Exponential(\"early_rate\", lam=1.0)    # taux avant (prior faible)\n",
+    "    late_rate = pm.Exponential(\"late_rate\", lam=1.0)      # taux apres\n",
+    "    rate = pm.math.switch(t2 <= cp2, early_rate, late_rate)\n",
+    "    pm.Poisson(\"disasters_obs\", mu=rate, observed=disasters)\n",
+    "    idata_d = pm.sample(\n",
+    "        2000, tune=1500, chains=4, cores=1, random_seed=42,\n",
+    "        target_accept=0.95, progressbar=False, idata_kwargs={\"log_likelihood\": False},\n",
+    "    )\n",
+    "\n",
+    "cp2_samples = idata_d.posterior[\"cp2\"].values.flatten().astype(int)\n",
+    "cp2_mode = int(np.bincount(cp2_samples, minlength=N2).argmax())\n",
+    "er = float(idata_d.posterior[\"early_rate\"].mean())\n",
+    "lr = float(idata_d.posterior[\"late_rate\"].mean())\n",
+    "print(f\"\\nAnnee de rupture detectee : {1851 + cp2_mode}  (indice {cp2_mode})\")\n",
+    "print(f\"Taux AVANT  : {er:5.2f} catastrophes/an\")\n",
+    "print(f\"Taux APRES  : {lr:5.2f} catastrophes/an\")\n",
+    "print(f\"Rapport de taux : {er / max(lr, 1e-6):.1f}x\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9227df",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Le postérieur concentre la rupture autour de **1890–1891** — soit exactement la période des grandes réformes de sécurité dans les mines britanniques. Le taux passe de ~3,1 à ~0,9 catastrophe par an, un rapport de ~3,3×. C'est le résultat historique de la littérature sur les modèles de point de rupture (Carlin, Gelfand & Smith 1992 ; PyMC en fait son exemple introductif). Cote Infer.NET ce sont des **messages EP** qui resolvait le postérieur ; cote PyMC c'est l'**échantillonnage CompoundStep** (NUTS + Metropolis sur `cp`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c56694e",
+   "metadata": {},
+   "source": [
+    "## 4. Vraie rupture ou caprice du bruit ? Le piege de la flexibilite\n",
+    "\n",
+    "Un modèle de point de rupture est **flexible** : il peut, si on le laisse faire, trouver une « meilleure » coupure dans n'importe quelle série — y compris du pur bruit. C'est le piège du surajustement. Pour le mesurer, on génère une série **sans rupture** (moyenne constante) et on lui applique le **même** modèle. On quantifie la concentration du postérieur sur `cp` par son **entropie** $H$ (en bits) : $H_{max} = \\log_2 N$ pour un postérieur plat (aucune idée sur la localisation), $H \\to 0$ pour un postérieur piqué sur un seul indice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9f088c32",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:37:03.259970Z",
+     "iopub.status.busy": "2026-07-03T23:37:03.259970Z",
+     "iopub.status.idle": "2026-07-03T23:37:51.391170Z",
+     "shell.execute_reply": "2026-07-03T23:37:51.389779Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sequential sampling (4 chains in 1 job)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "CompoundStep\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ">Metropolis: [cpC]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ">NUTS: [mc1, mc2, pc]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 46 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Serie AVEC rupture    : H(cp) =  0.111 bits / 6.644  =>  information = 6.533 bits\n",
+      "Controle SANS rupture : H(cp) =  6.056 bits / 6.644  =>  information = 0.588 bits\n",
+      "\n",
+      "=> Vraie rupture : H -> 0 (localisation quasi certaine).\n",
+      "=> Pur bruit    : H ~= Hmax (posterieur quasi PLAT) -- le modele N'identifie pas de coupure nette ;\n",
+      "                  il exprime honnetement son incertitude (moyennage MCMC).\n",
+      "=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. PyMC-8), pas la seule entropie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def H_bits(samples, n):\n",
+    "    \"\"\"Entropie de Shannon (bits) d'un posterieur discret empirique.\"\"\"\n",
+    "    counts = np.bincount(samples.astype(int), minlength=n)\n",
+    "    p = counts / counts.sum()\n",
+    "    p = p[p > 1e-12]\n",
+    "    return float(-(p * np.log2(p)).sum())\n",
+    "\n",
+    "# Entropie du posterieur cp sur la serie AVEC rupture (deja estime ci-dessus)\n",
+    "H_reel = H_bits(cp_samples, N)\n",
+    "Hmax_reel = np.log2(N)\n",
+    "\n",
+    "# --- Controle : serie SANS rupture (moyenne constante = 5) ---\n",
+    "np.random.seed(7)\n",
+    "Nc = 100\n",
+    "mu_const = 5.0\n",
+    "t_idx_c = np.arange(Nc)\n",
+    "data_ctrl = mu_const + 1.5 * np.random.randn(Nc)\n",
+    "\n",
+    "with pm.Model() as modele_ctrl:\n",
+    "    cpC = pm.DiscreteUniform(\"cpC\", lower=0, upper=Nc - 1)\n",
+    "    mc1 = pm.Normal(\"mc1\", mu=0.0, sigma=10.0)\n",
+    "    mc2 = pm.Normal(\"mc2\", mu=0.0, sigma=10.0)\n",
+    "    pc = pm.Gamma(\"pc\", alpha=1.0, beta=1.0)\n",
+    "    sc = pm.Deterministic(\"sc\", 1.0 / pt.sqrt(pc))\n",
+    "    muc = pm.math.switch(t_idx_c <= cpC, mc1, mc2)\n",
+    "    pm.Normal(\"yc\", mu=muc, sigma=sc, observed=data_ctrl)\n",
+    "    idata_c = pm.sample(\n",
+    "        2000, tune=1500, chains=4, cores=1, random_seed=42,\n",
+    "        target_accept=0.95, progressbar=False, idata_kwargs={\"log_likelihood\": False},\n",
+    "    )\n",
+    "\n",
+    "cpC_samples = idata_c.posterior[\"cpC\"].values.flatten().astype(int)\n",
+    "H_ctrl = H_bits(cpC_samples, Nc)\n",
+    "Hmax_ctrl = np.log2(Nc)\n",
+    "\n",
+    "print(f\"Serie AVEC rupture    : H(cp) = {H_reel:6.3f} bits / {Hmax_reel:.3f}  =>  information = {Hmax_reel - H_reel:5.3f} bits\")\n",
+    "print(f\"Controle SANS rupture : H(cp) = {H_ctrl:6.3f} bits / {Hmax_ctrl:.3f}  =>  information = {Hmax_ctrl - H_ctrl:5.3f} bits\")\n",
+    "print()\n",
+    "print(\"=> Vraie rupture : H -> 0 (localisation quasi certaine).\")\n",
+    "print(\"=> Pur bruit    : H ~= Hmax (posterieur quasi PLAT) -- le modele N'identifie pas de coupure nette ;\")\n",
+    "print(\"                  il exprime honnetement son incertitude (moyennage MCMC).\")\n",
+    "print(\"=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. PyMC-8), pas la seule entropie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49c71462",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "La série **avec** rupture pousse l'entropie vers 0 (localisation quasi certaine : ~6,5 bits d'information sur `cp`), tandis que le **contrôle** (pur bruit) laisse une entropie **haute**, proche de $H_{max}$ (postérieur quasi plat : < 1 bit d'information). Le modèle, confronté à une série sans rupture, **n'identifie pas** de coupure nette : l'échantillonnage MCMC, en moyennant sur l'incertitude de `cp`, **exprime honnêtement son ignorance**.\n",
+    "\n",
+    "C'est une différence marquée avec l'EP d'Infer.NET (côté C#) qui, propageant des messages **deterministes**, commettait une coupure spurieuse (~0,7 bit). Le moyennage stochastique de MCMC est ici plus prudent. Le contrôle présente néanmoins des **avertissements de convergence** (`r_hat > 1.01`, `ess` faible) — attendus quand `cp` est non-identifié (postérieur plat, mélange lent des chaînes).\n",
+    "\n",
+    "La leçon : la concentration du postérieur signale qu'une coupure est **possible**, mais seule la comparaison de modèles par **Bayes factor** (vraisemblance marginale, cf. [PyMC-8-Model-Selection](PyMC-8-Model-Selection.ipynb)) tranche définitivement entre « vraie rupture » et « bruit ». Le Bayes factor pénalise la flexibilité supplémentaire du modèle à rupture."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb02eede",
+   "metadata": {},
+   "source": [
+    "## 5. Exercices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97a2376e",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Deux points de rupture (trois regimes)\n",
+    "\n",
+    "Étendez le modèle à **deux** ruptures `cp1 < cp2` délimitant trois segments de moyennes `mu1, mu2, mu3`. Le postérieur devient joint sur `(cp1, cp2)`.\n",
+    "\n",
+    "**Indice :** générez une série à trois régimes, puis emboîtez les `switch` — `mean1` pour `t <= cp1`, `mean2` pour `cp1 < t <= cp2`, `mean3` au-delà (deux `pm.math.switch` emboîtés).\n",
+    "\n",
+    "**Étape 1.** Générez `data3` avec `mu = 2` sur `[0, cp1]`, `mu = 5` sur `[cp1, cp2]`, `mu = 8` au-delà.\n",
+    "**Étape 2.** Déclarez `cp1, cp2` (`DiscreteUniform`, avec `cp1 < cp2`), trois moyennes, et emboîtez les `switch`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1b84eb8d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:37:51.394169Z",
+     "iopub.status.busy": "2026-07-03T23:37:51.394169Z",
+     "iopub.status.idle": "2026-07-03T23:37:51.401285Z",
+     "shell.execute_reply": "2026-07-03T23:37:51.399268Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : deux points de rupture (trois regimes).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : deux points de rupture (a completer)\n",
+    "# TODO etudiant : declarer cp1, cp2 (DiscreteUniform, cp1 < cp2), mu1/mu2/mu3 et emboiter les switch.\n",
+    "print(\"Exercice 1 a completer : deux points de rupture (trois regimes).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d51a29d2",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Un changement de variance (moyenne constante)\n",
+    "\n",
+    "Détectez une rupture de **variance** seule : la moyenne reste constante, mais la précision bascule de `prec1` (régime calme) à `prec2` (régime turbulent) à l'instant `cp`.\n",
+    "\n",
+    "**Indice :** la moyenne `mu` est commune aux deux segments ; seules les précisions diffèrent. Placez `mu` *en dehors* du `switch`, et branchez le `sigma` (dérivé de la précision) à l'intérieur.\n",
+    "\n",
+    "**Étape 1.** Générez une série de moyenne 5 constante, de variance 0.25 avant `cp` et 4.0 après.\n",
+    "**Étape 2.** Adaptez le modèle (une moyenne commune, `sigma = switch(t <= cp, sigma1, sigma2)`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2c58e383",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:37:51.405303Z",
+     "iopub.status.busy": "2026-07-03T23:37:51.405303Z",
+     "iopub.status.idle": "2026-07-03T23:37:51.414401Z",
+     "shell.execute_reply": "2026-07-03T23:37:51.412846Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : detection d'un changement de variance.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : changement de variance (a completer)\n",
+    "# TODO etudiant : moyenne commune, sigma = switch(t <= cp, sigma1, sigma2) branche dans la Normal.\n",
+    "print(\"Exercice 2 a completer : detection d'un changement de variance.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "572aaed8",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Robustesse au signal et a la taille\n",
+    "\n",
+    "Étudiez comment la **concentration** du postérieur sur `cp` dépend (a) de l'amplitude du saut `delta = mu_apres - mu_avant` et (b) de la longueur `N` de la série.\n",
+    "\n",
+    "**Indice :** reprenez le modèle de la section 2 dans une boucle sur `delta dans {1, 2, 4}` et notez `H(cp)` à chaque fois.\n",
+    "\n",
+    "**Étape 1.** Pour chaque `delta`, générez une série et inférez le postérieur de `cp`.\n",
+    "**Étape 2.** Calculez l'entropie `H(cp)` (fonction `H_bits` ci-dessus).\n",
+    "**Étape 3.** Observez : un signal faible ou une courte série élargit le postérieur ; un signal fort ou une longue série le resserre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2d59af55",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-03T23:37:51.418414Z",
+     "iopub.status.busy": "2026-07-03T23:37:51.417395Z",
+     "iopub.status.idle": "2026-07-03T23:37:51.422393Z",
+     "shell.execute_reply": "2026-07-03T23:37:51.422393Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : robustesse du posterieur au signal et a la taille.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : robustesse au signal et a N (a completer)\n",
+    "# TODO etudiant : boucler sur delta dans {1, 2, 4}, mesurer H(cp) a chaque fois.\n",
+    "print(\"Exercice 3 a completer : robustesse du posterieur au signal et a la taille.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8873019",
+   "metadata": {},
+   "source": [
+    "## 6. Conclusion\n",
+    "\n",
+    "Le **point de rupture** complète la famille des séquences temporelles :\n",
+    "\n",
+    "| Notebook | État caché | Inférence |\n",
+    "|----------|-----------|-----------|\n",
+    "| [PyMC-11](PyMC-11-Sequences.ipynb) (HMM) | discret, **récurrent** (un par pas) | postérieur sur la trajectoire d'états |\n",
+    "| [Infer-17](../Infer/Infer-17-Kalman-Filter.ipynb) (Kalman) | continu, **récurrent** | postérieur gaussien pas-à-pas |\n",
+    "| **PyMC-18 (change-point)** | **entier structurel unique** | postérieur `Discrete` sur la localisation |\n",
+    "\n",
+    "Le trait distinctif : l'inconnue est un **indice structurel** couplé à toute la série via `pm.math.switch`. Cote PyMC, la discreteness de `cp` impose un **CompoundStep** (NUTS + Metropolis), la où EP (cote Infer.NET) propageait les messages analytiquement. Le piège épistémologique (surajustement d'une coupure spurieuse) est universel : seul le **Bayes factor** tranche.\n",
+    "\n",
+    "> **Jumeau de** [`Infer-18-Change-Point.ipynb`](../Infer/Infer-18-Change-Point.ipynb) *(Infer.NET / C#, inférence EP)* -- Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
@@ -32,10 +32,10 @@
    "id": "b8f8f126",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:36:15.119011Z",
-     "iopub.status.busy": "2026-07-03T23:36:15.119011Z",
-     "iopub.status.idle": "2026-07-03T23:36:20.407124Z",
-     "shell.execute_reply": "2026-07-03T23:36:20.405971Z"
+     "iopub.execute_input": "2026-07-04T12:48:23.663009Z",
+     "iopub.status.busy": "2026-07-04T12:48:23.663009Z",
+     "iopub.status.idle": "2026-07-04T12:48:27.257497Z",
+     "shell.execute_reply": "2026-07-04T12:48:27.257497Z"
     }
    },
    "outputs": [
@@ -90,10 +90,10 @@
    "id": "52d1acc3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:36:20.410123Z",
-     "iopub.status.busy": "2026-07-03T23:36:20.409119Z",
-     "iopub.status.idle": "2026-07-03T23:36:45.647349Z",
-     "shell.execute_reply": "2026-07-03T23:36:45.636471Z"
+     "iopub.execute_input": "2026-07-04T12:48:27.257497Z",
+     "iopub.status.busy": "2026-07-04T12:48:27.257497Z",
+     "iopub.status.idle": "2026-07-04T12:51:32.478182Z",
+     "shell.execute_reply": "2026-07-04T12:51:32.474597Z"
     }
    },
    "outputs": [
@@ -129,7 +129,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 18 seconds.\n"
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 33 seconds.\n"
      ]
     },
     {
@@ -182,10 +182,10 @@
    "id": "b1ec2032",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:36:45.662330Z",
-     "iopub.status.busy": "2026-07-03T23:36:45.662330Z",
-     "iopub.status.idle": "2026-07-03T23:36:45.692376Z",
-     "shell.execute_reply": "2026-07-03T23:36:45.689460Z"
+     "iopub.execute_input": "2026-07-04T12:51:32.481726Z",
+     "iopub.status.busy": "2026-07-04T12:51:32.481726Z",
+     "iopub.status.idle": "2026-07-04T12:51:32.496502Z",
+     "shell.execute_reply": "2026-07-04T12:51:32.493016Z"
     }
    },
    "outputs": [
@@ -239,10 +239,10 @@
    "id": "b28d33d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:36:45.698270Z",
-     "iopub.status.busy": "2026-07-03T23:36:45.698270Z",
-     "iopub.status.idle": "2026-07-03T23:37:03.256938Z",
-     "shell.execute_reply": "2026-07-03T23:37:03.255921Z"
+     "iopub.execute_input": "2026-07-04T12:51:32.504992Z",
+     "iopub.status.busy": "2026-07-04T12:51:32.504992Z",
+     "iopub.status.idle": "2026-07-04T12:51:59.258783Z",
+     "shell.execute_reply": "2026-07-04T12:51:59.247664Z"
     }
    },
    "outputs": [
@@ -285,7 +285,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 15 seconds.\n"
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 24 seconds.\n"
      ]
     },
     {
@@ -362,10 +362,10 @@
    "id": "9f088c32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:37:03.259970Z",
-     "iopub.status.busy": "2026-07-03T23:37:03.259970Z",
-     "iopub.status.idle": "2026-07-03T23:37:51.391170Z",
-     "shell.execute_reply": "2026-07-03T23:37:51.389779Z"
+     "iopub.execute_input": "2026-07-04T12:51:59.272682Z",
+     "iopub.status.busy": "2026-07-04T12:51:59.272682Z",
+     "iopub.status.idle": "2026-07-04T12:53:52.490438Z",
+     "shell.execute_reply": "2026-07-04T12:53:52.490438Z"
     }
    },
    "outputs": [
@@ -401,7 +401,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 46 seconds.\n"
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 108 seconds.\n"
      ]
     },
     {
@@ -520,10 +520,10 @@
    "id": "1b84eb8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:37:51.394169Z",
-     "iopub.status.busy": "2026-07-03T23:37:51.394169Z",
-     "iopub.status.idle": "2026-07-03T23:37:51.401285Z",
-     "shell.execute_reply": "2026-07-03T23:37:51.399268Z"
+     "iopub.execute_input": "2026-07-04T12:53:52.495703Z",
+     "iopub.status.busy": "2026-07-04T12:53:52.495703Z",
+     "iopub.status.idle": "2026-07-04T12:53:52.501218Z",
+     "shell.execute_reply": "2026-07-04T12:53:52.500713Z"
     }
    },
    "outputs": [
@@ -562,10 +562,10 @@
    "id": "2c58e383",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:37:51.405303Z",
-     "iopub.status.busy": "2026-07-03T23:37:51.405303Z",
-     "iopub.status.idle": "2026-07-03T23:37:51.414401Z",
-     "shell.execute_reply": "2026-07-03T23:37:51.412846Z"
+     "iopub.execute_input": "2026-07-04T12:53:52.504228Z",
+     "iopub.status.busy": "2026-07-04T12:53:52.504228Z",
+     "iopub.status.idle": "2026-07-04T12:53:52.516611Z",
+     "shell.execute_reply": "2026-07-04T12:53:52.515601Z"
     }
    },
    "outputs": [
@@ -605,10 +605,10 @@
    "id": "2d59af55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:37:51.418414Z",
-     "iopub.status.busy": "2026-07-03T23:37:51.417395Z",
-     "iopub.status.idle": "2026-07-03T23:37:51.422393Z",
-     "shell.execute_reply": "2026-07-03T23:37:51.422393Z"
+     "iopub.execute_input": "2026-07-04T12:53:52.519611Z",
+     "iopub.status.busy": "2026-07-04T12:53:52.518611Z",
+     "iopub.status.idle": "2026-07-04T12:53:52.526064Z",
+     "shell.execute_reply": "2026-07-04T12:53:52.524672Z"
     }
    },
    "outputs": [

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -81,6 +81,7 @@ La série illustre ce fil rouge sur plusieurs notebooks, chacun sur un cas non-c
 | 13 | [PyMC-13-Debugging](PyMC-13-Debugging.ipynb) | 45 min | Troubleshooting, diagnostics NUTS, convergence |
 | 14 | [PyMC-14-Causal-Inference](PyMC-14-Causal-Inference.ipynb) | 65 min | do-calculus de Pearl, `pm.do`, backdoor/front-door, paradoxe de Simpson, contrefactuel |
 | 16 | [PyMC-16-Modeles-Hierarchiques](PyMC-16-Modeles-Hierarchiques.ipynb) | 50 min | Partial pooling, shrinkage, paramétrisation non-centrée, divergences/funnel |
+| 18 | [PyMC-18-Change-Point](PyMC-18-Change-Point.ipynb) | 50 min | Change-point bayésien, `DiscreteUniform` + `switch`, catastrophes minières (Poisson), entropie |
 
 > **Théorie de la décision** : les notebooks décisionnels (utilité espérée, EVPI, MDPs, bandits) forment désormais une sous-série autonome dans [DecisionTheory/PyMC/](../DecisionTheory/PyMC/README.md) (1 à 7), miroir Python de [DecisionTheory/Infer/](../DecisionTheory/DecInfer/README.md).
 


### PR DESCRIPTION
## PyMC-18-Change-Point — port Infer-18 -> PyMC

Jumeau Python de [`Infer-18-Change-Point.ipynb`](../blob/main/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb) (Infer.NET / C#, inférence EP). **2ᵉ jumeau du pivot Python Probas** après PyMC-16 (PR #5271).

### Couvre les 3 cas du source
1. **Change-point gaussien** (synthétique N=100, vrai cp=50) : `cp ~ DiscreteUniform`, `mu = pm.math.switch(t <= cp, mean1, mean2)`.
2. **Catastrophes minières** (Jarrett 1979, 1851–1962, Poisson) — **exemple introductif canonique** de la doc PyMC.
3. **Piège du surajustement** (contrôle sans rupture + entropie de Shannon).

### Résultats (exec réels, kernel `coursia-ml-training`, python3)
- **Gaussien** : cp_mode = **50** (vrai 50), **98,75 %** de la masse postérieure sur t=50, mean1=1,68 (vrai 2,0), mean2=7,01 (vrai 7,0), sigma=1,36
- **Disasters** : rupture **1891**, taux **3,07 → 0,94** (rapport **3,3×**) — résultats historiques de Carlin, Gelfand & Smith 1992
- **Entropie** : H(cp) = **0,111 bits** (vraie rupture → location quasi certaine) vs **6,056 bits** (contrôle bruit → postérieur quasi plat)

### Fidélité / value-add PyMC vs Infer.NET EP
`cp` est **discrète** → PyMC compose un **CompoundStep** (NUTS pour les continus + Metropolis pour `cp`), là où EP propageait les messages analytiquement. **Différence pédagogique marquée sur le contrôle** : MCMC, en moyennant, laisse un postérieur **quasi plat** (H ≈ Hmax = honnête) sur une série sans rupture, là où l'EP déterministe d'Infer.NET commettait une coupure spurieuse (~0,7 bit). Documenté honnêtement (G.2) avec note sur les avertissements `r_hat` attendus quand `cp` est non-identifié.

### Conformité
- 8 code cells `[1..8]` séquentiel, **0 erreur**, **0 path-leak** (filterwarnings pytensor BLAS advisory), **C.1 = 0** (stubs `print`/`TODO`)
- `python3` kernelspec, re-exec `nbconvert kernel=coursia-ml-training`
- **3 exercices** stub (deux change-points / changement de variance / robustesse δ-N)
- README feuille `PyMC/README.md` : +1 row TOC
- **CATALOG-STATUS byte-identique** (0 churn, cron-owned)

> ⚠️ Légère convergence possible avec #5271 (PyMC-16) sur la row TOC du README (les deux insèrent après PyMC-14) — résolution triviale à la fusion.

`See #4956` (epic reste ouvert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)