### PR TITLE
docs(rl): section 'Contenu détaillé' Notebook 6e (GRPO) — reconcile table 17 vs detailed 16

### DIFF
--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -128,6 +128,17 @@ Cette série couvre les **fondements théoriques** (bandits, MDP, équation de B
 | Reparameterization | Trick pour gradient dans l'action |
 | Pendulum-v1 | Environnement continu de référence |
 
+### Notebook 6e - GRPO depuis zéro
+
+| Section | Contenu |
+|---------|---------|
+| Avantage relatif sans critic | Group Relative Policy Optimization (DeepSeek-R1), baseline de groupe au lieu d'un réseau critique |
+| Portfolio synthétique | Environnement auto-contenu, signal de récompense reproductible multi-seed |
+| Actor seul | Réseau de politique unique sans critic (contrairement à PPO/A2C/SAC) |
+| Mise à jour GRPO | Avantage intra-groupe + clip PPO + pénalité KL vs politique de référence |
+| Boucle multi-seed | Entraînement multi-seed, verdict de stabilité |
+| GRPO vs PPO/SAC | Ce que change le paradigme sans critic |
+
 ### Notebook 7 - Apprentissage Multi-Agent
 
 | Section | Contenu |


### PR DESCRIPTION
## What

`MyIA.AI.Notebooks/RL/README.md` — ajout section « Contenu détaillé » pour **Notebook 6e (GRPO)**, manquante depuis la livraison de `rl_6e_grpo_from_scratch` (PR #5349).

## G.1 finding (firsthand on `origin/main` 46962f369)

Le tableau « Notebooks » (l.22-38) liste **17 entrées** dont `rl_6e_grpo_from_scratch` (l.31), mais la section « Contenu détaillé » saute de **6d** (l.120) à **7** (l.131) — **6e est absent**. Incohérence interne prose : **table=17 vs detailed=16**.

- `grep -cE '^### Notebook'` = **16** (1,2,3,4,5,6,6b,6c,6d,7,8,9,10,11,12,13) — 6e manquant
- Table = **17** (idem + 6e)

`rl_6e` est livré sur `origin/main` (12 cells markdown + code, 3 exercices ✓ convention 3-exos).

## Fix

Ajout d'une section « ### Notebook 6e - GRPO depuis zéro » (6 lignes, **miroir exact du format 6b/6c/6d**) entre 6d et 7. Contenu extrait **firsthand** des headers markdown réels de `rl_6e_grpo_from_scratch.ipynb` :

| Row | Header markdown réel du notebook |
|-----|----------------------------------|
| Avantage relatif sans critic | `## 1. Pourquoi GRPO ? L'avantage relatif sans critic` |
| Portfolio synthétique | `## 2. Environnement Portfolio synthetique (auto-contenu)` |
| Actor seul | `## 3. Reseau de politique (Actor seul -- pas de Critic)` |
| Mise à jour GRPO | `## 4. ... avantage relatif intra-groupe + clip + KL` |
| Boucle multi-seed | `## 5. Boucle d'entrainement GRPO multi-seed` |
| GRPO vs PPO/SAC | `## 7. Ce que GRPO change vs PPO/SAC` |

## Scope

Prose-completeness après livraison `rl_6e` (**non §E tree reconciliation**) : la « Structure des fichiers » tree (l.447-468) est **déjà parfaite** — 17 notebooks + README, 0 sous-répertoire, reflète exactement le disque. Le `pedagogical_count: 16` du marker CATALOG-STATUS est automation-owned (catalog-pr-hygiene R1) et self-heal sur main via `catalog-cron.yml`.

Docs-only, single file, +11/-0. Markdown-only (C.2-exempt). Coherent avec la livraison rl_6e (#5349) et le « pont GRPO » documenté dans la Conclusion (l.503).

## Validation

- `git diff`: +11/-0 (single section), no prose change elsewhere
- **Catalogue byte-identique à `main`** (catalog-pr-hygiene R1)
- **CATALOG-STATUS marker untouched** (automation-owned)
- `check_docs_links.py --check`: **OK (0/3381)**

Co-Authored-By: Claude <noreply@anthropic.com>
