### PR TITLE
docs(sm): audit SmartContracts/README.md feuille §E — erc20_lean/ tree omission

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -133,6 +133,7 @@ SmartContracts/
 ├── 05-Alternative-Chains/      # Vyper, XRP, Bitcoin, Move, Solana (5 notebooks)
 ├── 06-Real-World/              # Cross-chain, deploy testnet/mainnet (4 notebooks)
 ├── foundry-lib/                # Workspace Foundry + sous-modules (forge-std, OpenZeppelin, ERC-4337)
+├── erc20_lean/                 # Projet Lake Lean 4 (invariant de conservation ERC-20, 0 sorry, cf #4047) — 1er lake Lean de la série
 ├── mon-premier-projet/         # Projet Foundry de démarrage (squelette scaffold)
 ├── scripts/                    # Setup multi-plateforme (setup.sh, WSL, kernel Jupyter)
 ├── requirements.txt            # Dépendances Python


### PR DESCRIPTION
## What

Audit feuille `SymbolicAI/SmartContracts/README.md` — whole-file gate §E (See #3975).

## G.1 finding (firsthand, cited-paths-vs-disk)

`erc20_lean/` (Lean 4 lake: `lakefile.lean` + `ERC20.lean` **0 sorry** + `ERC20.en.md` + `lean-toolchain` + `lake-manifest.json`, issue #4047, **1er lake Lean de la série SmartContract**) **EXISTS on disk** but was **OMITTED** from the "Structure des fichiers" tree (lines 126-140), while siblings `foundry-lib/`, `mon-premier-projet/`, `scripts/` ARE documented.

Added one tree entry:

```
├── erc20_lean/                 # Projet Lake Lean 4 (invariant de conservation ERC-20, 0 sorry, cf #4047) — 1er lake Lean de la série
```

## Validation

- `git diff`: +1/-0 (single tree line), no prose/marker change
- **Catalogue byte-identique à `main`** (catalog-pr-hygiene R1 — automation-owned, never regenerated on feature branch)
- `check_docs_links.py --check`: **OK (0/3346)**
- Marker `pedagogical_count=27`, "Vue d'ensemble" (27), disk (27) all consistent — no stale-marker issue

## Scope

Docs-only, single file, single line. Markdown-only (C.2-exempt). See #3975 (feuille §E whole-file gate).

Co-Authored-By: Claude <noreply@anthropic.com>
