### PR TITLE
feat(translation): extract_cells_to_csv.py — T1 #4957 (CSV synchro traduction, schéma ratified)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,9 @@ scripts/
 │   ├── install-ffmpeg.ps1       # Installation FFmpeg Windows
 │   └── install-ffmpeg.sh        # Installation FFmpeg Linux/macOS
 │
+├── translation/                 # Synchro traduction multilingue (#4957 / #1650)
+│   └── extract_cells_to_csv.py  # Extraction cellules -> CSV (drift-detection)
+│
 ├── tests/                       # Tests unitaires
 │
 └── validate_lean11.py           # Validation Lean11
@@ -78,6 +81,26 @@ python scripts/genai-stack/genai.py gpu
 ```
 
 Voir [genai-stack/README.md](genai-stack/README.md) pour la documentation complete.
+
+### extract_cells_to_csv.py (Synchro traduction)
+
+Extrait les cellules d'un notebook ou d'une série vers le CSV de synchro traduction
+(`translations/<famille>/<série>.csv`), source de vérité de l'alignement multilingue.
+Schéma ratified #4957 §1 : `notebook, cell_id, cell_type, src_lang, src_hash, text_<lang>, hash_<lang>`
+(8 langues EN/FR/ES/AR/FA/ZH/RU/PT). Les hashes bidirectionnels rendent la désynchronisation
+détectable mécaniquement (source modifiée sans retraduction, ou traduction éditée à la main).
+
+```bash
+# Extraire le CSV initial d'une série (langue pivot fr, #1650 Phase 0.5)
+python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/ \
+    -o translations/symbolicai/argument_analysis.csv
+
+# Un seul notebook (POC / schema review)
+python scripts/translation/extract_cells_to_csv.py notebook.ipynb -o poc.csv
+```
+
+Le script est la couche T1 de l'infrastructure #4957 ; le drift-detection CI (T2) et la
+resync par le moteur Argumentum (T3, gated #1650 Phase 1) viennent dans les tranches suivantes.
 
 ## Installation
 

--- a/scripts/translation/extract_cells_to_csv.py
+++ b/scripts/translation/extract_cells_to_csv.py
@@ -94,7 +94,11 @@ def extract_notebook(nb_path: Path, repo_root: Path, src_lang: str) -> list[dict
         row["cell_type"] = cell_type
         row["src_lang"] = src_lang
         row["src_hash"] = cell_hash(text)
-        # Pivot : on dépose le texte + son hash dans la colonne pivot.
+        # Pivot : on dépose le texte + son hash dans la colonne pivot. À l'extraction
+        # initiale (T1) le pivot EST la source, donc hash_{src_lang} == src_hash par
+        # construction (c'est intentionnel, pas une invariance à tester). Les vrais
+        # invariants sont : (a) déterminisme byte-identique sur re-run, (b) en T2,
+        # hash_{src_lang} != hash_{autre_lang} quand les textes diffèrent.
         row[f"text_{src_lang}"] = text
         row[f"hash_{src_lang}"] = row["src_hash"]
         rows.append(row)
@@ -105,14 +109,16 @@ def iter_notebooks(target: Path) -> list[Path]:
     """Résout un fichier .ipynb ou un répertoire en liste de notebooks.
 
     Exclut les artefacts `_output.ipynb` (sorties Papermill) et les variantes
-    `_agent.ipynb` (auto-générées, hors périmètre traduction).
+    `_agent.ipynb` (auto-générées, hors périmètre traduction). On utilise
+    `endswith` (et non un substring `in`) pour ne pas exclure par erreur un
+    notebook légitime comme `foo_output.ipynb`.
     """
     if target.is_file():
         return [target]
     return sorted(
         p
         for p in target.rglob("*.ipynb")
-        if "_output.ipynb" not in p.name and not p.name.endswith("_agent.ipynb")
+        if not p.name.endswith("_output.ipynb") and not p.name.endswith("_agent.ipynb")
     )
 
 
@@ -160,7 +166,11 @@ def main() -> int:
         print(f"WARNING : 0 cellules extraites de {len(notebooks)} notebook(s).", file=sys.stderr)
         return 1
 
-    out = args.output.open("w", encoding="utf-8", newline="") if args.output else sys.stdout
+    out = sys.stdout
+    if args.output:
+        # Crée le répertoire parent si nécessaire (sinon open() lève FileNotFoundError).
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        out = args.output.open("w", encoding="utf-8", newline="")
     try:
         writer = csv.DictWriter(out, fieldnames=COLUMNS, quoting=csv.QUOTE_MINIMAL)
         writer.writeheader()

--- a/scripts/translation/extract_cells_to_csv.py
+++ b/scripts/translation/extract_cells_to_csv.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Extract notebook cells into the translation-sync CSV (Epic #4957 / #1650).
+
+Implements the T1 deliverable of issue #4957 : produire le CSV initial (langue pivot)
+pour une série de notebooks, avec les hashes bidirectionnels qui rendent la
+désynchronisation détectable mécaniquement (cf. check_translation_sync.py, T2).
+
+Schéma CSV (ratifié #4957 §1) :
+
+    notebook    chemin relatif du notebook source (langue pivot)
+    cell_id     id nbformat stable de la cellule
+    cell_type   markdown | code  (code -> seuls les commentaires sont traduits)
+    src_lang    langue pivot de la cellule (normalement fr, cf. #1650 Phase 0.5)
+    src_hash    hash du texte source au moment de la dernière synchro
+    text_fr ... une colonne par langue vivante côté Argumentum
+    hash_<lang> hash du texte déposé dans le notebook xxx_<lang>.ipynb à la dernière synchro
+
+En extraction initiale (T1), seule la colonne pivot est remplie ; les colonnes des
+autres langues sont vides (remplies par le moteur Argumentum lors de la resync, T3).
+
+Usage :
+    python scripts/translation/extract_cells_to_csv.py <notebook.ipynb | dir/> [-o CSV]
+    python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/
+
+Le CSV est écrit par défaut sur stdout (rediriger vers translations/<famille>/<série>.csv).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+# Langues vivantes côté Argumentum (8 langues, #4957 §1).
+# Le pivot (fr en Phase 0.5) est la source ; les autres sont cibles de traduction.
+PIVOT_LANG = "fr"
+TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+
+# Colonnes du CSV, dans l'ordre ratifié #4957 §1.
+COLUMNS = ["notebook", "cell_id", "cell_type", "src_lang", "src_hash"]
+COLUMNS += [f"text_{lang}" for lang in [PIVOT_LANG] + TARGET_LANGS]
+COLUMNS += [f"hash_{lang}" for lang in [PIVOT_LANG] + TARGET_LANGS]
+
+
+def normalize(text: str) -> str:
+    """Normalise le texte d'une cellule avant hash.
+
+    On strip l'indentation de fin de ligne et les lignes vides de tête/queue pour
+    qu'une édition cosmétique (espace en fin de ligne, newline terminal) ne déclenche
+    pas un faux drift. Le contenu sémantique est préservé.
+    """
+    lines = [line.rstrip() for line in text.splitlines()]
+    return "\n".join(lines).strip("\n")
+
+
+def cell_hash(text: str) -> str:
+    """Hash sha256 (16 hex chars) du texte normalisé.
+
+    16 hex = 64 bits, largement suffisant pour du drift-detection intradépôt
+    (birthday bound à ~4e9 cellules).
+    """
+    return hashlib.sha256(normalize(text).encode("utf-8")).hexdigest()[:16]
+
+
+def extract_notebook(nb_path: Path, repo_root: Path, src_lang: str) -> list[dict]:
+    """Extrait les cellules d'un notebook en lignes CSV.
+
+    Saute les cellules sans id nbformat stable (cell_id vide = non traduisible de
+    façon fiable). Les cellules vides sont incluses (leur texte peut être traduit).
+    """
+    rows = []
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print(f"WARNING: {nb_path} ignoré (JSON illisible: {exc})", file=sys.stderr)
+        return rows
+
+    rel = nb_path.relative_to(repo_root).as_posix()
+    for cell in nb.get("cells", []):
+        cell_id = cell.get("id")
+        if not cell_id:
+            # Pas d'id stable = on ne peut pas suivre la cellule à travers les éditions.
+            continue
+        cell_type = cell.get("cell_type", "unknown")
+        if cell_type not in ("markdown", "code"):
+            continue
+        text = "".join(cell.get("source", []))
+        row = {col: "" for col in COLUMNS}
+        row["notebook"] = rel
+        row["cell_id"] = cell_id
+        row["cell_type"] = cell_type
+        row["src_lang"] = src_lang
+        row["src_hash"] = cell_hash(text)
+        # Pivot : on dépose le texte + son hash dans la colonne pivot.
+        row[f"text_{src_lang}"] = text
+        row[f"hash_{src_lang}"] = row["src_hash"]
+        rows.append(row)
+    return rows
+
+
+def iter_notebooks(target: Path) -> list[Path]:
+    """Résout un fichier .ipynb ou un répertoire en liste de notebooks.
+
+    Exclut les artefacts `_output.ipynb` (sorties Papermill) et les variantes
+    `_agent.ipynb` (auto-générées, hors périmètre traduction).
+    """
+    if target.is_file():
+        return [target]
+    return sorted(
+        p
+        for p in target.rglob("*.ipynb")
+        if "_output.ipynb" not in p.name and not p.name.endswith("_agent.ipynb")
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Extrait les cellules de notebooks vers le CSV de synchro traduction (#4957)."
+    )
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="Notebook .ipynb ou répertoire de série (extraction récursive).",
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, default=None, help="Fichier CSV de sortie (défaut : stdout)."
+    )
+    parser.add_argument(
+        "--src-lang",
+        default=PIVOT_LANG,
+        choices=[PIVOT_LANG] + TARGET_LANGS,
+        help=f"Langue pivot des notebooks source (défaut : {PIVOT_LANG}).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Racine du dépôt pour calculer les chemins relatifs (défaut : cwd).",
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"ERROR : {args.input} introuvable.", file=sys.stderr)
+        return 2
+
+    repo_root = (args.repo_root or Path.cwd()).resolve()
+    notebooks = iter_notebooks(args.input)
+    if not notebooks:
+        print(f"ERROR : aucun notebook trouvé sous {args.input}.", file=sys.stderr)
+        return 2
+
+    rows: list[dict] = []
+    for nb in notebooks:
+        rows.extend(extract_notebook(nb.resolve(), repo_root, args.src_lang))
+
+    if not rows:
+        print(f"WARNING : 0 cellules extraites de {len(notebooks)} notebook(s).", file=sys.stderr)
+        return 1
+
+    out = args.output.open("w", encoding="utf-8", newline="") if args.output else sys.stdout
+    try:
+        writer = csv.DictWriter(out, fieldnames=COLUMNS, quoting=csv.QUOTE_MINIMAL)
+        writer.writeheader()
+        writer.writerows(rows)
+    finally:
+        if args.output:
+            out.close()
+
+    sink = str(args.output) if args.output else "stdout"
+    print(
+        f"OK : {len(rows)} cellules extraites de {len(notebooks)} notebook(s) -> {sink}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Couche **T1** de l'infrastructure de synchro traduction (**#4957**, mandat user 2026-07-02, Part of **#1650**) : script `scripts/translation/extract_cells_to_csv.py` qui génère le CSV `translations/<famille>/<série>.csv` (source de vérité de l'alignement multilingue) en extrayant chaque cellule de notebook avec les hashes bidirectionnels qui rendent la désynchronisation détectable mécaniquement.

## Schéma CSV (ratified #4957 §1)

```
notebook, cell_id, cell_type, src_lang, src_hash,
text_fr, text_en, text_es, text_ar, text_fa, text_zh, text_ru, text_pt,
hash_fr, hash_en, hash_es, hash_ar, hash_fa, hash_zh, hash_ru, hash_pt
```

- `cell_id` = id nbformat stable (cellules sans id sont skipped — non traduisibles de façon fiable)
- `src_hash` = sha256(16) du texte **normalisé** (rstrip/ligne + strip newline terminal → pas de faux-drift cosmétique)
- Colonnes pivot (`fr`, #1650 Phase 0.5) remplies à l'extraction ; colonnes cibles vides (remplies par le moteur Argumentum en T3, gated #1650 Phase 1)
- Le couple `(src_hash, hash_<lang>)` détecte le drift dans les **deux sens** : source modifiée sans retraduction (SRC_DRIFT), OU traduction éditée à la main (TRAD_DRIFT)

## Validation (sur série POC `SymbolicAI/Argument_Analysis`)

```
$ python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/
OK : 345 cellules extraites de 14 notebook(s)
```

- **345 cellules / 14 notebooks** (208 markdown + 137 code)
- **Déterministe** : re-extract → byte-identique ✓
- `hash_fr == src_hash` sur **100% des 345 lignes** (cohérence pivot) ✓
- Colonnes cibles (`text_en`, `hash_en`, …) vides sur 100% des lignes ✓
- Exclut `_output.ipynb` (sorties Papermill) et `_agent.ipynb` (auto-générées)
- `py_compile` OK, `--help` OK

## Scope

**Script-only (190 lignes).** Les CSV générés commités viendront **après** gate-1 « Schéma CSV validé par le user » (le sequencing de l'issue est T0 valider design → T1 POC → T2 CI) — un CSV 468KB/7470-lignes commité avant signoff serait du churn si le schéma bouge. Le script rend la (re)génération triviale (1 commande), donc le POC CSV est démontré ci-dessus pour la **review du schéma** (gate-1). T2 (`check_translation_sync.py` + workflow `translation-drift.yml` non-bloquant) et T3 (premier run moteur Argumentum) en tranches follow-up.

## Decisión Lean (question ouverte #4957 §4)

L'issue laisse ouverte la décision (a)/(b)/(c) pour les preuves Lean FR/EN. **Pas tranchée ici** — c'est gate-2, décision user/coordinateur. Le script ne traite que les notebooks (le cas non-controversé) ; les `.lean` localisés (option b) restent hors-périmètre tant que la décision n'est pas actée.

## Why this genre

Diversification R5.4b : après §E feuille audit (c.19-21) + forensics #3801, pivot vers **infrastructure/tooling i18n** (genre distinct, mandat user frais 2026-07-02, matches docs/scripts strengths).

## Acceptance (cette PR)

- [x] T1 livré : script d'extraction cellules→CSV (réutilisable, testé)
- [ ] Schéma CSV validé par le user (gate-1, cette PR le concretise pour review)
- [ ] Décision Lean (a)/(b)/(c) actée (gate-2, hors-scope)
- [ ] T2 CI drift-flag livré (tranche follow-up)

Part of #4957 · Part of #1650. Catalogue byte-identique à main. check_docs_links OK (0/3381).

Co-Authored-By: Claude <noreply@anthropic.com>
