### PR TITLE
i18n(#4980): add Kelly.*_en siblings — EN mirrors, kelly_lean (lake fully bilingual)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Bet_en.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Bet_en.lean
@@ -1,0 +1,83 @@
+import Mathlib
+
+/-!
+# Kelly.Bet — Bernoulli bet, wagered fraction, wealth multipliers
+
+A **Bernoulli bet** (the canonical setting of the Kelly criterion): with
+probability `p` one wins and receives `b` times the stake `f` (net odds `b`), with
+probability `q = 1 − p` one loses the stake. The relative wealth after the bet is:
+- **`1 + b·f`** in case of a win (capital + profit `b·f`),
+- **`1 − f`** in case of a loss (capital − stake `f`).
+
+The **wagered fraction** `f` lives in the open interval `(−1/b, 1)`: beyond it both
+multipliers are no longer strictly positive (the log-growth is undefined). A negative
+fraction = betting *against* the player (short), `f = 0` = bet nothing.
+
+This module sets up the model. The optimal fraction `f*` and the flagship theorem live
+in `Kelly.lean`. See issue #4052.
+-/
+
+namespace KellyLean_en
+
+open Real
+
+/-- A Bernoulli bet parameterized by its win probability `p` and its net odds `b`. -/
+structure Bet where
+  /-- Win probability, strictly between 0 and 1. -/
+  p : ℝ
+  hp_pos : 0 < p
+  hp_lt_one : p < 1
+  /-- Net odds: profit `b` per unit staked in case of a win, `b > 0`. -/
+  b : ℝ
+  hb_pos : 0 < b
+
+/-- Loss probability, `q = 1 − p`. -/
+def q (β : Bet) : ℝ := 1 - β.p
+
+/-- The loss probability is strictly positive (since `p < 1`). -/
+lemma q_pos (β : Bet) : 0 < q β := by unfold q; linarith [β.hp_lt_one]
+
+/-- The loss probability is strictly less than 1 (since `p > 0`). -/
+lemma q_lt_one (β : Bet) : q β < 1 := by unfold q; linarith [β.hp_pos]
+
+/-- Probabilities sum to 1: `p + q = 1`. -/
+lemma pq_add_eq_one (β : Bet) : β.p + q β = 1 := by unfold q; ring
+
+/-- Wealth multiplier in case of a **win**: `1 + b·f` (capital + profit `b·f`). -/
+def winWealth (β : Bet) (f : ℝ) : ℝ := 1 + β.b * f
+
+-- Wealth multiplier in case of a **loss**: `1 − f` (capital − stake `f`).
+-- Le corps ne dépend pas de la cote `β.b` (perdre sa mise est universel), mais `β`
+-- est gardé en paramètre pour la symétrie d'API avec `winWealth`. L'option silences
+-- le linter `unusedVariables` (intentionnel : API symétrique).
+set_option linter.unusedVariables false in
+def loseWealth (β : Bet) (f : ℝ) : ℝ := 1 - f
+
+/-- The net odds satisfy `b + 1 > 0` (useful for domains). -/
+lemma b_add_one_pos (β : Bet) : 0 < β.b + 1 := by linarith [β.hb_pos]
+
+/-- `winWealth` is strictly positive on the admissible region `f > −1/b`. -/
+lemma winWealth_pos (β : Bet) (f : ℝ) (hf : -1 / β.b < f) : 0 < winWealth β f := by
+  unfold winWealth
+  rw [div_lt_iff₀ β.hb_pos] at hf
+  linarith [mul_comm β.b f]
+
+/-- `loseWealth` is strictly positive on the admissible region `f < 1`. -/
+lemma loseWealth_pos (β : Bet) (f : ℝ) (hf : f < 1) : 0 < loseWealth β f := by
+  unfold loseWealth; linarith
+
+/-- **Admissible region** of a fraction `f`: both multipliers are strictly
+    positive, i.e. `f ∈ (−1/b, 1)`. The log-growth is defined there. -/
+def Feasible (β : Bet) (f : ℝ) : Prop := -1 / β.b < f ∧ f < 1
+
+/-- Any admissible fraction makes `winWealth` strictly positive. -/
+lemma winWealth_pos_of_feasible (β : Bet) (f : ℝ) (hf : Feasible β f) :
+    0 < winWealth β f :=
+  winWealth_pos β f hf.1
+
+/-- Any admissible fraction makes `loseWealth` strictly positive. -/
+lemma loseWealth_pos_of_feasible (β : Bet) (f : ℝ) (hf : Feasible β f) :
+    0 < loseWealth β f :=
+  loseWealth_pos β f hf.2
+
+end KellyLean_en

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Growth_en.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Growth_en.lean
@@ -1,0 +1,58 @@
+import Mathlib
+import Kelly.Bet_en
+
+/-!
+# Kelly.Growth — the expected growth rate `g(f) = E[log(wealth)]`
+
+The **expected growth rate** of a Bernoulli bet under fraction `f` is
+
+    g(f) = p · log(1 + b·f) + q · log(1 − f)
+
+where `p` (resp. `q`) is the win (resp. loss) probability and `b` the net odds.
+Maximizing `g` amounts to maximizing the **asymptotic growth of compounded capital**
+over infinitely many independent bets (this is Kelly optimality). See issue #4052.
+
+This module defines `growth` and `growthGrad`, and establishes the **baseline facts**
+(zero growth without betting, slope at the origin = the edge). The strict concavity of
+`g` over the admissible region (a `g''(f) < 0` computation) is the proof strategy
+**bypassed** by the flagship optimality theorem, which directly proves `g(f) ≤ g(f*)`
+via the tangent `log t ≤ t − 1` rather than invoking abstract concavity — that flagship
+lives in `Kelly.lean`.
+-/
+
+namespace KellyLean_en
+
+open Real
+
+/-- The **expected growth rate** `g(f) = p·log(1 + b·f) + q·log(1 − f)`:
+    expectation of the logarithm of relative wealth. -/
+noncomputable def growth (β : Bet) (f : ℝ) : ℝ :=
+  β.p * log (winWealth β f) + q β * log (loseWealth β f)
+
+/-- The **slope** (derivative) of the growth rate: `g'(f) = p·b/(1+bf) − q/(1−f)`.
+    This is the quantity whose vanishing characterizes the optimal fraction. It is
+    exposed explicitly because it is at the heart of the optimality theorem (first-order
+    condition `growthGrad β f* = 0`). -/
+noncomputable def growthGrad (β : Bet) (f : ℝ) : ℝ :=
+  β.p * β.b / winWealth β f - q β / loseWealth β f
+
+/-- **Zero growth without betting**: `g(0) = 0`. Betting nothing (`f = 0`) leaves the
+    capital unchanged — both wealth multipliers equal `1`, and `log 1 = 0`. This is the
+    **baseline** of the Kelly criterion: any fraction `f` with `g(f) > 0` beats "do
+    nothing", any fraction with `g(f) < 0` is worse (cf `Kelly.kelly_optimal`, which
+    guarantees `g(f) ≤ g(f*)` and, the edge being positive, `g(f*) > 0 = g(0)`). -/
+lemma growth_zero (β : Bet) : growth β 0 = 0 := by
+  unfold growth winWealth loseWealth
+  simp [Real.log_one]
+
+/-- **Slope at the origin = the edge**: `g'(0) = b·p − q`. With no stake (`f = 0`), the
+    slope of the log-growth equals exactly the "edge" `b·p − q` — i.e. the **numerator**
+    of the Kelly fraction `f* = (b·p − q)/b`. Thus `g'(0) > 0` ⟺ `f* > 0` (favorable
+    bet, bet), `g'(0) < 0` ⟺ `f* < 0` (unfavorable bet, short). This is the bridge
+    between the local geometry of `g` (its slope at `0`) and the sign of the optimal
+    stake. -/
+lemma growthGrad_zero (β : Bet) : growthGrad β 0 = β.p * β.b - q β := by
+  unfold growthGrad winWealth loseWealth
+  simp [div_one]
+
+end KellyLean_en

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
@@ -1,0 +1,201 @@
+import Mathlib
+import Kelly.Bet_en
+import Kelly.Growth_en
+
+/-!
+# Kelly.Kelly — optimality of the fraction `f*` (Kelly criterion)
+
+The **Kelly theorem**: the optimal fraction to bet on a Bernoulli bet (win probability
+`p`, net odds `b`) is
+
+    f* = (b·p − q) / b        (q = 1 − p)
+
+which **uniquely maximizes** the expected growth rate `g(f) = p·log(1+bf) +
+q·log(1−f)`. Any over-bet (`f > f*`) or under-bet (`f < f*`) is strictly suboptimal.
+
+## Proof strategy
+
+We avoid abstract concavity and prove `g(f) ≤ g(f*)` **directly** via the tangent of
+the logarithm at 1, `log t ≤ t − 1` (with equality iff `t = 1`). Writing
+
+    g(f) − g(f*) = p · log((1+bf)/(1+bf*)) + q · log((1−f)/(1−f*))
+
+and applying `log t ≤ t − 1` to each ratio yields
+
+    g(f) − g(f*) ≤ (f − f*) · [p·b/(1+bf*) − q/(1−f*)] = (f − f*) · g'(f*).
+
+Now `g'(f*) = 0` (first-order condition, verified by computation). Hence
+`g(f) ≤ g(f*)`. Uniqueness follows from the strict version `log t < t − 1` for
+`t ≠ 1`: if `f ≠ f*`, the ratios differ from `1`, so the inequalities are strict, and
+`g(f) < g(f*)`.
+
+Reference: J. L. Kelly Jr., *A New Interpretation of Information Rate*, BSTT (1956).
+See issue #4052.
+-/
+
+namespace KellyLean_en
+
+open Real
+
+/-- The **Kelly fraction** `f* = (b·p − q)/b` (the optimal stake per unit of capital). -/
+noncomputable def kellyFrac (β : Bet) : ℝ := (β.b * β.p - q β) / β.b
+
+/-- The Kelly fraction lies in the admissible region `(−1/b, 1)`: both wealth
+    multipliers at `f*` are strictly positive. -/
+lemma kellyFrac_feasible (β : Bet) : Feasible β (kellyFrac β) := by
+  have hb := β.hb_pos
+  -- kellyFrac β * β.b = β.b·p − (1 − p)  (on multiplie par b > 0)
+  have hkf : kellyFrac β * β.b = β.b * β.p - (1 - β.p) := by
+    simp [kellyFrac, q]; field_simp [hb.ne']
+  refine ⟨?_, ?_⟩
+  · -- −1/b < f*  ⟺  −1 < f*·b  (b > 0)
+    rw [div_lt_iff₀ hb, hkf]
+    nlinarith [β.hp_pos, hb]
+  · -- f* < 1  ⟺  1 − f* = (1 − p)·(b + 1)/b > 0
+    have h1f : 1 - kellyFrac β = (1 - β.p) * (β.b + 1) / β.b := by
+      unfold kellyFrac q; field_simp [β.hb_pos.ne']; ring
+    have hpos : 0 < 1 - kellyFrac β := by
+      rw [h1f]
+      exact div_pos (mul_pos (by linarith [β.hp_lt_one]) (b_add_one_pos β)) β.hb_pos
+    linarith
+
+/-- Win multiplier evaluated at `f*`: `winWealth β f* = p · (b + 1)`. -/
+lemma winWealth_kelly (β : Bet) : winWealth β (kellyFrac β) = β.p * (β.b + 1) := by
+  unfold winWealth kellyFrac q; field_simp [β.hb_pos.ne']; ring
+
+/-- Loss multiplier evaluated at `f*`: `loseWealth β f* = q · (b + 1) / b`. -/
+lemma loseWealth_kelly (β : Bet) : loseWealth β (kellyFrac β) = q β * (β.b + 1) / β.b := by
+  unfold loseWealth kellyFrac q; field_simp [β.hb_pos.ne']; ring
+
+/-- **First-order condition**: the slope of the log-growth vanishes at `f*`,
+    `g'(f*) = growthGrad β f* = 0`. -/
+lemma growthGrad_kelly_zero (β : Bet) : growthGrad β (kellyFrac β) = 0 := by
+  have hq : q β ≠ 0 := (q_pos β).ne'
+  have hbo : β.b + 1 ≠ 0 := (b_add_one_pos β).ne'
+  have hpb : β.p * (β.b + 1) ≠ 0 := mul_ne_zero β.hp_pos.ne' hbo
+  rw [growthGrad, winWealth_kelly, loseWealth_kelly]
+  field_simp [β.hp_pos.ne', hq, β.hb_pos.ne', hbo, hpb]
+  ring
+
+/-- **Key upper bound**: for any admissible fraction `f`,
+    `g(f) − g(f*) ≤ (f − f*) · g'(f*)`. Follows from `log t ≤ t − 1` applied to both
+    ratios. -/
+lemma growth_diff_le (β : Bet) (f : ℝ) (hf : Feasible β f) :
+    growth β f - growth β (kellyFrac β) ≤ (f - kellyFrac β) * growthGrad β (kellyFrac β) := by
+  have hfs := kellyFrac_feasible β
+  set fstar := kellyFrac β with hfstar
+  have hwp := winWealth_pos_of_feasible β f hf
+  have hwl := loseWealth_pos_of_feasible β f hf
+  have hwsp := winWealth_pos_of_feasible β fstar hfs
+  have hwlp := loseWealth_pos_of_feasible β fstar hfs
+  -- g(f) − g(f*) = p·log(Ww_f/Ww_*) + q·log(Wl_f/Wl_*)
+  have h1 : log (winWealth β f / winWealth β fstar) =
+      log (winWealth β f) - log (winWealth β fstar) := Real.log_div hwp.ne' hwsp.ne'
+  have h2 : log (loseWealth β f / loseWealth β fstar) =
+      log (loseWealth β f) - log (loseWealth β fstar) := Real.log_div hwl.ne' hwlp.ne'
+  have hdiffeq : growth β f - growth β fstar =
+      β.p * log (winWealth β f / winWealth β fstar) +
+        q β * log (loseWealth β f / loseWealth β fstar) := by
+    unfold growth; rw [h1, h2]; ring
+  -- borne chaque rapport via log t ≤ t − 1 (en fait : égalité algébrique du majorant)
+  have hwin_bound : log (winWealth β f / winWealth β fstar) ≤
+      (f - fstar) * (β.b / winWealth β fstar) := by
+    refine (log_le_sub_one_of_pos (div_pos hwp hwsp)).trans ?_
+    simp only [winWealth] at hwsp ⊢
+    field_simp [hwsp.ne']
+    linarith
+  have hlose_bound : log (loseWealth β f / loseWealth β fstar) ≤
+      (f - fstar) * (-1 / loseWealth β fstar) := by
+    refine (log_le_sub_one_of_pos (div_pos hwl hwlp)).trans ?_
+    simp only [loseWealth] at hwlp ⊢
+    field_simp [hwlp.ne']
+    linarith
+  -- combine (p,q > 0 préservent les inégalités)
+  calc growth β f - growth β fstar
+      = β.p * log (winWealth β f / winWealth β fstar) +
+          q β * log (loseWealth β f / loseWealth β fstar) := hdiffeq
+    _ ≤ β.p * ((f - fstar) * (β.b / winWealth β fstar)) +
+          q β * ((f - fstar) * (-1 / loseWealth β fstar)) := by
+        refine add_le_add ?_ ?_
+        · exact mul_le_mul_of_nonneg_left hwin_bound β.hp_pos.le
+        · exact mul_le_mul_of_nonneg_left hlose_bound (q_pos β).le
+    _ = (f - fstar) * growthGrad β fstar := by
+        rw [growthGrad]; field_simp [hwsp.ne', hwlp.ne']; ring
+
+/-- **Kelly theorem** (maximizer): `f*` maximizes the expected growth rate.
+    For any admissible fraction `f`, `g(f) ≤ g(f*)`. -/
+theorem kelly_optimal (β : Bet) (f : ℝ) (hf : Feasible β f) :
+    growth β f ≤ growth β (kellyFrac β) := by
+  have hbound := growth_diff_le β f hf
+  rw [growthGrad_kelly_zero, mul_zero] at hbound
+  linarith
+
+/-- **Over-bet and under-bet are strictly suboptimal**: if `f ≠ f*` is admissible,
+    then `g(f) < g(f*)` (uniqueness of the maximizer). Follows from `log t < t − 1` for
+    `t ≠ 1`. -/
+theorem kelly_unique (β : Bet) (f : ℝ) (hf : Feasible β f) (hfne : f ≠ kellyFrac β) :
+    growth β f < growth β (kellyFrac β) := by
+  have hfs := kellyFrac_feasible β
+  set fstar := kellyFrac β with hfstar
+  have hwp := winWealth_pos_of_feasible β f hf
+  have hwl := loseWealth_pos_of_feasible β f hf
+  have hwsp := winWealth_pos_of_feasible β fstar hfs
+  have hwlp := loseWealth_pos_of_feasible β fstar hfs
+  -- f ≠ f* ⟹ les multiplicateurs de richesse diffèrent (1+b·_ et 1−_ sont injectifs)
+  have hwin_inj : winWealth β f = winWealth β fstar → f = fstar := by
+    intro h
+    unfold winWealth at h
+    have : β.b * f = β.b * fstar := by linarith
+    exact mul_left_cancel₀ β.hb_pos.ne' this
+  have hlose_inj : loseWealth β f = loseWealth β fstar → f = fstar := by
+    intro h; unfold loseWealth at h; linarith
+  have hwinne : winWealth β f / winWealth β fstar ≠ 1 := by
+    intro heq
+    apply hfne
+    apply hwin_inj
+    field_simp [hwsp.ne'] at heq
+    exact heq
+  have hlosene : loseWealth β f / loseWealth β fstar ≠ 1 := by
+    intro heq
+    apply hfne
+    apply hlose_inj
+    field_simp [hwlp.ne'] at heq
+    exact heq
+  -- versions strictes : log t < t − 1 pour t ≠ 1
+  have h1 : log (winWealth β f / winWealth β fstar) =
+      log (winWealth β f) - log (winWealth β fstar) := Real.log_div hwp.ne' hwsp.ne'
+  have h2 : log (loseWealth β f / loseWealth β fstar) =
+      log (loseWealth β f) - log (loseWealth β fstar) := Real.log_div hwl.ne' hwlp.ne'
+  have hdiffeq : growth β f - growth β fstar =
+      β.p * log (winWealth β f / winWealth β fstar) +
+        q β * log (loseWealth β f / loseWealth β fstar) := by
+    unfold growth; rw [h1, h2]; ring
+  -- f ≠ f* ⟹ AU MOINS l'un des rapports diffère de 1 ; utilisons la borne stricte
+  have hwin_strict : log (winWealth β f / winWealth β fstar) <
+      (f - fstar) * (β.b / winWealth β fstar) := by
+    refine (log_lt_sub_one_of_pos (div_pos hwp hwsp) hwinne).trans_le ?_
+    simp only [winWealth] at hwsp ⊢
+    field_simp [hwsp.ne']
+    linarith
+  have hlose_strict : log (loseWealth β f / loseWealth β fstar) <
+      (f - fstar) * (-1 / loseWealth β fstar) := by
+    refine (log_lt_sub_one_of_pos (div_pos hwl hwlp) hlosene).trans_le ?_
+    simp only [loseWealth] at hwlp ⊢
+    field_simp [hwlp.ne']
+    linarith
+  have hgrad0 : growthGrad β fstar = 0 := growthGrad_kelly_zero β
+  have hdiff : growth β f - growth β fstar < 0 := by
+    calc growth β f - growth β fstar
+        = β.p * log (winWealth β f / winWealth β fstar) +
+            q β * log (loseWealth β f / loseWealth β fstar) := hdiffeq
+      _ < β.p * ((f - fstar) * (β.b / winWealth β fstar)) +
+            q β * ((f - fstar) * (-1 / loseWealth β fstar)) := by
+          refine add_lt_add ?_ ?_
+          · exact mul_lt_mul_of_pos_left hwin_strict β.hp_pos
+          · exact mul_lt_mul_of_pos_left hlose_strict (q_pos β)
+      _ = (f - fstar) * growthGrad β fstar := by
+          rw [growthGrad]; field_simp [hwsp.ne', hwlp.ne']; ring
+      _ = 0 := by rw [hgrad0, mul_zero]
+  linarith
+
+end KellyLean_en


### PR DESCRIPTION
## i18n(#4980): add `Kelly.*_en` siblings — EN mirrors, kelly_lean (**lake fully bilingual**)

English mirrors of `Kelly/Bet.lean`, `Kelly/Growth.lean`, `Kelly/Kelly.lean` (FR-first canonical). Convention i18n Lean ratifiée ai-01 (2026-07-04, #4980 comment-4881909354) : distincts FR + EN siblings dans le même lake, les deux compilent ; contenu non-docstring byte-identique (drift-CI detectable).

### What — Kelly criterion formalization, EPIC #4052 (Lean roadmap #4038 Tier 2)

`kelly_lean` is the Lean 4 formalization of the **Kelly criterion** (position sizing): for a Bernoulli bet (win prob `p`, net odds `b`), the optimal fraction of capital to stake is `f* = (b·p − q)/b`, which **uniquely maximizes** expected log-growth `g(f) = p·log(1+bf) + q·log(1−f)`. The flagship proves `kelly_optimal` (maximizer) + `kelly_unique` (strict suboptimality of over/under-betting) via the log-tangent inequality `log t ≤ t − 1` (no abstract concavity invoked).

### Atomic — 3 EN siblings in one PR (small coherent lake)

| File | Role | FR→EN diff (non-docstring) |
|------|------|----------------------------|
| `Bet_en.lean` (leaf) | structure `Bet`, wealth multipliers, admissible region | namespace + end |
| `Growth_en.lean` | expected growth `growth` + derivative `growthGrad` | + import-swap `Bet_en`, namespace + end |
| `Kelly_en.lean` (**flagship**) | `kellyFrac`, first-order condition, `kelly_optimal` + `kelly_unique` | + 2 import-swaps, namespace + end |

Single PR (not stacked) because kelly_lean is one small coherent lake (344L total). Dependency chain Bet → Growth → Kelly all in the PR.

### Why this is safe — self-contained EN namespace, structure-field dot-notation only

All 3 EN siblings live in `namespace KellyLean_en`. The **only** dot-notation is **structure-field access** (`β.p`, `β.b`, `β.hp_pos`, `β.hp_lt_one`, `β.hb_pos` = fields of `structure Bet`), which resolves via the structure definition regardless of namespace. All other references are **prefix** function application (`q β`, `growth β`, `kellyFrac β`, `winWealth_pos_of_feasible β f hf`). **No `<value>.<namespace-fn>` dot-notation** that would resolve against a cross-namespace type → this is the SAFE profile, NOT the Lattice_en trap (84 dot-notation sites `μ.join` resolving a FR type against EN-namespace functions → 50 `Invalid field`).

### Sorry parity — no regression (flagship is 0-sorry)

| File | FR sorry | EN sorry |
|------|----------|----------|
| Bet | 0 | 0 |
| Growth | 0 | 0 |
| Kelly (flagship) | 0 | 0 |

The Kelly criterion is **fully proven in BOTH siblings** — no `sorry` anywhere.

### Verification (lean-merge-discipline HARD)

```
$ lake.exe build Kelly.Kelly_en
✔ [8493/8495] Built Kelly.Bet_en (32s)
✔ [8494/8495] Built Kelly.Growth_en (13s)
✔ [8495/8495] Built Kelly.Kelly_en (14s)
Build completed successfully (8495 jobs), exit 0
```
`Kelly_en` transitively builds `Bet_en` + `Growth_en` → the **entire EN side of the lake is verified** by this single build.

| Check | Result |
|-------|--------|
| `lake build Kelly.Kelly_en` | **SUCCESS** (8495 jobs, all 3 EN files) |
| FR files baseline | SUCCESS (0 sorry each) |
| sorry FR vs EN | 0 = 0 on all 3 (no regression) |
| FR files | byte-identical to main (anti-regression D) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — kelly_lean fully bilingual

After this PR merges, kelly_lean is **fully bilingual** (3/3 content files FR + EN). The umbrella `Kelly` lib auto-discovers all `_en` via globs `.submodules \`Kelly` (no lakefile change needed). → **globs `Kelly.*` UNBLOCKED** fleet-wide (c.219 Finding "globs expose broken _en" — kelly_lean has NONE).

FR files UNCHANGED. Pure +file addition (3 files, +342).

See #4980
See #4052
See #4038

🤖 Generated with [Claude Code](https://claude.com/claude-code)
