### PR TITLE
fix(lean): stable_marriage Lattice_en — open StableMarriage + import Lattice (See #4980 #5479)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/Lattice_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/Lattice_en.lean
@@ -32,6 +32,7 @@ import Mathlib.Data.Fin.VecNotation
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Tactic.Common
 import StableMarriage.Definitions
+import StableMarriage.Lattice
 
 /-
   Stable Marriage - Lattice Structure on Stable Matchings (EN sibling)
@@ -52,6 +53,7 @@ import StableMarriage.Definitions
 namespace StableMarriage_en
 
 open Function Finset Classical
+open StableMarriage
 
 variable {n : Nat} [NeZero n] (prof : PrefProfile n)
 


### PR DESCRIPTION
## Contexte

Issue #4980 (i18n FR+EN siblings Lean, axe E #4208) — PRs tranches créent des
siblings EN pour les fichiers FR canoniques. PR #5507 (tranche 9, c.242) a
corrigé le typo `end StableMarriage` → `end StableMarriage_en` dans
`GaleShapley_en.lean` L171 mais PR #5479 (globs `.submodules` dans lakefile
stable_marriage_lean) échoue **toujours** Lake build avec l'erreur :

```
Some required targets logged failures: StableMarriage.GaleShapley_en, StableMarriage.Lattice_en
```

(job CI [`85271435397`](https://github.com/jsboige/CoursIA/actions/runs/28759176395/job/85271435397),
échec confirmé 2m23s, exit 1).

## Cause racine — DEUX problèmes cumulatifs dans `Lattice_en.lean`

Diagnostic Sonnet subagent `a09a1d0824e3cda43` (model: sonnet, async, c.244).
Livrable : [scratchpad/Lattice_en_diagnostic.md](https://github.com/) (en
attendant publication ai-01).

### PB 1 (primaire) — Manque `open StableMarriage` dans le préambule EN

- L52-56 de `Lattice_en.lean` (vérifié sur main) :
  ```lean
  namespace StableMarriage_en

  open Function Finset Classical

  variable {n : Nat} [NeZero n] (prof : PrefProfile n)
  ```
- `PrefProfile`, `Matching`, `IsStable`, `IsBlockingPair`, `IsManOptimal`,
  `ManPrefers`, `WomanPrefers` sont définis dans `namespace StableMarriage` de
  `Definitions.lean` (L36 `structure PrefProfile`, L84 `structure Matching`,
  L105/L113/L120 prédicats). Lean 4 n'ouvre **pas** automatiquement
  `StableMarriage` quand on entre dans `namespace StableMarriage_en` — deux
  namespaces plats distincts. Sans `open StableMarriage`, ces noms courts
  sont **unknown identifier**.
- **Comparaison FR canonique** : `Lattice.lean` L41 `namespace StableMarriage`
  (le namespace courant contient les types) → résolution native des noms courts.
  Le EN sibling a perdu cette propriété en changeant de namespace.

### PB 2 (pattern L51) — Méthodes `Matching.xxx` en namespace EN ≠ FR

- L255, L264, L389, L480 de `Lattice_en.lean` :
  ```lean
  noncomputable def Matching.joinSpouse (μ ν : Matching n) (m : Fin n) : Fin n := ...
  noncomputable def Matching.meetSpouse (μ ν : Matching n) (m : Fin n) : Fin n := ...
  noncomputable def Matching.join (hμ : IsStable prof μ) (hν : IsStable prof ν) : Matching n where ...
  noncomputable def Matching.meet (hμ : IsStable prof μ) (hν : IsStable prof ν) : Matching n where ...
  ```
- Dans `namespace StableMarriage_en`, `def Matching.joinSpouse` crée
  `StableMarriage_en.Matching.joinSpouse`. La **dotted notation** `μ.joinSpouse prof ν m`
  (utilisée ~30 fois) résout par le **TYPE** de `μ`. Le type `Matching` est
  `StableMarriage.Matching` (FR canonique). Lean cherche `StableMarriage.Matching.joinSpouse`,
  qui **n'existe pas** dans l'environnement de `Lattice_en.lean` (le fichier n'importe
  pas `StableMarriage.Lattice`). **Pattern L51 confirmé** : "Lean dotted notation
  resolves by TYPE name". Définir une méthode dans le namespace EN ne la rend pas
  accessible via dotted sur un type du namespace FR.

## Fix proposé — 2L (import + open)

```diff
--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/Lattice_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/Lattice_en.lean
@@ -32,6 +32,7 @@ import Mathlib.Data.Fin.VecNotation
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Tactic.Common
 import StableMarriage.Definitions
+import StableMarriage.Lattice

@@ -52,6 +53,7 @@
 namespace StableMarriage_en

 open Function Finset Classical
+open StableMarriage
```

**Résolution** :
- `import StableMarriage.Lattice` rend `StableMarriage.Matching.joinSpouse/...`
  disponibles dans l'environnement de `Lattice_en.lean` → la dotted `μ.joinSpouse`
  résout correctement vers `StableMarriage.Matching.joinSpouse` (du FR canonique
  `Lattice.lean`).
- `open StableMarriage` expose les noms courts `PrefProfile`, `Matching`,
  `IsStable`, `IsBlockingPair`, `IsManOptimal`, `ManPrefers`, `WomanPrefers`.

**Effet collatéral anticipé** : les redéfinitions locales
`def Matching.joinSpouse/...` (L255/L264/L389/L480) deviennent du **dead code**
(la dotted notation préfère la version FR canonique via import). Warning linter
potentiel mais **pas FAIL** — namespaces distincts (`StableMarriage_en.Matching.*`
vs `StableMarriage.Matching.*`), pas de conflit de nom.

**Convention i18n** : le EN sibling devient dépendant du FR canonique Lattice.lean
(non plus un miroir autonome), mais la convention "contenu non-docstring byte-
identical entre siblings" reste préservée (aucune preuve ni statement modifiée —
seul le préambule change).

## Vérifications

- **R3 strict symétrique** : `1 file changed, 2 insertions(+), 0 deletions(-)`
  (toute modification positive, pas d'effacement).
- **LF préservé** : fichier en CRLF, vérifié `b'\r\n' count = 900 (898 + 2 nouvelles),
  0 CR-only`. Sed one-shot Python (anti-L35 Edit Windows flip LF→CRLF).
- **R8 anti-régression** : `grep -c sorry Lattice_en.lean` AVANT=3, APRÈS=3.
  Aucune preuve touchée. Les 3 `sorry` historiques (L154/L165/L796) sont
  commentaires du FR canonique. 33 lemmes/théorèmes en miroir FR↔EN byte-
  identiques hors préambule.
- **C151 self-check** : `gh pr list --search "Lattice_en"` → 0 doublon (seulement
  #5479 lakefile globs, distinct concern).
- **Anti-bundle L34** : PR 1 concern = 1 fix imports = distinct de #5479 (lakefile
  globs = autre concern). Pattern L85 (namespace/import fix standalone 1-2L avant
  activation globs).

## Note importante — GaleShapley_en.lean FAIL (même racine)

Le job CI mentionne aussi `StableMarriage.GaleShapley_en` en failure.

- **Typo L171** : `namespace StableMarriage_en` (L49) ouvert, `end StableMarriage`
  (L171) fermé — mismatch (cf L84 c.242). **Corrigé par PR #5507** (MERGEABLE
  CLEAN, c.242), mais **PR #5507 ne corrige PAS le PB 1** ni le PB 2 de
  `GaleShapley_en.lean`.
- `GaleShapley_en.lean` L51 `open Function` — manque `open StableMarriage`.
  `PrefProfile`, `Matching`, `IsStable` donc inaccessibles.
- La typo `end` corrigée par #5507 ne suffit pas : il faudra un fix similaire
  (ajout `open StableMarriage` + potentiel import) dans GaleShapley_en.lean aussi.
  **Sujet de PR dédiée séparée après vérification Sonnet** —

## Conformité règles

- **L34 C151 anti-bundle** : 1 PR = 1 fichier = 2 lignes = 1 concern (preamble
  imports Lattice_en).
- **L35 anti-flip LF→CRLF** : sed one-shot Python (L67), `data.count(b'\r\n')`
  validé 900 = pristine.
- **L43 `git commit -F <file>`** : apostrophes FR protégées.
- **L50 `--body-file <path>`** : backticks FR protégés.
- **L51 dotted notation leçon** : confirmée sur Lattice_en (`Matching.*` method
  dotted sur type FR canonical).
- **L67 sed one-shot Python** : appliqué pour les 2 lignes.
- **L77 dashboard firsthand** : vérifié que `mergeable: MERGEABLE` + UNSTABLE
  (incohérence GitHub) = Lake FAIL réel sur job `85271435397`.
- **L83 branche obsolète** : cette PR sur branche fraîche dédiée `fix/c245-...`.
- **L84 typo `end <namespace>`** : confirmée sur GaleShapley_en (résolue par
  #5507), Lattice_en namespace balanced OK L52/L898.
- **L85 namespace/import fix standalone PR avant globs** : pattern respecté.
- **L89 Sonnet subagent pattern** : token economy z.ai/GLM ne bloque PAS
  recherche Lean.
- **G.1 verify-before-claiming** : Sonnet a explicitement réfuté la prémisse
  initiale du task (`gsStep`/`gsRunSteps` 0 hit dans Lattice_en.lean), identifié
  la vraie cause (PB 1 + PB 2).
- **B.2 Lean proofs (cf pr-review-discipline §B)** : PR ne touche pas une preuve
  (seulement préambule imports), pas d'obligation `grep sorry` dans le body —
  le R8 anti-régression est inclus quand même comme preuve de non-régression.
- **R8 anti-régression** : aucune ligne de preuve touchée.

## Liens

- Issue : **#4980** (i18n Lean FR+EN siblings)
- PR débloquée : **#5479** (lakefile globs stable_marriage_lean .submodules)
- Diagnostic Sonnet : `Lattice_en_diagnostic.md` (scratchpad po-2026, c.244)
- Convention i18n ratifiée : ai-01 (2026-07-04, #4980 comment-4881909354)
- Sibling FR canonique inchangé : `StableMarriage/Lattice.lean`
- PR antérieure : **#5507** (fix typo `end StableMarriage_en` GaleShapley_en, c.242)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
