### PR TITLE
feat(semanticweb): SW-8-CSharp-SHACL — twin C# dotNetRDF SHACL validation

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -246,13 +246,14 @@ OWL (Web Ontology Language) étend RDFS avec des constructeurs logiques puissant
 
 ---
 
-### Partie 3 : Standards Modernes (Python uniquement)
+### Partie 3 : Standards Modernes (Python, avec jumeau C# SW-8)
 
-Cette partie couvre les standards modernes du Web Sémantique, exclusivement en Python (écosystème dominant pour l'IA).
+Cette partie couvre les standards modernes du Web Sémantique. L'écosystème Python (rdflib, pySHACL, owlready2) y domine, complété par un jumeau C# / dotNetRDF pour SHACL (parité .NET ⇄ Python, marathon #4956).
 
 | # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
 | 8 | **SW-8-Python-SHACL** | 45 min | Validation de données avec pySHACL |
+| 8 (C#) | **SW-8-CSharp-SHACL** | 45 min | Jumeau .NET de SW-8 : validation SHACL avec dotNetRDF (`VDS.RDF.Shacl`) |
 | 9 | **SW-9-Python-JSONLD** | 40 min | Données structurées pour le web |
 | 10 | **SW-10-Python-RDFStar** | 40 min | RDF 1.2, annotations et provenance |
 
@@ -489,6 +490,7 @@ SemanticWeb/
 ├── SW-6-CSharp-RDFS.ipynb
 ├── SW-7-CSharp-OWL.ipynb
 ├── SW-7b-Python-OWL.ipynb           # Sidetrack
+├── SW-8-CSharp-SHACL.ipynb           # Jumeau .NET de SW-8 (dotNetRDF.SHACL, marathon #4956)
 ├── SW-8-Python-SHACL.ipynb
 ├── SW-9-Python-JSONLD.ipynb
 ├── SW-10-Python-RDFStar.ipynb

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb
@@ -1,0 +1,2540 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-001",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004168,
+     "end_time": "2026-07-07T00:50:46.107234",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:46.103066",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# SW-8-CSharp-SHACL\n",
+    "\n",
+    "**Navigation** : [<< 7-OWL](SW-7-CSharp-OWL.ipynb) | [Index](README.md) | [SW-8-Python >>](SW-8-Python-SHACL.ipynb)\n",
+    "\n",
+    "## SHACL avec dotNetRDF : Valider la qualite de donnees RDF en C#\n",
+    "\n",
+    "Ce notebook est le **jumeau C# / .NET** du notebook [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb). La ou le notebook Python utilise **pySHACL** (le moteur SHACL de reference en Python), ce notebook utilise **dotNetRDF** (le moteur RDF/SHACL de reference en .NET). Les deux implementent la meme recommandation W3C SHACL (2017) : ce sont de veritables compagnons cross-langage sur un standard commun.\n",
+    "\n",
+    "> **Verdict SOTA (EPIC #3801)** : **SOTA-OK**. Ce notebook invoque le **vrai moteur SHACL de dotNetRDF** (espace de noms `VDS.RDF.Shacl`, package `dotNetRdf.Shacl` 3.4.1). Aucun workaround, aucune reimplementation jouet de la validation SHACL -- le moteur reel tourne et produit le rapport de validation standard.\n",
+    "\n",
+    "### Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. Definir des **shapes** SHACL (NodeShape, PropertyShape) pour contraindre un graphe RDF\n",
+    "2. Valider des donnees avec le moteur SHACL de dotNetRDF (`ShapesGraph.Validate`) et interpreter le rapport\n",
+    "3. Construire des shapes personnalisees (en Turtle ou par l'API C#)\n",
+    "4. Utiliser les severites (Violation / Warning / Info) et les operateurs logiques (`sh:or`, `sh:not`)\n",
+    "\n",
+    "### Concepts cles\n",
+    "\n",
+    "| Concept | Description |\n",
+    "|---------|-------------|\n",
+    "| SHACL | Shapes Constraint Language -- standard W3C 2017 pour valider des donnees RDF (monde ferme) |\n",
+    "| NodeShape | Forme qui cible des noeuds RDF (par classe ou par URI) |\n",
+    "| PropertyShape | Contrainte sur une propriete (cardinalite, type, motif, etc.) |\n",
+    "| ShapesGraph | Classe dotNetRDF (`VDS.RDF.Shacl.ShapesGraph`) qui encapsule les formes et lance la validation |\n",
+    "| Validation Report | Graphe RDF normalise decrivant chaque violation (`sh:ValidationResult`) |\n",
+    "\n",
+    "### Prerequis\n",
+    "- Notebook [SW-7-CSharp-OWL](SW-7-CSharp-OWL.ipynb) complete (ontologies, monde ouvert)\n",
+    "- Familiarite avec dotNetRDF (cf [SW-2-CSharp-RDFBasics](SW-2-CSharp-RDFBasics.ipynb))\n",
+    "\n",
+    "### Duree estimee : 45 minutes\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-002",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": "2026-07-07T00:50:46.107234",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:46.107234",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 0. Chargement de dotNetRDF\n",
+    "\n",
+    "dotNetRDF est la bibliotheque de reference pour manipuler RDF, SPARQL, RDFS, OWL et SHACL en .NET. Depuis la version 3.0, le support SHACL est inclus dans le meta-package `dotNetRDF` via le sous-package `dotNetRdf.Shacl` (namespace `VDS.RDF.Shacl`).\n",
+    "\n",
+    "| Espace de noms | Rôle dans ce notebook |\n",
+    "|----------------|------------------------|\n",
+    "| `VDS.RDF` | Graphes, noeuds, triplets (`Graph`, `IUriNode`, `ILiteralNode`) |\n",
+    "| `VDS.RDF.Parsing` | Lecture Turtle (`TurtleParser`) |\n",
+    "| `VDS.RDF.Shacl` | Moteur SHACL (`ShapesGraph`, `Validation.Report`, `Validation.Result`) |\n",
+    "| `VDS.RDF.Writing` | Serialisation des rapports (`CompressingTurtleWriter`) |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "sw8c-003",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:46.119450Z",
+     "iopub.status.busy": "2026-07-07T00:50:46.119450Z",
+     "iopub.status.idle": "2026-07-07T00:50:47.363260Z",
+     "shell.execute_reply": "2026-07-07T00:50:47.363260Z"
+    },
+    "papermill": {
+     "duration": 1.24697,
+     "end_time": "2026-07-07T00:50:47.363260",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:46.116290",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:c111:2207:fe12:2b8b:2048/\",\"http://2a01:e0a:9d4:f320:e9d1:aca6:71b4:2cf1:2048/\",\"http://fe80::902b:f9f6:2003:66a1%18:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%19:2048/\",\"http://172.24.224.1:2048/\",\"http://fe80::b5e6:392e:9c4:c699%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '35684.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>dotNetRDF, 3.4.1</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dotNetRDF 3.4.1 charge avec succes.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Espaces de noms SHACL disponibles : VDS.RDF.Shacl, VDS.RDF.Shacl.ShapesGraph\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   (Validation via new ShapesGraph(g).Validate(data))\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Chargement du meta-package dotNetRDF (inclut dotNetRdf.Shacl depuis la v3.0)\n",
+    "#r \"nuget: dotNetRDF, 3.4.1\"\n",
+    "\n",
+    "using VDS.RDF;\n",
+    "using VDS.RDF.Parsing;\n",
+    "using VDS.RDF.Shacl;\n",
+    "using VDS.RDF.Writing;\n",
+    "using System.IO;\n",
+    "using StringWriter = System.IO.StringWriter;\n",
+    "\n",
+    "Console.WriteLine(\"dotNetRDF 3.4.1 charge avec succes.\");\n",
+    "Console.WriteLine(\"Espaces de noms SHACL disponibles : VDS.RDF.Shacl, VDS.RDF.Shacl.ShapesGraph\");\n",
+    "Console.WriteLine(\"   (Validation via new ShapesGraph(g).Validate(data))\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-004",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017682,
+     "end_time": "2026-07-07T00:50:47.380942",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.363260",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Activation du moteur SHACL\n",
+    "\n",
+    "La cellule ci-dessus :\n",
+    "1. **`#r \"nuget: dotNetRDF, 3.4.1\"`** restore le meta-package (et son sous-package `dotNetRdf.Shacl`).\n",
+    "2. Les `using` exposent les espaces de noms `VDS.RDF.Shacl` (le moteur) et `VDS.RDF.Parsing` (le lecteur Turtle).\n",
+    "3. L'alias `using StringWriter = System.IO.StringWriter` evite un conflit de noms avec `VDS.RDF.Writing.StringWriter`.\n",
+    "\n",
+    "> **Note technique** : l'API SHACL de dotNetRDF est centree sur la classe `VDS.RDF.Shacl.ShapesGraph` qui encapsule le graphe des formes et expose deux methodes : `Conforms(data)` (booleen) et `Validate(data)` (rapport detaille). C'est l'equivalent C# de la fonction `pyshacl.validate(...)` du notebook Python.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-005",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": "2026-07-07T00:50:47.384317",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.384317",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Introduction a SHACL\n",
+    "\n",
+    "### Le probleme : l'hypothese du monde ouvert\n",
+    "\n",
+    "En RDF et OWL, on travaille sous l'**hypothese du monde ouvert** (*Open World Assumption*, OWA) : l'absence d'information ne signifie pas que cette information est fausse. Si un graphe RDF ne mentionne pas l'age d'une personne, OWL considere simplement que l'age est *inconnu*, pas qu'il est absent.\n",
+    "\n",
+    "C'est un probleme pour la **qualite des donnees**. Dans une application reelle, on veut pouvoir dire :\n",
+    "- \"Chaque personne **doit** avoir un nom\"\n",
+    "- \"L'age **doit** etre un entier positif\"\n",
+    "- \"Un email **doit** respecter un format precis\"\n",
+    "\n",
+    "OWL ne peut pas exprimer ces contraintes de validation. C'est la raison d'etre de **SHACL** (*Shapes Constraint Language*).\n",
+    "\n",
+    "### SHACL : Shapes Constraint Language\n",
+    "\n",
+    "SHACL est une **recommandation W3C** publiee en juillet 2017 (Knublauch & Topidis, \"SHACL Shapes Constraint Language\", W3C Rec. 2017). Elle definit un vocabulaire RDF pour decrire des contraintes (\"shapes\") que les donnees RDF doivent respecter.\n",
+    "\n",
+    "| Aspect | OWL (monde ouvert) | SHACL (monde ferme) |\n",
+    "|--------|-------------------|---------------------|\n",
+    "| **Hypothese** | Monde ouvert (OWA) | Monde ferme (CWA) |\n",
+    "| **Objectif** | Inference, raisonnement | Validation, qualite |\n",
+    "| **Absence de donnee** | Inconnue | Violation potentielle |\n",
+    "| **`minCount 1`** | Implique l'existence | Exige la presence |\n",
+    "| **Analogie** | Definition d'un concept | Formulaire de saisie |\n",
+    "| **Standard W3C** | OWL 2 (2012) | SHACL 1.0 (2017) |\n",
+    "\n",
+    "> **Point cle** : OWL decrit *ce qui est vrai* dans un domaine. SHACL decrit *ce que les donnees doivent respecter*. Les deux sont complementaires : OWL pour modeliser, SHACL pour valider.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-006",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010554,
+     "end_time": "2026-07-07T00:50:47.394871",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.384317",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. Concepts fondamentaux de SHACL\n",
+    "\n",
+    "SHACL repose sur deux types de formes (*shapes*) :\n",
+    "\n",
+    "| Concept | URI SHACL | Description |\n",
+    "|---------|-----------|-------------|\n",
+    "| **NodeShape** | `sh:NodeShape` | Forme qui s'applique a un noeud RDF (une ressource) |\n",
+    "| **PropertyShape** | `sh:PropertyShape` | Forme qui contraint une propriete specifique |\n",
+    "| **targetClass** | `sh:targetClass` | Cible tous les noeuds d'une classe donnee |\n",
+    "| **targetNode** | `sh:targetNode` | Cible un noeud specifique par son URI |\n",
+    "| **property** | `sh:property` | Lie une NodeShape a ses PropertyShapes |\n",
+    "| **path** | `sh:path` | Designe la propriete RDF a contraindre |\n",
+    "\n",
+    "### Architecture d'une shape SHACL (en Turtle)\n",
+    "\n",
+    "```turtle\n",
+    "ex:PersonShape a sh:NodeShape ;       # Forme pour les personnes\n",
+    "    sh:targetClass foaf:Person ;       # Cible : toutes les foaf:Person\n",
+    "    sh:property [                      # Contrainte sur une propriete\n",
+    "        sh:path foaf:name ;            # Propriete ciblee\n",
+    "        sh:minCount 1 ;                # Au moins une valeur\n",
+    "        sh:datatype xsd:string ;       # Type attendu\n",
+    "    ] .\n",
+    "```\n",
+    "\n",
+    "### Principaux types de contraintes\n",
+    "\n",
+    "| Categorie | Contrainte | Propriete SHACL | Exemple |\n",
+    "|-----------|------------|-----------------|---------|\n",
+    "| **Cardinalite** | Minimum / Maximum | `sh:minCount`, `sh:maxCount` | `sh:minCount 1` |\n",
+    "| **Type** | Type de donnee | `sh:datatype` | `sh:datatype xsd:string` |\n",
+    "| **Classe** | Classe RDF | `sh:class` | `sh:class foaf:Person` |\n",
+    "| **Noeud** | Type de noeud | `sh:nodeKind` | `sh:nodeKind sh:IRI` |\n",
+    "| **Chaine** | Longueur minimale | `sh:minLength` | `sh:minLength 2` |\n",
+    "| **Chaine** | Motif regex | `sh:pattern` | `sh:pattern \"^[A-Z]\"` |\n",
+    "| **Numerique** | Borne inclusive | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |\n",
+    "| **Valeur** | Liste autorisee | `sh:in` | `sh:in (\"FR\" \"DE\")` |\n",
+    "| **Logique** | OU / ET / NON | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | liste de sous-formes |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-007",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005291,
+     "end_time": "2026-07-07T00:50:47.400162",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.394871",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Explorer une shape SHACL existante\n",
+    "\n",
+    "Le fichier `data/person-shape.ttl` contient une forme SHACL pour valider des instances de `foaf:Person`. Chargeons-le avec le `TurtleParser` de dotNetRDF et affichons son contenu.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "sw8c-008",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:47.411576Z",
+     "iopub.status.busy": "2026-07-07T00:50:47.411576Z",
+     "iopub.status.idle": "2026-07-07T00:50:47.574981Z",
+     "shell.execute_reply": "2026-07-07T00:50:47.574981Z"
+    },
+    "papermill": {
+     "duration": 0.174819,
+     "end_time": "2026-07-07T00:50:47.574981",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.400162",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe des formes charge : 25 triplets\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Contenu de person-shape.ttl ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\r\n",
+      "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.\r\n",
+      "@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.\r\n",
+      "@prefix sh: <http://www.w3.org/ns/shacl#>.\r\n",
+      "@prefix ex: <http://example.org/>.\r\n",
+      "@prefix foaf: <http://xmlns.com/foaf/0.1/>.\r\n",
+      "@prefix schema: <http://schema.org/>.\r\n",
+      "\r\n",
+      "ex:PersonShape a sh:NodeShape;\r\n",
+      "               sh:property [sh:path foaf:name ; \r\n",
+      "                            sh:minCount 1  ; \r\n",
+      "                            sh:maxCount 1  ; \r\n",
+      "                            sh:datatype xsd:string ; \r\n",
+      "                            sh:minLength 2  ; \r\n",
+      "                            sh:message \"Une personne doit avoir exactement un nom (string, min 2 caracteres)\"@fr],\r\n",
+      "                           [sh:path foaf:mbox ; \r\n",
+      "                            sh:maxCount 1  ; \r\n",
+      "                            sh:pattern \"^mailto:.+@.+\\\\..+$\" ; \r\n",
+      "                            sh:message \"L'email doit etre au format mailto:user@domain.tld\"@fr],\r\n",
+      "                           [sh:path foaf:age ; \r\n",
+      "                            sh:maxCount 1  ; \r\n",
+      "                            sh:datatype xsd:integer ; \r\n",
+      "                            sh:minInclusive 0  ; \r\n",
+      "                            sh:maxInclusive 150  ; \r\n",
+      "                            sh:message \"L'age doit etre un entier entre 0 et 150\"@fr],\r\n",
+      "                           [sh:path foaf:knows ; \r\n",
+      "                            sh:class foaf:Person ; \r\n",
+      "                            sh:message \"La propriete knows doit pointer vers une autre Person\"@fr];\r\n",
+      "               sh:targetClass foaf:Person.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Chargement du graphe des formes SHACL depuis le fichier Turtle\n",
+    "IGraph shapesGraph = new Graph();\n",
+    "new TurtleParser().Load(shapesGraph, \"data/person-shape.ttl\");\n",
+    "\n",
+    "Console.WriteLine($\"Graphe des formes charge : {shapesGraph.Triples.Count} triplets\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "// Serialisation Turtle pour afficher le contenu lisible\n",
+    "var sw = new StringWriter();\n",
+    "new CompressingTurtleWriter().Save(shapesGraph, sw);\n",
+    "Console.WriteLine(\"=== Contenu de person-shape.ttl ===\");\n",
+    "Console.WriteLine(sw.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-009",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002894,
+     "end_time": "2026-07-07T00:50:47.582777",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.579883",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Analyse structurelle par programmation\n",
+    "\n",
+    "Plutot que de lire le fichier Turtle a l'oeil, parcourons le graphe SHACL avec dotNetRDF pour identifier automatiquement les NodeShapes, leurs cibles et les contraintes de chaque propriete. On utilise `GetTriplesWithSubjectPredicate` pour retrouver les cibles (`sh:targetClass`) et les sous-formes (`sh:property`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "sw8c-010",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:47.591228Z",
+     "iopub.status.busy": "2026-07-07T00:50:47.591228Z",
+     "iopub.status.idle": "2026-07-07T00:50:47.787355Z",
+     "shell.execute_reply": "2026-07-07T00:50:47.787355Z"
+    },
+    "papermill": {
+     "duration": 0.200816,
+     "end_time": "2026-07-07T00:50:47.787355",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.586539",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NodeShape : http://example.org/PersonShape\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cible (targetClass) : http://xmlns.com/foaf/0.1/Person\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Contraintes de propriete :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - name\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        minCount = 1^^http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        maxCount = 1^^http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        datatype = http://www.w3.org/2001/XMLSchema#string\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        minLength = 2^^http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        message = Une personne doit avoir exactement un nom (string, min 2 caracteres)@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - mbox\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        maxCount = 1^^http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        pattern = ^mailto:.+@.+\\..+$^^http://www.w3.org/2001/XMLSchema#string\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        message = L'email doit etre au format mailto:user@domain.tld@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - age\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        maxCount = 1^^http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        datatype = http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        minInclusive = 0^^http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        maxInclusive = 150^^http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        message = L'age doit etre un entier entre 0 et 150@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - knows\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        class = http://xmlns.com/foaf/0.1/Person\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        message = La propriete knows doit pointer vers une autre Person@fr\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Parcours structurel du graphe SHACL\n",
+    "IUriNode rdfType = shapesGraph.CreateUriNode(UriFactory.Create(\"http://www.w3.org/1999/02/22-rdf-syntax-ns#type\"));\n",
+    "IUriNode shNodeShape = shapesGraph.CreateUriNode(UriFactory.Create(\"http://www.w3.org/ns/shacl#NodeShape\"));\n",
+    "IUriNode shTargetClass = shapesGraph.CreateUriNode(UriFactory.Create(\"http://www.w3.org/ns/shacl#targetClass\"));\n",
+    "IUriNode shProperty = shapesGraph.CreateUriNode(UriFactory.Create(\"http://www.w3.org/ns/shacl#property\"));\n",
+    "IUriNode shPath = shapesGraph.CreateUriNode(UriFactory.Create(\"http://www.w3.org/ns/shacl#path\"));\n",
+    "IUriNode shMessage = shapesGraph.CreateUriNode(UriFactory.Create(\"http://www.w3.org/ns/shacl#message\"));\n",
+    "\n",
+    "foreach (Triple shapeT in shapesGraph.GetTriplesWithPredicateObject(rdfType, shNodeShape).ToList())\n",
+    "{\n",
+    "    INode shapeNode = shapeT.Subject;\n",
+    "    Console.WriteLine($\"NodeShape : {shapeNode}\");\n",
+    "\n",
+    "    // Cible (targetClass)\n",
+    "    foreach (Triple tgt in shapesGraph.GetTriplesWithSubjectPredicate(shapeNode, shTargetClass))\n",
+    "        Console.WriteLine($\"  Cible (targetClass) : {tgt.Object}\");\n",
+    "\n",
+    "    Console.WriteLine($\"  Contraintes de propriete :\");\n",
+    "    foreach (Triple propT in shapesGraph.GetTriplesWithSubjectPredicate(shapeNode, shProperty))\n",
+    "    {\n",
+    "        INode propShape = propT.Object;\n",
+    "        // Recuperer le path\n",
+    "        var pathTriples = shapesGraph.GetTriplesWithSubjectPredicate(propShape, shPath).ToList();\n",
+    "        string pathStr = pathTriples.Count > 0 ? pathTriples[0].Object.ToString() : \"?\";\n",
+    "        string pathLocal = pathStr.Contains(\"/\") ? pathStr.Split('/').Last() : pathStr;\n",
+    "        Console.WriteLine($\"    - {pathLocal}\");\n",
+    "\n",
+    "        // Lister toutes les contraintes (predicats sh:*)\n",
+    "        foreach (Triple c in shapesGraph.GetTriplesWithSubject(propShape))\n",
+    "        {\n",
+    "            string pred = c.Predicate.ToString();\n",
+    "            if (!pred.StartsWith(\"http://www.w3.org/ns/shacl#\")) continue;\n",
+    "            string local = pred.Split('#').Last();\n",
+    "            if (local == \"path\") continue;\n",
+    "            Console.WriteLine($\"        {local} = {c.Object}\");\n",
+    "        }\n",
+    "    }\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-011",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": "2026-07-07T00:50:47.787355",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.787355",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Structure de la forme PersonShape\n",
+    "\n",
+    "La forme `ex:PersonShape` cible toutes les instances de `foaf:Person` et impose 4 contraintes :\n",
+    "\n",
+    "| Propriete | Contraintes | Signification |\n",
+    "|-----------|-------------|---------------|\n",
+    "| `foaf:name` | minCount=1, maxCount=1, datatype=string, minLength=2 | Exactement un nom, chaine d'au moins 2 caracteres |\n",
+    "| `foaf:mbox` | maxCount=1, pattern=`^mailto:.+@.+\\\\..+$` | Au plus un email, format mailto: valide |\n",
+    "| `foaf:age` | maxCount=1, datatype=integer, minInclusive=0, maxInclusive=150 | Au plus un age, entier entre 0 et 150 |\n",
+    "| `foaf:knows` | class=foaf:Person | Les personnes connues doivent etre des foaf:Person |\n",
+    "\n",
+    "> **Note** : `foaf:mbox` et `foaf:age` n'ont pas de `minCount`, ils sont donc optionnels. Seul `foaf:name` est obligatoire (minCount=1).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-012",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005226,
+     "end_time": "2026-07-07T00:50:47.803824",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.798598",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Validation SHACL avec dotNetRDF\n",
+    "\n",
+    "### L'API `ShapesGraph`\n",
+    "\n",
+    "dotNetRDF expose la validation SHACL via la classe `VDS.RDF.Shacl.ShapesGraph` :\n",
+    "\n",
+    "| Membre | Signature | Description |\n",
+    "|--------|-----------|-------------|\n",
+    "| **Constructeur** | `new ShapesGraph(IGraph shapes)` | Encapsule un graphe de formes SHACL |\n",
+    "| **`Conforms`** | `bool Conforms(IGraph data)` | True si les donnees sont conformes (sans detail) |\n",
+    "| **`Validate`** | `Validation.Report Validate(IGraph data)` | Rapport detaille des resultats |\n",
+    "\n",
+    "Le rapport retourne par `Validate` expose :\n",
+    "- `report.Conforms` (booleen, False si au moins une violation `sh:Violation`)\n",
+    "- `report.Results` (collection de `Validation.Result`)\n",
+    "- Chaque `Result` a : `Severity`, `FocusNode`, `ResultPath`, `Message`, `SourceConstraintComponent`, `ResultValue`\n",
+    "\n",
+    "### Charger les donnees de test\n",
+    "\n",
+    "Le fichier `data/person-data.ttl` contient 7 personnes dont **5 presentent des erreurs volontaires**.\n",
+    "\n",
+    "> **Pie cross-langage (G.1, verified firsthand)** : le `TurtleParser` de dotNetRDF est **plus strict** que `rdflib`. Le fichier contient `<not-an-email>` comme URI relative (pour le test du pattern email) ; dotNetRDF refuse de parser une URI relative sans base. On fixe en assignant `graph.BaseUri` avant le chargement -- rdflib (Python) l'accepte silencieusement. C'est une difference de robustesse entre les deux parseurs, documentee ici pour la parite.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "sw8c-013",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:47.803824Z",
+     "iopub.status.busy": "2026-07-07T00:50:47.803824Z",
+     "iopub.status.idle": "2026-07-07T00:50:47.978737Z",
+     "shell.execute_reply": "2026-07-07T00:50:47.978737Z"
+    },
+    "papermill": {
+     "duration": 0.174913,
+     "end_time": "2026-07-07T00:50:47.978737",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.803824",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe de donnees charge : 25 triplets\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Personne     Nom                Age    Email                        Knows     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alice        Alice Dupont       30     mailto:alice@example.com     bob       \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bob          Bob Martin         25     -                            alice     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "charlie      [ABSENT]           40     -                            -         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "diana        Diana Leroy        -5     -                            -         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "eve          Eve Bernard        -      not-an-email                 -         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "frank        F                  55     -                            -         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grace        Grace Moreau       -      -                            myDog     \r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Chargement du graphe de donnees (avec base URI pour resoudre les URI relatives)\n",
+    "IGraph dataGraph = new Graph { BaseUri = UriFactory.Create(\"http://example.org/\") };\n",
+    "new TurtleParser().Load(dataGraph, new StreamReader(\"data/person-data.ttl\"));\n",
+    "\n",
+    "Console.WriteLine($\"Graphe de donnees charge : {dataGraph.Triples.Count} triplets\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "// Lister les personnes avec leurs proprietes\n",
+    "IUriNode rdfType2 = dataGraph.CreateUriNode(UriFactory.Create(\"http://www.w3.org/1999/02/22-rdf-syntax-ns#type\"));\n",
+    "IUriNode foafPerson = dataGraph.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/Person\"));\n",
+    "IUriNode foafName = dataGraph.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/name\"));\n",
+    "IUriNode foafAge = dataGraph.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/age\"));\n",
+    "IUriNode foafMbox = dataGraph.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/mbox\"));\n",
+    "IUriNode foafKnows = dataGraph.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/knows\"));\n",
+    "\n",
+    "Console.WriteLine($\"{\"Personne\",-12} {\"Nom\",-18} {\"Age\",-6} {\"Email\",-28} {\"Knows\",-10}\");\n",
+    "Console.WriteLine(new string('-', 76));\n",
+    "\n",
+    "// Personnes = sujets de (s rdf:type foaf:Person)\n",
+    "var persons = dataGraph.GetTriplesWithPredicateObject(rdfType2, foafPerson).Select(t => t.Subject).OrderBy(n => n.ToString()).ToList();\n",
+    "foreach (INode person in persons)\n",
+    "{\n",
+    "    string name = GetOne(dataGraph, person, foafName) ?? \"[ABSENT]\";\n",
+    "    string age = GetOne(dataGraph, person, foafAge) ?? \"-\";\n",
+    "    string mbox = GetOne(dataGraph, person, foafMbox) ?? \"-\";\n",
+    "    if (mbox.StartsWith(\"http\")) mbox = mbox.Split('/').Last();\n",
+    "    string knows = GetOne(dataGraph, person, foafKnows) ?? \"-\";\n",
+    "    if (knows.StartsWith(\"http\")) knows = knows.Split('/').Last();\n",
+    "    Console.WriteLine($\"{person.ToString().Split('/').Last(),-12} {name,-18} {age,-6} {mbox,-28} {knows,-10}\");\n",
+    "}\n",
+    "\n",
+    "// helper local : retourne la valeur \"propre\" d'un objet (le .Value d'un literal, sans le suffixe de datatype)\n",
+    "string GetOne(IGraph g, INode s, IUriNode p)\n",
+    "{\n",
+    "    var ts = g.GetTriplesWithSubjectPredicate(s, p).ToList();\n",
+    "    if (ts.Count == 0) return null;\n",
+    "    INode obj = ts[0].Object;\n",
+    "    return obj is ILiteralNode lit ? lit.Value : obj.ToString();\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-014",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0159,
+     "end_time": "2026-07-07T00:50:47.994637",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.978737",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Execution de la validation\n",
+    "\n",
+    "Lançons la validation en instanciant `ShapesGraph` sur le graphe des formes, puis en appelant `Validate` sur le graphe de donnees.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "sw8c-015",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.003380Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.003380Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.201900Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.201900Z"
+    },
+    "papermill": {
+     "duration": 0.207263,
+     "end_time": "2026-07-07T00:50:48.201900",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:47.994637",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Les donnees sont conformes : False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de resultats (violations + warnings + infos) : 5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Rapport detaille ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [MinCountConstraintComponent] focus=charlie, path=name, value=-\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Message : Une personne doit avoir exactement un nom (string, min 2 caracteres)@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [MinInclusiveConstraintComponent] focus=diana, path=age, value=-5^^http://www.w3.org/2001/XMLSchema#integer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Message : L'age doit etre un entier entre 0 et 150@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [PatternConstraintComponent] focus=eve, path=mbox, value=http://example.org/not-an-email\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Message : L'email doit etre au format mailto:user@domain.tld@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [MinLengthConstraintComponent] focus=frank, path=name, value=F^^http://www.w3.org/2001/XMLSchema#string\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Message : Une personne doit avoir exactement un nom (string, min 2 caracteres)@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ClassConstraintComponent] focus=grace, path=knows, value=http://example.org/myDog\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Message : La propriete knows doit pointer vers une autre Person@fr\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Validation SHACL via le moteur dotNetRDF\n",
+    "var shapes = new ShapesGraph(shapesGraph);\n",
+    "var report = shapes.Validate(dataGraph);\n",
+    "\n",
+    "Console.WriteLine($\"Les donnees sont conformes : {report.Conforms}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Nombre de resultats (violations + warnings + infos) : {report.Results.Count()}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"=== Rapport detaille ===\");\n",
+    "foreach (var r in report.Results)\n",
+    "{\n",
+    "    string focus = r.FocusNode.ToString().Split('/').Last();\n",
+    "    string path = r.ResultPath == null ? \"-\" : r.ResultPath.ToString().Split('/').Last();\n",
+    "    string component = r.SourceConstraintComponent.ToString().Split('#').Last();\n",
+    "    string value = r.ResultValue == null ? \"-\" : r.ResultValue.ToString();\n",
+    "    Console.WriteLine($\"  [{component}] focus={focus}, path={path}, value={value}\");\n",
+    "    Console.WriteLine($\"      Message : {r.Message}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "sw8c-016",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.215595Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.215595Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.263258Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.263258Z"
+    },
+    "papermill": {
+     "duration": 0.047663,
+     "end_time": "2026-07-07T00:50:48.263258",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.215595",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre total de violations : 5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Noeud        Propriete  Composant                    Severite    \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "charlie      name       MinCount                     Violation   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "diana        age        MinInclusive                 Violation   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "eve          mbox       Pattern                      Violation   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "frank        name       MinLength                    Violation   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grace        knows      Class                        Violation   \r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Analyse structuree : presentation tabulaire des violations\n",
+    "Console.WriteLine($\"Nombre total de violations : {report.Results.Count()}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"{\"Noeud\",-12} {\"Propriete\",-10} {\"Composant\",-28} {\"Severite\",-12}\");\n",
+    "Console.WriteLine(new string('-', 80));\n",
+    "\n",
+    "foreach (var r in report.Results.OrderBy(x => x.FocusNode.ToString()))\n",
+    "{\n",
+    "    string focus = r.FocusNode.ToString().Split('/').Last();\n",
+    "    string path = r.ResultPath == null ? \"-\" : r.ResultPath.ToString().Split('/').Last();\n",
+    "    string component = r.SourceConstraintComponent.ToString().Split('#').Last().Replace(\"ConstraintComponent\", \"\");\n",
+    "    string severity = r.Severity.ToString().Split('#').Last();\n",
+    "    Console.WriteLine($\"{focus,-12} {path,-10} {component,-28} {severity,-12}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-017",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": "2026-07-07T00:50:48.279269",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.279269",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Les 5 erreurs detectees\n",
+    "\n",
+    "Le fichier `person-data.ttl` contenait 5 erreurs volontaires, toutes detectees par le moteur SHACL de dotNetRDF. **Ces 5 violations correspondent exactement** aux 5 erreurs rapportedees par pySHACL dans le notebook Python ([SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb), section 4) -- les deux moteurs s'accordent sur le meme diagnostic.\n",
+    "\n",
+    "| Personne | Propriete | Composant de contrainte | Explication |\n",
+    "|----------|-----------|-------------------------|-------------|\n",
+    "| **alice** | - | (aucune) | Conforme : toutes les proprietes respectent les contraintes |\n",
+    "| **bob** | - | (aucune) | Conforme (email optionnel, pas de minCount sur mbox) |\n",
+    "| **charlie** | `foaf:name` | MinCount | Pas de nom alors que `minCount=1` est exige |\n",
+    "| **diana** | `foaf:age` | MinInclusive | Age negatif (-5) alors que `minInclusive=0` |\n",
+    "| **eve** | `foaf:mbox` | Pattern | Email `not-an-email` ne correspond pas au motif `^mailto:` |\n",
+    "| **frank** | `foaf:name` | MinLength | Nom \"F\" (1 caractere) trop court, `minLength=2` |\n",
+    "| **grace** | `foaf:knows` | Class | `ex:myDog` est un `ex:Dog`, pas un `foaf:Person` |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Alice et Bob passent la validation car leurs donnees sont completes et conformes.\n",
+    "2. Bob n'a pas d'email mais c'est conforme : `foaf:mbox` n'a pas de `minCount`.\n",
+    "3. Chaque violation est independante : un meme noeud pourrait cumuler plusieurs violations.\n",
+    "4. Les noms de composants (`MinCountConstraintComponent`, `MinInclusiveConstraintComponent`, etc.) sont les identifiants standardises du vocabulaire SHACL du W3C -- les memes que pySHACL.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-018",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015934,
+     "end_time": "2026-07-07T00:50:48.295203",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.279269",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Ecrire des shapes custom\n",
+    "\n",
+    "Plutot que de charger des fichiers Turtle existants, on peut construire des formes SHACL **directement en C#**, soit en parsant une chaine Turtle (l'approche la plus lisible, SHACL etant defini en Turtle), soit par l'API de graphe dotNetRDF (`Assert`, `CreateBlankNode`). Cette section montre les deux approches.\n",
+    "\n",
+    "### Catalogue des contraintes\n",
+    "\n",
+    "| Categorie | Propriete SHACL | Description |\n",
+    "|-----------|-----------------|-------------|\n",
+    "| Cardinalite | `sh:minCount`, `sh:maxCount` | Nombre min / max de valeurs |\n",
+    "| Type | `sh:datatype`, `sh:class`, `sh:nodeKind` | Type XSD, classe RDF, ou type de noeud |\n",
+    "| Chaine | `sh:pattern`, `sh:minLength`, `sh:maxLength` | Regex, longueurs min / max |\n",
+    "| Numerique | `sh:minInclusive`, `sh:maxInclusive` | Bornes inclusives |\n",
+    "| Valeur | `sh:hasValue`, `sh:in` | Valeur exacte, liste autorisee |\n",
+    "| Logique | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | Combinaisons de sous-formes |\n",
+    "\n",
+    "### Exemple guide : une ArticleShape (construction en Turtle inline)\n",
+    "\n",
+    "Creesons une forme SHACL pour valider des articles (`schema:Article`) :\n",
+    "- Titre obligatoire (`schema:headline`, string, min 5 caracteres)\n",
+    "- Au moins un auteur (`schema:author`, doit etre un `schema:Person`)\n",
+    "- Date de publication optionnelle (`schema:datePublished`, format `xsd:date`)\n",
+    "- Nombre de mots optionnel (`schema:wordCount`, entier entre 100 et 50000)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "sw8c-019",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.305008Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.305008Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.342907Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.342907Z"
+    },
+    "papermill": {
+     "duration": 0.047704,
+     "end_time": "2026-07-07T00:50:48.342907",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.295203",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ArticleShape chargee : 26 triplets dans le graphe des formes.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conforme : False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Violations : 4\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  article2 / headline -> MinLength : Un article doit avoir un titre (string, min 5 caracteres)@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  article3 / headline -> MinCount : Un article doit avoir un titre (string, min 5 caracteres)@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  article3 / author -> MinCount : Un article doit avoir au moins un auteur (schema:Person)@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  article4 / wordCount -> MinInclusive : Le nombre de mots doit etre entre 100 et 50000@fr\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Construction d'une ArticleShape par Turtle inline (format natif de SHACL)\n",
+    "string articleShapesTtl = @\"\n",
+    "@prefix sh: <http://www.w3.org/ns/shacl#> .\n",
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix schema: <http://schema.org/> .\n",
+    "\n",
+    "ex:ArticleShape a sh:NodeShape ;\n",
+    "    sh:targetClass schema:Article ;\n",
+    "    sh:property [\n",
+    "        sh:path schema:headline ;\n",
+    "        sh:minCount 1 ; sh:maxCount 1 ;\n",
+    "        sh:datatype xsd:string ; sh:minLength 5 ;\n",
+    "        sh:message \"\"Un article doit avoir un titre (string, min 5 caracteres)\"\"@fr ;\n",
+    "    ] ;\n",
+    "    sh:property [\n",
+    "        sh:path schema:author ;\n",
+    "        sh:minCount 1 ;\n",
+    "        sh:class schema:Person ;\n",
+    "        sh:message \"\"Un article doit avoir au moins un auteur (schema:Person)\"\"@fr ;\n",
+    "    ] ;\n",
+    "    sh:property [\n",
+    "        sh:path schema:datePublished ;\n",
+    "        sh:maxCount 1 ; sh:datatype xsd:date ;\n",
+    "        sh:message \"\"La date de publication doit etre au format xsd:date\"\"@fr ;\n",
+    "    ] ;\n",
+    "    sh:property [\n",
+    "        sh:path schema:wordCount ;\n",
+    "        sh:maxCount 1 ; sh:datatype xsd:integer ;\n",
+    "        sh:minInclusive 100 ; sh:maxInclusive 50000 ;\n",
+    "        sh:message \"\"Le nombre de mots doit etre entre 100 et 50000\"\"@fr ;\n",
+    "    ] .\n",
+    "\";\n",
+    "\n",
+    "IGraph articleShapes = new Graph();\n",
+    "new TurtleParser().Load(articleShapes, new StringReader(articleShapesTtl));\n",
+    "Console.WriteLine($\"ArticleShape chargee : {articleShapes.Triples.Count} triplets dans le graphe des formes.\");\n",
+    "\n",
+    "// Donnees de test : 1 article valide + 3 invalides\n",
+    "string articleDataTtl = @\"\n",
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix schema: <http://schema.org/> .\n",
+    "\n",
+    "ex:jean a schema:Person ; schema:name \"\"Jean Dupont\"\" .\n",
+    "\n",
+    "# Article 1 : valide\n",
+    "ex:article1 a schema:Article ;\n",
+    "    schema:headline \"\"Introduction au Web Semantique\"\" ;\n",
+    "    schema:author ex:jean ;\n",
+    "    schema:datePublished \"\"2024-01-15\"\"^^xsd:date ;\n",
+    "    schema:wordCount 5000 .\n",
+    "\n",
+    "# Article 2 : titre trop court (\"\"RDF\"\" = 3 caracteres < 5)\n",
+    "ex:article2 a schema:Article ;\n",
+    "    schema:headline \"\"RDF\"\" ;\n",
+    "    schema:author ex:jean .\n",
+    "\n",
+    "# Article 3 : pas de titre, pas d'auteur\n",
+    "ex:article3 a schema:Article ;\n",
+    "    schema:wordCount 200 .\n",
+    "\n",
+    "# Article 4 : nombre de mots hors bornes (10 < 100)\n",
+    "ex:article4 a schema:Article ;\n",
+    "    schema:headline \"\"Article avec trop peu de mots\"\" ;\n",
+    "    schema:author ex:jean ;\n",
+    "    schema:wordCount 10 .\n",
+    "\";\n",
+    "\n",
+    "IGraph articleData = new Graph { BaseUri = UriFactory.Create(\"http://example.org/\") };\n",
+    "new TurtleParser().Load(articleData, new StringReader(articleDataTtl));\n",
+    "\n",
+    "// Validation\n",
+    "var articleShapeGraph = new ShapesGraph(articleShapes);\n",
+    "var articleReport = articleShapeGraph.Validate(articleData);\n",
+    "\n",
+    "Console.WriteLine($\"Conforme : {articleReport.Conforms}\");\n",
+    "Console.WriteLine($\"Violations : {articleReport.Results.Count()}\");\n",
+    "Console.WriteLine();\n",
+    "foreach (var r in articleReport.Results.OrderBy(x => x.FocusNode.ToString()))\n",
+    "{\n",
+    "    string focus = r.FocusNode.ToString().Split('/').Last();\n",
+    "    string path = r.ResultPath == null ? \"-\" : r.ResultPath.ToString().Split('/').Last();\n",
+    "    string component = r.SourceConstraintComponent.ToString().Split('#').Last().Replace(\"ConstraintComponent\", \"\");\n",
+    "    Console.WriteLine($\"  {focus} / {path} -> {component} : {r.Message}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-020",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007046,
+     "end_time": "2026-07-07T00:50:48.365808",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.358762",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Validation de la forme personnalisee\n",
+    "\n",
+    "| Article | Violations | Detail |\n",
+    "|---------|-----------|--------|\n",
+    "| **article1** | 0 | Conforme : titre, auteur, date et wordCount respectent toutes les contraintes |\n",
+    "| **article2** | 1 | Titre \"RDF\" trop court (3 < 5 caracteres requis par minLength) |\n",
+    "| **article3** | 2 | Pas de titre (minCount=1) + pas d'auteur (minCount=1) |\n",
+    "| **article4** | 1 | wordCount=10 < minInclusive=100 |\n",
+    "\n",
+    "> **Bonne pratique** : ajoutz toujours des messages explicites (`sh:message`) pour faciliter le diagnostic. Les messages en francais sont plus utiles que les messages generiques du moteur.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-021",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009001,
+     "end_time": "2026-07-07T00:50:48.374809",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.365808",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "### Exercice 1 : MovieShape -- valider un dataset de films\n",
+    "\n",
+    "Creez une forme SHACL `ex:MovieShape` (en Turtle inline ou par l'API C#) pour valider des films (`schema:Movie`) avec :\n",
+    "- **Titre** (`schema:name`) : obligatoire, chaine, min 1 caractere\n",
+    "- **Annee** (`schema:datePublished`) : entier entre 1900 et 2030\n",
+    "- **Acteur** (`schema:actor`) : au moins un, doit etre un `schema:Person`\n",
+    "\n",
+    "Puis creez un graphe de donnees avec 2 films valides et 3 invalides, et validez.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Reutilisez le patron de l'`ArticleShape` (Turtle inline + `new TurtleParser().Load(g, new StringReader(ttl))`).\n",
+    "- Pour les bornes d'annee : `sh:minInclusive 1900 ; sh:maxInclusive 2030`.\n",
+    "- Pour exiger un acteur d'une classe donnee : `sh:minCount 1 ; sh:class schema:Person`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "sw8c-022",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.390907Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.390907Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.422816Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.422816Z"
+    },
+    "papermill": {
+     "duration": 0.048007,
+     "end_time": "2026-07-07T00:50:48.422816",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.374809",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : MovieShape\n",
+    "// TODO etudiant : definissez la forme MovieShape en Turtle\n",
+    "string movieShapesTtl = @\"\n",
+    "@prefix sh: <http://www.w3.org/ns/shacl#> .\n",
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix schema: <http://schema.org/> .\n",
+    "\n",
+    "# TODO etudiant : completez ex:MovieShape (titre, annee 1900-2030, acteur schema:Person)\n",
+    "ex:MovieShape a sh:NodeShape ;\n",
+    "    sh:targetClass schema:Movie .\n",
+    "\";\n",
+    "\n",
+    "// TODO etudiant : creez les donnees de test (2 films valides + 3 invalides)\n",
+    "// string movieDataTtl = @\"... \";\n",
+    "// IGraph movieData = new Graph { BaseUri = UriFactory.Create(\"http://example.org/\") };\n",
+    "// new TurtleParser().Load(movieData, new StringReader(movieDataTtl));\n",
+    "\n",
+    "// TODO etudiant : validez et affichez les violations\n",
+    "// var movieShapeGraph = new ShapesGraph(movieShapes);\n",
+    "// var movieReport = movieShapeGraph.Validate(movieData);\n",
+    "// Console.WriteLine($\"Conforme : {movieReport.Conforms}\");\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-023",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007895,
+     "end_time": "2026-07-07T00:50:48.430711",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.422816",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Severites SHACL\n",
+    "\n",
+    "SHACL definit trois niveaux de severite pour les violations. Par defaut, toutes les contraintes ont la severite `sh:Violation`, mais on peut les ajuster avec `sh:severity`.\n",
+    "\n",
+    "| Severite | URI | Comportement | Usage typique |\n",
+    "|----------|-----|-------------|---------------|\n",
+    "| **Violation** | `sh:Violation` | Erreur bloquante (defaut) | Donnee manquante obligatoire |\n",
+    "| **Warning** | `sh:Warning` | Avertissement non bloquant | Donnee recommandee mais optionnelle |\n",
+    "| **Info** | `sh:Info` | Information, suggestion | Bonne pratique non imposee |\n",
+    "\n",
+    "Le booleen `report.Conforms` retourne `False` **uniquement** pour les `sh:Violation`. Les warnings et infos n'affectent pas la conformite -- mais ils apparaissent dans `report.Results`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "sw8c-024",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.439418Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.439418Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.470558Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.470558Z"
+    },
+    "papermill": {
+     "duration": 0.03114,
+     "end_time": "2026-07-07T00:50:48.470558",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.439418",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conforme (Conforms) : False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre total de resultats : 3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultats classés par severite :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Violation ] Le nom est obligatoire (Violation)@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Warning   ] L'email est recommande (Warning)@fr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Info      ] Le telephone est souhaitable (Info)@fr\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demonstration des 3 niveaux de severite\n",
+    "string severityShapesTtl = @\"\n",
+    "@prefix sh: <http://www.w3.org/ns/shacl#> .\n",
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n",
+    "\n",
+    "ex:EmployeeShape a sh:NodeShape ;\n",
+    "    sh:targetClass ex:Employee ;\n",
+    "    sh:property [\n",
+    "        sh:path foaf:name ; sh:minCount 1 ;\n",
+    "        sh:severity sh:Violation ;\n",
+    "        sh:message \"\"Le nom est obligatoire (Violation)\"\"@fr ;\n",
+    "    ] ;\n",
+    "    sh:property [\n",
+    "        sh:path foaf:mbox ; sh:minCount 1 ;\n",
+    "        sh:severity sh:Warning ;\n",
+    "        sh:message \"\"L'email est recommande (Warning)\"\"@fr ;\n",
+    "    ] ;\n",
+    "    sh:property [\n",
+    "        sh:path ex:phone ; sh:minCount 1 ;\n",
+    "        sh:severity sh:Info ;\n",
+    "        sh:message \"\"Le telephone est souhaitable (Info)\"\"@fr ;\n",
+    "    ] .\n",
+    "\";\n",
+    "\n",
+    "IGraph severityShapes = new Graph();\n",
+    "new TurtleParser().Load(severityShapes, new StringReader(severityShapesTtl));\n",
+    "\n",
+    "// Employe sans nom, sans email, sans telephone\n",
+    "string severityDataTtl = @\"\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "ex:emp1 a ex:Employee .\n",
+    "\";\n",
+    "IGraph severityData = new Graph { BaseUri = UriFactory.Create(\"http://example.org/\") };\n",
+    "new TurtleParser().Load(severityData, new StringReader(severityDataTtl));\n",
+    "\n",
+    "var severityShapeGraph = new ShapesGraph(severityShapes);\n",
+    "var severityReport = severityShapeGraph.Validate(severityData);\n",
+    "\n",
+    "Console.WriteLine($\"Conforme (Conforms) : {severityReport.Conforms}\");\n",
+    "Console.WriteLine($\"Nombre total de resultats : {severityReport.Results.Count()}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Resultats classés par severite :\");\n",
+    "foreach (var r in severityReport.Results)\n",
+    "{\n",
+    "    string sev = r.Severity.ToString().Split('#').Last();\n",
+    "    Console.WriteLine($\"  [{sev,-10}] {r.Message}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-025",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": "2026-07-07T00:50:48.486707",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.486707",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Impact de la severite\n",
+    "\n",
+    "Bien que les 3 contraintes soient violees, le booleen `report.Conforms` ne depend que de `sh:Violation` :\n",
+    "\n",
+    "| Severite | Contrainte violee | Impact sur `Conforms` |\n",
+    "|----------|-------------------|----------------------|\n",
+    "| `sh:Violation` | Pas de nom | `Conforms = False` |\n",
+    "| `sh:Warning` | Pas d'email | Pas d'impact (avertissement seulement, mais present dans Results) |\n",
+    "| `sh:Info` | Pas de telephone | Pas d'impact (information seulement, mais present dans Results) |\n",
+    "\n",
+    "> **Bonne pratique** : utilisz `sh:Warning` pour les proprietes recommandees (best practices) et `sh:Info` pour les suggestions. Reservez `sh:Violation` aux exigences absolues.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-026",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01612,
+     "end_time": "2026-07-07T00:50:48.502827",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.486707",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "### Exercice 2 : Une forme avec severites mixtes\n",
+    "\n",
+    "Creez une forme `ex:StudentShape` pour valider des etudiants (`ex:Student`) avec les contraintes et severites suivantes :\n",
+    "\n",
+    "| Propriete | Contrainte | Severite |\n",
+    "|-----------|-----------|----------|\n",
+    "| `foaf:name` | Obligatoire, chaine | `sh:Violation` |\n",
+    "| `ex:studentId` | Obligatoire, motif `^[A-Z]{2}\\\\d{6}$` | `sh:Violation` |\n",
+    "| `foaf:mbox` | Recommande (minCount 1) | `sh:Warning` |\n",
+    "| `ex:phone` | Souhaitable (minCount 1) | `sh:Info` |\n",
+    "\n",
+    "Testez avec 3 etudiants : un complet, un sans email/telephone, un sans nom. Verifiez que `Conforms` est False (a cause du nom manquant) mais que tous les resultats apparaissent dans `report.Results`.\n",
+    "\n",
+    "**Indices** : `sh:pattern \"^[A-Z]{2}\\\\\\\\d{6}$\"` (echappement Turtle), `sh:severity sh:Warning`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "sw8c-027",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.502827Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.502827Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.518727Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.518727Z"
+    },
+    "papermill": {
+     "duration": 0.0159,
+     "end_time": "2026-07-07T00:50:48.518727",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.502827",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : StudentShape avec severites multiples\n",
+    "// TODO etudiant : definissez StudentShape en Turtle\n",
+    "string studentShapesTtl = @\"\n",
+    "@prefix sh: <http://www.w3.org/ns/shacl#> .\n",
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n",
+    "\n",
+    "# TODO etudiant : completez ex:StudentShape (name Violation, studentId Violation, mbox Warning, phone Info)\n",
+    "ex:StudentShape a sh:NodeShape ;\n",
+    "    sh:targetClass ex:Student .\n",
+    "\";\n",
+    "\n",
+    "// TODO etudiant : creez les 3 etudiants de test, validez, et affichez les resultats par severite\n",
+    "Console.WriteLine(\"Exercice a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-028",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015863,
+     "end_time": "2026-07-07T00:50:48.534590",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.518727",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 7. Contraintes avancees : operateurs logiques\n",
+    "\n",
+    "SHACL permet de combiner des contraintes avec des operateurs logiques :\n",
+    "\n",
+    "| Operateur | Propriete SHACL | Semantique |\n",
+    "|-----------|-----------------|------------|\n",
+    "| **OU** | `sh:or` | Au moins une des sous-formes doit etre satisfaite |\n",
+    "| **ET** | `sh:and` | Toutes les sous-formes doivent etre satisfaites |\n",
+    "| **NON** | `sh:not` | La sous-forme ne doit PAS etre satisfaite |\n",
+    "| **OU exclusif** | `sh:xone` | Exactement une sous-forme satisfaite |\n",
+    "\n",
+    "### Exemple guide : un Contact doit avoir un email OU un telephone (`sh:or`)\n",
+    "\n",
+    "La contrainte `sh:or` prend une liste RDF de sous-formes. Si au moins une sous-forme est satisfaite, la contrainte passe.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "sw8c-029",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.550329Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.550329Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.582250Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.582250Z"
+    },
+    "papermill": {
+     "duration": 0.04766,
+     "end_time": "2026-07-07T00:50:48.582250",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.534590",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conforme : False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de violations : 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  contact3 -> Or : Un contact doit avoir un email ou un telephone@fr\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Forme avancee avec sh:or (un Contact doit avoir un email OU un telephone)\n",
+    "string contactShapesTtl = @\"\n",
+    "@prefix sh: <http://www.w3.org/ns/shacl#> .\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix schema: <http://schema.org/> .\n",
+    "\n",
+    "ex:ContactShape a sh:NodeShape ;\n",
+    "    sh:targetClass ex:Contact ;\n",
+    "    sh:or (\n",
+    "        [ sh:path schema:email ; sh:minCount 1 ]\n",
+    "        [ sh:path schema:telephone ; sh:minCount 1 ]\n",
+    "    ) ;\n",
+    "    sh:message \"\"Un contact doit avoir un email ou un telephone\"\"@fr .\n",
+    "\";\n",
+    "\n",
+    "IGraph contactShapes = new Graph();\n",
+    "new TurtleParser().Load(contactShapes, new StringReader(contactShapesTtl));\n",
+    "\n",
+    "// 4 contacts : email seul, telephone seul, aucun, les deux\n",
+    "string contactDataTtl = @\"\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix schema: <http://schema.org/> .\n",
+    "\n",
+    "ex:contact1 a ex:Contact ; schema:name \"\"Alice\"\" ; schema:email \"\"alice@example.com\"\" .\n",
+    "ex:contact2 a ex:Contact ; schema:name \"\"Bob\"\" ; schema:telephone \"\"+33 1 23 45 67 89\"\" .\n",
+    "ex:contact3 a ex:Contact ; schema:name \"\"Charlie\"\" .\n",
+    "ex:contact4 a ex:Contact ; schema:name \"\"Diana\"\" ; schema:email \"\"diana@example.com\"\" ; schema:telephone \"\"+33 6 12 34 56 78\"\" .\n",
+    "\";\n",
+    "IGraph contactData = new Graph { BaseUri = UriFactory.Create(\"http://example.org/\") };\n",
+    "new TurtleParser().Load(contactData, new StringReader(contactDataTtl));\n",
+    "\n",
+    "var contactShapeGraph = new ShapesGraph(contactShapes);\n",
+    "var contactReport = contactShapeGraph.Validate(contactData);\n",
+    "\n",
+    "Console.WriteLine($\"Conforme : {contactReport.Conforms}\");\n",
+    "Console.WriteLine($\"Nombre de violations : {contactReport.Results.Count()}\");\n",
+    "Console.WriteLine();\n",
+    "foreach (var r in contactReport.Results)\n",
+    "{\n",
+    "    string focus = r.FocusNode.ToString().Split('/').Last();\n",
+    "    string component = r.SourceConstraintComponent.ToString().Split('#').Last().Replace(\"ConstraintComponent\", \"\");\n",
+    "    Console.WriteLine($\"  {focus} -> {component} : {r.Message}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-030",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004849,
+     "end_time": "2026-07-07T00:50:48.603016",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.598167",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Contraintes logiques\n",
+    "\n",
+    "| Contact | Email | Telephone | Resultat | Raison |\n",
+    "|---------|-------|-----------|----------|--------|\n",
+    "| contact1 | Oui | Non | Conforme | `sh:or` satisfait par l'email |\n",
+    "| contact2 | Non | Oui | Conforme | `sh:or` satisfait par le telephone |\n",
+    "| contact3 | Non | Non | **Violation OrConstraint** | `sh:or` non satisfait (aucune branche valide) |\n",
+    "| contact4 | Oui | Oui | Conforme | `sh:or` satisfait par les deux (OU inclusif) |\n",
+    "\n",
+    "> **Point cle** : `sh:or` est un OU **inclusif** : avoir les deux options satisfaites est aussi valide. Pour exiger exactement une option, utilisz `sh:xone` (OU exclusif).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-031",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01187,
+     "end_time": "2026-07-07T00:50:48.614886",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.603016",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "### Exercice 3 : Contrainte `sh:not` et enumeration `sh:in`\n",
+    "\n",
+    "On veut valider des comptes bancaires (`ex:Account`) avec :\n",
+    "- **`schema:name`** obligatoire (string)\n",
+    "- **`ex:status`** parmis `\"active\"`, `\"frozen\"`, `\"closed\"` (contrainte `sh:in`)\n",
+    "- **`sh:not`** : le compte ne doit PAS avoir à la fois `ex:status \"closed\"` ET `ex:balance` positif (un compte ferme ne peut pas etre credite)\n",
+    "\n",
+    "Construisez la forme et testez-la sur 3 comptes (1 valide, 2 invalides).\n",
+    "\n",
+    "**Indices** :\n",
+    "- `sh:in (\"active\" \"frozen\" \"closed\")` pour l'enumeration.\n",
+    "- `sh:not` prend une sous-forme ; combinez avec `sh:and` pour exprimer \"ferme ET balance>0\" a interdire :\n",
+    "  ```\n",
+    "  sh:not [ sh:and ( [ sh:path ex:status ; sh:hasValue \"closed\" ] [ sh:path ex:balance ; sh:minExclusive 0 ] ) ]\n",
+    "  ```\n",
+    "- Si votre version de SHACL/dotNetRDF rend `sh:not`+`sh:and` delicate, contentz-vous du `sh:in` seul (la structure de base). L'objectif est d'exprimer une contrainte negative.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "sw8c-032",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.614886Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.614886Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.631149Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.631149Z"
+    },
+    "papermill": {
+     "duration": 0.016263,
+     "end_time": "2026-07-07T00:50:48.631149",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.614886",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : AccountShape avec sh:in et sh:not\n",
+    "// TODO etudiant : definissez AccountShape\n",
+    "string accountShapesTtl = @\"\n",
+    "@prefix sh: <http://www.w3.org/ns/shacl#> .\n",
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix schema: <http://schema.org/> .\n",
+    "\n",
+    "# TODO etudiant : completez ex:AccountShape (name obligatoire, status dans {active,frozen,closed}, sh:not closed+balance>0)\n",
+    "ex:AccountShape a sh:NodeShape ;\n",
+    "    sh:targetClass ex:Account .\n",
+    "\";\n",
+    "\n",
+    "// TODO etudiant : creez 3 comptes (1 valide, 2 invalides), validez, affichez\n",
+    "Console.WriteLine(\"Exercice a completer\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-033",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003867,
+     "end_time": "2026-07-07T00:50:48.650561",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.646694",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 8. Exemple guide : construire une BookShape par l'API C#\n",
+    "\n",
+    "Jusqu'ici nous avons defini les shapes en Turtle inline. dotNetRDF permet aussi de **construire les formes par programmation** (Assert de triplets), comme le fait rdflib en Python. Cette section montre l'equivalent C# pour une `BookShape` :\n",
+    "\n",
+    "- **Titre** (`schema:name`) : obligatoire, chaine, min 1 caractere\n",
+    "- **ISBN** (`schema:isbn`) : motif EAN-13 `^97[89]-\\\\d-\\\\d{4}-\\\\d{4}-\\\\d$`\n",
+    "- **Annee** (`schema:datePublished`) : entier entre 1450 et 2030\n",
+    "- **Auteur** (`schema:author`) : au moins un, IRI de type `schema:Person`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "sw8c-034",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:50:48.662096Z",
+     "iopub.status.busy": "2026-07-07T00:50:48.662096Z",
+     "iopub.status.idle": "2026-07-07T00:50:48.741729Z",
+     "shell.execute_reply": "2026-07-07T00:50:48.741729Z"
+    },
+    "papermill": {
+     "duration": 0.091168,
+     "end_time": "2026-07-07T00:50:48.741729",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.650561",
+     "status": "completed"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BookShape construite : 21 triplets dans le graphe des formes.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conforme : False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Violations : 5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  book3 / name -> MinCount\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  book3 / isbn -> Pattern\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  book3 / author -> MinCount\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  book4 / datePublished -> MaxInclusive\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  book4 / author -> Class\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple guide : BookShape construite par l'API dotNetRDF (equivalent C# du build-shape Python)\n",
+    "IGraph bookShapes = new Graph();\n",
+    "bookShapes.NamespaceMap.AddNamespace(\"sh\", UriFactory.Create(\"http://www.w3.org/ns/shacl#\"));\n",
+    "bookShapes.NamespaceMap.AddNamespace(\"ex\", UriFactory.Create(\"http://example.org/\"));\n",
+    "bookShapes.NamespaceMap.AddNamespace(\"schema\", UriFactory.Create(\"http://schema.org/\"));\n",
+    "bookShapes.NamespaceMap.AddNamespace(\"xsd\", UriFactory.Create(\"http://www.w3.org/2001/XMLSchema#\"));\n",
+    "\n",
+    "IUriNode SH(string l) => bookShapes.CreateUriNode(UriFactory.Create(\"http://www.w3.org/ns/shacl#\" + l));\n",
+    "IUriNode SCHEMA(string l) => bookShapes.CreateUriNode(UriFactory.Create(\"http://schema.org/\" + l));\n",
+    "IUriNode XSD(string l) => bookShapes.CreateUriNode(UriFactory.Create(\"http://www.w3.org/2001/XMLSchema#\" + l));\n",
+    "\n",
+    "IUriNode bookShape = bookShapes.CreateUriNode(\"ex:BookShape\");\n",
+    "bookShapes.Assert(new Triple(bookShape, SH(\"type\"), SH(\"NodeShape\")));\n",
+    "bookShapes.Assert(new Triple(bookShape, SH(\"targetClass\"), SCHEMA(\"Book\")));\n",
+    "\n",
+    "// Contrainte 1 : titre obligatoire\n",
+    "IBlankNode titlePs = bookShapes.CreateBlankNode();\n",
+    "bookShapes.Assert(new Triple(bookShape, SH(\"property\"), titlePs));\n",
+    "bookShapes.Assert(new Triple(titlePs, SH(\"path\"), SCHEMA(\"name\")));\n",
+    "bookShapes.Assert(new Triple(titlePs, SH(\"minCount\"), (1).ToLiteral(bookShapes)));\n",
+    "bookShapes.Assert(new Triple(titlePs, SH(\"datatype\"), XSD(\"string\")));\n",
+    "bookShapes.Assert(new Triple(titlePs, SH(\"minLength\"), (1).ToLiteral(bookShapes)));\n",
+    "\n",
+    "// Contrainte 2 : ISBN avec pattern\n",
+    "IBlankNode isbnPs = bookShapes.CreateBlankNode();\n",
+    "bookShapes.Assert(new Triple(bookShape, SH(\"property\"), isbnPs));\n",
+    "bookShapes.Assert(new Triple(isbnPs, SH(\"path\"), SCHEMA(\"isbn\")));\n",
+    "bookShapes.Assert(new Triple(isbnPs, SH(\"datatype\"), XSD(\"string\")));\n",
+    "bookShapes.Assert(new Triple(isbnPs, SH(\"pattern\"), bookShapes.CreateLiteralNode(@\"^97[89]-\\d-\\d{4}-\\d{4}-\\d$\")));\n",
+    "\n",
+    "// Contrainte 3 : annee entre 1450 et 2030\n",
+    "IBlankNode yearPs = bookShapes.CreateBlankNode();\n",
+    "bookShapes.Assert(new Triple(bookShape, SH(\"property\"), yearPs));\n",
+    "bookShapes.Assert(new Triple(yearPs, SH(\"path\"), SCHEMA(\"datePublished\")));\n",
+    "bookShapes.Assert(new Triple(yearPs, SH(\"datatype\"), XSD(\"integer\")));\n",
+    "bookShapes.Assert(new Triple(yearPs, SH(\"minInclusive\"), (1450).ToLiteral(bookShapes)));\n",
+    "bookShapes.Assert(new Triple(yearPs, SH(\"maxInclusive\"), (2030).ToLiteral(bookShapes)));\n",
+    "\n",
+    "// Contrainte 4 : au moins un auteur (IRI de type schema:Person)\n",
+    "IBlankNode authorPs = bookShapes.CreateBlankNode();\n",
+    "bookShapes.Assert(new Triple(bookShape, SH(\"property\"), authorPs));\n",
+    "bookShapes.Assert(new Triple(authorPs, SH(\"path\"), SCHEMA(\"author\")));\n",
+    "bookShapes.Assert(new Triple(authorPs, SH(\"minCount\"), (1).ToLiteral(bookShapes)));\n",
+    "bookShapes.Assert(new Triple(authorPs, SH(\"nodeKind\"), SH(\"IRI\")));\n",
+    "bookShapes.Assert(new Triple(authorPs, SH(\"class\"), SCHEMA(\"Person\")));\n",
+    "\n",
+    "Console.WriteLine($\"BookShape construite : {bookShapes.Triples.Count} triplets dans le graphe des formes.\");\n",
+    "\n",
+    "// Donnees de test (2 valides + 2 invalides)\n",
+    "string bookDataTtl = @\"\n",
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
+    "@prefix ex: <http://example.org/> .\n",
+    "@prefix schema: <http://schema.org/> .\n",
+    "\n",
+    "ex:author1 a schema:Person .\n",
+    "ex:author2 a schema:Person .\n",
+    "\n",
+    "ex:book1 a schema:Book ;\n",
+    "    schema:name \"\"Clean Code\"\" ;\n",
+    "    schema:isbn \"\"978-0-1323-5088-4\"\" ;\n",
+    "    schema:datePublished 2008 ;\n",
+    "    schema:author ex:author1 .\n",
+    "\n",
+    "ex:book2 a schema:Book ;\n",
+    "    schema:name \"\"Design Patterns\"\" ;\n",
+    "    schema:isbn \"\"978-0-2016-3361-0\"\" ;\n",
+    "    schema:datePublished 1994 ;\n",
+    "    schema:author ex:author2 .\n",
+    "\n",
+    "# Invalide : pas de titre, ISBN errone, pas d'auteur\n",
+    "ex:book3 a schema:Book ;\n",
+    "    schema:isbn \"\"123-INVALID\"\" .\n",
+    "\n",
+    "# Invalide : annee hors bornes (3000 > 2030), auteur non-Person\n",
+    "ex:book4 a schema:Book ;\n",
+    "    schema:name \"\"Future Book\"\" ;\n",
+    "    schema:datePublished 3000 ;\n",
+    "    schema:author ex:robot .\n",
+    "ex:robot a schema:Organization .\n",
+    "\";\n",
+    "IGraph bookData = new Graph { BaseUri = UriFactory.Create(\"http://example.org/\") };\n",
+    "new TurtleParser().Load(bookData, new StringReader(bookDataTtl));\n",
+    "\n",
+    "var bookShapeGraph = new ShapesGraph(bookShapes);\n",
+    "var bookReport = bookShapeGraph.Validate(bookData);\n",
+    "\n",
+    "Console.WriteLine($\"Conforme : {bookReport.Conforms}\");\n",
+    "Console.WriteLine($\"Violations : {bookReport.Results.Count()}\");\n",
+    "Console.WriteLine();\n",
+    "foreach (var r in bookReport.Results.OrderBy(x => x.FocusNode.ToString()))\n",
+    "{\n",
+    "    string focus = r.FocusNode.ToString().Split('/').Last();\n",
+    "    string path = r.ResultPath == null ? \"-\" : r.ResultPath.ToString().Split('/').Last();\n",
+    "    string component = r.SourceConstraintComponent.ToString().Split('#').Last().Replace(\"ConstraintComponent\", \"\");\n",
+    "    Console.WriteLine($\"  {focus} / {path} -> {component}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-035",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006031,
+     "end_time": "2026-07-07T00:50:48.755087",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.749056",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : BookShape par l'API programmatique\n",
+    "\n",
+    "La construction par `Assert`/`CreateBlankNode` est l'equivalent C# du `graph.add((shape, sh.property, BNode()))` de rdflib. Elle est plus verbeuse que le Turtle inline mais utile quand les formes sont **generees dynamiquement** (depuis un schema SQL, une UI, etc.).\n",
+    "\n",
+    "| Livre | Violations | Detail |\n",
+    "|-------|-----------|--------|\n",
+    "| **book1** | 0 | Conforme |\n",
+    "| **book2** | 0 | Conforme |\n",
+    "| **book3** | 3 | Pas de titre (minCount), ISBN errone (pattern), pas d'auteur (minCount) |\n",
+    "| **book4** | 2 | Annee 3000 > 2030 (maxInclusive), auteur non-Person (class) |\n",
+    "\n",
+    "> **Quand utiliser Turtle inline vs API** : Turtle inline pour des formes fixes (lisibilite maximale, proche de la spec SHACL) ; API programmatique pour des formes generees par le code.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-036",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": "2026-07-07T00:50:48.759457",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.759457",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 9. Comparaison : dotNetRDF SHACL vs pySHACL\n",
+    "\n",
+    "Ce notebook et son jumeau [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb) appliquent le **meme standard W3C SHACL** via deux moteurs de reference. Les resultats concordent (mêmes 5 violations sur `person-data.ttl`, memes composants de contrainte, memes severites) ; les differences sont dans l'API.\n",
+    "\n",
+    "| Aspect | pySHACL (Python) | dotNetRDF (C#) |\n",
+    "|--------|------------------|----------------|\n",
+    "| **Point d'entree** | `validate(data_graph, shacl_graph=...)` | `new ShapesGraph(shapes).Validate(data)` |\n",
+    "| **Retour** | triplet `(conforms, results_graph, results_text)` | `Validation.Report` (objet type) |\n",
+    "| **Rapport** | graphe RDF + texte formate | `report.Results` (collection de `Result`) + graphe RDF |\n",
+    "| **Severites** | `sh:Violation` / `Warning` / `Info` | idem (meme vocabulaire W3C) |\n",
+    "| **Operateurs logiques** | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | idem |\n",
+    "| **Parsing Turtle** | `rdflib` (tolerant, URIs relatives acceptees) | `TurtleParser` (strict, exige une base URI) |\n",
+    "| **Construction API** | `graph.add((s, p, o))` + `BNode()` | `graph.Assert(new Triple(s, p, o))` + `CreateBlankNode()` |\n",
+    "| **Inference RDFS** | `inference='rdfs'` (parametre de `validate`) | pre-materialisation a faire avant validation |\n",
+    "| **Type de la forme** | `rdflib.Graph` | `VDS.RDF.Shacl.ShapesGraph` (encapsule un `IGraph`) |\n",
+    "\n",
+    "**Concordance verifiee firsthand (G.1)** : sur `person-shape.ttl` + `person-data.ttl`, les deux moteurs rapportent **exactement les 5 memes violations** (charlie/MinCount, diana/MinInclusive, eve/Pattern, frank/MinLength, grace/Class), avec les memes composants de contrainte standardises. C'est la garantie que SHACL est un **vrai standard** : deux implementations independantes convergent.\n",
+    "\n",
+    "> **Difference notable** : pySHACL materialise l'inference RDFS option (`inference='rdfs'`) lors de la validation ; dotNetRDF delegue l'inference au `VDS.RDF.Inferencing` (a effectuer avant validation si besoin). Pour les formes cibles par `sh:targetClass`, il faut s'assurer que les types explicites (`a foaf:Person`) sont presents dans le graphe de donnees.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw8c-037",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": "2026-07-07T00:50:48.772669",
+     "exception": false,
+     "start_time": "2026-07-07T00:50:48.772669",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Resume\n",
+    "\n",
+    "### Tableau recapitulatif\n",
+    "\n",
+    "| Concept | Ce que nous avons appris |\n",
+    "|---------|--------------------------|\n",
+    "| **SHACL** | Recommandation W3C 2017 pour la validation de donnees RDF (monde ferme) |\n",
+    "| **NodeShape / PropertyShape** | Forme sur un noeud / contrainte sur une propriete |\n",
+    "| **dotNetRDF SHACL** | `new ShapesGraph(shapes).Validate(data)` -> `Validation.Report` |\n",
+    "| **Rapport** | `report.Conforms` + `report.Results` (`Severity`, `FocusNode`, `ResultPath`, `Message`, `SourceConstraintComponent`) |\n",
+    "| **Severites** | `sh:Violation` (bloquant), `sh:Warning` (avertissement), `sh:Info` (suggestion) |\n",
+    "| **Operateurs logiques** | `sh:or`, `sh:and`, `sh:not`, `sh:xone` |\n",
+    "| **Construction** | Turtle inline (`new TurtleParser().Load(g, new StringReader(ttl))`) ou API (`Assert`/`CreateBlankNode`) |\n",
+    "| **Gotcha cross-langage** | `TurtleParser` dotNetRDF plus strict que `rdflib` (URI relative exige une base) |\n",
+    "\n",
+    "### Contraintes SHACL -- Reference rapide\n",
+    "\n",
+    "| Categorie | Propriete SHACL | Exemple |\n",
+    "|-----------|-----------------|---------|\n",
+    "| Cardinalite | `sh:minCount`, `sh:maxCount` | `sh:minCount 1` |\n",
+    "| Type | `sh:datatype`, `sh:class`, `sh:nodeKind` | `sh:datatype xsd:string` |\n",
+    "| Chaine | `sh:pattern`, `sh:minLength`, `sh:maxLength` | `sh:pattern \"^[A-Z]\"` |\n",
+    "| Numerique | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |\n",
+    "| Valeur | `sh:hasValue`, `sh:in` | `sh:in (\"FR\" \"DE\")` |\n",
+    "| Logique | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | Liste de sous-formes |\n",
+    "\n",
+    "### Exemples et exercices du notebook\n",
+    "\n",
+    "| Type | Titre | Section |\n",
+    "|------|-------|---------|\n",
+    "| **Exemple guide** | Validation de `person-data.ttl` (5 erreurs) | 4 |\n",
+    "| **Exemple guide** | ArticleShape en Turtle inline | 5 |\n",
+    "| **Exercice 1** | MovieShape -- valider un dataset de films | 5 |\n",
+    "| **Exemple guide** | EmployeeShape (severites Violation/Warning/Info) | 6 |\n",
+    "| **Exercice 2** | StudentShape avec severites mixtes | 6 |\n",
+    "| **Exemple guide** | ContactShape avec `sh:or` | 7 |\n",
+    "| **Exercice 3** | AccountShape avec `sh:in` et `sh:not` | 7 |\n",
+    "| **Exemple guide** | BookShape par l'API programmatique | 8 |\n",
+    "\n",
+    "### Ressources supplementaires\n",
+    "\n",
+    "- [W3C SHACL Specification](https://www.w3.org/TR/shacl/) -- Standard complet (Knublauch & Topidis, 2017)\n",
+    "- [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) -- Regles et fonctions\n",
+    "- [dotNetRDF SHACL User Guide](https://dotnetrdf.org/docs/user_guide/shacl/) -- Documentation du moteur C#\n",
+    "- [pySHACL Documentation](https://github.com/RDFLib/pySHACL) -- Le jumeau Python (notebook SW-8-Python)\n",
+    "- [SHACL Playground](https://shacl-playground.zazuko.com/) -- Testez vos formes en ligne\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a permis d'explorer la validation SHACL en C# avec le **vrai moteur dotNetRDF** (`VDS.RDF.Shacl`), jumeau du notebook Python pySHACL sur le meme standard W3C. Les points cles :\n",
+    "\n",
+    "- SHACL operationalise le **monde ferme** pour la qualite des donnees la ou OWL reste en monde ouvert.\n",
+    "- L'API dotNetRDF (`ShapesGraph.Validate` -> `Validation.Report`) est l'equivalent type de `pyshacl.validate`.\n",
+    "- Les **5 violations** sur les donnees de test concordent exactement entre dotNetRDF et pySHACL -- deux implementations independantes convergent sur le standard.\n",
+    "- Les severites et les operateurs logiques (`sh:or`, `sh:not`) ouvrent la voie a des contraintes business riches.\n",
+    "\n",
+    "**Pour aller plus loin** : combinez SHACL avec RDFS/OWL (SW-6, SW-7) pour valider des donnees inferees, et explorez SHACL Advanced Features (regles de transformation `sh:rule`) pour la materialisation.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [<< 7-OWL](SW-7-CSharp-OWL.ipynb) | [Index](README.md) | [SW-8-Python >>](SW-8-Python-SHACL.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 4.627836,
+   "end_time": "2026-07-07T00:50:48.898290",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-8-CSharp-SHACL.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-8-CSharp-SHACL_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-07T00:50:44.270454",
+   "version": "2.6.0"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "aliases": [],
+      "languageName": "csharp",
+      "name": "csharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Twin C# pedagogique du notebook Python `SW-8-Python-SHACL` (marathon **#4956** — parite .NET ⇄ Python, `See #4956`). Le Python original utilise **pySHACL** (moteur W3C SHACL de reference Python). Le twin C# invoque le **VRAI moteur dotNetRDF.Shacl** (`VDS.RDF.Shacl`, moteur W3C SHACL de reference .NET) — pas de workaround, pas de validateur jouet reimplemente a la main.

## SOTA verdict (EPIC #3801) — SOTA-OK

Le vrai `dotNetRDF.Shacl` est invoque : **9 appels `.Validate()`**, **21 references `ShapesGraph`**, **12 `using VDS.RDF.Shacl`**, package `dotNetRDF, 3.4.1` (meta-package incluant `dotNetRdf.Shacl`). Les deux twins (Python pySHACL + C# dotNetRDF) sont des compagnons cross-langage sur le **meme standard W3C SHACL 1.0 (2017)**. Une section comparative dediee (§9) documente les ecarts d'API, format de rapport, tolerance de parser et inférence entre les deux moteurs.

## Contenu (37 cells : 13 code, 24 markdown)

- **Concepts SHACL** : NodeShape/PropertyShape, composants de contrainte W3C (sh:datatype, sh:minCount, sh:minLength, sh:minInclusive, sh:pattern, sh:class, sh:in, sh:or, sh:not).
- **Parcours structurel** du graphe de formes (dotNetRDF API : enumeration shapes, constraints).
- **Validation dotNetRDF** sur `person-data.ttl` : **5 violations** avec noms de composants W3C standard.
- **Worked examples** : ArticleShape (4 violations), EmployeeShape (3, severites), ContactShape (1, sh:or), BookShape (5, via API dotNetRDF).
- **Severites** (Violation / Warning / Info) et impact.
- **Operateurs logiques** : sh:or (Contact doit avoir email OU telephone), sh:in, sh:not.
- **Section comparative** dotNetRDF vs pySHACL (API, format rapport, tolerance parser, inference).

## Preuve d'execution (H.1 / EXEC_PROVED)

Execute end-to-end via kernel `.net-csharp` (dotnet-interactive + dotNetRDF 3.4.1 restaure) :
- **13/13 cellules code** avec `execution_count` (1..13 sequentielles), **0 erreur**, **0 output vide**.
- `notebook_tools.py validate --quick` : **OK=1, Warnings=0, Errors=0**.

## Validation math/structuelle firsthand (Math Verification Standard)

dotNetRDF rapporte **exactement les 5 memes violations** que pySHACL sur `person-shape.ttl` + `person-data.ttl`, avec les **noms de composants W3C standard** :

| Focus node | Propriete | Composant W3C | Logique |
|------------|-----------|---------------|---------|
| charlie | foaf:name | MinCountConstraintComponent | 0 nom vs minCount=1 |
| diana | foaf:age | MinInclusiveConstraintComponent | age=-5 vs minInclusive=0 |
| eve | foaf:mbox | PatternConstraintComponent | not-an-email vs mailto: |
| frank | foaf:name | MinLengthConstraintComponent | "F" (1 char) vs min 2 |
| grace | foaf:knows | ClassConstraintComponent | knows->myDog (pas foaf:Person) |

Les noms de composants proviennent du vocabulaire W3C standardise (= preuve que le vrai moteur tourne, pas un validateur jouet). Les worked examples concordent egalement : ArticleShape=4, EmployeeShape=3, ContactShape=1, BookShape=5.

## G.1 self-corrections (3, appliquees avant commit)

1. **API dotNetRDF** : `GetTriplesWithSubjectPredicate(null, rdfType)` rejete (null comme sujet non valide) → `GetTriplesWithPredicateObject(rdfType, foafPerson)`.
2. **Type nested-namespace** : `Validation.Report` / `Validation.Result` explicites comme types = erreurs compilation en scripting Roslyn .NET Interactive → utilise `var` partout (resolve correctement depuis le retour de `Validate()`).
3. **Cleanup literal** : 1ere exec affichait `Alice Dupont^^http://www.w3.org/2001/XMLSchema#string` (suffixe datatype bruyant) → helper `GetOne` retourne `lit.Value`. + ecart tolerance parser documente (`TurtleParser` dotNetRDF rejette URI relative sans base ; rdflib accepte) → `graph.BaseUri` defini, ecart documente dans la prose pour valeur compagnon cross-langage authentique.

## Conventions respectees

- **C.1** : 0 `throw NotImplemented`/`assert False`/`1/0` partout ; 3 exercices stubs (MovieShape, StudentShape severites, AccountShape sh:in/sh:not) en patterns conformes (`// TODO etudiant`, `return null`, `Console.WriteLine`), distribues dans les sections 5/6/7.
- **C.2** : outputs commites, `execution_count` integers sur toutes les cellules code.
- **readme-french-first** : prose pedagogique en francais, 0 emojis.
- **§E** : +4/−2 dans `SemanticWeb/README.md` — 1 ligne table Partie 3 + 1 ligne tree + correction en-tete "Python uniquement" → "Python, avec jumeau C# SW-8" (= correction de coherence factuelle maintenant que SW-8 a un twin C#, pas du scope creep). Bloc `<!-- CATALOG-STATUS -->` byte-identical.

## Test plan

- [x] Execution end-to-end kernel `.net-csharp` (13/13 cellules, 0 erreur)
- [x] `notebook_tools.py validate --quick` OK
- [x] dotNetRDF SHACL invocation reelle verifiee (9× `.Validate`, 21× `ShapesGraph`)
- [x] Validation : 5 violations W3C-standard, hand-verifiees, match pySHACL
- [x] Grep C.1 (0 pattern interdit), 0 emoji, 0 CJK
- [x] §E surgical (CATALOG-STATUS byte-identical)

Part of #4956 (marathon parite .NET ⇄ Python). Famille SemanticWeb (SHACL/RDF) — rotation famille fraiche vs GT/Search/Planners/SL/Tweety.
