### PR TITLE
feat(planners): Planners-1-Introduction-Csharp — STRIPS + BFS twin (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
@@ -1,0 +1,1273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "79014e5f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00307,
+     "end_time": "2026-07-06T06:23:03.522756",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:03.519686",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Planners-1-Introduction-Csharp : la planification automatique from-scratch\n",
+    "\n",
+    "**Navigation** : [<< Setup](Planners-0-Setup.ipynb) | [Twin Python unified-planning](Planners-1-Introduction.ipynb) | [PDDL Basics >>](Planners-2-PDDL-Basics.ipynb)\n",
+    "\n",
+    "**Twin C#** du notebook Python [Planners-1-Introduction](Planners-1-Introduction.ipynb) (Python + lib `unified-planning`). Cette **premiere tranche = les fondations** : le modele **STRIPS** (Fikes & Nilsson, 1971), l'espace d'etats, et un **planificateur BFS from-scratch** qui resout le probleme canonique de l'interrupteur. Implementation **BCL .NET seule, 0 NuGet**.\n",
+    "\n",
+    "## Complementarite (#3801 Prong B)\n",
+    "\n",
+    "| Twin | Outil | Valeur |\n",
+    "|------|-------|--------|\n",
+    "| Python (unified-planning) | lib `up.shortcuts` (modelisation + solveur 1 appel) | resoudre vite des problemes PDDL reels |\n",
+    "| **This (.NET from-scratch)** | implementation C# main : STRIPS + BFS + state-space | **comprendre** la semantique STRIPS et la recherche dans l'espace d'etats |\n",
+    "\n",
+    "Pas d'equivalent NuGet maintenu et didactique a `unified-planning` en .NET → from-scratch = la valeur pedagogique. On code chaque brique (predicat, operateur, transition, recherche) pour comprendre **comment** un planificateur fonctionne, pas seulement comment l'invoquer.\n",
+    "\n",
+    "**Stack technique** : BCL .NET seule, **0 NuGet**. Kernel `.net-csharp` (.NET Interactive).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e868c323",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002633,
+     "end_time": "2026-07-06T06:23:03.528662",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:03.526029",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Qu'est-ce que la planification ?\n",
+    "\n",
+    "La **planification automatique** est la branche de l'IA qui genere des **sequences d'actions** pour atteindre un objectif. Etant donne :\n",
+    "- un **etat initial** (le monde tel qu'il est),\n",
+    "- un ensemble d'**actions** (chacune decrite par ses **preconditions** et ses **effets**),\n",
+    "- un **but** (un etat a atteindre),\n",
+    "\n",
+    "le planificateur cherche automatiquement une suite d'actions qui mene de l'etat initial au but. La question n'est pas « que predire ? » (apprentissage) mais « **que faire ?** ».\n",
+    "\n",
+    "**Contraste** :\n",
+    "- **Recherche (Search series)** : on explore un graphe donne. La planification **construit** ce graphe (l'espace d'etats) a partir de la semantique des actions.\n",
+    "- **CSP (Constraint series)** : on satisfait des contraintes sur des variables. La planification cherche une **sequence** (l'ordre compte).\n",
+    "\n",
+    "La planification est une technologie eprouvee : elle pilote des robots, optimise la logistique, et a dirige des engins spatiaux autonomes (Remote Agent sur Deep Space 1).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81beaf48",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002062,
+     "end_time": "2026-07-06T06:23:03.534839",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:03.532777",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Le modele STRIPS\n",
+    "\n",
+    "**STRIPS** (STanford Research Institute Problem Solver, Fikes & Nilsson 1971) est le formalisme canonique. L'etat du monde = un **ensemble de predicats** (faits vrais). Une action (appelee **operateur**) comporte :\n",
+    "\n",
+    "- un **nom** (ex: `allumer(lampe)`),\n",
+    "- des **preconditions** : predicats qui doivent etre vrais pour que l'action soit applicable,\n",
+    "- des **effets** : predicats **ajoutes** (deviennent vrais) et **retires** (deviennent faux) apres l'action.\n",
+    "\n",
+    "La **transition** : si l'etat courant contient toutes les preconditions, l'action est applicable. L'etat resultant = (etat courant − effets de retrait) ∪ effets d'ajout.\n",
+    "\n",
+    "### Formalisme\n",
+    "\n",
+    "Soit un operateur $o = (pre(o), add(o), del(o))$. Pour un etat $S$ :\n",
+    "\n",
+    "- **applicable** ssi $pre(o) \\subseteq S$\n",
+    "- **successeur** : $S' = (S \\setminus del(o)) \\cup add(o)$\n",
+    "\n",
+    "Un **plan** = sequence d'operateurs $o_1, o_2, \\dots, o_n$ telle que chaque $o_i$ est applicable dans l'etat atteint apres $o_1, \\dots, o_{i-1}$, et le but est atteint a la fin.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32e1d7ab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001818,
+     "end_time": "2026-07-06T06:23:03.538499",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:03.536681",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Setup et helpers invariant\n",
+    "\n",
+    "Helper de formatage invariant (evite la collision virgule-decimale FR dans les sorties).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d0d8756a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:03.549847Z",
+     "iopub.status.busy": "2026-07-06T06:23:03.545050Z",
+     "iopub.status.idle": "2026-07-06T06:23:04.864244Z",
+     "shell.execute_reply": "2026-07-06T06:23:04.860619Z"
+    },
+    "papermill": {
+     "duration": 1.324011,
+     "end_time": "2026-07-06T06:23:04.864340",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:03.540329",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '15556.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setup OK — kernel .net-csharp, BCL seule.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "\n",
+    "static string FI(double x, string fmt = \"F4\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "\n",
+    "Console.WriteLine(\"Setup OK — kernel .net-csharp, BCL seule.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0a5c9b7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002161,
+     "end_time": "2026-07-06T06:23:04.868984",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:04.866823",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Implementation du modele STRIPS from-scratch\n",
+    "\n",
+    "On represente l'**etat** comme un `HashSet<string>` de predicats (ex: `{\"lampe_allumee\", \"lampe_fonctionne\"}`). Un **operateur** est une classe avec preconditions, ajouts, retraits. La transition applique l'operateur si applicable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f82f1d12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:04.874212Z",
+     "iopub.status.busy": "2026-07-06T06:23:04.874059Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.012504Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.012338Z"
+    },
+    "papermill": {
+     "duration": 0.141521,
+     "end_time": "2026-07-06T06:23:05.012578",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:04.871057",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele STRIPS compile : Operator + IsApplicable + Apply + GoalReached.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Modele STRIPS from-scratch (BCL .NET seule).\n",
+    "// Un etat = HashSet<string> (ensemble de predicats vrais).\n",
+    "\n",
+    "// Un operateur STRIPS : nom + preconditions + effets (add/del).\n",
+    "class Operator {\n",
+    "    public string Name { get; init; } = \"\";\n",
+    "    public HashSet<string> Pre { get; init; } = new();\n",
+    "    public HashSet<string> Add { get; init; } = new();\n",
+    "    public HashSet<string> Del { get; init; } = new();\n",
+    "}\n",
+    "\n",
+    "// Une transition : applicable ssi pre <= S ; successeur = (S - del) | add.\n",
+    "static bool IsApplicable(Operator op, HashSet<string> s) => op.Pre.IsSubsetOf(s);\n",
+    "\n",
+    "static HashSet<string> Apply(Operator op, HashSet<string> s) {\n",
+    "    // On ne devrait appeler Apply que si IsApplicable.\n",
+    "    var s2 = new HashSet<string>(s);\n",
+    "    foreach (var d in op.Del) s2.Remove(d);\n",
+    "    foreach (var a in op.Add) s2.Add(a);\n",
+    "    return s2;\n",
+    "}\n",
+    "\n",
+    "// Le but est atteint ssi tous les predicats du but sont dans l'etat.\n",
+    "static bool GoalReached(HashSet<string> goal, HashSet<string> s) => goal.IsSubsetOf(s);\n",
+    "\n",
+    "Console.WriteLine(\"Modele STRIPS compile : Operator + IsApplicable + Apply + GoalReached.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f179450",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002576,
+     "end_time": "2026-07-06T06:23:05.018101",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.015525",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Exemple simple — l'interrupteur\n",
+    "\n",
+    "Le probleme canonique de l'interrupteur (cf twin Python) :\n",
+    "- **Etat initial** : la lampe est eteinte.\n",
+    "- **Actions** : `allumer` (pre: lampe en bon etat ; add: lampe allumee), `eteindre` (add: lampe eteinte, del: lampe allumee).\n",
+    "- **But** : la lampe est allumee.\n",
+    "\n",
+    "Ce probleme trivial sert de **sanity check** : un planificateur BFS doit trouver le plan `[allumer]`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b8d20167",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:05.024345Z",
+     "iopub.status.busy": "2026-07-06T06:23:05.024164Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.212139Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.212025Z"
+    },
+    "papermill": {
+     "duration": 0.191247,
+     "end_time": "2026-07-06T06:23:05.212197",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.020950",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etat initial  : {lampe_eteinte, lampe_fonctionne}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "But           : {lampe_allumee}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "But atteint directement ? False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'allumer' applicable ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apres 'allumer' : {lampe_allumee, lampe_fonctionne}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "But atteint apres 'allumer' ? True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple de l'interrupteur (sanity check).\n",
+    "\n",
+    "var allumer = new Operator {\n",
+    "    Name = \"allumer\",\n",
+    "    Pre = new HashSet<string> { \"lampe_fonctionne\" },\n",
+    "    Add = new HashSet<string> { \"lampe_allumee\" },\n",
+    "    Del = new HashSet<string> { \"lampe_eteinte\" }\n",
+    "};\n",
+    "var eteindre = new Operator {\n",
+    "    Name = \"eteindre\",\n",
+    "    Pre = new HashSet<string> { \"lampe_allumee\" },\n",
+    "    Add = new HashSet<string> { \"lampe_eteinte\" },\n",
+    "    Del = new HashSet<string> { \"lampe_allumee\" }\n",
+    "};\n",
+    "\n",
+    "HashSet<string> initial = new HashSet<string> { \"lampe_eteinte\", \"lampe_fonctionne\" };\n",
+    "var goal = new HashSet<string> { \"lampe_allumee\" };\n",
+    "\n",
+    "Console.WriteLine(\"Etat initial  : {\" + string.Join(\", \", initial.OrderBy(x => x)) + \"}\");\n",
+    "Console.WriteLine(\"But           : {\" + string.Join(\", \", goal) + \"}\");\n",
+    "Console.WriteLine(\"But atteint directement ? \" + GoalReached(goal, initial));\n",
+    "Console.WriteLine(\"'allumer' applicable ? \" + IsApplicable(allumer, initial));\n",
+    "var apres = Apply(allumer, initial);\n",
+    "Console.WriteLine(\"Apres 'allumer' : {\" + string.Join(\", \", apres.OrderBy(x => x)) + \"}\");\n",
+    "Console.WriteLine(\"But atteint apres 'allumer' ? \" + GoalReached(goal, apres));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d1c8dc6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002084,
+     "end_time": "2026-07-06T06:23:05.216933",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.214849",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation — l'interrupteur\n",
+    "\n",
+    "L'etat initial ne contient pas le but (`lampe_allumee` absent). L'action `allumer` est applicable car sa precondition `lampe_fonctionne` est satisfaite. Apres application, `lampe_allumee` est ajoutee → le but est atteint. Sanity OK : le plan `[allumer]` resout le probleme.\n",
+    "\n",
+    "C'est exactement ce que ferait `unified-planning` (twin Python) en un appel — mais ici on **voit** chaque etape (precondition, ajout, retrait).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84c1ff43",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002264,
+     "end_time": "2026-07-06T06:23:05.221378",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.219114",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Le planificateur BFS from-scratch\n",
+    "\n",
+    "Un planificateur = une **recherche dans l'espace d'etats**. L'espace d'etats = graphe ou les noeuds sont les etats et les aretes sont les operateurs applicables. On cherche un chemin de l'etat initial a un etat-but.\n",
+    "\n",
+    "**BFS (Breadth-First Search)** = parcours en largeur. Garantit le **plan le plus court** (en nombre d'actions). Pour un petit espace d'etats, BFS suffit. Pour de grands espaces, on aurait besoin d'heuristiques (A*, relaxations — cf Planners-5).\n",
+    "\n",
+    "Implementation : une file d'etats a explorer, un dictionnaire `etat -> (operateur, etat parent)` pour reconstruire le plan une fois le but atteint.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c896af4e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:05.226766Z",
+     "iopub.status.busy": "2026-07-06T06:23:05.226572Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.414034Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.413941Z"
+    },
+    "papermill": {
+     "duration": 0.190714,
+     "end_time": "2026-07-06T06:23:05.414171",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.223457",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Planificateur BFS compile.\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(3,20): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(45,30): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(45,41): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Planificateur BFS from-scratch — trouve le plan le plus court.\n",
+    "\n",
+    "static List<string>? PlanBFS(HashSet<string> initial, HashSet<string> goal, List<Operator> ops, int maxExpansions = 100000) {\n",
+    "    var queue = new Queue<HashSet<string>>();\n",
+    "    queue.Enqueue(initial);\n",
+    "    // came_from[etat] = (operateur applique, etat parent)\n",
+    "    var cameFrom = new Dictionary<string, (string opName, HashSet<string> parent)>(new StateComparer());\n",
+    "    cameFrom[StateKey(initial)] = (\"__INIT__\", initial);\n",
+    "\n",
+    "    int expansions = 0;\n",
+    "    while (queue.Count > 0 && expansions < maxExpansions) {\n",
+    "        var current = queue.Dequeue();\n",
+    "        expansions++;\n",
+    "        if (GoalReached(goal, current)) {\n",
+    "            // Reconstruire le plan.\n",
+    "            var plan = new List<string>();\n",
+    "            var key = StateKey(current);\n",
+    "            while (cameFrom[key].opName != \"__INIT__\") {\n",
+    "                var (opName, parent) = cameFrom[key];\n",
+    "                plan.Add(opName);\n",
+    "                key = StateKey(parent);\n",
+    "            }\n",
+    "            plan.Reverse();\n",
+    "            return plan;\n",
+    "        }\n",
+    "        foreach (var op in ops) {\n",
+    "            if (IsApplicable(op, current)) {\n",
+    "                var next = Apply(op, current);\n",
+    "                var nkey = StateKey(next);\n",
+    "                if (!cameFrom.ContainsKey(nkey)) {\n",
+    "                    cameFrom[nkey] = (op.Name, current);\n",
+    "                    queue.Enqueue(next);\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return null;  // pas de plan trouve dans maxExpansions\n",
+    "}\n",
+    "\n",
+    "// Cle string canonique pour un etat (predicats tries).\n",
+    "static string StateKey(HashSet<string> s) => string.Join(\"|\", s.OrderBy(x => x));\n",
+    "\n",
+    "// Comparateur d'etats base sur la cle string.\n",
+    "class StateComparer : IEqualityComparer<string> {\n",
+    "    public bool Equals(string? a, string? b) => a == b;\n",
+    "    public int GetHashCode(string s) => s?.GetHashCode() ?? 0;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Planificateur BFS compile.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38f56513",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002185,
+     "end_time": "2026-07-06T06:23:05.418756",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.416571",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Plan sur l'interrupteur\n",
+    "\n",
+    "Lançons BFS sur le probleme de l'interrupteur. Il doit trouver `[allumer]` (1 action, le plus court).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1ef47fda",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:05.425643Z",
+     "iopub.status.busy": "2026-07-06T06:23:05.425465Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.490844Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.490738Z"
+    },
+    "papermill": {
+     "duration": 0.069514,
+     "end_time": "2026-07-06T06:23:05.490900",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.421386",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plan trouve (1 action(s)) : [allumer]\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Plan sur l'interrupteur.\n",
+    "var ops = new List<Operator> { allumer, eteindre };\n",
+    "var plan = PlanBFS(initial, goal, ops);\n",
+    "if (plan != null) {\n",
+    "    Console.WriteLine($\"Plan trouve ({plan.Count} action(s)) : [{string.Join(\" -> \", plan)}]\");\n",
+    "} else {\n",
+    "    Console.WriteLine(\"Aucun plan trouve.\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dbe5489",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00255,
+     "end_time": "2026-07-06T06:23:05.495909",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.493359",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Probleme plus riche — multi-interrupteurs (non-trivial)\n",
+    "\n",
+    "L'interrupteur seul est trivial (1 action). Pour **mettre en valeur** le planificateur (cf #3801 Prong B — probleme non-trivial), considerons **N interrupteurs** a allumer dans un ordre quelconque, mais avec une contrainte : une **maitresse** (master switch) doit etre allumee avant de pouvoir allumer les autres (precondition chainee). Le but = tous les interrupteurs allumes.\n",
+    "\n",
+    "Ce probleme a une **structure** (la maitresse d'abord) que BFS doit decouvrir — ce n'est pas un graphe a cout uniforme trivial.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "13ecf78f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:05.503447Z",
+     "iopub.status.busy": "2026-07-06T06:23:05.503227Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.619800Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.619640Z"
+    },
+    "papermill": {
+     "duration": 0.121036,
+     "end_time": "2026-07-06T06:23:05.619874",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.498838",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Probleme : 3 interrupteurs + 1 maitresse\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etat initial : 4 predicats (tout eteint)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "But : master_on + 3 switch_*_on\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plan trouve (4 actions) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [allumer_master -> allumer_sw1 -> allumer_sw2 -> allumer_sw3]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'allumer_master' a la position 1/4 — doit etre PREMIERE (precondition chainee).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Structure decouverte par BFS : maitresse d'abord, puis les 3 interrupteurs (ordre arbitraire).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// N interrupteurs + maitresse (probleme non-trivial).\n",
+    "int N = 3;\n",
+    "var multiOps = new List<Operator>();\n",
+    "// allumer_master : pre = rien ; add = master_on\n",
+    "multiOps.Add(new Operator {\n",
+    "    Name = \"allumer_master\",\n",
+    "    Pre = new HashSet<string>(),\n",
+    "    Add = new HashSet<string> { \"master_on\" },\n",
+    "    Del = new HashSet<string> { \"master_off\" }\n",
+    "});\n",
+    "// allumer_i : pre = master_on ; add = switch_i_on ; del = switch_i_off\n",
+    "for (int i = 1; i <= N; i++) {\n",
+    "    int idx = i;\n",
+    "    multiOps.Add(new Operator {\n",
+    "        Name = $\"allumer_sw{idx}\",\n",
+    "        Pre = new HashSet<string> { \"master_on\" },\n",
+    "        Add = new HashSet<string> { $\"switch_{idx}_on\" },\n",
+    "        Del = new HashSet<string> { $\"switch_{idx}_off\" }\n",
+    "    });\n",
+    "}\n",
+    "\n",
+    "HashSet<string> multiInitial = new HashSet<string>();\n",
+    "multiInitial.Add(\"master_off\");\n",
+    "for (int i = 1; i <= N; i++) multiInitial.Add($\"switch_{i}_off\");\n",
+    "\n",
+    "var multiGoal = new HashSet<string> { \"master_on\" };\n",
+    "for (int i = 1; i <= N; i++) multiGoal.Add($\"switch_{i}_on\");\n",
+    "\n",
+    "Console.WriteLine($\"Probleme : {N} interrupteurs + 1 maitresse\");\n",
+    "Console.WriteLine($\"Etat initial : {multiInitial.Count} predicats (tout eteint)\");\n",
+    "Console.WriteLine($\"But : master_on + {N} switch_*_on\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "var multiPlan = PlanBFS(multiInitial, multiGoal, multiOps);\n",
+    "if (multiPlan != null) {\n",
+    "    Console.WriteLine($\"Plan trouve ({multiPlan.Count} actions) :\");\n",
+    "    Console.WriteLine($\"  [{string.Join(\" -> \", multiPlan)}]\");\n",
+    "    Console.WriteLine();\n",
+    "    // Verifier : master_on doit preceder tous allumer_sw*\n",
+    "    int masterIdx = multiPlan.IndexOf(\"allumer_master\");\n",
+    "    Console.WriteLine($\"'allumer_master' a la position {masterIdx + 1}/{multiPlan.Count} — doit etre PREMIERE (precondition chainee).\");\n",
+    "    Console.WriteLine($\"Structure decouverte par BFS : maitresse d'abord, puis les {N} interrupteurs (ordre arbitraire).\");\n",
+    "} else {\n",
+    "    Console.WriteLine(\"Aucun plan trouve.\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbe69b49",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003306,
+     "end_time": "2026-07-06T06:23:05.626659",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.623353",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation — multi-interrupteurs\n",
+    "\n",
+    "BFS decouvre automatiquement la **structure du probleme** :\n",
+    "- Il faut **d'abord** allumer la maitresse (seule action applicable sans precondition).\n",
+    "- **Puis** allumer chaque interrupteur (precondition `master_on` satisfaite).\n",
+    "\n",
+    "Le plan a `N+1` actions : `allumer_master` puis `allumer_sw1`, `allumer_sw2`, ..., `allumer_swN` (l'ordre des `sw*` est arbitraire — BFS trouve l'un des plans optimaux). C'est exactement le genre de plan que `unified-planning` produirait, mais ici on **voit** la recherche explorer l'espace d'etats.\n",
+    "\n",
+    "**Pourquoi c'est non-trivial** : sans precondition chainee, le probleme serait degenere (toutes les actions independantes). La maitresse force un **ordre partiel** que le planificateur doit decouvrir — c'est ce qui met BFS en valeur (cf #3801 Prong B, probleme non-degenere).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "904a4deb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003606,
+     "end_time": "2026-07-06T06:23:05.633615",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.630009",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Explosion combinatoire de l'espace d'etats\n",
+    "\n",
+    "Avec $n$ predicats (faits booléens), il y a jusqu'a $2^n$ etats possibles. Pour 10 predicats = 1024 etats, pour 20 = 1 million, pour 50 = $10^{15}$... C'est le **fleau de la combinatoire** qui motive les heuristiques (A*, relaxations — cf Planners-5).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e0dc89a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:05.642753Z",
+     "iopub.status.busy": "2026-07-06T06:23:05.642346Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.759060Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.758954Z"
+    },
+    "papermill": {
+     "duration": 0.12198,
+     "end_time": "2026-07-06T06:23:05.759116",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.637136",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Explosion combinatoire de l'espace d'etats (2^n) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  n predicats | etats possibles\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ----------- | ---------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "            5 |              32\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           10 |            1024\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           15 |           32768\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           20 |       1.05E+006\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           30 |       1.07E+009\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           50 |       1.13E+015\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> 50 predicats = ~1e15 etats : aucun planificateur aveugle (BFS) ne peut explorer.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> D'ou les HEURISTIQUES (A*, relaxations) pour guider la recherche (cf Planners-5).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Explosion combinatoire : 2^n etats pour n predicats.\n",
+    "Console.WriteLine(\"Explosion combinatoire de l'espace d'etats (2^n) :\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"  n predicats | etats possibles\");\n",
+    "Console.WriteLine(\"  ----------- | ---------------\");\n",
+    "foreach (int n in new[] { 5, 10, 15, 20, 30, 50 }) {\n",
+    "    double states = Math.Pow(2, n);\n",
+    "    string repr = states < 1e6 ? FI(states, \"F0\") : states.ToString(\"E2\", CultureInfo.InvariantCulture);\n",
+    "    Console.WriteLine($\"  {n,11} | {repr,15}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\">>> 50 predicats = ~1e15 etats : aucun planificateur aveugle (BFS) ne peut explorer.\");\n",
+    "Console.WriteLine(\">>> D'ou les HEURISTIQUES (A*, relaxations) pour guider la recherche (cf Planners-5).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af408776",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003456,
+     "end_time": "2026-07-06T06:23:05.766855",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.763399",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Types de planification\n",
+    "\n",
+    "La planification se declinent en plusieurs variantes (cf twin Python) :\n",
+    "\n",
+    "| Type | Caractéristique | Exemple |\n",
+    "|------|-----------------|---------|\n",
+    "| **Classique** | etats discrets, actions instantanées, deterministes | empiler des blocs, logistique |\n",
+    "| **Temporelle** | actions avec durée, chevauchement | ordonnancement de tâches |\n",
+    "| **HTN** (Hierarchical Task Network) | décomposition de tâches abstraites | planification militaire, cuisine |\n",
+    "| **Neuro-symbolique** | LLM + planificateur formel | agent LLM avec vérification |\n",
+    "\n",
+    "Ce notebook couvre les **fondations classiques** (STRIPS + BFS). Les notebooks suivants (PDDL, heuristiques, etc.) approfondissent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18c2fd01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003342,
+     "end_time": "2026-07-06T06:23:05.773588",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.770246",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 10. Exercices\n",
+    "\n",
+    "Trois exercices pour aller plus loin. Chaque stub est conforme a la regle C.1 (pas d'erreur volontaire — le notebook s'execute de bout en bout meme exercices non completes).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6429234",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002934,
+     "end_time": "2026-07-06T06:23:05.779616",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.776682",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Le monde des blocs (blocks world)\n",
+    "\n",
+    "**Enonce** : Modelisez le **monde des blocs** : 3 blocs A, B, C. Etat initial : A sur la table, B sur A, C sur la table. But : C sur B sur A (pyramide). Actions : `deplacer(x, y, z)` (pre: x sur y, bras libre ; add: x sur z ; del: x sur y).\n",
+    "\n",
+    "**Etape 1** : Definissez les operateurs (avec les predicats `sur(x,y)`, ` Bras_libre`, `sur_table(x)`).\n",
+    "**Etape 2** : Codez l'etat initial et le but.\n",
+    "**Etape 3** : Lancez `PlanBFS` et observez le plan.\n",
+    "\n",
+    "**Indice** : attention aux precondition `Bras_libre` — un seul bloc peut etre deplace a la fois. C'est un probleme classique (Sussman anomaly) plus riche que l'interrupteur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "081734da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:05.786853Z",
+     "iopub.status.busy": "2026-07-06T06:23:05.786696Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.837298Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.837175Z"
+    },
+    "papermill": {
+     "duration": 0.054722,
+     "end_time": "2026-07-06T06:23:05.837362",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.782640",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : monde des blocs (blocks world).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 — Monde des blocs (A sur table, B sur A, C sur table -> C sur B sur A).\n",
+    "// TODO etudiant : definissez les operateurs deplacer + etat initial + but, lancez PlanBFS.\n",
+    "Console.WriteLine(\"Exercice 1 a completer : monde des blocs (blocks world).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb56c748",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003796,
+     "end_time": "2026-07-06T06:23:05.844538",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.840742",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Ajouter une heuristique (A* au lieu de BFS)\n",
+    "\n",
+    "**Enonce** : BFS trouve le plan le plus court mais explore en aveugle. Implementez **A*** avec une heuristique simple : nombre de predicats du but non encore satisfaits dans l'etat courant.\n",
+    "\n",
+    "**Questions** : (a) A* explore-t-il moins d'etats que BFS sur le multi-interrupteurs ? (b) L'heuristique est-elle **admissible** (ne surestime jamais le cout) ?\n",
+    "\n",
+    "**Indice** : remplacez la `Queue` BFS par une `PriorityQueue` ordonnée par `g + h` (cout parcouru + heuristique). `g` = nombre d'actions depuis l'initial, `h` = predicats du but manquants.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8c79e00b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:05.851719Z",
+     "iopub.status.busy": "2026-07-06T06:23:05.851552Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.877196Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.877067Z"
+    },
+    "papermill": {
+     "duration": 0.029561,
+     "end_time": "2026-07-06T06:23:05.877260",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.847699",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : A* avec heuristique de but non-satisfait.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 — A* avec heuristique (predicats du but manquants).\n",
+    "// TODO etudiant : PriorityQueue g+h, h = |goal - S|, comparez explorations vs BFS.\n",
+    "Console.WriteLine(\"Exercice 2 a completer : A* avec heuristique de but non-satisfait.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "161351c5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003315,
+     "end_time": "2026-07-06T06:23:05.884367",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.881052",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Echec : probleme non-realisable\n",
+    "\n",
+    "**Enonce** : Creez un probleme **sans solution** (ex: but = lampe allumee, mais `lampe_fonctionne` absent de l'etat initial et aucune action ne l'etablit). Observez le comportement de `PlanBFS` (retourne `null` apres `maxExpansions`).\n",
+    "\n",
+    "**Questions** : (a) Combien d'etats BFS explore-t-il avant d'abandonner ? (b) Comment detecter l'**insatisfiabilite** plus tot (ex: analyse des preconditions — un fait du but non atteignable par aucun effet d'ajout) ?\n",
+    "\n",
+    "**Indice** : `maxExpansions` borne l'exploration. Un fait du but qui n'apparait dans aucun `Add` d'operateur est **mort** — detection statique possible.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "da8af1e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:05.891731Z",
+     "iopub.status.busy": "2026-07-06T06:23:05.891568Z",
+     "iopub.status.idle": "2026-07-06T06:23:05.920558Z",
+     "shell.execute_reply": "2026-07-06T06:23:05.920448Z"
+    },
+    "papermill": {
+     "duration": 0.033081,
+     "end_time": "2026-07-06T06:23:05.920615",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.887534",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : probleme non-realisable + detection statique.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 — Probleme non-realisable (but avec fait non-atteignable).\n",
+    "// TODO etudiant : etat initial sans lampe_fonctionne, but lampe_allumee, observez null.\n",
+    "Console.WriteLine(\"Exercice 3 a completer : probleme non-realisable + detection statique.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55c58a24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002934,
+     "end_time": "2026-07-06T06:23:05.926584",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:05.923650",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 11. Conclusion — Tranche 1 fondations\n",
+    "\n",
+    "**Ce que nous avons appris** :\n",
+    "\n",
+    "| Concept | Definition |\n",
+    "|---------|------------|\n",
+    "| **Planification** | Generer une sequence d'actions pour atteindre un but |\n",
+    "| **STRIPS** | Formalisme : etat = predicats, operateur = pre/add/del |\n",
+    "| **Transition** | $(S \\setminus del) \\cup add$ si $pre \\subseteq S$ |\n",
+    "| **BFS planner** | Recherche en largeur dans l'espace d'etats (plan le plus court) |\n",
+    "| **Explosion combinatoire** | $2^n$ etats pour $n$ predicats → motive les heuristiques |\n",
+    "\n",
+    "**Lecon cles** : un planificateur = une **recherche dans l'espace d'etats construit a partir de la semantique des actions**. Le twin Python `unified-planning` invoque un solveur ; ce twin from-scratch **construit** le solveur (modele STRIPS + BFS). Les deux sont complementaires : comprendre vs resoudre vite.\n",
+    "\n",
+    "**Suite** : PDDL (Planners-2 — le langage standard pour decrire ces problemes), heuristiques (Planners-5 — A*, relaxations pour combattre l'explosion combinatoire).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Implementation from-scratch, BCL .NET seule, 0 NuGet. Twin du notebook Python unified-planning [Planners-1-Introduction](Planners-1-Introduction.ipynb). Marathon #4956 (premier jumeau C# de la serie Planners).*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "duration": 4.801614,
+   "end_time": "2026-07-06T06:23:06.061749",
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/3cb4a5e4-afad-4632-af95-d13a321e6664/scratchpad/planners1_out.ipynb",
+   "start_time": "2026-07-06T06:23:01.260135"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

**Twin C#** de [Planners-1-Introduction](MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb) (Python + lib `unified-planning`). **Premier jumeau C# de la série Planners** (marathon #4956, famille fraîche — pivot Rule 6 hors du registre .NET Search/GameTheory/Tweety). Cette **tranche 1 = fondations** : modèle **STRIPS** (Fikes & Nilsson 1971), espace d'états, planificateur **BFS from-scratch**.

## Algorithme (STRIPS + BFS)

STRIPS : état = `HashSet<string>` de prédicats ; opérateur = (nom, preconditions, add, del). Transition : `applicable` ssi `pre ⊆ S` ; successeur = `(S \ del) ∪ add`. Planificateur BFS = parcours en largeur de l'espace d'états (garantit plan le plus court).

## Complémentarité (#3801 Prong B)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python (unified-planning) | `up.shortcuts` (modélisation + solveur 1 appel) | résoudre vite des problèmes PDDL réels |
| **This (.NET from-scratch)** | implémentation C# main : STRIPS + BFS + state-space | **comprendre** la sémantique STRIPS et la recherche |

Pas d'équivalent NuGet maintenu et didactique à `unified-planning` en .NET → from-scratch = la valeur pédagogique. BCL .NET seule, 0 NuGet.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **10/10 cellules code `execution_count` 1-10, 0 erreur**. Outputs vérifiés **firsthand** :

- **Switch (sanity)** : But `lampe_allumee` non atteint initialement ; `allumer` applicable (pre `lampe_fonctionne` ✓) ; après → but atteint ✓
- **BFS plan switch** : `[allumer]` (1 action, optimal — plan le plus court) ✓
- **Multi-interrupteurs (non-trivial, #3801 Prong B)** : 3 switches + master (precondition chainée). BFS découvre `[allumer_master -> allumer_sw1 -> sw2 -> sw3]` (4 actions), `allumer_master` en **position 1/4** = structure partiellement ordonnée découverte automatiquement ✓ — non-dégénéré (sans precondition chainée, le problème serait trivial)
- **Explosion combinatoire** : table 2^n (5→32, 10→1024, 50→1e15) = motive les heuristiques (A*, Planners-5) ✓

## SOTA-OK (#3801)

From-scratch = la valeur pédagogique. Problème non-trivial : multi-interrupteurs avec precondition chainée (master d'abord) — BFS doit découvrir l'ordre partiel, pas un graphe à coût uniforme dégénéré.

## Exercices (#2161)

3 stubs C.1-conformes : (1) monde des blocs (blocks world, Sussman), (2) A* avec heuristique (prédicats du but manquants), (3) problème non-réalisable + détection statique.

## Bug G.1 self-corrected

`using State = HashSet<string>;` (type alias) au top-level d'une cellule .NET Interactive **ne s'applique pas** aux déclarations `class`/`method` qui suivent dans les cells suivantes (scope alias) → compile error. **Fix** : abandonner l'alias, utiliser `HashSet<string>` concret partout (pattern .NET Interactive : pas de type-alias cross-cell).

## Scope

Atomique : 1 notebook (~980 lignes), 0 churn catalogue. Self-contained (vit sans dépendance externe — BCL seule).

## Marathon #4956

Premier jumeau C# de la série Planners (12 notebooks Python existants, 0 twin). Tranches suivantes possibles : Planners-3-State-Space (BFS/Dijkstra/A* sur grille), Planners-5-Heuristics (A*, relaxations).

**Revue souhaitée** : po-2025 ou ai-01.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
