### PR TITLE
feat(planners): Planners-6-Domains-Csharp — twin C# STRIPS planner from-scratch (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
@@ -1,0 +1,1338 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "eb3d4ef2",
+   "metadata": {},
+   "source": [
+    "# Planners-6-Domains-Csharp — Jumeau C# : planificateur STRIPS from-scratch\n",
+    "\n",
+    "> **Jumeau C# (.NET 9)** de [`Planners-6-Domains`](Planners-6-Domains.ipynb). Le notebook Python invoque le vrai moteur `unified-planning` (solveur `pyperplan`) pour résoudre des domaines PDDL classiques. **Ce jumeau prend le parti inverse (Prong B du marathon #4956)** : plutôt que d'appeler un solveur, on **reconstruit un planificateur STRIPS from-scratch** en C# pur (BCL .NET 9, zéro NuGet), puis on l'exécute sur les mêmes domaines canoniques (Block World, Tours de Hanoï, Gripper). L'objectif pédagogique est de rendre **visible la mécanique interne** que `pyperplan` cache : représentation de l'état, recherche avant (forward search), application des effets add/delete.\n",
+    "\n",
+    "**Source Python** : [`Planners-6-Domains.ipynb`](Planners-6-Domains.ipynb) — domaines PDDL + `unified-planning.shortcuts.OneshotPlanner(name='pyperplan')`.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Modéliser** un domaine STRIPS en C# : atomes, préconditions, effets (add/delete lists)\n",
+    "2. **Implémenter** un planificateur par **recherche avant** (BFS sur l'espace d'états) avec détection de cycles\n",
+    "3. **Reproduire** les domaines classiques (Block World, Hanoï, Gripper) et comparer les plans obtenus\n",
+    "4. **Mesurer** le coût de la recherche (nœuds explorés, longueur du plan) pour comprendre les enjeux d'explosion combinatoire\n",
+    "\n",
+    "### Prérequis\n",
+    "\n",
+    "- Concepts STRIPS (préconditions, effets) — voir [`Planners-2-PDDL-Basics`](Planners-2-PDDL-Basics.ipynb)\n",
+    "- Recherche en espace d'états (BFS) — voir [`Planners-3-State-Space`](Planners-3-State-Space.ipynb)\n",
+    "- .NET 9 + kernel `csharp` (kernel `.net-csharp`)\n",
+    "\n",
+    "### Durée estimée : 45 minutes\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    A[\"Modèle STRIPS<br/>(Atom, Action, State)\"] --> B[\"Planificateur BFS<br/>forward search\"]\n",
+    "    B --> C[\"Block World<br/>tour + reverse\"]\n",
+    "    B --> D[\"Tours de Hanoï<br/>3 disques\"]\n",
+    "    B --> E[\"Gripper<br/>2 balles, 2 pinces\"]\n",
+    "    C --> F[\"Analyse<br/>longueur / nœuds\"]\n",
+    "    D --> F\n",
+    "    E --> F\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7df45571",
+   "metadata": {},
+   "source": [
+    "## 1. Modèle STRIPS en C# pur\n",
+    "\n",
+    "Un état STRIPS est un **ensemble d'atomes booléens grounded** (ex. `on(a,b)`, `clear(a)`, `handempty`). Une **action** a un nom, des paramètres (déjà instanciés ici), une **précondition** (ensemble d'atomes qui doivent tous être vrais) et un **effet** décomposé en listes `add` / `del` (ce que l'action rend vrai / faux).\n",
+    "\n",
+    "On représente chaque atome par une simple chaîne normalisée — pas de parsing PDDL, on reste au plus près de la sémantique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "49d2a216",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:08.588420Z",
+     "iopub.status.busy": "2026-07-07T04:18:08.583403Z",
+     "iopub.status.idle": "2026-07-07T04:18:10.742801Z",
+     "shell.execute_reply": "2026-07-07T04:18:10.738602Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1668848.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modèle STRIPS chargé : Atom, Action (pre/add/del), State (immuable).\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(14,39): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(28,51): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(29,38): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(29,71): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(59,29): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(61,39): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// Modèle STRIPS from-scratch (BCL .NET 9, 0 NuGet)\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// Un atome grounded : \"on(a,b)\", \"clear(c)\", \"handempty\", \"at(b1,roomA)\".\n",
+    "// Représenté par une chaîne normalisée (trim + lower des args).\n",
+    "public readonly struct Atom : IEquatable<Atom>\n",
+    "{\n",
+    "    public readonly string Text;\n",
+    "    public Atom(string text) { Text = text.Trim(); }\n",
+    "    public bool Equals(Atom other) => Text == other.Text;\n",
+    "    public override bool Equals(object? o) => o is Atom a && Equals(a);\n",
+    "    public override int GetHashCode() => Text.GetHashCode();\n",
+    "    public override string ToString() => Text;\n",
+    "    public static bool operator ==(Atom a, Atom b) => a.Equals(b);\n",
+    "    public static bool operator !=(Atom a, Atom b) => !a.Equals(b);\n",
+    "}\n",
+    "\n",
+    "// Une action STRIPS grounded : précondition (conjonction d'atomes) + effet add/del.\n",
+    "public sealed class Action\n",
+    "{\n",
+    "    public string Name { get; }\n",
+    "    public HashSet<Atom> Pre { get; }\n",
+    "    public HashSet<Atom> Add { get; }\n",
+    "    public HashSet<Atom> Del { get; }\n",
+    "    public Action(string name, IEnumerable<string>? pre = null,\n",
+    "                  IEnumerable<string>? add = null, IEnumerable<string>? del = null)\n",
+    "    {\n",
+    "        Name = name;\n",
+    "        Pre = (pre ?? Array.Empty<string>()).Select(s => new Atom(s)).ToHashSet();\n",
+    "        Add = (add ?? Array.Empty<string>()).Select(s => new Atom(s)).ToHashSet();\n",
+    "        Del = (del ?? Array.Empty<string>()).Select(s => new Atom(s)).ToHashSet();\n",
+    "    }\n",
+    "    public override string ToString() => Name;\n",
+    "}\n",
+    "\n",
+    "// État : ensemble d'atomes. Immuable par copie à chaque transition.\n",
+    "public sealed class State : IEquatable<State>\n",
+    "{\n",
+    "    public HashSet<Atom> Facts { get; }\n",
+    "    public State(IEnumerable<string> facts) { Facts = facts.Select(s => new Atom(s)).ToHashSet(); }\n",
+    "    public State(HashSet<Atom> facts) { Facts = facts; }\n",
+    "    public bool Contains(Atom a) => Facts.Contains(a);\n",
+    "    public State Clone() => new State(new HashSet<Atom>(Facts));\n",
+    "\n",
+    "    // Une action est applicable ssi toutes ses préconditions sont satisfaites.\n",
+    "    public bool CanApply(Action a) => a.Pre.All(p => Facts.Contains(p));\n",
+    "\n",
+    "    // Appliquer : on retire Del puis on ajoute Add (ordre add-after-del, convention STRIPS).\n",
+    "    public State Apply(Action a)\n",
+    "    {\n",
+    "        var next = Clone();\n",
+    "        foreach (var d in a.Del) next.Facts.Remove(d);\n",
+    "        foreach (var x in a.Add) next.Facts.Add(x);\n",
+    "        return next;\n",
+    "    }\n",
+    "    public bool Equals(State? other) =>\n",
+    "        other is not null && Facts.SetEquals(other.Facts);\n",
+    "    public override bool Equals(object? o) => o is State s && Equals(s);\n",
+    "    public override int GetHashCode()\n",
+    "    {\n",
+    "        // Ordre-indépendant : XOR des hashes des atomes (suffisant pour BFS small-state).\n",
+    "        int h = 0;\n",
+    "        foreach (var a in Facts) h ^= a.GetHashCode();\n",
+    "        return h;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Modèle STRIPS chargé : Atom, Action (pre/add/del), State (immuable).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f7e534b",
+   "metadata": {},
+   "source": [
+    "## 2. Planificateur par recherche avant (BFS)\n",
+    "\n",
+    "Le moteur le plus simple : une **recherche en largeur** (BFS) dans l'espace d'états. À chaque nœud, on instancie toutes les actions applicables, on génère les états successeurs, et on garde la trace du chemin parcouru. La BFS garantit un plan **de longueur minimale** (en nombre d'actions) — c'est exactement ce que l'on veut pour Block World. Deux raffinements essentiels :\n",
+    "\n",
+    "- **Détection de cycles** : on mémorise les états déjà visités (via le hash ordre-indépendant) pour éviter de boucler.\n",
+    "- **Test de but** : le but est un ensemble d'atomes qui doivent **tous** être présents dans l'état courant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6e38d7ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:10.744887Z",
+     "iopub.status.busy": "2026-07-07T04:18:10.744697Z",
+     "iopub.status.idle": "2026-07-07T04:18:10.938740Z",
+     "shell.execute_reply": "2026-07-07T04:18:10.938299Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Planificateur BFS chargé : StripsPlanner.Solve (forward search + anti-cycle).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// Résultat d'une recherche : plan trouvé (séquence d'actions) + métriques.\n",
+    "public sealed class PlanResult\n",
+    "{\n",
+    "    public List<Action> Actions { get; set; } = new();\n",
+    "    public int NodesExpanded { get; set; }\n",
+    "    public int NodesGenerated { get; set; }\n",
+    "    public bool Solved { get; set; }\n",
+    "}\n",
+    "\n",
+    "public static class StripsPlanner\n",
+    "{\n",
+    "    // BFS forward-search. `goal` = atomes qui doivent tous être vrais à l'arrivée.\n",
+    "    public static PlanResult Solve(State init, List<Action> actions, HashSet<Atom> goal,\n",
+    "                                   int maxNodes = 200_000)\n",
+    "    {\n",
+    "        var result = new PlanResult();\n",
+    "\n",
+    "        // File de (état, chemin d'actions pour l'atteindre).\n",
+    "        var queue = new Queue<(State state, List<Action> path)>();\n",
+    "        queue.Enqueue((init, new List<Action>()));\n",
+    "\n",
+    "        var visited = new HashSet<State> { init };\n",
+    "\n",
+    "        while (queue.Count > 0)\n",
+    "        {\n",
+    "            var (cur, path) = queue.Dequeue();\n",
+    "            result.NodesExpanded++;\n",
+    "\n",
+    "            // Test de but : tous les atomes du but sont-ils présents ?\n",
+    "            if (goal.All(g => cur.Contains(g)))\n",
+    "            {\n",
+    "                result.Actions = path;\n",
+    "                result.Solved = true;\n",
+    "                return result;\n",
+    "            }\n",
+    "\n",
+    "            if (result.NodesExpanded > maxNodes)\n",
+    "                return result;  // explosion combinatoire — on abandonne proprement\n",
+    "\n",
+    "            // Successeurs : chaque action applicable produit un nouvel état.\n",
+    "            foreach (var a in actions)\n",
+    "            {\n",
+    "                if (!cur.CanApply(a)) continue;\n",
+    "                var next = cur.Apply(a);\n",
+    "                if (visited.Contains(next)) continue;   // anti-cycle\n",
+    "                visited.Add(next);\n",
+    "                var newPath = new List<Action>(path) { a };\n",
+    "                queue.Enqueue((next, newPath));\n",
+    "                result.NodesGenerated++;\n",
+    "            }\n",
+    "        }\n",
+    "        return result;  // Solved = false : but injoignable\n",
+    "    }\n",
+    "\n",
+    "    // Affiche un plan + métriques (BFS = plan minimal en nb d'actions).\n",
+    "    public static void PrintPlan(PlanResult r)\n",
+    "    {\n",
+    "        if (!r.Solved)\n",
+    "        {\n",
+    "            Console.WriteLine(\"AUCUN PLAN TROUVÉ (but injoignable ou explosion combinatoire).\");\n",
+    "            Console.WriteLine($\"  Nœuds explorés : {r.NodesExpanded}\");\n",
+    "            return;\n",
+    "        }\n",
+    "        Console.WriteLine($\"Solution trouvée ! Longueur du plan : {r.Actions.Count} action(s)\");\n",
+    "        Console.WriteLine(new string('=', 50));\n",
+    "        for (int i = 0; i < r.Actions.Count; i++)\n",
+    "            Console.WriteLine($\"  {i+1}. {r.Actions[i]}\");\n",
+    "        Console.WriteLine(new string('=', 50));\n",
+    "        Console.WriteLine($\"Nœuds explorés (expanded) : {r.NodesExpanded}\");\n",
+    "        Console.WriteLine($\"Nœuds générés (generated) : {r.NodesGenerated}\");\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Planificateur BFS chargé : StripsPlanner.Solve (forward search + anti-cycle).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "543ceee5",
+   "metadata": {},
+   "source": [
+    "## 3. Block World — construire une tour (c ← b ← a)\n",
+    "\n",
+    "On reprend **exactement** le problème `blocks-tower` du notebook Python : trois blocs `a, b, c` posés sur la table, bras vide ; but `on(a,b)` et `on(b,c)` (tour `c` portant `b` portant `a`). Les actions STRIPS sont les classiques `pick-up`, `put-down`, `stack`, `unstack`.\n",
+    "\n",
+    "Le moteur `pyperplan` (Python) trouve un plan en **4 actions**. Vérifions que notre BFS from-scratch retrouve la même longueur minimale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e8bd2be0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:10.940220Z",
+     "iopub.status.busy": "2026-07-07T04:18:10.940016Z",
+     "iopub.status.idle": "2026-07-07T04:18:11.074384Z",
+     "shell.execute_reply": "2026-07-07T04:18:11.074061Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problème 'blocks-tower' : construire la tour c <- b <- a\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "État initial : a, b, c sur la table\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution trouvée ! Longueur du plan : 4 action(s)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1. pick-up(b)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2. stack(b,c)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3. pick-up(a)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4. stack(a,b)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nœuds explorés (expanded) : 20\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nœuds générés (generated) : 21\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// --- Domaine Block World : actions grounded pour 3 blocs a, b, c ---\n",
+    "// Une fois instanciées, les actions sont des opérateurs concrets ; le planificateur\n",
+    "// les essaie toutes à chaque nœud (forward search).\n",
+    "\n",
+    "var blocksActions = new List<Action>();\n",
+    "\n",
+    "// pick-up(x) : prendre un bloc sur la table. Pre: clear(x), ontable(x), handempty.\n",
+    "foreach (var x in new[] { \"a\", \"b\", \"c\" })\n",
+    "{\n",
+    "    blocksActions.Add(new Action($\"pick-up({x})\",\n",
+    "        pre: new[] { $\"clear({x})\", $\"ontable({x})\", \"handempty\" },\n",
+    "        add: new[] { $\"holding({x})\" },\n",
+    "        del: new[] { $\"clear({x})\", $\"ontable({x})\", \"handempty\" }));\n",
+    "\n",
+    "    // put-down(x) : poser le bloc tenu sur la table.\n",
+    "    blocksActions.Add(new Action($\"put-down({x})\",\n",
+    "        pre: new[] { $\"holding({x})\" },\n",
+    "        add: new[] { $\"ontable({x})\", $\"clear({x})\", \"handempty\" },\n",
+    "        del: new[] { $\"holding({x})\" }));\n",
+    "\n",
+    "    // stack(x, y) : poser x sur y (y doit être clear).\n",
+    "    foreach (var y in new[] { \"a\", \"b\", \"c\" })\n",
+    "        if (x != y)\n",
+    "            blocksActions.Add(new Action($\"stack({x},{y})\",\n",
+    "                pre: new[] { $\"holding({x})\", $\"clear({y})\" },\n",
+    "                add: new[] { $\"on({x},{y})\", $\"clear({x})\", \"handempty\" },\n",
+    "                del: new[] { $\"holding({x})\", $\"clear({y})\" }));\n",
+    "\n",
+    "    // unstack(x, y) : prendre x qui est sur y.\n",
+    "    foreach (var y in new[] { \"a\", \"b\", \"c\" })\n",
+    "        if (x != y)\n",
+    "            blocksActions.Add(new Action($\"unstack({x},{y})\",\n",
+    "                pre: new[] { $\"on({x},{y})\", $\"clear({x})\", \"handempty\" },\n",
+    "                add: new[] { $\"holding({x})\", $\"clear({y})\" },\n",
+    "                del: new[] { $\"on({x},{y})\", $\"clear({x})\", \"handempty\" }));\n",
+    "}\n",
+    "\n",
+    "// État initial : a, b, c sur la table, tous clear, bras vide.\n",
+    "var bwInit = new State(new[] { \"ontable(a)\", \"ontable(b)\", \"ontable(c)\",\n",
+    "                                \"clear(a)\", \"clear(b)\", \"clear(c)\", \"handempty\" });\n",
+    "\n",
+    "// But : tour c <- b <- a  (a sur b, b sur c).\n",
+    "var bwGoal = new HashSet<Atom> { new(\"on(a,b)\"), new(\"on(b,c)\") };\n",
+    "\n",
+    "Console.WriteLine(\"Problème 'blocks-tower' : construire la tour c <- b <- a\");\n",
+    "Console.WriteLine(\"État initial : a, b, c sur la table\\n\");\n",
+    "var bwTower = StripsPlanner.Solve(bwInit, blocksActions, bwGoal);\n",
+    "StripsPlanner.PrintPlan(bwTower);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f501f8dc",
+   "metadata": {},
+   "source": [
+    "### 3.1 Inverser deux tours (problème `blocks-reverse`)\n",
+    "\n",
+    "Le second problème du notebook Python : deux tours initiales `table <- c <- d` et `table <- a <- b`, à inverser en `table <- d <- c` et `table <- b <- a`. On étend le domaine à 4 blocs. La BFS reste exacte (plan minimal), mais le nombre de nœuds explorés explose — c'est l'**explosion combinatoire** que le notebook Python mentionne en §5.2, rendue ici tangible par notre compteur `NodesExpanded`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c3d348e5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:11.076180Z",
+     "iopub.status.busy": "2026-07-07T04:18:11.075921Z",
+     "iopub.status.idle": "2026-07-07T04:18:11.195296Z",
+     "shell.execute_reply": "2026-07-07T04:18:11.194715Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problème 'blocks-reverse' : inverser deux tours (4 blocs)\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution trouvée ! Longueur du plan : 8 action(s)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1. unstack(b,a)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2. put-down(b)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3. pick-up(a)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4. stack(a,b)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  5. unstack(d,c)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  6. put-down(d)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  7. pick-up(c)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  8. stack(c,d)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nœuds explorés (expanded) : 85\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nœuds générés (generated) : 105\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// --- Block World étendu à 4 blocs a, b, c, d ---\n",
+    "var all4 = new[] { \"a\", \"b\", \"c\", \"d\" };\n",
+    "var blocksActions4 = new List<Action>();\n",
+    "foreach (var x in all4)\n",
+    "{\n",
+    "    blocksActions4.Add(new Action($\"pick-up({x})\",\n",
+    "        pre: new[] { $\"clear({x})\", $\"ontable({x})\", \"handempty\" },\n",
+    "        add: new[] { $\"holding({x})\" },\n",
+    "        del: new[] { $\"clear({x})\", $\"ontable({x})\", \"handempty\" }));\n",
+    "    blocksActions4.Add(new Action($\"put-down({x})\",\n",
+    "        pre: new[] { $\"holding({x})\" },\n",
+    "        add: new[] { $\"ontable({x})\", $\"clear({x})\", \"handempty\" },\n",
+    "        del: new[] { $\"holding({x})\" }));\n",
+    "    foreach (var y in all4)\n",
+    "        if (x != y)\n",
+    "        {\n",
+    "            blocksActions4.Add(new Action($\"stack({x},{y})\",\n",
+    "                pre: new[] { $\"holding({x})\", $\"clear({y})\" },\n",
+    "                add: new[] { $\"on({x},{y})\", $\"clear({x})\", \"handempty\" },\n",
+    "                del: new[] { $\"holding({x})\", $\"clear({y})\" }));\n",
+    "            blocksActions4.Add(new Action($\"unstack({x},{y})\",\n",
+    "                pre: new[] { $\"on({x},{y})\", $\"clear({x})\", \"handempty\" },\n",
+    "                add: new[] { $\"holding({x})\", $\"clear({y})\" },\n",
+    "                del: new[] { $\"on({x},{y})\", $\"clear({x})\", \"handempty\" }));\n",
+    "        }\n",
+    "}\n",
+    "\n",
+    "// État initial : table <- c <- d  ET  table <- a <- b.\n",
+    "var bw4Init = new State(new[] {\n",
+    "    \"ontable(c)\", \"on(d,c)\", \"clear(d)\",\n",
+    "    \"ontable(a)\", \"on(b,a)\", \"clear(b)\", \"handempty\" });\n",
+    "\n",
+    "// But : inverser -> table <- d <- c  ET  table <- b <- a.\n",
+    "var bw4Goal = new HashSet<Atom> {\n",
+    "    new(\"ontable(d)\"), new(\"on(c,d)\"),\n",
+    "    new(\"ontable(b)\"), new(\"on(a,b)\") };\n",
+    "\n",
+    "Console.WriteLine(\"Problème 'blocks-reverse' : inverser deux tours (4 blocs)\\n\");\n",
+    "var bwReverse = StripsPlanner.Solve(bw4Init, blocksActions4, bw4Goal);\n",
+    "StripsPlanner.PrintPlan(bwReverse);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16cebaac",
+   "metadata": {},
+   "source": [
+    "## 4. Tours de Hanoï (domaine `hanoi`)\n",
+    "\n",
+    "Le problème le plus célèbre de planification classique. Trois disques `d1 < d2 < d3` (du plus petit au plus grand), trois piquets `p1, p2, p3`. État initial : tous sur `p1` (`d3` en bas). But : tous sur `p3`. La règle STRIPS encode « un disque ne peut être posé que sur un disque plus grand ou sur un piquet vide ».\n",
+    "\n",
+    "La solution optimale en 3 disques fait **7 coups** (formule $2^n - 1$). Notons qu'en STRIPS pur, il faut **modéliser la contrainte de taille** explicitement — ici via le prédicat `clear` (rien au-dessus) et en n'autorisant `disk-on(X,Y)` que pour `Y` plus grand que `X` (les actions grounded sont générées uniquement pour les paires licites)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ff622eae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:11.197120Z",
+     "iopub.status.busy": "2026-07-07T04:18:11.196870Z",
+     "iopub.status.idle": "2026-07-07T04:18:11.385312Z",
+     "shell.execute_reply": "2026-07-07T04:18:11.385030Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tours de Hanoï : 3 disques de p1 vers p3\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution trouvée ! Longueur du plan : 7 action(s)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1. move(d1,d2->p3)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2. move(d2,d3->p2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3. move(d1,p3->d2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4. move(d3,p1->p3)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  5. move(d1,d2->p1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  6. move(d2,p2->d3)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  7. move(d1,p1->d2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nœuds explorés (expanded) : 25\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nœuds générés (generated) : 26\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Théorie : 2^3 - 1 = 7 coups optimaux attendus.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// --- Tours de Hanoï : 3 disques, 3 piquets ---\n",
+    "// Convention : d1 < d2 < d3 (d3 = plus grand). Un disque ne va que sur un plus grand.\n",
+    "var pegs = new[] { \"p1\", \"p2\", \"p3\" };\n",
+    "var disks = new[] { \"d1\", \"d2\", \"d3\" };   // d1 = petit, d3 = grand\n",
+    "int Rank(string d) => Array.IndexOf(disks, d);\n",
+    "\n",
+    "var hanoiActions = new List<Action>();\n",
+    "// move(x, from, to) : déplacer le disque x (au sommet de `from`) vers `to`.\n",
+    "// `from` parcourt piquets ET disques (un disque peut reposer sur un disque).\n",
+    "// CONTRAINTE DE TAILLE : on ne génère l'action que pour `to` licite (piquet OU disque\n",
+    "// plus grand que x). C'est ce qui empêche de poser un grand disque sur un petit.\n",
+    "var allSupports = pegs.Concat(disks).ToList();\n",
+    "foreach (var x in disks)\n",
+    "    foreach (var from in allSupports)\n",
+    "    {\n",
+    "        var legalDests = new List<string>(pegs);\n",
+    "        foreach (var y in disks)\n",
+    "            if (Rank(y) > Rank(x)) legalDests.Add(y);   // y plus grand -> x peut aller dessus\n",
+    "        foreach (var to in legalDests)\n",
+    "            if (from != to)\n",
+    "                hanoiActions.Add(new Action($\"move({x},{from}->{to})\",\n",
+    "                    pre: new[] { $\"on({x},{from})\", $\"clear({x})\", $\"clear({to})\" },\n",
+    "                    add: new[] { $\"on({x},{to})\", $\"clear({from})\" },\n",
+    "                    del: new[] { $\"on({x},{from})\", $\"clear({to})\" }));\n",
+    "    }\n",
+    "\n",
+    "// État initial : d3 sur p1, d2 sur d3, d1 sur d2 (d1 au sommet, clear).\n",
+    "var hanoiInit = new State(new[] {\n",
+    "    \"on(d3,p1)\", \"on(d2,d3)\", \"on(d1,d2)\", \"clear(d1)\",\n",
+    "    \"clear(p2)\", \"clear(p3)\" });\n",
+    "// But : tout sur p3 (d3 en bas, d2 au milieu, d1 au sommet).\n",
+    "var hanoiGoal = new HashSet<Atom> {\n",
+    "    new(\"on(d3,p3)\"), new(\"on(d2,d3)\"), new(\"on(d1,d2)\") };\n",
+    "\n",
+    "Console.WriteLine(\"Tours de Hanoï : 3 disques de p1 vers p3\\n\");\n",
+    "var hanoi = StripsPlanner.Solve(hanoiInit, hanoiActions, hanoiGoal);\n",
+    "StripsPlanner.PrintPlan(hanoi);\n",
+    "Console.WriteLine($\"\\nThéorie : 2^3 - 1 = {Math.Pow(2,3)-1} coups optimaux attendus.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6d76b25",
+   "metadata": {},
+   "source": [
+    "### Interprétation : Hanoï et l'explosion combinatoire\n",
+    "\n",
+    "La formule $2^n - 1$ donne la longueur du plan optimal, mais le **coût de la recherche** est bien pire. Notre BFS explore tous les états intermédiaires atteignables ; pour Hanoï à $n$ disques, l'espace d'états compte $3^n$ configurations légales. À $n = 3$, c'est trivial (27 états) ; à $n = 10$, on dépasse **59 000 états** — et un solveur PDDL comme `pyperplan` s'appuie justement sur des **heuristiques** (relaxation delete-free) pour ne pas tout explorer. C'est toute la différence entre notre BFS pédagogique (exact mais naïf) et un moteur de production : le nôtre *montre* la mécanique, `pyperplan` *l'optimise*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9962c1a5",
+   "metadata": {},
+   "source": [
+    "## 5. Domaine Gripper (robot à deux pinces)\n",
+    "\n",
+    "Le domaine `gripper` du notebook Python : un robot dans une pièce, doté de deux pinces (`g1`, `g2`), doit déplacer des balles d'une pièce (`roomA`) à l'autre (`roomB`). Trois actions : `move`, `pick`, `drop`. L'intérêt pédagogique est la **parallélisation potentielle** : avec deux pinces, le robot peut porter deux balles d'un coup, ce qui réduit le nombre de `move` (coûteux). Notre BFS retrouve le plan minimal — et on voit directement l'arbitrage *nombre de moves* vs *nombre de picks/drops*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "df4ee378",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:11.387164Z",
+     "iopub.status.busy": "2026-07-07T04:18:11.386890Z",
+     "iopub.status.idle": "2026-07-07T04:18:11.494308Z",
+     "shell.execute_reply": "2026-07-07T04:18:11.493971Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gripper : transporter 2 balles de roomA vers roomB (2 pinces)\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution trouvée ! Longueur du plan : 5 action(s)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1. pick(b1,roomA,g1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2. pick(b2,roomA,g2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3. move(roomA->roomB)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4. drop(b1,roomB,g1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  5. drop(b2,roomB,g2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nœuds explorés (expanded) : 25\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nœuds générés (generated) : 26\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// --- Domaine Gripper : 2 balles, 2 pinces, 2 pièces ---\n",
+    "var rooms = new[] { \"roomA\", \"roomB\" };\n",
+    "var balls = new[] { \"b1\", \"b2\" };\n",
+    "var grippers = new[] { \"g1\", \"g2\" };\n",
+    "\n",
+    "var gripperActions = new List<Action>();\n",
+    "// move(from, to) : déplacer le robot.\n",
+    "foreach (var from in rooms)\n",
+    "    foreach (var to in rooms)\n",
+    "        if (from != to)\n",
+    "            gripperActions.Add(new Action($\"move({from}->{to})\",\n",
+    "                pre: new[] { $\"at-robby({from})\" },\n",
+    "                add: new[] { $\"at-robby({to})\" },\n",
+    "                del: new[] { $\"at-robby({from})\" }));\n",
+    "\n",
+    "// pick(ball, room, gripper) / drop(ball, room, gripper).\n",
+    "foreach (var b in balls)\n",
+    "    foreach (var r in rooms)\n",
+    "        foreach (var g in grippers)\n",
+    "        {\n",
+    "            gripperActions.Add(new Action($\"pick({b},{r},{g})\",\n",
+    "                pre: new[] { $\"at({b},{r})\", $\"at-robby({r})\", $\"free({g})\" },\n",
+    "                add: new[] { $\"carry({b},{g})\" },\n",
+    "                del: new[] { $\"at({b},{r})\", $\"free({g})\" }));\n",
+    "            gripperActions.Add(new Action($\"drop({b},{r},{g})\",\n",
+    "                pre: new[] { $\"carry({b},{g})\", $\"at-robby({r})\" },\n",
+    "                add: new[] { $\"at({b},{r})\", $\"free({g})\" },\n",
+    "                del: new[] { $\"carry({b},{g})\" }));\n",
+    "        }\n",
+    "\n",
+    "// État initial : robot + balles en roomA, deux pinces libres.\n",
+    "var gripInit = new State(new[] {\n",
+    "    \"at-robby(roomA)\", \"at(b1,roomA)\", \"at(b2,roomA)\", \"free(g1)\", \"free(g2)\" });\n",
+    "// But : les deux balles en roomB.\n",
+    "var gripGoal = new HashSet<Atom> { new(\"at(b1,roomB)\"), new(\"at(b2,roomB)\") };\n",
+    "\n",
+    "Console.WriteLine(\"Gripper : transporter 2 balles de roomA vers roomB (2 pinces)\\n\");\n",
+    "var grip = StripsPlanner.Solve(gripInit, gripperActions, gripGoal);\n",
+    "StripsPlanner.PrintPlan(grip);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dcb0307",
+   "metadata": {},
+   "source": [
+    "## 6. Analyse comparative des domaines\n",
+    "\n",
+    "On récapitule les quatre problèmes résolus par notre BFS from-scratch. Deux métriques : **longueur du plan** (optimale en BFS) et **nœuds explorés** (le coût réel de la recherche). C'est ce second chiffre qui révèle l'enjeu : Block World à 4 blocs et Hanoï à 3 disques sont petits, mais la croissance est exponentielle — d'où le besoin, dans un solveur industriel, d'heuristiques."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d81d2045",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:11.496003Z",
+     "iopub.status.busy": "2026-07-07T04:18:11.495778Z",
+     "iopub.status.idle": "2026-07-07T04:18:11.583030Z",
+     "shell.execute_reply": "2026-07-07T04:18:11.582426Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Domaine                            Plan   Nœuds explorés     Statut\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block World (tour 3 blocs)            4               20     RÉSOLU\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block World (reverse, 4 blocs)        8               85     RÉSOLU\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tours de Hanoï (3 disques)            7               25     RÉSOLU\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gripper (2 balles, 2 pinces)          5               25     RÉSOLU\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lecture : le plan est optimal (BFS), mais 'Nœuds explorés' croît\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exponentiellement avec la taille du domaine — d'où les heuristiques de pyperplan.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// --- Tableau récapitulatif des 4 plans ---\n",
+    "var results = new (string Domain, int PlanLen, int Expanded, bool Solved)[]\n",
+    "{\n",
+    "    (\"Block World (tour 3 blocs)\", bwTower.Actions.Count, bwTower.NodesExpanded, bwTower.Solved),\n",
+    "    (\"Block World (reverse, 4 blocs)\", bwReverse.Actions.Count, bwReverse.NodesExpanded, bwReverse.Solved),\n",
+    "    (\"Tours de Hanoï (3 disques)\", hanoi.Actions.Count, hanoi.NodesExpanded, hanoi.Solved),\n",
+    "    (\"Gripper (2 balles, 2 pinces)\", grip.Actions.Count, grip.NodesExpanded, grip.Solved),\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine($\"{\"Domaine\",-32} {\"Plan\",6} {\"Nœuds explorés\",16} {\"Statut\",10}\");\n",
+    "Console.WriteLine(new string('-', 66));\n",
+    "foreach (var r in results)\n",
+    "    Console.WriteLine($\"{r.Domain,-32} {r.PlanLen,6} {r.Expanded,16} {(r.Solved ? \"RÉSOLU\" : \"ÉCHEC\"),10}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Lecture : le plan est optimal (BFS), mais 'Nœuds explorés' croît\");\n",
+    "Console.WriteLine(\"exponentiellement avec la taille du domaine — d'où les heuristiques de pyperplan.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6c1fad4",
+   "metadata": {},
+   "source": [
+    "### Comparaison avec le moteur `pyperplan` (notebook Python)\n",
+    "\n",
+    "| Domaine | Plan BFS from-scratch (C#) | Plan `pyperplan` (Python) | Statut |\n",
+    "|---------|----------------------------|---------------------------|--------|\n",
+    "| Block World tour (3 blocs) | minimal (BFS) | 4 actions (rapporté) | Concordant |\n",
+    "| Block World reverse (4 blocs) | minimal (BFS) | — | — |\n",
+    "| Tours de Hanoï (3 disques) | $2^3-1 = 7$ | idem (classique) | Concordant |\n",
+    "| Gripper (2 balles) | minimal (BFS) | — | — |\n",
+    "\n",
+    "Les longueurs concordent parce que **BFS garantit l'optimalité en nombre d'actions**. La différence est ailleurs : `pyperplan` explore **bien moins de nœuds** grâce à sa relaxation heuristique (il estime la distance au but sans les effets `del`), tandis que notre BFS naïf paie le coût intégral de l'explosion combinatoire. C'est précisément la leçon du notebook Python §5.2 : la modélisation déclare *le problème*, l'heuristique fait *toute la différence de performance*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41cf44e6",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices pour aller plus loin. Chacun est laissé en **stub** — votre travail est de compléter le code. Les exercices s'exécutent sans erreur même non complétés (convention C.1 : stub sans `throw`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1ffabe27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:11.584986Z",
+     "iopub.status.busy": "2026-07-07T04:18:11.584742Z",
+     "iopub.status.idle": "2026-07-07T04:18:11.657795Z",
+     "shell.execute_reply": "2026-07-07T04:18:11.657219Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 (Tirelire) — à compléter par l'étudiant.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// Exercice 1 : ajouter un domaine — \"Tirelire\" (deposit, withdraw).\n",
+    "// Objectif : modéliser un compteur d'argent. Prédicat balance(N) pour N dans {0..5}.\n",
+    "// Actions : deposit (balance(N) -> balance(N+1)), withdraw (balance(N) -> balance(N-1)).\n",
+    "// But : passer de balance(0) à balance(3).\n",
+    "// Indice : générez les actions dans une boucle pour chaque N licite (0..4 pour deposit).\n",
+    "// Étape 1 : créer la liste d'actions.\n",
+    "// Étape 2 : définir l'état initial et le but.\n",
+    "// Étape 3 : appeler StripsPlanner.Solve et afficher.\n",
+    "\n",
+    "// TODO étudiant : compléter ci-dessous.\n",
+    "var piggyActions = new List<Action>();   // à remplir\n",
+    "var piggyInit = new State(Array.Empty<string>());   // à remplir : balance(0)\n",
+    "var piggyGoal = new HashSet<Atom>();   // à remplir : balance(3)\n",
+    "\n",
+    "var piggy = StripsPlanner.Solve(piggyInit, piggyActions, piggyGoal);\n",
+    "Console.WriteLine(\"Exercice 1 (Tirelire) — à compléter par l'étudiant.\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6f712688",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:11.659396Z",
+     "iopub.status.busy": "2026-07-07T04:18:11.659169Z",
+     "iopub.status.idle": "2026-07-07T04:18:11.697011Z",
+     "shell.execute_reply": "2026-07-07T04:18:11.696732Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 (Hanoï 4 disques) — à compléter par l'étudiant.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// Exercice 2 : mesurer l'explosion combinatoire sur Hanoï.\n",
+    "// Objectif : ajouter un 4e disque (d4, plus grand que d3) et mesurer NodesExpanded.\n",
+    "// Indice : la solution optimale fait 2^4 - 1 = 15 coups ; comptez les nœuds explorés.\n",
+    "// Question d'analyse : par quel facteur NodesExpanded augmente-t-il vs 3 disques ?\n",
+    "// Étape 1 : étendre la liste `disks` à d1..d4 et régénérer hanoiActions.\n",
+    "// Étape 2 : reconstruire l'état initial (d4 en bas de p1) et le but.\n",
+    "// Étape 3 : Solve + PrintPlan, noter NodesExpanded.\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 2 (Hanoï 4 disques) — à compléter par l'étudiant.\");\n",
+    "// TODO étudiant : dupliquer le bloc Hanoï ci-dessus avec disks = { d1, d2, d3, d4 }.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "89e6805a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:18:11.698822Z",
+     "iopub.status.busy": "2026-07-07T04:18:11.698542Z",
+     "iopub.status.idle": "2026-07-07T04:18:11.741143Z",
+     "shell.execute_reply": "2026-07-07T04:18:11.740634Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 (A* avec heuristique naïve) — à compléter par l'étudiant.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// Exercice 3 : amélioration — remplacer BFS par A* avec une heuristique.\n",
+    "// Objectif : ajouter une heuristique \"nombre d'atomes du but non satisfaits\"\n",
+    "// (heuristique naïve, non admissible mais informative) et passer à une priority queue.\n",
+    "// Indice : Priority Queue existe en BCL (System.Collections.Generic.PriorityQueue<T, double>).\n",
+    "// Étape 1 : écrire une fonction h(State) = nb d'atomes du goal absents.\n",
+    "// Étape 2 : remplacer la Queue par une PriorityQueue<(State, path), double>, clé = path.Count + h(state).\n",
+    "// Étape 3 : comparer NodesExpanded (BFS vs A* naïf) sur Block World reverse.\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 3 (A* avec heuristique naïve) — à compléter par l'étudiant.\");\n",
+    "// TODO étudiant : implémenter StripsPlanner.AStar et comparer.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "480198e4",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce jumeau C# reconstruit **à la main** ce que `unified-planning` (notebook Python) délègue à un solveur externe. Les deux approches sont **complémentaires** et servent des apprentissages différents :\n",
+    "\n",
+    "- **Le notebook Python** apprend à **modéliser** en PDDL et à appeler un moteur industriel — compétence pratique (on ne réécrit pas un solveur en production).\n",
+    "- **Ce jumeau C#** apprend **comment fonctionne** un planificateur : représentation d'état, recherche avant, application d'effets, explosion combinatoire. C'est la mécanique interne rendue visible.\n",
+    "\n",
+    "### Ce que vous avez appris\n",
+    "\n",
+    "1. Un **état STRIPS** est un ensemble d'atomes ; une **action** est précondition + effets add/del.\n",
+    "2. La **recherche avant (BFS)** garantit un plan minimal mais paie l'explosion combinatoire.\n",
+    "3. Les **heuristiques** (relaxation delete-free chez `pyperplan`) sont ce qui rend la planification tractable sur de vrais domaines — notre BFS naïf atteint vite ses limites.\n",
+    "4. Les **domaines classiques** (Block World, Hanoï, Gripper) partagent la même structure (préconditions/effectes) mais exposent des défis de modélisation distincts (taille relative, parallélisme).\n",
+    "\n",
+    "### Prochaines étapes\n",
+    "\n",
+    "- [`Planners-7-OR-Tools`](Planners-7-OR-Tools.ipynb) : bascule vers la **programmation par contraintes** (CP-SAT) pour l'ordonnancement — un autre paradigme de planification.\n",
+    "- [`Planners-8-Temporal`](../03-Advanced/Planners-8-Temporal.ipynb) : planification temporelle (PDDL 2.1, actions duratives).\n",
+    "- Pour la version \"moteur réel\", revenir au notebook Python [`Planners-6-Domains`](Planners-6-Domains.ipynb) et son appel à `OneshotPlanner(name='pyperplan')`.\n",
+    "\n",
+    "## Ressources\n",
+    "\n",
+    "- Fikes, R. E., & Nilsson, N. J. (1971) — « STRIPS: A New Approach to the Application of Theorem Proving to Problem Solving », *Artificial Intelligence* 2(3-4). Le formalisme original (préconditions + add/delete lists).\n",
+    "- Russell, S., & Norvig, P. — *Artificial Intelligence: A Modern Approach* (4e éd., 2021), ch. « Planning and Acting in the Real World ». Recherche avant, heuristiques de relaxation.\n",
+    "- Bonet, B., & Geffner, H. (2001) — « Planning as heuristic search », *Artificial Intelligence* 129(1-2). Les heuristiques delete-free qui font le cœur de `pyperplan`/`Fast Downward`.\n",
+    "\n",
+    "## Navigation\n",
+    "\n",
+    "[← Planners (parent)](../README.md) | [Planners-6 Python](Planners-6-Domains.ipynb) | [Planners-7 →](Planners-7-OR-Tools.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -126,7 +126,8 @@ SymbolicAI/Planners/
 │   ├── Planners-5-Heuristics.ipynb      # h-add, h-max, h-FF
 │   ├── Planners-5-Heuristics-Csharp.ipynb # Twin C# h-max/h-add/h-FF/landmarks (See #4956)
 │   ├── Planners-5b-Lean-Relaxation.ipynb # Companion Lean 4 : preuve h+ <= h*
-│   └── Planners-6-Domains.ipynb         # Domaines classiques
+│   ├── Planners-6-Domains.ipynb         # Domaines classiques
+│   └── Planners-6-Domains-Csharp.ipynb  # Twin C# STRIPS from-scratch (BFS, Block World/Hanoi/Gripper) (See #4956)
 ├── 03-Advanced/
 │   ├── Planners-7-OR-Tools.ipynb        # CP-SAT
 │   ├── Planners-8-Temporal.ipynb        # Planification temporelle
@@ -220,6 +221,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 5 (C#) | [Planners-5-Heuristics-Csharp](02-Classical/Planners-5-Heuristics-Csharp.ipynb) | .NET (C#) | Twin C# du 5 : h-max/h-add/h-FF/landmarks from-scratch, démo non-admissibilité h^add (See #4956) | 40 min |
 | 5b | [Planners-5b-Lean-Relaxation](02-Classical/Planners-5b-Lean-Relaxation.ipynb) | Lean 4 | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de l'admissibilité de la relaxation (h⁺ ≤ h\*) dans le lake `planning_lean`, `#check` + `#print axioms` in-kernel (cf [#4053](https://github.com/jsboige/CoursIA/issues/4053) création du lake / PR #4168, companion natif) | 45 min |
 | 6 | [Planners-6-Domains](02-Classical/Planners-6-Domains.ipynb) | Python | Blocks World, Logistics, Gripper, Ferry, Hanoi | 50 min |
+| 6 (C#) | [Planners-6-Domains-Csharp](02-Classical/Planners-6-Domains-Csharp.ipynb) | .NET (C#) | Twin C# du 6 : planificateur STRIPS from-scratch (modèle Atom/Action/State, BFS forward + anti-cycle), domaines Block World + Hanoï + Gripper (See #4956) | 45 min |
 
 ### Partie 3 : Approches Avancées ([03-Advanced/](03-Advanced/README.md))
 


### PR DESCRIPTION
## Résumé

Jumeau C# (.NET 9, BCL pur, 0 NuGet) de [`Planners-6-Domains`](../blob/feature/planners6-domains-csharp/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains.ipynb) — **Prong B du marathon #4956** (parité .NET ⇄ Python).

Là où le notebook Python invoque le vrai moteur `unified-planning` (solveur `pyperplan`), ce jumeau **reconstruit un planificateur STRIPS from-scratch** en C# pur : modèle `Atom` / `Action` (préconditions + effets add/del) / `State` (immuable), recherche avant **BFS** avec détection de cycles. Objectif pédagogique : rendre **visible la mécanique interne** que `pyperplan` cache.

## Domaines résolus (plans OPTIMAUX — BFS = minimal en nb d'actions)

| Domaine | Plan | Nœuds explorés | Référence |
|---------|------|----------------|-----------|
| Block World tour (3 blocs) | **4** | 20 | Concordant (pyperplan rapporte 4) |
| Block World reverse (4 blocs) | **8** | 85 | — |
| Tours de Hanoï (3 disques) | **7** | 25 | $2^3-1$ (théorie), concordant |
| Gripper (2 balles, 2 pinces) | **5** | 25 | — |

Les longueurs concordent car BFS garantit l'optimalité en nombre d'actions. La différence avec `pyperplan` est ailleurs : le moteur industriel explore **bien moins de nœuds** grâce à sa relaxation heuristique (delete-free), tandis que le BFS naïf paie l'explosion combinatoire — c'est précisément la leçon §5.2 du notebook Python, rendue tangible par le compteur `NodesExpanded`.

## Validation (H.1 EXEC_PROVED)

```
nbconvert --execute --kernel .net-csharp  →  Writing 52642 bytes (SUCCESS, 0 error CS)
VÉRDICT forensique : code=10 ec_none=0 errors=0 C.1=0 leaks=0  →  EXEC_PROVED
```

- 3 exercices stub (convention C.1 : stub sans `throw`, exécutable end-to-end)
- 0 emoji, FR-first (prose pédagogique)

## §E / catalog-pr-hygiene

- README parent `Planners/README.md` : +1 ligne arborescence + 1 ligne table (twin 6 C#)
- **CATALOG-STATUS marker byte-identique** à `origin/main` (cron-only regen respecté)
- Diff two-dot propre : uniquement les 2 inserts twin (+ glyphe `└→├` pour Planners-6-Domains devenu non-terminal)

## Note (hors scope)

`Planners-1-Introduction-Csharp.ipynb` existe sur disque mais n'est pas listé dans l'arborescence/table du README parent — écart préexendant, **non traité ici** (un sujet par PR).

See #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
