### PR TITLE
fix(lean): Basic_en.lean namespace resolution — structure TUGame -> TUGame_en (c.235 #4980)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic_en.lean
@@ -45,7 +45,7 @@ abbrev Coalition (N : Type*) := Finset N
 /-- A TU (Transferable Utility) Game consists of a characteristic function v
     mapping coalitions to real values, with v(∅) = 0 -/
 @[ext]
-structure TUGame (N : Type*) [Fintype N] where
+structure TUGame_en (N : Type*) [Fintype N] where
   /-- The characteristic function: value of each coalition -/
   v : Finset N → ℝ
   /-- The empty coalition has value 0 -/
@@ -53,7 +53,7 @@ structure TUGame (N : Type*) [Fintype N] where
 
 namespace TUGame_en
 
-variable (G : TUGame N)
+variable (G : TUGame_en N)
 
 /-! ## Structural Properties -/
 
@@ -78,14 +78,14 @@ def marginalContribution (i : N) (S : Finset N) : ℝ :=
 
 /-- The unanimity game for coalition T (non-empty):
     v(S) = 1 if T ⊆ S, else 0 -/
-def unanimityGame (T : Finset N) (hT : T.Nonempty) : TUGame N where
+def unanimityGame (T : Finset N) (hT : T.Nonempty) : TUGame_en N where
   v := fun S => if T ⊆ S then 1 else 0
   empty_zero := by
     simp only [Finset.subset_empty]
     simp [hT.ne_empty]
 
 /-- The majority game: v(S) = 1 if |S| > n/2, else 0 -/
-def majorityGame : TUGame N where
+def majorityGame : TUGame_en N where
   v := fun S => if 2 * S.card > Fintype.card N then 1 else 0
   empty_zero := by simp
 
@@ -475,7 +475,7 @@ private lemma enumIndex_injective : Function.Injective (enumIndex : N → ℕ) :
   intro a b hab
   exact (Fintype.equivFin N).injective (Fin.ext hab)
 
-variable (G : TUGame N)
+variable (G : TUGame_en N)
 
 /-- Marginal vector along the fixed enumeration. -/
 noncomputable def marginalVector : Allocation N := fun i =>

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/lakefile.lean
@@ -16,13 +16,14 @@ lean_lib «CooperativeGames» where
   -- Includes: TU games, Shapley value, Core, Voting games
   --
   -- i18n FR-first (EPIC #4980 ratif 2026-07-04 11:58Z, comment-4881909354) :
-  -- Globs precis ciblant UNIQUEMENT les fichiers de cette tranche :
-  -- `ConeKernel.lean` (FR canonique) + `ConeKernel_en.lean` (EN sibling
-  -- verbatim). Pattern precis plutot que `.submodules \`CooperativeGames`
-  -- car un autre _en pre-existant sur main (`Basic_en.lean`, ajoute par
-  -- PR #5344 commit 24a2da95f) a un bug de namespace resolution
-  -- (`G.Convex` non-prefixe dans `namespace MarginalVector`, fail
-  -- `open TUGame` manquant) — le `.submodules` l'aurait active en
-  -- doublon de la presente PR. Le pattern precis compile SEUL les
-  -- fichiers de la tranche, sans toucher les autres _en pre-existants.
-  globs := #[`CooperativeGames.ConeKernel, `CooperativeGames.ConeKernel_en]
+  -- Globs precis par tranche livree (FR canonique + EN sibling). Le namespace
+  -- bug dormant de `Basic_en.lean` (PR #5344 commit 24a2da95f : `structure TUGame`
+  -- global mais defs dans `namespace TUGame_en` -> dot-notation `G.Core` cassée)
+  -- est desormais FIXE (rename `structure TUGame` -> `structure TUGame_en`,
+  -- miroir exact du FR), donc `Basic_en` rejoint les globs.
+  -- `Shapley`/`Shapley_en` restent EXCLUS : `Shapley_en.lean` (2035L) a des bugs
+  -- residuels (`sorry` + `introN failed` + refs `TUGame` a migrer vers `TUGame_en`)
+  -- au-dela du namespace — PR dediee separee requise (fix path #5441 comment).
+  -- Pattern precis plutot que `.submodules \`CooperativeGames` pour ne pas
+  -- activer `Shapley_en` broken en doublon.
+  globs := #[`CooperativeGames.Basic_en, `CooperativeGames.ConeKernel, `CooperativeGames.ConeKernel_en]


### PR DESCRIPTION
# fix(lean): Basic_en.lean namespace resolution — `structure TUGame` → `structure TUGame_en`

Fixes the dormant namespace bug in `Basic_en.lean` (PR #5344 commit `24a2da95f`) that **blocked the globs rollout fleet-wide** (MEMORY c.219) and made **#5441 UNSTABLE/CLOSED**. This is the first half of the #5441 fix path (the second half, Shapley_en residual bugs, requires a separate dedicated PR).

## Root cause (G.1 firsthand, `lake.exe` local po-2026)

Full diagnostic posted on [#5441 comment-4887993213](https://github.com/jsboige/CoursIA/pull/5441#issuecomment-4887993213).

`structure TUGame` was declared **GLOBAL** (L48) but the defs (`Superadditive`, `Convex`, `Core`, `Balanced`, `marginalContribution`, `marginalVector`, …) lived in `namespace TUGame_en` (L54). Lean 4 dot-notation `G.Core` with `G : TUGame N` resolves against the **type's namespace** (`TUGame`), where these defs do NOT exist:

```
error: Basic_en.lean:106: Invalid field `Core`: environment does not contain `TUGame.Core`
error: Basic_en.lean:140: Invalid field `Superadditive`: does not contain `TUGame.Superadditive`
error: Basic_en.lean:173: Invalid field `Balanced`
error: Basic_en.lean:281: Unknown identifier `N`
error: Basic_en.lean:288: Unknown identifier `G.v`
... (~30 errors total)
```

The previous parallel-session diagnostic (claiming **#5445 alone fixes it**) was **INCOMPLETE**: #5445 fixed only `open TUGame_en` in `Shapley_en.lean`; `Basic_en` itself remained broken. Confirmed firsthand: even with #5445 merged on `main`, building `Shapley_en` still fails on `Basic_en.olean does not exist`, and building `Basic_en` surfaces ~30 real namespace errors.

## Fix (mirror of FR canonical `Basic.lean` structure)

Rename `structure TUGame` → `structure TUGame_en` so the **type name matches the namespace**, and dot-notation `G.Core` resolves to `TUGame_en.Core` which now exists. This is exactly how the FR `Basic.lean` works (`structure TUGame` + `namespace TUGame` share the name).

| Line | Before | After |
|------|--------|-------|
| L48 | `structure TUGame (N : Type*) [Fintype N] where` | `structure TUGame_en (N : Type*) [Fintype N] where` |
| L56 | `variable (G : TUGame N)` | `variable (G : TUGame_en N)` |
| L81 | `def unanimityGame … : TUGame N where` | `: TUGame_en N where` |
| L88 | `def majorityGame : TUGame N where` | `: TUGame_en N where` |
| L478 | `variable (G : TUGame N)` | `variable (G : TUGame_en N)` |

**5 edits, +5/-5 on Basic_en.lean.** Pure structural rename — no proof body touched.

## lakefile — add `Basic_en` to globs (no longer orphan)

`Basic_en` was deliberately excluded from globs (comment cited the dormant bug). Now fixed → rejoins the globs. `Shapley`/`Shapley_en` stay EXCLUDED: `Shapley_en.lean` (2035L) has residual bugs beyond namespace (`sorry` L97/L253, `introN failed`, ~30 `TUGame` refs to migrate to `TUGame_en`) — **separate dedicated PR required** per the #5441 fix path. Comment updated to reflect the new reality.

## Verification (lean-merge-discipline HARD — lake build SUCCESS local)

```
$ lake.exe build CooperativeGames.Basic_en
✔ [8494/8494] Built CooperativeGames.Basic_en (15s)
Build completed successfully (8494 jobs)

$ lake.exe build  (all globs: Basic_en + ConeKernel + ConeKernel_en)
Build completed successfully (8496 jobs)
```

| Check | Result |
|-------|--------|
| `lake build CooperativeGames.Basic_en` | **SUCCESS** (8494 jobs, 15s) |
| `lake build` (all globs) | **SUCCESS** (8496 jobs) |
| sorry grep FR (`Basic.lean`) | **0** |
| sorry grep EN (`Basic_en.lean`) | **0** |
| olean produced | `Basic_en.olean` (738 808 bytes) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |
| Mathlib | rc1 `d568c8c0` (junctioned cache) |

## Anti-regression check (rule D)
- `Basic.lean` (FR canonical) **UNCHANGED**.
- `ConeKernel.lean` + `ConeKernel_en.lean` **UNCHANGED** (still compile).
- Pure structural rename (5 type refs), no proof touched. sorry 0 → 0.
- `git diff --stat`: 2 files, +16/−15 (lakefile comment rewrite accounts for the lakefile delta).

## Scope (atomic — R3)
1 domaine (Lean i18n infra), 2 fichiers, +16/−15. Well under the 3000-line / 15-file / 4-feature thresholds. One logical change: make `Basic_en` compile + rejoin globs.

## Catalog
Catalog files untouched — source-only `.lean` + lakefile change, no catalog drift.

## Unblocks
- **Globs rollout (MEMORY c.219)**: `Basic_en` was one of the 4 `_en` siblings blocking the fleet-wide `.submodules` → precise-globs migration. Now resolved.
- **#5441 fix path**: first half delivered. Second half (Shapley_en residual `sorry`/`introN`/`TUGame` refs) = next dedicated PR.

See #4980, See #5441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
