### PR TITLE
docs(hub): root notebooks README progression tree — add SMT/ (24 nb, 4th SymbolicAI family)

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -64,6 +64,7 @@ SymbolicAI
 ├── Lean/ - Theorem proving, LeanDojo, hommages (Grothendieck, Conway, FWT)
 ├── Planners/ - PDDL, Fast-Downward, OR-Tools, LLM planning
 ├── Tweety/ - Logiques classiques, argumentation
+├── SMT/ - Z3, Satisfiability Modulo Theories (LINQ C# + Python)
 ├── SymbolicLearning/ - ILP, neuro-symbolique, KG-LLM, automates (L*)
 └── Argument_Analysis/ - Analyse d'arguments
 ```


### PR DESCRIPTION
## What

Audit root hub `MyIA.AI.Notebooks/README.md` — progression pédagogique tree reconciliation (See #4959, P0 hub notebooks).

## G.1 finding (firsthand on `origin/main` 46962f369)

The "Progression pédagogique" tree (lines 61-68) lists **7 SymbolicAI subdirs** but **OMITS `SMT/`** — the **4th largest** SymbolicAI family (24 notebooks: `Z3/` LINQ C# series + `Z3-Python/` series).

**Triple inconsistency** (root tree is the outlier):
1. **SymbolicAI hub README** (`SymbolicAI/README.md`) structure tree *does* list `SMT/` with both subdirs (Z3/, Z3-Python/) — so the hub is complete, the root is stale.
2. **Root README prose** references Z3 **3×**:
   - l.5: « formalisée et vérifiée mécaniquement (Lean 4, Z3...) »
   - l.79: « C# (Tweety/Z3/SW/SC) »
   - l.118: « Symbolic: RDF, Z3 SMT, Lean 4, SmartContracts »
3. The root tree includes the **smallest** family (`Argument_Analysis/`, 6 notebooks) while omitting the **4th largest** (SMT, 24 notebooks) — not sensible curation, a genuine omission.

**Fix**: one-line addition to the SymbolicAI progression block:
```
├── SMT/ - Z3, Satisfiability Modulo Theories (LINQ C# + Python)
```

## Validation

- `git diff`: +1/-0 (single tree line), no prose change
- **Catalogue byte-identique à `main`** (catalog-pr-hygiene R1)
- `check_docs_links.py --check`: **OK (0/3381)**
- SMT substance cross-checked: 24 notebooks + own README on `origin/main`

## Scope

Docs-only, single file, single line. Markdown-only (C.2-exempt). See #4959 (hub/central READMEs, P0).

Co-Authored-By: Claude <noreply@anthropic.com>
