### PR TITLE
feat(secrets): centralize Qdrant client key + rotation runbook (See #16)

### DIFF
--- a/docker-configurations/SECURITY.md
+++ b/docker-configurations/SECURITY.md
@@ -1,9 +1,33 @@
 # Docker GenAI Security Audit
 
-**Date:** 2026-05-08
- **Issue:** #808
+**Date:** 2026-05-08 (runbook rotation ajouté 2026-07-04, issue #16)
+ **Issue:** #808 / #16
 **Auditor:** po-2023 (Claude Code)
 **Scope:** 20 containers on po-2023 (RTX 3080 Ti + RTX 3090)
+
+## Runbook — rotation d'un secret (1 commande)
+
+Tout secret **partagé** (clés API, tokens service↔client) vit dans `.secrets/master.env` (gitignored, source unique). La rotation se fait en **un render + un restart** — jamais d'édition éparpillée à la main.
+
+```bash
+# 1. Éditer la source unique
+$EDITOR .secrets/master.env                      # ex: QDRANT_API_KEY=<nouvelle valeur>
+
+# 2. Propager vers tous les .env consommateurs (idempotent)
+python scripts/secrets/render_envs.py
+
+# 3. Vérifier 0 drift (gate local, exit 1 si écart)
+python scripts/secrets/render_envs.py --check
+
+# 4. Redémarrer le container côté SERVEUR (OBLIGATOIRE — ComfyUI-Login
+#    régénère son hash bcrypt au restart, pas à chaud ; Qdrant relit
+#    QDRANT__SERVICE__API_KEY au startup)
+docker compose -f docker-configurations/services/<svc>/docker-compose.yml restart
+```
+
+**Spécificité Qdrant (cross-repo) :** la compose Qdrant vit dans `roo-extensions` (autre repo), pas CoursIA. Le côté **client** (`QDRANT_API_KEY`, notebooks CoursIA) est centralisé dans `master.env` via `SECRET_KEYS` → rotation auto côté notebooks. Le côté **serveur** (`QDRANT__SERVICE__API_KEY`, double underscore) reste une op manuelle inter-repo sur `roo-extensions` (même valeur que le client). Détail convention client/serveur : [docs/genai/secrets-management.md](../docs/genai/secrets-management.md).
+
+**Mots de passe par instance** (`COMFYUI_PASSWORD`, `FORGE_PASSWORD`, `WHISPER_*_PASSWORD`) NE sont PAS centralisés (un par container) — leur drift est prévenu par la règle du restart + self-check entrypoint, pas par render. Cf [docs/genai/secrets-management.md](../docs/genai/secrets-management.md).
 
 ## Executive Summary
 
@@ -113,7 +137,7 @@ API keys are passed via `.env` files and `environment:` blocks in docker-compose
 
 ### Next Steps (requires separate PR or manual ops)
 
-1. **Qdrant auth:** Add `QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY}` to environment + `.env` (Qdrant compose not in this repo — managed externally)
+1. **Qdrant auth (serveur) :** Add `QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY}` to environment + `.env` — compose Qdrant dans `roo-extensions` (autre repo), op manuelle inter-repo. Le côté **client** (`QDRANT_API_KEY`, notebooks CoursIA) est désormais centralisé dans `master.env` via `SECRET_KEYS` (render_envs.py) — rotation auto côté notebooks, cf runbook en tête de ce document.
 2. **Bind 127.0.0.1:** Change port bindings for services behind IIS reverse proxy
 
 ### Medium Priority (2-4h, requires testing)

--- a/docs/genai/secrets-management.md
+++ b/docs/genai/secrets-management.md
@@ -6,7 +6,7 @@
 
 ```
 .secrets/master.env                    <- SOURCE UNIQUE (éditer ici)
-   HF_TOKEN, OPENAI_API_KEY, COMFYUI_VIDEO_TOKEN, ... (18 clés partagées)
+   HF_TOKEN, OPENAI_API_KEY, COMFYUI_VIDEO_TOKEN, QDRANT_API_KEY, ... (19 clés partagées)
 
 scripts/secrets/render_envs.py
    --bootstrap   one-shot : lit les .env éparpillés, écrit master.env
@@ -53,10 +53,20 @@ python scripts/secrets/render_envs.py --check
 | LLM APIs payantes | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` | notebooks | Oui (facturation) |
 | Hubs / git | `CIVITAI_TOKEN`, `GITHUB_TOKEN` = `GITHUB_ACCESS_TOKEN` | services + notebooks | Oui |
 | Client API keys (server↔client) | `WHISPER_API_KEY`, `VLLM_API_KEY`, `TTS_API_KEY`, `QWEN_ASR_API_KEY`, `MUSICGEN_API_KEY`, `DEMUCS_API_KEY`, `FUNASR_API_KEY` | 1 service + notebooks | Moyen |
+| Qdrant vector DB (client) | `QDRANT_API_KEY` | notebooks RAG / SemanticKernel / Argument_Analysis | Moyen (flip serveur = op inter-repo roo-extensions) |
 | Tokens client ComfyUI | `COMFYUI_VIDEO_TOKEN`, `COMFYUI_API_TOKEN` | notebooks → services ComfyUI | Moyen |
 | Session | `SECRET_KEY` | 1 service | Oui |
 
 **Alias :** `HF_TOKEN`/`HUGGINGFACE_TOKEN` et `GITHUB_TOKEN`/`GITHUB_ACCESS_TOKEN` désignent le MÊME secret sous deux noms (services vs notebooks). Le render écrit la même valeur des deux côtés ; le bootstrap vérifie leur cohérence (abort si divergence).
+
+### Qdrant — convention client vs serveur (cross-repo)
+
+Qdrant expose la **même** clé API sous **deux noms** selon le côté :
+
+- **Serveur** Qdrant — `QDRANT__SERVICE__API_KEY` (double underscore, convention `config.yaml` Qdrant). Vit dans la compose `roo-extensions` (autre repo). **Non centralisé** ici : le flip de valeur est une op inter-repo manuelle.
+- **Client** (notebooks CoursIA) — `QDRANT_API_KEY` (simple underscore, convention des clients `qdrant-client`). Vit dans `MyIA.AI.Notebooks/GenAI/.env`. **Centralisé** dans `SECRET_KEYS` (render_envs.py).
+
+Les deux noms **doivent porter la même valeur** (sinon 401 côté client). Centraliser le côté client CoursIA permet aux notebooks de suivre la rotation sans action manuelle : `edit master.env → render_envs.py` propage vers `GenAI/.env`. Le **flip de la valeur côté serveur** (rotation effective, Qdrant redémarre avec la nouvelle clé) reste une opération manuelle inter-repo sur `roo-extensions` — tracker séparément, cf [SECURITY.md](../../docker-configurations/SECURITY.md).
 
 ## Secrets par instance (NON centralisés — config service)
 

--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -73,6 +73,13 @@ SECRET_KEYS: frozenset[str] = frozenset({
     "WHISPER_API_KEY", "VLLM_API_KEY", "TTS_API_KEY",
     "QWEN_ASR_API_KEY", "MUSICGEN_API_KEY", "DEMUCS_API_KEY",
     "FUNASR_API_KEY",
+    # Qdrant vector DB -- CLIENT side (notebooks RAG / SemanticKernel / Argument).
+    # NB: the Qdrant SERVER reads the SAME value under the double-underscore name
+    # ``QDRANT__SERVICE__API_KEY`` (config.yaml convention). The server compose
+    # lives in the ``roo-extensions`` repo (NOT CoursIA); only the CLIENT key is
+    # centralized here so notebook consumers stay in lock-step with the server on
+    # rotation. Both names MUST carry the same value.
+    "QDRANT_API_KEY",
     # OWUI native API (NB-20, #417) + TTS multi-voice gateway (#16, po-2023)
     "OWUI_API_KEY", "TTS_GATEWAY_API_KEY",
     # ComfyUI client tokens (notebook client <-> service must agree)


### PR DESCRIPTION
## Résumé

Répond au mandat user du 04/07 via ai-01 : « c'est myia-po-2023:CoursIA qui se charge de gérer tous les containers et les auth/secrets associés. Il faut qu'il le fasse BIEN pour gérer le tout facilement et rotater facilement quand il y a besoin. » → **#16 Sécurisation services IA, volet Qdrant**.

`QDRANT_API_KEY` était le **seul** secret service partagé absent de `SECRET_KEYS` dans `render_envs.py` — donc le seul à ne pas bénéficier de la rotation centralisée (edit master.env → render → restart). Cette PR corrige ce gap côté **client** CoursIA et documente le runbook de rotation 1-commande.

## Changements (3 fichiers, +45/−4)

### `scripts/secrets/render_envs.py`
- Ajout de `QDRANT_API_KEY` au frozenset `SECRET_KEYS` (21 clés, +1).
- Commentaire inline documentant la convention underscore : côté client `QDRANT_API_KEY` (simple underscore, centralisé ici) vs côté serveur `QDRANT__SERVICE__API_KEY` (double underscore, config.yaml Qdrant, compose dans `roo-extensions`).

### `docker-configurations/SECURITY.md`
- **Runbook rotation** ajouté en tête de document : éditer master.env → `render_envs.py` → `--check` → `docker compose restart`. Réponse directe au mandat « rotation facile ».
- Spécificité cross-repo Qdrant documentée (serveur = op manuelle roo-extensions, client = auto via SECRET_KEYS).
- Ligne de recommandation Qdrant mise à jour : client désormais auto-rotaté, seul le flip serveur reste inter-repo.

### `docs/genai/secrets-management.md`
- Compteur 18 → 19 clés partagées.
- Ligne Qdrant dans la table d'inventaire.
- Section dédiée « Qdrant — convention client vs serveur (cross-repo) ».

## Périmètre (doc/schema/config uniquement)

- **AUCUNE valeur secrète** dans la PR (master.env et .env sont gitignored).
- **AUCUNE action live-config** dans le repo (curl, docker restart, provider rotation = reportés sur dashboard, pas committés).
- Les `.env.example` consommateurs portaient déjà la ligne `QDRANT_API_KEY` (`MyIA.AI.Notebooks/GenAI/.env.example:249` + `qdrant.env.example`) — pas de modification template nécessaire, le render propagera la valeur au prochain `python scripts/secrets/render_envs.py`.

## Validation

- `ast.parse(render_envs.py)` → SYNTAX OK.
- `QDRANT_API_KEY in SECRET_KEYS` → True (21 clés, +1 vs main).
- `git diff --stat` → 3 fichiers, +45/−4, cohérent avec l'intention (doc/schema only).
- Markdown fence balance : SECURITY.md 18 (pair), secrets-management.md 6 (pair).
- MD060 table-alignment lint : table convertie en liste à puces (convention cross-repo) pour éviter les warnings d'alignement.

## Volets #16 ultérieurs (cycles suivants)

- **Inventaire auth LIVE** : curl non-authentifié par sous-domaine `*.myia.io` → table secured/open (preuve, pas assertion).
- **Résiduel Qwen rotation** : confirmer token exposé ~90j rotaté côté provider.
- **F1/F2/F3 hardening** (root, resource limits, bind 0.0.0.0) : tracker séparé si trop large (G.4).
- Coordination avec #2052 (validation auth GenAI cross-machine).

See #16 (sécurisation services IA, partial contribution — does not close the EPIC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)