### PR TITLE
docs(ict): reserve ICT-19 (enjeu battery) + purge stale ICT-19 refs

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb
@@ -62,10 +62,10 @@
    "id": "8a3e6792",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:55.369049Z",
-     "iopub.status.busy": "2026-07-03T08:31:55.368653Z",
-     "iopub.status.idle": "2026-07-03T08:31:56.204358Z",
-     "shell.execute_reply": "2026-07-03T08:31:56.202309Z"
+     "iopub.execute_input": "2026-07-06T00:36:34.615708Z",
+     "iopub.status.busy": "2026-07-06T00:36:34.615555Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.154125Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.153212Z"
     }
    },
    "outputs": [
@@ -73,7 +73,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Python : 3.13.3\n",
+      "Python : 3.13.14\n",
       "ICT-17 epsilon_machine : ['Dict', 'List', 'Sequence', 'Tuple', 'annotations', 'causal_state_partition', 'defaultdict', 'excess_entropy_estimate', 'np', 'partition_similarity', 'statistical_complexity']\n",
       "Substrats S1/S2/S3 modules : self_sorting, bistable, trajectories OK\n"
      ]
@@ -152,10 +152,10 @@
    "id": "20a9d3f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:56.210313Z",
-     "iopub.status.busy": "2026-07-03T08:31:56.209465Z",
-     "iopub.status.idle": "2026-07-03T08:31:56.228748Z",
-     "shell.execute_reply": "2026-07-03T08:31:56.226614Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.156135Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.155899Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.163244Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.162477Z"
     }
    },
    "outputs": [
@@ -226,10 +226,10 @@
    "id": "b9883ffd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:56.234820Z",
-     "iopub.status.busy": "2026-07-03T08:31:56.233965Z",
-     "iopub.status.idle": "2026-07-03T08:31:56.466701Z",
-     "shell.execute_reply": "2026-07-03T08:31:56.465064Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.165079Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.164915Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.561323Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.560766Z"
     }
    },
    "outputs": [
@@ -237,13 +237,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "S1 trajectoire generee : n=1500, distribution=[0, 901, 599]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "S1 trajectoire generee : n=1500, distribution=[0, 901, 599]\n",
       "S1 n_causal_states   : 2\n",
       "S1 C_mu (bits)       : 0.9709\n",
       "S1 E_estimate (bits) : 0.9562\n"
@@ -315,10 +309,10 @@
    "id": "c919eb4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:56.472460Z",
-     "iopub.status.busy": "2026-07-03T08:31:56.471763Z",
-     "iopub.status.idle": "2026-07-03T08:31:56.799748Z",
-     "shell.execute_reply": "2026-07-03T08:31:56.797895Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.562693Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.562537Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.642235Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.641629Z"
     }
    },
    "outputs": [
@@ -326,13 +320,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "S2 trajectoire : n=4800, distribution=1201/3599 (min/max des 4 categories)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "S2 trajectoire : n=4800, distribution=1201/3599 (min/max des 4 categories)\n",
       "S2 n_causal_states   : 8\n",
       "S2 C_mu (bits)       : 1.5540\n",
       "S2 E_estimate (bits) : 0.5458\n"
@@ -388,10 +376,10 @@
    "id": "2bf2eb91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:56.805562Z",
-     "iopub.status.busy": "2026-07-03T08:31:56.804545Z",
-     "iopub.status.idle": "2026-07-03T08:31:57.046091Z",
-     "shell.execute_reply": "2026-07-03T08:31:57.044588Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.643525Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.643391Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.709983Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.709601Z"
     }
    },
    "outputs": [
@@ -399,14 +387,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "S2 C_mu (mobile, n=46 fenetres):"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "S2 C_mu (mobile, n=46 fenetres):\n",
       "   r = 0.500  ->  C_mu = 0.081 bits\n",
       "   r = 0.517  ->  C_mu = 0.451 bits\n",
       "   r = 0.534  ->  C_mu = 0.379 bits\n",
@@ -452,13 +433,7 @@
       "   r = 1.381  ->  C_mu = 1.389 bits\n",
       "   r = 1.398  ->  C_mu = 1.277 bits\n",
       "   r = 1.432  ->  C_mu = 1.493 bits\n",
-      "   r = 1.449  ->  C_mu = 1.547 bits\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "   r = 1.449  ->  C_mu = 1.547 bits\n",
       "\n",
       "Pic de C_mu : r = 1.144 -> C_mu = 2.560 bits (fenetre 31/46)\n",
       "Gate bonus C_mu a la transition : PASSED\n"
@@ -524,10 +499,10 @@
    "id": "f670a9da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:57.051586Z",
-     "iopub.status.busy": "2026-07-03T08:31:57.050705Z",
-     "iopub.status.idle": "2026-07-03T08:31:57.202524Z",
-     "shell.execute_reply": "2026-07-03T08:31:57.200998Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.711321Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.711166Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.783541Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.782861Z"
     }
    },
    "outputs": [
@@ -607,10 +582,10 @@
    "id": "800cd2f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:57.207969Z",
-     "iopub.status.busy": "2026-07-03T08:31:57.207440Z",
-     "iopub.status.idle": "2026-07-03T08:31:57.450706Z",
-     "shell.execute_reply": "2026-07-03T08:31:57.448776Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.785150Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.785013Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.855243Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.854693Z"
     }
    },
    "outputs": [
@@ -744,7 +719,7 @@
     "# differentes -> VI_norm eleve meme quand les concepts s'accordent).\n",
     "#\n",
     "# Pour passer la gate il faudrait agreger plusieurs fusions Hoel pour\n",
-    "# reproduire la finesse Crutchfield -- c'est ICT-19 (FeatureCatastrophes)\n",
+    "# reproduire la finesse Crutchfield -- c'est ICT-20 (FeatureCatastrophes)\n",
     "# qui etend le banc. Ici on documente HONNETEMENT le resultat et on\n",
     "# utilise une autre metrique pour evaluer l'accord : le ratio\n",
     "# ``agree / n_used`` (combien d'occurrences tombent dans le meme cluster).\n",
@@ -760,7 +735,7 @@
     "# construction -- VI_norm = 1.0 reflete cette difference de \"grain\",\n",
     "# pas un desaccord semantique. Pour evaluer l'accord conceptuellement,\n",
     "# il faudrait iterer Hoel jusqu'a un nombre de macros comparable a\n",
-    "# Crutchfield -- c'est une extension (ICT-19 backlog).\n",
+    "# Crutchfield -- c'est une extension (ICT-20 backlog).\n",
     "g8_honnete = True  # toujours PASSED : on documente le resultat, pas un verdict binaire\n",
     "print(f\"\\nGate 8 documentee (VI=1.0 par difference de granularite) : \"\n",
     "      f\"{'HONNETE' if g8_honnete else 'INSUFFICISANT'}\")\n",
@@ -795,10 +770,10 @@
    "id": "ab6902fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:57.457521Z",
-     "iopub.status.busy": "2026-07-03T08:31:57.456578Z",
-     "iopub.status.idle": "2026-07-03T08:31:57.568650Z",
-     "shell.execute_reply": "2026-07-03T08:31:57.566670Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.856810Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.856639Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.880525Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.880048Z"
     }
    },
    "outputs": [
@@ -899,7 +874,14 @@
    "cell_type": "markdown",
    "id": "b33872b0",
    "metadata": {},
-   "source": "L'extension naturelle est ICT-18 (FlecheDuTempsReversibilisation) :\nproduction d'entropie thermodynamique et reversibilisation\n(Schnakenberg 1976, Seifert 2012, Cusinato & Lecomte 2024), numpy\nCPU-only -- un complement *thermodynamique* a ICT-17 qui evalue la\n*complexite temporelle* (fleche) plutot que la complexite de\nrepresentation (epsilon-machine)."
+   "source": [
+    "L'extension naturelle est ICT-18 (FlecheDuTempsReversibilisation) :\n",
+    "production d'entropie thermodynamique et reversibilisation\n",
+    "(Schnakenberg 1976, Seifert 2012, Cusinato & Lecomte 2024), numpy\n",
+    "CPU-only -- un complement *thermodynamique* a ICT-17 qui evalue la\n",
+    "*complexite temporelle* (fleche) plutot que la complexite de\n",
+    "representation (epsilon-machine)."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -929,10 +911,10 @@
    "id": "338dd0f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:57.575875Z",
-     "iopub.status.busy": "2026-07-03T08:31:57.574917Z",
-     "iopub.status.idle": "2026-07-03T08:31:57.584609Z",
-     "shell.execute_reply": "2026-07-03T08:31:57.582886Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.882062Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.881888Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.885476Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.885057Z"
     }
    },
    "outputs": [
@@ -985,10 +967,10 @@
    "id": "a215cd80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:57.590638Z",
-     "iopub.status.busy": "2026-07-03T08:31:57.589765Z",
-     "iopub.status.idle": "2026-07-03T08:31:57.597284Z",
-     "shell.execute_reply": "2026-07-03T08:31:57.596028Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.886805Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.886656Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.889677Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.889204Z"
     }
    },
    "outputs": [
@@ -1043,10 +1025,10 @@
    "id": "40c23a3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T08:31:57.603125Z",
-     "iopub.status.busy": "2026-07-03T08:31:57.602316Z",
-     "iopub.status.idle": "2026-07-03T08:31:57.609864Z",
-     "shell.execute_reply": "2026-07-03T08:31:57.608376Z"
+     "iopub.execute_input": "2026-07-06T00:36:40.891145Z",
+     "iopub.status.busy": "2026-07-06T00:36:40.890950Z",
+     "iopub.status.idle": "2026-07-06T00:36:40.894643Z",
+     "shell.execute_reply": "2026-07-06T00:36:40.894174Z"
     }
    },
    "outputs": [
@@ -1078,6 +1060,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "352bc665",
    "metadata": {},
    "source": [
     "## Bilan -- l'epsilon-machine, troisieme jambe computationnelle\n",
@@ -1127,15 +1110,33 @@
     "ferme la boucle : la memoire causale ($C_\\mu$) plafonne l'information\n",
     "predictive ($E$), exactement comme la compression ($K$) plafonne la memoire.\n",
     "Les trois quantites de l'ICT -- integration, surprise, computation -- sont\n",
-    "donc contraintes par une meme hierarchie de bornes.\n",
-    ""
+    "donc contraintes par une meme hierarchie de bornes.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "f0303fa2",
    "metadata": {},
-   "source": "Suite strate 5 :\n  - **ICT-18 (FlecheDuTempsReversibilisation)** : production d'entropie\n    thermodynamique et reversibilisation (Schnakenberg 1976, Seifert 2012,\n    Cusinato & Lecomte 2024). Applique ces 3 quantites au diagnostic\n    d'agentivite emergente (sigma, detailed balance error, distances\n    P_real vs P_reversibilized). GPU-free (numpy-only).\n  - **ICT-20** : feature et persona catastrophes, backlog.\n\n**Liens croises.**\n  - ICT-13 (compression zlib) partage la jambe $K$ (mesure de structure).\n  - ICT-15 (capstone) integre $\\Phi$, $F$, $K$ -- ICT-17 fournit la jambe\n    \"memoire $C_\\mu$\" et le \"plafond $E$\".\n  - ICT-10 (CatastropheGrammar) apprend des estimateurs $\\hat{p}_\\theta$\n    bornes par $E$ (Gate 9).\n  - ICT-2 (self-sorting) est le substrat S1, ICT-12 (valence) alimente S2.\n  - ICT-18 (FlecheDuTempsReversibilisation) : la reversibilisation\n    elimine la structure irreversible -- un parallel a ICT-17 sur la\n    *macro-structure predictive* au lieu de la *complexite temporelle*."
+   "source": [
+    "Suite strate 5 :\n",
+    "  - **ICT-18 (FlecheDuTempsReversibilisation)** : production d'entropie\n",
+    "    thermodynamique et reversibilisation (Schnakenberg 1976, Seifert 2012,\n",
+    "    Cusinato & Lecomte 2024). Applique ces 3 quantites au diagnostic\n",
+    "    d'agentivite emergente (sigma, detailed balance error, distances\n",
+    "    P_real vs P_reversibilized). GPU-free (numpy-only).\n",
+    "  - **ICT-20** : feature et persona catastrophes, backlog.\n",
+    "\n",
+    "**Liens croises.**\n",
+    "  - ICT-13 (compression zlib) partage la jambe $K$ (mesure de structure).\n",
+    "  - ICT-15 (capstone) integre $\\Phi$, $F$, $K$ -- ICT-17 fournit la jambe\n",
+    "    \"memoire $C_\\mu$\" et le \"plafond $E$\".\n",
+    "  - ICT-10 (CatastropheGrammar) apprend des estimateurs $\\hat{p}_\\theta$\n",
+    "    bornes par $E$ (Gate 9).\n",
+    "  - ICT-2 (self-sorting) est le substrat S1, ICT-12 (valence) alimente S2.\n",
+    "  - ICT-18 (FlecheDuTempsReversibilisation) : la reversibilisation\n",
+    "    elimine la structure irreversible -- un parallel a ICT-17 sur la\n",
+    "    *macro-structure predictive* au lieu de la *complexite temporelle*."
+   ]
   }
  ],
  "metadata": {
@@ -1159,7 +1160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.14"
   },
   "title": "ICT-17 EpsilonMachine (C198, See #5100)"
  },

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/README.md
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/README.md
@@ -85,7 +85,7 @@ Le retour à la théorie fondatrice (cf. [ICT-0-Annexe](ICT-0-Annexe-IntegratedC
 | **ICT-16** | MDLTwoPartCode — $F$ est la partie résiduelle du code $K$ + bosse complexité-entropie | [#5099](https://github.com/jsboige/CoursIA/issues/5099) |
 | **ICT-17** | $\epsilon$-machine (Crutchfield) vs Hoel — états causaux, complexité statistique, entropie d'excès | [#5100](https://github.com/jsboige/CoursIA/issues/5100) |
 | **ICT-18** | Flèche du temps & réversibilisation — production d'entropie, detailed balance, « que perd-on à réversibiliser ? » (ancré ICT-3, Levin/Fridman) *(GPU-free)* | [#5279](https://github.com/jsboige/CoursIA/issues/5279) |
-| **ICT-19** | Conceptual Reservoirs — *slot réservé*, spec à venir → Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588) | — |
+| **ICT-19** | 🚧 Batterie de l'ENJEU (auto-maintien vs pur dissipateur) — seconde batterie d'ICT-18, GPU-free, paire `(I_thermo, I_stake)` qui sépare l'agent (Gray-Scott S4) du pur dissipateur (S5). Spec squelette → [#4588 (commentaire)](https://github.com/jsboige/CoursIA/issues/4588) | [#5489](https://github.com/jsboige/CoursIA/issues/5489) |
 | **ICT-20** | FeatureCatastrophes — calibration, changepoints, EWS et hystérésis en feature-space | [#5103](https://github.com/jsboige/CoursIA/issues/5103) |
 | **ICT-21** | SAE (Qwen + Qwen-Scope) — des features SAE aux trajectoires d'états discrets, substrat S4 *(GPU)* | [#5101](https://github.com/jsboige/CoursIA/issues/5101) |
 | **ICT-22** | LLM comme quatrième substrat du banc cross-substrat *(GPU)* | [#5102](https://github.com/jsboige/CoursIA/issues/5102) |


### PR DESCRIPTION
Part of #4588 (Epic IIT->ICT). Suite au dispatch ai-01 #5483.

## Scope (bookkeeping atomique pour la réservation ICT-19)

**1. Purge des 2 refs `ICT-19` stale dans ICT-17-EpsilonMachine.ipynb (cell[13], commentaires).**
Le reflow de la strate 5 a renommé FeatureCatastrophes en **ICT-20** (#5103), mais 2 commentaires d'ICT-17 pointaient encore vers `ICT-19` :
- `c'est ICT-19 (FeatureCatastrophes)` -> `c'est ICT-20 (FeatureCatastrophes)`
- `(ICT-19 backlog)` -> `(ICT-20 backlog)`

Comment-only change (sémantique d'exécution identique). Re-exec C.2 via `nbconvert --execute` (CPU, kernel python3, modules `ict/` locaux) : **11 code cells, 0 erreurs, tous `execution_count` set**. Le grep `ICT-19` dans ICT-17 retourne maintenant 0 résultat.

**2. README strate-5 table (L88) : framing du slot ICT-19.**
`Conceptual Reservoirs — slot réservé, spec à venir` -> **🚧 Batterie de l'ENJEU (auto-maintien vs pur dissipateur)** = cadrage B (GPU-free), seconde batterie d'ICT-18, paire `(I_thermo, I_stake)` séparant l'agent (Gray-Scott S4) du pur dissipateur (S5). Lien vers la spec squelette (commentaire Epic #4588) + build issue #5489.

## Décision de scope (PROPOSÉE, non bloquante)

La spec squelette (postée sur #4588) propose la **batterie auto-maintien seul** (return-to-basin après `do(·)`) plutôt que la triade complète — plus discriminante, GPU-free garantie, ingrédient nommément manquant d'ICT-18. Acceptance criteria détaillés dans l'issue build #5489. ai-01/user à confirmer.

## Vérifications
- [x] Re-exec C.2 ICT-17 : 11/11 code cells, 0 erreurs (sortie `nbconvert` exit 0)
- [x] grep `ICT-19` dans ICT-17 = 0 (les 2 refs purgees)
- [x] source toujours en `list` (pas de corruption NotebookEdit)
- [x] catalogue byte-identical à main (0 churn `COURSE_CATALOG*`)
- [x] `#5102` body (ICT-22 LLMSubstrat) still references `ICT-19-LLMSubstrat.ipynb` -> sera corrigé séparément (`gh issue edit`, pas un commit repo)

Part of #4588
See #5483 #5489

🤖 Generated with [Claude Code](https://claude.com/claude-code)