### PR TITLE
fix(docs): GameTheory/README.md audit §E whole-file gate — tree omissions reconciled — See #3975

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -525,9 +525,12 @@ GameTheory/
 ├── GameTheory-1-Setup.ipynb ... GameTheory-17-MultiAgent-RL.ipynb  # 17 principaux
 ├── GameTheory-2b-Lean-Definitions.ipynb                            # Side tracks b (Lean)
 ├── GameTheory-4b-Lean-NashExistence.ipynb
+├── GameTheory-5b-Lean-Minimax.ipynb
 ├── GameTheory-8b-Lean-CombinatorialGames.ipynb
+├── GameTheory-11b-Lean-BayesianGamesExt.ipynb
 ├── GameTheory-15b-Lean-CooperativeGames.ipynb
 ├── GameTheory-4c-NashExistence-Python.ipynb                        # Side tracks c (Python)
+├── GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
 ├── GameTheory-8c-CombinatorialGames-Python.ipynb
 ├── GameTheory-15c-CooperativeGames-Python.ipynb
 ├── SocialChoice/                                                   # Sous-série Choix Social
@@ -552,7 +555,9 @@ GameTheory/
 ├── social_choice_lean/            # Projet Lake choix social (Arrow, Sen, Voting/Median Voter — 0 sorry)
 ├── social_choice_lean_peters/     # Projet Lake référence DominikPeters (0 sorry, toolchain v4.27.0-rc1)
 ├── stable_marriage_lean/          # Projet Lake Gale-Shapley (GS COMPLETE, 0 sorry — énoncés faux réfutés, exists_isManOptimal prouvé)
+├── minimax_lean/                  # Projet Lake minimax (companion natif GT-5b, von Neumann/Sion 0 sorry)
 ├── lean_game_defs/                # Types Lean partages (pas de Lake project)
+├── lean_game_defs_ext/            # Types Lean partages — extension (companion GT-11b Bayesian, Vickrey 0 sorry)
 ├── examples/
 │   ├── prisoners_dilemma.py
 │   ├── topology_2x2_periodic_table.py


### PR DESCRIPTION
## What

Audit **§E whole-file gate** on `MyIA.AI.Notebooks/GameTheory/README.md` (mandate user 2026-07-04, gate set by merged PR #5353). The "Structure des fichiers" reference tree (lines 521-568) omitted **5 entries that exist on disk AND are cited in the README's own structure/maturity tables** — a self-inconsistency where the prose describes a notebook/lake the tree does not list.

See #3975. Part of #4208 (editorial finition).

## Inconsistencies reconciled (all G.1 firsthand-verified)

| Omission | Proof it exists | Where README already cites it |
|----------|-----------------|-------------------------------|
| `GameTheory-5b-Lean-Minimax.ipynb` | `ls` on disk | Structure table line 125, maturity table line 201 |
| `GameTheory-11b-Lean-BayesianGamesExt.ipynb` | `ls` on disk | Structure table line 140, maturity table line 211 |
| `GameTheory-6c-RepeatedGames-FolkTheorem.ipynb` | `ls` on disk | Structure table line 127, maturity table line 203 |
| `minimax_lean/` (lake) | `ls` dir on disk | Prose line 125 ("companion natif GT-5b ... lake `minimax_lean`") |
| `lean_game_defs_ext/` (lake) | `ls` dir on disk | Prose line 140 ("lake `lean_game_defs_ext`") |

The tree now lists all 10 side-tracks (b+c) and all 7 lakes the prose references — making the reference diagram **internally consistent** with the rest of the README.

## Out of scope (automation-owned — NOT hand-fixed)

- **CATALOG-STATUS marker stale**: `root=24/total=28`, but disk has 27 root notebooks (catalog misses GT-8/8b/8c CombinatorialGames, added since marker). Per `catalog-pr-hygiene` HARD rule 1, the marker is **never regenerated on a feature branch** — the daily `catalog-cron.yml` self-heals it on `main`. Documented here, not fixed.

## Validation

- `check_docs_links.py --check` → **OK: No new broken links (0 pre-existing, 3346 total)**.
- Catalogue (`COURSE_CATALOG.generated.json` / `.md`) **byte-identical** to `origin/main` (catalog-pr-hygiene R1 respected).
- MD060 table-column-style warnings in this file are pre-existing informational (substance-correct), not introduced by this PR.
- Diff `+5/-0`, 1 file, R3 OK (<3000 lines, <15 files, single domain docs).

## Scope

Single file, 5 reference-tree additions reconciling the tree with the README's own prose. Atomic. No production code, no notebooks touched.

See #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)
