### PR TITLE
feat(lean): i18n tranche 1 - Graph_en.lean EN sibling (astar_lean #4980)

### DIFF
--- a/MyIA.AI.Notebooks/Search/astar_lean/Astar/Graph_en.lean
+++ b/MyIA.AI.Notebooks/Search/astar_lean/Astar/Graph_en.lean
@@ -1,0 +1,59 @@
+import Mathlib
+
+/-!
+# Astar.Graph — weighted graphs, paths, cost of a path
+
+English mirror of `AStar/Graph.lean` (FR-first canonical), tranche 1 EPIC #4980
+(astar_lean). Convention i18n Lean ratified by ai-01 (2026-07-04, #4980
+comment-4881909354): distinct FR + EN sibling files in the same lake, both
+compile; namespace `Astar_en` (anti-collision with FR `Astar`); non-docstring
+content byte-identical (CI drift-detectable); EN docstrings manually translated.
+
+Abstract model for the optimality proof of A* (issue #4048). A weighted directed
+graph with non-negative edges (`NNReal` ≡ ℝ≥0), paths seen as lists of vertices,
+and the cost of a path as the sum of the weights of its consecutive arcs.
+-/
+
+namespace Astar_en
+
+/- Abstract vertices: `V` is the vertex type, a parameter of the model. -/
+variable {V : Type*}
+
+/-- Weighted directed graph: `edge a b` is the non-negative cost of the arc
+    `a → b`. The value `0` means "no arc" (or a trivial loop). The
+    non-negativity assumption (`NNReal`) is exactly the assumption required
+    for the optimality of A*. -/
+structure WeightedGraph (V : Type*) where
+  /-- Weight (non-negative) of each directed arc. -/
+  edge : V → V → NNReal
+
+variable (G : WeightedGraph V)
+
+/-- A path is a list of consecutive vertices. -/
+abbrev Path (V : Type*) := List V
+
+/-- Cost of a path = sum of the weights of the consecutive arcs.
+
+    `pathCost [] = 0`, `pathCost [v] = 0` (a lone vertex has no arc),
+    `pathCost [v₀, v₁, v₂, ...] = edge v₀ v₁ + edge v₁ v₂ + ...`. -/
+def pathCost : Path V → NNReal
+  | [] => 0
+  | [_] => 0
+  | v₀ :: v₁ :: rest => G.edge v₀ v₁ + pathCost (v₁ :: rest)
+
+@[simp]
+theorem pathCost_nil : pathCost G ([] : Path V) = 0 := rfl
+
+@[simp]
+theorem pathCost_singleton (v : V) : pathCost G [v] = 0 := rfl
+
+@[simp]
+theorem pathCost_cons_cons (v₀ v₁ : V) (rest : Path V) :
+    pathCost G (v₀ :: v₁ :: rest) = G.edge v₀ v₁ + pathCost G (v₁ :: rest) := rfl
+
+/-- A path `p` goes from `start` to `goal`: it is non-empty, its first vertex
+    is `start` and its last vertex is `goal`. -/
+def PathFrom (start goal : V) (p : Path V) : Prop :=
+  p ≠ [] ∧ p.head? = some start ∧ p.getLast? = some goal
+
+end Astar_en


### PR DESCRIPTION
## Scope

English mirror of `AStar/Graph.lean` (FR-first canonical) — tranche 1 EPIC #4980 (astar_lean). First i18n sibling for this lake (FR=5 EN=0 → FR=5 EN=1). Diversifies family (4 prior cycles were GameTheory; astar_lean = Search family).

## Convention (ratified ai-01 2026-07-04, #4980 comment-4881909354)

- Distinct FR + EN sibling files in the same lake, both compile
- Namespace `Astar_en` (anti-collision with FR `Astar`)
- Non-docstring content byte-identical between siblings (CI drift-detectable)
- EN docstrings = manual translation of FR canonical

## Content (Graph_en.lean, 59 lines)

In `namespace Astar_en`, mirror of FR:
- `WeightedGraph` (V structure with `edge : V → V → NNReal` field)
- `Path` (abbrev List V), `pathCost` (recursive sum of consecutive arc weights)
- `pathCost_nil`, `pathCost_singleton`, `pathCost_cons_cons` (3 simp theorems, rfl)
- `PathFrom` (path from start to goal predicate)

Proofs byte-identical to FR (all `rfl`-based, 0 sorry).

## lake build SUCCESS firsthand (lean-merge-discipline HARD)

Toolchain `leanprover/lean4:v4.31.0-rc1`, mathlib rc1 junctioned `d568c8c0` (#4363), `lake.exe` Windows-native:

```
$ lake build Astar
Build completed successfully (8498 jobs)
```

Graph_en.olean produced: `.lake/build/lib/lean/Astar/Graph_en.olean` (69640 bytes). Lakefile globs `.submodules \`Astar` auto-discovers the new sibling (no lakefile change needed).

## Anti-regression

- **sorry 0/0** on Graph_en (FR Graph is 0-sorry, byte-identical code)
- FR `Graph.lean` untouched (verified `git status`)
- No `lakefile.lean` change

## Note technique (lesson firsthand c.229)

Use the compact module-doc format `/-! ... -/` identical to the FR (NOT a long multi-line module-header `/- ... -/`, which breaks the Lean 4 parser on the following `variable` declaration — caught firsthand during this PR, build failed first attempt, fixed by switching to the FR's `/-!` form).

## i18n rollout state (astar_lean)

| Module | FR | EN | This PR |
|--------|----|----|---------| 
| Graph | ✅ | ✅ **new** | ← tranche 1 |
| Heuristic | ✅ | — | prochain |
| Consistency | ✅ | — | prochain |
| Optimality | ✅ | — | prochain |

See #4980.
