### PR TITLE
docs(symbolicai): hub README SymbolicLearning count 11->12 (SL-12 delivered)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -66,7 +66,7 @@ Si vous vous intéressez au croisement IA symbolique / IA neuronale, la série A
 
 ### Parcours alternatif : Apprentissage symbolique (SymbolicLearning, ~9h30)
 
-La série SymbolicLearning (11 notebooks) suit le chapitre 19 d'AIMA : induction pure (Version Space), apprentissage guidé par la connaissance (EBL, RBL), programmation logique inductive (FOIL, résolution inverse, Progol), apprentissage actif d'automates (L* d'Angluin), puis intégration neuro-symbolique jusqu'à un capstone LLM + knowledge graph. Elle ne requiert que Python standard pour l'essentiel et peut être suivie indépendamment des autres phases.
+La série SymbolicLearning (12 notebooks) suit le chapitre 19 d'AIMA : induction pure (Version Space), apprentissage guidé par la connaissance (EBL, RBL), programmation logique inductive (FOIL, résolution inverse, Progol), apprentissage actif d'automates (L* d'Angluin), puis intégration neuro-symbolique jusqu'à un capstone LLM + knowledge graph. Elle ne requiert que Python standard pour l'essentiel et peut être suivie indépendamment des autres phases.
 
 ---
 


### PR DESCRIPTION
## What

Audit hub `SymbolicAI/README.md` — reconcile SymbolicLearning count after SL-12 delivery (See #4959, central/hub READMEs).

## G.1 finding (firsthand on `origin/main` fa3264207)

Hub line 69 said **"La série SymbolicLearning (11 notebooks)"** but **SL-1..12 = 12 notebooks exist on disk** — SL-12-DifferentiableLogicGateNetworks (difflogic, Petersen NeurIPS 2022) is delivered (12 code cells, executed 1..12, fully on `main`). The count claim was stale by 1.

**Fix**: `11 notebooks` → `12 notebooks` (single-token change, French wording preserved).

## Hors-scope (deferred to SL-12 owner po-2026, #5269)

The SL **feuille** README (`SymbolicAI/SymbolicLearning/README.md`) has the same staleness at multiple points — but reconciling it atomically requires **SL-12 phase/maturity classification** (which phase: neuro-symbolique Phase 5?; PRODUCTION vs BETA?), a judgment belonging to the SL-12 owner:
- Feuille prose l.468: "PRODUCTION sur 11 notebooks"
- Feuille table l.466: `| Total | 11 | PRODUCTION=11 |`
- Feuille table l.464: Phase 5 row (SL-7/8/9, needs SL-12 added + count 3→4)
- CATALOG-STATUS marker (l.451-453): `pedagogical_count: 11` — automation-owned, cron self-heals

Half-fixing the feuille (prose only) would create an internal inconsistency (prose 12 vs table Total 11); full-fixing needs the classification. Deferred to po-2026 for one atomic feuille reconciliation. This PR keeps scope to the **hub** (no table, unambiguous count).

## Validation

- `git diff`: +1/-1 (single count token), no prose/wording change
- **Catalogue byte-identique à `main`** (catalog-pr-hygiene R1)
- `check_docs_links.py --check`: **OK (0/3346)**

## Scope

Docs-only, single file, single token. Markdown-only (C.2-exempt). See #4959 (hub/central READMEs).

Co-Authored-By: Claude <noreply@anthropic.com>
