### PR TITLE
docs(infer): restore French accents in Infer-14-Causal-Inference markdown (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Causal-Inference.ipynb
@@ -16,7 +16,7 @@
     "## Objectifs\n",
     "\n",
     "- Distinguer **observation** `P(Y|X)` et **intervention** `P(Y|do(X))` (Pearl, 2000)\n",
-    "- Implementer le **do-operateur** par **mutilation de graphe** en Infer.NET\n",
+    "- Implementer le **do-opérateur** par **mutilation de graphe** en Infer.NET\n",
     "- Calculer l'effet causal via **backdoor** et **front-door adjustment**\n",
     "- Reconnaitre le **paradoxe de Simpson** et le resoudre causalement\n",
     "- Aborder le **contrefactuel** (Niveau 3 de l'echelle de Pearl)\n",
@@ -28,7 +28,7 @@
     "|-----------|---------|\n",
     "| [Infer-10-Thompson-Sampling](../DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb) | (fin de la serie) |\n",
     "\n",
-    "> **Pont inter-series (constellation causale)** : le do-calculus de Pearl se decline en **plusieurs paradigmes** dans ce depot, et ce notebook en est le versant **probabiliste distributionnel** (.NET/Infer.NET) -- les effets causaux y sont **calcules** par mutilation de graphe. Le jumeau **Python/PyMC** porte les memes exemples (barometre, Sprinkler) via l'operateur natif `pm.do` : voir [PyMC-14-Causal-Inference](../PyMC/PyMC-14-Causal-Inference.ipynb), ainsi que la demo historique `P(Cloudy|do(Rain))` dans [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb). Enfin, le traitement **symbolique** (Java/Tweety, raisonneur contrefactuel propositionnel) est dans [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb). La section **Constellation causale** en fin de notebook cartographie ces quatre implementations (y compris l'emergence causale a l'echelle, [ICT-5](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb)).\n"
+    "> **Pont inter-series (constellation causale)** : le do-calculus de Pearl se decline en **plusieurs paradigmes** dans ce depot, et ce notebook en est le versant **probabiliste distributionnel** (.NET/Infer.NET) -- les effets causaux y sont **calcules** par mutilation de graphe. Le jumeau **Python/PyMC** porte les mêmes exemples (barometre, Sprinkler) via l'opérateur natif `pm.do` : voir [PyMC-14-Causal-Inference](../PyMC/PyMC-14-Causal-Inference.ipynb), ainsi que la demo historique `P(Cloudy|do(Rain))` dans [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb). Enfin, le traitement **symbolique** (Java/Tweety, raisonneur contrefactuel propositionnel) est dans [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb). La section **Constellation causale** en fin de notebook cartographie ces quatre implementations (y compris l'emergence causale a l'echelle, [ICT-5](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb)).\n"
    ]
   },
   {
@@ -54,7 +54,7 @@
     "\n",
     "**Inegalite fondamentale** : `P(Y|X) != P(Y|do(X))` des qu'un **confondeur** (cause commune de X et Y) biaise l'observation. Ce notebook montre comment un **reseau bayesien observationnel** ne sait pas calculer `do(X)` seul — il faut **mutiler le graphe** (couper les arcs entrants de X), une operation que nous implementons explicitement en Infer.NET.\n",
     "\n",
-    "> **References** : Pearl, J. (1995), *Causal diagrams for empirical research*, JRSS B 57(3) ; Pearl, J. (2000), *Causality : Models, Reasoning, and Inference*, Cambridge University Press ; Pearl, J., Glymour, M. & Jewell, N. P. (2016), *Causal Inference in Statistics : A Primer*, Wiley.\n"
+    "> **Références** : Pearl, J. (1995), *Causal diagrams for empirical research*, JRSS B 57(3) ; Pearl, J. (2000), *Causality : Models, Reasoning, and Inference*, Cambridge University Press ; Pearl, J., Glymour, M. & Jewell, N. P. (2016), *Causal Inference in Statistics : A Primer*, Wiley.\n"
    ]
   },
   {
@@ -64,7 +64,7 @@
    "source": [
     "## 2. Configuration d'Infer.NET\n",
     "\n",
-    "Chargement du moteur d'inference probabiliste et du helper de visualisation des graphes de facteurs (meme `#load` que toute la serie, cf [Infer-3](Infer-3-Factor-Graphs.ipynb), [Infer-4](../DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb))."
+    "Chargement du moteur d'inference probabiliste et du helper de visualisation des graphes de facteurs (même `#load` que toute la serie, cf [Infer-3](Infer-3-Factor-Graphs.ipynb), [Infer-4](../DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb))."
    ]
   },
   {
@@ -485,7 +485,7 @@
    "source": [
     "### 3.2 Niveau 2 — Intervention `P(Storm | do(Barometre baisse))`\n",
     "\n",
-    "Maintenant **provoquons** la chute du barometre (par exemple en tapant dessus). Pour modeliser cette intervention, on **mutile le graphe** : on coupe l'arc `BassePression -> Barometre` et on force `Barometre = baisse` **independamment** de la pression. En Infer.NET cela se traduit par `Variable.Bernoulli(1.0)` (valeur forcee, sans parent) au lieu d'un `SetTo` conditionne a la pression — c'est l'idiome d'introduction du `do()` (deja utilise en [Infer-4 cell39](Infer-4-Bayesian-Networks.ipynb))."
+    "Maintenant **provoquons** la chute du barometre (par exemple en tapant dessus). Pour modeliser cette intervention, on **mutile le graphe** : on coupe l'arc `BassePression -> Barometre` et on force `Barometre = baisse` **independamment** de la pression. En Infer.NET cela se traduit par `Variable.Bernoulli(1.0)` (valeur forcee, sans parent) au lieu d'un `SetTo` conditionne a la pression — c'est l'idiome d'introduction du `do()` (déjà utilise en [Infer-4 cell39](Infer-4-Bayesian-Networks.ipynb))."
    ]
   },
   {
@@ -576,7 +576,7 @@
    "id": "f66599cbb521",
    "metadata": {},
    "source": [
-    "**Resultat** : `P(Storm|Barometre baisse)` (observation) **!=** `P(Storm|do(Barometre baisse))` (intervention). L'effet causal de l'intervention est nul — la chute du barometre ne provoque pas de tempete. L'observation etait **biaisee** par le confondeur `BassePression`.\n",
+    "**Resultat** : `P(Storm|Barometre baisse)` (observation) **!=** `P(Storm|do(Barometre baisse))` (intervention). L'effet causal de l'intervention est nul — la chute du barometre ne provoque pas de tempete. L'observation était **biaisee** par le confondeur `BassePression`.\n",
     "\n",
     "> **Prong-B (non-trivialite)** : ce resultat n'est pas une lecture triviale de CPT. Un reseau bayesien observationnel calcule `P(Storm|Barometre baisse)` mais ne sait **pas** calculer `do(Barometre baisse)` seul — il a fallu **mutiler le graphe** (couper l'arc entrant). Les deux quantites **different visiblement**, ce qui prouve que le `do()` fait un travail reel.\n"
    ]
@@ -588,7 +588,7 @@
    "source": [
     "## 4. Reseau Sprinkler — cross-check avec PyMC-4\n",
     "\n",
-    "Verifions sur le reseau canonique de Pearl (Cloudy -> {Sprinkler, Rain} -> WetGrass, deja construit en [Infer-4](Infer-4-Bayesian-Networks.ipynb)) que nos valeurs Infer.NET recoupent le jumeau Python/PyMC. La requete `P(Cloudy | Rain=True)` vs `P(Cloudy | do(Rain=True))` vaut **0.800 vs 0.500** dans [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) (section 8)."
+    "Verifions sur le reseau canonique de Pearl (Cloudy -> {Sprinkler, Rain} -> WetGrass, déjà construit en [Infer-4](Infer-4-Bayesian-Networks.ipynb)) que nos valeurs Infer.NET recoupent le jumeau Python/PyMC. La requete `P(Cloudy | Rain=True)` vs `P(Cloudy | do(Rain=True))` vaut **0.800 vs 0.500** dans [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) (section 8)."
    ]
   },
   {
@@ -1263,7 +1263,7 @@
     "\n",
     "$$ \\mathrm{CDE}(m) = P(Y{=}1 \\mid do(X{=}1), do(M{=}m)) - P(Y{=}1 \\mid do(X{=}0), do(M{=}m)) $$\n",
     "\n",
-    "Si l'effet total `TE = P(Y|do(X=1)) - P(Y|do(X=0))` est superieur au CDE, la difference capte la part qui passe **par le mediateur** (effet indirect). C'est une **double mutilation** de graphe -- le meme operateur `do()` qu'en section 3.2, applique deux fois.\n",
+    "Si l'effet total `TE = P(Y|do(X=1)) - P(Y|do(X=0))` est superieur au CDE, la difference capte la part qui passe **par le mediateur** (effet indirect). C'est une **double mutilation** de graphe -- le même opérateur `do()` qu'en section 3.2, applique deux fois.\n",
     "\n",
     "**Exemple.** X = suivre un programme de formation, M = competences acquises, Y = obtenir une promotion. La formation peut mener a la promotion de deux facons : directement (effet de signal / diplome) ou indirectement (les competences declenchent la promotion)."
    ]
@@ -1452,7 +1452,7 @@
    "source": [
     "**Lecture.** L'effet total de la formation sur la promotion vaut **0,460** (46 points de probabilite). Mais quand on fige les competences acquises (`do(M=0)`, \"formation sans competences\"), l'effet direct retombe a **0,300**. La difference **0,160** est la part **mediee** : ce que la formation apporte a la promotion *via* les competences. Le CDE a `M=1` (0,200) est encore plus bas, car `do(M=1)` place tout le monde en position \"competent\", ou la formation ajoute moins.\n",
     "\n",
-    "**Ce que montre la cellule.** La front-door (section 6) donnait l'effet total via le mediateur ; la mediation **decompose** cet effet. C'est le meme operateur `do()`, applique deux fois (double mutilation) -- l'inference par message passing Infer.NET (exacte sur ce SCM discret) rend TE et CDE calculables separement et comparables. **Non-trivialite** : l'effet direct (0,300) differe de l'effet total (0,460) de facon **visible**, preuve que le mediateur porte une part reelle de l'effet -- dans un SCM degenere sans chemin indirect, TE egalerais exactement CDE."
+    "**Ce que montre la cellule.** La front-door (section 6) donnait l'effet total via le mediateur ; la mediation **decompose** cet effet. C'est le même opérateur `do()`, applique deux fois (double mutilation) -- l'inference par message passing Infer.NET (exacte sur ce SCM discret) rend TE et CDE calculables separement et comparables. **Non-trivialite** : l'effet direct (0,300) differe de l'effet total (0,460) de facon **visible**, preuve que le mediateur porte une part reelle de l'effet -- dans un SCM degenere sans chemin indirect, TE egalerais exactement CDE."
    ]
   },
   {
@@ -1462,17 +1462,17 @@
    "source": [
     "## 9. Le do-calculus (regles de Pearl)\n",
     "\n",
-    "Pearl (1995) a demontre que **toute** quantite causale identifiable peut etre calculee a partir de trois regles de reecriture, qui transforment des expressions avec `do()` en expressions observationnelles (sans `do()`). Soit `G_X` le graphe mutile (arcs entrants de `X` supprimes) et `G_{underline{X}}` le graphe ou les arcs sortants de `X` sont supprimes :\n",
+    "Pearl (1995) a demontre que **toute** quantite causale identifiable peut être calculee a partir de trois regles de reecriture, qui transforment des expressions avec `do()` en expressions observationnelles (sans `do()`). Soit `G_X` le graphe mutile (arcs entrants de `X` supprimes) et `G_{underline{X}}` le graphe ou les arcs sortants de `X` sont supprimes :\n",
     "\n",
     "| Regle | Enonce | Effet |\n",
     "|-------|--------|-------|\n",
-    "| **Regle 1 (insertion/deletion)** | `P(y | do(x), z, w) = P(y | do(x), w)` si `Y _||_ Z | X, W` dans `G_X` | Observations irrelevantes peuvent etre retirees |\n",
-    "| **Regle 2 (action/observation)** | `P(y | do(x), do(z), w) = P(y | do(x), z, w)` si `Y _||_ Z | X, W` dans `G_{underline{X}}` | Une action peut etre remplacee par une observation |\n",
-    "| **Regle 3 (insertion/deletion d'actions)** | `P(y | do(x), do(z), w) = P(y | do(x), w)` si `Y _||_ Z | X, W` dans `G_{X, tilde{Z(W)}}` | Une action irrelevant peut etre retiree |\n",
+    "| **Regle 1 (insertion/deletion)** | `P(y | do(x), z, w) = P(y | do(x), w)` si `Y _||_ Z | X, W` dans `G_X` | Observations irrelevantes peuvent être retirees |\n",
+    "| **Regle 2 (action/observation)** | `P(y | do(x), do(z), w) = P(y | do(x), z, w)` si `Y _||_ Z | X, W` dans `G_{underline{X}}` | Une action peut être remplacee par une observation |\n",
+    "| **Regle 3 (insertion/deletion d'actions)** | `P(y | do(x), do(z), w) = P(y | do(x), w)` si `Y _||_ Z | X, W` dans `G_{X, tilde{Z(W)}}` | Une action irrelevant peut être retiree |\n",
     "\n",
     "**Critere backdoor** (Shpitser, Pearl & Verma) : un ensemble `Z` satisfait le critere backdoor relatif a `(X,Y)` si aucun noeud de `Z` n'est un descendant de `X`, et `Z` bloque tous les chemins backdoor (arcs entrants de `X`). Alors `P(Y|do(X)) = Somme_z P(Y|X,Z)P(Z)` — c'est exactement la formule appliquee en section 5.\n",
     "\n",
-    "> **Theoreme de completude** (Shpitser & Pearl, 2006) : les trois regles sont **completes** — si un effet causal n'est pas calculable par ces regles, il n'est **pas identifiable** a partir du graphe seul. C'est un plafond fondamental, pas une limite d'implementation."
+    "> **Théorème de completude** (Shpitser & Pearl, 2006) : les trois regles sont **complètes** — si un effet causal n'est pas calculable par ces regles, il n'est **pas identifiable** a partir du graphe seul. C'est un plafond fondamental, pas une limite d'implementation."
    ]
   },
   {
@@ -1484,12 +1484,12 @@
     "\n",
     "Le niveau 3 de l'echelle de Pearl repond aux questions **contrefactuelles** : *\"Sachant qu'un patient a pris le medicament ET a gueri, aurait-il gueri SANS medicament ?\"*\n",
     "\n",
-    "On resout cela en **deux etapes** (twin-network / abduction-prediction) :\n",
+    "On resout cela en **deux étapes** (twin-network / abduction-prediction) :\n",
     "\n",
     "1. **Abduction** : inferer le **posterieur** sur les variables latentes (ici la severite) sachant ce qu'on observe (pris le medicament, a gueri).\n",
     "2. **Prediction/action** : reutiliser ce posterieur comme **prior** dans le graphe **mutile** (`do(NoDrug)`) pour predire le resultat contrefactuel.\n",
     "\n",
-    "Cette etape est plus couteuse qu'une simple intervention (elle requiert une inference posterieure puis une seconde inference). C'est honnetement le plafond pratique de l'inference causale **deterministe** (message passing) sur ce type de SCM."
+    "Cette étape est plus couteuse qu'une simple intervention (elle requiert une inference posterieure puis une seconde inference). C'est honnetement le plafond pratique de l'inference causale **deterministe** (message passing) sur ce type de SCM."
    ]
   },
   {
@@ -1613,7 +1613,7 @@
    "source": [
     "## 11. Exercices\n",
     "\n",
-    "Quatre exercices pour ancrer le do-calculus. Chaque stub s'execute sans erreur (`Console.WriteLine`) ; a vous de completer le code entre les `// TODO`.\n",
+    "Quatre exercices pour ancrer le do-calculus. Chaque stub s'execute sans erreur (`Console.WriteLine`) ; a vous de compléter le code entre les `// TODO`.\n",
     "\n",
     "| # | Exercice | Concept |\n",
     "|---|----------|---------|\n",
@@ -1629,11 +1629,11 @@
    "source": [
     "### Exercice 1 - SCM confondu : education -> revenu\n",
     "\n",
-    "**Concept** (cf. section 3, barometre) : un meme parent latent `U` (niveau d'etudes des parents) cause a la fois `X` (education de l'enfant) et `Y` (revenu). L'**observation** `P(Revenu | Education=haute)` et l'**intervention** `P(Revenu | do(Education=haute))` different : seule la seconde isole l'effet causal de l'education, en coupant l'influence de `U` sur `X`.\n",
+    "**Concept** (cf. section 3, barometre) : un même parent latent `U` (niveau d'études des parents) cause a la fois `X` (education de l'enfant) et `Y` (revenu). L'**observation** `P(Revenu | Education=haute)` et l'**intervention** `P(Revenu | do(Education=haute))` different : seule la seconde isole l'effet causal de l'education, en coupant l'influence de `U` sur `X`.\n",
     "\n",
     "**Objectif** : coder le SCM (CPT via `Variable.If` comme en section 3), calculer les deux quantites, puis **mutiler l'arc `U -> X`** (`Bernoulli(1.0)` force) pour le `do()`.\n",
     "\n",
-    "Les etapes (`// Etape N`) et l'indice sont dans le code ci-dessous."
+    "Les étapes (`// Étape N`) et l'indice sont dans le code ci-dessous."
    ]
   },
   {
@@ -1782,20 +1782,20 @@
     "| Paradigme | Moteur / langage | Idiome du `do(X)` | Notebook | Ce qu'il apporte |\n",
     "|-----------|------------------|-------------------|----------|------------------|\n",
     "| **Probabiliste distributionnel** | Infer.NET (C#) | **Mutilation de graphe** : `Variable.Bernoulli(1.0)` force la valeur et coupe l'arc parent | ce notebook | Effet causal **calcule** par message passing deterministe (EP/VMP) sur le graphe mutile |\n",
-    "| **Probabiliste (transformation)** | PyMC (Python) | Operateur natif `pm.do` : l'intervention est une **transformation de modele de premiere classe** | [PyMC-14](../PyMC/PyMC-14-Causal-Inference.ipynb) | `do` rebranche comme un operateur du langage probabiliste |\n",
+    "| **Probabiliste (transformation)** | PyMC (Python) | Opérateur natif `pm.do` : l'intervention est une **transformation de modele de premiere classe** | [PyMC-14](../PyMC/PyMC-14-Causal-Inference.ipynb) | `do` rebranche comme un opérateur du langage probabiliste |\n",
     "| **Symbolique propositionnel** | Tweety (Java) | **Raisonneur contrefactuel** : logique classique, preuves argumentatives (pas de probabilites) | [Tweety-11](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | Raisonnement **qualitatif** : \"X cause-t-il Y ?\" sans chiffres |\n",
     "| **Emergence causale (echelle)** | PyPhi (Python) | **Intervention sur la partition** : `do_coarse_grain` / `do_blackbox` force une echelle macro et mesure l'information effective (EI) | [ICT-5-CausalEmergence](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb) | Le `do` s'applique a l'**echelle** : quelle description (micro vs macro) est causalement la plus forte (Hoel 2013, Jansma & Hoel 2025) |\n",
     "\n",
-    "**Valeurs croisees (verification inter-paradigme).** Sur le **meme** exemple du barometre (confondeur `BassePression -> {Barometre, Storm}`), les deux versants probabilistes **recoupent** exactement :\n",
+    "**Valeurs croisees (verification inter-paradigme).** Sur le **même** exemple du barometre (confondeur `BassePression -> {Barometre, Storm}`), les deux versants probabilistes **recoupent** exactement :\n",
     "\n",
     "| Quantite | Infer.NET (ce notebook, sec 3) | PyMC-14 |\n",
     "|----------|-------------------------------|---------|\n",
     "| `P(Storm | Barometre baisse)` (observation) | **0,656** | **0,656** |\n",
     "| `P(Storm | do(Barometre baisse))` (intervention) | **0,310** | **0,310** |\n",
     "\n",
-    "L'effondrement de la correlation (`0,656 -> 0,310`) lorsqu'on passe de l'observation a l'intervention est le **signal que le moteur fait un vrai travail causal** (mutilation, pas une simple lecture de CPT) -- et les deux moteurs, malgre leurs idiomes differents (mutilation Infer.NET vs `pm.do` PyMC), convergent vers les memes valeurs. Sur le reseau Sprinkler, `P(Cloudy|Rain)=0,800` vs `P(Cloudy|do(Rain))=0,500` (sec 4 ici, et [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) sec 8).\n",
+    "L'effondrement de la correlation (`0,656 -> 0,310`) lorsqu'on passe de l'observation a l'intervention est le **signal que le moteur fait un vrai travail causal** (mutilation, pas une simple lecture de CPT) -- et les deux moteurs, malgre leurs idiomes differents (mutilation Infer.NET vs `pm.do` PyMC), convergent vers les mêmes valeurs. Sur le reseau Sprinkler, `P(Cloudy|Rain)=0,800` vs `P(Cloudy|do(Rain))=0,500` (sec 4 ici, et [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) sec 8).\n",
     "\n",
-    "**L'angle ICT (emergence causale).** Le quatrieme paradigme, [ICT-5-CausalEmergence](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb), deplace la question : au lieu d'intervenir sur une **variable** (`do(X=x)`), il intervient sur l'**echelle de description** (`do_coarse_grain`) et mesure quelle partition (micro vs macro) maximise l'**information effective**. C'est le meme operateur d'intervention de Pearl, applique a la granularite du modele plutot qu'a la valeur d'un noeud -- d'ou l'expression *emergence causale* (la macro peut etre causalement plus forte que la micro).\n",
+    "**L'angle ICT (emergence causale).** Le quatrieme paradigme, [ICT-5-CausalEmergence](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb), deplace la question : au lieu d'intervenir sur une **variable** (`do(X=x)`), il intervient sur l'**echelle de description** (`do_coarse_grain`) et mesure quelle partition (micro vs macro) maximise l'**information effective**. C'est le même opérateur d'intervention de Pearl, applique a la granularite du modele plutot qu'a la valeur d'un noeud -- d'ou l'expression *emergence causale* (la macro peut être causalement plus forte que la micro).\n",
     "\n",
     "**Ce qu'il faut retenir.** Quatre implementations, **un seul do-calculus**. Le paradigme Infer.NET met l'accent sur la **structure** (mutiler le graphe = une operation que le moteur d'inference execute) ; PyMC met l'accent sur la **composabilite** (`do` comme transformation de modele) ; Tweety met l'accent sur le **raisonnement** (causalite sans nombres) ; ICT (PyPhi) met l'accent sur l'**echelle** (intervenir sur la partition, pas sur la variable). Choisir l'un ou l'autre, c'est choisir ce que l'on veut : des probabilites deterministes (message passing), du sampling flexible, des preuves qualitatives, ou identifier la bonne echelle de description."
    ]
@@ -1807,7 +1807,7 @@
    "source": [
     "## 12. Synthese\n",
     "\n",
-    "| Niveau | Question | Operateur | Methode Infer.NET |\n",
+    "| Niveau | Question | Opérateur | Méthode Infer.NET |\n",
     "|--------|----------|-----------|-------------------|\n",
     "| **1 Association** | Que voit-on ? | `P(Y|X)` | `ObservedValue` |\n",
     "| **2 Intervention** | Que se passe-t-il si on agit ? | `P(Y|do(X))` | **Mutilation** : `Bernoulli(1.0)` force, coupe l'arc parent |\n",
@@ -1821,15 +1821,15 @@
     "### Ce qu'il faut retenir\n",
     "\n",
     "- **`P(Y|X) != P(Y|do(X))`** : l'observation est biaisee par les confondeurs. Un reseau bayesien observationnel ne sait **pas** calculer `do(X)` seul — il faut **mutiler le graphe**.\n",
-    "- **La mutilation n'est pas une lecture de CPT** : couper les arcs entrants de `X` est une operation structurelle que le moteur d'inference Infer.NET execute apres qu'on a redefini `X` sans parent. La difference visible entre observation et intervention prouve que le `do()` fait un travail reel (Prong-B).\n",
+    "- **La mutilation n'est pas une lecture de CPT** : couper les arcs entrants de `X` est une operation structurelle que le moteur d'inference Infer.NET execute après qu'on a redefini `X` sans parent. La difference visible entre observation et intervention prouve que le `do()` fait un travail reel (Prong-B).\n",
     "- **Backdoor et front-door rendent l'effet causal identifiable** a partir de donnees observationnelles, sous conditions graphiques — formalisees par le do-calculus (Pearl 1995), complet (Shpitser & Pearl 2006).\n",
     "\n",
     "### Pour aller plus loin\n",
     "- **[Notebook-pont — du graphe causal au do-calculus](../DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb)** : l'armature formelle unifiée de Pearl (échelle + 3 règles) exécutée sur l'outil de référence `dowhy` (identification backdoor/front-door + estimation + réfutation), qui relie cette série à Tweety-11, PyMC-14 et ICT-5.\n",
     "\n",
-    "- **Pont symbolique** : [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) traite le `do()` et les contrefactuels en **Java/Tweety** (raisonnement propositionnel) — meme echelle de Pearl, paradigme different.\n",
-    "- **Pont Python** : [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb) demontre la meme distinction `P(Cloudy|Rain)` vs `P(Cloudy|do(Rain))` en MCMC.\n",
-    "- **References** : Pearl (2000) *Causality* ; Pearl, Glymour & Jewell (2016) *Causal Inference in Statistics : A Primer* ; Shpitser & Pearl (2006) *Identification of Conditional Interventional Effects*.\n",
+    "- **Pont symbolique** : [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) traite le `do()` et les contrefactuels en **Java/Tweety** (raisonnement propositionnel) — même echelle de Pearl, paradigme different.\n",
+    "- **Pont Python** : [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb) demontre la même distinction `P(Cloudy|Rain)` vs `P(Cloudy|do(Rain))` en MCMC.\n",
+    "- **Références** : Pearl (2000) *Causality* ; Pearl, Glymour & Jewell (2016) *Causal Inference in Statistics : A Primer* ; Shpitser & Pearl (2006) *Identification of Conditional Interventional Effects*.\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Summary

Restaure les accents français manquants dans le markdown d'`Infer-14-Causal-Inference.ipynb` (épic #2876). **Partition po-2024 = Infer** (cap 1/lane/jour respectée — 0 PR accent ce session, po-2023 = Sudoku aujourd'hui = autre partition, 0 collision).

## Mutations (38 au total, 14 cellules markdown)

| De-accented | Accented | Count |
|---|---|---|
| operateur | opérateur | 8 |
| etre | être | 5 |
| references | références | 2 |
| deja | déjà | 2 |
| etapes | étapes | 2 |
| etape | étape | 2 |
| theoreme | théorème | 1 |
| methode | méthode | 1 |
| apres | après | 1 |
| completer | compléter | 1 |
| completes | complètes | 1 |
| etudes | études | 1 |
| memes | mêmes | 2 |
| etait | était | 1 |
| (+ autres) | | |

## Validation (règle C.2 + MEMORY [[accent-pr-deaccent-verification]])

- **De-accent verification** : `deaccent(old) == deaccent(new)` pour toute cellule → **0 mismatch** = preuve mécanique qu'**aucun mot n'a été modifié**, seuls les accents ont été ajoutés (zéro typo risque)
- **Code cells changed : 0** (markdown-only → exception C.2, pas de re-exec)
- **Structure markdown préservée** byte-for-byte modulo accents (headers, tables, liens, gras)

## Anti-collision

`gh pr list --search "Infer accents"` = 0 PR concurrente. Partition MEMORY : po-2024=Infer, po-2023=Sudoku. Cap 1/lane/jour respectée.

See #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)