### PR TITLE
feat(symbolicai): SW-9-CSharp-JSONLD — twin C# JSON-LD dotNetRDF (.NET parity #4956 Prong B)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -278,6 +278,8 @@ JSON-LD est le pont entre le monde JSON des développeurs web et le Web Sémanti
 - Rich snippets Google : 73% des résultats utilisent des données structurées
 - Cas d'usage : e-commerce (Produit), articles (Article), organisations (Organization)
 
+> **Twin C# disponible** : [SW-9-CSharp-JSONLD](SW-9-CSharp-JSONLD.ipynb) — JSON-LD via dotNetRDF (`JsonLdParser`/`JsonLdWriter`, `TripleStore`). Compagnon cross-langage du notebook Python `rdflib` + `pyld` sur le même standard W3C JSON-LD 1.1 (marathon parité .NET ⇄ Python #4956, Prong B).
+
 #### SW-10-Python-RDFStar : Annotations et Provenance (40 min)
 
 RDF-Star (RDF 1.2) permet d'exprimer des statements à propos de statements, essentiel pour les annotations, la provenance et la confiance.
@@ -491,6 +493,7 @@ SemanticWeb/
 ├── SW-7b-Python-OWL.ipynb           # Sidetrack
 ├── SW-8-Python-SHACL.ipynb
 ├── SW-9-Python-JSONLD.ipynb
+├── SW-9-CSharp-JSONLD.ipynb         # Twin C# (marathon #4956 Prong B)
 ├── SW-10-Python-RDFStar.ipynb
 ├── SW-11-Python-KnowledgeGraphs.ipynb
 ├── SW-12-Python-GraphRAG.ipynb

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
@@ -1,0 +1,1517 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cb0fea89-87c9-42df-880c-4143c0b3e9b2",
+   "metadata": {},
+   "source": [
+    "# SW-9-CSharp-JSONLD — JSON-LD avec dotNetRDF (twin C#)\n",
+    "\n",
+    "Ce notebook est le **jumeau C# (.NET Interactive)** du notebook Python `SW-9-Python-JSONLD.ipynb`. Il explore **JSON-LD** (JavaScript Object Notation for Linked Data, W3C Recommendation 2014/2020) via **dotNetRDF** (`VDS.RDF.*`), le moteur .NET de reference — equivalent de `rdflib` + `pyld` cote Python.\n",
+    "\n",
+    "## Objectifs pedagogiques\n",
+    "\n",
+    "1. **Comprendre `@context`** : le dictionnaire de traduction entre termes JSON courts et IRIs RDF.\n",
+    "2. **Manipuler `@id` et `@type`** : identifier et typer les ressources dans un graphe.\n",
+    "3. **Parser du JSON-LD** en graphe RDF via `JsonLdParser` (charge un `TripleStore`).\n",
+    "4. **Serialiser un graphe RDF en JSON-LD** via `JsonLdWriter` (`TripleStore` -> JSON-LD).\n",
+    "5. **Explorer le vocabulaire Schema.org** et faire un round-trip JSON-LD <-> Turtle.\n",
+    "\n",
+    "## Pourquoi un twin C# ?\n",
+    "\n",
+    "Le notebook Python original s'appuie sur **`rdflib`** + **`jsonld`** (`pyld`). Ce twin C# invoque le **vrai moteur dotNetRDF** (`VDS.RDF.Parsing.JsonLdParser`, `VDS.RDF.Writing.JsonLdWriter`) — pas de workaround. Subtilite API : JSON-LD etant un format de **dataset** (graphe nomme, mot-cle `@graph`), le parser/writer dotNetRDF opere sur un `TripleStore` (collection de graphes), pas un `Graph` unique comme les autres serialisations RDF. Value-add (EPIC #4956 Prong B) : les deux twins sont des compagnons cross-langage sur le **meme standard W3C JSON-LD 1.1**.\n",
+    "\n",
+    "## Prerequis\n",
+    ".NET 9.0+ (kernel `csharp`). dotNetRDF 3.x (restaure via la directive nuget).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c2bacfd-ef33-4b3b-8734-1adfc6c1f289",
+   "metadata": {},
+   "source": [
+    "## Setup — chargement de dotNetRDF\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "31076692-b982-48cc-a2ae-9858ac01b4ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:49.478847Z",
+     "iopub.status.busy": "2026-07-07T02:09:49.473040Z",
+     "iopub.status.idle": "2026-07-07T02:09:51.349721Z",
+     "shell.execute_reply": "2026-07-07T02:09:51.344528Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1628652.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>dotNetRDF, 3.4.1</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "dotNetRDF: 3.4.1 charge — JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// dotNetRDF 3.x : meta-package incluant JsonLdParser / JsonLdWriter\n",
+    "#r \"nuget: dotNetRDF, 3.4.1\"\n",
+    "\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.IO;\n",
+    "using Newtonsoft.Json;\n",
+    "using Newtonsoft.Json.Linq;\n",
+    "using VDS.RDF;\n",
+    "using VDS.RDF.Parsing;\n",
+    "using VDS.RDF.Writing;\n",
+    "using StringWriter = System.IO.StringWriter;\n",
+    "\n",
+    "static void Show(object o) { try { display(o); } catch { Console.WriteLine(o); } }\n",
+    "static void Show(string label, object o) => Show($\"{label}: {o}\");\n",
+    "\n",
+    "Show(\"dotNetRDF\", \"3.4.1 charge — JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1de39cc-ed72-40e4-97c9-54fa3b8ea25f",
+   "metadata": {},
+   "source": [
+    "## Helpers de conversion RDF <-> JSON-LD\n",
+    "\n",
+    "On definit ici trois fonctions utilitaires qui encapsulent la subtilite API : JSON-LD se charge dans un `TripleStore` (dataset), pas un `Graph` unique. On extrait ensuite le graphe par defaut pour l'interroger comme un graphe RDF classique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b78b10fc-015f-499d-abd6-5579daee1b43",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:51.351328Z",
+     "iopub.status.busy": "2026-07-07T02:09:51.351120Z",
+     "iopub.status.idle": "2026-07-07T02:09:51.504047Z",
+     "shell.execute_reply": "2026-07-07T02:09:51.503749Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Helpers: LoadJsonLd / SerializeToJsonLd / SerializeToTurtle definis."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Helpers : JSON-LD <-> TripleStore <-> Graph + Turtle ---\n",
+    "// Parse JSON-LD -> TripleStore -> on renvoie le graphe par defaut (dataset a un seul graphe)\n",
+    "static IGraph LoadJsonLd(string json)\n",
+    "{\n",
+    "    var store = new TripleStore();\n",
+    "    using (var reader = new StringReader(json))\n",
+    "        new JsonLdParser().Load(store, reader);\n",
+    "    return store.Graphs.Count > 0 ? store.Graphs.First() : new Graph();\n",
+    "}\n",
+    "\n",
+    "// Serialise un graphe RDF -> JSON-LD (on l'emballe dans un TripleStore pour le writer)\n",
+    "static string SerializeToJsonLd(IGraph graph)\n",
+    "{\n",
+    "    var store = new TripleStore();\n",
+    "    store.Add(graph, false);\n",
+    "    var sw = new StringWriter();\n",
+    "    new JsonLdWriter().Save(store, sw);\n",
+    "    return sw.ToString();\n",
+    "}\n",
+    "\n",
+    "// Serialise un graphe RDF -> Turtle (comparaison)\n",
+    "static string SerializeToTurtle(IGraph graph)\n",
+    "{\n",
+    "    var sw = new StringWriter();\n",
+    "    new CompressingTurtleWriter().Save(graph, sw);\n",
+    "    return sw.ToString();\n",
+    "}\n",
+    "\n",
+    "Show(\"Helpers\", \"LoadJsonLd / SerializeToJsonLd / SerializeToTurtle definis.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c50f8e5d-f277-4752-a388-149c0979607d",
+   "metadata": {},
+   "source": [
+    "## Partie 1 — `@context` : le dictionnaire de traduction\n",
+    "\n",
+    "JSON-LD = JSON + un **`@context`** qui mappe les termes courts (cles JSON) vers des **IRIs** RDF (identifiants globaux). Cela rend JSON compatible Linked Data sans alourdir la syntaxe.\n",
+    "\n",
+    "Exemple : `\"name\"` -> `http://schema.org/name`, `\"Person\"` -> `http://schema.org/Person`.\n",
+    "\n",
+    "On construit d'abord un `@context` comme un `JObject` (Newtonsoft.Json), puis on l'utilise dans un document JSON-LD compact.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e55cbd41-717b-4a9c-ba94-8f345a41fd74",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:51.505584Z",
+     "iopub.status.busy": "2026-07-07T02:09:51.505380Z",
+     "iopub.status.idle": "2026-07-07T02:09:51.664013Z",
+     "shell.execute_reply": "2026-07-07T02:09:51.663783Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "@context (brut): {\r\n",
+       "  \"@vocab\": \"http://schema.org/\",\r\n",
+       "  \"name\": \"http://schema.org/name\",\r\n",
+       "  \"email\": \"http://schema.org/email\",\r\n",
+       "  \"url\": {\r\n",
+       "    \"@id\": \"http://schema.org/url\",\r\n",
+       "    \"@type\": \"@id\"\r\n",
+       "  },\r\n",
+       "  \"Person\": \"http://schema.org/Person\",\r\n",
+       "  \"knows\": \"http://schema.org/knows\"\r\n",
+       "}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Document JSON-LD compact: {\r\n",
+       "  \"@context\": {\r\n",
+       "    \"@vocab\": \"http://schema.org/\",\r\n",
+       "    \"name\": \"http://schema.org/name\",\r\n",
+       "    \"email\": \"http://schema.org/email\",\r\n",
+       "    \"url\": {\r\n",
+       "      \"@id\": \"http://schema.org/url\",\r\n",
+       "      \"@type\": \"@id\"\r\n",
+       "    },\r\n",
+       "    \"Person\": \"http://schema.org/Person\",\r\n",
+       "    \"knows\": \"http://schema.org/knows\"\r\n",
+       "  },\r\n",
+       "  \"@id\": \"http://example.org/alice\",\r\n",
+       "  \"@type\": \"Person\",\r\n",
+       "  \"name\": \"Alice Martin\",\r\n",
+       "  \"email\": \"alice@example.org\",\r\n",
+       "  \"url\": \"http://alice.example.org\",\r\n",
+       "  \"knows\": [\r\n",
+       "    \"http://example.org/bob\",\r\n",
+       "    \"http://example.org/carol\"\r\n",
+       "  ]\r\n",
+       "}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- @context : dictionnaire terme -> IRI (Schema.org) ---\n",
+    "var context = new JObject\n",
+    "{\n",
+    "    [\"@vocab\"] = \"http://schema.org/\",\n",
+    "    [\"name\"] = \"http://schema.org/name\",\n",
+    "    [\"email\"] = \"http://schema.org/email\",\n",
+    "    [\"url\"] = new JObject { [\"@id\"] = \"http://schema.org/url\", [\"@type\"] = \"@id\" },\n",
+    "    [\"Person\"] = \"http://schema.org/Person\",\n",
+    "    [\"knows\"] = \"http://schema.org/knows\"\n",
+    "};\n",
+    "Show(\"@context (brut)\", context.ToString(Formatting.Indented));\n",
+    "\n",
+    "// Document JSON-LD compact utilisant ce contexte\n",
+    "var person = new JObject\n",
+    "{\n",
+    "    [\"@context\"] = context,\n",
+    "    [\"@id\"] = \"http://example.org/alice\",\n",
+    "    [\"@type\"] = \"Person\",\n",
+    "    [\"name\"] = \"Alice Martin\",\n",
+    "    [\"email\"] = \"alice@example.org\",\n",
+    "    [\"url\"] = \"http://alice.example.org\",\n",
+    "    [\"knows\"] = new JArray { \"http://example.org/bob\", \"http://example.org/carol\" }\n",
+    "};\n",
+    "Show(\"Document JSON-LD compact\", person.ToString(Formatting.Indented));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3130f3a-f9e3-4a20-b2b7-53bbccdc4439",
+   "metadata": {},
+   "source": [
+    "## Partie 2 — Parser du JSON-LD en graphe RDF\n",
+    "\n",
+    "Le `JsonLdParser` de dotNetRDF lit un document JSON-LD dans un `TripleStore` (JSON-LD = format dataset). On extrait le graphe par defaut, puis on l'interroge comme n'importe quel graphe RDF — par exemple en le serialisant en Turtle.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f6ef0f8b-8404-4185-8a2c-14b27fecf248",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:51.665901Z",
+     "iopub.status.busy": "2026-07-07T02:09:51.665653Z",
+     "iopub.status.idle": "2026-07-07T02:09:51.922535Z",
+     "shell.execute_reply": "2026-07-07T02:09:51.922818Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Triplets RDF parses: 6"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Graphe (Turtle): @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\r\n",
+       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.\r\n",
+       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.\r\n",
+       "\r\n",
+       "<http://example.org/alice> <http://schema.org/email> \"alice@example.org\";\r\n",
+       "                           <http://schema.org/knows> \"http://example.org/bob\",\r\n",
+       "                                                     \"http://example.org/carol\";\r\n",
+       "                           <http://schema.org/name> \"Alice Martin\";\r\n",
+       "                           <http://schema.org/url> <http://alice.example.org/>;\r\n",
+       "                           a <http://schema.org/Person>.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Valeur de schema:name: Alice Martin^^http://www.w3.org/2001/XMLSchema#string"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Parser JSON-LD -> TripleStore -> graphe par defaut (dotNetRDF JsonLdParser) ---\n",
+    "var jsonLdDoc = person.ToString(Formatting.Indented);\n",
+    "var g = LoadJsonLd(jsonLdDoc);\n",
+    "Show(\"Triplets RDF parses\", g.Triples.Count);\n",
+    "Show(\"Graphe (Turtle)\", SerializeToTurtle(g));\n",
+    "\n",
+    "// On verifie les termes compacts -> IRIs complets : name doit pointer vers schema:name\n",
+    "var nameTriples = g.GetTriplesWithPredicate(g.CreateUriNode(new Uri(\"http://schema.org/name\")));\n",
+    "Show(\"Valeur de schema:name\", string.Join(\", \", nameTriples.Select(t => t.Object.ToString())));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a719092-7e97-4ca1-b4a1-9aa7c6af6882",
+   "metadata": {},
+   "source": [
+    "## Partie 3 — Serialiser un graphe RDF en JSON-LD\n",
+    "\n",
+    "Inversement, le `JsonLdWriter` produit du JSON-LD (forme etendue) a partir d'un `TripleStore`. On reconstruit un graphe RDF a la main (assertion de triplets), on l'emballe dans un store, puis on le serialise.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e3f97053-b1f7-4797-beac-9d855c4a4aee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:51.924980Z",
+     "iopub.status.busy": "2026-07-07T02:09:51.924764Z",
+     "iopub.status.idle": "2026-07-07T02:09:52.037555Z",
+     "shell.execute_reply": "2026-07-07T02:09:52.037084Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Graphe -> JSON-LD (forme etendue): [\r\n",
+       "  {\r\n",
+       "    \"@id\": \"http://schema.org/alice\",\r\n",
+       "    \"@type\": [\r\n",
+       "      \"http://schema.org/Person\"\r\n",
+       "    ],\r\n",
+       "    \"http://schema.org/name\": [\r\n",
+       "      {\r\n",
+       "        \"@value\": \"Alice\"\r\n",
+       "      }\r\n",
+       "    ],\r\n",
+       "    \"http://schema.org/knows\": [\r\n",
+       "      {\r\n",
+       "        \"@id\": \"http://schema.org/bob\"\r\n",
+       "      }\r\n",
+       "    ]\r\n",
+       "  }\r\n",
+       "]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Graphe -> Turtle (comparaison): @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\r\n",
+       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.\r\n",
+       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.\r\n",
+       "@prefix schema: <http://schema.org/>.\r\n",
+       "\r\n",
+       "schema:alice schema:knows schema:bob;\r\n",
+       "             schema:name \"Alice\";\r\n",
+       "             a schema:Person.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Construire un graphe RDF a la main, puis le serialiser en JSON-LD ---\n",
+    "var g2 = new Graph();\n",
+    "g2.NamespaceMap.AddNamespace(\"schema\", new Uri(\"http://schema.org/\"));\n",
+    "g2.NamespaceMap.AddNamespace(\"xsd\", new Uri(\"http://www.w3.org/2001/XMLSchema#\"));\n",
+    "var alice2 = g2.CreateUriNode(\"schema:alice\");\n",
+    "var personType = g2.CreateUriNode(\"schema:Person\");\n",
+    "var nameP = g2.CreateUriNode(\"schema:name\");\n",
+    "var knowsP = g2.CreateUriNode(\"schema:knows\");\n",
+    "var bob2 = g2.CreateUriNode(\"schema:bob\");\n",
+    "g2.Assert(new Triple(alice2, g2.CreateUriNode(\"rdf:type\"), personType));\n",
+    "g2.Assert(new Triple(alice2, nameP, g2.CreateLiteralNode(\"Alice\", new Uri(\"http://www.w3.org/2001/XMLSchema#string\"))));\n",
+    "g2.Assert(new Triple(alice2, knowsP, bob2));\n",
+    "\n",
+    "Show(\"Graphe -> JSON-LD (forme etendue)\", SerializeToJsonLd(g2));\n",
+    "Show(\"Graphe -> Turtle (comparaison)\", SerializeToTurtle(g2));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1dc3060-3cd5-40de-a4a1-ffb1e2bc58ba",
+   "metadata": {},
+   "source": [
+    "## Partie 4 — Explorer le vocabulaire Schema.org\n",
+    "\n",
+    "**Schema.org** est un vocabulaire collaboratif (Google, Microsoft, Yahoo, Yandex) pour decrire les choses du web : `Person`, `Product`, `Event`, `Place`, `Organization`... JSON-LD est le format recommande pour embarquer ces donnees structurees dans les pages HTML (SEO, rich snippets, knowledge graph).\n",
+    "\n",
+    "On construit un document Schema.org `Product` (avec une offre imbriquee et une note agregee) et on le valide en le parsant.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6b1d935a-b6ae-4777-a291-dab029da1f3e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:52.039444Z",
+     "iopub.status.busy": "2026-07-07T02:09:52.039077Z",
+     "iopub.status.idle": "2026-07-07T02:09:52.168848Z",
+     "shell.execute_reply": "2026-07-07T02:09:52.168689Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Schema.org Product (JSON-LD): {\r\n",
+       "  \"@context\": {\r\n",
+       "    \"@vocab\": \"http://schema.org/\"\r\n",
+       "  },\r\n",
+       "  \"@type\": \"Product\",\r\n",
+       "  \"@id\": \"http://shop.example.org/produit/42\",\r\n",
+       "  \"name\": \"Casque audio ANC\",\r\n",
+       "  \"description\": \"Casque sans fil a reduction de bruit active\",\r\n",
+       "  \"brand\": {\r\n",
+       "    \"@type\": \"Brand\",\r\n",
+       "    \"name\": \"AudioCo\"\r\n",
+       "  },\r\n",
+       "  \"offers\": {\r\n",
+       "    \"@type\": \"Offer\",\r\n",
+       "    \"price\": \"199.99\",\r\n",
+       "    \"priceCurrency\": \"EUR\",\r\n",
+       "    \"availability\": \"http://schema.org/InStock\"\r\n",
+       "  },\r\n",
+       "  \"aggregateRating\": {\r\n",
+       "    \"@type\": \"AggregateRating\",\r\n",
+       "    \"ratingValue\": \"4.5\",\r\n",
+       "    \"reviewCount\": \"127\"\r\n",
+       "  }\r\n",
+       "}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Triplets generes (Product): 15"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Types Schema.org rencontres: http://schema.org/Product, http://schema.org/AggregateRating, http://schema.org/Brand, http://schema.org/Offer"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Offre (price): 199.99^^http://www.w3.org/2001/XMLSchema#string"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Document Schema.org Product en JSON-LD ---\n",
+    "var product = new JObject\n",
+    "{\n",
+    "    [\"@context\"] = new JObject { [\"@vocab\"] = \"http://schema.org/\" },\n",
+    "    [\"@type\"] = \"Product\",\n",
+    "    [\"@id\"] = \"http://shop.example.org/produit/42\",\n",
+    "    [\"name\"] = \"Casque audio ANC\",\n",
+    "    [\"description\"] = \"Casque sans fil a reduction de bruit active\",\n",
+    "    [\"brand\"] = new JObject { [\"@type\"] = \"Brand\", [\"name\"] = \"AudioCo\" },\n",
+    "    [\"offers\"] = new JObject\n",
+    "    {\n",
+    "        [\"@type\"] = \"Offer\",\n",
+    "        [\"price\"] = \"199.99\",\n",
+    "        [\"priceCurrency\"] = \"EUR\",\n",
+    "        [\"availability\"] = \"http://schema.org/InStock\"\n",
+    "    },\n",
+    "    [\"aggregateRating\"] = new JObject\n",
+    "    {\n",
+    "        [\"@type\"] = \"AggregateRating\",\n",
+    "        [\"ratingValue\"] = \"4.5\",\n",
+    "        [\"reviewCount\"] = \"127\"\n",
+    "    }\n",
+    "};\n",
+    "Show(\"Schema.org Product (JSON-LD)\", product.ToString(Formatting.Indented));\n",
+    "\n",
+    "// Validation : on parse et on compte les triplets generes\n",
+    "var g3 = LoadJsonLd(product.ToString(Formatting.Indented));\n",
+    "Show(\"Triplets generes (Product)\", g3.Triples.Count);\n",
+    "// Les types distincts presents dans le graphe\n",
+    "var types = g3.Triples\n",
+    "    .Where(t => t.Predicate.ToString().EndsWith(\"type\") || t.Predicate.ToString().EndsWith(\"#type\"))\n",
+    "    .Select(t => t.Object.ToString())\n",
+    "    .Distinct();\n",
+    "Show(\"Types Schema.org rencontres\", string.Join(\", \", types));\n",
+    "// Le prix et la devise\n",
+    "var priceTriples = g3.GetTriplesWithPredicate(g3.CreateUriNode(new Uri(\"http://schema.org/price\")));\n",
+    "Show(\"Offre (price)\", string.Join(\", \", priceTriples.Select(t => t.Object.ToString())));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f95b7069-4c97-4631-9ec4-86cd2743e70e",
+   "metadata": {},
+   "source": [
+    "## Partie 5 — `@graph` : regrouper plusieurs ressources\n",
+    "\n",
+    "Le mot-cle `@graph` permet de regrouper plusieurs ressources sous un meme `@context`, sans que le nœud racine ne soit lui-meme une ressource nommee. C'est la forme naturelle pour les datasets (plusieurs sujets decrits ensemble).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ec1a5735-a6ff-4e8b-b18b-474cf23b984e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:52.170095Z",
+     "iopub.status.busy": "2026-07-07T02:09:52.169910Z",
+     "iopub.status.idle": "2026-07-07T02:09:52.258024Z",
+     "shell.execute_reply": "2026-07-07T02:09:52.257865Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Dataset @graph (3 personnes): {\r\n",
+       "  \"@context\": {\r\n",
+       "    \"@vocab\": \"http://schema.org/\"\r\n",
+       "  },\r\n",
+       "  \"@graph\": [\r\n",
+       "    {\r\n",
+       "      \"@id\": \"http://example.org/alice\",\r\n",
+       "      \"@type\": \"Person\",\r\n",
+       "      \"name\": \"Alice\",\r\n",
+       "      \"knows\": {\r\n",
+       "        \"@id\": \"http://example.org/bob\"\r\n",
+       "      }\r\n",
+       "    },\r\n",
+       "    {\r\n",
+       "      \"@id\": \"http://example.org/bob\",\r\n",
+       "      \"@type\": \"Person\",\r\n",
+       "      \"name\": \"Bob\"\r\n",
+       "    },\r\n",
+       "    {\r\n",
+       "      \"@id\": \"http://example.org/carol\",\r\n",
+       "      \"@type\": \"Person\",\r\n",
+       "      \"name\": \"Carol\"\r\n",
+       "    }\r\n",
+       "  ]\r\n",
+       "}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Triplets (dataset): 7"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Alice knows: http://example.org/bob"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- @graph : dataset de plusieurs ressources ---\n",
+    "var dataset = new JObject\n",
+    "{\n",
+    "    [\"@context\"] = new JObject { [\"@vocab\"] = \"http://schema.org/\" },\n",
+    "    [\"@graph\"] = new JArray\n",
+    "    {\n",
+    "        new JObject { [\"@id\"] = \"http://example.org/alice\", [\"@type\"] = \"Person\", [\"name\"] = \"Alice\", [\"knows\"] = new JObject { [\"@id\"] = \"http://example.org/bob\" } },\n",
+    "        new JObject { [\"@id\"] = \"http://example.org/bob\", [\"@type\"] = \"Person\", [\"name\"] = \"Bob\" },\n",
+    "        new JObject { [\"@id\"] = \"http://example.org/carol\", [\"@type\"] = \"Person\", [\"name\"] = \"Carol\" }\n",
+    "    }\n",
+    "};\n",
+    "Show(\"Dataset @graph (3 personnes)\", dataset.ToString(Formatting.Indented));\n",
+    "\n",
+    "var g4 = LoadJsonLd(dataset.ToString(Formatting.Indented));\n",
+    "Show(\"Triplets (dataset)\", g4.Triples.Count);\n",
+    "// Lien knows : Alice -> Bob\n",
+    "var aliceNode = g4.GetUriNode(new Uri(\"http://example.org/alice\"));\n",
+    "var knowsPred = g4.GetUriNode(new Uri(\"http://schema.org/knows\"));\n",
+    "var knowsTriples = g4.GetTriplesWithSubjectPredicate(aliceNode, knowsPred);\n",
+    "Show(\"Alice knows\", string.Join(\", \", knowsTriples.Select(t => t.Object.ToString())));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee72c805-ca45-40ed-aeb8-cb8ad69519dd",
+   "metadata": {},
+   "source": [
+    "## Partie 6 — Round-trip JSON-LD <-> Turtle\n",
+    "\n",
+    "Un test classique de conformite : parser du JSON-LD, serialiser en Turtle, re-parser, et verifier qu'on retrouve le meme graphe (round-trip). On verifie l'isomorphisme par egalite de l'ensemble des triplets (sujet, predicat, objet).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "87472c21-847a-443f-b80d-c97698c1e592",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:52.259276Z",
+     "iopub.status.busy": "2026-07-07T02:09:52.259072Z",
+     "iopub.status.idle": "2026-07-07T02:09:52.400411Z",
+     "shell.execute_reply": "2026-07-07T02:09:52.400695Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Triplets originaux: 3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Turtle intermediaire: @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\r\n",
+       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.\r\n",
+       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.\r\n",
+       "\r\n",
+       "<http://example.org/workshop> <http://schema.org/name> \"Atelier JSON-LD\";\r\n",
+       "                              <http://schema.org/startDate> \"2026-07-15\";\r\n",
+       "                              a <http://schema.org/Event>.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Triplets apres round-trip: 3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Round-trip JSON-LD -> Turtle coherent ?: OUI (isomorphe)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Re-serialisation JSON-LD (forme etendue): [\r\n",
+       "  {\r\n",
+       "    \"@id\": \"http://example.org/workshop\",\r\n",
+       "    \"http://schema.org/name\": [\r\n",
+       "      {\r\n",
+       "        \"@value\": \"Atelier JSON-LD\"\r\n",
+       "      }\r\n",
+       "    ],\r\n",
+       "    \"http://schema.org/startDate\": [\r\n",
+       "      {\r\n",
+       "        \"@value\": \"2026-07-15\"\r\n",
+       "      }\r\n",
+       "    ],\r\n",
+       "    \"@type\": [\r\n",
+       "      \"http://schema.org/Event\"\r\n",
+       "    ]\r\n",
+       "  }\r\n",
+       "]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Round-trip JSON-LD -> Turtle -> JSON-LD ---\n",
+    "var original = new JObject\n",
+    "{\n",
+    "    [\"@context\"] = new JObject { [\"@vocab\"] = \"http://schema.org/\" },\n",
+    "    [\"@id\"] = \"http://example.org/workshop\",\n",
+    "    [\"@type\"] = \"Event\",\n",
+    "    [\"name\"] = \"Atelier JSON-LD\",\n",
+    "    [\"startDate\"] = \"2026-07-15\"\n",
+    "};\n",
+    "var g5 = LoadJsonLd(original.ToString(Formatting.Indented));\n",
+    "Show(\"Triplets originaux\", g5.Triples.Count);\n",
+    "\n",
+    "// Turtle intermediaire\n",
+    "var turtle5 = SerializeToTurtle(g5);\n",
+    "Show(\"Turtle intermediaire\", turtle5);\n",
+    "\n",
+    "// Re-parse du Turtle -> nouveau graphe\n",
+    "var g5b = new Graph();\n",
+    "new TurtleParser().Load(g5b, new StringReader(turtle5));\n",
+    "Show(\"Triplets apres round-trip\", g5b.Triples.Count);\n",
+    "\n",
+    "// Isomorphisme : memes triplets (S,P,O) dans les deux graphes ?\n",
+    "var same = g5.Triples.Count == g5b.Triples.Count\n",
+    "    && g5.Triples.All(t => g5b.Triples.Any(u => u.Subject.Equals(t.Subject) && u.Predicate.Equals(t.Predicate) && u.Object.Equals(t.Object)));\n",
+    "Show(\"Round-trip JSON-LD -> Turtle coherent ?\", same ? \"OUI (isomorphe)\" : \"NON\");\n",
+    "\n",
+    "// Re-serialisation JSON-LD pour fermer la boucle\n",
+    "Show(\"Re-serialisation JSON-LD (forme etendue)\", SerializeToJsonLd(g5b));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3d47a4a-470f-4a4b-b04f-a3d28b0e810e",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# a couvert les 6 piliers de JSON-LD avec dotNetRDF :\n",
+    "\n",
+    "1. **`@context`** : dictionnaire terme -> IRI (Partie 1).\n",
+    "2. **Parsing JSON-LD -> graphe RDF** via `JsonLdParser` (Partie 2).\n",
+    "3. **Serialisation graphe -> JSON-LD** via `JsonLdWriter` (Partie 3).\n",
+    "4. **Schema.org** : vocabulaire de donnees structurees (Partie 4).\n",
+    "5. **`@graph`** : regroupement de ressources (Partie 5).\n",
+    "6. **Round-trip** JSON-LD <-> Turtle + isomorphisme (Partie 6).\n",
+    "\n",
+    "Le notebook Python original utilise `rdflib` + `pyld` ; ce twin C# utilise **dotNetRDF** (`VDS.RDF.*`). Les deux sont des moteurs W3C complets. Value-add (EPIC #4956 Prong B) : comparaison cross-langage des API sur le meme standard JSON-LD 1.1. Subtilite API notee : `JsonLdParser`/`JsonLdWriter` operent sur `TripleStore` (dataset), refletant que JSON-LD est nativement un format multi-graphes (mot-cle `@graph`).\n",
+    "\n",
+    "## Exercices\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "bcf67b26-a4c1-45a9-81ec-9fcf45dd1082",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:52.402270Z",
+     "iopub.status.busy": "2026-07-07T02:09:52.402092Z",
+     "iopub.status.idle": "2026-07-07T02:09:52.440457Z",
+     "shell.execute_reply": "2026-07-07T02:09:52.440298Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Contexte biblio (a completer): {}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : Compaction avec un contexte personnalise\n",
+    "// TODO etudiant : ecrivez un contexte qui compacte un graphe de livres\n",
+    "// en utilisant les termes courts \"titre\", \"auteur\", \"publie\".\n",
+    "// Indice : definissez un JObject @context mappant chaque terme court a son IRI complet.\n",
+    "// Etape 1 : ecrire le contexte. Etape 2 : l'utiliser pour construire un document JSON-LD compact.\n",
+    "public static JObject BuildBiblioContext()\n",
+    "{\n",
+    "    // TODO etudiant : retournez un contexte du type {\"@context\": {\"titre\": \"http://.../title\", ...}}\n",
+    "    return new JObject();\n",
+    "}\n",
+    "Show(\"Contexte biblio (a completer)\", BuildBiblioContext().ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e885d322-5e9e-4eb8-a653-3f26069bc557",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:52.442125Z",
+     "iopub.status.busy": "2026-07-07T02:09:52.441880Z",
+     "iopub.status.idle": "2026-07-07T02:09:52.555450Z",
+     "shell.execute_reply": "2026-07-07T02:09:52.555311Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Personnes extraites (a completer): 0 (a completer)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Newtonsoft.Json' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Framing (extraire un sous-graphe type)\n",
+    "// TODO etudiant : implementez une selection qui extrait tous les nœuds\n",
+    "// de type schema:Person dans un graphe et retourne leur @id + nom.\n",
+    "// Indice : enumeratez g4.Triples, filtrez par predicat rdf:type == http://schema.org/Person.\n",
+    "// Etape 1 : trouver les sujets de type Person. Etape 2 : pour chacun, recuperer son schema:name.\n",
+    "public static List<JObject> ExtractPersons(IGraph g)\n",
+    "{\n",
+    "    // TODO etudiant : retournez la liste des {\"@id\":..., \"name\":...}\n",
+    "    return new List<JObject>();\n",
+    "}\n",
+    "var persons = ExtractPersons(g4);\n",
+    "Show(\"Personnes extraites (a completer)\", persons.Count == 0 ? \"0 (a completer)\" : string.Join(\"; \", persons.Select(p => p.ToString())));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0083077a-0e66-4910-80ec-6e41a83c3552",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T02:09:52.556681Z",
+     "iopub.status.busy": "2026-07-07T02:09:52.556498Z",
+     "iopub.status.idle": "2026-07-07T02:09:52.586386Z",
+     "shell.execute_reply": "2026-07-07T02:09:52.586218Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "JSON-LD valide (cas correct): True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "JSON-LD valide (cas casse): True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Valider un JSON-LD mal forme\n",
+    "// TODO etudiant : ecrivez une fonction qui tente de parser un JSON-LD et\n",
+    "// retourne true s'il est valide (parsable en graphe RDF), false sinon.\n",
+    "// Indice : try/catch autour de LoadJsonLd (qui appelle JsonLdParser.Load).\n",
+    "public static bool IsValidJsonLd(string json)\n",
+    "{\n",
+    "    // TODO etudiant : retournez vrai si parsable, faux sinon\n",
+    "    return true;\n",
+    "}\n",
+    "Show(\"JSON-LD valide (cas correct)\", IsValidJsonLd(\"{\\\"@id\\\":\\\"http://x.org/a\\\",\\\"@type\\\":\\\"http://x.org/T\\\",\\\"http://x.org/name\\\":\\\"foo\\\"}\"));\n",
+    "Show(\"JSON-LD valide (cas casse)\", IsValidJsonLd(\"{ce n'est pas du json}\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fb0f730-1209-4f00-a4db-de4e9e81e84a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "*Twin C# du notebook Python `SW-9-Python-JSONLD.ipynb`. Marathon parite .NET <-> Python (#4956, Prong B). dotNetRDF 3.4.1 (vrai moteur W3C JSON-LD 1.1).*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": "csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Twin C# (.NET Interactive) du notebook Python `SW-9-Python-JSONLD.ipynb`. Explore **JSON-LD** (W3C Recommendation 1.1) via le **vrai moteur dotNetRDF 3.4.1** (`JsonLdParser` / `JsonLdWriter`), pas de workaround. Marathon parité .NET ⇄ Python **#4956, Prong B**.

- **6 parties** : `@context`/`@id`/`@type`/`@graph`, parse JSON-LD → graphe RDF, serialize graphe RDF → JSON-LD, Schema.org `Product`, dataset `@graph`, round-trip JSON-LD ↔ Turtle.
- **3 exercices** stub (compaction biblio, framing Persons, validation JSON-LD).
- **Value-add Prong B** : compagnon cross-langage sur le même standard W3C JSON-LD 1.1 — Python `rdflib` + `pyld` ↔ C# dotNetRDF.

## Subtilité API (vérifiée par probe)

`JsonLdParser` est `IStoreReader` et `JsonLdWriter` est `IStoreWriter` — ils opèrent sur un **`TripleStore`** (dataset), pas sur un `Graph` unique comme les autres sérialisations RDF. Cela reflète que JSON-LD est nativement un format multi-graphes (mot-clé `@graph`). Le notebook documente cette subtilité via 3 helpers (`LoadJsonLd`, `SerializeToJsonLd`, `SerializeToTurtle`).

```
JsonLdParser interfaces: IStoreReader
  Load(ITripleStore store, TextReader input)   # PAS de (IGraph, reader)
JsonLdWriter interfaces: IStoreWriter
```

## Validation (H.1 — EXEC_PROVED)

Exécuté via `jupyter nbconvert --execute --kernel .net-csharp --inplace` :

```
VERDICT: code=11 ec_none=0 errors=0 C.1=0 leaks=0
EXEC: EXEC_PROVED
```

- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`. Stubs conformes (`return new JObject()`, `return new List<JObject>()`, `return true`).
- **C.2** : 11/11 cellules `execution_count != null` + outputs cohérents.
- **Path-leak** : 0 (aucun chemin machine dans les outputs).
- **Outputs vérifiés firsthand** :
  - Partie 2 (parse) : 6 triplets, `schema:name` → "Alice Martin", `knows` → bob.
  - Partie 3 (serialize) : graphe construit → JSON-LD forme étendue + Turtle.
  - Partie 4 (Schema.org Product) : 15 triplets, 4 types (`Product`, `Offer`, `Brand`, `AggregateRating`), `price` 199.99.
  - Partie 5 (`@graph` dataset) : 7 triplets, Alice knows Bob.
  - Partie 6 (round-trip) : 3 → 3 triplets, **`OUI (isomorphe)`**.

## README

`MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md` : +1 ligne arborescence (fichier tree) + 1 note "Twin C# disponible" sous la section SW-9. **CATALOG-STATUS marqueur byte-identique** (cron régénère l'entrée < 24h, cf `catalog-pr-hygiene` HARD 1).

## Anti-régression

Nouveau fichier uniquement (1520 insertions, 0 deletion). Aucun code métier touché.

See #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)