### PR TITLE
fix(smt): correct Sudoku givens counts in Z3-Python-02 comments (Python + C# twin)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-02-Sudoku-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-02-Sudoku-Csharp.ipynb
@@ -226,7 +226,7 @@
     }
    ],
    "source": [
-    "// Puzzle facile : 35 indices donnes.\n",
+    "// Puzzle facile : 30 indices donnes.\n",
     "int[][] puzzle_facile = new int[][] {\n",
     "    new int[] {5, 3, 0, 0, 7, 0, 0, 0, 0},\n",
     "    new int[] {6, 0, 0, 1, 9, 5, 0, 0, 0},\n",
@@ -239,7 +239,7 @@
     "    new int[] {0, 0, 0, 0, 8, 0, 0, 7, 9},\n",
     "};\n",
     "\n",
-    "// Puzzle intermediaire : 30 indices donnes.\n",
+    "// Puzzle intermediaire : 36 indices donnes.\n",
     "int[][] puzzle_intermediaire = new int[][] {\n",
     "    new int[] {0, 0, 0, 2, 6, 0, 7, 0, 1},\n",
     "    new int[] {6, 8, 0, 0, 7, 0, 0, 9, 0},\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-02-Sudoku.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-02-Sudoku.ipynb
@@ -126,7 +126,7 @@
    ],
    "source": [
     "# Deux grilles de Sudoku (0 = case vide).\n",
-    "# Puzzle facile : 35 indices donnes.\n",
+    "# Puzzle facile : 30 indices donnes.\n",
     "puzzle_facile = [\n",
     "    [5, 3, 0, 0, 7, 0, 0, 0, 0],\n",
     "    [6, 0, 0, 1, 9, 5, 0, 0, 0],\n",
@@ -139,7 +139,7 @@
     "    [0, 0, 0, 0, 8, 0, 0, 7, 9],\n",
     "]\n",
     "\n",
-    "# Puzzle intermediaire : 30 indices donnes.\n",
+    "# Puzzle intermediaire : 36 indices donnes.\n",
     "puzzle_intermediaire = [\n",
     "    [0, 0, 0, 2, 6, 0, 7, 0, 1],\n",
     "    [6, 8, 0, 0, 7, 0, 0, 9, 0],\n",


### PR DESCRIPTION
## Ce que fait cette PR

Corrige un **bug pédagogique partagé** (Python + twin C#) : les commentaires inline des puzzles Sudoku indiquaient des comptes d'indices faux, contredisant les outputs runtime.

## Le bug

| Fichier | Commentaire (avant) | Output runtime réel | Vrai compte |
|---------|--------------------|--------------------------------------|
| `Z3-Python-02-Sudoku.ipynb` (Python) | `# Puzzle facile : 35 indices` | `Puzzle facile : 30 indices` | **30** |
| `Z3-Python-02-Sudoku.ipynb` (Python) | `# Puzzle intermediaire : 30 indices` | `Puzzle intermediaire : 36 indices` | **36** |
| `Z3-Python-02-Sudoku-Csharp.ipynb` (twin) | `// Puzzle facile : 35 indices` | `Puzzle facile : 30 indices` | **30** |
| `Z3-Python-02-Sudoku-Csharp.ipynb` (twin) | `// Puzzle intermediaire : 30 indices` | `Puzzle intermediaire : 36 indices` | **36** |

Un étudiant qui lit le code voyait `// 35 indices` mais la sortie affichait `30` → commentaire contredisant l'exécution = bug pédagogique (trompeur).

## Vérification ground-truth (firsthand)

Recomptage indépendant des cellules non-nulles (`!= 0`) dans chaque grille :
- `puzzle_facile` (grille Wikipedia canonique) : **30** givens
- `puzzle_intermediaire` : **36** givens

Les outputs runtime (`CompterIndices`) affichaient **déjà** les bons comptes (30/36) — seuls les commentaires étaient faux.

## Fix

Comment-only : `35 → 30` (facile), `30 → 36` (intermediaire), dans les 2 notebooks.

- **Outputs inchangés** (affichaient déjà 30/36 corrects) — pas de re-exécution nécessaire (C.3 surgical : les modifications comment-only n'affectent pas l'exécution, les outputs existants restent des témoins valides).
- Diff minimal byte-precise : **4 insertions / 4 deletions**, LF préservé, EOF convention per-file respectée, 0 churn output/metadata.
- `validate_pr_notebooks.py` : **2/2 PASS** (14 cellules).
- CATALOG byte-identique.

## Contexte

Soulevé par po-2024 review `cmt-4900118725` sur #5605 (finding COMMENTED non-bloquant : « commentaires code stale, la sortie imprime les vrais comptes 30/36, markdown correct, peut se faire en follow-up »). Ce twin C# a porté les commentaires stale du Python original → bug partagé cross-language, corrigé ici dans les 2 fichiers.

See #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
