### PR TITLE
fix(ml): ML-1 hint headings '### Etape N' H3 -> bullet bold-inline (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
@@ -48,13 +48,7 @@
    "cell_type": "markdown",
    "id": "f3127450",
    "metadata": {},
-   "source": [
-    "### Étape 1 — Référencer les bibliothèques\n",
-    "\n",
-    "En Python, on importe les modules. **NumPy** pour les tableaux numériques,\n",
-    "**scikit-learn** (`sklearn`) pour les algorithmes et métriques, **Matplotlib** pour les\n",
-    "visualisations."
-   ]
+   "source": "- **Étape 1 :** Référencer les bibliothèques\n\nEn Python, on importe les modules. **NumPy** pour les tableaux numériques,\n**scikit-learn** (`sklearn`) pour les algorithmes et métriques, **Matplotlib** pour les\nvisualisations.\n"
   },
   {
    "cell_type": "code",
@@ -116,15 +110,7 @@
    "cell_type": "markdown",
    "id": "233d552c",
    "metadata": {},
-   "source": [
-    "### Étape 2 — Définir les structures de données\n",
-    "\n",
-    "En ML.NET on définit des classes POCO (`HouseData`, `Prediction`). En Python on travaille\n",
-    "directement avec des **tableaux NumPy** : un tableau 2D `X` pour les features (ici la\n",
-    "taille) et un vecteur 1D `y` pour les étiquettes (ici le prix). C'est la convention\n",
-    "universelle de scikit-learn : `X` de forme `(n_samples, n_features)`, `y` de forme\n",
-    "`(n_samples,)`."
-   ]
+   "source": "- **Étape 2 :** Définir les structures de données\n\nEn ML.NET on définit des classes POCO (`HouseData`, `Prediction`). En Python on travaille\ndirectement avec des **tableaux NumPy** : un tableau 2D `X` pour les features (ici la\ntaille) et un vecteur 1D `y` pour les étiquettes (ici le prix). C'est la convention\nuniverselle de scikit-learn : `X` de forme `(n_samples, n_features)`, `y` de forme\n`(n_samples,)`.\n"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Résumé

Fix typo-only #3966 sur `MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb` (jumeau Python #4956 de `ML-1-Introduction.ipynb` .NET/ML.NET) : 2 cellules HINT-AS-HEADING flaggées par `scan_md_hierarchy.py` converties du pattern H3 `### Étape N — X` vers bullet bold-inline `- **Étape N :** X` (pattern canonique validé par PR #4757/#4758 Lab2-Lab7 ML-day3).

**Diff** : 1 fichier / +3/-17 = 17 lignes de source array → 1 string (NotebookEdit normalise les array source en string unique — cellules équivalentes en contenu, longueur de chaîne conservée). Atomique, R3 ultra-conservateur.

## Diagnostic

`python scripts/notebook_tools/scan_md_hierarchy.py "MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb"` :

```
## MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
  [HINT-AS-HEADING] cell 2  L3  Étape 1 — Référencer les bibliothèques
  [HINT-AS-HEADING] cell 6  L3  Étape 2 — Définir les structures de données

=== 1/1 notebooks flagged ===
```

2 cellules où le préfixe `Étape N` est interprété par le scanner comme un aside typographique (pattern `HINT_RE.match` du scanner ligne 19 du script — mots `etape|étape|step` classés en début de heading). Sur la version jumeau .NET (`ML-1-Introduction.ipynb`) le scanner ne flag rien (les cellules équivalentes portent `## Étape N` en H2 ou des labels différents). Donc **incohérence typo intra-série ML.NET ↔ ML.Python** : le jumeau Python a régressé sur la typo lors de la création #4956.

## Vérification rescan (g.1)

`python scripts/notebook_tools/scan_md_hierarchy.py "MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb"` post-fix :

```
=== 0/1 notebooks flagged ===
```

0/1 → fix légitime.

## Garde-fous respectés

- ✅ **Pattern canonique ML-day3** : applique exactement le format validé par les PRs #4757/#4758 Lab2-Lab7 (`### Étape N : X` H3 → `- **Étape N :** X` bullet bold). Le séparateur `—` (cadratin) est converti en `:` pour matcher la convention uniforme des PRs précédentes.
- ✅ **Anti-régression contenu** : seuls les niveaux de heading et le préfixe sont touchés. Le texte des cellules (NumPy/scikit-learn/Matplotlib, tableaux X/y shape, parité .NET POCO) est préservé verbatim.
- ✅ **Anti-régression cellules voisines** : les cellules H3 sans préfixe `Étape N` (Construire et entraîner le pipeline cell 9, Évaluer le modèle cell 11, Prédire le prix cell 14, Interprétation cell 18, Tests de prédiction cell 24, Interprétation classification cell 26) ne sont PAS touchées — le scanner ne les a jamais flaggées (le mot `Étape` seul, sans le pattern procédural, ne déclenche pas HINT_RE).
- ✅ **C.2 notebooks** : seules cellules MARKDOWN modifiées (pas de cellules code). Sorties précédentes des 12 cellules code VALIDES (préservées dans le diff : `git diff` ne touche aucun `outputs` ni `execution_count`). Exception C.2 = modif markdown → pas de re-exécution requise.
- ✅ **catalog-pr-hygiene R1** : aucun marqueur `<!-- CATALOG-STATUS -->` touché. Catalogue untouched sur branche (cron `catalog-cron.yml` sur main fait foi).
- ✅ **readme-french-first** : pas de doc README touchée.
- ✅ **C.1 notebook exercise stubs** : pas touché (les exercices 1/2/3 cells 28/30/32 contiennent `Étape N` mais en H3 AVEC contexte d'exercice, le scanner ne les flag pas et le pattern bullets casserait la sémantique).
- ✅ **3-exercises #2161** : les 3 exercices du notebook sont préservés (cells 28/30/32 H3 inchangés, cellules code stub `print("Exercice à compléter...")` intactes).

## Vérification post-fix

```bash
python scripts/notebook_tools/scan_md_hierarchy.py "MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb"
# === 0/1 notebooks flagged ===

python -c "import json; nb = json.load(open('MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb')); print('cells:', len(nb['cells']), '| code cells with outputs:', sum(1 for c in nb['cells'] if c.get('cell_type') == 'code' and c.get('outputs')))"
# cells: 36 | code cells with outputs: 12
```

Notebook reste valide (36 cellules, 12 cellules code avec outputs préservés).

## Bilan campagne C212 — sous-grain #3966

Cette PR est un **sous-grain** du rollout #3966 typo (5 partitions historiques couvertes + 11 PRs antérieures Lab/QC/SymbolicAI/Lean/GameTheory/SmartContracts/Merged). Après les livraisons ML-day3 Lab2-Lab7 (#4753-#4758), il restait **2 cellules HINT-AS-HEADING dans le seul notebook ML.NET Python** (1/1 ML-famille flagged), maintenant résolues.

**État final scanner post-C212** : 0/1 ML/ML.Net flagged, 3/227 QC partner-course lean-workspace flagged (notebooks QC auto-générés, hors scope typo typographique = pattern QC officiel, à documenter hors C212).

Refs: #3966
🤖 Generated with [Claude Code](https://claude.com/claude-code)