### PR TITLE
docs(lean): social_choice_lean/SocialChoice/SortedListCounting.lean FR-first i18n

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting.lean
@@ -1,37 +1,37 @@
 /-
-  Sorted List Counting Lemmas
-  ===========================
+  Lemmes de comptage sur listes triées
+  ====================================
 
-  Helper lemma stubs for counting elements in sorted lists relative to a pivot
-  (typically the median element at position `length / 2`).
+  Lemmes auxiliaires pour compter les éléments dans des listes triées relativement à un pivot
+  (typiquement l'élément médian à la position `length / 2`).
 
-  These lemmas factor out the structural counting argument required by
-  `Voting.lean median_voter_theorem_strict` (sorries at L355 and L385).
+  Ces lemmes factorisent l'argument structurel de comptage requis par
+  `Voting.lean median_voter_theorem_strict` (sorries aux lignes L355 et L385).
 
-  PROOF STRATEGY (factored from Voting.lean L338-L354):
-  1. Let `l` be a sorted list with pivot at position `k = l.length / 2`.
-  2. Decompose `l = take k ++ drop k`.
-  3. By sortedness, all elements in `drop k` are ≥ `l[k]`.
-  4. Therefore `l.countP (· < l[k]) ≤ (take k).length = k`.
-  5. Symmetrically, `l.countP (l[k] ≤ ·) ≥ (drop k).length = l.length - k`.
+  STRATÉGIE DE PREUVE (factorisée depuis Voting.lean L338-L354) :
+  1. Soit `l` une liste triée avec un pivot à la position `k = l.length / 2`.
+  2. Décomposer `l = take k ++ drop k`.
+  3. Par tri, tous les éléments de `drop k` sont ≥ `l[k]`.
+  4. Donc `l.countP (· < l[k]) ≤ (take k).length = k`.
+  5. Symétriquement, `l.countP (l[k] ≤ ·) ≥ (drop k).length = l.length - k`.
 
-  Once these helpers are proven, Voting.lean L355 and L385 reduce to a
-  bridging argument:
+  Une fois ces helpers prouvés, Voting.lean L355 et L385 se réduisent à un
+  argument de pont :
     A := Finset.filter (peaks i < median) Finset.univ
     A.card = (univ.toList.filter (peaks · < median)).length
            = (univ.toList.map peaks).countP (· < median)
-           = (sortedPeaksList.countP (· < median))   [by Perm.countP_eq]
-           ≤ k                                        [by countP_lt_kth_le_half]
+           = (sortedPeaksList.countP (· < median))   [par Perm.countP_eq]
+           ≤ k                                        [par countP_lt_kth_le_half]
 
-  KEY MATHLIB LEMMAS (target API):
-  - `List.Pairwise (· ≤ ·)` (sortedness primitive in current Mathlib)
+  LEMMES MATHLIB CLÉS (API cible) :
+  - `List.Pairwise (· ≤ ·)` (primitive de tri dans le Mathlib actuel)
   - `List.sorted_mergeSort` / `List.mergeSort_perm`
   - `List.Perm.countP_eq`, `List.countP_append`, `List.countP_eq_zero`
   - `List.length_take`, `List.length_drop`, `List.take_append_drop`
 
-  STATUS: stub file with lemma signatures (sorries).
-  Cycle 25 Wave 3 ai-01 backup for po-2026 Track 2.
-  Reference: dispatched in msg-20260511T233949-r0i1xs (2026-05-11).
+  STATUT : fichier avec preuves complètes (les sorries initiaux ont été comblés).
+  Cycle 25 Wave 3 ai-01 backup pour po-2026 Track 2.
+  Référence : dispatché dans msg-20260511T233949-r0i1xs (2026-05-11).
 -/
 
 import Mathlib.Data.List.Sort
@@ -42,19 +42,19 @@ namespace SocialChoice.SortedListCounting
 
 variable {α : Type*}
 
-/-! ## Counting elements relative to a sorted-list pivot -/
+/-! ## Comptage des éléments relatifs au pivot d'une liste triée -/
 
-/-- For a list `l` sorted with `(· ≤ ·)` and pivot `l[k]`, the number of
-    elements strictly less than `l[k]` is at most `k`.
+/-- Pour une liste `l` triée par `(· ≤ ·)` et un pivot `l[k]`, le nombre d'éléments
+    strictement inférieurs à `l[k]` est au plus `k`.
 
-    PROOF SKETCH (TODO po-2026 Track 2):
-    - Decompose `l = l.take k ++ l.drop k` via `List.take_append_drop`.
-    - `(l.take k).length = k` by `List.length_take` (using `hk : k < l.length`).
-    - `(l.drop k).head = l[k]` by indexing.
-    - By `Pairwise.drop` and head-of-drop reasoning, all elements of `l.drop k`
-      are `≥ l[k]`.
-    - Hence `(l.drop k).countP (· < l[k]) = 0` by `List.countP_eq_zero`.
-    - Combining via `List.countP_append` and `List.countP_le_length`:
+    ESQUISSE DE PREUVE :
+    - Décomposer `l = l.take k ++ l.drop k` via `List.take_append_drop`.
+    - `(l.take k).length = k` par `List.length_take` (en utilisant `hk : k < l.length`).
+    - `(l.drop k).head = l[k]` par indexation.
+    - Par `Pairwise.drop` et le raisonnement head-of-drop, tous les éléments de `l.drop k`
+      sont `≥ l[k]`.
+    - Donc `(l.drop k).countP (· < l[k]) = 0` par `List.countP_eq_zero`.
+    - Combinant via `List.countP_append` et `List.countP_le_length` :
         `l.countP (· < l[k]) = (l.take k).countP (· < l[k]) + 0 ≤ k`. -/
 theorem countP_lt_kth_le_half [LinearOrder α]
     {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
@@ -84,18 +84,18 @@ theorem countP_lt_kth_le_half [LinearOrder α]
       exact List.pairwise_iff_getElem.mp hsort k (k + i) hk hki_lt hlt
   omega
 
-/-- For a list `l` sorted with `(· ≤ ·)` and pivot `l[k]`, the number of
-    elements `≥ l[k]` is at least `l.length - k`.
+/-- Pour une liste `l` triée par `(· ≤ ·)` et un pivot `l[k]`, le nombre d'éléments
+    `≥ l[k]` est au moins `l.length - k`.
 
-    Dual of `countP_lt_kth_le_half`, giving a lower bound on the
-    "right side" of the pivot.
+    Dual de `countP_lt_kth_le_half`, donnant une borne inférieure sur
+    le « côté droit » du pivot.
 
-    PROOF SKETCH (TODO po-2026 Track 2):
-    - Decompose `l = l.take k ++ l.drop k`.
-    - `(l.drop k).length = l.length - k` by `List.length_drop`.
-    - All elements of `l.drop k` are `≥ l[k]` (head + sortedness).
-    - So `(l.drop k).countP (l[k] ≤ ·) = (l.drop k).length`.
-    - Adding `(l.take k).countP (l[k] ≤ ·) ≥ 0` gives the bound. -/
+    ESQUISSE DE PREUVE :
+    - Décomposer `l = l.take k ++ l.drop k`.
+    - `(l.drop k).length = l.length - k` par `List.length_drop`.
+    - Tous les éléments de `l.drop k` sont `≥ l[k]` (head + tri).
+    - Donc `(l.drop k).countP (l[k] ≤ ·) = (l.drop k).length`.
+    - Ajouter `(l.take k).countP (l[k] ≤ ·) ≥ 0` donne la borne. -/
 theorem countP_ge_kth_ge_half_succ [LinearOrder α]
     {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
     l.length - k ≤ l.countP (fun x => decide (l[k] ≤ x)) := by
@@ -121,11 +121,11 @@ theorem countP_ge_kth_ge_half_succ [LinearOrder α]
   rw [hdrop_all, hdrop_len]
   omega
 
-/-- Dual to `countP_ge_kth_ge_half_succ` from the left side: for a sorted list `l`
-    and pivot `l[k]`, the number of elements `≤ l[k]` is at least `k + 1`.
+/-- Dual de `countP_ge_kth_ge_half_succ` depuis le côté gauche : pour une liste triée `l`
+    et un pivot `l[k]`, le nombre d'éléments `≤ l[k]` est au moins `k + 1`.
 
-    PROOF: decompose `l = take (k+1) ++ drop (k+1)`. The first `k+1` elements
-    (positions `0..k`) are all `≤ l[k]` by sortedness, contributing `k+1`. -/
+    PREUVE : décomposer `l = take (k+1) ++ drop (k+1)`. Les `k+1` premiers éléments
+    (positions `0..k`) sont tous `≤ l[k]` par tri, contribuant `k+1`. -/
 theorem countP_le_kth_ge_half_succ [LinearOrder α]
     {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
     k + 1 ≤ l.countP (fun x => decide (x ≤ l[k])) := by
@@ -157,14 +157,14 @@ theorem countP_le_kth_ge_half_succ [LinearOrder α]
   rw [htake_all, htake_len]
   omega
 
-/-! ## Bridge: Finset.filter cardinality ↔ List.countP
+/-! ## Pont : cardinalité de Finset.filter ↔ List.countP
 
-    To apply `countP_lt_kth_le_half` / `countP_ge_kth_ge_half_succ` to
-    `Voting.lean median_voter_theorem_strict`, we need to translate
-    `(Finset.filter p Finset.univ).card` to `l.countP (decide ∘ p)` where
+    Pour appliquer `countP_lt_kth_le_half` / `countP_ge_kth_ge_half_succ` à
+    `Voting.lean median_voter_theorem_strict`, nous devons traduire
+    `(Finset.filter p Finset.univ).card` en `l.countP (decide ∘ p)` où
     `l := (Finset.univ.toList.map peaks).mergeSort (· ≤ ·)`. -/
 
-/-- Cardinality of a Finset filter equals countP on the underlying toList. -/
+/-- La cardinalité d'un filtre Finset vaut countP sur la toList sous-jacente. -/
 theorem finset_filter_card_eq_toList_countP
     {α : Type*} [DecidableEq α] (s : Finset α) (p : α → Bool) :
     (s.filter (fun a => p a = true)).card = s.toList.countP p := by
@@ -172,9 +172,9 @@ theorem finset_filter_card_eq_toList_countP
       ← Multiset.coe_toList s.val, Multiset.coe_countP]
   simp [Finset.toList]
 
-/-- Bridge specialised for `Fintype` and the median voter setup:
-    `A.card = (univ.toList.map f).countP p` (without going through filter).
-    The `mergeSort` step is left to the caller (via `List.Perm.countP_eq`). -/
+/-- Pont spécialisé pour `Fintype` et la configuration de l'électeur médian :
+    `A.card = (univ.toList.map f).countP p` (sans passer par le filtre).
+    L'étape `mergeSort` est laissée à l'appelant (via `List.Perm.countP_eq`). -/
 theorem finset_filter_lt_card_eq_toList_map_countP
     {ι α : Type*} [Fintype ι] [DecidableEq ι] (f : ι → α) (p : α → Bool) :
     (Finset.filter (fun i => p (f i) = true) Finset.univ).card =

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting_en.lean
@@ -1,0 +1,206 @@
+/-
+  Sorted List Counting Lemmas
+  ===========================
+
+  Helper lemma stubs for counting elements in sorted lists relative to a pivot
+  (typically the median element at position `length / 2`).
+
+  These lemmas factor out the structural counting argument required by
+  `Voting.lean median_voter_theorem_strict` (sorries at L355 and L385).
+
+  PROOF STRATEGY (factored from Voting.lean L338-L354):
+  1. Let `l` be a sorted list with pivot at position `k = l.length / 2`.
+  2. Decompose `l = take k ++ drop k`.
+  3. By sortedness, all elements in `drop k` are ≥ `l[k]`.
+  4. Therefore `l.countP (· < l[k]) ≤ (take k).length = k`.
+  5. Symmetrically, `l.countP (l[k] ≤ ·) ≥ (drop k).length = l.length - k`.
+
+  Once these helpers are proven, Voting.lean L355 and L385 reduce to a
+  bridging argument:
+    A := Finset.filter (peaks i < median) Finset.univ
+    A.card = (univ.toList.filter (peaks · < median)).length
+           = (univ.toList.map peaks).countP (· < median)
+           = (sortedPeaksList.countP (· < median))   [by Perm.countP_eq]
+           ≤ k                                        [by countP_lt_kth_le_half]
+
+  KEY MATHLIB LEMMAS (target API):
+  - `List.Pairwise (· ≤ ·)` (sortedness primitive in current Mathlib)
+  - `List.sorted_mergeSort` / `List.mergeSort_perm`
+  - `List.Perm.countP_eq`, `List.countP_append`, `List.countP_eq_zero`
+  - `List.length_take`, `List.length_drop`, `List.take_append_drop`
+
+  STATUS: stub file with lemma signatures (sorries).
+  Cycle 25 Wave 3 ai-01 backup for po-2026 Track 2.
+  Reference: dispatched in msg-20260511T233949-r0i1xs (2026-05-11).
+-/
+
+import Mathlib.Data.List.Sort
+import Mathlib.Data.List.Count
+import Mathlib.Tactic
+
+namespace SocialChoice_en.SortedListCounting
+/-
+  Sorted List Counting Lemmas (EN sibling)
+  =========================================
+
+  English mirror of `SocialChoice/SortedListCounting.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `SocialChoice_en.SortedListCounting` (le FR canonique reste
+  `SocialChoice.SortedListCounting`, notation pointée préservée).
+  Pas une traduction destructive : le fichier source EN historique est préservé ici
+  verbatim depuis `aaaf0c52ae` (pre-c.231 SortedListCounting tranche 4 FR commit) ;
+  seule la ligne `namespace` diffère pour éviter la collision de declaration.
+
+  Note : `SortedListCounting.lean` est importé par `Voting.lean` (ligne 28),
+  c'est pourquoi on n'enveloppe PAS le FR canonique dans un namespace supplémentaire
+  (risque de casser l'import cross-fichier). On suit donc le pattern Basic/Framework :
+  sibling EN seul avec namespace wrap, FR canonique reste top-level.
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+variable {α : Type*}
+
+/-! ## Counting elements relative to a sorted-list pivot -/
+
+/-- For a list `l` sorted with `(· ≤ ·)` and pivot `l[k]`, the number of
+    elements strictly less than `l[k]` is at most `k`.
+
+    PROOF SKETCH (TODO po-2026 Track 2):
+    - Decompose `l = l.take k ++ l.drop k` via `List.take_append_drop`.
+    - `(l.take k).length = k` by `List.length_take` (using `hk : k < l.length`).
+    - `(l.drop k).head = l[k]` by indexing.
+    - By `Pairwise.drop` and head-of-drop reasoning, all elements of `l.drop k`
+      are `≥ l[k]`.
+    - Hence `(l.drop k).countP (· < l[k]) = 0` by `List.countP_eq_zero`.
+    - Combining via `List.countP_append` and `List.countP_le_length`:
+        `l.countP (· < l[k]) = (l.take k).countP (· < l[k]) + 0 ≤ k`. -/
+theorem countP_lt_kth_le_half [LinearOrder α]
+    {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
+    l.countP (fun x => decide (x < l[k])) ≤ k := by
+  set p : α := l[k] with hp
+  have hsplit : l = l.take k ++ l.drop k := (List.take_append_drop k l).symm
+  conv_lhs => rw [hsplit]
+  rw [List.countP_append]
+  have h1 : (l.take k).countP (fun x => decide (x < p)) ≤ k := by
+    calc (l.take k).countP (fun x => decide (x < p))
+        ≤ (l.take k).length := List.countP_le_length
+      _ = min k l.length := List.length_take
+      _ ≤ k := min_le_left _ _
+  have h2 : (l.drop k).countP (fun x => decide (x < p)) = 0 := by
+    apply List.countP_eq_zero.mpr
+    intro x hx
+    simp only [decide_eq_true_eq, not_lt, hp]
+    rcases List.mem_iff_getElem.mp hx with ⟨i, hi, rfl⟩
+    rw [List.getElem_drop]
+    have hki_lt : k + i < l.length := by
+      have hi' := hi
+      rw [List.length_drop] at hi'
+      omega
+    by_cases hi0 : i = 0
+    · subst hi0; simp
+    · have hlt : k < k + i := by omega
+      exact List.pairwise_iff_getElem.mp hsort k (k + i) hk hki_lt hlt
+  omega
+
+/-- For a list `l` sorted with `(· ≤ ·)` and pivot `l[k]`, the number of
+    elements `≥ l[k]` is at least `l.length - k`.
+
+    Dual of `countP_lt_kth_le_half`, giving a lower bound on the
+    "right side" of the pivot.
+
+    PROOF SKETCH (TODO po-2026 Track 2):
+    - Decompose `l = l.take k ++ l.drop k`.
+    - `(l.drop k).length = l.length - k` by `List.length_drop`.
+    - All elements of `l.drop k` are `≥ l[k]` (head + sortedness).
+    - So `(l.drop k).countP (l[k] ≤ ·) = (l.drop k).length`.
+    - Adding `(l.take k).countP (l[k] ≤ ·) ≥ 0` gives the bound. -/
+theorem countP_ge_kth_ge_half_succ [LinearOrder α]
+    {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
+    l.length - k ≤ l.countP (fun x => decide (l[k] ≤ x)) := by
+  set p : α := l[k] with hp
+  have hsplit : l = l.take k ++ l.drop k := (List.take_append_drop k l).symm
+  conv_rhs => rw [hsplit]
+  rw [List.countP_append]
+  have hdrop_all : (l.drop k).countP (fun x => decide (p ≤ x)) = (l.drop k).length := by
+    rw [List.countP_eq_length]
+    intro x hx
+    simp only [decide_eq_true_eq, hp]
+    rcases List.mem_iff_getElem.mp hx with ⟨i, hi, rfl⟩
+    rw [List.getElem_drop]
+    have hki_lt : k + i < l.length := by
+      have hi' := hi
+      rw [List.length_drop] at hi'
+      omega
+    by_cases hi0 : i = 0
+    · subst hi0; simp
+    · have hlt : k < k + i := by omega
+      exact List.pairwise_iff_getElem.mp hsort k (k + i) hk hki_lt hlt
+  have hdrop_len : (l.drop k).length = l.length - k := List.length_drop
+  rw [hdrop_all, hdrop_len]
+  omega
+
+/-- Dual to `countP_ge_kth_ge_half_succ` from the left side: for a sorted list `l`
+    and pivot `l[k]`, the number of elements `≤ l[k]` is at least `k + 1`.
+
+    PROOF: decompose `l = take (k+1) ++ drop (k+1)`. The first `k+1` elements
+    (positions `0..k`) are all `≤ l[k]` by sortedness, contributing `k+1`. -/
+theorem countP_le_kth_ge_half_succ [LinearOrder α]
+    {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
+    k + 1 ≤ l.countP (fun x => decide (x ≤ l[k])) := by
+  set p : α := l[k] with hp
+  have hsplit : l = l.take (k + 1) ++ l.drop (k + 1) := (List.take_append_drop (k + 1) l).symm
+  conv_rhs => rw [hsplit]
+  rw [List.countP_append]
+  have htake_all : (l.take (k + 1)).countP (fun x => decide (x ≤ p)) = (l.take (k + 1)).length := by
+    rw [List.countP_eq_length]
+    intro x hx
+    simp only [decide_eq_true_eq, hp]
+    rcases List.mem_iff_getElem.mp hx with ⟨i, hi, rfl⟩
+    rw [List.getElem_take]
+    have hi_lt_k1 : i < k + 1 := by
+      have hi' := hi
+      rw [List.length_take] at hi'
+      omega
+    have hi_lt_l : i < l.length := by
+      have hi' := hi
+      rw [List.length_take] at hi'
+      omega
+    by_cases hi_eq : i = k
+    · subst hi_eq; simp
+    · have hlt : i < k := by omega
+      exact List.pairwise_iff_getElem.mp hsort i k hi_lt_l hk hlt
+  have htake_len : (l.take (k + 1)).length = k + 1 := by
+    rw [List.length_take]
+    omega
+  rw [htake_all, htake_len]
+  omega
+
+/-! ## Bridge: Finset.filter cardinality ↔ List.countP
+
+    To apply `countP_lt_kth_le_half` / `countP_ge_kth_ge_half_succ` to
+    `Voting.lean median_voter_theorem_strict`, we need to translate
+    `(Finset.filter p Finset.univ).card` to `l.countP (decide ∘ p)` where
+    `l := (Finset.univ.toList.map peaks).mergeSort (· ≤ ·)`. -/
+
+/-- Cardinality of a Finset filter equals countP on the underlying toList. -/
+theorem finset_filter_card_eq_toList_countP
+    {α : Type*} [DecidableEq α] (s : Finset α) (p : α → Bool) :
+    (s.filter (fun a => p a = true)).card = s.toList.countP p := by
+  rw [Finset.card, Finset.filter_val, ← Multiset.countP_eq_card_filter,
+      ← Multiset.coe_toList s.val, Multiset.coe_countP]
+  simp [Finset.toList]
+
+/-- Bridge specialised for `Fintype` and the median voter setup:
+    `A.card = (univ.toList.map f).countP p` (without going through filter).
+    The `mergeSort` step is left to the caller (via `List.Perm.countP_eq`). -/
+theorem finset_filter_lt_card_eq_toList_map_countP
+    {ι α : Type*} [Fintype ι] [DecidableEq ι] (f : ι → α) (p : α → Bool) :
+    (Finset.filter (fun i => p (f i) = true) Finset.univ).card =
+      (Finset.univ.toList.map f).countP p := by
+  rw [finset_filter_card_eq_toList_countP, List.countP_map]
+  rfl
+
+end SocialChoice_en.SortedListCounting


### PR DESCRIPTION
## Objectif

Implémenter la convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) sur `SortedListCounting.lean` : FR canonique + EN sibling distincts dans le même lake, les deux compilent, drift-CI détectable.

## Changements

### Fichiers modifiés (1 nouveau)

| Fichier | Avant | Après | Δ |
|---------|-------|-------|---|
| `SortedListCounting_en.lean` (EN sibling) NEW | inexistant | 206 lignes : verbatim depuis `aaaf0c52a` + préambule 14L + `namespace SocialChoice_en.SortedListCounting` | +206 lignes |

`SortedListCounting.lean` (FR canonique) reste inchangé dans ce reframe car **il est importé par `Voting.lean` ligne 28** (`import SocialChoice.SortedListCounting` + usage `SortedListCounting.finset_filter_lt_card_eq_toList_map_countP` à 5 endroits). Wrapper le FR dans un namespace supplémentaire casserait ces imports cross-fichier.

Donc on suit le pattern **Basic/Framework tranche 1+2** : sibling EN seul avec namespace wrap anti-collision, FR canonique reste top-level.

Total : **1 fichier créé, +206 lignes, 0 deletions** (le commit `cfad008c40` originel FR Option A est intact, ce commit s'y ajoute).

## Convention appliquée

- **FR canonique** (`SortedListCounting.lean`) : inchangé, déjà en `namespace SocialChoice.SortedListCounting` (notation pointée préservée pour aligner avec imports `Voting.lean`).
- **EN sibling** (`SortedListCounting_en.lean`) : verbatim EN depuis `aaaf0c52a` (pre-c.231 FR commit), sans modification du code tactique, seul le préambule + la ligne `namespace SocialChoice_en.SortedListCounting` diffèrent (anti-collision).

## Anti-régression D — vérifications

- ✅ `code tactique byte-identique FR↔EN` (defs + 4 theorems `countP_lt_kth_le_half` / `countP_ge_kth_ge_half_succ` / `countP_le_kth_ge_half_succ` / `finset_filter_card_eq_toList_countP` / `finset_filter_lt_card_eq_toList_map_countP`) — vérifié par script Python qui strip les commentaires et compare.
- ✅ `0 CJK parasite` post-Edit (filtre Unicode étendu 4 ranges, leçon c187 17e consécutive).
- ✅ `1=1 namespace...end` (notation pointée imbriquée dans EN sibling comme dans FR canonique).
- ✅ `0 renommage symboles Lean` (toutes les `theorem` inchangées de `aaaf0c52a`).
- ✅ Imports inchangés : `Mathlib.Data.List.Sort`, `Mathlib.Data.List.Count`, `Mathlib.Tactic`.

## Anti-collision namespace

`SortedListCounting.lean` est importé par `Voting.lean` (ligne 28) + usage direct du préfixe `SortedListCounting.foo` (5 endroits : L348, L355, L363, L419, L426, L433). Pour cette raison :
- **PAS de wrap FR** (casserait `import SocialChoice.SortedListCounting` côté `Voting.lean`)
- **sibling EN wrap minimal** : juste `SocialChoice_en.SortedListCounting` au lieu de `SocialChoice.SortedListCounting` (anti-collision via `_en`)

## Convention FR canonique + EN sibling

D'après la convention ratifiée par ai-01 (cf PR #5325 body amendé cycle 49, EPIC #4980) :
- fichiers `.lean` distincts FR + EN siblings dans le même lake
- les deux compilent
- drift-CI détectable : contenu non-docstring byte-identique entre siblings
- namespace sibling : `SocialChoice_en.<sub>` pour le EN, FR canonique reste `SocialChoice.<sub>`

Ce sibling EN est aligné avec :
- `Basic_en.lean` (PR #5310, tranche 1, cycle 49)
- `Framework_en.lean` (PR #5312, tranche 2, cycle 49)
- `MechanismDesign_en.lean` (PR #5313, tranche 3, cycle 50)
- (ce PR) tranche 4
- tranches 5-13 à venir

## Lake build REPORTÉ ai-01 (HARD `.claude/rules/lean-merge-discipline.md` §1)

`lake build SocialChoice` sera lancé par ai-01 pre-merge conformément à lean-merge-discipline. Pas d'env Lean local po-2025.

## Issue Links

- Implements #4980 (FR canonical + EN sibling convention)
- Part of #4208 (axe E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)