### PR TITLE
docs(search): register App-20 SudokuBenchmark in Applications leaf README (See #3973)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -1,8 +1,8 @@
 # Search - Applications
 
-C'est ici que la série Search se confronte au réel. Les 21 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents.
+C'est ici que la série Search se confronte au réel. Les 22 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents.
 
-Sous-série de **21 notebooks** | **~14h05** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`)
+Sous-série de **22 notebooks** | **~14h55** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`)
 
 ## Pourquoi cette sous-série
 
@@ -31,7 +31,7 @@ Un algorithme compris sur un exemple jouet n'est pas encore un algorithme maîtr
 ```text
 Applications/
 ├── Search/     # Applications purement Search (2 notebooks)
-├── CSP/        # Applications CSP (12 notebooks)
+├── CSP/        # Applications CSP (13 notebooks)
 └── Hybrid/     # Metaheuristiques / GA (7 notebooks)
 ```
 
@@ -41,7 +41,7 @@ flowchart LR
     P2["<b>Partie 2 — CSP</b><br/>modélisation déclarative<br/>(X, D, C) + propagation"]
     P4["<b>Partie 4 — Métaheuristiques</b><br/>SA, GA, ACO, recuit"]
     S["<b>Applications Search</b> (2)<br/>ConnectFour : Minimax,<br/>MCTS, DQN-RL"]
-    C["<b>Applications CSP</b> (12)<br/>N-Queens, GraphColoring,<br/>Nurse/JobShop, Minesweeper,<br/>Wordle, Picross, WFC..."]
+    C["<b>Applications CSP</b> (13)<br/>N-Queens, GraphColoring,<br/>Nurse/JobShop, Minesweeper,<br/>Wordle, Picross, WFC,<br/>Sudoku..."]
     H["<b>Applications Hybrides</b> (7)<br/>EdgeDetection, Portfolio,<br/>TSP, VRP, Hyperparameter"]
     P1 --> S
     P2 --> C
@@ -81,6 +81,7 @@ Le gros de la sous-série, et un panorama de ce que la programmation par contrai
 | 10 | [App-15-SportsScheduling](CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, équité, déplacements | Projet étudiant |
 | 11 | [App-16-Crossword-CSP](CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croisés : backtracking, OR-Tools, génération | Projet étudiant |
 | 12 | [App-19-ProceduralGeneration-WFC](CSP/App-19-ProceduralGeneration-WFC.ipynb) | ~45 min | Génération procédurale : Wave Function Collapse via CP-SAT | Projet étudiant |
+| 13 | [App-20-SudokuBenchmark-Python](CSP/App-20-SudokuBenchmark-Python.ipynb) | ~50 min | Benchmark comparatif : 4 solveurs Sudoku, un problème NP-complet | Nouveau |
 
 ---
 


### PR DESCRIPTION
## Résumé

Rafraîchissement éditorial de la feuille `Search/Applications/README.md` : le notebook **App-20-SudokuBenchmark-Python** (benchmark Prong-B #3801, ajouté via #5121) était orphelin dans toute la prose Applications. Il est désormais inscrit dans le tableau des applications CSP, avec correction des sous-comptes :

- total **21 → 22** notebooks (**~14h05 → ~14h55**)
- sous-groupe CSP **12 → 13** (arbre + diagramme mermaid + tableau)

## Portée

- **1 fichier** : `MyIA.AI.Notebooks/Search/Applications/README.md` (5 insertions, 4 suppressions).
- **FR-first** (No-Pendulum : pas de réécriture gratuite, freshness seulement).
- **CATALOG-STATUS intact** (bloc cron-owned ; le catalogue liste déjà Applications=22).
- Le README intermédiaire `Search/README.md` n'est **pas** touché : son alignement stats App-20 est déjà couvert par la PR ouverte **#5297** (pas de duplication).

Éditorial partiel — See #4208 / #4212 / #3973.