### PR TITLE
fix(ict-18): entropy_production directed cycles (real_zeros bug) + 11 tests

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/time_arrow.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/time_arrow.py
@@ -290,28 +290,32 @@ def entropy_production(P: np.ndarray, pi: np.ndarray) -> float:
     """
     P = np.asarray(P, dtype=float)
     pi = np.asarray(pi, dtype=float)
-    pi_safe = np.where(pi > 0, pi, 1.0)
+    pi_safe = np.where(pi > 0, pi, 1e-300)
     flux_go = pi_safe[:, None] * P          # pi_i * P[i, j]
     flux_back = pi_safe[None, :] * P.T       # pi_j * P[j, i]
-    # Eviter log(0) : on met les zeros a 1.
-    a = np.where(flux_go > 0, flux_go, 1.0)
-    b = np.where(flux_back > 0, flux_back, 1.0)
-    # Contribution par paire (i, j) ; on garde seulement la partie haute
-    # du triangle + diagonale (symmetrique en (i, j) -> (j, i)), divisee
-    # par 2 pour eviter le double comptage de (i, j) et (j, i).
-    d = (a - b) * np.log(a / b)
-    # On moyenne sur les paires en utilisant la matrice superieure.
+    # Regularisation eps : une transition strictement irreversible (P[i, j] > 0
+    # avec P[j, i] = 0) a une limite log(flux_go / 0+) -> +infini qui, sur des
+    # donnees empiriques, traduit une irreversibilite totale (cycle dirige,
+    # marche monotone non bornee). On borne ce terme par un petit eps (standard
+    # en thermo stochastique sur matrices estimees) afin d'obtenir un scalaire
+    # fini strictement positif refletant le flux net unidirectionnel.
+    #
+    # NB (fix ICT-19, Epic #4588) : la version precedente annulait a 0 toute
+    # paire dont l'un des flux etait nul (``real_zeros``), ce qui ecrasait a
+    # tort la contribution des cycles diriges (sigma = 0 pour une chaine
+    # clairement irreversible). La regularisation eps restaurait sigma = 6.11
+    # (vs 0.0) sur un cycle dirige 4-etats reguliarise eps=1e-3 ; sur un cycle
+    # pur (P[j,i]=0 exact) elle donne un sigma grand mais fini (23.5), coherent
+    # avec la limite thermodynamique. Cette correction ne change PAS les
+    # matrices empiriques estimees via ``transition_matrix`` (Laplace smoothing
+    # 1e-9 => tous flux strictement > 0 => ``real_zeros`` etait deja inactif),
+    # donc les substrats ICT-18 (S5a marche bornee etc.) sont inchanges.
+    eps = 1e-12
+    fg = np.where(flux_go > 0, flux_go, eps)
+    fb = np.where(flux_back > 0, flux_back, eps)
+    d = (fg - fb) * np.log(fg / fb)
     sigma = 0.5 * float(np.sum(d))
-    # Si on a mis des zeros a 1, le produit (a-b)*log(a/b) peut-etre
-    # artificiellement negatif quand le flux aller EST nul mais le flux
-    # retour est positif. On corrige : un flux aller nul doit contribuer 0
-    # (pas de transition nette dans cette direction).
-    real_zeros = (flux_go == 0) | (flux_back == 0)
-    d_corrige = np.where(real_zeros, 0.0, (flux_go - flux_back) * np.log(
-        np.where(flux_go > 0, flux_go, 1.0) / np.where(flux_back > 0, flux_back, 1.0)
-    ))
-    sigma_corrige = 0.5 * float(np.sum(d_corrige))
-    return max(sigma_corrige, 0.0)
+    return max(sigma, 0.0)
 
 
 # --------------------------------------------------------------------------- #

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_time_arrow.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_time_arrow.py
@@ -1,0 +1,173 @@
+"""Tests de ``ict.time_arrow`` : matrice de transition, stationnaire,
+production d'entropie (Schnakenberg).
+
+Couvre notamment le **bug fix ICT-19** (Epic #4588) : la version precedente de
+``entropy_production`` annulait a 0 les transitions strictement irreversibles
+(``real_zeros``), ecrasant a tort la contribution des cycles diriges. Ces tests
+verrouillent le comportement corrige : un cycle dirige DOIT donner sigma > 0.
+
+Numpy + pytest. Le module ne depend que de numpy.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PARENT = os.path.dirname(_HERE)
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+
+from ict import time_arrow  # noqa: E402
+
+
+def _stationary_power(P, n_iter=20000):
+    """Stationnaire par iteration de puissance (reference independante)."""
+    P = np.asarray(P, dtype=float)
+    n = P.shape[0]
+    pi = np.ones(n) / n
+    for _ in range(n_iter):
+        pi = pi @ P
+        pi = pi / pi.sum()
+    return pi
+
+
+# --------------------------------------------------------------------------- #
+#  transition_matrix
+# --------------------------------------------------------------------------- #
+
+def test_transition_matrix_rows_sum_to_one():
+    states = [0, 1, 0, 1, 0, 2, 0]
+    P = time_arrow.transition_matrix(states, n_symbols=3)
+    np.testing.assert_allclose(P.sum(axis=1), np.ones(3), atol=1e-9)
+
+
+def test_transition_matrix_counts_pairs():
+    # 0->1, 1->0, 0->1, 1->0, 0->2, 2->0  => depuis 0 : {1:2, 2:1}, depuis 1: {0:2}
+    states = [0, 1, 0, 1, 0, 2, 0]
+    P = time_arrow.transition_matrix(states, n_symbols=3, laplace_smoothing=0.0)
+    # depuis 0 : 2 vers 1, 1 vers 2 (+ self 0 non observe)
+    assert P[0, 1] == pytest.approx(2 / 3, abs=1e-6)
+    assert P[0, 2] == pytest.approx(1 / 3, abs=1e-6)
+    assert P[1, 0] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_transition_matrix_deterministic_cycle():
+    """Un cycle deterministe 0->1->2->0 donne P[i,(i+1)%3]=1."""
+    states = [i % 3 for i in range(300)]
+    P = time_arrow.transition_matrix(states, n_symbols=3, laplace_smoothing=0.0)
+    for i in range(3):
+        assert P[i, (i + 1) % 3] == pytest.approx(1.0, abs=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+#  stationary_distribution
+# --------------------------------------------------------------------------- #
+
+def test_stationary_uniform_for_doubly_stochastic():
+    P = np.array([[0.5, 0.25, 0.25],
+                  [0.25, 0.5, 0.25],
+                  [0.25, 0.25, 0.5]])
+    pi = time_arrow.stationary_distribution(P)
+    np.testing.assert_allclose(pi, np.ones(3) / 3, atol=1e-6)
+
+
+def test_stationary_matches_power_iteration():
+    P = np.array([[0.1, 0.9, 0.0],
+                  [0.0, 0.2, 0.8],
+                  [0.3, 0.0, 0.7]])
+    pi = time_arrow.stationary_distribution(P)
+    pi_ref = _stationary_power(P)
+    np.testing.assert_allclose(pi, pi_ref, atol=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+#  entropy_production -- bug fix ICT-19 (cycles diriges)
+# --------------------------------------------------------------------------- #
+
+def test_entropy_production_zero_for_detailed_balance():
+    """Une chaine reversible (detailed balance) donne sigma = 0."""
+    P = np.array([[0.5, 0.25, 0.25],
+                  [0.25, 0.5, 0.25],
+                  [0.25, 0.25, 0.5]])
+    pi = time_arrow.stationary_distribution(P)
+    sigma = time_arrow.entropy_production(P, pi)
+    assert sigma == pytest.approx(0.0, abs=1e-9)
+
+
+def test_entropy_production_positive_for_directed_cycle():
+    """BUG FIX ICT-19 : un cycle dirige (P[j,i]=0) DOIT donner sigma > 0.
+
+    La version precedente annulait cette contribution a 0 (``real_zeros``),
+    contredisant la thermo de base : un cycle dirige brise la reversibilite.
+    """
+    P = np.array([
+        [0.1, 0.9, 0.0, 0.0],
+        [0.0, 0.1, 0.9, 0.0],
+        [0.0, 0.0, 0.1, 0.9],
+        [0.9, 0.0, 0.0, 0.1],
+    ])
+    pi = time_arrow.stationary_distribution(P)
+    sigma = time_arrow.entropy_production(P, pi)
+    assert sigma > 0.5, (
+        f"un cycle dirige doit donner sigma > 0 (irreversibilite), obtenu {sigma}"
+    )
+
+
+def test_entropy_production_positive_for_regularized_cycle():
+    """Cycle dirige regularise (eps reverse) : sigma > 0, ordre coherent."""
+    eps = 1e-3
+    P = np.array([
+        [0.1, 0.9 - eps, 0.0, eps],
+        [eps, 0.1, 0.9 - eps, 0.0],
+        [0.0, eps, 0.1, 0.9 - eps],
+        [0.9 - eps, 0.0, eps, 0.1],
+    ])
+    pi = time_arrow.stationary_distribution(P)
+    sigma = time_arrow.entropy_production(P, pi)
+    assert sigma > 1.0, f"cycle regularise doit donner sigma > 1, obtenu {sigma}"
+
+
+def test_entropy_production_directed_beats_reversible():
+    """Le cycle dirige est strictement plus irreversible que le reversible."""
+    P_rev = np.array([[0.5, 0.25, 0.25],
+                      [0.25, 0.5, 0.25],
+                      [0.25, 0.25, 0.5]])
+    P_cycle = np.array([
+        [0.1, 0.9, 0.0, 0.0],
+        [0.0, 0.1, 0.9, 0.0],
+        [0.0, 0.0, 0.1, 0.9],
+        [0.9, 0.0, 0.0, 0.1],
+    ])
+    s_rev = time_arrow.entropy_production(P_rev, time_arrow.stationary_distribution(P_rev))
+    s_cyc = time_arrow.entropy_production(P_cycle, time_arrow.stationary_distribution(P_cycle))
+    assert s_cyc > s_rev
+
+
+def test_entropy_production_bounded_biased_walk_low():
+    """Une marche biaisee BORNEE (reflexion aux bords) est quasi-reversible :
+    sigma faible (detailed balance approximatif). C'est le substrat S5a d'ICT-18
+    -- le fix ne doit PAS le changer (tous flux > 0 via Laplace). Anti-regression."""
+    P = np.zeros((5, 5))
+    P[0, 0] = 0.3; P[0, 1] = 0.7
+    P[4, 4] = 0.3; P[4, 3] = 0.7
+    for i in range(1, 4):
+        P[i, i - 1] = 0.2; P[i, i] = 0.1; P[i, i + 1] = 0.7
+    pi = time_arrow.stationary_distribution(P)
+    sigma = time_arrow.entropy_production(P, pi)
+    # Marche bornee = quasi reversible (concentration au bord droit mais
+    # detailed balance approximatif). sigma doit rester petit (< 0.5).
+    assert sigma < 0.5, f"marche bornee devrait rester quasi-reversible, sigma={sigma}"
+
+
+def test_entropy_production_nonnegative():
+    """sigma >= 0 toujours (inegalite de Jensen)."""
+    rng = np.random.default_rng(0)
+    for _ in range(10):
+        P = rng.random((4, 4)) + 0.01
+        P = P / P.sum(axis=1, keepdims=True)
+        pi = time_arrow.stationary_distribution(P)
+        sigma = time_arrow.entropy_production(P, pi)
+        assert sigma >= -1e-9


### PR DESCRIPTION
Part of #4588 (Epic IIT→ICT). Fix standalone du module `ict.time_arrow` (merged ICT-18 #5279), découvert via l'investigation ICT-19 batterie ENJEU.

## Bug

`entropy_production` annulait à 0 les transitions strictement irréversibles :

```python
real_zeros = (flux_go == 0) | (flux_back == 0)
d_corrige = np.where(real_zeros, 0.0, ...)
```

Une transition purement irréversible (`P[i,j]>0` avec `P[j,i]=0` — cycle dirigé, marche monotone) → `flux_back==0` → contribution **annulée à 0**. Or c'est précisément le terme qui devrait contribuer au flux net. Un cycle dirigé 4-états donnait `sigma=0.0` alors qu'il brise clairement la réversibilité (Schnakenberg).

## Diagnostic firsthand (ICT-19, batterie ENJEU)

Le substrat S5 du notebook ICT-19 (marche monotone) donnait `I_thermo=0`, contredisant ICT-18 §2.bis (« S5 allume I_thermo »). Investigation c.71 : root cause = ce bug, qui annulait les transitions sans retour. Preuve reproductible : cycle dirigé 4-états → code `sigma=0.0` vs régularisé eps=1e-3 `sigma=6.11` (vrai Schnakenberg).

## Fix

ε-régularisation (1e-12) standard en thermo stochastique sur matrices estimées. Restitue `sigma=6.11` (cycle régularisé) / `23.5` (cycle pur). Docstring documente la correction + la non-régression sur substrats empiriques.

## Anti-régression VÉRIFIÉE (Stop & Repair)

Notebook ICT-18 re-exécuté (`nbconvert --execute --inplace`, kernel python3) :
- S5a (marche bornée) `sigma_real=0.0014` — **identique** pre/post fix
- S5b (oscillateur logistique) `sigma_real=4.6227` — **identique** pre/post fix
- C.2 : 11/11 `execution_count`, 0 erreur

Les substrats empiriques ICT-18 ont tous `flux>0` via Laplace smoothing (1e-9) → `real_zeros` était déjà inactif pour eux. Diff notebook = **timestamps metadata uniquement** (0 valeur numérique changée). Notebook **revert per règle C.3** (aucune cellule source modifiée, outputs inchangés).

## Tests — 11 nouveaux (suite ICT 340 → 351 passed, 0 régression)

Trou de test comblé : **0 couverture** `entropy_production` avant (aucun `test_time_arrow.py`). Couvre :
- `transition_matrix` : rows sum à 1, comptage paires, cycle déterministe
- `stationary_distribution` : uniforme (doubly-stochastic), power-iteration
- `entropy_production` : detailed balance=0, **cycle dirigé >0** (verrouille le fix), cycle régularisé >1, dirigé > réversible, marche bornée faible (anti-regression S5a), non-négativité

## Portée ICT-19 (honnête)

Ce fix corrige le bug pour cycles dirigés **stationnaires**. Il ne débloque PAS complètement le substrat S5 du notebook ICT-19 : problème plus profond documenté (`stake_index` >0 pour tout système ergodique ; I_stake≈0 nécessite non-ergodique = pas de stationnaire = `quick_thermo` artefact). Décision scope (fix entropy_production vs reframe batterie ENJEU) = ASK ai-01 (DM msg-...xg3d5f), non-résolue par ce fix standalone.

## Garde-fous
- ✅ GPU-free, numpy-only
- ✅ catalogue byte-identical (0 churn)
- ✅ `See #4588` (jamais `Closes` — issue build ICT-19 reste open)
- ✅ docstrings FR, C.1 clean (0 `raise NotImplementedError`)
- ✅ anti-régression vérifiée (notebook re-exec, valeurs identiques)

🤖 Generated with [Claude Code](https://claude.com/claude-code)