### PR TITLE
docs(qc): QuantConnect/README.md feuille §E audit — add 23b PatchTST + reconcile counts (See #3975)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -135,14 +135,15 @@ Appliquer ML classique au trading : classification directionnelle, régression p
 
 ---
 
-### Phase 7 : Deep Learning (3 notebooks, ~4.5h)
+### Phase 7 : Deep Learning (4 notebooks, ~6h)
 
-Deep Learning pour séries temporelles : LSTM, Transformers, Autoencoders.
+Deep Learning pour séries temporelles : LSTM, Transformers, PatchTST/iTransformer, Autoencoders.
 
 | # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 22 | [QC-Py-22-Deep-Learning-LSTM](Python/QC-Py-22-Deep-Learning-LSTM.ipynb) | 90 min | LSTM time series, TensorFlow/Keras, CPU-first |
 | 23 | [QC-Py-23-Attention-Transformers](Python/QC-Py-23-Attention-Transformers.ipynb) | 90 min | Transformer architecture, multi-head attention, temporal fusion |
+| 23b | [QC-Py-23b-PatchTST-iTransformer](Python/QC-Py-23b-PatchTST-iTransformer.ipynb) | 90 min | PatchTST patching, iTransformer inverted axes, prévision financière |
 | 24 | [QC-Py-24-Autoencoders-Anomaly](Python/QC-Py-24-Autoencoders-Anomaly.ipynb) | 75 min | Autoencoders pour détection anomalies, regime change |
 
 **Objectifs** : Maîtriser deep learning pour séries temporelles, design CPU-optimized.
@@ -180,11 +181,11 @@ Approfondissement RL au-delà du DQN de la Phase 8 : PPO, SAC/A2C, et applicatio
 
 ## Résumé de la Progression
 
-**Total cours linéaire** : **28 notebooks Python** (QC-Py-01 à QC-Py-28, ~32 heures de contenu) + **23 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, Cloud strategies QC-Py-Cloud-*, training QC-Py-30..32, dataset workflow).
+**Total cours linéaire** : **29 notebooks Python** (QC-Py-01 à QC-Py-28 + le 23b, ~33 heures de contenu) + **24 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, Cloud strategies QC-Py-Cloud-*, training QC-Py-30..32, dataset workflow).
 
 **Répartition cours linéaire (Phases 1-8)** :
 - **18 notebooks non-ML** (Fondations, Universe, Trading Avancé, Framework, Alternative Data) : ~18h
-- **10 notebooks ML/DL/AI** (Supervised Learning, Deep Learning, RL, LLM, Régime) : ~13h
+- **11 notebooks ML/DL/AI** (Supervised Learning, Deep Learning, RL, LLM, Régime) : ~15h
 
 **Progression pédagogique** : Maîtriser les fondations QuantConnect **avant** d'aborder le Machine Learning.
 
@@ -208,7 +209,7 @@ Approfondissement RL au-delà du DQN de la Phase 8 : PPO, SAC/A2C, et applicatio
 
 ## Projets de Stratégies
 
-Le dossier [`projects/`](projects/) contient **115 stratégies de trading** prêtes à backtester.
+Le dossier [`projects/`](projects/) contient **114 stratégies de trading** prêtes à backtester.
 
 ### Comment utiliser les projets
 


### PR DESCRIPTION
## §E whole-file gate audit — QuantConnect/README.md

Gate §E (mandate user 2026-07-04, PR #5353): a README-PR touching a series README must prove a whole-file audit (disk ↔ CATALOG-STATUS ↔ prose reconciliation, not just the corrected line).

### (a) find count per subfolder (disk ground-truth)

| Subfolder | Notebooks (source, excl. `_output`) |
|-----------|--------------------------------------|
| `Python/` | **53** QC-Py-XX source notebooks (+ 8 `_output.ipynb` artifacts = 61 total files) |
| `projects/` | **114** strategy subdirs |
| `ML-Training-Pipeline/` | 20 (own sub-series, Epic #1454) |
| `research/` | 21 |
| `kelly_lean/` | 1 |

### (b) disk ↔ CATALOG-STATUS ↔ prose reconciliation

- **CATALOG-STATUS** declares `Python=53, projects=49, pedagogical_count=105`.
- **Disk Python source = 53** → catalog **CORRECT** (the 61 vs 53 gap was `_output.ipynb` artifacts, not drift). CATALOG-STATUS **byte-identique** on this branch (untouched, catalog-pr-hygiene R1).
- **Prose was stale**:
  - L183 « 28 notebooks (QC-Py-01..28) » → **29** (23b-PatchTST missing from count + table)
  - L183 « 23 compléments » → **24** (Cloud strategies grew 14→15: `Cloud-06-VolTargeting` added)
  - L187 « 10 ML/DL/AI » → **11** (23b is DL)
  - L211 « 115 stratégies » → **114** (actual `projects/` count)
- Linear breakdown verified: Phase 1(4) + 2(4) + 3(4) + 4(3) + 5(3) = **18 non-ML** ✓ ; Phase 6(3) + 7(**4** now) + 8(4) = **11 ML/DL/AI** ✓ → 29 linear.
- Complements: 33-35(3) + 40-41(2) + Cloud-*(15) + 30-32(3) + Dataset(1) = **24** ✓.

### (c) notebook lists / tree / breakdowns current

- **Phase 7 table** was missing `QC-Py-23b-PatchTST-iTransformer` entirely (not cited anywhere in README — internal inconsistency vs disk). Added row (90 min, peer with 23-Attention-Transformers). The notebook's own navigation confirms `23 → 23b → 24` sequence.
- 23b exec health: 13/13 code cells `execution_count: 1..13`, 0 error (C.2 OK).
- All 32 `ipynb` links in QC README resolve (0 broken). `check_docs_links.py --check`: **OK, 0 new broken (3367 total)**.

### Diff summary

`+6 / −5`, 1 file. CATALOG-STATUS untouched. R3 atomic (single subject: QC feuille §E count reconciliation).

See #3975 (NOT `Closes` — epic tracker, partial contribution to the README-feuille wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)