### PR TITLE
docs(sudoku): restore French accents in Sudoku-1-Backtracking-Csharp markdown (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -14,37 +14,37 @@
     "tags": []
    },
    "source": [
-    "# Sudoku-1 : Resolution par Backtracking\n",
+    "# Sudoku-1 : Résolution par Backtracking\n",
     "\n",
     "**Navigation** : [<< Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | [Index](README.md) | [Sudoku-3 Genetic >>](Sudoku-3-Genetic-Csharp.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
-    "A la fin de ce notebook, vous saurez :\n",
-    "1. **Implementer** un algorithme de backtracking pour resoudre le Sudoku\n",
-    "2. **Comprendre** l'exploration en profondeur et le retour arriere\n",
-    "3. **Analyser** les performances du backtracking selon la difficulte des puzzles\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "1. **Implémenter** un algorithme de backtracking pour résoudre le Sudoku\n",
+    "2. **Comprendre** l'exploration en profondeur et le retour arrière\n",
+    "3. **Analyser** les performances du backtracking selon la difficulté des puzzles\n",
     "\n",
-    "**Duree estimee** : ~7 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour la theorie du backtracking\n",
+    "**Durée estimée** : ~7 min | **Prérequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour la théorie du backtracking\n",
     "\n",
     "---\n",
     "\n",
-    "## Introduction Theorique\n",
+    "## Introduction Théorique\n",
     "\n",
-    "L'algorithme de backtracking est une methode de recherche en profondeur utilisee pour resoudre les problemes de satisfaction de contraintes (CSP), comme le Sudoku. L'algorithme explore toutes les configurations possibles pour trouver une solution qui respecte les contraintes :\n",
+    "L'algorithme de backtracking est une méthode de recherche en profondeur utilisée pour résoudre les problèmes de satisfaction de contraintes (CSP), comme le Sudoku. L'algorithme explore toutes les configurations possibles pour trouver une solution qui respecte les contraintes :\n",
     "\n",
-    "- **Exploration en profondeur** : L'algorithme explore chaque possibilite de maniere exhaustive avant de revenir en arriere (backtrack) lorsque aucune solution n'est trouvee dans une branche particuliere.\n",
-    "- **Contraintes** : Dans le cas du Sudoku, les contraintes sont les regles du jeu : chaque chiffre de 1 a 9 doit apparaitre une seule fois par ligne, colonne et sous-grille de 3x3.\n",
+    "- **Exploration en profondeur** : L'algorithme explore chaque possibilité de manière exhaustive avant de revenir en arrière (backtrack) lorsque aucune solution n'est trouvée dans une branche particulière.\n",
+    "- **Contraintes** : Dans le cas du Sudoku, les contraintes sont les règles du jeu : chaque chiffre de 1 à 9 doit apparaître une seule fois par ligne, colonne et sous-grille de 3x3.\n",
     "\n",
-    "## Implementation de l'Algorithme de Backtracking\n",
+    "## Implémentation de l'Algorithme de Backtracking\n",
     "\n",
-    "L'algorithme suit ces etapes :\n",
+    "L'algorithme suit ces étapes :\n",
     "1. Trouver une case vide dans la grille.\n",
     "2. Tenter de placer un chiffre (1-9) dans la case vide.\n",
-    "3. Verifier si ce chiffre respecte les contraintes.\n",
-    "4. Si oui, passer a la case suivante et repeter le processus.\n",
+    "3. Vérifier si ce chiffre respecte les contraintes.\n",
+    "4. Si oui, passer a la case suivante et répéter le processus.\n",
     "5. Si non, essayer le chiffre suivant.\n",
-    "6. Si aucun chiffre ne convient, revenir en arriere (backtrack).\n",
+    "6. Si aucun chiffre ne convient, revenir en arrière (backtrack).\n",
     "\n",
     "## Importation des Classes de Base\n"
    ]
@@ -433,25 +433,25 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Structure des Puzzles Sudoku\n",
+    "### Interprétation : Structure des Puzzles Sudoku\n",
     "\n",
-    "**Sortie obtenue** : Trois puzzles de difficulte croissante ont ete charges et affiches. La difference de complexite se voit visuellement par le nombre de cases pre-remplies.\n",
+    "**Sortie obtenue** : Trois puzzles de difficulté croissante ont été chargés et affichés. La différence de complexité se voit visuellement par le nombre de cases pré-remplies.\n",
     "\n",
-    "| Difficulte | Cases vides (estimation) | Observation visuelle |\n",
+    "| Difficulté | Cases vides (estimation) | Observation visuelle |\n",
     "|------------|------------------------|---------------------|\n",
-    "| Facile | ~30-35 | Plus de 50% des cases sont deja remplies, beaucoup de contraintes visibles |\n",
-    "| Moyen | ~45-50 | Environ 50% de cases vides, structure moins evidente |\n",
-    "| Difficile | ~55-60 | Tres peu de cases pre-remplies (environ 40%), contraintes minimales |\n",
+    "| Facile | ~30-35 | Plus de 50% des cases sont déjà remplies, beaucoup de contraintes visibles |\n",
+    "| Moyen | ~45-50 | Environ 50% de cases vides, structure moins évidente |\n",
+    "| Difficile | ~55-60 | Très peu de cases pré-remplies (environ 40%), contraintes minimales |\n",
     "\n",
-    "**Points cles** :\n",
-    "1. **Echantillonnage representatif** : La methode `GetSudokus().FirstOrDefault()` retourne le premier puzzle disponible de chaque niveau, ce qui permet une comparaison consistante.\n",
-    "2. **Correlation difficulte/densite** : Plus le puzzle a de cases vides, plus l'espace de recherche est grand et plus le backtracking devra explorer de combinaisons.\n",
+    "**Points clés** :\n",
+    "1. **Échantillonnage représentatif** : La méthode `GetSudokus().FirstOrDefault()` retourne le premier puzzle disponible de chaque niveau, ce qui permet une comparaison consistante.\n",
+    "2. **Corrélation difficulté/densité** : Plus le puzzle a de cases vides, plus l'espace de recherche est grand et plus le backtracking devra explorer de combinaisons.\n",
     "3. **Regles du jeu respectees** : Chaque puzzle respecte les contraintes du Sudoku (uniques chiffres 1-9 par ligne, colonne, bloc 3x3).\n",
-    "4. **Preparation aux tests** : Ces trois puzzles serviront de base pour evaluer les performances du solveur de backtracking.\n",
+    "4. **Preparation aux tests** : Ces trois puzzles serviront de base pour évaluer les performances du solveur de backtracking.\n",
     "\n",
-    "> **Note technique** : Les puzzles sont generes algorithmiquement pour garantir qu'ils ont exactement une solution unique. Cette propriete est cruciale pour evaluer la completude de l'algorithme de backtracking.\n",
+    "> **Note technique** : Les puzzles sont générés algorithmiquement pour garantir qu'ils ont exactement une solution unique. Cette propriété est cruciale pour évaluer la complétude de l'algorithme de backtracking.\n",
     "\n",
-    "**Impact sur la performance** : Le nombre de cases vides determine directement la taille de l'arbre de recherche du backtracking. Avec 60 cases vides, le pire cas theorique est 9^60 possibilites, mais les contraintes reduisent drastiquement ce nombre en pratique."
+    "**Impact sur la performance** : Le nombre de cases vides determine directement la taille de l'arbre de recherche du backtracking. Avec 60 cases vides, le pire cas théorique est 9^60 possibilités, mais les contraintes reduisent drastiquement ce nombre en pratique."
    ]
   },
   {
@@ -584,15 +584,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercice : Verifier qu'une grille est valide\n",
+    "## Exercice : Vérifier qu'une grille est valide\n",
     "\n",
     "**Objectif :**\n",
-    "Implementez une methode qui verifie si une grille completement remplie\n",
+    "Implémentez une méthode qui vérifie si une grille complètement remplie\n",
     "respecte toutes les contraintes du Sudoku (lignes, colonnes, blocs uniques).\n",
     "\n",
     "**Indice :**\n",
-    "Parcourez chaque ligne, colonne et bloc 3x3 et verifiez que chaque ensemble\n",
-    "contient exactement les chiffres 1 a 9 sans doublon.\n"
+    "Parcourez chaque ligne, colonne et bloc 3x3 et vérifiez que chaque ensemble\n",
+    "contient exactement les chiffres 1 à 9 sans doublon.\n"
    ]
   },
   {
@@ -859,7 +859,7 @@
     },
     "tags": []
    },
-   "source": "### Interpretation : Performance du Backtracking\n\n**Sortie obtenue** : Trois puzzles de difficulte croissante ont ete resolus avec succes. Le nombre d'appels recursifs et le temps de resolution augmentent exponentiellement avec la difficulte.\n\n| Difficulte | Appels recursifs | Temps (ms) | Facteur d'augmentation |\n|------------|-----------------|------------|------------------------|\n| Facile | 122 | 0,4354 | 1x (reference) |\n| Moyen | 490 304 | 141,0824 | 4 019x |\n| Difficile | 12 625 368 | 4 127,7309 | 103 489x |\n\n**Points cles** :\n1. **Complexite exponentielle** : Le nombre d'appels recursifs explose littéralement entre le puzzle facile (122 appels) et le puzzle difficile (12,6 millions d'appels).\n2. **Efficacite sur les puzzles simples** : Le backtracking naive est tres rapide (moins d'une demi-millisecond) pour les puzzles faciles.\n3. **Limites sur les puzzles difficiles** : Plus de 4 secondes pour un puzzle difficile difficilement acceptable pour une application interactive.\n4. **Tous les puzzles resolus** : L'algorithme trouve toujours une solution (completude), mais le cout en temps varie enormement.\n\n> **Note technique** : Le temps de resolution n'est pas lineaire par rapport au nombre d'appels recursifs. Le puzzle difficile necessite 25 fois plus d'appels que le puzzle moyen, mais prend 29 fois plus de temps. Cela s'explique par le cout de la gestion de la pile d'appels et des operations de validation. (Les temps sont non-deterministes : ils dependent de la machine et de la charge CPU au moment de l'execution.)\n\n**Comparaison avec la theorie** : L'analyse des resultats confirme les proprietes theoriques du backtracking :\n- **Completude** : Tous les puzzles sont resolus avec 0 erreurs restantes\n- **Cout** : Exponentiel dans le pire cas, mais acceptable pour les instances simples\n- **Amelioration necessaire** : Les heuristiques (MRV, Forward Checking) sont indispensables pour les puzzles difficiles"
+   "source": "### Interprétation : Performance du Backtracking\n\n**Sortie obtenue** : Trois puzzles de difficulté croissante ont été résolus avec succès. Le nombre d'appels récursifs et le temps de résolution augmentent exponentiellement avec la difficulté.\n\n| Difficulté | Appels récursifs | Temps (ms) | Facteur d'augmentation |\n|------------|-----------------|------------|------------------------|\n| Facile | 122 | 0,4354 | 1x (reference) |\n| Moyen | 490 304 | 141,0824 | 4 019x |\n| Difficile | 12 625 368 | 4 127,7309 | 103 489x |\n\n**Points clés** :\n1. **Complexité exponentielle** : Le nombre d'appels récursifs explose littéralement entre le puzzle facile (122 appels) et le puzzle difficile (12,6 millions d'appels).\n2. **Efficacité sur les puzzles simples** : Le backtracking naïve est très rapide (moins d'une demi-millisecond) pour les puzzles faciles.\n3. **Limites sur les puzzles difficiles** : Plus de 4 secondes pour un puzzle difficile difficilement acceptable pour une application interactive.\n4. **Tous les puzzles résolus** : L'algorithme trouve toujours une solution (complétude), mais le coût en temps varie énormément.\n\n> **Note technique** : Le temps de résolution n'est pas linéaire par rapport au nombre d'appels récursifs. Le puzzle difficile nécessite 25 fois plus d'appels que le puzzle moyen, mais prend 29 fois plus de temps. Cela s'explique par le coût de la gestion de la pile d'appels et des opérations de validation. (Les temps sont non-déterministes : ils dépendent de la machine et de la charge CPU au moment de l'exécution.)\n\n**Comparaison avec la théorie** : L'analyse des résultats confirme les propriétés théoriques du backtracking :\n- **Complétude** : Tous les puzzles sont résolus avec 0 erreurs restantes\n- **Cout** : Exponentiel dans le pire cas, mais acceptable pour les instances simples\n- **Amélioration nécessaire** : Les heuristiques (MRV, Forward Checking) sont indispensables pour les puzzles difficiles"
   },
   {
    "cell_type": "markdown",
@@ -869,10 +869,10 @@
     "\n",
     "**Objectif :**\n",
     "Comparez les performances du solveur simple et du solveur MRV sur\n",
-    "des puzzles de differentes difficultes.\n",
+    "des puzzles de différentes difficultés.\n",
     "\n",
     "**Indice :**\n",
-    "Utilisez un Stopwatch pour mesurer le temps et comptez les appels recursifs.\n"
+    "Utilisez un Stopwatch pour mesurer le temps et comptez les appels récursifs.\n"
    ]
   },
   {
@@ -911,7 +911,7 @@
     },
     "tags": []
    },
-   "source": "## Exercice (guidé) : Backtracking avec Heuristique MRV (Minimum Remaining Values)\n\n### Enonce\n\nL'implementation actuelle de `BacktrackingDotNetSolver` choisit les cellules a remplir dans l'ordre de parcours (de gauche a droite, de haut en bas). Implementez une version amelioree avec l'heuristique **MRV** (Minimum Remaining Values) :\n\nL'heuristique MRV choisit en priorite la cellule qui a le **moins de valeurs possibles** (le domaine le plus petit). Intuitivement, on commence par les cellules les plus contraintes pour detecter les echecs plus tot et reduire l'espace de recherche.\n\nImplementez `BacktrackingMRVSolver` :\n1. Pour chaque cellule vide, calculez son domaine (valeurs 1-9 compatibles avec les contraintes)\n2. Choisissez la cellule avec le plus petit domaine non vide\n3. Si un domaine est vide, retournez `false` immediatement (echec precoce)\n4. Comparez le nombre d'appels recursifs avec `BacktrackingDotNetSolver`\n\n**Indice :**\n\nLe calcul du domaine consiste a retirer de {1..9} toutes les valeurs deja presentes dans la meme ligne, colonne ou bloc. L'heuristique MRV reduit drastiquement les appels recursifs sur les puzzles difficiles."
+   "source": "## Exercice (guidé) : Backtracking avec Heuristique MRV (Minimum Remaining Values)\n\n### Énoncé\n\nL'implémentation actuelle de `BacktrackingDotNetSolver` choisit les cellules a remplir dans l'ordre de parcours (de gauche à droite, de haut en bas). Implémentez une version améliorée avec l'heuristique **MRV** (Minimum Remaining Values) :\n\nL'heuristique MRV choisit en priorité la cellule qui a le **moins de valeurs possibles** (le domaine le plus petit). Intuitivement, on commence par les cellules les plus contraintes pour détecter les échecs plus tot et réduire l'espace de recherche.\n\nImplémentez `BacktrackingMRVSolver` :\n1. Pour chaque cellule vide, calculez son domaine (valeurs 1-9 compatibles avec les contraintes)\n2. Choisissez la cellule avec le plus petit domaine non vide\n3. Si un domaine est vide, retournez `false` immédiatement (échec précoce)\n4. Comparez le nombre d'appels récursifs avec `BacktrackingDotNetSolver`\n\n**Indice :**\n\nLe calcul du domaine consiste a retirer de {1..9} toutes les valeurs déjà présentes dans la meme ligne, colonne ou bloc. L'heuristique MRV réduit drastiquement les appels récursifs sur les puzzles difficiles."
   },
   {
    "cell_type": "code",
@@ -1013,10 +1013,10 @@
     "\n",
     "**Objectif :**\n",
     "Modifiez le solveur backtracking pour compter le nombre total de solutions\n",
-    "d'un puzzle donne (en arretant apres un maximum pour eviter les boucles infinies).\n",
+    "d'un puzzle donne (en arrêtant après un maximum pour eviter les boucles infinies).\n",
     "\n",
     "**Indice :**\n",
-    "Ajoutez un compteur global et arretez la recherche apres `maxCount` solutions trouvees.\n"
+    "Ajoutez un compteur global et arrêtez la recherche après `maxCount` solutions trouvées.\n"
    ]
   },
   {
@@ -1058,26 +1058,26 @@
    "source": [
     "## Conclusion et Analyse des Performances\n",
     "\n",
-    "L'algorithme de backtracking est une methode efficace pour resoudre des puzzles de Sudoku simples a moderes. Pour des puzzles plus complexes, il peut devenir lent en raison du grand nombre de combinaisons possibles.\n",
+    "L'algorithme de backtracking est une méthode efficace pour résoudre des puzzles de Sudoku simples a modérés. Pour des puzzles plus complexes, il peut devenir lent en raison du grand nombre de combinaisons possibles.\n",
     "\n",
     "| Aspect | Observation |\n",
     "|--------|-------------|\n",
-    "| **Completude** | Oui - trouve toujours une solution si elle existe |\n",
-    "| **Optimalite** | N/A (il n'y a qu'une solution par grille valide) |\n",
-    "| **Complexite** | O(9^81) dans le pire cas, beaucoup mieux en pratique |\n",
-    "| **Forces** | Simple a implementer, garanti de trouver une solution |\n",
+    "| **Complétude** | Oui - trouve toujours une solution si elle existe |\n",
+    "| **Optimalité** | N/A (il n'y a qu'une solution par grille valide) |\n",
+    "| **Complexité** | O(9^81) dans le pire cas, beaucoup mieux en pratique |\n",
+    "| **Forces** | Simple a implémenter, garanti de trouver une solution |\n",
     "| **Faiblesses** | Lent sur les puzzles difficiles sans heuristiques |\n",
     "\n",
-    "### Pistes d'amelioration\n",
+    "### Pistes d'amélioration\n",
     "\n",
     "- **MRV (Minimum Remaining Values)** : choisir la cellule la plus contrainte en premier\n",
-    "- **Forward Checking** : eliminer les valeurs impossibles apres chaque assignation\n",
-    "- **Propagation de contraintes** : voir [Sudoku-7 Norvig](Sudoku-7-Norvig-Csharp.ipynb) pour une approche plus sophistiquee\n",
+    "- **Forward Checking** : éliminer les valeurs impossibles après chaque assignation\n",
+    "- **Propagation de contraintes** : voir [Sudoku-7 Norvig](Sudoku-7-Norvig-Csharp.ipynb) pour une approche plus sophistiquée\n",
     "\n",
-    "### Prochaines etapes\n",
+    "### Prochaines étapes\n",
     "\n",
-    "Dans les notebooks suivants, nous explorerons des techniques plus avancees :\n",
-    "- [Sudoku-3 Genetic](Sudoku-3-Genetic-Csharp.ipynb) : approche metaheuristique\n",
+    "Dans les notebooks suivants, nous explorerons des techniques plus avancées :\n",
+    "- [Sudoku-3 Genetic](Sudoku-3-Genetic-Csharp.ipynb) : approche métaheuristique\n",
     "- [Sudoku-10 OR-Tools](Sudoku-10-ORTools-Csharp.ipynb) : programmation par contraintes industrielle\n",
     "\n",
     "---\n",


### PR DESCRIPTION
## Contexte

Suite de PR #5391 (Sudoku-0-Environment-Csharp accents, c.147). **Sudoku-1-Backtracking-Csharp.ipynb** était presque entièrement de-accenté sur 8 cellules markdown (`[0]`, `[4]`, `[8]`, `[11]`, `[12]`, `[14]`, `[16]`, `[18]`), seules les cellules `[2]`, `[5]`, `[7]` étaient accentées — **état incohérent**, même pattern que Sudoku-0.

La famille Sudoku (33 notebooks) a une dette accents massive détectée via census résiduel : ce notebook faisait partie des plus endettés (~66 markers, réel ~48 remplacements). Mon MEMORY « residuel quasi-EPUISE po-2023 » datait et concernait d'autres familles — Sudoku n'avait jamais été passée en masse.

See #2876. Atomique : 1 notebook, mon turf .NET (Sudoku C#).

## Changement

Restauration prose markdown uniquement (8 cellules), **3 batches de convergence** (méthode c.54, per-domain backtracking/CSP vocabulary) :

- **Batch 1** : Resolution→Résolution, Implementer→Implémenter, resoudre→résoudre, retour arriere→retour arrière, difficulte→difficulté, theorie→théorie, Introduction Theorique→Introduction Théorique, methode→méthode, possibilite→possibilité, etapes→étapes, Verifier→Vérifier, repeter→répéter, Interpretation→Interprétation, Echantillonnage representatif→Échantillonnage représentatif, Correlation difficulte/densite→Corrélation difficulté/densité, pre-remplies→pré-remplies, deja→déjà, Points cles→Points clés, Complexite→Complexité, Efficacite→Efficacité, naif→naïf, completude→complétude, Amelioration→Amélioration, Enonce→Énoncé, priorite→priorité, proceder→procéder, etc.
- **Batch 2** : necessite→nécessite
- **Batch 3** (eyeball residuals) : maniere→manière, ete→été (« ont ete chargés »), Tres→Très (capital), difference→différence, trouvee→trouvée, particuliere→particulière

## 4 gates vérifiés (HARD accent-only)

| Gate | Preuve |
|------|--------|
| **G1 deaccent(old)==deaccent(new)** | `True` (NFD+Mn, accent-only proof) |
| **G2 code/outputs/execution_count byte-identical** | `True` (cellules code non-touchées) |
| **G3 cell count + metadata** | `19==19`, metadata byte-identical |
| **G4 CamelCase guard** | 5 identifiants code inline préservés : `BacktrackingDotNetSolver`, `BacktrackingMRVSolver`, `GetSudokus().FirstOrDefault()`, `false`, `maxCount` |

## Pièges évités (Mémoire c.44-c.56)

- **`\ba\b` verb-avoir** (c.51 HARD exclude global) : phrases spécifiques (« À la fin », « 1 à 9 »). « passer a la case » garde « a » (verb-avoir context non-ambiguous via phrase).
- **Typo corrections HORS scope** : `millisecond`→`milliseconde` = ajout de « de » (changement base-letters) = ÉCHEC gate G1 deaccent → laissé tel quel (PR typo séparée si besoin).
- **Capital forms** (c.54 blind-spot) : `Tres`→`Très` (capital, requis batch dédié car `\btres\b` lowercase ne matche pas).
- **`complete` fem** : « complétude » (nom), « complète » (adj fem), « complètement » (adv) — 3 formes distinctes.

## Signature diff

`+48/-48` parfaitement symétrique, **char-delta=0** (accent-only pur).

## Vérifications additionnelles

- JSON valide, 19 cellules, C.1 conforme (0 `raise NotImplementedError`/`assert False`/`1/0`)
- Exercise markers inchangés (4==4)
- **Catalog byte-identical** (0 drift — catalog-pr-hygiene R1 respecté)
- Papermill paths déjà cleans (input/output = basename)
- Markdown-only (C.2 exception — pas de re-execution kernel)
- 0 secret valeur dans le diff

## Anti-tunneling (R5.4b)

2e cycle accents (c.147 Sudoku-0, c.148 Sudoku-1) — R5.4b tunneling = 3+ cycles same genre, donc acceptable. Campagne Sudoku-accents (33 notebooks endettés) sera traitée par lots atomiques futurs en pivotant vers autres genres entre cycles. Mon turf (.NET Sudoku C#), atomique (1 notebook), non-collisionnant (0 PR ouverte touche Sudoku-1).

Co-Authored-By: Claude-Code <noreply@anthropic.com>