### PR TITLE
Fix: Basic_en.lean rename structure TUGame -> TUGame_en (c.235 fix #5419 sibling uncompileable)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic_en.lean
@@ -45,7 +45,7 @@ abbrev Coalition (N : Type*) := Finset N
 /-- A TU (Transferable Utility) Game consists of a characteristic function v
     mapping coalitions to real values, with v(∅) = 0 -/
 @[ext]
-structure TUGame (N : Type*) [Fintype N] where
+structure TUGame_en (N : Type*) [Fintype N] where
   /-- The characteristic function: value of each coalition -/
   v : Finset N → ℝ
   /-- The empty coalition has value 0 -/
@@ -53,7 +53,7 @@ structure TUGame (N : Type*) [Fintype N] where
 
 namespace TUGame_en
 
-variable (G : TUGame N)
+variable (G : TUGame_en N)
 
 /-! ## Structural Properties -/
 
@@ -78,14 +78,14 @@ def marginalContribution (i : N) (S : Finset N) : ℝ :=
 
 /-- The unanimity game for coalition T (non-empty):
     v(S) = 1 if T ⊆ S, else 0 -/
-def unanimityGame (T : Finset N) (hT : T.Nonempty) : TUGame N where
+def unanimityGame (T : Finset N) (hT : T.Nonempty) : TUGame_en N where
   v := fun S => if T ⊆ S then 1 else 0
   empty_zero := by
     simp only [Finset.subset_empty]
     simp [hT.ne_empty]
 
 /-- The majority game: v(S) = 1 if |S| > n/2, else 0 -/
-def majorityGame : TUGame N where
+def majorityGame : TUGame_en N where
   v := fun S => if 2 * S.card > Fintype.card N then 1 else 0
   empty_zero := by simp
 
@@ -475,7 +475,7 @@ private lemma enumIndex_injective : Function.Injective (enumIndex : N → ℕ) :
   intro a b hab
   exact (Fintype.equivFin N).injective (Fin.ext hab)
 
-variable (G : TUGame N)
+variable (G : TUGame_en N)
 
 /-- Marginal vector along the fixed enumeration. -/
 noncomputable def marginalVector : Allocation N := fun i =>


### PR DESCRIPTION
## Contexte

PR #5476 (c.235) a echoue Lake build (`cooperative_games_lean`) sur `CooperativeGames.Basic_en` (job 85268682921, run 28758148436). Cause : `Basic_en.lean` declare sa `structure TUGame` au top-level (namespace module `CooperativeGames`) mais enveloppe ses definitions (`Superadditive`, `Convex`, `Core`, `marginalVector`, ...) dans `namespace TUGame_en`. Or la notation pointee Lean 4 `G.Method` resout `Method` en cherchant dans le namespace du **nom du type** (`CooperativeGames.TUGame.*`), pas dans le namespace courant (`CooperativeGames.TUGame_en.*`).

PR #5344 (commit `24a2da95f`) qui a ajoute `Basic_en.lean` a fait la substitution `namespace TUGame -> namespace TUGame_en` mais pas `structure TUGame -> structure TUGame_en`. Resultat : le code est byte-identique a `Basic.lean` (FR canonique, qui compile), mais les methodes utilisateur sont inaccessibles par `G.X` parce que pas dans le namespace du type.

## Diagnostic

Subagent Sonnet `ac4611f57c8064b2d` a compare ligne-par-ligne `Basic.lean` et `Basic_en.lean` en strippant les docstrings : **5 lignes differentes**, toutes des references au nom de la structure (`TUGame` au lieu de `TUGame_en`) :

- `Basic_en.lean:48` — `structure TUGame`
- `Basic_en.lean:56` — `variable (G : TUGame N)`
- `Basic_en.lean:81` — `def unanimityGame ... : TUGame N where`
- `Basic_en.lean:88` — `def majorityGame : TUGame N where`
- `Basic_en.lean:478` — `variable (G : TUGame N)`

Confiance diagnostic : HAUTE (subagent Sonnet, analyse line-by-line + semantique Lean 4 dotted notation documentee).

## Fix

5 substitutions (`TUGame` -> `TUGame_en`) au niveau du type, sans toucher au code tactique.

```diff
-structure TUGame (N : Type*) [Fintype N] where
+structure TUGame_en (N : Type*) [Fintype N] where

-variable (G : TUGame N)
+variable (G : TUGame_en N)

-def unanimityGame (T : Finset N) (hT : T.Nonempty) : TUGame N where
+def unanimityGame (T : Finset N) (hT : T.Nonempty) : TUGame_en N where

-def majorityGame : TUGame N where
+def majorityGame : TUGame_en N where
```

(plus la `variable (G : TUGame N)` ligne 478 dans `section MarginalVector`)

## Pourquoi une PR dediee (C151 anti-bundle)

- **PR #5476 = globs only** : ajouter `Basic`, `Basic_en`, `Shapley`, `Shapley_en` au tableau globs du lakefile
- **PR Basic_en fix = structure rename** : fix de la cause root du FAIL

Bundler les 2 dans une PR aurait viole L34 (C151 anti-bundle) : un fix orphelin namespace → PR dediee.

## Pattern identique a PR #5445

PR #5445 (`d051a6d1d`) fixait le **consommateur** `Shapley_en.lean` en remplacant `open TUGame` -> `open TUGame_en` (1 caractere, ligne 27). Cette PR-ci suit le meme pattern mais avec un fix different (rename structure au lieu de open directive) parce que `Basic_en.lean` declare sa propre structure, alors que `Shapley_en.lean` la consomme.

## Consequence post-merge

Une fois cette PR mergee, **PR #5476 doit passer Lake build** (la cause root du FAIL est eliminee). Coordination avec ai-01 pour rebase + retry.

## Statistiques

- **Fichiers** : 1 (`Basic_en.lean`)
- **Insertions** : +5
- **Deletions** : -5
- **Atomicite R3** : OK (single file, single concern : rename structure name)
- **Pas de scope creep** : aucun changement au code tactique, aucun ajout de lemme, aucun reformatage

## Liens

- Issue : #5419 (Shapley_en uncompileable, etend a Basic_en via PR #5476)
- Cause PR : #5476 (globs 4 modules Lake build FAIL)
- PR modele : #5445 `d051a6d1d` (Shapley_en `open TUGame` -> `open TUGame_en`)
- EPIC : #4980 (i18n FR+EN siblings)
- Lecons : L26 globs transitifs, L31 orphan-bug dormant, L32 `_en.lean` namespace pattern, L38 `tail -20` masque erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)