### PR TITLE
fix(search): split Search-5-GA packed exercise cell into 3 stubs (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
@@ -600,31 +600,113 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "// Stubs d'exercices (C.1 : pas d'erreur volontaire, TODO étudiant)\n",
-    "// Exercice 1 : remplacer Roulette par Tournament dans le constructeur, mesurer convGen.\n",
-    "// Exercice 2 : boucler sur PopulationSize in {20,50,100,200}, collecter best f(x).\n",
-    "// Exercice 3 : surcharger Run pour appeler MutateGauss avec AdaptiveRate(g, generations).\n",
-    "var sb = new StringBuilder();\n",
-    "sb.AppendLine(\"Exercice 1 à compléter : comparer Tournament vs Roulette.\");\n",
-    "sb.AppendLine(\"Exercice 2 à compléter : sweep PopulationSize sur Rastrigin.\");\n",
-    "sb.AppendLine(\"Exercice 3 à compléter : brancher AdaptiveRate dans Run.\");\n",
-    "sb.ToString().Display();"
-   ],
    "execution_count": 7,
+   "id": "ex74440",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:23:50.064389Z",
+     "iopub.status.busy": "2026-07-06T00:23:50.064201Z",
+     "iopub.status.idle": "2026-07-06T00:23:50.116172Z",
+     "shell.execute_reply": "2026-07-06T00:23:50.116051Z"
+    },
+    "papermill": {
+     "duration": 0.05511,
+     "end_time": "2026-07-06T00:23:50.116233",
+     "exception": false,
+     "start_time": "2026-07-06T00:23:50.061123",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Exercice 1 à compléter : comparer Tournament vs Roulette.\r\n",
-       "Exercice 2 à compléter : sweep PopulationSize sur Rastrigin.\r\n",
-       "Exercice 3 à compléter : brancher AdaptiveRate dans Run.\r\n"
+       "Exercice 1 à compléter : comparer Tournament vs Roulette (génération de convergence >= 19)."
       ]
      },
      "metadata": {},
      "output_type": "display_data"
     }
+   ],
+   "source": [
+    "// Exercice 1 — Tournoi vs roulette (étudiant à compléter)\n",
+    "// Remplacez la sélection Roulette par Tournament (k=3) sur OneMax, mesurez convGen.\n",
+    "\"Exercice 1 à compléter : comparer Tournament vs Roulette (génération de convergence >= 19).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ex70442",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:23:50.122492Z",
+     "iopub.status.busy": "2026-07-06T00:23:50.122315Z",
+     "iopub.status.idle": "2026-07-06T00:23:50.199229Z",
+     "shell.execute_reply": "2026-07-06T00:23:50.199052Z"
+    },
+    "papermill": {
+     "duration": 0.079989,
+     "end_time": "2026-07-06T00:23:50.199289",
+     "exception": false,
+     "start_time": "2026-07-06T00:23:50.119300",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 à compléter : sweep PopulationSize sur Rastrigin, afficher best f(x) final."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 — Effet de la taille de population (étudiant à compléter)\n",
+    "// Bouclez sur PopulationSize in {20, 50, 100, 200} sur Rastrigin, collectez best f(x).\n",
+    "\"Exercice 2 à compléter : sweep PopulationSize sur Rastrigin, afficher best f(x) final.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ex00251",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T00:23:50.206264Z",
+     "iopub.status.busy": "2026-07-06T00:23:50.206014Z",
+     "iopub.status.idle": "2026-07-06T00:23:50.256971Z",
+     "shell.execute_reply": "2026-07-06T00:23:50.256856Z"
+    },
+    "papermill": {
+     "duration": 0.055463,
+     "end_time": "2026-07-06T00:23:50.257028",
+     "exception": false,
+     "start_time": "2026-07-06T00:23:50.201565",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 à compléter : brancher AdaptiveRate dans Run, comparer la convergence au taux fixe."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 — Mutation adaptative (étudiant à compléter)\n",
+    "// Surchagez Run pour appeler MutateGauss avec AdaptiveRate(g, generations), comparez la trajectoire.\n",
+    "\"Exercice 3 à compléter : brancher AdaptiveRate dans Run, comparer la convergence au taux fixe.\".Display();\n"
    ]
   },
   {


### PR DESCRIPTION
Resolves the `count_exercises [1/3]` conformance flag raised by @po-2025 (c.57) on my merged PR #5442.

## Problem
`count_exercises.py` reported Search-5-GeneticAlgorithms-Csharp as **[1/3] non-conforming**: the 3 exercises (1: Tournament vs Roulette, 2: PopulationSize sweep, 3: AdaptiveRate mutation) were **packed in a single code cell** (cell[15]) with one StringBuilder displaying all three. The tool counts CELLS, so the packed stub counted as 1.

## Fix — decision (b) split
Split cell[15] into **3 separate code cells**, one exercise each, each with its own `// Exercice N` comment + `Display` stub (C.1: no voluntary error). `count_exercises` now reports **count=3 conforming=true**.

```
count_exercises.py --json Search-5-GeneticAlgorithms-Csharp.ipynb
→ count=3, conforming=true
```

## Surgical (C.3) — GA cells byte-identical
The GA demo cells (0-14) are kept **byte-identical to origin/main** (sources + outputs). Although the GA uses `seed=42`, papermill re-execution drifted some outputs — so I preserved the canonical origin/main outputs and injected **only** the 3 new stub cells with their real executed Display strings (ec=7/8/9). Verified: **0 mismatch on cells 0-14**.

| Gate | Result |
|------|--------|
| count_exercises | count=3 conforming=true ✓ |
| C.1 (no voluntary error) | clean (no throw/NotImplemented/assert/div0) ✓ |
| C.2 (exec proved) | 9/9 code cells execution_count set, 0 errors ✓ |
| C.3 (surgical scope) | cells 0-14 byte-identical origin/main, diff +97/-15 ✓ |
| G.1 (firsthand origin/main) | verified on fresh worktree, not stale local ✓ |

## Why split over accept-packed
Decision returned to me (po-2023, my PR). Split is conformant to the **letter** of #2161 ("cellules code stub") AND pedagogically cleaner — each exercise is isolated, the student tackles one at a time, and future scanners won't re-flag.

`See #2161` (conformance, not closing the epic).

Co-Authored-By: Claude-Code <noreply@anthropic.com>