### PR TITLE
fix(search): scrub papermill path leak in Search-1-StateSpace-Csharp metadata (See #3436)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
@@ -3698,8 +3698,8 @@
    "end_time": "2026-07-04T13:55:46.900147+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-1-StateSpace-Csharp.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\c--dev-CoursIA-2\\e9bd407d-0c7b-4f6e-a896-677f5f567bcc\\scratchpad\\Search-1-StateSpace-Csharp.executed.ipynb",
+   "input_path": "Search-1-StateSpace-Csharp.ipynb",
+   "output_path": "Search-1-StateSpace-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-04T13:55:40.498880+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Summary

Repo-wide `scrub_papermill_paths.py --scan-all` found **2 absolute machine-local paths** in `metadata.papermill` of `Search-1-StateSpace-Csharp.ipynb` — my own .NET marathon delivery (#4956, c.108-138). This cleans my delivery debt.

## Defect

| Field | Leaked value |
|-------|--------------|
| `metadata.papermill.input_path` | `C:\dev\CoursIA-2\MyIA.AI.Notebooks\Search\Part1-Foundations\Search-1-StateSpace-Csharp.ipynb` |
| `metadata.papermill.output_path` | `C:\Users\jsboi\AppData\Local\Temp\claude\c--dev-CoursIA-2\e9bd407d-...\scratchpad\Search-1-StateSpace-Csharp.executed.ipynb` |

Both scrubbed to the notebook's own basename (`Search-1-StateSpace-Csharp.ipynb`) — the target state for cleanly-executed notebooks (matches e.g. SC-10 canonical).

## Method

`python scripts/notebook_tools/scrub_papermill_paths.py --apply` — text-level surgical edit.

## Verification

- [x] **Surgical guarantee**: diff = `+2/-2`, only `metadata.papermill.input_path`/`output_path` changed (visual diff confirmed)
- [x] **48 cells byte-identical**: `cells: orig=48 cur=48`, **0 cell with source/outputs/execution_count changed** (programmatic check)
- [x] **Stop & Repair respected**: no cell-output scrubbing — `metadata.papermill` is the authorized exception per `secrets-hygiene.md` rule 6, not a cell-output edit
- [x] Post-apply scan: **0 defects** (`scrub_papermill_paths.py --scan`)
- [x] No collision (0 open PR touches this notebook)
- [x] Markdown-only metadata edit (C.2 exception — no re-exec needed)

## Scope

Atomic, 1 file, 2 lines. My own delivery debt (.NET turf). Metadata-only, low-risk.

The other defect found by the repo-wide scan (`ICT-18-ArrowOfTimeReversibilization.ipynb`) is **po-205 turf** (ICT = Python family, owner #4588/#4956-py) — signaled, not touched here (language-based partition).

See #3436