### PR TITLE
feat(smt): Z3-Python-04-Strings-Regex-Csharp — twin C# Microsoft.Z3 (string theory, regex)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -47,6 +47,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 | 03 | [Tactiques et théories](Z3-Python-03-Tactics.ipynb) | `Tactic`, `BitVec`, `Array` | ~35 min | PRODUCTION |
 | 03ᶜˢ | [Tactiques et théories (twin C# .NET)](Z3-Python-03-Tactics-Csharp.ipynb) | Parité .NET : tactiques, `BitVec`, `Array` via `Microsoft.Z3` (NuGet) | ~35 min | PRODUCTION |
 | 04 | [Chaînes et expressions régulières](Z3-Python-04-Strings-Regex.ipynb) | `String`, `Re` (théorie des chaînes Z3) | ~30 min | PRODUCTION |
+| 04ᶜˢ | [Chaînes et expressions régulières (twin C# .NET)](Z3-Python-04-Strings-Regex-Csharp.ipynb) | Parité .NET : théorie des chaînes, regex via `Microsoft.Z3` (NuGet) | ~30 min | PRODUCTION |
 | 05 | [Quantificateurs et preuves](Z3-Python-05-Quantifiers-Proofs.ipynb) | `ForAll`, `Exists`, preuves par réfutation, `unknown` | ~35 min | PRODUCTION |
 | 06 | [Optimisation avancée](Z3-Python-06-Advanced-Optimization.ipynb) | Pareto, objectifs multiples, `Optimize` hiérarchique, MaxSAT | ~40 min | PRODUCTION |
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-04-Strings-Regex-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-04-Strings-Regex-Csharp.ipynb
@@ -1,0 +1,1153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f4fda1e",
+   "metadata": {},
+   "source": [
+    "# Z3 (C# / .NET) — Theorie des chaines et expressions regulieres\n",
+    "\n",
+    "**Twin C# de `Z3-Python-04-Strings-Regex.ipynb`** (parite .NET, marathon #4956, suite de `Z3-Python-03-Tactics-Csharp`).\n",
+    "\n",
+    "Ce notebook explore la **theorie des chaines** (`String`) et des **expressions regulieres** (`Re`) du **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0). En Z3, une chaine est une *sequence* de caracteres : on peut raisonner symboliquement sur sa longueur, son prefixe, ses sous-chaines, et contraindre un solveur a **generer** une chaine satisfaisant une expression reguliere.\n",
+    "\n",
+    "## Plan\n",
+    "\n",
+    "1. Creation de chaines, `Length`, `MkExtract`, concatenation.\n",
+    "2. Recherche et substitution : `MkIndexOf`, `MkReplace`.\n",
+    "3. Trouver une chaine sous contraintes (`MkPrefixOf`, `MkSuffixOf`, `MkContains`).\n",
+    "4. Construction d'expressions regulieres (`MkToRe`, `MkRange`, `MkPlus`, `MkStar`).\n",
+    "5. `MkInRe` : faire generer une chaine par le solveur.\n",
+    "6. Detection d'insatisfiabilite (contradiction longueur/regex).\n",
+    "7. Politique de mot de passe (modelisation declarative).\n",
+    "8. Extraction d'extension de fichier.\n",
+    "9. Trois exercices.\n",
+    "\n",
+    "> **API .NET** : `ctx.StringSort` (sort des chaines), `ctx.MkString(\"x\")` (litteral, retourne `SeqExpr`), `ctx.MkConst(\"s\", ctx.StringSort)` (constante, a caster en `(SeqExpr)` car la surcharge statique retourne `Expr`). Les operations sur chaines sont des methodes plates : `MkLength`, `MkExtract(seq, off, len)`, `MkConcat(SeqExpr[])`, `MkPrefixOf`, `MkSuffixOf`, `MkContains`, `MkIndexOf`, `MkReplace`. Les regex : `MkToRe`, `MkRange`, `MkPlus`, `MkStar`, `MkUnion(ReExpr[])`, `MkConcat(ReExpr[])`, `MkInRe`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "572cc9af",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:49.463056Z",
+     "iopub.status.busy": "2026-07-07T06:05:49.458098Z",
+     "iopub.status.idle": "2026-07-07T06:05:52.757308Z",
+     "shell.execute_reply": "2026-07-07T06:05:52.752072Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '13816.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.Z3, 4.12.2</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : Microsoft.Z3 version Z3 4.12.2.0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.Z3\"\n",
+    "using Microsoft.Z3;\n",
+    "Console.WriteLine(\"Imports OK : Microsoft.Z3 version \" + Microsoft.Z3.Version.FullVersion);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0dcefba0",
+   "metadata": {},
+   "source": [
+    "## 1. Chaines, longueur, extraction, concatenation\n",
+    "\n",
+    "Un litteral chaine se cree avec `ctx.MkString(\"hello\")` (retourne un `SeqExpr`). La longueur est `ctx.MkLength(s)` (retourne un `IntExpr`). L'extraction d'une sous-chaine est `ctx.MkExtract(s, offset, longueur)` (attention : `offset` et `longueur` sont des `IntExpr`, donc `ctx.MkInt(6)` et non l'entier `6` directement). La concatenation prend un tableau : `ctx.MkConcat(new SeqExpr[]{a, b})`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4225307b",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:52.759061Z",
+     "iopub.status.busy": "2026-07-07T06:05:52.758806Z",
+     "iopub.status.idle": "2026-07-07T06:05:52.950398Z",
+     "shell.execute_reply": "2026-07-07T06:05:52.949986Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constante : \"hello\"\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Longueur (symbolique) : (str.len \"hello\")\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Concatenation : foo + bar = (str.++ \"foo\" \"bar\")\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MkExtract(EPITA-2026, 6, 4) = (str.substr \"EPITA-2026\" 6 4)  (= 2026)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "\n",
+    "// Litteral chaine et longueur\n",
+    "var mot = ctx.MkString(\"hello\");\n",
+    "Console.WriteLine(\"Constante : \" + mot);\n",
+    "Console.WriteLine(\"Longueur (symbolique) : \" + ctx.MkLength(mot));\n",
+    "\n",
+    "// Concatenation\n",
+    "var a = ctx.MkString(\"foo\");\n",
+    "var b = ctx.MkString(\"bar\");\n",
+    "var concatene = ctx.MkConcat(new SeqExpr[]{ a, b });\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Concatenation : foo + bar = \" + concatene);\n",
+    "\n",
+    "// Extraction de sous-chaine : MkExtract(seq, offset, longueur)\n",
+    "var extrait = ctx.MkExtract(ctx.MkString(\"EPITA-2026\"), ctx.MkInt(6), ctx.MkInt(4));\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"MkExtract(EPITA-2026, 6, 4) = \" + extrait + \"  (= 2026)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3eb71b96",
+   "metadata": {},
+   "source": [
+    "## 2. `MkIndexOf` et `MkReplace` : recherche et substitution\n",
+    "\n",
+    "`MkIndexOf(source, aiguille, debut)` retourne l'index de la premiere occurrence de `aiguille` dans `source` a partir de `debut` (ou `-1` si absent). `MkReplace(s, ancien, nouveau)` substitue toutes les occurrences. Sur des litteraux, la methode `.Simplify()` (equivalente de `simplify()` Python) force l'evaluation concrete.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1c76c6f3",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:52.952294Z",
+     "iopub.status.busy": "2026-07-07T06:05:52.952065Z",
+     "iopub.status.idle": "2026-07-07T06:05:53.262920Z",
+     "shell.execute_reply": "2026-07-07T06:05:53.262602Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IndexOf(EPITA-Symbolic, -, 0) = 5  (= 5)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IndexOf(EPITA-Symbolic, XYZ, 0) = -1  (= -1, non trouve)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Replace(a-b-c, -, _) = \"a_b-c\"  (= a_b-c, premiere occurrence seulement)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recherche code[L=8, Z3 a l index 3] : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  code = EDAZ3FHG\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "\n",
+    "// IndexOf : position d une sous-chaine (litteral -> Simplify evalue)\n",
+    "var pos = ctx.MkIndexOf(ctx.MkString(\"EPITA-Symbolic\"), ctx.MkString(\"-\"), ctx.MkInt(0));\n",
+    "Console.WriteLine(\"IndexOf(EPITA-Symbolic, -, 0) = \" + pos.Simplify() + \"  (= 5)\");\n",
+    "\n",
+    "var pos2 = ctx.MkIndexOf(ctx.MkString(\"EPITA-Symbolic\"), ctx.MkString(\"XYZ\"), ctx.MkInt(0));\n",
+    "Console.WriteLine(\"IndexOf(EPITA-Symbolic, XYZ, 0) = \" + pos2.Simplify() + \"  (= -1, non trouve)\");\n",
+    "\n",
+    "// Replace : substitution\n",
+    "var remplace = ctx.MkReplace(ctx.MkString(\"a-b-c\"), ctx.MkString(\"-\"), ctx.MkString(\"_\"));\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Replace(a-b-c, -, _) = \" + remplace.Simplify() + \"  (= a_b-c, premiere occurrence seulement)\");\n",
+    "\n",
+    "// Trouver une chaine de longueur 8 contenant Z3 a l index 3\n",
+    "var slv = ctx.MkSolver();\n",
+    "var code = (SeqExpr)ctx.MkConst(\"code\", ctx.StringSort);\n",
+    "slv.Add(ctx.MkEq(ctx.MkLength(code), ctx.MkInt(8)));\n",
+    "slv.Add(ctx.MkContains(code, ctx.MkString(\"Z3\")));\n",
+    "slv.Add(ctx.MkEq(ctx.MkIndexOf(code, ctx.MkString(\"Z3\"), ctx.MkInt(0)), ctx.MkInt(3)));\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Recherche code[L=8, Z3 a l index 3] : \" + slv.Check());\n",
+    "if (slv.Check() == Status.SATISFIABLE)\n",
+    "    Console.WriteLine(\"  code = \" + slv.Model.Evaluate(code).ToString().Trim('\"'));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2abcce0e",
+   "metadata": {},
+   "source": [
+    "## 3. Chaine sous contraintes : prefixe, suffixe, contenu\n",
+    "\n",
+    "On declare une chaine symbolique `txt` via `ctx.MkConst(\"txt\", ctx.StringSort)` (a caster en `(SeqExpr)`). Puis on impose : `txt` commence par `Hello` (`MkPrefixOf`), se termine par `World` (`MkSuffixOf`), contient `_` (`MkContains`), et a une longueur d'au moins 10. Le solveur **genere** une chaine satisfaisant toutes les contraintes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2e9e02bb",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:53.264756Z",
+     "iopub.status.busy": "2026-07-07T06:05:53.264525Z",
+     "iopub.status.idle": "2026-07-07T06:05:53.398586Z",
+     "shell.execute_reply": "2026-07-07T06:05:53.397933Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resolution : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  txt = HelloAB_CWorld\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  longueur = 14\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  prefixe Hello ? True, suffixe World ? True, contient _ ? True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "\n",
+    "var slv = ctx.MkSolver();\n",
+    "var txt = (SeqExpr)ctx.MkConst(\"txt\", ctx.StringSort);\n",
+    "\n",
+    "slv.Add(ctx.MkPrefixOf(ctx.MkString(\"Hello\"), txt));\n",
+    "slv.Add(ctx.MkSuffixOf(ctx.MkString(\"World\"), txt));\n",
+    "slv.Add(ctx.MkContains(txt, ctx.MkString(\"_\")));\n",
+    "slv.Add(ctx.MkGe(ctx.MkLength(txt), ctx.MkInt(10)));\n",
+    "\n",
+    "Console.WriteLine(\"Resolution : \" + slv.Check());\n",
+    "if (slv.Check() == Status.SATISFIABLE)\n",
+    "{\n",
+    "    string valeur = slv.Model.Evaluate(txt).ToString().Trim('\"');\n",
+    "    Console.WriteLine(\"  txt = \" + valeur);\n",
+    "    Console.WriteLine(\"  longueur = \" + valeur.Length);\n",
+    "    Console.WriteLine(\"  prefixe Hello ? \" + valeur.StartsWith(\"Hello\") + \", suffixe World ? \" + valeur.EndsWith(\"World\") + \", contient _ ? \" + valeur.Contains(\"_\"));\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e28a60f",
+   "metadata": {},
+   "source": [
+    "## 4. Construction d'expressions regulieres Z3\n",
+    "\n",
+    "Z3 possede sa propre theorie des expressions regulieres sur les chaines. Un litteral regex est `ctx.MkToRe(ctx.MkString(\"abc\"))`. Une plage de caracteres est `ctx.MkRange(ctx.MkString(\"a\"), ctx.MkString(\"z\"))` (un caractere entre a et z). Les combinateurs : `MkPlus(r)` (une ou plusieurs fois, `[r]+`), `MkStar(r)` (zero ou plus, `[r]*`), `MkUnion(ReExpr[])` (alternation), `MkConcat(ReExpr[])` (sequence).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "16c32512",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:53.400503Z",
+     "iopub.status.busy": "2026-07-07T06:05:53.400280Z",
+     "iopub.status.idle": "2026-07-07T06:05:53.495335Z",
+     "shell.execute_reply": "2026-07-07T06:05:53.494633Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MkToRe(abc) = (str.to_re \"abc\")\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MkRange(a,z) = (re.range \"a\" \"z\")\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Voyelle (union aeiou) = (let ((a!1 (re.union (re.union (re.union (str.to_re \"a\") (str.to_re \"e\"))\n",
+      "                               (str.to_re \"i\"))\n",
+      "                     (str.to_re \"o\"))))\n",
+      "  (re.union a!1 (str.to_re \"u\")))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mots [a-z]+ = (re.+ (re.range \"a\" \"z\"))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mots optionnels [a-z]* = (re.* (re.range \"a\" \"z\"))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mot+chiffre ([a-z]+[0-9]+) = (re.++ (re.+ (re.range \"a\" \"z\")) (re.+ (re.range \"0\" \"9\")))\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "\n",
+    "// Litteral regex\n",
+    "var rLit = ctx.MkToRe(ctx.MkString(\"abc\"));\n",
+    "Console.WriteLine(\"MkToRe(abc) = \" + rLit);\n",
+    "\n",
+    "// Plage : une lettre minuscule\n",
+    "var rMinuscule = ctx.MkRange(ctx.MkString(\"a\"), ctx.MkString(\"z\"));\n",
+    "Console.WriteLine(\"MkRange(a,z) = \" + rMinuscule);\n",
+    "\n",
+    "// Union : une voyelle\n",
+    "var rVoyelle = ctx.MkUnion(new ReExpr[]{\n",
+    "    ctx.MkToRe(ctx.MkString(\"a\")), ctx.MkToRe(ctx.MkString(\"e\")), ctx.MkToRe(ctx.MkString(\"i\")),\n",
+    "    ctx.MkToRe(ctx.MkString(\"o\")), ctx.MkToRe(ctx.MkString(\"u\")) });\n",
+    "Console.WriteLine(\"Voyelle (union aeiou) = \" + rVoyelle);\n",
+    "\n",
+    "// Plus : [a-z]+\n",
+    "Console.WriteLine(\"Mots [a-z]+ = \" + ctx.MkPlus(rMinuscule));\n",
+    "// Star : [a-z]*\n",
+    "Console.WriteLine(\"Mots optionnels [a-z]* = \" + ctx.MkStar(rMinuscule));\n",
+    "\n",
+    "// Concatenation : un mot suivi de chiffres\n",
+    "var rComplexe = ctx.MkConcat(new ReExpr[]{\n",
+    "    ctx.MkPlus(ctx.MkRange(ctx.MkString(\"a\"), ctx.MkString(\"z\"))),\n",
+    "    ctx.MkPlus(ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\"))) });\n",
+    "Console.WriteLine(\"Mot+chiffre ([a-z]+[0-9]+) = \" + rComplexe);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4806366",
+   "metadata": {},
+   "source": [
+    "## 5. `MkInRe` : appartenance et generation\n",
+    "\n",
+    "`ctx.MkInRe(chaine, regex)` affirme que `chaine` appartient au langage decrit par `regex`. Combine a un solveur, cela permet de **faire generer** une chaine correspondant a un motif. Exemple : un numero a 4 chiffres satisfait `[0-9]+` ET une longueur de 4.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d0d0fc70",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:53.497598Z",
+     "iopub.status.busy": "2026-07-07T06:05:53.497165Z",
+     "iopub.status.idle": "2026-07-07T06:05:53.728165Z",
+     "shell.execute_reply": "2026-07-07T06:05:53.727944Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Numero a 4 chiffres : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  numero = 0000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Email simplifie : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  email = p@k.h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Date AAAA-MM-JJ : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  date = 0-2-002224\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "\n",
+    "// Exemple 1 : un numero compose uniquement de 4 chiffres\n",
+    "var slv = ctx.MkSolver();\n",
+    "var numero = (SeqExpr)ctx.MkConst(\"numero\", ctx.StringSort);\n",
+    "var regexChiffres = ctx.MkPlus(ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\")));  // [0-9]+\n",
+    "slv.Add(ctx.MkInRe(numero, regexChiffres));\n",
+    "slv.Add(ctx.MkEq(ctx.MkLength(numero), ctx.MkInt(4)));\n",
+    "Console.WriteLine(\"Numero a 4 chiffres : \" + slv.Check());\n",
+    "if (slv.Check() == Status.SATISFIABLE)\n",
+    "    Console.WriteLine(\"  numero = \" + slv.Model.Evaluate(numero).ToString().Trim('\"'));\n",
+    "\n",
+    "// Exemple 2 : email simplifie (mot@mot.mot)\n",
+    "Console.WriteLine();\n",
+    "var slv2 = ctx.MkSolver();\n",
+    "var email = (SeqExpr)ctx.MkConst(\"email\", ctx.StringSort);\n",
+    "var mot = ctx.MkPlus(ctx.MkRange(ctx.MkString(\"a\"), ctx.MkString(\"z\")));\n",
+    "var regexEmail = ctx.MkConcat(new ReExpr[]{ mot, ctx.MkToRe(ctx.MkString(\"@\")), mot, ctx.MkToRe(ctx.MkString(\".\")), mot });\n",
+    "slv2.Add(ctx.MkInRe(email, regexEmail));\n",
+    "Console.WriteLine(\"Email simplifie : \" + slv2.Check());\n",
+    "if (slv2.Check() == Status.SATISFIABLE)\n",
+    "    Console.WriteLine(\"  email = \" + slv2.Model.Evaluate(email).ToString().Trim('\"'));\n",
+    "\n",
+    "// Exemple 3 : date AAAA-MM-JJ de longueur 10\n",
+    "Console.WriteLine();\n",
+    "var slv3 = ctx.MkSolver();\n",
+    "var date = (SeqExpr)ctx.MkConst(\"date\", ctx.StringSort);\n",
+    "var regexDate = ctx.MkConcat(new ReExpr[]{\n",
+    "    ctx.MkPlus(ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\"))),  // annee\n",
+    "    ctx.MkToRe(ctx.MkString(\"-\")),\n",
+    "    ctx.MkPlus(ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\"))),  // mois\n",
+    "    ctx.MkToRe(ctx.MkString(\"-\")),\n",
+    "    ctx.MkPlus(ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\")))   // jour\n",
+    "});\n",
+    "slv3.Add(ctx.MkInRe(date, regexDate));\n",
+    "slv3.Add(ctx.MkEq(ctx.MkLength(date), ctx.MkInt(10)));\n",
+    "Console.WriteLine(\"Date AAAA-MM-JJ : \" + slv3.Check());\n",
+    "if (slv3.Check() == Status.SATISFIABLE)\n",
+    "    Console.WriteLine(\"  date = \" + slv3.Model.Evaluate(date).ToString().Trim('\"'));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dba7ca8e",
+   "metadata": {},
+   "source": [
+    "## 6. Detection d'insatisfiabilite\n",
+    "\n",
+    "Une chaine de longueur 3 ne peut pas matcher une regex de 4 caracteres. De meme, un prefixe de 2 caracteres plus un suffixe de 2 caracteres depassent une longueur imposee de 3. Le solveur repond `UNSATISFIABLE`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3ce0adcc",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:53.729498Z",
+     "iopub.status.busy": "2026-07-07T06:05:53.729315Z",
+     "iopub.status.idle": "2026-07-07T06:05:53.832162Z",
+     "shell.execute_reply": "2026-07-07T06:05:53.831916Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contraintes : 4 chiffres ET longueur 3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-> Une chaine de 3 caracteres ne peut pas matcher 4 caracteres.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contraintes : prefixe AB + suffixe CD + longueur 3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-> Le prefixe (2) + le suffixe (2) depassent la longueur imposee (3).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "\n",
+    "// Cas 1 : 4 chiffres (longueur implicite 4) ET longueur imposee 3 -> impossible\n",
+    "var slv = ctx.MkSolver();\n",
+    "var x = (SeqExpr)ctx.MkConst(\"x\", ctx.StringSort);\n",
+    "var r4Chiffres = ctx.MkConcat(new ReExpr[]{\n",
+    "    ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\")),\n",
+    "    ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\")),\n",
+    "    ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\")),\n",
+    "    ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\")) });\n",
+    "slv.Add(ctx.MkInRe(x, r4Chiffres));\n",
+    "slv.Add(ctx.MkEq(ctx.MkLength(x), ctx.MkInt(3)));\n",
+    "Console.WriteLine(\"Contraintes : 4 chiffres ET longueur 3\");\n",
+    "Console.WriteLine(\"Resultat : \" + slv.Check());\n",
+    "Console.WriteLine(\"-> Une chaine de 3 caracteres ne peut pas matcher 4 caracteres.\");\n",
+    "\n",
+    "// Cas 2 : prefixe AB + suffixe CD + longueur 3 -> impossible (2+2 > 3)\n",
+    "Console.WriteLine();\n",
+    "var slv2 = ctx.MkSolver();\n",
+    "var y = (SeqExpr)ctx.MkConst(\"y\", ctx.StringSort);\n",
+    "slv2.Add(ctx.MkPrefixOf(ctx.MkString(\"AB\"), y));\n",
+    "slv2.Add(ctx.MkSuffixOf(ctx.MkString(\"CD\"), y));\n",
+    "slv2.Add(ctx.MkEq(ctx.MkLength(y), ctx.MkInt(3)));\n",
+    "Console.WriteLine(\"Contraintes : prefixe AB + suffixe CD + longueur 3\");\n",
+    "Console.WriteLine(\"Resultat : \" + slv2.Check());\n",
+    "Console.WriteLine(\"-> Le prefixe (2) + le suffixe (2) depassent la longueur imposee (3).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e24f9300",
+   "metadata": {},
+   "source": [
+    "## 7. Politique de mot de passe (modelisation declarative)\n",
+    "\n",
+    "On modelise une politique de mot de passe comme un ensemble de contraintes Z3 : longueur 8, 1er caractere majuscule, 5e caractere chiffre, reste en minuscules. Chaque contrainte positionnelle utilise `MkExtract(pwd, i, 1)` pour isoler le caractere a la position `i`, puis `MkInRe` pour borner sa plage. On fournit aussi une variante deterministe avec egalite exacte par position.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e5e34dfe",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:53.833812Z",
+     "iopub.status.busy": "2026-07-07T06:05:53.833606Z",
+     "iopub.status.idle": "2026-07-07T06:05:54.093958Z",
+     "shell.execute_reply": "2026-07-07T06:05:54.093474Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mot de passe (regex par position) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Pppp0ppp\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mot de passe (egalite exacte) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  XABC7DFE\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "\n",
+    "string GenererMotDePasseValide(Context ctx)\n",
+    "{\n",
+    "    var s = ctx.MkSolver();\n",
+    "    var pwd = (SeqExpr)ctx.MkConst(\"pwd\", ctx.StringSort);\n",
+    "    s.Add(ctx.MkEq(ctx.MkLength(pwd), ctx.MkInt(8)));            // longueur 8\n",
+    "    s.Add(ctx.MkInRe(ctx.MkExtract(pwd, ctx.MkInt(0), ctx.MkInt(1)), ctx.MkRange(ctx.MkString(\"A\"), ctx.MkString(\"Z\"))));  // 1er majuscule\n",
+    "    s.Add(ctx.MkInRe(ctx.MkExtract(pwd, ctx.MkInt(4), ctx.MkInt(1)), ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\"))));  // 5e chiffre\n",
+    "    foreach (var i in new long[]{1, 2, 3, 5, 6, 7})               // reste minuscules\n",
+    "        s.Add(ctx.MkInRe(ctx.MkExtract(pwd, ctx.MkInt(i), ctx.MkInt(1)), ctx.MkRange(ctx.MkString(\"a\"), ctx.MkString(\"z\"))));\n",
+    "    if (s.Check() == Status.SATISFIABLE)\n",
+    "        return s.Model.Evaluate(pwd).ToString().Trim('\"');\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "string GenererMotDePasseV2(Context ctx)\n",
+    "{\n",
+    "    // Variante deterministe : caracteres connus par position\n",
+    "    var s = ctx.MkSolver();\n",
+    "    var pwd = (SeqExpr)ctx.MkConst(\"pwd\", ctx.StringSort);\n",
+    "    s.Add(ctx.MkEq(ctx.MkLength(pwd), ctx.MkInt(8)));\n",
+    "    s.Add(ctx.MkEq(ctx.MkExtract(pwd, ctx.MkInt(0), ctx.MkInt(1)), ctx.MkString(\"X\")));  // 1er = majuscule fixe\n",
+    "    s.Add(ctx.MkEq(ctx.MkExtract(pwd, ctx.MkInt(4), ctx.MkInt(1)), ctx.MkString(\"7\")));   // 5e = chiffre fixe\n",
+    "    if (s.Check() == Status.SATISFIABLE)\n",
+    "        return s.Model.Evaluate(pwd).ToString().Trim('\"');\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "var ctx = new Context();\n",
+    "Console.WriteLine(\"Mot de passe (regex par position) :\");\n",
+    "Console.WriteLine(\"  \" + GenererMotDePasseValide(ctx));\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Mot de passe (egalite exacte) :\");\n",
+    "Console.WriteLine(\"  \" + GenererMotDePasseV2(ctx));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1a6b3be",
+   "metadata": {},
+   "source": [
+    "## 8. Extraction d'extension de fichier\n",
+    "\n",
+    "On cherche un nom de fichier valide : suffixe `.py`, longueur >= 5, format `[a-z0-9]+.py`. Puis on utilise `MkIndexOf` pour localiser le point et `MkExtract` pour separer le nom de l'extension. L'index du point est recupere via `((IntNum)m.Evaluate(idx)).Int64`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e2085f70",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:54.095633Z",
+     "iopub.status.busy": "2026-07-07T06:05:54.095408Z",
+     "iopub.status.idle": "2026-07-07T06:05:54.201527Z",
+     "shell.execute_reply": "2026-07-07T06:05:54.200989Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nom de fichier valide : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  fichier = a0.py\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IndexOf(.) = 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Extension extraite = .py\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Nom sans extension = a0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "\n",
+    "var slv = ctx.MkSolver();\n",
+    "var fichier = (SeqExpr)ctx.MkConst(\"fichier\", ctx.StringSort);\n",
+    "\n",
+    "// Suffixe .py, longueur >= 5, format [a-z0-9]+.py\n",
+    "slv.Add(ctx.MkSuffixOf(ctx.MkString(\".py\"), fichier));\n",
+    "slv.Add(ctx.MkGe(ctx.MkLength(fichier), ctx.MkInt(5)));\n",
+    "var carValide = ctx.MkUnion(new ReExpr[]{\n",
+    "    ctx.MkRange(ctx.MkString(\"a\"), ctx.MkString(\"z\")),\n",
+    "    ctx.MkRange(ctx.MkString(\"0\"), ctx.MkString(\"9\")) });\n",
+    "var regexFichier = ctx.MkConcat(new ReExpr[]{\n",
+    "    ctx.MkPlus(carValide), ctx.MkToRe(ctx.MkString(\".\")), ctx.MkToRe(ctx.MkString(\"p\")), ctx.MkToRe(ctx.MkString(\"y\")) });\n",
+    "slv.Add(ctx.MkInRe(fichier, regexFichier));\n",
+    "\n",
+    "Console.WriteLine(\"Nom de fichier valide : \" + slv.Check());\n",
+    "if (slv.Check() == Status.SATISFIABLE)\n",
+    "{\n",
+    "    var m = slv.Model;\n",
+    "    string nom = m.Evaluate(fichier).ToString().Trim('\"');\n",
+    "    Console.WriteLine(\"  fichier = \" + nom);\n",
+    "\n",
+    "    // Localiser le point puis extraire extension et nom seul\n",
+    "    var posPoint = ctx.MkIndexOf(fichier, ctx.MkString(\".\"), ctx.MkInt(0));\n",
+    "    long p = ((IntNum)m.Evaluate(posPoint)).Int64;\n",
+    "    long l = ((IntNum)m.Evaluate(ctx.MkLength(fichier))).Int64;\n",
+    "    string ext = m.Evaluate(ctx.MkExtract(fichier, ctx.MkInt(p), ctx.MkInt(l - p))).ToString().Trim('\"');\n",
+    "    string nomSeul = m.Evaluate(ctx.MkExtract(fichier, ctx.MkInt(0), ctx.MkInt(p))).ToString().Trim('\"');\n",
+    "    Console.WriteLine(\"  IndexOf(.) = \" + p);\n",
+    "    Console.WriteLine(\"  Extension extraite = \" + ext);\n",
+    "    Console.WriteLine(\"  Nom sans extension = \" + nomSeul);\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01463eb2",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices a completer. Les stubs retournent `null`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ee14b642",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:54.203376Z",
+     "iopub.status.busy": "2026-07-07T06:05:54.203119Z",
+     "iopub.status.idle": "2026-07-07T06:05:54.258975Z",
+     "shell.execute_reply": "2026-07-07T06:05:54.258548Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 (mot de passe valide ?) : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 : Valider qu un mot de passe respecte les regles de securite.\n",
+    "// Regles : longueur >= 8, contient un chiffre, contient une majuscule.\n",
+    "// Indice : creez un Solver, ajoutez les 3 contraintes.\n",
+    "// Etape 1 : MkLength(s) >= 8\n",
+    "// Etape 2 : forcer une position a contenir un chiffre (MkExtract + MkInRe + MkRange(0,9))\n",
+    "// Etape 3 : forcer une position a contenir une majuscule (MkRange(A,Z))\n",
+    "bool? ValiderMotDePasse(Context ctx, SeqExpr sChaine)\n",
+    "{\n",
+    "    // TODO etudiant : implementez la validation (3 contraintes + Check)\n",
+    "    return null;  // TODO etudiant : remplacer par true (sat) ou false (unsat)\n",
+    "}\n",
+    "\n",
+    "var ctxE1 = new Context();\n",
+    "var pwdE1 = (SeqExpr)ctxE1.MkConst(\"pwd_ex1\", ctxE1.StringSort);\n",
+    "var r1 = ValiderMotDePasse(ctxE1, pwdE1);\n",
+    "Console.WriteLine(\"Exercice 1 (mot de passe valide ?) : \" + (r1.HasValue ? r1.Value.ToString() : \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e5a063f5",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:54.260402Z",
+     "iopub.status.busy": "2026-07-07T06:05:54.260196Z",
+     "iopub.status.idle": "2026-07-07T06:05:54.293907Z",
+     "shell.execute_reply": "2026-07-07T06:05:54.293728Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 (chaine ab..cd) : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 : Trouver une chaine de 6 caracteres commencant par ab, finissant par cd.\n",
+    "// Contraintes : prefixe ab, suffixe cd, longueur 6, minuscules uniquement.\n",
+    "// Indice : Solver + variable SeqExpr + MkPrefixOf/MkSuffixOf/MkLength + MkInRe(MkStar(MkRange(a,z))).\n",
+    "// Etape 1 : MkPrefixOf(ab, s), MkSuffixOf(cd, s), MkLength(s) == 6\n",
+    "// Etape 2 : MkInRe(s, MkStar(MkRange(a, z)))\n",
+    "// Etape 3 : extraire s.Model.Evaluate(s).ToString().Trim('\"')\n",
+    "string TrouverMotMatchingRegex(Context ctx)\n",
+    "{\n",
+    "    // TODO etudiant : implementez la recherche\n",
+    "    return null;  // TODO etudiant : remplacer par la chaine trouvee\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 2 (chaine ab..cd) : \" + (TrouverMotMatchingRegex(new Context()) ?? \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1a9572ad",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:05:54.295311Z",
+     "iopub.status.busy": "2026-07-07T06:05:54.295142Z",
+     "iopub.status.idle": "2026-07-07T06:05:54.326382Z",
+     "shell.execute_reply": "2026-07-07T06:05:54.326169Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 (extension de rapport_final.pdf) : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 3 : Extraire l extension d un nom de fichier avec Z3.\n",
+    "// Retourne l extension (apres le dernier point) ou null si pas de point.\n",
+    "// Indice : convertissez nomFichier en MkString, puis utilisez MkIndexOf.\n",
+    "// Etape 1 : pos = MkIndexOf(MkString(nom), MkString(\".\"), MkInt(0)).Simplify()\n",
+    "// Etape 2 : si pos == -1 -> return null\n",
+    "// Etape 3 : ext = MkExtract(MkString(nom), pos+1, longueur - pos - 1)\n",
+    "// Etape 4 : extraire la valeur avec ((IntNum)...).Int64\n",
+    "string ExtraireExtension(Context ctx, string nomFichier)\n",
+    "{\n",
+    "    // TODO etudiant : implementez l extraction\n",
+    "    return null;  // TODO etudiant : remplacer par l extension trouvee\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 3 (extension de rapport_final.pdf) : \" + (ExtraireExtension(new Context(), \"rapport_final.pdf\") ?? \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbc08613",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# couvre la **theorie des chaines** (`MkString`/`MkLength`/`MkExtract`/`MkConcat`/`MkPrefixOf`/`MkSuffixOf`/`MkContains`/`MkIndexOf`/`MkReplace`) et la **theorie des expressions regulieres** (`MkToRe`/`MkRange`/`MkPlus`/`MkStar`/`MkUnion`/`MkConcat`/`MkInRe`) du moteur reel Microsoft.Z3. Le solveur peut non seulement *verifier* qu'une chaine satisfait une regex, mais aussi **generer** une chaine correspondant a un motif - une capacite unique de la theorie des chaines Z3.\n",
+    "\n",
+    "**Complementarite** : le twin Python utilise `String('s')` / `SubString` / `Range` / `InRe` (API pythonique aux operateurs `+`, `*`) ; ce twin C# montre l'API .NET plate (`ctx.MkString` / `ctx.MkExtract(seq, off, len)` / `ctx.MkRange` / `ctx.MkInRe`) avec ses specificites de typage (`SeqExpr` cast sur `MkConst`, formes tableau `SeqExpr[]`/`ReExpr[]` pour `MkConcat`/`MkUnion`). Les deux executent le **meme** moteur Z3 - la valeur ajoutee est la traduction des idiomes dans le systeme de types .NET.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": "csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Ce que fait cette PR

Etablit la parite .NET sur le notebook 04 de la serie Z3-Python : **twin C#** de `Z3-Python-04-Strings-Regex.ipynb` utilisant le **vrai moteur [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet `#r "nuget: Microsoft.Z3"`, v4.12.2.0) — le meme solveur que `z3-solver` Python (Prong A SOTA, EPIC #3801). Suite de `Z3-Python-03-Tactics-Csharp`. Série Z3-Python-Csharp maintenant **4/6** (01/02/03/04).

## Contenu (12 cells code + 11 md, EXEC_PROVED)

1. **Chaines** : `MkString`/`MkLength`/`MkExtract(seq, off, len)`/`MkConcat(SeqExpr[])`
2. **Recherche/substitution** : `MkIndexOf(source, aiguille, debut)`, `MkReplace` (1ere occurrence, semantique Z3), `.Simplify()` pour litteraux
3. **Chaine sous contraintes** : `MkPrefixOf`/`MkSuffixOf`/`MkContains` → resolution generative (`txt = HelloAB_CWorld`)
4. **Regex** : `MkToRe`/`MkRange`/`MkPlus`/`MkStar`/`MkUnion(ReExpr[])`/`MkConcat(ReExpr[])`
5. **`MkInRe`** : generation de chaines par le solveur (numero 4 chiffres `0000`, email `p@k.h`, date AAAA-MM-JJ)
6. **Insatisfiabilite** : 4 chiffres + longueur 3 = UNSAT ; prefixe AB + suffixe CD + longueur 3 = UNSAT
7. **Mot de passe** : politique declarative (1er majuscule, 5e chiffre via `MkExtract(pwd, i, 1)` positionnel + `MkInRe`)
8. **Extraction extension** : fichier `.py` via `MkIndexOf` + `MkExtract` (extension `.py`, nom `a0`)
9. **3 exercices C.1** : validation mot de passe, chaine ab..cd, extraction extension

## Verification EXEC_PROVED

| Critere | Resultat |
|---------|----------|
| execution_count | 1..12 contigus ✓ |
| errors | 0 ✓ |
| path-leaks | 0 ✓ |
| emoji | 0 ✓ |
| warning/erreur CS | 0 ✓ |
| throw/assert/NotImplemented | 0 ✓ |
| Microsoft.Z3 NuGet confirme | ✓ (`Z3 4.12.2.0`) |
| TODO etudiant (stubs C.1) | 6 (3 exos x 2) ✓ |
| Validator H.1/H.3/C.1 | PASS 1/1 (12 cells) ✓ |
| CATALOG byte-identique | ✓ |

## API Microsoft.Z3 string theory naillee (decouverte c.89, 4 probes reflection + functional)

L'API .NET est **plate** (pas de prefixe `Seq*`/`Re*`), les surcharges distinguent par type :

| Concept | Methode .NET | Retour |
|---------|-------------|--------|
| Sort des chaines | `ctx.StringSort` | `SeqSort` |
| Litteral | `ctx.MkString("x")` | `SeqExpr` (static, pas de cast) |
| Constante | `ctx.MkConst("s", ctx.StringSort)` | `Expr` static → **cast `(SeqExpr)`** obligatoire |
| Longueur | `ctx.MkLength(s)` | `IntExpr` |
| Sous-chaine | `ctx.MkExtract(s, MkInt(off), MkInt(len))` | `SeqExpr` (surcharge seq, pas BitVec) |
| Concat chaine | `ctx.MkConcat(SeqExpr[])` | `SeqExpr` |
| Prefixe/Suffixe/Contient | `MkPrefixOf`/`MkSuffixOf`/`MkContains` | `BoolExpr` |
| Index de | `ctx.MkIndexOf(s, sub, ArithExpr)` | `IntExpr` |
| Remplace | `ctx.MkReplace(s, old, new)` | `SeqExpr` (1ere occ. seulement) |
| Regex litteral | `ctx.MkToRe(MkString("abc"))` | `ReExpr` |
| Plage | `ctx.MkRange(MkString("a"), MkString("z"))` | `ReExpr` |
| `+`/`*`/`|`/concat | `MkPlus`/`MkStar`/`MkUnion(ReExpr[])`/`MkConcat(ReExpr[])` | `ReExpr` |
| Appartenance | `ctx.MkInRe(s, r)` | `BoolExpr` |

Extraction valeurs : `((IntNum)m.Evaluate(idx)).Int64` (entier), `m.Evaluate(s).ToString().Trim('"')` (chaine, les quotes SMT-LIB sont retirees).

## Valeur ajoutee du twin (parite .NET)

Le twin Python utilise `String('s')` / `SubString` / `Range` / `InRe` (API pythonique, operateurs `+`/`*`) ; ce twin C# montre l'API .NET plate avec ses specificites de typage : cast `(SeqExpr)` sur `MkConst` (retour statique `Expr`), formes tableau `SeqExpr[]`/`ReExpr[]` pour `MkConcat`/`MkUnion`, et `MkExtract(SeqExpr, IntExpr, IntExpr)` (surcharge seq distincte de la BitVec). Les outputs sont **concordants** avec le Python (symbolique pour les termes, evalues pour les IndexOf/Replace via `.Simplify()`, solutions generees identiques en nature). Les deux executent le **meme** moteur Z3.

## Diffs

- `+1154 / -0` : nouveau notebook (1153 lignes) + README `+1 ligne table` (ligne `04cs`)
- CATALOG byte-identique (regle catalog-pr-hygiene R1)
- EOF : C# twin convention (trailing newline `\n`), LF via `.gitattributes eol=lf`

See #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
