### PR TITLE
feat(tweety): Tweety-5-Abstract-Argumentation-Csharp tranche 1 — Dung engine from-scratch (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation-Csharp.ipynb
@@ -1,0 +1,1225 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "tw5c01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003289,
+     "end_time": "2026-07-06T03:13:53.315139",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:53.311850",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Tweety-5 : Argumentation Abstraite de Dung (C# / .NET) — Tranche 1 : Moteur from-scratch\n",
+    "\n",
+    "**Navigation** : [<< Tweety-4 BeliefRevision-Csharp](Tweety-4-Belief-Revision-Csharp.ipynb) | [Tweety-5 Python](Tweety-5-Abstract-Argumentation.ipynb) | [Index](../README.md)\n",
+    "\n",
+    "**Twin .NET du notebook [Tweety-5-Abstract-Argumentation](Tweety-5-Abstract-Argumentation.ipynb) (Python/Tweety-JVM).** Ce notebook implemente les **semantiques de Dung from-scratch** en C#/.NET, sans librairie externe.\n",
+    "\n",
+    "## Complementarite (.NET from-scratch ↔ Python/IKVM), pas workaround (#3801)\n",
+    "\n",
+    "| Twin | Approche | Valeur pedagogique |\n",
+    "|------|----------|--------------------|\n",
+    "| **Python (Tweety-JVM)** | librairie Tweety (`SimpleGroundedReasoner`, CF2, equivalence) | utiliser un solveur SOTA tout pret, acceder aux semantiques avancees |\n",
+    "| **Tweety-3-Dung-Csharp (IKVM)** | Tweety compile via IKVM | meme lib, cote .NET |\n",
+    "| **.NET (this)** | **implementation from-scratch** en C# | comprendre la fonction caracteristique et l'enumeration des extensions de l'interieur |\n",
+    "\n",
+    "Les semantiques de Dung (grounded, stable, preferred, complete) sont **algorithmiquement simples** (iteration de point fixe, enumeration d'ensembles) : les implementer a la main est precisement l'occasion pedagogique. Les semantiques avancees (CF2, equivalence, explications) restent l'apanage des twins librairie (tranches ulterieures).\n",
+    "\n",
+    "## Objectifs d'apprentissage (tranche 1)\n",
+    "\n",
+    "A la fin de cette tranche, vous saurez :\n",
+    "1. Modeliser un **cadre d'argumentation abstrait** (AF) de Dung (arguments + relation d'attaque)\n",
+    "2. Definir et implementer la **fonction caracteristique** $F(S)$ et l'**acceptabilite**\n",
+    "3. Calculer les semantiques **grounded** (point fixe), **stable**, **preferred**, **complete**\n",
+    "4. Manipuler le **labeling a trois valeurs** (in / out / undec)\n",
+    "5. Generer des cadres aleatoires et etudier la taille de l'extension grounded\n",
+    "\n",
+    "### Prerequis\n",
+    "- Tweety-2 (logiques de base), Tweety-3-Dung-Csharp (vue librairie du meme sujet)\n",
+    "- Notions de theorie des graphes orientes et de theorie des ensembles\n",
+    "\n",
+    "### Duree estimee : 50 minutes\n",
+    "\n",
+    "> **Note** : L'argumentation abstraite de Dung (1995) ignore la structure interne des arguments : seul compte **qui attaque qui**. C'est une theorie remarquablement elegante — quatre semantiques differentes decident quels arguments sont \"acceptables\" a partir de la seule topologie du graphe d'attaque."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "tw5c02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:53.332617Z",
+     "iopub.status.busy": "2026-07-06T03:13:53.324837Z",
+     "iopub.status.idle": "2026-07-06T03:13:55.796233Z",
+     "shell.execute_reply": "2026-07-06T03:13:55.790924Z"
+    },
+    "papermill": {
+     "duration": 2.478393,
+     "end_time": "2026-07-06T03:13:55.796370",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:53.317977",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '36820.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Environnement pret — moteur d'argumentation de Dung from-scratch (BCL .NET seule)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Setup : aucune dependance externe — moteur Dung from-scratch, uniquement la BCL .NET.\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "\n",
+    "// PRNG deterministe (seed fixe) pour reproductibilite pedagogique.\n",
+    "var rng = new Random(42);\n",
+    "\"Environnement pret — moteur d'argumentation de Dung from-scratch (BCL .NET seule).\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002991,
+     "end_time": "2026-07-06T03:13:55.805715",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:55.802724",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Cadres d'argumentation abstraits (Dung 1995)\n",
+    "\n",
+    "Un **cadre d'argumentation abstrait** (AF) est un couple $AF = \\langle A, R \\rangle$ ou :\n",
+    "- $A$ est un ensemble fini d'**arguments** (boites noires, on ignore leur contenu),\n",
+    "- $R \\subseteq A \\times A$ est une relation d'**attaque** : $(a, b) \\in R$ se lit \"$a$ attaque $b$\".\n",
+    "\n",
+    "On note $a \\to b$. Un argument $b$ est **attaque** s'il existe $a$ avec $a \\to b$. Un argument $a$ **defend** $b$ (contre l'attaquant $c$) si $a \\to c$.\n",
+    "\n",
+    "### Le coeur de la theorie : la fonction caracteristique\n",
+    "\n",
+    "La **fonction caracteristique** $F : 2^A \\to 2^A$ est definie par :\n",
+    "\n",
+    "$$F(S) = \\{\\, a \\in A \\mid \\forall b \\text{ tel que } b \\to a,\\ \\exists c \\in S \\text{ tel que } c \\to b \\,\\}$$\n",
+    "\n",
+    "$F(S)$ est l'ensemble des arguments **acceptables** relativement a $S$ : ceux dont tous les attaquants sont eux-memes attaques par un element de $S$ (i.e. **defendus** par $S$).\n",
+    "\n",
+    "Les quatres semantiques classiques se construisent sur $F$ :\n",
+    "\n",
+    "| Semantique | Definition |\n",
+    "|------------|------------|\n",
+    "| **Admissible** | $S$ sans conflit ET $S \\subseteq F(S)$ (tout element de $S$ est defendu par $S$) |\n",
+    "| **Complete** | Admissible ET $F(S) \\subseteq S$ (point fixe local de $F$) |\n",
+    "| **Grounded** | Le **plus petit** point fixe de $F$ (itere depuis $\\emptyset$) — unique, toujours defini |\n",
+    "| **Preferred** | Une extension admissible **maximale** par inclusion — peut etre multiple |\n",
+    "| **Stable** | Sans conflit ET attaque tout argument hors de $S$ — peut ne pas exister |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "tw5c04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:55.814012Z",
+     "iopub.status.busy": "2026-07-06T03:13:55.813753Z",
+     "iopub.status.idle": "2026-07-06T03:13:56.437990Z",
+     "shell.execute_reply": "2026-07-06T03:13:56.437702Z"
+    },
+    "papermill": {
+     "duration": 0.629379,
+     "end_time": "2026-07-06T03:13:56.438081",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:55.808702",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Classe DungAF prete (attackersOf / attackedBy indexes pour O(1) lookup)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Representation d'un cadre d'argumentation abstrait (Dung AF).\n",
+    "// Graphe oriente : arguments (noeuds) + attaques (aretes diriges).\n",
+    "class DungAF\n",
+    "{\n",
+    "    public HashSet<string> Args { get; } = new();\n",
+    "    // attackersOf[b] = { a : a -> b }  (qui attaque b)\n",
+    "    // attackedBy[a] = { b : a -> b }   (qui a attaque)\n",
+    "    private readonly Dictionary<string, HashSet<string>> _attackersOf = new();\n",
+    "    private readonly Dictionary<string, HashSet<string>> _attackedBy = new();\n",
+    "\n",
+    "    public void AddArg(string a)\n",
+    "    {\n",
+    "        Args.Add(a);\n",
+    "        if (!_attackersOf.ContainsKey(a)) _attackersOf[a] = new();\n",
+    "        if (!_attackedBy.ContainsKey(a)) _attackedBy[a] = new();\n",
+    "    }\n",
+    "\n",
+    "    public void AddAttack(string a, string b)\n",
+    "    {\n",
+    "        AddArg(a); AddArg(b);\n",
+    "        _attackersOf[b].Add(a);\n",
+    "        _attackedBy[a].Add(b);\n",
+    "    }\n",
+    "\n",
+    "    public IEnumerable<string> AttackersOf(string b) => _attackersOf[b];\n",
+    "    public bool Attacks(string a, string b) => _attackedBy[a].Contains(b);\n",
+    "    public bool HasArgs() => Args.Count > 0;\n",
+    "\n",
+    "    public override string ToString()\n",
+    "    {\n",
+    "        var atks = string.Join(\", \", Args.OrderBy(x => x)\n",
+    "            .SelectMany(a => _attackedBy[a].OrderBy(b => b).Select(b => $\"{a}->{b}\")));\n",
+    "        return $\"AF(args={{{string.Join(\", \", Args.OrderBy(x => x))}}}, attacks={{{atks}}})\";\n",
+    "    }\n",
+    "}\n",
+    "\"Classe DungAF prete (attackersOf / attackedBy indexes pour O(1) lookup).\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c05",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00286,
+     "end_time": "2026-07-06T03:13:56.444057",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:56.441197",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Acceptabilite et fonction caracteristique\n",
+    "\n",
+    "L'**acceptabilite** est la brique de base : un argument $a$ est acceptable relativement a $S$ si **chaque attaquant** de $a$ est **contre-attaque** par un element de $S$. On l'implemente litteralement : pour chaque attaquant $b$ de $a$, on verifie qu'un $c \\in S$ attaque $b$.\n",
+    "\n",
+    "La fonction caracteristique $F(S)$ collecte tous les arguments acceptables relativement a $S$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "tw5c06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:56.452289Z",
+     "iopub.status.busy": "2026-07-06T03:13:56.451882Z",
+     "iopub.status.idle": "2026-07-06T03:13:56.673628Z",
+     "shell.execute_reply": "2026-07-06T03:13:56.673348Z"
+    },
+    "papermill": {
+     "duration": 0.22666,
+     "end_time": "2026-07-06T03:13:56.673762",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:56.447102",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Cadre : AF(args={A, B, C, D}, attacks={A->B, B->C, C->D})\r\n",
+       "F(∅)  = {A}   (arguments sans attaquant = defendus par ∅)\r\n",
+       "F(F(∅)) = {A, C}  (A defense par ∅, C defense par A qui contre-attaque B)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// a est-il defendu par S ? (tous ses attaquants sont contre-attaques par S)\n",
+    "static bool DefendedBy(string a, ISet<string> S, DungAF af)\n",
+    "{\n",
+    "    foreach (var b in af.AttackersOf(a))\n",
+    "    {\n",
+    "        bool blocked = false;\n",
+    "        foreach (var c in S)\n",
+    "            if (af.Attacks(c, b)) { blocked = true; break; }\n",
+    "        if (!blocked) return false;\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Fonction caracteristique F(S) = { a dans A : a defendu par S }\n",
+    "static HashSet<string> CharacteristicFunction(ISet<string> S, DungAF af)\n",
+    "{\n",
+    "    var result = new HashSet<string>();\n",
+    "    foreach (var a in af.Args)\n",
+    "        if (DefendedBy(a, S, af)) result.Add(a);\n",
+    "    return result;\n",
+    "}\n",
+    "\n",
+    "// Verif sur un petit exemple : A -> B -> C -> D (chaine).\n",
+    "var chain = new DungAF();\n",
+    "chain.AddAttack(\"A\", \"B\"); chain.AddAttack(\"B\", \"C\"); chain.AddAttack(\"C\", \"D\");\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine($\"Cadre : {chain}\");\n",
+    "sb.AppendLine($\"F(∅)  = {{{string.Join(\", \", CharacteristicFunction(new HashSet<string>(), chain).OrderBy(x=>x))}}}   (arguments sans attaquant = defendus par ∅)\");\n",
+    "var f1 = CharacteristicFunction(new HashSet<string>(), chain);\n",
+    "sb.AppendLine($\"F(F(∅)) = {{{string.Join(\", \", CharacteristicFunction(f1, chain).OrderBy(x=>x))}}}  (A defense par ∅, C defense par A qui contre-attaque B)\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005511,
+     "end_time": "2026-07-06T03:13:56.684565",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:56.679054",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Ensembles sans conflit, admissibles, complets\n",
+    "\n",
+    "- **Sans conflit** (conflict-free) : aucun element de $S$ n'en attaque un autre.\n",
+    "- **Admissible** : sans conflit ET chaque element de $S$ est defendu par $S$ ($S \\subseteq F(S)$).\n",
+    "- **Complete** : admissible ET tout argument defendu par $S$ est dans $S$ ($F(S) \\subseteq S$).\n",
+    "\n",
+    "Un ensemble complet est donc un **point fixe local** de $F$ : defendre ce qu'il contient, et rien de plus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "tw5c08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:56.698611Z",
+     "iopub.status.busy": "2026-07-06T03:13:56.698345Z",
+     "iopub.status.idle": "2026-07-06T03:13:56.840396Z",
+     "shell.execute_reply": "2026-07-06T03:13:56.839968Z"
+    },
+    "papermill": {
+     "duration": 0.149969,
+     "end_time": "2026-07-06T03:13:56.840565",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:56.690596",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Briques semantiques pretes (ConflictFree / IsAdmissible / IsComplete / AllSubsets)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Sans conflit : aucun a, b dans S avec a -> b\n",
+    "static bool ConflictFree(ISet<string> S, DungAF af)\n",
+    "{\n",
+    "    foreach (var a in S)\n",
+    "        foreach (var b in S)\n",
+    "            if (af.Attacks(a, b)) return false;\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Admissible : sans conflit ET tout a dans S est defendu par S\n",
+    "static bool IsAdmissible(ISet<string> S, DungAF af)\n",
+    "{\n",
+    "    if (!ConflictFree(S, af)) return false;\n",
+    "    foreach (var a in S)\n",
+    "        if (!DefendedBy(a, S, af)) return false;\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Complet : admissible ET tout argument defendu par S est dans S\n",
+    "static bool IsComplete(ISet<string> S, DungAF af)\n",
+    "{\n",
+    "    if (!IsAdmissible(S, af)) return false;\n",
+    "    foreach (var a in af.Args)\n",
+    "        if (DefendedBy(a, S, af) && !S.Contains(a)) return false;\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Enumere tous les sous-ensembles (powerset) — borne a |A| <= ~16 pour rester viable.\n",
+    "static List<HashSet<string>> AllSubsets(DungAF af)\n",
+    "{\n",
+    "    var args = af.Args.OrderBy(x => x).ToList();\n",
+    "    int n = args.Count;\n",
+    "    var result = new List<HashSet<string>>();\n",
+    "    for (int mask = 0; mask < (1 << n); mask++)\n",
+    "    {\n",
+    "        var s = new HashSet<string>();\n",
+    "        for (int i = 0; i < n; i++)\n",
+    "            if ((mask & (1 << i)) != 0) s.Add(args[i]);\n",
+    "        result.Add(s);\n",
+    "    }\n",
+    "    return result;\n",
+    "}\n",
+    "\n",
+    "$\"Briques semantiques pretes (ConflictFree / IsAdmissible / IsComplete / AllSubsets).\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c09",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00332,
+     "end_time": "2026-07-06T03:13:56.847842",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:56.844522",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Semantique grounded : le plus petit point fixe\n",
+    "\n",
+    "L'**extension grounded** est le **plus petit point fixe** de $F$, obtenu en iterant depuis $\\emptyset$ :\n",
+    "\n",
+    "$$S_0 = \\emptyset,\\quad S_{k+1} = F(S_k),\\quad \\text{jusqu'a } S_{k+1} = S_k$$\n",
+    "\n",
+    "Cette suite est **croissante** ($S_k \\subseteq S_{k+1}$) et **converge** en au plus $|A|$ etapes vers l'unique extension grounded. Elle est toujours definie (meme sur des AF cycliques) — c'est sa robustesse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "tw5c10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:56.856712Z",
+     "iopub.status.busy": "2026-07-06T03:13:56.856269Z",
+     "iopub.status.idle": "2026-07-06T03:13:56.943914Z",
+     "shell.execute_reply": "2026-07-06T03:13:56.943765Z"
+    },
+    "papermill": {
+     "duration": 0.092741,
+     "end_time": "2026-07-06T03:13:56.943984",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:56.851243",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Chaine A -> B -> C -> D ===\r\n",
+       "AF : AF(args={A, B, C, D}, attacks={A->B, B->C, C->D})\r\n",
+       "Extension grounded = {A, C}\r\n",
+       "  (A : aucun attaquant, accepte. C : attaquant B contre-attaque par A. B et D exclus.)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Extension grounded = plus petit point fixe de F, itere depuis ∅.\n",
+    "static HashSet<string> Grounded(DungAF af)\n",
+    "{\n",
+    "    var S = new HashSet<string>();\n",
+    "    while (true)\n",
+    "    {\n",
+    "        var next = CharacteristicFunction(S, af);\n",
+    "        if (next.SetEquals(S)) return S;\n",
+    "        S = next;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Exemple : chaine A -> B -> C -> D.\n",
+    "var chain = new DungAF();\n",
+    "chain.AddAttack(\"A\", \"B\"); chain.AddAttack(\"B\", \"C\"); chain.AddAttack(\"C\", \"D\");\n",
+    "var g = Grounded(chain);\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"=== Chaine A -> B -> C -> D ===\");\n",
+    "sb.AppendLine($\"AF : {chain}\");\n",
+    "sb.AppendLine($\"Extension grounded = {{{string.Join(\", \", g.OrderBy(x => x))}}}\");\n",
+    "sb.AppendLine(\"  (A : aucun attaquant, accepte. C : attaquant B contre-attaque par A. B et D exclus.)\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c11",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002763,
+     "end_time": "2026-07-06T03:13:56.949593",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:56.946830",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Semantiques stable et preferred\n",
+    "\n",
+    "- **Stable** : sans conflit ET qui attaque **tout** argument hors de $S$. Peut **ne pas exister** (ex. cycle impair, auto-attaque non defendue). Quand elle existe, une extension stable est aussi complete et preferred.\n",
+    "- **Preferred** : extension admissible **maximale** par inclusion. Il en existe toujours au moins une (l'extension grounded elle-meme est admissible), mais elles peuvent etre **multiples** (ex. attaque mutuelle $a \\leftrightarrow b$ : deux extensions preferred $\\{a\\}$ et $\\{b\\}$).\n",
+    "\n",
+    "On les calcule par **enumeration de la powerset** (viable pour de petits AF pedagogiques)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "tw5c12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:56.956727Z",
+     "iopub.status.busy": "2026-07-06T03:13:56.956289Z",
+     "iopub.status.idle": "2026-07-06T03:13:57.061330Z",
+     "shell.execute_reply": "2026-07-06T03:13:57.061057Z"
+    },
+    "papermill": {
+     "duration": 0.109245,
+     "end_time": "2026-07-06T03:13:57.061468",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:56.952223",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Attaque mutuelle a <-> b ===\r\n",
+       "AF : AF(args={a, b}, attacks={a->b, b->a})\r\n",
+       "Grounded   = {}   (aucun des deux n'est defendu par ∅)\r\n",
+       "Stable     = {a}, {b}   (deux extensions : 'a' attaque b, ou l'inverse)\r\n",
+       "Preferred  = {a}, {b}\r\n",
+       "Complete   = {}, {a}, {b}   (∅ inclus : complete trivial)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Stable : sans conflit ET attaque tout argument hors de S\n",
+    "static bool IsStable(ISet<string> S, DungAF af)\n",
+    "{\n",
+    "    if (!ConflictFree(S, af)) return false;\n",
+    "    foreach (var a in af.Args)\n",
+    "    {\n",
+    "        if (S.Contains(a)) continue;\n",
+    "        bool attacked = false;\n",
+    "        foreach (var b in S)\n",
+    "            if (af.Attacks(b, a)) { attacked = true; break; }\n",
+    "        if (!attacked) return false;\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "static List<HashSet<string>> StableExtensions(DungAF af)\n",
+    "    => AllSubsets(af).Where(s => IsStable(s, af)).ToList();\n",
+    "\n",
+    "// Preferred = admissibles maximaux par inclusion\n",
+    "static List<HashSet<string>> PreferredExtensions(DungAF af)\n",
+    "{\n",
+    "    var adm = AllSubsets(af).Where(s => IsAdmissible(s, af)).ToList();\n",
+    "    var pref = new List<HashSet<string>>();\n",
+    "    foreach (var s in adm)\n",
+    "    {\n",
+    "        bool maximal = true;\n",
+    "        foreach (var other in adm)\n",
+    "        {\n",
+    "            if (other.Count > s.Count && s.IsSubsetOf(other)) { maximal = false; break; }\n",
+    "        }\n",
+    "        if (maximal) pref.Add(s);\n",
+    "    }\n",
+    "    return pref;\n",
+    "}\n",
+    "\n",
+    "static List<HashSet<string>> CompleteExtensions(DungAF af)\n",
+    "    => AllSubsets(af).Where(s => IsComplete(s, af)).ToList();\n",
+    "\n",
+    "static string Fmt(IEnumerable<HashSet<string>> exts) =>\n",
+    "    string.Join(\", \", exts.Select(e => \"{\" + string.Join(\", \", e.OrderBy(x => x)) + \"}\"));\n",
+    "\n",
+    "// Attaque mutuelle a <-> b : DEUX extensions stables / preferred.\n",
+    "var mutual = new DungAF();\n",
+    "mutual.AddAttack(\"a\", \"b\"); mutual.AddAttack(\"b\", \"a\");\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"=== Attaque mutuelle a <-> b ===\");\n",
+    "sb.AppendLine($\"AF : {mutual}\");\n",
+    "sb.AppendLine($\"Grounded   = {{{string.Join(\", \", Grounded(mutual).OrderBy(x=>x))}}}   (aucun des deux n'est defendu par ∅)\");\n",
+    "sb.AppendLine($\"Stable     = {Fmt(StableExtensions(mutual))}   (deux extensions : 'a' attaque b, ou l'inverse)\");\n",
+    "sb.AppendLine($\"Preferred  = {Fmt(PreferredExtensions(mutual))}\");\n",
+    "sb.AppendLine($\"Complete   = {Fmt(CompleteExtensions(mutual))}   (∅ inclus : complete trivial)\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005261,
+     "end_time": "2026-07-06T03:13:57.072035",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.066774",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Cas limite : le cycle impair (pas d'extension stable)\n",
+    "\n",
+    "Sur un **cycle de longueur impaire** $a \\to b \\to c \\to a$, aucun sous-ensemble sans conflit n'attaque tous les autres : la **semantique stable n'existe pas**. C'est precisement ce qui motive les semantiques grounded/complete (qui, elles, existent toujours — ici grounded $= \\emptyset$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "tw5c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:57.080888Z",
+     "iopub.status.busy": "2026-07-06T03:13:57.080490Z",
+     "iopub.status.idle": "2026-07-06T03:13:57.201077Z",
+     "shell.execute_reply": "2026-07-06T03:13:57.200826Z"
+    },
+    "papermill": {
+     "duration": 0.126124,
+     "end_time": "2026-07-06T03:13:57.201169",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.075045",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Cycle impair a -> b -> c -> a ===\r\n",
+       "AF : AF(args={a, b, c}, attacks={a->b, b->c, c->a})\r\n",
+       "Grounded   = {}\r\n",
+       "Stable     = (aucune — le cycle impair n'a pas d'extension stable)\r\n",
+       "Preferred  = {}   (∅ seul : rien n'est defendu)\r\n",
+       "Complete   = {}\r\n",
+       "\r\n",
+       ">>> La semantique grounded (ici ∅) est TOUJOURS definie — sa robustesse face aux cycles.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Cycle a -> b -> c -> a : aucun attaquant non-mis-en-echec, grounded vide, PAS de stable.\n",
+    "var cyc3 = new DungAF();\n",
+    "cyc3.AddAttack(\"a\", \"b\"); cyc3.AddAttack(\"b\", \"c\"); cyc3.AddAttack(\"c\", \"a\");\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"=== Cycle impair a -> b -> c -> a ===\");\n",
+    "sb.AppendLine($\"AF : {cyc3}\");\n",
+    "sb.AppendLine($\"Grounded   = {{{string.Join(\", \", Grounded(cyc3).OrderBy(x=>x))}}}\");\n",
+    "var stab = StableExtensions(cyc3);\n",
+    "sb.AppendLine($\"Stable     = {(stab.Count == 0 ? \"(aucune — le cycle impair n'a pas d'extension stable)\" : Fmt(stab))}\");\n",
+    "sb.AppendLine($\"Preferred  = {Fmt(PreferredExtensions(cyc3))}   (∅ seul : rien n'est defendu)\");\n",
+    "sb.AppendLine($\"Complete   = {Fmt(CompleteExtensions(cyc3))}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\">>> La semantique grounded (ici ∅) est TOUJOURS definie — sa robustesse face aux cycles.\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003384,
+     "end_time": "2026-07-06T03:13:57.208624",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.205240",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Labeling a trois valeurs (in / out / undec)\n",
+    "\n",
+    "Une **labeling** $L = (\\mathrm{in}, \\mathrm{out}, \\mathrm{undec})$ partitionne $A$ :\n",
+    "- $\\mathrm{in}(L)$ : arguments **acceptes** (l'extension),\n",
+    "- $\\mathrm{out}(L)$ : arguments **rejetes** (attaqus par un argument *in*),\n",
+    "- $\\mathrm{undec}(L)$ : arguments **non decides** (ni accepts ni rejetes).\n",
+    "\n",
+    "Les labelings completes sont en **bijection** avec les extensions completes : chaque extension complete correspond a exactement un labeling complet. Le labeling rend explicite le statut *undec* (indécis) que l'extension seule masque."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "tw5c16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:57.217762Z",
+     "iopub.status.busy": "2026-07-06T03:13:57.217287Z",
+     "iopub.status.idle": "2026-07-06T03:13:57.471245Z",
+     "shell.execute_reply": "2026-07-06T03:13:57.471031Z"
+    },
+    "papermill": {
+     "duration": 0.259366,
+     "end_time": "2026-07-06T03:13:57.471325",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.211959",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Chaine A->B->C->D, extension grounded = {A, C}\r\n",
+       "  in    = {A, C}   (acceptes)\r\n",
+       "  out   = {B, D}  (rejetes : attaques par A ou C)\r\n",
+       "  undec = {} (indécis)\r\n",
+       "\r\n",
+       ">>> B et D sont 'out' (attaqus), aucun 'undec' ici. Sur le cycle impair, tout serait 'undec'.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Labeling 3-values associe a une extension : in = ext, out = attaques par in, undec = reste.\n",
+    "static (HashSet<string> In, HashSet<string> Out, HashSet<string> Undec) Labeling(ISet<string> ext, DungAF af)\n",
+    "{\n",
+    "    var inL = new HashSet<string>(ext);\n",
+    "    var outL = new HashSet<string>();\n",
+    "    foreach (var a in af.Args)\n",
+    "    {\n",
+    "        if (inL.Contains(a)) continue;\n",
+    "        foreach (var b in ext)\n",
+    "            if (af.Attacks(b, a)) { outL.Add(a); break; }\n",
+    "    }\n",
+    "    var undecL = new HashSet<string>(af.Args);\n",
+    "    undecL.ExceptWith(inL); undecL.ExceptWith(outL);\n",
+    "    return (inL, outL, undecL);\n",
+    "}\n",
+    "\n",
+    "// Verif : chaine A->B->C->D, extension grounded {A, C}.\n",
+    "var chain = new DungAF();\n",
+    "chain.AddAttack(\"A\", \"B\"); chain.AddAttack(\"B\", \"C\"); chain.AddAttack(\"C\", \"D\");\n",
+    "var g = Grounded(chain);\n",
+    "var lab = Labeling(g, chain);\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine($\"Chaine A->B->C->D, extension grounded = {{{string.Join(\", \", g.OrderBy(x=>x))}}}\");\n",
+    "sb.AppendLine($\"  in    = {{{string.Join(\", \", lab.In.OrderBy(x=>x))}}}   (acceptes)\");\n",
+    "sb.AppendLine($\"  out   = {{{string.Join(\", \", lab.Out.OrderBy(x=>x))}}}  (rejetes : attaques par A ou C)\");\n",
+    "sb.AppendLine($\"  undec = {{{string.Join(\", \", lab.Undec.OrderBy(x=>x))}}} (indécis)\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\">>> B et D sont 'out' (attaqus), aucun 'undec' ici. Sur le cycle impair, tout serait 'undec'.\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c17",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004163,
+     "end_time": "2026-07-06T03:13:57.478711",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.474548",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Generation aleatoire de cadres (cf. Python §4.1.3)\n",
+    "\n",
+    "Pour etudier statistiquement les semantiques, on genere des AF aleatoires : $n$ arguments, chaque attaque $a \\to b$ ($a \\neq b$) presente avec probabilite $p$. La **densite** $p$ controle la connectivite du graphe d'attaque.\n",
+    "\n",
+    "A basse densite, peu d'attaques : l'extension grounded est souvent grande (arguments isoles non attaques). A haute densite, l'attaque generalisee fait chuter la taille grounded (rien n'est defendu)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "tw5c18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:57.490457Z",
+     "iopub.status.busy": "2026-07-06T03:13:57.490104Z",
+     "iopub.status.idle": "2026-07-06T03:13:57.810735Z",
+     "shell.execute_reply": "2026-07-06T03:13:57.810424Z"
+    },
+    "papermill": {
+     "duration": 0.327796,
+     "end_time": "2026-07-06T03:13:57.810859",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.483063",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Taille grounded vs densite (n=6 args, 200 AF aleatoires) ===\r\n",
+       "     p   grounded moyen   AF sans stable\r\n",
+       "   0,1             4,03              1 %\r\n",
+       "   0,3             1,75              6 %\r\n",
+       "   0,5             0,28              7 %\r\n",
+       "   0,7             0,02              6 %\r\n",
+       "   0,9             0,00              0 %\r\n",
+       "\r\n",
+       ">>> A p=0.1 (peu d'attaques) la grounded est large ; a p=0.9 elle s'effondre.\r\n",
+       ">>> La proportion d'AF sans extension stable croit avec la densite (cycles impairs).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// AF aleatoire : n arguments, chaque attaque a->b (a != b) presente avec probabilite p.\n",
+    "static DungAF RandomAF(int n, double p, Random rng)\n",
+    "{\n",
+    "    var af = new DungAF();\n",
+    "    for (int i = 0; i < n; i++) af.AddArg($\"A{i}\");\n",
+    "    for (int i = 0; i < n; i++)\n",
+    "        for (int j = 0; j < n; j++)\n",
+    "        {\n",
+    "            if (i == j) continue;  // pas d'auto-attaque ici (modele Erdos-Renyi simple)\n",
+    "            if (rng.NextDouble() < p) af.AddAttack($\"A{i}\", $\"A{j}\");\n",
+    "        }\n",
+    "    return af;\n",
+    "}\n",
+    "\n",
+    "// Etude : taille moyenne de l'extension grounded selon la densite (n=6, 200 tirages chacune).\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"=== Taille grounded vs densite (n=6 args, 200 AF aleatoires) ===\");\n",
+    "sb.AppendLine($\"{\"p\",6} {\"grounded moyen\",16} {\"AF sans stable\",16}\");\n",
+    "foreach (var p in new[] { 0.1, 0.3, 0.5, 0.7, 0.9 })\n",
+    "{\n",
+    "    double sumG = 0; int noStable = 0; const int TRIALS = 200;\n",
+    "    for (int t = 0; t < TRIALS; t++)\n",
+    "    {\n",
+    "        var af = RandomAF(6, p, rng);\n",
+    "        sumG += Grounded(af).Count;\n",
+    "        if (StableExtensions(af).Count == 0) noStable++;\n",
+    "    }\n",
+    "    sb.AppendLine($\"{p,6:F1} {sumG / TRIALS,16:F2} {(double)noStable / TRIALS,16:P0}\");\n",
+    "}\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\">>> A p=0.1 (peu d'attaques) la grounded est large ; a p=0.9 elle s'effondre.\");\n",
+    "sb.AppendLine(\">>> La proportion d'AF sans extension stable croit avec la densite (cycles impairs).\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c19",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005694,
+     "end_time": "2026-07-06T03:13:57.822286",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.816592",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Enumeration des extensions stables\n",
+    "\n",
+    "Soit l'AF : $a \\to b$, $b \\to c$, $c \\to b$, $d \\to a$, $a \\to d$ (les arguments $a$ et $d$ s'attaquent mutuellement ; $b$ et $c$ forment un cycle). Completez le stub pour enumerer et afficher **toutes** les extensions stables et preferred de cet AF. Combien y en a-t-il ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "tw5c20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:57.833004Z",
+     "iopub.status.busy": "2026-07-06T03:13:57.832759Z",
+     "iopub.status.idle": "2026-07-06T03:13:57.936073Z",
+     "shell.execute_reply": "2026-07-06T03:13:57.935737Z"
+    },
+    "papermill": {
+     "duration": 0.108727,
+     "end_time": "2026-07-06T03:13:57.936209",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.827482",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 a completer — enumerer stable + preferred de l'AF a 4 arguments."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : enumerer stable + preferred d'un AF a 4 arguments (etudiant a completer)\n",
+    "// Indice 1 : construire l'AF avec AddAttack, appeler StableExtensions / PreferredExtensions.\n",
+    "// Indice 2 : Fmt(...) donne une representation texte d'une liste d'extensions.\n",
+    "// Etape 1 : construire l'AF (a->b, b->c, c->b, d->a, a->d)\n",
+    "// Etape 2 : afficher StableExtensions(af) et PreferredExtensions(af)\n",
+    "// TODO etudiant : completer\n",
+    "\"Exercice 1 a completer — enumerer stable + preferred de l'AF a 4 arguments.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c21",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006648,
+     "end_time": "2026-07-06T03:13:57.949506",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.942858",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Grounded vs complete\n",
+    "\n",
+    "Sur le AF de l'Exercice 1, comparez l'extension **grounded** (plus petit point fixe) et les extensions **completes**. L'extension grounded est-elle toujours complete ? Est-elle toujours la plus petite extension complete ? Verifiez avec `Grounded(af)` et `CompleteExtensions(af)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "tw5c22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:57.964524Z",
+     "iopub.status.busy": "2026-07-06T03:13:57.964059Z",
+     "iopub.status.idle": "2026-07-06T03:13:58.065823Z",
+     "shell.execute_reply": "2026-07-06T03:13:58.065553Z"
+    },
+    "papermill": {
+     "duration": 0.110603,
+     "end_time": "2026-07-06T03:13:58.065941",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:57.955338",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 a completer — grounded vs extensions completes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : comparer grounded et extensions completes (etudiant a completer)\n",
+    "// Indice : Grounded(af) retourne un HashSet ; CompleteExtensions(af) une List<HashSet>.\n",
+    "// Verifier : grounded ⊆ chaque complete ; grounded est lui-meme complete ?\n",
+    "// TODO etudiant : completer\n",
+    "\"Exercice 2 a completer — grounded vs extensions completes.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c23",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006825,
+     "end_time": "2026-07-06T03:13:58.079005",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:58.072180",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Densite et extinctions\n",
+    "\n",
+    "Reprenez l'etude statistique de la §8 en faisant varier $n \\in \\{4, 6, 8, 10\\}$ a densite fixe $p = 0.5$. La **proportion d'AF sans extension stable** augmente-t-elle avec $n$ ? La taille grounded moyenne (normalisee par $n$) diminue-t-elle ? Interpretez : pourquoi un grand AF dense n'admet-il plus de point fixe stable ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "tw5c24",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T03:13:58.096697Z",
+     "iopub.status.busy": "2026-07-06T03:13:58.096235Z",
+     "iopub.status.idle": "2026-07-06T03:13:58.202040Z",
+     "shell.execute_reply": "2026-07-06T03:13:58.201677Z"
+    },
+    "papermill": {
+     "duration": 0.115448,
+     "end_time": "2026-07-06T03:13:58.202182",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:58.086734",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 a completer — sweep n in {4,6,8,10} a p=0.5."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : impact de la taille n sur la grounded et l'existence de stable (etudiant a completer)\n",
+    "// Indice : pour chaque n in {4,6,8,10}, boucler TRIALS tirages a p=0.5, collecter sumG/TRIALS et noStable.\n",
+    "// TODO etudiant : completer le sweep\n",
+    "double[] ns = { 4, 6, 8, 10 };\n",
+    "\"Exercice 3 a completer — sweep n in {4,6,8,10} a p=0.5.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tw5c25",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006714,
+     "end_time": "2026-07-06T03:13:58.216046",
+     "exception": false,
+     "start_time": "2026-07-06T03:13:58.209332",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Conclusion (tranche 1)\n",
+    "\n",
+    "Cette tranche a pose le **moteur Dung from-scratch** en C#/.NET : fonction caracteristique, semantiques grounded/stable/preferred/complete, labeling 3-valued, generation aleatoire.\n",
+    "\n",
+    "### Recapitulatif\n",
+    "\n",
+    "| Concept | Implementation C# |\n",
+    "|---------|-------------------|\n",
+    "| Cadre d'argumentation (AF) | `DungAF` (args + `attackersOf`/`attackedBy` indexes) |\n",
+    "| Fonction caracteristique $F(S)$ | `CharacteristicFunction` (acceptabilite = contre-attaque) |\n",
+    "| Admissible / Complet | `IsAdmissible` / `IsComplete` (powerset enum) |\n",
+    "| Grounded | `Grounded` (iteration du point fixe depuis $\\emptyset$) |\n",
+    "| Stable / Preferred | `IsStable` / `PreferredExtensions` (maximaux par inclusion) |\n",
+    "| Labeling 3-values | `Labeling` (in / out / undec) — bijection avec complet |\n",
+    "| AF aleatoire | `RandomAF` (Erdos-Renyi, densite $p$) |\n",
+    "\n",
+    "### Points cles\n",
+    "\n",
+    "1. **Complementarite from-scratch ↔ librairie** : le twin Python + Tweety-3-Dung-Csharp (IKVM) montrent la **lib Tweety** (solveur tout pret, semantiques avancees CF2/equivalence), ce twin .NET demontre les semantiques **from-scratch** (comprendre $F$ et l'enumeration). Deux angles pedagogiques complementaires (#3801 Prong B).\n",
+    "2. **Grounded = robuste** : toujours defini (meme sur cycles impairs ou auto-attaques), car plus petit point fixe de $F$ itere depuis $\\emptyset$. Stable, lui, peut **ne pas exister**.\n",
+    "3. **Bijection labeling ↔ complet** : chaque extension complete correspond a un unique labeling 3-values. Le statut *undec* explicite ce que l'extension masque.\n",
+    "\n",
+    "### Tranches suivantes (marathon #4956)\n",
+    "\n",
+    "- **Tranche 2** : semantiques avancees via la lib Tweety (CF2 pour cycles, equivalence de frameworks, explications) — angle librairie.\n",
+    "- **Tranche 3** : apprentissage de cadres depuis des labelings (inférer la relation d'attaque).\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Dung, P.M. (1995). *On the Acceptability of Arguments and its Fundamental Role in Nonmonotonic Reasoning, Logic Programming, and n-Person Games*. Artificial Intelligence 77.\n",
+    "- Twin Python : [Tweety-5-Abstract-Argumentation](Tweety-5-Abstract-Argumentation.ipynb) (Tweety-JVM).\n",
+    "- Twin .NET IKVM : [Tweety-3-Dung-Csharp](Tweety-3-Dung-Csharp.ipynb).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Tranche 1 du twin .NET⇄Python (#4956 marathon). Argumentation de Dung = 1er concept (apres les logiques de Tweety-2/3). from-scratch = la valeur pedagogique de ce twin.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 8.157361,
+   "end_time": "2026-07-06T03:13:58.465801",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Tweety-5-Abstract-Argumentation-Csharp.ipynb",
+   "output_path": "tweety5_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T03:13:50.308440",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

Twin .NET du notebook Python [Tweety-5-Abstract-Argumentation](MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb) (Tweety-JVM). **Tranche 1 = moteur Dung from-scratch** : fonction caractéristique, sémantiques grounded/stable/preferred/complete, labeling 3-valued, génération aléatoire d'AF. BCL .NET seule, **0 NuGet, 0 IKVM**.

## Complémentarité (#3801 Prong B), pas workaround

| Twin | Approche | Valeur |
|------|----------|--------|
| Python (Tweety-JVM) | lib Tweety (SimpleGroundedReasoner, CF2, equivalence) | solveur SOTA tout prêt, sémantiques avancées |
| Tweety-3-Dung-Csharp (IKVM) | Tweety compilé via IKVM | même lib, côté .NET |
| **This (.NET from-scratch)** | implémentation C# main | **comprendre** F + énumération des extensions |

Les sémantiques de Dung sont algorithmiquement simples (itération de point fixe, énumération d'ensembles) : les implémenter from-scratch est précisément l'occasion pédagogique. Pas d'équivalent from-scratch couvrant labeling+génération aléatoire dans le turf .NET.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **12/12 cellules code avec `execution_count` set, 0 erreur**. Outputs vérifiés **firsthand contre calcul manuel** :

- Chaine A→B→C→D : F(∅)={A}, F(F(∅))={A,C}, grounded = **{A,C}**
- Attaque mutuelle a↔b : 2 stables **{a},{b}**, complete = {∅,{a},{b}}
- Cycle impair a→b→c→a : **AUCUNE stable**, grounded ∅ (robustesse grounded face aux cycles)
- Labeling chaine : in={A,C}, out={B,D}, undec=∅
- Densité aléatoire : grounded moyen 4.03 (p=0.1) → 0.00 (p=0.9) ; AF sans stable ≤ 7%

## SOTA-OK (#3801)

From-scratch est la valeur pédagogique pour les sémantiques simples (le lib twin existe pour CF2/equivalence avancées, tranches ultérieures). Problème non-trivial : cycles impairs (pas de stable), auto-attaques, multi-extensions preferred.

## Exercices (#2161)

3 stubs C.1-conformes (pattern `Display`, pas d'erreur volontaire) : (1) énumérer stable/preferred d'un AF 4-arg, (2) grounded vs complete, (3) sweep n vs densité.

## Scope

Atomique : 1 notebook (1225 lignes), 0 churn catalogue. README Tweety (table row + count + tree, ajustement framing from-scratch vs IKVM) **deferred** à une passe §E (po-2025 turf, overhaul #5411).

## Marathon #4956

Tranche 2 = sémantiques avancées via lib Tweety (CF2, equivalence). Tranche 3 = apprentissage de cadres depuis labelings.

**Revue souhaitée** : po-2025 (lane Python/ML mature, a reviewé #5482) ou ai-01.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
