### PR TITLE
Fix: globs cooperative_games_lean — ajouter Basic, Basic_en, Shapley, Shapley_en (cycle c.235, See #5419)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/lakefile.lean
@@ -20,9 +20,25 @@ lean_lib «CooperativeGames» where
   -- `ConeKernel.lean` (FR canonique) + `ConeKernel_en.lean` (EN sibling
   -- verbatim). Pattern precis plutot que `.submodules \`CooperativeGames`
   -- car un autre _en pre-existant sur main (`Basic_en.lean`, ajoute par
-  -- PR #5344 commit 24a2da95f) a un bug de namespace resolution
-  -- (`G.Convex` non-prefixe dans `namespace MarginalVector`, fail
+  -- PR #5344 commit 24a2da95f) avait un bug de namespace resolution
+  -- presume (`G.Convex` non-prefixe dans `section MarginalVector`, fail
   -- `open TUGame` manquant) — le `.submodules` l'aurait active en
   -- doublon de la presente PR. Le pattern precis compile SEUL les
   -- fichiers de la tranche, sans toucher les autres _en pre-existants.
-  globs := #[`CooperativeGames.ConeKernel, `CooperativeGames.ConeKernel_en]
+  --
+  -- c.235 : ajout `Basic`, `Basic_en`, `Shapley`, `Shapley_en` au tableau
+  -- globs (PR #5441). Pattern precis cumulatif (PAS `.submodules`) pour
+  -- eviter de reactiver le bug namespace dormant de `Basic_en.lean`.
+  -- Empirique : Basic_en.lean a une structure identique a Basic.lean
+  -- (TUGame top-level + namespace TUGame_en + section MarginalVector),
+  -- donc le bug namespace `open TUGame` manquant n'est PAS confirme
+  -- — le commentaire pre-PR-#5441 etait speculatif. Si le build Lake
+  -- echoue apres ce PR, le diagnostic precis tombera dans les logs CI.
+  globs := #[
+    `CooperativeGames.ConeKernel,
+    `CooperativeGames.ConeKernel_en,
+    `CooperativeGames.Basic,
+    `CooperativeGames.Basic_en,
+    `CooperativeGames.Shapley,
+    `CooperativeGames.Shapley_en
+  ]


### PR DESCRIPTION
## Contexte

Suite directe PR #5441 (CLOSED par ai-01) : Lake build `cooperative_games_lean` echouait sur `CooperativeGames.Basic.olean does not exist` / `Basic_en.olean does not exist` (job 85266103249, run 28747124327, 2026-07-05T22:34Z).

**Root cause** : Shapley/Shapley_en etaient ajoutes aux globs mais transitent par Basic/Basic_en (imports `CooperativeGames.Basic` et `CooperativeGames.Basic_en`) qui n'etaient pas compiles. Le lakefile de c.230 (PR #5418 ConeKernel siblings) avait un commentaire speculatif pretendant que `Basic_en.lean` avait un bug namespace resolution dormant qui empechait sa compilation, donc le pattern `.submodules` broad avait ete evite en faveur d'un pattern precis.

## Diagnostic empirique pre-PR

J'ai compare `Basic_en.lean` et `Basic.lean` (FR canonique) ligne par ligne :
- Les deux ont `structure TUGame` top-level (pas dans namespace)
- Les deux ont `namespace TUGame[_en]` englobant les defs/theoremes
- Les deux ont `open BondarevaCone` (L231/L233)
- Les deux ont `section MarginalVector` (L452) avec `G.X` references
- **MEME STRUCTURE EXACTE** au nom du namespace pres (`TUGame` vs `TUGame_en`)

`Basic.lean` compile sur `main` depuis avant PR #5344 — donc le bug namespace `open TUGame` manquant n'est PAS confirme pour `Basic_en.lean`. Le commentaire pre-PR-#5441 etait speculatif.

## Fix

Ajout de 4 modules au tableau `globs` du lakefile (pattern precis cumulatif, PAS `.submodules` broad) :
- `CooperativeGames.Basic` (FR canonique, requis par Shapley.lean)
- `CooperativeGames.Basic_en` (EN sibling, requis par Shapley_en.lean)
- `CooperativeGames.Shapley` (FR canonique, deja dans PR #5441)
- `CooperativeGames.Shapley_en` (EN sibling, deja dans PR #5441)

Le pattern precis reste preferable a `.submodules` pour eviter une cascade involontaire si un autre `_en.lean` dormant etait reintroduit ulterieurement. Mais apres ce fix, **tous les modules i18n prevus pour `cooperative_games_lean` sont actives** — un futur passage a `.submodules` ne casserait rien de plus que ce que cette PR active deja.

## Si CI FAIL apres ce PR

Si Lake build echoue sur `Basic_en.lean` ou `Basic.lean`, le diagnostic precis tombera dans les logs CI etablira si oui ou non le bug namespace `open TUGame` est reel. Dans ce cas, un PR dedie fixant le namespace (analogue PR #5445 qui a fix Shapley_en via `d051a6d1d`) sera necessaire.

Mais le pattern identique Basic.lean/Basic_en.lean suggere fortement que le commentaire speculatif etait faux et que le seul fix requis etait l'ajout aux globs.

## Statistiques

- **Fichiers** : 1 (lakefile.lean)
- **Insertions** : +19
- **Deletions** : -3
- **Atomicite R3** : OK (single file, single concern, single purpose)

## Liens

- Issue : #5419 (Shapley_en uncompileable)
- PRs en chaine : #5441 (CLOSED superseded), #5445 (MERGED Shapley_en namespace fix)
- PR future potentielle : fix `Basic_en.lean` namespace si CI FAIL
- Lecons : L48 (globs transitive deps), L49 (orphan-bug check), L31 (dormant bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)