### PR TITLE
docs(smt): Z3 notebook 15 BitVectors — add series-style ## Conclusion cell (#3966 §E gap)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/15_BitVectors_Overflow.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/15_BitVectors_Overflow.ipynb
@@ -952,6 +952,28 @@
     "// Etape 2 : solver.Assert(...) -> Check -> prouver\n",
     "Console.WriteLine(\"Exercice 3 à compléter.\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0nc15fe",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook introduit la **théorie des bit-vectors**, dernier domaine SMT canonique non couvert par les notebooks 01-14 (limités aux entiers non bornés `IntSort`) et brique fondamentale de la **vérification matérielle et logicielle** (entiers bornés, débordement, arithmétique modulaire) :\n",
+    "\n",
+    "- Le débordement y est **décidable** (et non approché) : addition, multiplication, comparaisons et opérations bit-à-bit sont définies modulo 2ⁿ, Z3 en fait une théorie complète.\n",
+    "- La **preuve par réfutation** est le patron canonique : nier la propriété universelle (« tout `x, y ≥ 2³¹` déborde ») et obtenir `UNSAT` certifie le théorème ; nier la sûreté (« `p, q < 1000` et débordement ») prouve la réciproque d'absence.\n",
+    "- Les deux stacks convergent vers le **même prédicat non-trivial** `a + b < a` : l'API brute `MkBV*` câble la sorte à la main, le DSL `[BitVecWidth(n)]` déporte la largeur dans un attribut déclaratif — double verdict `SAT` sur 4 bits (enveloppement), `UNSAT` sur les entiers non bornés.\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "- Le débordement est **impossible par construction** sur les entiers non bornés (`a + b ≥ a`), mais **inévitable et calculable** sur les bit-vectors : c'est l'écart exact que la théorie `BitVec` capture.\n",
+    "- `MkExtract` (extraction de champs) ouvre la modélisation des **formats binaires et protocoles**, où l'on isole un octet ou un drapeau dans un mot de 32 bits.\n",
+    "- Le seuil `2³¹` (et non `2³⁰`) pour le théorème d'inévitabilité n'est pas anecdotique : `2³⁰ + 2³⁰ = 2³¹ < 2³²` ne déborde pas — la précision de la borne est elle-même une leçon de modélisation.\n",
+    "\n",
+    "**Référence** : la théorie `BitVec` est normalisée par SMT-LIB (logiques `QF_BV` et `BV`) et constitue le socle des **model checkers** matériels (STP, Boolector, Z3) pour la vérification de circuits et d'analyseurs statiques. La suite (notebook [16 — Real Arithmetic](16_RealArithmetic.ipynb)) quitte le domaine discret pour l'arithmétique des réels."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

**§E / #3966 gap closed** — the Z3/SMT series notebooks **01-14 and 18 all end with a `## Conclusion` wrap-up**; **notebook 15 (BitVectors_Overflow) was the sole one missing it** (it ended on the Exercice 3 code stub). This PR adds the concluding synthesis cell, matching the series convention.

## Gap evidence (firsthand audit of all 18 Z3 notebooks)

| Notebook | Last cell | Has `## Conclusion`? |
|----------|-----------|----------------------|
| 01-14, 18 | `## Conclusion` | ✅ yes (last cell) |
| **15 BitVectors_Overflow** | Exercice 3 code stub | ❌ **no — the gap** |
| 16, 17 | Exercice 3 | ⚠️ conclusion exists mid-notebook (reordering = cell-order #3248 risk, out of scope) |

→ Notebook 15 = the single unambiguous gap. Audit script: `scratchpad/survey_conclusions.py` (last-3-md-cell conclusion-marker detection across the family).

## Approach

One markdown cell appended at the end (after the Exercice 3 code stub). Content **grounded firsthand** in the notebook body — every claim verified against the cells:

- bit-vectors = the bounded / arithmetic-modulo SMT theory **uncovered by notebooks 01-14** (limited to unbounded `IntSort`) — stated in cell[0].
- overflow **impossible by construction** on unbounded ints (`a+b ≥ a`) but **decidable** on bit-vectors — sections 1 + 6.
- **refutation (UNSAT)** as the canonical proof pattern: universal theorem (`x,y ≥ 2³¹ ⇒ overflow`) + reciprocal (`p,q < 1000 ⇒ no overflow`) — sections 3-4.
- RAW `MkBV*` vs DSL `[BitVecWidth(n)]` **converge on predicate `a+b < a`** (double verdict SAT@4bits / UNSAT@unbounded) — section B4.
- `2³¹` (not `2³⁰`) inevitability threshold — `2³⁰+2³⁰ = 2³¹ < 2³²` does **not** overflow — section 3.
- `MkExtract` opens binary-format/protocol modeling — section 5.
- arc pointer to notebook 16 (Real Arithmetic).

Style matches the accented French of notebook 15's main sections (1-6 + exercises), not the less-accented B4 section. Length 1945 chars / 15 lines — within the series range (13: 1095, 14: 1533, 18: 1528).

## Validation — 4 gates (HARD)

| Gate | Check | Result |
|------|-------|--------|
| G1 | Code cells (source + outputs + execution_count) byte-identical before/after | ✅ PASS |
| G2 | Cell count 24 → 25 (exactly one markdown cell appended) | ✅ PASS |
| G3 | New last cell = `## Conclusion` markdown | ✅ PASS |
| G4 | Conclusion claims grounded in actual notebook content | ✅ PASS (verified each claim above) |

**C.2 exception**: markdown-only edit (code byte-identical) → **no kernel re-exec** needed; committed outputs stay valid. All 10 code cells retain `execution_count != null`.

## Diff

```
1 file changed, 22 insertions(+), 0 deletions(-)
```

Pure addition — no code touched, no reordering, no deletion. Atomique.

## Out of scope

- Notebooks 16/17 (conclusion mid-notebook, ends on Exercice 3) — fixing = cell reordering (#3248 risk), separate concern.
- Other SymbolicAI families (Tweety = po-2024 turf + build HOLD; SmartContracts = #5435 feuille §E OPEN; Lean = po-2026 turf; Python SymbolicLearning = po-2025 turf) — collision-avoided.

See #3966 (§E conclusion-cell gap, partial). See #4959.

Dispatch: cross-lane pickup (po-2023 .NET turf comprehensively drained across 5 axes × 3 cycles; this is a R5 pivot to a collision-free §E gap on my SMT-.NET specialty).

Co-Authored-By: Claude-Code <noreply@anthropic.com>