### PR TITLE
docs(security): re-verify F3 bind state firsthand — CoursIA side remediated (See #16)

### DIFF
--- a/docker-configurations/SECURITY.md
+++ b/docker-configurations/SECURITY.md
@@ -67,13 +67,33 @@ deploy:
       cpus: '2.0'
 ```
 
-### F3. All ports bind 0.0.0.0 (17/20 exposed)
+### F3. ~~All ports bind 0.0.0.0 (17/20 exposed)~~ — REMEDIATED on CoursIA side (re-verified 2026-07-04)
 
-17 services bind to `0.0.0.0`, accessible from any network interface. Only 3 TTS workers use internal networking.
+> **Status change (firsthand re-verification 2026-07-04, po-2023).** The 2026-05-08 finding "17/20 bind 0.0.0.0" is **substantially stale**. Live `docker ps` + compose inspection shows F3 has been remediated for **every CoursIA-managed service**: all bind `127.0.0.1` (localhost-only, not LAN-exposed). The only `0.0.0.0` exposures left are **cross-repo** (composes outside CoursIA).
 
-The IIS reverse proxy on `*.myia.io` domains provides auth, but direct LAN access on port X bypasses it entirely.
+**Verified bind state (2026-07-04):**
 
-**Fix:** Change port bindings from `0.0.0.0:PORT:PORT` to `127.0.0.1:PORT:PORT` for services behind IIS reverse proxy. Only expose services that need direct access.
+| Container | Bind (live `docker ps`) | Compose declares | Exposed to LAN? |
+|-----------|-------------------------|------------------|-----------------|
+| myia-qdrant | `0.0.0.0:6333-6334` | roo-extensions repo (cross-repo) | **YES — wide open, no auth** (see F4) |
+| claudish-proxy | `0.0.0.0:3000` | claudish repo (cross-repo) | YES — `proxyKey` empty = auth OFF (`POST /v1/messages` → 400, not 401/403) |
+| comfyui-qwen | `127.0.0.1:8188` | `127.0.0.1` | no |
+| comfyui-video | `127.0.0.1:8189` | `127.0.0.1` | no |
+| forge-turbo | `127.0.0.1:1111,127.0.0.1:17861` | `127.0.0.1` | no |
+| tts-gateway | `127.0.0.1:8196` | `127.0.0.1` | no |
+| tts-api | `127.0.0.1:8191` | `127.0.0.1` | no |
+| whisper-api | `127.0.0.1:8190` | `127.0.0.1` | no |
+| fast-downward | `127.0.0.1:8200` | `127.0.0.1` | no |
+| sd-forge-main (auto-stopped) | — | `127.0.0.1:7862` | no (when running) |
+| sdnext (auto-stopped) | — | `127.0.0.1:7861` | no (when running) |
+| demucs-api (auto-stopped) | — | `127.0.0.1` | no (when running) |
+| musicgen-api (auto-stopped) | — | `127.0.0.1` | no (when running) |
+| vllm-zimage (auto-stopped) | — | `127.0.0.1` | no (when running) |
+| whisper-webui (auto-stopped) | — | `127.0.0.1` | no (when running) |
+
+**Net result:** 0 CoursIA-managed service binds `0.0.0.0`. The two remaining LAN-exposed services (`myia-qdrant`, `claudish-proxy`) are **cross-repo** — their composes live in `roo-extensions` and `claudish` respectively, so the F3 fix for them is an inter-repo op, not a CoursIA PR. Auto-stopped services (idle-monitors) bind `127.0.0.1` per compose, so they do not regress to `0.0.0.0` when started on demand.
+
+**Original finding (2026-05-08, historical):** ~~17 services bind to `0.0.0.0`, accessible from any network interface. Only 3 TTS workers use internal networking. The IIS reverse proxy on `*.myia.io` domains provides auth, but direct LAN access on port X bypasses it entirely.~~ — **Remediated**, see verified table above.
 
 ### F4. 1 service has NO authentication, 1 had missing auth code
 


### PR DESCRIPTION
## Résumé

Suite #16 volet 3 : **re-vérification firsthand du finding F3** (« 17/20 services bind 0.0.0.0 »). Ce claim daté 2026-05-08 est **massivement stale** — `docker ps` + inspection compose 2026-07-04 montrent que F3 a été **remédié côté CoursIA** : tous les services gérés par CoursIA bindent désormais `127.0.0.1`. Les seules expositions `0.0.0.0` restantes sont **cross-repo** (composes hors CoursIA).

## Bind state vérifié firsthand (2026-07-04, po-2023)

| Container | Bind live | Compose | Exposé LAN ? |
|-----------|-----------|---------|--------------|
| myia-qdrant | `0.0.0.0:6333-6334` | roo-extensions (cross-repo) | **OUI — wide open, no auth** (F4) |
| claudish-proxy | `0.0.0.0:3000` | claudish repo (cross-repo) | OUI — `proxyKey` vide = auth OFF |
| comfyui-qwen/video, forge-turbo, tts-gateway/api, whisper-api, fast-downward | `127.0.0.1` | `127.0.0.1` | non |
| sd-forge-main, sdnext, demucs/musicgen-api, vllm-zimage, whisper-webui (auto-stopped) | — | `127.0.0.1` | non (quand démarrés) |

**Net : 0 service géré CoursIA ne bind `0.0.0.0`.** Les 2 expositions restantes (qdrant, claudish) sont cross-repo → op inter-repo, pas une PR CoursIA. Les services auto-stopped (idle-monitors) déclarent `127.0.0.1` en compose → pas de régression `0.0.0.0` au redémarrage à la demande.

## Changements

- **Titre F3** : `### F3. All ports bind 0.0.0.0 (17/20 exposed)` → `### F3. ~~...~~ — REMEDIATED on CoursIA side (re-verified 2026-07-04)`.
- **Bloc re-verification** : table vérifiée (container × bind live × compose × exposé LAN) avec date + probeur.
- **Net result** : conclusion explicite (0 CoursIA service en 0.0.0.0, 2 cross-repo restants = op inter-repo).
- **Original finding** : conservé en strikethrough pour audit trail (anti-perte, cf Consolider != Archiver).

## Validation

- `git diff --stat` → 1 fichier, +27/−7 (doc only).
- Markdown fence balance : 16 (pair).
- 0 valeur secrète inline (vérifié `git diff | grep`).
- Bind states prouvés via `docker ps` (running) + `grep compose` (stopped) — pas d'assertion.

## Contexte #16 (cycle c.134)

- **#5347** (c.133 volet 1) : centralisation `QDRANT_API_KEY` + runbook rotation.
- **#5348** (c.133 volet 2) : re-vérification auth Qdrant (reverse-proxy 401, LAN 200 wide-open).
- **Cette PR** (c.134 volet 3) : re-vérification F3 bind state — remédié côté CoursIA, 2 cross-repo restants.

Volets restants : Qwen rotation token (user-blocked, accès console provider), F1/F2 hardening (root/resource-limits — risque composite G.4 multi-services).

See #16 (sécurisation services IA, partial contribution — does not close the EPIC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)