### PR TITLE
feat(semanticweb): SW-3b-Python-GraphOperations — twin Python rdflib graph ops (marathon #4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -147,7 +147,7 @@ Cette partie pose les fondations du Web Sémantique en utilisant l'écosystème 
 |---|----------|-------|------------------|
 | 1 | **SW-1-CSharp-Setup** | 20 min | - |
 | 2 | **SW-2-CSharp-RDFBasics** | 45 min | SW-2b-Python-RDFBasics |
-| 3 | **SW-3-CSharp-GraphOperations** | 50 min | - |
+| 3 | **SW-3-CSharp-GraphOperations** | 50 min | SW-3b-Python-GraphOperations |
 | 4 | **SW-4-CSharp-SPARQL** | 45 min | SW-4b-Python-SPARQL |
 
 #### SW-1-CSharp-Setup : Premier pas dans le Web Sémantique (20 min)
@@ -482,6 +482,7 @@ SemanticWeb/
 ├── SW-2-CSharp-RDFBasics.ipynb
 ├── SW-2b-Python-RDFBasics.ipynb     # Sidetrack
 ├── SW-3-CSharp-GraphOperations.ipynb
+├── SW-3b-Python-GraphOperations.ipynb   # Sidetrack
 ├── SW-4-CSharp-SPARQL.ipynb
 ├── SW-4b-Python-SPARQL.ipynb        # Sidetrack
 ├── SW-5-CSharp-LinkedData.ipynb

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
@@ -1,0 +1,1552 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cded4740e1d7",
+   "metadata": {},
+   "source": [
+    "# SW-3b-Python-GraphOperations\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< SW-3 C#](SW-3-CSharp-GraphOperations.ipynb) | [SW-4b Python >>](SW-4b-Python-SPARQL.ipynb)\n",
+    "\n",
+    "## Operations sur les graphes RDF en Python avec rdflib\n",
+    "\n",
+    "> Ce notebook est le **twin Python** du notebook [SW-3-CSharp-GraphOperations](SW-3-CSharp-GraphOperations.ipynb) (dotNetRDF). Il manipule des **graphes RDF** au moyen de la bibliotheque **rdflib** (open-source, `rdflib.readthedocs.io`), qui implémente le modèle de données abstrait de **RDF 1.1** (Cyganiak, Wood, Lanthaler (eds.), *RDF 1.1 Concepts and Abstract Syntax*, Recommandation W3C, 25 fevrier 2014). Les formats de sérialisation couverts (Turtle, RDF/XML, N-Triples, Notation 3, JSON-LD, TriG, N-Quads) sont tous des sérialisations normalisées de ce modèle abstrait.\n",
+    "\n",
+    "### Duree estimee : 50 minutes\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Lire** des fichiers RDF dans differents formats (Turtle, RDF/XML, N-Triples) avec `rdflib`\n",
+    "2. **Ecrire** des graphes RDF vers plusieurs formats via `g.serialize()`\n",
+    "3. **Fusionner** des graphes RDF avec l'operateur `+=` et `|` (semantique d'ensemble)\n",
+    "4. **Selectionner** des triplets selon differents criteres avec `g.triples()` et les accesseurs dedies\n",
+    "5. **Manipuler** des listes RDF (creer, lire, modifier, supprimer) avec `rdflib.collection.Collection`\n",
+    "\n",
+    "### Prerequis\n",
+    "- Python 3.10+\n",
+    "- Avoir complete [SW-2b-Python-RDFBasics](SW-2b-Python-RDFBasics.ipynb)\n",
+    "\n",
+    "> **Note** : Ce notebook est le miroir Python de SW-3 (dotNetRDF). La comparaison API dotNetRDF vs rdflib est explicitement documentee dans la section 6."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a93ca502e05",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 0. Installation et Imports\n",
+    "\n",
+    "**rdflib** est l'equivalent Python direct de **dotNetRDF**. Elle fournit une API pythonique pour toutes les operations RDF : parsing, serialization, selection, listes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "40a1f526dc0b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:39.533732Z",
+     "iopub.status.busy": "2026-07-07T01:53:39.533732Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.707547Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.707547Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Installation silencieuse de rdflib\n",
+    "%pip install -q rdflib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc0b384e4c46",
+   "metadata": {},
+   "source": [
+    "### Interpretation\n",
+    "\n",
+    "L'option `-q` (quiet) reduit la verbosite de pip. Une fois installe, rdflib expose une API pythonique (tuples Python, iterateurs) pour toutes les operations RDF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a58b5323c865",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.707547Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.707547Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.768551Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.768551Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rdflib 7.6.0 pret.\n",
+      "\n",
+      "Modules charges :\n",
+      "  Graph, URIRef, Literal, BNode, Namespace  (noeuds RDF)\n",
+      "  RDF, RDFS, XSD                             (vocabulaires W3C)\n",
+      "  Collection                                (listes RDF)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from rdflib import Graph, URIRef, Literal, BNode, Namespace\n",
+    "from rdflib.namespace import RDF, RDFS, XSD\n",
+    "from rdflib.collection import Collection\n",
+    "import io\n",
+    "\n",
+    "try:\n",
+    "    RDFLIB_AVAILABLE = True\n",
+    "    import rdflib\n",
+    "    print(f\"rdflib {rdflib.__version__} pret.\")\n",
+    "    print()\n",
+    "    print(\"Modules charges :\")\n",
+    "    print(f\"  Graph, URIRef, Literal, BNode, Namespace  (noeuds RDF)\")\n",
+    "    print(f\"  RDF, RDFS, XSD                             (vocabulaires W3C)\")\n",
+    "    print(f\"  Collection                                (listes RDF)\")\n",
+    "except ImportError:\n",
+    "    RDFLIB_AVAILABLE = False\n",
+    "    print(\"rdflib non disponible. Installez avec : pip install rdflib\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9cd33ef9a35",
+   "metadata": {},
+   "source": [
+    "### Interpretation : imports\n",
+    "\n",
+    "| Module rdflib | Rôle | Equivalent dotNetRDF |\n",
+    "|---------------|------|----------------------|\n",
+    "| `Graph` | Conteneur de triplets (ensemble) | `VDS.RDF.Graph` |\n",
+    "| `URIRef` / `BNode` / `Literal` | Types de noeuds | `IUriNode` / `IBlankNode` / `ILiteralNode` |\n",
+    "| `RDF`, `RDFS`, `XSD` | Namespaces W3C pre-configures | `UriFactory` + `g.NamespaceMap` |\n",
+    "| `Collection` | Listes RDF (`rdf:first` / `rdf:rest`) | `VDS.RDF.Extensions.GetListItems` |\n",
+    "\n",
+    "> Les noeuds rdflib sont **independants du graphe** (`URIRef(\"...\")` est autonome), contrairement a dotNetRDF ou les noeuds sont cres via `g.CreateUriNode(...)` (lies au graphe)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "538c3da5472e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Lecture de fichiers RDF\n",
+    "\n",
+    "La methode centrale de lecture est `Graph.parse()`, qui accepte un chemin de fichier, une URL, un fichier objet ou une chaine. Formats supportes : `turtle`, `xml`, `nt`, `n3`, `json-ld`, `trig`, `nquads`. rdflib detecte automatiquement le format si l'extension du fichier est connue ou si un `format=` explicite est fourni.\n",
+    "\n",
+    "> Chaque format correspond a une Recommandation W3C distincte de la famille **RDF 1.1** : Turtle (Beckett, Berners-Lee, Prud'hommeaux, 2014), N-Triples (Ackaert, Sporny, Kellogg, 2014 - la forme canonique ligne-par-triplet), Notation 3 (Berners-Lee, 2006, note non normative), RDF/XML (Beckett, 2004), JSON-LD (Sporny et al., 2014). TriG et N-Quads etendent ces formats aux *datasets* (graphes nommes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "607d03d6902f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.768551Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.768551Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.776474Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.776474Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichier  : 4 triplets\n",
+      "Flux     : 4 triplets\n",
+      "Identique: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1.1 Chargement depuis un fichier Turtle\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    # Methode A : par chemin de fichier (le plus courant)\n",
+    "    g = Graph()\n",
+    "    g.parse(\"data/Example.ttl\", format=\"turtle\")\n",
+    "\n",
+    "    # Methode B : par flux (objet fichier en memoire)\n",
+    "    with open(\"data/Example.ttl\", \"rb\") as f:\n",
+    "        data_bytes = f.read()\n",
+    "    h = Graph()\n",
+    "    h.parse(data=data_bytes, format=\"turtle\")\n",
+    "\n",
+    "    print(f\"Fichier  : {len(g)} triplets\")\n",
+    "    print(f\"Flux     : {len(h)} triplets\")\n",
+    "    print(f\"Identique: {len(g) == len(h)}\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : lecture ignoree.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36bde774aa1b",
+   "metadata": {},
+   "source": [
+    "Les deux methodes sont equivalents. `parse(data=...)` accepte des `bytes`, utile quand les donnees RDF proviennent d'une reponse HTTP ou d'un flux in-memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "98842ff2fcf2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.776474Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.776474Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.784491Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.784491Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Format explicite (nt)  : 1 triplet\n",
+      "Format explicite (ttl) : 1 triplet\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1.2 Parsing depuis une chaine : format explicite vs auto-detection\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    triple_nt = b\"<http://example.org/a> <http://example.org/b> <http://example.org/c>.\"\n",
+    "\n",
+    "    # Auto-detection : rdflib devine le format (ici nt explicite car URI complets)\n",
+    "    g1 = Graph()\n",
+    "    g1.parse(data=triple_nt, format=\"nt\")\n",
+    "    print(f\"Format explicite (nt)  : {len(g1)} triplet\")\n",
+    "\n",
+    "    # Parsing Turtle depuis une chaine\n",
+    "    g2 = Graph()\n",
+    "    g2.parse(data=b'<http://example.org/a> <http://example.org/b> <http://example.org/c> .', format=\"turtle\")\n",
+    "    print(f\"Format explicite (ttl) : {len(g2)} triplet\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : parsing chaine ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "90c9744ccea6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.784491Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.784491Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.790254Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.790254Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "animals.ttl : 51 triplets (comptes apres chargement en memoire)\n",
+      "Note : rdflib n'expose pas de Handler haut-niveau equivalent a CountHandler.\n",
+      "       Pour les tres gros fichiers, voir rdflib.parser.Parser + sink custom.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1.3 Comptage : rdflib charge puis len(g)\n",
+    "# Note API : contrairement a dotNetRDF qui offre des \"Handlers\" (CountHandler, PagingHandler...)\n",
+    "# permettant de traiter un flux RDF SANS construire le graphe en memoire, rdflib construit\n",
+    "# toujours le graphe. Le comptage memoire-econome natif n'existe pas.\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g_animals = Graph()\n",
+    "    g_animals.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "    print(f\"animals.ttl : {len(g_animals)} triplets (comptes apres chargement en memoire)\")\n",
+    "\n",
+    "    # Equivalent \"flux sans graphe\" : on peut iterer sur un Parser brut avec un sink,\n",
+    "    # mais l'API est bas-niveau et rarement utilisee en pratique.\n",
+    "    from rdflib.parser import Parser\n",
+    "    print(\"Note : rdflib n'expose pas de Handler haut-niveau equivalent a CountHandler.\")\n",
+    "    print(\"       Pour les tres gros fichiers, voir rdflib.parser.Parser + sink custom.\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : comptage ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f5b923b30f4",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Methodes de lecture\n",
+    "\n",
+    "| Methode rdflib | Avantage | Equivalent dotNetRDF |\n",
+    "|----------------|----------|----------------------|\n",
+    "| `g.parse(\"file.ttl\", format=\"turtle\")` | Format explicite, fiable | `TurtleParser.Load(g, \"file.ttl\")` |\n",
+    "| `g.parse(data=bytes, format=\"nt\")` | En memoire, depuis HTTP | `NTriplesParser.Load(g, StringReader(...))` |\n",
+    "| `g.parse(\"file.ttl\")` (sans format) | Auto-detection par extension | `StringParser.Parse(g, str)` |\n",
+    "| `len(g)` apres `parse()` | Comptage simple | `CountHandler` (sans chargement) |\n",
+    "\n",
+    "**Difference notable** : dotNetRDF offre une API de **Handlers** (`CountHandler`, `PagingHandler`, `FilterHandler`) qui traitent les triplets en flux SANS construire le graphe en memoire - utile pour les tres gros fichiers. rdflib construit systematiquement le graphe ; pour le streaming massif, il faut descendre a l'API `Parser` + `sink` bas-niveau.\n",
+    "\n",
+    "> Les `Graph` rdflib sont **reutilisables** et l'operation `parse()` peut etre appelee plusieurs fois (les triplets s'accumulent)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba88fba2619a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. Ecriture de graphes RDF\n",
+    "\n",
+    "La methode centrale de serialization est `Graph.serialize(format=...)` qui retourne une chaine. Pour ecrire directement dans un fichier, utiliser `g.serialize(destination=\"file.ttl\", format=...)`. Formats : `turtle`, `nt`, `xml`, `json-ld`, `n3`, `trig`, `nquads`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1fcd12ade123",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.791998Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.790254Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.798231Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.798231Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== N-Triples ===\n",
+      "_:n2a84ade8f61549d8b1596d698048a888b1 <http://example.org/stuff/1.0/homePage> <http://purl.org/net/dajobe/> .\n",
+      "_:n2a84ade8f61549d8b1596d698048a888b1 <http://example.org/stuff/1.0/fullname> \"Dave Beckett\" .\n",
+      "<http://www.w3.org/TR/rdf-syntax-grammar> <http://purl.org/dc/elements/1.1/title> \"RDF/XML Syntax Specification (Revised)\" .\n",
+      "<http://www.w3.org/TR/rdf-syntax-grammar> <http://example.org/stuff/1.0/editor> _:n2a84ade8f61549d8b1596d698048a888b1 .\n",
+      "\n",
+      "=== Turtle ===\n",
+      "@prefix dc: <http://purl.org/dc/elements/1.1/> .\n",
+      "@prefix ex: <http://example.org/stuff/1.0/> .\n",
+      "\n",
+      "<http://www.w3.org/TR/rdf-syntax-grammar> ex:editor [ ex:fullname \"Dave Beckett\" ;\n",
+      "            ex:homePage <http://purl.org/net/dajobe/> ] ;\n",
+      "    dc:title \"RDF/XML Syntax Specification (Revised)\" .\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2.1 Comparaison de formats de sortie\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g = Graph()\n",
+    "    g.parse(\"data/Example.ttl\", format=\"turtle\")\n",
+    "\n",
+    "    nt_out = g.serialize(format=\"nt\")\n",
+    "    ttl_out = g.serialize(format=\"turtle\")\n",
+    "\n",
+    "    print(\"=== N-Triples ===\")\n",
+    "    print(nt_out)\n",
+    "    print(\"=== Turtle ===\")\n",
+    "    print(ttl_out)\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : ecriture ignoree.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfed8669d0e8",
+   "metadata": {},
+   "source": [
+    "#### Interpretation : Comparaison des formats de sortie\n",
+    "\n",
+    "**N-Triples** : format verbeux - chaque triplet occupe une ligne complete avec les URIs en entier. 4 triplets = 4 lignes. Pas de prefixe, pas de compression.\n",
+    "\n",
+    "**Turtle** : format compact - les prefixes sont definis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (meme sujet) et les proprietes sont imbriquees avec `[...]`. Le meme graphe tient en moins de lignes.\n",
+    "\n",
+    "Le ratio de compression est ici d'environ 2:1 (N-Triples plus long que Turtle). Sur des graphes plus grands avec beaucoup de prefixes, le gain peut atteindre 5:1 ou plus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "127986a6116a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.798231Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.798231Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.805515Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.805515Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Methode 1 (chaine)     : 630 car.\n",
+      "Methode 2 (fichier)    : 630 car.\n",
+      "Identiques             : True\n",
+      "\n",
+      "=== RDF/XML (extrait) ===\n",
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
+      "<rdf:RDF\n",
+      "   xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\n",
+      "   xmlns:ex=\"http://example.org/stuff/1.0/\"\n",
+      "   xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n",
+      ">\n",
+      "  <rdf:Description rdf:nodeID=\"n2a84ade8f61549d8b1596d698048a888b1\">\n",
+      "    <ex:fullname>Dave Beckett</ex:fullname>\n",
+      "    <ex:homePage rdf:resource=\"http://purl.org/net/dajobe/\"/>\n",
+      "  </rdf:Description>\n",
+      "  <r...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2.2 RDF/XML : deux methodes pour obtenir une chaine\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    # Methode 1 : serialize() retourne directement la chaine\n",
+    "    xml_str = g.serialize(format=\"xml\")\n",
+    "\n",
+    "    # Methode 2 : serialize() avec destination = fichier, puis relecture\n",
+    "    import tempfile, os\n",
+    "    tmp = os.path.join(tempfile.gettempdir(), \"sw3b_example.rdf\")\n",
+    "    g.serialize(destination=tmp, format=\"xml\")\n",
+    "    with open(tmp, \"r\", encoding=\"utf-8\") as f:\n",
+    "        xml_from_file = f.read()\n",
+    "\n",
+    "    print(f\"Methode 1 (chaine)     : {len(xml_str)} car.\")\n",
+    "    print(f\"Methode 2 (fichier)    : {len(xml_from_file)} car.\")\n",
+    "    print(f\"Identiques             : {xml_str == xml_from_file}\")\n",
+    "    print(f\"\\n=== RDF/XML (extrait) ===\\n{xml_str[:400]}...\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : RDF/XML ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca6a78313c17",
+   "metadata": {},
+   "source": [
+    "Les deux methodes sont equivalents : `serialize()` sans `destination` retourne une chaine, avec `destination=` ecrit dans un fichier. dotNetRDF proposait `StringWriter.Write(g, writer)` vs `writer.Save(g, sw)` - meme distinction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7c746252ccbc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.805515Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.805515Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.817311Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.817311Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Turtle standard ===\n",
+      "@prefix dc: <http://purl.org/dc/elements/1.1/> .\n",
+      "@prefix ex: <http://example.org/stuff/1.0/> .\n",
+      "\n",
+      "<http://www.w3.org/TR/rdf-syntax-grammar> ex:editor [ ex:fullname \"Dave Beckett\" ;\n",
+      "            ex:homePage <http://purl.org/net/dajobe/> ] ;\n",
+      "    dc:title \"RDF/XML Syntax Specification (Revised)\" .\n",
+      "\n",
+      "\n",
+      "=== JSON-LD avec indentation 2 ===\n",
+      "[\n",
+      "  {\n",
+      "    \"@id\": \"http://www.w3.org/TR/rdf-syntax-grammar\",\n",
+      "    \"http://example.org/stuff/1.0/editor\": [\n",
+      "      {\n",
+      "        \"@id\": \"_:n2a84ade8f61549d8b1596d698048a888b1\"\n",
+      "      }\n",
+      "    ],\n",
+      "    \"http://purl.org/dc/elements/1.1/title\": [\n",
+      "      {\n",
+      "        \"@value\": \"RDF/XML Syntax Specification (Revised)\"\n",
+      "      }\n",
+      "    ]\n",
+      "  },\n",
+      "  {\n",
+      "    \"@id\": \"_:n2a84ade8f61549d8b1596d698048a888b1\",\n",
+      "    \"http://example.org/stuff/1.0/fullname\": [\n",
+      "      {\n",
+      "        \"@value\": \"Dave Beckett\"\n",
+      "      }\n",
+      "    ],\n",
+      "    \"http://example.org/stuff/1.0/homePage\": [\n",
+      "      {\n",
+      "        \"@id\": \"http://purl.org/net/dajobe/\"\n",
+      "      }\n",
+      "    ]\n",
+      "  }\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2.3 Configuration avancee des writers\n",
+    "# rdflib expose moins d'options que dotNetRDF (pas de IPrettyPrintingWriter / ICompressingWriter\n",
+    "# equivalents). Les options disponibles : indent (int) et sort_keys (booleen) sur certains formats.\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    print(\"=== Turtle standard ===\")\n",
+    "    print(g.serialize(format=\"turtle\"))\n",
+    "\n",
+    "    print(\"=== JSON-LD avec indentation 2 ===\")\n",
+    "    print(g.serialize(format=\"json-ld\", indent=2))\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : configuration ignoree.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93d5e203bba8",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Writers et configuration\n",
+    "\n",
+    "| Format rdflib | Equivalent dotNetRDF | Lisibilite | Taille |\n",
+    "|---------------|----------------------|------------|--------|\n",
+    "| `g.serialize(format=\"nt\")` | `NTriplesWriter` | Faible | Verbose |\n",
+    "| `g.serialize(format=\"turtle\")` | `CompressingTurtleWriter` | Elevee | Compact |\n",
+    "| `g.serialize(format=\"xml\")` | `RdfXmlWriter` | Moyenne | Moyenne |\n",
+    "| `g.serialize(format=\"json-ld\")` | `JsonLdWriter` | Bonne (dev web) | Moyenne |\n",
+    "\n",
+    "**Difference notable** : dotNetRDF expose des **interfaces de configuration** riches (`IPrettyPrintingWriter`, `ICompressingWriter` avec `CompressionLevel`, `IHighSpeedWriter`). rdflib est plus minimaliste : l'argument `indent` (JSON-LD) et la convention interne de compression Turtle sont les seuls leviers. Pour un controle fin equivalent, il faut descendre vers des sous-modules (ex : `rdflib.plugins.serializers.turtle`).\n",
+    "\n",
+    "> Tous les formats rdflib sont accessibles via la methode unique `g.serialize(format=...)` - API uniforme, plus simple que dotNetRDF ou chaque writer a sa propre classe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c45c44fd8571",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Fusion de graphes\n",
+    "\n",
+    "rdflib implemente la **semantique d'ensemble** des graphes RDF : l'union (operateur `|` ou `+=`) combine deux graphes sans dupliquer les triplets identiques. Les blank nodes sont isoles par graphe (pas de collision)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "859eddd7b275",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.817311Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.817311Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.827828Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.827828Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe 1 (Example.ttl) : 4 triplets\n",
+      "Graphe 2 (animals.ttl) : 51 triplets\n",
+      "Apres fusion (+=)      : 55 triplets (somme theorique: 55)\n",
+      "Doublons supprimes     : 0\n",
+      "\n",
+      "Operateur | (new graph): 55 triplets (sources intactes: 4, 51)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 3.1 Fusion de deux graphes\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g1 = Graph()\n",
+    "    g2 = Graph()\n",
+    "    g1.parse(\"data/Example.ttl\", format=\"turtle\")\n",
+    "    g2.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "    somme = len(g1) + len(g2)\n",
+    "\n",
+    "    print(f\"Graphe 1 (Example.ttl) : {len(g1)} triplets\")\n",
+    "    print(f\"Graphe 2 (animals.ttl) : {len(g2)} triplets\")\n",
+    "\n",
+    "    # Operateur += : union en place (equivalent de g1.Merge(g2) en dotNetRDF)\n",
+    "    g1 += g2\n",
+    "    print(f\"Apres fusion (+=)      : {len(g1)} triplets (somme theorique: {somme})\")\n",
+    "    print(f\"Doublons supprimes     : {somme - len(g1)}\")\n",
+    "\n",
+    "    # Variante : operateur | retourne un NOUVEAU graphe (non destructif)\n",
+    "    g_a = Graph(); g_a.parse(\"data/Example.ttl\", format=\"turtle\")\n",
+    "    g_b = Graph(); g_b.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "    g_union = g_a | g_b\n",
+    "    print(f\"\\nOperateur | (new graph): {len(g_union)} triplets (sources intactes: {len(g_a)}, {len(g_b)})\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : fusion ignoree.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2285ee73b077",
+   "metadata": {},
+   "source": [
+    "### Interpretation : verification manuelle\n",
+    "\n",
+    "**Somme theorique** : 4 (Example.ttl) + 51 (animals.ttl) = **55**. Aucun triplet commun (les deux fichiers utilisent des namespaces disjoints : `http://example.org/stuff/1.0/` vs `http://example.org/animals#`), donc **0 doublon supprime**. Le resultat `55` confirme la semantique d'ensemble.\n",
+    "\n",
+    "| Aspect | rdflib | dotNetRDF |\n",
+    "|--------|--------|-----------|\n",
+    "| Union en place | `g1 += g2` | `g1.Merge(g2)` |\n",
+    "| Union non destructif | `g1 \\| g2` (nouveau graphe) | `g1.Merge(g2)` copie explicite requise |\n",
+    "| Dédoublonnage | Automatique (set semantics) | Automatique |\n",
+    "| Blank nodes | Isolés par graphe | Renommés pour éviter collision |\n",
+    "\n",
+    "- Les triplets identiques ne sont **pas dupliques** (semantique d'ensemble RDF)\n",
+    "- Les blank nodes sont **isoles** par graphe d'origine (pas de collision)\n",
+    "- `+=` modifie `g1` en place ; `|` retourne un nouveau graphe (API plus pythonique que `Merge`)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "450ade0ea577",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Selection de triplets\n",
+    "\n",
+    "`Graph` propose la methode generique `g.triples((s, p, o))` ou chaque composante peut etre `None` (joker). Des accesseurs dediees existent : `g.subjects(p, o)`, `g.predicates(s, o)`, `g.objects(s, p)`, `g.subject_instances`, `g.value()` (singleton). Les resultats sont des **generateurs** composables avec les comprehensions Python (equivalent LINQ)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "45f3ba93386b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.827828Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.827828Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.835395Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.835395Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Triplets rdf:type ===\n",
+      "  ex:Animal -> rdfs:Class\n",
+      "  ex:Mammal -> rdfs:Class\n",
+      "  ex:Bird -> rdfs:Class\n",
+      "  ex:Dog -> rdfs:Class\n",
+      "  ex:Cat -> rdfs:Class\n",
+      "  ex:Parrot -> rdfs:Class\n",
+      "  ex:name -> rdf:Property\n",
+      "  ex:age -> rdf:Property\n",
+      "  ex:sound -> rdf:Property\n",
+      "  ex:canFly -> rdf:Property\n",
+      "  ex:rex -> ex:Dog\n",
+      "  ex:buddy -> ex:Dog\n",
+      "  ex:minou -> ex:Cat\n",
+      "  ex:coco -> ex:Parrot\n",
+      "  (14 triplets rdf:type)\n",
+      "\n",
+      "=== Proprietes de ex:rex ===\n",
+      "  rdf:type -> ex:Dog\n",
+      "  ex:name -> \"Rex\"\n",
+      "  ex:age -> \"5\"^^xsd:integer\n",
+      "  ex:sound -> \"Woof\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4.1 Selection par predicat et par sujet\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g = Graph()\n",
+    "    g.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "    EX = Namespace(\"http://example.org/animals#\")\n",
+    "\n",
+    "    # Selection par predicat : tous les triplets rdf:type\n",
+    "    print(\"=== Triplets rdf:type ===\")\n",
+    "    type_count = 0\n",
+    "    for s, p, o in g.triples((None, RDF.type, None)):\n",
+    "        print(f\"  {s.n3(g.namespace_manager)} -> {o.n3(g.namespace_manager)}\")\n",
+    "        type_count += 1\n",
+    "    print(f\"  ({type_count} triplets rdf:type)\")\n",
+    "\n",
+    "    # Selection par sujet : toutes les proprietes de ex:rex\n",
+    "    rex = URIRef(\"http://example.org/animals#rex\")\n",
+    "    print(\"\\n=== Proprietes de ex:rex ===\")\n",
+    "    for s, p, o in g.triples((rex, None, None)):\n",
+    "        print(f\"  {p.n3(g.namespace_manager)} -> {o.n3(g.namespace_manager)}\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : selection ignoree.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c08705b85987",
+   "metadata": {},
+   "source": [
+    "#### Interpretation : Resultats de la selection\n",
+    "\n",
+    "**Selection par predicat** `rdf:type` : **14 triplets** trouves - 6 declarations de classes (Animal, Mammal, Bird, Dog, Cat, Parrot), 4 declarations de proprietes (name, age, sound, canFly) et 4 instances (rex/Dog, minou/Cat, coco/Parrot, buddy/Dog). Verification manuelle sur `animals.ttl` : 6 lignes `a rdfs:Class` + 4 lignes `a rdf:Property` + 4 lignes `a ex:<Classe>` = 14. Confirme.\n",
+    "\n",
+    "**Selection par sujet** `ex:rex` : **4 proprietes** - type (Dog), name (Rex), age (5), sound (Woof). Rex est un chien de 5 ans qui fait \"Woof\".\n",
+    "\n",
+    "Ces resultats illustrent que `g.triples((None, RDF.type, None))` retourne tous les usages d'un predicat (types, instances), tandis que `g.triples((rex, None, None))` decrit un noeud complet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0f089af95fd4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.837401Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.837401Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.841660Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.841660Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Noms des animaux ===\n",
+      "  ex:rex -> Rex\n",
+      "  ex:minou -> Minou\n",
+      "  ex:coco -> Coco\n",
+      "  ex:buddy -> Buddy\n",
+      "\n",
+      "=== Animaux > 5 ans (comprehension) ===\n",
+      "  ex:coco : 12\n",
+      "  ex:buddy : 7\n",
+      "\n",
+      "=== Animal le plus age ===\n",
+      "  ex:coco : 12 ans\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4.2 Selection combinee et comprehension Python (equivalent LINQ)\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    EX = Namespace(\"http://example.org/animals#\")\n",
+    "    name_prop = EX.name\n",
+    "    print(\"=== Noms des animaux ===\")\n",
+    "    for s, p, o in g.triples((None, name_prop, None)):\n",
+    "        print(f\"  {s.n3(g.namespace_manager)} -> {o}\")\n",
+    "\n",
+    "    # Comprehension Python : animaux de plus de 5 ans (equivalent du .Where(...) LINQ)\n",
+    "    age_prop = EX.age\n",
+    "    older = [(s, int(o)) for s, p, o in g.triples((None, age_prop, None)) if int(o) > 5]\n",
+    "    print(\"\\n=== Animaux > 5 ans (comprehension) ===\")\n",
+    "    for s, age in older:\n",
+    "        print(f\"  {s.n3(g.namespace_manager)} : {age}\")\n",
+    "\n",
+    "    # Animal le plus age (equivalent du .Max(...) LINQ)\n",
+    "    all_ages = [(s, int(o)) for s, p, o in g.triples((None, age_prop, None))]\n",
+    "    oldest = max(all_ages, key=lambda x: x[1])\n",
+    "    print(f\"\\n=== Animal le plus age ===\")\n",
+    "    print(f\"  {oldest[0].n3(g.namespace_manager)} : {oldest[1]} ans\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : selection combinee ignoree.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b75e0f8957b",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Methodes de selection\n",
+    "\n",
+    "| Methode rdflib | Pattern | Equivalent dotNetRDF | Equivalent SPARQL |\n",
+    "|----------------|---------|----------------------|-------------------|\n",
+    "| `g.triples((s, None, None))` | `s ? ?` | `GetTriplesWithSubject(s)` | `SELECT ?p ?o WHERE { s ?p ?o }` |\n",
+    "| `g.triples((None, p, None))` | `? p ?` | `GetTriplesWithPredicate(p)` | `SELECT ?s ?o WHERE { ?s p ?o }` |\n",
+    "| `g.triples((None, None, o))` | `? ? o` | `GetTriplesWithObject(o)` | `SELECT ?s ?p WHERE { ?s ?p o }` |\n",
+    "| `g.triples((s, p, None))` | `s p ?` | `GetTriplesWithSubjectPredicate(s,p)` | `SELECT ?o WHERE { s p ?o }` |\n",
+    "| `g.triples((None, p, o))` | `? p o` | `GetTriplesWithPredicateObject(p,o)` | `SELECT ?s WHERE { ?s p o }` |\n",
+    "| `g.value(s, p)` | singleton | (via `GetTriplesWithSubjectPredicate`) | `SELECT ?o WHERE { s p ?o } LIMIT 1` |\n",
+    "\n",
+    "**Verification manuelle** : la selection `rdf:type` renvoie **14** triplets (cf. cellule precedente), et le filtre \"age > 5\" doit retourner **coco (12)** et **buddy (7)** - ce que confirme la sortie. L'animal le plus age est **coco** a **12 ans**. Les resultats sont des **generateurs** (lazy evaluation), composables avec les comprehensions Python exactement comme `IEnumerable<Triple>` se compose avec LINQ."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8381e8f3bd8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Listes RDF\n",
+    "\n",
+    "Les listes RDF (RDF collections) sont des structures chainees encodees avec `rdf:first` et `rdf:rest`, terminant par `rdf:nil`. rdflib fournit la classe `rdflib.collection.Collection` qui encapsule cette structure avec une API de liste Python standard (`append`, `index`, `len`, iteration, `del`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "5ea15528e65f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.841660Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.841660Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.849070Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.849070Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Items (Collection) : [1, 2, 3]\n",
+      "Longueur           : 3\n",
+      "Noeuds intermediaires : 3\n",
+      "rdf:first count    : 3\n",
+      "rdf:rest count     : 3\n",
+      "Total liste        : 6 triplets\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5.1 Creer et lire une liste RDF\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g = Graph()\n",
+    "    rdf_data = \"\"\"\n",
+    "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n",
+    "@prefix ex: <http://example.org/ns#> .\n",
+    "ex:subj ex:pred _:b1 .\n",
+    "_:b1 rdf:first 1 . _:b1 rdf:rest _:b2 .\n",
+    "_:b2 rdf:first 2 . _:b2 rdf:rest _:b3 .\n",
+    "_:b3 rdf:first 3 . _:b3 rdf:rest rdf:nil .\n",
+    "\"\"\"\n",
+    "    g.parse(data=rdf_data, format=\"turtle\")\n",
+    "\n",
+    "    # Le predicat ex:pred pointe vers la tete de liste\n",
+    "    predicate = URIRef(\"http://example.org/ns#pred\")\n",
+    "    head = list(g.objects(subject=URIRef(\"http://example.org/ns#subj\"), predicate=predicate))[0]\n",
+    "\n",
+    "    # Collection encapsule l'acces haut-niveau\n",
+    "    col = Collection(g, head)\n",
+    "    print(f\"Items (Collection) : [{', '.join(str(i) for i in col)}]\")\n",
+    "    print(f\"Longueur           : {len(col)}\")\n",
+    "\n",
+    "    # Noeuds intermediaires = cells de la liste chainee\n",
+    "    list_nodes = []\n",
+    "    current = head\n",
+    "    while current != RDF.nil:\n",
+    "        list_nodes.append(current)\n",
+    "        rest = list(g.objects(current, RDF.rest))[0]\n",
+    "        current = rest\n",
+    "    print(f\"Noeuds intermediaires : {len(list_nodes)}\")\n",
+    "\n",
+    "    # Comptage des triplets rdf:first + rdf:rest\n",
+    "    first_triples = list(g.triples((None, RDF.first, None)))\n",
+    "    rest_triples = list(g.triples((None, RDF.rest, None)))\n",
+    "    print(f\"rdf:first count    : {len(first_triples)}\")\n",
+    "    print(f\"rdf:rest count     : {len(rest_triples)}\")\n",
+    "    print(f\"Total liste        : {len(first_triples) + len(rest_triples)} triplets\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : listes RDF ignorees.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3f2896257f9",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Structure interne\n",
+    "\n",
+    "```\n",
+    "head -> [1 | rest] -> [2 | rest] -> [3 | rest] -> rdf:nil\n",
+    "```\n",
+    "\n",
+    "| Element | Methode rdflib | Exemple |\n",
+    "|---------|----------------|---------|\n",
+    "| Valeurs (`rdf:first`) | `list(Collection(g, head))` | `[1, 2, 3]` |\n",
+    "| Noeuds intermediaires | parcours manuel via `rdf:rest` | `_:b1, _:b2, _:b3` |\n",
+    "| Tous les triplets | `g.triples((None, RDF.first, None))` + `rdf:rest` | 6 triplets (3 first + 3 rest) |\n",
+    "\n",
+    "**Verification manuelle** : une liste de 3 elements produit **3** `rdf:first` + **3** `rdf:rest` (le dernier `rdf:rest` pointe vers `rdf:nil`) = **6 triplets**. Confirme par la sortie. Chaque element coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier dont le `rdf:rest` pointe vers `rdf:nil`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c13644e58443",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.851205Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.850505Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.855943Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.855418Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avant           : [1, 2, 3]\n",
+      "Apres append    : [1, 2, 3, 4, 5]\n",
+      "Apres del '3'   : [1, 2, 4, 5]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5.2 Ajout et suppression d'elements : Collection.append + del col[index]\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    # Repartons d'une liste fraiche [1, 2, 3]\n",
+    "    g2 = Graph()\n",
+    "    head2 = BNode()\n",
+    "    Collection(g2, head2, [Literal(1), Literal(2), Literal(3)])\n",
+    "    col2 = Collection(g2, head2)\n",
+    "    def fmt(c): return '[' + ', '.join(str(x) for x in c) + ']'\n",
+    "\n",
+    "    print(f\"Avant           : {fmt(col2)}\")\n",
+    "\n",
+    "    # append = AddToList equivalent (ajoute en fin de liste)\n",
+    "    col2.append(Literal(4))\n",
+    "    col2.append(Literal(5))\n",
+    "    print(f\"Apres append    : {fmt(col2)}\")\n",
+    "\n",
+    "    # suppression par valeur : trouver l'index puis del (rdflib n'expose pas .remove(value))\n",
+    "    target = Literal(3)\n",
+    "    items = list(col2)\n",
+    "    if target in items:\n",
+    "        del col2[items.index(target)]\n",
+    "    print(f\"Apres del '3'   : {fmt(col2)}\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : ajout/suppression ignores.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0713ec95d6ea",
+   "metadata": {},
+   "source": [
+    "#### Interpretation : API des listes\n",
+    "\n",
+    "| Operation | dotNetRDF | rdflib |\n",
+    "|-----------|-----------|--------|\n",
+    "| **Creer** | `g.AssertList(elements)` | `Collection(g, head, elements)` |\n",
+    "| **Lire** | `g.GetListItems(root)` | `list(Collection(g, head))` |\n",
+    "| **Ajouter** | `g.AddToList(root, elements)` | `col.append(item)` |\n",
+    "| **Retirer par valeur** | `g.RemoveFromList(root, elements)` | `del col[col.index(item)]` |\n",
+    "| **Supprimer tout** | `g.RetractList(root)` | `col.clear()` |\n",
+    "\n",
+    "**Difference notable** : `RemoveFromList` (dotNetRDF) retire par **valeur** directement ; rdflib exige de trouver l'**index** puis `del col[index]`. API legerement moins ergonomique pour ce cas, mais conforme a l'idiome Python `del list[i]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "f3f4b27e7ef5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.857512Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.857512Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.862781Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.862262Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial           : [Alice, Bob, Charlie]\n",
+      "Apres ajout Diana : [Alice, Bob, Charlie, Diana]\n",
+      "Apres del Bob     : [Alice, Charlie, Diana]\n",
+      "Apres clear()     : [] | triplets 6 -> 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5.3 Cycle complet : creation, ajout, suppression, destruction\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g3 = Graph()\n",
+    "    head3 = BNode()\n",
+    "    # AssertList equivalent : creation depuis une liste de valeurs\n",
+    "    Collection(g3, head3, [Literal(\"Alice\"), Literal(\"Bob\"), Literal(\"Charlie\")])\n",
+    "    col3 = Collection(g3, head3)\n",
+    "    def fmt(c): return '[' + ', '.join(str(x) for x in c) + ']'\n",
+    "\n",
+    "    print(f\"Initial           : {fmt(col3)}\")\n",
+    "\n",
+    "    # Ajout\n",
+    "    col3.append(Literal(\"Diana\"))\n",
+    "    print(f\"Apres ajout Diana : {fmt(col3)}\")\n",
+    "\n",
+    "    # Suppression par valeur (index lookup)\n",
+    "    items = list(col3)\n",
+    "    del col3[items.index(Literal(\"Bob\"))]\n",
+    "    print(f\"Apres del Bob     : {fmt(col3)}\")\n",
+    "\n",
+    "    # RetractList equivalent : clear() detruit tous les triplets de la liste\n",
+    "    avant = len(g3)\n",
+    "    col3.clear()\n",
+    "    print(f\"Apres clear()     : {fmt(col3)} | triplets {avant} -> {len(g3)}\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : cycle complet ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a00b9a22cc99",
+   "metadata": {},
+   "source": [
+    "### Interpretation : API des listes (synthese)\n",
+    "\n",
+    "| Operation | Methode rdflib | Comportement |\n",
+    "|-----------|----------------|--------------|\n",
+    "| **Creer** | `Collection(g, head, [items])` | Genere blank nodes + triplets `rdf:first`/`rdf:rest` |\n",
+    "| **Ajouter** | `col.append(item)` | Ajoute en fin de liste (gere le chainage `rdf:rest`) |\n",
+    "| **Retirer** | `del col[col.index(item)]` | Supprime par index (recherche de valeur manuelle) |\n",
+    "| **Supprimer tout** | `col.clear()` | Supprime recursivement tous les triplets |\n",
+    "\n",
+    "> **Quand utiliser les listes RDF ?** : Collections ordonnees (sequences, etapes). Pour des ensembles non ordonnes, preferez des triplets individuels - la liste RDF est couteuse (2 triplets par element) et peu query-friendly (pas de `SELECT ?x WHERE { list ?p ?x }` direct)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5baf4038d2e2",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Comparaison cross-langage dotNetRDF vs rdflib\n",
+    "\n",
+    "| Aspect | dotNetRDF (C#) | rdflib (Python) |\n",
+    "|--------|----------------|-----------------|\n",
+    "| **Style API** | OOP verbeux, typage fort, interfaces multiples | Pythonique, concis, tuples natifs |\n",
+    "| **Noeuds** | Lies au graphe (`g.CreateUriNode(...)`) | Independants (`URIRef(...)`) |\n",
+    "| **Triple** | Objet `new Triple(s, p, o)` | Tuple Python `(s, p, o)` |\n",
+    "| **Lecture** | Classes par format (`TurtleParser`, `NTriplesParser`) + Handlers | API unique `g.parse(format=\"...\")` |\n",
+    "| **Ecriture** | Classes par format + interfaces (`IPrettyPrintingWriter`, `ICompressingWriter`) | API unique `g.serialize(format=\"...\")` (options limitees) |\n",
+    "| **Fusion** | `g1.Merge(g2)` (en place) | `g1 += g2` (en place) ou `g1 \\| g2` (nouveau) |\n",
+    "| **Selection** | `GetTriplesWithXxx(...)` (5 methodes) | `g.triples((s, p, o))` (une methode, `None` = joker) |\n",
+    "| **Listes RDF** | `Extensions.GetListItems`, `AssertList`, `AddToList`, `RetractList` | `rdflib.collection.Collection` (API liste Python) |\n",
+    "| **Streaming massif** | Handlers (`CountHandler`, `PagingHandler`) - pas de graphe en memoire | Construit systematiquement le graphe (gap) |\n",
+    "| **LINQ / comprehensions** | `IEnumerable<Triple>` + LINQ (`.Where`, `.Select`, `.Max`) | Generateurs + comprehensions Python (`[x for x in ...]`) |\n",
+    "\n",
+    "### Differences philosophiques\n",
+    "\n",
+    "- **dotNetRDF** privilegie l'**explicite** : un type distinct par parser/writer, interfaces de configuration fines, handlers pour le streaming. Avantage : controle precis, typage compile. Inconvenient : verbosite.\n",
+    "- **rdflib** privilegie l'**uniformite** : une seule methode `parse` / `serialize` avec un argument `format`, tuples Python natifs pour les triples. Avantage : concision, courbe d'apprentissage faible. Inconvenient : moins d'options de configuration, pas de streaming memoire-econome natif.\n",
+    "\n",
+    "> **A retenir** : Les deux bibliotheques implementent fidelement les memes standards W3C (RDF 1.1, Turtle, N-Triples, RDF/XML, JSON-LD). Les fichiers produits par l'un sont consommables par l'autre. Le choix depend de l'ecosysteme : .NET pour l'integration C# typée, Python pour la data science et l'IA."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52c28c63bbbd",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7. Exercices pratiques\n",
+    "\n",
+    "Mettez en pratique les concepts appris. Chaque **Exemple guide** est une solution complete commentee ; chaque **Exercice** est un squelette a completer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fdaf46d396a",
+   "metadata": {},
+   "source": [
+    "### Exemple guide 1 : Charger et explorer\n",
+    "\n",
+    "Chargez `data/animals.ttl` et affichez : le nombre total de triplets, les triplets `rdf:type`, et les proprietes de `ex:rex`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "107b87a9cfd2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.864878Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.864352Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.871184Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.870645Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total triplets : 51\n",
+      "Triplets rdf.type :\n",
+      "  ex:Animal -> rdfs:Class\n",
+      "  ex:Mammal -> rdfs:Class\n",
+      "  ex:Bird -> rdfs:Class\n",
+      "  ex:Dog -> rdfs:Class\n",
+      "  ex:Cat -> rdfs:Class\n",
+      "  ex:Parrot -> rdfs:Class\n",
+      "  ex:name -> rdf:Property\n",
+      "  ex:age -> rdf:Property\n",
+      "  ex:sound -> rdf:Property\n",
+      "  ex:canFly -> rdf:Property\n",
+      "  ex:rex -> ex:Dog\n",
+      "  ex:buddy -> ex:Dog\n",
+      "  ex:minou -> ex:Cat\n",
+      "  ex:coco -> ex:Parrot\n",
+      "Proprietes de rex :\n",
+      "  rdf:type -> http://example.org/animals#Dog\n",
+      "  ex:name -> Rex\n",
+      "  ex:age -> 5\n",
+      "  ex:sound -> Woof\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple guide 1 : Charger animals.ttl et explorer\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g = Graph()\n",
+    "    g.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "    print(f\"Total triplets : {len(g)}\")\n",
+    "\n",
+    "    # Selection de tous les triplets dont le predicat est rdf:type\n",
+    "    # rdf:type indique la classe d'appartenance d'une ressource (ex : rex est de type Dog)\n",
+    "    print(\"Triplets rdf.type :\")\n",
+    "    for s, p, o in g.triples((None, RDF.type, None)):\n",
+    "        print(f\"  {s.n3(g.namespace_manager)} -> {o.n3(g.namespace_manager)}\")\n",
+    "\n",
+    "    # Toutes les proprietes de ex:rex\n",
+    "    rex = URIRef(\"http://example.org/animals#rex\")\n",
+    "    print(\"Proprietes de rex :\")\n",
+    "    for s, p, o in g.triples((rex, None, None)):\n",
+    "        print(f\"  {p.n3(g.namespace_manager)} -> {o}\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : exemple 1 ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bfb1f02ecfa",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 : Recherche avancee dans un graphe\n",
+    "\n",
+    "Chargez `data/animals.ttl` et trouvez :\n",
+    "\n",
+    "1. Tous les animaux qui sont des chiens (`rdf:type` -> `ex:Dog`) en utilisant `g.triples((None, RDF.type, ex:Dog))`\n",
+    "2. Le nombre d'animaux qui peuvent voler (predicat `ex:canFly` avec valeur `True`)\n",
+    "3. L'animal le plus age (maximum de la valeur du predicat `ex:age`)\n",
+    "\n",
+    "**Indices** : utilisez `g.triples((None, RDF.type, URIRef(\"...Dog\")))` pour la question 1, et une comprehension Python avec `max(..., key=lambda ...)` pour la question 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "7932230323a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.872786Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.872786Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.876638Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.875905Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO etudiant : Chargez data/animals.ttl et trouvez :\n",
+    "# 1. Tous les animaux qui sont des chiens (rdf:type -> ex:Dog)\n",
+    "# 2. Le nombre d'animaux qui peuvent voler (predicat ex:canFly avec valeur True)\n",
+    "# 3. L'animal le plus age (maximum de ex:age)\n",
+    "#\n",
+    "# Indice : utilisez g.triples((None, RDF.type, URIRef(\"http://example.org/animals#Dog\"))) pour (1)\n",
+    "# et max(..., key=lambda x: x[1]) sur la liste des (sujet, age) pour (3)\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "674f61e43636",
+   "metadata": {},
+   "source": [
+    "### Exemple guide 2 : Fusionner et serialiser\n",
+    "\n",
+    "Chargez `data/Example.ttl` et `data/animals.ttl`, fusionnez-les, et ecrivez le resultat en Turtle compact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "13bef16eb13f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.878220Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.878220Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.887309Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.886768Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avant fusion - g1: 4, g2: 51"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Apres fusion : 55 triplets\n",
+      "@prefix dc: <http://purl.org/dc/elements/1.1/> .\n",
+      "@prefix ex: <http://example.org/stuff/1.0/> .\n",
+      "@prefix ns1: <http://example.org/animals#> .\n",
+      "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n",
+      "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+      "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
+      "\n",
+      "ns1:Animal a rdfs:Class ;\n",
+      "    rdfs:label \"Animal\"@fr ;\n",
+      "    rdfs:comment \"Classe racine de tous les animaux\"@fr .\n",
+      "\n",
+      "ns1:Bird a rdfs:Class ;\n",
+      "    rdfs:label \"Oiseau\"@fr ;\n",
+      "    rdfs:subClassOf ns1:Animal .\n",
+      "\n",
+      "ns1:Cat a rdfs:Class ;\n",
+      "    rdfs:label \"Chat\"@fr ;\n",
+      "    rdfs:subClassOf ns1:Mammal .\n",
+      "\n",
+      "ns1:Dog a rdfs:Class ;\n",
+      "    rdfs:label \"Chien\"@fr ;\n",
+      "    rdfs:subClassOf ns1:Mammal .\n",
+      "\n",
+      "ns1:Mammal a rdfs:Class ;\n",
+      "    rdfs:label \"Mammifere\"@fr ;\n",
+      "    rdfs:subClassOf ns1:Animal .\n",
+      "\n",
+      "ns1:Parrot a rdfs:Class ;\n",
+      "    rdfs:label \"Perroquet\"@fr ;\n",
+      "    rdfs:subClassOf ns1:Bird .\n",
+      "\n",
+      "ns1:age a rdf:Property ;\n",
+      "    rdfs:label \"age\"@fr ;\n",
+      "    rdfs:domain ns1:Animal ;\n",
+      "    rdfs:range xsd:integer .\n",
+      "\n",
+      "ns1:buddy a ns1:Dog ;\n",
+      "    ns1:age 7 ;\n",
+      "    ns1:name \"Buddy\" ;\n",
+      "    ns1:sound \"Woof woof\" .\n",
+      "\n",
+      "ns1:canFly a rdf:Property ;\n",
+      "    rdfs:label \"peut voler\"@fr ;\n",
+      "    rdfs:domain ns1:Animal ;\n",
+      "    rdfs:range xsd:boolean .\n",
+      "\n",
+      "ns1:coco a ns1:Parrot ;\n",
+      "    ns1:age 12 ;\n",
+      "    ns1:canFly true ;\n",
+      "    ns1:name \"Coco\" ;\n",
+      "    ns1:sound \"Coco veut un gateau\" .\n",
+      "\n",
+      "ns1:minou a ns1:Cat ;\n",
+      "    ns1:age 3 ;\n",
+      "    ns1:name \"Minou\" ;\n",
+      "    ns1:sound \"Miaou\" .\n",
+      "\n",
+      "ns1:name a rdf:Property ;\n",
+      "    rdfs:label \"nom\"@fr ;\n",
+      "    rdfs:domain ns1:Animal ;\n",
+      "    rdfs:range xsd:string .\n",
+      "\n",
+      "ns1:rex a ns1:Dog ;\n",
+      "    ns1:age 5 ;\n",
+      "    ns1:name \"Rex\" ;\n",
+      "    ns1:sound \"Woof\" .\n",
+      "\n",
+      "ns1:sound a rdf:Property ;\n",
+      "    rdfs:label \"cri\"@fr ;\n",
+      "    rdfs:domain ns1:Animal ;\n",
+      "    rdfs:range xsd:string .\n",
+      "\n",
+      "<http://www.w3.org/TR/rdf-syntax-grammar> ex:editor [ ex:fullname \"Dave Beckett\" ;\n",
+      "            ex:homePage <http://purl.org/net/dajobe/> ] ;\n",
+      "    dc:title \"RDF/XML Syntax Specification (Revised)\" .\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple guide 2 : Fusion + serialization Turtle\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g1 = Graph()\n",
+    "    g2 = Graph()\n",
+    "    g1.parse(\"data/Example.ttl\", format=\"turtle\")\n",
+    "    g2.parse(\"data/animals.ttl\", format=\"turtle\")\n",
+    "\n",
+    "    print(f\"Avant fusion - g1: {len(g1)}, g2: {len(g2)}\")\n",
+    "    # Union : les triplets identiques ne sont pas dupliques (semantique d'ensemble RDF)\n",
+    "    # Les blank nodes sont isoles par graphe (pas de collision)\n",
+    "    g1 += g2\n",
+    "    print(f\"Apres fusion : {len(g1)} triplets\")\n",
+    "\n",
+    "    result = g1.serialize(format=\"turtle\")\n",
+    "    print(result)\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : exemple 2 ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fff1da298eaa",
+   "metadata": {},
+   "source": [
+    "### Exercice 5 : Fusion avec donnees en memoire\n",
+    "\n",
+    "Chargez `data/animals.ttl` dans un graphe et la chaine N-Triples suivante dans un autre graphe avec `g.parse(data=..., format=\"nt\")` :\n",
+    "\n",
+    "```\n",
+    "<http://example.org/ns#dave> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns#Person> .\n",
+    "<http://example.org/ns#dave> <http://example.org/ns#name> \"Dave\" .\n",
+    "<http://example.org/ns#dave> <http://example.org/ns#age> \"40\" .\n",
+    "```\n",
+    "\n",
+    "Fusionnez les deux graphes et serialisez le resultat en N-Triples (pas Turtle)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "e3a70bc1f4ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.888916Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.888916Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.892062Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.891532Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO etudiant : Chargez data/animals.ttl dans un graphe g1\n",
+    "# Chargez la chaine N-Triples ci-dessus dans un graphe g2 avec g2.parse(data=..., format=\"nt\")\n",
+    "# Fusionnez g2 dans g1 (g1 += g2) et affichez le nombre total de triplets\n",
+    "# Serialisez le resultat en N-Triples (pas Turtle) avec g1.serialize(format=\"nt\")\n",
+    "#\n",
+    "# Indice : utilisez g.serialize(format=\"nt\") pour la serialisation\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "748385520221",
+   "metadata": {},
+   "source": [
+    "### Exemple guide 3 : Liste RDF\n",
+    "\n",
+    "Creez une liste `[\"Alice\", \"Bob\", \"Charlie\"]` avec `Collection`, ajoutez `\"Diana\"`, supprimez `\"Bob\"`, affichez le resultat."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "701cb45a086c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.893662Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.893662Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.899068Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.898511Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial          : [Alice, Bob, Charlie]\n",
+      "Apres ajout      : [Alice, Bob, Charlie, Diana]\n",
+      "Apres suppression: [Alice, Charlie, Diana]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple guide 3 : Liste RDF avec Collection\n",
+    "if RDFLIB_AVAILABLE:\n",
+    "    g = Graph()\n",
+    "    head = BNode()\n",
+    "    # Creation d'une liste RDF ordonnee [Alice, Bob, Charlie]\n",
+    "    # Collection genere une chaine de blank nodes relies par rdf:first et rdf:rest\n",
+    "    Collection(g, head, [Literal(\"Alice\"), Literal(\"Bob\"), Literal(\"Charlie\")])\n",
+    "    col = Collection(g, head)\n",
+    "\n",
+    "    # Fonction utilitaire pour afficher uniquement la valeur textuelle\n",
+    "    def fmt(c): return '[' + ', '.join(str(n) for n in c) + ']'\n",
+    "\n",
+    "    print(f\"Initial          : {fmt(col)}\")\n",
+    "\n",
+    "    # append insere \"Diana\" en fin de liste\n",
+    "    col.append(Literal(\"Diana\"))\n",
+    "    print(f\"Apres ajout      : {fmt(col)}\")\n",
+    "\n",
+    "    # suppression par valeur : on cherche l'index puis del col[index]\n",
+    "    items = list(col)\n",
+    "    del col[items.index(Literal(\"Bob\"))]\n",
+    "    print(f\"Apres suppression: {fmt(col)}\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : exemple 3 ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01c61ed98956",
+   "metadata": {},
+   "source": [
+    "### Exercice 6 : Liste RDF personnalisee\n",
+    "\n",
+    "Creez une liste RDF `[\"Paris\", \"Lyon\", \"Marseille\"]` avec `Collection`, ajoutez `\"Toulouse\"` avec `col.append(...)`, supprimez `\"Lyon\"` (index lookup + `del`). Affichez la liste apres chaque operation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "cc59074a79e6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T01:53:42.900629Z",
+     "iopub.status.busy": "2026-07-07T01:53:42.900112Z",
+     "iopub.status.idle": "2026-07-07T01:53:42.903826Z",
+     "shell.execute_reply": "2026-07-07T01:53:42.903306Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO etudiant : Creez une liste RDF [\"Paris\", \"Lyon\", \"Marseille\"] avec Collection\n",
+    "# Ajoutez \"Toulouse\" avec col.append(Literal(\"Toulouse\"))\n",
+    "# Supprimez \"Lyon\" avec del col[list(col).index(Literal(\"Lyon\"))]\n",
+    "# Affichez la liste apres chaque operation avec list(col)\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f527127a98e",
+   "metadata": {},
+   "source": [
+    "## References savantes\n",
+    "\n",
+    "- **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modele de donnees abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) dont derivent tous les formats manipules dans ce notebook.\n",
+    "- **RDF 1.1 Turtle** - Beckett, Berners-Lee, Prud'hommeaux, Recommandation W3C, 25 fevrier 2014. Format de serialization compact lisible par l'humain, le plus utilise en pratique.\n",
+    "- **RDF 1.1 N-Triples** - Ackaert, Sporny, Kellogg, Recommandation W3C, 25 fevrier 2014. Forme canonique ligne-par-triplet, base d'echange interoperaable.\n",
+    "- **Notation 3 (N3)** - Berners-Lee, *A Rough Guide to Notation 3*, note non normative 2006. Sur-ensemble de Turtle ajoutant regles et citerables.\n",
+    "- **rdflib** - bibliotheque open-source Python pour la manipulation de graphes RDF (`rdflib.readthedocs.io`), implemente les parsers/serializers uniformes `g.parse()` / `g.serialize()` utilises tout au long de ce notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0baf31f0c5d",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Resume\n",
+    "\n",
+    "| Section | Concepts cles | APIs rdflib principales | Equivalent dotNetRDF |\n",
+    "|---------|---------------|-------------------------|----------------------|\n",
+    "| **1. Lecture** | parse, formats, gap Handlers | `g.parse(format=...)`, `len(g)` | `TurtleParser`, `CountHandler` |\n",
+    "| **2. Ecriture** | serialize, multi-formats | `g.serialize(format=...)` | `NTriplesWriter`, `CompressingTurtleWriter` |\n",
+    "| **3. Fusion** | Union, deduplication | `g1 += g2`, `g1 \\| g2` | `IGraph.Merge()` |\n",
+    "| **4. Selection** | triples pattern, comprehensions | `g.triples((s,p,o))`, `g.value()` | `GetTriplesWithSubject`, LINQ |\n",
+    "| **5. Listes** | Collections ordonnees | `Collection(g, head, items)` | `AssertList`, `GetListItems`, `RetractList` |\n",
+    "\n",
+    "### Prochaine etape\n",
+    "\n",
+    "Dans **[SW-4b-Python-SPARQL](SW-4b-Python-SPARQL.ipynb)**, nous apprendrons a interroger les graphes RDF avec le langage SPARQL cote Python (equivalent de SW-4 C#).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< SW-3 C#](SW-3-CSharp-GraphOperations.ipynb) | [SW-4b Python >>](SW-4b-Python-SPARQL.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Twin Python pédagogique du notebook C# `SW-3-CSharp-GraphOperations`, dans le cadre du marathon de parité .NET ⇄ Python (**EPIC #4956**). Le C# original utilise **dotNetRDF**. Le twin Python utilise le **vrai moteur rdflib** (7.6.0) — pas de workaround, pas de réimplémentation jouet.

**R6 pivot Python** (suite) : famille SemanticWeb, langage Python. Convention SemanticWeb : C# = original, twin Python = suffixe `-Python` avec `b` (cf. `SW-2b`, `SW-5b`, `SW-7b`, et le twin précédent `SW-6b-Python-RDFS`). **Concept distinct de SW-6b** : CRUD graphe/serialisation/listes RDF (vs raisonnement RDFS) — diversité intra-famille.

## SOTA verdict (EPIC #3801) — SOTA-OK

Le vrai **rdflib** est invoqué pour toutes les opérations : `Graph.parse()` (lecture multi-format), `serialize(format=turtle|nt|xml|json-ld)` (écriture), `g1 += g2` / `g1 | g2` (fusion), `g.triples((s,p,o))` / `subjects`/`predicates`/`objects`/`value()` (sélection), `rdflib.collection.Collection` (listes RDF). **Écart INTRINSIC documenté honnêtement** : rdflib n'a pas d'API Handler de streaming équivalente au `CountHandler`/`PagingHandler`/`FilterHandler` de dotNetRDF (`parse()` construit toujours en mémoire). Le notebook le documente explicitement + pointe vers le `Parser` bas niveau + sink personnalisé pour le streaming massif — **pas de fausse sortie**, conforme Prong A.

## Contenu (50 cells : 20 code, 30 markdown)

Mirroir des 6 sections du C# : (1) Lecture RDF, (2) Écriture/sérialisation multi-format, (3) Fusion de graphes, (4) Sélection de triplets, (5) Listes RDF (`Collection`, append/delete/clear), (6) Exercices + section comparative cross-langage dotNetRDF vs rdflib.

## Preuve d'exécution (H.1 / EXEC_PROVED, vérifié firsthand)

- **20/20 cellules code** avec `execution_count` (1..20 contigus), **0 null, 0 erreur, 0 output vide**.
- `notebook_tools.py validate --quick` : **OK=1, Warnings=0, Errors=0**.
- **L268** : committed blob LF (`od -c` = `{ \n`), règle `*.ipynb text eol=lf` s'applique.

## Validation math firsthand (Math Verification Standard)

Mon calcul indépendant reproduit **exactement** les outputs du notebook :

| Opération | Ma valeur (indépendante) | Output notebook | Logique |
|-----------|--------------------------|-----------------|---------|
| `animals.ttl` triplets | 51 | 51 | fichier source |
| `Example.ttl` triplets | 4 | 4 | fichier source |
| Fusion `Example += animals` | 55 (0 doublon) | 55 | union ensembliste RDF (namespaces disjoints) |
| Sélection `rdf:type` sur animals | 14 | 14 | 6 classes + 4 propriétés + 4 instances |
| Collection RDF `[1,2,3]` | 6 (3 first + 3 rest, 1 nil) | 6 | chaîne `rdf:first`/`rdf:rest`/`rdf:nil` |

La fusion à 55 (et non 55−overlap) est documentée comme une conséquence de la sémantique d'ensemble RDF + namespaces disjoints — démonstration pédagogique de **pourquoi** l'union RDF n'est pas une concaténation naïve.

## Conventions respectées

- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0` ; 3 Exemples guidés (solutions complètes, CONSERVÉS) + 3 Exercices stubs (`print("Exercice à compléter")`) — labeling par contenu (cf exercise-example-labeling.md).
- **C.2** : outputs commités, `execution_count` entiers contigus.
- **readme-french-first** : prose française, 0 emoji, 0 CJK.
- **§E** : +2/−1 dans `SemanticWeb/README.md` (1 ligne table Partie 1 + 1 ligne tree), bloc `<!-- CATALOG-STATUS -->` byte-identical.
- **Délégation** : build → sous-agent notebook-designer (sonnet async) ; **vérification rigoureuse firsthand avant PR** (forensic H.5 + Math indépendante + validateur).

## Test plan

- [x] Execution end-to-end kernel `python3` (20/20 cellules, 0 erreur)
- [x] `notebook_tools.py validate --quick` OK
- [x] rdflib invocation réelle (parse/serialize/Collection/triples)
- [x] Math hand-verification indépendante (fusion 55, sélection 14, Collection 6)
- [x] Grep C.1 (0 pattern interdit), 0 emoji, 0 CJK
- [x] §E surgical (CATALOG-STATUS byte-identical)
- [x] Committed blob LF (L268)

Part of #4956 (marathon parité .NET ⇄ Python). Famille SemanticWeb — R6 pivot Python (CRUD graphe, distinct du raisonnement RDFS de SW-6b).