### PR TITLE
docs(qc): partner-course README resync — kit-transitoire section + stale QC-Py count (See #3976)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/README.md
@@ -156,6 +156,20 @@ Le répertoire `examples/` contient des projets validés avec des backtests posi
 
 ---
 
+## Kit de Transition — Stratégies ML & Framework
+
+Le répertoire [`kit-transitoire/`](kit-transitoire/README.md) regroupe **trois stratégies progressives de rotation sectorielle** (univers de 9 ETFs `XLK`..`XLRE`), chacune livrée avec un `main.py` déployable sur QC Cloud et un notebook de recherche QuantBook (`research.ipynb`) documentant les itérations et le calibrage. Backtests validés sur 2015-2024.
+
+| # | Stratégie | Type | Sharpe | CAGR | Max DD |
+|---|-----------|------|--------|------|--------|
+| 01 | **ML RandomForest** | Classification (14 features, ré-entraînement mensuel) | 0.556 | 11.43 % | 17.2 % |
+| 02 | **ML XGBoost** | Régression (20 features, ré-entraînement bi-hebdomadaire) | 0.521 | 12.81 % | 39.1 % |
+| 03 | **Framework Composite** | Alpha Models (`SectorMomentum` + `Defensive`, `MultiStrategyPCM` 70/30, `MaxDrawdownCircuitBreaker` 15 %) | 0.376 | 7.60 % | 20.6 % |
+
+Les trois stratégies partagent un filtre baissier (`SPY < SMA200` -> max 2 positions) et illustrent la progression pédagogique : ML supervisé -> ML avancé avec features riches -> architecture QC Framework propre (alpha models + PCM + risk). Documentation détaillée et comparaison complète : [`kit-transitoire/README.md`](kit-transitoire/README.md).
+
+---
+
 ## Notebooks de Recherche (QuantBook)
 
 Cinq projets Researcher avec des notebooks QuantBook opérationnels pour explorer les données QC Cloud :
@@ -272,7 +286,7 @@ Les exemples et templates couvrent **4 classes d'actifs** et **8+ concepts de tr
 
 ## Notebooks Compagnons
 
-28 notebooks Python progressifs dans `../Python/` (QC-Py-01 à QC-Py-28) :
+La série Python progressive dans [`../Python/`](../Python/README.md) (notebooks `QC-Py-*`) accompagne ce cours partenaire. Elle couvre l'écosystème QC de bout en bout, du premier algorithme au déploiement live :
 
 1. **Setup** : compte, IDE, premier algorithme
 2. **Fondations** : API, Resolution, Consolidators, QuantBook
@@ -281,6 +295,8 @@ Les exemples et templates couvrent **4 classes d'actifs** et **8+ concepts de tr
 5. **Framework** : Alpha, Portfolio Construction, Risk, Execution
 6. **ML/AI** : Features, modèles, ObjectStore, RL, NLP
 7. **Production** : paper trading, live, monitoring
+
+Le catalogue détaillé et les comptes à jour (les notebooks `QC-Py-*` continuent de croître) se trouvent dans le README canonique [`../Python/README.md`](../Python/README.md).
 
 ---
 


### PR DESCRIPTION
## Summary

§E feuille **#3976 Rank 2** (`partner-course-quant-trading/README.md`) — resync drift vs disque. Owner po-2024:CoursIA (turf QC).

Audit fichier-entier vs `origin/main` frais (anti stale-local) révèle **2 drifts structurels** :

| # | Drift | Fix |
|---|-------|-----|
| 1 | **Section `kit-transitoire/` MANQUANTE** — 3 stratégies ML/Framework progressives (01-ML-RandomForest, 02-ML-XGBoost, 03-Framework-Composite) existent sur disque avec `main.py` + `research.ipynb` QuantBook chacune, mais **jamais mentionnées** dans le README (grep 0 réf hors son propre README) | Ajout d'une section dédiée « Kit de Transition » avec tableau comparatif (Sharpe/CAGR/MaxDD validés 2015-2024, filtre baissier `SPY < SMA200`, progression pédagogique ML -> ML avancé -> QC Framework) |
| 2 | **"28 notebooks Python (QC-Py-01 à QC-Py-28)"** L275 STALE — série a grandi à 36 numérotés (jusqu'à QC-Py-41) ; hard-count qui re-drift à chaque ajout | Remplacé par pointeur vers README canonique [`../Python/README.md`](../Python/README.md) (source de vérité des comptes) |

## Preuves §E (audit fichier-entier, firsthand origin/main)

- **Disk↔prose reconciliation** :
  - `git ls-tree -r --name-only origin/main -- .../kit-transitoire/` = 3 dossiers (01/02/03) + README → **confirmé manquant du README**.
  - `git ls-tree ... | grep -oE 'QC-Py-[0-9]+' | sort -u` = 36 numérotés (QC-Py-01..28, 30..35, 40, 41) → **« 28 » stale confirmé**.
  - Sibling `Python/README.md` L17 = « 53 fichiers `.ipynb` » (count canonique) → pointer vers lui évite le re-drift.
- **Liens sortants vérifiés** : `../projects/README.md`, `../GETTING-STARTED.md`, `templates/starter|intermediate|advanced/README.md`, `kit-transitoire/README.md`, `README.en.md` = **tous existent** (`git cat-file -e origin/main:<path>`).
- **CATALOG byte-identique** : `git status` ne montre aucun churn `COURSE_CATALOG.*` (cron-only, règle catalog-pr-hygiene HARD 1).
- **`archive-2025/`** cité dans la checklist #3976 = **absent du README actuel** (déjà résolu ou erreur checklist, pas d'action).

## Scope (HARD 3 — atomique)

1 fichier (`partner-course-quant-trading/README.md`), +17/-1, 2 drifts cohérents « README reflète la réalité disque ». Pas de code, pas de notebooks touchés → pas de re-exécution C.2 requise.

## Conformité règles

- **FR-first** (readme-french-first) : prose ajoutée en français (le README est FR ; `.en.md` préservé tel quel, snapshot pré-bascule).
- **CATALOG-STATUS** : inchangé (cron-only).
- **`See #3976`** (pas `Closes` — l'epic #3973 reste ouvert, contribution partielle d'une feuille).
- **Collision check** : 0 PR open sur partner-course (`gh pr list --search`), 0 `[CLAIMED]` dashboard ±30min.

See #3976, See #3973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)