### PR TITLE
feat(sl): SL-5-InverseResolution-Csharp — .NET twin (LGG, bottom clause, Progol)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -213,6 +213,8 @@ Note : dans SL-7, le premier exercice de la numérotation interne est un exemple
 
 > **Parité .NET** : [SL-2-KnowledgeBasedLearning-Csharp.ipynb](SL-2-KnowledgeBasedLearning-Csharp.ipynb) est le jumeau C# (.NET Interactive) — EBL (chaînage avant + unification, arbre de preuve, variabilisation) et RBL (vérification de détermination) implémentés from-scratch, sans lib ML. Marathon parité .NET ⇄ Python (#4956).
 
+> **Parité .NET** : [SL-5-InverseResolution-Csharp.ipynb](SL-5-InverseResolution-Csharp.ipynb) est le jumeau C# (.NET Interactive) — LGG (Plotkin), θ-subsomption (skolemisation + backtracking), clause bottom (saturation bornée + variabilisation), recherche Progol (score `p−L`) implémentés from-scratch, sans lib ML. Marathon parité .NET ⇄ Python (#4956).
+
 ### SL-3-RelevanceLearning.ipynb
 
 | Section | Contenu |
@@ -433,6 +435,7 @@ SymbolicLearning/
 ├── SL-3-RelevanceLearning.ipynb             # Treillis, MINIMAL-CONSISTENT-DET, RBL vs sklearn
 ├── SL-4-InductiveLogicProgramming.ipynb     # FOIL, résolution inverse, knowledge graphs
 ├── SL-5-InverseResolution.ipynb             # LGG, theta-subsomption, clause bottom, Progol
+├── SL-5-InverseResolution-Csharp.ipynb      # Jumeau C# (.NET Interactive) — LGG + clause bottom + Progol, parité #4956
 ├── SL-6-ModernILP.ipynb                     # Aleph, Metagol, Popper, dILP (Lernd) — moteurs réels
 ├── SL-7-NeuroSymbolic.ipynb                 # T-norms, LTN, DeepProbLog
 ├── SL-8-KnowledgeGraphs-ILP.ipynb           # rdflib, AMIE rule mining

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
@@ -1,0 +1,1210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f009a5b2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.039648,
+     "end_time": "2026-07-06T07:57:12.278323+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:12.238675+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# SL-5 - Resolution Inverse & ILP (C#)\n",
+    "\n",
+    "> **Jumeau C#** du notebook [SL-5-InverseResolution.ipynb](SL-5-InverseResolution.ipynb).\n",
+    "> Marathon parite .NET ⇄ Python (#4956), EPIC #3801 Prong B.\n",
+    "> Algorithmes AIMA §19.5 (Inverse Resolution + Bottom-Clause ILP), implémentés **from-scratch en C# pur** (pas de lib ML, pas de Prolog externe).\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Représenter** clauses Horn et prédicats en C# (atomes = `(predicat, args)`, clause = `record`).\n",
+    "2. **Généraliser** deux exemples par **LGG** (Least General Generalization, Plotkin).\n",
+    "3. **Vérifier** la **θ-subsomption** (skolemisation + backtracking) pour ordonner la généralité.\n",
+    "4. **Construire** la **clause bottom** (saturation bornée + variabilisation).\n",
+    "5. **Rechercher** la meilleure clause consistante dans `[top, bottom]` (style Progol, score `p − L`).\n",
+    "6. **Apprendre** `grandfather/2` puis `grandmother/2` à partir d'un arbre généalogique.\n",
+    "\n",
+    "### Prérequis\n",
+    "- Notions de logique du premier ordre (clauses Horn, variables, unification).\n",
+    "- .NET 9.0 + dotnet-interactive (kernel `.net-csharp`).\n",
+    "- Avoir suivi [SL-1](SL-1-LogicalLearning-Csharp.ipynb), [SL-2](SL-2-KnowledgeBasedLearning-Csharp.ipynb).\n",
+    "\n",
+    "### Durée estimée : 65 minutes\n",
+    "\n",
+    "### Références\n",
+    "- Russell & Norvig, *AIMA* (3e éd.), §19.5.\n",
+    "- Muggleton, S. *Inductive Logic Programming* (1991-1995) — Progol, clause bottom.\n",
+    "- Notebook Python : [SL-5-InverseResolution.ipynb](SL-5-InverseResolution.ipynb).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88ed0203",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004937,
+     "end_time": "2026-07-06T07:57:12.296811+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:12.291874+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Représentation : atomes, clauses, couverture\n",
+    "\n",
+    "Un **atome** = `(prédicat, args)` (ValueTuple) où les args sont des termes (constantes\n",
+    "en minuscule, variables en majuscule). Une **clause** = `record Clause(Head, Body)`.\n",
+    "La clause couvre un exemple si la tête s'unifie et le corps est satisfiable sur les faits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "08fc4cd5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:57:12.329988Z",
+     "iopub.status.busy": "2026-07-06T07:57:12.317738Z",
+     "iopub.status.idle": "2026-07-06T07:57:20.849440Z",
+     "shell.execute_reply": "2026-07-06T07:57:20.820332Z"
+    },
+    "papermill": {
+     "duration": 8.547132,
+     "end_time": "2026-07-06T07:57:20.849770+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:12.302638+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '744208.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cible : grandfather(X, Y) :- male(X), parent(X, Z), parent(Z, Y).\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                 exemple | attendu | couvert\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(tom, ann) |    +    |   oui\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(tom, pat) |    +    |   oui\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(tom, sue) |    +    |   oui\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(bob, jim) |    +    |   oui\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(liz, eve) |    -    |   non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(liz, sue) |    -    |   non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(bob, ann) |    -    |   non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(pat, jim) |    -    |   non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(tom, bob) |    -    |   non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(ann, jim) |    -    |   non\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Linq;\n",
+    "\n",
+    "// Comparateur structurel d'atomes (sinon string[] compare par reference =>HashSet bug).\n",
+    "public class AtomEq : IEqualityComparer<(string,string[])> {\n",
+    "    public bool Equals((string,string[]) x, (string,string[]) y) =>\n",
+    "        x.Item1 == y.Item1 && x.Item2.SequenceEqual(y.Item2);\n",
+    "    public int GetHashCode((string,string[]) x) {\n",
+    "        int h = x.Item1.GetHashCode();\n",
+    "        foreach (var a in x.Item2) h = HashCode.Combine(h, a);\n",
+    "        return h;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Une clause Horn : tete + corps (conjonction de litteraux).\n",
+    "public record Clause((string,string[]) Head, List<(string,string[])> Body);\n",
+    "\n",
+    "bool IsVar(string t) => t.Length > 0 && char.IsUpper(t[0]);\n",
+    "\n",
+    "(string,string[]) Subst((string,string[]) atom, Dictionary<string,string> theta) =>\n",
+    "    (atom.Item1, atom.Item2.Select(a => theta.TryGetValue(a, out var v) ? v : a).ToArray());\n",
+    "\n",
+    "// Etend theta pour que pattern devienne fact ; null si impossible.\n",
+    "Dictionary<string,string> MatchAtom((string,string[]) pattern, (string,string[]) fact,\n",
+    "                                     Dictionary<string,string> theta) {\n",
+    "    if (pattern.Item1 != fact.Item1 || pattern.Item2.Length != fact.Item2.Length) return null;\n",
+    "    var th = new Dictionary<string,string>(theta);\n",
+    "    for (int i = 0; i < pattern.Item2.Length; i++) {\n",
+    "        string p = pattern.Item2[i], f = fact.Item2[i];\n",
+    "        if (IsVar(p)) { if (th.TryGetValue(p, out var v) && v != f) return null; th[p] = f; }\n",
+    "        else if (p != f) return null;\n",
+    "    }\n",
+    "    return th;\n",
+    "}\n",
+    "\n",
+    "bool BodySatisfiable(List<(string,string[])> body, List<(string,string[])> facts,\n",
+    "                     Dictionary<string,string> theta, int k = 0) {\n",
+    "    if (k == body.Count) return true;\n",
+    "    foreach (var fact in facts) {\n",
+    "        var th = MatchAtom(body[k], fact, theta);\n",
+    "        if (th != null && BodySatisfiable(body, facts, th, k + 1)) return true;\n",
+    "    }\n",
+    "    return false;\n",
+    "}\n",
+    "\n",
+    "bool Covers(Clause clause, (string,string[]) example, List<(string,string[])> facts) {\n",
+    "    var th = MatchAtom(clause.Head, example, new Dictionary<string,string>());\n",
+    "    return th != null && BodySatisfiable(clause.Body, facts, th);\n",
+    "}\n",
+    "\n",
+    "string Fmt((string,string[]) a) => $\"{a.Item1}({string.Join(\", \", a.Item2)})\";\n",
+    "string ShowClause(Clause c) =>\n",
+    "    Fmt(c.Head) + (c.Body.Count > 0 ? \" :- \" + string.Join(\", \", c.Body.Select(Fmt)) : \"\") + \".\";\n",
+    "\n",
+    "// Domaine : arbre genealogique\n",
+    "var FACTS = new List<(string,string[])> {\n",
+    "    (\"parent\", new[]{\"tom\",\"bob\"}), (\"parent\", new[]{\"tom\",\"liz\"}),\n",
+    "    (\"parent\", new[]{\"bob\",\"ann\"}), (\"parent\", new[]{\"bob\",\"pat\"}),\n",
+    "    (\"parent\", new[]{\"liz\",\"sue\"}), (\"parent\", new[]{\"pat\",\"jim\"}),\n",
+    "    (\"parent\", new[]{\"sue\",\"eve\"}),\n",
+    "    (\"male\", new[]{\"tom\"}), (\"male\", new[]{\"bob\"}), (\"male\", new[]{\"jim\"}),\n",
+    "    (\"female\", new[]{\"liz\"}), (\"female\", new[]{\"ann\"}), (\"female\", new[]{\"pat\"}),\n",
+    "    (\"female\", new[]{\"sue\"}), (\"female\", new[]{\"eve\"}),\n",
+    "};\n",
+    "var POS = new List<(string,string[])> {\n",
+    "    (\"grandfather\", new[]{\"tom\",\"ann\"}), (\"grandfather\", new[]{\"tom\",\"pat\"}),\n",
+    "    (\"grandfather\", new[]{\"tom\",\"sue\"}), (\"grandfather\", new[]{\"bob\",\"jim\"}) };\n",
+    "var NEG = new List<(string,string[])> {\n",
+    "    (\"grandfather\", new[]{\"liz\",\"eve\"}), (\"grandfather\", new[]{\"liz\",\"sue\"}),\n",
+    "    (\"grandfather\", new[]{\"bob\",\"ann\"}), (\"grandfather\", new[]{\"pat\",\"jim\"}),\n",
+    "    (\"grandfather\", new[]{\"tom\",\"bob\"}), (\"grandfather\", new[]{\"ann\",\"jim\"}) };\n",
+    "\n",
+    "// Cible (a retrouver par l'algorithme)\n",
+    "var target = new Clause(\n",
+    "    (\"grandfather\", new[]{\"X\",\"Y\"}),\n",
+    "    new List<(string,string[])>{\n",
+    "        (\"male\", new[]{\"X\"}), (\"parent\", new[]{\"X\",\"Z\"}), (\"parent\", new[]{\"Z\",\"Y\"})});\n",
+    "Console.WriteLine($\"Cible : {ShowClause(target)}\\n\");\n",
+    "Console.WriteLine($\"{\"exemple\",24} | attendu | couvert\");\n",
+    "Console.WriteLine(new string('-', 48));\n",
+    "foreach (var e in POS.Concat(NEG)) {\n",
+    "    string exp = POS.Contains(e, new AtomEq()) ? \"+\" : \"-\";\n",
+    "    string couv = Covers(target, e, FACTS) ? \"oui\" : \"non\";\n",
+    "    Console.WriteLine($\"{Fmt(e),24} |    {exp}    |   {couv}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88775903",
+   "metadata": {
+    "papermill": {
+     "duration": 0.016584,
+     "end_time": "2026-07-06T07:57:20.873228+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:20.856644+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. LGG — Least General Generalization (Plotkin)\n",
+    "\n",
+    "La **LGG** de deux clauses généralise leurs termes : si deux termes diffèrent, on\n",
+    "introduit une nouvelle variable partagée (table de mapping). C'est l'inverse de\n",
+    "l'unification : on remonte vers le plus général."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "18d4f2b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:57:20.888703Z",
+     "iopub.status.busy": "2026-07-06T07:57:20.888091Z",
+     "iopub.status.idle": "2026-07-06T07:57:21.355208Z",
+     "shell.execute_reply": "2026-07-06T07:57:21.354776Z"
+    },
+    "papermill": {
+     "duration": 0.475318,
+     "end_time": "2026-07-06T07:57:21.355389+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:20.880071+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LGG des deux explications :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  grandfather(V1, V2) :- male(V1), parent(V1, V3), parent(V4, V5), parent(bob, V6), parent(V3, V2).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Taille des corps : 3 et 3 litteraux -> LGG : 5 litteraux\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Couverture : 4/4 positifs, 0/6 negatifs\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// LGG de deux termes : meme terme -> lui-meme ; sinon variable fraiche partagee.\n",
+    "string LggTerm(string t1, string t2, Dictionary<(string,string),string> mapping) {\n",
+    "    if (t1 == t2) return t1;\n",
+    "    if (!mapping.ContainsKey((t1, t2))) mapping[(t1, t2)] = $\"V{mapping.Count + 1}\";\n",
+    "    return mapping[(t1, t2)];\n",
+    "}\n",
+    "\n",
+    "(string,string[])? LggAtom((string,string[]) a1, (string,string[]) a2,\n",
+    "                            Dictionary<(string,string),string> mapping) {\n",
+    "    if (a1.Item1 != a2.Item1 || a1.Item2.Length != a2.Item2.Length) return null;\n",
+    "    var args = a1.Item2.Zip(a2.Item2, (x, y) => LggTerm(x, y, mapping)).ToArray();\n",
+    "    return (a1.Item1, args);\n",
+    "}\n",
+    "\n",
+    "Clause LggClause(Clause c1, Clause c2) {\n",
+    "    var mapping = new Dictionary<(string,string),string>();\n",
+    "    var head = LggAtom(c1.Head, c2.Head, mapping) ?? (\"nil\", new string[0]);\n",
+    "    var body = new List<(string,string[])>();\n",
+    "    var seen = new HashSet<(string,string[])>(new AtomEq());\n",
+    "    foreach (var b1 in c1.Body)\n",
+    "        foreach (var b2 in c2.Body) {\n",
+    "            var g = LggAtom(b1, b2, mapping);\n",
+    "            if (g.HasValue && seen.Add(g.Value)) body.Add(g.Value);\n",
+    "        }\n",
+    "    return new Clause(head, body);\n",
+    "}\n",
+    "\n",
+    "// Deux explications au sol de deux exemples positifs differents.\n",
+    "var expl1 = new Clause(\n",
+    "    (\"grandfather\", new[]{\"tom\",\"ann\"}),\n",
+    "    new List<(string,string[])>{\n",
+    "        (\"male\", new[]{\"tom\"}), (\"parent\", new[]{\"tom\",\"bob\"}), (\"parent\", new[]{\"bob\",\"ann\"})});\n",
+    "var expl2 = new Clause(\n",
+    "    (\"grandfather\", new[]{\"bob\",\"jim\"}),\n",
+    "    new List<(string,string[])>{\n",
+    "        (\"male\", new[]{\"bob\"}), (\"parent\", new[]{\"bob\",\"pat\"}), (\"parent\", new[]{\"pat\",\"jim\"})});\n",
+    "var g = LggClause(expl1, expl2);\n",
+    "Console.WriteLine(\"LGG des deux explications :\");\n",
+    "Console.WriteLine($\"  {ShowClause(g)}\");\n",
+    "Console.WriteLine($\"\\nTaille des corps : {expl1.Body.Count} et {expl2.Body.Count} litteraux -> LGG : {g.Body.Count} litteraux\");\n",
+    "int posCovered = POS.Count(e => Covers(g, e, FACTS));\n",
+    "int negCovered = NEG.Count(e => Covers(g, e, FACTS));\n",
+    "Console.WriteLine($\"Couverture : {posCovered}/4 positifs, {negCovered}/6 negatifs\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbf1b5f0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006201,
+     "end_time": "2026-07-06T07:57:21.368175+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:21.361974+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. θ-subsomption — ordre de généralité\n",
+    "\n",
+    "`C θ-subsume D` s'il existe une substitution `θ` plongeant chaque littéral de `C`\n",
+    "dans `D`. On **skolémise** `D` (variables → constantes) puis on cherche `θ` par\n",
+    "backtracking. La clause la plus générale (`top`) subsume toutes les autres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6e824d31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:57:21.382867Z",
+     "iopub.status.busy": "2026-07-06T07:57:21.382409Z",
+     "iopub.status.idle": "2026-07-06T07:57:21.736615Z",
+     "shell.execute_reply": "2026-07-06T07:57:21.736190Z"
+    },
+    "papermill": {
+     "duration": 0.362725,
+     "end_time": "2026-07-06T07:57:21.736795+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:21.374070+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ordre de generalite top >= cible >= exemple au sol :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              top subsume cible           ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              top subsume exemple au sol  ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "            cible subsume top             ? False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "            cible subsume exemple au sol  ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   exemple au sol subsume top             ? False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   exemple au sol subsume cible           ? False\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// C theta-subsume D ? Skolemise D, puis backtrack pour plonger les litteraux de C.\n",
+    "bool Subsumes(Clause c, Clause d) {\n",
+    "    var dVars = new HashSet<string>();\n",
+    "    foreach (var a in new[]{d.Head}.Concat(d.Body))\n",
+    "        foreach (var t in a.Item2) if (IsVar(t)) dVars.Add(t);\n",
+    "    var sk = dVars.ToDictionary(v => v, v => $\"sk_{char.ToLower(v[0])}\");\n",
+    "    var dHead = Subst(d.Head, sk);\n",
+    "    var dBody = d.Body.Select(b => Subst(b, sk)).ToList();\n",
+    "\n",
+    "    var theta0 = MatchAtom(c.Head, dHead, new Dictionary<string,string>());\n",
+    "    if (theta0 == null) return false;\n",
+    "    bool Backtrack(List<(string,string[])> lits, Dictionary<string,string> theta) {\n",
+    "        if (lits.Count == 0) return true;\n",
+    "        foreach (var t in dBody) {\n",
+    "            var th = MatchAtom(lits[0], t, theta);\n",
+    "            if (th != null && Backtrack(lits.Skip(1).ToList(), th)) return true;\n",
+    "        }\n",
+    "        return false;\n",
+    "    }\n",
+    "    return Backtrack(c.Body, theta0);\n",
+    "}\n",
+    "\n",
+    "var top = new Clause((\"grandfather\", new[]{\"X\",\"Y\"}), new List<(string,string[])>());\n",
+    "var ground = expl1;\n",
+    "var chain = new[]{(\"top\", top), (\"cible\", target), (\"exemple au sol\", ground)};\n",
+    "Console.WriteLine(\"Ordre de generalite top >= cible >= exemple au sol :\");\n",
+    "for (int i = 0; i < chain.Length; i++)\n",
+    "for (int j = 0; j < chain.Length; j++) {\n",
+    "    if (i == j) continue;\n",
+    "    Console.WriteLine($\"  {chain[i].Item1,15} subsume {chain[j].Item1,-15} ? {Subsumes(chain[i].Item2, chain[j].Item2)}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcc44a2d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007826,
+     "end_time": "2026-07-06T07:57:21.777340+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:21.769514+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Clause bottom — saturation bornée\n",
+    "\n",
+    "La **clause bottom** d'un exemple positif = on enrichit l'exemple avec tous les faits\n",
+    "atteignables (profondeur `depth`), puis on **variabilise** les constantes. C'est la\n",
+    "clause la **plus spécifique** qui couvre l'exemple ; la cible recherchée la subsume."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e485ab3b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:57:21.797655Z",
+     "iopub.status.busy": "2026-07-06T07:57:21.797170Z",
+     "iopub.status.idle": "2026-07-06T07:57:22.105567Z",
+     "shell.execute_reply": "2026-07-06T07:57:22.105129Z"
+    },
+    "papermill": {
+     "duration": 0.320836,
+     "end_time": "2026-07-06T07:57:22.105750+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:21.784914+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exemple sature : grandfather(tom, ann)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Clause bottom (profondeur 2, 9 litteraux) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  grandfather(V1, V2) :- parent(V1, V3), parent(V1, V4), parent(V3, V2), male(V1), female(V2), parent(V3, V5), parent(V4, V6), male(V3), female(V4).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Variabilisation : tom -> V1, ann -> V2, bob -> V3, liz -> V4, pat -> V5, sue -> V6\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "La cible subsume-t-elle la clause bottom ? True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Clause bottom de l'exemple : saturation bornee puis variabilisation.\n",
+    "(Clause clause, Dictionary<string,string> mapping) BottomClause(\n",
+    "        (string,string[]) example, List<(string,string[])> facts,\n",
+    "        HashSet<string> bodyPreds, int depth = 2) {\n",
+    "    var inScope = new HashSet<string>(example.Item2);\n",
+    "    var groundBody = new List<(string,string[])>();\n",
+    "    for (int step = 0; step < depth; step++) {\n",
+    "        foreach (var f in facts) {\n",
+    "            if (!bodyPreds.Contains(f.Item1)) continue;\n",
+    "            if (groundBody.Contains(f, new AtomEq())) continue;\n",
+    "            if (f.Item2.Any(a => inScope.Contains(a))) groundBody.Add(f);\n",
+    "        }\n",
+    "        foreach (var f in groundBody)\n",
+    "            foreach (var a in f.Item2) inScope.Add(a);\n",
+    "    }\n",
+    "    var mapping = new Dictionary<string,string>();\n",
+    "    string VarOf(string c) {\n",
+    "        if (!mapping.ContainsKey(c)) mapping[c] = $\"V{mapping.Count + 1}\";\n",
+    "        return mapping[c];\n",
+    "    }\n",
+    "    var head = (example.Item1, example.Item2.Select(VarOf).ToArray());\n",
+    "    var body = groundBody.Select(f => (f.Item1, f.Item2.Select(VarOf).ToArray())).ToList();\n",
+    "    return (new Clause(head, body), mapping);\n",
+    "}\n",
+    "\n",
+    "var (bottom, bottomMap) = BottomClause(POS[0], FACTS, new HashSet<string>{\"parent\",\"male\",\"female\"}, depth: 2);\n",
+    "Console.WriteLine($\"Exemple sature : {Fmt(POS[0])}\");\n",
+    "Console.WriteLine($\"\\nClause bottom (profondeur 2, {bottom.Body.Count} litteraux) :\");\n",
+    "Console.WriteLine($\"  {ShowClause(bottom)}\");\n",
+    "Console.WriteLine($\"\\nVariabilisation : \" + string.Join(\", \", bottomMap.Select(kv => $\"{kv.Key} -> {kv.Value}\")));\n",
+    "Console.WriteLine($\"\\nLa cible subsume-t-elle la clause bottom ? {Subsumes(target, bottom)}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a3eefda",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007448,
+     "end_time": "2026-07-06T07:57:22.120979+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:22.113531+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Recherche Progol — meilleure clause consistante\n",
+    "\n",
+    "Dans le treillis `[top, bottom]`, on cherche la clause la **plus générale consistante**\n",
+    "(couvre des positifs, aucun négatif). Score = `positifs couverts − longueur du corps`\n",
+    "(biais de parcimonie). On restreint aux sous-ensembles **connectés** (liaison par variables)\n",
+    "et on énumère les combinaisons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "277ec634",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:57:22.142076Z",
+     "iopub.status.busy": "2026-07-06T07:57:22.141592Z",
+     "iopub.status.idle": "2026-07-06T07:57:22.861883Z",
+     "shell.execute_reply": "2026-07-06T07:57:22.861569Z"
+    },
+    "papermill": {
+     "duration": 0.732278,
+     "end_time": "2026-07-06T07:57:22.862025+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:22.129747+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apprentissage de grandfather/2 :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bottom = 9 litteraux -> grandfather(V1, V2) :- parent(V1, V3), parent(V3, V2), male(V1).  (p=4, score=1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Theorie finale :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  grandfather(V1, V2) :- parent(V1, V3), parent(V3, V2), male(V1).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Verification : 4/4 positifs couverts, 0/6 negatifs couverts\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(36,13): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(39,17): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Chaque litteral du corps doit etre relie a la tete par les variables.\n",
+    "bool IsConnected((string,string[]) head, List<(string,string[])> bodySubset) {\n",
+    "    var reached = new HashSet<string>(head.Item2);\n",
+    "    var pending = new List<(string,string[])>(bodySubset);\n",
+    "    bool progress = true;\n",
+    "    while (pending.Count > 0 && progress) {\n",
+    "        progress = false;\n",
+    "        for (int i = pending.Count - 1; i >= 0; i--) {\n",
+    "            if (pending[i].Item2.Any(a => reached.Contains(a))) {\n",
+    "                foreach (var a in pending[i].Item2) reached.Add(a);\n",
+    "                pending.RemoveAt(i);\n",
+    "                progress = true;\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return pending.Count == 0;\n",
+    "}\n",
+    "\n",
+    "// Toutes les combinaisons de taille k (analogue itertools.combinations).\n",
+    "IEnumerable<List<(string,string[])>> Combinations(List<(string,string[])> items, int k) {\n",
+    "    if (k == 0) { yield return new List<(string,string[])>(); yield break; }\n",
+    "    for (int i = 0; i <= items.Count - k; i++) {\n",
+    "        var first = items[i];\n",
+    "        foreach (var rest in Combinations(items.Skip(i + 1).ToList(), k - 1)) {\n",
+    "            var combo = new List<(string,string[])>{first};\n",
+    "            combo.AddRange(rest);\n",
+    "            yield return combo;\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Resultat de la recherche Progol : clause candidate + score.\n",
+    "public record ProgolResult(Clause Clause, int P, double Score);\n",
+    "\n",
+    "// Meilleure clause consistante dans [top, bottom], score = p - L.\n",
+    "ProgolResult? ProgolSearch(Clause bottom, List<(string,string[])> pos,\n",
+    "                           List<(string,string[])> neg,\n",
+    "                           List<(string,string[])> facts, int maxLen = 3) {\n",
+    "    ProgolResult? best = null;\n",
+    "    foreach (var sub in Enumerable.Range(1, maxLen).SelectMany(k => Combinations(bottom.Body, k))) {\n",
+    "        if (!IsConnected(bottom.Head, sub)) continue;\n",
+    "        var cl = new Clause(bottom.Head, sub);\n",
+    "        if (neg.Any(e => Covers(cl, e, facts))) continue;\n",
+    "        int p = pos.Count(e => Covers(cl, e, facts));\n",
+    "        if (p > 0 && (best == null || p - sub.Count > best.Score))\n",
+    "            best = new ProgolResult(cl, p, p - sub.Count);\n",
+    "    }\n",
+    "    return best;\n",
+    "}\n",
+    "\n",
+    "List<Clause> ProgolLearn(List<(string,string[])> pos, List<(string,string[])> neg,\n",
+    "                         List<(string,string[])> facts, HashSet<string> bodyPreds,\n",
+    "                         int depth = 2, int maxLen = 3) {\n",
+    "    var remaining = new List<(string,string[])>(pos);\n",
+    "    var theory = new List<Clause>();\n",
+    "    while (remaining.Count > 0) {\n",
+    "        var (bottom, _) = BottomClause(remaining[0], facts, bodyPreds, depth);\n",
+    "        var best = ProgolSearch(bottom, remaining, neg, facts, maxLen);\n",
+    "        if (best == null) { Console.WriteLine($\"  echec sur {Fmt(remaining[0])} : aucun candidat consistant\"); break; }\n",
+    "        Console.WriteLine($\"  bottom = {bottom.Body.Count} litteraux -> {ShowClause(best.Clause)}  (p={best.P}, score={best.Score})\");\n",
+    "        theory.Add(best.Clause);\n",
+    "        remaining = remaining.Where(e => !Covers(best.Clause, e, facts)).ToList();\n",
+    "    }\n",
+    "    return theory;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Apprentissage de grandfather/2 :\");\n",
+    "var theory = ProgolLearn(POS, NEG, FACTS, new HashSet<string>{\"parent\",\"male\",\"female\"});\n",
+    "Console.WriteLine(\"\\nTheorie finale :\");\n",
+    "foreach (var c in theory) Console.WriteLine($\"  {ShowClause(c)}\");\n",
+    "int okPos = theory.Sum(c => POS.Count(e => Covers(c, e, FACTS)));\n",
+    "int okNeg = theory.Sum(c => NEG.Count(e => Covers(c, e, FACTS)));\n",
+    "Console.WriteLine($\"\\nVerification : {okPos}/{POS.Count} positifs couverts, {okNeg}/{NEG.Count} negatifs couverts\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2813e827",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009025,
+     "end_time": "2026-07-06T07:57:22.879774+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:22.870749+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exemple guide — apprendre `grandmother/2`\n",
+    "\n",
+    "Sur le même arbre, la seule grand-mère est `liz` (de `eve`) : `liz` parent de `sue`,\n",
+    "`sue` parent de `eve`, et `liz` est `female`. Les autres grands-parents sont des\n",
+    "grands-pères (`male`) → un seul positif. **Avec un seul positif, ce sont les négatifs\n",
+    "qui portent le signal** et forcent le littéral `female(X)` (vs `male(X)` pour grandfather)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1bf1eb1b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:57:22.899411Z",
+     "iopub.status.busy": "2026-07-06T07:57:22.898976Z",
+     "iopub.status.idle": "2026-07-06T07:57:23.271087Z",
+     "shell.execute_reply": "2026-07-06T07:57:23.270509Z"
+    },
+    "papermill": {
+     "duration": 0.382843,
+     "end_time": "2026-07-06T07:57:23.271249+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:22.888406+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apprentissage de grandmother/2 :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bottom = 8 litteraux -> grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).  (p=1, score=-2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Theorie finale :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Verification : 1/1 positif(s) couvert(s), 0/10 negatif(s) couvert(s)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equivalente a grandmother(X,Y) :- female(X), parent(X,Z), parent(Z,Y) ? True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var POS_GM = new List<(string,string[])>{ (\"grandmother\", new[]{\"liz\",\"eve\"}) };\n",
+    "var NEG_GM = new List<(string,string[])> {\n",
+    "    (\"grandmother\", new[]{\"tom\",\"ann\"}), (\"grandmother\", new[]{\"tom\",\"pat\"}),\n",
+    "    (\"grandmother\", new[]{\"tom\",\"sue\"}), (\"grandmother\", new[]{\"bob\",\"jim\"}),\n",
+    "    (\"grandmother\", new[]{\"liz\",\"ann\"}), (\"grandmother\", new[]{\"liz\",\"pat\"}),\n",
+    "    (\"grandmother\", new[]{\"liz\",\"sue\"}), (\"grandmother\", new[]{\"pat\",\"jim\"}),\n",
+    "    (\"grandmother\", new[]{\"sue\",\"eve\"}), (\"grandmother\", new[]{\"ann\",\"jim\"}),\n",
+    "};\n",
+    "Console.WriteLine(\"Apprentissage de grandmother/2 :\");\n",
+    "var theoryGm = ProgolLearn(POS_GM, NEG_GM, FACTS, new HashSet<string>{\"parent\",\"male\",\"female\"});\n",
+    "Console.WriteLine(\"\\nTheorie finale :\");\n",
+    "foreach (var c in theoryGm) Console.WriteLine($\"  {ShowClause(c)}\");\n",
+    "int okPosGm = theoryGm.Sum(c => POS_GM.Count(e => Covers(c, e, FACTS)));\n",
+    "int okNegGm = theoryGm.Sum(c => NEG_GM.Count(e => Covers(c, e, FACTS)));\n",
+    "Console.WriteLine($\"\\nVerification : {okPosGm}/{POS_GM.Count} positif(s) couvert(s), {okNegGm}/{NEG_GM.Count} negatif(s) couvert(s)\");\n",
+    "var targetGm = new Clause(\n",
+    "    (\"grandmother\", new[]{\"X\",\"Y\"}),\n",
+    "    new List<(string,string[])>{\n",
+    "        (\"female\", new[]{\"X\"}), (\"parent\", new[]{\"X\",\"Z\"}), (\"parent\", new[]{\"Z\",\"Y\"})});\n",
+    "bool equiv = theoryGm.Any(c => Subsumes(c, targetGm) && Subsumes(targetGm, c));\n",
+    "Console.WriteLine($\"Equivalente a grandmother(X,Y) :- female(X), parent(X,Z), parent(Z,Y) ? {equiv}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "695bf88e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0072,
+     "end_time": "2026-07-06T07:57:23.287835+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:23.280635+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Au-delà : moteurs ILP réels (Aleph, Metagol, Popper)\n",
+    "\n",
+    "Le notebook Python [SL-5-InverseResolution.ipynb](SL-5-InverseResolution.ipynb)\n",
+    "montre ensuite comment invoquer de **vrais moteurs ILP** (Aleph sur SWI-Prolog via\n",
+    "le pont `janus_swi`, Metagol, Popper) sur le même problème. Ces moteurs implémentent\n",
+    "la recherche dans le treillis `[top, bottom]` avec des heuristiques avancées\n",
+    "(recherche `A*`, contraintes de mode, minimisation de clause).\n",
+    "\n",
+    "> **Ce jumeau C# s'arrête à la théorie from-scratch** : nous avons réimplémenté\n",
+    "> LGG, θ-subsomption, clause bottom et la recherche Progol à la main pour comprendre\n",
+    "> les **internes**. Le pont vers un moteur Prolog externe est hors scope C# pur\n",
+    "> (Prong B : on enseigne l'algorithme, pas on invoque une boîte noire). Pour la\n",
+    "> comparaison avec les moteurs réels, voir le notebook Python.\n",
+    "\n",
+    "| Concept | Implémentation C# (ce notebook) | Moteur réel (Python) |\n",
+    "|---------|----------------------------------|----------------------|\n",
+    "| Représentation | `record Clause(Head, Body)` | Termes Prolog |\n",
+    "| LGG | `LggClause` (§2) | Aleph `ig2` |\n",
+    "| Clause bottom | `BottomClause` (§4) | Aleph `saturate` |\n",
+    "| Recherche | `ProgolSearch` (§5), score `p−L` | Aleph `induce`, A* |\n",
+    "| Mode declarations | non (biais `body_preds`) | `modeh`/`modeb` |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5938dda",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008923,
+     "end_time": "2026-07-06T07:57:23.304724+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:23.295801+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : apprendre `uncle/2`\n",
+    "\n",
+    "Appliquez `ProgolLearn` pour apprendre `uncle(X, Y)` (X oncle de Y : X frère du\n",
+    "parent de Y). Définissez les positifs/négatifs sur l'arbre, puis vérifiez que la\n",
+    "clause apprise est équivalente à `uncle(X,Y) :- male(X), parent(Z,Y), parent(Z,X)`\n",
+    "où Z est le parent commun.\n",
+    "\n",
+    "**Indice** : sur cet arbre, `bob` est frère de `liz`, `liz` est mère de `sue` →\n",
+    "`bob` est oncle de `sue`. Les négatifs doivent exclure (a) les tantes (female),\n",
+    "(b) le père lui-même (parent direct), (c) les grands-pères."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "940fe07a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:57:23.327396Z",
+     "iopub.status.busy": "2026-07-06T07:57:23.326838Z",
+     "iopub.status.idle": "2026-07-06T07:57:23.547315Z",
+     "shell.execute_reply": "2026-07-06T07:57:23.546854Z"
+    },
+    "papermill": {
+     "duration": 0.232115,
+     "end_time": "2026-07-06T07:57:23.547492+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:23.315377+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice uncle/2 a completer (voir indice ci-dessus).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : apprendre uncle/2\n",
+    "// var POS_UNCLE = new List<(string,string[])>{\n",
+    "//     (\"uncle\", new[]{\"bob\",\"sue\"}),  // bob frere de liz, liz mere de sue\n",
+    "//     // TODO etudiant : autres oncles de l'arbre\n",
+    "// };\n",
+    "// var NEG_UNCLE = new List<(string,string[])>{\n",
+    "//     // TODO etudiant : exclure tantes (female), parents directs, grands-peres\n",
+    "// };\n",
+    "// var theoryUncle = ProgolLearn(POS_UNCLE, NEG_UNCLE, FACTS, new HashSet<string>{\"parent\",\"male\",\"female\"});\n",
+    "Console.WriteLine(\"Exercice uncle/2 a completer (voir indice ci-dessus).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a59f1286",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008315,
+     "end_time": "2026-07-06T07:57:23.565626+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T07:57:23.557311+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Bilan\n",
+    "\n",
+    "Ce notebook a présenté la **résolution inverse et l'ILP** from-scratch en C#, jumeau\n",
+    "du notebook Python :\n",
+    "\n",
+    "1. **Représentation** des clauses Horn (`record Clause`) + couverture par unification (`Covers`).\n",
+    "2. **LGG** (Plotkin) : généraliser deux explications en une variable partagée.\n",
+    "3. **θ-subsomption** : skolemisation + backtracking pour ordonner la généralité.\n",
+    "4. **Clause bottom** : saturation bornée + variabilisation (clause la plus spécifique).\n",
+    "5. **Recherche Progol** : meilleure clause consistante, score `p − L`, mode connecté.\n",
+    "6. **Apprentissage** de `grandfather/2` et `grandmother/2` (négatifs = signal).\n",
+    "\n",
+    "> **Parité** : jumeau C# de [SL-5-InverseResolution.ipynb](SL-5-InverseResolution.ipynb).\n",
+    "> Les deux implémentent les mêmes algorithmes from-scratch (pas de lib ML).\n",
+    "> Marathon parité .NET ⇄ Python (#4956), EPIC #3801 (Prong B).\n",
+    "\n",
+    "## Exercices supplémentaires\n",
+    "\n",
+    "### Exercice 2 : profondeur de la clause bottom\n",
+    "Testez `BottomClause` avec `depth=1` vs `depth=3`. Combien de littéraux ? La cible\n",
+    "subsume-t-elle toujours la clause bottom à profondeur 1 ? Pourquoi une profondeur\n",
+    "importante crée-t-elle une explosion combinatoire dans `ProgolSearch` ?\n",
+    "\n",
+    "### Exercice 3 : tolérance au bruit\n",
+    "Ajoutez un exemple positif erroné (ex : `(\"grandfather\", new[]{\"ann\",\"jim\"})`).\n",
+    "Que se passe-t-il ? Proposez un mécanisme de tolérance (ex : score `p − n − L`\n",
+    "autorisant quelques négatifs couverts, au lieu de tout rejeter).\n",
+    "\n",
+    "### Exercice 4 : réduction de Plotkin\n",
+    "Implémentez une réduction de théorie : si une clause `C` θ-subsume une autre `D`\n",
+    "dans la théorie apprise, retirer la plus spécifique. Pourquoi cela évite-t-il la\n",
+    "prolifération de clauses redondantes ?\n",
+    "\n",
+    "## Références\n",
+    "- Russell & Norvig, *AIMA* (3e éd.), §19.5.\n",
+    "- Plotkin, G. D. *A Note on Inductive Generalization* (1970) — LGG, θ-subsomption.\n",
+    "- Muggleton, S. *Inverse Entailment and Progol* (1995) — clause bottom.\n",
+    "- Notebook Python : [SL-5-InverseResolution.ipynb](SL-5-InverseResolution.ipynb).\n",
+    "- Marathon parité : #4956.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 33.201105,
+   "end_time": "2026-07-06T07:57:24.829210+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb",
+   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp/sl5_out.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T07:56:51.628105+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

C# (.NET Interactive) twin of `SL-5-InverseResolution.ipynb` — marathon .NET ⇄ Python parity (**#4956**). Pure C# from-scratch (no lib ML, no Prolog), AIMA §19.5 (Inverse Resolution + Bottom-Clause ILP). EPIC **#3801** Prong B (hand-rolled parity twin).

Suite logique de [SL-1 C#](https://github.com/jsboige/CoursIA/pull/5520) + [SL-2 C#](https://github.com/jsboige/CoursIA/pull/5529) (en attente merge).

## Contenu pédagogique

| § | Section | Algorithme |
|---|---------|-----------|
| 1 | Représentation | `record Clause(Head, Body)` + couverture par unification (`Covers`) |
| 2 | LGG (Plotkin) | `LggClause` — généraliser deux explications (variable partagée) |
| 3 | θ-subsomption | `Subsumes` — skolemisation + backtracking, ordre généralité |
| 4 | Clause bottom | `BottomClause` — saturation bornée + variabilisation |
| 5 | Recherche Progol | `ProgolSearch` — meilleure clause connectée consistante, score `p−L` |
| 6 | Exemple grandmother | apprentissage `grandmother/2` (négatifs = signal) |

## Preuve d'exécution (H.1 / C.2)

- **Papermill** `.net-csharp` : **17/17 cells, 7/7 code cells `ec=1-7` contigus, 0 errors**.
- **C.1 clean** : 0 `raise NotImplementedError` / `assert False` / `1/0` (grep). Exercice stub commenté.
- **Outputs matchent le twin Python** firsthand :
  - §0 : cible couvre 4/4 positifs, 0/6 négatifs (table identique)
  - §1 : LGG 5 littéraux, couverture 4/4 pos / 0/6 neg (identique)
  - §2 : ordre généralité `top ≥ cible ≥ exemple au sol` (top subsume tout, exemple ne subsume rien) — identique
  - §3 : clause bottom 9 littéraux (depth 2), cible subsume bottom = True — identique
  - §4 : **ProgolLearn découvre `grandfather(V1,V2) :- parent(V1,V3), parent(V3,V2), male(V1)`** = cible retrouvée, 4/4 pos 0/6 neg
  - §5 : grandmother `female(X), parent, parent` = équivalent cible = **True**

## Leçon technique C# mémorisée

Les **tuples à éléments nommés** `(Head: ..., Body: ...)` comme types de **paramètres/retours de méthodes** → compilation error opaque en .NET Interactive. Fix : `public record Clause(Head, Body)` concret. Cf `csharp-hashset-tuple-array-reference-equality.md` (même famille de pièges .NET Interactive).

## Anti-régression

Nouveau notebook (jumeau), pas de modification de code métier. README : +1 ligne arbre + 1 note §Parité (sous section SL-2). **CATALOG-STATUS byte-identique à `origin/main`** (jumeau = twin, pas nouveau notebook pédagogique, `SymbolicLearning=12` inchangé).

## §E audit fichier-entier (pr-review-discipline.md)

- **Disk count** : `ls *.ipynb` → 12 Python PRODUCTION + le nouveau jumeau C# (ce PR).
- **Prose ↔ structure ↔ CATALOG** : alignés (12 Python inchangés, 1 jumeau C# ajouté). CATALOG byte-identique.
- Compteurs `PRODUCTION=12` (Python) non modifiés — un jumeau n'augmente pas le compte pédagogique.

## Parité .NET ⇄ Python (marathon #4956)

SL-1 (#5520) → SL-2 (#5529) → **SL-5 (ce PR)**. Algorithmes équivalents from-scratch des deux côtés (pas de lib ML). Les cells Aleph/SWI-Prolog du notebook Python (pont vers moteur externe) sont remplacées par une note pédagogique Prong B (on enseigne l'algorithme, pas on invoque une boîte noire).

See #4956 (marathon), #3801 (Prong B SOTA registry).