### PR TITLE
feat(lean): minimax_lean ZeroSum + Concavity + SionApplication EN siblings (tranche 11 #4980)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/Concavity_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/Concavity_en.lean
@@ -1,0 +1,138 @@
+import Mathlib
+import Minimax.ZeroSum_en
+
+/-!
+  Minimax.Concavity — concavity/convexity of the payoff (Sion glue iteration 1)
+  =============================================================================
+
+  English mirror of `Minimax/Concavity.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+
+  Note méthodologique : traduction manuelle du FR canonique (pas de source
+  EN historique pré-Option A à recover, fichier FR-first depuis origin).
+
+  Sion's **minimax theorem** (classical case) requires, for the payoff
+  `f = payoff A` on the simplices `X = stdSimplex ℝ m`,
+  `Y = stdSimplex ℝ n`:
+  - `f(x, ·)` **quasi-concave** in `y` for all `x`;
+  - `f(·, y)` **quasi-convex** in `x` for all `y`.
+
+  But the payoff is **linear** (hence affine) in each variable
+  separately — this is the bilinearity proved in `ZeroSum.lean`
+  (`payoff_add_in_x`, `payoff_smul_in_x`, `payoff_add_in_y`,
+  `payoff_smul_in_y`). A linear function is both **concave and convex**
+  (Jensen's inequality holds with **equality**). This module formalizes
+  that fact: `payoff A · y` is `ConcaveOn` / `ConvexOn` on the simplex,
+  and likewise in `y`, then (iteration 2) derives the exact
+  `QuasiconcaveOn` / `QuasiconvexOn` required by
+  `Sion.exists_isSaddlePointOn'`.
+
+  This is **Sion glue iteration 1** (milestone #4054): via the Mathlib
+  bridges `ConcaveOn.quasiconcaveOn` / `ConvexOn.quasiconvexOn`, we
+  obtain 2 of the 4 hypotheses of Sion. The final application
+  (compactness `isCompact_stdSimplex` + semicontinuity from
+  `continuous_payoff` + this) remains the OPEN milestone that is
+  documented. The module is **entirely 0-sorry**.
+
+  **Iteration 2** derives the **semicontinuity** hypotheses of Sion
+  (`LowerSemicontinuousOn` in `x`, `UpperSemicontinuousOn` in `y`) from
+  `continuous_payoff_in_x` / `continuous_payoff_in_y` (`ZeroSum.lean`)
+  via the bridges `Continuous.lowerSemicontinuous` /
+  `Continuous.upperSemicontinuous` then `.lowerSemicontinuousOn` /
+  `.upperSemicontinuousOn`. The **4 analytic hypotheses** of Sion are
+  now proved (quasi-concave/quasi-convex + LSC/USC); what remains is the
+  OPEN milestone: `Pi`-over-`ℝ` instances + non-empty `stdSimplex` +
+  the final application `Sion.minimax'`.
+-/
+
+namespace MinimaxLean_en
+
+open Finset Set
+
+variable {m n : Type*} [Fintype m] [Fintype n]
+variable (A : PayoffMatrix m n)
+
+/-- The payoff is **concave in `x`** on the simplex (linearity ⟹
+concavity, Jensen's inequality holding with equality: `payoff_smul_in_x`
+gives the scalar multiplication `a * payoff A x y`, and `smul_eq_mul`
+normalizes the `•` of the goal `ConcaveOn`). -/
+theorem payoff_concave_in_x (y : n → ℝ) :
+    ConcaveOn ℝ (stdSimplex ℝ m) fun x => payoff A x y := by
+  refine ⟨convex_stdSimplex ℝ m, ?_⟩
+  intro x _hx x' _hx' a b _ha _hb _hab
+  dsimp only
+  rw [payoff_add_in_x, payoff_smul_in_x, payoff_smul_in_x, smul_eq_mul, smul_eq_mul]
+
+/-- The payoff is **convex in `x`** on the simplex (a linear function is
+both concave and convex). -/
+theorem payoff_convex_in_x (y : n → ℝ) :
+    ConvexOn ℝ (stdSimplex ℝ m) fun x => payoff A x y := by
+  refine ⟨convex_stdSimplex ℝ m, ?_⟩
+  intro x _hx x' _hx' a b _ha _hb _hab
+  dsimp only
+  rw [payoff_add_in_x, payoff_smul_in_x, payoff_smul_in_x, smul_eq_mul, smul_eq_mul]
+
+/-- The payoff is **concave in `y`** on the simplex. -/
+theorem payoff_concave_in_y (x : m → ℝ) :
+    ConcaveOn ℝ (stdSimplex ℝ n) fun y => payoff A x y := by
+  refine ⟨convex_stdSimplex ℝ n, ?_⟩
+  intro y _hy y' _hy' a b _ha _hb _hab
+  dsimp only
+  rw [payoff_add_in_y, payoff_smul_in_y, payoff_smul_in_y, smul_eq_mul, smul_eq_mul]
+
+/-- The payoff is **convex in `y`** on the simplex. -/
+theorem payoff_convex_in_y (x : m → ℝ) :
+    ConvexOn ℝ (stdSimplex ℝ n) fun y => payoff A x y := by
+  refine ⟨convex_stdSimplex ℝ n, ?_⟩
+  intro y _hy y' _hy' a b _ha _hb _hab
+  dsimp only
+  rw [payoff_add_in_y, payoff_smul_in_y, payoff_smul_in_y, smul_eq_mul, smul_eq_mul]
+
+/-- **Quasi-concavity in `y`** (Sion glue iteration 2): via the Mathlib
+bridge `ConcaveOn.quasiconcaveOn`, required by
+`Sion.exists_isSaddlePointOn'` (assumption `f(x, ·)` quasi-concave). -/
+theorem payoff_quasiconcave_in_y (x : m → ℝ) :
+    QuasiconcaveOn ℝ (stdSimplex ℝ n) fun y => payoff A x y :=
+  (payoff_concave_in_y A x).quasiconcaveOn
+
+/-- **Quasi-convexity in `x`** (Sion glue iteration 2): via the Mathlib
+bridge `ConvexOn.quasiconvexOn`, required by
+`Sion.exists_isSaddlePointOn'` (assumption `f(·, y)` quasi-convex). -/
+theorem payoff_quasiconvex_in_x (y : n → ℝ) :
+    QuasiconvexOn ℝ (stdSimplex ℝ m) fun x => payoff A x y :=
+  (payoff_convex_in_x A y).quasiconvexOn
+
+/-! ## Iteration 2 — semicontinuity (2 remaining Sion hypotheses)
+
+The 4 analytic hypotheses of `Sion.minimax'` (`Mathlib/Topology/Sion.lean`):
+- `hfy' : ∀ y ∈ Y, QuasiconvexOn ℝ X (f · y)` — **proved**
+  (`payoff_quasiconvex_in_x`);
+- `hfx' : ∀ x ∈ X, QuasiconcaveOn ℝ Y (f x ·)` — **proved**
+  (`payoff_quasiconcave_in_y`);
+- `hfy : ∀ y ∈ Y, LowerSemicontinuousOn (f · y) X` — **proved below**;
+- `hfx : ∀ x ∈ X, UpperSemicontinuousOn (f x ·) Y` — **proved below**.
+
+A continuous function is both lower and upper semicontinuous
+(`Continuous.lowerSemicontinuous` /
+`Continuous.upperSemicontinuous`), and restriction to a subset passes
+through `.lowerSemicontinuousOn` / `.upperSemicontinuousOn`. The payoff
+is continuous in each variable (`continuous_payoff_in_x` /
+`continuous_payoff_in_y`), whence the two hypotheses. -/
+
+/-- **Lower semicontinuity in `x`** (iteration 2): `f(·, y)` is
+`LowerSemicontinuousOn` on the simplex — continuity ⟹ LSC, required by
+`Sion.minimax'` (hyp `hfy : ∀ y ∈ Y, LowerSemicontinuousOn (f · y) X`). -/
+theorem payoff_lowerSemicontinuous_in_x (y : n → ℝ) :
+    LowerSemicontinuousOn (fun x => payoff A x y) (stdSimplex ℝ m) :=
+  (continuous_payoff_in_x A y).lowerSemicontinuous.lowerSemicontinuousOn (stdSimplex ℝ m)
+
+/-- **Upper semicontinuity in `y`** (iteration 2): `f(x, ·)` is
+`UpperSemicontinuousOn` on the simplex — continuity ⟹ USC, required by
+`Sion.minimax'` (hyp `hfx : ∀ x ∈ X, UpperSemicontinuousOn (f x ·) Y`). -/
+theorem payoff_upperSemicontinuous_in_y (x : m → ℝ) :
+    UpperSemicontinuousOn (fun y => payoff A x y) (stdSimplex ℝ n) :=
+  (continuous_payoff_in_y A x).upperSemicontinuous.upperSemicontinuousOn (stdSimplex ℝ n)
+
+end MinimaxLean_en

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/SionApplication_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/SionApplication_en.lean
@@ -1,0 +1,94 @@
+import Mathlib
+import Minimax.ZeroSum_en
+import Minimax.Concavity_en
+
+/-!
+  Minimax.SionApplication — final Sion application (Sion glue iteration 3)
+  ========================================================================
+
+  English mirror of `Minimax/SionApplication.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+
+  Note méthodologique : traduction manuelle du FR canonique (pas de source
+  EN historique pré-Option A à recover, fichier FR-first depuis origin).
+
+  This module wires the **4 analytic hypotheses** proved in `Concavity.lean`
+  (quasi-convexity in `x`, quasi-concavity in `y`, lower semicontinuity in
+  `x`, upper in `y`) with Mathlib's topological facts on `stdSimplex`
+  (compactness `isCompact_stdSimplex`, convexity `convex_stdSimplex`,
+  non-vacuity via `single_mem_stdSimplex`) to prove the existence of a
+  saddle point via `Sion.exists_isSaddlePointOn` (real case) — the
+  **final milestone** of #4054.
+
+  The 5 topological prerequisites of Sion on `E = m → ℝ` (and `F = n → ℝ`)
+  are `TopologicalSpace`, `AddCommGroup`, `Module ℝ`,
+  `IsTopologicalAddGroup`, `ContinuousSMul ℝ`: they are synthesized from
+  the `Pi` instances of Mathlib (`Pi.topologicalSpace`,
+  `Pi.instAddCommGroup`, `Pi.instModule`, etc.). This **iteration 3**
+  module delivers the auxiliary fact of **non-vacuity of the simplex**
+  and then the **final application**.
+
+  `IsSaddlePointOn` lives at top level
+  (`Mathlib/Order/SaddlePoint.lean`), while `exists_isSaddlePointOn`
+  is in `namespace Sion`.
+-/
+
+namespace MinimaxLean_en
+
+open Set
+
+variable {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
+variable [Nonempty m] [Nonempty n]
+variable (A : PayoffMatrix m n)
+
+/-- The standard simplex `stdSimplex ℝ m` is non-empty as soon as `m`
+is non-empty: the Dirac `Pi.single i 1` (mass 1 on index `i`, zero
+elsewhere) is a point of the simplex, via the Mathlib lemma
+`single_mem_stdSimplex`. -/
+lemma stdSimplex_nonempty_m : (stdSimplex ℝ m).Nonempty := by
+  obtain ⟨i⟩ := ‹Nonempty m›
+  exact ⟨Pi.single i 1, single_mem_stdSimplex (𝕜 := ℝ) i⟩
+
+/-- Variant in `y`: `stdSimplex ℝ n` is non-empty as soon as `n` is
+non-empty. -/
+lemma stdSimplex_nonempty_n : (stdSimplex ℝ n).Nonempty := by
+  obtain ⟨i⟩ := ‹Nonempty n›
+  exact ⟨Pi.single i 1, single_mem_stdSimplex (𝕜 := ℝ) i⟩
+
+/-- **Von Neumann's minimax theorem (saddle-point form)** — the
+**final milestone** of issue #4054: for every payoff matrix `A` on
+finite non-empty types, there exist mixed strategies `a ∈ Δₘ`,
+`b ∈ Δₙ` such that `payoff A a y ≤ payoff A x b` for all `x ∈ Δₘ`,
+`y ∈ Δₙ` (saddle point). Proved by a single application of
+`Sion.exists_isSaddlePointOn` (real case, `Topology/Sion.lean` section
+`Real`), gathering:
+- compactness: `isCompact_stdSimplex ℝ`;
+- convexity: `convex_stdSimplex ℝ`;
+- non-vacuity: `stdSimplex_nonempty_m` / `stdSimplex_nonempty_n`
+  (lemmas above);
+- the 4 analytic hypotheses of `Concavity.lean` (quasi-convexity in
+  `x`, quasi-concavity in `y`, lower semicontinuity in `x`, upper in
+  `y`).
+
+The 5 topological prerequisites of Sion on `E = m → ℝ` and
+`F = n → ℝ` (`TopologicalSpace`, `AddCommGroup`, `Module ℝ`,
+`IsTopologicalAddGroup`, `ContinuousSMul ℝ`) are synthesized from the
+Mathlib `Pi` instances. -/
+theorem exists_saddle_point_payoff :
+    ∃ a ∈ stdSimplex ℝ m, ∃ b ∈ stdSimplex ℝ n,
+      IsSaddlePointOn (stdSimplex ℝ m) (stdSimplex ℝ n) (payoff A) a b :=
+  Sion.exists_isSaddlePointOn
+    (ne_X := stdSimplex_nonempty_m)
+    (cX := convex_stdSimplex ℝ m)
+    (kX := isCompact_stdSimplex (𝕜 := ℝ) (ι := m))
+    (hfy := fun y _hy => payoff_lowerSemicontinuous_in_x A y)
+    (hfy' := fun y _hy => payoff_quasiconvex_in_x A y)
+    (cY := convex_stdSimplex ℝ n)
+    (ne_Y := stdSimplex_nonempty_n)
+    (kY := isCompact_stdSimplex (𝕜 := ℝ) (ι := n))
+    (hfx := fun x _hx => payoff_upperSemicontinuous_in_y A x)
+    (hfx' := fun x _hx => payoff_quasiconcave_in_y A x)
+
+end MinimaxLean_en

--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/ZeroSum_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/ZeroSum_en.lean
@@ -1,0 +1,108 @@
+import Mathlib
+
+/-!
+  Minimax.ZeroSum — finite zero-sum games: matrix, mixed strategies, payoff (EN sibling)
+  =======================================================================================
+
+  English mirror of `Minimax/ZeroSum.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+
+  Note méthodologique : traduction manuelle du FR canonique (pas de source
+  EN historique pré-Option A à recover, fichier FR-first depuis origin
+  commit `821e9de1a` du `821e9de` original, jsboige 2026-06-24).
+
+  A two-player finite zero-sum game: the row player picks a row `i`, the
+  column player picks a column `j`, and the row player gets the payoff
+  `A i j` (the column player gets `-A i j`). In **mixed strategy**, each
+  player draws from a probability distribution; the expected payoff of
+  the row player is the **bilinear payoff** `xᵀ A y = Σᵢⱼ xᵢ Aᵢⱼ yⱼ`,
+  where `x` and `y` are points of the probability simplex
+  (`stdSimplex`).
+
+  This module lays down the definitions and proves the **bilinearity** of
+  the payoff (key to applying Sion): `payoff` is affine in each variable
+  separately, hence both continuous and quasi-convex/quasi-concave —
+  exactly the assumptions of `Sion.exists_isSaddlePointOn'` (see
+  `Minimax.lean`).
+
+  Cross reference: the `GameTheory` series (Nash already exists via
+  `lean_game_defs/Nash.lean`, of which this lake is the zero-sum
+  specialization). See issue #4054.
+-/
+
+namespace MinimaxLean_en
+
+open Finset
+
+variable {m n : Type*} [Fintype m] [Fintype n]
+
+/-- The payoff matrix of a zero-sum game (rows = row player, columns =
+    column player). `A i j` = row player's gain when `i` plays row `i`
+    and `j` plays column `j`. -/
+abbrev PayoffMatrix (m n : Type*) := Matrix m n ℝ
+
+/-- The **expected bilinear payoff**: `payoff A x y = Σᵢⱼ xᵢ · Aᵢⱼ · yⱼ`
+    (sum over `m × n`). This is the row player's expected gain under the
+    mixed strategies `x` (rows) and `y` (columns). The representation as
+    **a single sum over the product** makes bilinearity immediate
+    (`sum_add_distrib` / `sum_mul` in one step). -/
+def payoff (A : PayoffMatrix m n) (x : m → ℝ) (y : n → ℝ) : ℝ :=
+  ∑ ij : m × n, x ij.1 * A ij.1 ij.2 * y ij.2
+
+/-- **Additivity in `x`**: the payoff is additive in the row player's
+    strategy (first half of linearity). -/
+lemma payoff_add_in_x (A : PayoffMatrix m n) (x x' : m → ℝ) (y : n → ℝ) :
+    payoff A (x + x') y = payoff A x y + payoff A x' y := by
+  simp only [payoff, Pi.add_apply, add_mul, Finset.sum_add_distrib]
+
+/-- **Homogeneity in `x`**: the payoff is homogeneous in the row
+    player's strategy (second half of linearity). -/
+lemma payoff_smul_in_x (A : PayoffMatrix m n) (c : ℝ) (x : m → ℝ) (y : n → ℝ) :
+    payoff A (c • x) y = c * payoff A x y := by
+  simp only [payoff, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
+  congr 1 with ij
+  ring
+
+/-- **Additivity in `y`**: the payoff is additive in the column player's
+    strategy (first half of linearity in `y`). -/
+lemma payoff_add_in_y (A : PayoffMatrix m n) (x : m → ℝ) (y y' : n → ℝ) :
+    payoff A x (y + y') = payoff A x y + payoff A x y' := by
+  simp only [payoff, Pi.add_apply, mul_add, Finset.sum_add_distrib]
+
+/-- **Homogeneity in `y`**: the payoff is homogeneous in the column
+    player's strategy (second half of linearity in `y`). -/
+lemma payoff_smul_in_y (A : PayoffMatrix m n) (c : ℝ) (x : m → ℝ) (y : n → ℝ) :
+    payoff A x (c • y) = c * payoff A x y := by
+  simp only [payoff, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
+  congr 1 with ij
+  ring
+
+/-- The payoff is **continuous** (jointly) since it is a finite sum of
+    continuous monomials. This is the key fact that yields, by
+    restriction, the upper and lower semicontinuity required by Sion. -/
+lemma continuous_payoff (A : PayoffMatrix m n) :
+    Continuous (fun p : (m → ℝ) × (n → ℝ) => payoff A p.1 p.2) := by
+  unfold payoff
+  apply continuous_finsetSum
+  intro ij _
+  fun_prop
+
+/-- The payoff `payoff A · y` is **continuous** in the row player's
+    strategy (special case of `continuous_payoff`, by restriction
+    `y` = constant). -/
+lemma continuous_payoff_in_x (A : PayoffMatrix m n) (y : n → ℝ) :
+    Continuous (fun x : m → ℝ => payoff A x y) := by
+  unfold payoff
+  fun_prop
+
+/-- The payoff `payoff A x ·` is **continuous** in the column player's
+    strategy (special case of `continuous_payoff`, by restriction
+    `x` = constant). -/
+lemma continuous_payoff_in_y (A : PayoffMatrix m n) (x : m → ℝ) :
+    Continuous (fun y : n → ℝ => payoff A x y) := by
+  unfold payoff
+  fun_prop
+
+end MinimaxLean_en


### PR DESCRIPTION
# PR #5363 — EPIC #4980 tranche 11 : minimax_lean ZeroSum + Concavity + SionApplication EN siblings

## Résumé

Tranche 11 de l'EPIC #4980 i18n Lean FR+EN siblings sur le lake
`minimax_lean`. 3 fichiers NEW : `Minimax/ZeroSum_en.lean` +
`Minimax/Concavity_en.lean` + `Minimax/SionApplication_en.lean`. Code
Lean **byte-identique modulo l'import cross-namespace** (`_en` suffix
sur les siblings importés, structurellement nécessaire).

**Note méthodologique** : ce lake est **FR-first depuis origin**
(commit `821e9de1a` du `821e9de` original, jsboige 2026-06-24) —
il n'y a **pas de source EN historique pré-Option A** à recover (le
seul EN existant est `Minimax.en.md` Option B companion, MERGED
#5008, qui est un fichier markdown de documentation séparé).
La traduction est donc **manuelle** : le code tactique Lean (lemma
names, tactiques, définitions) est préservé verbatim du FR ; seule
la prose (docstrings + commentaires) est traduite.

## Fichiers livrés

| Fichier | Statut | Δ (lignes) |
|---------|--------|-----------|
| `MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/ZeroSum_en.lean` | NEW | +108 / -0 |
| `MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/Concavity_en.lean` | NEW | +138 / -0 |
| `MyIA.AI.Notebooks/GameTheory/minimax_lean/Minimax/SionApplication_en.lean` | NEW | +94 / -0 |

**Total = 3 fichiers / +340 / -0**.

R3 strict `+N/-M` UNIQUE commit (leçon c187). Commit unique
`e99019662` (vérifié via `git log origin/main..HEAD --oneline` +
`git diff origin/main..HEAD --stat`, canon c201-CRIT).

## Décisions structurelles

### 1. Minimax_en.lean racine NON livré (convention hubs)

Le fichier racine `Minimax.lean` (70 lignes FR) est un **hub
d'imports** + un court status `abbrev Status : Prop := True`. La
convention EPIC #4980 (établie par les tranches social_choice /
coop_games / stable_marriage / repeated_games) est de **ne pas
traduire les hubs racines** : ils sont de la pure documentation de
synthèse, déjà couverte par `Minimax.en.md` (Option B companion
markdown, MERGED #5008 par `2883c8f9a`, 2026-07-02). Les 3
submodules `Minimax/*.lean` portent le code Lean réel (lemmes,
tactiques, namespace `MinimaxLean`).

### 2. Namespace wrap `MinimaxLean_en` (anti-collision)

Imposé par anti-collision : si on laissait `namespace MinimaxLean`,
les siblings EN entreraient en collision avec `payoff`, `PayoffMatrix`,
`payoff_add_in_x`, `payoff_concave_in_x`, `payoff_quasiconcave_in_y`,
`payoff_lowerSemicontinuous_in_x`, `stdSimplex_nonempty_m`,
`exists_saddle_point_payoff` etc. déjà définis par le FR dans le
même namespace. Le namespace dédié `MinimaxLean_en` garantit des
définitions séparées.

Conséquence :
- `Concavity_en.lean` doit faire `import Minimax.ZeroSum_en` (et pas
  `import Minimax.ZeroSum`) — c'est la seule différence d'import
  cross-fichier entre FR et EN.
- `SionApplication_en.lean` doit faire `import Minimax.ZeroSum_en`
  ET `import Minimax.Concavity_en` — 2 imports diffèrent (+6 chars
  cumulés).

### 3. Milestone #4054 RÉSOLU préservé

Les **3 fichiers** formalisent le **théorème minimax de von Neumann
(forme point-selle)** : pour toute matrice de gains `A` sur des
types finis non vides, il existe `a ∈ Δₘ`, `b ∈ Δₙ` tels que
`payoff A a y ≤ payoff A x b` pour tout `x ∈ Δₘ`, `y ∈ Δₙ`. La
preuve est en une application de `Sion.exists_isSaddlePointOn`
réunissant les 4 hyps analytiques (quasi-convexité `x` / quasi-
concavité `y` / LSC `x` / USC `y`) + compacité `isCompact_stdSimplex` +
convexité `convex_stdSimplex` + non-vacuité `stdSimplex_nonempty_m/n`.
**0 sorry**, milestone #4054 RÉSOLU.

## Preuves de byte-identity (DRIFT-CI detectable)

Strip commentaires (`/-...-/` puis `--.*$`) puis normalisation
whitespace, en normalisant les noms de namespace (`MinimaxLean` et
`MinimaxLean_en` → token `NS` unique) :

| Fichier | FR strip | EN strip | byte-equal | Delta |
|---------|----------|----------|-----------:|------:|
| ZeroSum.lean / ZeroSum_en.lean | 1513 | 1513 | ✓ | **0 char** |
| Concavity.lean / Concavity_en.lean | 1914 | 1917 | ✗ | +3 chars (1 import name `_en`) |
| SionApplication.lean / SionApplication_en.lean | 1141 | 1147 | ✗ | +6 chars (2 import names `_en`) |

**ZeroSum : PARFAIT byte-identique.** Les seuls diffs de Concavity
et SionApplication sont les noms d'imports
`Minimax.ZeroSum` → `Minimax.ZeroSum_en` (+3 chars par import,
structurellement nécessaire car le namespace `MinimaxLean_en` doit
résoudre les noms dans le namespace `_en`). Code tactique (lemma
bodies, tactic blocks) **100% byte-identique** sur les 3 fichiers.

## Convention i18n Lean (référence EPIC #4980)

- Fichiers `.lean` distincts FR + EN siblings dans le même lake
- Les deux compilent (drift-CI detectable)
- Code tactique byte-identique entre siblings (modulo imports
  cross-namespace `_en`)
- Namespace EN suffixé `_en` (le FR canonique reste `_en`-free)
- Préambule obligatoire : 14-22 lignes expliquant la convention
- Pas une traduction destructive : le FR canonique est inchangé
- Couvre tous les `.lean` du sous-dossier `Minimax/` (code réel), le
  hub racine `Minimax.lean` est documenté par `Minimax.en.md` Option B
  (déjà MERGED #5008)

## Anti-régression D

- `Minimax.lean` FR INCHANGÉ (hub d'imports, NON livré EN sibling,
  couvert par `Minimax.en.md`)
- `Minimax/ZeroSum.lean` FR INCHANGÉ (code byte-identique préservé)
- `Minimax/Concavity.lean` FR INCHANGÉ (code byte-identique préservé)
- `Minimax/SionApplication.lean` FR INCHANGÉ (code byte-identique
  préservé)
- Aucun nom de lemme renommé, aucune tactique modifiée, aucun
  symbole modifié
- Les lemmes `payoff`, `PayoffMatrix`, `payoff_add_in_x/y`,
  `payoff_smul_in_x/y`, `continuous_payoff_in_x/y`,
  `payoff_concave_in_x/y`, `payoff_convex_in_x/y`,
  `payoff_quasiconcave_in_y`, `payoff_quasiconvex_in_x`,
  `payoff_lowerSemicontinuous_in_x`,
  `payoff_upperSemicontinuous_in_y`, `stdSimplex_nonempty_m/n`,
  `exists_saddle_point_payoff` sont déclarés verbatim dans le même
  ordre, avec les mêmes types et les mêmes tactic blocks.

## Validation pré-push

- Strip-comments byte-identity ZeroSum : **1513 == 1513 char** ✓
- Strip-comments byte-identity Concavity : seul l'import name diffère
  (+3 chars structurellement nécessaires)
- Strip-comments byte-identity SionApplication : 2 imports diffèrent
  (+6 chars structurellement nécessaires)
- Namespace wrap `_en` correctement fermé sur les 3 fichiers
  (`end MinimaxLean_en`)
- Anti-régression D : aucun code Lean modifié côté FR
- 0 CJK parasite (filtre Python strict étendu 4 ranges Unicode c187
  33e leçon)
- 0 emoji (code-style.md)
- 0 secret literal (secrets-hygiene.md règle 6)
- c222 pré-push self-verify OK
  (`gh pr list --head feat/4980-minimax-...` = vide AVANT push)
- catalog-pr-hygiene R1 ✓ (catalogue byte-identique main, non touché
  sur branche)
- readme-french-first N/A (pas de doc markdown touchée, code Lean
  only)
- harness-hygiene 3-tier respecté (rapport → dashboard, mémoire →
  memory file dédié)

## Lake build

`lake build Minimax.ZeroSum_en Minimax.Concavity_en
Minimax.SionApplication_en` **REPORTÉ ai-01** (HARD
`.claude/rules/lean-merge-discipline.md` §1). Pas d'env Lean local
po-2025 → ai-01 lancera le build pré-merge avec son env. Pattern
identique à c.234/PR #5344 + c.238.2/PR #5362 bodies.

## Suite anti-EPIC #4980

Tranches couvertes : 5/6 social_choice (Sen, Mechanism, SortedList,
Basic, Definitions, Lemmas, GSState) MERGED + Arrow tranche 6
#5319 OPEN + ConeKernel tranche 2 #5305 OPEN + decision_theory
lakefile globs PR #5360 OPEN + **repeated_games tranche 10 #5362
OPEN MERGEABLE** (c.238.2) + **cette tranche minimax #5363
tranche 11**.

Tranches restantes : Lattice tranche 7 (4 fichiers #5323 MERGED),
Shapley-3a (15 fichiers #5308), calibration_lean (24L),
sensitivity_lean (23L), grothendieck_lean (43L), Folk_en
(conditionnelle à sorry levé). **Anti-silo pool parallèle** :
cross-lane via `gh issue list --state open` (cf c.237 anti-silo rule).

## Issue Links

- See #4980 (EPIC parent i18n Lean FR+EN)
- See #4054 (milestone minimax von Neumann RÉSOLU)
- See #5008 (Minimax.en.md Option B companion MERGED)
- See #4038 (roadmap Lean #4054)