### PR TITLE
feat(ict): add ict.stake — ENJEU battery instrument (return-to-basin after do(.))

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
@@ -65,6 +65,7 @@ from . import feature_dynamics
 from . import time_arrow
 from . import synthesis
 from . import persona_cusp
+from . import stake
 
 __all__ = [
     "Cell", "Probe", "SelfSortingArray", "KinSortingArray", "ALGOTYPES",
@@ -73,5 +74,5 @@ __all__ = [
     "scale_free", "early_warning", "bistable", "reaction_diffusion", "agency",
     "multiscale_agency", "catastrophe", "valence", "strategic_morphodynamics",
     "free_energy", "compression", "mdl", "epsilon_machine", "feature_dynamics",
-    "time_arrow", "synthesis", "persona_cusp",
+    "time_arrow", "synthesis", "persona_cusp", "stake",
 ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/stake.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/stake.py
@@ -1,0 +1,244 @@
+"""La batterie de l'ENJEU : auto-maintien discret apres intervention ``do(.)``
+(strate 5, ICT-19 ; Epic #4588, reframe #5352).
+
+ICT-18 (``ict.time_arrow``) outille le **MOYEN** de la triade teleonomique
+*moyen / fin / enjeu* : lafleche du temps thermodynamique, ``I_thermo`` =
+distance de la chaine reelle a sa projection reversibilisee. L'instrument est
+**necessaire mais pas suffisant** (ICT-18 section 2.bis, substrat S5 controle
+faux-positif) : un pur dissipateur (marche aleatoire biaisee, oscillateur
+pilote) allume ``I_thermo`` au meme ordre qu'un agent, parce qu'il dissipe --
+sans pour autant defendre un soi. Manque le *stake* : l'auto-maintien, la
+cloture de contraintes, la resistance active a l'equilibration (Friston ;
+Mossio & Moreno 2015).
+
+Ce module comble exactement ce manque : il construit le complement **ENJEU**
+``I_stake`` = return-to-basin apres perturbation ``do(.)`` (intervention causale
+de Pearl, fil rouge ICT-5). Un substrat qui a un enjeu revient activement vers
+son bassin apres un kick ; un pur dissipateur n'a pas de bassin a defendre et
+derive. La **PAIRE** ``(I_thermo, I_stake)`` separe l'agent (Gray-Scott S4 :
+dissipe ET regenere son motif apres ablation) du pur dissipateur (S5 : dissipe
+SANS enjeu) -- la decoupe qu'ICT-18 seul ne sait pas faire.
+
+Portee honnete (ICT-18 spec squelette, Epic #4588) : ``I_stake`` mesure
+l'auto-maintien seul (return-to-basin), pas la triade complete. La *FIN*
+(accessibilite cinematique, Levin *competency for free*) est mesuree par
+ICT-2/3/9 ; l'ajouter ici serait re-mesurer ce qu'ils mesurent deja.
+
+Le module est volontairement **discret et generique** : il operere sur des
+etats scalaires (entiers ou flottants) munis d'une fonction de pas ``step_fn``.
+Les substrats 2D (Gray-Scott S4) reutilisent ``ict.agency`` (qui est specifique
+aux champs ``U``/``V``) ; le present module couvre les substrats discrets S1
+(tri), S3 (Axelrod / automate), S5a (marche biaisee) et continus S2 (bistable).
+Aucune dependance hors numpy.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+Number = Union[int, float]
+StepFn = Callable[[np.ndarray], np.ndarray]
+
+
+def basin_anchor(states: Sequence) -> float:
+    """Le point de consigne que le substrat defend (le *soi* a maintenir).
+
+    Pour une trajectoire discrete ou continue, l'ancre du bassin = la moyenne
+    temporelle (l'etat autours duquel le systeme passe le plus de temps a
+    l'equilibre libre). On l'estime par la moyenne empirique de la trajectoire
+    libre (avant perturbation).
+
+    Choix documente : on prend la moyenne, pas le mode, pour rester coherent
+    entre substrats discrets (S1/S3) et continus (S2 bistable). Pour un
+    substrat strictement multimodal (plusieurs attracteurs), l'ancre est le
+    barycentre des modes -- l'instrument mesure alors le retour vers ce
+    barycentre, ce qui sous-estime l'enjeu reel (un retour vers N'IMPORTE LEQUEL
+    des modes compte). Le notebook ICT-19 documentera cette limite et
+    travaillera sur des substrats a attracteur principal unique.
+    """
+    arr = np.asarray(states, dtype=float)
+    if arr.size == 0:
+        raise ValueError("basin_anchor: trajectoire vide")
+    return float(arr.mean())
+
+
+def do_kick(
+    state: np.ndarray,
+    delta: float,
+    lo: Optional[float] = None,
+    hi: Optional[float] = None,
+) -> np.ndarray:
+    """Intervention causale ``do(x <- x + delta)`` (Pearl, fil rouge ICT-5).
+
+    Ajoute ``delta`` a l'etat, puis clip aux bornes ``[lo, hi]`` si fournies
+    (les substrats discrets ont un alphabet fini ; les implicites bornes).
+
+    NB : c'est une *intervention* (do-calculus), pas une observation. On ne
+    conditionne pas par un evenement -- on force l'etat hors du bassin, puis on
+    relache la dynamique libre et on mesure le retour. C'est exactement la
+    structure d'ICT-9 (``ict.agency.ablate``) generalisee aux etats discrets.
+    """
+    kicked = np.asarray(state, dtype=float) + float(delta)
+    if lo is not None or hi is not None:
+        kicked = np.clip(kicked, lo if lo is not None else -np.inf,
+                         hi if hi is not None else np.inf)
+    return kicked
+
+
+def distance_to_anchor(traj: np.ndarray, anchor: float) -> np.ndarray:
+    """Distance absolue ``|traj[t] - anchor|`` a chaque pas de temps.
+
+    Vecteur de la distance au bassin sur la trajectoire. Sous `I_stake`, on
+    regarde si cette distance **decroit** apres le kick (retour = agent) ou
+    **reste elevee / croit** (pas de soi = pur dissipateur).
+    """
+    return np.abs(np.asarray(traj, dtype=float) - float(anchor))
+
+
+def recovery_curve(
+    kicked_state: np.ndarray,
+    step_fn: StepFn,
+    steps: int,
+    anchor: float,
+) -> np.ndarray:
+    """Distance au bassin au cours du temps apres un kick ``do(.)``.
+
+    Part de ``kicked_state``, integre ``step_fn`` pendant ``steps`` pas, et
+    renvoie ``|state_t - anchor|`` pour ``t = 0..steps`` (``t=0`` = distance
+    immediatement apres le kick, avant toute relaxation).
+
+    Un substrat avec enjeu produit une courbe **decroissante** (retour vers
+    l'ancre) ; un pur dissipateur produit une courbe **plate ou croissante**
+    (derive sans cible).
+    """
+    if steps < 0:
+        raise ValueError("recovery_curve: steps doit etre >= 0")
+    distances = np.empty(steps + 1, dtype=float)
+    state = np.asarray(kicked_state, dtype=float).copy()
+    distances[0] = float(np.abs(state - anchor).sum())
+    for t in range(1, steps + 1):
+        state = step_fn(state)
+        distances[t] = float(np.abs(state - anchor).sum())
+    return distances
+
+
+def stake_index(
+    kicked_state: np.ndarray,
+    step_fn: StepFn,
+    steps: int,
+    anchor: float,
+    free_step_fn: Optional[StepFn] = None,
+    free_init: Optional[np.ndarray] = None,
+) -> float:
+    """Indice d'ENJEU ``I_stake`` : gain de retour au bassin apres ``do(.)``.
+
+    Mesure combien un substrat revient activement vers son ancre apres un kick,
+    **au-dela de la derive spontanee**. Renvoie un scalaire dans ``[-1, 1]`` :
+
+    * ``I_stake > 0`` : le substrat revient vers son bassin (auto-maintien =
+      enjeu). Un agent (Gray-Scott S4 sur substrat 2D, ou chaine restauratrice
+      sur substrat discret) donne ``I_stake`` strictement positif.
+    * ``I_stake ~= 0`` : pas de retour signicatif au-dela de la derive. Un pur
+      dissipateur (S5 : marche biaisee, oscillateur pilote) donne ``I_stake``
+      proche de zero -- c'est le controle faux-positif d'ICT-18.
+    * ``I_stake < 0`` : le substrat s'eloigne du bassin apres le kick (instabilite).
+
+    Parametres :
+      - ``kicked_state`` : etat immediatement apres ``do(.)`` (sortie de
+        ``do_kick``).
+      - ``step_fn`` : un pas de la dynamique libre du substrat (``state ->
+        state``).
+      - ``steps`` : horizon de relaxation (assez long pour que le retour se
+        manifeste, assez court pour rester pedagogique).
+      - ``anchor`` : ancre du bassin (``basin_anchor``).
+      - ``free_step_fn`` / ``free_init`` (optionnel) : dynamique et etat initial
+        d'un **controle libre** (meme substrat sans kick). Si fourni, la derive
+        spontanee est soustraite -- un substrat dont le bassin deriverait tout
+        seul ne fait pas passer ``I_stake`` artificiellement. Si omis, on
+        soustrait la distance initiale (hypothese : libre = stationnaire).
+
+    Formule :
+      ``I_stake = (d0 - d_final) / d0 - (d0_free - d_final_free) / d0_free``
+      ``= fraction de distance regagnee (kick) - fraction regagnee (libre)``
+
+    La normalisation par la distance initiale ``d0`` rend l'indice invariant
+    a l'amplitude du kick (un kick plus fort donne plus de retour absolu mais
+    la meme fraction regagnee si le substrat a un vrai enjeu).
+    """
+    d_kick = recovery_curve(kicked_state, step_fn, steps, anchor)
+    d0 = d_kick[0]
+    if d0 < 1e-12:
+        return 0.0  # kick nul : pas d'enjeu mesurable
+    frac_kick = (d0 - d_kick[-1]) / d0
+
+    if free_step_fn is not None and free_init is not None:
+        d_free = recovery_curve(free_init, free_step_fn, steps, anchor)
+        d0_free = d_free[0]
+        if d0_free < 1e-12:
+            frac_free = 0.0
+        else:
+            frac_free = (d0_free - d_free[-1]) / d0_free
+    else:
+        frac_free = 0.0  # hypothese : libre = stationnaire (derive nulle)
+
+    return float(np.clip(frac_kick - frac_free, -1.0, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Substrats de demonstration (le contraste falsifiable)
+# ---------------------------------------------------------------------------
+
+def restoring_step(state: np.ndarray, strength: float = 0.3,
+                   rng: Optional[np.random.Generator] = None) -> np.ndarray:
+    """Pas d'une chaine **restauratrice** : tire vers 0 (l'ancre) avec bruit.
+
+    Modele minimal d'un substrat qui defend un point de consigne : chaque pas,
+    l'etat se rapproche de 0 d'un facteur ``strength`` + petit bruit. C'est
+    l'analogue discret d'un ressort amorti -- un vrai soi. Apres un kick, la
+    trajectoire revient vers 0 : ``I_stake > 0``.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+    return state * (1.0 - strength) + rng.normal(0.0, 0.05, size=np.shape(state))
+
+
+def drift_step(state: np.ndarray, bias: float = 0.4,
+               rng: Optional[np.random.Generator] = None) -> np.ndarray:
+    """Pas d'une **marche aleatoire biaisee** : derive sans cible (S5a).
+
+    Aucune force de rappel -- l'etat derive a chaque pas d'un terme ``bias``
+    constant + bruit. C'est le **controle faux-positif** d'ICT-18 (substrat S5a)
+    : dissipe (fleche du temps non-nulle, ``I_thermo > 0``) MAIS n'a aucun bassin
+    a defender. Apres un kick, la trajectoire ne revient pas : ``I_stake ~= 0``.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+    return state + bias + rng.normal(0.0, 0.1, size=np.shape(state))
+
+
+def demo_contrast(steps: int = 50, seed: int = 42) -> Tuple[float, float]:
+    """Contraste falsifiable : restauratrice (agent) vs derive (pur dissipateur).
+
+    Renvoie ``(I_stake_restoring, I_stake_drift)``. La prediction falsifiable
+    (gate ENJEU-1 du notebook ICT-19) : ``I_stake_restoring > I_stake_drift``
+    avec une marge claire, bien que les deux substrats dissipe (a bruit pres).
+    Si faux, la batterie ne discrimine pas -- resultat nul honnete, pas un
+    succes maquille.
+    """
+    rng_r = np.random.default_rng(seed)
+    rng_d = np.random.default_rng(seed + 1)
+    anchor = 0.0
+    kick = 5.0
+    i_r = stake_index(
+        kicked_state=do_kick(np.array([0.0]), kick),
+        step_fn=lambda s: restoring_step(s, 0.3, rng_r),
+        steps=steps, anchor=anchor,
+    )
+    i_d = stake_index(
+        kicked_state=do_kick(np.array([0.0]), kick),
+        step_fn=lambda s: drift_step(s, 0.4, rng_d),
+        steps=steps, anchor=anchor,
+    )
+    return i_r, i_d

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_stake.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_stake.py
@@ -1,0 +1,175 @@
+"""Tests de la batterie ENJEU (module ICT-19 ``ict.stake``).
+
+Verifient les primitives (ancre, kick ``do(.)``, distance, courbe de
+recuperation) et surtout la **gate falsifiable ENJEU-1** : un substrat
+restaurateur (auto-maintien = agent) donne ``I_stake > 0`` alors qu'un pur
+dissipateur (marche biaisee = controle faux-positif S5 d'ICT-18) donne
+``I_stake ~= 0``. C'est la decoupe que la paire ``(I_thermo, I_stake)`` opere
+et qu'``I_thermo`` seul (ICT-18) ne sait pas faire.
+
+Numpy + pytest. Le module ne depend que de numpy.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PARENT = os.path.dirname(_HERE)
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+
+from ict import stake  # noqa: E402
+
+
+def test_basin_anchor_mean():
+    """L'ancre = moyenne empirique de la trajectoire libre."""
+    assert stake.basin_anchor([0.0, 1.0, 2.0, 3.0]) == pytest.approx(1.5)
+    assert stake.basin_anchor([-2.0, 2.0]) == pytest.approx(0.0)
+    # discrete states : la moyenne marche aussi
+    assert stake.basin_anchor([0, 0, 1, 0, 1]) == pytest.approx(0.4)
+
+
+def test_basin_anchor_empty_raises():
+    with pytest.raises(ValueError):
+        stake.basin_anchor([])
+
+
+def test_do_kick_basic():
+    """do(x <- x + delta) : addition pure hors bornes."""
+    kicked = stake.do_kick(np.array([0.0]), 5.0)
+    assert float(kicked[0]) == pytest.approx(5.0)
+
+
+def test_do_kick_clipped():
+    """Le kick respecte l'alphabet fini (clip aux bornes)."""
+    kicked = stake.do_kick(np.array([3.0]), 5.0, lo=0.0, hi=4.0)
+    assert float(kicked[0]) == pytest.approx(4.0)
+    kicked_lo = stake.do_kick(np.array([1.0]), -5.0, lo=0.0, hi=4.0)
+    assert float(kicked_lo[0]) == pytest.approx(0.0)
+
+
+def test_distance_to_anchor_monotone_shape():
+    """La distance a l'ancre croit avec l'ecart."""
+    traj = np.array([0.0, 1.0, 2.0, 3.0])
+    d = stake.distance_to_anchor(traj, anchor=0.0)
+    np.testing.assert_allclose(d, np.array([0.0, 1.0, 2.0, 3.0]))
+
+
+def test_recovery_curve_length_and_start():
+    """La courbe de recuperation a ``steps+1`` points et demarre a ``d0``."""
+    anchor = 0.0
+    kicked = stake.do_kick(np.array([0.0]), 5.0)
+    curve = stake.recovery_curve(kicked, lambda s: s * 0.5, steps=10, anchor=anchor)
+    assert len(curve) == 11
+    # t=0 = distance immediatement apres le kick (avant relaxation)
+    assert curve[0] == pytest.approx(5.0)
+
+
+def test_recovery_curve_restoring_decreases():
+    """Un substrat restaurateur : la distance au bassin DECROIT apres le kick."""
+    rng = np.random.default_rng(0)
+    anchor = 0.0
+    kicked = stake.do_kick(np.array([0.0]), 5.0)
+    curve = stake.recovery_curve(
+        kicked, lambda s: stake.restoring_step(s, 0.5, rng), steps=40, anchor=anchor
+    )
+    # La distance finale doit etre nettement inferieure a la distance initiale.
+    assert curve[-1] < curve[0] * 0.5
+
+
+def test_recovery_curve_drift_does_not_return():
+    """Un pur dissipateur (marche biaisee) : la distance ne decroit pas vers l'ancre."""
+    rng = np.random.default_rng(0)
+    anchor = 0.0
+    kicked = stake.do_kick(np.array([0.0]), 5.0)
+    curve = stake.recovery_curve(
+        kicked, lambda s: stake.drift_step(s, 0.4, rng), steps=40, anchor=anchor
+    )
+    # Le biais +0.4 par pas pousse l'etat vers le haut : la distance au bassin
+    # (ancre=0) croit, elle ne decroit pas. Pas de retour.
+    assert curve[-1] >= curve[0]
+
+
+def test_stake_index_restoring_positive():
+    """Gate ENJEU-1 (partie agent) : restauratrice -> I_stake > 0."""
+    rng = np.random.default_rng(42)
+    anchor = 0.0
+    i = stake.stake_index(
+        kicked_state=stake.do_kick(np.array([0.0]), 5.0),
+        step_fn=lambda s: stake.restoring_step(s, 0.3, rng),
+        steps=50, anchor=anchor,
+    )
+    assert i > 0.3, f"restauratrice devrait donner I_stake > 0.3, obtenu {i}"
+
+
+def test_stake_index_drift_near_zero():
+    """Gate ENJEU-1 (partie controle faux-positif) : derive -> I_stake ~= 0 ou negatif."""
+    rng = np.random.default_rng(7)
+    anchor = 0.0
+    i = stake.stake_index(
+        kicked_state=stake.do_kick(np.array([0.0]), 5.0),
+        step_fn=lambda s: stake.drift_step(s, 0.4, rng),
+        steps=50, anchor=anchor,
+    )
+    # Pas de retour : la fraction regagnee est <= 0 (derive eloigne du bassin).
+    assert i <= 0.05, f"derive devrait donner I_stake ~= 0 ou negatif, obtenu {i}"
+
+
+def test_stake_index_discriminates():
+    """Gate ENJEU-1 (decoupe) : restauratrice > derive d'une marge claire.
+
+    C'est le coeur falsifiable de la batterie : les deux substrats dissipe, mais
+    seul le restaurateur a un enjeu. Si la batterie ne separait pas les deux,
+    elle serait inutile (meme porte que I_thermo seul).
+    """
+    i_r, i_d = stake.demo_contrast(steps=50, seed=42)
+    assert i_r - i_d > 0.3, (
+        f"la batterie devrait separer restauratrice et derive d'au moins 0.3, "
+        f"obtenu I_stake_restoring={i_r:.3f} vs I_stake_drift={i_d:.3f}"
+    )
+
+
+def test_stake_index_zero_kick_returns_zero():
+    """Un kick nul (etat deja a l'ancre) -> pas d'enjeu mesurable (0)."""
+    i = stake.stake_index(
+        kicked_state=np.array([0.0]),
+        step_fn=lambda s: stake.restoring_step(s, 0.3, np.random.default_rng(0)),
+        steps=10, anchor=0.0,
+    )
+    assert i == 0.0
+
+
+def test_stake_index_in_range():
+    """I_stake est borne dans [-1, 1] (clip)."""
+    rng = np.random.default_rng(1)
+    i = stake.stake_index(
+        kicked_state=stake.do_kick(np.array([0.0]), 100.0),
+        step_fn=lambda s: stake.restoring_step(s, 0.9, rng),
+        steps=20, anchor=0.0,
+    )
+    assert -1.0 <= i <= 1.0
+
+
+def test_stake_index_free_drift_subtracted():
+    """Avec un controle libre fourni, la derive spontanee est soustraite.
+
+    Un substrat dont le bassin deriverait tout seul ne doit pas faire passer
+    I_stake artificiellement : la fraction regagnee par derive libre est
+    retiree de la fraction regagnee apres kick.
+    """
+    # Restaurateur dont l'ancre est 0 ; kick a +5, libre part de 0.
+    rng_k = np.random.default_rng(3)
+    rng_f = np.random.default_rng(4)
+    i_with_free = stake.stake_index(
+        kicked_state=stake.do_kick(np.array([0.0]), 5.0),
+        step_fn=lambda s: stake.restoring_step(s, 0.3, rng_k),
+        steps=30, anchor=0.0,
+        free_step_fn=lambda s: stake.restoring_step(s, 0.3, rng_f),
+        free_init=np.array([0.0]),
+    )
+    # Libre part de l'ancre -> frac_free ~ 0 (reste a 0) ; i_with_free ~ i seul.
+    # Just verify it's still positive and reasonable.
+    assert i_with_free > 0.0


### PR DESCRIPTION
Part of #4588 (Epic IIT→ICT). Tranche 1 (library-first) of ICT-19 build (#5489, dispatch #5483 cadrage B).

## Contexte théorique (triade moyen/fin/enjeu, reframe #5352)

ICT-18 (`ict.time_arrow`, MERGED) outille le **MOYEN** : `I_thermo` = flèche thermodynamique. **Nécessaire mais pas suffisant** — le contrôle S5 (pur dissipateur : marche biaisée, oscillateur pilote) allume `I_thermo` au même ordre qu'un agent parce qu'il dissipe, sans défendre un soi (ICT-18 §2.bis). L'ingrédient manquant = l'**ENJEU** (auto-maintien, clôture de contraintes, résistance à l'équilibration, Friston ; Mossio & Moreno 2015).

Ce module construit le complément : `I_stake` = return-to-basin après perturbation `do(·)` (intervention causale de Pearl, fil rouge ICT-5). La **PAIRE** `(I_thermo, I_stake)` sépare l'agent (Gray-Scott S4 : dissipe ET régénère) du pur dissipateur (S5 : dissipe SANS enjeu) — la découpe qu'ICT-18 seul ne sait pas faire.

## Scope-invariant

La décision de scope finale (auto-maintien **seul** vs **triade complète** {moyen, fin, enjeu}) est PROPOSÉE sur la spec [#4588 (commentaire)](https://github.com/jsboige/CoursIA/issues/4588#issuecomment-4888171494) et gated ai-01/user. Mais le **return-to-basin discret est needed dans les deux cas** → l'instrument est safe à lander maintenant. La FIN (Levin competency) reste mesurée par ICT-2/3/9 ; l'ajouter ici serait re-mesurer.

## API

| Fonction | Rôle |
|----------|------|
| `basin_anchor(states)` | Le point de consigne (soi) = moyenne empirique |
| `do_kick(state, delta, lo, hi)` | Intervention `do(x ← x+δ)` (Pearl), clip-bornée |
| `distance_to_anchor(traj, anchor)` | distance au bassin |
| `recovery_curve(kicked, step_fn, steps, anchor)` | Distance au bassin `t=0..steps` après kick |
| `stake_index(...)` ∈ `[−1, 1]` | **`I_stake`** : fraction regagnée (kick) − fraction regagnée (libre). `>0` = agent revient ; `≈0` = pur dissipateur dérive |
| `restoring_step` / `drift_step` | Primitives démo (ressort amorti vs marche biaisée S5a) |
| `demo_contrast(steps, seed)` | Contraste falsifiable (gate ENJEU-1) |

## Tests — 14 nouveaux (suite ICT 340 passed, 0 régression)

- Primitives : ancre (moyenne + empty raises), kick (addition + clip), distance (monotone), recovery_curve (longueur + départ + décroissance restauratrice + non-retour dérive).
- **Gate ENJEU-1 (falsifiable)** :
  - `test_stake_index_restoring_positive` : restauratrice → `I_stake > 0.3` ✓
  - `test_stake_index_drift_near_zero` : dérive → `I_stake ≤ 0.05` ✓
  - `test_stake_index_discriminates` : `I_stake_restoring − I_stake_drift > 0.3` ✓ (la batterie sépare les deux substrats qui dissipent tous deux)
- Edge cases : kick nul → 0, `I_stake` borné `[-1,1]`, contrôle libre soustrait la dérive spontanée.

## Garde-fous
- ✅ GPU-free, numpy-only (cohérent ICT-18)
- ✅ library-first (pas de notebook — tranche 2 séparée, pattern CE 2.0 #4606 / synthesis #4948)
- ✅ catalogue byte-identical (0 churn `COURSE_CATALOG*`)
- ✅ `Part of #4588 / See #5483 #5489` (jamais `Closes` — issue build reste open pour tranche 2 notebook)
- ✅ docstrings FR (readme-french-first), aucune dépendance hors numpy

## Tranche 2 (follow-up, separate PR)
Notebook `ICT-19-EnjeuBattery.ipynb` : applique la batterie aux substrats S1 (tri), S2 (bistable), S3 (Axelrod), S4 (Gray-Scott via `ict.agency`), S5 (contrôle négatif). Gate ENJEU-1 (`I_stake(S4) > I_stake(S5)` avec `I_thermo(S4) ≈ I_thermo(S5)`), Gate ENJEU-2 (graduation). 3 exercices C.1, prose FR, exec CPU. Gated sur confirmation scope ai-01/user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
