### PR TITLE
Fix: social_choice_lean lakefile globs precis (14 modules FR+EN) - c.255 orphan-trap fix

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/lakefile.lean
@@ -14,3 +14,33 @@ require mathlib from git
 lean_lib «SocialChoice» where
   -- Port of asouther4/lean-social-choice to Lean 4
   -- Arrow's Impossibility Theorem and Sen's Theorem
+  --
+  -- i18n FR-first (EPIC #4980 ratif 2026-07-04 11:58Z, comment-4881909354) :
+  -- Globs precis par module (FR canonique + EN sibling verbatim) :
+  --   - 7 modules canoniques (Arrow, Basic, Framework, MechanismDesign,
+  --     Sen, SortedListCounting, Voting) — deja compiles transitivement
+  --     via SocialChoice.lean racine. Globs explicite = preuve in-graph CI.
+  --   - 7 EN siblings (Arrow_en, Basic_en, Framework_en, MechanismDesign_en,
+  --     Sen_en, SortedListCounting_en, Voting_en) — en cours de finalisation
+  --     via PRs #5500/#5502/#5505 + fix namespace.
+  --   - _SmokeTest (sanity check nat).
+  --
+  -- Pattern precis (decision c.255 ai-01 msg msg-20260706T080634-aa4ur6)
+  -- au lieu de `.submodules \`SocialChoice` broad qui ne compile QUE
+  -- `SocialChoice.lean` racine (= default Lake = `Glob.one` du root
+  -- SEUL, voir Lake README "Defaults to a `Glob.one` of each of the
+  -- library's `roots`"). Conséquence : 0 module SocialChoice.* listé
+  -- dans le log Lake, false-green "Built SocialChoice" = juste la
+  -- lib aggregate. Les 7 EN siblings etaient des ORPHELINS silencieux.
+  --
+  -- Lake build REPORTE ai-01 (WDAC po-2026 bloque Lean local).
+  globs := #[
+    `SocialChoice.Arrow, `SocialChoice.Arrow_en,
+    `SocialChoice.Basic, `SocialChoice.Basic_en,
+    `SocialChoice.Framework, `SocialChoice.Framework_en,
+    `SocialChoice.MechanismDesign, `SocialChoice.MechanismDesign_en,
+    `SocialChoice.Sen, `SocialChoice.Sen_en,
+    `SocialChoice.SortedListCounting, `SocialChoice.SortedListCounting_en,
+    `SocialChoice.Voting, `SocialChoice.Voting_en,
+    `SocialChoice.SmokeTest
+  ]


### PR DESCRIPTION
## Résumé

Fix l'orphan-trap silencieux de `social_choice_lean` : les 7 modules **EN siblings** (`Arrow_en`, `Basic_en`, `Framework_en`, `MechanismDesign_en`, `Sen_en`, `SortedListCounting_en`, `Voting_en`) **n'étaient jamais compilés** par Lake, alors que le build retournait `Built SocialChoice` SUCCESS — une fausse impression de compilation.

## Diagnostic firsthand c.255

Vérification via le log du job Lake build (`runs/28763388275/job/85282954336`, PR #5500) :

| Métrique | Valeur | Verdict |
|----------|--------|---------|
| Lignes `✔ [N/M] Built` total | 22 | Beaucoup de batteries + mathlib |
| Lignes `Built SocialChoice.*` (modules) | **0** | Aucun module listé |
| Ligne finale `Built SocialChoice` | 1 | Lib aggregate, pas un module |

**Cause documentée** ([Lake README](https://github.com/leanprover/lean4/blob/master/src/lake/README.md)) :
> `globs` defaults to a `Glob.one` of each of the library's `roots`. A `Glob.one` for a module builds that **single module** (not its submodules).

Le `lean_lib «SocialChoice»` du lakefile actuel **n'a aucun `globs` custom** → default Lake discovery = compile **uniquement** `SocialChoice.lean` racine. Comme `SocialChoice.lean` importe `SocialChoice.Basic/Framework/Arrow/Sen/Voting/SortedListCounting` (6 modules FR), ceux-ci sont compilés **transitivement**. Mais les 7 `_en` siblings ne sont **importés nulle part** → **ORPHELINS**.

## Changement

Ajout d'un bloc `globs` explicite listant **15 modules** :

```lean
globs := #[
  `SocialChoice.Arrow, `SocialChoice.Arrow_en,
  `SocialChoice.Basic, `SocialChoice.Basic_en,
  `SocialChoice.Framework, `SocialChoice.Framework_en,
  `SocialChoice.MechanismDesign, `SocialChoice.MechanismDesign_en,
  `SocialChoice.Sen, `SocialChoice.Sen_en,
  `SocialChoice.SortedListCounting, `SocialChoice.SortedListCounting_en,
  `SocialChoice.Voting, `SocialChoice.Voting_en,
  `SocialChoice.SmokeTest
]
```

Pattern **précis** (cf PR #5418 MERGED 2026-07-05T10:46:44Z) au lieu de `.submodules \`SocialChoice` broad qui ne compilerait toujours que les modules sans risque de réintroduire un bug dormant comme `Basic_en.lean` côté coop_games (c.234 #5441, namespace resolution `G.Convex` non-préfixé).

## Conséquences attendues

1. **7 FR canonique** : déjà compilés transitivement, globs explicite = **preuve in-graph CI** (énumérés dans le log).
2. **7 EN siblings** : **test décisif**. Soit :
   - **✅ Tout compile** : orphan levé en 1 PR, #5500/#5502/#5505 deviennent **non-substantiels** (le namespace swap était redondant, mais à merger pour le diff prose).
   - **❌ FAIL sur les _en** : confirme que **les PRs #5500/#5502/#5505 sont des FIXES NÉCESSAIRES** dont le namespace swap visait à corriger les bugs que Lake ne voyait pas. Chaîne de merge = (a) merge #5500+#5502+#5505 D'ABORD, puis (b) re-trigger ce PR fix globs.

## Décision c.255

Cette PR est l'**instrument de vérité** que ai-01 a demandé dans le MSG `msg-20260706T080634-aa4ur6` : « fix glob-par-lake requis ». Lake build REPORTE ai-01 (WDAC po-2026 bloque Lean local, cf `.claude/rules/lean-merge-discipline.md` §1).

## Liens

- **Issue** : #4980 (i18n Lean FR+EN siblings)
- **EPIC** : #4208 (axe E finition)
- **PRs impactées** : #5500 (Voting_en namespace), #5502 (Arrow_en dot-notation), #5505 (Framework_en swap) — deviennent soit redondantes soit urgentes selon verdict Lake
- **PR lakefile fix coordonnée** : #5537 (stable_marriage globs précis c.255)
- **Pattern référence** : #5418 (cooperative_games ConeKernel + ConeKernel_en MERGED 2026-07-05T10:46:44Z)
- **MSG ai-01** : `msg-20260706T080634-aa4ur6` (HIGH, décision c.255 L102 TRANCHÉE)
- **Lake build log référence** : `runs/28763388275/job/85282954336` (PR #5500, 0 module SocialChoice.* listé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
