### PR TITLE
fix(probas): repair DecInfer-9 broken cross-reference to DecPyMC-7

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "| Notebook | Contenu |\n",
     "|----------|---------|\n",
-    "| [**PyMC-7 (Python)**](../PyMC/PyMC-7-Sequential.ipynb) | Implementation : bandits, Gittins, UCB, Thompson Sampling |\n",
+    "| [**DecPyMC-7 (Python)**](../PyMC/DecPyMC-7-Sequential.ipynb) | Implementation : bandits, Gittins, UCB, Thompson Sampling |\n",
     "| **DecInfer-9 (Lean)** (ce notebook) | Formalisation : types, lemmes, theoreme d'optimalite |\n",
     "\n",
     "### Duree estimee : 60 minutes"


### PR DESCRIPTION
## Problem

`DecInfer-9-Lean-Gittins.ipynb` cell[0] "Correspondance Python / Lean (bandits multi-bras)" table contained a broken link:

- Link: `[**PyMC-7 (Python)**](../PyMC/PyMC-7-Sequential.ipynb)` → target **does not exist**
- The notebook rename in #5203 (DecisionTheory/PyMC notebooks `PyMC-*` → `DecPyMC-*`) left this link pointing at the old notebook name.

## Root cause

Two compounding effects:
1. The link target `Probas/PyMC/PyMC-7-Sequential.ipynb` does not exist on disk.
2. `PyMC-7` in the bayesian corpus is "Classification bayesienne et tests A/B" — **not** the multi-bras content the table describes ("bandits, Gittins, UCB, Thompson Sampling").

## Fix

Re-target to the actual Python companion: `DecPyMC-7-Sequential.ipynb` (header "MDPs, Bandits et POMDPs", §8 Bandits Multi-Bras + Thompson Sampling exercise), and align the label `PyMC-7` → `DecPyMC-7`.

```diff
-| [**PyMC-7 (Python)**](../PyMC/PyMC-7-Sequential.ipynb) | Implementation : bandits, Gittins, UCB, Thompson Sampling |
+| [**DecPyMC-7 (Python)**](../PyMC/DecPyMC-7-Sequential.ipynb) | Implementation : bandits, Gittins, UCB, Thompson Sampling |
```

## Firsthand verification (G.1)

- broken target `Probas/PyMC/PyMC-7-Sequential.ipynb` → absent
- new target `Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb` → **exists**, link resolves from `DecInfer/` folder
- `DecPyMC-7-Sequential` cell[0] header + cell[30] §8 "Bandits Multi-Bras" + cell[32] Thompson Sampling exercise confirm the bandits/Gittins/Thompson content match
- cell count 23 unchanged, cell[0] stays markdown, 0 code cells touched

## Scope

Markdown-only change (1 line + trailing newline). No code cells modified → C.2 exception (outputs préservés). No catalog/`CATALOG-STATUS` markers touched.

See #5081 (renaming epic that left this residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)