### PR TITLE
feat(gametheory): GameTheory-9-BackwardInduction-Csharp — backward induction / SPE twin (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction-Csharp.ipynb
@@ -1,0 +1,1438 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d1f24059",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006461,
+     "end_time": "2026-07-06T09:29:34.442098",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:34.435637",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-9-BackwardInduction (C#)\n",
+    "\n",
+    "## Induction arriere et equilibre de sous-jeu parfait (SPE)\n",
+    "\n",
+    "**Twin C#** du notebook [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb) (Python + numpy/matplotlib).\n",
+    "**Marathon parite .NET ⇄ Python** (#4956), suite de [GameTheory-11-BayesianGames-Csharp](GameTheory-11-BayesianGames-Csharp.ipynb).\n",
+    "BCL .NET seule, 0 NuGet, **from-scratch** (Prong B #3801 : comprendre l'algorithme recursif, pas invoquer numpy).\n",
+    "\n",
+    "### Objectifs\n",
+    "- Modeliser un **jeu sous forme extensive** (arbre de jeu) en C#\n",
+    "- Implementer l'**induction arriere** (backward induction) pour resoudre un jeu a information parfaite\n",
+    "- Illustrer les **paradoxes classiques** : jeu du mille-pattes (centipede), guerre d'usure (war of attrition), chaine de magasins (chain store)\n",
+    "- Demontrer la notion d'**equilibre de sous-jeu parfait** (Subgame Perfect Equilibrium, Selten 1965)\n",
+    "\n",
+    "### Duree estimee : 40 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "613ce655",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001969,
+     "end_time": "2026-07-06T09:29:34.447404",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:34.445435",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Structure de donnees : arbre de jeu\n",
+    "\n",
+    "Un jeu sous forme extensive est un **arbre** ou :\n",
+    "- Chaque noeud appartient a un joueur (ou est terminal, ou est un noeud de chance)\n",
+    "- Chaque arete est une **action**\n",
+    "- Les feuilles portent les **gains** (payoffs) de chaque joueur\n",
+    "\n",
+    "On represente cela par deux classes simples : `GameNode` et `ExtensiveFormGame`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d4baad93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:34.461892Z",
+     "iopub.status.busy": "2026-07-06T09:29:34.456789Z",
+     "iopub.status.idle": "2026-07-06T09:29:36.176103Z",
+     "shell.execute_reply": "2026-07-06T09:29:36.172343Z"
+    },
+    "papermill": {
+     "duration": 1.724838,
+     "end_time": "2026-07-06T09:29:36.176205",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:34.451367",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '62180.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Classes definies : GameNode (noeud), ExtensiveFormGame (arbre de jeu)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System.Globalization;\n",
+    "\n",
+    "// Helper format invariant (Bug marathon #2 : CurrentCulture ne persiste pas entre cells)\n",
+    "static string FI(double x, string fmt = \"F2\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "static string FV(double[] v, string fmt = \"F2\") => \"[\" + string.Join(\", \", v.Select(x => FI(x, fmt))) + \"]\";\n",
+    "\n",
+    "// Noeud d'un arbre de jeu. player = -1 (terminal), 0 (nature/chance), >= 1 (joueur).\n",
+    "public class GameNode\n",
+    "{\n",
+    "    public string NodeId;\n",
+    "    public int Player;\n",
+    "    public List<string> Actions = new();\n",
+    "    public Dictionary<string, GameNode> Children = new();\n",
+    "    public double[] Payoffs { get; set; }       // non-null uniquement si terminal\n",
+    "    public string Infoset { get; set; }         // ensemble d'information (optionnel)\n",
+    "\n",
+    "    public bool IsTerminal() => Player == -1;\n",
+    "    public bool IsChance() => Player == 0;\n",
+    "\n",
+    "    public GameNode(string id, int player)\n",
+    "    {\n",
+    "        NodeId = id;\n",
+    "        Player = player;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Jeu sous forme extensive.\n",
+    "public class ExtensiveFormGame\n",
+    "{\n",
+    "    public string Name;\n",
+    "    public int NumPlayers;\n",
+    "    public GameNode Root;\n",
+    "    public Dictionary<string, GameNode> Nodes = new();\n",
+    "\n",
+    "    public ExtensiveFormGame(string name, int numPlayers)\n",
+    "    {\n",
+    "        Name = name;\n",
+    "        NumPlayers = numPlayers;\n",
+    "    }\n",
+    "\n",
+    "    public void AddNode(GameNode node) { Nodes[node.NodeId] = node; }\n",
+    "    public void SetRoot(GameNode node) { Root = node; AddNode(node); }\n",
+    "}\n",
+    "\n",
+    "display(\"Classes definies : GameNode (noeud), ExtensiveFormGame (arbre de jeu)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "896a3823",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002234,
+     "end_time": "2026-07-06T09:29:36.181048",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.178814",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Algorithme d'induction arriere\n",
+    "\n",
+    "**Principe** (Zermelo 1913, formalise par Selten 1965) : on resout le jeu en partant des **feuilles** et en remontant vers la racine.\n",
+    "\n",
+    "- **Noeud terminal** : retourner les gains.\n",
+    "- **Noeud de chance** (nature) : retourner l'**esperance** ponderee des gains des enfants.\n",
+    "- **Noeud de decision** (joueur `p`) : le joueur choisit l'action qui **maximise son propre gain** ; on enregistre cette action optimale.\n",
+    "\n",
+    "Cet algorithme produit un **equilibre de sous-jeu parfait** (SPE) : la strategie est rationnelle dans **chaque** sous-jeu, meme hors du chemin d'equilibre. C'est plus fort que l'equilibre de Nash (qui peut reposer sur des menaces non credibles)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f4e414c0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:36.186523Z",
+     "iopub.status.busy": "2026-07-06T09:29:36.186329Z",
+     "iopub.status.idle": "2026-07-06T09:29:36.389697Z",
+     "shell.execute_reply": "2026-07-06T09:29:36.389580Z"
+    },
+    "papermill": {
+     "duration": 0.206612,
+     "end_time": "2026-07-06T09:29:36.389755",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.183143",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Fonction BackwardInduction definie"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Resultat d'induction arriere pour un noeud de decision.\n",
+    "public class NodeSolution\n",
+    "{\n",
+    "    public string OptimalAction;\n",
+    "    public double[] EquilibriumPayoffs;\n",
+    "}\n",
+    "\n",
+    "// Induction arriere : resout le jeu par recursion depuis la racine.\n",
+    "// Retourne : (solution par noeud de decision, gains d'equilibre globaux).\n",
+    "public static (Dictionary<string, NodeSolution> solution, double[] eqPayoffs) BackwardInduction(ExtensiveFormGame game)\n",
+    "{\n",
+    "    var solution = new Dictionary<string, NodeSolution>();\n",
+    "\n",
+    "    double[] Solve(GameNode node)\n",
+    "    {\n",
+    "        if (node.IsTerminal())\n",
+    "            return node.Payoffs;\n",
+    "\n",
+    "        if (node.IsChance())\n",
+    "        {\n",
+    "            // Esperance sur les resultats de nature (payoffs egaux a 1/n ici, mais generique)\n",
+    "            var expected = new double[game.NumPlayers];\n",
+    "            double total = 0.0;\n",
+    "            foreach (var kv in node.Children)\n",
+    "            {\n",
+    "                double w = node.Actions.Contains(kv.Key) ? 1.0 / node.Children.Count : 0.0;\n",
+    "                var cp = Solve(kv.Value);\n",
+    "                for (int i = 0; i < game.NumPlayers; i++) expected[i] += w * cp[i];\n",
+    "                total += w;\n",
+    "            }\n",
+    "            return expected;\n",
+    "        }\n",
+    "\n",
+    "        // Noeud de decision : le joueur 'node.Player' maximise son propre gain.\n",
+    "        int player = node.Player;\n",
+    "        string bestAction = null;\n",
+    "        double[] bestPayoffs = null;\n",
+    "        double bestValue = double.NegativeInfinity;\n",
+    "\n",
+    "        foreach (var action in node.Actions)\n",
+    "        {\n",
+    "            var childPayoffs = Solve(node.Children[action]);\n",
+    "            double playerValue = childPayoffs[player - 1];  // joueurs 1-indexes, tableau 0-indexe\n",
+    "            if (playerValue > bestValue)\n",
+    "            {\n",
+    "                bestValue = playerValue;\n",
+    "                bestAction = action;\n",
+    "                bestPayoffs = childPayoffs;\n",
+    "            }\n",
+    "        }\n",
+    "\n",
+    "        solution[node.NodeId] = new NodeSolution { OptimalAction = bestAction, EquilibriumPayoffs = bestPayoffs };\n",
+    "        return bestPayoffs;\n",
+    "    }\n",
+    "\n",
+    "    var eq = Solve(game.Root);\n",
+    "    return (solution, eq);\n",
+    "}\n",
+    "\n",
+    "// Affiche la solution d'induction arriere.\n",
+    "public static void DisplayBackwardInduction(ExtensiveFormGame game, Dictionary<string, NodeSolution> solution)\n",
+    "{\n",
+    "    var sb = new StringBuilder();\n",
+    "    sb.AppendLine(\"Solution par induction arriere : \" + game.Name);\n",
+    "    sb.AppendLine(new string('=', 60));\n",
+    "    foreach (var kv in solution)\n",
+    "    {\n",
+    "        var node = game.Nodes[kv.Key];\n",
+    "        var sol = kv.Value;\n",
+    "        sb.AppendLine(\"  Noeud \" + kv.Key + \" (J\" + node.Player + \"): joue '\" + sol.OptimalAction + \"' -> \" + FV(sol.EquilibriumPayoffs));\n",
+    "    }\n",
+    "    display(sb.ToString());\n",
+    "}\n",
+    "\n",
+    "display(\"Fonction BackwardInduction definie\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c877705",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001982,
+     "end_time": "2026-07-06T09:29:36.394095",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.392113",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Jeu d'entree sur le marche\n",
+    "\n",
+    "Un **entrant** (J1) decide d'entrer (`Enter`) ou de rester hors du marche (`Out`).\n",
+    "S'il entre, l'**incumbent** (J2, monopole en place) choisit entre `Fight` (guerre des prix) et `Accommodate` (accepter).\n",
+    "\n",
+    "| Issue | Entrant | Incumbent |\n",
+    "|-------|---------|-----------|\n",
+    "| Out | 0 | 2 |\n",
+    "| Enter puis Fight | -1 | -1 |\n",
+    "| Enter puis Accommodate | 1 | 1 |\n",
+    "\n",
+    "**Intuition** : la menace \"Fight\" est-elle credible ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "89e2a0a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:36.399167Z",
+     "iopub.status.busy": "2026-07-06T09:29:36.399002Z",
+     "iopub.status.idle": "2026-07-06T09:29:36.482391Z",
+     "shell.execute_reply": "2026-07-06T09:29:36.482278Z"
+    },
+    "papermill": {
+     "duration": 0.086291,
+     "end_time": "2026-07-06T09:29:36.482450",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.396159",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solution par induction arriere : Entry Game\r\n",
+       "============================================================\r\n",
+       "  Noeud incumbent (J2): joue 'Accommodate' -> [1.00, 1.00]\r\n",
+       "  Noeud entrant (J1): joue 'Enter' -> [1.00, 1.00]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Gains a l'equilibre : [1.00, 1.00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Interpretation :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  - Si l'Entrant entre, l'Incumbent prefere Accommoder (1 > -1)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  - Sachant cela, l'Entrant prefere Entrer (1 > 0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  -> La menace 'Fight' n'est PAS credible (non-SPE). L'entree se produit."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Construction du jeu d'entree.\n",
+    "public static ExtensiveFormGame CreateEntryGame()\n",
+    "{\n",
+    "    var game = new ExtensiveFormGame(\"Entry Game\", 2);\n",
+    "\n",
+    "    var outT = new GameNode(\"out\", -1); outT.Payoffs = new double[]{0, 2};\n",
+    "    var fightT = new GameNode(\"fight\", -1); fightT.Payoffs = new double[]{-1, -1};\n",
+    "    var accT = new GameNode(\"accommodate\", -1); accT.Payoffs = new double[]{1, 1};\n",
+    "\n",
+    "    var incumbent = new GameNode(\"incumbent\", 2);\n",
+    "    incumbent.Actions = new List<string>{\"Fight\", \"Accommodate\"};\n",
+    "    incumbent.Children[\"Fight\"] = fightT;\n",
+    "    incumbent.Children[\"Accommodate\"] = accT;\n",
+    "    incumbent.Infoset = \"I2\";\n",
+    "\n",
+    "    var entrant = new GameNode(\"entrant\", 1);\n",
+    "    entrant.Actions = new List<string>{\"Enter\", \"Out\"};\n",
+    "    entrant.Children[\"Enter\"] = incumbent;\n",
+    "    entrant.Children[\"Out\"] = outT;\n",
+    "    entrant.Infoset = \"I1\";\n",
+    "\n",
+    "    game.SetRoot(entrant);\n",
+    "    game.AddNode(incumbent); game.AddNode(outT); game.AddNode(fightT); game.AddNode(accT);\n",
+    "    return game;\n",
+    "}\n",
+    "\n",
+    "var entryGame = CreateEntryGame();\n",
+    "var (entrySolution, entryEq) = BackwardInduction(entryGame);\n",
+    "DisplayBackwardInduction(entryGame, entrySolution);\n",
+    "display(\"Gains a l'equilibre : \" + FV(entryEq));\n",
+    "display(\"Interpretation :\");\n",
+    "display(\"  - Si l'Entrant entre, l'Incumbent prefere Accommoder (1 > -1)\");\n",
+    "display(\"  - Sachant cela, l'Entrant prefere Entrer (1 > 0)\");\n",
+    "display(\"  -> La menace 'Fight' n'est PAS credible (non-SPE). L'entree se produit.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "110ef98d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003086,
+     "end_time": "2026-07-06T09:29:36.488063",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.484977",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Le paradoxe du mille-pattes (Centipede)\n",
+    "\n",
+    "Deux joueurs passent ou prennent a tour de role. La cagnotte **grossit** a chaque tour.\n",
+    "Si un joueur prend (`Take`), il empoche la grosse part et l'autre la petite. Si tout le monde passe jusqu'au bout, gain egal.\n",
+    "\n",
+    "**Paradoxe** : l'induction arriere dit \"Take des le premier tour\", mais empiriquement les humains cooperent longtemps. C'est le conflit classique entre rationalite backward et intuition forward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3f277917",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:36.494469Z",
+     "iopub.status.busy": "2026-07-06T09:29:36.494276Z",
+     "iopub.status.idle": "2026-07-06T09:29:36.581157Z",
+     "shell.execute_reply": "2026-07-06T09:29:36.581022Z"
+    },
+    "papermill": {
+     "duration": 0.090499,
+     "end_time": "2026-07-06T09:29:36.581221",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.490722",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solution par induction arriere : Centipede (6 tours)\r\n",
+       "============================================================\r\n",
+       "  Noeud node_5 (J2): joue 'Take' -> [4.00, 6.00]\r\n",
+       "  Noeud node_4 (J1): joue 'Take' -> [5.00, 3.00]\r\n",
+       "  Noeud node_3 (J2): joue 'Take' -> [2.00, 4.00]\r\n",
+       "  Noeud node_2 (J1): joue 'Take' -> [3.00, 1.00]\r\n",
+       "  Noeud node_1 (J2): joue 'Take' -> [0.00, 2.00]\r\n",
+       "  Noeud node_0 (J1): joue 'Take' -> [1.00, 0.00]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Gains a l'equilibre SPE : [1.00, 0.00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Paradoxe : bien que les gains cooperatifs (6, 6) soient plus eleves,"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "l'equilibre de sous-jeu parfait impose Take des le tour 0 (1, 0)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Construction du jeu du mille-pattes a n_rounds tours.\n",
+    "public static ExtensiveFormGame CreateCentipedeGame(int nRounds = 6)\n",
+    "{\n",
+    "    var game = new ExtensiveFormGame(\"Centipede (\" + nRounds + \" tours)\", 2);\n",
+    "\n",
+    "    // Gains si \"Take\" au tour t (player qui prend = grosse cagnotte).\n",
+    "    double[] PayoffsAtRound(int t)\n",
+    "    {\n",
+    "        double bigPile = t + 1;\n",
+    "        double smallPile = Math.Max(0, t - 1);\n",
+    "        int player = (t % 2 == 0) ? 1 : 2;\n",
+    "        return (player == 1) ? new double[]{bigPile, smallPile} : new double[]{smallPile, bigPile};\n",
+    "    }\n",
+    "\n",
+    "    // Dernier terminal (si tous passent jusqu'au bout).\n",
+    "    var lastPass = new GameNode(\"end\", -1);\n",
+    "    lastPass.Payoffs = new double[]{nRounds, nRounds};\n",
+    "    game.AddNode(lastPass);\n",
+    "\n",
+    "    GameNode nextNode = lastPass;\n",
+    "    for (int t = nRounds - 1; t >= 0; t--)\n",
+    "    {\n",
+    "        int player = (t % 2 == 0) ? 1 : 2;\n",
+    "        var payoffs = PayoffsAtRound(t);\n",
+    "        var takeTerminal = new GameNode(\"take_\" + t, -1);\n",
+    "        takeTerminal.Payoffs = payoffs;\n",
+    "        game.AddNode(takeTerminal);\n",
+    "\n",
+    "        var decision = new GameNode(\"node_\" + t, player);\n",
+    "        decision.Actions = new List<string>{\"Take\", \"Pass\"};\n",
+    "        decision.Children[\"Take\"] = takeTerminal;\n",
+    "        decision.Children[\"Pass\"] = nextNode;\n",
+    "        game.AddNode(decision);\n",
+    "        nextNode = decision;\n",
+    "    }\n",
+    "    game.SetRoot(nextNode);\n",
+    "    return game;\n",
+    "}\n",
+    "\n",
+    "var centipede6 = CreateCentipedeGame(6);\n",
+    "var (centSolution, centEq) = BackwardInduction(centipede6);\n",
+    "DisplayBackwardInduction(centipede6, centSolution);\n",
+    "display(\"Gains a l'equilibre SPE : \" + FV(centEq));\n",
+    "display(\"Paradoxe : bien que les gains cooperatifs (6, 6) soient plus eleves,\");\n",
+    "display(\"l'equilibre de sous-jeu parfait impose Take des le tour 0 (1, 0).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50a9d519",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002641,
+     "end_time": "2026-07-06T09:29:36.586682",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.584041",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Efficacite et rationalite limitee\n",
+    "\n",
+    "Comparons le gain **SPE** (Take immediat) au gain **cooperatif** (Pass jusqu'au bout).\n",
+    "Avec une probabilite d'erreur (rationalite limitee), le comportement change : on peut montrer qu'il devient rationnel de Passer si l'adversaire est susceptible de se tromper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0e63e3bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:36.593466Z",
+     "iopub.status.busy": "2026-07-06T09:29:36.593260Z",
+     "iopub.status.idle": "2026-07-06T09:29:36.739178Z",
+     "shell.execute_reply": "2026-07-06T09:29:36.739047Z"
+    },
+    "papermill": {
+     "duration": 0.14971,
+     "end_time": "2026-07-06T09:29:36.739244",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.589534",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Efficacite SPE vs Cooperation (Centipede) :\r\n",
+       "--------------------------------------------------------\r\n",
+       "  Tours |  SPE (Take t=0) | Cooperatif (fin) | Ratio\r\n",
+       "  00002 |  1.0          |  2.0            | 2.0x\r\n",
+       "  00004 |  1.0          |  4.0            | 4.0x\r\n",
+       "  00006 |  1.0          |  6.0            | 6.0x\r\n",
+       "  00008 |  1.0          |  8.0            | 8.0x\r\n",
+       "  00010 |  1.0          |  10.0            | 10.0x\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Conclusion : l'ecart d'efficacite SPE vs cooperation CROIT avec le nombre de tours."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "C'est pourquoi le paradoxe est si marque dans les versions longues du mille-pattes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Analyse d'efficacite : SPE vs cooperation, en fonction de n_rounds.\n",
+    "var sbEff = new StringBuilder();\n",
+    "sbEff.AppendLine(\"Efficacite SPE vs Cooperation (Centipede) :\");\n",
+    "sbEff.AppendLine(new string('-', 56));\n",
+    "sbEff.AppendLine(\"  Tours |  SPE (Take t=0) | Cooperatif (fin) | Ratio\");\n",
+    "foreach (var n in new[]{2, 4, 6, 8, 10})\n",
+    "{\n",
+    "    var g = CreateCentipedeGame(n);\n",
+    "    var (_, eq) = BackwardInduction(g);\n",
+    "    double speP1 = eq[0];\n",
+    "    double coopP1 = n;  // gain cooperatif du joueur 1\n",
+    "    double ratio = (coopP1 > 0) ? coopP1 / Math.Max(0.001, speP1) : 0;\n",
+    "    sbEff.AppendLine(\"  \" + n.ToString(\"D5\") + \" |  \" + FI(speP1, \"F1\") + \"          |  \" + FI(coopP1, \"F1\") + \"            | \" + FI(ratio, \"F1\") + \"x\");\n",
+    "}\n",
+    "display(sbEff.ToString());\n",
+    "display(\"Conclusion : l'ecart d'efficacite SPE vs cooperation CROIT avec le nombre de tours.\");\n",
+    "display(\"C'est pourquoi le paradoxe est si marque dans les versions longues du mille-pattes.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57eccf11",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002882,
+     "end_time": "2026-07-06T09:29:36.745349",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.742467",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Guerre d'usure (War of Attrition)\n",
+    "\n",
+    "Deux joueurs s'affrontent ; a chaque tour chacun peut `Quit` (abandonner) ou `Fight` (continuer).\n",
+    "Le gagnant empoche un prix **V**, mais chaque tour de combat coute **c** aux deux joueurs.\n",
+    "\n",
+    "**Tension** : abandonner vite economise les couts, mais si l'autre abandonne d'abord, on gagne V."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d31d2352",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:36.751697Z",
+     "iopub.status.busy": "2026-07-06T09:29:36.751533Z",
+     "iopub.status.idle": "2026-07-06T09:29:36.812838Z",
+     "shell.execute_reply": "2026-07-06T09:29:36.812730Z"
+    },
+    "papermill": {
+     "duration": 0.064814,
+     "end_time": "2026-07-06T09:29:36.812895",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.748081",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solution par induction arriere : War of Attrition (V=10, c=1)\r\n",
+       "============================================================\r\n",
+       "  Noeud j2_4 (J2): joue 'Quit' -> [5.00, -4.00]\r\n",
+       "  Noeud j1_4 (J1): joue 'Fight' -> [5.00, -4.00]\r\n",
+       "  Noeud j2_3 (J2): joue 'Quit' -> [6.00, -3.00]\r\n",
+       "  Noeud j1_3 (J1): joue 'Fight' -> [6.00, -3.00]\r\n",
+       "  Noeud j2_2 (J2): joue 'Quit' -> [7.00, -2.00]\r\n",
+       "  Noeud j1_2 (J1): joue 'Fight' -> [7.00, -2.00]\r\n",
+       "  Noeud j2_1 (J2): joue 'Quit' -> [8.00, -1.00]\r\n",
+       "  Noeud j1_1 (J1): joue 'Fight' -> [8.00, -1.00]\r\n",
+       "  Noeud j2_0 (J2): joue 'Quit' -> [9.00, -0.00]\r\n",
+       "  Noeud j1_0 (J1): joue 'Fight' -> [9.00, -0.00]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Gains a l'equilibre : [9.00, -0.00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Analyse : au dernier tour possible, abandonner domine ; par induction,"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "la guerre d'usure se termine tot. Le ratio V/c determine la duree d'escalade."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Guerre d'usure sequentielle (simplifiee) : J1 puis J2 decident a chaque tour.\n",
+    "public static ExtensiveFormGame CreateWarOfAttrition(int maxRounds = 5, double V = 10, double c = 1)\n",
+    "{\n",
+    "    var game = new ExtensiveFormGame(\"War of Attrition (V=\" + FI(V, \"F0\") + \", c=\" + FI(c, \"F0\") + \")\", 2);\n",
+    "\n",
+    "    GameNode BuildRound(int round, double cost1, double cost2)\n",
+    "    {\n",
+    "        if (round >= maxRounds)\n",
+    "        {\n",
+    "            var tie = new GameNode(\"tie_\" + round, -1);\n",
+    "            tie.Payoffs = new double[]{ -cost1, -cost2 };\n",
+    "            game.AddNode(tie);\n",
+    "            return tie;\n",
+    "        }\n",
+    "        // J1 abandonne : J2 gagne V.\n",
+    "        var j1Quit = new GameNode(\"j1_quit_\" + round, -1);\n",
+    "        j1Quit.Payoffs = new double[]{ -cost1, V - cost2 };\n",
+    "        game.AddNode(j1Quit);\n",
+    "        // J2 abandonne (si J1 continue) : J1 gagne V, mais a paye un c supplementaire.\n",
+    "        var j2Quit = new GameNode(\"j2_quit_\" + round, -1);\n",
+    "        j2Quit.Payoffs = new double[]{ V - cost1 - c, -cost2 };\n",
+    "        game.AddNode(j2Quit);\n",
+    "        // Tour suivant (les deux continuent).\n",
+    "        var nextRound = BuildRound(round + 1, cost1 + c, cost2 + c);\n",
+    "\n",
+    "        var j2Node = new GameNode(\"j2_\" + round, 2);\n",
+    "        j2Node.Actions = new List<string>{\"Quit\", \"Fight\"};\n",
+    "        j2Node.Children[\"Quit\"] = j2Quit;\n",
+    "        j2Node.Children[\"Fight\"] = nextRound;\n",
+    "        j2Node.Infoset = \"I2_\" + round;\n",
+    "        game.AddNode(j2Node);\n",
+    "\n",
+    "        var j1Node = new GameNode(\"j1_\" + round, 1);\n",
+    "        j1Node.Actions = new List<string>{\"Quit\", \"Fight\"};\n",
+    "        j1Node.Children[\"Quit\"] = j1Quit;\n",
+    "        j1Node.Children[\"Fight\"] = j2Node;\n",
+    "        j1Node.Infoset = \"I1_\" + round;\n",
+    "        game.AddNode(j1Node);\n",
+    "        return j1Node;\n",
+    "    }\n",
+    "\n",
+    "    var root = BuildRound(0, 0, 0);\n",
+    "    game.SetRoot(root);\n",
+    "    return game;\n",
+    "}\n",
+    "\n",
+    "var woa = CreateWarOfAttrition(5, 10, 1);\n",
+    "var (woaSolution, woaEq) = BackwardInduction(woa);\n",
+    "DisplayBackwardInduction(woa, woaSolution);\n",
+    "display(\"Gains a l'equilibre : \" + FV(woaEq));\n",
+    "display(\"Analyse : au dernier tour possible, abandonner domine ; par induction,\");\n",
+    "display(\"la guerre d'usure se termine tot. Le ratio V/c determine la duree d'escalade.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e9f4792",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002847,
+     "end_time": "2026-07-06T09:29:36.818640",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.815793",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Paradoxe de la chaine de magasins (Chain Store)\n",
+    "\n",
+    "Un monopole (J2) fait face a `n` entrants **sequentiellement**. Pour chaque entrant, le monopole peut `Fight` (agressif, cout -1 pour les deux) ou `Accommodate` (+1 pour les deux). Si le monopole combat, cela dissuade... en theorie.\n",
+    "\n",
+    "**Paradoxe de Selten** : l'induction arriere dit \"Accommodate partout\" (le dernier entrant n'a rien a craindre, donc l'avant-dernier non plus, etc.), mais intuitivement le monopole a interet a construire une reputation agressive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "653cbd89",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:36.825051Z",
+     "iopub.status.busy": "2026-07-06T09:29:36.824849Z",
+     "iopub.status.idle": "2026-07-06T09:29:36.901332Z",
+     "shell.execute_reply": "2026-07-06T09:29:36.901151Z"
+    },
+    "papermill": {
+     "duration": 0.080125,
+     "end_time": "2026-07-06T09:29:36.901432",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.821307",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Chain Store (3 entrants) - solution synthetique :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Gains d'equilibre SPE : [0.00, 6.00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Monopole : Accommodate=3 fois, Fight=0 fois"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Paradoxe : l'induction arriere pousse le monopole a Accommoder a chaque marche."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Une analyse 'forward' suggere pourtant qu'une reputation agressive serait rationnelle."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Chaine de magasins : n entrants sequentiels, monopole Fight/Accommodate a chaque fois.\n",
+    "public static ExtensiveFormGame CreateChainStoreGame(int nEntrants = 3)\n",
+    "{\n",
+    "    var game = new ExtensiveFormGame(\"Chain Store (\" + nEntrants + \" entrants)\", 2);\n",
+    "\n",
+    "    GameNode BuildMarket(int market, double monopolyTotal)\n",
+    "    {\n",
+    "        if (market >= nEntrants)\n",
+    "        {\n",
+    "            var end = new GameNode(\"end\", -1);\n",
+    "            end.Payoffs = new double[]{ 0, monopolyTotal };\n",
+    "            game.AddNode(end);\n",
+    "            return end;\n",
+    "        }\n",
+    "        // Monopole combat sur ce marche.\n",
+    "        var fightContinue = BuildMarket(market + 1, monopolyTotal - 1);\n",
+    "        var fightTerminal = new GameNode(\"fight_\" + market, -1);\n",
+    "        fightTerminal.Payoffs = new double[]{ -1, -1 };\n",
+    "        game.AddNode(fightTerminal);\n",
+    "        // Monopole accepte sur ce marche.\n",
+    "        var accContinue = BuildMarket(market + 1, monopolyTotal + 1);\n",
+    "\n",
+    "        var monopole = new GameNode(\"monopole_\" + market, 2);\n",
+    "        monopole.Actions = new List<string>{\"Fight\", \"Accommodate\"};\n",
+    "        monopole.Children[\"Fight\"] = fightContinue;\n",
+    "        monopole.Children[\"Accommodate\"] = accContinue;\n",
+    "        monopole.Infoset = \"I2_\" + market;\n",
+    "        game.AddNode(monopole);\n",
+    "\n",
+    "        var entrant = new GameNode(\"entrant_\" + market, 1);\n",
+    "        entrant.Actions = new List<string>{\"Stay Out\", \"Enter\"};\n",
+    "        entrant.Children[\"Stay Out\"] = BuildMarket(market + 1, monopolyTotal + 2);\n",
+    "        entrant.Children[\"Enter\"] = monopole;\n",
+    "        game.AddNode(entrant);\n",
+    "        return entrant;\n",
+    "    }\n",
+    "\n",
+    "    var root = BuildMarket(0, 0);\n",
+    "    game.SetRoot(root);\n",
+    "    return game;\n",
+    "}\n",
+    "\n",
+    "var cs = CreateChainStoreGame(3);\n",
+    "var (csSolution, csEq) = BackwardInduction(cs);\n",
+    "display(\"Chain Store (3 entrants) - solution synthetique :\");\n",
+    "display(\"  Gains d'equilibre SPE : \" + FV(csEq));\n",
+    "int accommodateCount = csSolution.Values.Count(s => s.OptimalAction == \"Accommodate\");\n",
+    "int fightCount = csSolution.Values.Count(s => s.OptimalAction == \"Fight\");\n",
+    "display(\"  Monopole : Accommodate=\" + accommodateCount + \" fois, Fight=\" + fightCount + \" fois\");\n",
+    "display(\"Paradoxe : l'induction arriere pousse le monopole a Accommoder a chaque marche.\");\n",
+    "display(\"Une analyse 'forward' suggere pourtant qu'une reputation agressive serait rationnelle.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2aa15996",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004093,
+     "end_time": "2026-07-06T09:29:36.910214",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.906121",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Visualisation ASCII de l'arbre de jeu\n",
+    "\n",
+    "Le notebook Python utilise `matplotlib` ; ce twin C# dessine l'arbre en **ASCII** (complementaire, Prong B). L'equilibre SPE est marque par une astérisque `*`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "509efa95",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:36.920056Z",
+     "iopub.status.busy": "2026-07-06T09:29:36.919830Z",
+     "iopub.status.idle": "2026-07-06T09:29:37.001152Z",
+     "shell.execute_reply": "2026-07-06T09:29:37.001026Z"
+    },
+    "papermill": {
+     "duration": 0.086487,
+     "end_time": "2026-07-06T09:29:37.001215",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:36.914728",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Arbre de jeu 'Entry Game' (* = chemin SPE) :\r\n",
+       " *(entrant, J1)\r\n",
+       "      |--  *[Enter]\r\n",
+       "      |     +--  *(incumbent, J2)\r\n",
+       "      |          |--   [Fight]\r\n",
+       "      |          |     +--   [fight] = [-1.00, -1.00]\r\n",
+       "      |          +--  *[Accommodate]\r\n",
+       "      |               +--  *[accommodate] = [1.00, 1.00]\r\n",
+       "      +--   [Out]\r\n",
+       "           +--   [out] = [0.00, 2.00]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Dessine l'arbre de jeu en ASCII avec le chemin SPE marque.\n",
+    "public static void DrawTreeAscii(ExtensiveFormGame game, Dictionary<string, NodeSolution> solution)\n",
+    "{\n",
+    "    var sb = new StringBuilder();\n",
+    "    void Rec(GameNode node, string indent, bool isLast, bool onPath)\n",
+    "    {\n",
+    "        string marker = onPath ? \" *\" : \"  \";\n",
+    "        string branch = (indent.Length == 0) ? \"\" : (isLast ? \" +-- \" : \" |-- \");\n",
+    "        string label;\n",
+    "        if (node.IsTerminal())\n",
+    "            label = \"[\" + node.NodeId + \"] = \" + FV(node.Payoffs);\n",
+    "        else if (node.IsChance())\n",
+    "            label = \"(\" + node.NodeId + \", Nature)\";\n",
+    "        else\n",
+    "            label = \"(\" + node.NodeId + \", J\" + node.Player + \")\";\n",
+    "        sb.AppendLine(indent + branch + marker + label);\n",
+    "\n",
+    "        string childIndent = indent + (isLast ? \"     \" : \" |    \");\n",
+    "        string optAction = null;\n",
+    "        if (solution.ContainsKey(node.NodeId)) optAction = solution[node.NodeId].OptimalAction;\n",
+    "        int n = node.Actions.Count;\n",
+    "        for (int i = 0; i < n; i++)\n",
+    "        {\n",
+    "            var action = node.Actions[i];\n",
+    "            var child = node.Children[action];\n",
+    "            bool childOnPath = onPath && (action == optAction);\n",
+    "            // edge label\n",
+    "            string edgeMark = (action == optAction) ? \" *\" : \"  \";\n",
+    "            sb.AppendLine(childIndent + (i == n - 1 ? \" +-- \" : \" |-- \") + edgeMark + \"[\" + action + \"]\");\n",
+    "            string grandIndent = childIndent + (i == n - 1 ? \"     \" : \" |    \");\n",
+    "            Rec(child, grandIndent, true, childOnPath);\n",
+    "        }\n",
+    "    }\n",
+    "    sb.AppendLine(\"Arbre de jeu '\" + game.Name + \"' (* = chemin SPE) :\");\n",
+    "    Rec(game.Root, \"\", true, true);\n",
+    "    display(sb.ToString());\n",
+    "}\n",
+    "\n",
+    "DrawTreeAscii(entryGame, entrySolution);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a019d79c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003431,
+     "end_time": "2026-07-06T09:29:37.007975",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.004544",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Resume\n",
+    "\n",
+    "### Points cles\n",
+    "- L'**induction arriere** resout exactement les jeux a **information parfaite** en remontant des feuilles vers la racine.\n",
+    "- Elle produit un **equilibre de sous-jeu parfait** (SPE) : rationnel dans chaque sous-jeu, sans menaces non credibles.\n",
+    "- Les **paradoxes** (centipede, chain store) montrent la tension entre cette rationalite \"backward\" et l'intuition \"forward\" (reputation, cooperation).\n",
+    "\n",
+    "### Comparaison avec le twin Python\n",
+    "| Aspect | Python | C# (ce notebook) |\n",
+    "|--------|--------|-------------------|\n",
+    "| Structure | `@dataclass` + numpy | `class` mutable + `double[]` |\n",
+    "| Recursion | `def solve(node)` interne | `double[] Solve(GameNode)` locale |\n",
+    "| Visualisation | `matplotlib` (graphe) | ASCII tree (complementaire) |\n",
+    "| Dependance | numpy | BCL seule (0 NuGet) |\n",
+    "\n",
+    "### Applications\n",
+    "- Theorie des jeux extensive (negociations, duree, reputation)\n",
+    "- Economie (entry deterrence, price wars)\n",
+    "- IA : planification adversariale, jeu a somme nulle parfait"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cf2e0a6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003702,
+     "end_time": "2026-07-06T09:29:37.015401",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.011699",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 10. Exercices\n",
+    "\n",
+    "> **Convention** : ces cellules sont des **stubs a completer** (regle C.1 : pas d'erreur volontaire).\n",
+    "> Le notebook s'execute de bout en bout meme si les exercices ne sont pas resolus."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7a35f2d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003243,
+     "end_time": "2026-07-06T09:29:37.022100",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.018857",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Jeu de negociation (bargaining) a 3 tours\n",
+    "\n",
+    "Deux joueurs se partagent un gain de 4. A chaque tour, celui qui propose fait une offre (x, 4-x) ; l'autre accepte ou refuse. Si refus, le gain **diminue** (discount 0.5 par tour). Apres 3 tours, le jeu s'arrete.\n",
+    "\n",
+    "**Objectif** : construire l'arbre, resoudre par induction arriere, identifier l'offre d'equilibre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "96fcead5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:37.029891Z",
+     "iopub.status.busy": "2026-07-06T09:29:37.029725Z",
+     "iopub.status.idle": "2026-07-06T09:29:37.072579Z",
+     "shell.execute_reply": "2026-07-06T09:29:37.072452Z"
+    },
+    "papermill": {
+     "duration": 0.047133,
+     "end_time": "2026-07-06T09:29:37.072639",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.025506",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 (bargaining) a completer : voir indice ci-dessus."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Bargaining a 3 tours (a completer)\n",
+    "// Etape 1 : construire l'arbre ExtensiveFormGame avec discount 0.5 par tour refuse\n",
+    "// Etape 2 : appeler BackwardInduction et afficher l'offre d'equilibre\n",
+    "// Indice : au tour 3 (dernier), l'offreur prend tout le reste ; remontez avec le discount.\n",
+    "// var bargaining = ... ;\n",
+    "// var (bSol, bEq) = BackwardInduction(bargaining);\n",
+    "// DisplayBackwardInduction(bargaining, bSol);\n",
+    "display(\"Exercice 1 (bargaining) a completer : voir indice ci-dessus.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "982016f6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003534,
+     "end_time": "2026-07-06T09:29:37.079590",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.076056",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Jeu de l'ultimatum\n",
+    "\n",
+    "Le proposeur offre une part x de 10 ; le recepteur accepte (10-x, x) ou refuse (0, 0).\n",
+    "\n",
+    "**Objectif** : determiner l'offre SPE. Quel x le proposeur choisit-il a l'equilibre ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0eaee4fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:37.087253Z",
+     "iopub.status.busy": "2026-07-06T09:29:37.087098Z",
+     "iopub.status.idle": "2026-07-06T09:29:37.131070Z",
+     "shell.execute_reply": "2026-07-06T09:29:37.130949Z"
+    },
+    "papermill": {
+     "duration": 0.048246,
+     "end_time": "2026-07-06T09:29:37.131129",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.082883",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 (ultimatum) a completer : construire l'arbre puis BackwardInduction."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Jeu de l'ultimatum (a completer)\n",
+    "// Etape 1 : construire l'arbre (proposeur offre parmi {1, 2, ..., 5}, recepteur Accept/Reject)\n",
+    "// Etape 2 : resoudre par induction arriere\n",
+    "// Indice : le recepteur accepte toujours x > 0 (x > 0 > 0 du rejet) ; le proposeur offre donc le minimum.\n",
+    "// var ultimatum = ... ;\n",
+    "display(\"Exercice 2 (ultimatum) a completer : construire l'arbre puis BackwardInduction.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42ed9a92",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003075,
+     "end_time": "2026-07-06T09:29:37.137671",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.134596",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Take-Away (Nim a 1 tas)\n",
+    "\n",
+    "`n` jetons sur la table. 2 joueurs retirent a tour de role 1 a `max_take` jetons. Celui qui prend le **dernier** gagne.\n",
+    "\n",
+    "**Objectif** : modeliser comme jeu extensive (arbre), resoudre par induction, identifier les positions gagnantes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7b787de9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T09:29:37.145371Z",
+     "iopub.status.busy": "2026-07-06T09:29:37.145120Z",
+     "iopub.status.idle": "2026-07-06T09:29:37.208213Z",
+     "shell.execute_reply": "2026-07-06T09:29:37.208086Z"
+    },
+    "papermill": {
+     "duration": 0.067227,
+     "end_time": "2026-07-06T09:29:37.208277",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.141050",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 (Take-Away) a completer : modeliser l'arbre puis BackwardInduction."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Take-Away / Nim a 1 tas (a completer)\n",
+    "// Etape 1 : ecrire une fonction buildTakeAway(n, maxTake) -> ExtensiveFormGame\n",
+    "// Etape 2 : resoudre et determiner pour quels n le joueur 1 gagne\n",
+    "// Indice : les positions perdantes sont les multiples de (maxTake + 1).\n",
+    "// public static ExtensiveFormGame BuildTakeAway(int n, int maxTake) { ... }\n",
+    "display(\"Exercice 3 (Take-Away) a completer : modeliser l'arbre puis BackwardInduction.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "587f3b85",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003464,
+     "end_time": "2026-07-06T09:29:37.215553",
+     "exception": false,
+     "start_time": "2026-07-06T09:29:37.212089",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "**See** #4956 (marathon parite .NET), #3801 (Prong B : from-scratch), #2161 (exercices).\n",
+    "**Suite** : [GameTheory-11-BayesianGames-Csharp](GameTheory-11-BayesianGames-Csharp.ipynb) (jeux bayesiens)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.281089,
+   "end_time": "2026-07-06T09:29:37.351421",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-9-BackwardInduction-Csharp.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/gt9_csharp_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T09:29:32.070332",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -135,6 +135,7 @@ flowchart TD
 | 8b | [GameTheory-8b-Lean-CombinatorialGames](GameTheory-8b-Lean-CombinatorialGames.ipynb) | Lean 4 | PGame mathlib, Nim formel | 50 min |
 | 8c | [GameTheory-8c-CombinatorialGames-Python](GameTheory-8c-CombinatorialGames-Python.ipynb) | Python | Approfondissement jeux combinatoires | 40 min |
 | 9 | [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb) | Python | Induction arrière, mille-pattes, escalade | 55 min |
+| 9 (C#) | [GameTheory-9-BackwardInduction-Csharp](GameTheory-9-BackwardInduction-Csharp.ipynb) | .NET (C#) | Twin C# du 9 : induction arrière from-scratch, Entry/Centipede/War-of-Attrition/Chain-Store (See #4956) | 40 min |
 | 10 | [GameTheory-10-ForwardInduction-SPE](GameTheory-10-ForwardInduction-SPE.ipynb) | Python | Induction avant, SPE, menaces crédibles | 60 min |
 | 11 | [GameTheory-11-BayesianGames](GameTheory-11-BayesianGames.ipynb) | Python | Jeux bayésiens, information incomplète | 55 min |
 | 11b | [GameTheory-11b-Lean-BayesianGamesExt](GameTheory-11b-Lean-BayesianGamesExt.ipynb) | Lean 4 | Companion natif : théorème de Vickrey (enchère au second prix) prouvé 0-sorry dans le lake `lean_game_defs_ext` (module Bayesian, sans Mathlib) | 50 min |


### PR DESCRIPTION
## Résumé

**Twin C#** de [GameTheory-9-BackwardInduction](MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb) (Python + numpy/matplotlib). **Suite du marathon .NET ⇄ Python** (#4956), volet **formes extensives / induction arrière**. BCL .NET seule, 0 NuGet, **from-scratch** (Prong B #3801). **Rule 6 rotation** : c.46 reviews → c.47 BUILD, famille GameTheory tranche fraîche (extensive form ≠ Bayesian GT-11 ni Nash-existence GT-4c).

## Algorithme / démarche

- **Classes** : `GameNode` (mutable, `Player` = -1 terminal / 0 nature / ≥1 joueur, `Actions`, `Children`, `Payoffs {get;set;}`, `Infoset {get;set;}`) + `ExtensiveFormGame` (`Root`, `Nodes`).
- **BackwardInduction** récursif (Zermelo 1913, Selten 1965 SPE) :
  - Noeud terminal → `Payoffs`.
  - Noeud de chance → espérance pondérée des gains enfants.
  - Noeud de décision (joueur `p`) → **max** sur les actions du gain `childPayoffs[p-1]` ; enregistre l'action optimale (`NodeSolution`).
- **4 jeux classiques** résolus et interprétés :
  1. **Entry Game** (Entrant vs Incumbent) — menace "Fight" non credible.
  2. **Centipede** (6 tours) — paradoxe : SPE = Take immédiat [1,0] vs cooperatif [6,6].
  3. **War of Attrition** (V=10, c=1, 5 rounds) — escalade et abandonment.
  4. **Chain Store** (3 entrants) — paradoxe de Selten : Accommodate partout (reputation non rationnelle en SPE).
- **Visualisation ASCII** de l'arbre de jeu avec chemin SPE marqué `*` (complémentaire au matplotlib Python).

## Complémentarité (#3801 Prong B)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python | numpy + matplotlib | simulation vectorielle + graphe |
| **This (.NET BCL seule)** | from-scratch (récursion sur arbre, classes mutables) | **comprendre la mécanique** de l'induction arrière et des paradoxes SPE |

**Point clé** : la résolution est **algorithmique pure** (récursion sur arbre), pas un appel numpy. Les paradoxes (centipede Take-immediat, chain-store Accommodate-tout) emergent du code from-scratch, rendant leur mécanique explicite.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **11/11 cellules code `execution_count` 1-11, 0 erreur, 0 warning CS**. Outputs vérifiés **firsthand** :

- **Entry Game** : incumbent Accommodate (1 > -1) → entrant Enter (1 > 0) → eq [1.00, 1.00]. Menace Fight non credible ✓
- **Centipede 6** : tous les noeuds Take en remontant (node_5 → node_0), SPE [1.00, 0.00] (vs cooperatif [6,6]) ✓
- **Efficiency** : ratio SPE/cooperatif croît 2x→10x (n=2→10) ✓
- **Chain Store 3** : Accommodate 3 fois, Fight 0 fois, eq [0.00, 6.00] ✓
- **ASCII tree Entry Game** : chemin SPE `Enter → Accommodate` marqué `*` ✓

## Bugs G.1 self-corrected (déjà topic file marathon)

2 bugs c.47, classe connue (topic file `dotnet-csharp-twins-marathon-4956.md`) :
1. **CS0219** (variable unused) : `double monopTotal = 0;` dans `CreateChainStoreGame` non utilisée (j'utilise le paramètre `monopolyTotal`). Fix : retirer la ligne.
2. **CS0649** (field jamais assigné dans la cell de déclaration) : `public double[] Payoffs;` et `public string Infoset;` sont assignés dans des cells ultérieures → le compileur de la cell 0 (déclaration de classe) ne voit pas ces assignations et warn. Fix : auto-properties `{ get; set; }` (syntaxe d'accès identique, élimine le warning).

## SOTA-OK (#3801)

Vrai problème non-trivial : l'induction arrière + les paradoxes SPE (centipede, chain-store) sont au cœur de la théorie des jeux extensive. From-scratch = comprendre la récursion sur arbre et l'émergence des paradoxes, pas invoquer numpy. BCL .NET seule, 0 NuGet.

## Exercices (#2161)

3 stubs C.1-conformes : (1) bargaining à 3 tours avec discount, (2) jeu de l'ultimatum, (3) Take-Away (Nim 1 tas, positions gagnantes).

## Scope

Atomique : 1 notebook (26 cells, 11 code) + README table Partie 2 (+1 ligne). Self-contained (BCL seule). CATALOG-STATUS + fichiers catalogue byte-identical (R1). H.3 + C.1 = NONE.

## Marathon #4956

Suite GameTheory C# : GT-2 (NormalForm) + GT-11-Bayesian (#5540 OPEN) → **GT-9-BackwardInduction**. Tranches futures possibles : GT-5 (ZeroSum-Minimax, LP), GT-7 (ExtensiveForm).

See #4956, #3801. Revue souhaitée : po-2025, po-2024 (GT-4c C# owner) ou ai-01.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
