### PR TITLE
feat(symbolic-learning): SL-3-RelevanceLearning-Csharp — RBL twin (.NET parity #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -176,6 +176,7 @@ Note : dans SL-7, le premier exercice de la numérotation interne est un exemple
 | 1 | [SL-1 - Apprentissage Logique](SL-1-LogicalLearning.ipynb) | CBH, Version Space, Candidate Elimination | 50 min |
 | 2 | [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb) | EBL, introduction au RBL (déterminations) | 45 min |
 | 3 | [SL-3 - Apprentissage Basé sur la Pertinence](SL-3-RelevanceLearning.ipynb) | Treillis des déterminations, MINIMAL-CONSISTENT-DET, RBL vs sklearn | 50 min |
+| 3 (C#) | [SL-3 - RBL (Twin C#)](SL-3-RelevanceLearning-Csharp.ipynb) | **Jumeau C#** — Treillis des déterminations, MINIMAL-CONSISTENT-DET (BFS), PAC bound, information mutuelle from-scratch (See #4956) | 50 min |
 | 4 | [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb) | FOIL, résolution inverse, clauses Horn, knowledge graphs, Popper (LFF) | 55 min |
 | 4 (C#) | [SL-4 - ILP (Twin C#)](SL-4-InductiveLogicProgramming-Csharp.ipynb) | **Jumeau C#** — FOIL (gain Quinlan) + résolution inverse (V/W) + unification from-scratch, mini-KG (See #4956) | 50 min |
 | 5 | [SL-5 - Résolution Inverse et Progol](SL-5-InverseResolution.ipynb) | LGG de Plotkin, theta-subsomption, clause bottom, recherche Progol | 60 min |
@@ -434,6 +435,7 @@ SymbolicLearning/
 ├── SL-2-KnowledgeBasedLearning.ipynb        # EBL, RBL
 ├── SL-2-KnowledgeBasedLearning-Csharp.ipynb # Jumeau C# (.NET Interactive) — EBL + RBL, parité #4956
 ├── SL-3-RelevanceLearning.ipynb             # Treillis, MINIMAL-CONSISTENT-DET, RBL vs sklearn
+├── SL-3-RelevanceLearning-Csharp.ipynb # Jumeau C# (.NET Interactive) — Treillis + MINIMAL-CONSISTENT-DET + PAC + MI, parité #4956
 ├── SL-4-InductiveLogicProgramming.ipynb     # FOIL, résolution inverse, knowledge graphs
 ├── SL-4-InductiveLogicProgramming-Csharp.ipynb  # Jumeau C# (.NET Interactive) — FOIL + V/W + unification, parité #4956
 ├── SL-5-InverseResolution.ipynb             # LGG, theta-subsomption, clause bottom, Progol

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning-Csharp.ipynb
@@ -1,0 +1,1165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "50a20e10",
+   "metadata": {},
+   "source": [
+    "# SL-3 — Apprentissage basé sur la pertinence (twin C# from-scratch)\n",
+    "\n",
+    "Ce notebook est le **jumeau C# / .NET** de [SL-3-RelevanceLearning.ipynb](SL-3-RelevanceLearning.ipynb) — marathon de parité #4956.\n",
+    "\n",
+    "La version Python déroule le **Relevance-Based Learning (RBL, AIMA §19.4)** en pur Python. Ce twin C# **réimplémente le moteur\n",
+    "from-scratch** (BCL .NET 9, 0 NuGet) : déterminations fonctionnelles, treillis des déterminations, clé minimale,\n",
+    "borne PAC, information mutuelle pour la sélection d'attributs. sklearn/Python = `RECOVERABLE-MACHINE` ; le moteur from-scratch EST la substance.\n",
+    "\n",
+    "**Idée centrale (RBL)** : au lieu d'apprendre dans l'espace d'hypothèses complet (2^n sous-ensembles d'attributs),\n",
+    "on cherche le **plus petit sous-ensemble d'attributs qui détermine fonctionnellement la cible** — la *détermination minimale*.\n",
+    "Cela réduit exponentiellement l'espace (2^n → 2^d, d ≪ n) et le nombre d'exemples requis devient linéaire en d."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a053018",
+   "metadata": {},
+   "source": [
+    "## 1. Déterminations fonctionnelles\n",
+    "\n",
+    "Une **détermination** `attrs → target` tient si, pour tout groupe de lignes partageant les mêmes valeurs d'`attrs`,\n",
+    "la valeur de `target` est constante. C'est l'analogue d'une **dépendance fonctionnelle** en théorie des bases de données.\n",
+    "Une violation = deux lignes mêmes attrs, target différent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "78db8fdb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:02.868732Z",
+     "iopub.status.busy": "2026-07-06T23:21:02.864501Z",
+     "iopub.status.idle": "2026-07-06T23:21:04.368799Z",
+     "shell.execute_reply": "2026-07-06T23:21:04.362956Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '32684.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Apprentissage base sur la pertinence (RBL, AIMA 19.4) — moteur from-scratch."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "static void Show(string s) { s.Display(); }\n",
+    "Show(\"Apprentissage base sur la pertinence (RBL, AIMA 19.4) — moteur from-scratch.\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "401bb366",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:04.370347Z",
+     "iopub.status.busy": "2026-07-06T23:21:04.370126Z",
+     "iopub.status.idle": "2026-07-06T23:21:04.883464Z",
+     "shell.execute_reply": "2026-07-06T23:21:04.883230Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CheckDetermination pret : groupe par signature, detecte les violations de target constante."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "// Une ligne de donnees : dictionnaire attribut -> valeur (string, domaine discret).\n",
+    "public sealed class Row : Dictionary<string,string> { }\n",
+    "\n",
+    "// Resultat de la verification d'une determination, avec diagnostic des violations.\n",
+    "public sealed class DeterminationResult\n",
+    "{\n",
+    "    public List<string> Attrs = new();\n",
+    "    public string Target = \"\";\n",
+    "    public bool Holds;\n",
+    "    public List<(Row A, Row B)> Violations = new();  // paires de lignes en conflit\n",
+    "    public int Coverage;                              // nombre de groupes distincts\n",
+    "}\n",
+    "\n",
+    "// Verifie si detAttrs determinent target (target constante dans chaque groupe).\n",
+    "public static DeterminationResult CheckDetermination(List<Row> data, List<string> detAttrs, string targetAttr)\n",
+    "{\n",
+    "    var res = new DeterminationResult { Attrs = detAttrs, Target = targetAttr };\n",
+    "    // Grouper par signature des attrs determinants.\n",
+    "    var groups = new Dictionary<string, List<Row>>();\n",
+    "    foreach (var row in data)\n",
+    "    {\n",
+    "        string key = string.Join(\"\\x1f\", detAttrs.Select(a => row[a]));  // unit separator evite les collisions\n",
+    "        if (!groups.ContainsKey(key)) groups[key] = new List<Row>();\n",
+    "        groups[key].Add(row);\n",
+    "    }\n",
+    "    res.Coverage = groups.Count;\n",
+    "    foreach (var kv in groups)\n",
+    "    {\n",
+    "        var targetValues = kv.Value.Select(r => r[targetAttr]).Distinct().ToList();\n",
+    "        if (targetValues.Count > 1)\n",
+    "        {\n",
+    "            // Violation : on garde la premiere paire en conflit pour le diagnostic.\n",
+    "            res.Violations.Add((kv.Value[0], kv.Value[1]));\n",
+    "        }\n",
+    "    }\n",
+    "    res.Holds = res.Violations.Count == 0;\n",
+    "    return res;\n",
+    "}\n",
+    "\n",
+    "Show(\"CheckDetermination pret : groupe par signature, detecte les violations de target constante.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6091c05",
+   "metadata": {},
+   "source": [
+    "## 2. Treillis des déterminations (powerset)\n",
+    "\n",
+    "L'ensemble des sous-ensembles d'attributs forme un **treillis**. Pour chaque sous-ensemble, on note s'il détermine la cible.\n",
+    "Visualiser ce treillis révèle la structure : la détermination est **anti-monotone** (si un ensemble détermine, ses sur-ensembles aussi)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fba8797a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:04.885020Z",
+     "iopub.status.busy": "2026-07-06T23:21:04.884814Z",
+     "iopub.status.idle": "2026-07-06T23:21:05.080440Z",
+     "shell.execute_reply": "2026-07-06T23:21:05.080225Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BuildDeterminationLattice pret : powerset complet evalue."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "// Toutes les combinaisons de taille k (substitut a itertools.combinations).\n",
+    "public static IEnumerable<List<string>> Combinations(List<string> items, int k)\n",
+    "{\n",
+    "    if (k == 0) { yield return new List<string>(); yield break; }\n",
+    "    if (k > items.Count) yield break;\n",
+    "    for (int i = 0; i <= items.Count - k; i++)\n",
+    "    {\n",
+    "        var head = items[i];\n",
+    "        foreach (var tail in Combinations(items.Skip(i + 1).ToList(), k - 1))\n",
+    "        {\n",
+    "            var combo = new List<string> { head };\n",
+    "            combo.AddRange(tail);\n",
+    "            yield return combo;\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Cle trieee pour indexer le lattice (evite HashSet comme cle de dict).\n",
+    "public static string SortedKey(List<string> attrs) => string.Join(\",\", attrs.OrderBy(a => a));\n",
+    "\n",
+    "// Construit le treillis complet : chaque sous-ensemble -> tient ou non.\n",
+    "public static Dictionary<string,bool> BuildDeterminationLattice(List<Row> data, List<string> allAttrs, string targetAttr)\n",
+    "{\n",
+    "    var lattice = new Dictionary<string,bool>();\n",
+    "    for (int size = 0; size <= allAttrs.Count; size++)\n",
+    "        foreach (var subset in Combinations(allAttrs, size))\n",
+    "        {\n",
+    "            bool holds;\n",
+    "            if (size == 0)\n",
+    "            {\n",
+    "                // L'ensemble vide ne determine que s'il n'y a qu'une seule valeur cible.\n",
+    "                holds = data.Select(r => r[targetAttr]).Distinct().Count() == 1;\n",
+    "            }\n",
+    "            else\n",
+    "            {\n",
+    "                holds = CheckDetermination(data, subset, targetAttr).Holds;\n",
+    "            }\n",
+    "            lattice[SortedKey(subset)] = holds;\n",
+    "        }\n",
+    "    return lattice;\n",
+    "}\n",
+    "\n",
+    "Show(\"BuildDeterminationLattice pret : powerset complet evalue.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ac26f00",
+   "metadata": {},
+   "source": [
+    "## 3. Détermination minimale (clé candidate)\n",
+    "\n",
+    "La **détermination minimale** est le plus petit sous-ensemble qui détermine la cible.\n",
+    "On l'obtient par recherche en largeur (BFS par taille croissante) — le premier trouvé est minimal.\n",
+    "C'est l'analogue d'une **clé candidate minimale** en bases de données."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3c3ee7e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:05.081784Z",
+     "iopub.status.busy": "2026-07-06T23:21:05.081589Z",
+     "iopub.status.idle": "2026-07-06T23:21:05.223277Z",
+     "shell.execute_reply": "2026-07-06T23:21:05.222863Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MinimalConsistentDet pret : BFS par taille, retourne le + petit sous-ensemble valide."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "public sealed class DetSearchResult\n",
+    "{\n",
+    "    public List<string>? Determination;\n",
+    "    public int SubsetsTested;\n",
+    "    public int LevelsExplored;\n",
+    "    public int? FoundAtLevel;\n",
+    "}\n",
+    "\n",
+    "// Recherche BFS par taille croissante : retourne le plus petit sous-ensemble valide.\n",
+    "public static DetSearchResult MinimalConsistentDet(List<Row> data, List<string> allAttrs, string targetAttr, bool verbose = true)\n",
+    "{\n",
+    "    int totalTested = 0;\n",
+    "    var sb = new StringBuilder();\n",
+    "    for (int size = 1; size <= allAttrs.Count; size++)\n",
+    "    {\n",
+    "        var subsets = Combinations(allAttrs, size).ToList();\n",
+    "        if (verbose) sb.AppendLine($\"  Niveau {size} : test de {subsets.Count} combinaisons...\");\n",
+    "        foreach (var subset in subsets)\n",
+    "        {\n",
+    "            totalTested++;\n",
+    "            if (CheckDetermination(data, subset, targetAttr).Holds)\n",
+    "            {\n",
+    "                if (verbose) sb.AppendLine($\"    TROUVE : {{{string.Join(\", \", subset)}}} apres {totalTested} tests\");\n",
+    "                if (verbose) Show(sb.ToString());\n",
+    "                return new DetSearchResult { Determination = subset, SubsetsTested = totalTested, LevelsExplored = size, FoundAtLevel = size };\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    if (verbose) { sb.AppendLine($\"  Aucune determination trouvee ({totalTested} tests)\"); Show(sb.ToString()); }\n",
+    "    return new DetSearchResult { Determination = null, SubsetsTested = totalTested, LevelsExplored = allAttrs.Count, FoundAtLevel = null };\n",
+    "}\n",
+    "\n",
+    "Show(\"MinimalConsistentDet pret : BFS par taille, retourne le + petit sous-ensemble valide.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dff01d39",
+   "metadata": {},
+   "source": [
+    "## 4. Application — activité biologique des molécules\n",
+    "\n",
+    "Quelles propriétés moléculaires (mw, logp, hbd, hba) déterminent si une molécule est **active** ?\n",
+    "La recherche de détermination minimale répond en explorant le treillis par taille croissante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3ea6e7c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:05.225379Z",
+     "iopub.status.busy": "2026-07-06T23:21:05.224891Z",
+     "iopub.status.idle": "2026-07-06T23:21:05.452540Z",
+     "shell.execute_reply": "2026-07-06T23:21:05.452371Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Donnees : proprietes moleculaires (10 molecules)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "      MW |   LogP |   HBD |    HBA |   Activite\r\n",
+       "--------------------------------------------------\r\n",
+       "     low |    low |   low |    low |   inactive\r\n",
+       "     low |    low |   low |   high |   inactive\r\n",
+       "  medium |   high |   low |   high |     active\r\n",
+       "  medium |   high |  high |   high |     active\r\n",
+       "    high |   high |   low |   high |     active\r\n",
+       "    high |   high |  high |   high |     active\r\n",
+       "    high |    low |  high |    low |   inactive\r\n",
+       "  medium |    low |  high |    low |   inactive\r\n",
+       "     low |   high |   low |    low |   inactive\r\n",
+       "  medium |   high |   low |    low |     active\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "Recherche de determination minimale :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Niveau 1 : test de 4 combinaisons...\r\n",
+       "  Niveau 2 : test de 6 combinaisons...\r\n",
+       "    TROUVE : {mw, logp} apres 5 tests\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "Determination minimale : {mw, logp}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sous-ensembles testes : 5 / 15"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Reduction espace : O(2^4) -> O(2^2), facteur 4"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "Row R(params (string k,string v)[] pairs)\n",
+    "{\n",
+    "    var d = new Row();\n",
+    "    foreach (var (k,v) in pairs) d[k] = v;\n",
+    "    return d;\n",
+    "}\n",
+    "\n",
+    "var moleculeData = new List<Row>\n",
+    "{\n",
+    "    R((\"mw\",\"low\"),(\"logp\",\"low\"),(\"hbd\",\"low\"),(\"hba\",\"low\"),(\"activity\",\"inactive\")),\n",
+    "    R((\"mw\",\"low\"),(\"logp\",\"low\"),(\"hbd\",\"low\"),(\"hba\",\"high\"),(\"activity\",\"inactive\")),\n",
+    "    R((\"mw\",\"medium\"),(\"logp\",\"high\"),(\"hbd\",\"low\"),(\"hba\",\"high\"),(\"activity\",\"active\")),\n",
+    "    R((\"mw\",\"medium\"),(\"logp\",\"high\"),(\"hbd\",\"high\"),(\"hba\",\"high\"),(\"activity\",\"active\")),\n",
+    "    R((\"mw\",\"high\"),(\"logp\",\"high\"),(\"hbd\",\"low\"),(\"hba\",\"high\"),(\"activity\",\"active\")),\n",
+    "    R((\"mw\",\"high\"),(\"logp\",\"high\"),(\"hbd\",\"high\"),(\"hba\",\"high\"),(\"activity\",\"active\")),\n",
+    "    R((\"mw\",\"high\"),(\"logp\",\"low\"),(\"hbd\",\"high\"),(\"hba\",\"low\"),(\"activity\",\"inactive\")),\n",
+    "    R((\"mw\",\"medium\"),(\"logp\",\"low\"),(\"hbd\",\"high\"),(\"hba\",\"low\"),(\"activity\",\"inactive\")),\n",
+    "    R((\"mw\",\"low\"),(\"logp\",\"high\"),(\"hbd\",\"low\"),(\"hba\",\"low\"),(\"activity\",\"inactive\")),\n",
+    "    R((\"mw\",\"medium\"),(\"logp\",\"high\"),(\"hbd\",\"low\"),(\"hba\",\"low\"),(\"activity\",\"active\")),\n",
+    "};\n",
+    "\n",
+    "var MOL_ATTRS = new List<string> { \"mw\", \"logp\", \"hbd\", \"hba\" };\n",
+    "\n",
+    "Show(\"Donnees : proprietes moleculaires (10 molecules)\");\n",
+    "var hdr = new StringBuilder();\n",
+    "hdr.AppendLine($\"{\"MW\",8} | {\"LogP\",6} | {\"HBD\",5} | {\"HBA\",6} | {\"Activite\",10}\");\n",
+    "hdr.AppendLine(new string('-', 50));\n",
+    "foreach (var row in moleculeData)\n",
+    "    hdr.AppendLine($\"{row[\"mw\"],8} | {row[\"logp\"],6} | {row[\"hbd\"],5} | {row[\"hba\"],6} | {row[\"activity\"],10}\");\n",
+    "Show(hdr.ToString());\n",
+    "\n",
+    "Show(\"\\nRecherche de determination minimale :\");\n",
+    "var molRes = MinimalConsistentDet(moleculeData, MOL_ATTRS, \"activity\");\n",
+    "\n",
+    "if (molRes.Determination is not null)\n",
+    "{\n",
+    "    int d = molRes.Determination.Count, n = MOL_ATTRS.Count;\n",
+    "    Show($\"\\nDetermination minimale : {{{string.Join(\", \", molRes.Determination)}}}\");\n",
+    "    Show($\"Sous-ensembles testes : {molRes.SubsetsTested} / {(1 << n) - 1}\");\n",
+    "    Show($\"Reduction espace : O(2^{n}) -> O(2^{d}), facteur {1 << (n - d)}\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    Show(\"\\nAucune determination fonctionnelle trouvee.\");\n",
+    "    Show(\"-> Le concept est probablement disjonctif ou depend d'interactions.\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bada08c",
+   "metadata": {},
+   "source": [
+    "## 5. Borne PAC — l'avantage quantifié\n",
+    "\n",
+    "En apprentissage PAC (Probably Approximately Correct), le nombre d'exemples suffisant pour apprendre dans un espace d'hypothèses fini vaut :\n",
+    "\n",
+    "> m ≥ (1/ε)·(ln|H| + ln(1/δ)),  avec |H| = 2^n (sélection d'attributs).\n",
+    "\n",
+    "Le RBL réduit |H| de 2^n à 2^d (d = taille de la détermination) : le nombre d'exemples devient **linéaire en d** au lieu de n."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8c4d6537",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:05.454336Z",
+     "iopub.status.busy": "2026-07-06T23:21:05.453869Z",
+     "iopub.status.idle": "2026-07-06T23:21:05.563625Z",
+     "shell.execute_reply": "2026-07-06T23:21:05.563456Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Analyse de complexite : RBL vs selection aveugle\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       " n (total) |  d (pertinent) |   |H| sans RBL |   |H| avec RBL |  m sans |  m avec"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "------------------------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "         5 |              1 |             32 |              2 |      65 |      37"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "        10 |              2 |           1024 |              4 |     100 |      44"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "        20 |              2 |        1048576 |              4 |     169 |      44"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "        20 |              3 |        1048576 |              8 |     169 |      51"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "        50 |              3 | 1125899906842624 |              8 |     377 |      51"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "       100 |              5 |          2^100 |             32 |     724 |      65"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "La reduction de l'espace est EXPONENTIELLE (2^n -> 2^d) ; m devient lineaire en d."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Pour n=100 et d=5 : 724 exemples sans RBL contre 65 avec la determination."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "// Borne PAC : m >= (1/eps) * (ln|H| + ln(1/delta)), avec |H| = 2^n_attrs.\n",
+    "public static int PacBound(int nAttrs, double epsilon = 0.1, double delta = 0.05)\n",
+    "{\n",
+    "    double lnH = nAttrs * Math.Log(2);          // ln(|H|) = n * ln(2)\n",
+    "    return (int)Math.Ceiling((1.0 / epsilon) * (lnH + Math.Log(1.0 / delta)));\n",
+    "}\n",
+    "\n",
+    "Show(\"Analyse de complexite : RBL vs selection aveugle\\n\");\n",
+    "// |H| = 2^k ; pour k grand (> 62) le cast long deborde : on affiche alors la forme symbolique.\n",
+    "string HStr(int k) => k <= 62 ? ((long)Math.Pow(2, k)).ToString() : $\"2^{k}\";\n",
+    "\n",
+    "Show($\"{\"n (total)\",10} | {\"d (pertinent)\",14} | {\"|H| sans RBL\",14} | {\"|H| avec RBL\",14} | {\"m sans\",7} | {\"m avec\",7}\");\n",
+    "Show(new string('-', 78));\n",
+    "foreach (var (n, d) in new[] { (5,1), (10,2), (20,2), (20,3), (50,3), (100,5) })\n",
+    "{\n",
+    "    Show($\"{n,10} | {d,14} | {HStr(n),14} | {HStr(d),14} | {PacBound(n),7} | {PacBound(d),7}\");\n",
+    "}\n",
+    "Show(\"\\nLa reduction de l'espace est EXPONENTIELLE (2^n -> 2^d) ; m devient lineaire en d.\");\n",
+    "Show($\"Pour n=100 et d=5 : {PacBound(100)} exemples sans RBL contre {PacBound(5)} avec la determination.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "518ae76c",
+   "metadata": {},
+   "source": [
+    "## 6. Parallèle RBL ↔ Web Sémantique (OWL)\n",
+    "\n",
+    "Une détermination `metal → conductivité` (RBL) correspond à déclarer `:aConductivite` comme **`owl:FunctionalProperty`** :\n",
+    "chaque sujet a au plus une valeur. Un reasoner OWL (HermiT, Pellet) détecterait les violations comme une incohérence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5a603d09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:05.564787Z",
+     "iopub.status.busy": "2026-07-06T23:21:05.564607Z",
+     "iopub.status.idle": "2026-07-06T23:21:05.699356Z",
+     "shell.execute_reply": "2026-07-06T23:21:05.698976Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Parallele RBL <-> Web Semantique : la MEME contrainte, deux formalismes"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Propriete fonctionnelle :aConductivite — violations detectees :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  :Fe a 2 objets distincts : [high, medium]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "Une determination RBL = exactement une owl:FunctionalProperty ; les deux formalismes"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "expriment la meme contrainte fonctionnelle (un sujet -> au plus un objet)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "// Mini triple-store (sujet, predicat, objet) en pur C#.\n",
+    "public sealed record Triple(string S, string P, string O);\n",
+    "\n",
+    "// Detecte les violations de fonctionnalite d'une propriete OWL :\n",
+    "// un sujet avec plusieurs objets distincts = incoherence.\n",
+    "public static Dictionary<string, List<string>> FunctionalViolations(List<Triple> triples, string prop)\n",
+    "{\n",
+    "    var objects = new Dictionary<string, HashSet<string>>();\n",
+    "    foreach (var t in triples)\n",
+    "        if (t.P == prop)\n",
+    "        {\n",
+    "            if (!objects.ContainsKey(t.S)) objects[t.S] = new HashSet<string>();\n",
+    "            objects[t.S].Add(t.O);\n",
+    "        }\n",
+    "    return objects.Where(kv => kv.Value.Count > 1)\n",
+    "                  .OrderBy(kv => kv.Key)\n",
+    "                  .ToDictionary(kv => kv.Key, kv => kv.Value.OrderBy(o => o).ToList());\n",
+    "}\n",
+    "\n",
+    "var copperData = new List<Row>\n",
+    "{\n",
+    "    R((\"metal\",\"Cu\"),(\"conductivity\",\"high\")),\n",
+    "    R((\"metal\",\"Ag\"),(\"conductivity\",\"high\")),\n",
+    "    R((\"metal\",\"Fe\"),(\"conductivity\",\"medium\")),\n",
+    "    R((\"metal\",\"Cu\"),(\"conductivity\",\"high\")),   // doublon coherent\n",
+    "};\n",
+    "\n",
+    "var triples = new List<Triple>();\n",
+    "foreach (var r in copperData) triples.Add(new Triple($\":{r[\"metal\"]}\", \":aConductivite\", r[\"conductivity\"]));\n",
+    "triples.Add(new Triple(\":aConductivite\", \"rdf:type\", \"owl:FunctionalProperty\"));\n",
+    "\n",
+    "// Injectons une incoherence : Fe avec 2 valeurs.\n",
+    "triples.Add(new Triple(\":Fe\", \":aConductivite\", \"high\"));\n",
+    "\n",
+    "var viol = FunctionalViolations(triples, \":aConductivite\");\n",
+    "Show(\"Parallele RBL <-> Web Semantique : la MEME contrainte, deux formalismes\");\n",
+    "Show($\"Propriete fonctionnelle :aConductivite — violations detectees :\");\n",
+    "if (viol.Count == 0) Show(\"  (aucune — coherent)\");\n",
+    "foreach (var kv in viol)\n",
+    "    Show($\"  {kv.Key} a {kv.Value.Count} objets distincts : [{string.Join(\", \", kv.Value)}]\");\n",
+    "Show(\"\\nUne determination RBL = exactement une owl:FunctionalProperty ; les deux formalismes\");\n",
+    "Show(\"expriment la meme contrainte fonctionnelle (un sujet -> au plus un objet).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "846f8493",
+   "metadata": {},
+   "source": [
+    "## 7. Information mutuelle — sélection guidée\n",
+    "\n",
+    "Le treillis des déterminations grandit comme 2^n. Une heuristique : guider la recherche par **l'information mutuelle**\n",
+    "I(attr ; target). Les attributs à forte MI sont des candidats prioritaires pour la détermination."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a016d1f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:05.700580Z",
+     "iopub.status.busy": "2026-07-06T23:21:05.700403Z",
+     "iopub.status.idle": "2026-07-06T23:21:05.874229Z",
+     "shell.execute_reply": "2026-07-06T23:21:05.873566Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Scores d'information mutuelle des proprietes moleculaires vs activite :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  I(logp ; activity) = 0,6100 bits"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  I(mw ; activity) = 0,4000 bits"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  I(hba ; activity) = 0,2781 bits"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  I(hbd ; activity) = 0,0000 bits"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "L'attribut avec la plus forte MI est le meilleur candidat pour demarrer la recherche de determination."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "// Entropie de Shannon (base 2) d'une distribution de valeurs.\n",
+    "public static double Entropy(IEnumerable<string> values)\n",
+    "{\n",
+    "    var list = values.ToList();\n",
+    "    if (list.Count == 0) return 0;\n",
+    "    return list.GroupBy(v => v)\n",
+    "               .Select(g => (double)g.Count() / list.Count)\n",
+    "               .Sum(p => -p * Math.Log2(p));\n",
+    "}\n",
+    "\n",
+    "// Information mutuelle I(attr ; target) = H(target) - H(target | attr).\n",
+    "public static double MutualInformation(List<Row> data, string attr, string targetAttr)\n",
+    "{\n",
+    "    double hTarget = Entropy(data.Select(r => r[targetAttr]));\n",
+    "    double hCond = data.GroupBy(r => r[attr])\n",
+    "                      .Select(g => (double)g.Count() / data.Count * Entropy(g.Select(r => r[targetAttr])))\n",
+    "                      .Sum();\n",
+    "    return hTarget - hCond;\n",
+    "}\n",
+    "\n",
+    "Show(\"Scores d'information mutuelle des proprietes moleculaires vs activite :\");\n",
+    "var miScores = MOL_ATTRS.ToDictionary(a => a, a => MutualInformation(moleculeData, a, \"activity\"));\n",
+    "foreach (var kv in miScores.OrderByDescending(kv => kv.Value))\n",
+    "    Show($\"  I({kv.Key} ; activity) = {kv.Value:F4} bits\");\n",
+    "\n",
+    "Show(\"\\nL'attribut avec la plus forte MI est le meilleur candidat pour demarrer la recherche de determination.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c25c7f04",
+   "metadata": {},
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "### Exercice 1 — Prédiction par détermination\n",
+    "\n",
+    "Utilisez la détermination minimale trouvée (section 4) pour **prédire** l'activité d'une nouvelle molécule.\n",
+    "Si ses valeurs pour les attributs déterminants correspondent à un groupe connu, renvoyez l'activité de ce groupe ; sinon `\"?\"`.\n",
+    "\n",
+    "> Indice : groupez `moleculeData` par signature de la détermination ; cherchez le groupe correspondant à la nouvelle ligne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ce50643a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:05.877063Z",
+     "iopub.status.busy": "2026-07-06T23:21:05.876630Z",
+     "iopub.status.idle": "2026-07-06T23:21:05.929073Z",
+     "shell.execute_reply": "2026-07-06T23:21:05.928852Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  (attendu pour high/high/low/high : 'active')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "// TODO etudiant : predire l'activite d'une nouvelle molecule via la determination minimale.\n",
+    "// Si aucune ligne connue ne partage la signature -> renvoyer \"?\".\n",
+    "static string PredictActivity(List<Row> data, List<string> detAttrs, Row newRow)\n",
+    "{\n",
+    "    // Indice : grouper data par signature detAttrs, chercher le groupe de newRow.\n",
+    "    return \"?\";  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "var testRow = R((\"mw\",\"high\"),(\"logp\",\"high\"),(\"hbd\",\"low\"),(\"hba\",\"high\"));\n",
+    "string? predicted = null;  // TODO etudiant : PredictActivity(moleculeData, molRes.Determination ?? MOL_ATTRS, testRow);\n",
+    "Show(\"Exercice 1 a completer\");\n",
+    "Show($\"  (attendu pour {testRow[\"mw\"]}/{testRow[\"logp\"]}/{testRow[\"hbd\"]}/{testRow[\"hba\"]} : 'active')\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6af317f",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Borne PAC stratifiée\n",
+    "\n",
+    "Après RBL, la borne PAC peut être **resserrée** : si la détermination a taille d, |H| = 2^d.\n",
+    "Implémentez une borne qui prend en compte la détermination trouvée et comparez-la à la borne brute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "945f13fb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:05.930867Z",
+     "iopub.status.busy": "2026-07-06T23:21:05.930664Z",
+     "iopub.status.idle": "2026-07-06T23:21:05.981081Z",
+     "shell.execute_reply": "2026-07-06T23:21:05.980752Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  (attendu : mSans > mAvec, reduction ~ factorielle en n-d)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "// TODO etudiant : borne PAC apres RBL (|H| = 2^d au lieu de 2^n).\n",
+    "// Retourner (mSansRBL, mAvecRBL) pour n attributs dont d pertinents.\n",
+    "static (int mSans, int mAvec) StratifiedPacBound(int n, int d, double epsilon = 0.1, double delta = 0.05)\n",
+    "{\n",
+    "    // Indice : reutiliser PacBound avec n puis d.\n",
+    "    return (0, 0);  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "var sp = (0, 0);  // TODO etudiant : StratifiedPacBound(20, 2);\n",
+    "Show(\"Exercice 2 a completer\");\n",
+    "Show(\"  (attendu : mSans > mAvec, reduction ~ factorielle en n-d)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de9f1c08",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Pruning anti-monotone du treillis\n",
+    "\n",
+    "La détermination est **anti-monotone** : si un sous-ensemble ne détermine pas la cible, aucun de ses sous-ensembles ne le peut non plus\n",
+    "(en fait c'est l'inverse — si un sur-ensemble détermine, ses sous-ensembles aussi... à vérifier !).\n",
+    "Implémentez une recherche de détermination minimale qui **élague** le treillis en exploitant cette propriété pour éviter des tests inutiles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "bdebdef8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:21:05.982672Z",
+     "iopub.status.busy": "2026-07-06T23:21:05.982442Z",
+     "iopub.status.idle": "2026-07-06T23:21:06.017810Z",
+     "shell.execute_reply": "2026-07-06T23:21:06.017596Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 a completer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  (reflechir : anti-monotonie = si A determine, tout sur-ensemble de A determine aussi)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "\n",
+    "// TODO etudiant : MinimalConsistentDet avec pruning anti-monotone.\n",
+    "// Si un sous-ensemble de taille k ne determine PAS, aucun sous-ensemble de taille < k contenu dedans\n",
+    "// ne peut determiner (propriete a verifier/demontrer). Elager en consequence.\n",
+    "static List<string>? PrunedMinimalDet(List<Row> data, List<string> allAttrs, string targetAttr)\n",
+    "{\n",
+    "    // Indice : memoiser les sous-ensembles echoues ; skipper leurs subsets.\n",
+    "    return null;  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "List<string>? pruned = null;  // TODO etudiant : PrunedMinimalDet(moleculeData, MOL_ATTRS, \"activity\");\n",
+    "Show(\"Exercice 3 a completer\");\n",
+    "Show(\"  (reflechir : anti-monotonie = si A determine, tout sur-ensemble de A determine aussi)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70763225",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Synthèse\n",
+    "\n",
+    "Ce twin C# a réimplémenté **from-scratch** les piliers du Relevance-Based Learning :\n",
+    "\n",
+    "| Concept | Implémentation |\n",
+    "|---------|----------------|\n",
+    "| Détermination fonctionnelle | `CheckDetermination` (groupage par signature) |\n",
+    "| Treillis des déterminations | `BuildDeterminationLattice` (powerset) |\n",
+    "| Détermination minimale | `MinimalConsistentDet` (BFS par taille) |\n",
+    "| Borne PAC | `PacBound` (m ≥ (1/ε)·(ln2^n + ln(1/δ))) |\n",
+    "| Parallèle OWL | `FunctionalViolations` (owl:FunctionalProperty) |\n",
+    "| Sélection par MI | `MutualInformation` (H(target) − H(target|attr)) |\n",
+    "\n",
+    "La lib Python (sklearn/AIMA) fournit ces constructions en boîte noire ; l'implémentation from-scratch rend **visible**\n",
+    "pourquoi la détermination minimale réduit exponentiellement l'espace d'hypothèses (2^n → 2^d) et rend le nombre d'exemples linéaire en d.\n",
+    "\n",
+    "**Voir aussi** : [SL-3-RelevanceLearning.ipynb](SL-3-RelevanceLearning.ipynb) (Python), [SL-4-InductiveLogicProgramming-Csharp.ipynb](SL-4-InductiveLogicProgramming-Csharp.ipynb), marathon #4956, EPIC #3801."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## SL-3-RelevanceLearning-Csharp — Jumeau C# de SL-3 (Marathon parité #4956)

Jumeau .NET Interactive de [SL-3-RelevanceLearning.ipynb](SL-3-RelevanceLearning.ipynb) — Apprentissage Basé sur la Pertinence (Relevance-Based Learning, AIMA §19.4).

### Contenu (tout from-scratch, pas de sklearn/numpy)

| Concept | Implémentation C# |
|--------|-------------------|
| **Déterminations fonctionnelles** | `CheckDetermination` — group by signature (clé unit-separator), détecte violations target-constant |
| **Treillis des déterminations** | `BuildDeterminationLattice` — powerset 2^n |
| **MINIMAL-CONSISTENT-DET** | BFS par taille croissante, retourne la plus petite clé candidate valide |
| **PAC bound** | `PacBound(n, eps=0.1, delta=0.05)` — m >= (1/eps)(n ln2 + ln(1/delta)) ; affichage symbolique 2^k pour k>62 (anti-overflow) |
| **FunctionalProperty OWL** | `FunctionalViolations` — parallèle propriété fonctionnelle OWL |
| **Information mutuelle** | `MutualInformation` = H(target) - H(target|attr) from-scratch (Math.Log2) |
| **Combinations** | récursif (substitut itertools.combinations) |

### Validation (EXEC_PROVED)
- **11/11 cellules code** `execution_count` 1-11, **0 error**, **0 warning CS**, **0 path-leak**
- Outputs vérifiés firsthand : détermination {mw, logp} trouvée après 5 tests (réduction facteur 4, O(2^4) -> O(2^2)), PAC n=5 -> m=65/37, FunctionalViolations, MI(logp)=0.6100 bits, 2^100 symbolique (overflow corrigé)

### §E README
+1 ligne table `3 (C#)` après SL-3 Python + +1 ligne tree. CATALOG byte-identique préservé.

### Prong B (#3801)
Implémentation from-scratch complémentaire au twin Python (qui utilise sklearn/numpy pour la comparaison) : value-add authentique (moteur RBL pur type system), pas un simple miroir.

### Exercices (3, règle C.1)
`PredictActivity` / `StratifiedPacBound` / `PrunedMinimalDet` — stubs `pass`/`return null` (pas de `raise NotImplementedException`).

See #4956 (marathon parité .NET <-> Python)
See #3801 (registre SOTA axe-2)
