### PR TITLE
feat(semanticweb): SW-10-CSharp-RDFStar — twin C# dotNetRDF de RDF-Star (#4956)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -256,6 +256,7 @@ Cette partie couvre les standards modernes du Web Sémantique. L'écosystème Py
 | 8 (C#) | **SW-8-CSharp-SHACL** | 45 min | Jumeau .NET de SW-8 : validation SHACL avec dotNetRDF (`VDS.RDF.Shacl`) |
 | 9 | **SW-9-Python-JSONLD** | 40 min | Données structurées pour le web |
 | 10 | **SW-10-Python-RDFStar** | 40 min | RDF 1.2, annotations et provenance |
+| 10 (C#) | **SW-10-CSharp-RDFStar** | 40 min | Jumeau .NET de SW-10 : réification + annotations de confiance avec dotNetRDF (`Graph`, `TripleStore`, graphes nommés) |
 
 #### SW-8-Python-SHACL : Validation de Qualité des Données (45 min)
 
@@ -291,6 +292,8 @@ RDF-Star (RDF 1.2) permet d'exprimer des statements à propos de statements, ess
 - Syntaxe Turtle-Star et N-Triples-Star
 - SPARQL-Star : requêtes sur les quoted triples
 - rdflib support expérimental RDF-Star
+
+> **Twin C# disponible** : [SW-10-CSharp-RDFStar](SW-10-CSharp-RDFStar.ipynb) — réification classique (4 triplets `rdf:Statement` par fait annoté), annotations de confiance/source et graphes nommés via dotNetRDF (`Graph(IRefNode)`, `TripleStore`, `SparqlQueryParser`). Compagnon cross-langage du notebook Python `rdflib` sur la même thématique RDF-Star/provenance (marathon parité .NET ⇄ Python #4956, Prong B).
 
 ---
 
@@ -499,6 +502,7 @@ SemanticWeb/
 ├── SW-9-Python-JSONLD.ipynb
 ├── SW-9-CSharp-JSONLD.ipynb         # Twin C# (marathon #4956 Prong B)
 ├── SW-10-Python-RDFStar.ipynb
+├── SW-10-CSharp-RDFStar.ipynb       # Twin C# (marathon #4956 Prong B)
 ├── SW-11-Python-KnowledgeGraphs.ipynb
 ├── SW-12-Python-GraphRAG.ipynb
 ├── SW-13-Python-Reasoners.ipynb     # Bonus

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
@@ -1,0 +1,1079 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0d778293",
+   "metadata": {},
+   "source": [
+    "# SW-10-CSharp-RDFStar — Jumeau C# : annoter des triplets (réification) via dotNetRDF\n",
+    "\n",
+    "> **Jumeau C# (.NET 9)** de [`SW-10-Python-RDFStar`](SW-10-Python-RDFStar.ipynb). Le notebook Python utilise **rdflib** pour illustrer l'annotation de triplets (provenance, confiance, validité temporelle) via la **réification classique** RDF (4 triplets par assertion) et les **graphes nommés** (`rdflib.Dataset`). **Ce jumeau invoque le vrai moteur .NET natif** : **dotNetRDF 3.4.1** (`VDS.RDF.Graph`, `Triple`, `SparqlQueryParser`, `ExecuteQuery`) — pas une réimplémentation jouet.\n",
+    "\n",
+    "**Source Python** : [`SW-10-Python-RDFStar.ipynb`](SW-10-Python-RDFStar.ipynb) — `rdflib.Graph`/`Dataset`, `reify()` helper, requêtes SPARQL sur `rdf:Statement`.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Comprendre la limitation** fondamentale de RDF : un triplet est une affirmation atomique, on ne peut pas (en RDF 1.0) annoter directement un triplet.\n",
+    "2. **Maîtriser la réification classique** : décomposer une assertion en 4 triplets (`rdf:Statement` + `rdf:subject`/`predicate`/`object`) pour pouvoir l'annoter.\n",
+    "3. **Construire un graphe de connaissances annoté** : provenance, score de confiance, validité temporelle.\n",
+    "4. **Interroger** ces annotations via SPARQL (`SparqlQueryParser` + `ExecuteQuery`), avec filtrage.\n",
+    "5. **Découvrir les graphes nommés** comme alternative plus compacte à la réification.\n",
+    "\n",
+    "## Vérification mathématique (cibles de concordance)\n",
+    "\n",
+    "- **Coût de la réification** : annoter 1 fait = **7 triplets** exactement (1 original + 4 réification + 2 annotations). Concordance avec rdflib.\n",
+    "- **Graphe de connaissances** : 4 personnes (8 triplets `type`/`name`) + faits annotés.\n",
+    "- **Requête SPARQL filtrée** : 2 relations à confiance ≥ 0,60 (Alice→Bob 0,95, Bob→Carol 0,60), 2 à confiance < 0,60 (Carol→Dave 0,30, Alice→Dave 0,50). Concordance avec le twin Python.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d33bcbe",
+   "metadata": {},
+   "source": [
+    "## 1. Installation et espace de noms\n",
+    "\n",
+    "dotNetRDF est le moteur .NET natif pour RDF/SPARQL. On charge le NuGet `dotNetRDF` 3.4.1 (le même que `SW-9-CSharp-JSONLD`). On définit les préfixes et URI de base comme le twin Python (`ex:`, `foaf:`, `rdf:`, `xsd:`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7a93dd6f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:49.971062Z",
+     "iopub.status.busy": "2026-07-07T07:26:49.963379Z",
+     "iopub.status.idle": "2026-07-07T07:26:51.694190Z",
+     "shell.execute_reply": "2026-07-07T07:26:51.689895Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1710860.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>dotNetRDF, 3.4.1</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dotNetRDF charge (VDS.RDF) -- marathon #4956, parite avec SW-10-Python-RDFStar (rdflib)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: dotNetRDF, 3.4.1\"\n",
+    "\n",
+    "using VDS.RDF;\n",
+    "using VDS.RDF.Parsing;\n",
+    "using VDS.RDF.Query;\n",
+    "using VDS.RDF.Writing;\n",
+    "using System;\n",
+    "using System.IO;\n",
+    "using System.Text;\n",
+    "\n",
+    "Console.WriteLine(\"dotNetRDF charge (VDS.RDF) -- marathon #4956, parite avec SW-10-Python-RDFStar (rdflib)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de19e0e3",
+   "metadata": {},
+   "source": [
+    "## 2. Le problème : pourquoi annoter des triplets ?\n",
+    "\n",
+    "RDF représente des faits sous forme de **triplets** (sujet, prédicat, objet). Mais un triplet est atomique : on ne peut pas lui attacher directement une provenance, un score de confiance ou une date. Pour dire « Alice affirme que Bob connaît Carol avec 85 % de confiance », il faut **réifier** le triplet — le décomposer en 4 triplets auxiliaires — puis annoter ce nœud-réification.\n",
+    "\n",
+    "### 2.1 La réification classique : 4 triplets pour 1 assertion\n",
+    "\n",
+    "La réification d'un triplet `(s, p, o)` crée un nœud `stmt` typé `rdf:Statement` relié au triplet original via `rdf:subject`, `rdf:predicate`, `rdf:object`. On peut alors annoter `stmt` (source, confiance, date) sans toucher au fait original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f5354f21",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:51.695671Z",
+     "iopub.status.busy": "2026-07-07T07:26:51.695446Z",
+     "iopub.status.idle": "2026-07-07T07:26:52.037987Z",
+     "shell.execute_reply": "2026-07-07T07:26:52.037726Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre total de triplets : 7\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - Fait original : 1 triplet\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - Reification : 4 triplets\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - Annotations : 2 triplets\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - Total : 7 triplets pour annoter 1 fait\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Espace de noms et URI de base (identiques au twin Python)\n",
+    "const string NS = \"http://example.org/\";\n",
+    "var g = new Graph();\n",
+    "g.NamespaceMap.AddNamespace(\"ex\", new Uri(NS));\n",
+    "g.NamespaceMap.AddNamespace(\"foaf\", new Uri(\"http://xmlns.com/foaf/0.1/\"));\n",
+    "\n",
+    "// Helper : un URI node racourci\n",
+    "IUriNode U(string local) => g.CreateUriNode(\"ex:\" + local);\n",
+    "IUriNode Pred(Uri u) => g.CreateUriNode(u);\n",
+    "IUriNode rdfType = g.CreateUriNode(\"rdf:type\");\n",
+    "IUriNode rdfStmt = g.CreateUriNode(\"rdf:Statement\");\n",
+    "IUriNode rdfSubject = g.CreateUriNode(\"rdf:subject\");\n",
+    "IUriNode rdfPredicate = g.CreateUriNode(\"rdf:predicate\");\n",
+    "IUriNode rdfObject = g.CreateUriNode(\"rdf:object\");\n",
+    "IUriNode foafKnows = Pred(new Uri(\"http://xmlns.com/foaf/0.1/knows\"));\n",
+    "\n",
+    "// Reification classique : decomposer le triplet (Bob, knows, Carol)\n",
+    "g.Assert(new Triple(U(\"Bob\"), foafKnows, U(\"Carol\")));          // le fait original (1)\n",
+    "\n",
+    "var stmt = U(\"statement1\");\n",
+    "g.Assert(new Triple(stmt, rdfType, rdfStmt));                   // rdf:type rdf:Statement\n",
+    "g.Assert(new Triple(stmt, rdfSubject, U(\"Bob\")));               // rdf:subject Bob\n",
+    "g.Assert(new Triple(stmt, rdfPredicate, foafKnows));            // rdf:predicate foaf:knows\n",
+    "g.Assert(new Triple(stmt, rdfObject, U(\"Carol\")));              // rdf:object Carol   (4)\n",
+    "\n",
+    "// Annotations : qui affirme ce fait, avec quel degre de confiance ?\n",
+    "g.Assert(new Triple(stmt, U(\"assertedBy\"), U(\"Alice\")));        // assertedBy Alice\n",
+    "g.Assert(new Triple(stmt, U(\"confidence\"), g.CreateLiteralNode(\"0.85\", new Uri(\"http://www.w3.org/2001/XMLSchema#double\"))));  // (2)\n",
+    "\n",
+    "Console.WriteLine($\"Nombre total de triplets : {g.Triples.Count}\");\n",
+    "Console.WriteLine(\"  - Fait original : 1 triplet\");\n",
+    "Console.WriteLine(\"  - Reification : 4 triplets\");\n",
+    "Console.WriteLine(\"  - Annotations : 2 triplets\");\n",
+    "Console.WriteLine(\"  - Total : 7 triplets pour annoter 1 fait\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33eb9622",
+   "metadata": {},
+   "source": [
+    "### Interprétation : coût de la réification\n",
+    "\n",
+    "| Approche | Triplets nécessaires | Lisibilité | Garantie d'existence du fait |\n",
+    "|----------|---------------------|------------|------------------------------|\n",
+    "| Triplet nu | 1 | excellente | oui (le triplet existe) |\n",
+    "| Réification + annotations | **7** | verbeuse | non (le fait original peut ne pas exister) |\n",
+    "\n",
+    "C'est précisément ce coût (4 triplets auxiliaires + N annotations) que **RDF-star** (RDF 1.2) vise à éliminer avec la syntaxe `<< s p o >>`. Mais la réification reste le mécanisme portable, indépendant du moteur. La sérialisation Turtle ci-dessous montre les 7 triplets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ab397f35",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:52.039854Z",
+     "iopub.status.busy": "2026-07-07T07:26:52.039605Z",
+     "iopub.status.idle": "2026-07-07T07:26:52.114807Z",
+     "shell.execute_reply": "2026-07-07T07:26:52.114627Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\r\n",
+      "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.\r\n",
+      "@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.\r\n",
+      "@prefix ex: <http://example.org/>.\r\n",
+      "@prefix foaf: <http://xmlns.com/foaf/0.1/>.\r\n",
+      "\r\n",
+      "ex:Bob foaf:knows ex:Carol.\r\n",
+      "ex:statement1 ex:assertedBy ex:Alice;\r\n",
+      "              ex:confidence \"0.85\"^^xsd:double;\r\n",
+      "              rdf:object ex:Carol;\r\n",
+      "              rdf:predicate foaf:knows;\r\n",
+      "              rdf:subject ex:Bob;\r\n",
+      "              a rdf:Statement.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Serialisation Turtle (equivalent rdflib.serialize(format=\"turtle\"))\n",
+    "var writer = new CompressingTurtleWriter();\n",
+    "var sw = new System.IO.StringWriter();\n",
+    "writer.Save(g, sw);\n",
+    "Console.WriteLine(sw.ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4049d8cd",
+   "metadata": {},
+   "source": [
+    "## 3. Fonction utilitaire `Reify()`\n",
+    "\n",
+    "Pour réduire la verbosité, le twin Python définit une fonction `reify(graph, s, p, o)`. Voici l'équivalent C# : elle crée le nœud-réification `rdf:Statement` + les 3 liens, sans répéter le fait original (à ajouter séparément). Retourne le nœud `stmt` pour annotation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6b0f0df5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:52.116577Z",
+     "iopub.status.busy": "2026-07-07T07:26:52.116365Z",
+     "iopub.status.idle": "2026-07-07T07:26:52.217246Z",
+     "shell.execute_reply": "2026-07-07T07:26:52.216792Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apres 2e fait reifie : graphe g = 14 triplets au total\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Reify : cree les 4 triplets de reification et retourne le noeud statement.\n",
+    "// (Le fait original doit etre ajoute separement si on veut qu'il existe dans le graphe.)\n",
+    "IUriNode Reify(IUriNode s, IUriNode p, IUriNode o, string name)\n",
+    "{\n",
+    "    var stmtNode = U(name);\n",
+    "    g.Assert(new Triple(stmtNode, rdfType, rdfStmt));\n",
+    "    g.Assert(new Triple(stmtNode, rdfSubject, s));\n",
+    "    g.Assert(new Triple(stmtNode, rdfPredicate, p));\n",
+    "    g.Assert(new Triple(stmtNode, rdfObject, o));\n",
+    "    return stmtNode;\n",
+    "}\n",
+    "\n",
+    "// Helper pour creer un LiteralNode de confiance typé xsd:double.\n",
+    "ILiteralNode Confidence(double v) =>\n",
+    "    g.CreateLiteralNode(v.ToString(System.Globalization.CultureInfo.InvariantCulture),\n",
+    "                         new Uri(\"http://www.w3.org/2001/XMLSchema#double\"));\n",
+    "\n",
+    "// Demo : un 2e fait reifie via le helper (Bob connait Dave, affirmé par Carol).\n",
+    "g.Assert(new Triple(U(\"Bob\"), foafKnows, U(\"Dave\")));              // fait original\n",
+    "var stmt2 = Reify(U(\"Bob\"), foafKnows, U(\"Dave\"), \"statement2\");\n",
+    "g.Assert(new Triple(stmt2, U(\"assertedBy\"), U(\"Carol\")));\n",
+    "g.Assert(new Triple(stmt2, U(\"confidence\"), Confidence(0.60)));\n",
+    "\n",
+    "Console.WriteLine($\"Apres 2e fait reifie : graphe g = {g.Triples.Count} triplets au total\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3708973",
+   "metadata": {},
+   "source": [
+    "## 4. Graphe de connaissances annoté\n",
+    "\n",
+    "Construisons un graphe réaliste : 4 personnes (Alice, Bob, Carol, Dave) reliées par `foaf:knows`, chaque relation annotée d'un score de confiance et d'une source. Le fait 4 (Alice connaît Dave) est **seulement affirmé par Bob** mais n'existe pas comme triplet direct — c'est précisément l'intérêt de la réification : on peut enregistrer une affirmation sans l'ajouter au graphe des faits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "59781798",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:52.219080Z",
+     "iopub.status.busy": "2026-07-07T07:26:52.218768Z",
+     "iopub.status.idle": "2026-07-07T07:26:52.434212Z",
+     "shell.execute_reply": "2026-07-07T07:26:52.433781Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe de connaissances : 35 triplets\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var gk = new Graph();\n",
+    "gk.NamespaceMap.AddNamespace(\"ex\", new Uri(NS));\n",
+    "gk.NamespaceMap.AddNamespace(\"foaf\", new Uri(\"http://xmlns.com/foaf/0.1/\"));\n",
+    "\n",
+    "// Helpers locaux (gk)\n",
+    "IUriNode N(string local) => gk.CreateUriNode(\"ex:\" + local);\n",
+    "IUriNode foafName = gk.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/name\"));\n",
+    "IUriNode rdfTypeK = gk.CreateUriNode(\"rdf:type\");\n",
+    "IUriNode foafPerson = gk.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/Person\"));\n",
+    "IUriNode knowsK = gk.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/knows\"));\n",
+    "ILiteralNode Str(string s) => gk.CreateLiteralNode(s);\n",
+    "ILiteralNode Conf(double v) => gk.CreateLiteralNode(\n",
+    "    v.ToString(System.Globalization.CultureInfo.InvariantCulture),\n",
+    "    new Uri(\"http://www.w3.org/2001/XMLSchema#double\"));\n",
+    "\n",
+    "// Reify sur gk : retourne le noeud statement\n",
+    "IUriNode ReifyK(IUriNode s, IUriNode p, IUriNode o, string name)\n",
+    "{\n",
+    "    var st = N(name);\n",
+    "    gk.Assert(new Triple(st, rdfTypeK, gk.CreateUriNode(\"rdf:Statement\")));\n",
+    "    gk.Assert(new Triple(st, gk.CreateUriNode(\"rdf:subject\"), s));\n",
+    "    gk.Assert(new Triple(st, gk.CreateUriNode(\"rdf:predicate\"), p));\n",
+    "    gk.Assert(new Triple(st, gk.CreateUriNode(\"rdf:object\"), o));\n",
+    "    return st;\n",
+    "}\n",
+    "\n",
+    "// === Personnes ===\n",
+    "foreach (var (name, uri) in new[] { (\"Alice Dupont\", N(\"Alice\")), (\"Bob Martin\", N(\"Bob\")),\n",
+    "                                     (\"Carol Laurent\", N(\"Carol\")), (\"Dave Petit\", N(\"Dave\")) })\n",
+    "{\n",
+    "    gk.Assert(new Triple(uri, rdfTypeK, foafPerson));\n",
+    "    gk.Assert(new Triple(uri, foafName, Str(name)));\n",
+    "}\n",
+    "\n",
+    "// === Fait 1 : Alice connait Bob (haute confiance, LinkedIn) ===\n",
+    "gk.Assert(new Triple(N(\"Alice\"), knowsK, N(\"Bob\")));\n",
+    "var s1 = ReifyK(N(\"Alice\"), knowsK, N(\"Bob\"), \"stmt1\");\n",
+    "gk.Assert(new Triple(s1, N(\"confidence\"), Conf(0.95)));\n",
+    "gk.Assert(new Triple(s1, N(\"source\"), Str(\"LinkedIn\")));\n",
+    "\n",
+    "// === Fait 2 : Bob connait Carol (confiance moyenne, Twitter) ===\n",
+    "gk.Assert(new Triple(N(\"Bob\"), knowsK, N(\"Carol\")));\n",
+    "var s2 = ReifyK(N(\"Bob\"), knowsK, N(\"Carol\"), \"stmt2\");\n",
+    "gk.Assert(new Triple(s2, N(\"confidence\"), Conf(0.60)));\n",
+    "gk.Assert(new Triple(s2, N(\"source\"), Str(\"Twitter\")));\n",
+    "\n",
+    "// === Fait 3 : Carol connait Dave (basse confiance, rumeur) ===\n",
+    "gk.Assert(new Triple(N(\"Carol\"), knowsK, N(\"Dave\")));\n",
+    "var s3 = ReifyK(N(\"Carol\"), knowsK, N(\"Dave\"), \"stmt3\");\n",
+    "gk.Assert(new Triple(s3, N(\"confidence\"), Conf(0.30)));\n",
+    "gk.Assert(new Triple(s3, N(\"source\"), Str(\"Rumeur\")));\n",
+    "\n",
+    "// === Fait 4 : Alice connait Dave (NON asserte, seulement affirme par Bob) ===\n",
+    "var s4 = ReifyK(N(\"Alice\"), knowsK, N(\"Dave\"), \"stmt4\");\n",
+    "gk.Assert(new Triple(s4, N(\"assertedBy\"), N(\"Bob\")));\n",
+    "gk.Assert(new Triple(s4, N(\"confidence\"), Conf(0.50)));\n",
+    "\n",
+    "Console.WriteLine($\"Graphe de connaissances : {gk.Triples.Count} triplets\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "044c1b8b",
+   "metadata": {},
+   "source": [
+    "## 5. Interroger les annotations avec SPARQL\n",
+    "\n",
+    "Pour extraire les relations annotées, on joint sur `rdf:subject`/`rdf:predicate`/`rdf:object` et on récupère les annotations. La requête ci-dessous liste toutes les relations connues avec leur confiance et source, triées par confiance décroissante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "98d2e2ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:52.436072Z",
+     "iopub.status.busy": "2026-07-07T07:26:52.435736Z",
+     "iopub.status.idle": "2026-07-07T07:26:52.701835Z",
+     "shell.execute_reply": "2026-07-07T07:26:52.701651Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Relations annotées (triées par confiance) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Personne 1   Personne 2    Confiance Source      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice        Bob                0,95 LinkedIn    \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bob          Carol              0,60 Twitter     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice        Dave               0,50 -           \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Carol        Dave               0,30 Rumeur      \r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Requete 1 : toutes les relations annotées (joiture sur rdf:Statement)\n",
+    "string queryAll = @\"\n",
+    "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+    "PREFIX ex:   <http://example.org/>\n",
+    "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "\n",
+    "SELECT ?person1 ?person2 ?confidence ?source\n",
+    "WHERE {\n",
+    "    ?stmt a rdf:Statement ;\n",
+    "          rdf:subject ?person1 ;\n",
+    "          rdf:predicate foaf:knows ;\n",
+    "          rdf:object ?person2 ;\n",
+    "          ex:confidence ?confidence .\n",
+    "    OPTIONAL { ?stmt ex:source ?source . }\n",
+    "}\n",
+    "ORDER BY DESC(?confidence)\";\n",
+    "\n",
+    "// Helper : extraire la valeur lexicale d'un LiteralNode (sans le suffixe ^^datatype).\n",
+    "// r[v].ToString() renvoie \"0.95^^...XSD#double\" -> on veut \"0.95\".\n",
+    "double ConfVal(ISparqlResult r, string v) =>\n",
+    "    double.Parse(((ILiteralNode)r[v]).Value, System.Globalization.CultureInfo.InvariantCulture);\n",
+    "// Helper : valeur lexicale d'un LiteralNode string (sans le suffixe ^^datatype).\n",
+    "string LitStr(ISparqlResult r, string v) => r.HasValue(v) && r[v] is ILiteralNode ln ? ln.Value : \"-\";\n",
+    "\n",
+    "var parser = new SparqlQueryParser();\n",
+    "var q = parser.ParseFromString(queryAll);\n",
+    "var results = gk.ExecuteQuery(q) as SparqlResultSet;\n",
+    "\n",
+    "Console.WriteLine(\"=== Relations annotées (triées par confiance) ===\");\n",
+    "Console.WriteLine($\"{\"Personne 1\",-12} {\"Personne 2\",-12} {\"Confiance\",10} {\"Source\",-12}\");\n",
+    "Console.WriteLine(new string('-', 50));\n",
+    "foreach (var r in results)\n",
+    "{\n",
+    "    var p1 = r[\"person1\"].ToString().Split('/').Last();\n",
+    "    var p2 = r[\"person2\"].ToString().Split('/').Last();\n",
+    "    var conf = ConfVal(r, \"confidence\");\n",
+    "    var src = LitStr(r, \"source\");\n",
+    "    Console.WriteLine($\"{p1,-12} {p2,-12} {conf,10:F2} {src,-12}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0134858",
+   "metadata": {},
+   "source": [
+    "## 6. Filtrer par score de confiance\n",
+    "\n",
+    "Cas d'usage clé : séparer les **faits fiables** (confiance ≥ 0,60) des **faits incertains** (< 0,60). On utilise une clause `FILTER` SPARQL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0fe19c31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:52.703197Z",
+     "iopub.status.busy": "2026-07-07T07:26:52.702986Z",
+     "iopub.status.idle": "2026-07-07T07:26:52.815215Z",
+     "shell.execute_reply": "2026-07-07T07:26:52.814881Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Relations FIABLES (confiance >= 0.60) : 2 ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Alice connait Bob (confiance=0,95, source=LinkedIn)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Bob connait Carol (confiance=0,60, source=Twitter)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Relations INCERTAINES (confiance < 0.60) : 2 ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Carol connait Dave (confiance=0,30, source=Rumeur)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Alice connait Dave (confiance=0,50, source=-)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "string queryHigh = @\"\n",
+    "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+    "PREFIX ex:   <http://example.org/>\n",
+    "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>\n",
+    "\n",
+    "SELECT ?person1 ?person2 ?confidence ?source\n",
+    "WHERE {\n",
+    "    ?stmt a rdf:Statement ;\n",
+    "          rdf:subject ?person1 ;\n",
+    "          rdf:predicate foaf:knows ;\n",
+    "          rdf:object ?person2 ;\n",
+    "          ex:confidence ?confidence .\n",
+    "    FILTER (?confidence >= \"\"0.60\"\"^^xsd:double)\n",
+    "    OPTIONAL { ?stmt ex:source ?source . }\n",
+    "}\n",
+    "ORDER BY DESC(?confidence)\";\n",
+    "\n",
+    "string queryLow = @\"\n",
+    "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+    "PREFIX ex:   <http://example.org/>\n",
+    "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>\n",
+    "\n",
+    "SELECT ?person1 ?person2 ?confidence ?source\n",
+    "WHERE {\n",
+    "    ?stmt a rdf:Statement ;\n",
+    "          rdf:subject ?person1 ;\n",
+    "          rdf:predicate foaf:knows ;\n",
+    "          rdf:object ?person2 ;\n",
+    "          ex:confidence ?confidence .\n",
+    "    FILTER (?confidence < \"\"0.60\"\"^^xsd:double)\n",
+    "    OPTIONAL { ?stmt ex:source ?source . }\n",
+    "}\n",
+    "ORDER BY ?confidence\";\n",
+    "\n",
+    "var rsHigh = (SparqlResultSet)gk.ExecuteQuery(new SparqlQueryParser().ParseFromString(queryHigh));\n",
+    "var rsLow  = (SparqlResultSet)gk.ExecuteQuery(new SparqlQueryParser().ParseFromString(queryLow));\n",
+    "\n",
+    "Console.WriteLine($\"=== Relations FIABLES (confiance >= 0.60) : {rsHigh.Count} ===\");\n",
+    "foreach (var r in rsHigh)\n",
+    "{\n",
+    "    var p1 = r[\"person1\"].ToString().Split('/').Last();\n",
+    "    var p2 = r[\"person2\"].ToString().Split('/').Last();\n",
+    "    var src = LitStr(r, \"source\");\n",
+    "    var conf = ConfVal(r, \"confidence\");\n",
+    "    Console.WriteLine($\"  {p1} connait {p2} (confiance={conf:F2}, source={src})\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"=== Relations INCERTAINES (confiance < 0.60) : {rsLow.Count} ===\");\n",
+    "foreach (var r in rsLow)\n",
+    "{\n",
+    "    var p1 = r[\"person1\"].ToString().Split('/').Last();\n",
+    "    var p2 = r[\"person2\"].ToString().Split('/').Last();\n",
+    "    var src = LitStr(r, \"source\");\n",
+    "    var conf = ConfVal(r, \"confidence\");\n",
+    "    Console.WriteLine($\"  {p1} connait {p2} (confiance={conf:F2}, source={src})\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d555f91f",
+   "metadata": {},
+   "source": [
+    "## 7. Alternative : les graphes nommés\n",
+    "\n",
+    "Les **graphes nommés** (Named Graphs) offrent une autre approche pour grouper des triplets par contexte : plutôt que de réifier chaque triplet individuellement, on regroupe un ensemble de triplets sous une URI de graphe. On peut alors annoter le graphe tout entier (provenance, confiance globale). dotNetRDF expose cela via la classe `VDS.RDF.ThreadSafeTripleStore` + `IGraph` nommés."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a56c12f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:52.816774Z",
+     "iopub.status.busy": "2026-07-07T07:26:52.816550Z",
+     "iopub.status.idle": "2026-07-07T07:26:52.954644Z",
+     "shell.execute_reply": "2026-07-07T07:26:52.954399Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Graphes nommés du store ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  graphe linkedin : 1 triplet(s)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    http://example.org/Alice http://xmlns.com/foaf/0.1/knows http://example.org/Bob\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  graphe twitter : 1 triplet(s)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    http://example.org/Bob http://xmlns.com/foaf/0.1/knows http://example.org/Carol\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var store = new TripleStore();\n",
+    "\n",
+    "// dotNetRDF 3.x : un graphe nomme se construit via Graph(IRefNode) -- le noeud-nom\n",
+    "// (Name, IRefNode) definit l'identite du graphe dans le store. Le vieux pattern\n",
+    "// `new Graph { BaseUri = uri }` laisse Name == null et les graphes se confondent\n",
+    "// avec le graphe par defaut -> collision a l'ajout. On garde aussi un guard HasGraph\n",
+    "// (non deprecate, via IRefNode) pour rester idempotent sur re-execution dans l'IDE.\n",
+    "var nLinkedIn = new Graph().CreateUriNode(UriFactory.Create(NS + \"graph/linkedin\"));\n",
+    "var gLinkedIn = new Graph(nLinkedIn);\n",
+    "gLinkedIn.Assert(new Triple(\n",
+    "    gLinkedIn.CreateUriNode(UriFactory.Create(NS + \"Alice\")),\n",
+    "    gLinkedIn.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/knows\")),\n",
+    "    gLinkedIn.CreateUriNode(UriFactory.Create(NS + \"Bob\"))));\n",
+    "if (!store.HasGraph(nLinkedIn)) store.Add(gLinkedIn);\n",
+    "\n",
+    "var nTwitter = new Graph().CreateUriNode(UriFactory.Create(NS + \"graph/twitter\"));\n",
+    "var gTwitter = new Graph(nTwitter);\n",
+    "gTwitter.Assert(new Triple(\n",
+    "    gTwitter.CreateUriNode(UriFactory.Create(NS + \"Bob\")),\n",
+    "    gTwitter.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/knows\")),\n",
+    "    gTwitter.CreateUriNode(UriFactory.Create(NS + \"Carol\"))));\n",
+    "if (!store.HasGraph(nTwitter)) store.Add(gTwitter);\n",
+    "\n",
+    "// dotNetRDF 3.x : les requetes sur store passent par un ISparqlQueryProcessor.\n",
+    "// On liste ici directement les graphes nommes du store et leur contenu (plus pedagogique).\n",
+    "Console.WriteLine(\"=== Graphes nommés du store ===\");\n",
+    "foreach (IGraph ng in store.Graphs)\n",
+    "{\n",
+    "    var gName = ng.Name is IUriNode un ? un.Uri.ToString().Split('/').Last() : \"(default)\";\n",
+    "    Console.WriteLine($\"  graphe {gName} : {ng.Triples.Count} triplet(s)\");\n",
+    "    foreach (var t in ng.Triples)\n",
+    "        Console.WriteLine($\"    {t.Subject} {t.Predicate} {t.Object}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1378d546",
+   "metadata": {},
+   "source": [
+    "## 8. Sérialisation et interopérabilité\n",
+    "\n",
+    "dotNetRDF supporte plusieurs formats de sérialisation (Turtle, N-Triples, RDF/XML, JSON-LD). Le Turtle (compressé) est le plus lisible pour la réification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "059719f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:52.955919Z",
+     "iopub.status.busy": "2026-07-07T07:26:52.955730Z",
+     "iopub.status.idle": "2026-07-07T07:26:53.060922Z",
+     "shell.execute_reply": "2026-07-07T07:26:53.060609Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Serialisation Turtle : 1370 caracteres, 35 triplets\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- (extrait) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\r\n",
+      "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.\r\n",
+      "@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.\r\n",
+      "@prefix ex: <http://example.org/>.\r\n",
+      "@prefix foaf: <http://xmlns.com/foaf/0.1/>.\r\n",
+      "\r\n",
+      "ex:Alice a foaf:Person;\r\n",
+      "         foaf:knows ex:Bob;\r\n",
+      "         foaf:name \"Alice Dupont\".\r\n",
+      "ex:Bob a foaf:Person;\r\n",
+      "       foaf:knows ex:Carol;\r\n",
+      "       foaf:name \"Bob Martin\".\r\n",
+      "ex:Carol a foaf:Person;\r\n",
+      "         foaf:knows ex:Dave;\r\n",
+      "         foaf:name \"\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Serialisation du graphe de connaissances en Turtle compressé\n",
+    "var w = new CompressingTurtleWriter();\n",
+    "var sw2 = new System.IO.StringWriter();\n",
+    "w.Save(gk, sw2);\n",
+    "var turtle = sw2.ToString();\n",
+    "Console.WriteLine($\"Serialisation Turtle : {turtle.Length} caracteres, {gk.Triples.Count} triplets\");\n",
+    "Console.WriteLine(\"--- (extrait) ---\");\n",
+    "Console.WriteLine(turtle.Substring(0, Math.Min(500, turtle.Length)));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0739e446",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices ci-dessous sont à compléter (convention C.1 : stubs exécutables sans erreur).\n",
+    "\n",
+    "### Exercice 1 — Ajouter une annotation de date de validité\n",
+    "Étendez le graphe de connaissances : pour chaque fait annoté, ajoutez un triplet `ex:validSince` avec une date typée `xsd:date`. Modifiez ensuite la requête SPARQL pour afficher cette colonne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "115b76ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:53.062244Z",
+     "iopub.status.busy": "2026-07-07T07:26:53.062058Z",
+     "iopub.status.idle": "2026-07-07T07:26:53.093903Z",
+     "shell.execute_reply": "2026-07-07T07:26:53.093720Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : annotation de date de validite sur les faits.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 : annotation temporelle\n",
+    "// TODO : pour chaque stmt (stmt1..stmt4), ajouter gk.Assert(new Triple(stmt, N(\"validSince\"),\n",
+    "//        gk.CreateLiteralNode(\"2020-01-01\", xsd:date))).\n",
+    "// Indice : utilisez gk.CreateLiteralNode(dateStr, new Uri(\"http://www.w3.org/2001/XMLSchema#date\")).\n",
+    "// Etape 1 : choisir une date de validité par fait. Etape 2 : modifier queryAll pour ajouter ?since.\n",
+    "Console.WriteLine(\"Exercice 1 a completer : annotation de date de validite sur les faits.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cda2c21",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Requête de transitivité inférée\n",
+    "Alice connaît Bob (0,95), Bob connaît Carol (0,60). Écrivez une requête SPARQL qui calcule les « connaissances transitives » (chemins de longueur 2) et combine les confiances par produit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "11445963",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:53.095336Z",
+     "iopub.status.busy": "2026-07-07T07:26:53.095125Z",
+     "iopub.status.idle": "2026-07-07T07:26:53.123411Z",
+     "shell.execute_reply": "2026-07-07T07:26:53.123242Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : requete de connaissances transitives (longueur 2).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : transitivité des connaissances\n",
+    "// TODO : requete SPARQL avec deux jointures ?a foaf:knows ?b . ?b foaf:knows ?c .\n",
+    "// Indice : la confiance d'un chemin a->b->c = confiance(a->b) * confiance(b->c).\n",
+    "// Etape 1 : ecrire la jointure sur les stmt reifies. Etape 2 : multiplier les confiances dans le SELECT.\n",
+    "Console.WriteLine(\"Exercice 2 a completer : requete de connaissances transitives (longueur 2).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96ac3c34",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Graphes nommés multi-sources\n",
+    "Construisez un 3e graphe nommé (par ex. `graph/intranet`) avec un fait Bob→Dave, puis écrivez une requête qui fusionne les 3 graphes et identifie les faits présents dans plusieurs sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "24ac542f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:26:53.124654Z",
+     "iopub.status.busy": "2026-07-07T07:26:53.124461Z",
+     "iopub.status.idle": "2026-07-07T07:26:53.152184Z",
+     "shell.execute_reply": "2026-07-07T07:26:53.152006Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : 3e graphe nommé + detection des faits multi-sources.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : fusion multi-sources via graphes nommés\n",
+    "// TODO : ajouter store.Add(gIntranet) avec un fait, puis requete UNION/GRAPH combinant les sources.\n",
+    "// Indice : une requete SELECT ?g ?s ?o WHERE { GRAPH ?g { ?s foaf:knows ?o } } liste tous les faits\n",
+    "// avec leur graphe d'origine ; un GROUP BY ?s ?o HAVING(COUNT(*)>1) trouve les faits multi-sources.\n",
+    "Console.WriteLine(\"Exercice 3 a completer : 3e graphe nommé + detection des faits multi-sources.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7527bc67",
+   "metadata": {},
+   "source": [
+    "## 9. Conclusion — synthèse\n",
+    "\n",
+    "| Mécanisme | Coût (triplets) | Lisibilité | Portabilité |\n",
+    "|-----------|----------------|------------|-------------|\n",
+    "| Triplet nu | 1 | excellente | totale |\n",
+    "| Réification classique | 4 + N annotations | verbeuse | totale (RDF 1.0) |\n",
+    "| RDF-star (`<< >>`) | 1 + N | excellente | récente (RDF 1.2) |\n",
+    "| Graphes nommés | 1 + annotation du graphe | bonne | totale (SPARQL 1.1) |\n",
+    "\n",
+    "**Leçon clé** : la **réification classique** est le mécanisme portable pour annoter des triplets (provenance, confiance, temporalité) — au prix d'une verbosité de 4 triplets auxiliaires par fait. RDF-star (RDF 1.2) vise à éliminer ce coût avec une syntaxe dédiée `<< s p o >>`, mais reste un standard jeune. Les **graphes nommés** offrent un compromis intermédiaire : grouper des triplets par contexte et annoter le groupe. dotNetRDF gère les trois (Graph, SparqlQueryParser, TripleStore) avec la même API `VDS.RDF` que ce notebook utilise.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [`<< SW-9 JSONLD`](SW-9-CSharp-JSONLD.ipynb) | [Index SemanticWeb](README.md) | Jumeau Python : [`SW-10-Python-RDFStar`](SW-10-Python-RDFStar.ipynb)\n",
+    "\n",
+    "*Marathon #4956 — parité .NET ⇄ Python. Prong A : vrai moteur dotNetRDF 3.4.1 natif invoqué.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Jumeau .NET (**dotNetRDF 3.4.1**) du notebook Python [SW-10-Python-RDFStar](MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb) (rdflib), dans le cadre du **marathon de parité .NET ⇄ Python #4956** (Prong B).

Ajoute un 3e twin C# à la série SemanticWeb (après SW-8-CSharp-SHACL et SW-9-CSharp-JSONLD).

## Contenu (12 cellules code, 26 cellules total)

- **Réification classique** : 4 triplets `rdf:Statement` par fait annoté (1 fait → 7 triplets)
- 2e fait réifié → graphe `g` = 14 triplets
- **Graphe de connaissances** : 35 triplets
- **Annotations confiance/source** : Alice→Bob 0.95 (LinkedIn), Bob→Carol 0.60 (Twitter), Alice→Dave 0.50, Carol→Dave 0.30 (Rumeur)
- **Requêtage SPARQL** + tri par confiance → **FIABLES 2 / INCERTAINES 2**
- **Graphes nommés** via `Graph(IRefNode)` + `TripleStore` (linkedin, twitter)
- **Sérialisation Turtle** compressé (1370 caractères)
- **3 exercices stubbés** (validité temporelle, transitivité, graphe multi-source)

## Execution réelle (H.1 EXEC_PROVED)

```
code=12  ec_none=0  errors=0  C.1=0  leaks=0
ec=[1..12] contigus
nbconvert --execute --kernel .net-csharp  →  EXIT 0 (clean, no CS warnings)
```

Math anchors CONCORDANT avec le twin Python : 7/14/35 triplets, FIABLES 2/INCERTAINES 2.

## API dotNetRDF 3.x découverte (notes pour les twins suivants)

| Piège | Solution |
|-------|----------|
| `new Graph { BaseUri = uri }` laisse `Name == null` → collision dans le store | Constructeur `Graph(IRefNode)` (Name non-null) |
| `ConfVal(SparqlResult r,...)` → CS1503 | `ISparqlResult` (interface, pas la classe concrète) |
| `r["confidence"].ToString()` = `"0.95^^...XSD#double"` → FormatException | `((ILiteralNode)r[v]).Value` lit la valeur sans suffixe datatype |
| `store.HasGraph(Uri)` déprécié (CS0618) | `store.HasGraph(IRefNode)` |
| `TripleStore.ExecuteQuery` absent en 3.x | Itérer `store.Graphs` ou `ISparqlQueryProcessor` |

## SOTA (EPIC #3801, Prong A) — SOTA-OK

Vrai moteur natif .NET **dotNetRDF 3.4.1** invoqué proprement (`#r "nuget: dotNetRDF, 3.4.1"`) : `Graph`, `Triple`, `SparqlQueryParser`, `ExecuteQuery`, `SparqlResultSet`, `CompressingTurtleWriter`, `TripleStore`, `Graph(IRefNode)`. Pas de workaround dégradé, pas de réimplémentation jouet. Problème non-trivial : réification + annotations de confiance + graphes nommés = l'API réelle du moteur exercée.

## §E — audit fichier-entier README

- +1 ligne table Partie 3 (`10 (C#) | SW-10-CSharp-RDFStar`)
- +1 §Twin C# après la section SW-10-Python (parallèle au §Twin SW-9-CSharp)
- +1 ligne arbre `Structure des fichiers`
- **CATALOG-STATUS byte-identique à main (22)** — catalog-drift CI bump 22→23

Alignement trois-voies vérifié : prose ↔ tree ↔ disk cohérents.

## Anti-regression (section D)

N/A — nouveau notebook (pas de code de production remplacé). Stubs d'exercice conformes C.1 (`print("...a completer")`, aucun `raise NotImplementedException`/`throw`/`1/0`).

See #4956 (partial delivery — 3e twin C# SemanticWeb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)