### PR TITLE
fix(lean): social_choice Voting_en namespace — swap FR import to EN sibling (See #4980)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting_en.lean
@@ -25,7 +25,7 @@ import Mathlib.Order.Defs.LinearOrder
 import Mathlib.Tactic
 
 import SocialChoice.Basic
-import SocialChoice.SortedListCounting
+import SocialChoice.SortedListCounting_en
 
 namespace SocialChoice_en
 /-!


### PR DESCRIPTION
## fix(lean): social_choice `Voting_en` namespace — swap FR import to EN sibling

Fixes the 4 `Unknown identifier` build errors in `Voting_en.lean` (social_choice_lean), closing 1 of the 3 broken `_en` siblings that block the lake's globs rollout (**MEMORY c.219**, deep-queue #3 gate).

### Root cause (verified firsthand — c.219 "fixable `open SocialChoice`" was INCOMPLETE)

`Voting_en.lean` declares `namespace SocialChoice_en` and imported the **FR** module `SocialChoice.SortedListCounting`, referencing its lemmas unqualified:

```lean
import SocialChoice.SortedListCounting   -- FR
namespace SocialChoice_en
...
  exact SortedListCounting.countP_lt_kth_le_half hsorted hn  -- L378
```

Inside `namespace SocialChoice_en`, Lean resolves the bare prefix `SortedListCounting.foo` as **`SocialChoice_en.SortedListCounting.foo`** (it prepends the enclosing namespace) — which does **not exist** in the FR module (FR defines `SocialChoice.SortedListCounting.foo`). Result:

```
Voting_en.lean:370:14: Unknown identifier `SortedListCounting.finset_filter_lt_card_eq_toList_map_countP`
Voting_en.lean:378:16: Unknown identifier `SortedListCounting.countP_lt_kth_le_half`
Voting_en.lean:441:14: Unknown identifier `SortedListCounting.finset_filter_lt_card_eq_toList_map_countP`
Voting_en.lean:448:16: Unknown identifier `SortedListCounting.countP_le_kth_ge_half_succ`
```

### Fix (minimal, 1 line)

Swap L28 import to the **EN sibling** `SocialChoice.SortedListCounting_en` (defines the same 3 lemmas in `namespace SocialChoice_en.SortedListCounting`, verified byte-identical semantics per i18n convention #4980). The bare `SortedListCounting.foo` then resolves correctly within `namespace SocialChoice_en`.

Same namespace-resolution pattern as the cooperative_games `Basic_en` fix (#5480). FR `Voting.lean` UNCHANGED (anti-regression rule D). `SocialChoice.Basic` import (L27, FR) UNCHANGED — those refs resolve without error, left as-is (minimal fix, don't touch what works).

### Verification (lean-merge-discipline HARD — lake build SUCCESS local)

```
$ lake.exe build SocialChoice.Voting_en
Build completed successfully (2948 jobs)
```
| Check | Result |
|-------|--------|
| `lake build SocialChoice.Voting_en` | **SUCCESS** (2948 jobs, exit 0) |
| 4 `Unknown identifier` errors | **GONE** |
| FR `Voting.lean` | byte-identical (0 changes) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — atomic, 1 of 3 broken _en (G.5 no-shopping-cart)

This PR fixes **Voting_en ONLY**. Firsthand `lake build` of all 7 `_en` reveals social_choice_lean has **3 broken** `_en` (not just Voting_en). The other 2 are **different bug types** → separate PRs:

| File | Status | Bug type | Follow-up |
|------|--------|----------|-----------|
| `Voting_en.lean` | ✅ fixed (this PR) | namespace/import | — |
| `Arrow_en.lean` | ❌ broken | namespace/def (`_root_.is_strictly_best` unknown + kernel `SocialChoice_en.is_extremal.is_strictly_worst`) | separate PR |
| `Framework_en.lean` | ❌ broken (L211) | **proof** bug (`Tactic \`contradiction\` failed`) | separate PR |
| `Basic_en`, `MechanismDesign_en`, `Sen_en`, `SortedListCounting_en` | ✅ build clean | — | — |

**Globs rollout status**: STILL BLOCKED on Arrow_en + Framework_en (lake-wide globs require all `_en` build). This PR is necessary-but-not-sufficient progress toward unblocking globs (closes 1 of 3).

### Anti-regression (rule D)
- No FR file modified — `Voting.lean` byte-identical to `main`.
- Pure 1-line edit (+1/-1). No existing proof/impl touched.

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
