### PR TITLE
feat(sudoku): Sudoku-13-SymbolicAutomata-Python — twin Python (regex, Z3, recursion (?&rec)) (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -9,7 +9,7 @@ maturity: PRODUCTION=28, BETA=4, ALPHA=1
 
 [← Notebooks](../README.md) | [→ Search](../Search/README.md)
 
-Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. Les 33 notebooks couvrent **13 paires miroir C#/Python** (algorithmes comparables dans les deux langages), **3 notebooks C# uniquement** (13-SymbolicAutomata, 14-BDD, 0-Environment), **3 notebooks Python uniquement** (16-NeuralNetwork, 17-LLM, 18-Comparison-benchmark) et **1 companion Lean natif** ([Sudoku-19](Sudoku-19-Lean-Propagation.ipynb), preuve formelle de la propagation de contraintes). Cette structure laisse à chaque étudiant le choix de son langage sur la majorité des algorithmes.
+Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. Les 34 notebooks couvrent **14 paires miroir C#/Python** (algorithmes comparables dans les deux langages), **2 notebooks C# uniquement** (14-BDD, 0-Environment), **3 notebooks Python uniquement** (16-NeuralNetwork, 17-LLM, 18-Comparison-benchmark) et **1 companion Lean natif** ([Sudoku-19](Sudoku-19-Lean-Propagation.ipynb), preuve formelle de la propagation de contraintes). Cette structure laisse à chaque étudiant le choix de son langage sur la majorité des algorithmes.
 
 **À qui s'adresse cette série** : étudiants en informatique (L2-M2) découvrant les paradigmes algorithmiques, candidats à des entretiens techniques, et enseignants cherchant un fil rouge pédagogique. Les notebooks Python ne nécessitent que Python 3.10+. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en IA : les concepts sont introduits depuis le backtracking.
 
@@ -600,6 +600,7 @@ Sudoku/
 ├── Sudoku-12-Z3-Csharp.ipynb              # Z3 SMT C#
 ├── Sudoku-12-Z3-Python.ipynb              # Z3 SMT Python
 ├── Sudoku-13-SymbolicAutomata-Csharp.ipynb # Automates symboliques C#
+├── Sudoku-13-SymbolicAutomata-Python.ipynb # Twin Python (regex, Z3, récursion (?&rec))
 ├── Sudoku-14-BDD-Csharp.ipynb             # BDD/MDD C#
 ├── Sudoku-15-Infer-Csharp.ipynb           # Infer.NET C#
 ├── Sudoku-15-Infer-Python.ipynb           # NumPyro Python

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
@@ -1,0 +1,873 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "92986127",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003235,
+     "end_time": "2026-07-06T07:00:11.538697",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.535462",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "**Navigation** : [<< Sudoku-12 Z3 Python](Sudoku-12-Z3-Python.ipynb) | [Index](README.md) | [Sudoku-14 BDD Python >>](Sudoku-14-BDD-Python.ipynb)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "# Sudoku-13 : Le Sudoku comme Regex Symbolique — twin Python (Conway -> BREX/Rex -> RE#)\n",
+    "\n",
+    "> **Twin Python** de [Sudoku-13-SymbolicAutomata-Csharp](Sudoku-13-SymbolicAutomata-Csharp.ipynb). Ce notebook reprend, **cote Python**, la tentation de representer un Sudoku non pas comme un monstre PCRE a backtracking, mais comme une **chaine declarative tractable**.\n",
+    "\n",
+    "## Complementarite (#3801 Prong B)\n",
+    "\n",
+    "| Twin | Outils | Valeur |\n",
+    "|------|--------|--------|\n",
+    "| C# (Resharp RE# + Microsoft.Automata + Z3.NET) | DLLs `.deploy` in-repo, intersection declarative | la chaine d'outils symboliques de Veanes (AutomataDotNet) |\n",
+    "| **Python (z3-solver + regex + automata-lib)** | PyPI, idiomatique Python | **la recursivite `(?&rec)` du module `regex`** — capability que .NET REJETE |\n",
+    "\n",
+    "**Le point de bascule** : les Sudoku-en-un-regex celebres (Conway, ikegami PerlMonks 471168) reposent sur la **recursion `(?R)`/`(?&nom)`** — un langage **non regulier**. Le twin C# demontre (cellule 15) que `System.Text.RegularExpressions` **rejette** cette syntaxe a la construction. Le module Python [`regex`](https://pypi.org/project/regex/) la **supporte** : ce twin peut donc *executer* une approche recursive que le twin C# ne fait qu'evoquer. C'est la valeur complementaire — pas un simple miroir."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94288333",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003527,
+     "end_time": "2026-07-06T07:00:11.544367",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.540840",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Introduction : un Sudoku comme grand regex ?\n",
+    "\n",
+    "L'idee : representer chaque contrainte Sudoku (ligne, colonne, bloc) comme un **motif regex**, puis les **combiner** (intersection / conjunction de lookaheads) pour obtenir un seul predicat declaratif. Un moteur d'automates ou un solveur SMT peut alors soit *reconnaitre* une grille valide, soit *produire* une solution.\n",
+    "\n",
+    "Trois barreaux de l'echelle, du folklore a la rigueur :\n",
+    "1. **Barreau 1 — le monstre PCRE** : « le Sudoku en un seul regex », backtracking detourne, illisible.\n",
+    "2. **Barreau 2 — la reconnaissance Python** : la contrainte de ligne comme conjunction de lookaheads.\n",
+    "3. **Barreau 3 — la resolution Z3** : le vrai solveur qui *produit* la grille solution.\n",
+    "\n",
+    "Et le declic complementaire : la **recursion `(?&rec)`** de `regex`, que .NET ne sait pas faire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3bb89e1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001459,
+     "end_time": "2026-07-06T07:00:11.547316",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.545857",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Barreau 1 — le monstre PCRE : « le Sudoku en un seul regex »\n",
+    "\n",
+    "Le folklore Perl des PerlMonks (milieu des annees 2000) : empiler le backtracking d'un moteur regex pour en faire un solveur de recherche. Le resultat est un monstre illisible, deroule dans un fichier texte. On charge ici la forme **deroulee** (lignee Conway/PCRE), enregistree dans `assets/sudoku-unrolled.regex.txt`, et on n'en affiche qu'un **troncage** (tete + queue) — l'extrait reel, pas un fragment reconstruit a la main."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "739ddb62",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.552438Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.552248Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.571003Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.570575Z"
+    },
+    "papermill": {
+     "duration": 0.022668,
+     "end_time": "2026-07-06T07:00:11.571713",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.549045",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Asset charge : sudoku-unrolled.regex.txt (13,514 caracteres)\n",
+      "\n",
+      "Troncage (tete + queue) :\n",
+      "\\A\n",
+      "\n",
+      "\\d*(\\d)\n",
+      "(?!(?:.*\\n)+(?:.{10}){0}\\1\\b)\n",
+      "(?!\\d*\\ (?:.{10})*  ...[TRONQUE]...  *\\n)+(?:.{10}){8}\\81\\b)\n",
+      "(?!\\d*\\ (?:.{10})*?\\81\\b)\n",
+      "\\d*\\s+\n",
+      "\n",
+      "\\Z\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le VRAI monstre regex (forme deroulee, lignee Conway/folklore PCRE) charge depuis assets/.\n",
+    "# On en affiche un TRONCAGE : tete + queue, extraits du fichier reel.\n",
+    "from pathlib import Path\n",
+    "\n",
+    "candidats = [\n",
+    "    Path(\"assets/sudoku-unrolled.regex.txt\"),\n",
+    "    Path(\"MyIA.AI.Notebooks/Sudoku/assets/sudoku-unrolled.regex.txt\"),\n",
+    "    Path(\"..\", \"Sudoku\", \"assets\", \"sudoku-unrolled.regex.txt\"),\n",
+    "]\n",
+    "chemin = next((p for p in candidats if p.exists()), None)\n",
+    "\n",
+    "if chemin is None:\n",
+    "    print(\"Fichier d'asset introuvable. Chemins tentes :\")\n",
+    "    for p in candidats:\n",
+    "        print(\" \", p)\n",
+    "    monstre = \"\"\n",
+    "else:\n",
+    "    monstre = chemin.read_text(encoding=\"utf-8\").strip()\n",
+    "    print(f\"Asset charge : {chemin.name} ({len(monstre):,} caracteres)\")\n",
+    "    print()\n",
+    "    # Troncage tete + queue (60 + 60 caracteres), l'extrait reel du fichier.\n",
+    "    if len(monstre) > 130:\n",
+    "        extrait = monstre[:60] + \"  ...[TRONQUE]...  \" + monstre[-60:]\n",
+    "    else:\n",
+    "        extrait = monstre\n",
+    "    print(\"Troncage (tete + queue) :\")\n",
+    "    print(extrait)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "807276b4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001682,
+     "end_time": "2026-07-06T07:00:11.575191",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.573509",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : le monstre PCRE = l'anti-modele\n",
+    "\n",
+    "Ce monstre demontre par l'absurde que **detourner le backtracking d'un moteur regex pour faire de la recherche** conduit a une representation illisible. La contrainte d'unicite Sudoku n'est *pas* naturelle en PCRE : elle s'exprime en empilant des assertions lookahead gigognes. On garde ce barreau comme **temoin historique** (le folklore existe, il tourne), mais on cherche une forme *declarative*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c631cbc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00186,
+     "end_time": "2026-07-06T07:00:11.578741",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.576881",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Barreau 2 — la reconnaissance Python (lookaheads)\n",
+    "\n",
+    "La contrainte « une ligne Sudoku valide = 9 chiffres distincts de 1 a 9 » se reformule en **presence de chaque chiffre** : pour une chaine de longueur 9 sur l'alphabet `[1-9]`, la presence de chacun des 9 chiffres equivaut a la distinctness. C'est l'idiome Python de l'intersection RE# du twin C# : une conjunction de **lookaheads** `(?=.*d)`.\n",
+    "\n",
+    "C'est de la **reconnaissance** : on valide une ligne *deja remplie*, on ne resout rien."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "38b99e2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.584864Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.584452Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.588790Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.588392Z"
+    },
+    "papermill": {
+     "duration": 0.00811,
+     "end_time": "2026-07-06T07:00:11.589445",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.581335",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reconnaissance d'une ligne Sudoku (lookaheads Python) :\n",
+      "  '123456789'    attendu=True  obtenu=True  OK\n",
+      "  '987654321'    attendu=True  obtenu=True  OK\n",
+      "  '123456788'    attendu=False obtenu=False OK\n",
+      "  '112345678'    attendu=False obtenu=False OK\n",
+      "  '12345678'     attendu=False obtenu=False OK\n",
+      "  '1234567890'   attendu=False obtenu=False OK\n"
+     ]
+    }
+   ],
+   "source": [
+    "# La contrainte de ligne Sudoku comme conjunction de lookaheads (idiome Python).\n",
+    "# Pour une chaine de longueur 9 sur [1-9], presence de chaque chiffre <=> distinctness.\n",
+    "import re\n",
+    "\n",
+    "LIGNE_VALIDE = re.compile(\n",
+    "    r\"^(?=.*1)(?=.*2)(?=.*3)(?=.*4)(?=.*5)\"\n",
+    "    r\"(?=.*6)(?=.*7)(?=.*8)(?=.*9)[1-9]{9}$\"\n",
+    ")\n",
+    "\n",
+    "# Reconnaissance (validation d'une ligne deja remplie) — pas de resolution.\n",
+    "tests = {\n",
+    "    \"123456789\": True,   # ligne valide\n",
+    "    \"987654321\": True,   # valide, ordre inverse\n",
+    "    \"123456788\": False,  # 9 absent, 8 double\n",
+    "    \"112345678\": False,  # 9 absent, 1 double\n",
+    "    \"12345678\":  False,  # trop court (8)\n",
+    "    \"1234567890\": False, # trop long (10)\n",
+    "}\n",
+    "print(\"Reconnaissance d'une ligne Sudoku (lookaheads Python) :\")\n",
+    "for s, attendu in tests.items():\n",
+    "    obtenu = bool(LIGNE_VALIDE.match(s))\n",
+    "    statut = \"OK\" if obtenu == attendu else \"ECHEC\"\n",
+    "    print(f\"  {s!r:14s} attendu={str(attendu):5s} obtenu={str(obtenu):5s} {statut}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f54df36c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001644,
+     "end_time": "2026-07-06T07:00:11.592815",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.591171",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — ligne valide AVEC 5 avant 7 (intersection + ordre)\n",
+    "Recopiez le motif `LIGNE_VALIDE` et croisez-le avec la contrainte d'ordre `.*5.*7.*` (le 5 doit apparaitre avant le 7). *Indice* : un lookahead supplementaire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c4eff3f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.597020Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.596768Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.599690Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.599249Z"
+    },
+    "papermill": {
+     "duration": 0.005872,
+     "end_time": "2026-07-06T07:00:11.600336",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.594464",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : la ligne doit etre valide ET 5 doit apparaitre avant 7.\n",
+      "  (ajoutez le lookahead d'ordre au motif ci-dessus)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : ligne Sudoku valide AVEC 5 avant 7 (intersection & ordre)\n",
+    "# TODO etudiant : completer le motif ci-dessous.\n",
+    "# Indice : croisez la contrainte de ligne valide avec un lookahead (?:.*5.*7.*)\n",
+    "ligne_avec_5_avant_7 = r\"^[1-9]{9}$\"  # TODO etudiant : completer l'intersection\n",
+    "exo_re = re.compile(ligne_avec_5_avant_7)\n",
+    "print(\"Exercice a completer : la ligne doit etre valide ET 5 doit apparaitre avant 7.\")\n",
+    "print(\"  (ajoutez le lookahead d'ordre au motif ci-dessus)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9231fa71",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001778,
+     "end_time": "2026-07-06T07:00:11.604163",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.602385",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Barreau 3 — la resolution Z3 (le vrai solveur)\n",
+    "\n",
+    "La reconnaissance valide ; elle ne **resout** pas. Pour produire une grille solution a partir de cases vides, on passe au solveur SMT **Z3** : 81 entiers `x_r_c` dans `[1,9]`, une contrainte `Distinct` par ligne, colonne et bloc, et les cases connues fixees. C'est le resolveur de production — le temoin = la grille solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7581d1df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.608349Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.608186Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.674624Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.674161Z"
+    },
+    "papermill": {
+     "duration": 0.06938,
+     "end_time": "2026-07-06T07:00:11.675305",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.605925",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resolution Z3 : sat en 41.1 ms\n",
+      "Grille solution :\n",
+      "  5 3 4 6 7 8 9 1 2\n",
+      "  6 7 2 1 9 5 3 4 8\n",
+      "  1 9 8 3 4 2 5 6 7\n",
+      "  8 5 9 7 6 1 4 2 3\n",
+      "  4 2 6 8 5 3 7 9 1\n",
+      "  7 1 3 9 2 4 8 5 6\n",
+      "  9 6 1 5 3 7 2 8 4\n",
+      "  2 8 7 4 1 9 6 3 5\n",
+      "  3 4 5 2 8 6 1 7 9\n",
+      "Les 9 lignes passent la reconnaissance regex : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Resolution du Sudoku par Z3 : 81 entiers + Distinct sur lignes/colonnes/blocs.\n",
+    "# C'est le VRAI resolveur de production (le temoin = la grille solution).\n",
+    "from z3 import Solver, Int, Distinct, sat\n",
+    "import time\n",
+    "\n",
+    "# Grille de test (puzzle classique, 0 = case vide)\n",
+    "PUZZLE = [\n",
+    "    [5,3,0,0,7,0,0,0,0],\n",
+    "    [6,0,0,1,9,5,0,0,0],\n",
+    "    [0,9,8,0,0,0,0,6,0],\n",
+    "    [8,0,0,0,6,0,0,0,3],\n",
+    "    [4,0,0,8,0,3,0,0,1],\n",
+    "    [7,0,0,0,2,0,0,0,6],\n",
+    "    [0,6,0,0,0,0,2,8,0],\n",
+    "    [0,0,0,4,1,9,0,0,5],\n",
+    "    [0,0,0,0,8,0,0,7,9],\n",
+    "]\n",
+    "\n",
+    "def resoudre_sudoku_z3(puzzle):\n",
+    "    s = Solver()\n",
+    "    X = [[Int(f\"x_{r}_{c}\") for c in range(9)] for r in range(9)]\n",
+    "    for r in range(9):\n",
+    "        for c in range(9):\n",
+    "            s.add(X[r][c] >= 1, X[r][c] <= 9)\n",
+    "            if puzzle[r][c] != 0:\n",
+    "                s.add(X[r][c] == puzzle[r][c])\n",
+    "        s.add(Distinct([X[r][c] for c in range(9)]))       # ligne\n",
+    "    for c in range(9):\n",
+    "        s.add(Distinct([X[r][c] for r in range(9)]))       # colonne\n",
+    "    for br in range(0, 9, 3):                               # bloc 3x3\n",
+    "        for bc in range(0, 9, 3):\n",
+    "            s.add(Distinct([X[br+i][bc+j] for i in range(3) for j in range(3)]))\n",
+    "    if s.check() != sat:\n",
+    "        return None\n",
+    "    m = s.model()\n",
+    "    return [[m[X[r][c]].as_long() for c in range(9)] for r in range(9)]\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "solution = resoudre_sudoku_z3(PUZZLE)\n",
+    "dt_z3 = time.perf_counter() - t0\n",
+    "\n",
+    "print(f\"Resolution Z3 : sat en {dt_z3*1000:.1f} ms\")\n",
+    "print(\"Grille solution :\")\n",
+    "for r in range(9):\n",
+    "    print(\"  \" + \" \".join(str(solution[r][c]) for c in range(9)))\n",
+    "# Verification : chaque ligne doit passer la reconnaissance lookahead.\n",
+    "ok = all(LIGNE_VALIDE.match(\"\".join(map(str, solution[r]))) for r in range(9))\n",
+    "print(f\"Les 9 lignes passent la reconnaissance regex : {ok}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ff0f87c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001863,
+     "end_time": "2026-07-06T07:00:11.679351",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.677488",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Sudoku-X (variantes avec contraintes de diagonales)\n",
+    "Reprenez le schema de `resoudre_sudoku_z3` et ajoutez deux contraintes `Distinct` : sur la diagonale principale (`cells[i, i]`) et l'anti-diagonale (`cells[i, 8-i]`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c87338d8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.684117Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.683917Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.687250Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.686897Z"
+    },
+    "papermill": {
+     "duration": 0.006713,
+     "end_time": "2026-07-06T07:00:11.688011",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.681298",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : Sudoku-X (contraintes diagonales supplementaires).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : resoudre_sudoku_x (variante avec contraintes de diagonales)\n",
+    "# TODO etudiant : reprendre resoudre_sudoku_z3 et ajouter deux Distinct sur les diagonales.\n",
+    "# Indice : diagonale principale = X[i][i], anti-diagonale = X[i][8-i] pour i in range(9).\n",
+    "def resoudre_sudoku_x(puzzle):\n",
+    "    return puzzle  # TODO etudiant : remplacer par la resolution avec contraintes diagonales\n",
+    "\n",
+    "print(\"Exercice a completer : Sudoku-X (contraintes diagonales supplementaires).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b17247c2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002428,
+     "end_time": "2026-07-06T07:00:11.692381",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.689953",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Barreau 4 — la theorie des chaines Z3 (re.*)\n",
+    "\n",
+    "Z3 ne fait pas que resoudre sur des entiers : il expose une **theorie des chaines** avec un sort d'expressions regulieres (`Re`). On peut encoder la contrainte de ligne comme un *automate* sur le sort chaine, et laisser le solveur **reconnaitre** la validite. C'est le pont Python equivalent au `RegexToSMTConverter` du twin C# (Microsoft.Automata) : on croise le moteur regex et le moteur SMT."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2742fd4e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.697135Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.696769Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.704787Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.704378Z"
+    },
+    "papermill": {
+     "duration": 0.011257,
+     "end_time": "2026-07-06T07:00:11.705471",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.694214",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reconnaissance via la theorie des chaines Z3 (sort Re) :\n",
+      "  '123456789' -> sat\n",
+      "  '123456788' -> unsat\n",
+      "  '12345678'  -> unsat\n",
+      "L'automate Z3 reconnait ce que le solveur produit (boucle bouclee).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Theorie des chaines Z3 : la contrainte de ligne comme regex sur le sort String.\n",
+    "# Pont Python equivalent au RegexToSMTConverter du twin C# (Microsoft.Automata).\n",
+    "from z3 import String, StringVal, Range, Concat, InRe, Contains, Solver\n",
+    "\n",
+    "def ligne_valide_smt(chaine_attendue):\n",
+    "    \"\"\"Reconnait (sat) ou rejette (unsat) une ligne via la theorie des chaines Z3.\"\"\"\n",
+    "    s = Solver()\n",
+    "    ligne = String(\"ligne\")\n",
+    "    digit = Range(StringVal(\"1\"), StringVal(\"9\"))   # [1-9] comme un Re\n",
+    "    neuf_digits = Concat(*[digit] * 9)                 # longueur 9 sur [1-9]\n",
+    "    s.add(InRe(ligne, neuf_digits))                    # appartenance a l'automate\n",
+    "    for d in \"123456789\":                              # presence de chaque chiffre\n",
+    "        s.add(Contains(ligne, StringVal(d)))\n",
+    "    s.add(ligne == StringVal(chaine_attendue))\n",
+    "    return str(s.check())\n",
+    "\n",
+    "print(\"Reconnaissance via la theorie des chaines Z3 (sort Re) :\")\n",
+    "print(f\"  '123456789' -> {ligne_valide_smt('123456789')}\")   # sat : valide\n",
+    "print(f\"  '123456788' -> {ligne_valide_smt('123456788')}\")   # unsat : 9 absent\n",
+    "print(f\"  '12345678'  -> {ligne_valide_smt('12345678')}\" )   # unsat : trop court\n",
+    "print(\"L'automate Z3 reconnait ce que le solveur produit (boucle bouclee).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5a48069",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001915,
+     "end_time": "2026-07-06T07:00:11.709403",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.707488",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Le declic complementaire — la recursion `(?&rec)` que .NET rejette\n",
+    "\n",
+    "Les Sudoku-en-un-regex **celebres** (Conway, ikegami PerlMonks 471168, Davidebyzero) reposent sur la **recursion `(?R)`/`(?&nom)`** — un langage **non regulier** (hors du pouvoir d'expression d'un automate fini). Le twin C# (cellule 15) demontre que `System.Text.RegularExpressions` **rejette** cette syntaxe a la construction : .NET ne sait pas recurser un motif.\n",
+    "\n",
+    "Le module Python [`regex`](https://pypi.org/project/regex/) le **supporte**. On le demontre sur le langage canonique non-regulier `a^n b^n` (context-free) : un motif recursif le reconnait exactement. C'est la valeur **complementaire** du twin Python — il execute ce que le twin C# ne fait qu'evoquer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8cd6348c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.714425Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.714188Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.726089Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.725644Z"
+    },
+    "papermill": {
+     "duration": 0.01544,
+     "end_time": "2026-07-06T07:00:11.726804",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.711364",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recursion (?&rec) du module regex sur le langage non-regulier a^n b^n :\n",
+      "  'ab'       -> True\n",
+      "  'aabb'     -> True\n",
+      "  'aaabbb'   -> True\n",
+      "  'aaaabbbb' -> True\n",
+      "  'aab'      -> False\n",
+      "  'aba'      -> False\n",
+      "  'ba'       -> False\n",
+      "\n",
+      "stdlib re REJETTE la recursion : unknown extension ?& at position 11\n",
+      "\n",
+      "Conclusion Prong B : le module 'regex' supporte (?&rec) = langage non-regulier.\n",
+      ".NET System.Text.RegularExpressions REJETE (?R)/(?&rec) — cf twin C# cellule 15.\n",
+      "Les Sudoku-en-un-regex celebres reposent sur cette recursion : seul le twin Python peut l'executer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PRONG B : la recursion (?&rec) du module 'regex' — capability absente de .NET et de stdlib re.\n",
+    "import regex\n",
+    "import re\n",
+    "\n",
+    "# Langage non-regulier a^n b^n (context-free) reconnu par recursion nommee.\n",
+    "# (?&rec) recurse le CORPS du groupe (a...b) sans re-ancrer ^ $.\n",
+    "AN_BN = regex.compile(r\"^(?P<rec>a(?&rec)?b)$\")\n",
+    "\n",
+    "print(\"Recursion (?&rec) du module regex sur le langage non-regulier a^n b^n :\")\n",
+    "for s in [\"ab\", \"aabb\", \"aaabbb\", \"aaaabbbb\", \"aab\", \"aba\", \"ba\"]:\n",
+    "    print(f\"  {s!r:10s} -> {bool(AN_BN.match(s))}\")\n",
+    "\n",
+    "print()\n",
+    "# Confirmation : stdlib 're' rejette la recursion (tout comme .NET).\n",
+    "try:\n",
+    "    re.compile(r\"^(?P<rec>a(?&rec)?b)$\")\n",
+    "    print(\"stdlib re : compile (inasattendu)\")\n",
+    "except re.error as e:\n",
+    "    print(f\"stdlib re REJETTE la recursion : {e}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Conclusion Prong B : le module 'regex' supporte (?&rec) = langage non-regulier.\")\n",
+    "print(\".NET System.Text.RegularExpressions REJETE (?R)/(?&rec) — cf twin C# cellule 15.\")\n",
+    "print(\"Les Sudoku-en-un-regex celebres reposent sur cette recursion : seul le twin Python peut l'executer.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a2f13f6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001939,
+     "end_time": "2026-07-06T07:00:11.730809",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.728870",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Le contre-point : backtracking recursif naif\n",
+    "\n",
+    "Le contre-point de l'approche declarative : le **backtracking recursif naif**. La pile d'appels EST la pile de contexte (legere, zero allocation par essai). C'est l'outil qui epouse le substrat — robuste, trivial a ecrire, et competitif sur un 9x9. On le compare en temps au solveur Z3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "91fc7d83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.735643Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.735460Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.763199Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.762683Z"
+    },
+    "papermill": {
+     "duration": 0.03112,
+     "end_time": "2026-07-06T07:00:11.763926",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.732806",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Backtracking recursif : resolu en 22.4 ms\n",
+      "Z3 (barreau 3)         : resolu en 41.1 ms\n",
+      "Les deux solveurs donnent la meme grille : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Backtracking recursif naif : la pile d'appels = pile de contexte. Outil qui epouse le substrat.\n",
+    "import copy\n",
+    "\n",
+    "def _valide(g, r, c, v):\n",
+    "    if v in g[r]:\n",
+    "        return False\n",
+    "    if any(g[i][c] == v for i in range(9)):\n",
+    "        return False\n",
+    "    br, bc = 3 * (r // 3), 3 * (c // 3)\n",
+    "    return not any(g[br+i][bc+j] == v for i in range(3) for j in range(3))\n",
+    "\n",
+    "def resoudre_backtracking(g):\n",
+    "    for r in range(9):\n",
+    "        for c in range(9):\n",
+    "            if g[r][c] == 0:\n",
+    "                for v in range(1, 10):\n",
+    "                    if _valide(g, r, c, v):\n",
+    "                        g[r][c] = v\n",
+    "                        if resoudre_backtracking(g):\n",
+    "                            return True\n",
+    "                        g[r][c] = 0\n",
+    "                return False\n",
+    "    return True\n",
+    "\n",
+    "grille_bt = copy.deepcopy(PUZZLE)\n",
+    "t0 = time.perf_counter()\n",
+    "ok_bt = resoudre_backtracking(grille_bt)\n",
+    "dt_bt = time.perf_counter() - t0\n",
+    "\n",
+    "print(f\"Backtracking recursif : {'resolu' if ok_bt else 'echec'} en {dt_bt*1000:.1f} ms\")\n",
+    "print(f\"Z3 (barreau 3)         : resolu en {dt_z3*1000:.1f} ms\")\n",
+    "identique = grille_bt == solution\n",
+    "print(f\"Les deux solveurs donnent la meme grille : {identique}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "253accad",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002157,
+     "end_time": "2026-07-06T07:00:11.768473",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.766316",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Reconnaissance vs resolution — le tableau comparatif\n",
+    "\n",
+    "Trois outils, trois roles distincts. La reconnaissance (regex) certifie en temps lineaire ce qu'elle ne sait pas produire. La resolution (Z3) produit. La recursion (`regex` `(?&rec)`) franchit la frontiere du regulier — le seul outil des trois qui puisse exprimer un Sudoku-en-un-regex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c9bb7c1f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:00:11.773678Z",
+     "iopub.status.busy": "2026-07-06T07:00:11.773489Z",
+     "iopub.status.idle": "2026-07-06T07:00:11.777595Z",
+     "shell.execute_reply": "2026-07-06T07:00:11.777184Z"
+    },
+    "papermill": {
+     "duration": 0.007447,
+     "end_time": "2026-07-06T07:00:11.778263",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.770816",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Reconnaissance vs Resolution ===\n",
+      "Tache                                            Outil                Role\n",
+      "----------------------------------------------------------------------------------------\n",
+      "Verifier une ligne/grille deja remplie           re (lookaheads)      reconnaissance\n",
+      "Resoudre un puzzle (cases vides)                 z3-solver            resolution\n",
+      "Reconnaitre via automate (sort Re Z3)            z3 theorie chaines   reconnaissance SMT\n",
+      "Langage non-regulier a^n b^n / Sudoku-regex      regex (?&rec)        au-dela du regulier\n",
+      "Backtracking recursif naif                       Python pur           epouse le substrat\n",
+      "\n",
+      "EXERCICE (conceptuel) : pour chaque tache, indiquer l'outil et la justification.\n",
+      "(a) Verifier qu'une grille remplie respecte les regles : re lookaheads -> ...\n",
+      "(b) Resoudre un puzzle a partir de cases vides       : z3              -> ...\n",
+      "(c) Matcher un langage non-regulier imbrique          : regex (?&rec)  -> ...\n",
+      "    (completer la justification de chaque choix)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"=== Reconnaissance vs Resolution ===\")\n",
+    "print(f\"{'Tache':<48} {'Outil':<20} {'Role'}\")\n",
+    "print(\"-\" * 88)\n",
+    "lignes = [\n",
+    "    (\"Verifier une ligne/grille deja remplie\",     \"re (lookaheads)\",   \"reconnaissance\"),\n",
+    "    (\"Resoudre un puzzle (cases vides)\",            \"z3-solver\",         \"resolution\"),\n",
+    "    (\"Reconnaitre via automate (sort Re Z3)\",      \"z3 theorie chaines\",\"reconnaissance SMT\"),\n",
+    "    (\"Langage non-regulier a^n b^n / Sudoku-regex\", \"regex (?&rec)\",     \"au-dela du regulier\"),\n",
+    "    (\"Backtracking recursif naif\",                  \"Python pur\",        \"epouse le substrat\"),\n",
+    "]\n",
+    "for tache, outil, role in lignes:\n",
+    "    print(f\"{tache:<48} {outil:<20} {role}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"EXERCICE (conceptuel) : pour chaque tache, indiquer l'outil et la justification.\")\n",
+    "print(\"(a) Verifier qu'une grille remplie respecte les regles : re lookaheads -> ...\")\n",
+    "print(\"(b) Resoudre un puzzle a partir de cases vides       : z3              -> ...\")\n",
+    "print(\"(c) Matcher un langage non-regulier imbrique          : regex (?&rec)  -> ...\")\n",
+    "print(\"    (completer la justification de chaque choix)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7bebf2e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001991,
+     "end_time": "2026-07-06T07:00:11.782650",
+     "exception": false,
+     "start_time": "2026-07-06T07:00:11.780659",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Conclusion — l'echelle Python, du folklore au non-regulier\n",
+    "\n",
+    "Ce twin Python parcourt la meme echelle que le twin C# — Conway -> reconnaissance -> resolution -> theorie des chaines — mais **complete** la ou le C# bute : la **recursion `(?&rec)`** du module `regex` execute les langages non-reguliers que `System.Text.RegularExpressions` rejette. Les Sudoku-en-un-regex celebres reposent precisement sur cette recursion ; le twin Python est donc le seul des deux a pouvoir *demontrer* cette voie, pas seulement l'evoquer.\n",
+    "\n",
+    "**Bilan complementaire (#3801 Prong B)** :\n",
+    "- `re` + lookaheads : reconnaissance lineaire d'une ligne/grille valide.\n",
+    "- `z3-solver` : resolution (production de la grille) + theorie des chaines (reconnaissance SMT).\n",
+    "- `regex` `(?&rec)` : le seul outil des deux twins qui franchit la frontiere du regulier.\n",
+    "- Backtracking recursif : le contre-point robuste, competitif sur 9x9.\n",
+    "\n",
+    "> Retour au [twin C#](Sudoku-13-SymbolicAutomata-Csharp.ipynb) — ou le barreau recursion est documente comme un mur (.NET rejette `(?R)`)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2.184449,
+   "end_time": "2026-07-06T07:00:11.924489",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Sudoku-13-SymbolicAutomata-Python.ipynb",
+   "output_path": "sudoku13_py_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T07:00:09.740040",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

**Twin Python** de [Sudoku-13-SymbolicAutomata-Csharp](MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb). **Gap de parité firsthand** : Sudoku-13-Csharp existait sans jumeau Python (Sudoku-12/14/15 ont tous un twin Python). Marathon #4956 (parité .NET ⇄ Python). **Rule 6** : pivot OFF .NET après 6 cycles .NET d'affilée → famille Python.

## Algorithme / démarche

Reprend l'échelle du twin C# (Conway → reconnaissance → résolution → théorie des chaînes), en Python :
- **Barreau 1** : le monstre PCRE (folklore PerlMonks), chargé depuis `assets/sudoku-unrolled.regex.txt` (troncage tête+queue, extrait réel).
- **Barreau 2** : reconnaissance d'une ligne Sudoku comme conjunction de lookaheads `(?=.*d)` — l'idiome Python de l'intersection RE#.
- **Barreau 3** : résolution Z3 (le vrai solveur, 81 entiers + `Distinct` par ligne/colonne/bloc).
- **Barreau 4** : théorie des chaînes Z3 (`Range`/`Concat`/`InRe`/`Contains` sur le sort `Re`) — reconnaissance SMT, équivalent Python du `RegexToSMTConverter` C#.
- **Contre-point** : backtracking récursif naïf (la pile d'appels = pile de contexte).

## Complémentarité (#3801 Prong B) — la valeur ajoutée

| Twin | Outils | Valeur |
|------|--------|--------|
| C# (Resharp RE# + Microsoft.Automata + Z3.NET) | DLLs `.deploy` in-repo | la chaîne symbolique de Veanes (AutomataDotNet) |
| **This (z3-solver + regex + re)** | PyPI, idiomatique Python | **la récursion `(?&rec)` du module `regex`** — capability que .NET REJETTE |

**Le point de bascule** : les Sudoku-en-un-regex célèbres (Conway, ikegami PerlMonks 471168) reposent sur la récursion `(?R)`/`(?&nom)` — un langage **non régulier**. Le twin C# (cellule 15) démontre que `System.Text.RegularExpressions` **rejette** cette syntaxe à la construction. Le module Python `regex` la **supporte** : ce twin **exécute** une approche récursive que le twin C# ne fait qu'évoquer. Démonstration sur le langage canonique non-régulier `a^n b^n` — valeur complémentaire, pas un simple miroir.

## Exec prouvée (C.2/H.1)

Papermill kernel `python3` (`C:\Python313`, z3 4.15.4 + regex 2026.2.28), **9/9 cellules code `execution_count` 1-9, 0 erreur**. Outputs vérifiés **firsthand** :

- **Asset** : 13 514 caractères, troncage tête+queue du vrai regex déroulé (`\A`, `\d*(\d)`, lookaheads `(?!(?:.*\n)+...)`) ✓
- **Reconnaissance lookaheads** : 6/6 cas (123456789 T, 987654321 T, 123456788 F, 112345678 F, 12345678 F, 1234567890 F) ✓
- **Z3 solveur** : `sat` en 41.1 ms, grille solution complète valide, les 9 lignes passent la reconnaissance regex ✓
- **Théorie des chaînes Z3** : `123456789`→sat, `123456788`→unsat, `12345678`→unsat ✓
- **Récursion `(?&rec)` (Prong B)** : `a^n b^n` — ab/aabb/aaabbb/aaaabbbb→True, aab/aba/ba→False ; stdlib `re` REJETTE `(?&)` ("unknown extension") ✓
- **Backtracking** : résolu en 22.4 ms, même grille que Z3 ✓

## SOTA-OK (#3801)

Vrais outils SOTA invoqués proprement : `z3-solver` (résolution + théorie des chaînes), module `regex` (récursion non-régulière), `re` (reconnaissance lookahead). Pas de workaround dégradé. Problème non-trivial : l'échelle Conway→résolution + la frontière du régulier.

## Exercices (#2161)

3 stubs C.1-conformes : (1) ligne valide avec 5 avant 7 (intersection + ordre), (2) Sudoku-X (contraintes de diagonales Z3), (3) classification conceptuelle reconnaissance vs résolution.

## Scope

Atomique : 1 notebook (873 lignes) + README stats (33→34 notebooks, 13→14 paires miroir, 3→2 C#-uniquement). Catalogue byte-identical (R1). Self-contained (BCL Python + PyPI standards).

## Marathon #4956

Sudoku-13 rejoint les paires miroir (14 paires désormais). Complète la parité de la sous-série SymbolicAutomata.

See #4956. Revue souhaitée : po-2025 ou ai-01.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
