### PR TITLE
refactor(lean): decision_theory_lean lakefile roots -> globs.* (i18n #4980 finding 2)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/lakefile.lean
@@ -7,14 +7,28 @@ package decision_theory_lean where
 require mathlib from git
   "https://github.com/leanprover-community/mathlib4.git" @ "v4.30.0-rc2"
 
+-- Convention i18n EPIC #4980 (ratifiée user 04/07, finding 2 ai-01) :
+-- `globs` (et non `roots`) pour que `lake build` auto-découvre les siblings
+-- `_en` (miroir EN, namespace `<Lib>_en`). Avec `roots := #[`<Lib>]`, le root
+-- n'importe que ses deps transitives — le sibling `_en` (namespace distinct)
+-- n'est PAS built par défaut, seulement via `lake build <Lib>.*_en` explicite.
+-- `globs := #[`<Lib>.*]` couvre TOUS les modules sous `<Lib>/`, `_en` inclus →
+-- la CI drift-detection voit les deux langues. Zéro toucher aux fichiers .lean.
+--
+-- NOTE technique (validated firsthand po-2026, à propager à la fleet) :
+-- la forme bare `globs := #[`<Lib>]` NE fonctionne PAS — elle ne matche que le
+-- module root, pas les enfants. Il FAUT le suffixe `.*` : `globs := #[`<Lib>.*]`.
+-- Test firsthand sur decision_theory_lean (Utility.Basic_en/Axioms_en) :
+--   bare `Utility`  → 8497 jobs, _en NON built
+--   `Utility.*`     → 8499 jobs, _en built (Basic_en 16s + Axioms_en 15s)
 @[default_target]
 lean_lib Gittins where
-  roots := #[`Gittins]
+  globs := #[`Gittins.*]
 
 @[default_target]
 lean_lib Utility where
-  roots := #[`Utility]
+  globs := #[`Utility.*]
 
 @[default_target]
 lean_lib Coherence where
-  roots := #[`Coherence]
+  globs := #[`Coherence.*]


### PR DESCRIPTION
## Summary

Applies **ai-01 Finding 2** (ratified fleet rule, EPIC #4980, msg-vi03zs): switch decision_theory_lean's 3 libs (Gittins, Utility, Coherence) from `roots := #[`<Lib>]` to `globs` so `lake build` **auto-discovers the i18n `_en` siblings** (namespace `<Lib>_en`). With `roots`, the umbrella root imports only its transitive deps — the `_en` sibling (distinct namespace) is NOT built by default, only via explicit `lake build <Lib>.*_en`. `globs` makes CI drift-detection see both languages. **Zero `.lean` file touch** (ai-01's constraint).

## ⚠️ Firsthand correction to ai-01's Finding 2 (KEY fleet intel)

ai-01's Finding 2 said: `roots := #[`<Lib>]` → `globs := #[`<Lib>]`. **Validated empirically — the bare form does NOT work.** The correct syntax requires the `.*` suffix:

| globs syntax | jobs | `_en` built? |
|---|---|---|
| `` #[`Utility] `` (bare, ai-01 as stated) | 8497 | ❌ NO (matches root module only) |
| `` #[`Utility.*] `` (with `.*`) | 8499 | ✅ YES (Basic_en 16s + Axioms_en 15s) |

**Test method**: cleared `Utility.Basic_en.olean` + `Utility.Axioms_en.olean`, ran `lake build Utility` (no explicit `_en`), checked regeneration. Bare glob → not rebuilt. `.*` glob → both regenerated.

This correction is documented in the lakefile comment for **fleet propagation** (16 remaining i18n PRs across GameTheory/SymbolicAI lakes must use `.*`, not bare).

## §E whole-file audit (new gate, ai-01 PR #5353)

Per the new §E gate (README/series PR must prove whole-file audit in body), applied to lakefile:

- **Build**: `lake build` (default, CI behavior) = **8509 jobs SUCCESS** — all 3 libs + `_en` siblings auto-discovered
- **Sorry count** (anti-regression, FX-7 token-grep, exclude `.lake`): **2** — unchanged (GittinsTheorem.lean L99/L103, MDP/Bellman INTRINSIC, per c.209 #5272)
- **Diff scope**: single file `lakefile.lean`, +17/-3, infra-only (0 `.lean` logic files, 0 proof changes)
- **All modules built**: Gittins.{Basic,Discount,GittinsTheorem}, Utility.{Basic,Basic_en,Axioms,Axioms_en,Representation}, Coherence.{Basic,DutchBook,Probability} — oleans verified present at `.lake/build/lib/lean/`

## Environment

- Toolchain `leanprover/lean4:v4.31.0-rc1`, Mathlib `v4.30.0-rc2` junctioned to rc1 cache `d568c8c0` (cluster convergence #4364)
- `lake.exe` Windows-native (~10x faster than WSL on junctioned cache, c.209 learning)

## Context

- My turf (decision_theory_lean under Probas, Gittins/decision-theory lane). c.212 delivered `Basic_en.lean` + `Axioms_en.lean` (MERGED) — this PR makes the lakefile forward-compatible for future `_en` siblings on Gittins/Coherence too.
- No collision: no OPEN PR touches this lakefile.

`See #4980` (partial — fleet-wide globs rollout across remaining lakes; this PR validates the syntax on one lake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)