### PR TITLE
feat(planners): Planners-8-Temporal-Csharp — twin C# planification temporelle from-scratch (See #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal-Csharp.ipynb
@@ -1,0 +1,1008 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d030aa58-d0dc-4685-afb0-a88a89d3b321",
+   "metadata": {},
+   "source": [
+    "# Planners-8-Temporal — Planification Temporelle (twin C#)\n",
+    "\n",
+    "Ce notebook est le **jumeau C# (.NET Interactive)** du notebook Python `Planners-8-Temporal.ipynb`. Il réimplémente **from-scratch** (BCL .NET, **0 NuGet**, 0 `unified_planning`, 0 `ortools`) les concepts de la planification temporelle : **PDDL 2.1 actions duratives**, **algèbre d'intervalles d'Allen**, **réseau temporel simple (STN)** et **ordonnancement avec contraintes de précédence et ressources**.\n",
+    "\n",
+    "## Objectifs pédagogiques\n",
+    "\n",
+    "1. **Modéliser une action durative** PDDL 2.1 (conditions `at start`, `over all`, `at end`, effets).\n",
+    "2. **Manipuler l'algèbre d'intervalles d'Allen** (13 relations binaires entre intervalles temporels).\n",
+    "3. **Construire et vérifier un STN** (Simple Temporal Network) par Floyd-Warshall sur la matrice des distances.\n",
+    "4. **Détecter les conflits temporels** (exclusion mutuelle, chevauchement interdit).\n",
+    "5. **Ordonnancer** des tâches avec précédence + ressources capacitaires (variante RCPSP), produire un diagramme de Gantt ASCII.\n",
+    "\n",
+    "## Pourquoi un twin from-scratch ?\n",
+    "\n",
+    "Le notebook Python original s'appuie sur **`unified_planning`** (API Python de planification) et **`ortools` CP-SAT (Google)** pour exprimer et résoudre le problème temporel. Ces libs ne sont pas mobilisables nativement côté .NET Interactive sans NuGet lourds. Le twin C# reconstruit les **concepts** — Allen, STN, Floyd-Warshall, scheduling — pour les rendre **transparents et exécutables** sur toute machine .NET 9+. Le *value-add* (EPIC #4956 Prong B) est pédagogique : chaque mécanisme (composition d'Allen, propagation de contraintes STN, heuristique de scheduling) est visible dans le code C#.\n",
+    "\n",
+    "## Prérequis\n",
+    "\n",
+    ".NET 9.0+ (kernel `csharp`). Familiarité avec la planification classique state-space (cf. `Planners-3-State-Space-Csharp.ipynb`). Aucune librairie externe.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26b7dc8f-9800-46ea-9c9c-1e8c678ee04a",
+   "metadata": {},
+   "source": [
+    "## Setup — utilitaires d'affichage\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "94dc3baf-79c8-4622-b388-22f4a0313fc0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:16.785934Z",
+     "iopub.status.busy": "2026-07-07T00:59:16.779656Z",
+     "iopub.status.idle": "2026-07-07T00:59:18.440516Z",
+     "shell.execute_reply": "2026-07-07T00:59:18.435235Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1622036.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Setup: OK — BCL .NET, 0 NuGet (pas de unified_planning / ortools)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "\n",
+    "static void Show(object o) { try { display(o); } catch { Console.WriteLine(o); } }\n",
+    "static void Show(string label, object o) => Show($\"{label}: {o}\");\n",
+    "\n",
+    "Show(\"Setup\", \"OK — BCL .NET, 0 NuGet (pas de unified_planning / ortools).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d61498b-98bb-4d28-8fba-26538ce08071",
+   "metadata": {},
+   "source": [
+    "## Partie 1 — PDDL 2.1 : actions duratives\n",
+    "\n",
+    "En planification classique (STRIPS/PDDL 1), une action est *instantanée*. **PDDL 2.1** (Fox & Long, 2003) introduit les **actions duratives** : une action s'étend sur un intervalle $[t_{start}, t_{end}]$ de durée $\\delta$, avec des conditions et effets qualifiés temporellement :\n",
+    "\n",
+    "- `at start` : condition/effect au début de l'action,\n",
+    "- `over all` : condition maintenue pendant toute la durée,\n",
+    "- `at end` : condition/effect à la fin.\n",
+    "\n",
+    "Cela permet la **concurrence** : deux actions duratives peuvent se chevaucher si elles ne se violent pas mutuellement (exclusion mutuelle temporelle sur une ressource, par exemple).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "be120d1c-f4ea-446e-90d9-61fec5228b66",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:18.442794Z",
+     "iopub.status.busy": "2026-07-07T00:59:18.442505Z",
+     "iopub.status.idle": "2026-07-07T00:59:18.707612Z",
+     "shell.execute_reply": "2026-07-07T00:59:18.707401Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Action durative move(A,B): durative-action move(robot, A, B) [duration in [4, 4]]\r\n",
+       "  condition:\r\n",
+       "    AtStart(robot_at(A))\r\n",
+       "    OverAll(battery > 5)\r\n",
+       "  effect:\r\n",
+       "    AtStart(not robot_at(A))\r\n",
+       "    AtEnd(robot_at(B))\r\n",
+       "    AtEnd(battery -= 4)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Action durative charge: durative-action charge(robot) [duration in [3, 3]]\r\n",
+       "  condition:\r\n",
+       "    AtStart(robot_at(dock))\r\n",
+       "  effect:\r\n",
+       "    AtEnd(battery = 100)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- PDDL 2.1 : action durative from-scratch ---\n",
+    "public enum TemporalQualifier { AtStart, OverAll, AtEnd }\n",
+    "\n",
+    "public sealed class TimedCondition\n",
+    "{\n",
+    "    public TemporalQualifier When { get; }\n",
+    "    public string Predicate { get; }   // ex: \"robot_at(A)\", \"battery > 10\"\n",
+    "    public TimedCondition(TemporalQualifier q, string pred) { When = q; Predicate = pred; }\n",
+    "    public override string ToString() => $\"{When}({Predicate})\";\n",
+    "}\n",
+    "\n",
+    "public sealed class DurativeAction\n",
+    "{\n",
+    "    public string Name { get; }\n",
+    "    public double MinDuration { get; }\n",
+    "    public double MaxDuration { get; }\n",
+    "    public List<TimedCondition> Conditions { get; } = new();\n",
+    "    public List<TimedCondition> Effects { get; } = new();\n",
+    "    public DurativeAction(string name, double durMin, double durMax) { Name = name; MinDuration = durMin; MaxDuration = durMax; }\n",
+    "    public DurativeAction Cond(TemporalQualifier q, string p) { Conditions.Add(new TimedCondition(q, p)); return this; }\n",
+    "    public DurativeAction Eff(TemporalQualifier q, string p) { Effects.Add(new TimedCondition(q, p)); return this; }\n",
+    "    public override string ToString()\n",
+    "    {\n",
+    "        var sb = new StringBuilder();\n",
+    "        sb.AppendLine($\"durative-action {Name} [duration in [{MinDuration}, {MaxDuration}]]\");\n",
+    "        sb.AppendLine(\"  condition:\");\n",
+    "        foreach (var c in Conditions) sb.AppendLine($\"    {c}\");\n",
+    "        sb.AppendLine(\"  effect:\");\n",
+    "        foreach (var e in Effects) sb.AppendLine($\"    {e}\");\n",
+    "        return sb.ToString();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Action move(A, B) : deplacement classique avec duree ---\n",
+    "var moveAB = new DurativeAction(\"move(robot, A, B)\", 4.0, 4.0)\n",
+    "    .Cond(TemporalQualifier.AtStart, \"robot_at(A)\")\n",
+    "    .Cond(TemporalQualifier.OverAll, \"battery > 5\")\n",
+    "    .Eff(TemporalQualifier.AtStart, \"not robot_at(A)\")\n",
+    "    .Eff(TemporalQualifier.AtEnd, \"robot_at(B)\")\n",
+    "    .Eff(TemporalQualifier.AtEnd, \"battery -= 4\");\n",
+    "Show(\"Action durative move(A,B)\", moveAB.ToString());\n",
+    "\n",
+    "// --- Action charge : recharge la batterie ---\n",
+    "var charge = new DurativeAction(\"charge(robot)\", 3.0, 3.0)\n",
+    "    .Cond(TemporalQualifier.AtStart, \"robot_at(dock)\")\n",
+    "    .Eff(TemporalQualifier.AtEnd, \"battery = 100\");\n",
+    "Show(\"Action durative charge\", charge.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a286df0e-86f2-4441-ae36-16f1508ffc62",
+   "metadata": {},
+   "source": [
+    "## Partie 2 — Algèbre d'intervalles d'Allen\n",
+    "\n",
+    "**Allen (1983)** définit **13 relations binaires** entre deux intervalles temporels $I_1 = [s_1, e_1]$ et $I_2 = [s_2, e_2]$ (avec $s_i < e_i$) : `before`, `after`, `meets`, `met-by`, `overlaps`, `overlapped-by`, `during`, `contains`, `starts`, `started-by`, `finishes`, `finished-by`, `equals`.\n",
+    "\n",
+    "Elles forment une **algèbre de relation** avec une table de composition (si $R_1(I_1,I_2)$ et $R_2(I_2,I_3)$ alors $R_1 \\circ R_2 \\subseteq \\{\\text{relations possibles}\\}(I_1,I_3)$). On implémente la classification par comparaison des bornes, puis la table de composition pour la propagation de contraintes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c8dd5548-0705-46b5-a2fb-3ae93b8358a2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:18.709100Z",
+     "iopub.status.busy": "2026-07-07T00:59:18.708876Z",
+     "iopub.status.idle": "2026-07-07T00:59:19.099396Z",
+     "shell.execute_reply": "2026-07-07T00:59:19.099012Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Allen: Matrice des relations d'Allen :\r\n",
+       "       I1  I2  I3  I4\r\n",
+       "I1  equal        meets        overlaps     contains     \r\n",
+       "I2  met-by       equal        overlapped-by after        \r\n",
+       "I3  overlapped-by overlaps     equal        overlapped-by \r\n",
+       "I4  during       before       overlaps     equal        \r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Inverse de meets: met-by"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Allen Interval Algebra from-scratch ---\n",
+    "public readonly struct Interval\n",
+    "{\n",
+    "    public double Start { get; }\n",
+    "    public double End { get; }\n",
+    "    public string Name { get; }\n",
+    "    public Interval(string name, double s, double e) { Name = name; Start = s; End = e; }\n",
+    "    public double Duration => End - Start;\n",
+    "    public override string ToString() => $\"{Name}[{Start},{End}]\";\n",
+    "}\n",
+    "\n",
+    "public enum AllenRel\n",
+    "{\n",
+    "    Before, After, Meets, MetBy,\n",
+    "    Overlaps, OverlappedBy, During, Contains,\n",
+    "    Starts, StartedBy, Finishes, FinishedBy, Equal\n",
+    "}\n",
+    "\n",
+    "public static class AllenAlgebra\n",
+    "{\n",
+    "    public static string RelStr(AllenRel r) => r switch\n",
+    "    {\n",
+    "        AllenRel.Before => \"before\", AllenRel.After => \"after\",\n",
+    "        AllenRel.Meets => \"meets\", AllenRel.MetBy => \"met-by\",\n",
+    "        AllenRel.Overlaps => \"overlaps\", AllenRel.OverlappedBy => \"overlapped-by\",\n",
+    "        AllenRel.During => \"during\", AllenRel.Contains => \"contains\",\n",
+    "        AllenRel.Starts => \"starts\", AllenRel.StartedBy => \"started-by\",\n",
+    "        AllenRel.Finishes => \"finishes\", AllenRel.FinishedBy => \"finished-by\",\n",
+    "        AllenRel.Equal => \"equal\", _ => \"?\"\n",
+    "    };\n",
+    "\n",
+    "    // Classifie la relation entre deux intervalles (bornes strictement comparees).\n",
+    "    public static AllenRel Classify(Interval a, Interval b)\n",
+    "    {\n",
+    "        const double EPS = 1e-9;\n",
+    "        double s1=a.Start, e1=a.End, s2=b.Start, e2=b.End;\n",
+    "        bool SEq(double x, double y) => Math.Abs(x - y) < EPS;\n",
+    "        if (SEq(s1,s2) && SEq(e1,e2)) return AllenRel.Equal;\n",
+    "        if (SEq(e1,s2)) return AllenRel.Meets;\n",
+    "        if (SEq(s1,e2)) return AllenRel.MetBy;\n",
+    "        if (e1 < s2) return AllenRel.Before;\n",
+    "        if (s1 > e2) return AllenRel.After;\n",
+    "        if (SEq(s1,s2) && e1 < e2) return AllenRel.Starts;\n",
+    "        if (SEq(s1,s2) && e1 > e2) return AllenRel.StartedBy;\n",
+    "        if (SEq(e1,e2) && s1 > s2) return AllenRel.Finishes;\n",
+    "        if (SEq(e1,e2) && s1 < s2) return AllenRel.FinishedBy;\n",
+    "        if (s1 > s2 && e1 < e2) return AllenRel.During;\n",
+    "        if (s1 < s2 && e1 > e2) return AllenRel.Contains;\n",
+    "        if (s1 < s2 && e1 < e2 && e1 > s2) return AllenRel.Overlaps;\n",
+    "        if (s1 > s2 && e1 > e2 && s1 < e2) return AllenRel.OverlappedBy;\n",
+    "        return AllenRel.Equal;\n",
+    "    }\n",
+    "\n",
+    "    // Inverse d'une relation (symetrie de l'algebre d'Allen).\n",
+    "    public static AllenRel Inverse(AllenRel r) => r switch\n",
+    "    {\n",
+    "        AllenRel.Before => AllenRel.After, AllenRel.After => AllenRel.Before,\n",
+    "        AllenRel.Meets => AllenRel.MetBy, AllenRel.MetBy => AllenRel.Meets,\n",
+    "        AllenRel.Overlaps => AllenRel.OverlappedBy, AllenRel.OverlappedBy => AllenRel.Overlaps,\n",
+    "        AllenRel.During => AllenRel.Contains, AllenRel.Contains => AllenRel.During,\n",
+    "        AllenRel.Starts => AllenRel.StartedBy, AllenRel.StartedBy => AllenRel.Starts,\n",
+    "        AllenRel.Finishes => AllenRel.FinishedBy, AllenRel.FinishedBy => AllenRel.Finishes,\n",
+    "        _ => AllenRel.Equal\n",
+    "    };\n",
+    "}\n",
+    "\n",
+    "// --- Demonstration : 4 intervalles ---\n",
+    "var I1 = new Interval(\"I1\", 0, 5);     // [0,5]\n",
+    "var I2 = new Interval(\"I2\", 5, 8);     // meets I1\n",
+    "var I3 = new Interval(\"I3\", 3, 7);     // overlaps I1\n",
+    "var I4 = new Interval(\"I4\", 1, 4);     // during I1\n",
+    "var ivals = new[] { I1, I2, I3, I4 };\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"Matrice des relations d'Allen :\");\n",
+    "sb.AppendLine($\"       {string.Join(\"  \", ivals.Select(i => i.Name))}\");\n",
+    "foreach (var a in ivals)\n",
+    "{\n",
+    "    sb.Append($\"{a.Name}  \");\n",
+    "    foreach (var b in ivals)\n",
+    "        sb.Append($\"{AllenAlgebra.RelStr(AllenAlgebra.Classify(a,b)),-12} \");\n",
+    "    sb.AppendLine();\n",
+    "}\n",
+    "Show(\"Allen\", sb.ToString());\n",
+    "Show(\"Inverse de meets\", AllenAlgebra.RelStr(AllenAlgebra.Inverse(AllenRel.Meets)));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ad7e450-ea3e-4323-8fea-f475854ecedd",
+   "metadata": {},
+   "source": [
+    "## Partie 3 — Réseau temporel simple (STN) et Floyd-Warshall\n",
+    "\n",
+    "Un **Simple Temporal Network** (Dechter, Meiri & Pearl, 1991) est un graphe dont les arêtes contraignent la distance temporelle entre deux événements (timepoints). Une arête $X \\xrightarrow{[a,b]} Y$ impose $a \\leq t_Y - t_X \\leq b$.\n",
+    "\n",
+    "On encode chaque contrainte $[a,b]$ par deux arêtes orientées dans la **matrice des distances** $D$ :\n",
+    "- $D[X,Y] \\leq b$ (borne supérieure),\n",
+    "- $D[Y,X] \\leq -a$ (borne inférieure, retournée).\n",
+    "\n",
+    "Le STN est **consistant** ssi aucun cycle négatif n'apparaît après l'exécution de **Floyd-Warshall** (all-pairs shortest path). Un cycle négatif $\\Rightarrow$ contradiction temporelle insatisfiable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7daf4e07-9ed7-421d-aae6-cef76930f3d2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:19.100719Z",
+     "iopub.status.busy": "2026-07-07T00:59:19.100499Z",
+     "iopub.status.idle": "2026-07-07T00:59:19.248516Z",
+     "shell.execute_reply": "2026-07-07T00:59:19.248166Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "STN 1: STN (4 nodes): X0, A, B, C\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "STN 1 consistant ?: True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Bornes X0->C: [2, 12]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "STN 2 (contradictoire): STN (2 nodes): A, B\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "STN 2 consistant ?: False"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Diagonale (cycle negatif ?): OUI, D[A,A]=-10 (contradiction)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- STN + Floyd-Warshall from-scratch ---\n",
+    "public sealed class STN\n",
+    "{\n",
+    "    public List<string> Nodes { get; } = new();\n",
+    "    public double[,] Dist;   // matrice des distances\n",
+    "    private int n => Nodes.Count;\n",
+    "    public STN(IEnumerable<string> nodes)\n",
+    "    {\n",
+    "        Nodes = nodes.ToList();\n",
+    "        int N = Nodes.Count;\n",
+    "        Dist = new double[N, N];\n",
+    "        for (int i = 0; i < N; i++)\n",
+    "            for (int j = 0; j < N; j++)\n",
+    "                Dist[i, j] = i == j ? 0 : double.PositiveInfinity;\n",
+    "    }\n",
+    "    public int Idx(string node) => Nodes.IndexOf(node);\n",
+    "    // Contrainte a <= tY - tX <= b\n",
+    "    public void AddConstraint(string x, string y, double a, double b)\n",
+    "    {\n",
+    "        int X = Idx(x), Y = Idx(y);\n",
+    "        Dist[X, Y] = Math.Min(Dist[X, Y], b);\n",
+    "        Dist[Y, X] = Math.Min(Dist[Y, X], -a);\n",
+    "    }\n",
+    "    // Floyd-Warshall : retourne true si consistant (pas de cycle negatif).\n",
+    "    public (bool Consistent, double[,] D) FloydWarshall()\n",
+    "    {\n",
+    "        int N = n;\n",
+    "        var D = (double[,])Dist.Clone();\n",
+    "        for (int k = 0; k < N; k++)\n",
+    "            for (int i = 0; i < N; i++)\n",
+    "                for (int j = 0; j < N; j++)\n",
+    "                    if (D[i, k] + D[k, j] < D[i, j])\n",
+    "                        D[i, j] = D[i, k] + D[k, j];\n",
+    "        bool consistent = true;\n",
+    "        for (int i = 0; i < N; i++) if (D[i, i] < 0) consistent = false;\n",
+    "        return (consistent, D);\n",
+    "    }\n",
+    "    public string Dump()\n",
+    "    {\n",
+    "        var sb = new StringBuilder();\n",
+    "        sb.AppendLine($\"STN ({n} nodes): {string.Join(\", \", Nodes)}\");\n",
+    "        return sb.ToString();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- STN consistant : 3 evenements A, B, C ---\n",
+    "var stn1 = new STN(new[] { \"X0\", \"A\", \"B\", \"C\" });\n",
+    "stn1.AddConstraint(\"X0\", \"A\", 1, 5);    // A se produit entre t=1 et t=5\n",
+    "stn1.AddConstraint(\"X0\", \"B\", 2, 8);    // B entre t=2 et t=8\n",
+    "stn1.AddConstraint(\"A\", \"B\", 1, 10);    // B apres A, au moins 1 unite plus tard\n",
+    "stn1.AddConstraint(\"B\", \"C\", 0, 4);     // C apres B, dans les 4 unites\n",
+    "stn1.AddConstraint(\"X0\", \"C\", 0, 15);   // C avant t=15\n",
+    "var (ok1, D1) = stn1.FloydWarshall();\n",
+    "Show(\"STN 1\", stn1.Dump());\n",
+    "Show(\"STN 1 consistant ?\", ok1);\n",
+    "Show(\"Bornes X0->C\", $\"[{-D1[stn1.Idx(\"C\"), stn1.Idx(\"X0\")]}, {D1[stn1.Idx(\"X0\"), stn1.Idx(\"C\")]}]\");\n",
+    "\n",
+    "// --- STN INCONSISTANT : A avant B, B avant A (cycle negatif) ---\n",
+    "var stn2 = new STN(new[] { \"A\", \"B\" });\n",
+    "stn2.AddConstraint(\"A\", \"B\", 5, 10);    // B apres A d'au moins 5\n",
+    "stn2.AddConstraint(\"B\", \"A\", 5, 10);    // A apres B d'au moins 5 => contradiction\n",
+    "var (ok2, D2) = stn2.FloydWarshall();\n",
+    "Show(\"STN 2 (contradictoire)\", stn2.Dump());\n",
+    "Show(\"STN 2 consistant ?\", ok2);\n",
+    "Show(\"Diagonale (cycle negatif ?)\", D2[0,0] < 0 ? $\"OUI, D[A,A]={D2[0,0]} (contradiction)\" : \"non\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a989637d-fde9-4593-a12d-f66457f1dc92",
+   "metadata": {},
+   "source": [
+    "## Partie 4 — Conflits temporels et exclusion mutuelle\n",
+    "\n",
+    "Deux actions duratives sont en **exclusion mutuelle temporelle** si elles ne peuvent pas se chevaucher (par exemple, deux actions utilisant exclusivement la même ressource). On détecte un conflit en testant si leurs intervalles planifiés sont en relation `overlaps` / `during` / `contains` / etc. (tout sauf `before`/`after`/`meets`/`met-by`/`equal` disjoint).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "34a87be1-8984-42a0-8480-6042abdbeb11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:19.249954Z",
+     "iopub.status.busy": "2026-07-07T00:59:19.249708Z",
+     "iopub.status.idle": "2026-07-07T00:59:19.347171Z",
+     "shell.execute_reply": "2026-07-07T00:59:19.346787Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Schedule 1 conflits: AUCUN (OK)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Schedule 2 conflits: weld_A<->weld_B [weld_A[0,5]] vs [weld_B[3,8]]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Detection de conflits temporels ---\n",
+    "public static class TemporalMutex\n",
+    "{\n",
+    "    // Deux intervalles sont-ils en conflit (chevauchement) ?\n",
+    "    public static bool Conflicts(Interval a, Interval b)\n",
+    "    {\n",
+    "        var rel = AllenAlgebra.Classify(a, b);\n",
+    "        // Conflit si les intervalles se chevauchent (pas strictement ordonnes).\n",
+    "        return rel != AllenRel.Before && rel != AllenRel.After\n",
+    "            && rel != AllenRel.Meets && rel != AllenRel.MetBy;\n",
+    "    }\n",
+    "    // Verifie qu'un schedule (liste d'intervalles nommes) n'a pas de conflit 2-a-2.\n",
+    "    public static List<(Interval, Interval)> FindConflicts(List<Interval> schedule)\n",
+    "    {\n",
+    "        var conflicts = new List<(Interval, Interval)>();\n",
+    "        for (int i = 0; i < schedule.Count; i++)\n",
+    "            for (int j = i + 1; j < schedule.Count; j++)\n",
+    "                if (Conflicts(schedule[i], schedule[j]))\n",
+    "                    conflicts.Add((schedule[i], schedule[j]));\n",
+    "        return conflicts;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Schedule sans conflit ---\n",
+    "var sched1 = new List<Interval>\n",
+    "{\n",
+    "    new Interval(\"weld\", 0, 4),\n",
+    "    new Interval(\"paint\", 4, 7),    // meets weld, pas de conflit\n",
+    "    new Interval(\"inspect\", 8, 10), // apres, pas de conflit\n",
+    "};\n",
+    "var conflicts1 = TemporalMutex.FindConflicts(sched1);\n",
+    "Show(\"Schedule 1 conflits\", conflicts1.Count == 0 ? \"AUCUN (OK)\" : string.Join(\"; \", conflicts1.Select(c => $\"{c.Item1.Name}<->{c.Item2.Name}\")));\n",
+    "\n",
+    "// --- Schedule avec conflit (meme machine) ---\n",
+    "var sched2 = new List<Interval>\n",
+    "{\n",
+    "    new Interval(\"weld_A\", 0, 5),\n",
+    "    new Interval(\"weld_B\", 3, 8),    // overlaps weld_A => conflit (1 machine)\n",
+    "};\n",
+    "var conflicts2 = TemporalMutex.FindConflicts(sched2);\n",
+    "Show(\"Schedule 2 conflits\", conflicts2.Count == 0 ? \"AUCUN\" : string.Join(\"; \", conflicts2.Select(c => $\"{c.Item1.Name}<->{c.Item2.Name} [{c.Item1}] vs [{c.Item2}]\")));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0af6f97a-e55e-4e85-8257-007530743e45",
+   "metadata": {},
+   "source": [
+    "## Partie 5 — Ordonnancement (RCPSP-lite) et diagramme de Gantt\n",
+    "\n",
+    "On assemble les briques précédentes : étant donné un ensemble de **tâches** (durée, précédences, demande en ressource) et une **capacité** de ressource, on calcule un **schedule** par heuristique gloutonne (liste de priorité + placement au plus tôt sous contraintes de précédence et de capacité). On produit ensuite un **diagramme de Gantt ASCII**.\n",
+    "\n",
+    "C'est une variante simplifiée du **RCPSP** (Resource-Constrained Project Scheduling Problem, NP-difficile). L'heuristique gloutonne ne garantit pas l'optimalité (makespan minimal) mais produit un schedule réalisable en temps polynomial — la comparaison avec l'optimum known d'un benchmark (ex: PSPLIB) est laissée en exercice.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "91dd4758-156c-4ccc-80ff-eb99121ca072",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:19.348640Z",
+     "iopub.status.busy": "2026-07-07T00:59:19.348434Z",
+     "iopub.status.idle": "2026-07-07T00:59:19.521679Z",
+     "shell.execute_reply": "2026-07-07T00:59:19.521428Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Schedule atelier: Gantt (makespan = 10, capacite = 2):\r\n",
+       "task         |01234567890\r\n",
+       "-------------------------\r\n",
+       "A            |###........\r\n",
+       "B            |##.........\r\n",
+       "C            |...####....\r\n",
+       "D            |..##.......\r\n",
+       "E            |.......###.\r\n",
+       "load         |2222111222.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Makespan: 10"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Realisable ?: OUI (toutes planifiees)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Ordonnancement glouton RCPSP-lite + Gantt ASCII ---\n",
+    "public sealed class Task\n",
+    "{\n",
+    "    public string Name { get; }\n",
+    "    public double Duration { get; }\n",
+    "    public double Demand { get; }                 // demande en ressource\n",
+    "    public List<string> Predecessors { get; } = new();\n",
+    "    public double Start { get; set; } = -1;       // -1 = non planifiee\n",
+    "    public double Finish => Start + Duration;\n",
+    "    public Task(string name, double dur, double demand, params string[] preds)\n",
+    "    { Name = name; Duration = dur; Demand = demand; Predecessors = preds.ToList(); }\n",
+    "}\n",
+    "\n",
+    "public sealed class Scheduler\n",
+    "{\n",
+    "    public double Capacity { get; }\n",
+    "    public Scheduler(double cap) { Capacity = cap; }\n",
+    "\n",
+    "    // Heuristique gloutonne : a chaque pas, planifier la tache disponible\n",
+    "    // (predecesseurs finis) dont le placement au plus tot respecte la capacite.\n",
+    "    // Les evenements temporels = fins de taches deja planifiees (grille discretee).\n",
+    "    public void ScheduleAll(List<Task> tasks)\n",
+    "    {\n",
+    "        var done = new HashSet<string>();\n",
+    "        double horizon = tasks.Sum(t => t.Duration) + 1;\n",
+    "        // Grille de temps fine\n",
+    "        var grid = Enumerable.Range(0, (int)Math.Ceiling(horizon) + 1).Select(i => (double)i).ToList();\n",
+    "        while (done.Count < tasks.Count)\n",
+    "        {\n",
+    "            // Taches disponibles\n",
+    "            var ready = tasks.Where(t => !done.Contains(t.Name)\n",
+    "                && t.Predecessors.All(p => done.Contains(p))).ToList();\n",
+    "            if (ready.Count == 0) { /* deadlock cyclique */ break; }\n",
+    "            // Par priorite : duree la plus longue d'abord (LPT heuristic)\n",
+    "            ready = ready.OrderByDescending(t => t.Duration).ToList();\n",
+    "            bool placed = false;\n",
+    "            foreach (var t in ready)\n",
+    "            {\n",
+    "                // Trouver le plus tot start >= max(fins predecesseurs) tel que\n",
+    "                // pendant [start, start+dur] la capacite est respectee a tout instant.\n",
+    "                double earliest = t.Predecessors.Count == 0 ? 0\n",
+    "                    : t.Predecessors.Max(p => tasks.First(x => x.Name == p).Finish);\n",
+    "                for (double s = earliest; s <= horizon; s += 1.0)\n",
+    "                {\n",
+    "                    bool ok = true;\n",
+    "                    for (double tt = s; tt < s + t.Duration; tt += 1.0)\n",
+    "                    {\n",
+    "                        double used = tasks.Where(x => x.Start >= 0\n",
+    "                            && tt >= x.Start && tt < x.Start + x.Duration).Sum(x => x.Demand);\n",
+    "                        if (used + t.Demand > Capacity + 1e-9) { ok = false; break; }\n",
+    "                    }\n",
+    "                    if (ok) { t.Start = s; done.Add(t.Name); placed = true; break; }\n",
+    "                }\n",
+    "                if (placed) break;\n",
+    "                if (!placed && t.Start < 0) { /* impossible ce tour */ }\n",
+    "            }\n",
+    "            if (!placed) break;  // aucun placement possible => arreter (evite boucle infinie)\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    // Diagramme de Gantt ASCII : lignes = taches, colonnes = unites de temps.\n",
+    "    public string Gantt(List<Task> tasks)\n",
+    "    {\n",
+    "        double makespan = tasks.Max(t => t.Finish);\n",
+    "        int W = (int)Math.Ceiling(makespan) + 1;\n",
+    "        var sb = new StringBuilder();\n",
+    "        sb.AppendLine($\"Gantt (makespan = {makespan}, capacite = {Capacity}):\");\n",
+    "        sb.Append(\"task\".PadRight(12) + \" |\");\n",
+    "        for (int t = 0; t < W; t++) sb.Append((t % 10).ToString());\n",
+    "        sb.AppendLine();\n",
+    "        sb.AppendLine(new string('-', 14 + W));\n",
+    "        foreach (var t in tasks)\n",
+    "        {\n",
+    "            sb.Append(t.Name.PadRight(12) + \" |\");\n",
+    "            var row = new string('.', W).ToCharArray();\n",
+    "            for (int k = 0; k < W; k++)\n",
+    "                if (k >= t.Start && k < t.Start + t.Duration) row[k] = '#';\n",
+    "            sb.AppendLine(new string(row));\n",
+    "        }\n",
+    "        // Usage de capacite par unite de temps\n",
+    "        sb.Append(\"load\".PadRight(12) + \" |\");\n",
+    "        for (int k = 0; k < W; k++)\n",
+    "        {\n",
+    "            double used = tasks.Where(x => x.Start >= 0 && k >= x.Start && k < x.Start + x.Duration).Sum(x => x.Demand);\n",
+    "            sb.Append(used == 0 ? \".\" : Math.Floor(used).ToString());\n",
+    "        }\n",
+    "        sb.AppendLine();\n",
+    "        return sb.ToString();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- Scenario : atelier avec 2 machines (capacite = 2) ---\n",
+    "var tasks = new List<Task>\n",
+    "{\n",
+    "    new Task(\"A\", 3, 1),             // duree 3, demande 1 machine\n",
+    "    new Task(\"B\", 2, 1),\n",
+    "    new Task(\"C\", 4, 1, \"A\"),        // C apres A\n",
+    "    new Task(\"D\", 2, 1, \"B\"),\n",
+    "    new Task(\"E\", 3, 2, \"C\", \"D\"),   // E apres C et D, demande 2 machines\n",
+    "};\n",
+    "var sched = new Scheduler(2);\n",
+    "sched.ScheduleAll(tasks);\n",
+    "Show(\"Schedule atelier\", sched.Gantt(tasks));\n",
+    "Show(\"Makespan\", tasks.Max(t => t.Finish));\n",
+    "Show(\"Realisable ?\", tasks.All(t => t.Start >= 0) ? \"OUI (toutes planifiees)\" : \"NON (certaines non placees)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d92c904-c43a-4067-9d50-c7ee0f788694",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# a reconstruit **from-scratch** les 4 piliers de la planification temporelle :\n",
+    "\n",
+    "1. **PDDL 2.1 actions duratives** — conditions `at start`/`over all`/`at end`, effets (Partie 1).\n",
+    "2. **Algèbre d'intervalles d'Allen** — 13 relations, classification, inverse (Partie 2).\n",
+    "3. **Réseau temporel simple (STN)** — matrice des distances, Floyd-Warshall, consistance (Partie 3).\n",
+    "4. **Conflits temporels et scheduling** — exclusion mutuelle, RCPSP-lite glouton, Gantt ASCII (Parties 4-5).\n",
+    "\n",
+    "Le notebook Python original atteint ces concepts via **`unified_planning` + `ortools` CP-SAT** ; le twin C# les rend **transparents et exécutables** sans dépendance externe.\n",
+    "\n",
+    "### Limitations\n",
+    "\n",
+    "- L'algorithme de scheduling est **glouton (LPT)**, non optimal (RCPSP est NP-difficile).\n",
+    "- La table de **composition d'Allen** complète (213 entrées) n'est pas implémentée (exercice).\n",
+    "- La sémantique PDDL 2.1 est **conceptuelle** (pas de solveur complet).\n",
+    "\n",
+    "## Exercices\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5f74acc6-30f9-4629-a38c-d501d9c41194",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:19.523036Z",
+     "iopub.status.busy": "2026-07-07T00:59:19.522787Z",
+     "iopub.status.idle": "2026-07-07T00:59:19.600103Z",
+     "shell.execute_reply": "2026-07-07T00:59:19.599744Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Compose(before,before):  (a completer)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Table de composition d'Allen\n",
+    "// TODO etudiant : implementez la table de composition COMPOSE(R1, R2) retourmant\n",
+    "// l'ENSEMBLE des relations possibles entre I1 et I3 sachant R1(I1,I2) et R2(I2,I3).\n",
+    "// Indice : Allen 1983, Table III. Pour before o before = {before}, etc.\n",
+    "// Etape 1 : representer la table par un dictionnaire (R1,R2) -> HashSet<AllenRel>.\n",
+    "// Etape 2 : remplir au moins before/after/meets/equals (les cas les plus frequents).\n",
+    "public static HashSet<AllenRel> Compose(AllenRel r1, AllenRel r2)\n",
+    "{\n",
+    "    // TODO etudiant\n",
+    "    var result = new HashSet<AllenRel>();\n",
+    "    // Indice : before o before = {before}. Commencez par ce cas.\n",
+    "    return result;\n",
+    "}\n",
+    "Show(\"Compose(before,before)\", string.Join(\",\", Compose(AllenRel.Before, AllenRel.Before).Select(AllenAlgebra.RelStr)) + \" (a completer)\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9d79467d-4264-4b9d-ade1-95b9663bea40",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:19.601415Z",
+     "iopub.status.busy": "2026-07-07T00:59:19.601219Z",
+     "iopub.status.idle": "2026-07-07T00:59:19.658907Z",
+     "shell.execute_reply": "2026-07-07T00:59:19.658427Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Deadline a 12 (a completer): True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Deadline dans le STN\n",
+    "// TODO etudiant : ajoutez une contrainte de deadline (t_C <= T_max) au STN1\n",
+    "// et verifiez la consistan ce. Indice : AddConstraint(\"X0\", \"C\", 0, T_max).\n",
+    "// Etape 1 : choisir un T_max (ex: 12). Etape 2 : re-invoquer FloydWarshall.\n",
+    "public static bool DeadlineConsistent(STN stn, string node, double deadline)\n",
+    "{\n",
+    "    // TODO etudiant\n",
+    "    return true;  // retournez vrai si le STN + deadline reste consistant\n",
+    "}\n",
+    "Show(\"Deadline a 12 (a completer)\", DeadlineConsistent(stn1, \"C\", 12.0));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3b931b8c-47b9-40b7-91de-74d22c818007",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T00:59:19.660617Z",
+     "iopub.status.busy": "2026-07-07T00:59:19.660390Z",
+     "iopub.status.idle": "2026-07-07T00:59:19.687335Z",
+     "shell.execute_reply": "2026-07-07T00:59:19.686977Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Makespan optimal (a completer): ∞"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Optimalite du makespan (comparaison brute-force)\n",
+    "// TODO etudiant : pour le scenario atelier (5 taches), calculez le makespan OPTIMAL\n",
+    "// par enumeration des permutations valides (precedence-respecting topological orders)\n",
+    "// et comparez avec le makespan glouton ci-dessus.\n",
+    "// Indice : enumerer les ordres topologiques, pour chacun simuler ScheduleAll, garder min.\n",
+    "// Etape 1 : enumerer les ordres topologiques des taches. Etape 2 : evaluer chacun.\n",
+    "public static double OptimalMakespan(List<Task> tasks, double capacity)\n",
+    "{\n",
+    "    // TODO etudiant\n",
+    "    return double.PositiveInfinity;  // retournez le makespan minimal\n",
+    "}\n",
+    "Show(\"Makespan optimal (a completer)\", OptimalMakespan(tasks, 2.0));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf574749-2b30-479c-b9ba-f1dd57b5ee3d",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "*Twin C# du notebook Python `Planners-8-Temporal.ipynb`. Marathon parité .NET ⇄ Python (#4956, Prong B). From-scratch BCL .NET, 0 NuGet, 0 unified_planning / ortools.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": "csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -129,6 +129,7 @@ SymbolicAI/Planners/
 ├── 03-Advanced/
 │   ├── Planners-7-OR-Tools.ipynb        # CP-SAT
 │   ├── Planners-8-Temporal.ipynb        # Planification temporelle
+│   ├── Planners-8-Temporal-Csharp.ipynb # Twin C# Allen + STN + RCPSP-lite from-scratch (See #4956)
 │   ├── Planners-9-HTN.ipynb             # Planification hiérarchique
 │   └── Planners-9-HTN-Csharp.ipynb      # Twin C# SHOP2 HTN solver from-scratch (See #4956)
 ├── 04-NeuroSymbolic/
@@ -224,6 +225,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 |---|----------|--------|---------|-------|
 | 7 | [Planners-7-OR-Tools](03-Advanced/Planners-7-OR-Tools.ipynb) | Python | CP-SAT, programmation par contraintes, scheduling | 45 min |
 | 8 | [Planners-8-Temporal](03-Advanced/Planners-8-Temporal.ipynb) | Python | PDDL 2.1, durées, parallélisme, ordonnancement | 40 min |
+| 8 (C#) | [Planners-8-Temporal-Csharp](03-Advanced/Planners-8-Temporal-Csharp.ipynb) | .NET (C#) | Twin C# du 8 : PDDL 2.1 actions duratives + algèbre d'Allen (13 relations) + STN Floyd-Warshall + RCPSP-lite glouton + Gantt ASCII from-scratch (See #4956) | 40 min |
 | 9 | [Planners-9-HTN](03-Advanced/Planners-9-HTN.ipynb) | Python | Hierarchical Task Networks, méthodes, décomposition | 45 min |
 | 9 (C#) | [Planners-9-HTN-Csharp](03-Advanced/Planners-9-HTN-Csharp.ipynb) | .NET (C#) | Twin C# du 9 : solveur HTN SHOP2 from-scratch (State/Pred, Methods, backtracking), domaines Logistics + Cafe (See #4956) | 40 min |
 


### PR DESCRIPTION
## Summary

Twin C# (.NET Interactive, **BCL .NET 10, 0 NuGet, 0 `unified_planning`, 0 `ortools`**) du notebook Python `Planners-8-Temporal.ipynb`. EPIC **#4956** Prong B (value-add : transparence des mécanismes vs libs Python).

Le notebook Python original s'appuie sur **`unified_planning`** + **`ortools` CP-SAT** pour exprimer et résoudre le problème temporel. Ce twin reconstruit **from-scratch les concepts** — Allen, STN, Floyd-Warshall, scheduling — pour les rendre observables et exécutables sur toute machine .NET 9+.

## Contenu (4 piliers, from-scratch)

1. **PDDL 2.1 actions duratives** — `DurativeAction`, conditions `at start`/`over all`/`at end`, effets (Fox & Long, 2003).
2. **Algèbre d'intervalles d'Allen** — 13 relations (Allen 1983), classification par comparaison de bornes, inverse.
3. **STN (Simple Temporal Network)** — matrice des distances, **Floyd-Warshall**, détection de cycle négatif (Dechter, Meiri & Pearl, 1991).
4. **Conflits temporels + scheduling** — exclusion mutuelle temporelle, **RCPSP-lite glouton (LPT)**, diagramme de **Gantt ASCII**.

## Validation

- **EXEC_PROVED** via `nbconvert --execute --kernel .net-csharp` : 9 code cells, `execution_count` 1-9, 0 error, 0 warning CS, 0 path-leak.
- **C.1 conforme** : 0 `raise`/`assert False`/`1/0`. 3 exercices stubs (table composition Allen, deadline STN, makespan optimal brute-force).
- **Math verification firsthand** :
  - **STN1** (4 nodes : X0,A,B,C) consistant = `True` ; bornes X0→C propagées.
  - **STN2** contradictoire (A après B d'au moins 5 **et** B après A d'au moins 5) consistant = `False` via cycle négatif `D[A,A] < 0`.
  - **Conflits** : schedule 2 détecte `weld_A <-> weld_B` (overlaps, même machine).
  - **Atelier** (5 tâches, capacité 2) : LPT glouton → makespan = **10** (A[0,3]+B[0,2] parallèle cap=2, C[3,7] après A, D[2,4] après B, E[7,10] après C+D demande 2 machines), réalisable OUI.
- **G.1 self-correction** : bug CS1739 (`Scheduler(capacity: 2)` → `Scheduler(2)`, param constructeur `cap`) corrigé avant commit.

## §E README

+1 ligne table mapping (`8 (C#)`) + +1 ligne arborescence. **CATALOG-STATUS byte-identique** (catalog-pr-hygiene HARD 1).

## Verdict SOTA (EPIC #3801)

**SOTA-OK** : twin from-scratch C# pur. Le notebook Python = `unified_planning` + `ortools` CP-SAT (RECOVERABLE-MACHINE via NuGet, mais le twin from-scratch est le value-add Prong B — Allen/STN/Floyd-Warshall/scheduling observables dans le code C#). Complémentaire, non redondant.

See #4956.