### PR TITLE
fix(lean): social_choice Arrow_en dot-notation — qualify is_strictly_best/worst (See #4980)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Arrow_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Arrow_en.lean
@@ -105,8 +105,8 @@ lemma is_extremal.is_strictly_best {R : σ → σ → Prop} {b : σ} {X : Finset
   | Or.inr hworst => absurd hworst h
 
 lemma is_extremal.is_strictly_worst {R : σ → σ → Prop} {b : σ} {X : Finset σ}
-    (hextr : is_extremal R b X) (h : ¬_root_.is_strictly_best R b X) :
-    _root_.is_strictly_worst R b X :=
+    (hextr : is_extremal R b X) (h : ¬SocialChoice_en.is_strictly_best R b X) :
+    SocialChoice_en.is_strictly_worst R b X :=
   match hextr with
   | Or.inl hbest => absurd hbest h
   | Or.inr hworst => hworst


### PR DESCRIPTION
## fix(lean): social_choice `Arrow_en` dot-notation — qualify `is_strictly_best/worst`

Fixes the 4 build errors in `Arrow_en.lean` (social_choice_lean). Closes 2 of 3 broken `_en` siblings blocking the lake's globs rollout (**MEMORY c.219**, follow-up to Voting_en fix #5500).

### Root cause (verified firsthand)

`Arrow_en.lean` (L107-109, lemma `is_extremal.is_strictly_worst`) copied the FR `_root_.is_strictly_best` / `_root_.is_strictly_worst` prefixes verbatim from FR `Arrow.lean`. But the namespace placement **differs between FR and EN**:

| File | `def is_strictly_best` location | `_root_.` valid? |
|------|---------------------------------|------------------|
| FR `Arrow.lean` | root level (no namespace) | **yes** (root def) |
| EN `Arrow_en.lean` | inside `namespace SocialChoice_en` (L46) | **no** (def is `SocialChoice_en.is_strictly_best`) |

So `_root_.is_strictly_best` does not resolve in EN:
```
Arrow_en.lean:108:38: Unknown identifier `_root_.is_strictly_best`
Arrow_en.lean:109:4: Unknown identifier `_root_.is_strictly_worst`
Arrow_en.lean:110:2: Tactic `cases` failed with a nested error
Arrow_en.lean:216:8: (kernel) unknown constant 'SocialChoice_en.is_extremal.is_strictly_worst'
```

### Fix (2 lines, L108-109)

Replace `_root_.` with the fully-qualified EN namespace `SocialChoice_en.is_strictly_best/worst`.

**Why fully-qualified (not bare)?** The lemma lives in `namespace is_extremal`. Inside it, Lean's dot-notation parses the bare `is_strictly_best` as **`is_extremal.is_strictly_best`** (dot-notation on the `is_extremal` type) — producing `Application type mismatch: R has type σ → σ → Prop but is expected to have type is_extremal`. Fully-qualifying with `SocialChoice_en.` bypasses the dot-notation resolution. Same trap family as cooperative_games `Basic_en` (#5480).

### Verification (lean-merge-discipline HARD — lake build SUCCESS local)

```
$ lake.exe build SocialChoice.Arrow_en
Build completed successfully (2948 jobs), exit 0
```
| Check | Result |
|-------|--------|
| `lake build SocialChoice.Arrow_en` | **SUCCESS** (2948 jobs, exit 0) |
| 4 build errors | **GONE** |
| FR `Arrow.lean` | byte-identical (0 changes) |
| Sister lemma `is_extremal.is_strictly_best` (L100-104) | left as-is (already builds; unqualified works there) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — 2 of 3 broken _en now closed

| File | Status | PR |
|------|--------|----|
| `Voting_en.lean` | ✅ fixed | #5500 (import swap FR→EN sibling) |
| `Arrow_en.lean` | ✅ fixed | **this PR** (dot-notation namespace qualify) |
| `Framework_en.lean` | ❌ broken (L211) | **PROOF** bug (`Tactic contradiction failed`) — different bug type, separate PR |
| `Basic_en`, `MechanismDesign_en`, `Sen_en`, `SortedListCounting_en` | ✅ build clean | — |

**Globs rollout status**: STILL BLOCKED on `Framework_en` only (1 of 3 remaining). After Framework_en fix, social_choice_lean globs (`SocialChoice.*`) can be safely enabled (all `_en` build clean), unblocking MEMORY c.219 for this lake.

### Anti-regression (rule D)
- No FR file modified — `Arrow.lean` byte-identical to `main`.
- Pure 2-line edit (+2/-2). No existing proof/impl touched (only the 2 `_root_.` prefixes → `SocialChoice_en.`).

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
