### PR TITLE
feat(search-apps): App-13b-TSP-Metaheuristics-CSharp — twin C# TSP from-scratch

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
@@ -1,0 +1,1129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6a1e3f6d-397a-4d21-9131-c59b1ef7a99c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006465,
+     "end_time": "2026-07-06T11:51:56.403385",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:56.396920",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# App-13b : TSP (Voyageur de Commerce) \u2014 Jumeau C#\n",
+    "\n",
+    "> **Twin C#** de [`App-13-TSP-Metaheuristics`](App-13-TSP-Metaheuristics.ipynb) (Python : brute force, plus-proche-voisin, 2-opt, recuit simul\u00e9, GA, ACO, OR-Tools).\n",
+    "> Suite du marathon **.NET \u21c4 Python** (#4956), volet **Search / Applications / Hybrid**.\n",
+    "> BCL .NET seule, **0 NuGet**, **from-scratch** (Prong B #3801).\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Mod\u00e9liser le **Traveling Salesman Problem** (TSP) : villes, coordonn\u00e9es, matrice de distances, longueur d'une tourn\u00e9e.\n",
+    "2. Distinguer **m\u00e9thode exacte** (force brute, factorielle \u2014 r\u00e9serv\u00e9e aux petites instances) et **heuristiques**.\n",
+    "3. Impl\u00e9menter **from-scratch** les trois piliers de la r\u00e9solution approch\u00e9e du TSP :\n",
+    "   - **construction** (plus proche voisin \u2014 glouton),\n",
+    "   - **recherche locale** (2-opt \u2014 inversion de segments),\n",
+    "   - **m\u00e9taheuristique** (recuit simul\u00e9 sur l'espace des permutations).\n",
+    "4. Comparer empiriquement qualit\u00e9 vs temps sur des instances Euclidiennes.\n",
+    "\n",
+    "## Compl\u00e9mentarit\u00e9 (#3801 Prong B)\n",
+    "\n",
+    "| Twin | Outil | Valeur |\n",
+    "|------|-------|--------|\n",
+    "| Python | **OR-Tools** routing + numpy + matplotlib | solveur industriel (routing), visualisation |\n",
+    "| Twins C# Hybrid existants (App-9b, App-10b) | **GeneticSharp** (librairie .NET) | algorithme g\u00e9n\u00e9tique cl\u00e9 en main |\n",
+    "| **Ce twin (.NET BCL seule)** | **from-scratch** (2-opt, recuit simul\u00e9 sur permutations) | **comprendre** les heuristiques canoniques du TSP |\n",
+    "\n",
+    "\u2605 Le twin Python **appelle** OR-Tools ; les autres twins C# appellent **GeneticSharp**. Ce twin **d\u00e9roule les heuristiques \u00e0 la main** (2-opt = inversion de segment, recuit simul\u00e9 = move 2-opt + crit\u00e8re de Metropolis) \u2014 la m\u00e9canique que les librairies cachent.\n",
+    "\n",
+    "**Dur\u00e9e estim\u00e9e : 45 min.** Pr\u00e9requis : [`Search-4`](../../Part1-Foundations/Search-4-LocalSearch.ipynb) (recherche locale), [`Search-11`](../../Part3-Advanced/Search-11-SimulatedAnnealing.ipynb) (recuit simul\u00e9).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f6f5a78-1d31-41ad-829a-305804699c6f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001691,
+     "end_time": "2026-07-06T11:51:56.408050",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:56.406359",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Repr\u00e9sentation du probl\u00e8me\n",
+    "\n",
+    "Le TSP : \u00e9tant donn\u00e9 N villes et les distances entre elles, trouver la tourn\u00e9e ferm\u00e9e la plus courte passant par chaque ville exactement une fois. NP-dur. On travaille en Euclidien : les villes sont des points du plan, la distance est la distance Euclidienne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c4295fbd-233b-48b4-a869-fb9514f084b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:56.422010Z",
+     "iopub.status.busy": "2026-07-06T11:51:56.416996Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.153456Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.150021Z"
+    },
+    "papermill": {
+     "duration": 1.743975,
+     "end_time": "2026-07-06T11:51:58.153555",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:56.409580",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '42940.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Instance Euclidienne : 6 villes. Matrice 6x6 (extrait) :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "           0     1     2     3     4     5"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   0    0.00 66.35 51.43 37.63 79.33 44.89"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   1   66.35  0.00 26.37 59.90 24.33 28.70"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   2   51.43 26.37  0.00 60.97 49.87  6.64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   3   37.63 59.90 60.97  0.00 60.42 55.25"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   4   79.33 24.33 49.87 60.42  0.00 50.76"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   5   44.89 28.70  6.64 55.25 50.76  0.00"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Tourn\u00e9e [0,1,2,3,4,5] longueur = 309.75"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "\n",
+    "static string FI(double x, string fmt = \"F2\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "static string FI(long x) => x.ToString(\"N0\", CultureInfo.InvariantCulture);\n",
+    "static void Show(string s) => display(s);\n",
+    "\n",
+    "// Instance du TSP : N villes, coordonn\u00e9es Euclidiennes, matrice des distances pr\u00e9calcul\u00e9e.\n",
+    "public class TSPInstance {\n",
+    "    public int N;\n",
+    "    public double[] X; public double[] Y;\n",
+    "    public double[][] D;              // matrice NxN des distances Euclidiennes\n",
+    "    public TSPInstance(double[] xs, double[] ys) {\n",
+    "        N = xs.Length; X = xs; Y = ys;\n",
+    "        D = new double[N][];\n",
+    "        for (int i = 0; i < N; i++) { D[i] = new double[N]; for (int j = 0; j < N; j++) {\n",
+    "            double dx = X[i] - X[j], dy = Y[i] - Y[j]; D[i][j] = Math.Sqrt(dx*dx + dy*dy); } }\n",
+    "    }\n",
+    "    // longueur d'une tourn\u00e9e ferm\u00e9e : somme des ar\u00eates cons\u00e9cutives + retour au d\u00e9part\n",
+    "    public double TourLength(int[] tour) {\n",
+    "        double s = 0; for (int k = 0; k < N; k++) s += D[tour[k]][tour[(k+1) % N]]; return s;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// instance reproductible : N villes dans [0,100)^2 via RNG seeded\n",
+    "static TSPInstance RandomInstance(int n, int seed) {\n",
+    "    var rnd = new Random(seed);\n",
+    "    var xs = new double[n]; var ys = new double[n];\n",
+    "    for (int i = 0; i < n; i++) { xs[i] = rnd.NextDouble()*100; ys[i] = rnd.NextDouble()*100; }\n",
+    "    return new TSPInstance(xs, ys);\n",
+    "}\n",
+    "\n",
+    "// affiche une tourn\u00e9e en abr\u00e9g\u00e9\n",
+    "static string TourStr(int[] tour) => \"[\" + string.Join(\",\", tour.Take(Math.Min(tour.Length,12))) + (tour.Length>12 ? \",...]\" : \"]\");\n",
+    "\n",
+    "var small = RandomInstance(6, 42);\n",
+    "Show(\"Instance Euclidienne : \" + small.N + \" villes. Matrice 6x6 (extrait) :\");\n",
+    "var m = \"      \";\n",
+    "for (int j = 0; j < small.N; j++) m += j.ToString().PadLeft(6);\n",
+    "Show(m);\n",
+    "for (int i = 0; i < small.N; i++) Show(i.ToString().PadLeft(4) + \"  \" + string.Join(\"\", Enumerable.Range(0, small.N).Select(j => small.D[i][j].ToString(\"F2\", CultureInfo.InvariantCulture).PadLeft(6))));\n",
+    "var t = new int[]{0,1,2,3,4,5};\n",
+    "Show(\"Tourn\u00e9e [0,1,2,3,4,5] longueur = \" + FI(small.TourLength(t)));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6a170c7-dcd5-402d-961a-f54f4524caa3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002077,
+     "end_time": "2026-07-06T11:51:58.158027",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.155950",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. M\u00e9thode exacte : force brute (r\u00e9f\u00e9rence)\n",
+    "\n",
+    "La force brute \u00e9num\u00e8re toutes les $(N-1)!$ tourn\u00e9es (en fixant la ville de d\u00e9part \u00e0 0 pour casser la sym\u00e9trie cyclique). Garantit l'optimum global mais devient inutilisable au-del\u00e0 de ~10 villes. Sert de **r\u00e9f\u00e9rence** pour mesurer la qualit\u00e9 des heuristiques."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "91b4f7c3-f94c-44c6-b2c4-9ac3cf4d5a7a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.165900Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.165625Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.297789Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.297592Z"
+    },
+    "papermill": {
+     "duration": 0.136724,
+     "end_time": "2026-07-06T11:51:58.297860",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.161136",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Force brute N=8 : optimum = 293.19 en 1.2 ms (5,040 = 7! permutations testees)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Tourn\u00e9e optimale : [0,5,4,7,1,6,2,3]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Croissance : (N-1)! -> N=10 = 362880, N=12 = 4e7, N=15 = 8.7e10 (inatteignable)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// force brute : \u00e9num\u00e8re toutes les permutations des villes 1..N-1 (ville 0 fix\u00e9e), garde la meilleure\n",
+    "static (int[] tour, double len, long tried) BruteForce(TSPInstance tsp) {\n",
+    "    int n = tsp.N;\n",
+    "    var rest = Enumerable.Range(1, n - 1).ToArray();\n",
+    "    int[] bestTour = null; double bestLen = double.MaxValue; long tried = 0;\n",
+    "    void Permute(int k) {\n",
+    "        if (k == rest.Length) {\n",
+    "            var tour = new int[n]; tour[0] = 0; for (int i = 0; i < rest.Length; i++) tour[i+1] = rest[i];\n",
+    "            tried++;\n",
+    "            double len = tsp.TourLength(tour);\n",
+    "            if (len < bestLen) { bestLen = len; bestTour = (int[])tour.Clone(); }\n",
+    "            return;\n",
+    "        }\n",
+    "        for (int i = k; i < rest.Length; i++) {\n",
+    "            (rest[k], rest[i]) = (rest[i], rest[k]);\n",
+    "            Permute(k + 1);\n",
+    "            (rest[k], rest[i]) = (rest[i], rest[k]);\n",
+    "        }\n",
+    "    }\n",
+    "    Permute(0);\n",
+    "    return (bestTour, bestLen, tried);\n",
+    "}\n",
+    "\n",
+    "var inst8 = RandomInstance(8, 7);\n",
+    "var sw = System.Diagnostics.Stopwatch.StartNew();\n",
+    "var (bt, bl, tried) = BruteForce(inst8);\n",
+    "sw.Stop();\n",
+    "Show(\"Force brute N=8 : optimum = \" + FI(bl) + \" en \" + FI(sw.Elapsed.TotalMilliseconds, \"F1\") + \" ms (\" + FI(tried) + \" = 7! permutations testees).\");\n",
+    "Show(\"Tourn\u00e9e optimale : \" + TourStr(bt));\n",
+    "Show(\"Croissance : (N-1)! -> N=10 = 362880, N=12 = 4e7, N=15 = 8.7e10 (inatteignable).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56e04982-f0d6-4f1f-869e-b8edd28c22ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002309,
+     "end_time": "2026-07-06T11:51:58.302809",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.300500",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Heuristique de construction : plus proche voisin\n",
+    "\n",
+    "Glouton : on part de la ville 0, et \u00e0 chaque \u00e9tape on va \u00e0 la ville non visit\u00e9e la plus proche. Rapide ($O(N^2)$) mais myope \u2014 construit des tourn\u00e9es typiquement 20-30% au-dessus de l'optimum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "57a0573f-f033-43ff-ad7e-669b97cae264",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.308587Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.308411Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.349382Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.349275Z"
+    },
+    "papermill": {
+     "duration": 0.044362,
+     "end_time": "2026-07-06T11:51:58.349438",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.305076",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Plus proche voisin N=8 : longueur = 344.77 (vs optimum 293.19, gap = 17.6%)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Tourn\u00e9e NN : [0,5,2,3,4,7,1,6]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// plus proche voisin : greedy, O(N^2)\n",
+    "static (int[] tour, double len) NearestNeighbor(TSPInstance tsp) {\n",
+    "    int n = tsp.N; var visited = new bool[n];\n",
+    "    var tour = new int[n]; tour[0] = 0; visited[0] = true;\n",
+    "    for (int k = 1; k < n; k++) {\n",
+    "        int prev = tour[k-1]; int best = -1; double bestD = double.MaxValue;\n",
+    "        for (int j = 0; j < n; j++) { if (!visited[j] && tsp.D[prev][j] < bestD) { bestD = tsp.D[prev][j]; best = j; } }\n",
+    "        tour[k] = best; visited[best] = true;\n",
+    "    }\n",
+    "    return (tour, tsp.TourLength(tour));\n",
+    "}\n",
+    "\n",
+    "var (nnTour, nnLen) = NearestNeighbor(inst8);\n",
+    "Show(\"Plus proche voisin N=8 : longueur = \" + FI(nnLen) + \" (vs optimum \" + FI(bl) + \", gap = \" + FI(100*(nnLen-bl)/bl, \"F1\") + \"%).\");\n",
+    "Show(\"Tourn\u00e9e NN : \" + TourStr(nnTour));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb07ce8a-bfbd-4795-9bc8-f676801decc4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002352,
+     "end_time": "2026-07-06T11:51:58.354283",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.351931",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Recherche locale : 2-opt\n",
+    "\n",
+    "Le **2-opt** est la recherche locale canonique du TSP. Principe : tant qu'il existe deux ar\u00eates de la tourn\u00e9e qui se croisent (ou sont sous-optimales), on **inverse le segment** entre elles. Une inversion de segment supprime deux ar\u00eates $(a,b)$ et $(c,d)$ et les remplace par $(a,c)$ et $(b,d)$. On it\u00e8re jusqu'\u00e0 un optimum local (plus aucune inversion n'am\u00e9liore).\n",
+    "\n",
+    "C'est l'op\u00e9ration de base que tous les solveurs TSP utilisent en post-optimisation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "28f18de6-1d18-4cbd-9483-2df2163d66bc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.359985Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.359807Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.406373Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.406245Z"
+    },
+    "papermill": {
+     "duration": 0.049903,
+     "end_time": "2026-07-06T11:51:58.406429",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.356526",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2-opt (depuis NN) N=8 : longueur = 293.19 (4 inversions). Gap vs optimum = 0.00%."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2-opt rapproche fortement de l'optimum en O(N^2) par passage."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// 2-opt : r\u00e9p\u00e8te les inversions de segments am\u00e9liorantes jusqu'\u00e0 optimum local\n",
+    "static (int[] tour, double len, int improvements) TwoOpt(TSPInstance tsp, int[] initTour) {\n",
+    "    int n = tsp.N; var tour = (int[])initTour.Clone(); int improvements = 0;\n",
+    "    bool improved = true;\n",
+    "    while (improved) {\n",
+    "        improved = false;\n",
+    "        for (int i = 1; i < n - 1; i++) {\n",
+    "            for (int j = i + 1; j < n; j++) {\n",
+    "                int a = tour[i-1], b = tour[i], c = tour[j], d = (j+1 < n) ? tour[j+1] : tour[0];\n",
+    "                double before = tsp.D[a][b] + tsp.D[c][d];\n",
+    "                double after  = tsp.D[a][c] + tsp.D[b][d];\n",
+    "                if (after + 1e-12 < before) {\n",
+    "                    Array.Reverse(tour, i, j - i + 1);\n",
+    "                    improvements++; improved = true;\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return (tour, tsp.TourLength(tour), improvements);\n",
+    "}\n",
+    "\n",
+    "// 2-opt sur la tourn\u00e9e du plus proche voisin\n",
+    "var (opt2Tour, opt2Len, opt2Imp) = TwoOpt(inst8, nnTour);\n",
+    "Show(\"2-opt (depuis NN) N=8 : longueur = \" + FI(opt2Len) + \" (\" + opt2Imp + \" inversions). Gap vs optimum = \" + FI(100*(opt2Len-bl)/bl, \"F2\") + \"%.\");\n",
+    "Show(\"2-opt rapproche fortement de l'optimum en O(N^2) par passage.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e409b28-9f9b-432c-a1a1-8ff9db1dc39a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002339,
+     "end_time": "2026-07-06T11:51:58.411195",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.408856",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. M\u00e9taheuristique : recuit simul\u00e9 sur permutations\n",
+    "\n",
+    "Le **recuit simul\u00e9** (Simulated Annealing) escape les optima locaux du 2-opt en acceptant parfois des mouvements d\u00e9gradants avec probabilit\u00e9 $\\exp(-\\Delta/T)$, o\u00f9 $T$ d\u00e9cro\u00eet g\u00e9om\u00e9triquement. Sur le TSP, le mouvement propos\u00e9 est une **inversion 2-opt al\u00e9atoire**. \u00c0 haute temp\u00e9rature, exploration ; \u00e0 basse temp\u00e9rature, exploitation \u2192 convergence vers un (tr\u00e8s bon) optimum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0415d578-1b00-406c-af37-d8df4c81504e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.418535Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.418346Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.458378Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.458218Z"
+    },
+    "papermill": {
+     "duration": 0.044114,
+     "end_time": "2026-07-06T11:51:58.458437",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.414323",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Recuit simul\u00e9 N=8 (depuis NN, 20000 iters) : longueur = 293.19 (2056 moves acceptes). Gap vs optimum = -0.00%."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// recuit simul\u00e9 sur permutations : move = inversion 2-opt al\u00e9atoire, acceptation de Metropolis\n",
+    "static (int[] tour, double len, int accepted) SimulatedAnnealing(TSPInstance tsp, int[] initTour, double T0, double alpha, int iters, int seed) {\n",
+    "    int n = tsp.N; var tour = (int[])initTour.Clone(); var rnd = new Random(seed);\n",
+    "    double curLen = tsp.TourLength(tour); int accepted = 0;\n",
+    "    int[] best = (int[])tour.Clone(); double bestLen = curLen;\n",
+    "    double T = T0;\n",
+    "    for (int it = 0; it < iters; it++) {\n",
+    "        int i = 1 + rnd.Next(n - 1); int j = 1 + rnd.Next(n - 1);\n",
+    "        if (i == j) continue; if (i > j) (i, j) = (j, i);\n",
+    "        int a = tour[i-1], b = tour[i], c = tour[j], d = (j+1 < n) ? tour[j+1] : tour[0];\n",
+    "        double delta = (tsp.D[a][c] + tsp.D[b][d]) - (tsp.D[a][b] + tsp.D[c][d]);\n",
+    "        if (delta <= 0 || rnd.NextDouble() < Math.Exp(-delta / T)) {\n",
+    "            Array.Reverse(tour, i, j - i + 1);\n",
+    "            curLen += delta; accepted++;\n",
+    "            if (curLen < bestLen) { bestLen = curLen; best = (int[])tour.Clone(); }\n",
+    "        }\n",
+    "        T *= alpha;\n",
+    "    }\n",
+    "    return (best, bestLen, accepted);\n",
+    "}\n",
+    "\n",
+    "var (saTour, saLen, saAcc) = SimulatedAnnealing(inst8, nnTour, T0: 50.0, alpha: 0.9995, iters: 20000, seed: 1);\n",
+    "Show(\"Recuit simul\u00e9 N=8 (depuis NN, 20000 iters) : longueur = \" + FI(saLen) + \" (\" + saAcc + \" moves acceptes). Gap vs optimum = \" + FI(100*(saLen-bl)/bl, \"F2\") + \"%.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "833095d7-ec99-43b5-b3e3-67282e2ddd2b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002543,
+     "end_time": "2026-07-06T11:51:58.463628",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.461085",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. \u2605 Benchmark comparatif\n",
+    "\n",
+    "On compare les quatre approches sur des instances de taille croissante. La force brute donne l'optimum pour N\u226410 ; au-del\u00e0, on compare les heuristiques entre elles (le 2-opt et le recuit simul\u00e9 s'approchent de l'optimal, le plus-proche-voisin reste en retrait).\n",
+    "\n",
+    "C'est l'enseignement central : **exact \u2194 approch\u00e9** bascule d\u00e8s que l'espace explose \u2014 le m\u00eame mouvement qu'on observe pour le backtracking na\u00eff sur les autres probl\u00e8mes combinatoires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "92ae3d30-47a7-4ca8-997d-ea8688fa6916",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.469276Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.469109Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.607627Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.607507Z"
+    },
+    "papermill": {
+     "duration": 0.141802,
+     "end_time": "2026-07-06T11:51:58.607686",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.465884",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "    N |   brut(opt) |          NN |       2-opt |          SA |   gap NN |  gap 2opt |   gap SA"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--------------------------------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    6 |      278.24 |      328.09 |      278.24 |      278.24 |    17.9% |      0.0% |    -0.0%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    8 |      293.19 |      344.77 |      293.19 |      293.19 |    17.6% |      0.0% |    -0.0%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   10 |      314.41 |      365.98 |      314.41 |      314.41 |    16.4% |      0.0% |     0.0%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   30 |       (N/A) |      554.61 |      475.12 |      463.26 |    19.7% |      2.6% |     0.0%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   60 |       (N/A) |      780.76 |      638.90 |      663.51 |    22.2% |      0.0% |     3.9%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  100 |       (N/A) |      940.91 |      803.45 |      820.65 |    17.1% |      0.0% |     2.1%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Interpretation : NN est rapide mais sous-optimal (gap ~10-25%). 2-opt et SA rapprochent"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "fortement de l'optimum (gap souvent < 2-3%). Au-dela de N=10, la force brute est infaisable."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Show(\"N\".PadLeft(5) + \" | \" + \"brut(opt)\".PadLeft(11) + \" | \" + \"NN\".PadLeft(11) + \" | \" + \"2-opt\".PadLeft(11) + \" | \" + \"SA\".PadLeft(11) + \" | \" + \"gap NN\".PadLeft(8) + \" | \" + \"gap 2opt\".PadLeft(9) + \" | \" + \"gap SA\".PadLeft(8));\n",
+    "Show(new string('-', 86));\n",
+    "foreach (var n in new[]{6, 8, 10, 30, 60, 100}) {\n",
+    "    var inst = RandomInstance(n, 7);\n",
+    "    var (nnT, nnL) = NearestNeighbor(inst);\n",
+    "    var (o2T, o2L, o2I) = TwoOpt(inst, nnT);\n",
+    "    var (saT, saL, saA) = SimulatedAnnealing(inst, nnT, T0: Math.Max(50.0, n*1.5), alpha: 0.9995, iters: Math.Min(60000, n*1000), seed: 1);\n",
+    "    string brutCell; double opt = -1;\n",
+    "    if (n <= 10) {\n",
+    "        var swb = System.Diagnostics.Stopwatch.StartNew();\n",
+    "        var (bT, bL, bTr) = BruteForce(inst); swb.Stop();\n",
+    "        opt = bL; brutCell = FI(bL);\n",
+    "    } else { brutCell = \"(N/A)\"; opt = Math.Min(o2L, saL); }   // r\u00e9f\u00e9rence = meilleur heuristique au-del\u00e0\n",
+    "    double gNN = opt > 0 ? 100*(nnL - opt)/opt : 0;\n",
+    "    double g2 = opt > 0 ? 100*(o2L - opt)/opt : 0;\n",
+    "    double gSA = opt > 0 ? 100*(saL - opt)/opt : 0;\n",
+    "    Show(n.ToString().PadLeft(5) + \" | \" + brutCell.PadLeft(11) + \" | \" + FI(nnL).PadLeft(11) + \" | \" + FI(o2L).PadLeft(11) + \" | \" + FI(saL).PadLeft(11) + \" | \" + (FI(gNN,\"F1\")+\"%\").PadLeft(8) + \" | \" + (FI(g2,\"F1\")+\"%\").PadLeft(9) + \" | \" + (FI(gSA,\"F1\")+\"%\").PadLeft(8));\n",
+    "}\n",
+    "Show(\"Interpretation : NN est rapide mais sous-optimal (gap ~10-25%). 2-opt et SA rapprochent\");\n",
+    "Show(\"fortement de l'optimum (gap souvent < 2-3%). Au-dela de N=10, la force brute est infaisable.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccfdb229-0fe2-4894-9b20-74350424a5f4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002914,
+     "end_time": "2026-07-06T11:51:58.613779",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.610865",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Synth\u00e8se\n",
+    "\n",
+    "| Approche | Type | Complexit\u00e9 | Qualit\u00e9 | Quand l'utiliser |\n",
+    "|----------|------|------------|---------|------------------|\n",
+    "| Force brute | exacte | $O((N-1)!)$ | optimum global | N \u2264 10 (r\u00e9f\u00e9rence) |\n",
+    "| Plus proche voisin | construction gloutonne | $O(N^2)$ | 10-25% au-dessus | initialisation rapide |\n",
+    "| **2-opt** | recherche locale | $O(N^2)$/passage | < 3% au-dessus (opt local) | post-optimisation syst\u00e9matique |\n",
+    "| **Recuit simul\u00e9** | m\u00e9taheuristique | $O(I \\cdot N)$/it\u00e9ration | < 2-3%, \u00e9chappe aux optima locaux | instances moyen/grandes |\n",
+    "\n",
+    "**Le\u00e7on** : le TSP illustre le basculement **exact \u2194 approch\u00e9**. La force brute garantit l'optimum mais explose ; les heuristiques (construction + recherche locale + m\u00e9taheuristique) s'approchent de l'optimum \u00e0 un co\u00fbt polynomial. C'est le sch\u00e9ma universel de l'optimisation combinatoire. Les solveurs industriels (OR-Tools, twin Python) combinent ces briques (construction + 2-opt + LK + branch-and-bound) \u00e0 l'\u00e9chelle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2e6af927-59b4-4ad5-9aca-4a979e863656",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.620638Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.620473Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.645971Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.646059Z"
+    },
+    "papermill": {
+     "duration": 0.029726,
+     "end_time": "2026-07-06T11:51:58.646119",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.616393",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Synthese affichee ci-dessus (tableau markdown)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Show(\"Synthese affichee ci-dessus (tableau markdown).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd83dcbc-6e62-4cc5-a6d3-30dcde065102",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002857,
+     "end_time": "2026-07-06T11:51:58.652007",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.649150",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "### Exercice 1 : insertion de villes (heuristique Or-opt)\n",
+    "\n",
+    "Le 2-opt inverse des segments. Une autre recherche locale classique est l'**Or-opt** : extraire un segment de 1-3 villes et le r\u00e9ins\u00e9rer ailleurs. Impl\u00e9menter ce mouvement et le combiner au 2-opt.\n",
+    "\n",
+    "> **Indice** : `Array.Copy` pour extraire puis ins\u00e9rer ; recalculer le delta de longueur sur les ar\u00eates affect\u00e9es seulement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2c0f9c30-1cb6-4f28-8abb-b7db21ef6042",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.658998Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.658838Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.702793Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.702680Z"
+    },
+    "papermill": {
+     "duration": 0.04793,
+     "end_time": "2026-07-06T11:51:58.702850",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.654920",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 a completer \u2014 Or-opt combine au 2-opt."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Or-opt (deplacement de segment court) combine au 2-opt\n",
+    "// Etape 1 : ecrire OrOpt(tsp, tour) qui tente de deplacer chaque segment [i..i+k] (k=1..3) vers une autre position si cela raccourcit.\n",
+    "// Etape 2 : alterner TwoOpt et OrOpt jusqu'a fixpoint, comparer la qualite au 2-opt seul.\n",
+    "Show(\"Exercice 1 a completer \u2014 Or-opt combine au 2-opt.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "174d0832-18cf-4401-892f-a2dc80b3133a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00326,
+     "end_time": "2026-07-06T11:51:58.709157",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.705897",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : colonies de fourmis (ACO)\n",
+    "\n",
+    "L'ACO adapte la m\u00e9taphore des fourmis : chaque \u00ab fourmi \u00bb construit une tourn\u00e9e en pond\u00e9rant le choix de la prochaine ville par une **ph\u00e9romone** \u03c4 et une heuristique \u03b7 = 1/d. Les ph\u00e9romones \u00e9vaporent et sont renforc\u00e9es par les meilleures tourn\u00e9es. Impl\u00e9menter une version simple.\n",
+    "\n",
+    "> **Indice** : probabilit\u00e9 $P(i \to j) \\propto \tau_{ij}^\u0007lpha \\cdot \\eta_{ij}^\beta$ ; mise \u00e0 jour $\tau \\leftarrow (1-\r",
+    "ho)\tau + \\Delta\tau$ apr\u00e8s chaque it\u00e9ration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4905c22b-8226-4387-8258-247f639a7769",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.716248Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.716098Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.738258Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.738151Z"
+    },
+    "papermill": {
+     "duration": 0.026071,
+     "end_time": "2026-07-06T11:51:58.738312",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.712241",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 a completer - ACO (construction ponderee par pheromones + evaporation)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : ACO simplifie\n",
+    "// Etape 1 : matrice de pheromones tau initialisee a 1.\n",
+    "// Etape 2 : chaque fourmi construit une tournee par tirage pondere (tau^alpha * (1/d)^beta).\n",
+    "// Etape 3 : evaporation (tau *= (1-rho)) + depot sur la meilleure tournee. Iterer.\n",
+    "Show(\"Exercice 2 a completer - ACO (construction ponderee par pheromones + evaporation).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ec603a9-ce22-4936-a63d-8518e670f9b7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002807,
+     "end_time": "2026-07-06T11:51:58.744328",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.741521",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : optimalit\u00e9 du 2-opt sur un instance sym\u00e9trique\n",
+    "\n",
+    "Construire une instance o\u00f9 les villes sont plac\u00e9es sur un cercle. Montrer que (a) le 2-opt depuis n'importe quelle tourn\u00e9e atteint l'optimum (parcours du cercle), et (b) le plus-proche-voisin l'atteint aussi. Pourquoi cette instance est-elle \u00ab facile \u00bb ?\n",
+    "\n",
+    "> **Indice** : sur un cercle, la tourn\u00e9e optimale est le p\u00e9rim\u00e8tre dans l'ordre des angles ; toute ar\u00eate \u00ab crois\u00e9e \u00bb est strictement plus longue que sa correction 2-opt (in\u00e9galit\u00e9 triangulaire)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "dc10d571-044c-4d34-85ef-fc3b2a17a209",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T11:51:58.751293Z",
+     "iopub.status.busy": "2026-07-06T11:51:58.751135Z",
+     "iopub.status.idle": "2026-07-06T11:51:58.780070Z",
+     "shell.execute_reply": "2026-07-06T11:51:58.779895Z"
+    },
+    "papermill": {
+     "duration": 0.032915,
+     "end_time": "2026-07-06T11:51:58.780131",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.747216",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 a completer - circularite => 2-opt atteint l'optimum."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : villes sur un cercle, montrer que 2-opt atteint l'optimum (perimetre)\n",
+    "// Etape 1 : generer N points equirepartis sur un cercle de rayon R.\n",
+    "// Etape 2 : lancer NN + 2-opt depuis une tournee aleatoire, comparer au perimetre 2*pi*R.\n",
+    "// Etape 3 : verifier que 2-opt converge vers le perimetre (gap ~0%).\n",
+    "Show(\"Exercice 3 a completer - circularite => 2-opt atteint l'optimum.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b98dcdc8-a03a-454d-94d1-fed637e98c27",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003106,
+     "end_time": "2026-07-06T11:51:58.786396",
+     "exception": false,
+     "start_time": "2026-07-06T11:51:58.783290",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# a **d\u00e9roul\u00e9 from-scratch** les piliers de la r\u00e9solution approch\u00e9e du TSP :\n",
+    "\n",
+    "- **Force brute** (exacte, r\u00e9f\u00e9rence, factorielle) ;\n",
+    "- **Plus proche voisin** (construction gloutonne) ;\n",
+    "- **2-opt** (recherche locale canonique par inversion de segments) ;\n",
+    "- **Recuit simul\u00e9** (m\u00e9taheuristique, move 2-opt + crit\u00e8re de Metropolis).\n",
+    "\n",
+    "\u2605 **Le\u00e7on** : le TSP cristallise le basculement exact \u2194 approch\u00e9. Les solveurs industriels (OR-Tools, twin Python ; GeneticSharp, autres twins C#) combinent ces briques \u00e0 grande \u00e9chelle ; ce twin les **expose individuellement** pour qu'on saisisse la m\u00e9canique de chaque heuristique.\n",
+    "\n",
+    "**Lien avec les Foundations** : recherche locale \u21c4 [`Search-4`](../../Part1-Foundations/Search-4-LocalSearch.ipynb), recuit simul\u00e9 \u21c4 [`Search-11`](../../Part3-Advanced/Search-11-SimulatedAnnealing.ipynb), solveur industriel \u21c4 [`App-13-TSP-Metaheuristics`](App-13-TSP-Metaheuristics.ipynb) (twin Python).\n",
+    "\n",
+    "---\n",
+    "*Marathon .NET \u21c4 Python #4956 \u2014 Search/Applications/Hybrid, tranche TSP / voyageur de commerce. See #4956, #3801.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "duration": 4.788981,
+   "end_time": "2026-07-06T11:51:58.921053",
+   "exception": null,
+   "input_path": "App-13b-TSP-Metaheuristics-CSharp.ipynb",
+   "output_path": "App-13b-TSP-Metaheuristics-CSharp.ipynb",
+   "start_time": "2026-07-06T11:51:54.132072"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -1,6 +1,6 @@
 # Search - Applications
 
-C'est ici que la série Search se confronte au réel. Les 28 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents. À cela s'ajoutent les **jumeaux C#** (App-1b, App-2b, App-3b, App-4b, App-6-Csharp, App-9b, App-10b, App-11b, App-17b) qui déroulent les mêmes algorithmes *from-scratch* en .NET, en complément des versions Python qui invoquent des solveurs industriels.
+C'est ici que la série Search se confronte au réel. Les 28 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents. À cela s'ajoutent les **jumeaux C#** (App-1b, App-2b, App-3b, App-4b, App-6-Csharp, App-9b, App-10b, App-11b, App-13b, App-17b) qui déroulent les mêmes algorithmes *from-scratch* en .NET, en complément des versions Python qui invoquent des solveurs industriels.
 
 Sous-série de **28 notebooks** | **~16h10** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`) ; .NET 9 (`dotnet-interactive`) pour les jumeaux C#
 
@@ -102,6 +102,7 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 | 3 | [App-10-Portfolio](Hybrid/App-10-Portfolio.ipynb) | ~40 min | Multi-objectif, frontière de Pareto | Existant |
 | 4 | [App-10b-Portfolio-CSharp](Hybrid/App-10b-Portfolio-CSharp.ipynb) | ~30 min | GeneticSharp (C#) | Existant |
 | 5 | [App-13-TSP-Metaheuristics](Hybrid/App-13-TSP-Metaheuristics.ipynb) | ~50 min | TSP : SA, GA, ACO, OR-Tools routing | Classique |
+| 5b | [App-13b-TSP-Metaheuristics-CSharp](Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb) | ~45 min | Twin C# : force brute, plus proche voisin, 2-opt from-scratch, recuit simulé sur permutations | Classique |
 | 6 | [App-17-VRP-Logistics](Hybrid/App-17-VRP-Logistics.ipynb) | ~60 min | Vehicle Routing : SA, GA, ACO, CP-SAT | Projet étudiant |
 | 6b | [App-17b-VRP-Logistics-CSharp](Hybrid/App-17b-VRP-Logistics-Csharp.ipynb) | ~50 min | Twin C# : Nearest-Neighbor, cheapest-insertion, 2-opt, recuit simulé (métaheuristiques from-scratch) | Jumeau .NET |
 | 7 | [App-18-HyperparameterTuning](Hybrid/App-18-HyperparameterTuning.ipynb) | ~40 min | Optimisation ML : Bayésienne, GA, PSO, Optuna | Nouveau |
@@ -146,6 +147,7 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 | App-10 Portfolio | Search-5 (GA), Search-9 (PL) | pygad |
 | App-10b Portfolio | Search-5 (GA) | GeneticSharp (.NET) |
 | App-13 TSP-Metaheuristics | Search-4, Search-5 | ortools |
+| App-13b TSP-Metaheuristics (C#) | Search-4 (LocalSearch), Search-11 (SA) | dotnet-interactive |
 | App-17 VRP-Logistics | Search-4, Search-5, CSP-3 | ortools |
 | App-17b VRP-Logistics (C#) | Search-4 (LocalSearch), Search-5 (SA) | dotnet-interactive |
 | App-18 HyperparameterTuning | Search-4, Search-5 | optuna, scikit-learn |


### PR DESCRIPTION
## Résumé

**Twin C#** de [App-13-TSP-Metaheuristics](MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb) (Python : brute force, plus-proche-voisin, 2-opt, recuit simulé, GA, ACO, OR-Tools). Suite du marathon **.NET ⇄ Python** (#4956), volet **Search / Applications / Hybrid** — **Rule 6 rotation de GENRE** (c.49 NQueens backtracking → c.50 GraphColoring heuristics → c.51 Picross propagation → **c.52 TSP Hybrid/métaheuristiques**).

## Algorithme / démarche

4 approches **toutes from-scratch** (BCL .NET, `Math`, `Array.Reverse`, `Random`, `Stopwatch`, 0 NuGet) :

1. **Force brute** (exacte, factorielle — énumère les $(N-1)!$ tournées, ville 0 fixée). Référence pour $N \le 10$.
2. **Plus proche voisin** (construction gloutonne $O(N^2)$) — rapide mais myope.
3. **2-opt** (recherche locale canonique : inversion de segments améliorants jusqu'à optimum local).
4. **Recuit simulé sur permutations** (move 2-opt aléatoire + critère de Metropolis $\exp(-\Delta/T)$ + cooling géométrique).

## Complémentarité (#3801 Prong B) — distinctif

| Twin | Outil | Valeur |
|------|-------|--------|
| Python | **OR-Tools routing** + numpy + matplotlib | solveur industriel |
| Twins C# Hybrid existants (App-9b, App-10b) | **GeneticSharp** (librairie .NET) | algorithme génétique clé en main |
| **Ce twin (.NET BCL seule)** | **from-scratch** (2-opt, recuit simulé sur permutations) | **comprendre** les heuristiques canoniques du TSP |

★ Le twin Python **appelle** OR-Tools ; les twins C# Hybrid existants **appellent GeneticSharp**. Ce twin **déroule les heuristiques à la main** : 2-opt = inversion de segment (la recherche locale la plus utilisée en TSP), recuit simulé = move 2-opt + Metropolis. C'est la mécanique que les librairies cachent — rendue explicite.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **10/10 cellules code `execution_count` 1-10, 0 erreur, 0 warning CS**. Outputs vérifiés **firsthand** :
- Matrice Euclidienne 6×6 + longueur tournée = 309.75
- Force brute N=8 : optimum 293.19 (5040 = 7! permutations, 1.2 ms)
- Plus proche voisin N=8 : 344.77, **gap 17.6%** vs optimum (sous-optimal comme attendu)
- **2-opt depuis NN N=8 : 293.19 = optimum** (gap 0.00%, 4 inversions) — atteint l'optimal sur petite instance
- Recuit simulé N=8 : 293.19 = optimum (2056 moves acceptés)
- **Benchmark honnête** : N=6/8/10 brute exacte + 2-opt/SA à l'optimum ; N=30 (2-opt 2.6%, SA 0%), N=60 (2-opt 0%, SA 3.9%), N=100 (2-opt 0%, SA 2.1%) ; **NN systématiquement 17-22% au-dessus**. Le basculement exact↔approché est démontré.

## Bugs G.1 self-corrected

Topic file `dotnet-csharp-twins-marathon-4956.md` (12 bugs) appliqués en préventif : helper `FI`/`Show`+`display()`, headers `PadLeft`+`new string('-')` (pas de single-quote interpolation), **concaténation `+` pour toute interpolation avec littéral chaîne** (pas de `$"...{FI(x,"F2")}..."`), `(int[])x.Clone()`, `Array.Reverse(tour, i, j-i+1)` pour l'inversion de segment. Aucun bug nouveau.

## SOTA-OK (#3801)

Verdict **SOTA-OK** : pas de workaround. Le twin assume sa nature from-scratch (Prong B : pas d'équivalent NuGet didactique à « comprendre 2-opt et le recuit simulé TSP de l'intérieur ») et exhibe la mécanique. **Prong B non-trivialité** : le benchmark exhibe un vrai basculement exact↔approché (NN 17-22% au-dessus vs 2-opt/SA proches de l'optimal), pas un cas dégénéré.

## Exercices (#2161)

3 stubs C.1-conformes (sans `raise NotImplementedError`) :
1. **Or-opt** (déplacement de segment court) combiné au 2-opt.
2. **ACO** (colonies de fourmis : construction pondérée par phéromones + évaporation).
3. Circularité : villes sur un cercle, montrer que 2-opt atteint l'optimum (périmètre).

## Scope

Atomique : 1 notebook (22 cells, 10 code) + Applications/README.md (Hybrid 7→8, total 23→24 + row 5b + prereq + twin list). Self-contained (BCL seule). CATALOG byte-identical (R1, 0 bloc CATALOG-STATUS). H.3 + C.1 = NONE.

⚠️ **Collision additive header-line-3** avec #5548 (App-2b), #5549 (App-6), #5550 (App-11b) : toutes touchent la ligne de compte total + la liste des twins C#. ai-01 reconcile la liste des twins au merge. **Ligne Hybrid 35 distincte de la ligne CSP 34** = pas d'aggravation de la collision CSP (c'est l'avantage de la rotation de genre).

## Marathon #4956

4e twin C# Search/**Applications** (c.49 NQueens CSP, c.50 GraphColoring CSP, c.51 Picross CSP, **c.52 TSP Hybrid**). Voisin Python : App-13 (OR-Tools industriel).

See #4956, #3801. Revue souhaitée : ai-01, po-2024 (Search .NET owner), po-2025.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
