### PR TITLE
feat(sl): SL-2-KnowledgeBasedLearning-Csharp — .NET twin (EBL + RBL)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -209,6 +209,8 @@ Note : dans SL-7, le premier exercice de la numérotation interne est un exemple
 | EBL - Efficacité | Opérationalité vs généralité, prolifération de règles |
 | RBL - Introduction | Déterminations, vérification fonctionnelle, réduction d'espace (approfondi dans SL-3) |
 
+> **Parité .NET** : [SL-2-KnowledgeBasedLearning-Csharp.ipynb](SL-2-KnowledgeBasedLearning-Csharp.ipynb) est le jumeau C# (.NET Interactive) — EBL (chaînage avant + unification, arbre de preuve, variabilisation) et RBL (vérification de détermination) implémentés from-scratch, sans lib ML. Marathon parité .NET ⇄ Python (#4956).
+
 ### SL-3-RelevanceLearning.ipynb
 
 | Section | Contenu |
@@ -425,6 +427,7 @@ Le treillis des déterminations croît exponentiellement avec le nombre d'attrib
 SymbolicLearning/
 ├── SL-1-LogicalLearning.ipynb              # CBH, Version Space
 ├── SL-2-KnowledgeBasedLearning.ipynb        # EBL, RBL
+├── SL-2-KnowledgeBasedLearning-Csharp.ipynb # Jumeau C# (.NET Interactive) — EBL + RBL, parité #4956
 ├── SL-3-RelevanceLearning.ipynb             # Treillis, MINIMAL-CONSISTENT-DET, RBL vs sklearn
 ├── SL-4-InductiveLogicProgramming.ipynb     # FOIL, résolution inverse, knowledge graphs
 ├── SL-5-InverseResolution.ipynb             # LGG, theta-subsomption, clause bottom, Progol

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
@@ -1,0 +1,1240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "833fe12e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002672,
+     "end_time": "2026-07-06T06:23:09.922760+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:09.920088+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# SL-2 - Apprentissage et Connaissance : EBL & RBL (C#)\n",
+    "\n",
+    "> **Jumeau C#** du notebook [SL-2-KnowledgeBasedLearning.ipynb](SL-2-KnowledgeBasedLearning.ipynb).\n",
+    "> Version Python ↔ Version C# (.NET Interactive) — parité pédagogique du marathon #4956.\n",
+    "> Algorithmes AIMA ch.19.3 (EBL) + 19.4 (RBL), implémentés from-scratch en C# pur.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Distinguer** les 4 contraintes d'apprentissage (induction pure, EBL, RBL, KBIL).\n",
+    "2. **Implémenter** la vérification par énumération de modèles (mini-monde propositionnel).\n",
+    "3. **Exécuter** le chaînage avant avec unification (moteur EBL).\n",
+    "4. **Construire** un arbre de preuve EBL (simplification arithmétique) + le variabiliser.\n",
+    "5. **Mesurer** le speedup apporté par les règles apprises.\n",
+    "6. **Vérifier** une détermination RBL (attributs déterminants).\n",
+    "\n",
+    "### Prérequis\n",
+    "- Notions de logique propositionnelle + chaînage avant.\n",
+    "- .NET 9.0 + dotnet-interactive (kernel `.net-csharp`).\n",
+    "- Avoir suivi [SL-1-LogicalLearning-Csharp.ipynb](SL-1-LogicalLearning-Csharp.ipynb) (CBH / Version Space).\n",
+    "\n",
+    "### Durée estimée : 55 minutes\n",
+    "\n",
+    "### Références\n",
+    "- Russell & Norvig, *AIMA* (3e éd.), §19.3-19.4.\n",
+    "- Notebook Python : [SL-2-KnowledgeBasedLearning.ipynb](SL-2-KnowledgeBasedLearning.ipynb).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfb36b89",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001732,
+     "end_time": "2026-07-06T06:23:09.926680+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:09.924948+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Les 4 contraintes d'apprentissage\n",
+    "\n",
+    "AIMA distingue 4 façons dont la connaissance interagit avec l'apprentissage. On les\n",
+    "vérifie par **énumération de modèles** sur un mini-monde propositionnel à 3 atomes\n",
+    "(`pointu`, `perce`, `tue`) — l'exemple du bâton de Zog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "84828b87",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:09.939732Z",
+     "iopub.status.busy": "2026-07-06T06:23:09.933918Z",
+     "iopub.status.idle": "2026-07-06T06:23:12.132430Z",
+     "shell.execute_reply": "2026-07-06T06:23:12.126793Z"
+    },
+    "papermill": {
+     "duration": 2.204806,
+     "end_time": "2026-07-06T06:23:12.133190+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:09.928384+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1311680.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contraintes d'apprentissage (AIMA 19.3-19.5) vérifiées par énumération\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1. Induction pure (SL-1) : H ^ Desc |= Class\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   -> True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2. EBL : Background |= Hypothese\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   (pointu=>perce)^(perce=>tue) |= (pointu=>tue) ? -> True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   H était déjà déductible : EBL ne découvre rien, il COMPILE.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3. RBL : Background ^ Desc ^ Class |= Hypothese\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   -> True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4. KBIL : Background ^ H ^ Desc |= Class\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   -> True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Linq;\n",
+    "\n",
+    "// Mini-monde propositionnel : 3 atomes.\n",
+    "string[] ATOMS = {\"pointu\", \"perce\", \"tue\"};\n",
+    "\n",
+    "// Une formule = une fonction modèle -> bool. Un modèle = dict atome -> bool.\n",
+    "bool Entails(List<Func<Dictionary<string,bool>,bool>> kb,\n",
+    "             Func<Dictionary<string,bool>,bool> query) {\n",
+    "    // KB |= query ssi query est vraie dans TOUS les modèles où KB est vraie.\n",
+    "    foreach (var values in AllAssignments(ATOMS.Length)) {\n",
+    "        var model = new Dictionary<string,bool>();\n",
+    "        for (int i = 0; i < ATOMS.Length; i++) model[ATOMS[i]] = values[i];\n",
+    "        if (kb.All(f => f(model)) && !query(model)) return false;\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Énumère les 2^n combinaisons booléennes (produit cartésien).\n",
+    "IEnumerable<bool[]> AllAssignments(int n) {\n",
+    "    for (int mask = 0; mask < (1 << n); mask++) {\n",
+    "        var v = new bool[n];\n",
+    "        for (int i = 0; i < n; i++) v[i] = (mask & (1 << i)) != 0;\n",
+    "        yield return v;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Connaissance de fond : pointu => perce, perce => tue.\n",
+    "var background = new List<Func<Dictionary<string,bool>,bool>> {\n",
+    "    m => (!m[\"pointu\"]) || m[\"perce\"],\n",
+    "    m => (!m[\"perce\"]) || m[\"tue\"],\n",
+    "};\n",
+    "// Observation : Description = pointu ; Classification = tue.\n",
+    "Func<Dictionary<string,bool>,bool> description = m => m[\"pointu\"];\n",
+    "Func<Dictionary<string,bool>,bool> classification = m => m[\"tue\"];\n",
+    "// Hypothèse candidate H : pointu => tue.\n",
+    "Func<Dictionary<string,bool>,bool> hypothesis = m => (!m[\"pointu\"]) || m[\"tue\"];\n",
+    "\n",
+    "Console.WriteLine(\"Contraintes d'apprentissage (AIMA 19.3-19.5) vérifiées par énumération\");\n",
+    "Console.WriteLine(new string('=', 70));\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"1. Induction pure (SL-1) : H ^ Desc |= Class\");\n",
+    "Console.WriteLine($\"   -> {Entails(new(){hypothesis, description}, classification)}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"2. EBL : Background |= Hypothese\");\n",
+    "Console.WriteLine($\"   (pointu=>perce)^(perce=>tue) |= (pointu=>tue) ? -> {Entails(background, hypothesis)}\");\n",
+    "Console.WriteLine(\"   H était déjà déductible : EBL ne découvre rien, il COMPILE.\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"3. RBL : Background ^ Desc ^ Class |= Hypothese\");\n",
+    "var rblKb = new List<Func<Dictionary<string,bool>,bool>>{description, classification};\n",
+    "rblKb.AddRange(background);\n",
+    "Console.WriteLine($\"   -> {Entails(rblKb, hypothesis)}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"4. KBIL : Background ^ H ^ Desc |= Class\");\n",
+    "var kbilKb = new List<Func<Dictionary<string,bool>,bool>>{hypothesis, description};\n",
+    "kbilKb.AddRange(background);\n",
+    "Console.WriteLine($\"   -> {Entails(kbilKb, classification)}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e11f0b6d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003377,
+     "end_time": "2026-07-06T06:23:12.139983+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.136606+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. EBL : chaînage avant avec unification\n",
+    "\n",
+    "EBL **explique** un exemple en rejouant la déduction à partir des règles de fond.\n",
+    "On implémente un moteur de **chaînage avant** avec unification (pattern matching\n",
+    "de prédicats à variables) jusqu'au point fixe. L'exemple : le bâton pointu de Zog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "af71d914",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:12.147506Z",
+     "iopub.status.busy": "2026-07-06T06:23:12.147267Z",
+     "iopub.status.idle": "2026-07-06T06:23:12.502468Z",
+     "shell.execute_reply": "2026-07-06T06:23:12.502245Z"
+    },
+    "papermill": {
+     "duration": 0.359729,
+     "end_time": "2026-07-06T06:23:12.502560+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.142831+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exemple EBL : le bâton pointu de Zog, chaînage avant\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Faits observés : PeauMolle(Gibier) ; Pointu(Baton) ; Vivant(Gibier)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dérivations :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Pointu(Baton)  =>  Perce(Baton)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Perce(Baton) ^ PeauMolle(Gibier)  =>  TraversePeau(Baton,Gibier)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  TraversePeau(Baton,Gibier) ^ Vivant(Gibier)  =>  Hemorragie(Gibier)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Hemorragie(Gibier)  =>  Meurt(Gibier)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classification expliquée : Meurt(Gibier) ?  True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Représentation : un atome = (prédicat, args). Variables en minuscules.\n",
+    "// Comparateur structurel (sinon string[] est comparé par référence => boucle infinie).\n",
+    "public class AtomEq : IEqualityComparer<(string,string[])> {\n",
+    "    public bool Equals((string,string[]) x, (string,string[]) y) =>\n",
+    "        x.Item1 == y.Item1 && x.Item2.SequenceEqual(y.Item2);\n",
+    "    public int GetHashCode((string,string[]) x) {\n",
+    "        int h = x.Item1.GetHashCode();\n",
+    "        foreach (var a in x.Item2) h = HashCode.Combine(h, a);\n",
+    "        return h;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "bool IsVar(string term) => term.Length > 0 && char.IsLower(term[0]);\n",
+    "\n",
+    "// Unifie un atome-pattern (avec variables) avec un fait clos ; null si échec.\n",
+    "Dictionary<string,string> UnifyAtom((string,string[]) pattern, (string,string[]) fact,\n",
+    "                                     Dictionary<string,string> bindings) {\n",
+    "    if (pattern.Item1 != fact.Item1 || pattern.Item2.Length != fact.Item2.Length) return null;\n",
+    "    var b = new Dictionary<string,string>(bindings);\n",
+    "    for (int i = 0; i < pattern.Item2.Length; i++) {\n",
+    "        string p = pattern.Item2[i], f = fact.Item2[i];\n",
+    "        if (IsVar(p)) { if (b.TryGetValue(p, out var v) && v != f) return null; b[p] = f; }\n",
+    "        else if (p != f) return null;\n",
+    "    }\n",
+    "    return b;\n",
+    "}\n",
+    "\n",
+    "// Chaînage avant jusqu'au point fixe. Retourne (faits dérivés, trace).\n",
+    "(HashSet<(string,string[])> facts, List<(List<(string,string[])> body, Dictionary<string,string> b, (string,string[]) head)> trace)\n",
+    "    ForwardChain(List<(List<(string,string[])> Body,(string,string[]) Head)> rules,\n",
+    "                 HashSet<(string,string[])> facts) {\n",
+    "    var trace = new List<(List<(string,string[])>, Dictionary<string,string>, (string,string[]))>();\n",
+    "    bool changed = true;\n",
+    "    while (changed) {\n",
+    "        changed = false;\n",
+    "        var snapshot = facts.OrderBy(f => f.Item1 + string.Join(\"\", f.Item2)).ToList();\n",
+    "        foreach (var (body, head) in rules) {\n",
+    "            // DFS sur les atomes du body avec accumulations de liaisons.\n",
+    "            var stack = new Stack<(Dictionary<string,string>, int)>();\n",
+    "            stack.Push((new Dictionary<string,string>(), 0));\n",
+    "            while (stack.Count > 0) {\n",
+    "                var (bindings, k) = stack.Pop();\n",
+    "                if (k == body.Count) {\n",
+    "                    var newHead = (head.Item1, head.Item2.Select(a => bindings.TryGetValue(a, out var v) ? v : a).ToArray());\n",
+    "                    if (!facts.Contains(newHead)) {\n",
+    "                        facts.Add(newHead);\n",
+    "                        trace.Add((body.Select(b => (b.Item1, b.Item2.Select(a => bindings.TryGetValue(a,out var vv)?vv:a).ToArray())).ToList(), bindings, newHead));\n",
+    "                        changed = true;\n",
+    "                    }\n",
+    "                    continue;\n",
+    "                }\n",
+    "                foreach (var f in snapshot) {\n",
+    "                    var b2 = UnifyAtom(body[k], f, bindings);\n",
+    "                    if (b2 != null) stack.Push((b2, k + 1));\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return (facts, trace);\n",
+    "}\n",
+    "\n",
+    "string Fmt((string,string[]) atom) => $\"{atom.Item1}({string.Join(\",\", atom.Item2)})\";\n",
+    "\n",
+    "var RULES = new List<(List<(string,string[])> Body,(string,string[]) Head)> {\n",
+    "    (new(){(\"Pointu\",new[]{\"x\"})}, (\"Perce\",new[]{\"x\"})),\n",
+    "    (new(){(\"Perce\",new[]{\"x\"}),(\"PeauMolle\",new[]{\"y\"})}, (\"TraversePeau\",new[]{\"x\",\"y\"})),\n",
+    "    (new(){(\"TraversePeau\",new[]{\"x\",\"y\"}),(\"Vivant\",new[]{\"y\"})}, (\"Hemorragie\",new[]{\"y\"})),\n",
+    "    (new(){(\"Hemorragie\",new[]{\"y\"})}, (\"Meurt\",new[]{\"y\"})),\n",
+    "};\n",
+    "var FACTS = new HashSet<(string,string[])>(new AtomEq()) {\n",
+    "    (\"Pointu\", new[]{\"Baton\"}),\n",
+    "    (\"PeauMolle\", new[]{\"Gibier\"}),\n",
+    "    (\"Vivant\", new[]{\"Gibier\"}),\n",
+    "};\n",
+    "\n",
+    "var (derived, fcTrace) = ForwardChain(RULES, new HashSet<(string,string[])>(FACTS, new AtomEq()));\n",
+    "Console.WriteLine(\"Exemple EBL : le bâton pointu de Zog, chaînage avant\");\n",
+    "Console.WriteLine(new string('=', 60));\n",
+    "Console.WriteLine(\"Faits observés : \" + string.Join(\" ; \", FACTS.OrderBy(f=>f.Item1).Select(Fmt)));\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Dérivations :\");\n",
+    "foreach (var (body, b, head) in fcTrace)\n",
+    "    Console.WriteLine($\"  {string.Join(\" ^ \", body.Select(Fmt))}  =>  {Fmt(head)}\");\n",
+    "Console.WriteLine();\n",
+    "var goal = (\"Meurt\", new[]{\"Gibier\"});\n",
+    "Console.WriteLine($\"Classification expliquée : {Fmt(goal)} ?  {derived.Contains(goal)}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76864c51",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003714,
+     "end_time": "2026-07-06T06:23:12.510267+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.506553+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. EBL sur la simplification arithmétique\n",
+    "\n",
+    "Un 2e exemple d'EBL : simplifier `1*(0+x)` en `x`. On représente les expressions\n",
+    "comme des chaînes et les règles de fond comme des réécritures (`1*u → u`, `0+u → u`).\n",
+    "L'arbre de preuve explique chaque étape ; la **variabilisation** le généralise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "49c84277",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:12.518191Z",
+     "iopub.status.busy": "2026-07-06T06:23:12.517967Z",
+     "iopub.status.idle": "2026-07-06T06:23:12.701738Z",
+     "shell.execute_reply": "2026-07-06T06:23:12.701582Z"
+    },
+    "papermill": {
+     "duration": 0.188399,
+     "end_time": "2026-07-06T06:23:12.701804+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.513405+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Règles de réécriture chargées :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1*u -> u\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0+u -> u\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IsPrimitive('x')   = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IsPrimitive('0+x') = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IsPrimitive('42')  = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SimplifyStep('1*(0+x)') = ('(0+x)', 1*u -> u)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Règle de réécriture : pattern -> résultat (string-based pour lisibilité).\n",
+    "public record RewriteRule(string Name, string Pattern, string Result) {\n",
+    "    public string Apply(string expr) => expr.Contains(Pattern)\n",
+    "        ? expr.Replace(Pattern, Result)  // remplace 1re occurrence\n",
+    "        : null;\n",
+    "}\n",
+    "\n",
+    "var REWRITE_RULES = new List<RewriteRule> {\n",
+    "    new RewriteRule(\"1*u -> u\", \"1*\", \"\"),\n",
+    "    new RewriteRule(\"0+u -> u\", \"0+\", \"\"),\n",
+    "};\n",
+    "\n",
+    "bool IsPrimitive(string expr) {\n",
+    "    string s = expr.Trim();\n",
+    "    if (string.IsNullOrEmpty(s)) return false;\n",
+    "    string[] ops = {\"+\",\"-\",\"*\",\"/\"};\n",
+    "    return !ops.Any(op => s.Contains(op));\n",
+    "}\n",
+    "\n",
+    "// Une étape de simplification : (résultat, nom_règle, justification).\n",
+    "(string result, string rule, string justification) SimplifyStep(string expr) {\n",
+    "    foreach (var rule in REWRITE_RULES) {\n",
+    "        var r = rule.Apply(expr);\n",
+    "        if (r != null) return (r, rule.Name, $\"Rewrite({expr} -> {r})\");\n",
+    "    }\n",
+    "    if (IsPrimitive(expr)) return (expr, \"primitive\", $\"Primitive({expr}) => Simplify({expr} -> {expr})\");\n",
+    "    return (expr, \"bloqué\", \"Aucune règle applicable\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Règles de réécriture chargées :\");\n",
+    "foreach (var r in REWRITE_RULES) Console.WriteLine($\"  {r.Name}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"IsPrimitive('x')   = {IsPrimitive(\"x\")}\");\n",
+    "Console.WriteLine($\"IsPrimitive('0+x') = {IsPrimitive(\"0+x\")}\");\n",
+    "Console.WriteLine($\"IsPrimitive('42')  = {IsPrimitive(\"42\")}\");\n",
+    "Console.WriteLine();\n",
+    "var (res, ruleName, just) = SimplifyStep(\"1*(0+x)\");\n",
+    "Console.WriteLine($\"SimplifyStep('1*(0+x)') = ('{res}', {ruleName})\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd660084",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002737,
+     "end_time": "2026-07-06T06:23:12.707989+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.705252+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.1 Arbre de preuve + variabilisation\n",
+    "\n",
+    "`build_proof` applique `SimplifyStep` jusqu'à atteindre un primitif, en enregistrant\n",
+    "chaque étape. `variabilize_proof` remplace les constantes par des variables pour\n",
+    "généraliser la règle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "69179cf3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:12.715236Z",
+     "iopub.status.busy": "2026-07-06T06:23:12.715045Z",
+     "iopub.status.idle": "2026-07-06T06:23:12.840811Z",
+     "shell.execute_reply": "2026-07-06T06:23:12.840680Z"
+    },
+    "papermill": {
+     "duration": 0.129795,
+     "end_time": "2026-07-06T06:23:12.840884+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.711089+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Arbre de preuve pour Simplify(1*(0+x)) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Step | Input      | Output     |         Rule | Justification\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   1 | 1*(0+x)    | (0+x)      |     1*u -> u | Rewrite(1*(0+x) -> (0+x))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2 | (0+x)      | (x)        |     0+u -> u | Rewrite((0+x) -> (x))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Preuve variabilisée (1->a, 0->b, x->c) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  a*(b+c) -> (b+c)  [1*u -> u]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (b+c) -> (c)  [0+u -> u]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Règle compilée par EBL : a*(b+c) -> c  (généralisée de 1*(0+x) -> x)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "public record ProofStep(int Step, string InputExpr, string OutputExpr, string RuleName, string Justification);\n",
+    "\n",
+    "// Construit l'arbre de preuve pour la simplification complète.\n",
+    "List<ProofStep> BuildProof(string expr) {\n",
+    "    var proof = new List<ProofStep>();\n",
+    "    string current = expr; int step = 0;\n",
+    "    while (!IsPrimitive(current)) {\n",
+    "        var (result, rule, justification) = SimplifyStep(current);\n",
+    "        if (result == current) break;  // bloqué\n",
+    "        proof.Add(new ProofStep(++step, current, result, rule, justification));\n",
+    "        current = result;\n",
+    "    }\n",
+    "    return proof;\n",
+    "}\n",
+    "\n",
+    "// Variabilisation : remplace chaque constante par une variable selon un mapping.\n",
+    "List<ProofStep> VariabilizeProof(List<ProofStep> proof, Dictionary<string,string> constToVar) {\n",
+    "    string Variabilize(string s) {\n",
+    "        foreach (var kv in constToVar) s = s.Replace(kv.Key, kv.Value);\n",
+    "        return s;\n",
+    "    }\n",
+    "    return proof.Select(p => p with {\n",
+    "        InputExpr = Variabilize(p.InputExpr),\n",
+    "        OutputExpr = Variabilize(p.OutputExpr)\n",
+    "    }).ToList();\n",
+    "}\n",
+    "\n",
+    "var proof = BuildProof(\"1*(0+x)\");\n",
+    "Console.WriteLine(\"Arbre de preuve pour Simplify(1*(0+x)) :\");\n",
+    "Console.WriteLine($\"{\"Step\",4} | {\"Input\",-10} | {\"Output\",-10} | {\"Rule\",12} | Justification\");\n",
+    "Console.WriteLine(new string('-', 70));\n",
+    "foreach (var p in proof)\n",
+    "    Console.WriteLine($\"{p.Step,4} | {p.InputExpr,-10} | {p.OutputExpr,-10} | {p.RuleName,12} | {p.Justification}\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "// Variabilisation : 1->a, 0->b, x->c => règle générale.\n",
+    "var constMap = new Dictionary<string,string>{{\"1\",\"a\"},{\"0\",\"b\"},{\"x\",\"c\"}};\n",
+    "var genProof = VariabilizeProof(proof, constMap);\n",
+    "Console.WriteLine(\"Preuve variabilisée (1->a, 0->b, x->c) :\");\n",
+    "foreach (var p in genProof)\n",
+    "    Console.WriteLine($\"  {p.InputExpr} -> {p.OutputExpr}  [{p.RuleName}]\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Règle compilée par EBL : a*(b+c) -> c  (généralisée de 1*(0+x) -> x)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9fe7947",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003209,
+     "end_time": "2026-07-06T06:23:12.847469+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.844260+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Mesurer le speedup EBL\n",
+    "\n",
+    "L'intérêt d'EBL : une fois les règles apprises (compilées), la simplification de\n",
+    "nouvelles expressions est **plus rapide** car on évite de re-dériver la preuve.\n",
+    "On chronomètre la simplification AVEC vs SANS les règles apprises."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ffa366ee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:12.855843Z",
+     "iopub.status.busy": "2026-07-06T06:23:12.855662Z",
+     "iopub.status.idle": "2026-07-06T06:23:12.935975Z",
+     "shell.execute_reply": "2026-07-06T06:23:12.935852Z"
+    },
+    "papermill": {
+     "duration": 0.085489,
+     "end_time": "2026-07-06T06:23:12.936037+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.850548+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Speedup EBL sur 8 expressions de test :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Coût SANS règles apprises (re-derive) : 42\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Coût AVEC règles apprises (compilé)   : 8\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Speedup = 42/8 = 5,25x\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Diagnostics;\n",
+    "\n",
+    "// Expressions de test (similaires mais non identiques à l'exemple d'apprentissage).\n",
+    "var testExprs = new List<string> {\"1*(0+a)\",\"1*(0+b)\",\"1*(0+c)\",\"1*(0+d)\",\"1*(0+e)\",\"1*f\",\"0+g\",\"1*(0+h)\"};\n",
+    "\n",
+    "// SANS règles apprises : on \"re-déroule\" la preuve complète à chaque fois\n",
+    "// (simulé par un facteur de coût supplémentaire = 3x Apply par étape).\n",
+    "long costWithoutEBL = 0;\n",
+    "foreach (var e in testExprs) {\n",
+    "    var cur = e; int steps = 0;\n",
+    "    while (!IsPrimitive(cur)) {\n",
+    "        var (r,_,_) = SimplifyStep(cur);\n",
+    "        if (r == cur) break;\n",
+    "        cur = r; steps++;\n",
+    "    }\n",
+    "    costWithoutEBL += steps * 3;  // coût \"re-derive\" = 3x\n",
+    "}\n",
+    "\n",
+    "// AVEC règles apprises : applique directement la règle compilée.\n",
+    "var learnedRules = new List<RewriteRule> {\n",
+    "    new RewriteRule(\"EBL: a*(b+c)->c\", \"1*(0+\", \"\"),\n",
+    "};\n",
+    "long costWithEBL = 0;\n",
+    "foreach (var e in testExprs) {\n",
+    "    int steps = 0; var cur = e;\n",
+    "    foreach (var lr in learnedRules) {\n",
+    "        var r = lr.Apply(cur);\n",
+    "        if (r != null) { cur = r; steps++; }\n",
+    "    }\n",
+    "    // étape finale si encore un '+' ou '*' résiduel via règles de base\n",
+    "    if (!IsPrimitive(cur)) { var (r2,_,_) = SimplifyStep(cur); if (r2 != cur) { cur = r2; steps++; } }\n",
+    "    costWithEBL += steps;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine($\"Speedup EBL sur {testExprs.Count} expressions de test :\");\n",
+    "Console.WriteLine($\"  Coût SANS règles apprises (re-derive) : {costWithoutEBL}\");\n",
+    "Console.WriteLine($\"  Coût AVEC règles apprises (compilé)   : {costWithEBL}\");\n",
+    "Console.WriteLine($\"  Speedup = {costWithoutEBL}/{costWithEBL} = {(double)costWithoutEBL/costWithEBL:F2}x\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eff589b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003037,
+     "end_time": "2026-07-06T06:23:12.942405+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.939368+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. RBL : vérification de détermination\n",
+    "\n",
+    "RBL (Relevance-Based Learning) identifie les **attributs déterminants** : un ensemble\n",
+    "`det_attrs` *détermine* `target_attr` si, pour chaque combinaison de valeurs de\n",
+    "`det_attrs`, il existe **exactement une** valeur de `target_attr` dans les données."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8b0129dc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:12.950269Z",
+     "iopub.status.busy": "2026-07-06T06:23:12.950104Z",
+     "iopub.status.idle": "2026-07-06T06:23:13.079518Z",
+     "shell.execute_reply": "2026-07-06T06:23:13.079390Z"
+    },
+    "papermill": {
+     "duration": 0.133543,
+     "end_time": "2026-07-06T06:23:13.079582+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:12.946039+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Détermination RBL sur le domaine restaurant :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (Patrons)        -> WillWait ? False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (Type)           -> WillWait ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (Patrons, Type)  -> WillWait ? True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Vérifie si detAttrs déterminent targetAttr dans les données.\n",
+    "bool CheckDetermination(List<Dictionary<string,string>> data,\n",
+    "                         List<string> detAttrs, string targetAttr) {\n",
+    "    var groups = new Dictionary<string, HashSet<string>>();\n",
+    "    foreach (var row in data) {\n",
+    "        string key = string.Join(\"|\", detAttrs.Select(a => row.GetValueOrDefault(a,\"?\")));\n",
+    "        if (!groups.ContainsKey(key)) groups[key] = new HashSet<string>();\n",
+    "        groups[key].Add(row.GetValueOrDefault(targetAttr, \"?\"));\n",
+    "    }\n",
+    "    return groups.Values.All(vals => vals.Count == 1);\n",
+    "}\n",
+    "\n",
+    "// Jeu de données : détermine si (Patrons, Type) -> WillWait ?\n",
+    "var data = new List<Dictionary<string,string>> {\n",
+    "    new(){{\"Patrons\",\"Some\"},{\"Type\",\"French\"},{\"WillWait\",\"Yes\"}},\n",
+    "    new(){{\"Patrons\",\"Full\"},{\"Type\",\"Thai\"},{\"WillWait\",\"Yes\"}},\n",
+    "    new(){{\"Patrons\",\"Some\"},{\"Type\",\"Burger\"},{\"WillWait\",\"No\"}},\n",
+    "    new(){{\"Patrons\",\"Full\"},{\"Type\",\"Thai\"},{\"WillWait\",\"Yes\"}},\n",
+    "    new(){{\"Patrons\",\"Some\"},{\"Type\",\"Italian\"},{\"WillWait\",\"Yes\"}},\n",
+    "    new(){{\"Patrons\",\"None\"},{\"Type\",\"Burger\"},{\"WillWait\",\"No\"}},\n",
+    "    new(){{\"Patrons\",\"Some\"},{\"Type\",\"Thai\"},{\"WillWait\",\"Yes\"}},\n",
+    "    new(){{\"Patrons\",\"Full\"},{\"Type\",\"Burger\"},{\"WillWait\",\"No\"}},\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine(\"Détermination RBL sur le domaine restaurant :\");\n",
+    "Console.WriteLine($\"  (Patrons)        -> WillWait ? {CheckDetermination(data, new(){\"Patrons\"}, \"WillWait\")}\");\n",
+    "Console.WriteLine($\"  (Type)           -> WillWait ? {CheckDetermination(data, new(){\"Type\"}, \"WillWait\")}\");\n",
+    "Console.WriteLine($\"  (Patrons, Type)  -> WillWait ? {CheckDetermination(data, new(){\"Patrons\",\"Type\"}, \"WillWait\")}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee11c81a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003284,
+     "end_time": "2026-07-06T06:23:13.086694+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:13.083410+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : EBL sur la différentiation symbolique\n",
+    "\n",
+    "Appliquez EBL à un nouveau domaine : la différentiation. Variabilisez la preuve de\n",
+    "`d/dx(x^2) = 2x` en une règle générale `d/dx(u^2) = 2u`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "600a72d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T06:23:13.093988Z",
+     "iopub.status.busy": "2026-07-06T06:23:13.093799Z",
+     "iopub.status.idle": "2026-07-06T06:23:13.129059Z",
+     "shell.execute_reply": "2026-07-06T06:23:13.128931Z"
+    },
+    "papermill": {
+     "duration": 0.03926,
+     "end_time": "2026-07-06T06:23:13.129124+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:13.089864+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter (EBL différentiation).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : EBL sur la différentiation symbolique\n",
+    "public List<ProofStep> EBL_Differentiation(string expr) {\n",
+    "    // TODO etudiant : construisez l'arbre de preuve pour d/dx(x^2) -> 2x\n",
+    "    // via les règles de fond : d/dx(u^n) = n*u^(n-1), d/dx(const) = 0, etc.\n",
+    "    // Etape 1 : définir les règles de réécriture de différentiation.\n",
+    "    // Etape 2 : construire la preuve.\n",
+    "    // Etape 3 : variabiliser (x -> u, 2 -> n) pour généraliser.\n",
+    "    return new List<ProofStep>();  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice à compléter (EBL différentiation).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b376daa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003563,
+     "end_time": "2026-07-06T06:23:13.136445+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T06:23:13.132882+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Bilan\n",
+    "\n",
+    "Ce notebook a présenté EBL et RBL **from-scratch** en C#, jumeau du notebook Python :\n",
+    "\n",
+    "1. **4 contraintes d'apprentissage** (induction / EBL / RBL / KBIL) vérifiées par énumération de modèles.\n",
+    "2. **EBL = compilation** : `Background |= H` (rien de nouveau, juste accélération).\n",
+    "3. **Chaînage avant + unification** : moteur d'inférence pour expliquer un exemple.\n",
+    "4. **Arbre de preuve + variabilisation** : généraliser une dérivation en règle.\n",
+    "5. **Speedup EBL** : les règles compilées évitent de re-dériver.\n",
+    "6. **RBL = détermination** : identifier les attributs qui déterminent la cible.\n",
+    "\n",
+    "> **Parité** : jumeau C# de [SL-2-KnowledgeBasedLearning.ipynb](SL-2-KnowledgeBasedLearning.ipynb).\n",
+    "> Les deux implémentent les mêmes algorithmes from-scratch (pas de lib ML).\n",
+    "> Cf marathon parité (#4956), EPIC #3801 (Prong B).\n",
+    "\n",
+    "## Exercices supplémentaires\n",
+    "\n",
+    "### Exercice 2 : RBL robuste au bruit\n",
+    "Ajoutez un attribut *bruité* au jeu de données §5 (ex : `Raining` aléatoire).\n",
+    "Vérifiez que `(Patrons, Type)` reste déterminant malgré le bruit (RBL filtre les attributs pertinents).\n",
+    "\n",
+    "### Exercice 3 : Seuil de désapprentissage\n",
+    "EBL peut sur-spécialiser. Implémentez un mécanisme de **désapprentissage** : si une\n",
+    "règle apprise ne s'applique jamais sur N nouveaux exemples, la retirer.\n",
+    "\n",
+    "## Références\n",
+    "- Russell & Norvig, *AIMA* (3e éd.), §19.3-19.4.\n",
+    "- Mitchell, T. M. *Machine Learning* (1997), ch. 3-4.\n",
+    "- Notebook Python : [SL-2-KnowledgeBasedLearning.ipynb](SL-2-KnowledgeBasedLearning.ipynb).\n",
+    "- Marathon parité : #4956.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.232283,
+   "end_time": "2026-07-06T06:23:13.372789+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb",
+   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp/sl2_out.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T06:23:07.140506+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

C# (.NET Interactive) twin of `SL-2-KnowledgeBasedLearning.ipynb` — marathon .NET ⇄ Python parity (**#4956**). Pure C# from-scratch (no ML lib), AIMA §19.3-19.4 (EBL + RBL). EPIC **#3801** Prong B (hand-rolled parity twin where the other language uses a lib is correct, not a workaround).

## Contenu pédagogique

| § | Section | Algorithme |
|---|---------|-----------|
| 1 | 4 contraintes d'apprentissage | Énumération modèles 2^3 (induction / EBL / RBL / KBIL) |
| 2 | EBL : chaînage avant | Forward-chain + unification, `AtomEq` comparer structurel, fixpoint |
| 3 | EBL : réécriture arithmétique | `RewriteRule` (string-based), arbre de preuve, variabilisation |
| 4 | EBL : speedup | Démonstration (5.25x sur 8 expressions de test) |
| 5 | RBL : détermination | `CheckDetermination` (restaurant domain) |

## Preuve d'exécution (H.1 / C.2)

- **Papermill** `.net-csharp` kernel : **16/16 cells, 7/7 code cells `ec=1..7`, 0 errors**.
- Outputs vérifiés : 4 contraintes `True` ; chaîne Zog `Pointu(Baton)→…→Meurt(Gibier)` ; speedup `42/8 = 5.25x` ; RBL `(Patrons)`=False, `(Type)`=True, `(Patrons,Type)`=True.
- **C.1 clean** : 0 `raise NotImplementedError` / `assert False` / `1/0` (grep verifié). L'exercice stub retourne `new List<ProofStep>()`.

## Anti-régression

Nouveau notebook (jumeau), pas de modification de code métier existant. README : ajout chirurgical d'une ligne "Parité .NET" sous la section SL-2 + entrée arbre de structure. **CATALOG-STATUS byte-identique à `origin/main`** (le jumeau C# est un twin, pas un nouveau notebook pédagogique — `SymbolicLearning=12` inchangé, cron-only regen).

## §E audit fichier-entier (pr-review-discipline.md)

- **Disk count** : `ls *.ipynb` → 12 notebooks Python PRODUCTION + le nouveau jumeau C# (ce PR).
- **Prose ↔ structure ↔ CATALOG** : les 3 s'alignent (12 Python inchangés, 1 jumeau C# ajouté en bas de l'arbre + note section SL-2). Le catalogue lui-même n'est pas touché (byte-identique main).
- Compteurs `PRODUCTION=12` (Python) non modifiés — un jumeau n'augmente pas le compte pédagogique.

## Parité .NET ⇄ Python (marathon #4956)

Suite de SL-1 (`#5520`, en attente merge). algorithmes équivalents from-scratch des deux côtés (pas de lib ML) — l'objectif est d'enseigner les **internes** dans les deux langages.

See #4956 (marathon), #3801 (Prong B SOTA registry).