### PR TITLE
docs(ml): ML/README.md hub — reconcile tree+table with ML-1/2/3/8 Python twins

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -55,8 +55,11 @@ Cette série sert les cours d'introduction au Machine Learning appliqué. Elle s
 ML/
 ├── ML.Net/                           # Tutoriels ML.NET (C#)
 │   ├── ML-1-Introduction.ipynb
+│   ├── ML-1-Introduction-Python.ipynb   # jumeau scikit-learn (regression/logistique) ⇄ ML.NET pipeline
 │   ├── ML-2-Data&Features.ipynb
+│   ├── ML-2-Data&Features-Python.ipynb   # jumeau scikit-learn (ColumnTransformer) ⇄ IDataView/Transforms
 │   ├── ML-3-Entrainement&AutoML.ipynb
+│   ├── ML-3-Entrainement-Python.ipynb   # jumeau scikit-learn (SDCA/LightGBM ⇄ Linear/GradientBoosting)
 │   ├── ML-4-Evaluation.ipynb
 │   ├── ML-5-TimeSeries.ipynb
 │   ├── ML-5-TimeSeries-Python.ipynb   # jumeau scikit-learn (STL+SARIMA) ⇄ ForecastBySsa
@@ -64,6 +67,7 @@ ML/
 │   ├── ML-7-Recommendation.ipynb
 │   ├── ML-7-Recommendation-Python.ipynb   # jumeau scikit-learn (NMF) ⇄ MatrixFactorization
 │   ├── ML-8-Clustering.ipynb
+│   ├── ML-8-Clustering-Python.ipynb   # jumeau scikit-learn (KMeans) ⇄ K-Means ML.NET
 │   ├── ML-9-Anomaly-Detection.ipynb
 │   ├── ML-9-Anomaly-Detection-Python.ipynb   # jumeau scikit-learn (PCA+résidu) ⇄ RandomizedPca
 │   ├── TP-prevision-ventes.ipynb
@@ -85,8 +89,11 @@ Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du 
 | # | Notebook | Contenu | Focus |
 |---|----------|---------|-------|
 | 1 | [ML-1-Introduction](ML.Net/ML-1-Introduction.ipynb) | Hello ML.NET World, pipeline de base | Fondamentaux |
+| 1-Py | [ML-1-Introduction-Python](ML.Net/ML-1-Introduction-Python.ipynb) | **Jumeau Python** : pipeline ML.NET ⇄ scikit-learn (régression + classification) | Parité .NET⇄Python |
 | 2 | [ML-2-Data&Features](ML.Net/ML-2-Data&Features.ipynb) | IDataView, TextLoader, encodage | Préparation données |
+| 2-Py | [ML-2-Data&Features-Python](ML.Net/ML-2-Data&Features-Python.ipynb) | **Jumeau Python** : `IDataView`/Transforms ⇄ `ColumnTransformer`+`Pipeline` (scikit-learn) | Parité .NET⇄Python |
 | 3 | [ML-3-Entrainement&AutoML](ML.Net/ML-3-Entrainement&AutoML.ipynb) | SDCA, LightGBM, AutoML | Entraînement |
+| 3-Py | [ML-3-Entrainement-Python](ML.Net/ML-3-Entrainement-Python.ipynb) | **Jumeau Python** : SDCA/LightGBM/AutoML ⇄ `LinearRegression`/`GradientBoosting`/`GridSearchCV` | Parité .NET⇄Python |
 | 4 | [ML-4-Evaluation](ML.Net/ML-4-Evaluation.ipynb) | Cross-validation, métriques, PFI | Évaluation |
 | 5 | [ML-5-TimeSeries](ML.Net/ML-5-TimeSeries.ipynb) | Forecasts temporelles, windowing | Séries temporelles |
 | 5-Py | [ML-5-TimeSeries-Python](ML.Net/ML-5-TimeSeries-Python.ipynb) | **Jumeau Python** : `ForecastBySsa` ⇄ `STL`+`SARIMA` (statsmodels) | Parité .NET⇄Python |
@@ -94,6 +101,7 @@ Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du 
 | 7 | [ML-7-Recommendation](ML.Net/ML-7-Recommendation.ipynb) | Système de recommandation | Recommandations |
 | 7-Py | [ML-7-Recommendation-Python](ML.Net/ML-7-Recommendation-Python.ipynb) | **Jumeau Python** : `MatrixFactorization` ⇄ `NMF` (scikit-learn) | Parité .NET⇄Python |
 | 8 | [ML-8-Clustering](ML.Net/ML-8-Clustering.ipynb) | K-Means, segmentation RFM, méthode du coude | Non-supervisé |
+| 8-Py | [ML-8-Clustering-Python](ML.Net/ML-8-Clustering-Python.ipynb) | **Jumeau Python** : `ClusteringCatalog` ⇄ `KMeans` scikit-learn + méthode du coude | Parité .NET⇄Python |
 | 9 | [ML-9-Anomaly-Detection](ML.Net/ML-9-Anomaly-Detection.ipynb) | Randomized PCA, AUC, seuil de décision | Détection d'anomalies |
 | 9-Py | [ML-9-Anomaly-Detection-Python](ML.Net/ML-9-Anomaly-Detection-Python.ipynb) | **Jumeau Python** : `RandomizedPca` ⇄ `PCA`+résidu (scikit-learn) | Parité .NET⇄Python |
 | TP | [TP-prevision-ventes](ML.Net/TP-prevision-ventes.ipynb) | Régression bayésienne (Infer.NET) | Application pratique |


### PR DESCRIPTION
## Contexte

Note éditoriale ai-01 sur #4956 (2026-07-04) : la **réconciliation du hub intermédiaire ML/README.md** était **différée** jusqu'à stabilisation de la tranche parité ML.Net→Python (« PAS de rewrite mid-campagne […] réconciliation différée jusqu'à stabilisation »). Avec 8/9 jumeaux maintenant landés (ML-1/2/3/5/7/8/9 merged + ML-4 in flight #5451, ML-6 ONNX = SKIP permanent), le seuil de stabilisation est atteint — cette PR livre la réconciliation différée.

## Drift réel (firsthand `git ls-tree origin/main` + `Read`)

Le hub `ML/README.md` listait **seulement 3 jumeaux** (ML-5/7/9-Python) dans l'arbre de structure ET la table de notebooks, manquant les **4 jumeaux fondamentaux/clustering** landés pendant la merge wave c.N+58 :
- ML-1-Introduction-Python (#5433 MERGED)
- ML-2-Data&Features-Python (#5447 MERGED)
- ML-3-Entrainement-Python (#5434 MERGED)
- ML-8-Clustering-Python (#5432 MERGED)

La prose du hub (L12, L17-20) documentait déjà correctement l'arc « 3 fils » incluant les jumeaux de parité — c'est uniquement **l'arbre + la table** qui étaient en retard sur le disque.

## Changement (8 lignes, 0 deletion, atomique)

- **Arbre de structure** : +4 lignes `├── ML-{1,2,3,8}-*-Python.ipynb` aux positions canoniques (sous chaque notebook parent), avec commentaire de mapping (ex: `⇄ IDataView/Transforms`).
- **Table de notebooks** : +4 lignes `N-Py` (1-Py, 2-Py, 3-Py, 8-Py) au format des lignes jumeaux existantes (5-Py, 7-Py, 9-Py).

## §E gate — audit fichier entier (preuves)

**(a) Disk** : 7 jumeaux Python sur origin/main (`git ls-tree -r --name-only origin/main` → ML-1/2/3/5/7/8/9-Python.ipynb).
**(b) Prose ↔ structure** : prose du hub « 3 fils » (L17-20) déjà correcte beforehand (décrivait les jumeaux en général), seul l'arbre/table lagged. Maintenant réconciliés : 7/7 jumeaux listés (ML-4 pending #5451, ML-6 légitimement sans twin ONNX).
**(c) check_docs_links.py** : **0 broken / 3424 links** repo-wide post-fix. Les 4 nouvelles cibles existent toutes (vérifié `ls`).

## Hygiène

- **Anti-collision G.4** : édite le HUB `ML/README.md`, distinct de #5453 (leaf `ML.Net/README.md` table) et #5451 (ML-4 leaf link) — 0 fichier overlap.
- **Catalogue byte-identique** : `CATALOG-STATUS` marker (lignes 2-8) untouched, vérifié `git diff` vide sur ce bloc.
- **Anti-pendulum** : suit le format exact des lignes jumeaux existantes (5-Py/7-Py/9-Py), pas de reframing.
- **Note process** : commit initialement créé sur main par erreur (main local), rescué via `git branch` + `git reset --hard origin/main` avant tout push — origin/main JAMAIS poussé directement.

See #4956 (note éditoriale ai-01), #3973, #4208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)