### PR TITLE
fix(docs): Sudoku/README.md audit §E whole-file gate — réconciliation disque↔catalogue 33 nb

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -341,7 +341,7 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 16 | Neural Network | CNN PyTorch : apprentissage de patterns visuels sur grilles |
 | 17 | LLM | LLM Solver : prompt engineering pour résolution logique, limites |
 | 18 | Comparison | Benchmark comparatif : toutes les approches sur Easy/Medium/Hard/Expert |
-| 19 | [Sudoku-19-Lean-Propagation](Sudoku-19-Lean-Propagation.ipynb) | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la soundness de la propagation (naked/hidden single, clé de voûte `peer_excludes_value`) dans le lake `sudoku_lean`, `#check` + `#print axioms` in-kernel (jonction Mathlib #2611) |
+| 19 | [Sudoku-19-Lean-Propagation](Sudoku-19-Lean-Propagation.ipynb) | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la soundness de la propagation (naked/hidden single, clé de voûte `peer_excludes_value`) dans le lake `sudoku_lean`, `#check` + `#print axioms` in-kernel — voir [#4055](https://github.com/jsboige/CoursIA/issues/4055) (création du lake) et `LEAN_INVENTORY.md` du dossier |
 
 ---
 
@@ -366,7 +366,7 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 14 | BDD | Oui | - | (C# uniquement) |
 | 15 | Infer (Probabiliste) | Oui | Oui | **NumPyro** + JAX |
 | 16 | Neural Network | - | Oui | **PyTorch** CNN |
-| 17 | LLM | - | Oui | **Semantic Kernel** |
+| 17 | LLM | - | Oui | **openai** SDK (compatible ChatCompletion API) |
 | 18 | Comparison | - | Oui | Benchmark comparatif |
 
 **Légende** : Oui = disponible, - = non applicable
@@ -462,13 +462,13 @@ Sudoku-0-Csharp (Environment - comprendre les structures)
 dotnet --version
 
 # Les packages NuGet sont installés dans les notebooks :
-# - GeneticSharp
-# - Google.OrTools
-# - Microsoft.Z3
-# - DlxLib
-# - Microsoft.ML.Probabilistic
-# - Microsoft.SemanticKernel (pour LLM)
-# - Plotly.NET
+# - GeneticSharp          (Sudoku-3 Genetic)
+# - Google.OrTools        (Sudoku-10 OR-Tools CP-SAT)
+# - Microsoft.Z3          (Sudoku-12 Z3 SMT, Sudoku-13 Symbolic Automata)
+# - DlxLib                (Sudoku-2 Dancing Links)
+# - Microsoft.ML.Probabilistic  (Sudoku-15 Infer.NET)
+# - IKVM 8.15.0           (Sudoku-11 Choco — runtime Java-sur-.NET + DLL précompilée)
+# - Plotly.NET            (visualisations, notebooks 0-15)
 ```
 
 **Note sur les outputs** : Les notebooks C# contiennent des outputs de cellule exécutées. Les notebooks avec dépendances `#!import` doivent être exécutés dans l'ordre (0 -> 1 -> 2...).
@@ -480,7 +480,7 @@ dotnet --version
 python -m venv venv
 
 # Installer les dépendances
-pip install numpy matplotlib ortools z3-solver pygad torch networkx mealpy simanneal jpype1 semantic-kernel
+pip install numpy pandas scipy matplotlib ortools z3-solver pygad simanneal mealpy networkx torch jax numpyro jpype1 openai
 ```
 
 ## Performances Attendues
@@ -560,7 +560,7 @@ Les notebooks sont adaptés de projets étudiants :
 | **Neural Network** | 4 architectures de réseaux de neurones | `Sudoku.NeuralNetwork` |
 | **PSO** | Optimisation par essaim de particules | `Sudoku.PSO` (7 fichiers) |
 | **AIMA CSP** | CSP inspiré de AIMA | `Sudoku.CspAima` |
-| **Graph Coloring** | Coloration de graphe | `Sodoku.GraphColoring` (11 fichiers) |
+| **Graph Coloring** | Coloration de graphe | `Sudoku.GraphColoring` (11 fichiers) |
 | **Choco** | 5 implémentations Choco | `Sudoku.ChocoSolvers` |
 | **LLM** | Résolution par LLM | `Sudoku.LLM-ChatGPTenzin` |
 
@@ -569,6 +569,11 @@ Les notebooks sont adaptés de projets étudiants :
 ```
 Sudoku/
 ├── README.md                              # Ce fichier
+├── LEAN_INVENTORY.md                      # Inventaire transverse des lakes Lean de la série
+├── index.qmd                              # Listing Quarto (sous-ensembles C# / Python)
+├── requirements.txt                       # Dépendances Python (16 notebooks Python)
+├── choco-solver-4.10.17-jar-with-dependencies.jar  # JAR Choco (utilisé par nb-11 Python via JPype)
+├── org.chocosolver.solver.dll             # DLL Choco précompilée (utilisée par nb-11 C# via IKVM)
 ├── Sudoku-0-Environment-Csharp.ipynb      # Classes de base C#
 ├── Sudoku-1-Backtracking-Csharp.ipynb     # Backtracking C#
 ├── Sudoku-1-Backtracking-Python.ipynb     # Backtracking Python
@@ -601,10 +606,38 @@ Sudoku/
 ├── Sudoku-16-NeuralNetwork-Python.ipynb   # Réseau de neurones Python
 ├── Sudoku-17-LLM-Python.ipynb             # LLM Solver Python
 ├── Sudoku-18-Comparison-Python.ipynb      # Benchmark comparatif Python
-└── Puzzles/                               # Fichiers de puzzles
-    ├── Sudoku_Easy51.txt
-    ├── Sudoku_hardest.txt
-    └── Sudoku_top95.txt
+├── Sudoku-19-Lean-Propagation.ipynb       # Companion Lean natif (preuve de soundness)
+├── Puzzles/                               # Fichiers de puzzles
+│   ├── Sudoku_Easy51.txt
+│   ├── Sudoku_hardest.txt
+│   └── Sudoku_top95.txt
+├── assets/                                # Ressources statiques (regex de validation sudoku)
+│   └── sudoku-unrolled.regex.txt
+├── models/                                # Modèles entraînés (RRN .pt)
+│   └── sudoku_rrn_v4_best.pt
+├── sudoku_models/                         # Checkpoints d'entraînement comparatif
+│   └── checkpoints/
+├── sudoku_lean/                           # Lake Lean 4 (preuve de propagation, 3 modules, 0 sorry)
+│   ├── Sudoku.lean                        # Umbrella
+│   ├── Sudoku/Basic.lean
+│   ├── Sudoku/Propagation.lean
+│   ├── Sudoku/ExactCover.lean
+│   ├── Sudoku.en.md
+│   ├── lakefile.lean
+│   ├── lake-manifest.json
+│   └── lean-toolchain
+├── scripts/                               # Scripts Python (entraînement thermal-safe)
+│   ├── thermal_safe_train.py
+│   └── checkpoints/
+├── CompiledModels/                        # Artefacts C# compilés (Infer.NET)
+│   ├── RobustSudokuModel.cs
+│   └── RobustSudokuModel.dll
+└── GeneratedSource/                       # Code source généré par Infer.NET
+    ├── Model0_EP.cs
+    ├── Model1_EP.cs
+    ├── Model2_EP.cs
+    ├── Model3_EP.cs
+    └── Model_EP.cs
 ```
 
 ## Ressources
@@ -621,7 +654,7 @@ Sudoku/
 - [GeneticSharp](https://github.com/giacomelli/GeneticSharp)
 - [Choco Solver](https://choco-solver.org/)
 - [Infer.NET Documentation](https://dotnet.github.io/infer/)
-- [Microsoft Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/)
+- [OpenAI Python SDK](https://github.com/openai/openai-python) (utilisé par Sudoku-17 LLM Solver)
 - [PyTorch](https://pytorch.org/)
 
 ## FAQ / Troubleshooting
@@ -731,4 +764,4 @@ Voir la licence du repository principal.
 
 ---
 
-*Version 1.1.0 — Juin 2026*
+*Version 1.2.0 — Juillet 2026*


### PR DESCRIPTION
## Résumé

Audit §E whole-file gate sur `MyIA.AI.Notebooks/Sudoku/README.md` (734 lignes, gate merged in PR #5353), réconcilie la prose descriptive du README avec l'état réel du disque et du marqueur `<!-- CATALOG-STATUS -->` (byte-identique à `main`).

**10 incohérences corrigées** entre prose / disque / marqueur catalogue. PR atomique (1 fichier, +50/-17, R3 OK : <3000 lignes, 1 fichier).

## Vérification — audit §E whole-file

**(a) `ls` / `find` count par sous-dossier cité (relevé firsthand 2026-07-04) :**

```
Sudoku/
├── 33 notebooks principaux (16 C# + 16 Python + 1 Lean) + 8 _output.ipynb
│   ├── 13 paires miroir (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15)
│   ├── 3 C#-only (0-Environment, 13-SymbolicAutomata, 14-BDD)
│   ├── 3 Python-only (16-NeuralNetwork, 17-LLM, 18-Comparison)
│   └── 1 Lean companion (19-Lean-Propagation)
├── 8 _output.ipynb (suffixe, pas dossier)
├── LEAN_INVENTORY.md                       # Inventaire Lean
├── index.qmd                               # Listing Quarto
├── requirements.txt                        # 16 deps Python
├── choco-solver-4.10.17-jar-with-dependencies.jar
├── org.chocosolver.solver.dll              # 11.9 MB
├── Puzzles/        : 3 fichiers (Easy51, hardest, top95)
├── assets/         : 1 regex (sudoku-unrolled)
├── models/         : 1 modèle RRN (.pt)
├── sudoku_models/  : checkpoints/ (8 .pt)
├── sudoku_lean/    : 3 modules Lean (Basic.lean, Propagation.lean, ExactCover.lean) + umbrella + lakefile
├── scripts/        : thermal_safe_train.py + checkpoints/
├── CompiledModels/ : 2 fichiers (RobustSudokuModel.cs + .dll)
└── GeneratedSource/: 5 fichiers (Model*_EP.cs)
```

**(b) Réconciliation disque ↔ `CATALOG-STATUS` ↔ prose :**

| Source | Avant | Après |
|--------|-------|-------|
| Marqueur `CATALOG-STATUS` (l. 3-8) | `pedagogical_count: 33, breakdown: root=33, maturity: PRODUCTION=28, BETA=4, ALPHA=1` | inchangé (BYTE-IDENTIQUE à `main`) |
| Prose intro L12 | 13 paires + 3 C# + 3 Python + 1 Lean = 20 ≠ 33 | inchangé (33 = somme correcte 13×2+3+3+1) |
| Tree Structure L569-608 | 33 notebooks + 3 puzzles | 33 notebooks + 9 entrées omises ajoutées (Sudoku-19 + deps + sous-dossiers) |

**(c) Tableaux "Structure des Notebooks", "Algorithmes Couverts", "Performances Attendues", "Sources Projets Étudiants"** vérifiés à jour contre le disque.

## 10 incohérences corrigées (détail)

| # | Section | Type | Incohérence |
|---|---------|------|-------------|
| 1 | Tableau L344 Companion row | claim | "jonction Mathlib #2611" → #2611 = `infra(Lean): mutualiser les 12 checkouts Mathlib (~61 GB)` (CLOSED, infra), **PAS** la création du lake. Remplacé par [#4055](https://github.com/jsboige/CoursIA/issues/4055) (création du lake sudoku_lean) + lien vers `LEAN_INVENTORY.md` du dossier (67 lignes, source de vérité) |
| 2 | Tableau L370 structure row 17 LLM | package | "Semantic Kernel" listé pour Sudoku-17 mais le notebook utilise `openai` (10 occurrences), **0 occurrence** de `semantic_kernel`. Reformulation : "**openai** SDK (compatible ChatCompletion API)" |
| 3 | Prérequis C# L466-471 | package | "Microsoft.SemanticKernel (pour LLM)" listé dans les 7 NuGet — **0 usage** dans les 16 notebooks C# du dossier (grep vérifié). Remplacé par `IKVM 8.15.0` (utilisé par Sudoku-11 Choco via `#r "org.chocosolver.solver.dll"`). Packages réorganisés avec annotation des notebooks utilisateurs (GeneticSharp→nb-3, IKVM→nb-11, etc.) |
| 4 | Prérequis Python L483 | package | `pip install numpy matplotlib ortools z3-solver pygad torch networkx mealpy simanneal jpype1 semantic-kernel` (11 packages) — `semantic-kernel` n'existe pas dans requirements.txt (0 usage), et **manquent** pandas, scipy, jax, numpyro, openai (présents dans requirements.txt, vérifié par grep). Remplacement par la liste 15 packages alignée sur `requirements.txt` |
| 5 | Sources Projets Étudiants L563 | typo | `Sodoku.GraphColoring` (11 fichiers) → `Sudoku.GraphColoring` (typo `Sodoku` corrigée) |
| 6 | Tree Structure L569-608 | omission | Tree omet **9 entrées présentes sur disque** : `Sudoku-19-Lean-Propagation.ipynb` (le companion Lean annoncé en intro L12 !), `LEAN_INVENTORY.md`, `index.qmd`, `requirements.txt`, `choco-solver-4.10.17-jar-with-dependencies.jar`, `org.chocosolver.solver.dll`, et les 7 sous-dossiers `assets/`, `models/`, `sudoku_models/`, `sudoku_lean/`, `scripts/`, `CompiledModels/`, `GeneratedSource/`. Tree completé |
| 7 | Bibliothèques L624 | héritage | "Microsoft Semantic Kernel" listé → corrigé en "OpenAI Python SDK" (cf #2). Référencé sur la même autorité (Sudoku-17 LLM Solver) |
| 8 | Footer L734 | version | "Version 1.1.0 — Juin 2026" → "Version 1.2.0 — Juillet 2026" (audit §E = incrément version mineure par convention) |
| 9 | CompiledModels/GeneratedSource C# | sous-ensemble | Non documentés en prose mais tree mentionne maintenant leur rôle (artefacts Infer.NET) — sous-ensemble du fix #6 |
| 10 | sudoku_lean/ lake | sous-ensemble | Non documenté en prose ; tree décrit maintenant les 3 modules (Basic.lean, Propagation.lean, ExactCover.lean) + 0 sorry confirmé par LEAN_INVENTORY.md — sous-ensemble du fix #6 |

## Garde-fous respectés

- ✅ **catalog-pr-hygiene R1** : marqueur `<!-- CATALOG-STATUS -->` BYTE-IDENTIQUE à `main` (cf `git diff origin/main -- README.md | grep "<!-- CATALOG"` = vide)
- ✅ **readme-french-first** : PRIMARY = FR (README.md), aucun changement d'i18n (hors scope §E)
- ✅ **R3 compliance** : 1 fichier / +50/-17 = << 3000 lignes / < 15 fichiers
- ✅ **G.9 anti-filler** : `See #3975` (Epic non close par cette PR — c'est un audit feuille §E)
- ✅ **G.1 verify-before-claiming** : tous les nombres vérifiés firsthand (`ls *.ipynb | grep -v _output | wc -l` = 33 ; `ls *Csharp.ipynb` = 16 ; `ls *Python.ipynb` = 16 ; `grep -c semantic_kernel` = 0 dans 16 nb C# + nb-17 Python ; `grep -c openai` = 10 dans nb-17 ; `ls sudoku_lean/Sudoku/` = 3 modules)
- ✅ **C.1/C.2 notebook** : aucun notebook touché (audit §E est doc-only, le scope notebooks reste SOTA-OK par C207)

## Hors-scope (suivi séparé)

- **i18n `README.en.md`** : Phase 0.5 #1650 — child issue à ouvrir si user décide de backfill maintenant.
- **MD060 table-column-style warnings + MD036** : informational, body markdown linter (présents avant et après PR — substance correcte, format alerte mineure).
- **§E feuille redo GameTheory / SemanticWeb / SymbolicLearning / SmartContracts / Search / Planners** : 6 feuilles restantes du rollout #3975 à dispatcher.

## Test plan

```bash
# 1. Vérifier qu'aucun notebook ni script n'est touché
git diff origin/main --stat

# 2. Vérifier le marqueur byte-identique
git diff origin/main -- MyIA.AI.Notebooks/Sudoku/README.md | \
  grep -E "^[+-].*<!-- CATALOG" || echo "OK marker intact"

# 3. Vérifier la cohérence 33 / 33 / 13+3+3+1
cd MyIA.AI.Notebooks/Sudoku
echo "Total : $(ls *.ipynb | grep -v _output | wc -l)"
echo "C# : $(ls *Csharp.ipynb | grep -v _output | wc -l)"
echo "Python : $(ls *Python.ipynb | grep -v _output | wc -l)"
echo "Lean : $(ls *Lean* | wc -l)"

# 4. Vérifier qu'aucun semantic-kernel ne reste en prose
grep -n "semantic-kernel\|Semantic Kernel" MyIA.AI.Notebooks/Sudoku/README.md || echo "OK no stale reference"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)