### PR TITLE
fix(search-apps): correct Applications tree count Search 2->3 after #5612

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -30,7 +30,7 @@ Un algorithme compris sur un exemple jouet n'est pas encore un algorithme maîtr
 
 ```text
 Applications/
-├── Search/     # Applications purement Search (2 notebooks)
+├── Search/     # Applications purement Search (3 notebooks : 2 Python + 1 twin C#)
 ├── CSP/        # Applications CSP (23 notebooks : 13 Python + 10 twins C#)
 └── Hybrid/     # Metaheuristiques / GA (9 notebooks : 5 Python + 4 twins C#)
 ```


### PR DESCRIPTION
## Summary

1-line §E correction of a tree-block count drift introduced by #5612 (App-14-ConnectFour-Adversarial-CSharp, merged). The prose count / sub-series / table / prereq were updated in #5612, but the `Applications/` tree-block count for the `Search/` subdir was not — it still read "2 notebooks" while the disk has 3.

## Change

```diff
-├── Search/     # Applications purement Search (2 notebooks)
+├── Search/     # Applications purement Search (3 notebooks : 2 Python + 1 twin C#)
```

Aligns with the CSP/Hybrid breakdown convention (which already include twins: `CSP (23 : 13 Python + 10 twins)`, `Hybrid (9 : 5 Python + 4 twins)`).

## §E consistency (all counts vs disk, fresh origin/main)

| Location | Value | Disk |
|----------|-------|------|
| Prose | 35 notebooks | total = 35 ✓ |
| Sub-series | 35 | ✓ |
| Tree Search/ | 3 (2 Python + 1 twin) | Search = 3 ✓ |
| Tree CSP/ | 23 (13 Python + 10 twins) | CSP = 23 ✓ |
| Tree Hybrid/ | 9 (5 Python + 4 twins) | Hybrid = 9 ✓ |

CATALOG-STATUS byte-identical (this README has no marker). LF-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
