### PR TITLE
feat(tweety): Tweety-6-Structured-Argumentation-Csharp — twin C# ASPIC+ from-scratch

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -192,6 +192,7 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 5  | [Tweety-5-Abstract-Argumentation](Tweety-5-Abstract-Argumentation.ipynb) | Dung AF, Sémantiques, CF2, Génération         | 55 min  | Python |
 | 5b | [Tweety-5b-Lean-Argumentation](Tweety-5b-Lean-Argumentation.ipynb) | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de Dung dans le lake `argumentation_lean` (grounded = point fixe Knaster–Tarski), `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) | 45 min  | Lean BETA |
 | 6  | [Tweety-6-Structured-Argumentation](Tweety-6-Structured-Argumentation.ipynb) | ASPIC+, DeLP, ABA, ASP                            | 60 min  | Python |
+| 6c | [Tweety-6-Structured-Argumentation-Csharp](Tweety-6-Structured-Argumentation-Csharp.ipynb) | Twin C# ASPIC+ from-scratch (BCL, pas IKVM ; DeLP/ABA/ASP conceptuel) | 35 min | C# PROD |
 | 7a | [Tweety-7a-Extended-Frameworks](Tweety-7a-Extended-Frameworks.ipynb) | ADF, Bipolar, WAF, SAF, SetAF, Extended             | 50 min  | Python |
 | 7b | [Tweety-7b-Ranking-Probabilistic](Tweety-7b-Ranking-Probabilistic.ipynb) | Ranking Semantics, Probabiliste                   | 40 min  | Python |
 | 7bc | [Tweety-7b-Ranking-Probabilistic-Csharp](Tweety-7b-Ranking-Probabilistic-Csharp.ipynb) | Ranking/Probabiliste .NET (IKVM, c.179 PR #5231) | 30 min  | C# PROD |
@@ -204,11 +205,11 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 10c | [Tweety-10-MLN-Csharp](Tweety-10-MLN-Csharp.ipynb) | MLN porté .NET (IKVM, c.188 PR #5209)                | 30 min  | C# PROD |
 | 11 | [Tweety-11-Causal](Tweety-11-Causal.ipynb) | Raisonnement causal : do-calculus, interventions, contrefactuels | 50 min  | Python |
 
-**Durée totale estimée** : ~13h (Python) + ~6h (C#/.NET). Le tableau ci-dessus couvre les **26 notebooks principaux** (12 Python + 13 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
+**Durée totale estimée** : ~13h (Python) + ~6h (C#/.NET). Le tableau ci-dessus couvre les **27 notebooks principaux** (12 Python + 14 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
 
 ## En quoi chaque notebook est unique
 
-Chaque notebook introduit un concept ou cadre théorique spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun — couvrant les **26 notebooks principaux** (12 Python + 13 C#/.NET + 1 Lean companion) :
+Chaque notebook introduit un concept ou cadre théorique spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun — couvrant les **27 notebooks principaux** (12 Python + 14 C#/.NET + 1 Lean companion) :
 
 | #  | Notebook                      | Concept clé enseigné                                                    |
 |----|-------------------------------|--------------------------------------------------------------------------|
@@ -345,6 +346,7 @@ Tweety/
 ├── Tweety-5-Abstract-Argumentation.ipynb         # Dung, sémantiques, CF2
 ├── Tweety-5b-Lean-Argumentation.ipynb            # Companion kernel Lean 4
 ├── Tweety-6-Structured-Argumentation.ipynb       # ASPIC+, DeLP, ABA, ASP
+├── Tweety-6-Structured-Argumentation-Csharp.ipynb # Twin C# ASPIC+ from-scratch (BCL)
 ├── Tweety-7a-Extended-Frameworks.ipynb           # ADF, Bipolar, WAF, SAF
 ├── Tweety-7b-Ranking-Probabilistic.ipynb         # Ranking Semantics
 ├── Tweety-7b-Ranking-Probabilistic-Csharp.ipynb  # Ranking/Probabiliste .NET

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation-Csharp.ipynb
@@ -1,0 +1,1080 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d1dc9363",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002347,
+     "end_time": "2026-07-06T14:55:30.435129",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:30.432782",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Tweety-6 \u2014 Argumentation structuree (twin C# / .NET Interactive)\n",
+    "\n",
+    "**Twin C#** du notebook Python [Tweety-6-Structured-Argumentation.ipynb](Tweety-6-Structured-Argumentation.ipynb) (marathon #4956, parite .NET <-> Python, axe-2 SOTA #3801 Prong B).\n",
+    "\n",
+    "Le notebook Python invoque la bibliotheque Java **TweetyProject** (via `jpype` + JVM) pour construire des arguments structurees : ASPIC+, DeLP, ABA, argumentation deductive, ASP. Ce twin **deroule le moteur ASPIC+ a la main** (BCL .NET 9, 0 NuGet, aucune JVM), dans la meme lignee que le [Tweety-5-Csharp](Tweety-5-Abstract-Argumentation-Csharp.ipynb) qui implementait le cadre abstrait de Dung from-scratch.\n",
+    "\n",
+    "## Idea cle\n",
+    "\n",
+    "L'argumentation **abstraite** de Dung (Tweety-5) traite les arguments comme des boites noires : on ne sait pas *d'ou* ils viennent ni *pourquoi* ils s'attaquent. L'argumentation **structuree** (ASPIC+) repond a ces deux questions :\n",
+    "\n",
+    "- **Construction** : un argument est construit en appliquant des regles (strictes `->` ou defaisables `=>`) a partir d'axiomes. Les arguments se composent recursivement.\n",
+    "- **Attaque** : deux arguments s'attaquent quand leurs conclusions se contredisent (rebut), ou quand l'un minconforte une regle defaisable de l'autre (undercut).\n",
+    "\n",
+    "On verifie **mathematiquement** que la conversion ASPIC+ -> Dung redonne le bon cadre abstrait, et que la s\u00e9mantique grounded isole les arguments defendus.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ae983e52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:30.449998Z",
+     "iopub.status.busy": "2026-07-06T14:55:30.443326Z",
+     "iopub.status.idle": "2026-07-06T14:55:32.597484Z",
+     "shell.execute_reply": "2026-07-06T14:55:32.585412Z"
+    },
+    "papermill": {
+     "duration": 2.160708,
+     "end_time": "2026-07-06T14:55:32.597765",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:30.437057",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '47816.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Environnement pret \u2014 moteur ASPIC+ from-scratch (BCL .NET seule, 0 NuGet, 0 JVM)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Setup : aucune dependance externe \u2014 moteur ASPIC+ from-scratch, uniquement la BCL .NET.\n",
+    "// Meme convention que Tweety-5-Csharp (Dung from-scratch).\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "\n",
+    "// Helper de formatage invariant (CultureInfo NE persiste PAS entre cellules -> helper FI).\n",
+    "static string FI(double x, string fmt = \"F2\")\n",
+    "{\n",
+    "    var s = x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "    // Tue les -0.0 parasites (mathematiquement nuls).\n",
+    "    if (s == \"-0\" || s == \"-0.0\" || s == \"-0.00\") s = s.Substring(1);\n",
+    "    return s;\n",
+    "}\n",
+    "// Affichage headless (Console.WriteLine est avale en papermill ; .Display() capture).\n",
+    "static void Show(string s) { s.Display(); }\n",
+    "\n",
+    "\"Environnement pret \u2014 moteur ASPIC+ from-scratch (BCL .NET seule, 0 NuGet, 0 JVM).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32384654",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003126,
+     "end_time": "2026-07-06T14:55:32.609198",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:32.606072",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Theorie ASPIC+ : regles et axiomes\n",
+    "\n",
+    "Une theorie ASPIC+ (en logique propositionnelle) comporte :\n",
+    "\n",
+    "- des **axiomes** (faits certains, non attaquables) ;\n",
+    "- des **regles strictes** `premises -> conclusion` : deduction inattaquable (logique classique) ;\n",
+    "- des **regles defaisables** `premises => conclusion` : inference remise en cause (le coeur du debat).\n",
+    "\n",
+    "Une **formule** est une proposition (`d`) ou sa negation (`!d`). Deux formules sont **contradictoires** si l'une est la negation de l'autre : `Compl(d) = !d`, `Compl(!d) = d`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "47701331",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:32.620007Z",
+     "iopub.status.busy": "2026-07-06T14:55:32.619646Z",
+     "iopub.status.idle": "2026-07-06T14:55:32.970050Z",
+     "shell.execute_reply": "2026-07-06T14:55:32.969799Z"
+    },
+    "papermill": {
+     "duration": 0.355899,
+     "end_time": "2026-07-06T14:55:32.970146",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:32.614247",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Classes pretes : AspicRule (stricte/defaisable), AspicTheory (axiomes + regles)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Representation d'une theorie ASPIC+ : axiomes + regles (strictes / defaisables).\n",
+    "// Les formules sont des chaines (\"d\", \"!d\") ; la negation est prefixee par '!'.\n",
+    "\n",
+    "static string Compl(string f) => f.StartsWith(\"!\") ? f.Substring(1) : \"!\" + f;\n",
+    "\n",
+    "class AspicRule\n",
+    "{\n",
+    "    public string Name { get; set; }\n",
+    "    public List<string> Premises { get; set; } = new();\n",
+    "    public string Conclusion { get; set; }\n",
+    "    public bool Defeasible { get; set; }\n",
+    "    public string Display() =>\n",
+    "        this.Premises.Count == 0\n",
+    "            ? (this.Defeasible ? \"T => \" : \"T -> \") + this.Conclusion\n",
+    "            : string.Join(\", \", this.Premises) + (this.Defeasible ? \" => \" : \" -> \") + this.Conclusion;\n",
+    "}\n",
+    "\n",
+    "class AspicTheory\n",
+    "{\n",
+    "    public List<string> Axioms { get; } = new();\n",
+    "    public List<AspicRule> Rules { get; } = new();\n",
+    "    public void AddAxiom(string p) { if (!this.Axioms.Contains(p)) this.Axioms.Add(p); }\n",
+    "    public void AddRule(AspicRule r) { this.Rules.Add(r); }\n",
+    "    public override string ToString()\n",
+    "    {\n",
+    "        var parts = new List<string>();\n",
+    "        foreach (var ax in this.Axioms) parts.Add(\"T -> \" + ax);\n",
+    "        foreach (var r in this.Rules) parts.Add(r.Display());\n",
+    "        return \"ArgumentationSystem [rules=[\" + string.Join(\", \", parts) + \"]]\";\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Show(\"Classes pretes : AspicRule (stricte/defaisable), AspicTheory (axiomes + regles).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5233106",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003634,
+     "end_time": "2026-07-06T14:55:32.976979",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:32.973345",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Construction recursive des arguments\n",
+    "\n",
+    "Un **argument** est soit :\n",
+    "- un **axiome** (feuille) : ` -> c` (conclusion c tiree directement d'un axiome) ;\n",
+    "- l'application d'une **regle** a des sous-arguments : `premises => conclusion [sous-args]`.\n",
+    "\n",
+    "On construit tous les arguments par **point fixe** : on part des axiomes, puis on applique iterativement toute regle dont les premisses sont deja derivables, jusqu'a ne plus rien pouvoir ajouter.\n",
+    "\n",
+    "> Chaque conclusion n'etant ici produite que par une seule regle, on obtient exactement un argument par conclusion derivee (pas d'explosion combinatoire).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a95de405",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:32.984598Z",
+     "iopub.status.busy": "2026-07-06T14:55:32.984421Z",
+     "iopub.status.idle": "2026-07-06T14:55:33.247356Z",
+     "shell.execute_reply": "2026-07-06T14:55:33.247212Z"
+    },
+    "papermill": {
+     "duration": 0.266555,
+     "end_time": "2026-07-06T14:55:33.247426",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:32.980871",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AspicArgument + AspicBuilder prets (construction recursive par point fixe)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Argument ASPIC+ : structure recursive (conclusion + regle sommitale + sous-arguments).\n",
+    "// ToString reproduit la convention Tweety :  -> c  (axiome)  |  p1, p2 => c [sub1, sub2]  (regle).\n",
+    "\n",
+    "class AspicArgument\n",
+    "{\n",
+    "    public string Conclusion { get; set; }\n",
+    "    public AspicRule TopRule { get; set; }          // null => argument d'axiome\n",
+    "    public List<AspicArgument> Subs { get; set; } = new();  // un sous-argument par premisse de TopRule\n",
+    "    public bool IsAxiom => this.TopRule == null;\n",
+    "    public bool IsDefeasible => this.TopRule != null && this.TopRule.Defeasible;\n",
+    "\n",
+    "    public string Display()\n",
+    "    {\n",
+    "        if (this.IsAxiom) return \" -> \" + this.Conclusion;\n",
+    "        var pre = string.Join(\", \", this.TopRule.Premises);\n",
+    "        var arrow = this.TopRule.Defeasible ? \" => \" : \" -> \";\n",
+    "        var subs = string.Join(\", \", this.Subs.Select(s => s.Display()));\n",
+    "        return pre + arrow + this.Conclusion + \" [\" + subs + \"]\";\n",
+    "    }\n",
+    "    // Signature de canonicalite pour dedoublonner (conclusion + regle + structure des sous-args).\n",
+    "    public string Key() => this.IsAxiom\n",
+    "        ? \"AX:\" + this.Conclusion\n",
+    "        : this.TopRule.Name + \"[\" + string.Join(\"|\", this.Subs.Select(s => s.Key())) + \"]\";\n",
+    "}\n",
+    "\n",
+    "static class AspicBuilder\n",
+    "{\n",
+    "    // Construit tous les arguments d'une theorie par point fixe.\n",
+    "    public static List<AspicArgument> Build(AspicTheory t)\n",
+    "    {\n",
+    "        var args = new List<AspicArgument>();\n",
+    "        var byKey = new Dictionary<string, AspicArgument>();\n",
+    "        // Arguments d'axiomes.\n",
+    "        foreach (var ax in t.Axioms)\n",
+    "        {\n",
+    "            var a = new AspicArgument { Conclusion = ax };\n",
+    "            if (!byKey.ContainsKey(a.Key())) { byKey[a.Key()] = a; args.Add(a); }\n",
+    "        }\n",
+    "        // Point fixe : appliquer toute regle dont les premisses sont derivables.\n",
+    "        bool changed = true;\n",
+    "        while (changed)\n",
+    "        {\n",
+    "            changed = false;\n",
+    "            // conclusions deja derivables (cle = conclusion, valeur = un argument canonique).\n",
+    "            var derivable = args.GroupBy(a => a.Conclusion).ToDictionary(g => g.Key, g => g.First());\n",
+    "            foreach (var rule in t.Rules)\n",
+    "            {\n",
+    "                if (!rule.Premises.All(p => derivable.ContainsKey(p))) continue;\n",
+    "                // Un argument par application : sous-argument canonique pour chaque premisse.\n",
+    "                var subs = rule.Premises.Select(p => derivable[p]).ToList();\n",
+    "                var arg = new AspicArgument { Conclusion = rule.Conclusion, TopRule = rule, Subs = subs };\n",
+    "                if (!byKey.ContainsKey(arg.Key()))\n",
+    "                {\n",
+    "                    byKey[arg.Key()] = arg;\n",
+    "                    args.Add(arg);\n",
+    "                    changed = true;\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "        return args;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Show(\"AspicArgument + AspicBuilder prets (construction recursive par point fixe).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ded28d27",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002475,
+     "end_time": "2026-07-06T14:55:33.252598",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.250123",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Exemple : theorie avec contradiction sur `d`\n",
+    "\n",
+    "Theorie (une seule regle par conclusion, une contradiction sur `d`) :\n",
+    "\n",
+    "- **Axiomes** : `b`, `c`\n",
+    "- **Regles defaisables** :\n",
+    "  - `r1 : b, c => a`\n",
+    "  - `r2 : b => d`\n",
+    "  - `r3 : a => !d`\n",
+    "\n",
+    "On derive `a` (via r1), puis `d` (via r2) et `!d` (via r3) : `d` et `!d` sont contradictoires -> conflit.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9858e9a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:33.258883Z",
+     "iopub.status.busy": "2026-07-06T14:55:33.258691Z",
+     "iopub.status.idle": "2026-07-06T14:55:33.454550Z",
+     "shell.execute_reply": "2026-07-06T14:55:33.454366Z"
+    },
+    "papermill": {
+     "duration": 0.199647,
+     "end_time": "2026-07-06T14:55:33.454628",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.254981",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "--- Theorie ASPIC+ ---\r\n",
+       "ArgumentationSystem [rules=[T -> b, T -> c, b, c => a, b => d, a => !d]]\r\n",
+       "\r\n",
+       "--- Arguments construits (5) ---\r\n",
+       "  -  -> b\r\n",
+       "  -  -> c\r\n",
+       "  - b, c => a [ -> b,  -> c]\r\n",
+       "  - b => d [ -> b]\r\n",
+       "  - a => !d [b, c => a [ -> b,  -> c]]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Construction de l'exemple ASPIC+ et enumeration des arguments.\n",
+    "var t = new AspicTheory();\n",
+    "t.AddAxiom(\"b\");\n",
+    "t.AddAxiom(\"c\");\n",
+    "t.AddRule(new AspicRule { Name = \"r1\", Premises = new() { \"b\", \"c\" }, Conclusion = \"a\", Defeasible = true });\n",
+    "t.AddRule(new AspicRule { Name = \"r2\", Premises = new() { \"b\" },     Conclusion = \"d\", Defeasible = true });\n",
+    "t.AddRule(new AspicRule { Name = \"r3\", Premises = new() { \"a\" },     Conclusion = \"!d\", Defeasible = true });\n",
+    "\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"--- Theorie ASPIC+ ---\");\n",
+    "sb.AppendLine(t.ToString());\n",
+    "\n",
+    "var args = AspicBuilder.Build(t);\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"--- Arguments construits (\" + args.Count + \") ---\");\n",
+    "foreach (var a in args) sb.AppendLine(\"  - \" + a.Display());\n",
+    "\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94fbfb65",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002699,
+     "end_time": "2026-07-06T14:55:33.460258",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.457559",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "On obtient **5 arguments** :\n",
+    "\n",
+    "| Argument | Conclusion | Structure |\n",
+    "|----------|-----------|-----------|\n",
+    "| ` -> b` | b | axiome |\n",
+    "| ` -> c` | c | axiome |\n",
+    "| `b => d [ -> b]` | d | r2 sur l'axiome b |\n",
+    "| `b, c => a [ -> b,  -> c]` | a | r1 sur les axiomes b, c |\n",
+    "| `a => !d [b, c => a [...]]` | !d | r3 sur l'argument de a (recursif) |\n",
+    "\n",
+    "L'argument pour `!d` **emboite** l'argument pour `a`, qui lui-meme emboite ceux de `b` et `c` : c'est la composition recursive propre a l'argumentation structuree.\n",
+    "\n",
+    "## 4. Attaques : rebut entre arguments defaisables\n",
+    "\n",
+    "En ASPIC+, un argument defaisable A **rebut** un argument defaisable B si la conclusion de A contredit celle de B (`Conclusion(A) = Compl(Conclusion(B))`). Le rebut est **symetrique** entre arguments defaisables : si A rebut B et que B est defaisable, B rebut A aussi.\n",
+    "\n",
+    "> **Simplification honnete** : on modelise le **rebut sur la conclusion sommitale** entre arguments defaisables. L'ASPIC+ complet ajoute l'*undermine* (attaque d'une premisse) et l'*undercut* (attaque directe d'une regle defaisable) \u2014 non necessaire pour cet exemple (pur conflit de conclusion), et signale ici pour transparence.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "07e1da2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:33.471018Z",
+     "iopub.status.busy": "2026-07-06T14:55:33.470620Z",
+     "iopub.status.idle": "2026-07-06T14:55:33.581063Z",
+     "shell.execute_reply": "2026-07-06T14:55:33.580926Z"
+    },
+    "papermill": {
+     "duration": 0.115413,
+     "end_time": "2026-07-06T14:55:33.581130",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.465717",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "--- Attaques generees (2) ---\r\n",
+       "  - (b => d [ -> b], a => !d [b, c => a [ -> b,  -> c]])\r\n",
+       "  - (a => !d [b, c => a [ -> b,  -> c]], b => d [ -> b])\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Generation des attaques (rebut symetrique entre arguments defaisables).\n",
+    "// A rebut B <=> A defaisable ET B defaisable ET Conclusion(A) = Compl(Conclusion(B)).\n",
+    "\n",
+    "static List<(AspicArgument, AspicArgument)> Rebuttals(List<AspicArgument> args)\n",
+    "{\n",
+    "    var atks = new List<(AspicArgument, AspicArgument)>();\n",
+    "    foreach (var a in args)\n",
+    "    {\n",
+    "        if (!a.IsDefeasible) continue;\n",
+    "        foreach (var b in args)\n",
+    "        {\n",
+    "            if (!b.IsDefeasible) continue;\n",
+    "            if (a.Conclusion == Compl(b.Conclusion))\n",
+    "                atks.Add((a, b));\n",
+    "        }\n",
+    "    }\n",
+    "    return atks;\n",
+    "}\n",
+    "\n",
+    "var attacks = Rebuttals(args);\n",
+    "var sb2 = new StringBuilder();\n",
+    "sb2.AppendLine(\"--- Attaques generees (\" + attacks.Count + \") ---\");\n",
+    "foreach (var (a, b) in attacks)\n",
+    "    sb2.AppendLine(\"  - (\" + a.Display() + \", \" + b.Display() + \")\");\n",
+    "Show(sb2.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3ea9a35",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002393,
+     "end_time": "2026-07-06T14:55:33.586377",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.583984",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Deux attaques symetriques :\n",
+    "- `arg_d` (conclut `d`) rebut `arg_!d` (conclut `!d`)\n",
+    "- `arg_!d` rebut `arg_d`\n",
+    "\n",
+    "Ni `arg_a`, ni les axiomes ne sont attaques (leurs conclusions ne sont contredites par personne).\n",
+    "\n",
+    "## 5. Conversion vers Dung + semantique grounded\n",
+    "\n",
+    "On projette les arguments en noeuds et les attaques en aretes : on retrouve un **cadre de Dung** abstrait. On lui applique alors la **fonction caracteristique** de Tweety-5-Csharp :\n",
+    "\n",
+    "- $F(S)$ = arguments dont **tous** les attaquants sont contre-attaques par $S$ ;\n",
+    "- $F(\\emptyset)$ = arguments sans attaquant ;\n",
+    "- on itere $F$ jusqu'au point fixe = **extension grounded** (sceptique).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "91699731",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:33.592749Z",
+     "iopub.status.busy": "2026-07-06T14:55:33.592542Z",
+     "iopub.status.idle": "2026-07-06T14:55:33.714312Z",
+     "shell.execute_reply": "2026-07-06T14:55:33.714179Z"
+    },
+    "papermill": {
+     "duration": 0.125669,
+     "end_time": "2026-07-06T14:55:33.714380",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.588711",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "--- Conversion en AF de Dung ---\r\n",
+       "Arguments (5) :  -> b,  -> c, a => !d [b, c => a [ -> b,  -> c]], b => d [ -> b], b, c => a [ -> b,  -> c]\r\n",
+       "\r\n",
+       "--- Extension grounded ---\r\n",
+       "{  -> b,  -> c, b, c => a [ -> b,  -> c] }\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Cadre de Dung abstrait (repris de Tweety-5-Csharp) + fonction caracteristique.\n",
+    "class DungAF\n",
+    "{\n",
+    "    public HashSet<string> Args { get; } = new();\n",
+    "    private readonly Dictionary<string, HashSet<string>> _attackersOf = new();\n",
+    "    private readonly Dictionary<string, HashSet<string>> _attackedBy = new();\n",
+    "    public void AddArg(string a) { this.Args.Add(a); if(!this._attackersOf.ContainsKey(a)) this._attackersOf[a]=new(); if(!this._attackedBy.ContainsKey(a)) this._attackedBy[a]=new(); }\n",
+    "    public void AddAttack(string a, string b) { this.AddArg(a); this.AddArg(b); this._attackersOf[b].Add(a); this._attackedBy[a].Add(b); }\n",
+    "    public IEnumerable<string> AttackersOf(string b) => this._attackersOf[b];\n",
+    "    public bool Attacks(string a, string b) => this._attackedBy[a].Contains(b);\n",
+    "}\n",
+    "static bool DefendedBy(string a, ISet<string> S, DungAF af)\n",
+    "{\n",
+    "    foreach (var b in af.AttackersOf(a)) { bool blocked=false; foreach(var c in S) if(af.Attacks(c,b)){blocked=true;break;} if(!blocked) return false; }\n",
+    "    return true;\n",
+    "}\n",
+    "static HashSet<string> F(ISet<string> S, DungAF af)\n",
+    "{\n",
+    "    var r = new HashSet<string>(); foreach (var a in af.Args) if (DefendedBy(a, S, af)) r.Add(a); return r;\n",
+    "}\n",
+    "// Extension grounded = point fixe de F partant de l'ensemble vide.\n",
+    "static HashSet<string> Grounded(DungAF af)\n",
+    "{\n",
+    "    var E = new HashSet<string>(); var prev = new HashSet<string>();\n",
+    "    do { prev = E; E = F(E, af); } while (E.Count != prev.Count);\n",
+    "    return E;\n",
+    "}\n",
+    "\n",
+    "// Conversion ASPIC+ -> Dung : les arguments deviennent des noeuds (id = Display).\n",
+    "var af = new DungAF();\n",
+    "foreach (var a in args) af.AddArg(a.Display());\n",
+    "foreach (var (a, b) in attacks) af.AddAttack(a.Display(), b.Display());\n",
+    "\n",
+    "var sb3 = new StringBuilder();\n",
+    "sb3.AppendLine(\"--- Conversion en AF de Dung ---\");\n",
+    "sb3.AppendLine(\"Arguments (\" + af.Args.Count + \") : \" + string.Join(\", \", af.Args.OrderBy(x => x)));\n",
+    "sb3.AppendLine();\n",
+    "var grounded = Grounded(af);\n",
+    "sb3.AppendLine(\"--- Extension grounded ---\");\n",
+    "sb3.AppendLine(\"{ \" + string.Join(\", \", grounded.OrderBy(x => x)) + \" }\");\n",
+    "Show(sb3.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d1a78b2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002244,
+     "end_time": "2026-07-06T14:55:33.719211",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.716967",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture du resultat** :\n",
+    "\n",
+    "- Les arguments ` -> b`, ` -> c` et `b, c => a [...]` sont **acceptes** (sans attaquant, ou defendus).\n",
+    "- Les arguments `b => d [...]` et `a => !d [...]` sont **rejetes** : ils se rebutent mutuellement, et **aucun** tiers ne defend l'un contre l'autre. Le doute l'emporte : ni `d` ni `!d` n'est conclu.\n",
+    "\n",
+    "C'est exactement le verdict **sceptique** de la semantique grounded face a un cycle d'attaque symetrique non resoluble \u2014 et il correspond a l'extension calculee par TweetyProject sur la meme theorie.\n",
+    "\n",
+    "## 6. Au-dela d'ASPIC+ : DeLP, ABA, ASP (sections conceptuelles)\n",
+    "\n",
+    "Le notebook Python illustre quatre autres formalismes structurees via TweetyProject (JVM). **Aucun n'a d'equivalent BCL .NET direct** \u2014 ce sont des systemes dedies (moteurs Java, solveurs ASP). Ce twin les documente **honnetement** (verdict **INTRINSIC** au sens #3801) sans maquiller un faux rendu.\n",
+    "\n",
+    "| Formalisme | Idee | Fait tourner dans ce twin ? |\n",
+    "|-----------|------|-----------------------------|\n",
+    "| **ASPIC+** | Regles strictes/defaisables -> arguments -> Dung | **Oui, from-scratch** (sections 1-5) |\n",
+    "| **DeLP** (Defeasible Logic Programming) | Debat sur regles defaisables + requetes dialectiques | Non (moteur Java `arg.delp`) \u2014 conceptuel |\n",
+    "| **ABA** (Assumption-Based Argumentation) | Atttaquer des *hypothses* (assumptions) inversees | Non (moteur Java `arg.aba`) \u2014 conceptuel |\n",
+    "| **Argumentation deductive** | Arbres de preuve PL + contre-arguments | Non (moteur Java `arg.deductive`) \u2014 conceptuel |\n",
+    "| **ASP** (Answer Set Programming) | Ensembles-reponses d'un programme logique | Non (solveur `dlv`/`clingo`) \u2014 conceptuel |\n",
+    "\n",
+    "**Pourquoi ce plafond est honnete** : ASPIC+ est le formalisme le plus expressif dont le **moteur** (construction d'arguments + rebut + Dung) se reconstruit proprement en BCL. DeLP/ABA/ASP reposent sur des infrastructures dediees (moteurs d'inf\u00e9rence, solveurs) qui n'ont pas d'equivalent .NET leger \u2014 invoquer une JVM ou un solver externe depasserait le cadre d'un twin pedagogique BCL. La valeur du twin reside dans l'**explication du moteur** ASPIC+ (ce que TweetyProject cache), pas dans la reproduction exhaustive des cinq formalismes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ac3186b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:33.725041Z",
+     "iopub.status.busy": "2026-07-06T14:55:33.724883Z",
+     "iopub.status.idle": "2026-07-06T14:55:33.807869Z",
+     "shell.execute_reply": "2026-07-06T14:55:33.807709Z"
+    },
+    "papermill": {
+     "duration": 0.086597,
+     "end_time": "2026-07-06T14:55:33.807942",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.721345",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+---------------------+------------------------------------------------+--------------------------------+\r\n",
+       "| Formalisme          | Idee cle                                       | Dans ce twin C# ?              |\r\n",
+       "+---------------------+------------------------------------------------+--------------------------------+\r\n",
+       "| ASPIC+              | Regles strictes/defaisables, rebut/undercut/undermine -> Dung | From-scratch (sections 1-5)    |\r\n",
+       "| DeLP                | Programmation logique defaisable + arbre dialectique | Intrinseque (moteur Java arg.delp) |\r\n",
+       "| ABA                 | Attaque d'hypotheses (assumptions) par contraires | Intrinseque (moteur Java arg.aba) |\r\n",
+       "| Arg. deductive      | Arbre de preuve PL + contre-arguments          | Intrinseque (moteur Java arg.deductive) |\r\n",
+       "| ASP                 | Ensembles-reponses d'un programme logique      | Intrinseque (solveur dlv/clingo) |\r\n",
+       "+---------------------+------------------------------------------------+--------------------------------+\r\n",
+       "\r\n",
+       "Verdict #3801 : ASPIC+ = SOTA-OK (moteur from-scratch). DeLP/ABA/ASP/Arg.deductive = INTRINSIC\r\n",
+       "(pas d'equivalent BCL .NET ; le notebook Python + JVM TweetyProject reste la reference d'execution).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Synthese comparative des formalismes d'argumentation structuree (conceptuel).\n",
+    "var rows = new[] {\n",
+    "    (\"ASPIC+\",            \"Regles strictes/defaisables, rebut/undercut/undermine -> Dung\", \"From-scratch (sections 1-5)\"),\n",
+    "    (\"DeLP\",              \"Programmation logique defaisable + arbre dialectique\",          \"Intrinseque (moteur Java arg.delp)\"),\n",
+    "    (\"ABA\",               \"Attaque d'hypotheses (assumptions) par contraires\",             \"Intrinseque (moteur Java arg.aba)\"),\n",
+    "    (\"Arg. deductive\",    \"Arbre de preuve PL + contre-arguments\",                         \"Intrinseque (moteur Java arg.deductive)\"),\n",
+    "    (\"ASP\",               \"Ensembles-reponses d'un programme logique\",                     \"Intrinseque (solveur dlv/clingo)\"),\n",
+    "};\n",
+    "var sb4 = new StringBuilder();\n",
+    "sb4.AppendLine(\"+---------------------+------------------------------------------------+--------------------------------+\");\n",
+    "sb4.AppendLine(\"| Formalisme          | Idee cle                                       | Dans ce twin C# ?              |\");\n",
+    "sb4.AppendLine(\"+---------------------+------------------------------------------------+--------------------------------+\");\n",
+    "foreach (var (n, idea, here) in rows)\n",
+    "    sb4.AppendLine(\"| \" + n.PadRight(19) + \" | \" + idea.PadRight(46) + \" | \" + here.PadRight(30) + \" |\");\n",
+    "sb4.AppendLine(\"+---------------------+------------------------------------------------+--------------------------------+\");\n",
+    "sb4.AppendLine();\n",
+    "sb4.AppendLine(\"Verdict #3801 : ASPIC+ = SOTA-OK (moteur from-scratch). DeLP/ABA/ASP/Arg.deductive = INTRINSIC\");\n",
+    "sb4.AppendLine(\"(pas d'equivalent BCL .NET ; le notebook Python + JVM TweetyProject reste la reference d'execution).\");\n",
+    "Show(sb4.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63611905",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003189,
+     "end_time": "2026-07-06T14:55:33.814023",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.810834",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices (#2161)\n",
+    "\n",
+    "Trois exercices pour manipuler le moteur ASPIC+.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aac6e2c5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003005,
+     "end_time": "2026-07-06T14:55:33.820221",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.817216",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 \u2014 Une quatrieme regle defaisable\n",
+    "\n",
+    "Ajoutez une regle `r4 : c => !a` a la theorie de la section 3 (en plus de r1, r2, r3).\n",
+    "\n",
+    "1. Construisez le nouvel argument pour `!a`.\n",
+    "2. Identifiez la nouvelle paire d'attaques (rebut entre `arg_a` et `arg_!a`).\n",
+    "3. Recalculez l'extension grounded : `a` et `!a` sont-ils acceptes ? Que devient `d` (r3 depend de `a`) ?\n",
+    "\n",
+    "**Indice** : un nouveau cycle symetrique apparait au niveau de `a`. Observez comment l'effet se *propage* aux arguments qui utilisent `a` comme premisse.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "25156861",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:33.828860Z",
+     "iopub.status.busy": "2026-07-06T14:55:33.828376Z",
+     "iopub.status.idle": "2026-07-06T14:55:33.916161Z",
+     "shell.execute_reply": "2026-07-06T14:55:33.916044Z"
+    },
+    "papermill": {
+     "duration": 0.092914,
+     "end_time": "2026-07-06T14:55:33.916220",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.823306",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 a completer : observer la propagation du conflit sur 'a' vers 'd'."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : a completer\n",
+    "// Etape 1 : reconstruire la theorie avec r4 (c => !a).\n",
+    "// Etape 2 : enumerer les arguments et identifier les rebuttals supplementaires.\n",
+    "// Etape 3 : calculer l'extension grounded et comparer avec la section 5.\n",
+    "// var tex1 = new AspicTheory();\n",
+    "// tex1.AddAxiom(\"b\"); tex1.AddAxiom(\"c\");\n",
+    "// tex1.AddRule(... r1, r2, r3 ...);\n",
+    "// tex1.AddRule(new AspicRule { Name = \"r4\", Premises = new() { \"c\" }, Conclusion = \"!a\", Defeasible = true });\n",
+    "// var argsEx1 = AspicBuilder.Build(tex1);\n",
+    "\"Exercice 1 a completer : observer la propagation du conflit sur 'a' vers 'd'.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3949f49",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002379,
+     "end_time": "2026-07-06T14:55:33.921189",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.918810",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 \u2014 Attaque undercut (extension du modele)\n",
+    "\n",
+    "L'ASPIC+ complet definit l'**undercut** : un argument peut attaquer *directement une regle defaisable* de l'autre (et non sa conclusion). On ajoute pour cela des formules `!r_i` signifiant \u00ab la regle r_i n'est pas fiable \u00bb.\n",
+    "\n",
+    "1. Ajoutez un axiome `!r2` (l'adversaire conteste la regle `b => d`).\n",
+    "2. Proposez une regle de generation d'attaque : un argument concluant `!r_i` undercut tout argument dont la regle sommitale est `r_i`.\n",
+    "3. Recalculez l'extension grounded : `d` est-il encore attaqu\u00e9 ? Par qui ?\n",
+    "\n",
+    "**Indice** : contrairement au rebut (symetrique), l'undercut est **directif** (A undercut B ne signifie pas que B undercut A). Il faut distinguer les deux types d'aretes dans le cadre de Dung.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c4ac640c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:33.927326Z",
+     "iopub.status.busy": "2026-07-06T14:55:33.927156Z",
+     "iopub.status.idle": "2026-07-06T14:55:33.971481Z",
+     "shell.execute_reply": "2026-07-06T14:55:33.971336Z"
+    },
+    "papermill": {
+     "duration": 0.047873,
+     "end_time": "2026-07-06T14:55:33.971550",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.923677",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 a completer : modeliser l'undercut (attaque directive d'une regle)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : a completer\n",
+    "// Etape 1 : etendre la theorie avec un axiome !r2.\n",
+    "// Etape 2 : ecrire la regle d'undercut (un argument conclusant !r_i undercut l'argument de top-rule r_i).\n",
+    "// Indice : il faudra peut-etre suivre le Name de la regle sommitale de chaque argument.\n",
+    "\"Exercice 2 a completer : modeliser l'undercut (attaque directive d'une regle).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b040d65c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002931,
+     "end_time": "2026-07-06T14:55:33.977578",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.974647",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 \u2014 Comparaison ASPIC+ vs ABA sur un exemple medical\n",
+    "\n",
+    "On veut modeliser un debat medical : \u00ab Le patient a la maladie M (symptome S => M). Mais le traitement T provoque aussi S (T => S). Le patient suit T. \u00bb\n",
+    "\n",
+    "1. Modelisez ce debat en ASPIC+ (axiomes + regles defaisables) et lancez le moteur.\n",
+    "2. Decrivez (en prose) comment **ABA** representerait le meme debat : quelles sont les *assomptions* ? quels sont leurs *contraires* ?\n",
+    "3. Quel formalisme est le plus naturel pour ce cas, et pourquoi ?\n",
+    "\n",
+    "**Indice** : ABA inverse des assumptions (`assume(S)`) dont le contraire (`S -> conflict`) peut etre attaqu\u00e9. ASPIC+ raisonne en avant (regles), ABA en arriere (assumptions).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "13b54263",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T14:55:33.984784Z",
+     "iopub.status.busy": "2026-07-06T14:55:33.984581Z",
+     "iopub.status.idle": "2026-07-06T14:55:34.044966Z",
+     "shell.execute_reply": "2026-07-06T14:55:34.044824Z"
+    },
+    "papermill": {
+     "duration": 0.06456,
+     "end_time": "2026-07-06T14:55:34.045038",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:33.980478",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 a completer : comparer ASPIC+ (avant) et ABA (arriere, assumptions) sur un cas medical."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : a completer\n",
+    "// Etape 1 : modeliser en ASPIC+ (axiome 'T', regles 'S => M' et 'T => S', plus une regle 'S => ...').\n",
+    "// Etape 2 : decrire en commentaire la representation ABA equivalent (assumptions + contraires).\n",
+    "// Etape 3 : argumenter (en commentaire) le choix du formalisme.\n",
+    "\"Exercice 3 a completer : comparer ASPIC+ (avant) et ABA (arriere, assumptions) sur un cas medical.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74f90ebc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00605,
+     "end_time": "2026-07-06T14:55:34.054332",
+     "exception": false,
+     "start_time": "2026-07-06T14:55:34.048282",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# a **deroule le moteur ASPIC+ from-scratch** (BCL .NET 9, 0 NuGet, 0 JVM) :\n",
+    "\n",
+    "1. **Construction recursive** des arguments par point fixe a partir des axiomes et regles (strictes/defaisables).\n",
+    "2. **Attaques** par rebut symetrique entre arguments defaisables de conclusions contradictoires.\n",
+    "3. **Conversion vers Dung** puis **semantique grounded** reutilisant le moteur abstrait de Tweety-5-Csharp.\n",
+    "4. **Verification mathematique** : sur la theorie `r1,r2,r3 + axiomes b,c`, le moteur isole `{b, c, a}` et rejette `{d, !d}` (cycle symetrique non resoluble) \u2014 conforme au verdict sceptique attendu.\n",
+    "\n",
+    "**Complementarite (#3801 Prong B)** : le notebook Python execute TweetyProject (JVM, boite noire) ; ce twin rend **explicite** le moteur (construction d'arguments, classification des attaques, projection vers Dung). Les formalismes sans equivalent BCL (DeLP, ABA, ASP) sont documentes honnetement (verdict INTRINSIC) et renvoient au twin Python pour l'execution.\n",
+    "\n",
+    "See #4956, #3801.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.562924,
+   "end_time": "2026-07-06T14:55:34.191983",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Tweety-6-Structured-Argumentation-Csharp.ipynb",
+   "output_path": "tweety6_exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-06T14:55:27.629059",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

**Twin C# (.NET Interactive)** de [Tweety-6-Structured-Argumentation.ipynb](MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb) — marathon **#4956** (parité .NET ⇄ Python), volet **SymbolicAI/Tweety**, axe-2 SOTA **#3801** Prong B.

Le notebook Python invoque **TweetyProject** (Java, via `jpype` + JVM) pour 5 formalismes d'argumentation structurée (ASPIC+, DeLP, ABA, argumentation déductive, ASP). Ce twin **déroule le moteur ASPIC+ à la main** (BCL .NET 9, **0 NuGet, 0 JVM, 0 IKVM**), dans la lignée du [Tweety-5-Csharp](MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation-Csharp.ipynb) (Dung from-scratch) dont il **réutilise le moteur abstrait** pour la sémantique.

## Algorithme (Prong B, from-scratch)

1. **Théorie ASPIC+** : `AspicRule` (stricte `->` / défeasible `=>`, prémisses + conclusion) + `AspicTheory` (axiomes + règles). Formules = chaînes (`d`, `!d`), `Compl(f)` gère la négation.
2. **Construction récursive des arguments** (`AspicBuilder.Build`, point fixe) : on part des axiomes, on applique itérativement toute rèle dont les prémisses sont dérivables. `AspicArgument` = conclusion + rèle sommitale + sous-arguments (un par prémisse), composition récursive. Déduplication par clé canonique.
3. **Attaques** (`Rebuttals`) : **rebut symétrique** entre arguments défeasibles dont les conclusions se contredisent (`Conclusion(A) = Compl(Conclusion(B))`).
4. **Conversion → Dung** : projection arguments↔nœuds, attaques↔arêtes, puis **fonction caractéristique** itérée jusqu'au point fixe = **extension grounded** (moteur repris de Tweety-5-Csharp).

## Exec prouvée (C.2/H.1)

Papermill kernel `.net-csharp`, **10/10 cellules code `execution_count` 1-10, 0 erreur, 0 output vide**. Outputs vérifiés **firsthand** et comparés à TweetyProject :

- **Théorie** : `ArgumentationSystem [rules=[T -> b, T -> c, b, c => a, b => d, a => !d]]` ✓ (axiomes b, c + règles défeasibles r1/r2/r3).
- ★ **5 arguments construits** (correspondance exacte avec Tweety) :
  - ` -> b`, ` -> c` (axiomes)
  - `b, c => a [ -> b,  -> c]` (r1)
  - `b => d [ -> b]` (r2)
  - `a => !d [b, c => a [ -> b,  -> c]]` (r3, **sous-argument récursif** emboîté) ✓
- ★ **2 attaques symétriques** (rebut entre arg_d et arg_¬d) — correspondance exacte avec Tweety :
  - `(b => d [...], a => !d [...])`
  - `(a => !d [...], b => d [...])`
- ★ **Extension grounded = {arg_b, arg_c, arg_a}** — correspondance **exacte** avec la sortie Tweety `{ -> b, -> c, b, c => a [ -> b,  -> c]}`. `d` et `!d` sont rejetés (cycle de rebut symétrique non résolu, verdict sceptique correct).

## Complémentarité (#3801 Prong B) — distinctif

| Aspect | Python (twin) | Twin C# (ici) |
|--------|---------------|----------------|
| ASPIC+ | `org.tweetyproject.arg.aspic` (JVM, boîte noire) | **moteur from-scratch** (construction récursive + rebut + Dung) |
| DeLP / ABA / déductif / ASP | `jpype` + modules Tweety (exécution) | **section conceptuelle** (verdict INTRINSIC, pas d'équivalent BCL .NET) |
| Dépendances | JVM + JARs Tweety (42) | **BCL seule, 0 NuGet, 0 IKVM** |

★ Le cœur du notebook (sections 1-5 : théorie + construction + attaques + conversion Dung + grounded) est **from-scratch SOTA-OK** : ce que TweetyProject cache, ce twin le rend explicite. Les formalismes sans équivalent BCL (DeLP, ABA, argumentation déductive, ASP) sont documentés **honnêtement** (verdict **INTRINSIC** #3801) avec un tableau comparatif, renvoi au twin Python pour l'exécution.

## Bugs G.1 self-corrected (avant exécution)

2 bugs détectés et corrigés **pendant le développement** :
1. **Stubs exercices `Console.WriteLine` avalé** : en papermill headless `.net-csharp`, `Console.WriteLine` ne produit pas d'output → cellules d'exercice sans sortie (violation C.2 « outputs cohérents »). Fix : `"…".Display()` (capture `text/plain`). (Leçon marathon dotnet-interactive-headless-display-vs-console.)
2. **CS0219 var unused** : le stub exercice 1 déclarait `var tex1 = new AspicTheory();` non utilisé → warning. Fix : commenter la déclaration (scaffolding en commentaires, étudiant la saisit).

## Exercices (#2161)

3 stubs C.1-conformes (sans `raise NotImplementedError`) :
1. **Ajouter une 4e règle défeasible** `c => !a` : observer la **propagation** du nouveau conflit sur `a` vers `d` (r3 dépend de `a`).
2. **Modéliser l'undercut** (extension du modèle) : axiome `!r2` + règle d'attaque directive d'une règle (vs rebut symétrique).
3. **Comparer ASPIC+ vs ABA** sur un cas médical (raisonnement avant vs assumptions inversées).

## Scope

Atomique : 1 notebook (22 cells, 10 code) + SymbolicAI/Tweety/README.md (4 lignes : table row `6c` + tree entry + 2 compteurs 26→27 / 13→14 C#). Self-contained (BCL seule). **CATALOG byte-identique** à main (two-dot `git diff origin/main`). Mermaid fence balance OK (24, pair). C.1 = 0.

### §E README audit (whole-file gate)

Ajout cohérent : table row `6c` + tree entry + 2 compteurs (26→27 notebooks, 13→14 C#/.NET). **Note pré-existing gap hors-scope** : `Tweety-5-Abstract-Argumentation-Csharp.ipynb` existe sur disque mais est absent de la table ET de l'arbre (incohérence préexistante, #5367-style). Non corrigé ici (atomic scope : Tweety-6-Csharp uniquement) — flag pour follow-up.

## Marathon #4956

Pivot **famille** (Rule 6 rotation) après 2 BUILD .NET GameTheory consécutifs (c.55 GT-5, c.57 GT-7) : **1er twin C# Tweety** (SymbolicAI) — anti-concentration respectée (po-2024 sur Search-docs/GT/i18n, pas Tweety). Voisin Python : Tweety-6 (TweetyProject/JVM). Réutilise le moteur Dung de Tweety-5-Csharp.

See #4956, #3801. Revue souhaitée : ai-01, po-2024 (SymbolicAI/.NET owner), po-2025.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
