### PR TITLE
docs(dectheory): fix 3 post-rename #5203 drifts in DecInfer + DecPyMC READMEs (§E)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/README.md
@@ -118,7 +118,7 @@ Applications : A/B testing adaptatif, recommandation en ligne, essais cliniques 
 | Série | Lien | Relation |
 | --- | --- | --- |
 | [Corpus bayésien Infer](../../Infer/README.md) | Posteriors (Beta, gaussianes) | Le posterior est l'input de la politique de décision |
-| [PyMC](../PyMC/README.md) | PyMC-1 à PyMC-7 | Même arc décision en Python/NUTS (Thompson MCMC, diagnostics ArviZ) |
+| [PyMC](../PyMC/README.md) | DecPyMC-1 à DecPyMC-7 | Même arc décision en Python/NUTS (Thompson MCMC, diagnostics ArviZ) |
 | [Lake `decision_theory_lean`](../../decision_theory_lean/) | Companions 2, 9 | Preuves formelles Lean 4 (vNM, Gittins) |
 | [GameTheory](../../../GameTheory/README.md) | Décision sous incertitude | Miroir : adversaire rationnel vs processus stochastique |
 | [RL](../../../RL/README.md) | MDPs (DecInfer-8) | L'agent apprend la politique par interaction |

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
@@ -30,8 +30,8 @@ Jusqu'à la restructure (#4725), la théorie de la décision était imbriquée d
 
 ```mermaid
 flowchart TD
-    A["<b>Fondations</b> (1-3)<br/>axiomes vNM · utilité de l'argent<br/>aversion au risque"]
-    B["<b>Multi-attributs & réseaux</b> (4-5)<br/>MAUT · diagrammes d'influence"]
+    A["<b>Fondations</b> (1-2)<br/>axiomes vNM · utilité de l'argent<br/>aversion au risque"]
+    B["<b>Multi-attributs & réseaux</b> (3-4)<br/>MAUT · diagrammes d'influence"]
     C["<b>Valeur & robustesse</b> (5-6)<br/>EVPI/EVSI · Minimax/regret"]
     D["<b>Séquentiel & bandits</b> (7)<br/>MDPs · Thompson Sampling MCMC"]
     BAY["Corpus bayésien<br/>../../PyMC/ (posteriors)"]
@@ -55,7 +55,7 @@ Là où l'arc [Infer.NET](../DecInfer/README.md) calcule les posteriors de bandi
 | --- | --- | --- |
 | [Corpus bayésien PyMC](../../PyMC/README.md) | Posteriors (Beta, gaussiennes) | Le posterior est l'input de la politique de décision |
 | [Arc décision Infer.NET](../DecInfer/README.md) | DecInfer-1 à DecInfer-10 | Même arc décision en C# (message passing EP/VMP), avec companions Lean 4 (vNM, Gittins) |
-| [Inférence causale DecPyMC-14](../../PyMC/PyMC-14-Causal-Inference.ipynb) | `do(·)` de Pearl | L'intervention comme transformation de modèle avant la décision |
+| [Inférence causale PyMC-14](../../PyMC/PyMC-14-Causal-Inference.ipynb) | `do(·)` de Pearl | L'intervention comme transformation de modèle avant la décision |
 | [Lake `decision_theory_lean`](../../decision_theory_lean/) | Formalisation | Preuves formelles Lean 4 (vNM sound, Gittins) — companions côté Infer.NET |
 | [GameTheory](../../../GameTheory/README.md) | Décision sous incertitude | Miroir : adversaire rationnel vs processus stochastique |
 | [RL](../../../RL/README.md) | MDPs (DecPyMC-7) | L'agent apprend la politique par interaction |


### PR DESCRIPTION
## Summary

§E feuille audit firsthand on `DecisionTheory/{DecInfer,PyMC}/README.md` found **3 drifts** residual to rename #5203 (PyMC → DecPyMC) + extract #4725. These are intra-file incoherences (mermaid vs prose, stale rename labels) — the canonical §E drift class that a table-only audit misses (leçon c.N+24).

## Drifts fixed

1. **DecPyMC Mermaid L33-34** — ranges `(1-3)(4-5)` were copy-pasted from DecInfer, but `DecPyMC-3 = Multi-Attribute` (not Fondations). Fixed to `(1-2)(3-4)` to match prose L46 (« 3-4 étendent multi-critères et réseaux »). **Intra-file coherence restored** (mermaid ↔ prose).
2. **DecPyMC L58 link label** « Inférence causale DecPyMC-14 » → « PyMC-14 » : DecPyMC series stops at 7, `PyMC-14-Causal-Inference.ipynb` lives in the main corpus (`../PyMC/`).
3. **DecInfer L121 ponts table** « PyMC-1 à PyMC-7 » → « DecPyMC-1 à DecPyMC-7 » : rename #5203 renamed notebooks `DecPyMC-N`, label must follow.

## Gate §E #5353 evidence (whole-file audit)

**(a) find count per subfolder** (exclude `_output.ipynb`, checkpoints, `.lake/`):
- `DecInfer/` = **10** notebooks (`DecInfer-1`..`DecInfer-10`) ✓
- `DecPyMC/` (=`DecisionTheory/PyMC/`) = **7** notebooks (`DecPyMC-1`..`DecPyMC-7`) ✓

**(b) disk ↔ CATALOG-STATUS ↔ prose reconciliation**:
- DecPyMC prose L5 « 7 notebooks » = 7 disk = 7 table entries (L19-25) ✓
- DecInfer prose L5 « 10 notebooks » = 10 disk = 10 table entries (L19-28) ✓
- Detail sections (DecPyMC 1-7, DecInfer 1-10) all match disk ✓
- Catalog not on branch (catalog-pr-hygiene HARD 1) — drift is prose-only, fixed in prose.

**(c) notebook lists / tree / breakdowns current**:
- `python scripts/check_docs_links.py --check --quiet` → **0 broken** (filter DecisionTheory)
- Manual resolve: `DecInfer-1`, `DecPyMC-1`, `../PyMC/PyMC-14-Causal-Inference.ipynb`, `../PyMC/README.md`, `DecInfer/README.md` → all OK
- All 3 drifts were intra-file incoherence (mermaid-vs-prose, stale rename labels), not missing/extra notebooks.

## Scope

+4/-4 markdown-only, 2 files (same series, same rename #5203 root cause = legitimate groupment per §E « exiger groupement » for small doc PRs). No notebook touched, no catalog regenerated.

## Anti-regression

No code/notebook/prove touched. Markdown-only label/range corrections. Pre-existing MD060 linter warnings on DecInfer L18 (table separator style) untouched — not introduced by this PR.

See #3975 (feuille §E rollout), #5081 (renumbering epic).