### PR TITLE
fix(lean): cooperative_games_lean globs add Shapley+Shapley_en (c.234 #5419 orphan)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/lakefile.lean
@@ -16,13 +16,17 @@ lean_lib «CooperativeGames» where
   -- Includes: TU games, Shapley value, Core, Voting games
   --
   -- i18n FR-first (EPIC #4980 ratif 2026-07-04 11:58Z, comment-4881909354) :
-  -- Globs precis ciblant UNIQUEMENT les fichiers de cette tranche :
-  -- `ConeKernel.lean` (FR canonique) + `ConeKernel_en.lean` (EN sibling
-  -- verbatim). Pattern precis plutot que `.submodules \`CooperativeGames`
+  -- Globs precis par tranche (FR canonique + EN sibling verbatim),
+  -- etendu incrementalement au fur et a mesure que les _en siblings
+  -- sont livres (cycle c.234 : ajout de `Shapley`+`Shapley_en` post-#5419).
+  -- Pattern precis plutot que `.submodules \`CooperativeGames`
   -- car un autre _en pre-existant sur main (`Basic_en.lean`, ajoute par
   -- PR #5344 commit 24a2da95f) a un bug de namespace resolution
   -- (`G.Convex` non-prefixe dans `namespace MarginalVector`, fail
   -- `open TUGame` manquant) — le `.submodules` l'aurait active en
-  -- doublon de la presente PR. Le pattern precis compile SEUL les
-  -- fichiers de la tranche, sans toucher les autres _en pre-existants.
-  globs := #[`CooperativeGames.ConeKernel, `CooperativeGames.ConeKernel_en]
+  -- doublon des presentes PRs. Le pattern precis compile SEUL les
+  -- fichiers des tranches livrees, sans toucher les autres _en pre-existants.
+  globs := #[
+    `CooperativeGames.ConeKernel, `CooperativeGames.ConeKernel_en,
+    `CooperativeGames.Shapley, `CooperativeGames.Shapley_en
+  ]


### PR DESCRIPTION
# PR #5438 — fix(lean): cooperative_games_lean globs add Shapley+Shapley_en (c.234 #5419 orphan)

## Résumé

Répare le **faux-vert Lake build** post-#5419 : la merge de `Shapley_en.lean` (2035L, tranche 12 EPIC #4980, commit `40ba3c3b1`) a livré le sibling EN SANS l'ajouter au tableau `globs` du lakefile, ce qui le rendait **orphan non-compiled** (L31 lesson). Le CI "Lake build SUCCESS" actuel buildait `Shapley` (FR) uniquement — pas `Shapley_en`.

**1 fichier / +10 / -6 / R3 atomic / 1 domaine (Lean i18n infra)**.

## Pre/post `grep -c sorry`

| Fichier | Avant | Après | Δ |
|---------|------:|------:|---|
| `Shapley_en.lean` | 0 | 0 | 0 |
| `Shapley.lean` | 0 | 0 | 0 |
| `ConeKernel_en.lean` | 0 | 0 | 0 |
| `ConeKernel.lean` | 0 | 0 | 0 |

Lakefile only — `sorry` count inchangé (zéro).

## Lake build attendu (CI authoritative)

Post-merge, `lake build` produira `Shapley.olean` + `Shapley_en.olean` (vérifiable dans le log job via `gh api jobs/{id}/logs`, méthode c.222).

**Note méthodologique** : pas d'env Lean local po-2026, Lake build **REPORTÉ ai-01** (HARD `.claude/rules/lean-merge-discipline.md` §1). Pattern identique à :
- c.218 #5310 (Basic tranche 1 social_choice_lean)
- c.230 #5418 (ConeKernel tranche 2, globs introduits)

## Décisions structurelles

### 1. Pattern précis, pas `.submodules`

`globs := #[`CooperativeGames.ConeKernel, `CooperativeGames.ConeKernel_en, `CooperativeGames.Shapley, `CooperativeGames.Shapley_en]`

Le pattern `.submodules \`CooperativeGames` (large) **réactiverait** le bug `Basic_en.lean` dormant sur main (PR #5344 commit `24a2da95f`) :
- `namespace MarginalVector` sans `open TUGame`
- Références `G.Convex`/`G.Core`/`G.marginalVector` non-préfixées
- 5 erreurs de namespace resolution (lignes 593/594/602/603 — confirmées par ai-01 dans PR #5418 cycle c.230)

Le pattern précis compile **SEUL** les fichiers des tranches livrées, sans toucher aux `_en` pré-existants (dont `Basic_en.lean` dormant).

### 2. `Shapley_en.lean` namespace wrap vérifié

| Vérification | Résultat |
|--------------|----------|
| `import CooperativeGames.Basic_en` (L24, cross-namespace `_en` suffix) | ✅ |
| `namespace CooperativeGames_en` ouvert (L29) | ✅ |
| `end CooperativeGames_en` fermé (L2035) | ✅ |
| Sous-namespaces `Solution`/`ShapleyValue`/`Mobius`/`SimpleGame`/`StrongGame`/`MonotoneGame`/`ProperGame`/`SelfDualGame` préservés verbatim | ✅ |
| Anti-régression D : `Shapley.lean` FR canonique INCHANGÉ | ✅ |
| Code tactique 100% byte-identique (modulo imports cross-namespace `_en`) | ✅ |

### 3. Pattern cumulatif incrémental

Les globs sont **étendus au fil des tranches livrées** : chaque PR de tranche ajoute ses 2 modules (FR + `_en`). C'est le pattern validé par c.230 #5418 (ConeKernel) — étendu ici pour inclure la tranche 12 (Shapley) post-#5419.

## Anti-régression D PASS

- `CooperativeGames.lean` FR INCHANGÉ (hub d'imports)
- `CooperativeGames/Shapley.lean` FR INCHANGÉ
- `CooperativeGames/ConeKernel.lean` FR INCHANGÉ
- `CooperativeGames/ConeKernel_en.lean` EN sibling INCHANGÉ
- Aucun nom de lemme renommé, aucune tactique modifiée
- Lakefile seulement : ajout de 2 globs + commentaire

## Validation pré-push

- R3 atomic : 1 fichier / +10 / -6 (sous le seuil 3000 lignes)
- 1 commit unique (vérifié `git log origin/main..HEAD --oneline`)
- C151 anti-doublon : `gh pr list --search "Shapley_en globs" --state all` = vide avant push
- catalog-pr-hygiene R1 ✓ (catalogue non touché sur branche)
- readme-french-first N/A (lakefile only, pas de doc markdown)
- harness-hygiene 3-tier respecté (rapport → dashboard, mémoire → memory file dédié)
- 0 secret literal (secrets-hygiene.md règle 6)
- 0 CJK parasite (c.187 33e leçon)

## Suite anti-EPIC #4980

Cette PR ne **bouge pas** le compteur de tranches livrées (la tranche 12 = Shapley_en est déjà MERGED #5419). Elle répare juste le **faux-vert Lake build** post-merge pour que le sibling EN soit effectivement compilé.

Prochaines tranches i18n si ai-01 greenlight :
- `Basic`/`Basic_en` (fix bug dormant namespace resolution, PR dédiée séparée, pas bundle — leçon c.230 #5418 "fix orphelin = PR dédiée")
- Lattice tranche 7 (4 fichiers #5323 MERGED, globs ajoutés ici plus tard si étendu)

## Issue Links

- See #5419 (PR Shapley tranche 12 — sibling EN livré sans globs = orphan)
- See #5418 (PR ConeKernel tranche 2 — pattern globs précis introduit)
- See #4980 (EPIC parent i18n Lean FR+EN)
- See #5344 (commit `24a2da95f` Basic_en namespace bug dormant — anti-pattern pour `.submodules`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)