### PR TITLE
feat(smt): Z3-Python-01-Introduction-Csharp — twin C# Microsoft.Z3 (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -41,6 +41,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 | # | Notebook | Sujet | Durée | Statut |
 |---|----------|-------|------|--------|
 | 01 | [Introduction](Z3-Python-01-Introduction.ipynb) | `Solver`, `Int`/`Bool`/`Real`, sat/unsat, `Optimize` | ~30 min | PRODUCTION |
+| 01ᶜˢ | [Introduction (twin C# .NET)](Z3-Python-01-Introduction-Csharp.ipynb) | Parité .NET : même moteur Z3 via `Microsoft.Z3` (NuGet) | ~30 min | PRODUCTION |
 | 02 | [Sudoku](Z3-Python-02-Sudoku.ipynb) | Sudoku comme CSP, `Distinct`, visualisation matplotlib | ~25 min | PRODUCTION |
 | 03 | [Tactiques et théories](Z3-Python-03-Tactics.ipynb) | `Tactic`, `BitVec`, `Array` | ~35 min | PRODUCTION |
 | 04 | [Chaînes et expressions régulières](Z3-Python-04-Strings-Regex.ipynb) | `String`, `Re` (théorie des chaînes Z3) | ~30 min | PRODUCTION |

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-01-Introduction-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-01-Introduction-Csharp.ipynb
@@ -1,0 +1,789 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "be974b19",
+   "metadata": {},
+   "source": [
+    "# Z3 (C# / .NET) — Introduction au solveur SMT\n",
+    "\n",
+    "**Twin C# de `Z3-Python-01-Introduction.ipynb`** (parite .NET, marathon #4956).\n",
+    "\n",
+    "Ce notebook est l'equivalent .NET de l'introduction au solveur SMT Z3. Il utilise le **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (binding .NET officiel de Z3), le meme solveur que la version Python (`z3-solver`), via le package NuGet `Microsoft.Z3`. Aucune re-implementation jouet : les contraintes sont resolues par le vrai moteur SOTA.\n",
+    "\n",
+    "## Pre-requis\n",
+    "\n",
+    "- Kernel `.NET (C#)` (.NET Interactive).\n",
+    "- Le package NuGet `Microsoft.Z3` est restaure automatiquement par la premiere cellule.\n",
+    "\n",
+    "## Plan\n",
+    "\n",
+    "1. Deux entiers sous contraintes lineaires.\n",
+    "2. Insatisfiabilite et noyau (unsat core).\n",
+    "3. Le menteur (logique booleenne).\n",
+    "4. Arithmetique rationnelle exacte.\n",
+    "5. Mini sac a dos (optimisation).\n",
+    "6. Trois exercices.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "eac25c0b",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:39.129769Z",
+     "iopub.status.busy": "2026-07-07T04:08:39.125306Z",
+     "iopub.status.idle": "2026-07-07T04:08:42.599262Z",
+     "shell.execute_reply": "2026-07-07T04:08:42.594987Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '60256.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.Z3, 4.12.2</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : Microsoft.Z3 version Z3 4.12.2.0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.Z3\"\n",
+    "using Microsoft.Z3;\n",
+    "Console.WriteLine(\"Imports OK : Microsoft.Z3 version \" + Microsoft.Z3.Version.FullVersion);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb858d70",
+   "metadata": {},
+   "source": [
+    "## 1. Deux entiers sous contraintes lineaires\n",
+    "\n",
+    "On cherche deux entiers `x` et `y` tels que `x + y = 10`, `x > 0`, `y > 0`, et `x > y`. Z3 construit un **Solver**, on ajoute les contraintes, puis on appelle `Check()` qui renvoie un statut (`SATISFIABLE`, `UNSATISFIABLE`, `UNKNOWN`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0f209d3f",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:42.600866Z",
+     "iopub.status.busy": "2026-07-07T04:08:42.600671Z",
+     "iopub.status.idle": "2026-07-07T04:08:42.825640Z",
+     "shell.execute_reply": "2026-07-07T04:08:42.825442Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat de s.Check() : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele trouve :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  x = 9\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  y = 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Verification : x + y = 10\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var ctx1 = new Context();\n",
+    "var x = ctx1.MkIntConst(\"x\");\n",
+    "var y = ctx1.MkIntConst(\"y\");\n",
+    "var s = ctx1.MkSolver();\n",
+    "s.Add(ctx1.MkEq(ctx1.MkAdd(x, y), ctx1.MkInt(10)));\n",
+    "s.Add(ctx1.MkGt(x, ctx1.MkInt(0)));\n",
+    "s.Add(ctx1.MkGt(y, ctx1.MkInt(0)));\n",
+    "s.Add(ctx1.MkGt(x, y));\n",
+    "var resultat = s.Check();\n",
+    "Console.WriteLine(\"Resultat de s.Check() : \" + resultat);\n",
+    "if (resultat == Status.SATISFIABLE)\n",
+    "{\n",
+    "    var m = s.Model;\n",
+    "    long xv = ((IntNum)m.Evaluate(x)).Int64;\n",
+    "    long yv = ((IntNum)m.Evaluate(y)).Int64;\n",
+    "    Console.WriteLine(\"Modele trouve :\");\n",
+    "    Console.WriteLine(\"  x = \" + xv);\n",
+    "    Console.WriteLine(\"  y = \" + yv);\n",
+    "    Console.WriteLine(\"  Verification : x + y = \" + (xv + yv));\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deddca37",
+   "metadata": {},
+   "source": [
+    "## 2. Exemple insatisfiable et noyau d'insatisfiabilite\n",
+    "\n",
+    "Deux contraintes contradictoires (`x > 5` ET `x < 3`) renvoient `UNSATISFIABLE`. Pour **identifier quelles contraintes sont en conflit**, on nomme chaque assertion avec `AssertAndTrack` puis on recupere le **noyau (unsat core)** : l'ensemble minimal de contraintes qui suffisent a provoquer l'insatisfiabilite.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b4fcd5b7",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:42.827274Z",
+     "iopub.status.busy": "2026-07-07T04:08:42.827071Z",
+     "iopub.status.idle": "2026-07-07T04:08:43.024964Z",
+     "shell.execute_reply": "2026-07-07T04:08:43.024798Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contraintes : x > 5 ET x < 3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat de s.check() : UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avec AssertAndTrack :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Noyau d insatisfiabilite (contraintes en conflit) : [c2, c1]\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var ctx2 = new Context();\n",
+    "var x2 = ctx2.MkIntConst(\"x\");\n",
+    "var s2 = ctx2.MkSolver();\n",
+    "s2.Add(ctx2.MkGt(x2, ctx2.MkInt(5)));\n",
+    "s2.Add(ctx2.MkLt(x2, ctx2.MkInt(3)));\n",
+    "Console.WriteLine(\"Contraintes : x > 5 ET x < 3\");\n",
+    "Console.WriteLine(\"Resultat de s.check() : \" + s2.Check());\n",
+    "\n",
+    "// Noyau d insatisfiabilite via AssertAndTrack.\n",
+    "var s3 = ctx2.MkSolver();\n",
+    "var c1 = ctx2.MkBoolConst(\"c1\");\n",
+    "var c2 = ctx2.MkBoolConst(\"c2\");\n",
+    "s3.AssertAndTrack(ctx2.MkGt(x2, ctx2.MkInt(5)), c1);\n",
+    "s3.AssertAndTrack(ctx2.MkLt(x2, ctx2.MkInt(3)), c2);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Avec AssertAndTrack :\");\n",
+    "Console.WriteLine(\"Resultat : \" + s3.Check());\n",
+    "var core = s3.UnsatCore;\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "for (int k = 0; k < core.Length; k++) { if (k > 0) sb.Append(\", \"); sb.Append(core[k]); }\n",
+    "Console.WriteLine(\"Noyau d insatisfiabilite (contraintes en conflit) : [\" + sb + \"]\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a19055a0",
+   "metadata": {},
+   "source": [
+    "## 3. Le menteur : qui dit la verite ?\n",
+    "\n",
+    "Trois personnes A, B, C. A affirme que B ment, B affirme que C ment, C affirme que A et B mentent tous les deux. Modelise en logique booleenne : `A == non B`, `B == non C`, `C == (non A et non B)`. Z3 trouve qui dit la verite.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f47d6e84",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:43.026193Z",
+     "iopub.status.busy": "2026-07-07T04:08:43.026005Z",
+     "iopub.status.idle": "2026-07-07T04:08:43.108470Z",
+     "shell.execute_reply": "2026-07-07T04:08:43.108011Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A dit la verite : False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "B dit la verite : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C dit la verite : False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Synthese : B dit la verite.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var ctx3 = new Context();\n",
+    "var A = ctx3.MkBoolConst(\"A\");\n",
+    "var B = ctx3.MkBoolConst(\"B\");\n",
+    "var C = ctx3.MkBoolConst(\"C\");\n",
+    "var s = ctx3.MkSolver();\n",
+    "s.Add(ctx3.MkEq(A, ctx3.MkNot(B)));\n",
+    "s.Add(ctx3.MkEq(B, ctx3.MkNot(C)));\n",
+    "s.Add(ctx3.MkEq(C, ctx3.MkAnd(ctx3.MkNot(A), ctx3.MkNot(B))));\n",
+    "Console.WriteLine(\"Resultat : \" + s.Check());\n",
+    "var m = s.Model;\n",
+    "bool av = ((BoolExpr)m.Evaluate(A)).BoolValue == Z3_lbool.Z3_L_TRUE;\n",
+    "bool bv = ((BoolExpr)m.Evaluate(B)).BoolValue == Z3_lbool.Z3_L_TRUE;\n",
+    "bool cv = ((BoolExpr)m.Evaluate(C)).BoolValue == Z3_lbool.Z3_L_TRUE;\n",
+    "Console.WriteLine(\"A dit la verite : \" + av);\n",
+    "Console.WriteLine(\"B dit la verite : \" + bv);\n",
+    "Console.WriteLine(\"C dit la verite : \" + cv);\n",
+    "string veridique = av ? \"A\" : (bv ? \"B\" : \"C\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Synthese : \" + veridique + \" dit la verite.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0635ace8",
+   "metadata": {},
+   "source": [
+    "## 4. Arithmetique rationnelle exacte avec `Real`\n",
+    "\n",
+    "Trois enfants se partagent 10 euros : l'aine recoit le double du cadet, le benjamin recoit 1 euro de plus que le cadet. Z3 resout en **arithmetique rationnelle exacte** (fractions, pas de flottants) : `cadet = 9/4`, `aine = 9/2`, `benjamin = 13/4`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b121b827",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:43.109867Z",
+     "iopub.status.busy": "2026-07-07T04:08:43.109643Z",
+     "iopub.status.idle": "2026-07-07T04:08:43.243581Z",
+     "shell.execute_reply": "2026-07-07T04:08:43.243375Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Partage de 10 euros : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Aine     : 9/2 euros\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cadet    : 9/4 euros\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Benjamin : 13/4 euros\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var ctx4 = new Context();\n",
+    "var aine = ctx4.MkRealConst(\"aine\");\n",
+    "var cadet = ctx4.MkRealConst(\"cadet\");\n",
+    "var benjamin = ctx4.MkRealConst(\"benjamin\");\n",
+    "var s = ctx4.MkSolver();\n",
+    "s.Add(ctx4.MkEq(ctx4.MkAdd(aine, cadet, benjamin), ctx4.MkReal(10)));\n",
+    "s.Add(ctx4.MkEq(aine, ctx4.MkMul(ctx4.MkReal(2), cadet)));\n",
+    "s.Add(ctx4.MkEq(benjamin, ctx4.MkAdd(cadet, ctx4.MkReal(1))));\n",
+    "Console.WriteLine(\"Partage de 10 euros : \" + s.Check());\n",
+    "var m = s.Model;\n",
+    "Console.WriteLine(\"  Aine     : \" + m.Evaluate(aine) + \" euros\");\n",
+    "Console.WriteLine(\"  Cadet    : \" + m.Evaluate(cadet) + \" euros\");\n",
+    "Console.WriteLine(\"  Benjamin : \" + m.Evaluate(benjamin) + \" euros\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11857d25",
+   "metadata": {},
+   "source": [
+    "## 5. Mini sac a dos : maximiser la valeur sous contrainte de poids\n",
+    "\n",
+    "Trois objets A (valeur 4, poids 2), B (valeur 5, poids 3), C (valeur 7, poids 5). Capacite maximale 10 kg. On veut **maximiser la valeur** transportee. Z3 fournit un `Optimize` qui accepte un objectif `MkMaximize`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9f94ae52",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:43.245325Z",
+     "iopub.status.busy": "2026-07-07T04:08:43.244927Z",
+     "iopub.status.idle": "2026-07-07T04:08:43.351851Z",
+     "shell.execute_reply": "2026-07-07T04:08:43.351633Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimisation : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution optimale :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Objet A (v=4, p=2) : 5 unites\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Objet B (v=5, p=3) : 0 unites\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Objet C (v=7, p=5) : 0 unites\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Poids total : 10 / 10 kg\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Valeur totale : 20\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var ctx5 = new Context();\n",
+    "var n_a = ctx5.MkIntConst(\"n_a\");\n",
+    "var n_b = ctx5.MkIntConst(\"n_b\");\n",
+    "var n_c = ctx5.MkIntConst(\"n_c\");\n",
+    "var opt = ctx5.MkOptimize();\n",
+    "opt.Add(ctx5.MkGe(n_a, ctx5.MkInt(0)));\n",
+    "opt.Add(ctx5.MkGe(n_b, ctx5.MkInt(0)));\n",
+    "opt.Add(ctx5.MkGe(n_c, ctx5.MkInt(0)));\n",
+    "opt.Add(ctx5.MkLe(ctx5.MkAdd(ctx5.MkMul(ctx5.MkInt(2), n_a), ctx5.MkMul(ctx5.MkInt(3), n_b), ctx5.MkMul(ctx5.MkInt(5), n_c)), ctx5.MkInt(10)));\n",
+    "var valeur = ctx5.MkAdd(ctx5.MkMul(ctx5.MkInt(4), n_a), ctx5.MkMul(ctx5.MkInt(5), n_b), ctx5.MkMul(ctx5.MkInt(7), n_c));\n",
+    "opt.MkMaximize(valeur);\n",
+    "Console.WriteLine(\"Optimisation : \" + opt.Check());\n",
+    "var m = opt.Model;\n",
+    "long na = ((IntNum)m.Evaluate(n_a)).Int64;\n",
+    "long nb = ((IntNum)m.Evaluate(n_b)).Int64;\n",
+    "long nc = ((IntNum)m.Evaluate(n_c)).Int64;\n",
+    "Console.WriteLine(\"Solution optimale :\");\n",
+    "Console.WriteLine(\"  Objet A (v=4, p=2) : \" + na + \" unites\");\n",
+    "Console.WriteLine(\"  Objet B (v=5, p=3) : \" + nb + \" unites\");\n",
+    "Console.WriteLine(\"  Objet C (v=7, p=5) : \" + nc + \" unites\");\n",
+    "Console.WriteLine(\"  Poids total : \" + (2*na + 3*nb + 5*nc) + \" / 10 kg\");\n",
+    "Console.WriteLine(\"  Valeur totale : \" + (4*na + 5*nb + 7*nc));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60204dc0",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices a completer. Les stubs retournent `null` : a vous d'implementer la resolution avec Z3. **Objectif pedagogique** : manipuler `Solver`, `Optimize`, `Check`, `Model`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "73984b08",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:43.353265Z",
+     "iopub.status.busy": "2026-07-07T04:08:43.353026Z",
+     "iopub.status.idle": "2026-07-07T04:08:43.448630Z",
+     "shell.execute_reply": "2026-07-07T04:08:43.448467Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Triplet pythagoricien : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 : Trouver un triplet pythagoricien avec Z3.\n",
+    "// Retourne (a, b, c) tel que a^2 + b^2 = c^2, avec a < b < c <= borneMax.\n",
+    "// Indice : creez un Solver, des variables Int, ajoutez les contraintes, puis Check() et Model.\n",
+    "// Etape 1 : declarer les variables a, b, c\n",
+    "// Etape 2 : ajouter a*a + b*b == c*c et les bornes a < b < c <= borneMax\n",
+    "// Etape 3 : extraire le modele et retourner (a, b, c)\n",
+    "(long A, long B, long C)? TrouverTripletPythagoricien(int borneMax = 20)\n",
+    "{\n",
+    "    // TODO etudiant : implementez la resolution avec un Solver Z3\n",
+    "    return null;  // TODO etudiant : remplacer par le triplet trouve\n",
+    "}\n",
+    "\n",
+    "var triplet = TrouverTripletPythagoricien(20);\n",
+    "Console.WriteLine(\"Triplet pythagoricien : \" + (triplet.HasValue ? triplet.ToString() : \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "965f98f0",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:43.449924Z",
+     "iopub.status.busy": "2026-07-07T04:08:43.449687Z",
+     "iopub.status.idle": "2026-07-07T04:08:43.511332Z",
+     "shell.execute_reply": "2026-07-07T04:08:43.511127Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Planning optimal : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 : Ordonnancer deux taches sans chevauchement.\n",
+    "// Planifier T1 (3h) et T2 (2h) sans chevauchement, T2 finissant au plus tot.\n",
+    "// Indice : utilisez Optimize avec debut_T1 >= 0, debut_T2 >= 0.\n",
+    "// Etape 1 : declarer debut_T1, debut_T2\n",
+    "// Etape 2 : contrainte debut_T2 >= debut_T1 + 3 (pas de chevauchement, T1 avant)\n",
+    "// Etape 3 : minimiser debut_T2 + 2 (fin de T2)\n",
+    "(long DebutT1, long DebutT2)? OrdonnancerTaches()\n",
+    "{\n",
+    "    // TODO etudiant : implementez l ordonnancement optimal avec Optimize\n",
+    "    return null;  // TODO etudiant : remplacer par (debut_T1, debut_T2)\n",
+    "}\n",
+    "\n",
+    "var planning = OrdonnancerTaches();\n",
+    "Console.WriteLine(\"Planning optimal : \" + (planning.HasValue ? planning.ToString() : \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b9192031",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:08:43.512712Z",
+     "iopub.status.busy": "2026-07-07T04:08:43.512475Z",
+     "iopub.status.idle": "2026-07-07T04:08:43.552417Z",
+     "shell.execute_reply": "2026-07-07T04:08:43.552205Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Allocation optimale : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 3 : Maximiser le profit de production sous contrainte de machine.\n",
+    "// Produits P et Q. p >= 2, q >= 2, 2*p + 4*q <= 20. Maximiser 30*p + 50*q.\n",
+    "// Indice : utilisez Optimize, declarez p et q (Int), ajoutez les contraintes, maximizez.\n",
+    "// Etape 1 : declarer p, q (Int)\n",
+    "// Etape 2 : ajouter les contraintes de production\n",
+    "// Etape 3 : MkMaximize(30*p + 50*q) et extraire le modele\n",
+    "(long P, long Q, long Profit)? AllocationOptimale()\n",
+    "{\n",
+    "    // TODO etudiant : implementez l allocation optimale avec Optimize\n",
+    "    return null;  // TODO etudiant : remplacer par (p, q, profit)\n",
+    "}\n",
+    "\n",
+    "var res = AllocationOptimale();\n",
+    "Console.WriteLine(\"Allocation optimale : \" + (res.HasValue ? res.ToString() : \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea555e2c",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# couvre les memes concepts que la version Python : **Satisfiabilite** (`Solver`, `Check`, `Model`), **noyau d'insatisfiabilite** (`AssertAndTrack`, `UnsatCore`), **logique booleenne** (`BoolConst`, `MkNot`, `MkAnd`), **arithmetique rationnelle exacte** (`Real`, fractions), et **optimisation** (`Optimize`, `MkMaximize`).\n",
+    "\n",
+    "Le binding `Microsoft.Z3` expose exactement le meme moteur Z3 que `z3-solver` (Python) : les resultats sont identiques, seuls l'API et le langage changent. C'est l'illustration qu'un solveur SMT SOTA est utilisable de facon native en .NET.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": "csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Ce que fait cette PR

Twin C# .NET de `Z3-Python-01-Introduction.ipynb` (marathon parité .NET/Python #4956). Nouveau notebook `Z3-Python-01-Introduction-Csharp.ipynb` dans le même dossier que l'original Python.

## Prong A — vrai moteur SOTA (EPIC #3801)

Utilise le **vrai moteur Microsoft.Z3** (NuGet `Microsoft.Z3`, version **Z3 4.12.2.0**) — le binding .NET officiel du même solveur Z3 que `z3-solver` (Python). **Aucune ré-implémentation jouet** : les contraintes sont résolues par le moteur SOTA réel. Verdict: **SOTA-OK**.

## Couverture pédagogique (parité Python)

| Section | Concept Z3 | Résultat (re-dérivé firsthand) |
|---------|-----------|-------------------------------|
| 1. Contraintes linéaires | `Solver`/`Check`/`Model`, `Int` | x=9, y=1 (x+y=10, x>0, y>0, x>y) ✓ |
| 2. Insatisfiabilité | `AssertAndTrack`/`UnsatCore` | UNSATISFIABLE, noyau [c1, c2] ✓ |
| 3. Le menteur | `Bool`, `MkNot`, `MkAnd` | B dit la vérité (A=F, B=T, C=F) ✓ |
| 4. Rationnel exact | `Real`, fractions | cadet=9/4, aine=9/2, benjamin=13/4 ✓ |
| 5. Sac à dos | `Optimize`/`MkMaximize` | a=5, valeur=20 (optimal) ✓ |
| 6-8. Exercices | 3 stubs (C.1) | triplet pythagoricien, scheduling, profit |

## Validation (EXEC_PROVED)

- `validate_pr_notebooks.py` : **1/1 PASS** (9 cellules code)
- 9/9 `execution_count` contigus (1-9), **0 error**, **0 path-leak**
- **0 warning CS**, **0 error CS**
- C.1 conforme : **0** `throw new NotImplementedException` ; stubs `return null` + `// TODO etudiant`
- Microsoft.Z3 NuGet + `using Microsoft.Z3` confirmés dans le source

## §E README

- `Z3-Python/README.md` : +1 ligne (table Vue d'ensemble, twin `01ᶜˢ`)
- CATALOG byte-identique (non touché, règle catalog-pr-hygiene R1)
- Nouveau notebook dans le même dossier que l'original (convention marathon, cf `Sudoku-12-Z3-Csharp`, `SW-*-Csharp`)

See #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
