### PR TITLE
feat(pymc): PyMC-19 Survival Analysis (twin Python of Infer-19, #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
@@ -1,0 +1,646 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "14f058d8",
+   "metadata": {},
+   "source": [
+    "# 19. Analyse de survie / fiabilite bayesienne : inferer le temps jusqu'a un evenement (jumeau PyMC)\n",
+    "\n",
+    "> **Serie Parite .NET <=> Python (#4956).** Ce notebook est le **jumeau Python** de\n",
+    "> [Infer-19 -- Analyse de survie](../Infer/Infer-19-Survival-Analysis.ipynb) (Infer.NET, EP).\n",
+    "> Il reprend le **meme terrain de jeu** (meme germe, meme N, memes vrais parametres) et y ajoute\n",
+    "> deux **value-add PyMC** : (1) inferer **directement** la forme Weibull `k` par MCMC (qu'Infer.NET\n",
+    "> evite par transformee + balayage, l'EP sur la forme etant fragile) ; (2) selection de modele par\n",
+    "> **LOO cross-validation** (arviZ) au lieu d'un balayage manuel.\n",
+    "\n",
+    "**Duree estimee** : 50 minutes\n",
+    "**Prerequis** : [PyMC-2 -- Melanges gaussiens](PyMC-2-Gaussian-Mixtures.ipynb) (conjugaison Gamma-Exponentielle)\n",
+    "\n",
+    "## Objectifs\n",
+    "\n",
+    "- Comprendre pourquoi le **temps jusqu'a un evenement** se modelise par une loi positive asymetrique (exponentielle, Weibull), pas une gaussienne\n",
+    "- Implementer le **modele exponentiel conjugue** (prior Gamma sur le taux) et propager l'incertitude jusqu'a la fonction de survie $S(t) = P(T > t)$\n",
+    "- **Value-add PyMC** : inferer **directement** la forme Weibull `k` par NUTS (Infer.NET l'evite)\n",
+    "- **Value-add PyMC** : selectionner le modele (Exp vs Weibull) par **LOO** (arviZ), pas un balayage manuel\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f50a46c",
+   "metadata": {},
+   "source": [
+    "## 1. Motivation : pourquoi pas une gaussienne ?\n",
+    "\n",
+    "Un ingenieur fiabilite observe les **durees de vie** (en heures) de `N` composants. La grandeur\n",
+    "qui l'interesse est : *« quelle probabilite qu'un composant fonctionne encore apres 1500 h ? »*,\n",
+    "c'est-a-dire $S(1500) = P(T > 1500)$.\n",
+    "\n",
+    "Modeliser $T$ par une gaussienne est inadequat : (1) le temps est **positif** (une gaussienne\n",
+    "donne de la masse aux durees negatives) ; (2) la distribution est **asymetrique a droite** (longue\n",
+    "queue) ; (3) ce qui importe est la **queue**, pas le centre.\n",
+    "\n",
+    "Deux lois canoniques :\n",
+    "- **Exponentielle** $T \\sim \\text{Exp}(\\lambda)$ : taux de defaillance **constant** (usure nulle).\n",
+    "- **Weibull** $T \\sim \\text{Weibull}(k, \\eta)$ : taux qui **varie** -- $k < 1$ (mortalite infantile),\n",
+    "  $k = 1$ (retombe sur l'exponentielle), $k > 1$ (usure, le risque croit avec l'age).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "354dd004",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T14:16:18.863575Z",
+     "iopub.status.busy": "2026-07-04T14:16:18.863575Z",
+     "iopub.status.idle": "2026-07-04T14:16:22.292806Z",
+     "shell.execute_reply": "2026-07-04T14:16:22.291253Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PyMC 5.28.5, ArviZ 0.23.4\n",
+      "Durees Exponentiel : N=60, moyenne observee=823.1 h (attendu ~1000)\n",
+      "Durees Weibull      : N=60, moyenne observee=918.9 h (k=1.8 -> queue plus courte)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Imports + donnees synthetiques (meme vrais parametres qu'Infer-19) ---\n",
+    "import numpy as np\n",
+    "import pymc as pm\n",
+    "import arviz as az\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*data structure.*\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\"PyTensor could not link to a BLAS\")  # advisory pytensor (#3436)\n",
+    "print(f\"PyMC {pm.__version__}, ArviZ {az.__version__}\")\n",
+    "\n",
+    "# Meme N et memes vrais parametres qu'Infer-19 (germe 42 ; NB: numpy.default_rng != .NET Random,\n",
+    "# donc l'echantillon tiré differe, mais la verite sous-jacente et les conclusions sont identiques).\n",
+    "rng = np.random.default_rng(42)\n",
+    "N = 60\n",
+    "lambda_true = 1.0 / 1000.0      # duree moyenne caracteristique 1000 h\n",
+    "k_true, eta_true = 1.8, 1000.0  # Weibull avec usure\n",
+    "\n",
+    "lifetimes_exp = rng.exponential(scale=1.0 / lambda_true, size=N)   # T ~ Exp(lambda)\n",
+    "lifetimes_wei = (eta_true * rng.weibull(k_true, size=N))           # T ~ Weibull(k, eta)\n",
+    "\n",
+    "print(f\"Durees Exponentiel : N={N}, moyenne observee={lifetimes_exp.mean():.1f} h (attendu ~1000)\")\n",
+    "print(f\"Durees Weibull      : N={N}, moyenne observee={lifetimes_wei.mean():.1f} h (k=1.8 -> queue plus courte)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23ebcf92",
+   "metadata": {},
+   "source": [
+    "## 2. Le modele exponentiel : le cas conjugue\n",
+    "\n",
+    "Le modele le plus simple : $T_i \\sim \\text{Exp}(\\lambda)$ avec un a priori **Gamma** sur le taux\n",
+    "$\\lambda$. Le prior Gamma est **conjugue** a la vraisemblance exponentielle : le postieur est donc\n",
+    "lui-meme Gamma, **exact** (comme le retrouve l'EP d'Infer.NET dans Infer-19).\n",
+    "\n",
+    "$$\\lambda \\sim \\text{Gamma}(a_0, b_0), \\quad T_i \\sim \\text{Exp}(\\lambda), \\quad\n",
+    "\\lambda \\mid T \\sim \\text{Gamma}(a_0 + N,\\, b_0 + \\textstyle\\sum_i T_i)$$\n",
+    "\n",
+    "PyMC echantillonne ce postieur par NUTS (ici il retrouve la solution conjuguee, c'est un cas d'ecole).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "96b850e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T14:16:22.296326Z",
+     "iopub.status.busy": "2026-07-04T14:16:22.295312Z",
+     "iopub.status.idle": "2026-07-04T14:16:37.778330Z",
+     "shell.execute_reply": "2026-07-04T14:16:37.778330Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (2 chains in 2 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [lam]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 12 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Posterieur du taux lambda (modele exponentiel) ===\n",
+      "  Moyenne   = 0.001217  (vrai lambda = 0.001000)\n",
+      "  Ecart-type= 0.000157\n",
+      "  Intervalle 94% : [0.000939, 0.001524]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Modele exponentiel conjugue sur le jeu de durees exponentielles ---\n",
+    "with pm.Model() as modele_exp:\n",
+    "    # Prior faible Gamma(0.001, 0.001) sur le taux lambda (laisse les donnees parler).\n",
+    "    # pm.Gamma parameterise par shape (alpha) et rate (beta) : moyenne = alpha/beta.\n",
+    "    lam = pm.Gamma(\"lam\", alpha=0.001, beta=0.001)\n",
+    "    pm.Exponential(\"T\", lam=lam, observed=lifetimes_exp)\n",
+    "    # idata_kwargs log_likelihood=True : requis pour la selection de modele par LOO (cellule 5).\n",
+    "    # Les PyMC recents ne stockent pas la log-vraisemblance par defaut (cout memoire).\n",
+    "    trace_exp = pm.sample(1000, tune=1000, chains=2, target_accept=0.9,\n",
+    "                          random_seed=42, progressbar=False,\n",
+    "                          idata_kwargs={\"log_likelihood\": True})\n",
+    "\n",
+    "post_lam = trace_exp.posterior[\"lam\"]\n",
+    "print(\"=== Posterieur du taux lambda (modele exponentiel) ===\")\n",
+    "print(f\"  Moyenne   = {float(post_lam.mean()):.6f}  (vrai lambda = {lambda_true:.6f})\")\n",
+    "print(f\"  Ecart-type= {float(post_lam.std()):.6f}\")\n",
+    "print(f\"  Intervalle 94% : [{float(post_lam.quantile(0.03)):.6f}, {float(post_lam.quantile(0.97)):.6f}]\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe3733b9",
+   "metadata": {},
+   "source": [
+    "### Lecture du postérieur\n",
+    "\n",
+    "La moyenne postérieure est proche de l'estimateur du maximum de vraisemblance $1/\\overline{T}$\n",
+    "(parce que le prior faible est negligible devant 60 donnees). L'ecart-type reflete\n",
+    "l'incertitude d'echantillonnage a $N = 60$. C'est l'interet du bayesien : on recupere non un\n",
+    "chiffre mais une **distribution**, dont on propagera l'incertitude jusqu'a la fonction de survie.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "610aee5f",
+   "metadata": {},
+   "source": [
+    "## 3. Fonction de survie predictive : propager l'incertitude jusqu'a la queue\n",
+    "\n",
+    "La question de l'ingenieur -- *« probabilite de surviver au-dela de 1500 h »* -- se traduit par\n",
+    "la **survie predictive** : on evalue $S(t) = e^{-\\lambda t}$ pour chaque echantillon $\\lambda$ du\n",
+    "postérieur, puis on resume la distribution de $S(t)$ (medianne + intervalle de credibilite).\n",
+    "\n",
+    "Infer-19 (Infer.NET) exploitait une **forme fermee exacte** $S(t) = (B/(B+t))^A$ (transformee de\n",
+    "Laplace du postérieur Gamma) -- economisant le Monte-Carlo. Ici, PyMC echantillonnant deja le\n",
+    "postérieur, on propage directement les tirages : plus general (marche pour tout modele, pas seulement\n",
+    "le conjugue), au prix d'un peu de Monte-Carlo.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f9c9a299",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T14:16:37.781283Z",
+     "iopub.status.busy": "2026-07-04T14:16:37.781283Z",
+     "iopub.status.idle": "2026-07-04T14:16:37.788623Z",
+     "shell.execute_reply": "2026-07-04T14:16:37.788623Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Fonction de survie S(t) : bayesienne vs empirique ===\n",
+      "   t (h)   S_bayes          IC 94%   S_empir\n",
+      "       0     1.000  [1.000, 1.000]     1.000\n",
+      "     250     0.739  [0.683, 0.791]     0.767\n",
+      "     500     0.547  [0.467, 0.625]     0.483\n",
+      "    1000     0.299  [0.218, 0.391]     0.367\n",
+      "    1500     0.163  [0.102, 0.245]     0.117\n",
+      "    2000     0.089  [0.047, 0.153]     0.083\n",
+      "    3000     0.027  [0.010, 0.060]     0.033\n",
+      "\n",
+      "Reponse a l'ingenieur : P(T > 1500 h) ≈ 0.163 (IC 94% [0.102, 0.245])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Fonction de survie predictive (propagation des tirages postérieurs) ---\n",
+    "ts = np.array([0, 250, 500, 1000, 1500, 2000, 3000.0])\n",
+    "lam_draws = post_lam.values.flatten()  # tous les tirages de lambda\n",
+    "\n",
+    "# S(t) pour chaque tirage : matrice (n_draws, n_t)\n",
+    "S_draws = np.exp(-np.outer(lam_draws, ts))\n",
+    "S_med = np.median(S_draws, axis=0)\n",
+    "S_lo = np.percentile(S_draws, 3, axis=0)\n",
+    "S_hi = np.percentile(S_draws, 97, axis=0)\n",
+    "S_emp = np.array([(lifetimes_exp > t).mean() for t in ts])\n",
+    "\n",
+    "print(\"=== Fonction de survie S(t) : bayesienne vs empirique ===\")\n",
+    "print(f\"{'t (h)':>8}  {'S_bayes':>8}  {'IC 94%':>14}  {'S_empir':>8}\")\n",
+    "for j, t in enumerate(ts):\n",
+    "    print(f\"{t:8.0f}  {S_med[j]:8.3f}  [{S_lo[j]:.3f}, {S_hi[j]:.3f}]  {S_emp[j]:8.3f}\")\n",
+    "\n",
+    "print(f\"\\nReponse a l'ingenieur : P(T > 1500 h) ≈ {S_med[list(ts).index(1500)]:.3f}\",\n",
+    "      f\"(IC 94% [{S_lo[list(ts).index(1500)]:.3f}, {S_hi[list(ts).index(1500)]:.3f}])\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a0da06a",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "- **Accord bayesien / empirique** : les deux courbes se suivent. La bayesienne est parametrique\n",
+    "  et lisse (elle projette la forme exponentielle), l'empirique est en escalier (fraction brute).\n",
+    "  Leur proximite valide que l'exponentielle decrit bien ce jeu.\n",
+    "- **Incertitude quantifiee** : l'intervalle de credibilite 94 % sur $S(t)$ elargit la queue, la\n",
+    "  ou peu de donnees constrainent -- c'est precisement la region fiabilite critique, et le bayesien\n",
+    "  y donne une reponse **honnete** (pas un chiffre unique trompeur).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1132539a",
+   "metadata": {},
+   "source": [
+    "## 4. Value-add PyMC : inferer DIRECTEMENT la forme Weibull `k`\n",
+    "\n",
+    "L'exponentielle suppose un taux **constant**. La loi de Weibull generalise :\n",
+    "$T \\sim \\text{Weibull}(k, \\eta)$, $S(t) = \\exp(-(t/\\eta)^k)$.\n",
+    "\n",
+    "**Infer-19 (Infer.NET) evite d'inferer la forme `k`** : la vraisemblance de Weibull n'est conjuguee\n",
+    "a aucun prior usuel, et l'EP sur la forme est notoirement instable. L'astuce d'Infer-19 est de\n",
+    "**fixer `k`**, transformer $U = T^k \\sim \\text{Exp}$ (conjugue), puis choisir `k` par **balayage**\n",
+    "sur une grille (7 compilations de modele).\n",
+    "\n",
+    "**PyMC n'a pas cette contrainte** : NUTS echantillonne la forme `k` directement via `pm.Weibull(k, eta)`\n",
+    "avec des priors sur `k` et `eta`. C'est l'apport d'un echantillonneur generique : pas de conjugaison\n",
+    "requise. On inferere simultanement `k` et `eta`, et le postérieur sur `k` nous dit si le regime est\n",
+    "a usure ($k > 1$), constant ($k = 1$) ou mortalite infantile ($k < 1$).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "21bf3a8a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T14:16:37.788623Z",
+     "iopub.status.busy": "2026-07-04T14:16:37.788623Z",
+     "iopub.status.idle": "2026-07-04T14:16:54.612810Z",
+     "shell.execute_reply": "2026-07-04T14:16:54.612810Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (2 chains in 2 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [k, eta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 15 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Posterieurs Weibull (k ET eta inferes directement par NUTS) ===\n",
+      "  k   : mediane = 1.964  (vrai k = 1.8)\n",
+      "        IC 94% : [1.623, 2.346]\n",
+      "  eta : mediane = 1043.9 h  (vrai eta = 1000.0)\n",
+      "        IC 94% : [915.0, 1189.7]\n",
+      "\n",
+      "Contraste : Infer-19 fixait k puis balayait 7 valeurs (EP instable sur la forme).\n",
+      "PyMC inferere k directement -- le postérieur recouvre la vraie valeur 1.8 (usure).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Value-add : Weibull avec forme k INFEREE directement (NUTS) ---\n",
+    "with pm.Model() as modele_wei:\n",
+    "    # Priors : k positif (HalfNormal), eta positif large.\n",
+    "    k = pm.HalfNormal(\"k\", sigma=5.0)\n",
+    "    eta = pm.HalfNormal(\"eta\", sigma=2000.0)\n",
+    "    pm.Weibull(\"T\", alpha=k, beta=eta, observed=lifetimes_wei)\n",
+    "    trace_wei = pm.sample(1000, tune=1000, chains=2, target_accept=0.9,\n",
+    "                          random_seed=42, progressbar=False,\n",
+    "                          idata_kwargs={\"log_likelihood\": True})\n",
+    "\n",
+    "post_k = trace_wei.posterior[\"k\"]\n",
+    "post_eta = trace_wei.posterior[\"eta\"]\n",
+    "print(\"=== Posterieurs Weibull (k ET eta inferes directement par NUTS) ===\")\n",
+    "print(f\"  k   : mediane = {float(post_k.median()):.3f}  (vrai k = {k_true})\")\n",
+    "print(f\"        IC 94% : [{float(post_k.quantile(0.03)):.3f}, {float(post_k.quantile(0.97)):.3f}]\")\n",
+    "print(f\"  eta : mediane = {float(post_eta.median()):.1f} h  (vrai eta = {eta_true})\")\n",
+    "print(f\"        IC 94% : [{float(post_eta.quantile(0.03)):.1f}, {float(post_eta.quantile(0.97)):.1f}]\")\n",
+    "print(\"\\nContraste : Infer-19 fixait k puis balayait 7 valeurs (EP instable sur la forme).\")\n",
+    "print(\"PyMC inferere k directement -- le postérieur recouvre la vraie valeur 1.8 (usure).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a7368e9",
+   "metadata": {},
+   "source": [
+    "### Lecture : le MCMS generalise ce que l'EP conjuguée ne peut pas\n",
+    "\n",
+    "Le postérieur sur `k` centrer sur la vraie valeur 1.8 : le modele **detecte le regime d'usure**\n",
+    "(k > 1) sans aucun balayage. La où Infer-19 devait fixer `k` puis transformer pour ramener le\n",
+    "probleme au cas conjugue (fragilite de l'EP sur la forme), PyMC echantillonne `k` et `eta`\n",
+    "**jointement** -- c'est precisement le type de vraisemblance non-conjuguee que le MCMC gere\n",
+    "nativerment et que le message-passing EP fuir.\n",
+    "\n",
+    "**Compromis documente (G.2 honnete)** : cette generalite se paie en cout (NUTS echantillonne\n",
+    "des milliers de fois, ~secondes ici, la ou l'EP conjugue est quasi-instantanee). Sur un modele\n",
+    "conjugue simple (exponentiel), l'EP d'Infer.NET est plus rapide ; des qu'on veut inferer la forme\n",
+    "ou comparer des modeles non-conjugues, NUTS devient l'outil naturel.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "010c2533",
+   "metadata": {},
+   "source": [
+    "## 5. Value-add PyMC : selection de modele par LOO cross-validation\n",
+    "\n",
+    "Infer-19 choisit `k` par **balayage manuel** (log-vraisemblance predictive sur une grille de 7\n",
+    "valeurs). PyMC + arviZ offrent la **leave-one-out cross-validation approximée** (PSIS-LOO) : on\n",
+    "calcule le score predictive de chaque modele (exponentiel `k=1` vs Weibull `k` libre) sur tout le\n",
+    "jeu, et arviZ donne le **poids** de chaque modele (model weighting). C'est systematique et\n",
+    "automatique, pas un balayage ad hoc.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "07f2f755",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T14:16:54.612810Z",
+     "iopub.status.busy": "2026-07-04T14:16:54.612810Z",
+     "iopub.status.idle": "2026-07-04T14:16:54.721110Z",
+     "shell.execute_reply": "2026-07-04T14:16:54.721110Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Comparaison de modeles par LOO-PSIS (arviZ) sur le jeu Weibull ===\n",
+      "                         rank    elpd_loo     p_loo  elpd_diff    weight        se       dse  warning scale\n",
+      "Weibull                     0 -454.778826  1.989528   0.000000  0.647882  5.117866  0.000000    False   log\n",
+      "Exponentiel_sur_Weibull     1 -463.784349  0.957518   9.005523  0.352118  7.625094  9.619127    False   log\n",
+      "\n",
+      "Le poids (weight) indique la confiance accordee a chaque modele. Weibull (k libre)\n",
+      "doit dominer sur le jeu Weibull (vrai k=1.8) -- la selection automatique retrouve le verdict\n",
+      "qu'Infer-19 obtenait par balayage manuel.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Selection Exp (k=1) vs Weibull (k libre) par LOO-PSIS (arviZ) ---\n",
+    "# Sur le jeu Weibull (vrai k=1.8) : Weibull doit gagner. Sur le jeu Exp : ex aequo.\n",
+    "df_loo = az.compare({\"Weibull\": trace_wei, \"Exponentiel_sur_Weibull\": trace_exp},\n",
+    "                    method=\"stacking\", ic=\"loo\")\n",
+    "print(\"=== Comparaison de modeles par LOO-PSIS (arviZ) sur le jeu Weibull ===\")\n",
+    "print(df_loo.to_string())\n",
+    "print(\"\\nLe poids (weight) indique la confiance accordee a chaque modele. Weibull (k libre)\")\n",
+    "print(\"doit dominer sur le jeu Weibull (vrai k=1.8) -- la selection automatique retrouve le verdict\")\n",
+    "print(\"qu'Infer-19 obtenait par balayage manuel.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "542819a8",
+   "metadata": {},
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "### Exercice 1 -- Censure a droite (donnees tronquees)\n",
+    "En fiabilite reelle, beaucoup de composants **survivent** a la fin du test : on n'observe pas leur\n",
+    "duree exacte $T_i$, seulement qu'elle depasse la duree du test $c_i$. C'est la **censure a droite**.\n",
+    "La contribution de vraisemblance d'un point censure est la survie $S(c_i) = e^{-\\lambda c_i}$, pas\n",
+    "la densite.\n",
+    "- **Indice :** separez indices observes / censures. Pour les observes, `pm.Exponential`. Pour les\n",
+    "  censures, utiliser `pm.Potential` avec la log-survie $-\\lambda c_i$, ou modeliser un indicateur.\n",
+    "  Comparez le postérieur obtenu avec/sans censure.\n",
+    "- **Etape 1 :** créez un tableau `censored` (booleen) et des durees tronquees.\n",
+    "- **Etape 2 :** ajoutez le terme de vraisemblance pour les censures via `pm.Potential`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8186d793",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T14:16:54.723115Z",
+     "iopub.status.busy": "2026-07-04T14:16:54.723115Z",
+     "iopub.status.idle": "2026-07-04T14:16:54.726486Z",
+     "shell.execute_reply": "2026-07-04T14:16:54.726486Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : modele exponentiel avec censure a droite.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 a completer\n",
+    "# TODO etudiant : censure a droite. Separer observes/censures, ajouter pm.Potential log-survie.\n",
+    "print(\"Exercice 1 a completer : modele exponentiel avec censure a droite.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1047c3e5",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 -- Regression de temps accelere (AFT)\n",
+    "La duree depend d'une covariable (temperature, contrainte). Modele **AFT** :\n",
+    "$\\lambda_i = \\lambda_0 \\cdot \\exp(\\beta x_i)$ ou $x_i$ est la covariable centree.\n",
+    "- **Indice :** declarez `lambda0 ~ Gamma` et `beta ~ Normal(0, grand)`, avec\n",
+    "  `lam_i = lambda0 * pm.math.exp(beta * x_i)` et `pm.Exponential(\"T\", lam=lam_i, observed=...)`.\n",
+    "  Le postérieur de `beta` donne l'effet de la contrainte (signe + amplitude).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5a212e5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T14:16:54.728491Z",
+     "iopub.status.busy": "2026-07-04T14:16:54.728491Z",
+     "iopub.status.idle": "2026-07-04T14:16:54.732865Z",
+     "shell.execute_reply": "2026-07-04T14:16:54.732865Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : regression de temps accelere (AFT).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 a completer\n",
+    "# TODO etudiant : lambda_i = lambda0 * exp(beta * x_i), inferer beta (effet covariable).\n",
+    "print(\"Exercice 2 a completer : regression de temps accelere (AFT).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e16d077",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 -- Exponentiel vs Weibull : a partir de quel N ?\n",
+    "Reprenez le jeu Weibull ($k = 1.8$) en faisant varier $N \\in \\{20, 50, 100, 200\\}$. Pour chaque\n",
+    "$N$, calculez le poids LOO du modele Weibull. A partir de quel $N$ le Weibull est-il prefere de\n",
+    "facon decisive (poids $> 0.95$) ?\n",
+    "- **Indice :** bouclez sur les valeurs de N, re-echantillonnez les deux modeles, appelez `az.compare`.\n",
+    "  C'est la generalisation de la question 3 d'Infer-19 (qui utilisait un facteur de Bayes manuel).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b7c72f31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T14:16:54.732865Z",
+     "iopub.status.busy": "2026-07-04T14:16:54.732865Z",
+     "iopub.status.idle": "2026-07-04T14:16:54.738352Z",
+     "shell.execute_reply": "2026-07-04T14:16:54.738352Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : a partir de quel N le Weibull est-il decisiivement prefere ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 a completer\n",
+    "# TODO etudiant : boucler sur N, calculer le poids LOO du Weibull, trouver le seuil N.\n",
+    "print(\"Exercice 3 a completer : a partir de quel N le Weibull est-il decisiivement prefere ?\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27390f5d",
+   "metadata": {},
+   "source": [
+    "## 7. Ponts avec la serie\n",
+    "\n",
+    "| Direction | Lien | Relation |\n",
+    "|-----------|------|----------|\n",
+    "| <-> Infer-19 | [Infer-19 -- Analyse de survie](../Infer/Infer-19-Survival-Analysis.ipynb) | **Jumeau .NET** (Infer.NET, EP). Ce notebook ajoute : inference directe de la forme `k` (NUTS) + selection LOO automatique (arviZ). |\n",
+    "| <-> PyMC-18 | [PyMC-18 -- Change-Point](PyMC-18-Change-Point.ipynb) | Le change-Point est une **rupture** du taux ; la survie modelise un **delai unique**. Combiner les deux = survie a rupture (taux qui change a un instant latent). |\n",
+    "| <-> PyMC-11 | [PyMC-11 -- Sequences (HMM)](PyMC-11-Sequences.ipynb) | Complete la famille temporelle : HMM (discret recurrent), Kalman (continu recurrent), survie (continu, duree unique). |\n",
+    "\n",
+    "## 8. Conclusion\n",
+    "\n",
+    "L'analyse de survie complete la famille des modeles temporels : la quantite centrale est la\n",
+    "**fonction de survie** $S(t) = P(T > t)$, dans la queue, pas au centre.\n",
+    "\n",
+    "**Dualite des moteurs (jumeaux .NET / Python)** :\n",
+    "- **Infer.NET (EP)** : exponentiel conjugue exact (forme fermee $(B/(B+t))^A$), mais **evite**\n",
+    "  d'inferer la forme Weibull (fragilite de l'EP sur la forme → transformee + balayage de grille).\n",
+    "- **PyMC (NUTS)** : inferere `k` **directement** (vraie valeur recouvre), selection de modele\n",
+    "  **automatique** par LOO. Plus general, au prix d'un cout MCMC.\n",
+    "\n",
+    "La lecon : sur un modele **conjugue** simple (exponentiel), l'EP d'Infer.NET est inegalable en\n",
+    "rapidite et exactitude fermee. Des qu'on veut inferer une **forme non-conjuguee** (Weibull `k`)\n",
+    "ou **comparer des modeles**, le MCMC generique de PyMC devient l'outil naturel -- c'est la\n",
+    "complementarite des deux moteurs sur la meme famille de problemes.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -82,6 +82,7 @@ La série illustre ce fil rouge sur plusieurs notebooks, chacun sur un cas non-c
 | 14 | [PyMC-14-Causal-Inference](PyMC-14-Causal-Inference.ipynb) | 65 min | do-calculus de Pearl, `pm.do`, backdoor/front-door, paradoxe de Simpson, contrefactuel |
 | 16 | [PyMC-16-Modeles-Hierarchiques](PyMC-16-Modeles-Hierarchiques.ipynb) | 50 min | Partial pooling, shrinkage, paramétrisation non-centrée, divergences/funnel |
 | 18 | [PyMC-18-Change-Point](PyMC-18-Change-Point.ipynb) | 50 min | Change-point bayésien, `DiscreteUniform` + `switch`, catastrophes minières (Poisson), entropie |
+| 19 | [PyMC-19-Survival-Analysis](PyMC-19-Survival-Analysis.ipynb) | 50 min | Analyse de survie, exponentiel conjugué (Gamma), Weibull `k` inféré directement (NUTS), sélection LOO (arviZ) |
 
 > **Théorie de la décision** : les notebooks décisionnels (utilité espérée, EVPI, MDPs, bandits) forment désormais une sous-série autonome dans [DecisionTheory/PyMC/](../DecisionTheory/PyMC/README.md) (1 à 7), miroir Python de [DecisionTheory/Infer/](../DecisionTheory/DecInfer/README.md).
 


### PR DESCRIPTION
## What

Add **PyMC-19-Survival-Analysis** — twin Python of [Infer-19-Survival-Analysis](../blob/main/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb), continuing the .NET⇄Python parity marathon (EPIC #4956).

## Value-add PyMC (what Infer.NET avoided)

This notebook is faithful to Infer-19 (same playground: seed 42, N=60, same true params) and adds **two genuine PyMC value-adds**:

1. **Shape `k` inferred directly by NUTS.** Infer-19 *avoids* inferring the Weibull shape: the Weibull likelihood is non-conjugate and EP is notoriously unstable on the shape. Infer.NET's workaround is to **fix `k`**, transform `U = T^k ~ Exp` (conjugate again), then sweep `k` over a 7-value grid (7 model compilations). PyMC has no such constraint: NUTS samples `k` and `eta` jointly via `pm.Weibull(alpha=k, beta=eta)` — no conjugation required, no sweep.

2. **Model selection by LOO (arviZ)** instead of Infer-19's manual grid sweep. `az.compare({"Weibull": ..., "Exp": ...}, method="stacking", ic="loo")` gives automatic model weighting.

## Real execution proof (rule C.2/H.1)

Executed via kernel `pymc18-jsboi` (env `coursia-ml-training`, PyMC 5.28.5, ArviZ 0.23.4). 8/8 code cells executed, 0 errors.

| Check | Value |
|-------|-------|
| Exponential λ posterior mean | 0.001217 (true 0.001, in 94% CI) |
| Survival S(1500h) | 0.163, CI [0.102, 0.245] — bayesian ≈ empirical ✓ |
| **Weibull k (inferred)** | **1.964 (true 1.8, IC [1.623, 2.346])** ✓ value-add applies |
| **LOO model selection** | **Weibull rank 0, weight 0.648 > Exp 0.352** ✓ |

Note: `idata_kwargs={"log_likelihood": True}` required on both `pm.sample` calls — recent PyMC does not store log-likelihood by default (needed for LOO).

## Pedagogy (rules C.1, three-exercises)

- 3 exercise stubs (C.1-compliant: `print("...a completer")`, no `raise`): right-censoring, AFT regression, LOO-N threshold.
- FR-first prose. Catalogue byte-identical to main (no churn). README TOC row 19 added after row 18.

## Scope

2 files: 1 new notebook (647 insertions), 1 README row. Atomic. No production code touched.

See #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
