### PR TITLE
docs(secrets): document WHISPER_API_KEY cross-repo rotation procedure (See #16)

### DIFF
--- a/docs/genai/secrets-management.md
+++ b/docs/genai/secrets-management.md
@@ -68,6 +68,35 @@ Qdrant expose la **même** clé API sous **deux noms** selon le côté :
 
 Les deux noms **doivent porter la même valeur** (sinon 401 côté client). Centraliser le côté client CoursIA permet aux notebooks de suivre la rotation sans action manuelle : `edit master.env → render_envs.py` propage vers `GenAI/.env`. Le **flip de la valeur côté serveur** (rotation effective, Qdrant redémarre avec la nouvelle clé) reste une opération manuelle inter-repo sur `roo-extensions` — tracker séparément, cf [SECURITY.md](../../docker-configurations/SECURITY.md).
 
+### WHISPER_API_KEY — convention client ↔ service + propagation cross-repos
+
+`WHISPER_API_KEY` est un **bearer token partagé** entre le service `whisper-api` (po-2023, port 8190) et ses consommateurs — notebooks CoursIA ET **plusieurs workspaces cross-repo**. Comme Qdrant, sa rotation a deux volets : CoursIA (automatisé) et cross-repo (manuel).
+
+**Côté CoursIA (automatisé via `render_envs.py`) :** `WHISPER_API_KEY` est dans `SECRET_KEYS` et `whisper-api/.env` est un `TARGET_ENV` (glob `services/*/.env`). La rotation suit le [runbook canonique](#rotation-dun-secret-procédure-canonique) ci-dessus — `edit master.env → render_envs.py → docker compose restart whisper-api`. Le compose injecte `API_KEY=${WHISPER_API_KEY:-}` ; l'auth est active (vérifié 2026-07-05 : `POST /v1/audio/transcriptions` sans bearer → 401).
+
+**Côté cross-repo (propagation manuelle) :** le même token est consommé par des workspaces hors CoursIA. Après rotation CoursIA, propager la nouvelle valeur à chaque consommateur (RooSync privé ou édition du `.env`/config local du workspace) :
+
+| Workspace | Usage | Méthode de propagation |
+|-----------|-------|------------------------|
+| `roo-extensions` | sk-agent MCP speech-to-text | config MCP / `.env` local |
+| `myia-open-webui` | Web UI STT | `.env` / config |
+| `hermes-agent` (**repo public**) | pipeline ASR | ⚠️ **JAMAIS dans le repo public** — env var runtime ou RooSync privé (cf incident 2026-05-16 ci-dessous) |
+| `nanoclaw` | pipeline ASR | config locale (cf `nanoclaw-asr-dependency`) |
+
+> Cette liste reflète les consommateurs connus à la dernière rotation (2026-05). **Vérifier le déploiement courant** avant de rotater — un nouveau consommateur aurait pu être ajouté.
+
+**Vérification post-rotation (sur po-2023, après restart du container) :**
+
+```bash
+# Token manquant → 401 (auth active, requête refusée)
+curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:8190/v1/audio/transcriptions
+
+# Token valide → 500 (auth passe, mais pas de fichier audio = attendu)
+curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer <nouveau_token>" -X POST http://localhost:8190/v1/audio/transcriptions
+```
+
+**Incident fondateur (hermes-agent, 2026-05-16) :** un `WHISPER_API_KEY` a fuité via un `.env.example` commité dans le repo **public** `jsboige/hermes-agent`. Résolution : token rotaté, container restarté, fuite corrigée côté hermes-agent. **Règle dure :** dans tout repo public, utiliser des placeholders (`YOUR_API_KEY_HERE`), jamais la valeur réelle — même dans un `.env.example`. Cet incident motive le ⚠️ sur la ligne `hermes-agent` ci-dessus.
+
 ## Secrets par instance (NON centralisés — config service)
 
 Ces secrets sont légitimement **différents par instance** (un mot de passe par container). Ils restent dans le `.env` de leur service et ne sont jamais collapsés :
@@ -97,7 +126,6 @@ Diagnostic erroné "drift bcrypt / plaintext perdu" sur `comfyui-video` → dema
 ## À faire (phase 2, optionnel)
 
 - Brancher `render_envs.py --check` en pre-commit local (hook `pre-commit`, pas CI — `.env` absents du checkout CI).
-- Documenter la rotation `WHISPER_API_KEY` (le token du reverse-proxy IIS `whisper-api.myia.io`) dans la procédure — actuellement dans `docker-configurations/services/whisper-api/.env` + propagation cross-repos (cf mémoire `whisper-token-rotation.md`).
 - Étendre `master.env` aux tokens cross-repos (roo-extensions, hermes-agent) via un master partagé si besoin.
 
 ## Voir aussi


### PR DESCRIPTION
## Summary

Resolves the explicit TODO L100 in `docs/genai/secrets-management.md`: « Documenter la rotation `WHISPER_API_KEY` ... + propagation cross-repos (cf mémoire `whisper-token-rotation.md`). »

This serves the **user mandate for #16 (PRIORITÉ 1)**: « *c'est myia-po-2023:CoursIA qui se charge de gérer tous les containers et les auth/secrets associés. Il faut qu'il le fasse BIEN pour gérer le tout facilement et rotater facilement quand il y a besoin. * »

## What's added

A dedicated `### WHISPER_API_KEY — convention client ↔ service + propagation cross-repos` section paralleling the existing **Qdrant client/server** convention (the architectural sibling: shared bearer token with a CoursIA-automated side + a cross-repo-manual side).

| Aspect | Content |
|--------|---------|
| **CoursIA side** | Automated via `render_envs.py` runbook — `WHISPER_API_KEY` is in `SECRET_KEYS`, `whisper-api/.env` is a `TARGET_ENV` (glob `services/*/.env`). Compose injects `API_KEY=\${WHISPER_API_KEY:-}`. Auth **verified active firsthand 2026-07-05**: `POST /v1/audio/transcriptions` without bearer → 401. |
| **Cross-repo side** | 4 workspaces table (roo-extensions, myia-open-webui, **hermes-agent [PUBLIC repo warning]**, nanoclaw) with propagation method each. |
| **Verification** | Post-rotation curl commands (401 without token = auth working, 500 with token = auth passes, no audio = expected). |
| **Incident** | Founding incident 2026-05-16 (token leaked via `hermes-agent` `.env.example` in **public** repo) + the hard rule: placeholders only in public repos. |

The TODO line is removed from the "À faire (phase 2, optionnel)" section (the other 2 items remain, out of scope).

## Why this is the right grain

- **#16 PRIORITÉ 1** (user mandate) — not a filler doc edit.
- **Explicit doc debt** — the file itself flagged this gap.
- **Firsthand-grounded** — auth state verified live on po-2023 this cycle (not from the 49-day-old memory, which was stale: it said "edit .env directly" but the key is now centralized in master.env via `SECRET_KEYS`).
- **Non-duplicative** — extends existing Qdrant cross-repo pattern, references the canonical runbook (anchor link validated), doesn't restate SECURITY.md.
- **Anti-tunneling R5.4b** — pivot genre: 2 §E-count cycles → 1 security-doc cycle.
- **Not user-blocked** — documenting the procedure is mine to do; the *live* rotation itself would need the user/provider, but that's not what this PR does.

## Verification

- [x] Fence balance preserved (```count = 8, even)
- [x] Anchor link `#rotation-dun-secret-procédure-canonique` → matches existing `## Rotation d'un secret` header (L22)
- [x] **0 secret value in diff** — only placeholders (`<nouveau_token>`), verified against the 2026-05-16 incident token prefixes (`HcE_kr3n`/`ucoQtp68` not present)
- [x] Markdown-only edit (C.2 exception — no notebook re-exec)
- [x] MD060 table-style warning = pre-existing file style (same as Qdrant/per-instance tables, not a regression)
- [x] No collision (0 open PRs touch `docs/genai/secrets-management.md`; #5347/#3160 merged earlier)
- [x] Gitleaks clean (no literals, no `os.getenv("KEY", "<literal>")`)

See #16