### PR TITLE
fix(tweety): re-exec Tweety-2 cell[18] — close C.2 debt (SimplePlReasoner stub)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
@@ -71,128 +71,18 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
-       "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::7d45:cacc:b8c8:f231%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '256556.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": "\r\n<div>\r\n    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n    </div>\r\n    <script type='text/javascript'>\r\nasync function probeAddresses(probingAddresses) {\r\n    function timeout(ms, promise) {\r\n        return new Promise(function (resolve, reject) {\r\n            setTimeout(function () {\r\n                reject(new Error('timeout'))\r\n            }, ms)\r\n            promise.then(resolve, reject)\r\n        })\r\n    }\r\n\r\n    if (Array.isArray(probingAddresses)) {\r\n        for (let i = 0; i < probingAddresses.length; i++) {\r\n\r\n            let rootUrl = probingAddresses[i];\r\n\r\n            if (!rootUrl.endsWith('/')) {\r\n                rootUrl = `${rootUrl}/`;\r\n            }\r\n\r\n            try {\r\n                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n                    method: 'POST',\r\n                    cache: 'no-cache',\r\n                    mode: 'cors',\r\n                    timeout: 1000,\r\n                    headers: {\r\n                        'Content-Type': 'text/plain'\r\n                    },\r\n                    body: probingAddresses[i]\r\n                }));\r\n\r\n                if (response.status == 200) {\r\n                    return rootUrl;\r\n                }\r\n            }\r\n            catch (e) { }\r\n        }\r\n    }\r\n}\r\n\r\nfunction loadDotnetInteractiveApi() {\r\n    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n        .then((root) => {\r\n        // use probing to find host url and api resources\r\n        // load interactive helpers and language services\r\n        let dotnetInteractiveRequire = require.config({\r\n        context: '949024.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n                paths:\r\n            {\r\n                'dotnet-interactive': `${root}resources`\r\n                }\r\n        }) || require;\r\n\r\n            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n\r\n            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n                let paths = {};\r\n                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n                \r\n                let internalRequire = require.config({\r\n                    context: extensionCacheBuster,\r\n                    paths: paths,\r\n                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n                    }) || require;\r\n\r\n                return internalRequire\r\n            };\r\n        \r\n            dotnetInteractiveRequire([\r\n                    'dotnet-interactive/dotnet-interactive'\r\n                ],\r\n                function (dotnet) {\r\n                    dotnet.init(window);\r\n                },\r\n                function (error) {\r\n                    console.log(error);\r\n                }\r\n            );\r\n        })\r\n        .catch(error => {console.log(error);});\r\n    }\r\n\r\n// ensure `require` is available globally\r\nif ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n    let require_script = document.createElement('script');\r\n    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n    require_script.setAttribute('type', 'text/javascript');\r\n    \r\n    \r\n    require_script.onload = function() {\r\n        loadDotnetInteractiveApi();\r\n    };\r\n\r\n    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n}\r\nelse {\r\n    loadDotnetInteractiveApi();\r\n}\r\n\r\n    </script>\r\n</div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>IKVM, 8.15.0</span></li><li><span>IKVM.Image, 8.15.0</span></li></ul></div></div>"
-      ]
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>IKVM</span></li><li><span>IKVM.Image</span></li><li><span>IKVM.Image.runtime.win-x64</span></li></ul></div><div></div></div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -218,11 +108,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True)\r\n"
-     ]
+     "name": "stdout",
+     "text": "IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True)\r\n"
     }
    ],
    "source": [
@@ -304,11 +192,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Tweety (IKVM) reference chargee : org.tweetyproject.tweety-pl v1.30.0.0 (7,0 Mo).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Tweety (IKVM) reference chargee : org.tweetyproject.tweety-pl v1.30.0.0 (7,0 Mo).\r\n"
     }
    ],
    "source": [
@@ -348,39 +234,29 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "a       = a\r\n"
-     ]
+     "name": "stdout",
+     "text": "a       = a\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "!b      = !b\r\n"
-     ]
+     "name": "stdout",
+     "text": "!b      = !b\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "a && !c = a&&!c\r\n"
-     ]
+     "name": "stdout",
+     "text": "a && !c = a&&!c\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "a || b  = a||b\r\n"
-     ]
+     "name": "stdout",
+     "text": "a || b  = a||b\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "a => b  = (a=>b)\r\n"
-     ]
+     "name": "stdout",
+     "text": "a => b  = (a=>b)\r\n"
     }
    ],
    "source": [
@@ -431,18 +307,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Parse de '(a || b) && !c' = (a||b)&&!c\r\n"
-     ]
+     "name": "stdout",
+     "text": "Parse de '(a || b) && !c' = (a||b)&&!c\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "XOR 'a ^^ b' = a^^b\r\n"
-     ]
+     "name": "stdout",
+     "text": "XOR 'a ^^ b' = a^^b\r\n"
     }
    ],
    "source": [
@@ -484,18 +356,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Base de croyances KB = { a&&!c, (a=>b), a, !b }\r\n"
-     ]
+     "name": "stdout",
+     "text": "Base de croyances KB = { a&&!c, (a=>b), a, !b }\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Nombre de formules : 4\r\n"
-     ]
+     "name": "stdout",
+     "text": "Nombre de formules : 4\r\n"
     }
    ],
    "source": [
@@ -556,11 +424,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 1 a completer\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 1 a completer\r\n"
     }
    ],
    "source": [
@@ -587,11 +453,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 2 a completer\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 2 a completer\r\n"
     }
    ],
    "source": [
@@ -616,10 +480,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "6c64944b1d4d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 3 a completer — SimplePlReasoner.query(KB, c) sur {a, a=>b, b=>c}\r\n"
+    }
+   ],
    "source": [
     "// Exercice 3 : Conséquence logique via SimplePlReasoner.\n",
     "//\n",


### PR DESCRIPTION
## Summary

Ferme une dette C.2 sur `Tweety-2-Basic-Logics-Csharp.ipynb` : cell[18] « Exercice 3 : SimplePlReasoner » était **null-exec** (1/10 code cells). La NOTE kernel du notebook clamait *« RECOVERABLE-MACHINE, VS Code Interactive requis »* — **stale** : cells 3-16 utilisent les mêmes `#r IKVM 8.15` + `org.tweetyproject.tweety-pl.dll` et **sont** exécutées (`ec=1..9`).

## Fix

**Per-cell kernel exec** via `jupyter_client.KernelManager` direct (recipe MEMORY `dotnet-interactive-nbconvert-cell0-nuget-block`, prouvée sur ML-5 c.N+49 / PR #5430) :
- `os.chdir(NB_DIR)` avant `start_kernel()` (dotnet-interactive `ContentRootPath` = process cwd)
- `KernelManager(kernel_name='.net-csharp')` (le `cwd=` param ne se propage pas)
- per-cell `get_iopub_msg`, capture stream/execute_result/display_data/error, idle = done

Bypass nbclient CLI wrapper. Les 10 code cells re-exécutées avec succès, `ec [1..10]`, **0 erreur**. cell[18] maintenant `ec=10`, output « Exercice 3 a completer » (stub C.1 conforme).

## Validation (règle C.2)

- **Anti-regression** : **0 source diff** (source byte-identical vs `origin/main`, vérifié via `git show`)
- **C.2** : 10/10 code cells `ec [1..10]`, 0 null, **0 erreur**, outputs substantiels (stream/display_data)
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0`
- **0 path leak** (outputs + source)
- **cell[6]** `#r "dll"` 0 outputs = **INTRINSIC** Constat 3 #5039 (directive `#r` silencieuse par défaut, documenté MEMORY `dotnet-interactive-r-dll-silent-alc-invisible`)

Diff `+41/-171` = outputs régénérés plus compacts via per-cell kernel (l'original VS Code avait des outputs verbeux), pas de suppression de contenu.

## Leçon (généralise c.N+49)

La recipe per-cell kernel s'applique à **tous** les notebooks .NET (Tweety, ML.Net, Sudoku…), pas seulement ML.Net. Tout verdict `RECOVERABLE-MACHINE, VS Code Interactive requis` dans une NOTE kernel est **stale post-c.N+49** : le per-cell kernel exec marche sans VS Code. `RECOVERABLE-LOCAL`, pas `MACHINE`.

## Anti-collision

`gh pr list --search "Tweety-2"` = 0 PR sur ce notebook (#5424/#5427 = READMEs). Control group Tweety-2 (Basic-Logics, pl.dll) exécuté OK — pas dans le cluster defectif Tw-3 (Advanced-Logics/Conditional-Logics/QBF, IKVM drop core types, MEMORY `tweety-dotnet-new-module-build-gated`).

See #5039 #5005 #5147

🤖 Generated with [Claude Code](https://claude.com/claude-code)