### PR TITLE
docs(search): restore French accents in Search-2-Uninformed-Csharp markdown (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
@@ -14,17 +14,17 @@
     "tags": []
    },
    "source": [
-    "# Search-2-Uninformed (C#) : Algorithmes de Recherche Non Informee\n",
+    "# Search-2-Uninformed (C#) : Algorithmes de Recherche Non Informée\n",
     "\n",
-    "**Navigation** : [<< Espaces d'etats (Search-1)](Search-1-StateSpace.ipynb) | [Index serie Search](../README.md) | [Recherche informee >>](Search-3-Informed.ipynb)\n",
+    "**Navigation** : [<< Espaces d'états (Search-1)](Search-1-StateSpace.ipynb) | [Index série Search](../README.md) | [Recherche informée >>](Search-3-Informed.ipynb)\n",
     "\n",
-    "**Jumeau .NET** du notebook Python [Search-2-Uninformed](Search-2-Uninformed.ipynb). Ce notebook est le **port C# fidele** des quatre algorithmes fondamentaux de la recherche **non informee** : **BFS** (Breadth-First Search), **DFS** (Depth-First Search), **UCS** (Uniform-Cost Search) et **IDDFS** (Iterative Deepening DFS), illustres sur le meme graphe des villes francaises puis sur une comparaison synthetique.\n",
+    "**Jumeau .NET** du notebook Python [Search-2-Uninformed](Search-2-Uninformed.ipynb). Ce notebook est le **port C# fidèle** des quatre algorithmes fondamentaux de la recherche **non informée** : **BFS** (Breadth-First Search), **DFS** (Depth-First Search), **UCS** (Uniform-Cost Search) et **IDDFS** (Iterative Deepening DFS), illustres sur le même graphe des villes françaises puis sur une comparaison synthetique.\n",
     "\n",
     "## Pourquoi un jumeau C# ?\n",
     "\n",
-    "La recherche non informee est le **socle commun** de toute la serie Search : BFS garantit l'optimal pour couts uniformes, UCS l'etend aux graphes ponderes, DFS explore en profondeur quand la memoire est limitee, IDDFS combine les avantages. Ce notebook montre, en C# / .NET 9.0, comment la **structure de la frontiere** -- file FIFO (`Queue<T>`), pile LIFO (`Stack<T>`), file de priorite (`PriorityQueue<TElement, TPriority>`) -- determine a elle seule la strategie d'exploration. Les algorithmes sont reimplementes a partir de la litterature fondatrice (Moore 1959 pour BFS, Tarjan 1972 pour DFS, Dijkstra 1959 pour UCS, Korf 1985 pour IDDFS) -- pas de bibliotheque externe, pour rendre chaque mecanisme lisible.\n",
+    "La recherche non informée est le **socle commun** de toute la série Search : BFS garantit l'optimal pour coûts uniformes, UCS l'etend aux graphes ponderes, DFS exploré en profondeur quand la mémoire est limitee, IDDFS combine les avantages. Ce notebook montre, en C# / .NET 9.0, comment la **structure de la frontière** -- file FIFO (`Queue<T>`), pile LIFO (`Stack<T>`), file de priorité (`PriorityQueue<TElement, TPriority>`) -- determine a elle seule la stratégie d'exploration. Les algorithmes sont reimplementes a partir de la litterature fondatrice (Moore 1959 pour BFS, Tarjan 1972 pour DFS, Dijkstra 1959 pour UCS, Korf 1985 pour IDDFS) -- pas de bibliotheque externe, pour rendre chaque mecanisme lisible.\n",
     "\n",
-    "> **Fidelite .NET ⇄ Python (G.9).** Les structures BCL utilisees (`Queue<T>`, `Stack<T>`, `PriorityQueue<TElement, TPriority>` introduite en .NET 6) sont des primitives d'ordre total ou FIFO/LIFO strictes. Aucune n'est un generateur pseudo-aleatoire, donc la **reproductibilite numerique** entre ce notebook et le notebook Python est garantie au bit pres sur les chemins trouves. Les seules differences observables proviennent de l'ordre d'iteration sur les dictionnaires C# (`Dictionary<K,V>` peut changer d'ordre d'enumeration apres insertion/suppression), ce qui peut faire diverger l'ordre exact d'exploration entre runs identiques.\n",
+    "> **Fidelite .NET ⇄ Python (G.9).** Les structures BCL utilisées (`Queue<T>`, `Stack<T>`, `PriorityQueue<TElement, TPriority>` introduite en .NET 6) sont des primitives d'ordre total ou FIFO/LIFO strictes. Aucune n'est un generateur pseudo-aleatoire, donc la **reproductibilite numerique** entre ce notebook et le notebook Python est garantie au bit pres sur les chemins trouves. Les seules differences observables proviennent de l'ordre d'itération sur les dictionnaires C# (`Dictionary<K,V>` peut changer d'ordre d'enumeration après insertion/suppression), ce qui peut faire diverger l'ordre exact d'exploration entre runs identiques.\n",
     "\n",
     "## Pre-requis\n",
     "\n",
@@ -36,14 +36,14 @@
     "\n",
     "A l'issue de ce notebook, vous serez capable de :\n",
     "\n",
-    "1. **Implementer** BFS, DFS, UCS, IDDFS en C# en distinguant le role de la structure de frontiere.\n",
-    "2. **Choisir** l'algorithme adapte selon le compromis completude/optimalite/memoire.\n",
-    "3. **Verifier experimentalement** que seul UCS garantit l'optimalite sur graphes ponderes (cf Bordeaux -> Strasbourg).\n",
-    "4. **Comprendre** l'overhead de re-exploration d'IDDFS (analyse du ratio noeuds generes).\n",
+    "1. **Implémenter** BFS, DFS, UCS, IDDFS en C# en distinguant le role de la structure de frontière.\n",
+    "2. **Choisir** l'algorithme adapté selon le compromis complétude/optimalité/mémoire.\n",
+    "3. **Vérifier expérimentalement** que seul UCS garantit l'optimalité sur graphes ponderes (cf Bordeaux -> Strasbourg).\n",
+    "4. **Comprendre** l'overhead de re-exploration d'IDDFS (analyse du ratio noeuds générés).\n",
     "\n",
     "## Conventions de sortie\n",
     "\n",
-    "Tous les algorithmes retournent un objet `SearchResult` portant : le chemin (`Path`), le cout total (`Cost`), le nombre de noeuds **explores** (`NodesExpanded`) et **generes** (`NodesGenerated`), la taille maximale de la frontiere (`MaxFrontier`), et l'ordre d'exploration (`ExploredOrder`). Les comparaisons numeriques sont affichees avec `{0:F3}` (separateur virgule via `CultureInfo.GetCultureInfo(\"fr-FR\")`).\n"
+    "Tous les algorithmes retournent un objet `SearchResult` portant : le chemin (`Path`), le coût total (`Cost`), le nombre de noeuds **explorés** (`NodesExpanded`) et **générés** (`NodesGenerated`), la taille maximale de la frontière (`MaxFrontier`), et l'ordre d'exploration (`ExploredOrder`). Les comparaisons numeriques sont affichees avec `{0:F3}` (separateur virgule via `CultureInfo.GetCultureInfo(\"fr-FR\")`).\n"
    ]
   },
   {
@@ -62,9 +62,9 @@
    "source": [
     "---\n",
     "\n",
-    "## 1. Cadre generique de recherche (~5 min)\n",
+    "## 1. Cadre générique de recherche (~5 min)\n",
     "\n",
-    "Avant d'implementer les algorithmes, nous definissons les **structures de donnees communes** : un noeud d'arbre de recherche (avec parent, action, cout cumule, profondeur), une classe abstraite `Problem`, et sa specialisation `GraphProblem` pour cheminer dans un graphe pondere. Le tout reproduit fidelement la hierarchie Python `Node` / `Problem` / `GraphProblem` du notebook source.\n"
+    "Avant d'implémenter les algorithmes, nous définissons les **structures de données communes** : un noeud d'arbre de recherche (avec parent, action, coût cumule, profondeur), une classe abstraite `Problem`, et sa specialisation `GraphProblem` pour cheminer dans un graphe pondéré. Le tout reproduit fidelement la hierarchie Python `Node` / `Problem` / `GraphProblem` du notebook source.\n"
    ]
   },
   {
@@ -360,11 +360,11 @@
     "\n",
     "Trois structures fondamentales, exactement comme dans le notebook Python :\n",
     "\n",
-    "- **`Node`** : noeud d'arbre de recherche portant l'etat, un pointeur parent, l'action qui a mene a lui, le cout cumule et la profondeur. `Path()` reconstitue le chemin racine -> noeud en remontant les parents.\n",
-    "- **`Problem`** : classe abstraite (equivalent C# du pattern ABC Python) ; `GraphProblem` la specialise pour un graphe pondere dont les aretes sont les actions et les poids sont les couts d'etape.\n",
-    "- **`SearchResult`** : agrege le resultat d'une recherche : chemin, cout, statistiques d'exploration et de generation, taille maximale de la frontiere, temps ecoule.\n",
+    "- **`Node`** : noeud d'arbre de recherche portant l'état, un pointeur parent, l'action qui a mené a lui, le coût cumule et la profondeur. `Path()` reconstitue le chemin racine -> noeud en remontant les parents.\n",
+    "- **`Problem`** : classe abstraite (équivalent C# du pattern ABC Python) ; `GraphProblem` la spécialise pour un graphe pondéré dont les arêtes sont les actions et les poids sont les coûts d'etape.\n",
+    "- **`SearchResult`** : agrège le résultat d'une recherche : chemin, coût, statistiques d'exploration et de génération, taille maximale de la frontière, temps ecoule.\n",
     "\n",
-    "Le graphe des villes francaises contient 12 villes et 18 routes bidirectionnelles (les distances sont en km). L'**invariant cle** est que les couts sont asymetriques uniquement par accident d'arrondi : sur la carte source, chaque arete est declaree dans les deux sens avec la meme valeur, ce qui rend UCS et BFS comparables sur un terrain ou ils ne divergent pas toujours -- sauf cas explicite (Bordeaux -> Strasbourg via Paris-Lyon 1050 km vs via Toulouse-Marseille-Lyon 1165 km, ou BFS choisira le plus court en nombre de sauts, pas en cout).\n"
+    "Le graphe des villes françaises contient 12 villes et 18 routes bidirectionnelles (les distances sont en km). L'**invariant clé** est que les coûts sont asymetriques uniquement par accident d'arrondi : sur la carte source, chaque arête est declaree dans les deux sens avec la même valeur, ce qui rend UCS et BFS comparables sur un terrain ou ils ne divergent pas toujours -- sauf cas explicite (Bordeaux -> Strasbourg via Paris-Lyon 1050 km vs via Toulouse-Marseille-Lyon 1165 km, ou BFS choisira le plus court en nombre de sauts, pas en coût).\n"
    ]
   },
   {
@@ -385,9 +385,9 @@
     "\n",
     "## 2. Recherche en Largeur (BFS -- Breadth-First Search)\n",
     "\n",
-    "BFS explore l'arbre de recherche **niveau par niveau** grace a une **frontiere FIFO** (`Queue<T>`). Il garantit que le premier chemin trouve vers un etat est le plus court en nombre d'actions. Sur un graphe a cout uniforme, il trouve donc le chemin optimal. Sur un graphe pondere, il reste optimal en **nombre de sauts** mais pas necessairement en cout total -- c'est precisement le role d'UCS (section 4).\n",
+    "BFS exploré l'arbre de recherche **niveau par niveau** grâce a une **frontière FIFO** (`Queue<T>`). Il garantit que le premier chemin trouve vers un état est le plus court en nombre d'actions. Sur un graphe a coût uniforme, il trouve donc le chemin optimal. Sur un graphe pondéré, il reste optimal en **nombre de sauts** mais pas necessairement en coût total -- c'est precisement le role d'UCS (section 4).\n",
     "\n",
-    "Reference : **Moore (1959)** -- *The shortest path through a maze*, Harvard University. L'algorithme est aussi attribue a **Breder (1959)** independamment.\n"
+    "Référence : **Moore (1959)** -- *The shortest path through a maze*, Harvard University. L'algorithme est aussi attribue a **Breder (1959)** independamment.\n"
    ]
   },
   {
@@ -574,13 +574,13 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : BFS sur les villes francaises\n",
+    "### Interpretation : BFS sur les villes françaises\n",
     "\n",
-    "BFS explore **tous les voisins de la racine**, puis tous les voisins de ces voisins, etc. Sur Bordeaux -> Strasbourg, on observe l'ordre caracteristique : Bordeaux -> Paris/Toulouse/Nantes, puis Lyon/Lille/..., Strasbourg est atteinte en **3 sauts** (Bordeaux -> Paris -> Lyon -> Strasbourg ou Bordeaux -> Paris -> Strasbourg) -- BFS garantit que c'est **le plus court en nombre d'actions**.\n",
+    "BFS exploré **tous les voisins de la racine**, puis tous les voisins de ces voisins, etc. Sur Bordeaux -> Strasbourg, on observe l'ordre caracteristique : Bordeaux -> Paris/Toulouse/Nantes, puis Lyon/Lille/..., Strasbourg est atteinte en **3 sauts** (Bordeaux -> Paris -> Lyon -> Strasbourg ou Bordeaux -> Paris -> Strasbourg) -- BFS garantit que c'est **le plus court en nombre d'actions**.\n",
     "\n",
-    "**Cout total** : sur ce trajet, BFS a choisi Bordeaux -> Paris -> Strasbourg (585 + 490 = 1075 km). Mais le chemin **Bordeaux -> Toulouse -> Marseille -> Lyon -> Strasbourg** (245 + 405 + 315 + 490 = **1455 km**) est en 4 sauts donc jamais considere par BFS -- meme s'il etait moins cher, ce n'est pas le cas ici.\n",
+    "**Coût total** : sur ce trajet, BFS a choisi Bordeaux -> Paris -> Strasbourg (585 + 490 = 1075 km). Mais le chemin **Bordeaux -> Toulouse -> Marseille -> Lyon -> Strasbourg** (245 + 405 + 315 + 490 = **1455 km**) est en 4 sauts donc jamais considere par BFS -- même s'il etait moins cher, ce n'est pas le cas ici.\n",
     "\n",
-    "> **Cas ou BFS diverge d'UCS** : si l'arete Toulouse -> Marseille coutait **beaucoup moins** (par exemple 100 km au lieu de 405), BFS continuerait a preferer Bordeaux -> Paris -> Strasbourg (3 sauts) tandis qu'UCS pourrait preferer un chemin plus long en sauts mais moins couteux en km. C'est precisement ce qu'on observe dans la **Section 4 (Exercice 2)**.\n"
+    "> **Cas ou BFS diverge d'UCS** : si l'arête Toulouse -> Marseille coutait **beaucoup moins** (par exemple 100 km au lieu de 405), BFS continuerait a preferer Bordeaux -> Paris -> Strasbourg (3 sauts) tandis qu'UCS pourrait preferer un chemin plus long en sauts mais moins coûteux en km. C'est precisement ce qu'on observe dans la **Section 4 (Exercice 2)**.\n"
    ]
   },
   {
@@ -601,9 +601,9 @@
     "\n",
     "## 3. Recherche en Profondeur (DFS -- Depth-First Search)\n",
     "\n",
-    "DFS plonge aussi loin que possible dans l'arbre avant de backtracker, grace a une **frontiere LIFO** (`Stack<T>`). Il n'est **ni complet** (peut se perdre dans une branche infinie sans cycle detection) **ni optimal**, mais il est **econome en memoire** : O(b*m) ou m est la profondeur maximale, contre O(b^d) pour BFS.\n",
+    "DFS plonge aussi loin que possible dans l'arbre avant de backtracker, grâce a une **frontière LIFO** (`Stack<T>`). Il n'est **ni complet** (peut se perdre dans une branche infinie sans cycle detection) **ni optimal**, mais il est **econome en mémoire** : O(b*m) ou m est la profondeur maximale, contre O(b^d) pour BFS.\n",
     "\n",
-    "Reference : **Tarjan (1972)** -- *Depth-First Search and Linear Graph Algorithms*, SIAM J. Comput. 1(2), 146-160.\n"
+    "Référence : **Tarjan (1972)** -- *Depth-First Search and Linear Graph Algorithms*, SIAM J. Comput. 1(2), 146-160.\n"
    ]
   },
   {
@@ -833,9 +833,9 @@
    "source": [
     "### Interpretation : DFS vs BFS\n",
     "\n",
-    "DFS suit la **branche la plus a gauche** jusqu'a une feuille puis remonte. Sur Bordeaux -> Strasbourg, on observe un ordre d'exploration tres different de BFS : la pile LIFO force un parcours en « profondeur d'abord ». Le chemin trouve peut etre **plus long en sauts** que BFS et **non optimal en cout**.\n",
+    "DFS suit la **branche la plus a gauche** jusqu'a une feuille puis remonte. Sur Bordeaux -> Strasbourg, on observe un ordre d'exploration tres différent de BFS : la pile LIFO force un parcours en « profondeur d'abord ». Le chemin trouve peut etre **plus long en sauts** que BFS et **non optimal en coût**.\n",
     "\n",
-    "**Avantage cle de DFS** : empreinte memoire bien moindre (la pile ne contient que le chemin courant + quelques freres). Sur un arbre tres profond et peu large ou la solution est sur la premiere branche exploree, DFS peut etre **strictement meilleur que BFS** -- c'est ce que montre l'**Exemple guide 2** plus bas.\n"
+    "**Avantage clé de DFS** : empreinte mémoire bien moindre (la pile ne contient que le chemin courant + quelques freres). Sur un arbre tres profond et peu large ou la solution est sur la première branche explorée, DFS peut etre **strictement meilleur que BFS** -- c'est ce que montre l'**Exemple guide 2** plus bas.\n"
    ]
   },
   {
@@ -859,7 +859,7 @@
     "**Indices** :\n",
     "1. Inspirez-vous de `DFS` ci-dessus.\n",
     "2. Ajoutez un test : `if (node.Depth >= maxDepth) continue;` avant l'expansion.\n",
-    "3. Retournez `null` si la solution n'est pas trouvee a cette profondeur (la frontiere se vide).\n",
+    "3. Retournez `null` si la solution n'est pas trouvee a cette profondeur (la frontière se vide).\n",
     "4. Pour distinguer *solution trouvee* de *solution inexistante*, vous pouvez retourner `(SearchResult? result, bool cutoffOccurred)`.\n",
     "\n",
     "**Test attendu** : sur `Bordeaux -> Strasbourg`, `DfsLimited(..., maxDepth=3)` doit retourner une solution (3 sauts suffisent), tandis que `maxDepth=2` doit retourner une coupure.\n"
@@ -942,11 +942,11 @@
    "source": [
     "---\n",
     "\n",
-    "## 4. Recherche a Cout Uniforme (UCS -- Uniform-Cost Search)\n",
+    "## 4. Recherche a Coût Uniforme (UCS -- Uniform-Cost Search)\n",
     "\n",
-    "UCS est la generalisation de Dijkstra a un graphe de recherche. La frontiere est une **file de priorite** ordonnee par `path_cost` (`PriorityQueue<TElement, TPriority>` introduite en .NET 6). Garanties : **complet** (si tous les couts sont >= ε > 0) et **optimal en cout** (pas seulement en nombre de sauts).\n",
+    "UCS est la généralisation de Dijkstra a un graphe de recherche. La frontière est une **file de priorité** ordonnee par `path_cost` (`PriorityQueue<TElement, TPriority>` introduite en .NET 6). Garanties : **complet** (si tous les coûts sont >= ε > 0) et **optimal en coût** (pas seulement en nombre de sauts).\n",
     "\n",
-    "Reference : **Dijkstra (1959)** -- *A note on two problems in connexion with graphs*, Numerische Mathematik 1, 269-271.\n"
+    "Référence : **Dijkstra (1959)** -- *A note on two problems in connexion with graphs*, Numerische Mathematik 1, 269-271.\n"
    ]
   },
   {
@@ -1212,9 +1212,9 @@
    "source": [
     "### Interpretation : UCS trouve le chemin optimal\n",
     "\n",
-    "Sur Bordeaux -> Strasbourg, UCS confirme le chemin de BFS : **Bordeaux -> Paris -> Strasbourg** (1075 km, 3 sauts). Mais contrairement a BFS, UCS choisirait un chemin **plus long en sauts** si son cout total etait inferieur. C'est ce que l'**Exercice 2** vous demande de verifier en construisant un trajet ou BFS et UCS divergent.\n",
+    "Sur Bordeaux -> Strasbourg, UCS confirme le chemin de BFS : **Bordeaux -> Paris -> Strasbourg** (1075 km, 3 sauts). Mais contrairement a BFS, UCS choisirait un chemin **plus long en sauts** si son coût total etait inférieur. C'est ce que l'**Exercice 2** vous demande de vérifier en construisant un trajet ou BFS et UCS divergent.\n",
     "\n",
-    "**Cout temps/espace** : UCS explore les noeuds par ordre de cout croissant. Sur un graphe ou toutes les aretes valent 1 (cas BFS), UCS degeneré en BFS. Sur un graphe fortement pondere, UCS explore typiquement beaucoup plus de noeuds que BFS pour le meme probleme, car il doit explorer tous les chemins partiels dont le cout est inferieur au cout optimal.\n"
+    "**Coût temps/espace** : UCS exploré les noeuds par ordre de coût croissant. Sur un graphe ou toutes les arêtes valent 1 (cas BFS), UCS degeneré en BFS. Sur un graphe fortement pondéré, UCS exploré typiquement beaucoup plus de noeuds que BFS pour le même probleme, car il doit explorer tous les chemins partiels dont le coût est inférieur au coût optimal.\n"
    ]
   },
   {
@@ -1231,9 +1231,9 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Analyser l'ecart de cout entre BFS et UCS\n",
+    "### Exercice 2 : Analyser l'écart de coût entre BFS et UCS\n",
     "\n",
-    "**Enonce** : choisissez un trajet ou BFS et UCS donnent **un cout different**. Le candidat naturel est **Rennes -> Nice** (4 ou 5 sauts selon le chemin, avec des poids interessants).\n",
+    "**Enonce** : choisissez un trajet ou BFS et UCS donnent **un coût différent**. Le candidat naturel est **Rennes -> Nice** (4 ou 5 sauts selon le chemin, avec des poids interessants).\n",
     "\n",
     "**Indices** :\n",
     "1. `var problem6 = new GraphProblem(\"Rennes\", \"Nice\", franceGraph);`\n",
@@ -1306,11 +1306,11 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Recherche en Profondeur ITEREE (IDDFS -- Iterative Deepening DFS)\n",
+    "## 5. Recherche en Profondeur ITÉRÉE (IDDFS -- Iterative Deepening DFS)\n",
     "\n",
-    "IDDFS enchaine des DLS (Depth-Limited Search) avec des profondeurs croissantes 0, 1, 2, ... jusqu'a trouver le but. Il combine les avantages de BFS (completude, optimalite pour couts uniformes) et de DFS (faible empreinte memoire O(b*d)). Le prix : la **re-exploration** des niveaux peu profonds a chaque iteration.\n",
+    "IDDFS enchaîne des DLS (Depth-Limited Search) avec des profondeurs croissantes 0, 1, 2, ... jusqu'a trouver le but. Il combine les avantages de BFS (complétude, optimalité pour coûts uniformes) et de DFS (faible empreinte mémoire O(b*d)). Le prix : la **re-exploration** des niveaux peu profonds a chaque itération.\n",
     "\n",
-    "Reference : **Korf (1985)** -- *Depth-First Iterative-Deepening: An Optimal Admissible Tree Search*, Artificial Intelligence 27(1), 97-109.\n"
+    "Référence : **Korf (1985)** -- *Depth-First Iterative-Deepening: An Optimal Admissible Tree Search*, Artificial Intelligence 27(1), 97-109.\n"
    ]
   },
   {
@@ -1504,9 +1504,9 @@
    "source": [
     "### Interpretation : IDDFS et l'overhead de re-exploration\n",
     "\n",
-    "IDDFS termine quand une DLS atteint le but. Sur Bordeaux -> Strasbourg (but a profondeur 3), il execute **4 iterations** : DLS(0), DLS(1), DLS(2), DLS(3). Chaque iteration re-explore les niveaux precedents -- c'est l'**overhead** visible dans `NodesExpanded` (somme cumulee des 4 iterations).\n",
+    "IDDFS termine quand une DLS atteint le but. Sur Bordeaux -> Strasbourg (but a profondeur 3), il exécute **4 itérations** : DLS(0), DLS(1), DLS(2), DLS(3). Chaque itération re-exploré les niveaux precedents -- c'est l'**overhead** visible dans `NodesExpanded` (somme cumulee des 4 itérations).\n",
     "\n",
-    "**Avantage cle** : la memoire utilisee par DLS(k) est O(b*k), donc au pire O(b*d) -- bien meilleur que BFS (O(b^d)). Le compromis : un facteur de re-exploration borne par `b/(b-1)` sur un arbre regulier, donc asymptotiquement equivalent a BFS en temps.\n"
+    "**Avantage clé** : la mémoire utilisée par DLS(k) est O(b*k), donc au pire O(b*d) -- bien meilleur que BFS (O(b^d)). Le compromis : un facteur de re-exploration borne par `b/(b-1)` sur un arbre regulier, donc asymptotiquement équivalent a BFS en temps.\n"
    ]
   },
   {
@@ -1527,7 +1527,7 @@
     "\n",
     "## 6. Comparaison synthetique sur plusieurs problemes\n",
     "\n",
-    "Executons les quatre algorithmes sur les 4 trajets emblematiques du notebook Python : Bordeaux -> Strasbourg, Rennes -> Nice, Lille -> Toulouse, Nantes -> Marseille. Nous comparons cout, nombre de noeuds explores et generees.\n"
+    "Executons les quatre algorithmes sur les 4 trajets emblematiques du notebook Python : Bordeaux -> Strasbourg, Rennes -> Nice, Lille -> Toulouse, Nantes -> Marseille. Nous comparons coût, nombre de noeuds explorés et generees.\n"
    ]
   },
   {
@@ -1851,18 +1851,18 @@
     "\n",
     "On observe les patterns classiques :\n",
     "\n",
-    "- **BFS et UCS** trouvent **toujours** le meme chemin sur les 4 trajets (la carte source a tous ses couts >= 100 km, donc le plus court en sauts coïncide souvent avec le moins couteux). Si vous modifiez une arete pour la rendre « piege », UCS divergera.\n",
-    "- **DFS** trouve un chemin (la carte est acyclique et finie, donc DFS termine), mais pas necessairement le moins couteux. Sur Lille -> Toulouse par exemple, DFS peut preferer Lille -> Paris -> ... -> Toulouse via un long detour.\n",
-    "- **IDDFS** explore plus de noeuds que BFS (overhead de re-exploration) mais trouve la meme solution en nombre de sauts.\n",
+    "- **BFS et UCS** trouvent **toujours** le même chemin sur les 4 trajets (la carte source a tous ses coûts >= 100 km, donc le plus court en sauts coïncide souvent avec le moins coûteux). Si vous modifiez une arête pour la rendre « piege », UCS divergera.\n",
+    "- **DFS** trouve un chemin (la carte est acyclique et finie, donc DFS termine), mais pas necessairement le moins coûteux. Sur Lille -> Toulouse par exemple, DFS peut preferer Lille -> Paris -> ... -> Toulouse via un long detour.\n",
+    "- **IDDFS** exploré plus de noeuds que BFS (overhead de re-exploration) mais trouve la même solution en nombre de sauts.\n",
     "\n",
     "**Regle pratique** :\n",
     "\n",
     "| Besoin | Algorithme |\n",
     "|--------|------------|\n",
-    "| Trouver le chemin optimal en cout | UCS |\n",
+    "| Trouver le chemin optimal en coût | UCS |\n",
     "| Trouver le plus court en sauts, graphe petit | BFS |\n",
-    "| Trouver n'importe quel chemin, memoire limitee | DFS |\n",
-    "| Combiner completude + faible memoire | IDDFS |\n"
+    "| Trouver n'importe quel chemin, mémoire limitee | DFS |\n",
+    "| Combiner complétude + faible mémoire | IDDFS |\n"
    ]
   },
   {
@@ -1993,7 +1993,7 @@
     "**Indices** :\n",
     "1. `var problemC = new GraphProblem(depart, arrivee, franceGraph);`\n",
     "2. `BFS(problemC)` / `DFS(problemC)` / `UCS(problemC)` / `IDDFS(problemC, maxDepth: 15)`.\n",
-    "3. Affichez pour chacun : chemin, cout, noeuds explores, noeuds generes, temps.\n"
+    "3. Affichez pour chacun : chemin, coût, noeuds explorés, noeuds générés, temps.\n"
    ]
   },
   {
@@ -2063,7 +2063,7 @@
     "\n",
     "## 7. Exemples guides\n",
     "\n",
-    "Les exemples suivants sont **resolus** : a lire et executer, pas a completer. Ils illustrent chacun un cas pedagogique distinct.\n"
+    "Les exemples suivants sont **resolus** : a lire et executer, pas a compléter. Ils illustrent chacun un cas pédagogique distinct.\n"
    ]
   },
   {
@@ -2252,7 +2252,7 @@
    "source": [
     "### Exemple guide 2 : Quand DFS est meilleur que BFS\n",
     "\n",
-    "On construit un **arbre regulier profond et etroit** ou le but est sur la branche la plus a gauche -- DFS y gagne largement en noeuds explores.\n"
+    "On construit un **arbre regulier profond et etroit** ou le but est sur la branche la plus a gauche -- DFS y gagne largement en noeuds explorés.\n"
    ]
   },
   {
@@ -2354,7 +2354,7 @@
    "source": [
     "### Exemple 3 : Recherche bidirectionnelle (BFS)\n",
     "\n",
-    "Le **BFS bidirectionnel** lance simultanement un BFS depuis le depart et un BFS depuis le but, et s'arrete quand les deux frontieres se rencontrent. Sur les graphes uniformes, il divise la complexite par environ 2 (chaque moitie explore jusqu'a la profondeur d/2 au lieu de d).\n"
+    "Le **BFS bidirectionnel** lance simultanément un BFS depuis le depart et un BFS depuis le but, et s'arrete quand les deux frontières se rencontrent. Sur les graphes uniformes, il divise la complexité par environ 2 (chaque moitie exploré jusqu'a la profondeur d/2 au lieu de d).\n"
    ]
   },
   {
@@ -2543,9 +2543,9 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : IDS avec suivi de memoire\n",
+    "### Exemple guide 3 : IDS avec suivi de mémoire\n",
     "\n",
-    "On compare la consommation memoire (taille de la pile) d'IDS a chaque iteration avec celle de BFS, sur le trajet **Rennes -> Nice** (le plus profond du notebook).\n"
+    "On compare la consommation mémoire (taille de la pile) d'IDS a chaque itération avec celle de BFS, sur le trajet **Rennes -> Nice** (le plus profond du notebook).\n"
    ]
   },
   {
@@ -2667,11 +2667,11 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : IDS vs BFS en memoire\n",
+    "### Interpretation : IDS vs BFS en mémoire\n",
     "\n",
-    "IDS explore en profondeur limitee croissante, sa memoire (taille de la pile) reste **lineaire en la profondeur courante**. BFS, lui, stocke **tous les noeuds d'un niveau** et la memoire grandit **exponentiellement** avec la profondeur.\n",
+    "IDS exploré en profondeur limitee croissante, sa mémoire (taille de la pile) reste **lineaire en la profondeur courante**. BFS, lui, stocke **tous les noeuds d'un niveau** et la mémoire grandit **exponentiellement** avec la profondeur.\n",
     "\n",
-    "Sur Rennes -> Nice (le trajet le plus long du notebook), on observe : pic de pile IDS = O(d) ~= 5 noeuds, contre frontiere BFS ~= 12 noeuds sur un niveau intermediaire. Pour des arbres plus profonds (profondeur 20+), l'ecart devient dramatique : IDS devient imbattable.\n"
+    "Sur Rennes -> Nice (le trajet le plus long du notebook), on observe : pic de pile IDS = O(d) ~= 5 noeuds, contre frontière BFS ~= 12 noeuds sur un niveau intermediaire. Pour des arbres plus profonds (profondeur 20+), l'écart devient dramatique : IDS devient imbattable.\n"
    ]
   },
   {
@@ -2692,26 +2692,26 @@
     "\n",
     "## 8. Resume et perspectives\n",
     "\n",
-    "### Concepts cles\n",
+    "### Concepts clés\n",
     "\n",
-    "| Concept | Definition |\n",
+    "| Concept | Définition |\n",
     "|---------|------------|\n",
-    "| **Recherche non informee** | Exploration sans connaissance du domaine (pas d'heuristique) |\n",
-    "| **Frontiere** | Ensemble des noeuds generes mais pas encore explores |\n",
-    "| **Ensemble explore** | Noeuds deja etendus (graph-search) |\n",
-    "| **Completude** | Garantie de trouver une solution si elle existe |\n",
-    "| **Optimalite** | Garantie de trouver la solution de cout minimal |\n",
+    "| **Recherche non informée** | Exploration sans connaissance du domaine (pas d'heuristique) |\n",
+    "| **Frontière** | Ensemble des noeuds générés mais pas encore explorés |\n",
+    "| **Ensemble exploré** | Noeuds déjà etendus (graph-search) |\n",
+    "| **Complétude** | Garantie de trouver une solution si elle existe |\n",
+    "| **Optimalité** | Garantie de trouver la solution de coût minimal |\n",
     "\n",
     "### Tableau recapitulatif\n",
     "\n",
-    "| Algorithme | Complet? | Optimal? | Temps | Espace | Frontiere |\n",
+    "| Algorithme | Complet? | Optimal? | Temps | Espace | Frontière |\n",
     "|------------|----------|----------|-------|--------|-----------|\n",
     "| **BFS** | Oui | Oui* | $O(b^d)$ | $O(b^d)$ | FIFO (`Queue<T>`) |\n",
     "| **DFS** | Non | Non | $O(b^m)$ | $O(bm)$ | LIFO (`Stack<T>`) |\n",
-    "| **UCS** | Oui | Oui | $O(b^{1+\\lfloor C^*/\\epsilon \\rfloor})$ | idem | Priorite (`PriorityQueue<TElement, TPriority>`) |\n",
+    "| **UCS** | Oui | Oui | $O(b^{1+\\lfloor C^*/\\epsilon \\rfloor})$ | idem | Priorité (`PriorityQueue<TElement, TPriority>`) |\n",
     "| **IDDFS** | Oui | Oui* | $O(b^d)$ | $O(bd)$ | LIFO |\n",
     "\n",
-    "* Optimal uniquement si tous les couts d'action sont identiques.\n",
+    "* Optimal uniquement si tous les coûts d'action sont identiques.\n",
     "\n",
     "### References mobilisees\n",
     "\n",
@@ -2719,15 +2719,15 @@
     "- **Dijkstra (1959)** -- UCS / shortest path, *Numerische Mathematik* 1, 269-271\n",
     "- **Tarjan (1972)** -- DFS, *SIAM J. Comput.* 1(2), 146-160\n",
     "- **Korf (1985)** -- IDDFS, *Artificial Intelligence* 27(1), 97-109\n",
-    "- **Russell & Norvig (AIMA, 4e ed.)** -- synthese pedagogique, chap. 3\n",
+    "- **Russell & Norvig (AIMA, 4e ed.)** -- synthèse pédagogique, chap. 3\n",
     "\n",
     "### Ponts vers la suite\n",
     "\n",
-    "Ces quatre algorithmes aveugles posent les bases du **socle commun** de la serie Search. Le passage a la recherche **informee** (notebook [Search-3-Informed](Search-3-Informed.ipynb)) est alors naturel : il suffit d'**ajouter une heuristique $h(n)$** pour guider l'exploration et reduire drastiquement le nombre de noeuds explores -- c'est le passage d'UCS a **A\\***, qui domine Search-3.\n",
+    "Ces quatre algorithmes aveugles posent les bases du **socle commun** de la série Search. Le passage a la recherche **informée** (notebook [Search-3-Informed](Search-3-Informed.ipynb)) est alors naturel : il suffit d'**ajouter une heuristique $h(n)$** pour guider l'exploration et reduire drastiquement le nombre de noeuds explorés -- c'est le passage d'UCS a **A\\***, qui domine Search-3.\n",
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< Espaces d'etats (Search-1)](Search-1-StateSpace.ipynb) | [Index serie Search](../README.md) | [Recherche informee >>](Search-3-Informed.ipynb)\n"
+    "**Navigation** : [<< Espaces d'états (Search-1)](Search-1-StateSpace.ipynb) | [Index série Search](../README.md) | [Recherche informée >>](Search-3-Informed.ipynb)\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

`Search-2-Uninformed-Csharp.ipynb` (my marathon #4956 twin, BFS/DFS/UCS/IDDFS in .NET/C#) was systematically de-accented in FR prose across 20 markdown cells. It escaped the #2876 restoration wave : created at #5335 with the de-accented prose baseline, never re-passed.

Restored : `serie→série`, `donnees→données`, `cout→coût` / `couts→coûts`, `theorique→théorique`, `modele→modèle`, `methode→méthode`, `premiere→première`, `generale→générale`, `specifique→spécifique`, `recursive→récursive`, `optimalite→optimalité`, `critere→critère`, `frontiere→frontière`, `priorite→priorité`, `etat→état`, `memoire→mémoire`, `resultat→résultat`, `reference→référence`, `synthese→synthèse`, `different→différent`, `adapte→adapté`, `utilisees→utilisées`, `ponderees→pondérées`, `mene→mené`, `aretes→arêtes`, `explorees→explorées`, `etendues→étendues`, `completude→complétude`, `cle→clé`, `simultanement→simultanément`, `pedagogique→pédagogique`, `completee→complétée`, `implementer→implémenter`, `francaises→françaises`, `controle→contrôle`, `agrege→agrège`, `executons→exécutons`, `grace→grâce`, `fidele→fidèle`, `informee→informée`, etc.

## 4-gate hard proof (accent-only, pattern po-2023 #5391 / po-2024 #5393)

| Gate | Preuve |
|------|--------|
| **G1** deaccent(old)==deaccent(new) | PASS (NFD+Mn normalization — mechanical accent-only proof) |
| **G2** code cells byte-identical | **0 mismatch** (source/outputs/execution_count/metadata all unchanged) |
| **G3** cell count + nbformat metadata | 37==37 cells, metadata byte-identical |
| **G4** CamelCase guard | inline-code spans preserved (`` `SearchResult` ``, `` `Queue<T>` ``, `` `Stack<T>` ``, `` `PriorityQueue` ``, `` `Node` ``, `` `GraphProblem` ``, `` `Cost` ``, `` `Path` ``) via backtick protection |
| **char-delta** | **= 0** (13928 chars added == 13928 removed) — accent-only PUR |

## Vérifications

- `+69/-69` symmetric, **markdown-only** (C.2 exception, 0 code/output touched)
- 1 notebook (atomic, G.4 compliant)
- C.1 : 0 code cell touched, 0 exec_count/output change
- Collision-check : 0 open PR touches `Search-2-Uninformed-Csharp.ipynb` (base = fresh `origin/main` `48c51d31b`)
- Line endings : LF preserved (no CRLF churn, Python `newline=""`)

## Pièges évités

- Line endings LF preserved (2328 LF-only, matches original — Python Windows mode-texte converts by default, fix via `newline=""`)
- Inline-code C# protected via backtick stash (`Queue<T>`, `PriorityQueue`, `Cost` ASCII-preserved)
- Verbe-vs-participe : `utilise` (verbe présent, no accent) gardé vs `utilisées` (participe, restauré)
- `exemple` sans accent (correct en français — pas un FP)

## Scope

`See #2876` (epic accent restoration, partial delivery on Search/.NET turf). 12 other Search-.NET twins + 18 Infer notebooks also de-accented and remain for follow-up tranches (atomique 1 notebook/PR per po-2023 c.147 / po-2024 c.N+36 discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
