### PR TITLE
i18n(#4980): add Sensitivity.Hypercube_en — EN sibling, sensitivity_lean (leaf 1/4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Hypercube_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Hypercube_en.lean
@@ -1,0 +1,138 @@
+/-
+  Copyright (c) 2019 Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
+  Patrick Massot. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Authors: Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
+    Patrick Massot
+
+  Port of mathlib4/Archive/Sensitivity.lean to standalone Lake workspace.
+
+  EN sibling of `Sensitivity/Hypercube.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  distinct `.lean` files FR + EN siblings in the same lake, both compile.
+  Drift-CI detectable: non-docstring content byte-identical between siblings.
+
+  Note méthodologique : traduction manuelle du FR canonique. This is the LEAF
+  module (only Mathlib imports, no `Sensitivity.*` sibling dependency), so the
+  EN sibling is fully self-contained — it defines its own `Q` / `π` / `adjacent`
+  inside `namespace Sensitivity_en`, with no cross-namespace dot-notation on a
+  FR-defined type (contrast with the Lattice_en trap). Downstream EN modules
+  (`VectorSpace_en`, `Operator_en`, `MainTheorem_en`) will import this one.
+
+  See #4980. Part of #4208 (axe E).
+-/
+import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.Analysis.Real.Sqrt
+import Mathlib.Tactic.FinCases
+
+/-!
+# The hypercube for Huang's sensitivity theorem
+
+This file defines the hypercube `Q n = Fin n → Bool` and its adjacency relation.
+-/
+
+namespace Sensitivity_en
+
+noncomputable section
+
+open Bool Finset Fintype
+
+/-!
+### The hypercube
+
+Notations:
+- `ℕ` denotes natural numbers (including zero).
+- `Fin n` = {0, ⋯ , n - 1}.
+- `Bool` = {`true`, `false`}.
+-/
+
+
+/-- The hypercube in dimension `n`. -/
+abbrev Q (n : ℕ) :=
+  Fin n → Bool
+
+/-- The projection from `Q n.succ` to `Q n` forgetting the first value
+    (i.e. the image of zero). -/
+def π {n : ℕ} : Q n.succ → Q n := fun p => p ∘ Fin.succ
+
+namespace Q
+
+@[ext]
+theorem ext {n} {f g : Q n} (h : ∀ x, f x = g x) : f = g := funext h
+
+variable (n : ℕ)
+
+/-- `Q 0` has a unique element. -/
+instance : Unique (Q 0) :=
+  ⟨⟨fun _ => true⟩, by intro; ext x; fin_cases x⟩
+
+/-- `Q n` has 2^n elements. -/
+theorem card : Fintype.card (Q n) = 2 ^ n := by simp
+
+variable {n}
+
+theorem succ_n_eq (p q : Q n.succ) : p = q ↔ p 0 = q 0 ∧ π p = π q := by
+  constructor
+  · rintro rfl; exact ⟨rfl, rfl⟩
+  · rintro ⟨h₀, h⟩
+    ext x
+    by_cases hx : x = 0
+    · rwa [hx]
+    · rw [← Fin.succ_pred x hx]
+      convert congr_fun h (Fin.pred x hx)
+
+/-- The adjacency relation defining the graph structure on `Q n`:
+`p.adjacent q` if there is an edge from `p` to `q` in `Q n`. -/
+def adjacent {n : ℕ} (p : Q n) : Set (Q n) := { q | ∃! i, p i ≠ q i }
+
+/-- In `Q 0`, no two vertices are adjacent. -/
+theorem not_adjacent_zero (p q : Q 0) : q ∉ p.adjacent := by rintro ⟨v, _⟩; apply finZeroElim v
+
+/-- If `p` and `q` in `Q n.succ` have different values at zero then they are adjacent
+iff their projections to `Q n` are equal. -/
+theorem adj_iff_proj_eq {p q : Q n.succ} (h₀ : p 0 ≠ q 0) : q ∈ p.adjacent ↔ π p = π q := by
+  constructor
+  · rintro ⟨i, _, h_uni⟩
+    ext x; by_contra hx
+    apply Fin.succ_ne_zero x
+    rw [h_uni _ hx, h_uni _ h₀]
+  · intro heq
+    use 0, h₀
+    intro y hy
+    contrapose! hy
+    rw [← Fin.succ_pred _ hy]
+    apply congr_fun heq
+
+/-- If `p` and `q` in `Q n.succ` have the same value at zero then they are adjacent
+iff their projections to `Q n` are adjacent. -/
+theorem adj_iff_proj_adj {p q : Q n.succ} (h₀ : p 0 = q 0) :
+    q ∈ p.adjacent ↔ π q ∈ (π p).adjacent := by
+  constructor
+  · rintro ⟨i, h_eq, h_uni⟩
+    have h_i : i ≠ 0 := fun h_i => absurd h₀ (by rwa [h_i] at h_eq)
+    use i.pred h_i,
+      show p (Fin.succ (Fin.pred i _)) ≠ q (Fin.succ (Fin.pred i _)) by rwa [Fin.succ_pred]
+    intro y hy
+    simp [Eq.symm (h_uni _ hy)]
+  · rintro ⟨i, h_eq, h_uni⟩
+    use i.succ, h_eq
+    intro y hy
+    rw [← Fin.pred_inj (ha := (?ha : y ≠ 0)) (hb := (?hb : i.succ ≠ 0)),
+      Fin.pred_succ]
+    case ha =>
+      contrapose hy
+      rw [hy, h₀]
+    case hb =>
+      apply Fin.succ_ne_zero
+    apply h_uni
+    simp [π, hy]
+
+@[symm]
+theorem adjacent.symm {p q : Q n} : q ∈ p.adjacent ↔ p ∈ q.adjacent := by
+  simp only [adjacent, ne_comm, Set.mem_setOf_eq]
+
+end Q
+
+end
+
+end Sensitivity_en


### PR DESCRIPTION
## i18n(#4980): add `Sensitivity.Hypercube_en` — EN sibling, sensitivity_lean (leaf module 1/4)

English mirror of `Sensitivity/Hypercube.lean` (FR-first canonical). Convention i18n Lean ratifiée ai-01 (2026-07-04, #4980 comment-4881909354) : distincts FR + EN siblings dans le même lake, les deux compilent ; contenu non-docstring byte-identique (drift-CI detectable).

### Why this is safe — the LEAF module, fully self-contained

`Hypercube_en` is the **leaf** of sensitivity_lean (only Mathlib imports, no `Sensitivity.*` sibling dependency). It defines its own `Q` (abbrev `Fin n → Bool`), `π` (projection), and `adjacent` (graph relation) **all inside `namespace Sensitivity_en`**. No cross-namespace dot-notation on a FR-defined type.

This is the **safe profile** (structure/abbrev-defined-in-same-namespace), NOT the Lattice_en trap (84 dot-notation sites resolving a FR type `Matching` against EN-namespace functions → 50 `Invalid field` errors). Verified firsthand before creation.

### Code diff vs FR Hypercube.lean (non-docstring)

EXACTLY 2 lines :
```
- namespace Sensitivity    + namespace Sensitivity_en
- end Sensitivity          + end Sensitivity_en
```
Docstrings translated FR → EN (the FR file already carries inline "English:" translations, used verbatim as the EN sibling's primary docstrings). **Code/proofs byte-identical** (`Q`, `π`, `adjacent`, all theorems untouched).

### Dependency chain — starts the rollout

```
Hypercube (leaf, Mathlib-only)  ← this PR
   ↓
VectorSpace  →  Operator  →  MainTheorem (flagship Huang degree theorem)
```
Each `_en` is a separate tranche (build-verify per file). After all 4 + globs `Sensitivity.*`, the lake is fully bilingual fleet-wide.

### Sorry parity — no regression

| File | sorry |
|------|-------|
| FR `Hypercube.lean` | 0 |
| EN `Hypercube_en.lean` | 0 |

sensitivity_lean is 0-sorry throughout (proven Huang sensitivity theorem).

### Verification (lean-merge-discipline HARD)

```
$ lake.exe build Sensitivity.Hypercube_en
Build completed successfully (1642 jobs), exit 0
```
| Check | Result |
|-------|--------|
| `lake build Sensitivity.Hypercube_en` | **SUCCESS** (1642 jobs) |
| post-rebase build (against fresh main) | SUCCESS (1642 jobs) |
| FR `Hypercube.lean` baseline | SUCCESS (1642 jobs) |
| sorry FR vs EN | 0 = 0 (no regression) |
| FR `Hypercube.lean` | byte-identical to main (anti-regression D) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — sensitivity_lean i18n rollout 1/4

| Module | _en sibling | Status |
|--------|-------------|--------|
| `Hypercube.lean` (leaf) | ✅ **Hypercube_en** | **this PR** |
| `VectorSpace.lean` | — | future tranche |
| `Operator.lean` | — | future tranche |
| `MainTheorem.lean` (flagship) | — | future tranche |

FR `Hypercube.lean` UNCHANGED. Pure +file addition.

See #4980
See #4208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
