### PR TITLE
i18n(#4980): decision_theory_lean Gittins EN siblings — fully bilingual lake

### DIFF
--- a/.github/workflows/lean-decision-theory.yml
+++ b/.github/workflows/lean-decision-theory.yml
@@ -4,11 +4,16 @@ name: Lean CI (decision_theory_lean)
 # at the Probas series root, lifted from Probas/Infer/gittins_lean in PR #4058
 # (lake content unchanged by the lift). First module: Gittins index. Research scaffolding.
 #
-# sorry-filter-mode=standalone-tactic, baseline=3: a CONSERVATIVE regression floor
+# sorry-filter-mode=standalone-tactic, baseline=4: a CONSERVATIVE regression floor
 # counting only standalone `sorry` tokens (never false-positives on prose; catches
 # any NEW standalone sorry; UNDERCOUNTS inline-commented ones). Authoritative sorry
-# profile: see decision_theory_lean/README.md (Discount.lean = 0 since PR #2911,
-# GittinsTheorem.lean = 5). Consolidated per ai-01 DRY decision (matrix). See lean-build.yml.
+# profile: GittinsTheorem.lean = 2 (INTRINSIC gittins_optimality, #4039 MDP barrier),
+# mirrored 1:1 in the EN sibling GittinsTheorem_en.lean = 2 (i18n #4980 mandates
+# byte-identical proofs FR↔EN, including INTRINSIC sorries), lake total = 4.
+# Discount.lean / Discount_en.lean = 0 since PR #2911. Raised 3→4 in the i18n PR
+# adding the Gittins_en siblings (documented justification: faithful EN mirror of
+# an existing INTRINSIC sorry, NOT a regression). Consolidated per ai-01 DRY
+# decision (matrix). See lean-build.yml.
 
 on:
   push:
@@ -33,5 +38,5 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/Probas/decision_theory_lean
       display-name: decision_theory_lean
-      sorry-baseline: "3"
+      sorry-baseline: "4"
       sorry-filter-mode: standalone-tactic

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Basic_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Basic_en.lean
@@ -1,0 +1,39 @@
+import Mathlib.Data.Real.Basic
+
+/-!
+# Basic Definitions — Multi-Armed Bandits
+
+Core types for the bandit problem: arms, instances, policies, and value functions.
+Means and discount factors are carried on `ℝ` (not `Float`) so that order laws are
+reflexive — a bandit mean is a real number, never a `NaN`. Sampled reward histories
+stay `Float` (empirical quantities); the two notions are deliberately distinct.
+-/
+
+namespace Gittins_en
+
+/-- A bandit arm characterized by its true mean reward. -/
+structure BanditArm where
+  name : String
+  trueMean : ℝ
+
+/-- A bandit instance: a collection of arms with a discount factor. -/
+structure BanditInstance where
+  arms : Array BanditArm
+  discount : ℝ  -- gamma in (0, 1)
+
+/-- A policy maps each time step to the index of the arm to pull. -/
+def Policy := Nat → Nat
+
+/-- A reward history for a single arm. -/
+def RewardHistory := List Float
+
+/-- Number of times an arm has been pulled. -/
+def pullCount (history : RewardHistory) : Nat := history.length
+
+/-- Empirical mean from a reward history. Returns 0 for empty history. -/
+def empiricalMean (history : RewardHistory) : Float :=
+  match history with
+  | [] => 0.0
+  | _ => history.foldl (· + ·) 0.0 / history.length.toFloat
+
+end Gittins_en

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Discount_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Discount_en.lean
@@ -1,0 +1,107 @@
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Data.Real.Basic
+
+/-!
+# Geometric Discount — Proved Identities
+
+Lemmas about geometric discounting using Mathlib's real analysis.
+These are the building blocks for the Gittins index formalization.
+-/
+
+namespace Gittins_en
+
+open Real
+
+/-!
+## Geometric Series
+
+The geometric series Σ γ^n converges to 1/(1-γ) for |γ| < 1.
+Mathlib provides `tsum_geometric_of_lt_one` for this.
+-/
+
+/-- The partial sum of a geometric series: Σ_{k=0}^{n-1} γ^k -/
+def geometricPartialSum (γ : ℝ) (n : ℕ) : ℝ :=
+  (List.range n).foldl (fun acc k => acc + γ ^ k) 0
+
+/-!
+## Foundational facts on the finite partial sum
+
+The infinite geometric series (`∑' n, γ^n`) is handled below via Mathlib. These
+lemmas establish the elementary identities on the *finite* partial sum
+`geometricPartialSum γ n` — the empty sum, the telescoping recurrence that builds
+it term-by-term, and the textbook closed form `(1 − γ^n)/(1 − γ)` valid for
+`γ ≠ 1`. They are the finite counterpart of `geometric_series_converges` and make
+the partial-sum definition usable (it was previously defined but unused).
+-/
+
+/-- **Empty partial sum.** `geometricPartialSum γ 0 = 0` — summing over the empty
+    range `List.range 0 = []` yields the additive identity. -/
+lemma geometricPartialSum_zero (γ : ℝ) : geometricPartialSum γ 0 = 0 := by
+  simp [geometricPartialSum]
+
+/-- **Telescoping recurrence.** Each added term contributes `γ^n`:
+    `geometricPartialSum γ (n+1) = geometricPartialSum γ n + γ^n`. This is the
+    stepwise identity underlying the finite sum (and the induction engine for the
+    closed form below). -/
+lemma geometricPartialSum_succ (γ : ℝ) (n : ℕ) :
+    geometricPartialSum γ (n + 1) = geometricPartialSum γ n + γ ^ n := by
+  simp only [geometricPartialSum, List.range_succ, List.foldl_append,
+    List.foldl_cons, List.foldl_nil]
+
+/-- **Closed form of the finite partial sum** (textbook identity). For `γ ≠ 1`,
+    the partial sum `Σ_{k=0}^{n-1} γ^k` equals `(1 − γ^n) / (1 − γ)`. Proved by
+    induction on `n` using the recurrence `geometricPartialSum_succ`. This is the
+    finite analogue of `geometric_series_converges` (which takes `n → ∞`). -/
+lemma geometricPartialSum_closed {γ : ℝ} (hγ : γ ≠ 1) (n : ℕ) :
+    geometricPartialSum γ n = (1 - γ ^ n) / (1 - γ) := by
+  have hdenom : (1:ℝ) - γ ≠ 0 := sub_ne_zero.mpr hγ.symm
+  induction n with
+  | zero => simp [geometricPartialSum]
+  | succ k ih =>
+    rw [geometricPartialSum_succ, ih]
+    field_simp [hdenom]
+    ring
+
+/-- For 0 ≤ γ < 1, the geometric series converges.
+    This wraps Mathlib's `tsum_geometric_of_lt_one`. -/
+theorem geometric_series_converges {γ : ℝ} (hγ₁ : 0 ≤ γ) (hγ₂ : γ < 1) :
+    ∑' n : ℕ, γ ^ n = 1 / (1 - γ) := by
+  rw [one_div]
+  exact tsum_geometric_of_lt_one hγ₁ hγ₂
+
+/-- For 0 ≤ γ < 1, 1 - γ > 0. -/
+lemma one_minus_gamma_pos {γ : ℝ} (h : γ < 1) (h₀ : 0 ≤ γ) : 0 < 1 - γ := by
+  linarith
+
+/-- For 0 < γ < 1, the discounted infinite sum of a constant reward r equals r/(1-γ).
+    This is the fundamental identity used in bandit value computation. -/
+theorem present_value_constant {γ r : ℝ} (hγ₁ : 0 < γ) (hγ₂ : γ < 1) (hr : 0 ≤ r) :
+    ∑' n : ℕ, γ ^ n * r = r / (1 - γ) := by
+  have hγ₁' : 0 ≤ γ := le_of_lt hγ₁
+  -- Sum_n gamma^n * r = (Sum_n gamma^n) * r = (1-gamma)^{-1} * r = r / (1-gamma)
+  rw [tsum_mul_right, tsum_geometric_of_lt_one hγ₁' hγ₂]
+  ring
+
+/-- Discount factor closer to 1 gives higher present value.
+    If γ₁ ≤ γ₂, then Σ γ₁^n ≤ Σ γ₂^n.
+
+    **Proof strategy**: rewrite both tsums via the closed-form geometric
+    identity `∑' n, γ^n = 1/(1-γ)` (`geometric_series_converges`), then reduce
+    the goal to `1/(1-γ₁) ≤ 1/(1-γ₂)`. Since `γ₁ ≤ γ₂` we have
+    `1-γ₂ ≤ 1-γ₁`, and both denominators are positive (`γ₂ < 1`), so
+    `one_div_le_one_div_of_le` closes the goal. This sidesteps the missing
+    `tsum_le_tsum` on `ℝ` (not available in Mathlib v4.30.0-rc2 for bare `ℝ`
+    series) by exploiting the closed form. -/
+theorem discount_monotone {γ₁ γ₂ : ℝ} (h₁ : 0 ≤ γ₁) (h₂ : γ₁ ≤ γ₂) (h₃ : γ₂ < 1) :
+    ∑' n : ℕ, γ₁ ^ n ≤ ∑' n : ℕ, γ₂ ^ n := by
+  have hγ₁_lt : γ₁ < 1 := lt_of_le_of_lt h₂ h₃
+  have hγ₂_nn : 0 ≤ γ₂ := le_trans h₁ h₂
+  rw [geometric_series_converges h₁ hγ₁_lt, geometric_series_converges hγ₂_nn h₃]
+  -- Goal: 1 / (1 - γ₁) ≤ 1 / (1 - γ₂)
+  -- Since γ₁ ≤ γ₂, we have 1 - γ₂ ≤ 1 - γ₁; both denominators are positive.
+  apply one_div_le_one_div_of_le
+  · exact sub_pos.mpr (by linarith)  -- 0 < 1 - γ₂
+  · linarith                        -- 1 - γ₂ ≤ 1 - γ₁
+
+end Gittins_en

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/GittinsTheorem_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/GittinsTheorem_en.lean
@@ -1,0 +1,146 @@
+import Gittins.Basic_en
+import Gittins.Discount_en
+
+/-!
+# Gittins Index Theorem — structural facts + INTRINSIC optimality
+
+This file formalizes the Gittins index for multi-armed bandits with geometric
+discounting, split into two layers:
+
+* **Provable structural facts (known-mean model).** `BanditArm` carries only the
+  true mean — no posterior distribution — so the model it represents is the
+  *known-arm* setting. There the Gittins index equals the true mean (the
+  retirement value at which playing vs. retiring is indifferent under geometric
+  discounting): `gittins_index_known_arm` holds definitionally and
+  `gittins_index_monotone_discount` holds because the index is `γ`-independent
+  for a known arm — the classical `γ`-dependence lives in the *exploration* term,
+  which is absent here (see `discount_monotone` in `Discount.lean` for the
+  `γ`-dependence of the discounted value on the `ℝ` side).
+
+* **INTRINSIC optimality (MDP-gated, court-terme).** The central
+  `gittins_optimality` theorem — the Gittins index policy maximizes the expected
+  discounted reward — requires the value-function / Bellman / optimal-stopping
+  machinery, which is absent from Mathlib. Its two `sorry` sites (the expected-
+  value operator `V` and the optimality proof) are recorded honestly as the
+  INTRINSIC barrier, not as placeholder workarounds (see #4039).
+-/
+
+namespace Gittins_en
+
+/-!
+## Gittins Index Definition
+
+The Gittins index of an arm is the supremum of "retirement values"
+such that continuing to play the arm is better than retiring with that value.
+-/
+
+/-- The Gittins index of a bandit arm.
+
+    In the **known-mean model** that `BanditArm` represents (an arm carrying only
+    its true mean — no posterior uncertainty), the Gittins index equals the true
+    mean. It is the retirement value `λ` at which playing the arm forever
+    (`μ · Σ γⁿ = μ / (1 - γ)`, see `present_value_constant` in `Discount.lean`)
+    is indifferent to retiring at `λ` (`λ / (1 - γ)`), i.e. `λ = μ`.
+
+    The `γ`-dependence and the non-triviality of the classical Gittins index live
+    entirely in the *exploration* term, which requires an uncertain posterior
+    (e.g. Beta–Bernoulli) and the optimal-stopping / Bellman machinery that is
+    absent from Mathlib. That barrier is recorded at `gittins_optimality` below
+    (INTRINSIC, court-terme, #4039). -/
+def gittinsIndex (arm : BanditArm) (γ : ℝ) (history : RewardHistory) : ℝ :=
+  arm.trueMean
+
+/-!
+## Optimality Theorem
+
+The Gittins index policy (play the arm with highest Gittins index)
+is optimal for the discounted infinite-horizon multi-armed bandit.
+-/
+
+/-- A Gittins index policy: at each step, play the arm with highest Gittins index. -/
+noncomputable def gittinsPolicy (inst : BanditInstance) (histories : Array RewardHistory) : Nat :=
+  -- Argmax of the Gittins index over the arms (in the known-mean model this is
+  -- the highest-`trueMean` arm, i.e. the greedy arm — correct for known arms).
+  ((Array.range inst.arms.size).foldl
+    (fun (best : Nat × ℝ) i =>
+      match inst.arms[i]? with
+      | none => best
+      | some arm =>
+        let g := gittinsIndex arm inst.discount (histories[i]?.getD [])
+        if g > best.2 then (i, g) else best)
+    (0, 0)).1
+
+/-- **Gittins Index Theorem** (Gittins 1979, Weber 1992): the Gittins index
+    policy maximizes the total expected discounted reward for the multi-armed
+    bandit with geometric discounting.
+
+    **INTRINSIC (MDP-gated, court-terme, #4039).** This is the central result of
+    the theory and the genuine formalization barrier. The two `sorry` sites below
+    are NOT placeholder workarounds; they record precisely what Mathlib lacks:
+
+    * `V` (the expected-value operator): formalizing `E[Σ γⁿ · r_{policy n}]`
+      requires a bandit reward-process type, a probability-coupling / expectation
+      operator over reward distributions, and an infinite-horizon discounted sum
+      over `Float` (`Discount.lean` has the `ℝ` side via Mathlib's `tsum`, not
+      the `Float` side nor the expectation).
+    * the optimality proof: requires the Bellman / dynamic-programming operator,
+      index decomposability across arms, and induction on the planning horizon —
+      i.e. a full MDP / optimal-stopping formalization.
+
+    `BanditArm` carries only `trueMean`, so even stating `V` faithfully needs
+    infrastructure beyond the current model. A complete proof is estimated at
+    ~2000–5000 lines of supporting definitions; this is left as the INTRINSIC
+    court-terme target rather than a degraded workaround.
+-/
+theorem gittins_optimality {γ : ℝ} (hγ : 0 < γ ∧ γ < 1)
+    (inst : BanditInstance) :
+    ∀ π : Policy,
+      let V (policy : Policy) : ℝ :=
+        sorry
+      V (fun _ => gittinsPolicy inst (Array.replicate inst.arms.size []))
+        ≥
+      V π := by
+  sorry
+
+/-!
+## Structural Properties (proven, known-mean model)
+
+These are the provable properties of the Gittins index in the known-mean model
+that `BanditArm` represents. They hold definitionally / by reflexivity because
+the index equals `trueMean`; the remaining open question is the MDP-gated
+`gittins_optimality` above (INTRINSIC, #4039).
+-/
+
+/-- The Gittins index of a known arm (empty history — no posterior uncertainty)
+    equals its true mean. Definitional in the known-mean model: the index is
+    calibrated to the retirement value `μ`, independent of `history` and `γ`. -/
+theorem gittins_index_known_arm (arm : BanditArm) (γ : ℝ) :
+    gittinsIndex arm γ [] = arm.trueMean := by
+  rfl
+
+/-- The Gittins index is non-decreasing in the discount factor `γ`.
+
+    In the known-mean model the index is `γ`-independent (it equals `trueMean`
+    regardless of patience), so the inequality holds *with equality* — the
+    `γ`-dependence of the classical index arises purely from the exploration
+    value, absent for a known arm (`discount_monotone` in `Discount.lean` captures
+    the `γ`-dependence of the *discounted value* on the `ℝ` side).
+
+    **Proven (#4039 Barrier B closed).** After the `Float → ℝ` port of
+    `BanditArm.trueMean` / `BanditInstance.discount`, the goal reduces to
+    `arm.trueMean ≤ arm.trueMean` on `ℝ`, which holds by reflexivity (`le_refl`).
+    The earlier `Float`-order wart (IEEE 754 `≤` not reflexive, no `Preorder Float`
+    instance) is gone: a bandit mean is a real number, never `NaN`. -/
+theorem gittins_index_monotone_discount (arm : BanditArm) (γ₁ γ₂ : ℝ)
+    (h : γ₁ ≤ γ₂) :
+    gittinsIndex arm γ₁ [] ≤ gittinsIndex arm γ₂ [] := by
+  simp only [gittinsIndex]
+  apply le_refl
+
+/-- For the 2-armed bandit, the Gittins policy outperforms the greedy policy. -/
+theorem gittins_beats_greedy (inst : BanditInstance)
+    (h : inst.arms.size = 2) :
+    True := by  -- Placeholder: the actual statement needs V(gittins) ≥ V(greedy)
+  trivial
+
+end Gittins_en

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.md
@@ -45,6 +45,11 @@ Notebook compagnon Lean :
   `gittins_index_monotone_discount` = **0 sorry** (prouvés, ce dernier via le port
   `Float→ℝ` PR #5272). Les modules **`Utility` et `Coherence` entiers = 0 sorry**
   (entièrement prouvés, jalon ouvert documenté non `sorry`-backed).
+- **i18n (#4980)** : les 3 modules `Gittins` existent en siblings FR + EN
+  (`Basic_en`/`Discount_en`/`GittinsTheorem_en`, `namespace Gittins_en`), preuves
+  byte-identiques (les 2 INTRINSIC sorries de `gittins_optimality` sont mirorrés
+  fidèlement — d'où le total lake standalone-sorry = 4). `Utility` et `Coherence`
+  disposent aussi de leurs siblings EN.
 - **Build** : `lake build Gittins Utility Coherence` (dépend de Mathlib4)
 - **Dépendances** : Mathlib4 (`v4.30.0-rc2`) — analyse réelle pour les lemmes
   d'actualisation, structure ordonnée et affine de `ℝ` pour vNM, théorie des `Finset`
@@ -222,7 +227,7 @@ La formalization du module `Gittins` se scinde en deux couches distinctes, l'une
 
 ### Couche prouvée (modèle à moyenne connue)
 
-`BanditArm` (cf `Basic.lean`) ne porte que `trueMean : Float` — pas de
+`BanditArm` (cf `Basic.lean`) ne porte que `trueMean : ℝ` — pas de
 postérieure, pas d'incertitude. Dans ce modèle l'indice de Gittins **égale la
 vraie moyenne** : c'est la valeur de retraite `λ` à laquelle jouer le bras
 indéfiniment (`μ·Σγⁿ = μ/(1−γ)`, cf `present_value_constant`) est indifférent à


### PR DESCRIPTION
## Summary

Adds the three English-mirror modules for the **Gittins** lake, completing **decision_theory_lean as a fully bilingual lake** (Utility + Coherence + Gittins all now have their EN siblings). Convention **#4980**: distinct FR + EN files, EN uses `namespace Gittins_en`, Lake discovers `*_en.lean` via the existing `globs := #[`Gittins.*]` (suffix form → no lakefile change).

| File | Role | sorry |
|------|------|-------|
| `Gittins/Basic_en.lean` | BanditArm / BanditInstance / Policy / RewardHistory / pullCount / empiricalMean | 0 |
| `Gittins/Discount_en.lean` | geometric_series_converges / present_value_constant / discount_monotone (+ finite partial-sum lemmas) | 0 |
| `Gittins/GittinsTheorem_en.lean` | gittinsIndex / gittinsPolicy / gittins_index_known_arm / gittins_index_monotone_discount / gittins_beats_greedy / **gittins_optimality (INTRINSIC)** | **2** |

## Mirror profile — SELF-CONTAINED SAFE

Verified per the i18n safety test (c.243/255/256, [lean-i18n-convention](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/) — *not* memory):

- **All dot-notation is STRUCTURE-FIELD access on types defined LOCALLY in the EN sibling chain**: `arm.trueMean`, `inst.arms`, `inst.discount`, `best.1/.2`. `BanditArm` / `BanditInstance` are defined in `Basic_en.lean` as `Gittins_en.*`.
- **No namespace-fn dot-notation** (`def X.foo` trap), **no imported-FR type**. `gittinsIndex` / `gittinsPolicy` are called as prefix applications.
- **Import-consistency rule (c.267)**: the EN chain imports `Gittins.Basic_en` + `Gittins.Discount_en` (consistent EN base). All types unify on `Gittins_en.*` → no 2-universe collision.

## Byte-identity + sorry parity

Content byte-identical FR↔EN for all 3 modules when excluding the structural EN additions (import/open lines, namespace suffix) per finding 1. Sorry parity: **Basic 0=0, Discount 0=0, GittinsTheorem 2=2**.

## The 2 INTRINSIC sorries — faithfully mirrored (NOT a regression)

The 2 sorries in `gittins_optimality` (the value operator `V` + the optimality proof) are the **INTRINSIC MDP barrier** of #4039 — Mathlib lacks the Bellman / optimal-stopping / expected-value-over-distributions machinery. They are **faithfully mirrored** into `GittinsTheorem_en.lean` (i18n #4980 mandates byte-identical proofs FR↔EN, including INTRINSIC sorries).

**Anti-regression rule D does NOT apply**: this mirrors an *existing* INTRINSIC sorry into a new sibling, it does not replace a proof with `sorry`. The lake's standalone-sorry count rises **2 → 4**, so:

- **`lean-decision-theory.yml`**: `sorry-baseline` raised **3 → 4** with this documented justification (per the workflow's own guidance: "If intentional (new intractable/scaffolding target), raise sorry-baseline ... WITH a documented justification").
- **README** Statut section: documents the bilingual state + the sorry-baseline rationale.

## §E whole-file audit (README)

- Added an i18n note to the Statut section (bilingual state + sorry-baseline rationale).
- Corrected a stale `trueMean : Float` → `: ℝ` (port #5272 done — line 230 contradicted `Basic.lean:17` `trueMean : ℝ` and the README's own Statut line 45). The `Float` mention in the INTRINSIC table (line 243) is **correct** (refers to `RewardHistory` empirical quantities, deliberately `Float`).

## Validation

- **Local lake build**: blocked by the cluster-level stale mathlib rc1 cache (c.261 — `d568c8c0` force-pushed, shared cache obsolete). **CI fresh clone = source of truth** for this PR (same fallback as #5565/#5567). The `lean_lib Gittins where globs := #[`Gittins.*]` covers the `_en` siblings (suffix form, c.218).
- **CI expected**: `Lean CI (decision_theory_lean)` — sorry check 4 ≤ baseline 4 = PASS, then lake build fresh clone.
- **No lakefile change** (globs already cover `_en`).

See #4980 (i18n — partial: decision_theory_lean now fully bilingual; 2 Lean DEFERs remain elsewhere: stable_marriage `Lattice_en`, cooperative_games `Shapley_en`).
See #4039 (Gittins index — Barrier B closed via Float→ℝ port #5272; Barrier A INTRINSIC MDP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
