### PR TITLE
docs(ml): ML.Net README — add ML-3/ML-8 Python twin links (See #4959)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -35,7 +35,7 @@ Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : p
 |---|----------|---------|-------|
 | 1 | [ML-1-Introduction](ML-1-Introduction.ipynb) | Hello ML.NET World, pipeline de base · *jumeau [Python](ML-1-Introduction-Python.ipynb)* | 30-40 min |
 | 2 | [ML-2-Data&Features](ML-2-Data&Features.ipynb) | IDataView, TextLoader, encodage · *jumeau [Python](ML-2-Data&Features-Python.ipynb)* | 40-50 min |
-| 3 | [ML-3-Entrainement&AutoML](ML-3-Entrainement&AutoML.ipynb) | SDCA, LightGBM, AutoML | 45-60 min |
+| 3 | [ML-3-Entrainement&AutoML](ML-3-Entrainement&AutoML.ipynb) | SDCA, LightGBM, AutoML · *jumeau [Python](ML-3-Entrainement-Python.ipynb)* | 45-60 min |
 | 4 | [ML-4-Evaluation](ML-4-Evaluation.ipynb) | Cross-validation, métriques, PFI | 40-50 min |
 
 ### Fonctionnalités avancées (ML-5 à ML-9)
@@ -45,7 +45,7 @@ Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : p
 | 5 | [ML-5-TimeSeries](ML-5-TimeSeries.ipynb) | **Time Series Forecasting** avec ForecastBySsa (SSA) | [ML-5-Python](ML-5-TimeSeries-Python.ipynb) — STL + SARIMA | 45-60 min |
 | 6 | [ML-6-ONNX](ML-6-ONNX.ipynb) | **ONNX Integration** : modèles Python/PyTorch dans .NET | — (pont inter-langage, par nature .NET-centrique) | 45-60 min |
 | 7 | [ML-7-Recommendation](ML-7-Recommendation.ipynb) | **Recommandation** : Matrix Factorization, collaborative filtering | [ML-7-Python](ML-7-Recommendation-Python.ipynb) — NMF | 45-60 min |
-| 8 | [ML-8-Clustering](ML-8-Clustering.ipynb) | **Clustering non-supervisé** : K-Means, segmentation RFM, méthode du coude | — (déjà couvert en Python : [2.6-Clustering](../DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb)) | 45-60 min |
+| 8 | [ML-8-Clustering](ML-8-Clustering.ipynb) | **Clustering non-supervisé** : K-Means, segmentation RFM, méthode du coude | [ML-8-Python](ML-8-Clustering-Python.ipynb) — KMeans scikit-learn + méthode du coude | 45-60 min |
 | 9 | [ML-9-Anomaly-Detection](ML-9-Anomaly-Detection.ipynb) | **Détection d'anomalies** : Randomized PCA, AUC, seuil de décision | [ML-9-Python](ML-9-Anomaly-Detection-Python.ipynb) — PCA + erreur de reconstruction | 45-60 min |
 
 ### TP Pratique


### PR DESCRIPTION
## Contexte

La merge wave c.N+58 (2026-07-05) a ajouté les jumeaux Python co-localisés **ML-3-Entrainement-Python** (#5434) et **ML-8-Clustering-Python** (#5432), mais la table de la série ML.Net dans `ML/ML.Net/README.md` n'a pas été mise à jour. Deux entrées de la table pointaient donc à tort vers l'absence de jumeau alors que les fichiers existent sur `main`.

## Changements (2 lignes, atomique)

| Ligne | Avant | Après |
|-------|-------|-------|
| 38 (ML-3) | `SDCA, LightGBM, AutoML` (pas de jumeau) | + `· *jumeau [Python](ML-3-Entrainement-Python.ipynb)*` |
| 48 (ML-8) | `— (déjà couvert en Python : [2.6-Clustering](...))` | `[ML-8-Python](ML-8-Clustering-Python.ipynb) — KMeans scikit-learn + méthode du coude` |

**Note anti-collision** : le lien jumeau ML-4 (ligne 39) est géré séparément par #5451 (ma PR OPEN sur le twin ML-4). Ne pas dupliquer ici (G.4 atomic — une feature par PR).

## §E gate — audit fichier entier (preuves)

**(a) Comptage disk (git ls-tree origin/main)** : 7 jumeaux Python co-localisés existent dans `ML/ML.Net/` :
`ML-1-Introduction-Python`, `ML-2-Data&Features-Python`, `ML-3-Entrainement-Python`, `ML-5-TimeSeries-Python`, `ML-7-Recommendation-Python`, `ML-8-Clustering-Python`, `ML-9-Anomaly-Detection-Python`.

**(b) Réconciliation disk ↔ prose ↔ table** :
- La prose (ligne 14) dit « Plusieurs notebooks disposent d'un jumeau Python co-localisé » et donne 3 exemples illustratifs (ML-9 RandomizedPca, ML-5 ForecastBySsa, ML-7 MatrixFactorization) — pas de count à réconcilier, prose toujours correcte.
- La table (lignes 36-49) liste maintenant 6/7 jumeaux correctement : ML-1, ML-2, **ML-3 (fix)**, ML-5, ML-7, **ML-8 (fix)**, ML-9. Reste ML-4 (→ #5451) et ML-6 (légitimement sans jumeau — ONNX est .NET-centrique par nature, documenté en prose).

**(c) Vérification structure** : `python scripts/check_docs_links.py` → **0 broken / 3421 links** repo-wide post-fix. Les 2 nouvelles cibles existent (23 KB et 185 KB sur la branche).

## Hygiène

- Catalogue byte-identique à `main` (cron-owned, règle catalog-pr-hygiene — non touché sur la branche).
- Branche créée depuis `origin/main` frais (rebase clean).
- Re-exécution non requise (modifs markdown uniquement, règle C.2 — seule la structure des liens change).

See #4959 (passe intermédiaires, ne clôt pas l'EPIC). See #4956 (parité .NET ⇄ Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)