### PR TITLE
docs(ml): 1.2-NumPy DataScienceWithAgents — add ## Conclusion cell (See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb
@@ -376,6 +376,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "np12concl",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a posé les **fondations NumPy** indispensables à toute la data science Python — le socle sur lequel s'appuient Pandas (notebook [1.3](1.3-Analyse_de_Donnees_avec_Pandas.ipynb)), scikit-learn et les frameworks de deep learning.\n",
+    "\n",
+    "**Ce qu'il faut retenir** :\n",
+    "\n",
+    "- **L'objet `ndarray`** (section Création) est un tableau N-dimensionnel **typé et contigu en mémoire** : contrairement aux listes Python (tableaux de pointeurs vers des objets dispersés), il stocke des données homogènes dans un bloc compact — d'où des gains de vitesse et de mémoire souvent d'un ordre de grandeur.\n",
+    "- **La vectorisation** (section Opérations) remplace les boucles `for` explicites : `a + b`, `a * 2`, `a.mean()` s'appliquent élément par élément via du code C natif sous le capot. C'est le **déplacement sémantique clé** — penser « tableau entier » plutôt que « élément par élément ».\n",
+    "- **Les opérations 2D** (Exercice 3 : transposition, produit matriciel, extraction de sous-matrices) ouvrent l'algèbre linéaire : NumPy traite matrices et vecteurs comme des citoyens de première classe, ce que les exercices de statistiques (somme, moyenne, carré) ont commencé à exploiter.\n",
+    "\n",
+    "**Le pont vers Pandas** : NumPy manipule des **tableaux numériques nus** ; Pandas (1.3) ajoute par-dessus l'**indexation par étiquettes** (lignes et colonnes nommées) et le **typage hétérogène** (colonnes de types différents) — mais tout `DataFrame` Pandas enveloppe un `ndarray` NumPy. Maîtriser la vectorisation ici, c'est comprendre pourquoi une opération Pandas vectorisée bat toujours une boucle `iterrows`.\n",
+    "\n",
+    "**Pour aller plus loin** : le **broadcasting** (diffusion automatique entre formes compatibles, ex. `tableau_2D + vecteur_1D`), les fonctions d'algèbre linéaire de `np.linalg` (inverse, déterminant, valeurs propres) et la génération aléatoire reproductible (`np.random.default_rng(seed)`) sont les prochaines capacités à explorer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Références\n",


### PR DESCRIPTION
## §E conclusion-cell gap (#3966)

**Gap proven firsthand (series convention):** sibling `1.3-Analyse_de_Donnees_avec_Pandas.ipynb` HAS a `## Conclusion` cell (cell[18]); `1.2-Manipulation_de_Donnees_avec_NumPy.ipynb` did NOT — it ended: exercises → `## Références`, no synthesis. Series convention = conclusion cell **before** References.

## What the conclusion synthesizes (grounded in actual notebook content)

The sibling 1.3 conclusion is generic-template quality (*"Les concepts fondamentaux ont ete presents"*). This one is **specific and grounded**:

- **`ndarray` memory model** (cf. Création cell[2]): typed, contiguous block vs Python lists (array of pointers) → order-of-magnitude speed/memory gains.
- **Vectorisation as semantic shift** (cf. Opérations cell[4]): `a + b`, `a * 2`, `a.mean()` apply element-wise via native C — think "whole array" not "element by element".
- **2D operations → linear algebra** (cf. Exercice 3 cell[11]): transposition, matrix product — matrices/vectors as first-class citizens, building on Exercice 2 statistics (cell[7]).
- **Bridge to Pandas 1.3** (cf. Navigation cell[0]): NumPy = naked numerical arrays; Pandas adds label-indexing + heterogeneous typing, but every DataFrame wraps an `ndarray`. Mastering vectorisation here = understanding why vectorised Pandas beats `iterrows`.
- **Pour aller plus loin**: broadcasting, `np.linalg`, reproducible RNG (`default_rng(seed)`).

## 4 gates HARD — PASS

| Gate | Check | Result |
|------|-------|--------|
| G1 | code cells (source+outputs+execution_count) byte-identical | PASS |
| G2 | cell count 14 → 15 (exactly one markdown inserted) | PASS |
| G3 | cells[0..12] unchanged; References shifted [13]→[14]; conclusion at [13] | PASS |
| G4 | grounded in actual content (cells 0/2/4/7/11) | PASS firsthand |

- **C.1**: 0 `raise NotImplementedError`/`assert False`/`1/0` in notebook. PASS.
- **C.2 exception**: markdown-only edit, code byte-identical → no kernel re-exec. Code `execution_count` sequence `[1,2,3,4,5]` preserved. PASS.
- **Diff**: +20/−0, atomique. nbformat 4.5 (cells carry `id`).

## Style

Accented French — matches 1.2 prose register (cells 0-4 Objectifs/Qu'est-ce-que/Création/Vectorisation + References cell, all accented). Only the exercise md cells (7/9/11) are non-accented; the dominant prose register is accented, so the conclusion follows it.

## Collision / scope

- Collision check (`gh pr list --search Manipulation_de_Donnees`): 0 PR. No agent actively on DataScienceWithAgents/01-PythonForDataScience.
- Scope: 1 file, 1 cell, markdown-only. Not a composite.

See #3966 (partial contribution to the §E epic, not closing).