### PR TITLE
docs(infer): fix stale tree block — remove ghost Gittins, extend to Infer-19

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -830,13 +830,15 @@ var posterior = moteur.Infer<DistributionType>(variable);
 
 ```
 Infer/
-+-- Infer-1-Setup.ipynb ... Infer-17-Kalman-Filter.ipynb
-+-- Infer-9-Lean-Gittins.ipynb    # Companion Lean 4 (preuves formelles Gittins)
++-- Infer-1-Setup.ipynb ... Infer-19-Survival-Analysis.ipynb   # 19 notebooks (Infer-9 = Topic-Models)
 +-- Infer-Glossary.md
 +-- FactorGraphHelper.cs          # Helper pour visualisation Graphviz
 +-- README.md
++-- data/                         # Datasets (murder_mystery.json, matches.csv, skills_quiz.csv, ...)
 +-- scripts/                      # Scripts de maintenance
 ```
+
+> Le companion Lean 4 (preuves formelles de l'indice de Gittins) vit dans l'arc théorie de la décision : [`../DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb`](../DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb) (post-renumérotation #5200).
 
 ## Domaines d'Application
 


### PR DESCRIPTION
## Problem

§E feuille audit (gate #5353) of `Probas/Infer/README.md` found the **"Structure des Fichiers" tree block** (lines 831-839) stale on two points:

1. **GHOST entry** : `Infer-9-Lean-Gittins.ipynb` listed as living in `Probas/Infer/` — but the rename in #5200 (DecisionTheory/Infer → DecInfer) moved this notebook to `Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb`. The file no longer exists in `Probas/Infer/` (verified firsthand : `ls Probas/Infer/*Gittins*` → No such file).

2. **STALE range** : tree stopped at `Infer-17-Kalman-Filter`, but `Infer-18-Change-Point` and `Infer-19-Survival-Analysis` exist on disk (tracked). The intro prose (line 5) already correctly says "corpus bayésien (19 notebooks)" — only the tree was behind.

## Fix

```diff
 Infer/
-+-- Infer-1-Setup.ipynb ... Infer-17-Kalman-Filter.ipynb
-+-- Infer-9-Lean-Gittins.ipynb    # Companion Lean 4 (preuves formelles Gittins)
++-- Infer-1-Setup.ipynb ... Infer-19-Survival-Analysis.ipynb   # 19 notebooks (Infer-9 = Topic-Models)
 +-- Infer-Glossary.md
 +-- FactorGraphHelper.cs          # Helper pour visualisation Graphviz
 +-- README.md
++-- data/                         # Datasets (murder_mystery.json, matches.csv, skills_quiz.csv, ...)
 +-- scripts/                      # Scripts de maintenance
 ```

+> Le companion Lean 4 (preuves formelles de l'indice de Gittins) vit dans l'arc théorie de la décision : [`../DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb`](...) (post-renumérotation #5200).
```

- Drop ghost Gittins line, replace with a blockquote pointer to the real location (preserves the cross-reference intent that was the original purpose of the line)
- Extend range to Infer-19
- Add the missing `data/` directory

## §E re-audit (a)(b)(c) firsthand

| Check | Result |
|---|---|
| (a) find count per subfolder | 19 .ipynb at root, `scripts/`, `data/` |
| (b) disk ↔ prose ↔ tree | disk=19 ↔ prose line 5 "corpus bayésien (19 notebooks)"=19 ↔ tree (post-fix) |
| (c) notebook lists/tree current | tree now reflects Infer-19 + no ghost + data/ present |
| `check_docs_links.py --check` | **0 broken** (3404 total) |
| `DecInfer-9-Lean-Gittins.ipynb` target | exists at `Probas/DecisionTheory/DecInfer/` |

## Scope

Markdown-only (4 insertions, 2 deletions). CATALOG-STATUS markers untouched (catalog-pr-hygiene R1). No notebook modified.

See #5081 (renaming epic that left this residue) + #3973 (README ascendant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)