### PR TITLE
feat(infer-3): add 3rd exercise on Variable.Case (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
@@ -2523,6 +2523,63 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice : Motif du crime avec `Variable.Case`\n",
+    "\n",
+    "Le modele Murder Mystery actuel utilise `Variable.If/IfNot` pour le meurtrier binaire (Auburn vs Grey). Generalisons : supposons que l'on veuille modeliser le **motif du crime** comme une variable discrete a trois valeurs (jalousie, argent, motif personnel), et que chaque motif induise un suspect different.\n",
+    "\n",
+    "**Objectif** : Construire un modele ou le motif (variable discrete a 3 valeurs) conditionne la probabilite qu'Auburn soit le meurtrier, en utilisant le pattern `Variable.Case` adapte aux variables entieres a plus de 2 valeurs.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Definir `Variable<int> motif = Variable.Discrete(p_jalousie, p_argent, p_personnel)` avec une distribution prior sur les 3 motifs\n",
+    "2. Pour chaque valeur de `motif`, definir une branche via `Variable.Case(motif, ...)` qui assigne une probabilite de culpabilite d'Auburn differente\n",
+    "3. Inferer la distribution posterieure du motif et de la culpabilite\n",
+    "4. Comparer les trois branches : quel motif rend Auburn le plus probablement coupable ?\n",
+    "\n",
+    "**Indices** :\n",
+    "- `Variable.Case` prend un `Variable<int>` et un tableau de `Variable<T>` ; chaque index correspond a une branche\n",
+    "- Referencez la section 9 ci-dessus pour la syntaxe complete de `Variable.Case` vs `Variable.Switch`\n",
+    "- Commencez par definir les trois probabilites de culpabilite conditionnelles (ex. jalousie -> 0.8, argent -> 0.4, personnel -> 0.6)\n",
+    "- Question supplementaire : que se passe-t-il si vous ajoutez l'evidence \"arme = revolver\" comme dans la section 5 ? Le posterieur du motif change-t-il ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer : Motif du crime avec Variable.Case\r\n"
+    }
+   ],
+   "source": [
+    "// Exercice : Motif du crime avec Variable.Case\n",
+    "// TODO: Definir le prior sur le motif (3 valeurs: 0=jalousie, 1=argent, 2=personnel)\n",
+    "// Indice: Variable<int> motif = Variable.Discrete(new double[] { 0.3, 0.4, 0.3 });\n",
+    "\n",
+    "// TODO: Definir les probabilites de culpabilite d'Auburn pour chaque motif\n",
+    "// Indice: double[] pAuburnSiMotif = { 0.8, 0.4, 0.6 };\n",
+    "\n",
+    "// TODO: Construire le modele avec Variable.Case(motif, ...)\n",
+    "// Indice: Variable<bool> auburnCoupable = Variable.Case(motif,\n",
+    "//   Variable.Bernoulli(pAuburnSiMotif[0]),\n",
+    "//   Variable.Bernoulli(pAuburnSiMotif[1]),\n",
+    "//   Variable.Bernoulli(pAuburnSiMotif[2]));\n",
+    "\n",
+    "// TODO: Inferer le posterieur du motif et de la culpabilite\n",
+    "// Indice: var infer = new InferenceEngine();\n",
+    "// Console.WriteLine($\"Motif posterieur: {infer.Infer(motif)}\");\n",
+    "// Console.WriteLine($\"P(Auburn coupable) = {infer.Infer(auburnCoupable)}\");\n",
+    "\n",
+    "// Question supplementaire : ajouter l'evidence arme = revolver et observer le changement\n",
+    "Console.WriteLine(\"Exercice a completer : Motif du crime avec Variable.Case\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0d6d0ba2",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Problem

`Infer-3-Factor-Graphs.ipynb` had only **2 exercises** (cell[20] "Sensibilité au prior", cell[32] "Monty Hall 4 portes") — below the **≥3 threshold** of #2161 (convention 3 exercices par notebook pédagogique).

Section 9 "Patterns de Conditionnement Infer.NET" documents `Variable.If/IfNot/Case/Switch` with a syntax block and pattern-choice table, but had **no application exercise** closing the section — a pedagogical gap.

## Fix

Add a 3rd exercise **"Motif du crime avec `Variable.Case`"** inserted right after the section 9 content (before section 10 "Exemple guide"):

- **MD cell** : contexte + objectif + étapes (4) + indices. Le motif du crime (3 valeurs discrètes : jalousie/argent/personnel) conditionne la probabilité de culpabilité d'Auburn — généralisation naturelle du pattern binaire `Variable.If` du Murder Mystery vers le pattern multi-valued `Variable.Case`.
- **CODE cell stub** : squelette C# avec `// TODO` + `// Indice` (définir `Variable.Discrete`, `Variable.Case` à 3 branches, inférer posterieur), `Console.WriteLine("Exercice a completer...")` final.

## Firsthand verification

| Check | Result |
|---|---|
| `count_exercises.py` canonical | Conforming=1, Sub-threshold=0 → **≥3 exos atteint** |
| C.1 (no voluntary error) | `grep -E 'raise NotImplementedError\|assert False\|1/0\|throw new NotImplemented'` = **0** |
| C.2 (commit WITH outputs) | exec_count=1, output="Exercice a completer : Motif du crime avec Variable.Case" |
| H.3 / #5214 (.NET exec proof) | cell executed locally via `.net-csharp` kernel → verdict **EXEC_PROVED** |
| #2161 stub patterns | `// TODO` + `// Indice` + `Console.WriteLine(...)` (C.1-conformant) |

## Scope

Atomique 1-notebook/PR (G.4). +57/-0 lignes (pure additif, 0 cellule supprimée, 0 code existant modifié). Le contenu section 9 existant est préservé tel quel.

## Convention exo

Le stub suit exactement le style des 2 exos existants (cell[20-21], cell[32-33]) : MD header avec Etapes + Indices, puis CODE cell avec TODO commentés. Pas de `raise NotImplementedError` (règle C.1).

See #2161 (epic transverse clot, rollout progressif) + #2876 (FR-first, contenu FR cohérent avec le reste du notebook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)