### PR TITLE
docs(tweety): reconcile README §E — add missing C# pilot row, fix Python/C# counts (#3975)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -68,7 +68,7 @@ Les notebooks utilisent **deux implémentations** pour exécuter TweetyProject, 
 
 | Implémentation           | Stack                          | Kernel        | JVM requise ?                     | Notebooks                                                                                                                               |
 | ------------------------ | ------------------------------ | ------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| **Python** (originelle)  | JPype (pont Java↔Python)       | Python 3      | Oui (JDK téléchargé par le setup) | `Tweety-1` à `Tweety-11` (13 notebooks)                                                                                                 |
+| **Python** (originelle)  | JPype (pont Java↔Python)       | Python 3      | Oui (JDK téléchargé par le setup) | `Tweety-1` à `Tweety-11` (12 notebooks)                                                                                                 |
 | **C#/.NET** (port natif) | IKVM 8.15 (bytecode Java→.NET) | `.net-csharp` | **Non** (runtime IKVM pur .NET)   | `Tweety-2-Basic-Logics-Csharp`, `Tweety-2b-Semantics-Csharp`, `Tweety-2c-FOL-Csharp`, `Tweety-3-Dung-Csharp`, `Tweety-4-Aspic-Csharp`   |
 
 Les deux implémentations couvrent les mêmes concepts fondamentaux (logique propositionnelle, sémantique des mondes possibles, logique du premier ordre, argumentation de Dung) ; le port C# les expose **sans JVM**, directement dans le runtime .NET, ce qui les rend exécutables côté .NET Interactive comme n'importe quel notebook C#. Les notebooks `-Csharp` vivent **à côté** de leurs homologues Python (pas dans un sous-dossier), pour faciliter la comparaison des deux stacks sur un même concept. Voir EPIC [#4667](https://github.com/jsboige/CoursIA/issues/4667).
@@ -175,6 +175,7 @@ Pour les praticiens intéressés par les applications multi-agents :
 | **Fondations** |
 | 1  | [Tweety-1-Setup](Tweety-1-Setup.ipynb)    | Configuration JVM, JARs, outils externes                       | 20 min  | Python |
 | 2  | [Tweety-2-Basic-Logics](Tweety-2-Basic-Logics.ipynb) | Logique Propositionnelle et FOL                          | 45 min  | Python |
+| 2a | [Tweety-2-Basic-Logics-Csharp](Tweety-2-Basic-Logics-Csharp.ipynb) | Logique propositionnelle .NET (IKVM, port pilot #4792) | 30 min | C# PROD |
 | 2b | [Tweety-2b-Semantics-Csharp](Tweety-2b-Semantics-Csharp.ipynb) | Sémantique propositionnelle .NET (mondes possibles)  | 30 min  | C# BETA |
 | 2c | [Tweety-2c-FOL-Csharp](Tweety-2c-FOL-Csharp.ipynb) | FOL porté .NET (IKVM)                                    | 30 min  | C# BETA |
 | 3  | [Tweety-3-Advanced-Logics](Tweety-3-Advanced-Logics.ipynb) | DL, Modale, QBF, Conditionnelle                      | 40 min  | Python |
@@ -203,11 +204,11 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 10c | [Tweety-10-MLN-Csharp](Tweety-10-MLN-Csharp.ipynb) | MLN porté .NET (IKVM, c.188 PR #5209)                | 30 min  | C# PROD |
 | 11 | [Tweety-11-Causal](Tweety-11-Causal.ipynb) | Raisonnement causal : do-calculus, interventions, contrefactuels | 50 min  | Python |
 
-**Durée totale estimée** : ~13h (Python) + ~6h (C#/.NET). Le tableau ci-dessus couvre les **26 notebooks principaux** (13 Python + 13 C#/.NET) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
+**Durée totale estimée** : ~13h (Python) + ~6h (C#/.NET). Le tableau ci-dessus couvre les **26 notebooks principaux** (12 Python + 13 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
 
 ## En quoi chaque notebook est unique
 
-Chaque notebook introduit un concept ou cadre théorique spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun — couvrant les **26 notebooks principaux** (13 Python + 12 C#/.NET + 1 Lean companion) :
+Chaque notebook introduit un concept ou cadre théorique spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun — couvrant les **26 notebooks principaux** (12 Python + 13 C#/.NET + 1 Lean companion) :
 
 | #  | Notebook                      | Concept clé enseigné                                                    |
 |----|-------------------------------|--------------------------------------------------------------------------|


### PR DESCRIPTION
## §E feuille audit — Tweety README (#3975)

Whole-file reconciliation **disk ↔ table ↔ prose** per [pr-review-discipline.md §E](../../blob/main/.claude/rules/pr-review-discipline.md). Tweety README had **stale-body severe** (signaled po-2023 previous cycle, not a drive-by feuille).

## Disk truth (kernel scan firsthand, non-output .ipynb)

| Kernel | Count | Notebooks |
|--------|-------|-----------|
| `python3` | **12** | Tweety-1,2,3,4,5,6,7a,7b,8,9,10,11 |
| `.net-csharp` (main) | **13** | incl. **Tweety-2-Basic-Logics-Csharp** (pilot #4792) |
| `.net-csharp` (probe) | 1 | `_probes/Tweety-IKVM-Init-Probe` |
| `lean4` | **1** | Tweety-5b-Lean-Argumentation |
| **Total** | **27** | = CATALOG `pedagogical_count: 27` ✓ |

**Principaux** (excl probe) = 12 Py + 13 C# + 1 Lean = **26**.

## 3 drifts fixed

### 1. Main table missing the C# pilot (factual completeness)

`Tweety-2-Basic-Logics-Csharp.ipynb` (24KB, real, commit #4792 "feat(tweety): C#/.NET port pilot") was **absent** from the main pedagogical table — all 12 other C# ports (2b, 2c, 3c-*, 4c-*, 7bc, 9c, 10c) were listed, this one absent. Table had 25 rows while prose claimed 26.

→ **Added row 2a** (after Python Tweety-2, before 2b). Maturity tag **C# PROD**, inferred from:
- 9/10 code cells executed (the 1 unexecuted = Exercise 3 stub `// Exercice 3 : Conséquence logique...`, conforme C.1, not an error)
- 15 outputs
- 3/3 exercises present (enrichment #5157 "2/3 → 3/3")
- IKVM load-confirmation cells (#5119)
- 3 enrichment rounds (#4792 pilot → #5119 → #5157)

### 2. Prose "13 Python" × 3 → "12 Python"

Prose claimed 13 Python notebooks in 3 places (implementation table l.71, synthese l.206 + l.210). Disk has **12** python3 kernels. Fixed all 3.

### 3. l.206 ↔ l.210 contradiction reconciled

| Line | Before | Issue |
|------|--------|-------|
| l.206 | "(13 Python + 13 C#/.NET)" | wrong Py count; Lean not mentioned |
| l.210 | "(13 Python + 12 C#/.NET + 1 Lean)" | wrong Py count; wrong C# count (12 vs 13) |

Both → **"(12 Python + 13 C#/.NET + 1 Lean companion)"** = 26 principaux. Now consistent with each other AND with disk (12 Py + 13 C# + 1 Lean).

## Gates
- **G.1 disk-grounded**: kernel scan firsthand, 12 py + 13 c# + 1 lean = 26 main.
- **CATALOG-STATUS byte-identical** (catalog-pr-hygiene R1 — `pedagogical_count: 27` untouched).
- **check_docs_links --check**: 0 broken / 3384 total (new row link resolves to 24KB notebook on disk).
- **Table recount**: 13 C# rows + 12 Python rows + 1 Lean row = 26 ✓.

## Notes
- Markdown-only edit (table row + prose counts) — no notebook touched, C.2/C.3 N/A.
- Concept/learning-path table (l.214+) is **condensed-by-design** (one C# port per concept area, not exhaustive) — left as-is.
- Maturity tag C# PROD inferred from enrichment + execution evidence; ai-01 may adjust if a formal maturity audit disagrees.

See #3975.

Co-Authored-By: Claude-Code <noreply@anthropic.com>