### PR TITLE
docs(security): re-verify Qdrant auth state firsthand (See #16)

### DIFF
--- a/docker-configurations/SECURITY.md
+++ b/docker-configurations/SECURITY.md
@@ -7,9 +7,11 @@
 
 ## Executive Summary
 
-**20/20 containers run as root with unlimited resources.** 1 service has NO authentication at all (Qdrant). 1 service had no auth code (tts-gateway, now fixed). Remaining exposed services have auth configured but bind to 0.0.0.0.
+**20/20 containers run as root with unlimited resources.** 1 service (Qdrant) has its reverse-proxy endpoint secured but its **direct LAN port still wide-open** (re-verified 2026-07-04, see §F4). 1 service had no auth code (tts-gateway, now fixed). Remaining exposed services have auth configured but bind to 0.0.0.0.
 
-Overall risk: **HIGH**. Qdrant (vector DB) is the most critical exposure: full CRUD with no auth on port 6333. Services are accessible from the local network (0.0.0.0 bind). The IIS reverse proxy provides auth on `*.myia.io` domains, but direct port access bypasses it entirely.
+Overall risk: **HIGH**. Qdrant (vector DB) remains the most critical exposure: the IIS reverse proxy on `qdrant.myia.io` enforces auth (401 on `/collections` without a key), but **direct LAN access on port 6333 returns collection data with no auth at all** (`GET http://LAN:6333/collections` → `{"result":{"collections":[]}}`, 200). The `0.0.0.0` bind means anyone on the LAN can read/write vectors by bypassing the reverse proxy. Fix (set `QDRANT__SERVICE__API_KEY` on the Qdrant container OR bind `127.0.0.1:6333`) is a live inter-repo op on the `roo-extensions` compose — see the **Runbook** section at the top of this document and §F4.
+
+> **Re-verification 2026-07-04 (po-2023, firsthand probes).** Qdrant reverse-proxy auth = ACTIVE (`https://qdrant.myia.io/collections` → 401 "Must provide an API key"). Qdrant direct LAN port 6333 = OPEN (`http://localhost:6333/collections` → 200 with data, container `myia-qdrant` binds `0.0.0.0:6333-6334`). whisper-api / tts-api / comfyui-video reverse-proxy = 401 (secured). demucs-api / z-image reverse-proxy = 502, musicgen-api = timeout (services down — availability, not auth). Live-config fix for Qdrant LAN exposure tracked on dashboard (inter-repo `roo-extensions`).
 
 ## Audit Table
 
@@ -79,8 +81,8 @@ The IIS reverse proxy on `*.myia.io` domains provides auth, but direct LAN acces
 
 | Service | Port | Issue |
 |---------|------|-------|
-| Qdrant | 6333-6334 | Full CRUD, no API key, no auth. Anyone on LAN can read/write/delete vectors |
-| tts-gateway | 8196 | Was missing auth middleware import (FIXED in this PR — now uses shared/auth_middleware.py) |
+| Qdrant | 6333-6334 | **Re-verified 2026-07-04.** Reverse-proxy `qdrant.myia.io` = 401 (auth ACTIVE). Direct LAN `0.0.0.0:6333` = 200 with collection data, **no auth**. `QDRANT__SERVICE__API_KEY` not set server-side (else `/collections` would demand a key on direct port too). Full CRUD open on LAN. |
+| tts-gateway | 8196 | Was missing auth middleware import (FIXED in earlier PR — now uses shared/auth_middleware.py) |
 
 Note: SD Forge/SDNext/forge-turbo already have `--gradio-auth` with user/password from env vars. Whisper-webui already has `--username`/`--password` in entrypoint. These services auth is ACTIVE but they still bind 0.0.0.0 (see F3).
 


### PR DESCRIPTION
## Résumé

Volet 2 du mandat #16 (sécurisation services IA) : **inventaire auth firsthand** du déploiement live po-2023, opposé aux claims statiques du SECURITY.md daté 2026-05-08. Un seul fichier modifié (`docker-configurations/SECURITY.md`), doc only.

## Découvertes de re-vérification (probes 2026-07-04, po-2023)

Le SECURITY.md disait « Qdrant = NO auth, CRITICAL ». La re-vérification firsthand nuance :

| Endpoint | Résultat probe | Conclusion |
|----------|----------------|------------|
| `https://qdrant.myia.io/collections` | **401** « Must provide an API key » | Reverse-proxy IIS = auth ACTIVE ✓ |
| `http://localhost:6333/collections` | **200** `{"result":{"collections":[]}}` | **Direct LAN port = WIDE OPEN** ✗ |
| `https://whisper-api.myia.io` | 401 | sécurisé ✓ |
| `https://tts-api.myia.io` | 401 | sécurisé ✓ |
| `https://comfyui-video.myia.io` | 401 | sécurisé ✓ |
| `https://demucs-api.myia.io` | 502 | service DOWN (availability) |
| `https://z-image.myia.io` | 502 | service DOWN (availability) |
| `https://musicgen-api.myia.io` | timeout | service DOWN (availability) |

**Conclusion :** le claim « Qdrant NO auth » est **partiellement stale** — le reverse-proxy public exige bien une clé (le flip documenté dans la mémoire `security-auth-flip-qdrant-claudish` a pris effet côté IIS). En revanche, le **port LAN direct 6333 reste wide-open** : le container `myia-qdrant` bind toujours `0.0.0.0:6333-6334` (F3 non appliqué) ET `QDRANT__SERVICE__API_KEY` n'est pas set server-side (sinon `/collections` exigerait la clé même en direct). F3/F4 du SECURITY.md restent donc **valides côté LAN**.

## Changements

- **Executive Summary** : claim « 1 service has NO authentication at all (Qdrant) » → nuancé en « reverse-proxy endpoint secured but direct LAN port still wide-open », avec les résultats de probe cités inline.
- **Bloc re-verification 2026-07-04** ajouté sous l'Executive Summary (date, probeur, chaque endpoint + résultat).
- **F4 table (ligne Qdrant)** : « Full CRUD, no auth » → re-verified avec les 2 constats (reverse-proxy 401, direct LAN 200 avec data, `QDRANT__SERVICE__API_KEY` non set server-side).

## Live fix = hors-scope CoursIA (inter-repo)

Le fix de l'exposition LAN Qdrant (set `QDRANT__SERVICE__API_KEY` sur le container OU bind `127.0.0.1:6333`) est une **op live sur la compose `roo-extensions`** (autre repo) — pas faisable côté CoursIA. Tracker sur dashboard, décision user requise (option a vs b + exécuteur).

## Validation

- `git diff --stat` → 1 fichier, +6/−4 (doc only).
- Markdown fence balance : 16 (pair).
- 0 valeur secrète inline (vérifié `git diff | grep`).
- MD060 table-alignment warnings : pattern préexistant sur les wide-tables SECURITY.md (F4 était déjà large avant l'edit) ; conversion en liste = hors-scope ce volet.

## Volet 1 (complémentaire, déjà livré)

PR #5347 = volet 1 (centralisation `QDRANT_API_KEY` côté client + runbook rotation). Cette PR #volet2 est disjointe (re-verification doc, atomic).

See #16 (sécurisation services IA, partial contribution — does not close the EPIC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)