### PR TITLE
docs(search): CSP-1-Fundamentals-Csharp — add MRV interpretation transition cell (#3966 §E)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -1173,6 +1173,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c5p1tr4n",
+   "metadata": {},
+   "source": [
+    "**Interpretation** : MRV choisit **SA** (Southern Australia) parce qu'il ne lui reste qu'**une seule valeur viable** (`Bleu`) -- c'est la variable la plus contrainte du graphe. C'est le principe **fail-fast** : traiter en priorite la variable la plus susceptible de provoquer une impasse, afin de detecter l'echec tot dans l'arbre de recherche et d'eviter d'explorer de larges sous-arbres voues a l'echec.\n",
+    "\n",
+    "- Au **tie-break** (plusieurs variables avec le meme nombre de valeurs viables), le **degree heuristic** departage en choisissant celle qui a le plus de voisins non assignes --limiter ainsi la propagation future des contraintes.\n",
+    "- Sur ce petit graphe de coloration, l'effet de MRV reste modeste ; il devient decisif sur des CSP denses ou une variable presqu'entièrement determinee (`viables == 1`) dechoue immediatement si on la traite en dernier.\n",
+    "\n",
+    "MRV repond a la **premiere** question (quel ordre de variables ?). Reste la **seconde** : parmi les valeurs viables d'une variable, **quel ordre essayer** ? C'est le role complementaire de **LCV (Least Constraining Value)** -- presente dans la cellule suivante."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "51b6440b",


### PR DESCRIPTION
## Summary

**§E / #3966 transition-cell gap closed** — Section 5 (Heuristiques MRV/LCV) of `CSP-1-Fundamentals-Csharp.ipynb` had a **5-code-cell wall** (cell[17..21]) with no markdown transition between the MRV demo and the LCV introduction. A repo-wide scan of the entire .NET turf (Sudoku + Search + SMT/Z3 + SmartContracts) found this to be the **sole code wall ≥ 4 consecutive code cells**.

## Gap evidence (firsthand, repo-wide .NET scan)

Scan script `scratchpad/survey_transitions.py` over all .NET notebooks:
```
  Search\Part2-CSP\CSP-1-Fundamentals-Csharp.ipynb: code-wall runs [(17, 5)]
```
**1 gap total** across Sudoku + Search + SMT/Z3 + SmartContracts .NET families. All other .NET notebooks have markdown transitions every <4 code cells.

## Approach

Insert ONE interpretation markdown cell after the MRV demo (cell[18]) to break the 5-wall into **(2 code)(md)(3 code)**, matching the series convention of interpretation-after-demo (cf cell[15] after the backtracking demo).

Content **grounded firsthand** in the MRV demo output (cell[18] stdout):

- **SA chosen** because only 1 viable value (`Bleu`), deg=3 → the most constrained variable.
- **fail-fast** principle: treat the most constrained variable first to detect dead-ends early and prune large doomed subtrees.
- **degree heuristic** tie-break (most unconstrained neighbors) limits future constraint propagation.
- **bridge to LCV**: MRV answers the variable-ordering question; LCV (next cell) answers the complementary value-ordering question.

Style: **non-accented French** matching the CSP-Csharp series convention (`definie`, `egalite`, `Heuristique`, `Interpretation`).

## Validation — 4 gates (HARD)

| Gate | Check | Result |
|------|-------|--------|
| G1 | Code cells (source + outputs + execution_count + id) byte-identical before/after | ✅ PASS |
| G2 | Cell count 40 → 41 (exactly one markdown inserted) | ✅ PASS |
| G3 | Head cells [0..18] unchanged + tail [19..] shifted to [20..] + new cell at [19] | ✅ PASS |
| G4 | Transition grounded in actual MRV demo output (SA=1 viable, deg=3) | ✅ PASS |

**C.2 exception**: markdown-only (code byte-identical) → no kernel re-exec. Execution_count sequence **contiguous 1..19** preserved. All 19 code cells retain `execution_count != null`.

## Diff

```
1 file changed, 13 insertions(+), 0 deletions(-)
```

Pure addition — no code touched, no reordering of existing cells, no deletion. Atomique.

## Cross-axis drainage status (.NET po-2023 turf)

This closes the last open §E axis on the .NET turf:
- ✅ §E conclusion-cells: Sudoku (c.18), Z3 (c.19, #5458), Search/SmartContracts (c.20 = 0 gap)
- ✅ §E transition-cells: **this PR** (sole gap was CSP-1)
- ✅ exercises #2161, accents #2876 (cap), FR-first READMEs, §E feuilles, path-leak CLOSED

**.NET §E (conclusions + transitions) = fully DRAINED repo-wide.**

## Out of scope

- Python families (Argument_Analysis, SymbolicLearning, Tweety, ML, ICT, QC-Py) = active §E campaigns by po-2024/po-2025.
- CSP-1 Python twin (`CSP-1-Fundamentals.ipynb`) — separate notebook, po-2025 turf.

See #3966 (§E transition-cell gap, partial). See #4959.

Dispatch: cross-lane pickup (po-2023 .NET turf §E comprehensively drained across 6 axes; this is the last collision-free §E gap on the .NET turf).

Co-Authored-By: Claude-Code <noreply@anthropic.com>