### PR TITLE
docs(search): §E cross-ref drift — Part1/Part2 '21 applications' → 22 (See #4959)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -12,7 +12,7 @@ Trois extensions complètent le panorama. La couverture exacte et les Dancing Li
 
 ## Pourquoi cette partie
 
-Cette partie est l'alphabet de toute la série : la formalisation en espace d'états, le backtracking et les heuristiques qu'on y construit sont réutilisés tels quels par la programmation par contraintes (Partie 2) et par les 21 notebooks d'application. Mais son véritable enseignement est un réflexe d'ingénieur : chaque algorithme y est présenté comme un compromis — complétude contre mémoire, garantie contre temps de calcul, exploration contre exploitation — et jamais comme une recette. C'est ce réflexe, plus que tel ou tel algorithme, qui distingue celui qui applique une bibliothèque de celui qui choisit une stratégie.
+Cette partie est l'alphabet de toute la série : la formalisation en espace d'états, le backtracking et les heuristiques qu'on y construit sont réutilisés tels quels par la programmation par contraintes (Partie 2) et par les 22 notebooks d'application. Mais son véritable enseignement est un réflexe d'ingénieur : chaque algorithme y est présenté comme un compromis — complétude contre mémoire, garantie contre temps de calcul, exploration contre exploitation — et jamais comme une recette. C'est ce réflexe, plus que tel ou tel algorithme, qui distingue celui qui applique une bibliothèque de celui qui choisit une stratégie.
 
 ## Objectifs d'apprentissage
 
@@ -132,7 +132,7 @@ Le véritable enseignement, au-delà du catalogue d'algorithmes, est un **réfle
 ### Prochaines étapes
 
 - **La programmation par contraintes** : la suite naturelle est la [Partie 2 (CSP)](../Part2-CSP/README.md), qui réutilise le backtracking et les heuristiques de cette partie pour propager des contraintes plutôt que d'énumérer — la réduction de l'espace de recherche y devient systématique plutôt qu'heuristique.
-- **Les applications** : les [21 notebooks d'application](../Applications/README.md) (détection de contours, TSP, VRP, optimisation de portefeuille, hyperparameter tuning) mobilisent directement les métaheuristiques et la recherche locale vues ici sur des problèmes réels.
+- **Les applications** : les [22 notebooks d'application](../Applications/README.md) (détection de contours, TSP, VRP, optimisation de portefeuille, hyperparameter tuning) mobilisent directement les métaheuristiques et la recherche locale vues ici sur des problèmes réels.
 - **Les ponts vers les autres séries** : les Dancing Links irriguent [Sudoku](../../Sudoku/README.md), Minimax et MCTS se prolongent dans [GameTheory](../../GameTheory/README.md) (OpenSpiel) puis [RL](../../RL/README.md) (politiques apprises), et les prédicats Z3 de Search-10 ouvrent sur [SymbolicAI](../../SymbolicAI/README.md). Reprendre un de ces ponts après avoir posé les fondations de la recherche donne aux primitives une nouvelle profondeur.
 - **La série dans son ensemble** : le [sommaire Search](../README.md) cartographie les quatre parties et les applications — celle-ci est le socle commun.
 

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -94,7 +94,7 @@ Pour le setup complet, voir le [README de la série Search](../README.md).
 | Solveur CP-SAT trop lent sur les grandes instances | Préférer les contraintes globales (AllDifferent, Cumulative) aux contraintes binaires équivalentes ; utiliser LNS (CSP-3) |
 | Comment choisir entre CP-SAT et un solveur SAT ? | CP-SAT pour les contraintes globales et l'optimisation (objectif), SAT pour la décision pure ; CSP-6 détaille les compromis |
 | CSP-9 : les algorithmes distribués ne convergent pas | Vérifier que le réseau de contraintes est un arbre, ou utiliser AWC (Weak-Commitment) au lieu d'ABT |
-| Où sont les applications concrètes ? | Voir [Applications](../Applications/README.md) : 21 notebooks (N-Queens, Nurse Scheduling, VRP, TSP...) |
+| Où sont les applications concrètes ? | Voir [Applications](../Applications/README.md) : 22 notebooks (N-Queens, Nurse Scheduling, VRP, TSP...) |
 
 ## Ponts vers SymbolicAI
 
@@ -134,7 +134,7 @@ CSP-1 (Fundamentals) ──> CSP-2 (Consistency) ──> CSP-3 (Advanced)
 | Série | Lien | Relation |
 | ------- | ------ | ---------- |
 | [Partie 1 : Search](../Part1-Foundations/README.md) | Fondamentaux | Prérequis : backtracking, heuristiques |
-| [Applications](../Applications/README.md) | 21 notebooks d'application | Mise en pratique des CSP |
+| [Applications](../Applications/README.md) | 22 notebooks d'application | Mise en pratique des CSP |
 | [Search (parent)](../README.md) | Vue d'ensemble | Contexte et parcours global |
 | [Sudoku](../../Sudoku/) | Résolution par contraintes | Application directe des CSP |
 | [SymbolicAI/SMT/Z3](../../SymbolicAI/SMT/Z3/README.md) | Solveur SMT | CSP-6 (LCG) et automates symboliques |
@@ -170,7 +170,7 @@ Le véritable enseignement est une **sensibilité à la modélisation** : le mê
 
 ### Prochaines étapes
 
-- **Les applications** : les [21 notebooks d'application](../Applications/README.md) (N-Queens, Nurse Scheduling, VRP, TSP, Picross, Minesweeper CSP) mettent en pratique CP-SAT sur des problèmes concrets avec benchmark baseline-comparison.
+- **Les applications** : les [22 notebooks d'application](../Applications/README.md) (N-Queens, Nurse Scheduling, VRP, TSP, Picross, Minesweeper CSP) mettent en pratique CP-SAT sur des problèmes concrets avec benchmark baseline-comparison.
 - **Vers le raisonnement symbolique** : la modélisation déclarative de cette partie est le premier contact avec un mode de raisonnement qu'approfondissent [Z3/SMT](../../SymbolicAI/SMT/Z3/README.md) (SMT solving), les [Planners](../../SymbolicAI/Planners/) (PDDL, HTN) et [Tweety](../../SymbolicAI/Tweety/) (logique formelle) côté SymbolicAI. CSP-6 (LCG) fait explicitement le pont vers SAT.
 - **Retour aux fondamentaux** : après avoir vu la puissance de la propagation, reprendre [Search-2 (backtracking)](../Part1-Foundations/Search-2-Uninformed.ipynb) — le DFS y apparaît comme un cas particulier de CSP sans propagation, et l'on mesure le saut qu'apportent AC-3/MAC.
 - **La série dans son ensemble** : le [sommaire Search](../README.md) cartographie les quatre parties et les applications — celle-ci est le socle déclaratif qui prolonge la Partie 1 (recherche) et prépare la Partie 4 (métaheuristiques) et les Applications.


### PR DESCRIPTION
## Summary

Companion to #5383 (root Search/README.md count drift). The Applications count drift (21 → 22, from App-9b/App-10b C# twins) propagated as **cross-references** in the Part feuilles READMEs. Applications/README.md itself already says 22 correctly — these 5 cross-refs in Part1/Part2 were stale.

## §E whole-file audit — 5 cross-ref drifts

| File | Line | Context | Before | After |
|------|------|---------|--------|-------|
| Part1-Foundations/README.md | L15 | intro prose | 21 notebooks d'application | 22 |
| Part1-Foundations/README.md | L135 | "Les applications" ponts | 21 notebooks d'application | 22 |
| Part2-CSP/README.md | L97 | FAQ table | 21 notebooks | 22 |
| Part2-CSP/README.md | L137 | ponts table | 21 notebooks d'application | 22 |
| Part2-CSP/README.md | L173 | "Les applications" ponts | 21 notebooks d'application | 22 |

## Ground truth

`git ls-tree -r origin/main` Applications: **22 notebooks** (20 Python + 2 C#: App-9b-EdgeDetection-CSharp, App-10b-Portfolio-CSharp). Applications/README.md L3/L5 already correctly says "22 notebooks" — these were the only stale cross-references.

## Verification

- [x] §E whole-file audit on `origin/main` (both Part READMEs)
- [x] 0 occurrences "21 notebooks" remaining post-fix (grep verified)
- [x] Applications/README.md cross-checked = 22 (consistent)
- [x] Mermaid fence balance preserved (Part1=2, Part2=4, both even)
- [x] Markdown-only — no code/notebook change (C.2 exception)
- [x] gitleaks clean
- [x] No collision: #5380 adds Search-3 row to Part1 (different lines), #5376 = root notebooks README

## Scope

Atomic §E cross-ref fix, 2 files, 5 lines. Markdown-only. Companion to #5383.

See #4959 (READMEs centraux/intermédiaires)
See #4956 (marathon root cause)
See #3975 (§E whole-file gate)