### PR TITLE
feat(planners): Planners-4-Fast-Downward-Csharp — twin C# SAS+ planner from-scratch (translator + A*/GBFS/EHC + h-FF)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward-Csharp.ipynb
@@ -1,0 +1,1226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f4bc7eae",
+   "metadata": {},
+   "source": "# Planners-4-Fast-Downward (C#)\n\n## Architecture Fast Downward, SAS+, A\\*, GBFS et Enforced Hill Climbing\n\n**Navigation** : [<< Planners-3 State-Space (C#)](../01-Foundation/Planners-3-State-Space-Csharp.ipynb) | [Index](../README.md) | [Planners-5 Heuristics (C#) >>](Planners-5-Heuristics-Csharp.ipynb)\n\n**Twin C# (.NET Interactive)** de [Planners-4-Fast-Downward.ipynb](Planners-4-Fast-Downward.ipynb) — marathon **#4956** (parite .NET <-> Python).\n\n[Fast Downward](https://www.fast-downward.org/) (Helmert 2006, gagnant a plusieurs reprises de l'IPC) est le planificateur de reference de la planification classique. Son architecture se decompose en trois etapes : un **translator** (PDDL -> **SAS+**), un preprocessor C++ et un **moteur de recherche** C++. Ce twin C# **rend visibles les internes** que le binaire Fast Downward cache : la representation **SAS+** (variables multi-valuees), les operateurs a **prevail/precondition/effect**, le **graphe de plan relaxation** (RPG) pour l'heuristique h^FF, et les trois strategies de recherche **A\\***, **Greedy Best-First** et **Enforced Hill Climbing**.\n\n### Objectifs d'apprentissage\n\nA la fin de ce notebook, vous saurez :\n\n1. **Representer** un probleme en **SAS+** (variables multi-valuees) plutot qu'en STRIPS booleen.\n2. **Decoder** la traduction PDDL -> SAS+ (concept du translator Fast Downward).\n3. **Implementer** trois strategies de recherche from-scratch : **A\\*** (optimal, h admissible), **GBFS** (satisficing), **EHC** (Hoffmann & Nebel 2001).\n4. **Calculer** l'heuristique **h^FF** par **graphe de plan relaxation** (delete-relaxation).\n5. **Comparer** empiriquement noeuds expanses et optimalite sur les domaines **Ferry** et **Logistics**.\n\n### Prerequis\n\n- [Planners-3-State-Space-Csharp](../01-Foundation/Planners-3-State-Space-Csharp.ipynb) (BFS / DFS / Greedy / A\\* from-scratch, admissibilite).\n- [Planners-5-Heuristics-Csharp](Planners-5-Heuristics-Csharp.ipynb) (relaxation, h^max, h^add, h^FF, landmarks) — ce notebook reutilise h^max et h^FF.\n\n### Duree estimee : 45 minutes\n\n> **Verdict SOTA (#3801 Prong A).** Ce twin C# est un **planificateur SAS+ pedagogique from-scratch** (SOTA-OK pour le concept du moteur). Le notebook Python [Planners-4-Fast-Downward](Planners-4-Fast-Downward.ipynb) invoque le **vrai Fast Downward** (IPC winner, Helmert 2006) via Docker + `unified-planning` = **RECOVERABLE-MACHINE** (le solveur reel n'est pas lie a .NET pedagogique). Le twin from-scratch rend visibles les internes (representation SAS+, operateurs prevail/pre/eff, RPG, EHC) que Fast Downward cache dans son binaire C++ — compagnon pedagogique intentionnel, meme pattern que le twin [App-19 WFC C#](../../Search/Applications/CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb). Implementation en BCL .NET 9 **pure, 0 NuGet**."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b99f00d",
+   "metadata": {},
+   "source": [
+    "## 1. Pourquoi SAS+ ? L'apport cle de Fast Downward\n",
+    "\n",
+    "Le **translator** de Fast Downward convertit un probleme PDDL (predicats booleens) en une representation **SAS+** (Simplified Action Structures) ou l'etat est un vecteur de **variables multi-valuees**. C'est le changement de representation fondateur du planificateur.\n",
+    "\n",
+    "| PDDL (STRIPS)                       | SAS+                                    |\n",
+    "|-------------------------------------|-----------------------------------------|\n",
+    "| Predicats booleens `(on a b)`       | Variables multi-valuees `on_a = b`      |\n",
+    "| Etat = ensemble de faits vrais      | Etat = `Dictionary<var, val>`           |\n",
+    "| Action = (precond, add, del)        | Operateur = (prevail, pre, eff)         |\n",
+    "| Actions parametrees non instantiees | Operateurs deja instanties (groundes)   |\n",
+    "| Doublons d'encodage                 | Variables irrelevantes eliminees        |\n",
+    "\n",
+    "**Trois avantages concrets de SAS+** :\n",
+    "\n",
+    "1. **Compacite** : une variable `ferry_pos{L,R}` remplace deux predicats booleens mutuellement exclusifs (`ferry_at_L`, `ferry_at_R`). L'etat est un vecteur court, pas un gros ensemble.\n",
+    "2. **Reformulation en domaine fini (FDR)** : chaque variable a un domaine fini connu -> l'espace d'etats estborne et denombrable, ce qui permet des index compacts et des heuristiques structurelles (pattern databases, merge-and-shrink).\n",
+    "3. **Operateurs a prevail** : les conditions sur les variables **non modifiees** par l'operateur (prevail) sont separees des preconditions sur les variables modifiees. Cela reflete la structure causale et accelere la recherche.\n",
+    "\n",
+    "### Architecture en trois etapes\n",
+    "\n",
+    "```\n",
+    "PDDL (domain + problem)\n",
+    "        |\n",
+    "   [TRANSLATOR]   Python : parse PDDL, construit la tache SAS+ (variables, domaines, operateurs)\n",
+    "        |\n",
+    "   [PREPROCESSOR]  C++    : simplifie, elimine variables invariantes, construit le successor generator\n",
+    "        |\n",
+    "   [SEARCH]        C++    : A* / GBFS / EHC avec heuristique (h^max, LM-cut, h^FF, ...)\n",
+    "        |\n",
+    "   Plan (sequence d'actions)\n",
+    "```\n",
+    "\n",
+    "Ce twin C# implemente les **trois couches conceptuelles** (representation SAS+, heuristique RPG, recherche) en code pedagogique lisible — Fast Downward les optimise en C++ industriel.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "175cc0d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:18.101607Z",
+     "iopub.status.busy": "2026-07-07T00:16:18.093956Z",
+     "iopub.status.idle": "2026-07-07T00:16:19.416383Z",
+     "shell.execute_reply": "2026-07-07T00:16:19.412863Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:c111:2207:fe12:2b8b:2048/\",\"http://2a01:e0a:9d4:f320:e9d1:aca6:71b4:2cf1:2048/\",\"http://fe80::902b:f9f6:2003:66a1%18:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%19:2048/\",\"http://172.24.224.1:2048/\",\"http://fe80::b5e6:392e:9c4:c699%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '3408.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Imports OK : System.Linq, Globalization, DotNet.Interactive (BCL .NET 9, 0 NuGet)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"Microsoft.DotNet.Interactive\"\n",
+    "\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "using Microsoft.DotNet.Interactive;\n",
+    "\n",
+    "static string FI(double x, string fmt = \"F4\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "\n",
+    "\"Imports OK : System.Linq, Globalization, DotNet.Interactive (BCL .NET 9, 0 NuGet)\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bf43932",
+   "metadata": {},
+   "source": [
+    "## 2. Representation SAS+\n",
+    "\n",
+    "Un **etat SAS+** est un dictionnaire `Dictionary<string,int>` : chaque variable a une valeur entiere codant son domaine (par ex. `ferry_pos = 0` pour `left`). Un **operateur SAS+** se decompose en trois parties, distinguees par leur role causal :\n",
+    "\n",
+    "- **Prevail** : conditions `var = val` sur des variables que l'operateur **ne modifie pas** (elles doivent tenir au moment de l'application et restent invariantes).\n",
+    "- **Precondition** (pre) : valeurs **\"from\"** des variables que l'operateur **modifie** (la valeur requise avant l'effet).\n",
+    "- **Effect** (eff) : affectations `var -> nouvelle valeur` appliquees a l'etat.\n",
+    "\n",
+    "Separer prevail et pre reflte le fait qu'une variable non modifiee n'a pas besoin d'etre lue-then-written : elle est juste un contexte. C'est une optimisation centrale de SAS+.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "da68fa73",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:19.417486Z",
+     "iopub.status.busy": "2026-07-07T00:16:19.417486Z",
+     "iopub.status.idle": "2026-07-07T00:16:19.714979Z",
+     "shell.execute_reply": "2026-07-07T00:16:19.713962Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Structures SAS+ definies : record SasOperator(Prevail/Precondition/Effect), ApplyOp, Applicable, StateKey, SatisfiesGoal."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// SAS+ : etat = variables multi-valuees. Un operateur a Prevail / Precondition / Effect.\n",
+    "public record SasOperator(\n",
+    "    string Name,\n",
+    "    Dictionary<string, int> Prevail,\n",
+    "    Dictionary<string, int> Precondition,\n",
+    "    Dictionary<string, int> Effect,\n",
+    "    int Cost = 1);\n",
+    "\n",
+    "// Cle canonique d'un etat (pour hash / closed set) : \"car1=0;car2=0;car3=0;empty=1;ferry_pos=0\".\n",
+    "public static string StateKey(Dictionary<string, int> s) =>\n",
+    "    string.Join(\";\", s.OrderBy(kv => kv.Key).Select(kv => $\"{kv.Key}={kv.Value}\"));\n",
+    "\n",
+    "public static Dictionary<string, int> CloneState(Dictionary<string, int> s) => new(s);\n",
+    "\n",
+    "// Un operateur est applicable ssi toutes ses conditions (prevail + pre) tiennent dans l'etat.\n",
+    "public static bool Applicable(Dictionary<string, int> s, SasOperator op)\n",
+    "{\n",
+    "    foreach (var (v, val) in op.Prevail)\n",
+    "        if (!s.TryGetValue(v, out var sv) || sv != val) return false;\n",
+    "    foreach (var (v, val) in op.Precondition)\n",
+    "        if (!s.TryGetValue(v, out var sv) || sv != val) return false;\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Appliquer : on n'ecrit que les variables de Effect (prevail reste invariant par construction).\n",
+    "public static Dictionary<string, int> ApplyOp(Dictionary<string, int> s, SasOperator op)\n",
+    "{\n",
+    "    var s2 = CloneState(s);\n",
+    "    foreach (var (v, val) in op.Effect) s2[v] = val;\n",
+    "    return s2;\n",
+    "}\n",
+    "\n",
+    "// Le but est atteint si toutes les paires var=val requises sont presentes dans l'etat.\n",
+    "public static bool SatisfiesGoal(Dictionary<string, int> s, Dictionary<string, int> goal) =>\n",
+    "    goal.All(kv => s.TryGetValue(kv.Key, out var sv) && sv == kv.Value);\n",
+    "\n",
+    "\"Structures SAS+ definies : record SasOperator(Prevail/Precondition/Effect), ApplyOp, Applicable, StateKey, SatisfiesGoal.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee675613",
+   "metadata": {},
+   "source": [
+    "## 3. Le translator (PDDL -> SAS+)\n",
+    "\n",
+    "Le **translator** Fast Downward parse un domaine PDDL et produit un encodage SAS+ equivalent. L'algorithme complet (Helmert 2009) est sophistique : decoupage en **invariants mutuels** (deux faits jamais vrais simultanement deviennent les valeurs d'une meme variable), grounding des operateurs, detection des variables derivables. Nous n'implementons pas ce pipeline ici — nous **hardcodons le resultat de la traduction** sur un petit domaine pour illustrer la correspondance.\n",
+    "\n",
+    "### Domaine Ferry en PDDL (rappel)\n",
+    "\n",
+    "```lisp\n",
+    "(:action board :parameters (?c - car ?l - location)\n",
+    "  :precondition (and (car-at ?c ?l) (ferry-at ?l) (empty-ferry))\n",
+    "  :effect (and (not (car-at ?c ?l)) (car-on-ferry ?c) (not (empty-ferry))))\n",
+    "(:action sail   :parameters (?from ?to - location)\n",
+    "  :precondition (ferry-at ?from)\n",
+    "  :effect (and (not (ferry-at ?from)) (ferry-at ?to)))\n",
+    "(:action debark :parameters (?c - car ?l - location)\n",
+    "  :precondition (and (car-on-ferry ?c) (ferry-at ?l))\n",
+    "  :effect (and (not (car-on-ferry ?c)) (car-at ?c ?l) (empty-ferry)))\n",
+    "```\n",
+    "\n",
+    "### Meme domaine apres traduction en SAS+\n",
+    "\n",
+    "Le translator detecte les invariants : `car-at_X_left` et `car-at_X_right` et `car-on-ferry_X` sont mutuellement exclusifs -> une seule variable `car_X` a 3 valeurs `{left, right, on_ferry}`. De meme `ferry-at_left` / `ferry-at_right` -> variable `ferry_pos` a 2 valeurs, et `empty-ferry`/`not-empty` -> variable `empty` a 2 valeurs.\n",
+    "\n",
+    "| Operateur PDDL                        | Operateur SAS+ (prevail / pre / eff)                                  |\n",
+    "|---------------------------------------|-----------------------------------------------------------------------|\n",
+    "| `board(car1, left)`                   | prevail `{ferry_pos=left, empty=YES}` pre `{car1=left}` eff `{car1=on_ferry, empty=NO}` |\n",
+    "| `sail(left, right)`                   | prevail `{}` pre `{ferry_pos=left}` eff `{ferry_pos=right}`           |\n",
+    "| `debark(car1, right)`                 | prevail `{ferry_pos=right}` pre `{car1=on_ferry}` eff `{car1=right, empty=YES}` |\n",
+    "\n",
+    "L'encodage SAS+ est plus compact (5 variables vs ~10 predicats) et les operateurs sont deja **instanties** (groundes), pret pour la recherche.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c055cefa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:19.715458Z",
+     "iopub.status.busy": "2026-07-07T00:16:19.715458Z",
+     "iopub.status.idle": "2026-07-07T00:16:19.831120Z",
+     "shell.execute_reply": "2026-07-07T00:16:19.831120Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Domaine FERRY (SAS+) : 14 operateurs, 5 variables multi-valuees.\r\n",
+       "Variables : ferry_pos{L,R}, empty{NO,YES}, car1/car2/car3{L,R,CARRIED}\r\n",
+       "Espace d'etats = 2 x 2 x 3 x 3 x 3 = 108 etats.\r\n",
+       "Etat initial : car1=0;car2=0;car3=0;empty=1;ferry_pos=0\r\n",
+       "But          : car1=1;car2=1;car3=1\r\n",
+       "\r\n",
+       "Echantillon d'operateurs SAS+ (prevail / pre / eff) :\r\n",
+       "  board(car1,L)    prevail={empty=1,ferry_pos=0} pre={car1=0} eff={car1=2,empty=0}\r\n",
+       "  board(car1,R)    prevail={empty=1,ferry_pos=1} pre={car1=1} eff={car1=2,empty=0}\r\n",
+       "  sail(L,R)        prevail={} pre={ferry_pos=0} eff={ferry_pos=1}\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Domaine FERRY encode directement en SAS+ (3 voitures, 2 rives, capacite ferry = 1).\n",
+    "// Valeurs encodees en int. ferry_pos{0=left,1=right}, empty{0=NO,1=YES}, car_i{0=left,1=right,2=CARRIED}.\n",
+    "const int LEFT = 0, RIGHT = 1;\n",
+    "const int EM_NO = 0, EM_YES = 1;\n",
+    "const int CARRIED = 2;\n",
+    "\n",
+    "List<SasOperator> FerryOps()\n",
+    "{\n",
+    "    var ops = new List<SasOperator>();\n",
+    "    string[] cars = { \"car1\", \"car2\", \"car3\" };\n",
+    "    string Tag(int side) => side == LEFT ? \"L\" : \"R\";\n",
+    "    foreach (var car in cars)\n",
+    "    {\n",
+    "        // board(car, side) : prevail ferry_pos=side, empty=YES ; pre car=side ; eff car=CARRIED, empty=NO.\n",
+    "        foreach (var side in new[] { LEFT, RIGHT })\n",
+    "            ops.Add(new SasOperator(\n",
+    "                $\"board({car},{Tag(side)})\",\n",
+    "                Prevail: new() { [\"ferry_pos\"] = side, [\"empty\"] = EM_YES },\n",
+    "                Precondition: new() { [car] = side },\n",
+    "                Effect: new() { [car] = CARRIED, [\"empty\"] = EM_NO }));\n",
+    "        // debark(car, side) : prevail ferry_pos=side ; pre car=CARRIED ; eff car=side, empty=YES.\n",
+    "        foreach (var side in new[] { LEFT, RIGHT })\n",
+    "            ops.Add(new SasOperator(\n",
+    "                $\"debark({car},{Tag(side)})\",\n",
+    "                Prevail: new() { [\"ferry_pos\"] = side },\n",
+    "                Precondition: new() { [car] = CARRIED },\n",
+    "                Effect: new() { [car] = side, [\"empty\"] = EM_YES }));\n",
+    "    }\n",
+    "    ops.Add(new SasOperator(\"sail(L,R)\", new(), new() { [\"ferry_pos\"] = LEFT }, new() { [\"ferry_pos\"] = RIGHT }));\n",
+    "    ops.Add(new SasOperator(\"sail(R,L)\", new(), new() { [\"ferry_pos\"] = RIGHT }, new() { [\"ferry_pos\"] = LEFT }));\n",
+    "    return ops;\n",
+    "}\n",
+    "\n",
+    "var ferryInit = new Dictionary<string, int>\n",
+    "{\n",
+    "    [\"ferry_pos\"] = LEFT, [\"empty\"] = EM_YES,\n",
+    "    [\"car1\"] = LEFT, [\"car2\"] = LEFT, [\"car3\"] = LEFT,\n",
+    "};\n",
+    "var ferryGoal = new Dictionary<string, int>\n",
+    "{\n",
+    "    [\"car1\"] = RIGHT, [\"car2\"] = RIGHT, [\"car3\"] = RIGHT,\n",
+    "};\n",
+    "var ferryOps = FerryOps();\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine($\"Domaine FERRY (SAS+) : {ferryOps.Count} operateurs, 5 variables multi-valuees.\");\n",
+    "sb.AppendLine(\"Variables : ferry_pos{L,R}, empty{NO,YES}, car1/car2/car3{L,R,CARRIED}\");\n",
+    "sb.AppendLine($\"Espace d'etats = 2 x 2 x 3 x 3 x 3 = {2 * 2 * 3 * 3 * 3} etats.\");\n",
+    "sb.AppendLine($\"Etat initial : {StateKey(ferryInit)}\");\n",
+    "sb.AppendLine($\"But          : {StateKey(ferryGoal)}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Echantillon d'operateurs SAS+ (prevail / pre / eff) :\");\n",
+    "foreach (var op in ferryOps.Where(o => o.Name.StartsWith(\"board(car1\") || o.Name.StartsWith(\"sail\")).Take(3))\n",
+    "{\n",
+    "    string Fmt(Dictionary<string, int> d) => string.Join(\",\", d.OrderBy(kv => kv.Key).Select(kv => $\"{kv.Key}={kv.Value}\"));\n",
+    "    sb.AppendLine($\"  {op.Name,-16} prevail={{{Fmt(op.Prevail)}}} pre={{{Fmt(op.Precondition)}}} eff={{{Fmt(op.Effect)}}}\");\n",
+    "}\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19cfe0d3",
+   "metadata": {},
+   "source": "### Interpretation : l'encodage SAS+ du Ferry\n\n**Observations** :\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| Variables | 5 ( ferry_pos, empty, car1, car2, car3 ) | vecteur compact vs ~10 predicats PDDL |\n| Operateurs | 14 (6 board + 6 debark + 2 sail) | deja groundes, instanties par (car, side) |\n| Espace d'etats | 108 | 2 x 2 x 3 x 3 x 3 — petit, soluble exactement |\n| Prevail distinct de pre | `board` a prevail `ferry_pos, empty` (non modifies) + pre `car1` (modifie) | reflete la structure causale |\n\n**Plan optimal theorique** : pour `n` voitures, capacite 1, ferry du cote de depart, le plan compte `3n + (n-1) = 4n - 1` actions (n cycles board-sail-debark + n-1 sail-retour, sauf apres la derniere). Pour n=3 -> **11 actions**. C'est ce qu'A\\* doit retrouver."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b745c48",
+   "metadata": {},
+   "source": [
+    "## 4. Heuristique h^FF par graphe de plan relaxation (RPG)\n",
+    "\n",
+    "Les trois recherches ci-dessous ont besoin d'une heuristique `h(s)` estimant le cout restant. On construit le **graphe de plan relaxation** (RPG) : on ignore les effets de **suppression** (delete-relaxation), et on propage les faits couche par couche. Dans le monde relaxe, le nombre de faits vrais ne fait que croitre — le probleme devient polynomial.\n",
+    "\n",
+    "**Projection SAS+ -> atomes** : la relaxation est plus simple a raisonner sur des propositions booleennes independantes. On projette chaque paire `(var=val)` en un atome string `\"var=val\"`. L'operateur SAS+ devient un operateur STRIPS relaxe `(pre-atomes, add-atomes)`. C'est la reduction standard (Bonet & Geffner 2001) ; elle est admissible pour **h^max** car la relaxation est un sur-ensemble de l'atteignabilite reelle.\n",
+    "\n",
+    "- **h^max** (admissible) : `cost(fact) = min_a [ cost(a) + max_{p in pre(a)} cost(p) ]`, puis `h^max = max_{g in goal} cost(g)`. Minore le cout optimal -> A\\* avec h^max est **optimal**.\n",
+    "- **h^FF** (non admissible mais tres informative) : on extrait gloutonnement un **plan relaxe** depuis le but en remontant le meilleur achiever de chaque fait, et `h^FF = nombre d'actions du plan relaxe`. C'est l'heuristique de reference pour la planification satisficing (Hoffmann & Nebel 2001).\n",
+    "\n",
+    "Le detail des propagations (point fixe, double-compte de h^add vs max) est dans [Planners-5-Heuristics-Csharp](Planners-5-Heuristics-Csharp.ipynb) ; ici on reutilise la meme mecanique, adaptee a la projection d'atomes SAS+.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0d747276",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:19.833353Z",
+     "iopub.status.busy": "2026-07-07T00:16:19.833353Z",
+     "iopub.status.idle": "2026-07-07T00:16:19.945733Z",
+     "shell.execute_reply": "2026-07-07T00:16:19.944350Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "h^max(Ferry init) = 2   (admissible : minore h*)\r\n",
+       "h^FF (Ferry init) = 7   (informatif : guide GBFS/EHC)\r\n",
+       "\r\n",
+       "Lecture : h^max est faible (les 3 voitures partagent le ferry dans la relaxation) ;\r\n",
+       "h^FF compte un plan relaxe de 7 actions (board x3 + sail + debark x3, les 2 sail-retour economises).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Heuristiques par relaxation de suppression sur SAS+ (projection en atomes).\n",
+    "// Chaque paire (var=val) devient un atome string \"var=val\". L'operateur relaxe = (pre-atomes, add-atomes).\n",
+    "\n",
+    "public static HashSet<string> StateAtoms(Dictionary<string, int> s) =>\n",
+    "    s.Select(kv => $\"{kv.Key}={kv.Value}\").ToHashSet();\n",
+    "\n",
+    "public static (HashSet<string> pre, HashSet<string> add) RelaxedOp(SasOperator op)\n",
+    "{\n",
+    "    var pre = new HashSet<string>();\n",
+    "    foreach (var (v, val) in op.Prevail) pre.Add($\"{v}={val}\");\n",
+    "    foreach (var (v, val) in op.Precondition) pre.Add($\"{v}={val}\");\n",
+    "    var add = new HashSet<string>();\n",
+    "    foreach (var (v, val) in op.Effect) add.Add($\"{v}={val}\");\n",
+    "    return (pre, add);\n",
+    "}\n",
+    "\n",
+    "// h^max : propagation point-fixe, h = max des couts des atomes du but. ADMISSIBLE -> A* optimal.\n",
+    "public static int HMaxSas(List<SasOperator> ops, Dictionary<string, int> goal, Dictionary<string, int> state)\n",
+    "{\n",
+    "    var relaxed = ops.Select(RelaxedOp).ToList();\n",
+    "    var goalAtoms = goal.Select(kv => $\"{kv.Key}={kv.Value}\").ToHashSet();\n",
+    "    var cost = new Dictionary<string, int>();\n",
+    "    foreach (var a in StateAtoms(state)) cost[a] = 0;\n",
+    "    bool changed = true; int iter = 0;\n",
+    "    while (changed && iter++ < 1000)\n",
+    "    {\n",
+    "        changed = false;\n",
+    "        foreach (var (pre, add) in relaxed)\n",
+    "            if (pre.All(p => cost.ContainsKey(p)))\n",
+    "            {\n",
+    "                int c = (pre.Count == 0 ? 0 : pre.Max(p => cost[p])) + 1;\n",
+    "                foreach (var a in add)\n",
+    "                    if (!cost.ContainsKey(a) || cost[a] > c) { cost[a] = c; changed = true; }\n",
+    "            }\n",
+    "    }\n",
+    "    if (goalAtoms.All(g => cost.ContainsKey(g))) return goalAtoms.Max(g => cost[g]);\n",
+    "    return int.MaxValue;\n",
+    "}\n",
+    "\n",
+    "// h^FF : graphe de relaxation + extraction gloutonne d'un plan relaxe depuis le but. Non admissible.\n",
+    "public static int HFFSas(List<SasOperator> ops, Dictionary<string, int> goal, Dictionary<string, int> state)\n",
+    "{\n",
+    "    var relaxed = ops.Select(RelaxedOp).ToList();\n",
+    "    var goalAtoms = goal.Select(kv => $\"{kv.Key}={kv.Value}\").ToHashSet();\n",
+    "    var initState = StateAtoms(state);\n",
+    "    var cost = new Dictionary<string, int>();\n",
+    "    var achiever = new Dictionary<string, (HashSet<string> pre, HashSet<string> add)>();\n",
+    "    foreach (var a in initState) cost[a] = 0;\n",
+    "    bool changed = true;\n",
+    "    while (changed)\n",
+    "    {\n",
+    "        changed = false;\n",
+    "        foreach (var ro in relaxed)\n",
+    "            if (ro.pre.All(p => cost.ContainsKey(p)))\n",
+    "            {\n",
+    "                int c = (ro.pre.Count == 0 ? 0 : ro.pre.Sum(p => cost[p])) + 1;\n",
+    "                foreach (var a in ro.add)\n",
+    "                    if (!cost.ContainsKey(a) || cost[a] > c) { cost[a] = c; achiever[a] = ro; changed = true; }\n",
+    "            }\n",
+    "    }\n",
+    "    if (!goalAtoms.All(g => cost.ContainsKey(g))) return int.MaxValue;\n",
+    "    // Extraction gloutonne : on remonte les achievers depuis le but.\n",
+    "    var plan = new HashSet<(HashSet<string>, HashSet<string>)>();\n",
+    "    var done = new HashSet<string>();\n",
+    "    var stack = new Stack<string>(goalAtoms);\n",
+    "    int guard = 0;\n",
+    "    while (stack.Count > 0 && guard++ < 10000)\n",
+    "    {\n",
+    "        var f = stack.Pop();\n",
+    "        if (done.Contains(f) || initState.Contains(f)) continue;\n",
+    "        done.Add(f);\n",
+    "        if (achiever.TryGetValue(f, out var ro))\n",
+    "        {\n",
+    "            plan.Add(ro);\n",
+    "            foreach (var p in ro.pre) stack.Push(p);\n",
+    "        }\n",
+    "    }\n",
+    "    return plan.Count;\n",
+    "}\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine($\"h^max(Ferry init) = {HMaxSas(ferryOps, ferryGoal, ferryInit)}   (admissible : minore h*)\");\n",
+    "sb.AppendLine($\"h^FF (Ferry init) = {HFFSas(ferryOps, ferryGoal, ferryInit)}   (informatif : guide GBFS/EHC)\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Lecture : h^max est faible (les 3 voitures partagent le ferry dans la relaxation) ;\");\n",
+    "sb.AppendLine(\"h^FF compte un plan relaxe de 7 actions (board x3 + sail + debark x3, les 2 sail-retour economises).\");\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33e308f0",
+   "metadata": {},
+   "source": [
+    "## 5. Recherche A\\* (optimale avec h^max admissible)\n",
+    "\n",
+    "A\\* ordonne la frontiere par `f(n) = g(n) + h(n)` ou `g` est le cout accumule depuis l'initial et `h` l'estimation restante. Avec une heuristique **admissible** (ici h^max), A\\* est garanti de retourner le plan **de cout optimal**. On l'implemente avec la `PriorityQueue` .NET 9 ; les etats sont identifies par leur cle canonique (`StateKey`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9dae61ce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:19.947394Z",
+     "iopub.status.busy": "2026-07-07T00:16:19.946379Z",
+     "iopub.status.idle": "2026-07-07T00:16:20.043577Z",
+     "shell.execute_reply": "2026-07-07T00:16:20.043577Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A* (h^max) sur Ferry : cout=11, noeuds expanses=37, longueur plan=11\r\n",
+       "Plan optimal : [board(car1,L), sail(L,R), debark(car1,R), sail(R,L), board(car3,L), sail(L,R), debark(car3,R), sail(R,L), board(car2,L), sail(L,R), debark(car2,R)]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// A* sur SAS+ : f = g + h. Optimal si h admissible (on branche h^max dessus).\n",
+    "public static (List<string> plan, int cost, int nodesExpanded) AStarSas(\n",
+    "    Dictionary<string, int> init, Dictionary<string, int> goal, List<SasOperator> ops,\n",
+    "    Func<Dictionary<string, int>, int> h)\n",
+    "{\n",
+    "    var frontier = new PriorityQueue<string, int>();\n",
+    "    string iKey = StateKey(init);\n",
+    "    frontier.Enqueue(iKey, h(init));\n",
+    "    var gScore = new Dictionary<string, int> { [iKey] = 0 };\n",
+    "    var stateOf = new Dictionary<string, Dictionary<string, int>> { [iKey] = init };\n",
+    "    var cameFrom = new Dictionary<string, (string parent, string op)>();\n",
+    "    var closed = new HashSet<string>();\n",
+    "    int nodes = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        frontier.TryDequeue(out var curKey, out _);\n",
+    "        if (closed.Contains(curKey)) continue;\n",
+    "        closed.Add(curKey);\n",
+    "        var cur = stateOf[curKey];\n",
+    "        nodes++;\n",
+    "        if (SatisfiesGoal(cur, goal))\n",
+    "        {\n",
+    "            var plan = new List<string>();\n",
+    "            var k = curKey;\n",
+    "            while (cameFrom.ContainsKey(k)) { plan.Add(cameFrom[k].op); k = cameFrom[k].parent; }\n",
+    "            plan.Reverse();\n",
+    "            return (plan, gScore[curKey], nodes);\n",
+    "        }\n",
+    "        foreach (var op in ops.Where(o => Applicable(cur, o)))\n",
+    "        {\n",
+    "            var next = ApplyOp(cur, op);\n",
+    "            string nKey = StateKey(next);\n",
+    "            if (closed.Contains(nKey)) continue;\n",
+    "            int tentative = gScore[curKey] + op.Cost;\n",
+    "            if (tentative < gScore.GetValueOrDefault(nKey, int.MaxValue))\n",
+    "            {\n",
+    "                gScore[nKey] = tentative;\n",
+    "                stateOf[nKey] = next;\n",
+    "                cameFrom[nKey] = (curKey, op.Name);\n",
+    "                frontier.Enqueue(nKey, tentative + h(next));   // f = g + h\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return (new(), -1, nodes);\n",
+    "}\n",
+    "\n",
+    "var (planA, costA, nodesA) = AStarSas(ferryInit, ferryGoal, ferryOps, s => HMaxSas(ferryOps, ferryGoal, s));\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine($\"A* (h^max) sur Ferry : cout={costA}, noeuds expanses={nodesA}, longueur plan={planA.Count}\");\n",
+    "sb.AppendLine($\"Plan optimal : [{string.Join(\", \", planA)}]\");\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cbfe0ee",
+   "metadata": {},
+   "source": [
+    "## 6. Greedy Best-First Search (satisficing)\n",
+    "\n",
+    "GBFS ordonne la frontiere par **`h(n)` uniquement** (le cout `g` accumule est ignore). Cela pousse la recherche droit vers le but estime — beaucoup plus rapide en pratique, mais **sans garantie d'optimalite**. On la branche sur h^FF, l'heuristique la plus informative pour la planification satisficing.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1dcac91d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:20.044259Z",
+     "iopub.status.busy": "2026-07-07T00:16:20.044259Z",
+     "iopub.status.idle": "2026-07-07T00:16:20.082180Z",
+     "shell.execute_reply": "2026-07-07T00:16:20.082180Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GBFS (h^FF) sur Ferry : cout=11, noeuds expanses=12, longueur plan=11\r\n",
+       "Plan : [board(car1,L), sail(L,R), debark(car1,R), sail(R,L), board(car2,L), sail(L,R), debark(car2,R), sail(R,L), board(car3,L), sail(L,R), debark(car3,R)]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Greedy Best-First Search : priorite = h uniquement. Rapide, NON optimal.\n",
+    "public static (List<string> plan, int cost, int nodesExpanded) GBFSSas(\n",
+    "    Dictionary<string, int> init, Dictionary<string, int> goal, List<SasOperator> ops,\n",
+    "    Func<Dictionary<string, int>, int> h)\n",
+    "{\n",
+    "    var frontier = new PriorityQueue<string, int>();\n",
+    "    string iKey = StateKey(init);\n",
+    "    frontier.Enqueue(iKey, h(init));\n",
+    "    var gScore = new Dictionary<string, int> { [iKey] = 0 };\n",
+    "    var stateOf = new Dictionary<string, Dictionary<string, int>> { [iKey] = init };\n",
+    "    var cameFrom = new Dictionary<string, (string parent, string op)>();\n",
+    "    var closed = new HashSet<string>();\n",
+    "    int nodes = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        frontier.TryDequeue(out var curKey, out _);\n",
+    "        if (closed.Contains(curKey)) continue;\n",
+    "        closed.Add(curKey);\n",
+    "        var cur = stateOf[curKey];\n",
+    "        nodes++;\n",
+    "        if (SatisfiesGoal(cur, goal))\n",
+    "        {\n",
+    "            var plan = new List<string>();\n",
+    "            var k = curKey;\n",
+    "            while (cameFrom.ContainsKey(k)) { plan.Add(cameFrom[k].op); k = cameFrom[k].parent; }\n",
+    "            plan.Reverse();\n",
+    "            return (plan, gScore[curKey], nodes);\n",
+    "        }\n",
+    "        foreach (var op in ops.Where(o => Applicable(cur, o)))\n",
+    "        {\n",
+    "            var next = ApplyOp(cur, op);\n",
+    "            string nKey = StateKey(next);\n",
+    "            if (closed.Contains(nKey)) continue;\n",
+    "            int tentative = gScore[curKey] + op.Cost;\n",
+    "            if (tentative < gScore.GetValueOrDefault(nKey, int.MaxValue))\n",
+    "            {\n",
+    "                gScore[nKey] = tentative;\n",
+    "                stateOf[nKey] = next;\n",
+    "                cameFrom[nKey] = (curKey, op.Name);\n",
+    "                frontier.Enqueue(nKey, h(next));   // f = h seul (greedy)\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return (new(), -1, nodes);\n",
+    "}\n",
+    "\n",
+    "var (planG, costG, nodesG) = GBFSSas(ferryInit, ferryGoal, ferryOps, s => HFFSas(ferryOps, ferryGoal, s));\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine($\"GBFS (h^FF) sur Ferry : cout={costG}, noeuds expanses={nodesG}, longueur plan={planG.Count}\");\n",
+    "sb.AppendLine($\"Plan : [{string.Join(\", \", planG)}]\");\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69e1146e",
+   "metadata": {},
+   "source": [
+    "## 7. Enforced Hill Climbing (EHC) — la strategie de recherche de FF\n",
+    "\n",
+    "**EHC** (Hoffmann & Nebel 2001) est l'algorithme **distinctif** de ce notebook : il n'apparait ni dans Planners-3 (state-space generique) ni dans Planners-5 (heuristiques pures). C'est le coeur du planificateur FF.\n",
+    "\n",
+    "**Principe** : EHC ne maintient pas de frontiere globale. A chaque etape, depuis l'etat courant, il fait une **BFS** a la recherche d'un etat de heuristique **strictement inferieure**. Des qu'il en trouve un, il **commit tout le chemin** (toutes les actions intermediaires) vers cet etat ameliorant, puis recommence depuis la. Si la BFS epuise tout l'espace reachable sans trouver d'ameliorant, EHC **echoue** (ou, dans le FF complet, bascule sur GBFS en fallback).\n",
+    "\n",
+    "```\n",
+    "current = initial ; plan = []\n",
+    "tant que h(current) > 0 :\n",
+    "    (trouve, chemin, noeuds) = BFS-pour-un-etat-strictement-mieux-que-h(current)\n",
+    "    si non trouve : retourner ECHEC\n",
+    "    appliquer chemin a current ; plan += chemin\n",
+    "retourner plan\n",
+    "```\n",
+    "\n",
+    "L'idee : h^FF est souvent **parfaitement informative** sur les problemes faciles — la BFS trouve un ameliorant a faible profondeur, et EHC descend en escalier vers le but en tres peu de noeuds expanses. Sur les problemes ou h^FF a des plateaux ou des minima locaux, EHC peut en revanche echouer la ou A\\* (avec replan complet) reussit.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6cf1bbb8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:20.082180Z",
+     "iopub.status.busy": "2026-07-07T00:16:20.082180Z",
+     "iopub.status.idle": "2026-07-07T00:16:20.137662Z",
+     "shell.execute_reply": "2026-07-07T00:16:20.137662Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EHC (h^FF) sur Ferry : succes=True, cout=11, noeuds expanses=15, longueur plan=11\r\n",
+       "Plan : [board(car1,L), sail(L,R), debark(car1,R), sail(R,L), board(car2,L), sail(L,R), debark(car2,R), sail(R,L), board(car3,L), sail(L,R), debark(car3,R)]\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Enforced Hill Climbing : a chaque pas, BFS depuis current vers un etat strictement meilleur ;\n",
+    "// on commit le chemin et on recommence. Si aucun ameliorant accessible : ECHEC.\n",
+    "public static (List<string> plan, int cost, int nodesExpanded, bool success) EHCSas(\n",
+    "    Dictionary<string, int> init, Dictionary<string, int> goal, List<SasOperator> ops,\n",
+    "    Func<Dictionary<string, int>, int> h)\n",
+    "{\n",
+    "    var plan = new List<string>();\n",
+    "    int nodes = 0;\n",
+    "    var current = CloneState(init);\n",
+    "    int hCur = h(current);\n",
+    "    int guard = 0;\n",
+    "    while (hCur > 0 && hCur < int.MaxValue && guard++ < 100000)\n",
+    "    {\n",
+    "        var (found, path, bfsNodes) = BfsImprove(current, hCur, ops, h);\n",
+    "        nodes += bfsNodes;\n",
+    "        if (!found) return (plan, -1, nodes, false);   // bloque : aucun ameliorant accessible\n",
+    "        foreach (var opName in path)\n",
+    "        {\n",
+    "            var op = ops.First(o => o.Name == opName);\n",
+    "            current = ApplyOp(current, op);\n",
+    "            plan.Add(opName);\n",
+    "        }\n",
+    "        hCur = h(current);\n",
+    "    }\n",
+    "    bool ok = hCur == 0 && SatisfiesGoal(current, goal);\n",
+    "    return (plan, ok ? plan.Count : -1, nodes, ok);\n",
+    "}\n",
+    "\n",
+    "// BFS cherchant un etat de heuristique strictement inferieure a hTarget (depuis start).\n",
+    "static (bool found, List<string> path, int nodes) BfsImprove(\n",
+    "    Dictionary<string, int> start, int hTarget, List<SasOperator> ops, Func<Dictionary<string, int>, int> h)\n",
+    "{\n",
+    "    string sKey = StateKey(start);\n",
+    "    var q = new Queue<string>(); q.Enqueue(sKey);\n",
+    "    var stateOf = new Dictionary<string, Dictionary<string, int>> { [sKey] = start };\n",
+    "    var cameFrom = new Dictionary<string, (string parent, string op)>();\n",
+    "    var seen = new HashSet<string> { sKey };\n",
+    "    int nodes = 0;\n",
+    "    while (q.Count > 0)\n",
+    "    {\n",
+    "        var ck = q.Dequeue();\n",
+    "        var cur = stateOf[ck];\n",
+    "        nodes++;\n",
+    "        foreach (var op in ops.Where(o => Applicable(cur, o)))\n",
+    "        {\n",
+    "            var next = ApplyOp(cur, op);\n",
+    "            var nk = StateKey(next);\n",
+    "            if (seen.Contains(nk)) continue;\n",
+    "            seen.Add(nk); stateOf[nk] = next; cameFrom[nk] = (ck, op.Name);\n",
+    "            if (h(next) < hTarget)\n",
+    "            {\n",
+    "                var path = new List<string>();\n",
+    "                var k = nk;\n",
+    "                while (cameFrom.ContainsKey(k)) { path.Add(cameFrom[k].op); k = cameFrom[k].parent; }\n",
+    "                path.Reverse();\n",
+    "                return (true, path, nodes);\n",
+    "            }\n",
+    "            q.Enqueue(nk);\n",
+    "        }\n",
+    "    }\n",
+    "    return (false, new List<string>(), nodes);\n",
+    "}\n",
+    "\n",
+    "var (planE, costE, nodesE, okE) = EHCSas(ferryInit, ferryGoal, ferryOps, s => HFFSas(ferryOps, ferryGoal, s));\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine($\"EHC (h^FF) sur Ferry : succes={okE}, cout={costE}, noeuds expanses={nodesE}, longueur plan={planE.Count}\");\n",
+    "if (okE) sb.AppendLine($\"Plan : [{string.Join(\", \", planE)}]\");\n",
+    "else sb.AppendLine(\"(EHC bloque : aucun etat ameliorant accessible — EHC tombe dans un plateau/minimum local de h^FF.)\");\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "648217a4",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — EHC avec profondeur de BFS bornee\n",
+    "\n",
+    "L'EHC ci-dessus explore **tout** le sous-espace reachable a chaque phase (BFS illimitee). Sur de gros domaines, cela coute cher. Implementez une variante **bornee** : la BFS s'arrete a une profondeur `maxDepth` donnee ; si aucun ameliorant trouve dans cette profondeur, on retourne ECHEC (ou on bascule en BFS complete).\n",
+    "\n",
+    "**Indices** : ajoutez un parametre `maxDepth` a `BfsImprove` ; suivez la profondeur dans la queue (file de tuples `(stateKey, depth)`) ; ne detronque pas la condition d'amelioration `h(next) < hTarget`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8599e41b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:20.139665Z",
+     "iopub.status.busy": "2026-07-07T00:16:20.138762Z",
+     "iopub.status.idle": "2026-07-07T00:16:20.184980Z",
+     "shell.execute_reply": "2026-07-07T00:16:20.184980Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 (EHC borne en profondeur) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : EHC avec BFS de profondeur bornee.\n",
+    "// TODO etudiant : implementer EHCDepthBounded en limitant la profondeur d'exploration de chaque phase.\n",
+    "// Indice : modifier BfsImprove pour suivre (key, depth) et stopper l'enqueue au-dela de maxDepth.\n",
+    "// Etape 1 : ajouter maxDepth a la signature.\n",
+    "// Etape 2 : propager la profondeur dans la queue.\n",
+    "// Etape 3 : si aucune amelioration trouvee dans la profondeur -> retourner (false).\n",
+    "public static (List<string> plan, int cost, int nodesExpanded, bool success) EHCDepthBounded(\n",
+    "    Dictionary<string, int> init, Dictionary<string, int> goal, List<SasOperator> ops,\n",
+    "    Func<Dictionary<string, int>, int> h, int maxDepth)\n",
+    "{\n",
+    "    return (new List<string>(), -1, 0, false);   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice 1 (EHC borne en profondeur) a completer.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dba4f5b7",
+   "metadata": {},
+   "source": [
+    "## 8. Comparaison empirique A\\* / GBFS / EHC sur le Ferry\n",
+    "\n",
+    "On execute les trois recherches sur le **meme** probleme Ferry et on compare : cout du plan, optimalite (par rapport au cout trouve par A\\* + h^max admissible), nombre de noeuds expanses. C'est le punchline pedagogique — trois strategies tres differentes pour le meme planificateur sous-jacent.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "29901bcc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:20.189378Z",
+     "iopub.status.busy": "2026-07-07T00:16:20.189378Z",
+     "iopub.status.idle": "2026-07-07T00:16:20.226349Z",
+     "shell.execute_reply": "2026-07-07T00:16:20.226349Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Comparaison A* (h^max) / GBFS (h^FF) / EHC (h^FF) sur Ferry (3 voitures) ===\r\n",
+       "Algo   Heur.   Cout   Optimal   Noeuds   Plan(len)\r\n",
+       "--------------------------------------------------\r\n",
+       "A*     h^max   11     OUI       37       11\r\n",
+       "GBFS   h^FF    11     OUI       12       11\r\n",
+       "EHC    h^FF    11     OUI       15       11\r\n",
+       "\r\n",
+       "h* (cout optimal, garanti par A* + h^max admissible) = 11.\r\n",
+       "Plan optimal theorique pour 3 voitures : 4*3 - 1 = 11 actions (cf §3).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Comparaison sur le meme probleme Ferry. A* (h^max) = reference optimale.\n",
+    "string gOpt = costG == costA ? \"OUI\" : \"NON\";\n",
+    "string eCost = costE > 0 ? costE.ToString() : \"ECHEC\";\n",
+    "string eOpt = !okE ? \"ECHEC\" : (costE == costA ? \"OUI\" : \"NON\");\n",
+    "int eLen = costE > 0 ? planE.Count : 0;\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"=== Comparaison A* (h^max) / GBFS (h^FF) / EHC (h^FF) sur Ferry (3 voitures) ===\");\n",
+    "sb.AppendLine($\"{\"Algo\",-6} {\"Heur.\",-7} {\"Cout\",-6} {\"Optimal\",-9} {\"Noeuds\",-8} {\"Plan(len)\"}\");\n",
+    "sb.AppendLine(new string('-', 50));\n",
+    "sb.AppendLine($\"{\"A*\",-6} {\"h^max\",-7} {costA,-6} {\"OUI\",-9} {nodesA,-8} {planA.Count}\");\n",
+    "sb.AppendLine($\"{\"GBFS\",-6} {\"h^FF\",-7} {costG,-6} {gOpt,-9} {nodesG,-8} {planG.Count}\");\n",
+    "sb.AppendLine($\"{\"EHC\",-6} {\"h^FF\",-7} {eCost,-6} {eOpt,-9} {nodesE,-8} {eLen}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine($\"h* (cout optimal, garanti par A* + h^max admissible) = {costA}.\");\n",
+    "sb.AppendLine($\"Plan optimal theorique pour 3 voitures : 4*3 - 1 = 11 actions (cf §3).\");\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10ae6cfe",
+   "metadata": {},
+   "source": "### Interpretation : trois strategies, trois compromis\n\nResultats observes (execution reelle ci-dessus) :\n\n| Algorithme | Heuristique | Cout | Optimal | Noeuds expanses |\n|------------|-------------|------|---------|-----------------|\n| **A\\* (h^max)** | h^max (admissible) | 11 | OUI (garanti) | 37 |\n| **GBFS (h^FF)** | h^FF | 11 | OUI (sur cette instance) | 12 |\n| **EHC (h^FF)**  | h^FF | 11 | OUI (sur cette instance) | 15 |\n\n**Lecture** : sur le Ferry, h^FF est suffisamment informative pour que **GBFS et EHC trouvent aussi le plan optimal** (11 actions), tout en expansant environ **3 fois moins de noeuds** qu'A\\*. A\\* paie le cout de l'optimalite garantie : il prouve qu'aucun plan plus court n'existe en rouvrant davantage d'etats (37).\n\n> **Auto-correction G.1.** Une premiere version de cette interpretation affirmait que EHC expansait **le moins** de noeuds des trois. L'execution reelle infirme : sur cette instance, c'est **GBFS (12 noeuds)** qui en expansse le moins, devant EHC (15). La predominance \"EHC = le plus rapide\" est une tendance generale (EHC ne maintient pas de closed set global entre phases), **pas une garantie sur chaque instance**. Verifie contre l'output, corrige.\n\n**Generalisation** : la difference d'optimalite s'observe sur des domaines ou h^FF presente des plateaux (Logistics a plus de colis, Satellite). Sur les petits domaines ou h^FF est quasi parfait, les trois strategies convergent vers l'optimal — cf §9 Logistics."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "355a9459",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Encoder le domaine Gripper en SAS+\n",
+    "\n",
+    "Le domaine **Gripper** (IPC canonique) : un robot a **deux pinces** (left, right) et doit deplacer des balles entre deux pieces. Chaque pince tient au plus une balle. Encodez ce domaine en SAS+ et resolvez-le avec A\\*.\n",
+    "\n",
+    "**Indices / suggestions de variables** : `robot{roomA, roomB}`, `gripperL{free, ball1, ball2}`, `gripperR{free, ball1, ball2}`, `ball_i{roomA, roomB}`. Operateurs : `pick(ball, room, gripper)`, `drop(ball, room, gripper)`, `move(A,B)`, `move(B,A)`. Inspirez-vous de `FerryOps()` pour la structure prevail/pre/eff.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1a207d8b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:20.226349Z",
+     "iopub.status.busy": "2026-07-07T00:16:20.226349Z",
+     "iopub.status.idle": "2026-07-07T00:16:20.272459Z",
+     "shell.execute_reply": "2026-07-07T00:16:20.271451Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 (Gripper en SAS+) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : encoder GRIPPER en SAS+ (2 pinces, N balles, 2 pieces).\n",
+    "// TODO etudiant : implementer GripperOps() + un probleme (balles en A, but en B), puis resoudre par A*.\n",
+    "// Indice : une pince est une variable multi-valuee {free, ball1, ball2, ...}.\n",
+    "// Etape 1 : definir les operateurs pick/drop/move avec prevail/pre/eff.\n",
+    "// Etape 2 : construire l'etat initial (robot en A, pinces libres, balles en A) et le but (balles en B).\n",
+    "// Etape 3 : appeler AStarSas(...) et verifier le plan.\n",
+    "public static List<SasOperator> GripperOps()\n",
+    "{\n",
+    "    return new List<SasOperator>();   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice 2 (Gripper en SAS+) a completer.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cbb2cf2",
+   "metadata": {},
+   "source": [
+    "## 9. Translator demo : Logistics en SAS+\n",
+    "\n",
+    "Pour illustrer le **translator** sur un second domaine, encodons **Logistics** : 1 camion transporte 2 colis entre 2 lieux (A, B). Le camion a capacite illimitee (modele simplifie — ajouter une capacite est un exercice classique). Le translator PDDL -> SAS+ donnerait :\n",
+    "\n",
+    "| Variable SAS+ | Domaine | Sens |\n",
+    "|---------------|---------|------|\n",
+    "| `truck`       | {A, B}  | position du camion |\n",
+    "| `pkg1`        | {A, B, in_truck} | ou est le colis 1 |\n",
+    "| `pkg2`        | {A, B, in_truck} | ou est le colis 2 |\n",
+    "\n",
+    "Espace d'etats = `2 x 3 x 3 = 18` etats. Probleme : camion, pkg1, pkg2 tous en A ; but : pkg1 et pkg2 en B. Plan optimal attendu : `load(pkg1,A), load(pkg2,A), drive(A,B), unload(pkg1,B), unload(pkg2,B)` = **5 actions**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8eeda23c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:20.273851Z",
+     "iopub.status.busy": "2026-07-07T00:16:20.273851Z",
+     "iopub.status.idle": "2026-07-07T00:16:20.315233Z",
+     "shell.execute_reply": "2026-07-07T00:16:20.315233Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Logistics (SAS+) : 3 variables, 10 operateurs, espace = 2 x 3 x 3 = 18 etats.\r\n",
+       "Probleme : truck + pkg1 + pkg2 en A ; but pkg1 et pkg2 en B.\r\n",
+       "\r\n",
+       "A* (h^max) : cout=5, noeuds=10\r\n",
+       "   plan : [load(pkg1,A), load(pkg2,A), drive(A,B), unload(pkg2,B), unload(pkg1,B)]\r\n",
+       "GBFS(h^FF) : cout=5, noeuds=6, longueur=5\r\n",
+       "EHC (h^FF) : succes=True, cout=5, noeuds=5\r\n",
+       "\r\n",
+       "Cout optimal attendu = 5 : load(pkg1,A), load(pkg2,A), drive(A,B), unload(pkg1,B), unload(pkg2,B).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Domaine LOGISTICS en SAS+ : 1 camion (capacite illimitee), 2 colis, 2 lieux (A,B).\n",
+    "// Variables : truck{A,B}, pkg1{A,B,in_truck}, pkg2{A,B,in_truck}.\n",
+    "const int LOC_A = 0, LOC_B = 1, IN_TRUCK = 2;\n",
+    "\n",
+    "List<SasOperator> LogisticsOps()\n",
+    "{\n",
+    "    var ops = new List<SasOperator>();\n",
+    "    ops.Add(new SasOperator(\"drive(A,B)\", new(), new() { [\"truck\"] = LOC_A }, new() { [\"truck\"] = LOC_B }));\n",
+    "    ops.Add(new SasOperator(\"drive(B,A)\", new(), new() { [\"truck\"] = LOC_B }, new() { [\"truck\"] = LOC_A }));\n",
+    "    foreach (var pkg in new[] { \"pkg1\", \"pkg2\" })\n",
+    "        foreach (var loc in new[] { LOC_A, LOC_B })\n",
+    "        {\n",
+    "            string tag = loc == LOC_A ? \"A\" : \"B\";\n",
+    "            // load(pkg, loc) : prevail truck=loc ; pre pkg=loc ; eff pkg=in_truck.\n",
+    "            ops.Add(new SasOperator($\"load({pkg},{tag})\",\n",
+    "                Prevail: new() { [\"truck\"] = loc }, Precondition: new() { [pkg] = loc },\n",
+    "                Effect: new() { [pkg] = IN_TRUCK }));\n",
+    "            // unload(pkg, loc) : prevail truck=loc ; pre pkg=in_truck ; eff pkg=loc.\n",
+    "            ops.Add(new SasOperator($\"unload({pkg},{tag})\",\n",
+    "                Prevail: new() { [\"truck\"] = loc }, Precondition: new() { [pkg] = IN_TRUCK },\n",
+    "                Effect: new() { [pkg] = loc }));\n",
+    "        }\n",
+    "    return ops;\n",
+    "}\n",
+    "\n",
+    "var logInit = new Dictionary<string, int> { [\"truck\"] = LOC_A, [\"pkg1\"] = LOC_A, [\"pkg2\"] = LOC_A };\n",
+    "var logGoal = new Dictionary<string, int> { [\"pkg1\"] = LOC_B, [\"pkg2\"] = LOC_B };\n",
+    "var logOps = LogisticsOps();\n",
+    "\n",
+    "var (planLA, costLA, nodesLA) = AStarSas(logInit, logGoal, logOps, s => HMaxSas(logOps, logGoal, s));\n",
+    "var (planLE, costLE, nodesLE, okLE) = EHCSas(logInit, logGoal, logOps, s => HFFSas(logOps, logGoal, s));\n",
+    "var (planLG, costLG, nodesLG) = GBFSSas(logInit, logGoal, logOps, s => HFFSas(logOps, logGoal, s));\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine($\"Logistics (SAS+) : 3 variables, {logOps.Count} operateurs, espace = 2 x 3 x 3 = {2 * 3 * 3} etats.\");\n",
+    "sb.AppendLine($\"Probleme : truck + pkg1 + pkg2 en A ; but pkg1 et pkg2 en B.\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine($\"A* (h^max) : cout={costLA}, noeuds={nodesLA}\");\n",
+    "sb.AppendLine($\"   plan : [{string.Join(\", \", planLA)}]\");\n",
+    "sb.AppendLine($\"GBFS(h^FF) : cout={costLG}, noeuds={nodesLG}, longueur={planLG.Count}\");\n",
+    "sb.AppendLine($\"EHC (h^FF) : succes={okLE}, cout={costLE}, noeuds={nodesLE}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine($\"Cout optimal attendu = 5 : load(pkg1,A), load(pkg2,A), drive(A,B), unload(pkg1,B), unload(pkg2,B).\");\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "640835fe",
+   "metadata": {},
+   "source": "### Interpretation : Logistics\n\nSur ce petit domaine, **A\\*, GBFS et EHC convergent vers le meme plan optimal de 5 actions** : la structure est tellement simple que les trois strategies convergent. On notera toutefois que sur cette instance precise, **h^FF est exactement egal a h\\*** (le plan relaxe coincide avec le plan reel : pas d'interaction cachee) — EHC descend donc en escalier direct, une action par phase (5 phases, 5 noeuds expanses).\n\n**Ce que le translator apporte ici** : en passant des predicats PDDL `(at pkg1 A) / (at pkg1 B) / (in pkg1 truck)` a une seule variable `pkg1{A, B, in_truck}`, l'encodage elimine les etats impossibles (pkg1 ne peut pas etre simultanement en A et dans le camion) et compactifie la representation."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ad1a58a",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — h^max vs h^FF comme guidage pour A\\*\n",
+    "\n",
+    "Comparez les deux heuristiques comme fonction de guidage **pour A\\*** sur le domaine Ferry. A\\* + h^max est optimal (h^max admissible) mais h^max est faible ; A\\* + h^FF n'est **pas** garanti optimal (h^FF non admissible) mais explore generalement beaucoup moins de noeuds. Quantifiez le trade-off.\n",
+    "\n",
+    "**Indices** : appelez `AStarSas(ferryInit, ferryGoal, ferryOps, s => HFFSas(...))` et comparez `nodesA` (h^max) au nombre de noeuds avec h^FF. Comparez aussi les couts — A\\* + h^FF peut retourner un plan **non optimal** (cout potentiellement superieur a `costA`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f5056e81",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:16:20.315233Z",
+     "iopub.status.busy": "2026-07-07T00:16:20.315233Z",
+     "iopub.status.idle": "2026-07-07T00:16:20.331276Z",
+     "shell.execute_reply": "2026-07-07T00:16:20.331276Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 (h^max vs h^FF en A*) a completer."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : comparer h^max vs h^FF comme guidage de A* sur Ferry.\n",
+    "// TODO etudiant : executer AStarSas avec h = HFFSas (non admissible), noter le nombre de noeuds et le cout,\n",
+    "// et comparer a A* + h^max (cout optimal).\n",
+    "// Indice : A* + h^FF n'est PAS garanti optimal mais explore generalement moins de noeuds.\n",
+    "// Etape 1 : var (planAFF, costAFF, nodesAFF) = AStarSas(..., s => HFFSas(...));\n",
+    "// Etape 2 : comparer nodesAFF vs nodesA, et costAFF vs costA.\n",
+    "public static (int nodesHMax, int nodesHFF, int costHMax, int costHFF) CompareAStarHeuristics()\n",
+    "{\n",
+    "    return (0, 0, 0, 0);   // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "\"Exercice 3 (h^max vs h^FF en A*) a completer.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "856e1d0f",
+   "metadata": {},
+   "source": [
+    "## 10. Conclusion\n",
+    "\n",
+    "### Ce que vous avez appris\n",
+    "\n",
+    "1. **SAS+** : un etat est un vecteur de variables multi-valuees (`Dictionary<string,int>`), plus compact que STRIPS. Un operateur se decompose en **prevail** (conditions sur variables invariantes), **precondition** (valeurs from des variables modifiees), **effect** (affectations).\n",
+    "2. **Translator** : le concept de la conversion PDDL -> SAS+ (invariants mutuels -> variables, grounding -> operateurs instanties).\n",
+    "3. **A\\*** (optimal avec h^max admissible), **GBFS** (satisficing avec h^FF), **EHC** (escalier BFS par amelioration strict, strategie du planificateur FF).\n",
+    "4. **h^FF** : graphe de plan relaxation (delete-relaxation) + extraction gloutonne d'un plan relaxe, appliquee via la projection d'atomes SAS+.\n",
+    "5. **Trade-off optimalite/vitesse** : A\\* prouve l'optimalite au prix de plus de noeuds ; GBFS/EHC sacrifient la garantie pour la vitesse.\n",
+    "\n",
+    "### Lien avec Fast Downward et le twin Python\n",
+    "\n",
+    "| Concept de ce twin | Equivalent Fast Downward (C++) |\n",
+    "|--------------------|-------------------------------|\n",
+    "| `SasOperator(Prevail/Pre/Eff)` | fichier `output.sas` du translator |\n",
+    "| `HMaxSas` / `HFFSas` | heuristiques `hmax()` / `ff()` du moteur |\n",
+    "| `AStarSas` | `astar(...)` |\n",
+    "| `GBFSSas` | `eager_greedy(...)` / `lazy_greedy(...)` |\n",
+    "| `EHCSas` | `ehc(...)` |\n",
+    "\n",
+    "Le notebook Python [Planners-4-Fast-Downward](Planners-4-Fast-Downward.ipynb) **appelle le vrai Fast Downward** via Docker + `unified-planning` (RECOVERABLE-MACHINE) : il montre les performances et la sortie brute du solveur industriel. Ce twin C# montre **comment ca marche a l'interieur** : les structures, les boucles, les compromis. Les deux sont complementaires.\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "\n",
+    "- **Heuristiques admissibles plus fortes** : LM-cut, pattern databases, merge-and-shrink — cf [Planners-5-Heuristics-Csharp](Planners-5-Heuristics-Csharp.ipynb).\n",
+    "- **Recherche par contraintes** : [Planners-7-OR-Tools](../03-Advanced/Planners-7-OR-Tools.ipynb) (CP-SAT).\n",
+    "- **Planification hierarchique** : [Planners-9-HTN-Csharp](../03-Advanced/Planners-9-HTN-Csharp.ipynb) (SHOP2).\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "- Helmert (2006), *The Fast Downward Planning System*, JAIR.\n",
+    "- Helmert (2009), *Concise finite-domain representations for PDDL planning tasks*, IJCAI.\n",
+    "- Hoffmann & Nebel (2001), *The FF planning system: Fast plan generation through heuristic search*, JAIR.\n",
+    "- Bonet & Geffner (2001), *Planning as heuristic search*, AIJ.\n",
+    "\n",
+    "---\n",
+    "*Marathon #4956 (parite .NET <-> Python). Twin C# du notebook Python [Planners-4-Fast-Downward.ipynb](Planners-4-Fast-Downward.ipynb). Regitre SOTA : EPIC #3801.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -122,6 +122,7 @@ SymbolicAI/Planners/
 │   └── Planners-3-State-Space-Csharp.ipynb # Twin C# BFS/DFS/Greedy/A* (See #4956)
 ├── 02-Classical/
 │   ├── Planners-4-Fast-Downward.ipynb   # A*, heuristiques
+│   ├── Planners-4-Fast-Downward-Csharp.ipynb # Twin C# SAS+/A*/GBFS/EHC from-scratch (See #4956)
 │   ├── Planners-5-Heuristics.ipynb      # h-add, h-max, h-FF
 │   ├── Planners-5-Heuristics-Csharp.ipynb # Twin C# h-max/h-add/h-FF/landmarks (See #4956)
 │   ├── Planners-5b-Lean-Relaxation.ipynb # Companion Lean 4 : preuve h+ <= h*
@@ -213,6 +214,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | # | Notebook | Kernel | Contenu | Durée |
 |---|----------|--------|---------|-------|
 | 4 | [Planners-4-Fast-Downward](02-Classical/Planners-4-Fast-Downward.ipynb) | Python | Architecture FD, Docker, A*, GBFS, EHC, heuristiques | 45 min |
+| 4 (C#) | [Planners-4-Fast-Downward-Csharp](02-Classical/Planners-4-Fast-Downward-Csharp.ipynb) | .NET (C#) | Twin C# du 4 : planificateur SAS+ from-scratch (prevail/pre/eff), A\*/GBFS/EHC, h^max/h^FF par RPG, domaines Ferry + Logistics (See #4956) | 45 min |
 | 5 | [Planners-5-Heuristics](02-Classical/Planners-5-Heuristics.ipynb) | Python | h-add, h-max, h-FF, landmarks | 40 min |
 | 5 (C#) | [Planners-5-Heuristics-Csharp](02-Classical/Planners-5-Heuristics-Csharp.ipynb) | .NET (C#) | Twin C# du 5 : h-max/h-add/h-FF/landmarks from-scratch, démo non-admissibilité h^add (See #4956) | 40 min |
 | 5b | [Planners-5b-Lean-Relaxation](02-Classical/Planners-5b-Lean-Relaxation.ipynb) | Lean 4 | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de l'admissibilité de la relaxation (h⁺ ≤ h\*) dans le lake `planning_lean`, `#check` + `#print axioms` in-kernel (cf [#4053](https://github.com/jsboige/CoursIA/issues/4053) création du lake / PR #4168, companion natif) | 45 min |


### PR DESCRIPTION
## Summary

Twin C# pedagogique du notebook Python `Planners-4-Fast-Downward` (marathon **#4956** — parite .NET <-> Python, `See #4956`). Le Python original invoque le vrai **Fast Downward** (IPC winner) via Docker + `unified-planning`. Le twin C# est un **planificateur SAS+ from-scratch** (BCL .NET 9, 0 NuGet) qui rend visibles les internes que le solveur industriel masque : la representation SAS+, le concept de translator, et trois algorithmes de recherche.

## Contenu distinctif

vs les twins C# existants (Planners-2 STRIPS, Planners-3 A*, Planners-5 heuristics, Planners-9 HTN), ce notebook apporte des concepts **non couverts ailleurs** :

- **Representation SAS+** : etat = variables multi-valuees (`Dictionary<string,int>`), operateur avec separation **Prevail / Precondition / Effect**. Domaine **Ferry** encode directement en SAS+ (3 voitures, 2 rives, capacite 1 ; 5 variables, espace d'etats = 108).
- **Concept de translator** (PDDL -> SAS+) : correspondance variables / domaines / operateurs, encode sur le Ferry.
- **Trois algorithmes from-scratch** :
  - **A\*** (admissible, `f = g + h^max`)
  - **Greedy Best-First Search** (satisficing, rapide)
  - **Enforced Hill Climbing** (Hoffmann FF : BFS plateau vers un etat strictement meilleur + commit) — algorithme distinctif non present dans les autres twins
- **Heuristique h^FF** par Relaxed Planning Graph (delete-relaxation), self-contained.
- **Tableau comparatif A\* / GBFS / EHC** sur la meme instance (cout, optimalite, noeuds expanses) — le punchline pedagogique.
- Domaine additionnel : **Logistics** (2 colis, 2 lieux, capacite illimitee ; 3 variables, espace = 18).

## Preuve d'execution (H.1 / EXEC_PROVED)

Re-execute end-to-end via kernel `.net-csharp` (dotnet-interactive, .NET local) :
- **12/12 cellules code** avec `execution_count` (1..12), **0 erreur**, **0 output vide**.
- `notebook_tools.py validate --quick` : **OK=1, Warnings=0, Errors=0**.

## Verification mathematique firsthand (Math Verification Standard)

| Domaine | Optimal theorique | A\* (h^max) | GBFS (h^FF) | EHC (h^FF) |
|---------|-------------------|-------------|-------------|------------|
| Ferry (n=3) | 4n-1 = **11** | cout=11, 37 noeuds | cout=11, 12 noeuds | cout=11, 15 noeuds |
| Logistics (2 colis) | **5** | cout=5, 10 noeuds | cout=5, 6 noeuds | cout=5, 5 noeuds |

- Plan A\* Ferry hand-valide : 2 round-trips (4×2) + 1 one-way (3) = 11 actions -> car1/2/3 = R = but.
- h^max(Ferry init) = 2 (admissible), h^FF(Ferry init) = 7.
- **G.1 self-correction documentee dans le notebook** : sur Ferry, GBFS(12) < EHC(15) < A\*(37) noeuds. La prose initiale disait « EHC = le moins de noeuds » ; corrigee apres execution (EHC est une tendance generale, pas une garantie par instance — meme discipline de self-correction que le twin App-19 WFC).

## SOTA verdict (EPIC #3801)

Twin from-scratch = **SOTA-OK** (concept pedagogique du moteur SAS+). Le Python original invoque le vrai Fast Downward via Docker + `unified-planning` = **RECOVERABLE-MACHINE** (companions intentionnels, meme pattern que le twin Search-15 NetworkX : from-scratch rend les internes visibles, le vrai solveur reste la reference). Cross-links vers Planners-3-Csharp (A\*) et Planners-5-Csharp (heuristiques).

## Conventions respectees

- **C.1** : 0 `raise`/`throw`/`assert False`/`1/0`/`NotImplemented` partout ; 3 exercices stubs (`# Exercice 1` EHC borne, `# Exercice 2` Gripper en SAS+, `# Exercice 3` h^max vs h^FF) en patterns conformes (`return ...; // TODO etudiant`), distribues dans le notebook.
- **C.2** : outputs commites, `execution_count` integers sur toutes les cellules code.
- **§E** : +1 ligne arbre + 1 ligne table dans `Planners/README.md` (style identique a Planners-5-Csharp / Planners-9-Csharp), bloc `<!-- CATALOG-STATUS -->` byte-identical (regen geree par cron, cf `catalog-pr-hygiene` HARD 1).
- **readme-french-first** : prose pedagogique en francais, pas d'emojis.

## Test plan

- [x] Execution end-to-end kernel `.net-csharp` (12/12 cellules, 0 erreur)
- [x] `notebook_tools.py validate --quick` OK
- [x] Math hand-verification (Ferry 4n-1=11, Logistics=5, plans valides)
- [x] Grep C.1 (0 pattern interdit)
- [x] §E surgical (CATALOG-STATUS byte-identical)

Part of #4956 (marathon parite .NET <-> Python). Twin ~33e du marathon.
