### PR TITLE
docs(planners): Planners/README.md feuille audit §E — planning_lean/ + requirements.txt tree omissions

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -131,6 +131,8 @@ SymbolicAI/Planners/
 │   ├── Planners-10-LLM-Planning.ipynb   # LLM + Planning
 │   ├── Planners-11-Unified-Planning.ipynb # Interface unifiée
 │   └── Planners-12-LOOP.ipynb           # Learning to Plan
+├── planning_lean/                        # Projet Lake Lean 4 (preuve formelle 0-sorry de l'admissibilité de la relaxation h+ <= h*, cf Planners-5b)
+├── requirements.txt                      # Dépendances Python (unified-planning, Fast Downward, etc.)
 └── archive/
     └── Fast-Downward-Legacy.ipynb       # Version archivée
 ```


### PR DESCRIPTION
## What

Audit feuille `SymbolicAI/Planners/README.md` — whole-file gate §E (See #3975).

## G.1 finding (firsthand, structure-tree vs disk vs prose)

The "Structure des fichiers" tree (lines 113-136) lists `README.md` + 5 content subdirs (`00-Environment`..`04-NeuroSymbolic`) + `archive/` but **OMITS two entries that EXIST on disk AND are referenced in the README's own prose/tables**:

- **`planning_lean/`** — Lean 4 lake (`lakefile.lean` on disk), referenced **3× in prose/tables** (l.52, l.167, l.200) as the lake where **Planners-5b** proves the relaxation admissibility `h⁺ ≤ h*` **0-sorry**. The tree documents the `Planners-5b-Lean-Relaxation.ipynb` companion but not the lake it lives in.
- **`requirements.txt`** — Python deps file, exists on disk.

Adding both lines makes the tree **internally consistent** with the prose (the same inconsistency pattern as SmartContracts `erc20_lean/` in #5372).

## Validation

- `git diff`: +2/-0 (two tree lines), no prose/marker change
- **Catalogue byte-identique à `main`** (catalog-pr-hygiene R1 — this family has no CATALOG-STATUS marker, fully hand-maintained)
- `check_docs_links.py --check`: **OK (0/3346)**
- 14 active notebooks (Planners-0..12 + 5b) + archive all correctly listed in tree

## Scope

Docs-only, single file, two lines. Markdown-only (C.2-exempt). See #3975 (feuille §E whole-file gate).

Co-Authored-By: Claude <noreply@anthropic.com>
