### PR TITLE
docs(gametheory): fix flowchart TD fil transversal — add 5b/11b/6c notebooks (#3975)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -102,8 +102,8 @@ flowchart TD
         P3["<b>Phase 3</b><br/>Notebooks 13-17<br/>frontières : CFR, mécanismes, RL"]
         P1 --> P2 --> P3
     end
-    LEAN["<b>Fil transversal Lean (b)</b><br/>2b · 4b · 8b · 15b<br/>preuve formelle des grands théorèmes"]
-    PYC["<b>Fil transversal Python (c)</b><br/>4c · 8c · 15c<br/>variantes &amp; visualisations"]
+    LEAN["<b>Fil transversal Lean (b)</b><br/>2b · 4b · 5b · 8b · 11b · 15b<br/>preuve formelle des grands théorèmes"]
+    PYC["<b>Fil transversal Python (c)</b><br/>4c · 6c · 8c · 15c<br/>variantes &amp; visualisations"]
     SC["<b>Sous-série SocialChoice</b><br/>SC-01 → SC-04<br/>Arrow · Sen · vote · SAT/Z3"]
     FIL -.->|"formalise"| LEAN
     FIL -.->|"approfondit"| PYC


### PR DESCRIPTION
## Contexte

Flowchart TD \"Vue d'ensemble\" (header du README GameTheory) listait incomplètement les notebooks des fils transversaux Lean (b) et Python (c). Les notebooks **5b** (Lean-Minimax), **11b** (Lean-BayesianGamesExt) et **6c** (RepeatedGames-FolkTheorem) existent sur disque mais étaient absents des bubbles `LEAN` et `PYC`.

Drift résiduel **non couvert par #5414** (whole-file §E audit mergé) qui visait stats/table/tree/pipeline/L4-label mais pas les bubbles du flowchart TD de header.

## Fix
- Fil Lean (b) : \`2b · 4b · 8b · 15b\` → \`2b · 4b · 5b · 8b · 11b · 15b\`
- Fil Python (c) : \`4c · 8c · 15c\` → \`4c · 6c · 8c · 15c\`

## G.1 verify-before-claiming
Notebooks confirmés exister sur disque (origin/main) :
- \`GameTheory-5b-Lean-Minimax.ipynb\` ✓
- \`GameTheory-11b-Lean-BayesianGamesExt.ipynb\` ✓
- \`GameTheory-6c-RepeatedGames-FolkTheorem.ipynb\` ✓

## Relation avec #5402 (supersede partiel)
**Closes #5402.** #5402 (ma PR précédente, base stale post-#5414) couvrait 4 hunks ; après merge de #5414 :
- Tree entries (cooperative/repeated/conway/stable/minimax lakes) → **déjà couverts par #5414**
- Flowchart LR L4 \"#3954\" → #3954 est MERGED (Bondareva-Shapley prouvé), référence légitime, **pas un drift**
- Mapping table \"Notebooks SC-01/SC-02\" → **SC-01/SC-02 n'existent pas** (\`find\` vide), claim non-vérifiable, **écarté** (G.1)
- **Flowchart TD bubbles 5b/11b/6c** → delta unique + G.1-vérifié, **repris ici**

Sur instruction ai-01 (deep queue dispatch msg-20260705T101258) : rebase vs close décidé → close #5402 + fresh surgical PR avec le delta unique vérifié (évite force-push sur base stale).

## Garde-fous
- ✅ catalog-pr-hygiene R1 : marqueur CATALOG-STATUS byte-identique (\`grep CATALOG\` vide dans le diff)
- ✅ check_docs_links : 0/3386 broken
- ✅ R3 atomique : 1 fichier / +2/-2, markdown-only

See #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)