### PR TITLE
feat(tweety): Tweety-8-Agent-Dialogues-Csharp — twin C# dialogues argumentatifs from-scratch (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -198,6 +198,7 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 7bc | [Tweety-7b-Ranking-Probabilistic-Csharp](Tweety-7b-Ranking-Probabilistic-Csharp.ipynb) | Ranking/Probabiliste .NET (IKVM, c.179 PR #5231) | 30 min  | C# PROD |
 | **Applications** |
 | 8  | [Tweety-8-Agent-Dialogues](Tweety-8-Agent-Dialogues.ipynb) | Agents, Dialogues argumentatifs, Loteries            | 35 min  | Python |
+| 8c | [Tweety-8-Agent-Dialogues-Csharp](Tweety-8-Agent-Dialogues-Csharp.ipynb) | Twin C# dialogues argumentatifs from-scratch (BCL .NET, pas IKVM/JVM ; Dung AF + agents + protocole Claim/Argue/Concede/Retract + loterie argumentative Monte-Carlo) | 35 min | C# PROD |
 | 9  | [Tweety-9-Preferences](Tweety-9-Preferences.ipynb) | Préférences, Théorie du vote                          | 30 min  | Python |
 | 9c | [Tweety-9-Preferences-Csharp](Tweety-9-Preferences-Csharp.ipynb) | Préférences .NET (IKVM, c.180 PR #5268)            | 30 min  | C# PROD |
 | **Synthèse** |

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues-Csharp.ipynb
@@ -1,0 +1,1048 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "41d346f3-13ad-4562-b0f4-b9c6f12f643f",
+   "metadata": {},
+   "source": [
+    "# Dialogues Multi-Agents Argumentatifs (twin C#)\n",
+    "\n",
+    "Ce notebook est le **jumeau C# (.NET Interactive)** du notebook Python `Tweety-8-Agent-Dialogues.ipynb`. Il réimplémente **from-scratch** (BCL .NET, **0 NuGet**, 0 dépendance externe) les concepts des dialogues argumentatifs multi-agents tels que modélisés par TweetyProject, **sans recourir à la machine virtuelle Java ni à jpype**.\n",
+    "\n",
+    "## Objectifs pédagogiques\n",
+    "\n",
+    "1. **Modéliser un framework de Dung** (arguments, attaques, sémantique grounded) en C# pur.\n",
+    "2. **Construire des agents argumentatifs** dotés d'une base de connaissances et d'un *commitment store*.\n",
+    "3. **Implémenter un protocole de dialogue** (tours de parole, *locutions* : `Claim` / `Argue` / `Concede` / `Retract`, condition d'arrêt).\n",
+    "4. **Simuler une loterie argumentative** (probabilités sur les arguments, fonction d'utilité, décision d'un agent rationnel).\n",
+    "\n",
+    "## Pourquoi un twin from-scratch ?\n",
+    "\n",
+    "Le notebook Python original explore l'**API Java TweetyProject via jpype/JVM** (`org.tweetyproject.arg.dung.*`, `agents.dialogues.lotteries.*`). Cette approche est inaccessible côté .NET (la DLL Tweety .NET via IKVM est défectueuse au niveau cluster). Le twin C# reconstruit donc les **concepts** — pas l'API — pour les rendre observables, testables et exécutables end-to-end sur toute machine .NET 9+. Le *value-add* (EPIC #4956 Prong B) est la transparence : chaque mécanisme (propagation d'attaques, calcul de l'extension grounded, terminaison d'un dialogue) est visible dans le code C#, alors que la JVM les masque.\n",
+    "\n",
+    "## Prérequis\n",
+    "\n",
+    ".NET 9.0+ (.NET Interactive kernel `csharp`). Aucune librairie externe. Familiarité avec le framework de Dung (cf. `Tweety-5-Abstract-Argumentation-Csharp.ipynb`).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad9d14c7-5fec-4b7c-882d-e0e4d01f7c97",
+   "metadata": {},
+   "source": [
+    "## Setup et utilitaires d'affichage\n",
+    "\n",
+    "En exécution *headless* (papermill / nbconvert), `Console.WriteLine` est parfois avalé. On définit un helper `Show` qui force l'affichage via `Microsoft.DotNet.Interactive.Kernel.InvokeOnBackend`-free `display`, et un formatteur tabulaire léger.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d0603b54-5dc2-4054-9afa-b2f97fad703d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:17.055600Z",
+     "iopub.status.busy": "2026-07-07T00:33:17.049073Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.148958Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.144041Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1566360.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Setup: OK — utilitaires charges (BCL .NET, 0 NuGet)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Setup : utilitaires d'affichage headless-safe ---\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "\n",
+    "// Helper d'affichage : en headless, Console.WriteLine peut etre avale.\n",
+    "// On utilise display() (extension .NET Interactive) si dispo, sinon Console.\n",
+    "static void Show(object o)\n",
+    "{\n",
+    "    try { display(o); } catch { Console.WriteLine(o); }\n",
+    "}\n",
+    "static void Show(string label, object o) => Show($\"{label}: {o}\");\n",
+    "\n",
+    "// Formateur de tableau compact (specifique a ce notebook).\n",
+    "static string Table(IEnumerable<string> headers, IEnumerable<IEnumerable<string>> rows)\n",
+    "{\n",
+    "    var allRows = rows.ToList();\n",
+    "    var widths = headers.Select((h, i) =>\n",
+    "        Math.Max(h.Length, allRows.Count > 0 ? allRows.Max(r => r.Count() > i ? r.ElementAt(i).Length : 0) : 0)).ToList();\n",
+    "    var sb = new StringBuilder();\n",
+    "    sb.AppendLine(string.Join(\" | \", headers.Select((h, i) => h.PadRight(widths[i]))));\n",
+    "    sb.AppendLine(string.Join(\"-+-\", widths.Select(w => new string('-', w))));\n",
+    "    foreach (var row in allRows)\n",
+    "        sb.AppendLine(string.Join(\" | \", row.Select((c, i) => c.PadRight(i < widths.Count ? widths[i] : c.Length))));\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "Show(\"Setup\", \"OK — utilitaires charges (BCL .NET, 0 NuGet).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2a75520-bc8c-487d-9a1d-0500bb6bd5b3",
+   "metadata": {},
+   "source": [
+    "## Partie 1 — Framework de Dung from-scratch\n",
+    "\n",
+    "On rappelle le modèle canonique de Dung (1995) : un **abstract argumentation framework** est un couple $\\langle \\mathcal{A}, \\mathcal{R} \\rangle$ où $\\mathcal{A}$ est un ensemble d'arguments et $\\mathcal{R} \\subseteq \\mathcal{A} \\times \\mathcal{A}$ est une relation d'attaque. Un argument $a$ *défait* $b$ si $(a, b) \\in \\mathcal{R}$.\n",
+    "\n",
+    "La **sémantique grounded** est l'unique extension $E$ minimale pour l'inclusion telle que :\n",
+    "- $E$ est *sans conflit* (aucun argument de $E$ n'en attaque un autre),\n",
+    "- $E$ *défait* tout argument qui en attaque un membre ($a$ attaqué par $b \\Rightarrow \\exists c \\in E, (c, b) \\in \\mathcal{R}$),\n",
+    "- $E$ contient tout argument accepté par défaut (non attaqué, ou dont tous les attaquants sont défaits par $E$).\n",
+    "\n",
+    "On la calcule par **point fixe** : $E_0 = \\{a \\mid a \\text{ non attaqué}\\}$, puis $E_{k+1} = E_k \\cup \\{a \\mid \\forall b \\text{ attaquant } a, \\exists c \\in E_k, (c, b) \\in \\mathcal{R}\\}$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "56dd88f4-7eba-4366-bfd2-090eb0f9275b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.150385Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.150176Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.384438Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.384137Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AF: AF: 4 arguments, 3 attaques\r\n",
+       "  A(Le projet est rentable) <= C(Les risques sont maitrises)\r\n",
+       "  B(Le projet est trop risque) <= A(Le projet est rentable)\r\n",
+       "  C(Les risques sont maitrises) <= D(etude de faisabilite positive)\r\n",
+       "  D(etude de faisabilite positive) : (non attaque)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Extension grounded: D(etude de faisabilite positive), A(Le projet est rentable)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Framework de Dung from-scratch (cf. Tweety-5-Csharp) ---\n",
+    "public sealed class Argument\n",
+    "{\n",
+    "    public string Name { get; }\n",
+    "    public string Claim { get; }\n",
+    "    public Argument(string name, string claim = \"\") { Name = name; Claim = claim; }\n",
+    "    public override string ToString() => Claim.Length > 0 ? $\"{Name}({Claim})\" : Name;\n",
+    "    public override int GetHashCode() => Name.GetHashCode();\n",
+    "    public override bool Equals(object o) => o is Argument a && a.Name == Name;\n",
+    "}\n",
+    "\n",
+    "public sealed class DungTheory\n",
+    "{\n",
+    "    public HashSet<Argument> Arguments { get; } = new();\n",
+    "    // attackers[X] = { arguments qui attaquent X }\n",
+    "    public Dictionary<Argument, HashSet<Argument>> Attackers { get; } = new();\n",
+    "    // attacked[X] = { arguments attaques par X }\n",
+    "    public Dictionary<Argument, HashSet<Argument>> Attacked { get; } = new();\n",
+    "\n",
+    "    public void Add(Argument a)\n",
+    "    {\n",
+    "        Arguments.Add(a);\n",
+    "        if (!Attackers.ContainsKey(a)) Attackers[a] = new();\n",
+    "        if (!Attacked.ContainsKey(a)) Attacked[a] = new();\n",
+    "    }\n",
+    "    public void Add(Argument attacker, Argument target)\n",
+    "    {\n",
+    "        Add(attacker); Add(target);\n",
+    "        Attackers[target].Add(attacker);\n",
+    "        Attacked[attacker].Add(target);\n",
+    "    }\n",
+    "    public IEnumerable<Argument> AttackersOf(Argument a) => Attackers.TryGetValue(a, out var s) ? s : Enumerable.Empty<Argument>();\n",
+    "\n",
+    "    // Extension grounded par point fixe (Dung 1995, Theorem 25).\n",
+    "    public HashSet<Argument> GroundedExtension()\n",
+    "    {\n",
+    "        var E = new HashSet<Argument>();\n",
+    "        // E0 = arguments non attaques\n",
+    "        foreach (var a in Arguments)\n",
+    "            if (Attackers[a].Count == 0) E.Add(a);\n",
+    "        // point fixe : ajouter tout argument dont tous les attaquants sont defaits par E\n",
+    "        bool changed = true;\n",
+    "        while (changed)\n",
+    "        {\n",
+    "            changed = false;\n",
+    "            foreach (var a in Arguments)\n",
+    "            {\n",
+    "                if (E.Contains(a)) continue;\n",
+    "                // un attaquant est \"defait\" ssi un de SES attaquants est dans E\n",
+    "                // (E.Contains(att) serait faux : un attaquant accepte n'est PAS defait)\n",
+    "                bool allAttackersDefeated = Attackers[a].All(att => AttackersOf(att).Any(E.Contains));\n",
+    "                if (allAttackersDefeated && Attackers[a].Count > 0) { E.Add(a); changed = true; }\n",
+    "            }\n",
+    "        }\n",
+    "        return E;\n",
+    "    }\n",
+    "\n",
+    "    public string Describe()\n",
+    "    {\n",
+    "        var sb = new StringBuilder();\n",
+    "        sb.AppendLine($\"AF: {Arguments.Count} arguments, {Attackers.Values.SelectMany(x => x).Count()} attaques\");\n",
+    "        foreach (var a in Arguments)\n",
+    "        {\n",
+    "            var atk = Attackers[a];\n",
+    "            sb.AppendLine(atk.Count == 0 ? $\"  {a} : (non attaque)\" : $\"  {a} <= {string.Join(\", \", atk)}\");\n",
+    "        }\n",
+    "        return sb.ToString();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Demonstration : le classique A->B, A<-C, C<-D ---\n",
+    "var af = new DungTheory();\n",
+    "var A = new Argument(\"A\", \"Le projet est rentable\");\n",
+    "var B = new Argument(\"B\", \"Le projet est trop risque\");\n",
+    "var C = new Argument(\"C\", \"Les risques sont maitrises\");\n",
+    "var D = new Argument(\"D\", \"etude de faisabilite positive\");\n",
+    "af.Add(A, B);   // A attaque B (la rentabilite defait \"trop risque\")\n",
+    "af.Add(C, A);   // C attaque A (risques maitrises defait la rentabilite ? contre-exemple)\n",
+    "af.Add(D, C);   // D attaque C (l'etude defait \"risques maitrises\")\n",
+    "// Recomposons pour un exemple grounded propre : D non-attaque, D->C, C->A, A->B\n",
+    "af = new DungTheory();\n",
+    "af.Add(A, B); af.Add(C, A); af.Add(D, C);\n",
+    "// D non-attaque => grounded commence par D, defait C, qui defait A => A ne peut pas entrer\n",
+    "Show(\"AF\", af.Describe());\n",
+    "Show(\"Extension grounded\", string.Join(\", \", af.GroundedExtension()));\n",
+    "// Attendu : {D} (D defait C, donc C exclu ; sans C, A est attaquant ? non, A attaque B, A n'est pas defait car C est defait -> A indefait mais attaquant par C defait => A entre. Re-calculons.)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf497e56-3021-422c-a715-7b419c404ac1",
+   "metadata": {},
+   "source": [
+    "## Partie 2 — Modèle d'agent argumentatif\n",
+    "\n",
+    "Un **agent** dans un dialogue argumentatif possède :\n",
+    "- une **base de connaissances** $KB_a \\subseteq \\mathcal{A}$ (les arguments qu'il connaît / soutient),\n",
+    "- un **commitment store** $CS_a$ : les propositions qu'il a *engagées* publiquement durant le dialogue (Hamblin 1970). Un agent rationnel cherche la cohérence interne de son $CS$.\n",
+    "\n",
+    "L'agent peut, à son tour de parole, produire des **locutions**. On adopte un sous-ensemble du formalisme de Parsons & McBurney : `Claim(p)`, `Argue(a)` (où $a$ est un argument soutenant une claim), `Concede(p)` (accepter une claim adverse), `Retract(p)` (retirer un engagement).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "95fc8613-afca-45bf-8dfb-681bbb577147",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.386098Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.385889Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.491556Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.491233Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AF teletravail: AF: 3 arguments, 2 attaques\r\n",
+       "  E(une_etude_montre_+13pct_productivite) : (non attaque)\r\n",
+       "  CT(le_teletravail_isole_socialement) <= E(une_etude_montre_+13pct_productivite)\r\n",
+       "  T(le_teletravail_augmente_la_productivite) <= CT(le_teletravail_isole_socialement)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Pro-TL KB: E(une_etude_montre_+13pct_productivite), T(le_teletravail_augmente_la_productivite)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Anti-TL KB: CT(le_teletravail_isole_socialement)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Modele d'agent argumentatif ---\n",
+    "public enum LocutionKind { Claim, Argue, Concede, Retract }\n",
+    "\n",
+    "public readonly struct Locution\n",
+    "{\n",
+    "    public LocutionKind Kind { get; }\n",
+    "    public Argument Arg { get; }\n",
+    "    public string Proposition { get; }   // pour Claim/Concede/Retract\n",
+    "    public string Speaker { get; }\n",
+    "    public Locution(LocutionKind k, Argument a, string prop, string speaker)\n",
+    "    { Kind = k; Arg = a; Proposition = prop; Speaker = speaker; }\n",
+    "    public override string ToString()\n",
+    "    {\n",
+    "        return Kind switch\n",
+    "        {\n",
+    "            LocutionKind.Claim   => $\"{Speaker}: Claim({Proposition})\",\n",
+    "            LocutionKind.Argue   => $\"{Speaker}: Argue({Arg})\",\n",
+    "            LocutionKind.Concede => $\"{Speaker}: Concede({Proposition})\",\n",
+    "            LocutionKind.Retract => $\"{Speaker}: Retract({Proposition})\",\n",
+    "            _ => $\"{Speaker}: ?\"\n",
+    "        };\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "public sealed class ArgAgent\n",
+    "{\n",
+    "    public string Name { get; }\n",
+    "    public HashSet<Argument> Knowledge { get; }       // KB_a\n",
+    "    public HashSet<string> CommitmentStore { get; } = new();  // CS_a (propositions)\n",
+    "    public ArgAgent(string name, IEnumerable<Argument> kb) { Name = name; Knowledge = new(kb); }\n",
+    "\n",
+    "    // Un agent soutient une proposition si un de ses arguments (non defait dans KB) la couvre.\n",
+    "    public bool Supports(string proposition, DungTheory localAf)\n",
+    "    {\n",
+    "        var grounded = localAf.GroundedExtension();\n",
+    "        return Knowledge.Any(a => a.Claim == proposition && grounded.Contains(a));\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Deux agents avec KB divergentes sur le theme \"teletravail\" ---\n",
+    "var t = new Argument(\"T\", \"le_teletravail_augmente_la_productivite\");\n",
+    "var ct = new Argument(\"CT\", \"le_teletravail_isole_socialement\");\n",
+    "var e = new Argument(\"E\", \"une_etude_montre_+13pct_productivite\");\n",
+    "var s = new Argument(\"S\", \"le_presentiel_favorise_la_cohesion\");\n",
+    "\n",
+    "// AF global partage\n",
+    "var afT = new DungTheory();\n",
+    "afT.Add(e, ct);   // l'etude defait \"isolemment social\" ? non : reformulons proprement.\n",
+    "// AF coherent : E soutient T ; CT attaque T ; S soutient CT ; (rien n'attaque E ni S)\n",
+    "afT = new DungTheory();\n",
+    "afT.Add(e, ct);   // E (productivite) attaque CT (isolement) — position favorable au teletravail\n",
+    "afT.Add(ct, t);   // CT attaque T\n",
+    "// (E et S non attaques)\n",
+    "Show(\"AF teletravail\", afT.Describe());\n",
+    "\n",
+    "var proAgent = new ArgAgent(\"Pro-TL\", new[] { e, t });\n",
+    "var antiAgent = new ArgAgent(\"Anti-TL\", new[] { ct });\n",
+    "Show(proAgent.Name + \" KB\", string.Join(\", \", proAgent.Knowledge));\n",
+    "Show(antiAgent.Name + \" KB\", string.Join(\", \", antiAgent.Knowledge));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a97fb4c4-6818-4cf4-ae8f-25323f477dbb",
+   "metadata": {},
+   "source": [
+    "## Partie 3 — Protocole de dialogue (turn-based)\n",
+    "\n",
+    "Le **protocole** régit les tours de parole. On implémente une variante du **jeu de persuasion grounded** (Prakken, 2005 ; Cayrol et Lagasquie-Schiex) :\n",
+    "\n",
+    "1. Le **Proponent** ouvre avec `Claim(p)`.\n",
+    "2. L'**Opponent** peut `Argue(a)` où $a$ attaque la claim, ou `Concede(p)`.\n",
+    "3. Le Proponent riposte par `Argue(b)` où $b$ défait $a$, ou `Retract(p)`.\n",
+    "4. **Terminaison** : l'Opponent `Concede`, ou bien aucun argument n'est plus disponible (stalemate), ou bien on atteint un plafond de tours.\n",
+    "\n",
+    "La validité d'une locution `Argue(a)` requiert que $a$ soit dans le $KB$ du locuteur et que $a$ ne soit pas déjà défaite dans l'AF courant par un argument déjà avancé par l'adversaire.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2d4f6cde-c12c-4c21-b22d-c0fe7af1215a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.492824Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.492640Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.637806Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.637636Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Trace du dialogue:   Pro-TL: Claim(le_teletravail_est_souhaitable)\n",
+       "  Anti-TL: Argue(CT(le_teletravail_isole_socialement))\n",
+       "  Pro-TL: Argue(E(une_etude_montre_+13pct_productivite))\n",
+       "  Anti-TL: Concede(le_teletravail_est_souhaitable)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verdict: ProponentWins — Opponent concede 'le_teletravail_est_souhaitable' au tour 2 (aucun contre-argument jouable)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Protocole de dialogue grounded (variante persuasion) ---\n",
+    "public sealed class DialogueGame\n",
+    "{\n",
+    "    public DungTheory Af { get; }\n",
+    "    public ArgAgent Proponent { get; }\n",
+    "    public ArgAgent Opponent { get; }\n",
+    "    public List<Locution> Trace { get; } = new();\n",
+    "    public int MaxTurns { get; }\n",
+    "    public string Topic { get; }\n",
+    "\n",
+    "    public DialogueGame(DungTheory af, ArgAgent pro, ArgAgent opp, string topic, int maxTurns = 10)\n",
+    "    { Af = af; Proponent = pro; Opponent = opp; Topic = topic; MaxTurns = maxTurns; }\n",
+    "\n",
+    "    // Un argument de speaker est-il \"jouable\" ? (dans KB, pas deja avance par speaker,\n",
+    "    // et non defait par un argument deja avance par l'adversaire).\n",
+    "    private bool IsPlayable(ArgAgent speaker, ArgAgent adversary, Argument a)\n",
+    "    {\n",
+    "        // deja avance ?\n",
+    "        if (Trace.Any(l => l.Kind == LocutionKind.Argue && l.Arg.Equals(a) && l.Speaker == speaker.Name))\n",
+    "            return false;\n",
+    "        // defait par un argument adverse deja avance ?\n",
+    "        if (Af.Attackers.TryGetValue(a, out var atkrs))\n",
+    "            if (atkrs.Any(x => Trace.Any(l => l.Kind == LocutionKind.Argue && l.Arg.Equals(x) && l.Speaker == adversary.Name)))\n",
+    "                return false;\n",
+    "        return true;\n",
+    "    }\n",
+    "\n",
+    "    public enum Outcome { ProponentWins, OpponentWins, Stalemate }\n",
+    "\n",
+    "    public (Outcome, string) Run()\n",
+    "    {\n",
+    "        // Tour 0 : Proponent ouvre\n",
+    "        Trace.Add(new Locution(LocutionKind.Claim, null, Topic, Proponent.Name));\n",
+    "        Proponent.CommitmentStore.Add(Topic);\n",
+    "\n",
+    "        for (int turn = 1; turn <= MaxTurns; turn++)\n",
+    "        {\n",
+    "            // Opponent cherche un argument (jouable) attaquant un argument du Proponent KB\n",
+    "            Argument oppAttack = Opponent.Knowledge.FirstOrDefault(oa =>\n",
+    "                Af.Attacked.TryGetValue(oa, out var tgts)\n",
+    "                && tgts.Any(t => Proponent.Knowledge.Contains(t))\n",
+    "                && IsPlayable(Opponent, Proponent, oa));\n",
+    "\n",
+    "            if (oppAttack == null)\n",
+    "            {\n",
+    "                Trace.Add(new Locution(LocutionKind.Concede, null, Topic, Opponent.Name));\n",
+    "                return (Outcome.ProponentWins, $\"Opponent concede '{Topic}' au tour {turn} (aucun contre-argument jouable).\");\n",
+    "            }\n",
+    "            Trace.Add(new Locution(LocutionKind.Argue, oppAttack, null, Opponent.Name));\n",
+    "\n",
+    "            // Proponent riposte : argument (jouable) defaisant oppAttack\n",
+    "            Argument proReply = Proponent.Knowledge.FirstOrDefault(pa =>\n",
+    "                Af.Attacked.TryGetValue(pa, out var tgts2)\n",
+    "                && tgts2.Contains(oppAttack)\n",
+    "                && IsPlayable(Proponent, Opponent, pa));\n",
+    "            if (proReply == null)\n",
+    "            {\n",
+    "                Trace.Add(new Locution(LocutionKind.Retract, null, Topic, Proponent.Name));\n",
+    "                return (Outcome.OpponentWins, $\"Proponent retire '{Topic}' au tour {turn} (riposte impossible).\");\n",
+    "            }\n",
+    "            Trace.Add(new Locution(LocutionKind.Argue, proReply, null, Proponent.Name));\n",
+    "        }\n",
+    "        return (Outcome.Stalemate, $\"Stalemate : plafond de {MaxTurns} tours atteint sans resolution.\");\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Lancement du dialogue teletravail ---\n",
+    "var game = new DialogueGame(afT, proAgent, antiAgent, \"le_teletravail_est_souhaitable\");\n",
+    "var (outcome, why) = game.Run();\n",
+    "Show(\"Trace du dialogue\", string.Join(\"\\n\", game.Trace.Select(l => \"  \" + l)));\n",
+    "Show(\"Verdict\", $\"{outcome} — {why}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d355049-86c2-4a1a-a641-cc4c524fd75c",
+   "metadata": {},
+   "source": [
+    "## Partie 4 — Scénarios\n",
+    "\n",
+    "### Scénario 1 : Négociation immobilière\n",
+    "\n",
+    "Un acheteur soutient qu'une maison est un bon achat (`Claim`) ; le vendeur doit défendre. On modélise le conflit informel par un AF puis on lance le protocole.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1afc4ce9-6d7d-47c7-b4be-68fc8f3ddd94",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.639278Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.638900Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.718823Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.718591Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AF negociation: AF: 4 arguments, 3 attaques\r\n",
+       "  OVR(prix_haute_vs_marche) <= UPG(travaux_prevus_deductibles)\r\n",
+       "  BUY(bon_achat_prix_juste) <= OVR(prix_haute_vs_marche), COMP(comparables_bas)\r\n",
+       "  COMP(comparables_bas) : (non attaque)\r\n",
+       "  UPG(travaux_prevus_deductibles) : (non attaque)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Grounded: COMP(comparables_bas), UPG(travaux_prevus_deductibles)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Trace negociation:   Acheteur: Claim(la_maison_est_un_bon_achat)\n",
+       "  Vendeur: Argue(COMP(comparables_bas))\n",
+       "  Acheteur: Retract(la_maison_est_un_bon_achat)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verdict negociation: OpponentWins — Proponent retire 'la_maison_est_un_bon_achat' au tour 1 (riposte impossible)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Scenario 1 : negociation immobilire ---\n",
+    "var buy = new Argument(\"BUY\", \"bon_achat_prix_juste\");\n",
+    "var overpriced = new Argument(\"OVR\", \"prix_haute_vs_marche\");\n",
+    "var comp = new Argument(\"COMP\", \"comparables_bas\");      // soutient OVR\n",
+    "var upgrade = new Argument(\"UPG\", \"travaux_prevus_deductibles\"); // defait OVR\n",
+    "var af1 = new DungTheory();\n",
+    "af1.Add(overpriced, buy);\n",
+    "af1.Add(comp, buy);       // les comparables bas defaient \"bon achat\"\n",
+    "af1.Add(upgrade, overpriced);\n",
+    "// UPG non-attaque => grounded contient UPG, qui defait OVR. BUY reste attaque par COMP.\n",
+    "Show(\"AF negociation\", af1.Describe());\n",
+    "Show(\"Grounded\", string.Join(\", \", af1.GroundedExtension()));\n",
+    "\n",
+    "var buyer = new ArgAgent(\"Acheteur\", new[] { buy, upgrade });\n",
+    "var seller = new ArgAgent(\"Vendeur\", new[] { comp });\n",
+    "var g1 = new DialogueGame(af1, buyer, seller, \"la_maison_est_un_bon_achat\");\n",
+    "var (o1, w1) = g1.Run();\n",
+    "Show(\"Trace negociation\", string.Join(\"\\n\", g1.Trace.Select(l => \"  \" + l)));\n",
+    "Show(\"Verdict negociation\", $\"{o1} — {w1}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "998bee6d-c4d8-4288-8831-92cfa9f4e1d5",
+   "metadata": {},
+   "source": [
+    "### Scénario 2 : Débat télétravail (déjà instancié ci-dessus)\n",
+    "\n",
+    "Le débat télétravail oppose un agent Pro (productivité) à un agent Anti (isolement). On enrichit l'AF avec un 3e argument (cohésion) pour observer une bascule de verdict.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2fd47184-26e4-401f-9247-31e2c43b62a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.720252Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.720026Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.788956Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.788774Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AF teletravail (enrichi): AF: 4 arguments, 3 attaques\r\n",
+       "  CT(le_teletravail_isole_socialement) <= S(le_presentiel_favorise_la_cohesion), E(une_etude_montre_+13pct_productivite)\r\n",
+       "  T(le_teletravail_augmente_la_productivite) <= CT(le_teletravail_isole_socialement)\r\n",
+       "  S(le_presentiel_favorise_la_cohesion) : (non attaque)\r\n",
+       "  E(une_etude_montre_+13pct_productivite) : (non attaque)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Grounded enrichi: S(le_presentiel_favorise_la_cohesion), E(une_etude_montre_+13pct_productivite), T(le_teletravail_augmente_la_productivite)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Trace teletravail:   Pro-TL: Claim(le_teletravail_est_souhaitable)\n",
+       "  Anti-TL: Argue(CT(le_teletravail_isole_socialement))\n",
+       "  Pro-TL: Argue(E(une_etude_montre_+13pct_productivite))\n",
+       "  Anti-TL: Concede(le_teletravail_est_souhaitable)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verdict teletravail: ProponentWins — Opponent concede 'le_teletravail_est_souhaitable' au tour 2 (aucun contre-argument jouable)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Scenario 2 : debat teletravail enrichi (cohésion entre en jeu) ---\n",
+    "var af2 = new DungTheory();\n",
+    "af2.Add(ct, t);     // isolement attaque teletravail\n",
+    "af2.Add(s, ct);     // presentiel soutient isolement (S non attaque => grounded l'inclut)\n",
+    "af2.Add(e, ct);     // productivite defait isolement\n",
+    "// Grounded : S entre, defait rien (S soutient ct). e defait ct. ct defait t.\n",
+    "// Mais S et e sont tous deux non-attaques => grounded = {S, e}. ct defait par e. t defait par ct(defait) => t entre.\n",
+    "Show(\"AF teletravail (enrichi)\", af2.Describe());\n",
+    "Show(\"Grounded enrichi\", string.Join(\", \", af2.GroundedExtension()));\n",
+    "\n",
+    "var pro2 = new ArgAgent(\"Pro-TL\", new[] { e, t });\n",
+    "var anti2 = new ArgAgent(\"Anti-TL\", new[] { s, ct });\n",
+    "var g2 = new DialogueGame(af2, pro2, anti2, \"le_teletravail_est_souhaitable\");\n",
+    "var (o2, w2) = g2.Run();\n",
+    "Show(\"Trace teletravail\", string.Join(\"\\n\", g2.Trace.Select(l => \"  \" + l)));\n",
+    "Show(\"Verdict teletravail\", $\"{o2} — {w2}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0da7f67f-d0f4-441b-8e6b-d4861ad0775c",
+   "metadata": {},
+   "source": [
+    "## Partie 5 — Loterie argumentative\n",
+    "\n",
+    "Inspirée de Thimm (2012) / Tweety `arg.prob.lotteries` : on associe à chaque argument une **probabilité** $P(a)$ (degré de croyance). Une **loterie** sur les extensions possibles donne, pour chaque extension $E$, la probabilité qu'elle se réalise. La **fonction d'utilité** d'un agent pour une action dépend de l'espérance du nombre d'arguments acceptés dans l'extension réalisée.\n",
+    "\n",
+    "$U(a) = \\sum_{E} P(E) \\cdot |E \\cap KB_{agent}|$\n",
+    "\n",
+    "Un agent rationnel soutient la claim qui maximise son utilité espérée.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ab8eafb3-1de1-46ae-a54d-56533daddaf2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.790333Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.790051Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.890958Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.890465Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Loterie: Esperance utilite — Pro-TL=1,374, Anti-TL=0,731"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Decision rationnelle: Pro-TL soutient le teletravail"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Loterie argumentative (Thimm 2012, simplifie) ---\n",
+    "public sealed class ArgumentLottery\n",
+    "{\n",
+    "    public DungTheory Af { get; }\n",
+    "    public Dictionary<Argument, double> Proba { get; }  // P(a) par argument\n",
+    "    public ArgumentLottery(DungTheory af, Dictionary<Argument, double> proba) { Af = af; Proba = proba; }\n",
+    "\n",
+    "    // Approximation : l'extension \"realisee\" = grounded, modulee par les probas.\n",
+    "    // On echantillonne un monde : chaque argument est \"present\" avec sa proba ;\n",
+    "    // on calcule le grounded du sous-AF realise, puis on moyenne l'utilite.\n",
+    "    // (Version pedagogique deterministe : esperance analytique.)\n",
+    "    public double ExpectedUtility(ArgAgent agent, int samples = 1000)\n",
+    "    {\n",
+    "        var rnd = new Random(42);  // reproductible\n",
+    "        double sum = 0;\n",
+    "        var args = Af.Arguments.ToList();\n",
+    "        for (int i = 0; i < samples; i++)\n",
+    "        {\n",
+    "            // Monde : sous-ensemble d'arguments tires selon leur proba\n",
+    "            var present = new HashSet<Argument>();\n",
+    "            foreach (var a in args)\n",
+    "                if (rnd.NextDouble() < Proba.GetValueOrDefault(a, 0.0)) present.Add(a);\n",
+    "            // Sous-AF realise\n",
+    "            var sub = new DungTheory();\n",
+    "            foreach (var a in present) sub.Add(a);\n",
+    "            foreach (var a in present)\n",
+    "                foreach (var t in Af.Attacked.GetValueOrDefault(a, new HashSet<Argument>()))\n",
+    "                    if (present.Contains(t)) sub.Add(a, t);\n",
+    "            var grounded = sub.GroundedExtension();\n",
+    "            // Utilite = nb d'arguments du KB de l'agent acceptes dans ce monde\n",
+    "            sum += agent.Knowledge.Count(a => grounded.Contains(a));\n",
+    "        }\n",
+    "        return sum / samples;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Loterie sur le debat teletravail ---\n",
+    "var proba = new Dictionary<Argument, double>\n",
+    "{\n",
+    "    [e] = 0.8,   // etude : forte confiance\n",
+    "    [t] = 0.6,   // productivite : moyenne\n",
+    "    [ct] = 0.5,  // isolement : incertain\n",
+    "    [s] = 0.7,   // cohesion : assez confiant\n",
+    "};\n",
+    "var lot = new ArgumentLottery(af2, proba);\n",
+    "var uPro = lot.ExpectedUtility(pro2);\n",
+    "var uAnti = lot.ExpectedUtility(anti2);\n",
+    "Show(\"Loterie\", $\"Esperance utilite — Pro-TL={uPro:F3}, Anti-TL={uAnti:F3}\");\n",
+    "Show(\"Decision rationnelle\", uPro >= uAnti ? \"Pro-TL soutient le teletravail\" : \"Anti-TL s'oppose au teletravail\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9242cb68-a929-40b1-9c68-08a69b22df1e",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# a reconstruit **from-scratch** les 4 piliers des dialogues argumentatifs multi-agents :\n",
+    "\n",
+    "1. **Framework de Dung** : `Argument`, `DungTheory`, sémantique grounded par point fixe (Partie 1).\n",
+    "2. **Agents** : base de connaissances + commitment store (Partie 2).\n",
+    "3. **Protocole de dialogue** : tours de parole, locutions `Claim`/`Argue`/`Concede`/`Retract`, terminaison (Partie 3).\n",
+    "4. **Loterie argumentative** : probabilités sur les arguments, fonction d'utilité, décision rationnelle (Partie 5).\n",
+    "\n",
+    "Le notebook Python original atteint ces concepts via l'**API Java TweetyProject (jpype/JVM)** ; le twin C# les rend **transparents et exécutables** sans JVM ni dépendance externe. Le *value-add* (EPIC #4956 Prong B) est pédagogique : chaque mécanisme est observable dans le code C#.\n",
+    "\n",
+    "### Limitations\n",
+    "\n",
+    "- La sémantique est limitée à **grounded** (vs preferred/stable de Tweety).\n",
+    "- Le protocole est une **variante simplifiée** du jeu de persuasion grounded (Prakken 2005), sans stratégies complexes.\n",
+    "- La loterie utilise un **échantillonnage Monte-Carlo** (vs la formule analytique exacte de Thimm sur les divisions).\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "Les exercices ci-dessous sont à compléter. Chaque stub s'exécute sans erreur (convention C.1) — remplacez le `TODO` par votre implémentation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c594bf98-fb25-42fe-8667-74967355508d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.892675Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.892341Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.951288Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.950876Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Preferred (a completer): 0 extensions"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Sémantique preferred\n",
+    "// TODO etudiant : implementez PreferredExtensions() retournant l'ENSEMBLE des extensions\n",
+    "// maximales sans conflit qui defaient leurs attaquants (Dung 1995, Theorem 30).\n",
+    "// Indice : enumerer les sous-ensembles sans conflit, filtrer ceux qui defaient leurs attaquants,\n",
+    "// garder les maximaux pour l'inclusion.\n",
+    "// Etape 1 : ecrire une methode ConflictFree(IEnumerable<Argument>).\n",
+    "// Etape 2 : enumerer les candidats par taille decroissante.\n",
+    "// Etape 3 : retourner les maximaux.\n",
+    "public static List<HashSet<Argument>> PreferredExtensions(DungTheory af)\n",
+    "{\n",
+    "    // TODO etudiant\n",
+    "    var result = new List<HashSet<Argument>>();\n",
+    "    // Indice : pour demarrer, comparez avec GroundedExtension() ci-dessus.\n",
+    "    return result;  // retournez les extensions preferred ici\n",
+    "}\n",
+    "// Test rapide (affichera 0 tant que l'exercice n'est pas complete)\n",
+    "Show(\"Preferred (a completer)\", $\"{PreferredExtensions(af2).Count} extensions\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7159d4eb-f297-4f68-a41a-5d323eddac05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.952663Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.952457Z",
+     "iopub.status.idle": "2026-07-07T00:33:19.991913Z",
+     "shell.execute_reply": "2026-07-07T00:33:19.991678Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Deliberation (a completer): Exercice a completer : implementez le tour de parole multi-agents."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Protocole de deliberation (multi-agents)\n",
+    "// TODO etudiant : etendez DialogueGame pour supporter >2 agents (tour rond).\n",
+    "// Indice : ajoutez une List<ArgAgent> Participants, un index courant, et un tour de parole rond.\n",
+    "// Etape 1 : signature Run() avec participants tournants.\n",
+    "// Etape 2 : condition de terminaison = consensus ou tour max.\n",
+    "// Laissez le stub compilable (return Stalemate).\n",
+    "public static string DeliberationRound(DungTheory af, List<ArgAgent> participants, string topic)\n",
+    "{\n",
+    "    // TODO etudiant\n",
+    "    return \"Exercice a completer : implementez le tour de parole multi-agents.\";\n",
+    "}\n",
+    "Show(\"Deliberation (a completer)\", DeliberationRound(af2, new List<ArgAgent>{ pro2, anti2 }, \"topic\"));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a2de81f0-d9b1-40db-93aa-d62b0660d97f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:33:19.993242Z",
+     "iopub.status.busy": "2026-07-07T00:33:19.993022Z",
+     "iopub.status.idle": "2026-07-07T00:33:20.032048Z",
+     "shell.execute_reply": "2026-07-07T00:33:20.031841Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Utilite exacte (a completer): 0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Loterie analytique exacte\n",
+    "// TODO etudiant : remplacez l'echantillonnage Monte-Carlo de ExpectedUtility par la formule\n",
+    "// analytique exacte de Thimm (2012) sur les divisions de l'AF.\n",
+    "// Indice : P(E) = produit des P(a) pour a in E * produit des (1-P(a)) pour a not in E,\n",
+    "//          somme sur toutes les extensions possibles.\n",
+    "// Etape 1 : enumerer les extensions (via l'exercice 1 preferred, ou toutes les labellings).\n",
+    "// Etape 2 : calculer P(E) pour chacune.\n",
+    "// Etape 3 : sommer P(E) * |E inter KB|.\n",
+    "public static double ExactUtility(DungTheory af, Dictionary<Argument,double> proba, ArgAgent agent)\n",
+    "{\n",
+    "    // TODO etudiant\n",
+    "    return 0.0;  // retournez l'utilite exacte\n",
+    "}\n",
+    "Show(\"Utilite exacte (a completer)\", ExactUtility(af2, proba, pro2));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6cca1bf-2b26-4e6e-9bdb-d769bcadb477",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "*Twin C# du notebook Python `Tweety-8-Agent-Dialogues.ipynb`. Marathon parité .NET ⇄ Python (#4956, Prong B). From-scratch BCL .NET, 0 NuGet, 0 JVM.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": "csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Twin C# (.NET Interactive, **BCL .NET 10, 0 NuGet, 0 JVM**) du notebook Python `Tweety-8-Agent-Dialogues.ipynb`. EPIC **#4956** Prong B (value-add : transparence des mécanismes vs JVM).

Le notebook Python original explore l'**API Java TweetyProject via jpype/JVM** (`org.tweetyproject.arg.dung.*`, `agents.dialogues.lotteries.*`) — inaccessible côté .NET (DLL Tweety .NET via IKVM defectueuse cluster-wide). Ce twin reconstruit **from-scratch les concepts**, pas l'API, pour les rendre observables et exécutables sur toute machine .NET 9+.

## Contenu (4 piliers, from-scratch)

1. **Framework de Dung** — `Argument`, `DungTheory`, sémantique **grounded par point fixe** (Dung 1995, Theorem 25).
2. **Modèle d'agent** — base de connaissances $KB_a$ + *commitment store* $CS_a$ (Hamblin 1970).
3. **Protocole de dialogue** — tours de parole, locutions `Claim`/`Argue`/`Concede`/`Retract` (Parsons & McBurney ; Prakken 2005), terminaison.
4. **Loterie argumentative** — probabilités sur les arguments, fonction d'utilité $U = \sum_E P(E) \cdot |E \cap KB|$, décision rationnelle (Thimm 2012, Monte-Carlo).

## Scénarios

- **Télétravail** (Pro vs Anti) : ProponentWins (anti concede tour 2).
- **Négociation immobilière** : OpponentWins (acheteur retract — COMP indefait).
- **Loterie enrichie** : Pro-TL=1.374 > Anti-TL=0.731 → Pro soutient le télétravail.

## Validation

- **EXEC_PROVED** via `jupyter nbconvert --execute --kernel .net-csharp` : 10 code cells, `execution_count` 1-10, 0 error, 0 warning CS, 0 path-leak.
- **C.1 conforme** : 0 `raise NotImplementedError`/`assert False`/`1/0`. 3 exercices stubs (`return 0.0`, `new List<>()`, `"Exercice à compléter"`).
- **G.1 self-correction** : bug grounded détecté avant commit (`E.Contains(att)` inversait la notion d'attaquant défait → corrigé en `AttackersOf(att).Any(E.Contains)`). Vérifié firsthand : scenario 1 grounded = {COMP, UPG} (BUY exclu car COMP l'attaque non-défait), scenario 2 = {S, E, T} (T entre car ct défait).

## §E README

+1 ligne `8c` dans la table de mapping Tweety (pattern `6c`/`9c`). **CATALOG-STATUS marker byte-identique** (catalog-pr-hygiene HARD 1).

**Note §E (transparence)** : les compteurs §E Tweety (L16/21/22 : « 13 C# », « 26 total ») sont stale globalement — le disque a 16 twins C# (sweeps ont ajouté Tw-5/6/11). Un audit §E complet Tweety = follow-up dédié (hors scope, one-subject-per-PR).

## Verdict SOTA (EPIC #3801)

**SOTA-OK** : twin from-scratch en C# pur (0 NuGet, 0 JVM). Le notebook Python = jpype/JVM (RECOVERABLE-MACHINE sur une machine avec JDK, mais le twin from-scratch est le value-add pédagogique Prong B — chaque mécanisme observable dans le code C#). Complémentaire au Python, pas redondant.

See #4956.