### PR TITLE
feat(gametheory): GameTheory-13-ImperfectInfo-CFR-Csharp — twin C# CFR/CFR+ (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb
@@ -1,0 +1,1134 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1f5b40d6-3021-452a-8097-651b53dcdfd4",
+   "metadata": {},
+   "source": [
+    "# GameTheory-13 : Jeux a Information Imparfaite et CFR (C#)\n",
+    "\n",
+    "**Navigation** : [<< 12-Reputation](GameTheory-12-ReputationGames.ipynb) | [Index](../README.md) | [14-DifferentialGames >>](GameTheory-14-DifferentialGames.ipynb)\n",
+    "\n",
+    "**Twin C# (.NET Interactive)** de [GameTheory-13-ImperfectInfo-CFR.ipynb](GameTheory-13-ImperfectInfo-CFR.ipynb) — marathon **#4956** (parite .NET <-> Python).\n",
+    "\n",
+    "La theorie des jeux a **information complete** (echecs, poker vu par Dieu) se resout par minimax ou induction a rebours. Mais le **poker** est a **information imparfaite** : chaque joueur connait sa carte cachee, pas celle de l'adversaire. L'algorithme de reference pour ces jeux est **CFR** (Counterfactual Regret Minimization, Zinkevich et al. 2007) — c'est lui qui a permis de **resoudre** le Heads-Up Limit Texas Hold'em (Bowling et al. 2015). La strategie moyenne produite par CFR **converge vers un equilibre de Nash**.\n",
+    "\n",
+    "## Plan pedagogique\n",
+    "\n",
+    "1. **Kuhn Poker** — le plus petit jeu de poker realiste (3 cartes, 2 actions)\n",
+    "2. **Regret et Regret Matching** — minimiser le regret cumule (demo Pierre-Feuille-Ciseaux)\n",
+    "3. **CFR Vanilla** — recursion contrefactuelle sur l'arbre de jeu\n",
+    "4. **CFR+** — variante avec regrets ecretes (Tammelin 2014)\n",
+    "5. **Convergence** — la strategie moyenne converge vers Nash\n",
+    "6. **Exercices**\n",
+    "\n",
+    "> **Parite #4956** : la version Python deroule un solveur CFR from-scratch (§3-4) ET le compare a **OpenSpiel** (librarie Google DeepMind, boite noire). Ce twin C# (BCL .NET 9, **0 NuGet**) traduit le solveur from-scratch (le coeur pedagogique — recursion contrefactuelle, regret matching, accumulation de strategie moyenne) ; la comparaison OpenSpiel (Python-only, pas d'equivalent C# du meme niveau) devient une note documentee honnete (**RECOVERABLE-MACHINE**) : le from-scratch CFR solver EST la substance.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "349283e3-d762-496c-a21a-be5057aac30b",
+   "metadata": {},
+   "source": [
+    "## 1. Kuhn Poker : notre jeu de reference\n",
+    "\n",
+    "Le **Kuhn Poker** (Kuhn 1950) est le plus petit poker a information imparfaite encore non-trivial. Trois cartes (Jack=0, Queen=1, King=2), deux joueurs, ante de 1. Chaque joueur recoit une carte, le joueur 1 ouvre (passe ou mise), etc. Les historiques terminaux sont `pp` (check-check : abattage), `pbp` (check-bet-fold), `pbb` (check-bet-call : abattage), `bp` (bet-fold), `bb` (bet-call : abattage).\n",
+    "\n",
+    "Un **information set** (infoset) = carte du joueur + historique visible. Deux situations dans le meme infoset sont **indistinguables** pour le joueur (c'est la cle de l'information imparfaite)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "84114e29-0fb7-474a-8444-321eb0545125",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:43.774537Z",
+     "iopub.status.busy": "2026-07-06T20:50:43.769275Z",
+     "iopub.status.idle": "2026-07-06T20:50:45.783753Z",
+     "shell.execute_reply": "2026-07-06T20:50:45.779559Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1558556.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Tests Kuhn Poker :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'pp' terminal ? True  |  'p' terminal ? False"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Payoff 'bb' avec K vs J  : 2   (attendu +2)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Payoff 'bp' (bet-fold)   : 1   (attendu +1)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Payoff 'pp' avec Q vs J  : 1   (attendu +1)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Infoset J2 avec Q apres 'p' : Qp   (attendu 'Qp')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "static void Show(string s) { s.Display(); }\n",
+    "\n",
+    "// Kuhn Poker : 3 cartes (J=0, Q=1, K=2), 2 actions (Pass=0, Bet=1).\n",
+    "public static class Kuhn\n",
+    "{\n",
+    "    public const int PASS = 0;\n",
+    "    public const int BET = 1;\n",
+    "    public const int NUM_ACTIONS = 2;\n",
+    "    public static readonly string[] CardName = { \"J\", \"Q\", \"K\" };\n",
+    "\n",
+    "    public static bool IsTerminal(string history)\n",
+    "        => history == \"pp\" || history == \"pbp\" || history == \"pbb\"\n",
+    "           || history == \"bp\" || history == \"bb\";\n",
+    "\n",
+    "    // Payoff du joueur courant a un etat terminal. cards = [card0, card1].\n",
+    "    public static double GetPayoff(string history, int[] cards)\n",
+    "    {\n",
+    "        bool p1Higher = cards[0] > cards[1];\n",
+    "        return history switch\n",
+    "        {\n",
+    "            \"pp\"  => p1Higher ? 1 : -1,     // check-check : abattage (pot=2, net +-1)\n",
+    "            \"pbp\" => -1,                    // check-bet-fold : J1 perd l'ante\n",
+    "            \"pbb\" => p1Higher ? 2 : -2,     // check-bet-call : abattage (pot=4, net +-2)\n",
+    "            \"bp\"  => 1,                     // bet-fold : J1 gagne l'ante\n",
+    "            \"bb\"  => p1Higher ? 2 : -2,     // bet-call : abattage (pot=4, net +-2)\n",
+    "            _ => 0\n",
+    "        };\n",
+    "    }\n",
+    "\n",
+    "    public static string GetInfoSet(string history, int card)\n",
+    "        => CardName[card] + history;\n",
+    "\n",
+    "    public static int GetCurrentPlayer(string history)\n",
+    "        => history.Length % 2;   // 0 = J1, 1 = J2 (alternance)\n",
+    "}\n",
+    "\n",
+    "// Tests du modele de jeu.\n",
+    "$\"Tests Kuhn Poker :\".Display();\n",
+    "$\"'pp' terminal ? {Kuhn.IsTerminal(\"pp\")}  |  'p' terminal ? {Kuhn.IsTerminal(\"p\")}\".Display();\n",
+    "$\"Payoff 'bb' avec K vs J  : {Kuhn.GetPayoff(\"bb\", new[]{ 2, 0 })}   (attendu +2)\".Display();\n",
+    "$\"Payoff 'bp' (bet-fold)   : {Kuhn.GetPayoff(\"bp\", new[]{ 0, 2 })}   (attendu +1)\".Display();\n",
+    "$\"Payoff 'pp' avec Q vs J  : {Kuhn.GetPayoff(\"pp\", new[]{ 1, 0 })}   (attendu +1)\".Display();\n",
+    "$\"Infoset J2 avec Q apres 'p' : {Kuhn.GetInfoSet(\"p\", 1)}   (attendu 'Qp')\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b04defc-bd1c-47dd-a94f-7311a14a55e6",
+   "metadata": {},
+   "source": [
+    "## 2. Regret et Regret Matching\n",
+    "\n",
+    "Le **regret** d'avoir joue l'action $a$ au lieu de la strategie $\\sigma$ est la difference d'utilite : $R(a) = u(a) - \\sum_b \\sigma(b) u(b)$. On accumule ces regrets au fil des iterations, et la **strategie courante** est proportionnelle aux **regrets positifs cumules** :\n",
+    "\n",
+    "$$\\sigma(a) = \\frac{\\max(0, R_{sum}(a))}{\\sum_b \\max(0, R_{sum}(b))}$$\n",
+    "\n",
+    "(quand tous les regrets sont <= 0, strategie uniforme.) Theoreme : le regret matching sur un jeu a somme nulle **converge vers l'equilibre de Nash**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e69af678-3666-4aef-a87e-512adff6b14c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:45.785468Z",
+     "iopub.status.busy": "2026-07-06T20:50:45.785273Z",
+     "iopub.status.idle": "2026-07-06T20:50:46.133547Z",
+     "shell.execute_reply": "2026-07-06T20:50:46.133329Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Regret Matching vs adversaire 'toujours Pierre' (1000 iter) :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Pierre=0,000  Feuille=0,999  Ciseaux=0,000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  -> Converge vers Feuille (meilleure reponse pure a 'toujours Pierre'). Attendu (0.000, 1.000, 0.000)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Regret Matching pour un agent (N actions).\n",
+    "public class RegretMatcher\n",
+    "{\n",
+    "    public int NumActions;\n",
+    "    public double[] RegretSum;\n",
+    "    public double[] StrategySum;\n",
+    "\n",
+    "    public RegretMatcher(int numActions)\n",
+    "    {\n",
+    "        NumActions = numActions;\n",
+    "        RegretSum = new double[numActions];\n",
+    "        StrategySum = new double[numActions];\n",
+    "    }\n",
+    "\n",
+    "    // Strategie courante : proportionnelle aux regrets positifs cumules.\n",
+    "    public double[] GetStrategy()\n",
+    "    {\n",
+    "        var s = new double[NumActions];\n",
+    "        double norm = 0;\n",
+    "        for (int a = 0; a < NumActions; a++)\n",
+    "        {\n",
+    "            s[a] = Math.Max(0, RegretSum[a]);\n",
+    "            norm += s[a];\n",
+    "        }\n",
+    "        if (norm > 0)\n",
+    "            for (int a = 0; a < NumActions; a++) s[a] /= norm;\n",
+    "        else\n",
+    "            for (int a = 0; a < NumActions; a++) s[a] = 1.0 / NumActions;   // uniforme\n",
+    "        return s;\n",
+    "    }\n",
+    "\n",
+    "    // Strategie moyenne (converge vers Nash en jeu a somme nulle).\n",
+    "    public double[] GetAverageStrategy()\n",
+    "    {\n",
+    "        var s = new double[NumActions];\n",
+    "        double norm = StrategySum.Sum();\n",
+    "        if (norm > 0)\n",
+    "            for (int a = 0; a < NumActions; a++) s[a] = StrategySum[a] / norm;\n",
+    "        else\n",
+    "            for (int a = 0; a < NumActions; a++) s[a] = 1.0 / NumActions;\n",
+    "        return s;\n",
+    "    }\n",
+    "\n",
+    "    // Mise a jour : actionUtilities[a] = utilite observee de l'action a.\n",
+    "    public void Update(double[] actionUtilities, double reachProb = 1.0)\n",
+    "    {\n",
+    "        var strategy = GetStrategy();\n",
+    "        double expected = 0;\n",
+    "        for (int a = 0; a < NumActions; a++) expected += strategy[a] * actionUtilities[a];\n",
+    "        for (int a = 0; a < NumActions; a++)\n",
+    "            RegretSum[a] += actionUtilities[a] - expected;   // regret = u(a) - u(sigma)\n",
+    "        for (int a = 0; a < NumActions; a++)\n",
+    "            StrategySum[a] += reachProb * strategy[a];\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Demonstration : regret matching sur Pierre-Feuille-Ciseaux, face a un adversaire qui joue toujours Pierre.\n",
+    "var rps = new RegretMatcher(3);   // 0=Pierre, 1=Feuille, 2=Ciseaux\n",
+    "var utilVsRock = new double[] { 0.0, 1.0, -1.0 };   // Pierre=0, Feuille=+1, Ciseaux=-1\n",
+    "for (int t = 0; t < 1000; t++) rps.Update(utilVsRock);\n",
+    "var avg = rps.GetAverageStrategy();\n",
+    "$\"Regret Matching vs adversaire 'toujours Pierre' (1000 iter) :\".Display();\n",
+    "$\"  Pierre={avg[0]:F3}  Feuille={avg[1]:F3}  Ciseaux={avg[2]:F3}\".Display();\n",
+    "$\"  -> Converge vers Feuille (meilleure reponse pure a 'toujours Pierre'). Attendu (0.000, 1.000, 0.000).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d88de92-3842-4c8e-be1b-1441dd4a2829",
+   "metadata": {},
+   "source": [
+    "## 3. CFR Vanilla : la recursion contrefactuelle\n",
+    "\n",
+    "CFR applique le regret matching **a chaque information set** de l'arbre de jeu, en parcourant recursivement toutes les attributions de cartes. L'idee cle est la **reach probability contrefactuelle** : on met a jour le regret d'un infoset seulement avec la probabilite d'atteindre ce noeud **sans tenir compte du joueur courant** (puisqu'on veut evaluer ce qui se passerait si CE joueur jouait differemment, toute chose egale par ailleurs).\n",
+    "\n",
+    "```\n",
+    "cfr(history, cards, reach_probs):\n",
+    "  si terminal : retourner le payoff\n",
+    "  player = joueur courant ; infoset = carte[player] + history\n",
+    "  strategy = regret_matching(infoset)\n",
+    "  pour chaque action a :\n",
+    "     child_util = cfr(history + a, cards, reach * strategy[a] pour player)\n",
+    "     node_util += strategy[a] * child_util\n",
+    "  pour chaque action a :\n",
+    "     regret = child_util[player] - node_util[player]\n",
+    "     regret_sum[infoset][a] += reach_probs[opponent] * regret   # contrefactuel\n",
+    "  strategy_sum[infoset] += reach_probs[player] * strategy\n",
+    "  retourner node_util\n",
+    "```\n",
+    "\n",
+    "Theoreme (Zinkevich 2007) : la **strategie moyenne** issue de `strategy_sum` converge vers un epsilon-equilibre de Nash quand le nombre d'iterations croit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "64fda1b1-d8fd-4b65-8ba4-d84cc5874aac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:46.135268Z",
+     "iopub.status.busy": "2026-07-06T20:50:46.135024Z",
+     "iopub.status.idle": "2026-07-06T20:50:46.268756Z",
+     "shell.execute_reply": "2026-07-06T20:50:46.268401Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solveur CFR vanilla (Kuhn Poker) pret."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Solveur CFR vanilla pour Kuhn Poker. Stocke regret_sum et strategy_sum par infoset.\n",
+    "public class CFRSolver\n",
+    "{\n",
+    "    public Dictionary<string, double[]> RegretSum = new();\n",
+    "    public Dictionary<string, double[]> StrategySum = new();\n",
+    "    public int Iterations = 0;\n",
+    "\n",
+    "    protected virtual double[] GetRegret(string infoset)\n",
+    "    {\n",
+    "        if (!RegretSum.ContainsKey(infoset)) RegretSum[infoset] = new double[Kuhn.NUM_ACTIONS];\n",
+    "        return RegretSum[infoset];\n",
+    "    }\n",
+    "\n",
+    "    public double[] GetStrategy(string infoset)\n",
+    "    {\n",
+    "        var regrets = GetRegret(infoset);\n",
+    "        var s = new double[Kuhn.NUM_ACTIONS];\n",
+    "        double norm = 0;\n",
+    "        for (int a = 0; a < Kuhn.NUM_ACTIONS; a++) { s[a] = Math.Max(0, regrets[a]); norm += s[a]; }\n",
+    "        if (norm > 0)\n",
+    "            for (int a = 0; a < Kuhn.NUM_ACTIONS; a++) s[a] /= norm;\n",
+    "        else\n",
+    "            for (int a = 0; a < Kuhn.NUM_ACTIONS; a++) s[a] = 1.0 / Kuhn.NUM_ACTIONS;\n",
+    "        return s;\n",
+    "    }\n",
+    "\n",
+    "    public double[] GetAverageStrategy(string infoset)\n",
+    "    {\n",
+    "        if (!StrategySum.ContainsKey(infoset)) return Enumerable.Repeat(1.0 / Kuhn.NUM_ACTIONS, Kuhn.NUM_ACTIONS).ToArray();\n",
+    "        var ss = StrategySum[infoset];\n",
+    "        double norm = ss.Sum();\n",
+    "        var s = new double[Kuhn.NUM_ACTIONS];\n",
+    "        if (norm > 0) for (int a = 0; a < Kuhn.NUM_ACTIONS; a++) s[a] = ss[a] / norm;\n",
+    "        else for (int a = 0; a < Kuhn.NUM_ACTIONS; a++) s[a] = 1.0 / Kuhn.NUM_ACTIONS;\n",
+    "        return s;\n",
+    "    }\n",
+    "\n",
+    "    // Recursion CFR principale. Retourne [util_J0, util_J1].\n",
+    "    public virtual double[] Cfr(string history, int[] cards, double[] reach)\n",
+    "    {\n",
+    "        if (Kuhn.IsTerminal(history))\n",
+    "        {\n",
+    "            double p = Kuhn.GetPayoff(history, cards);   // payoff de J1\n",
+    "            return new double[] { p, -p };\n",
+    "        }\n",
+    "        int player = Kuhn.GetCurrentPlayer(history);\n",
+    "        int opponent = 1 - player;\n",
+    "        string infoset = Kuhn.GetInfoSet(history, cards[player]);\n",
+    "        var strategy = GetStrategy(infoset);\n",
+    "\n",
+    "        var childUtil = new double[Kuhn.NUM_ACTIONS][];\n",
+    "        double[] nodeUtil = { 0, 0 };\n",
+    "        for (int a = 0; a < Kuhn.NUM_ACTIONS; a++)\n",
+    "        {\n",
+    "            char ac = a == Kuhn.PASS ? 'p' : 'b';\n",
+    "            var newReach = (double[])reach.Clone();\n",
+    "            newReach[player] *= strategy[a];\n",
+    "            childUtil[a] = Cfr(history + ac, cards, newReach);\n",
+    "            nodeUtil[0] += strategy[a] * childUtil[a][0];\n",
+    "            nodeUtil[1] += strategy[a] * childUtil[a][1];\n",
+    "        }\n",
+    "\n",
+    "        // Mise a jour contrefactuelle : regret pondere par reach de l'adversaire.\n",
+    "        double cfReach = reach[opponent];\n",
+    "        var rs = GetRegret(infoset);\n",
+    "        for (int a = 0; a < Kuhn.NUM_ACTIONS; a++)\n",
+    "        {\n",
+    "            double regret = childUtil[a][player] - nodeUtil[player];\n",
+    "            rs[a] += cfReach * regret;\n",
+    "        }\n",
+    "\n",
+    "        // Accumulation de la strategie (ponderee par reach du joueur courant).\n",
+    "        if (!StrategySum.ContainsKey(infoset)) StrategySum[infoset] = new double[Kuhn.NUM_ACTIONS];\n",
+    "        var ss = StrategySum[infoset];\n",
+    "        for (int a = 0; a < Kuhn.NUM_ACTIONS; a++) ss[a] += reach[player] * strategy[a];\n",
+    "\n",
+    "        return nodeUtil;\n",
+    "    }\n",
+    "\n",
+    "    // Toutes les distributions de cartes (J1, J2) avec 3 cartes distinctes.\n",
+    "    static readonly int[][] CardPermutations = {\n",
+    "        new[]{0,1}, new[]{0,2}, new[]{1,0}, new[]{1,2}, new[]{2,0}, new[]{2,1}\n",
+    "    };\n",
+    "\n",
+    "    public virtual double Train(int iterations)\n",
+    "    {\n",
+    "        double totalAvg = 0;\n",
+    "        for (int i = 0; i < iterations; i++)\n",
+    "        {\n",
+    "            double totalUtil = 0;\n",
+    "            foreach (var cards in CardPermutations)\n",
+    "                totalUtil += Cfr(\"\", cards, new double[]{ 1.0, 1.0 })[0];\n",
+    "            totalAvg += totalUtil / CardPermutations.Length;\n",
+    "            Iterations++;\n",
+    "        }\n",
+    "        return totalAvg / iterations;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "\"Solveur CFR vanilla (Kuhn Poker) pret.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2adc7e21-8944-4b82-b27e-526bbae602ca",
+   "metadata": {},
+   "source": [
+    "## 3.1 Entrainement et valeur du jeu\n",
+    "\n",
+    "On entraine CFR sur un grand nombre d'iterations. La **valeur du jeu** (utilite moyenne par coup pour J1) converge vers la valeur de Nash : Kuhn (1950) a demontre que cette valeur vaut $-1/18 \\approx -0{,}0556$ pour le joueur 1 (leger desavantage du premier joueur)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a965de6c-3d4a-44a6-a000-c0d6a5499272",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:46.270125Z",
+     "iopub.status.busy": "2026-07-06T20:50:46.269941Z",
+     "iopub.status.idle": "2026-07-06T20:50:46.727140Z",
+     "shell.execute_reply": "2026-07-06T20:50:46.726865Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Entrainement CFR vanilla sur Kuhn Poker (20000 iterations)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Valeur du jeu pour J1 = -0,0565    (valeur de Nash theorique = -0,0556)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Iterations executees : 20000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var solver = new CFRSolver();\n",
+    "int N = 20000;\n",
+    "double gameValue = solver.Train(N);\n",
+    "$\"Entrainement CFR vanilla sur Kuhn Poker ({N} iterations).\".Display();\n",
+    "$\"Valeur du jeu pour J1 = {gameValue:F4}    (valeur de Nash theorique = {-1.0/18.0:F4})\".Display();\n",
+    "$\"Iterations executees : {solver.Iterations}\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c02f480-556d-4939-9443-0fee8a2128b4",
+   "metadata": {},
+   "source": [
+    "## 3.2 Strategies apprises (strategie moyenne)\n",
+    "\n",
+    "La strategie moyenne converge vers un equilibre de Nash. Pour Kuhn Poker, on s'attend notamment a : le joueur avec le **King** mise presque toujours ; avec **Jack** face a une mise, il se couche (King bat Jack a l'abattage) ; les melanges (bluffs avec Jack, value bets avec King) emergent dans les infosets intermediaires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6ccbd53e-f138-45db-9e6f-7d373716a00b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:46.729217Z",
+     "iopub.status.busy": "2026-07-06T20:50:46.728963Z",
+     "iopub.status.idle": "2026-07-06T20:50:46.872892Z",
+     "shell.execute_reply": "2026-07-06T20:50:46.872621Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Strategies Nash apprises par CFR (format : [Pass, Bet]) :\r\n",
+       "Infoset  Pass     Bet       interpretation\r\n",
+       "----------------------------------------------------\r\n",
+       "J        0,779    0,221     \r\n",
+       "Jp       0,667    0,333     \r\n",
+       "Jpb      1,000    0,000     Jack face a mise : fold (King bat Jack)\r\n",
+       "Jb       1,000    0,000     \r\n",
+       "Q        1,000    0,000     \r\n",
+       "Qp       1,000    0,000     \r\n",
+       "Qpb      0,439    0,561     \r\n",
+       "Qb       0,659    0,341     \r\n",
+       "K        0,339    0,661     King : value bet\r\n",
+       "Kp       0,000    1,000     \r\n",
+       "Kpb      0,000    1,000     \r\n",
+       "Kb       0,000    1,000     \r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verification : King mise (bet) avec proba ~ 0,661 (Nash : King value-bet, proba >= 1/3 ; Kuhn 1950 donne une famille d'equilibres)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verification : Jack face a mise se couche (pass) avec proba ~ 1,000 (Nash : Jack fold face a bet, attendu ~ 1.0)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Afficher la strategie moyenne de chaque infoset (triee par carte puis historique).\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"Strategies Nash apprises par CFR (format : [Pass, Bet]) :\");\n",
+    "sb.AppendLine($\"{\"Infoset\",-8} {\"Pass\",-8} {\"Bet\",-8}  interpretation\");\n",
+    "sb.AppendLine(new string('-', 52));\n",
+    "// Toutes les infosets non-terminales : carte dans {J,Q,K}, historique dans {\"\", \"p\", \"b\", \"pb\"}.\n",
+    "string[] histories = { \"\", \"p\", \"pb\", \"b\" };\n",
+    "foreach (var card in new[]{ 0, 1, 2 })\n",
+    "  foreach (var h in histories)\n",
+    "  {\n",
+    "      // ne pas lister les situations impossibles/terminales.\n",
+    "      if (Kuhn.IsTerminal(h)) continue;\n",
+    "      // \"pb\" n'est atteignable que pour J1 (J1 a passe, J2 a mise) ; \"b\" que pour J2 (J1 a mise).\n",
+    "      // On garde tout pour simplicite — la strategie d'un infoset jamais atteint reste uniforme.\n",
+    "      string infoset = Kuhn.GetInfoSet(h, card);\n",
+    "      var strat = solver.GetAverageStrategy(infoset);\n",
+    "      string readout = infoset switch\n",
+    "      {\n",
+    "          \"K\"  => \"King : value bet\",\n",
+    "          \"Jpb\" => \"Jack face a mise : fold (King bat Jack)\",\n",
+    "          _ => \"\"\n",
+    "      };\n",
+    "      sb.AppendLine($\"{infoset,-8} {strat[0],-8:F3} {strat[1],-8:F3}  {readout}\");\n",
+    "  }\n",
+    "Show(sb.ToString());\n",
+    "\n",
+    "// Verifier deux resultats canoniques.\n",
+    "double[] kStrat = solver.GetAverageStrategy(\"K\");\n",
+    "double[] jpbStrat = solver.GetAverageStrategy(\"Jpb\");\n",
+    "$\"Verification : King mise (bet) avec proba ~ {kStrat[1]:F3} (Nash : King value-bet, proba >= 1/3 ; Kuhn 1950 donne une famille d'equilibres).\".Display();\n",
+    "$\"Verification : Jack face a mise se couche (pass) avec proba ~ {jpbStrat[0]:F3} (Nash : Jack fold face a bet, attendu ~ 1.0).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eab0987-04c0-411d-ad77-7561372021c9",
+   "metadata": {},
+   "source": [
+    "## 4. Variante CFR+ (Tammelin 2014)\n",
+    "\n",
+    "**CFR+** accelere la convergence avec deux modifications :\n",
+    "1. **Regrets ecretes** : on maintient `regret_sum[a] = max(0, regret_sum[a] + cf_reach * regret)` (les regrets negatifs sont immediatement remis a zero).\n",
+    "2. **Accumulation ponderee** : la strategie est accumulee avec un poids croissant `w = t+1` (iterations recentes privilegiees).\n",
+    "\n",
+    "CFR+ a ete l'algorithme cle de la resolution du Heads-Up Limit Texas Hold'em (Bowling 2015)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5902b33a-c2ef-4c7b-bc98-af953b382af6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:46.874613Z",
+     "iopub.status.busy": "2026-07-06T20:50:46.874390Z",
+     "iopub.status.idle": "2026-07-06T20:50:47.411612Z",
+     "shell.execute_reply": "2026-07-06T20:50:47.411409Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Entrainement CFR+ sur Kuhn Poker (20000 iterations)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Valeur du jeu (CFR+) pour J1 = -0,0572    (Nash = -0,0556)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Convergence CFR vs CFR+ : |valeur - (-1/18)|  vanilla=0,0009  CFR+=0,0016  (CFR+ converge generalement plus vite)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// CFR+ : variant avec regrets ecretes (Tammelin 2014).\n",
+    "public class CFRPlusSolver : CFRSolver\n",
+    "{\n",
+    "    protected override double[] GetRegret(string infoset)\n",
+    "    {\n",
+    "        if (!RegretSum.ContainsKey(infoset)) RegretSum[infoset] = new double[Kuhn.NUM_ACTIONS];\n",
+    "        return RegretSum[infoset];\n",
+    "    }\n",
+    "\n",
+    "    public override double[] Cfr(string history, int[] cards, double[] reach)\n",
+    "    {\n",
+    "        if (Kuhn.IsTerminal(history))\n",
+    "        {\n",
+    "            double p = Kuhn.GetPayoff(history, cards);\n",
+    "            return new double[] { p, -p };\n",
+    "        }\n",
+    "        int player = Kuhn.GetCurrentPlayer(history);\n",
+    "        int opponent = 1 - player;\n",
+    "        string infoset = Kuhn.GetInfoSet(history, cards[player]);\n",
+    "        var strategy = GetStrategy(infoset);\n",
+    "\n",
+    "        var childUtil = new double[Kuhn.NUM_ACTIONS][];\n",
+    "        double[] nodeUtil = { 0, 0 };\n",
+    "        for (int a = 0; a < Kuhn.NUM_ACTIONS; a++)\n",
+    "        {\n",
+    "            char ac = a == Kuhn.PASS ? 'p' : 'b';\n",
+    "            var newReach = (double[])reach.Clone();\n",
+    "            newReach[player] *= strategy[a];\n",
+    "            childUtil[a] = Cfr(history + ac, cards, newReach);\n",
+    "            nodeUtil[0] += strategy[a] * childUtil[a][0];\n",
+    "            nodeUtil[1] += strategy[a] * childUtil[a][1];\n",
+    "        }\n",
+    "\n",
+    "        // CFR+ : (1) regrets ecretes a chaque mise a jour.\n",
+    "        double cfReach = reach[opponent];\n",
+    "        var rs = GetRegret(infoset);\n",
+    "        for (int a = 0; a < Kuhn.NUM_ACTIONS; a++)\n",
+    "        {\n",
+    "            double regret = childUtil[a][player] - nodeUtil[player];\n",
+    "            rs[a] = Math.Max(0, rs[a] + cfReach * regret);\n",
+    "        }\n",
+    "\n",
+    "        // CFR+ : (2) strategie accumulee avec poids croissant w = iterations+1.\n",
+    "        if (!StrategySum.ContainsKey(infoset)) StrategySum[infoset] = new double[Kuhn.NUM_ACTIONS];\n",
+    "        double w = Iterations + 1;\n",
+    "        var ss = StrategySum[infoset];\n",
+    "        for (int a = 0; a < Kuhn.NUM_ACTIONS; a++) ss[a] += w * reach[player] * strategy[a];\n",
+    "\n",
+    "        return nodeUtil;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var solverPlus = new CFRPlusSolver();\n",
+    "double gvPlus = solverPlus.Train(N);\n",
+    "$\"Entrainement CFR+ sur Kuhn Poker ({N} iterations).\".Display();\n",
+    "$\"Valeur du jeu (CFR+) pour J1 = {gvPlus:F4}    (Nash = {-1.0/18.0:F4})\".Display();\n",
+    "$\"Convergence CFR vs CFR+ : |valeur - (-1/18)|  vanilla={Math.Abs(gameValue - (-1.0/18.0)):F4}  CFR+={Math.Abs(gvPlus - (-1.0/18.0)):F4}  (CFR+ converge generalement plus vite)\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26450afe-3b6a-49ae-bef2-eb0b184fa269",
+   "metadata": {},
+   "source": [
+    "## 5. Visualisation de la convergence\n",
+    "\n",
+    "On re-entraine CFR pour quelques paliers d'iterations et on trace la valeur du jeu : elle doit converger vers $-1/18$. Courbe ASCII (axe horizontal = iterations en echelle log, axe vertical = valeur pour J1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a756c098-f73d-4e0e-a17c-168f99dfe606",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:47.413375Z",
+     "iopub.status.busy": "2026-07-06T20:50:47.413134Z",
+     "iopub.status.idle": "2026-07-06T20:50:48.508625Z",
+     "shell.execute_reply": "2026-07-06T20:50:48.508191Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Convergence CFR : valeur du jeu (J1) vs iterations (ligne '- -' = Nash = -0,0556)\r\n",
+       " -0,009 |                                                  \r\n",
+       " -0,016 |*                                                 \r\n",
+       " -0,023 |                                                  \r\n",
+       " -0,029 |                                                  \r\n",
+       " -0,036 |                                                  \r\n",
+       " -0,043 |                                                  \r\n",
+       " -0,050 |                                                  \r\n",
+       " -0,057 |- - - - - - - * - - - - - - * - - -*- - - * - - -*\r\n",
+       " -0,064 |                     *                            \r\n",
+       " -0,071 |                                                  \r\n",
+       " -0,078 |                                                  \r\n",
+       " -0,084 |                                                  \r\n",
+       " -0,091 |       *                                          \r\n",
+       " -0,098 |                                                  \r\n",
+       "        +--------------------------------------------------\r\n",
+       "         iter: 10 ... 30000 (log-scale approx)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Convergence constatee : la valeur du jeu se rapproche de la ligne de Nash (-0,0556) a mesure que les iterations augmentent."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Courbe ASCII : valeur du jeu vs iterations (CFR vanilla).\n",
+    "int[] checkpoints = { 10, 30, 100, 300, 1000, 3000, 10000, 30000 };\n",
+    "var pts = new List<(int iter, double val)>();\n",
+    "foreach (var cp in checkpoints)\n",
+    "{\n",
+    "    var s = new CFRSolver();\n",
+    "    double v = s.Train(cp);\n",
+    "    pts.Add((cp, v));\n",
+    "}\n",
+    "\n",
+    "double vmin = pts.Min(p => p.val), vmax = pts.Max(p => p.val);\n",
+    "double nash = -1.0 / 18.0;\n",
+    "// elargir un peu l'echelle pour inclure la ligne de Nash.\n",
+    "vmin = Math.Min(vmin, nash) - 0.01; vmax = Math.Max(vmax, nash) + 0.01;\n",
+    "int H = 14, W = 50;\n",
+    "var canvas = new char[H, W];\n",
+    "for (int r = 0; r < H; r++) for (int c = 0; c < W; c++) canvas[r, c] = ' ';\n",
+    "\n",
+    "// ligne de Nash (pointille).\n",
+    "int nashCol = -1;\n",
+    "for (int c = 0; c < W; c++)\n",
+    "{\n",
+    "    double frac = (double)c / (W - 1);\n",
+    "    int iter = (int)Math.Round(checkpoints[0] + frac * (checkpoints[^1] - checkpoints[0]));\n",
+    "    // place la colonne la plus proche de Nash sur l'axe vertical\n",
+    "}\n",
+    "// determiner la ligne correspondant a 'nash' sur l'axe vertical\n",
+    "int RowFor(double v) => H - 1 - (int)Math.Round((v - vmin) / (vmax - vmin) * (H - 1));\n",
+    "int nashRow = RowFor(nash);\n",
+    "for (int c = 0; c < W; c++) if (c % 2 == 0) canvas[nashRow, c] = '-';\n",
+    "\n",
+    "// points CFR.\n",
+    "for (int i = 0; i < pts.Count; i++)\n",
+    "{\n",
+    "    int c = (int)Math.Round((double)i / (pts.Count - 1) * (W - 1));\n",
+    "    int r = RowFor(pts[i].val);\n",
+    "    if (r >= 0 && r < H && c >= 0 && c < W) canvas[r, c] = '*';\n",
+    "}\n",
+    "\n",
+    "var sb2 = new StringBuilder();\n",
+    "sb2.AppendLine($\"Convergence CFR : valeur du jeu (J1) vs iterations (ligne '- -' = Nash = {nash:F4})\");\n",
+    "for (int r = 0; r < H; r++)\n",
+    "{\n",
+    "    var line = new StringBuilder();\n",
+    "    for (int c = 0; c < W; c++) line.Append(canvas[r, c]);\n",
+    "    double v = vmax - (double)r / (H - 1) * (vmax - vmin);\n",
+    "    sb2.AppendLine($\"{v,7:F3} |{line}\");\n",
+    "}\n",
+    "sb2.AppendLine($\"        +{new string('-', W)}\");\n",
+    "sb2.AppendLine($\"         iter: {checkpoints[0]} ... {checkpoints[^1]} (log-scale approx)\");\n",
+    "Show(sb2.ToString());\n",
+    "$\"Convergence constatee : la valeur du jeu se rapproche de la ligne de Nash ({nash:F4}) a mesure que les iterations augmentent.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6db5b6e7-8428-4d18-b14e-80d358137892",
+   "metadata": {},
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "> **Convention C.1** : les stubs s'executent sans erreur (jamais `throw`). Remplir le corps, re-executer, verifier.\n",
+    "\n",
+    "### Exercice 1 — Leduc Poker (generalisation a 2 tours)\n",
+    "\n",
+    "Implementer un solveur CFR pour **Leduc Poker** (6 cartes : 3 rangs x 2 couleurs, 2 tours de mise). C'est le deuxieme benchmark canonique du poker a information imparfaite apres Kuhn.\n",
+    "\n",
+    "**Indice** : etendre le modele de jeu (historique plus long, plus d'actions legales), garder la recursion CFR identique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ada659fa-039c-4423-9651-096c9ae54fe6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:48.510234Z",
+     "iopub.status.busy": "2026-07-06T20:50:48.510034Z",
+     "iopub.status.idle": "2026-07-06T20:50:48.621015Z",
+     "shell.execute_reply": "2026-07-06T20:50:48.620817Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 1 : Leduc Poker (2 tours, 6 cartes). Generalisation de CFR.\n",
+    "// TODO etudiant : modeliser Leduc + lancer CFR.\n",
+    "static double SolveLeduc()\n",
+    "{\n",
+    "    // Indice : nouvelle classe Leduc avec IsTerminal/GetPayoff/GetInfoSet etendus,\n",
+    "    //          reutiliser CFRSolver en parametrant le jeu.\n",
+    "    return 0.0;   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice a completer\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "907d93af-90c2-4ea9-948e-efc09abcb3cf",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Exploitabilite (best-response)\n",
+    "\n",
+    "Coder le calcul de l'**exploitabilite** d'une strategie : $\\mathrm{expl}(\\sigma) = \\frac{1}{2}(\\mathrm{BR}_1(\\sigma_2) + \\mathrm{BR}_2(\\sigma_1)) - v(\\mathrm{Nash})$, ou $\\mathrm{BR}$ est la meilleure reponse. Une strategie proche de Nash a une exploitabilite proche de 0.\n",
+    "\n",
+    "**Indice** : calculer la meilleure reponse d'un joueur face a la strategie fixee de l'autre, par programmation dynamique sur l'arbre de jeu."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "34b90d09-aa2d-4fe4-b023-5763c0b7615e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:48.622690Z",
+     "iopub.status.busy": "2026-07-06T20:50:48.622496Z",
+     "iopub.status.idle": "2026-07-06T20:50:48.691383Z",
+     "shell.execute_reply": "2026-07-06T20:50:48.691135Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 2 : exploitabilite d'une strategie CFR.\n",
+    "// TODO etudiant : best-response de chaque joueur, puis moyenne.\n",
+    "static double Exploitability(CFRSolver solver)\n",
+    "{\n",
+    "    // Indice : BR de J1 face a strategy(J2), BR de J2 face a strategy(J1), moyenne - valeur Nash.\n",
+    "    return 0.0;   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice a completer\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5c8e0f0-2737-404a-9d28-70d46d1afa96",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — External Sampling MCCFR\n",
+    "\n",
+    "Les variantes **Monte Carlo CFR** echantillonnent les actions plutot que de tout parcourir. Implementer **External Sampling** : on echantillonne les actions de l'adversaire et du hasard, on explore exhaustivement celles du joueur courant.\n",
+    "\n",
+    "**Indice** : dans la recursion, tirer une seule action pour l'adversaire (au lieu de sommer), garder l'exploration complete pour le joueur courant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e74039ec-8c9f-4d7c-9d45-24773d159fb6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T20:50:48.693024Z",
+     "iopub.status.busy": "2026-07-06T20:50:48.692771Z",
+     "iopub.status.idle": "2026-07-06T20:50:48.768661Z",
+     "shell.execute_reply": "2026-07-06T20:50:48.768087Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 3 : External Sampling MCCFR.\n",
+    "// TODO etudiant : recursion avec echantillonnage des actions adverses.\n",
+    "static double ExternalSamplingCfr()\n",
+    "{\n",
+    "    // Indice : Random.NextDouble pour tirer l'action adverse selon sa strategie courante.\n",
+    "    return 0.0;   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice a completer\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02d1dbb2-2069-402a-aebb-ca929bd2310b",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "### Ce que vous avez appris\n",
+    "\n",
+    "- **Information imparfaite** — contrairement aux jeux d'echecs, le joueur ne connait pas tout l'etat ; les **information sets** regroupent les situations indistinguables.\n",
+    "- **Regret Matching** — strategie proportionnelle aux regrets positifs cumules ; converge vers Nash en jeu a somme nulle (demo Pierre-Feuille-Ciseaux).\n",
+    "- **CFR (Zinkevich 2007)** — regret matching applique a chaque infoset via une recursion **contrefactuelle** (reach probability de l'adversaire). La strategie moyenne converge vers un epsilon-Nash.\n",
+    "- **CFR+ (Tammelin 2014)** — variant a regrets ecretes qui a permis de **resoudre** le Heads-Up Limit Texas Hold'em (Bowling 2015).\n",
+    "- **Valeur du jeu** — Kuhn Poker : $-1/18$ pour J1 (leger desavantage du premier joueur), retrouve par CFR.\n",
+    "\n",
+    "### Pont avec la version Python\n",
+    "\n",
+    "La version Python ([GameTheory-13-ImperfectInfo-CFR.ipynb](GameTheory-13-ImperfectInfo-CFR.ipynb)) deroule le meme solveur CFR from-scratch (§3-4) et le compare a **OpenSpiel** (Google DeepMind). Ce twin C# traduit le coeur from-scratch (BCL .NET 9, 0 NuGet) — les internes (recursion contrefactuelle, reach probabilities, accumulation de strategie moyenne) sont visibles. La comparaison OpenSpiel (Python-only) est documentee honnetement comme **RECOVERABLE-MACHINE**.\n",
+    "\n",
+    "### Parite #4956\n",
+    "\n",
+    "Twin de parite legitime (Prong B) : les deux langages deroulent le solveur CFR from-scratch. La where Python s'appuie sur OpenSpiel pour la comparaison SOTA, le C# rend visible la mecanique de la recursion contrefactuelle. Le notebook [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb) couvre l'induction a rebours en information complete (point de contraste).\n",
+    "\n",
+    "---\n",
+    "*Marathon #4956 (parite .NET <-> Python).*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": ".net-csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -152,6 +152,7 @@ flowchart TD
 | # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
 | 13 | [GameTheory-13-ImperfectInfo-CFR](GameTheory-13-ImperfectInfo-CFR.ipynb) | Python | CFR vanilla, MCCFR, Deep CFR | 70 min |
+| 13 (C#) | [GameTheory-13-ImperfectInfo-CFR-Csharp](GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb) | .NET (C#) | Twin C# du 13 : CFR/CFR+ regret-matching from-scratch sur Kuhn Poker (récursion contrefactuelle, reach probabilities) (See #4956) | 60 min |
 | 14 | [GameTheory-14-DifferentialGames](GameTheory-14-DifferentialGames.ipynb) | Python | Boucle ouverte/fermée, Stackelberg | 60 min |
 | 15 | [GameTheory-15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb) | Python | Shapley, Core, Bondareva-Shapley | 65 min |
 | 15b | [GameTheory-15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) | Lean 4 | Axiomes Shapley formels, Core | 55 min |
@@ -545,6 +546,7 @@ GameTheory/
 ├── GameTheory-15c-CooperativeGames-Python.ipynb
 ├── GameTheory-11-BayesianGames-Csharp.ipynb                     # Twin .NET/C# (marathon #4956, Prong B)
 ├── GameTheory-5-ZeroSum-Minimax-Csharp.ipynb                    # Twin C# simplexe from-scratch (marathon #4956, Prong B)
+├── GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb                # Twin C# CFR/CFR+ regret-matching from-scratch (marathon #4956, Prong B)
 ├── GameTheory-7-ExtensiveForm-Csharp.ipynb                      # Twin C# arbre de jeu + infosets from-scratch (marathon #4956, Prong B)
 ├── SocialChoice/                                                   # Sous-série Choix Social
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb


### PR DESCRIPTION
Twin C# (.NET Interactive) de [GameTheory-13-ImperfectInfo-CFR.ipynb](MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb) — **marathon parité #4956**.

## Substance pédagogique (Prong B, #3801)

Solveur **CFR (Counterfactual Regret Minimization, Zinkevich 2007) + CFR+ (Tammelin 2014) + regret matching from-scratch** sur Kuhn Poker (BCL .NET 9, **0 NuGet**) — les internes de la récursion contrefactuelle sont visibles :

- **Kuhn Poker** : 3 cartes (J/Q/K), 2 actions (pass/bet), information sets (carte + historique visible), 5 historiques terminaux, payoffs.
- **RegretMatcher** : stratégie proportionnelle aux regrets positifs cumulés ($\sigma(a) = \max(0, R_{sum}(a)) / \sum_b \max(0, R_{sum}(b))$). Démo Pierre-Feuille-Ciseaux (converge vers Feuille vs toujours-Pierre).
- **CFRSolver** : récursion `cfr(history, cards, reach)` — **reach probability contrefactuelle**, mise à jour `regret_sum[a] += reach[opponent] * (action_util[player] - node_util[player])`, accumulation `strategy_sum += reach[player] * strategy`. Théorème : la stratégie moyenne converge vers un epsilon-Nash.
- **CFRPlusSolver** : variant à **regrets écrétés** (`max(0, regret_sum + delta)`) + stratégie pondérée (`w = t+1`), Tammelin 2014 — clé de la résolution du Heads-Up Limit Texas Hold'em (Bowling 2015).
- **Visualisation ASCII** de la convergence (valeur du jeu → Nash).

## Parité #4956 (complémentarité .NET ⇄ Python)

La version Python déroule le solveur from-scratch (§3-4) ET le compare à **OpenSpiel** (Google DeepMind, boîte noire). Ce twin C# traduit le **cœur from-scratch** (récursion contrefactuelle + regret matching + accumulation de stratégie moyenne). La comparaison OpenSpiel (Python-only, pas d'équivalent C# du même niveau) est documentée honnêtement comme **RECOVERABLE-MACHINE** : le from-scratch CFR solver EST la substance.

## Preuve d'exécution (D. + H.)

- **10/10 cellules code** `execution_count` 1→10, **0 erreur**, **0 warning CS** (`#nullable enable`), **0 exec-no-output**.
- **0 path-leak** (sorties = stratégies/probas/valeurs numériques uniquement).
- **C.1 clean** : 0 `raise`/`assert False`/`throw NotImplementedException`. 3 stubs d'exercice retournent `0.0` / `"Exercice a completer"`.
- **Exécution** : `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=.net-csharp` → Writing 47399 bytes, shutdown propre.

### Hand-verification (G.1) contre Nash de Kuhn (Kuhn 1950)

| Quantité | CFR vanilla | CFR+ | Théorie (Kuhn 1950) | Verdict |
|----------|-------------|------|---------------------|---------|
| Game value (J1) | **-0.0565** | -0.0572 | -1/18 = **-0.0556** | ✓ (|diff| = 0.0009 / 0.0016) |
| RPS vs toujours-Pierre | (0.000, 0.999, 0.000) | — | best response = Feuille | ✓ |
| Queen (Q) check | pass 1.000 | — | Q always checks | ✓ |
| Jack face bet (Jpb) | pass 1.000 | — | Jack always folds | ✓ |
| King (Kp/Kpb/Kb) | bet 1.000 | — | King always aggressive | ✓ |
| Jack bluff (J) | bet 0.221 | — | α ∈ [0, 1/3] | ✓ |
| King value (K) | bet 0.661 | — | β ≥ 1/3 (famille d'équilibres) | ✓ |
| Queen face bet (Qpb/Qb) | mix 0.56/0.34 | — | mixing | ✓ |

Toutes les stratégies sont cohérentes avec la famille d'équilibres de Nash de Kuhn poker.

**Note G.1** : une 1re prose disait « King attendu ~ 1.0 » — inexact (Kuhn 1950 donne une *famille* d'équilibres β ∈ [1/3, 1], donc 0.661 est valide sans être ~1.0). Corrigé en « King value-bet, proba ≥ 1/3 ».

## §E — audit fichier entier

README [GameTheory/README.md](MyIA.AI.Notebooks/GameTheory/README.md) :
- **+1 tree line** `GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb` dans la section Structure des fichiers.
- **+1 table row** `13 (C#)` dans la table Partie 3.
- Pattern **cohérent** avec les twins GT-4c/GT-5/GT-7/GT-11 C# (tree line + table row).
- **CATALOG byte-identique à main** (regen cron-only, HARD 1 catalog-pr-hygiene).
- Base **fresh** (origin/main 7634e75a5, reset branch pointer) — diff two-dot `origin/main..HEAD` chirurgical (+2 lignes README, 0 changement de prose existante).

## Non-trivialité (Prong B, #3801)

Le problème est **non-dégénéré** : CFR sur Kuhn Poker est le benchmark canonique de l'IA du poker imparfait — la récursion contrefactuelle (reach probabilities distinctes par joueur), la convergence vers une *famille* d'équilibres (pas un Nash unique), et la comparaison vanilla vs CFR+ exercent réellement la mécanique du regret. Ce n'est pas un simple min-max.

## Scope

Atomique (1 notebook + README §E, +1136/-0, 2 fichiers). 1 algorithme (CFR/CFR+), 1 domaine (Kuhn Poker).

See #4956, #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)