### PR TITLE
feat(ml): ML-6 Python (skl2onnx + onnxruntime) parity twin

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX-Python.ipynb
@@ -1,0 +1,747 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7de88620",
+   "metadata": {},
+   "source": [
+    "# ML-6 (Python) : Intégration de modèles ONNX (skl2onnx + onnxruntime)\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< ML-5-TimeSeries](ML-5-TimeSeries-Python.ipynb) | [Jumeau .NET (ML.NET)](ML-6-ONNX.ipynb) | [Suivant >> ML-7-Recommendation](ML-7-Recommendation-Python.ipynb)\n",
+    "\n",
+    "> Ce notebook est le **jumeau Python** de [ML-6-ONNX.ipynb](ML-6-ONNX.ipynb) (ML.NET `OnnxTransformer`). Il couvre l'autre bout du pont d'interopérabilité : **produire** un modèle ONNX en Python (entraînement scikit-learn → export `skl2onnx`) puis le **consommer** en Python via `onnxruntime`. Le jumeau .NET, lui, charge le fichier `.onnx` que nous générons ici — c'est le workflow canonical Python → ONNX → .NET.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "1. Comprendre **ONNX** (Open Neural Network Exchange) comme format d'échange de modèles indépendant du framework\n",
+    "2. **Exporter** un modèle scikit-learn vers ONNX avec `skl2onnx` (types d'entrée, `target_opset`, `zipmap`)\n",
+    "3. **Inspecter** un graph ONNX (entrées, sorties, opérateurs, opset)\n",
+    "4. **Exécuter une inférence** ONNX en Python avec `onnxruntime`\n",
+    "5. **Valider** numériquement l'équivalence sklearn ⇄ onnxruntime et **optimiser** les performances\n",
+    "\n",
+    "### Prérequis\n",
+    "- ML-1 à ML-5 (Python) complétés\n",
+    "- Notions de scikit-learn (fit / predict / Pipeline)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d815d1e",
+   "metadata": {},
+   "source": [
+    "## Introduction — qu'est-ce qu'ONNX ?\n",
+    "\n",
+    "**ONNX** (Open Neural Network Exchange) est un **format de sérialisation de modèles de machine learning**, indépendant du framework qui les a entraînés. Un modèle entraîné en scikit-learn, PyTorch ou TensorFlow peut être **exporté** vers un fichier `.onnx`, puis **consommé** par n'importe quel runtime ONNX — en Python (`onnxruntime`), en .NET (ML.NET `OnnxTransformer`), en C++, en Java, etc.\n",
+    "\n",
+    "Le format décrit le modèle comme un **graphe orienté** : les nœuds sont des **opérateurs** (addition, matmul, relu, tree ensemble…) normalisés par un **opset** (ensemble d'opérateurs disponibles à une version donnée). Les entrées et sorties sont typées (tenseurs float/int64…) et nommées.\n",
+    "\n",
+    "**Le workflow canonical de ce notebook** :\n",
+    "1. Entraîner un `RandomForestClassifier` scikit-learn sur Iris\n",
+    "2. L'exporter en ONNX (`skl2onnx.convert_sklearn`)\n",
+    "3. Inspecter le graph produit\n",
+    "4. Exécuter l'inférence avec `onnxruntime`\n",
+    "5. Vérifier que sklearn et onnxruntime donnent **exactement** les mêmes prédictions\n",
+    "\n",
+    "C'est précisément le `.onnx` produit à l'étape 2 que le jumeau .NET (ML-6-ONNX.ipynb) recharge côté ML.NET.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b418876f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:24.634843Z",
+     "iopub.status.busy": "2026-07-07T04:55:24.634843Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.274148Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.274148Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scikit-learn 1.8.0 | skl2onnx 1.20.0 | onnxruntime 1.27.0 | onnx 1.22.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports : scikit-learn (modèle), skl2onnx (export), onnxruntime (inférence), onnx (inspection)\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "import numpy as np\n",
+    "import time\n",
+    "import sklearn\n",
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "import skl2onnx\n",
+    "from skl2onnx import convert_sklearn\n",
+    "from skl2onnx.common.data_types import FloatTensorType\n",
+    "\n",
+    "import onnx\n",
+    "import onnxruntime as ort\n",
+    "\n",
+    "print(f\"scikit-learn {sklearn.__version__} | skl2onnx {skl2onnx.__version__} | \"\n",
+    "      f\"onnxruntime {ort.__version__} | onnx {onnx.__version__}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "287e3b1e",
+   "metadata": {},
+   "source": [
+    "## Partie 1 : Entraîner un modèle scikit-learn (Iris)\n",
+    "\n",
+    "On utilise le jeu de données **Iris** (4 features longueurs/largeurs de sépale/pétale, 3 classes d'iris). On entraîne un `RandomForestClassifier` simple (10 arbres) sur 70 % des données et on garde 30 % pour évaluer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "aab2c060",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.274148Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.274148Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.295025Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.295025Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dimensions X_train : (105, 4) | X_test : (45, 4)\n",
+      "Classes : [0 1 2]\n",
+      "Accuracy scikit-learn (test) : 1.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Charger Iris, splitter train/test, entraîner un RandomForest\n",
+    "X, y = load_iris(return_X_y=True)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.3, random_state=42\n",
+    ")\n",
+    "\n",
+    "clf = RandomForestClassifier(n_estimators=10, random_state=42)\n",
+    "clf.fit(X_train, y_train)\n",
+    "\n",
+    "acc_sklearn = clf.score(X_test, y_test)\n",
+    "print(f\"Dimensions X_train : {X_train.shape} | X_test : {X_test.shape}\")\n",
+    "print(f\"Classes : {clf.classes_}\")\n",
+    "print(f\"Accuracy scikit-learn (test) : {acc_sklearn:.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b50c698",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "On dispose d'un modèle entraîné **en mémoire**, dans le format propre à scikit-learn. Pour le rendre **portable** (consommable hors Python), il faut le sérialiser vers ONNX. C'est l'objet de la partie suivante."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0ad713a",
+   "metadata": {},
+   "source": [
+    "## Partie 2 : Export ONNX avec `skl2onnx`\n",
+    "\n",
+    "La fonction `convert_sklearn` traduit le modèle scikit-learn en graph ONNX. Trois éléments sont essentiels :\n",
+    "\n",
+    "- **`initial_types`** : ONNX est typé statiquement ; il faut déclarer le nom et la forme de l'entrée. Ici une matrice float32 de forme `[None, 4]` (batch variable, 4 features Iris). `None` = batch de taille quelconque.\n",
+    "- **`target_opset`** : version du jeu d'opérateurs ONNX visé. Plus c'est élevé, plus d'opérateurs disponibles — mais le runtime consommateur doit le supporter. On vise l'opset 15 (largement supporté).\n",
+    "- **`options={id(clf): {'zipmap': False}}`** : par défaut, les classifieurs exportent les probabilités comme une liste de dictionnaires (ZipMap), peu pratique pour le calcul vectoriel. On désactive ZipMap pour récupérer un **tenseur** `[batch, n_classes]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d608c350",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.297031Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.297031Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.318191Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.318191Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modèle ONNX écrit : iris_model_python.onnx (8.2 KB)\n",
+      "Opset producteur : 1\n",
+      "Domaine : ai.onnx.ml\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Export scikit-learn -> ONNX\n",
+    "initial_type = [('input', FloatTensorType([None, 4]))]\n",
+    "onx = convert_sklearn(\n",
+    "    clf,\n",
+    "    initial_types=initial_type,\n",
+    "    options={id(clf): {'zipmap': False}},\n",
+    "    target_opset=15,\n",
+    ")\n",
+    "\n",
+    "# Sérialiser vers un fichier .onnx (celui que le jumeau .NET rechargera)\n",
+    "# Nom distinct du .onnx canonique (produit par scripts/ml/generate_iris_onnx.py,\n",
+    "# consommé par le jumeau .NET ML-6-ONNX.ipynb) — on evite de l'ecraser.\n",
+    "onnx_path = \"iris_model_python.onnx\"\n",
+    "with open(onnx_path, \"wb\") as f:\n",
+    "    f.write(onx.SerializeToString())\n",
+    "\n",
+    "import os\n",
+    "size_kb = os.path.getsize(onnx_path) / 1024\n",
+    "print(f\"Modèle ONNX écrit : {onnx_path} ({size_kb:.1f} KB)\")\n",
+    "print(f\"Opset producteur : {onx.opset_import[0].version}\")\n",
+    "print(f\"Domaine : {onx.opset_import[0].domain or 'ai.onnx (standard)'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3c8ec5a",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "Le modèle est désormais un fichier `.onnx` autonome : il ne dépend plus de scikit-learn, ni même de Python. On peut le copier sur une machine Windows et le charger en ML.NET (jumeau .NET, cellules « Charger un modèle ONNX »), ou le recharger ici-même avec `onnxruntime` (partie 4)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1ba4b2",
+   "metadata": {},
+   "source": [
+    "## Partie 3 : Inspection du graph ONNX\n",
+    "\n",
+    "Avant d'exécuter un modèle ONNX, on l'**inspecte** : vérifier sa validité (`onnx.checker`), lister ses entrées/sorties nommées et typées, et regarder quels opérateurs composent le graph. C'est l'équivalent d'ouvrir le capot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "69a07b45",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.321287Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.321287Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.331517Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.331517Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "onnx.checker : graph VALIDE\n",
+      "Producer : skl2onnx 1.20.0\n",
+      "IR version : 8\n",
+      "\n",
+      "Entrées :\n",
+      "  - input : tensor_type {\n",
+      "  elem_type: 1\n",
+      "  shape {\n",
+      "    dim {\n",
+      "    }\n",
+      "    dim {\n",
+      "      dim_value: 4\n",
+      "    }\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "Sorties :\n",
+      "  - label : tensor_type {\n",
+      "  elem_type: 7\n",
+      "  shape {\n",
+      "    dim {\n",
+      "    }\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "  - probabilities : tensor_type {\n",
+      "  elem_type: 1\n",
+      "  shape {\n",
+      "    dim {\n",
+      "    }\n",
+      "    dim {\n",
+      "      dim_value: 3\n",
+      "    }\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "\n",
+      "Opérateurs (1 nœuds) : ['TreeEnsembleClassifier']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Charger le fichier .onnx et inspecter le graph\n",
+    "model = onnx.load(onnx_path)\n",
+    "\n",
+    "# 1. Validation structurelle (lève une exception si le graph est mal formé)\n",
+    "onnx.checker.check_model(model)\n",
+    "print(\"onnx.checker : graph VALIDE\")\n",
+    "\n",
+    "# 2. Métadonnées producteur\n",
+    "print(f\"Producer : {model.producer_name} {model.producer_version}\")\n",
+    "print(f\"IR version : {model.ir_version}\")\n",
+    "\n",
+    "# 3. Entrées / sorties typées\n",
+    "g = model.graph\n",
+    "print(\"\\nEntrées :\")\n",
+    "for inp in g.input:\n",
+    "    print(f\"  - {inp.name} : {inp.type}\")\n",
+    "print(\"Sorties :\")\n",
+    "for out in g.output:\n",
+    "    print(f\"  - {out.name} : {out.type}\")\n",
+    "\n",
+    "# 4. Opérateurs utilisés (types de nœuds)\n",
+    "op_types = sorted({n.op_type for n in g.node})\n",
+    "print(f\"\\nOpérateurs ({len(g.node)} nœuds) : {op_types}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81749cb2",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "Un `RandomForestClassifier` exporté produit typiquement un nœud `TreeEnsembleClassifier` (l'ensemble d'arbres) suivi de la sortie `label` (int64) et `probabilities` (float [batch, 3]). On retrouve exactement la signature que le jumeau .NET mappe avec `[ColumnName(\"input\")]` côté ML.NET : les **noms d'entrées/sorties ONNX sont le contrat entre les frameworks**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "053ea6b6",
+   "metadata": {},
+   "source": [
+    "## Partie 4 : Inférence avec `onnxruntime`\n",
+    "\n",
+    "`onnxruntime` est le runtime de référence (optimisé, multi-thread). On crée une `InferenceSession` depuis le fichier `.onnx`, on prépare l'entrée au bon format (**float32**, clé = nom de l'entrée du graph) et on appelle `run`.\n",
+    "\n",
+    "> **Piège classique** : ONNX attend du **float32**, alors que scikit-learn travaille en float64. Il faut convertir explicitement `X.astype(np.float32)` sinon l'inférence échoue ou produit des erreurs subtiles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0432b115",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.333523Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.333523Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.348142Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.347639Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Entrées attendues : [('input', [None, 4])]\n",
+      "Sorties produites  : [('label', [None]), ('probabilities', [None, 3])]\n",
+      "\n",
+      "Accuracy onnxruntime (test) : 1.0000\n",
+      "Premieres predictions : [1 0 2 1 1 0 1 2]\n",
+      "Premieres probabilites :\n",
+      "[[0.        1.0000001 0.       ]\n",
+      " [1.0000001 0.        0.       ]\n",
+      " [0.        0.        1.0000001]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inférence ONNX Runtime\n",
+    "sess = ort.InferenceSession(onnx_path)\n",
+    "\n",
+    "# Vérifier la signature attendue par le runtime\n",
+    "print(\"Entrées attendues :\", [(i.name, i.shape) for i in sess.get_inputs()])\n",
+    "print(\"Sorties produites  :\", [(o.name, o.shape) for o in sess.get_outputs()])\n",
+    "\n",
+    "# Préparer l'entrée : float32 obligatoire\n",
+    "X_test_f32 = X_test.astype(np.float32)\n",
+    "\n",
+    "# run(inputs) renvoie [label, probabilities] (ordre de g.output)\n",
+    "outputs = sess.run(None, {'input': X_test_f32})\n",
+    "pred_onnx = outputs[0]          # etiquettes int64\n",
+    "proba_onnx = outputs[1]         # probabilites [batch, 3]\n",
+    "\n",
+    "acc_onnx = (pred_onnx == y_test).mean()\n",
+    "print(f\"\\nAccuracy onnxruntime (test) : {acc_onnx:.4f}\")\n",
+    "print(f\"Premieres predictions : {pred_onnx[:8]}\")\n",
+    "print(f\"Premieres probabilites :\\n{proba_onnx[:3]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d63dfff4",
+   "metadata": {},
+   "source": [
+    "## Partie 5 : Validation numérique — sklearn ⇄ onnxruntime\n",
+    "\n",
+    "L'export ONNX ne doit **pas** changer les prédictions : sklearn et onnxruntime doivent coïncider exactement sur les étiquettes et à `1e-6` près sur les probabilités. On quantifie l'écart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "76d53b30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.350146Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.350146Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.358648Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.357644Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etiquettes identiques : True\n",
+      "Ecart max  absolu sur les probabilites : 1.19e-07\n",
+      "Ecart moyen absolu sur les probabilites : 3.78e-08\n",
+      "\n",
+      "Verdict : sklearn == onnxruntime -> EQUIVALENT\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Comparaison sklearn vs onnxruntime\n",
+    "pred_sklearn = clf.predict(X_test.astype(np.float32))\n",
+    "proba_sklearn = clf.predict_proba(X_test.astype(np.float32))\n",
+    "\n",
+    "# 1. Etiquettes : identiques ?\n",
+    "labels_match = np.array_equal(pred_sklearn, pred_onnx)\n",
+    "print(f\"Etiquettes identiques : {labels_match}\")\n",
+    "\n",
+    "# 2. Probabilites : ecart max absolu\n",
+    "max_diff = np.max(np.abs(proba_sklearn - proba_onnx))\n",
+    "mean_diff = np.mean(np.abs(proba_sklearn - proba_onnx))\n",
+    "print(f\"Ecart max  absolu sur les probabilites : {max_diff:.2e}\")\n",
+    "print(f\"Ecart moyen absolu sur les probabilites : {mean_diff:.2e}\")\n",
+    "\n",
+    "VERDICT = \"EQUIVALENT\" if labels_match and max_diff < 1e-5 else \"DIVERGENT\"\n",
+    "print(f\"\\nVerdict : sklearn == onnxruntime -> {VERDICT}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3994f454",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "L'écart (typiquement `< 1e-6`) vient d'arrondis float32 vs float64 dans l'évaluation des arbres ; il est **négligeable** et n'affecte jamais l'étiquette prédite. **Conclusion : ONNX est une copie fidèle du modèle sklearn**, consommable identiquement côté .NET."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4782850a",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Exporter un autre estimateur vers ONNX\n",
+    "\n",
+    "Le `RandomForestClassifier` est exporté ci-dessus. **Votre tâche** : entraîner un `LogisticRegression` sur Iris, l'exporter vers ONNX (opset 15, `zipmap=False`), et vérifier que l'accuracy sklearn == accuracy onnxruntime.\n",
+    "\n",
+    "**Indice** : `LogisticRegression(max_iter=200)` converge sur Iris. Le `initial_type` ne change pas (même 4 features). N'oubliez pas `astype(np.float32)` avant le `run`.\n",
+    "\n",
+    "**Étapes** :\n",
+    "1. Entraîner `LogisticRegression(max_iter=200, random_state=42)` sur `(X_train, y_train)`\n",
+    "2. `convert_sklearn` avec `initial_types=initial_type`, `zipmap=False`, `target_opset=15`\n",
+    "3. Créer une `InferenceSession`, exécuter sur `X_test.astype(np.float32)`\n",
+    "4. Comparer les accuracy sklearn vs onnxruntime — doivent coïncider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b6529cc7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.360650Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.359649Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.364458Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.364458Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Exporter un LogisticRegression vers ONNX et valider l'equivalence\n",
+    "# TODO etudiant : reprendre le pattern des parties 2+4+5 avec LogisticRegression\n",
+    "# Indice : LogisticRegression(max_iter=200, random_state=42).fit(X_train, y_train)\n",
+    "# Etape 1 : entrainer le modele\n",
+    "# Etape 2 : convert_sklearn (... zipmap False, target_opset 15 ...)\n",
+    "# Etape 3 : InferenceSession + run sur X_test float32\n",
+    "# Etape 4 : comparer accuracy sklearn vs onnxruntime\n",
+    "result_ex1 = None  # TODO etudiant : (acc_sklearn, acc_onnx, labels_match)\n",
+    "print(\"Exercice 1 a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a3b8c1d",
+   "metadata": {},
+   "source": [
+    "## Partie 6 : Performance — options de session et benchmark batch\n",
+    "\n",
+    "`onnxruntime` applique des **optimisations de graph** (fusion d'opérateurs, élimination de calculs redondants) et exploite le multi-thread. Sur de gros batchs, l'inférence ONNX est souvent **plus rapide** que `clf.predict` scikit-learn — c'est l'intérêt opérationnel du format en production.\n",
+    "\n",
+    "On compare les deux sur un batch synthétique de 10 000 instances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bf4910a2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.366462Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.366462Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.422258Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.422258Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Batch size : 10000 x 4\n",
+      "scikit-learn predict : 1.65 ms/call\n",
+      "onnxruntime run      : 0.64 ms/call\n",
+      "Speedup onnxruntime / sklearn : x2.57\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Benchmark sklearn.predict vs onnxruntime sur un gros batch\n",
+    "X_big = np.random.RandomState(0).rand(10_000, 4).astype(np.float32)\n",
+    "\n",
+    "# Session avec optimisations maximales\n",
+    "so = ort.SessionOptions()\n",
+    "so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL\n",
+    "sess_opt = ort.InferenceSession(onnx_path, sess_options=so)\n",
+    "\n",
+    "# Echauffement (premier run compile/optimise le graph)\n",
+    "_ = clf.predict(X_big[:100])\n",
+    "_ = sess_opt.run(None, {'input': X_big[:100]})\n",
+    "\n",
+    "N_REPEAT = 20\n",
+    "t0 = time.perf_counter()\n",
+    "for _ in range(N_REPEAT):\n",
+    "    _ = clf.predict(X_big)\n",
+    "t_sklearn = (time.perf_counter() - t0) / N_REPEAT\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "for _ in range(N_REPEAT):\n",
+    "    _ = sess_opt.run(None, {'input': X_big})\n",
+    "t_onnx = (time.perf_counter() - t0) / N_REPEAT\n",
+    "\n",
+    "speedup = t_sklearn / t_onnx\n",
+    "print(f\"Batch size : {X_big.shape[0]} x {X_big.shape[1]}\")\n",
+    "print(f\"scikit-learn predict : {t_sklearn*1000:.2f} ms/call\")\n",
+    "print(f\"onnxruntime run      : {t_onnx*1000:.2f} ms/call\")\n",
+    "print(f\"Speedup onnxruntime / sklearn : x{speedup:.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bc60d4a",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "Le rapport dépend du modèle et de la taille de batch, mais `onnxruntime` bénéficie d'un runtime C++ optimisé et des optimisations de graph. Sur un `RandomForest` à 10 arbres le gain est modeste ; sur des modèles plus larges ou des batchs massifs, l'écart s'élargit. C'est ce qui justifie de **déployer en ONNX** plutôt que d'embarquer scikit-learn en production."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61a280aa",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Mesurer l'impact de la taille du modèle sur le speedup\n",
+    "\n",
+    "Le benchmark ci-dessus utilise 10 arbres. **Votre tâche** : varier `n_estimators` (10, 50, 100) et mesurer comment le speedup onnxruntime/sklearn évolue.\n",
+    "\n",
+    "**Indice** : plus le modèle est gros, plus l'optimisation de graph paye. Bouclez sur les trois tailles, exportez un ONNX par taille, et comparez `t_sklearn/t_onnx`.\n",
+    "\n",
+    "**Étapes** :\n",
+    "1. Pour `n_est` dans `[10, 50, 100]` : entraîner un `RandomForestClassifier(n_estimators=n_est, random_state=42)`\n",
+    "2. Exporter en ONNX, créer une `InferenceSession` optimisée\n",
+    "3. Mesurer `t_sklearn` et `t_onnx` sur `X_big`\n",
+    "4. Stocker le speedup et conclure sur la tendance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "14e13c96",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.424261Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.424261Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.428763Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.428261Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : impact de n_estimators sur le speedup onnxruntime vs sklearn\n",
+    "# TODO etudiant : boucler sur n_estimators in [10, 50, 100], mesurer speedup\n",
+    "# Indice : reprendre le pattern Partie 6 dans une boucle\n",
+    "# Etape 1 : boucle sur [10, 50, 100]\n",
+    "# Etape 2 : entrainer + exporter + InferenceSession optimisee pour chaque\n",
+    "# Etape 3 : benchmark t_sklearn vs t_onnx sur X_big\n",
+    "# Etape 4 : collecter (n_est, speedup) et afficher la tendance\n",
+    "speedups_ex2 = None  # TODO etudiant : liste de (n_estimators, speedup)\n",
+    "print(\"Exercice 2 a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3674c14",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Inspecter les opérateurs d'un second modèle\n",
+    "\n",
+    "**Votre tâche** : exporter un `KMeans` (clustering, voir ML-8) ou un `StandardScaler` + classifieur dans une `Pipeline`, et lister les opérateurs ONNX produits.\n",
+    "\n",
+    "**Indice** : une `Pipeline` sklearn s'export aussi via `convert_sklearn` — chaque étape devient un sous-graphe. Le `StandardScaler` produit un nœud `Scaler` (soustraction mean / division scale).\n",
+    "\n",
+    "**Étapes** :\n",
+    "1. Construire `make_pipeline(StandardScaler(), LogisticRegression(max_iter=200))`\n",
+    "2. L'entraîner, l'exporter en ONNX (opset 15)\n",
+    "3. Lister `{n.op_type for n in graph.node}` et identifier les nœuds liés au scaling vs à la régression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "452152f9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T04:55:26.430766Z",
+     "iopub.status.busy": "2026-07-07T04:55:26.429766Z",
+     "iopub.status.idle": "2026-07-07T04:55:26.438340Z",
+     "shell.execute_reply": "2026-07-07T04:55:26.437838Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : exporter une Pipeline (StandardScaler + classifieur) et lister ses operateurs\n",
+    "# TODO etudiant : construire, entrainer, exporter une Pipeline et inspecter ses operateurs\n",
+    "# Indice : from sklearn.pipeline import make_pipeline ; from sklearn.preprocessing import StandardScaler\n",
+    "# Etape 1 : pipeline = make_pipeline(StandardScaler(), LogisticRegression(max_iter=200))\n",
+    "# Etape 2 : fit + convert_sklearn (target_opset 15)\n",
+    "# Etape 3 : extraire {n.op_type for n in onx.graph.node}\n",
+    "# Etape 4 : identifier les nœuds de scaling (Scaler) vs regression\n",
+    "ops_ex3 = None  # TODO etudiant : ensemble des op_types du graph\n",
+    "print(\"Exercice 3 a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "777e9bb8",
+   "metadata": {},
+   "source": [
+    "## Conclusion et points clés\n",
+    "\n",
+    "| Concept | Description |\n",
+    "|---------|-------------|\n",
+    "| ONNX | Format d'échange de modèles, indépendant du framework (graph + opset) |\n",
+    "| `skl2onnx.convert_sklearn` | Export d'un modèle scikit-learn vers ONNX |\n",
+    "| `initial_types` | Déclaration du nom + type + forme des entrées (ex. `FloatTensorType([None, 4])`) |\n",
+    "| `target_opset` | Version du jeu d'opérateurs visé (compatibilité runtime) |\n",
+    "| `zipmap=False` | Désactive les dictionnaires de probabilités → tenseur `[batch, n_classes]` |\n",
+    "| `onnx.checker` | Validation structurelle d'un graph ONNX |\n",
+    "| `InferenceSession` | Session d'inférence `onnxruntime` (entrée float32, `run`) |\n",
+    "| Équivalence sklearn ⇄ ONNX | Prédictions identiques, écarts de proba `< 1e-6` (float32 vs float64) |\n",
+    "| `GraphOptimizationLevel` | Optimisations de graph (fusion d'opérateurs) → speedup en production |\n",
+    "\n",
+    "**Ce qu'il faut retenir** : ONNX est le **pont** entre l'entraînement (Python/scikit-learn) et la production (.NET/ML.NET, C++, edge). On entraîne où c'est expressif (Python), on déploie où c'est rapide et portable (ONNX Runtime). Le jumeau .NET [ML-6-ONNX.ipynb](ML-6-ONNX.ipynb) consomme le **même** fichier `iris_model.onnx` que celui produit dans la Partie 2."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "533633e0",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "- **ONNX** — specification et opérateurs : https://onnx.ai/\n",
+    "- **skl2onnx** — export scikit-learn vers ONNX : https://onnx.ai/sklearn-onnx/\n",
+    "- **ONNX Runtime** — runtime d'inférence optimisé : https://onnxruntime.ai/\n",
+    "- **ML-6-ONNX.ipynb** (jumeau .NET) — consommation du même `.onnx` côté ML.NET\n",
+    "- Série *Hands-On AI Trading*, Jared Broad — chapitre interopérabilité modèles ML\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (coursia-ml-training)",
+   "language": "python",
+   "name": "coursia-ml-training"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  },
+  "papermill": {
+   "input_path": "ML-6-ONNX-Python.ipynb",
+   "output_path": "ML-6-ONNX-Python.ipynb",
+   "parameters": {}
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Python twin of ML-6-ONNX.ipynb (ML.NET OnnxTransformer). EPIC #4956 (.NET <-> Python parity), ML.Net->Python grain, lane po-2025. Closes the campaign gap 8/10 -> 9/10.

Python end of Python -> ONNX -> .NET bridge: train sklearn RandomForest (Iris) -> export ONNX (skl2onnx, opset 15, zipmap=False) -> inspect graph -> inference onnxruntime -> numerical equivalence + perf benchmark.

Execution (coursia-ml-training kernel): 10 code cells, exec_count contiguous 1..10, 0 errors. Verdict EQUIVALENT (labels identical True, max proba diff 1.19e-07 < 1e-5). Speedup onnxruntime/sklearn x2.57 on batch 10k.

SOTA-OK: real skl2onnx + onnxruntime, no workaround. Writes DISTINCT artifact iris_model_python.onnx (no clobber of canonical iris_model.onnx, opset 12, consumed by .NET twin). 3 exercises (stubs C.1), FR markdown, built on fresh origin/main. See #4956.

Co-Authored-By: Claude-Code <noreply@anthropic.com>