### PR TITLE
docs(lean): fix grothendieck_lean/README.en.md L68 toolchain drift (c.294 complement of #5570)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -65,7 +65,7 @@ lake build Grothendieck
 
 ## Toolchain
 
-Aligned with other SymbolicAI/Lean projects: `leanprover/lean4:v4.30.0-rc2`
+Aligned with other SymbolicAI/Lean projects: `leanprover/lean4:v4.31.0-rc1`
 
 ## References
 


### PR DESCRIPTION
## Résumé

Self-catch c.294 (L268 propagé à moi-même) : PR #5570 (c.292, sha `3121b1b34`) a corrigé le FR sibling `grothendieck_lean/README.md:84` mais a raté l'EN sibling `README.en.md:68`. Audit G.1 firsthand `grep -rn "v4.30.0-rc2" MyIA.AI.Notebooks/` c.294 a attrapé le drift restant.

**Valeur réelle (`grothendieck_lean/lean-toolchain` sur disque)** : `v4.31.0-rc1` (bump upstream #4364).
**Valeur README.en.md L68** : `v4.30.0-rc2` (drift depuis PR #4995 c.286).

C'est exactement le pattern **L266 sibling-EN-oublié** documenté c.292 — sauf que c.294 c'est **moi-même** qui l'ai raté dans mon propre audit avant de pousser #5570. **Leçon L268 propagée à moi-même** : quand un PR corrige des fichiers FR↔EN en miroir, grepper les DEUX siblings avant de fermer la PR.

## Changement

**1 ligne** au total :

```diff
 MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md

-Aligned with other SymbolicAI/Lean projects: `leanprover/lean4:v4.30.0-rc2`
+Aligned with other SymbolicAI/Lean projects: `leanprover/lean4:v4.31.0-rc1`
```

**Diff** : `+1/-1` (1 ligne × 1 fichier), markdown prose seul, **aucun code `.lean` touché**.

## Vérifications anti-régression

- [x] **Aucun `.lean` modifié** (text-only markdown)
- [x] **LF préservé** (122 LF / 0 CRLF post-Edit ; vérifié via `python3 -c "..."` direct binary read)
- [x] **CATALOG-STATUS inchangés** (catalog-pr-hygiene R1 : aucun marqueur regénéré)
- [x] **Pas de regénération catalogue** (R1)
- [x] **Branche fresh depuis origin/main** (catalog-pr-hygiene R2 : HEAD `7634e75a5`, R5.4b MUST honorée)
- [x] **Atomicité** (catalog-pr-hygiene R3 : un seul livrable = 1 ligne de drift, 1 sujet vérifiable)
- [x] **Pas de force push, pas de direct push main** (git-workflow rules)
- [x] **Pas de traduction destructive** (readme-french-first.md R2 : prose inchangée sinon)

## Scope

See #3973, See #3979 — tranche feuille READMEs/STATUS SymbolicAI Lean (#3973 rollout multi-README multi-tranche, donc `See`, pas `Closes`).

## Anti-regression rules

- **Branche fraîche depuis origin/main** (catalog-pr-hygiene R2) — pas un rebase d'une branche stale
- **Pas de force push, pas de direct push main** (git-workflow rules)
- **Pas de regénération catalogue** (catalog-pr-hygiene R1)
- **Pas de traduction destructive** (readme-french-first.md R2)

## Out-of-scope (intentionnel)

- **19 autres fichiers `.md`** contenant `v4.30.0-rc2` en prose : `LAKE_CACHE_NUKE_PROCEDURE.md` (procédure de nuke), `LEAN_INVENTORY.md` (inventaire historique), `cooperative_games_lean/docs/...`, `conway_cgt_lean/README.en.md`, `decision_theory_lean/README.en.md`, `lean_game_defs_ext/README.md`, etc. — **non-toolchain claims** (procédure, inventaire, mentions historiques) — tracké hors scope c.294.
- **5 cellules in-cell rc2** dans `MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-{14,15b,16a}-*.ipynb` : ces cellules documentent le toolchain au moment où le notebook a été écrit. La re-exécution Lean (papermill + lean4-wsl kernel) n'est **pas tractable depuis po-2026** (WDAC bloque `lake` local). **Tracké hors scope c.293** ; cf PR #5574 body section "Out-of-scope".
- **1 snapshot historique** `prover/session_state/reference_docs/stable_marriage/upstream/lean-toolchain` `v4.25.0` : immuable, snapshot upstream stable_marriage.

## Leçons

- **🔥 L268 self-catch c.294** : le pattern "sibling-EN-oublié" ne s'applique pas qu'aux PRs des autres — **il s'applique aussi à mes propres PRs**. PR #5570 (c.292) avait corrigé FR `README.md:84` mais raté EN `README.en.md:68`. **Réflexe à intégrer** : avant `git commit` sur une PR FR↔EN, `grep -rn "<valeur>" <lake>/` sur les deux siblings.
- **#5570 + #5573 + #5574 + #5575 = quadruple toolchain-drift sibling coverage** : 4 PRs atomiques, 0 collision fichiers, total = `+12/-12` sur 10 fichiers `.md`. Pattern L243+L261+L262 généralisé à 4 livrables text-only.
- **Edit tool Windows CRLF flip c.292 + c.293 attrapé 2 fois** : c.294 = `grothendieck_lean/README.en.md` (122 LF, 0 CRLF post-Edit) — **PAS de flip cette fois**. Anticipation systématique avant `git diff --stat` post-Edit a fonctionné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>