### PR TITLE
docs(search): fix stale Mermaid count Phase 3 node (21->22 cas reels)

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -66,7 +66,7 @@ Les 22 notebooks d'applications illustrent chaque concept sur des cas réels : p
 flowchart LR
     P1["<b>Phase 1 — Fondements</b> (~7h)<br/>Search-1 … Search-7<br/><i>Trois paradigmes :</i><br/>• exploration systématique<br/>&nbsp;&nbsp;(BFS, UCS, A*)<br/>• optimisation locale<br/>&nbsp;&nbsp;(SA, Tabu, GA)<br/>• recherche dans les jeux<br/>&nbsp;&nbsp;(Minimax, MCTS)"]
     P2["<b>Phase 2 — Programmation<br/>par contraintes</b> (~6h)<br/>CSP-1 … CSP-6<br/><i>Réduire l'espace<br/>plutôt que l'explorer</i><br/>backtracking → AC-3<br/>→ contraintes globales<br/>→ ordonnancement<br/>→ CP + SAT / ML / LLM"]
-    P3["<b>Phase 3 — Applications<br/>&amp; frontières</b> (~18h)<br/>21 cas réels : TSP, VRP,<br/>RCPSP, Bin Packing,<br/>Wordle, Picross…<br/>+ notebooks avancés<br/>(LP, automates,<br/>souples, temporelles)"]
+    P3["<b>Phase 3 — Applications<br/>&amp; frontières</b> (~18h)<br/>22 cas réels : TSP, VRP,<br/>RCPSP, Bin Packing,<br/>Wordle, Picross…<br/>+ notebooks avancés<br/>(LP, automates,<br/>souples, temporelles)"]
     BR["<b>Séries connexes</b><br/>Sudoku (DLX)<br/>SymbolicAI (Z3)<br/>GameTheory (Minimax/MCTS)<br/>RL (MCTS + DQN)"]
     P4["<b>Side-track .NET 9</b><br/>Part 4 — Métaheuristiques<br/>composables<br/>MGS-1 … MGS-19<br/><i>reconstruire &amp; composer<br/>au-dessus de GeneticSharp</i>"]
     P1 -->|"backtracking = DFS"| P2


### PR DESCRIPTION
## §E feuille audit — Search README (#3975)

Whole-file reconciliation **disk ↔ prose ↔ CATALOG-STATUS** per [pr-review-discipline.md §E](../../blob/main/.claude/rules/pr-review-discipline.md) (audit fichier-entier obligatoire).

## Disk truth (counted firsthand, non-output .ipynb)

| Section | Disk | CATALOG-STATUS | Prose |
|---------|------|----------------|-------|
| Part1-Foundations | 18 | 18 | 18 ✓ |
| Part2-CSP | 18 | 18 | 18 ✓ |
| Part3-Advanced | 5 | 5 | 5 ✓ |
| Part4-Metaheuristics | 19 | 19 | 19 ✓ |
| Applications/Search | 2 | — | — |
| Applications/CSP | 13 | — | — |
| Applications/Hybrid | 7 | — | — |
| **Applications total** | **22** | **22** | **22** (l.14, l.63) ✓ |
| **Total** | **82** | **82** | **82** (l.719) ✓ |

## The single drift fixed

Mermaid flowchart node P3 said **"21 cas réels"** while:
- Prose l.14: "Les **applications** (**22 notebooks**)"
- Prose l.63: "Les **22 notebooks** d'applications illustrent chaque concept sur des **cas réels**"
- CATALOG-STATUS breakdown: `Applications=22`
- Disk: `Applications/` = 22 .ipynb (Search=2, CSP=13, Hybrid=7)

→ Fixed **21 → 22** in the P3 Mermaid node to align with sibling prose + disk + catalog. Identical pattern to the GameTheory flowchart count fixes (po-2025, #5402).

## Audit scope (whole-file proof)

- Structure tree (l.475-535): complete and accurate (Part1/2/3/4 counts + Applications subdirs all match disk).
- Mermaid block (l.65-77): P1/P2/P4 nodes carry no numeric counts (only ranges Search-1..7, CSP-1..6, MGS-1..19, all correct); P3 was the only stale count.
- Cross-series links (Sudoku, SymbolicAI, GameTheory, RL): resolve.
- Total counts (82 pedagogical, 64 Python + 18 C# twins): consistent l.14/l.63/l.630/l.719.

## Notes

- Markdown-only edit (Mermaid node) — no notebook touched, C.2/C.3 N/A.
- **CATALOG-STATUS marker left byte-identical** (catalog-pr-hygiene R1 — automation-owned; catalog-cron/catalog-drift CI regenerate it).
- README was freshly regenerated by catalog-cron (commit `3caa17b17`) — prose counts are authoritative; the Mermaid node was the lone human-prose residual.

See #3975.

Co-Authored-By: Claude-Code <noreply@anthropic.com>