### PR TITLE
fix(sc23): repair broken 'Notebook suivant' nav link in SC-23-Cross-Chain

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
@@ -1140,7 +1140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "id": "cell-11",
    "metadata": {
     "execution": {
@@ -1182,7 +1182,7 @@
       "\n",
       "---\n",
       "\n",
-      "**Notebook suivant** : [SC-15-Final-Project](../06-Real-World/SC-15-Final-Project.ipynb)\n",
+      "**Notebook suivant** : [SC-24-Testnet-Deploy](SC-24-Testnet-Deploy.ipynb)\n",
       "\n"
      ]
     }
@@ -1208,7 +1208,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook suivant** : [SC-15-Final-Project](../06-Real-World/SC-15-Final-Project.ipynb)\n",
+    "**Notebook suivant** : [SC-24-Testnet-Deploy](SC-24-Testnet-Deploy.ipynb)\n",
     "\"\"\")"
    ]
   },


### PR DESCRIPTION
## What

Cell 19 (resume footer, pure `print()`) of `SC-23-Cross-Chain.ipynb` linked to `[SC-15-Final-Project](../06-Real-World/SC-15-Final-Project.ipynb)` — **a notebook that does not exist on disk** (broken link). This PR repairs the navigation.

## Disk-grounded target (G.1)

- **SC-15** is the **Zero-Knowledge-Proofs** notebook, lives in `04-Privacy-Cryptography/` — not a "Final-Project" and not in `06-Real-World/`.
- The real **"Final-Project"** notebook is **SC-26** (last of the series).
- **SC-23** is the **first** notebook in `06-Real-World/`, so the correct *sequential next* is **SC-24-Testnet-Deploy** (same directory, exists on disk — 51667 bytes).
- `NEW = [SC-24-Testnet-Deploy](SC-24-Testnet-Deploy.ipynb)` (sibling-relative, same dir).

Verified by counting `06-Real-World/` contents, confirming SC-15 real topic (ZKP), SC-23 position (1st), SC-24 presence.

## Honest re-execution (C.2, c.99 pattern)

Cell 19 is a pure `print("""...""")` resume footer with **no imports, no deps** — so it is standalone-executable. Re-ran it standalone via `papermill --kernel python3` and transplanted the **real** output + exec_count (1) into the notebook (byte-identical output modulo the link change). `exec_count 8 → 1` reflects this real standalone re-exec. No hand-edited outputs (Stop & Repair respected).

- `papermill rc=0`, `exec_count=1`, `outputs=1`, `output_type=stream` (no error).
- New link present in **both** source and output; old broken link gone from both.

## Verification

- **Byte-identity**: 31/31 other cells byte-identical (`json.dumps` round-trip, indent=1, c.99/c.103). Only cell 19 changed.
- **numstat**: `+3/−3` (3 logical changes: exec_count, source link, output link). No parasitic trailing-newline diff (origin ends with `}`, no `\n`; preserved exactly).
- **C.1 clean**: `0` occurrences of `raise NotImplementedError | assert False | 1/0`.
- **Link resolves**: `SC-24-Testnet-Deploy.ipynb` exists on disk.
- **nbformat**: `INVALID` is **PRE-EXISTING on `origin/main`** (19 markdown cells carry stray `execution_count`/`outputs` keys = papermill metadata pollution). Unrelated to this fix, not introduced here, out of scope (would be a separate cleanup PR).

## Scope

Single broken link found by extending the broken-link scanner (re `#3436`) to SmartContracts. No `Closes` — one link, partial to broader SC-series link hygiene. French-first N/A (code/footer only, no doc prose added).

Co-Authored-By: Claude-Code <noreply@anthropic.com>