### PR TITLE
docs(qc): restore accents in 2 partner-course example READMEs (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/README.md
@@ -1,16 +1,16 @@
 # Sector Dual Momentum Strategy (ID: 20216980)
 
-Strategie de momentum sectoriel sur les constituants du SPY.
+Stratégie de momentum sectoriel sur les constituants du SPY.
 
 ## Architecture
 - `main.py` - Algorithme principal avec universe ETF SPY top 200
 - `DualMomentumAlphaModel.py` - Alpha model momentum sectoriel
 - `MyPcm.py` - Risk Parity Portfolio Construction avec leverage
-- `CustomImmediateExecutionModel.py` - Execution avec leverage ajustable
+- `CustomImmediateExecutionModel.py` - Exécution avec leverage ajustable
 - `FredRate.py` - Custom data: taux Fed Funds (FRED)
 - `research.ipynb` - Analyse performances sectorielles
 
-## Concepts enseignes
+## Concepts enseignés
 - Dual momentum (sector + individual)
 - Universe selection dynamique
 - Custom data (FRED)

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Trend-Following/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Trend-Following/README.md
@@ -11,7 +11,7 @@ Stratégie trend following avec oracles multiples (MACD, RSI, Bollinger).
 - `bollinger_oracle.py` - Oracle Bollinger (position relative)
 - `research.ipynb` - Analyse SMA derivative et signaux
 
-## Concepts enseignes
+## Concepts enseignés
 - Multi-oracle scoring
 - Détection de tendance (Higher Highs, Lower Lows)
 - ATR trailing stop-loss


### PR DESCRIPTION
## Summary

Restauration des accents français manquants dans les 2 READMEs d'exemples `partner-course` qui n'avaient pas été couverts par #4855 (po-2024). Complète la cohérence FR du dossier `partner-course-quant-trading/examples/` : les 3 exemples (Crypto-MultiCanal, Sector-Momentum, Trend-Following) partagent désormais des diacritiques françaises cohérentes.

Campagne **#2876** (restauration d'accents, EPIC de finition éditoriale).

## Changes

**`Sector-Momentum/README.md`** (3 corrections) :
- L3 : `Strategie` → `Stratégie` (prose)
- L9 : `Execution` → `Exécution` (description fichier)
- L13 : `## Concepts enseignes` → `## Concepts enseignés` (heading)

**`Trend-Following/README.md`** (1 correction) :
- L14 : `## Concepts enseignes` → `## Concepts enseignés` (heading) — résiduel non touché par #4855 qui avait corrigé la prose (`Strategie`, `Détection`) mais oublié ce heading.

## Scope

- **Pas de changement structurel** : aucun titre traduit, aucune section renommée, aucun lien modifié.
- **Scope borné au dossier `examples/`** (achèvement de la slice #4855, pas nouvelle incursion).
- `check_docs_links` : **0 lien cassé sur 3325 scannés**.

## Why

`Crypto-MultiCanal` (3e exemple du dossier) était déjà correctement accentué (#4435 + #4855). `Sector-Momentum` et le heading `Concepts enseignés` de `Trend-Following` étaient les résiduels — inconsistance corrigée.

See #2876 (contribution partielle à la campagne d'accents, ne clôt pas l'EPIC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
