### PR TITLE
docs(genai): restore French diacritics in Playwright-OWUI module 01 README (See #2876)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/01-decouverte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/01-decouverte/README.md
@@ -4,7 +4,7 @@
 
 ## Objectifs pédagogiques
 
-A la fin de ce module, vous serez capable de :
+À la fin de ce module, vous serez capable de :
 
 - Installer Playwright et comprendre son architecture
 - Écrire un premier test E2E sur une application web réelle
@@ -14,14 +14,14 @@ A la fin de ce module, vous serez capable de :
 
 ## Prérequis
 
-- Node.js 18+ installe
+- Node.js 18+ installé
 - Une instance Open WebUI accessible (fournie par l'enseignant ou locale)
-- VS Code avec l'extension Playwright recommandee
-- Fichier `.env` configure (voir `.env.example` a la racine)
+- VS Code avec l'extension Playwright recommandée
+- Fichier `.env` configuré (voir `.env.example` à la racine)
 
 ## Durée estimée
 
-**2 a 3 heures**
+**2 à 3 heures**
 
 ## Contenu du module
 
@@ -29,7 +29,7 @@ A la fin de ce module, vous serez capable de :
 
 **Pourquoi Playwright ?**
 - Framework de test E2E par Microsoft, multi-navigateurs (Chromium, Firefox, WebKit)
-- Auto-wait intelligent : attend automatiquement que les elements soient visibles/cliquables
+- Auto-wait intelligent : attend automatiquement que les éléments soient visibles/cliquables
 - Mode trace et video pour le débogage
 - API simple et TypeScript-native
 
@@ -45,8 +45,8 @@ projet/
 
 **Sélecteurs — par ordre de préférence :**
 1. **IDs** : `#chat-input` — Les plus stables
-2. **Roles ARIA** : `button[aria-label="..."]` — Accessibles et resilients
-3. **getByRole/getByText** : Semantiques, recommandes par Playwright
+2. **Roles ARIA** : `button[aria-label="..."]` — Accessibles et résilients
+3. **getByRole/getByText** : Sémantiques, recommandés par Playwright
 4. **Classes CSS** : `.chat-user` — Fragiles, dernier recours
 
 ### Partie pratique
@@ -62,14 +62,14 @@ Le fichier `01-decouverte.spec.ts` contient 4 exercices progressifs :
 
 ### Exercices supplémentaires
 
-1. **Modifier un sélecteur** : Remplacez un sélecteur CSS par un `getByRole()` equivalent
-2. **Ajouter un test** : Verifiez que le bouton "Nouveau Chat" est visible
+1. **Modifier un sélecteur** : Remplacez un sélecteur CSS par un `getByRole()` équivalent
+2. **Ajouter un test** : Vérifiez que le bouton "Nouveau Chat" est visible
 3. **Mode debug** : Lancez `npm run test:debug` et utilisez le Playwright Inspector
 
 ## Commandes
 
 ```bash
-# Installer les dependances
+# Installer les dépendances
 npm install
 
 # Installer les navigateurs Playwright
@@ -88,9 +88,9 @@ PWDEBUG=1 npx playwright test --grep "01" --headed
 npm run report
 ```
 
-## Points cles a retenir
+## Points clés à retenir
 
-- Playwright attend automatiquement les elements (auto-wait) — pas besoin de `sleep()`
-- `storageState` permet de réutiliser une session authentifiee sans se reconnecter a chaque test
-- Préférez les sélecteurs semantiques (roles, labels) aux sélecteurs CSS fragiles
+- Playwright attend automatiquement les éléments (auto-wait) — pas besoin de `sleep()`
+- `storageState` permet de réutiliser une session authentifiée sans se reconnecter à chaque test
+- Préférez les sélecteurs sémantiques (roles, labels) aux sélecteurs CSS fragiles
 - Le mode `--headed` est indispensable pour comprendre ce que fait le test visuellement


### PR DESCRIPTION
## Contexte

Issue #2876 (CLOSED mais rollout perenne cf `coordinator-discipline.md` Règle 4 fallback never-empty) : READMEs francophones du dépôt écrits systématiquement sans accents par défaut des LLMs. PRs précédentes notables :
- #4405 (MERGED) : 9 modules Playwright-OWUI READMEs diacritics pass
- #5484 (OPEN MERGEABLE) : module 04 (04-rag-tools-avances)
- #5491 (OPEN MERGEABLE, c.237 module 05) : 05-multi-tenant-ci

Cette PR traite **1 seul fichier** : `MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/01-decouverte/README.md` (97 lignes, sibling de #5484/#5491). Pas d'autre modif de portée.

## Modifications

**15 lignes changées (15 insertions / 15 deletions, diff symétrique R3 strict)** :

| Ligne | Avant | Après |
|---|---|---|
| L7 | `A la fin` | `À la fin` |
| L17 | `installe` | `installé` |
| L19 | `recommandee` | `recommandée` |
| L20 | `configure ... a la racine` | `configuré ... à la racine` |
| L24 | `2 a 3 heures` | `2 à 3 heures` |
| L32 | `elements` | `éléments` |
| L48 | `resilients` | `résilients` |
| L49 | `Semantiques, recommandes` | `Sémantiques, recommandés` |
| L65 | `equivalent` | `équivalent` |
| L66 | `Verifiez` | `Vérifiez` |
| L72 | `dependances` | `dépendances` |
| L91 | `Points cles a retenir` | `Points clés à retenir` |
| L93 | `elements` | `éléments` |
| L94 | `authentifiee ... a chaque` | `authentifiée ... à chaque` |
| L95 | `semantiques` | `sémantiques` |

## Conformité CLAUDE.md / rules

- **R3 atomicité** : 1 fichier, 1 sujet, 15+/15- symétrique (cf `pr-review-discipline.md` §E < 50 lignes OK)
- **Convention readme-french-first.md** : nouveau contenu = FR (cette PR ajoute des accents, pas du contenu)
- **Pas de scope creep** : tree paths `├── fixtures/ ... donnees` (L40-43) NON modifiés pour cohérence avec 00-Parcours-QA-OWUI.ipynb + .spec.ts qui conservent la même nomenclature
- **Pas de régression** : seul change la typographie (accents), le sens est strictement préservé
- **Line endings** : LF préservé (vérifié `python -c "data.count(b'\\r\\n')"` → 0)
- **Encoding** : UTF-8 no BOM (vérifié `data[:3] != b'\xef\xbb\xbf'`)

## Vérification post-Edit

```bash
$ git diff --stat
 .../Playwright-OWUI/01-decouverte/README.md        | 30 +++++++++++-----------
 1 file changed, 15 insertions(+), 15 deletions(-)

$ python -c "..."  # check CRLF/BOM
Size: 3645 bytes
CRLF count: 0
UTF-8 BOM: False
```

## Liens

- Issue : #2876 (accents manquants, CLOSED mais rollout perenne)
- Pivot cross-lane : saturée PRs #4980 (5 PRs OPEN #5423/#5476/#5477/#5479/#5480) — PO #2876 bonne pioche pour ce cycle
- Convention `readme-french-first.md` Règle 1 : nouveau contenu = FR
- Fallback perenne `coordinator-discipline.md` Règle 4
- FileWriting L50 : `--body-file` (backticks FR protected)
- Sibling PRs : #5484 (module 04), #5491 (module 05) — R34 anti-bundle respectée (1 PR/module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)