### PR TITLE
feat(gametheory): GameTheory-15-CooperativeGames-Csharp — twin C# cooperative (.NET parity #4956)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames-Csharp.ipynb
@@ -1,0 +1,1142 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d91794b6",
+   "metadata": {},
+   "source": [
+    "# GameTheory-15 — Jeux Coopératifs (Twin C#)\n",
+    "\n",
+    "**Jumeau C# (.NET Interactive)** de `GameTheory-15-CooperativeGames.ipynb` — marathon parité .NET ⇄ Python (#4956).\n",
+    "\n",
+    "Ce notebook réimplémente from-scratch en C# pur (BCL .NET 9, **0 NuGet**) la **théorie des jeux coopératifs** : contrairement aux jeux non-coopératifs (où l'on étudie les stratégies individuelles), les jeux coopératifs modélisent ce qu'une **coalition** peut obtenir seule, via une **fonction caractéristique** `v : 2^N → ℝ`. On y calcule la **valeur de Shapley** (répartition juste par contribution marginale moyenne), l'**indice de pouvoir de Banzhaf** (pouvoir de swing dans un vote pondéré), le **core** (répartitions non bloquables par aucune coalition), et l'on étudie les **jeux convexes** (où Shapley ∈ core).\n",
+    "\n",
+    "> L'original Python s'appuie sur `numpy`/`itertools` ; ce twin traduit l'énumération des coalitions (powerset) et des permutations en C# (LINQ + récursion), et restitue les résultats en **tables console**.\n",
+    "\n",
+    "**Voir aussi** : [GameTheory-15 (Python)](GameTheory-15-CooperativeGames.ipynb) · marathon [#4956](https://github.com/jsboige/CoursIA/issues/4956) · registre SOTA [#3801](https://github.com/jsboige/CoursIA/issues/3801).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b9be608",
+   "metadata": {},
+   "source": [
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Modéliser un **jeu coopératif à utilité transférable** (TU game) via sa fonction caractéristique.\n",
+    "2. Énumérer **coalitions** (powerset) et **permutations**.\n",
+    "3. Calculer la **valeur de Shapley** (contribution marginale moyenne sur toutes les permutations).\n",
+    "4. Calculer l'**indice de pouvoir de Banzhaf** (swing, vote pondéré).\n",
+    "5. Définir le **core** et tester la **non-vacuité** (efficacité + inégalités de coalition).\n",
+    "6. Reconnaître les **jeux convexes** (marginales croissantes ⟹ core non vide, Shapley ∈ core).\n",
+    "\n",
+    "### Prérequis\n",
+    "- Théorie des jeux en forme normale (cf. [GameTheory-2](GameTheory-2-NormalForm-Csharp.ipynb), [GameTheory-4](GameTheory-4-NashEquilibrium-Csharp.ipynb)).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e97b4899",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:13.322154Z",
+     "iopub.status.busy": "2026-07-07T00:23:13.314934Z",
+     "iopub.status.idle": "2026-07-07T00:23:15.436078Z",
+     "shell.execute_reply": "2026-07-07T00:23:15.430494Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '12112.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Types charges : CooperativeGame (v: 2^N -> R via bitmask), helper Show()."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Setup : types de base pour un jeu cooperatif (TU game).\n",
+    "#nullable enable\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "public static void Show(object? o) => (o?.ToString() ?? \"<null>\").Display();\n",
+    "\n",
+    "// Un jeu cooperatif a utilite transferable : fonction caracteristique v: 2^N -> R.\n",
+    "// Representee par un dictionnaire : cle = coalition (sorted string of player indices), valeur = v(S).\n",
+    "public sealed class CooperativeGame\n",
+    "{\n",
+    "    public int N { get; }                       // nombre de joueurs\n",
+    "    public string[] Players { get; }\n",
+    "    private readonly Dictionary<long, double> _v = new();   // cle = bitmask de la coalition\n",
+    "    public CooperativeGame(int n, string[]? names = null)\n",
+    "    { N = n; Players = names ?? Enumerable.Range(0,n).Select(i=>$\"J{i+1}\").ToArray(); }\n",
+    "    public CooperativeGame SetV(IEnumerable<int> coalition, double value)\n",
+    "    { _v[Mask(coalition)] = value; return this; }\n",
+    "    public double V(IEnumerable<int> coalition) => _v.TryGetValue(Mask(coalition), out var val) ? val : 0.0;\n",
+    "    public long Mask(IEnumerable<int> coalition) { long m = 0; foreach (var i in coalition) m |= 1L << i; return m; }\n",
+    "    public IEnumerable<int> PlayersAsIndices => Enumerable.Range(0, N);\n",
+    "    public double VGrand => V(PlayersAsIndices);   // v(N)\n",
+    "}\n",
+    "\n",
+    "Show(\"Types charges : CooperativeGame (v: 2^N -> R via bitmask), helper Show().\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94c4acec",
+   "metadata": {},
+   "source": [
+    "## 1. Fonction caractéristique et coalitions\n",
+    "\n",
+    "### Définition\n",
+    "Un **jeu coopératif à utilité transférable** (von Neumann-Morgenstern 1944) est un couple `(N, v)` où `N = {1,…,n}` est l'ensemble des joueurs et `v : 2^N → ℝ` est la **fonction caractéristique** : `v(S)` est la valeur que la coalition `S` peut garantir seule (son « worth »). Conventions : `v(∅) = 0`, `v(S) ≥ 0` souvent.\n",
+    "\n",
+    "### Énumération des coalitions\n",
+    "L'ensemble des coalitions = le **powerset** de `N` (`2^n` coalitions). On l'énumère via les **bitmasks** de `0` à `2^n − 1`.\n",
+    "\n",
+    "### Propriétés\n",
+    "- **Superadditivité** : `v(S ∪ T) ≥ v(S) + v(T)` si `S ∩ T = ∅` (fusioner paie).\n",
+    "- **Convexité** : `v(S ∪ {i}) − v(S)` **croît** avec `S` (rend les grandes coalitions stables).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4b8e539a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:15.437993Z",
+     "iopub.status.busy": "2026-07-07T00:23:15.437745Z",
+     "iopub.status.idle": "2026-07-07T00:23:15.623375Z",
+     "shell.execute_reply": "2026-07-07T00:23:15.623218Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AllCoalitions (powerset bitmask) + IsSuperadditive + IsConvex definis."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Enumere toutes les coalitions (powerset) via bitmask.\n",
+    "public static List<List<int>> AllCoalitions(int n, bool includeEmpty = true)\n",
+    "{\n",
+    "    var res = new List<List<int>>();\n",
+    "    long total = 1L << n;\n",
+    "    for (long m = 0; m < total; m++)\n",
+    "    {\n",
+    "        if (m == 0 && !includeEmpty) continue;\n",
+    "        var c = new List<int>();\n",
+    "        for (int i = 0; i < n; i++) if ((m & (1L << i)) != 0) c.Add(i);\n",
+    "        res.Add(c);\n",
+    "    }\n",
+    "    return res;\n",
+    "}\n",
+    "\n",
+    "// Test de superadditivite : v(S u T) >= v(S) + v(T) pour S, T disjoints.\n",
+    "public static bool IsSuperadditive(CooperativeGame g)\n",
+    "{\n",
+    "    var coalitions = AllCoalitions(g.N, includeEmpty: false);\n",
+    "    foreach (var S in coalitions)\n",
+    "        foreach (var T in coalitions)\n",
+    "        {\n",
+    "            if (S.Intersect(T).Any()) continue;\n",
+    "            var union = S.Concat(T).ToList();\n",
+    "            if (g.V(union) + 1e-9 < g.V(S) + g.V(T)) return false;\n",
+    "        }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Test de convexite : marginales croissantes (v(S u {i}) - v(S)) croit avec S).\n",
+    "public static bool IsConvex(CooperativeGame g)\n",
+    "{\n",
+    "    foreach (int i in g.PlayersAsIndices)\n",
+    "    {\n",
+    "        var others = g.PlayersAsIndices.Where(j => j != i).ToList();\n",
+    "        var coalitionsWithoutI = AllCoalitions(g.N - 1, includeEmpty: true);\n",
+    "        // reindexer : mappper les coalitions de 'others' vers les vrais indices\n",
+    "        for (int a = 0; a < coalitionsWithoutI.Count; a++)\n",
+    "        for (int b = a + 1; b < coalitionsWithoutI.Count; b++)\n",
+    "        {\n",
+    "            var Sa = coalitionsWithoutI[a].Select(idx => others[idx]).ToList();\n",
+    "            var Sb = coalitionsWithoutI[b].Select(idx => others[idx]).ToList();\n",
+    "            // convexite : S subset T => marginale_i(S) <= marginale_i(T)\n",
+    "            if (Sa.All(x => Sb.Contains(x)))\n",
+    "            {\n",
+    "                double margS = g.V(Sa.Append(i)) - g.V(Sa);\n",
+    "                double margT = g.V(Sb.Append(i)) - g.V(Sb);\n",
+    "                if (margS > margT + 1e-9) return false;\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "Show(\"AllCoalitions (powerset bitmask) + IsSuperadditive + IsConvex definis.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f89048df",
+   "metadata": {},
+   "source": [
+    "### Interprétation : le « glove game » (jeu des gants)\n",
+    "\n",
+    "Le **glove game** canonique : 3 joueurs — le joueur 1 a un gant **gauche** (L), les joueurs 2 et 3 ont un gant **droit** (R). Une paire (L, R) vaut 1, sinon 0. Fonction caractéristique :\n",
+    "- `v({1}) = v({2}) = v({3}) = 0` (un seul gant ne sert à rien)\n",
+    "- `v({1,2}) = v({1,3}) = 1` (une paire), `v({2,3}) = 0` (deux droits)\n",
+    "- `v({1,2,3}) = 1` (une seule paire réalisable)\n",
+    "\n",
+    "Le joueur 1 (détenteur du gauche rare) a un **pouvoir de marché** : il est dans toutes les coalitions rentables.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "677bb0be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:15.624542Z",
+     "iopub.status.busy": "2026-07-07T00:23:15.624361Z",
+     "iopub.status.idle": "2026-07-07T00:23:15.739142Z",
+     "shell.execute_reply": "2026-07-07T00:23:15.738913Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Glove game (1 gauche, 2 droits) -- v(S) pour chaque coalition :\r\n",
+       "  v({ L1 }) = 0\r\n",
+       "  v({ R2 }) = 0\r\n",
+       "  v({ L1R2 }) = 1\r\n",
+       "  v({ R3 }) = 0\r\n",
+       "  v({ L1R3 }) = 1\r\n",
+       "  v({ R2R3 }) = 0\r\n",
+       "  v({ L1R2R3 }) = 1\r\n",
+       "\r\n",
+       "Superadditive : True\r\n",
+       "Convexe       : False\r\n",
+       "v(N) = v(grand coalition) = 1\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Glove game : 1 gauche (J1), 2 droits (J2, J3). Une paire (L,R) = 1.\n",
+    "var glove = new CooperativeGame(3, new[]{ \"L1\", \"R2\", \"R3\" });\n",
+    "glove.SetV(new[]{0}, 0).SetV(new[]{1}, 0).SetV(new[]{2}, 0);\n",
+    "glove.SetV(new[]{0,1}, 1).SetV(new[]{0,2}, 1).SetV(new[]{1,2}, 0);\n",
+    "glove.SetV(new[]{0,1,2}, 1);\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Glove game (1 gauche, 2 droits) -- v(S) pour chaque coalition :\");\n",
+    "foreach (var c in AllCoalitions(3, includeEmpty: false))\n",
+    "{\n",
+    "    var names = string.Join(\"\", c.Select(i => glove.Players[i]));\n",
+    "    sb.AppendLine($\"  v({{ {names} }}) = {glove.V(c)}\");\n",
+    "}\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine($\"Superadditive : {IsSuperadditive(glove)}\");\n",
+    "sb.AppendLine($\"Convexe       : {IsConvex(glove)}\");\n",
+    "sb.AppendLine($\"v(N) = v(grand coalition) = {glove.VGrand}\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a67d5a39",
+   "metadata": {},
+   "source": [
+    "### Interprétation des résultats\n",
+    "- **Superadditif** : oui (fusioner des coalitions disjointes ne diminue jamais la valeur — une coalition plus grosse accède à plus de gants).\n",
+    "- **Non convexe** : la marginale du joueur 1 **décroît** (passer de {2} à {2,3} comme partenaires ne crée qu'une paire au maximum). Le jeu n'est pas convexe, donc on n'a **pas** la garantie que le core soit non vide (on le vérifiera plus bas).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2507cf8f",
+   "metadata": {},
+   "source": [
+    "## 2. La valeur de Shapley\n",
+    "\n",
+    "### Définition (Shapley 1953)\n",
+    "La **valeur de Shapley** `φ_i` du joueur `i` est la **moyenne de ses contributions marginales** sur **toutes les permutations** des joueurs (modélisant tous les ordres d'arrivée équiprobables) :\n",
+    "\n",
+    "$$\\varphi_i = \\frac{1}{n!} \\sum_{\\pi \\in S_n} \\big[ v(\\{\\text{joueurs avant } i \\text{ dans } \\pi\\} \\cup \\{i\\}) - v(\\text{joueurs avant } i) \\big]$$\n",
+    "\n",
+    "### Propriétés (axiomes caractérisant Shapley)\n",
+    "- **Efficacité** : `Σ_i φ_i = v(N)` (tout est redistribué).\n",
+    "- **Symétrie** : deux joueurs interchangeables ont même φ.\n",
+    "- **Joueur nul** : si `i` ne contribue jamais (`v(S∪{i})=v(S)` ∀S), alors `φ_i = 0`.\n",
+    "- **Additivité** : `φ` est linéaire en `v`.\n",
+    "\n",
+    "Shapley est l'**unique** valeur satisfaisant ces 4 axiomes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "46b42651",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:15.740616Z",
+     "iopub.status.busy": "2026-07-07T00:23:15.740427Z",
+     "iopub.status.idle": "2026-07-07T00:23:15.894444Z",
+     "shell.execute_reply": "2026-07-07T00:23:15.894235Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Valeur de Shapley du glove game :\r\n",
+       "  phi_L1 = 0,6667\r\n",
+       "  phi_R2 = 0,1667\r\n",
+       "  phi_R3 = 0,1667\r\n",
+       "  Somme = 1,0000  (efficacite : doit egaler v(N) = 1)\r\n",
+       "\r\n",
+       "Lecture : le detenteur du gant gauche (L1, rare) capte ~2/3 de la valeur,\r\n",
+       "les deux detenteurs droits se partagent le reste (symetrie R2/R3).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Enumere toutes les permutations (Heap iteratif) des indices 0..n-1.\n",
+    "public static IEnumerable<List<int>> Permutations(int n)\n",
+    "{\n",
+    "    var a = Enumerable.Range(0, n).ToArray();\n",
+    "    var c = new int[n];\n",
+    "    yield return a.ToList();\n",
+    "    int i = 0;\n",
+    "    while (i < n)\n",
+    "    {\n",
+    "        if (c[i] < i)\n",
+    "        {\n",
+    "            if (i % 2 == 0) (a[0], a[i]) = (a[i], a[0]);\n",
+    "            else (a[c[i]], a[i]) = (a[i], a[c[i]]);\n",
+    "            yield return a.ToList();\n",
+    "            c[i]++;\n",
+    "            i = 0;\n",
+    "        }\n",
+    "        else { c[i] = 0; i++; }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Valeur de Shapley : moyenne des contributions marginales sur toutes les permutations.\n",
+    "public static double[] Shapley(CooperativeGame g)\n",
+    "{\n",
+    "    double[] phi = new double[g.N];\n",
+    "    long count = 0;\n",
+    "    foreach (var perm in Permutations(g.N))\n",
+    "    {\n",
+    "        var before = new List<int>();\n",
+    "        foreach (int i in perm)\n",
+    "        {\n",
+    "            var withI = new List<int>(before) { i };\n",
+    "            phi[i] += g.V(withI) - g.V(before);\n",
+    "            before = withI;\n",
+    "        }\n",
+    "        count++;\n",
+    "    }\n",
+    "    for (int i = 0; i < g.N; i++) phi[i] /= count;\n",
+    "    return phi;\n",
+    "}\n",
+    "\n",
+    "var phiGlove = Shapley(glove);\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Valeur de Shapley du glove game :\");\n",
+    "for (int i = 0; i < 3; i++) sb.AppendLine($\"  phi_{glove.Players[i]} = {phiGlove[i]:F4}\");\n",
+    "sb.AppendLine($\"  Somme = {phiGlove.Sum():F4}  (efficacite : doit egaler v(N) = {glove.VGrand})\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Lecture : le detenteur du gant gauche (L1, rare) capte ~2/3 de la valeur,\");\n",
+    "sb.AppendLine(\"les deux detenteurs droits se partagent le reste (symetrie R2/R3).\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b824ca42",
+   "metadata": {},
+   "source": [
+    "### Interprétation : Shapley du glove game\n",
+    "\n",
+    "La valeur de Shapley donne `φ_{L1} = 2/3`, `φ_{R2} = φ_{R3} = 1/6`. Vérification :\n",
+    "- **Efficacité** : `2/3 + 1/6 + 1/6 = 1 = v(N)` ✓.\n",
+    "- **Symétrie** : R2 et R3 (interchangeables) ont même φ ✓.\n",
+    "- **Pouvoir du rare** : L1 (le gauche) est dans toutes les coalitions rentables, d'où sa contribution marginale moyenne élevée.\n",
+    "\n",
+    "Le joueur qui détient la ressource **rare** (complémentaire) capture l'essentiel de la valeur — c'est l'intuition économique de Shapley (prix d'un facteur rare).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38da1421",
+   "metadata": {},
+   "source": [
+    "## 3. Indice de pouvoir de Banzhaf\n",
+    "\n",
+    "### Définition (Banzhaf 1965)\n",
+    "Dans un jeu de **vote pondéré** (chaque joueur a un poids, une coalition gagne si son poids total ≥ quota `q`), l'**indice de Banzhaf** mesure le **pouvoir de swing** d'un joueur : combien de coalitions deviennent gagnantes par son ajout.\n",
+    "\n",
+    "Un joueur `i` est **décisif** dans la coalition `S` (avec `i ∉ S`) si `S` perd mais `S ∪ {i}` gagne. L'indice de Banzhaf **non normalisé** :\n",
+    "\n",
+    "$$\\beta_i = |\\{ S \\subseteq N \\setminus \\{i\\} : S \\text{ perd}, S \\cup \\{i\\} \\text{ gagne} \\}|$$\n",
+    "\n",
+    "L'indice **normalisé** `β_i^* = β_i / Σ_j β_j` donne la part de pouvoir.\n",
+    "\n",
+    "> Contrairement à Shapley (qui pondère par la taille de coalition), Banzhaf traite toutes les coalitions équiprobablement. Utile en **analyse de pouvoir de vote** (Conseil de l'UE, assemblées d'actionnaires).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b509f4a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:15.896146Z",
+     "iopub.status.busy": "2026-07-07T00:23:15.895825Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.049122Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.048905Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Jeu de vote pondere : poids [50, 49, 1], quota = 50\r\n",
+       "Coalitions gagnantes :\r\n",
+       "  { A50 } poids=50\r\n",
+       "  { A50,B49 } poids=99\r\n",
+       "  { A50,C1 } poids=51\r\n",
+       "  { B49,C1 } poids=50\r\n",
+       "  { A50,B49,C1 } poids=100\r\n",
+       "\r\n",
+       "Indice de Banzhaf :\r\n",
+       "  beta_A50 = 3  (normalise = 0,6000)\r\n",
+       "  beta_B49 = 1  (normalise = 0,2000)\r\n",
+       "  beta_C1 = 1  (normalise = 0,2000)\r\n",
+       "\r\n",
+       "Lecon : bien que C1 n'ait que 1% du capital, il a autant de pouvoir de swing\r\n",
+       "que B49 (chacun decisive dans 1 coalition pivot, {B49,C1}=50). Le poids != le pouvoir.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Jeu de vote pondere : v(S) = 1 si sum(poids) >= q, sinon 0.\n",
+    "#nullable enable\n",
+    "public static CooperativeGame WeightedVotingGame(int[] weights, double q, string[]? names = null)\n",
+    "{\n",
+    "    int n = weights.Length;\n",
+    "    var g = new CooperativeGame(n, names);\n",
+    "    foreach (var S in AllCoalitions(n, includeEmpty: true))\n",
+    "        g.SetV(S, S.Sum(i => weights[i]) >= q ? 1.0 : 0.0);\n",
+    "    return g;\n",
+    "}\n",
+    "\n",
+    "// Indice de Banzhaf non normalise : nombre de swing coalitions pour chaque joueur.\n",
+    "public static double[] Banzhaf(CooperativeGame g)\n",
+    "{\n",
+    "    double[] beta = new double[g.N];\n",
+    "    var coalitions = AllCoalitions(g.N, includeEmpty: true);\n",
+    "    foreach (int i in g.PlayersAsIndices)\n",
+    "    {\n",
+    "        foreach (var S in coalitions)\n",
+    "        {\n",
+    "            if (S.Contains(i)) continue;\n",
+    "            var withI = new List<int>(S) { i };\n",
+    "            bool Sloses = g.V(S) < 0.5;        // v=0\n",
+    "            bool Swing = g.V(withI) >= 0.5;    // v=1\n",
+    "            if (Sloses && Swing) beta[i] += 1;\n",
+    "        }\n",
+    "    }\n",
+    "    return beta;\n",
+    "}\n",
+    "\n",
+    "// Exemple : 3 actionnaires, poids [50, 49, 1], quota 50 (majorite).\n",
+    "int[] weights = { 50, 49, 1 };\n",
+    "var wvg = WeightedVotingGame(weights, 50.0, new[]{ \"A50\", \"B49\", \"C1\" });\n",
+    "var beta = Banzhaf(wvg);\n",
+    "double bsum = beta.Sum();\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Jeu de vote pondere : poids [50, 49, 1], quota = 50\");\n",
+    "sb.AppendLine(\"Coalitions gagnantes :\");\n",
+    "foreach (var S in AllCoalitions(3, includeEmpty: false))\n",
+    "    if (wvg.V(S) >= 0.5) sb.AppendLine($\"  {{ {string.Join(\",\", S.Select(i=>wvg.Players[i]))} }} poids={S.Sum(i=>weights[i])}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Indice de Banzhaf :\");\n",
+    "for (int i = 0; i < 3; i++) sb.AppendLine($\"  beta_{wvg.Players[i]} = {beta[i]:F0}  (normalise = {beta[i]/bsum:F4})\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Lecon : bien que C1 n'ait que 1% du capital, il a autant de pouvoir de swing\");\n",
+    "sb.AppendLine(\"que B49 (chacun decisive dans 1 coalition pivot, {B49,C1}=50). Le poids != le pouvoir.\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73969cbc",
+   "metadata": {},
+   "source": [
+    "### Interprétation : poids ≠ pouvoir\n",
+    "Dans le vote `[50, 49, 1]` (quota 50), l'indice de Banzhaf vaut **β = (3, 1, 1)** :\n",
+    "- **A50** est décisif dans **3** coalitions (`{}`→`{A50}`, `{B49}`→`{A50,B49}`, `{C1}`→`{A50,C1}`) → β = 3.\n",
+    "- **B49** est décisif dans **1** coalition (`{C1}`→`{B49,C1}` = 50 ≥ 50) → β = 1.\n",
+    "- **C1** est décisif dans **1** coalition (`{B49}`→`{B49,C1}` = 50 ≥ 50) → β = 1.\n",
+    "\n",
+    "Ainsi **B49 et C1 ont le même pouvoir de swing** (1 chacun) malgré l'écart de capital (49 vs 1). C'est le cœur de l'analyse de Banzhaf : le **poids nominal est trompeur**, seul compte le nombre de coalitions pivot. Normalisé : `(0.6, 0.2, 0.2)` — C1 (1% du capital) détient **20%** du pouvoir.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17cde487",
+   "metadata": {},
+   "source": [
+    "## 4. Le core\n",
+    "\n",
+    "### Définition\n",
+    "Le **core** (Gillies 1959) est l'ensemble des **imputations** `x = (x_1,…,x_n)` que **aucune coalition ne peut bloquer** :\n",
+    "- **Efficacité** : `Σ_i x_i = v(N)` (tout est distribué).\n",
+    "- **Rationalité coalitionnelle** : `Σ_{i∈S} x_i ≥ v(S)` pour **toute** coalition `S`.\n",
+    "\n",
+    "Une coalition `S` pour laquelle `Σ_{i∈S} x_i < v(S)` peut **bloquer** `x` (elle obtient moins seule qu'en se séparable). Le core = répartitions **stables** (non bloquables).\n",
+    "\n",
+    "### Non-vacuité\n",
+    "Le core peut être **vide** (aucune répartition stable). Le **théorème de Bondareva-Shapley** : le core est non vide ssi le jeu est **équilibré**. Une condition suffisante : le jeu est **convexe** (alors Shapley ∈ core).\n",
+    "\n",
+    "### Test pratique\n",
+    "Pour un petit jeu, on teste la non-vacuité en cherchant une imputation `x` efficace satisfaisant toutes les inégalités `Σ_{i∈S} x_i ≥ v(S)`. C'est un **programme linéaire** (feasibility). On l'illustre ici par vérification directe de candidats (Shapley, imputation extrêmale).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "59e91314",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:16.050821Z",
+     "iopub.status.busy": "2026-07-07T00:23:16.050559Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.173130Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.172739Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Core du glove game : Shapley est-il stable ?\r\n",
+       "  Shapley = (0,6667, 0,1667, 0,1667)\r\n",
+       "  Dans le core : False\r\n",
+       "  Coalitions bloquantes :\r\n",
+       "    - S={ L1,R2 }: x(S)=0,8333 < v(S)=1\r\n",
+       "    - S={ L1,R3 }: x(S)=0,8333 < v(S)=1\r\n",
+       "\r\n",
+       "Candidat extremital x = (1, 0, 0) (L1 prend tout) :\r\n",
+       "  Dans le core : True  (coalitions bloquantes : 0)\r\n",
+       "\r\n",
+       "Lecon : le core du glove game est NON VIDE. L1 peut capturer toute la valeur\r\n",
+       "(x=(1,0,0) est stable : R2 et R3 seuls valent 0, donc ne peuvent bloquer).\r\n",
+       "C'est l'extreme : le detenteur du facteur rare peut tout extraire.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Teste si une imputation x est dans le core (efficace + rationnelle pour toute coalition).\n",
+    "public static (bool inCore, List<string> blocking) IsInCore(CooperativeGame g, double[] x)\n",
+    "{\n",
+    "    var blocking = new List<string>();\n",
+    "    if (Math.Abs(x.Sum() - g.VGrand) > 1e-9)\n",
+    "    { blocking.Add($\"efficacite: sum x = {x.Sum():F4} != v(N) = {g.VGrand}\"); return (false, blocking); }\n",
+    "    foreach (var S in AllCoalitions(g.N, includeEmpty: false))\n",
+    "    {\n",
+    "        if (S.Count == g.N) continue;   // grand coalition = efficacite deja teste\n",
+    "        double xs = S.Sum(i => x[i]);\n",
+    "        if (xs + 1e-9 < g.V(S))\n",
+    "            blocking.Add($\"S={{ {string.Join(\",\", S.Select(i=>g.Players[i]))} }}: x(S)={xs:F4} < v(S)={g.V(S)}\");\n",
+    "    }\n",
+    "    return (blocking.Count == 0, blocking);\n",
+    "}\n",
+    "\n",
+    "// Shapley est-il dans le core du glove game ?\n",
+    "var (inCore, blockers) = IsInCore(glove, phiGlove);\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Core du glove game : Shapley est-il stable ?\");\n",
+    "sb.AppendLine($\"  Shapley = ({phiGlove[0]:F4}, {phiGlove[1]:F4}, {phiGlove[2]:F4})\");\n",
+    "sb.AppendLine($\"  Dans le core : {inCore}\");\n",
+    "if (!inCore)\n",
+    "{\n",
+    "    sb.AppendLine(\"  Coalitions bloquantes :\");\n",
+    "    foreach (var b in blockers) sb.AppendLine($\"    - {b}\");\n",
+    "}\n",
+    "sb.AppendLine();\n",
+    "// Le core du glove game : x1+x2+x3 = 1, x1+x2>=1, x1+x3>=1, x2+x3>=0, x1,x2,x3>=0.\n",
+    "// => x1 >= 1 - x2 et x1 >= 1 - x3, avec x2+x3 <= 1 - x1. Si x1 < 1, on a x2+x3 > 0 ok.\n",
+    "// Core non vide : tout x avec x1 dans [..], par ex. x=(1,0,0) : x1+x2=1>=1, x1+x3=1>=1, x2+x3=0>=0. STABLE.\n",
+    "sb.AppendLine(\"Candidat extremital x = (1, 0, 0) (L1 prend tout) :\");\n",
+    "var extreme = new double[]{ 1.0, 0.0, 0.0 };\n",
+    "var (inCore2, blockers2) = IsInCore(glove, extreme);\n",
+    "sb.AppendLine($\"  Dans le core : {inCore2}  (coalitions bloquantes : {blockers2.Count})\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Lecon : le core du glove game est NON VIDE. L1 peut capturer toute la valeur\");\n",
+    "sb.AppendLine(\"(x=(1,0,0) est stable : R2 et R3 seuls valent 0, donc ne peuvent bloquer).\");\n",
+    "sb.AppendLine(\"C'est l'extreme : le detenteur du facteur rare peut tout extraire.\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6381cb5a",
+   "metadata": {},
+   "source": [
+    "### Interprétation : core du glove game\n",
+    "Le core du glove game est **non vide** et contient les imputations où `x_{L1} ≥ 1` contraint — en fait `x = (1, 0, 0)` est stable : L1 prend tout, et R2/R3 seuls valent 0 donc ne peuvent bloquer. Le Shapley `(2/3, 1/6, 1/6)` **n'est pas** dans le core (la coalition {L1, R2} vaut 1 mais ne reçoit que 2/3 + 1/6 = 5/6 < 1 → bloque). C'est un exemple où **Shapley ∉ core** car le jeu n'est **pas convexe**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68c2403f",
+   "metadata": {},
+   "source": [
+    "## 5. Jeux convexes : Shapley ∈ core\n",
+    "\n",
+    "### Théorème (Shapley 1971)\n",
+    "Si le jeu est **convexe** (marginales croissantes : `v(S ∪ {i}) − v(S)` croît avec `S ⊆ T`), alors :\n",
+    "1. Le **core est non vide**.\n",
+    "2. La **valeur de Shapley est dans le core** (Shapley est une répartition stable).\n",
+    "\n",
+    "C'est le cas « idéal » où équité (Shapley) et stabilité (core) coïncident.\n",
+    "\n",
+    "### Exemple : le jeu d'aéroport\n",
+    "Coût de construction d'une piste dont chaque joueur `i` a besoin d'une longueur `ℓ_i`. Le coût d'une coalition `S` = `max_{i∈S} ℓ_i` (la plus grande longueur requise). Ce jeu de coût est **concave** (dual du convexe) : les économies d'échelle sont décroissantes. La répartition Shapley des coûts est dans le core.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "286d741d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:16.175019Z",
+     "iopub.status.busy": "2026-07-07T00:23:16.174650Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.274350Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.274153Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Airport game (jeu de cout) : longueurs [1000, 3000, 6000]\r\n",
+       "  Cout total (grand coalition) = max = 6000\r\n",
+       "  Repartition Shapley des couts :\r\n",
+       "    Petit (L=1000) paye 333,33\r\n",
+       "    Moyen (L=3000) paye 1333,33\r\n",
+       "    Gros (L=6000) paye 4333,33\r\n",
+       "    Somme = 6000,00 (doit egaler cout total)\r\n",
+       "\r\n",
+       "Lecture : le petit avion paye seulement le troncon 0-1000 (qu'il partage a parts\r\n",
+       "egales au debut), le moyen paye le supplement 1000-3000, le gros le 3000-6000.\r\n",
+       "C'est la tarification Shapley : chacun paye son increment marginal moyen.\r\n",
+       "Le jeu de cout etant concave, cette repartition est dans le core (stable).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Airport game (jeu de cout) : c(S) = max longueur requise par S. Concave => Shapley des couts dans le core.\n",
+    "// On modelise comme un jeu (v = -cout, convexe) ou directement sur les couts.\n",
+    "// Longueurs requises : 3 avions (petit=1000, moyen=3000, gros=6000).\n",
+    "double[] lengths = { 1000.0, 3000.0, 6000.0 };\n",
+    "string[] planeNames = { \"Petit\", \"Moyen\", \"Gros\" };\n",
+    "int nn = 3;\n",
+    "// cout d'une coalition = max longueur\n",
+    "double Cost(List<int> S) => S.Count == 0 ? 0.0 : S.Max(i => lengths[i]);\n",
+    "\n",
+    "// Shapley des couts : contribution marginale de cout.\n",
+    "double[] shapleyCost = new double[nn];\n",
+    "long cnt = 0;\n",
+    "foreach (var perm in Permutations(nn))\n",
+    "{\n",
+    "    var before = new List<int>();\n",
+    "    foreach (int i in perm)\n",
+    "    {\n",
+    "        var withI = new List<int>(before) { i };\n",
+    "        shapleyCost[i] += Cost(withI) - Cost(before);\n",
+    "        before = withI;\n",
+    "    }\n",
+    "    cnt++;\n",
+    "}\n",
+    "for (int i = 0; i < nn; i++) shapleyCost[i] /= cnt;\n",
+    "\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Airport game (jeu de cout) : longueurs [1000, 3000, 6000]\");\n",
+    "sb.AppendLine($\"  Cout total (grand coalition) = max = {Cost(new List<int>{0,1,2})}\");\n",
+    "sb.AppendLine(\"  Repartition Shapley des couts :\");\n",
+    "for (int i = 0; i < nn; i++) sb.AppendLine($\"    {planeNames[i]} (L={lengths[i]:F0}) paye {shapleyCost[i]:F2}\");\n",
+    "sb.AppendLine($\"    Somme = {shapleyCost.Sum():F2} (doit egaler cout total)\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Lecture : le petit avion paye seulement le troncon 0-1000 (qu'il partage a parts\");\n",
+    "sb.AppendLine(\"egales au debut), le moyen paye le supplement 1000-3000, le gros le 3000-6000.\");\n",
+    "sb.AppendLine(\"C'est la tarification Shapley : chacun paye son increment marginal moyen.\");\n",
+    "sb.AppendLine(\"Le jeu de cout etant concave, cette repartition est dans le core (stable).\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22398c1f",
+   "metadata": {},
+   "source": [
+    "### Interprétation : tarification Shapley de l'aéroport\n",
+    "La valeur de Shapley répartit le coût **par tranches d'usage marginal** : le petit avion (1000m) partage la première tranche avec tous, le gros (6000m) paie seul la dernière. C'est la base de la **tarification équitable des coûts communs** (aéroports, réseaux, projets jointifs). Le caractère concave du jeu de coût garantit la stabilité (personne ne paie plus que sa longueur seule → pas de blocage).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e1d071b",
+   "metadata": {},
+   "source": [
+    "## 6. Synthèse\n",
+    "\n",
+    "| Concept | Formule / Test | Rôle |\n",
+    "|---------|----------------|------|\n",
+    "| **Fonction caractéristique** `v(S)` | `2^N → ℝ` | valeur d'une coalition seule |\n",
+    "| **Superadditivité** | `v(S∪T) ≥ v(S)+v(T)` si `S∩T=∅` | fusioner paie |\n",
+    "| **Convexité** | marginales `v(S∪{i})−v(S)` croissantes en `S` | stabilité garantie |\n",
+    "| **Shapley** `φ_i` | moyenne des marginales sur `n!` permutations | répartition équitable (4 axiomes) |\n",
+    "| **Banzhaf** `β_i` | nombre de coalitions swing | pouvoir de vote |\n",
+    "| **Core** | `Σx_i=v(N)` et `Σ_{i∈S}x_i≥v(S)` ∀S | répartitions non bloquables |\n",
+    "| **Convexe ⟹ Shapley ∈ core** | théorème de Shapley 1971 | équité + stabilité conjointes |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "37a4538f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:16.275962Z",
+     "iopub.status.busy": "2026-07-07T00:23:16.275752Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.375114Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.374769Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Synthese : glove game (non convexe) vs airport game (concave)\r\n",
+       "----------------------------------------------------------\r\n",
+       "Jeu             Shapley in core   Convexe   Core          \r\n",
+       "----------------------------------------------------------\r\n",
+       "Glove game      NON               non       non vide      \r\n",
+       "Airport (cout)  OUI (stable)      concave   non vide      \r\n",
+       "----------------------------------------------------------\r\n",
+       "\r\n",
+       "Lecon generale :\r\n",
+       "- jeux CONVEXES : Shapley = repartition equitable ET stable (dans le core).\r\n",
+       "- jeux non convexes : Shapley peut etre bloquee par une coalition ;\r\n",
+       "  le core peut etre vide ou contenir des imputations extremes.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Synthese : glove game (non convexe) vs airport game (concave)\");\n",
+    "sb.AppendLine(new string('-', 58));\n",
+    "sb.AppendLine($\"{\"Jeu\",-16}{\"Shapley in core\",-18}{\"Convexe\",-10}{\"Core\",-14}\");\n",
+    "sb.AppendLine(new string('-', 58));\n",
+    "sb.AppendLine($\"{\"Glove game\",-16}{\"NON\",-18}{\"non\",-10}{\"non vide\",-14}\");\n",
+    "sb.AppendLine($\"{\"Airport (cout)\",-16}{\"OUI (stable)\",-18}{\"concave\",-10}{\"non vide\",-14}\");\n",
+    "sb.AppendLine(new string('-', 58));\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"Lecon generale :\");\n",
+    "sb.AppendLine(\"- jeux CONVEXES : Shapley = repartition equitable ET stable (dans le core).\");\n",
+    "sb.AppendLine(\"- jeux non convexes : Shapley peut etre bloquee par une coalition ;\");\n",
+    "sb.AppendLine(\"  le core peut etre vide ou contenir des imputations extremes.\");\n",
+    "Show(sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b141449d",
+   "metadata": {},
+   "source": [
+    "### Interprétation du tableau comparatif\n",
+    "La convexité (ou concavité d'un jeu de coût) est la condition clé : elle **garantit** que la répartition équitable (Shapley) est aussi **stable** (dans le core). Hors convexité, équité et stabilité divergent — c'est le cœur de la difficulté des jeux coopératifs non convexes (négociation, externalités).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f818f2b",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "> Stubs à compléter (jamais `throw` : le notebook s'exécute end-to-end, règle C.1).\n",
+    "\n",
+    "### Exercice 1 — Jeu de vote pondéré (Conseil de l'UE)\n",
+    "Construire un jeu de vote pondéré représentant le Conseil de l'UE (poids des grands pays) et calculer les indices de Banzhaf. Qui a le plus de pouvoir relatif ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4c5ba678",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:16.376533Z",
+     "iopub.status.busy": "2026-07-07T00:23:16.376348Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.412770Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.412559Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 (Conseil UE) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 — Conseil UE (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : definir les poids des pays (FR, DE, IT, ES = 29 chacun, etc.) et le quota (62%).\n",
+    "// Etape 1 : WeightedVotingGame + Banzhaf. Etape 2 : comparer beta_i normalise au poids.\n",
+    "Console.WriteLine(\"Exercice 1 (Conseil UE) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96c218aa",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Bankruptcy game\n",
+    "Trois créanciers réclament 100, 200, 300 ; l'actif disponible est 350. Modéliser comme jeu coopératif (`v(S) = max(0, actif − somme des réclamations hors S)`) et calculer Shapley. Comparer à la règle proportionnelle.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ee4e4c53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:16.413891Z",
+     "iopub.status.busy": "2026-07-07T00:23:16.413706Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.445667Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.445307Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 (Bankruptcy) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 — Bankruptcy game (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : v(S) = max(0, E - sum_{i notin S} claim_i). Shapley vs proportionnel.\n",
+    "Console.WriteLine(\"Exercice 2 (Bankruptcy) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be4f9a34",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Core vide\n",
+    "Construire un jeu à 3 joueurs dont le core est **vide** (ex: jeu non équilibré) et le vérifier (aucune imputation stable).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fb937938",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:16.446939Z",
+     "iopub.status.busy": "2026-07-07T00:23:16.446759Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.472179Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.471808Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 (Core vide) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 — Core vide (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : definir v tq aucune imputation x (sum=v(N), x(S)>=v(S) forall S) n'existe.\n",
+    "// Indice : jeu a majority avec 3 joueurs, v(S)=1 si |S|>=2, v(N)=1 => core vide.\n",
+    "Console.WriteLine(\"Exercice 3 (Core vide) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae7f3a9e",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 — Nucleolus\n",
+    "Le **nucleolus** est la répartition qui minimise lexicographiquement le vecteur des excès (mécontentement max des coalitions). L'implémenter (avancé) et comparer à Shapley sur le glove game.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cf1d05fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:16.473442Z",
+     "iopub.status.busy": "2026-07-07T00:23:16.473256Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.498807Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.498652Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 4 (Nucleolus) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 4 — Nucleolus (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : trier les excès e_S(x) = v(S) - x(S), minimiser le max lexicographiquement.\n",
+    "Console.WriteLine(\"Exercice 4 (Nucleolus) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04231388",
+   "metadata": {},
+   "source": [
+    "### Exercice 5 — Convexité et core\n",
+    "Montrer (par énumération) que pour un jeu convexe à 3 joueurs, la valeur de Shapley satisfait toutes les inégalités du core.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f61b9f6b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:23:16.500076Z",
+     "iopub.status.busy": "2026-07-07T00:23:16.499903Z",
+     "iopub.status.idle": "2026-07-07T00:23:16.531279Z",
+     "shell.execute_reply": "2026-07-07T00:23:16.530958Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 5 (Convexite) a completer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 5 — Convexite => Shapley in core (a completer).\n",
+    "#nullable enable\n",
+    "// TODO etudiant : construire un jeu convexe (v convex), calculer Shapley, verifier IsInCore.\n",
+    "Console.WriteLine(\"Exercice 5 (Convexite) a completer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47d93349",
+   "metadata": {},
+   "source": [
+    "## 8. Résumé\n",
+    "\n",
+    "### Points clés\n",
+    "- **Jeu coopératif** `(N, v)` : `v(S)` = valeur d'une coalition.\n",
+    "- **Shapley** : répartition équitable (contribution marginale moyenne, 4 axiomes).\n",
+    "- **Banzhaf** : pouvoir de swing (poids ≠ pouvoir).\n",
+    "- **Core** : répartitions non bloquables (efficacité + rationalité coalitionnelle).\n",
+    "- **Convexité** ⟹ core non vide **et** Shapley ∈ core (équité + stabilité).\n",
+    "\n",
+    "### Leçon centrale\n",
+    "La théorie coopérative sépare **équité** (Shapley) et **stabilité** (core). Elles coïncident pour les jeux convexes ; sinon, il faut choisir — ou chercher d'autres solutions (nucleolus, valeur de Nash).\n",
+    "\n",
+    "### Prochaine étape\n",
+    "- [GameTheory-16 (Choix social / Mechanism Design)](GameTheory-16-MechanismDesign-Csharp.ipynb) : agrégation des préférences et conception d'enchères.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Twin C# .NET Interactive** du notebook Python `GameTheory-15-CooperativeGames.ipynb`. Implémentation from-scratch (BCL .NET 9, 0 NuGet) — marathon [#4956](https://github.com/jsboige/CoursIA/issues/4956), registre SOTA [#3801](https://github.com/jsboige/CoursIA/issues/3801).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -162,6 +162,7 @@ flowchart TD
 | 14 | [GameTheory-14-DifferentialGames](GameTheory-14-DifferentialGames.ipynb) | Python | Boucle ouverte/fermée, Stackelberg | 60 min |
 | 14 (C#) | [GameTheory-14-DifferentialGames-Csharp](GameTheory-14-DifferentialGames-Csharp.ipynb) | .NET (C#) | Twin C# du 14 : **RK4 from-scratch** (remplace scipy.solve_ivp), **Riccati couplée backward** pour LQ feedback, Cournot/Stackelberg closed-form, poursuite-evasion (Isaacs) modelisée en RK4 (See #4956) | 60 min |
 | 15 | [GameTheory-15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb) | Python | Shapley, Core, Bondareva-Shapley | 65 min |
+| 15 (C#) | [GameTheory-15-CooperativeGames-Csharp](GameTheory-15-CooperativeGames-Csharp.ipynb) | .NET (C#) | Twin C# du 15 : Shapley (permutations), Banzhaf (swing), core, convexité, airport game from-scratch (See #4956) | 65 min |
 | 15b | [GameTheory-15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) | Lean 4 | Axiomes Shapley formels, Core | 55 min |
 | 15c | [GameTheory-15c-CooperativeGames-Python](GameTheory-15c-CooperativeGames-Python.ipynb) | Python | Exemples avancés (Glove Game, politique) | 40 min |
 | 16 | [GameTheory-16-MechanismDesign](GameTheory-16-MechanismDesign.ipynb) | Python | Principe de révélation, VCG, matching | 65 min |
@@ -561,6 +562,7 @@ GameTheory/
 ├── GameTheory-8-CombinatorialGames-Csharp.ipynb                 # Twin C# P/N + nim-sum (Bouton) + mex + Grundy DP + Sprague-Grundy (marathon #4956)
 ├── GameTheory-7-ExtensiveForm-Csharp.ipynb                      # Twin C# arbre de jeu + infosets from-scratch (marathon #4956, Prong B)
 ├── GameTheory-14-DifferentialGames-Csharp.ipynb                 # Twin C# jeux différentiels : RK4 + Riccati from-scratch, pursuit-evasion (marathon #4956, Prong B)
+├── GameTheory-15-CooperativeGames-Csharp.ipynb                  # Twin C# Shapley + Banzhaf + core + convexité + airport game from-scratch (marathon #4956)
 ├── GameTheory-10-ForwardInduction-SPE-Csharp.ipynb              # Twin C# SPE/backward-induction + trembling-hand + forward induction + burn money (marathon #4956)
 ├── SocialChoice/                                                   # Sous-série Choix Social
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb


### PR DESCRIPTION
## GameTheory-15-CooperativeGames-Csharp — Jumeau C# de GT-15 (Marathon parité #4956)

Jumeau .NET Interactive de [GameTheory-15-CooperativeGames.ipynb](GameTheory-15-CooperativeGames.ipynb) — théorie des jeux coopératifs (paradigme coopératif ≠ non-coopératif).

### Contenu (tout from-scratch, BCL .NET 9, 0 NuGet/numpy/itertools)

| Concept | Implémentation C# |
|--------|-------------------|
| **Fonction caractéristique** `v(S)` | `CooperativeGame` (dictionnaire bitmask coalition→valeur) |
| **Coalitions (powerset)** | `AllCoalitions` (énumération bitmask `0..2^n−1`) |
| **Permutations** | algorithme itératif de Heap |
| **Superadditivité / Convexité** | `IsSuperadditive` (fusion disjointe), `IsConvex` (marginales croissantes) |
| **Valeur de Shapley** | `Shapley` = moyenne des contributions marginales sur `n!` permutations |
| **Indice de Banzhaf** | `Banzhaf` = nombre de coalitions swing (vote pondéré) |
| **Core** | `IsInCore` (efficacité `Σx=v(N)` + rationalité `Σ_{i∈S}x_i≥v(S)`) |
| **Airport game** | tarification Shapley des coûts communs (jeu de coût concave) |

### Validation (EXEC_PROVED)
- **13/13 cellules code** `execution_count` 1-13, **0 error**, **0 warning CS**, **0 path-leak**
- Outputs vérifiés firsthand (Math Verification Standard, recomptés manuellement) :
  - **Glove game** v({L1,R2})=1, v({R2,R3})=0 ✓ ; superadditif, non convexe
  - **Shapley glove** = (2/3, 1/6, 1/6), somme=1=v(N) ✓ (efficacité + symétrie R2/R3)
  - **Banzhaf [50,49,1]** = (3,1,1) normalisé (0.6, 0.2, 0.2) — C1 (1% capital) = 20% pouvoir ✓ (swings recomptés : A50 decisif dans {},{B49},{C1} ; B49 et C1 chacun dans {B49,C1})
  - **Core glove** : Shapley ∉ core (bloqué par {L1,R2} 0.833<1), mais x=(1,0,0) ∈ core ✓ (non-convexe → Shapley∉core)
  - **Airport [1000,3000,6000]** : Shapley coûts=(333.33, 1333.33, 4333.33), somme=6000 ✓ (recompté sur 6 permutations)

### §E README
+1 ligne table `15 (C#)` après GT-15 Python + +1 ligne tree. CATALOG byte-identique préservé.

### Prong B (#3801)
From-scratch complémentaire au twin Python (numpy/itertools) : moteur coopératif typé C# (Shapley/Banzhaf/core via type system + LINQ), value-add authentique, pas un miroir.

### Exercices (5, règle C.1)
Conseil UE / Bankruptcy / Core vide / Nucleolus / Convexité⇒Shapley∈core — stubs `Console.WriteLine("...a completer")` (pas de `throw`).

### G.1 self-corrections (3, avant commit)
1. CS8632 warning sur `string[]?` sans `#nullable enable` dans cell Banzhaf → ajouté (0 warning).
2. Prose md Banzhaf disait "2 coalitions avec A50" (faux) → corrigé "1 coalition pivot {B49,C1}".
3. `sb.AppendLine` code Banzhaf imprimait aussi "2 coalitions" → corrigé (output honnête).

See #4956 (marathon parité .NET ⇄ Python)
See #3801 (registre SOTA axe-2)
