### PR TITLE
fix(lean): social_choice Framework_en — swap FR import to EN sibling Basic_en (See #4980)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Framework_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Framework_en.lean
@@ -36,7 +36,7 @@
   Reference: John Geanakoplos, "Three Brief Proofs of Arrow's Impossibility Theorem" (2005)
 -/
 
-import SocialChoice.Basic
+import SocialChoice.Basic_en
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic
 


### PR DESCRIPTION
## fix(lean): social_choice `Framework_en` — swap FR import to EN sibling (`Basic_en`)

Fixes the L211 `Tactic \`contradiction\` failed` proof failure in `Framework_en.lean`. **This was misclassified as a "proof bug" (c.219) — it's the same import-mismatch as Voting_en (#5500).** Closes **3 of 3** broken `_en` in social_choice_lean → unblocks lake-wide globs rollout (MEMORY c.219 for this lake).

### Root cause (verified firsthand)

`Framework_en.lean` (`namespace SocialChoice_en`, L43) imported the **FR** module `SocialChoice.Basic` (L39) and built its `PrefOrder` structures against the **FR** `PrefOrder` (defined in FR `Basic.lean` L160, root namespace), while defining its own `makeabove_rel` (L94) and proof lemmas **inside `namespace SocialChoice_en`**. The namespace mismatch — FR `PrefOrder` struct + EN `makeabove_rel` — left a branch of the `first|`-chain in the `makeabove_pref.trans` proof unable to close:

```
Framework_en.lean:211:17: Tactic `contradiction` failed
case pos
  h✝¹ : ¬r.rel a x   hxy : True   h✝ : r.rel a z   hyz : True
  y = b
  ⊢ r.rel x z
```

**The goal is provable**: `r.total` gives `r.rel x a` (from `¬r.rel a x`), then `r.trans : r.rel x a → r.rel a z → r.rel x z`. But under the FR-PrefOrder-field + EN-makeabove_rel routing, the case fell to a bare `contradiction` branch that had no contradicting hypotheses.

### Proof the failure was the import, NOT the logic

| Check | Result |
|-------|--------|
| EN `trans` proof code (L192-218) vs FR (L154-180) | **byte-identical** (unified diff, non-docstring) |
| `lake build SocialChoice.Framework` (FR) | **SUCCESS** (2947 jobs) — same proof builds clean |
| `lake build SocialChoice.Framework_en` (EN, before fix) | **FAIL** (L211) |

Same proof code, FR builds, EN fails → the divergence is import routing (FR PrefOrder vs EN makeabove_rel namespace), not proof logic.

### Fix (minimal, 1 line)

Swap L39 import `SocialChoice.Basic` (FR) → `SocialChoice.Basic_en` (EN sibling, defines its own `PrefOrder` in `namespace SocialChoice_en` L182, byte-identical semantics per i18n convention #4980). The EN `PrefOrder` then matches the EN `makeabove_rel` + proof lemmas, and `trans` closes the same way FR does. Same import-swap pattern as Voting_en (#5500) and cooperative_games Basic_en (#5480).

**Proof code UNCHANGED** (byte-identical to FR — the proof was always correct, only the import routing was wrong). FR `Framework.lean` UNCHANGED (anti-regression rule D).

### Verification (lean-merge-discipline HARD — lake build SUCCESS local)

```
$ lake.exe build SocialChoice.Framework_en
Build completed successfully (2947 jobs), exit 0
```
| Check | Result |
|-------|--------|
| `lake build SocialChoice.Framework_en` | **SUCCESS** (2947 jobs, exit 0) |
| L211 `contradiction failed` | **GONE** |
| FR `Framework.lean` | byte-identical (0 changes) |
| EN proof code | byte-identical to FR (0 changes) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — 3 of 3 broken _en in social_choice_lean now closed

| File | Status | PR | Root cause |
|------|--------|----|------------|
| `Voting_en.lean` | ✅ fixed | #5500 | import FR→EN sibling (SortedListCounting) |
| `Arrow_en.lean` | ✅ fixed | #5502 | dot-notation `_root_.`→`SocialChoice_en.` |
| `Framework_en.lean` | ✅ fixed | **this PR** | import FR→EN sibling (Basic) |
| `Basic_en`, `MechanismDesign_en`, `Sen_en`, `SortedListCounting_en` | ✅ build clean | — | — |

**After all 3 PRs merge**, the full 7-`_en` build will be green and **social_choice_lean globs (`SocialChoice.*`) can be safely enabled** — unblocking MEMORY c.219 for this lake (one of the 2 lakes still missing globs, the other being stable_marriage_lean).

> Note: on THIS branch (base = main), `lake build` of all 7 `_en` still fails on Arrow_en + Voting_en — their fixes are on separate branches (#5502, #5500) not yet in main. Each fix is verified isolated; the 3 are independent (different _en files, different root causes).

### Anti-regression (rule D)
- No FR file modified — `Framework.lean` byte-identical to `main`.
- Pure 1-line edit (+1/-1, import only). No existing proof/impl touched (proof code unchanged).

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
