### PR TITLE
fix(gitattributes): enforce LF on source/config files (*.sh, *.lean, *.env, *.en.md) — L268 root-cause

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,18 @@
 COURSE_CATALOG.generated.json text eol=lf
 MyIA.AI.Notebooks/README.md text eol=lf
 MyIA.AI.Notebooks/*/README.md text eol=lf
+# Source/config files that are consumed by Linux/WSL tooling (Lean lakes,
+# shell scripts, env files) MUST be LF — a CRLF shebang (e.g. "#!/bin/bash\r")
+# breaks WSL with "bad interpreter", and CRLF in .lean breaks lake on Linux.
+# Pattern "L268": the Edit tool on Windows flips LF->CRLF intermittently when
+# no explicit eol rule is set. Found 5x (i18n *.en.md c.268, *.sh + .env c.281).
+*.lean text eol=lf
+*.sh text eol=lf
+.env text eol=lf
+.env.example text eol=lf
+*.en.md text eol=lf
+# Lean lake manifests are JSON consumed cross-platform; keep LF.
+lake-manifest.json text eol=lf
 # Git LFS tracking for model files referenced by notebooks
 *.pt filter=lfs diff=lfs merge=lfs -text
 *.pkl filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary

Structural **root-cause** fix for the **L268 CRLF pattern**: the Windows Edit tool intermittently flips `LF→CRLF` on files that lack an explicit `text eol=lf` rule in `.gitattributes`. **5 cluster-wide occurrences** to date:

| # | Where | Cycle | Impact |
|---|-------|-------|--------|
| 1 | i18n `*.en.md` siblings (i18n rollout) | c.268 | masked churn |
| 2 | `_run_lean_snippet.sh` shebang | c.281 | **`#!/bin/bash\r` → WSL "bad interpreter"** |
| 3 | `.env.example` (142/142 symmetric churn) | c.281 | masked churn |
| 4–5 | (residual occurrences tracked under L268) | — | — |

## What this PR does

Adds **6 explicit `text eol=lf` rules** for source/config files consumed by Linux/WSL tooling:

- `*.lean` — CRLF breaks `lake` on Linux
- `*.sh` — CRLF shebang breaks WSL with `bad interpreter: /bin/bash\r: No such file or directory`
- `.env` / `.env.example` — consumed by Linux/Docker tooling
- `*.en.md` — i18n siblings, same L268 flip observed
- `lake-manifest.json` — cross-platform JSON (Lean lakes)

## Preventive, NOT renormalizing (verified)

This rule set affects **future commits only**. Verified no churn on existing files:

```
$ git add .gitattributes && git status --short
M  .gitattributes          # only this file
```

Staging the `.gitattributes` change reveals **no CRLF churn** on existing `.sh`/`.lean`/`.env`/`*.en.md` files in the tree — confirming this is purely preventive and does **not** introduce a wide renormalization (the exact failure mode that poisoned the catalog in `catalog-pr-hygiene` HARD 1).

## Closes the loop I flagged twice

I explicitly recommended this structural fix as "hors scope" in two prior contributions:

- **#5589** body: *"Suggestion hors scope : ajouter `*.en.md text eol=lf` dans `.gitattributes` pour fix structurel"*
- **#5594** cross-review (my finding): *"Fix structurel (follow-up, hors scope) : ajouter dans `.gitattributes` `*.sh text eol=lf` ... C'est exactement la suggestion que j'avais faite dans #5589"*

This PR delivers that follow-up atomically.

## §E (catalog-drift / README)

This PR touches **only** `.gitattributes` (not a README, not the catalog). The `COURSE_CATALOG.generated.*` + README `text eol=lf` rules (already present, lines 6-8) are unchanged byte-for-byte. **CATALOG-STATUS: N/A** (no README/catalog touched).

## Atomic / single-subject

1 file changed, +12 lines, 0 deletions. No code, no renormalization, no cross-file churn. Matches `catalog-pr-hygiene` HARD 3 (one subject per PR) and the `git-workflow` branch discipline.

## Test plan

- [x] Meta-check: the edited `.gitattributes` is itself LF (0 CR, `od -c` verified) — no L268 self-pollution
- [x] Impact test: staging reveals **no CRLF churn** on existing files (preventive confirmed)
- [x] Diff is `+12/-0` (purely additive comment + rules)
- [x] Base is fresh `origin/main` (`e8107684`, no stale-base label)
- [x] No secret / no inline literal introduced

See #5589, #5594. L268 root-cause follow-up.