### PR TITLE
docs(genai): restore French diacritics in Playwright-OWUI module 05 README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/05-multi-tenant-ci/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/05-multi-tenant-ci/README.md
@@ -4,50 +4,50 @@
 
 ## Objectifs pédagogiques
 
-A la fin de ce module, vous serez capable de :
+À la fin de ce module, vous serez capable de :
 
 - Tester des APIs REST directement avec Playwright (sans navigateur)
 - Comprendre l'architecture multi-tenant d'Open WebUI
-- Vérifier l'isolation des donnees entre tenants
+- Vérifier l'isolation des données entre tenants
 - Valider le partage de ressources (KBs, modèles) entre instances
-- Integrer les tests Playwright dans un pipeline CI/CD
+- Intégrer les tests Playwright dans un pipeline CI/CD
 
 ## Durée estimée
 
-**3 a 4 heures**
+**3 à 4 heures**
 
 ## Contenu du module
 
 ### Partie théorique
 
 **Tests API vs Tests UI :**
-Playwright n'est pas limite aux interactions navigateur.
-Sa classe `APIRequestContext` permet de faire des requetes HTTP directes.
+Playwright n'est pas limité aux interactions navigateur.
+Sa classe `APIRequestContext` permet de faire des requêtes HTTP directes.
 
 ```typescript
-// Test UI (lent, mais teste l'experience utilisateur)
+// Test UI (lent, mais teste l'expérience utilisateur)
 await page.goto('/admin');
 await expect(page.getByText('Users')).toBeVisible();
 
-// Test API (rapide, teste les donnees et la logique metier)
+// Test API (rapide, teste les données et la logique métier)
 const response = await request.get('/api/v1/users');
 const users = await response.json();
 expect(users.length).toBeGreaterThan(0);
 ```
 
 **Quand utiliser l'API vs le navigateur :**
-| Scenario | Approche |
+| Scénario | Approche |
 |----------|----------|
 | Vérifier un rendu visuel | Navigateur (page) |
-| Comparer des donnees entre instances | API (request) |
+| Comparer des données entre instances | API (request) |
 | Tester l'authentification | Les deux |
 | Vérifier la performance | API + metrics |
 
 **Architecture multi-tenant :**
-Chaque "tenant" est une instance independante d'Open WebUI :
-- Base de donnees PostgreSQL séparée
-- Configuration independante (modèles, fonctions, users)
-- Certaines ressources partagees (KBs via Qdrant, modèles LLM)
+Chaque "tenant" est une instance indépendante d'Open WebUI :
+- Base de données PostgreSQL séparée
+- Configuration indépendante (modèles, fonctions, users)
+- Certaines ressources partagées (KBs via Qdrant, modèles LLM)
 
 ### Partie pratique
 
@@ -57,9 +57,9 @@ Chaque "tenant" est une instance independante d'Open WebUI :
 | Modèles API | Lister les modèles via API | `request.get()`, headers |
 | KBs API | Lister les knowledge bases via API | Pagination API |
 | Multi-tenant auth | Authentification sur deux instances | Isolation |
-| KB partagees | Vérifier le partage de KBs | Comparison cross-tenant |
-| Modèles identiques | Vérifier la parite des modèles | Assertions en boucle |
-| Isolation donnees | Vérifier l'isolation des users | Sécurité multi-tenant |
+| KB partagées | Vérifier le partage de KBs | Comparison cross-tenant |
+| Modèles identiques | Vérifier la parité des modèles | Assertions en boucle |
+| Isolation données | Vérifier l'isolation des users | Sécurité multi-tenant |
 
 ## Commandes
 
@@ -101,7 +101,7 @@ jobs:
 ### Bonnes pratiques CI/CD
 
 1. **Secrets** : Ne jamais hardcoder les credentials — utiliser les secrets CI
-2. **Retries** : Activer 1-2 retries en CI (reseaux instables)
+2. **Retries** : Activer 1-2 retries en CI (réseaux instables)
 3. **Rapports** : Toujours uploader le rapport HTML comme artefact
 4. **Timeouts** : Augmenter les timeouts en CI (machines plus lentes)
 5. **Screenshots** : `only-on-failure` pour le débogage post-mortem


### PR DESCRIPTION
## Contexte

Issue #2876 (CLOSED mais rollout perenne cf `coordinator-discipline.md` Règle 4 fallback never-empty) : READMEs francophones du dépôt écrits systématiquement sans accents par défaut des LLMs. PRs précédentes notables :
- #4405 (MERGED) : 9 modules Playwright-OWUI READMEs diacritics pass, scope large (141+/141-)
- #5484 (OPEN MERGEABLE) : module 04 (04-rag-tools-avances) — focus resserré post-pass global

Cette PR traite **1 seul fichier** : `MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/05-multi-tenant-ci/README.md` (108 lignes). Pas d'autre modif de portée.

## Modifications

**18 lignes changées (18 insertions / 18 deletions, diff symétrique R3 strict)** :

| Ligne | Avant | Après |
|---|---|---|
| L7 | `A la fin` | `À la fin` |
| L11 | `donnees` | `données` |
| L13 | `Integrer` | `Intégrer` |
| L17 | `3 a 4 heures` | `3 à 4 heures` |
| L24 | `pas limite` | `pas limité` |
| L25 | `requetes` | `requêtes` |
| L28 | `l'experience` | `l'expérience` |
| L32 | `donnees`/`metier` | `données`/`métier` |
| L39 | `Scenario` | `Scénario` |
| L42 | `donnees` | `données` |
| L47 | `independante` | `indépendante` |
| L48 | `donnees` | `données` |
| L49 | `independante` | `indépendante` |
| L50 | `partagees` | `partagées` |
| L60 | `KB partagees` | `KB partagées` |
| L61 | `parite` | `parité` |
| L62 | `Isolation donnees` | `Isolation données` |
| L104 | `reseaux` | `réseaux` |

## Conformité CLAUDE.md / rules

- **R3 atomicité** : 1 fichier, 1 sujet, 18+/18- symétrique (cf `pr-review-discipline.md` §E < 50 lignes OK)
- **Convention readme-french-first.md** : nouveau contenu = FR (cette PR ajoute des accents, pas du contenu)
- **Pas de scope creep** : pas de modif du `.spec.ts`, pas de refactor table, pas de modif liens
- **Pas de régression** : seul change la typographie (accents), le sens est strictement préservé (`SOTA-not-workaround` G/H : aucun outil dégradé ici, juste typo)
- **Line endings** : LF préservé (vérifié `xxd | head` : `0a` pas `0d 0a`)
- **Encoding** : UTF-8 no BOM (vérifié `file README.md`)

## Vérification post-Edit

```bash
$ python -c "..." # check remaining accent gaps
Check complete.   # AUCUN gap restant
```

## Liens

- Issue : #2876 (accents manquants, CLOSED mais rollout perenne)
- Pivot cross-lane : saturée PRs #4980 (5 PRs OPEN #5423/#5476/#5477/#5479/#5480) — PO #2876 bonne pioche pour ce cycle (cf c.236 PR #5484 module 04)
- Convention `readme-french-first.md` Règle 1 : nouveau contenu = FR
- Fallback perenne `coordinator-discipline.md` Règle 4
- FileWriting L50 : `--body-file` (backticks FR protected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)