### PR TITLE
feat(smt): Z3-Python-05-Quantifiers-Proofs-Csharp — twin C# Microsoft.Z3 (ForAll, Exists, refutation)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -48,6 +48,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 | 03ᶜˢ | [Tactiques et théories (twin C# .NET)](Z3-Python-03-Tactics-Csharp.ipynb) | Parité .NET : tactiques, `BitVec`, `Array` via `Microsoft.Z3` (NuGet) | ~35 min | PRODUCTION |
 | 04 | [Chaînes et expressions régulières](Z3-Python-04-Strings-Regex.ipynb) | `String`, `Re` (théorie des chaînes Z3) | ~30 min | PRODUCTION |
 | 05 | [Quantificateurs et preuves](Z3-Python-05-Quantifiers-Proofs.ipynb) | `ForAll`, `Exists`, preuves par réfutation, `unknown` | ~35 min | PRODUCTION |
+| 05ᶜˢ | [Quantificateurs et preuves (twin C# .NET)](Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb) | Parité .NET : `MkForall`, `MkExists`, réfutation, `ReasonUnknown` via `Microsoft.Z3` (NuGet) | ~35 min | PRODUCTION |
 | 06 | [Optimisation avancée](Z3-Python-06-Advanced-Optimization.ipynb) | Pareto, objectifs multiples, `Optimize` hiérarchique, MaxSAT | ~40 min | PRODUCTION |
 
 ### Fil pédagogique

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb
@@ -1,0 +1,1074 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b578c3e9",
+   "metadata": {},
+   "source": [
+    "# Z3 (C# / .NET) — Quantificateurs et preuves par refutation\n",
+    "\n",
+    "**Twin C# de `Z3-Python-05-Quantifiers-Proofs.ipynb`** (parite .NET, marathon #4956, suite de `Z3-Python-04-Strings-Regex-Csharp`).\n",
+    "\n",
+    "Ce notebook aborde les **quantificateurs** (`ForAll`, `Exists`) et la notion de **preuve formelle par refutation** avec le **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0). Une formule est *valide* (un theoreme) si sa **negation** est insatisfiable : on demande au solveur de trouver un contre-exemple, et s'il n'en existe aucun, la formule est demontree.\n",
+    "\n",
+    "## Plan\n",
+    "\n",
+    "1. Preuve de l'identite additive par refutation (`ForAll x, x+0 == x`).\n",
+    "2. Trois proprietes elementaires (multiplicatif, commutativite, neutre a droite).\n",
+    "3. `Exists` sat : existe-t-il un `x` tel que `x*x == 4` ? Piege de la variable liee.\n",
+    "4. `Exists` unsat : un carre reel est toujours positif (`x*x < 0` impossible).\n",
+    "5. Trichotomie et monotonie du carre sur les reels positifs.\n",
+    "6. Quantificateurs imbriques (`ForAll x, Exists y, y > x` = pas de plus grand reel).\n",
+    "7. Le cas honnete `unknown` : dernier theoreme de Fermat (`a^3 + b^3 == c^3`).\n",
+    "8. Model checking : skolemisation d'un `Exists x, ForAll y`.\n",
+    "9. Trois exercices.\n",
+    "\n",
+    "> **API .NET** : `ctx.MkForall(new Expr[]{x}, body)` / `ctx.MkExists(new Expr[]{x}, body)` ou `x` est une constante creee via `ctx.MkConst(\"x\", sort)` (le *body* utilise `x` directement, pas de de-Bruijn). `ctx.MkImplies`, `MkOr`, `MkAnd`, `MkNot` pour les connecteurs. Le timeout se regle via `s.Set(\"timeout\", 3000)` ; la raison d'un `UNKNOWN` se lit via la propriete `s.ReasonUnknown`. Les constantes reelles/entieres retournees par `MkConst` sont statiquement `Expr` → a caster en `(ArithExpr)` pour `MkAdd`/`MkMul`/`MkLt`/etc.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f4dabbd7",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:38.335746Z",
+     "iopub.status.busy": "2026-07-07T06:25:38.328704Z",
+     "iopub.status.idle": "2026-07-07T06:25:42.053125Z",
+     "shell.execute_reply": "2026-07-07T06:25:42.049311Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '38596.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.Z3, 4.12.2</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : Microsoft.Z3 version Z3 4.12.2.0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.Z3\"\n",
+    "using Microsoft.Z3;\n",
+    "Console.WriteLine(\"Imports OK : Microsoft.Z3 version \" + Microsoft.Z3.Version.FullVersion);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e43718b6",
+   "metadata": {},
+   "source": [
+    "## 1. Preuve par refutation : `ForAll x, x + 0 == x`\n",
+    "\n",
+    "Pour prouver qu'une formule universelle est valide, on ajoute sa **negation** au solveur. Si le solveur repond `UNSATISFIABLE`, c'est qu'il n'existe aucun contre-exemple : la formule est donc un theoreme. Ici `x + 0 == x` pour tout reel `x`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3cb83eff",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:42.054777Z",
+     "iopub.status.busy": "2026-07-07T06:25:42.054568Z",
+     "iopub.status.idle": "2026-07-07T06:25:42.233489Z",
+     "shell.execute_reply": "2026-07-07T06:25:42.233158Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule a prouver : (forall ((x Real)) (= (+ x 0.0) x))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Negation de la formule : UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Aucun contre-exemple trouve : la formule est VALIDE (theoreme).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "var x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort);\n",
+    "\n",
+    "// La formule que nous voulons prouver : pour tout x reel, x + 0 == x\n",
+    "var body = ctx.MkEq(ctx.MkAdd(x, ctx.MkReal(0)), x);\n",
+    "var formule = ctx.MkForall(new Expr[]{ x }, body);\n",
+    "Console.WriteLine(\"Formule a prouver : \" + formule);\n",
+    "\n",
+    "// Technique : verifier que la NEGATION est insatisfiable\n",
+    "var s = ctx.MkSolver();\n",
+    "s.Add(ctx.MkNot(formule));  // Existe-t-il un x tel que x + 0 != x ?\n",
+    "\n",
+    "Status resultat = s.Check();\n",
+    "Console.WriteLine(\"Negation de la formule : \" + resultat);\n",
+    "\n",
+    "if (resultat == Status.UNSATISFIABLE)\n",
+    "    Console.WriteLine(\"=> Aucun contre-exemple trouve : la formule est VALIDE (theoreme).\");\n",
+    "else if (resultat == Status.SATISFIABLE)\n",
+    "    Console.WriteLine(\"=> Contre-exemple trouve : \" + s.Model);\n",
+    "else\n",
+    "    Console.WriteLine(\"=> Z3 ne peut pas conclure (unknown).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a739626",
+   "metadata": {},
+   "source": [
+    "## 2. Trois proprietes elementaires\n",
+    "\n",
+    "On automatise la preuve par refutation sur trois proprietes : l'identite multiplicative (`x * 1 == x`), la commutativite de l'addition (`x + y == y + x`), et le neutre additif a droite (`0 + x == x`). Pour chacune, on nie la formule universelle et on regarde le verdict du solveur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2f44846e",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:42.234981Z",
+     "iopub.status.busy": "2026-07-07T06:25:42.234701Z",
+     "iopub.status.idle": "2026-07-07T06:25:42.389156Z",
+     "shell.execute_reply": "2026-07-07T06:25:42.388986Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Identite multiplicative : x * 1 == x\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => VALIDE (negation = UNSATISFIABLE)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Commutativite de l addition : x + y == y + x\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => VALIDE (negation = UNSATISFIABLE)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Neutre additif a droite : 0 + x == x\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => VALIDE (negation = UNSATISFIABLE)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "using System.Collections.Generic;\n",
+    "var ctx = new Context();\n",
+    "var x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort);\n",
+    "var y = (ArithExpr)ctx.MkConst(\"y\", ctx.RealSort);\n",
+    "\n",
+    "var proprietes = new (string nom, Quantifier formule)[]{\n",
+    "    (\"Identite multiplicative : x * 1 == x\",\n",
+    "        ctx.MkForall(new Expr[]{ x }, ctx.MkEq(ctx.MkMul(x, ctx.MkReal(1)), x))),\n",
+    "    (\"Commutativite de l addition : x + y == y + x\",\n",
+    "        ctx.MkForall(new Expr[]{ x, y }, ctx.MkEq(ctx.MkAdd(x, y), ctx.MkAdd(y, x)))),\n",
+    "    (\"Neutre additif a droite : 0 + x == x\",\n",
+    "        ctx.MkForall(new Expr[]{ x }, ctx.MkEq(ctx.MkAdd(ctx.MkReal(0), x), x))),\n",
+    "};\n",
+    "\n",
+    "foreach (var (nom, formule) in proprietes)\n",
+    "{\n",
+    "    var s = ctx.MkSolver();\n",
+    "    s.Add(ctx.MkNot(formule));\n",
+    "    var res = s.Check();\n",
+    "    string statut = res == Status.UNSATISFIABLE ? \"VALIDE\" : (res == Status.SATISFIABLE ? \"FAUSSE\" : \"UNKNOWN\");\n",
+    "    Console.WriteLine(nom);\n",
+    "    Console.WriteLine(\"  => \" + statut + \" (negation = \" + res + \")\");\n",
+    "    Console.WriteLine();\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c61e0c9f",
+   "metadata": {},
+   "source": [
+    "## 3. `Exists` satisfiable : existe-t-il `x` tel que `x*x == 4` ?\n",
+    "\n",
+    "Le quantificateur existentiel `MkExists` demontre l'existence d'un temoin. **Piege classique** : la variable liee par `Exists` n'apparait **pas** dans le modele (elle est quantifiee) — `m.Evaluate(x)` ne donne pas de temoin lisible. Pour obtenir une valeur concrete, on **skolemise** : on reasserte la meme contrainte sur une constante *libre*, dont la valeur est alors lisible dans le modele.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bb7cd41a",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:42.390546Z",
+     "iopub.status.busy": "2026-07-07T06:25:42.390374Z",
+     "iopub.status.idle": "2026-07-07T06:25:42.546363Z",
+     "shell.execute_reply": "2026-07-07T06:25:42.546103Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule   : (exists ((x Real)) (= (* x x) 4.0))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Existence : SATISFIABLE (un temoin existe)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "m[x] (x lie par Exists) : x  <- aucun temoin lisible ici\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Temoin concret (constante libre) : racine = 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification : 2 * 2 = 4 (attendu : 4)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "var x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort);\n",
+    "\n",
+    "// Etape 1 : prouver l existence avec le quantificateur existentiel\n",
+    "var formule = ctx.MkExists(new Expr[]{ x }, ctx.MkEq(ctx.MkMul(x, x), ctx.MkReal(4)));\n",
+    "var s = ctx.MkSolver();\n",
+    "s.Add(formule);\n",
+    "var res = s.Check();\n",
+    "Console.WriteLine(\"Formule   : \" + formule);\n",
+    "Console.WriteLine(\"Existence : \" + res + \" (un temoin existe)\");\n",
+    "\n",
+    "// Piege : x est LIEE par Exists -> pas dans le modele\n",
+    "Console.WriteLine(\"m[x] (x lie par Exists) : \" + s.Model.Evaluate(x) + \"  <- aucun temoin lisible ici\");\n",
+    "\n",
+    "// Etape 2 : skolemisation sur une constante LIBRE\n",
+    "var racine = (ArithExpr)ctx.MkConst(\"racine\", ctx.RealSort);\n",
+    "var s2 = ctx.MkSolver();\n",
+    "s2.Add(ctx.MkEq(ctx.MkMul(racine, racine), ctx.MkReal(4)));\n",
+    "s2.Check();\n",
+    "var temoin = s2.Model.Evaluate(racine);\n",
+    "Console.WriteLine(\"Temoin concret (constante libre) : racine = \" + temoin);\n",
+    "Console.WriteLine(\"Verification : \" + temoin + \" * \" + temoin + \" = \" + ctx.MkMul((ArithExpr)temoin, (ArithExpr)temoin).Simplify() + \" (attendu : 4)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "613e9fef",
+   "metadata": {},
+   "source": [
+    "## 4. `Exists` insatisfiable : un carre negatif n'existe pas\n",
+    "\n",
+    "A l'inverse, `MkExists(new Expr[]{ x }, x*x < 0)` est insatisfiable sur les reels : un carre est toujours positif ou nul. Le solveur repond `UNSATISFIABLE`, demontrant que la formule existentielle est fausse.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0934a165",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:42.548672Z",
+     "iopub.status.busy": "2026-07-07T06:25:42.548215Z",
+     "iopub.status.idle": "2026-07-07T06:25:42.667580Z",
+     "shell.execute_reply": "2026-07-07T06:25:42.667341Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule : (exists ((x Real)) (< (* x x) 0.0))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(Un carre reel est toujours positif ou nul)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Aucun reel x tel que x*x < 0 : la formule est FAUSSE.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "var x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort);\n",
+    "\n",
+    "var formule = ctx.MkExists(new Expr[]{ x }, ctx.MkLt(ctx.MkMul(x, x), ctx.MkReal(0)));\n",
+    "Console.WriteLine(\"Formule : \" + formule);\n",
+    "Console.WriteLine(\"(Un carre reel est toujours positif ou nul)\");\n",
+    "\n",
+    "var s = ctx.MkSolver();\n",
+    "s.Add(formule);\n",
+    "var res = s.Check();\n",
+    "Console.WriteLine(\"Resultat : \" + res);\n",
+    "if (res == Status.UNSATISFIABLE)\n",
+    "    Console.WriteLine(\"=> Aucun reel x tel que x*x < 0 : la formule est FAUSSE.\");\n",
+    "else if (res == Status.SATISFIABLE)\n",
+    "    Console.WriteLine(\"=> Temoin trouve : \" + s.Model);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb7c93c0",
+   "metadata": {},
+   "source": [
+    "## 5. Trichotomie et monotonie du carre\n",
+    "\n",
+    "Deux theoremes classiques prouves par refutation. **Trichotomie** : pour tout reel `x`, exactement un des trois cas `x < 0`, `x == 0`, `x > 0` est vrai. **Monotonie du carre** : pour tous `x, y >= 0`, si `x <= y` alors `x*x <= y*y`. On nie chaque formule universelle et on constate `UNSATISFIABLE`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c6175173",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:42.669181Z",
+     "iopub.status.busy": "2026-07-07T06:25:42.668931Z",
+     "iopub.status.idle": "2026-07-07T06:25:42.778047Z",
+     "shell.execute_reply": "2026-07-07T06:25:42.777328Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Theoreme de trichotomie : (forall ((x Real)) (or (< x 0.0) (= x 0.0) (> x 0.0)))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Negation = UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Trichotomie : VALIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Monotonicite du carre (x >= 0) : (forall ((x Real) (y Real))\n",
+      "  (=> (and (>= x 0.0) (>= y 0.0) (<= x y)) (<= (* x x) (* y y))))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Negation = UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Monotonicite : VALIDE\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "var x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort);\n",
+    "var y = (ArithExpr)ctx.MkConst(\"y\", ctx.RealSort);\n",
+    "\n",
+    "// Preuve 1 : trichotomie sur les reels\n",
+    "var trichotomie = ctx.MkForall(new Expr[]{ x }, ctx.MkOr(\n",
+    "    ctx.MkLt(x, ctx.MkReal(0)),\n",
+    "    ctx.MkEq(x, ctx.MkReal(0)),\n",
+    "    ctx.MkGt(x, ctx.MkReal(0))));\n",
+    "Console.WriteLine(\"Theoreme de trichotomie : \" + trichotomie);\n",
+    "var s = ctx.MkSolver();\n",
+    "s.Add(ctx.MkNot(trichotomie));\n",
+    "var res = s.Check();\n",
+    "Console.WriteLine(\"Negation = \" + res);\n",
+    "Console.WriteLine(\"=> Trichotomie : \" + (res == Status.UNSATISFIABLE ? \"VALIDE\" : \"NON PROUVEE\"));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "// Preuve 2 : monotonie du carre sur les reels positifs\n",
+    "var monotonicite = ctx.MkForall(new Expr[]{ x, y }, ctx.MkImplies(\n",
+    "    ctx.MkAnd(ctx.MkGe(x, ctx.MkReal(0)), ctx.MkGe(y, ctx.MkReal(0)), ctx.MkLe(x, y)),\n",
+    "    ctx.MkLe(ctx.MkMul(x, x), ctx.MkMul(y, y))));\n",
+    "Console.WriteLine(\"Monotonicite du carre (x >= 0) : \" + monotonicite);\n",
+    "var s2 = ctx.MkSolver();\n",
+    "s2.Add(ctx.MkNot(monotonicite));\n",
+    "var res2 = s2.Check();\n",
+    "Console.WriteLine(\"Negation = \" + res2);\n",
+    "Console.WriteLine(\"=> Monotonicite : \" + (res2 == Status.UNSATISFIABLE ? \"VALIDE\" : \"NON PROUVEE\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0e7ed77",
+   "metadata": {},
+   "source": [
+    "## 6. Quantificateurs imbriques : pas de plus grand reel\n",
+    "\n",
+    "Une formule peut imbriquer `ForAll` et `Exists`. L'enonce « il n'existe pas de plus grand reel » se formalise : `ForAll x, Exists y, y > x` — pour tout `x`, on peut toujours trouver un `y` strictement plus grand. On nie la formule entiere et le solveur repond `UNSATISFIABLE`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6573134b",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:42.779882Z",
+     "iopub.status.busy": "2026-07-07T06:25:42.779513Z",
+     "iopub.status.idle": "2026-07-07T06:25:42.883679Z",
+     "shell.execute_reply": "2026-07-07T06:25:42.883158Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formule : (forall ((x Real)) (exists ((y Real)) (> y x)))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Negation = UNSATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> VALIDE : il n existe pas de plus grand reel (theoreme).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "var x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort);\n",
+    "var y = (ArithExpr)ctx.MkConst(\"y\", ctx.RealSort);\n",
+    "\n",
+    "// ForAll x, Exists y, y > x\n",
+    "var pasDePlusGrand = ctx.MkForall(new Expr[]{ x },\n",
+    "    ctx.MkExists(new Expr[]{ y }, ctx.MkGt(y, x)));\n",
+    "Console.WriteLine(\"Formule : \" + pasDePlusGrand);\n",
+    "\n",
+    "var s = ctx.MkSolver();\n",
+    "s.Add(ctx.MkNot(pasDePlusGrand));\n",
+    "var res = s.Check();\n",
+    "Console.WriteLine(\"Negation = \" + res);\n",
+    "if (res == Status.UNSATISFIABLE)\n",
+    "    Console.WriteLine(\"=> VALIDE : il n existe pas de plus grand reel (theoreme).\");\n",
+    "else if (res == Status.SATISFIABLE)\n",
+    "    Console.WriteLine(\"=> FAUSSE : contre-exemple trouve. \" + s.Model);\n",
+    "else\n",
+    "    Console.WriteLine(\"=> Z3 ne peut pas conclure (unknown).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4aa7aae",
+   "metadata": {},
+   "source": [
+    "## 7. Le cas honnete `unknown` : Fermat\n",
+    "\n",
+    "L'arithmetique non lineaire entiere est **indecidable en general** : Z3 ne peut pas toujours trancher. Existe-t-il des entiers `a, b, c > 1` tels que `a^3 + b^3 == c^3` ? Le dernier theoreme de Fermat dit non, mais cette preuve depasse Z3. Sans budget de temps, Z3 chercherait indefiniment ; on borne donc avec un timeout, et le solveur repond honnetement `UNKNOWN` avec une raison (`timeout`). Ce n'est **pas un bug** mais une limite fondamentale de la decision automatique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "feac25a6",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:42.885331Z",
+     "iopub.status.busy": "2026-07-07T06:25:42.885039Z",
+     "iopub.status.idle": "2026-07-07T06:25:45.996655Z",
+     "shell.execute_reply": "2026-07-07T06:25:45.996414Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Probleme : a^3 + b^3 == c^3  avec a, b, c > 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : UNKNOWN\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> UNKNOWN : Z3 abandonne (raison : timeout).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   L arithmetique non lineaire entiere est indecidable en general :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   ce n est PAS un bug, mais une limite fondamentale de la decision automatique.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "var a = (ArithExpr)ctx.MkConst(\"a\", ctx.IntSort);\n",
+    "var b = (ArithExpr)ctx.MkConst(\"b\", ctx.IntSort);\n",
+    "var c = (ArithExpr)ctx.MkConst(\"c\", ctx.IntSort);\n",
+    "\n",
+    "var s = ctx.MkSolver();\n",
+    "s.Set(\"timeout\", 3000);  // 3 secondes ; au-dela, Z3 abandonne\n",
+    "s.Add(ctx.MkGt(a, ctx.MkInt(1)), ctx.MkGt(b, ctx.MkInt(1)), ctx.MkGt(c, ctx.MkInt(1)));\n",
+    "var a3 = ctx.MkMul(a, ctx.MkMul(a, a));\n",
+    "var b3 = ctx.MkMul(b, ctx.MkMul(b, b));\n",
+    "var c3 = ctx.MkMul(c, ctx.MkMul(c, c));\n",
+    "s.Add(ctx.MkEq(ctx.MkAdd(a3, b3), c3));\n",
+    "\n",
+    "Console.WriteLine(\"Probleme : a^3 + b^3 == c^3  avec a, b, c > 1\");\n",
+    "var res = s.Check();\n",
+    "Console.WriteLine(\"Resultat : \" + res);\n",
+    "\n",
+    "if (res == Status.SATISFIABLE)\n",
+    "    Console.WriteLine(\"=> Temoin trouve : \" + s.Model);\n",
+    "else if (res == Status.UNSATISFIABLE)\n",
+    "    Console.WriteLine(\"=> Aucune solution (prouve).\");\n",
+    "else\n",
+    "{\n",
+    "    Console.WriteLine(\"=> UNKNOWN : Z3 abandonne (raison : \" + s.ReasonUnknown + \").\");\n",
+    "    Console.WriteLine(\"   L arithmetique non lineaire entiere est indecidable en general :\");\n",
+    "    Console.WriteLine(\"   ce n est PAS un bug, mais une limite fondamentale de la decision automatique.\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6525b475",
+   "metadata": {},
+   "source": [
+    "## 8. Model checking : skolemiser un `Exists x, ForAll y`\n",
+    "\n",
+    "On cherche s'il existe un `x` tel que pour tout `y >= 0`, `x <= y`. Le `Exists x` externe est le temoin recherche. Pour lire sa valeur, on le **skolemise** : on declare `x` comme constante *libre* et le `ForAll` ne porte plus que sur `y`. Le solveur trouve alors un modele (par exemple `x = 0`), dont la valeur devient lisible via `m.Evaluate(x)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "adb1e011",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:45.998079Z",
+     "iopub.status.busy": "2026-07-07T06:25:45.997843Z",
+     "iopub.status.idle": "2026-07-07T06:25:46.118302Z",
+     "shell.execute_reply": "2026-07-07T06:25:46.118115Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contrainte sur x (temoin libre) : (forall ((y Real)) (=> (>= y 0.0) (<= x y)))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : SATISFIABLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele trouve : x = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Interpretation : 0 est <= a tout y >= 0 (un minorant des reels positifs)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification : x <= 1/10 ? true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification : x <= 1/1000 ? true\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using Microsoft.Z3;\n",
+    "var ctx = new Context();\n",
+    "var x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort);\n",
+    "var y = (ArithExpr)ctx.MkConst(\"y\", ctx.RealSort);\n",
+    "\n",
+    "// ForAll y >= 0 => x <= y  (x skolemise, libre)\n",
+    "var contrainte = ctx.MkForall(new Expr[]{ y },\n",
+    "    ctx.MkImplies(ctx.MkGe(y, ctx.MkReal(0)), ctx.MkLe(x, y)));\n",
+    "Console.WriteLine(\"Contrainte sur x (temoin libre) : \" + contrainte);\n",
+    "\n",
+    "var s = ctx.MkSolver();\n",
+    "s.Add(contrainte);\n",
+    "var res = s.Check();\n",
+    "Console.WriteLine(\"Resultat : \" + res);\n",
+    "\n",
+    "if (res == Status.SATISFIABLE)\n",
+    "{\n",
+    "    var m = s.Model;\n",
+    "    var valX = m.Evaluate(x);  // x est libre -> sa valeur est lisible\n",
+    "    Console.WriteLine(\"Modele trouve : x = \" + valX);\n",
+    "    Console.WriteLine(\"Interpretation : \" + valX + \" est <= a tout y >= 0 (un minorant des reels positifs)\");\n",
+    "    // Verifier x <= 1/10 et x <= 1/1000 contre le modele\n",
+    "    Console.WriteLine(\"Verification : x <= 1/10 ? \" + m.Evaluate(ctx.MkLe(x, ctx.MkReal(1, 10))));\n",
+    "    Console.WriteLine(\"Verification : x <= 1/1000 ? \" + m.Evaluate(ctx.MkLe(x, ctx.MkReal(1, 1000))));\n",
+    "}\n",
+    "else if (res == Status.UNSATISFIABLE)\n",
+    "    Console.WriteLine(\"=> Aucun modele : la formule est fausse.\");\n",
+    "else\n",
+    "    Console.WriteLine(\"=> Z3 ne peut pas conclure (unknown).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c995b42",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices a completer. Les stubs retournent `null`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "9db9178b",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:46.119714Z",
+     "iopub.status.busy": "2026-07-07T06:25:46.119520Z",
+     "iopub.status.idle": "2026-07-07T06:25:46.226009Z",
+     "shell.execute_reply": "2026-07-07T06:25:46.225776Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 (x * 1 == x valide ?) : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 : Prouver l identite multiplicative par refutation.\n",
+    "// Verifier que ForAll(x, x * 1 == x) est valide sur les reels.\n",
+    "// Indice : niez la formule et regardez le verdict.\n",
+    "// Etape 1 : declarer x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort)\n",
+    "// Etape 2 : formule = ctx.MkForall(new Expr[]{x}, ctx.MkEq(ctx.MkMul(x, ctx.MkReal(1)), x))\n",
+    "// Etape 3 : s.Add(ctx.MkNot(formule)), return s.Check() == Status.UNSATISFIABLE\n",
+    "bool? ProuverIdentiteMultiplicative(Context ctx)\n",
+    "{\n",
+    "    // TODO etudiant : implementez la preuve par refutation\n",
+    "    return null;  // TODO etudiant : remplacer par true (valide) ou false (fause)\n",
+    "}\n",
+    "\n",
+    "var r1 = ProuverIdentiteMultiplicative(new Context());\n",
+    "Console.WriteLine(\"Exercice 1 (x * 1 == x valide ?) : \" + (r1.HasValue ? r1.Value.ToString() : \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "bbe6d063",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:46.227370Z",
+     "iopub.status.busy": "2026-07-07T06:25:46.227198Z",
+     "iopub.status.idle": "2026-07-07T06:25:46.266252Z",
+     "shell.execute_reply": "2026-07-07T06:25:46.265907Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 (un carre negatif existe ?) : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 : Verifier si un carre negatif existe sur les reels.\n",
+    "// Existe-t-il x reel tel que x*x < 0 ? Retourne true si sat, false sinon.\n",
+    "// Indice : MkExists + MkLt(x*x, 0) + Check.\n",
+    "// Etape 1 : declarer x = (ArithExpr)ctx.MkConst(\"x\", ctx.RealSort)\n",
+    "// Etape 2 : s.Add(ctx.MkExists(new Expr[]{x}, ctx.MkLt(ctx.MkMul(x,x), ctx.MkReal(0))))\n",
+    "// Etape 3 : return s.Check() == Status.SATISFIABLE\n",
+    "bool? ExisteCarreNegatif(Context ctx)\n",
+    "{\n",
+    "    // TODO etudiant : implementez la verification\n",
+    "    return null;  // TODO etudiant : remplacer par true ou false\n",
+    "}\n",
+    "\n",
+    "var r2 = ExisteCarreNegatif(new Context());\n",
+    "Console.WriteLine(\"Exercice 2 (un carre negatif existe ?) : \" + (r2.HasValue ? r2.Value.ToString() : \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1f38bc69",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-07-07T06:25:46.267298Z",
+     "iopub.status.busy": "2026-07-07T06:25:46.267125Z",
+     "iopub.status.idle": "2026-07-07T06:25:46.303499Z",
+     "shell.execute_reply": "2026-07-07T06:25:46.303154Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 (pas de plus grand reel, valide ?) : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 3 : Prouver qu il n existe pas de plus grand reel.\n",
+    "// Verifier que ForAll(x, Exists(y, y > x)) est valide sur les reels.\n",
+    "// Indice : niez toute la formule et regardez le verdict.\n",
+    "// Etape 1 : declarer x, y = (ArithExpr)ctx.MkConst(..., ctx.RealSort)\n",
+    "// Etape 2 : nest = ctx.MkForall(new Expr[]{x}, ctx.MkExists(new Expr[]{y}, ctx.MkGt(y, x)))\n",
+    "// Etape 3 : s.Add(ctx.MkNot(nest)), return s.Check() == Status.UNSATISFIABLE\n",
+    "bool? ProuverPasDePlusGrandReel(Context ctx)\n",
+    "{\n",
+    "    // TODO etudiant : implementez la preuve par refutation\n",
+    "    return null;  // TODO etudiant : remplacer par true ou false\n",
+    "}\n",
+    "\n",
+    "var r3 = ProuverPasDePlusGrandReel(new Context());\n",
+    "Console.WriteLine(\"Exercice 3 (pas de plus grand reel, valide ?) : \" + (r3.HasValue ? r3.Value.ToString() : \"(a completer)\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43fd5af5",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# couvre les **quantificateurs** (`MkForall`/`MkExists` sur `new Expr[]{ constantes }`) et la **preuve par refutation** (une formule universelle est valide ssi sa negation est insatisfiable) avec le moteur reel Microsoft.Z3. On a prouve l'identite additive/multiplicative, la commutativite, la trichotomie, la monotonie du carre, et l'absence de plus grand reel ; traite le piege de la variable liee par `Exists` (skolemisation) ; et affronte honnetement la limite `UNKNOWN` de l'arithmetique non lineaire entiere (Fermat, avec `ReasonUnknown`).\n",
+    "\n",
+    "**Complementarite** : le twin Python utilise `ForAll([x], ...)` / `Exists([x], ...)` / `is_true(simplify(...))` (API pythonique, `unsat`/`sat`/`unknown` litteraux) ; ce twin C# montre l'API .NET (`MkForall(new Expr[]{x}, body)` / `Status.UNSATISFIABLE` enum / `ReasonUnknown` propriete / `Set(\"timeout\", N)`), avec le casting `(ArithExpr)` systematique des constantes reelles/entieres. Les deux executent le **meme** moteur Z3 et demontrent les memes theoremes.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "polyglot_notebook": {
+   "kernelName": "csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Ce que fait cette PR

Etablit la parite .NET sur le notebook 05 de la serie Z3-Python : **twin C#** de `Z3-Python-05-Quantifiers-Proofs.ipynb` utilisant le **vrai moteur [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet `#r "nuget: Microsoft.Z3"`, v4.12.2.0) — le meme solveur que `z3-solver` Python (Prong A SOTA, EPIC #3801). Suite de `Z3-Python-04-Strings-Regex-Csharp`. **Série Z3-Python-Csharp maintenant 5/6** (01/02/03/04/05).

## Contenu (12 cells code + 11 md, EXEC_PROVED)

1. **Preuve par refutation** : `ForAll x, x+0 == x` (negation `UNSAT` => `VALIDE`)
2. **3 proprietes elementaires** : multiplicatif (`x*1==x`), commutativite addition (`x+y==y+x`), neutre droite (`0+x==x`)
3. **`Exists` sat** : `x*x==4` — piege de la variable liee (`m[x]` illisible) + skolemisation (constante libre `racine=2`)
4. **`Exists` unsat** : `x*x < 0` impossible (carre reel positif)
5. **Theoremes** : trichotomie (`x<0 OU x==0 OU x>0`) + monotonie carre sur reels positifs (`x<=y => x*x<=y*y`)
6. **Quantificateurs imbriques** : `ForAll x, Exists y, y>x` (pas de plus grand reel)
7. **Cas honnete `unknown`** : Fermat `a^3+b^3==c^3`, timeout 3s, `ReasonUnknown`
8. **Model checking** : skolemiser `Exists x, ForAll y>=0 => x<=y` (temoin `x=0`)
9. **3 exercices C.1** : identite multiplicative, carre negatif, pas de plus grand reel

## Verification EXEC_PROVED

| Critere | Resultat |
|---------|----------|
| execution_count | 1..12 contigus ✓ |
| errors | 0 ✓ |
| path-leaks | 0 ✓ |
| emoji | 0 ✓ |
| warning/erreur CS | 0 ✓ |
| throw/assert/NotImplemented | 0 ✓ |
| Microsoft.Z3 NuGet confirme | ✓ (`Z3 4.12.2.0`) |
| TODO etudiant (stubs C.1) | 6 (3 exos x 2) ✓ |
| Validator H.1/H.3/C.1 | PASS 1/1 (12 cells) ✓ |
| CATALOG byte-identique | ✓ |

## API Microsoft.Z3 quantifiers naillee (decouverte c.90, 2 probes reflection + functional)

| Concept | Methode .NET | Note |
|---------|-------------|------|
| Pour tout | `ctx.MkForall(new Expr[]{constantes}, body)` | body utilise les MkConst directement |
| Il existe | `ctx.MkExists(new Expr[]{constantes}, body)` | idem |
| Implique/Or/And/Not | `MkImplies`/`MkOr(BoolExpr[])`/`MkAnd`/`MkNot` | connecteurs |
| Constante reelle/entiere | `ctx.MkConst("x", ctx.RealSort/IntSort)` | **cast `(ArithExpr)`** pour MkAdd/MkMul/MkLt/MkGt (CS1503 sinon) |
| Timeout | `s.Set("timeout", 3000)` | `uint` |
| Raison UNKNOWN | `s.ReasonUnknown` | propriete |
| Verdict | `Status.UNSATISFIABLE` (theoreme) / `UNKNOWN` | enum |

## Valeur ajoutee du twin (parite .NET)

Le twin Python utilise `ForAll([x], ...)` / `Exists([x], ...)` / `is_true(simplify(...))` / litteraux `unsat`/`sat`/`unknown` (API pythonique) ; ce twin C# montre l'API .NET : `MkForall(new Expr[]{x}, body)` / `Status.UNSATISFIABLE` enum / `ReasonUnknown` propriete / `Set("timeout", N)`, avec le cast `(ArithExpr)` systematique des constantes reelles/entieres. Les deux demontrent les **memes theoremes** (identite additive/multiplicative, commutativite, trichotomie, monotonie, pas de plus grand reel) et affrontent la **meme limite** `UNKNOWN` (Fermat, arithmetique non lineaire entiere indecidable). Le piege de skolemisation (variable liee par `Exists` illisible dans le modele) est traduit fidelement.

## Diffs

- `+1075 / -0` : nouveau notebook (1074 lignes) + README `+1 ligne table` (ligne `05cs`)
- CATALOG byte-identique (regle catalog-pr-hygiene R1)
- EOF : C# twin convention (trailing newline `\n`), LF via `.gitattributes eol=lf`

See #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
