### PR TITLE
docs(ml): list ML-4-Evaluation-Python jumeau in §E-entier ML table (EPIC #3974)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -95,6 +95,7 @@ Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du 
 | 3 | [ML-3-Entrainement&AutoML](ML.Net/ML-3-Entrainement&AutoML.ipynb) | SDCA, LightGBM, AutoML | Entraînement |
 | 3-Py | [ML-3-Entrainement-Python](ML.Net/ML-3-Entrainement-Python.ipynb) | **Jumeau Python** : SDCA/LightGBM/AutoML ⇄ `LinearRegression`/`GradientBoosting`/`GridSearchCV` | Parité .NET⇄Python |
 | 4 | [ML-4-Evaluation](ML.Net/ML-4-Evaluation.ipynb) | Cross-validation, métriques, PFI | Évaluation |
+| 4-Py | [ML-4-Evaluation-Python](ML.Net/ML-4-Evaluation-Python.ipynb) | **Jumeau Python** : cross-validation + métriques + PFI ⇄ `cross_val_score` + `permutation_importance` (scikit-learn) | Parité .NET⇄Python |
 | 5 | [ML-5-TimeSeries](ML.Net/ML-5-TimeSeries.ipynb) | Forecasts temporelles, windowing | Séries temporelles |
 | 5-Py | [ML-5-TimeSeries-Python](ML.Net/ML-5-TimeSeries-Python.ipynb) | **Jumeau Python** : `ForecastBySsa` ⇄ `STL`+`SARIMA` (statsmodels) | Parité .NET⇄Python |
 | 6 | [ML-6-ONNX](ML.Net/ML-6-ONNX.ipynb) | Export ONNX, inférence en production | Déploiement |


### PR DESCRIPTION
## §E-fix slim EPIC #3974 tranche ML — ajout ML-4-Evaluation-Python à la table jumeaux Python

**Substance** : 1 fichier / +1 ligne / 1 commit unique / 1 domaine ML. R3 atomic strict.

### Audit G.1 §E-entier `MyIA.AI.Notebooks/ML/` (whole-file, format #5424 Probas)

| Source | ML.Net | DSWA | Total |
|--------|--------|------|-------|
| CATALOG-STATUS | 13 | 27 | **40** |
| Disque .ipynb firsthand | **18** | **27** | **45** |
| Table README (prose) | **17** | **27** | **44** |

**Drift confirmé** : `ML.Net` table ligne 91-107 = 17 entrées (1, 1-Py, 2, 2-Py, 3, 3-Py, 4, 5, 5-Py, 6, 7, 7-Py, 8, 8-Py, 9, 9-Py, TP). Disque = **18** fichiers = `ML-1, ML-1-Py, ML-2, ML-2-Py, ML-3, ML-3-Py, ML-4, ML-4-Py, ML-5, ML-5-Py, ML-6, ML-7, ML-7-Py, ML-8, ML-8-Py, ML-9, ML-9-Py, TP`. **Manque dans la table : `ML-4-Evaluation-Python`** (jumeau Python pour ML-4 Evaluation, parité avec les 8 autres jumeaux Python déjà listés).

### Fix

Ajout de la ligne `4-Py | [ML-4-Evaluation-Python] | Jumeau Python : cross-validation + métriques + PFI ⇄ cross_val_score + permutation_importance (scikit-learn) | Parité .NET⇄Python` entre la ligne `4` (ML-4-Evaluation) et la ligne `5` (ML-5-TimeSeries). Restaure la parité listing avec ML-1/2/3/5/7/8/9 jumeaux Python.

### CATALOG-STATUS — non touché (R1 catalog-pr-hygiene)

Le bloc `<!-- CATALOG-STATUS -->` (L3-L8) indique `ML.Net=13` qui est obsolète (disque = 18). **R1 catalog-pr-hygiene interdit la régénération manuelle du catalogue sur une branche feature** : le `.github/workflows/catalog-cron.yml` quotidien sur `main` régénèrera `ML.Net=18` dans <24h. Ne pas toucher au marqueur auto-généré.

### DSWA & learning_theory_lean — pas de drift

- **DSWA tables** : 27 listés = 27 disque (01-PythonForDataScience 2, 02-ML-Cours 8, PythonAgentsForDataScience 7, AgenticDataScience 10). Aucune omission.
- **learning_theory_lean** : 19 fichiers `.lean` (lake frère hors CAT canonique — la section "Théorie formelle" du README en fait foi via `lake build SUCCESS` en guise de preuve d'exécution, pas via `execution_count`).

### Verdict

PR §E-fix slim légitime (≠ CLEAN_DONE, ≠ README filler) : restaure une **incohérence prosaque factuelle** qui empêchait la découvrabilité de `ML-4-Evaluation-Python` depuis le hub ML. Substance > doc : la table jumeaux Python est la porte d'entrée pédagogique, omettre un jumeau casse la parité .NET⇄Python annoncée dès l'intro.

### Méta

- c187 (HARD) UNIQUE commit `4fd66cf1c` (1f / +1 / 0 deletions)
- c201-CRIT ✓ `git diff origin/main..HEAD --stat` = `1 file changed, 1 insertion(+)`
- c222 self-verify ✓ `gh pr list --head fix/3974-ml-readme-ml-4-py-omission --state all` vide avant push
- C297-HARD respectée : 10 dependabot pre-existants = info hors-scope R3
- Submodule `Search/MetaGeneticSharp` non touché (dirty worktree pré-existant)
- `See #3973` + `See #3974` (cf R4 catalog-pr-hygiene : `Closes` interdit car sous-tâche d'Epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)