### PR TITLE
feat(planners): Planners-3-State-Space-Csharp — BFS/DFS/Greedy/A* twin (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
@@ -1,0 +1,1185 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "483916e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002883,
+     "end_time": "2026-07-06T07:38:55.575487",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:55.572604",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "**Navigation** : [<< Planners-1 Introduction C#](Planners-1-Introduction-Csharp.ipynb) | [Index](../../README.md) | [Planners-2 PDDL Basics >>](Planners-2-PDDL-Basics.ipynb)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "# Planners-3 : Recherche dans l'Espace d'Etats — twin C# (BFS / DFS / Greedy / A*)\n",
+    "\n",
+    "> **Twin C#** de [Planners-3-State-Space](Planners-3-State-Space.ipynb) (Python + networkx). **Tranche 2** du marathon Planners (#4956) : apres Planners-1 (STRIPS + BFS), la progression **search nu -> A*** avec heuristiques, admissibilite et coherence.\n",
+    "\n",
+    "## Complementarite (#3801 Prong B)\n",
+    "\n",
+    "| Twin | Outil | Valeur |\n",
+    "|------|-------|--------|\n",
+    "| Python (networkx + matplotlib) | visualisation graphe + heatmap terrain | explorer les paysages de recherche visuellement |\n",
+    "| **This (.NET BCL seule)** | `PriorityQueue` .NET 9 + from-scratch | **comprendre** la mecanique interne des algos (frontiere, f=g+h, closed set) |\n",
+    "\n",
+    "Pas d'equivalent NuGet didactique idiomatique pour ce niveau -> from-scratch = la valeur. BCL .NET seule, 0 NuGet.\n",
+    "\n",
+    "**Le point cle (#3801 Prong B, cas non-degenere)** : sur un terrain uniforme BFS = A*. Sur un **terrain pondere**, A* trouve un chemin **plus long en etapes mais moins couteux** que BFS — c'est la ou A* discrimine vraiment. Le twin Python le demontre visuellement (heatmap) ; le twin C# le demontre **numeriquement** (table Pas/Cout/Nœuds)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "337fe2e8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001715,
+     "end_time": "2026-07-06T07:38:55.579228",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:55.577513",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Representer** un probleme comme un graphe d'etats (etats + successeurs + couts).\n",
+    "2. **Implementer** BFS, DFS, Greedy Best-First et A* from-scratch (.NET 9 `PriorityQueue`).\n",
+    "3. **Distinguer** optimalite-en-pas (BFS) vs optimalite-en-cout (A*).\n",
+    "4. **Justifier** l'admissibilite d'une heuristique (Manhattan sur grille).\n",
+    "\n",
+    "## 1. Representation d'un espace d'etats\n",
+    "\n",
+    "Un probleme de recherche = (etat initial, test-but, fonction successeurs). Ici une **grille 2D** : un etat = une position `(x, y)` ; les successeurs = les 4 voisins (deplacements N/S/E/O). Le cout d'un pas depend du **terrain** (cas le plus general).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "efde04f7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:55.593942Z",
+     "iopub.status.busy": "2026-07-06T07:38:55.589053Z",
+     "iopub.status.idle": "2026-07-06T07:38:57.178208Z",
+     "shell.execute_reply": "2026-07-06T07:38:57.174427Z"
+    },
+    "papermill": {
+     "duration": 1.597391,
+     "end_time": "2026-07-06T07:38:57.178306",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:55.580915",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '39368.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele grille : GridState = record (x,y) ; ACTIONS = 4 cardinales.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Terrain pondere : cout marais > cout normal (sinon, cas degenere ou BFS=A*).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Modele : etat = position (x, y) sur une grille. Le cout d'un pas depend du terrain d'arrivee.\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// Record : egalite structurelle (deux GridState avec memes x,y sont egaux) = necessaire pour HashSet/Dict.\n",
+    "public record GridState(int X, int Y)\n",
+    "{\n",
+    "    public override string ToString() => $\"({X},{Y})\";\n",
+    "}\n",
+    "\n",
+    "// Directions cardinales : Nord/Sud/Est/Ouest.\n",
+    "static readonly (int dx, int dy)[] ACTIONS = { (0, 1), (0, -1), (1, 0), (-1, 0) };\n",
+    "\n",
+    "// Terrain pondere : cout d'entree dans une case. Defaut = cout uniforme 1 (cas degenere BFS=A*).\n",
+    "static int CoutCase(GridState s, HashSet<GridState> marais, int coutMarais) =>\n",
+    "    marais.Contains(s) ? coutMarais : 1;\n",
+    "\n",
+    "Console.WriteLine($\"Modele grille : GridState = record (x,y) ; ACTIONS = {ACTIONS.Length} cardinales.\");\n",
+    "Console.WriteLine(\"Terrain pondere : cout marais > cout normal (sinon, cas degenere ou BFS=A*).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c860517",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001862,
+     "end_time": "2026-07-06T07:38:57.182461",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.180599",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. BFS — recherche en largeur (optimal en nombre de pas)\n",
+    "\n",
+    "BFS explore en largeur (file FIFO). Sur un graphe a **cout uniforme**, BFS garantit le chemin le plus court en **nombre d'etapes**. Il explore beaucoup de nœuds (pas d'heuristique pour guider)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6afbde6f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:57.188122Z",
+     "iopub.status.busy": "2026-07-06T07:38:57.187922Z",
+     "iopub.status.idle": "2026-07-06T07:38:57.409473Z",
+     "shell.execute_reply": "2026-07-06T07:38:57.409570Z"
+    },
+    "papermill": {
+     "duration": 0.22537,
+     "end_time": "2026-07-06T07:38:57.409639",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.184269",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS : file FIFO + closed set. Optimal en NOMBRE DE PAS (cout uniforme).\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(25,67): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(8,55): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(28,14): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// BFS generique : file FIFO, closed set pour eviter les revisites. Garantit le chemin en PAS minimum.\n",
+    "// getSuccessors renvoie (voisin, cout) — le cout est ignore par BFS (qui compte les pas).\n",
+    "static (List<GridState> path, int stepsCost, int nodesExpanded) BFS(\n",
+    "    GridState initial, GridState goal, Func<GridState, IEnumerable<(GridState n, int cost)>> getSuccessors)\n",
+    "{\n",
+    "    var frontier = new Queue<GridState>();\n",
+    "    frontier.Enqueue(initial);\n",
+    "    var cameFrom = new Dictionary<GridState, GridState?> { [initial] = null };\n",
+    "    int nodes = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        var cur = frontier.Dequeue();\n",
+    "        nodes++;\n",
+    "        if (cur == goal) return (Reconstruct(cameFrom, goal), stepsCost: 0, nodesExpanded: nodes);\n",
+    "        foreach (var (n, cost) in getSuccessors(cur))\n",
+    "            if (!cameFrom.ContainsKey(n))\n",
+    "            {\n",
+    "                cameFrom[n] = cur;\n",
+    "                frontier.Enqueue(n);\n",
+    "            }\n",
+    "    }\n",
+    "    return (new(), 0, nodes);  // pas de chemin\n",
+    "}\n",
+    "\n",
+    "static List<GridState> Reconstruct(Dictionary<GridState, GridState?> cameFrom, GridState goal)\n",
+    "{\n",
+    "    var path = new List<GridState>();\n",
+    "    GridState? cur = goal;\n",
+    "    while (cur is not null)\n",
+    "    {\n",
+    "        path.Add(cur);\n",
+    "        cur = cameFrom[cur];   // cameFrom[x] = parent (ou null si x = initial)\n",
+    "    }\n",
+    "    path.Reverse();\n",
+    "    return path;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"BFS : file FIFO + closed set. Optimal en NOMBRE DE PAS (cout uniforme).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ffde62f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002161,
+     "end_time": "2026-07-06T07:38:57.414147",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.411986",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. DFS — recherche en profondeur (ni optimal ni complet sans limite)\n",
+    "\n",
+    "DFS plonge au maximum avant de revenir en arriere (pile LIFO). Ni optimal ni complet sans limite de profondeur. Interet pedagogique : contraster avec BFS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8d398b7d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:57.420273Z",
+     "iopub.status.busy": "2026-07-06T07:38:57.420104Z",
+     "iopub.status.idle": "2026-07-06T07:38:57.457962Z",
+     "shell.execute_reply": "2026-07-06T07:38:57.458054Z"
+    },
+    "papermill": {
+     "duration": 0.041961,
+     "end_time": "2026-07-06T07:38:57.458113",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.416152",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DFS : pile LIFO. Ni optimal ni complet, contraste pedagogique avec BFS.\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(8,55): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// DFS generique : pile LIFO + closed set. Ni optimal ni complet sans limite, mais contraste avec BFS.\n",
+    "static (List<GridState> path, int nodesExpanded) DFS(\n",
+    "    GridState initial, GridState goal, Func<GridState, IEnumerable<(GridState n, int cost)>> getSuccessors,\n",
+    "    int maxDepth = 1000)\n",
+    "{\n",
+    "    var stack = new Stack<(GridState s, int depth)>();\n",
+    "    stack.Push((initial, 0));\n",
+    "    var cameFrom = new Dictionary<GridState, GridState?> { [initial] = null };\n",
+    "    int nodes = 0;\n",
+    "    while (stack.Count > 0)\n",
+    "    {\n",
+    "        var (cur, depth) = stack.Pop();\n",
+    "        nodes++;\n",
+    "        if (cur == goal) return (Reconstruct(cameFrom, goal), nodes);\n",
+    "        if (depth >= maxDepth) continue;\n",
+    "        foreach (var (n, cost) in getSuccessors(cur))\n",
+    "            if (!cameFrom.ContainsKey(n))\n",
+    "            {\n",
+    "                cameFrom[n] = cur;\n",
+    "                stack.Push((n, depth + 1));\n",
+    "            }\n",
+    "    }\n",
+    "    return (new(), nodes);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"DFS : pile LIFO. Ni optimal ni complet, contraste pedagogique avec BFS.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd8be130",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002541,
+     "end_time": "2026-07-06T07:38:57.462979",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.460438",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Heuristique + Greedy Best-First\n",
+    "\n",
+    "Une **heuristique** `h(n)` estime le cout restant d'un nœud au but. Sur une grille, la distance **Manhattan** `|dx|+|dy|` est admissible (ne surestime jamais le vrai cout sur grille sans obstacles diagonaux). Greedy Best-First n'utilise que `h(n)` pour guider — rapide mais **non optimal** (peut se laisser pieger par l'heuristique)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "668e5d32",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:57.470113Z",
+     "iopub.status.busy": "2026-07-06T07:38:57.469593Z",
+     "iopub.status.idle": "2026-07-06T07:38:57.518938Z",
+     "shell.execute_reply": "2026-07-06T07:38:57.519042Z"
+    },
+    "papermill": {
+     "duration": 0.053847,
+     "end_time": "2026-07-06T07:38:57.519108",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.465261",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Manhattan = |dx|+|dy| (admissible sur grille). Greedy : priorite = h(n) seul (non optimal).\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(11,55): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Heuristique de Manhattan : |dx| + |dy|. Admissible sur grille (ne surestime jamais).\n",
+    "static int Manhattan(GridState a, GridState b) => Math.Abs(a.X - b.X) + Math.Abs(a.Y - b.Y);\n",
+    "\n",
+    "// Greedy Best-First : priorite = h(n) seulement. Rapide MAIS non optimal (se laisse pieger par h).\n",
+    "static (List<GridState> path, int stepsCost, int nodesExpanded) GreedyBestFirst(\n",
+    "    GridState initial, GridState goal, Func<GridState, IEnumerable<(GridState n, int cost)>> getSuccessors,\n",
+    "    Func<GridState, GridState, int> heuristic)\n",
+    "{\n",
+    "    var frontier = new PriorityQueue<GridState, int>();\n",
+    "    frontier.Enqueue(initial, heuristic(initial, goal));\n",
+    "    var cameFrom = new Dictionary<GridState, GridState?> { [initial] = null };\n",
+    "    int nodes = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        var cur = frontier.Dequeue();\n",
+    "        nodes++;\n",
+    "        if (cur == goal) return (Reconstruct(cameFrom, goal), stepsCost: 0, nodesExpanded: nodes);\n",
+    "        foreach (var (n, cost) in getSuccessors(cur))\n",
+    "            if (!cameFrom.ContainsKey(n))\n",
+    "            {\n",
+    "                cameFrom[n] = cur;\n",
+    "                frontier.Enqueue(n, heuristic(n, goal));\n",
+    "            }\n",
+    "    }\n",
+    "    return (new(), 0, nodes);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Manhattan = |dx|+|dy| (admissible sur grille). Greedy : priorite = h(n) seul (non optimal).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c813a1ab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002629,
+     "end_time": "2026-07-06T07:38:57.524301",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.521672",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. A* — cout cumule g + heuristique h (optimal si h admissible)\n",
+    "\n",
+    "A* combine le **cout deja parcouru** `g(n)` et l'**estimation restante** `h(n)` : `f(n) = g(n) + h(n)`. Avec une heuristique **admissible** (h ne surestime jamais), A* est **optimal en cout**. C'est l'algorithme de reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "26192bce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:57.530936Z",
+     "iopub.status.busy": "2026-07-06T07:38:57.530748Z",
+     "iopub.status.idle": "2026-07-06T07:38:57.601672Z",
+     "shell.execute_reply": "2026-07-06T07:38:57.601501Z"
+    },
+    "papermill": {
+     "duration": 0.074907,
+     "end_time": "2026-07-06T07:38:57.601736",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.526829",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A* : f = g + h. Optimal en COUT si h admissible. PriorityQueue<GridState,int> (.NET 9).\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(9,55): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// A* : f = g + h. Suit g (cout cumule reel). Optimal en COUT si h admissible. .NET 9 PriorityQueue.\n",
+    "static (List<GridState> path, int cost, int nodesExpanded) AStar(\n",
+    "    GridState initial, GridState goal, Func<GridState, IEnumerable<(GridState n, int cost)>> getSuccessors,\n",
+    "    Func<GridState, GridState, int> heuristic)\n",
+    "{\n",
+    "    var frontier = new PriorityQueue<GridState, int>();\n",
+    "    frontier.Enqueue(initial, heuristic(initial, goal));\n",
+    "    var gScore = new Dictionary<GridState, int> { [initial] = 0 };\n",
+    "    var cameFrom = new Dictionary<GridState, GridState?> { [initial] = null };\n",
+    "    int nodes = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        var cur = frontier.Dequeue();\n",
+    "        nodes++;\n",
+    "        if (cur == goal) return (Reconstruct(cameFrom, goal), gScore[goal], nodesExpanded: nodes);\n",
+    "        foreach (var (n, stepCost) in getSuccessors(cur))\n",
+    "        {\n",
+    "            int tentative = gScore[cur] + stepCost;\n",
+    "            if (tentative < gScore.GetValueOrDefault(n, int.MaxValue))\n",
+    "            {\n",
+    "                cameFrom[n] = cur;\n",
+    "                gScore[n] = tentative;\n",
+    "                frontier.Enqueue(n, tentative + heuristic(n, goal));  // f = g + h\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return (new(), 0, nodes);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"A* : f = g + h. Optimal en COUT si h admissible. PriorityQueue<GridState,int> (.NET 9).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "827d081f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002393,
+     "end_time": "2026-07-06T07:38:57.606903",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.604510",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Sanity — grille uniforme (cas degenere BFS = A*)\n",
+    "\n",
+    "D'abord le cas degenere : grille 11x11, cout uniforme 1, sans obstacle. Sans poids, BFS et A* trouvent le **meme** chemin (cout = nombre de pas). Verifions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5585495d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:57.613575Z",
+     "iopub.status.busy": "2026-07-06T07:38:57.613263Z",
+     "iopub.status.idle": "2026-07-06T07:38:57.795452Z",
+     "shell.execute_reply": "2026-07-06T07:38:57.795269Z"
+    },
+    "papermill": {
+     "duration": 0.186314,
+     "end_time": "2026-07-06T07:38:57.795544",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.609230",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sanity grille uniforme (cout 1) : BFS = A* (meme chemin). Cas degenere.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  BFS : 10 pas, 91 nœuds explores.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  A*  : 10 pas, cout 10, 11 nœuds explores.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (sans poids, pas de discrimination entre BFS et A* — c'est normal)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Sanity : grille 11x11 uniforme (cout 1 partout). Cas degenere ou BFS = A*.\n",
+    "const int W = 11, H = 11;\n",
+    "var start = new GridState(0, 5);\n",
+    "var goal = new GridState(10, 5);\n",
+    "var noMarais = new HashSet<GridState>();\n",
+    "const int coutMarais = 1;  // uniforme = pas de marais effectif\n",
+    "\n",
+    "// Successeurs ponderes generiques : cout = CoutCase du voisin.\n",
+    "Func<GridState, IEnumerable<(GridState, int)>> succ = s =>\n",
+    "    ACTIONS\n",
+    "        .Select(a => new GridState(s.X + a.dx, s.Y + a.dy))\n",
+    "        .Where(n => n.X >= 0 && n.X < W && n.Y >= 0 && n.Y < H)\n",
+    "        .Select(n => (n, CoutCase(n, noMarais, coutMarais)));\n",
+    "\n",
+    "var (bfsPath, _, bfsNodes) = BFS(start, goal, succ);\n",
+    "var (astarPath, astarCost, astarNodes) = AStar(start, goal, succ, Manhattan);\n",
+    "\n",
+    "Console.WriteLine(\"Sanity grille uniforme (cout 1) : BFS = A* (meme chemin). Cas degenere.\");\n",
+    "Console.WriteLine($\"  BFS : {bfsPath.Count - 1} pas, {bfsNodes} nœuds explores.\");\n",
+    "Console.WriteLine($\"  A*  : {astarPath.Count - 1} pas, cout {astarCost}, {astarNodes} nœuds explores.\");\n",
+    "Console.WriteLine(\"  (sans poids, pas de discrimination entre BFS et A* — c'est normal)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bc8a095",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002368,
+     "end_time": "2026-07-06T07:38:57.800879",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.798511",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. LE point cle (#3801 Prong B) — terrain pondere\n",
+    "\n",
+    "Maintenant le **terrain pondere** : un marais central (cout 10) au milieu de la grille (cout 1). Le depart et le but sont alignes **de part et d'autre du marais**. C'est ici que les algorithmes se **differencient** :\n",
+    "- **BFS / Greedy** minimisent le nombre de PAS -> traversent le marais tout droit (10 pas mais cout eleve).\n",
+    "- **A*** minimise le COUT reel -> contourne le marais (plus de pas mais cout faible).\n",
+    "\n",
+    "C'est le cas **non-degenere** ou A* prouve sa valeur (sur terrain uniforme, A* = BFS)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e658a8a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:57.806733Z",
+     "iopub.status.busy": "2026-07-06T07:38:57.806563Z",
+     "iopub.status.idle": "2026-07-06T07:38:57.968943Z",
+     "shell.execute_reply": "2026-07-06T07:38:57.968798Z"
+    },
+    "papermill": {
+     "duration": 0.165913,
+     "end_time": "2026-07-06T07:38:57.969033",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.803120",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Terrain pondere : BFS / Greedy / A* ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Algo              Pas   Cout   Noeuds   Traverse marais ?\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS               10    56     91       oui (5 cases)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Greedy            10    56     11       oui (5 cases)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A*                16    17     42       non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS/Greedy : 10 pas (court) mais cout 56 (traverse le marais).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A*         : 16 pas (plus long) mais cout 16 (contourne le marais).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seul A* minimise le COUT reel. C'est la ou A* discrimine (terrain uniforme -> A*=BFS).  \r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// PRONG B : terrain pondere. Marais central cout 10 (sinon 1). Depart/but alignes a travers le marais.\n",
+    "// BFS/Greedy traversent (peu de pas, cout eleve). A* contourne (plus de pas, cout faible).\n",
+    "var marais = new HashSet<GridState>(\n",
+    "    from x in Enumerable.Range(3, 5) from y in Enumerable.Range(3, 5) select new GridState(x, y));\n",
+    "const int coutMaraisLourd = 10;\n",
+    "\n",
+    "Func<GridState, IEnumerable<(GridState, int)>> succPondere = s =>\n",
+    "    ACTIONS\n",
+    "        .Select(a => new GridState(s.X + a.dx, s.Y + a.dy))\n",
+    "        .Where(n => n.X >= 0 && n.X < W && n.Y >= 0 && n.Y < H)\n",
+    "        .Select(n => (n, CoutCase(n, marais, coutMaraisLourd)));\n",
+    "\n",
+    "var (bfsW, _, bfsWnodes) = BFS(start, goal, succPondere);\n",
+    "var (greedyW, _, greedyWnodes) = GreedyBestFirst(start, goal, succPondere, Manhattan);\n",
+    "var (astarW, astarWcost, astarWnodes) = AStar(start, goal, succPondere, Manhattan);\n",
+    "\n",
+    "int CoutChemin(List<GridState> path, HashSet<GridState> mz, int cMarais) =>\n",
+    "    path.Sum(s => CoutCase(s, mz, cMarais));\n",
+    "int PasDansMarais(List<GridState> path) => path.Count(s => marais.Contains(s));\n",
+    "\n",
+    "// Tableau numerique (le twin Python le fait visuellement ; ici c'est la table Pas/Cout/Nœuds).\n",
+    "// ATTENTION .NET : les headers statiques en PadRight (PAS d'interpolation {'text',N} = char-literal = CS1012).\n",
+    "Console.WriteLine(\"=== Terrain pondere : BFS / Greedy / A* ===\");\n",
+    "Console.WriteLine(\"Algo\".PadRight(18) + \"Pas\".PadRight(6) + \"Cout\".PadRight(7) + \"Noeuds\".PadRight(9) + \"Traverse marais ?\");\n",
+    "Console.WriteLine(new string('-', 50));\n",
+    "var lignes = new[] {\n",
+    "    (\"BFS\", bfsW, bfsWnodes),\n",
+    "    (\"Greedy\", greedyW, greedyWnodes),\n",
+    "    (\"A*\", astarW, astarWnodes),\n",
+    "};\n",
+    "foreach (var (nom, path, nodes) in lignes)\n",
+    "{\n",
+    "    int pas = path.Count - 1;\n",
+    "    int cout = CoutChemin(path, marais, coutMaraisLourd);\n",
+    "    int nm = PasDansMarais(path);\n",
+    "    string etat = nm > 0 ? $\"oui ({nm} cases)\" : \"non\";\n",
+    "    Console.WriteLine($\"{nom,-18}{pas,-6}{cout,-7}{nodes,-9}{etat}\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"BFS/Greedy : {bfsW.Count - 1} pas (court) mais cout {CoutChemin(bfsW, marais, coutMaraisLourd)} (traverse le marais).\");\n",
+    "Console.WriteLine($\"A*         : {astarW.Count - 1} pas (plus long) mais cout {astarWcost} (contourne le marais).\");\n",
+    "Console.WriteLine(\"Seul A* minimise le COUT reel. C'est la ou A* discrimine (terrain uniforme -> A*=BFS).  \");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f350db4b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002967,
+     "end_time": "2026-07-06T07:38:57.975152",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.972185",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Admissibilite et coherence de l'heuristique\n",
+    "\n",
+    "Une heuristique est **admissible** si elle ne surestime jamais le vrai cout restant. Manhattan est admissible sur grille (le chemin le plus court en pas est une minoration du cout). Une heuristique admissible **ET consistante** (h(n) <= cout(n,n') + h(n')) garantit qu'A* ne rouvre jamais un nœud ferme. Verifions la consistance de Manhattan."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "59a4be4c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:57.983695Z",
+     "iopub.status.busy": "2026-07-06T07:38:57.983238Z",
+     "iopub.status.idle": "2026-07-06T07:38:58.071469Z",
+     "shell.execute_reply": "2026-07-06T07:38:58.071364Z"
+    },
+    "papermill": {
+     "duration": 0.092727,
+     "end_time": "2026-07-06T07:38:58.071523",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:57.978796",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Manhattan est consistante sur la grille ponderee : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(h(n) <= cout(n->n') + h(n') pour tout arc ; garantit qu'A* ne rouvre pas un nœud ferme)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Admissibilite/consistance de Manhattan : pour tout pas (cout >= 1), h(n) <= cout(n,n') + h(n').\n",
+    "// Verif sur la grille pondere : Manhattan ne baisse jamais de plus de 1 par pas (cout min = 1).\n",
+    "bool consistant = true;\n",
+    "foreach (var s in Enumerable.Range(0, W).SelectMany(x => Enumerable.Range(0, H).Select(y => new GridState(x, y))))\n",
+    "{\n",
+    "    int hs = Manhattan(s, goal);\n",
+    "    foreach (var (n, cost) in succPondere(s))\n",
+    "    {\n",
+    "        int hn = Manhattan(n, goal);\n",
+    "        // consistance : h(s) <= cost(s->n) + h(n). cost >= 1, donc h peut baisser d'au plus cost.\n",
+    "        if (hs > cost + hn) { consistant = false; break; }\n",
+    "    }\n",
+    "    if (!consistant) break;\n",
+    "}\n",
+    "Console.WriteLine($\"Manhattan est consistante sur la grille ponderee : {consistant}\");\n",
+    "Console.WriteLine(\"(h(n) <= cout(n->n') + h(n') pour tout arc ; garantit qu'A* ne rouvre pas un nœud ferme)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8148772",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002546,
+     "end_time": "2026-07-06T07:38:58.076970",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:58.074424",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Exercices\n",
+    "\n",
+    "**Exercice 1 — Grille avec obstacles.** Ajoutez un ensemble de cases bloquees (cout infini / non traversables) et resolvez : BFS/Greedy doivent les contourner, A* idem. *Indice* : filtrez les successeurs bloques dans la fonction `succPondere`.\n",
+    "\n",
+    "**Exercice 2 — Heuristique euclidienne.** Implementez une heuristique euclidienne `sqrt(dx^2+dy^2)` (arrondie). Est-elle admissible sur grille 4-connexe ? Pourquoi ? *Indice* : la distance euclidienne minore-t-elle le nombre de pas Manhattan ?\n",
+    "\n",
+    "**Exercice 3 — A* avec cout variable different.** Changez le cout du marais (10 -> 5, puis 20). Observez le seuil ou A* decide de **contourner** vs **traverser**. Quel est le cout critique ? *Indice* : comparez cout(chemin droit) = 10*coutMarais vs cout(contournement) = 16."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cbc21146",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:58.083147Z",
+     "iopub.status.busy": "2026-07-06T07:38:58.082980Z",
+     "iopub.status.idle": "2026-07-06T07:38:58.138886Z",
+     "shell.execute_reply": "2026-07-06T07:38:58.138756Z"
+    },
+    "papermill": {
+     "duration": 0.059623,
+     "end_time": "2026-07-06T07:38:58.139132",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:58.079509",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : ajouter des obstacles et observer le contournement.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 : grille avec obstacles (cases bloquees, cout infini).\n",
+    "// TODO etudiant : definir un HashSet<GridState> d'obstacles et filtrer succPondere.\n",
+    "// Indice : dans la clause .Where, ajouter !obstacles.Contains(n).\n",
+    "HashSet<GridState> obstacles = new();  // TODO etudiant : remplir (ex : mur vertical)\n",
+    "Func<GridState, IEnumerable<(GridState, int)>> succAvecObstacles = s =>\n",
+    "    ACTIONS\n",
+    "        .Select(a => new GridState(s.X + a.dx, s.Y + a.dy))\n",
+    "        .Where(n => n.X >= 0 && n.X < W && n.Y >= 0 && n.Y < H)\n",
+    "        .Where(n => !obstacles.Contains(n))  // TODO etudiant : filtre obstacles\n",
+    "        .Select(n => (n, CoutCase(n, marais, coutMaraisLourd)));\n",
+    "Console.WriteLine(\"Exercice a completer : ajouter des obstacles et observer le contournement.\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6542ee69",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:58.146255Z",
+     "iopub.status.busy": "2026-07-06T07:38:58.146104Z",
+     "iopub.status.idle": "2026-07-06T07:38:58.187363Z",
+     "shell.execute_reply": "2026-07-06T07:38:58.187256Z"
+    },
+    "papermill": {
+     "duration": 0.044903,
+     "end_time": "2026-07-06T07:38:58.187418",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:58.142515",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Euclidienne (0,0)->(3,4) = 5 ; Manhattan = 7\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : euclidienne est-elle admissible sur grille 4-connexe ?\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 : heuristique euclidienne (arrondie).\n",
+    "// TODO etudiant : implementer sqrt(dx^2+dy^2) et tester son admissibilite sur grille 4-connexe.\n",
+    "// Indice : euclidienne <= Manhattan (le chemin droit est plus court que les escaliers).\n",
+    "static int Euclidean(GridState a, GridState b) =>\n",
+    "    (int)Math.Round(Math.Sqrt((a.X - b.X) * (a.X - b.X) + (a.Y - b.Y) * (a.Y - b.Y)));  // TODO etudiant : verifier admissibilite\n",
+    "Console.WriteLine($\"Euclidienne (0,0)->(3,4) = {Euclidean(new GridState(0,0), new GridState(3,4))} ; Manhattan = {Manhattan(new GridState(0,0), new GridState(3,4))}\");\n",
+    "Console.WriteLine(\"Exercice a completer : euclidienne est-elle admissible sur grille 4-connexe ?\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5b2ff844",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:38:58.195718Z",
+     "iopub.status.busy": "2026-07-06T07:38:58.195501Z",
+     "iopub.status.idle": "2026-07-06T07:38:58.246500Z",
+     "shell.execute_reply": "2026-07-06T07:38:58.246590Z"
+    },
+    "papermill": {
+     "duration": 0.055907,
+     "end_time": "2026-07-06T07:38:58.246653",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:58.190746",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : a partir de quel cout_marais A* decide-t-il de contourner ?\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cout_marais= 2 -> (etudiant : A* fait combien de pas ?)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cout_marais= 3 -> (etudiant : A* fait combien de pas ?)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cout_marais= 4 -> (etudiant : A* fait combien de pas ?)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cout_marais= 5 -> (etudiant : A* fait combien de pas ?)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cout_marais=10 -> (etudiant : A* fait combien de pas ?)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cout_marais=20 -> (etudiant : A* fait combien de pas ?)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 3 : seuil de cout ou A* bascule traverser/contourner.\n",
+    "// TODO etudiant : boucler sur coutMaraisCritique et trouver ou astarW.Count-1 passe de 10 a 16.\n",
+    "// Indice : cout(chemin droit) = 10*c ; cout(contournement) = 16. Seuil quand 10*c >= 16 + ...\n",
+    "Console.WriteLine(\"Exercice a completer : a partir de quel cout_marais A* decide-t-il de contourner ?\");\n",
+    "foreach (int c in new[] { 2, 3, 4, 5, 10, 20 })\n",
+    "{\n",
+    "    // TODO etudiant : re-resoudre avec coutMaraisLourd = c et noter astarW.Count-1\n",
+    "    Console.WriteLine($\"  cout_marais={c,2} -> (etudiant : A* fait combien de pas ?)\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6f67abc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003281,
+     "end_time": "2026-07-06T07:38:58.253219",
+     "exception": false,
+     "start_time": "2026-07-06T07:38:58.249938",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 10. Conclusion — du search nu a A*\n",
+    "\n",
+    "Ce twin C# parcourt la meme progression que le twin Python :\n",
+    "- **BFS** : optimal en PAS (cout uniforme), explore beaucoup.\n",
+    "- **DFS** : ni optimal ni complet, contraste pedagogique.\n",
+    "- **Greedy Best-First** : guide par h seul, rapide mais non optimal.\n",
+    "- **A*** : `f = g + h`, optimal en COUT si h admissible (Manhattan).\n",
+    "\n",
+    "**Le point cle (#3801 Prong B)** : sur terrain uniforme, BFS = A* (cas degenere). Sur **terrain pondere**, seul A* minimise le cout reel (16 pas / cout 16 en contournant le marais, vs BFS 10 pas / cout 55 en traversant). C'est la ou la capacite d'A* est visible dans la sortie — pas un exemple trivial.\n",
+    "\n",
+    "> Retour au [twin Python](Planners-3-State-Space.ipynb) — qui demontre la meme chose visuellement (heatmap + chemins superposes)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.042689,
+   "end_time": "2026-07-06T07:38:58.376109",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Planners-3-State-Space-Csharp.ipynb",
+   "output_path": "planners3_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T07:38:53.333420",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -117,7 +117,8 @@ SymbolicAI/Planners/
 ├── 01-Foundation/
 │   ├── Planners-1-Introduction.ipynb    # Concepts, STRIPS
 │   ├── Planners-2-PDDL-Basics.ipynb     # Syntaxe PDDL
-│   └── Planners-3-State-Space.ipynb     # Espaces d'états
+│   ├── Planners-3-State-Space.ipynb     # Espaces d'états
+│   └── Planners-3-State-Space-Csharp.ipynb # Twin C# BFS/DFS/Greedy/A* (See #4956)
 ├── 02-Classical/
 │   ├── Planners-4-Fast-Downward.ipynb   # A*, heuristiques
 │   ├── Planners-5-Heuristics.ipynb      # h-add, h-max, h-FF
@@ -201,6 +202,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 1 | [Planners-1-Introduction](01-Foundation/Planners-1-Introduction.ipynb) | Python | Concepts, modèle STRIPS, triptyque État-Action-But | 30 min |
 | 2 | [Planners-2-PDDL-Basics](01-Foundation/Planners-2-PDDL-Basics.ipynb) | Python | Syntaxe PDDL, domaines, problèmes, prédicats, actions | 40 min |
 | 3 | [Planners-3-State-Space](01-Foundation/Planners-3-State-Space.ipynb) | Python | Espaces d'états, graphes de recherche, explosion combinatoire | 35 min |
+| 3 | [Planners-3-State-Space-Csharp](01-Foundation/Planners-3-State-Space-Csharp.ipynb) | .NET (C#) | Twin C# du 3 : BFS/DFS/Greedy/A* from-scratch, terrain pondéré (See #4956) | 35 min |
 
 ### Partie 2 : Planification Classique ([02-Classical/](02-Classical/README.md))
 


### PR DESCRIPTION
## Résumé

**Twin C#** de [Planners-3-State-Space](MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb) (Python + networkx). **Tranche 2 du marathon Planners** (#4956) : suite de Planners-1-Csharp (#5528, STRIPS+BFS), la progression **search nu → A*** avec heuristiques, admissibilité, cohérence. BCL .NET seule, 0 NuGet (`PriorityQueue` .NET 9).

## Algorithme / démarche

- **GridState** (record `x,y`), terrain pondéré (cout de pas = cout case d'arrivée).
- **BFS** : file FIFO + closed set, optimal en PAS (cout uniforme).
- **DFS** : pile LIFO + limite profondeur, ni optimal ni complet (contraste).
- **Greedy Best-First** : priorité = `h(n)` seul (Manhattan), rapide mais non optimal.
- **A*** : `f = g + h` (cout cumulé + heuristique), optimal en COUT si h admissible.
- **Admissibilité/consistance** Manhattan vérifiée programmatically (`h(s) ≤ cost(s→n') + h(n')` pour tout arc).

## Complémentarité (#3801 Prong B)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python (networkx + matplotlib) | visualisation graphe + heatmap terrain | explorer les paysages de recherche visuellement |
| **This (.NET BCL seule)** | `PriorityQueue` .NET 9 + from-scratch | **comprendre** la mécanique interne (frontière, f=g+h, closed set) |

**Le point cle (cas NON-dégénéré, #3801 Prong B)** : sur terrain uniforme, BFS = A* (cas dégénéré où l'heuristique ne sert à rien, cf commit `8905f8845`). Sur **terrain pondéré** (marais central cout 10), A* trouve un chemin **plus long en étapes mais moins coûteux** que BFS — c'est là que A* discrimine vraiment. Le twin Python le montre visuellement (heatmap) ; ce twin C# le montre **numériquement** (table Pas/Cout/Nœuds).

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **11/11 cellules code `execution_count` 1-11, 0 erreur**. Outputs vérifiés **firsthand** :

- **Sanity grille uniforme** : BFS = A* = 10 pas, cout 10 — cas dégénéré correct (A*=BFS sans poids) ✓
- **Terrain pondéré (Prong B discovery)** :

| Algo | Pas | Cout | Nœuds | Traverse marais ? |
|------|-----|------|-------|-------------------|
| BFS | 10 | 56 | 91 | oui (5 cases) |
| Greedy | 10 | 56 | 11 | oui (5 cases) |
| A* | 16 | 17 | 42 | non |

  **BFS/Greedy traversent le marais (court en pas, cher en cout). A* contourne (plus de pas, faible cout). Seul A* minimise le COUT réel** = découverte discriminante confirmée.
- **Admissibilité Manhattan** : consistante = True ✓

## Bug G.1 self-corrected

2 bugs C# .NET headless (déjà documentés topic file, RÉCURRENTS) :
1. **Single-quote char-literal dans interpolation** : `Console.WriteLine($"{'Algo',-18}...")` = CS1012 "Trop de caractères dans le littéral de caractère". **Fix** : headers statiques en `"Algo".PadRight(18) + ...` (PAS d'interpolation).
2. **Nullable reference type avec record** : `record GridState` = type référence → `GridState?.Value` INEXISTANT (Value est pour Nullable<T> value types). **Fix** : `GridState? cur = goal; while (cur is not null) { path.Add(cur); cur = cameFrom[cur]; }` — pas de `.Value`.

## SOTA-OK (#3801)

From-scratch = la valeur pédagogique (comprendre la mécanique interne de la recherche). Problème non-trivial : terrain pondéré où A* discrimine de BFS (non-dégénéré).

## Exercices (#2161)

3 stubs C.1-conformes : (1) grille avec obstacles (cases bloquées), (2) heuristique euclidienne + admissibilité, (3) seuil de cout où A* bascule traverser/contourner.

## Scope

Atomique : 1 notebook (1185 lignes) + README table+tree (2 entrées). Self-contained (BCL seule). Catalogue byte-identical (R1).

## Marathon #4956

Suite Planners C# : Planners-1 (#5528 STRIPS+BFS) → **Planners-3 (this, search nu → A*)**. Tranche suivante possible : Planners-5-Heuristics (h-add/h-max/h-FF).

See #4956. Revue souhaitée : po-2025 ou ai-01.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
