### PR TITLE
feat(search): Search-9-LinearProgramming-Csharp — OrTools LP twin (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
@@ -1,0 +1,939 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "s9c01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004563,
+     "end_time": "2026-07-06T00:01:37.313405",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:37.308842",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Search-9 : Programmation Linéaire et Simplexe (C# / .NET)\n",
+    "\n",
+    "**Navigation** : [<< Search-8 Dancing Links](Search-8-DancingLinks-Csharp.ipynb) | [Index](../README.md) | [Search-10 SymbolicAutomata >>](Search-10-SymbolicAutomata-Csharp.ipynb)\n",
+    "\n",
+    "**Twin .NET du notebook [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) (Python/PuLP).** Ce notebook est le port fidèle en C#/.NET utilisant **Google OrTools** (`Google.OrTools.LinearSolver`) — le solveur SOTA de Google, natif sur NuGet.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "1. Formuler un problème d'optimisation en **programmation linéaire** (variables, fonction objectif, contraintes)\n",
+    "2. Résoudre un LP continu avec le solveur **GLOP** (simplexe) d'OrTools\n",
+    "3. Distinguer **PL continue** (variables réelles) et **PLNE** (variables entières/binaires) et résoudre un sac à dos avec **CBC**\n",
+    "4. Lire une **analyse de sensibilité** (prix fictifs / *shadow prices*) et interpréter la dualité\n",
+    "\n",
+    "### Prérequis\n",
+    "- Notions d'algèbre linéaire et de géométrie des polyèdres (sommets, région admissible)\n",
+    "- Search-1 à Search-8 (modélisation de problèmes de recherche)\n",
+    "\n",
+    "### Durée estimée : 60 minutes\n",
+    "\n",
+    "> **Note** : OrTools fournit plusieurs solveurs. **GLOP** (Google) est un simplexe pour la PL continue ; **CBC** (COIN-OR) gère la PLNE (variables entières/binaires). Les deux sont embarqués dans le NuGet `Google.OrTools`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "s9c02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:01:37.324775Z",
+     "iopub.status.busy": "2026-07-06T00:01:37.320203Z",
+     "iopub.status.idle": "2026-07-06T00:01:38.822202Z",
+     "shell.execute_reply": "2026-07-06T00:01:38.817926Z"
+    },
+    "papermill": {
+     "duration": 1.507081,
+     "end_time": "2026-07-06T00:01:38.822306",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:37.315225",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '47680.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.11.4210</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Environnement prêt — Google.OrTools.LinearSolver chargé."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Setup : chargement du solveur SOTA Google OrTools via NuGet.\n",
+    "#r \"nuget: Google.OrTools, 9.11.4210\"\n",
+    "\n",
+    "using Google.OrTools.LinearSolver;\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "\n",
+    "\"Environnement prêt — Google.OrTools.LinearSolver chargé.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002191,
+     "end_time": "2026-07-06T00:01:38.826859",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:38.824668",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Introduction à la Programmation Linéaire\n",
+    "\n",
+    "La **programmation linéaire (PL)** modélise un problème d'optimisation dont la fonction objectif et les contraintes sont des combinaisons **linéaires** des variables de décision :\n",
+    "\n",
+    "$$\\max / \\min\\ z = c_1 x_1 + c_2 x_2 + \\dots + c_n x_n$$\n",
+    "\n",
+    "sous contraintes $a_{i1}x_1 + a_{i2}x_2 + \\dots + a_{in}x_n \\le / = / \\ge\\ b_i$ et $x_j \\ge 0$.\n",
+    "\n",
+    "### Pourquoi le simplexe est SOTA\n",
+    "\n",
+    "L'algorithme du **simplexe** (Dantzig, 1947) exploite une propriété géométrique fondamentale : l'optimum d'un LP est atteint en un **sommet** du polyèdre des solutions admissibles. Plutôt qu'énumérer les sommets (exponentiel), le simplexe *pivote* de sommet en sommet adjacent en améliaurant toujours l'objectif — convergent en pratique en O(n) itérations bien que O(2ⁿ) dans le pire cas théorique.\n",
+    "\n",
+    "**OrTools GLOP** implémente le simplexe révisé avec règles de pivotage anti-cyclage : c'est le vrai outil SOTA, pas une réimplémentation pédagogique.\n",
+    "\n",
+    "### Exemple introductif — Problème de production\n",
+    "\n",
+    "Un atelier fabrique deux produits P1 et P2. Chaque unité de P1 rapporte **3 €** et consomme 1 h machine + 2 h main-d'œuvre. Chaque unité de P2 rapporte **2 €** et consomme 2 h machine + 1 h main-d'œuvre. Disponibilités : 4 h machine, 5 h main-d'œuvre. **Combien produire de chaque pour maximiser le profit ?**\n",
+    "\n",
+    "| Ressource | P1 (unité) | P2 (unité) | Disponible |\n",
+    "|-----------|-----------:|-----------:|-----------:|\n",
+    "| Machine   | 1 h        | 2 h        | 4 h        |\n",
+    "| Main-d'œuvre | 2 h     | 1 h        | 5 h        |\n",
+    "| **Profit**| 3 €        | 2 €        | —          |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002025,
+     "end_time": "2026-07-06T00:01:38.830925",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:38.828900",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Premier exemple avec OrTools — Problème de production\n",
+    "\n",
+    "Formulation :\n",
+    "\n",
+    "$$\\max\\ z = 3x_1 + 2x_2 \\quad \\text{s.c.} \\quad x_1 + 2x_2 \\le 4,\\ \\ 2x_1 + x_2 \\le 5,\\ \\ x_1, x_2 \\ge 0$$\n",
+    "\n",
+    "L'API OrTools est proche de PuLP : on crée un `Solver`, des variables (`MakeNumVar`), on ajoute des contraintes (`solver.Add`), on fixe l'objectif (`Maximize`/`Minimize`), puis on appelle `Solve()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "s9c05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:01:38.836441Z",
+     "iopub.status.busy": "2026-07-06T00:01:38.836234Z",
+     "iopub.status.idle": "2026-07-06T00:01:39.129255Z",
+     "shell.execute_reply": "2026-07-06T00:01:39.129086Z"
+    },
+    "papermill": {
+     "duration": 0.296317,
+     "end_time": "2026-07-06T00:01:39.129335",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:38.833018",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Problème de Production (GLOP) ===\r\n",
+       "Statut          : OPTIMAL\r\n",
+       "x1 (P1)         : 2,00 unités\r\n",
+       "x2 (P2)         : 1,00 unités\r\n",
+       "Profit maximal z: 8,00 €\r\n",
+       "\r\n",
+       "--- Vérification des contraintes ---\r\n",
+       "  Machine     : 4,00 <= 4\r\n",
+       "  Main-d'œuvre: 5,00 <= 5\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Problème de production — PL continue (GLOP)\n",
+    "var solver = Solver.CreateSolver(\"GLOP\");\n",
+    "\n",
+    "var x1 = solver.MakeNumVar(0.0, double.PositiveInfinity, \"x1\");\n",
+    "var x2 = solver.MakeNumVar(0.0, double.PositiveInfinity, \"x2\");\n",
+    "\n",
+    "solver.Add(x1 + 2 * x2 <= 4.0);\n",
+    "solver.Add(2 * x1 + x2 <= 5.0);\n",
+    "solver.Maximize(3 * x1 + 2 * x2);\n",
+    "\n",
+    "var result = solver.Solve();\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"=== Problème de Production (GLOP) ===\");\n",
+    "sb.AppendLine($\"Statut          : {result}\");\n",
+    "sb.AppendLine($\"x1 (P1)         : {x1.SolutionValue():F2} unités\");\n",
+    "sb.AppendLine($\"x2 (P2)         : {x2.SolutionValue():F2} unités\");\n",
+    "sb.AppendLine($\"Profit maximal z: {solver.Objective().Value():F2} €\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"--- Vérification des contraintes ---\");\n",
+    "sb.AppendLine($\"  Machine     : {x1.SolutionValue() + 2*x2.SolutionValue():F2} <= 4\");\n",
+    "sb.AppendLine($\"  Main-d'œuvre: {2*x1.SolutionValue() + x2.SolutionValue():F2} <= 5\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c06",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002135,
+     "end_time": "2026-07-06T00:01:39.136250",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.134115",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : Production — Solution optimale\n",
+    "\n",
+    "La solution optimale est **x1 = 2, x2 = 1** pour un profit de **8 €** (3·2 + 2·1). Vérification :\n",
+    "- Machine : 2 + 2·1 = 4 = 4 (contrainte saturée)\n",
+    "- Main-d'œuvre : 2·2 + 1 = 5 = 5 (contrainte saturée)\n",
+    "\n",
+    "Les **deux contraintes sont saturées** : le point optimal est le sommet du polyèdre à l'intersection des deux droites. C'est précisément ce que le simplexe exploite — il se déplace sur la frontière jusqu'au sommet qui maximise z.\n",
+    "\n",
+    "> **Comparaison PuLP ↔ OrTools** : `LpProblem(\"Production\", LpMaximize)` ↔ `Solver.CreateSolver(\"GLOP\")` + `Maximize(...)` ; `LpVariable('x1', lowBound=0)` ↔ `MakeNumVar(0, inf, \"x1\")` ; `prob += 3*x1+2*x2` ↔ `Maximize(3*x1+2*x2)`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002096,
+     "end_time": "2026-07-06T00:01:39.140482",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.138386",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Méthodologie de formulation — Problème de diet\n",
+    "\n",
+    "Le **problème de diet** (minimisation) illustre la formulation avec contraintes `≥` (couverture minimale) et objectif de minimisation. Deux aliments A et B ; A coûte 1 €/unité, B coûte 2 €/unité. Apports :\n",
+    "\n",
+    "| Nutriment | Aliment A | Aliment B | Besoin minimal |\n",
+    "|-----------|----------:|----------:|---------------:|\n",
+    "| Protéines | 2         | 3         | 12             |\n",
+    "| Calcium   | 10        | 5         | 30             |\n",
+    "| Fer       | 5         | 10        | 20             |\n",
+    "\n",
+    "$$\\min\\ z = x_A + 2x_B \\quad \\text{s.c.} \\quad 2x_A+3x_B \\ge 12,\\ \\ 10x_A+5x_B \\ge 30,\\ \\ 5x_A+10x_B \\ge 20,\\ \\ x_A,x_B \\ge 0$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "s9c08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:01:39.145810Z",
+     "iopub.status.busy": "2026-07-06T00:01:39.145632Z",
+     "iopub.status.idle": "2026-07-06T00:01:39.217219Z",
+     "shell.execute_reply": "2026-07-06T00:01:39.217070Z"
+    },
+    "papermill": {
+     "duration": 0.074728,
+     "end_time": "2026-07-06T00:01:39.217282",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.142554",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Problème de Diet (minimisation) ===\r\n",
+       "Statut     : OPTIMAL\r\n",
+       "xA (aliment A): 6,00 unités\r\n",
+       "xB (aliment B): 0,00 unités\r\n",
+       "Coût minimal : 6,00 €\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Problème de diet — minimisation (GLOP)\n",
+    "var solverDiet = Solver.CreateSolver(\"GLOP\");\n",
+    "var xA = solverDiet.MakeNumVar(0.0, double.PositiveInfinity, \"xA\");\n",
+    "var xB = solverDiet.MakeNumVar(0.0, double.PositiveInfinity, \"xB\");\n",
+    "\n",
+    "solverDiet.Add(2 * xA + 3 * xB >= 12.0);   // Protéines\n",
+    "solverDiet.Add(10 * xA + 5 * xB >= 30.0);  // Calcium\n",
+    "solverDiet.Add(5 * xA + 10 * xB >= 20.0);  // Fer\n",
+    "solverDiet.Minimize(xA + 2 * xB);\n",
+    "\n",
+    "var statutDiet = solverDiet.Solve();\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"=== Problème de Diet (minimisation) ===\");\n",
+    "sb.AppendLine($\"Statut     : {statutDiet}\");\n",
+    "sb.AppendLine($\"xA (aliment A): {xA.SolutionValue():F2} unités\");\n",
+    "sb.AppendLine($\"xB (aliment B): {xB.SolutionValue():F2} unités\");\n",
+    "sb.AppendLine($\"Coût minimal : {solverDiet.Objective().Value():F2} €\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c09",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001984,
+     "end_time": "2026-07-06T00:01:39.221518",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.219534",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : Diet — Mélange optimal\n",
+    "\n",
+    "Le simplexe trouve le mélange au coût minimal satisfaisant les apports : **xA = 6, xB = 0** pour un coût de **6 €**.\n",
+    "\n",
+    "Vérifions quelles contraintes sont saturées à ce point :\n",
+    "- Protéines : 2·6 + 3·0 = **12 = 12** (saturée)\n",
+    "- Calcium   : 10·6 + 5·0 = **60 ≫ 30** (largeur de 30 — surplus)\n",
+    "- Fer       : 5·6 + 10·0 = **30 > 20** (surplus)\n",
+    "\n",
+    "Seule la contrainte de **protéines** est saturée : c'est elle qui « tire » la solution. L'aliment A étant le moins cher (1 € vs 2 €) et riche en calcium/fer, le solveur en remplit jusqu'à satisfaire la protéine — d'où le surplus sur les autres nutriments. C'est l'**écart de relaxation** typique d'un problème de minimisation.\n",
+    "\n",
+    "### Exercice : Problème de mélange industriel\n",
+    "\n",
+    "À vous de modéliser un mélange industriel (par ex. alliage métallurgique : 3 métaux, puretés minimales, coût minimal). Formulez puis complétez le stub ci-dessous."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "s9c10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:01:39.226294Z",
+     "iopub.status.busy": "2026-07-06T00:01:39.226136Z",
+     "iopub.status.idle": "2026-07-06T00:01:39.288047Z",
+     "shell.execute_reply": "2026-07-06T00:01:39.287929Z"
+    },
+    "papermill": {
+     "duration": 0.064622,
+     "end_time": "2026-07-06T00:01:39.288103",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.223481",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice à compléter — voir l'énoncé ci-dessus."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice : Problème de mélange industriel (étudiant à compléter)\n",
+    "// Objectif : modéliser un mélange à coût minimal sous contraintes de qualité.\n",
+    "// Indice 1 : créer un Solver.CreateSolver(\"GLOP\") + MakeNumVar par ingrédient.\n",
+    "// Indice 2 : les contraintes de pureté sont des >= (couverture minimale).\n",
+    "// Étape 1 : définir les variables\n",
+    "// Étape 2 : ajouter l'objectif Minimize(cout_total)\n",
+    "// Étape 3 : ajouter les contraintes de qualité\n",
+    "// Étape 4 : solver.Solve() et afficher\n",
+    "var solverMelange = Solver.CreateSolver(\"GLOP\");\n",
+    "// TODO étudiant : compléter la modélisation\n",
+    "\"Exercice à compléter — voir l'énoncé ci-dessus.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c11",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001908,
+     "end_time": "2026-07-06T00:01:39.292206",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.290298",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Analyse de sensibilité et dualité\n",
+    "\n",
+    "L'**analyse de sensibilité** répond à : *de combien l'objectif améliorerait-il si on relâchait une contrainte d'une unité ?* La réponse = **prix fictif** (*shadow price* / valeur duale) de la contrainte.\n",
+    "\n",
+    "OrTools expose ces valeurs via `Constraint.DualValue()`. Pour une maximisation sous contraintes `≤`, la valeur duale est **positive** : c'est précisément le gain marginal de l'objectif si l'on relâche le second membre d'une unité. C'est la **dualité forte** du LP : le problème primal (max) et son dual (min) ont la même valeur optimale à l'optimum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "s9c12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:01:39.296590Z",
+     "iopub.status.busy": "2026-07-06T00:01:39.296425Z",
+     "iopub.status.idle": "2026-07-06T00:01:39.383541Z",
+     "shell.execute_reply": "2026-07-06T00:01:39.383428Z"
+    },
+    "papermill": {
+     "duration": 0.089644,
+     "end_time": "2026-07-06T00:01:39.383596",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.293952",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Analyse de Sensibilité (shadow prices) ===\r\n",
+       "Solution optimale : x1=2,00, x2=1,00, z=8,00\r\n",
+       "\r\n",
+       "Prix fictifs (valeur marginale d'une unité supplémentaire de ressource) :\r\n",
+       "  Machine     : dual = 0,33 €/h\r\n",
+       "  Main-d'œuvre: dual = 1,33 €/h\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Analyse de sensibilité — prix fictifs (problème de production)\n",
+    "var solverSens = Solver.CreateSolver(\"GLOP\");\n",
+    "var s1 = solverSens.MakeNumVar(0.0, double.PositiveInfinity, \"x1\");\n",
+    "var s2 = solverSens.MakeNumVar(0.0, double.PositiveInfinity, \"x2\");\n",
+    "\n",
+    "var cMachine = solverSens.MakeConstraint(double.NegativeInfinity, 4.0, \"Machine\");\n",
+    "cMachine.SetCoefficient(s1, 1.0); cMachine.SetCoefficient(s2, 2.0);\n",
+    "var cMO = solverSens.MakeConstraint(double.NegativeInfinity, 5.0, \"MainOeuvre\");\n",
+    "cMO.SetCoefficient(s1, 2.0); cMO.SetCoefficient(s2, 1.0);\n",
+    "solverSens.Maximize(3 * s1 + 2 * s2);\n",
+    "solverSens.Solve();\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"=== Analyse de Sensibilité (shadow prices) ===\");\n",
+    "sb.AppendLine($\"Solution optimale : x1={s1.SolutionValue():F2}, x2={s2.SolutionValue():F2}, z={solverSens.Objective().Value():F2}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Prix fictifs (valeur marginale d'une unité supplémentaire de ressource) :\");\n",
+    "sb.AppendLine($\"  Machine     : dual = {cMachine.DualValue():F2} €/h\");\n",
+    "sb.AppendLine($\"  Main-d'œuvre: dual = {cMO.DualValue():F2} €/h\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002184,
+     "end_time": "2026-07-06T00:01:39.388055",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.385871",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : Shadow Prices\n",
+    "\n",
+    "Le prix fictif d'une ressource mesure sa **valeur marginale** : *combien vaudrait une heure supplémentaire de cette ressource ?* Ici la **Main-d'œuvre** vaut **1,33 €/h** (contre 0,33 €/h pour la Machine) : c'est la ressource la plus tendue, celle dont une heure supplémentaire rapporterait le plus. La Machine, moins critique, n'a qu'une faible valeur marginale.\n",
+    "\n",
+    "**Règle de complémentarité** : à l'optimum, soit une contrainte est saturée (dual > 0), soit son dual est nul (contrainte non saturée = ressource en surplus, sans valeur marginale). C'est le **théorème de l'écart complémentaire**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c14",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002082,
+     "end_time": "2026-07-06T00:01:39.392498",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.390416",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Programmation Linéaire en Nombres Entiers (PLNE)\n",
+    "\n",
+    "Quand les variables doivent être **entières** (on ne peut produire 2,3 unités) ou **binaires** (décision oui/non), on bascule en PLNE. Le solveur **CBC** (COIN-OR Branch-and-Cut) explore un arbre de分支 en résolvant des relaxations continues — c'est NP-difficile mais CBC le gère efficacement pour les tailles pédagogiques.\n",
+    "\n",
+    "### Problème du sac à dos\n",
+    "\n",
+    "5 objets, capacité 7 kg, maximiser la valeur :\n",
+    "\n",
+    "| Objet | 1 | 2 | 3 | 4 | 5 |\n",
+    "|-------|--:|--:|--:|--:|--:|\n",
+    "| Poids (kg) | 2 | 1 | 3 | 2 | 4 |\n",
+    "| Valeur (€) | 12 | 10 | 20 | 15 | 25 |\n",
+    "\n",
+    "$$\\max \\sum_j v_j x_j \\quad \\text{s.c.} \\quad \\sum_j p_j x_j \\le 7,\\ \\ x_j \\in \\{0,1\\}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "s9c15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:01:39.397650Z",
+     "iopub.status.busy": "2026-07-06T00:01:39.397472Z",
+     "iopub.status.idle": "2026-07-06T00:01:39.622955Z",
+     "shell.execute_reply": "2026-07-06T00:01:39.622701Z"
+    },
+    "papermill": {
+     "duration": 0.228515,
+     "end_time": "2026-07-06T00:01:39.623038",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.394523",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Sac à dos (PLNE, CBC) ===\r\n",
+       "Capacité : 7 kg\r\n",
+       "Statut   : OPTIMAL\r\n",
+       "Valeur optimale : 50 €\r\n",
+       "Objets sélectionnés :\r\n",
+       "  x2 = 1  (poids 1 kg, valeur 10 €)\r\n",
+       "  x4 = 1  (poids 2 kg, valeur 15 €)\r\n",
+       "  x5 = 1  (poids 4 kg, valeur 25 €)\r\n",
+       "Poids total utilisé : 7 kg / 7 kg\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Sac à dos — PLNE binaire (CBC)\n",
+    "var solverK = Solver.CreateSolver(\"CBC\");\n",
+    "var poids  = new double[] { 2, 1, 3, 2, 4 };\n",
+    "var valeurs = new double[] { 12, 10, 20, 15, 25 };\n",
+    "double capacite = 7.0;\n",
+    "\n",
+    "var xk = new Variable[poids.Length];\n",
+    "for (int j = 0; j < poids.Length; j++)\n",
+    "    xk[j] = solverK.MakeIntVar(0, 1, $\"x{j+1}\");\n",
+    "\n",
+    "var cCap = solverK.MakeConstraint(double.NegativeInfinity, capacite, \"Capacite\");\n",
+    "for (int j = 0; j < poids.Length; j++)\n",
+    "    cCap.SetCoefficient(xk[j], poids[j]);\n",
+    "\n",
+    "// Objectif : somme pondérée valeur·x. On accumule les termes (double * Variable -> LinearExpr)\n",
+    "// car LinearExpr n'admet ni la conversion depuis int ni Sum() statique dans OrTools 9.11.\n",
+    "LinearExpr obj = valeurs[0] * xk[0];\n",
+    "for (int j = 1; j < poids.Length; j++)\n",
+    "    obj += valeurs[j] * xk[j];\n",
+    "solverK.Maximize(obj);\n",
+    "var statutK = solverK.Solve();\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"=== Sac à dos (PLNE, CBC) ===\");\n",
+    "sb.AppendLine($\"Capacité : {capacite} kg\");\n",
+    "sb.AppendLine($\"Statut   : {statutK}\");\n",
+    "sb.AppendLine($\"Valeur optimale : {solverK.Objective().Value():F0} €\");\n",
+    "sb.AppendLine(\"Objets sélectionnés :\");\n",
+    "double poidsTotal = 0;\n",
+    "for (int j = 0; j < poids.Length; j++)\n",
+    "{\n",
+    "    if (xk[j].SolutionValue() > 0.5)\n",
+    "    {\n",
+    "        sb.AppendLine($\"  x{j+1} = 1  (poids {poids[j]} kg, valeur {valeurs[j]} €)\");\n",
+    "        poidsTotal += poids[j];\n",
+    "    }\n",
+    "}\n",
+    "sb.AppendLine($\"Poids total utilisé : {poidsTotal:F0} kg / {capacite} kg\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002534,
+     "end_time": "2026-07-06T00:01:39.628204",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.625670",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : Sac à dos — Sélection optimale\n",
+    "\n",
+    "Le branch-and-cut de CBC trouve la combinaison binaire optimale. Notez qu'**arrondir** la solution de la relaxation continue ne donne PAS l'optimum entier — c'est toute la raison d'être du PLNE : la relaxation est une **borne supérieure** (pour un max), le PLNE donne la vraie solution faisable.\n",
+    "\n",
+    "### Exercice : Problème de couverture d'ensemble (Set Cover)\n",
+    "\n",
+    "Modélisez un set cover : un ensemble d'éléments à couvrir par des sous-ensembles de coût donné, minimiser le coût total. Variables binaires `x_S ∈ {0,1}` par sous-ensemble, contraintes `≥ 1` par élément. Complétez le stub."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "s9c17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:01:39.635057Z",
+     "iopub.status.busy": "2026-07-06T00:01:39.634629Z",
+     "iopub.status.idle": "2026-07-06T00:01:39.693215Z",
+     "shell.execute_reply": "2026-07-06T00:01:39.693019Z"
+    },
+    "papermill": {
+     "duration": 0.062491,
+     "end_time": "2026-07-06T00:01:39.693315",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.630824",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice à compléter — voir l'énoncé ci-dessus."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice : Set Cover (étudiant à compléter)\n",
+    "// Indice 1 : Solver.CreateSolver(\"CBC\") + MakeIntVar(0,1) par sous-ensemble.\n",
+    "// Indice 2 : pour chaque élément, la somme des x_S qui le couvrent doit être >= 1.\n",
+    "// Étape 1 : variables binaires par sous-ensemble\n",
+    "// Étape 2 : Minimize(coût total)\n",
+    "// Étape 3 : contraintes de couverture (>= 1 par élément)\n",
+    "// Étape 4 : Solve() + afficher les sous-ensembles choisis\n",
+    "var solverSC = Solver.CreateSolver(\"CBC\");\n",
+    "// TODO étudiant : modéliser le set cover\n",
+    "\"Exercice à compléter — voir l'énoncé ci-dessus.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c18",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001901,
+     "end_time": "2026-07-06T00:01:39.697545",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.695644",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Optimisation multi-objectif avec contraintes priorisées\n",
+    "\n",
+    "Modélisez un problème à deux objectifs (par ex. maximiser profit ET minimiser émissions CO₂) via la **méthode des poids** ou les **contraintes priorisées** (un objectif principal, l'autre borné). Formulez puis complétez le stub."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "s9c19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:01:39.703087Z",
+     "iopub.status.busy": "2026-07-06T00:01:39.702859Z",
+     "iopub.status.idle": "2026-07-06T00:01:39.772161Z",
+     "shell.execute_reply": "2026-07-06T00:01:39.772022Z"
+    },
+    "papermill": {
+     "duration": 0.072778,
+     "end_time": "2026-07-06T00:01:39.772228",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.699450",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice à compléter — voir l'énoncé ci-dessus."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice : Multi-objectif par contraintes priorisées (étudiant à compléter)\n",
+    "// Indice : max profit s.c. émissions <= seuil. Faire varier le seuil = front de Pareto.\n",
+    "// Étape 1 : variables + objectif profit (Maximize)\n",
+    "// Étape 2 : contrainte d'émission (<= seuil)\n",
+    "// Étape 3 : Solve() pour plusieurs valeurs de seuil\n",
+    "var solverMO = Solver.CreateSolver(\"GLOP\");\n",
+    "// TODO étudiant : optimisation multi-objectif\n",
+    "\"Exercice à compléter — voir l'énoncé ci-dessus.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s9c20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002393,
+     "end_time": "2026-07-06T00:01:39.777373",
+     "exception": false,
+     "start_time": "2026-07-06T00:01:39.774980",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Conclusion\n",
+    "\n",
+    "Ce notebook a présenté la **programmation linéaire en C#/.NET** avec Google OrTools — le pendant du notebook Python/PuLP.\n",
+    "\n",
+    "### Récapitulatif\n",
+    "\n",
+    "| Concept | API OrTools | Solveur | Équivalent PuLP |\n",
+    "|--------|-------------|---------|-----------------|\n",
+    "| PL continue (max/min) | `MakeNumVar`, `solver.Add`, `Maximize`/`Minimize` | **GLOP** (simplexe) | `LpProblem`, `LpVariable('Continuous')` |\n",
+    "| PLNE binaire/entière | `MakeIntVar(0,1)` / `MakeIntVar` | **CBC** (branch-and-cut) | `LpVariable('Binary')` / `('Integer')` |\n",
+    "| Analyse de sensibilité | `Constraint.DualValue()` | GLOP | `prob.constraints[i].pi` |\n",
+    "| Contrainte nommée | `MakeConstraint(lb, ub, \"name\")` + `SetCoefficient` | — | `prob += expr, \"name\"` |\n",
+    "\n",
+    "### Points clés\n",
+    "\n",
+    "1. **OrTools est le vrai solveur SOTA** (GLOP = simplexe révisé Google, CBC = branch-and-cut COIN-OR) — ce n'est pas une réimplémentation pédagogique. Les solveurs sont embarqués nativement dans le NuGet.\n",
+    "2. **Géométrie du simplexe** : l'optimum d'un LP est un sommet du polyèdre admissible ; le simplexe pivote de sommet en sommet.\n",
+    "3. **Dualité forte** : les *shadow prices* (`DualValue`) mesurent la valeur marginale des ressources et satisfont l'écart complémentaire.\n",
+    "4. **PLNE ≠ PL arrondie** : le branch-and-cut explore un arbre ; la relaxation continue n'est qu'une borne.\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "\n",
+    "- **Problème de transport** (3 usines → 4 magasins) : variable `x_ij` par paire, équilibre offre/demande — tranche ultérieure de ce twin.\n",
+    "- **Méthode du simplexe à la main** : voir [Search-1-StateSpace](Search-1-StateSpace-Csharp.ipynb) pour les fondations géométriques.\n",
+    "- **OrTools avancé** : `Google.OrTools.Sat` (CP-SAT) pour la programmation par contraintes, `Google.OrTools.Graph` pour le flot min-cost.\n",
+    "\n",
+    "### Références\n",
+    "\n",
+    "- Google OrTools — [Linear Solver](https://developers.google.com/optimization/lp) (GLOP, CBC, GLPK, SCIP).\n",
+    "- Dantzig, G. (1947), origine du simplexe.\n",
+    "- Vanderbei, R., *Linear Programming: Foundations and Extensions*.\n",
+    "- Twin Python : [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) (PuLP).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*First tranche du twin .NET⇄Python (#4956, marathon). Sections suivantes à venir : transport, multi-dépôts, multi-objectif, comparaison PL vs PLNE approfondie.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 4.978619,
+   "end_time": "2026-07-06T00:01:40.011338",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T00:01:35.032719",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
First tranche of the .NET twin of Search-9-LinearProgramming.ipynb (Python/PuLP), porting linear programming to C#/.NET with the real Google OrTools solver. Part of #4956 marathon.

**SOTA-OK (#3801)**: invokes Google.OrTools.LinearSolver — GLOP (simplex) for continuous LP, CBC (branch-and-cut) for integer PLNE. Not a toy reimpl.

Content (20 cells, 8 code executed end-to-end, 0 errors):
- Production (max 3x1+2x2) -> GLOP OPTIMAL x1=2 x2=1 z=8
- Diet (min cost) -> GLOP OPTIMAL xA=6 cost=6
- Sensitivity (shadow prices) -> GLOP Machine=0.33 MO=1.33
- Knapsack PLNE (5 objets cap 7) -> CBC OPTIMAL value=50
- 3 exercise stubs (#2161, no voluntary error C.1)

Exec proved (C.2/H.1): papermill .net-csharp, 8/8 ec set, 0 errors, real outputs committed. Markdown G.1-corrected against actual solver output.

Partial delivery (See #4956, not Closes). No catalog/README touch (catalog-drift CI owns new entries).

Co-Authored-By: Claude-Code <noreply@anthropic.com>