### PR TITLE
fix(docs): SemanticWeb/README.md audit §E — rdflib range inconsistency — See #3975

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -439,7 +439,7 @@ cp .env.example .env
 | Technologie | Version | Notebooks | Rôle |
 |-------------|---------|-----------|------|
 | dotNetRDF | 3.4.1 | SW-1 à SW-7 | Core RDF/SPARQL en .NET |
-| rdflib | 7.5.0 | Sidetracks, SW-8 à SW-12 | Core RDF/SPARQL en Python |
+| rdflib | 7.5.0 | Sidetracks, SW-8 à SW-13 | Core RDF/SPARQL en Python |
 | pySHACL | 0.27.0 | SW-8 | Validation SHACL |
 | OWLReady2 | 0.50+ | SW-7b, SW-11 | Manipulation ontologies |
 | SPARQLWrapper | 2.0+ | SW-5b | Requêtes endpoints distants |


### PR DESCRIPTION
## What

Audit **§E whole-file gate** on `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md` (mandate user 2026-07-04, gate set by merged PR #5353). The Technologies table (line 442) cited `rdflib` for notebooks **"SW-8 à SW-12"**, but **SW-13-Python-Reasoners also uses rdflib** — and every other mention of the Python range in this same README correctly says "SW-8 à SW-13" (lines 23, 33, 71, 404). Line 442 was the **sole outlier** — an internal inconsistency the whole-file gate is meant to catch.

See #3975. Part of #4208 (editorial finition).

## G.1 firsthand verification

- **SW-13-Python-Reasoners.ipynb** uses rdflib: **28 occurrences**, `import rdflib` present, `Graph(` 18×, `Namespace(` 8×. Verified by reading the notebook source directly.
- **4 other consistent mentions** in this README all say "SW-8 à SW-13": line 23 (Stats table), line 33 (MCP Jupyter), line 71 (stacks), line 404 (prerequisites).
- Line 442 said "SW-8 à SW-12" → **inconsistent outlier**. Fixed to "SW-8 à SW-13".

## Out of scope (automation-owned — NOT hand-fixed)

- **CATALOG-STATUS marker stale**: `pedagogical_count: 18`, but disk **and** catalog JSON both have **17 notebooks** (SW-1..13 + 2b/4b/5b/7b). The marker is never regenerated on a feature branch (catalog-pr-hygiene HARD rule 1) — the daily `catalog-cron.yml` self-heals it on `main`. Documented here, not fixed.

## Structure-tree check (clean)

The "Structure des fichiers" tree (lines 461-504) lists all **17 notebooks** matching disk, all 12 cited `data/` files exist (Example.ttl, animals.ttl, university.owl, person-shape.ttl, person-data.ttl, movies.csv, temp_company.ttl/owl, pizza_test.owl, product.jsonld, example.srj/srx), and `RDF.Net-Legacy/` contents match (RDF.Net.ipynb + Example.ttl + example.srj/srx). No tree inconsistencies.

## Validation

- `check_docs_links.py --check` → **OK: No new broken links (0 pre-existing, 3346 total)**.
- Catalogue **byte-identical** to `origin/main` (catalog-pr-hygiene R1 respected).
- MD060 table-column-style warnings pre-existing/informational, not introduced.
- Diff `+1/-1`, 1 file, R3 OK.

See #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)
