### PR TITLE
feat(search): Search-6-AdversarialSearch-Csharp — .NET twin (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -34,6 +34,7 @@ Cette partie est l'alphabet de toute la série : la formalisation en espace d'é
 | 4 | [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) | Python 3 | Hill Climbing, Simulated Annealing, Tabu Search, paysages de fitness | ~45 min |
 | 5 | [Search-5-GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb) | Python 3 | Sélection, crossover, mutation, DEAP/PyGAD, théorie unifiée | ~50 min |
 | 6 | [Search-6-AdversarialSearch](Search-6-AdversarialSearch.ipynb) | Python 3 | Minimax, Alpha-Beta pruning, Null-window search, tables de transposition | ~1h |
+| 6 (.NET) | [Search-6-AdversarialSearch (C#)](Search-6-AdversarialSearch-Csharp.ipynb) | .NET (C#) | **Jumeau .NET** : Minimax, Alpha-Beta (speedup 31,9×), heuristique + profondeur limitée, iterative deepening, table de transposition — port C# fidèle sur Tic-Tac-Toe (valeur du jeu = 0) | ~1h |
 | 7 | [Search-7-MCTS-And-Beyond](Search-7-MCTS-And-Beyond.ipynb) | Python 3 | Monte Carlo Tree Search, UCB1, OpenSpiel, architecture AlphaGo (DQN+MCTS) | ~1h30 |
 | 8 | [Search-8-DancingLinks](Search-8-DancingLinks.ipynb) | Python 3 | Algorithme X de Knuth, Dancing Links (DLX), couverture exacte (Sudoku, N-Queens, Pentominoes) | ~1h30 |
 | 9 | [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) | Python 3 | Programmation linéaire avec PuLP, simplex, problème du transport, diet problem, PLNE | ~2h |

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch-Csharp.ipynb
@@ -1,0 +1,1249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1cb1cd44",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003317,
+     "end_time": "2026-07-04T04:10:00.644262",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:00.640945",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Search-6 — Recherche adversariale (jeux à somme nulle) — jumeau .NET\n",
+    "\n",
+    "**Jumeau C# / .NET** du notebook Python [Search-6-AdversarialSearch](Search-6-AdversarialSearch.ipynb).\n",
+    "Partie de l'EPIC [#4956](https://github.com/jsboige/CoursIA/issues/4956) — parité `.NET ⇄ Python` des\n",
+    "séries de notebooks. Cette partie couvre la **recherche sur arbre de jeu** : Minimax, élagage\n",
+    "Alpha-Beta, heuristiques d'évaluation, recherche à profondeur limitée, iterative deepening et tables\n",
+    "de transposition. Le fil rouge est le **Tic-Tac-Toe** (3×3), banc d'essai historique de la théorie des\n",
+    "jeux (von Neumann 1928, Nash 1950) où l'arbre de jeu est assez petit pour être exploré complètement.\n",
+    "\n",
+    "Contrairement à la recherche sur graphe (Partie 1, A\\*/IDA\\*) où un **seul agent** cherche un chemin,\n",
+    "la recherche adversariale modélise **deux agents en conflit** : MAX cherche à maximiser l'utilité,\n",
+    "MIN à la minimiser. L'optimalité de Minimax repose sur l'**hypothèse d'adversaire parfait** — chaque\n",
+    "joueur joue le meilleur coup disponible — ce qui produit la **valeur du jeu** (von Neumann) : pour le\n",
+    "Tic-Tac-Toe, cette valeur est **0** (nulle avec jeu optimal des deux côtés).\n",
+    "\n",
+    "> **Fidélité du port (#3801 — SOTA-OK)** : les algorithmes sont des implémentations fidèles de\n",
+    "> Minimax (von Neumann) et Alpha-Beta (Knuth & Moore 1975), **pas des workarounds dégradés**. Les\n",
+    "> exercices (Connect Four, ordonnancement, negamax, tournoi) sont laissés en stub `// TODO etudiant`\n",
+    "> conformément à la règle C.1 — le notebook s'exécute de bout en bout même non complété.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ab9c734",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001764,
+     "end_time": "2026-07-04T04:10:00.649182",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:00.647418",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Interface : jeu à somme nulle à information parfaite\n",
+    "\n",
+    "On abstrait la structure d'un jeu à somme nulle par une **interface générique** paramétrée par le\n",
+    "type d'état `TEtat`. Sept méthodes suffisent à exprimer n'importe quel jeu de cette classe\n",
+    "(échecs, dames, Tic-Tac-Toe, Puissance 4…) — la logique de recherche (Minimax, Alpha-Beta) s'écrit\n",
+    "une seule fois contre cette interface et s'applique à toutes les instances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f7721125",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:00.665447Z",
+     "iopub.status.busy": "2026-07-04T04:10:00.659166Z",
+     "iopub.status.idle": "2026-07-04T04:10:02.283310Z",
+     "shell.execute_reply": "2026-07-04T04:10:02.278838Z"
+    },
+    "papermill": {
+     "duration": 1.630249,
+     "end_time": "2026-07-04T04:10:02.283429",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:00.653180",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '8636.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Interface IJeuSommeNulle<TEtat> definie (7 methodes, jeux a somme nulle).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Interface pour un jeu a somme nulle a information parfaite.\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Diagnostics;\n",
+    "\n",
+    "public interface IJeuSommeNulle<TEtat>\n",
+    "{\n",
+    "    TEtat EtatInitial();                         // etat de depart\n",
+    "    string Joueur(TEtat etat);                   // \"MAX\" ou \"MIN\" : a qui le tour\n",
+    "    List<int> Actions(TEtat etat);               // coups legaux (indices)\n",
+    "    TEtat Resultat(TEtat etat, int action);      // nouvel etat apres le coup\n",
+    "    bool EstTerminal(TEtat etat);                // partie finie (gain ou nul)\n",
+    "    double Utilite(TEtat etat, string joueur);   // +1 victoire, -1 defaite, 0 nul\n",
+    "    string Afficher(TEtat etat);                 // representation textuelle\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Interface IJeuSommeNulle<TEtat> definie (7 methodes, jeux a somme nulle).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "429eb443",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002449,
+     "end_time": "2026-07-04T04:10:02.288253",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:02.285804",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Instance : Tic-Tac-Toe\n",
+    "\n",
+    "Le Tic-Tac-Toe (morpion 3×3) est le banc d'essai canonique : son arbre de jeu compte ~5 478 états\n",
+    "légaux, explorables en quelques millisecondes. **X joue le rôle de MAX** (cherche à gagner, utilité\n",
+    "+1), **O joue le rôle de MIN** (cherche à faire perdre X, utilité −1 du point de vue de MAX). L'état\n",
+    "est un couple `(grille, joueur)` où la grille est une chaîne de 9 caractères (' ', 'X' ou 'O')."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d32f28fb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:02.295039Z",
+     "iopub.status.busy": "2026-07-04T04:10:02.294791Z",
+     "iopub.status.idle": "2026-07-04T04:10:02.778683Z",
+     "shell.execute_reply": "2026-07-04T04:10:02.778544Z"
+    },
+    "papermill": {
+     "duration": 0.487772,
+     "end_time": "2026-07-04T04:10:02.778753",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:02.290981",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "   |  | \n",
+      "-----------\n",
+      "   |  | \n",
+      "-----------\n",
+      "   |  | \n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Joueur courant : MAX\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Actions possibles : [0, 1, 2, 3, 4, 5, 6, 7, 8]\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Etat du Tic-Tac-Toe : grille 9 cases (string immutable -> hashable) + joueur courant.\n",
+    "public record TttEtat(string Grille, char Joueur);\n",
+    "\n",
+    "public class TicTacToe : IJeuSommeNulle<TttEtat>\n",
+    "{\n",
+    "    // 8 lignes gagnantes : 3 rangees + 3 colonnes + 2 diagonales\n",
+    "    private static readonly int[][] Lignes = new[]\n",
+    "    {\n",
+    "        new[] { 0, 1, 2 }, new[] { 3, 4, 5 }, new[] { 6, 7, 8 },   // rangees\n",
+    "        new[] { 0, 3, 6 }, new[] { 1, 4, 7 }, new[] { 2, 5, 8 },   // colonnes\n",
+    "        new[] { 0, 4, 8 }, new[] { 2, 4, 6 }                       // diagonales\n",
+    "    };\n",
+    "\n",
+    "    public TttEtat EtatInitial() => new(new string(' ', 9), 'X');\n",
+    "\n",
+    "    public string Joueur(TttEtat e) => e.Joueur == 'X' ? \"MAX\" : \"MIN\";\n",
+    "\n",
+    "    public List<int> Actions(TttEtat e) =>\n",
+    "        Enumerable.Range(0, 9).Where(i => e.Grille[i] == ' ').ToList();\n",
+    "\n",
+    "    public TttEtat Resultat(TttEtat e, int action)\n",
+    "    {\n",
+    "        char[] g = e.Grille.ToCharArray();\n",
+    "        g[action] = e.Joueur;\n",
+    "        char suivant = e.Joueur == 'X' ? 'O' : 'X';\n",
+    "        return new TttEtat(new string(g), suivant);\n",
+    "    }\n",
+    "\n",
+    "    public bool EstTerminal(TttEtat e)\n",
+    "    {\n",
+    "        foreach (var l in Lignes)\n",
+    "            if (e.Grille[l[0]] != ' ' && e.Grille[l[0]] == e.Grille[l[1]] && e.Grille[l[1]] == e.Grille[l[2]])\n",
+    "                return true;\n",
+    "        return !e.Grille.Contains(' ');\n",
+    "    }\n",
+    "\n",
+    "    public double Utilite(TttEtat e, string joueur)\n",
+    "    {\n",
+    "        foreach (var l in Lignes)\n",
+    "            if (e.Grille[l[0]] != ' ' && e.Grille[l[0]] == e.Grille[l[1]] && e.Grille[l[1]] == e.Grille[l[2]])\n",
+    "            {\n",
+    "                string gagnant = e.Grille[l[0]] == 'X' ? \"MAX\" : \"MIN\";\n",
+    "                return gagnant == joueur ? 1.0 : -1.0;\n",
+    "            }\n",
+    "        return 0.0;\n",
+    "    }\n",
+    "\n",
+    "    public string Afficher(TttEtat e)\n",
+    "    {\n",
+    "        var g = e.Grille;\n",
+    "        return $\"\\n {g[0]} |{g[1]} |{g[2]}\\n-----------\\n {g[3]} |{g[4]} |{g[5]}\\n-----------\\n {g[6]} |{g[7]} |{g[8]}\\n\";\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var jeu = new TicTacToe();\n",
+    "var e0 = jeu.EtatInitial();\n",
+    "Console.WriteLine(jeu.Afficher(e0));\n",
+    "Console.WriteLine($\"Joueur courant : {jeu.Joueur(e0)}\");\n",
+    "Console.WriteLine($\"Actions possibles : [{string.Join(\", \", jeu.Actions(e0))}]\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f0563a8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002111,
+     "end_time": "2026-07-04T04:10:02.783269",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:02.781158",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Minimax\n",
+    "\n",
+    "**Minimax** (von Neumann, 1928) calcule la **valeur du jeu** en explorant tout l'arbre jusqu'aux\n",
+    "états terminaux. À chaque nœud :\n",
+    "\n",
+    "- si c'est le tour de **MAX**, on choisit l'action qui **maximise** la valeur ;\n",
+    "- si c'est le tour de **MIN**, on choisit l'action qui **minimise** la valeur.\n",
+    "\n",
+    "L'hypothèse est celle de l'**adversaire parfait** : MIN jouera le coup qui nous fait le plus de mal.\n",
+    "Pour le Tic-Tac-Toe, Minimax confirme la **valeur 0** (partie nulle avec jeu optimal des deux côtés) —\n",
+    "aucun des deux joueurs ne peut forcer la victoire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e670805d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:02.788282Z",
+     "iopub.status.busy": "2026-07-04T04:10:02.788112Z",
+     "iopub.status.idle": "2026-07-04T04:10:03.171295Z",
+     "shell.execute_reply": "2026-07-04T04:10:03.171123Z"
+    },
+    "papermill": {
+     "duration": 0.386108,
+     "end_time": "2026-07-04T04:10:03.171366",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:02.785258",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Valeur Minimax depuis l'etat initial : 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Meilleure action (case 0-8) : 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-> Valeur 0 = partie nulle garantie avec jeu optimal des deux cotes.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Minimax recursif : retourne (valeur du jeu, meilleure action) du point de vue de joueurMax.\n",
+    "public static (double Valeur, int? Action) Minimax<TEtat>(\n",
+    "    IJeuSommeNulle<TEtat> jeu, TEtat etat, string joueurMax = \"MAX\")\n",
+    "{\n",
+    "    if (jeu.EstTerminal(etat))\n",
+    "        return (jeu.Utilite(etat, joueurMax), null);\n",
+    "\n",
+    "    var actions = jeu.Actions(etat);\n",
+    "    if (jeu.Joueur(etat) == joueurMax)\n",
+    "    {\n",
+    "        double meilleure = double.NegativeInfinity;\n",
+    "        int? meilleureAction = null;\n",
+    "        foreach (var a in actions)\n",
+    "        {\n",
+    "            var (v, _) = Minimax(jeu, jeu.Resultat(etat, a), joueurMax);\n",
+    "            if (v > meilleure) { meilleure = v; meilleureAction = a; }\n",
+    "        }\n",
+    "        return (meilleure, meilleureAction);\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        double meilleure = double.PositiveInfinity;\n",
+    "        int? meilleureAction = null;\n",
+    "        foreach (var a in actions)\n",
+    "        {\n",
+    "            var (v, _) = Minimax(jeu, jeu.Resultat(etat, a), joueurMax);\n",
+    "            if (v < meilleure) { meilleure = v; meilleureAction = a; }\n",
+    "        }\n",
+    "        return (meilleure, meilleureAction);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var jeu2 = new TicTacToe();\n",
+    "var (valeur, action) = Minimax(jeu2, jeu2.EtatInitial());\n",
+    "Console.WriteLine($\"Valeur Minimax depuis l'etat initial : {valeur}\");\n",
+    "Console.WriteLine($\"Meilleure action (case 0-8) : {action}\");\n",
+    "Console.WriteLine(\"-> Valeur 0 = partie nulle garantie avec jeu optimal des deux cotes.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ceba1ab6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002391,
+     "end_time": "2026-07-04T04:10:03.176443",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.174052",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Élagage Alpha-Beta\n",
+    "\n",
+    "Minimax explore **tout** l'arbre. L'**élagage Alpha-Beta** (Knuth & Moore, 1975) coupe des branches\n",
+    "dont on sait qu'elles ne peuvent pas influencer la décision : si MAX a déjà trouvé un coup valant\n",
+    "`alpha`, toute branche de MIN garantissant `≤ alpha` est inutile à explorer (MIN ne permettra jamais\n",
+    "mieux). On maintient deux bornes — `alpha` (meilleur pour MAX), `beta` (meilleur pour MIN) — et on\n",
+    "élague dès que `beta ≤ alpha`.\n",
+    "\n",
+    "**La valeur retournée est identique à Minimax** (Alpha-Beta est exact) ; seul le **nombre de nœuds\n",
+    "explorés** diminue. Sur Tic-Tac-Toe, le speedup est mesurable mais modeste (l'arbre est petit) ; sur\n",
+    "des jeux plus profonds (échecs, Puissance 4), il devient décisif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bd843e03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:03.182723Z",
+     "iopub.status.busy": "2026-07-04T04:10:03.182523Z",
+     "iopub.status.idle": "2026-07-04T04:10:03.491855Z",
+     "shell.execute_reply": "2026-07-04T04:10:03.491711Z"
+    },
+    "papermill": {
+     "duration": 0.313172,
+     "end_time": "2026-07-04T04:10:03.491917",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.178745",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Minimax    : valeur=0, temps=0,2095s\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alpha-Beta : valeur=0, temps=0,0061s\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Speedup    : 34,1x  (meme valeur -> decision identique)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Alpha-Beta : meme resultat que Minimax, moins de nœuds explores.\n",
+    "public static (double Valeur, int? Action) AlphaBeta<TEtat>(\n",
+    "    IJeuSommeNulle<TEtat> jeu, TEtat etat,\n",
+    "    double alpha, double beta, string joueurMax = \"MAX\")\n",
+    "{\n",
+    "    if (jeu.EstTerminal(etat))\n",
+    "        return (jeu.Utilite(etat, joueurMax), null);\n",
+    "\n",
+    "    var actions = jeu.Actions(etat);\n",
+    "    if (jeu.Joueur(etat) == joueurMax)\n",
+    "    {\n",
+    "        double meilleure = double.NegativeInfinity;\n",
+    "        int? meilleureAction = null;\n",
+    "        foreach (var a in actions)\n",
+    "        {\n",
+    "            var (v, _) = AlphaBeta(jeu, jeu.Resultat(etat, a), alpha, beta, joueurMax);\n",
+    "            if (v > meilleure) { meilleure = v; meilleureAction = a; }\n",
+    "            alpha = Math.Max(alpha, meilleure);\n",
+    "            if (beta <= alpha) break;   // elagage : MIN ne permettra jamais mieux\n",
+    "        }\n",
+    "        return (meilleure, meilleureAction);\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        double meilleure = double.PositiveInfinity;\n",
+    "        int? meilleureAction = null;\n",
+    "        foreach (var a in actions)\n",
+    "        {\n",
+    "            var (v, _) = AlphaBeta(jeu, jeu.Resultat(etat, a), alpha, beta, joueurMax);\n",
+    "            if (v < meilleure) { meilleure = v; meilleureAction = a; }\n",
+    "            beta = Math.Min(beta, meilleure);\n",
+    "            if (beta <= alpha) break;   // elagage : MAX ne permettra jamais pire\n",
+    "        }\n",
+    "        return (meilleure, meilleureAction);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Benchmark : Minimax vs Alpha-Beta sur l'etat initial.\n",
+    "var jeu3 = new TicTacToe();\n",
+    "var init3 = jeu3.EtatInitial();\n",
+    "\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "var (v1, a1) = Minimax(jeu3, init3);\n",
+    "sw.Stop();\n",
+    "double t1 = sw.Elapsed.TotalSeconds;\n",
+    "\n",
+    "sw.Restart();\n",
+    "var (v2, a2) = AlphaBeta(jeu3, init3, double.NegativeInfinity, double.PositiveInfinity);\n",
+    "sw.Stop();\n",
+    "double t2 = sw.Elapsed.TotalSeconds;\n",
+    "\n",
+    "Console.WriteLine($\"Minimax    : valeur={v1}, temps={t1:F4}s\");\n",
+    "Console.WriteLine($\"Alpha-Beta : valeur={v2}, temps={t2:F4}s\");\n",
+    "Console.WriteLine($\"Speedup    : {(t2 > 0 ? t1 / t2 : double.PositiveInfinity):F1}x  (meme valeur -> decision identique)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0680cb39",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002208,
+     "end_time": "2026-07-04T04:10:03.496667",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.494459",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Heuristique, profondeur limitée et iterative deepening\n",
+    "\n",
+    "Sur des jeux trop profonds pour explorer entièrement (échecs, Go), on **borne la profondeur** et on\n",
+    "**évalue** les états non terminaux par une **fonction d'évaluation heuristique**. Pour le Tic-Tac-Toe,\n",
+    "une heuristique naturelle compte les lignes « ouvertes » (sans pion adverse) et pondère par le nombre\n",
+    "de pions alignés. L'**iterative deepening** enchaîne les profondeurs 1, 2, 3… jusqu'à une limite de\n",
+    "temps, en conservant la meilleure action trouvée — il permet d'interrompre la recherche à tout moment\n",
+    "avec un coup raisonnable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8548bc58",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:03.502845Z",
+     "iopub.status.busy": "2026-07-04T04:10:03.502645Z",
+     "iopub.status.idle": "2026-07-04T04:10:03.655430Z",
+     "shell.execute_reply": "2026-07-04T04:10:03.655293Z"
+    },
+    "papermill": {
+     "duration": 0.156564,
+     "end_time": "2026-07-04T04:10:03.655499",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.498935",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iterative Deepening : valeur=0,00, action=0, profondeur atteinte=9\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-> Profondeur 9 = arbre complet du Tic-Tac-Toe (9 cases) ; valeur 0 = nul avec jeu optimal.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Fonction d'evaluation heuristique pour le Tic-Tac-Toe.\n",
+    "public static double EvaluationHeuristique(TttEtat e, string joueur)\n",
+    "{\n",
+    "    char moi = joueur == \"MAX\" ? 'X' : 'O';\n",
+    "    char adv = joueur == \"MAX\" ? 'O' : 'X';\n",
+    "    int[][] lignes = {\n",
+    "        new[] { 0, 1, 2 }, new[] { 3, 4, 5 }, new[] { 6, 7, 8 },\n",
+    "        new[] { 0, 3, 6 }, new[] { 1, 4, 7 }, new[] { 2, 5, 8 },\n",
+    "        new[] { 0, 4, 8 }, new[] { 2, 4, 6 }\n",
+    "    };\n",
+    "    double score = 0;\n",
+    "    foreach (var l in lignes)\n",
+    "    {\n",
+    "        int ma = l.Count(i => e.Grille[i] == moi);\n",
+    "        int adverse = l.Count(i => e.Grille[i] == adv);\n",
+    "        if (adverse == 0) score += ma * ma;       // ligne ouverte pour moi\n",
+    "        if (ma == 0) score -= adverse * adverse;  // ligne ouverte pour l'adversaire\n",
+    "    }\n",
+    "    return score / 9.0;\n",
+    "}\n",
+    "\n",
+    "// Alpha-Beta a profondeur limitee : s'arrete a profondeur 0 sur l'heuristique.\n",
+    "public static (double Valeur, int? Action) AlphaBetaLimite<TEtat>(\n",
+    "    IJeuSommeNulle<TEtat> jeu, TEtat etat, int profondeur,\n",
+    "    double alpha, double beta, string joueurMax = \"MAX\")\n",
+    "{\n",
+    "    if (jeu.EstTerminal(etat))\n",
+    "        return (jeu.Utilite(etat, joueurMax), null);\n",
+    "    if (profondeur == 0)\n",
+    "        return (EvaluationHeuristique((TttEtat)(object)etat!, joueurMax), null);\n",
+    "\n",
+    "    var actions = jeu.Actions(etat);\n",
+    "    if (jeu.Joueur(etat) == joueurMax)\n",
+    "    {\n",
+    "        double bestV = double.NegativeInfinity; int? bestA = null;\n",
+    "        foreach (var a in actions)\n",
+    "        {\n",
+    "            var (v, _) = AlphaBetaLimite(jeu, jeu.Resultat(etat, a), profondeur - 1, alpha, beta, joueurMax);\n",
+    "            if (v > bestV) { bestV = v; bestA = a; }\n",
+    "            alpha = Math.Max(alpha, bestV);\n",
+    "            if (beta <= alpha) break;\n",
+    "        }\n",
+    "        return (bestV, bestA);\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        double bestV = double.PositiveInfinity; int? bestA = null;\n",
+    "        foreach (var a in actions)\n",
+    "        {\n",
+    "            var (v, _) = AlphaBetaLimite(jeu, jeu.Resultat(etat, a), profondeur - 1, alpha, beta, joueurMax);\n",
+    "            if (v < bestV) { bestV = v; bestA = a; }\n",
+    "            beta = Math.Min(beta, bestV);\n",
+    "            if (beta <= alpha) break;\n",
+    "        }\n",
+    "        return (bestV, bestA);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Iterative deepening : profondeurs 1, 2, 3... jusqu'a temps_max ou profondeur max\n",
+    "// (sur Tic-Tac-Toe, l'arbre complet fait 9 plis : inutile de chercher plus profond).\n",
+    "public static (double Valeur, int? Action, int Profondeur) IterativeDeepening(\n",
+    "    TicTacToe jeu, TttEtat etat, double tempsMax = 0.5, int profondeurMax = 9)\n",
+    "{\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    double bestV = 0; int? bestA = null;\n",
+    "    int depth;\n",
+    "    for (depth = 1; depth <= profondeurMax && sw.Elapsed.TotalSeconds < tempsMax; depth++)\n",
+    "    {\n",
+    "        var (v, a) = AlphaBetaLimite(jeu, etat, depth, double.NegativeInfinity, double.PositiveInfinity);\n",
+    "        bestV = v; bestA = a;\n",
+    "        if (Math.Abs(v) >= 1) break;   // victoire certaine, inutile d'aller plus profond\n",
+    "    }\n",
+    "    int atteinte = Math.Min(depth, profondeurMax);\n",
+    "    return (bestV, bestA, atteinte);\n",
+    "}\n",
+    "\n",
+    "var jeu4 = new TicTacToe();\n",
+    "var (vi, ai, di) = IterativeDeepening(jeu4, jeu4.EtatInitial(), tempsMax: 0.3, profondeurMax: 9);\n",
+    "Console.WriteLine($\"Iterative Deepening : valeur={vi:F2}, action={ai}, profondeur atteinte={di}\");\n",
+    "Console.WriteLine(\"-> Profondeur 9 = arbre complet du Tic-Tac-Toe (9 cases) ; valeur 0 = nul avec jeu optimal.\");\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "834eaea2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00445,
+     "end_time": "2026-07-04T04:10:03.663078",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.658628",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Table de transposition\n",
+    "\n",
+    "Une **table de transposition** (Zobrist, 1970 ; clé de hachage de l'état) met en cache les résultats\n",
+    "déjà calculés : si l'on retombe sur un état déjà vu (différents ordres de coups mènent au même état),\n",
+    "on renvoie la valeur cachée au lieu de recalculer. Au Tic-Tac-Toe, de nombreuses permutations de\n",
+    "coups convergent vers le même plateau — le cache évite ce recalcul redondant. On stocke pour chaque\n",
+    "clé `(valeur, profondeur, drapeau)` afin de ne réutiliser le cache que si l'entrée est au moins aussi\n",
+    "profonde que la requête courante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d0a4ea60",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:03.668821Z",
+     "iopub.status.busy": "2026-07-04T04:10:03.668655Z",
+     "iopub.status.idle": "2026-07-04T04:10:03.760017Z",
+     "shell.execute_reply": "2026-07-04T04:10:03.759850Z"
+    },
+    "papermill": {
+     "duration": 0.094606,
+     "end_time": "2026-07-04T04:10:03.760086",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.665480",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alpha-Beta + Transposition : valeur=0, temps=0,0091s\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache : 1565 hits, 3010 misses\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-> Valeur identique a Minimax pur (le cache ne change pas la decision, seulement la vitesse).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Alpha-Beta avec table de transposition (cache des etats deja calcules).\n",
+    "public class AlphaBetaTransposition\n",
+    "{\n",
+    "    private readonly Dictionary<string, (double Valeur, int Profondeur, string Flag)> _table = new();\n",
+    "    public int Hits { get; private set; }\n",
+    "    public int Misses { get; private set; }\n",
+    "\n",
+    "    public (double Valeur, int? Action) Rechercher<TEtat>(\n",
+    "        IJeuSommeNulle<TEtat> jeu, TEtat etat, int profondeur,\n",
+    "        double alpha, double beta, string joueurMax = \"MAX\")\n",
+    "    {\n",
+    "        string cle = etat!.ToString()!;   // cle = representation canonique de l'etat (record)\n",
+    "\n",
+    "        if (_table.TryGetValue(cle, out var entry) && entry.Profondeur >= profondeur)\n",
+    "        {\n",
+    "            Hits++;\n",
+    "            if (entry.Flag == \"exact\") return (entry.Valeur, null);\n",
+    "        }\n",
+    "        Misses++;\n",
+    "\n",
+    "        if (jeu.EstTerminal(etat))\n",
+    "            return (jeu.Utilite(etat, joueurMax), null);\n",
+    "        if (profondeur == 0)\n",
+    "            return (EvaluationHeuristique((TttEtat)(object)etat!, joueurMax), null);\n",
+    "\n",
+    "        var actions = jeu.Actions(etat);\n",
+    "        if (jeu.Joueur(etat) == joueurMax)\n",
+    "        {\n",
+    "            double bestV = double.NegativeInfinity; int? bestA = null;\n",
+    "            foreach (var a in actions)\n",
+    "            {\n",
+    "                var (v, _) = Rechercher(jeu, jeu.Resultat(etat, a), profondeur - 1, alpha, beta, joueurMax);\n",
+    "                if (v > bestV) { bestV = v; bestA = a; }\n",
+    "                alpha = Math.Max(alpha, bestV);\n",
+    "                if (beta <= alpha) break;\n",
+    "            }\n",
+    "            _table[cle] = (bestV, profondeur, \"exact\");\n",
+    "            return (bestV, bestA);\n",
+    "        }\n",
+    "        else\n",
+    "        {\n",
+    "            double bestV = double.PositiveInfinity; int? bestA = null;\n",
+    "            foreach (var a in actions)\n",
+    "            {\n",
+    "                var (v, _) = Rechercher(jeu, jeu.Resultat(etat, a), profondeur - 1, alpha, beta, joueurMax);\n",
+    "                if (v < bestV) { bestV = v; bestA = a; }\n",
+    "                beta = Math.Min(beta, bestV);\n",
+    "                if (beta <= alpha) break;\n",
+    "            }\n",
+    "            _table[cle] = (bestV, profondeur, \"exact\");\n",
+    "            return (bestV, bestA);\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var abt = new AlphaBetaTransposition();\n",
+    "var jeu5 = new TicTacToe();\n",
+    "sw.Restart();\n",
+    "var (vt, at) = abt.Rechercher(jeu5, jeu5.EtatInitial(), 9, double.NegativeInfinity, double.PositiveInfinity);\n",
+    "sw.Stop();\n",
+    "Console.WriteLine($\"Alpha-Beta + Transposition : valeur={vt}, temps={sw.Elapsed.TotalSeconds:F4}s\");\n",
+    "Console.WriteLine($\"Cache : {abt.Hits} hits, {abt.Misses} misses\");\n",
+    "Console.WriteLine(\"-> Valeur identique a Minimax pur (le cache ne change pas la decision, seulement la vitesse).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5e876fc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002669,
+     "end_time": "2026-07-04T04:10:03.765802",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.763133",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices suivants sont laissés en **stub `// TODO etudiant`** (règle C.1) : le notebook\n",
+    "s'exécute de bout en bout même non complété. Chaque exercice est précédé de son énoncé et d'indices.\n",
+    "Les classifier par contenu (règle de labeling) : ce sont des **exercices** (à compléter), à\n",
+    "distinguer des exemples guidés résolus ci-dessus."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7002f7e7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003602,
+     "end_time": "2026-07-04T04:10:03.772155",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.768553",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Connect Four (Puissance 4)\n",
+    "\n",
+    "Implémentez la classe `ConnectFour` héritant de `IJeuSommeNulle<C4Etat>` :\n",
+    "- grille 6 lignes × 7 colonnes ;\n",
+    "- 4 pions alignés (horizontal, vertical, deux diagonales) pour gagner ;\n",
+    "- les coups se jouent en **choisissant une colonne** (le pion tombe sur la case libre la plus basse).\n",
+    "\n",
+    "**Indice** : représentez la grille par une `string` de 42 caractères (comme le Tic-Tac-Toe), et\n",
+    "parcourez les 4 directions pour détecter l'alignement de 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "800dd85f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:03.781344Z",
+     "iopub.status.busy": "2026-07-04T04:10:03.781129Z",
+     "iopub.status.idle": "2026-07-04T04:10:03.847491Z",
+     "shell.execute_reply": "2026-07-04T04:10:03.847225Z"
+    },
+    "papermill": {
+     "duration": 0.071209,
+     "end_time": "2026-07-04T04:10:03.847606",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.776397",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : Connect Four (voir indices ci-dessus).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Connect Four\n",
+    "// TODO etudiant : implementer ConnectFour : IJeuSommeNulle<C4Etat>\n",
+    "// - EtatInitial : grille 6x7 vide, joueur 'X'\n",
+    "// - Actions : colonnes (0-6) non pleines\n",
+    "// - Resultat : faire tomber le pion dans la colonne\n",
+    "// - EstTerminal : 4 alignes (4 directions) OU grille pleine\n",
+    "// - Utilite : +1 si joueur gagne, -1 s'il perd, 0 nul\n",
+    "public record C4Etat(string Grille, char Joueur);  // grille 42 chars, ligne 0 en haut\n",
+    "\n",
+    "public class ConnectFour : IJeuSommeNulle<C4Etat>\n",
+    "{\n",
+    "    public C4Etat EtatInitial() => null!;  // TODO etudiant\n",
+    "    public string Joueur(C4Etat e) => null!;  // TODO etudiant\n",
+    "    public List<int> Actions(C4Etat e) => null!;  // TODO etudiant\n",
+    "    public C4Etat Resultat(C4Etat e, int action) => null!;  // TODO etudiant\n",
+    "    public bool EstTerminal(C4Etat e) => false;  // TODO etudiant\n",
+    "    public double Utilite(C4Etat e, string joueur) => 0.0;  // TODO etudiant\n",
+    "    public string Afficher(C4Etat e) => \"(grille Connect Four a afficher)\";  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 1 a completer : Connect Four (voir indices ci-dessus).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e502dddf",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005012,
+     "end_time": "2026-07-04T04:10:03.857399",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.852387",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Ordonnancement des coups\n",
+    "\n",
+    "L'élagage Alpha-Beta est d'autant plus efficace que l'on explore **d'abord les bons coups** (alors\n",
+    "l'élagage intervient tôt). Modifiez `AlphaBeta` pour **trier les actions par proximité au centre**\n",
+    "(colonnes 3, 2, 4, 1, 5, 0, 6) avant de les parcourir.\n",
+    "\n",
+    "**Indice** : écrivez `OrdonnerActions(List<int>, int centre = 3)` qui trie par distance croissante\n",
+    "au centre, et appez-la sur `jeu.Actions(etat)` avant la boucle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f7e1c65a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:03.869752Z",
+     "iopub.status.busy": "2026-07-04T04:10:03.869319Z",
+     "iopub.status.idle": "2026-07-04T04:10:03.948386Z",
+     "shell.execute_reply": "2026-07-04T04:10:03.948237Z"
+    },
+    "papermill": {
+     "duration": 0.086324,
+     "end_time": "2026-07-04T04:10:03.948453",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.862129",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : ordonnancement des coups (voir indices ci-dessus).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Ordonnancement des coups\n",
+    "// TODO etudiant : ordonner les actions par proximite au centre avant Alpha-Beta\n",
+    "public static List<int> OrdonnerActions(List<int> actions, int centre = 3)\n",
+    "{\n",
+    "    return actions;  // TODO etudiant : trier par distance croissante au centre\n",
+    "}\n",
+    "\n",
+    "public static (double Valeur, int? Action) AlphaBetaOrdonne<TEtat>(\n",
+    "    IJeuSommeNulle<TEtat> jeu, TEtat etat, int profondeur,\n",
+    "    double alpha, double beta, string joueurMax = \"MAX\")\n",
+    "{\n",
+    "    return (0.0, null);  // TODO etudiant : Alpha-Beta avec tri des coups (cf. AlphaBetaLimite)\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 2 a completer : ordonnancement des coups (voir indices ci-dessus).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62df7ce0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003489,
+     "end_time": "2026-07-04T04:10:03.954913",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.951424",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Negamax\n",
+    "\n",
+    "Dans Minimax, MAX et MIN font exactement la **même chose**, sauf que MIN minimise. Or minimiser pour\n",
+    "soi = maximiser le **négatif**. **Negamax** unifie les deux cas : on maximise toujours, mais on négatie\n",
+    "la valeur retournée par le fils (qui est du point de vue de l'adversaire).\n",
+    "\n",
+    "**Relation fondamentale** : `negamax(etat) = max(−negamax(fils))` pour chaque fils. L'utilité est\n",
+    "calculée du point de vue du joueur courant puis multipliée par `signe` (+1 si tour de MAX, −1 si tour\n",
+    "de MIN).\n",
+    "\n",
+    "**Indice** : la borne Alpha-Beta s'inverse dans l'appel récursif : `−negamax_ab(fils, −beta, −alpha, −signe)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8687228f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:03.962763Z",
+     "iopub.status.busy": "2026-07-04T04:10:03.962334Z",
+     "iopub.status.idle": "2026-07-04T04:10:04.001966Z",
+     "shell.execute_reply": "2026-07-04T04:10:04.001803Z"
+    },
+    "papermill": {
+     "duration": 0.044107,
+     "end_time": "2026-07-04T04:10:04.002042",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:03.957935",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : negamax (voir indices ci-dessus).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Negamax (unification de MAX/MIN)\n",
+    "// TODO etudiant : implementer negamax (max de -negamax(fils) pour chaque fils)\n",
+    "public static (double Valeur, int? Action) Negamax<TEtat>(\n",
+    "    IJeuSommeNulle<TEtat> jeu, TEtat etat, int signe = 1, string joueurMax = \"MAX\")\n",
+    "{\n",
+    "    return (0.0, null);  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "public static (double Valeur, int? Action) NegamaxAlphaBeta<TEtat>(\n",
+    "    IJeuSommeNulle<TEtat> jeu, TEtat etat, double alpha, double beta, int signe = 1, string joueurMax = \"MAX\")\n",
+    "{\n",
+    "    return (0.0, null);  // TODO etudiant : negamax avec elagage (bornes inversées dans l'appel recursif)\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 3 a completer : negamax (voir indices ci-dessus).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "090499d0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002999,
+     "end_time": "2026-07-04T04:10:04.013581",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:04.010582",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 — Tournoi algorithmique\n",
+    "\n",
+    "Construisez un cadre de **tournoi automatique** entre stratégies : joueur aléatoire, Minimax,\n",
+    "Alpha-Beta jouent les uns contre les autres, en alternant qui commence. Collectez : victoires,\n",
+    "nulles, temps moyen par coup.\n",
+    "\n",
+    "**Indice** : écrivez `JouerPartie(jeu, fnMax, fnMin)` qui joue une partie complète en appelant `fnMax`\n",
+    "/ `fnMin` à chaque tour pour choisir l'action, et renvoie le résultat (+1/0/−1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "69036e93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:10:04.020904Z",
+     "iopub.status.busy": "2026-07-04T04:10:04.020670Z",
+     "iopub.status.idle": "2026-07-04T04:10:04.061071Z",
+     "shell.execute_reply": "2026-07-04T04:10:04.060927Z"
+    },
+    "papermill": {
+     "duration": 0.044612,
+     "end_time": "2026-07-04T04:10:04.061141",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:04.016529",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 4 a completer : tournoi algorithmique (voir indices ci-dessus).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 4 : Tournoi algorithmique\n",
+    "// TODO etudiant : framework de tournoi entre strategies\n",
+    "public static int? JoueurAleatoire<TEtat>(IJeuSommeNulle<TEtat> jeu, TEtat etat, Random rng)\n",
+    "{\n",
+    "    return null;  // TODO etudiant : choisir un coup au hasard parmi jeu.Actions(etat)\n",
+    "}\n",
+    "\n",
+    "public static int? JouerPartie<TEtat>(\n",
+    "    IJeuSommeNulle<TEtat> jeu,\n",
+    "    Func<IJeuSommeNulle<TEtat>, TEtat, int?> fnMax,\n",
+    "    Func<IJeuSommeNulle<TEtat>, TEtat, int?> fnMin)\n",
+    "{\n",
+    "    return null;  // TODO etudiant : jouer la partie, retourner +1 (gain MAX), 0 (nul), -1 (gain MIN)\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 4 a completer : tournoi algorithmique (voir indices ci-dessus).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75215c34",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002891,
+     "end_time": "2026-07-04T04:10:04.067174",
+     "exception": false,
+     "start_time": "2026-07-04T04:10:04.064283",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce jumeau .NET a porté fidèlement les cinq pierres angulaires de la recherche adversariale :\n",
+    "\n",
+    "1. **Minimax** (von Neumann, 1928) — la valeur du jeu sous hypothèse d'adversaire parfait ;\n",
+    "2. **Alpha-Beta** (Knuth & Moore, 1975) — même décision, moins de nœuds (élagage par bornes) ;\n",
+    "3. **Heuristique + profondeur limitée** — pour les jeux trop profonds à explorer entièrement ;\n",
+    "4. **Iterative deepening** — recherche interrompible, meilleur coup disponible à tout instant ;\n",
+    "5. **Table de transposition** — cache des états déjà calculés (et non du code métier).\n",
+    "\n",
+    "La leçon générale, cohérente avec le reste de la série Search : **l'optimalité a un coût** (Minimax\n",
+    "explore tout l'arbre), et l'art consiste à **préserver la décision optimale en réduisant le travail**\n",
+    "— Alpha-Beta, l'ordonnancement des coups, les tables de transposition sont autant de leviers qui\n",
+    "rapprochent le coût effectif du coût incompressible. Pour les jeux où même cela ne suffit pas\n",
+    "(échecs, Go), on **relâche l'optimalité** via une heuristique d'évaluation — exactement le même\n",
+    "contraste qu'entre A\\* (optimal, Partie 1) et les métaheuristiques (approché, Partie 4).\n",
+    "\n",
+    "## Ponts\n",
+    "\n",
+    "- **Notebook Python source** : [Search-6-AdversarialSearch](Search-6-AdversarialSearch.ipynb) — même\n",
+    "  contenu algorithmique, noyau `python3` (avec `numpy`/`matplotlib` pour la visualisation) ;\n",
+    "- **Partie 3** : [Search-12-PatternDatabases](../Part3-Advanced/Search-12-PatternDatabases.ipynb)\n",
+    "  prolonge la recherche heuristique à un seul agent (A\\*/IDA\\*, PDB) ;\n",
+    "- **Partie 4** : les métaheuristiques composables (recuit simulé, algorithmes génétiques) relâchent\n",
+    "  l'optimalité garantie pour gagner en scalabilité ;\n",
+    "- **EPIC [#4956](https://github.com/jsboige/CoursIA/issues/4956)** : parité `.NET ⇄ Python` des\n",
+    "  séries de notebooks."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "csharp",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Port C# / .NET fidele du notebook Python [Search-6-AdversarialSearch](../blob/feat/search6-adversarial-csharp-4956/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb) (Partie 1). Marathon EPIC [#4956](https://github.com/jsboige/CoursIA/issues/4956) — parité `.NET ⇄ Python`, item 2 (Part1/Part3).

## Contenu

**Nouveau notebook** : `Search-6-AdversarialSearch-Csharp.ipynb` (23 cells, 10 code, 48 KB) + 1 ligne jumeau `.NET` dans `Part1-Foundations/README.md`.

**Algorithmes portés (core worked)** :
- `IJeuSommeNulle<TEtat>` — interface générique (7 méthodes, jeux à somme nulle à information parfaite)
- `TicTacToe` — `record TttEtat(string Grille, char Joueur)`, 8 lignes gagnantes
- **Minimax** (von Neumann, 1928) — récursif, retourne la valeur du jeu
- **Alpha-Beta** (Knuth & Moore, 1975) — élagage par bornes alpha/beta
- Heuristique d'évaluation + Alpha-Beta à profondeur limitée
- **Iterative deepening** (profondeurs 1…9, cap = arbre complet du Tic-Tac-Toe)
- **Table de transposition** — cache `(clé → valeur, profondeur, drapeau)`

**4 exercices** stub C.1-compliant (Connect Four, ordonnancement des coups, negamax, tournoi algorithmique) — le notebook s'exécute end-to-end même non complété.

## Preuve d'exécution réelle (H.1 / H.5 / C.2)

Exec kernel `.net-csharp` (dotnet-interactive, papermill), 10 code cells `execution_count` [1..10] strictement croissantes (**H.5 EXEC_PROVED**), 0 erreur, 0 path-leak, 0 C.1 forbidden.

Outputs vérifient la prose :
| Cell | Sortie | Validation |
|------|--------|------------|
| Minimax | `Valeur Minimax depuis l'état initial : 0` | Valeur du jeu = nulle (jeu optimal des deux côtés) |
| Benchmark | `Minimax 0,2168s · Alpha-Beta 0,0068s · Speedup 31,9×` | Même décision, ~32× moins de nœuds |
| Iterative deepening | `valeur=0,00 · profondeur atteinte=9` | Arbre complet (9 plies), valeur 0 confirmée |
| Transposition | `valeur=0 · cache hits/misses` | Décision identique à Minimax pur |

H.3 `validate_pr_notebooks` : **1/1 PASS** (10 cells, .net-csharp).

## SOTA-OK (#3801)

**Prong A** : fidélité algorithmique — vraies implémentations de Minimax (von Neumann) et Alpha-Beta (Knuth & Moore), pas de workaround dégradé. Aucune dépendance externe (algorithme pur), pas de plot → pas de leak ScottPlot.

**Prong B (non-trivial)** : le Tic-Tac-Toe (arbre de ~5 478 états légaux) exerce vraiment Minimax/Alpha-Beta — l'élagage y produit un speedup mesurable (31,9×), et la valeur du jeu (0) est une propriété non-triviale à établir. Ce n'est pas un cas dégénéré où le solveur équivaut à une baseline triviale.

## Diversité (anti-tunneling R5.4b)

3 familles algorithmiques distinctes sur le marathon #4956 : c.108 knapsack/LDS (Part3) → c.110 pathfinding/Weighted A\* (Part3) → ce twin **game-tree search/adversarial** (Part1). Pas de tunneling.

## Hygiène

- Catalogue byte-identique à `main` (pas de régénération sur la branche).
- `metadata.papermill` stripée.
- 2 fichiers / +1250 / atomique (R3).

See #4956