### PR TITLE
i18n(#4980): add ERC20.*_en siblings — EN mirrors, erc20_lean (lake fully bilingual)

### DIFF
--- a/.github/workflows/lean-erc20.yml
+++ b/.github/workflows/lean-erc20.yml
@@ -1,0 +1,47 @@
+name: Lean CI (erc20_lean)
+
+# CI for erc20_lean (MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean) —
+# formal verification of the ERC-20 fungible-token conservation invariant:
+# sum of balances = totalSupply, preserved by transfer/mint/burn. A machine-
+# state model (addresses = Fin n, balances = Address → ℕ, supplyInvariant).
+# The first Lean lake in the SmartContract series (roadmap #4038, issue #4047).
+# i18n #4980: FR+EN siblings (State/Ops/Invariant + _en mirrors).
+#
+# Gap in coverage: erc20_lean had NO regression workflow — its `_en` siblings
+# (#5545) were "CLEAN" with zero Lean verification behind it (the caller
+# workflow was missing). This wires it into the lean-build matrix the same way
+# finiteness_lean / sensitivity_lean / decision_theory_lean are, so the CI
+# drift-detection actually compiles both FR and EN modules.
+#
+# sorry-filter-mode=standalone-tactic, baseline=0: the module is entirely
+# sorry-free (verified: `grep -cE '^\\s*sorry...' ERC20/*.lean` = 0 on all 6
+# files FR+EN). standalone-tactic counts only standalone `sorry` tokens (never
+# prose false-positives). See lean-build.yml.
+#
+# Mathlib required (v4.31.0-rc1).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean
+      display-name: erc20_lean
+      sorry-baseline: "0"
+      sorry-filter-mode: standalone-tactic

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/ERC20/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/ERC20/Invariant_en.lean
@@ -1,0 +1,178 @@
+import Mathlib
+import ERC20.State_en
+import ERC20.Ops_en
+
+/-!
+# ERC20.Invariant — preservation of the conservation invariant
+
+We prove that the invariant `Σ balances = totalSupply` is preserved by each of
+the three standard operations (`mint`, `burn`, `transfer`), then by an arbitrary
+sequence of reachable operations (induction on the trace). These are the target
+theorems of issue #4047.
+
+The key technical ingredient is the **additive extraction** of a point from a
+finite sum: on `Fin n` (a finite type), `∑ a ∈ s, f a = f a₀ + ∑ a ∈ s.erase a₀, f a`
+whenever `a₀ ∈ s`. We carefully avoid distributing truncated subtraction on `ℕ`
+over the sum (`∑ (f - g) = ∑ f - ∑ g` is false in general on `ℕ`), reasoning
+instead by extraction (via `insert_erase`/`sum_insert`, additive form) then
+`ℕ` arithmetic (`Nat.add_sub_assoc`, `omega`).
+-/
+
+namespace ERC20_en
+
+variable {n : ℕ}
+
+open Finset
+
+/-- Additive extraction of a point from a finite sum: if `a ∈ s`, the sum over
+    `s` equals the value at `a` plus the sum over `s.erase a`. Additive form
+    (no subtraction), hence valid over `ℕ`. -/
+lemma sum_split_mem (f : Address n → ℕ) (s : Finset (Address n)) (a : Address n)
+    (ha : a ∈ s) : (∑ x ∈ s, f x) = f a + ∑ x ∈ s.erase a, f x := by
+  conv_lhs => rw [← insert_erase ha]
+  exact sum_insert (fun h => (mem_erase.mp h).1 rfl)
+
+/-- Special case `s = univ` (the sum over all addresses). -/
+lemma sum_univ_split (f : Address n → ℕ) (a : Address n) :
+    (∑ x : Address n, f x) = f a + ∑ x ∈ (univ : Finset (Address n)).erase a, f x :=
+  sum_split_mem f univ a (mem_univ a)
+
+/-- A single account balance is bounded by the total supply (under the invariant):
+    each term of an `ℕ` sum is bounded by the total sum. -/
+lemma balance_le_totalSupply (s : State n) (a : Address n) (h : supplyInvariant s) :
+    s.balances a ≤ s.totalSupply := by
+  rw [← h]
+  exact single_le_sum (fun _ _ => Nat.zero_le _) (mem_univ a)
+
+/-- **`mint` preserves the supply.** Minting `amount` to `dst` credits `amount`
+    to the balances AND to the total supply: the invariant is conserved. -/
+theorem mint_preserves_supply (s : State n) (dst : Address n) (amount : ℕ)
+    (h : supplyInvariant s) : supplyInvariant (mint s dst amount) := by
+  show ∑ a : Address n, (mint s dst amount).balances a = (mint s dst amount).totalSupply
+  simp only [mint]
+  have key : ∀ a : Address n,
+      (if a = dst then s.balances a + amount else s.balances a) =
+      s.balances a + (if a = dst then amount else (0:ℕ)) := by
+    intro a; split_ifs <;> simp
+  rw [sum_congr rfl (fun a _ => key a), sum_add_distrib,
+      sum_univ_split (fun a : Address n => if a = dst then amount else (0:ℕ)) dst,
+      if_pos (rfl : dst = dst)]
+  -- Le surplus (`amount`) ne vient que de `dst` ; sur `erase dst`, l'ite vaut 0.
+  have hr : ∑ a ∈ (univ : Finset (Address n)).erase dst,
+      (if a = dst then amount else (0:ℕ)) = 0 := by
+    apply sum_eq_zero
+    intro a ha
+    rw [mem_erase] at ha
+    exact if_neg ha.1
+  rw [hr, add_zero, ← h]
+
+/-- **`burn` preserves the supply.** Burning `amount` from `src` (sufficient
+    balance) removes `amount` from the balances AND from the total supply: the
+    invariant is conserved. -/
+theorem burn_preserves_supply (s : State n) (src : Address n) (amount : ℕ)
+    (hguard : s.balances src ≥ amount) (h : supplyInvariant s) :
+    supplyInvariant (burn s src amount) := by
+  show ∑ a : Address n, (burn s src amount).balances a = (burn s src amount).totalSupply
+  simp only [burn]
+  rw [← h, sum_univ_split
+        (fun a : Address n => if a = src then s.balances a - amount else s.balances a) src,
+      if_pos (rfl : src = src)]
+  -- Sur `erase src` (a ≠ src), l'ite dégénère vers `s.balances a`.
+  have hr : ∑ a ∈ (univ : Finset (Address n)).erase src,
+      (if a = src then s.balances a - amount else s.balances a : ℕ) =
+    ∑ a ∈ (univ : Finset (Address n)).erase src, s.balances a := by
+    apply sum_congr rfl
+    intro a ha
+    rw [mem_erase] at ha
+    exact if_neg ha.1
+  rw [hr, sum_univ_split s.balances src]
+  omega
+
+/-- **`transfer` preserves the supply.** Transferring `amount` from `src` to
+    `dst` (distinct addresses, sufficient balance) moves the tokens without
+    creating or destroying: the sum of balances is unchanged, as is the total
+    supply. -/
+theorem transfer_preserves_supply (s : State n) (src dst : Address n) (amount : ℕ)
+    (hguard : s.balances src ≥ amount) (hne : src ≠ dst) (h : supplyInvariant s) :
+    supplyInvariant (transfer s src dst amount) := by
+  show ∑ a : Address n, (transfer s src dst amount).balances a =
+        (transfer s src dst amount).totalSupply
+  simp only [transfer]
+  rw [← h, sum_univ_split
+        (fun a : Address n =>
+          if a = src then s.balances a - amount
+          else if a = dst then s.balances a + amount else s.balances a) src,
+      if_pos (rfl : src = src)]
+  -- Sur `erase src` (a ≠ src), l'ite dégénère vers la branche `dst`.
+  have hr1 : ∑ a ∈ (univ : Finset (Address n)).erase src,
+      (if a = src then s.balances a - amount
+        else if a = dst then s.balances a + amount else s.balances a : ℕ) =
+    ∑ a ∈ (univ : Finset (Address n)).erase src,
+        (if a = dst then s.balances a + amount else s.balances a) := by
+    apply sum_congr rfl
+    intro a ha
+    rw [mem_erase] at ha
+    exact if_neg ha.1
+  have hdst_mem : (dst : Address n) ∈ (univ : Finset (Address n)).erase src :=
+    mem_erase.mpr ⟨hne.symm, mem_univ _⟩
+  rw [hr1, sum_split_mem _ _ dst hdst_mem, if_pos (rfl : dst = dst)]
+  -- Sur `(erase src).erase dst` (a ≠ src, a ≠ dst), l'ite vaut `s.balances a`.
+  have hr2 : ∑ a ∈ ((univ : Finset (Address n)).erase src).erase dst,
+        (if a = dst then s.balances a + amount else s.balances a) =
+      ∑ a ∈ ((univ : Finset (Address n)).erase src).erase dst, s.balances a := by
+    apply sum_congr rfl
+    intro a ha
+    rw [mem_erase] at ha
+    exact if_neg ha.1
+  rw [hr2, sum_univ_split s.balances src,
+      sum_split_mem s.balances ((univ : Finset (Address n)).erase src) dst hdst_mem]
+  omega
+
+/-- **`transfer` debits the source exactly by `amount`, without underflow.**
+    The source account balance after `transfer` is `bal src - amount`, and the
+    guard makes this subtraction reversible (no semantic underflow). -/
+theorem transfer_no_underflow (s : State n) (src dst : Address n) (amount : ℕ)
+    (hguard : s.balances src ≥ amount) :
+    (transfer s src dst amount).balances src = s.balances src - amount ∧
+    s.balances src - amount + amount = s.balances src := by
+  refine ⟨?_, Nat.sub_add_cancel hguard⟩
+  simp [transfer]
+
+/-- **Reachable operation.** A step `s → s'` is one of the three operations
+    `mint`/`burn`/`transfer` executed from a state carrying the invariant. -/
+inductive Op (n : ℕ) : State n → State n → Prop
+  | mint (s : State n) (dst : Address n) (amount : ℕ) (h : supplyInvariant s) :
+      Op n s (mint s dst amount)
+  | burn (s : State n) (src : Address n) (amount : ℕ)
+      (hguard : s.balances src ≥ amount) (h : supplyInvariant s) :
+      Op n s (burn s src amount)
+  | transfer (s : State n) (src dst : Address n) (amount : ℕ)
+      (hguard : s.balances src ≥ amount) (hne : src ≠ dst) (h : supplyInvariant s) :
+      Op n s (transfer s src dst amount)
+
+/-- A reachable operation preserves the invariant (case-by-case). -/
+lemma op_preserves_invariant (s s' : State n) (hop : Op n s s') (h : supplyInvariant s) :
+    supplyInvariant s' := by
+  cases hop with
+  | mint dst amount _ => exact mint_preserves_supply s dst amount h
+  | burn src amount hguard _ => exact burn_preserves_supply s src amount hguard h
+  | transfer src dst amount hguard hne _ =>
+    exact transfer_preserves_supply s src dst amount hguard hne h
+
+/-- **Reflexive-transitive reachability.** `Reachable n s s'`: `s'` is reachable
+    from `s` by zero, one or several operations. -/
+inductive Reachable (n : ℕ) : State n → State n → Prop
+  | refl (s : State n) : Reachable n s s
+  | step (s₁ s₂ s₃ : State n) (hop : Op n s₁ s₂) (hrest : Reachable n s₂ s₃) :
+      Reachable n s₁ s₃
+
+/-- **Induction on the trace:** any sequence of reachable operations preserves
+    the invariant end-to-end. The final state still carries the invariant. -/
+theorem reachable_preserves_invariant (s s' : State n) (h : supplyInvariant s)
+    (hr : Reachable n s s') : supplyInvariant s' := by
+  induction hr with
+  | refl => exact h
+  | step s₁ s₂ s₃ hop hrest ih =>
+    exact ih (op_preserves_invariant s₁ s₂ hop h)
+
+end ERC20_en

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/ERC20/Ops_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/ERC20/Ops_en.lean
@@ -1,0 +1,42 @@
+import Mathlib
+import ERC20.State_en
+
+/-!
+# ERC20.Ops — guarded transitions (transfer, mint, burn)
+
+The three standard operations of an ERC-20 token, viewed as guarded state
+transitions. The guards (`sufficient balance`) ensure the absence of underflow:
+a `transfer`/`burn` cannot withdraw more than the present balance.
+
+Note: the names `src`/`dst` (source/destination) substitute the usual ERC-20
+parameters `from`/`to`, which are reserved keywords in Lean 4.
+-/
+
+namespace ERC20_en
+
+variable {n : ℕ}
+
+/-- `mint dst amount`: mints `amount` tokens credited to the `dst` account, and
+    increases the total supply by the same amount. (Privileged operation of the
+    contract owner.) -/
+def mint (s : State n) (dst : Address n) (amount : ℕ) : State n :=
+  { balances := fun a => if a = dst then s.balances a + amount else s.balances a
+    totalSupply := s.totalSupply + amount }
+
+/-- `burn src amount`: burns `amount` tokens from the `src` account (implicit
+    guard: sufficient balance), and decreases the total supply by the same amount. -/
+def burn (s : State n) (src : Address n) (amount : ℕ) : State n :=
+  { balances := fun a => if a = src then s.balances a - amount else s.balances a
+    totalSupply := s.totalSupply - amount }
+
+/-- `transfer src dst amount`: transfers `amount` tokens from `src` to `dst`.
+    The total supply is unchanged (internal move of tokens). The source account
+    balance must cover `amount` (guard, checked in `transfer_no_underflow`). -/
+def transfer (s : State n) (src dst : Address n) (amount : ℕ) : State n :=
+  { balances := fun a =>
+      if a = src then s.balances a - amount
+      else if a = dst then s.balances a + amount
+      else s.balances a
+    totalSupply := s.totalSupply }
+
+end ERC20_en

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/ERC20/State_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/ERC20/State_en.lean
@@ -1,0 +1,36 @@
+import Mathlib
+
+/-!
+# ERC20.State — state of an ERC-20 token (balances + total supply)
+
+Finite state-machine modelling of the ERC-20 fungible-token standard
+(issue #4047). Addresses are `Fin n` (a finite number of potential holders,
+equipped with a `Fintype`), balances are `Address → ℕ`, the total supply an
+`ℕ`. The founding invariant `Σ balances = totalSupply` is defined here.
+-/
+
+namespace ERC20_en
+
+variable {n : ℕ}
+
+/-- An address = the `i`-th account among `n` potential holders. The type
+    `Fin n` is finite (`Fintype`), which makes the sum of balances well-defined. -/
+abbrev Address (n : ℕ) := Fin n
+
+/-- The global state of an ERC-20 token: the balance table of each address plus
+    the total supply (initially minted, preserved by `transfer`, symmetrically
+    modified by `mint`/`burn`). -/
+structure State (n : ℕ) where
+  /-- Current balance of each address. -/
+  balances : Address n → ℕ
+  /-- Total supply of the token: the conserved sum of balances under the invariant. -/
+  totalSupply : ℕ
+
+/-- **ERC-20 conservation invariant**: the sum of the balances of all addresses
+    equals the total supply. This is the defining property of a fungible token —
+    no token can be created or destroyed by `transfer` (only `mint`/`burn` do so,
+    symmetrically on the supply). -/
+def supplyInvariant (s : State n) : Prop :=
+  ∑ a : Address n, s.balances a = s.totalSupply
+
+end ERC20_en


### PR DESCRIPTION
## i18n(#4980): add `ERC20.*_en` siblings — EN mirrors, erc20_lean (**lake fully bilingual**)

English mirrors of `ERC20/State.lean`, `ERC20/Ops.lean`, `ERC20/Invariant.lean` (FR-first canonical). Convention i18n Lean ratifiée ai-01 (2026-07-04, #4980 comment-4881909354): distincts FR + EN siblings dans le même lake, les deux compilent; contenu non-docstring byte-identique (drift-CI detectable).

### What — ERC-20 conservation invariant, issue #4047

`erc20_lean` is the Lean 4 formalization of the **ERC-20 fungible-token standard**: the founding conservation invariant `∑ balances = totalSupply` is **proven preserved** by each of `mint`/`burn`/`transfer`, then by an arbitrary reachable operation sequence (induction on the trace). The flagship is `reachable_preserves_invariant` (trace induction).

### Atomic — 3 EN siblings in one PR (small coherent lake)

| File | Role | FR→EN diff (non-docstring) |
|------|------|----------------------------|
| `State_en.lean` (leaf) | `abbrev Address`, `structure State` (balances + totalSupply), `supplyInvariant` | namespace + end |
| `Ops_en.lean` | guarded transitions `mint`/`burn`/`transfer` | + import-swap `State_en`, drop redundant `open ERC20`, namespace + end |
| `Invariant_en.lean` (**flagship**) | point-extraction lemmas, 4 preservation theorems, `Op`/`Reachable` inductives, `reachable_preserves_invariant` | + 2 import-swaps, namespace + end (`open Finset` KEPT — Mathlib) |

Single PR (not stacked) because erc20_lean is one small coherent lake (257L total). Dependency chain State → Ops → Invariant all in the PR.

### Why this is safe — self-contained EN namespace, structure-field dot-notation only

All 3 EN siblings live in `namespace ERC20_en`. The **only** dot-notation is **structure-field access** (`s.balances`, `s.totalSupply`, `(mint s dst amount).balances`, `(transfer s src dst amount).totalSupply` = fields of `structure State`), which resolves via the structure definition regardless of namespace. All function references are **prefix** application (`mint s dst amount`, `burn s src amount`, `transfer s src dst amount`, `supplyInvariant s`, `op_preserves_invariant s s' hop h`). The `inductive Op`/`Reachable` constructors resolve within the EN namespace. **No `<value>.<namespace-fn>` dot-notation** that would resolve against a cross-namespace type → this is the SAFE profile, NOT the Lattice_en trap.

### Sorry parity — no regression (lake is 0-sorry)

| File | FR sorry | EN sorry |
|------|----------|----------|
| State | 0 | 0 |
| Ops | 0 | 0 |
| Invariant (flagship) | 0 | 0 |

The ERC-20 conservation invariant is **fully proven in BOTH siblings** — no `sorry` anywhere.

### Verification (lean-merge-discipline HARD)

```
$ lake.exe build ERC20.Invariant_en
✔ [8493/8495] Built ERC20.State_en (37s)
✔ [8494/8495] Built ERC20.Ops_en (13s)
✔ [8495/8495] Built ERC20.Invariant_en (13s)
Build completed successfully (8495 jobs), exit 0
```
`Invariant_en` transitively builds `State_en` + `Ops_en` → the **entire EN side of the lake is verified** by this single build.

| Check | Result |
|-------|--------|
| `lake build ERC20.Invariant_en` | **SUCCESS** (8495 jobs, all 3 EN files) |
| FR files baseline | SUCCESS (0 sorry each) |
| sorry FR vs EN | 0 = 0 on all 3 (no regression) |
| FR files | byte-identical to main (anti-regression D) |
| Toolchain | `leanprover/lean4:v4.31.0-rc1` (cluster convergence #4364) |

### Scope — erc20_lean fully bilingual + i18n lake inventory CONCLUDED

After this PR merges, erc20_lean is **fully bilingual** (3/3 content files FR + EN). The umbrella `ERC20` lib auto-discovers all `_en` via globs `.submodules \`ERC20` (no lakefile change needed). → **globs `ERC20.*` UNBLOCKED** fleet-wide (c.219 Finding "globs expose broken _en" — erc20_lean has NONE).

**This concludes the i18n lake-creation inventory**: all clean-profile lakes are now fully bilingual (sensitivity, kelly, repeated_games, planning, sudoku, calibration, erc20 + the ConeKernel-only cooperative_games). Remaining lakes are STRUCTURAL DEFER (stable_marriage `Lattice_en`, cooperative_games `Basic_en`, argumentation_lean — structure-namespace coincidence trap requiring non-byte-identical multi-file renames, cf [[lean-i18n-convention]]).

FR files UNCHANGED. Pure +file addition (3 files, +256).

See #4980
See #4047

🤖 Generated with [Claude Code](https://claude.com/claude-code)
