### PR TITLE
docs(iit): IIT/README.md feuille §E — ICT tree + strates stale (1..15/deux -> 1..18,20,23/cinq strates)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -274,7 +274,7 @@ IIT/
 ├── IIT-3-CoarseGrainingMacroPhi.ipynb # Notebook 3 : coarse-graining & échelle du Φ
 ├── ICT-Series/                 # Extension expérimentale ICT (Epic #4588) — voir son README
 │   ├── ICT-0-Framing.md        # Cadrage de la série ICT
-│   ├── ICT-1..15-*.ipynb       # 15 notebooks numérotés + ICT-Synthese (2 strates : tri auto-organisé, morphogenèse dynamique)
+│   ├── ICT-*.ipynb             # 20 notebooks numérotés (1..18, 20, 23) + ICT-Synthese (5 strates, Epic #4588 — cf son README)
 │   ├── ict/                    # Package Python autonome (simulations + mesures)
 │   ├── tests/                  # Suite pytest de validation des modules ict/
 │   └── README.md               # Documentation de la série ICT
@@ -314,12 +314,15 @@ La série IIT étudie des structures causales **à un instant donné**. Une exte
 **ICT** (Integrated Causal Trajectories, Epic #4588), prolonge ce regard vers les **trajectoires**
 de structures causales : comment une organisation se maintient, se transforme, se répare, change
 d'échelle et traverse un espace de possibles ($C_0 \rightarrow C_1 \rightarrow \dots \rightarrow C_n$).
-Elle progresse en deux strates — le **tri auto-organisé** transparent (ICT-0 à ICT-7), puis la
-**morphogenèse dynamique** à paysages d'attracteurs engendrés (ICT-8+).
+Elle progresse en cinq strates — le **tri auto-organisé** transparent (strate 1, ICT-0 à ICT-7), la
+**morphogenèse dynamique** à paysages d'attracteurs engendrés (strate 2, ICT-8 à ICT-10), les
+**trajectoires intégrées** régime-dépendantes (strate 3, ICT-11 à ICT-13), la jambe
+**représentationnelle** énergie libre / surprise (strate 4, ICT-14), puis la **théorie fondatrice**
+cross-substrat et la réversibilisation outillée (strate 5, ICT-15+).
 
 ICT vit dans le sous-répertoire [`ICT-Series/`](ICT-Series/README.md), placé sous IIT pour respecter
 l'ordre de lecture (ICT prolonge IIT). **Voir son [README dédié](ICT-Series/README.md)** pour la liste
-complète des notebooks, les deux strates et le détail des mesures *sans complaisance*. La série
+complète des notebooks, les cinq strates et le détail des mesures *sans complaisance*. La série
 partage l'environnement Python d'IIT (`scripts/setup_pyphi_env.ps1`, `requirements.txt`).
 
 ## Ponts causaux : le do-calculus de Pearl à travers les paradigmes


### PR DESCRIPTION
## What

Audit feuille `IIT/README.md` — whole-file gate §E (See #3974, familles Python).

## G.1 finding (firsthand on `origin/main` fa3bd6207)

The "Structure des fichiers" tree (line 277) **and** the "Extension ICT" prose (lines 317-322) were **stale by 3 levels** vs disk and the ICT-Series README:

| Claim (stale) | Reality (origin/main) |
|---------------|----------------------|
| `ICT-1..15-*.ipynb` | ICT-1..18 + ICT-20 + ICT-23 (strate 5 delivered 20 & 23) |
| "15 notebooks numérotés + ICT-Synthese" | 20 numbered + ICT-Synthese = 21 |
| "2 strates : tri auto-organisé, morphogenèse dynamique" | **5 strates** (per `ICT-Series/README.md` line 16: tri / morphogenèse / trajectoires intégrées / représentationnelle / théorie fondatrice cross-substrat) |

**Fix** (2 edits, same file):
1. Tree line 277: `ICT-*.ipynb # 20 notebooks numérotés (1..18, 20, 23) + ICT-Synthese (5 strates, Epic #4588 — cf son README)`
2. Prose lines 317-322: "deux strates" → "cinq strates" with the per-strate breakdown (1: ICT-0..7, 2: ICT-8..10, 3: ICT-11..13, 4: ICT-14, 5: ICT-15+).

## Hors-scope (G.1 honnête)

The `CATALOG-STATUS` marker (`breakdown: ICT-Series=19`) is **stale vs disk=21** — but it is **automation-owned** (catalog-pr-hygiene R1: never regenerated on a feature branch). The daily `catalog-cron.yml` self-heals it on `main`. Documented here, not fixed.

## Validation

- `git diff`: +7/-4 (one tree line + one prose paragraph), no marker change
- **Catalogue byte-identique à `main`** (catalog-pr-hygiene R1)
- `check_docs_links.py --check`: **OK (0/3346)**
- Disk count cross-checked via `git ls-tree origin/main`

## Scope

Docs-only, single file. Markdown-only (C.2-exempt). See #3974 (feuille §E whole-file gate, familles Python).

Co-Authored-By: Claude <noreply@anthropic.com>
