### PR TITLE
fix(sudoku): repair 6 broken cross-reference links in Sudoku-6 + Sudoku-13

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -799,7 +799,7 @@
     "| **Logique M2L-str** (Veanes & D'Antoni) | `exists x,y. x<y && P_5(x) && P_7(y)` | le compilateur logique vers SFA |\n",
     "| **Contraintes** (Z3, section 6) | `Distinct` + appartenances | le solveur SMT |\n",
     "\n",
-    "> **Le meme `&`, vu d'en haut.** Les trois registres partagent l'**algebre de Boole** des langages reguliers (cf notebook [10](../SymbolicAI/SMT/Z3/10_Witness_Génération_Automata.ipynb), section 3). La conjonction logique `&&` de M2L-str, l'intersection `&` de RE# et le `re.inter` SMT-LIB sont **la meme operation** dans trois notations. Mais la *forme* sous laquelle on emet cette conjonction decide si Z3 atterrit le 9x9 (section 6b) - une question que la théorie de Veanes nomme **decomposition monadique**, et que l'ordre `x < y` de cet exercice illustre justement par la negative (cf section 6b)."
+    "> **Le meme `&`, vu d'en haut.** Les trois registres partagent l'**algebre de Boole** des langages reguliers (cf notebook [10](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb), section 3). La conjonction logique `&&` de M2L-str, l'intersection `&` de RE# et le `re.inter` SMT-LIB sont **la meme operation** dans trois notations. Mais la *forme* sous laquelle on emet cette conjonction decide si Z3 atterrit le 9x9 (section 6b) - une question que la théorie de Veanes nomme **decomposition monadique**, et que l'ordre `x < y` de cet exercice illustre justement par la negative (cf section 6b)."
    ]
   },
   {
@@ -1029,7 +1029,7 @@
     "\n",
     "| Echelle | Forme d'emission du tous-distincts | Témoin via la théorie des chaînes Z3 |\n",
     "|---------|-----------------------------------|--------------------------------------|\n",
-    "| **`A & ~B` général** (mot de passe, entree de test) | `re.inter` / `re.comp` | **rapide** (~100 ms, cf [notebook 10](../SymbolicAI/SMT/Z3/10_Witness_Génération_Automata.ipynb)) |\n",
+    "| **`A & ~B` général** (mot de passe, entree de test) | `re.inter` / `re.comp` | **rapide** (~100 ms, cf [notebook 10](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb)) |\n",
     "| **Grille 4x4** (Shidoku) | appartenance **fondue** en `re.inter` | **atterrit** (~1,7 s, cellule plus bas) |\n",
     "| **1 ligne 9x9** (9 cases) | appartenance **fondue** en `re.inter` (10-way) | **atterrit** mais lent (~12,5 s) |\n",
     "| **Grille 9x9** | appartenance **fondue** en `re.inter` (27 groupes qui se chevauchent) | **`unknown`** (> 60 s - le produit d'automates sature) |\n",
@@ -1805,7 +1805,7 @@
     "| chaînes Z3, tous-distincts en **inegalites 2 a 2** | (oui) | **grille complete** | **atterrit (~0,8 s)** |\n",
     "| Z3 `Distinct` (entiers) | - | grille complete | **~38 ms (production)** |\n",
     "\n",
-    "> **Murs tombes, forme d'emission décisive.** Le payoff *général* de la génération de témoin `A & ~B` est demontre dans le notebook **[10 - Generer un témoin depuis A & ~B](../SymbolicAI/SMT/Z3/10_Witness_Génération_Automata.ipynb)** de la serie Z3. Le Sudoku, lui, montre la leçon la plus fine : ce n'est ni le moteur ni le substrat, ni meme \"appartenance vs inegalite\" qui decide, mais la **forme d'emission** du meme `&` d'appartenances - *fondu* en `re.inter` (sature au 9x9) vs *eclate* en `str.contains` natif (atterrit). Le regex *n'est pas* le mauvais outil : bien emis, il atterrit la grille 9x9 complete, sans une seule inegalite."
+    "> **Murs tombes, forme d'emission décisive.** Le payoff *général* de la génération de témoin `A & ~B` est demontre dans le notebook **[10 - Generer un témoin depuis A & ~B](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb)** de la serie Z3. Le Sudoku, lui, montre la leçon la plus fine : ce n'est ni le moteur ni le substrat, ni meme \"appartenance vs inegalite\" qui decide, mais la **forme d'emission** du meme `&` d'appartenances - *fondu* en `re.inter` (sature au 9x9) vs *eclate* en `str.contains` natif (atterrit). Le regex *n'est pas* le mauvais outil : bien emis, il atterrit la grille 9x9 complete, sans une seule inegalite."
    ]
   },
   {
@@ -3038,7 +3038,7 @@
     "\n",
     "**Leçon** : decrire une contrainte par intersection reguliere (`Ligne & Colonne & Bloc`) est une représentation elegante qui **atterrit** la grille - 4x4 complete, **et 9x9 complete** sans quitter l'appartenance reguliere. Ce qui decide la reussite n'est ni le moteur (DFA vs dérivées vs SMT) ni le substrat (chaîne vs entier), mais la **forme d'emission du tous-distincts** : *fondu* en un produit d'automates (`re.inter`/`str.in_re`), il sature a l'echelle des 27 groupes qui se chevauchent ; *eclate* en la primitive native `str.contains` (= `.*d.*` par chiffre), il atterrit - et les inegalites 2 a 2 (dont `Distinct` est le sucre) plus vite encore, mais hors du regex. RE# en est le verificateur lineaire, pas le solveur ; l'ironie (RE# valide plus vite qu'il ne produit) est le pont entre cette serie Sudoku et la serie Z3 (Epic #1206).\n",
     "\n",
-    "La **chaîne moderne** (section 6b, et notebook [10](../SymbolicAI/SMT/Z3/10_Witness_Génération_Automata.ipynb) de la serie Z3) fait tomber **les deux murs** de 2020 : `&`/`~` compile vers la théorie des chaînes de Z3, qui ne cape aucun témoin et ne construit aucun produit d'automates. Le revers n'est donc pas \"Z3 string-theory ne sait pas faire le Sudoku\" - il le fait, le 9x9 inclus (cf section 6c) - mais \"il faut emettre l'appartenance dans la bonne forme : `str.contains` natif, pas `re.inter` fondu\".\n",
+    "La **chaîne moderne** (section 6b, et notebook [10](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb) de la serie Z3) fait tomber **les deux murs** de 2020 : `&`/`~` compile vers la théorie des chaînes de Z3, qui ne cape aucun témoin et ne construit aucun produit d'automates. Le revers n'est donc pas \"Z3 string-theory ne sait pas faire le Sudoku\" - il le fait, le 9x9 inclus (cf section 6c) - mais \"il faut emettre l'appartenance dans la bonne forme : `str.contains` natif, pas `re.inter` fondu\".\n",
     "\n",
     "Le **banc d'essai** (section 8 ci-dessus) confirme empiriquement chaque case de ce tableau : le regex deroule s'effondre (timeout, faux negatif), la voie chaînes-en-appartenance-fondue fait `unknown`, la **meme** appartenance eclatee en `str.contains` (P3'') et les inegalites (P3') et `Distinct` atterrissent, et le backtracking C# naif est le vainqueur discret. Le DLX, lui, est l'optimum dedie : cf [Sudoku-2-DancingLinks](Sudoku-2-DancingLinks-Csharp.ipynb).\n",
     "\n",
@@ -3159,7 +3159,7 @@
     "### Connexions dans cette serie\n",
     "- **[Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb)** : le resolveur Z3 explore en profondeur (bit-vectors, optimisations). Ce notebook (13) presente le meme Z3 sous l'angle narratif \"regex symbolique -> SMT -> témoin\".\n",
     "- **Epic #1206 (Z3.Linq DSL)** : un autre \"geste\" de l'auteur (2018), etendre un front-end declaratif pour laisser Z3 temoigner. La compilation regex -> SMT et le DSL Z3.Linq sont **le meme geste dans deux librairies**.\n",
-    "- **[Notebook 10 - Generer un témoin depuis A & ~B](../SymbolicAI/SMT/Z3/10_Witness_Génération_Automata.ipynb)** : le fork Automata leve le cap du témoin (#6) et generalise `A & ~B` (mots de passe, entrees de test) - le cas ou la théorie des chaînes de Z3 est rapide. La section 6b ci-dessus mesure le spectre (rapide en général, lent sur une ligne, `unknown` a 81).\n",
+    "- **[Notebook 10 - Generer un témoin depuis A & ~B](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb)** : le fork Automata leve le cap du témoin (#6) et generalise `A & ~B` (mots de passe, entrees de test) - le cas ou la théorie des chaînes de Z3 est rapide. La section 6b ci-dessus mesure le spectre (rapide en général, lent sur une ligne, `unknown` a 81).\n",
     "- **Epic #2162 (Game of Life, Lean)** : **John** Conway, a ne pas confondre avec **Damian** (regex).\n",
     "\n",
     "### La preuve Lean derriere RE#\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "| << Precedent | [Index](./README.md) | Suivant >> |\n",
     "|-------------|---------------------|-----------|\n",
-    "| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) |"
+    "| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb) |"
    ]
   },
   {
@@ -1659,7 +1659,7 @@
   {
    "cell_type": "markdown",
    "id": "339cfefc",
-   "source": "## Resume et perspectives\n\nCe notebook a transpose en C# le cadre academique AIMA pour la resolution de Sudoku par programmation par contraintes. La classe generique `CSP<TVariable, TValue>` a permis d'implementer quatre algorithmes de complexite croissante : le backtracking simple (~2,9 millions d'assignations sur 2 puzzles bornes), le backtracking ameliore MRV+LCV (366 assignations sur 3 puzzles), le Forward Checking (91 assignations) et le MAC (86 assignations, 5 backtracks). Le benchmark borne pour rester sous ~60s/cellule (#4940) confirme que MAC est le plus robuste avec un minimum de retours en arriere, tandis que Forward Checking est le plus rapide sur les instances faciles grace a son overhead reduit.\n\nL'implementation des heuristiques MRV (selection de la variable la plus contrainte) et LCV (ordonnancement des valeurs les moins contraignantes) a illustre les principes \"fail-first\" et \"succeed-first\" fondamentaux en recherche combinatoire. L'exercice CBJ (Conflict-Based Backjumping) complete cette etude en proposant d'implementer un mecanisme de remontee directe vers la variable responsable d'un conflit, evitant ainsi les retours en arriere chronologiques inutiles.\n\nLe notebook suivant, [Sudoku-7-Norvig](Sudoku-7-Norvig.ipynb), presente l'approche de Peter Norvig qui combine propagation de contraintes (naked singles, hidden singles) et recherche pour une resolution elegante et performante.",
+   "source": "## Resume et perspectives\n\nCe notebook a transpose en C# le cadre academique AIMA pour la resolution de Sudoku par programmation par contraintes. La classe generique `CSP<TVariable, TValue>` a permis d'implementer quatre algorithmes de complexite croissante : le backtracking simple (~2,9 millions d'assignations sur 2 puzzles bornes), le backtracking ameliore MRV+LCV (366 assignations sur 3 puzzles), le Forward Checking (91 assignations) et le MAC (86 assignations, 5 backtracks). Le benchmark borne pour rester sous ~60s/cellule (#4940) confirme que MAC est le plus robuste avec un minimum de retours en arriere, tandis que Forward Checking est le plus rapide sur les instances faciles grace a son overhead reduit.\n\nL'implementation des heuristiques MRV (selection de la variable la plus contrainte) et LCV (ordonnancement des valeurs les moins contraignantes) a illustre les principes \"fail-first\" et \"succeed-first\" fondamentaux en recherche combinatoire. L'exercice CBJ (Conflict-Based Backjumping) complete cette etude en proposant d'implementer un mecanisme de remontee directe vers la variable responsable d'un conflit, evitant ainsi les retours en arriere chronologiques inutiles.\n\nLe notebook suivant, [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb), presente l'approche de Peter Norvig qui combine propagation de contraintes (naked singles, hidden singles) et recherche pour une resolution elegante et performante.",
    "metadata": {}
   },
   {
@@ -1762,7 +1762,7 @@
     "\n",
     "| << Precedent | [Index](./README.md) | Suivant >> |\n",
     "|-------------|---------------------|-----------|\n",
-    "| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) |"
+    "| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb) |"
    ]
   }
  ],


### PR DESCRIPTION
## Problem

Repo-wide intra-notebook broken-link scan found **6 broken `.ipynb` cross-references** in 2 Sudoku notebooks (markdown links pointing to non-existent files).

### Sudoku-13-SymbolicAutomata-Csharp (5 occurrences, 5 cells)

```diff
-[10](../SymbolicAI/SMT/Z3/10_Witness_Génération_Automata.ipynb)
+[10](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb)
```

The actual file is `10_Witness_Generation_Automata.ipynb` (no accent on "Génération" → "Generation"). The accented filename was preserved at face value by the **G4 CamelCase/inline-code guard** of #5326 (accent restoration pass) — correctly conservative on prose, but a *filename* is ASCII on disk, so the accent made the link 404. Affects 5 markdown cells (table refs, blockquotes, prose pointing to Z3 notebook 10).

### Sudoku-6-AIMA-CSP-Csharp (3 occurrences, 2 nav tables + 1 prose)

```diff
-| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) |
+| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb) |
```

`[Sudoku-7-Norvig](Sudoku-7-Norvig.ipynb)` → the actual file is `Sudoku-7-Norvig-Csharp.ipynb` (missing `-Csharp` suffix). Affects cell[0] navigation table, the "Résumé et perspectives" prose link, and the trailing navigation table. Both label and URL are aligned to the real filename.

## Firsthand verification (G.1)

| Check | Result |
|---|---|
| Z3 notebook 10 exists | `SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb` ✓ |
| Sudoku-7-Norvig-Csharp exists | `Sudoku/Sudoku-7-Norvig-Csharp.ipynb` ✓ |
| Re-scan broken links | **0 residual** on Sudoku-13 + Sudoku-6 (all 6 fixed) |
| `validate_pr_notebooks` | **EXEC_PROVED** both (markdown-only, 0 code touched) |
| C.2 exception | outputs preserved, no re-exec needed |

## Scope

Markdown-only (+9/-9). Atomique same-family broken-link fix (G.4). No code cell touched, no catalog/`CATALOG-STATUS` markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)