### PR TITLE
docs(lean): social_choice_lean/SocialChoice/MechanismDesign.lean FR-first i18n (See #4980 #1650, Part of #4208)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/MechanismDesign.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/MechanismDesign.lean
@@ -16,6 +16,8 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic
 
+namespace SocialChoice
+
 /-! ## Enchère de Vickrey à 2 enchérisseurs -/
 
 namespace VickreyTwoBidder
@@ -75,3 +77,5 @@ theorem vickrey3_truthful_bidder0 (v0 v1 v2 b0 : ℕ) :
   split_ifs <;> simp_all; omega
 
 end VickreyThreeBidder
+
+end SocialChoice

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/MechanismDesign.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/MechanismDesign.lean
@@ -16,58 +16,59 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic
 
-/-! ## 2-Bidder Vickrey Auction -/
+/-! ## Enchère de Vickrey à 2 enchérisseurs -/
 
 namespace VickreyTwoBidder
 
-/-- Utility for bidder i in 2-bidder Vickrey auction with valuations (v0, v1)
-    and bids (b0, b1). Winner is highest bidder, pays the other's bid. -/
+/-- Utilité pour l'enchérisseur i dans une enchère de Vickrey à 2 enchérisseurs
+    avec des valorisations (v0, v1) et des mises (b0, b1). Le gagnant est le
+    plus offrant, il paie la mise de l'autre. -/
 def utility (v0 v1 b0 b1 : ℕ) (i : Fin 2) : ℤ :=
   if b0 ≥ b1 then
-    -- bidder 0 wins
+    -- l'enchérisseur 0 gagne
     if i = 0 then (v0 : ℤ) - b1 else 0
   else
-    -- bidder 1 wins
+    -- l'enchérisseur 1 gagne
     if i = 1 then (v1 : ℤ) - b0 else 0
 
-/-- **Theorem 1**: Vickrey (second-price) auction is truthful for bidder 0.
-    Truthful bidding (b0 = v0) gives utility ≥ any other bid b0. -/
+/-- **Théorème 1** : l'enchère de Vickrey (deuxième prix) est vérace pour l'enchérisseur 0.
+    L'enchère vérace (b0 = v0) donne une utilité ≥ toute autre mise b0. -/
 theorem vickrey_truthful_bidder0 (v0 v1 b0 : ℕ) :
     utility v0 v1 v0 v1 0 ≥ utility v0 v1 b0 v1 0 := by
   unfold utility
   split_ifs <;> omega
 
-/-- **Theorem 2**: Vickrey (second-price) auction is truthful for bidder 1.
-    Symmetric to Theorem 1. -/
+/-- **Théorème 2** : l'enchère de Vickrey (deuxième prix) est vérace pour l'enchérisseur 1.
+    Symétrique au Théorème 1. -/
 theorem vickrey_truthful_bidder1 (v0 v1 b1 : ℕ) :
     utility v0 v1 v0 v1 1 ≥ utility v0 v1 v0 b1 1 := by
   unfold utility
   split_ifs <;> omega
 
-/-- **Theorem 3**: First-price auction is NOT truthful.
-    Counter-example: v = (10, 5). Truthful utility = 0. Shading to 6 gives utility = 4. -/
+/-- **Théorème 3** : l'enchère au premier prix N'est PAS vérace.
+    Contre-exemple : v = (10, 5). L'utilité vérace = 0. Un bradage à 6 donne utilité = 4. -/
 theorem first_price_not_truthful :
     (0 : ℤ) < (4 : ℤ) := by native_decide
 
 end VickreyTwoBidder
 
-/-! ## 3-Bidder Vickrey Auction -/
+/-! ## Enchère de Vickrey à 3 enchérisseurs -/
 
 namespace VickreyThreeBidder
 
 set_option linter.unusedVariables false in
-/-- Utility for bidder 0 in a 3-bidder Vickrey auction.
-    Valuations (v0, v1, v2), bids (b0, b1, b2).
-    Winner pays the second-highest bid. -/
+/-- Utilité pour l'enchérisseur 0 dans une enchère de Vickrey à 3 enchérisseurs.
+    Valorisations (v0, v1, v2), mises (b0, b1, b2).
+    Le gagnant paie la deuxième mise la plus élevée. -/
 def utility0 (v0 v1 v2 b0 b1 b2 : ℕ) : ℤ :=
   if b0 ≥ b1 ∧ b0 ≥ b2 then
-    -- bidder 0 wins, pays max(b1, b2)
+    -- l'enchérisseur 0 gagne, paie max(b1, b2)
     (v0 : ℤ) - max b1 b2
   else
     0
 
-/-- **Theorem 4**: Vickrey auction is truthful for bidder 0 with 3 bidders.
-    Your bid determines whether you win, not what you pay. -/
+/-- **Théorème 4** : l'enchère de Vickrey est vérace pour l'enchérisseur 0 avec 3 enchérisseurs.
+    Votre mise détermine si vous gagnez, pas ce que vous payez. -/
 theorem vickrey3_truthful_bidder0 (v0 v1 v2 b0 : ℕ) :
     utility0 v0 v1 v2 v0 v1 v2 ≥ utility0 v0 v1 v2 b0 v1 v2 := by
   unfold utility0

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/MechanismDesign_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/MechanismDesign_en.lean
@@ -1,0 +1,95 @@
+/-
+  Mechanism Design — Auction Formalization
+  =========================================
+
+  Decidability results for auction-based mechanism design on finite domains.
+
+  - Vickrey (second-price) auction truthfulness: proved by omega + case split
+  - First-price auction non-truthfulness: concrete counter-example via native_decide
+  - 3-bidder Vickrey truthfulness: proved by omega + case split
+
+  Reference: Vickrey (1961), "Counterspeculation, Auctions, and Competitive Sealed Tenders"
+  Reference: #1469 — Mechanism Design kickstart
+-/
+
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic
+
+namespace SocialChoice_en
+/-
+  Mechanism Design — Auction Formalization (EN sibling)
+  =====================================================
+
+  English mirror of `SocialChoice/MechanismDesign.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `SocialChoice_en` (le FR canonique reste `SocialChoice`).
+  Pas une traduction destructive : le fichier source EN historique est préservé ici
+  verbatim depuis `aaaf0c52ae` (pre-c.230 MechanismDesign tranche 3 FR commit) ;
+  seule la ligne `namespace` diffère pour éviter la collision de declaration.
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+/-! ## 2-Bidder Vickrey Auction -/
+
+namespace VickreyTwoBidder
+
+/-- Utility for bidder i in 2-bidder Vickrey auction with valuations (v0, v1)
+    and bids (b0, b1). Winner is highest bidder, pays the other's bid. -/
+def utility (v0 v1 b0 b1 : ℕ) (i : Fin 2) : ℤ :=
+  if b0 ≥ b1 then
+    -- bidder 0 wins
+    if i = 0 then (v0 : ℤ) - b1 else 0
+  else
+    -- bidder 1 wins
+    if i = 1 then (v1 : ℤ) - b0 else 0
+
+/-- **Theorem 1**: Vickrey (second-price) auction is truthful for bidder 0.
+    Truthful bidding (b0 = v0) gives utility ≥ any other bid b0. -/
+theorem vickrey_truthful_bidder0 (v0 v1 b0 : ℕ) :
+    utility v0 v1 v0 v1 0 ≥ utility v0 v1 b0 v1 0 := by
+  unfold utility
+  split_ifs <;> omega
+
+/-- **Theorem 2**: Vickrey (second-price) auction is truthful for bidder 1.
+    Symmetric to Theorem 1. -/
+theorem vickrey_truthful_bidder1 (v0 v1 b1 : ℕ) :
+    utility v0 v1 v0 v1 1 ≥ utility v0 v1 v0 b1 1 := by
+  unfold utility
+  split_ifs <;> omega
+
+/-- **Theorem 3**: First-price auction is NOT truthful.
+    Counter-example: v = (10, 5). Truthful utility = 0. Shading to 6 gives utility = 4. -/
+theorem first_price_not_truthful :
+    (0 : ℤ) < (4 : ℤ) := by native_decide
+
+end VickreyTwoBidder
+
+/-! ## 3-Bidder Vickrey Auction -/
+
+namespace VickreyThreeBidder
+
+set_option linter.unusedVariables false in
+/-- Utility for bidder 0 in a 3-bidder Vickrey auction.
+    Valuations (v0, v1, v2), bids (b0, b1, b2).
+    Winner pays the second-highest bid. -/
+def utility0 (v0 v1 v2 b0 b1 b2 : ℕ) : ℤ :=
+  if b0 ≥ b1 ∧ b0 ≥ b2 then
+    -- bidder 0 wins, pays max(b1, b2)
+    (v0 : ℤ) - max b1 b2
+  else
+    0
+
+/-- **Theorem 4**: Vickrey auction is truthful for bidder 0 with 3 bidders.
+    Your bid determines whether you win, not what you pay. -/
+theorem vickrey3_truthful_bidder0 (v0 v1 v2 b0 : ℕ) :
+    utility0 v0 v1 v2 v0 v1 v2 ≥ utility0 v0 v1 v2 b0 v1 v2 := by
+  unfold utility0
+  split_ifs <;> simp_all; omega
+
+end VickreyThreeBidder
+
+end SocialChoice_en


### PR DESCRIPTION
## Objectif

Implémenter la convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) sur `MechanismDesign.lean` : FR canonique + EN sibling distincts dans le même lake, les deux compilent, drift-CI détectable.

## Changements

### Fichiers modifiés (2)

| Fichier | Avant | Après | Δ |
|---------|-------|-------|---|
| `MechanismDesign.lean` (FR canonique) | top-level `VickreyTwoBidder` / `VickreyThreeBidder` | wrap dans `namespace SocialChoice` | +4 lignes (2 namespace, 1 end, 1 blank) |
| `MechanismDesign_en.lean` (EN sibling) NEW | inexistant | 95 lignes : verbatim depuis `aaaf0c52a` + préambule 14L + `namespace SocialChoice_en` | +95 lignes |

Total : **2 fichiers, +99 lignes, 0 deletions** (le commit `44b5550b4` originel FR Option A est intact, ce commit s'y ajoute).

## Convention appliquée

- **FR canonique** (`MechanismDesign.lean`) : wrap top-level dans `namespace SocialChoice`, code tactique byte-identique FR↔EN. Alignement avec `Voting.lean` (déjà mergé par po-2026), `Arrow.lean` (déjà mergé).
- **EN sibling** (`MechanismDesign_en.lean`) : verbatim EN depuis `aaaf0c52a` (pre-c.230 FR commit), sans modification du code tactique, seul le préambule + la ligne `namespace SocialChoice_en` diffèrent (anti-collision).

## Anti-régression D — vérifications

- ✅ `code tactique byte-identique FR↔EN` (defs `utility`, `utility0` ; theorems `vickrey_truthful_bidder0/1`, `first_price_not_truthful`, `vickrey3_truthful_bidder0`) — vérifié par script Python qui strip les commentaires et compare.
- ✅ `0 CJK parasite` post-Edit (filtre Unicode étendu 4 ranges, leçon c187 17e consécutive).
- ✅ `6=6 namespace...end` (3 paires : SocialChoice(en) + VickreyTwoBidder + VickreyThreeBidder côté FR ; SocialChoice_en + mêmes sub-namespaces côté EN).
- ✅ `0 renommage symboles Lean` (`def utility`, `def utility0`, `theorem vickrey_*`, etc. inchangés de `aaaf0c52a`).
- ✅ Imports inchangés : `Mathlib.Data.Fintype.Basic`, `Mathlib.Data.Finset.Basic`, `Mathlib.Tactic`.

## Anti-collision namespace

`MechanismDesign.lean` n'est importé par PERSONNE dans le lake (`grep -r "SocialChoice.MechanismDesign" MyIA.AI.Notebooks/GameTheory/social_choice_lean/` → 0 résultats), donc le wrap FR dans `namespace SocialChoice` est safe.

## Convention FR canonique + EN sibling

D'après la convention ratifiée par ai-01 (cf PR #5325 body amendé cycle 49, EPIC #4980) :
- fichiers `.lean` distincts FR + EN siblings dans le même lake
- les deux compilent
- drift-CI détectable : contenu non-docstring byte-identique entre siblings
- namespace sibling : `SocialChoice_en` pour le EN, FR canonique reste `SocialChoice`

Ce sibling EN est aligné avec :
- `Basic_en.lean` (PR #5310, tranche 1, cycle 49)
- `Framework_en.lean` (PR #5312, tranche 2, cycle 49)
- (ce PR) tranche 3
- tranches 4-13 à venir

## Lake build REPORTÉ ai-01 (HARD `.claude/rules/lean-merge-discipline.md` §1)

`lake build SocialChoice` sera lancé par ai-01 pre-merge conformément à lean-merge-discipline. Pas d'env Lean local po-2025.

## Issue Links

- Implements #4980 (FR canonical + EN sibling convention)
- Part of #4208 (axe E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
