### PR TITLE
feat(tweety): Tweety-11-Causal-Csharp — twin C# moteur causal booléen from-scratch (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -204,8 +204,9 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 10 | [Tweety-10-MLN](Tweety-10-MLN.ipynb)       | Markov Logic Networks (FOL pondérée)                      | 50 min  | Python |
 | 10c | [Tweety-10-MLN-Csharp](Tweety-10-MLN-Csharp.ipynb) | MLN porté .NET (IKVM, c.188 PR #5209)                | 30 min  | C# PROD |
 | 11 | [Tweety-11-Causal](Tweety-11-Causal.ipynb) | Raisonnement causal : do-calculus, interventions, contrefactuels | 50 min  | Python |
+| 11c | [Tweety-11-Causal-Csharp](Tweety-11-Causal-Csharp.ipynb) | Twin C# moteur causal booléen from-scratch (do-operator, contrefactuel) | 35 min  | C# PROD |
 
-**Durée totale estimée** : ~13h (Python) + ~6h (C#/.NET). Le tableau ci-dessus couvre les **27 notebooks principaux** (12 Python + 14 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
+**Durée totale estimée** : ~13h (Python) + ~7h (C#/.NET). Le tableau ci-dessus couvre les **29 notebooks principaux** (12 Python + 16 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
 
 ## En quoi chaque notebook est unique
 
@@ -356,6 +357,7 @@ Tweety/
 ├── Tweety-10-MLN.ipynb                           # Markov Logic Networks
 ├── Tweety-10-MLN-Csharp.ipynb                    # MLN .NET (IKVM)
 ├── Tweety-11-Causal.ipynb                        # do-calculus Pearl
+├── Tweety-11-Causal-Csharp.ipynb                 # Twin C# moteur causal from-scratch (marathon #4956, Prong B)
 ├── libs/                                          # JARs Tweety (42 : 39 modules 1.30 + 3 deps)
 ├── jdk-17-portable/                               # JDK Zulu (téléchargé auto)
 ├── scripts/

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal-Csharp.ipynb
@@ -1,0 +1,1165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "22185c95",
+   "metadata": {},
+   "source": [
+    "# Tweety-11 — Inférence causale & do-calculus (twin C# from-scratch)\n",
+    "\n",
+    "Ce notebook est le **jumeau C# / .NET** de [Tweety-11-Causal.ipynb](Tweety-11-Causal.ipynb) — marathon de parité #4956.\n",
+    "\n",
+    "La version Python s'appuie sur **Tweety `causal-1.30.jar`** (via JPype) : un reasoner causal **argumentatif** construit sur\n",
+    "des *Structural Causal Models* booléens. Ce twin C# **réimplémente le moteur causal from-scratch** (BCL .NET 9, 0 NuGet)\n",
+    "pour rendre **visibles les internes** : la chirurgie de graphe du do-operator, l'énumération des mondes possibles,\n",
+    "la sémantique contrefactuelle. La lib Java Tweety = `RECOVERABLE-MACHINE` (Python-only) ; le moteur from-scratch EST la substance.\n",
+    "\n",
+    "**Pourquoi from-scratch ?** L'enjeu pédagogique de l'inférence causale (Pearl) n'est pas d'appeler une boîte noire,\n",
+    "mais de *voir* pourquoi `P(rain | observe drops) != P(rain | do drops)`. Cela exige d'exposer le graphe causal orienté,\n",
+    "la surgery `do(X)` qui rompt les liens entrants, et l'évaluation des mondes possibles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "613cd651",
+   "metadata": {},
+   "source": [
+    "## 1. Moteur causal — modèles structurels booléens\n",
+    "\n",
+    "Un **Structural Causal Model (SCM)** booléen est un DAG d'atomes propositionnels :\n",
+    "- les **atomes de fond** (exogènes) sont les causes racines, libres ;\n",
+    "- les **atomes expliqués** (endogènes) sont définis par une **équation booléenne** sur leurs parents.\n",
+    "\n",
+    "Étant donné une assignation des atomes de fond, tous les atomes expliqués sont **déterminés** par propagation\n",
+    "(le graphe est acyclique). Un *monde possible* = une assignation complète cohérente avec les équations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "27e6a6d2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:19.118527Z",
+     "iopub.status.busy": "2026-07-06T21:51:19.113298Z",
+     "iopub.status.idle": "2026-07-06T21:51:20.634803Z",
+     "shell.execute_reply": "2026-07-06T21:51:20.630047Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '55260.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Moteur d'inference causale (Boolean structural causal models, from-scratch)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "static void Show(string s) { s.Display(); }\n",
+    "Show(\"Moteur d'inference causale (Boolean structural causal models, from-scratch).\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4e8ecb7c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:20.636509Z",
+     "iopub.status.busy": "2026-07-06T21:51:20.636185Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.185303Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.185097Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "StructuralCausalModel + parser de formules + propagation + Intervene (do-operator) prets."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// --- Formule booleenne sur des atomes : || && ! ( ) + (vrai) - (faux) ---\n",
+    "public sealed class Formula\n",
+    "{\n",
+    "    public Func<IReadOnlyDictionary<string,bool>, bool> Eval;\n",
+    "    public HashSet<string> Vars;\n",
+    "    public Formula(Func<IReadOnlyDictionary<string,bool>, bool> e, HashSet<string> v) { Eval = e; Vars = v; }\n",
+    "    public static Formula Atom(string n) => new(a => a[n], new() { n });\n",
+    "    public static Formula Const(bool b) => new(_ => b, new());\n",
+    "    public static Formula Not(Formula f) => new(a => !f.Eval(a), f.Vars);\n",
+    "    public static Formula And(Formula x, Formula y) => new(a => x.Eval(a) && y.Eval(a), Union(x.Vars, y.Vars));\n",
+    "    public static Formula Or(Formula x, Formula y)  => new(a => x.Eval(a) || y.Eval(a), Union(x.Vars, y.Vars));\n",
+    "    static HashSet<string> Union(HashSet<string> a, HashSet<string> b) { var s = new HashSet<string>(a); s.UnionWith(b); return s; }\n",
+    "}\n",
+    "\n",
+    "// Petite analyse recursive descendante (tokeniseur + grammaire PL minimale).\n",
+    "public static class FormulaParser\n",
+    "{\n",
+    "    public static Formula Parse(string src)\n",
+    "    {\n",
+    "        var toks = Tokenize(src);\n",
+    "        int i = 0;\n",
+    "        Formula f = ParseOr(toks, ref i);\n",
+    "        return f;\n",
+    "    }\n",
+    "    static List<string> Tokenize(string s)\n",
+    "    {\n",
+    "        var t = new List<string>();\n",
+    "        int i = 0;\n",
+    "        while (i < s.Length)\n",
+    "        {\n",
+    "            char c = s[i];\n",
+    "            if (char.IsWhiteSpace(c)) { i++; continue; }\n",
+    "            if (c == '(' || c == ')' || c == '+' || c == '-' || c == '!') { t.Add(c.ToString()); i++; continue; }\n",
+    "            if (c == '&' && i + 1 < s.Length && s[i + 1] == '&') { t.Add(\"&&\"); i += 2; continue; }\n",
+    "            if (c == '|' && i + 1 < s.Length && s[i + 1] == '|') { t.Add(\"||\"); i += 2; continue; }\n",
+    "            if (char.IsLetter(c) || c == '_')\n",
+    "            {\n",
+    "                int j = i;\n",
+    "                while (j < s.Length && (char.IsLetterOrDigit(s[j]) || s[j] == '_')) j++;\n",
+    "                t.Add(s.Substring(i, j - i)); i = j; continue;\n",
+    "            }\n",
+    "            throw new ArgumentException($\"Caractere inattendu '{c}' dans la formule : {s}\");\n",
+    "        }\n",
+    "        return t;\n",
+    "    }\n",
+    "    static Formula ParseOr(List<string> t, ref int i)\n",
+    "    {\n",
+    "        Formula f = ParseAnd(t, ref i);\n",
+    "        while (i < t.Count && t[i] == \"||\") { i++; f = Formula.Or(f, ParseAnd(t, ref i)); }\n",
+    "        return f;\n",
+    "    }\n",
+    "    static Formula ParseAnd(List<string> t, ref int i)\n",
+    "    {\n",
+    "        Formula f = ParseNot(t, ref i);\n",
+    "        while (i < t.Count && t[i] == \"&&\") { i++; f = Formula.And(f, ParseNot(t, ref i)); }\n",
+    "        return f;\n",
+    "    }\n",
+    "    static Formula ParseNot(List<string> t, ref int i)\n",
+    "    {\n",
+    "        if (i < t.Count && t[i] == \"!\") { i++; return Formula.Not(ParseNot(t, ref i)); }\n",
+    "        return ParsePrimary(t, ref i);\n",
+    "    }\n",
+    "    static Formula ParsePrimary(List<string> t, ref int i)\n",
+    "    {\n",
+    "        string tok = t[i];\n",
+    "        if (tok == \"+\") { i++; return Formula.Const(true); }\n",
+    "        if (tok == \"-\") { i++; return Formula.Const(false); }\n",
+    "        if (tok == \"(\") { i++; Formula f = ParseOr(t, ref i); i++; return f; } // saute ')'\n",
+    "        i++; return Formula.Atom(tok); // identificateur\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Modele causal structurel booleen ---\n",
+    "public sealed class StructuralCausalModel\n",
+    "{\n",
+    "    public enum Kind { Background, Explainable }\n",
+    "    public Dictionary<string, Kind> Kinds = new();\n",
+    "    public Dictionary<string, Formula> Eq = new();   // eq d'evaluation\n",
+    "    public Dictionary<string, string> EqSrc = new(); // eq source pour affichage\n",
+    "\n",
+    "    public List<string> Background => Kinds.Where(kv => kv.Value == Kind.Background).Select(kv => kv.Key).ToList();\n",
+    "    public List<string> Explainable => Kinds.Where(kv => kv.Value == Kind.Explainable).Select(kv => kv.Key).ToList();\n",
+    "\n",
+    "    public void AddBackgroundAtom(string a) { Kinds[a] = Kind.Background; }\n",
+    "    public void AddExplainableAtom(string a, string src) { Kinds[a] = Kind.Explainable; Eq[a] = FormulaParser.Parse(src); EqSrc[a] = src; }\n",
+    "\n",
+    "    // Ordre topologique sur les atomes expliques (Kahn ; les atomes de fond sont des sources).\n",
+    "    List<string> TopoOrder()\n",
+    "    {\n",
+    "        var remaining = Explainable.ToHashSet();\n",
+    "        var order = new List<string>();\n",
+    "        bool progress = true;\n",
+    "        while (remaining.Count > 0)\n",
+    "        {\n",
+    "            progress = false;\n",
+    "            foreach (var a in remaining.ToList())\n",
+    "            {\n",
+    "                bool depsOk = Eq[a].Vars.All(d => !remaining.Contains(d));\n",
+    "                if (depsOk) { order.Add(a); remaining.Remove(a); progress = true; }\n",
+    "            }\n",
+    "            if (!progress) throw new InvalidOperationException(\"SCM cyclique (equations structurelles doivent etre acycliques).\");\n",
+    "        }\n",
+    "        return order;\n",
+    "    }\n",
+    "\n",
+    "    // Propage : etant donne les atomes de fond, calcule le monde complet.\n",
+    "    public Dictionary<string, bool> Propagate(Dictionary<string, bool> bg)\n",
+    "    {\n",
+    "        var w = new Dictionary<string, bool>(bg);\n",
+    "        foreach (var a in TopoOrder()) w[a] = Eq[a].Eval(w);\n",
+    "        return w;\n",
+    "    }\n",
+    "\n",
+    "    // Tous les mondes possibles = produit de toutes les assignations des atomes de fond.\n",
+    "    public List<Dictionary<string, bool>> AllWorlds()\n",
+    "    {\n",
+    "        var bg = Background;\n",
+    "        var worlds = new List<Dictionary<string, bool>>();\n",
+    "        int n = bg.Count;\n",
+    "        for (int mask = 0; mask < (1 << n); mask++)\n",
+    "        {\n",
+    "            var assign = new Dictionary<string, bool>();\n",
+    "            for (int i = 0; i < n; i++) assign[bg[i]] = ((mask >> i) & 1) == 1;\n",
+    "            worlds.Add(Propagate(assign));\n",
+    "        }\n",
+    "        return worlds;\n",
+    "    }\n",
+    "\n",
+    "    public Dictionary<string, bool> BackgroundOf(Dictionary<string, bool> world)\n",
+    "    {\n",
+    "        var b = new Dictionary<string, bool>();\n",
+    "        foreach (var a in Background) b[a] = world[a];\n",
+    "        return b;\n",
+    "    }\n",
+    "\n",
+    "    // Chirurgie du do-operator : do(X = val) rompt les liens entrants vers X (X devient constante).\n",
+    "    public StructuralCausalModel Intervene(string atom, bool val)\n",
+    "    {\n",
+    "        var c = Clone();\n",
+    "        c.Kinds[atom] = Kind.Explainable;   // n'est plus libre : fixe par l'intervention\n",
+    "        c.Eq[atom] = Formula.Const(val);\n",
+    "        c.EqSrc[atom] = val ? \"+\" : \"-\";\n",
+    "        return c;\n",
+    "    }\n",
+    "\n",
+    "    public StructuralCausalModel Clone()\n",
+    "    {\n",
+    "        var c = new StructuralCausalModel();\n",
+    "        foreach (var kv in Kinds) c.Kinds[kv.Key] = kv.Value;\n",
+    "        foreach (var kv in Eq) c.Eq[kv.Key] = kv.Value;\n",
+    "        foreach (var kv in EqSrc) c.EqSrc[kv.Key] = kv.Value;\n",
+    "        return c;\n",
+    "    }\n",
+    "\n",
+    "    public string PrettyPrint()\n",
+    "    {\n",
+    "        var sb = new StringBuilder();\n",
+    "        foreach (var a in Background) sb.AppendLine($\"  [fond]      {a}\");\n",
+    "        foreach (var a in Explainable) sb.AppendLine($\"  [explique]  {a} <=> {EqSrc[a]}\");\n",
+    "        return sb.ToString().TrimEnd();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Show(\"StructuralCausalModel + parser de formules + propagation + Intervene (do-operator) prets.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ad2c98d",
+   "metadata": {},
+   "source": [
+    "## 2. Reasoner causal — observation, intervention, contrefactuel\n",
+    "\n",
+    "Trois types de requetes causales (Pearl) :\n",
+    "\n",
+    "- **Observation** `P(Y | observe X)` : correlation. Parmi les mondes ou X est vrai, Y est-il etabli ?\n",
+    "- **Intervention** `P(Y | do X)` : on applique la chirurgie `do(X)` puis on mesure Y. Casse les confondeurs.\n",
+    "- **Contrefactuel** `observe W ; si X avait ete autre, Y aurait-il eu lieu ?` : monde reel + monde contrefactuel.\n",
+    "\n",
+    "> Convention : une requete renvoie **True** si la conclusion est **etablie dans tous les mondes consistants**\n",
+    "> (si elle est vraie dans certains et fausse dans d'autres, la reponse est **False** = non determine)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e3fc1ddb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.187253Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.186782Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.273129Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.272867Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CausalKnowledgeBase + InterventionalStatement + CounterfactualStatement + CausalReasoner prets."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Base de connaissance causale : enveloppe le SCM (tous les mondes du modele sont candidats).\n",
+    "public sealed class CausalKnowledgeBase\n",
+    "{\n",
+    "    public StructuralCausalModel Model;\n",
+    "    public CausalKnowledgeBase(StructuralCausalModel m) { Model = m; }\n",
+    "    public List<Dictionary<string,bool>> Worlds() => Model.AllWorlds();\n",
+    "}\n",
+    "\n",
+    "// Declaration d'intervention : do(atom=val) pour plusieurs atomes + conclusion.\n",
+    "public sealed class InterventionalStatement\n",
+    "{\n",
+    "    public List<(string Atom, bool Val)> Interventions = new();\n",
+    "    public string Conclusion = \"\";\n",
+    "    public void AddIntervention(string atom, bool val) => Interventions.Add((atom, val));\n",
+    "    public void SetConclusion(string c) => Conclusion = c;\n",
+    "}\n",
+    "\n",
+    "// Declaration contrefactuelle : observations (monde reel) + interventions contrefactuelles + conclusion.\n",
+    "public sealed class CounterfactualStatement\n",
+    "{\n",
+    "    public List<(string Atom, bool Val)> Observations = new();\n",
+    "    public List<(string Atom, bool Val)> CfInterventions = new();\n",
+    "    public string Conclusion = \"\";\n",
+    "    public void AddObservation(string atom, bool val) => Observations.Add((atom, val));\n",
+    "    public void AddCounterfactualIntervention(string atom, bool val) => CfInterventions.Add((atom, val));\n",
+    "    public void SetConclusion(string c) => Conclusion = c;\n",
+    "}\n",
+    "\n",
+    "public sealed class CausalReasoner\n",
+    "{\n",
+    "    // Observation : conclusion etablie dans tous les mondes ou les atomes observes ont la valeur donnee.\n",
+    "    public bool Query(CausalKnowledgeBase ckb, List<(string Atom, bool Val)> observed, string conclusion)\n",
+    "    {\n",
+    "        var consistent = ckb.Worlds().Where(w => observed.All(o => w[o.Atom] == o.Val)).ToList();\n",
+    "        if (consistent.Count == 0) return false;\n",
+    "        return consistent.All(w => w[conclusion]);\n",
+    "    }\n",
+    "    // Raccourci : observer un atome = True.\n",
+    "    public bool Query(CausalKnowledgeBase ckb, List<string> observedTrue, string conclusion)\n",
+    "        => Query(ckb, observedTrue.Select(a => (a, true)).ToList(), conclusion);\n",
+    "\n",
+    "    // Intervention : on applique do(*) puis on demande si la conclusion est etablie dans tous les mondes.\n",
+    "    public bool Query(CausalKnowledgeBase ckb, InterventionalStatement stmt)\n",
+    "    {\n",
+    "        var m = ckb.Model;\n",
+    "        foreach (var iv in stmt.Interventions) m = m.Intervene(iv.Atom, iv.Val);\n",
+    "        var worlds = m.AllWorlds();\n",
+    "        if (worlds.Count == 0) return false;\n",
+    "        return worlds.All(w => w[stmt.Conclusion]);\n",
+    "    }\n",
+    "\n",
+    "    // Contrefactuel : mondes reels consistants avec l'observation ; sur CHACUN (fond fixe) on applique\n",
+    "    // l'intervention contrefactuelle et on re-evalue. La conclusion doit tenir dans tous les mondes contrefactuels.\n",
+    "    public bool Query(CausalKnowledgeBase ckb, CounterfactualStatement stmt)\n",
+    "    {\n",
+    "        var actual = ckb.Worlds().Where(w => stmt.Observations.All(o => w[o.Atom] == o.Val)).ToList();\n",
+    "        if (actual.Count == 0) return false;\n",
+    "        foreach (var w in actual)\n",
+    "        {\n",
+    "            var m = ckb.Model;\n",
+    "            foreach (var ci in stmt.CfInterventions) m = m.Intervene(ci.Atom, ci.Val);\n",
+    "            var cfWorld = m.Propagate(m.BackgroundOf(w));  // fond du monde reel, puis surgery\n",
+    "            if (!cfWorld[stmt.Conclusion]) return false;\n",
+    "        }\n",
+    "        return true;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Show(\"CausalKnowledgeBase + InterventionalStatement + CounterfactualStatement + CausalReasoner prets.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f7d8cbd",
+   "metadata": {},
+   "source": [
+    "## 3. Le baromètre — corrélation n'est pas causalité\n",
+    "\n",
+    "Exemple canonique : un baromètre qui tombe (`drops`) et la pluie (`rain`) sont **toutes deux causées** par l'orage (`storm`).\n",
+    "Observer le baromètre prédit la pluie (corrélation). **Forcer** le baromètre ne fait PAS pleuvoir (pas de lien causal `drops -> rain`).\n",
+    "\n",
+    "> C'est la distinction fondamentale `P(rain | drops) != P(rain | do drops)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2282ed95",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.274428Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.274225Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.320797Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.320589Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SCM barometre :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  [fond]      storm\r\n",
+       "  [explique]  drops <=> storm\r\n",
+       "  [explique]  rain <=> storm"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var storm = \"storm\"; var drops = \"drops\"; var rain = \"rain\";\n",
+    "\n",
+    "var barometer = new StructuralCausalModel();\n",
+    "barometer.AddBackgroundAtom(storm);            // storm = cause racine exogene\n",
+    "barometer.AddExplainableAtom(drops, \"storm\");  // drops  <=> storm\n",
+    "barometer.AddExplainableAtom(rain,  \"storm\");  // rain   <=> storm\n",
+    "\n",
+    "Show(\"SCM barometre :\");\n",
+    "Show(barometer.PrettyPrint());\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3ec954e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.322044Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.321840Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.365394Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.365196Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[OBSERVATION] observe(drops=True) -> pleut-il ? True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  -> Le barometre predit la pluie : P(rain | drops) = True (correlation via storm)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[INTERVENTION] do(drops=True)     -> pleut-il ? False"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  -> Forcer le barometre NE FAIT PAS pleuvoir : P(rain | do(drops)) = False"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var ckb_bar = new CausalKnowledgeBase(barometer);\n",
+    "var reasoner = new CausalReasoner();\n",
+    "\n",
+    "// NIVEAU 1 : observation (correlation)\n",
+    "bool p_rain_if_drops = reasoner.Query(ckb_bar, new List<string> { drops }, rain);\n",
+    "Show($\"[OBSERVATION] observe(drops=True) -> pleut-il ? {p_rain_if_drops}\");\n",
+    "Show(\"  -> Le barometre predit la pluie : P(rain | drops) = True (correlation via storm)\");\n",
+    "\n",
+    "// NIVEAU 2 : intervention do(drops=True)\n",
+    "var do_drops = new InterventionalStatement();\n",
+    "do_drops.AddIntervention(drops, true);\n",
+    "do_drops.SetConclusion(rain);\n",
+    "bool p_rain_if_do_drops = reasoner.Query(ckb_bar, do_drops);\n",
+    "Show($\"[INTERVENTION] do(drops=True)     -> pleut-il ? {p_rain_if_do_drops}\");\n",
+    "Show(\"  -> Forcer le barometre NE FAIT PAS pleuvoir : P(rain | do(drops)) = False\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84511081",
+   "metadata": {},
+   "source": [
+    "**Visualisation de la chirurgie** : `do(drops=True)` remplace l'équation `drops <=> storm` par `drops <=> +` (constante).\n",
+    "Le lien `storm -> drops` est **rompu** — `drops` ne dépend plus de `storm`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "61fc580d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.366738Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.366530Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.409282Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.409415Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SCM original :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    [fond]      storm\r\n",
+       "    [explique]  drops <=> storm\r\n",
+       "    [explique]  rain <=> storm"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "SCM apres do(drops=True) :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    [fond]      storm\r\n",
+       "    [explique]  drops <=> +\r\n",
+       "    [explique]  rain <=> storm"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "=> L'equation 'drops <=> storm' est devenue 'drops <=> +' (constante)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   Le lien storm -> drops est ROMPU : drops ne depend plus de storm."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Show(\"SCM original :\");\n",
+    "Show(\"  \" + barometer.PrettyPrint().Replace(\"\\n\", \"\\n  \"));\n",
+    "\n",
+    "Show(\"\\nSCM apres do(drops=True) :\");\n",
+    "var barometer_do = barometer.Intervene(drops, true);\n",
+    "Show(\"  \" + barometer_do.PrettyPrint().Replace(\"\\n\", \"\\n  \"));\n",
+    "Show(\"\\n=> L'equation 'drops <=> storm' est devenue 'drops <=> +' (constante).\");\n",
+    "Show(\"   Le lien storm -> drops est ROMPU : drops ne depend plus de storm.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa30c257",
+   "metadata": {},
+   "source": [
+    "## 4. Réseau Sprinkler — isoler l'effet causal propre\n",
+    "\n",
+    "Un SCM plus riche : `cloudy` cause `sprinkler` et `rain` ; tous deux causent `wet`.\n",
+    "C'est lejouet classique pour montrer que `do(rain)` casse le confondeur `cloudy` tandis que `do(sprinkler)` préserve la causalité directe vers `wet`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f59585fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.410917Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.410677Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.451732Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.451359Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SCM reseau Sprinkler :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  [fond]      cloudy\r\n",
+       "  [explique]  sprinkler <=> cloudy\r\n",
+       "  [explique]  rain <=> cloudy\r\n",
+       "  [explique]  wet <=> sprinkler || rain"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Base causale prete."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var cloudy = \"cloudy\"; var sprinkler = \"sprinkler\"; var rain2 = \"rain\"; var wet = \"wet\";\n",
+    "\n",
+    "var sprinkler_net = new StructuralCausalModel();\n",
+    "sprinkler_net.AddBackgroundAtom(cloudy);\n",
+    "sprinkler_net.AddExplainableAtom(sprinkler, \"cloudy\");\n",
+    "sprinkler_net.AddExplainableAtom(rain2,    \"cloudy\");\n",
+    "sprinkler_net.AddExplainableAtom(wet, \"sprinkler || rain\");   // wet = sprinkler OR rain\n",
+    "\n",
+    "Show(\"SCM reseau Sprinkler :\");\n",
+    "Show(sprinkler_net.PrettyPrint());\n",
+    "\n",
+    "var ckb_sp = new CausalKnowledgeBase(sprinkler_net);\n",
+    "Show(\"Base causale prete.\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5fe956b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.453647Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.453331Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.542084Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.541548Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Correlation vs Causalite dans le reseau Sprinkler ===\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[OBS]  observe(rain=True)  -> sprinkler actif ? True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "       (correlation : rain et sprinkler coincident via cloudy)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[INT]  do(rain=True)       -> sprinkler actif ? False"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "       (intervention : do(rain) CASSE cloudy->rain, donc plus de correlation avec sprinkler)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[INT]  do(sprinkler=True)  -> herbe mouillee ? True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "       (causalite directe preservee : sprinkler CAUSE wet)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "=> P(sprinkler | observe rain) != P(sprinkler | do rain)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   Signature du do-calculus : l'intervention isole l'effet causal propre."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Show(\"=== Correlation vs Causalite dans le reseau Sprinkler ===\\n\");\n",
+    "\n",
+    "// (a) OBSERVATION : observe(rain=True) -> sprinkler ?\n",
+    "bool p_sp_if_rain = reasoner.Query(ckb_sp, new List<string> { rain2 }, sprinkler);\n",
+    "Show($\"[OBS]  observe(rain=True)  -> sprinkler actif ? {p_sp_if_rain}\");\n",
+    "Show(\"       (correlation : rain et sprinkler coincident via cloudy)\\n\");\n",
+    "\n",
+    "// (b) INTERVENTION : do(rain=True) -> sprinkler ?\n",
+    "var do_rain = new InterventionalStatement();\n",
+    "do_rain.AddIntervention(rain2, true);\n",
+    "do_rain.SetConclusion(sprinkler);\n",
+    "bool p_sp_if_do_rain = reasoner.Query(ckb_sp, do_rain);\n",
+    "Show($\"[INT]  do(rain=True)       -> sprinkler actif ? {p_sp_if_do_rain}\");\n",
+    "Show(\"       (intervention : do(rain) CASSE cloudy->rain, donc plus de correlation avec sprinkler)\\n\");\n",
+    "\n",
+    "// (c) INTERVENTION causale directe : do(sprinkler=True) -> wet ?\n",
+    "var do_sp = new InterventionalStatement();\n",
+    "do_sp.AddIntervention(sprinkler, true);\n",
+    "do_sp.SetConclusion(wet);\n",
+    "bool p_wet_if_do_sp = reasoner.Query(ckb_sp, do_sp);\n",
+    "Show($\"[INT]  do(sprinkler=True)  -> herbe mouillee ? {p_wet_if_do_sp}\");\n",
+    "Show(\"       (causalite directe preservee : sprinkler CAUSE wet)\\n\");\n",
+    "\n",
+    "Show(\"=> P(sprinkler | observe rain) != P(sprinkler | do rain)\");\n",
+    "Show(\"   Signature du do-calculus : l'intervention isole l'effet causal propre.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5571b2be",
+   "metadata": {},
+   "source": [
+    "## 5. Raisonnement contrefactuel — mondes possibles\n",
+    "\n",
+    "Un **contrefactuel** : « on a observé `wet=True` ; si `sprinkler` avait été OFF, l'herbe aurait-elle tout de même été mouillée ? »\n",
+    "\n",
+    "Sémantique des mondes possibles : on fixe le monde réel (observé), on applique l'intervention contrefactuelle\n",
+    "en gardant les variables exogènes **fixes**, puis on ré-évalue la conclusion dans le monde contrefactuel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "55b0ab33",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.543864Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.543627Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.585319Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.584599Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[CONTREFACTUEL] observe(wet=True) ; 'si sprinkler avait ete OFF, herbe mouillee ?' True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  -> Oui : sous cloudy=True, rain aurait mouille l'herbe meme sans arrosage."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var cf = new CounterfactualStatement();\n",
+    "cf.AddObservation(wet, true);                  // monde reel : on a observe wet=True\n",
+    "cf.AddCounterfactualIntervention(sprinkler, false); // monde contrefactuel : sprinkler=False\n",
+    "cf.SetConclusion(wet);                         // question : wet dans le monde contrefactuel ?\n",
+    "\n",
+    "bool result_cf = reasoner.Query(ckb_sp, cf);\n",
+    "Show($\"[CONTREFACTUEL] observe(wet=True) ; 'si sprinkler avait ete OFF, herbe mouillee ?' {result_cf}\");\n",
+    "Show(\"  -> Oui : sous cloudy=True, rain aurait mouille l'herbe meme sans arrosage.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4125a1a9",
+   "metadata": {},
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "### Exercice 1 — Conclondant caché (ability / education / income)\n",
+    "\n",
+    "Construisez un SCM où `ability` cause à la fois `education` et `income` (`ability` est le **conclondant**).\n",
+    "Comparez `observe(education=True) -> income` (biaisé par le conclondant) et `do(education=True) -> income` (effet causal propre).\n",
+    "\n",
+    "> Indice : avec `ability` comme cause commune, l'observation `education` **porte** l'information sur `ability` (donc sur `income`),\n",
+    "> mais l'intervention `do(education)` coupe ce lien — l'effet direct devrait tomber à False."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f46df358",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.587322Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.587083Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.634006Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.633728Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  (attendu : observe(education) -> income True ; do(education) -> income False)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 1 : a completer\n",
+    "var ability = \"ability\"; var education = \"education\"; var income = \"income\";\n",
+    "\n",
+    "// TODO etudiant : construire le SCM edu_model\n",
+    "//   - ability  = atome de fond\n",
+    "//   - education = f(ability)\n",
+    "//   - income    = f(ability)   [ability est le confondeur !]\n",
+    "StructuralCausalModel? edu_model = null;  // TODO etudiant : new StructuralCausalModel() ...\n",
+    "\n",
+    "// TODO etudiant : comparer observe(education) -> income  vs  do(education) -> income\n",
+    "bool? result_observe = null;  // TODO etudiant\n",
+    "bool? result_do      = null;  // TODO etudiant\n",
+    "\n",
+    "Show(\"Exercice 1 a completer\");\n",
+    "Show(\"  (attendu : observe(education) -> income True ; do(education) -> income False)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fbe9474",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — L'intervention ne remonte pas la causalité\n",
+    "\n",
+    "Sur `ckb_sp`, comparez `do(cloudy=True) -> wet` (cause ancêtre, effet transmis) et `do(wet=True) -> rain`.\n",
+    "Le graphe est **orienté** : forcer un effet ne propage rien vers ses causes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "307c3e0a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.635633Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.635404Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.667191Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.666689Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 2 : a completer\n",
+    "// TODO etudiant : construire 2 InterventionalStatement et interroger ckb_sp\n",
+    "// Indice : do(wet=True) sur un EFFET ne remonte pas la causalite (le graphe est oriente).\n",
+    "\n",
+    "InterventionalStatement? ex2_a = null;  // TODO etudiant : do(cloudy=True) -> wet\n",
+    "InterventionalStatement? ex2_b = null;  // TODO etudiant : do(wet=True)    -> rain\n",
+    "Show(\"Exercice 2 a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51d8cf5f",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Contrefactuel sur la cause\n",
+    "\n",
+    "Construisez un `CounterfactualStatement` sur `ckb_sp` : `observe(rain=True)` ; intervention contrefactuelle `cloudy=False` ;\n",
+    "conclusion `rain`. Réfléchissez : `cloudy` est la **cause** de `rain` — si `cloudy` avait été faux, `rain` aurait-il eu lieu ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "3d4bfc0a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T21:51:21.668610Z",
+     "iopub.status.busy": "2026-07-06T21:51:21.668349Z",
+     "iopub.status.idle": "2026-07-06T21:51:21.703981Z",
+     "shell.execute_reply": "2026-07-06T21:51:21.703670Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  (reflechir : cloudy est la cause de rain ; si cloudy avait ete faux, rain n'aurait pas eu lieu)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Exercice 3 : a completer\n",
+    "// TODO etudiant : CounterfactualStatement sur ckb_sp\n",
+    "//   observe(rain=True) ; cf-intervention cloudy=False ; conclusion = rain\n",
+    "CounterfactualStatement? cf_ex3 = null;  // TODO etudiant\n",
+    "Show(\"Exercice 3 a completer\");\n",
+    "Show(\"  (reflechir : cloudy est la cause de rain ; si cloudy avait ete faux, rain n'aurait pas eu lieu)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02c12c96",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Synthèse\n",
+    "\n",
+    "Ce twin C# a réimplémenté **from-scratch** les trois piliers de l'inférence causale de Pearl :\n",
+    "\n",
+    "| Requête | Sémantique implémentée |\n",
+    "|--------|------------------------|\n",
+    "| `observe(X)` | filtrer les mondes possibles consistants |\n",
+    "| `do(X)` | **chirurgie de graphe** : remplacer l'équation de X par une constante |\n",
+    "| contrefactuel | monde réel observé + surgery sur fond **fixe** |\n",
+    "\n",
+    "La lib Tweety `causal-1.30.jar` (reasoner **argumentatif**) fournit la même sémantique en boîte noire ;\n",
+    "l'implémentation from-scratch rend **visible** pourquoi l'intervention isole l'effet causal propre — la valeur pédagogique.\n",
+    "\n",
+    "**Voir aussi** : [Tweety-11-Causal.ipynb](Tweety-11-Causal.ipynb) (Python + Tweety jar), marathon #4956, EPIC #3801."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Twin C# (.NET Interactive) de [Tweety-11-Causal.ipynb](MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal.ipynb) — **marathon parité #4956**.

## Substance pédagogique (Prong B, #3801)

Réimplémente **from-scratch** un moteur causal booléen (BCL .NET 9, **0 NuGet**) rendant visibles les internes du do-calculus de Pearl :

- **StructuralCausalModel** : atomes de fond (exogènes) + atomes expliqués (endogènes) définis par équations structurelles booléennes.
- **Parser PL minimale** (`|| && ! () + -`) — récursive descendante.
- **Propagation** par ordre topologique (Kahn) ; énumération des **mondes possibles** (produit des assignations de fond).
- **do-operator via chirurgie de graphe** : `Intervene(atom, val)` remplace l'équation de `atom` par une constante → **rompt les liens entrants** (le cœur de l'inférence causale).
- **Contrefactuels** par sémantique des mondes possibles : monde réel observé + surgery contrefactuelle sur fond **fixe**.

## Parité #4956 (complémentarité .NET ⇄ Python)

La version Python s'appuie sur **Tweety `causal-1.30.jar`** (JPype) : un reasoner causal **argumentatif** en boîte noire. Ce twin C# traduit le **cœur sémantique from-scratch** — la chirurgie `do(X)` et l'évaluation des mondes possibles deviennent **lisibles**. La lib Tweety = `RECOVERABLE-MACHINE` (Python-only) ; le moteur from-scratch EST la substance pédagogique.

## Preuve d'exécution (D. + H.)

- **12/12 cellules code** `execution_count` 1→12, **0 erreur**, **0 warning CS** (`#nullable enable`), **0 exec-no-output**.
- **0 path-leak** (sorties = valeurs booléennes uniquement ; pas de bloc `papermill` metadata injecté par nbconvert).
- **C.1 clean** : 0 `raise`/`assert False`/`throw NotImplementedException`. 3 stubs d'exercice retournent `null` + `Show("Exercice a completer")`.

### Hand-verification (G.1) — sémantique causale de Pearl

| Requête | Output | Théorie (Pearl) | Verdict |
|---------|--------|-----------------|---------|
| Baromètre `observe(drops)` → rain | **True** | corrélation via storm | ✓ |
| Baromètre `do(drops)` → rain | **False** | surgery casse `drops <=> storm` | ✓ |
| Sprinkler `observe(rain)` → sprinkler | **True** | corrélation via cloudy | ✓ |
| Sprinkler `do(rain)` → sprinkler | **False** | surgery casse `cloudy->rain` (confondeur) | ✓ |
| Sprinkler `do(sprinkler)` → wet | **True** | causalité directe préservée | ✓ |
| Contrefactuel `observe(wet)` + cf `sprinkler=False` → wet | **True** | rainy monde : rain aurait mouillé | ✓ |

**Visualisation de la chirurgie** : la cellule 6 montre le SCM avant/après `do(drops=True)` — `drops <=> storm` devient `drops <=> +` (constante), lien rompu.

## §E — audit fichier entier

README [Tweety/README.md](MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md) :
- **+1 table row** `11c` après Tweety-11 Python (pattern Tweety-10/10c).
- **+1 tree line** `Tweety-11-Causal-Csharp.ipynb` (pattern cohérent twins C# existants).
- **Count réconcilié disk-truth** : 27→**29 notebooks** (14→**16 C#/.NET**) — le compte prose était déjà stale (15 C# pré-ajout) ; audité vs disque (16 C# + 12 Python + 1 Lean = 29).
- **CATALOG byte-identique à main** (regen cron-only, HARD 1 catalog-pr-hygiene).
- Base **fresh** (origin/main 7634e75a5) — diff chirurgical, atomique (+1168/-1, 2 fichiers).

## Non-trivialité (Prong B, #3801)

Le problème est **non-dégénéré** : la distinction `P(Y|observe X) ≠ P(Y|do X)` (confondeurs) et les contrefactuels (qui exigent de fixer le monde réel puis appliquer la surgery) ne se réduisent pas à un simple calcul booléen — la sémantique des mondes possibles et la chirurgie de graphe sont l'enjeu pédagogique réel.

See #4956, #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)