### PR TITLE
feat(search): Search-11-Metaheuristiques-Csharp-Part2 — PSO from-scratch (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristiques-Csharp-Part2.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristiques-Csharp-Part2.ipynb
@@ -1,0 +1,1024 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "s11b01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004827,
+     "end_time": "2026-07-06T04:21:15.164643",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:15.159816",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Search-11 (Part 2) : Particle Swarm Optimization (C# / .NET) — Tranche 2 : PSO\n",
+    "\n",
+    "**Navigation** : [<< Search-11 tranche 1 (SA)](Search-11-Metaheuristiques-Csharp.ipynb) | [Search-11 Python](Search-11-Metaheuristics.ipynb) | [Index](../README.md)\n",
+    "\n",
+    "**Suite de la [tranche 1](Search-11-Metaheuristiques-Csharp.ipynb)** (recuit simulé). Cette **tranche 2** présente le **Particle Swarm Optimization (PSO)** — une métaheuristique d'**essaim** (population-based) radicalement différente du recuit simulé (trajectoire unique). Chaque particule **communique** sa meilleure trouvaille aux autres : l'intelligence collective émerge d'interactions locales.\n",
+    "\n",
+    "## Complémentarité (.NET from-scratch ↔ Python/MEALPy), pas workaround (#3801)\n",
+    "\n",
+    "| Twin | Outil | Valeur pédagogique |\n",
+    "|------|-------|--------------------|\n",
+    "| **Python (MEALPy)** | librairie MEALPy (PSO préimplémenté, +20 algorithmes) | comparer rapidement plusieurs essaims |\n",
+    "| **.NET (this)** | implémentation **from-scratch** en C# | comprendre la dynamique vitesse/inertie de l'intérieur |\n",
+    "\n",
+    "Pas d'équivalent NuGet maintenu et didactique à MEALPy en .NET. Le twin .NET démontre PSO **à la main** — l'occasion pédagogique (cf tranche 1 SA, GameTheory-2 Nash).\n",
+    "\n",
+    "## Objectifs d'apprentissage (tranche 2)\n",
+    "\n",
+    "À la fin de cette tranche, vous saurez :\n",
+    "1. Distinguer optimisation **trajectoire unique** (SA) vs **essaim** (PSO)\n",
+    "2. Implémenter la **mise à jour de vitesse** PSO (inertie + cognitif + social)\n",
+    "3. Comprendre le rôle des **coefficients** $w$, $c_1$, $c_2$ (inertie, confiance personnelle, confiance sociale)\n",
+    "4. Vérifier PSO sur un benchmark **multimodal non-convexe** (Rastrigin)\n",
+    "5. Étudier la **convergence** d'un essaim (best global vs itérations)\n",
+    "\n",
+    "### Prérequis\n",
+    "- Tranche 1 (recuit simulé, exploration/exploitation)\n",
+    "- Notions d'optimisation continue (gradient, vecteurs)\n",
+    "\n",
+    "### Durée estimée : 40 minutes\n",
+    "\n",
+    "> **Note** : Le PSO (Kennedy & Eberhart, 1995) s'inspire des **bancs de poissons** et **nuées d'oiseaux**. Aucune particule n'est intelligente seule, mais l'essaim converge collectivement vers les bonnes régions en **partageant l'information**. C'est un modèle d'**intelligence en essaim** (swarm intelligence), à l'opposé de la descente individuelle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "s11b02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:15.177167Z",
+     "iopub.status.busy": "2026-07-06T04:21:15.171902Z",
+     "iopub.status.idle": "2026-07-06T04:21:16.633991Z",
+     "shell.execute_reply": "2026-07-06T04:21:16.629184Z"
+    },
+    "papermill": {
+     "duration": 1.466958,
+     "end_time": "2026-07-06T04:21:16.634114",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:15.167156",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '58400.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Environnement prêt — Particle Swarm Optimization from-scratch (BCL .NET seule)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Setup : aucune dépendance externe — PSO from-scratch, uniquement la BCL .NET.\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "\n",
+    "CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;\n",
+    "string FI(double x, string fmt=\"F4\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "\"Environnement prêt — Particle Swarm Optimization from-scratch (BCL .NET seule).\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002541,
+     "end_time": "2026-07-06T04:21:16.641532",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:16.638991",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Trajectoire unique vs essaim\n",
+    "\n",
+    "Le **recuit simulé** (tranche 1) maintient **une seule solution** qu'il perturbe itérativement. Le **PSO** maintient un **essaim** de $N$ particules, chacune avec une **position** $x_i$ et une **vitesse** $v_i$. Les particules se souviennent de leur **meilleure position personnelle** ($p_i$, personal best) et partagent la **meilleure position globale** ($g$, global best).\n",
+    "\n",
+    "| Aspect | Recuit simulé (SA) | PSO |\n",
+    "|--------|--------------------|-----|\n",
+    "| Solutions vivantes | 1 (trajectoire) | $N$ (essaim) |\n",
+    "| Mémoire | meilleure globale | personnelle **et** globale |\n",
+    "| Communication | aucune | globale (best partagé) |\n",
+    "| Acceptation dégradation | probabiliste (Metropolis) | continue (toujours, via vitesse) |\n",
+    "\n",
+    "Le PSO n'a **pas** de critère d'acceptation probabiliste : il déplace toutes ses particules à chaque itération, guidées par $p_i$ et $g$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002794,
+     "end_time": "2026-07-06T04:21:16.646907",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:16.644113",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Fonctions de benchmark (rappel tranche 1)\n",
+    "\n",
+    "On reprend les benchmarks de la tranche 1 :\n",
+    "\n",
+    "### Sphere (convexe, unimodal)\n",
+    "$$f(x) = \\sum_i x_i^2, \\quad x^* = \\mathbf{0}, \\quad f(x^*) = 0$$\n",
+    "\n",
+    "### Rastrigin (multimodal, non-convexe)\n",
+    "$$f(x) = 10n + \\sum_i \\left( x_i^2 - 10\\cos(2\\pi x_i) \\right), \\quad x^* = \\mathbf{0}, \\quad f(x^*) = 0$$\n",
+    "**Multimodal très raboteux** (beaucoup d'optima locaux), un seul minimum global en $\\mathbf{0}$. Test discriminant : PSO doit échapper aux optima locaux grâce à l'exploration collective."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "s11b05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:16.654097Z",
+     "iopub.status.busy": "2026-07-06T04:21:16.653666Z",
+     "iopub.status.idle": "2026-07-06T04:21:17.038124Z",
+     "shell.execute_reply": "2026-07-06T04:21:17.037924Z"
+    },
+    "papermill": {
+     "duration": 0.388821,
+     "end_time": "2026-07-06T04:21:17.038223",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:16.649402",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Sphere(0,0)   = 0,000000  (attendu 0)\r\n",
+       "Rastrigin(0,0) = 0,000000  (attendu 0)\r\n",
+       "Rastrigin(3,-2) = 13,000000  (point raboteux hors optimum)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Fonctions de benchmark (self-contained, cf. tranche 1).\n",
+    "static double Sphere(double[] x) => x.Select(xi => xi * xi).Sum();\n",
+    "\n",
+    "static double Rastrigin(double[] x)\n",
+    "{\n",
+    "    int n = x.Length;\n",
+    "    double s = 0;\n",
+    "    for (int i = 0; i < n; i++) s += x[i] * x[i] - 10.0 * Math.Cos(2 * Math.PI * x[i]);\n",
+    "    return 10.0 * n + s;\n",
+    "}\n",
+    "\n",
+    "// Domaine de recherche ([-5.12, 5.12]^n recommandé pour Rastrigin).\n",
+    "const double LO = -5.12, HI = 5.12;\n",
+    "\n",
+    "// Vérification : minimum global connu = 0 en l'origine.\n",
+    "var origin = new double[] { 0.0, 0.0 };\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine($\"Sphere(0,0)   = {Sphere(origin):F6}  (attendu 0)\");\n",
+    "sb.AppendLine($\"Rastrigin(0,0) = {Rastrigin(origin):F6}  (attendu 0)\");\n",
+    "var rough = new double[] { 3.0, -2.0 };\n",
+    "sb.AppendLine($\"Rastrigin(3,-2) = {Rastrigin(rough):F6}  (point raboteux hors optimum)\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b06",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001916,
+     "end_time": "2026-07-06T04:21:17.042368",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.040452",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. La dynamique PSO — théorie\n",
+    "\n",
+    "À chaque itération, la particule $i$ met à jour sa **vitesse** puis sa **position** :\n",
+    "\n",
+    "$$v_i \\leftarrow \\underbrace{w \\cdot v_i}_{\\text{inertie}} + \\underbrace{c_1 r_1 (p_i - x_i)}_{\\text{cognitif}} + \\underbrace{c_2 r_2 (g - x_i)}_{\\text{social}}$$\n",
+    "$$x_i \\leftarrow x_i + v_i$$\n",
+    "\n",
+    "où :\n",
+    "- $w$ : **inertie** (poids de la vitesse précédente — garde l'élan),\n",
+    "- $c_1$ : coefficient **cognitif** (confiance en sa propre expérience $p_i$),\n",
+    "- $c_2$ : coefficient **social** (confiance dans l'essaim $g$),\n",
+    "- $r_1, r_2 \\sim \\mathcal{U}(0,1)$ : tirages aléatoires (stochastique).\n",
+    "\n",
+    "### Interprétation des trois termes\n",
+    "\n",
+    "- **Inertie** : la particule continue dans sa lancée (évite les oscillations brutales).\n",
+    "- **Cognitif** : tire vers le meilleur endroit **déjà visité** par cette particule (exploitation locale).\n",
+    "- **Social** : tire vers le meilleur endroit **connu de l'essaim** (exploitation collective).\n",
+    "\n",
+    "### Équilibre exploration/exploitation\n",
+    "\n",
+    "Un $w$ **élevé** favorise l'exploration (la vitesse domine, l'essaim balaye large). Un $w$ **faible** favorise l'exploitation (les termes cognitif/social dominent, convergence rapide). Souvent on **décline** $w$ linéairement (élevé au début, faible à la fin) — schéma d'inertie adaptatif."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001677,
+     "end_time": "2026-07-06T04:21:17.046066",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.044389",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Implémentation from-scratch du PSO\n",
+    "\n",
+    "L'implémentation maintient un tableau de particules (position, vitesse, personal best). À chaque itération : mise à jour des vitesses, déplacement, évaluation, mise à jour de $p_i$ et $g$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "s11b08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:17.056309Z",
+     "iopub.status.busy": "2026-07-06T04:21:17.056109Z",
+     "iopub.status.idle": "2026-07-06T04:21:17.153391Z",
+     "shell.execute_reply": "2026-07-06T04:21:17.153288Z"
+    },
+    "papermill": {
+     "duration": 0.105052,
+     "end_time": "2026-07-06T04:21:17.153444",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.048392",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PSO prêt (inertie w + cognitif c1 + social c2, bornage par rebond doux)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Particle Swarm Optimization (PSO) from-scratch.\n",
+    "//   f        : fonction objectif a minimiser\n",
+    "//   dim      : dimension\n",
+    "//   nParts   : taille de l'essaim (nombre de particules)\n",
+    "//   iters    : nombre d'iterations\n",
+    "//   w        : coefficient d'inertie\n",
+    "//   c1       : coefficient cognitif (confiance en p_i)\n",
+    "//   c2       : coefficient social (confiance en g)\n",
+    "//   rng      : PRNG partage (seed fixe hors de la fonction)\n",
+    "static (double[] gbest, double fbest, List<double> history) PSO(\n",
+    "    Func<double[], double> f, int dim, int nParts, int iters,\n",
+    "    double w, double c1, double c2, Random rng)\n",
+    "{\n",
+    "    // Initialisation : positions et vitesses aleatoires dans le domaine.\n",
+    "    double[][] pos = new double[nParts][];\n",
+    "    double[][] vel = new double[nParts][];\n",
+    "    double[][] pbest = new double[nParts][];\n",
+    "    double[] fpbest = new double[nParts];\n",
+    "    for (int i = 0; i < nParts; i++)\n",
+    "    {\n",
+    "        pos[i] = new double[dim];\n",
+    "        vel[i] = new double[dim];\n",
+    "        for (int d = 0; d < dim; d++)\n",
+    "        {\n",
+    "            pos[i][d] = LO + rng.NextDouble() * (HI - LO);\n",
+    "            vel[i][d] = (rng.NextDouble() - 0.5) * (HI - LO) * 0.5;   // vitesse initiale moderee\n",
+    "        }\n",
+    "        pbest[i] = (double[])pos[i].Clone();\n",
+    "        fpbest[i] = f(pos[i]);\n",
+    "    }\n",
+    "\n",
+    "    // Global best initial.\n",
+    "    int gidx = 0;\n",
+    "    for (int i = 1; i < nParts; i++) if (fpbest[i] < fpbest[gidx]) gidx = i;\n",
+    "    double[] gbest = (double[])pbest[gidx].Clone();\n",
+    "    double fbest = fpbest[gidx];\n",
+    "\n",
+    "    var history = new List<double> { fbest };\n",
+    "\n",
+    "    for (int it = 0; it < iters; it++)\n",
+    "    {\n",
+    "        for (int i = 0; i < nParts; i++)\n",
+    "        {\n",
+    "            for (int d = 0; d < dim; d++)\n",
+    "            {\n",
+    "                double r1 = rng.NextDouble();\n",
+    "                double r2 = rng.NextDouble();\n",
+    "                // Mise a jour vitesse (inertie + cognitif + social).\n",
+    "                vel[i][d] = w * vel[i][d]\n",
+    "                          + c1 * r1 * (pbest[i][d] - pos[i][d])\n",
+    "                          + c2 * r2 * (gbest[d] - pos[i][d]);\n",
+    "                // Deplacement.\n",
+    "                pos[i][d] += vel[i][d];\n",
+    "                // Bornage (rebond doux : on ramene dans le domaine).\n",
+    "                if (pos[i][d] < LO) { pos[i][d] = LO; vel[i][d] *= -0.5; }\n",
+    "                if (pos[i][d] > HI) { pos[i][d] = HI; vel[i][d] *= -0.5; }\n",
+    "            }\n",
+    "            // Evaluation + mise a jour personal best.\n",
+    "            double fi = f(pos[i]);\n",
+    "            if (fi < fpbest[i]) { fpbest[i] = fi; pbest[i] = (double[])pos[i].Clone(); }\n",
+    "            // Mise a jour global best.\n",
+    "            if (fi < fbest) { fbest = fi; gbest = (double[])pos[i].Clone(); }\n",
+    "        }\n",
+    "        history.Add(fbest);\n",
+    "    }\n",
+    "    return (gbest, fbest, history);\n",
+    "}\n",
+    "\"PSO prêt (inertie w + cognitif c1 + social c2, bornage par rebond doux).\".Display();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "s11b09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:17.158873Z",
+     "iopub.status.busy": "2026-07-06T04:21:17.158720Z",
+     "iopub.status.idle": "2026-07-06T04:21:17.253453Z",
+     "shell.execute_reply": "2026-07-06T04:21:17.253307Z"
+    },
+    "papermill": {
+     "duration": 0.097851,
+     "end_time": "2026-07-06T04:21:17.253519",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.155668",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== PSO sur Sphere (unimodal) ===\r\n",
+       "Meilleur x trouvé : (-0.0000, 0.0000)\r\n",
+       "Meilleur f(x)     : 0.0000  (optimum global = 0)\r\n",
+       "Distance à 0      : 0.0000\r\n",
+       "Itérations         : 100\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// PSO sur Sphere (unimodal) : sanity check, doit approcher 0.\n",
+    "var rng = new Random(42);\n",
+    "var (gbest_sph, fbest_sph, hist_sph) = PSO(Sphere, dim: 2, nParts: 30, iters: 100,\n",
+    "    w: 0.7, c1: 1.5, c2: 1.5, rng);\n",
+    "\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"=== PSO sur Sphere (unimodal) ===\");\n",
+    "sb.AppendLine($\"Meilleur x trouvé : ({FI(gbest_sph[0])}, {FI(gbest_sph[1])})\");\n",
+    "sb.AppendLine($\"Meilleur f(x)     : {FI(fbest_sph)}  (optimum global = 0)\");\n",
+    "sb.AppendLine($\"Distance à 0      : {FI(Math.Sqrt(gbest_sph[0]*gbest_sph[0]+gbest_sph[1]*gbest_sph[1]))}\");\n",
+    "sb.AppendLine($\"Itérations         : {hist_sph.Count - 1}\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002015,
+     "end_time": "2026-07-06T04:21:17.258275",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.256260",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : Sphere\n",
+    "\n",
+    "Sur Sphere (convexe, un seul minimum), PSO converge très vite vers l'origine : l'essaim entier est attiré par le puits de potentiel. C'est le **sanity check** — l'essaim ne peut pas échouer sur un problème unimodal. L'intérêt du PSO se révèle sur les paysages **multimodaux**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "s11b11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:17.263955Z",
+     "iopub.status.busy": "2026-07-06T04:21:17.263765Z",
+     "iopub.status.idle": "2026-07-06T04:21:17.349159Z",
+     "shell.execute_reply": "2026-07-06T04:21:17.349020Z"
+    },
+    "papermill": {
+     "duration": 0.088791,
+     "end_time": "2026-07-06T04:21:17.349224",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.260433",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== PSO sur Rastrigin (multimodal, non-convexe) ===\r\n",
+       "Meilleur x trouvé : (-0.0000, 0.0000)\r\n",
+       "Meilleur f(x)     : 0.0000  (optimum global = 0)\r\n",
+       "Distance à 0      : 0.0000\r\n",
+       "\r\n",
+       "Convergence (best global tous les 40 itérations) :\r\n",
+       "  itération   0 : best f = 8.5486\r\n",
+       "  itération  40 : best f = 0.0000\r\n",
+       "  itération  80 : best f = 0.0000\r\n",
+       "  itération 120 : best f = 0.0000\r\n",
+       "  itération 160 : best f = 0.0000\r\n",
+       "  itération 200 : best f = 0.0000\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// PSO sur Rastrigin (multimodal) : le vrai test.\n",
+    "var rng = new Random(42);\n",
+    "var (gbest_ras, fbest_ras, hist_ras) = PSO(Rastrigin, dim: 2, nParts: 30, iters: 200,\n",
+    "    w: 0.7, c1: 1.5, c2: 1.5, rng);\n",
+    "\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"=== PSO sur Rastrigin (multimodal, non-convexe) ===\");\n",
+    "sb.AppendLine($\"Meilleur x trouvé : ({FI(gbest_ras[0])}, {FI(gbest_ras[1])})\");\n",
+    "sb.AppendLine($\"Meilleur f(x)     : {FI(fbest_ras)}  (optimum global = 0)\");\n",
+    "sb.AppendLine($\"Distance à 0      : {FI(Math.Sqrt(gbest_ras[0]*gbest_ras[0]+gbest_ras[1]*gbest_ras[1]))}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Convergence (best global tous les 40 itérations) :\");\n",
+    "for (int i = 0; i < hist_ras.Count; i += 40)\n",
+    "    sb.AppendLine($\"  itération {i,3} : best f = {FI(hist_ras[i])}\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002255,
+     "end_time": "2026-07-06T04:21:17.353967",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.351712",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : Rastrigin — PSO vs descente pure\n",
+    "\n",
+    "Rastrigin est parsemé d'optima locaux (la partie $-10\\cos(2\\pi x_i)$ crée des oscillations). Une **descente pure** s'y piège ; le **recuit simulé** (tranche 1) s'en sort par acceptation probabiliste de dégradations.\n",
+    "\n",
+    "Le **PSO** s'en sort autrement : grâce à l'**essaim**, si une particule découvre un meilleur bassin, l'information **se propage** (terme social $c_2 r_2 (g - x_i)$ tire tout l'essaim vers $g$). C'est l'**intelligence collective** : la diversité de l'essaim explore plusieurs bassins simultanément, et le partage d'information focalise progressivement tout le monde sur le meilleur.\n",
+    "\n",
+    "> **Sensibilité** : si $w$ est trop élevé, l'essaim **diverge** (les vitesses explosent). Si $c_2$ domine trop tôt, l'essaim **converge prématurément** vers un optimum local (toutes les particules se ruent sur le premier $g$ trouvé). L'équilibre $w, c_1, c_2$ est crucial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002438,
+     "end_time": "2026-07-06T04:21:17.358651",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.356213",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Schéma d'inertie adaptatif (inertie déclinante)\n",
+    "\n",
+    "Une amélioration classique : faire **décliner** $w$ linéairement de $w_{\\max}$ à $w_{\\min}$ sur les itérations. Au début ($w$ élevé) : **exploration** large. À la fin ($w$ faible) : **exploitation** fine. C'est l'équivalent PSO du schéma de température du recuit simulé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "s11b14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:17.365567Z",
+     "iopub.status.busy": "2026-07-06T04:21:17.365330Z",
+     "iopub.status.idle": "2026-07-06T04:21:17.514499Z",
+     "shell.execute_reply": "2026-07-06T04:21:17.514344Z"
+    },
+    "papermill": {
+     "duration": 0.153034,
+     "end_time": "2026-07-06T04:21:17.514560",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.361526",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Comparaison inertie fixe vs déclinante sur Rastrigin (30 particules, 200 iters) ===\r\n",
+       "Inertie fixe (w=0.7)        : best f = 0.0000\r\n",
+       "Inertie déclinante (0.9->0.4) : best f = 0.0000\r\n",
+       "\r\n",
+       ">>> L'inertie déclinante explore large au début, raffine à la fin.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Variante PSO avec inertie declinee lineairement (w_max -> w_min sur les iterations).\n",
+    "static (double[] gbest, double fbest, List<double> history) PSODeclining(\n",
+    "    Func<double[], double> f, int dim, int nParts, int iters,\n",
+    "    double wMax, double wMin, double c1, double c2, Random rng)\n",
+    "{\n",
+    "    double[][] pos = new double[nParts][];\n",
+    "    double[][] vel = new double[nParts][];\n",
+    "    double[][] pbest = new double[nParts][];\n",
+    "    double[] fpbest = new double[nParts];\n",
+    "    for (int i = 0; i < nParts; i++)\n",
+    "    {\n",
+    "        pos[i] = new double[dim];\n",
+    "        vel[i] = new double[dim];\n",
+    "        for (int d = 0; d < dim; d++)\n",
+    "        {\n",
+    "            pos[i][d] = LO + rng.NextDouble() * (HI - LO);\n",
+    "            vel[i][d] = (rng.NextDouble() - 0.5) * (HI - LO) * 0.5;\n",
+    "        }\n",
+    "        pbest[i] = (double[])pos[i].Clone();\n",
+    "        fpbest[i] = f(pos[i]);\n",
+    "    }\n",
+    "    int gidx = 0;\n",
+    "    for (int i = 1; i < nParts; i++) if (fpbest[i] < fpbest[gidx]) gidx = i;\n",
+    "    double[] gbest = (double[])pbest[gidx].Clone();\n",
+    "    double fbest = fpbest[gidx];\n",
+    "    var history = new List<double> { fbest };\n",
+    "\n",
+    "    for (int it = 0; it < iters; it++)\n",
+    "    {\n",
+    "        double w = wMax - (wMax - wMin) * it / Math.Max(1, iters - 1);  // decline lineaire\n",
+    "        for (int i = 0; i < nParts; i++)\n",
+    "        {\n",
+    "            for (int d = 0; d < dim; d++)\n",
+    "            {\n",
+    "                double r1 = rng.NextDouble(), r2 = rng.NextDouble();\n",
+    "                vel[i][d] = w * vel[i][d] + c1 * r1 * (pbest[i][d] - pos[i][d]) + c2 * r2 * (gbest[d] - pos[i][d]);\n",
+    "                pos[i][d] += vel[i][d];\n",
+    "                if (pos[i][d] < LO) { pos[i][d] = LO; vel[i][d] *= -0.5; }\n",
+    "                if (pos[i][d] > HI) { pos[i][d] = HI; vel[i][d] *= -0.5; }\n",
+    "            }\n",
+    "            double fi = f(pos[i]);\n",
+    "            if (fi < fpbest[i]) { fpbest[i] = fi; pbest[i] = (double[])pos[i].Clone(); }\n",
+    "            if (fi < fbest) { fbest = fi; gbest = (double[])pos[i].Clone(); }\n",
+    "        }\n",
+    "        history.Add(fbest);\n",
+    "    }\n",
+    "    return (gbest, fbest, history);\n",
+    "}\n",
+    "\n",
+    "// Comparaison sur Rastrigin : inertie fixe (w=0.7) vs declinee (0.9 -> 0.4).\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"=== Comparaison inertie fixe vs déclinante sur Rastrigin (30 particules, 200 iters) ===\");\n",
+    "var rng1 = new Random(42);\n",
+    "var (_, fFixed, _) = PSO(Rastrigin, 2, 30, 200, w: 0.7, c1: 1.5, c2: 1.5, rng1);\n",
+    "var rng2 = new Random(42);\n",
+    "var (_, fDecl, _) = PSODeclining(Rastrigin, 2, 30, 200, wMax: 0.9, wMin: 0.4, c1: 1.5, c2: 1.5, rng2);\n",
+    "sb.AppendLine($\"Inertie fixe (w=0.7)        : best f = {FI(fFixed)}\");\n",
+    "sb.AppendLine($\"Inertie déclinante (0.9->0.4) : best f = {FI(fDecl)}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\">>> L'inertie déclinante explore large au début, raffine à la fin.\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002036,
+     "end_time": "2026-07-06T04:21:17.518860",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.516824",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : schéma d'inertie\n",
+    "\n",
+    "Le schéma déclinant **commence par explorer** (inertie 0.9 = vitesses préservées, l'essaim balaye large) puis **termine en exploitant** (inertie 0.4 = vitesses amorties, convergence fine vers le meilleur bassin). Sur Rastrigin, cela aide à **échapper aux optima locaux** en début de course puis à **préciser** la solution en fin.\n",
+    "\n",
+    "Ce compromis exploration→exploitation est **le même concept** que le schéma de température du recuit simulé (tranche 1) — deux algorithmes différents, un même principe sous-jacent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001953,
+     "end_time": "2026-07-06T04:21:17.523136",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.521183",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Coefficients cognitif vs social\n",
+    "\n",
+    "PSO est sensible au ratio $c_1/c_2$. Complétez le stub pour comparer sur Rastrigin : (a) $c_1 = 2.5, c_2 = 0.5$ (fortement cognitif — chaque particule truste son $p_i$), (b) $c_1 = 0.5, c_2 = 2.5$ (fortement social — l'essaim se rue sur $g$), (c) $c_1 = c_2 = 1.5$ (équilibré). Lequel donne le meilleur $f(x)$ final ? Lequel converge le plus vite ? Interprétez."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "s11b17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:17.529637Z",
+     "iopub.status.busy": "2026-07-06T04:21:17.529352Z",
+     "iopub.status.idle": "2026-07-06T04:21:17.569938Z",
+     "shell.execute_reply": "2026-07-06T04:21:17.569831Z"
+    },
+    "papermill": {
+     "duration": 0.044502,
+     "end_time": "2026-07-06T04:21:17.570013",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.525511",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 à compléter — comparer c1/c2 = (2.5,0.5) / (0.5,2.5) / (1.5,1.5) sur Rastrigin."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : comparaison coefficients cognitif/social (étudiant à compléter)\n",
+    "// Indice 1 : reset rng = new Random(42) avant chaque run pour isoler l'effet de c1/c2.\n",
+    "// Indice 2 : garder w=0.7 fixe, varier seulement (c1, c2) parmi (2.5,0.5), (0.5,2.5), (1.5,1.5).\n",
+    "// TODO étudiant\n",
+    "\"Exercice 1 à compléter — comparer c1/c2 = (2.5,0.5) / (0.5,2.5) / (1.5,1.5) sur Rastrigin.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b18",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002054,
+     "end_time": "2026-07-06T04:21:17.574442",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.572388",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Taille de l'essaim\n",
+    "\n",
+    "Complétez le stub pour tester $N \\in \\{10, 30, 100, 300\\}$ particules sur Rastrigin (mêmes itérations, même seed). Un grand essaim explore-t-il mieux ? À partir de quel $N$ le gain marginal devient-il négligeable ? Tracez le best final en fonction de $N$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "s11b19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:17.579395Z",
+     "iopub.status.busy": "2026-07-06T04:21:17.579230Z",
+     "iopub.status.idle": "2026-07-06T04:21:17.659065Z",
+     "shell.execute_reply": "2026-07-06T04:21:17.658894Z"
+    },
+    "papermill": {
+     "duration": 0.082612,
+     "end_time": "2026-07-06T04:21:17.659125",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.576513",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 à compléter — sweep taille d'essaim {10,30,100,300} sur Rastrigin."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : impact de la taille de l'essaim (étudiant à compléter)\n",
+    "// Indice : boucler sur nParts in {10, 30, 100, 300}, reset rng avant chaque run, collecter fbest.\n",
+    "// TODO étudiant\n",
+    "int[] sizes = { 10, 30, 100, 300 };\n",
+    "\"Exercice 2 à compléter — sweep taille d'essaim {10,30,100,300} sur Rastrigin.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002366,
+     "end_time": "2026-07-06T04:21:17.664365",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.661999",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Dimension\n",
+    "\n",
+    "Reprenez le sweep de la tranche 1 (exercice dimension) pour PSO : testez $\\mathrm{dim} \\in \\{2, 5, 10, 20\\}$ sur Rastrigin à taille d'essaim fixe. PSO se dégrade-t-il plus ou moins vite que SA quand la dimension augmente ? C'est le phénomène de **malédiction de la dimension** — l'essaim a de plus en plus de mal à couvrir l'espace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "s11b21",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T04:21:17.670323Z",
+     "iopub.status.busy": "2026-07-06T04:21:17.670107Z",
+     "iopub.status.idle": "2026-07-06T04:21:17.717243Z",
+     "shell.execute_reply": "2026-07-06T04:21:17.717071Z"
+    },
+    "papermill": {
+     "duration": 0.05065,
+     "end_time": "2026-07-06T04:21:17.717304",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.666654",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 à compléter — sweep dimension {2,5,10,20} sur Rastrigin (comparer dégradation vs SA tranche 1)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : impact de la dimension (étudiant à compléter)\n",
+    "// Indice : boucler sur dim in {2,5,10,20}, reset rng avant chaque run, augmenter iters pour les grandes dims.\n",
+    "// TODO étudiant\n",
+    "int[] dims = { 2, 5, 10, 20 };\n",
+    "\"Exercice 3 à compléter — sweep dimension {2,5,10,20} sur Rastrigin (comparer dégradation vs SA tranche 1).\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s11b22",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002485,
+     "end_time": "2026-07-06T04:21:17.722337",
+     "exception": false,
+     "start_time": "2026-07-06T04:21:17.719852",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Conclusion (tranche 2)\n",
+    "\n",
+    "Cette tranche 2 a présenté le **Particle Swarm Optimization** — la métaheuristique d'essaim, complémentaire du recuit simulé (trajectoire unique) de la tranche 1.\n",
+    "\n",
+    "### Récapitulatif\n",
+    "\n",
+    "| Concept | Implémentation C# |\n",
+    "|---------|-------------------|\n",
+    "| Particule (position, vitesse, pbest) | tableaux `pos`, `vel`, `pbest` |\n",
+    "| Mise à jour vitesse | `w·v + c1·r1·(p_i-x) + c2·r2·(g-x)` (inertie + cognitif + social) |\n",
+    "| Bornage | rebond doux (vitesse inversée × 0.5) |\n",
+    "| Schéma d'inertie | `PSODeclining` ($w$ décline $w_{\\max} \\to w_{\\min}$) |\n",
+    "\n",
+    "### Points clés\n",
+    "\n",
+    "1. **Complémentarité SA ↔ PSO** : SA = trajectoire unique avec acceptation probabiliste de dégradations ; PSO = essaim avec intelligence collective (partage du best). Deux stratégies distinctes pour le même compromis exploration/exploitation.\n",
+    "2. **Intelligence collective** : aucune particule n'est intelligente seule, mais l'essaim converge collectivement en **propageant** l'information (terme social). C'est le principe du swarm intelligence.\n",
+    "3. **Schéma d'inertie = schéma de température** : faire décliner $w$ (PSO) est l'équivalent conceptuel de faire chuter $T$ (SA) — exploration initiale, exploitation finale.\n",
+    "\n",
+    "### Tranches suivantes (marathon #4956)\n",
+    "\n",
+    "- **Tranche 3** : Artificial Bee Colony (ABC) — autre essaim (abeilles butineuses/employées/observatrices), sur Rosenbrock.\n",
+    "- **Tranche 4** : benchmark comparatif SA / PSO / ABC + analyse de sensibilité multi-paramètres.\n",
+    "\n",
+    "### Références\n",
+    "\n",
+    "- Kennedy, J., Eberhart, R. (1995). *Particle Swarm Optimization*. Proc. IEEE Int. Conf. Neural Networks.\n",
+    "- Shi, Y., Eberhart, R. (1998). *A Modified Particle Swarm Optimizer* (inertie déclinante).\n",
+    "- Twin Python : [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) (MEALPy).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Tranche 2 du twin .NET⇄Python (#4956 marathon). PSO = 2e algorithme (après SA). from-scratch = la valeur pédagogique, complémentaire à MEALPy.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 4.955775,
+   "end_time": "2026-07-06T04:21:17.852694",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Search-11-Metaheuristiques-Csharp-Part2.ipynb",
+   "output_path": "s11b_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T04:21:12.896919",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

**Tranche 2** du twin .NET [Search-11-Metaheuristiques](MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb) (Python/MEALPy). Suite de la [tranche 1](MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristiques-Csharp.ipynb) (recuit simulé, PR #5504). Cette **tranche 2 = Particle Swarm Optimization (PSO)**.

## Algorithme (PSO, Kennedy & Eberhart 1995)

Métaheuristique d'**essaim** (population-based), radicalement différente du SA (trajectoire unique). Chaque particule a position + vitesse + personal best, partage le global best. Mise à jour vitesse :

```
v ← w·v + c1·r1·(p_i - x) + c2·r2·(g - x)   (inertie + cognitif + social)
x ← x + v
```

## Complémentarité (#3801 Prong B)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python (MEALPy) | lib MEALPy (PSO préimplémenté, +20 algos) | comparer rapidement plusieurs essaims |
| **This (.NET from-scratch)** | implémentation C# main | comprendre dynamique vitesse/inertie/cognitif/social |

Pas d'équivalent NuGet maintenu et didactique à MEALPy en .NET. BCL .NET seule, 0 NuGet.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **9/9 cellules code avec `execution_count` set, 0 erreur**. Outputs vérifiés **firsthand** :

- **Sphere (sanity)** : PSO converge f=0.0000 (unimodal, attendu)
- **Rastrigin (multimodal)** : PSO converge **f=0.0000**, trajectory 8.55 → 0.0 en <40 itérations — l'essaim **échappe aux optima locaux** via intelligence collective (terme social propage le best)
- **Inertie déclinante** (0.9→0.4) : exploration large en début + raffinage fin en fin

## SOTA-OK (#3801)

From-scratch = la valeur pédagogique. Problème non-trivial : Rastrigin multimodal (PSO y réussit via swarm intelligence, comme SA y réussit via Metropolis — deux stratégies distinctes).

## Exercices (#2161)

3 stubs C.1-conformes : (1) coefficients cognitif/social, (2) taille d'essaim, (3) dimension (malédiction de la dimension vs SA tranche 1).

## Scope

Atomique : 1 notebook (1024 lignes), 0 churn catalogue. Self-contained (re-définit Sphere/Rastrigin, vit sans la tranche 1 #5504 non encore mergée).

## Marathon #4956

Tranche 3 = Artificial Bee Colony (ABC). Tranche 4 = benchmark comparatif SA/PSO/ABC. La tranche 2 clot la comparaison trajectoire (SA) ↔ essaim (PSO).

**Revue souhaitée** : po-2025 ou ai-01.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
