### PR TITLE
feat(ict-9): add agency.local_structure(V, mask) — local observable for ICT-19 repair

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/agency.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/agency.py
@@ -84,6 +84,32 @@ def structure(V: np.ndarray) -> float:
     return float(np.var(V))
 
 
+def local_structure(V: np.ndarray, mask: np.ndarray) -> float:
+    """Structure spatiale restreinte a une region (masque booleen).
+
+    Variance de ``V`` sur les seules cellules selectionnees par ``mask`` (un
+    tableau booleen de meme forme que ``V``, typiquement produit par
+    :func:`disk_mask` ou :func:`quadrant_mask`). C'est le complement local de
+    :func:`structure` : quand on ablate une sous-region du champ (cf
+    :func:`ablate`), la variance **globale** bouge a peine (l'ablation d'un
+    disque de rayon 8 dans un champ 32x32 ne change que ~8% des cellules) et
+    ne capte donc pas la perte de motif. La variance **locale au masque**
+    tombe a zero apres ablation (les cellules sont uniformisees a ``V=0``) et
+    remonte si la dynamique regenere un motif a cet endroit -- c'est
+    l'observable qu'il faut pour mesurer la reparation *in situ* apres une
+    intervention ``do(.)`` (Pearl), fil rouge ICT-9 et batterie ENJEU d'ICT-19.
+
+    Retourne ``0.0`` si le masque est vide ou ne selectionne qu'une seule
+    cellule (variance non definie).
+    """
+    V = np.asarray(V, dtype=float)
+    mask = np.asarray(mask, dtype=bool)
+    vals = V[mask]
+    if vals.size < 2:
+        return 0.0
+    return float(np.var(vals))
+
+
 def spatial_autocorrelation(field: np.ndarray) -> float:
     """Auto-correlation spatiale au decalage 1 (moyenne des deux axes, bords periodiques).
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_agency.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_agency.py
@@ -62,6 +62,54 @@ def test_structure_increases_with_contrast():
     assert agency.structure(contrasted) > agency.structure(flat)
 
 
+def test_local_structure_uniform_region_is_zero():
+    """Une region uniforme a une local_structure nulle (comme structure globale)."""
+    V = np.full((10, 10), 0.42)
+    mask = agency.disk_mask(10, cx=5, cy=5, radius=3)
+    assert agency.local_structure(V, mask) == pytest.approx(0.0)
+
+
+def test_local_structure_captures_contrast_in_region():
+    """local_structure capte le contraste restreint au masque (motif local)."""
+    rng = np.random.default_rng(0)
+    V = np.full((20, 20), 0.5)
+    mask = agency.disk_mask(20, cx=10, cy=10, radius=4)
+    V[mask] = rng.choice([0.0, 1.0], size=mask.sum())
+    assert agency.local_structure(V, mask) > 0.1
+    elsewhere = agency.disk_mask(20, cx=0, cy=0, radius=3)
+    assert agency.local_structure(V, elsewhere) == pytest.approx(0.0)
+
+
+def test_local_structure_drops_to_zero_after_ablation():
+    """Le cas d'usage ICT-9/ICT-19 : apres ablate(mask), local_structure(mask) -> 0.
+
+    C'est le complement local que structure() globale ne capte pas : ablater
+    un disque de rayon 8 dans un champ 32x32 change a peine la variance globale
+    mais annule la variance locale au masque.
+    """
+    rng = np.random.default_rng(123)
+    V = rng.choice([0.0, 1.0], size=(32, 32))
+    mask = agency.disk_mask(32, cx=16, cy=16, radius=8)
+    before = agency.local_structure(V, mask)
+    assert before > 0.1
+    U = np.full((32, 32), 1.0)
+    _, V_abl = agency.ablate(U, V, mask)
+    after = agency.local_structure(V_abl, mask)
+    assert after == pytest.approx(0.0)
+    assert abs(agency.structure(V) - agency.structure(V_abl)) < 0.05
+
+
+def test_local_structure_empty_or_single_mask_is_zero():
+    """Masque vide ou single-cell -> variance non definie -> 0.0."""
+    V = np.full((6, 6), 0.5)
+    V[0, 0] = 1.0
+    empty = np.zeros((6, 6), dtype=bool)
+    assert agency.local_structure(V, empty) == 0.0
+    single = np.zeros((6, 6), dtype=bool)
+    single[3, 3] = True
+    assert agency.local_structure(V, single) == 0.0
+
+
 def test_pattern_distance_zero_for_identical():
     a = np.random.default_rng(0).standard_normal((12, 12))
     assert agency.pattern_distance(a, a) == pytest.approx(0.0)


### PR DESCRIPTION
Part of #4588 (Epic IIT→ICT). Ajoute la primitive locale manquante à `ict.agency` (module merged ICT-9), nécessaire pour le fix S4 de la batterie ENJEU d'ICT-19.

## Primitive

```python
def local_structure(V: np.ndarray, mask: np.ndarray) -> float:
    """Variance de V restreinte aux cellules du masque booléen."""
```

Complément **local** de `structure(V)` (variance globale). Masque typiquement produit par `disk_mask`/`quadrant_mask`.

## Motivation (diagnostic firsthand ICT-19 c.70)

Après `ablate(mask)`, la variance **globale** du champ bouge à peine — ablater un disque rayon 8 dans un champ 32×32 ne change que ~8% des cellules → `structure(V)` ne capte pas la perte de motif. La variance **locale au masque** tombe à zéro (cellules uniformisées à `V=0`) et remonte si la dynamique régénère un motif — c'est l'observable pour mesurer la réparation *in situ* après intervention `do(·)` (Pearl), fil rouge ICT-9 et batterie ENJEU d'ICT-19.

Le banc notebook ICT-19 (#5526) committe `S4 I_stake = −0.5083` (l'agent Gray-Scott, censé avoir un enjeu positif) parce que `structure(V)` globale (1) rate l'ablation et (2) l'ancre est estimée sur 20 pas pré-warmup. **Fix validé c.70** : warmup 500 + `local_structure(V, mask)` → `I_stake(S4) = +0.87`, contrôle diffusion +0.04, `repair_gain = +0.83` (S4 régénère activement sa structure locale — Levin/Mordvintsev enfin capturé).

Cette PR pose la primitive dans le module ; l'intégration notebook ICT-19 suit en follow-up (décision scope ai-01, DM msg-...xg3d5f c.65→74).

## Validation empirique

`local_structure()` du module reproduit exactement le fix S4 c.70 (testé sur le worktree) : ancre 0.005763, post-ablation 0.000000, **I_stake(S4) = +0.8768** (vs −0.5083 cassé).

## Tests — 4 nouveaux (suite ICT 340 → 344 passed, 0 régression)

- `test_local_structure_uniform_region_is_zero` : région uniforme → 0
- `test_local_structure_captures_contrast_in_region` : capte contraste restreint au masque, ailleurs reste 0
- `test_local_structure_drops_to_zero_after_ablation` : **cas d'usage ICT-9/19** — après `ablate(mask)`, `local_structure(mask)→0` alors que `structure` globale bouge à peine
- `test_local_structure_empty_or_single_mask_is_zero` : masque vide/single-cell → 0

## Garde-fous
- ✅ GPU-free, numpy-only ; catalogue byte-identical ; `See #4588` ; docstrings FR ; C.1 clean
- ✅ anti-régression (344 passed, fonction additive — 0 modification de `structure` existante)
- ✅ complémentaire de #5527 (fix entropy_production) — les 2 préparent la gate ENJEU-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)