### PR TITLE
feat(search-apps): App-6-Minesweeper-Csharp — .NET twin (CSP backtracking from-scratch)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb
@@ -1,0 +1,3148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f9b04a05",
+   "metadata": {},
+   "source": [
+    "# App-6 - Demineur (C#) : CSP, probabilites et NP-completude\n",
+    "\n",
+    "> **Jumeau C#** du notebook [App-6-Minesweeper.ipynb](App-6-Minesweeper.ipynb).\n",
+    "> Marathon parite .NET ⇄ Python (#4956), EPIC #3801 Prong B.\n",
+    "> Le Demineur modélisé comme CSP : solveur par règles (Rule 1/2), solveur CSP\n",
+    "> (**énumération backtracking from-scratch**, pas de lib `python-constraint`),\n",
+    "> solveur probabiliste. Implémenté **from-scratch en C# pur** (BCL seule, 0 NuGet,\n",
+    "> matplotlib → visualisation ASCII).\n",
+    "\n",
+    "**Navigation** : [<< App-5-Timetabling](App-5-Timetabling.ipynb) | [App-7-Wordle >>](App-7-Wordle.ipynb) | [Twin Python](App-6-Minesweeper.ipynb) | [Index CSP](../README.md)\n",
+    "\n",
+    "**Kernel** : .NET 9.0 + dotnet-interactive (`.net-csharp`)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Le Démineur est un **problème de contraintes** : chaque chiffre révélé contraint\n",
+    "ses voisins inconnus. Ce notebook C# accompagne le twin Python et fournit :\n",
+    "\n",
+    "1. **Représentation** du plateau (génération, révélation en cascade, marquage).\n",
+    "2. **Solveur par règles** (déductions locales Rule 1 / Rule 2).\n",
+    "3. **Solveur CSP** — énumération **backtracking from-scratch** de toutes les\n",
+    "   affectations cohérentes de la frontière binaire (le twin Python délègue à\n",
+    "   `python-constraint.Problem` + `ExactSumConstraint` + `getSolutions()`).\n",
+    "4. **Solveur probabiliste** (règles → CSP → choix de la cellule à P(mine) minimale).\n",
+    "5. **Benchmark** comparant les trois approches sur N parties.\n",
+    "\n",
+    "### Pourquoi le CSP intéressant en IA ?\n",
+    "\n",
+    "Le Démineur est **NP-complet** (Kaye 2000) : trouver la stratégie gagnante optimale\n",
+    "est intrinsèquement dur. Les solveurs ci-dessous illustrent la hiérarchie classique\n",
+    "raisonnement-contraint / recherche exhaustive / décision probabiliste sous incertitude.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Modéliser** le Démineur comme un CSP binaire (frontière de cellules inconnues).\n",
+    "2. **Implémenter** les règles de déduction locale (Rule 1, Rule 2).\n",
+    "3. **Énumérer** les solutions d'un CSP binaire par **backtracking from-scratch**\n",
+    "   (sans lib externe) — comprendre la mécanique que `python-constraint` cache.\n",
+    "4. **Calculer** la probabilité de mine par cellule (fréquence sur les solutions).\n",
+    "5. **Combiner** règles + CSP + probabilités en une stratégie hybride.\n",
+    "\n",
+    "### Prerequis\n",
+    "- Notions de CSP (variables, domaine, contraintes) — voir [App-1-NQueens](App-1-NQueens.ipynb).\n",
+    "- Récursion / backtracking.\n",
+    "- .NET 9.0 + dotnet-interactive.\n",
+    "\n",
+    "### Duree estimee : 50 minutes\n",
+    "\n",
+    "### Source\n",
+    "- Kaye, R. *Minesweeper is NP-complete* (Mathematical Intelligencer, 2000).\n",
+    "- Twin Python : [App-6-Minesweeper.ipynb](App-6-Minesweeper.ipynb).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e249b6fe",
+   "metadata": {},
+   "source": [
+    "## 1. Representation du plateau\n",
+    "\n",
+    "`MinesweeperBoard` : grille `rows x cols` avec un ensemble de mines, un tableau\n",
+    "d'indices (`numbers[r,c]` = nombre de mines voisines), un ensemble de cellules\n",
+    "révélées et un ensemble de cellules marquées (drapeaux). La révélation d'un 0\n",
+    "propage en cascade (flood-fill) aux voisins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "22b109cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:24:24.310593Z",
+     "iopub.status.busy": "2026-07-06T11:24:24.304858Z",
+     "iopub.status.idle": "2026-07-06T11:24:26.625375Z",
+     "shell.execute_reply": "2026-07-06T11:24:26.621090Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1416232.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plateau : 8x8, 10 mines\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules revelees apres le premier clic : 15\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules restantes (inconnues)          : 49\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mines a trouver                          : 10\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "public class MinesweeperBoard\n",
+    "{\n",
+    "    public int Rows, Cols, NMines;\n",
+    "    public HashSet<(int r, int c)> Mines = new();\n",
+    "    public int[,] Numbers;          // nombre de mines voisines\n",
+    "    public HashSet<(int r, int c)> Revealed = new();\n",
+    "    public HashSet<(int r, int c)> Flagged = new();\n",
+    "    public bool GameOver, Won;\n",
+    "    private static readonly (int r, int c)[] Offsets = {\n",
+    "        (-1,-1),(-1,0),(-1,1),(0,-1),(0,1),(1,-1),(1,0),(1,1)\n",
+    "    };\n",
+    "\n",
+    "    public MinesweeperBoard(int rows, int cols, int nMines, (int r,int c)? safeCell, Random rng)\n",
+    "    {\n",
+    "        Rows = rows; Cols = cols; NMines = nMines;\n",
+    "        Numbers = new int[rows, cols];\n",
+    "        // Cellules candidates (exclure safe_cell + ses voisins pour un premier clic sûr)\n",
+    "        var excluded = new HashSet<(int r, int c)>();\n",
+    "        if (safeCell is { } sc) { excluded.Add(sc); foreach (var n in Neighbors(sc.r, sc.c)) excluded.Add(n); }\n",
+    "        var candidates = new List<(int r, int c)>();\n",
+    "        for (int r = 0; r < rows; r++) for (int c = 0; c < cols; c++)\n",
+    "            if (!excluded.Contains((r,c))) candidates.Add((r,c));\n",
+    "        // Echantillonner nMines mines (Fisher-Yates partiel)\n",
+    "        for (int i = 0; i < Math.Min(nMines, candidates.Count); i++) {\n",
+    "            int j = rng.Next(i, candidates.Count);\n",
+    "            (candidates[i], candidates[j]) = (candidates[j], candidates[i]);\n",
+    "            Mines.Add(candidates[i]);\n",
+    "        }\n",
+    "        // Calculer les indices\n",
+    "        for (int r = 0; r < rows; r++) for (int c = 0; c < cols; c++)\n",
+    "            if (!Mines.Contains((r,c))) {\n",
+    "                int cnt = 0; foreach (var (nr,nc) in Neighbors(r,c)) if (Mines.Contains((nr,nc))) cnt++;\n",
+    "                Numbers[r,c] = cnt;\n",
+    "            }\n",
+    "    }\n",
+    "\n",
+    "    public List<(int r, int c)> Neighbors(int r, int c) {\n",
+    "        var res = new List<(int r, int c)>(8);\n",
+    "        foreach (var (dr,dc) in Offsets) {\n",
+    "            int nr = r+dr, nc = c+dc;\n",
+    "            if (nr >= 0 && nr < Rows && nc >= 0 && nc < Cols) res.Add((nr,nc));\n",
+    "        }\n",
+    "        return res;\n",
+    "    }\n",
+    "\n",
+    "    public bool Reveal(int r, int c) {\n",
+    "        if (Revealed.Contains((r,c)) || Flagged.Contains((r,c))) return true;\n",
+    "        if (Mines.Contains((r,c))) { GameOver = true; return false; }\n",
+    "        Revealed.Add((r,c));\n",
+    "        if (Numbers[r,c] == 0)\n",
+    "            foreach (var (nr,nc) in Neighbors(r,c))\n",
+    "                if (!Revealed.Contains((nr,nc))) Reveal(nr,nc);\n",
+    "        int safeCells = Rows*Cols - Mines.Count;\n",
+    "        if (Revealed.Count == safeCells) Won = true;\n",
+    "        return true;\n",
+    "    }\n",
+    "\n",
+    "    public void Flag(int r, int c) {\n",
+    "        if (Revealed.Contains((r,c))) return;\n",
+    "        if (!Flagged.Add((r,c))) Flagged.Remove((r,c));  // toggle\n",
+    "    }\n",
+    "\n",
+    "    public List<(int r,int c)> UnknownNeighbors(int r, int c) =>\n",
+    "        Neighbors(r,c).Where(p => !Revealed.Contains(p) && !Flagged.Contains(p)).ToList();\n",
+    "    public List<(int r,int c)> FlaggedNeighbors(int r, int c) =>\n",
+    "        Neighbors(r,c).Where(p => Flagged.Contains(p)).ToList();\n",
+    "    public int RemainingMines => NMines - Flagged.Count;\n",
+    "\n",
+    "    public MinesweeperBoard Copy() {\n",
+    "        var b = new MinesweeperBoard(Rows, Cols, 0, null, null) {\n",
+    "            Rows = Rows, Cols = Cols, NMines = NMines, Numbers = (int[,])Numbers.Clone(),\n",
+    "            Mines = new HashSet<(int r, int c)>(Mines), Revealed = new HashSet<(int r, int c)>(Revealed),\n",
+    "            Flagged = new HashSet<(int r, int c)>(Flagged), GameOver = GameOver, Won = Won\n",
+    "        };\n",
+    "        return b;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Plateau de demonstration : 8x8, 10 mines, premier clic (4,4) garantit sur.\n",
+    "var rng0 = new Random(1);\n",
+    "var board0 = new MinesweeperBoard(8, 8, 10, safeCell: (4,4), rng0);\n",
+    "board0.Reveal(4, 4);\n",
+    "Console.WriteLine($\"Plateau : {board0.Rows}x{board0.Cols}, {board0.NMines} mines\");\n",
+    "Console.WriteLine($\"Cellules revelees apres le premier clic : {board0.Revealed.Count}\");\n",
+    "Console.WriteLine($\"Cellules restantes (inconnues)          : {board0.Rows*board0.Cols - board0.Revealed.Count}\");\n",
+    "Console.WriteLine($\"Mines a trouver                          : {board0.RemainingMines}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0fe922a",
+   "metadata": {},
+   "source": [
+    "## 2. Visualisation ASCII du plateau\n",
+    "\n",
+    "Le twin Python trace le plateau en couleurs avec `matplotlib`. En C# pur (sans\n",
+    "lib de plot), on visualise avec une grille ASCII : `.` pour inconnu, chiffre pour\n",
+    "révélé, `F` pour drapeau, `*` pour mine (en mode debug)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7464a302",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:24:26.626903Z",
+     "iopub.status.busy": "2026-07-06T11:24:26.626663Z",
+     "iopub.status.idle": "2026-07-06T11:24:26.743454Z",
+     "shell.execute_reply": "2026-07-06T11:24:26.699849Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Etat apres le premier clic (4,4) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Plateau complet (mines revelees) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Visualisation ASCII d'un plateau de Demineur.\n",
+    "void DrawBoard(MinesweeperBoard b, string title, bool showMines = false) {\n",
+    "    Console.WriteLine($\"--- {title} ---\");\n",
+    "    Console.Write(\"   \");\n",
+    "    for (int c = 0; c < b.Cols; c++) Console.Write(c % 10);\n",
+    "    Console.WriteLine();\n",
+    "    for (int r = 0; r < b.Rows; r++) {\n",
+    "        Console.Write($\"{r % 10}: \");\n",
+    "        for (int c = 0; c < b.Cols; c++) {\n",
+    "            var p = (r, c);\n",
+    "            if (b.Revealed.Contains(p))\n",
+    "                Console.Write(b.Numbers[r, c] == 0 ? ' ' : b.Numbers[r, c].ToString()[0]);\n",
+    "            else if (b.Flagged.Contains(p)) Console.Write('F');\n",
+    "            else if (showMines && b.Mines.Contains(p)) Console.Write('*');\n",
+    "            else Console.Write('.');\n",
+    "        }\n",
+    "        Console.WriteLine();\n",
+    "    }\n",
+    "    Console.WriteLine();\n",
+    "}\n",
+    "\n",
+    "DrawBoard(board0, \"Etat apres le premier clic (4,4)\");\n",
+    "DrawBoard(board0, \"Plateau complet (mines revelees)\", showMines: true);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3a4aecd",
+   "metadata": {},
+   "source": [
+    "## 3. Solveur par regles simples\n",
+    "\n",
+    "Deux regles locales suffisantes pour de nombreuses situations :\n",
+    "\n",
+    "- **Regle 1** : si le nombre de mines restantes à placer autour d'une cellule révélée\n",
+    "  égale le nombre de voisins inconnus, alors **tous les inconnus sont des mines**.\n",
+    "- **Regle 2** : s'il ne reste aucune mine à placer autour d'une cellule révélée,\n",
+    "  alors **tous les inconnus sont sûrs**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d46939ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:24:26.745753Z",
+     "iopub.status.busy": "2026-07-06T11:24:26.745472Z",
+     "iopub.status.idle": "2026-07-06T11:24:26.827248Z",
+     "shell.execute_reply": "2026-07-06T11:24:26.810923Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regles : 2 iterations, 1 deductions\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules revelees : 15/54 sures\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Drapeaux poses    : 1/10\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Partie gagnee ?   : False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Apres solveur par regles ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "F"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "public class RuleBasedSolver\n",
+    "{\n",
+    "    public MinesweeperBoard Board;\n",
+    "    public List<(string kind, (int r,int c) cell, (int r,int c) src)> MovesLog = new();\n",
+    "\n",
+    "    public RuleBasedSolver(MinesweeperBoard board) { Board = board; }\n",
+    "\n",
+    "    public bool SolveStep() {\n",
+    "        bool progress = false;\n",
+    "        for (int r = 0; r < Board.Rows; r++) for (int c = 0; c < Board.Cols; c++) {\n",
+    "            if (!Board.Revealed.Contains((r,c))) continue;\n",
+    "            int num = Board.Numbers[r, c];\n",
+    "            if (num == 0) continue;\n",
+    "            var unknown = Board.UnknownNeighbors(r, c);\n",
+    "            var flagged = Board.FlaggedNeighbors(r, c);\n",
+    "            int remaining = num - flagged.Count;\n",
+    "            if (remaining == unknown.Count && unknown.Count > 0) {\n",
+    "                foreach (var (ur,uc) in unknown) { Board.Flag(ur, uc); MovesLog.Add((\"flag\", (ur,uc), (r,c))); progress = true; }\n",
+    "            } else if (remaining == 0 && unknown.Count > 0) {\n",
+    "                foreach (var (ur,uc) in unknown) {\n",
+    "                    bool safe = Board.Reveal(ur, uc); MovesLog.Add((\"reveal\", (ur,uc), (r,c)));\n",
+    "                    if (!safe) return false; progress = true;\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "        return progress;\n",
+    "    }\n",
+    "\n",
+    "    public int Solve(int maxIter = 100) {\n",
+    "        int i;\n",
+    "        for (i = 0; i < maxIter; i++) {\n",
+    "            if (Board.GameOver || Board.Won) break;\n",
+    "            if (!SolveStep()) break;\n",
+    "        }\n",
+    "        return i + 1;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Test sur le plateau de demonstration.\n",
+    "var boardRules = board0.Copy();\n",
+    "var ruleSolver = new RuleBasedSolver(boardRules);\n",
+    "int iters = ruleSolver.Solve();\n",
+    "Console.WriteLine($\"Regles : {iters} iterations, {ruleSolver.MovesLog.Count} deductions\");\n",
+    "Console.WriteLine($\"Cellules revelees : {boardRules.Revealed.Count}/{boardRules.Rows*boardRules.Cols - boardRules.NMines} sures\");\n",
+    "Console.WriteLine($\"Drapeaux poses    : {boardRules.Flagged.Count}/{boardRules.NMines}\");\n",
+    "Console.WriteLine($\"Partie gagnee ?   : {boardRules.Won}\");\n",
+    "DrawBoard(boardRules, \"Apres solveur par regles\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a354ce4",
+   "metadata": {},
+   "source": [
+    "## 4. Solveur CSP — enumeration backtracking from-scratch\n",
+    "\n",
+    "C'est le coeur du **Prong B**. Le twin Python construit un `Problem` via la lib\n",
+    "`python-constraint`, ajoute des `ExactSumConstraint(remaining)` et appelle\n",
+    "`getSolutions()`. Ici on implémente **manuellement** l'énumération :\n",
+    "\n",
+    "1. **Frontière** = cellules inconnues adjacentes à une cellule révélée.\n",
+    "2. **Variables binaires** : chaque cellule-frontière vaut 0 (sûre) ou 1 (mine).\n",
+    "3. **Contraintes** : pour chaque cellule révélée non-nulle, la somme de ses\n",
+    "   voisins-frontière inconnus = `remaining` (indice − drapeaux déjà posés).\n",
+    "4. **Backtracking** : on instancie les variables une par une (0 puis 1), on\n",
+    "   vérifie chaque contrainte dès que toutes ses variables sont assignées, on\n",
+    "   élague toute branche violant une contrainte. On collecte **toutes** les\n",
+    "   solutions complètes.\n",
+    "5. **Déduction** : une cellule forcée sûre (mine) = valant 0 (1) dans **toutes**\n",
+    "   les solutions.\n",
+    "\n",
+    "La complexité est `O(2^k)` pour une frontière de taille k ; on plafonne k pour\n",
+    "garder un runtime pédagogique (le twin Python bénéficie de la propagation de la\n",
+    "lib, ici on voit la recherche brute)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2a7c756d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:24:26.829073Z",
+     "iopub.status.busy": "2026-07-06T11:24:26.828809Z",
+     "iopub.status.idle": "2026-07-06T11:24:27.026705Z",
+     "shell.execute_reply": "2026-07-06T11:24:27.026529Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apres regles : 15 revelees, 1 drapeaux, gagne=False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frontiere CSP : 19 cellules, 11 contraintes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solutions CSP enumerees : 23\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules forcees sures  : 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules forcees mines  : 0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "public class CSPSolver\n",
+    "{\n",
+    "    public MinesweeperBoard Board;\n",
+    "    public CSPSolver(MinesweeperBoard board) { Board = board; }\n",
+    "\n",
+    "    public HashSet<(int r, int c)> Frontier() {\n",
+    "        var f = new HashSet<(int r, int c)>();\n",
+    "        foreach (var (r,c) in Board.Revealed)\n",
+    "            foreach (var n in Board.Neighbors(r,c))\n",
+    "                if (!Board.Revealed.Contains(n) && !Board.Flagged.Contains(n)) f.Add(n);\n",
+    "        return f;\n",
+    "    }\n",
+    "\n",
+    "    // Retourne la liste des contraintes : (variables impliquees, somme exacte attendue).\n",
+    "    public List<(List<(int r, int c)> vars, int sum)> Constraints(HashSet<(int r, int c)> frontier) {\n",
+    "        var res = new List<(List<(int r, int c)>, int)>();\n",
+    "        foreach (var (r,c) in Board.Revealed) {\n",
+    "            int num = Board.Numbers[r, c];\n",
+    "            if (num == 0) continue;\n",
+    "            var unknown = Board.UnknownNeighbors(r, c);\n",
+    "            var inFront = unknown.Where(u => frontier.Contains(u)).ToList();\n",
+    "            if (inFront.Count == 0) continue;\n",
+    "            int remaining = num - Board.FlaggedNeighbors(r, c).Count;\n",
+    "            res.Add((inFront, remaining));\n",
+    "        }\n",
+    "        return res;\n",
+    "    }\n",
+    "\n",
+    "    // Enumeration backtracking de toutes les solutions. Retourne une liste de\n",
+    "    // dictionnaires (cellule -> 0/1). Plafonne la taille de frontiere.\n",
+    "    public List<Dictionary<(int r, int c), int>> AllSolutions(int maxFrontier = 22) {\n",
+    "        var frontier = Frontier().ToList();\n",
+    "        if (frontier.Count == 0 || frontier.Count > maxFrontier) return new();\n",
+    "        var constraints = Constraints(frontier.ToHashSet());\n",
+    "        var varIdx = new Dictionary<(int r, int c), int>();\n",
+    "        for (int i = 0; i < frontier.Count; i++) varIdx[frontier[i]] = i;\n",
+    "        // Pour chaque contrainte : liste d'indices + somme\n",
+    "        var cIdx = constraints.Select(c => (c.vars.Select(v => varIdx[v]).ToList(), c.sum)).ToList();\n",
+    "        // Ordre : pour chaque index, quelles contraintes deviennent verifiables quand il est assigne en dernier\n",
+    "        var assign = new int[frontier.Count];\n",
+    "        var solutions = new List<Dictionary<(int r, int c), int>>();\n",
+    "        void Dfs(int pos) {\n",
+    "            if (pos == frontier.Count) {\n",
+    "                // Toutes contraintes deja verifiees en cours ; enregistrer\n",
+    "                var sol = new Dictionary<(int r, int c), int>();\n",
+    "                for (int i = 0; i < frontier.Count; i++) sol[frontier[i]] = assign[i];\n",
+    "                solutions.Add(sol);\n",
+    "                return;\n",
+    "            }\n",
+    "            for (int v = 0; v <= 1; v++) {\n",
+    "                assign[pos] = v;\n",
+    "                // Verifier toute contrainte dont la variable de plus grand index == pos\n",
+    "                bool ok = true;\n",
+    "                foreach (var (vars, sum) in cIdx) {\n",
+    "                    int maxI = vars.Max();\n",
+    "                    if (maxI == pos) {  // contrainte complete a ce stade\n",
+    "                        int s = 0; foreach (var vi in vars) s += assign[vi];\n",
+    "                        if (s != sum) { ok = false; break; }\n",
+    "                    }\n",
+    "                }\n",
+    "                if (ok) Dfs(pos + 1);\n",
+    "            }\n",
+    "        }\n",
+    "        Dfs(0);\n",
+    "        return solutions;\n",
+    "    }\n",
+    "\n",
+    "    // Deduit les cellules forcees a partir de toutes les solutions.\n",
+    "    public (HashSet<(int r, int c)> safe, HashSet<(int r, int c)> mines) Solve(out List<Dictionary<(int r, int c),int>> sols) {\n",
+    "        sols = AllSolutions();\n",
+    "        var safe = new HashSet<(int r, int c)>();\n",
+    "        var mines = new HashSet<(int r, int c)>();\n",
+    "        if (sols.Count == 0) return (safe, mines);\n",
+    "        var frontier = sols[0].Keys.ToList();\n",
+    "        foreach (var cell in frontier) {\n",
+    "            var vals = sols.Select(s => s[cell]).Distinct().ToList();\n",
+    "            if (vals.Count == 1) {\n",
+    "                if (vals[0] == 0) safe.Add(cell); else mines.Add(cell);\n",
+    "            }\n",
+    "        }\n",
+    "        return (safe, mines);\n",
+    "    }\n",
+    "\n",
+    "    // Probabilite de mine par cellule = freq(mines) sur les solutions.\n",
+    "    public Dictionary<(int r, int c), double> Probabilities(List<Dictionary<(int r, int c),int>> sols) {\n",
+    "        var probs = new Dictionary<(int r, int c), double>();\n",
+    "        if (sols.Count == 0) return probs;\n",
+    "        var cells = sols[0].Keys;\n",
+    "        foreach (var cell in cells) {\n",
+    "            int mineCount = sols.Count(s => s[cell] == 1);\n",
+    "            probs[cell] = (double)mineCount / sols.Count;\n",
+    "        }\n",
+    "        return probs;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Demonstration : partir du plateau bloque par les regles et deduire via CSP.\n",
+    "var boardCsp = board0.Copy();\n",
+    "var rs = new RuleBasedSolver(boardCsp); rs.Solve();\n",
+    "Console.WriteLine($\"Apres regles : {boardCsp.Revealed.Count} revelees, {boardCsp.Flagged.Count} drapeaux, gagne={boardCsp.Won}\");\n",
+    "var csp = new CSPSolver(boardCsp);\n",
+    "var frontier = csp.Frontier();\n",
+    "var constraints = csp.Constraints(frontier);\n",
+    "Console.WriteLine($\"Frontiere CSP : {frontier.Count} cellules, {constraints.Count} contraintes\");\n",
+    "var (safe, mines) = csp.Solve(out var sols);\n",
+    "Console.WriteLine($\"Solutions CSP enumerees : {sols.Count}\");\n",
+    "Console.WriteLine($\"Cellules forcees sures  : {safe.Count}\");\n",
+    "Console.WriteLine($\"Cellules forcees mines  : {mines.Count}\");\n",
+    "if (frontier.Count > 0 && frontier.Count <= 12) {\n",
+    "    Console.Write(\"Frontiere : \");\n",
+    "    foreach (var p in frontier.Take(12)) Console.Write($\"{p} \");\n",
+    "    Console.WriteLine();\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d618f42",
+   "metadata": {},
+   "source": [
+    "## 5. Solveur probabiliste — combiner regles, CSP et choix min-risk\n",
+    "\n",
+    "Quand ni les règles ni le CSP ne forcent de cellule, on choisit la cellule à\n",
+    "**plus faible probabilité de mine**. Le solveur probabiliste orchestre :\n",
+    "\n",
+    "1. Appliquer les règles (gratuit, sûr).\n",
+    "2. Si bloqué, résoudre le CSP pour les cellules forcées.\n",
+    "3. Si toujours bloqué, calculer P(mine) de chaque cellule (frontière via CSP,\n",
+    "   hors-frontière via ratio mines-restantes / cellules-hors-frontière) et\n",
+    "   révéler la cellule la moins risquée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7e15d5b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:24:27.028239Z",
+     "iopub.status.busy": "2026-07-06T11:24:27.028019Z",
+     "iopub.status.idle": "2026-07-06T11:24:27.197457Z",
+     "shell.execute_reply": "2026-07-06T11:24:27.197106Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Partie probabiliste : gagne=True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Decisions : rules=31, csp=3, guess=1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Devinettes faites : 1\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "public class ProbabilisticSolver\n",
+    "{\n",
+    "    public MinesweeperBoard Board;\n",
+    "    public Dictionary<string, int> Decisions = new() { [\"rules\"]=0, [\"csp\"]=0, [\"guess\"]=0 };\n",
+    "    public List<((int r,int c), double prob)> Guesses = new();\n",
+    "\n",
+    "    public ProbabilisticSolver(MinesweeperBoard board) { Board = board; }\n",
+    "\n",
+    "    ((int r,int c)? cell, double prob) ChooseBest(CSPSolver csp, List<Dictionary<(int r, int c),int>> sols) {\n",
+    "        var frontier = csp.Frontier();\n",
+    "        var probs = csp.Probabilities(sols);\n",
+    "        // Cellules hors frontiere : proba uniforme = mines restantes non attribuees / nb\n",
+    "        var allUnknown = new List<(int r, int c)>();\n",
+    "        for (int r = 0; r < Board.Rows; r++) for (int c = 0; c < Board.Cols; c++) {\n",
+    "            var p = (r, c);\n",
+    "            if (!Board.Revealed.Contains(p) && !Board.Flagged.Contains(p)) allUnknown.Add(p);\n",
+    "        }\n",
+    "        var nonFrontier = allUnknown.Where(p => !frontier.Contains(p)).ToList();\n",
+    "        if (nonFrontier.Count > 0) {\n",
+    "            double minesInFrontier = frontier.Sum(p => probs.GetValueOrDefault(p, 0.5));\n",
+    "            double rem = Math.Max(0, Board.RemainingMines - minesInFrontier);\n",
+    "            double nfProb = rem / nonFrontier.Count;\n",
+    "            foreach (var p in nonFrontier) probs[p] = nfProb;\n",
+    "        }\n",
+    "        if (probs.Count == 0) return (null, 1.0);\n",
+    "        var best = probs.Aggregate((a, b) => a.Value <= b.Value ? a : b);\n",
+    "        return (best.Key, best.Value);\n",
+    "    }\n",
+    "\n",
+    "    public bool PlayGame(bool verbose = false) {\n",
+    "        while (!Board.GameOver && !Board.Won) {\n",
+    "            // 1. Regles\n",
+    "            var rs = new RuleBasedSolver(Board); rs.Solve();\n",
+    "            if (rs.MovesLog.Count > 0) { Decisions[\"rules\"] += rs.MovesLog.Count; continue; }\n",
+    "            if (Board.GameOver || Board.Won) break;\n",
+    "            // 2. CSP\n",
+    "            var csp = new CSPSolver(Board);\n",
+    "            var (safe, mines) = csp.Solve(out var sols);\n",
+    "            if (safe.Count + mines.Count > 0) {\n",
+    "                foreach (var m in mines) Board.Flag(m.r, m.c);\n",
+    "                foreach (var s in safe) Board.Reveal(s.r, s.c);\n",
+    "                Decisions[\"csp\"] += safe.Count + mines.Count;\n",
+    "                continue;\n",
+    "            }\n",
+    "            if (Board.GameOver || Board.Won) break;\n",
+    "            // 3. Choix probabiliste\n",
+    "            var (cell, prob) = ChooseBest(csp, sols);\n",
+    "            if (cell is null) break;\n",
+    "            if (verbose) Console.WriteLine($\"  Devinette : {cell} (P(mine) = {prob:P1})\");\n",
+    "            var cellPos = (cell.Value.Item1, cell.Value.Item2);\n",
+    "            Guesses.Add((cellPos, prob));\n",
+    "            Decisions[\"guess\"]++;\n",
+    "            Board.Reveal(cellPos.Item1, cellPos.Item2);\n",
+    "        }\n",
+    "        return Board.Won;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Demonstration : une partie complete avec solveur probabiliste.\n",
+    "var boardProb = new MinesweeperBoard(8, 8, 10, safeCell: (4,4), new Random(2));\n",
+    "boardProb.Reveal(4, 4);\n",
+    "var pSolver = new ProbabilisticSolver(boardProb);\n",
+    "bool won = pSolver.PlayGame(verbose: false);\n",
+    "Console.WriteLine($\"Partie probabiliste : gagne={won}\");\n",
+    "Console.WriteLine($\"Decisions : rules={pSolver.Decisions[\"rules\"]}, csp={pSolver.Decisions[\"csp\"]}, guess={pSolver.Decisions[\"guess\"]}\");\n",
+    "Console.WriteLine($\"Devinettes faites : {pSolver.Guesses.Count}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec8421d6",
+   "metadata": {},
+   "source": [
+    "## 6. Strategies pures pour le benchmark\n",
+    "\n",
+    "Trois stratégies isolées pour mesurer chaque contribution :\n",
+    "\n",
+    "- **play_rule_only** : règles + tirage aléatoire quand bloqué.\n",
+    "- **play_csp_only** : règles + CSP + tirage aléatoire quand bloqué.\n",
+    "- **play_probabilistic** : règles + CSP + choix min-risk quand bloqué."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "73c294ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:24:27.198940Z",
+     "iopub.status.busy": "2026-07-06T11:24:27.198724Z",
+     "iopub.status.idle": "2026-07-06T11:24:27.292167Z",
+     "shell.execute_reply": "2026-07-06T11:24:27.291957Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Trois strategies definies : PlayRuleOnly, PlayCspOnly, PlayProbabilistic.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Strategie 1 : regles + aleatoire quand bloque.\n",
+    "(string, Dictionary<string,int>) PlayRuleOnly(MinesweeperBoard b, Random rng) {\n",
+    "    var dec = new Dictionary<string,int> { [\"rules\"]=0, [\"random\"]=0 };\n",
+    "    while (!b.GameOver && !b.Won) {\n",
+    "        var s = new RuleBasedSolver(b); s.Solve();\n",
+    "        if (s.MovesLog.Count > 0) { dec[\"rules\"] += s.MovesLog.Count; continue; }\n",
+    "        if (b.GameOver || b.Won) break;\n",
+    "        var unknown = new List<(int r, int c)>();\n",
+    "        for (int r = 0; r < b.Rows; r++) for (int c = 0; c < b.Cols; c++) {\n",
+    "            var p = (r, c);\n",
+    "            if (!b.Revealed.Contains(p) && !b.Flagged.Contains(p)) unknown.Add(p);\n",
+    "        }\n",
+    "        if (unknown.Count == 0) break;\n",
+    "        var pick = unknown[rng.Next(unknown.Count)];\n",
+    "        b.Reveal(pick.r, pick.c); dec[\"random\"]++;\n",
+    "    }\n",
+    "    return (b.Won ? \"win\" : \"loss\", dec);\n",
+    "}\n",
+    "\n",
+    "// Strategie 2 : regles + CSP + aleatoire quand bloque.\n",
+    "(string, Dictionary<string,int>) PlayCspOnly(MinesweeperBoard b, Random rng) {\n",
+    "    var dec = new Dictionary<string,int> { [\"rules\"]=0, [\"csp\"]=0, [\"random\"]=0 };\n",
+    "    while (!b.GameOver && !b.Won) {\n",
+    "        var s = new RuleBasedSolver(b); s.Solve();\n",
+    "        if (s.MovesLog.Count > 0) { dec[\"rules\"] += s.MovesLog.Count; continue; }\n",
+    "        if (b.GameOver || b.Won) break;\n",
+    "        var csp = new CSPSolver(b);\n",
+    "        var (safe, mines) = csp.Solve(out _);\n",
+    "        if (safe.Count + mines.Count > 0) {\n",
+    "            foreach (var m in mines) b.Flag(m.r, m.c);\n",
+    "            foreach (var sf in safe) b.Reveal(sf.r, sf.c);\n",
+    "            dec[\"csp\"] += safe.Count + mines.Count; continue;\n",
+    "        }\n",
+    "        if (b.GameOver || b.Won) break;\n",
+    "        var unknown = new List<(int r, int c)>();\n",
+    "        for (int r = 0; r < b.Rows; r++) for (int c = 0; c < b.Cols; c++) {\n",
+    "            var p = (r, c);\n",
+    "            if (!b.Revealed.Contains(p) && !b.Flagged.Contains(p)) unknown.Add(p);\n",
+    "        }\n",
+    "        if (unknown.Count == 0) break;\n",
+    "        var pick = unknown[rng.Next(unknown.Count)];\n",
+    "        b.Reveal(pick.r, pick.c); dec[\"random\"]++;\n",
+    "    }\n",
+    "    return (b.Won ? \"win\" : \"loss\", dec);\n",
+    "}\n",
+    "\n",
+    "// Strategie 3 : regles + CSP + choix probabiliste.\n",
+    "(string, Dictionary<string,int>) PlayProbabilistic(MinesweeperBoard b, Random rng) {\n",
+    "    var dec = new Dictionary<string,int> { [\"rules\"]=0, [\"csp\"]=0, [\"guess\"]=0 };\n",
+    "    while (!b.GameOver && !b.Won) {\n",
+    "        var s = new RuleBasedSolver(b); s.Solve();\n",
+    "        if (s.MovesLog.Count > 0) { dec[\"rules\"] += s.MovesLog.Count; continue; }\n",
+    "        if (b.GameOver || b.Won) break;\n",
+    "        var csp = new CSPSolver(b);\n",
+    "        var (safe, mines) = csp.Solve(out var sols);\n",
+    "        if (safe.Count + mines.Count > 0) {\n",
+    "            foreach (var m in mines) b.Flag(m.r, m.c);\n",
+    "            foreach (var sf in safe) b.Reveal(sf.r, sf.c);\n",
+    "            dec[\"csp\"] += safe.Count + mines.Count; continue;\n",
+    "        }\n",
+    "        if (b.GameOver || b.Won) break;\n",
+    "        // Choix min-risk (fallback aleatoire si CSP vide)\n",
+    "        var probs = csp.Probabilities(sols);\n",
+    "        var frontier = csp.Frontier();\n",
+    "        (int r,int c) pick;\n",
+    "        if (probs.Count > 0) {\n",
+    "            // Etendre aux hors-frontiere\n",
+    "            var allUnknown = new List<(int r, int c)>();\n",
+    "            for (int r = 0; r < b.Rows; r++) for (int c = 0; c < b.Cols; c++) {\n",
+    "                var p = (r, c);\n",
+    "                if (!b.Revealed.Contains(p) && !b.Flagged.Contains(p)) allUnknown.Add(p);\n",
+    "            }\n",
+    "            var nonFrontier = allUnknown.Where(p => !frontier.Contains(p)).ToList();\n",
+    "            if (nonFrontier.Count > 0) {\n",
+    "                double minesInFrontier = frontier.Sum(p => probs.GetValueOrDefault(p, 0.5));\n",
+    "                double rem = Math.Max(0, b.RemainingMines - minesInFrontier);\n",
+    "                double nfProb = rem / nonFrontier.Count;\n",
+    "                foreach (var p in nonFrontier) probs[p] = nfProb;\n",
+    "            }\n",
+    "            pick = probs.Aggregate((a, x) => a.Value <= x.Value ? a : x).Key;\n",
+    "        } else {\n",
+    "            var unknown = new List<(int r, int c)>();\n",
+    "            for (int r = 0; r < b.Rows; r++) for (int c = 0; c < b.Cols; c++) {\n",
+    "                var p = (r, c);\n",
+    "                if (!b.Revealed.Contains(p) && !b.Flagged.Contains(p)) unknown.Add(p);\n",
+    "            }\n",
+    "            if (unknown.Count == 0) break;\n",
+    "            pick = unknown[rng.Next(unknown.Count)];\n",
+    "        }\n",
+    "        b.Reveal(pick.r, pick.c); dec[\"guess\"]++;\n",
+    "    }\n",
+    "    return (b.Won ? \"win\" : \"loss\", dec);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Trois strategies definies : PlayRuleOnly, PlayCspOnly, PlayProbabilistic.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4420e431",
+   "metadata": {},
+   "source": [
+    "## 7. Benchmark — comparer les trois approches\n",
+    "\n",
+    "On joue N parties (graines reproductibles) avec chaque stratégie et on mesure le\n",
+    "taux de victoire. Le twin Python utilise les mêmes graines (`random.seed(1000+game_id)`\n",
+    "pour le plateau, `random.seed(2000+game_id)` pour le solveur)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1b4322d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:24:27.293466Z",
+     "iopub.status.busy": "2026-07-06T11:24:27.293244Z",
+     "iopub.status.idle": "2026-07-06T11:24:27.562180Z",
+     "shell.execute_reply": "2026-07-06T11:24:27.561972Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Benchmark : 50 parties, plateau 8x8, 10 mines\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regles + aleatoire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Victoires : 32/50 (64%)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Temps moyen : 0,4 ms/partie\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Decisions cumulees : rules=1131, random=46\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regles + CSP + aleatoire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Victoires : 36/50 (72%)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Temps moyen : 0,6 ms/partie\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Decisions cumulees : rules=1113, csp=134, random=29\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regles + CSP + probabilites\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Victoires : 41/50 (82%)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Temps moyen : 0,7 ms/partie\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Decisions cumulees : rules=1138, csp=147, guess=32\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Benchmark sur N parties (meme graines que le twin Python).\n",
+    "int N_GAMES = 50;\n",
+    "int ROWS = 8, COLS = 8, NMINES = 10;\n",
+    "\n",
+    "(string name, Func<MinesweeperBoard, Random, (string, Dictionary<string,int>)> play)[] approaches = {\n",
+    "    (\"Regles + aleatoire\",        (b, rng) => PlayRuleOnly(b, rng)),\n",
+    "    (\"Regles + CSP + aleatoire\",  (b, rng) => PlayCspOnly(b, rng)),\n",
+    "    (\"Regles + CSP + probabilites\", (b, rng) => PlayProbabilistic(b, rng)),\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine($\"Benchmark : {N_GAMES} parties, plateau {ROWS}x{COLS}, {NMINES} mines\\n\");\n",
+    "foreach (var (name, play) in approaches) {\n",
+    "    int wins = 0;\n",
+    "    double totalMs = 0;\n",
+    "    var totalDec = new Dictionary<string,int>();\n",
+    "    for (int g = 0; g < N_GAMES; g++) {\n",
+    "        var boardRng = new Random(1000 + g);   // meme graine plateau que twin Python\n",
+    "        var b = new MinesweeperBoard(ROWS, COLS, NMINES, safeCell: (ROWS/2, COLS/2), boardRng);\n",
+    "        b.Reveal(ROWS/2, COLS/2);\n",
+    "        var solverRng = new Random(2000 + g);  // graine solveur\n",
+    "        var sw = System.Diagnostics.Stopwatch.StartNew();\n",
+    "        var (res, dec) = play(b, solverRng);\n",
+    "        sw.Stop();\n",
+    "        totalMs += sw.Elapsed.TotalMilliseconds;\n",
+    "        if (res == \"win\") wins++;\n",
+    "        foreach (var kv in dec) totalDec[kv.Key] = totalDec.GetValueOrDefault(kv.Key, 0) + kv.Value;\n",
+    "    }\n",
+    "    double winRate = (double)wins / N_GAMES * 100;\n",
+    "    double avgMs = totalMs / N_GAMES;\n",
+    "    Console.WriteLine($\"{name}\");\n",
+    "    Console.WriteLine($\"  Victoires : {wins}/{N_GAMES} ({winRate:F0}%)\");\n",
+    "    Console.WriteLine($\"  Temps moyen : {avgMs:F1} ms/partie\");\n",
+    "    Console.WriteLine($\"  Decisions cumulees : {string.Join(\", \", totalDec.Select(kv => $\"{kv.Key}={kv.Value}\"))}\");\n",
+    "    Console.WriteLine();\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "865d5176",
+   "metadata": {},
+   "source": [
+    "## Exercice : solveur global (contrainte du total de mines)\n",
+    "\n",
+    "Le solveur CSP ci-dessus n'utilise que les contraintes **locales** (une par cellule\n",
+    "révélée). Une amélioration : ajouter la **contrainte globale** « le nombre total de\n",
+    "mines marquées dans la frontière ne dépasse pas `remaining_mines` ».\n",
+    "\n",
+    "1. Ajoutez une contrainte globale dans `Constraints(...)` : la somme de **toutes**\n",
+    "   les variables de frontière doit être `<= Board.RemainingMines`.\n",
+    "2. Relancez le benchmark — le taux de victoire augmente-t-il ?\n",
+    "3. (Bonus) Forcez aussi une **égalité** quand toute mine restante est dans la frontière.\n",
+    "\n",
+    "**Indice** : ajoutez `(frontier.ToList(), Board.RemainingMines)` comme contrainte\n",
+    "`ExactSum` (pas juste `<=`) quand `frontier.Count` est petit et que les mines\n",
+    "hors-frontière sont connues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "112f7ffd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:24:27.563691Z",
+     "iopub.status.busy": "2026-07-06T11:24:27.563503Z",
+     "iopub.status.idle": "2026-07-06T11:24:27.624270Z",
+     "shell.execute_reply": "2026-07-06T11:24:27.623958Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice contrainte globale a completer (voir indice ci-dessus).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : contrainte globale sur le total de mines\n",
+    "// TODO etudiant : modifier CSPSolver.Constraints pour ajouter une contrainte\n",
+    "//   globale (somme de toutes les vars de frontiere <= Board.RemainingMines),\n",
+    "//   puis relancer le benchmark pour mesurer l'impact sur le taux de victoire.\n",
+    "Console.WriteLine(\"Exercice contrainte globale a completer (voir indice ci-dessus).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "661476af",
+   "metadata": {},
+   "source": [
+    "## Bilan\n",
+    "\n",
+    "Ce notebook C# a présenté le **Démineur comme CSP**, jumeau C# du notebook Python :\n",
+    "\n",
+    "1. **Représentation** du plateau avec génération sûre (Fisher-Yates partiel) et révélation en cascade.\n",
+    "2. **Solveur par règles** (Rule 1 = tous inconnus mines, Rule 2 = tous inconnus sûrs).\n",
+    "3. **Solveur CSP** — énumération **backtracking from-scratch** avec élagage par contrainte\n",
+    "   (le twin Python délègue à `python-constraint` ; ici on voit la recherche 2^k).\n",
+    "4. **Solveur probabiliste** combinant règles → CSP → choix min-risk (frontière via\n",
+    "   fréquence des solutions, hors-frontière via ratio uniforme).\n",
+    "5. **Benchmark** isolant la contribution de chaque couche (règles / CSP / probabilités).\n",
+    "\n",
+    "> **Parité** : jumeau C# de [App-6-Minesweeper.ipynb](App-6-Minesweeper.ipynb).\n",
+    "> Le twin Python utilise `python-constraint` (lib) + numpy + matplotlib ; le twin C#\n",
+    "> implémente le CSP backtracking **from-scratch** (BCL pure, 0 NuGet) et remplace\n",
+    "> matplotlib par une grille ASCII (Prong B : on enseigne l'algorithme, pas la lib).\n",
+    "> Marathon parité .NET ⇄ Python (#4956), EPIC #3801 (Prong B).\n",
+    "\n",
+    "## Exercices supplementaires\n",
+    "\n",
+    "### Exercice 2 : generation differee des mines (safe-click garanti)\n",
+    "Implémentez une variante `LazyMinesweeperBoard` qui ne place les mines qu'au premier\n",
+    "clic, en excluant la cellule cliquée et ses voisins. Pourquoi cette approche est-elle\n",
+    "standard dans les Démineurs modernes ? (Indice : un premier clic qui tue casse le jeu.)\n",
+    "\n",
+    "### Exercice 3 : benchmark 16x16 (difficulte intermediaire)\n",
+    "Relancez le benchmark avec un plateau `16x16, 40 mines` (niveau Intermédiaire).\n",
+    "Comment évolue l'écart de taux de victoire entre les trois stratégies ? Pourquoi le\n",
+    "CSP devient-il plus déterminant sur les grands plateaux ?\n",
+    "\n",
+    "## References\n",
+    "- Kaye, R. *Minesweeper is NP-complete* (Mathematical Intelligencer, 2000).\n",
+    "- Twin Python : [App-6-Minesweeper.ipynb](App-6-Minesweeper.ipynb).\n",
+    "- Marathon parité : #4956.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -76,6 +76,7 @@ Le gros de la sous-série, et un panorama de ce que la programmation par contrai
 | 4 | [App-4-JobShopScheduling](CSP/App-4-JobShopScheduling.ipynb) | ~60 min | Intervalles, précédences, makespan | Projet étudiant |
 | 5 | [App-5-Timetabling](CSP/App-5-Timetabling.ipynb) | ~50 min | MiniZinc + OR-Tools | Projet étudiant |
 | 6 | [App-6-Minesweeper](CSP/App-6-Minesweeper.ipynb) | ~50 min | CSP + probabilités + LLM | Projet étudiant |
+| 6 | [App-6-Minesweeper-Csharp](CSP/App-6-Minesweeper-Csharp.ipynb) | ~50 min | **Jumeau C#** — CSP backtracking from-scratch + probabilités, parité #4956 | Jumeau .NET |
 | 7 | [App-7-Wordle](CSP/App-7-Wordle.ipynb) | ~45 min | Filtrage CSP + théorie de l'information | Projet étudiant |
 | 8 | [App-8-MiniZinc](CSP/App-8-MiniZinc.ipynb) | ~50 min | Syntaxe MiniZinc, contraintes globales | Nouveau |
 | 9 | [App-11-Picross](CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : 27Mx speedup CP-SAT | Projet étudiant |

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -515,6 +515,7 @@ Search/
 │   │   ├── App-4-JobShopScheduling.ipynb
 │   │   ├── App-5-Timetabling.ipynb
 │   │   ├── App-6-Minesweeper.ipynb
+│   │   ├── App-6-Minesweeper-Csharp.ipynb
 │   │   ├── App-7-Wordle.ipynb
 │   │   ├── App-8-MiniZinc.ipynb
 │   │   ├── App-11-Picross.ipynb


### PR DESCRIPTION
## Summary

Jumeau C# (.NET Interactive) de [App-6-Minesweeper.ipynb](MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb).

- Marathon parité .NET ⇄ Python (**#4956**), EPIC **#3801 Prong B**.
- Famille fraîche (Search/Applications/CSP — premier jumeau C# App-* de ma lane).
- Algorithme **from-scratch en C# pur** (BCL seule, 0 NuGet ; matplotlib → ASCII).

## Prong B — complémentarité (#3801)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python | `python-constraint` (`Problem` + `ExactSumConstraint` + `getSolutions()`) + numpy + matplotlib | résolution via lib industrielle |
| **This (.NET BCL seule)** | **backtracking DFS from-scratch** (frontière binaire, élagage par contrainte) | **comprendre** la mécanique CSP 2^k que la lib cache |

## Algorithmes portés

| Python | C# |
|---|---|
| `MinesweeperBoard` (numpy) | `MinesweeperBoard` (`HashSet<(int r,int c)>` + `int[,]`) |
| `RuleBasedSolver` (Rule 1/2) | `RuleBasedSolver` |
| `CSPSolver` (python-constraint `getSolutions`) | `CSPSolver` (**backtracking from-scratch**) |
| `ProbabilisticSolver` | `ProbabilisticSolver` (rules→CSP→min-risk) |
| `draw_board` (matplotlib) | `DrawBoard` (grille ASCII) |
| benchmark 100 games | benchmark 50 games (mêmes graines `1000+g`/`2000+g`) |

## Validation — H.1 EXEC_PROVED

| Preuve | Résultat |
|---|---|
| `jupyter nbconvert --execute` kernel `.net-csharp` | **8/8 code cells execution_count=1-8, 0 erreur** |
| C.1 (no volontaire error) | `grep -nE "raise NotImplementedError\|assert False\|1/0"` = **0** |
| Benchmark firsthand | Règles **64%** → +CSP **72%** → +Probabilités **82%** (hiérarchie mesurable, chaque couche apporte) |
| CSP demo | 19 cellules frontière, 11 contraintes, **23 solutions énumérées** via backtracking from-scratch |

## SOTA verdict (#3801)

**SOTA-OK / Prong B** : le twin Python lui-même n'implémente pas le solveur CSP à la main (il invoque `python-constraint`). Le twin C# implémente le **backtracking from-scratch** — complémentarité pédagogique authentique (pas un workaround dégradé). ASCII art = Prong B (matplotlib Python ↔ ASCII C#).

## READMEs

- `Search/Applications/README.md` : table ligne 6 C#
- `Search/README.md` : arbre structure (entrée C#)

`CATALOG-STATUS` + `COURSE_CATALOG.generated.*` **byte-identiques à main** (two-dot diff vérifié — règle `catalog-pr-hygiene` HARD 1, leçon #5535 appliquée).

## Scope

1 notebook créé (8 code cells, 18 total) + 2 lignes README. Atomique. Catalogue untouched.

See #4956, #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)