### PR TITLE
enrich(genai): Mermaid render of Session concept (Claude-CLI-Sessions) — See #4212

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/02-Claude-CLI-Sessions.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/02-Claude-CLI-Sessions.ipynb
@@ -149,6 +149,26 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Rendu du schema (Mermaid)** : la meme structure que le diagramme ASCII ci-dessus, restituee nativement par GitHub / JupyterLab. Chaque message successif alimente le contexte cumule renvoye a Claude :\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    subgraph Session[\"Session - ~/.claude/sessions/\"]\n",
+    "        direction LR\n",
+    "        M1[\"Msg 1\"] --> M2[\"Msg 2\"] --> M3[\"Msg 3\"] --> M4[\"Msg 4\"]\n",
+    "    end\n",
+    "    M1 --> Mem[\"Claude se souvient de tout le contexte\"]\n",
+    "    M2 --> Mem\n",
+    "    M3 --> Mem\n",
+    "    M4 --> Mem\n",
+    "```\n"
+   ],
+   "id": "mermaid-session-concept"
+  },
+  {
+   "cell_type": "markdown",
    "id": "4ad0b082",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## What

Add a **Mermaid render** of the Session concept in `02-Claude-CLI-Sessions.ipynb` (cell 3 → new cell 4). The Session architecture (Msg1 → Msg2 → Msg3 → Msg4, each feeding Claude's cumulative context) was drawn only as ASCII box art, which renders as fragile monospace on GitHub and breaks on narrow viewports. Mermaid renders natively on GitHub/JupyterLab.

See #4212 (GenAI Mermaid rolling filen, Part of #4208). Part of axe-2 editorial finition.

## Why (real value, not a workaround)

This is the documented #4212 gap: ASCII architecture diagrams that were **never drawn as a real figure**. Cell 3 had a genuine multi-box session diagram with zero matplotlib/Mermaid render. The Mermaid cell is the native render of that exact architecture — not a decorative duplicate.

**Straggler scan firsthand** (G.1): of 116 GenAI notebooks with box-corner ASCII art, only **5 have zero Mermaid render**. This PR covers 1 of those 5 (`02-Claude-CLI-Sessions`). The remaining 4 are separate atomic PRs (R3 one-notebook-per-PR, the established filen convention).

## Anti-regression (ASCII preserved)

The original ASCII diagram in cell 3 is **kept intact**. The new Mermaid cell is a *rendered companion* inserted after it (cell 4). This matches the convention already used in **19 other GenAI notebooks** that keep box-art alongside its Mermaid render (e.g. `02-5-Multi-Model-TTS-Gateway`, `01-4-Forge-SD-XL-Turbo`, `01-5-Qwen-Image-Edit`). Zero notebooks in the repo *replace* ASCII with Mermaid — so this PR follows the conservative preserve+add pattern.

## Validation (rules C.2 / H.1)

- **Markdown-only change → C.2-exempt**: no code cell touched, no kernel re-exec needed; existing `execution_count`/`outputs` of all code cells unchanged.
- **nbformat VALID**, 34 cells (+1 markdown), no `MissingIDFieldWarning` (cell id `mermaid-session-concept` added).
- **Diff atomic**: `+20/-0`, single notebook file. Catalogue byte-identical to `origin/main` (catalog-pr-hygiene respected — never regenerated on feature branch).
- **FR-first** (readme-french-first): new markdown prose in French.
- **No emojis** in the Mermaid diagram (code-style rule).

## Scope

1 file, 1 new markdown cell. Atomic. No production code touched.

See #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
