### PR TITLE
feat(semanticweb): SW-6b-Python-RDFS — twin Python rdflib+owlrl RDFS (marathon #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -205,7 +205,7 @@ Cette partie étend vos compétences aux données du Web ouvert et aux ontologie
 | # | Notebook | Durée | Sidetrack Python |
 |---|----------|-------|------------------|
 | 5 | **SW-5-CSharp-LinkedData** | 50 min | SW-5b-Python-LinkedData |
-| 6 | **SW-6-CSharp-RDFS** | 40 min | - |
+| 6 | **SW-6-CSharp-RDFS** | 40 min | SW-6b-Python-RDFS |
 | 7 | **SW-7-CSharp-OWL** | 50 min | SW-7b-Python-OWL |
 
 #### SW-5-CSharp-LinkedData : DBpedia, Wikidata et Requêtes Fédérées (50 min)
@@ -487,6 +487,7 @@ SemanticWeb/
 ├── SW-5-CSharp-LinkedData.ipynb
 ├── SW-5b-Python-LinkedData.ipynb    # Sidetrack
 ├── SW-6-CSharp-RDFS.ipynb
+├── SW-6b-Python-RDFS.ipynb           # Sidetrack
 ├── SW-7-CSharp-OWL.ipynb
 ├── SW-7b-Python-OWL.ipynb           # Sidetrack
 ├── SW-8-Python-SHACL.ipynb

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
@@ -1,0 +1,1452 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "611f0eb0",
+   "metadata": {},
+   "source": [
+    "# SW-6b-Python-RDFS\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< SW-6 C#](SW-6-CSharp-RDFS.ipynb) | [SW-7b Python OWL >>](SW-7b-Python-OWL.ipynb)\n",
+    "\n",
+    "## RDFS en Python avec rdflib + owlrl : Schema et Inference\n",
+    "\n",
+    "Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des concepts RDFS du notebook SW-6 (dotNetRDF). Vous y decouvrirez comment **rdflib** (construction de schemas, parsing Turtle, requetes SPARQL) et **owlrl** (vrai raisonneur RDFS) cooperent pour reproduire en Python le travail du `StaticRdfsReasoner` de dotNetRDF.\n",
+    "\n",
+    "### Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. Construire un schema RDFS en Python avec rdflib (`rdfs:Class`, `rdfs:subClassOf`, `rdfs:domain`, `rdfs:range`)\n",
+    "2. Charger un fichier Turtle existant (`data/animals.ttl`) et explorer sa hierarchie de classes\n",
+    "3. Appliquer un **vrai raisonneur RDFS** (owlrl) pour materialiser les triplets inferes\n",
+    "4. Interroger les donnees enrichies par SPARQL\n",
+    "5. Faire la correspondance entre dotNetRDF (`StaticRdfsReasoner`) et rdflib + owlrl (`DeductiveClosure`)\n",
+    "\n",
+    "### Prerequis\n",
+    "- SW-6-CSharp-RDFS recommande (pour la comprehension conceptuelle)\n",
+    "- Python 3.10+\n",
+    "- Notebooks SW-2b et SW-4b (bases rdflib + SPARQL en Python)\n",
+    "\n",
+    "### Duree estimee : 40 minutes\n",
+    "\n",
+    "> **Note** : owlrl est le raisonneur RDFS/OWL de reference en Python pur (implementation des regles d'entailment W3C RDF 1.1 Semantics). Nous ne reinventerons **pas** l'inference a la main dans les cellules de production : une cellule de demonstration pedagogique expose le mecanisme (point fixe), puis owlrl prend le relais pour le travail reel.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac5a3934",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Installation et imports\n",
+    "\n",
+    "**rdflib** est le coeur Python du Web Semantique (equivalent de dotNetRDF). **owlrl** est le raisonneur RDFS/OWL-RL qui materialise les triplets inferes (equivalent du `StaticRdfsReasoner` de dotNetRDF).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "02fc2fca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:33.485927Z",
+     "iopub.status.busy": "2026-07-07T01:32:33.485927Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.658941Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.658941Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Installation silencieuse des dependances\n",
+    "%pip install -q rdflib owlrl\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "742c4f32",
+   "metadata": {},
+   "source": [
+    "Import des bibliotheques. Les namespaces W3C (`RDF`, `RDFS`, `XSD`) sont preconfigures dans rdflib, ce qui evite de manipuler les URIs completes a la main."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ae7ab997",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.658941Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.658941Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.724092Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.724092Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports rdflib + owlrl prets.\n",
+      "rdflib version : 7.6.0\n",
+      "owlrl version  : 7.1.4\n",
+      "\n",
+      "Namespaces W3C preconfigures :\n",
+      "  RDF.type       = http://www.w3.org/1999/02/22-rdf-syntax-ns#type\n",
+      "  RDFS.subClassOf= http://www.w3.org/2000/01/rdf-schema#subClassOf\n",
+      "  RDFS.domain    = http://www.w3.org/2000/01/rdf-schema#domain\n",
+      "  RDFS.range     = http://www.w3.org/2000/01/rdf-schema#range\n",
+      "  RDFS.label     = http://www.w3.org/2000/01/rdf-schema#label\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    from rdflib import Graph, URIRef, Literal, BNode, Namespace\n",
+    "    from rdflib.namespace import RDF, RDFS, XSD\n",
+    "    import owlrl\n",
+    "\n",
+    "    LIBS_AVAILABLE = True\n",
+    "    print(\"Imports rdflib + owlrl prets.\")\n",
+    "    print(f\"rdflib version : {__import__('rdflib').__version__}\")\n",
+    "    print(f\"owlrl version  : {owlrl.__version__}\")\n",
+    "    print()\n",
+    "    print(\"Namespaces W3C preconfigures :\")\n",
+    "    print(f\"  RDF.type       = {RDF.type}\")\n",
+    "    print(f\"  RDFS.subClassOf= {RDFS.subClassOf}\")\n",
+    "    print(f\"  RDFS.domain    = {RDFS.domain}\")\n",
+    "    print(f\"  RDFS.range     = {RDFS.range}\")\n",
+    "    print(f\"  RDFS.label     = {RDFS.label}\")\n",
+    "except ImportError as e:\n",
+    "    LIBS_AVAILABLE = False\n",
+    "    print(f\"Bibliotheque manquante : {e}\")\n",
+    "    print(\"Installez avec : pip install rdflib owlrl\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e3d6344",
+   "metadata": {},
+   "source": [
+    "### Interpretation : imports\n",
+    "\n",
+    "| Symbole rdflib | Equivalent dotNetRDF |\n",
+    "|---------------|----------------------|\n",
+    "| `Graph` | `IGraph` / `Graph` |\n",
+    "| `URIRef` | `IUriNode` |\n",
+    "| `Literal` | `ILiteralNode` |\n",
+    "| `RDF.type` | `rdf:type` (URI complete) |\n",
+    "| `RDFS.subClassOf` | `rdfs:subClassOf` |\n",
+    "| `owlrl.DeductiveClosure` | `StaticRdfsReasoner` |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. rdflib expose les namespaces W3C comme attributs Python (`RDFS.subClassOf` au lieu de l'URI complete `http://www.w3.org/2000/01/rdf-schema#subClassOf`).\n",
+    "2. owlrl est un **module separe** de rdflib : on l'invoque explicitement quand on veut du raisonnement. C'est une difference philosophique avec dotNetRDF ou le raisonneur est integre."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdd1ff5a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Qu'est-ce que RDFS ?\n",
+    "\n",
+    "**RDF Schema (RDFS)** est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des donnees RDF. Tandis que RDF permet d'exprimer des faits sous forme de triplets (sujet, predicat, objet), RDFS ajoute la capacite de definir :\n",
+    "\n",
+    "> **RDF Schema (RDFS)** est standardise par le **W3C** dans RDF Schema 1.1 (Brickley & Guha, W3C Recommendation 2014). C'est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des donnees RDF -- classes, hierarchies, domaines/portees de proprietes et regles d'inference.\n",
+    "\n",
+    "- Des **classes** et des **hierarchies de classes**\n",
+    "- Des **proprietes** avec domaine et portee\n",
+    "- Des **regles d'inference** implicites\n",
+    "\n",
+    "### RDFS dans la pile du Web Semantique\n",
+    "\n",
+    "```\n",
+    "     +------------------+\n",
+    "     |   OWL (SW-7)     |  <- Logique descriptive\n",
+    "     +------------------+\n",
+    "     |   RDFS (SW-6)    |  <- Vocabulaires, hierarchies  <-- Nous sommes ici\n",
+    "     +------------------+\n",
+    "     | SPARQL (SW-4/5)  |  <- Interrogation\n",
+    "     +------------------+\n",
+    "     |   RDF (SW-1/2/3) |  <- Triplets, graphes\n",
+    "     +------------------+\n",
+    "     |   URI / IRI      |  <- Identifiants\n",
+    "     +------------------+\n",
+    "```\n",
+    "\n",
+    "### RDF seul vs RDFS\n",
+    "\n",
+    "| Capacite | RDF seul | RDF + RDFS |\n",
+    "|----------|----------|------------|\n",
+    "| Exprimer des faits (triplets) | Oui | Oui |\n",
+    "| Definir des classes | Non | `rdfs:Class` |\n",
+    "| Hierarchies de classes | Non | `rdfs:subClassOf` |\n",
+    "| Hierarchies de proprietes | Non | `rdfs:subPropertyOf` |\n",
+    "| Contraindre domaine/portee | Non | `rdfs:domain`, `rdfs:range` |\n",
+    "| Inference automatique | Non | Oui (regles RDFS) |\n",
+    "| Documentation | Limite | `rdfs:label`, `rdfs:comment` |\n",
+    "\n",
+    "### Vocabulaire RDFS complet\n",
+    "\n",
+    "Le namespace RDFS est `http://www.w3.org/2000/01/rdf-schema#`. Voici les termes essentiels :\n",
+    "\n",
+    "| Terme RDFS | Type | Description |\n",
+    "|------------|------|-------------|\n",
+    "| `rdfs:Class` | Classe | Definit une classe (un ensemble de ressources) |\n",
+    "| `rdfs:subClassOf` | Propriete | A est une sous-classe de B (A $\\subseteq$ B) |\n",
+    "| `rdfs:subPropertyOf` | Propriete | P1 est une sous-propriete de P2 |\n",
+    "| `rdfs:domain` | Propriete | Le sujet d'un triplet avec P est de type C |\n",
+    "| `rdfs:range` | Propriete | L'objet d'un triplet avec P est de type C |\n",
+    "| `rdfs:label` | Propriete | Etiquette lisible par un humain |\n",
+    "| `rdfs:comment` | Propriete | Description textuelle |\n",
+    "| `rdfs:Resource` | Classe | Superclasse de toutes les ressources |\n",
+    "| `rdfs:Literal` | Classe | Classe des valeurs litterales |\n",
+    "| `rdfs:Datatype` | Classe | Classe des types de donnees |\n",
+    "| `rdfs:seeAlso` | Propriete | Lien vers une ressource connexe |\n",
+    "| `rdfs:isDefinedBy` | Propriete | Lien vers la definition de la ressource |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98757612",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Construire un schema RDFS en code\n",
+    "\n",
+    "Construisons une taxonomie animale en Python avec rdflib. Nous allons creer la hierarchie suivante :\n",
+    "\n",
+    "```\n",
+    "  Animal\n",
+    "  |-- Mammal (Mammifere)\n",
+    "  |   |-- Dog (Chien)\n",
+    "  |   +-- Cat (Chat)\n",
+    "  +-- Bird (Oiseau)\n",
+    "      +-- Parrot (Perroquet)\n",
+    "```\n",
+    "\n",
+    "La meme **taxonomie**, rendue sous forme de graphe : chaque fleche `rdfs:subClassOf` pointe de la sous-classe vers sa super-classe (sens de lecture « est une sorte de »).\n",
+    "\n",
+    "```mermaid\n",
+    "graph BT\n",
+    "    Dog[\"ex:Dog Chien\"]\n",
+    "    Cat[\"ex:Cat Chat\"]\n",
+    "    Parrot[\"ex:Parrot Perroquet\"]\n",
+    "    Mammal[\"ex:Mammal Mammifere\"]\n",
+    "    Bird[\"ex:Bird Oiseau\"]\n",
+    "    Animal[\"ex:Animal\"]\n",
+    "    Dog -->|rdfs:subClassOf| Mammal\n",
+    "    Cat -->|rdfs:subClassOf| Mammal\n",
+    "    Parrot -->|rdfs:subClassOf| Bird\n",
+    "    Mammal -->|rdfs:subClassOf| Animal\n",
+    "    Bird -->|rdfs:subClassOf| Animal\n",
+    "    classDef root fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef mid fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "    classDef leaf fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
+    "    class Animal root\n",
+    "    class Mammal,Bird mid\n",
+    "    class Dog,Cat,Parrot leaf\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Les 5 relations `rdfs:subClassOf` (Dog/Cat < Mammal, Parrot < Bird, Mammal/Bird < Animal) forment un **arbre d'heritage**. RDFS garantit que cette relation est *transitive* : `Dog <: Mammal` et `Mammal <: Animal` impliquent `Dog <: Animal`. C'est cette transitivite que le raisonneur exploite pour typer les instances par toutes leurs classes ancetres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "71a4b36b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.725108Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.725108Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.731640Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.731640Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Schema RDFS cree : 18 triplets\n",
+      "\n",
+      "Hierarchie de classes :\n",
+      "  Mammal rdfs:subClassOf Animal\n",
+      "  Bird rdfs:subClassOf Animal\n",
+      "  Dog rdfs:subClassOf Mammal\n",
+      "  Cat rdfs:subClassOf Mammal\n",
+      "  Parrot rdfs:subClassOf Bird\n"
+     ]
+    }
+   ],
+   "source": [
+    "if LIBS_AVAILABLE:\n",
+    "    # Construire un schema RDFS en Python avec rdflib\n",
+    "    schema = Graph()\n",
+    "\n",
+    "    # Namespace personnalise pour notre taxonomie animale\n",
+    "    EX = Namespace(\"http://example.org/animals#\")\n",
+    "    schema.bind(\"ex\", EX)\n",
+    "    schema.bind(\"rdfs\", RDFS)\n",
+    "    schema.bind(\"rdf\", RDF)\n",
+    "    schema.bind(\"xsd\", XSD)\n",
+    "\n",
+    "    # --- Definition des classes ---\n",
+    "    animal = EX.Animal\n",
+    "    mammal = EX.Mammal\n",
+    "    bird = EX.Bird\n",
+    "    dog = EX.Dog\n",
+    "    cat = EX.Cat\n",
+    "    parrot = EX.Parrot\n",
+    "\n",
+    "    # Declarer les classes comme instances de rdfs:Class\n",
+    "    for cls in (animal, mammal, bird, dog, cat, parrot):\n",
+    "        schema.add((cls, RDF.type, RDFS.Class))\n",
+    "\n",
+    "    # Hierarchie de classes (rdfs:subClassOf)\n",
+    "    schema.add((mammal, RDFS.subClassOf, animal))\n",
+    "    schema.add((bird,   RDFS.subClassOf, animal))\n",
+    "    schema.add((dog,    RDFS.subClassOf, mammal))\n",
+    "    schema.add((cat,    RDFS.subClassOf, mammal))\n",
+    "    schema.add((parrot, RDFS.subClassOf, bird))\n",
+    "\n",
+    "    # Etiquettes (rdfs:label) en francais\n",
+    "    schema.add((animal, RDFS.label, Literal(\"Animal\", lang=\"fr\")))\n",
+    "    schema.add((mammal, RDFS.label, Literal(\"Mammifere\", lang=\"fr\")))\n",
+    "    schema.add((bird,   RDFS.label, Literal(\"Oiseau\", lang=\"fr\")))\n",
+    "    schema.add((dog,    RDFS.label, Literal(\"Chien\", lang=\"fr\")))\n",
+    "    schema.add((cat,    RDFS.label, Literal(\"Chat\", lang=\"fr\")))\n",
+    "    schema.add((parrot, RDFS.label, Literal(\"Perroquet\", lang=\"fr\")))\n",
+    "\n",
+    "    # Commentaire sur la classe racine\n",
+    "    schema.add((animal, RDFS.comment, Literal(\"Classe racine de tous les animaux\", lang=\"fr\")))\n",
+    "\n",
+    "    print(f\"Schema RDFS cree : {len(schema)} triplets\")\n",
+    "    print()\n",
+    "    print(\"Hierarchie de classes :\")\n",
+    "    for s, _, o in schema.triples((None, RDFS.subClassOf, None)):\n",
+    "        child = str(s).split(\"#\")[-1]\n",
+    "        parent = str(o).split(\"#\")[-1]\n",
+    "        print(f\"  {child} rdfs:subClassOf {parent}\")\n",
+    "else:\n",
+    "    print(\"Bibliotheques non disponibles : construction du schema ignoree.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "267a6458",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Construction du schema\n",
+    "\n",
+    "Nous avons cree un schema RDFS complet avec :\n",
+    "- **6 classes** organisees en hierarchie\n",
+    "- **5 relations `rdfs:subClassOf`** definissant l'arbre taxonomique\n",
+    "- **6 etiquettes `rdfs:label`** en francais\n",
+    "- **1 commentaire `rdfs:comment`** sur la classe racine\n",
+    "\n",
+    "| Operation | rdflib (Python) | dotNetRDF (C#) |\n",
+    "|-----------|-----------------|----------------|\n",
+    "| Creer un graphe | `g = Graph()` | `IGraph g = new Graph()` |\n",
+    "| Ajouter un triplet | `g.add((s, p, o))` | `g.Assert(new Triple(s, p, o))` |\n",
+    "| Litteral avec langue | `Literal(\"Animal\", lang=\"fr\")` | `g.CreateLiteralNode(\"Animal\", \"fr\")` |\n",
+    "| Namespace | `g.bind(\"ex\", EX)` | `g.NamespaceMap.AddNamespace(\"ex\", uri)` |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Chaque classe est declaree comme instance de `rdfs:Class` via `rdf:type`\n",
+    "2. `rdfs:subClassOf` est **transitif** : Dog < Mammal < Animal, donc Dog < Animal\n",
+    "3. Les etiquettes multilingues utilisent les tags de langue (`lang=\"fr\"`, `lang=\"en\"`, etc.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "351139d8",
+   "metadata": {},
+   "source": [
+    "### Ajout de proprietes avec domaine et portee\n",
+    "\n",
+    "Definissons des proprietes pour notre taxonomie, avec `rdfs:domain` (type du sujet) et `rdfs:range` (type de l'objet/valeur)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0a4d9805",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.731640Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.731640Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.738153Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.738153Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Schema enrichi : 34 triplets\n",
+      "\n",
+      "Proprietes definies :\n",
+      "  ex:name      domain=Animal    range=string\n",
+      "  ex:age       domain=Animal    range=integer\n",
+      "  ex:sound     domain=Animal    range=string\n",
+      "  ex:canFly    domain=Animal    range=boolean\n"
+     ]
+    }
+   ],
+   "source": [
+    "if LIBS_AVAILABLE:\n",
+    "    # Proprietes avec domaine et portee\n",
+    "    name_prop   = EX.name\n",
+    "    age_prop    = EX.age\n",
+    "    sound_prop  = EX.sound\n",
+    "    canfly_prop = EX.canFly\n",
+    "\n",
+    "    # ex:name - propriete avec domaine Animal, portee xsd:string\n",
+    "    schema.add((name_prop,   RDF.type, RDF.Property))\n",
+    "    schema.add((name_prop,   RDFS.domain, animal))\n",
+    "    schema.add((name_prop,   RDFS.range, XSD.string))\n",
+    "    schema.add((name_prop,   RDFS.label, Literal(\"nom\", lang=\"fr\")))\n",
+    "\n",
+    "    # ex:age - propriete avec domaine Animal, portee xsd:integer\n",
+    "    schema.add((age_prop,    RDF.type, RDF.Property))\n",
+    "    schema.add((age_prop,    RDFS.domain, animal))\n",
+    "    schema.add((age_prop,    RDFS.range, XSD.integer))\n",
+    "    schema.add((age_prop,    RDFS.label, Literal(\"age\", lang=\"fr\")))\n",
+    "\n",
+    "    # ex:sound - propriete avec domaine Animal, portee xsd:string\n",
+    "    schema.add((sound_prop,  RDF.type, RDF.Property))\n",
+    "    schema.add((sound_prop,  RDFS.domain, animal))\n",
+    "    schema.add((sound_prop,  RDFS.range, XSD.string))\n",
+    "    schema.add((sound_prop,  RDFS.label, Literal(\"cri\", lang=\"fr\")))\n",
+    "\n",
+    "    # ex:canFly - propriete avec domaine Animal, portee xsd:boolean\n",
+    "    schema.add((canfly_prop, RDF.type, RDF.Property))\n",
+    "    schema.add((canfly_prop, RDFS.domain, animal))\n",
+    "    schema.add((canfly_prop, RDFS.range, XSD.boolean))\n",
+    "    schema.add((canfly_prop, RDFS.label, Literal(\"peut voler\", lang=\"fr\")))\n",
+    "\n",
+    "    print(f\"Schema enrichi : {len(schema)} triplets\")\n",
+    "    print()\n",
+    "    print(\"Proprietes definies :\")\n",
+    "    for p in (name_prop, age_prop, sound_prop, canfly_prop):\n",
+    "        name = str(p).split(\"#\")[-1]\n",
+    "        domain = str(next(schema.objects(p, RDFS.domain))).split(\"#\")[-1]\n",
+    "        rng = str(next(schema.objects(p, RDFS.range))).split(\"#\")[-1]\n",
+    "        print(f\"  ex:{name:8s}  domain={domain:8s}  range={rng}\")\n",
+    "else:\n",
+    "    print(\"Bibliotheques non disponibles : proprietes ignorees.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec36378d",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Domaine et portee\n",
+    "\n",
+    "| Propriete | Domaine | Portee | Signification |\n",
+    "|-----------|---------|--------|---------------|\n",
+    "| `ex:name` | `ex:Animal` | `xsd:string` | Le nom est une chaine, applicable a tout Animal |\n",
+    "| `ex:age` | `ex:Animal` | `xsd:integer` | L'age est un entier |\n",
+    "| `ex:sound` | `ex:Animal` | `xsd:string` | Le cri est une chaine |\n",
+    "| `ex:canFly` | `ex:Animal` | `xsd:boolean` | Capacite de vol, vrai/faux |\n",
+    "\n",
+    "**Consequence de `rdfs:domain`** : si on ecrit `ex:rex ex:name \"Rex\"`, alors un raisonneur RDFS peut **inferer** que `ex:rex rdf:type ex:Animal` (car `ex:name` a pour domaine `ex:Animal`).\n",
+    "\n",
+    "> **Attention** : `rdfs:domain` et `rdfs:range` ne sont pas des contraintes de validation (comme en SQL). Ce sont des **regles d'inference**. Si le domaine est viole, RDFS ne signale pas d'erreur -- il infere un type supplementaire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dd16b92",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Charger et explorer `animals.ttl`\n",
+    "\n",
+    "Le fichier `data/animals.ttl` contient la hierarchie complete avec des instances. Chargeons-le avec le parser Turtle de rdflib et explorons sa structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0a3db2b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.738153Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.738153Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.746084Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.746084Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe charge : 51 triplets\n",
+      "\n",
+      "Namespaces declares :\n",
+      "  brick  -> https://brickschema.org/schema/Brick#\n",
+      "  csvw   -> http://www.w3.org/ns/csvw#\n",
+      "  dc     -> http://purl.org/dc/elements/1.1/\n",
+      "  dcat   -> http://www.w3.org/ns/dcat#\n",
+      "  dcmitype -> http://purl.org/dc/dcmitype/\n",
+      "  dcterms -> http://purl.org/dc/terms/\n",
+      "  dcam   -> http://purl.org/dc/dcam/\n",
+      "  doap   -> http://usefulinc.com/ns/doap#\n",
+      "  foaf   -> http://xmlns.com/foaf/0.1/\n",
+      "  geo    -> http://www.opengis.net/ont/geosparql#\n",
+      "  odrl   -> http://www.w3.org/ns/odrl/2/\n",
+      "  org    -> http://www.w3.org/ns/org#\n",
+      "  prof   -> http://www.w3.org/ns/dx/prof/\n",
+      "  prov   -> http://www.w3.org/ns/prov#\n",
+      "  qb     -> http://purl.org/linked-data/cube#\n",
+      "  schema -> https://schema.org/\n",
+      "  sh     -> http://www.w3.org/ns/shacl#\n",
+      "  skos   -> http://www.w3.org/2004/02/skos/core#\n",
+      "  sosa   -> http://www.w3.org/ns/sosa/\n",
+      "  ssn    -> http://www.w3.org/ns/ssn/\n",
+      "  time   -> http://www.w3.org/2006/time#\n",
+      "  vann   -> http://purl.org/vocab/vann/\n",
+      "  void   -> http://rdfs.org/ns/void#\n",
+      "  wgs    -> https://www.w3.org/2003/01/geo/wgs84_pos#\n",
+      "  owl    -> http://www.w3.org/2002/07/owl#\n",
+      "  rdf    -> http://www.w3.org/1999/02/22-rdf-syntax-ns#\n",
+      "  rdfs   -> http://www.w3.org/2000/01/rdf-schema#\n",
+      "  xsd    -> http://www.w3.org/2001/XMLSchema#\n",
+      "  xml    -> http://www.w3.org/XML/1998/namespace\n",
+      "  ex     -> http://example.org/animals#\n",
+      "\n",
+      "Classes definies :\n",
+      "  - Animal\n",
+      "  - Mammal\n",
+      "  - Bird\n",
+      "  - Dog\n",
+      "  - Cat\n",
+      "  - Parrot\n"
+     ]
+    }
+   ],
+   "source": [
+    "if LIBS_AVAILABLE:\n",
+    "    # Charger le fichier animals.ttl avec rdflib\n",
+    "    animals = Graph()\n",
+    "    animals.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "\n",
+    "    print(f\"Graphe charge : {len(animals)} triplets\")\n",
+    "    print()\n",
+    "    print(\"Namespaces declares :\")\n",
+    "    for prefix, ns in animals.namespaces():\n",
+    "        print(f\"  {prefix:6s} -> {ns}\")\n",
+    "    print()\n",
+    "\n",
+    "    # Lister toutes les classes (sujets de type rdfs:Class)\n",
+    "    print(\"Classes definies :\")\n",
+    "    for cls in animals.subjects(RDF.type, RDFS.Class):\n",
+    "        name = str(cls).split(\"#\")[-1]\n",
+    "        print(f\"  - {name}\")\n",
+    "else:\n",
+    "    print(\"Bibliotheques non disponibles : chargement ignore.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef88b8c5",
+   "metadata": {},
+   "source": [
+    "Explorons maintenant la hierarchie de classes et les instances declarees (avant toute inference)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fd2b3607",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.746084Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.746084Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.751125Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.751125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hierarchie de classes (rdfs:subClassOf) :\n",
+      "  Mammal --> Animal\n",
+      "  Bird --> Animal\n",
+      "  Dog --> Mammal\n",
+      "  Cat --> Mammal\n",
+      "  Parrot --> Bird\n",
+      "\n",
+      "Instances par classe (avant inference) :\n",
+      "  Dog : ['buddy', 'rex']\n",
+      "  Cat : ['minou']\n",
+      "  Parrot : ['coco']\n"
+     ]
+    }
+   ],
+   "source": [
+    "if LIBS_AVAILABLE:\n",
+    "    # Explorer la hierarchie de classes\n",
+    "    print(\"Hierarchie de classes (rdfs:subClassOf) :\")\n",
+    "    for s, _, o in animals.triples((None, RDFS.subClassOf, None)):\n",
+    "        child = str(s).split(\"#\")[-1]\n",
+    "        parent = str(o).split(\"#\")[-1]\n",
+    "        print(f\"  {child} --> {parent}\")\n",
+    "    print()\n",
+    "\n",
+    "    # Lister les instances par classe (uniquement les classes \"feuilles\")\n",
+    "    print(\"Instances par classe (avant inference) :\")\n",
+    "    for cls_name in (\"Dog\", \"Cat\", \"Parrot\"):\n",
+    "        cls_uri = URIRef(f\"http://example.org/animals#{cls_name}\")\n",
+    "        instances = sorted(str(s).split(\"#\")[-1] for s in animals.subjects(RDF.type, cls_uri))\n",
+    "        print(f\"  {cls_name} : {instances}\")\n",
+    "else:\n",
+    "    print(\"Bibliotheques non disponibles : exploration ignoree.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ae872a2",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Structure du fichier animals.ttl\n",
+    "\n",
+    "Le fichier Turtle contient :\n",
+    "\n",
+    "| Element | Quantite | Exemples |\n",
+    "|---------|----------|----------|\n",
+    "| Classes | 6 | Animal, Mammal, Bird, Dog, Cat, Parrot |\n",
+    "| Proprietes | 4 | name, age, sound, canFly |\n",
+    "| Instances | 4 | rex (Dog), minou (Cat), coco (Parrot), buddy (Dog) |\n",
+    "| Relations subClassOf | 5 | Dog < Mammal < Animal, etc. |\n",
+    "\n",
+    "**Observation importante** : Les instances sont typees avec leur classe la plus specifique (ex: `ex:rex a ex:Dog`), mais **pas** avec les classes parentes. Un raisonneur RDFS deduira que Rex est aussi un Mammal et un Animal."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59010712",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Inference RDFS\n",
+    "\n",
+    "L'inference RDFS permet de **deduire automatiquement** de nouveaux triplets a partir des regles RDFS. Le mecanisme principal est la **transitivite de `rdfs:subClassOf`**.\n",
+    "\n",
+    "> Les regles d'inference RDFS presentees ci-dessous (rdfs2, rdfs3, rdfs5, rdfs9, rdfs11) sont les **regles d'entailment** formellement specifiees dans RDF 1.1 Semantics (Hayes & Patel-Schneider, W3C Recommendation 2014). Elles definissent quels triplets peuvent etre deduits a partir d'un graphe RDFS.\n",
+    "\n",
+    "### Regles d'inference RDFS essentielles\n",
+    "\n",
+    "| Regle | Premisses | Conclusion |\n",
+    "|-------|-----------|------------|\n",
+    "| **rdfs9** (heritage de type) | `?C rdfs:subClassOf ?D` et `?X rdf:type ?C` | `?X rdf:type ?D` |\n",
+    "| **rdfs11** (transitivite) | `?A rdfs:subClassOf ?B` et `?B rdfs:subClassOf ?C` | `?A rdfs:subClassOf ?C` |\n",
+    "| **rdfs5** (sous-propriete) | `?P rdfs:subPropertyOf ?Q` et `?X ?P ?Y` | `?X ?Q ?Y` |\n",
+    "| **rdfs2** (domaine) | `?P rdfs:domain ?C` et `?X ?P ?Y` | `?X rdf:type ?C` |\n",
+    "| **rdfs3** (portee) | `?P rdfs:range ?C` et `?X ?P ?Y` | `?Y rdf:type ?C` |\n",
+    "\n",
+    "### Exemple concret\n",
+    "\n",
+    "Avec nos donnees :\n",
+    "```turtle\n",
+    "ex:Dog rdfs:subClassOf ex:Mammal .\n",
+    "ex:Mammal rdfs:subClassOf ex:Animal .\n",
+    "ex:rex rdf:type ex:Dog .\n",
+    "```\n",
+    "\n",
+    "L'inference RDFS deduit :\n",
+    "```turtle\n",
+    "ex:rex rdf:type ex:Mammal .         # Par rdfs9 (Dog < Mammal)\n",
+    "ex:rex rdf:type ex:Animal .         # Par rdfs9 (Mammal < Animal)\n",
+    "ex:Dog rdfs:subClassOf ex:Animal .  # Par rdfs11 (transitivite)\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e16c9de3",
+   "metadata": {},
+   "source": [
+    "### Demonstration : inference manuelle (pedagogique)\n",
+    "\n",
+    "Implementons d'abord l'inference manuellement, **a but pedagogique uniquement**, pour bien comprendre le mecanisme du point fixe. En production, on utilise owlrl (section suivante) qui applique l'ensemble complet des regles W3C."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "703a1e74",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.751125Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.751125Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.757854Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.757854Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== AVANT inference ===\n",
+      "Nombre de triplets : 3\n",
+      "Types de rex :\n",
+      "  rex rdf:type Dog\n",
+      "\n",
+      "Iteration 1 : 1 triplet(s) infere(s)\n",
+      "  + rex rdf:type Mammal\n",
+      "Iteration 2 : 1 triplet(s) infere(s)\n",
+      "  + rex rdf:type Animal\n",
+      "\n",
+      "=== APRES inference ===\n",
+      "Nombre de triplets : 5\n",
+      "Types de rex :\n",
+      "  rex rdf:type Animal\n",
+      "  rex rdf:type Dog\n",
+      "  rex rdf:type Mammal\n"
+     ]
+    }
+   ],
+   "source": [
+    "if LIBS_AVAILABLE:\n",
+    "    # Demonstration pedagogique : implementer manuellement la regle rdfs9\n",
+    "    # (heritage de type par rdfs:subClassOf) avec un point fixe.\n",
+    "    #\n",
+    "    # ATTENTION : cette cellule est pedagogique. Pour du raisonnement reel,\n",
+    "    # utilisez owlrl (cellule suivante) qui couvre l'ensemble des regles W3C.\n",
+    "\n",
+    "    data = Graph()\n",
+    "    data.bind(\"ex\", Namespace(\"http://example.org/animals#\"))\n",
+    "\n",
+    "    animal_n = URIRef(\"http://example.org/animals#Animal\")\n",
+    "    mammal_n = URIRef(\"http://example.org/animals#Mammal\")\n",
+    "    dog_n    = URIRef(\"http://example.org/animals#Dog\")\n",
+    "    rex      = URIRef(\"http://example.org/animals#rex\")\n",
+    "\n",
+    "    # Schema\n",
+    "    data.add((dog_n,    RDFS.subClassOf, mammal_n))\n",
+    "    data.add((mammal_n, RDFS.subClassOf, animal_n))\n",
+    "\n",
+    "    # Instance\n",
+    "    data.add((rex, RDF.type, dog_n))\n",
+    "\n",
+    "    print(\"=== AVANT inference ===\")\n",
+    "    print(f\"Nombre de triplets : {len(data)}\")\n",
+    "    print(\"Types de rex :\")\n",
+    "    for _, _, o in data.triples((rex, RDF.type, None)):\n",
+    "        print(f\"  rex rdf:type {str(o).split('#')[-1]}\")\n",
+    "    print()\n",
+    "\n",
+    "    # --- Inference manuelle : regle rdfs9 ---\n",
+    "    # Pour chaque \"?X rdf:type ?C\" et \"?C rdfs:subClassOf ?D\", ajouter \"?X rdf:type ?D\"\n",
+    "    iteration = 0\n",
+    "    while True:\n",
+    "        iteration += 1\n",
+    "        new_triples = []\n",
+    "        # Snapshot des types et sous-classes courantes\n",
+    "        for x, _, c in list(data.triples((None, RDF.type, None))):\n",
+    "            for _, _, d in data.triples((c, RDFS.subClassOf, None)):\n",
+    "                inferred = (x, RDF.type, d)\n",
+    "                if inferred not in data and inferred not in new_triples:\n",
+    "                    new_triples.append(inferred)\n",
+    "\n",
+    "        if not new_triples:\n",
+    "            break\n",
+    "\n",
+    "        for t in new_triples:\n",
+    "            data.add(t)\n",
+    "\n",
+    "        print(f\"Iteration {iteration} : {len(new_triples)} triplet(s) infere(s)\")\n",
+    "        for s, _, o in new_triples:\n",
+    "            print(f\"  + {str(s).split('#')[-1]} rdf:type {str(o).split('#')[-1]}\")\n",
+    "    print()\n",
+    "\n",
+    "    print(\"=== APRES inference ===\")\n",
+    "    print(f\"Nombre de triplets : {len(data)}\")\n",
+    "    print(\"Types de rex :\")\n",
+    "    for _, _, o in sorted(data.triples((rex, RDF.type, None)), key=lambda t: str(t[2])):\n",
+    "        print(f\"  rex rdf:type {str(o).split('#')[-1]}\")\n",
+    "else:\n",
+    "    print(\"Bibliotheques non disponibles : demonstration ignoree.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4624215",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Inference manuelle\n",
+    "\n",
+    "**Sortie obtenue** : A partir de 3 triplets initiaux, l'inference a deduit 2 triplets supplementaires.\n",
+    "\n",
+    "| Iteration | Triplet infere | Regle appliquee |\n",
+    "|-----------|---------------|------------------|\n",
+    "| 1 | `rex rdf:type Mammal` | rdfs9 : rex est Dog, Dog < Mammal |\n",
+    "| 2 | `rex rdf:type Animal` | rdfs9 : rex est Mammal, Mammal < Animal |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. L'algorithme est un **point fixe** : on itere jusqu'a ce qu'aucun nouveau triplet ne soit infere\n",
+    "2. Chaque iteration propage les types d'un niveau dans la hierarchie\n",
+    "3. Le nombre d'iterations depend de la **profondeur** de la hierarchie de classes\n",
+    "\n",
+    "> **En pratique**, on utilise owlrl plutot que cette implementation manuelle. Mais comprendre le mecanisme est essentiel : owlrl applique la meme logique de point fixe, mais sur les **51 regles** d'entailment W3C complet (rdfs2, rdfs3, rdfs5, rdfs7, rdfs9, rdfs11, etc.), pas seulement rdfs9.\n",
+    "\n",
+    "La regle d'inférence **rdfs9** (heritage de type par `rdfs:subClassOf`), rendue sous forme de graphe pour l'instance `ex:rex`. En trait plein : les 3 triplets *assertes* ; en tirete ambre : les 2 triplets *inferes* par transitivite.\n",
+    "\n",
+    "```mermaid\n",
+    "graph BT\n",
+    "    rex[\"ex:rex (instance)\"]\n",
+    "    Dog[\"ex:Dog\"]\n",
+    "    Mammal[\"ex:Mammal\"]\n",
+    "    Animal[\"ex:Animal\"]\n",
+    "    rex -->|\"rdf:type (asserte)\"| Dog\n",
+    "    Dog -->|\"rdfs:subClassOf\"| Mammal\n",
+    "    Mammal -->|\"rdfs:subClassOf\"| Animal\n",
+    "    rex -.->|\"rdf:type (infere)\"| Mammal\n",
+    "    rex -.->|\"rdf:type (infere)\"| Animal\n",
+    "    classDef inst fill:#cfe2ff,stroke:#084298,color:#052c65\n",
+    "    classDef cls fill:#d1e7dd,stroke:#0f5132,color:#052e16\n",
+    "    class rex inst\n",
+    "    class Dog,Mammal,Animal cls\n",
+    "    linkStyle 3,4 stroke:#b8860b,stroke-width:2px\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** Partant de **3 triplets** (`rex rdf:type Dog`, `Dog subClassOf Mammal`, `Mammal subClassOf Animal`), la regle rdfs9 — *« si `?x rdf:type ?C` et `?C rdfs:subClassOf ?D`, alors `?x rdf:type ?D` »* — deduit **2 triplets** supplementaires : `rex rdf:type Mammal` puis, en reappliquant la regle, `rex rdf:type Animal`. Le point-fixe est atteint quand plus aucun nouveau triplet n'apparait."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e081d9ad",
+   "metadata": {},
+   "source": [
+    "### Utilisation du raisonneur RDFS owlrl\n",
+    "\n",
+    "**owlrl** est le raisonneur RDFS/OWL de reference en Python pur. Il implemente l'ensemble des regles d'entailment du W3C (RDF 1.1 Semantics) et materialise les triplets inferes directement dans le graphe. C'est l'equivalent fonctionnel du `StaticRdfsReasoner` de dotNetRDF.\n",
+    "\n",
+    "L'API principale est `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(graph)` : on instancie une closure avec un jeu de semantiques (ici RDFS seul ; `owlrl.OWLRL_Semantics` pour OWL 2 RL), puis on appelle `expand()` qui mute le graphe en place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0a441ee8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.757854Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.757854Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.775973Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.775973Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avant inference : 51 triplets\n",
+      "Types de rex avant inference :\n",
+      "  - Dog\n",
+      "\n",
+      "Apres inference : 148 triplets (+97 inferes)\n",
+      "\n",
+      "Types de rex apres inference :\n",
+      "  - Animal\n",
+      "  - Dog\n",
+      "  - Mammal\n",
+      "\n",
+      "Types de coco apres inference :\n",
+      "  - Animal\n",
+      "  - Bird\n",
+      "  - Parrot\n"
+     ]
+    }
+   ],
+   "source": [
+    "if LIBS_AVAILABLE:\n",
+    "    # Charger animals.ttl dans un nouveau graphe frais\n",
+    "    animal_graph = Graph()\n",
+    "    animal_graph.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "\n",
+    "    triplets_before = len(animal_graph)\n",
+    "    print(f\"Avant inference : {triplets_before} triplets\")\n",
+    "\n",
+    "    rex_uri  = URIRef(\"http://example.org/animals#rex\")\n",
+    "    coco_uri = URIRef(\"http://example.org/animals#coco\")\n",
+    "\n",
+    "    print(\"Types de rex avant inference :\")\n",
+    "    for _, _, o in sorted(animal_graph.triples((rex_uri, RDF.type, None)), key=lambda t: str(t[2])):\n",
+    "        print(f\"  - {str(o).split('#')[-1]}\")\n",
+    "    print()\n",
+    "\n",
+    "    # === Application du VRAI raisonneur RDFS owlrl ===\n",
+    "    # owlrl.DeductiveClosure.expand() materialise les triplets inferes dans le graphe.\n",
+    "    # C'est l'equivalent Python de `StaticRdfsReasoner.Apply(graph)` en dotNetRDF.\n",
+    "    owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(animal_graph)\n",
+    "\n",
+    "    triplets_after = len(animal_graph)\n",
+    "    print(f\"Apres inference : {triplets_after} triplets (+{triplets_after - triplets_before} inferes)\")\n",
+    "    print()\n",
+    "\n",
+    "    print(\"Types de rex apres inference :\")\n",
+    "    for _, _, o in sorted(animal_graph.triples((rex_uri, RDF.type, None)), key=lambda t: str(t[2])):\n",
+    "        if \"animals#\" in str(o):\n",
+    "            print(f\"  - {str(o).split('#')[-1]}\")\n",
+    "    print()\n",
+    "\n",
+    "    print(\"Types de coco apres inference :\")\n",
+    "    for _, _, o in sorted(animal_graph.triples((coco_uri, RDF.type, None)), key=lambda t: str(t[2])):\n",
+    "        if \"animals#\" in str(o):\n",
+    "            print(f\"  - {str(o).split('#')[-1]}\")\n",
+    "else:\n",
+    "    print(\"Bibliotheques non disponibles : raisonneur ignore.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f69650f",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Raisonneur RDFS owlrl\n",
+    "\n",
+    "Le `DeductiveClosure(RDFS_Semantics)` a enrichi le graphe automatiquement. Le nombre de triplets inferes est nettement plus grand que dans la demo manuelle car owlrl applique **l'ensemble des regles W3C**, pas seulement rdfs9 :\n",
+    "\n",
+    "| Regle W3C | Effet materialise |\n",
+    "|-----------|-------------------|\n",
+    "| **rdfs9** | `rex rdf:type Mammal`, `rex rdf:type Animal`, etc. |\n",
+    "| **rdfs3** | Les objets des proprietes typees `xsd:string` deviennent des litteraux string |\n",
+    "| **rdfs2** | Les sujets de `ex:name` etc. sont types `ex:Animal` (meme si non declares) |\n",
+    "| **rdfs11** | `Dog rdfs:subClassOf Animal` (transitivite de la hierarchie) |\n",
+    "| axiomatique | Tout est aussi `rdfs:Resource`, `rdf:type` est typing, etc. |\n",
+    "\n",
+    "| Instance | Types explicites | Types inferes (animaux) |\n",
+    "|----------|-----------------|-------------------------|\n",
+    "| `rex` | Dog | Mammal, Animal |\n",
+    "| `minou` | Cat | Mammal, Animal |\n",
+    "| `coco` | Parrot | Bird, Animal |\n",
+    "| `buddy` | Dog | Mammal, Animal |\n",
+    "\n",
+    "**Comparaison** :\n",
+    "- **Sans inference** : seul le type le plus specifique est present\n",
+    "- **Avec inference** : tous les super-types sont materialises dans le graphe\n",
+    "\n",
+    "> **Note technique** : owlrl materialise les triplets inferes **directement dans le graphe**. C'est une approche de **materialisation** (par opposition au raisonnement a la requete). C'est exactement la meme philosophie que `StaticRdfsReasoner` en dotNetRDF."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7254545",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 6. Interroger les donnees enrichies par l'inference\n",
+    "\n",
+    "Maintenant que le graphe a ete enrichi par owlrl, utilisons SPARQL pour interroger les donnees inferees. rdflib integre un moteur SPARQL natif : `graph.query(sparql_string)` retourne un iterable de lignes de resultats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8ed1c096",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.775973Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.775973Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.882422Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.882422Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tous les animaux (grace a l'inference rdf:type Animal) :\n",
+      "------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Buddy      (type: Dog)\n",
+      "  Buddy      (type: Mammal)\n",
+      "  Coco       (type: Bird)\n",
+      "  Coco       (type: Parrot)\n",
+      "  Minou      (type: Cat)\n",
+      "  Minou      (type: Mammal)\n",
+      "  Rex        (type: Dog)\n",
+      "  Rex        (type: Mammal)\n",
+      "\n",
+      "(8 lignes de resultat)\n"
+     ]
+    }
+   ],
+   "source": [
+    "if LIBS_AVAILABLE:\n",
+    "    # Requete SPARQL : trouver tous les animaux (grace a l'inference)\n",
+    "    # NB : le FILTER restreint ?type aux classes de notre namespace animals# pour\n",
+    "    # exclure le typing axiomatique rdfs:Resource qu'owlrl materialise aussi.\n",
+    "    query1 = \"\"\"\n",
+    "    PREFIX ex: <http://example.org/animals#>\n",
+    "    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+    "\n",
+    "    SELECT ?animal ?name ?type\n",
+    "    WHERE {\n",
+    "        ?animal rdf:type ex:Animal .\n",
+    "        ?animal ex:name ?name .\n",
+    "        ?animal rdf:type ?type .\n",
+    "        FILTER(STRSTARTS(STR(?type), \"http://example.org/animals#\") && ?type != ex:Animal)\n",
+    "    }\n",
+    "    ORDER BY ?name ?type\n",
+    "    \"\"\"\n",
+    "\n",
+    "    print(\"Tous les animaux (grace a l'inference rdf:type Animal) :\")\n",
+    "    print(\"-\" * 60)\n",
+    "    rows = list(animal_graph.query(query1))\n",
+    "    for row in rows:\n",
+    "        name = str(row.name)\n",
+    "        type_uri = str(row.type)\n",
+    "        type_name = type_uri.split(\"#\")[-1]\n",
+    "        print(f\"  {name:10s} (type: {type_name})\")\n",
+    "    print(f\"\\n({len(rows)} lignes de resultat)\")\n",
+    "else:\n",
+    "    print(\"Bibliotheques non disponibles : requete SPARQL ignoree.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10bf1cc7",
+   "metadata": {},
+   "source": [
+    "La requete `?animal rdf:type ex:Animal` retourne **tous les animaux**, y compris ceux qui sont seulement types comme Dog, Cat ou Parrot. C'est la puissance de l'inference RDFS : on interroge a un niveau d'abstraction eleve sans avoir a enumerer toutes les sous-classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "162b7df7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.882422Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.882422Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.900885Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.900885Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tous les mammiferes (Dogs + Cats, grace a l'inference) :\n",
+      "------------------------------------------------------------\n",
+      "  Buddy      : Woof woof\n",
+      "  Minou      : Miaou\n",
+      "  Rex        : Woof\n",
+      "\n",
+      "Nombre d'instances par classe (avec inference) :\n",
+      "--------------------------------------------------\n",
+      "  Animal     : 4 instance(s)\n",
+      "  Mammal     : 3 instance(s)\n",
+      "  Dog        : 2 instance(s)\n",
+      "  Bird       : 1 instance(s)\n",
+      "  Cat        : 1 instance(s)\n",
+      "  Parrot     : 1 instance(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "if LIBS_AVAILABLE:\n",
+    "    # Requete 2 : trouver tous les mammiferes (chiens ET chats, par inference)\n",
+    "    query2 = \"\"\"\n",
+    "    PREFIX ex: <http://example.org/animals#>\n",
+    "    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+    "\n",
+    "    SELECT ?animal ?name ?sound\n",
+    "    WHERE {\n",
+    "        ?animal rdf:type ex:Mammal .\n",
+    "        ?animal ex:name ?name .\n",
+    "        OPTIONAL { ?animal ex:sound ?sound . }\n",
+    "    }\n",
+    "    ORDER BY ?name\n",
+    "    \"\"\"\n",
+    "\n",
+    "    print(\"Tous les mammiferes (Dogs + Cats, grace a l'inference) :\")\n",
+    "    print(\"-\" * 60)\n",
+    "    for row in animal_graph.query(query2):\n",
+    "        name = str(row.name)\n",
+    "        sound = str(row.sound) if row.sound is not None else \"(inconnu)\"\n",
+    "        print(f\"  {name:10s} : {sound}\")\n",
+    "    print()\n",
+    "\n",
+    "    # Requete 3 : compter les instances par classe\n",
+    "    # NB : on nomme les variables ?cls (pas ?class, mot-cle Python) et ?n\n",
+    "    # (pas ?count, qui collide avec ResultRow.count -- la methode de tuple Row).\n",
+    "    query3 = \"\"\"\n",
+    "    PREFIX ex: <http://example.org/animals#>\n",
+    "    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+    "    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+    "\n",
+    "    SELECT ?cls (COUNT(DISTINCT ?instance) AS ?n)\n",
+    "    WHERE {\n",
+    "        ?cls a rdfs:Class .\n",
+    "        ?instance a ?cls .\n",
+    "        FILTER(STRSTARTS(STR(?cls), \"http://example.org/animals#\"))\n",
+    "    }\n",
+    "    GROUP BY ?cls\n",
+    "    ORDER BY DESC(?n)\n",
+    "    \"\"\"\n",
+    "\n",
+    "    print(\"Nombre d'instances par classe (avec inference) :\")\n",
+    "    print(\"-\" * 50)\n",
+    "    for row in animal_graph.query(query3):\n",
+    "        cls_name = str(row.cls).split(\"#\")[-1]\n",
+    "        n = str(row.n)\n",
+    "        print(f\"  {cls_name:10s} : {n} instance(s)\")\n",
+    "else:\n",
+    "    print(\"Bibliotheques non disponibles : requetes SPARQL ignorees.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff8aa2dd",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Requetes sur donnees inferees\n",
+    "\n",
+    "| Classe | Instances directes | Instances inferees | Total |\n",
+    "|--------|-------------------|--------------------|-------|\n",
+    "| Animal | 0 | 4 (rex, minou, coco, buddy) | 4 |\n",
+    "| Mammal | 0 | 3 (rex, minou, buddy) | 3 |\n",
+    "| Bird | 0 | 1 (coco) | 1 |\n",
+    "| Dog | 2 (rex, buddy) | 0 | 2 |\n",
+    "| Cat | 1 (minou) | 0 | 1 |\n",
+    "| Parrot | 1 (coco) | 0 | 1 |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. La classe `Animal` n'a **aucune instance directe** mais 4 par inference\n",
+    "2. Les requetes SPARQL fonctionnent sur le graphe materialise, incluant les triplets inferes\n",
+    "3. C'est un avantage majeur de RDFS : les donnees sont flexibles mais interrogeables a differents niveaux d'abstraction\n",
+    "\n",
+    "> **Note** : la clause `FILTER(STRSTARTS(STR(?class), \"http://example.org/animals#\"))` restreint le comptage aux classes de notre namespace. Sans elle, owlrl a aussi materialise des triplets axiomatiques comme `rex rdf:type rdfs:Resource` qui gonfleraient les comptes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfead585",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 7. Comparaison cross-language : dotNetRDF vs rdflib + owlrl\n",
+    "\n",
+    "Le notebook SW-6 (C#) et le present notebook (Python) traitent du **meme domaine** (taxonomie animale RDFS) avec des **moteurs RDFS reels** equivalents. Cette section repertorie les differences fines observees entre les deux stacks -- c'est la valeur ajoutée du miroir Python.\n",
+    "\n",
+    "### Synthese operationnelle\n",
+    "\n",
+    "| Aspect | dotNetRDF (SW-6 C#) | rdflib + owlrl (present) |\n",
+    "|--------|---------------------|---------------------------|\n",
+    "| **API graphe** | `Graph.Assert(new Triple(s, p, o))` | `g.add((s, p, o))` -- tuple Python |\n",
+    "| **Parsing Turtle** | `TurtleParser().Load(g, \"file.ttl\")` | `g.parse(\"file.ttl\", format=\"turtle\")` |\n",
+    "| **SPARQL** | `LeviathanQueryProcessor` + `SparqlQueryParser` | `g.query(sparql_string)` -- one-liner |\n",
+    "| **Raisonneur RDFS** | `StaticRdfsReasoner.Apply(g)` (une ligne) | `owlrl.DeductiveClosure(RDFS_Semantics).expand(g)` |\n",
+    "| **Couverture des regles** | Regles RDFS core (rdfs2/3/5/7/9/11) | RDFS Semantics complet (RDF 1.1) |\n",
+    "| **Materialisation** | Mutations in-place du graphe | Mutations in-place du graphe (meme philosophie) |\n",
+    "| **Rapport d'execution** | Aucun (silencieux) | Aucun (silencieux) ; `closure.closure_ok` disponible |\n",
+    "\n",
+    "### Difficultes rencontrees (et comment les contourner)\n",
+    "\n",
+    "| Difficulte | Solution cote Python |\n",
+    "|------------|----------------------|\n",
+    "| L'API `owlrl.RDFSClosure.RDFSClosure(g)` n'existe pas dans owlrl 7.x (pourtant citee dans d'anciens tutoriels) | Utiliser `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)` -- l'API moderne |\n",
+    "| rdflib `Literal` vs litteral Turtle `5` (entier non type) | rdflib devine `XSD.integer` au parsing ; pour les assertions en code, utiliser `Literal(5, datatype=XSD.integer)` |\n",
+    "| Les prefixes dans la sortie SPARQL | Iterer sur `row.varname` donne des objets rdflib natifs ; formater avec `.split(\"#\")[-1]` |\n",
+    "| owlrl ajoute aussi des triplets axiomatics (`rdfs:Resource`, etc.) | Filtrer par namespace `STRSTARTS(STR(?x), \"http://example.org/animals#\")` dans SPARQL |\n",
+    "\n",
+    "### Ergonomie comparee\n",
+    "\n",
+    "L'API rdflib est plus **pythonique** (tuples, iterations naturelles, namespaces W3C comme constantes), tandis que dotNetRDF est plus **typee** (`IUriNode` vs `URIRef`, `Triple` objet vs tuple). Pour du raisonnement, **owlrl est plus verbeux a invoquer** (3 symboles : `DeductiveClosure` + `RDFS_Semantics` + `expand`) mais couvre davantage de regles W3C que le `StaticRdfsReasoner` de dotNetRDF qui se limite au coeur RDFS.\n",
+    "\n",
+    "> **Choix pratique** : pour un cours Python-first de Web Semantique, le binome rdflib + owlrl est autonomme et couvre tout le programme RDFS/OWL-RL. Pour un cours .NET, dotNetRDF integre raisonneur et SPARQL dans la meme bibliotheque, ce qui evite une dependance supplementaire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d14a290e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices ci-dessous sont a completer. Le notebook doit pouvoir s'executer de bout en bout meme si les exercices restent vides (les stubs utilisent `print(\"Exercice a completer\")` -- jamais d'erreur volontaire).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42f0a956",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Creer un vocabulaire RDFS pour une bibliotheque\n",
+    "\n",
+    "Creez un schema RDFS pour un domaine de bibliotheque avec :\n",
+    "- Classes : `Publication`, `Book`, `Article`, `Author`, `Publisher`\n",
+    "- Hierarchie : `Book` et `Article` sont des sous-classes de `Publication`\n",
+    "- Proprietes : `title` (domain: Publication, range: string), `writtenBy` (domain: Publication, range: Author), `publishedBy` (domain: Book, range: Publisher), `year` (domain: Publication, range: integer)\n",
+    "- Instances : au moins 2 livres et 1 article avec leurs auteurs\n",
+    "- Appliquez le raisonneur owlrl et verifiez que les types sont bien inferes (un `Book` devient aussi une `Publication`).\n",
+    "\n",
+    "**Indices** :\n",
+    "- Inspirez-vous de la section 3 : `g.add((EX.Book, RDFS.subClassOf, EX.Publication))` declare la hierarchie.\n",
+    "- Pour les proprietes : `g.add((EX.title, RDF.type, RDF.Property))` + `g.add((EX.title, RDFS.domain, EX.Publication))` + `g.add((EX.title, RDFS.range, XSD.string))`.\n",
+    "- Pour le raisonnement : `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)` puis verifiez qu'une instance de `Book` a bien aussi `rdf:type Publication`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "193898f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.900885Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.900885Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.905166Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.905166Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : vocabulaire RDFS pour une bibliotheque\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Vocabulaire RDFS pour une bibliotheque\n",
+    "# TODO etudiant : construire le schema, les instances, appliquer owlrl\n",
+    "#\n",
+    "# Etape 1 : creer le graphe et le namespace EX = Namespace(\"http://example.org/library#\")\n",
+    "# Etape 2 : declarer les 5 classes (Publication, Book, Article, Author, Publisher)\n",
+    "# Etape 3 : declarer la hierarchie (Book < Publication, Article < Publication)\n",
+    "# Etape 4 : declarer les 4 proprietes avec domain/range\n",
+    "# Etape 5 : creer 2 instances de Book et 1 instance de Article\n",
+    "# Etape 6 : appliquer owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)\n",
+    "# Etape 7 : verifier qu'un livre a bien rdf:type Publication (en plus de Book)\n",
+    "\n",
+    "print(\"Exercice 1 a completer : vocabulaire RDFS pour une bibliotheque\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b016946a",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Requete SPARQL avec inference RDFS\n",
+    "\n",
+    "Les sections precedentes ont montre le raisonneur owlrl et les requetes SPARQL. Reproduisez le pattern complet sur le fichier `data/animals.ttl` :\n",
+    "\n",
+    "**Indices** :\n",
+    "- Chargez `data/animals.ttl` dans un graphe frais avec `g.parse(...)`.\n",
+    "- Appliquez owlrl : `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)`.\n",
+    "- Ecrivez une requete SPARQL qui retourne **tous les animaux dont le cri contient la lettre \"o\"** (indice : `FILTER(CONTAINS(LCASE(?sound), \"o\"))`).\n",
+    "- Verifiez que le resultat inclut aussi bien `rex` (Dog) que `buddy` (Dog) et `coco` (Parrot) -- tous trois typés `Animal` par inference, meme si seul `rex` est declare explicitement comme Dog dans le fichier source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "552a9040",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.905166Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.905166Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.908640Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.908640Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : requete SPARQL sur donnees enrichies par owlrl\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Requete SPARQL sur donnees enrichies par owlrl\n",
+    "# TODO etudiant : charger animals.ttl, appliquer owlrl, executer une SPARQL\n",
+    "#\n",
+    "# Etape 1 : g = Graph() ; g.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "# Etape 2 : owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)\n",
+    "# Etape 3 : ecrire une SPARQL qui trouve tous les animaux (rdf:type ex:Animal)\n",
+    "#           dont le cri (ex:sound) contient la lettre \"o\"\n",
+    "# Etape 4 : afficher les resultats (au moins rex ET buddy, qui sont Animal par inference)\n",
+    "\n",
+    "print(\"Exercice 2 a completer : requete SPARQL sur donnees enrichies par owlrl\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54f90afc",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Chaine d'inference profonde (transitivite)\n",
+    "\n",
+    "Creez une hierarchie de classes plus profonde pour tester la transitivite de `rdfs:subClassOf` :\n",
+    "- `LivingThing` > `Animal` > `Vertebrate` > `Mammal` > `Primate` > `Human`\n",
+    "- Creez une instance `alice rdf:type Human`\n",
+    "- Affichez les types de `alice` **avant** inference\n",
+    "- Appliquez owlrl et affichez les types de `alice` **apres** inference\n",
+    "- Verifiez que `alice` est bien typee par les **6 classes** de la hierarchie (LivingThing, Animal, Vertebrate, Mammal, Primate, Human)\n",
+    "\n",
+    "**Indices** :\n",
+    "- Une boucle `for i in range(len(chain) - 1): g.add((chain[i+1], RDFS.subClassOf, chain[i]))` permet de declarer la chaine en une ligne.\n",
+    "- Apres `expand(g)`, parcourez `g.triples((alice, RDF.type, None))` et collectez les noms de classes.\n",
+    "- owlrl materialise aussi le typing `rdfs:Resource` ; filtrez par namespace `http://example.org/biology#` pour ne garder que vos classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "af715bf6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:32:36.908640Z",
+     "iopub.status.busy": "2026-07-07T01:32:36.908640Z",
+     "iopub.status.idle": "2026-07-07T01:32:36.912755Z",
+     "shell.execute_reply": "2026-07-07T01:32:36.912755Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : chaine d'inference profonde\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Chaine d'inference profonde\n",
+    "# TODO etudiant : hierarchie profonde, instance alice, owlrl, verification\n",
+    "#\n",
+    "# Etape 1 : g = Graph() ; BIO = Namespace(\"http://example.org/biology#\")\n",
+    "# Etape 2 : declarer la chaine LivingThing > Animal > Vertebrate > Mammal > Primate > Human\n",
+    "# Etape 3 : creer alice rdf:type Human\n",
+    "# Etape 4 : afficher les types AVANT inference (1 seul : Human)\n",
+    "# Etape 5 : appliquer owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)\n",
+    "# Etape 6 : afficher les types APRES inference (6 classes attendues)\n",
+    "\n",
+    "print(\"Exercice 3 a completer : chaine d'inference profonde\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fc3bd3e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Resume\n",
+    "\n",
+    "### Vocabulaire RDFS essentiel\n",
+    "\n",
+    "| Terme | Utilisation | Exemple |\n",
+    "|-------|------------|----------|\n",
+    "| `rdfs:Class` | Declarer une classe | `ex:Dog rdf:type rdfs:Class` |\n",
+    "| `rdfs:subClassOf` | Hierarchie de classes | `ex:Dog rdfs:subClassOf ex:Mammal` |\n",
+    "| `rdfs:subPropertyOf` | Hierarchie de proprietes | `ex:father rdfs:subPropertyOf ex:parent` |\n",
+    "| `rdfs:domain` | Type du sujet | `ex:name rdfs:domain ex:Animal` |\n",
+    "| `rdfs:range` | Type de l'objet/valeur | `ex:name rdfs:range xsd:string` |\n",
+    "| `rdfs:label` | Etiquette lisible | `ex:Dog rdfs:label \"Chien\"@fr` |\n",
+    "| `rdfs:comment` | Description | `ex:Dog rdfs:comment \"Un canide domestique\"` |\n",
+    "\n",
+    "### Ce que nous avons appris\n",
+    "\n",
+    "1. **RDFS enrichit RDF** avec un vocabulaire pour decrire la structure des donnees\n",
+    "2. **Les hierarchies de classes** (`rdfs:subClassOf`) permettent l'heritage de type\n",
+    "3. **L'inference RDFS** deduit automatiquement des triplets implicites (regles rdfs2/3/5/9/11 du W3C)\n",
+    "4. **owlrl.DeductiveClosure(RDFS_Semantics).expand(g)** materialise les triplets inferes dans le graphe -- equivalent Python du `StaticRdfsReasoner` de dotNetRDF\n",
+    "5. **SPARQL sur donnees inferees** permet d'interroger a differents niveaux d'abstraction\n",
+    "\n",
+    "### Equivalences dotNetRDF / rdflib + owlrl\n",
+    "\n",
+    "| Operation | dotNetRDF (SW-6 C#) | rdflib + owlrl (present) |\n",
+    "|-----------|---------------------|---------------------------|\n",
+    "| Ajouter un triplet | `g.Assert(new Triple(s, p, o))` | `g.add((s, p, o))` |\n",
+    "| Litteral avec langue | `g.CreateLiteralNode(\"Chien\", \"fr\")` | `Literal(\"Chien\", lang=\"fr\")` |\n",
+    "| Charger Turtle | `TurtleParser().Load(g, file)` | `g.parse(file, format=\"turtle\")` |\n",
+    "| SPARQL | `LeviathanQueryProcessor` + parser | `g.query(sparql_string)` |\n",
+    "| Raisonneur RDFS | `StaticRdfsReasoner.Apply(g)` | `owlrl.DeductiveClosure(RDFS_Semantics).expand(g)` |\n",
+    "\n",
+    "### Limites de RDFS\n",
+    "\n",
+    "RDFS est volontairement simple. Il ne permet **pas** de :\n",
+    "- Definir des classes disjointes (Dog et Cat ne peuvent pas etre la meme instance)\n",
+    "- Exprimer des cardinalites (une personne a exactement 2 parents)\n",
+    "- Declarer des proprietes inverses (teaches / taughtBy)\n",
+    "- Exprimer des classes par union/intersection\n",
+    "\n",
+    "Pour ces fonctionnalites, il faut passer a **OWL** (notebook suivant).\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "- **RDF Schema 1.1** -- Brickley & Guha, W3C Recommendation (2014). [w3.org/TR/rdf-schema](https://www.w3.org/TR/rdf-schema/)\n",
+    "- **RDF 1.1 Semantics** -- Hayes & Patel-Schneider, W3C Recommendation (2014). Specifie formellement les regles d'entailment rdfs2/3/5/9/11. [w3.org/TR/rdf11-mt](https://www.w3.org/TR/rdf11-mt/)\n",
+    "- **rdflib documentation** -- [rdflib.readthedocs.io](https://rdflib.readthedocs.io/)\n",
+    "- **owlrl** -- Raisonneur RDFS/OWL-RL en Python pur. [github.com/RDFLib/OWL-RL](https://github.com/RDFLib/OWL-RL)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< SW-6 C#](SW-6-CSharp-RDFS.ipynb) | [SW-7b Python OWL >>](SW-7b-Python-OWL.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Twin Python pédagogique du notebook C# `SW-6-CSharp-RDFS`, dans le cadre du marathon de parité .NET ⇄ Python (**EPIC #4956**). Le C# original utilise le raisonneur RDFS **dotNetRDF** (`StaticRdfsReasoner`). Le twin Python invoque le **VRAI moteur RDFS owlrl** (`DeductiveClosure(RDFS_Semantics).expand`) — pas de workaround, pas d'inférence réimplémentée à la main en production.

**R6 pivot Python** : après 5 cycles .NET successifs (alerte dashboard c.280), ce cycle pivote vers Python (langage) tout en restant sur la famille SemanticWeb (connue c.280 SW-8). La convention SemanticWeb est inversée : les notebooks C# sont les originaux, les twins Python sont suffixés `-Python` avec `b` (cf. `SW-2b`, `SW-4b`, `SW-5b`, `SW-7b`).

## SOTA verdict (EPIC #3801) — SOTA-OK

Le vrai moteur **owlrl** est invoqué (rdflib 7.6.0 + owlrl 7.1.4) : `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)` — l'**API canonique** owlrl (PAS l'API obsolète `RDFSClosure.RDFSClosure` qui n'existe pas en 7.x). Une cellule pédagogique démontre manuellement la règle rdfs9 par point-fixe **uniquement pour illustrer le mécanisme** (clairement marquée), jamais comme reasoner de production. Les deux twins (C# dotNetRDF + Python owlrl) sont des compagnons cross-langage sur le **même standard W3C RDFS**. Une section comparative documente les écarts d'API, d'invocation du reasoner et de format de sortie.

## Contenu (39 cells : 13 code, 26 markdown)

- **Vocabulaire RDFS** : rdfs:Class, rdfs:subClassOf, rdfs:domain, rdfs:range, rdf:Property, rdfs:subPropertyOf, rdfs:label, rdfs:comment.
- **Construction d'un schéma** RDFS en code (rdflib `Graph`, namespaces).
- **Chargement** de `data/animals.ttl` (même fichier que le C# — fidélité cross-langage).
- **Inférence RDFS** : démonstration manuelle (rdfs9 point-fixe) puis **le vrai reasoner owlrl**.
- **Requêtes SPARQL** sur données enrichies par l'inférence (instances inférées d'une superclasse).
- **Section comparative** dotNetRDF vs rdflib+owlrl.
- **3 exercices** stub (vocabulaire RDFS bibliothèque, requête SPARQL+inference, chaîne d'inférence profonde).

## Preuve d'exécution (H.1 / EXEC_PROVED, vérifié firsthand)

- **13/13 cellules code** avec `execution_count` (1..13 contigus), **0 null, 0 erreur, 0 output vide**.
- `notebook_tools.py validate --quick` : **OK=1, Warnings=0, Errors=0**.
- **L268 check** : le blob commité est LF (`od -c` = `{ \n`), la règle `.gitattributes` `*.ipynb text eol=lf` s'applique — pas de fuite CRLF.

## Validation math/structuelle firsthand (Math Verification Standard)

Mon calcul indépendant sur `animals.ttl` reproduit **exactement** les outputs du notebook :

| Vérification | Ma valeur (indépendante) | Output notebook | Règle RDFS |
|--------------|--------------------------|-----------------|------------|
| Triplets avant→après closure | 51 → 148 (+97 inférés) | 51 → 148 (+97) | owlrl closure complète |
| `rex rdf:type` | [Animal, Dog, Mammal, Resource] | identique | **rdfs9** (transitivité sous-classe) |
| Instances inférées de `ex:Animal` | [buddy, coco, minou, rex] | identique | rdfs9 + rdfs2 (domain) |
| `Dog rdfs:subClassOf Animal` (inféré) | True | True | **rdfs11** (transitivité subClassOf) |

Le chaîne rdfs9 est documentée avec dérivation explicite : `rex rdf:type Dog` + `Dog subClassOf Mammal` → `rex rdf:type Mammal` + `Mammal subClassOf Animal` → `rex rdf:type Animal`.

## Conventions respectées

- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0` partout ; 3 exercices stubs (`# TODO étudiant`, `pass`, `return None`) en patterns conformes, distribués ec 11/12/13.
- **C.2** : outputs commités, `execution_count` entiers contigus sur toutes les cellules code.
- **readme-french-first** : prose pédagogique en français, 0 emoji, 0 CJK.
- **§E** : +2/−1 dans `SemanticWeb/README.md` (1 ligne table Partie 3 + 1 ligne tree), bloc `<!-- CATALOG-STATUS -->` byte-identical.
- **Délégation** : build → sous-agent notebook-designer (sonnet async) ; **vérification rigoureuse firsthand avant PR** (forensic H.5 + Math indépendante + validateur) par le parent. Quality bar = SW-8/Planners-4.

## Test plan

- [x] Execution end-to-end kernel `python3` (13/13 cellules, 0 erreur)
- [x] `notebook_tools.py validate --quick` OK
- [x] owlrl canonical invocation vérifiée (`DeductiveClosure(RDFS_Semantics).expand`)
- [x] Math hand-verification indépendante (51→148/97, rdfs9/rdfs11, 4 instances Animal)
- [x] Grep C.1 (0 pattern interdit), 0 emoji, 0 CJK
- [x] §E surgical (CATALOG-STATUS byte-identical)
- [x] Committed blob LF (L268 N/A — règle eol=lf existante)

Part of #4956 (marathon parité .NET ⇄ Python). Famille SemanticWeb (RDFS) — R6 pivot Python après alerte 5e .NET successive.