### PR TITLE
docs(ml): reconcile ML README with 3 ML.NET parity twins (ML-5/7/9-Python)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -35,7 +35,7 @@ Avoir ces trois angles permet de comprendre que le ML n'est pas lié à un langa
 
 ## Parcours d'apprentissage
 
-### Track A : ML.NET (.NET/C#, 9 notebooks + TP, ~7h)
+### Track A : ML.NET (.NET/C#, 13 notebooks C# ⇄ Python + TP, ~7h)
 
 Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML). Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Les notebooks 8-9 ouvrent sur l'apprentissage non-supervisé : clustering K-Means (segmentation RFM, méthode du coude) puis détection d'anomalies par Randomized PCA (maintenance prédictive, choix du seuil de décision). Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
 
@@ -59,10 +59,13 @@ ML/
 │   ├── ML-3-Entrainement&AutoML.ipynb
 │   ├── ML-4-Evaluation.ipynb
 │   ├── ML-5-TimeSeries.ipynb
+│   ├── ML-5-TimeSeries-Python.ipynb   # jumeau scikit-learn (STL+SARIMA) ⇄ ForecastBySsa
 │   ├── ML-6-ONNX.ipynb
 │   ├── ML-7-Recommendation.ipynb
+│   ├── ML-7-Recommendation-Python.ipynb   # jumeau scikit-learn (NMF) ⇄ MatrixFactorization
 │   ├── ML-8-Clustering.ipynb
 │   ├── ML-9-Anomaly-Detection.ipynb
+│   ├── ML-9-Anomaly-Detection-Python.ipynb   # jumeau scikit-learn (PCA+résidu) ⇄ RandomizedPca
 │   ├── TP-prevision-ventes.ipynb
 │   └── taxi-fare.csv
 │
@@ -86,10 +89,13 @@ Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du 
 | 3 | [ML-3-Entrainement&AutoML](ML.Net/ML-3-Entrainement&AutoML.ipynb) | SDCA, LightGBM, AutoML | Entraînement |
 | 4 | [ML-4-Evaluation](ML.Net/ML-4-Evaluation.ipynb) | Cross-validation, métriques, PFI | Évaluation |
 | 5 | [ML-5-TimeSeries](ML.Net/ML-5-TimeSeries.ipynb) | Forecasts temporelles, windowing | Séries temporelles |
+| 5-Py | [ML-5-TimeSeries-Python](ML.Net/ML-5-TimeSeries-Python.ipynb) | **Jumeau Python** : `ForecastBySsa` ⇄ `STL`+`SARIMA` (statsmodels) | Parité .NET⇄Python |
 | 6 | [ML-6-ONNX](ML.Net/ML-6-ONNX.ipynb) | Export ONNX, inférence en production | Déploiement |
 | 7 | [ML-7-Recommendation](ML.Net/ML-7-Recommendation.ipynb) | Système de recommandation | Recommandations |
+| 7-Py | [ML-7-Recommendation-Python](ML.Net/ML-7-Recommendation-Python.ipynb) | **Jumeau Python** : `MatrixFactorization` ⇄ `NMF` (scikit-learn) | Parité .NET⇄Python |
 | 8 | [ML-8-Clustering](ML.Net/ML-8-Clustering.ipynb) | K-Means, segmentation RFM, méthode du coude | Non-supervisé |
 | 9 | [ML-9-Anomaly-Detection](ML.Net/ML-9-Anomaly-Detection.ipynb) | Randomized PCA, AUC, seuil de décision | Détection d'anomalies |
+| 9-Py | [ML-9-Anomaly-Detection-Python](ML.Net/ML-9-Anomaly-Detection-Python.ipynb) | **Jumeau Python** : `RandomizedPca` ⇄ `PCA`+résidu (scikit-learn) | Parité .NET⇄Python |
 | TP | [TP-prevision-ventes](ML.Net/TP-prevision-ventes.ipynb) | Régression bayésienne (Infer.NET) | Application pratique |
 
 ### Installation ML.NET


### PR DESCRIPTION
## Audit fichier-entier gate §E (#5353)

`MyIA.AI.Notebooks/ML/README.md` — la prose ML.NET était **périmée** : table et structure tree annonçaient « 9 notebooks + TP » alors que le disque contient **13 notebooks** (les 3 jumeaux Python de parité #5263 / #5265 / #5266 manquaient). Plainte user 2026-07-04 (#5345 Probas) : « intro corrigée mais listes de notebooks laissées périmées » — même classe de stale, corrigée ici.

## Preuve (a)(b)(c) — gate §E #5353

### (a) `find` count par sous-dossier ML cité
```
ML.Net/                            : 13 ipynb  (ML-1..9 C# + TP + 3 twins Python)
DataScienceWithAgents/01-PythonForDataScience :  2
DataScienceWithAgents/02-ML-Cours             :  8   (2.1-2.8)
DataScienceWithAgents/PythonAgentsForDataScience : 7   (Labs 1-7, Days 1-3)
DataScienceWithAgents/AgenticDataScience      : 10   (Labs 8-17, Days 4-7)
learning_theory_lean/                         : lake Lean 4 (Novikoff), pas un notebook
```
**Total notebooks pédagogiques = 13 + 27 = 40.**

### (b) Réconciliation disque ↔ CATALOG-STATUS ↔ prose

| Source | ML.Net | DSA | Total | Coherent ? |
|--------|--------|-----|-------|------------|
| **Disque** (`find`) | 13 | 27 | 40 | ✓ |
| **CATALOG-STATUS** (L3-8) | 13 | 27 | 40 | ✓ (INTACT, cron-owned — non touché) |
| **Prose** (avant PR) | ~~9+TP~~ | 27 | ~~40~~ | ✗ heading + tree + table STALE |
| **Prose** (après PR) | 13 | 27 | 40 | ✓ alignée |

Le catalogue était **correct** (breakdown `DataScienceWithAgents=27, ML.Net=13`) — c'est la **prose** qui dérivait. Régénérer le catalogue aurait été l'erreur (cron-only, #catalog-pr-hygiene) ; on aligne la prose sur le catalogue.

### (c) Entrées ML.Net manquantes — vérifiées firsthand

Les 3 jumeaux Python de parité (signalés par ai-01, confirmés réels) :

| Notebook | Cells | Taille | PR d'origine | Équivalence .NET ⇄ Python |
|----------|-------|--------|--------------|----------------------------|
| `ML-5-TimeSeries-Python.ipynb` | 30 | 644 KB | #5266 MERGED | `ForecastBySsa` ⇄ `STL`+`SARIMA` (statsmodels) |
| `ML-7-Recommendation-Python.ipynb` | 24 | 27 KB | #5265 MERGED | `MatrixFactorization` ⇄ `NMF` (scikit-learn) |
| `ML-9-Anomaly-Detection-Python.ipynb` | 29 | 35 KB | #5263 MERGED | `RandomizedPca` ⇄ `PCA`+résidu (scikit-learn) |

Tous 3 déjà documentés génériquement en prose (L20 : *« plusieurs notebooks avancés de la série ML.NET disposent d'un jumeau Python co-localisé (`*-Python.ipynb`) »*) mais **absents** du heading (L38), de l'arbre de structure (L56-67) et de la table (L82-93). Cette PR les inscrit explicitement aux 3 endroits.

## Changements (7 insertions, 1 deletion)

1. **Heading L38** : `9 notebooks + TP` → `13 notebooks C# ⇄ Python + TP`
2. **Structure tree** : 3 lignes ajoutées (twins inline avec commentaire d'équivalence)
3. **Table ML.NET** : 3 lignes `5-Py` / `7-Py` / `9-Py` ajoutées (description de parité)

## Vérifications

- **CATALOG-STATUS markers** : byte-identiques (vérifié `git diff | grep CATALOG-STATUS` = 0 changement) — automation-owned, non touché.
- **FR-first** (#readme-french-first) : README déjà FR, ajout FR cohérent.
- **No-pendulum** : pas de réécriture de la prose existante (déjà correcte sur le fond), uniquement inscription des 3 entrées manquantes là où elles devaient figurer.
- **Scope atomique** (G.4) : 1 fichier, 1 sujet (ML.Net parity twins), 7+/-1.

## Liens

See #3975 (feuille GenAI + familles Python — ML.NET est sa sous-famille .NET). Part of #3973 (hub ascendant) et #4956 (parité .NET ⇄ Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)