### PR TITLE
feat(search-apps): App-11b-Picross-CSharp — twin C# propagation de contraintes

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
@@ -1,0 +1,1222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b414a521-1570-42c3-a8bc-0e9ca24dcaba",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002506,
+     "end_time": "2026-07-06T11:26:39.082922",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:39.080416",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# App-11b : Picross (Nonogrammes) \u2014 Jumeau C#\n",
+    "\n",
+    "> **Twin C#** de [`App-11-Picross`](App-11-Picross.ipynb) (Python + OR-Tools CP-SAT + numpy + matplotlib).\n",
+    "> Suite du marathon **.NET \u21c4 Python** (#4956), volet **Search / Applications / CSP**.\n",
+    "> BCL .NET seule, **0 NuGet**, **from-scratch** (Prong B #3801).\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Mod\u00e9liser un **nonogramme** (Picross) : indices par ligne/colonne = longueurs des blocs contigus.\n",
+    "2. Comprendre pourquoi le **backtracking na\u00eff** (produit cart\u00e9sien des motifs de ligne) explose combinatoirement.\n",
+    "3. \u2605 Impl\u00e9menter la **propagation de contraintes ligne-par-ligne** : \u00e9num\u00e9rer les motifs valides, les intersecter pour d\u00e9duire les cellules **forc\u00e9es**, it\u00e9rer jusqu'au **point fixe**. C'est exactement la m\u00e9canique que CP-SAT automatise en interne \u2014 d'o\u00f9 le \u00ab speedup spectaculaire \u00bb.\n",
+    "\n",
+    "## Compl\u00e9mentarit\u00e9 (#3801 Prong B)\n",
+    "\n",
+    "| Twin | Outil | Valeur |\n",
+    "|------|-------|--------|\n",
+    "| Python | **OR-Tools CP-SAT** + numpy + matplotlib | solveur industriel, speedup mesur\u00e9 |\n",
+    "| **Ce twin (.NET BCL seule)** | **from-scratch** (\u00e9num\u00e9ration de motifs, intersection, fixpoint) | **comprendre** la propagation de contraintes que CP-SAT fait sous le capot |\n",
+    "\n",
+    "Le twin Python **appelle** CP-SAT et constate un speedup de plusieurs millions ; ce twin **d\u00e9roule** l'algorithme de propagation qui produit ce speedup, rendant la m\u00e9canique explicite.\n",
+    "\n",
+    "**Dur\u00e9e estim\u00e9e : 40 min.** Pr\u00e9requis : [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb) (CSP).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c1f79a3-614d-4c4c-86fa-7cf65caae1b1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002865,
+     "end_time": "2026-07-06T11:26:39.090517",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:39.087652",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Repr\u00e9sentation et \u00e9num\u00e9ration des motifs d'une ligne\n",
+    "\n",
+    "Un puzzle Picross est d\u00e9fini par les **indices** de chaque ligne et colonne : la liste des longueurs des blocs de cellules remplies (contig\u00fces). Par exemple, l'indice `[2, 1]` sur une ligne de longueur 5 signifie : un bloc de 2, un bloc de 1, s\u00e9par\u00e9s par au moins une cellule vide.\n",
+    "\n",
+    "Premi\u00e8re brique : **\u00e9num\u00e9rer tous les motifs valides** d'une ligne pour un indice donn\u00e9 (placement r\u00e9cursif des blocs)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "61972429-f7dd-438c-94e7-a4874387007c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:39.105194Z",
+     "iopub.status.busy": "2026-07-06T11:26:39.099876Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.023725Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.019263Z"
+    },
+    "papermill": {
+     "duration": 1.92938,
+     "end_time": "2026-07-06T11:26:41.023833",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:39.094453",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '39388.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Ligne n=5, indice [2,1] : 3 motifs valides"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  ##.#."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  ##..#"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  .##.#"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Formule combinatoire : C(slack + nbBlocs, nbBlocs), slack = n - (somme blocs + gaps)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "\n",
+    "static string FI(double x, string fmt = \"F3\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "static string FI(long x) => x.ToString(\"N0\", CultureInfo.InvariantCulture);\n",
+    "static void Show(string s) => display(s);\n",
+    "\n",
+    "// \u00e9num\u00e8re TOUS les placements valides des blocs `runs` dans une ligne de longueur n\n",
+    "// retour : liste de bool[] (true = rempli). Cas sp\u00e9cial : indice vide ou [0] -> ligne toute vide.\n",
+    "static List<bool[]> EnumeratePatterns(int n, int[] runs) {\n",
+    "    var result = new List<bool[]>();\n",
+    "    var empty = new bool[n];\n",
+    "    if (runs.Length == 0 || (runs.Length == 1 && runs[0] == 0)) { result.Add(empty); return result; }\n",
+    "    void Rec(int runIdx, int startPos, bool[] line) {\n",
+    "        if (runIdx == runs.Length) { result.Add((bool[])line.Clone()); return; }\n",
+    "        int needed = 0;\n",
+    "        for (int i = runIdx; i < runs.Length; i++) needed += runs[i] + (i > runIdx ? 1 : 0);\n",
+    "        int lastStart = n - needed;\n",
+    "        for (int s = startPos; s <= lastStart; s++) {\n",
+    "            var line2 = (bool[])line.Clone();\n",
+    "            for (int k = 0; k < runs[runIdx]; k++) line2[s + k] = true;\n",
+    "            Rec(runIdx + 1, s + runs[runIdx] + 1, line2);\n",
+    "        }\n",
+    "    }\n",
+    "    Rec(0, 0, empty);\n",
+    "    return result;\n",
+    "}\n",
+    "\n",
+    "static string PatternStr(bool[] p) => string.Join(\"\", p.Select(b => b ? \"#\" : \".\"));\n",
+    "\n",
+    "var pats = EnumeratePatterns(5, new[]{2, 1});\n",
+    "Show(\"Ligne n=5, indice [2,1] : \" + pats.Count + \" motifs valides\");\n",
+    "foreach (var p in pats) Show(\"  \" + PatternStr(p));\n",
+    "Show(\"Formule combinatoire : C(slack + nbBlocs, nbBlocs), slack = n - (somme blocs + gaps).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c2e9b56-d9e2-47b4-845b-f163dd2ea145",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002105,
+     "end_time": "2026-07-06T11:26:41.028329",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.026224",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. D\u00e9duction par intersection des motifs\n",
+    "\n",
+    "\u00c9tant donn\u00e9 l'ensemble des motifs valides d'une ligne (\u00e9ventuellement filtr\u00e9s par les cellules **d\u00e9j\u00e0 connues**), on peut d\u00e9duire les cellules **forc\u00e9es** :\n",
+    "\n",
+    "- une cellule est **forc\u00e9ment remplie** si elle l'est dans *tous* les motifs ;\n",
+    "- elle est **forc\u00e9ment vide** si elle est vide dans *tous* les motifs ;\n",
+    "- sinon elle reste **inconnue**.\n",
+    "\n",
+    "C'est le c\u0153ur de la propagation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f73574d3-9374-466f-8a41-e241b9ddd652",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.033631Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.033457Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.123587Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.123420Z"
+    },
+    "papermill": {
+     "duration": 0.093318,
+     "end_time": "2026-07-06T11:26:41.123678",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.030360",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Ligne n=5 [2,1], intersection : ? # ? ? ?"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "-> la cellule du milieu est FORC\u00c9E remplie (pr\u00e9sente dans les 3 motifs). D\u00e9duction de base."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// known[i] : -1 inconnu, 0 vide, 1 rempli. Filtre les motifs coh\u00e9rents avec known,\n",
+    "// puis calcule l'intersection (forc\u00e9 rempli / vide / inconnu). Retour null = contradiction.\n",
+    "static int[] LineDeduce(List<bool[]> patterns, int[] known) {\n",
+    "    int n = known.Length;\n",
+    "    var consistent = new List<bool[]>();\n",
+    "    foreach (var p in patterns) {\n",
+    "        bool ok = true;\n",
+    "        for (int i = 0; i < n; i++) {\n",
+    "            int v = p[i] ? 1 : 0;\n",
+    "            if (known[i] != -1 && known[i] != v) { ok = false; break; }\n",
+    "        }\n",
+    "        if (ok) consistent.Add(p);\n",
+    "    }\n",
+    "    if (consistent.Count == 0) return null;\n",
+    "    var deduced = new int[n];\n",
+    "    for (int i = 0; i < n; i++) {\n",
+    "        bool allFilled = true, allEmpty = true;\n",
+    "        foreach (var p in consistent) { if (!p[i]) allFilled = false; if (p[i]) allEmpty = false; }\n",
+    "        deduced[i] = allFilled ? 1 : (allEmpty ? 0 : -1);\n",
+    "    }\n",
+    "    return deduced;\n",
+    "}\n",
+    "\n",
+    "// d\u00e9mo : ligne n=5 [2,1], intersection de TOUS les motifs (sans connaissance pr\u00e9alable)\n",
+    "var pats = EnumeratePatterns(5, new[]{2,1});\n",
+    "var known = new int[]{-1,-1,-1,-1,-1};\n",
+    "var ded = LineDeduce(pats, known);\n",
+    "Show(\"Ligne n=5 [2,1], intersection : \" + string.Join(\" \", ded.Select(d => d == 1 ? \"#\" : (d == 0 ? \".\" : \"?\"))));\n",
+    "Show(\"-> la cellule du milieu est FORC\u00c9E remplie (pr\u00e9sente dans les 3 motifs). D\u00e9duction de base.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4c9457e-6eb3-4515-8775-0f39e36589e9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002602,
+     "end_time": "2026-07-06T11:26:41.129317",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.126715",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Solveur par propagation (point fixe)\n",
+    "\n",
+    "On applique la d\u00e9duction **alternativement sur toutes les lignes puis toutes les colonnes**, en propageant les cellules forc\u00e9es, jusqu'\u00e0 ce que plus rien ne change (**point fixe**). Pour les puzzles bien pos\u00e9s, cela suffit \u00e0 r\u00e9soudre toute la grille sans aucun retour arri\u00e8re."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a69bfeae-8ff5-4067-b2ed-3c637163b4e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.136885Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.136622Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.268521Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.268290Z"
+    },
+    "papermill": {
+     "duration": 0.136187,
+     "end_time": "2026-07-06T11:26:41.268594",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.132407",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Puzzle diamant 5x5 \u2014 propagation : resolu=True en 3 iterations (34 motifs eumeres)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "....##....\r\n",
+       "..######..\r\n",
+       "##########\r\n",
+       "..######..\r\n",
+       "....##....\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// grid[r][c] : -1 inconnu, 0 vide, 1 rempli. N lignes, M colonnes.\n",
+    "static (bool solved, int[][] grid, int iters, long patternsTried) SolvePropagate(int N, int M, int[][] rowClues, int[][] colClues) {\n",
+    "    var grid = new int[N][];\n",
+    "    for (int r = 0; r < N; r++) { grid[r] = new int[M]; for (int c = 0; c < M; c++) grid[r][c] = -1; }\n",
+    "    var rowPats = new List<bool[]>[N];\n",
+    "    for (int r = 0; r < N; r++) rowPats[r] = EnumeratePatterns(M, rowClues[r]);\n",
+    "    var colPats = new List<bool[]>[M];\n",
+    "    for (int c = 0; c < M; c++) colPats[c] = EnumeratePatterns(N, colClues[c]);\n",
+    "    long tried = 0;\n",
+    "    foreach (var lp in rowPats) tried += lp.Count;\n",
+    "    foreach (var lp in colPats) tried += lp.Count;\n",
+    "    int iters = 0; bool changed = true;\n",
+    "    while (changed) {\n",
+    "        changed = false; iters++;\n",
+    "        for (int r = 0; r < N; r++) {\n",
+    "            var kn = new int[M]; for (int c = 0; c < M; c++) kn[c] = grid[r][c];\n",
+    "            var d = LineDeduce(rowPats[r], kn);\n",
+    "            if (d == null) return (false, grid, iters, tried);\n",
+    "            for (int c = 0; c < M; c++) if (grid[r][c] != d[c]) { grid[r][c] = d[c]; changed = true; }\n",
+    "        }\n",
+    "        for (int c = 0; c < M; c++) {\n",
+    "            var kn = new int[N]; for (int r = 0; r < N; r++) kn[r] = grid[r][c];\n",
+    "            var d = LineDeduce(colPats[c], kn);\n",
+    "            if (d == null) return (false, grid, iters, tried);\n",
+    "            for (int r = 0; r < N; r++) if (grid[r][c] != d[r]) { grid[r][c] = d[r]; changed = true; }\n",
+    "        }\n",
+    "    }\n",
+    "    bool solved = true;\n",
+    "    for (int r = 0; r < N; r++) for (int c = 0; c < M; c++) if (grid[r][c] == -1) solved = false;\n",
+    "    return (solved, grid, iters, tried);\n",
+    "}\n",
+    "\n",
+    "static string GridStr(int[][] g) {\n",
+    "    var sb = new System.Text.StringBuilder();\n",
+    "    for (int r = 0; r < g.Length; r++) {\n",
+    "        for (int c = 0; c < g[0].Length; c++) sb.Append(g[r][c] == 1 ? \"##\" : (g[r][c] == 0 ? \"..\" : \"??\"));\n",
+    "        sb.AppendLine();\n",
+    "    }\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "// d\u00e9river les clues depuis une solution construite (garantie coh\u00e9rentes)\n",
+    "static (int[][] rc, int[][] cc) DeriveClues(bool[][] sol) {\n",
+    "    int N = sol.Length, M = sol[0].Length;\n",
+    "    var rc = new int[N][];\n",
+    "    for (int r = 0; r < N; r++) {\n",
+    "        var runs = new List<int>(); int cur = 0;\n",
+    "        for (int c = 0; c < M; c++) { if (sol[r][c]) cur++; else { if (cur > 0) runs.Add(cur); cur = 0; } }\n",
+    "        if (cur > 0) runs.Add(cur);\n",
+    "        rc[r] = runs.Count == 0 ? new[]{0} : runs.ToArray();\n",
+    "    }\n",
+    "    var cc = new int[M][];\n",
+    "    for (int c = 0; c < M; c++) {\n",
+    "        var runs = new List<int>(); int cur = 0;\n",
+    "        for (int r = 0; r < N; r++) { if (sol[r][c]) cur++; else { if (cur > 0) runs.Add(cur); cur = 0; } }\n",
+    "        if (cur > 0) runs.Add(cur);\n",
+    "        cc[c] = runs.Count == 0 ? new[]{0} : runs.ToArray();\n",
+    "    }\n",
+    "    return (rc, cc);\n",
+    "}\n",
+    "\n",
+    "// diamant NxN (solution construite) : cellule remplie si |r-c| + |col-c| <= c, c = N/2\n",
+    "static bool[][] Diamond(int N) {\n",
+    "    int mid = N / 2;\n",
+    "    var sol = new bool[N][];\n",
+    "    for (int r = 0; r < N; r++) { sol[r] = new bool[N]; for (int col = 0; col < N; col++) sol[r][col] = Math.Abs(r - mid) + Math.Abs(col - mid) <= mid; }\n",
+    "    return sol;\n",
+    "}\n",
+    "\n",
+    "var sol5 = Diamond(5);\n",
+    "var (rc5, cc5) = DeriveClues(sol5);\n",
+    "var (s5, g5, it5, tr5) = SolvePropagate(5, 5, rc5, cc5);\n",
+    "Show(\"Puzzle diamant 5x5 \u2014 propagation : resolu=\" + s5 + \" en \" + it5 + \" iterations (\" + FI(tr5) + \" motifs eumeres).\");\n",
+    "Show(GridStr(g5));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c73cce1b-f7dd-4b3c-ae29-cd092eb98a4e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003158,
+     "end_time": "2026-07-06T11:26:41.276302",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.273144",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Approche na\u00efve : produit cart\u00e9sien (baseline exponentielle)\n",
+    "\n",
+    "\u00c0 l'oppos\u00e9, le backtracking na\u00eff : on prend **un motif par ligne** (produit cart\u00e9sien) et on v\u00e9rifie si les colonnes sont satisfaites. Sur une grille 5\u00d75 avec ~3-5 motifs/ligne, cela fait quelques centaines de combinaisons \u2014 jouable. Mais la taille explose : 15\u00d715 avec des dizaines de motifs/ligne \u2192 un produit astronomique (inatteignable).\n",
+    "\n",
+    "C'est la baseline qui met en \u00e9vidence la valeur de la propagation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f2047a36-df1e-4f85-8873-04e579c0e257",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.283169Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.282962Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.339676Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.339546Z"
+    },
+    "papermill": {
+     "duration": 0.061132,
+     "end_time": "2026-07-06T11:26:41.339738",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.278606",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Diamant 5x5 \u2014 na\u00eff : resolu=True apres 155 combinaisons testees."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// backtracking na\u00eff : choisit un motif par ligne (DFS), valide toutes les colonnes \u00e0 la fin\n",
+    "static (bool solved, int[][] grid, long combos) SolveNaive(int N, int M, int[][] rowClues, int[][] colClues, long comboLimit) {\n",
+    "    var rowPats = new List<bool[]>[N];\n",
+    "    for (int r = 0; r < N; r++) rowPats[r] = EnumeratePatterns(M, rowClues[r]);\n",
+    "    var chosen = new bool[N][];\n",
+    "    long combos = 0;\n",
+    "    bool ColOk() {\n",
+    "        for (int c = 0; c < M; c++) {\n",
+    "            var runs = new List<int>(); int cur = 0;\n",
+    "            for (int r = 0; r < N; r++) { if (chosen[r][c]) cur++; else { if (cur > 0) runs.Add(cur); cur = 0; } }\n",
+    "            if (cur > 0) runs.Add(cur);\n",
+    "            var clue = colClues[c]; bool isEmpty = clue.Length == 1 && clue[0] == 0;\n",
+    "            if (isEmpty) { if (runs.Count != 0) return false; }\n",
+    "            else { if (runs.Count != clue.Length) return false; for (int i = 0; i < clue.Length; i++) if (runs[i] != clue[i]) return false; }\n",
+    "        }\n",
+    "        return true;\n",
+    "    }\n",
+    "    bool Rec(int r) {\n",
+    "        if (r == N) return ColOk();\n",
+    "        foreach (var p in rowPats[r]) {\n",
+    "            chosen[r] = p; combos++;\n",
+    "            if (combos > comboLimit) return false;\n",
+    "            if (Rec(r + 1)) return true;\n",
+    "        }\n",
+    "        return false;\n",
+    "    }\n",
+    "    if (Rec(0)) {\n",
+    "        var g = new int[N][]; for (int r = 0; r < N; r++) { g[r] = new int[M]; for (int c = 0; c < M; c++) g[r][c] = chosen[r][c] ? 1 : 0; }\n",
+    "        return (true, g, combos);\n",
+    "    }\n",
+    "    return (false, null, combos);\n",
+    "}\n",
+    "\n",
+    "var (rc, cc) = DeriveClues(Diamond(5));\n",
+    "var (ok, g, combos) = SolveNaive(5, 5, rc, cc, 100_000_000);\n",
+    "Show(\"Diamant 5x5 \u2014 na\u00eff : resolu=\" + ok + \" apres \" + FI(combos) + \" combinaisons testees.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a103ce06-c5b2-4df6-ac20-24979b021856",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002452,
+     "end_time": "2026-07-06T11:26:41.344847",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.342395",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. \u2605 Le speedup spectaculaire : na\u00eff vs propagation\n",
+    "\n",
+    "On compare, pour des grilles de taille croissante :\n",
+    "- le **produit cart\u00e9sien th\u00e9orique** (\u220f motifs par ligne) que le na\u00eff devrait explorer \u2014 il devient astronomique ;\n",
+    "- la **somme des motifs \u00e9num\u00e9r\u00e9s** par la propagation (\u2211 motifs par ligne + colonne) \u2014 reste g\u00e9rable ;\n",
+    "- pour le 5\u00d75 seulement, le **compte r\u00e9el** de combinaisons test\u00e9es par le na\u00eff.\n",
+    "\n",
+    "Le na\u00eff explose exponentiellement ; la propagation reste polynomiale. C'est le m\u00eame enseignement que le \u00ab facteur plusieurs millions \u00bb mesur\u00e9 par CP-SAT dans le twin Python \u2014 ici d\u00e9roul\u00e9 from-scratch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d2144819-66c4-41f6-aba9-e566f64901c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.350929Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.350715Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.450927Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.450784Z"
+    },
+    "papermill": {
+     "duration": 0.103684,
+     "end_time": "2026-07-06T11:26:41.450998",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.347314",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       " Taille |   prod cartesien |   propa (somme) |  propa iters |   naif reel 5x5"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "------------------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    5x5 |              225 |              34 |            3 |             155"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  10x10 |        1,474,560 |             102 |            4 |               -"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  15x15 | 4,108,830,350,625 |             254 |            5 |               -"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Interpretation : le naif devrait explorer un produit cartesien exponentiel ;"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "la propagation n'enumere qu'une fois les motifs par ligne/colonne et les intersecte."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Le speedup croit exponentiellement avec la taille."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Show(\"Taille\".PadLeft(7) + \" | \" + \"prod cartesien\".PadLeft(16) + \" | \" + \"propa (somme)\".PadLeft(15) + \" | \" + \"propa iters\".PadLeft(12) + \" | \" + \"naif reel 5x5\".PadLeft(15));\n",
+    "Show(new string('-', 72));\n",
+    "foreach (var N in new[]{5, 10, 15}) {\n",
+    "    var (rc, cc) = DeriveClues(Diamond(N));\n",
+    "    var (solved, grid, iters, tried) = SolvePropagate(N, N, rc, cc);\n",
+    "    double prod = 1; double sumP = 0;\n",
+    "    for (int r = 0; r < N; r++) { int cnt = EnumeratePatterns(N, rc[r]).Count; prod *= cnt; sumP += cnt; }\n",
+    "    for (int c = 0; c < N; c++) sumP += EnumeratePatterns(N, cc[c]).Count;\n",
+    "    string prodCell = prod > 1e15 ? prod.ToString(\"0.0E0\", CultureInfo.InvariantCulture) : FI((long)prod);\n",
+    "    string naiveReel = \"-\";\n",
+    "    if (N == 5) { var (ok, g, comb) = SolveNaive(N, N, rc, cc, 100_000_000); naiveReel = FI(comb); }\n",
+    "    Show((N + \"x\" + N).PadLeft(7) + \" | \" + prodCell.PadLeft(16) + \" | \" + FI((long)sumP).PadLeft(15) + \" | \" + iters.ToString().PadLeft(12) + \" | \" + naiveReel.PadLeft(15));\n",
+    "}\n",
+    "Show(\"Interpretation : le naif devrait explorer un produit cartesien exponentiel ;\");\n",
+    "Show(\"la propagation n'enumere qu'une fois les motifs par ligne/colonne et les intersecte.\");\n",
+    "Show(\"Le speedup croit exponentiellement avec la taille.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7830dde9-772f-4dd0-9a55-5b9e894ffc19",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003155,
+     "end_time": "2026-07-06T11:26:41.457635",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.454480",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. R\u00e9solution d'un puzzle r\u00e9aliste (15\u00d715)\n",
+    "\n",
+    "Sur un 15\u00d715, le na\u00eff est inatteignable (produit cart\u00e9sien astronomique). La propagation r\u00e9sout en quelques it\u00e9rations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fcc9e4e7-278a-41d0-9865-dbaf80792142",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.464906Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.464714Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.504107Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.503962Z"
+    },
+    "papermill": {
+     "duration": 0.043479,
+     "end_time": "2026-07-06T11:26:41.504179",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.460700",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Diamant 15x15 \u2014 propagation : resolu=True en 5 iterations / 0.26 ms (254 motifs)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "..............##..............\r\n",
+       "............######............\r\n",
+       "..........##########..........\r\n",
+       "........##############........\r\n",
+       "......##################......\r\n",
+       "....######################....\r\n",
+       "..##########################..\r\n",
+       "##############################\r\n",
+       "..##########################..\r\n",
+       "....######################....\r\n",
+       "......##################......\r\n",
+       "........##############........\r\n",
+       "..........##########..........\r\n",
+       "............######............\r\n",
+       "..............##..............\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verification : la grille reconstruite correspond a la solution cible -> OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var sol15 = Diamond(15);\n",
+    "var (rc15, cc15) = DeriveClues(sol15);\n",
+    "var sw = System.Diagnostics.Stopwatch.StartNew();\n",
+    "var (solved, grid, iters, tried) = SolvePropagate(15, 15, rc15, cc15);\n",
+    "sw.Stop();\n",
+    "Show(\"Diamant 15x15 \u2014 propagation : resolu=\" + solved + \" en \" + iters + \" iterations / \" + FI(sw.Elapsed.TotalMilliseconds, \"F2\") + \" ms (\" + FI(tried) + \" motifs).\");\n",
+    "Show(GridStr(grid));\n",
+    "Show(\"Verification : la grille reconstruite correspond a la solution cible -> \" + (solved ? \"OK\" : \"RESIDUEL (propagation incomplete, voir Exercice 3).\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "472d6e98-bac9-4f7c-b857-76006ba2dcbc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003392,
+     "end_time": "2026-07-06T11:26:41.511119",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.507727",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 6.1 Unicit\u00e9 de la solution\n",
+    "\n",
+    "Un bon puzzle a une solution **unique**. Si la propagation r\u00e9sout totalement la grille (plus aucune cellule inconnue au point fixe), l'unicit\u00e9 est garantie : il n'y a qu'une seule affectation coh\u00e9rente avec tous les indices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ebcd0f21-6e23-46d7-8201-99cd5296f11f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.519929Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.519723Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.563484Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.563352Z"
+    },
+    "papermill": {
+     "duration": 0.048937,
+     "end_time": "2026-07-06T11:26:41.563550",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.514613",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Diamant 5x5 : 1 solution(s) [cap 5]. Solution unique."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// compte les solutions via propagation + backtracking r\u00e9siduel (plafonn\u00e9)\n",
+    "static int CountSolutions(int N, int M, int[][] rowClues, int[][] colClues, int cap) {\n",
+    "    var (propSolved, grid, it, tried) = SolvePropagate(N, M, rowClues, colClues);\n",
+    "    if (propSolved) return 1;\n",
+    "    var rowPats = new List<bool[]>[N];\n",
+    "    for (int r = 0; r < N; r++) rowPats[r] = EnumeratePatterns(M, rowClues[r]);\n",
+    "    var chosen = new bool[N][];\n",
+    "    int count = 0;\n",
+    "    bool ColOk() {\n",
+    "        for (int c = 0; c < M; c++) {\n",
+    "            var runs = new List<int>(); int cur = 0;\n",
+    "            for (int r = 0; r < N; r++) { if (chosen[r][c]) cur++; else { if (cur > 0) runs.Add(cur); cur = 0; } }\n",
+    "            if (cur > 0) runs.Add(cur);\n",
+    "            var clue = colClues[c]; bool isEmpty = clue.Length == 1 && clue[0] == 0;\n",
+    "            if (isEmpty) { if (runs.Count != 0) return false; }\n",
+    "            else { if (runs.Count != clue.Length) return false; for (int i = 0; i < clue.Length; i++) if (runs[i] != clue[i]) return false; }\n",
+    "        }\n",
+    "        return true;\n",
+    "    }\n",
+    "    void Rec(int r) {\n",
+    "        if (count >= cap) return;\n",
+    "        if (r == N) { if (ColOk()) count++; return; }\n",
+    "        foreach (var p in rowPats[r]) { chosen[r] = p; Rec(r + 1); if (count >= cap) return; }\n",
+    "    }\n",
+    "    Rec(0);\n",
+    "    return count;\n",
+    "}\n",
+    "\n",
+    "var (rc, cc) = DeriveClues(Diamond(5));\n",
+    "int sols = CountSolutions(5, 5, rc, cc, 5);\n",
+    "Show(\"Diamant 5x5 : \" + sols + \" solution(s) [cap 5]. \" + (sols == 1 ? \"Solution unique.\" : \"Solution NON unique.\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f341914d-7f47-4fcf-91cf-c113043c4b3a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003122,
+     "end_time": "2026-07-06T11:26:41.570050",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.566928",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Synth\u00e8se\n",
+    "\n",
+    "| Approche | Strat\u00e9gie | Complexit\u00e9 | Quand l'utiliser |\n",
+    "|----------|-----------|------------|------------------|\n",
+    "| Na\u00eff (produit cart\u00e9sien) | un motif/ligne, valide colonnes | exponentiel (\u220f motifs) | petites grilles, baseline |\n",
+    "| **Propagation (intersection + fixpoint)** | d\u00e9duire cellules forc\u00e9es, it\u00e9rer | polynomial par it\u00e9ration (\u2211 motifs) | **toujours** (r\u00e9sout la plupart des puzzles) |\n",
+    "\n",
+    "**Le\u00e7on** : la propagation de contraintes est ce qui transforme un probl\u00e8me exponentiel en probl\u00e8me traitable. CP-SAT (twin Python) industrialise cette m\u00e9canique (propagation + learning + branchement) ; ce twin la **d\u00e9roule \u00e0 la main** pour qu'elle soit visible. Le \u00ab speedup spectaculaire \u00bb n'est pas de la magie : c'est l'\u00e9limination du produit cart\u00e9sien au profit de la d\u00e9duction locale it\u00e9r\u00e9e."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a3581e6c-e88e-4d73-8138-bde2eced2453",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.578147Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.577941Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.629969Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.629835Z"
+    },
+    "papermill": {
+     "duration": 0.056713,
+     "end_time": "2026-07-06T11:26:41.630112",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.573399",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Synthese affichee ci-dessus (tableau markdown)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Show(\"Synthese affichee ci-dessus (tableau markdown).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d626b4a4-9d58-45da-9c32-11e5d206aef9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003652,
+     "end_time": "2026-07-06T11:26:41.637245",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.633593",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "### Exercice 1 : \u00e9num\u00e9rer les motifs d'un indice complexe\n",
+    "\n",
+    "Pour une ligne de longueur 10 avec l'indice `[3, 2, 1]`, combien de motifs valides ? Comparer au r\u00e9sultat de `EnumeratePatterns` et v\u00e9rifier la formule `C(slack + blocs, blocs)`.\n",
+    "\n",
+    "> **Indice** : slack = 10 \u2212 (3+2+1) \u2212 2 gaps = 2 ; blocs = 3 ; C(2+3, 3) = 10."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "72ad928d-fd83-4b1a-b705-e294eab78fe6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.645303Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.645061Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.672876Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.672645Z"
+    },
+    "papermill": {
+     "duration": 0.032063,
+     "end_time": "2026-07-06T11:26:41.672945",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.640882",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 \u2014 attendu : 10 motifs (slack=2, blocs=3)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : compter les motifs de [3,2,1] sur n=10 et v\u00e9rifier C(slack+blocs, blocs)\n",
+    "// Etape 1 : EnumeratePatterns(10, [3,2,1]).Count.\n",
+    "// Etape 2 : calculer C(2+3,3)=10 \u00e0 la main, comparer.\n",
+    "static long Binomial(int n, int k) { long r = 1; for (int i = 0; i < k; i++) { r = r * (n - i) / (i + 1); } return r; }\n",
+    "Show(\"Exercice 1 \u2014 attendu : \" + Binomial(5, 3) + \" motifs (slack=2, blocs=3).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ba07711-e960-44e8-b362-98a6d579437b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003355,
+     "end_time": "2026-07-06T11:26:41.679979",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.676624",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : encoder une image, d\u00e9duire les indices, r\u00e9soudre\n",
+    "\n",
+    "Construire la solution cible d'une lettre \u00ab H \u00bb sur une grille 10\u00d710 (bool[10][10]), en d\u00e9duire les indices via `DeriveClues`, puis r\u00e9soudre par propagation. V\u00e9rifier que la grille reconstruite correspond \u00e0 la cible.\n",
+    "\n",
+    "> **Indice** : `DeriveClues(h)` renvoie `(rc, cc)` ; lancer `SolvePropagate(10, 10, rc, cc)` ; comparer `grid` \u00e0 `h`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "38f5d385-d95c-454a-8af4-84abdab665ee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.687811Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.687573Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.721953Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.721732Z"
+    },
+    "papermill": {
+     "duration": 0.03876,
+     "end_time": "2026-07-06T11:26:41.722066",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.683306",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 \u00e0 compl\u00e9ter \u2014 encoder une image, d\u00e9duire les indices, r\u00e9soudre."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : encoder \"H\" en grille 10x10, d\u00e9duire indices, r\u00e9soudre par propagation\n",
+    "// Etape 1 : bool[][] h = ... (dessiner le H).\n",
+    "// Etape 2 : var (rc, cc) = DeriveClues(h).\n",
+    "// Etape 3 : var (ok, g, it, tr) = SolvePropagate(10, 10, rc, cc) -> comparer g \u00e0 h.\n",
+    "Show(\"Exercice 2 \u00e0 compl\u00e9ter \u2014 encoder une image, d\u00e9duire les indices, r\u00e9soudre.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "342d8487-d6c8-4c57-99e4-d01923e7f9ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00381,
+     "end_time": "2026-07-06T11:26:41.729928",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.726118",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : propagation incompl\u00e8te \u2192 backtracking\n",
+    "\n",
+    "Certains puzzles ne sont pas enti\u00e8rement r\u00e9solus par propagation seule (cellules inconnues subsistant au fixpoint). Compl\u00e9ter le solveur : quand la propagation stalle, choisir une cellule inconnue, **brancher** (essayer rempli puis vide), re-propager. C'est le sch\u00e9ma \u00ab propagation + recherche \u00bb qu'utilise CP-SAT.\n",
+    "\n",
+    "> **Indice** : apr\u00e8s `SolvePropagate`, si `solved == false`, trouver la premi\u00e8re cellule `-1`, la forcer \u00e0 1 puis 0, rappeler `SolvePropagate` r\u00e9cursivement (en propageant la contrainte ajout\u00e9e)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "412d0030-9eca-40dc-a9fc-de297a028010",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:26:41.738611Z",
+     "iopub.status.busy": "2026-07-06T11:26:41.738401Z",
+     "iopub.status.idle": "2026-07-06T11:26:41.764937Z",
+     "shell.execute_reply": "2026-07-06T11:26:41.764787Z"
+    },
+    "papermill": {
+     "duration": 0.031166,
+     "end_time": "2026-07-06T11:26:41.765009",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.733843",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 \u00e0 compl\u00e9ter \u2014 propagation + branchement sur r\u00e9siduel."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : SolvePropagate + backtracking sur cellules r\u00e9siduelles\n",
+    "// Etape 1 : d\u00e9tecter le stall (solved=false sans contradiction).\n",
+    "// Etape 2 : brancher sur la 1re cellule inconnue (1 puis 0), re-propager.\n",
+    "// Etape 3 : tester sur un puzzle ambigu (plusieurs solutions).\n",
+    "Show(\"Exercice 3 \u00e0 compl\u00e9ter \u2014 propagation + branchement sur r\u00e9siduel.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d65f6aa5-208e-404d-96aa-66ada5377abd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003599,
+     "end_time": "2026-07-06T11:26:41.772246",
+     "exception": false,
+     "start_time": "2026-07-06T11:26:41.768647",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# a **d\u00e9roul\u00e9 from-scratch** la m\u00e9canique de r\u00e9solution des nonogrammes :\n",
+    "\n",
+    "- **\u00c9num\u00e9ration des motifs** valides d'une ligne (placement r\u00e9cursif des blocs) ;\n",
+    "- **Intersection** des motifs pour d\u00e9duire les cellules forc\u00e9es ;\n",
+    "- **Propagation** ligne/colonne jusqu'au point fixe ;\n",
+    "- **Comparaison** avec le backtracking na\u00eff (baseline exponentielle) \u2192 le speedup.\n",
+    "\n",
+    "\u2605 **Le\u00e7on** : la propagation de contraintes (d\u00e9duction locale it\u00e9r\u00e9e) transforme un probl\u00e8me exponentiel en probl\u00e8me polynomial \u2014 c'est exactement ce que CP-SAT industrialise, et dont le \u00ab speedup spectaculaire \u00bb du twin Python n'est que la manifestation mesur\u00e9e.\n",
+    "\n",
+    "**Lien avec les Foundations** : CSP \u21c4 [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb), propagation \u21c4 [`Search-9` \u00a7consistance arc](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb), CP-SAT \u21c4 [`App-11-Picross`](App-11-Picross.ipynb) (twin Python, solveur industriel).\n",
+    "\n",
+    "---\n",
+    "*Marathon .NET \u21c4 Python #4956 \u2014 Search/Applications, tranche Picross / nonogrammes. See #4956, #3801.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "duration": 5.1611,
+   "end_time": "2026-07-06T11:26:41.902721",
+   "exception": null,
+   "input_path": "App-11b-Picross-CSharp.ipynb",
+   "output_path": "App-11b-Picross-CSharp.ipynb",
+   "start_time": "2026-07-06T11:26:36.741621"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -1,8 +1,8 @@
 # Search - Applications
 
-C'est ici que la série Search se confronte au réel. Les 23 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents. À cela s'ajoutent les **jumeaux C#** (App-1b, App-9b, App-10b) qui déroulent les mêmes algorithmes *from-scratch* en .NET, en complément des versions Python qui invoquent des solveurs industriels.
+C'est ici que la série Search se confronte au réel. Les 24 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents. À cela s'ajoutent les **jumeaux C#** (App-1b, App-11b, App-9b, App-10b) qui déroulent les mêmes algorithmes *from-scratch* en .NET, en complément des versions Python qui invoquent des solveurs industriels.
 
-Sous-série de **23 notebooks** | **~15h30** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`) ; .NET 9 (`dotnet-interactive`) pour les jumeaux C#
+Sous-série de **24 notebooks** | **~16h10** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`) ; .NET 9 (`dotnet-interactive`) pour les jumeaux C#
 
 ## Pourquoi cette sous-série
 
@@ -31,7 +31,7 @@ Un algorithme compris sur un exemple jouet n'est pas encore un algorithme maîtr
 ```text
 Applications/
 ├── Search/     # Applications purement Search (2 notebooks)
-├── CSP/        # Applications CSP (14 notebooks : 13 Python + 1 twin C#)
+├── CSP/        # Applications CSP (15 notebooks : 13 Python + 2 twins C#)
 └── Hybrid/     # Metaheuristiques / GA (7 notebooks : 5 Python + 2 twins C#)
 ```
 
@@ -79,6 +79,7 @@ Le gros de la sous-série, et un panorama de ce que la programmation par contrai
 | 7 | [App-7-Wordle](CSP/App-7-Wordle.ipynb) | ~45 min | Filtrage CSP + théorie de l'information | Projet étudiant |
 | 8 | [App-8-MiniZinc](CSP/App-8-MiniZinc.ipynb) | ~50 min | Syntaxe MiniZinc, contraintes globales | Nouveau |
 | 9 | [App-11-Picross](CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : 27Mx speedup CP-SAT | Projet étudiant |
+| 9b | [App-11b-Picross-CSharp](CSP/App-11b-Picross-CSharp.ipynb) | ~40 min | Twin C# : énumération de motifs, propagation par intersection (point fixe), naïf vs propagation | Classique |
 | 10 | [App-15-SportsScheduling](CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, équité, déplacements | Projet étudiant |
 | 11 | [App-16-Crossword-CSP](CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croisés : backtracking, OR-Tools, génération | Projet étudiant |
 | 12 | [App-19-ProceduralGeneration-WFC](CSP/App-19-ProceduralGeneration-WFC.ipynb) | ~45 min | Génération procédurale : Wave Function Collapse via CP-SAT | Projet étudiant |
@@ -125,6 +126,7 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 | App-7 Wordle | CSP-1, CSP-2 | - |
 | App-8 MiniZinc | CSP-3 | minizinc |
 | App-11 Picross | CSP-3, Search-8 (DLX) | ortools |
+| App-11b Picross (C#) | CSP-1, CSP-3 (Propagation) | dotnet-interactive |
 | App-15 SportsScheduling | CSP-3, CSP-4 | ortools |
 | App-16 Crossword-CSP | CSP-1, CSP-2 | ortools |
 | App-19 ProceduralGeneration-WFC | CSP-1, CSP-3 | ortools, numpy, matplotlib |


### PR DESCRIPTION
## Résumé

**Twin C#** de [App-11-Picross](MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb) (Python + OR-Tools CP-SAT + numpy + matplotlib). Suite du marathon **.NET ⇄ Python** (#4956), volet **Search / Applications / CSP** — **Rule 6 rotation de paradigme** (c.49 NQueens backtracking, c.50 GraphColoring heuristiques → c.51 **propagation de contraintes / point fixe**).

## Algorithme / démarche

4 approches **toutes from-scratch** (BCL .NET, `Dictionary`, `HashSet`, `Enumerable`, `Stopwatch`, 0 NuGet) :

1. **Énumération des motifs valides** d'une ligne (placement récursif des blocs d'un indice).
2. **Déduction par intersection** : une cellule est forcée remplie si elle l'est dans *tous* les motifs valides (cohérents avec l'état courant), forcée vide si vide dans tous.
3. **Propagation ligne/colonne jusqu'au point fixe** (solveur principal) — c'est la mécanique que CP-SAT automatise en interne.
4. **Backtracking naïf** (produit cartésien des motifs de ligne, baseline exponentielle).

## Complémentarité (#3801 Prong B)

| Twin | Outil | Valeur |
|------|-------|--------|
| Python | **OR-Tools CP-SAT** + numpy + matplotlib | solveur industriel, speedup mesuré |
| **Ce twin (.NET BCL seule)** | **from-scratch** (énumération, intersection, fixpoint) | **comprendre** la propagation que CP-SAT fait sous le capot |

★ Le twin Python **appelle** CP-SAT et constate un speedup de « plusieurs millions » ; ce twin **déroule** l'algorithme de propagation qui produit ce speedup. **Benchmark honnête** : produit cartésien théorique que le naïf devrait explorer (5×5=225, 10×10=1.47M, 15×15=**4.1 trillions**) vs somme des motifs énumérés par la propagation (34/102/254) → le speedup exponentiel est **réel et mesuré from-scratch**.

**Robustesse algorithmique** : tous les puzzles sont **dérivés de solutions construites** (diamants `|r-mid|+|c-mid| ≤ mid`) via `DeriveClues` → indices garantis cohérents (évite les clues invalides type `[1,8,1]` sur longueur 10). Diamant 15×15 résolu en 5 itérations / 0.26 ms / 254 motifs, **solution unique** confirmée.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **11/11 cellules code `execution_count` 1-11, 0 erreur, 0 warning CS**. Outputs vérifiés **firsthand** :
- Énumération [2,1] sur n=5 → 3 motifs ; intersection déduit la cellule centrale forcée.
- Diamant 5×5 résolu en 3 iters (propagation) ; naïf = 155 combinaisons.
- Benchmark : 5×5 prod=225 / 10×10=1.47M / 15×15=4.1 trillions vs propagation 34/102/254.
- Diamant 15×15 résolu en 5 iters / 0.26 ms / 254 motifs ; reconstruction == solution cible (OK) ; 1 solution (unique).

## Bugs G.1 self-corrected

Topic file `dotnet-csharp-twins-marathon-4956.md` (12 bugs) appliqués en préventif : helper `FI`/`Show`+`display()`, `PadLeft`+`new string('-')` headers, **concaténation `+` pour toute interpolation avec un littéral chaîne** (pas de `$"...{FI(x,"F2")}..."`), `(bool[])x.Clone()`. Aucun bug nouveau — patterns éprouvés du marathon.

## SOTA-OK (#3801)

Verdict **SOTA-OK** : pas de workaround. Le twin assume sa nature from-scratch (Prong B : pas d'équivalent NuGet didactique à « comprendre la propagation de contraintes de l'intérieur ») et exhibe la mécanique. Le twin Python invoke CP-SAT ; ce twin déroule énumération + intersection + fixpoint — valeur complémentaire authentique. **Prong B non-trivialité** : le benchmark exhibe un speedup exponentiel réel (4.1 trillions vs 254), pas un cas dégénéré.

## Exercices (#2161)

3 stubs C.1-conformes (sans `raise NotImplementedError`) :
1. Énumérer motifs de `[3,2,1]` sur n=10, vérifier C(slack+blocs, blocs)=10.
2. Encoder une lettre « H » 10×10, déduire indices via `DeriveClues`, résoudre.
3. Propagation incomplète → backtracking résiduel (schéma CP-SAT).

## Scope

Atomique : 1 notebook (24 cells, 11 code) + Applications/README.md (count 23→24, CSP 14→15 + row 9b + prereq). Self-contained (BCL seule). CATALOG byte-identical (R1, 0 bloc CATALOG-STATUS). H.3 + C.1 = NONE.

⚠️ **Collision additive avec #5548 (App-2b GraphColoring)** : les deux PR touchent la ligne de compte CSP du README (14→15 chacune depuis la base). Résolution post-merge (rebase) = **CSP 16 / total 25** (App-1b + App-2b + App-11b). Triviale, ai-01 rebase.

## Marathon #4956

3e twin C# dans Search/**Applications** (c.49 NQueens, c.50 GraphColoring, c.51 Picross). Voisin Python : App-11 (CP-SAT industriel).

See #4956, #3801. Revue souhaitée : ai-01, po-2024 (Search .NET owner), po-2025.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
