### PR TITLE
i18n(#4980): add Sensitivity.VectorSpace_en — EN sibling, sensitivity_lean (module 2/4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Hypercube_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Hypercube_en.lean
@@ -1,0 +1,138 @@
+/-
+  Copyright (c) 2019 Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
+  Patrick Massot. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Authors: Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
+    Patrick Massot
+
+  Port of mathlib4/Archive/Sensitivity.lean to standalone Lake workspace.
+
+  EN sibling of `Sensitivity/Hypercube.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  distinct `.lean` files FR + EN siblings in the same lake, both compile.
+  Drift-CI detectable: non-docstring content byte-identical between siblings.
+
+  Note méthodologique : traduction manuelle du FR canonique. This is the LEAF
+  module (only Mathlib imports, no `Sensitivity.*` sibling dependency), so the
+  EN sibling is fully self-contained — it defines its own `Q` / `π` / `adjacent`
+  inside `namespace Sensitivity_en`, with no cross-namespace dot-notation on a
+  FR-defined type (contrast with the Lattice_en trap). Downstream EN modules
+  (`VectorSpace_en`, `Operator_en`, `MainTheorem_en`) will import this one.
+
+  See #4980. Part of #4208 (axe E).
+-/
+import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.Analysis.Real.Sqrt
+import Mathlib.Tactic.FinCases
+
+/-!
+# The hypercube for Huang's sensitivity theorem
+
+This file defines the hypercube `Q n = Fin n → Bool` and its adjacency relation.
+-/
+
+namespace Sensitivity_en
+
+noncomputable section
+
+open Bool Finset Fintype
+
+/-!
+### The hypercube
+
+Notations:
+- `ℕ` denotes natural numbers (including zero).
+- `Fin n` = {0, ⋯ , n - 1}.
+- `Bool` = {`true`, `false`}.
+-/
+
+
+/-- The hypercube in dimension `n`. -/
+abbrev Q (n : ℕ) :=
+  Fin n → Bool
+
+/-- The projection from `Q n.succ` to `Q n` forgetting the first value
+    (i.e. the image of zero). -/
+def π {n : ℕ} : Q n.succ → Q n := fun p => p ∘ Fin.succ
+
+namespace Q
+
+@[ext]
+theorem ext {n} {f g : Q n} (h : ∀ x, f x = g x) : f = g := funext h
+
+variable (n : ℕ)
+
+/-- `Q 0` has a unique element. -/
+instance : Unique (Q 0) :=
+  ⟨⟨fun _ => true⟩, by intro; ext x; fin_cases x⟩
+
+/-- `Q n` has 2^n elements. -/
+theorem card : Fintype.card (Q n) = 2 ^ n := by simp
+
+variable {n}
+
+theorem succ_n_eq (p q : Q n.succ) : p = q ↔ p 0 = q 0 ∧ π p = π q := by
+  constructor
+  · rintro rfl; exact ⟨rfl, rfl⟩
+  · rintro ⟨h₀, h⟩
+    ext x
+    by_cases hx : x = 0
+    · rwa [hx]
+    · rw [← Fin.succ_pred x hx]
+      convert congr_fun h (Fin.pred x hx)
+
+/-- The adjacency relation defining the graph structure on `Q n`:
+`p.adjacent q` if there is an edge from `p` to `q` in `Q n`. -/
+def adjacent {n : ℕ} (p : Q n) : Set (Q n) := { q | ∃! i, p i ≠ q i }
+
+/-- In `Q 0`, no two vertices are adjacent. -/
+theorem not_adjacent_zero (p q : Q 0) : q ∉ p.adjacent := by rintro ⟨v, _⟩; apply finZeroElim v
+
+/-- If `p` and `q` in `Q n.succ` have different values at zero then they are adjacent
+iff their projections to `Q n` are equal. -/
+theorem adj_iff_proj_eq {p q : Q n.succ} (h₀ : p 0 ≠ q 0) : q ∈ p.adjacent ↔ π p = π q := by
+  constructor
+  · rintro ⟨i, _, h_uni⟩
+    ext x; by_contra hx
+    apply Fin.succ_ne_zero x
+    rw [h_uni _ hx, h_uni _ h₀]
+  · intro heq
+    use 0, h₀
+    intro y hy
+    contrapose! hy
+    rw [← Fin.succ_pred _ hy]
+    apply congr_fun heq
+
+/-- If `p` and `q` in `Q n.succ` have the same value at zero then they are adjacent
+iff their projections to `Q n` are adjacent. -/
+theorem adj_iff_proj_adj {p q : Q n.succ} (h₀ : p 0 = q 0) :
+    q ∈ p.adjacent ↔ π q ∈ (π p).adjacent := by
+  constructor
+  · rintro ⟨i, h_eq, h_uni⟩
+    have h_i : i ≠ 0 := fun h_i => absurd h₀ (by rwa [h_i] at h_eq)
+    use i.pred h_i,
+      show p (Fin.succ (Fin.pred i _)) ≠ q (Fin.succ (Fin.pred i _)) by rwa [Fin.succ_pred]
+    intro y hy
+    simp [Eq.symm (h_uni _ hy)]
+  · rintro ⟨i, h_eq, h_uni⟩
+    use i.succ, h_eq
+    intro y hy
+    rw [← Fin.pred_inj (ha := (?ha : y ≠ 0)) (hb := (?hb : i.succ ≠ 0)),
+      Fin.pred_succ]
+    case ha =>
+      contrapose hy
+      rw [hy, h₀]
+    case hb =>
+      apply Fin.succ_ne_zero
+    apply h_uni
+    simp [π, hy]
+
+@[symm]
+theorem adjacent.symm {p q : Q n} : q ∈ p.adjacent ↔ p ∈ q.adjacent := by
+  simp only [adjacent, ne_comm, Set.mem_setOf_eq]
+
+end Q
+
+end
+
+end Sensitivity_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/VectorSpace_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/VectorSpace_en.lean
@@ -1,0 +1,145 @@
+/-
+  Copyright (c) 2019 Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
+  Patrick Massot. All rights reserved.
+  Released under Apache 2.0 license as described in the file LICENSE.
+  Authors: Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
+    Patrick Massot
+
+  Port of mathlib4/Archive/Sensitivity.lean to standalone Lake workspace.
+
+  EN sibling of `Sensitivity/VectorSpace.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  distinct `.lean` files FR + EN siblings in the same lake, both compile.
+  Drift-CI detectable: non-docstring content byte-identical between siblings.
+
+  Note méthodologique : traduction manuelle du FR canonique. Imports the EN leaf
+  `Sensitivity.Hypercube_en` (defines `Q`, `π`, `adjacent` in `namespace
+  Sensitivity_en`). Self-contained within the EN namespace: defines its own `V`,
+  `e`, `ε`, `duality` — no cross-namespace dot-notation on a FR-defined type
+  (safe profile, same as Hypercube_en).
+
+  See #4980. Part of #4208 (axe E).
+-/
+import Sensitivity.Hypercube_en
+import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.LinearAlgebra.Dual.Lemmas
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+
+/-!
+# Vector space for Huang's sensitivity theorem
+
+This file defines the free vector space `V n` on vertices of the hypercube,
+the basis `e`, the dual basis `ε`, and proves duality and dimension results.
+-/
+
+namespace Sensitivity_en
+
+noncomputable section
+
+open Function LinearMap Module Module.DualBases
+
+local notation "√" => Real.sqrt
+
+/-! ### The vector space -/
+
+
+/-- The free vector space on vertices of a hypercube, defined inductively. -/
+def V : ℕ → Type
+  | 0 => ℝ
+  | n + 1 => V n × V n
+
+@[simp]
+theorem V_zero : V 0 = ℝ := rfl
+
+@[simp]
+theorem V_succ {n : ℕ} : V (n + 1) = (V n × V n) := rfl
+
+namespace V
+
+@[ext]
+theorem ext {n : ℕ} {p q : V n.succ} (h₁ : p.1 = q.1) (h₂ : p.2 = q.2) : p = q := Prod.ext h₁ h₂
+
+variable (n : ℕ)
+
+instance : DecidableEq (V n) := by induction n <;> · dsimp only [V]; infer_instance
+
+instance : AddCommGroup (V n) := by induction n <;> · dsimp only [V]; infer_instance
+
+set_option backward.isDefEq.respectTransparency false in
+instance : Module ℝ (V n) := by induction n <;> · dsimp only [V]; infer_instance
+
+end V
+
+/-- The basis of `V` indexed by the hypercube, defined inductively. -/
+noncomputable def e : ∀ {n}, Q n → V n
+  | 0 => fun _ => (1 : ℝ)
+  | Nat.succ _ => fun x => cond (x 0) (e (π x), 0) (0, e (π x))
+
+@[simp]
+theorem e_zero_apply (x : Q 0) : e x = (1 : ℝ) :=
+  rfl
+
+/-- The dual basis to `e`, defined inductively. -/
+noncomputable def ε : ∀ {n : ℕ}, Q n → V n →ₗ[ℝ] ℝ
+  | 0, _ => LinearMap.id
+  | Nat.succ _, p =>
+    cond (p 0) ((ε <| π p).comp <| LinearMap.fst _ _ _) ((ε <| π p).comp <| LinearMap.snd _ _ _)
+
+variable {n : ℕ}
+
+set_option backward.isDefEq.respectTransparency false in
+open Classical in
+theorem duality (p q : Q n) : ε p (e q) = if p = q then 1 else 0 := by
+  induction n with
+  | zero => simp [Subsingleton.elim (α := Q 0) p q, ε, e]
+  | succ n IH =>
+    dsimp [ε, e]
+    cases hp : p 0 <;> cases hq : q 0
+    all_goals
+      simp only [Bool.cond_true, Bool.cond_false, LinearMap.fst_apply, LinearMap.snd_apply,
+        LinearMap.comp_apply, IH]
+      congr 1; simp [Q.succ_n_eq, hp, hq]
+
+/-- Any vector in `V n` annihilated by all `ε p`'s is zero. -/
+theorem epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 := by
+  induction n with
+  | zero => dsimp [ε] at h; exact h fun _ => true
+  | succ n ih =>
+    obtain ⟨v₁, v₂⟩ := v
+    ext <;> change _ = (0 : V n) <;> simp only <;> apply ih <;> intro p <;>
+      [let q : Q n.succ := fun i => if h : i = 0 then true else p (i.pred h);
+      let q : Q n.succ := fun i => if h : i = 0 then false else p (i.pred h)]
+    all_goals
+      specialize h q
+      first
+      | rw [ε, show q 0 = true from rfl, Bool.cond_true] at h
+      | rw [ε, show q 0 = false from rfl, Bool.cond_false] at h
+      rwa [show p = π q by ext; simp [q, Fin.succ_ne_zero, π]]
+
+open Module
+
+open Classical in
+/-- `e` and `ε` are dual families of vectors. -/
+theorem dualBases_e_ε (n : ℕ) : DualBases (@e n) (@ε n) where
+  eval_same := by simp [duality]
+  eval_of_ne _ _ h := by simp [duality, h]
+  total h := sub_eq_zero.mp <| epsilon_total fun i ↦ by
+    simpa only [map_sub, sub_eq_zero] using h i
+
+theorem dim_V : Module.rank ℝ (V n) = 2 ^ n := by
+  have : Module.rank ℝ (V n) = (2 ^ n : ℕ) := by
+    classical
+    rw [rank_eq_card_basis (dualBases_e_ε _).basis, Q.card]
+  assumption_mod_cast
+
+open Classical in
+instance : FiniteDimensional ℝ (V n) :=
+  (dualBases_e_ε _).basis.finiteDimensional_of_finite
+
+theorem finrank_V : finrank ℝ (V n) = 2 ^ n := by
+  have := @dim_V n
+  rw [← finrank_eq_rank] at this; assumption_mod_cast
+
+end
+
+end Sensitivity_en


### PR DESCRIPTION
## i18n(#4980): add `Sensitivity.VectorSpace_en` — EN sibling, sensitivity_lean (module 2/4)

English mirror of `Sensitivity/VectorSpace.lean` (FR-first canonical). Convention i18n Lean ratifiée ai-01 (2026-07-04, #4980 comment-4881909354) : distincts FR + EN siblings dans le même lake, les deux compilent ; contenu non-docstring byte-identique (drift-CI detectable).

### STACKED on #5521 (Hypercube_en)

This PR is **stacked** on #5521 (`feat/4980-sensitivity-hypercube-en`, leaf module 1/4). The diff vs `main` currently shows BOTH `Hypercube_en.lean` + `VectorSpace_en.lean` because the parent (#5521) is still open. **Merge order**: #5521 first → GitHub auto-retargets this PR → its diff shrinks to just `VectorSpace_en.lean`. The atomic increment here is ONE file (`VectorSpace_en.lean`, 145L).

### Why this is safe — self-contained EN namespace

`VectorSpace_en` imports the EN leaf `Sensitivity.Hypercube_en` (defines `Q`, `π`, `adjacent` in `namespace Sensitivity_en`). It then defines its **own** `V`, `e`, `ε`, `duality`, `epsilon_total`, `dualBases_e_ε`, `dim_V`, `finrank_V` all inside `namespace Sensitivity_en`. **No cross-namespace dot-notation on a FR-defined type** (safe profile, same as Hypercube_en).

Verified firsthand: `Q` (FR-defined type) is used only as a **bare type reference** (`Q n`, `p q : Q n`) and `Q.succ_n_eq` is **fully-qualified** (L100) — there is no `<value>.<fr-method>` dot-notation that would resolve against the FR type. This is the SAFE profile, NOT the Lattice_en trap (84 dot-notation sites `μ.join/.meet` resolving a FR type `Matching` against EN-namespace functions → 50 `Invalid field` errors).

### Code diff vs FR VectorSpace.lean (non-docstring)

EXACTLY 3 lines, all namespace/import resolution :
```
-import Sensitivity.Hypercube     +import Sensitivity.Hypercube_en
-namespace Sensitivity            +namespace Sensitivity_en
-end Sensitivity                  +end Sensitivity_en
```
Docstrings translated FR → EN (the FR file already carries inline "English:" translations, used verbatim as the EN sibling's primary docstrings). **Code/proofs byte-identical.**

### Sorry parity — no regression

| File | sorry |
|------|-------|
| FR `VectorSpace.lean` | 0 |
| EN `VectorSpace_en.lean` | 0 |

sensitivity_lean is 0-sorry throughout (proven Huang sensitivity theorem).

### Verification (lean-merge-discipline HARD)

```
$ lake.exe build Sensitivity.VectorSpace_en
✔ [1931/1931] Built Sensitivity.VectorSpace_en (8.0s)
Build completed successfully (1931 jobs), exit 0
```
| Check | Result |
|-------|--------|
| `lake build Sensitivity.VectorSpace_en` | **SUCCESS** (1931 jobs) |
| FR `VectorSpace.lean` baseline | SUCCESS (0 sorry) |
| sorry FR vs EN | 0 = 0 (no regression) |
| FR `VectorSpace.lean` | byte-identical to main (anti-regression D) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — sensitivity_lean i18n rollout 2/4

| Module | _en sibling | Status |
|--------|-------------|--------|
| `Hypercube.lean` (leaf) | ✅ Hypercube_en | #5521 (this stack's base) |
| `VectorSpace.lean` | ✅ **VectorSpace_en** | **this PR** |
| `Operator.lean` | — | future tranche (3/4) |
| `MainTheorem.lean` (flagship) | — | future tranche (4/4) |

FR `VectorSpace.lean` UNCHANGED. Pure +file addition.

See #4980
See #4208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
