### PR TITLE
docs(ict): re-group strate 5 — insert ICT-18 réversibilisation + ICT-19 reserved slot (See #4588)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-0-Framing.md
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-0-Framing.md
@@ -57,15 +57,41 @@ porte le premier. Aucun des deux ne remplace l'autre :
   compression cherchent à capturer) ;
 - la **méthode** construit les cas calculables qui instancient ce langage et permettent de le
   mesurer *sans complaisance* ;
-- la **strate 5** (ICT-14 → ICT-22) ferme la boucle : sur le banc cross-substrat (ICT-15 #5090),
+- la **strate 5** (ICT-14 → ICT-24) ferme la boucle : sur le banc cross-substrat (ICT-15 #5090),
   les trois scalaires fondateurs $\Phi / F / K$ se rencontrent ; l'identité MDL (ICT-16 #5099),
-  l'$\epsilon$-machine (ICT-17 #5100) et le LLM comme quatrième substrat (ICT-19 #5102) réalisent
+  l'$\epsilon$-machine (ICT-17 #5100) et le LLM comme quatrième substrat (ICT-22 #5102) réalisent
   littéralement la théorie fondatrice, sur des substrats où le tri ne suffit plus.
 
 Cette double lecture est assumée et documentée ici précisément parce qu'elle a longtemps été
 implicite — la série se présentait comme « Integrated Causal Trajectories » (méthode), alors que
 la théorie fondatrice parle « Integrated Complexity Theory ». Le cadrage explicite évite la
 confusion et nomme l'enjeu.
+
+## Flèche du temps & réversibilisation — l'idée fondatrice
+
+Le panorama qui a orienté la série vers la *complexité intégrée* portait un **fil conducteur
+resté non-dit** : la **réversibilisation**. Une trajectoire qui développe une compétence
+« gratuite » (*for free*), non prévue par le mécanisme programmé, est exactement ce qu'un
+processus **à l'équilibre / réversible** (au sens du *detailed balance*) ne peut PAS produire.
+L'émergence a une **signature thermodynamique** : elle brise la symétrie temporelle. Or, jusqu'ici,
+la série mesurait l'intégration ($\Phi$), la surprise ($F$), la compression ($K$) — jamais
+l'irréversibilité elle-même. Il manquait l'**instrument de mesure** de la flèche du temps.
+
+**L'ancrage Levin / Fridman.** Dans son entretien avec Lex Fridman sur les algorithmes de tri,
+Michael Levin est fasciné par l'émergence, dans un simple tri, d'un **mécanisme algorithmique
+non programmé** — un travail supplémentaire *for free* qui va, dit-il, « dans le sens d'une
+réversibilisation ». C'est très précisément la compétence *for free* que **ICT-3**
+(`RobustnessDelayedGratification`) démontre en strate 1 : le tri « fait plus que trier ». La
+flèche du temps est ici une **flèche causale** (Reichenbach, ordre de Pearl, flèche
+thermodynamique) ; la **production d'entropie** en est la signature quantitative — la marque
+thermodynamique de l'agentivité.
+
+**Cet instrument est construit en ICT-18 — Flèche du temps & réversibilisation** ([#5279](https://github.com/jsboige/CoursIA/issues/5279),
+GPU-free). Appliqué *rétrospectivement* aux trajectoires déjà enregistrées (tri, May bistable,
+Axelrod, Gray-Scott), il répond à une question centrale et falsifiable : **« que perd-on quand
+on force une trajectoire ICT à devenir réversible ? »** La réponse, mesurée (production d'entropie
+$\sigma$, erreur de *detailed balance*, quantités effacées par la projection réversible), est la
+quantité d'agentivité / de calcul émergent que la trajectoire portait.
 
 ## Deux articles fondateurs
 
@@ -328,11 +354,13 @@ IIT/
 | **ICT-15** | IntegratedComplexity — convergence Φ/F/K sur le banc cross-substrat. Le gate de convergence des trois scalaires fondateurs (information intégrée, énergie libre, complexité de Kolmogorov) sur le squelette de Thom. *Strate 4 / charnière vers strate 5*. Voir issue #5090 | 🚧 planifié |
 | **ICT-16** | MDLTwoPartCode — le pont MDL : F (énergie libre) est la partie résiduelle du code K (Kolmogorov) + la bosse complexité-entropie. Identité MDL ↔ énergie libre. *Strate 5*. Voir issue #5099 | 🚧 planifié |
 | **ICT-17** | EpsilonMachine — états causaux, complexité statistique, entropie d'excès : le gate Crutchfield vs Hoel. L'$\epsilon$-machine comme alternative computationnelle à l'émergence causale Hoel. *Strate 5*. Voir issue #5100 | 🚧 planifié |
-| **ICT-18** | SAETrajectoires — Qwen + Qwen-Scope : des features SAE aux trajectoires d'états discrets, le substrat S4 (LLM sparse autoencoder). *Strate 5, GPU-required*. Voir issue #5101 | 🚧 planifié |
-| **ICT-19** | LLMSubstrat — le transformer comme quatrième substrat du banc cross-substrat (tri, Gray-Scott, Axelrod, LLM). Double contrôle (passif / actif). *Strate 5, GPU-required*. Voir issue #5102 | 🚧 planifié |
+| **ICT-18** | Flèche du temps & réversibilisation — l'**idée fondatrice** enfin outillée. Instrument rétrospectif GPU-free (`ict/time_arrow.py`) appliqué aux trajectoires déjà construites (tri, May, Axelrod, Gray-Scott) : distribution stationnaire, inversion temporelle, réversibilisation, production d'entropie. Question centrale : *que perd-on quand on force une trajectoire ICT à devenir réversible ?* Ancré ICT-3 (compétence *for free*) + entretien Fridman/Levin. *Strate 5, GPU-free*. Voir issue #5279 | 🚧 planifié |
+| **ICT-19** | Conceptual Reservoirs — *slot réservé*, spécification à venir (réservoirs conceptuels, mémoire cross-substrat). → Epic #4588 | 🔖 réservé |
 | **ICT-20** | FeatureCatastrophes — calibration : changepoints, EWS et hystérésis sur transitions anodines en feature-space. *Strate 5*. Voir issue #5103 | 🚧 planifié |
-| **ICT-21** | PersonaCatastrophe — expliquer le désalignement émergent par fronce, énergie libre et MDL : jouet + mesure in-context (capstone strate 5). Voir issue #5104 | 🚧 planifié |
-| **ICT-22** | InoculationRL — réplication poids : GRPO à récompense hackable × inoculation, rewardspy, panel persona (capstone final, pont PostTraining). *Strate 5, GPU-required*. Voir issue #5105 | 🚧 planifié |
+| **ICT-21** | SAETrajectoires — Qwen + Qwen-Scope : des features SAE aux trajectoires d'états discrets, le substrat S4 (LLM sparse autoencoder). *Strate 5, GPU-required*. Voir issue #5101 | 🚧 planifié |
+| **ICT-22** | LLMSubstrat — le transformer comme quatrième substrat du banc cross-substrat (tri, Gray-Scott, Axelrod, LLM). Double contrôle (passif / actif). *Strate 5, GPU-required*. Voir issue #5102 | 🚧 planifié |
+| **ICT-23** | PersonaCatastrophe — expliquer le désalignement émergent par fronce, énergie libre et MDL : jouet + mesure in-context (capstone strate 5). Voir issue #5104 | 🚧 planifié |
+| **ICT-24** | InoculationRL — réplication poids : GRPO à récompense hackable × inoculation, rewardspy, panel persona (capstone final, pont PostTraining). *Strate 5, GPU-required*. Voir issue #5105 | 🚧 planifié |
 
 ## Strate 2 — du tri transparent à la morphogenèse dynamique
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/README.md
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/README.md
@@ -13,7 +13,7 @@ La série [IIT](../README.md) étudie des structures causales **à un instant do
 
 ICT s'appuie sur un package léger `ict/` posé à côté de PyPhi (autonome pour les simulations et mesures, PyPhi pour les calculs IIT stricts), et s'ouvre sur deux articles fondateurs : le tri vu comme morphogenèse minimale (Zhang, Goldstein & Levin, 2025) et l'ingénierie de l'émergence multi-échelle (Jansma & Hoel, 2025).
 
-La série progresse en **deux strates**. La **strate 1** (ICT-0 à ICT-7) prend le **tri auto-organisé** comme banc d'essai entièrement transparent : trajectoires enregistrables, compétences inattendues réelles, pont vers la causal emergence. Elle bute toutefois sur trois limites — un **attracteur global unique**, un **but imposé de l'extérieur**, une **hiérarchie non générative**. La **strate 2** (ICT-8+) ouvre la *morphogenèse dynamique* sur des systèmes dont le paysage d'attracteurs est **engendré par la dynamique** (bifurcation, réaction-diffusion), levant ces limites une à une.
+La série progresse en **cinq strates**. La **strate 1** (ICT-0 à ICT-7) prend le **tri auto-organisé** comme banc d'essai entièrement transparent : trajectoires enregistrables, compétences inattendues réelles — ce travail *for free* qui, chez Levin, va « dans le sens d'une réversibilisation » — et pont vers la causal emergence. Elle bute sur trois limites — un **attracteur global unique**, un **but imposé de l'extérieur**, une **hiérarchie non générative**. La **strate 2** (ICT-8 à ICT-10) ouvre la *morphogenèse dynamique* sur des paysages d'attracteurs **engendrés par la dynamique** (bifurcation, réaction-diffusion, grammaire des catastrophes), levant ces limites une à une. La **strate 3** (ICT-11 à ICT-13) mesure des **trajectoires intégrées** régime-dépendantes (profils d'agence, champs de valence, morphodynamique stratégique). La **strate 4** (ICT-14) ajoute la jambe **représentationnelle** — énergie libre et surprise. La **strate 5** (ICT-15 à ICT-24) réalise la *théorie fondatrice* cross-substrat (convergence $\Phi/F/K$, identité MDL, LLM comme substrat) et **outille enfin la réversibilisation** — l'idée fondatrice restée implicite : forcer une trajectoire à devenir réversible et mesurer *ce qu'on perd* révèle la quantité d'agentivité qu'elle portait (ICT-18, flèche du temps & réversibilisation).
 
 > **Caractère expérimental.** ICT est une série de recherche en construction (statut ALPHA). Elle pose des mesures *sans complaisance* : chaque notebook confronte une intuition séduisante (émergence, agence, criticalité) à une mesure qui peut la **réfuter**, et signale explicitement les fantômes statistiques (signal apparent issu de degrés de liberté cachés).
 
@@ -77,18 +77,20 @@ La strate 3 se conclut sur la feuille de route de [ICT-0-Framing](ICT-0-Framing.
 
 ### Strate 5 — réalisation de la théorie fondatrice (cross-substrat, MDL, LLM)
 
-Le retour à la théorie fondatrice (cf. [ICT-0-Annexe](ICT-0-Annexe-IntegratedComplexityTheory.md)) : les trois scalaires fondateurs $\Phi / F / K$ convergent sur un banc cross-substrat. *Planifiée, scope ICT-15..22 (#5090 #5099..#5105).*
+Le retour à la théorie fondatrice (cf. [ICT-0-Annexe](ICT-0-Annexe-IntegratedComplexityTheory.md)) : les trois scalaires fondateurs $\Phi / F / K$ convergent sur un banc cross-substrat, et la **réversibilisation** — l'idée fondatrice restée implicite — y est enfin outillée (ICT-18). *Planifiée, scope ICT-15..24 (#5090 #5099..#5105 #5279).*
 
 | Notebook | Sujet | Issue |
 |----------|-------|-------|
 | **ICT-15** | Convergence Φ/F/K sur le banc cross-substrat, gate de convergence sur le squelette de Thom | [#5090](https://github.com/jsboige/CoursIA/issues/5090) |
 | **ICT-16** | MDLTwoPartCode — $F$ est la partie résiduelle du code $K$ + bosse complexité-entropie | [#5099](https://github.com/jsboige/CoursIA/issues/5099) |
 | **ICT-17** | $\epsilon$-machine (Crutchfield) vs Hoel — états causaux, complexité statistique, entropie d'excès | [#5100](https://github.com/jsboige/CoursIA/issues/5100) |
-| **ICT-18** | SAE (Qwen + Qwen-Scope) — des features SAE aux trajectoires d'états discrets, substrat S4 *(GPU)* | [#5101](https://github.com/jsboige/CoursIA/issues/5101) |
-| **ICT-19** | LLM comme quatrième substrat du banc cross-substrat *(GPU)* | [#5102](https://github.com/jsboige/CoursIA/issues/5102) |
+| **ICT-18** | Flèche du temps & réversibilisation — production d'entropie, detailed balance, « que perd-on à réversibiliser ? » (ancré ICT-3, Levin/Fridman) *(GPU-free)* | [#5279](https://github.com/jsboige/CoursIA/issues/5279) |
+| **ICT-19** | Conceptual Reservoirs — *slot réservé*, spec à venir → Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588) | — |
 | **ICT-20** | FeatureCatastrophes — calibration, changepoints, EWS et hystérésis en feature-space | [#5103](https://github.com/jsboige/CoursIA/issues/5103) |
-| **ICT-21** | PersonaCatastrophe — désalignement émergent par fronce, énergie libre et MDL (capstone) | [#5104](https://github.com/jsboige/CoursIA/issues/5104) |
-| **ICT-22** | InoculationRL — GRPO à récompense hackable × inoculation, panel persona (capstone final) *(GPU)* | [#5105](https://github.com/jsboige/CoursIA/issues/5105) |
+| **ICT-21** | SAE (Qwen + Qwen-Scope) — des features SAE aux trajectoires d'états discrets, substrat S4 *(GPU)* | [#5101](https://github.com/jsboige/CoursIA/issues/5101) |
+| **ICT-22** | LLM comme quatrième substrat du banc cross-substrat *(GPU)* | [#5102](https://github.com/jsboige/CoursIA/issues/5102) |
+| **ICT-23** | PersonaCatastrophe — désalignement émergent par fronce, énergie libre et MDL (capstone) | [#5104](https://github.com/jsboige/CoursIA/issues/5104) |
+| **ICT-24** | InoculationRL — GRPO à récompense hackable × inoculation, panel persona (capstone final) *(GPU)* | [#5105](https://github.com/jsboige/CoursIA/issues/5105) |
 
 > La **double lecture du sigle** (« Integrated Complexity Theory » ↔ « Integrated Causal Trajectories ») est documentée dans [ICT-0-Framing § « Double lecture du sigle »](ICT-0-Framing.md#double-lecture-du-sigle). La strate 5 réalise littéralement la théorie fondatrice (identité MDL #5099, convergence $\Phi/F/K$ #5090, LLM comme substrat #5102).
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
@@ -16,6 +16,20 @@ notebook ICT-8 ; May 1977 ; Scheffer et al. 2009), puis **agence morphologique**
 reparation de forme apres ablation par reaction-diffusion (``reaction_diffusion``
 + ``agency``, notebook ICT-9 ; Gray & Scott 1983 ; Pearson 1993 ; Mordvintsev
 et al. 2020 ; Levin).
+
+Strate 3 (agentivite et valence) : morphodynamique strategique et signature
+de valence (``strategic_morphodynamics``, ``valence``, ``multiscale_agency``,
+``catastrophe``, notebooks ICT-11..13 ; Axelrod 1984 ; Thom 1972).
+
+Strate 4 (energie libre) : le principe d'energie libre comme lecture unifiee
+de l'agentivite morphologique (``free_energy``, notebook ICT-14 ; Friston).
+
+Strate 5 (theorie fondatrice cross-substrat) : compression et longueur de
+description minimale (``compression``, ``mdl``, ``epsilon_machine`` ;
+Crutchfield ; Hoel), dynamique de features en panel (``feature_dynamics``,
+notebook ICT-20) et synthese (``synthesis``). La fleche du temps /
+reversibilisation (ICT-18) y outille retrospectivement la signature
+thermodynamique de l'agentivite.
 """
 
 from .self_sorting import Cell, Probe, SelfSortingArray, ALGOTYPES
@@ -31,9 +45,14 @@ from . import early_warning
 from . import bistable
 from . import reaction_diffusion
 from . import agency
+from . import multiscale_agency
 from . import catastrophe
+from . import valence
+from . import strategic_morphodynamics
 from . import free_energy
 from . import compression
+from . import mdl
+from . import epsilon_machine
 from . import feature_dynamics
 from . import synthesis
 
@@ -42,5 +61,7 @@ __all__ = [
     "GrazingModel", "GrayScott",
     "sorting_metrics", "trajectories", "causal_emergence", "tpm_estimation",
     "scale_free", "early_warning", "bistable", "reaction_diffusion", "agency",
-    "catastrophe", "free_energy", "compression", "feature_dynamics", "synthesis",
+    "multiscale_agency", "catastrophe", "valence", "strategic_morphodynamics",
+    "free_energy", "compression", "mdl", "epsilon_machine", "feature_dynamics",
+    "synthesis",
 ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/feature_dynamics.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/feature_dynamics.py
@@ -2,7 +2,7 @@
 
 Outille le notebook **ICT-20 — FeatureCatastrophes** : la calibration de
 methode (changepoints, EWS, hysteresis) sur des **transitions anodines** dans
-un espace de features, **avant** la lecture chargee d'ICT-21 (PersonaCatastrophe).
+un espace de features, **avant** la lecture chargee d'ICT-23 (PersonaCatastrophe).
 
 Pourquoi un adaptateur, pas une reinvention
 --------------------------------------------
@@ -25,13 +25,13 @@ un detecteur de changepoint *complementaire* :
 * :func:`simulate_neutral_transition` -- generateur de **panel synthetique**
   : trajectoire AR(1) avec saut de moyenne a un indice connu, controle du
   rapport signal/bruit. C'est le substrat de la calibration GPU-free : quand
-  les traces reelles ICT-18 (#5101) seront disponibles, on remplacera ce
+  les traces reelles ICT-21 (#5101) seront disponibles, on remplacera ce
   generateur par leur chargement, mais toute la chaine EWS/CUSUM/heredite
   reste inchangee.
 * :func:`hysteresis_residual` -- mesure de **retour a la ligne de base** sur
   une boucle aller-retour (forward puis backward). Toute hysteresis residuelle
   est un **fond de non-retour de l'instrument**, a soustraire de la lecture
-  ICT-21 (Gate bonus du cahier des charges).
+  ICT-23 (Gate bonus du cahier des charges).
 
 Numpy uniquement (comme le reste du package leger ``ict``). Pas de scipy,
 pas de ruptures, pas de statsmodels : tout est ecrit a la main et teste
@@ -41,7 +41,7 @@ References
 ----------
 * Scheffer M. et al., *Early-warning signals for critical transitions*,
   Nature 461 (2009) -- les EWS que nous calibrons ici sur transitions
-  anodines avant la lecture chargee d'ICT-21.
+  anodines avant la lecture chargee d'ICT-23.
 * Page E.S., *Continuous Inspection Schemes*, Biometrika 41 (1954) -- CUSUM.
 * Thom R., *Stabilite structurelle et morphogenese* (1972) -- la sensibilite
   aux parametres de controle qui motive ``changepoint_argmax_derivative``.
@@ -325,7 +325,7 @@ def hysteresis_residual(
 
     Un residu nul = parcours reversible (pas d'hysteresis instrinseque de
     la methode). Un residu non nul = **fond de non-retour de l'instrument**,
-    a soustraire lors de la lecture ICT-21 (Gate bonus du cahier des charges).
+    a soustraire lors de la lecture ICT-23 (Gate bonus du cahier des charges).
 
     Parametres
     ----------


### PR DESCRIPTION
## Résumé

Couche **documentaire** (PR-A d'une séquence de 3) qui re-groupe la numérotation de la strate 5 de la série ICT pour intégrer **la flèche du temps / réversibilisation** — *l'idée fondatrice d'ICT, jamais outillée jusqu'ici* — sans toucher aux slots gelés ICT-1..17.

Décalage approuvé user (2026-07-04) :

| # | Titre | Statut | Issue |
|---|-------|--------|-------|
| **ICT-18** | Flèche du temps & réversibilisation (NEW, **GPU-free**) | 🚧 planifié | #5279 |
| **ICT-19** | Conceptual Reservoirs (*slot réservé*, held) | 🔖 réservé | → #4588 |
| **ICT-20** | FeatureCatastrophes (inchangé) | 🚧 planifié | #5103 |
| **ICT-21** | SAETrajectoires (ex-18, GPU) | 🚧 planifié | #5101 |
| **ICT-22** | LLMSubstrat (ex-19, GPU) | 🚧 planifié | #5102 |
| **ICT-23** | PersonaCatastrophe (ex-21) | 🚧 planifié | #5104 |
| **ICT-24** | InoculationRL (ex-22, GPU) | 🚧 planifié | #5105 |

## Fichiers (non-notebook uniquement — pas de re-exec)

- **README.md** — restructure « deux strates » → cinq strates ; fil conducteur Levin « for free » / réversibilisation ; table strate 5 (10 lignes ordonnées) ; freshness `ICT-15..24` + #5279. Marqueurs `CATALOG-STATUS` **inchangés** (cron-owned).
- **ICT-0-Framing.md** — nouvelle section « Flèche du temps & réversibilisation — l'idée fondatrice » ; table roadmap 7 lignes (ICT-18..24).
- **ict/__init__.py** — docstring étendue aux strates 3/4/5 ; **+5 exports manquants** (`multiscale_agency`, `valence`, `strategic_morphodynamics`, `mdl`, `epsilon_machine`) → `__all__` = **26 modules** (vérifié `python -c "import ict"`).
- **ict/feature_dynamics.py** — **docstrings seulement** : réfs SAE `ICT-18→21`, PersonaCatastrophe `ICT-21→23`. Aucun changement fonctionnel → pas de ré-exécution.

## Vérifications

- `python -c "import ict; print(len(ict.__all__))"` → **26** (non-régressif, +5 exports).
- `git diff` `feature_dynamics.py` → 5 hunks 100% docstring/commentaire.
- Diffstat : 4 fichiers, 69+/18−, tous non-notebook.

## Suite

- **PR-B** (dispatch po-2025) : `ICT-18-ArrowOfTimeReversibilization.ipynb` + `ict/time_arrow.py` (GPU-free) + renumber notebook-interne. Corps = #5279.
- **PR-C** : slot ICT-19 Conceptual Reservoirs (réservé).

See #4588
See #5279

🤖 Generated with [Claude Code](https://claude.com/claude-code)