### PR TITLE
docs(qcpy): add missing QC-Py-23b row to Phase 4 pedagogical table (§E #3976)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -139,6 +139,7 @@ Les notebooks NON EXÉCUTÉS doivent être exécutés (kernel local pour les ind
 | [QC-Py-21-Portfolio-Optimization-ML](QC-Py-21-Portfolio-Optimization-ML.ipynb) | Optimisation ML de portefeuille |
 | [QC-Py-22-Deep-Learning-LSTM](QC-Py-22-Deep-Learning-LSTM.ipynb) | Réseaux LSTM pour séries temporelles |
 | [QC-Py-23-Attention-Transformers](QC-Py-23-Attention-Transformers.ipynb) | Transformers, attention mechanism |
+| [QC-Py-23b-PatchTST-iTransformer](QC-Py-23b-PatchTST-iTransformer.ipynb) | PatchTST, iTransformer — transformers spécialisés séries temporelles |
 | [QC-Py-24-Autoencoders-Anomaly](QC-Py-24-Autoencoders-Anomaly.ipynb) | Détection d'anomalies, autoencodeurs |
 | [QC-Py-25-Reinforcement-Learning](QC-Py-25-Reinforcement-Learning.ipynb) | RL, DQN, environnement trading |
 | [QC-Py-26-LLM-Trading-Signals](QC-Py-26-LLM-Trading-Signals.ipynb) | LLM pour signaux de trading |


### PR DESCRIPTION
## Summary

§E feuille audit firsthand on `QuantConnect/Python/README.md` (deep queue ai-01 #1, assigned turf QC) found **1 drift** : `QC-Py-23b-PatchTST-iTransformer` was present on disk AND in the execution-audit table (L57, « EXÉCUTÉ 13/13 ») but **MISSING from the Phase 4 pedagogical table** (L134-146). Intra-file incoherence — the notebook was added (to disk + exec table) without updating the pedagogical table.

## Drift fixed

Added row between QC-Py-23 and QC-Py-24 in the Phase 4 table. Position matches the nav links inside the notebook itself (« << QC-Py-23-Attention-Transformers / >> QC-Py-24-Autoencoders-Anomaly »). Description grounded in notebook cell[0] header (« PatchTST et iTransformer pour Prevision Financiere »).

## Gate §E #5353 evidence (whole-file audit)

**(a) find count** (excl `_output.ipynb`, checkpoints, examples): **53** `.ipynb` on disk = L88 « 53 notebooks total » ✓

**(b) disk ↔ CATALOG-STATUS ↔ prose reconciliation**:
- L88 « 53 notebooks total — 18 exécutés, 25 non exécutés, 10 doc cloud » coherent (counts verified row-by-row from exec table: 18 EXÉCUTÉ + 10 doc cloud + 25 NON EXÉCUTÉ = 53) ✓
- 4-type table L12-15: 16+2+6+33 = 57 entries (multi-category, L17 explains the delta vs 53 files) ✓
- Catalog not on branch (catalog-pr-hygiene HARD 1) — drift is prose-only, fixed in prose.

**(c) notebook lists / tree / breakdowns current**:
- Phase tables (1: 01-04, 2: 05-10, 3: 11-17, 4: 18-28, Training: 30-32, RL: 33-35, Paper: 40-41, Cloud: 15, Utilitaires: 1) — **23b was the only gap**, now fixed.
- `python scripts/check_docs_links.py --check --quiet` → **0 broken**

## Scope

+1/-0 markdown-only, 1 file. No notebook touched, no catalog regenerated. The root `QuantConnect/README.md` was already refreshed by #5370 (my earlier PR) — this is the Python subseries feuille, a separate file not touched by #5370.

See #3976 (QC feuille §E), #3975.