### PR TITLE
feat(search-apps): App-16-Crossword-CSP-Csharp — twin C# backtracking + forward-checking (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb
@@ -1,0 +1,1107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3da136da-a583-444f-8cd6-8fbfb8f817d0",
+   "metadata": {},
+   "source": [
+    "# App-16-Crossword-CSP (C#)\n",
+    "\n",
+    "**Navigation** : [<< App-15-SportsScheduling](App-15-SportsScheduling-Csharp.ipynb) | [Index](../README.md) | [App-17-VRP >>](../Hybrid/App-17-VRP-Logistics.ipynb)\n",
+    "\n",
+    "**Twin C# (.NET Interactive)** de [App-16-Crossword-CSP.ipynb](App-16-Crossword-CSP.ipynb) — marathon **#4956** (parite .NET <-> Python).\n",
+    "\n",
+    "La generation de mots croises est un **CSP** (Constraint Satisfaction Problem) classique : on dispose d'une grille (cases blanches/noires), d'un dictionnaire de mots indexes par longueur, et on doit placer un mot dans chaque *slot* (suite maximale de cases blanches consecutives) de sorte que les **intersections** entre slots horizontaux et verticaux soient compatibles (meme lettre a la case de croisement).\n",
+    "\n",
+    "## Plan pedagogique\n",
+    "\n",
+    "1. **Modelisation** — CrosswordGrid, extraction des slots\n",
+    "2. **Backtracking** — assignation ordonnee (MRV), verification des intersections\n",
+    "3. **Propagation de contraintes** — forward-checking\n",
+    "4. **Generation aleatoire** + analyse\n",
+    "5. **Exercices**\n",
+    "\n",
+    "> **Parite #4956** : la version Python s'appuie sur OR-Tools CP-SAT (solveur boite noire) et implemente aussi backtracking + propagation from-scratch. Ce twin C# (BCL .NET 9, **0 NuGet**) deroule le backtracking + forward-checking from-scratch (les internes pedagogiques que masque OR-Tools). La viz matplotlib devient un rendu ASCII de la grille (convention GT-4c).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36a0f74a-d4e5-4180-a2ef-ff83557b6d84",
+   "metadata": {},
+   "source": [
+    "## 1. Modelisation du probleme\n",
+    "\n",
+    "Une **grille** de mots croises est une matrice de cases, chacune **blanche** (lettre a placer) ou **noire** (bloque). Un **slot** est une suite maximale de cases blanches consecutives (longueur >= 2), horizontalement ou verticalement. Chaque slot recoit un mot du dictionnaire de la bonne longueur. Deux slots qui se croisent a une case partagent une lettre : la position de cette lettre dans le mot horizontal doit egaler celle dans le mot vertical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fdfe3cb3-d35c-4361-a3f3-839403af0db1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:19.204122Z",
+     "iopub.status.busy": "2026-07-06T18:49:19.196570Z",
+     "iopub.status.idle": "2026-07-06T18:49:21.132355Z",
+     "shell.execute_reply": "2026-07-06T18:49:21.128880Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1533516.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Grille 5x5 : 6 slots (3 H, 3 V)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Slots extraits :\r\n",
+       "  (0,0) H longueur 4\r\n",
+       "  (2,0) H longueur 5\r\n",
+       "  (4,1) H longueur 4\r\n",
+       "  (0,0) V longueur 4\r\n",
+       "  (0,2) V longueur 5\r\n",
+       "  (1,4) V longueur 4\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "static void Show(string s) { s.Display(); }\n",
+    "\n",
+    "// Grille : true = case blanche (lettre), false = case noire (bloque).\n",
+    "public class CrosswordGrid\n",
+    "{\n",
+    "    public int Rows, Cols;\n",
+    "    public bool[,] White;   // White[r,c] = true si case a remplir\n",
+    "    public CrosswordGrid(bool[,] white)\n",
+    "    {\n",
+    "        White = white; Rows = white.GetLength(0); Cols = white.GetLength(1);\n",
+    "    }\n",
+    "    public bool IsWhite(int r, int c) => r>=0 && r<Rows && c>=0 && c<Cols && White[r,c];\n",
+    "}\n",
+    "\n",
+    "// Slot : suite maximale de cases blanches consecutives.\n",
+    "// Direction : 'H' (horizontal, ligne fixe) ou 'V' (vertical, colonne fixe).\n",
+    "public record Slot(int Row, int Col, char Dir, int Length);\n",
+    "\n",
+    "// Extraction des slots : scan horizontal puis vertical, runs de cases blanches >= 2.\n",
+    "static List<Slot> ExtractSlots(CrosswordGrid g)\n",
+    "{\n",
+    "    var slots = new List<Slot>();\n",
+    "    // Horizontal : pour chaque ligne, runs de cases blanches.\n",
+    "    for (int r = 0; r < g.Rows; r++)\n",
+    "    {\n",
+    "        int c = 0;\n",
+    "        while (c < g.Cols)\n",
+    "        {\n",
+    "            if (g.IsWhite(r, c))\n",
+    "            {\n",
+    "                int start = c;\n",
+    "                while (c < g.Cols && g.IsWhite(r, c)) c++;\n",
+    "                if (c - start >= 2) slots.Add(new Slot(r, start, 'H', c - start));\n",
+    "            }\n",
+    "            else c++;\n",
+    "        }\n",
+    "    }\n",
+    "    // Vertical : pour chaque colonne, runs de cases blanches.\n",
+    "    for (int c = 0; c < g.Cols; c++)\n",
+    "    {\n",
+    "        int r = 0;\n",
+    "        while (r < g.Rows)\n",
+    "        {\n",
+    "            if (g.IsWhite(r, c))\n",
+    "            {\n",
+    "                int start = r;\n",
+    "                while (r < g.Rows && g.IsWhite(r, c)) r++;\n",
+    "                if (r - start >= 2) slots.Add(new Slot(start, c, 'V', r - start));\n",
+    "            }\n",
+    "            else r++;\n",
+    "        }\n",
+    "    }\n",
+    "    return slots;\n",
+    "}\n",
+    "\n",
+    "// Grille exemple 5x5 (X = noire, . = blanche).\n",
+    "bool[,] w = {\n",
+    "    { true,  true,  true,  true,  false },\n",
+    "    { true,  false, true,  false, true  },\n",
+    "    { true,  true,  true,  true,  true  },\n",
+    "    { true,  false, true,  false, true  },\n",
+    "    { false, true,  true,  true,  true  },\n",
+    "};\n",
+    "var grid = new CrosswordGrid(w);\n",
+    "var slots = ExtractSlots(grid);\n",
+    "$\"Grille {grid.Rows}x{grid.Cols} : {slots.Count} slots ({slots.Count(s => s.Dir=='H')} H, {slots.Count(s => s.Dir=='V')} V)\".Display();\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"Slots extraits :\");\n",
+    "foreach (var s in slots)\n",
+    "    sb.AppendLine($\"  ({s.Row},{s.Col}) {s.Dir} longueur {s.Length}\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "babea4d9-fcba-4de9-a453-59d4c610d188",
+   "metadata": {},
+   "source": [
+    "### 1.1 Intersections entre slots\n",
+    "\n",
+    "Deux slots se croisent ssi l'un est horizontal, l'autre vertical, et la case de croisement appartient aux deux. A l'intersection, la lettre du slot H a une position $i$ et celle du slot V une position $j$ ; elles doivent etre egales dans toute solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8194c326-1ee5-41ce-9fb9-dba6b464e1e6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:21.133691Z",
+     "iopub.status.busy": "2026-07-06T18:49:21.133473Z",
+     "iopub.status.idle": "2026-07-06T18:49:21.284151Z",
+     "shell.execute_reply": "2026-07-06T18:49:21.283842Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Intersections detectees : 7 (paires de slots se croisant)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slots[0] x slots[3] : pos 0 = pos 0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slots[0] x slots[4] : pos 2 = pos 0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slots[1] x slots[3] : pos 0 = pos 2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slots[1] x slots[4] : pos 2 = pos 2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slots[1] x slots[5] : pos 4 = pos 1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Intersection de deux slots : (position dans slot1, position dans slot2) ou null.\n",
+    "static (int i1, int i2)? Intersect(Slot a, Slot b)\n",
+    "{\n",
+    "    // Un horizontal, l'autre vertical.\n",
+    "    Slot h = a.Dir == 'H' ? a : b;\n",
+    "    Slot v = a.Dir == 'H' ? b : a;\n",
+    "    if (a.Dir == b.Dir) return null;\n",
+    "    // Le slot H couvre la ligne h.Row, colonnes h.Col .. h.Col+h.Length-1.\n",
+    "    // Le slot V couvre la colonne v.Col, lignes v.Row .. v.Row+v.Length-1.\n",
+    "    // Croisement a la case (h.Row, v.Col) si v.Col dans [h.Col, h.Col+h.Length-1]\n",
+    "    // et h.Row dans [v.Row, v.Row+v.Length-1].\n",
+    "    if (v.Col >= h.Col && v.Col < h.Col + h.Length &&\n",
+    "        h.Row >= v.Row && h.Row < v.Row + v.Length)\n",
+    "    {\n",
+    "        int iH = v.Col - h.Col;   // position dans le slot H\n",
+    "        int iV = h.Row - v.Row;   // position dans le slot V\n",
+    "        // Retourner dans l'ordre (a, b).\n",
+    "        return a.Dir == 'H' ? (iH, iV) : (iV, iH);\n",
+    "    }\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "// Pre-calcul de toutes les intersections d'une liste de slots.\n",
+    "// intersections[(i,j)] = (pos dans slot i, pos dans slot j).\n",
+    "static Dictionary<(int,int),(int,int)> AllIntersections(List<Slot> slots)\n",
+    "{\n",
+    "    var inter = new Dictionary<(int,int),(int,int)>();\n",
+    "    for (int i = 0; i < slots.Count; i++)\n",
+    "        for (int j = i+1; j < slots.Count; j++)\n",
+    "        {\n",
+    "            var x = Intersect(slots[i], slots[j]);\n",
+    "            if (x is (int p1, int p2)) inter[(i,j)] = (p1,p2);\n",
+    "        }\n",
+    "    return inter;\n",
+    "}\n",
+    "\n",
+    "var inter = AllIntersections(slots);\n",
+    "$\"Intersections detectees : {inter.Count} (paires de slots se croisant)\".Display();\n",
+    "foreach (var kv in inter.Take(5))\n",
+    "    $\"  slots[{kv.Key.Item1}] x slots[{kv.Key.Item2}] : pos {kv.Value.Item1} = pos {kv.Value.Item2}\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d612d59-fcfc-4a3a-ae87-874f27e9aada",
+   "metadata": {},
+   "source": [
+    "## 2. Solveur Backtracking (from-scratch)\n",
+    "\n",
+    "On assigne les slots un par un. Pour chaque slot, on essaie chaque mot du dictionnaire de la bonne longueur ; on accepte le mot s'il est **compatible** avec les slots deja assignes qui le croisent (meme lettre a l'intersection). On recurse jusqu'a ce que tous les slots soient assignes (succes) ou qu'aucun mot ne convienne (echec -> retour arriere).\n",
+    "\n",
+    "**Heuristique MRV (Minimum Remaining Values)** : on choisit a chaque etape le slot non-assigne avec le **moins** de candidats restants, ce qui reduit drastiquement la taille de l'arbre de recherche."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0ecfbc07-3964-4050-bdd2-a21fad23254d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:21.285421Z",
+     "iopub.status.busy": "2026-07-06T18:49:21.285211Z",
+     "iopub.status.idle": "2026-07-06T18:49:21.499031Z",
+     "shell.execute_reply": "2026-07-06T18:49:21.498614Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver pret (backtracking + MRV + verification intersections)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Compatible : un mot candidat pour slot 'i' respecte-t-il les intersections avec les slots deja assignes ?\n",
+    "static bool Compatible(int i, string word, List<Slot> slots, Dictionary<(int,int),(int,int)> inter, Dictionary<int,string> assignment)\n",
+    "{\n",
+    "    foreach (var kv in inter)\n",
+    "    {\n",
+    "        int a = kv.Key.Item1, b = kv.Key.Item2;\n",
+    "        int other = -1; int posI = -1, posOther = -1;\n",
+    "        if (a == i) { other = b; posI = kv.Value.Item1; posOther = kv.Value.Item2; }\n",
+    "        else if (b == i) { other = a; posI = kv.Value.Item2; posOther = kv.Value.Item1; }\n",
+    "        else continue;\n",
+    "        if (!assignment.ContainsKey(other)) continue;   // l'autre pas encore assigne\n",
+    "        if (word[posI] != assignment[other][posOther]) return false;\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Backtracking avec heuristique MRV. Retourne l'assignation complete ou null.\n",
+    "static Dictionary<int,string>? SolveBacktrack(List<Slot> slots, Dictionary<int,List<string>> dictByLen, Dictionary<(int,int),(int,int)> inter)\n",
+    "{\n",
+    "    var assignment = new Dictionary<int,string>();\n",
+    "    bool Recurse()\n",
+    "    {\n",
+    "        if (assignment.Count == slots.Count) return true;   // tous assignes\n",
+    "        // MRV : slot non-assigne avec le moins de candidats compatibles.\n",
+    "        int best = -1; int bestCount = int.MaxValue; List<string>? bestCands = null;\n",
+    "        for (int i = 0; i < slots.Count; i++)\n",
+    "        {\n",
+    "            if (assignment.ContainsKey(i)) continue;\n",
+    "            int len = slots[i].Length;\n",
+    "            var cands = dictByLen.GetValueOrDefault(len, new List<string>())\n",
+    "                        .Where(w => Compatible(i, w, slots, inter, assignment)).ToList();\n",
+    "            if (cands.Count < bestCount) { bestCount = cands.Count; best = i; bestCands = cands; if (bestCount == 0) break; }\n",
+    "        }\n",
+    "        if (bestCands == null || bestCands.Count == 0) return false;\n",
+    "        foreach (var w in bestCands)\n",
+    "        {\n",
+    "            assignment[best] = w;\n",
+    "            if (Recurse()) return true;\n",
+    "            assignment.Remove(best);\n",
+    "        }\n",
+    "        return false;\n",
+    "    }\n",
+    "    return Recurse() ? assignment : null;\n",
+    "}\n",
+    "\"Solver pret (backtracking + MRV + verification intersections).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d2613b6-0149-4151-a7af-6cc99740bdc3",
+   "metadata": {},
+   "source": [
+    "### 2.1 Resolution sur la grille exemple\n",
+    "\n",
+    "On construit un dictionnaire reduit indexe par longueur, puis on lance le backtracking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "07a5b9bb-c318-4424-a9a3-27c179a5be13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:21.500633Z",
+     "iopub.status.busy": "2026-07-06T18:49:21.500422Z",
+     "iopub.status.idle": "2026-07-06T18:49:21.665758Z",
+     "shell.execute_reply": "2026-07-06T18:49:21.665424Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solution trouvee : 6 slots assignes"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slot 0 (H @ 0,0, len 4) = CODE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slot 1 (H @ 2,0, len 5) = DEPTH"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slot 2 (H @ 4,1, len 4) = SHIP"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slot 3 (V @ 0,0, len 4) = CODE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slot 4 (V @ 0,2, len 5) = DEPTH"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  slot 5 (V @ 1,4, len 4) = SHIP"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Dictionnaire reduit indexe par longueur (mots majuscules sans accents).\n",
+    "var dictionary = new Dictionary<int,List<string>> {\n",
+    "    [2] = new(){ \"AI\", \"OK\", \"GO\", \"NO\", \"OR\", \"AN\", \"AT\", \"IN\", \"IS\", \"IT\", \"ON\", \"UP\", \"US\" },\n",
+    "    [3] = new(){ \"CAT\", \"DOG\", \"RUN\", \"SUN\", \"TOP\", \"KEY\", \"ICE\", \"OLD\", \"NEW\", \"BAR\", \"FOR\", \"OUT\", \"TWO\", \"ONE\", \"SIX\", \"TEN\", \"AGE\", \"AIR\", \"ART\", \"BAD\", \"BAG\", \"BED\", \"BIG\", \"BIT\", \"BOX\", \"BOY\", \"BUS\", \"BUY\", \"CAR\", \"CUP\", \"CUT\", \"DAY\", \"DRY\", \"EAT\", \"END\", \"EYE\", \"FAR\", \"FEW\", \"FLY\", \"FUN\" },\n",
+    "    [4] = new(){ \"CODE\", \"DATA\", \"FILE\", \"GAME\", \"GRID\", \"HASH\", \"HELP\", \"IDEA\", \"INFO\", \"JAZZ\", \"JOIN\", \"JUMP\", \"KEYS\", \"KIND\", \"LAKE\", \"LAMP\", \"LOAD\", \"LOOP\", \"NODE\", \"OPEN\", \"PATH\", \"PLAN\", \"PLAY\", \"READ\", \"REST\", \"ROOT\", \"RULE\", \"SAVE\", \"SEED\", \"SHIP\", \"SHOW\", \"SIGN\", \"SIZE\", \"SLOT\", \"STAR\", \"STOP\", \"TASK\", \"TEST\", \"TEXT\", \"TIME\", \"TREE\", \"TYPE\", \"USER\", \"VIEW\", \"WAIT\", \"WALK\", \"WAVE\", \"WIND\", \"WORD\", \"WORK\", \"ZERO\" },\n",
+    "    [5] = new(){ \"ALPHA\", \"ARRAY\", \"BASIC\", \"BRAIN\", \"BUILD\", \"CACHE\", \"CHAIN\", \"CHAR\", \"CHECK\", \"CLASS\", \"CLEAR\", \"CLICK\", \"CODES\", \"DEBUG\", \"DEPTH\", \"ENTRY\", \"ERROR\", \"EVENT\", \"FALSE\", \"FETCH\", \"FIELD\", \"FILES\", \"FLAGS\", \"FLOAT\", \"FRAME\", \"GRAPH\", \"GROUP\", \"HEAP\", \"INPUT\", \"LOGIC\", \"LOOP\", \"MATCH\", \"MODEL\", \"MOTOR\", \"NODES\", \"NORTH\", \"OBJECT\", \"ORDER\", \"OUTPUT\", \"PARSE\", \"PHASE\", \"POINT\", \"PRINT\", \"QUEUE\", \"RANGE\", \"RIGHT\", \"ROUND\", \"SCOPE\", \"SHARE\", \"SHEET\", \"SHIFT\", \"SIGHT\", \"SLEEP\", \"SLOT\", \"STACK\", \"STATE\", \"STORE\", \"STYLE\", \"SWING\", \"TABLE\", \"TERMS\", \"THREE\", \"THROW\", \"TOPIC\", \"TRACE\", \"TRACK\", \"TRAIN\", \"TREE\", \"TRUST\", \"TRUTH\", \"TUPLE\", \"TYPE\", \"UNCLE\", \"UNDER\", \"UNION\", \"UNTIL\", \"USAGE\", \"VALID\", \"VALUE\", \"VIDEO\", \"WORLD\" },\n",
+    "};\n",
+    "\n",
+    "var solution = SolveBacktrack(slots, dictionary, inter);\n",
+    "if (solution != null)\n",
+    "{\n",
+    "    $\"Solution trouvee : {solution.Count} slots assignes\".Display();\n",
+    "    foreach (var kv in solution.OrderBy(x => x.Key))\n",
+    "        $\"  slot {kv.Key} ({slots[kv.Key].Dir} @ {slots[kv.Key].Row},{slots[kv.Key].Col}, len {slots[kv.Key].Length}) = {kv.Value}\".Display();\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    \"Aucune solution (dictionnaire trop petit ou grille trop contrainte).\".Display();\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b7755a-5e5e-47d0-916c-e56f3200efd0",
+   "metadata": {},
+   "source": [
+    "### 2.2 Affichage de la grille remplie\n",
+    "\n",
+    "On reconstruit la grille de lettres depuis l'assignation des slots et on l'affiche en ASCII."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0d46b66a-511e-4c60-81b7-1ffa3d3b0d5e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:21.667011Z",
+     "iopub.status.busy": "2026-07-06T18:49:21.666808Z",
+     "iopub.status.idle": "2026-07-06T18:49:21.723293Z",
+     "shell.execute_reply": "2026-07-06T18:49:21.722945Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Grille remplie :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "CODE#\r\n",
+       "O#E#S\r\n",
+       "DEPTH\r\n",
+       "E#T#I\r\n",
+       "#SHIP\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Affiche la grille remplie : '#' = case noire, '.' = case blanche isolee, sinon la lettre.\n",
+    "static string RenderFilled(CrosswordGrid g, List<Slot> slots, Dictionary<int,string>? assignment)\n",
+    "{\n",
+    "    char[,] letters = new char[g.Rows, g.Cols];\n",
+    "    for (int r = 0; r < g.Rows; r++)\n",
+    "        for (int c = 0; c < g.Cols; c++) letters[r,c] = g.IsWhite(r,c) ? '.' : '#';\n",
+    "    if (assignment != null)\n",
+    "    {\n",
+    "        foreach (var kv in assignment)\n",
+    "        {\n",
+    "            var s = slots[kv.Key]; var w = kv.Value;\n",
+    "            for (int k = 0; k < s.Length; k++)\n",
+    "            {\n",
+    "                int r = s.Dir == 'H' ? s.Row : s.Row + k;\n",
+    "                int c = s.Dir == 'H' ? s.Col + k : s.Col;\n",
+    "                letters[r,c] = w[k];\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    var sb = new StringBuilder();\n",
+    "    for (int r = 0; r < g.Rows; r++)\n",
+    "    {\n",
+    "        for (int c = 0; c < g.Cols; c++) sb.Append(letters[r,c]);\n",
+    "        sb.AppendLine();\n",
+    "    }\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "Show(\"Grille remplie :\");\n",
+    "Show(RenderFilled(grid, slots, solution));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f55eef4-e0c6-4aa3-ab67-91e898850730",
+   "metadata": {},
+   "source": [
+    "## 3. Propagation de contraintes (forward-checking)\n",
+    "\n",
+    "Le backtracking pur verifie la compatibilite seulement avec les slots **deja assignes**. Le **forward-checking** va plus loin : apres chaque assignation, on filtre les candidats des slots **non encore assignes** qui croisent le slot courant, et on detecte les **domaines vides** (un slot sans candidat restant) pour couper la recherche plus tot.\n",
+    "\n",
+    "On instrumente le solveur pour compter les **noeuds explores** et comparer les deux strategies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f59d02b3-431b-4f8e-b4cb-c19b4b34c66e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:21.724616Z",
+     "iopub.status.busy": "2026-07-06T18:49:21.724392Z",
+     "iopub.status.idle": "2026-07-06T18:49:21.834461Z",
+     "shell.execute_reply": "2026-07-06T18:49:21.834076Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Forward-checking : solution trouvee en 7 noeuds"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Backtracking + forward-checking : apres chaque assignation, on elimine des candidats\n",
+    "// des slots non-assignes croisant le slot courant. Coupe si un domaine devient vide.\n",
+    "static (Dictionary<int,string>? sol, int nodes) SolveForwardCheck(List<Slot> slots, Dictionary<int,List<string>> dictByLen, Dictionary<(int,int),(int,int)> inter)\n",
+    "{\n",
+    "    int nodes = 0;\n",
+    "    var domains = new Dictionary<int, HashSet<string>>();\n",
+    "    for (int i = 0; i < slots.Count; i++)\n",
+    "        domains[i] = new HashSet<string>(dictByLen.GetValueOrDefault(slots[i].Length, new List<string>()));\n",
+    "    var assignment = new Dictionary<int,string>();\n",
+    "    bool Recurse()\n",
+    "    {\n",
+    "        nodes++;\n",
+    "        if (assignment.Count == slots.Count) return true;\n",
+    "        // MRV sur les domaines courants.\n",
+    "        int best = -1; int bestCount = int.MaxValue;\n",
+    "        for (int i = 0; i < slots.Count; i++)\n",
+    "        {\n",
+    "            if (assignment.ContainsKey(i)) continue;\n",
+    "            int cnt = domains[i].Count(d => Compatible(i, d, slots, inter, assignment));\n",
+    "            if (cnt < bestCount) { bestCount = cnt; best = i; if (cnt == 0) break; }\n",
+    "        }\n",
+    "        if (bestCount == 0) return false;\n",
+    "        var cands = domains[best].Where(d => Compatible(best, d, slots, inter, assignment)).ToList();\n",
+    "        foreach (var w in cands)\n",
+    "        {\n",
+    "            assignment[best] = w;\n",
+    "            // Forward-check : sauver et filtrer les domaines des slots croisant 'best'.\n",
+    "            var saved = new Dictionary<int, HashSet<string>>();\n",
+    "            foreach (var kv in inter)\n",
+    "            {\n",
+    "                int a = kv.Key.Item1, b = kv.Key.Item2; int other = -1; int posBest = -1, posOther = -1;\n",
+    "                if (a == best) { other = b; posBest = kv.Value.Item1; posOther = kv.Value.Item2; }\n",
+    "                else if (b == best) { other = a; posBest = kv.Value.Item2; posOther = kv.Value.Item1; }\n",
+    "                else continue;\n",
+    "                if (assignment.ContainsKey(other) || saved.ContainsKey(other)) continue;\n",
+    "                saved[other] = new HashSet<string>(domains[other]);\n",
+    "                domains[other].RemoveWhere(d => d[posOther] != w[posBest]);\n",
+    "                if (domains[other].Count == 0) { assignment.Remove(best); goto restore; }\n",
+    "            }\n",
+    "            if (Recurse()) return true;\n",
+    "            restore:\n",
+    "            foreach (var kv in saved) domains[kv.Key] = kv.Value;\n",
+    "            assignment.Remove(best);\n",
+    "        }\n",
+    "        return false;\n",
+    "    }\n",
+    "    return (Recurse() ? assignment : null, nodes);\n",
+    "}\n",
+    "\n",
+    "var (solFC, nodesFC) = SolveForwardCheck(slots, dictionary, inter);\n",
+    "$\"Forward-checking : {(solFC != null ? \"solution trouvee\" : \"echec\")} en {nodesFC} noeuds\".Display();\n",
+    "// Backtracking simple instrumente (meme MRV, sans FC) pour comparaison.\n",
+    "int nodesBT = 0; // on relance un comptage leger via SolveBacktrack instrumente ci-dessous.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9435603-22df-4b68-88f2-e1129dfebf61",
+   "metadata": {},
+   "source": [
+    "### 3.1 Comparaison backtracking vs forward-checking\n",
+    "\n",
+    "Sur des grilles plus grandes ou des dictionnaires plus pauvres, le forward-checking explore beaucoup moins de noeuds : il detecte tôt les culs-de-sac."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e161d4a3-7c8c-4b6b-aa9d-04811e127d74",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:21.835746Z",
+     "iopub.status.busy": "2026-07-06T18:49:21.835549Z",
+     "iopub.status.idle": "2026-07-06T18:49:21.913021Z",
+     "shell.execute_reply": "2026-07-06T18:49:21.912785Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       " Strategie          | Noeuds explores | Solution\r\n",
+       "---------------------------------------------\r\n",
+       " Backtracking (MRV) |               8 | oui\r\n",
+       " Forward-checking   |               7 | oui\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verdict : forward-checking explore 7 noeuds vs 8 pour le backtracking simple (MRV deja actif dans les deux)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Backtracking simple re-instrumente pour compter les noeuds (sans forward-checking).\n",
+    "static (Dictionary<int,string>? sol, int nodes) SolveBacktrackCounted(List<Slot> slots, Dictionary<int,List<string>> dictByLen, Dictionary<(int,int),(int,int)> inter)\n",
+    "{\n",
+    "    int nodes = 0;\n",
+    "    var assignment = new Dictionary<int,string>();\n",
+    "    bool Recurse()\n",
+    "    {\n",
+    "        nodes++;\n",
+    "        if (assignment.Count == slots.Count) return true;\n",
+    "        int best = -1, bestCount = int.MaxValue; List<string>? bestCands = null;\n",
+    "        for (int i = 0; i < slots.Count; i++)\n",
+    "        {\n",
+    "            if (assignment.ContainsKey(i)) continue;\n",
+    "            var cands = dictByLen.GetValueOrDefault(slots[i].Length, new List<string>()).Where(w => Compatible(i,w,slots,inter,assignment)).ToList();\n",
+    "            if (cands.Count < bestCount) { bestCount = cands.Count; best = i; bestCands = cands; if (bestCount == 0) break; }\n",
+    "        }\n",
+    "        if (bestCands == null || bestCands.Count == 0) return false;\n",
+    "        foreach (var w in bestCands) { assignment[best] = w; if (Recurse()) return true; assignment.Remove(best); }\n",
+    "        return false;\n",
+    "    }\n",
+    "    return (Recurse() ? assignment : null, nodes);\n",
+    "}\n",
+    "\n",
+    "var (solBT, nodesBT2) = SolveBacktrackCounted(slots, dictionary, inter);\n",
+    "var sb2 = new StringBuilder();\n",
+    "sb2.AppendLine(\" Strategie          | Noeuds explores | Solution\");\n",
+    "sb2.AppendLine(new string('-', 45));\n",
+    "sb2.AppendLine($\" Backtracking (MRV) | {nodesBT2,15} | {(solBT != null ? \"oui\" : \"non\")}\");\n",
+    "sb2.AppendLine($\" Forward-checking   | {nodesFC,15} | {(solFC != null ? \"oui\" : \"non\")}\");\n",
+    "Show(sb2.ToString());\n",
+    "$\"Verdict : forward-checking explore {nodesFC} noeuds vs {nodesBT2} pour le backtracking simple (MRV deja actif dans les deux).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f90f0adc-7028-4879-8879-c782f9c2e323",
+   "metadata": {},
+   "source": [
+    "## 4. Generation de grille aleatoire\n",
+    "\n",
+    "On genere une grille en placant des cases noires avec une probabilite donnee, puis on verifie qu'elle admet des slots (sinon on regenere). La **densite** de cases noires controle la difficulte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8d8f1773-aef4-42a1-8ad6-1b19894587bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:21.914588Z",
+     "iopub.status.busy": "2026-07-06T18:49:21.914385Z",
+     "iopub.status.idle": "2026-07-06T18:49:22.018078Z",
+     "shell.execute_reply": "2026-07-06T18:49:22.017770Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Grille aleatoire 6x6 (densite noire ~0.20) : 14 slots"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Grille vide (# = noire, . = blanche) :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       ".##.#.\r\n",
+       "..#...\r\n",
+       ".....#\r\n",
+       "...##.\r\n",
+       "..#.#.\r\n",
+       "..##..\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Generation aleatoire d'une grille avec densite de cases noires.\n",
+    "static CrosswordGrid GenerateRandomGrid(int rows, int cols, double blackDensity)\n",
+    "{\n",
+    "    var rng = new Random(42);\n",
+    "    bool[,] w;\n",
+    "    do\n",
+    "    {\n",
+    "        w = new bool[rows, cols];\n",
+    "        for (int r = 0; r < rows; r++)\n",
+    "            for (int c = 0; c < cols; c++)\n",
+    "                w[r,c] = rng.NextDouble() >= blackDensity;\n",
+    "    } while (ExtractSlots(new CrosswordGrid(w)).Count == 0);   // au moins 1 slot\n",
+    "    return new CrosswordGrid(w);\n",
+    "}\n",
+    "\n",
+    "var g2 = GenerateRandomGrid(6, 6, 0.20);\n",
+    "var slots2 = ExtractSlots(g2);\n",
+    "$\"Grille aleatoire 6x6 (densite noire ~0.20) : {slots2.Count} slots\".Display();\n",
+    "Show(\"Grille vide (# = noire, . = blanche) :\");\n",
+    "Show(RenderFilled(g2, slots2, null));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2de7a56f-d85a-4a3f-8ca7-a25b31157b03",
+   "metadata": {},
+   "source": [
+    "## 5. Exercices\n",
+    "\n",
+    "> **Convention C.1** : les stubs s'executent sans erreur (jamais `throw`). Remplir le corps, re-executer, verifier.\n",
+    "\n",
+    "### Exercice 1 — Compter les mots elimines par propagation\n",
+    "\n",
+    "Etant donne une grille et un dictionnaire, pour chaque slot, compter combien de mots du dictionnaire (de la bonne longueur) sont **elimines** par les intersections avec les slots deja assignes.\n",
+    "\n",
+    "**Indice** : pour chaque slot non-assigne, filtrer les mots compatibles avec l'assignation courante et soustraire du total."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9cd6b723-875d-4c31-9d4f-d0ed5d948ebd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:22.019880Z",
+     "iopub.status.busy": "2026-07-06T18:49:22.019597Z",
+     "iopub.status.idle": "2026-07-06T18:49:22.072546Z",
+     "shell.execute_reply": "2026-07-06T18:49:22.072344Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : nombre total de mots elimines par propagation apres une assignation partielle.\n",
+    "// TODO etudiant : retourner le compte total sur tous les slots non-assignes.\n",
+    "static int CountEliminatedWords(CrosswordGrid g, Dictionary<int,List<string>> dictByLen, List<Slot> slots, Dictionary<(int,int),(int,int)> inter, Dictionary<int,string> assignment)\n",
+    "{\n",
+    "    int total = 0;\n",
+    "    // Indice : pour chaque slot non-assigne, total += (taille domaine initial - candidats compatibles restants).\n",
+    "    return total;   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice a completer\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c699955-eec7-4e76-8266-226548931d15",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Generation de grille optimisee (maximiser les intersections)\n",
+    "\n",
+    "Generer une grille qui maximise le nombre d'intersections entre slots (grille plus riche, mots croises plus serres).\n",
+    "\n",
+    "**Indice** : balayer plusieurs grilles aleatoires et garder celle avec le plus d'intersections via `AllIntersections`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c558989c-c547-49e3-92e0-c85491e5b61d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:22.073926Z",
+     "iopub.status.busy": "2026-07-06T18:49:22.073722Z",
+     "iopub.status.idle": "2026-07-06T18:49:22.148501Z",
+     "shell.execute_reply": "2026-07-06T18:49:22.148232Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : grille maximisant le nombre d'intersections parmi N tirages.\n",
+    "// TODO etudiant : retourner la meilleure grille et son compte d'intersections.\n",
+    "static (CrosswordGrid best, int interCount) GenerateOptimizedGrid(int rows, int cols, int trials = 20)\n",
+    "{\n",
+    "    // Indice : GenerateRandomGrid + ExtractSlots + AllIntersections, garder le max.\n",
+    "    return (GenerateRandomGrid(rows, cols, 0.20), 0);   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice a completer\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "990976dc-afa9-4ba9-8f23-0f1119a7d11d",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Contraintes de theme (reflexion)\n",
+    "\n",
+    "Etendre le solveur pour n'utiliser que des mots d'un **theme** donne (ex : informatique). Quelle structure de dictionnaire permet de filtrer efficacement par theme sans parcourir toute la liste ?\n",
+    "\n",
+    "**Indice** : indexer le dictionnaire par `(theme, longueur)` plutot que par `longueur` seule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "feed2ae5-54b8-442b-b7e3-73b7c8afe25a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T18:49:22.150104Z",
+     "iopub.status.busy": "2026-07-06T18:49:22.149848Z",
+     "iopub.status.idle": "2026-07-06T18:49:22.206942Z",
+     "shell.execute_reply": "2026-07-06T18:49:22.206377Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 (reflexion) : structure de dictionnaire par theme.\n",
+    "// TODO etudiant : proposer une signature et un stub de filtrage par theme.\n",
+    "// Indice : Dictionary<(string theme, int length), List<string>>\n",
+    "static List<string> WordsByTheme(Dictionary<(string,int),List<string>> themedDict, string theme, int length)\n",
+    "{\n",
+    "    // TODO etudiant : retourner themedDict[(theme, length)] si present, sinon liste vide.\n",
+    "    return new List<string>();   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice a completer\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b628e519-a080-4b6b-b003-694f41c1f3ea",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "### Ce que vous avez appris\n",
+    "\n",
+    "- **Modelisation CSP** — grille, slots (runs maximaux de cases blanches), intersections (cases de croisement partageant une lettre).\n",
+    "- **Extraction des slots** — scan horizontal/vertical, runs de longueur >= 2.\n",
+    "- **Backtracking** — assignation slot par slot, verification de compatibilite aux intersections, heuristique **MRV** (slot le plus contraint d'abord).\n",
+    "- **Forward-checking** — apres chaque assignation, filtrage des domaines des slots croisant le courant ; coupe des culs-de-sac (domaine vide) plus tot que le backtracking pur.\n",
+    "- **Generation aleatoire** — densite de cases noires controle la difficulte.\n",
+    "\n",
+    "### Pont avec la version Python\n",
+    "\n",
+    "La version Python ([App-16-Crossword-CSP.ipynb](App-16-Crossword-CSP.ipynb)) combine un solveur OR-Tools CP-SAT (boite noire) et des solveurs backtracking + propagation from-scratch. Ce twin C# deroule les solveurs from-scratch en C# pur (BCL .NET 9, 0 NuGet) — les internes que masque OR-Tools — et la viz matplotlib devient un rendu ASCII de la grille. Le notebook [App-15-SportsScheduling](App-15-SportsScheduling.ipynb) couvre un autre CSP (planification sportive).\n",
+    "\n",
+    "### Parite #4956\n",
+    "\n",
+    "Twin de parite legitime (Prong B) : OR-Tools CP-SAT cote Python vs backtracking + forward-checking from-scratch cote C#. L'interet est la visibilite des internes (extraction de slots, MRV, forward-checking) et la confirmation que les deux approches convergent vers la meme solution sur la grille exemple.\n",
+    "\n",
+    "---\n",
+    "*Marathon #4956 (parite .NET <-> Python).*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": ".net-csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -521,6 +521,7 @@ Search/
 │   │   ├── App-11-Picross.ipynb
 │   │   ├── App-15-SportsScheduling.ipynb
 │   │   ├── App-16-Crossword-CSP.ipynb
+│   │   ├── App-16-Crossword-CSP-Csharp.ipynb   # Twin C# backtracking + forward-checking from-scratch (marathon #4956, Prong B)
 │   │   └── App-19-ProceduralGeneration-WFC.ipynb
 │   │
 │   └── Hybrid/                            # Metaheuristiques (7 notebooks)


### PR DESCRIPTION
Twin C# (.NET Interactive) de \`App-16-Crossword-CSP.ipynb\` — marathon **#4956** (parité .NET ⇄ Python).

## Summary

Solveurs de mots croisés **from-scratch** (BCL .NET 9, **0 NuGet**), viz matplotlib → rendu ASCII grille. **Prong B** (EPIC #3801) : Python s'appuie sur OR-Tools CP-SAT (boîte noire) ; C# déroule le backtracking + forward-checking à la main (les internes pédagogiques).

| Algorithme | Implémentation C# | Cas canonique vérifié |
|-----------|-------------------|----------------------|
| **Slot extraction** | runs maximaux H/V de cases blanches ≥ 2 | grille 5×5 → 6 slots (3H, 3V), 7 intersections |
| **Backtracking + MRV** | assignation par slot, compatibilité intersections, heuristique Minimum Remaining Values | solution CODE/DEPTH/SHIP (H) × CODE/DEPTH/SHIP (V), consistante à chaque croisement |
| **Forward-checking** | filtrage des domaines après chaque assignation, coupe des domaines vides | 7 nœuds vs 8 pour backtracking simple (MRV actif dans les 2) |

## Validation (HARD rules)

- **C.2 EXEC_PROVED** : 11/11 cellules code `execution_count` 1-11, 0 erreur, **0 warning CS** (`#nullable enable` ajouté), 0 exec-no-output.
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`. 3 exercices stub (`// TODO étudiant`, `return`).
- **0 path-leak** : sorties ne contiennent aucun chemin machine.
- **§E propre** : CATALOG byte-identique à main (HARD rule 1, regen cron-only). README +1 ligne arbre structure (cohérent avec App-6-Minesweeper-Csharp, pattern marathon #4956 = tree line only). Comptes §E gérés par passes d'audit dédiées (hors scope de cette PR substance).
- **Scope atomique** : 2 fichiers (+1108/-0).

## Math vérifiée

- **Solution** : slot 0 (H @ 0,0, len 4) = CODE, slot 3 (V @ 0,0, len 4) = CODE → intersection (0,0) = 'C' ✓. slot 1 (H @ 2,0, len 5) = DEPTH, slot 4 (V @ 0,2, len 5) = DEPTH → intersection (2,2) = 'P' ✓. Toutes 7 intersections consistent.
- **Forward-checking** : après chaque assignation, filtre les mots des slots croisant le courant par lettre incompatible ; coupe si un domaine devient vide. Explore strictement ≤ backtracking simple (7 ≤ 8 nœuds).

## Pont Python

La version Python (`App-16-Crossword-CSP.ipynb`) combine un solveur OR-Tools CP-SAT (boîte noire) et des solveurs backtracking + propagation from-scratch. Ce twin C# déroule les solveurs from-scratch en C# pur — les internes que masque OR-Tools.

See #4956 (marathon parité .NET ⇄ Python), #3801 (Prong B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)