### PR TITLE
feat(prover): wire mistral provider for Leanstral 1.5 A/B (step 1/N) — See #5475

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -45,6 +45,23 @@ PROVIDERS = {
                               "anthropic/claude-haiku-4.5"),
         }
     },
+    # Leanstral 1.5 (Mistral, Lean-specialized MoE 119B/6B-active, Apache-2.0,
+    # free API) — A/B candidate vs glm-5.1 on our research-level sorries
+    # (issue #5475, EPIC #3801 axe-2 SOTA). Added 2026-07-06.
+    # OpenAI-compat confirmed (ai-01 curl /v1/models -> HTTP 200). Model-id is
+    # the alias `labs-leanstral-1-5` (NOT `leanstral-1-5` which 404s — piège #4
+    # llm-endpoints.md). For a reproducible A/B, pin the snapshot
+    # `labs-leanstral-1-5-1` by overriding MISTRAL_CHAT_MODEL_ID in .env.
+    # Leanstral is a thinking model (reasoning:true) so the reasoning_content
+    # handling already in place for zai/glm applies — re-verify at smoke-test.
+    "mistral": {
+        "base_url": os.getenv("MISTRAL_BASE_URL", "https://api.mistral.ai/v1"),
+        "api_key": os.getenv("MISTRAL_API_KEY", ""),
+        "models": {
+            "reasoning": os.getenv("MISTRAL_CHAT_MODEL_ID", "labs-leanstral-1-5"),
+            "fast": os.getenv("MISTRAL_FAST_MODEL_ID", "labs-leanstral-1-5"),
+        }
+    },
 }
 
 SHAPLEY_IMPORTS = """import Mathlib.Data.Finset.Basic


### PR DESCRIPTION
## feat(prover): wire `mistral` provider for Leanstral 1.5 A/B — step 1/N

Adds the `mistral` provider to `PROVIDERS` in the prover harness config, enabling the dispatched A/B of **Leanstral 1.5** (Mistral, Lean-specialized MoE 119B/6B-active, Apache-2.0, free API) vs our `glm-5.1` workhorse on our research-level sorries. **See #5475** (EPIC #3801 axe-2 SOTA).

### Scope (atomic, +17 lines, pure addition — 1 file)

| Item | Before | After |
|------|--------|-------|
| `PROVIDERS` keys | `zai`, `local`, `openrouter` | + `mistral` |
| Model-id | n/a | `labs-leanstral-1-5` (alias) — **NOT** `leanstral-1-5` (= 404) |
| `create_client("mistral")` | n/a | works unchanged (dict lookup) |
| `--provider mistral` CLI | n/a | wired (run_prover_bg.py → create_client → PROVIDERS) |

**Zero regression**: pure PROVIDERS addition; `zai`/`local`/`openrouter` entries byte-identical.

### Model-id correction (piège #4 `llm-endpoints.md`)

The issue body snippet cited `leanstral-1-5`, but ai-01's live `curl /v1/models` (2026-07-06) confirmed the API namespaces it under **`labs-leanstral-1-5`** (alias) → snapshot `labs-leanstral-1-5-1`. Using `leanstral-1-5` = 404. This PR uses the alias; for a reproducible A/B, pin the snapshot via `MISTRAL_CHAT_MODEL_ID=labs-leanstral-1-5-1` in `.env`.

Leanstral is a thinking model (`reasoning:true`) — the `reasoning_content` handling already in place for `zai`/glm applies (piège #2), to re-verify at smoke-test.

### Verification (step 1 — plumbing)

| Check | Result |
|-------|--------|
| `python -m py_compile config.py` | **OK** |
| PROVIDERS structural (ast) | 4 keys: `zai, local, openrouter, mistral`; `mistral.models` defaults = `labs-leanstral-1-5` (reasoning+fast) |
| End-to-end `--provider` wiring | `run_prover_bg.py:219 --provider` → `create_client(provider)` → `PROVIDERS[provider]` ✓ |
| Network reachability (po-2026 host) | `curl https://api.mistral.ai/v1/models` → **HTTP 401** (expected without auth: endpoint reachable, OpenAI-compat routing OK, only key missing) |

### ⏳ Steps 2-4 (smoke + A/B) — PENDING key propagation to po-2026 host

The functional smoke-test + A/B (acceptance for #5475) require `MISTRAL_API_KEY` **on the po-2026 host**. ai-01 provisioned the key on **its own host** (2026-07-06, in `Lean/.env` + `.secrets/master.env`), but `Lean/.env` is **gitignored/machine-local** so it did **not** propagate to po-2026:

- Verified firsthand: `grep MISTRAL MyIA.AI.Notebooks/SymbolicAI/Lean/.env` → **0 matches** (po-2026 host has `zai`/`openai`/`anthropic`/`openrouter`/`local` only).
- `.secrets/` directory does not exist on po-2026 host.
- No MISTRAL key-propagation message/attachment in inbox.

**Verdict (sota-not-workaround): RECOVERABLE-USER-HAND / RECOVERABLE-MACHINE** — plumbing is correct (401 proves routing), the only blocker is the secret reaching this host. Requested via RooSync privé (msg to ai-01). Two convergence paths:
1. ai-01 sends `MISTRAL_API_KEY` via RooSync privé (attachment + `destruct_after`, per secrets-roosync-policy) → I complete smoke + A/B on po-2026.
2. ai-01 runs the smoke + A/B on this branch directly (key present on its host) → posts results, merges.

### Acceptance status (#5475)

- [x] Provider `mistral` branché (plumbing verified) — **this PR**
- [ ] smoke-test vert (demo 0/20 on `labs-leanstral-1-5`) — pending key
- [ ] Tableau A/B ≥3 sorries `glm-5.1` vs `labs-leanstral-1-5` (demos 20/18/19/16), `grep -c sorry` avant/après + `lake build` local per sorry résolu — pending key
- [ ] Verdict honnête BEATS / NO BEATS / INCONCLUSIVE — pending A/B
- [x] Zéro régression de preuve (no `.lean` touched, pure PROVIDERS addition)

This PR is **step 1/N** (plumbing). It does NOT claim the A/B. `See #5475` (not `Closes` — the A/B is the deliverable that closes it).

See #5475
See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
