### PR TITLE
docs(smartcontracts): reconcile 7 feuilles §E — "six sous-séries" → "sept" (#3975)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/README.md
@@ -68,7 +68,7 @@ Cette sous-série d'ouverture vous a posé les **deux socles** sur lesquels tout
 
 - **Solidity par la pratique** : la suite immédiate est [01-Solidity-Foundation](../01-Solidity-Foundation/README.md) (SC-3 Solidity Basics et au-delà), qui exploite l'environnement désormais opérationnel pour écrire de vrais contrats — variables, fonctions, modifiers, événements, héritage.
 - **Approfondir les primitives** : [SC-0-Cypherpunk-Origins](SC-0-Cypherpunk-Origins.ipynb) mérite d'être repris après avoir écrit des contrats en Solidity — la théorie du hachage et de Merkle prend tout son sens quand on manipule `keccak256` et le stockage d'un contrat.
-- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les six sous-séries (Foundations, Solidity, Foundry-Testing, Privacy/Cryptography, Alternative-Chains, Real-World) — cette sous-série n'est que le seuil.
+- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les sept sous-séries (Foundations, Solidity Fondements, Solidity Avancé, Foundry-Testing, Privacy/Cryptography, Alternative-Chains, Real-World) — cette sous-série n'est que le seuil.
 
 ### Le fil rouge
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/README.md
@@ -102,7 +102,7 @@ Chaque concept est illustré par un contrat compilé et déployé **réellement*
 
 - **Standards et cas d'usage réels** : la suite immédiate est [02-Solidity-Advanced](../02-Solidity-Advanced/README.md) (SC-7 à SC-11), qui construit sur ces fondamentaux — ERC-20/721/1155, primitives DeFi, gouvernance DAO, account abstraction, assistance LLM.
 - **Revenir aux fondations** : si la théorie du gas et des data locations (SC-4) reste abstraite, reprenez [SC-0-Cypherpunk-Origins](../00-Foundations/SC-0-Cypherpunk-Origins.ipynb) — comprendre *pourquoi* une blockchain fait payer chaque opération éclaire le modèle économique de la EVM.
-- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les six sous-séries — celle-ci n'est que le socle du langage.
+- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les sept sous-séries — celle-ci n'est que le socle du langage.
 
 ### Le fil rouge
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/README.md
@@ -115,7 +115,7 @@ Comme la sous-série 01, chaque concept est illustré par un contrat compilé et
 
 - **Tester ce qu'on a construit** : la suite immédiate est [03-Foundry-Testing](../03-Foundry-Testing/README.md) (SC-12 à SC-14) — tests, fuzzing d'invariants et vérification formelle. On ne peut déployer en production des standards ERC et des pools DeFi sans une assurance sur leurs propriétés.
 - **Approfondir la gouvernance** : SC-9 (DAO) mérite d'être relu après [GameTheory/SocialChoice](../../../GameTheory/SocialChoice/README.md) — le théorème d'Arrow y est prouvé formellement, et éclaire les limites de tout système de vote on-chain.
-- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les six sous-séries — celle-ci est le cœur applicatif.
+- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les sept sous-séries — celle-ci est le cœur applicatif.
 
 ### Le fil rouge
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/README.md
@@ -111,7 +111,7 @@ Cette sous-série a une signature pédagogique particulière : le code Solidity 
 
 - **Appliquer la preuve à la confidentialité** : la suite est [04-Privacy-Cryptography](../04-Privacy-Cryptography/README.md) (SC-15 à SC-17), où la rigueur formelle des protocoles cryptographiques (ZKP, chiffrement homomorphe) devient centrale.
 - **Approfondir la preuve formelle** : [SymbolicAI/Lean](../../Lean/README.md) développe le même paradigme (spécifier puis prouver) dans un cadre mathématique pur — CVL et Lean sont deux instances du même idéal de vérification.
-- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les six sous-séries — celle-ci est le garde-fous qualité.
+- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les sept sous-séries — celle-ci est le garde-fous qualité.
 
 ### Le fil rouge
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/README.md
@@ -117,7 +117,7 @@ La crypto `pycryptodome` et `phe` est réellement exécutée dans les outputs co
 
 - **Quitter la EVM** : la suite est [05-Alternative-Chains](../05-Alternative-Chains/README.md) (SC-18 à SC-22), qui élargit le horizon à Vyper, XRP, Bitcoin, Move et Solana.
 - **Le capstone** : [06-Real-World / SC-26](../06-Real-World/SC-26-Final-Project.ipynb) réutilisera directement ZKP (SC-15) et Paillier (SC-16) dans une DApp de vote complète — ces primitives prennent tout leur sens assemblées.
-- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les six sous-séries — celle-ci est le socle cryptographique.
+- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les sept sous-séries — celle-ci est le socle cryptographique.
 
 ### Le fil rouge
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/README.md
@@ -117,7 +117,7 @@ La signature pédagogique est multi-langage (Vyper, Bitcoin Script, Move, Rust p
 
 - **Le déploiement réel** : la suite est [06-Real-World](../06-Real-World/README.md) (SC-23 à SC-26), qui confronte ces modèles à des réseaux publics (testnets, mainnets L2) et les assemble dans un capstone.
 - **Revenir sur Ethereum** : après avoir vu UTXO, ressources et paradigmes alternatifs, relire [01-Solidity-Foundation](../01-Solidity-Foundation/README.md) — le modèle Account/EVM apparaît alors comme *un* choix, non *le* choix.
-- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les six sous-séries — celle-ci est le décentrement comparatif.
+- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les sept sous-séries — celle-ci est le décentrement comparatif.
 
 ### Le fil rouge
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/README.md
@@ -127,7 +127,7 @@ Ces notebooks supposent des clés API et private keys lues depuis l'environnemen
 
 - **Le retour aux fondamentaux** : après ce capstone, la série est complète. Le meilleur approfondissement est de reprendre un notebook fondateur ([SC-0](../00-Foundations/SC-0-Cypherpunk-Origins.ipynb) ou [SC-3](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb)) — les primitives et la syntaxe se comprennent autrement une fois qu'on a déployé et sécurisé un système réel.
 - **Au-delà des smart contracts** : [SymbolicAI/Lean](../../Lean/README.md) prolonge l'idéal de vérification (cf SC-14) vers la preuve mathématique ; [GameTheory/SocialChoice](../../../GameTheory/SocialChoice/README.md) approfondit les fondations théoriques du vote (cf SC-9/SC-17, capstone SC-26).
-- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les six sous-séries — celle-ci clôt le parcours SC-0 → SC-26.
+- **La série dans son ensemble** : le [sommaire SmartContracts](../README.md) cartographie les sept sous-séries — celle-ci clôt le parcours SC-0 → SC-26.
 
 ### Le fil rouge
 


### PR DESCRIPTION
## Summary

Whole-file §E audit + reconciliation of the **7 SmartContracts sub-series README feuilles** (00-Foundations → 06-Real-World). See #3975 (READMEs feuilles — SymbolicAI non-Lean + Sudoku + GameTheory). Aligns with ai-01 06:50Z steer ("prioriser §E feuilles #3975").

## Drift G.1 firsthand

All 7 feuilles claimed the top-level README **"cartographie les six sous-séries"** — a copy-paste drift that fused `01-Solidity-Foundation` and `02-Solidity-Advanced` into a single "Solidity" entry. The **top-level README is authoritative and correct**: `7 sous-séries` (L602), tree lists 7 dirs (L128-134), parcours Partie 0-6 (=7 phases). `00-Foundations` additionally enumerated only 6 names (missing Solidity Avancé).

## Fix

- `six → sept` in all 7 feuilles
- `00-Foundations` enumeration now lists the 7 actual names: Foundations, Solidity Fondements, Solidity Avancé, Foundry-Testing, Privacy/Cryptography, Alternative-Chains, Real-World

## Whole-file §E audit (gate pr-review-discipline §E #5353 — disk ↔ prose ↔ structure)

| Check | Result |
|-------|--------|
| Per-sub-series disk counts | 00=3, 01=4, 02=5, 03=3, 04=3, 05=5, 06=4 → **27 total** ✓ matches top-level L38 "27 (SC-0 à SC-26)" |
| Feuille "Total: N notebooks" claims | All 7 match disk ✓ |
| Feuille notebook-table lists | All 7 match disk filenames ✓ |
| `check_docs_links.py --check` | **0 broken** (3387 total), exit 0 |
| CATALOG-STATUS markers touched | **None** (feuilles have no markers; automation-owned, R1 catalog-pr-hygiene) |

## Validation

- Markdown-only, 7 files, +7/-7 (atomique R3)
- No notebook/code change → no re-exec needed
- Branch `docs/sc-3975-feuille-audit` off fresh `origin/main` (R2 rebase frais)

See #3975.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
