### PR TITLE
fix(lean): stable_marriage GaleShapley_en — open StableMarriage + end typo (See #4980 #5479)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/GaleShapley_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/GaleShapley_en.lean
@@ -48,7 +48,8 @@ import StableMarriage.Lattice
 
 namespace StableMarriage_en
 
-open Function
+open Function Finset Classical
+open StableMarriage
 
 variable {n : Nat} [NeZero n]
 
@@ -168,4 +169,4 @@ theorem gale_shapley_woman_pessimal (prof : PrefProfile n)
     rw [hm'def, hinv_eq] at hgt
     exact Nat.lt_irrefl _ (mod_cast hgt)
 
-end StableMarriage
+end StableMarriage_en


### PR DESCRIPTION
## Contexte

Issue #4980 (i18n FR+EN siblings Lean, axe E #4208) — PRs tranches créent
des siblings EN pour les fichiers FR canoniques. PR #5507 (c.242) a corrigé
le typo `end StableMarriage` → `end StableMarriage_en` dans
`GaleShapley_en.lean` L171 MAIS ne corrigeait pas le PB 1 (namespace
résolution). PR #5514 (c.245) a corrigé Lattice_en.lean avec Option B 2L
(`import StableMarriage.Lattice` + `open StableMarriage`) — **Lake build
SUCCESS** confirmé c.246 (job CI `85294765989` 04:24Z).

PR #5479 (lakefile globs `.submodules` stable_marriage_lean) échoue Lake
build avec erreur :

```
Some required targets logged failures: StableMarriage.GaleShapley_en
```

(GaleShapley_en est un des 4 fichiers du globs : Basic + Basic_en + Shapley
+ Shapley_en + GaleShapley_en + Lattice_en).

## Cause racine — `open StableMarriage` manquant

Diagnostic Sonnet subagent `ada16ec4946696fca` (model: sonnet, async, c.246)
identifie **2 bugs cumulatifs** dans `GaleShapley_en.lean` :

### PB 1 (primaire) — Manque `open StableMarriage` dans le préambule EN

- L49-53 de `GaleShapley_en.lean` (vérifié sur main `fcd064df5`) :
  ```lean
  namespace StableMarriage_en

  open Function

  variable {n : Nat} [NeZero n]
  ```
- ~40 sites de référence en short-name échouent : types (`PrefProfile`,
  `Matching`, `IsStable`, `IsManOptimal`, `IsBlockingPair`, `GSConsistent`)
  en annotations + noms courts de fonctions/lemmas (`gsRunSteps`,
  `gsTerminated*`, `spouse_inverse`, `exists_isManOptimal`) en corps de
  preuves.
- **Comparaison FR canonique** : `GaleShapley.lean` `namespace StableMarriage`
  (le namespace courant contient les types) → résolution native des noms
  courts. Le EN sibling a perdu cette propriété en changeant de namespace.

### PB 3 (typo, L84 c.242) — `end StableMarriage` ne matche pas le namespace ouvert

- L171 de `GaleShapley_en.lean` :
  ```lean
  end StableMarriage    ← TYPO : devrait être end StableMarriage_en
  ```
- Leçon L84 : bug dormant activé par les globs `#5479` qui compilent enfin
  le EN sibling. PR #5507 (c.242, OPEN MERGEABLE typo-only) couvre ce
  PB 3 mais pas le PB 1.

### Simplification vs Lattice_en (cf #5514 c.245)

`GaleShapley_en.lean` n'a **aucune** `def Matching.xxx` ni `def PrefProfile.xxx`
locale (grep 0 hit). Pas de dotted-notation-piège type Lattice_en. Imports
déjà complets (`import StableMarriage.{Definitions,Lemmas,Lattice}` L45-L47,
identiques FR canonique). Le fix = juste ajouter `open StableMarriage` + typo
`end` = 2L R3 strict.

## Fix proposé — 2L (1 ajout open + 1 typo end)

```diff
--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/GaleShapley_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/GaleShapley_en.lean
@@ -48,7 +48,8 @@ import StableMarriage.Lattice

 namespace StableMarriage_en

-open Function
+open Function Finset Classical
+open StableMarriage

 variable {n : Nat} [NeZero n]

@@ -168,4 +169,4 @@ theorem gale_shapley_woman_pessimal (prof : PrefProfile n)
     rw [hm'def, hinv_eq] at hgt
     exact Nat.lt_irrefl _ (mod_cast hgt)

-end StableMarriage
+end StableMarriage_en
```

**Résolution** :
- `open StableMarriage` : expose les noms courts `PrefProfile`, `Matching`,
  `IsStable`, `IsBlockingPair`, `IsManOptimal`, `ManPrefers`, `WomanPrefers`,
  `GSConsistent` → résout les ~40 sites de référence.
- `end StableMarriage_en` : ferme le namespace correctement.

**Convention i18n** : le EN sibling devient dépendant du FR canonique pour la
résolution des noms courts (trade-off Option B, L93). Le contenu non-docstring
reste byte-identique entre siblings (aucune preuve ni statement modifiée).

## Cette PR SUPERSÈDE PR #5507

#5507 (c.242, OPEN MERGEABLE typo-only) corrigeait **seulement** le `end` typo
(PB 3). Notre fix 2L = PB 1 + PB 3 ensemble (strict superset). C151 doublon
géré par ai-01 : fermer #5507 post-merge de cette PR.

Note : le merge de #5507 SEUL n'aurait pas suffi (le `open StableMarriage`
manquant aurait toujours fait échouer la compile sur les ~40 sites).

## Vérifications

- **R3 strict** : `1 file changed, 3 insertions(+), 2 deletions(-)` — 1
  fichier, 3 insertions, 2 suppressions (net +1 ligne, 2 sites distincts).
- **LF préservé** : CRLF=0 (fichier LF pur, baseline 0, après 0). Sed
  one-shot Python (L67 anti-L35 Edit Windows flip).
- **R8 anti-régression** : `grep -c sorry` AVANT=0, APRÈS=0. Sonnet a vérifié
  diff sur `gale_shapley_stable` L84-102 EN vs L94-112 FR = empty diff.
  6 théorèmes en miroir FR↔EN parfait. 0 ligne de preuve touchée.
- **C151 self-check** : `gh pr list --search "GaleShapley_en"` → 3 PRs
  (#5507 typo-only, #5514 Lattice_en Lake SUCCESS, #5479 globs UNSTABLE).
  Pas de doublon de cette PR complète.
- **Anti-bundle L34** : 1 PR = 1 fichier = 2 sites = 1 concern (preamble +
  end namespace de GaleShapley_en). Distinct de #5514 (Lattice_en) et #5480
  (Basic_en).

## Conformité règles

- **L34 C151 anti-bundle** : 1 PR = 1 fichier = 2 sites = 1 concern.
- **L35 anti-flip LF→CRLF** : sed one-shot Python (L67), CRLF=0 vérifié.
- **L43 `git commit -F <file>`** : apostrophes FR protégées.
- **L50 `--body-file <path>`** : backticks FR protégés.
- **L51 dotted notation leçon** : confirmée N/A ici (0 `def Matching.xxx`
  dans GaleShapley_en).
- **L67 sed one-shot Python** : appliqué pour les 2 sites.
- **L77 dashboard firsthand** : vérifié `mergeStateStatus` de #5507/#5514/
  #5479/#5480 avant PR.
- **L83 branche obsolète** : cette PR sur branche fraîche dédiée
  `fix/c246-...` (fresh from origin/main `fcd064df5`).
- **L84 typo `end <namespace>`** : PB 3 corrigé (L171 typo).
- **L85 namespace/import fix standalone PR avant globs activation** :
  pattern respecté (cf #5514, #5480).
- **L89 Sonnet subagent pattern** : diagnostic livré HAUTE qualité, async
  escalade Lean validée (token economy z.ai/GLM ne bloque PAS recherche).
- **L91 Sonnet Option B appliquée** : extension cohérente du pattern
  #5514 (Lattice_en c.245) → #5514bis (GaleShapley_en c.247).
- **L93 EN sibling trade-off** : Option B rend EN sibling dépendant FR
  canonical (trade-off accepté, contenu byte-identique préservé).
- **R8 anti-régression** : aucune ligne de preuve touchée, grep sorry stable.
- **G.1 verify-before-claiming** : Sonnet a explicitement réfuté les
  assertions parasites (gsStep/gsRunSteps sont bien dans le fichier, PB 1+3
  identifiés, PB 2 N/A vérifié par grep).
- **B.2 Lean proofs** : PR ne touche pas une preuve (seulement préambule +
  end namespace), R8 inclus comme preuve non-régression.

## Note Lake build

`Lake build SUCCESS` local po-2026 impossible (WDAC bloque Lean local,
cf [.claude/rules/lean-merge-discipline.md](../../.claude/rules/lean-merge-discipline.md)).
Validation 100% via CI ai-01 / po-2024 WSL. Diagnostic Sonnet = analyse
statique pure + comparaison FR/EN byte-par-byte (cf `scratchpad/c246-galeshapley-en-diagnostic.md`).

**Log CI détaillé inaccessible** : `lean-build.yml` utilise `tail` (L38 leçon)
qui masque les erreurs spécifiques. La confiance dans le fix vient de :
- Identité du code hors préambule (FR↔EN byte-identique)
- Imports identiques au FR canonique
- 0 redéfinition locale de méthode (grep)
- Pattern validé sur #5514 (Lake SUCCESS c.246 04:24Z)

## Liens

- Issue : **#4980** (i18n Lean FR+EN siblings)
- PR débloquée : **#5479** (lakefile globs stable_marriage_lean, UNSTABLE)
- PR sœur : **#5514** (Lattice_en fix 2L, Lake SUCCESS c.246, MERGEABLE)
- PR sœur : **#5480** (Basic_en namespace fix 5L, MERGEABLE)
- PR obsolète post-merge : **#5507** (typo-only, strict sous-ensemble)
- Diagnostic Sonnet : `scratchpad/c246-galeshapley-en-diagnostic.md` (po-2026)
- Convention i18n ratifiée : ai-01 (2026-07-04, #4980 comment-4881909354)
- Sibling FR canonique inchangé : `StableMarriage/GaleShapley.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)