### PR TITLE
docs(lean): reframe Axioms.lean i18n FR+EN siblings (#4980 ratification)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Utility/Axioms.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Utility/Axioms.lean
@@ -2,60 +2,66 @@ import Mathlib
 import Utility.Basic
 
 /-!
-# von Neumann–Morgenstern Axioms
+# Axiomes de von Neumann–Morgenstern
 
-The four axioms a preference over lotteries must satisfy to admit an
-expected-utility representation:
+Les quatre axiomes qu'une préférence sur les loteries doit satisfaire pour
+admettre une représentation en utilité espérée :
 
-1. **Completeness** — any two lotteries are comparable.
-2. **Transitivity** — preference chains do not cycle.
-3. **Independence (substitution)** — a common mixture preserves preference.
-4. **Continuity (Archimedean)** — no lottery is infinitely better or worse
-   than another; intermediate mixtures exist.
+1. **Complétude** — deux loteries quelconques sont comparables.
+2. **Transitivité** — les chaînes de préférence ne cyclent pas.
+3. **Indépendance (substitution)** — un mélange commun préserve la préférence.
+4. **Continuité (Archimédienne)** — aucune loterie n'est infiniment meilleure
+   ou pire qu'une autre ; des mélanges intermédiaires existent.
 
-A preference satisfying all four is `IsRational`.
+Une préférence satisfaisant les quatre est `IsRational`.
+
+Convention i18n (EPIC #4980, PR pilote #5303) : FR-first appliqué sur les
+en-têtes et docstrings publics. Le code tactique et les commentaires
+intra-preuve restent en anglais (références Mathlib, notation formelle).
 -/
 
 namespace Utility
 
 variable {α : Type*} [Fintype α]
 
-/-- A preference relation is a binary relation on lotteries. Read `P p q` as
-"lottery `p` is weakly preferred to lottery `q`" (p ≽ q). -/
+/-- Une relation de préférence est une relation binaire sur les loteries. Lire
+`P p q` comme « la loterie `p` est faiblement préférée à la loterie `q` » (p ≽ q). -/
 abbrev Pref (α : Type*) [Fintype α] := Lottery α → Lottery α → Prop
 
-/-- Strict preference derived from a weak one: `p ≻ q` means `p ≽ q` but not
-`q ≽ p`. -/
+/-- Préférence stricte dérivée d'une préférence faible : `p ≻ q` signifie
+`p ≽ q` mais non `q ≽ p`. -/
 def StrictPref (P : Pref α) (p q : Lottery α) : Prop := P p q ∧ ¬ P q p
 
-/-- **Completeness**: any two lotteries are comparable in at least one
-direction. -/
+/-- **Complétude** : deux loteries quelconques sont comparables dans au moins
+une direction. -/
 def IsComplete (P : Pref α) : Prop :=
   ∀ p q : Lottery α, P p q ∨ P q p
 
-/-- **Transitivity**: preference chains propagate. -/
+/-- **Transitivité** : les chaînes de préférence se propagent. -/
 def IsTransitive (P : Pref α) : Prop :=
   ∀ p q r : Lottery α, P p q → P q r → P p r
 
-/-- **Independence (substitution)**: if `p ≽ q`, then mixing both with the same
-third lottery `r` preserves the preference, for any mixing weight `t ∈ [0,1]`. -/
+/-- **Indépendance (substitution)** : si `p ≽ q`, alors mélanger les deux avec
+une même troisième loterie `r` préserve la préférence, pour tout poids de
+mélange `t ∈ [0,1]`. -/
 def IsIndependent (P : Pref α) : Prop :=
   ∀ (p q r : Lottery α) (t : ℝ) (ht0 : 0 ≤ t) (ht1 : t ≤ 1),
     P p q → P (mix t p r ht0 ht1) (mix t q r ht0 ht1)
 
-/-- **Continuity (Archimedean / mixture solvability)**: if `p ≽ q ≽ r`, then
-some convex mixture of `p` and `r` is indifferent to `q`. Equivalently, no
-lottery is infinitely better or worse than another; `q` can always be matched
-by mixing the extremes. This is the standard solvability form of the Archimedean
-axiom, equivalent to the two-witness "no lexicographic dominance" form for
-complete transitive orders. -/
+/-- **Continuité (Archimédienne / résolvabilité des mélanges)** : si
+`p ≽ q ≽ r`, alors un certain mélange convexe de `p` et `r` est indifférent à
+`q`. De manière équivalente, aucune loterie n'est infiniment meilleure ou
+pire qu'une autre ; `q` peut toujours être obtenu en mélangeant les extrêmes.
+C'est la forme standard de résolvabilité de l'axiome archimédien, équivalente
+à la forme « pas de dominance lexicographique » à deux témoins pour les ordres
+transitifs complets. -/
 def IsContinuous (P : Pref α) : Prop :=
   ∀ p q r : Lottery α,
     P p q → P q r →
       ∃ (t : ℝ) (ht0 : 0 ≤ t) (ht1 : t ≤ 1),
         P (mix t p r ht0 ht1) q ∧ P q (mix t p r ht0 ht1)
 
-/-- A **rational** preference satisfies all four VNM axioms. -/
+/-- Une préférence **rationnelle** satisfait les quatre axiomes VNM. -/
 structure IsRational (P : Pref α) : Prop where
   protected complete : IsComplete P
   protected transitive : IsTransitive P

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Utility/Axioms_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Utility/Axioms_en.lean
@@ -1,0 +1,70 @@
+import Mathlib
+import Utility.Basic
+
+/-!
+# von Neumann–Morgenstern Axioms (English mirror)
+
+The four axioms a preference over lotteries must satisfy to admit an
+expected-utility representation:
+
+1. **Completeness** — any two lotteries are comparable.
+2. **Transitivity** — preference chains do not cycle.
+3. **Independence (substitution)** — a common mixture preserves preference.
+4. **Continuity (Archimedean)** — no lottery is infinitely better or worse
+   than another; intermediate mixtures exist.
+
+A preference satisfying all four is `IsRational`.
+
+English mirror of `Axioms.lean` (French canonical). Convention EPIC #4980:
+siblings `Foo.lean` (FR) + `Foo_en.lean` (EN), both compile in one lake.
+-/
+
+namespace Utility_en
+
+open Utility
+
+variable {α : Type*} [Fintype α]
+
+/-- A preference relation is a binary relation on lotteries. Read `P p q` as
+"lottery `p` is weakly preferred to lottery `q`" (p ≽ q). -/
+abbrev Pref (α : Type*) [Fintype α] := Lottery α → Lottery α → Prop
+
+/-- Strict preference derived from a weak one: `p ≻ q` means `p ≽ q` but not
+`q ≽ p`. -/
+def StrictPref (P : Pref α) (p q : Lottery α) : Prop := P p q ∧ ¬ P q p
+
+/-- **Completeness**: any two lotteries are comparable in at least one
+direction. -/
+def IsComplete (P : Pref α) : Prop :=
+  ∀ p q : Lottery α, P p q ∨ P q p
+
+/-- **Transitivity**: preference chains propagate. -/
+def IsTransitive (P : Pref α) : Prop :=
+  ∀ p q r : Lottery α, P p q → P q r → P p r
+
+/-- **Independence (substitution)**: if `p ≽ q`, then mixing both with the same
+third lottery `r` preserves the preference, for any mixing weight `t ∈ [0,1]`. -/
+def IsIndependent (P : Pref α) : Prop :=
+  ∀ (p q r : Lottery α) (t : ℝ) (ht0 : 0 ≤ t) (ht1 : t ≤ 1),
+    P p q → P (mix t p r ht0 ht1) (mix t q r ht0 ht1)
+
+/-- **Continuity (Archimedean / mixture solvability)**: if `p ≽ q ≽ r`, then
+some convex mixture of `p` and `r` is indifferent to `q`. Equivalently, no
+lottery is infinitely better or worse than another; `q` can always be matched
+by mixing the extremes. This is the standard solvability form of the Archimedean
+axiom, equivalent to the two-witness "no lexicographic dominance" form for
+complete transitive orders. -/
+def IsContinuous (P : Pref α) : Prop :=
+  ∀ p q r : Lottery α,
+    P p q → P q r →
+      ∃ (t : ℝ) (ht0 : 0 ≤ t) (ht1 : t ≤ 1),
+        P (mix t p r ht0 ht1) q ∧ P q (mix t p r ht0 ht1)
+
+/-- A **rational** preference satisfies all four VNM axioms. -/
+structure IsRational (P : Pref α) : Prop where
+  protected complete : IsComplete P
+  protected transitive : IsTransitive P
+  protected independent : IsIndependent P
+  protected continuous : IsContinuous P
+
+end Utility_en


### PR DESCRIPTION
## Résumé

**REFRAME** de cette PR selon la convention i18n Lean **ratifiée par le user** le 2026-07-04
([#4980 comment-4881909354](https://github.com/jsboige/CoursIA/issues/4980#issuecomment-4881909354)).
L'Option A « FR-only in-place » (pilote #5303) est **SUPERSEDED** — elle contredisait
le verbatim #4980 (« pas une traduction destructive »).

Nouvelle convention = **2 fichiers siblings** `Foo.lean` (FR canonique) + `Foo_en.lean`
(miroir EN), les 2 compilent dans 1 seul lake (comme les notebooks `foo_en.ipynb`).

### Fichiers de cette PR
- **`Utility/Axioms.lean`** — FR canonique (namespace `Utility`, inchangé depuis c.211).
- **`Utility/Axioms_en.lean`** — miroir EN (namespace `Utility_en` + `open Utility`).

Les quatre axiomes VNM (complétude, transitivité, indépendance, continuité) + `IsRational`,
dans les deux langues, docstrings non-bilingues.

## Résolution technique du namespace (finding pour ai-01)

Le commentaire de ratification dit « EN verbatim + les 2 compilent ». Mais `Axioms.lean`
déclare ses symboles dans `namespace Utility` (`Pref`, `IsComplete`, …). Un sibling
`Axioms_en.lean` « EN verbatim » re-déclarerait `Utility.Pref` → **collision de
déclaration** (Lake FAIL).

**Résolution** : le sibling EN utilise `namespace Utility_en` (+ `open Utility` pour
résoudre les types de base `Lottery`, `mix` depuis `Utility.Basic`). Les déclarations
deviennent `Utility_en.Pref`, `Utility_en.IsComplete`, etc. — pas de collision.
Docstrings EN byte-identiques à `origin/main` ; déclarations byte-identiques modulo
le suffixe de namespace. **Ce pattern doit se propager aux 16 autres PRs i18n.**

## Anti-régression (FX-7 / Section B Lean)

| Vérification | Résultat |
|---|---|
| `grep -c sorry` FR / EN | **0 / 0** (définitions pures, 0 preuve, 0 tactic) |
| Symboles préservés (FR + EN) | **7 + 7** : `Pref`, `StrictPref`, `IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous`, `IsRational` |
| Corps de définition | byte-identique entre FR et EN (modulo namespace suffix) |
| Renommages de symboles | **0** |

## Validation (lean-merge-discipline HARD — lake build local)

Windows-native `lake.exe`, toolchain `v4.31.0-rc1`, Mathlib junctioned `d568c8c0` :

- **`lake build Utility.Axioms`** (FR) : **SUCCESS** `[8494/8494]` — pas de régression.
- **`lake build Utility.Axioms_en`** (EN sibling) : **SUCCESS** `[8494/8494] Built Utility.Axioms_en (151s)`.

Les 2 compilent. Warnings `manifest out of date` / `batteries local changes` : préexistants et bénins.

### Caveat auto-discovery (2e finding pour ai-01)
Avec `lean_lib Utility where roots := #[`Utility]`, le sibling `_en` n'est **pas**
auto-built par `lake build` (default) car non importé par `Utility.lean`. Il faut
soit un build explicite `lake build Utility.Axioms_en`, soit ajouter l'import à
`Utility.lean`, soit passer à `globs`. À trancher côté coordination pour la CI drift.

## Contexte

G.1 stale catch (c.211) : dispatch ai-01 « coop_games_lean » était stale (saturé).
Pivot vers `decision_theory_lean` (mon lake firsthand Gittins c.187-209, 0 PR i18n
hors mes livraisons). PR sœur : **#5315** (`Utility/Basic.lean`, reframe en cours).

See #4980, See #1650, Part of #4208.
