### PR TITLE
feat(search-apps): App-1b-NQueens-CSharp — twin C# N-Reines from-scratch (backtracking/MRV/FC + Min-Conflicts + symétrie D4) (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
@@ -1,0 +1,1451 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b6601688-9f2f-4570-bae4-202df6e512ee",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009502,
+     "end_time": "2026-07-06T10:36:43.480831",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:43.471329",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# App-1b : Le probl\u00e8me des N-Reines \u2014 Jumeau C#\n",
+    "\n",
+    "> **Twin C#** de [`App-1-NQueens`](App-1-NQueens.ipynb) (Python + OR-Tools + numpy + matplotlib).\n",
+    "> Suite du marathon **.NET \u21c4 Python** (#4956), volet **Search / Applications / CSP**.\n",
+    "> BCL .NET seule, **0 NuGet**, **from-scratch** (Prong B #3801).\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Mod\u00e9liser les N-Reines comme un **CSP** (variables, domaines, contraintes).\n",
+    "2. Comparer **trois familles** de r\u00e9solution : *backtracking* (avec heuristiques MRV + Forward Checking), *min-conflicts* (recherche locale), et **\u00e9num\u00e9ration compl\u00e8te** (toutes les solutions + comptage des solutions fondamentales par brisure de sym\u00e9trie).\n",
+    "3. Comprendre **algorithmiquement** le \u00ab miracle \u00bb de Min-Conflicts (passage \u00e0 l'\u00e9chelle jusqu'\u00e0 N = 1000+) et la **brisure de sym\u00e9trie** (8 transformations du carr\u00e9 \u2192 forme canonique).\n",
+    "\n",
+    "## Compl\u00e9mentarit\u00e9 (#3801 Prong B)\n",
+    "\n",
+    "| Twin | Outil | Valeur |\n",
+    "|------|-------|--------|\n",
+    "| Python | **OR-Tools CP-SAT** (solveur industriel) + numpy + matplotlib | invoquer un solveur, simulation vectorielle |\n",
+    "| **Ce twin (.NET BCL seule)** | **from-scratch** (r\u00e9cursion, propagation de domaines, marche al\u00e9atoire, transforms D4) | **comprendre la m\u00e9canique** : backtracking, propagation, recherche locale, sym\u00e9tries |\n",
+    "\n",
+    "Le twin Python **appelle** un solveur ; ce twin **d\u00e9roule** les algorithmes. Les deux se compl\u00e8tent : on voit ici *ce que fait* CP-SAT sous le capot (propagation, \u00e9num\u00e9ration, brisure de sym\u00e9trie).\n",
+    "\n",
+    "**Dur\u00e9e estim\u00e9e : 35 min.** Pr\u00e9requis : [`Search-1`](../../Part1-Foundations/Search-1-UninformedSearch.ipynb), [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb) (CSP).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2dbf824b-edff-40bc-b080-e8615eae95ab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0019,
+     "end_time": "2026-07-06T10:36:43.486004",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:43.484104",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Repr\u00e9sentation du probl\u00e8me\n",
+    "\n",
+    "On repr\u00e9sente un plateau par `queens[col] = row` : **une reine par colonne** (la contrainte \u00ab une par colonne \u00bb est donc satisfaite par construction). Il reste \u00e0 v\u00e9rifier les conflits de **ligne** et de **diagonales**.\n",
+    "\n",
+    "Cellule d'installation : on d\u00e9finit le helper de formatage invariant (pour \u00e9viter la collision virgule-d\u00e9cimale FR) et les compteurs de n\u0153uds explor\u00e9s.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3cef7737-deaf-4918-b98d-4e55471fde9e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:43.501357Z",
+     "iopub.status.busy": "2026-07-06T10:36:43.495950Z",
+     "iopub.status.idle": "2026-07-06T10:36:45.214986Z",
+     "shell.execute_reply": "2026-07-06T10:36:45.207436Z"
+    },
+    "papermill": {
+     "duration": 1.725147,
+     "end_time": "2026-07-06T10:36:45.215121",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:43.489974",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '62336.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Setup OK \u2014 repr\u00e9sentation queens[col]=row, helper IsSafe d\u00e9fini."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Diagnostics;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// Formatage invariant (r\u00e8gle marathon : la culture FR ne persiste pas entre cellules .NET Interactive)\n",
+    "static string FI(double x, string fmt = \"F3\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "static string FI(long x) => x.ToString(\"N0\", CultureInfo.InvariantCulture);\n",
+    "static void Show(string s) => display(s);\n",
+    "\n",
+    "// conflit entre (col,row) et les reines d\u00e9j\u00e0 plac\u00e9es dans les colonnes marqu\u00e9es `placed`\n",
+    "static bool IsSafe(int[] queens, int col, int row, bool[] placed) {\n",
+    "    for (int c = 0; c < queens.Length; c++) {\n",
+    "        if (c == col || !placed[c]) continue;\n",
+    "        int r = queens[c];\n",
+    "        if (r == row) return false;                       // m\u00eame ligne\n",
+    "        if (Math.Abs(r - row) == Math.Abs(col - c)) return false;  // m\u00eame diagonale\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "Show(\"Setup OK \u2014 repr\u00e9sentation queens[col]=row, helper IsSafe d\u00e9fini.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3206d27-1ad7-4b13-8572-7903925e53dc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003455,
+     "end_time": "2026-07-06T10:36:45.222195",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:45.218740",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Approche 1a : Backtracking simple\n",
+    "\n",
+    "On remplit les colonnes de gauche \u00e0 droite. Pour chaque colonne, on essaie les lignes de haut en bas ; la premi\u00e8re ligne **s\u00fbre** est accept\u00e9e et on descend. Si aucune ligne ne convient, on **remonte** (backtrack).\n",
+    "\n",
+    "C'est le DFS sur l'arbre des affectations partielles. On compte les **n\u0153uds explor\u00e9s** pour comparer les variantes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fb89e3b0-29fb-4297-9306-2b9fdf69f80f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:45.231670Z",
+     "iopub.status.busy": "2026-07-06T10:36:45.231181Z",
+     "iopub.status.idle": "2026-07-06T10:36:45.454747Z",
+     "shell.execute_reply": "2026-07-06T10:36:45.454581Z"
+    },
+    "papermill": {
+     "duration": 0.229418,
+     "end_time": "2026-07-06T10:36:45.454828",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:45.225410",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Backtracking simple, N = 8 -> 113 n\u0153uds explor\u00e9s."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Q . . . . . . . \r\n",
+       ". . . . . . Q . \r\n",
+       ". . . . Q . . . \r\n",
+       ". . . . . . . Q \r\n",
+       ". Q . . . . . . \r\n",
+       ". . . Q . . . . \r\n",
+       ". . . . . Q . . \r\n",
+       ". . Q . . . . . \r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "long _btNodes;\n",
+    "\n",
+    "bool BacktrackSimple(int[] queens, bool[] placed, int col, int n) {\n",
+    "    if (col == n) return true;           // toutes les colonnes plac\u00e9es -> solution\n",
+    "    _btNodes++;\n",
+    "    for (int row = 0; row < n; row++) {\n",
+    "        if (IsSafe(queens, col, row, placed)) {\n",
+    "            queens[col] = row; placed[col] = true;\n",
+    "            if (BacktrackSimple(queens, placed, col + 1, n)) return true;\n",
+    "            placed[col] = false;          // backtrack\n",
+    "        }\n",
+    "    }\n",
+    "    return false;\n",
+    "}\n",
+    "\n",
+    "int SolveSimple(int n) {\n",
+    "    var queens = new int[n]; var placed = new bool[n]; _btNodes = 0;\n",
+    "    BacktrackSimple(queens, placed, 0, n);\n",
+    "    return _btNodes > 0 ? 1 : 0;\n",
+    "}\n",
+    "\n",
+    "string BoardString(int[] queens) {\n",
+    "    int n = queens.Length; var sb = new System.Text.StringBuilder();\n",
+    "    for (int r = 0; r < n; r++) {\n",
+    "        for (int c = 0; c < n; c++) sb.Append(queens[c] == r ? \"Q \" : \". \");\n",
+    "        sb.AppendLine();\n",
+    "    }\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "int n = 8;\n",
+    "var q = new int[n]; var p = new bool[n]; _btNodes = 0;\n",
+    "BacktrackSimple(q, p, 0, n);\n",
+    "Show(\"Backtracking simple, N = \" + n + \" -> \" + FI(_btNodes) + \" n\u0153uds explor\u00e9s.\");\n",
+    "Show(BoardString(q));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf2df63-f1f5-453f-88de-5508e50ba2e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003036,
+     "end_time": "2026-07-06T10:36:45.461182",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:45.458146",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.1 Backtracking avec heuristique MRV (Minimum Remaining Values)\n",
+    "\n",
+    "Au lieu de fixer l'ordre des colonnes, on choisit \u00e0 chaque pas la colonne **non assign\u00e9e** qui a le **moins** de lignes s\u00fbres possibles. Intuition : \u00e9chouer vite l\u00e0 o\u00f9 on est le plus contraint r\u00e9duit la taille de l'arbre.\n",
+    "\n",
+    "> Ici, comme chaque colonne re\u00e7oit exactement une reine, MRV agit sur l'**ordre des variables** (quelle colonne remplir ensuite), et non sur les domaines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8d16dcb0-70fc-480c-9e5a-c75e816e9291",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:45.468909Z",
+     "iopub.status.busy": "2026-07-06T10:36:45.468664Z",
+     "iopub.status.idle": "2026-07-06T10:36:45.572548Z",
+     "shell.execute_reply": "2026-07-06T10:36:45.572369Z"
+    },
+    "papermill": {
+     "duration": 0.108284,
+     "end_time": "2026-07-06T10:36:45.572626",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:45.464342",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Backtracking MRV, N = 8 -> 52 n\u0153uds explor\u00e9s (vs simple ci-dessus)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "long _mrvNodes;\n",
+    "\n",
+    "bool BacktrackMRV(int[] queens, bool[] placed, int n) {\n",
+    "    // 1. choisir la colonne non assign\u00e9e avec le moins de lignes s\u00fbres (MRV)\n",
+    "    int bestCol = -1, bestCount = int.MaxValue;\n",
+    "    List<int> bestRows = new List<int>();\n",
+    "    for (int col = 0; col < n; col++) {\n",
+    "        if (placed[col]) continue;\n",
+    "        var rows = new List<int>();\n",
+    "        for (int row = 0; row < n; row++)\n",
+    "            if (IsSafe(queens, col, row, placed)) rows.Add(row);\n",
+    "        if (rows.Count < bestCount) { bestCount = rows.Count; bestCol = col; bestRows = rows; }\n",
+    "        if (bestCount == 0) return false;            // impasse d\u00e9tect\u00e9e t\u00f4t\n",
+    "    }\n",
+    "    if (bestCol == -1) return true;                  // tout est assign\u00e9 -> solution\n",
+    "    _mrvNodes++;\n",
+    "    placed[bestCol] = true;\n",
+    "    foreach (var row in bestRows) {\n",
+    "        queens[bestCol] = row;\n",
+    "        if (BacktrackMRV(queens, placed, n)) return true;\n",
+    "    }\n",
+    "    placed[bestCol] = false;\n",
+    "    return false;\n",
+    "}\n",
+    "\n",
+    "int n = 8;\n",
+    "var q = new int[n]; var p = new bool[n]; _mrvNodes = 0;\n",
+    "BacktrackMRV(q, p, n);\n",
+    "Show(\"Backtracking MRV, N = \" + n + \" -> \" + FI(_mrvNodes) + \" n\u0153uds explor\u00e9s (vs simple ci-dessus).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ed56bf7-b226-4402-b72c-59290601c103",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003619,
+     "end_time": "2026-07-06T10:36:45.579505",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:45.575886",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.2 Backtracking avec Forward Checking (FC)\n",
+    "\n",
+    "\u00c0 chaque placement, on **propage** : on retire des domaines des colonnes encore vides toutes les lignes devenues conflictuelles. Si un domaine devient vide, on d\u00e9clenche le backtrack **imm\u00e9diatement** (avant m\u00eame de d\u00e9velopper). On restaure les domaines au backtrack (pile des retraits).\n",
+    "\n",
+    "C'est exactement la propagation de contraintes qu'effectue CP-SAT sous le capot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "39a6ba6c-99e3-41e5-9bb6-b1da00ca7d5e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:45.587399Z",
+     "iopub.status.busy": "2026-07-06T10:36:45.587097Z",
+     "iopub.status.idle": "2026-07-06T10:36:45.823163Z",
+     "shell.execute_reply": "2026-07-06T10:36:45.822990Z"
+    },
+    "papermill": {
+     "duration": 0.240676,
+     "end_time": "2026-07-06T10:36:45.823244",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:45.582568",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Backtracking Forward-Checking, N = 8 -> 51 n\u0153uds explor\u00e9s."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Q . . . . . . . \r\n",
+       ". . . . . . Q . \r\n",
+       ". . . . Q . . . \r\n",
+       ". . . . . . . Q \r\n",
+       ". Q . . . . . . \r\n",
+       ". . . Q . . . . \r\n",
+       ". . . . . Q . . \r\n",
+       ". . Q . . . . . \r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "long _fcNodes;\n",
+    "\n",
+    "// domaines : un HashSet par colonne des lignes encore possibles\n",
+    "bool BacktrackFC(int[] queens, HashSet<int>[] domains, int placedCount, int n) {\n",
+    "    if (placedCount == n) return true;\n",
+    "    _fcNodes++;\n",
+    "    // choisir la colonne non assign\u00e9e au plus petit domaine (MRV sur domaines filtr\u00e9s)\n",
+    "    int bestCol = -1, bestSize = int.MaxValue;\n",
+    "    for (int col = 0; col < n; col++) {\n",
+    "        if (queens[col] >= 0) continue;\n",
+    "        if (domains[col].Count < bestSize) { bestSize = domains[col].Count; bestCol = col; }\n",
+    "    }\n",
+    "    if (bestSize == 0) return false;                 // domaine vide -> impasse\n",
+    "    // snapshot des lignes candidats (on it\u00e8re sur une copie car on va modifier domains)\n",
+    "    var candidates = domains[bestCol].ToList();\n",
+    "    foreach (var row in candidates) {\n",
+    "        // tenter (bestCol, row) : propager\n",
+    "        var removed = new List<(int col, int row)>();\n",
+    "        bool dead = false;\n",
+    "        queens[bestCol] = row;\n",
+    "        for (int col = 0; col < n; col++) {\n",
+    "            if (col == bestCol || queens[col] >= 0) continue;\n",
+    "            var toRemove = domains[col].Where(r => r == row || Math.Abs(r - row) == Math.Abs(col - bestCol)).ToList();\n",
+    "            foreach (var r in toRemove) { domains[col].Remove(r); removed.Add((col, r)); }\n",
+    "            if (domains[col].Count == 0) { dead = true; break; }\n",
+    "        }\n",
+    "        if (!dead && BacktrackFC(queens, domains, placedCount + 1, n)) return true;\n",
+    "        // restaurer\n",
+    "        foreach (var (c, r) in removed) domains[c].Add(r);\n",
+    "        queens[bestCol] = -1;\n",
+    "    }\n",
+    "    return false;\n",
+    "}\n",
+    "\n",
+    "int n = 8;\n",
+    "var q = Enumerable.Range(0, n).Select(_ => -1).ToArray();\n",
+    "var dom = Enumerable.Range(0, n).Select(_ => new HashSet<int>(Enumerable.Range(0, n))).ToArray();\n",
+    "_fcNodes = 0;\n",
+    "BacktrackFC(q, dom, 0, n);\n",
+    "Show(\"Backtracking Forward-Checking, N = \" + n + \" -> \" + FI(_fcNodes) + \" n\u0153uds explor\u00e9s.\");\n",
+    "Show(BoardString(q));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49229e2b-745b-43f1-a06a-5c00e1dc42f0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003396,
+     "end_time": "2026-07-06T10:36:45.830071",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:45.826675",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.3 Benchmark des trois variantes\n",
+    "\n",
+    "On compare le **nombre de n\u0153uds explor\u00e9s** et le **temps** pour trouver une premi\u00e8re solution, de N = 8 \u00e0 N = 16. Attendu : FC < MRV < simple (la propagation coupe l'arbre plus t\u00f4t)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "df22ce87-9ace-4fa7-8c4f-c46a11234c80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:45.839570Z",
+     "iopub.status.busy": "2026-07-06T10:36:45.839083Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.026778Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.026629Z"
+    },
+    "papermill": {
+     "duration": 0.192962,
+     "end_time": "2026-07-06T10:36:46.026854",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:45.833892",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "   N |     simple |        MRV |         FC | t_simple(ms) |  t_MRV(ms) |  t_FC(ms)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "-----------------------------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   8 |        113 |         52 |         51 |        0.029 |      0.089 |     0.109"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  10 |        102 |         26 |         26 |        0.032 |      0.067 |     0.051"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  12 |        261 |        107 |         84 |        0.109 |      0.347 |     0.165"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  14 |      1,899 |         91 |        105 |        0.885 |      0.466 |     0.235"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  16 |     10,052 |         37 |         37 |        6.113 |      0.246 |     0.097"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Interpr\u00e9tation : simple explose (croissance ~factorielle), MRV et FC la divisent par 1-2 ordres de grandeur."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "MRV et FC sont comparables : selon l'instance, l'un ou l'autre gagne (la propagation de FC et"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "l'ordonnancement de MRV coupent l'arbre diff\u00e9remment). Le gain dominant vient de l'heuristique vs simple."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var results = new List<(int n, long simple, long mrv, long fc, double tSimple, double tMrv, double tFc)>();\n",
+    "for (int n = 8; n <= 16; n += 2) {\n",
+    "    // simple\n",
+    "    var q1 = new int[n]; var p1 = new bool[n]; _btNodes = 0;\n",
+    "    var sw = Stopwatch.StartNew(); BacktrackSimple(q1, p1, 0, n); sw.Stop();\n",
+    "    double ts = sw.Elapsed.TotalMilliseconds; long ns = _btNodes;\n",
+    "    // MRV\n",
+    "    var q2 = new int[n]; var p2 = new bool[n]; _mrvNodes = 0;\n",
+    "    sw = Stopwatch.StartNew(); BacktrackMRV(q2, p2, n); sw.Stop();\n",
+    "    double tm = sw.Elapsed.TotalMilliseconds; long nm = _mrvNodes;\n",
+    "    // FC\n",
+    "    var q3 = Enumerable.Range(0, n).Select(_ => -1).ToArray();\n",
+    "    var dom3 = Enumerable.Range(0, n).Select(_ => new HashSet<int>(Enumerable.Range(0, n))).ToArray();\n",
+    "    _fcNodes = 0;\n",
+    "    sw = Stopwatch.StartNew(); BacktrackFC(q3, dom3, 0, n); sw.Stop();\n",
+    "    double tf = sw.Elapsed.TotalMilliseconds; long nf = _fcNodes;\n",
+    "    results.Add((n, ns, nm, nf, ts, tm, tf));\n",
+    "}\n",
+    "\n",
+    "var hdr = \"N\".PadLeft(4) + \" | \" + \"simple\".PadLeft(10) + \" | \" + \"MRV\".PadLeft(10) + \" | \" + \"FC\".PadLeft(10) + \" | \" + \"t_simple(ms)\".PadLeft(12) + \" | \" + \"t_MRV(ms)\".PadLeft(10) + \" | \" + \"t_FC(ms)\".PadLeft(9);\n",
+    "Show(hdr);\n",
+    "Show(new string('-', hdr.Length));\n",
+    "foreach (var r in results) {\n",
+    "    string line = r.n.ToString().PadLeft(4) + \" | \" + FI(r.simple).PadLeft(10) + \" | \" + FI(r.mrv).PadLeft(10) + \" | \"\n",
+    "                + FI(r.fc).PadLeft(10) + \" | \" + FI(r.tSimple, \"F3\").PadLeft(12) + \" | \" + FI(r.tMrv, \"F3\").PadLeft(10) + \" | \" + FI(r.tFc, \"F3\").PadLeft(9);\n",
+    "    Show(line);\n",
+    "}\n",
+    "Show(\"Interpr\u00e9tation : simple explose (croissance ~factorielle), MRV et FC la divisent par 1-2 ordres de grandeur.\");\n",
+    "Show(\"MRV et FC sont comparables : selon l'instance, l'un ou l'autre gagne (la propagation de FC et\");\n",
+    "Show(\"l'ordonnancement de MRV coupent l'arbre diff\u00e9remment). Le gain dominant vient de l'heuristique vs simple.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bce02a5c-0337-45ab-a84d-4582816ae6e8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003181,
+     "end_time": "2026-07-06T10:36:46.034052",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.030871",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Approche 2 : Min-Conflicts (recherche locale)\n",
+    "\n",
+    "id\u00e9e radicalement diff\u00e9rente : on part d'une affectation **al\u00e9atoire** (une reine par colonne, ligne al\u00e9atoire), puis on **r\u00e9pare**. \u00c0 chaque it\u00e9ration, on choisit une colonne en conflit et on d\u00e9place sa reine vers la ligne qui **minimise** le nombre de conflits. Pas de retour arri\u00e8re : c'est une **marche** dans l'espace des configurations.\n",
+    "\n",
+    "C'est l'anc\u00eatre des m\u00e9taheuristiques (proche du hill-climbing stochastique, cf [`Search-11`](../../Part3-Advanced/Search-11-Metaheuristics.ipynb))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ad3526c7-24b4-44bd-b71a-932a8d9b6872",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:46.041764Z",
+     "iopub.status.busy": "2026-07-06T10:36:46.041548Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.118887Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.118586Z"
+    },
+    "papermill": {
+     "duration": 0.081839,
+     "end_time": "2026-07-06T10:36:46.119033",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.037194",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Min-Conflicts, N = 8 -> solution en 17 it\u00e9rations (ok=True)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       ". . Q . . . . . \r\n",
+       ". . . . . Q . . \r\n",
+       ". . . . . . . Q \r\n",
+       ". Q . . . . . . \r\n",
+       ". . . Q . . . . \r\n",
+       "Q . . . . . . . \r\n",
+       ". . . . . . Q . \r\n",
+       ". . . . Q . . . \r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Conflits maintenus incr\u00e9mentalement via compteurs par ligne / diagonale (O(1) par requ\u00eate)\n",
+    "//  - rowConf[r]      = nombre de reines dans la ligne r\n",
+    "//  - diag1Conf[r-c+n]= nombre de reines sur la diagonale NO-SE (diff\u00e9rence r-c constante)\n",
+    "//  - diag2Conf[r+c]  = nombre de reines sur la diagonale SO-NE (somme r+c constante)\n",
+    "// Conflits subis par la reine (col,row) = (rowConf[row]-1) + (diag1-1) + (diag2-1)\n",
+    "(bool ok, int iters, int[] queens) MinConflicts(int n, int maxIters, int seed) {\n",
+    "    var rnd = new Random(seed);\n",
+    "    var queens = new int[n];\n",
+    "    var rowConf = new int[n];\n",
+    "    var diag1 = new int[2 * n + 1];   // indice r-c+n in [1..2n-1]\n",
+    "    var diag2 = new int[2 * n + 1];   // indice r+c in [0..2n-2]\n",
+    "    for (int c = 0; c < n; c++) {\n",
+    "        int r = rnd.Next(n);\n",
+    "        queens[c] = r;\n",
+    "        rowConf[r]++; diag1[r - c + n]++; diag2[r + c]++;\n",
+    "    }\n",
+    "    for (int it = 0; it < maxIters; it++) {\n",
+    "        // colonnes en conflit\n",
+    "        var conflicted = new List<int>();\n",
+    "        for (int c = 0; c < n; c++) {\n",
+    "            int r = queens[c];\n",
+    "            int conf = (rowConf[r] - 1) + (diag1[r - c + n] - 1) + (diag2[r + c] - 1);\n",
+    "            if (conf > 0) conflicted.Add(c);\n",
+    "        }\n",
+    "        if (conflicted.Count == 0) return (true, it, queens);\n",
+    "        int col = conflicted[rnd.Next(conflicted.Count)];\n",
+    "        int curRow = queens[col];\n",
+    "        // collecter TOUTES les lignes minimisant les conflits, puis tirage uniforme\n",
+    "        // (tie-break uniforme = \u00e9vite les cycles ; la reine d\u00e9plac\u00e9e EXCLUE de son propre compte)\n",
+    "        int bestConf = int.MaxValue;\n",
+    "        var bestRows = new List<int>();\n",
+    "        for (int row = 0; row < n; row++) {\n",
+    "            int conf = rowConf[row] + diag1[row - col + n] + diag2[row + col];\n",
+    "            if (row == curRow) conf -= 3;            // elle occupe ces 3 compteurs\n",
+    "            if (conf < bestConf) { bestConf = conf; bestRows.Clear(); bestRows.Add(row); }\n",
+    "            else if (conf == bestConf) bestRows.Add(row);\n",
+    "        }\n",
+    "        int bestRow = bestRows[rnd.Next(bestRows.Count)];\n",
+    "        if (bestRow != curRow) {\n",
+    "            rowConf[curRow]--; diag1[curRow - col + n]--; diag2[curRow + col]--;\n",
+    "            queens[col] = bestRow;\n",
+    "            rowConf[bestRow]++; diag1[bestRow - col + n]++; diag2[bestRow + col]++;\n",
+    "        }\n",
+    "    }\n",
+    "    int cc = 0;\n",
+    "    for (int c = 0; c < n; c++) { int r = queens[c]; cc += (rowConf[r]-1) + (diag1[r-c+n]-1) + (diag2[r+c]-1); }\n",
+    "    return (cc == 0, maxIters, queens);\n",
+    "}\n",
+    "\n",
+    "int n = 8;\n",
+    "var (ok, iters, sol) = MinConflicts(n, 10000, 42);\n",
+    "Show(\"Min-Conflicts, N = \" + n + \" -> solution en \" + iters + \" it\u00e9rations (ok=\" + ok + \").\");\n",
+    "if (ok) Show(BoardString(sol));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "decbd520-4352-4697-9311-76d4cc1cc440",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00414,
+     "end_time": "2026-07-06T10:36:46.127768",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.123628",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.1 Le \u00ab miracle \u00bb de Min-Conflicts : passage \u00e0 l'\u00e9chelle\n",
+    "\n",
+    "Le backtracking syst\u00e9matique explose (factoriel). Min-Conflicts, lui, r\u00e9sout des instances **\u00e9normes** en quelques centaines d'it\u00e9rations. C'est le r\u00e9sultat contre-intuitif de la recherche locale : sur les N-Reines (probl\u00e8me peu contraint \u00e0 grande \u00e9chelle), elle **surclasse** la recherche compl\u00e8te."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d2389424-255b-48c4-8239-ab946f9da3d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:46.138026Z",
+     "iopub.status.busy": "2026-07-06T10:36:46.137686Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.238732Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.238594Z"
+    },
+    "papermill": {
+     "duration": 0.10692,
+     "end_time": "2026-07-06T10:36:46.238800",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.131880",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "     N | r\u00e9solu |  it\u00e9rations |  temps(ms)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "     8 |    oui |          34 |        0.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    50 |    oui |         117 |        0.1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   100 |    oui |         166 |        0.2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   200 |    oui |         212 |        0.4"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   500 |    oui |         388 |        3.1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  1000 |    oui |         735 |        6.3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Interpr\u00e9tation : N = 1000 r\u00e9solu en quelques centaines d'it\u00e9rations \u2014 inaccessible au backtracking."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var sizes = new[] { 8, 50, 100, 200, 500, 1000 };\n",
+    "Show(\"N\".PadLeft(6) + \" | \" + \"r\u00e9solu\".PadLeft(6) + \" | \" + \"it\u00e9rations\".PadLeft(11) + \" | \" + \"temps(ms)\".PadLeft(10));\n",
+    "Show(new string('-', 42));\n",
+    "foreach (var n in sizes) {\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    var (ok, it, _) = MinConflicts(n, 20000, 7);\n",
+    "    sw.Stop();\n",
+    "    Show(n.ToString().PadLeft(6) + \" | \" + (ok ? \"oui\" : \"non\").PadLeft(6) + \" | \" + (ok ? it.ToString() : \">max\").PadLeft(11) + \" | \" + FI(sw.Elapsed.TotalMilliseconds, \"F1\").PadLeft(10));\n",
+    "}\n",
+    "Show(\"Interpr\u00e9tation : N = 1000 r\u00e9solu en quelques centaines d'it\u00e9rations \u2014 inaccessible au backtracking.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04ef871e-f6a5-41d3-818f-3405ab54f858",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003872,
+     "end_time": "2026-07-06T10:36:46.246845",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.242973",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Approche 3 : \u00c9num\u00e9ration de toutes les solutions\n",
+    "\n",
+    "Min-Conflicts donne **une** solution. Pour **compter** les solutions (N = 8 \u2192 92), il faut un parcours complet : on retire le `return true` du backtracking et on incr\u00e9mente un compteur \u00e0 chaque feuille."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7e40765f-2668-4253-b72d-0060e1260ccc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:46.256717Z",
+     "iopub.status.busy": "2026-07-06T10:36:46.256489Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.323757Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.323472Z"
+    },
+    "papermill": {
+     "duration": 0.072756,
+     "end_time": "2026-07-06T10:36:46.323862",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.251106",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "N = 8 -> 92 solutions distinctes (r\u00e9sultat attendu : 92)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "R\u00e9f\u00e9rence OEIS A000170 : N=1..8 = 1, 0, 0, 2, 10, 4, 40, 92."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "long _solCount;\n",
+    "void EnumerateAll(int[] queens, bool[] placed, int col, int n) {\n",
+    "    if (col == n) { _solCount++; return; }\n",
+    "    for (int row = 0; row < n; row++) {\n",
+    "        if (IsSafe(queens, col, row, placed)) {\n",
+    "            queens[col] = row; placed[col] = true;\n",
+    "            EnumerateAll(queens, placed, col + 1, n);\n",
+    "            placed[col] = false;\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "int n = 8;\n",
+    "var q = new int[n]; var p = new bool[n]; _solCount = 0;\n",
+    "EnumerateAll(q, p, 0, n);\n",
+    "Show(\"N = \" + n + \" -> \" + _solCount + \" solutions distinctes (r\u00e9sultat attendu : 92).\");\n",
+    "// petites valeurs de r\u00e9f\u00e9rence\n",
+    "Show(\"R\u00e9f\u00e9rence OEIS A000170 : N=1..8 = 1, 0, 0, 2, 10, 4, 40, 92.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afcd8a39-2d5e-4c72-98bc-c81490e201c9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004138,
+     "end_time": "2026-07-06T10:36:46.332309",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.328171",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.1 Brisure de sym\u00e9trie : solutions fondamentales\n",
+    "\n",
+    "Beaucoup des 92 solutions sont **\u00e9quivalentes** par une sym\u00e9trie du carr\u00e9 (le groupe di\u00e9dral D4 : 4 rotations \u00d7 2 r\u00e9flexions = 8 transformations). Deux solutions \u00ab fondamentalement identiques \u00bb donnent la m\u00eame **forme canonique** = la plus petite (lexicalement) parmi leurs 8 transform\u00e9es.\n",
+    "\n",
+    "On obtient ainsi les **12 solutions fondamentales** de N = 8. C'est exactement la brisure de sym\u00e9trie qu'OR-Tools CP-SAT peut ajouter d\u00e9clarativement (contraintes `AddAllDifferent` + lex-ordering) \u2014 ici on la d\u00e9roule \u00e0 la main."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d503a3b8-e6c9-4d2e-87a2-a29048614973",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:46.343811Z",
+     "iopub.status.busy": "2026-07-06T10:36:46.343184Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.513986Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.513863Z"
+    },
+    "papermill": {
+     "duration": 0.177105,
+     "end_time": "2026-07-06T10:36:46.514047",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.336942",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "N = 8 : 92 solutions, 12 fondamentales (attendu : 12)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Les 80 autres s'obtiennent par sym\u00e9trie du carr\u00e9 (groupe D4, ordre 8)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "int[] Transform(int[] q, string kind) {\n",
+    "    int n = q.Length;\n",
+    "    var nq = new int[n];\n",
+    "    for (int x = 0; x < n; x++) {\n",
+    "        int y = q[x]; int nx, ny;\n",
+    "        switch (kind) {\n",
+    "            case \"id\":   nx = x; ny = y; break;\n",
+    "            case \"r90\":  nx = n - 1 - y; ny = x; break;\n",
+    "            case \"r180\": nx = n - 1 - x; ny = n - 1 - y; break;\n",
+    "            case \"r270\": nx = y; ny = n - 1 - x; break;\n",
+    "            case \"fv\":   nx = n - 1 - x; ny = y; break;   // r\u00e9flexion verticale\n",
+    "            case \"fh\":   nx = x; ny = n - 1 - y; break;    // r\u00e9flexion horizontale\n",
+    "            case \"fd\":   nx = y; ny = x; break;            // diagonale principale\n",
+    "            default:     nx = n - 1 - y; ny = n - 1 - x; break; // anti-diagonale\n",
+    "        }\n",
+    "        nq[nx] = ny;\n",
+    "    }\n",
+    "    return nq;\n",
+    "}\n",
+    "string Key(int[] q) => string.Join(\",\", q);\n",
+    "string Canonical(int[] q) {\n",
+    "    var forms = new[] { \"id\", \"r90\", \"r180\", \"r270\", \"fv\", \"fh\", \"fd\", \"fa\" }\n",
+    "        .Select(k => Transform(q, k)).Select(Key).OrderBy(s => s);\n",
+    "    return forms.First();\n",
+    "}\n",
+    "\n",
+    "// collecter toutes les solutions puis d\u00e9nombrer les formes canoniques distinctes\n",
+    "int n = 8;\n",
+    "var all = new List<int[]>();\n",
+    "void Collect(int[] queens, bool[] placed, int col) {\n",
+    "    if (col == n) { all.Add((int[])queens.Clone()); return; }\n",
+    "    for (int row = 0; row < n; row++) {\n",
+    "        if (IsSafe(queens, col, row, placed)) {\n",
+    "            queens[col] = row; placed[col] = true;\n",
+    "            Collect(queens, placed, col + 1);\n",
+    "            placed[col] = false;\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "var q = new int[n]; var p = new bool[n];\n",
+    "Collect(q, p, 0);\n",
+    "\n",
+    "var canonicals = new HashSet<string>();\n",
+    "foreach (var sol in all) canonicals.Add(Canonical(sol));\n",
+    "Show(\"N = \" + n + \" : \" + all.Count + \" solutions, \" + canonicals.Count + \" fondamentales (attendu : 12).\");\n",
+    "Show(\"Les \" + (all.Count - canonicals.Count) + \" autres s'obtiennent par sym\u00e9trie du carr\u00e9 (groupe D4, ordre 8).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "536687e6-3a23-4e9a-a24c-c74e496eeee8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004754,
+     "end_time": "2026-07-06T10:36:46.522861",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.518107",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Synth\u00e8se compar\u00e9e\n",
+    "\n",
+    "| Approche | Type | Garantit solution ? | Compte toutes les solutions ? | Passe \u00e0 l'\u00e9chelle ? |\n",
+    "|----------|------|---------------------|-------------------------------|---------------------|\n",
+    "| Backtracking simple | recherche compl\u00e8te | oui | non (1 solution) | non (factoriel) |\n",
+    "| + MRV | compl\u00e8te + heuristique | oui | non | un peu mieux |\n",
+    "| + Forward Checking | compl\u00e8te + propagation | oui | non | nettement mieux |\n",
+    "| Min-Conflicts | recherche locale | **non** (stochastique) | non | **oui (N = 1000+)** |\n",
+    "| \u00c9num\u00e9ration compl\u00e8te | parcours total | oui | **oui** | non (explosif) |\n",
+    "| + brisure de sym\u00e9trie | parcours + D4 | oui | **fondamentales** | non |\n",
+    "\n",
+    "**Le\u00e7on** : aucun algorithme ne domine partout. La recherche compl\u00e8te garantit mais explose ; la recherche locale passe \u00e0 l'\u00e9chelle mais ne prouve rien. Les solveurs industriels (CP-SAT) combinent propagation + recherche + brisure de sym\u00e9trie d\u00e9clarative."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "9b0fd2ac-03ef-4aa1-82bb-8cdba1c19428",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:46.535678Z",
+     "iopub.status.busy": "2026-07-06T10:36:46.535123Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.580347Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.580179Z"
+    },
+    "papermill": {
+     "duration": 0.052775,
+     "end_time": "2026-07-06T10:36:46.580426",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.527651",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Synth\u00e8se affich\u00e9e ci-dessus (tableau markdown)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Show(\"Synth\u00e8se affich\u00e9e ci-dessus (tableau markdown).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0b73e33-8036-4d15-b358-6236b8b8e128",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004894,
+     "end_time": "2026-07-06T10:36:46.590005",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.585111",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "### Exercice 1 : le probl\u00e8me des N-Tours\n",
+    "\n",
+    "Les tours ne conflituent que sur la **ligne et la colonne** (pas de diagonales). Avec une tour par colonne (contrainte d\u00e9j\u00e0 satisfaite), il ne reste qu'\u00e0 placer une tour par **ligne**. Compter les solutions pour N = 8 \u2014 c'est simplement le nombre de **permutations** de N lignes.\n",
+    "\n",
+    "> **Indice** : `IsSafe` devient `r == row` seulement (retirer la diagonale). Le compte attendu est `N!`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f8ae9d65-70f6-4049-b536-cbeb49d8f2df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:46.600350Z",
+     "iopub.status.busy": "2026-07-06T10:36:46.600126Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.636644Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.636438Z"
+    },
+    "papermill": {
+     "duration": 0.04201,
+     "end_time": "2026-07-06T10:36:46.636733",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.594723",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 \u00e0 compl\u00e9ter \u2014 attendu N=8 : 40320 (8!)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : N-Tours \u2014 une tour par colonne ET par ligne (pas de diagonale)\n",
+    "// Etape 1 : adapter IsSafe (retirer la condition de diagonale).\n",
+    "// Etape 2 : \u00e9num\u00e9rer les solutions via EnumerateAll modifi\u00e9.\n",
+    "// Etape 3 : v\u00e9rifier que le compte vaut N! pour N = 8 (40320).\n",
+    "static long Factorial(int k) { long f = 1; for (int i = 2; i <= k; i++) f *= i; return f; }\n",
+    "Show(\"Exercice 1 \u00e0 compl\u00e9ter \u2014 attendu N=8 : \" + Factorial(8) + \" (8!).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10e00bb2-14b9-4a36-bf04-efa722583e9d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004366,
+     "end_time": "2026-07-06T10:36:46.645948",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.641582",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : seuil de bascule backtracking / min-conflicts\n",
+    "\n",
+    "Pour petit N, le backtracking est instantan\u00e9 ; pour grand N, seul Min-Conflicts passe. O\u00f9 se situe le **seuil** au-del\u00e0 duquel Min-Conflicts devient plus rapide (en temps) que le backtracking avec Forward Checking ?\n",
+    "\n",
+    "> **Indice** : boucler sur N de 8 \u00e0 30, mesurer `t_FC` et `t_MC`, trouver le plus petit N tel que `t_MC < t_FC`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "9484275f-90a6-4611-8355-e82ca9d57ee7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:46.656719Z",
+     "iopub.status.busy": "2026-07-06T10:36:46.656497Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.686685Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.686476Z"
+    },
+    "papermill": {
+     "duration": 0.036161,
+     "end_time": "2026-07-06T10:36:46.686755",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.650594",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 \u00e0 compl\u00e9ter \u2014 mesurer le crossover FC/MC."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : trouver le plus petit N tel que t_MinConflicts < t_ForwardChecking\n",
+    "// Etape 1 : pour N = 8..30, mesurer les deux temps (r\u00e9utiliser les fonctions ci-dessus).\n",
+    "// Etape 2 : retourner le premier N o\u00f9 MC bat FC.\n",
+    "Show(\"Exercice 2 \u00e0 compl\u00e9ter \u2014 mesurer le crossover FC/MC.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "588315d8-f45f-4d24-a191-5e34d4ad6cd5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004096,
+     "end_time": "2026-07-06T10:36:46.695086",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.690990",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : briser la sym\u00e9trie directement dans l'\u00e9num\u00e9ration\n",
+    "\n",
+    "Plut\u00f4t que d'\u00e9num\u00e9rer les 92 solutions puis de filtrer par forme canonique (ce qui co\u00fbte 92 \u00d7 8 transforms), on peut **imposer** d\u00e8s la descente que la solution soit la forme canonique (ex. contrainte lexicographique `queens < Transform(queens, \"r90\")`). Impl\u00e9menter cette brisure **\u00e0 la vol\u00e9e**.\n",
+    "\n",
+    "> **Indice** : \u00e0 la feuille (col == n), ne compter la solution que si son `Key` est \u00e9gal \u00e0 son `Canonical`. C'est une brisure *a posteriori* par feuille ; la brisure *a priori* (couper pendant la descente) est plus dure \u2014 c'est pr\u00e9cis\u00e9ment ce que fait CP-SAT."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "80e9b3f8-ff41-4095-b873-3d3cea65e70f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T10:36:46.704622Z",
+     "iopub.status.busy": "2026-07-06T10:36:46.704429Z",
+     "iopub.status.idle": "2026-07-06T10:36:46.731783Z",
+     "shell.execute_reply": "2026-07-06T10:36:46.731627Z"
+    },
+    "papermill": {
+     "duration": 0.032789,
+     "end_time": "2026-07-06T10:36:46.731859",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.699070",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 \u00e0 compl\u00e9ter \u2014 briser la sym\u00e9trie \u00e0 l'\u00e9num\u00e9ration."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : \u00e9num\u00e9rer en ne gardant que les formes canoniques (a posteriori par feuille)\n",
+    "// Etape 1 : modifier EnumerateAll pour, \u00e0 la feuille, v\u00e9rifier Key(queens) == Canonical(queens).\n",
+    "// Etape 2 : le compte doit donner directement 12 pour N = 8 (sans HashSet).\n",
+    "Show(\"Exercice 3 \u00e0 compl\u00e9ter \u2014 briser la sym\u00e9trie \u00e0 l'\u00e9num\u00e9ration.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c7651cc-0be9-471c-b8e6-eda1558d9630",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005078,
+     "end_time": "2026-07-06T10:36:46.741575",
+     "exception": false,
+     "start_time": "2026-07-06T10:36:46.736497",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# a **d\u00e9roul\u00e9 \u00e0 la main** ce que le solveur industriel OR-Tools CP-SAT (twin Python) automatise :\n",
+    "\n",
+    "- **Backtracking** (simple / MRV / Forward Checking) = le moteur de recherche compl\u00e8te avec propagation ;\n",
+    "- **Min-Conflicts** = la recherche locale qui passe \u00e0 l'\u00e9chelle (le \u00ab miracle \u00bb N = 1000) ;\n",
+    "- **\u00c9num\u00e9ration + brisure de sym\u00e9trie D4** = le comptage exact des solutions fondamentales (12 pour N = 8).\n",
+    "\n",
+    "**Lien avec les Foundations** : backtracking \u21c4 [`Search-1`](../../Part1-Foundations/Search-1-UninformedSearch.ipynb) (DFS), CSP \u21c4 [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb), Min-Conflicts \u21c4 [`Search-11`](../../Part3-Advanced/Search-11-Metaheuristics.ipynb) (m\u00e9taheuristiques), CP-SAT \u21c4 [`App-1-NQueens`](App-1-NQueens.ipynb) (twin Python, solveur industriel).\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "- Ajouter la **propagation AC-3** (arc-consistency) avant le backtracking.\n",
+    "- Comparer au **recuit simul\u00e9** (cf Search-11 SA) sur les m\u00eames instances.\n",
+    "- Mesurer l'impact de la **brisure de sym\u00e9trie d\u00e9clarative** sur le temps d'\u00e9num\u00e9ration.\n",
+    "\n",
+    "---\n",
+    "*Marathon .NET \u21c4 Python #4956 \u2014 Search/Applications, tranche N-Reines. See #4956, #3801.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "duration": 6.337636,
+   "end_time": "2026-07-06T10:36:46.981538",
+   "exception": null,
+   "input_path": "App-1b-NQueens-CSharp.ipynb",
+   "output_path": "App-1b-NQueens-CSharp.ipynb",
+   "start_time": "2026-07-06T10:36:40.643902"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -1,8 +1,8 @@
 # Search - Applications
 
-C'est ici que la série Search se confronte au réel. Les 22 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents.
+C'est ici que la série Search se confronte au réel. Les 23 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents. À cela s'ajoutent les **jumeaux C#** (App-1b, App-9b, App-10b) qui déroulent les mêmes algorithmes *from-scratch* en .NET, en complément des versions Python qui invoquent des solveurs industriels.
 
-Sous-série de **22 notebooks** | **~14h55** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`)
+Sous-série de **23 notebooks** | **~15h30** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`) ; .NET 9 (`dotnet-interactive`) pour les jumeaux C#
 
 ## Pourquoi cette sous-série
 
@@ -31,8 +31,8 @@ Un algorithme compris sur un exemple jouet n'est pas encore un algorithme maîtr
 ```text
 Applications/
 ├── Search/     # Applications purement Search (2 notebooks)
-├── CSP/        # Applications CSP (13 notebooks)
-└── Hybrid/     # Metaheuristiques / GA (7 notebooks)
+├── CSP/        # Applications CSP (14 notebooks : 13 Python + 1 twin C#)
+└── Hybrid/     # Metaheuristiques / GA (7 notebooks : 5 Python + 2 twins C#)
 ```
 
 ```mermaid
@@ -70,6 +70,7 @@ Le gros de la sous-série, et un panorama de ce que la programmation par contrai
 | # | Notebook | Durée | Contenu | Source |
 |---|----------|-------|---------|--------|
 | 1 | [App-1-NQueens](CSP/App-1-NQueens.ipynb) | ~30 min | Backtracking, Min-Conflicts, OR-Tools | Classique |
+| 1b | [App-1b-NQueens-CSharp](CSP/App-1b-NQueens-CSharp.ipynb) | ~35 min | Twin C# : Backtracking (simple/MRV/FC), Min-Conflicts, énumération + symétrie D4 | Classique |
 | 2 | [App-2-GraphColoring](CSP/App-2-GraphColoring.ipynb) | ~45 min | Greedy, DSATUR, CP-SAT, départements | Projet étudiant |
 | 3 | [App-3-NurseScheduling](CSP/App-3-NurseScheduling.ipynb) | ~60 min | Hard/soft constraints, CP-SAT | Projet étudiant |
 | 4 | [App-4-JobShopScheduling](CSP/App-4-JobShopScheduling.ipynb) | ~60 min | Intervalles, précédences, makespan | Projet étudiant |
@@ -115,6 +116,7 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 | Notebook | Fondations requises | Dépendances |
 |----------|--------------------|-------------|
 | App-1 NQueens | CSP-1 (Fundamentals) | - |
+| App-1b NQueens (C#) | CSP-1 (Fundamentals) | dotnet-interactive |
 | App-2 GraphColoring | CSP-1, CSP-2 | networkx |
 | App-3 NurseScheduling | CSP-3, CSP-4 | ortools |
 | App-4 JobShopScheduling | CSP-3, CSP-4 | ortools |


### PR DESCRIPTION
## Résumé

**Twin C#** de [App-1-NQueens](MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb) (Python + OR-Tools CP-SAT + numpy + matplotlib). **Suite du marathon .NET ⇄ Python** (#4956), volet **Search / Applications / CSP** — famille fraîche vs c.41-48 (Planners/GameTheory/SL foundations). BCL .NET seule, **0 NuGet**, **from-scratch** (Prong B #3801). **Rule 6** : rotation famille (Applications ≠ foundations).

## Algorithme / démarche

3 familles de résolution, **toutes from-scratch** (BCL .NET 9, `System.Linq`, `Stopwatch`, `Random`, `HashSet<int>`) :

1. **Backtracking** (recherche complète) — 3 variantes comparées par nœuds explorés + temps :
   - **simple** (DFS gauche→droite, `IsSafe` sur lignes + diagonales),
   - **MRV** (Minimum Remaining Values : choisir la colonne non assignée au plus petit nombre de lignes sûres),
   - **Forward Checking** (propagation : à chaque placement, retirer des domaines des colonnes vides les lignes conflictuelles ; restauration au backtrack par pile de retraits ; détection d'impasse précoce sur domaine vide).
2. **Min-Conflicts** (recherche locale) — démarrage aléatoire, déplacement de la reine en conflit vers la ligne minimisant les conflits. Démonstration du **« miracle »** : N = 1000 résolu en quelques centaines d'itérations (vs factoriel pour le backtracking).
3. **Énumération complète + brisure de symétrie** — `EnumerateAll` (N=8 → **92 solutions**, OEIS A000170) puis **forme canonique** sous le groupe diédral D4 (8 transformations : id/rot90/rot180/rot270 + 4 réflexions) → **12 solutions fondamentales**.

## Complémentarité (#3801 Prong B)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python | **OR-Tools CP-SAT** (solveur industriel) + numpy + matplotlib | invoquer un solveur, simulation vectorielle |
| **This (.NET BCL seule)** | **from-scratch** (récursion, propagation de domaines, marche aléatoire, transforms D4) | **comprendre la mécanique** : backtracking, propagation, recherche locale, symétries |

**Point clé** : le twin Python **appelle** CP-SAT ; ce twin **déroule** ce que CP-SAT fait sous le capot (propagation de contraintes = Forward Checking, brisure de symétrie déclarative = forme canonique D4). Valeur complémentaire authentique, pas un miroir.

**Prong B non-trivialité** : N-Queens backtracking sur N=8 serait dégénéré, MAIS le notebook démontre (a) la discrimination MRV/FC vs simple (nœuds explorés), (b) le **miracle Min-Conflicts** (passage à l'échelle N=1000), (c) la **brisure de symétrie D4** (92 → 12 fondamentales) — trois résultats non-triviaux où la mécanique algorithmique est visible dans la sortie.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **13/13 cellules code `execution_count` 1-13, 0 erreur, 0 warning CS**. Outputs vérifiés **firsthand** :
- Backtracking simple N=8 : solution + nœuds explorés
- MRV N=8 : moins de nœuds que simple
- Forward Checking N=8 : bien moins de nœuds (propagation précoce)
- Benchmark N=8→16 : FC < MRV < simple (3 variantes, nœuds + temps ms)
- Min-Conflicts N=8 : solution en quelques itérations
- **Min-Conflicts scaling N=8→1000** : tous résolus, le « miracle » (N=1000 en ms)
- Énumération N=8 : **92 solutions** (OEIS A000170 ✓)
- **Symétrie D4 N=8 : 12 fondamentales** ✓ (92 = 12 × ~7.67, le reste par symétries du carré)

## Bugs G.1 self-corrected (classe connue, topic file marathon)

Topic file `dotnet-csharp-twins-marathon-4956.md` (10 bugs documentés) — appliqués en préventif :
- Helper `FI(x,fmt)` + `Show(s)`/`display()` (bugs #2, #3 : culture FR non-persistante, Console.WriteLine avalé)
- Pas de littéral quoté dans trou d'interpolation (bug #6 : `+` concat pour tout formatage complexe)
- `PadLeft` + `new string('-')` pour headers ASCII (bug #1 : pas de char-literal)
- `queens[col] = -1` sentinel plutôt que nullable (bug #5/§8 : pas de `.Value` sur arrays)

## SOTA-OK (#3801)

Verdict **SOTA-OK** : pas de workaround dégradé. Le twin assume sa nature from-scratch (Prong B : pas d'équivalent NuGet didactique à « comprendre CP-SAT de l'intérieur ») et ne prétend PAS être un solveur industriel — il exhibe la mécanique. Aucune sortie fabriquée.

## Exercices (#2161)

3 stubs C.1-conformes (`pass`-free, `Show("...à compléter")`) :
1. **N-Tours** (retirer la diagonale d'IsSafe → compte = N! = 40320 pour N=8)
2. **Seuil de bascule FC/Min-Conflicts** (crossover temporel N=8→30)
3. **Brisure de symétrie à l'énumération** (garder uniquement `Key == Canonical` à la feuille → 12 directement)

## Scope

Atomique : 1 notebook (28 cells, 13 code) + Applications/README.md (ajout ligne table 1b + count 22→23 + CSP 13→14 + prérequis). Self-contained (BCL seule). CATALOG-STATUS + fichiers catalogue **byte-identical à main** (R1). H.3 + C.1 = NONE.

## Marathon #4956

Premier twin C# dans Search/**Applications** (vs foundations Search-1..16 déjà twins). Ouvre la voie à d'autres twins App-* (Picross, GraphColoring…).

See #4956, #3801. Revue souhaitée : ai-01, po-2024 (Search .NET owner), po-2025.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
