### PR TITLE
i18n(#4980): add RepeatedGames.Folk_en — EN sibling, repeated_games_lean (content 4/4)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/RepeatedGames/Folk_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/RepeatedGames/Folk_en.lean
@@ -1,0 +1,125 @@
+import Mathlib.Tactic
+
+import RepeatedGames.Stage
+import RepeatedGames.Discounting_en
+import RepeatedGames.GrimTrigger_en
+
+/-!
+  Folk Theorem (STRETCH) — EN sibling
+  ===================================
+
+  English mirror of `RepeatedGames/Folk.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  distinct `.lean` files FR + EN siblings in the same lake, both compile.
+  Drift-CI detectable: non-docstring content byte-identical between siblings.
+
+  Note méthodologique : traduction manuelle du FR canonique (pas de source
+  EN historique pré-Option A à recover, fichier FR-first depuis origin).
+
+  Namespace sibling : `RepeatedGames_en` (the FR canonical stays
+  `RepeatedGames`). Shared types `PrisonersDilemma`, `PDAction` (defined in
+  `Stage.lean` under `namespace RepeatedGames`) are re-exposed via
+  `open RepeatedGames` so the EN sibling resolves them as FR `GrimTrigger_en`
+  does. Field projections `g.P`/`g.R`/`g.S`/`g.T` are structure-field access
+  (not namespace dot-notation), hence safe under the open.
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+/-!
+  Repeated Games - Folk Theorem (STRETCH)
+  ========================================
+
+  The Folk theorem (Folk 1950s, formally Fudenberg–Maskin 1986, see also
+  Aumann–Shapley 1994 for the continuous-time analogue) states, in its
+  discounted payoff version:
+
+    Every feasible payoff profile that is strictly individually rational can
+    be sustained as a subgame-perfect Nash equilibrium in the limit as the
+  discount factor δ → 1.
+
+  This is a STRETCH module, optional per Issue #4880 ("Folk.lean — minimal
+  version of the Folk theorem... If scaffolded, declare it explicitly as
+  stretch with its sorries counted — 0-sorry is required only on the
+  flagship theorem").
+
+  The proof requires:
+  - The set of feasible payoffs is a polytope (geometric fact over n-stage
+    games);
+  - For each target feasible point strictly inside the individual-rational
+    polytope, construct a strategy profile that alternates between the
+    target joint action and a punishment phase;
+  - As δ → 1, the weight on the punishment phase vanishes, so the discounted
+    average converges to the target payoff.
+
+  These proofs use polytope topology, extreme-point arguments, and
+  minmax-constrained optimization — substantially harder than GrimTrigger.
+  Several lemmas carry `sorry` as placeholders; the prover BG harness will
+  attempt them in later iterations but they are flagged as low-priority.
+
+  Type-forced definitions (lesson Lidman L39, PR #4899): `IndividuallyRational`
+  is bounded by `g.P` and `Feasible` is a convex constraint on the four joint
+  actions, **so correctness is forced by the type system, not by any cited
+  numerical data** (no KnotInfo-style tables, no source labels). The `sorry`
+  on `folk_theorem_discounted` is the genuine hard direction (Fudenberg–Maskin
+  polytope topology, OUT of scope of the GrimTrigger sprint).
+-/
+
+namespace RepeatedGames_en
+
+open RepeatedGames
+
+
+/-- Individual rationality: a payoff vector `u` is individually rational if
+    each coordinate exceeds the player's minmax payoff (the worst a player
+    can be forced to by the others). For a 2-player PD this is just `g.P`
+    (the row player can be made to earn `P` if the column always defects).
+    Type-forced via `≥ g.P` (no cited constants). -/
+def IndividuallyRational (g : PrisonersDilemma) (u_row u_col : ℝ) : Prop :=
+  u_row ≥ g.P ∧ u_col ≥ g.P
+
+/-- Feasibility: a payoff vector is achievable as the expected payoff of
+    some distribution over joint actions. In a 2x2 PD the feasible set is the
+    convex hull of the four payoff profiles `(R, R), (S, T), (T, S), (P, P)`,
+    characterized by non-negative weights summing to one. Type-forced: the
+    formulas `g.R`, `g.S`, `g.T`, `g.P` are projections of the `PrisonersDilemma`
+    structure, not external numerical data. -/
+def Feasible (g : PrisonersDilemma) (u_row u_col : ℝ) : Prop :=
+  ∃ pCC pCD pDC pDD : ℝ,  -- probability weights summing to 1
+    pCC + pCD + pDC + pDD = 1 ∧
+    pCC ≥ 0 ∧ pCD ≥ 0 ∧ pDC ≥ 0 ∧ pDD ≥ 0 ∧
+    u_row = pCC * g.R + pCD * g.S + pDC * g.T + pDD * g.P ∧
+    u_col = pCC * g.R + pCD * g.T + pDC * g.S + pDD * g.P
+
+/-- The DISCOUNTED Folk theorem (Fudenberg–Maskin 1986, simplified for 2x2):
+
+      For every strictly individually rational feasible payoff `u`,
+      there exists δ* < 1 and a strategy profile such that for all δ ≥ δ*
+      the unique subgame-perfect equilibrium payoff is `u`.
+
+    `sorry` (STRETCH) — requires convexity + extreme-point machinery; BG
+    prover priority LOW (cf Issue #4880 closing criteria 1, only
+    `grim_trigger_sustains_iff` is required). The hard direction is the
+    existence of the strategy profile given the polytope constraints;
+    Fudenberg–Maskin 1986 proof spans several pages and is not a one-tactic
+    matter. -/
+theorem folk_theorem_discounted (g : PrisonersDilemma) :
+    ∀ (u_row u_col : ℝ),
+      IndividuallyRational g u_row u_col →
+      Feasible g u_row u_col →
+      u_row > g.P ∧ u_col > g.P →  -- strict IR
+      ∃ (δ_star : ℝ), δ_star < 1 ∧
+        ∀ (d : ℝ), d ≥ δ_star →
+          ∃ (_stratProfile : List (PDAction × PDAction) → PDAction × PDAction),
+            True := by
+  sorry
+
+/-- A degenerate corollary: when δ = 0, the only subgame-perfect equilibrium
+    of the repeated PD is the one-shot Nash equilibrium (defect, defect),
+    yielding payoff (P, P). This is the boundary case of the Folk theorem and
+    helps anchor the construction (the proof elides to a 1-stage argument).
+    Trivial and proven: the hypothesis is discharged directly. -/
+theorem folk_theorem_boundary (g : PrisonersDilemma) :
+    True := by trivial
+
+end RepeatedGames_en


### PR DESCRIPTION
## i18n(#4980): add `RepeatedGames.Folk_en` — EN sibling, repeated_games_lean (content 4/4 complete)

English mirror of `RepeatedGames/Folk.lean` (FR-first canonical). Convention i18n Lean ratifiée ai-01 (2026-07-04, #4980 comment-4881909354) : distincts FR + EN siblings dans le même lake, les deux compilent ; contenu non-docstring byte-identique (drift-CI detectable).

### Pattern — replicates the WORKING GrimTrigger_en sibling

Not a namespace-fix (unlike the social_choice trilogy) — a **creation** that follows the proven working sibling in the same lake:

```lean
namespace RepeatedGames_en
open RepeatedGames          -- expose FR shared types PrisonersDilemma, PDAction (Stage.lean)
-- body byte-identical to FR Folk.lean
end RepeatedGames_en
```

**Why this is safe (NOT the Lattice_en trap)** : `g.P`/`g.R`/`g.S`/`g.T` are **structure-field access** on `PrisonersDilemma` (a structure in Stage.lean), not namespace dot-notation on a function defined in a sibling namespace. Field projections resolve via the structure definition once the type is in scope (`open RepeatedGames`) — they don't require the projection to live in `RepeatedGames_en`. This is the exact same safety profile as GrimTrigger_en (builds SUCCESS, the model for this PR).

`open PDAction` intentionally NOT added : Folk uses `PDAction` only as a **type** (`List (PDAction × PDAction) → PDAction × PDAction`), not its constructors — `open RepeatedGames` alone resolves it. Verified firsthand (builds either way; omitted for maximal FR byte-identity, since FR Folk has no `open PDAction`).

### Code diff vs FR Folk.lean (non-docstring)

EXACTLY 5 lines, all namespace/import resolution :
```
-import RepeatedGames.Discounting     +import RepeatedGames.Discounting_en
-import RepeatedGames.GrimTrigger     +import RepeatedGames.GrimTrigger_en
-namespace RepeatedGames              +namespace RepeatedGames_en
                                     +open RepeatedGames          (minimal add)
-end RepeatedGames                    +end RepeatedGames_en
```
Docstrings translated FR → EN (per convention). **Code/proofs byte-identical.**

### STRETCH sorry preserved (NOT a regression)

`folk_theorem_discounted` (L107) carries `sorry` — Fudenberg–Maskin polytope topology, **OUT of scope** per Issue #4880 closing criteria 1 (only `grim_trigger_sustains_iff` is required ; BG prover LOW priority). This is documented stretch scaffolding, byte-identical to FR Folk.lean at the same site.

**Sorry parity verified firsthand** : FR=5 / EN=5 (no regression). `folk_theorem_boundary` is proven (`trivial`).

### Verification (lean-merge-discipline HARD)

```
$ lake.exe build RepeatedGames.Folk_en
Build completed successfully (2949 jobs), exit 0
```
| Check | Result |
|-------|--------|
| `lake build RepeatedGames.Folk_en` | **SUCCESS** (2949 jobs) |
| sorry count FR vs EN | 5 = 5 (parity, no regression) |
| post-rebase build (against fresh main) | SUCCESS (2949 jobs) |
| FR `Folk.lean` | byte-identical to main (0 changes, anti-regression D) |
| Build warnings | byte-identical to FR (sorry L107 + unused `g` L123) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — repeated_games_lean content rollout 4/4

| File | _en sibling | PR |
|------|-------------|-----|
| `Stage.lean` | ✅ Stage_en | (existing) |
| `Discounting.lean` | ✅ Discounting_en | (existing) |
| `GrimTrigger.lean` | ✅ GrimTrigger_en | (existing) |
| `Folk.lean` | ✅ **Folk_en** | **this PR** |

Content rollout complete (4/4). Only the umbrella `RepeatedGames.lean` (48L, pure imports) remains without an _en entry-point — a separate trivial tranche if the globs require it.

After this PR merges, `repeated_games_lean` has all content files bilingually compiled → globs `RepeatedGames.*` build clean fleet-wide (one of the lakes unblocked once the c.219 `_en` fixes land).

See #4980
See #4208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
