### PR TITLE
Fix: accents manquants README Playwright-OWUI module 04 (RAG/outils MCP)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/04-rag-tools-avances/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/04-rag-tools-avances/README.md
@@ -1,16 +1,16 @@
-# Module 04 - RAG, Outils MCP & Fonctionnalites avancées
+# Module 04 - RAG, Outils MCP & Fonctionnalités avancées
 
-> **Format** : Fichier TypeScript `.spec.ts` avec tests commentés. Ouvrez `04-rag-tools.spec.ts` dans VS Code. Certains tests dependent de la configuration de l'instance (KBs, outils MCP, canaux) — les tests non-applicables seront automatiquement skipped.
+> **Format** : Fichier TypeScript `.spec.ts` avec tests commentés. Ouvrez `04-rag-tools.spec.ts` dans VS Code. Certains tests dépendent de la configuration de l'instance (KBs, outils MCP, canaux) — les tests non-applicables seront automatiquement skipped.
 
 ## Objectifs pédagogiques
 
-A la fin de ce module, vous serez capable de :
+À la fin de ce module, vous serez capable de :
 
-- Tester l'integration RAG (Retrieval-Augmented Génération) avec des knowledge bases
+- Tester l'intégration RAG (Retrieval-Augmented Génération) avec des knowledge bases
 - Interagir avec les outils MCP (Model Context Protocol) via Playwright
-- Tester la fonctionnalite Channels (canaux de discussion de groupe)
+- Tester la fonctionnalité Channels (canaux de discussion de groupe)
 - Écrire des tests plus complexes combinant navigation et interactions
-- Gérer les interactions conditionnelles (elements optionnels)
+- Gérer les interactions conditionnelles (éléments optionnels)
 
 ## Durée estimée
 
@@ -30,21 +30,21 @@ Clic sur le bouton "+" dans la barre de chat
   → Menu avec "Joindre une connaissance"
   → Clic → Liste des KBs disponibles
   → Clic sur "Bibliographie IA"
-  → La KB est attachee au chat
+  → La KB est attachée au chat
   → Les questions suivantes utilisent les documents de la KB
 ```
 
 > **Note historique** : Avant v0.8.8, le raccourci `#` dans le chat input
-> déclenchait un popup de selection de KB. Ce raccourci a été remplacé.
+> déclenchait un popup de sélection de KB. Ce raccourci a été remplacé.
 
 **Outils MCP :**
-Le Model Context Protocol (MCP) permet d'etendre les capacités du LLM
+Le Model Context Protocol (MCP) permet d'étendre les capacités du LLM
 avec des outils externes (recherche web, exécution de code, etc.).
-Depuis v0.8.8+, les outils sont accessibles via un bouton icone (engrenages)
+Depuis v0.8.8+, les outils sont accessibles via un bouton icône (engrenages)
 dans la barre de chat, qui ouvre un menu avec : Outils, Recherche Web, Image, Code.
 
 **Channels :**
-Les canaux sont des espaces de discussion collaboratifs, similaires a Slack.
+Les canaux sont des espaces de discussion collaboratifs, similaires à Slack.
 Il n'y a pas de page `/channels` — les canaux sont accessibles via la sidebar
 ou par URL directe `/channels/{id}`.
 
@@ -53,11 +53,11 @@ ou par URL directe `/channels/{id}`.
 | Test | Description | Concepts |
 |------|-------------|----------|
 | RAG — menu "+" | Attacher une KB via "Joindre une connaissance" | Menus, sélecteurs |
-| RAG — chat avec KB | Poser une question avec KB attachee | Workflow multi-étapes |
-| MCP — menu outils | Vérifier la presence des outils (bouton engrenages) | Sélecteurs positionnels |
+| RAG — chat avec KB | Poser une question avec KB attachée | Workflow multi-étapes |
+| MCP — menu outils | Vérifier la présence des outils (bouton engrenages) | Sélecteurs positionnels |
 | MCP — activer outils | Ouvrir le sélecteur d'outils | Dialogs, menus |
 | MCP — recherche web | Déclencher une recherche via outil | Toggles, tests fonctionnels |
-| Channels — naviguer | Acceder a un canal via API + URL directe | API + navigateur combines |
+| Channels — naviguer | Accéder à un canal via API + URL directe | API + navigateur combinés |
 | Channels — poster | Envoyer un message dans un canal | TipTap dans un autre contexte |
 
 ## Commandes
@@ -67,7 +67,7 @@ npm run test:module4
 npx playwright test --grep "04" --headed
 ```
 
-## Points cles a retenir
+## Points clés à retenir
 
 - Les KBs s'attachent via le bouton `+` → "Joindre une connaissance" (v0.8.8+)
 - Les outils MCP sont optionnels — utilisez `test.skip()` si absents


### PR DESCRIPTION
## Contexte

Issue #2876 (CLOSED mais rollout perenne cf `coordinator-discipline.md` Règle 4 fallback never-empty) : READMEs francophones du dépôt écrits systématiquement sans accents par défaut des LLMs. Top 10 fichiers dans l'issue body, mais le rollout est repo-wide famille-partitionné.

Cette PR traite **1 seul fichier** : `MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/04-rag-tools-avances/README.md` (76 lignes). Pas d'autre modif de portée.

## Modifications

15 lignes changées (15 insertions / 15 deletions, diff symétrique R3 strict) :

- Titre : `Fonctionnalites` → `Fonctionnalités`
- Format blockquote : `dependent` → `dépendent`
- Intro : `A la fin` → `À la fin`
- Objectifs : `integration` → `intégration`, `fonctionnalite` → `fonctionnalité`, `elements` → `éléments`
- Workflow : `attachee` → `attachée`
- Note historique : `selection` → `sélection`
- MCP : `etendre` → `étendre`, `icone` → `icône`
- Channels intro : `similaires a Slack` → `similaires à Slack`
- Table : `attachee` → `attachée`, `presence` → `présence`, `Acceder a` → `Accéder à`, `combines` → `combinés`
- Section titre : `Points cles a retenir` → `Points clés à retenir`

## Conformité CLAUDE.md / rules

- **R3 atomicité** : 1 fichier, 1 sujet, 15+/15- symétrique (cf `pr-review-discipline.md` §E < 50 lignes OK)
- **Convention readme-french-first.md** : nouveau contenu = FR (cette PR ajoute des accents, pas du contenu)
- **Pas de scope creep** : pas de modif du `.spec.ts`, pas de refactor table, pas de modif liens
- **Pas de régression** : seul change la typographie (accents), le sens est strictement préservé (`SOTA-not-workaround` G/H : aucun outil dégradé ici, juste typo)

## Vérification

```bash
$ file README.md
README.md: Unicode text, UTF-8 text   # LF, UTF-8 no BOM, RAS

$ grep -nE "\b(generale|generer|periode|donnees|developpement|definir|etude|evenement|etat|reponse|programme|elementaire|presenter|identifier|integration|modele|probleme|algorithme|premiere|derniere|annee|reliee|systeme|fonctionnalite|configuration|processus|execution|controle|methode)\b" README.md
3:> ... Certains tests dépendent de la configuration ...  # false positive (déjà accentué : dépendent)
```

Aucune autre occurrence non-accentuée dans le fichier.

## Liens

- Issue : #2876 (accents manquants, CLOSED mais rollout perenne)
- Pivot cross-lane : saturee PRs #4980 (5 PRs OPEN #5423/#5476/#5477/#5479/#5480) — PO #2876 bonne pioche pour ce cycle
- Convention `readme-french-first.md` Règle 1 : nouveau contenu = FR
- Fallback perenne `coordinator-discipline.md` Règle 4
- FileWriting L50 : `--body-file` (backticks FR protected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)