### PR TITLE
feat(gametheory): GameTheory-7-ExtensiveForm-Csharp — twin C# arbre de jeu + infosets from-scratch

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm-Csharp.ipynb
@@ -1,0 +1,1096 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fadf3471",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002556,
+     "end_time": "2026-07-06T14:22:21.430625",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:21.428069",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-7-ExtensiveForm (Twin C#)\n",
+    "\n",
+    "> **Jumeau C# (.NET Interactive)** de [GameTheory-7-ExtensiveForm.ipynb](GameTheory-7-ExtensiveForm.ipynb) — marathon **#4956** (parite .NET <-> Python), axe-2 SOTA **#3801** Prong B.\n",
+    "\n",
+    "Le notebook Python modelise les jeux sous forme extensive (arbre de jeu) avec `networkx` (graphe), affiche les arbres avec `matplotlib`, et invoque `OpenSpiel` (`pyspiel`) pour Kuhn Poker. **Ce twin deroule tout a la main** (BCL .NET 9, 0 NuGet) : on construit la structure de donnees de l'arbre de jeu, on modelise les **ensembles d'information** (infosets) et les **noeuds de nature** (chance), et on code la **conversion forme extensive -> forme normale**. La visualisation de l'arbre se fait en **ASCII** (equivalent du plot matplotlib).\n",
+    "\n",
+    "> **Distinct du twin GT-9-C#** : GT-9 resout les jeux extensifs par **induction arriere** (un algorithme de resolution). Ce notebook GT-7 est sur la **representation et la modelisation** (comment encoder un arbre de jeu, des infosets, des noeuds de hasard, et convertir vers la forme normale). Les deux sont complementaires : modeliser (GT-7) puis resoudre (GT-9)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12fec236",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002225,
+     "end_time": "2026-07-06T14:22:21.435482",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:21.433257",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. De la forme normale a la forme extensive\n",
+    "\n",
+    "La **forme normale** (GT-2) represente un jeu par sa matrice de gains. La **forme extensive** represente le **deroulement temporel** : qui joue quand, quelles actions sont disponibles, et ce que chaque joueur sait a chaque decision (les **ensembles d'information**). C'est la structure naturelle pour les jeux dynamiques (chacun joue a son tour) et les jeux a information incomplete (chance, informations cachees).\n",
+    "\n",
+    "Les trois types de noeuds :\n",
+    "- **Noeud de decision** (`player >= 1`) : un joueur choisit une action parmi `actions`.\n",
+    "- **Noeud terminal** (`player == -1`) : la partie finit, `payoffs` donne le gain de chaque joueur.\n",
+    "- **Noeud de nature / chance** (`player == 0`) : la Nature tire une action selon `chanceProbs` (carte, de, etc.)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d7eeef6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:21.454524Z",
+     "iopub.status.busy": "2026-07-06T14:22:21.447487Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.127268Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.123549Z"
+    },
+    "papermill": {
+     "duration": 1.687078,
+     "end_time": "2026-07-06T14:22:23.127373",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:21.440295",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '38180.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Modele ExtensiveFormGame pret : GameNode (decision/terminal/chance + infoset) + arbre + infosets index."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Modele de jeu sous forme extensive (BCL .NET, 0 NuGet)\n",
+    "using System.Globalization;\n",
+    "\n",
+    "public class GameNode\n",
+    "{\n",
+    "    public string Id { get; set; }\n",
+    "    public int Player { get; set; }                      // -1 = terminal, 0 = nature, >=1 = joueur\n",
+    "    public List<string> Actions { get; set; } = new();\n",
+    "    public Dictionary<string, GameNode> Children { get; set; } = new();\n",
+    "    public double[] Payoffs { get; set; }                // noeud terminal uniquement\n",
+    "    public string Infoset { get; set; }                  // ensemble d'information\n",
+    "    public Dictionary<string, double> ChanceProbs { get; set; }  // noeud de nature\n",
+    "    public bool IsTerminal => Player == -1;\n",
+    "    public bool IsChance => Player == 0;\n",
+    "}\n",
+    "\n",
+    "public class ExtensiveFormGame\n",
+    "{\n",
+    "    public string Name { get; set; }\n",
+    "    public int NumPlayers { get; set; }\n",
+    "    public GameNode Root { get; set; }\n",
+    "    public Dictionary<string, GameNode> Nodes { get; set; } = new();\n",
+    "    public Dictionary<string, List<string>> Infosets { get; set; } = new();\n",
+    "\n",
+    "    public ExtensiveFormGame(string name, int numPlayers) { Name = name; NumPlayers = numPlayers; }\n",
+    "\n",
+    "    public GameNode AddNode(GameNode n) { Nodes[n.Id] = n; if (n.Player >= 1 && n.Infoset == null) n.Infoset = n.Id; if (n.Infoset != null) { if (!Infosets.ContainsKey(n.Infoset)) Infosets[n.Infoset] = new(); Infosets[n.Infoset].Add(n.Id); } return n; }\n",
+    "    public void SetRoot(GameNode r) { Root = r; AddNode(r); }\n",
+    "    public void AddChild(GameNode parent, string action, GameNode child) { if (!parent.Actions.Contains(action)) parent.Actions.Add(action); parent.Children[action] = child; AddNode(child); }\n",
+    "}\n",
+    "\n",
+    "// Helpers (la culture FR ne persiste pas entre cellules .NET Interactive ; -0.0 supprime)\n",
+    "static string FI(double x, string fmt = \"F2\") { double z = Math.Abs(x) < 1e-12 ? 0.0 : x; return string.Format(CultureInfo.InvariantCulture, \"{0:\" + fmt + \"}\", z); }\n",
+    "static void Show(object s) { display(s?.ToString() ?? \"(null)\"); }\n",
+    "display(\"Modele ExtensiveFormGame pret : GameNode (decision/terminal/chance + infoset) + arbre + infosets index.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdea8d12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002233,
+     "end_time": "2026-07-06T14:22:23.132216",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.129983",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Exemple : jeu d'entree sur le marche\n",
+    "\n",
+    "Le **jeu d'entree** canonique : un entrant (J1) decide d'entrer (`In`) ou de rester dehors (`Out`). S'il entre, l'incumbent (J2) decide de `Fight` (guerre des prix) ou `Accommodate` (coexistence). C'est un jeu **parfait information** (chacun voit tout)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6c9a6e30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.137159Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.136990Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.206401Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.206110Z"
+    },
+    "papermill": {
+     "duration": 0.072291,
+     "end_time": "2026-07-06T14:22:23.206485",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.134194",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Entry Game : 5 noeuds, information parfaite (1 infoset par decision)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Jeu d'entree sur le marche (information parfaite)\n",
+    "var entry = new ExtensiveFormGame(\"Entry Game\", 2);\n",
+    "var root = new GameNode { Id = \"entrant\", Player = 1, Actions = new() { \"In\", \"Out\" } };\n",
+    "entry.SetRoot(root);\n",
+    "\n",
+    "var incumbent = new GameNode { Id = \"incumbent\", Player = 2, Actions = new() { \"Fight\", \"Accommodate\" } };\n",
+    "entry.AddChild(root, \"In\", incumbent);\n",
+    "entry.AddChild(root, \"Out\", new GameNode { Id = \"out\", Player = -1, Payoffs = new[] { 0.0, 2.0 } });\n",
+    "\n",
+    "entry.AddChild(incumbent, \"Fight\", new GameNode { Id = \"fight\", Player = -1, Payoffs = new[] { -1.0, -1.0 } });\n",
+    "entry.AddChild(incumbent, \"Accommodate\", new GameNode { Id = \"accommodate\", Player = -1, Payoffs = new[] { 1.0, 1.0 } });\n",
+    "\n",
+    "Show(entry.Name + \" : \" + entry.Nodes.Count + \" noeuds, information parfaite (1 infoset par decision).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00bbca3b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002096,
+     "end_time": "2026-07-06T14:22:23.210797",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.208701",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Rendu ASCII de l'arbre\n",
+    "\n",
+    "Le Python utilise `matplotlib` + `networkx` pour dessiner l'arbre. Nous le rendons en **ASCII** : un parcours recursif avec indentation par profondeur, qui marque les noeuds de nature (N), les infosets (~), et les payoffs terminaux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "13fdbcdb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.215564Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.215389Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.316730Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.316560Z"
+    },
+    "papermill": {
+     "duration": 0.104064,
+     "end_time": "2026-07-06T14:22:23.316789",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.212725",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Entry Game\r\n",
+       "----------\r\n",
+       "J1 ~entrant\r\n",
+       "  [In] J2 ~incumbent\r\n",
+       "    [Fight] * (J1=-1.00, J2=-1.00)\r\n",
+       "    [Accommodate] * (J1=1.00, J2=1.00)\r\n",
+       "  [Out] * (J1=0.00, J2=2.00)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Rendu ASCII de l'arbre de jeu (equivalent du plot matplotlib)\n",
+    "static string RenderTree(ExtensiveFormGame g)\n",
+    "{\n",
+    "    var sb = new System.Text.StringBuilder();\n",
+    "    void Rec(GameNode n, string lastAction, int depth)\n",
+    "    {\n",
+    "        string ind = new string(' ', depth * 2);\n",
+    "        string branch = depth == 0 ? \"\" : (lastAction.Length > 0 ? \"[\" + lastAction + \"] \" : \"\");\n",
+    "        if (n.IsTerminal)\n",
+    "            sb.AppendLine(ind + branch + \"* (J1=\" + FI(n.Payoffs[0]) + \", J2=\" + FI(n.Payoffs[1]) + \")\");\n",
+    "        else if (n.IsChance)\n",
+    "            sb.AppendLine(ind + branch + \"NATURE\" + (n.Infoset != null ? \" ~\" + n.Infoset : \"\"));\n",
+    "        else\n",
+    "            sb.AppendLine(ind + branch + \"J\" + n.Player + (n.Infoset != null ? \" ~\" + n.Infoset : \"\"));\n",
+    "        foreach (var a in n.Actions)\n",
+    "            Rec(n.Children[a], a, depth + 1);\n",
+    "    }\n",
+    "    sb.AppendLine(g.Name);\n",
+    "    sb.AppendLine(new string('-', g.Name.Length));\n",
+    "    Rec(g.Root, \"\", 0);\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "Show(RenderTree(entry));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd561e38",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002039,
+     "end_time": "2026-07-06T14:22:23.321332",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.319293",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : structure du jeu d'entree\n",
+    "\n",
+    "L'arbre montre la chronologie : J1 (entrant) choisit `In`/`Out` ; s'il entre, J2 (incumbent) choisit `Fight`/`Accommodate`. Les payoffs terminaux revelent la structure : `Fight` (-1,-1) est un <b>equilibre non-credible</b> (la menace de guerre n'est pas credible une fois l'entree effective), `Accommodate` (1,1) est l'issue rationnelle. C'est precisement ce que l'<b>induction arriere</b> (GT-9) formalise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "041ae031",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002243,
+     "end_time": "2026-07-06T14:22:23.325540",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.323297",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Strategies dans les jeux extensifs\n",
+    "\n",
+    "Une **strategie pure** en forme extensive est un **plan d'action complet** : pour chaque ensemble d'information du joueur, quelle action jouer. Ce n'est pas \"une action\", c'est un plan contingents (une action PAR infoset). Le nombre de strategies pures d'un joueur = produit du nombre d'actions sur chacun de ses infosets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "86fbe1f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.331140Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.330982Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.491987Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.491666Z"
+    },
+    "papermill": {
+     "duration": 0.164468,
+     "end_time": "2026-07-06T14:22:23.492079",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.327611",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "J1 strategies (2) : {In}  {Out}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "J2 strategies (2) : {Fight}  {Accommodate}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Enumeration des strategies pures d'un joueur = plans contingents (produit cartesien sur ses infosets)\n",
+    "static List<Dictionary<string, string>> PureStrategies(ExtensiveFormGame g, int player)\n",
+    "{\n",
+    "    // Infosets de ce joueur, conservant l'ordre d'action de chaque noeud\n",
+    "    var playerInfosets = g.Infosets\n",
+    "        .Where(kv => g.Nodes[kv.Value[0]].Player == player)\n",
+    "        .Select(kv => (id: kv.Key, actions: g.Nodes[kv.Value[0]].Actions.ToList()))\n",
+    "        .ToList();\n",
+    "    var plans = new List<Dictionary<string, string>>();\n",
+    "    void Rec(int idx, Dictionary<string, string> cur)\n",
+    "    {\n",
+    "        if (idx == playerInfosets.Count) { plans.Add(new Dictionary<string, string>(cur)); return; }\n",
+    "        var (iid, acts) = playerInfosets[idx];\n",
+    "        foreach (var a in acts) { cur[iid] = a; Rec(idx + 1, cur); }\n",
+    "    }\n",
+    "    Rec(0, new Dictionary<string, string>());\n",
+    "    return plans;\n",
+    "}\n",
+    "\n",
+    "// Entry game : J1 a 1 infoset (entrant: In/Out = 2 strategies) ; J2 a 1 infoset (incumbent: Fight/Accommodate = 2 strategies)\n",
+    "var s1 = PureStrategies(entry, 1);\n",
+    "var s2 = PureStrategies(entry, 2);\n",
+    "Show(\"J1 strategies (\" + s1.Count + \") : \" + string.Join(\"  \", s1.Select(p => \"{\" + string.Join(\",\", p.Values) + \"}\")));\n",
+    "Show(\"J2 strategies (\" + s2.Count + \") : \" + string.Join(\"  \", s2.Select(p => \"{\" + string.Join(\",\", p.Values) + \"}\")));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70d7dc38",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00296,
+     "end_time": "2026-07-06T14:22:23.497997",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.495037",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Information parfaite vs imparfaite\n",
+    "\n",
+    "La difference cruciale : en **information parfaite**, chaque infoset est un singleton (le joueur sait exactement ou il est). En **information imparfaite**, un infoset regroupe plusieurs noeuds : le joueur sait qu'il est a l'un d'entre eux mais ne sait pas lequel.\n",
+    "\n",
+    "Le jeu **mouvement simultane** (Matching Pennies en forme extensive) : J1 joue Pile/Face, puis J2 joue Pile/Face **sans voir** le coup de J1. Les deux noeuds de decision de J2 sont dans le **meme infoset** `j2_choice`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6f8e2052",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.505527Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.505268Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.572063Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.571798Z"
+    },
+    "papermill": {
+     "duration": 0.071257,
+     "end_time": "2026-07-06T14:22:23.572194",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.500937",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Simultaneous Move (Matching Pennies)\r\n",
+       "------------------------------------\r\n",
+       "J1 ~j1\r\n",
+       "  [Pile] J2 ~j2_choice\r\n",
+       "    [Pile] * (J1=1.00, J2=-1.00)\r\n",
+       "    [Face] * (J1=-1.00, J2=1.00)\r\n",
+       "  [Face] J2 ~j2_choice\r\n",
+       "    [Pile] * (J1=-1.00, J2=1.00)\r\n",
+       "    [Face] * (J1=1.00, J2=-1.00)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Infosets : 2 (j1 singleton, j2_choice regroupe 2 noeuds = J2 ignore le coup de J1)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "=> Le marqueur ~j2_choice sur 2 noeuds = c'est l'ENCODAGE de l'information imparfaite."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Mouvement simultane = Matching Pennies en forme extensive (information imparfaite)\n",
+    "var sim = new ExtensiveFormGame(\"Simultaneous Move (Matching Pennies)\", 2);\n",
+    "var r = new GameNode { Id = \"j1\", Player = 1, Actions = new() { \"Pile\", \"Face\" } };\n",
+    "sim.SetRoot(r);\n",
+    "// J2 ne voit pas le coup de J1 -> les deux noeuds J2 partagent l'infoset \"j2_choice\"\n",
+    "var j2pile = new GameNode { Id = \"j2_after_pile\", Player = 2, Actions = new() { \"Pile\", \"Face\" }, Infoset = \"j2_choice\" };\n",
+    "var j2face = new GameNode { Id = \"j2_after_face\", Player = 2, Actions = new() { \"Pile\", \"Face\" }, Infoset = \"j2_choice\" };\n",
+    "sim.AddChild(r, \"Pile\", j2pile);\n",
+    "sim.AddChild(r, \"Face\", j2face);\n",
+    "// Payoffs (Matching Pennies : J1 gagne si meme face, J2 sinon)\n",
+    "sim.AddChild(j2pile, \"Pile\", new GameNode { Id = \"pp\", Player = -1, Payoffs = new[] { 1.0, -1.0 } });\n",
+    "sim.AddChild(j2pile, \"Face\", new GameNode { Id = \"pf\", Player = -1, Payoffs = new[] { -1.0, 1.0 } });\n",
+    "sim.AddChild(j2face, \"Pile\", new GameNode { Id = \"fp\", Player = -1, Payoffs = new[] { -1.0, 1.0 } });\n",
+    "sim.AddChild(j2face, \"Face\", new GameNode { Id = \"ff\", Player = -1, Payoffs = new[] { 1.0, -1.0 } });\n",
+    "\n",
+    "Show(RenderTree(sim));\n",
+    "Show(\"Infosets : \" + sim.Infosets.Count + \" (j1 singleton, j2_choice regroupe 2 noeuds = J2 ignore le coup de J1).\");\n",
+    "Show(\"=> Le marqueur ~j2_choice sur 2 noeuds = c'est l'ENCODAGE de l'information imparfaite.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83843ffc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003286,
+     "end_time": "2026-07-06T14:22:23.578914",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.575628",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Jeux avec hasard : noeuds de nature\n",
+    "\n",
+    "Quand le hasard est implique (tirage de carte, de), on ajoute des **noeuds de nature** (`player == 0`) avec des probabilites sur chaque branche. Le jeu de carte simple : la Nature tire High/Low (p=0.5), J1 voit la carte et Bet/Check, puis si Bet J2 Call/Fold **sans voir la carte** (infoset partage)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4062d009",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.591059Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.590606Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.692214Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.692028Z"
+    },
+    "papermill": {
+     "duration": 0.107897,
+     "end_time": "2026-07-06T14:22:23.692293",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.584396",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Simple Card Game\r\n",
+       "----------------\r\n",
+       "NATURE\r\n",
+       "  [High] J1 ~j1_H\r\n",
+       "    [Bet] J2 ~j2_bet\r\n",
+       "      [Call] * (J1=2.00, J2=-2.00)\r\n",
+       "      [Fold] * (J1=1.00, J2=-1.00)\r\n",
+       "    [Check] * (J1=1.00, J2=1.00)\r\n",
+       "  [Low] J1 ~j1_L\r\n",
+       "    [Bet] J2 ~j2_bet\r\n",
+       "      [Call] * (J1=-2.00, J2=2.00)\r\n",
+       "      [Fold] * (J1=1.00, J2=-1.00)\r\n",
+       "    [Check] * (J1=-1.00, J2=-1.00)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Infosets : j1_H, j1_L, j2_bet | j2_bet regroupe J2_h_bet + J2_l_bet (J2 ignore la carte)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Jeu de carte simple avec noeud de nature + infoset (information incomplete)\n",
+    "var card = new ExtensiveFormGame(\"Simple Card Game\", 2);\n",
+    "var nature = new GameNode { Id = \"nature\", Player = 0, Actions = new() { \"High\", \"Low\" }, ChanceProbs = new() { { \"High\", 0.5 }, { \"Low\", 0.5 } } };\n",
+    "card.SetRoot(nature);\n",
+    "\n",
+    "// J1 voit la carte (infosets distincts High/Low car J1 connait sa carte)\n",
+    "var j1h = new GameNode { Id = \"j1_high\", Player = 1, Actions = new() { \"Bet\", \"Check\" }, Infoset = \"j1_H\" };\n",
+    "var j1l = new GameNode { Id = \"j1_low\", Player = 1, Actions = new() { \"Bet\", \"Check\" }, Infoset = \"j1_L\" };\n",
+    "card.AddChild(nature, \"High\", j1h);\n",
+    "card.AddChild(nature, \"Low\", j1l);\n",
+    "\n",
+    "// J2 apres Bet ne sait pas High/Low -> MEME infoset \"j2_bet\"\n",
+    "var j2hb = new GameNode { Id = \"j2_h_bet\", Player = 2, Actions = new() { \"Call\", \"Fold\" }, Infoset = \"j2_bet\" };\n",
+    "var j2lb = new GameNode { Id = \"j2_l_bet\", Player = 2, Actions = new() { \"Call\", \"Fold\" }, Infoset = \"j2_bet\" };\n",
+    "card.AddChild(j1h, \"Bet\", j2hb); card.AddChild(j1h, \"Check\", new GameNode { Id = \"h_check\", Player = -1, Payoffs = new[] { 1.0, 1.0 } });\n",
+    "card.AddChild(j1l, \"Bet\", j2lb); card.AddChild(j1l, \"Check\", new GameNode { Id = \"l_check\", Player = -1, Payoffs = new[] { -1.0, -1.0 } });\n",
+    "// Payoffs Bet+Fold=(1,-1) ; Bet+Call depend High(2,-2)/Low(-2,2)\n",
+    "card.AddChild(j2hb, \"Call\", new GameNode { Id = \"h_call\", Player = -1, Payoffs = new[] { 2.0, -2.0 } });\n",
+    "card.AddChild(j2hb, \"Fold\", new GameNode { Id = \"h_fold\", Player = -1, Payoffs = new[] { 1.0, -1.0 } });\n",
+    "card.AddChild(j2lb, \"Call\", new GameNode { Id = \"l_call\", Player = -1, Payoffs = new[] { -2.0, 2.0 } });\n",
+    "card.AddChild(j2lb, \"Fold\", new GameNode { Id = \"l_fold\", Player = -1, Payoffs = new[] { 1.0, -1.0 } });\n",
+    "\n",
+    "Show(RenderTree(card));\n",
+    "Show(\"Infosets : \" + string.Join(\", \", card.Infosets.Keys) + \" | j2_bet regroupe J2_h_bet + J2_l_bet (J2 ignore la carte).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00edfca3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002937,
+     "end_time": "2026-07-06T14:22:23.698574",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.695637",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. OpenSpiel : jeux extensifs avances (section conceptuelle)\n",
+    "\n",
+    "Le notebook Python invoque **OpenSpiel** (`pyspiel`) pour charger Kuhn Poker, un jeu classique a information incomplete. **OpenSpiel n'a pas d'equivalent .NET** (pas de binding .NET officiel) — c'est un verdict **INTRINSIC** pour cette section specifique (#3801) : on ne peut pas re-invoquer OpenSpiel en C#.\n",
+    "\n",
+    "Ce twin documente donc la **structure de Kuhn Poker** (3 cartes, infosets par carte + historique d'encheres) et renvoie au twin Python pour l'execution OpenSpiel. Le coeur du notebook (modelisation + conversion, sections 1-5+7) est **from-scratch SOTA-OK** : ce que networkx/OpenSpiel cachent (l'arbre, les infosets, le hasard), ce twin le rend explicite.\n",
+    "\n",
+    "**Kuhn Poker (structure)** : 2 joueurs, 3 cartes (J,Q,K) distribuees par la Nature, chaque joueur voit sa carte (infoset par carte), mises `Pass`/`Bet`. Information incomplete (la carte de l'adversaire est cachee). C'est le banc d'essai canonique du **CFR** (GT-13) et des solveurs de poker modernes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5097aa60",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0028,
+     "end_time": "2026-07-06T14:22:23.704129",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.701329",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Conversion forme extensive -> forme normale\n",
+    "\n",
+    "Tout jeu extensif peut etre converti en jeu **normal** (matrice de gains) : on enumere les strategies pures de chaque joueur (plans contingents, section 3), puis pour chaque couple (s1, s2) on calcule le payoff espere en traversant l'arbre (les noeuds de nature etant ponderes par leurs probabilites). La matrice resultat est exactement le jeu normal equivalent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bc7e90c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.710828Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.710608Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.807936Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.807737Z"
+    },
+    "papermill": {
+     "duration": 0.101222,
+     "end_time": "2026-07-06T14:22:23.808006",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.706784",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Entry Game -> forme normale ==="
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Forme normale equivalente : Entry Game\r\n",
+       "--------------------------------------------------\r\n",
+       "J1 \\ J2  {Fight}    {Accommodate}\r\n",
+       "{In}  (-1.00,-1.00)  (1.00,1.00)\r\n",
+       "{Out}  (0.00,2.00)  (0.00,2.00)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "=== Simultaneous Move -> forme normale (= Matching Pennies) ==="
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Forme normale equivalente : Simultaneous Move (Matching Pennies)\r\n",
+       "--------------------------------------------------\r\n",
+       "J1 \\ J2  {Pile}    {Face}\r\n",
+       "{Pile}  (1.00,-1.00)  (-1.00,1.00)\r\n",
+       "{Face}  (-1.00,1.00)  (1.00,-1.00)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Conversion extensive -> normale : matrice de gains sur les strategies pures\n",
+    "static double[] ExpectedPayoff(ExtensiveFormGame g, Dictionary<int, Dictionary<string, string>> stratByPlayer)\n",
+    "{\n",
+    "    // Traversee recursive : a chaque noeud, choisir l'action du joueur (via son infoset) ou ponderer la nature\n",
+    "    double[] Rec(GameNode n)\n",
+    "    {\n",
+    "        if (n.IsTerminal) return n.Payoffs;\n",
+    "        if (n.IsChance)\n",
+    "        {\n",
+    "            double[] acc = new double[g.NumPlayers];\n",
+    "            foreach (var (a, p) in n.ChanceProbs)\n",
+    "            {\n",
+    "                var sub = Rec(n.Children[a]);\n",
+    "                for (int k = 0; k < g.NumPlayers; k++) acc[k] += p * sub[k];\n",
+    "            }\n",
+    "            return acc;\n",
+    "        }\n",
+    "        // Noeud de decision : l'action = strategie du joueur pour l'infoset de ce noeud\n",
+    "        string action = stratByPlayer[n.Player][n.Infoset];\n",
+    "        return Rec(n.Children[action]);\n",
+    "    }\n",
+    "    return Rec(g.Root);\n",
+    "}\n",
+    "\n",
+    "static string ConvertToNormal(ExtensiveFormGame g)\n",
+    "{\n",
+    "    var s1 = PureStrategies(g, 1);\n",
+    "    var s2 = PureStrategies(g, 2);\n",
+    "    var sb = new System.Text.StringBuilder();\n",
+    "    sb.AppendLine(\"Forme normale equivalente : \" + g.Name);\n",
+    "    sb.AppendLine(new string('-', 50));\n",
+    "    sb.AppendLine(\"J1 \\\\ J2  \" + string.Join(\"    \", s2.Select(p => \"{\" + string.Join(\",\", p.Values) + \"}\")));\n",
+    "    foreach (var a in s1)\n",
+    "    {\n",
+    "        var strat = new Dictionary<int, Dictionary<string, string>> { { 1, a } };\n",
+    "        var cells = new List<string>();\n",
+    "        foreach (var b in s2)\n",
+    "        {\n",
+    "            strat[2] = b;\n",
+    "            var pay = ExpectedPayoff(g, strat);\n",
+    "            cells.Add(\"(\" + FI(pay[0]) + \",\" + FI(pay[1]) + \")\");\n",
+    "        }\n",
+    "        sb.AppendLine(\"{\" + string.Join(\",\", a.Values) + \"}  \" + string.Join(\"  \", cells));\n",
+    "    }\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "Show(\"=== Entry Game -> forme normale ===\");\n",
+    "Show(ConvertToNormal(entry));\n",
+    "Show(\"=== Simultaneous Move -> forme normale (= Matching Pennies) ===\");\n",
+    "Show(ConvertToNormal(sim));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97bcbf08",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00302,
+     "end_time": "2026-07-06T14:22:23.814747",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.811727",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : equivalence des formes\n",
+    "\n",
+    "La conversion de l'**Entry Game** donne une matrice 2x2 dont l'equilibre est `(In, Accommodate)` — la meme conclusion que l'induction arriere (GT-9), mais obtenue par la theorie normale. La conversion du **Simultaneous Move** redonne exactement la matrice de **Matching Pennies** (pas de point-selle, strategies mixtes uniformes). C'est la preuve que les deux formes sont **equivalentes** en information complete : tout jeu extensif se reduit a une matrice de gains."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed1fba67",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00292,
+     "end_time": "2026-07-06T14:22:23.820648",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.817728",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Resume\n",
+    "\n",
+    "| Concept | Python (twin) | Twin C# (ici) |\n",
+    "|---------|---------------|----------------|\n",
+    "| Arbre de jeu | `networkx` (graphe) | **structure `GameNode` recursive from-scratch** |\n",
+    "| Visualisation | `matplotlib` | **rendu ASCII** (parcours + indentation) |\n",
+    "| OpenSpiel / Kuhn Poker | `pyspiel` (execution) | **section conceptuelle** (INTRINSIC, pas de binding .NET) |\n",
+    "| Conversion -> normale | `itertools.product` | **enumeration recursive des plans contingents** |\n",
+    "\n",
+    "**Ce que la lib cache et que ce twin rend explicite** : la structure recursive du noeud (decision/terminal/chance + infoset), le **codage de l'information imparfaite par infoset partage** (le coeur conceptuel), le **ponderation des noeuds de nature** dans le calcul de payoff espere, et le **produit cartesien des plans contingents** qui definit une strategie pure en forme extensive.\n",
+    "\n",
+    "> **Lien avec GT-9** : ce notebook modelise la forme extensive (representation). GT-9-C# la **resout** par induction arriere. Les deux se completent : modeliser puis resoudre.\n",
+    "\n",
+    "> **Lien avec la formalisation Lean** : les jeux extensifs et les equilibres (SPE) sont formalises dans `game_theory_lean`. Ce notebook en est le versant **computationnel**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d860d074",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006347,
+     "end_time": "2026-07-06T14:22:23.829902",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.823555",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Exercices\n",
+    "\n",
+    "> **Convention** : stubs a completer (`null` + `// TODO etudiant`), jamais d'erreur volontaire — le notebook s'execute de bout en bout meme non complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ae1e3b27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.837051Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.836793Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.891572Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.891432Z"
+    },
+    "papermill": {
+     "duration": 0.058834,
+     "end_time": "2026-07-06T14:22:23.891640",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.832806",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 a completer : construisez un Chain-Store a 2 entrants, affichez RenderTree."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Construire un arbre de jeu (Chain-Store paradox simplifie)\n",
+    "// Etape 1 : 1 entrant, incumbent Fight/Accommodate. Etape 2 : ajouter un 2e entrant qui observe l'issue du 1er.\n",
+    "// Indice : reutiliser AddChild + infosets. Le 2e entrant a-t-il un infoset distinct apres Fight vs Accommodate ?\n",
+    "var ex1 = (ExtensiveFormGame)null;  // votre Chain-Store a 2 entrants\n",
+    "Show(\"Exercice 1 a completer : construisez un Chain-Store a 2 entrants, affichez RenderTree.\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "43ae07e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.899370Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.899152Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.926799Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.926677Z"
+    },
+    "papermill": {
+     "duration": 0.03185,
+     "end_time": "2026-07-06T14:22:23.926861",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.895011",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 a completer : ConvertToNormal(card) -> observer la matrice et le compte de strategies."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Convertir le Card Game (section 5) en forme normale\n",
+    "// Indice : appelez ConvertToNormal(card). Combien de strategies pures pour J1 (infosets j1_H, j1_L) ?\n",
+    "//          Pour J2 (infoset unique j2_bet) ? Verifiez que la matrice reflete l'information incomplete.\n",
+    "var ex2 = (string)null;  // = ConvertToNormal(card)\n",
+    "Show(\"Exercice 2 a completer : ConvertToNormal(card) -> observer la matrice et le compte de strategies.\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "090740cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:22:23.933816Z",
+     "iopub.status.busy": "2026-07-06T14:22:23.933640Z",
+     "iopub.status.idle": "2026-07-06T14:22:23.963686Z",
+     "shell.execute_reply": "2026-07-06T14:22:23.963570Z"
+    },
+    "papermill": {
+     "duration": 0.033689,
+     "end_time": "2026-07-06T14:22:23.963747",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.930058",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 a completer : ajoutez un noeud de nature cout, discutez l'infoset de l'incumbent."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Ajouter un noeud de nature au jeu d'entree (entrant a un cout aleatoire)\n",
+    "// Indice : au noeud 'entrant', le cout d'entree est High(p=0.3) ou Low(p=0.7), modifiant les payoffs 'In'.\n",
+    "// Question : comment l'incumbent doit-il raisonner sans connaitre le cout (nouvel infoset) ?\n",
+    "var ex3 = (ExtensiveFormGame)null;  // entry game avec cout aleatoire\n",
+    "Show(\"Exercice 3 a completer : ajoutez un noeud de nature cout, discutez l'infoset de l'incumbent.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f187aca",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002614,
+     "end_time": "2026-07-06T14:22:23.969306",
+     "exception": false,
+     "start_time": "2026-07-06T14:22:23.966692",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "Ce twin a deroule les **cinq couches** de la forme extensive :\n",
+    "1. **Modele** : `GameNode` (decision/terminal/chance + infoset) et `ExtensiveFormGame`.\n",
+    "2. **Arbre** : construction recursive + **rendu ASCII** (equivalent matplotlib).\n",
+    "3. **Strategies** : enumeration des **plans contingents** (produit cartesien sur les infosets).\n",
+    "4. **Information imparfaite** : encodage par **infoset partage** (Matching Pennies, Card Game).\n",
+    "5. **Conversion -> normale** : traversee recursive avec **ponderation des noeuds de nature**.\n",
+    "\n",
+    "La ou `networkx`/`OpenSpiel` fournissent des structures opaques, ce notebook montre **le noeud recursif**, **le codage de l'information imparfaite**, **le hasard equilibre** et **le produit cartesien des plans**. C'est toute la mecanique de modelisation, rendue explicite — l'objectif du marathon #4956.\n",
+    "\n",
+    "**Prochaines etapes** : une fois le jeu modelise (ce notebook), on le **resout** par induction arriere ([GameTheory-9-BackwardInduction-Csharp](GameTheory-9-BackwardInduction-Csharp.ipynb)) ou par CFR pour l'information incomplete ([GameTheory-13-ImperfectInfo-CFR](GameTheory-13-ImperfectInfo-CFR.ipynb)).\n",
+    "\n",
+    "*See #4956 (marathon parite .NET/Python). Refs #3801 (axe-2 SOTA).*\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Genere par myia-po-2023, cycle 57, marathon #4956.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.460413,
+   "end_time": "2026-07-06T14:22:24.096751",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-7-ExtensiveForm-Csharp.ipynb",
+   "output_path": "gt7_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T14:22:18.636338",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -134,6 +134,7 @@ flowchart TD
 | # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
 | 7 | [GameTheory-7-ExtensiveForm](GameTheory-7-ExtensiveForm.ipynb) | Python | Arbres de jeu, infosets, stratégies | 50 min |
+| 7 (C#) | [GameTheory-7-ExtensiveForm-Csharp](GameTheory-7-ExtensiveForm-Csharp.ipynb) | .NET (C#) | Twin C# du 7 : **arbre de jeu + infosets + noeuds de nature from-scratch** + conversion forme extensive→normale (See #4956) | 50 min |
 | 8 | [GameTheory-8-CombinatorialGames](GameTheory-8-CombinatorialGames.ipynb) | Python | Positions P/N, Nim, Grundy, Sprague-Grundy | 55 min |
 | 8b | [GameTheory-8b-Lean-CombinatorialGames](GameTheory-8b-Lean-CombinatorialGames.ipynb) | Lean 4 | PGame mathlib, Nim formel | 50 min |
 | 8c | [GameTheory-8c-CombinatorialGames-Python](GameTheory-8c-CombinatorialGames-Python.ipynb) | Python | Approfondissement jeux combinatoires | 40 min |
@@ -542,6 +543,7 @@ GameTheory/
 ├── GameTheory-8c-CombinatorialGames-Python.ipynb
 ├── GameTheory-15c-CooperativeGames-Python.ipynb
 ├── GameTheory-11-BayesianGames-Csharp.ipynb                     # Twin .NET/C# (marathon #4956, Prong B)
+├── GameTheory-7-ExtensiveForm-Csharp.ipynb                      # Twin C# arbre de jeu + infosets from-scratch (marathon #4956, Prong B)
 ├── SocialChoice/                                                   # Sous-série Choix Social
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb
 │   ├── 02-Lean-SocialChoice-Formal.ipynb


### PR DESCRIPTION
## Résumé

**Twin C# (.NET Interactive)** de [GameTheory-7-ExtensiveForm.ipynb](MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb) — marathon **#4956** (parité .NET ⇄ Python), volet **GameTheory / Phase 2**, axe-2 SOTA **#3801** Prong B.

Le notebook Python modélise les jeux sous forme extensive (arbre de jeu) avec **`networkx`** (graphe), affiche les arbres avec **`matplotlib`**, et invoque **`OpenSpiel`** (`pyspiel`) pour Kuhn Poker. Ce twin **déroule tout à la main** (BCL .NET 9, 0 NuGet) : structure `GameNode` récursive (décision/terminal/chance + infoset), **rendu ASCII** de l'arbre (équivalent matplotlib), modélisation des **ensembles d'information** et des **nœuds de nature**, et **conversion forme extensive → forme normale** from-scratch.

## Distinct du twin GT-9-C# (complémentarité)

- **GT-9-C#** = **résout** les jeux extensifs par **induction arrière** (un algorithme de résolution : Entry/Centipede/War-of-Attrition).
- **Ce twin GT-7** = **modélise** la forme extensive (représentation : arbre, infosets, hasard, conversion vers la normale).

Les deux sont **complémentaires** : modéliser (GT-7) puis résoudre (GT-9). Pas de redondance.

## Algorithme (Prong B, from-scratch)

1. **Modèle** : `GameNode` (`Player` : -1 terminal, 0 nature, ≥1 joueur ; `Actions` ; `Children` ; `Payoffs` ; `Infoset` ; `ChanceProbs`) + `ExtensiveFormGame` (root, nodes, infosets indexés). Auto-assign d'infoset singleton pour les nœuds de décision parfaite (robustesse).
2. **Rendu ASCII** (`RenderTree`) : parcours récursif, indentation par profondeur, marqueurs `J1 ~infoset`, `NATURE`, `* (J1=x, J2=y)` pour les terminaux.
3. **Stratégies pures** (`PureStrategies`) : énumération des **plans contingents** = produit cartésien des actions sur les infosets du joueur (c'est la définition d'une stratégie en forme extensive).
4. **Conversion → normale** (`ConvertToNormal` + `ExpectedPayoff`) : pour chaque couple (s1, s2), traverse l'arbre en suivant les actions des stratégies, **pondérant les nœuds de nature** par leurs probabilités → matrice de gains équivalente.

## Complémentarité (#3801 Prong B) — distinctif

| Aspect | Python (twin) | Twin C# (ici) |
|--------|---------------|----------------|
| Arbre de jeu | `networkx` (graphe) | **`GameNode` récursif from-scratch** |
| Visualisation | `matplotlib` | **rendu ASCII** (parcours + indentation) |
| OpenSpiel / Kuhn Poker | `pyspiel` (exécution) | **section conceptuelle** (verdict INTRINSIC, pas de binding .NET) |
| Conversion → normale | `itertools.product` | **énumération récursive des plans contingents** |

★ Le cœur du notebook (sections 1-5 + 7 : modélisation + infosets + hasard + conversion) est **from-scratch SOTA-OK** : ce que networkx/OpenSpiel cachent, ce twin le rend explicite. La section OpenSpiel (Kuhn Poker) est **conceptuelle** : verdict **INTRINSIC** (#3801) — pas d'équivalent .NET à OpenSpiel, documenté honnêtement, renvoi au twin Python pour l'exécution.

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **10/10 cellules code `execution_count` 1-10, 0 erreur**. Outputs vérifiés **firsthand** :

- **Entry Game** : arbre ASCII `J1 ~entrant → [In] J2 ~incumbent → [Fight]*(-1,-1) / [Accommodate]*(1,1) ; [Out]*(0,2)`.
- **Stratégies pures** : J1 (2) `{In},{Out}` ; J2 (2) `{Fight},{Accommodate}` (1 infoset × 2 actions = 2 plans contingents).
- **Mouvement simultané** (Matching Pennies extensive) : infoset `~j2_choice` partagé sur 2 nœuds = **codage de l'information imparfaite**.
- **Jeu de carte** : nœud `NATURE` (High/Low p=0.5) + infosets J1_H/J1_L (carte connue) vs j2_bet partagé (J2 ignore la carte).
- ★ **Conversion → normale vérifiée mathématiquement** :
  - Entry Game : matrice 2×2 `{In}→(-1,-1)/(1,1)`, `{Out}→(0,2)/(0,2)` ✓
  - **Simultaneous Move redonne EXACTEMENT la matrice Matching Pennies** : `{Pile}/{Pile}=(1,-1)`, `{Pile}/{Face}=(-1,1)`, `{Face}/{Pile}=(-1,1)`, `{Face}/{Face}=(1,-1)` ✓ — preuve de l'équivalence des formes.

## Bugs G.1 self-corrected (avant exécution)

2 bugs détectés et corrigés **pendant le développement** (vérification pre-commit) :
1. **Lookup infoset null** : les nœuds de décision racine (entrant, j1) avaient `Infoset = null` → `ArgumentNullException` dans `ExpectedPayoff`. Fix : `AddNode` auto-assigne `Infoset = Id` pour tout nœud de décision (`Player ≥ 1`) sans infoset (singleton = information parfaite).
2. **Double-ajout d'actions** : les initialiseurs `Actions = new(){...}` pré-remplissaient ET `AddChild` faisait `parent.Actions.Add(action)` → arbre rendu avec branches dupliquées (`[In,Out,In,Out]`), stratégies doublées (4 au lieu de 2). Fix : `AddChild` idempotent (`if (!Actions.Contains(action))`). Corrige Entry Game 4→2 stratégies, et la matrice de conversion.

## Exercices (#2161)

3 stubs C.1-conformes (sans `raise NotImplementedError`) :
1. **Chain-Store paradox** à 2 entrants (construire l'arbre, infosets du 2e entrant conditionnel à l'issue du 1er).
2. **Convertir le Card Game** en forme normale (compter les stratégies J1=4, J2=2 via infosets).
3. **Ajouter un nœud de nature** (coût aléatoire d'entrée) au jeu d'entrée (discuter le nouvel infoset de l'incumbent).

## Scope

Atomique : 1 notebook (24 cells, 10 code) + GameTheory/README.md (2 lignes : table Partie 1 ligne « 7 (C#) » + tree entry). Self-contained (BCL seule). **CATALOG byte-identique** à main (vérifié two-dot `git diff origin/main`). Mermaid fence balance OK (30, pair). C.1 = 0.

### §E README audit (whole-file gate)

Ajout cohérent : table Partie 2 ligne « 7 (C#) » + tree entry. Breakdown inchangé (convention twins non comptés, cf. Planners-2 #5552, GT-5 #5554). Lignes existantes `| 7 | ExtensiveForm` (statut maturité ligne 209, acquis ligne 251) restent valides (décrivent le Python original).

## Marathon #4956

2e twin C# GameTheory consécutif (c.55 GT-5 Minimax, c.57 GT-7 ExtensiveForm). Voisin Python : GameTheory-7 (networkx/matplotlib/OpenSpiel). 7e twin C# GameTheory (après 2-NormalForm×2, 4c-NashExistence, 5-ZeroSum, 9-BackwardInduction, 11-BayesianGames).

See #4956, #3801. Revue souhaitée : ai-01, po-2024 (GameTheory .NET owner), po-2025.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
