### PR TITLE
feat(tweety): Tweety-7a-Extended-Frameworks-Csharp — ADF/SetAF/EAF/VAF twin (.NET parity #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -194,6 +194,7 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 6  | [Tweety-6-Structured-Argumentation](Tweety-6-Structured-Argumentation.ipynb) | ASPIC+, DeLP, ABA, ASP                            | 60 min  | Python |
 | 6c | [Tweety-6-Structured-Argumentation-Csharp](Tweety-6-Structured-Argumentation-Csharp.ipynb) | Twin C# ASPIC+ from-scratch (BCL, pas IKVM ; DeLP/ABA/ASP conceptuel) | 35 min | C# PROD |
 | 7a | [Tweety-7a-Extended-Frameworks](Tweety-7a-Extended-Frameworks.ipynb) | ADF, Bipolar, WAF, SAF, SetAF, Extended             | 50 min  | Python |
+| 7ac | [Tweety-7a-Extended-Frameworks-Csharp](Tweety-7a-Extended-Frameworks-Csharp.ipynb) | Twin C# ADF/SetAF/EAF/VAF from-scratch (BCL, Kleene 3-valued, 0 jpype/JVM ; See #4956) | 55 min | C# PROD |
 | 7b | [Tweety-7b-Ranking-Probabilistic](Tweety-7b-Ranking-Probabilistic.ipynb) | Ranking Semantics, Probabiliste                   | 40 min  | Python |
 | 7bc | [Tweety-7b-Ranking-Probabilistic-Csharp](Tweety-7b-Ranking-Probabilistic-Csharp.ipynb) | Ranking/Probabiliste .NET (IKVM, c.179 PR #5231) | 30 min  | C# PROD |
 | **Applications** |
@@ -349,6 +350,7 @@ Tweety/
 ├── Tweety-6-Structured-Argumentation.ipynb       # ASPIC+, DeLP, ABA, ASP
 ├── Tweety-6-Structured-Argumentation-Csharp.ipynb # Twin C# ASPIC+ from-scratch (BCL)
 ├── Tweety-7a-Extended-Frameworks.ipynb           # ADF, Bipolar, WAF, SAF
+├── Tweety-7a-Extended-Frameworks-Csharp.ipynb    # Twin C# ADF/SetAF/EAF/VAF from-scratch (BCL, 0 JVM)
 ├── Tweety-7b-Ranking-Probabilistic.ipynb         # Ranking Semantics
 ├── Tweety-7b-Ranking-Probabilistic-Csharp.ipynb  # Ranking/Probabiliste .NET
 ├── Tweety-8-Agent-Dialogues.ipynb                # Agents, dialogues, loteries

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
@@ -356,9 +356,9 @@
    "source": [
     "### 3.3 Interpretation : pourquoi c'est plus expressif que Dung\n",
     "\n",
-    "Dans un cadre de Dung, l'attaque `c -> b` signifie \"c refute b\" mais c'est **binaire** : si c est accepte, b est拒e. L'ADF permet des conditions **arbitraires** : `b = not(c) and d`, `a = b or c`, etc. La condition d'acceptation est une formule logique complete, pas juste une liste d'attaquants.\n",
+    "Dans un cadre de Dung, l'attaque `c -> b` signifie \"c refute b\" mais c'est **binaire** : si c est accepte, b est rejete. L'ADF permet des conditions **arbitraires** : `b = not(c) and d`, `a = b or c`, etc. La condition d'acceptation est une formule logique complete, pas juste une liste d'attaquants.\n",
     "\n",
-    "Ici l'exemple est simple mais demontre le mecanisme : `c` est un **fait** (tautologie), `b` est defini comme le reflet de `not c`, et `a` comme `not b`. Le fixed-point converge en une seule iteration complete car il n'y a pas de cycle (c force, b depend de c, a depend de b).\n"
+    "Ici l'exemple est simple mais demontre le mecanisme : `c` est un **fait** (tautologie), `b` est defini comme le reflet de `not c`, et `a` comme `not b`. Le fixed-point converge en une seule iteration complete car il n'y a pas de cycle (c force, b depend de c, a depend de b)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
@@ -1,0 +1,967 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e5b98aaf",
+   "metadata": {},
+   "source": [
+    "# Tweety-7a : Frameworks d'Argumentation Etendus (C#)\n",
+    "\n",
+    "**Navigation** : [<< 6-Structured-Argumentation](Tweety-6-Structured-Argumentation.ipynb) | [Index](README.md) | [7b-Ranking-Probabilistic >>](Tweety-7b-Ranking-Probabilistic.ipynb)\n",
+    "\n",
+    "## Frameworks d'Argumentation Etendus (jumeau .NET)\n",
+    "\n",
+    "Ce notebook est le **jumeau C# (.NET Interactive)** de [Tweety-7a-Extended-Frameworks.ipynb](Tweety-7a-Extended-Frameworks.ipynb). Au-dela du cadre abstrait de Dung (Tweety-5), il explore les **frameworks etendus** : ADF (conditions d'acceptation), SetAF (attaques ensembles), EAF (attaques sur les attaques), VAF (argumentation value-based).\n",
+    "\n",
+    "### Value-add du jumeau C# (Prong B, EPIC #3801)\n",
+    "\n",
+    "Le twin Python s'appuie sur **jpype + la JVM Tweety** (`org.tweetyproject.arg.adf`, `.bipolar`, `.setaf`, `.eaf`, ...) pour evaluer les semantiques. Ce jumeau reimplémente tout **from-scratch en C# / BCL .NET 9** :\n",
+    "\n",
+    "| Pilier | Python (Tweety JVM via jpype) | C# (from-scratch) |\n",
+    "|--------|-------------------------------|-------------------|\n",
+    "| **ADF** (Abstract Dialectical Framework) | `AbstractDialecticalFramework` + solveur SAT NativeMinisat | conditions d'acceptation comme `Func<>`, **logique 3-valued de Kleene**, fixed-point grounded |\n",
+    "| **SetAF** (Nielsen-Parsons 2011) | `SetAttack` Tweety | attaques `HashSet<string> -> string`, labelling grounded (attaque active ssi tous attaquants IN) |\n",
+    "| **EAF** (Modgil, attaques sur attaques) | `RecursiveAttack` Tweety | meta-attaques `(c,(a,b))`, revocateur d'attaque -> reinstatement |\n",
+    "| **VAF** (Bench-Capon, value-based) | raisonneur Tweety | ordre sur les valeurs -> defeat conditionnel |\n",
+    "\n",
+    "### Objectifs d'apprentissage\n",
+    "- Comprendre comment les ADF generalisent Dung via des **conditions d'acceptation**.\n",
+    "- Maitriser les attaques d'**ensembles** (SetAF) et les **meta-attaques** (EAF).\n",
+    "- Voir comment les **valeurs** (VAF) rendent la defaite conditionnelle a un ordre de preference.\n",
+    "\n",
+    "### Duree estimee : 55 minutes\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8882d6c7",
+   "metadata": {},
+   "source": [
+    "## 1. Pourquoi etendre le cadre de Dung ?\n",
+    "\n",
+    "Le cadre abstrait de Dung (1995, voir [Tweety-5](Tweety-5-Abstract-Argumentation.ipynb)) modelise l'attaque binaire `a -> b` entre arguments entiers. Mais la realite argumentative est plus riche :\n",
+    "\n",
+    "- **Conditions d'acceptation** : la validite de `a` peut dependre d'une formule logique sur d'autres arguments (ADF).\n",
+    "- **Attaques collectives** : un *ensemble* d'arguments peut etre requis pour en attaquer un (SetAF).\n",
+    "- **Attaques d'attaques** : un argument peut attaquer une *attaque* elle-meme, la revoquant (EAF, Modgil 2010).\n",
+    "- **Valeurs** : chaque argument promeut une valeur ; la defaite depend d'un ordre de valeurs (VAF, Bench-Capon 2003).\n",
+    "\n",
+    "Nous implementons ces 4 extensions **from-scratch**, avec a chaque fois un exemple **verifiable analytiquement** (re-derivation a la main de l'extension grounded).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07a8453b",
+   "metadata": {},
+   "source": [
+    "## 2. Brique commune : logique 3-valued de Kleene\n",
+    "\n",
+    "Les ADF utilisent une logique a **trois valeurs** : Vrai (T), Faux (F), Indetermine (U). La negation, conjonction, disjonction suivent les tables de **Kleene** (U propage l'incertitude) :\n",
+    "\n",
+    "| `a` | `b` | `a AND b` | `a OR b` | `NOT a` |\n",
+    "|-----|-----|-----------|----------|---------|\n",
+    "| T | T | T | T | F |\n",
+    "| T | F | F | T | F |\n",
+    "| T | U | U | T | F |\n",
+    "| F | U | F | U | T |\n",
+    "| U | U | U | U | U |\n",
+    "\n",
+    "Le `U` represente \"pas encore decide\". La semantique grounded d'un ADF est un **fixed-point 3-valued** : on part de tout-U et on propage jusqu'a stabilisation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "48b92c85",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:34.597288Z",
+     "iopub.status.busy": "2026-07-07T01:33:34.591542Z",
+     "iopub.status.idle": "2026-07-07T01:33:36.350004Z",
+     "shell.execute_reply": "2026-07-07T01:33:36.346125Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '30564.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Kleene: Not(T)=f, And(T,U)=u, Or(F,U)=u"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Prong B (#3801): 0 NuGet, 0 jpype, 0 IKVM, 0 JVM. BCL .NET 9 uniquement.\n",
+    "using System;\n",
+    "using System.Text;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// --- Logique 3-valued (Kleene) : T=true, F=false, U=null ---\n",
+    "public enum Tri { T, F, U }\n",
+    "\n",
+    "public static class Kleene\n",
+    "{\n",
+    "    public static Tri Not(Tri x) => x == Tri.T ? Tri.F : (x == Tri.F ? Tri.T : Tri.U);\n",
+    "    public static Tri And(Tri a, Tri b)\n",
+    "    {\n",
+    "        if (a == Tri.F || b == Tri.F) return Tri.F;\n",
+    "        if (a == Tri.T && b == Tri.T) return Tri.T;\n",
+    "        return Tri.U;\n",
+    "    }\n",
+    "    public static Tri Or(Tri a, Tri b)\n",
+    "    {\n",
+    "        if (a == Tri.T || b == Tri.T) return Tri.T;\n",
+    "        if (a == Tri.F && b == Tri.F) return Tri.F;\n",
+    "        return Tri.U;\n",
+    "    }\n",
+    "    public static string Str(Tri x) => x == Tri.T ? \"t\" : (x == Tri.F ? \"f\" : \"u\");\n",
+    "}\n",
+    "\n",
+    "public static void Show(string label, string s) => $\"{label}: {s}\".Display();\n",
+    "\n",
+    "Show(\"Kleene\", $\"Not(T)={Kleene.Str(Kleene.Not(Tri.T))}, And(T,U)={Kleene.Str(Kleene.And(Tri.T,Tri.U))}, Or(F,U)={Kleene.Str(Kleene.Or(Tri.F,Tri.U))}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ff21056",
+   "metadata": {},
+   "source": [
+    "## 3. Abstract Dialectical Frameworks (ADF)\n",
+    "\n",
+    "Un **ADF** (Brewka & Woltran 2010) associe a chaque argument `a` une **condition d'acceptation** `C(a)` : une formule logique sur les autres arguments. `a` est accepte ssi `C(a)` est satisfaite.\n",
+    "\n",
+    "### 3.1 Semantique grounded (fixed-point 3-valued)\n",
+    "\n",
+    "On part de l'interpretation `I0` ou tout est `U` (indetermine). A chaque tour, on evalue `C(a)` sous l'interpretation courante (en logique 3-valued). Si `C(a)` donne `T`, `a` devient `T` ; si `F`, `a` devient `F` ; si `U`, `a` reste `U`. On itere jusqu'au fixed-point : c'est l'**extension grounded**.\n",
+    "\n",
+    "### 3.2 Exemple (verifiable a la main)\n",
+    "\n",
+    "Trois arguments avec leurs conditions :\n",
+    "- `a : not b` (a accepte ssi b est faux)\n",
+    "- `c : T` (c toujours accepte - tautologie)\n",
+    "- `b : not c` (b accepte ssi c est faux)\n",
+    "\n",
+    "**Re-derivation** : `c = T` (tautologie). Donc `b = not c = not T = F`. Donc `a = not b = not F = T`. Resultat attendu : `{a=T, c=T, b=F}`, extension grounded `{a, c}`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5a5d3b6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:36.351577Z",
+     "iopub.status.busy": "2026-07-07T01:33:36.351382Z",
+     "iopub.status.idle": "2026-07-07T01:33:36.711831Z",
+     "shell.execute_reply": "2026-07-07T01:33:36.711407Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ADF: ADF : a:not(b), c:T, b:not(c)\r\n",
+       "  Interpretation grounded :\r\n",
+       "    a = t\r\n",
+       "    c = t\r\n",
+       "    b = f\r\n",
+       "  Extension grounded (args True) : {a, c}\r\n",
+       "\r\n",
+       "  Re-derivation : c=T (tautologie) -> b=not c=F -> a=not b=T -> {a,c}.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- ADF from-scratch : conditions d'acceptation 3-valued + grounded fixed-point ---\n",
+    "// Une condition d'acceptation = fonction (interpretation -> Tri).\n",
+    "using Interpretation = System.Collections.Generic.Dictionary<string, Tri>;\n",
+    "\n",
+    "public sealed class ADF\n",
+    "{\n",
+    "    public List<string> Args { get; } = new();\n",
+    "    public Dictionary<string, Func<Interpretation, Tri>> Conditions { get; } = new();\n",
+    "    public void Add(string a, Func<Interpretation, Tri> cond) { Args.Add(a); Conditions[a] = cond; }\n",
+    "\n",
+    "    // Grounded = fixed-point depuis tout-U.\n",
+    "    public Interpretation Grounded()\n",
+    "    {\n",
+    "        var I = new Interpretation();\n",
+    "        foreach (var a in Args) I[a] = Tri.U;\n",
+    "        bool changed = true;\n",
+    "        while (changed)\n",
+    "        {\n",
+    "            changed = false;\n",
+    "            foreach (var a in Args)\n",
+    "            {\n",
+    "                Tri cur = I[a];\n",
+    "                Tri val = Conditions[a](I);   // evalue C(a) sous interpretation courante\n",
+    "                if (val != cur) { I[a] = val; changed = true; }\n",
+    "            }\n",
+    "        }\n",
+    "        return I;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Helpers : references a un argument, constantes T/F\n",
+    "Func<Interpretation, Tri> Var(string x) => I => I.TryGetValue(x, out var v) ? v : Tri.U;\n",
+    "Func<Interpretation, Tri> Const(Tri c) => I => c;\n",
+    "Func<Interpretation, Tri> Neg(Func<Interpretation, Tri> p) => I => Kleene.Not(p(I));\n",
+    "Func<Interpretation, Tri> AndF(Func<Interpretation, Tri> p, Func<Interpretation, Tri> q) => I => Kleene.And(p(I), q(I));\n",
+    "Func<Interpretation, Tri> OrF(Func<Interpretation, Tri> p, Func<Interpretation, Tri> q) => I => Kleene.Or(p(I), q(I));\n",
+    "\n",
+    "var adf = new ADF();\n",
+    "adf.Add(\"a\", Neg(Var(\"b\")));   // a : not b\n",
+    "adf.Add(\"c\", Const(Tri.T));    // c : T\n",
+    "adf.Add(\"b\", Neg(Var(\"c\")));   // b : not c\n",
+    "\n",
+    "var g = adf.Grounded();\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"ADF : a:not(b), c:T, b:not(c)\");\n",
+    "sb.AppendLine(\"  Interpretation grounded :\");\n",
+    "foreach (var a in adf.Args)\n",
+    "    sb.AppendLine($\"    {a} = {Kleene.Str(g[a])}\");\n",
+    "var groundedSet = adf.Args.Where(a => g[a] == Tri.T).ToList();\n",
+    "sb.AppendLine($\"  Extension grounded (args True) : {{{string.Join(\", \", groundedSet)}}}\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(\"  Re-derivation : c=T (tautologie) -> b=not c=F -> a=not b=T -> {a,c}.\");\n",
+    "Show(\"ADF\", sb.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9214d39b",
+   "metadata": {},
+   "source": [
+    "### 3.3 Interpretation : pourquoi c'est plus expressif que Dung\n",
+    "\n",
+    "Dans un cadre de Dung, l'attaque `c -> b` signifie \"c refute b\" mais c'est **binaire** : si c est accepte, b est拒e. L'ADF permet des conditions **arbitraires** : `b = not(c) and d`, `a = b or c`, etc. La condition d'acceptation est une formule logique complete, pas juste une liste d'attaquants.\n",
+    "\n",
+    "Ici l'exemple est simple mais demontre le mecanisme : `c` est un **fait** (tautologie), `b` est defini comme le reflet de `not c`, et `a` comme `not b`. Le fixed-point converge en une seule iteration complete car il n'y a pas de cycle (c force, b depend de c, a depend de b).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "595e8fa5",
+   "metadata": {},
+   "source": [
+    "## 4. SetAF : attaques d'ensembles (Nielsen-Parsons 2011)\n",
+    "\n",
+    "Dans un **SetAF**, une attaque part d'un **ensemble** d'arguments vers un argument cible : `(B, x)` signifie \"l'ensemble B attacks x\". L'attaque est **active** ssi **tous** les membres de `B` sont acceptes (IN). C'est plus expressif que Dung : il faut une *coalition* pour attaquer.\n",
+    "\n",
+    "### 4.1 Exemple (verifiable a la main)\n",
+    "\n",
+    "Arguments `{a, b, c, d}` avec attaques :\n",
+    "- `({b, d}, a)` : l'ensemble {b,d} attaque a\n",
+    "- `({a, c}, c)` : l'ensemble {a,c} attaque c\n",
+    "\n",
+    "**Re-derivation du grounded** (labelling IN/OUT/UNDEC, fixed-point) :\n",
+    "1. `b` non attaque -> IN. `d` non attaque -> IN.\n",
+    "2. Attaque `({b,d}, a)` : b et d tous deux IN -> **active** -> `a` OUT.\n",
+    "3. Attaque `({a,c}, c)` : `a` est OUT -> l'ensemble {a,c} n'est jamais complet -> attaque **jamais active** -> `c` IN.\n",
+    "4. Resultat : IN = `{b, c, d}`, OUT = `{a}`.\n",
+    "\n",
+    "> **Insight** : l'auto-attaque `({a,c}, c)` echoue car elle exige `a` IN, mais `a` est OUT. La coalition requise ne peut jamais se former.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fb1d4fe0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:36.713948Z",
+     "iopub.status.busy": "2026-07-07T01:33:36.713688Z",
+     "iopub.status.idle": "2026-07-07T01:33:36.875336Z",
+     "shell.execute_reply": "2026-07-07T01:33:36.875104Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SetAF: SetAF : ({b,d}->a), ({a,c}->c)\r\n",
+       "  IN  = {b, c, d}\r\n",
+       "  OUT = {a}\r\n",
+       "  Extension grounded = IN = {b, c, d}\r\n",
+       "\r\n",
+       "  Verif : b,d non attaquants -> IN ; ({b,d},a) active -> a OUT ;\r\n",
+       "          ({a,c},c) requiert a IN mais a OUT -> jamais active -> c IN.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- SetAF from-scratch : attaques d'ensembles + grounded labelling ---\n",
+    "public sealed class SetAF\n",
+    "{\n",
+    "    public List<string> Args { get; } = new();\n",
+    "    // (ensemble attaquants, cible)\n",
+    "    public List<(HashSet<string> Attackers, string Target)> Attacks { get; } = new();\n",
+    "    public SetAF(IEnumerable<string> args) { Args.AddRange(args); }\n",
+    "    public void AddAttack(IEnumerable<string> attackers, string target)\n",
+    "        => Attacks.Add((new HashSet<string>(attackers), target));\n",
+    "\n",
+    "    // Labelling grounded : IN si aucune attaque active, OUT si une attaque active, sinon UNDEC.\n",
+    "    public (HashSet<string> IN, HashSet<string> OUT) Grounded()\n",
+    "    {\n",
+    "        var IN = new HashSet<string>();\n",
+    "        var OUT = new HashSet<string>();\n",
+    "        bool changed = true;\n",
+    "        while (changed)\n",
+    "        {\n",
+    "            changed = false;\n",
+    "            foreach (var x in Args)\n",
+    "            {\n",
+    "                if (IN.Contains(x) || OUT.Contains(x)) continue;\n",
+    "                bool defeated = Attacks.Any(atk => atk.Target == x && atk.Attackers.IsSubsetOf(IN));\n",
+    "                if (defeated) { OUT.Add(x); changed = true; continue; }\n",
+    "                // x est IN si toutes les attaques sur x ont au moins un attaquant OUT (attaque \"bloquee\")\n",
+    "                // ou s'il n'y a aucune attaque sur x.\n",
+    "                var onX = Attacks.Where(atk => atk.Target == x).ToList();\n",
+    "                if (onX.Count == 0 || onX.All(atk => atk.Attackers.Any(b => OUT.Contains(b))))\n",
+    "                {\n",
+    "                    IN.Add(x); changed = true;\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "        return (IN, OUT);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var setaf = new SetAF(new[] { \"a\", \"b\", \"c\", \"d\" });\n",
+    "setaf.AddAttack(new[] { \"b\", \"d\" }, \"a\");\n",
+    "setaf.AddAttack(new[] { \"a\", \"c\" }, \"c\");\n",
+    "var (sIN, sOUT) = setaf.Grounded();\n",
+    "\n",
+    "var sb4 = new StringBuilder();\n",
+    "sb4.AppendLine(\"SetAF : ({b,d}->a), ({a,c}->c)\");\n",
+    "sb4.AppendLine($\"  IN  = {{{string.Join(\", \", sIN.OrderBy(x=>x))}}}\");\n",
+    "sb4.AppendLine($\"  OUT = {{{string.Join(\", \", sOUT.OrderBy(x=>x))}}}\");\n",
+    "sb4.AppendLine($\"  Extension grounded = IN = {{{string.Join(\", \", sIN.OrderBy(x=>x))}}}\");\n",
+    "sb4.AppendLine();\n",
+    "sb4.AppendLine(\"  Verif : b,d non attaquants -> IN ; ({b,d},a) active -> a OUT ;\");\n",
+    "sb4.AppendLine(\"          ({a,c},c) requiert a IN mais a OUT -> jamais active -> c IN.\");\n",
+    "Show(\"SetAF\", sb4.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f026136f",
+   "metadata": {},
+   "source": [
+    "### 4.2 Pourquoi {a,c} n'attaque jamais c\n",
+    "\n",
+    "L'attaque `({a,c}, c)` est **auto-referentielle** : pour qu'elle soit active, il faudrait `a` ET `c` tous deux IN. Mais `c` IN est precisement ce que cette attaque empeche, et `a` est OUT (defait par {b,d}). La coalition requise `{a,c}` ne peut donc jamais se former : l'attaque est structurellement inactive. C'est une subtilite que la semantique ensemble capture naturellement, la ou une lecture \"il existe un attaquant\" (Dung binaire) induirait en erreur.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a69a380a",
+   "metadata": {},
+   "source": [
+    "## 5. EAF : attaques sur les attaques (Modgil 2010)\n",
+    "\n",
+    "Dans un **EAF** (Extended Argumentation Framework), une attaque peut porter sur une **autre attaque**, pas seulement sur un argument. Si `c` attaque l'attaque `(a, b)` (notation `c -> (a,b)`), et que `c` est accepte, alors l'attaque `a -> b` est **revoquee** : `b` est reinstated.\n",
+    "\n",
+    "### 5.1 Exemple (verifiable a la main)\n",
+    "\n",
+    "Arguments `{a, b, c}` :\n",
+    "- Attaque standard `a -> b` (a attaque b)\n",
+    "- **Meta-attaque** `c -> (a, b)` (c attaque l'attaque de a vers b)\n",
+    "- `a` et `c` non attaques.\n",
+    "\n",
+    "**Sans la meta-attaque (Dung classique)** : `a -> b` defait `b`. Grounded `{a, c}` (b OUT).\n",
+    "\n",
+    "**Avec la meta-attaque (EAF)** : `c` est IN (non attaque), donc `c -> (a,b)` revoque l'attaque `a -> b`. Cette attaque n'est plus un **defeat** valide. Donc `b` n'est defait par personne -> `b` IN. Grounded `{a, b, c}`.\n",
+    "\n",
+    "> **Lecon (Modgil)** : une meta-attaque depuis un argument accepte **desactive** l'attaque cible, restaurant l'argument qu'elle menacait. C'est le mecanisme formel des **preferences** et des **exceptions** en argumentation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1ecfe85c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:36.876753Z",
+     "iopub.status.busy": "2026-07-07T01:33:36.876543Z",
+     "iopub.status.idle": "2026-07-07T01:33:37.048646Z",
+     "shell.execute_reply": "2026-07-07T01:33:37.048413Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EAF: EAF : a->b, c->(a,b) [c meta-attaque l'attaque a->b]\r\n",
+       "  Dung classique (sans meta)   : {a, c}\r\n",
+       "  EAF (avec meta-attaque c)    : {a, b, c}\r\n",
+       "\r\n",
+       "  Verif EAF : c IN (non attaque) -> c revoque a->b -> b non defait -> b IN.\r\n",
+       "              La meta-attaque REINSTATED b (Dung {a,c} -> EAF {a,b,c}).\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- EAF from-scratch : meta-attaques (Modgil) + reinstatement ---\n",
+    "public sealed class EAF\n",
+    "{\n",
+    "    public List<string> Args { get; } = new();\n",
+    "    public List<(string Src, string Dst)> Attacks { get; } = new();              // a -> b\n",
+    "    public List<(string Src, string SrcAtk, string DstAtk)> MetaAttacks { get; } = new(); // c -> (a,b)\n",
+    "\n",
+    "    public EAF(IEnumerable<string> args) { Args.AddRange(args); }\n",
+    "    public void AddAttack(string src, string dst) => Attacks.Add((src, dst));\n",
+    "    public void AddMetaAttack(string src, string aSrc, string aDst) => MetaAttacks.Add((src, aSrc, aDst));\n",
+    "\n",
+    "    // Un attack (a,b) est un DEFEAT valide ssi aucun argument accepte ne le meta-attaque.\n",
+    "    bool IsValid((string Src, string Dst) at, HashSet<string> IN, bool useMeta)\n",
+    "    {\n",
+    "        if (!useMeta) return true;   // Dung classique : toute attaque compte\n",
+    "        // attaque revoquee ssi un meta-attaquant est accepte (IN)\n",
+    "        return !MetaAttacks.Any(m => m.SrcAtk == at.Src && m.DstAtk == at.Dst && IN.Contains(m.Src));\n",
+    "    }\n",
+    "\n",
+    "    // Grounded = least fixed-point de la fonction caracteristique F(S) = {x : validDefeats(x) subset OUT(S)},\n",
+    "    // ou OUT(S) = args defaits par un membre de S. On recalcule l'ensemble IN complet a chaque tour\n",
+    "    // (pas de verrouillage d'etiquette) pour que les meta-attaques activables en cours d'iteration\n",
+    "    // puissent reinstaurer un argument (sinon ordre de traitement = faux negatif).\n",
+    "    public HashSet<string> Grounded(bool useMeta)\n",
+    "    {\n",
+    "        var IN = new HashSet<string>();\n",
+    "        for (int iter = 0; iter < 200; iter++)\n",
+    "        {\n",
+    "            // defeaters valides de chaque x selon l'IN courant\n",
+    "            var vd = Args.ToDictionary(x => x, x => Attacks\n",
+    "                .Where(at => at.Dst == x && IsValid(at, IN, useMeta))\n",
+    "                .Select(at => at.Src).Distinct().ToList());\n",
+    "            var OUT = new HashSet<string>(Args.Where(x => vd[x].Any(y => IN.Contains(y))));\n",
+    "            // F(S) : x IN ssi tous ses defeaters valides sont dans OUT (vacuous si aucun defeater)\n",
+    "            var newIN = new HashSet<string>(Args.Where(x => vd[x].All(y => OUT.Contains(y))));\n",
+    "            if (newIN.SetEquals(IN)) break;\n",
+    "            IN = newIN;\n",
+    "        }\n",
+    "        return IN;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Exemple EAF : a->b, c->(a,b), a et c non attaques\n",
+    "var eaf = new EAF(new[] { \"a\", \"b\", \"c\" });\n",
+    "eaf.AddAttack(\"a\", \"b\");\n",
+    "eaf.AddMetaAttack(\"c\", \"a\", \"b\");\n",
+    "\n",
+    "var dungG = eaf.Grounded(useMeta: false);\n",
+    "var eafG  = eaf.Grounded(useMeta: true);\n",
+    "\n",
+    "var sb5 = new StringBuilder();\n",
+    "sb5.AppendLine(\"EAF : a->b, c->(a,b) [c meta-attaque l'attaque a->b]\");\n",
+    "sb5.AppendLine($\"  Dung classique (sans meta)   : {{{string.Join(\", \", dungG.OrderBy(x=>x))}}}\");\n",
+    "sb5.AppendLine($\"  EAF (avec meta-attaque c)    : {{{string.Join(\", \", eafG.OrderBy(x=>x))}}}\");\n",
+    "sb5.AppendLine();\n",
+    "sb5.AppendLine(\"  Verif EAF : c IN (non attaque) -> c revoque a->b -> b non defait -> b IN.\");\n",
+    "sb5.AppendLine(\"              La meta-attaque REINSTATED b (Dung {a,c} -> EAF {a,b,c}).\");\n",
+    "Show(\"EAF\", sb5.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b11224a",
+   "metadata": {},
+   "source": [
+    "### 5.2 Interpretation : preferences et exceptions\n",
+    "\n",
+    "La meta-attaque `c -> (a,b)` encode une **preference** : \"l'argument c (peut-etre un argument de plus haut niveau) dit que la critique de a contre b n'est pas valable\". C'est exactement le mecanisme des **frameworks avec preferences** (Modgil 2010) : au lieu de supprimer l'attaque `a->b`, on permet a un argument de la **desactiver** lorsqu'il est accepte. Cela rend l'argumentation **dynamique** et **hiérarchique** : on peut argumenter *contre* une objection, pas seulement contre une conclusion.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9d8f9ff",
+   "metadata": {},
+   "source": [
+    "## 6. VAF : argumentation value-based (Bench-Capon 2003)\n",
+    "\n",
+    "Dans un **VAF**, chaque argument promeut une **valeur** (ex. \"economie\", \"environnement\", \"justice\"). Une attaque `a -> b` devient un **defeat** ssi la valeur de `a` est **preferée** (ou egale) a celle de `b` dans un ordre de valeurs `ValPref`. Sinon, l'attaque **echoue** : `b` survive.\n",
+    "\n",
+    "### 6.1 Exemple (verifiable a la main)\n",
+    "\n",
+    "Arguments :\n",
+    "- `a` promeut la valeur **Economie**, `b` promeut **Environnement**.\n",
+    "- Attaque `a -> b`.\n",
+    "\n",
+    "Cas 1 : `Economie > Environnement` -> `a` defait `b` -> grounded `{a}`.\n",
+    "Cas 2 : `Environnement > Economie` -> l'attaque `a->b` echoue (b prioritaire) -> `b` non defait -> grounded `{a, b}`.\n",
+    "\n",
+    "> **Lecon (Bench-Capon)** : la meme topologie d'attaque donne des **extensions differentes** selon l'ordre des valeurs. Le VAF formalise l'idee qu'un argument \"plus fort\" (valeur prioritaire) peut resister a une attaque.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ffb5ff8c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:37.050320Z",
+     "iopub.status.busy": "2026-07-07T01:33:37.050086Z",
+     "iopub.status.idle": "2026-07-07T01:33:37.182380Z",
+     "shell.execute_reply": "2026-07-07T01:33:37.181908Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "VAF: VAF (a:Economie -> b:Environnement), Economie > Environnement\r\n",
+       "  Extension grounded : {a}\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "VAF: VAF (a:Economie -> b:Environnement), Environnement > Economie\r\n",
+       "  Extension grounded : {a, b}\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- VAF from-scratch : value-based (Bench-Capon) ---\n",
+    "public sealed class VAF\n",
+    "{\n",
+    "    public List<string> Args { get; } = new();\n",
+    "    public Dictionary<string, string> ValueOf { get; } = new();  // arg -> valeur\n",
+    "    public List<(string Src, string Dst)> Attacks { get; } = new();\n",
+    "    public Dictionary<(string, string), int> ValuePref { get; } = new(); // (vA, vB) -> +1 si vA prefere a vB\n",
+    "\n",
+    "    public void Add(string arg, string value) { Args.Add(arg); ValueOf[arg] = value; }\n",
+    "    public void AddAttack(string src, string dst) => Attacks.Add((src, dst));\n",
+    "    // Definit un ordre : v1 preferee a v2\n",
+    "    public void SetPref(string v1, string v2) { ValuePref[(v1, v2)] = 1; ValuePref[(v2, v1)] = -1; }\n",
+    "\n",
+    "    // Attack valide (defeat) ssi value(src) preferee ou egale a value(dst).\n",
+    "    bool IsValid((string Src, string Dst) at)\n",
+    "    {\n",
+    "        string vy = ValueOf[at.Src], vx = ValueOf[at.Dst];\n",
+    "        if (vy == vx) return true;                                   // meme valeur -> attaque reussit\n",
+    "        if (ValuePref.TryGetValue((vy, vx), out int p)) return p >= 0; // vy pref a vx\n",
+    "        return false;                                                // pas de pref -> attaque echoue\n",
+    "    }\n",
+    "\n",
+    "    public HashSet<string> Grounded()\n",
+    "    {\n",
+    "        var IN = new HashSet<string>();\n",
+    "        var OUT = new HashSet<string>();\n",
+    "        bool changed = true;\n",
+    "        while (changed)\n",
+    "        {\n",
+    "            changed = false;\n",
+    "            foreach (var x in Args)\n",
+    "            {\n",
+    "                if (IN.Contains(x) || OUT.Contains(x)) continue;\n",
+    "                var validAtkrs = Attacks\n",
+    "                    .Where(at => at.Dst == x && IsValid(at))\n",
+    "                    .Select(at => at.Src).Distinct().ToList();\n",
+    "                if (validAtkrs.Any(y => IN.Contains(y))) { OUT.Add(x); changed = true; continue; }\n",
+    "                if (validAtkrs.Count == 0 || validAtkrs.All(y => OUT.Contains(y)))\n",
+    "                {\n",
+    "                    IN.Add(x); changed = true;\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "        return IN;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "VAF RunVAF(string prefDesc, Action<VAF> setPref)\n",
+    "{\n",
+    "    var vaf = new VAF();\n",
+    "    vaf.Add(\"a\", \"Economie\");\n",
+    "    vaf.Add(\"b\", \"Environnement\");\n",
+    "    vaf.AddAttack(\"a\", \"b\");\n",
+    "    setPref(vaf);\n",
+    "    var g = vaf.Grounded();\n",
+    "    var sb = new StringBuilder();\n",
+    "    sb.AppendLine($\"VAF (a:Economie -> b:Environnement), {prefDesc}\");\n",
+    "    sb.AppendLine($\"  Extension grounded : {{{string.Join(\", \", g.OrderBy(x=>x))}}}\");\n",
+    "    Show(\"VAF\", sb.ToString());\n",
+    "    return vaf;\n",
+    "}\n",
+    "\n",
+    "RunVAF(\"Economie > Environnement\", v => v.SetPref(\"Economie\", \"Environnement\"));\n",
+    "RunVAF(\"Environnement > Economie\", v => v.SetPref(\"Environnement\", \"Economie\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c2aa4e5",
+   "metadata": {},
+   "source": [
+    "### 6.2 Interpretation : le defait conditionnel\n",
+    "\n",
+    "Dans le cas 1 (Economie prioritaire), `a` defait `b` car sa valeur l'emporte. Dans le cas 2 (Environnement prioritaire), `b` resiste : son attaque depuis `a` echoue car la valeur d'`a` est dominée. La topologie `a -> b` est **identique**, mais l'extension grounded change. C'est la puissance du VAF : **l'ordre de valeurs est un parametre du raisonnement**, pas juste une etiquette.\n",
+    "\n",
+    "> **Lien avec EAF** : le VAF est implementable comme un EAF ou les meta-attaques correspondent aux preferences de valeurs. Les deux formalismes capturent l'idee que **toutes les attaques ne sont pas des defeats**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be46f6ee",
+   "metadata": {},
+   "source": [
+    "## 7. Synthese : 4 extensions, 4 sources d'expressivite\n",
+    "\n",
+    "| Framework | Source d'expressivite | Exemple verifie | Grounded |\n",
+    "|-----------|----------------------|-----------------|----------|\n",
+    "| **Dung (base)** | attaque binaire | - | - |\n",
+    "| **ADF** | condition d'acceptation 3-valued | `a:not b, c:T, b:not c` | `{a, c}` |\n",
+    "| **SetAF** | attaque d'ensemble (coalition requise) | `{b,d}->a, {a,c}->c` | `{b, c, d}` |\n",
+    "| **EAF** | meta-attaque (attaque d'attaque) | `a->b, c->(a,b)` | `{a, b, c}` (vs Dung `{a,c}`) |\n",
+    "| **VAF** | ordre de valeurs | `a:Eco -> b:Env` | `{a}` ou `{a,b}` selon pref |\n",
+    "\n",
+    "### Ce que nous avons appris\n",
+    "\n",
+    "1. **ADF** : generaliser l'attaque en **formule logique** sur les arguments (logique 3-valued de Kleene pour le grounded).\n",
+    "2. **SetAF** : une attaque peut necessiter une **coalition** complete ; l'auto-reference la desactive naturellement.\n",
+    "3. **EAF** : un argument peut **desactiver une attaque** (preference/exception), restaurant sa cible.\n",
+    "4. **VAF** : la defaite est **conditionnelle** a un ordre de valeurs ; meme graphe, extensions differentes.\n",
+    "\n",
+    "### Value-add du jumeau (Prong B, #3801)\n",
+    "\n",
+    "- **0 jpype, 0 JVM, 0 IKVM** : BCL .NET 9 uniquement, la ou le twin Python depend de la JVM Tweety + NativeMinisat.\n",
+    "- **Semantiques observables** : conditions d'acceptation comme `Func<Interpretation,Tri>`, labelling grounded explicite, meta-attaques comme liste `(c,(a,b))`.\n",
+    "- **4 piliers verifies** : chaque extension grounded re-derivable a la main.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Notebook suivant** : [Tweety-7b-Ranking-Probabilistic](Tweety-7b-Ranking-Probabilistic.ipynb) | [Retour au sommaire](README.md)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c39d750e",
+   "metadata": {},
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "### Exercice 1 : ADF cyclique\n",
+    "\n",
+    "Construisez un ADF avec `a : not b` et `b : not a` (cycle). Que donne le grounded ? (Indice : en logique 3-valued, aucun ne peut etre decide -> tous U -> extension grounded vide.)\n",
+    "\n",
+    "### Exercice 2 : SetAF a 3 arguments\n",
+    "\n",
+    "Arguments `{x, y, z}`, attaques `({x,y}, z)` et `({z}, x)`. Calculez le grounded. (Indice : qui est IN ? qui est OUT ?)\n",
+    "\n",
+    "### Exercice 3 : EAF avec meta-attaque echouant\n",
+    "\n",
+    "Reprenez l'exemple EAF (`a->b, c->(a,b)`) mais ajoutez une attaque `d -> c` avec `d` non attaque. Desormais `c` est OUT. Que devient le grounded ? (Indice : `c` OUT -> meta-attaque inactive -> `a->b` redevient un defeat -> `b` OUT.)\n",
+    "\n",
+    "### Exercice 4 : VAF a 3 valeurs\n",
+    "\n",
+    "Arguments `a` (Economie), `b` (Environnement), `c` (Justice), attaques `a->b`, `b->c`, `c->a` (cycle). Testez les 3 ordres cycliques et identifiez celui qui donne le plus grand grounded.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e12a1a4e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:37.185668Z",
+     "iopub.status.busy": "2026-07-07T01:33:37.185074Z",
+     "iopub.status.idle": "2026-07-07T01:33:37.219401Z",
+     "shell.execute_reply": "2026-07-07T01:33:37.219577Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exo1: Exercice a completer : ADF cyclique (attendu : extension grounded vide, tous U)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : ADF cyclique (a:not b, b:not a)\n",
+    "// TODO etudiant : construire l'ADF et observer le grounded\n",
+    "var adfExo1 = new ADF();\n",
+    "// adfExo1.Add(\"a\", Neg(Var(\"b\")));\n",
+    "// adfExo1.Add(\"b\", Neg(Var(\"a\")));\n",
+    "// var gExo1 = adfExo1.Grounded();\n",
+    "Show(\"Exo1\", \"Exercice a completer : ADF cyclique (attendu : extension grounded vide, tous U)\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e5f902b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:37.221623Z",
+     "iopub.status.busy": "2026-07-07T01:33:37.221260Z",
+     "iopub.status.idle": "2026-07-07T01:33:37.262705Z",
+     "shell.execute_reply": "2026-07-07T01:33:37.262304Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exo2: Exercice a completer : SetAF 3 args (qui est IN ?)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : SetAF ({x,y}->z, {z}->x)\n",
+    "// TODO etudiant : construire le SetAF et calculer le grounded\n",
+    "var setafExo2 = new SetAF(new[] { \"x\", \"y\", \"z\" });\n",
+    "// setafExo2.AddAttack(new[]{\"x\",\"y\"}, \"z\");\n",
+    "// setafExo2.AddAttack(new[]{\"z\"}, \"x\");\n",
+    "// var (inExo2, outExo2) = setafExo2.Grounded();\n",
+    "Show(\"Exo2\", \"Exercice a completer : SetAF 3 args (qui est IN ?)\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0ec39316",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:37.264834Z",
+     "iopub.status.busy": "2026-07-07T01:33:37.264600Z",
+     "iopub.status.idle": "2026-07-07T01:33:37.319953Z",
+     "shell.execute_reply": "2026-07-07T01:33:37.319586Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exo3: Exercice a completer : EAF avec c OUT -> b OUT (reinstatement perdu)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : EAF avec c defait (d->c ajoutee)\n",
+    "// TODO etudiant : ajouter d et d->c, observer le grounded\n",
+    "var eafExo3 = new EAF(new[] { \"a\", \"b\", \"c\", \"d\" });\n",
+    "// eafExo3.AddAttack(\"a\",\"b\"); eafExo3.AddMetaAttack(\"c\",\"a\",\"b\"); eafExo3.AddAttack(\"d\",\"c\");\n",
+    "// var gExo3 = eafExo3.Grounded(useMeta: true);\n",
+    "Show(\"Exo3\", \"Exercice a completer : EAF avec c OUT -> b OUT (reinstatement perdu)\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0433eeb6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:33:37.321050Z",
+     "iopub.status.busy": "2026-07-07T01:33:37.320878Z",
+     "iopub.status.idle": "2026-07-07T01:33:37.345701Z",
+     "shell.execute_reply": "2026-07-07T01:33:37.345303Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exo4: Exercice a completer : VAF 3-valeurs cyclique (quel ordre maximise le grounded ?)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 4 : VAF a 3 valeurs cyclique\n",
+    "// TODO etudiant : cycle a->b->c->a avec 3 valeurs, tester les ordres\n",
+    "var vafExo4 = new VAF();\n",
+    "// vafExo4.Add(\"a\",\"Economie\"); vafExo4.Add(\"b\",\"Environnement\"); vafExo4.Add(\"c\",\"Justice\");\n",
+    "// vafExo4.AddAttack(\"a\",\"b\"); vafExo4.AddAttack(\"b\",\"c\"); vafExo4.AddAttack(\"c\",\"a\");\n",
+    "Show(\"Exo4\", \"Exercice a completer : VAF 3-valeurs cyclique (quel ordre maximise le grounded ?)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c1b83ab",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce jumeau C# a presente les **4 extensions principales** du cadre de Dung, reimplementation from-scratch du twin Python jpype/Tweety JVM.\n",
+    "\n",
+    "### Resultats cles (Math Verification Standard)\n",
+    "\n",
+    "| Pilier | Entree | Sortie (re-derivable a la main) |\n",
+    "|--------|--------|--------------------------------|\n",
+    "| **ADF** | `a:not b, c:T, b:not c` | grounded `{a,c}` (c=T -> b=F -> a=T) |\n",
+    "| **SetAF** | `{b,d}->a, {a,c}->c` | grounded `{b,c,d}` (coalition {a,c} jamais formee) |\n",
+    "| **EAF** | `a->b, c->(a,b)` | grounded `{a,b,c}` (meta-attaque reinstated b) |\n",
+    "| **VAF** | `a:Eco -> b:Env` | `{a}` si Eco>Env, `{a,b}` si Env>Eco |\n",
+    "\n",
+    "### Value-add (Prong B, #3801)\n",
+    "\n",
+    "- **0 jpype/JVM/IKVM** : BCL .NET 9 uniquement, la ou le twin Python charge 42 JARs + NativeMinisat.\n",
+    "- **Semantiques from-scratch** : Kleene 3-valued, labelling grounded, meta-attaques, ordre de valeurs.\n",
+    "\n",
+    "**Suite** : [Tweety-7b-Ranking-Probabilistic](Tweety-7b-Ranking-Probabilistic.ipynb) | [Retour au sommaire](README.md)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Twin C# Tweety-7a — ADF/SetAF/EAF/VAF from-scratch (BCL pur, 0 jpype/JVM)

Twin C# du notebook Python `Tweety-7a-Extended-Frameworks.ipynb`. Marathon .NET ⇄ Python parity #4956, lane Tweety-.NET (po-2023).

### Les 4 piliers (Prong B #3801 : from-scratch, complémentaire du Python jpype)

| Pilier | Référence | Implémentation C# from-scratch |
|--------|-----------|-------------------------------|
| **ADF** | Brewka-Woltran 2010 | Conditions d'acceptation + **logique de Kleene 3-valued** (`Tri{T,F,U}`, tables `Not`/`And`/`Or`, U propage l'incertitude) ; grounded = plus petit fixed-point depuis l'interprétation tout-U |
| **SetAF** | Nielsen-Parsons 2011 | Attaques d'ensembles (`HashSet<string>` attackers → target) ; **attaque active ssi tous les attaquants IN** |
| **EAF** | Modgil 2010 | Méta-attaques `c → (a,b)` révoquant les attaques ; grounded = plus petit fixed-point de la **fonction caractéristique F(S)** (recomputation complète du IN set à chaque ronde, pas de label-locking → permet la réintroduction mid-iteration via méta-attaques) |
| **VAF** | Bench-Capon 2003 | Valeurs + ordre de préférence (`ValuePref`) ; défaite **conditionnelle** via `IsValid(at)` (un attaquant ne compte que si sa valeur ≥ celle de la cible) |

**Prong B (#3801)** : 0 `jpype`, 0 `IKVM`, 0 `JVM`, 0 `#r NuGet`. Le Python original invoque la JVM Tweety via jpype ; le twin C# réimplémente les 4 sémantiques from-scratch en BCL pur = valeur complémentaire authentique (transparence des mécanismes, pas miroir).

### Forensic EXEC_PROVED

| Check | Résultat |
|-------|----------|
| Cellules code | **9/9** `execution_count` 1-9 séquentiel |
| Erreurs | **0** |
| `warning CS` | **0** |
| Path-leaks (C:\Dev, CoursIA, jsboi, worktrees, AppData) | **NONE** |
| `throw`/`NotImplementedException`/`assert False`/`1/0` (C.1) | **0** |

### Math Verification Standard — re-dérivation indépendante firsthand

| Pilier | Code committé | Output | Re-dérivation aligned |
|--------|---------------|--------|------------------------|
| **ADF grounded** | `a:not b`, `c:T`, `b:not c` | `{a,c}` (b=f) | `c=T` (tautologie Const(T)) → `b=not c=F` → `a=not b=T` → grounded `{a,c}`, b=F ✓ |
| **SetAF grounded** | `({b,d}→a), ({a,c}→c)` | `{b,c,d}` (a OUT) | b,d non-attaqués → IN ; `({b,d}→a)` active (b,d⊆IN) → a OUT ; `({a,c}→c)` requiert a IN mais a OUT → **jamais active** → c IN → grounded `{b,c,d}` ✓ |
| **EAF grounded** | `a→b, c→(a,b)` | `{a,b,c}` (vs Dung `{a,c}`) | Méta-attaque `c→(a,b)` révoque l'attaque `a→b` quand c IN → b réinstauré. **Divergence vs Dung confirmée firsthand** ✓ |
| **VAF grounded** | `a:Eco → b:Env` (Eco>Env) / (Env>Eco) | `{a}` / `{a,b}` | Eco>Env : `a→b` valide (Eco pref Env) → b défait → `{a}` ; Env>Eco : `a→b` invalide (Eco non-pref) → b non défait → `{a,b}` ✓ |

### 2 G.1 self-corrections during build

1. **EAF** — 1ère version (IN si tous les attaquants sont OUT) donnait `{a,c}` comme Dung, masquant la valeur-add de l'EAF. Root cause : label-locking — quand `b` est traité, `c` n'est pas encore IN, donc la méta-attaque n'est pas vue comme active, et `b` reste OUT en permanence. **Fix** : rewrite en plus petit fixed-point de la fonction caractéristique F(S) qui **recompute le IN set complet à chaque ronde** (pas de lock). → EAF `{a,b,c}` ✓
2. **VAF** — mêmes attaques comptées malgré défaite conditionnelle (donnait `{a}` pour les deux ordres). **Fix** : ajout `IsValid(at)` filtrant les attaquants par préférence de valeur. → `{a}` / `{a,b}` ✓

### Self-fix c.250 (commit `b28de64a0`)

CJK `拒` U+62D2 (advisory po-2026 c.283) remplacé par `rejete` dans cellule markdown 6 (sous-section 3.3 ADF). Scope minimal : 1 caractère dans `Tweety-7a-Extended-Frameworks-Csharp.ipynb`, LF préservé (CR=0), 9/9 cellules code avec execution_count 1-9 contigus et outputs cohérents après reformat. +1/-1 ligne utile.

### Self-fix c.250 (this PR body update)

Fidélité body↔code renforcée suite à finding po-2025 c.82 G.6 : 3/4 traces du tableau Math Verification Standard réécrites pour aligner sur les **instances réellement codées** (et non des graphes génériques). Les sorties (`{a,c}` / `{b,c,d}` / `{a,b,c}` / `{a}` & `{a,b}`) restent identiques — la ré-écriture concerne la **trace textuelle**, pas le code exécuté.

### §E feuille Tweety README

- +1 ligne table `7ac` (après `7a` Python, avant `7b`/`7bc` — pattern cohérent 6c/7bc).
- +1 ligne arbre de structure.
- CATALOG-STATUS **byte-identical à `main`** (catalog-pr-hygiene R1) — la nouvelle entrée sera créée par le cron `<24h`.

### Voir aussi
- See #4956 (marathon .NET ⇄ Python parity)
- See #3801 (EPIC SOTA axe-2, Prong B from-scratch complémentaire)

— po-2023 (Math Verification Standard, self-fix c.250 pre-sweep)