### PR TITLE
feat(gametheory): GameTheory-4c-NashExistence-Csharp — .NET twin (Brouwer fixed-point)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
@@ -1,0 +1,3872 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7e785bc4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002465,
+     "end_time": "2026-07-06T08:47:50.360737+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:50.358272+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory 4c - Théorème d'Existence de Nash (C#)\n",
+    "\n",
+    "> **Jumeau C#** du notebook [GameTheory-4c-NashExistence-Python.ipynb](GameTheory-4c-NashExistence-Python.ipynb).\n",
+    "> Marathon parité .NET ⇄ Python (#4956), EPIC #3801 Prong B.\n",
+    "> Théorème de Brouwer (point fixe) ⇒ existence d'un équilibre de Nash en stratégies mixtes, implémenté **from-scratch en C# pur** (pas de lib externe, visualisations en ASCII).\n",
+    "\n",
+    "**Navigation** : [<< 4-NashEquilibrium](GameTheory-4-NashEquilibrium.ipynb) | [4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) | [Twin Python](GameTheory-4c-NashExistence-Python.ipynb) | [Index](README.md)\n",
+    "\n",
+    "**Kernel** : .NET 9.0 + dotnet-interactive (`.net-csharp`)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Ce notebook C# accompagne le notebook Lean 4b (théorème formel). Il fournit :\n",
+    "\n",
+    "1. **Illustrations numériques** du théorème de Brouwer (recherche de points fixes par itération)\n",
+    "2. **Algorithmes** de points fixes 1D et sur le simplexe\n",
+    "3. **Exemple concret** : Matching Pennies, meilleure réponse perturbée\n",
+    "4. **Dynamique de meilleure réponse** convergeant vers l'équilibre de Nash\n",
+    "\n",
+    "### Pourquoi le théorème de Brouwer implique Nash\n",
+    "\n",
+    "Le théorème de Brouwer dit que toute fonction continue `f : Δ → Δ` d'un convexe compact\n",
+    "(le simplexe `Δ`) dans lui-même admet un point fixe `x* = f(x*)`. Nash (1950) montre que\n",
+    "la **meilleure réponse** d'un joueur, vue comme correspondance multivaluée, peut être\n",
+    "transformée en une fonction continue sur le simplexe des profils mixtes — dont le point\n",
+    "fixe est un équilibre de Nash. On l'illustre ici numériquement.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Implémenter** la recherche de point fixe par itération (1D et simplexe).\n",
+    "2. **Projeter** sur le simplexe (clipping + normalisation).\n",
+    "3. **Calculer** le gain espéré d'un profil mixte contre une matrice de gains.\n",
+    "4. **Définir** la meilleure réponse perturbée (regret matching) — continue, garant de Brouwer.\n",
+    "5. **Démontrer** la convergence vers l'équilibre de Matching Pennies `(0.5, 0.5)`.\n",
+    "\n",
+    "### Prérequis\n",
+    "- Notions de théorie des jeux (stratégie mixte, matrice de gains, meilleure réponse).\n",
+    "- .NET 9.0 + dotnet-interactive.\n",
+    "- Avoir suivi [GameTheory-4-NashEquilibrium](GameTheory-4-NashEquilibrium.ipynb).\n",
+    "\n",
+    "### Durée estimée : 45 minutes\n",
+    "\n",
+    "### Références\n",
+    "- Nash, J. *Equilibrium Points in n-Person Games* (1950).\n",
+    "- Brouwer, L. E. J. *Über Abbildung von Mannigfaltigkeiten* (1911).\n",
+    "- Notebook Python : [GameTheory-4c-NashExistence-Python.ipynb](GameTheory-4c-NashExistence-Python.ipynb).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0dcaa7ae",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001714,
+     "end_time": "2026-07-06T08:47:50.367344+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:50.365630+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Point fixe en dimension 1\n",
+    "\n",
+    "Un **point fixe** de `f` est `x*` tel que `f(x*) = x*`. On le cherche par itération :\n",
+    "`x_{n+1} = f(x_n)`. Si `f` est contractante, la suite converge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5c88a5ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:47:50.382630Z",
+     "iopub.status.busy": "2026-07-06T08:47:50.374815Z",
+     "iopub.status.idle": "2026-07-06T08:47:52.383987Z",
+     "shell.execute_reply": "2026-07-06T08:47:52.379999Z"
+    },
+    "papermill": {
+     "duration": 2.015516,
+     "end_time": "2026-07-06T08:47:52.384511+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:50.368995+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1391188.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Point fixe trouve   : 1,0000000000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification f(x*)  : 1,0000000000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iterations          : 6\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|f(x*) - x*|        : 1,11E-015\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Linq;\n",
+    "\n",
+    "// Recherche d'un point fixe par iteration, 1D.\n",
+    "(double fixedPoint, List<double> history) FindFixedPoint1D(Func<double,double> f,\n",
+    "        double x0 = 0.5, double tol = 1e-6, int maxIter = 100) {\n",
+    "    double x = x0;\n",
+    "    var history = new List<double>{x};\n",
+    "    for (int i = 0; i < maxIter; i++) {\n",
+    "        double xNew = f(x);\n",
+    "        history.Add(xNew);\n",
+    "        if (Math.Abs(xNew - x) < tol) return (xNew, history);\n",
+    "        x = xNew;\n",
+    "    }\n",
+    "    return (x, history);\n",
+    "}\n",
+    "\n",
+    "// Exemple : f(x) = 0.5 * (x + 1/x) converge vers 1 (moyenne babylonienne).\n",
+    "Func<double,double> f = x => 0.5 * (x + 1.0 / Math.Max(x, 0.01));\n",
+    "var (fixedPt, history) = FindFixedPoint1D(f, x0: 2.0);\n",
+    "Console.WriteLine($\"Point fixe trouve   : {fixedPt:F10}\");\n",
+    "Console.WriteLine($\"Verification f(x*)  : {f(fixedPt):F10}\");\n",
+    "Console.WriteLine($\"Iterations          : {history.Count}\");\n",
+    "Console.WriteLine($\"|f(x*) - x*|        : {Math.Abs(f(fixedPt) - fixedPt):E2}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96beab94",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001897,
+     "end_time": "2026-07-06T08:47:52.388833+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:52.386936+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Point fixe sur le simplexe\n",
+    "\n",
+    "Le **simplexe** `Δ = {x ∈ ℝⁿ : x_i ≥ 0, Σ x_i = 1}` est convexe compact. On projette\n",
+    "après chaque itération : clip des négatifs + normalisation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6f5c939e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:47:52.393412Z",
+     "iopub.status.busy": "2026-07-06T08:47:52.393244Z",
+     "iopub.status.idle": "2026-07-06T08:47:52.596290Z",
+     "shell.execute_reply": "2026-07-06T08:47:52.596390Z"
+    },
+    "papermill": {
+     "duration": 0.20584,
+     "end_time": "2026-07-06T08:47:52.596472+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:52.390632+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Point fixe 2D : [0,5000, 0,5000]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Somme         : 1,000000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iterations    : 106\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(14,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Projection sur le simplexe : clip negatifs + normalisation.\n",
+    "double[] ProjectSimplex(double[] x) {\n",
+    "    var proj = x.Select(v => Math.Max(0, v)).ToArray();\n",
+    "    double s = proj.Sum();\n",
+    "    if (s < 1e-12) return Enumerable.Range(0, x.Length).Select(_ => 1.0 / x.Length).ToArray();\n",
+    "    return proj.Select(v => v / s).ToArray();\n",
+    "}\n",
+    "\n",
+    "// Norme euclidienne.\n",
+    "double Norm(double[] v) => Math.Sqrt(v.Select(a => a * a).Sum());\n",
+    "\n",
+    "// Recherche de point fixe sur le simplexe (dimension n-1 implicite via x.Length).\n",
+    "(double[] fixedPoint, List<double[]> history) FindFixedPointSimplex(\n",
+    "        Func<double[],double[]> f, double[]? x0 = null, int n = 2,\n",
+    "        double tol = 1e-6, int maxIter = 1000) {\n",
+    "    double[] x = (double[])(x0 ?? Enumerable.Range(0, n).Select(_ => 1.0 / n).ToArray()).Clone();\n",
+    "    var history = new List<double[]> { (double[])x.Clone() };\n",
+    "    for (int i = 0; i < maxIter; i++) {\n",
+    "        double[] xNew = ProjectSimplex(f(x));\n",
+    "        history.Add((double[])xNew.Clone());\n",
+    "        if (Norm(Sub(xNew, x)) < tol) return (xNew, history);\n",
+    "        x = xNew;\n",
+    "    }\n",
+    "    return (x, history);\n",
+    "}\n",
+    "double[] Sub(double[] a, double[] b) => a.Zip(b, (u, v) => u - v).ToArray();\n",
+    "string FmtV(double[] v) => \"[\" + string.Join(\", \", v.Select(x => x.ToString(\"F4\"))) + \"]\";\n",
+    "\n",
+    "// Exemple : contraction vers (0.5, 0.5).\n",
+    "double[] center = {0.5, 0.5};\n",
+    "Func<double[],double[]> exampleMap = x => x.Zip(center, (u, c) => 0.9 * u + 0.1 * c).ToArray();\n",
+    "var (fixed2d, hist2d) = FindFixedPointSimplex(exampleMap, x0: new[]{0.1, 0.9});\n",
+    "Console.WriteLine($\"Point fixe 2D : {FmtV(fixed2d)}\");\n",
+    "Console.WriteLine($\"Somme         : {fixed2d.Sum():F6}\");\n",
+    "Console.WriteLine($\"Iterations    : {hist2d.Count}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1705618a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003498,
+     "end_time": "2026-07-06T08:47:52.603318+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:52.599820+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Matching Pennies — matrice de gains et meilleure réponse\n",
+    "\n",
+    "**Matching Pennies** : le joueur 1 veut *matcher* (même face), le joueur 2 veut\n",
+    "*mismatcher*. L'équilibre de Nash est le profil mixte uniforme `(0.5, 0.5)`.\n",
+    "\n",
+    "| | Pile (J2) | Face (J2) |\n",
+    "|---|---|---|\n",
+    "| **Pile (J1)** | (+1, −1) | (−1, +1) |\n",
+    "| **Face (J1)** | (−1, +1) | (+1, −1) |\n",
+    "\n",
+    "La **meilleure réponse perturbée** (regret matching) ajoute du poids aux actions dont\n",
+    "le regret est positif — c'est une fonction **continue** du profil, donc Brouwer s'applique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "07fa3394",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:47:52.634473Z",
+     "iopub.status.busy": "2026-07-06T08:47:52.609737Z",
+     "iopub.status.idle": "2026-07-06T08:47:52.749459Z",
+     "shell.execute_reply": "2026-07-06T08:47:52.749331Z"
+    },
+    "papermill": {
+     "duration": 0.14307,
+     "end_time": "2026-07-06T08:47:52.749522+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:52.606452+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MATCHING PENNIES - Point fixe\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Strategie initiale     : [0,5000, 0,5000]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gain espere J1 (U1)    : 0,0000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gain espere J2 (U2)    : 0,0000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BR perturbee J1        : [0,5000, 0,5000]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Est un point fixe ?    : True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Matrices de gains (2x2). U1 = joueur 1 (match), U2 = joueur 2 (mismatch).\n",
+    "double[,] U1 = {{1, -1}, {-1, 1}};\n",
+    "double[,] U2 = {{-1, 1}, {1, -1}};\n",
+    "\n",
+    "// Gain espere : sigma1 . U . sigma2\n",
+    "double ExpectedPayoff(double[] sigma1, double[] sigma2, double[,] U) {\n",
+    "    double s = 0;\n",
+    "    for (int i = 0; i < sigma1.Length; i++)\n",
+    "        for (int j = 0; j < sigma2.Length; j++)\n",
+    "            s += sigma1[i] * U[i, j] * sigma2[j];\n",
+    "    return s;\n",
+    "}\n",
+    "\n",
+    "// Meilleure reponse perturbee (regret matching, continue).\n",
+    "double[] PerturbedBR(double[] sigma, double[,] U, double epsilon = 0.1) {\n",
+    "    double current = ExpectedPayoff(sigma, sigma, U);\n",
+    "    var regrets = new double[sigma.Length];\n",
+    "    for (int a = 0; a < sigma.Length; a++) {\n",
+    "        var pure = new double[sigma.Length]; pure[a] = 1.0;\n",
+    "        double gainA = ExpectedPayoff(pure, sigma, U);\n",
+    "        regrets[a] = Math.Max(0, gainA - current);\n",
+    "    }\n",
+    "    var perturbed = sigma.Zip(regrets, (s, r) => s + epsilon * r).ToArray();\n",
+    "    return ProjectSimplex(perturbed);\n",
+    "}\n",
+    "\n",
+    "double[] sigmaUniform = {0.5, 0.5};\n",
+    "Console.WriteLine(new string('=', 50));\n",
+    "Console.WriteLine(\"MATCHING PENNIES - Point fixe\");\n",
+    "Console.WriteLine(new string('=', 50));\n",
+    "Console.WriteLine($\"Strategie initiale     : {FmtV(sigmaUniform)}\");\n",
+    "Console.WriteLine($\"Gain espere J1 (U1)    : {ExpectedPayoff(sigmaUniform, sigmaUniform, U1):F4}\");\n",
+    "Console.WriteLine($\"Gain espere J2 (U2)    : {ExpectedPayoff(sigmaUniform, sigmaUniform, U2):F4}\");\n",
+    "Console.WriteLine();\n",
+    "var br1 = PerturbedBR(sigmaUniform, U1);\n",
+    "Console.WriteLine($\"BR perturbee J1        : {FmtV(br1)}\");\n",
+    "bool isFixed = sigmaUniform.Zip(br1, (a, b) => Math.Abs(a - b) < 1e-6).All(t => t);\n",
+    "Console.WriteLine($\"Est un point fixe ?    : {isFixed}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12ada44b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002442,
+     "end_time": "2026-07-06T08:47:52.756117+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:52.753675+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Dynamique de meilleure réponse — convergence vers Nash\n",
+    "\n",
+    "On itère la dynamique `σ_{n+1} = ½·(BR₁(σ_n) + BR₂(σ_n))` depuis plusieurs points de\n",
+    "départ. Tous convergent vers `(0.5, 0.5)` = équilibre de Nash de Matching Pennies.\n",
+    "(Le notebook Python trace la trajectoire en matplotlib ; ici on l'affiche en table.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "32a28564",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:47:52.764630Z",
+     "iopub.status.busy": "2026-07-06T08:47:52.764457Z",
+     "iopub.status.idle": "2026-07-06T08:47:52.855660Z",
+     "shell.execute_reply": "2026-07-06T08:47:52.855508Z"
+    },
+    "papermill": {
+     "duration": 0.094771,
+     "end_time": "2026-07-06T08:47:52.855765+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:52.760994+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Convergence vers Nash (0.5, 0.5) depuis 3 departs :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Depart         | Apres 5 it     | Apres 20 it    | Apres 50 it   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0,9000, 0,1000] | [0,6507, 0,3493] | [0,5531, 0,4469] | [0,5233, 0,4767]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0,1000, 0,9000] | [0,3493, 0,6507] | [0,4469, 0,5531] | [0,4767, 0,5233]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0,7000, 0,3000] | [0,6098, 0,3902] | [0,5470, 0,4530] | [0,5220, 0,4780]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> Tous les points de depart convergent vers (0.5, 0.5) = equilibre de Nash.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> C'est l'illustration numerique du theoreme de Brouwer :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> la dynamique continue BR a un point fixe sur le simplexe.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Dynamique de meilleure reponse (moyenne des BR des 2 joueurs).\n",
+    "double[] NashDynamicsStep(double[] sigma, double[,] u1, double[,] u2, double epsilon = 0.2) {\n",
+    "    var br1 = PerturbedBR(sigma, u1, epsilon);\n",
+    "    var br2 = PerturbedBR(sigma, u2, epsilon);\n",
+    "    return br1.Zip(br2, (a, b) => 0.5 * (a + b)).ToArray();\n",
+    "}\n",
+    "\n",
+    "double[][] startingPoints = {\n",
+    "    new[]{0.9, 0.1}, new[]{0.1, 0.9}, new[]{0.7, 0.3},\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine(\"Convergence vers Nash (0.5, 0.5) depuis 3 departs :\");\n",
+    "Console.WriteLine($\"{\"Depart\",-14} | {\"Apres 5 it\",-14} | {\"Apres 20 it\",-14} | {\"Apres 50 it\",-14}\");\n",
+    "Console.WriteLine(new string('-', 66));\n",
+    "foreach (var s0 in startingPoints) {\n",
+    "    double[] s = (double[])s0.Clone();\n",
+    "    var t5 = s; var t20 = s; var t50 = s;\n",
+    "    for (int i = 1; i <= 50; i++) {\n",
+    "        s = NashDynamicsStep(s, U1, U2);\n",
+    "        if (i == 5) t5 = (double[])s.Clone();\n",
+    "        if (i == 20) t20 = (double[])s.Clone();\n",
+    "        if (i == 50) t50 = (double[])s.Clone();\n",
+    "    }\n",
+    "    Console.WriteLine($\"{FmtV(s0),-14} | {FmtV(t5),-14} | {FmtV(t20),-14} | {FmtV(t50),-14}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\">>> Tous les points de depart convergent vers (0.5, 0.5) = equilibre de Nash.\");\n",
+    "Console.WriteLine(\">>> C'est l'illustration numerique du theoreme de Brouwer :\");\n",
+    "Console.WriteLine(\">>> la dynamique continue BR a un point fixe sur le simplexe.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de39c7a4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004347,
+     "end_time": "2026-07-06T08:47:52.864020+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:52.859673+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Visualisation ASCII de la trajectoire\n",
+    "\n",
+    "Le notebook Python trace la trajectoire 2D sur le simplexe `[P(Heads), P(Tails)]`.\n",
+    "En C# pur (sans matplotlib), on visualise la convergence avec une grille ASCII : chaque\n",
+    "`#` est un pas de la trajectoire, `N` est le Nash, `D` le départ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "19a8f19a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:47:52.875242Z",
+     "iopub.status.busy": "2026-07-06T08:47:52.874990Z",
+     "iopub.status.idle": "2026-07-06T08:47:53.092612Z",
+     "shell.execute_reply": "2026-07-06T08:47:52.984695Z"
+    },
+    "papermill": {
+     "duration": 0.222308,
+     "end_time": "2026-07-06T08:47:53.092719+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:52.870411+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Depart [0,9000, 0,1000] -> Nash (0.5, 0.5)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(Tails)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1,0 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,9 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,8 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,5 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,4 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,2 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,1 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "D"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,0 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    0.0          1.0  P(Heads)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    D=depart  #=trajectoire  N=Nash(0.5,0.5)\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Depart [0,1000, 0,9000] -> Nash (0.5, 0.5)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P(Tails)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1,0 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,9 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "D"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,8 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,6 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,5 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,4 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,2 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,1 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0,0 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    0.0          1.0  P(Heads)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    D=depart  #=trajectoire  N=Nash(0.5,0.5)\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Visualisation ASCII de la trajectoire sur le simplexe 2D.\n",
+    "void DrawTrajectoryASCII(double[] start) {\n",
+    "    const int W = 21, H = 9;  // grille W x H\n",
+    "    var grid = new char[H, W];\n",
+    "    for (int r = 0; r < H; r++) for (int c = 0; c < W; c++) grid[r, c] = '.';\n",
+    "    // Axes : x = P(Heads) [0,1], y = P(Tails) [0,1].\n",
+    "    int Col(double x) => Math.Clamp((int)Math.Round(x * (W - 1)), 0, W - 1);\n",
+    "    int Row(double y) => Math.Clamp(H - 1 - (int)Math.Round(y * (H - 1)), 0, H - 1);\n",
+    "    // Nash (0.5, 0.5)\n",
+    "    grid[Row(0.5), Col(0.5)] = 'N';\n",
+    "    // Depart\n",
+    "    grid[Row(start[1]), Col(start[0])] = 'D';\n",
+    "    // Trajectoire\n",
+    "    double[] s = (double[])start.Clone();\n",
+    "    for (int i = 0; i < 50; i++) {\n",
+    "        s = NashDynamicsStep(s, U1, U2);\n",
+    "        int r = Row(s[1]), c = Col(s[0]);\n",
+    "        if (grid[r, c] == '.') grid[r, c] = '#';\n",
+    "    }\n",
+    "    grid[Row(0.5), Col(0.5)] = 'N';  // re-stamp Nash par-dessus\n",
+    "    Console.WriteLine($\"Depart {FmtV(start)} -> Nash (0.5, 0.5)\");\n",
+    "    Console.WriteLine($\"  P(Tails)\");\n",
+    "    for (int r = 0; r < H; r++) {\n",
+    "        Console.Write($\"  {1.0 - (double)r/(H-1):F1} \");\n",
+    "        for (int c = 0; c < W; c++) Console.Write(grid[r, c]);\n",
+    "        Console.WriteLine();\n",
+    "    }\n",
+    "    Console.WriteLine($\"    0.0{\" \".PadLeft(W/2)}1.0  P(Heads)\");\n",
+    "    Console.WriteLine(\"    D=depart  #=trajectoire  N=Nash(0.5,0.5)\\n\");\n",
+    "}\n",
+    "\n",
+    "DrawTrajectoryASCII(new[]{0.9, 0.1});\n",
+    "DrawTrajectoryASCII(new[]{0.1, 0.9});\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dab67d51",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017808,
+     "end_time": "2026-07-06T08:47:53.128395+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:53.110587+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : équilibre de Chicken (Guerre froide)\n",
+    "\n",
+    "Appliquez `FindFixedPointSimplex` au jeu **Chicken** ( Hawk-Dove) :\n",
+    "\n",
+    "| | Dove (J2) | Hawk (J2) |\n",
+    "|---|---|---|\n",
+    "| **Dove (J1)** | (3, 3) | (1, 4) |\n",
+    "| **Hawk (J1)** | (4, 1) | (0, 0) |\n",
+    "\n",
+    "1. Définissez les matrices `U1_chicken` / `U2_chicken`.\n",
+    "2. Itérez la dynamique `NashDynamicsStep` depuis `(0.9, 0.1)`.\n",
+    "3. Vérifiez que la limite est l'équilibre mixte `(1/3, 2/3)` (Dove, Hawk).\n",
+    "\n",
+    "**Indice** : Chicken a **deux** équilibres purs `(Hawk, Dove)` et `(Dove, Hawk)` plus\n",
+    "un mixte. La dynamique perturbée converge vers le mixte car elle ne saute jamais\n",
+    "exactement aux stratégies pures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "646cc3e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:47:53.166846Z",
+     "iopub.status.busy": "2026-07-06T08:47:53.166526Z",
+     "iopub.status.idle": "2026-07-06T08:47:53.208006Z",
+     "shell.execute_reply": "2026-07-06T08:47:53.207739Z"
+    },
+    "papermill": {
+     "duration": 0.06181,
+     "end_time": "2026-07-06T08:47:53.208118+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:53.146308+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice Chicken a completer (voir indice ci-dessus).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : equilibre mixte de Chicken\n",
+    "// double[,] U1_chicken = {{3, 1}, {4, 0}};\n",
+    "// double[,] U2_chicken = {{3, 4}, {1, 0}};\n",
+    "// TODO etudiant : iterer NashDynamicsStep depuis (0.9, 0.1) sur ces matrices\n",
+    "//                 et verifier la limite (1/3, 2/3).\n",
+    "Console.WriteLine(\"Exercice Chicken a completer (voir indice ci-dessus).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06825320",
+   "metadata": {
+    "papermill": {
+     "duration": 0.018886,
+     "end_time": "2026-07-06T08:47:53.246397+00:00",
+     "exception": false,
+     "start_time": "2026-07-06T08:47:53.227511+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Bilan\n",
+    "\n",
+    "Ce notebook a présenté le **théorème d'existence de Nash** via Brouwer, jumeau C# du\n",
+    "notebook Python :\n",
+    "\n",
+    "1. **Point fixe 1D** par itération de fonction (convergence des contractions).\n",
+    "2. **Point fixe sur le simplexe** avec projection (clipping + normalisation).\n",
+    "3. **Matching Pennies** : matrice de gains + gain espéré `σ₁·U·σ₂`.\n",
+    "4. **Meilleure réponse perturbée** (regret matching) — continue, Brouwer s'applique.\n",
+    "5. **Dynamique** convergeant vers `(0.5, 0.5)` = équilibre de Nash.\n",
+    "6. **Visualisation ASCII** des trajectoires (équivalent matplotlib du twin Python).\n",
+    "\n",
+    "> **Parité** : jumeau C# de [GameTheory-4c-NashExistence-Python.ipynb](GameTheory-4c-NashExistence-Python.ipynb).\n",
+    "> Les mêmes algorithmes from-scratch (pas de nashpy/pygambit). matplotlib remplacé\n",
+    "> par visualisation ASCII (Prong B : on enseigne l'algorithme en C# pur).\n",
+    "> Marathon parité .NET ⇄ Python (#4956), EPIC #3801 (Prong B).\n",
+    "\n",
+    "## Exercices supplémentaires\n",
+    "\n",
+    "### Exercice 2 : dynamique de meilleure réponse alternée\n",
+    "Au lieu de moyenner `BR₁` et `BR₂` simultanément, alternez-les (J1 joue, puis J2\n",
+    "répond, etc.). La convergence diffère-t-elle ? Pourquoi la simultanéité est-elle\n",
+    "plus proche de la preuve originale de Nash ?\n",
+    "\n",
+    "### Exercice 3 : vérificateur d'hypothèses de Brouwer\n",
+    "Implémentez une fonction qui vérifie qu'une fonction `f : Δ → Δ` satisfait les\n",
+    "hypothèses de Brouwer : (a) continue, (b) `Δ` convexe compact, (c) `f(Δ) ⊆ Δ`.\n",
+    "Tester sur `perturbedBR` (qui les satisfait) et sur une fonction discontinue (qui\n",
+    "les viole — peut ne pas converger).\n",
+    "\n",
+    "## Références\n",
+    "- Nash, J. *Equilibrium Points in n-Person Games* (PNAS 1950).\n",
+    "- Brouwer, L. E. J. *Über Abbildung von Mannigfaltigkeiten* (1911).\n",
+    "- Notebook Python : [GameTheory-4c-NashExistence-Python.ipynb](GameTheory-4c-NashExistence-Python.ipynb).\n",
+    "- Marathon parité : #4956.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.990302,
+   "end_time": "2026-07-06T08:47:53.499799+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb",
+   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp/gt4c_out.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T08:47:46.509497+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -26,6 +26,8 @@ Cette série est construite sur une **dualité délibérée simulation/preuve** 
 
 Les deux approches se nourrissent mutuellement. Le notebook Python montre *pourquoi* l'équilibre de Nash est plausible ; le notebook Lean prouve *qu'il existe forcément*. Le notebook SocialChoice/01 montre qu'Arrow est *contre-intuitif* ; `Arrow.lean` prouve qu'il est *inévitable*.
 
+**Parité .NET** : le notebook [GameTheory-4c-NashExistence-Csharp.ipynb](GameTheory-4c-NashExistence-Csharp.ipynb) est le jumeau C# (.NET Interactive) de la version Python 4c — implémentation from-scratch des mêmes algorithmes (point fixe de Brouwer par itération, projection sur le simplexe, regret matching / meilleure réponse perturbée, dynamique de convergence vers Nash sur Matching Pennies) en C# pur (pas de lib externe, matplotlib → visualisation ASCII/console). Marathon parité .NET ⇄ Python (#4956), EPIC #3801 Prong B.
+
 Au-delà de la théorie classique, cette série couvre les **applications contemporaines** qui utilisent la théorie des jeux en production : enchères VCG pour la publicité en ligne (milliards de transactions/jour), systèmes de matching (Gale-Shapley pour les affectations étudiant-hôpital), IA de poker (Libratus/Pluribus), et gouvernance on-chain (DAO, vote vérifiable).
 
 ## Statistiques catalogue à jour
@@ -121,6 +123,7 @@ flowchart TD
 | 4 | [GameTheory-4-NashEquilibrium](GameTheory-4-NashEquilibrium.ipynb) | Python | Nash pur/mixte, Lemke-Howson, analyse paramétrique | 60 min |
 | 4b | [GameTheory-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) | Lean 4 | Brouwer, Kakutani, preuve existence Nash | 55 min |
 | 4c | [GameTheory-4c-NashExistence-Python](GameTheory-4c-NashExistence-Python.ipynb) | Python | Illustrations numériques point fixe | 35 min |
+| 4c | [GameTheory-4c-NashExistence-Csharp](GameTheory-4c-NashExistence-Csharp.ipynb) | C# (.NET) | **Jumeau C#** — Brouwer point fixe + Matching Pennies, from-scratch, parité #4956 | 45 min |
 | 5 | [GameTheory-5-ZeroSum-Minimax](GameTheory-5-ZeroSum-Minimax.ipynb) | Python | Théorème minimax, LP primal/dual, Von Neumann | 40 min |
 | 5b | [GameTheory-5b-Lean-Minimax](GameTheory-5b-Lean-Minimax.ipynb) | Lean 4 | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de von Neumann dans le lake `minimax_lean` (Sion), `#check` + `#print axioms` in-kernel — voir [#4054](https://github.com/jsboige/CoursIA/issues/4054) (création du lake) et `LEAN_INVENTORY.md` du dossier | 45 min |
 | 6 | [GameTheory-6-EvolutionTrust](GameTheory-6-EvolutionTrust.ipynb) | Python | Tournoi Axelrod, tit-for-tat, replicator dynamics | 65 min |
@@ -532,6 +535,7 @@ GameTheory/
 ├── GameTheory-11b-Lean-BayesianGamesExt.ipynb
 ├── GameTheory-15b-Lean-CooperativeGames.ipynb
 ├── GameTheory-4c-NashExistence-Python.ipynb                        # Side tracks c (Python 4 : 4c, 6c, 8c, 15c)
+├── GameTheory-4c-NashExistence-Csharp.ipynb                        # Jumeau C# (.NET Interactive) — Brouwer point fixe + Matching Pennies, parité #4956
 ├── GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
 ├── GameTheory-8c-CombinatorialGames-Python.ipynb
 ├── GameTheory-15c-CooperativeGames-Python.ipynb


### PR DESCRIPTION
## Summary

Jumeau C# (.NET Interactive) de [GameTheory-4c-NashExistence-Python.ipynb](MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb).

- Marathon parité .NET ⇄ Python (**#4956**), EPIC **#3801 Prong B**.
- Algorithme implémenté **from-scratch en C# pur** (pas de lib externe ; matplotlib remplacé par visualisation ASCII/console — Prong B : on enseigne l'algorithme, le twin Python garde nashpy/matplotlib).

## Algorithmes portés

| Python (twin) | C# (ce notebook) |
|---|---|
| `find_fixed_point_1d` | `FindFixedPoint1D` (itération de contraction, 1D) |
| `project_simplex` / `find_fixed_point_simplex` | `ProjectSimplex` (clip+normalisation) / `FindFixedPointSimplex` |
| `expected_payoff` | `ExpectedPayoff` (`sigma1 . U . sigma2`) |
| `perturbed_br` (regret matching) | `PerturbedBR` (continue ⇒ Brouwer s'applique) |
| dynamique de convergence | `NashDynamicsStep` (moyenne BR1+BR2) |
| matplotlib trajectory plot | `DrawTrajectoryASCII` (grille 21x9, D/N) |

Jeu d'illustration : **Matching Pennies** `U1={{1,-1},{-1,1}}`, `U2={{-1,1},{1,-1}}`, équilibre mixte `(0.5, 0.5)`.

## Validation — H.1 EXEC_PROVED

| Preuve | Résultat |
|---|---|
| Papermill `.net-csharp` | **14/14 cellules, 6/6 code execution_count=1-6, 0 erreur** |
| C.1 (no volontaire error) | `grep -nE "raise NotImplementedError\|assert False\|1/0"` = **0** |
| Parité numérique vs twin Python | point fixe `f(x)=0.5(x+1/x)` = **1.0** (`\|f-x*\|=1.1e-15`) ; Matching Pennies `(0.5,0.5)` = **point fixe True** (gains J1/J2 = 0) ; convergence depuis 3 départs vers **[0.52, 0.48]** après 50 it |

## SOTA verdict (#3801)

**SOTA-OK** pour la parité : le twin Python lui-même n'utilise pas nashpy (deps = numpy + matplotlib uniquement), les deux twins sont from-scratch. ASCII art = **Prong B** (complémentarité pédagogique), pas un workaround dégradé — le twin Python trace en matplotlib, le twin C# enseigne l'algorithme en C# pur sans dépendance.

## README

`MyIA.AI.Notebooks/GameTheory/README.md` mis à jour :
- §Parité .NET (sous « Pourquoi cette série »)
- Table Partie 1 : ligne 4c C#
- Arbre structure : entrée C# jumeau

`CATALOG-STATUS` **byte-identique à `main`** (règle `catalog-pr-hygiene` HARD 1 : pas de regen sur branche feature ; le cron `catalog-cron.yml` mettra le compte à jour sur `main`).

## Scope

1 notebook créé + 4 lignes README. Atomique. Pas de catalogue touché.

See #4956, #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)