### PR TITLE
docs(lean): fix lean_game_defs_ext/README.md L4 toolchain drift (c.238 complement of #5573 — audit cross-worker finding)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md
@@ -1,7 +1,7 @@
 # lean_game_defs_ext — Jeux bayésiens en Lean 4 (core uniquement)
 
 Formalisation des jeux bayésiens finis à deux joueurs (espaces de types
-de Harsanyi) en Lean 4 **sans Mathlib** (toolchain `v4.30.0-rc2`, core
+de Harsanyi) en Lean 4 **sans Mathlib** (toolchain `v4.31.0-rc1`, core
 uniquement — évite la mutualisation des checkouts Mathlib, cf #2611).
 Compagnon formel de `GameTheory-11-BayesianGames.ipynb`. Phase 1 de
 l'Epic #2610.


### PR DESCRIPTION
## Résumé

Fix d'un **drift toolchain** sur `MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md` L4 — `v4.30.0-rc2` → `v4.31.0-rc1`. **Tranche feuille READMEs fermée** : ce fichier était le **seul gap résiduel** du rollout mirror-gap toolchain (#4995 + #5570 + #5573 + #5574 + #5575).

## Contexte de la découverte

Cette PR a été scopée par **po-2026** (audit cross-worker) suite à un commentaire de fond sur ma PR #5573 (c.237). L'audit 28+ fichiers que j'avais mené ratait `lean_game_defs_ext/README.md` L4. po-2026 a corrigé first-hand :

> Ton audit 28+ fichiers (body) **omet `lean_game_defs_ext/README.md` L4** [...]
> `lean_game_defs_ext/lean-toolchain` = `v4.31.0-rc1` (vérifié firsthand). Ce lake est **sans Mathlib** (core uniquement) — la claim « toolchain v4.30.0-rc2 » est donc un claim de **Toolchain pur** (pas un pin Mathlib), et est **drifted**. Non couvert par #5570/#5573/#5574/#5575. À inclure dans la tranche.

J'ai vérifié first-hand avant de fixer :
- `MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lean-toolchain` = `v4.31.0-rc1` (ground-truth)
- `lakefile.toml` n'utilise **pas** Mathlib (claim Toolchain pure, pas confusion possible avec pin Mathlib)
- Le claim `v4.30.0-rc2` README L4 est donc bien un drift

## Changements

**1 remplacement** `v4.30.0-rc2` → `v4.31.0-rc1` dans **1 fichier** :

| Fichier | Occurrence corrigée |
|---------|---------------------|
| `MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md` | L4 (Toolchain pure claim, sans Mathlib) |

**Total : 1 fichier / +1/-1 lignes / 0 nouveau fichier.**

Ce fichier **n'a pas de `README.en.md` sibling** (le projet est FR-only, aucun `README.en.md` à bumper en parallèle — PR FR-only justifiée, scope strict).

## Source de vérité

`lean-toolchain` réel = `leanprover/lean4:v4.31.0-rc1` (vérifié first-hand sur le fichier).

## Pourquoi ce scope restreint (1 fichier, pas plus)

Suite au **Finding 2 de po-2026 sur ma PR #5573**, **je rétracte `decision_theory_lean` du scope "toolchain drift"** que j'avais annoncé comme "rollout séparé" :

> Ton body liste `decision_theory_lean` sous « drift à fixer dans le rollout séparé » : `README.md` L49/L69/L261 + `README.en.md` L41/L60/L96 + `lakefile.lean` L8 + `Discount.lean` L94 + `LEAN_INVENTORY.md` L17. **Vérification firsthand : ce ne sont PAS des claims Toolchain, ce sont des claims de VERSION MATHLIB, et ils sont ACCURATES.**

Preuve : `decision_theory_lean/lakefile.lean:8` pin `mathlib4.git @ "v4.30.0-rc2"`. Le lake utilise **Mathlib rc2 + Lean toolchain rc1** (combinaison forward-compatible validée par po-2026 c.294 dans PR #5571 Lean CI PASS 1m35s). Les claims README/Discount.lean = claims Mathlib = **accurate**. **À NE PAS FIXER**.

**Scope résiduel C238 (futurs rollouts séparés, hors scope cette PR)** :

| Catégorie | Fichiers | Action |
|-----------|----------|--------|
| **Mathlib claims accurate (NE PAS fixer)** | `decision_theory_lean/{README,README.en,lakefile,Discount}.lean` | laisser |
| **Inventaires cohortes (EPIC #4038)** | `SymbolicAI/Lean/LEAN_INVENTORY.md` + `Probas/LEAN_INVENTORY.md` + `GameTheory/LEAN_INVENTORY.md` | out of scope cette PR (snapshot historique) |
| **Notebooks cell-string figées** | `Lean-16a-Conway`, `Lean-15b-Grothendieck`, `Lean-14-Finiteness`, `GameTheory-15b-CooperativeGames` | out of scope (ré-exécution = cycle dédié) |
| **Scripts/code/config** | `agent_tests/prover/{config.py,kb_v5_recos.md}`, `_run_lean_snippet.sh`, `docs/LAKE_CACHE_NUKE_PROCEDURE.md` | out of scope (scripts, pas doc publique) |
| **Autres STATUS.md historiques** | `GameTheory/conway_cgt_lean/README.en.md` (déjà rc1, false positive grep), `GameTheory/social_choice_lean/STATUS.md` (déjà fixée par #5574) | déjà couverts |

**Scope retenu** = strict gap résiduel = `lean_game_defs_ext/README.md` L4 uniquement. **Tranche feuille READMEs fermée** avec cette PR.

## Anti-doublon C213-HARD-Q

`gh pr list --author myia-po-2023 --state all` direct — 0 PR sur `lean_game_defs_ext/README.md` par moi. `gh pr list --state all --search "lean_game_defs_ext"` — 0 PR cross-lane sur ce fichier par aucun worker.

## Méthode anti-CRLF-flip L267

Python binary read/write replace avec check `b"\r\n"` reject si original était LF. Vérification `git diff --stat` = `1 file changed, 1 insertion(+), 1 deletion(-)` exactement attendu, 0 churn parasite, encoding LF préservé.

## Tests / vérifications

- `grep -rn 'v4\.30\.0-rc2' MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/` → **0 résultats** après ce PR
- `git diff --cached --stat` → `1 file changed, 1 insertion(+), 1 deletion(-)` (zéro churn parasite)
- `git diff` reviewé : aucune modification de CRLF/encoding, byte-identity modulo rc2→rc1
- Lean CI N/A : aucune modification `.lean`
- Lean local build N/A : aucune modification du code source

## Conformité

- **catalog-pr-hygiene R1** : 0 fichier catalogue touché
- **catalog-pr-hygiene R2** : rebase frais depuis `origin/main` `7634e75a5` (branche `docs/lean-game-defs-ext-toolchain-drift`)
- **catalog-pr-hygiene R3** : atomique strict, +1/-1 / 1 fichier / 1 feature (toolchain drift sibling) / 1 domaine (docs-Lean)
- **catalog-pr-hygiene R4** : `See #3979` (tranche feuille READMEs), `See #3973` (EPIC catalogues READMEs), `See #5573` (c.237 PR mirror gap EN siblings), `See #4364` (toolchain bump reel rc1 upstream) — 0 `Closes` (contribution partielle tranche)
- **readme-french-first R1** : body PR rédigé en français
- **L267 anti-CRLF-flip** : Python binary write replace
- **L268 self-catch propagé** : audit cross-worker (po-2026) a détecté le gap → fix immédiat par worker concerné (po-2023)
- **C238-L1 NEW** : "**tranche feuille READMEs fermée**" = signal de fin du rollout #3979 (5+1+1+1 PRs SUCCESS en l'espace c.292-c.238) → permettre l'**enchaînement** vers d'autres rollouts (status: à reporter dashboard)

## Leçons C238 (C238-L1)

### C238-L1 : audit cross-worker = filet de sécurité anti-gap

L'audit 28+ fichiers que j'avais mené en c.237 ratait 1 fichier (`lean_game_defs_ext/README.md` L4). po-2026 l'a détecté via une vérification first-hand du commentaire de PR #5573. **L'incident est resté microscopique** parce que po-2026 a pris le temps de vérifier indépendamment.

**Implication pédagogique** : un audit `grep` d'un périmètre large a un **taux d'omission non-nul** — l'audit ground-truth du reviewer indépendant est le filet de sécurité. **Pattern recommandé pour les futurs audits `grep` étendus** : (a) commit de l'audit en commentaire de PR avec ligne grep explicite + commande exacte, (b) reviewers ground-truth peuvent re-greper first-hand.

### C238-L2 : claim Toolchain vs claim Mathlib — discrimination first-hand

PR #5573 c.237 body listait `decision_theory_lean` comme "drift à fixer dans rollout séparé" sans vérifier si les claims `v4.30.0-rc2` étaient des **claims Toolchain** (drift) ou des **claims Mathlib** (accurate). po-2026 a vérifié first-hand et confirmé : `lakefile.lean:8` pin `mathlib4.git @ "v4.30.0-rc2"` → claim Mathlib → **accurate**. 

**Implication pédagogique** : avant de classer un fichier dans un scope "drift", **toujours vérifier le lakefile** du lake correspondant pour discriminer Toolchain (lean-toolchain file) vs Mathlib (lakefile.lean pin). Le critère :
- Si `lean-toolchain` (fichier seul) = vX.Y.Z et le fichier README claim la même vX.Y.Z → claim Toolchain
- Si `lakefile.lean` pin `mathlib4.git @ "vX.Y.Z"` et le fichier README claim la même vX.Y.Z → claim Mathlib
- Si un lake utilise les deux claims (Toolchain X + Mathlib Y), lire **les deux** avant de bumper

## Liens

- See #3973 (EPIC catalogues READMEs)
- See #3979 (tranche feuille READMEs Knot/Grothendieck/Lean math)
- See #5573 (c.237 PR mirror gap EN siblings — fix principal)
- See #5570 (c.292 po-2026 PR grothendieck_lean/README.en.md)
- See #5574 (c.293 po-2026 PR 3 STATUS/FORMAL_STATUS siblings)
- See #5575 (c.294 po-2026 self-catch grothendieck_lean/README.en.md L68 complement)
- See #4364 (toolchain bump reel rc1 upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)