### PR TITLE
feat(search): Search-2-Uninformed-Csharp — .NET twin BFS/DFS/UCS/IDDFS (See #4956, See #5332)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -30,6 +30,7 @@ Cette partie est l'alphabet de toute la série : la formalisation en espace d'é
 |---|----------|--------|---------|-------|
 | 1 | [Search-1-StateSpace](Search-1-StateSpace.ipynb) | Python 3 | Espaces d'états, formalisation (S, A, T, G), taquin, aspirateur, recherche d'itinéraire | ~40 min |
 | 2 | [Search-2-Uninformed](Search-2-Uninformed.ipynb) | Python 3 | BFS, DFS, UCS, IDDFS : comparaison des algorithmes non informés | ~50 min |
+| 2 (.NET) | [Search-2-Uninformed (C#)](Search-2-Uninformed-Csharp.ipynb) | .NET (C#) | **Jumeau .NET** : BFS/DFS/UCS/IDDFS via BCL .NET (`Queue`/`Stack`/`PriorityQueue`), graphe des villes françaises, BFS bidirectionnel — port C# fidèle ; démontre Prong B (UCS strictement meilleur que BFS sur Rennes→Strasbourg : 985 vs 1130 km) | ~50 min |
 | 3 | [Search-3-Informed](Search-3-Informed.ipynb) | Python 3 | A*, Greedy, IDA*, heuristiques admissibles et consistantes | ~50 min |
 | 4 | [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) | Python 3 | Hill Climbing, Simulated Annealing, Tabu Search, paysages de fitness | ~45 min |
 | 4 (.NET) | [Search-4-LocalSearch (C#)](Search-4-LocalSearch-Csharp.ipynb) | .NET (C#) | **Jumeau .NET** : Hill Climbing (steepest-ascent), Random-Restart, recuit simulé (critère de Metropolis, programmes de refroidissement), recherche tabou (liste tabou) — port C# fidèle sur paysage 1D multimodal puis N-Reines (benchmark taux de succès) | ~45 min |

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
@@ -1,0 +1,1439 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0cdc54df6a14",
+   "metadata": {},
+   "source": [
+    "# Search-2-Uninformed (C#) : Algorithmes de Recherche Non Informée\n",
+    "\n",
+    "**Navigation** : [<< Espaces d'états (Search-1)](Search-1-StateSpace.ipynb) | [Index Partie 1](README.md) | [Recherche informée (Search-3) >>](Search-3-Informed.ipynb)\n",
+    "\n",
+    "**Jumeau .NET** du notebook Python [Search-2-Uninformed.ipynb](Search-2-Uninformed.ipynb) — port fidèle en C# .NET 9.0, dans le cadre du marathon de parité .NET ⇄ Python (#4956). Les quatre algorithmes fondamentaux de la recherche **non informée** sont réimplémentés à l'aide de la BCL .NET (`Queue`, `Stack`, `PriorityQueue`), sans bibliothèque externe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6ba2773c020",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Introduction (~5 min)\n",
+    "\n",
+    "Un algorithme de recherche **non informé** (uninformed / blind search) explore l'espace d'états **sans knowledge supplémentaire** sur le problème — aucune heuristique, aucune estimation de la distance au but. Sa stratégie est entièrement déterminée par l'ordre d'expansion des nœuds.\n",
+    "\n",
+    "| Algorithme | Structure | Complétude | Optimalité | Complexité mémoire |\n",
+    "|------------|-----------|------------|------------|--------------------|\n",
+    "| **BFS** (largeur) | File FIFO | Oui (graphe fini) | Oui si coûts unitaires | O(b^d) |\n",
+    "| **DFS** (profondeur) | Pile LIFO | Non (cycles) | Non | O(b·m) |\n",
+    "| **UCS** (coût uniforme) | File de priorité | Oui | Oui (coûts ≥ 0) | O(b^(1+C*/ε)) |\n",
+    "| **IDDFS** (profondeur itérée) | DFS borné itératif | Oui | Oui si coûts unitaires | O(b·d) |\n",
+    "\n",
+    "Nous illustrerons chaque algorithme sur le même problème de référence : trouver un itinéraire entre villes françaises sur un graphe routier pondéré par les distances kilométriques."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df41894819b9",
+   "metadata": {},
+   "source": [
+    "## 2. Cadre générique de recherche\n",
+    "\n",
+    "Avant d'implémenter chaque algorithme, définissons les briques communes : un `Node` (nœud de recherche), une classe abstraite `Problem`, et un `GraphProblem` concret pour les graphes pondérés."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "35a65f5ce44d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:49.015206Z",
+     "iopub.status.busy": "2026-07-04T13:33:49.010181Z",
+     "iopub.status.idle": "2026-07-04T13:33:50.816419Z",
+     "shell.execute_reply": "2026-07-04T13:33:50.812293Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '752848.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cadre Node + Problem défini.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Définition du nœud de recherche et du problème générique ---\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// Noeud dans l'arbre de recherche : état + parent + coût g depuis la racine.\n",
+    "public record Node(string State, Node Parent, int Action, double G)\n",
+    "{\n",
+    "    // Reconstruction du chemin depuis la racine jusqu'à ce noeud.\n",
+    "    public List<Node> Path()\n",
+    "    {\n",
+    "        var path = new List<Node>();\n",
+    "        for (Node n = this; n != null; n = n.Parent) path.Add(n);\n",
+    "        path.Reverse();\n",
+    "        return path;\n",
+    "    }\n",
+    "    public int Depth => Parent is null ? 0 : Parent.Depth + 1;\n",
+    "}\n",
+    "\n",
+    "// Problème de recherche abstrait (interface unifiée pour tous les algorithmes).\n",
+    "public abstract class Problem\n",
+    "{\n",
+    "    public string Initial { get; }\n",
+    "    public string Goal { get; }\n",
+    "    protected Problem(string initial, string goal) { Initial = initial; Goal = goal; }\n",
+    "    public abstract IEnumerable<(string next, double cost)> Actions(string state);\n",
+    "    public bool IsGoal(string state) => state == Goal;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Cadre Node + Problem défini.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0981fc34fae6",
+   "metadata": {},
+   "source": [
+    "### Problème concret : villes françaises\n",
+    "\n",
+    "Définissons le graphe routier des villes françaises (12 villes, distances kilométriques symétriques). C'est notre problème de référence pour toute la suite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2922664d014e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:50.818010Z",
+     "iopub.status.busy": "2026-07-04T13:33:50.817733Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.173149Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.172729Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe des villes françaises chargé : 12 villes, 18 routes.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Problème de cheminement sur graphe pondéré + carte des villes françaises ---\n",
+    "public class GraphProblem : Problem\n",
+    "{\n",
+    "    private readonly Dictionary<string, Dictionary<string, double>> _graph;\n",
+    "    public GraphProblem(string initial, string goal,\n",
+    "                        Dictionary<string, Dictionary<string, double>> graph)\n",
+    "        : base(initial, goal) => _graph = graph;\n",
+    "\n",
+    "    public override IEnumerable<(string next, double cost)> Actions(string state)\n",
+    "    {\n",
+    "        if (_graph.TryGetValue(state, out var nbrs))\n",
+    "            foreach (var kv in nbrs)\n",
+    "                yield return (kv.Key, kv.Value);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Carte routière française (distances en km, arêtes symétriques).\n",
+    "var franceGraph = new Dictionary<string, Dictionary<string, double>>\n",
+    "{\n",
+    "    [\"Paris\"]      = new(){ [\"Lyon\"]=465, [\"Lille\"]=225, [\"Strasbourg\"]=490, [\"Nantes\"]=385, [\"Bordeaux\"]=585 },\n",
+    "    [\"Lyon\"]       = new(){ [\"Paris\"]=465, [\"Marseille\"]=315, [\"Grenoble\"]=110, [\"Strasbourg\"]=490 },\n",
+    "    [\"Marseille\"]  = new(){ [\"Lyon\"]=315, [\"Toulouse\"]=405, [\"Nice\"]=200, [\"Montpellier\"]=170 },\n",
+    "    [\"Toulouse\"]   = new(){ [\"Marseille\"]=405, [\"Bordeaux\"]=245, [\"Montpellier\"]=245 },\n",
+    "    [\"Bordeaux\"]   = new(){ [\"Paris\"]=585, [\"Toulouse\"]=245, [\"Nantes\"]=340 },\n",
+    "    [\"Nantes\"]     = new(){ [\"Paris\"]=385, [\"Bordeaux\"]=340, [\"Rennes\"]=110 },\n",
+    "    [\"Rennes\"]     = new(){ [\"Nantes\"]=110, [\"Lille\"]=600 },\n",
+    "    [\"Lille\"]      = new(){ [\"Paris\"]=225, [\"Rennes\"]=600, [\"Strasbourg\"]=530 },\n",
+    "    [\"Strasbourg\"] = new(){ [\"Paris\"]=490, [\"Lyon\"]=490, [\"Lille\"]=530 },\n",
+    "    [\"Nice\"]       = new(){ [\"Marseille\"]=200, [\"Grenoble\"]=330 },\n",
+    "    [\"Grenoble\"]   = new(){ [\"Lyon\"]=110, [\"Nice\"]=330 },\n",
+    "    [\"Montpellier\"]= new(){ [\"Marseille\"]=170, [\"Toulouse\"]=245 },\n",
+    "};\n",
+    "\n",
+    "int roads = franceGraph.Values.Sum(d => d.Count) / 2;\n",
+    "Console.WriteLine($\"Graphe des villes françaises chargé : {franceGraph.Count} villes, {roads} routes.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a364bdc68689",
+   "metadata": {},
+   "source": [
+    "### Utilitaire d'affichage\n",
+    "\n",
+    "Encapsulons le résultat d'une recherche (chemin, coût, nombre de nœuds explorés) dans un petit enregistrement, avec un formateur textuel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "91631c33b2c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.174607Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.174387Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.271298Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.270887Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SearchResult défini.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Résultat de recherche + formateur ---\n",
+    "public record SearchResult(Node Goal, int Explored, string Name)\n",
+    "{\n",
+    "    public double Cost => Goal?.G ?? double.PositiveInfinity;\n",
+    "    public int Length => Goal?.Depth ?? -1;\n",
+    "    public bool Found => Goal is not null;\n",
+    "    public string PathString => Found ? string.Join(\" -> \", Goal.Path().Select(n => n.State)) : \"—\";\n",
+    "\n",
+    "    public void Print()\n",
+    "    {\n",
+    "        if (!Found) { Console.WriteLine($\"{Name} : AUCUN CHEMIN TROUVÉ ({Explored} noeuds explorés)\"); return; }\n",
+    "        Console.WriteLine($\"{Name} : {PathString}\");\n",
+    "        Console.WriteLine($\"         coût = {Cost,7:F0} km | {Length} sauts | {Explored} noeuds explorés\");\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"SearchResult défini.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbe75bd88c53",
+   "metadata": {},
+   "source": [
+    "## 3. Recherche en Largeur (BFS — Breadth-First Search)\n",
+    "\n",
+    "BFS explore l'arbre **niveau par niveau** : tous les nœuds de profondeur *k* sont développés avant ceux de profondeur *k+1*. Implémentée avec une **file FIFO** (`Queue<T>`), elle garantit de trouver le chemin en **le moins de sauts** (optimal seulement si tous les coûts sont unitaires)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ee5ab44e20d0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.272596Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.272336Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.370241Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.370064Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS : Bordeaux -> Paris -> Strasbourg\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         coût =    1075 km | 2 sauts | 7 noeuds explorés\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- BFS : recherche en largeur (file FIFO) + ensemble des visités ---\n",
+    "public static SearchResult BFS(Problem p, string start = null)\n",
+    "{\n",
+    "    string s0 = start ?? p.Initial;\n",
+    "    var frontier = new Queue<Node>();\n",
+    "    frontier.Enqueue(new Node(s0, null, 0, 0));\n",
+    "    var explored = new HashSet<string> { s0 };\n",
+    "    int exploredCount = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        var node = frontier.Dequeue();\n",
+    "        exploredCount++;\n",
+    "        if (p.IsGoal(node.State)) return new SearchResult(node, exploredCount, \"BFS\");\n",
+    "        foreach (var (next, cost) in p.Actions(node.State))\n",
+    "            if (!explored.Contains(next) && !frontier.Any(n => n.State == next))\n",
+    "            {\n",
+    "                explored.Add(next);\n",
+    "                frontier.Enqueue(new Node(next, node, 0, node.G + cost));\n",
+    "            }\n",
+    "    }\n",
+    "    return new SearchResult(null, exploredCount, \"BFS\");\n",
+    "}\n",
+    "\n",
+    "var pBS = new GraphProblem(\"Bordeaux\", \"Strasbourg\", franceGraph);\n",
+    "var bfsRes = BFS(pBS);\n",
+    "bfsRes.Print();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4af7a55a9444",
+   "metadata": {},
+   "source": [
+    "### Interprétation — BFS sur les villes françaises\n",
+    "\n",
+    "BFS trouve le chemin en **le moins de sauts** (Bordeaux → Paris → Strasbourg, 2 sauts). Mais ce n'est pas forcément le **moins coûteux** en kilomètres : BFS ignore les poids des arêtes. C'est précisément ce que corrige UCS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "174770f1c44f",
+   "metadata": {},
+   "source": [
+    "## 4. Recherche en Profondeur (DFS — Depth-First Search)\n",
+    "\n",
+    "DFS plonge **le plus profondément possible** avant de remonter. Implémentée avec une **pile LIFO** (`Stack<T>`), elle est économe en mémoire mais ne garantit ni l'optimalité ni, sur un graphe cyclique sans suivi des visités, la terminaison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "200363c0ccd7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.371526Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.371353Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.427509Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.427310Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DFS : Bordeaux -> Paris -> Lyon -> Strasbourg\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         coût =    1540 km | 3 sauts | 9 noeuds explorés\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- DFS : recherche en profondeur (pile LIFO) + visités ---\n",
+    "public static SearchResult DFS(Problem p, string start = null)\n",
+    "{\n",
+    "    string s0 = start ?? p.Initial;\n",
+    "    var frontier = new Stack<Node>();\n",
+    "    frontier.Push(new Node(s0, null, 0, 0));\n",
+    "    var explored = new HashSet<string>();\n",
+    "    int exploredCount = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        var node = frontier.Pop();\n",
+    "        if (explored.Contains(node.State)) continue;\n",
+    "        explored.Add(node.State);\n",
+    "        exploredCount++;\n",
+    "        if (p.IsGoal(node.State)) return new SearchResult(node, exploredCount, \"DFS\");\n",
+    "        // empiler dans l'ordre inverse pour conserver l'ordre d'expansion naturel\n",
+    "        var actions = p.Actions(node.State).Reverse().ToList();\n",
+    "        foreach (var (next, cost) in actions)\n",
+    "            if (!explored.Contains(next))\n",
+    "                frontier.Push(new Node(next, node, 0, node.G + cost));\n",
+    "    }\n",
+    "    return new SearchResult(null, exploredCount, \"DFS\");\n",
+    "}\n",
+    "\n",
+    "var dfsRes = DFS(pBS);\n",
+    "dfsRes.Print();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "781d6ce7570a",
+   "metadata": {},
+   "source": [
+    "### Interprétation — DFS vs BFS\n",
+    "\n",
+    "DFS suit un chemin en profondeur avant tout autre : il descend jusqu'au but dès qu'il le peut, sans garantie de minimiser ni les sauts ni le coût. Le chemin retourné dépend de l'ordre d'expansion des voisins — c'est pourquoi DFS n'est pas optimal.\n",
+    "\n",
+    "### Exercice 1 : DFS avec limite de profondeur\n",
+    "\n",
+    "**Objectif** : implémentez `DfsLimited(problem, maxDepth)` — une variante de DFS qui n'explore pas au-delà de `maxDepth`. C'est la brique de base d'IDDFS (section 6). *Indice* : ajoutez un test sur `node.Depth` avant d'empiler les successeurs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a8c6dbf7a02a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.428921Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.428679Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.455078Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.454860Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "// --- Exercice 1 : DFS avec limite de profondeur (STUB) ---\n",
+    "// TODO étudiant : implémentez DfsLimited(p, maxDepth) qui retourne un SearchResult.\n",
+    "// Il doit se comporter comme DFS mais refuser d'empiler un successeur dont la profondeur\n",
+    "// dépasserait maxDepth. Le stub ci-dessous retourne null — à compléter.\n",
+    "public static SearchResult DfsLimited(Problem p, int maxDepth)\n",
+    "{\n",
+    "    // Indice : structure identique à DFS, avec la garde :\n",
+    "    //   if (node.Depth + 1 > maxDepth) continue;\n",
+    "    return null;  // TODO étudiant\n",
+    "}\n",
+    "\n",
+    "// Test (à décommenter une fois complété) :\n",
+    "// Console.WriteLine(\"DFS limité (profondeur 3) Bordeaux -> Strasbourg :\");\n",
+    "// DfsLimited(pBS, 3)?.Print();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c36f54374071",
+   "metadata": {},
+   "source": [
+    "### Illustration : ordre d'expansion BFS vs DFS sur un arbre\n",
+    "\n",
+    "Pour visualiser la différence, construisons un petit arbre binaire et observons l'ordre de visite de chaque algorithme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2035a96c909f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.456483Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.456213Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.539809Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.539649Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS : A, B, C, D, E, F, G, H, I, J, K, L, M, N, O\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DFS : A, B, D, H, I, E, J, K, C, F, L, M, G, N, O\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Ordre d'expansion BFS vs DFS sur un arbre binaire de profondeur 3 ---\n",
+    "// Noeuds étiquetets A (racine), B-C (niveau 1), D-E-F-G (niveau 2), H..O (niveau 3).\n",
+    "var tree = new Dictionary<string, List<string>>\n",
+    "{\n",
+    "    [\"A\"] = new(){ \"B\", \"C\" },\n",
+    "    [\"B\"] = new(){ \"D\", \"E\" }, [\"C\"] = new(){ \"F\", \"G\" },\n",
+    "    [\"D\"] = new(){ \"H\", \"I\" }, [\"E\"] = new(){ \"J\", \"K\" },\n",
+    "    [\"F\"] = new(){ \"L\", \"M\" }, [\"G\"] = new(){ \"N\", \"O\" },\n",
+    "};\n",
+    "// Snapshot des clés avant mutation : on ajoute les feuilles pendant l'itération.\n",
+    "foreach (var k in tree.Keys.ToList())\n",
+    "    foreach (var c in tree[k])\n",
+    "        if (!tree.ContainsKey(c)) tree[c] = new List<string>();\n",
+    "\n",
+    "List<string> BfsOrder(Dictionary<string,List<string>> g, string root)\n",
+    "{\n",
+    "    var order = new List<string>();\n",
+    "    var q = new Queue<string>(); q.Enqueue(root);\n",
+    "    var seen = new HashSet<string>{ root };\n",
+    "    while (q.Count > 0)\n",
+    "    {\n",
+    "        var n = q.Dequeue(); order.Add(n);\n",
+    "        foreach (var c in g.GetValueOrDefault(n, new())) if (seen.Add(c)) q.Enqueue(c);\n",
+    "    }\n",
+    "    return order;\n",
+    "}\n",
+    "List<string> DfsOrder(Dictionary<string,List<string>> g, string root)\n",
+    "{\n",
+    "    var order = new List<string>();\n",
+    "    var st = new Stack<string>(); st.Push(root);\n",
+    "    var seen = new HashSet<string>();\n",
+    "    while (st.Count > 0)\n",
+    "    {\n",
+    "        var n = st.Pop();\n",
+    "        if (!seen.Add(n)) continue;\n",
+    "        order.Add(n);\n",
+    "        foreach (var c in Enumerable.Reverse(g.GetValueOrDefault(n, new()))) st.Push(c);\n",
+    "    }\n",
+    "    return order;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"BFS : \" + string.Join(\", \", BfsOrder(tree, \"A\")));\n",
+    "Console.WriteLine(\"DFS : \" + string.Join(\", \", DfsOrder(tree, \"A\")));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d70462967bab",
+   "metadata": {},
+   "source": [
+    "### Interprétation — Ordres d'exploration\n",
+    "\n",
+    "- **BFS** visite `A, B, C, D, E, F, G, H, …` : par niveaux, largeur d'abord.\n",
+    "- **DFS** visite `A, B, D, H, I, E, J, K, …` : descend branche gauche jusqu'au fond, puis remonte.\n",
+    "\n",
+    "Ces deux ordres sont la signature des deux stratégies : BFS garantit le plus court chemin en nombre d'arêtes ; DFS garantit une faible empreinte mémoire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ce086215e19",
+   "metadata": {},
+   "source": [
+    "## 5. Recherche à Coût Uniforme (UCS — Uniform Cost Search)\n",
+    "\n",
+    "UCS généralise BFS aux **graphes pondérés** : au lieu d'expanser le nœud le moins profond, on expansse le nœud de **coût g minimal** (coût cumulé depuis la source). Implémentée avec une **file de priorité** (`PriorityQueue<TElement, TPriority>`), UCS garantit l'optimalité dès que les coûts sont ≥ 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "48618c0c83a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.541512Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.541273Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.608475Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.608156Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "UCS : Bordeaux -> Paris -> Strasbourg\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         coût =    1075 km | 2 sauts | 13 noeuds explorés\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- UCS : recherche à coût uniforme (file de priorité sur g) ---\n",
+    "public static SearchResult UCS(Problem p, string start = null)\n",
+    "{\n",
+    "    string s0 = start ?? p.Initial;\n",
+    "    var frontier = new PriorityQueue<Node, double>();\n",
+    "    frontier.Enqueue(new Node(s0, null, 0, 0), 0);\n",
+    "    var bestG = new Dictionary<string, double> { [s0] = 0 };\n",
+    "    int exploredCount = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        var node = frontier.Dequeue();\n",
+    "        exploredCount++;\n",
+    "        if (p.IsGoal(node.State)) return new SearchResult(node, exploredCount, \"UCS\");\n",
+    "        foreach (var (next, cost) in p.Actions(node.State))\n",
+    "        {\n",
+    "            double g = node.G + cost;\n",
+    "            if (!bestG.TryGetValue(next, out double prev) || g < prev)\n",
+    "            {\n",
+    "                bestG[next] = g;\n",
+    "                frontier.Enqueue(new Node(next, node, 0, g), g);\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return new SearchResult(null, exploredCount, \"UCS\");\n",
+    "}\n",
+    "\n",
+    "var ucsRes = UCS(pBS);\n",
+    "ucsRes.Print();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97494d9f8425",
+   "metadata": {},
+   "source": [
+    "### Interprétation — UCS trouve le chemin optimal en coût\n",
+    "\n",
+    "Sur Bordeaux → Strasbourg, UCS et BFS convergent ici vers le même chemin (le graphe est quasi-métrique sur cette paire : le chemin en le moins de sauts est aussi le moins coûteux). Ce n'est **pas** toujours le cas — c'est l'objet de la démonstration suivante.\n",
+    "\n",
+    "### Démonstration Prong B : quand UCS bat BFS strictement\n",
+    "\n",
+    "Prenons le trajet **Rennes → Strasbourg**. BFS privilégie le chemin en le moins de sauts (Rennes → Lille → Strasbourg, 2 sauts), qui coûte 600 + 530 = **1130 km**. UCS, lui, examine le coût et trouve un chemin à 3 sauts strictement moins cher : Rennes → Nantes → Paris → Strasbourg = 110 + 385 + 490 = **985 km** (−13 %). C'est l'apport réel d'UCS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "58afe2df906c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.609735Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.609527Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.639278Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.639084Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Trajet Rennes -> Strasbourg :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS : Rennes -> Lille -> Strasbourg\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         coût =    1130 km | 2 sauts | 6 noeuds explorés\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "UCS : Rennes -> Nantes -> Paris -> Strasbourg\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         coût =     985 km | 3 sauts | 9 noeuds explorés\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> UCS économise 1130 - 985 = 145 km (-13 %) en empruntant un chemin À 3 sauts moins cher que le chemin à 2 sauts de BFS.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Démonstration Prong B : UCS strictement meilleur que BFS sur Rennes -> Strasbourg ---\n",
+    "var pRS = new GraphProblem(\"Rennes\", \"Strasbourg\", franceGraph);\n",
+    "Console.WriteLine(\"Trajet Rennes -> Strasbourg :\");\n",
+    "BFS(pRS, \"Rennes\").Print();\n",
+    "UCS(pRS, \"Rennes\").Print();\n",
+    "Console.WriteLine(\">>> UCS économise 1130 - 985 = 145 km (-13 %) en empruntant un chemin À 3 sauts moins cher que le chemin à 2 sauts de BFS.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c50b78f4935b",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Analyser l'écart de coût entre BFS et UCS\n",
+    "\n",
+    "**Objectif** : identifiez un autre trajet dans le graphe où BFS ne trouve pas le chemin optimal en coût, et quantifiez l'écart. *Indice* : cherchez une paire de villes directement reliées par une arête coûteuse, pour laquelle un détour par 2 arêtes bon marché est globalement moins cher."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "59774aae518f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.640809Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.640628Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.676610Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.676389Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 à compléter — choix initial (non optimal) : Rennes -> Nice\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Exercice 2 : Analyser l'écart BFS vs UCS (STUB) ---\n",
+    "// TODO étudiant : choisissez une paire (origine, destination) dans franceGraph,\n",
+    "// lancez BFS et UCS, puis affichez l'écart de coût en km.\n",
+    "// Exemple de structure attendue :\n",
+    "//   var p = new GraphProblem(\"<villeA>\", \"<villeB>\", franceGraph);\n",
+    "//   var b = BFS(p); var u = UCS(p);\n",
+    "//   Console.WriteLine($\"Écart : {b.Cost - u.Cost:F0} km\");\n",
+    "string villeA = \"Rennes\";   // TODO étudiant : à remplacer\n",
+    "string villeB = \"Nice\";     // TODO étudiant : à remplacer\n",
+    "Console.WriteLine(\"Exercice 2 à compléter — choix initial (non optimal) : \" + villeA + \" -> \" + villeB);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "212e4c7b3bef",
+   "metadata": {},
+   "source": [
+    "## 6. Recherche en Profondeur Itérée (IDDFS — Iterative Deepening DFS)\n",
+    "\n",
+    "IDDFS combine les garanties de BFS (complétude, optimalité en coûts unitaires) avec la **frugalité mémoire de DFS**. On lance une série de recherches DFS bornées à profondeur 0, 1, 2, … jusqu'à trouver le but. Le coût de la re-exploration reste modeste (overhead logarithmique)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2b2bf25b48b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.677942Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.677745Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.747362Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.747131Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IDDFS : Bordeaux -> Paris -> Strasbourg\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         coût =    1075 km | 2 sauts | 10 noeuds explorés\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- IDDFS : profondeur limitée + approfondissement itératif ---\n",
+    "// DLS : DFS borné à limit (retourne le noeud-but ou null).\n",
+    "public static Node DepthLimitedSearch(Problem p, int limit, out int explored)\n",
+    "{\n",
+    "    explored = 0;\n",
+    "    var frontier = new Stack<Node>();\n",
+    "    frontier.Push(new Node(p.Initial, null, 0, 0));\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        var node = frontier.Pop();\n",
+    "        explored++;\n",
+    "        if (p.IsGoal(node.State)) return node;\n",
+    "        if (node.Depth < limit)\n",
+    "            foreach (var (next, cost) in p.Actions(node.State).Reverse())\n",
+    "                frontier.Push(new Node(next, node, 0, node.G + cost));\n",
+    "    }\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "public static SearchResult IDDFS(Problem p, int maxLimit = 20)\n",
+    "{\n",
+    "    int totalExplored = 0;\n",
+    "    for (int limit = 0; limit <= maxLimit; limit++)\n",
+    "    {\n",
+    "        var goal = DepthLimitedSearch(p, limit, out int explored);\n",
+    "        totalExplored += explored;\n",
+    "        if (goal is not null) return new SearchResult(goal, totalExplored, $\"IDDFS\");\n",
+    "    }\n",
+    "    return new SearchResult(null, totalExplored, \"IDDFS\");\n",
+    "}\n",
+    "\n",
+    "var iddfsRes = IDDFS(pBS);\n",
+    "iddfsRes.Print();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e1904f2f3d0",
+   "metadata": {},
+   "source": [
+    "### Interprétation — IDDFS et l'overhead de re-exploration\n",
+    "\n",
+    "IDDFS re-explore les nœuds peu profonds à chaque itération. Sur un arbre de facteur de branchement *b* et profondeur solution *d*, l'overhead théorique est `b/(b−1)` (asymptotiquement négligeable). C'est le prix à payer pour une empreinte mémoire en `O(b·d)` au lieu de `O(b^d)` pour BFS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51dc8c5c5d8d",
+   "metadata": {},
+   "source": [
+    "## 7. Comparaison des quatre algorithmes\n",
+    "\n",
+    "Comparons BFS, DFS, UCS et IDDFS sur plusieurs trajets. Le tableau ci-dessous résume coût (km), nombre de sauts et nœuds explorés."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "360d370f774c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.748936Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.748689Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.836747Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.836227Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Trajet                     Algo   Coût (km)  Sauts  Explorés  \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Strasbourg     BFS    1075       2      7         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Strasbourg     DFS    1540       3      9         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Strasbourg     UCS    1075       2      13        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Strasbourg     IDDFS  1075       2      10        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rennes -> Strasbourg       BFS    1130       2      6         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rennes -> Strasbourg       DFS    1450       4      11        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rennes -> Strasbourg       UCS    985        3      9         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rennes -> Strasbourg       IDDFS  1130       2      13        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rennes -> Nice             BFS    1475       5      12        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rennes -> Nice             DFS    1475       5      9         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rennes -> Nice             UCS    1300       5      12        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rennes -> Nice             IDDFS  1475       5      152       \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Nice           BFS    850        3      12        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Nice           DFS    1565       4      7         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Nice           UCS    850        3      9         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Nice           IDDFS  850        3      48        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lille -> Marseille         BFS    1005       3      8         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lille -> Marseille         DFS    1005       3      4         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lille -> Marseille         UCS    1005       3      9         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lille -> Marseille         IDDFS  1005       3      24        \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Comparaison complète sur plusieurs trajets ---\n",
+    "var testCases = new (string from, string to)[]\n",
+    "{\n",
+    "    (\"Bordeaux\", \"Strasbourg\"),\n",
+    "    (\"Rennes\", \"Strasbourg\"),\n",
+    "    (\"Rennes\", \"Nice\"),\n",
+    "    (\"Bordeaux\", \"Nice\"),\n",
+    "    (\"Lille\", \"Marseille\"),\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine($\"{\"Trajet\",-26} {\"Algo\",-6} {\"Coût (km)\",-10} {\"Sauts\",-6} {\"Explorés\",-10}\");\n",
+    "Console.WriteLine(new string('-', 62));\n",
+    "foreach (var (f, t) in testCases)\n",
+    "{\n",
+    "    var p = new GraphProblem(f, t, franceGraph);\n",
+    "    var results = new[] { (\"BFS\", BFS(p)), (\"DFS\", DFS(p)), (\"UCS\", UCS(p)), (\"IDDFS\", IDDFS(p)) };\n",
+    "    foreach (var (name, r) in results)\n",
+    "    {\n",
+    "        string cost = r.Found ? r.Cost.ToString(\"F0\") : \"—\";\n",
+    "        string len  = r.Found ? r.Length.ToString()    : \"—\";\n",
+    "        Console.WriteLine($\"{f + \" -> \" + t,-26} {name,-6} {cost,-10} {len,-6} {r.Explored,-10}\");\n",
+    "    }\n",
+    "    Console.WriteLine();\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9343014ff2bb",
+   "metadata": {},
+   "source": [
+    "### Interprétation — Comparaison expérimentale\n",
+    "\n",
+    "- **UCS** donne systématiquement le coût minimal (référence d'optimalité).\n",
+    "- **BFS** minimize les sauts ; il peut être sous-optimal en coût (cf. Rennes → Strasbourg).\n",
+    "- **DFS** est rapide mais ni optimal ni reproductible (dépend de l'ordre des voisins).\n",
+    "- **IDDFS** récupère l'optimalité en sauts de BFS avec la mémoire de DFS, au prix d'une exploration supérieure.\n",
+    "\n",
+    "### Exercice 3 : Comparaison expérimentale personnalisée\n",
+    "\n",
+    "**Objectif** : choisissez 3 trajets et expliquez pour chacun quel algorithme utiliseriez-vous en production, et pourquoi (compromis optimalité / mémoire / temps)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e99216836c2f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.838405Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.838221Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.884803Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.884495Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Paris -> Nice : BFS=980 km, UCS=905 km\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lille -> Nice : BFS=1205 km, UCS=1130 km\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bordeaux -> Lyon : BFS=1050 km, UCS=965 km\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> Complétez : quel algorithme pour quel scénario ? Argumentez.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Exercice 3 : Comparaison expérimentale personnalisée (STUB) ---\n",
+    "// TODO étudiant : choisissez 3 trajets, lancez les 4 algorithmes, et documentez\n",
+    "// dans une cellule markdown le compromis optimalité/mémoire/temps de chacun.\n",
+    "var mesTrajets = new (string, string)[] { (\"Paris\", \"Nice\"), (\"Lille\", \"Nice\"), (\"Bordeaux\", \"Lyon\") };\n",
+    "foreach (var (f, t) in mesTrajets)\n",
+    "{\n",
+    "    var p = new GraphProblem(f, t, franceGraph);\n",
+    "    Console.WriteLine($\"{f} -> {t} : BFS={BFS(p).Cost:F0} km, UCS={UCS(p).Cost:F0} km\");\n",
+    "}\n",
+    "Console.WriteLine(\">>> Complétez : quel algorithme pour quel scénario ? Argumentez.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70d684df4d2b",
+   "metadata": {},
+   "source": [
+    "## 8. Exemples guidés\n",
+    "\n",
+    "### Exemple guidé 1 : Trace manuelle de BFS sur un petit graphe\n",
+    "\n",
+    "Considérons le graphe `A-B-C-D` avec un nœud but D. Tracons pas à pas l'exécution de BFS depuis A : frontière FIFO, nœuds explorés."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "994d0386daaa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.886122Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.885909Z",
+     "iopub.status.idle": "2026-07-04T13:33:51.929175Z",
+     "shell.execute_reply": "2026-07-04T13:33:51.928967Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exemple guide 1 — BFS A -> D :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS : A -> B -> D\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         coût =       6 km | 2 sauts | 4 noeuds explorés\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS trouve A -> B -> D (2 sauts, coût 6), mais UCS trouve A -> B -> C -> D (3 sauts, coût 4) — cheaper.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "UCS : A -> B -> C -> D\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         coût =       4 km | 3 sauts | 5 noeuds explorés\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Exemple guide 1 : trace BFS sur un petit graphe ---\n",
+    "var smallGraph = new Dictionary<string, Dictionary<string, double>>\n",
+    "{\n",
+    "    [\"A\"] = new(){ [\"B\"]=1, [\"C\"]=4 },\n",
+    "    [\"B\"] = new(){ [\"A\"]=1, [\"C\"]=2, [\"D\"]=5 },\n",
+    "    [\"C\"] = new(){ [\"A\"]=4, [\"B\"]=2, [\"D\"]=1 },\n",
+    "    [\"D\"] = new(){ [\"B\"]=5, [\"C\"]=1 },\n",
+    "};\n",
+    "var pSmall = new GraphProblem(\"A\", \"D\", smallGraph);\n",
+    "Console.WriteLine(\"Exemple guide 1 — BFS A -> D :\");\n",
+    "BFS(pSmall).Print();\n",
+    "Console.WriteLine(\"BFS trouve A -> B -> D (2 sauts, coût 6), mais UCS trouve A -> B -> C -> D (3 sauts, coût 4) — cheaper.\");\n",
+    "UCS(pSmall).Print();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4da37a326950",
+   "metadata": {},
+   "source": [
+    "### Exemple guidé 2 : BFS bidirectionnel\n",
+    "\n",
+    "**Principe** : lancez simultanément un BFS depuis la source (avant) et un BFS depuis le but (arrière). Quand les deux frontières se rencontrent, on a un chemin. Cette approche divise grossièrement la complexité par la racine de la taille de l'espace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a2e9b73c12e0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T13:33:51.930591Z",
+     "iopub.status.busy": "2026-07-04T13:33:51.930388Z",
+     "iopub.status.idle": "2026-07-04T13:33:52.034277Z",
+     "shell.execute_reply": "2026-07-04T13:33:52.034055Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS bidirectionnel Rennes -> Nice :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rencontre à : Lyon | noeuds explorés = 7\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chemin (côté avant) : Rennes -> Nantes -> Paris -> Lyon\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Exemple guide 2 : BFS bidirectionnel ---\n",
+    "// Pour simplifier (graphe symétrique non pondéré), on alterne expansion avant/arrière\n",
+    "// jusqu'à intersection des ensembles visités.\n",
+    "public static SearchResult BidirectionalBFS(GraphProblem p)\n",
+    "{\n",
+    "    // Deux files BFS : avant depuis la source, arrière depuis le but.\n",
+    "    // Le graphe étant symétrique, p.Actions(node.State) donne les voisins dans les deux sens.\n",
+    "    var fwd = new Queue<Node>(); fwd.Enqueue(new Node(p.Initial, null, 0, 0));\n",
+    "    var bwd = new Queue<Node>(); bwd.Enqueue(new Node(p.Goal, null, 0, 0));\n",
+    "    var fwdSeen = new Dictionary<string, Node> { [p.Initial] = fwd.Peek() };\n",
+    "    var bwdSeen = new Dictionary<string, Node> { [p.Goal] = bwd.Peek() };\n",
+    "    int explored = 0;\n",
+    "    while (fwd.Count > 0 && bwd.Count > 0)\n",
+    "    {\n",
+    "        Node ExpandOne(Queue<Node> q, Dictionary<string, Node> mine, Dictionary<string, Node> theirs)\n",
+    "        {\n",
+    "            var node = q.Dequeue();\n",
+    "            explored++;\n",
+    "            foreach (var (next, cost) in p.Actions(node.State))\n",
+    "            {\n",
+    "                if (mine.ContainsKey(next)) continue;\n",
+    "                var child = new Node(next, node, 0, node.G + cost);\n",
+    "                mine[next] = child;\n",
+    "                if (theirs.ContainsKey(next)) return child;   // rencontre des deux côtés\n",
+    "                q.Enqueue(child);\n",
+    "            }\n",
+    "            return null;\n",
+    "        }\n",
+    "        var meet1 = ExpandOne(fwd, fwdSeen, bwdSeen);\n",
+    "        if (meet1 is not null)\n",
+    "            return new SearchResult(meet1, explored, \"BiBFS\");\n",
+    "        var meet2 = ExpandOne(bwd, bwdSeen, fwdSeen);\n",
+    "        if (meet2 is not null)\n",
+    "            return new SearchResult(meet2, explored, \"BiBFS\");\n",
+    "    }\n",
+    "    return new SearchResult(null, explored, \"BiBFS\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"BFS bidirectionnel Rennes -> Nice :\");\n",
+    "var pRN = new GraphProblem(\"Rennes\", \"Nice\", franceGraph);\n",
+    "var biRes = BidirectionalBFS(pRN);\n",
+    "Console.WriteLine($\"Rencontre à : {biRes.Goal?.State} | noeuds explorés = {biRes.Explored}\");\n",
+    "Console.WriteLine($\"Chemin (côté avant) : {string.Join(\" -> \", biRes.Goal?.Path().Select(n => n.State) ?? Array.Empty<string>())}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92438ed9f797",
+   "metadata": {},
+   "source": [
+    "### Interprétation — BFS bidirectionnel\n",
+    "\n",
+    "Le BFS bidirectionnel explore environ deux fois moins de nœuds qu'un BFS simple pour le même trajet : chaque moitié ne parcourt que la moitié de la profondeur. Le coût est la gestion de deux frontières et la détection d'intersection."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "525899e4e1a8",
+   "metadata": {},
+   "source": [
+    "## 9. Résumé\n",
+    "\n",
+    "### Concepts clés\n",
+    "\n",
+    "| Concept | Définition |\n",
+    "|---------|------------|\n",
+    "| **Recherche non informée** | Exploration sans heuristique, pilotée uniquement par l'ordre d'expansion. |\n",
+    "| **BFS** | File FIFO ; optimal en nombre de sauts ; mémoire O(b^d). |\n",
+    "| **DFS** | Pile LIFO ; non optimal ; mémoire O(b·m). |\n",
+    "| **UCS** | File de priorité sur le coût g ; optimal en coût ; nécessite coûts ≥ 0. |\n",
+    "| **IDDFS** | DFS borné itérativement ; optimal en sauts + mémoire O(b·d). |\n",
+    "| **BFS bidirectionnel** | Deux BFS (avant/arrière) ; divise la complexité. |\n",
+    "\n",
+    "### Leçon .NET\n",
+    "\n",
+    "Ce jumeau C# utilise exclusivement la BCL : `Queue<T>` (BFS), `Stack<T>` (DFS), `PriorityQueue<TElement, TPriority>` (UCS, .NET 6+), `HashSet<T>` (visités). Aucune bibliothèque de graphe externe n'est nécessaire — les algorithmes de recherche non informée sont assez simples pour une implémentation pédagogique directe, et c'est précisément le but.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [<< Espaces d'états (Search-1)](Search-1-StateSpace.ipynb) | [Index Partie 1](README.md) | [Recherche informée (Search-3) >>](Search-3-Informed.ipynb)\n",
+    "\n",
+    "*Jumeau .NET du notebook Python Search-2-Uninformed — marathon de parité #4956.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

EPIC **#4956** item 2 (parité .NET ⇄ Python). Port C# .NET 9.0 fidèle du notebook Python [Search-2-Uninformed.ipynb](Search-2-Uninformed.ipynb), exécuté end-to-end sur kernel `.net-csharp`. Issue dispatch : **#5332** (lane po-2024:CoursIA-2).

## Algorithmes (BCL .NET, aucune lib externe — SOTA-OK Prong A)

| Algorithme | Structure BCL | Propriété |
|------------|---------------|-----------|
| **BFS** | `Queue<T>` (FIFO) + visités | Optimal en sauts |
| **DFS** | `Stack<T>` (LIFO) + visités | Frugal en mémoire |
| **UCS** | `PriorityQueue<Node, double>` | Optimal en coût (≥0) |
| **IDDFS** | DFS borné itératif (`DepthLimitedSearch`) | Optimal en sauts + mémoire O(b·d) |
| **BFS bidirectionnel** | Double file avant/arrière | Divise la complexité |

Sur le graphe des villes françaises (12 villes, distances km symétriques).

## Prong B (#3801) — non-trivialité démontrée firsthand

L'issue #5332 suggérait « Bordeaux→Strasbourg via Lyon ou Toulouse-Marseille » pour démontrer qu'UCS bat BFS. **Vérification firsthand** : sur Bordeaux→Strasbourg, BFS et UCS **convergent** à 1075 km (le graphe est quasi-métrique sur cette paire — le chemin en le moins de sauts est aussi le moins coûteux). La suggestion de l'issue ne discrimine donc pas.

La **vraie démonstration Prong B** porte sur **Rennes→Strasbourg** : BFS minimise les sauts et trouve Rennes→Lille→Strasbourg (2 sauts, **1130 km**), mais UCS trouve un chemin à 3 sauts strictement moins cher : Rennes→Nantes→Paris→Strasbourg = **985 km (−13 %)**. C'est le contre-exemple honnête, documenté comme tel dans le notebook (section 5).

## Exercices & exemples (#2161, C.1)

- **3 exercices stub** (cohabitent avec exemples résolus) : (1) DFS limité en profondeur — brique d'IDDFS, (2) analyse écart BFS/UCS, (3) comparaison expérimentale personnalisée. Patterns C.1 conformes (`return null` / `// TODO étudiant`, **0** `throw`/`NotImplementedException`/`raise`).
- **2 exemples guides résolus** : (1) trace BFS sur petit graphe A→D (BFS trouve A→B→D en 6, UCS trouve A→B→C→D en 4 — cheaper), (2) BFS bidirectionnel Rennes→Nice (rencontre à Lyon, **7 nœuds explorés** vs 12 pour BFS simple).

## Exécution réelle (H.5 EXEC_PROVED)

`jupyter nbconvert --execute --ExecutePreprocessor.kernel_name=.net-csharp` — **15/15 cellules code**, `execution_count` 1..15 strictement croissant, **0 erreur**. Le tableau comparatif des 4 algorithmes sur 5 trajets (Bordeaux→Strasbourg, Rennes→Strasbourg, Rennes→Nice, Bordeaux→Nice, Lille→Marseille) est produit en sortie avec coût km / sauts / nœuds explorés.

**Conformité #5214 advisory** : `.net-csharp` exécuté **localement** (dotnet-interactive 1.0.712001 installé), `exec_count != null` partout — preuve d'exécution locale conforme.

## README

1 ligne ajoutée au tableau Part1 (jumeau .NET Search-2), format identique aux jumeaux Search-4 (#5300) et Search-6 (#5293). **0 marqueur CATALOG-STATUS** dans ce README feuille (catalogue byte-identique à `main`, géré par le cron).

## Self-review (5 points B)

1. **Scope réel** : 1 notebook créé + 1 ligne README. Nouveau notebook, 0 code production touché (anti-régression N/A).
2. **Validation post-fix** : re-exécution nbconvert après les 2 fixes (Collection-modified cell 16, cleanup réflexion morte) → EXEC_PROVED 15/15.
3. **Cohérence pédagogique** : suit la structure Python (intro → cadre → BFS → DFS → UCS → IDDFS → comparaison → exemples) en jumeau compact, comme les modèles Search-4/6 C#.
4. **Exécution réelle** : EXEC_PROVED (ci-dessus), pas de markdown-workaround.
5. **Régression** : grep C.1 (0 violation), secret scan (0 credential), 0 marqueur catalogue touché.

## Références

- **See #4956** — EPIC parité .NET⇄Python (marathon, ne clôt pas).
- **See #5332** — issue dispatch (lane po-2024:CoursIA-2, item 2 du marathon).

Pas de `Closes` : contribution au marathon #4956 + livraison du grain #5332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)