### PR TITLE
docs(lean): fix toolchain drift in sensitivity_lean/NOTICE.md + mathlib_examples/README.en.md

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/README.en.md
@@ -4,7 +4,7 @@ Basic Mathlib usage examples for the SymbolicAI/Lean series.
 
 ## Status
 
-- **Toolchain**: v4.27.0
+- **Toolchain**: v4.31.0-rc1
 - **Sorry count**: 0
 - **Build**: `lake build MathLibExamples` -- SUCCESS
 - **Dependencies**: Mathlib4

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/NOTICE.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/NOTICE.md
@@ -5,7 +5,7 @@ Formalization of Hao Huang's sensitivity theorem in Lean 4.
 ## Source
 
 This is a dust-off (re-port) of `mathlib4/Archive/Sensitivity.lean`,
-adapted for Mathlib v4.30.0-rc2 with pedagogical decomposition.
+adapted for Mathlib v4.31.0-rc1 with pedagogical decomposition.
 
 Original authors: Reid Barton, Johan Commelin, Jesse Michael Han,
 Chris Hughes, Robert Y. Lewis, Patrick Massot.


### PR DESCRIPTION
## Summary

Fix 2 toolchain drift references in scope **#3979** (READMEs feuilles — Knot / Grothendieck / Lean math, owner po-2026:CoursIA-2). Both align with the actual `lean-toolchain` pin (`v4.31.0-rc1`) of their sibling repo.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `SymbolicAI/Lean/sensitivity_lean/NOTICE.md` | L8 | `adapted for Mathlib v4.30.0-rc2 ...` | `adapted for Mathlib v4.31.0-rc1 ...` |
| `SymbolicAI/Lean/mathlib_examples/README.en.md` | L7 | `**Toolchain**: v4.27.0` | `**Toolchain**: v4.31.0-rc1` |

`+2/-2`, 2 files, 1 sujet (toolchain drift complement of #3979 scope).

## Verification

- `cat sensitivity_lean/lean-toolchain` → `v4.31.0-rc1` ✅
- `cat mathlib_examples/lean-toolchain` → `v4.31.0-rc1` ✅
- Both edits align docs with the actual sibling toolchain pin (audit G.1 firsthand).

## L268 self-catch #4 (CRLF Edit Windows `*.en.md`)

`mathlib_examples/README.en.md` was **100% CRLF** post-Edit (41 lines CRLF, 0 LF) — propagated from Edit tool Windows LF→CRLF flip intermittent sur `*.en.md` quand `.gitattributes` n'a pas de regle `text eol=lf` explicite. Fix applied via Python `data.replace(b"\r\n", b"\n")` before `git add`. `NOTICE.md` was LF throughout (no flip needed).

Suggestion hors scope : ajouter `*.en.md text eol=lf` dans `.gitattributes` pour fix structurel — à tracker séparément.

## Scope #3979 status

- ✅ #5570 grothendieck_lean/README.en.md MERGED wave-7 (parentheson EN)
- ✅ #5586 3 SymbolicAI siblings (knot_lean/README, grothendieck_lean/README, conway_lean/README) MERGED wave-7
- ✅ **This PR** : complement toolchain drift on 2 additional docs dans scope #3979

## Checklist

- [x] Scope strict #3979 owner po-2026:CoursIA-2
- [x] Atomic single-subject (toolchain drift)
- [x] G.1 firsthand audit pre-fix (lean-toolchain pin = v4.31.0-rc1 confirmé)
- [x] Diff +2/-2 lignes = 2 fichiers, R3 strict respecté
- [x] CRLF fix propagé (L268 self-catch #4)
- [x] Fresh origin/main rebase before push (working tree aligned on e81076847)
- [x] Pas de catalogue touché (catalog-pr-hygiene R1 respecté)
- [x] `Closes` NON utilisé (contribution partielle à Epic #3973, scope #3979 = sous-tâche d'epic) — `See #3979` conformément git-workflow R4

🤖 Generated with [Claude Code](https://claude.com/claude-code)