### PR TITLE
fix(ict): scrub papermill path leak in ICT-18 metadata (See #3436)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb
@@ -1297,8 +1297,8 @@
    "end_time": "2026-07-04T12:13:56.972794+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\IIT\\ICT-Series\\ICT-18-ArrowOfTimeReversibilization.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\IIT\\ICT-Series\\ICT-18-ArrowOfTimeReversibilization_output.ipynb",
+   "input_path": "ICT-18-ArrowOfTimeReversibilization.ipynb",
+   "output_path": "ICT-18-ArrowOfTimeReversibilization.ipynb",
    "parameters": {},
    "start_time": "2026-07-04T12:13:52.097462+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## What

Scrub absolute machine-path leak in `ICT-18-ArrowOfTimeReversibilization.ipynb` `metadata.papermill.input_path`/`output_path` (See #3436, residual repo-wide papermill-path sweep).

## Bug (firsthand, on `origin/main` 48c51d31b)

`scrub_papermill_paths.py --scan-all` flags ICT-18 with **2 path leaks**:
- `input_path: C:\dev\CoursIA-2\MyIA.AI.Notebooks\IIT\ICT-Series\ICT-18-ArrowOfTimeReversibilization.ipynb`
- `output_path: C:\dev\CoursIA-2\...\ICT-18-ArrowOfTimeReversibilization_output.ipynb`

The `C:\dev\CoursIA-2\` prefix is the **CoursIA-2 shared-tree checkout** (lane-2 machine path, from execution on that checkout). Leaks the contributor's local directory structure + breaks reproducibility (temp path gone).

## Fix

`scrub_papermill_paths.py --apply` → both paths normalized to basename (`ICT-18-ArrowOfTimeReversibilization.ipynb`), matching the canonical target state (cf SC-10, #5389 Search-1-Csharp).

## Verification (G.1)

- **Surgical**: `git diff` = +2/−2, ONLY `metadata.papermill.input_path`/`output_path` changed. Programmatic check: 4 changed lines, **0 non-metadata-path lines**.
- **0 cell source / outputs / execution_count modified** (Stop & Repair respected — this is the `metadata.papermill` exception, secrets-hygiene rule 6, NOT a cell-output scrub).
- Post-apply scan: **0 defect** on ICT-18.

## Scope

Single file, single notebook, metadata-only. Atomique (R3). Python turf (po-2025 ICT forensic c.31). **po-2023 c.146 explicitly left this residual for po-2025** (language-partition: ICT-Series Python). `Search-1-StateSpace-Csharp` defect NOT touched — po-2023 #5389 (OPEN) already covers it, would collide.

Co-Authored-By: Claude <noreply@anthropic.com>
