### PR TITLE
feat(gametheory): GameTheory-10-ForwardInduction-SPE-Csharp — twin C# refinements (.NET parity #4956)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE-Csharp.ipynb
@@ -1,0 +1,1076 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "08132f1e",
+   "metadata": {},
+   "source": [
+    "# GameTheory-10 — Équilibres Parfaits de Sous-Jeux et Induction Avant (Twin C#)\n",
+    "\n",
+    "**Jumeau C# (.NET Interactive)** de `GameTheory-10-ForwardInduction-SPE.ipynb` — marathon parité .NET ⇄ Python (#4956).\n",
+    "\n",
+    "Ce notebook réimplémente from-scratch en C# pur (BCL .NET 9, **0 NuGet**) les **raffinements d'équilibre** sur la forme extensive : équilibre parfait de sous-jeux (SPE via **backward induction**), analyse des **menaces crédibles**, **perfection en mains tremblantes** (trembling-hand), **induction avant** (forward induction, logique de Cho-Kreps) et **signal par brûlage** (burn money).\n",
+    "\n",
+    "> L'original Python s'appuie sur `numpy`/`matplotlib` pour les calculs et graphes ; ce twin traduit les algorithmes en type system C# + `HashSet`/LINQ, et restitue les résultats en **tables console**. La valeur ajoutée n'est pas un miroir : c'est un **moteur de théorie des jeux extensifs typé**, où l'arbre de jeu, la récursion de backward induction et la détection des sous-jeux vivent dans le système de types.\n",
+    "\n",
+    "**Voir aussi** : [GameTheory-10 (Python)](GameTheory-10-ForwardInduction-SPE.ipynb) · marathon [#4956](https://github.com/jsboige/CoursIA/issues/4956) · registre SOTA [#3801](https://github.com/jsboige/CoursIA/issues/3801).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd7c32d8",
+   "metadata": {},
+   "source": [
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Définir un **jeu sous forme extensive** (arbre, nœuds de décision, nœuds terminaux, paiements).\n",
+    "2. Calculer l'**équilibre parfait de sous-jeux (SPE)** par **backward induction** (récursion sur l'arbre).\n",
+    "3. Distinguer **menace crédible** vs **non-crédible** (pourquoi certains équilibres de Nash ne survivent pas).\n",
+    "4. Appliquer la **perfection en mains tremblantes** (perturbation ε).\n",
+    "5. Maîtriser l'**induction avant** (forward induction) : déduire les intentions d'un joueur de ses actions hors-chemin.\n",
+    "6. Analyser le **signal par brûlage** (burn money).\n",
+    "\n",
+    "### Prérequis\n",
+    "- Théorie de l'équilibre de Nash (cf. [GameTheory-4](GameTheory-4-NashEquilibrium-Csharp.ipynb)).\n",
+    "- Forme extensive (cf. [GameTheory-7](GameTheory-7-ExtensiveForm-Csharp.ipynb)).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "07891ccb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:57:59.792241Z",
+     "iopub.status.busy": "2026-07-06T23:57:59.787486Z",
+     "iopub.status.idle": "2026-07-06T23:58:01.595652Z",
+     "shell.execute_reply": "2026-07-06T23:58:01.591350Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '54644.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Types charges : GameNode (arbre), ExtensiveFormGame, helper Show()."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Setup : types de base pour un jeu sous forme extensive.\n",
+    "#nullable enable\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// Helper d'affichage (headless-safe : .Display() capture text/plain).\n",
+    "public static void Show(object? o) => (o?.ToString() ?? \"<null>\").Display();\n",
+    "\n",
+    "// Noeud d'un arbre de jeu extensif (information parfaite : singleton info-set).\n",
+    "public sealed class GameNode\n",
+    "{\n",
+    "    public int Id { get; }\n",
+    "    public int Player { get; }               // joueur qui decide (-1 = terminal)\n",
+    "    public List<GameNode> Children { get; } = new();\n",
+    "    public List<string> Actions { get; } = new();   // etiquette d'action par enfant\n",
+    "    public double[]? Payoffs { get; }        // paiement terminal (null si decision)\n",
+    "    public bool IsTerminal => Player < 0;\n",
+    "    public GameNode(int id, int player, double[]? payoffs = null)\n",
+    "    { Id = id; Player = player; Payoffs = payoffs; }\n",
+    "    public GameNode AddChild(string action, GameNode child) { Actions.Add(action); Children.Add(child); return this; }\n",
+    "}\n",
+    "\n",
+    "// Un jeu extensif = racine + nombre de joueurs.\n",
+    "public sealed class ExtensiveFormGame\n",
+    "{\n",
+    "    public GameNode Root { get; }\n",
+    "    public int NPlayers { get; }\n",
+    "    public string[] PlayerNames { get; }\n",
+    "    public ExtensiveFormGame(GameNode root, int n, string[]? names = null)\n",
+    "    { Root = root; NPlayers = n; PlayerNames = names ?? Enumerable.Range(0,n).Select(i=>$\"J{i+1}\").ToArray(); }\n",
+    "}\n",
+    "\n",
+    "Show(\"Types charges : GameNode (arbre), ExtensiveFormGame, helper Show().\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "622f22b0",
+   "metadata": {},
+   "source": [
+    "## 1. Sous-jeux et équilibre parfait (SPE)\n",
+    "\n",
+    "### 1.1 Définition d'un sous-jeu\n",
+    "Un **sous-jeu** est un sous-arbre commençant à un nœud de décision et contenant tous ses descendants (sans couper d'information). En information parfaite, **tout nœud de décision est racine d'un sous-jeu**.\n",
+    "\n",
+    "### 1.2 SPE par backward induction\n",
+    "L'**équilibre parfait de sous-jeux** (Selten 1965) est un profil de stratégie qui forme un équilibre de Nash dans **chaque** sous-jeu. On le calcule par **backward induction** : à chaque nœud de décision, le joueur choisit l'action maximisant son paiement sachant que la suite se jouera selon le SPE des sous-jeux plus profonds.\n",
+    "\n",
+    "> Le SPE élimine les **menaces non crédibles** : un équilibre de Nash peut reposer sur une action hors-chemin qu'un joueur rationnel ne jouerait jamais si le nœud était atteint. Le SPE, lui, exige la rationalité à **tous** les nœuds.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ef03dffd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:01.597854Z",
+     "iopub.status.busy": "2026-07-06T23:58:01.597441Z",
+     "iopub.status.idle": "2026-07-06T23:58:01.857920Z",
+     "shell.execute_reply": "2026-07-06T23:58:01.857567Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BackwardInduction + enumeration des sous-jeux definis."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Backward induction : retourne les paiements SPE + le chemin d'actions.\n",
+    "#nullable enable\n",
+    "public static (double[] payoffs, List<(int nodeId, string action)> path) BackwardInduction(GameNode n)\n",
+    "{\n",
+    "    if (n.IsTerminal) return (n.Payoffs!, new List<(int,string)>());\n",
+    "    double[]? best = null;\n",
+    "    int bestIdx = 0;\n",
+    "    for (int i = 0; i < n.Children.Count; i++)\n",
+    "    {\n",
+    "        var (cp, _) = BackwardInduction(n.Children[i]);\n",
+    "        if (best == null || cp[n.Player] > best[n.Player] + 1e-12)\n",
+    "        { best = cp; bestIdx = i; }\n",
+    "    }\n",
+    "    var path = new List<(int,string)> { (n.Id, n.Actions[bestIdx]) };\n",
+    "    var (_, sub) = BackwardInduction(n.Children[bestIdx]);\n",
+    "    path.AddRange(sub);\n",
+    "    return (best!, path);\n",
+    "}\n",
+    "\n",
+    "// Enumere tous les sous-jeux (racines = tous les nœuds de decision, info parfaite).\n",
+    "public static List<GameNode> AllDecisionNodes(GameNode n, List<GameNode>? acc = null)\n",
+    "{\n",
+    "    acc ??= new();\n",
+    "    if (!n.IsTerminal) acc.Add(n);\n",
+    "    foreach (var c in n.Children) AllDecisionNodes(c, acc);\n",
+    "    return acc;\n",
+    "}\n",
+    "\n",
+    "Show(\"BackwardInduction + enumeration des sous-jeux definis.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c5ebfcd",
+   "metadata": {},
+   "source": [
+    "### Interprétation : SPE sur le jeu d'entrée (entrant vs incumbent)\n",
+    "\n",
+    "Le jeu d'entrée canonique : un **entrant** décide d'**Entrer** (In) ou **Rester dehors** (Out). S'il entre, l'**incumbent** choisit **Accommoder** (Acc) ou **Combattre** (Fight).\n",
+    "\n",
+    "- `Out` → entrant 1, incumbent 2\n",
+    "- `In → Acc` → entrant 2, incumbent 1\n",
+    "- `In → Fight` → entrant −1, incumbent −1\n",
+    "\n",
+    "L'incumbent a une **menace** (« je combattrai »), mais au nœud incumbent, Accommoder (1) domine strictement Combattre (−1) : la menace est **non crédible**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3d049ddb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:01.859604Z",
+     "iopub.status.busy": "2026-07-06T23:58:01.859420Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.000129Z",
+     "shell.execute_reply": "2026-07-06T23:58:01.999798Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Jeu d'entree (entrant vs incumbent)\r\n",
+       "  Joueurs : Entrant, Incumbent\r\n",
+       "  Sous-jeux (racines) : 2 (nœuds 1, 2)\r\n",
+       "\r\n",
+       "SPE (backward induction) :\r\n",
+       "  Nœud 1 -> In\r\n",
+       "  Nœud 2 -> Acc\r\n",
+       "  Paiement SPE = (2, 1)  (Entrant, Incumbent)\r\n",
+       "\r\n",
+       "Analyse menace (Fight) : au nœud incumbent (joueur 1),\r\n",
+       "  Acc = 1, Fight = -1  -> Accommoder domine strictement.\r\n",
+       "  => 'Fight' est une menace NON CRÉDIBLE (hors-chemin SPE).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Construction de l'arbre du jeu d'entree.\n",
+    "var nOut = new GameNode(3, -1, new double[]{ 1.0, 2.0 });\n",
+    "var nAcc = new GameNode(4, -1, new double[]{ 2.0, 1.0 });\n",
+    "var nFight = new GameNode(5, -1, new double[]{ -1.0, -1.0 });\n",
+    "var incumbent = new GameNode(2, 1);  // joueur 2 (incumbent) decide\n",
+    "incumbent.AddChild(\"Acc\", nAcc).AddChild(\"Fight\", nFight);\n",
+    "var entrant = new GameNode(1, 0);   // joueur 1 (entrant) decide\n",
+    "entrant.AddChild(\"Out\", nOut).AddChild(\"In\", incumbent);\n",
+    "\n",
+    "var entryGame = new ExtensiveFormGame(entrant, 2, new[]{ \"Entrant\", \"Incumbent\" });\n",
+    "\n",
+    "var (spePay, spePath) = BackwardInduction(entryGame.Root);\n",
+    "var subgames = AllDecisionNodes(entryGame.Root);\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Jeu d'entree (entrant vs incumbent)\");\n",
+    "sb.AppendLine($\"  Joueurs : {string.Join(\", \", entryGame.PlayerNames)}\");\n",
+    "sb.AppendLine($\"  Sous-jeux (racines) : {subgames.Count} (nœuds {string.Join(\", \", subgames.Select(s=>s.Id))})\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"SPE (backward induction) :\");\n",
+    "foreach (var (nid, act) in spePath) sb.AppendLine($\"  Nœud {nid} -> {act}\");\n",
+    "sb.AppendLine($\"  Paiement SPE = ({spePay[0]}, {spePay[1]})  (Entrant, Incumbent)\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Analyse menace (Fight) : au nœud incumbent (joueur 1),\");\n",
+    "sb.AppendLine($\"  Acc = {nAcc.Payoffs![1]}, Fight = {nFight.Payoffs![1]}  -> Accommoder domine strictement.\");\n",
+    "sb.AppendLine(\"  => 'Fight' est une menace NON CRÉDIBLE (hors-chemin SPE).\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08a0deb7",
+   "metadata": {},
+   "source": [
+    "### Interprétation des résultats\n",
+    "\n",
+    "Le SPE est **(In, Acc)** avec paiement **(2, 1)**. Le profil `(Out, Fight)` — où l'entrant reste dehors par peur de la menace — est un **équilibre de Nash** (l'entrant sort car il croit à Fight ; l'incumbent annonce Fight, jamais testé car l'entrant sort). Mais ce n'est **pas un SPE** : si l'entrant entrait quand même, l'incumbent rationnel accommoderait. C'est le cœur de la distinction Nash vs SPE.\n",
+    "\n",
+    "Le nombre de sous-jeux = 2 (nœuds 1 et 2) : la racine et le nœud incumbent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7392500c",
+   "metadata": {},
+   "source": [
+    "## 2. Menaces et promesses crédibles\n",
+    "\n",
+    "### 2.1 Menace non crédible\n",
+    "On parle de **menace non crédible** quand un joueur annonce une action punitive qui **n'est pas dans son intérêt** une fois le nœud atteint. Le SPE l'élimine automatiquement (rationalité à tous les nœuds).\n",
+    "\n",
+    "### 2.2 Rendre une menace crédible\n",
+    "Pour rendre une menace crédible, un joueur peut **s'engager** (brûler ses ponts, signer un contrat, déléguer à un agent). En modifiant l'arbre (par exemple en retirant l'option Accommoder), la menace devient rationnelle au nœud atteint, donc **survit au SPE**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a2d34a90",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.001687Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.001499Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.075811Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.075632Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Variante 'engagement' : Fight rapporte desormais 3 a l'incumbent (engagement credible).\r\n",
+       "  Au nœud incumbent : Acc = 1, Fight = 3 -> Fight domine.\r\n",
+       "  => Menace CREMBLEE credible, le SPE bascule :\r\n",
+       "    Nœud 1 -> Out\r\n",
+       "  Paiement SPE = (1, 2)\r\n",
+       "\r\n",
+       "Leçon : changer la structure de paiements (engagement) transforme une menace\r\n",
+       "non credible en credible, et modifie l'issue du jeu (l'entrant prefere sortir).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Rendre la menace credible : l'incumbent s'engage publiquement a Combattre.\n",
+    "// On modifie l'arbre : l'incumbent n'a plus que 'Fight' (Acc retire).\n",
+    "var nAcc2 = new GameNode(4, -1, new double[]{ 2.0, 1.0 });\n",
+    "var nFight2 = new GameNode(5, -1, new double[]{ -1.0, 3.0 });  // Fight desormais rentable (engagement)\n",
+    "var incumbentCommit = new GameNode(2, 1);\n",
+    "incumbentCommit.AddChild(\"Acc\", nAcc2).AddChild(\"Fight\", nFight2);\n",
+    "var entrantCommit = new GameNode(1, 0);\n",
+    "entrantCommit.AddChild(\"Out\", new GameNode(3,-1,new double[]{1.0,2.0}))\n",
+    "            .AddChild(\"In\", incumbentCommit);\n",
+    "\n",
+    "var (spe2, path2) = BackwardInduction(entrantCommit);\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Variante 'engagement' : Fight rapporte desormais 3 a l'incumbent (engagement credible).\");\n",
+    "sb.AppendLine($\"  Au nœud incumbent : Acc = {nAcc2.Payoffs![1]}, Fight = {nFight2.Payoffs![1]} -> Fight domine.\");\n",
+    "sb.AppendLine(\"  => Menace CREMBLEE credible, le SPE bascule :\");\n",
+    "foreach (var (nid, act) in path2) sb.AppendLine($\"    Nœud {nid} -> {act}\");\n",
+    "sb.AppendLine($\"  Paiement SPE = ({spe2[0]}, {spe2[1]})\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Leçon : changer la structure de paiements (engagement) transforme une menace\");\n",
+    "sb.AppendLine(\"non credible en credible, et modifie l'issue du jeu (l'entrant prefere sortir).\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbbd166e",
+   "metadata": {},
+   "source": [
+    "### Le paradoxe de l'engagement\n",
+    "**Paradoxe** : se lier les mains (retirer une option, s'engager à une action coûteuse ex ante) peut **augmenter** le paiement d'un joueur. C'est le principe de la **dissuasion par engagement** (Schelling) : la crédibilité d'une menace vient de l'impossibilité de revenir en arrière.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29b52989",
+   "metadata": {},
+   "source": [
+    "## 3. Induction avant (Forward Induction)\n",
+    "\n",
+    "### 3.1 Principe\n",
+    "L'**induction avant** (Cho-Kreps 1987) déduit les **intentions** d'un joueur de ses **actions passées**, en supposant qu'il est rationnel : si un joueur renonce à une option sûre pour entrer dans un sous-jeu, il **signale** qu'il a l'intention de jouer l'équilibre qui justifie ce renoncement.\n",
+    "\n",
+    "Contrairement au SPE (qui ne regarde que les sous-jeux en partant de la fin), l'induction avant exploite la **logique de signal** des actions hors-chemin.\n",
+    "\n",
+    "### 3.2 Exemple : Chasse au Cerf avec option extérieure\n",
+    "- Le joueur 1 choisit d'abord : **Out** (paiement garanti 3 pour les deux) ou **In** (entrer dans la Chasse au Cerf).\n",
+    "- Chasse au Cerf : `Stag/Stag = (4,4)`, `Stag/Hare = (0,3)`, `Hare/Stag = (3,0)`, `Hare/Hare = (2,2)`.\n",
+    "\n",
+    "**Logique d'induction avant** : si P1 renonce à Out (3) pour jouer In, la seule façon d'obtenir plus que 3 est de jouer **Stag** (si P2 joue Stag, on obtient 4 > 3 ; Hare ne donne que 2 < 3). P2, voyant que P1 a renoncé à Out, **infère** que P1 jouera Stag → P2 joue Stag → **(Stag, Stag)**.\n",
+    "\n",
+    "Cet équilibre **n'est pas sélectionné** par le seul SPE (qui admet aussi (Hare, Hare) dans le sous-jeu).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "75ca498a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.077334Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.077100Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.212574Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.211984Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Stag Hunt + option exterieure (Out = 3)\r\n",
+       "Equilibres de Nash purs du sous-jeu Stag Hunt :\r\n",
+       "  (Stag, Stag) -> paiement (4, 4)\r\n",
+       "  (Hare, Hare) -> paiement (2, 2)\r\n",
+       "\r\n",
+       "Induction avant (Cho-Kreps) :\r\n",
+       "  P1 renonce a Out (3) pour jouer In.\r\n",
+       "  - Si P1 comptait jouer Hare, son paiement max serait 3 (= 3 de Out), pas strictement superieur -> renoncer a Out pour Hare n'est jamais rentable.\r\n",
+       "  - Seul Stag peut justifier le renoncement (paiement max Stag = 4, et 4 > 3 si P2 joue Stag).\r\n",
+       "  => P2 infere P1 = Stag -> P2 joue Stag (best response a Stag = Stag).\r\n",
+       "  => Forward induction selectionne (Stag, Stag) = (4, 4).\r\n",
+       "\r\n",
+       "Comparaison : SPE admet (Stag,Stag) ET (Hare,Hare) comme sous-jeu-NE ;\r\n",
+       "forward induction selectionne (Stag,Stag) en exploitant le signal du renoncement a Out.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Forward induction sur Stag Hunt + option exterieure (Cho-Kreps).\n",
+    "// Matrice du sous-jeu Stag Hunt (lignes = P1, colonnes = P2) : [Stag, Hare]\n",
+    "double[,] stagHunt = {\n",
+    "    { 4.0, 0.0 },   // P1 Stag : (vs Stag=4, vs Hare=0)\n",
+    "    { 3.0, 2.0 }    // P1 Hare : (vs Stag=3, vs Hare=2)\n",
+    "};\n",
+    "// P2 (colonne) paiements :\n",
+    "double[,] stagHuntP2 = {\n",
+    "    { 4.0, 3.0 },   // P2 vs P1=Stag : (Stag=4, Hare=3)\n",
+    "    { 0.0, 2.0 }    // P2 vs P1=Hare : (Stag=0, Hare=2)\n",
+    "};\n",
+    "string[] actions = { \"Stag\", \"Hare\" };\n",
+    "double outPayoff = 3.0;  // option exterieure garantie\n",
+    "\n",
+    "// Equilibres de Nash du sous-jeu (strategies pures) : identifier les best-responses croises.\n",
+    "var bestP1 = new List<int>();   // meilleure reponse de P1 a chaque action de P2\n",
+    "var bestP2 = new List<int>();\n",
+    "for (int j = 0; j < 2; j++)\n",
+    "{\n",
+    "    int bi = 0;\n",
+    "    for (int i = 1; i < 2; i++) if (stagHunt[i, j] > stagHunt[bi, j]) bi = i;\n",
+    "    bestP1.Add(bi);\n",
+    "}\n",
+    "for (int i = 0; i < 2; i++)\n",
+    "{\n",
+    "    int bj = 0;\n",
+    "    for (int j = 1; j < 2; j++) if (stagHuntP2[i, j] > stagHuntP2[i, bj]) bj = j;\n",
+    "    bestP2.Add(bj);\n",
+    "}\n",
+    "var nashPure = new List<(int i, int j)>();\n",
+    "for (int i = 0; i < 2; i++)\n",
+    "    for (int j = 0; j < 2; j++)\n",
+    "        if (bestP1[j] == i && bestP2[i] == j)\n",
+    "            nashPure.Add((i, j));\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Stag Hunt + option exterieure (Out = 3)\");\n",
+    "sb.AppendLine(\"Equilibres de Nash purs du sous-jeu Stag Hunt :\");\n",
+    "foreach (var (i, j) in nashPure)\n",
+    "    sb.AppendLine($\"  ({actions[i]}, {actions[j]}) -> paiement ({stagHunt[i,j]}, {stagHuntP2[i,j]})\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Induction avant (Cho-Kreps) :\");\n",
+    "sb.AppendLine($\"  P1 renonce a Out ({outPayoff}) pour jouer In.\");\n",
+    "sb.AppendLine($\"  - Si P1 comptait jouer Hare, son paiement max serait {Math.Max(stagHunt[1,0], stagHunt[1,1])} (= {outPayoff} de Out), pas strictement superieur -> renoncer a Out pour Hare n'est jamais rentable.\");\n",
+    "double stagBest = Math.Max(stagHunt[0,0], stagHunt[0,1]);  // P1 Stag vs best of P2\n",
+    "sb.AppendLine($\"  - Seul Stag peut justifier le renoncement (paiement max Stag = {stagBest}, et {stagHunt[0,0]} > {outPayoff} si P2 joue Stag).\");\n",
+    "sb.AppendLine($\"  => P2 infere P1 = Stag -> P2 joue Stag (best response a Stag = {actions[bestP2[0]]}).\");\n",
+    "sb.AppendLine($\"  => Forward induction selectionne (Stag, Stag) = ({stagHunt[0,0]}, {stagHuntP2[0,0]}).\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Comparaison : SPE admet (Stag,Stag) ET (Hare,Hare) comme sous-jeu-NE ;\");\n",
+    "sb.AppendLine(\"forward induction selectionne (Stag,Stag) en exploitant le signal du renoncement a Out.\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c1b7300",
+   "metadata": {},
+   "source": [
+    "### Pourquoi l'induction avant est puissante\n",
+    "L'induction avant **sélectionne** parmi plusieurs SPE celui cohérent avec la rationalité passée. Elle capture l'idée que les actions **communiquent** : renoncer à une option sûre est un acte de **signal**. C'est la base des jeux de signal (Spence) et du raffinement des équilibres en information incomplète.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df921399",
+   "metadata": {},
+   "source": [
+    "## 4. Perfection en mains tremblantes (Trembling-hand perfection)\n",
+    "\n",
+    "### 4.1 Motivation\n",
+    "Le SPE exige la rationalité à tous les nœuds, mais un nœud hors-chemin n'est **jamais atteint** : on peut y mettre n'importe quelle action. La **perfection en mains tremblantes** (Selten 1975) exige que l'équilibre soit robuste à de **petites erreurs** (tremblements) : chaque joueur joue chaque action avec une probabilité ε > 0, et l'équilibre est la limite quand ε → 0.\n",
+    "\n",
+    "### 4.2 Définition\n",
+    "Un profil est **trembling-hand parfait** s'il est la limite d'une suite d'équilibres ε-perturbés où **toutes** les actions sont jouées avec probabilité positive.\n",
+    "\n",
+    "### 4.3 Conséquences\n",
+    "La perfection élimine les équilibres qui nécessitent qu'un joueur soit **certain** qu'un nœud hors-chemin ne sera jamais atteint.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9f6a0bfc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.214702Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.214338Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.342402Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.341978Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Trembling-hand perfection (eps = 0,1) sur le jeu d'entree\r\n",
+       "  Au nœud incumbent : Acc = 1, Fight = -1\r\n",
+       "    -> Accommodate domine : True (robuste sous tremblement, le dominant reste dominant).\r\n",
+       "  Esperance entrant (In->Acc) avec tremblement Out = 1,900\r\n",
+       "    vs Out pur = 1  -> In preferable : True\r\n",
+       "\r\n",
+       "Verdict : le SPE (In, Acc) est trembling-hand parfait. Meme avec 10% de chance\r\n",
+       "de 'trembler' vers Out, Accommodate reste strictement dominant pour l'incumbent,\r\n",
+       "et In reste preferable pour l'entrant. L'equilibre ne s'appuie sur aucune certitude\r\n",
+       "qu'un nœud hors-chemin serait evite.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Trembling-hand : on perturbe le jeu d'entree par epsilon (l'entrant peut 'trembler').\n",
+    "// Entrant joue In avec (1-eps), Out avec eps. Au nœud incumbent, on calcule le paiement\n",
+    "// esperé de Acc vs Fight, pour verifier la robustesse du SPE sous tremblement.\n",
+    "double eps = 0.10;   // 10% de tremblement\n",
+    "// Au nœud incumbent (atteint avec proba 1-eps), les paiements Acc/Fight sont inchanges\n",
+    "// (le tremblement est sur le choix de l'entrant, pas sur l'incumbent).\n",
+    "double accIncumbent = 1.0;     // paiement si Accommodate\n",
+    "double fightIncumbent = -1.0;  // paiement si Fight\n",
+    "bool accDominates = accIncumbent > fightIncumbent;\n",
+    "\n",
+    "// Esperance pour l'entrant sous (In->Acc) avec tremblement Out :\n",
+    "double entrantInAcc = (1 - eps) * 2.0 + eps * 1.0;   // In(2) w.p. 1-eps, Out(1) w.p. eps\n",
+    "double entrantOut = 1.0;\n",
+    "bool inPreferred = entrantInAcc > entrantOut;\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine($\"Trembling-hand perfection (eps = {eps}) sur le jeu d'entree\");\n",
+    "sb.AppendLine($\"  Au nœud incumbent : Acc = {accIncumbent}, Fight = {fightIncumbent}\");\n",
+    "sb.AppendLine($\"    -> Accommodate domine : {accDominates} (robuste sous tremblement, le dominant reste dominant).\");\n",
+    "sb.AppendLine($\"  Esperance entrant (In->Acc) avec tremblement Out = {entrantInAcc:F3}\");\n",
+    "sb.AppendLine($\"    vs Out pur = {entrantOut}  -> In preferable : {inPreferred}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Verdict : le SPE (In, Acc) est trembling-hand parfait. Meme avec 10% de chance\");\n",
+    "sb.AppendLine(\"de 'trembler' vers Out, Accommodate reste strictement dominant pour l'incumbent,\");\n",
+    "sb.AppendLine(\"et In reste preferable pour l'entrant. L'equilibre ne s'appuie sur aucune certitude\");\n",
+    "sb.AppendLine(\"qu'un nœud hors-chemin serait evite.\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26bd4c9c",
+   "metadata": {},
+   "source": [
+    "### Interprétation des résultats numériques\n",
+    "La perfection en mains tremblantes confirme le SPE **(In, Acc)** : parce que Accommodate **domine strictement** Fight, aucun tremblement ne renverse la préférence de l'incumbent. À l'inverse, un équilibre qui s'appuierait sur une indifférence ou une menace non crédible serait **éliminé** par le tremblement (l'erreur infime renverse le calcul).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ed9078e",
+   "metadata": {},
+   "source": [
+    "## 5. Application : le jeu du « Burn Money »\n",
+    "\n",
+    "Le **burn money** (brûler de l'argent) est un mécanisme de signal par **coût auto-infligé** : un joueur peut, avant un jeu simultané, brûler un montant `c`. Brûler est coûteux mais **signe** la force (seul un joueur comptant jouer l'action agressive a intérêt à brûler, car le gain futur compense le coût).\n",
+    "\n",
+    "C'est une illustration directe de l'induction avant : l'action de brûler, bien que coûteuse, **communique** l'intention et modifie l'équilibre sélectionné.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "829f89a9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.343890Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.343686Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.412725Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.412541Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Burn Money (signal par cout auto-inflige)\r\n",
+       "  BoS : (Opera,Opera)=(3,2), (Football,Football)=(2,3)\r\n",
+       "  Cout du burn c = 1\r\n",
+       "  P1 : Opera+Burn = 2 (>= Football sans burn = 2) -> burn rentable : True\r\n",
+       "\r\n",
+       "Logique d'induction avant appliquee :\r\n",
+       "  Si P1 brule c, il signale qu'il jouera Opera (sinon bruler serait pur gaspillage).\r\n",
+       "  P2, voyant le burn, infere P1=Opera -> P2 joue Opera (son 2e meilleur, mais coherent).\r\n",
+       "  => Selection de l'equilibre (Opera, Opera) = (3, 2), P1 payant le cout.\r\n",
+       "\r\n",
+       "Condition de credibilite du signal : le cout c doit etre tel que bruler n'est\r\n",
+       "rentable QUE si P1 compte jouer l'action signalee (condition de separabilite).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Burn money : modele simplifie en deux etapes.\n",
+    "// Etape 1 : P1 choisit Burn (cout c) ou Not.\n",
+    "// Etape 2 : jeu de coordination (Battle of Sexes simplifie).\n",
+    "//   P1 signale sa 'force' : si Burn, P2 infere que P1 jouera l'action preferee de P1.\n",
+    "// Matrice BoS : [Opera, Football] -- P1 prefere Opera, P2 prefere Football.\n",
+    "double[,] bosP1 = { { 3.0, 0.0 }, { 0.0, 2.0 } };  // P1 (Opera, Football) vs P2 (Opera, Football)\n",
+    "double[,] bosP2 = { { 2.0, 0.0 }, { 0.0, 3.0 } };\n",
+    "double c = 1.0;   // cout du burn\n",
+    "\n",
+    "// Deux equilibres purs du BoS : (Opera, Opera)=(3,2), (Football, Football)=(2,3).\n",
+    "// Sans burn : coordination ambigue (deux equilibres).\n",
+    "// Avec burn : P1 'achete' la credibilite d'Opera (3 - c = 2 >= 2 de Football).\n",
+    "double p1OperaBurn = bosP1[0,0] - c;    // 3 - 1 = 2\n",
+    "double p1FootballNoBurn = bosP1[1,1];   // 2\n",
+    "bool burnProfitable = p1OperaBurn >= p1FootballNoBurn;\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Burn Money (signal par cout auto-inflige)\");\n",
+    "sb.AppendLine($\"  BoS : (Opera,Opera)=({bosP1[0,0]},{bosP2[0,0]}), (Football,Football)=({bosP1[1,1]},{bosP2[1,1]})\");\n",
+    "sb.AppendLine($\"  Cout du burn c = {c}\");\n",
+    "sb.AppendLine($\"  P1 : Opera+Burn = {p1OperaBurn} (>= Football sans burn = {p1FootballNoBurn}) -> burn rentable : {burnProfitable}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Logique d'induction avant appliquee :\");\n",
+    "sb.AppendLine(\"  Si P1 brule c, il signale qu'il jouera Opera (sinon bruler serait pur gaspillage).\");\n",
+    "sb.AppendLine(\"  P2, voyant le burn, infere P1=Opera -> P2 joue Opera (son 2e meilleur, mais coherent).\");\n",
+    "sb.AppendLine($\"  => Selection de l'equilibre (Opera, Opera) = ({bosP1[0,0]}, {bosP2[0,0]}), P1 payant le cout.\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Condition de credibilite du signal : le cout c doit etre tel que bruler n'est\");\n",
+    "sb.AppendLine(\"rentable QUE si P1 compte jouer l'action signalee (condition de separabilite).\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3958c415",
+   "metadata": {},
+   "source": [
+    "### Le paradoxe du « Burn Money »\n",
+    "Le burn money semble **irrationnel** (détruire de la valeur), mais il **modifie l'équilibre sélectionné** en faveur du joueur qui brûle. C'est une illustration frappante du pouvoir de l'**engagement coûteux** : un signal crédible doit être **coûteux à imiter** (principe de Spence).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43fdf5d0",
+   "metadata": {},
+   "source": [
+    "## 6. Comparaison des raffinements\n",
+    "\n",
+    "Les raffinements d'équilibre forment une **hiérarchie** : chaque raffinement elimine strictement plus d'équilibres que le precedent.\n",
+    "\n",
+    "| Raffinement | Idée | Élimine |\n",
+    "|-------------|------|---------|\n",
+    "| **Nash** | Aucun n'a intérêt à dévier unilatéralement | (référence, le plus permissif) |\n",
+    "| **SPE** | Nash dans chaque sous-jeu (backward induction) | menaces non crédibles |\n",
+    "| **Trembling-hand** | Robuste à de petites erreurs (ε) | équilibres fragiles à un nœud hors-chemin |\n",
+    "| **Forward induction** | Actions passées = signaux d'intention | SPE incohérents avec la rationalité passée |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cf82e40a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.414491Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.414174Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.516842Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.516521Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Hierarchie des raffinements (du plus permissif au plus exigeant)\r\n",
+       "------------------------------------------------------------\r\n",
+       "Raffinement           Jeu d'entree        Stag Hunt+Out     \r\n",
+       "------------------------------------------------------------\r\n",
+       "Nash                  (In,Acc),(Out,F)    3 eq. (Stag,Hare,mix)\r\n",
+       "SPE                   (In,Acc) seul       (Stag,Stag),(Hare,Hare)\r\n",
+       "Trembling-hand        (In,Acc) robuste    elimine mixte     \r\n",
+       "Forward induction     (In,Acc)            (Stag,Stag) seul  \r\n",
+       "------------------------------------------------------------\r\n",
+       "\r\n",
+       "Chaque raffinement est un SUR-ENSEMBLE d'exigences :\r\n",
+       "  Nash subset SPE subset Trembling-hand subset Forward-induction-coherent.\r\n",
+       "Plus on raffine, plus on 'selecte' parmi les equilibres de Nash.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Synthese : hierarchie des raffinements sur nos exemples.\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Hierarchie des raffinements (du plus permissif au plus exigeant)\");\n",
+    "sb.AppendLine(new string('-', 60));\n",
+    "sb.AppendLine($\"{\"Raffinement\",-22}{\"Jeu d'entree\",-20}{\"Stag Hunt+Out\",-18}\");\n",
+    "sb.AppendLine(new string('-', 60));\n",
+    "sb.AppendLine($\"{\"Nash\",-22}{\"(In,Acc),(Out,F)\",-20}{\"3 eq. (Stag,Hare,mix)\",-18}\");\n",
+    "sb.AppendLine($\"{\"SPE\",-22}{\"(In,Acc) seul\",-20}{\"(Stag,Stag),(Hare,Hare)\",-18}\");\n",
+    "sb.AppendLine($\"{\"Trembling-hand\",-22}{\"(In,Acc) robuste\",-20}{\"elimine mixte\",-18}\");\n",
+    "sb.AppendLine($\"{\"Forward induction\",-22}{\"(In,Acc)\",-20}{\"(Stag,Stag) seul\",-18}\");\n",
+    "sb.AppendLine(new string('-', 60));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Chaque raffinement est un SUR-ENSEMBLE d'exigences :\");\n",
+    "sb.AppendLine(\"  Nash subset SPE subset Trembling-hand subset Forward-induction-coherent.\");\n",
+    "sb.AppendLine(\"Plus on raffine, plus on 'selecte' parmi les equilibres de Nash.\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37386163",
+   "metadata": {},
+   "source": [
+    "### Interprétation du tableau comparatif\n",
+    "- Sur le **jeu d'entrée**, Nash admet `(Out, Fight)` (menace non crédible) ; SPE et au-delà l'éliminent.\n",
+    "- Sur **Stag Hunt + Out**, le SPE admet deux équilibres purs ; l'induction avant en sélectionne un seul `(Stag, Stag)`.\n",
+    "\n",
+    "Aucun raffinement n'est « universellement le bon » : le choix dépend du contexte (erreurs réelles → trembling-hand ; signaux → forward induction).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13b5c1de",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "> Les exercices ci-dessous sont des **stubs** à compléter. Ils utilisent `pass`/`return null` (jamais `throw`) : le notebook s'exécute de bout en bout même non complété (règle C.1).\n",
+    "\n",
+    "### Exercice 1 — Beer-Quiche Game\n",
+    "Le jeu **Beer-Quiche** (Cho-Kreps 1987) : un joueur de type Fort ou Faible choisit de manger Bière ou Quiche ; l'autre joueur observe le choix (pas le type) et décide Combattre ou Ne pas combattre. Implémenter l'arbre et identifier l'équilibre de signal.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fe81cbb0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.518333Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.518152Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.554014Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.553833Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 (Beer-Quiche) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 — Beer-Quiche (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : construire l'arbre (nature choisit type Fort/Naible, P1 choisit Beer/Quiche,\n",
+    "// P2 observe l'action puis choisit Fight/NotFight) et identifier l'equilibre separateur vs melange.\n",
+    "// Indice : l'equilibre pooling (les deux types jouent Beer) survit si P2 croit \"Fort\" voyant Beer.\n",
+    "// Etape 1 : definir les nœuds et paiements.\n",
+    "// Etape 2 : appliquer BackwardInduction sur chaque sous-jeu d'information (ici, hors scope info imparfaite).\n",
+    "Console.WriteLine(\"Exercice 1 (Beer-Quiche) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5270bde",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Négociation avec options extérieures\n",
+    "Deux joueurs négocient (jeu séquentiel type Rubinstein) avec des options extérieures. Montrer comment une option extérieure crédible améliore le paiement d'un joueur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0af6a5f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.555180Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.555004Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.589113Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.588880Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 (Negociation) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 — Negociation avec options exterieures (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : modeliser un jeu de negotiation a 2 tours avec options exterieures.\n",
+    "// Indice : l'option exterieure borne le paiement minimum (outside option principle).\n",
+    "// Etape 1 : construire l'arbre a 2 tours. Etape 2 : backward induction.\n",
+    "Console.WriteLine(\"Exercice 2 (Negociation) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19612450",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Engagement séquentiel\n",
+    "Un joueur peut s'engager séquentiellement (capacité de production, R&D) avant un jeu de marché. Implémenter l'arbre et mesurer la valeur de l'engagement.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8f632c48",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.590557Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.590350Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.619424Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.619213Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 (Engagement) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 — Engagement sequentiel (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : arbre a deux etages (engagement puis competition Cournot/Stackelberg).\n",
+    "// Indice : Stackelberg = engagement de capacite, le leader gagne plus qu'en Cournot simultane.\n",
+    "Console.WriteLine(\"Exercice 3 (Engagement) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "197e005c",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 — Jeu d'entrée avec signal de prix\n",
+    "Un entrant signale sa qualité par un prix d'introduction bas (limit pricing). Implémenter la logique de signal.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "3a56fe13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.620967Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.620744Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.651535Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.651359Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 4 (Signal prix) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 4 — Signal de prix (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : modele de signal (qualite haute/basse) avec cout du signal croise.\n",
+    "// Indice : signal credible = cout plus faible pour haute qualite que pour basse (condition de Spence).\n",
+    "Console.WriteLine(\"Exercice 4 (Signal prix) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c84b5760",
+   "metadata": {},
+   "source": [
+    "### Exercice 5 — Identification des SPE\n",
+    "Étant donné un arbre de jeu (fourni), énumérer **tous** les SPE (pas seulement celui de backward induction pur — gérer les égalités).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c1155322",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T23:58:02.653053Z",
+     "iopub.status.busy": "2026-07-06T23:58:02.652826Z",
+     "iopub.status.idle": "2026-07-06T23:58:02.682319Z",
+     "shell.execute_reply": "2026-07-06T23:58:02.681678Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 5 (Tous les SPE) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 5 — Tous les SPE (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : etendre BackwardInduction pour enumerer TOUS les SPE (en cas d'egalite de paiement),\n",
+    "// en retournant l'ensemble des profils optimaux a chaque nœud.\n",
+    "// Indice : au lieu d'un argmax unique, collecter tous les argmax a chaque nœud puis faire le produit cartesien.\n",
+    "Console.WriteLine(\"Exercice 5 (Tous les SPE) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45051275",
+   "metadata": {},
+   "source": [
+    "## 8. Résumé\n",
+    "\n",
+    "### Points clés\n",
+    "- **SPE** (backward induction) = équilibre de Nash dans **chaque** sous-jeu ; élimine les **menaces non crédibles**.\n",
+    "- **Menace crédible** = action punitive rationnelle au nœud atteint ; on peut la **créer** par engagement (changer l'arbre).\n",
+    "- **Trembling-hand perfection** = robustesse aux petites erreurs (ε).\n",
+    "- **Forward induction** = les actions passées **signalent** les intentions (logique Cho-Kreps).\n",
+    "- **Burn money** = signal coûteux auto-infligé ; modifie l'équilibre sélectionné.\n",
+    "\n",
+    "### Hiérarchie\n",
+    "`Nash ⊂ SPE ⊂ Trembling-hand ⊂ Forward-induction-coherent` — chaque raffinement sélectionne strictement moins d'équilibres.\n",
+    "\n",
+    "### Prochaine étape\n",
+    "- [GameTheory-11 (Bayésien)](GameTheory-11-BayesianGames-Csharp.ipynb) : information incomplète.\n",
+    "- [GameTheory-12 (Réputation)](GameTheory-12-ReputationGames-Csharp.ipynb) : jeux répétés et signal.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Twin C# .NET Interactive** du notebook Python `GameTheory-10-ForwardInduction-SPE.ipynb`. Implémentation from-scratch (BCL .NET 9, 0 NuGet) — marathon [#4956](https://github.com/jsboige/CoursIA/issues/4956), registre SOTA [#3801](https://github.com/jsboige/CoursIA/issues/3801).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -144,6 +144,7 @@ flowchart TD
 | 9 | [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb) | Python | Induction arrière, mille-pattes, escalade | 55 min |
 | 9 (C#) | [GameTheory-9-BackwardInduction-Csharp](GameTheory-9-BackwardInduction-Csharp.ipynb) | .NET (C#) | Twin C# du 9 : induction arrière from-scratch, Entry/Centipede/War-of-Attrition/Chain-Store (See #4956) | 40 min |
 | 10 | [GameTheory-10-ForwardInduction-SPE](GameTheory-10-ForwardInduction-SPE.ipynb) | Python | Induction avant, SPE, menaces crédibles | 60 min |
+| 10 (C#) | [GameTheory-10-ForwardInduction-SPE-Csharp](GameTheory-10-ForwardInduction-SPE-Csharp.ipynb) | .NET (C#) | Twin C# du 10 : SPE/backward-induction from-scratch, menaces crédibles, trembling-hand (ε), forward induction (Cho-Kreps), burn money (See #4956) | 60 min |
 | 11 | [GameTheory-11-BayesianGames](GameTheory-11-BayesianGames.ipynb) | Python | Jeux bayésiens, information incomplète | 55 min |
 | 11 (C#) | [GameTheory-11-BayesianGames-Csharp](GameTheory-11-BayesianGames-Csharp.ipynb) | C# (.NET) | Twin .NET de 11 (marathon #4956) : jeux bayésiens from-scratch (BCL seule), Cournot résolu analytiquement (déterminant = 6, indépendant du prior) | 65 min |
 | 11b | [GameTheory-11b-Lean-BayesianGamesExt](GameTheory-11b-Lean-BayesianGamesExt.ipynb) | Lean 4 | Companion natif : théorème de Vickrey (enchère au second prix) prouvé 0-sorry dans le lake `lean_game_defs_ext` (module Bayesian, sans Mathlib) | 50 min |
@@ -549,6 +550,7 @@ GameTheory/
 ├── GameTheory-5-ZeroSum-Minimax-Csharp.ipynb                    # Twin C# simplexe from-scratch (marathon #4956, Prong B)
 ├── GameTheory-4-NashEquilibrium-Csharp.ipynb                    # Twin C# NE pur/mixte + support enum (Gauss) from-scratch (marathon #4956, Prong B)
 ├── GameTheory-7-ExtensiveForm-Csharp.ipynb                      # Twin C# arbre de jeu + infosets from-scratch (marathon #4956, Prong B)
+├── GameTheory-10-ForwardInduction-SPE-Csharp.ipynb              # Twin C# SPE/backward-induction + trembling-hand + forward induction + burn money (marathon #4956)
 ├── SocialChoice/                                                   # Sous-série Choix Social
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb
 │   ├── 02-Lean-SocialChoice-Formal.ipynb


### PR DESCRIPTION
## GameTheory-10-ForwardInduction-SPE-Csharp — Jumeau C# de GT-10 (Marathon parité #4956)

Jumeau .NET Interactive de [GameTheory-10-ForwardInduction-SPE.ipynb](GameTheory-10-ForwardInduction-SPE.ipynb) — raffinements d'équilibre sur forme extensive.

### Contenu (tout from-scratch, BCL .NET 9, 0 NuGet/numpy/nashpy)

| Concept | Implémentation C# |
|--------|-------------------|
| **Arbre de jeu extensif** | `GameNode` (Decision/Terminal) + `ExtensiveFormGame` (info parfaite) |
| **SPE / Backward induction** | récursion sur l'arbre : à chaque nœud le joueur maximise son paiement, retourne paiements + chemin |
| **Énumération sous-jeux** | `AllDecisionNodes` (info parfaite = tout nœud de décision est racine de sous-jeu) |
| **Menaces crédibles** | entry game (entrant/incumbent) + variante engagement (Schelling) |
| **Trembling-hand** | perturbation ε, calcul d'espérance, robustesse du dominant |
| **Forward induction** | Stag Hunt + option extérieure, logique Cho-Kreps (signal du renoncement) |
| **Burn money** | BoS + coût auto-infligé, condition de séparabilité (Spence) |

### Validation (EXEC_PROVED)
- **13/13 cellules code** `execution_count` 1-13, **0 error**, **0 warning CS**, **0 path-leak**
- Outputs vérifiés firsthand (Math Verification Standard) :
  - Entry SPE = **(In, Acc)** paiement **(2, 1)** ; menace Fight non crédible (Acc domine strictement 1 > −1)
  - Variante engagement : Fight=3 > Acc=1 → SPE bascule à **(Out)** paiement (1, 2)
  - Stag Hunt NE purs = (Stag,Stag)=(4,4) et (Hare,Hare)=(2,2) ; forward induction sélectionne (Stag,Stag)
  - Trembling ε=0.1 : E[entrant | In→Acc] = 1.9 > Out=1 ; Accommodate reste strictement dominant
  - Burn money : Opera+Burn = 3−1 = 2 ≥ Football = 2 (rentable à l'indifférence)

### §E README
+1 ligne table `10 (C#)` après GT-10 Python + +1 ligne tree. CATALOG byte-identique préservé.

### Prong B (#3801)
From-scratch complémentaire au twin Python (numpy/matplotlib) : moteur de théorie des jeux extensifs typé C#, value-add authentique (type system + récursion), pas un miroir.

### Exercices (5, règle C.1)
Beer-Quiche / Négociation / Engagement séquentiel / Signal de prix / Tous les SPE — stubs `Console.WriteLine("...a completer")` (pas de `throw`).

### G.1 self-corrections (2, avant commit)
1. CS8632 warnings (2×) sur `double[]?` sans `#nullable enable` dans la cellule BackwardInduction → ajouté `#nullable enable` (0 warning).
2. Output forward induction disait `"Hare max 3 < 3"` (faux, 3 = 3) → corrigé en `"3 (= Out), pas strictement supérieur"`.

See #4956 (marathon parité .NET ⇄ Python)
See #3801 (registre SOTA axe-2)
