### PR TITLE
fix(ict): repair broken GameTheory-6c cross-reference in ICT-13 cell[0]

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb
@@ -31,7 +31,7 @@
     "d'invasion eleve).\n",
     "\n",
     "La théorie (grim trigger, seuil $\\delta \\ge (T-R)/(T-P)$, Folk theorem) est\n",
-    "traitée **par renvoi** a [GameTheory-6c](../../GameTheory/GameTheory-6c-Repeated-Games-Folk.ipynb)\n",
+    "traitée **par renvoi** a [GameTheory-6c](../../GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem.ipynb)\n",
     "(merge `182bf33cc`) et, quand il sera livre, au lake formel `repeated_games_lean`\n",
     "([#4880](https://github.com/jsboige/CoursIA/issues/4880)). Ce notebook **verifie\n",
     "numériquement** ses prévisions au lieu de re-dériver la théorie.\n",


### PR DESCRIPTION
## Summary

Repo-wide broken-link scan (continuation of the c.N+44 method that delivered #5412 Sudoku + #5396 DecInfer-9) found **1 broken `.ipynb` cross-reference** in ICT-13.

`ICT-13-AxelrodStrategicMorphodynamics.ipynb` cell[0] (header) pointed to `GameTheory-6c-Repeated-Games-Folk.ipynb`, but the actual file is `GameTheory-6c-RepeatedGames-FolkTheorem.ipynb` (camelCase, no extra hyphens). The cross-reference is now correct and resolves on disk (`os.path.exists` verified).

## Fix

Surgical string replace of the filename inside the markdown link (1 occurrence). Byte-for-byte preservation elsewhere — JSON still valid, no reformatting churn. Cell[0] is a markdown header with no `execution_count`/`outputs`, so the C.2 markdown-only exception applies (no re-execution needed).

## Scope

+1/-1, 1 file, markdown-only (link filename correction). No code cell touched.

## Context

- **No collision** : #5398 (po-2025 diacritics on ICT-13, MERGED) was accents-only and did not touch this link. All ICT-13 PRs are MERGED.
- **Scan coverage** : scanned 808 notebooks repo-wide → 4 broken `.ipynb` links total. This is the **1 actionable** one. The other 3 are in `Search/archive/CSPs_Intro.ipynb` (legacy archive, `EXCLUDE_PEDAGOGICAL`, out of scope — archives are not pedagogical turf).
- **R5.5 cross-lane** : po-2024 notebook turf fixing a cross-reference to GameTheory (same pattern as #5412 Sudoku cross-lane fix earlier this session).

See deep queue ai-01 #3 (repo-wide broken-link scan, continuation).