### PR TITLE
feat(search): Search-15-NetworkX-Csharp — twin C# graph theory (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb
@@ -1,0 +1,997 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8f2ab8c5-564e-437d-9bd1-dee4e6f4808b",
+   "metadata": {},
+   "source": [
+    "# Search-15 : Theorie des Graphes avec NetworkX (C#)\n",
+    "\n",
+    "**Navigation** : [<< 14-WeightedAstar](Search-14-WeightedAstar-Csharp.ipynb) | [Index](../README.md) | [16-QuikGraph >>](Search-16-QuikGraph.ipynb)\n",
+    "\n",
+    "**Twin C# (.NET Interactive)** de [Search-15-NetworkX.ipynb](Search-15-NetworkX.ipynb) — marathon **#4956** (parite .NET <-> Python).\n",
+    "\n",
+    "**NetworkX** est la librairie de reference pour la theorie des graphes en Python (200+ algorithmes). Ce twin C# (.NET 9, **0 NuGet**) **reimplemente from-scratch** les moteurs algorithmiques centraux : construction de graphe (adjacency list pondere), parcours (BFS/DFS), plus courts chemins (Dijkstra avec priority queue), centralites (degre, proximite, intermediaire, PageRank), et flot maximum (Ford-Fulkerson). Les **internes** (queue FIFO du BFS, relaxation du Dijkstra, accumulation des chemins pour l'intermediaire, iteration de puissance du PageRank) sont visibles — c'est tout l'interet pedagogique.\n",
+    "\n",
+    "## Plan pedagogique\n",
+    "\n",
+    "1. **Graphe pondere** — modele adjacency list (oriente / non-oriente)\n",
+    "2. **Parcours BFS / DFS** — exploration du graphe\n",
+    "3. **Plus courts chemins** — Dijkstra (tas de priorite, relaxation)\n",
+    "4. **Centralites** — qui est important ? (degre, proximite, intermediaire, PageRank)\n",
+    "5. **Flot maximum** — Ford-Fulkerson (chemin augmentant BFS)\n",
+    "6. **Exercices**\n",
+    "\n",
+    "> **Parite #4956** : la version Python s'appuie sur **networkx** (boite noire industrielle, 200+ algos) pour TOUT. Ce twin C# (BCL .NET 9, **0 NuGet**) traduit les **moteurs from-scratch** (le coeur algorithmique). networkx = **RECOVERABLE-MACHINE** : pas d'equivalent C# du meme niveau en une seule lib pour ce notebook pedagogique ; le from-scratch engine EST la substance. Louvain (communautes) et matching pondere (Hongrois) — couverts par networkx cote Python mais complexes au-dela du coeur — deviennent des **exercices** cote C#.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e761f921-1467-407a-8323-29565c6d8753",
+   "metadata": {},
+   "source": [
+    "## 1. Graphe pondere : modele adjacency list\n",
+    "\n",
+    "Un graphe $G = (V, E)$ : un ensemble de **sommets** $V$ et d'**aretes** $E$. On modelise ici une **adjacency list** : pour chaque sommet, la liste de ses voisins (avec poids). Le graphe peut etre **oriente** ou **non-oriente**. Les poids servent aux plus courts chemins (Dijkstra) et au flot (capacites)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4a4c56cc-ea28-45c3-a0ad-6a138537c458",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:51.890829Z",
+     "iopub.status.busy": "2026-07-06T21:16:51.883949Z",
+     "iopub.status.idle": "2026-07-06T21:16:54.311722Z",
+     "shell.execute_reply": "2026-07-06T21:16:54.305378Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1570244.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Graphe de test : 6 sommets, oriente=False"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Adjacency list :\r\n",
+       "  A -> [B:4, D:2]\r\n",
+       "  B -> [A:4, C:3, E:1]\r\n",
+       "  C -> [B:3, F:5]\r\n",
+       "  D -> [A:2, E:6]\r\n",
+       "  E -> [B:1, D:6, F:2]\r\n",
+       "  F -> [C:5, E:2]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "static void Show(string s) { s.Display(); }\n",
+    "\n",
+    "// Arete ponderee : destination + poids (cout ou capacite).\n",
+    "public record Edge(string To, double Weight);\n",
+    "\n",
+    "// Graphe oriente ou non-oriente, adjacency list.\n",
+    "public class Graph\n",
+    "{\n",
+    "    public bool Directed;\n",
+    "    public Dictionary<string, List<Edge>> Adj = new();\n",
+    "\n",
+    "    public Graph(bool directed = false) { Directed = directed; }\n",
+    "\n",
+    "    public Graph AddNode(string v)\n",
+    "    {\n",
+    "        if (!Adj.ContainsKey(v)) Adj[v] = new List<Edge>();\n",
+    "        return this;\n",
+    "    }\n",
+    "\n",
+    "    public Graph AddEdge(string from, string to, double weight = 1.0)\n",
+    "    {\n",
+    "        AddNode(from); AddNode(to);\n",
+    "        Adj[from].Add(new Edge(to, weight));\n",
+    "        if (!Directed) Adj[to].Add(new Edge(from, weight));\n",
+    "        return this;\n",
+    "    }\n",
+    "\n",
+    "    public IEnumerable<string> Nodes => Adj.Keys.OrderBy(k => k);\n",
+    "    public int NodeCount => Adj.Count;\n",
+    "}\n",
+    "\n",
+    "// Graphe de test (reseau de villes, poids = distance). Reponses analytiques connues.\n",
+    "//     A --4-- B --3-- C\n",
+    "//     |       |       |\n",
+    "//     2       1       5\n",
+    "//     |       |       |\n",
+    "//     D --6-- E --2-- F\n",
+    "var g = new Graph(directed: false)\n",
+    "    .AddEdge(\"A\",\"B\",4).AddEdge(\"B\",\"C\",3)\n",
+    "    .AddEdge(\"A\",\"D\",2).AddEdge(\"B\",\"E\",1).AddEdge(\"C\",\"F\",5)\n",
+    "    .AddEdge(\"D\",\"E\",6).AddEdge(\"E\",\"F\",2);\n",
+    "\n",
+    "$\"Graphe de test : {g.NodeCount} sommets, oriente={g.Directed}\".Display();\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"Adjacency list :\");\n",
+    "foreach (var v in g.Nodes)\n",
+    "    sb.AppendLine($\"  {v} -> [{string.Join(\", \", g.Adj[v].OrderBy(e=>e.To).Select(e => $\"{e.To}:{e.Weight}\"))}]\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db1b3e68-4c42-4937-80c4-1ebd72d3ee5d",
+   "metadata": {},
+   "source": [
+    "## 2. Parcours BFS et DFS\n",
+    "\n",
+    "Deux facons fondamentales d'explorer un graphe depuis une source :\n",
+    "\n",
+    "- **BFS (Breadth-First Search)** — explore par couches (tous les voisins d'abord, puis les voisins des voisins). Trouve les plus courts chemins **en nombre d'aretes**. Structure : **queue FIFO**.\n",
+    "- **DFS (Depth-First Search)** — plonge le plus profond possible avant de revenir (backtracking). Utilise pour la detection de cycles, la tri-topologique. Structure : **pile LIFO** (ou recursion)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "faaae46d-7fc3-4adc-9bcc-d84ff8bf1e58",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:54.314095Z",
+     "iopub.status.busy": "2026-07-06T21:16:54.313716Z",
+     "iopub.status.idle": "2026-07-06T21:16:54.704659Z",
+     "shell.execute_reply": "2026-07-06T21:16:54.704356Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BFS depuis A : ordre = [A, B, D, C, E, F]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Distances (nb aretes) : A=0  B=1  C=2  D=1  E=2  F=3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  -> A=0, B=D=1, C=E=2, F=3 (attendu : 3 sauts A-B-E-F ou A-B-C-F)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DFS depuis A : ordre = [A, B, C, F, E, D]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// BFS : retourne l'ordre de visite + les distances (en nombre d'aretes) depuis la source.\n",
+    "public static (List<string> order, Dictionary<string,int> dist) BFS(Graph g, string source)\n",
+    "{\n",
+    "    var order = new List<string>();\n",
+    "    var dist = new Dictionary<string,int>();\n",
+    "    var q = new Queue<string>();\n",
+    "    var seen = new HashSet<string>();\n",
+    "    q.Enqueue(source); seen.Add(source); dist[source] = 0;\n",
+    "    while (q.Count > 0)\n",
+    "    {\n",
+    "        var u = q.Dequeue();\n",
+    "        order.Add(u);\n",
+    "        foreach (var e in g.Adj[u].OrderBy(e => e.To))   // deterministe (tri par voisin)\n",
+    "            if (seen.Add(e.To))\n",
+    "            {\n",
+    "                dist[e.To] = dist[u] + 1;\n",
+    "                q.Enqueue(e.To);\n",
+    "            }\n",
+    "    }\n",
+    "    return (order, dist);\n",
+    "}\n",
+    "\n",
+    "// DFS iteratif (pile) : retourne l'ordre de visite.\n",
+    "public static List<string> DFS(Graph g, string source)\n",
+    "{\n",
+    "    var order = new List<string>();\n",
+    "    var seen = new HashSet<string>();\n",
+    "    var st = new Stack<string>();\n",
+    "    st.Push(source);\n",
+    "    while (st.Count > 0)\n",
+    "    {\n",
+    "        var u = st.Pop();\n",
+    "        if (!seen.Add(u)) continue;\n",
+    "        order.Add(u);\n",
+    "        // empiler dans l'ordre inverse pour visiter les voisins dans l'ordre (deterministe).\n",
+    "        foreach (var e in g.Adj[u].OrderBy(e => e.To).Reverse())\n",
+    "            if (!seen.Contains(e.To)) st.Push(e.To);\n",
+    "    }\n",
+    "    return order;\n",
+    "}\n",
+    "\n",
+    "var (bfsOrder, bfsDist) = BFS(g, \"A\");\n",
+    "$\"BFS depuis A : ordre = [{string.Join(\", \", bfsOrder)}]\".Display();\n",
+    "$\"Distances (nb aretes) : {string.Join(\"  \", bfsDist.OrderBy(kv=>kv.Key).Select(kv => $\"{kv.Key}={kv.Value}\"))}\".Display();\n",
+    "$\"  -> A=0, B=D=1, C=E=2, F=3 (attendu : 3 sauts A-B-E-F ou A-B-C-F)\".Display();\n",
+    "$\"DFS depuis A : ordre = [{string.Join(\", \", DFS(g, \"A\"))}]\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9610948-4314-4d60-8994-b1cfc8e4b630",
+   "metadata": {},
+   "source": [
+    "## 3. Plus courts chemins : Dijkstra\n",
+    "\n",
+    "L'algorithme de **Dijkstra** (1959) trouve les plus courts chemins depuis une source vers tous les sommets, sur un graphe a **poids positifs**. Principe :\n",
+    "\n",
+    "1. Initialiser `dist[source]=0`, tous les autres a $+\\infty$.\n",
+    "2. Extraire le sommet non-finalise de plus petite distance (**priority queue**).\n",
+    "3. **Relacher** chaque arete sortante : si `dist[u] + poids < dist[v]`, mettre a jour `dist[v]` et enregistrer le predecesseur.\n",
+    "4. Marquer `u` finalise, repeter.\n",
+    "\n",
+    "Le **tas de priorite** (min-heap) est la cle de l'efficacite : $O((V+E) \\log V)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f098fdf2-64ff-487d-9a5b-1eedeed6d30a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:54.706423Z",
+     "iopub.status.busy": "2026-07-06T21:16:54.706148Z",
+     "iopub.status.idle": "2026-07-06T21:16:54.914135Z",
+     "shell.execute_reply": "2026-07-06T21:16:54.913805Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Dijkstra depuis A :\r\n",
+       "  dist(A -> A) = 0   chemin = [A]\r\n",
+       "  dist(A -> B) = 4   chemin = [A -> B]\r\n",
+       "  dist(A -> C) = 7   chemin = [A -> B -> C]\r\n",
+       "  dist(A -> D) = 2   chemin = [A -> D]\r\n",
+       "  dist(A -> E) = 5   chemin = [A -> B -> E]\r\n",
+       "  dist(A -> F) = 7   chemin = [A -> B -> E -> F]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verification analytique : A->F = 7 (A-B-E-F : 4+1+2), A->C = 7 (A-B-C : 4+3)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Dijkstra : plus courts chemins depuis source (poids positifs).\n",
+    "// Retourne (distances, predecesseurs).\n",
+    "public static (Dictionary<string,double> dist, Dictionary<string,string?> prev) Dijkstra(Graph g, string source)\n",
+    "{\n",
+    "    var dist = new Dictionary<string,double>();\n",
+    "    var prev = new Dictionary<string,string?>();\n",
+    "    foreach (var v in g.Nodes) { dist[v] = double.PositiveInfinity; prev[v] = null; }\n",
+    "    dist[source] = 0;\n",
+    "\n",
+    "    // Min-heap simulé : (distance, sommet). On retire les entries stale (deja finalisees).\n",
+    "    var pq = new PriorityQueue<string, double>();\n",
+    "    pq.Enqueue(source, 0);\n",
+    "    var finalized = new HashSet<string>();\n",
+    "\n",
+    "    while (pq.Count > 0)\n",
+    "    {\n",
+    "        var u = pq.Dequeue();\n",
+    "        if (!finalized.Add(u)) continue;   // deja finalise -> skip (entry stale)\n",
+    "        foreach (var e in g.Adj[u])\n",
+    "        {\n",
+    "            double nd = dist[u] + e.Weight;\n",
+    "            if (nd < dist[e.To])\n",
+    "            {\n",
+    "                dist[e.To] = nd;\n",
+    "                prev[e.To] = u;\n",
+    "                pq.Enqueue(e.To, nd);\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return (dist, prev);\n",
+    "}\n",
+    "\n",
+    "// Reconstruire le chemin source -> cible depuis les predecesseurs.\n",
+    "public static List<string> ReconstructPath(Dictionary<string,string?> prev, string target)\n",
+    "{\n",
+    "    var path = new List<string>();\n",
+    "    string? cur = target;\n",
+    "    while (cur != null) { path.Add(cur); cur = prev[cur]; }\n",
+    "    path.Reverse();\n",
+    "    return path;\n",
+    "}\n",
+    "\n",
+    "var (djDist, djPrev) = Dijkstra(g, \"A\");\n",
+    "var sb2 = new StringBuilder();\n",
+    "sb2.AppendLine(\"Dijkstra depuis A :\");\n",
+    "foreach (var v in g.Nodes)\n",
+    "    sb2.AppendLine($\"  dist(A -> {v}) = {djDist[v]}   chemin = [{string.Join(\" -> \", ReconstructPath(djPrev, v))}]\");\n",
+    "Show(sb2.ToString());\n",
+    "$\"Verification analytique : A->F = 7 (A-B-E-F : 4+1+2), A->C = 7 (A-B-C : 4+3).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88b1d2f5-57e2-4836-9d1e-f2e57bb5d5ef",
+   "metadata": {},
+   "source": [
+    "## 4. Centralites — qui est important dans le reseau ?\n",
+    "\n",
+    "Differentes **centralites** mesurent l'importance d'un sommet selon des criteres distincts :\n",
+    "\n",
+    "- **Degre** : nombre de voisins. Simple, local.\n",
+    "- **Proximite (closeness)** : $C_C(v) = (n-1) / \\sum_u d(v,u)$. Eleve si $v$ est proche de tous les autres.\n",
+    "- **Intermediaire (betweenness)** : $C_B(v) = \\sum_{s \\neq v \\neq t} \\sigma_{st}(v)/\\sigma_{st}$ — fraction des plus courts chemins passant par $v$.\n",
+    "- **PageRank** : vecteur propre de la matrice de transition (Page et al. 1999). Approxime par **iteration de puissance** : $\\pi_{k+1} = (1-d)\\mathbf{1}/n + d \\, A^T \\pi_k$, $d=0{,}85$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "48bb33b8-997b-4623-adb2-0ebdc1b7a44c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:54.916105Z",
+     "iopub.status.busy": "2026-07-06T21:16:54.915792Z",
+     "iopub.status.idle": "2026-07-06T21:16:55.180206Z",
+     "shell.execute_reply": "2026-07-06T21:16:55.179848Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Node  Deg  Closeness  Between    PageRank \r\n",
+       "------------------------------------------\r\n",
+       "A     2    0,200      2,000      0,1460   \r\n",
+       "B     3    0,294      5,000      0,2080   \r\n",
+       "C     2    0,179      0,000      0,1460   \r\n",
+       "D     2    0,161      0,000      0,1460   \r\n",
+       "E     3    0,278      3,000      0,2080   \r\n",
+       "F     2    0,200      0,000      0,1460   \r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Attendu : B a la betweenness la plus haute (5.0, carrefour central sur 5 plus courts chemins A-C/A-E/A-F/C-D/C-E), E 2e (3.0)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Centralite de degre (non-oriente : nombre de voisins).\n",
+    "public static Dictionary<string,int> DegreeCentrality(Graph g)\n",
+    "    => g.Nodes.ToDictionary(v => v, v => g.Adj[v].Count);\n",
+    "\n",
+    "// Centralite de proximite : (n-1) / somme des distances depuis v.\n",
+    "public static Dictionary<string,double> ClosenessCentrality(Graph g)\n",
+    "{\n",
+    "    var res = new Dictionary<string,double>();\n",
+    "    int n = g.NodeCount;\n",
+    "    foreach (var v in g.Nodes)\n",
+    "    {\n",
+    "        var (d, _) = Dijkstra(g, v);\n",
+    "        double total = d.Values.Where(x => x != double.PositiveInfinity && x > 0).Sum();\n",
+    "        res[v] = total > 0 ? (n - 1) / total : 0;\n",
+    "    }\n",
+    "    return res;\n",
+    "}\n",
+    "\n",
+    "// Centralite intermediaire : fraction des plus courts chemins (s,t) passant par v.\n",
+    "// Brandes algorithm (2001) — O(VE) au lieu de O(V^3).\n",
+    "public static Dictionary<string,double> BetweennessCentrality(Graph g)\n",
+    "{\n",
+    "    var bet = g.Nodes.ToDictionary(v => v, v => 0.0);\n",
+    "    foreach (var s in g.Nodes)\n",
+    "    {\n",
+    "        // single-source shortest paths (BFS sur graphe non ponderé equivalente via Dijkstra)\n",
+    "        var (dist, prev) = Dijkstra(g, s);\n",
+    "        // compter les plus courts chemins et l'intermediaire par accumulation des dependances.\n",
+    "        var stack = new List<string>();\n",
+    "        var P = g.Nodes.ToDictionary(v => v, v => new List<string>());\n",
+    "        var sigma = g.Nodes.ToDictionary(v => v, v => 0.0);\n",
+    "        sigma[s] = 1;\n",
+    "        // ordre par distance croissante\n",
+    "        var ordered = g.Nodes.OrderBy(v => dist[v]).ToList();\n",
+    "        foreach (var w in ordered)\n",
+    "        {\n",
+    "            if (dist[w] == double.PositiveInfinity) continue;\n",
+    "            stack.Add(w);\n",
+    "            foreach (var e in g.Adj[w])\n",
+    "                if (dist[e.To] == dist[w] + e.Weight)\n",
+    "                {\n",
+    "                    P[e.To].Add(w);\n",
+    "                    sigma[e.To] += sigma[w];\n",
+    "                }\n",
+    "        }\n",
+    "        var delta = g.Nodes.ToDictionary(v => v, v => 0.0);\n",
+    "        foreach (var w in Enumerable.Reverse(stack))\n",
+    "            foreach (var p in P[w])\n",
+    "                delta[p] += (sigma[p] / sigma[w]) * (1 + delta[w]);\n",
+    "            // (on retire le facteur s lui-meme : convention standard)\n",
+    "        foreach (var w in stack)\n",
+    "            if (w != s) bet[w] += delta[w];\n",
+    "    }\n",
+    "    // Normaliser pour graphe non-oriente : diviser par 2 (chaque paire comptee 2 fois).\n",
+    "    if (!g.Directed) foreach (var k in bet.Keys.ToList()) bet[k] /= 2;\n",
+    "    return bet;\n",
+    "}\n",
+    "\n",
+    "// PageRank : iteration de puissance avec damping factor d=0.85.\n",
+    "public static Dictionary<string,double> PageRank(Graph g, double d = 0.85, int iters = 100)\n",
+    "{\n",
+    "    int n = g.NodeCount;\n",
+    "    // Construire la matrice de transition : M[j,i] = 1/outdeg(i) si i->j.\n",
+    "    var pr = g.Nodes.ToDictionary(v => v, v => 1.0 / n);\n",
+    "    var outDeg = g.Nodes.ToDictionary(v => v, v => g.Adj[v].Count);\n",
+    "    for (int it = 0; it < iters; it++)\n",
+    "    {\n",
+    "        var next = g.Nodes.ToDictionary(v => v, v => (1 - d) / n);\n",
+    "        foreach (var u in g.Nodes)\n",
+    "        {\n",
+    "            if (outDeg[u] == 0)\n",
+    "            {\n",
+    "                // dangling node : redistribuer uniformement.\n",
+    "                foreach (var v in g.Nodes) next[v] += d * pr[u] / n;\n",
+    "                continue;\n",
+    "            }\n",
+    "            foreach (var e in g.Adj[u])\n",
+    "                next[e.To] += d * pr[u] / outDeg[u];\n",
+    "        }\n",
+    "        pr = next;\n",
+    "    }\n",
+    "    return pr;\n",
+    "}\n",
+    "\n",
+    "var deg = DegreeCentrality(g);\n",
+    "var clo = ClosenessCentrality(g);\n",
+    "var bet = BetweennessCentrality(g);\n",
+    "var pr  = PageRank(g);\n",
+    "\n",
+    "var sb3 = new StringBuilder();\n",
+    "sb3.AppendLine($\"{\"Node\",-5} {\"Deg\",-4} {\"Closeness\",-10} {\"Between\",-10} {\"PageRank\",-9}\");\n",
+    "sb3.AppendLine(new string('-', 42));\n",
+    "foreach (var v in g.Nodes)\n",
+    "    sb3.AppendLine($\"{v,-5} {deg[v],-4} {clo[v],-10:F3} {bet[v],-10:F3} {pr[v],-9:F4}\");\n",
+    "Show(sb3.ToString());\n",
+    "$\"Attendu : B a la betweenness la plus haute (5.0, carrefour central sur 5 plus courts chemins A-C/A-E/A-F/C-D/C-E), E 2e (3.0).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad6eeb81-67ac-488d-96da-eb502c17e4d2",
+   "metadata": {},
+   "source": [
+    "## 5. Flot maximum : Ford-Fulkerson\n",
+    "\n",
+    "Le **flot maximum** de $s$ a $t$ sur un graphe de capacites : la quantite maximale qu'on peut acheminer. **Ford-Fulkerson** (1956) procede par augmentation :\n",
+    "\n",
+    "1. Tant qu'il existe un **chemin augmentant** de $s$ a $t$ dans le **graphe residuel** (trouve par BFS = variante Edmonds-Karp).\n",
+    "2. Calculer la capacite residuelle minimale `bottleneck` sur ce chemin.\n",
+    "3. Augmenter le flot de `bottleneck`, mettre a jour les aretes residuelles.\n",
+    "\n",
+    "Theoreme max-flow/min-cut (Ford-Fulkerson) : le flot maximum = la capacite de la coupe minimale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "72ad6dd1-c764-4d30-834e-de0db3ab52fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:55.182134Z",
+     "iopub.status.busy": "2026-07-06T21:16:55.181811Z",
+     "iopub.status.idle": "2026-07-06T21:16:55.359336Z",
+     "shell.execute_reply": "2026-07-06T21:16:55.359090Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Flot maximum s -> t = 5   (attendu : 5 = min(coupe sortie s=6, coupe entree t=5))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Flot maximum (Ford-Fulkerson / Edmonds-Karp : chemin augmentant via BFS).\n",
+    "public static double MaxFlow(Graph g, string source, string sink)\n",
+    "{\n",
+    "    // Graphe residuel : capacites[u][v].\n",
+    "    var cap = new Dictionary<string, Dictionary<string,double>>();\n",
+    "    foreach (var u in g.Nodes)\n",
+    "    {\n",
+    "        cap[u] = new();\n",
+    "        foreach (var e in g.Adj[u]) cap[u][e.To] = e.Weight;\n",
+    "        foreach (var v in g.Nodes) if (!cap[u].ContainsKey(v)) cap[u][v] = 0;\n",
+    "    }\n",
+    "    double maxFlow = 0;\n",
+    "\n",
+    "    while (true)\n",
+    "    {\n",
+    "        // BFS pour un chemin augmentant dans le graphe residuel.\n",
+    "        var parent = new Dictionary<string,string?>();\n",
+    "        var q = new Queue<string>();\n",
+    "        q.Enqueue(source); parent[source] = null;\n",
+    "        while (q.Count > 0 && !parent.ContainsKey(sink))\n",
+    "        {\n",
+    "            var u = q.Dequeue();\n",
+    "            foreach (var v in cap[u].Keys)\n",
+    "                if (!parent.ContainsKey(v) && cap[u][v] > 0)\n",
+    "                {\n",
+    "                    parent[v] = u;\n",
+    "                    q.Enqueue(v);\n",
+    "                }\n",
+    "        }\n",
+    "        if (!parent.ContainsKey(sink)) break;   // plus de chemin augmentant\n",
+    "\n",
+    "        // bottleneck = capacite residuelle minimale sur le chemin.\n",
+    "        double bottleneck = double.PositiveInfinity;\n",
+    "        string? cur = sink;\n",
+    "        while (parent[cur!] != null) { var p = parent[cur!]!; bottleneck = Math.Min(bottleneck, cap[p][cur!]); cur = p; }\n",
+    "\n",
+    "        // augmenter.\n",
+    "        cur = sink;\n",
+    "        while (parent[cur!] != null) { var p = parent[cur!]!; cap[p][cur!] -= bottleneck; cap[cur!][p] += bottleneck; cur = p; }\n",
+    "        maxFlow += bottleneck;\n",
+    "    }\n",
+    "    return maxFlow;\n",
+    "}\n",
+    "\n",
+    "// Graphe de test pour le flot (capacites). max-flow s->t = 5 (analytique).\n",
+    "//     s --4-- a --3-- t\n",
+    "//      \\      |       /\n",
+    "//       2     1      2\n",
+    "//        \\   |    /\n",
+    "//         b --2-- c\n",
+    "var flowG = new Graph(directed: true)\n",
+    "    .AddEdge(\"s\",\"a\",4).AddEdge(\"a\",\"t\",3)\n",
+    "    .AddEdge(\"s\",\"b\",2).AddEdge(\"b\",\"c\",2).AddEdge(\"c\",\"t\",2)\n",
+    "    .AddEdge(\"a\",\"b\",1);\n",
+    "\n",
+    "double mf = MaxFlow(flowG, \"s\", \"t\");\n",
+    "$\"Flot maximum s -> t = {mf}   (attendu : 5 = min(coupe sortie s=6, coupe entree t=5))\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c644ee1a-a154-447d-ae46-f9400831fc29",
+   "metadata": {},
+   "source": [
+    "## 5.1 Visualisation ASCII du graphe\n",
+    "\n",
+    "En Python, networkx + matplotlib produisent une figure. En C# headless, on dessine le graphe en ASCII (les sommets et leurs aretes ponderees) pour valider la structure visuellement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5cad3ed9-cce3-4824-ba5c-d4443c5159ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:55.361006Z",
+     "iopub.status.busy": "2026-07-06T21:16:55.360703Z",
+     "iopub.status.idle": "2026-07-06T21:16:55.445388Z",
+     "shell.execute_reply": "2026-07-06T21:16:55.445104Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Graphe de test (reseau de villes) :\r\n",
+       "\r\n",
+       "    A --4-- B --3-- C\r\n",
+       "    |       |       |\r\n",
+       "    2       1       5\r\n",
+       "    |       |       |\r\n",
+       "    D --6-- E --2-- F\r\n",
+       "\r\n",
+       "Adjacency detail (verification structure) :\r\n",
+       "  [A] -> B(4), D(2)\r\n",
+       "  [B] -> A(4), C(3), E(1)\r\n",
+       "  [C] -> B(3), F(5)\r\n",
+       "  [D] -> A(2), E(6)\r\n",
+       "  [E] -> B(1), D(6), F(2)\r\n",
+       "  [F] -> C(5), E(2)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Dessin ASCII du graphe : chaque noeud + ses aretes.\n",
+    "var sbDraw = new StringBuilder();\n",
+    "sbDraw.AppendLine(\"Graphe de test (reseau de villes) :\");\n",
+    "sbDraw.AppendLine();\n",
+    "sbDraw.AppendLine(\"    A --4-- B --3-- C\");\n",
+    "sbDraw.AppendLine(\"    |       |       |\");\n",
+    "sbDraw.AppendLine(\"    2       1       5\");\n",
+    "sbDraw.AppendLine(\"    |       |       |\");\n",
+    "sbDraw.AppendLine(\"    D --6-- E --2-- F\");\n",
+    "sbDraw.AppendLine();\n",
+    "sbDraw.AppendLine(\"Adjacency detail (verification structure) :\");\n",
+    "foreach (var v in g.Nodes)\n",
+    "{\n",
+    "    var nbrs = g.Adj[v].OrderBy(e => e.To).Select(e => $\"{e.To}({e.Weight})\");\n",
+    "    sbDraw.AppendLine($\"  [{v}] -> {string.Join(\", \", nbrs)}\");\n",
+    "}\n",
+    "Show(sbDraw.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "993a5ee8-03e5-4716-b777-15389d1edbfe",
+   "metadata": {},
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "> **Convention C.1** : les stubs s'executent sans erreur (jamais `throw`). Remplir le corps, re-executer, verifier.\n",
+    "\n",
+    "### Exercice 1 — Detection de cycles (DFS 3 couleurs)\n",
+    "\n",
+    "Implementer la **detection de cycles** dans un graphe oriente via DFS a 3 couleurs (BLANC/GRIS/NOIR). Un cycle existe si on atteint un sommet GRIS pendant le DFS.\n",
+    "\n",
+    "**Indice** : marquer GRIS en entrant, NOIR en sortant ; si un voisin est GRIS -> cycle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7dce2b69-1070-4e30-8bdd-3f10de886b91",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:55.447133Z",
+     "iopub.status.busy": "2026-07-06T21:16:55.446866Z",
+     "iopub.status.idle": "2026-07-06T21:16:55.519929Z",
+     "shell.execute_reply": "2026-07-06T21:16:55.519706Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "HasCycle(acyclique) = False   (attendu False)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "HasCycle(cyclique)  = False   (attendu True)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 1 : detection de cycle (DFS 3 couleurs) sur graphe oriente.\n",
+    "// TODO etudiant : retourner true si le graphe contient un cycle.\n",
+    "static bool HasCycle(Graph g)\n",
+    "{\n",
+    "    // Indice : BLANC=non visite, GRIS=en cours (dans la pile DFS), NOIR=termine.\n",
+    "    //          si on atteint un voisin GRIS -> cycle.\n",
+    "    return false;   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "// Tests (sur 2 graphes : un sans cycle, un avec).\n",
+    "var acyclic = new Graph(directed: true).AddEdge(\"a\",\"b\").AddEdge(\"b\",\"c\").AddEdge(\"a\",\"c\");\n",
+    "var cyclic  = new Graph(directed: true).AddEdge(\"a\",\"b\").AddEdge(\"b\",\"c\").AddEdge(\"c\",\"a\");\n",
+    "$\"HasCycle(acyclique) = {HasCycle(acyclic)}   (attendu False)\".Display();\n",
+    "$\"HasCycle(cyclique)  = {HasCycle(cyclic)}   (attendu True)\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03b009ed-6496-407d-adfa-e9c914f28572",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — A* avec heuristique\n",
+    "\n",
+    "Implementer **A*** (A-star) sur un graphe pondere avec une **heuristique admissible** $h(v) \\leq h^*(v)$ (distance reelle vers la cible). A* etend Dijkstra en priorisant les sommets par `g(v) + h(v)`.\n",
+    "\n",
+    "**Indice** : meme structure que Dijkstra, mais la priority queue ordonne par `dist[u] + h(u)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "87ca7f3a-b0d8-47ac-bd62-920265832315",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:55.521483Z",
+     "iopub.status.busy": "2026-07-06T21:16:55.521224Z",
+     "iopub.status.idle": "2026-07-06T21:16:55.613166Z",
+     "shell.execute_reply": "2026-07-06T21:16:55.612857Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice a completer (tester avec heuristique = distance euclidienne approchee vers F)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 2 : A* avec heuristique admissible.\n",
+    "// TODO etudiant : plus court chemin source->target avec heuristique.\n",
+    "static double AStar(Graph g, string source, string target, Dictionary<string,double> heuristic)\n",
+    "{\n",
+    "    // Indice : priority queue ordonnee par dist[u] + h[u] ; stop des que target est finalise.\n",
+    "    return 0.0;   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "$\"Exercice a completer (tester avec heuristique = distance euclidienne approchee vers F).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc2b31f0-c727-442c-a5bb-c16d1cd2fbf2",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Detection de communautes (Louvain)\n",
+    "\n",
+    "**Louvain** (Blondel et al. 2008) est l'algorithme SOTA de detection de communautes (maximisation de **modularite**). networkx l'offre en une ligne ; l'implementer from-scratch depasse le coeur de ce notebook.\n",
+    "\n",
+    "**Indice** : la modularite $Q = \\frac{1}{2m}\\sum_{ij}\\left[A_{ij} - \\frac{k_i k_j}{2m}\\right]\\delta(c_i, c_j)$. Louvain optimise $Q$ en deux phases repetees : (1) deplacer chaque noeud vers la communaute qui maximise le gain de modularite, (2) construire le meta-graphe des communautes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a1d86cfd-aaf9-431a-87de-b422973b2864",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:16:55.614897Z",
+     "iopub.status.busy": "2026-07-06T21:16:55.614642Z",
+     "iopub.status.idle": "2026-07-06T21:16:55.670550Z",
+     "shell.execute_reply": "2026-07-06T21:16:55.670042Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice a completer (Louvain complet = meta-graphe + iteration, hors scope coeur)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 3 : modularite d'un partitionnement (brique de base de Louvain).\n",
+    "// TODO etudiant : calculer Q pour un partitionnement donne.\n",
+    "static double Modularity(Graph g, Dictionary<string,int> community)\n",
+    "{\n",
+    "    // Indice : Q = (1/2m) * sum_ij [ A_ij - k_i*k_j/(2m) ] * delta(c_i, c_j)\n",
+    "    return 0.0;   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "$\"Exercice a completer (Louvain complet = meta-graphe + iteration, hors scope coeur).\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e5d87ab-d52a-4f07-ae74-8ce442e57e01",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "### Ce que vous avez appris\n",
+    "\n",
+    "- **Modele de graphe** — adjacency list ponderee (oriente / non-oriente), la structure de donnees universelle.\n",
+    "- **Parcours BFS / DFS** — queue FIFO vs pile LIFO ; BFS donne les plus courts chemins en nombre d'aretes.\n",
+    "- **Dijkstra** — plus courts chemins a poids positifs via priority queue et relaxation des aretes.\n",
+    "- **Centralites** — degre (local), proximite (moyenne), intermediaire (carrefour, algorithme de Brandes), PageRank (vecteur propre par iteration de puissance).\n",
+    "- **Flot maximum** — Ford-Fulkerson / Edmonds-Karp : chemins augmentants BFS dans le graphe residuel ; theoreme max-flow/min-cut.\n",
+    "\n",
+    "### Pont avec la version Python\n",
+    "\n",
+    "La version Python ([Search-15-NetworkX.ipynb](Search-15-NetworkX.ipynb)) utilise **networkx** (200+ algorithmes, boite noire industrielle) et matplotlib pour la visualisation. Ce twin C# (BCL .NET 9, 0 NuGet) **reimplemente from-scratch** les moteurs centraux (adjacency list, BFS/DFS, Dijkstra, centralites, Ford-Fulkerson) — les internes algorithmiques sont visibles. networkx reste l'outil SOTA cote Python (**RECOVERABLE-MACHINE**) : pas d'equivalent C# du meme niveau en une seule lib pedagogique. Louvain (communautes) et le matching pondere (Hongrois), couverts par networkx cote Python, sont laisses en exercices (complexite au-dela du coeur).\n",
+    "\n",
+    "### Parite #4956\n",
+    "\n",
+    "Twin de parite legitime (Prong B) : les deux langages couvrent les memes concepts (graphe, parcours, plus courts chemins, centralites, flot). Ou Python s'appuie sur networkx, le C# rend visible la mecanique de chaque algorithme. Le notebook [Search-3-Informed-Csharp](../Part1-Foundations/Search-3-Informed-Csharp.ipynb) couvre A* en detail (point de complement).\n",
+    "\n",
+    "---\n",
+    "*Marathon #4956 (parite .NET <-> Python).*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": ".net-csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -197,6 +197,7 @@ Algorithmes de recherche classiques, recherche adversariale et métaheuristiques
 | 10 | [Search-10-SymbolicAutomata](Part1-Foundations/Search-10-SymbolicAutomata.ipynb) | ~2h | DFA/NFA (automata-lib), prédicats Z3, automates symboliques | Search-1, SymbolicAI/SMT/Z3 |
 | 11 | [Search-11-Metaheuristics](Part1-Foundations/Search-11-Metaheuristics.ipynb) | ~1h30 | PSO, ABC, SA, BRO avec MEALPy, benchmark comparatif | Search-4, Search-5 |
 | 15 | [Search-15-NetworkX](Part1-Foundations/Search-15-NetworkX.ipynb) | ~1h | `networkx` : `Graph`/`DiGraph`, DFS/BFS, Dijkstra, Bellman-Ford, centralités de degré, MST, Floyd-Warshall | Search-2 |
+| 15 (C#) | [Search-15-NetworkX-Csharp](Part1-Foundations/Search-15-NetworkX-Csharp.ipynb) | ~1h | Twin C# du 15 : graphes from-scratch (adjacency list, BFS/DFS, Dijkstra, centralités degré/closeness/betweenness/PageRank, Ford-Fulkerson max-flow) (See #4956) | Search-2, notions C#/.NET |
 | 16 | [Search-16-QuikGraph](Part1-Foundations/Search-16-QuikGraph.ipynb) | ~1h | QuikGraph 2.5.0 (.NET, NuGet) : AdjacencyGraph/BidirectionalGraph, DFS/BFS, Dijkstra, Edmonds-Karp (flot max), parité C# ↔ NetworkX | Search-1, notions C#/.NET |
 
 ---
@@ -485,6 +486,7 @@ Search/
 │   ├── Search-10-SymbolicAutomata.ipynb
 │   ├── Search-11-Metaheuristics.ipynb
 │   ├── Search-15-NetworkX.ipynb
+│   ├── Search-15-NetworkX-Csharp.ipynb   # Twin C# graphes from-scratch (BFS/DFS, Dijkstra, centralités, Ford-Fulkerson) (See #4956)
 │   └── Search-16-QuikGraph.ipynb
 │
 ├── Part2-CSP/                             # Programmation par Contraintes (18 notebooks : 9 Python + 9 jumeaux C#)


### PR DESCRIPTION
Twin C# (.NET Interactive) de [Search-15-NetworkX.ipynb](MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb) — **marathon parité #4956**.

## Substance pédagogique (Prong B, #3801)

**Moteurs de théorie des graphes from-scratch** (BCL .NET 9, **0 NuGet**) — les internes algorithmiques sont visibles :

- **Modèle graphe** : adjacency list pondérée (orienté / non-orienté), `record Edge(To, Weight)`.
- **BFS** (queue FIFO, distances en nombre d'arêtes) + **DFS** (pile LIFO, itératif déterministe).
- **Dijkstra** : plus courts chemins à poids positifs via `PriorityQueue<string,double>` + relaxation des arêtes + reconstruction de chemin (prédecesseurs).
- **Centralités** :
  - **Degré** (nombre de voisins).
  - **Proximité** (closeness = (n-1)/Σdist).
  - **Intermédiaire** (betweenness, **algorithme de Brandes** O(VE) — accumulation des dépendances par single-source shortest paths).
  - **PageRank** (itération de puissance, damping 0.85, gestion dangling nodes).
- **Flot maximum** : **Ford-Fulkerson / Edmonds-Karp** (chemins augmentants BFS dans le graphe résiduel, bottleneck, théorème max-flow/min-cut).
- **3 exercices** : détection de cycles (DFS 3 couleurs), A* avec heuristique admissible, modularité Louvain.

## Parité #4956 (complémentarité .NET ⇄ Python)

La version Python s'appuie sur **networkx** (boîte noire industrielle, 200+ algos) + matplotlib. Ce twin C# traduit les **moteurs from-scratch** (le cœur algorithmique). networkx = **RECOVERABLE-MACHINE** : pas d'équivalent C# du même niveau en une seule lib pédagogique. Louvain (communautés) + matching pondéré (Hongrois), couverts par networkx côté Python mais complexes au-delà du cœur, deviennent des **exercices** côté C#.

## Preuve d'exécution (D. + H.)

- **9/9 cellules code** `execution_count` 1→9, **0 erreur**, **0 warning CS** (`#nullable enable`), **0 exec-no-output**.
- **0 path-leak** (sorties = sommets/distances/chemins/flots uniquement).
- **C.1 clean** : 0 `raise`/`assert False`/`throw NotImplementedException`. 3 stubs d'exercice retournent `false`/`0.0` + `"Exercice a completer"`.
- **Exécution** : `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=.net-csharp` → Writing 41193 bytes, shutdown propre.

### Hand-verification (G.1) sur un graphe de test 6-sommets (A-F)

```
    A --4-- B --3-- C
    |       |       |
    2       1       5
    |       |       |
    D --6-- E --2-- F
```

| Quantité | Output C# | Réponse analytique | Verdict |
|----------|-----------|--------------------|---------| 
| Dijkstra A→F | 7 | A-B-E-F : 4+1+2 = 7 | ✓ |
| Dijkstra A→E | 5 | A-B-E : 4+1 = 5 < A-D-E : 8 | ✓ |
| Dijkstra A→C | 7 | A-B-C : 4+3 = 7 | ✓ |
| Betweenness B | 5.0 | carrefour de 5 PCC (A-C, A-E, A-F, C-D, C-E) | ✓ |
| Betweenness E | 3.0 | sur 3 PCC (A-F, B-F, D-F) | ✓ |
| PageRank B = E | 0.208 | degré max (3) | ✓ |
| Max-flow s→t | 5 | min-cut {s,a,b,c}\|{t} = a→t(3)+c→t(2) | ✓ |

**Note G.1** : une 1re prose disait « E a la betweenness la plus haute » — inexact (B=5.0 > E=3.0). Corrigé en « B carrefour central sur 5 plus courts chemins ».

## §E — audit fichier entier

README [Search/README.md](MyIA.AI.Notebooks/Search/README.md) :
- **+1 tree line** `Search-15-NetworkX-Csharp.ipynb` dans la section Structure (Part1-Foundations).
- **+1 table row** `15 (C#)` dans la table des notebooks.
- **CATALOG byte-identique à main** (regen cron-only, HARD 1 catalog-pr-hygiene).
- Base **fresh** (origin/main 7634e75a5). Diff two-dot chirurgical (+2 lignes README, +997 notebook, atomique).

## Non-trivialité (Prong B, #3801)

Le graphe de test est **non-dégénéré** : la betweenness (Brandes) et le PageRank (power iteration avec dangling nodes) discriminent réellement les sommets, et le max-flow illustre le théorème max-flow/min-cut sur un réseau à chemins multiples. Ce n'est pas un BFS trivial.

## Scope

Atomique (1 notebook + README §E, +999/-0, 2 fichiers). 1 domaine (théorie des graphes), 5 familles d'algorithmes.

See #4956, #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)