### PR TITLE
fix(search): Search-15-NetworkX — correct broken CaseStudies/SmartGrid link

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
@@ -1702,7 +1702,7 @@
     "- **[Search-3-Informed](Search-3-Informed.ipynb)** — A\\* fait main (notre implémentation pédagogique avant de passer à NetworkX)\n",
     "- **[Search-8-DancingLinks](Search-8-DancingLinks.ipynb)** — couverture exacte avec Knuth DLX (graphe biparti d'incidence)\n",
     "- **[Partie 2 : CSP](../Part2-CSP/README.md)** — les graphes sont le substrat des problèmes de routing et scheduling (OR-Tools, Choco)\n",
-    "- **[Recherche opérationnelle / SmartGrid](../../CaseStudies/SmartGrid/README.md)** — optimisation de réseaux électriques (flot max, network simplex)\n",
+    "- **[Recherche opérationnelle / SmartGrid](../../CaseStudies/SmartGrid-Energy/README.md)** — optimisation de réseaux électriques (flot max, network simplex)\n",
     "\n",
     "### Pour aller plus loin\n",
     "\n",


### PR DESCRIPTION
## Summary

Fix a **real broken intra-notebook markdown link** in `Search-15-NetworkX.ipynb` (cell[40], conclusion). The case-study pointer referenced a directory that does not exist on disk.

## The bug

```diff
- [Recherche opérationnelle / SmartGrid](../../CaseStudies/SmartGrid/README.md)
+ [Recherche opérationnelle / SmartGrid](../../CaseStudies/SmartGrid-Energy/README.md)
```

The actual directory is **`CaseStudies/SmartGrid-Energy/`**, not `CaseStudies/SmartGrid/`:

- ✅ `MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/README.md` — exists
- ❌ `MyIA.AI.Notebooks/CaseStudies/SmartGrid/` — does not exist

## Why this is a real gap (firsthand)

- The canonical `scripts/check_docs_links.py` reports **0 broken links / 3405 total** — because it scans **`.md` files only**, not `.ipynb` source. This broken link lives inside a notebook markdown cell, so the canonical checker never sees it.
- A targeted notebook-link resolver scan (resolve relative markdown links in every `.ipynb` against disk) surfaced it. Among the ~28 unresolved notebook links, most are intentional (`Z3.Linq/solutions/...` = gitignored fork build output, present on machines running the SMT-.NET turf; `.claude/rules/...` = student-context references) — **only this one is a real typo** (wrong directory name).
- Repo-wide grep confirms **1 occurrence** of the `SmartGrid/` typo (no others).

## Approach

One-line URL fix. Display text `SmartGrid` kept as-is (readable short label — the dir is `SmartGrid-Energy` but the display shorthand is fine for a conclusion pointer).

## Validation

- **Markdown-only**: code cells byte-identical → **C.2 exception**, no kernel re-exec.
- Cell count 42 unchanged; all 21 code cells retain `execution_count != null`.
- JSON valid post-edit.
- No remaining `SmartGrid/` typo in the notebook.

## Diff

```
1 file changed, 2 insertions(+), 2 deletions(-)
```

Pure 1-line URL replacement (the +2/-2 is the JSON line appearing in both - and +).

See #4959 (broken-link hygiene). Notebook-link resolver is a complementary scan to the canonical `check_docs_links.py` (which covers .md only).

Dispatch: cross-lane pickup (Search-15 is Python = po-2025 turf, but 0 PR active on this file, last commit is the enrich #2326; the fix is a trivial typo correction, atomique, no pedagogical decision needed).

Co-Authored-By: Claude-Code <noreply@anthropic.com>