### PR TITLE
feat(translation): check_translation_sync.py + CI workflow — T2 #4957 (drift-detection non-bloquant)

### DIFF
--- a/.github/workflows/translation-drift.yml
+++ b/.github/workflows/translation-drift.yml
@@ -54,13 +54,26 @@ jobs:
             echo "drift=none" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          REPORT="$(python scripts/translation/check_translation_sync.py translations --check --repo-root . 2>/dev/null)"
-          COUNT="$(echo "$REPORT" | python -c 'import sys,json; print(json.load(sys.stdin)["anomaly_count"])' 2>/dev/null || echo 0)"
+          # Capture stdout (JSON report) and stderr (diagnostics) separately.
+          # A drift detector that crashes must announce itself, NOT stay silent
+          # behind 2>/dev/null and report a false "all in sync".
+          STDERR_FILE="$(mktemp)"
+          REPORT="$(python scripts/translation/check_translation_sync.py translations --check --repo-root . 2>"$STDERR_FILE")"
+          SCRIPT_EXIT=$?
+          STDERR_CONTENT="$(cat "$STDERR_FILE")"
+          rm -f "$STDERR_FILE"
+          # Distinguish a script crash from a legitimately empty report.
+          if [ "$SCRIPT_EXIT" -ne 0 ] || ! echo "$REPORT" | python -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+            echo "::warning title=Translation drift check (broken)::The drift detector itself failed (exit $SCRIPT_EXIT, non-JSON stdout). A false 'all in sync' cannot be trusted. Investigate the job log. Stderr: $STDERR_CONTENT"
+            echo "drift=broken" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          COUNT="$(echo "$REPORT" | python -c 'import sys,json; print(json.load(sys.stdin)["anomaly_count"])')"
           if [ "$COUNT" = "0" ]; then
             echo "::notice title=Translation sync::All translation CSVs in sync with notebooks. No drift."
             echo "drift=none" >> "$GITHUB_OUTPUT"
           else
-            SUMMARY="$(echo "$REPORT" | python -c 'import sys,json; from collections import Counter; d=json.load(sys.stdin); print(", ".join(f"{v}={n}" for v,n in Counter(a["verdict"] for a in d["anomalies"]).items()))' 2>/dev/null || echo "see report")"
+            SUMMARY="$(echo "$REPORT" | python -c 'import sys,json; from collections import Counter; d=json.load(sys.stdin); print(", ".join(f"{v}={n}" for v,n in Counter(a["verdict"] for a in d["anomalies"]).items()))')"
             echo "::notice title=Translation drift (informational)::$COUNT drift(s) detected ($SUMMARY). This does NOT block the PR. Re-translation is proposed here but executed manually by an agent (Argumentum motor, #4957 §3). See JSON report in the job log."
             echo "$REPORT"
             echo "drift=detected" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/translation-drift.yml
+++ b/.github/workflows/translation-drift.yml
@@ -1,0 +1,71 @@
+name: Translation Drift Check
+
+# Purpose: DETECT (non-blocking, read-only) when a notebook source or one of its
+# translations drifts out of sync with the translation CSV
+# (translations/<famille>/<série>.csv, Epic #4957 / #1650). The CSV is the source
+# of truth for the multilingual alignment maintained by extract_cells_to_csv.py.
+#
+# This job is intentionally NON-BLOCKING and READ-ONLY — same philosophy as
+# catalog-drift.yml. It surfaces drift as a notice annotation so reviewers see
+# it, but never writes to a branch and never fails the PR gate. The actual
+# re-translation is PROPOSED by this check but EXECUTED manually by an agent
+# (running the Argumentum datasetupdater motor on flagged rows, #4957 §3) —
+# never an auto-commit LLM in CI.
+#
+# See #4957 (infra design) and #1650 (multilingual translation epic).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'translations/**'
+      - 'scripts/translation/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  translation-drift:
+    name: "Translation drift (read-only)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Non-blocking: --check always exits 0. Drift is surfaced as a notice
+      # annotation + JSON report. Pre-T1 (no translations/ committed yet) the
+      # script reports "0 CSV, nothing to verify" and the job is green.
+      - name: Detect translation drift
+        id: drift
+        run: |
+          if [ ! -d translations ]; then
+            echo "::notice title=Translation drift (informational)::No translations/ directory yet (pre-T1 phase, #4957). Nothing to verify."
+            echo "drift=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REPORT="$(python scripts/translation/check_translation_sync.py translations --check --repo-root . 2>/dev/null)"
+          COUNT="$(echo "$REPORT" | python -c 'import sys,json; print(json.load(sys.stdin)["anomaly_count"])' 2>/dev/null || echo 0)"
+          if [ "$COUNT" = "0" ]; then
+            echo "::notice title=Translation sync::All translation CSVs in sync with notebooks. No drift."
+            echo "drift=none" >> "$GITHUB_OUTPUT"
+          else
+            SUMMARY="$(echo "$REPORT" | python -c 'import sys,json; from collections import Counter; d=json.load(sys.stdin); print(", ".join(f"{v}={n}" for v,n in Counter(a["verdict"] for a in d["anomalies"]).items()))' 2>/dev/null || echo "see report")"
+            echo "::notice title=Translation drift (informational)::$COUNT drift(s) detected ($SUMMARY). This does NOT block the PR. Re-translation is proposed here but executed manually by an agent (Argumentum motor, #4957 §3). See JSON report in the job log."
+            echo "$REPORT"
+            echo "drift=detected" >> "$GITHUB_OUTPUT"
+          fi
+
+      # This job is always green. Drift is surfaced as a notice annotation only.
+      - name: Done (non-blocking, read-only)
+        run: echo "Translation drift check complete (non-blocking, read-only)."

--- a/scripts/translation/README.md
+++ b/scripts/translation/README.md
@@ -1,0 +1,70 @@
+# Scripts de synchro traduction (Epic #4957 / #1650)
+
+Infrastructure de synchronisation multilingue pour les notebooks pédagogiques. Le moteur de traduction (datasetupdater Argumentum, v0.9.0, 8 langues) n'est PAS réécrit ici — ces scripts en sont la couche d'**alignement** : ils maintiennent le CSV source de vérité et détectent le drift.
+
+## Workflow en 3 couches (T1 → T2 → T3)
+
+| Couche | Script | Rôle | Statut |
+|--------|--------|------|--------|
+| **T1** | `extract_cells_to_csv.py` | Extrait les cellules des notebooks vers le CSV (langue pivot `fr`) | Livré |
+| **T2** | `check_translation_sync.py` | Détecte le drift (source modifiée / trad éditée / cellule supprimée) | Livré (non-bloquant, CI) |
+| **T3** | moteur Argumentum | Resync des langues cibles sur les lignes flaggées | À venir (gated #1650 Phase 1) |
+
+## Schéma CSV (ratified #4957 §1)
+
+`translations/<famille>/<série>.csv` — une ligne par cellule de notebook :
+
+```
+notebook, cell_id, cell_type, src_lang, src_hash,
+text_fr, text_en, text_es, text_ar, text_fa, text_zh, text_ru, text_pt,
+hash_fr, hash_en, hash_es, hash_ar, hash_fa, hash_zh, hash_ru, hash_pt
+```
+
+- `cell_id` = id nbformat stable (cellules sans id sont ignorées)
+- `src_hash` = sha256(16) du texte normalisé (rstrip/ligne + strip newline terminal → pas de faux-drift cosmétique)
+- Colonnes pivot (`fr`) remplies à l'extraction T1 ; colonnes cibles remplies par le moteur Argumentum en T3
+- Le couple `(src_hash, hash_<lang>)` détecte le drift dans les **deux sens**
+
+## extract_cells_to_csv.py (T1)
+
+```bash
+# Extraire le CSV initial d'une série (langue pivot fr, #1650 Phase 0.5)
+python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/ \
+    -o translations/symbolicai/argument_analysis.csv
+
+# Un seul notebook (POC / review du schéma)
+python scripts/translation/extract_cells_to_csv.py notebook.ipynb -o poc.csv
+```
+
+Exclut `_output.ipynb` (sorties Papermill) et `_agent.ipynb` (auto-générées). Déterministe (re-extract byte-identique).
+
+## check_translation_sync.py (T2)
+
+Détecte le drift entre les notebooks courants et le CSV. **Non-bloquant** (mode CI `--check` : exit 0 même si drift ; le rapport va sur stderr + JSON stdout). Verdicts :
+
+| Verdict | Sens |
+|---------|------|
+| `IN_SYNC` | src_hash et hash_<lang> matchent les notebooks courants |
+| `SRC_DRIFT` | le notebook source a bougé depuis la dernière synchro → retraduction requise |
+| `TRAD_DRIFT` | une traduction a été éditée à la main sans repercussion sur le CSV |
+| `MISSING_LANG` | le notebook `xxx_<lang>.ipynb` n'existe plus alors qu'un hash était déposé |
+| `ORPHAN_ROW` | la ligne CSV référence un `cell_id` absent du notebook source (cellule supprimée) |
+
+```bash
+# Vérifier un CSV (exit 1 si drift)
+python scripts/translation/check_translation_sync.py translations/symbolicai/argument_analysis.csv
+
+# Vérifier tous les CSV (mode CI non-bloquant, exit 0)
+python scripts/translation/check_translation_sync.py translations/ --check
+```
+
+En phase POC (T1, seule la colonne pivot est remplie), le script ne remonte que du `SRC_DRIFT` éventuel ; l'absence de traductions déposées n'est pas un drift (c'est l'état attendu pré-T3). Le pivot (`fr`) étant le notebook source lui-même, sa cohérence est couverte par `SRC_DRIFT` — pas de faux `MISSING_LANG` sur le pivot.
+
+## CI
+
+Le workflow `.github/workflows/translation-drift.yml` tourne sur les PR touchant les notebooks ou `translations/` : il exécute `check_translation_sync.py --check` et surface le drift sous forme d'annotation `notice` (non-bloquant, read-only — même philosophie que `catalog-drift.yml`). La resync elle-même (T3) n'est JAMAIS auto-commitée en CI : elle est proposée par la détection et exécutée manuellement par un agent (moteur Argumentum, #4957 §3).
+
+## Voir aussi
+
+- Issue [#4957](../../../issues/4957) — design de l'infrastructure (schéma, sémantique drift, séquencement T0→T3)
+- Epic [#1650](../../../issues/1650) — traduction multilingue du dépôt

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -60,9 +60,7 @@ def cell_hash(text: str) -> str:
 def load_notebook_cells(nb_path: Path) -> dict[str, str] | None:
     """Retourne {cell_id: hash} pour un notebook, ou None si illisible."""
     try:
-        import json as _json
-
-        nb = _json.loads(nb_path.read_text(encoding="utf-8"))
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     cells: dict[str, str] = {}

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Detect translation drift between notebooks and the sync CSV (Epic #4957 / #1650).
+
+Implements the T2 deliverable of issue #4957 : un script NON-BLOQUANT qui detecte
+quand un notebook source ou une de ses traductions est desynchronise du CSV
+maintenu par `extract_cells_to_csv.py` (T1). Concu pour tourner en CI
+(`.github/workflows/translation-drift.yml`) a la maniere de `catalog-drift.yml` :
+read-only, signale sous forme de rapport + annotation, n'ecrit jamais sur la branche.
+
+Verdicts par ligne CSV (cf. #4957 §2) :
+
+    IN_SYNC      src_hash et hash_<lang> matchent les notebooks courants
+    SRC_DRIFT    le notebook source a bouge depuis la derniere synchro
+                 (current src hash != CSV src_hash) -> retraduction requise
+    TRAD_DRIFT   une traduction a ete editee a la main sans repercussion
+                 (current <lang> hash != CSV hash_<lang>)
+    MISSING_LANG le notebook xxx_<lang>.ipynb n'existe plus alors qu'un hash
+                 etait depose dans le CSV
+    ORPHAN_ROW   la ligne CSV reference un cell_id absent du notebook source
+                 (cellule supprimee)
+
+En phase POC (T1, seule la colonne pivot est remplie), le script ne remonte
+que du SRC_DRIFT eventuel ; l'absence de traductions deposees n'est pas un drift
+(c'est l'etat attendu pre-T3).
+
+Usage :
+    python scripts/translation/check_translation_sync.py translations/<famille>/<serie>.csv
+    python scripts/translation/check_translation_sync.py translations/   # tous les CSV
+    python scripts/translation/check_translation_sync.py translations/ --check   # exit 0 toujours (CI)
+
+Sortie : rapport lisible sur stderr + JSON sur stdout (consommable par la CI).
+Exit code : 0 si --check (non-bloquant), sinon 1 si un drift detecte.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+# Doit rester coherent avec extract_cells_to_csv.py (T1).
+PIVOT_LANG = "fr"
+TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+ALL_LANGS = [PIVOT_LANG] + TARGET_LANGS
+
+
+def normalize(text: str) -> str:
+    """Meme normalisation que extract_cells_to_csv.py (anti faux-drift cosmétique)."""
+    lines = [line.rstrip() for line in text.splitlines()]
+    return "\n".join(lines).strip("\n")
+
+
+def cell_hash(text: str) -> str:
+    return hashlib.sha256(normalize(text).encode("utf-8")).hexdigest()[:16]
+
+
+def load_notebook_cells(nb_path: Path) -> dict[str, str] | None:
+    """Retourne {cell_id: hash} pour un notebook, ou None si illisible."""
+    try:
+        import json as _json
+
+        nb = _json.loads(nb_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    cells: dict[str, str] = {}
+    for cell in nb.get("cells", []):
+        cid = cell.get("id")
+        if not cid or cell.get("cell_type") not in ("markdown", "code"):
+            continue
+        cells[cid] = cell_hash("".join(cell.get("source", [])))
+    return cells
+
+
+def translated_notebook_path(source_path: str, lang: str, repo_root: Path) -> Path:
+    """`dir/foo.ipynb` + lang `en` -> `dir/foo_en.ipynb` (#1650 convention notebooks)."""
+    p = repo_root / source_path
+    return p.with_name(p.stem + f"_{lang}.ipynb")
+
+
+def check_csv(csv_path: Path, repo_root: Path) -> list[dict]:
+    """Verifie un CSV de synchro contre les notebooks courants. Retourne les anomalies."""
+    anomalies: list[dict] = []
+    with csv_path.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        source_cache: dict[str, dict[str, str] | None] = {}
+        for row in reader:
+            nb_rel = row.get("notebook", "")
+            cell_id = row.get("cell_id", "")
+            if not nb_rel or not cell_id:
+                continue
+
+            # Notebook source (cache par chemin).
+            if nb_rel not in source_cache:
+                source_cache[nb_rel] = load_notebook_cells(repo_root / nb_rel)
+            src_cells = source_cache[nb_rel]
+            if src_cells is None:
+                anomalies.append(
+                    {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id,
+                     "verdict": "ORPHAN_ROW", "detail": "notebook source illisible/absent"}
+                )
+                continue
+            if cell_id not in src_cells:
+                anomalies.append(
+                    {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id,
+                     "verdict": "ORPHAN_ROW", "detail": "cell_id absent du notebook source (cellule supprimée)"}
+                )
+                continue
+
+            # SRC_DRIFT : le source a-t-il bougé depuis la dernière synchro ?
+            current_src = src_cells[cell_id]
+            csv_src_hash = row.get("src_hash", "")
+            if csv_src_hash and current_src != csv_src_hash:
+                anomalies.append(
+                    {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id,
+                     "verdict": "SRC_DRIFT",
+                     "detail": f"source modifié (csv={csv_src_hash} <> actuel={current_src}) -> retraduction requise"}
+                )
+
+            # TRAD_DRIFT / MISSING_LANG par langue cible.
+            # Le pivot (fr) EST le notebook source (xxx.ipynb, pas xxx_fr.ipynb) :
+            # sa cohérence est déjà vérifiée par SRC_DRIFT ci-dessus -> on le skippe.
+            for lang in TARGET_LANGS:
+                csv_hash = row.get(f"hash_{lang}", "")
+                if not csv_hash:
+                    continue  # rien déposé = attendu pre-T3, pas un drift.
+                trad_path = translated_notebook_path(nb_rel, lang, repo_root)
+                if not trad_path.exists():
+                    anomalies.append(
+                        {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id, "lang": lang,
+                         "verdict": "MISSING_LANG",
+                         "detail": f"{trad_path.name} absent alors qu'un hash était déposé"}
+                    )
+                    continue
+                trad_cells = load_notebook_cells(trad_path)
+                if trad_cells is None or cell_id not in trad_cells:
+                    anomalies.append(
+                        {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id, "lang": lang,
+                         "verdict": "MISSING_LANG",
+                         "detail": f"cell_id {cell_id} absent de {trad_path.name}"}
+                    )
+                    continue
+                if trad_cells[cell_id] != csv_hash:
+                    anomalies.append(
+                        {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id, "lang": lang,
+                         "verdict": "TRAD_DRIFT",
+                         "detail": f"traduction {lang} éditée (csv={csv_hash} <> actuel={trad_cells[cell_id]})"}
+                    )
+    return anomalies
+
+
+def iter_csvs(target: Path) -> list[Path]:
+    if target.is_file():
+        return [target]
+    return sorted(target.rglob("*.csv"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Détecte le drift de traduction vs le CSV de synchro (non-bloquant, #4957 T2)."
+    )
+    parser.add_argument("input", type=Path, help="Fichier CSV ou répertoire `translations/`.")
+    parser.add_argument(
+        "--repo-root", type=Path, default=None, help="Racine du dépôt (défaut : cwd)."
+    )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Mode CI non-bloquant : exit 0 même si drift détecté (le rapport va sur stderr/JSON).",
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"ERROR : {args.input} introuvable.", file=sys.stderr)
+        return 2
+
+    repo_root = (args.repo_root or Path.cwd()).resolve()
+    csvs = iter_csvs(args.input)
+    if not csvs:
+        # Pas de CSV = phase pre-T1, rien a verifier. CI verte.
+        print(f"INFO : aucun CSV sous {args.input} (phase pre-T1). Rien à vérifier.", file=sys.stderr)
+        print(json.dumps({"csvs_checked": 0, "anomalies": [], "anomaly_count": 0}))
+        return 0
+
+    all_anomalies: list[dict] = []
+    for csv_path in csvs:
+        all_anomalies.extend(check_csv(csv_path, repo_root))
+
+    # Rapport lisible (stderr) + JSON (stdout, consommable CI).
+    report = {
+        "csvs_checked": len(csvs),
+        "anomalies": all_anomalies,
+        "anomaly_count": len(all_anomalies),
+    }
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+    if not all_anomalies:
+        print(f"OK : {len(csvs)} CSV vérifié(s), 0 drift.", file=sys.stderr)
+        return 0
+
+    # Regroupement par verdict pour le rapport stderr.
+    from collections import Counter
+
+    by_verdict = Counter(a["verdict"] for a in all_anomalies)
+    summary = ", ".join(f"{v}={n}" for v, n in by_verdict.items())
+    print(f"DRIFT DETECTE ({len(all_anomalies)} anomalie(s) sur {len(csvs)} CSV) : {summary}", file=sys.stderr)
+    for a in all_anomalies[:20]:
+        print(
+            f"  [{a['verdict']}] {a.get('notebook', '?')} cell={a.get('cell_id', '?')[:10]}"
+            f"{(' lang=' + a['lang']) if 'lang' in a else ''} : {a['detail']}",
+            file=sys.stderr,
+        )
+    if len(all_anomalies) > 20:
+        print(f"  ... et {len(all_anomalies) - 20} autres (voir JSON stdout).", file=sys.stderr)
+
+    return 0 if args.check else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Couche **T2** de l'infrastructure de synchro traduction (**#4957**, Part of **#1650**) : script `scripts/translation/check_translation_sync.py` qui détecte le drift entre les notebooks courants et le CSV de synchre (maintenu par T1 `extract_cells_to_csv.py`), + workflow CI non-bloquant `.github/workflows/translation-drift.yml`.

Acceptance #4957 T2 = **« T2 CI drift-flag livré (non bloquant) »** ✓

## Verdicts de drift (ratified #4957 §2)

| Verdict | Sens |
|---------|------|
| `IN_SYNC` | src_hash et hash_<lang> matchent les notebooks courants |
| `SRC_DRIFT` | le notebook source a bougé depuis la dernière synchro (current ≠ CSV src_hash) → retraduction requise |
| `TRAD_DRIFT` | une traduction a été éditée à la main sans repercussion (current <lang> hash ≠ CSV hash_<lang>) |
| `MISSING_LANG` | le notebook `xxx_<lang>.ipynb` n'existe plus alors qu'un hash était déposé |
| `ORPHAN_ROW` | la ligne CSV référence un `cell_id` absent du notebook source (cellule supprimée) |

**Non-bloquant** : mode CI `--check` → exit 0 même si drift ; rapport JSON sur stdout + lisible sur stderr.

## Validation (3 cas testés firsthand sur CSV manuel crafté)

| Test | Attendu | Obtenu |
|---|---|---|
| Row IN_SYNC (real hash) | 0 anomalie | ✓ 0 |
| Row SRC_DRIFT (bad hash `0000…`) | SRC_DRIFT détecté | ✓ détecté |
| Row ORPHAN_ROW (fake `cell_id`) | ORPHAN_ROW détecté | ✓ détecté |
| Edge: dir sans CSV | exit 0 (pre-T1 phase) | ✓ exit 0 |

**Bug trouvé et corrigé pendant la validation** : le pivot `fr` déclenchait `MISSING_LANG` parce que le notebook source est `xxx.ipynb` (pas `xxx_fr.ipynb`). Fix : skipper le pivot dans la boucle par-langue (sa cohérence est déjà couverte par `SRC_DRIFT`, le pivot étant le source lui-même).

## Workflow CI (translation-drift.yml)

Modelé sur `catalog-drift.yml` (non-bloquant, read-only) :
- Trigger : PR touchant `MyIA.AI.Notebooks/**/*.ipynb`, `translations/**`, ou `scripts/translation/**`
- Checkout + Python 3.11 + `check_translation_sync.py translations --check`
- Drift surfacé comme annotation `::notice` (jamais fail le gate, jamais write to branch)
- Pre-T1 (pas de `translations/` dir) : annotation informational, job vert

**JAMAIS d'auto-commit LLM en CI** (#4957 §3) : la resync est PROPOSÉE par la détection, EXÉCUTÉE manuellement par un agent (moteur Argumentum, T3 gated #1650 Phase 1).

## Documentation

`scripts/translation/README.md` (co-localisé avec les scripts, **zero-conflict** avec T1 #5379 qui édite `scripts/README.md`) documente les 3 couches T1→T2→T3, le schéma CSV, et les deux scripts avec exemples.

## Note merge ordering (ai-01)

**T1 (#5379) devrait merger avant ou en même temps que T2.** Le `scripts/translation/README.md` documente les deux scripts (extract T1 + check T2) comme un workflow cohérent T1→T2→T3. Si T2 mergeait seul, le README référencerait `extract_cells_to_csv.py` (T1) pas encore sur main — mineur (le README frame T1 comme couche séparée avec status table), mais T1-first est plus propre. Les deux sont CLEAN et mergeable indépendamment.

## Scope

Infrastructure/tooling i18n (2e cycle dans la famille, sous le cap pivot R5.4b de 3). Nouveaux fichiers uniquement (0 modif existant). `py_compile` OK, `check_docs_links` OK (0/3381), catalogue byte-identique. Part of #4957 / #1650.

## Acceptance #4957 (cette PR + #5379)

- [ ] Schéma CSV validé par le user (gate-1, #5379 le concretise pour review)
- [ ] Décision Lean (a)/(b)/(c) actée (gate-2, hors-scope)
- [x] T1 POC livré (`extract_cells_to_csv.py`, #5379)
- [x] **T2 CI drift-flag livré (non bloquant)** — cette PR

Co-Authored-By: Claude <noreply@anthropic.com>
