### PR TITLE
i18n(#4980): add Sudoku.*_en siblings — EN mirrors, sudoku_lean (lake fully bilingual)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Basic_en.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Basic_en.lean
@@ -1,0 +1,85 @@
+import Mathlib
+
+/-!
+# Sudoku.Basic — constraint structure, solutions, peers
+
+Abstract formalization of a Sudoku (more generally: any constraint-satisfaction
+problem with "all-distinct scopes"). A concrete 9×9 Sudoku is one instance of this
+framework: the **scopes** are its 27 families (9 rows, 9 columns, 9 blocks), each of
+which must carry **all-distinct** values.
+
+The abstraction is deliberate: the soundness theorems of propagation
+(`Propagation.lean`) hold for **any** structure of this type, not only the 9×9. This is
+the right level of formalization — the propagation logic does not depend on there being
+9 values or 3×3 blocks, only on the invariant "all-distinct per scope".
+
+Cross-reference: the `Sudoku` series (backtracking, OR-Tools, .NET, Infer.NET) whose
+solvers this lake formally grounds by propagation. See issue #4055.
+-/
+
+namespace Sudoku_en
+
+variable {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V] [DecidableEq V]
+
+/-- The constraint structure of a Sudoku: a finite set of **scopes** (each a
+    `Finset` of cells) that must carry all-distinct values. -/
+abbrev Scopes (ι : Type*) := Finset (Finset ι)
+
+/-- A complete assignment: one value per cell. -/
+abbrev Solution (ι V : Type*) := ι → V
+
+/-- `σ` is **all-distinct on `s`** if two distinct cells of `s` never carry the same
+    value (injectivity of `σ` on `s`). -/
+def AllDistinctOn (σ : Solution ι V) (s : Finset ι) : Prop :=
+  ∀ ⦃c c'⦄, c ∈ s → c' ∈ s → σ c = σ c' → c = c'
+
+/-- `σ` is a **solution** of the structure `scopes` if it is all-distinct on each
+    scope. This is the fundamental Sudoku invariant (each row, column and block
+    contains each value at most once). -/
+def IsSolution (scopes : Scopes ι) (σ : Solution ι V) : Prop :=
+  ∀ s ∈ scopes, AllDistinctOn σ s
+
+/-- `σ` **agrees** with a partial assignment `a` wherever `a` is defined. -/
+def AgreesWith (σ : Solution ι V) (a : ι → Option V) : Prop :=
+  ∀ i, ∀ v, a i = some v → σ i = v
+
+/-- `c'` is a **peer** of `c` if they are distinct and share at least one scope. Two
+    peer cells cannot carry the same value in a solution. -/
+def IsPeer (scopes : Scopes ι) (c c' : ι) : Prop :=
+  c ≠ c' ∧ ∃ s ∈ scopes, c ∈ s ∧ c' ∈ s
+
+/-- A value `v` is **present in scope `s`** if some cell of `s` carries it. For a
+    "full house" scope (|s| = |V|) of a solution, every value is present there (full
+    house lemma). -/
+def PresentIn (σ : Solution ι V) (s : Finset ι) (v : V) : Prop :=
+  ∃ c ∈ s, σ c = v
+
+/-- **Full house lemma.** If a scope `s` contains as many cells as there are possible
+    values (`s.card = card V`) and an assignment `σ` is all-distinct on `s`, then
+    **every** value `v` is present in `s`.
+
+    This is the pigeonhole argument: `σ` restricted to `s` is injective, so its image
+    has `card s = card V` distinct elements — the entirety of `V` — hence every value
+    appears there. This lemma makes the `PresentIn σ s v` hypothesis of the "hidden
+    single" (`Propagation.hidden_single_sound`) automatic in the full-house case
+    (cf #4055). -/
+theorem full_house_present {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
+    [DecidableEq V] (σ : Solution ι V) (s : Finset ι) (v : V)
+    (hcard : s.card = Fintype.card V) (hAD : AllDistinctOn σ s) : PresentIn σ s v := by
+  -- `AllDistinctOn σ s` ⟺ `Set.InjOn σ s` (same shape, Finset/Set membership defeq)
+  have hinj : Set.InjOn σ s := by
+    intros c hc c' hc' heq
+    exact hAD hc hc' heq
+  -- The image `σ '' s` has the same cardinality as `s` (injectivity)
+  have hcard_img : (Finset.image σ s).card = s.card := Finset.card_image_of_injOn hinj
+  -- `σ '' s ⊆ univ`, same cardinality as `univ` (= card V) ⟹ `σ '' s = univ`
+  have hsub : Finset.image σ s ⊆ (Finset.univ : Finset V) := Finset.subset_univ _
+  have heq_img : Finset.image σ s = (Finset.univ : Finset V) := by
+    apply Finset.eq_of_subset_of_card_le hsub
+    rw [hcard_img, hcard]; simp
+  -- `v ∈ σ '' s` (= univ), then `mem_image` ⟺ `∃ c ∈ s, σ c = v` = `PresentIn`
+  have hmem : v ∈ Finset.image σ s := heq_img ▸ Finset.mem_univ v
+  rw [Finset.mem_image] at hmem
+  exact hmem
+
+end Sudoku_en

--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/ExactCover_en.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/ExactCover_en.lean
@@ -1,0 +1,209 @@
+import Mathlib
+import Sudoku.Basic_en
+
+-- The section variable `[Fintype V] [DecidableEq V]` is required by the
+-- "full house" milestone lemmas (`toSelection_scopeVal_unique`,
+-- `solution_imp_exact_cover` via `full_house_present` which cites `Fintype.card V`)
+-- but not by the structural lemmas (`toSelection`, `mem_toSelection_iff`,
+-- `toSelection_cell_unique`) which only mobilize the image structure on `ι`.
+set_option linter.unusedSectionVars false
+
+/-!
+# Sudoku.ExactCover — Sudoku ⇔ exact cover reduction (Knuth)
+
+Issue #4055 (remaining milestone after `Propagation.lean`). **Exact cover**
+(exact cover, Knuth 2000, "Dancing Links") is the canonical encoding of a Sudoku into
+a universal problem: we express each Sudoku constraint as an "element" to be covered,
+each possible placement `(cell, value)` as an option covering a small subset of
+elements, and a Sudoku solution as an **exact cover** — a selection of options where
+each element is covered **exactly once**.
+
+## The encoding (Knuth, 4 constraint families)
+
+For a concrete Sudoku (9×9), the universe of constraints counts `4 × 81 = 324`
+elements split into 4 families:
+
+1. **Cell** — `cell c`: "cell `c` receives exactly one value" (81 constraints);
+2. **Row** — `scopeVal ℓ v`: "row `ℓ` contains value `v`";
+3. **Column** — likewise;
+4. **Block** — likewise.
+
+In our abstract framework (`Sudoku.Basic`), families 2–4 merge into a single one:
+`scopeVal s v` for a scope `s ∈ scopes`. The constraint universe reduces to two
+families: `cell c` and `scopeVal s v`.
+
+An option `(c, v) : ι × V` covers `{cell c} ∪ {scopeVal s v | s ∈ scopes, c ∈ s}`.
+The selection associated with an assignment `σ` is `toSelection σ = {(c, σ c) | c}`.
+
+## Result
+
+The capstone theorem `sudoku_iff_exact_cover` (under the "full house" hypothesis
+`∀ s ∈ scopes, s.card = card V`, satisfied by the 9×9 Sudoku where each scope has 9
+cells for 9 values) establishes the **complete equivalence** between solving the
+Sudoku and solving an exact-cover problem:
+
+  `(∃ σ, IsSolution scopes σ) ↔ (∃ sel, IsExactCover sel scopes)`.
+
+**Forward direction** `solution_imp_exact_cover` — a solution is an exact cover:
+
+- Each **cell** is covered exactly once — by construction of `toSelection` (one option
+  `(c, σ c)` per cell), via `mem_toSelection_iff`.
+- Each **(scope, value)** is covered **at most** once — this is exactly `AllDistinctOn`
+  (the definition of `IsSolution`);
+- and **at least** once — by the full house lemma `full_house_present`
+  (`Sudoku.Basic`), which says that in a full scope every value appears.
+
+**Backward direction** `exact_cover_imp_solution` — an exact cover yields a solution:
+the reconstructed assignment `fromSelection` (the unique value of each cell) is
+all-distinct on each scope, since two cells of the same scope carrying the same value
+would violate the `∃!` uniqueness of the (scope, value) pair; and its selection gives
+back exactly `sel` (`toSelection_fromSelection`).
+
+**Honest framing (G.3/G.9).** The equivalence is proven in full (0 `sorry`). The
+axioms are the standard Lean 4 kernel trio (`propext`, `Classical.choice`,
+`Quot.sound`) — `Classical.choice` shows up for the non-constructive construction
+`fromSelection` (extracting a witness per cell from the cover `∃!`), as in any
+Mathlib-dependent proof; no ad hoc axiom. The massive computational result "17 clues
+minimum" remains out of scope (not formalizable).
+-/
+
+namespace Sudoku_en
+
+variable {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V] [DecidableEq V]
+
+/-- A selection of placements (cell, value) — the analogue of a subfamily of options
+    in Knuth's encoding. -/
+abbrev ExactCover.Sel (ι V : Type*) := Finset (ι × V)
+
+/-- `sel` is an **exact cover** of the structure `scopes` if each cell is covered
+    exactly once (a single value per cell) AND each (scope, value) pair — for every
+    declared scope — is covered exactly once (a single cell of the scope carries the
+    value). -/
+def ExactCover.IsExactCover (sel : Sel ι V) (scopes : Scopes ι) : Prop :=
+  (∀ c : ι, ∃! v : V, (c, v) ∈ sel) ∧
+  (∀ s ∈ scopes, ∀ v : V, ∃! c : ι, c ∈ s ∧ (c, v) ∈ sel)
+
+/-- The selection associated with an assignment `σ`: one placement `(c, σ c)` per
+    cell. By construction, each cell appears there exactly once. -/
+def toSelection (σ : Solution ι V) : ExactCover.Sel ι V :=
+  Finset.univ.image (fun c : ι => (c, σ c))
+
+/-- **Membership characterization.** `(c, v)` is in the selection associated with `σ`
+    if and only if `v = σ c`. This is the key lemma that reduces any question about the
+    selection to a question about `σ` itself. -/
+theorem mem_toSelection_iff (σ : Solution ι V) (c : ι) (v : V) :
+    (c, v) ∈ toSelection σ ↔ σ c = v := by
+  constructor
+  · intro h
+    rw [toSelection, Finset.mem_image] at h
+    obtain ⟨x, -, hx⟩ := h
+    injection hx with h1 h2
+    subst h1
+    exact h2
+  · intro h
+    rw [toSelection, Finset.mem_image]
+    refine ⟨c, Finset.mem_univ _, ?_⟩
+    rw [h]
+
+/-! ## Forward direction: a solution is an exact cover -/
+
+/-- **Cell covered exactly once.** In `toSelection σ`, each cell `c` receives a unique
+    value (`σ c`) — the cell-exhaustiveness of the encoding, by construction. -/
+theorem toSelection_cell_unique (σ : Solution ι V) (c : ι) :
+    ∃! v : V, (c, v) ∈ toSelection σ := by
+  refine ⟨σ c, (mem_toSelection_iff σ c (σ c)).mpr rfl, ?_⟩
+  rintro v hv
+  exact ((mem_toSelection_iff σ c v).mp hv).symm
+
+/-- **(scope, value) pair covered exactly once (solution + full house).** If `σ` is
+    all-distinct on `s` and `s` is full (`s.card = card V`), then for any value `v`
+    there is a **unique** cell `c ∈ s` carrying `v`: existence by the full house lemma
+    (`full_house_present`), uniqueness by `AllDistinctOn` (injectivity). -/
+theorem toSelection_scopeVal_unique (σ : Solution ι V) (s : Finset ι) (v : V)
+    (hcard : s.card = Fintype.card V) (hAD : AllDistinctOn σ s) :
+    ∃! c : ι, c ∈ s ∧ (c, v) ∈ toSelection σ := by
+  obtain ⟨c, hcs, hσcv⟩ := full_house_present σ s v hcard hAD
+  refine ⟨c, ⟨hcs, (mem_toSelection_iff σ c v).mpr hσcv⟩, ?_⟩
+  rintro c' ⟨hc's, hcv'⟩
+  rw [mem_toSelection_iff] at hcv'
+  exact hAD hc's hcs (hcv'.trans hσcv.symm)
+
+/-- **Forward direction of the equivalence.** A solution of a "full house" structure
+    (every scope has as many cells as values — the 9×9 Sudoku case) is an exact cover
+    in Knuth's sense. -/
+theorem solution_imp_exact_cover (scopes : Scopes ι) (σ : Solution ι V)
+    (hσ : IsSolution scopes σ)
+    (hfull : ∀ s ∈ scopes, s.card = Fintype.card V) :
+    ExactCover.IsExactCover (toSelection σ) scopes :=
+  ⟨fun c => toSelection_cell_unique σ c,
+   fun s hs v => toSelection_scopeVal_unique σ s v (hfull s hs) (hσ s hs)⟩
+
+/-! ## Backward direction: an exact cover is a solution -/
+
+/-- **Inverse construction.** From a selection where each cell is covered exactly once,
+    we recover the assignment: the unique value carried by each cell. Non-constructive
+    (extracting a witness per cell from the cover `∃!`) — relies on the
+    `Classical.choice` axiom. -/
+noncomputable def fromSelection (sel : ExactCover.Sel ι V)
+    (hcell : ∀ c : ι, ∃! v : V, (c, v) ∈ sel) : Solution ι V :=
+  fun c => Classical.choose (ExistsUnique.exists (hcell c))
+
+/-- Cell `c` indeed carries its reconstructed value in `sel`. -/
+theorem fromSelection_mem (sel : ExactCover.Sel ι V)
+    (hcell : ∀ c : ι, ∃! v : V, (c, v) ∈ sel) (c : ι) :
+    (c, fromSelection sel hcell c) ∈ sel :=
+  Classical.choose_spec (ExistsUnique.exists (hcell c))
+
+/-- **Dual characterization of `mem_toSelection_iff`.** `(c, v)` is in `sel` if and
+    only if the reconstructed value of `c` equals `v` — by uniqueness of the value
+    covering `c`. -/
+theorem mem_fromSelection_iff (sel : ExactCover.Sel ι V)
+    (hcell : ∀ c : ι, ∃! v : V, (c, v) ∈ sel) (c : ι) (v : V) :
+    (c, v) ∈ sel ↔ fromSelection sel hcell c = v := by
+  refine ⟨fun hcv => ?_, fun h => ?_⟩
+  · obtain ⟨w, hw, huniq⟩ := hcell c
+    have h1 : fromSelection sel hcell c = w := huniq _ (fromSelection_mem sel hcell c)
+    have h2 : v = w := huniq v hcv
+    rw [h1, h2]
+  · rw [← h]; exact fromSelection_mem sel hcell c
+
+/-- **The reconstructed selection is the original selection.** `toSelection` applied to
+    the assignment reconstructed from `sel` gives back exactly `sel`: the two membership
+    characterizations coincide. -/
+theorem toSelection_fromSelection (sel : ExactCover.Sel ι V)
+    (hcell : ∀ c : ι, ∃! v : V, (c, v) ∈ sel) :
+    toSelection (fromSelection sel hcell) = sel := by
+  ext ⟨c, v⟩
+  rw [mem_toSelection_iff, mem_fromSelection_iff]
+
+/-- **Backward direction of the equivalence.** An exact cover yields a solution: the
+    reconstructed assignment is all-distinct on each scope (since two cells of the same
+    scope carrying the same value would violate the `∃!` uniqueness of the
+    (scope, value) pair), and its selection is the original selection. -/
+theorem exact_cover_imp_solution (scopes : Scopes ι) (sel : ExactCover.Sel ι V)
+    (hec : ExactCover.IsExactCover sel scopes) :
+    ∃ σ, IsSolution scopes σ ∧ toSelection σ = sel :=
+  ⟨fromSelection sel hec.1,
+   (fun s hs c c' hcs hc's hcc' => by
+      have hcv : (c, fromSelection sel hec.1 c) ∈ sel := fromSelection_mem sel hec.1 c
+      have hc'v : (c', fromSelection sel hec.1 c) ∈ sel := by
+        rw [hcc']; exact fromSelection_mem sel hec.1 c'
+      obtain ⟨c0, ⟨hc0s, hc0v⟩, hc0uniq⟩ := hec.2 s hs (fromSelection sel hec.1 c)
+      rw [hc0uniq c ⟨hcs, hcv⟩, hc0uniq c' ⟨hc's, hc'v⟩]),
+   toSelection_fromSelection sel hec.1⟩
+
+/-- **Sudoku ⇔ exact cover equivalence (Knuth).** Under the "full house" hypothesis
+    (the 9×9 Sudoku case), a structure admits a solution if and only if it admits an
+    exact cover. This is the complete equivalence theorem — the forward direction
+    (`solution_imp_exact_cover`) plus the backward direction
+    (`exact_cover_imp_solution`). -/
+theorem sudoku_iff_exact_cover (scopes : Scopes ι)
+    (hfull : ∀ s ∈ scopes, s.card = Fintype.card V) :
+    (∃ σ : Solution ι V, IsSolution scopes σ) ↔
+      (∃ sel : ExactCover.Sel ι V, ExactCover.IsExactCover sel scopes) := by
+  refine ⟨fun ⟨σ, hσ⟩ => ⟨toSelection σ, solution_imp_exact_cover scopes σ hσ hfull⟩,
+          fun ⟨sel, hec⟩ => ?_⟩
+  obtain ⟨σ, hσ, _⟩ := exact_cover_imp_solution scopes sel hec
+  exact ⟨σ, hσ⟩
+
+end Sudoku_en

--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Propagation_en.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku/Propagation_en.lean
@@ -1,0 +1,97 @@
+import Mathlib
+import Sudoku.Basic_en
+
+/-!
+# Sudoku.Propagation — soundness of propagation rules
+
+Issue #4055. Sudoku solvers (backtracking, OR-Tools, .NET of the `Sudoku` series)
+speed up solving by **propagating** constraints: as soon as a value is placed, the
+now-impossible candidates are eliminated. Two canonical rules:
+
+- **Naked single**: a cell whose only remaining candidate is `v` must contain `v`.
+- **Hidden single**: a value that can only go into a single cell of a scope must go
+  there.
+
+This module proves the **soundness** of these rules: they **remove no valid solution**
+— eliminating a candidate via propagation means eliminating an assignment that **no
+solution uses**. The keystone is `peer_excludes_value`: an assigned cell excludes its
+value from all its peers.
+
+**Honest framing (G.3/G.9).** The soundness of both propagation rules is proven in
+full (0 `sorry`). The **Sudoku ⇔ exact cover reduction** (Knuth, 4 constraint
+families), as well as completeness (do the rules suffice to solve every Sudoku? no in
+general — hence backtracking), are natural milestones left **open**, deliberately
+**not `sorry`-backed**: the library stays entirely `sorry`-free. The massive
+computational result "17 clues minimum" is out of scope (not formalizable).
+-/
+
+namespace Sudoku_en
+
+/-! ## Keystone: exclusion by peers -/
+
+/-- **Keystone.** In a solution, a cell `c` carrying value `v` excludes `v` from every
+    **peer** cell `c'` (same scope): `σ c' ≠ v`. This is the fundamental fact from
+    which all propagation rules derive.
+
+    **Proof** (0 `sorry`): `c` and `c'` share a scope `s`; `σ` is all-distinct on `s`,
+    so `σ c = σ c'` would imply `c = c'`, contradicting `c ≠ c'` (peer definition). -/
+theorem peer_excludes_value {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
+    [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V)
+    (hσ : IsSolution scopes σ) (c c' : ι) (v : V)
+    (hpeer : IsPeer scopes c c') (hcv : σ c = v) :
+    σ c' ≠ v := by
+  obtain ⟨hcc', s, hs, hcs, hc's⟩ := hpeer
+  intro hc'v
+  have hcc : c = c' := hσ s hs hcs hc's (hcv.trans hc'v.symm)
+  exact hcc' hcc
+
+/-! ## Naked single -/
+
+/-- **Naked single (soundness).** If, in a solution `σ`, every value except `v` is
+    already carried by **peers** of `c` (i.e. each `w ≠ v` appears on a peer cell of
+    `c`), then `σ c = v`.
+
+    This formalizes the "naked single": cell `c` has only `v` left as a possible
+    candidate (all other values are excluded by its peers), so every solution places
+    `v` there. The rule removes no solution because it identifies a **forced** value.
+
+    **Proof** (0 `sorry`): by contradiction, `σ c = w ≠ v`. By the coverage hypothesis,
+    `w` appears on a peer `c'` of `c`; but `peer_excludes_value` forbids `c'` from
+    carrying `σ c`. Contradiction. -/
+theorem naked_single_sound {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
+    [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V)
+    (hσ : IsSolution scopes σ) (c : ι) (v : V)
+    (hcover : ∀ w : V, w ≠ v → ∃ c' : ι, IsPeer scopes c c' ∧ σ c' = w) :
+    σ c = v := by
+  by_contra hne
+  obtain ⟨c', hpeer, hc'w⟩ := hcover (σ c) hne
+  exact peer_excludes_value scopes σ hσ c c' (σ c) hpeer rfl hc'w
+
+/-! ## Hidden single -/
+
+/-- **Hidden single (soundness).** If, in a solution `σ` of structure `scopes`, value
+    `v` is present in scope `s` (`PresentIn σ s v`), that `c ∈ s`, and that `v` is
+    **excluded** from every other cell `c' ∈ s` (each `c' ≠ c` has a peer carrying
+    `v`), then `σ c = v`.
+
+    This formalizes the "hidden single": within a scope, `v` can only go into `c`, so
+    every solution places it there. For a "full house" scope (`|s| = |V|`), the
+    `PresentIn σ s v` hypothesis is automatic (every value appears).
+
+    **Proof** (0 `sorry`): `v` appears at `c0 ∈ s`. If `c0 ≠ c`, the exclusion
+    hypothesis gives a peer `c''` of `c0` carrying `v`; but `peer_excludes_value`
+    forbids `c''` from carrying `σ c0 = v`. Contradiction. Hence `c0 = c`, `σ c = v`. -/
+theorem hidden_single_sound {ι V : Type*} [Fintype ι] [DecidableEq ι] [Fintype V]
+    [DecidableEq V] (scopes : Scopes ι) (σ : Solution ι V)
+    (hσ : IsSolution scopes σ) (s : Finset ι) (_hs : s ∈ scopes)
+    (c : ι) (v : V) (_hcs : c ∈ s)
+    (hvin : PresentIn σ s v)
+    (hexcl : ∀ c' ∈ s, c' ≠ c → ∃ c'' : ι, IsPeer scopes c' c'' ∧ σ c'' = v) :
+    σ c = v := by
+  obtain ⟨c0, hc0s, hc0v⟩ := hvin
+  by_contra hne
+  have hc0c : c0 ≠ c := fun heq => hne (heq ▸ hc0v)
+  obtain ⟨c'', hpeer, hc''v⟩ := hexcl c0 hc0s hc0c
+  exact peer_excludes_value scopes σ hσ c0 c'' v hpeer hc0v hc''v
+
+end Sudoku_en


### PR DESCRIPTION
## i18n(#4980): add `Sudoku.*_en` siblings — EN mirrors, sudoku_lean (**lake fully bilingual**)

English mirrors of `Sudoku/Basic.lean`, `Sudoku/ExactCover.lean`, `Sudoku/Propagation.lean` (FR-first canonical). Convention i18n Lean ratifiée ai-01 (2026-07-04, #4980 comment-4881909354) : distincts FR + EN siblings dans le même lake, les deux compilent ; contenu non-docstring byte-identique (drift-CI detectable).

### What — Sudoku formalization (constraint structure + exact cover + propagation soundness), EPIC #4055 (Lean roadmap #4038 Tier 2)

`sudoku_lean` is the Lean 4 formalization of Sudoku solving:
- **Basic**: abstract constraint structure (scopes/solution type aliases), `AllDistinctOn`/`IsSolution`/`IsPeer`/`PresentIn` defs, `full_house_present` (pigeonhole lemma).
- **ExactCover**: the Sudoku ⇔ exact-cover reduction à la Knuth "Dancing Links" — capstone `sudoku_iff_exact_cover` establishes `(∃ σ, IsSolution) ↔ (∃ sel, IsExactCover)` under the full-house hypothesis, **0 sorry**.
- **Propagation**: soundness of the two canonical propagation rules (`naked_single_sound`, `hidden_single_sound`) via the keystone `peer_excludes_value`, **0 sorry**.

### Atomic — 3 EN siblings in one PR (small coherent lake)

| File | Role | FR→EN diff (non-docstring) |
|------|------|----------------------------|
| `Basic_en.lean` (leaf) | constraint structure, type aliases, `full_house_present` | namespace + end |
| `ExactCover_en.lean` | Knuth exact-cover encoding, capstone `sudoku_iff_exact_cover` | + import-swap, namespace + end |
| `Propagation_en.lean` | keystone `peer_excludes_value` + naked/hidden single soundness | + import-swap, namespace + end |

Single PR (not stacked) because sudoku_lean is one small coherent lake (391L total). ExactCover and Propagation both depend only on Basic, all in the PR.

### Why this is safe — no `structure`, prefix application only (verified firsthand)

**SAFE profile (NOT the Lattice_en trap).** `sudoku_lean` has **no `structure`** (only `abbrev` type aliases `Scopes`/`Solution`/`Sel`), so there is no `structure X` + `namespace X` coincidence. All defs are namespace functions with explicit parameters, and **all call sites are PREFIX application** (`IsSolution scopes σ`, `AllDistinctOn σ s`, `IsExactCover sel scopes`, `ExactCover.IsExactCover` fully-qualified). Verified firsthand: `grep` for lowercase-value dot-notation (`af.foo`-style trap signal) returned empty across all 3 modules.

### Sorry parity — no regression (0 sorry throughout)

| File | FR sorry | EN sorry |
|------|----------|----------|
| Basic | 0 | 0 |
| ExactCover | 0 | 0 |
| Propagation | 0 | 0 |

The exact-cover equivalence and propagation soundness are **fully proven in BOTH siblings** — no `sorry` anywhere. Axioms = standard Lean 4 kernel trio (`propext`, `Classical.choice`, `Quot.sound`); `Classical.choice` only for the non-constructive `fromSelection`, as in any Mathlib-dependent proof.

### Verification (lean-merge-discipline HARD)

```
$ lake.exe build Sudoku.Propagation_en Sudoku.ExactCover_en
✔ [8493/8495] Built Sudoku.Basic_en (14s)
✔ [8494/8495] Built Sudoku.Propagation_en (14s)
✔ [8495/8495] Built Sudoku.ExactCover_en (14s)
Build completed successfully (8495 jobs), exit 0
```
Both targets transitively build `Basic_en` → the **entire EN side of the lake is verified**.

| Check | Result |
|-------|--------|
| `lake build` (Propagation_en + ExactCover_en) | **SUCCESS** (8495 jobs, all 3 EN files) |
| FR files baseline | SUCCESS (0 sorry each) |
| sorry FR vs EN | 0 = 0 on all 3 (no regression) |
| FR files | byte-identical to main (anti-regression D) |
| non-docstring code diff | namespace + end + import-swap only — proofs byte-identical |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — sudoku_lean fully bilingual

Lakefile UNCHANGED: already `globs := #[.submodules \`Sudoku]` auto-discovers the `_en` submodules. After this PR merges, sudoku_lean is **fully bilingual** (3/3 content files FR + EN) and `lake build Sudoku` builds the EN side automatically → **globs `Sudoku.*` UNBLOCKED** fleet-wide (c.219 Finding "globs expose broken _en" — sudoku_lean has NONE).

FR files UNCHANGED. Pure +file addition (3 files, +391).

See #4980
See #4055
See #4038

🤖 Generated with [Claude Code](https://claude.com/claude-code)
