### PR TITLE
docs(semweb): fix 6 wrong notebook numbers in cross-series connections (#3975)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -540,16 +540,16 @@ SemanticWeb/
 
 Les graphes de connaissances RDF/OWL (SW-1 à SW-6) fournissent des représentations riches du monde que les planificateurs PDDL (Planners-2 à Planners-9) peuvent exploiter :
 
-- **Ontologies OWL (SW-4/5) et domaines PDDL (Planners-6)** : les ontologies définissent les types et relations du domaine ; les fichiers PDDL définissent les actions et contraintes. Les deux formalisent la sémantique d'un domaine pour le raisonnement automatique.
-- **SPARQL (SW-3) + planification** : les requêtes SPARQL sur un graphe de connaissances peuvent générer les états initiaux et buts d'un problème de planification.
+- **Ontologies OWL (SW-7) et domaines PDDL (Planners-6)** : les ontologies définissent les types et relations du domaine ; les fichiers PDDL définissent les actions et contraintes. Les deux formalisent la sémantique d'un domaine pour le raisonnement automatique.
+- **SPARQL (SW-4) + planification** : les requêtes SPARQL sur un graphe de connaissances peuvent générer les états initiaux et buts d'un problème de planification.
 - **GraphRAG (SW-12) + LLM Planning (Planners-10)** : le RAG basé sur les graphes de connaissances améliore la génération de plans par les LLMs en fournissant un contexte structuré.
 
 ### SemanticWeb et Tweety (Logique et Argumentation)
 
 Les logiques de description (OWL) et les logiques classiques (Tweety) partagent des fondements communs :
 
-- **OWL-DL (SW-4/5) et logique propositionnelle/FOL (Tweety-2/3)** : OWL-DL est une logique de description décidable, fragment de la logique du premier ordre. Les SAT solvers de Tweety complètent les raisonneurs OWL (HermiT, Pellet).
-- **SHACL (SW-7) et validation** : les contraintes SHACL sur les graphes RDF sont analogues aux contraintes logiques de Tweety. Les deux approches valident la cohérence de bases de connaissances.
+- **OWL-DL (SW-7) et logique propositionnelle/FOL (Tweety-2/3)** : OWL-DL est une logique de description décidable, fragment de la logique du premier ordre. Les SAT solvers de Tweety complètent les raisonneurs OWL (HermiT, Pellet).
+- **SHACL (SW-8) et validation** : les contraintes SHACL sur les graphes RDF sont analogues aux contraintes logiques de Tweety. Les deux approches valident la cohérence de bases de connaissances.
 - **Raisonnement monotone (OWL) vs non-monotone (Tweety-6/7)** : les ontologies OWL font du raisonnement monotone (ajout de faits ne rétracte rien) ; Tweety explore le raisonnement non-monotone (defeasible, priorité).
 
 ### SemanticWeb et Lean (Vérification Formelle)
@@ -563,7 +563,7 @@ La vérification de cohérence des ontologies OWL est une forme de vérification
 
 Les smart contracts et le web sémantique convergent dans les données décentralisées :
 
-- **Graphes de connaissances on-chain** : les NFTs ERC-721 (SC-7) avec métadonnées JSON-LD (SW-8) créent des graphes de connaissances décentralisés. Les DID (Decentralized Identifiers) utilisent RDF pour l'identité auto-souveraine.
+- **Graphes de connaissances on-chain** : les NFTs ERC-721 (SC-7) avec métadonnées JSON-LD (SW-9) créent des graphes de connaissances décentralisés. Les DID (Decentralized Identifiers) utilisent RDF pour l'identité auto-souveraine.
 - **Oracle data integration** : les oracles blockchain (SC-8 DeFi) peuvent servir de sources RDF pour enrichir les graphes de connaissances en temps réel.
 
 ---


### PR DESCRIPTION
## What

Feuille audit (whole-file §E) of `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md`. See #3975 (README ascendant, feuilles).

## Bug (firsthand, grounded on `origin/main` 3caa17b17)

The "Connections cross-séries" section (l. 537-567) had **6 systematically shifted SW notebook numbers**, contradicting both disk filenames and the "Concepts clés" table (l. 73-87) which is correct. Markdown-only +5/−5:

| Line | Before (wrong) | After (correct) | Why |
|------|----------------|-----------------|-----|
| 541 | Ontologies OWL **(SW-4/5)** | **SW-7** | SW-4=SPARQL, SW-5=LinkedData, SW-7=OWL |
| 544 | SPARQL **(SW-3)** | **SW-4** | SW-3=GraphOperations, SW-4=SPARQL |
| 551 | OWL-DL **(SW-4/5)** | **SW-7** | same as l. 541 |
| 552 | SHACL **(SW-7)** | **SW-8** | SW-7=OWL, SW-8=SHACL |
| 566 | JSON-LD **(SW-8)** | **SW-9** | SW-8=SHACL, SW-9=JSON-LD |

The errors were systematic (the whole section had numbers off by 1-3), not incidental. Cross-checked against the Concepts clés table which has the correct mapping: RDF=SW-2, Graphe=SW-3, SPARQL=SW-4, LinkedData=SW-5, RDFS=SW-6, OWL=SW-7, SHACL=SW-8, JSON-LD=SW-9, RDF-Star=SW-10, KG=SW-11, GraphRAG=SW-12.

## Verification (G.1 — all grounded against disk)

- **CATALOG-STATUS marker byte-identical** (catalog-pr-hygiene R1: never regen on a feature branch).
- **check_docs_links --check**: `OK: No new broken links. (0 pre-existing, 3383 total)`.
- **Cross-lane links** resolve: Tweety, Planners, Lean, SmartContracts, Argument_Analysis, GenAI, `docs/grothendieckian-lens.md`.
- **SC-7 Token-Standards** and **SC-8 DeFi-Primitives** exist on disk (claims at l. 566-567 valid).
- **17 SW notebooks on disk** (13 main + 4 sidetracks `2b/4b/5b/7b`), all matching their README table/structure entries.

## Note (not fixed here — automation-owned)

Disk has **17 SW notebooks** but marker says `pedagogical_count: 18`. This drift is **not touched** in this PR — the marker is automation-owned (daily `catalog-cron.yml` reconciles it on `main`). Per R1 `catalog-pr-hygiene`, an agent never regenerates the marker on a feature branch. Flagging here so the cron picks it up.

## Scope

Single file, single README, prose-only. Atomique (R3). Markdown-only: no notebook touched, no re-exec needed (C.2-exempt).

See #3975 (feuille = partial contribution, not `Closes`).

Co-Authored-By: Claude <noreply@anthropic.com>
