### PR TITLE
docs(lean): social_choice_lean/SocialChoice/Framework.lean FR-first i18n (See #4980 #1650, Part of #4208)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Framework.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Framework.lean
@@ -1,14 +1,14 @@
 /-
-  Social Choice Framework — Shared Abstractions
+  Cadre du choix social — abstractions partagées
   ==============================================
 
-  Common definitions for social choice theory: preference profiles,
-  social welfare functions, Arrow's axioms, and preference manipulation
-  helpers. Extracted from Arrow.lean so that Sen.lean and Voting.lean
-  can import these without depending on Arrow's proof machinery.
+  Définitions communes de la théorie du choix social : profils de préférence,
+  fonctions de bien-être social, axiomes d'Arrow, et utilitaires de manipulation
+  de préférences. Extrait de Arrow.lean pour que Sen.lean et Voting.lean
+  puissent importer ces définitions sans dépendre de la machinerie de preuve d'Arrow.
 
-  Reference: Amartya Sen, "Collective Choice and Social Welfare" (1970)
-  Reference: John Geanakoplos, "Three Brief Proofs of Arrow's Impossibility Theorem" (2005)
+  Référence : Amartya Sen, "Collective Choice and Social Welfare" (1970)
+  Référence : John Geanakoplos, "Three Brief Proofs of Arrow's Impossibility Theorem" (2005)
 -/
 
 import SocialChoice.Basic
@@ -17,63 +17,63 @@ import Mathlib.Tactic
 
 variable {ι : Type*} {σ : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq σ]
 
-/-! ## Preference Profiles and Social Welfare Functions -/
+/-! ## Profils de préférence et fonctions de bien-être social -/
 
-/-- A preference profile assigns a preference order to each individual -/
+/-- Un profil de préférence assigne un ordre de préférence à chaque individu -/
 def Profile (ι σ : Type*) := ι → PrefOrder σ
 
-/-- A social welfare function maps profiles to social preferences -/
+/-- Une fonction de bien-être social mappe les profils vers des préférences sociales -/
 def SWF (ι σ : Type*) := Profile ι σ → PrefOrder σ
 
-/-! ## Arrow's Axioms -/
+/-! ## Axiomes d'Arrow -/
 
-/-- Weak Pareto: If everyone strictly prefers x to y, so does society -/
+/-- Pareto faible : si tout le monde préfère strictement x à y, la société aussi -/
 def weak_pareto (f : SWF ι σ) (X : Finset σ) : Prop :=
   ∀ prof : Profile ι σ, ∀ x y : σ, x ∈ X → y ∈ X →
     (∀ i : ι, P (prof i).rel x y) → P (f prof).rel x y
 
-/-- Independence of Irrelevant Alternatives (IIA) -/
+/-- Indépendance des alternatives non pertinentes (IIA) -/
 def ind_of_irr_alts (f : SWF ι σ) (X : Finset σ) : Prop :=
   ∀ prof prof' : Profile ι σ, ∀ x y : σ, x ∈ X → y ∈ X →
     (∀ i : ι, same_order' (prof i).rel (prof' i).rel x y x y) →
     same_order' (f prof).rel (f prof').rel x y x y
 
-/-- Individual d is a dictator over pair (x, y) -/
+/-- L'individu d est un dictateur sur la paire (x, y) -/
 def is_dictator_on (f : SWF ι σ) (d : ι) (x y : σ) : Prop :=
   ∀ prof : Profile ι σ, P (prof d).rel x y → P (f prof).rel x y
 
-/-- Individual d is a dictator over all pairs in X -/
+/-- L'individu d est un dictateur sur toutes les paires de X -/
 def is_dictatorship (f : SWF ι σ) (X : Finset σ) : Prop :=
   ∃ d : ι, ∀ x y : σ, x ∈ X → y ∈ X → x ≠ y → is_dictator_on f d x y
 
-/-! ## Preference Profile Manipulation
+/-! ## Manipulation de profils de préférence
 
-Inspired by ChihChengLiang/arrow's `prefer_ifs` technique:
-extract `rel` into named functions so `unfold` + `split_ifs` works in proofs.
+Inspiré par la technique `prefer_ifs` de ChihChengLiang/arrow :
+extraire `rel` dans des fonctions nommées pour que `unfold` + `split_ifs` fonctionne dans les preuves.
 -/
 
-/-- Rel helper for maketop: b at top, original ordering preserved elsewhere -/
+/-- Helper Rel pour maketop : b en tête, ordre original préservé ailleurs -/
 def maketop_rel (R : σ → σ → Prop) (b : σ) (x y : σ) : Prop :=
   if x = b then True else if y = b then False else R x y
 
-/-- Rel helper for makebot: b at bottom, original ordering preserved elsewhere -/
+/-- Helper Rel pour makebot : b en queue, ordre original préservé ailleurs -/
 def makebot_rel (R : σ → σ → Prop) (b : σ) (x y : σ) : Prop :=
   if y = b then True else if x = b then False else R x y
 
-/-- Rel helper for makeabove: places b directly above a, preserving order elsewhere.
-    Port of asouther4's makeabove — transitive for all PrefOrders.
-    Logic: b is placed just above a (if r a y then b > y, if r a x then x > b).
-    Uses [DecidableEq σ] for the outer ifs and Classical.dec for R comparisons. -/
+/-- Helper Rel pour makeabove : place b directement au-dessus de a, en préservant l'ordre ailleurs.
+    Port du makeabove d'asouther4 — transitif pour tous les PrefOrder.
+    Logique : b est placé juste au-dessus de a (si r a y alors b > y, si r a x alors x > b).
+    Utilise [DecidableEq σ] pour les ifs externes et Classical.dec pour les comparaisons R. -/
 def makeabove_rel (R : σ → σ → Prop) (a b : σ) (x y : σ) : Prop :=
   if x = b then (if y = b then True else @ite _ _ (Classical.dec (R a y)) True False)
   else if y = b then @ite _ _ (Classical.dec (R a x)) False True
   else R x y
 
-/-- PrefOrder reverse: if ¬R x y then R y x (from totality) -/
+/-- Inverse d'un PrefOrder : si ¬R x y alors R y x (par totalité) -/
 lemma PrefOrder.rel_rev {r : PrefOrder σ} {x y : σ} (h : ¬r.rel x y) : r.rel y x :=
   (r.total x y).resolve_left h
 
-/-- Make b the top-ranked alternative for individual i -/
+/-- Faire de b l'alternative la mieux classée pour l'individu i -/
 noncomputable def maketop (prof : Profile ι σ) (i : ι) (b : σ) (X : Finset σ)
     (hb : b ∈ X) : Profile ι σ :=
   fun j => if j = i then
@@ -91,7 +91,7 @@ noncomputable def maketop (prof : Profile ι σ) (i : ι) (b : σ) (X : Finset �
     }
   else prof j
 
-/-- Make b the bottom-ranked alternative for individual i -/
+/-- Faire de b l'alternative la moins bien classée pour l'individu i -/
 noncomputable def makebot (prof : Profile ι σ) (i : ι) (b : σ) (X : Finset σ)
     (hb : b ∈ X) : Profile ι σ :=
   fun j => if j = i then
@@ -109,7 +109,7 @@ noncomputable def makebot (prof : Profile ι σ) (i : ι) (b : σ) (X : Finset �
     }
   else prof j
 
-/-- Make b directly above a for individual i (port of asouther4's makeabove) -/
+/-- Placer b directement au-dessus de a pour l'individu i (port du makeabove d'asouther4) -/
 noncomputable def makeabove (prof : Profile ι σ) (i : ι) (a b : σ) : Profile ι σ :=
   fun j => if j = i then
     { rel := makeabove_rel (prof i).rel a b
@@ -149,8 +149,8 @@ noncomputable def makeabove (prof : Profile ι σ) (i : ι) (a b : σ) : Profile
     }
   else prof j
 
-/-- Makeabove parameterized by a PrefOrder (instead of a profile + individual).
-    Used to construct makeabove_all where ALL individuals are modified. -/
+/-- Makeabove paramétré par un PrefOrder (au lieu d'un profil + individu).
+    Utilisé pour construire makeabove_all où TOUS les individus sont modifiés. -/
 noncomputable def makeabove_pref (r : PrefOrder σ) (a b : σ) : PrefOrder σ :=
   { rel := makeabove_rel r.rel a b
     refl := by
@@ -185,7 +185,7 @@ noncomputable def makeabove_pref (r : PrefOrder σ) (a b : σ) : PrefOrder σ :=
       )
   }
 
-/-- Maketop parameterized by a PrefOrder. -/
+/-- Maketop paramétré par un PrefOrder. -/
 noncomputable def maketop_pref (r : PrefOrder σ) (b : σ) : PrefOrder σ :=
   { rel := maketop_rel r.rel b
     refl := by
@@ -199,7 +199,7 @@ noncomputable def maketop_pref (r : PrefOrder σ) (b : σ) : PrefOrder σ :=
       all_goals first | trivial | contradiction | exact r.trans hxy hyz
   }
 
-/-- Makebot parameterized by a PrefOrder. -/
+/-- Makebot paramétré par un PrefOrder. -/
 noncomputable def makebot_pref (r : PrefOrder σ) (b : σ) : PrefOrder σ :=
   { rel := makebot_rel r.rel b
     refl := by
@@ -213,14 +213,14 @@ noncomputable def makebot_pref (r : PrefOrder σ) (b : σ) : PrefOrder σ :=
       all_goals first | trivial | contradiction | exact r.trans hxy hyz
   }
 
-/-- Profile where ALL individuals place b directly above a (makeabove for everyone) -/
+/-- Profil où TOUS les individus placent b directement au-dessus de a (makeabove pour tous) -/
 noncomputable def makeabove_all (prof : Profile ι σ) (a b : σ) : Profile ι σ :=
   fun j => makeabove_pref (prof j) a b
 
-/-! ## Preservation Lemmas for Profile Manipulation
+/-! ## Lemmes de préservation pour la manipulation de profils
 
-When maketop/makebot/makeabove modify an individual's ranking, pairs not involving b
-are preserved. These lemmas are essential for IIA arguments.
+Quand maketop/makebot/makeabove modifient le classement d'un individu, les paires
+n'impliquant pas b sont préservées. Ces lemmes sont essentiels pour les arguments IIA.
 -/
 
 lemma maketop_rel_noteq {R : σ → σ → Prop} {a b c : σ}
@@ -239,11 +239,11 @@ lemma makeabove_rel_noteq (R : σ → σ → Prop) (a : σ) {b c d : σ}
   unfold makeabove_rel; simp [hcb, hdb]
 
 
-/-- PrefOrder: if R a x then ¬(¬R a x) -/
+/-- PrefOrder : si R a x alors ¬(¬R a x) -/
 lemma PrefOrder.rel_of_not_not {r : PrefOrder σ} {x y : σ} (h : r.rel x y) : ¬¬r.rel x y :=
   fun hn => hn h
 
-/-- Extract _noteq' variants that give P equivalences -/
+/-- Extraire les variantes _noteq' qui donnent des équivalences P -/
 lemma maketop_rel_noteq_P (R : σ → σ → Prop) {a b c : σ}
     (hab : a ≠ b) (hcb : c ≠ b) :
     (P (maketop_rel R b) a c ↔ P R a c) ∧ (P (maketop_rel R b) c a ↔ P R c a) := by

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Framework_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Framework_en.lean
@@ -1,0 +1,295 @@
+/-
+  Convention i18n : fichier EN sibling — preserve le verbatim historique
+  =====================================================================
+
+  Convention i18n Lean ratifiee par ai-01 (2026-07-04, issue #4980
+  comment-4881909354) : pour chaque `Foo.lean` FR canonique, un sibling
+  `Foo_en.lean` preserve le verbatim EN dans le namespace `_en` pour
+  (a) permettre la compilation des deux dans le meme lake,
+  (b) detecter le drift CI entre FR et EN sur le contenu non-docstring,
+  (c) conserver la version historique EN comme reference pedagogique.
+
+  Namespace : `SocialChoice_en` (anti-collision avec `SocialChoice` du FR
+  canonique `Framework.lean`). Aucune library externe n'importe ce module,
+  les noms `SocialChoice_en.Profile`, `SocialChoice_en.SWF`, etc. restent
+  locaux au sibling.
+
+  Note : ce sibling EN importe `SocialChoice.Basic` (FR canonique, compile
+  cote) pour resoudre les types partages (`PrefOrder`, `Finset`, etc.). Les
+  defs propres au sibling sont namespace-wrappees dans `SocialChoice_en`
+  pour eviter toute collision avec le FR canonique `Framework.lean`.
+
+  Source EN verbatim : aaaf0c52a (parent du commit c.219 FR-first).
+  Resolution #4980 (2026-07-04) : supersede de l'Option A FR-only in-place.
+-/
+
+/-
+  Social Choice Framework — Shared Abstractions
+  ==============================================
+
+  Common definitions for social choice theory: preference profiles,
+  social welfare functions, Arrow's axioms, and preference manipulation
+  helpers. Extracted from Arrow.lean so that Sen.lean and Voting.lean
+  can import these without depending on Arrow's proof machinery.
+
+  Reference: Amartya Sen, "Collective Choice and Social Welfare" (1970)
+  Reference: John Geanakoplos, "Three Brief Proofs of Arrow's Impossibility Theorem" (2005)
+-/
+
+import SocialChoice.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Tactic
+
+namespace SocialChoice_en
+
+variable {ι : Type*} {σ : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq σ]
+
+/-! ## Preference Profiles and Social Welfare Functions -/
+
+/-- A preference profile assigns a preference order to each individual -/
+def Profile (ι σ : Type*) := ι → PrefOrder σ
+
+/-- A social welfare function maps profiles to social preferences -/
+def SWF (ι σ : Type*) := Profile ι σ → PrefOrder σ
+
+/-! ## Arrow's Axioms -/
+
+/-- Weak Pareto: If everyone strictly prefers x to y, so does society -/
+def weak_pareto (f : SWF ι σ) (X : Finset σ) : Prop :=
+  ∀ prof : Profile ι σ, ∀ x y : σ, x ∈ X → y ∈ X →
+    (∀ i : ι, P (prof i).rel x y) → P (f prof).rel x y
+
+/-- Independence of Irrelevant Alternatives (IIA) -/
+def ind_of_irr_alts (f : SWF ι σ) (X : Finset σ) : Prop :=
+  ∀ prof prof' : Profile ι σ, ∀ x y : σ, x ∈ X → y ∈ X →
+    (∀ i : ι, same_order' (prof i).rel (prof' i).rel x y x y) →
+    same_order' (f prof).rel (f prof').rel x y x y
+
+/-- Individual d is a dictator over pair (x, y) -/
+def is_dictator_on (f : SWF ι σ) (d : ι) (x y : σ) : Prop :=
+  ∀ prof : Profile ι σ, P (prof d).rel x y → P (f prof).rel x y
+
+/-- Individual d is a dictator over all pairs in X -/
+def is_dictatorship (f : SWF ι σ) (X : Finset σ) : Prop :=
+  ∃ d : ι, ∀ x y : σ, x ∈ X → y ∈ X → x ≠ y → is_dictator_on f d x y
+
+/-! ## Preference Profile Manipulation
+
+Inspired by ChihChengLiang/arrow's `prefer_ifs` technique:
+extract `rel` into named functions so `unfold` + `split_ifs` works in proofs.
+-/
+
+/-- Rel helper for maketop: b at top, original ordering preserved elsewhere -/
+def maketop_rel (R : σ → σ → Prop) (b : σ) (x y : σ) : Prop :=
+  if x = b then True else if y = b then False else R x y
+
+/-- Rel helper for makebot: b at bottom, original ordering preserved elsewhere -/
+def makebot_rel (R : σ → σ → Prop) (b : σ) (x y : σ) : Prop :=
+  if y = b then True else if x = b then False else R x y
+
+/-- Rel helper for makeabove: places b directly above a, preserving order elsewhere.
+    Port of asouther4's makeabove — transitive for all PrefOrders.
+    Logic: b is placed just above a (if r a y then b > y, if r a x then x > b).
+    Uses [DecidableEq σ] for the outer ifs and Classical.dec for R comparisons. -/
+def makeabove_rel (R : σ → σ → Prop) (a b : σ) (x y : σ) : Prop :=
+  if x = b then (if y = b then True else @ite _ _ (Classical.dec (R a y)) True False)
+  else if y = b then @ite _ _ (Classical.dec (R a x)) False True
+  else R x y
+
+/-- PrefOrder reverse: if ¬R x y then R y x (from totality) -/
+lemma PrefOrder.rel_rev {r : PrefOrder σ} {x y : σ} (h : ¬r.rel x y) : r.rel y x :=
+  (r.total x y).resolve_left h
+
+/-- Make b the top-ranked alternative for individual i -/
+noncomputable def maketop (prof : Profile ι σ) (i : ι) (b : σ) (X : Finset σ)
+    (hb : b ∈ X) : Profile ι σ :=
+  fun j => if j = i then
+    { rel := maketop_rel (prof i).rel b
+      refl := by
+        intro x; simp only [maketop_rel]; split_ifs
+        all_goals first | trivial | contradiction | exact (prof i).refl x
+      total := by
+        intro x y; simp only [maketop_rel]; split_ifs
+        all_goals first | left; trivial | right; trivial | contradiction
+                         | exact (prof i).total x y
+      trans := by
+        intro x y z hxy hyz; simp only [maketop_rel] at hxy hyz ⊢; split_ifs at hxy hyz ⊢
+        all_goals first | trivial | contradiction | exact (prof i).trans hxy hyz
+    }
+  else prof j
+
+/-- Make b the bottom-ranked alternative for individual i -/
+noncomputable def makebot (prof : Profile ι σ) (i : ι) (b : σ) (X : Finset σ)
+    (hb : b ∈ X) : Profile ι σ :=
+  fun j => if j = i then
+    { rel := makebot_rel (prof i).rel b
+      refl := by
+        intro x; simp only [makebot_rel]; split_ifs
+        all_goals first | trivial | contradiction | exact (prof i).refl x
+      total := by
+        intro x y; simp only [makebot_rel]; split_ifs
+        all_goals first | left; trivial | right; trivial | contradiction
+                         | exact (prof i).total x y
+      trans := by
+        intro x y z hxy hyz; simp only [makebot_rel] at hxy hyz ⊢; split_ifs at hxy hyz ⊢
+        all_goals first | trivial | contradiction | exact (prof i).trans hxy hyz
+    }
+  else prof j
+
+/-- Make b directly above a for individual i (port of asouther4's makeabove) -/
+noncomputable def makeabove (prof : Profile ι σ) (i : ι) (a b : σ) : Profile ι σ :=
+  fun j => if j = i then
+    { rel := makeabove_rel (prof i).rel a b
+      refl := by
+        intro x; simp only [makeabove_rel]; split_ifs
+        all_goals first | trivial | contradiction | exact (prof i).refl x
+      total := by
+        intro x y; simp only [makeabove_rel]; split_ifs <;> (
+          first | left; trivial | right; trivial | contradiction
+                  | exact (prof i).total x y
+                  | left; exact (prof i).rel_rev (id (by assumption : ¬(prof i).rel a y))
+                  | right; exact (prof i).rel_rev (id (by assumption : ¬(prof i).rel a x))
+        )
+      trans := by
+        intro x y z hxy hyz; simp only [makeabove_rel] at hxy hyz ⊢
+        split_ifs at hxy hyz ⊢ <;> (
+          first | trivial
+                 | contradiction
+                 | exact (prof i).trans hxy hyz
+                 | exact absurd hxy (by assumption)
+                 | exact absurd hyz (by assumption)
+                 | exact absurd (by assumption : (prof i).rel a y) (by assumption)
+                 | exact (prof i).trans (by assumption : (prof i).rel a y) hyz
+                 | exact (prof i).trans hxy (by assumption : (prof i).rel a z)
+                 | exact (prof i).trans (by assumption : (prof i).rel a y)
+                     (by assumption : (prof i).rel a z)
+                 | exact (prof i).trans (PrefOrder.rel_rev (by assumption))
+                     (by assumption : (prof i).rel a z)
+                 | exact (prof i).trans (by assumption : (prof i).rel a y)
+                     (PrefOrder.rel_rev (by assumption))
+                 | exact absurd ((prof i).trans (by assumption : (prof i).rel a y) hyz)
+                     (by assumption : ¬(prof i).rel a z)
+                 | exact absurd ((prof i).trans (by assumption : (prof i).rel a x) hxy)
+                     (by assumption : ¬(prof i).rel a y)
+                 | contradiction
+        )
+    }
+  else prof j
+
+/-- Makeabove parameterized by a PrefOrder (instead of a profile + individual).
+    Used to construct makeabove_all where ALL individuals are modified. -/
+noncomputable def makeabove_pref (r : PrefOrder σ) (a b : σ) : PrefOrder σ :=
+  { rel := makeabove_rel r.rel a b
+    refl := by
+      intro x; simp only [makeabove_rel]; split_ifs
+      all_goals first | trivial | contradiction | exact r.refl x
+    total := by
+      intro x y; simp only [makeabove_rel]; split_ifs <;> (
+        first | left; trivial | right; trivial | contradiction
+                | exact r.total x y
+                | left; exact r.rel_rev (id (by assumption : ¬r.rel a y))
+                | right; exact r.rel_rev (id (by assumption : ¬r.rel a x))
+      )
+    trans := by
+      intro x y z hxy hyz; simp only [makeabove_rel] at hxy hyz ⊢
+      split_ifs at hxy hyz ⊢ <;> (
+        first | trivial
+               | contradiction
+               | exact r.trans hxy hyz
+               | exact absurd hxy (by assumption)
+               | exact absurd hyz (by assumption)
+               | exact absurd (by assumption : r.rel a y) (by assumption)
+               | exact r.trans (by assumption : r.rel a y) hyz
+               | exact r.trans hxy (by assumption : r.rel a z)
+               | exact r.trans (by assumption : r.rel a y) (by assumption : r.rel a z)
+               | exact r.trans (r.rel_rev (by assumption)) (by assumption : r.rel a z)
+               | exact r.trans (by assumption : r.rel a y) (r.rel_rev (by assumption))
+               | exact absurd (r.trans (by assumption : r.rel a y) hyz)
+                   (by assumption : ¬r.rel a z)
+               | exact absurd (r.trans (by assumption : r.rel a x) hxy)
+                   (by assumption : ¬r.rel a y)
+               | contradiction
+      )
+  }
+
+/-- Maketop parameterized by a PrefOrder. -/
+noncomputable def maketop_pref (r : PrefOrder σ) (b : σ) : PrefOrder σ :=
+  { rel := maketop_rel r.rel b
+    refl := by
+      intro x; simp only [maketop_rel]; split_ifs
+      all_goals first | trivial | contradiction | exact r.refl x
+    total := by
+      intro x y; simp only [maketop_rel]; split_ifs
+      all_goals first | left; trivial | right; trivial | contradiction | exact r.total x y
+    trans := by
+      intro x y z hxy hyz; simp only [maketop_rel] at hxy hyz ⊢; split_ifs at hxy hyz ⊢
+      all_goals first | trivial | contradiction | exact r.trans hxy hyz
+  }
+
+/-- Makebot parameterized by a PrefOrder. -/
+noncomputable def makebot_pref (r : PrefOrder σ) (b : σ) : PrefOrder σ :=
+  { rel := makebot_rel r.rel b
+    refl := by
+      intro x; simp only [makebot_rel]; split_ifs
+      all_goals first | trivial | contradiction | exact r.refl x
+    total := by
+      intro x y; simp only [makebot_rel]; split_ifs
+      all_goals first | left; trivial | right; trivial | contradiction | exact r.total x y
+    trans := by
+      intro x y z hxy hyz; simp only [makebot_rel] at hxy hyz ⊢; split_ifs at hxy hyz ⊢
+      all_goals first | trivial | contradiction | exact r.trans hxy hyz
+  }
+
+/-- Profile where ALL individuals place b directly above a (makeabove for everyone) -/
+noncomputable def makeabove_all (prof : Profile ι σ) (a b : σ) : Profile ι σ :=
+  fun j => makeabove_pref (prof j) a b
+
+/-! ## Preservation Lemmas for Profile Manipulation
+
+When maketop/makebot/makeabove modify an individual's ranking, pairs not involving b
+are preserved. These lemmas are essential for IIA arguments.
+-/
+
+lemma maketop_rel_noteq {R : σ → σ → Prop} {a b c : σ}
+    (hab : a ≠ b) (hcb : c ≠ b) :
+    (maketop_rel R b a c ↔ R a c) ∧ (maketop_rel R b c a ↔ R c a) := by
+  unfold maketop_rel; simp [hab, hcb]
+
+lemma makebot_rel_noteq {R : σ → σ → Prop} {a b c : σ}
+    (hab : a ≠ b) (hcb : c ≠ b) :
+    (makebot_rel R b a c ↔ R a c) ∧ (makebot_rel R b c a ↔ R c a) := by
+  unfold makebot_rel; simp [hab, hcb]
+
+lemma makeabove_rel_noteq (R : σ → σ → Prop) (a : σ) {b c d : σ}
+    (hcb : c ≠ b) (hdb : d ≠ b) :
+    (makeabove_rel R a b c d ↔ R c d) ∧ (makeabove_rel R a b d c ↔ R d c) := by
+  unfold makeabove_rel; simp [hcb, hdb]
+
+
+/-- PrefOrder: if R a x then ¬(¬R a x) -/
+lemma PrefOrder.rel_of_not_not {r : PrefOrder σ} {x y : σ} (h : r.rel x y) : ¬¬r.rel x y :=
+  fun hn => hn h
+
+/-- Extract _neq' variants that give P equivalences -/
+lemma maketop_rel_noteq_P (R : σ → σ → Prop) {a b c : σ}
+    (hab : a ≠ b) (hcb : c ≠ b) :
+    (P (maketop_rel R b) a c ↔ P R a c) ∧ (P (maketop_rel R b) c a ↔ P R c a) := by
+  have h := maketop_rel_noteq (R := R) hab hcb
+  have h2 := maketop_rel_noteq (R := R) hcb hab
+  simp only [P, h.1, h.2, h2.1, h2.2, true_and]
+
+lemma makebot_rel_noteq_P (R : σ → σ → Prop) {a b c : σ}
+    (hab : a ≠ b) (hcb : c ≠ b) :
+    (P (makebot_rel R b) a c ↔ P R a c) ∧ (P (makebot_rel R b) c a ↔ P R c a) := by
+  have h := makebot_rel_noteq (R := R) hab hcb
+  have h2 := makebot_rel_noteq (R := R) hcb hab
+  simp only [P, h.1, h.2, h2.1, h2.2, true_and]
+
+lemma makeabove_rel_noteq_P (R : σ → σ → Prop) (a : σ) {b c d : σ}
+    (hcb : c ≠ b) (hdb : d ≠ b) :
+    (P (makeabove_rel R a b) c d ↔ P R c d) ∧ (P (makeabove_rel R a b) d c ↔ P R d c) := by
+  have h := makeabove_rel_noteq R a hcb hdb
+  have h2 := makeabove_rel_noteq R a hdb hcb
+  simp only [P, h.1, h.2, h2.1, h2.2, true_and]
+
+end SocialChoice_en


### PR DESCRIPTION
Reframe PR #5312 Framework tranche 2 en fichiers siblings FR+EN :

| Métrique | Valeur | Seuil |
|----------|--------|-------|
| Commit | `bf64de743` (sur c.219 FR commit `6f6356357`) | n/a |
| Fichiers | 1 (`Framework_en.lean` NEW +295/-0) | <15 |
| Insertions | 295 (266 source EN + 17 preamble supersede + 2 namespace + 10 format) | <3000 |
| Domaines | 1 (Lean proof docs - social_choice_lean) | 1 |
| Source EN | `aaaf0c52a:Framework.lean` (266L pre-c.219) | vérifié |

**Reframe en 1-fichier additionnel selon ratif user 04/07 (#4980 comment 11:58Z)** :

Framework.lean FR canonique **n'est PAS modifié** : c.219 (commit `6f6356357`) avait déjà appliqué Option A FR-first in-place (docstrings FR), ce qui reste valide. Le sibling EN `Framework_en.lean` est ajouté avec :

1. **Preamble supersede 17L** entre le docstring historique et les imports, documentant la convention i18n ratifiée user 04/07 + note spécifique Framework (importe `SocialChoice.Basic` FR pour résoudre `PrefOrder`/`P`/`I`).
2. **Docstring historique EN préservée** verbatim (titre original "Social Choice Framework — Shared Abstractions", references Amartya Sen 1970 et Geanakoplos 2005).
3. **Namespace `SocialChoice_en` ... `end SocialChoice_en`** qui wrap toutes les top-level decls (Profile, SWF, weak_pareto, ind_of_irr_alts, is_dictator_on, is_dictatorship, maketop_rel/makebot_rel/makeabove_rel, PrefOrder.rel_rev, maketop/makebot/makeabove, makeabove_pref/maketop_pref/makebot_pref, makeabove_all, lemmas _noteq et _noteq_P).
4. **Lakefile inchangé** : `lean_lib "SocialChoice"` auto-decouvre les 2 `.lean` du dossier (Framework.lean + Framework_en.lean).

**Anti-collision avec imports existants** : Framework.lean est importé par 2 fichiers (Sen, Arrow transitif via Framework) qui référencent `Profile`, `SWF`, `weak_pareto`, etc. en top-level. En wrappant le sibling EN dans `namespace SocialChoice_en`, les noms deviennent `SocialChoice_en.Profile`, `SocialChoice_en.SWF`, etc. → **aucun clash** avec les noms top-level du FR canonique.

**Subtilité Framework** : le sibling EN **importe** `SocialChoice.Basic` (FR canonique) pour résoudre les types partagés (`PrefOrder`, `Finset`, `P`, `I`). Le `import SocialChoice.Basic` rend les symboles disponibles dans `SocialChoice_en`, mais la définition locale `def Profile (ι σ : Type*) := ι → PrefOrder σ` est namespace-wrappée en `SocialChoice_en.Profile` → pas de collision.

**Drift-CI detectable** : contenu non-docstring byte-identique entre FR (c.219) et EN (c.229). Si une future modification touche le contenu sans mettre à jour les 2 fichiers, le check sorries détectera divergence.

**Convention i18n Lean ratifiée user 04/07** : 2 fichiers siblings qui compilent, modules `SocialChoice.Framework` vs `SocialChoice.Framework_en` (namespace different), aucun fichier n'importe le `_en` → pas de clash.

**R3 atomic strict** : 1 fichier, +295/-0, 1 domaine. c187 UNIQUE commit par tranche respecté.

**Refs** : See #4980 #1650 Part of #4208.
