### PR TITLE
feat(secrets): centralize MISTRAL_API_KEY for easy rotation (#16, #5475)

### DIFF
--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -51,6 +51,12 @@ MASTER_ENV = REPO_ROOT / ".secrets" / "master.env"
 TARGET_ENVS = [
     *sorted((REPO_ROOT / "docker-configurations" / "services").glob("*/.env")),
     REPO_ROOT / "MyIA.AI.Notebooks" / "GenAI" / ".env",
+    # Lean prover harness: agent_tests/prover/config.py loads this .env.
+    # Centralizes MISTRAL_API_KEY (Leanstral trial, #5475) + ANTHROPIC_API_KEY
+    # so rotation = edit master.env + render (cf #16 "rotation facile").
+    # Only keys present in master.env are rewritten; the prover's own
+    # ZAI/LOCAL/OPENROUTER config (absent from master) is left untouched.
+    REPO_ROOT / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean" / ".env",
 ]
 
 # Keys whose VALUE is a shared secret and must be synced from master.env.
@@ -66,7 +72,7 @@ SECRET_KEYS: frozenset[str] = frozenset({
     # Hugging Face (aliased -- same logical token, two names)
     "HF_TOKEN", "HUGGINGFACE_TOKEN",
     # Paid LLM APIs (centrally managed, rotation-sensitive)
-    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "MISTRAL_API_KEY",
     # Model hubs / git
     "CIVITAI_TOKEN", "GITHUB_TOKEN", "GITHUB_ACCESS_TOKEN",
     # Per-service client API keys (server defines the value; clients must match)


### PR DESCRIPTION
## Objet

Rendre la **rotation de la clé Mistral** (Leanstral 1.5, essai #5475) aussi simple que les autres secrets partagés : *éditer `.secrets/master.env` + `python scripts/secrets/render_envs.py`*. Répond au mandat #16 « faire ça bien / rotation facile ».

## Changement (2 hunks, `scripts/secrets/render_envs.py`)

1. **`MISTRAL_API_KEY` ajoutée à `SECRET_KEYS`** (rangée « Paid LLM APIs, rotation-sensitive », à côté d'OPENAI/ANTHROPIC/OPENROUTER).
2. **`.env` du harnais prover Lean ajouté à `TARGET_ENVS`** (`MyIA.AI.Notebooks/SymbolicAI/Lean/.env`, chargé par `agent_tests/prover/config.py`).

## Sûreté (drift-safe, vérifié)

`sync()` ne réécrit **que** les clés présentes dans `master.env` (ligne 256). Dans le `.env` prover :
- `ANTHROPIC_API_KEY` + `MISTRAL_API_KEY` = déjà **égales** à master → **no-op** (vérifié valeur par valeur, sans les afficher).
- `ZAI_*`, `LOCAL_LLM_*`, `OPENROUTER_API_KEY` (absente de master), `LEAN_PROJECT_DIR` → **intouchées** (config service-spécifique).

Preuve : `python scripts/secrets/render_envs.py --check` → **exit 0, `No drift`**, master.env à 7 clés (MISTRAL incluse).

## Notes

- Aucun secret dans ce diff : `master.env` et le `.env` prover sont **gitignored** ; seul le script (liste de noms de clés) change.
- Débloque les steps 2-4 de #5475 (smoke-test + A/B `glm-5.1` vs `labs-leanstral-1-5`).

See #16
See #5475

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
