### PR TITLE
feat(planners): Planners-5-Heuristics-Csharp — h-max/h-add/h-FF/landmarks twin (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
@@ -1,0 +1,1313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bc077f37",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004142,
+     "end_time": "2026-07-06T08:51:59.537919",
+     "exception": false,
+     "start_time": "2026-07-06T08:51:59.533777",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Planners-5-Heuristics-Csharp\n",
+    "\n",
+    "## Heuristiques en planification classique : relaxation, h^max, h^add, h^FF, landmarks\n",
+    "\n",
+    "### Objectifs d'apprentissage\n",
+    "\n",
+    "- Comprendre la **relaxation de suppression** (delete-relaxation) comme approximation admissible.\n",
+    "- Implementer **h^max** (admissible) et **h^add** (non admissible) par propagation de couts.\n",
+    "- Construire **h^FF** par extraction gloutonne d'un plan relaxe.\n",
+    "- Extraire des **landmarks** et definir **h_landmark_count**.\n",
+    "- **Observer concretement la non-admissibilite de h^add** sur un enabler partage.\n",
+    "\n",
+    "### Prerequis\n",
+    "\n",
+    "- Planners-1-Introduction-Csharp (STRIPS, BFS).\n",
+    "- Planners-3-State-Space-Csharp (A*, admissibilite d'une heuristique).\n",
+    "\n",
+    "### Duree estimee : 40 minutes\n",
+    "\n",
+    "> **Twin C#** de [Planners-5-Heuristics](Planners-5-Heuristics.ipynb) (Python + unified-planning).\n",
+    "> **Complementarite (#3801 Prong B)** : le twin Python appelle la lib `unified-planning`\n",
+    "> (pas d'equivalent NuGet maintenu) ; ce twin C# implemente **from-scratch** la propagation de couts\n",
+    "> et l'extraction de plan relaxe -- la valeur pedagogique est de **comprendre la mecanique** des\n",
+    "> heuristiques de relaxation (Bonet & Geffner 2001, Hoffmann & Nebel 2001)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a8734485",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:51:59.550059Z",
+     "iopub.status.busy": "2026-07-06T08:51:59.545375Z",
+     "iopub.status.idle": "2026-07-06T08:52:00.868786Z",
+     "shell.execute_reply": "2026-07-06T08:52:00.865669Z"
+    },
+    "papermill": {
+     "duration": 1.328427,
+     "end_time": "2026-07-06T08:52:00.868882",
+     "exception": false,
+     "start_time": "2026-07-06T08:51:59.540455",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '22480.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Imports OK : System.Linq, Globalization, DotNet.Interactive (BCL seule, 0 NuGet)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"Microsoft.DotNet.Interactive\"\n",
+    "\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "\n",
+    "static string FI(double x, string fmt = \"F4\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "\n",
+    "\"Imports OK : System.Linq, Globalization, DotNet.Interactive (BCL seule, 0 NuGet)\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5736a4d3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002352,
+     "end_time": "2026-07-06T08:52:00.875777",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:00.873425",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Introduction aux heuristiques\n",
+    "\n",
+    "Une heuristique $h(s)$ estime le cout du chemin d'un etat $s$ jusqu'au but. Sans heuristique, A* se\n",
+    "reduit a Dijkstra (exploration uniforme) ; une bonne heuristique **ordinaire** le guide vers le but et\n",
+    "reduit drastiquement le nombre de nœuds explores (cf Planners-3).\n",
+    "\n",
+    "## 2. Proprietes des heuristiques\n",
+    "\n",
+    "### 2.1 Admissibilite\n",
+    "\n",
+    "$h$ est **admissible** si $h(s) \\le h^*(s)$ pour tout etat $s$ ($h^*$ = cout optimal reel).\n",
+    "Admissible + consistant => A* trouve la solution optimale.\n",
+    "\n",
+    "### 2.2 Coherence (consistance)\n",
+    "\n",
+    "$h$ est **consistant** si $h(s) \\le c(s, s') + h(s')$ pour tout arc $s \\to s'$. La consistance implique\n",
+    "l'admissibilite (et evite de re-ouvrir des nœuds en A*).\n",
+    "\n",
+    "### 2.3 Tableau recapitulatif\n",
+    "\n",
+    "| Heuristique | Admissible | Consistante | Commentaire |\n",
+    "|-------------|------------|-------------|-------------|\n",
+    "| h^max       | Oui        | Oui         | max des couts de faits du but |\n",
+    "| h^add       | Non        | Non         | somme -> double-compte les enablers partages |\n",
+    "| h^FF        | Non (mais proche) | Non   | cardinalite d'un plan relaxe glouton |\n",
+    "| h_landmark  | Non        | Non         | compte de landmarks non atteints |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0324a371",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002042,
+     "end_time": "2026-07-06T08:52:00.880076",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:00.878034",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Heuristiques basees sur la relaxation\n",
+    "\n",
+    "### 3.1 La relaxation de suppression (delete relaxation)\n",
+    "\n",
+    "On ignore les effets de **suppression** d'une action (on ne garde que les `add_effects`). Dans le\n",
+    "monde relaxe, le nombre de faits vrais ne fait que croitre : un plan relaxe existe ssi le but est\n",
+    "atteignable. Le **cout** d'un fait dans ce monde relaxe se calcule par **propagation jusqu'a point fixe**.\n",
+    "\n",
+    "### 3.2 Heuristique h^max\n",
+    "\n",
+    "Pour chaque fait $f$, $cost(f)$ = cout cumule minimal pour le rendre vrai dans le monde relaxe :\n",
+    "\n",
+    "- $cost(f) = 0$ si $f \\in s$ (deja vrai)\n",
+    "- $cost(f) = \\min_{a : f \\in add(a)} \\big[\\, cost(a) + \\max_{p \\in pre(a)} cost(p) \\,\\big]$\n",
+    "\n",
+    "avec $cost(a)$ = cout de l'action. Alors $h^{max}(s) = \\max_{g \\in G} cost(g)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f63d96a4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:00.885270Z",
+     "iopub.status.busy": "2026-07-06T08:52:00.885115Z",
+     "iopub.status.idle": "2026-07-06T08:52:01.254800Z",
+     "shell.execute_reply": "2026-07-06T08:52:01.254647Z"
+    },
+    "papermill": {
+     "duration": 0.372772,
+     "end_time": "2026-07-06T08:52:01.254869",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:00.882097",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Structures STRIPS + heuristique h^max definies"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Structures STRIPS + heuristique h^max\n",
+    "public record STRIPSAction(string Name, HashSet<string> Preconditions,\n",
+    "                           HashSet<string> AddEffects, int Cost = 1);\n",
+    "\n",
+    "public record STRIPSProblem(HashSet<string> InitialState,\n",
+    "                            HashSet<string> Goal,\n",
+    "                            List<STRIPSAction> Actions);\n",
+    "\n",
+    "public static int HMax(STRIPSProblem problem, HashSet<string> state)\n",
+    "{\n",
+    "    var factCosts = new Dictionary<string, int>();\n",
+    "    foreach (var f in state) factCosts[f] = 0;\n",
+    "\n",
+    "    bool changed = true;\n",
+    "    int iter = 0;\n",
+    "    while (changed && iter < 1000)\n",
+    "    {\n",
+    "        changed = false; iter++;\n",
+    "        foreach (var a in problem.Actions)\n",
+    "        {\n",
+    "            if (a.Preconditions.All(p => factCosts.ContainsKey(p)))\n",
+    "            {\n",
+    "                int actionCost = a.Preconditions.Max(p => factCosts[p]) + a.Cost;\n",
+    "                foreach (var eff in a.AddEffects)\n",
+    "                    if (!factCosts.ContainsKey(eff) || factCosts[eff] > actionCost)\n",
+    "                    {\n",
+    "                        factCosts[eff] = actionCost;\n",
+    "                        changed = true;\n",
+    "                    }\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    if (problem.Goal.All(g => factCosts.ContainsKey(g)))\n",
+    "        return problem.Goal.Max(g => factCosts[g]);\n",
+    "    return int.MaxValue;  // but non atteignable\n",
+    "}\n",
+    "\n",
+    "\"Structures STRIPS + heuristique h^max definies\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c98be5c3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002472,
+     "end_time": "2026-07-06T08:52:01.260022",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.257550",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple : le probleme de l'interrupteur\n",
+    "\n",
+    "Etat initial `{off}`, but `{on}`. Action `turn_on : {off} -> {on}` (cout 1).\n",
+    "$h^{max}$ = 1 = cout optimal reel => admissible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "328ef2b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:01.267076Z",
+     "iopub.status.busy": "2026-07-06T08:52:01.266505Z",
+     "iopub.status.idle": "2026-07-06T08:52:01.408631Z",
+     "shell.execute_reply": "2026-07-06T08:52:01.408480Z"
+    },
+    "papermill": {
+     "duration": 0.146075,
+     "end_time": "2026-07-06T08:52:01.408705",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.262630",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "h^max depuis l'etat initial : 1\r\n",
+       "Cout optimal reel : 1 (turn_on)\r\n",
+       "Admissible ? True\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Probleme de l'interrupteur\n",
+    "var switchActions = new List<STRIPSAction>{\n",
+    "    new(\"turn_on\",  new(){\"off\"}, new(){\"on\"},  1),\n",
+    "    new(\"turn_off\", new(){\"on\"},  new(){\"off\"}, 1),\n",
+    "};\n",
+    "var switchProblem = new STRIPSProblem(\n",
+    "    InitialState: new(){\"off\"},\n",
+    "    Goal: new(){\"on\"},\n",
+    "    Actions: switchActions);\n",
+    "\n",
+    "int hVal = HMax(switchProblem, new(){\"off\"});\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"h^max depuis l'etat initial : \" + hVal);\n",
+    "sb.AppendLine(\"Cout optimal reel : 1 (turn_on)\");\n",
+    "sb.AppendLine(\"Admissible ? \" + (hVal <= 1));\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "421a8ea3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002677,
+     "end_time": "2026-07-06T08:52:01.414341",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.411664",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.3 Heuristique h^add (additive)\n",
+    "\n",
+    "Comme h^max, mais $cost(f) = \\min_a [\\, cost(a) + \\mathbf{sum}_{p \\in pre(a)} cost(p)\\,]$ et\n",
+    "$h^{add}(s) = \\mathbf{sum}_{g \\in G} cost(g)$. La **somme** (au lieu du max) surestime car elle\n",
+    "compte plusieurs fois un meme enabler partage entre sous-buts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "55e527da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:01.421198Z",
+     "iopub.status.busy": "2026-07-06T08:52:01.420996Z",
+     "iopub.status.idle": "2026-07-06T08:52:01.550576Z",
+     "shell.execute_reply": "2026-07-06T08:52:01.550295Z"
+    },
+    "papermill": {
+     "duration": 0.133515,
+     "end_time": "2026-07-06T08:52:01.550703",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.417188",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "h^add depuis l'etat initial : 1\r\n",
+       "Actions helpful : [turn_on]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Heuristique h^add (somme additive) + actions helpful\n",
+    "public static (int hValue, HashSet<string> helpful) HAdd(STRIPSProblem problem, HashSet<string> state)\n",
+    "{\n",
+    "    var factCosts = new Dictionary<string, int>();\n",
+    "    var bestAction = new Dictionary<string, STRIPSAction>();  // meilleur achiever par fait\n",
+    "    foreach (var f in state) factCosts[f] = 0;  // faits initiaux : cout 0, pas d'achiever\n",
+    "\n",
+    "    bool changed = true;\n",
+    "    int iter = 0;\n",
+    "    while (changed && iter < 1000)\n",
+    "    {\n",
+    "        changed = false; iter++;\n",
+    "        foreach (var a in problem.Actions)\n",
+    "        {\n",
+    "            if (a.Preconditions.All(p => factCosts.ContainsKey(p)))\n",
+    "            {\n",
+    "                int actionCost = a.Preconditions.Sum(p => factCosts[p]) + a.Cost;\n",
+    "                foreach (var eff in a.AddEffects)\n",
+    "                    if (!factCosts.ContainsKey(eff) || factCosts[eff] > actionCost)\n",
+    "                    {\n",
+    "                        factCosts[eff] = actionCost;\n",
+    "                        bestAction[eff] = a;\n",
+    "                        changed = true;\n",
+    "                    }\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    var helpful = new HashSet<string>();\n",
+    "    foreach (var g in problem.Goal)\n",
+    "    {\n",
+    "        if (!factCosts.ContainsKey(g)) return (int.MaxValue, new HashSet<string>());\n",
+    "        if (bestAction.TryGetValue(g, out var ba)) helpful.Add(ba.Name);\n",
+    "    }\n",
+    "    int h = problem.Goal.Sum(g => factCosts[g]);\n",
+    "    return (h, helpful);\n",
+    "}\n",
+    "\n",
+    "var (hAddSwitch, helpSwitch) = HAdd(switchProblem, new(){\"off\"});\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"h^add depuis l'etat initial : \" + hAddSwitch);\n",
+    "sb.AppendLine(\"Actions helpful : [\" + string.Join(\", \", helpSwitch) + \"]\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1ca665c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002583,
+     "end_time": "2026-07-06T08:52:01.557368",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.554785",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.4 Comparaison h^max vs h^add : trois interrupteurs\n",
+    "\n",
+    "But `{on_1, on_2, on_3}`, trois actions independantes `turn_on_i : {off_i} -> {on_i}` (cout 1 chacune).\n",
+    "Cout optimal reel $h^* = 3$. Sur cette instance les **deux** heuristiques sont admissibles (3 interrupteurs\n",
+    "independants -> pas d'enabler partage) : $h^{max} = 3$, $h^{add} = 3$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a8b55b77",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:01.564101Z",
+     "iopub.status.busy": "2026-07-06T08:52:01.563889Z",
+     "iopub.status.idle": "2026-07-06T08:52:01.690603Z",
+     "shell.execute_reply": "2026-07-06T08:52:01.690474Z"
+    },
+    "papermill": {
+     "duration": 0.130669,
+     "end_time": "2026-07-06T08:52:01.690668",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.559999",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Comparaison h^max vs h^add (3 interrupteurs independants)\r\n",
+       "================================================\r\n",
+       "h^max       : 1\r\n",
+       "h^add       : 3\r\n",
+       "h* (optimal): 3\r\n",
+       "\r\n",
+       "h^max admissible ? True\r\n",
+       "h^add admissible ? True\r\n",
+       "\r\n",
+       "Actions helpful (h^add) : [turn_on_1, turn_on_2, turn_on_3]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Trois interrupteurs independants\n",
+    "var multiSwitch = new List<STRIPSAction>{\n",
+    "    new(\"turn_on_1\", new(){\"off_1\"}, new(){\"on_1\"}, 1),\n",
+    "    new(\"turn_on_2\", new(){\"off_2\"}, new(){\"on_2\"}, 1),\n",
+    "    new(\"turn_on_3\", new(){\"off_3\"}, new(){\"on_3\"}, 1),\n",
+    "};\n",
+    "var multiProblem = new STRIPSProblem(\n",
+    "    InitialState: new(){\"off_1\", \"off_2\", \"off_3\"},\n",
+    "    Goal: new(){\"on_1\", \"on_2\", \"on_3\"},\n",
+    "    Actions: multiSwitch);\n",
+    "\n",
+    "var init3 = new HashSet<string>{\"off_1\", \"off_2\", \"off_3\"};\n",
+    "int hMaxMulti = HMax(multiProblem, init3);\n",
+    "var (hAddMulti, helpMulti) = HAdd(multiProblem, init3);\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Comparaison h^max vs h^add (3 interrupteurs independants)\");\n",
+    "sb.AppendLine(new string('=', 48));\n",
+    "sb.AppendLine(\"h^max       : \" + hMaxMulti);\n",
+    "sb.AppendLine(\"h^add       : \" + hAddMulti);\n",
+    "sb.AppendLine(\"h* (optimal): 3\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"h^max admissible ? \" + (hMaxMulti <= 3));\n",
+    "sb.AppendLine(\"h^add admissible ? \" + (hAddMulti <= 3));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Actions helpful (h^add) : [\" + string.Join(\", \", helpMulti) + \"]\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8111015",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002212,
+     "end_time": "2026-07-06T08:52:01.695516",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.693304",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.5 Demonstration : h^add n'est PAS admissible en general\n",
+    "\n",
+    "On construit une instance ou un **enabler est partage** entre deux sous-buts : `setup : {s} -> {p}`\n",
+    "produit `p`, puis `make_g1 : {p} -> {g1}` et `make_g2 : {p} -> {g2}` l'utilisent tous deux. But `{g1, g2}`.\n",
+    "\n",
+    "Cout optimal reel $h^* = 3$ (`setup`, `make_g1`, `make_g2`). Mais h^add **double-compte** `setup` :\n",
+    "$cost(p)=1$, $cost(g_1)=2$, $cost(g_2)=2$, $h^{add} = 2+2 = 4 > h^* = 3$. La relaxation additive ne voit\n",
+    "pas que `setup` s'execute une seule fois. C'est l'observation concrete de la non-admissibilite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "67483724",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:01.701806Z",
+     "iopub.status.busy": "2026-07-06T08:52:01.701620Z",
+     "iopub.status.idle": "2026-07-06T08:52:01.767568Z",
+     "shell.execute_reply": "2026-07-06T08:52:01.767450Z"
+    },
+    "papermill": {
+     "duration": 0.069792,
+     "end_time": "2026-07-06T08:52:01.767626",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.697834",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Demonstration de non-admissibilite de h^add\r\n",
+       "====================================================\r\n",
+       "h^max : 2   (<= h*=3, admissible)\r\n",
+       "h^add : 4   (> h*=3, INADMISSIBLE)\r\n",
+       "h*    : 3\r\n",
+       "\r\n",
+       "Cause : h^add compte setup (cout 1) dans le chemin de g1 ET dans celui de g2.\r\n",
+       "        Cout reel de setup = 1 (execute une fois). Cout h^add de setup = 2.\r\n",
+       "\r\n",
+       "=> h^max reste admissible (max <= h*). h^add surestime la relaxation additive.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Enabler partage entre deux sous-buts -> h^add double-compte\n",
+    "var sharedActions = new List<STRIPSAction>{\n",
+    "    new(\"setup\",   new(){\"s\"},  new(){\"p\"},  1),  // enabler partage\n",
+    "    new(\"make_g1\", new(){\"p\"},  new(){\"g1\"}, 1),\n",
+    "    new(\"make_g2\", new(){\"p\"},  new(){\"g2\"}, 1),\n",
+    "};\n",
+    "var sharedProblem = new STRIPSProblem(\n",
+    "    InitialState: new(){\"s\"},\n",
+    "    Goal: new(){\"g1\", \"g2\"},\n",
+    "    Actions: sharedActions);\n",
+    "\n",
+    "int hMaxShared = HMax(sharedProblem, new(){\"s\"});\n",
+    "var (hAddShared, _) = HAdd(sharedProblem, new(){\"s\"});\n",
+    "int hStarShared = 3;  // setup, make_g1, make_g2\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Demonstration de non-admissibilite de h^add\");\n",
+    "sb.AppendLine(new string('=', 52));\n",
+    "sb.AppendLine(\"h^max : \" + hMaxShared + \"   (<= h*=3, admissible)\");\n",
+    "sb.AppendLine(\"h^add : \" + hAddShared + \"   (> h*=3, INADMISSIBLE)\");\n",
+    "sb.AppendLine(\"h*    : \" + hStarShared);\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Cause : h^add compte setup (cout 1) dans le chemin de g1 ET dans celui de g2.\");\n",
+    "sb.AppendLine(\"        Cout reel de setup = 1 (execute une fois). Cout h^add de setup = 2.\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"=> h^max reste admissible (max <= h*). h^add surestime la relaxation additive.\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9c02272",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002144,
+     "end_time": "2026-07-06T08:52:01.772143",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.769999",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Heuristique FF (Fast Forward)\n",
+    "\n",
+    "### 4.1 Principe\n",
+    "\n",
+    "h^FF (Hoffmann & Nebel 2001) evite le double-compte de h^add en **extrayant un plan relaxe** :\n",
+    "\n",
+    "1. Construire le graphe de relaxation (propagation h^add-style, en gardant le meilleur *achiever* par fait).\n",
+    "2. Extraire **gloutonnement** un plan relaxe depuis les faits du but (un achiever par fait, recursivement ses Preconditions).\n",
+    "3. $h^{FF}(s)$ = **nombre d'actions** du plan relaxe extrait.\n",
+    "\n",
+    "### 4.2 Proprietes\n",
+    "\n",
+    "h^FF n'est pas admissible en theorie, mais **très proche de h\\*** en pratique (elle ignore les deletes\n",
+    "mais ne double-compte pas les enablers partages). C'est l'heuristique de reference pour la planification satisfiable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7ca7d946",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:01.777204Z",
+     "iopub.status.busy": "2026-07-06T08:52:01.777054Z",
+     "iopub.status.idle": "2026-07-06T08:52:01.862863Z",
+     "shell.execute_reply": "2026-07-06T08:52:01.862698Z"
+    },
+    "papermill": {
+     "duration": 0.088714,
+     "end_time": "2026-07-06T08:52:01.862939",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.774225",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "h^FF (3 interrupteurs) : 3\r\n",
+       "Actions helpful : [turn_on_1, turn_on_2, turn_on_3]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Heuristique h^FF : extraction gloutonne d'un plan relaxe\n",
+    "public static (int hValue, HashSet<string> helpful) HFF(STRIPSProblem problem, HashSet<string> state)\n",
+    "{\n",
+    "    var factCosts = new Dictionary<string, int>();\n",
+    "    var achiever = new Dictionary<string, STRIPSAction>();\n",
+    "    foreach (var f in state) factCosts[f] = 0;  // faits initiaux : pas d'achiever\n",
+    "\n",
+    "    bool changed = true;\n",
+    "    while (changed)\n",
+    "    {\n",
+    "        changed = false;\n",
+    "        foreach (var a in problem.Actions)\n",
+    "            if (a.Preconditions.All(p => factCosts.ContainsKey(p)))\n",
+    "            {\n",
+    "                int actionCost = a.Preconditions.Sum(p => factCosts[p]) + a.Cost;\n",
+    "                foreach (var eff in a.AddEffects)\n",
+    "                    if (!factCosts.ContainsKey(eff) || factCosts[eff] > actionCost)\n",
+    "                    {\n",
+    "                        factCosts[eff] = actionCost;\n",
+    "                        achiever[eff] = a;\n",
+    "                        changed = true;\n",
+    "                    }\n",
+    "            }\n",
+    "    }\n",
+    "    if (!problem.Goal.All(g => factCosts.ContainsKey(g)))\n",
+    "        return (int.MaxValue, new HashSet<string>());\n",
+    "\n",
+    "    // Extraction gloutonne du plan relaxe depuis le but\n",
+    "    var planActions = new HashSet<string>();\n",
+    "    var processed = new HashSet<string>();\n",
+    "    var stack = new Stack<string>(problem.Goal);\n",
+    "    int guard = 0;\n",
+    "    while (stack.Count > 0 && guard < 10000)\n",
+    "    {\n",
+    "        guard++;\n",
+    "        var fact = stack.Pop();\n",
+    "        if (processed.Contains(fact) || state.Contains(fact)) continue;\n",
+    "        processed.Add(fact);\n",
+    "        if (achiever.TryGetValue(fact, out var a))\n",
+    "        {\n",
+    "            planActions.Add(a.Name);\n",
+    "            foreach (var p in a.Preconditions) stack.Push(p);\n",
+    "        }\n",
+    "    }\n",
+    "    // Actions helpful = actions du plan relaxe applicables dans l'etat courant\n",
+    "    var helpful = new HashSet<string>();\n",
+    "    foreach (var a in problem.Actions)\n",
+    "        if (a.Preconditions.IsSubsetOf(state) && planActions.Contains(a.Name))\n",
+    "            helpful.Add(a.Name);\n",
+    "    return (planActions.Count, helpful);\n",
+    "}\n",
+    "\n",
+    "var (hFFMulti, ffHelp) = HFF(multiProblem, new HashSet<string>{\"off_1\",\"off_2\",\"off_3\"});\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"h^FF (3 interrupteurs) : \" + hFFMulti);\n",
+    "sb.AppendLine(\"Actions helpful : [\" + string.Join(\", \", ffHelp) + \"]\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7a5928e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003052,
+     "end_time": "2026-07-06T08:52:01.869279",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.866227",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Heuristiques basees sur les landmarks\n",
+    "\n",
+    "### 5.1 Definition\n",
+    "\n",
+    "Un **landmark** est un fait (ou ensemble d'actions) qui doit etre vrai (ou executé) dans **tout** plan\n",
+    "valide. La presence de landmarks impose un ordre partiel : si toute action qui atteint $L_2$ a pour\n",
+    "Precondition $L_1$, alors $L_1$ doit preceder $L_2$.\n",
+    "\n",
+    "### 5.2 Extraction simple (backchaining depuis le but)\n",
+    "\n",
+    "Une approximation : tout fait du but absent de l'etat initial est un landmark ; pour chaque landmark,\n",
+    "les Preconditions de ses achievers sont des landmarks potentiels (et doivent le preceder)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "33038e62",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:01.877190Z",
+     "iopub.status.busy": "2026-07-06T08:52:01.876920Z",
+     "iopub.status.idle": "2026-07-06T08:52:01.990704Z",
+     "shell.execute_reply": "2026-07-06T08:52:01.990554Z"
+    },
+    "papermill": {
+     "duration": 0.118204,
+     "end_time": "2026-07-06T08:52:01.990759",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.872555",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Landmarks extraits (3 interrupteurs) :\r\n",
+       "  - on_1\r\n",
+       "  - on_2\r\n",
+       "  - on_3\r\n",
+       "\r\n",
+       "Ordre des landmarks (avant -> apres) :\r\n",
+       "\r\n",
+       "h_landmark_count depuis l'etat initial : 3\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Extraction de landmarks simples (backchaining depuis le but)\n",
+    "public static (HashSet<string> landmarks, List<(string before, string after)> order)\n",
+    "    ExtractLandmarks(STRIPSProblem problem)\n",
+    "{\n",
+    "    var landmarks = new HashSet<string>();\n",
+    "    var order = new List<(string, string)>();\n",
+    "    foreach (var g in problem.Goal)\n",
+    "        if (!problem.InitialState.Contains(g)) landmarks.Add(g);\n",
+    "    foreach (var lm in landmarks.ToList())  // snapshot\n",
+    "        foreach (var a in problem.Actions)\n",
+    "            if (a.AddEffects.Contains(lm))\n",
+    "                foreach (var pre in a.Preconditions)\n",
+    "                    if (!problem.InitialState.Contains(pre))\n",
+    "                    {\n",
+    "                        landmarks.Add(pre);\n",
+    "                        order.Add((pre, lm));\n",
+    "                    }\n",
+    "    return (landmarks, order);\n",
+    "}\n",
+    "\n",
+    "public static int HLandmarkCount(STRIPSProblem problem, HashSet<string> state)\n",
+    "{\n",
+    "    var (lms, _) = ExtractLandmarks(problem);\n",
+    "    int unsat = lms.Count(lm => !state.Contains(lm));\n",
+    "    return unsat;\n",
+    "}\n",
+    "\n",
+    "var (lms, lorder) = ExtractLandmarks(multiProblem);\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Landmarks extraits (3 interrupteurs) :\");\n",
+    "foreach (var lm in lms) sb.AppendLine(\"  - \" + lm);\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Ordre des landmarks (avant -> apres) :\");\n",
+    "foreach (var (before, after) in lorder) sb.AppendLine(\"  \" + before + \" -> \" + after);\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"h_landmark_count depuis l'etat initial : \" + HLandmarkCount(multiProblem, new HashSet<string>{\"off_1\",\"off_2\",\"off_3\"}));\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2844a6a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002318,
+     "end_time": "2026-07-06T08:52:01.995632",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.993314",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Benchmark : Blocks World simplifie\n",
+    "\n",
+    "Trois blocs A, B, C sur table, tous clairs, main vide. But : `on_a_b` (A sur B) ET `on_b_c` (B sur C).\n",
+    "Cout optimal $h^* = 4$ : `pick_up_b`, `stack_b_c`, `pick_up_a`, `stack_a_b`.\n",
+    "On compare les quatre heuristiques sur l'etat initial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5a3ea178",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:02.002098Z",
+     "iopub.status.busy": "2026-07-06T08:52:02.001935Z",
+     "iopub.status.idle": "2026-07-06T08:52:02.082137Z",
+     "shell.execute_reply": "2026-07-06T08:52:02.082005Z"
+    },
+    "papermill": {
+     "duration": 0.084312,
+     "end_time": "2026-07-06T08:52:02.082199",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:01.997887",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Benchmark Blocks World (but : on_a_b, on_b_c)\r\n",
+       "========================================================\r\n",
+       "  Heuristique      Valeur   <= h*=4 ? (admissible)\r\n",
+       "  ------------------------------------------------\r\n",
+       "  h^max                2      True\r\n",
+       "  h^add                4      True\r\n",
+       "  h^FF                 4      True\r\n",
+       "  h_landmark_count     4      True\r\n",
+       "  h*                   4\r\n",
+       "\r\n",
+       "Observation : h^max seule garantit admissible. Les autres peuvent\r\n",
+       "surestimer mais restent informatives pour une recherche satisfiable.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Blocks World simplifie : A,B,C sur table -> (A sur B) et (B sur C)\n",
+    "var blocksActions = new List<STRIPSAction>{\n",
+    "    new(\"pick_up_a\", new(){\"clear_a\",\"ontable_a\",\"handempty\"}, new(){\"holding_a\"}, 1),\n",
+    "    new(\"pick_up_b\", new(){\"clear_b\",\"ontable_b\",\"handempty\"}, new(){\"holding_b\"}, 1),\n",
+    "    new(\"pick_up_c\", new(){\"clear_c\",\"ontable_c\",\"handempty\"}, new(){\"holding_c\"}, 1),\n",
+    "    new(\"stack_a_b\", new(){\"holding_a\",\"clear_b\"}, new(){\"on_a_b\",\"clear_a\",\"handempty\"}, 1),\n",
+    "    new(\"stack_b_c\", new(){\"holding_b\",\"clear_c\"}, new(){\"on_b_c\",\"clear_b\",\"handempty\"}, 1),\n",
+    "    new(\"stack_a_c\", new(){\"holding_a\",\"clear_c\"}, new(){\"on_a_c\",\"clear_a\",\"handempty\"}, 1),\n",
+    "};\n",
+    "var blocksProblem = new STRIPSProblem(\n",
+    "    InitialState: new(){\"clear_a\",\"clear_b\",\"clear_c\",\"ontable_a\",\"ontable_b\",\"ontable_c\",\"handempty\"},\n",
+    "    Goal: new(){\"on_a_b\",\"on_b_c\"},\n",
+    "    Actions: blocksActions);\n",
+    "\n",
+    "var initB = new HashSet<string>{\"clear_a\",\"clear_b\",\"clear_c\",\"ontable_a\",\"ontable_b\",\"ontable_c\",\"handempty\"};\n",
+    "int hMaxB = HMax(blocksProblem, initB);\n",
+    "var (hAddB, _) = HAdd(blocksProblem, initB);\n",
+    "var (hFFB, _) = HFF(blocksProblem, initB);\n",
+    "int hLmB = HLandmarkCount(blocksProblem, initB);\n",
+    "int hStarB = 4;\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Benchmark Blocks World (but : on_a_b, on_b_c)\");\n",
+    "sb.AppendLine(new string('=', 56));\n",
+    "sb.AppendLine(\"  Heuristique      Valeur   <= h*=4 ? (admissible)\");\n",
+    "sb.AppendLine(\"  \" + new string('-', 48));\n",
+    "sb.AppendLine(\"  h^max            \" + hMaxB.ToString().PadLeft(5) + \"      \" + (hMaxB <= hStarB));\n",
+    "sb.AppendLine(\"  h^add            \" + hAddB.ToString().PadLeft(5) + \"      \" + (hAddB <= hStarB));\n",
+    "sb.AppendLine(\"  h^FF             \" + hFFB.ToString().PadLeft(5) + \"      \" + (hFFB <= hStarB));\n",
+    "sb.AppendLine(\"  h_landmark_count \" + hLmB.ToString().PadLeft(5) + \"      \" + (hLmB <= hStarB));\n",
+    "sb.AppendLine(\"  h*               \" + hStarB.ToString().PadLeft(5));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Observation : h^max seule garantit admissible. Les autres peuvent\");\n",
+    "sb.AppendLine(\"surestimer mais restent informatives pour une recherche satisfiable.\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c7e2377",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002592,
+     "end_time": "2026-07-06T08:52:02.087759",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:02.085167",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "> Conformement a la regle C.1, les stubs ci-dessous s'executent sans erreur (rendent une valeur\n",
+    "> par defaut ou affichent un message) et ne bloquent pas le notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3de4bc62",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003124,
+     "end_time": "2026-07-06T08:52:02.093731",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:02.090607",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : h^goalcount\n",
+    "\n",
+    "Implementer l'heuristique **goalcount** : nombre de faits du but **non encore satisfaits** dans l'etat.\n",
+    "C'est l'heuristique la plus simple (et la moins informative) : elle ignore les Preconditions et les couts.\n",
+    "\n",
+    "**Indice :** `problem.Goal.Count(g => !state.Contains(g))`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "05778994",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:02.101649Z",
+     "iopub.status.busy": "2026-07-06T08:52:02.101448Z",
+     "iopub.status.idle": "2026-07-06T08:52:02.162865Z",
+     "shell.execute_reply": "2026-07-06T08:52:02.162748Z"
+    },
+    "papermill": {
+     "duration": 0.065906,
+     "end_time": "2026-07-06T08:52:02.162923",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:02.097017",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 (goalcount) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : h^goalcount (a completer)\n",
+    "// TODO etudiant : compter les faits du but non satisfaits dans l'etat.\n",
+    "// Resultat attendu sur blocksProblem/initB : 2 (on_a_b et on_b_c absents).\n",
+    "int? hGoalCount = null;  // TODO etudiant : affecter la valeur\n",
+    "\"Exercice 1 (goalcount) a completer.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "695e3c61",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002717,
+     "end_time": "2026-07-06T08:52:02.168250",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:02.165533",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : coherence de h^max\n",
+    "\n",
+    "Verifier **empiriquement** la consistance de h^max sur le Blocks World : pour chaque successeur $s'$\n",
+    "d'un etat $s$ (via une action applicable), on doit avoir $h^{max}(s) \\le cost(a) + h^{max}(s')$.\n",
+    "\n",
+    "**Indice :** enumerer les actions applicables, calculer l'etat successeur `(state \\ del) ∪ add`,\n",
+    "appliquer `HMax` au successeur et comparer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "093c089c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:02.174260Z",
+     "iopub.status.busy": "2026-07-06T08:52:02.174105Z",
+     "iopub.status.idle": "2026-07-06T08:52:02.222765Z",
+     "shell.execute_reply": "2026-07-06T08:52:02.222577Z"
+    },
+    "papermill": {
+     "duration": 0.052123,
+     "end_time": "2026-07-06T08:52:02.222852",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:02.170729",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 (coherence h^max) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : coherence de h^max (a completer)\n",
+    "// TODO etudiant : pour chaque action applicable dans initB, calculer le successeur\n",
+    "// et verifier h^max(initB) <= cost(a) + h^max(successeur).\n",
+    "bool? hMaxConsistent = null;  // TODO etudiant : true si la coherence tient partout\n",
+    "\"Exercice 2 (coherence h^max) a completer.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e6ca20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004524,
+     "end_time": "2026-07-06T08:52:02.231555",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:02.227031",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : comparer h^FF au plan optimal\n",
+    "\n",
+    "Sur une instance que vous concevez (ex. 4 blocs a empiler), calculer h^FF et le comparer au cout\n",
+    "optimal reel $h^*$ (trouve par BFS sur l'espace d'etats, cf Planners-3). h^FF est-elle admissible\n",
+    "sur votre instance ?\n",
+    "\n",
+    "**Indice :** reutiliser `HFF` et un BFS sur les etats (HashSet<string>)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f8cc0826",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T08:52:02.241443Z",
+     "iopub.status.busy": "2026-07-06T08:52:02.240859Z",
+     "iopub.status.idle": "2026-07-06T08:52:02.306028Z",
+     "shell.execute_reply": "2026-07-06T08:52:02.305748Z"
+    },
+    "papermill": {
+     "duration": 0.07065,
+     "end_time": "2026-07-06T08:52:02.306173",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:02.235523",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 (h^FF vs optimal) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : h^FF vs plan optimal (a completer)\n",
+    "// TODO etudiant : definir un probleme a 4 blocs, calculer h^FF et h* (BFS), comparer.\n",
+    "int? hFFcmp = null;     // TODO etudiant : valeur h^FF\n",
+    "int? hStarCmp = null;   // TODO etudiant : cout optimal BFS\n",
+    "\"Exercice 3 (h^FF vs optimal) a completer.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "909db533",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005194,
+     "end_time": "2026-07-06T08:52:02.318420",
+     "exception": false,
+     "start_time": "2026-07-06T08:52:02.313226",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Resume et guide de selection\n",
+    "\n",
+    "### Points cles\n",
+    "\n",
+    "1. **Delete-relaxation** : ignorer les effects de suppression rend le probleme plus facile (faits croissants) tout en restant informatif.\n",
+    "2. **h^max** = max des couts de faits du but -> **admissible** et **consistant** -> A* optimal.\n",
+    "3. **h^add** = somme -> **non admissible** (double-compte les enablers partages), mais plus informative pour guider.\n",
+    "4. **h^FF** = cardinalite d'un plan relaxe glouton -> bon compromis, heuristique de reference pour la planification satisfiable.\n",
+    "5. **Landmarks** : faits obligatoires dans tout plan -> heuristique h_landmark_count (non admissible mais structurelle).\n",
+    "\n",
+    "### Guide de selection\n",
+    "\n",
+    "- Recherche **optimale** : h^max (ou une combination admissible type LM-cut).\n",
+    "- Recherche **satisfiable** rapide : h^FF + actions helpful (preferred operators) -> greedy/hill-climbing.\n",
+    "- Besoin de **structure** : landmarks (orderings, cuts).\n",
+    "\n",
+    "### Lien avec Fast Downward\n",
+    "\n",
+    "Fast Downward (Helmert 2006) combine ces idees : traduction en FDR, pattern databases, et surtout\n",
+    "**LM-cut** (une heuristique admissible basee sur les landmarks, au cout h^max). Ce twin C# couvre les\n",
+    "fondations algorithmiques ; le notebook Python branche le vrai moteur via `unified-planning`.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "- Bonet & Geffner (2001), *Planning as heuristic search*.\n",
+    "- Hoffmann & Nebel (2001), *The FF planning system: Fast plan generation through heuristic search*.\n",
+    "- Helmert (2006), *The Fast Downward planning system*.\n",
+    "- Porteus, Kautz & others, *Landmarks in planning*.\n",
+    "\n",
+    "> Twin C# dans le cadre du marathon de parite .NET/Python (#4956), suite Planners-1 (#5528) -> Planners-3 (#5534) -> **Planners-5**."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.353155,
+   "end_time": "2026-07-06T08:52:02.572604",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\\Planners-5-Heuristics-Csharp.ipynb",
+   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\planners5_csharp_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T08:51:57.219449",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -122,6 +122,7 @@ SymbolicAI/Planners/
 ├── 02-Classical/
 │   ├── Planners-4-Fast-Downward.ipynb   # A*, heuristiques
 │   ├── Planners-5-Heuristics.ipynb      # h-add, h-max, h-FF
+│   ├── Planners-5-Heuristics-Csharp.ipynb # Twin C# h-max/h-add/h-FF/landmarks (See #4956)
 │   ├── Planners-5b-Lean-Relaxation.ipynb # Companion Lean 4 : preuve h+ <= h*
 │   └── Planners-6-Domains.ipynb         # Domaines classiques
 ├── 03-Advanced/
@@ -210,6 +211,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 |---|----------|--------|---------|-------|
 | 4 | [Planners-4-Fast-Downward](02-Classical/Planners-4-Fast-Downward.ipynb) | Python | Architecture FD, Docker, A*, GBFS, EHC, heuristiques | 45 min |
 | 5 | [Planners-5-Heuristics](02-Classical/Planners-5-Heuristics.ipynb) | Python | h-add, h-max, h-FF, landmarks | 40 min |
+| 5 (C#) | [Planners-5-Heuristics-Csharp](02-Classical/Planners-5-Heuristics-Csharp.ipynb) | .NET (C#) | Twin C# du 5 : h-max/h-add/h-FF/landmarks from-scratch, démo non-admissibilité h^add (See #4956) | 40 min |
 | 5b | [Planners-5b-Lean-Relaxation](02-Classical/Planners-5b-Lean-Relaxation.ipynb) | Lean 4 | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de l'admissibilité de la relaxation (h⁺ ≤ h\*) dans le lake `planning_lean`, `#check` + `#print axioms` in-kernel (cf [#4053](https://github.com/jsboige/CoursIA/issues/4053) création du lake / PR #4168, companion natif) | 45 min |
 | 6 | [Planners-6-Domains](02-Classical/Planners-6-Domains.ipynb) | Python | Blocks World, Logistics, Gripper, Ferry, Hanoi | 50 min |
 


### PR DESCRIPTION
## Résumé

**Twin C#** de [Planners-5-Heuristics](MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb) (Python + unified-planning). **Tranche 3 du marathon Planners C#** (#4956) : suite de Planners-1 (#5528, STRIPS+BFS) et Planners-3 (#5534, search→A*), volet **heuristiques de relaxation**. BCL .NET seule, 0 NuGet. **Rule 6 rotation** : GameTheory c.44 → Planners c.45 (alternance, pas monotonie).

## Algorithme / démarche

- **STRIPS** (`record STRIPSAction`/`STRIPSProblem`), `HashSet<string>` pour les états.
- **h^max** : relaxation de suppression, propagation de couts jusqu'a point fixe, $cost(f)=\min_a[cost(a)+\max_{p\in pre}cost(p)]$, $h^{max}=\max_{g\in G}cost(g)$. **Admissible**.
- **h^add** : meme propagation mais $cost(f)=\min_a[cost(a)+\sum_{p\in pre}cost(p))$, $h^{add}=\sum cost(g)$. **Non admissible** (double-compte les enablers partages).
- **h^FF** : graphe de relaxation (h^add-style) + extraction gloutonne d'un plan relaxe depuis le but (DFS sur les achievers). $h^{FF}$ = nombre d'actions du plan relaxe.
- **Landmarks** : backchaining depuis le but (faits du but absents de l'initial + Preconditions des achievers) + ordre partiel. **h_landmark_count** = landmarks non atteints.
- **Benchmark Blocks World** (A,B,C sur table → on_a_b, on_b_c) : comparaison des 4 heuristiques.

## Complémentarité (#3801 Prong B)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python (unified-planning) | lib `up` (pas d'équivalent NuGet maintenu) | brancher le vrai moteur |
| **This (.NET BCL seule)** | from-scratch (propagation, extraction de plan) | **comprendre la mécanique** des heuristiques de relaxation (Bonet & Geffner 2001, Hoffmann & Nebel 2001) |

**Le point cle** : la **non-admissibilité de h^add est démontrée concrètement** sur une instance à enabler partagé (`setup : {s}→{p}`, puis `make_g1`/`make_g2` via `p`) — h^add=4 > h*=3 car `setup` est compté dans les deux chemins. Cette observation est rendue explicite par l'implémentation from-scratch (le twin Python délègue à unified-planning qui cache cette mécanique).

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **12/12 cellules code `execution_count` 1-12, 0 erreur, 0 warning CS**. Outputs vérifiés **firsthand** :

- **h^max (interrupteur)** : 1 = h* → admissible ✓
- **h^max vs h^add (3 interrupteurs indépendants)** : h^max=1 (max), h^add=3 (somme), h*=3, tous deux admissibles ✓
- **★ Non-admissibilité h^add (enabler partagé)** : h^max=2 (≤3, admissible), **h^add=4 (>3, INADMISSIBLE)** ✓
- **h^FF (3 interrupteurs)** : 3 + actions helpful = {turn_on_1,2,3} ✓
- **Landmarks (3 interrupteurs)** : {on_1,on_2,on_3}, h_landmark_count=3 ✓
- **Benchmark Blocks World** (h*=4) : h^max=2, h^add=4, h^FF=4, h_landmark=4 ✓

## Bugs G.1 self-corrected (déjà topic file, RÉCURRENTS)

2 bugs C# .NET headless (documentés marathon, réutilisés proprement ce cycle) :
1. **Named-arg case mismatch** (CS1739) : `record STRIPSProblem(InitialState, Goal, Actions)` → les appels doivent utiliser `InitialState:`/`Goal:`/`Actions:` (PascalCase), pas `initial_state:` (snake_case Python).
2. **Newline littéral dans string classique** (CS1010) : un `\n` Python dans le générateur devient newline physique dans la source C# → casser la string. Fix : `AppendLine()` séparés ou concaténation `+`.

## SOTA-OK (#3801)

Vrai problème non-trivial : les heuristiques de relaxation (h^max/h^add/h^FF/landmarks) sont le cœur algorithmique de la planification moderne (Fast Downward). From-scratch = comprendre la propagation de couts et l'extraction de plan relaxe, pas invoquer une lib. BCL .NET seule, 0 NuGet.

## Exercices (#2161)

3 stubs C.1-conformes : (1) h^goalcount (compte faits du but non satisfaits), (2) vérification empirique de la cohérence de h^max sur les successeurs, (3) comparaison h^FF vs plan optimal BFS sur 4 blocs.

## Scope

Atomique : 1 notebook (27 cells, 12 code) + README table+tree (2 entrées). Self-contained (BCL seule). CATALOG-STATUS + fichiers catalogue byte-identical (R1).

## Marathon #4956

Suite Planners C# : Planners-1 (#5528 STRIPS+BFS) → Planners-3 (#5534 search→A*) → **Planners-5 (heuristiques de relaxation)**. Tranche suivante possible : Planners-7 (OR-Tools, .NET natif).

See #4956. Revue souhaitée : po-2025 ou ai-01.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
