### PR TITLE
feat(gametheory): GameTheory-11-BayesianGames-Csharp — first GameTheory C# twin (Cournot analytic) (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames-Csharp.ipynb
@@ -1,0 +1,1477 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "860c7b6b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004335,
+     "end_time": "2026-07-06T08:27:29.556755",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:29.552420",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-11-BayesianGames-Csharp\n",
+    "\n",
+    "## Jeux Bayesiens en forme normale : Information Incomplete et Croyances\n",
+    "\n",
+    "### Objectifs d'apprentissage\n",
+    "\n",
+    "- Modeliser un jeu **bayesien** (Harsanyi) : types, croyances a priori, profils d'actions.\n",
+    "- Calculer un **equilibre bayesien de Nash** (BNE) en strategies pures par best-response.\n",
+    "- Resoudre analytiquement le **duopole de Cournot avec couts incertains** (systeme lineaire 2x2).\n",
+    "- Simuler une **enchere au premier prix** et verifier le **theoreme d'equivalence du revenu**.\n",
+    "\n",
+    "### Prerequis\n",
+    "\n",
+    "- GameTheory-2-NormalForm-Csharp (Nash en information complete).\n",
+    "- Probabilites : probabilite conditionnelle, esperance.\n",
+    "\n",
+    "### Duree estimee : 65 minutes\n",
+    "\n",
+    "> **Twin C#** de [GameTheory-11-BayesianGames](GameTheory-11-BayesianGames.ipynb) (Python + numpy/scipy).\n",
+    "> **Complementarite (#3801 Prong B)** : le twin Python resout Cournot numeriquement (`scipy.optimize.fsolve`) ;\n",
+    "> ce twin C# resout le **meme systeme analytiquement** et demontre que le **determinant vaut 6 independamment**\n",
+    "> du prior -- un resultat algebraique invisible dans le solveur numerique. Aucun NuGet : BCL .NET seule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "41d98228",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:29.582008Z",
+     "iopub.status.busy": "2026-07-06T08:27:29.570463Z",
+     "iopub.status.idle": "2026-07-06T08:27:32.594933Z",
+     "shell.execute_reply": "2026-07-06T08:27:32.587459Z"
+    },
+    "papermill": {
+     "duration": 3.034725,
+     "end_time": "2026-07-06T08:27:32.595129",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:29.560404",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '64212.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Imports OK : System.Linq, Globalization, DotNet.Interactive (BCL seule, 0 NuGet)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"Microsoft.DotNet.Interactive\"\n",
+    "\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "\n",
+    "// Helper formatage invariant (la culture FR ne persiste pas entre cellules .NET Interactive)\n",
+    "static string FI(double x, string fmt = \"F4\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "\n",
+    "// RNG deterministe pour les simulations d'enchere (reproductibilite)\n",
+    "static Random NewRng(int seed) => new Random(seed);\n",
+    "\n",
+    "\"Imports OK : System.Linq, Globalization, DotNet.Interactive (BCL seule, 0 NuGet)\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5335f203",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003706,
+     "end_time": "2026-07-06T08:27:32.606540",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:32.602834",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Information imparfaite vs information incomplete\n",
+    "\n",
+    "### 1.1 Distinction fondamentale\n",
+    "\n",
+    "- **Information imparfaite** : un joueur n'observe pas les coups passes (jeux dynamiques, actions simultanees).\n",
+    "- **Information incomplete** : un joueur ignore les **caracteristiques** (couts, valuations, preferences) d'autrui.\n",
+    "\n",
+    "### 1.2 Transformation de Harsanyi\n",
+    "\n",
+    "Harsanyi (1967) ramene l'information incomplete a l'information imparfaite en introduisant la **Nature** :\n",
+    "\n",
+    "1. La Nature tire un **profil de types** $t = (t_1, \\dots, t_n)$ selon une distribution **a priori** $p(t)$ commune.\n",
+    "2. Chaque joueur $i$ observe **son propre type** $t_i$ (information privee).\n",
+    "3. Les joueurs choisissent simultanement une action ; le gain depend du profil de types ET du profil d'actions.\n",
+    "\n",
+    "Les croyances d'un joueur sur les types d'autrui se deduisent de $p$ par **regle de Bayes** :\n",
+    "\n",
+    "$$P(t_{-i} \\mid t_i) = \\frac{p(t_i, t_{-i})}{\\sum_{t'_{-i}} p(t_i, t'_{-i})}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b57cb700",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:32.618749Z",
+     "iopub.status.busy": "2026-07-06T08:27:32.618422Z",
+     "iopub.status.idle": "2026-07-06T08:27:33.403671Z",
+     "shell.execute_reply": "2026-07-06T08:27:33.403449Z"
+    },
+    "papermill": {
+     "duration": 0.792083,
+     "end_time": "2026-07-06T08:27:33.403754",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:32.611671",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Classe BayesianGame definie (Harsanyi, croyances par Bayes)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Representation generale d'un jeu bayesien (Harsanyi).\n",
+    "// Cle du prior : profil de types joint en chaine \"|\".\n",
+    "\n",
+    "public class BayesianGame\n",
+    "{\n",
+    "    public string Name;\n",
+    "    public string[] Players;\n",
+    "    public Dictionary<string, string[]> Types;    // joueur -> types possibles\n",
+    "    public Dictionary<string, double> Prior;       // cle = string.Join(\"|\", profil de types)\n",
+    "    public Dictionary<string, string[]> Actions;   // joueur -> actions possibles\n",
+    "    public Func<string[], string[], double[]> Payoffs; // (types, actions) -> gains par joueur\n",
+    "\n",
+    "    static string Key(params string[] parts) => string.Join(\"|\", parts);\n",
+    "\n",
+    "    public BayesianGame(string name, string[] players, Dictionary<string,string[]> types,\n",
+    "        Dictionary<string,double> prior, Dictionary<string,string[]> actions,\n",
+    "        Func<string[],string[],double[]> payoffs)\n",
+    "    {\n",
+    "        Name = name; Players = players; Types = types; Prior = prior; Actions = actions; Payoffs = payoffs;\n",
+    "        double total = prior.Values.Sum();\n",
+    "        if (Math.Abs(total - 1.0) > 1e-6)\n",
+    "            throw new ArgumentException(\"Le prior doit sommer a 1, obtenu \" + FI(total));\n",
+    "    }\n",
+    "\n",
+    "    // Produit cartesien de plusieurs ensembles de types\n",
+    "    public static IEnumerable<string[]> Cartesian(string[][] pools)\n",
+    "    {\n",
+    "        var result = new List<string[]> { new string[0] };\n",
+    "        foreach (var pool in pools)\n",
+    "        {\n",
+    "            var next = new List<string[]>();\n",
+    "            foreach (var r in result)\n",
+    "                foreach (var p in pool)\n",
+    "                {\n",
+    "                    var arr = new string[r.Length + 1];\n",
+    "                    Array.Copy(r, arr, r.Length); arr[r.Length] = p;\n",
+    "                    next.Add(arr);\n",
+    "                }\n",
+    "            result = next;\n",
+    "        }\n",
+    "        return result;\n",
+    "    }\n",
+    "\n",
+    "    // P(types d'autrui | mon type) par la regle de Bayes\n",
+    "    public double GetConditionalProb(string player, string playerType, string[] otherTypes)\n",
+    "    {\n",
+    "        int pidx = Array.IndexOf(Players, player);\n",
+    "        var full = new List<string>(otherTypes);\n",
+    "        full.Insert(pidx, playerType);\n",
+    "        double num = Prior.GetValueOrDefault(Key(full.ToArray()), 0.0);\n",
+    "\n",
+    "        var others = Players.Where(p => p != player).ToArray();\n",
+    "        double den = 0.0;\n",
+    "        foreach (var combo in Cartesian(others.Select(o => Types[o]).ToArray()))\n",
+    "        {\n",
+    "            var f = new List<string>(combo);\n",
+    "            f.Insert(pidx, playerType);\n",
+    "            den += Prior.GetValueOrDefault(Key(f.ToArray()), 0.0);\n",
+    "        }\n",
+    "        return den == 0 ? 0 : num / den;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "public static void DisplayBayesianGame(BayesianGame g)\n",
+    "{\n",
+    "    var sb = new System.Text.StringBuilder();\n",
+    "    sb.AppendLine(\"Jeu Bayesien : \" + g.Name);\n",
+    "    sb.AppendLine(new string('=', 50));\n",
+    "    sb.AppendLine(\"Joueurs : \" + string.Join(\", \", g.Players));\n",
+    "    sb.AppendLine(\"Types :\");\n",
+    "    foreach (var kv in g.Types)\n",
+    "        sb.AppendLine(\"  \" + kv.Key + \" -> [\" + string.Join(\", \", kv.Value) + \"]\");\n",
+    "    sb.AppendLine(\"Actions :\");\n",
+    "    foreach (var kv in g.Actions)\n",
+    "        sb.AppendLine(\"  \" + kv.Key + \" -> [\" + string.Join(\", \", kv.Value) + \"]\");\n",
+    "    sb.AppendLine(\"Distribution a priori :\");\n",
+    "    foreach (var kv in g.Prior)\n",
+    "        if (kv.Value > 0) sb.AppendLine(\"  P\" + kv.Key + \" = \" + FI(kv.Value, \"F3\"));\n",
+    "    sb.ToString().Display();\n",
+    "}\n",
+    "\n",
+    "\"Classe BayesianGame definie (Harsanyi, croyances par Bayes)\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19bc56b0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003099,
+     "end_time": "2026-07-06T08:27:33.410332",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:33.407233",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Equilibre bayesien de Nash\n",
+    "\n",
+    "### 2.1 Definition\n",
+    "\n",
+    "Un profil de strategies $s = (s_1, \\dots, s_n)$ (ou $s_i : T_i \\to A_i$ mappe le type d'un joueur a une action)\n",
+    "est un **equilibre bayesien de Nash** si, pour chaque joueur $i$ et chaque type $t_i$ :\n",
+    "\n",
+    "$$s_i(t_i) \\in \\arg\\max_{a_i \\in A_i} \\; \\sum_{t_{-i}} P(t_{-i} \\mid t_i) \\cdot u_i\\big(t_i, t_{-i},\\, a_i,\\, s_{-i}(t_{-i})\\big)$$\n",
+    "\n",
+    "### 2.2 Interpretation\n",
+    "\n",
+    "Chaque type joue sa **meilleure reponse** en esperance, **sachant son type** et croyant que les autres\n",
+    "jouent selon le profil. La verification est purement combinatoire (pas de solveur) : on enumere les\n",
+    "deviations alternatives et on exige qu'aucune ne soit strictement profitable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6282277a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:33.418963Z",
+     "iopub.status.busy": "2026-07-06T08:27:33.418522Z",
+     "iopub.status.idle": "2026-07-06T08:27:33.516025Z",
+     "shell.execute_reply": "2026-07-06T08:27:33.515785Z"
+    },
+    "papermill": {
+     "duration": 0.102694,
+     "end_time": "2026-07-06T08:27:33.516112",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:33.413418",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Fonctions definies : ComputeExpectedPayoff, IsBayesianNashEquilibrium"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Gain espere d'un joueur (type donne, action donnee) face aux strategies pures d'autrui.\n",
+    "public static double ComputeExpectedPayoff(BayesianGame game, string player, string playerType,\n",
+    "    string playerAction, Dictionary<string, Dictionary<string,string>> strategies)\n",
+    "{\n",
+    "    int pidx = Array.IndexOf(game.Players, player);\n",
+    "    var others = game.Players.Where(p => p != player).ToArray();\n",
+    "    double expected = 0.0;\n",
+    "    foreach (var otherTypes in BayesianGame.Cartesian(others.Select(o => game.Types[o]).ToArray()))\n",
+    "    {\n",
+    "        double prob = game.GetConditionalProb(player, playerType, otherTypes);\n",
+    "        if (prob == 0) continue;\n",
+    "        var allTypes = new List<string>(otherTypes);\n",
+    "        allTypes.Insert(pidx, playerType);\n",
+    "        var allActions = new List<string>();\n",
+    "        int oi = 0;\n",
+    "        for (int k = 0; k < game.Players.Length; k++)\n",
+    "        {\n",
+    "            if (k == pidx) allActions.Add(playerAction);\n",
+    "            else { allActions.Add(strategies[game.Players[k]][otherTypes[oi]]); oi++; }\n",
+    "        }\n",
+    "        double[] pay = game.Payoffs(allTypes.ToArray(), allActions.ToArray());\n",
+    "        expected += prob * pay[pidx];\n",
+    "    }\n",
+    "    return expected;\n",
+    "}\n",
+    "\n",
+    "// Verifie qu'un profil de strategies pures est un BNE (aucune deviation profitable).\n",
+    "public static bool IsBayesianNashEquilibrium(BayesianGame game,\n",
+    "    Dictionary<string, Dictionary<string,string>> strategies)\n",
+    "{\n",
+    "    foreach (var player in game.Players)\n",
+    "        foreach (var t in game.Types[player])\n",
+    "        {\n",
+    "            string cur = strategies[player][t];\n",
+    "            double uCur = ComputeExpectedPayoff(game, player, t, cur, strategies);\n",
+    "            foreach (var alt in game.Actions[player])\n",
+    "            {\n",
+    "                if (alt == cur) continue;\n",
+    "                double uAlt = ComputeExpectedPayoff(game, player, t, alt, strategies);\n",
+    "                if (uAlt > uCur + 1e-6) return false;\n",
+    "            }\n",
+    "        }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "\"Fonctions definies : ComputeExpectedPayoff, IsBayesianNashEquilibrium\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99eebd78",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004017,
+     "end_time": "2026-07-06T08:27:33.523329",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:33.519312",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Exemple : Bataille des Sexes avec incertitude\n",
+    "\n",
+    "J1 n'a pas d'incertitude (type unique `N`). J2 a deux types possibles :\n",
+    "- type **O** (prefere l'Opera) avec probabilite $p = 0.7$\n",
+    "- type **F** (prefere le Foot) avec probabilite $1-p = 0.3$\n",
+    "\n",
+    "Les gains : si les deux choisissent la meme activite, chacun gagne ; sinon (0,0). Mais le type de J2\n",
+    "change **quelle activite il prefere**. J1 ne sait pas a qui il a affaire : c'est l'essence du jeu bayesien.\n",
+    "\n",
+    "On enumere toutes les strategies pures (J1 : 1 action ; J2 : 1 action par type, soit 2x2 = 4) et on garde\n",
+    "celles qui passent le test de meilleure reponse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7d0d8389",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:33.530631Z",
+     "iopub.status.busy": "2026-07-06T08:27:33.530375Z",
+     "iopub.status.idle": "2026-07-06T08:27:33.737151Z",
+     "shell.execute_reply": "2026-07-06T08:27:33.736784Z"
+    },
+    "papermill": {
+     "duration": 0.21082,
+     "end_time": "2026-07-06T08:27:33.737305",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:33.526485",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Jeu Bayesien : BoS with Uncertainty\r\n",
+       "==================================================\r\n",
+       "Joueurs : J1, J2\r\n",
+       "Types :\r\n",
+       "  J1 -> [N]\r\n",
+       "  J2 -> [O, F]\r\n",
+       "Actions :\r\n",
+       "  J1 -> [O, F]\r\n",
+       "  J2 -> [O, F]\r\n",
+       "Distribution a priori :\r\n",
+       "  PN|O = 0.700\r\n",
+       "  PN|F = 0.300\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Probabilite que J2 prefere Opera : p = 0.70"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Recherche des equilibres bayesiens de Nash\n",
+       "==================================================\n",
+       "\n",
+       "BNE #1:\n",
+       "  J1        joue O\n",
+       "  J2 type O joue O\n",
+       "  J2 type F joue O\n",
+       "  Gains esperes : J1=2.00, J2(O)=1.00, J2(F)=0.00\n",
+       "\n",
+       "BNE #2:\n",
+       "  J1        joue O\n",
+       "  J2 type O joue O\n",
+       "  J2 type F joue F\n",
+       "  Gains esperes : J1=1.40, J2(O)=1.00, J2(F)=0.00\n",
+       "\n",
+       "BNE #3:\n",
+       "  J1        joue F\n",
+       "  J2 type O joue F\n",
+       "  J2 type F joue F\n",
+       "  Gains esperes : J1=1.00, J2(O)=0.00, J2(F)=2.00\n",
+       "\n",
+       "Total : 3 equilibre(s) bayesien(s) de Nash en strategies pures."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Construction de la Bataille des Sexes bayesienne\n",
+    "double pBos = 0.7;\n",
+    "\n",
+    "double[] bosPayoffs(string[] types, string[] actions)\n",
+    "{\n",
+    "    string t2 = types[1];\n",
+    "    string a1 = actions[0], a2 = actions[1];\n",
+    "    if (a1 == a2)\n",
+    "    {\n",
+    "        if (a1 == \"O\")\n",
+    "            return t2 == \"O\" ? new[]{2.0, 1.0} : new[]{2.0, 0.0};\n",
+    "        else\n",
+    "            return t2 == \"F\" ? new[]{1.0, 2.0} : new[]{1.0, 0.0};\n",
+    "    }\n",
+    "    return new[]{0.0, 0.0};\n",
+    "}\n",
+    "\n",
+    "var bosGame = new BayesianGame(\n",
+    "    name: \"BoS with Uncertainty\",\n",
+    "    players: new[]{\"J1\", \"J2\"},\n",
+    "    types: new Dictionary<string,string[]>{{\"J1\",new[]{\"N\"}},{\"J2\",new[]{\"O\",\"F\"}}},\n",
+    "    prior: new Dictionary<string,double>{{\"N|O\", pBos}, {\"N|F\", 1-pBos}},\n",
+    "    actions: new Dictionary<string,string[]>{{\"J1\",new[]{\"O\",\"F\"}},{\"J2\",new[]{\"O\",\"F\"}}},\n",
+    "    payoffs: bosPayoffs\n",
+    ");\n",
+    "\n",
+    "DisplayBayesianGame(bosGame);\n",
+    "(\"Probabilite que J2 prefere Opera : p = \" + FI(pBos, \"F2\")).Display();\n",
+    "\n",
+    "// Enumeration des equilibres bayesiens de Nash\n",
+    "var bneResults = new List<string>();\n",
+    "bneResults.Add(\"Recherche des equilibres bayesiens de Nash\");\n",
+    "bneResults.Add(new string('=', 50));\n",
+    "int nBne = 0;\n",
+    "foreach (var a1 in bosGame.Actions[\"J1\"])\n",
+    "  foreach (var a2O in bosGame.Actions[\"J2\"])\n",
+    "    foreach (var a2F in bosGame.Actions[\"J2\"])\n",
+    "    {\n",
+    "        var strat = new Dictionary<string,Dictionary<string,string>>{\n",
+    "            {\"J1\", new Dictionary<string,string>{{\"N\", a1}}},\n",
+    "            {\"J2\", new Dictionary<string,string>{{\"O\", a2O},{\"F\", a2F}}}};\n",
+    "        if (IsBayesianNashEquilibrium(bosGame, strat))\n",
+    "        {\n",
+    "            nBne++;\n",
+    "            double u1 = ComputeExpectedPayoff(bosGame, \"J1\", \"N\", a1, strat);\n",
+    "            double u2O = ComputeExpectedPayoff(bosGame, \"J2\", \"O\", a2O, strat);\n",
+    "            double u2F = ComputeExpectedPayoff(bosGame, \"J2\", \"F\", a2F, strat);\n",
+    "            bneResults.Add(\"\");\n",
+    "            bneResults.Add(\"BNE #\" + nBne + \":\");\n",
+    "            bneResults.Add(\"  J1        joue \" + a1);\n",
+    "            bneResults.Add(\"  J2 type O joue \" + a2O);\n",
+    "            bneResults.Add(\"  J2 type F joue \" + a2F);\n",
+    "            bneResults.Add(\"  Gains esperes : J1=\" + FI(u1,\"F2\") + \", J2(O)=\" + FI(u2O,\"F2\") + \", J2(F)=\" + FI(u2F,\"F2\"));\n",
+    "        }\n",
+    "    }\n",
+    "bneResults.Add(\"\");\n",
+    "bneResults.Add(\"Total : \" + nBne + \" equilibre(s) bayesien(s) de Nash en strategies pures.\");\n",
+    "string.Join(\"\\n\", bneResults).Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6ee6772",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006401,
+     "end_time": "2026-07-06T08:27:33.750423",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:33.744022",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Cournot avec couts incertains\n",
+    "\n",
+    "### 4.1 Le modele\n",
+    "\n",
+    "Duopole avec demande lineaire $P = a - Q$. Chaque firme $i$ a un cout marginal $c_i \\in \\{c_L, c_H\\}$\n",
+    "tire independamment avec $P(c_L) = \\pi$. La firme connait **son** cout mais ignore celui du rival.\n",
+    "\n",
+    "### 4.2 Strategie d'equilibre (solution analytique)\n",
+    "\n",
+    "Une strategie est une quantite par type : $q_L$ si cout bas, $q_H$ si cout haut. La condition du premier\n",
+    "ordre d'une firme de type $\\theta$ donne :\n",
+    "\n",
+    "$$a - 2 q_\\theta - \\mathbb{E}[q_{-i}] - c_\\theta = 0, \\qquad \\mathbb{E}[q_{-i}] = \\pi q_L + (1-\\pi) q_H$$\n",
+    "\n",
+    "En reinjectant dans les deux CPO (types $L$ et $H$) on obtient le **systeme lineaire 2x2** :\n",
+    "\n",
+    "$$\\begin{pmatrix} 2+\\pi & 1-\\pi \\\\ \\pi & 3-\\pi \\end{pmatrix}\\begin{pmatrix} q_L \\\\ q_H \\end{pmatrix} = \\begin{pmatrix} a-c_L \\\\ a-c_H \\end{pmatrix}$$\n",
+    "\n",
+    "**Resultat algebraique (Prong B)** : le **determinant vaut $(2+\\pi)(3-\\pi) - \\pi(1-\\pi) = 6$**,\n",
+    "**independamment de $\\pi$**. Ce fait est invisible dans le solveur numerique `fsolve` du twin Python.\n",
+    "\n",
+    "$$q_L^* = \\tfrac{(a-c_L)(3-\\pi) - (1-\\pi)(a-c_H)}{6}, \\qquad q_H^* = \\tfrac{(2+\\pi)(a-c_H) - \\pi(a-c_L)}{6}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7b387c6f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:33.766020Z",
+     "iopub.status.busy": "2026-07-06T08:27:33.765511Z",
+     "iopub.status.idle": "2026-07-06T08:27:34.050838Z",
+     "shell.execute_reply": "2026-07-06T08:27:34.050639Z"
+    },
+    "papermill": {
+     "duration": 0.294007,
+     "end_time": "2026-07-06T08:27:34.050935",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:33.756928",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Cournot avec couts incertains (resolution analytique)\r\n",
+       "======================================================\r\n",
+       "Demande : P = 100 - Q    couts : c_L = 10, c_H = 30    P(c_L) = 0.50\r\n",
+       "Determinant du systeme = 6 (= 6, independant du prior)\r\n",
+       "\r\n",
+       "Solution du BNE (par firme) :\r\n",
+       "  q*(c_L) = 31.6667\r\n",
+       "  q*(c_H) = 21.6667\r\n",
+       "  E[q du rival] = 26.6667\r\n",
+       "\r\n",
+       "Scenarios possibles :\r\n",
+       "  scenario      proba      q1      q2    Prix     pi1     pi2\r\n",
+       "  --------------------------------------------------------\r\n",
+       "  (c_L,c_L)      0.25  31.6667 31.6667    36.7   844.4   844.4\r\n",
+       "  (c_L,c_H)      0.25  31.6667 21.6667    46.7  1161.1   361.1\r\n",
+       "  (c_H,c_L)      0.25  21.6667 31.6667    46.7   361.1  1161.1\r\n",
+       "  (c_H,c_H)      0.25  21.6667 21.6667    56.7   577.8   577.8\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Resolution analytique du Cournot bayesien (systeme lineaire 2x2, determinant = 6)\n",
+    "public static (double qL, double qH) SolveCournotBayesian(double a=100, double cL=10, double cH=30, double probL=0.5)\n",
+    "{\n",
+    "    double pi = probL;\n",
+    "    double a11 = 2 + pi, a12 = 1 - pi;\n",
+    "    double a21 = pi,     a22 = 3 - pi;\n",
+    "    double b1 = a - cL,  b2 = a - cH;\n",
+    "    double det = a11*a22 - a12*a21;   // = 6, independant de pi\n",
+    "    double qL = (b1*a22 - a12*b2) / det;\n",
+    "    double qH = (a11*b2 - b1*a21) / det;\n",
+    "    return (qL, qH);\n",
+    "}\n",
+    "\n",
+    "double aC = 100, cL = 10, cH = 30, probL = 0.5;\n",
+    "var (qL, qH) = SolveCournotBayesian(aC, cL, cH, probL);\n",
+    "double Eq = probL*qL + (1-probL)*qH;\n",
+    "double detSys = (2+probL)*(3-probL) - (1-probL)*probL;\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Cournot avec couts incertains (resolution analytique)\");\n",
+    "sb.AppendLine(new string('=', 54));\n",
+    "sb.AppendLine(\"Demande : P = \" + aC + \" - Q    couts : c_L = \" + cL + \", c_H = \" + cH + \"    P(c_L) = \" + FI(probL,\"F2\"));\n",
+    "sb.AppendLine(\"Determinant du systeme = \" + detSys + \" (= 6, independant du prior)\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Solution du BNE (par firme) :\");\n",
+    "sb.AppendLine(\"  q*(c_L) = \" + FI(qL));\n",
+    "sb.AppendLine(\"  q*(c_H) = \" + FI(qH));\n",
+    "sb.AppendLine(\"  E[q du rival] = \" + FI(Eq));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Scenarios possibles :\");\n",
+    "sb.AppendLine(\"  scenario      proba      q1      q2    Prix     pi1     pi2\");\n",
+    "sb.AppendLine(\"  \" + new string('-', 56));\n",
+    "double[] probs = {probL*probL, probL*(1-probL), (1-probL)*probL, (1-probL)*(1-probL)};\n",
+    "(double c1,double c2)[] combos = {(cL,cL),(cL,cH),(cH,cL),(cH,cH)};\n",
+    "for (int k = 0; k < 4; k++)\n",
+    "{\n",
+    "    var (c1,c2) = combos[k];\n",
+    "    double q1 = c1==cL?qL:qH, q2 = c2==cL?qL:qH;\n",
+    "    double P = aC - q1 - q2;\n",
+    "    double pi1 = (P-c1)*q1, pi2 = (P-c2)*q2;\n",
+    "    string scen = \"  (\" + (c1==cL?\"c_L\":\"c_H\") + \",\" + (c2==cL?\"c_L\":\"c_H\") + \")\";\n",
+    "    sb.AppendLine(scen.PadRight(13) + \" \" + FI(probs[k],\"F2\").PadLeft(7) + \" \"\n",
+    "        + FI(q1).PadLeft(8) + FI(q2).PadLeft(8) + FI(P,\"F1\").PadLeft(8)\n",
+    "        + FI(pi1,\"F1\").PadLeft(8) + FI(pi2,\"F1\").PadLeft(8));\n",
+    "}\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "44645bb9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:34.061236Z",
+     "iopub.status.busy": "2026-07-06T08:27:34.060961Z",
+     "iopub.status.idle": "2026-07-06T08:27:34.183490Z",
+     "shell.execute_reply": "2026-07-06T08:27:34.183236Z"
+    },
+    "papermill": {
+     "duration": 0.128225,
+     "end_time": "2026-07-06T08:27:34.183582",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.055357",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Comparaison : Information complete vs incomplete\r\n",
+       "============================================================\r\n",
+       "\r\n",
+       "1. Information complete (Nash classique, q_i = (a - 2 c_i + c_j)/3) :\r\n",
+       "  (c1=c_L, c2=c_L) : q1=30.00, q2=30.00, P=40.0\r\n",
+       "  (c1=c_L, c2=c_H) : q1=36.67, q2=16.67, P=46.7\r\n",
+       "  (c1=c_H, c2=c_H) : q1=23.33, q2=23.33, P=53.3\r\n",
+       "\r\n",
+       "2. Information incomplete (prob_L = 0.5) :\r\n",
+       "  q*(c_L) = 31.6667, q*(c_H) = 21.6667\r\n",
+       "\r\n",
+       "Observations :\r\n",
+       "  - En info incomplete, le type a cout BAS produit PLUS qu'en info complete :\r\n",
+       "    q_L^incomplete = 31.6667 vs q_L^complete(cc_L) = 30.0000.\r\n",
+       "    (E[q_rival]=26.67 < 30 : rival moins agressif en moyenne -> il produit davantage)\r\n",
+       "  - Le type a cout HAUT produit MOINS qu'en info complete :\r\n",
+       "    q_H^incomplete = 21.6667 vs q_H^complete(cc_H) = 23.3333.\r\n",
+       "    (E[q_rival]=26.67 > 23.33 : rival plus agressif en moyenne -> il produit moins)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Comparaison : information complete vs incomplete\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Comparaison : Information complete vs incomplete\");\n",
+    "sb.AppendLine(new string('=', 60));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"1. Information complete (Nash classique, q_i = (a - 2 c_i + c_j)/3) :\");\n",
+    "foreach (var (c1,c2) in new[]{(cL,cL),(cL,cH),(cH,cH)})\n",
+    "{\n",
+    "    double q1 = (aC - 2*c1 + c2)/3, q2 = (aC - 2*c2 + c1)/3;\n",
+    "    double P = aC - q1 - q2;\n",
+    "    sb.AppendLine(\"  (c1=\" + (c1==cL?\"c_L\":\"c_H\") + \", c2=\" + (c2==cL?\"c_L\":\"c_H\")\n",
+    "        + \") : q1=\" + FI(q1,\"F2\") + \", q2=\" + FI(q2,\"F2\") + \", P=\" + FI(P,\"F1\"));\n",
+    "}\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"2. Information incomplete (prob_L = 0.5) :\");\n",
+    "sb.AppendLine(\"  q*(c_L) = \" + FI(qL) + \", q*(c_H) = \" + FI(qH));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Observations :\");\n",
+    "sb.AppendLine(\"  - En info incomplete, le type a cout BAS produit PLUS qu'en info complete :\");\n",
+    "sb.AppendLine(\"    q_L^incomplete = \" + FI(qL) + \" vs q_L^complete(cc_L) = \" + FI((aC - 2*cL + cL)/3) + \".\");\n",
+    "sb.AppendLine(\"    (E[q_rival]=26.67 < 30 : rival moins agressif en moyenne -> il produit davantage)\");\n",
+    "sb.AppendLine(\"  - Le type a cout HAUT produit MOINS qu'en info complete :\");\n",
+    "sb.AppendLine(\"    q_H^incomplete = \" + FI(qH) + \" vs q_H^complete(cc_H) = \" + FI((aC - 2*cH + cH)/3) + \".\");\n",
+    "sb.AppendLine(\"    (E[q_rival]=26.67 > 23.33 : rival plus agressif en moyenne -> il produit moins)\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41372dcd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003364,
+     "end_time": "2026-07-06T08:27:34.190618",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.187254",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Encheres a valeurs privees\n",
+    "\n",
+    "### 5.1 Enchere au premier prix\n",
+    "\n",
+    "$n$ encherisseurs, valuations $v_i \\sim U[0,1]$ independantes (i.i.d.). Chacun fait une offre scellee ;\n",
+    "le plus offrant paie son offre et gagne l'objet. L'equilibre bayesien symetrique est :\n",
+    "\n",
+    "$$b(v) = \\frac{n-1}{n}\\, v$$\n",
+    "\n",
+    "### 5.2 Theoreme d'equivalence du revenu\n",
+    "\n",
+    "Pour des encherisseurs neutres au risque et des valuations i.i.d., **tous les formats d'enchere standard**\n",
+    "(premier prix, second prix/Vickrey, anglais, hollandais) rapportent au vendeur le **meme revenu espere** :\n",
+    "\n",
+    "$$\\mathbb{E}[R] = \\frac{n-1}{n+1}$$\n",
+    "\n",
+    "On verifie numeriquement ce resultat en simulant les deux formats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6efcfcb6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:34.199368Z",
+     "iopub.status.busy": "2026-07-06T08:27:34.199109Z",
+     "iopub.status.idle": "2026-07-06T08:27:34.317567Z",
+     "shell.execute_reply": "2026-07-06T08:27:34.317366Z"
+    },
+    "papermill": {
+     "duration": 0.123568,
+     "end_time": "2026-07-06T08:27:34.317677",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.194109",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Enchere au premier prix avec 2 encherisseurs\r\n",
+       "==================================================\r\n",
+       "Valuations : v_i ~ U[0,1] i.i.d.\r\n",
+       "Strategie d'equilibre : b(v) = 0.500 * v\r\n",
+       "\r\n",
+       "Resultats de simulation (20000 encheres, seed=42) :\r\n",
+       "  Revenue moyen du vendeur : 0.3336  (theorie = 0.3333)\r\n",
+       "  Surplus moyen du gagnant  : 0.3336\r\n",
+       "  Efficacite (bien au plus valuant) : 100.0%\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Simulation Monte-Carlo de l'enchere au premier prix (b(v) = (n-1)/n * v)\n",
+    "public static (double meanRevenue, double meanSurplus, double efficiency, double theoretical)\n",
+    "    AnalyzeFirstPriceAuction(int n, int nSims, int seed=42)\n",
+    "{\n",
+    "    var rng = NewRng(seed);\n",
+    "    double sumRev = 0, sumSurp = 0; int effCount = 0;\n",
+    "    for (int s = 0; s < nSims; s++)\n",
+    "    {\n",
+    "        var values = new double[n];\n",
+    "        for (int i = 0; i < n; i++) values[i] = rng.NextDouble();\n",
+    "        var bids = new double[n];\n",
+    "        double coef = (double)(n-1)/n;\n",
+    "        for (int i = 0; i < n; i++) bids[i] = coef * values[i];\n",
+    "        int winner = 0;\n",
+    "        for (int i = 1; i < n; i++) if (bids[i] > bids[winner]) winner = i;\n",
+    "        int highest = 0;\n",
+    "        for (int i = 1; i < n; i++) if (values[i] > values[highest]) highest = i;\n",
+    "        sumRev += bids[winner];\n",
+    "        sumSurp += values[winner] - bids[winner];\n",
+    "        if (winner == highest) effCount++;\n",
+    "    }\n",
+    "    return (sumRev/nSims, sumSurp/nSims, (double)effCount/nSims, (double)(n-1)/(n+1));\n",
+    "}\n",
+    "\n",
+    "int nBidders = 2, nSim = 20000;\n",
+    "var (rev, surp, eff, theo) = AnalyzeFirstPriceAuction(nBidders, nSim);\n",
+    "double bv2 = (double)(nBidders-1)/nBidders;\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Enchere au premier prix avec \" + nBidders + \" encherisseurs\");\n",
+    "sb.AppendLine(new string('=', 50));\n",
+    "sb.AppendLine(\"Valuations : v_i ~ U[0,1] i.i.d.\");\n",
+    "sb.AppendLine(\"Strategie d'equilibre : b(v) = \" + FI(bv2,\"F3\") + \" * v\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Resultats de simulation (\" + nSim + \" encheres, seed=42) :\");\n",
+    "sb.AppendLine(\"  Revenue moyen du vendeur : \" + FI(rev) + \"  (theorie = \" + FI(theo) + \")\");\n",
+    "sb.AppendLine(\"  Surplus moyen du gagnant  : \" + FI(surp));\n",
+    "sb.AppendLine(\"  Efficacite (bien au plus valuant) : \" + FI(eff*100,\"F1\") + \"%\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cf8cc00b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:34.328073Z",
+     "iopub.status.busy": "2026-07-06T08:27:34.327643Z",
+     "iopub.status.idle": "2026-07-06T08:27:34.560635Z",
+     "shell.execute_reply": "2026-07-06T08:27:34.560344Z"
+    },
+    "papermill": {
+     "duration": 0.238827,
+     "end_time": "2026-07-06T08:27:34.560731",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.321904",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Comparaison : Premier prix vs Second prix (Vickrey)\r\n",
+       "============================================================\r\n",
+       "\r\n",
+       "  n   1er prix    2e prix   Theorie (n-1)/(n+1)\r\n",
+       "  --------------------------------------------\r\n",
+       "   2      0.3336      0.3345      0.3333\r\n",
+       "   3      0.5002      0.4995      0.5000\r\n",
+       "   5      0.6666      0.6660      0.6667\r\n",
+       "  10      0.8177      0.8171      0.8182\r\n",
+       "\r\n",
+       "Theoreme d'equivalence du revenu : les deux formats donnent le MEME\r\n",
+       "revenu espere (encherisseurs neutres au risque, valuations i.i.d.).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Theoreme d'equivalence du revenu : comparaison 1er prix vs 2e prix (Vickrey)\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Comparaison : Premier prix vs Second prix (Vickrey)\");\n",
+    "sb.AppendLine(new string('=', 60));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"  n   1er prix    2e prix   Theorie (n-1)/(n+1)\");\n",
+    "sb.AppendLine(\"  \" + new string('-', 44));\n",
+    "int nSimCmp = 20000;\n",
+    "foreach (var n in new[]{2,3,5,10})\n",
+    "{\n",
+    "    var rng = NewRng(42);\n",
+    "    double sum1 = 0, sum2 = 0;\n",
+    "    for (int s = 0; s < nSimCmp; s++)\n",
+    "    {\n",
+    "        var values = new double[n];\n",
+    "        for (int i = 0; i < n; i++) values[i] = rng.NextDouble();\n",
+    "        double maxBid = double.MinValue;\n",
+    "        for (int i = 0; i < n; i++) { double b = (double)(n-1)/n * values[i]; if (b > maxBid) maxBid = b; }\n",
+    "        sum1 += maxBid;\n",
+    "        Array.Sort(values, (x,y) => y.CompareTo(x));\n",
+    "        sum2 += values[1];\n",
+    "    }\n",
+    "    double r1 = sum1/nSimCmp, r2 = sum2/nSimCmp, rt = (double)(n-1)/(n+1);\n",
+    "    sb.AppendLine(\"  \" + n.ToString().PadLeft(2) + \"  \" + FI(r1).PadLeft(10) + \"  \" + FI(r2).PadLeft(10) + \"  \" + FI(rt).PadLeft(10));\n",
+    "}\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Theoreme d'equivalence du revenu : les deux formats donnent le MEME\");\n",
+    "sb.AppendLine(\"revenu espere (encherisseurs neutres au risque, valuations i.i.d.).\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cbd0add",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006495,
+     "end_time": "2026-07-06T08:27:34.571695",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.565200",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Introduction aux jeux de signalisation (signaling)\n",
+    "\n",
+    "### 6.1 Structure\n",
+    "\n",
+    "Les jeux de signalisation sont des jeux **dynamiques** bayesiens : un **emetteur** (type prive) envoie un\n",
+    "message $m$ ; un **receveur** observe $m$ et choisit une action. Le message peut reveler ou masquer le type.\n",
+    "\n",
+    "### 6.2 Types d'equilibres\n",
+    "\n",
+    "- **Separateurs** : chaque type envoie un message distinct (le message revele le type).\n",
+    "- **Melangeants (pooling)** : tous les types envoient le meme message (le message ne revele rien).\n",
+    "\n",
+    "### Modele de Spence (1973)\n",
+    "\n",
+    "L'education coute plus cher au type `Faible` (cout marginal `cF = 2`) qu'au type `Fort` (`cS = 1`).\n",
+    "Le salaire propose est `w` ; un employeur competitif paye `w = E[productivite | diplome observe]`.\n",
+    "A l'equilibre separatateur, le diplome sert de **signal credible** : seuls les Forts l'acquierent car\n",
+    "le cout pour les Faibles l'emporte le gain salarial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c5733637",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:34.586466Z",
+     "iopub.status.busy": "2026-07-06T08:27:34.586177Z",
+     "iopub.status.idle": "2026-07-06T08:27:34.747680Z",
+     "shell.execute_reply": "2026-07-06T08:27:34.747476Z"
+    },
+    "papermill": {
+     "duration": 0.168461,
+     "end_time": "2026-07-06T08:27:34.747771",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.579310",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Modele de Spence - le diplome comme signal\r\n",
+       "==================================================\r\n",
+       "Salaire diplome = 2.0, salaire non diplome = 1.0\r\n",
+       "Cout education : Faible = 2.0, Fort = 1.0\r\n",
+       "\r\n",
+       "Surplus net du diplome (gain salarial - cout) :\r\n",
+       "  Faible : 1.0 - 2.0 = -1.00 -> n'acquiere PAS\r\n",
+       "  Fort   : 1.0 - 1.0 = 0.00 -> acquiere\r\n",
+       "\r\n",
+       "Equilibre SEPARATEUR credible : le diplome signale le type (seuls les Forts l'acquierent).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Modele de Spence : cout net d'acquerir un diplome selon le type\n",
+    "public static (double surplusF, double surplusS) SpenceSurplus(double wageGrad, double wageNoGrad,\n",
+    "    double costF, double costS)\n",
+    "{\n",
+    "    double gain = wageGrad - wageNoGrad;\n",
+    "    return (gain - costF, gain - costS);\n",
+    "}\n",
+    "\n",
+    "double wGrad = 2.0, wNo = 1.0;\n",
+    "double cF = 2.0, cS = 1.0;\n",
+    "var (surpF, surpS) = SpenceSurplus(wGrad, wNo, cF, cS);\n",
+    "string fa = surpF < 0 ? \"n'acquiere PAS\" : \"acquiere\";\n",
+    "string fo = surpS < 0 ? \"n'acquiere PAS\" : \"acquiere\";\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Modele de Spence - le diplome comme signal\");\n",
+    "sb.AppendLine(new string('=', 50));\n",
+    "sb.AppendLine(\"Salaire diplome = \" + FI(wGrad,\"F1\") + \", salaire non diplome = \" + FI(wNo,\"F1\"));\n",
+    "sb.AppendLine(\"Cout education : Faible = \" + FI(cF,\"F1\") + \", Fort = \" + FI(cS,\"F1\"));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Surplus net du diplome (gain salarial - cout) :\");\n",
+    "sb.AppendLine(\"  Faible : \" + FI(wGrad-wNo,\"F1\") + \" - \" + FI(cF,\"F1\") + \" = \" + FI(surpF,\"F2\") + \" -> \" + fa);\n",
+    "sb.AppendLine(\"  Fort   : \" + FI(wGrad-wNo,\"F1\") + \" - \" + FI(cS,\"F1\") + \" = \" + FI(surpS,\"F2\") + \" -> \" + fo);\n",
+    "sb.AppendLine();\n",
+    "if (surpF < 0 && surpS >= 0)\n",
+    "    sb.AppendLine(\"Equilibre SEPARATEUR credible : le diplome signale le type (seuls les Forts l'acquierent).\");\n",
+    "else\n",
+    "    sb.AppendLine(\"Condition de single-crossing non respectee : pas de separation par le diplome.\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75631f1a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003734,
+     "end_time": "2026-07-06T08:27:34.755966",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.752232",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "> Conformement a la regle C.1, les exercices ci-dessous sont des **stubs** a completer : ils\n",
+    "> s'executent sans erreur (rendent `null` ou affichent un message) et ne bloquent pas le notebook.\n",
+    "> Indice : chaque exercice est une variante d'un exemple ci-dessus."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "054194c7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003783,
+     "end_time": "2026-07-06T08:27:34.763432",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.759649",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Enchere All-Pay\n",
+    "\n",
+    "Dans une enchere **all-pay**, **tous** les encherisseurs paient leur offre (pas seulement le gagnant).\n",
+    "Pour $n=2$ encherisseurs et $v_i \\sim U[0,1]$, la strategie d'equilibre symetrique est $b(v) = v^2/2$.\n",
+    "\n",
+    "**Indice :** dans `AnalyzeFirstPriceAuction`, chaque joueur paie `bids[i]` (pas seulement `bids[winner]`).\n",
+    "Le revenue moyen devient $\\sum_i \\mathbb{E}[b(v_i)]$. Resultat attendu : $\\mathbb{E}[R] = 1/3 \\approx 0{,}333$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1aa7ff2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:34.773557Z",
+     "iopub.status.busy": "2026-07-06T08:27:34.773298Z",
+     "iopub.status.idle": "2026-07-06T08:27:34.880557Z",
+     "shell.execute_reply": "2026-07-06T08:27:34.880376Z"
+    },
+    "papermill": {
+     "duration": 0.113182,
+     "end_time": "2026-07-06T08:27:34.880644",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.767462",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 (All-Pay) a completer. Revenue theorique attendu ~ 0.333."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Enchere All-Pay (a completer)\n",
+    "// TODO etudiant : simuler une enchere all-pay a n=2 encherisseurs avec b(v) = v^2 / 2.\n",
+    "// Etape 1 : tirer v1, v2 ~ U[0,1] ; Etape 2 : bids = v^2 / 2 ; Etape 3 : revenue = bids[0] + bids[1].\n",
+    "// Resultat attendu (theorie) : E[revenue] = 2 * E[v^2/2] = E[v^2] = 1/3 ~ 0.333.\n",
+    "double? allpayRevenue = null;  // TODO etudiant : affecter le revenue moyen simule\n",
+    "\"Exercice 1 (All-Pay) a completer. Revenue theorique attendu ~ 0.333.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5135281a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004079,
+     "end_time": "2026-07-06T08:27:34.889312",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.885233",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Enchere de Vickrey et revelation sincere\n",
+    "\n",
+    "Dans une enchere au **second prix** (Vickrey), le gagnant paie la **deuxieme** offre. On veut verifier\n",
+    "empiriquement que **dire la verite** ($b = v$) est une strategie faiblement dominante.\n",
+    "\n",
+    "**Indice :** pour chaque tirage $(v_1, v_2)$, comparer le surplus de J1 quand $b_1 = v_1$ vs $b_1 = v_1 \\pm \\epsilon$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5c7a652d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:34.899459Z",
+     "iopub.status.busy": "2026-07-06T08:27:34.899206Z",
+     "iopub.status.idle": "2026-07-06T08:27:34.962196Z",
+     "shell.execute_reply": "2026-07-06T08:27:34.962005Z"
+    },
+    "papermill": {
+     "duration": 0.068578,
+     "end_time": "2026-07-06T08:27:34.962286",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.893708",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 (Vickrey) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Enchere de Vickrey (a completer)\n",
+    "// TODO etudiant : verifier que b(v) = v est faiblement dominant au second prix.\n",
+    "// Etape 1 : tirer v1, v2 ~ U[0,1] ; Etape 2 : si v1 > v2, J1 gagne et paie v2 (surplus = v1 - v2).\n",
+    "// Etape 3 : comparer a b1 = v1 + eps et b1 = v1 - eps. Resultat : la verite n'est jamais battue.\n",
+    "double? vickreyAdvantage = null;  // TODO etudiant : difference d'esperance (verite - meilleure deviation)\n",
+    "\"Exercice 2 (Vickrey) a completer.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "717a987d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004446,
+     "end_time": "2026-07-06T08:27:34.971182",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.966736",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Selection adverse (Akerlof, le marche des tacots)\n",
+    "\n",
+    "Des voitures de qualite $q \\sim U[0,1]$. L'acheteur valorise $q$ mais ne l'observe pas ; il offre\n",
+    "$p = \\mathbb{E}[q \\mid \\text{vendu}]$. Le vendeur connait $q$ et vend si $p \\geq q$. A l'equilibre,\n",
+    "seules les voitures $q \\leq p$ sont mises en vente, donc $p = p/2$, soit $p = 0$ : **selection adverse**.\n",
+    "\n",
+    "**Indice :** resoudre $p = \\mathbb{E}[q \\mid q \\leq p] = p/2$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f1934bfd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:34.981612Z",
+     "iopub.status.busy": "2026-07-06T08:27:34.981344Z",
+     "iopub.status.idle": "2026-07-06T08:27:35.072387Z",
+     "shell.execute_reply": "2026-07-06T08:27:35.071620Z"
+    },
+    "papermill": {
+     "duration": 0.097033,
+     "end_time": "2026-07-06T08:27:35.072506",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:34.975473",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 (Akerlof) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Selection adverse d'Akerlof (a completer)\n",
+    "// TODO etudiant : calculer le prix d'equilibre du marche des tacots.\n",
+    "// Etape 1 : poser E[q | q <= p] = p/2 ; Etape 2 : resoudre p = p/2 ; Etape 3 : conclure.\n",
+    "// Resultat attendu : p* = 0 -> le marche s'effondre (seuls les tacots restent).\n",
+    "double? akerlofPrice = null;  // TODO etudiant : prix d'equilibre\n",
+    "\"Exercice 3 (Akerlof) a completer.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0873d129",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005475,
+     "end_time": "2026-07-06T08:27:35.084055",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:35.078580",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : Calcul d'un BNE sur un jeu a 2 types\n",
+    "\n",
+    "Soit un jeu bayesien ou J1 a un type unique et J2 a deux types equiprobables. Construire la matrice de\n",
+    "gain et utiliser `IsBayesianNashEquilibrium` pour **enumerer tous les BNE**.\n",
+    "\n",
+    "**Indice :** reprendre la structure de la cellule BoS mais changer la fonction `payoffs` (par exemple\n",
+    "un jeu Chicken bayesien : type agressif vs prudent)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "67f5bb5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:27:35.096271Z",
+     "iopub.status.busy": "2026-07-06T08:27:35.095791Z",
+     "iopub.status.idle": "2026-07-06T08:27:35.200723Z",
+     "shell.execute_reply": "2026-07-06T08:27:35.200308Z"
+    },
+    "papermill": {
+     "duration": 0.111966,
+     "end_time": "2026-07-06T08:27:35.200853",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:35.088887",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 4 (BNE) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 4 : Enumeration d'un BNE (a completer)\n",
+    "// TODO etudiant : definir un nouveau jeu bayesien (ex. Chicken avec type agressif/prudent)\n",
+    "// et enumerer ses equilibres avec IsBayesianNashEquilibrium.\n",
+    "// Etape 1 : definir chickenPayoffs ; Etape 2 : construire le BayesianGame ; Etape 3 : enumerer.\n",
+    "int? nbBneExo = null;  // TODO etudiant : nombre de BNE trouves\n",
+    "\"Exercice 4 (BNE) a completer.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33c1581b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008402,
+     "end_time": "2026-07-06T08:27:35.215827",
+     "exception": false,
+     "start_time": "2026-07-06T08:27:35.207425",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Resume\n",
+    "\n",
+    "### Points cles\n",
+    "\n",
+    "1. **Harsanyi** ramene l'information incomplete a l'information imparfaite via les **types** et un **prior** commun.\n",
+    "2. Les croyances se deduisent par **regle de Bayes** ; un BNE exige la meilleure reponse en esperance de chaque type.\n",
+    "3. **Cournot bayesien** : le systeme lineaire a un **determinant 6 independant du prior** (resultat algebraique propre au twin C#).\n",
+    "4. **Equivalence du revenu** : tous les formats d'enchere standards rapportent le meme revenu espere.\n",
+    "5. **Signaling** : a l'equilibre separatateur, un signal couteux (diplome) revele crediblement le type.\n",
+    "\n",
+    "### Prochaine etape\n",
+    "\n",
+    "- Forme extensive et equilibre sequentiel (perfect Bayesian equilibrium).\n",
+    "- Mecanismes de revelation (principe de revelation, Vickrey-Clarke-Groves).\n",
+    "\n",
+    "## References academiques\n",
+    "\n",
+    "- Harsanyi (1967), *Games with Incomplete Information Played by Bayesian Players*.\n",
+    "- Spence (1973), *Job Market Signaling*.\n",
+    "- Myerson (1981), *Optimal Auction Design*.\n",
+    "- Krishna (2009), *Auction Theory*, Academic Press.\n",
+    "\n",
+    "> Twin C# dans le cadre du marathon de parite .NET/Python (#4956). Complementarite #3801 Prong B :\n",
+    "> Cournot analytique (determinant = 6) la ou le twin Python utilise `scipy.optimize.fsolve`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 9.942034,
+   "end_time": "2026-07-06T08:27:35.468655",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks\\GameTheory\\GameTheory-11-BayesianGames-Csharp.ipynb",
+   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\gt11_csharp_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T08:27:25.526621",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -137,6 +137,7 @@ flowchart TD
 | 9 | [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb) | Python | Induction arrière, mille-pattes, escalade | 55 min |
 | 10 | [GameTheory-10-ForwardInduction-SPE](GameTheory-10-ForwardInduction-SPE.ipynb) | Python | Induction avant, SPE, menaces crédibles | 60 min |
 | 11 | [GameTheory-11-BayesianGames](GameTheory-11-BayesianGames.ipynb) | Python | Jeux bayésiens, information incomplète | 55 min |
+| 11 (C#) | [GameTheory-11-BayesianGames-Csharp](GameTheory-11-BayesianGames-Csharp.ipynb) | C# (.NET) | Twin .NET de 11 (marathon #4956) : jeux bayésiens from-scratch (BCL seule), Cournot résolu analytiquement (déterminant = 6, indépendant du prior) | 65 min |
 | 11b | [GameTheory-11b-Lean-BayesianGamesExt](GameTheory-11b-Lean-BayesianGamesExt.ipynb) | Lean 4 | Companion natif : théorème de Vickrey (enchère au second prix) prouvé 0-sorry dans le lake `lean_game_defs_ext` (module Bayesian, sans Mathlib) | 50 min |
 | 12 | [GameTheory-12-ReputationGames](GameTheory-12-ReputationGames.ipynb) | Python | Jeux de réputation, signaling | 50 min |
 
@@ -535,6 +536,7 @@ GameTheory/
 ├── GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
 ├── GameTheory-8c-CombinatorialGames-Python.ipynb
 ├── GameTheory-15c-CooperativeGames-Python.ipynb
+├── GameTheory-11-BayesianGames-Csharp.ipynb                     # Twin .NET/C# (marathon #4956, Prong B)
 ├── SocialChoice/                                                   # Sous-série Choix Social
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb
 │   ├── 02-Lean-SocialChoice-Formal.ipynb


### PR DESCRIPTION
## Résumé

**Twin C#** de [GameTheory-11-BayesianGames](MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb) (Python + numpy/scipy). **Premier twin C# de toute la série GameTheory** (0 jumeau .NET jusqu'ici : la série était Python + Lean uniquement). Marathon de parité #4956, **rotation de famille Rule 6** (c.41/c.43 = Planners ; c.44 = GameTheory).

## Algorithme / démarche

- **BayesianGame** (Harsanyi) from-scratch : types, prior commun, fonction de gain `(types, actions) -> gains`.
- **Croyances par Bayes** : `GetConditionalProb` = P(types d'autrui | mon type) via produit cartésien des types.
- **Équilibre bayesien de Nash (BNE)** : `IsBayesianNashEquilibrium` vérifie (sans solveur) qu'aucune déviation n'est profitable en espérance pour chaque type.
- **BoS avec incertitude** : énumère les 8 stratégies pures, trouve 3 BNE.
- **Cournot à couts incertains** : résolu **analytiquement** (système linéaire 2×2).
- **Enchère au premier prix** : simulation Monte-Carlo (20 000 tirages, RNG seed 42) + équivalence du revenu 1er vs 2e prix.
- **Modèle de Spence** : équilibre séparateur (diplôme comme signal crédible).

## Complémentarité (#3801 Prong B)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python (numpy + scipy) | `scipy.optimize.fsolve` (résolution numérique) | explorer numériquement |
| **This (.NET BCL seule)** | résolution **analytique** from-scratch | **comprendre** la structure algebraique |

**Le point cle (Prong B discovery)** : le système linéaire de Cournot a un **déterminant qui vaut exactement 6, indépendamment du prior π** : `(2+π)(3-π) - π(1-π) = 6`. Ce fait algebraique est **invisible** dans le solveur numérique `fsolve` du twin Python — le twin C# le rend explicite. De plus, la vérification de BNE est **combinatoire pure** (pas de solveur), ce qui force à comprendre la mécanique de meilleure réponse en espérance.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **13/13 cellules code `execution_count` 1-13, 0 erreur**. Outputs vérifiés **firsthand** :

- **BoS bayesien** : 3 BNE en stratégies pures (J1=O/J2O=O/J2F=O ; J1=O/J2O=O/J2F=F séparateur ; J1=F/J2O=F/J2F=F) ✓
- **Cournot analytique** : q\*(c_L)=31.6667, q\*(c_H)=21.6667 — déterminant = 6 ✓ (vérifié : (2.5)(2.5)−(0.5)(0.5)=6)
- **Équivalence du revenu** : 1er prix vs 2e prix pour n=2,3,5,10 → revenus quasi-identiques, correspondent à (n−1)/(n+1) ✓
  - n=2: 0.3336/0.3345/0.3333 ; n=10: 0.8177/0.8171/0.8182
- **Spence** : séparateur crédible (Faible surplus=−1 n'acquiert pas, Fort surplus=0 acquiert) ✓

## Correction d'une interprétation économique

En dérivant analytiquement Cournot, j'ai trouvé que la prose du twin Python (et ma première version) était **inversée** :
- Le type à cout **BAS** produit **PLUS** en info incomplète (q_L=31.67 > 30.0) — car E[q_rival]=26.67 < 30 (rival moins agressif en moyenne).
- Le type à cout **HAUT** produit **MOINS** (q_H=21.67 < 23.33) — car E[q_rival]=26.67 > 23.33 (rival plus agressif en moyenne).

Ce twin C# énonce la **bonne** intuition, dérivée des nombres — valeur ajoutée du twin analytique.

## Bug G.1 self-corrected (c.44)

**Nouveau bug .NET Interactive headless** (à documenter dans le topic file marathon) : les **littéraux chaîne quotés à l'intérieur d'un trou d'interpolation** `$"...{FI(x, "F2")}..."` ou `$"...{string.Join(", ", v)}..."` font échouer le parseur .NET Interactive (CS8076/CS1039 — le séparateur virgule du littéral interne est confondu avec un spec de format, et les `\"` échappés ne resolvnt pas le problème). **Fix** : utiliser la **concaténation `+`** pour toute interpolation contenant un appel de méthode avec un littéral chaîne en argument ; réserver l'interpolation `$"{var}"` aux **variables simples uniquement**.

## SOTA-OK (#3801)

Problème non-trivial (Prong B) : jeux bayésiens multi-types + Cournot + enchères + signaling — exercent réellement la mécanique bayesienne (croyances, BNE, Harsanyi), pas un cas dégénéré. BCL .NET seule, 0 NuGet.

## Exercices (#2161)

4 stubs C.1-conformes : (1) enchère All-Pay, (2) Vickrey/révélation sincère, (3) sélection adverse d'Akerlof, (4) énumération de BNE sur Chicken bayesien.

## Scope

Atomique : 1 notebook (26 cells, 13 code) + README table+tree (2 entrées). Self-contained (BCL seule). CATALOG-STATUS + fichiers catalogue byte-identical (R1, cron reconciliera les comptes).

## Marathon #4956

GameTheory rejoint le marathon de parité. **Premier twin C# GameTheory** (série était Python+Lean uniquement). Suite naturelle : GameTheory-2-NormalForm-Csharp (déjà mergé #5510/#5511) → **GameTheory-11-Bayesian (this)**. Tranches futures possibles : GT-9 Backward Induction C#, GT-12 Reputation/Signaling C#.

See #4956. Revue souhaitée : po-2025 ou ai-01.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
